### PR TITLE
dont use buildjet for e2e or frontend tests

### DIFF
--- a/.github/actions/build-e2e-matrix/action.yml
+++ b/.github/actions/build-e2e-matrix/action.yml
@@ -49,8 +49,8 @@ runs:
             ["visualizations-charts", {} ],
             ["visualizations-tabular", {} ],
             ["oss-subset", { edition: 'oss', context: "special" } ],
-            ["slow", { runner: beefierRunner, context: "special" } ],
-            ["flaky", { runner: beefierRunner, context: "special" } ],
+            ["slow", { context: "special" } ],
+            ["flaky", { context: "special" } ],
             ["mongo", { context: "qa-database" } ],
           ];
 

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -70,7 +70,7 @@ jobs:
   fe-tests-unit:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.frontend_all == 'true'
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
       JEST_JUNIT_OUTPUT_DIR: ./target/junit


### PR DESCRIPTION
suddenly all our buildjet ci jobs are struggling, this moves them to github runners.