### PR TITLE
Avoid adding home column part to aliases in specific joins

### DIFF
--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -475,24 +475,28 @@
     (generator base-name)))
 
 (mu/defn add-default-alias :- ::lib.schema.join/join
-  "Add a default generated `:alias` to a join clause."
+  "Add a default generated `:alias` to a join clause that does not already have one."
   [query        :- ::lib.schema/query
    stage-number :- :int
    a-join       :- lib.join.util/JoinWithOptionalAlias]
-  (let [stage       (lib.util/query-stage query stage-number)
-        home-cols   (lib.metadata.calculation/visible-columns query stage-number stage)
-        cond-fields (lib.util.match/match (:conditions a-join) :field)
-        home-col    (select-home-column home-cols cond-fields)
-        join-alias  (-> (calculate-join-alias query a-join home-col)
-                        (generate-unique-name (keep :alias (:joins stage))))
-        join-cols   (lib.metadata.calculation/returned-columns
-                     (lib.query/query-with-stages query (:stages a-join)))]
-    (-> a-join
-        (update :conditions
-                (fn [conditions]
-                  (mapv #(add-alias-to-condition query stage-number % join-alias home-cols join-cols)
-                        conditions)))
-        (with-join-alias join-alias))))
+  (if (contains? a-join :alias)
+    ;; if the join clause comes with an alias, keep it and assume that the
+    ;; condition fields have the right join-aliases too
+    a-join
+    (let [stage       (lib.util/query-stage query stage-number)
+          home-cols   (lib.metadata.calculation/visible-columns query stage-number stage)
+          cond-fields (lib.util.match/match (:conditions a-join) :field)
+          home-col    (select-home-column home-cols cond-fields)
+          join-alias  (-> (calculate-join-alias query a-join home-col)
+                          (generate-unique-name (keep :alias (:joins stage))))
+          join-cols   (lib.metadata.calculation/returned-columns
+                       (lib.query/query-with-stages query (:stages a-join)))]
+      (-> a-join
+          (update :conditions
+                  (fn [conditions]
+                    (mapv #(add-alias-to-condition query stage-number % join-alias home-cols join-cols)
+                          conditions)))
+          (with-join-alias join-alias)))))
 
 (declare join-conditions
          joined-thing


### PR DESCRIPTION
Closes #40477

This PR changes how alias is generated. In case there are more than one foreign key columns in the joining query with target of a joined field, that is used in the condition rhs, home field part of the alias string is left out.

Reason being, that if the lhs is changed later, alias still corresponds to the new reality.