### PR TITLE
Render click actions popover inside the embedding SDK root

### DIFF
--- a/frontend/src/metabase/components/Popover/TippyPopover.tsx
+++ b/frontend/src/metabase/components/Popover/TippyPopover.tsx
@@ -5,6 +5,7 @@ import PropTypes from "prop-types";
 import { useState, useMemo, useCallback } from "react";
 import type * as tippy from "tippy.js";
 
+import { EMBEDDING_SDK_ROOT_ELEMENT_ID } from "embedding-sdk/config";
 import EventSandbox from "metabase/components/EventSandbox";
 import { isCypressActive } from "metabase/env";
 import useSequencedContentCloseHandler from "metabase/hooks/use-sequenced-content-close-handler";
@@ -35,7 +36,9 @@ const propTypes = {
 };
 
 function appendTo() {
-  return document.body;
+  return (
+    document.getElementById(EMBEDDING_SDK_ROOT_ELEMENT_ID) || document.body
+  );
 }
 
 function getPopperOptions({


### PR DESCRIPTION
Part of this [convo on Slack](https://metaboat.slack.com/archives/C063Q3F1HPF/p1713794416218099)

This render the visualization click actions popover inside the embedding SDK root.

#### How to verify
1. We render this popover under the embedding SDK root when using the SDK.
    ![Screenshot 2024-04-23 at 7 53 35 PM](https://github.com/metabase/metabase/assets/1937582/3addfc62-015d-4db5-8adc-e0fbde62815e)
3. We render this popover under `body` in the normal app
    ![Screenshot 2024-04-23 at 7 54 56 PM](https://github.com/metabase/metabase/assets/1937582/8f26b698-70fc-47d7-b6cc-bfcecfe63818)

