### PR TITLE
Exclude internal content from admin checklist and usage stats

### DIFF
--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -18,8 +18,8 @@
     :refer [Card Collection Dashboard DashboardCard Database Field LegacyMetric
             PermissionsGroup Pulse PulseCard PulseChannel QueryCache Segment
             Table User]]
-   [metabase.models.interface :as mi]
    [metabase.models.humanization :as humanization]
+   [metabase.models.interface :as mi]
    [metabase.public-settings :as public-settings]
    [metabase.util :as u]
    [metabase.util.honey-sql-2 :as h2x]

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -18,6 +18,7 @@
     :refer [Card Collection Dashboard DashboardCard Database Field LegacyMetric
             PermissionsGroup Pulse PulseCard PulseChannel QueryCache Segment
             Table User]]
+   [metabase.models.interface :as mi]
    [metabase.models.humanization :as humanization]
    [metabase.public-settings :as public-settings]
    [metabase.util :as u]
@@ -179,8 +180,8 @@
   "Get metrics based on questions
   TODO characterize by # executions and avg latency"
   []
-  (let [cards (t2/select [Card :query_type :public_uuid :enable_embedding :embedding_params :dataset_query]
-                         :creator_id [:not= config/internal-mb-user-id])]
+  (let [cards (t2/select [:model/Card :query_type :public_uuid :enable_embedding :embedding_params :dataset_query]
+                         {:where (mi/exclude-internal-content-hsql :model/Card)})]
     {:questions (merge-count-maps (for [card cards]
                                     (let [native? (= (keyword (:query_type card)) :native)]
                                       {:total       1
@@ -204,11 +205,12 @@
   "Get metrics based on dashboards
   TODO characterize by # of revisions, and created by an admin"
   []
-  (let [dashboards (t2/select [Dashboard :creator_id :public_uuid :parameters :enable_embedding :embedding_params] :creator_id [:not= config/internal-mb-user-id])
+  (let [dashboards (t2/select [:model/Dashboard :creator_id :public_uuid :parameters :enable_embedding :embedding_params]
+                              {:where (mi/exclude-internal-content-hsql :model/Dashboard)})
         dashcards  (t2/query {:select :dc.*
                               :from [[(t2/table-name DashboardCard) :dc]]
                               :join [[(t2/table-name Dashboard) :d] [:= :d.id :dc.dashboard_id]]
-                              :where [:not [:= :d.creator_id config/internal-mb-user-id]]})]
+                              :where (mi/exclude-internal-content-hsql :model/Dashboard :table-alias :d)})]
     {:dashboards         (count dashboards)
      :with_params        (count (filter (comp seq :parameters) dashboards))
      :num_dashs_per_user (medium-histogram dashboards :creator_id)
@@ -302,8 +304,8 @@
 (defn- collection-metrics
   "Get metrics on Collection usage."
   []
-  (let [collections (t2/select Collection :type [:not= "instance-analytics"] :is_sample false)
-        cards       (t2/select [Card :collection_id] :creator_id [:not= config/internal-mb-user-id])]
+  (let [collections (t2/select Collection {:where (mi/exclude-internal-content-hsql :model/Collection)})
+        cards       (t2/select [Card :collection_id] {:where (mi/exclude-internal-content-hsql :model/Card)})]
     {:collections              (count collections)
      :cards_in_collections     (count (filter :collection_id cards))
      :cards_not_in_collections (count (remove :collection_id cards))

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -573,7 +573,7 @@
 
 (defmethod mi/exclude-internal-content-hsql :model/Card
   [_model & {:keys [table-alias]}]
-  [:not= (h2x/identifier :field (some-> table-alias name) :creator_id) config/internal-mb-user-id])
+  [:not= (h2x/identifier :field table-alias :creator_id) config/internal-mb-user-id])
 
 ;;; ----------------------------------------------- Creating Cards ----------------------------------------------------
 

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -43,6 +43,7 @@
    [metabase.shared.util.i18n :refer [trs]]
    [metabase.util :as u]
    [metabase.util.embed :refer [maybe-populate-initially-published-at]]
+   [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
@@ -569,6 +570,10 @@
 (defmethod serdes/hash-fields :model/Card
   [_card]
   [:name (serdes/hydrated-hash :collection) :created_at])
+
+(defmethod mi/exclude-internal-content-hsql :model/Card
+  [_model & {:keys [table-alias]}]
+  [:not= (h2x/identifier :field (some-> table-alias name) :creator_id) config/internal-mb-user-id])
 
 ;;; ----------------------------------------------- Creating Cards ----------------------------------------------------
 

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -944,6 +944,13 @@
           :read  (perms/collection-read-path collection-or-id)
           :write (perms/collection-readwrite-path collection-or-id))})))
 
+(defmethod mi/exclude-internal-content-hsql :model/Collection
+  [_model & {:keys [table-alias]}]
+  (let [maybe-alias #(h2x/identifier :field (some-> table-alias name) %)]
+    [:and
+     [:not= (maybe-alias :type) "instance-analytics"]
+     [:= (maybe-alias :is_sample) false]]))
+
 (defn- parent-identity-hash [coll]
   (let [parent-id (-> coll
                       (t2/hydrate :parent_id)

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -948,8 +948,8 @@
   [_model & {:keys [table-alias]}]
   (let [maybe-alias #(h2x/identifier :field (some-> table-alias name) %)]
     [:and
-     [:not= (maybe-alias :type) "instance-analytics"]
-     [:= (maybe-alias :is_sample) false]]))
+     [:not= (maybe-alias :type) [:inline "instance-analytics"]]
+     [:not (maybe-alias :is_sample)]]))
 
 (defn- parent-identity-hash [coll]
   (let [parent-id (-> coll

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -944,11 +944,15 @@
           :read  (perms/collection-read-path collection-or-id)
           :write (perms/collection-readwrite-path collection-or-id))})))
 
+(def ^:private instance-analytics-collection-type
+  "The value of the `:type` field for the `instance-analytics` Collection created in [[metabase-enterprise.audit-db]]"
+  "instance-analytics")
+
 (defmethod mi/exclude-internal-content-hsql :model/Collection
   [_model & {:keys [table-alias]}]
   (let [maybe-alias #(h2x/identifier :field (some-> table-alias name) %)]
     [:and
-     [:not= (maybe-alias :type) [:inline "instance-analytics"]]
+     [:not= (maybe-alias :type) [:inline instance-analytics-collection-type]]
      [:not (maybe-alias :is_sample)]]))
 
 (defn- parent-identity-hash [coll]

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -6,6 +6,7 @@
    [clojure.string :as str]
    [medley.core :as m]
    [metabase.automagic-dashboards.populate :as populate]
+   [metabase.config :as config]
    [metabase.db.query :as mdb.query]
    [metabase.events :as events]
    [metabase.models.audit-log :as audit-log]
@@ -29,6 +30,7 @@
    [metabase.query-processor.async :as qp.async]
    [metabase.util :as u]
    [metabase.util.embed :refer [maybe-populate-initially-published-at]]
+   [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.i18n :as i18n :refer [deferred-tru deferred-trun tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
@@ -568,6 +570,10 @@
   [_model k dashboards]
   (let [dashboards-with-cards (t2/hydrate dashboards [:dashcards :card])]
     (map #(assoc %1 k %2) dashboards (map dashboard->resolved-params dashboards-with-cards))))
+
+(defmethod mi/exclude-internal-content-hsql :model/Dashboard
+  [_model & {:keys [table-alias]}]
+  [:not= (h2x/identifier :field (some-> table-alias name) :creator_id) config/internal-mb-user-id])
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                               SERIALIZATION                                                    |

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -573,7 +573,7 @@
 
 (defmethod mi/exclude-internal-content-hsql :model/Dashboard
   [_model & {:keys [table-alias]}]
-  [:not= (h2x/identifier :field (some-> table-alias name) :creator_id) config/internal-mb-user-id])
+  [:not= (h2x/identifier :field table-alias :creator_id) config/internal-mb-user-id])
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                               SERIALIZATION                                                    |

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -323,7 +323,7 @@
 
 (defmethod mi/exclude-internal-content-hsql :model/Database
   [_model & {:keys [table-alias]}]
-  (let [maybe-alias #(h2x/identifier :field (some-> table-alias name) %)]
+  (let [maybe-alias #(h2x/identifier :field table-alias %)]
     [:not [:or (maybe-alias :is_sample) (maybe-alias :is_audit)]]))
 
 ;;; ---------------------------------------------- Hydration / Util Fns ----------------------------------------------

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -22,6 +22,7 @@
     :refer [defenterprise]]
    [metabase.sync.schedules :as sync.schedules]
    [metabase.util :as u]
+   [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.i18n :refer [deferred-tru trs]]
    [metabase.util.log :as log]
    [methodical.core :as methodical]
@@ -319,6 +320,11 @@
   :type           :boolean
   :visibility     :public
   :database-local :only)
+
+(defmethod mi/exclude-internal-content-hsql :model/Database
+  [_model & {:keys [table-alias]}]
+  (let [maybe-alias #(h2x/identifier :field (some-> table-alias name) %)]
+    [:not [:or (maybe-alias :is_sample) (maybe-alias :is_audit)]]))
 
 ;;; ---------------------------------------------- Hydration / Util Fns ----------------------------------------------
 

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -725,7 +725,7 @@
   "Returns a HoneySQL expression to exclude instances of the model that were created automatically as part of internally
    used content, such as Metabase Analytics, the sample database, or the sample dashboard. If a `table-alias` (string
    or keyword) is provided any columns will have a table alias in the returned expression."
-  {:added "0.32.0", :arglists '([model & {:keys [table-alias]}])}
+  {:arglists '([model & {:keys [table-alias]}])}
   dispatch-on-model)
 
 (defmethod exclude-internal-content-hsql :default

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -727,3 +727,7 @@
    or keyword) is provided any columns will have a table alias in the returned expression."
   {:added "0.32.0", :arglists '([model & {:keys [table-alias]}])}
   dispatch-on-model)
+
+(defmethod exclude-internal-content-hsql :default
+  [_model & _]
+  [:= [:inline 1] [:inline 1]])

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -720,3 +720,10 @@
     (let [key->hydrated-items (instance-key->hydrated-data-fn)]
       (for [item instances]
         (assoc item hydration-key (get key->hydrated-items (get item instance-key) default))))))
+
+(defmulti exclude-internal-content-hsql
+  "Returns a HoneySQL expression to exclude instances of the model that were created automatically as part of internally
+   used content, such as Metabase Analytics, the sample database, or the sample dashboard. If a `table-alias` (string
+   or keyword) is provided any columns will have a table alias in the returned expression."
+  {:added "0.32.0", :arglists '([model & {:keys [table-alias]}])}
+  dispatch-on-model)

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -240,7 +240,7 @@
 
 (defmethod mi/exclude-internal-content-hsql :model/User
   [_model & {:keys [table-alias]}]
-  [:and [:not= (h2x/identifier :field (some-> table-alias name) :type) [:inline "internal"]]])
+  [:and [:not= (h2x/identifier :field table-alias :type) [:inline "internal"]]])
 
 ;;; -------------------------------------------------- Permissions ---------------------------------------------------
 

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -23,6 +23,7 @@
    [metabase.public-settings.premium-features :as premium-features]
    [metabase.setup :as setup]
    [metabase.util :as u]
+   [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.i18n :as i18n :refer [deferred-tru trs tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
@@ -236,6 +237,10 @@
    [:id ms/PositiveInt]
    ;; is_group_manager only included if `advanced-permissions` is enabled
    [:is_group_manager {:optional true} :boolean]])
+
+(defmethod mi/exclude-internal-content-hsql :model/User
+  [_model & {:keys [table-alias]}]
+  [:and [:not= (h2x/identifier :field (some-> table-alias name) :type) [:inline "internal"]]])
 
 ;;; -------------------------------------------------- Permissions ---------------------------------------------------
 

--- a/test/metabase/analytics/stats_test.clj
+++ b/test/metabase/analytics/stats_test.clj
@@ -3,6 +3,7 @@
    [clojure.test :refer :all]
    [java-time.api :as t]
    [metabase.analytics.stats :as stats :refer [anonymous-usage-stats]]
+   [metabase.core :as mbc]
    [metabase.db :as mdb]
    [metabase.email :as email]
    [metabase.integrations.slack :as slack]
@@ -290,6 +291,7 @@
   (testing "Internal content doesn't contribute to stats"
     (mt/with-temp-empty-app-db [_conn :h2]
       (mdb/setup-db! :create-sample-content? true)
+      (mbc/ensure-audit-db-installed!)
       (testing "sense check: internal content exists"
         (is (true? (t2/exists? :model/User)))
         (is (true? (t2/exists? :model/Database)))

--- a/test/metabase/analytics/stats_test.clj
+++ b/test/metabase/analytics/stats_test.clj
@@ -291,10 +291,22 @@
     (mt/with-temp-empty-app-db [_conn :h2]
       (mdb/setup-db! :create-sample-content? true)
       (testing "sense check: Collection, Dashboard, and Cards exist"
+        (is (true? (t2/exists? :model/User)))
+        (is (true? (t2/exists? :model/Database)))
+        (is (true? (t2/exists? :model/Table)))
+        (is (true? (t2/exists? :model/Field)))
         (is (true? (t2/exists? :model/Collection)))
         (is (true? (t2/exists? :model/Dashboard)))
         (is (true? (t2/exists? :model/Card))))
       (testing "All metrics should be empty"
+        (is (= {:users {}}
+               (#'stats/user-metrics)))
+        (is (= {:databases {}, :dbms_versions {}}
+               (#'stats/database-metrics)))
+        (is (= {:tables 0, :num_per_database {}, :num_per_schema {}}
+               (#'stats/table-metrics)))
+        (is (= {:num_per_table {}, :fields 0}
+               (#'stats/field-metrics)))
         (is (= {:collections 0, :cards_in_collections 0, :cards_not_in_collections 0, :num_cards_per_collection {}}
                (#'stats/collection-metrics)))
         (is (= {:questions {}, :public {}, :embedded {}}

--- a/test/metabase/analytics/stats_test.clj
+++ b/test/metabase/analytics/stats_test.clj
@@ -286,11 +286,11 @@
                                          ["6-10" [:int {:min 1}]]]]]
                 (#'stats/alert-metrics)))))
 
-(deftest sample-content-metrics-test
-  (testing "Sample content doesn't contribute to stats"
+(deftest internal-content-metrics-test
+  (testing "Internal content doesn't contribute to stats"
     (mt/with-temp-empty-app-db [_conn :h2]
       (mdb/setup-db! :create-sample-content? true)
-      (testing "sense check: Collection, Dashboard, and Cards exist"
+      (testing "sense check: internal content exists"
         (is (true? (t2/exists? :model/User)))
         (is (true? (t2/exists? :model/Database)))
         (is (true? (t2/exists? :model/Table)))

--- a/test/metabase/api/setup_test.clj
+++ b/test/metabase/api/setup_test.clj
@@ -421,7 +421,7 @@
 (deftest internal-content-setup-test
   (testing "Internally created state like Metabase Analytics shouldn't affect the checklist"
     (mt/with-temp-empty-app-db [_conn :h2]
-      (mdb/setup-db! :create-sample-content? false)
+      (mdb/setup-db! :create-sample-content? true)
       (mbc/ensure-audit-db-installed!)
       (testing "Sense check: internal content exists"
         (is (true? (t2/exists? :model/User)))

--- a/test/metabase/api/setup_test.clj
+++ b/test/metabase/api/setup_test.clj
@@ -4,10 +4,10 @@
    [clojure.spec.alpha :as s]
    [clojure.test :refer :all]
    [medley.core :as m]
-   [metabase-enterprise.audit-db :as audit-db]
    [metabase.analytics.snowplow-test :as snowplow-test]
    [metabase.api.setup :as api.setup]
    [metabase.config :as config]
+   [metabase.core :as mbc]
    [metabase.db :as mdb]
    [metabase.driver.h2 :as h2]
    [metabase.events :as events]
@@ -422,7 +422,7 @@
   (testing "Internally created state like Metabase Analytics shouldn't affect the checklist"
     (mt/with-temp-empty-app-db [_conn :h2]
       (mdb/setup-db! :create-sample-content? false)
-      (is (= ::audit-db/installed (audit-db/ensure-audit-db-installed!)))
+      (mbc/ensure-audit-db-installed!)
       (testing "Sense check: internal content exists"
         (is (true? (t2/exists? :model/User)))
         (is (true? (t2/exists? :model/Database)))

--- a/test/metabase/api/setup_test.clj
+++ b/test/metabase/api/setup_test.clj
@@ -4,9 +4,11 @@
    [clojure.spec.alpha :as s]
    [clojure.test :refer :all]
    [medley.core :as m]
+   [metabase-enterprise.audit-db :as audit-db]
    [metabase.analytics.snowplow-test :as snowplow-test]
    [metabase.api.setup :as api.setup]
    [metabase.config :as config]
+   [metabase.db :as mdb]
    [metabase.driver.h2 :as h2]
    [metabase.events :as events]
    [metabase.http-client :as client]
@@ -180,8 +182,8 @@
 
 (s/def ::setup!-args
   (s/cat :expected-status (s/? integer?)
-            :f               any?
-            :args            (s/* any?)))
+         :f               any?
+         :args            (s/* any?)))
 
 (defn- setup!
   {:arglists '([expected-status? f & args])}
@@ -415,6 +417,34 @@
     (testing "require superusers"
       (is (= "You don't have permissions to do that."
              (mt/user-http-request :rasta :get 403 "setup/admin_checklist"))))))
+
+(deftest internal-content-setup-test
+  (testing "Internally created state like Metabase Analytics shouldn't affect the checklist"
+    (mt/with-temp-empty-app-db [_conn :h2]
+      (mdb/setup-db! :create-sample-content? false)
+      (is (= ::audit-db/installed (audit-db/ensure-audit-db-installed!)))
+      (testing "Sense check: internal content exists"
+        (is (true? (t2/exists? :model/User)))
+        (is (true? (t2/exists? :model/Database)))
+        (is (true? (t2/exists? :model/Table)))
+        (is (true? (t2/exists? :model/Field)))
+        (is (true? (t2/exists? :model/Collection)))
+        (is (true? (t2/exists? :model/Dashboard)))
+        (is (true? (t2/exists? :model/Card))))
+      (testing "All state should be empty"
+        (is (=? {:db-type    :h2
+                 :configured {:email false
+                              :slack false}
+                 :counts     {:user  0
+                              :card  0
+                              :table 0}
+                 :exists     {:non-sample-db false
+                              :dashboard     false
+                              :pulse         false
+                              :hidden-table  false
+                              :collection    false
+                              :model         false}}
+                (#'api.setup/state-for-checklist)))))))
 
 (deftest annotate-test
   (testing "identifies next step"


### PR DESCRIPTION
1. Fixes https://github.com/metabase/metabase/issues/41335
2. Follows up on https://github.com/metabase/metabase/pull/41522, excluding more things from anonymous usage stats: users, databases, tables, and fields. This new behaviour was approved [here](https://metaboat.slack.com/archives/C0641E4PB9B/p1713811895337679) on slack.

### Implementation details

I've created a new multimethod [`metabase.models.interface/exclude-internal-content-hsql`](https://github.com/metabase/metabase/blob/0b6ae3534cd94456699aed05ec0ebf4a4030576c/src/metabase/models/interface.clj#L724-L729) that is used in both `metabase.api.setup/state-for-checklist` and `metabase.analytics.stats/anonymous-usage-stats` to filter out internal content from their statistics and counts.