### PR TITLE
fix timeline event type errors

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/timeline-events/option.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/timeline-events/option.ts
@@ -55,7 +55,6 @@ export const getTimelineEventsSeries = (
       const dataUri = svgToImageUri(iconSvg);
 
       return {
-        z: CHART_STYLE.timelineEvents.zIndex,
         name: "timeline-event",
         xAxis: date,
         symbolSize: 16,
@@ -82,7 +81,6 @@ export const getTimelineEventsSeries = (
     animation: false,
     type: "line",
     data: [],
-    z: CHART_STYLE.timelineEvents.zIndex,
     markLine: {
       blur: {
         label: {


### PR DESCRIPTION
### Description

Fixing type errors to get CI green.

In https://github.com/metabase/metabase/pull/40931 we removed the `CHART_STYLE.timelineEvents.zIndex` property, but accidentally left in it's import and usage.

### Demo

![Screenshot 2024-04-22 at 3.58.17 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/013e1d67-b864-40af-b15f-413a81d90334.png)

Confirmed timeline events still render under series