### PR TITLE
tabbing through save question modal

### DIFF
--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -298,6 +298,11 @@ describe("scenarios > question > new", () => {
       cy.findByText("Orders").click();
     });
     cy.findByTestId("qb-header").findByText("Save").click();
+
+    cy.log("should be able to tab through fields (metabase#41683)");
+    cy.realPress("Tab").realPress("Tab");
+    cy.findByLabelText("Description").should("be.focused");
+
     cy.findByTestId("save-question-modal")
       .findByLabelText(/Which collection/)
       .click();

--- a/frontend/src/metabase/query_builder/components/QueryModals.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryModals.tsx
@@ -118,29 +118,27 @@ class QueryModals extends Component<QueryModalsProps> {
     switch (modal) {
       case MODAL_TYPES.SAVE:
         return (
-          <Modal form onClose={onCloseModal}>
-            <SaveQuestionModal
-              question={this.props.question}
-              originalQuestion={this.props.originalQuestion}
-              initialCollectionId={this.props.initialCollectionId}
-              onSave={async (question: Question) => {
-                // if saving modified question, don't show "add to dashboard" modal
-                await this.props.onSave(question);
+          <SaveQuestionModal
+            question={this.props.question}
+            originalQuestion={this.props.originalQuestion}
+            initialCollectionId={this.props.initialCollectionId}
+            onSave={async (question: Question) => {
+              // if saving modified question, don't show "add to dashboard" modal
+              await this.props.onSave(question);
+              onCloseModal();
+            }}
+            onCreate={async question => {
+              await this.props.onCreate(question);
+              const type = question.type();
+              if (type === "model") {
                 onCloseModal();
-              }}
-              onCreate={async question => {
-                await this.props.onCreate(question);
-                const type = question.type();
-                if (type === "model") {
-                  onCloseModal();
-                  setQueryBuilderMode("view");
-                } else {
-                  onOpenModal(MODAL_TYPES.SAVED);
-                }
-              }}
-              onClose={onCloseModal}
-            />
-          </Modal>
+                setQueryBuilderMode("view");
+              } else {
+                onOpenModal(MODAL_TYPES.SAVED);
+              }
+            }}
+            onClose={onCloseModal}
+          />
         );
       case MODAL_TYPES.SAVED:
         return (


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/41683

### Description
Fixing tabbing in the save question modal. This was broken because the Mantine modal component was wrapped in our own modal component, and both components were trying to trap focus. I added a quick assertion to an existing e2e test to protect against regressions.

### How to verify

1. New question -> Sample Dataset -> Orders
2. click save
3. attempt to tab through the form in the modal

### Demo
![chrome_vZoXHX0l7o](https://github.com/metabase/metabase/assets/1328979/02e53127-5dfc-4a1a-9eb6-830a30351470)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
