### PR TITLE
improve loki workflows

### DIFF
--- a/.github/workflows/loki-update.yml
+++ b/.github/workflows/loki-update.yml
@@ -59,15 +59,14 @@ jobs:
           git push
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-
-      - name: Post Comment
+      - name: Remove 'loki-update' label
         uses: actions/github-script@v3
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            github.issues.createComment({
+            github.issues.removeLabel({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: "Snapshots have been updated"
+              name: 'loki-update'
             })

--- a/.github/workflows/loki.yml
+++ b/.github/workflows/loki.yml
@@ -57,8 +57,9 @@ jobs:
         run: yarn test-visual:loki-report
 
       - name: Upload Artifact
+        id: artifact-upload-step
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: loki-report
           path: .loki/
@@ -70,8 +71,8 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const runUrl = `https://github.com/metabase/metabase/actions/runs/${{ github.run_id }}`
-            const comment = `🚨 Visual Regression Tests failed. Get the [report artifact](${runUrl})`
+            const artifactUrl = "${{ steps.artifact-upload-step.outputs.artifact-url }}"
+            const comment = `🚨 Visual Regression Tests failed. Get the [report artifact](${artifactUrl})`
             github.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,

--- a/.github/workflows/loki.yml
+++ b/.github/workflows/loki.yml
@@ -64,18 +64,3 @@ jobs:
           name: loki-report
           path: .loki/
           if-no-files-found: ignore
-
-      - name: Post Comment with Report Link
-        if: failure()
-        uses: actions/github-script@v3
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            const artifactUrl = "${{ steps.artifact-upload-step.outputs.artifact-url }}"
-            const comment = `🚨 Visual Regression Tests failed. Get the [report artifact](${artifactUrl})`
-            github.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: comment
-            })


### PR DESCRIPTION
## Description

- Removes posting the comment about failed percy specs
- `loki-update` label gets removed by the workflow once it updated the snapshots