### PR TITLE
Add `collection.effective_ancestors` to model search results

### DIFF
--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -444,9 +444,9 @@
           results)))
 
 (defn add-dataset-collection-hierarchy
-  "Adds collection names to datasets."
+  "Adds `collection_effective_ancestors` to *datasets* in the search results."
   [search-results]
-  (let [;; this function takes a search result (with `collection_id` and `collection_location`) and returns the
+  (let [;; this helper function takes a search result (with `collection_id` and `collection_location`) and returns the
         ;; effective location of the result.
         result->loc (fn [{:keys [collection_id collection_location]}]
                       (:effective_location

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -99,6 +99,7 @@
    [:map {:closed true}
     [:search-string                                        [:maybe ms/NonBlankString]]
     [:archived?                                            :boolean]
+    [:model-ancestors?                                     :boolean]
     [:current-user-perms                                   [:set perms.u/PathSchema]]
     [:models                                               [:set SearchableModel]]
     [:filter-items-in-personal-collection {:optional true} [:enum "only" "exclude"]]
@@ -138,6 +139,7 @@
    :collection_id       :integer
    :collection_name     :text
    :collection_type     :text
+   :collection_location :text
    :collection_authority_level :text
    ;; returned for Card and Dashboard
    :collection_position :integer
@@ -270,6 +272,7 @@
   [_]
   (conj default-columns :collection_id :collection_position :dataset_query :display :creator_id
         [:collection.name :collection_name]
+        [:collection.location :collection_location]
         [:collection.authority_level :collection_authority_level]
         bookmark-col dashboardcard-count-col))
 

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -301,12 +301,12 @@
      (max (- stale-time days-ago) 0)
      stale-time)))
 
-(defn- serialize
+(defn serialize
   "Massage the raw result from the DB and match data into something more useful for the client"
-  [result all-scores relevant-scores]
-  (let [{:keys [name display_name collection_id collection_name collection_authority_level collection_type]} result
-        matching-columns            (into #{} (remove nil? (map :column relevant-scores)))
-        match-context-thunk         (first (keep :match-context-thunk relevant-scores))]
+  [{:as result :keys [all-scores relevant-scores name display_name collection_id collection_name
+                      collection_authority_level collection_type collection_effective_ancestors]}]
+  (let [matching-columns    (into #{} (remove nil? (map :column relevant-scores)))
+        match-context-thunk (first (keep :match-context-thunk relevant-scores))]
     (-> result
         (assoc
          :name           (if (and (contains? matching-columns :display_name) display_name)
@@ -316,14 +316,20 @@
                                     (empty?
                                      (remove matching-columns search.config/displayed-columns)))
                            (match-context-thunk))
-         :collection     {:id              collection_id
-                          :name            collection_name
-                          :authority_level collection_authority_level
-                          :type            collection_type}
+         :collection     (merge {:id              collection_id
+                                 :name            collection_name
+                                 :authority_level collection_authority_level
+                                 :type            collection_type}
+                                (when collection_effective_ancestors
+                                  {:effective_ancestors collection_effective_ancestors}))
          :scores          all-scores)
         (update :dataset_query #(some-> % json/parse-string mbql.normalize/normalize))
         (dissoc
+         :all-scores
+         :relevant-scores
+         :collection_effective_ancestors
          :collection_id
+         :collection_location
          :collection_name
          :collection_type
          :display_name))))
@@ -397,7 +403,7 @@
                           0
                           text-matches)))
       {:score total-score
-       :result (serialize result all-scores relevant-scores)}
+       :result (assoc result :all-scores all-scores :relevant-scores relevant-scores)}
       {:score 0})))
 
 (defn compare-score

--- a/test/metabase/search/filter_test.clj
+++ b/test/metabase/search/filter_test.clj
@@ -11,6 +11,7 @@
   {:search-string       nil
    :archived?           false
    :models             search.config/all-models
+   :model-ancestors?   false
    :current-user-perms #{"/"}})
 
 (deftest ^:parallel ->applicable-models-test

--- a/test/metabase/search/scoring_test.clj
+++ b/test/metabase/search/scoring_test.clj
@@ -280,11 +280,13 @@
                   :database 1}
           result {:name          "card"
                   :model         "card"
-                  :dataset_query (json/generate-string query)}]
-      (is (= query (-> result (#'scoring/serialize {} {}) :dataset_query)))))
+                  :dataset_query (json/generate-string query)
+                  :all-scores {}
+                  :relevant-scores {}}]
+      (is (= query (-> result scoring/serialize :dataset_query)))))
   (testing "Doesn't error on other models without a query"
-    (is (nil? (-> {:name "dash" :model "dashboard"}
-                  (#'scoring/serialize {} {})
+    (is (nil? (-> {:name "dash" :model "dashboard" :all-scores {} :relevant-scores {}}
+                  (#'scoring/serialize)
                   :dataset_query)))))
 
 (deftest ^:parallel force-weight-test


### PR DESCRIPTION
fixes https://github.com/metabase/metabase/issues/41909

The ultimate goal here is to be able to display a UI like so:

![image](https://github.com/metabase/metabase/assets/2152134/2f2658d3-2ac5-412e-b79c-951103cd6552)

To do this, we want the frontend to have access to the effective ancestors of model search results.

This was a bit more painful than I'd hoped. The primary issue was that we tied two things together:

- scoring results

- "serializing" results (really, partially serializing results, because we do more work to shape the data later)

Why is this a problem? The `top-scorers` function took a transducer and returned the *serialized* top scorers. Later, when we need to operate on *all* the top results (in this case, to collect all the collection IDs and names that we know of), we're looking at the serialized results.

In our case, we needed some data (collection location) that wasn't included after serialization. We could add it, of course, but it's frustrating to need to change the API of what data is *returned* from the endpoint for purely internal purposes (changing the data available during *processing*).

I ended up pulling serialization out of the scoring function. At some point down the road, we should go ahead and move the `serialize` function out of the `search.scoring` namespace entirely - there's really no reason for it to belong there as far as I can tell.
