### PR TITLE
fix invalid series names in tooltip

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js
@@ -112,10 +112,10 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
         ["Custom Q2", "56.66"],
       ];
 
-      showTooltipForFirstCircleInSeries("#88BF4D");
+      showTooltipForCircleInSeries("#88BF4D");
       testTooltipText(originalSeriesTooltipText);
 
-      showTooltipForFirstCircleInSeries("#A989C5");
+      showTooltipForCircleInSeries("#A989C5");
       testTooltipText(addedSeriesTooltipText);
 
       openDashCardVisualizationOptions();
@@ -125,10 +125,10 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
 
       saveDashCardVisualizationOptions();
 
-      showTooltipForFirstCircleInSeries("#88BF4D");
+      showTooltipForCircleInSeries("#88BF4D");
       testTooltipText(updatedOriginalSeriesTooltipText);
 
-      showTooltipForFirstCircleInSeries("#A989C5");
+      showTooltipForCircleInSeries("#A989C5");
       testTooltipText(updatedAddedSeriesTooltipText);
     });
   });
@@ -220,36 +220,39 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
     });
 
     it("should show updated column titles in tooltips after editing them via Visualization Options", () => {
+      // Checking the second datum since the first circle of one series is covered with a circle from the other series
+      const circleIndex = 1;
       const originalSeriesColors = ["#A989C5", "#88BF4D"];
-      const addedSeriesColors = ["#509EE3", "#98D9D9"];
+      const addedSeriesColors = ["#98D9D9", "#509EE3"];
       const originalSeriesTooltipText = [
-        ["Created At", "2022"],
-        ["Average of Total", "56.66"],
-        ["Cumulative sum of Quantity", "3,236"],
+        ["Created At", "2023"],
+        ["Average of Total", "56.86"],
+        ["Cumulative sum of Quantity", "17,587"],
       ];
       const updatedOriginalSeriesTooltipText = [
-        ["Created At", "2022"],
-        ["Q1 Custom 1", "56.66"],
-        ["Q1 Custom 2", "3,236"],
+        ["Created At", "2023"],
+        ["Q1 Custom 1", "56.86"],
+        ["Q1 Custom 2", "17,587"],
       ];
 
       const addedSeriesTooltipText = [
-        ["Created At", "2022"],
-        ["Average of Discount", "5.03"],
-        ["Sum of Discount", "342.09"],
+        ["Created At", "2023"],
+        ["Average of Discount", "5.41"],
+        ["Sum of Discount", "1,953.08"],
       ];
       const updatedAddedSeriesTooltipText = [
-        ["Created At", "2022"],
-        ["Q2 Custom 1", "5.03"],
-        ["Q2 Custom 2", "342.09"],
+        ["Created At", "2023"],
+        ["Q2 Custom 1", "5.41"],
+        ["Q2 Custom 2", "1,953.08"],
       ];
 
       originalSeriesColors.forEach(color => {
-        showTooltipForFirstCircleInSeries(color);
+        showTooltipForCircleInSeries(color, circleIndex);
         testTooltipText(originalSeriesTooltipText);
       });
+
       addedSeriesColors.forEach(color => {
-        showTooltipForFirstCircleInSeries(color);
+        showTooltipForCircleInSeries(color, circleIndex);
         testTooltipText(addedSeriesTooltipText);
       });
 
@@ -276,11 +279,11 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       saveDashCardVisualizationOptions();
 
       originalSeriesColors.forEach(color => {
-        showTooltipForFirstCircleInSeries(color);
+        showTooltipForCircleInSeries(color, circleIndex);
         testTooltipText(updatedOriginalSeriesTooltipText);
       });
       addedSeriesColors.forEach(color => {
-        showTooltipForFirstCircleInSeries(color);
+        showTooltipForCircleInSeries(color, circleIndex);
         testTooltipText(updatedAddedSeriesTooltipText);
       });
     });
@@ -361,8 +364,8 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
     });
 
     it("should show updated column titles in tooltips after editing them via Visualization Options", () => {
-      const originalSeriesIndex = 0;
-      const addedSeriesIndex = 1;
+      const originalSeriesColor = "#88BF4D";
+      const addedSeriesColor = "#A989C5";
       const originalSeriesTooltipText = [
         ["Created At", "2022"],
         ["Sum of Total", "42,156.87"],
@@ -381,10 +384,10 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
         ["Custom Q2", "56.66"],
       ];
 
-      showTooltipForFirstBarInSeries(originalSeriesIndex);
+      showTooltipForFirstBarInSeries(originalSeriesColor);
       testTooltipText(originalSeriesTooltipText);
 
-      showTooltipForFirstBarInSeries(addedSeriesIndex);
+      showTooltipForFirstBarInSeries(addedSeriesColor);
       testTooltipText(addedSeriesTooltipText);
 
       openDashCardVisualizationOptions();
@@ -394,10 +397,10 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
 
       saveDashCardVisualizationOptions();
 
-      showTooltipForFirstBarInSeries(originalSeriesIndex);
+      showTooltipForFirstBarInSeries(originalSeriesColor);
       testTooltipText(updatedOriginalSeriesTooltipText);
 
-      showTooltipForFirstBarInSeries(addedSeriesIndex);
+      showTooltipForFirstBarInSeries(addedSeriesColor);
       testTooltipText(updatedAddedSeriesTooltipText);
     });
   });
@@ -433,8 +436,8 @@ function setupDashboard(cardId, addedSeriesCardId) {
   });
 }
 
-function showTooltipForFirstCircleInSeries(seriesColor) {
-  cartesianChartCircleWithColor(seriesColor).realHover();
+function showTooltipForCircleInSeries(seriesColor, index = 0) {
+  cartesianChartCircleWithColor(seriesColor).eq(index).realHover();
 }
 
 function showTooltipForFirstBarInSeries(seriesColor) {

--- a/frontend/src/metabase/static-viz/components/ComboChart/settings.ts
+++ b/frontend/src/metabase/static-viz/components/ComboChart/settings.ts
@@ -1,9 +1,9 @@
 import { getCommonStaticVizSettings } from "metabase/static-viz/lib/settings";
+import { getCardsColumns } from "metabase/visualizations/echarts/cartesian/model";
 import {
-  getCardsColumns,
   getCardsSeriesModels,
-} from "metabase/visualizations/echarts/cartesian/model";
-import { getDimensionModel } from "metabase/visualizations/echarts/cartesian/model/series";
+  getDimensionModel,
+} from "metabase/visualizations/echarts/cartesian/model/series";
 import type { LegacySeriesSettingsObjectKey } from "metabase/visualizations/echarts/cartesian/model/types";
 import {
   getDefaultBubbleSizeCol,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
@@ -11,7 +11,7 @@ import {
   sortDataset,
 } from "metabase/visualizations/echarts/cartesian/model/dataset";
 import {
-  getCardSeriesModels,
+  getCardsSeriesModels,
   getDimensionModel,
 } from "metabase/visualizations/echarts/cartesian/model/series";
 import type {
@@ -19,7 +19,6 @@ import type {
   ShowWarning,
 } from "metabase/visualizations/echarts/cartesian/model/types";
 import { getScatterPlotDataset } from "metabase/visualizations/echarts/cartesian/scatter/model";
-import type { CartesianChartColumns } from "metabase/visualizations/lib/graph/columns";
 import { getCartesianChartColumns } from "metabase/visualizations/lib/graph/columns";
 import { getSingleSeriesDimensionsAndMetrics } from "metabase/visualizations/lib/utils";
 import type {
@@ -75,27 +74,6 @@ export const getCardsColumns = (
 
     const cardSettings = getSettingsWithDefaultMetricsAndDimensions(series);
     return getCartesianChartColumns(data.cols, cardSettings);
-  });
-};
-
-export const getCardsSeriesModels = (
-  rawSeries: RawSeries,
-  cardsColumns: CartesianChartColumns[],
-  settings: ComputedVisualizationSettings,
-  renderingContext: RenderingContext,
-) => {
-  const hasMultipleCards = rawSeries.length > 1;
-  return rawSeries.flatMap((cardDataset, index) => {
-    const cardColumns = cardsColumns[index];
-
-    return getCardSeriesModels(
-      cardDataset,
-      cardColumns,
-      hasMultipleCards,
-      index === 0,
-      settings,
-      renderingContext,
-    );
   });
 };
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/series.ts
@@ -123,7 +123,7 @@ export const getCardsSeriesModels = (
  * @param {RenderingContext} renderingContext - The rendering context.
  * @returns {SeriesModel[]} The generated series models for the card.
  */
-const getCardSeriesModels = (
+export const getCardSeriesModels = (
   { card, data }: SingleSeries,
   columns: CartesianChartColumns,
   hasMultipleCards: boolean,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/series.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/series.unit.spec.ts
@@ -1,0 +1,355 @@
+import type {
+  BreakoutChartColumns,
+  CartesianChartColumns,
+} from "metabase/visualizations/lib/graph/columns";
+import type {
+  ComputedVisualizationSettings,
+  RenderingContext,
+} from "metabase/visualizations/types";
+import type { SingleSeries } from "metabase-types/api";
+import {
+  createMockCard,
+  createMockColumn,
+  createMockDatasetData,
+  createMockVisualizationSettings,
+} from "metabase-types/api/mocks";
+
+import { getCardsSeriesModels } from "./series";
+
+const createMockComputedVisualizationSettings = (
+  opts: Partial<ComputedVisualizationSettings> = {},
+) => {
+  return createMockVisualizationSettings({
+    series: () => ({}),
+    ...opts,
+  });
+};
+
+const renderingContextMock: RenderingContext = {
+  formatValue: value => `formatted: ${value}`,
+  getColor: colorName => colorName,
+  measureText: () => 0,
+  fontFamily: "Lato",
+};
+
+describe("series", () => {
+  const metricColumns: CartesianChartColumns = {
+    dimension: {
+      index: 0,
+      column: createMockColumn({ name: "month", display_name: "Month" }),
+    },
+    metrics: [
+      {
+        index: 2,
+        column: createMockColumn({
+          name: "count",
+          display_name: "Count",
+          base_type: "type/Integer",
+        }),
+      },
+    ],
+  };
+
+  const metricSeries: SingleSeries = {
+    card: createMockCard({ id: 1, name: "metric card" }),
+    data: createMockDatasetData({
+      rows: [
+        [1, "category1", 200],
+        [2, "category1", 300],
+        [3, "category2", 400],
+        [3, "category3", 500],
+      ],
+      cols: [
+        metricColumns.dimension.column,
+        createMockColumn({ name: "category", display_name: "Category" }),
+        metricColumns.metrics[0].column,
+      ],
+    }),
+  };
+
+  const breakoutColumns: BreakoutChartColumns = {
+    dimension: {
+      index: 0,
+      column: createMockColumn({
+        name: "also_month",
+        display_name: "Also Month",
+      }),
+    },
+    metric: {
+      index: 2,
+      column: createMockColumn({
+        name: "count",
+        display_name: "Count",
+        base_type: "type/Integer",
+      }),
+    },
+    breakout: {
+      index: 1,
+      column: createMockColumn({ name: "type", display_name: "Type" }),
+    },
+  };
+
+  const breakoutSeries: SingleSeries = {
+    card: createMockCard({ id: 2, name: "breakout card" }),
+    data: createMockDatasetData({
+      rows: [
+        [1, "type1", 100],
+        [2, "type1", 200],
+        [3, "type2", 300],
+        [3, "type2", 400],
+      ],
+      cols: [
+        breakoutColumns.dimension.column,
+        breakoutColumns.breakout.column,
+        breakoutColumns.metric.column,
+      ],
+    }),
+  };
+
+  describe("getCardsSeriesModels", () => {
+    describe("single metric card", () => {
+      it("should return a series model with default names", () => {
+        const rawSeries = [metricSeries];
+        const cardsColumns = [metricColumns];
+
+        const result = getCardsSeriesModels(
+          rawSeries,
+          cardsColumns,
+          createMockComputedVisualizationSettings(),
+          renderingContextMock,
+        );
+
+        expect(result).toHaveLength(1);
+        expect(result[0]).toMatchObject({
+          cardId: metricSeries.card.id,
+          column: metricColumns.metrics[0].column,
+          columnIndex: metricColumns.metrics[0].index,
+          dataKey: "1:count",
+          legacySeriesSettingsObjectKey: {
+            card: { _seriesKey: metricColumns.metrics[0].column.name },
+          },
+          name: metricColumns.metrics[0].column.display_name,
+          tooltipName: metricColumns.metrics[0].column.display_name,
+          vizSettingsKey: metricColumns.metrics[0].column.name,
+        });
+      });
+
+      it("should return a series model with overriden name", () => {
+        const rawSeries = [metricSeries];
+        const cardsColumns = [metricColumns];
+
+        const result = getCardsSeriesModels(
+          rawSeries,
+          cardsColumns,
+          createMockComputedVisualizationSettings({
+            series_settings: {
+              [metricColumns.metrics[0].column.name]: {
+                title: "foo",
+              },
+            },
+          }),
+          renderingContextMock,
+        );
+
+        expect(result).toHaveLength(1);
+        expect(result[0]).toMatchObject({
+          dataKey: "1:count",
+          name: "foo",
+          tooltipName: "foo",
+        });
+      });
+    });
+
+    describe("single breakout card", () => {
+      it("should return a series model with default names", () => {
+        const rawSeries = [breakoutSeries];
+        const cardsColumns = [breakoutColumns];
+
+        const result = getCardsSeriesModels(
+          rawSeries,
+          cardsColumns,
+          createMockComputedVisualizationSettings(),
+          renderingContextMock,
+        );
+
+        expect(result).toHaveLength(2);
+        expect(result[0]).toMatchObject({
+          cardId: breakoutSeries.card.id,
+          column: breakoutColumns.metric.column,
+          columnIndex: breakoutColumns.metric.index,
+          dataKey: "2:count:type1",
+          legacySeriesSettingsObjectKey: {
+            card: { _seriesKey: "formatted: type1" },
+          },
+          name: "formatted: type1",
+          tooltipName: breakoutColumns.metric.column.display_name,
+          vizSettingsKey: "formatted: type1",
+        });
+        expect(result[1]).toMatchObject({
+          cardId: breakoutSeries.card.id,
+          column: breakoutColumns.metric.column,
+          columnIndex: breakoutColumns.metric.index,
+          dataKey: "2:count:type2",
+          legacySeriesSettingsObjectKey: {
+            card: { _seriesKey: "formatted: type2" },
+          },
+          name: "formatted: type2",
+          tooltipName: breakoutColumns.metric.column.display_name,
+          vizSettingsKey: "formatted: type2",
+        });
+      });
+
+      it("should return a series model with overriden names", () => {
+        const rawSeries = [breakoutSeries];
+        const cardsColumns = [breakoutColumns];
+
+        const result = getCardsSeriesModels(
+          rawSeries,
+          cardsColumns,
+          createMockComputedVisualizationSettings({
+            series_settings: {
+              "formatted: type2": {
+                title: "foo",
+              },
+            },
+          }),
+          renderingContextMock,
+        );
+
+        expect(result).toHaveLength(2);
+        expect(result[0]).toMatchObject({
+          dataKey: "2:count:type1",
+          name: "formatted: type1",
+          tooltipName: breakoutColumns.metric.column.display_name,
+        });
+        expect(result[1]).toMatchObject({
+          dataKey: "2:count:type2",
+          name: "foo",
+          tooltipName: "Count",
+        });
+      });
+
+      it("when breakout values are null and '' should give (empty) series names", () => {
+        const rawSeries = [
+          {
+            ...breakoutSeries,
+            data: {
+              ...breakoutSeries.data,
+              rows: [
+                [1, "", 100],
+                [2, null, 200],
+              ],
+            },
+          },
+        ];
+        const cardsColumns = [breakoutColumns];
+
+        const result = getCardsSeriesModels(
+          rawSeries,
+          cardsColumns,
+          createMockComputedVisualizationSettings(),
+          renderingContextMock,
+        );
+
+        expect(result).toHaveLength(2);
+        expect(result[0]).toMatchObject({
+          dataKey: "2:count:",
+          name: "(empty)",
+          tooltipName: breakoutColumns.metric.column.display_name,
+        });
+        expect(result[1]).toMatchObject({
+          dataKey: "2:count:null",
+          name: "(empty)",
+          tooltipName: "Count",
+        });
+      });
+    });
+
+    describe("combined cards", () => {
+      const rawSeries = [metricSeries, breakoutSeries];
+      const cardsColumns = [metricColumns, breakoutColumns];
+
+      it("should return series models of two combined cards with default names", () => {
+        const result = getCardsSeriesModels(
+          rawSeries,
+          cardsColumns,
+          createMockComputedVisualizationSettings(),
+          renderingContextMock,
+        );
+
+        expect(result).toHaveLength(3);
+        expect(result[0]).toMatchObject({
+          cardId: metricSeries.card.id,
+          column: metricColumns.metrics[0].column,
+          columnIndex: metricColumns.metrics[0].index,
+          dataKey: "1:count",
+          legacySeriesSettingsObjectKey: {
+            card: { _seriesKey: metricColumns.metrics[0].column.name },
+          },
+          name: metricSeries.card.name,
+          tooltipName: metricColumns.metrics[0].column.display_name,
+          vizSettingsKey: metricColumns.metrics[0].column.name,
+        });
+        expect(result[1]).toMatchObject({
+          cardId: breakoutSeries.card.id,
+          column: breakoutColumns.metric.column,
+          columnIndex: breakoutColumns.metric.index,
+          dataKey: "2:count:type1",
+          legacySeriesSettingsObjectKey: {
+            card: { _seriesKey: "breakout card: formatted: type1" },
+          },
+          name: "breakout card: formatted: type1",
+          tooltipName: breakoutColumns.metric.column.display_name,
+          vizSettingsKey: "breakout card: formatted: type1",
+        });
+        expect(result[2]).toMatchObject({
+          cardId: breakoutSeries.card.id,
+          column: breakoutColumns.metric.column,
+          columnIndex: breakoutColumns.metric.index,
+          dataKey: "2:count:type2",
+          legacySeriesSettingsObjectKey: {
+            card: { _seriesKey: "breakout card: formatted: type2" },
+          },
+          name: "breakout card: formatted: type2",
+          tooltipName: breakoutColumns.metric.column.display_name,
+          vizSettingsKey: "breakout card: formatted: type2",
+        });
+      });
+
+      it("should return series models of two combined cards with overriden names", () => {
+        const result = getCardsSeriesModels(
+          rawSeries,
+          cardsColumns,
+          createMockComputedVisualizationSettings({
+            series_settings: {
+              [metricColumns.metrics[0].column.name]: {
+                title: "foo",
+              },
+              "breakout card: formatted: type2": {
+                title: "bar",
+              },
+            },
+          }),
+          renderingContextMock,
+        );
+
+        expect(result).toHaveLength(3);
+        expect(result[0]).toMatchObject({
+          dataKey: "1:count",
+          name: "foo",
+          tooltipName: "foo",
+        });
+        expect(result[1]).toMatchObject({
+          dataKey: "2:count:type1",
+          name: "breakout card: formatted: type1",
+          tooltipName: breakoutColumns.metric.column.display_name,
+        });
+        expect(result[2]).toMatchObject({
+          dataKey: "2:count:type2",
+          name: "bar",
+          tooltipName: breakoutColumns.metric.column.display_name,
+        });
+      });
+    });
+  });
+});

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
@@ -52,6 +52,7 @@ export type RegularSeriesModel = BaseSeriesModel & {
   legacySeriesSettingsObjectKey: LegacySeriesSettingsObjectKey;
 
   cardId?: number;
+  tooltipName: string;
 
   column: DatasetColumn;
   columnIndex: number;

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
@@ -26,6 +26,7 @@ import {
 } from "metabase/visualizations/lib/renderer_utils";
 import { dimensionIsTimeseries } from "metabase/visualizations/lib/timeseries";
 import { formatValueForTooltip } from "metabase/visualizations/lib/tooltip";
+import { getFriendlyName } from "metabase/visualizations/lib/utils";
 import type {
   ComputedVisualizationSettings,
   DataPoint,
@@ -131,7 +132,6 @@ export const getEventColumnsData = (
   chartModel: BaseCartesianChartModel,
   seriesIndex: number,
   dataIndex: number,
-  hasCombinedCards: boolean,
 ): DataPoint[] => {
   const datum = chartModel.dataset[dataIndex];
 
@@ -156,11 +156,9 @@ export const getEventColumnsData = (
       const col = chartModel.columnByDataKey[dataKey];
       const columnSeriesModel = seriesModelsByDataKey[dataKey];
       const key =
-        columnSeriesModel == null ||
-        "breakoutColumn" in columnSeriesModel ||
-        hasCombinedCards
-          ? col.display_name
-          : columnSeriesModel?.name;
+        columnSeriesModel == null
+          ? getFriendlyName(col)
+          : columnSeriesModel.tooltipName;
       const displayValue =
         isBreakoutSeries && seriesModel.breakoutColumn === col
           ? seriesModel.name
@@ -281,7 +279,6 @@ export const getSeriesHoverData = (
   chartModel: BaseCartesianChartModel,
   settings: ComputedVisualizationSettings,
   event: EChartsSeriesMouseEvent,
-  hasCombinedCards: boolean,
 ) => {
   const { dataIndex: echartsDataIndex, seriesId } = event;
   const dataIndex = getDataIndex(
@@ -302,12 +299,7 @@ export const getSeriesHoverData = (
     return;
   }
 
-  const data = getEventColumnsData(
-    chartModel,
-    seriesIndex,
-    dataIndex,
-    hasCombinedCards,
-  );
+  const data = getEventColumnsData(chartModel, seriesIndex, dataIndex);
 
   const stackedTooltipModel =
     settings["graph.tooltip_type"] === "series_comparison"
@@ -393,7 +385,6 @@ export const getSeriesClickData = (
   chartModel: BaseCartesianChartModel,
   settings: ComputedVisualizationSettings,
   event: EChartsSeriesMouseEvent,
-  hasCombinedCards: boolean,
 ): ClickObject | undefined => {
   const { seriesId, dataIndex: echartsDataIndex } = event;
   const dataIndex = getDataIndex(
@@ -409,12 +400,7 @@ export const getSeriesClickData = (
 
   const datum = chartModel.dataset[dataIndex];
 
-  const data = getEventColumnsData(
-    chartModel,
-    seriesIndex,
-    dataIndex,
-    hasCombinedCards,
-  );
+  const data = getEventColumnsData(chartModel, seriesIndex, dataIndex);
   const dimensions = getEventDimensions(
     chartModel,
     datum,

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
@@ -52,7 +52,6 @@ export const useChartEvents = (
   }: VisualizationProps,
 ) => {
   const isBrushing = useRef<boolean>();
-  const hasCombinedCards = rawSeries.length > 1;
 
   const onOpenQuestion = useCallback(
     (cardId?: CardId) => {
@@ -101,12 +100,7 @@ export const useChartEvents = (
             return;
           }
 
-          const hoveredData = getSeriesHoverData(
-            chartModel,
-            settings,
-            event,
-            hasCombinedCards,
-          );
+          const hoveredData = getSeriesHoverData(chartModel, settings, event);
 
           const isSameDatumHovered =
             hoveredData?.index === hovered?.index &&
@@ -116,20 +110,13 @@ export const useChartEvents = (
             return;
           }
 
-          onHoverChange?.(
-            getSeriesHoverData(chartModel, settings, event, hasCombinedCards),
-          );
+          onHoverChange?.(getSeriesHoverData(chartModel, settings, event));
         },
       },
       {
         eventName: "click",
         handler: (event: EChartsSeriesMouseEvent) => {
-          const clickData = getSeriesClickData(
-            chartModel,
-            settings,
-            event,
-            hasCombinedCards,
-          );
+          const clickData = getSeriesClickData(chartModel, settings, event);
 
           if (timelineEventsModel && event.name === "timeline-event") {
             onOpenTimelines?.();
@@ -196,7 +183,6 @@ export const useChartEvents = (
       onOpenTimelines,
       onSelectTimelineEvents,
       onDeselectTimelineEvents,
-      hasCombinedCards,
     ],
   );
 

--- a/frontend/test/__support__/echarts.ts
+++ b/frontend/test/__support__/echarts.ts
@@ -11,6 +11,7 @@ export const createMockSeriesModel = (
   return {
     dataKey,
     name: `name for ${dataKey}`,
+    tooltipName: `tooltip name for ${dataKey}`,
     color: "red",
     legacySeriesSettingsObjectKey: { card: { _seriesKey: dataKey } },
     vizSettingsKey: dataKey,


### PR DESCRIPTION
### Description

Fixes invalid tooltip series names. Previously we used series name for columns that are used by the series in tooltips. However, series names (what we show in legends) may differ from what we need to show in tooltips:

Here is a break down of what we need to show when cards are combined.
**For a single metric card**
Series name: `card name`
Tooltip name: `column name`
When series name is overriden in settings both series name and tooltip name should use the specified value.

**For a multiple metric card**
Series name: `card name: column name`
Tooltip name: `column name`
When series name is overriden in settings both series name and tooltip name should use the specified value.

**For a breakout card**
Series name: `card name: breakout value`
Tooltip name: `column name`
When series name is overriden in settings both series name and tooltip name should use the specified value.

### How to verify

Verify cases above and/or ensure `e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js` and `e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js` are green

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
