### PR TITLE
embedding homepage analytics

### DIFF
--- a/e2e/test/scenarios/onboarding/embedding-homepage.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/embedding-homepage.cy.spec.ts
@@ -1,0 +1,78 @@
+import {
+  describeWithSnowplow,
+  expectGoodSnowplowEvent,
+  expectNoBadSnowplowEvents,
+  isEE,
+  main,
+  popover,
+  resetSnowplow,
+  restore,
+} from "e2e/support/helpers";
+
+describeWithSnowplow("scenarios > embedding-homepage > snowplow events", () => {
+  beforeEach(() => {
+    restore("default");
+    resetSnowplow();
+
+    cy.signInAsAdmin();
+    cy.intercept("GET", "/api/session/properties", req => {
+      req.continue(res => {
+        res.body["embedding-homepage"] = "visible";
+        res.body["setup-embedding-autoenabled"] = true;
+        res.body["example-dashboard-id"] = 1;
+        res.body["setup-license-active-at-setup"] = true;
+        res.send();
+      });
+    });
+  });
+
+  afterEach(() => {
+    expectNoBadSnowplowEvents();
+  });
+
+  it("embedding_homepage_quickstart_click", () => {
+    cy.visit("/");
+    main().findByText("Interactive").click();
+
+    main()
+      .findByText("Build it with the quick start")
+      // we don't want to actually visit the page and spam the analytics of the website
+      .closest("a")
+      .invoke("removeAttr", "href")
+      .click();
+
+    expectGoodSnowplowEvent({
+      event: "embedding_homepage_quickstart_click",
+      initial_tab: isEE ? "interactive" : "static",
+    });
+
+    // check that we didn't actually navigate to the page
+    cy.url().should("eq", Cypress.config().baseUrl + "/");
+  });
+
+  it("embedding_homepage_example_dashboard_click", () => {
+    cy.visit("/");
+
+    main().findByText("Static").click();
+
+    // the example-dashboard-id is mocked, it's normal that we'll get to a permision error page
+    main().findByText("Embed this example dashboard").click();
+
+    expectGoodSnowplowEvent({
+      event: "embedding_homepage_example_dashboard_click",
+      initial_tab: isEE ? "interactive" : "static",
+    });
+  });
+
+  it("embedding_homepage_dismissed", () => {
+    cy.visit("/");
+
+    main().findByText("Hide these").click();
+    popover().findByText("Embedding done, all good").click();
+
+    expectGoodSnowplowEvent({
+      event: "embedding_homepage_dismissed",
+      dismiss_reason: "dismissed-done",
+    });
+  });
+});

--- a/e2e/test/scenarios/onboarding/embedding-homepage.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/embedding-homepage.cy.spec.ts
@@ -30,7 +30,7 @@ describeWithSnowplow("scenarios > embedding-homepage > snowplow events", () => {
     expectNoBadSnowplowEvents();
   });
 
-  it("embedding_homepage_quickstart_click", () => {
+  it("clicking on the quickstart button should send the 'embedding_homepage_quickstart_click' event", () => {
     cy.visit("/");
     main().findByText("Interactive").click();
 
@@ -50,7 +50,7 @@ describeWithSnowplow("scenarios > embedding-homepage > snowplow events", () => {
     cy.url().should("eq", Cypress.config().baseUrl + "/");
   });
 
-  it("embedding_homepage_example_dashboard_click", () => {
+  it("opening the example dashboard from the button should send the 'embedding_homepage_example_dashboard_click' event", () => {
     cy.visit("/");
 
     main().findByText("Static").click();
@@ -64,7 +64,7 @@ describeWithSnowplow("scenarios > embedding-homepage > snowplow events", () => {
     });
   });
 
-  it("embedding_homepage_dismissed", () => {
+  it("dismissing the homepage should send the 'embedding_homepage_dismissed' event", () => {
     cy.visit("/");
 
     main().findByText("Hide these").click();

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -211,6 +211,15 @@ interface InstanceSettings {
   "user-visibility": string | null;
 }
 
+export type EmbeddingHomepageDismissReason =
+  | "dismissed-done"
+  | "dismissed-run-into-issues"
+  | "dismissed-not-interested-now";
+export type EmbeddingHomepageStatus =
+  | EmbeddingHomepageDismissReason
+  | "visible"
+  | "hidden";
+
 interface AdminSettings {
   "active-users-count"?: number;
   "deprecation-notice-version"?: string;
@@ -229,12 +238,7 @@ interface AdminSettings {
   "version-info": VersionInfo | null;
   "last-acknowledged-version": string | null;
   "show-static-embed-terms": boolean | null;
-  "embedding-homepage":
-    | "visible"
-    | "hidden"
-    | "dismissed-done"
-    | "dismissed-run-into-issues"
-    | "dismissed-not-interested-now";
+  "embedding-homepage": EmbeddingHomepageStatus;
   "setup-embedding-autoenabled": boolean;
   "setup-license-active-at-setup": boolean;
 }

--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.stories.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.stories.tsx
@@ -28,7 +28,7 @@ export const Default: Story = {
       <EmbedHomepageView
         {...args}
         exampleDashboardId={args.hasExampleDashboard ? 1 : null}
-        key={args.defaultTab}
+        key={args.initialTab}
       />
     );
   },
@@ -36,7 +36,7 @@ export const Default: Story = {
     embeddingAutoEnabled: true,
     hasExampleDashboard: true,
     licenseActiveAtSetup: true,
-    defaultTab: "interactive",
+    initialTab: "interactive",
     interactiveEmbeddingQuickstartUrl:
       "https://www.metabase.com/docs/latest/embedding/interactive-embedding-quick-start-guide.html",
     embeddingDocsUrl:

--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.tsx
@@ -8,11 +8,11 @@ import { useDispatch, useSelector } from "metabase/lib/redux";
 import { isEEBuild } from "metabase/lib/utils";
 import { addUndo } from "metabase/redux/undo";
 import { getDocsUrl, getSetting } from "metabase/selectors/settings";
+import type { EmbeddingHomepageDismissReason } from "metabase-types/api";
 
 import { EmbedHomepageView } from "./EmbedHomepageView";
 import { FeedbackModal } from "./FeedbackModal";
 import { dismissEmbeddingHomepage } from "./actions";
-import type { EmbedHomepageDismissReason } from "./types";
 
 export const EmbedHomepage = () => {
   const [feedbackModalOpened, setFeedbackModalOpened] = useState(false);
@@ -58,7 +58,7 @@ export const EmbedHomepage = () => {
     return "static";
   }, [plan]);
 
-  const onDismiss = (reason: EmbedHomepageDismissReason) => {
+  const onDismiss = (reason: EmbeddingHomepageDismissReason) => {
     if (reason === "dismissed-run-into-issues") {
       setFeedbackModalOpened(true);
     } else {

--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.tsx
@@ -47,7 +47,7 @@ export const EmbedHomepage = () => {
     getPlan(getSetting(state, "token-features")),
   );
 
-  const defaultTab = useMemo(() => {
+  const initialTab = useMemo(() => {
     // we want to show the interactive tab for EE builds
     // unless it's a starter cloud plan, which is EE build but doesn't have interactive embedding
     if (isEEBuild()) {
@@ -98,7 +98,7 @@ export const EmbedHomepage = () => {
         exampleDashboardId={exampleDashboardId}
         embeddingAutoEnabled={embeddingAutoEnabled}
         licenseActiveAtSetup={licenseActiveAtSetup}
-        defaultTab={defaultTab}
+        initialTab={initialTab}
         interactiveEmbeddingQuickstartUrl={interactiveEmbeddingQuickStartUrl}
         embeddingDocsUrl={embeddingDocsUrl}
         // eslint-disable-next-line no-unconditional-metabase-links-render -- only visible to admins

--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState } from "react";
 import { t } from "ttag";
 
-import { updateSetting } from "metabase/admin/settings/settings";
 import { useSendProductFeedbackMutation } from "metabase/api/product-feedback";
 import { useSetting } from "metabase/common/hooks";
 import { getPlan } from "metabase/common/utils/plan";
@@ -12,6 +11,7 @@ import { getDocsUrl, getSetting } from "metabase/selectors/settings";
 
 import { EmbedHomepageView } from "./EmbedHomepageView";
 import { FeedbackModal } from "./FeedbackModal";
+import { dismissEmbeddingHomepage } from "./actions";
 import type { EmbedHomepageDismissReason } from "./types";
 
 export const EmbedHomepage = () => {
@@ -60,7 +60,7 @@ export const EmbedHomepage = () => {
     if (reason === "dismissed-run-into-issues") {
       setFeedbackModalOpened(true);
     } else {
-      dispatch(updateSetting({ key: "embedding-homepage", value: reason }));
+      dispatch(dismissEmbeddingHomepage(reason));
     }
   };
 
@@ -71,12 +71,7 @@ export const EmbedHomepage = () => {
     comment?: string;
     email?: string;
   }) => {
-    dispatch(
-      updateSetting({
-        key: "embedding-homepage",
-        value: "dismiss-run-into-issues",
-      }),
-    );
+    dispatch(dismissEmbeddingHomepage("dismissed-run-into-issues"));
 
     setFeedbackModalOpened(false);
     sendProductFeedback({

--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.tsx
@@ -47,6 +47,8 @@ export const EmbedHomepage = () => {
     getPlan(getSetting(state, "token-features")),
   );
 
+  const utmTags = `?utm_source=${plan}&utm_media=embedding-homepage`;
+
   const initialTab = useMemo(() => {
     // we want to show the interactive tab for EE builds
     // unless it's a starter cloud plan, which is EE build but doesn't have interactive embedding
@@ -94,12 +96,16 @@ export const EmbedHomepage = () => {
         embeddingAutoEnabled={embeddingAutoEnabled}
         licenseActiveAtSetup={licenseActiveAtSetup}
         initialTab={initialTab}
-        interactiveEmbeddingQuickstartUrl={interactiveEmbeddingQuickStartUrl}
-        embeddingDocsUrl={embeddingDocsUrl}
-        // eslint-disable-next-line no-unconditional-metabase-links-render -- only visible to admins
-        analyticsDocsUrl="https://www.metabase.com/learn/customer-facing-analytics/"
-        learnMoreInteractiveEmbedUrl={learnMoreInteractiveEmbedding}
-        learnMoreStaticEmbedUrl={learnMoreStaticEmbedding}
+        interactiveEmbeddingQuickstartUrl={
+          interactiveEmbeddingQuickStartUrl + utmTags
+        }
+        embeddingDocsUrl={embeddingDocsUrl + utmTags}
+        analyticsDocsUrl={
+          // eslint-disable-next-line no-unconditional-metabase-links-render -- only visible to admins
+          "https://www.metabase.com/learn/customer-facing-analytics/" + utmTags
+        }
+        learnMoreInteractiveEmbedUrl={learnMoreInteractiveEmbedding + utmTags}
+        learnMoreStaticEmbedUrl={learnMoreStaticEmbedding + utmTags}
       />
       <FeedbackModal
         opened={feedbackModalOpened}

--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepageView.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepageView.tsx
@@ -13,17 +13,18 @@ import {
   Text,
   Title,
 } from "metabase/ui";
+import type { EmbeddingHomepageDismissReason } from "metabase-types/api";
 
 import { InteractiveTabContent } from "./InteractiveTabContent";
 import { StaticTabContent } from "./StaticTabContent";
-import type { EmbedHomepageDismissReason, InitialTab } from "./types";
+import type { EmbeddingHomepageInitialTab } from "./types";
 
 export type EmbedHomepageViewProps = {
   embeddingAutoEnabled: boolean;
   exampleDashboardId: number | null;
   licenseActiveAtSetup: boolean;
-  initialTab: InitialTab;
-  onDismiss: (reason: EmbedHomepageDismissReason) => void;
+  initialTab: EmbeddingHomepageInitialTab;
+  onDismiss: (reason: EmbeddingHomepageDismissReason) => void;
   // links
   interactiveEmbeddingQuickstartUrl: string;
   embeddingDocsUrl: string;

--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepageView.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepageView.tsx
@@ -16,13 +16,13 @@ import {
 
 import { InteractiveTabContent } from "./InteractiveTabContent";
 import { StaticTabContent } from "./StaticTabContent";
-import type { EmbedHomepageDismissReason } from "./types";
+import type { EmbedHomepageDismissReason, InitialTab } from "./types";
 
 export type EmbedHomepageViewProps = {
   embeddingAutoEnabled: boolean;
   exampleDashboardId: number | null;
   licenseActiveAtSetup: boolean;
-  initialTab: "interactive" | "static";
+  initialTab: InitialTab;
   onDismiss: (reason: EmbedHomepageDismissReason) => void;
   // links
   interactiveEmbeddingQuickstartUrl: string;

--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepageView.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepageView.tsx
@@ -22,7 +22,7 @@ export type EmbedHomepageViewProps = {
   embeddingAutoEnabled: boolean;
   exampleDashboardId: number | null;
   licenseActiveAtSetup: boolean;
-  defaultTab: "interactive" | "static";
+  initialTab: "interactive" | "static";
   onDismiss: (reason: EmbedHomepageDismissReason) => void;
   // links
   interactiveEmbeddingQuickstartUrl: string;
@@ -35,7 +35,7 @@ export type EmbedHomepageViewProps = {
 export const EmbedHomepageView = (props: EmbedHomepageViewProps) => {
   const {
     embeddingAutoEnabled,
-    defaultTab,
+    initialTab,
     embeddingDocsUrl,
     analyticsDocsUrl,
     onDismiss,
@@ -69,7 +69,7 @@ export const EmbedHomepageView = (props: EmbedHomepageViewProps) => {
       <Card px="xl" py="lg">
         {/* eslint-disable-next-line no-literal-metabase-strings -- only visible to admins */}
         <Title order={2} mb="md">{t`Embedding Metabase`}</Title>
-        <Tabs defaultValue={defaultTab}>
+        <Tabs defaultValue={initialTab}>
           <Tabs.List>
             <Tabs.Tab value="interactive">{t`Interactive`}</Tabs.Tab>
             <Tabs.Tab value="static">{t`Static`}</Tabs.Tab>

--- a/frontend/src/metabase/home/components/EmbedHomepage/InteractiveTabContent.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/InteractiveTabContent.tsx
@@ -5,6 +5,7 @@ import ExternalLink from "metabase/core/components/ExternalLink";
 import { Anchor, Button, Icon, Text, List } from "metabase/ui";
 
 import type { EmbedHomepageViewProps } from "./EmbedHomepageView";
+import { trackEmbeddingHomepageQuickstartClick } from "./analytics";
 
 export const InteractiveTabContent = ({
   embeddingAutoEnabled,
@@ -12,6 +13,7 @@ export const InteractiveTabContent = ({
   exampleDashboardId,
   licenseActiveAtSetup,
   learnMoreInteractiveEmbedUrl,
+  initialTab,
 }: EmbedHomepageViewProps) => {
   return (
     <>
@@ -55,7 +57,12 @@ export const InteractiveTabContent = ({
         <List.Item>{t`Customize the look and feel of your application to match your brand.`}</List.Item>
       </List>
 
-      <ExternalLink href={interactiveEmbeddingQuickstartUrl}>
+      <ExternalLink
+        href={interactiveEmbeddingQuickstartUrl}
+        // ExternalLink stops clicks events by default
+        onClickCapture={() => {}}
+        onClick={() => trackEmbeddingHomepageQuickstartClick(initialTab)}
+      >
         <Button
           variant="filled"
           mb="sm"

--- a/frontend/src/metabase/home/components/EmbedHomepage/InteractiveTabContent.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/InteractiveTabContent.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router";
 import { t, jt } from "ttag";
+import _ from "underscore";
 
 import ExternalLink from "metabase/core/components/ExternalLink";
 import { Anchor, Button, Icon, Text, List } from "metabase/ui";
@@ -60,7 +61,7 @@ export const InteractiveTabContent = ({
       <ExternalLink
         href={interactiveEmbeddingQuickstartUrl}
         // ExternalLink stops clicks events by default
-        onClickCapture={() => {}}
+        onClickCapture={_.noop}
         onClick={() => trackEmbeddingHomepageQuickstartClick(initialTab)}
       >
         <Button

--- a/frontend/src/metabase/home/components/EmbedHomepage/StaticTabContent.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/StaticTabContent.tsx
@@ -6,11 +6,13 @@ import { isNotNull } from "metabase/lib/types";
 import { Anchor, Button, Icon, Text, List } from "metabase/ui";
 
 import type { EmbedHomepageViewProps } from "./EmbedHomepageView";
+import { trackEmbeddingHomepageExampleDashboardClick } from "./analytics";
 
 export const StaticTabContent = ({
   embeddingAutoEnabled,
   exampleDashboardId,
   learnMoreStaticEmbedUrl,
+  initialTab,
 }: EmbedHomepageViewProps) => {
   return (
     <>
@@ -43,7 +45,12 @@ export const StaticTabContent = ({
       </List>
 
       {isNotNull(exampleDashboardId) && (
-        <Link to={`/dashboard/${exampleDashboardId}`}>
+        <Link
+          onClick={() =>
+            trackEmbeddingHomepageExampleDashboardClick(initialTab)
+          }
+          to={`/dashboard/${exampleDashboardId}`}
+        >
           <Button
             variant="filled"
             mb="sm"

--- a/frontend/src/metabase/home/components/EmbedHomepage/actions.ts
+++ b/frontend/src/metabase/home/components/EmbedHomepage/actions.ts
@@ -1,12 +1,12 @@
 import { updateSetting } from "metabase/admin/settings/settings";
 import { createAsyncThunk } from "metabase/lib/redux";
+import type { EmbeddingHomepageDismissReason } from "metabase-types/api";
 
 import { trackEmbeddingHomepageDismissed } from "./analytics";
-import type { EmbedHomepageDismissReason } from "./types";
 
 export const dismissEmbeddingHomepage = createAsyncThunk(
   "metabase/embedding-homepage/dismiss",
-  async (reason: EmbedHomepageDismissReason, { dispatch }) => {
+  async (reason: EmbeddingHomepageDismissReason, { dispatch }) => {
     dispatch(updateSetting({ key: "embedding-homepage", value: reason }));
     trackEmbeddingHomepageDismissed(reason);
   },

--- a/frontend/src/metabase/home/components/EmbedHomepage/actions.ts
+++ b/frontend/src/metabase/home/components/EmbedHomepage/actions.ts
@@ -1,0 +1,13 @@
+import { updateSetting } from "metabase/admin/settings/settings";
+import { createAsyncThunk } from "metabase/lib/redux";
+
+import { trackEmbeddingHomepageDismissed } from "./analytics";
+import type { EmbedHomepageDismissReason } from "./types";
+
+export const dismissEmbeddingHomepage = createAsyncThunk(
+  "metabase/embedding-homepage/dismiss",
+  async (reason: EmbedHomepageDismissReason, { dispatch }) => {
+    dispatch(updateSetting({ key: "embedding-homepage", value: reason }));
+    trackEmbeddingHomepageDismissed(reason);
+  },
+);

--- a/frontend/src/metabase/home/components/EmbedHomepage/analytics.ts
+++ b/frontend/src/metabase/home/components/EmbedHomepage/analytics.ts
@@ -1,0 +1,33 @@
+import { trackSchemaEvent } from "metabase/lib/analytics";
+
+import type { EmbedHomepageDismissReason, InitialTab } from "./types";
+
+const SCHEMA_NAME = "embedding_homepage";
+const SCHEMA_VERSION = "1-0-0";
+
+export const trackEmbeddingHomepageDismissed = (
+  dismiss_reason: EmbedHomepageDismissReason,
+) => {
+  trackSchemaEvent(SCHEMA_NAME, SCHEMA_VERSION, {
+    event: "embedding_homepage_dismissed",
+    dismiss_reason,
+  });
+};
+
+export const trackEmbeddingHomepageQuickstartClick = (
+  initial_tab: InitialTab,
+) => {
+  trackSchemaEvent(SCHEMA_NAME, SCHEMA_VERSION, {
+    event: "embedding_homepage_quickstart_click",
+    initial_tab,
+  });
+};
+
+export const trackEmbeddingHomepageExampleDashboardClick = (
+  initial_tab: InitialTab,
+) => {
+  trackSchemaEvent(SCHEMA_NAME, SCHEMA_VERSION, {
+    event: "embedding_homepage_example_dashboard_click",
+    initial_tab,
+  });
+};

--- a/frontend/src/metabase/home/components/EmbedHomepage/analytics.ts
+++ b/frontend/src/metabase/home/components/EmbedHomepage/analytics.ts
@@ -1,12 +1,13 @@
 import { trackSchemaEvent } from "metabase/lib/analytics";
+import type { EmbeddingHomepageDismissReason } from "metabase-types/api";
 
-import type { EmbedHomepageDismissReason, InitialTab } from "./types";
+import type { EmbeddingHomepageInitialTab } from "./types";
 
 const SCHEMA_NAME = "embedding_homepage";
 const SCHEMA_VERSION = "1-0-0";
 
 export const trackEmbeddingHomepageDismissed = (
-  dismiss_reason: EmbedHomepageDismissReason,
+  dismiss_reason: EmbeddingHomepageDismissReason,
 ) => {
   trackSchemaEvent(SCHEMA_NAME, SCHEMA_VERSION, {
     event: "embedding_homepage_dismissed",
@@ -15,7 +16,7 @@ export const trackEmbeddingHomepageDismissed = (
 };
 
 export const trackEmbeddingHomepageQuickstartClick = (
-  initial_tab: InitialTab,
+  initial_tab: EmbeddingHomepageInitialTab,
 ) => {
   trackSchemaEvent(SCHEMA_NAME, SCHEMA_VERSION, {
     event: "embedding_homepage_quickstart_click",
@@ -24,7 +25,7 @@ export const trackEmbeddingHomepageQuickstartClick = (
 };
 
 export const trackEmbeddingHomepageExampleDashboardClick = (
-  initial_tab: InitialTab,
+  initial_tab: EmbeddingHomepageInitialTab,
 ) => {
   trackSchemaEvent(SCHEMA_NAME, SCHEMA_VERSION, {
     event: "embedding_homepage_example_dashboard_click",

--- a/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
@@ -167,7 +167,7 @@ describe("EmbedHomepage (OSS)", () => {
       const lastCall = getLastHomepageSettingSettingCall();
 
       const body = await lastCall?.request?.json();
-      expect(body).toEqual({ value: "dismiss-run-into-issues" });
+      expect(body).toEqual({ value: "dismissed-run-into-issues" });
 
       const feedbackBody = await getLastFeedbackCall()?.request?.json();
 
@@ -196,7 +196,7 @@ describe("EmbedHomepage (OSS)", () => {
 
       const lastCall = getLastHomepageSettingSettingCall();
       const body = await lastCall?.request?.json();
-      expect(body).toEqual({ value: "dismiss-run-into-issues" });
+      expect(body).toEqual({ value: "dismissed-run-into-issues" });
 
       const feedbackBody = await getLastFeedbackCall()?.request?.json();
 

--- a/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
@@ -27,7 +27,7 @@ describe("EmbedHomepage (OSS)", () => {
     setup();
     expect(screen.getByText("Learn more")).toHaveAttribute(
       "href",
-      "https://www.metabase.com/docs/latest/embedding/static-embedding.html",
+      "https://www.metabase.com/docs/latest/embedding/static-embedding.html?utm_source=oss&utm_media=embedding-homepage",
     );
   });
 

--- a/frontend/src/metabase/home/components/EmbedHomepage/types.ts
+++ b/frontend/src/metabase/home/components/EmbedHomepage/types.ts
@@ -1,8 +1,1 @@
-import type { Settings } from "metabase-types/api";
-
-export type EmbedHomepageDismissReason = Exclude<
-  Settings["embedding-homepage"],
-  "visible" | "hidden"
->;
-
-export type InitialTab = "static" | "interactive";
+export type EmbeddingHomepageInitialTab = "static" | "interactive";

--- a/frontend/src/metabase/home/components/EmbedHomepage/types.ts
+++ b/frontend/src/metabase/home/components/EmbedHomepage/types.ts
@@ -4,3 +4,5 @@ export type EmbedHomepageDismissReason = Exclude<
   Settings["embedding-homepage"],
   "visible" | "hidden"
 >;
+
+export type InitialTab = "static" | "interactive";

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/StaticEmbedSetupPane.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/StaticEmbedSetupPane.tsx
@@ -77,6 +77,7 @@ export const StaticEmbedSetupPane = ({
 
   const siteUrl = useSetting("site-url");
   const secretKey = checkNotNull(useSetting("embedding-secret-key"));
+  const exampleDashboardId = useSetting("example-dashboard-id");
   const initialEmbeddingParams = getDefaultEmbeddingParams(
     resource,
     resourceParameters,
@@ -164,6 +165,7 @@ export const StaticEmbedSetupPane = ({
     trackStaticEmbedPublished({
       artifact: resourceType,
       resource,
+      isExampleDashboard: exampleDashboardId === resource.id,
       params: countEmbeddingParameterOptions({
         ...convertResourceParametersToEmbeddingParams(resourceParameters),
         ...embeddingParams,

--- a/frontend/src/metabase/public/lib/analytics.ts
+++ b/frontend/src/metabase/public/lib/analytics.ts
@@ -8,7 +8,7 @@ import type {
 } from "./types";
 
 const SCHEMA_NAME = "embed_flow";
-const SCHEMA_VERSION = "1-0-0";
+const SCHEMA_VERSION = "1-0-1";
 
 type Appearance = {
   titled: boolean;
@@ -33,10 +33,12 @@ export const trackStaticEmbedPublished = ({
   artifact,
   resource,
   params,
+  isExampleDashboard,
 }: {
   artifact: EmbedResourceType;
   resource: EmbedResource;
   params: Record<string, number>;
+  isExampleDashboard: boolean;
 }): void => {
   const now = Date.now();
   trackSchemaEvent(SCHEMA_NAME, SCHEMA_VERSION, {
@@ -50,6 +52,7 @@ export const trackStaticEmbedPublished = ({
       ? toSecond(now - new Date(resource.initially_published_at).getTime())
       : null,
     params,
+    isExampleDashboard,
   });
 };
 

--- a/frontend/src/metabase/public/lib/analytics.ts
+++ b/frontend/src/metabase/public/lib/analytics.ts
@@ -52,7 +52,7 @@ export const trackStaticEmbedPublished = ({
       ? toSecond(now - new Date(resource.initially_published_at).getTime())
       : null,
     params,
-    isExampleDashboard,
+    is_example_dashboard: isExampleDashboard,
   });
 };
 

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/embed_flow/jsonschema/1-0-1
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/embed_flow/jsonschema/1-0-1
@@ -1,0 +1,198 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "User interactions with public links, static embedding, and public embedding",
+  "self": {
+    "vendor": "com.metabase",
+    "name": "embed_flow",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "event": {
+      "type": "string",
+      "enum": [
+        "static_embed_discarded",
+        "static_embed_published",
+        "static_embed_unpublished",
+        "static_embed_code_copied",
+        "public_link_copied",
+        "public_embed_code_copied",
+        "public_link_removed"
+      ],
+      "description": "The type of event being recorded."
+    },
+    "artifact": {
+      "type": "string",
+      "enum": [
+        "dashboard",
+        "question"
+      ],
+      "description": "The type of artifact involved in the event (either a dashboard or a question)."
+    },
+    "new_embed": {
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "description": "Indicates if the embed is new."
+    },
+    "params": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "description": "Parameters related to the artifact.",
+      "properties": {
+        "locked": {
+          "type": "integer",
+          "description": "Number of locked parameters in the artifact.",
+          "minimum": 0,
+          "maximum": 2147483647
+        },
+        "editable": {
+          "type": "integer",
+          "description": "Number of editable parameters in the artifact.",
+          "minimum": 0,
+          "maximum": 2147483647
+        },
+        "disabled": {
+          "type": "integer",
+          "description": "Number of disabled parameters in the artifact.",
+          "minimum": 0,
+          "maximum": 2147483647
+        }
+      }
+    },
+    "first_published_at": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "date-time",
+      "description": "The timestamp when the artifact was first published."
+    },
+    "language": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "The backend or view language of the artifact.",
+      "maxLength": 1024
+    },
+    "location": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "code_overview",
+        "code_params",
+        "code_appearance"
+      ],
+      "description": "The location in the code where the event is triggered."
+    },
+    "code": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "backend",
+        "view"
+      ],
+      "description": "Type of the language of the artifact where the event is triggered."
+    },
+    "appearance": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "description": "The appearance settings of the artifact.",
+      "properties": {
+        "title": {
+          "type": "boolean",
+          "description": "Indicates if the title is visible."
+        },
+        "border": {
+          "type": "boolean",
+          "description": "Indicates if the border is visible."
+        },
+        "theme": {
+          "type": [
+            "string"
+          ],
+          "enum": [
+            "light",
+            "night",
+            "transparent"
+          ],
+          "description": "The theme of the artifact's appearance."
+        },
+        "font": {
+          "type": "string",
+          "enum": [
+            "instance",
+            "custom"
+          ],
+          "description": "The font type used in the artifact."
+        },
+        "hide_download_button": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Indicates if the download button is hidden. It will be null on OSS instance since it's not supported."
+        }
+      }
+    },
+    "format": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "html",
+        "csv",
+        "xlsx",
+        "json",
+        null
+      ],
+      "description": "The format of the public link."
+    },
+    "source": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "public-embed",
+        "public-share"
+      ],
+      "description": "Location where the public link is copied from"
+    },
+    "time_since_creation": {
+      "description": "Number of seconds from the creation of the artifact until the event is triggered.",
+      "type": [
+        "number",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "time_since_initial_publication": {
+      "description": "Number of seconds from the initial publication of the artifact until the event is triggered.",
+      "type": [
+        "number",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    }
+  },
+  "required": [
+    "event",
+    "artifact"
+  ],
+  "additionalProperties": false
+}

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/embed_flow/jsonschema/1-0-1
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/embed_flow/jsonschema/1-0-1
@@ -5,7 +5,7 @@
     "vendor": "com.metabase",
     "name": "embed_flow",
     "format": "jsonschema",
-    "version": "1-0-0"
+    "version": "1-0-1"
   },
   "type": "object",
   "properties": {
@@ -188,6 +188,13 @@
       ],
       "minimum": 0,
       "maximum": 2147483647
+    },
+    "is_example_dashboard": {
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "description": "Indicates if the dashboard is the example dashboard linked in the embedding homepage."
     }
   },
   "required": [

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/embedding_homepage/jsonschema/1-0-0
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/embedding_homepage/jsonschema/1-0-0
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "User interactions with the embedding-homepage",
+  "self": {
+    "vendor": "com.metabase",
+    "name": "embedding-homepage",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "event": {
+      "type": "string",
+      "enum": [
+        "embedding_homepage_dismissed",
+        "embedding_homepage_quickstart_click",
+        "embedding_homepage_example_dashboard_click"
+      ],
+      "description": "The type of event being recorded."
+    },
+    "dismiss_reason": {
+      "type": "string",
+      "enum": [
+        "dismissed-done",
+        "dismissed-run-into-issues",
+        "dismissed-not-interested-now"
+      ],
+      "description": "The reason the user dismissed the homepage."
+    },
+    "initial_tab": {
+      "type": "string",
+      "enum": [
+        "static",
+        "interactive"
+      ],
+      "description": "The tab that was initially selected when the user first viewed the homepage."
+    }
+  },
+  "required": [
+    "event"
+  ],
+  "additionalProperties": false
+}


### PR DESCRIPTION
Part of [[Epic] Initial homepage experience for embedding admins](https://github.com/metabase/metabase/issues/40005)

Slack thread: https://metaboat.slack.com/archives/C063Q3F1HPF/p1713357720005299

~UTM Tags on the links are still missing**, I'll add them on a separate PR~

I added temp utm tags, there's a discussion about how to structure them consistently in the app but for now we're using the ones in this PR: [slack thread](https://metaboat.slack.com/archives/C063Q3F1HPF/p1713893576320249?thread_ts=1713357720.005299&cid=C063Q3F1HPF)

### Description

This PR contains:
- 3 new events for the embedding homepage
- one change to the event dispatched when we publish a dashboard, I added a field to check if it's the example dashboard. We need the info for the funnel of the embedding homepage to see if they actually did followed it
