### PR TITLE
fix echarts remapping support

### DIFF
--- a/frontend/src/metabase/static-viz/components/StaticVisualization/StaticVisualization.tsx
+++ b/frontend/src/metabase/static-viz/components/StaticVisualization/StaticVisualization.tsx
@@ -1,3 +1,4 @@
+import { extractRemappings } from "metabase/visualizations";
 import type { StaticVisualizationProps } from "metabase/visualizations/types";
 
 import { ComboChart } from "../ComboChart";
@@ -9,23 +10,27 @@ import { WaterfallChart } from "../WaterfallChart/WaterfallChart";
 
 export const StaticVisualization = (props: StaticVisualizationProps) => {
   const display = props.rawSeries[0].card.display;
+  const staticVisualizationProps = {
+    ...props,
+    rawSeries: extractRemappings(props.rawSeries),
+  };
 
   switch (display) {
     case "line":
     case "area":
     case "bar":
     case "combo":
-      return <ComboChart {...props} />;
+      return <ComboChart {...staticVisualizationProps} />;
     case "scatter":
-      return <ScatterPlot {...props} />;
+      return <ScatterPlot {...staticVisualizationProps} />;
     case "waterfall":
-      return <WaterfallChart {...props} />;
+      return <WaterfallChart {...staticVisualizationProps} />;
     case "funnel":
-      return <FunnelBarChart {...props} />;
+      return <FunnelBarChart {...staticVisualizationProps} />;
     case "scalar":
-      return <ScalarChart {...props} />;
+      return <ScalarChart {...staticVisualizationProps} />;
     case "smartscalar":
-      return <SmartScalar {...props} />;
+      return <SmartScalar {...staticVisualizationProps} />;
   }
 
   throw new Error(`Unsupported display type: ${display}`);

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-models-and-option.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-models-and-option.ts
@@ -3,6 +3,7 @@ import { useCallback, useMemo } from "react";
 import { color } from "metabase/lib/colors";
 import { formatValue } from "metabase/lib/formatting";
 import { measureTextWidth } from "metabase/lib/measure-text";
+import { extractRemappings } from "metabase/visualizations";
 import { getChartMeasurements } from "metabase/visualizations/echarts/cartesian/chart-measurements";
 import { getCartesianChartModel } from "metabase/visualizations/echarts/cartesian/model";
 import type { CartesianChartModel } from "metabase/visualizations/echarts/cartesian/model/types";
@@ -28,9 +29,14 @@ export function useModelsAndOption({
   selectedTimelineEventIds,
   onRender,
 }: VisualizationProps) {
+  const rawSeriesWithRemappings = useMemo(
+    () => extractRemappings(rawSeries),
+    [rawSeries],
+  );
+
   const seriesToRender = useMemo(
-    () => (isPlaceholder ? transformedSeries : rawSeries),
-    [isPlaceholder, transformedSeries, rawSeries],
+    () => (isPlaceholder ? transformedSeries : rawSeriesWithRemappings),
+    [isPlaceholder, transformedSeries, rawSeriesWithRemappings],
   );
 
   const showWarning = useCallback(


### PR DESCRIPTION
### Description

Fixes missing column remapping support.

### How to verify

Open Orders: Product.ID [column settings](http://localhost:3000/admin/datamodel/database/1/schema/1:PUBLIC/table/5/field/40/general) and change "Display values" to "Ean":
<img width="1726" alt="Screenshot 2024-04-23 at 2 09 15 AM" src="https://github.com/metabase/metabase/assets/14301985/64f883b9-3610-4f9b-af9a-21fc227e4e5d">

Create a question: Orders grouped by Product ID. For convenience add a filter: Product ID < 5.
Ensure it shows Ean values instead of Product IDs:
<img width="1724" alt="Screenshot 2024-04-23 at 2 09 29 AM" src="https://github.com/metabase/metabase/assets/14301985/3bdff9d4-0f76-45c9-a765-36fb09be5cfe">

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
