### PR TITLE
Export input wrapper and remove label hack

### DIFF
--- a/frontend/src/metabase/components/Schedule/components.tsx
+++ b/frontend/src/metabase/components/Schedule/components.tsx
@@ -175,6 +175,9 @@ export const AutoWidthSelect = (props: SelectProps) => {
           paddingRight: 0,
           marginTop: 0,
         },
+        label: {
+          marginBottom: 0,
+        },
         input: { paddingRight: 0 },
       }}
       {...props}

--- a/frontend/src/metabase/components/Schedule/components.tsx
+++ b/frontend/src/metabase/components/Schedule/components.tsx
@@ -174,7 +174,6 @@ export const AutoWidthSelect = (props: SelectProps) => {
         wrapper: {
           paddingRight: 0,
           marginTop: 0,
-          "&:not(:only-child)": { marginTop: "0" },
         },
         input: { paddingRight: 0 },
       }}

--- a/frontend/src/metabase/ui/components/inputs/Autocomplete/Autocomplete.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Autocomplete/Autocomplete.styled.tsx
@@ -18,7 +18,7 @@ export const getAutocompleteOverrides =
         maxDropdownHeight: 512,
       }),
       styles: (theme, _, { size = "md" }) => ({
-        ...getSelectInputOverrides(theme, size),
+        ...getSelectInputOverrides(theme),
         ...getSelectItemsOverrides(theme, size),
       }),
     },

--- a/frontend/src/metabase/ui/components/inputs/DateInput/DateInput.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/DateInput/DateInput.styled.tsx
@@ -1,5 +1,4 @@
 import type { MantineThemeOverride } from "@mantine/core";
-import { getSize } from "@mantine/core";
 
 export const getDateInputOverrides =
   (): MantineThemeOverride["components"] => ({
@@ -7,18 +6,9 @@ export const getDateInputOverrides =
       defaultProps: {
         size: "md",
       },
-      styles: (theme, _, { size = "md" }) => ({
-        wrapper: {
-          "&:not(:only-child)": {
-            marginTop: theme.spacing.xs,
-          },
-        },
+      styles: theme => ({
         calendar: {
           padding: `${theme.spacing.sm} ${theme.spacing.md}`,
-        },
-        label: {
-          color: theme.fn.themeColor("text-medium"),
-          fontSize: getSize({ size, sizes: theme.fontSizes }),
         },
       }),
     },

--- a/frontend/src/metabase/ui/components/inputs/FileInput/FileInput.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/FileInput/FileInput.styled.tsx
@@ -1,5 +1,4 @@
 import type { MantineThemeOverride } from "@mantine/core";
-import { getSize } from "@mantine/core";
 
 import { FileInputValue } from "./FileInputValue";
 
@@ -10,16 +9,5 @@ export const getFileInputOverrides =
         size: "md",
         valueComponent: FileInputValue,
       },
-      styles: (theme, _, { size = "md" }) => ({
-        wrapper: {
-          "&:not(:only-child)": {
-            marginTop: theme.spacing.xs,
-          },
-        },
-        label: {
-          color: theme.fn.themeColor("text-medium"),
-          fontSize: getSize({ size, sizes: theme.fontSizes }),
-        },
-      }),
     },
   });

--- a/frontend/src/metabase/ui/components/inputs/Input/Input.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Input/Input.styled.tsx
@@ -36,6 +36,11 @@ export const getInputOverrides = (): MantineThemeOverride["components"] => ({
           },
         },
       },
+      label: {
+        color: theme.fn.themeColor("text-medium"),
+        fontSize: getSize({ size, sizes: theme.fontSizes }),
+        marginBottom: theme.spacing.xs,
+      },
       icon: {
         color: theme.fn.themeColor("text-dark"),
       },

--- a/frontend/src/metabase/ui/components/inputs/Input/index.ts
+++ b/frontend/src/metabase/ui/components/inputs/Input/index.ts
@@ -1,1 +1,2 @@
+export { Input } from "@mantine/core";
 export { getInputOverrides } from "./Input.styled";

--- a/frontend/src/metabase/ui/components/inputs/MultiSelect/MultiSelect.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiSelect/MultiSelect.styled.tsx
@@ -34,7 +34,7 @@ export const getMultiSelectOverrides =
         { invalid }: MultiSelectStylesParams,
         { size = "md" },
       ) => ({
-        ...getSelectInputOverrides(theme, size),
+        ...getSelectInputOverrides(theme),
         ...getSelectItemsOverrides(theme, size),
         values: {
           minHeight: getSize({ size, sizes: SIZES }),

--- a/frontend/src/metabase/ui/components/inputs/Select/Select.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Select/Select.styled.tsx
@@ -4,7 +4,7 @@ import type {
   MantineThemeOverride,
   CSSObject,
 } from "@mantine/core";
-import { getStylesRef, px, rem } from "@mantine/core";
+import { getStylesRef, px, rem, getSize } from "@mantine/core";
 
 import { SelectDropdown } from "./SelectDropdown";
 import { SelectItem } from "./SelectItem";
@@ -21,9 +21,9 @@ export const getSelectOverrides = (): MantineThemeOverride["components"] => ({
         color: "text-dark",
       },
     }),
-    styles: theme => ({
+    styles: (theme, _, { size = "md" }) => ({
       ...getSelectInputOverrides(theme),
-      ...getSelectItemsOverrides(theme),
+      ...getSelectItemsOverrides(theme, size),
       // For epic (metabase#38699)
       dropdown: {
         ">div": {

--- a/frontend/src/metabase/ui/components/inputs/Select/Select.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Select/Select.styled.tsx
@@ -4,7 +4,7 @@ import type {
   MantineThemeOverride,
   CSSObject,
 } from "@mantine/core";
-import { getSize, getStylesRef, px, rem } from "@mantine/core";
+import { getStylesRef, px, rem } from "@mantine/core";
 
 import { SelectDropdown } from "./SelectDropdown";
 import { SelectItem } from "./SelectItem";
@@ -21,9 +21,9 @@ export const getSelectOverrides = (): MantineThemeOverride["components"] => ({
         color: "text-dark",
       },
     }),
-    styles: (theme, _, { size = "md" }) => ({
-      ...getSelectInputOverrides(theme, size),
-      ...getSelectItemsOverrides(theme, size),
+    styles: theme => ({
+      ...getSelectInputOverrides(theme),
+      ...getSelectItemsOverrides(theme),
       // For epic (metabase#38699)
       dropdown: {
         ">div": {
@@ -38,7 +38,6 @@ export const getSelectOverrides = (): MantineThemeOverride["components"] => ({
 
 export const getSelectInputOverrides = (
   theme: MantineTheme,
-  size: MantineSize | number,
 ): Record<string, CSSObject> => {
   return {
     root: {
@@ -51,9 +50,7 @@ export const getSelectInputOverrides = (
       },
     },
     label: {
-      color: theme.fn.themeColor("text-medium"),
       ref: getStylesRef("label"),
-      fontSize: getSize({ size, sizes: theme.fontSizes }),
     },
     description: {
       ref: getStylesRef("description"),
@@ -64,9 +61,6 @@ export const getSelectInputOverrides = (
     wrapper: {
       ref: getStylesRef("wrapper"),
       color: theme.fn.themeColor("text-dark"),
-      "&:not(:only-child)": {
-        marginTop: theme.spacing.xs,
-      },
       [`&:has(.${getStylesRef("input")}[data-disabled])`]: {
         opacity: 1,
         pointerEvents: "auto",

--- a/frontend/src/metabase/ui/components/inputs/TextInput/TextInput.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/TextInput/TextInput.styled.tsx
@@ -1,5 +1,4 @@
 import type { MantineThemeOverride } from "@mantine/core";
-import { getSize } from "@mantine/core";
 
 export const getTextInputOverrides =
   (): MantineThemeOverride["components"] => ({
@@ -7,16 +6,5 @@ export const getTextInputOverrides =
       defaultProps: {
         size: "md",
       },
-      styles: (theme, _, { size = "md" }) => ({
-        wrapper: {
-          "&:not(:only-child)": {
-            marginTop: theme.spacing.xs,
-          },
-        },
-        label: {
-          color: theme.fn.themeColor("text-medium"),
-          fontSize: getSize({ size, sizes: theme.fontSizes }),
-        },
-      }),
     },
   });

--- a/frontend/src/metabase/ui/components/inputs/Textarea/Textarea.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Textarea/Textarea.styled.tsx
@@ -1,5 +1,4 @@
 import type { MantineThemeOverride } from "@mantine/core";
-import { getSize } from "@mantine/core";
 
 export const getTextareaOverrides = (): MantineThemeOverride["components"] => ({
   Textarea: {
@@ -9,16 +8,5 @@ export const getTextareaOverrides = (): MantineThemeOverride["components"] => ({
       minRows: 2,
       maxRows: 6,
     },
-    styles: (theme, _, { size = "md" }) => ({
-      wrapper: {
-        "&:not(:only-child)": {
-          marginTop: theme.spacing.xs,
-        },
-      },
-      label: {
-        color: theme.fn.themeColor("text-medium"),
-        fontSize: getSize({ size, sizes: theme.fontSizes }),
-      },
-    }),
   },
 });

--- a/frontend/src/metabase/ui/components/inputs/TimeInput/TimeInput.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/TimeInput/TimeInput.styled.tsx
@@ -6,12 +6,5 @@ export const getTimeInputOverrides =
       defaultProps: {
         size: "md",
       },
-      styles: theme => ({
-        wrapper: {
-          "&:not(:only-child)": {
-            marginTop: theme.spacing.xs,
-          },
-        },
-      }),
     },
   });


### PR DESCRIPTION
This PR proposes to remove the `&:not(:only-child)` wrapper hack from our input components 

- TextInput
- TextArea
- Select
- FileInput
- DateInput
- TimeInput

All these components share an underlying component: `Input`, and it makes more sense to implement it there.

The components share this basic structure:
```
<Input.Wrapper>
  {label && <label>{label}</label>}
  <{actual input control} />
</Input.Wrapper>
```

This makes use of the observation that `&:not(:only-child)` is functionally equivalent to the `label` component being rendered. Therefore makes more sense to add a bottom margin to the `label` component than it is to add a top margin to the input when the label is rendered.

This is easier to reason about and potentially override.