### PR TITLE
Track public and embedded card views, and collection views in the view log

### DIFF
--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -16,6 +16,7 @@
    [metabase.db.query :as mdb.query]
    [metabase.driver.common.parameters :as params]
    [metabase.driver.common.parameters.parse :as params.parse]
+   [metabase.events :as events]
    [metabase.legacy-mbql.normalize :as mbql.normalize]
    [metabase.models.card :as card :refer [Card]]
    [metabase.models.collection :as collection :refer [Collection]]
@@ -860,13 +861,15 @@
    pinned_state   [:maybe (into [:enum] valid-pinned-state-values)]
    sort_column    [:maybe (into [:enum] valid-sort-columns)]
    sort_direction [:maybe (into [:enum] valid-sort-directions)]}
-  (let [model-kwds (set (map keyword (u/one-or-many models)))]
-    (collection-children (api/read-check Collection id)
-                         {:models       model-kwds
-                          :archived?    archived
-                          :pinned-state (keyword pinned_state)
-                          :sort-info    [(or (some-> sort_column normalize-sort-choice) :name)
-                                         (or (some-> sort_direction normalize-sort-choice) :asc)]})))
+  (let [model-kwds (set (map keyword (u/one-or-many models)))
+        collection (api/read-check Collection id)]
+    (u/prog1 (collection-children collection
+                                  {:models       model-kwds
+                                   :archived?    archived
+                                   :pinned-state (keyword pinned_state)
+                                   :sort-info    [(or (some-> sort_column normalize-sort-choice) :name)
+                                                  (or (some-> sort_direction normalize-sort-choice) :asc)]})
+      (events/publish-event! :event/collection-read {:object collection :user-id api/*current-user-id*}))))
 
 
 ;;; -------------------------------------------- GET /api/collection/root --------------------------------------------

--- a/src/metabase/api/embed.clj
+++ b/src/metabase/api/embed.clj
@@ -390,7 +390,8 @@
   [token]
   (let [unsigned (embed/unsign token)]
     (check-embedding-enabled-for-card (embed/get-in-unsigned-token-or-throw unsigned [:resource :question]))
-    (card-for-unsigned-token unsigned, :constraints [:enable_embedding true])))
+    (u/prog1 (card-for-unsigned-token unsigned, :constraints [:enable_embedding true])
+      (events/publish-event! :event/card-read {:object <>, :user-id api/*current-user-id*}))))
 
 (defn ^:private run-query-for-unsigned-token-async
   "Run the query belonging to Card identified by `unsigned-token`. Checks that embedding is enabled both globally and

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -98,7 +98,8 @@
   [uuid]
   {uuid ms/UUIDString}
   (validation/check-public-sharing-enabled)
-  (card-with-uuid uuid))
+  (u/prog1 (card-with-uuid uuid)
+    (events/publish-event! :event/card-read {:object <>, :user-id api/*current-user-id*})))
 
 (defmulti ^:private transform-qp-result
   "Transform results to be suitable for a public endpoint"

--- a/src/metabase/events/schema.clj
+++ b/src/metabase/events/schema.clj
@@ -4,6 +4,14 @@
    [malli.util :as mut]
    [toucan2.core :as t2]))
 
+;; collection events
+(let [default-schema (mc/schema
+                      [:map {:closed true}
+                       [:user-id  pos-int?]
+                       [:object   [:fn #(t2/instance-of? :model/Collection %)]]])]
+  (def ^:private collection-events-schemas
+    {:event/collection-read default-schema}))
+
 ;; dashboard events
 
 (let [default-schema (mc/schema
@@ -28,7 +36,7 @@
 
 (let [default-schema (mc/schema
                       [:map {:closed true}
-                       [:user-id  pos-int?]
+                       [:user-id  [:maybe pos-int?]]
                        [:object   [:fn #(t2/instance-of? :model/Card %)]]])]
   (def ^:private card-events-schemas
     {:event/card-create default-schema
@@ -131,13 +139,14 @@
 
 (def topic->schema
   "Returns the schema for an event topic."
-  (merge dashboard-events-schemas
+  (merge alert-schema
          card-events-schemas
-         user-events-schema
-         metric-related-schema
-         segment-related-schema
+         collection-events-schemas
+         dashboard-events-schemas
          database-events
-         alert-schema
+         metric-related-schema
+         permission-failure-events
          pulse-schemas
          table-events
-         permission-failure-events))
+         user-events-schema
+         segment-related-schema))

--- a/src/metabase/events/view_log.clj
+++ b/src/metabase/events/view_log.clj
@@ -47,6 +47,19 @@
       (catch Throwable e
         (log/warnf e "Failed to process view_log event. %s" topic)))))
 
+(derive ::collection-read-event :metabase/event)
+(derive :event/collection-read ::collection-read-event)
+
+(m/defmethod events/publish-event! ::collection-read-event
+  "Handle processing for a generic read event notification"
+  [topic event]
+  (try
+    (-> event
+        generate-view
+        record-views!)
+    (catch Throwable e
+      (log/warnf e "Failed to process view_log event. %s" topic))))
+
 (derive ::read-permission-failure :metabase/event)
 (derive :event/read-permission-failure ::read-permission-failure)
 

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -15,7 +15,6 @@
    [metabase.api.pivots :as api.pivots]
    [metabase.config :as config]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
-   [metabase.events.view-log-test :as view-log-test]
    [metabase.http-client :as client]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
@@ -29,7 +28,6 @@
    [metabase.models.permissions-group :as perms-group]
    [metabase.models.revision :as revision]
    [metabase.permissions.util :as perms.u]
-   [metabase.public-settings.premium-features :as premium-features]
    [metabase.query-processor :as qp]
    [metabase.query-processor.async :as qp.async]
    [metabase.query-processor.card :as qp.card]
@@ -3349,18 +3347,6 @@
           (is (= {:body   {:message "The uploads database does not exist."},
                   :status 422}
                  (upload-example-csv-via-api!))))))))
-
-(deftest card-read-event-test
-  (when (premium-features/log-enabled?)
-    (testing "Card reads (views) via the API are recorded in the view_log"
-      (t2.with-temp/with-temp [:model/Card card {:name "My Cool Card" :type :question}]
-        (testing "GET /api/card/:id"
-          (mt/user-http-request :crowberto :get 200 (format "card/%s" (u/id card)))
-          (is (partial=
-               {:user_id  (mt/user->id :crowberto)
-                :model    "card"
-                :model_id (u/id card)}
-               (view-log-test/latest-view (mt/user->id :crowberto) (u/id card)))))))))
 
 (deftest pivot-from-model-test
   (testing "Pivot options should match fields through models (#35319)"

--- a/test/metabase/api/embed_test.clj
+++ b/test/metabase/api/embed_test.clj
@@ -15,14 +15,12 @@
    [metabase.api.pivots :as api.pivots]
    [metabase.api.public-test :as public-test]
    [metabase.config :as config]
-   [metabase.events.view-log-test :as view-log-test]
    [metabase.http-client :as client]
    [metabase.models
     :refer [Card Dashboard DashboardCard DashboardCardSeries]]
    [metabase.models.field-values :as field-values]
    [metabase.models.interface :as mi]
    [metabase.models.params.chain-filter-test :as chain-filer-test]
-   [metabase.public-settings.premium-features :as premium-features]
    [metabase.query-processor.middleware.constraints :as qp.constraints]
    [metabase.query-processor.middleware.process-userland-query-test :as process-userland-query-test]
    [metabase.query-processor.test-util :as qp.test-util]
@@ -160,7 +158,7 @@
 
 ;;; ------------------------------------------- GET /api/embed/card/:token -------------------------------------------
 
-(defn- card-url [card & [additional-token-params]] (str "embed/card/" (card-token card additional-token-params)))
+(defn card-url [card & [additional-token-params]] (str "embed/card/" (card-token card additional-token-params)))
 
 (deftest it-should-be-possible-to-use-this-endpoint-successfully-if-all-the-conditions-are-met
   (with-embedding-enabled-and-new-secret-key
@@ -527,7 +525,7 @@
 
 ;;; ---------------------------------------- GET /api/embed/dashboard/:token -----------------------------------------
 
-(defn- dashboard-url [dashboard & [additional-token-params]]
+(defn dashboard-url [dashboard & [additional-token-params]]
   (str "embed/dashboard/" (dash-token dashboard additional-token-params)))
 
 (deftest it-should-be-possible-to-call-this-endpoint-successfully
@@ -536,18 +534,6 @@
       (is (= successful-dashboard-info
              (dissoc-id-and-name
               (client/client :get 200 (dashboard-url dash))))))))
-
-(deftest embedding-logs-view-test
-  (when (premium-features/log-enabled?)
-    (with-embedding-enabled-and-new-secret-key
-      (t2.with-temp/with-temp [Dashboard dash {:enable_embedding true}]
-        (testing "Viewing an embedding logs the correct view log event."
-          (client/client :get 200 (dashboard-url dash))
-          (is (partial=
-               {:model      "dashboard"
-                :model_id   (:id dash)
-                :has_access true}
-               (view-log-test/latest-view nil (:id dash)))))))))
 
 (deftest bad-dashboard-id-fails
   (with-embedding-enabled-and-new-secret-key

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -13,7 +13,6 @@
    [metabase.api.pivots :as api.pivots]
    [metabase.api.public :as api.public]
    [metabase.config :as config]
-   [metabase.events.view-log-test :as view-log-test]
    [metabase.http-client :as client]
    [metabase.models
     :refer [Card Collection Dashboard DashboardCard DashboardCardSeries
@@ -22,7 +21,6 @@
    [metabase.models.params.chain-filter-test :as chain-filter-test]
    [metabase.models.permissions :as perms]
    [metabase.models.permissions-group :as perms-group]
-   [metabase.public-settings.premium-features :as premium-features]
    [metabase.test :as mt]
    [metabase.util :as u]
    [throttle.core :as throttle]
@@ -48,7 +46,7 @@
                                           :type         :number
                                           :required     false}}}})
 
-(defn- do-with-temp-public-card [m f]
+(defn do-with-temp-public-card [m f]
   (let [m (merge (when-not (:dataset_query m)
                    {:dataset_query (mt/mbql-query venues {:aggregation [[:count]]})})
                  (when-not (:parameters m)
@@ -65,13 +63,14 @@
       ;; public sharing is disabled; but we still want to test it
       (f (assoc card :public_uuid (:public_uuid m))))))
 
-(defmacro ^:private with-temp-public-card {:style/indent 1} [[binding & [card]] & body]
+(defmacro with-temp-public-card {:style/indent 1} [[binding & [card]] & body]
   `(do-with-temp-public-card
     ~card
     (fn [~binding]
       ~@body)))
 
-(defn- do-with-temp-public-dashboard [m f]
+(defn do-with-temp-public-dashboard
+  [m f]
   (let [m (merge
            (when-not (:parameters m)
              {:parameters [{:id      "_VENUE_ID_"
@@ -85,13 +84,13 @@
     (t2.with-temp/with-temp [Dashboard dashboard m]
       (f (assoc dashboard :public_uuid (:public_uuid m))))))
 
-(defmacro ^:private with-temp-public-dashboard {:style/indent 1} [[binding & [dashboard]] & body]
+(defmacro with-temp-public-dashboard {:style/indent 1} [[binding & [dashboard]] & body]
   `(do-with-temp-public-dashboard
     ~dashboard
     (fn [~binding]
       ~@body)))
 
-(defn- add-card-to-dashboard! [card dashboard & {parameter-mappings :parameter_mappings, :as kvs}]
+(defn add-card-to-dashboard! [card dashboard & {parameter-mappings :parameter_mappings, :as kvs}]
   (first (t2/insert-returning-instances! DashboardCard (merge {:dashboard_id       (u/the-id dashboard)
                                                                :card_id            (u/the-id card)
                                                                :row                0
@@ -106,7 +105,7 @@
 
 ;; TODO -- we can probably use [[metabase.api.dashboard-test/with-chain-filter-fixtures]] for mocking this stuff
 ;; instead since it does mostly the same stuff anyway
-(defmacro ^:private with-temp-public-dashboard-and-card
+(defmacro with-temp-public-dashboard-and-card
   {:style/indent 1}
   [[dashboard-binding card-binding & [dashcard-binding]] & body]
   (let [dashcard-binding (or dashcard-binding (gensym "dashcard"))]
@@ -130,8 +129,7 @@
 
       (with-temp-public-card [{uuid :public_uuid, card-id :id}]
         (testing "Happy path -- should be able to fetch the Card"
-          (is (= #{:dataset_query :description :display :id :name :visualization_settings :parameters :param_values :param_fields}
-                 (set (keys (client/client :get 200 (str "public/card/" uuid)))))))
+          (client/client :get 200 (str "public/card/" uuid)))
 
         (testing "Check that we cannot fetch a public Card if public sharing is disabled"
           (mt/with-temporary-setting-values [enable-public-sharing false]
@@ -527,7 +525,9 @@
         (is (= "Not found."
                (client/client :get 404 (str "public/dashboard/" (random-uuid)))))))))
 
-(defn- fetch-public-dashboard [{uuid :public_uuid}]
+(defn fetch-public-dashboard
+  "Fetch a public dashboard by it's public UUID."
+  [{uuid :public_uuid}]
   (-> (client/client :get 200 (str "public/dashboard/" uuid))
       (select-keys [:name :dashcards :tabs])
       (update :name boolean)
@@ -549,18 +549,6 @@
          (t2/update! :model/Dashboard :id dashboard-id (shared-obj))
          (is (= {:name true, :dashcards 2, :tabs 2}
                 (fetch-public-dashboard (t2/select-one :model/Dashboard :id dashboard-id)))))))))
-
-(deftest public-dashboard-logs-view-test
-  (when (premium-features/log-enabled?)
-    (testing "Viewing a public dashboard logs the correct view log event."
-      (mt/with-temporary-setting-values [enable-public-sharing true]
-        (with-temp-public-dashboard-and-card [dash _]
-          (fetch-public-dashboard dash)
-          (is (partial=
-               {:model      "dashboard"
-                :model_id   (:id dash)
-                :has_access true}
-               (view-log-test/latest-view nil (:id dash)))))))))
 
 (deftest public-dashboard-with-implicit-action-only-expose-unhidden-fields
   (mt/with-temporary-setting-values [enable-public-sharing true]


### PR DESCRIPTION
This PR fills in the gaps where we were tracking some views of entities and not others in the view log. The goal is to enable implementing [auto cleanup collections](https://www.notion.so/metabase/Auto-cleanup-collections-54b3b58e254a48e69b26a054c84fd944), an up-coming EE feature.

It is part of milestone 3 of https://github.com/metabase/metabase/issues/38229

After this PR, these are the endpoints through which we track view log events for:

dashboards:
- `GET /api/dashboard/:id`
- `GET /api/public/dashboard/:uuid`
- `GET /api/embed/dashboard/:uuid`

cards:
- `GET /api/card/:id`
- `GET /api/public/card/:uuid` (new)
- `GET /api/embed/card/:uuid` (new)

collections:
- `GET /api/collection/:id/items` (new)

### Tests

I've put all the tests for the view log in one namespace, `metabase.events.view-log-test`. Previously they were all spread out over the api namespaces. Having them all in one namespace makes it much easier to check what endpoints create view log records.