### PR TITLE
Fix TippyPopover default text color not visible after migration

### DIFF
--- a/frontend/src/metabase/css/components/tippy.module.css
+++ b/frontend/src/metabase/css/components/tippy.module.css
@@ -1,3 +1,7 @@
 :global(.tippy-content) {
   white-space: pre-wrap;
 }
+
+:global(.tippy-box) {
+  color: inherit;
+}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/41688
Relate to Epic https://github.com/metabase/metabase/issues/38811

### Description
This is how it looks after the migration, when [`color: (--non-existing-var)` was removed](https://github.com/metabase/metabase/commit/855b32452bb9fbcb800002f57fe11b4a8e31b048#diff-80e9da3c53d203b191b76db172e9c778cf38d00390b6b731c488d9523b21fc2dL56)
![Screenshot 2024-04-23 at 1 52 48 PM](https://github.com/metabase/metabase/assets/1937582/d4f21cf1-24ea-4458-a414-9862280419c0)

The color will be from `.tippy-box` rule instead.

The problem was from the way how default `color` is determined on Tippy popover. We previously used `color: var(--color-text-default)` but this custom property doesn't exist. What it actually does is overriding `color` from `.tippy-box` instead and since the CSS custom property doesn't exist, it ends up inheriting the color from `body`.

So to fix this I override `.tippy-box` color to be `color: inherit`, so it will use color from the root node style instead which is exactly the same way when we use `color: var(--this-var-do-not-exist)` before.

### How to verify

Check any popover and use TippyPopover under the hood e.g.
- Table viz column formatting
    ![image](https://github.com/metabase/metabase/assets/1937582/f80655bf-575f-4d58-9618-61093fa7632f)

- Notebook editor > custom column > function helper popover
    ![image](https://github.com/metabase/metabase/assets/1937582/357dd6cc-abc2-4cf7-b102-63bca86afc9b)

- When adding a new user to a group > type something to show the autocompletion popover
    ![image](https://github.com/metabase/metabase/assets/1937582/2e4b6d1a-2a4f-4b90-b056-b6adb4b4a674)

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~ Only style change
