### PR TITLE
Test for sample database having sync scheduled

### DIFF
--- a/resources/sample-content.edn
+++ b/resources/sample-content.edn
@@ -51,6 +51,28 @@
    :created_at #t "2024-04-11T12:41:25.429317Z",
    :public_uuid nil,
    :points_of_interest nil}),
+ :data_permissions
+ ({:id 1,
+   :group_id 1,
+   :perm_type "perms/view-data",
+   :db_id 1,
+   :schema_name nil,
+   :table_id nil,
+   :perm_value "unrestricted"}
+  {:id 2,
+   :group_id 1,
+   :perm_type "perms/create-queries",
+   :db_id 1,
+   :schema_name nil,
+   :table_id nil,
+   :perm_value "query-builder-and-native"}
+  {:id 3,
+   :group_id 1,
+   :perm_type "perms/download-results",
+   :db_id 1,
+   :schema_name nil,
+   :table_id nil,
+   :perm_value "one-million-rows"}),
  :metabase_table
  ({:description
    "Piespace does some anonymous analytics tracking on how users interact with their platform. They’ve only had time to implement a few events, but you know how it is. Pies come first.",

--- a/resources/sample-content.edn
+++ b/resources/sample-content.edn
@@ -72,7 +72,21 @@
    :db_id 1,
    :schema_name nil,
    :table_id nil,
-   :perm_value "one-million-rows"}),
+   :perm_value "one-million-rows"}
+  {:id 4,
+   :group_id 1,
+   :perm_type "perms/manage-table-metadata",
+   :db_id 1,
+   :schema_name nil,
+   :table_id nil,
+   :perm_value "no"}
+  {:id 5,
+   :group_id 1,
+   :perm_type "perms/manage-database",
+   :db_id 1,
+   :schema_name nil,
+   :table_id nil,
+   :perm_value "no"}),
  :metabase_table
  ({:description
    "Piespace does some anonymous analytics tracking on how users interact with their platform. They’ve only had time to implement a few events, but you know how it is. Pies come first.",

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -1199,21 +1199,15 @@
                                   :report_dashboard
                                   :dashboard_tab
                                   :report_dashboardcard
-                                  :dashboardcard_series]]
+                                  :dashboardcard_series
+                                  :permissions_group
+                                  :data_permissions]]
                 (when-let [values (seq (table-name->rows table-name))]
                   (t2/query {:insert-into table-name :values values})))
               (let [group-id (:id (t2/query-one {:select :id :from :permissions_group :where [:= :name "All Users"]}))]
                 (t2/query {:insert-into :permissions
                            :values      [{:object   (format "/collection/%s/" example-collection-id)
-                                          :group_id group-id}]})
-                (t2/query {:insert-into :data_permissions
-                           :values      (for [[perm-type perm-value] {"perms/view-data"        "unrestricted"
-                                                                      "perms/create-queries"   "query-builder-and-native"
-                                                                      "perms/download-results" "one-million-rows"}]
-                                          {:perm_type  perm-type
-                                           :perm_value perm-value
-                                           :group_id   group-id
-                                           :db_id      expected-sample-db-id})}))
+                                          :group_id group-id}]}))
               (t2/query {:insert-into :setting
                          :values      [{:key   "example-dashboard-id"
                                         :value (str example-dashboard-id)}]})))))))
@@ -1221,7 +1215,7 @@
 (comment
   ;; How to create `resources/sample-content.edn` used in `CreateSampleContent`
   ;; -----------------------------------------------------------------------------
-  ;; Start a fresh metabase instance without the :ee alias
+  ;; Start a fresh metabase instance without the :ee alias so instance analytics stuff is not created.
   ;; 1. create a collection with dashboards, or import one with (metabase.cmd/import "<path>")
   ;; 2. execute the following to spit out the collection to an EDN file:
   (let [pretty-spit (fn [file-name data]
@@ -1239,7 +1233,8 @@
                                      :report_card
                                      :parameter_card
                                      :dashboard_tab
-                                     :dashboardcard_series]
+                                     :dashboardcard_series
+                                     :data_permissions]
                          :let [query (cond-> {:select [:*] :from table-name}
                                        (= table-name :collection) (assoc :where [:and
                                                                                  [:= :namespace nil] ; excludes the analytics namespace

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -24,6 +24,7 @@
    [metabase.models.setting :as setting]
    [metabase.native-query-analyzer :as query-analyzer]
    [metabase.task :as task]
+   [metabase.task.sync-databases-test :as task.sync-databases-test]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
@@ -1658,19 +1659,19 @@
           (doseq [db (concat db-with-scan-fv db-without-scan-fv)]
             (#'database/check-and-schedule-tasks-for-db! (t2/instance :model/Database db))
             (testing "sanity check that the schedule exists"
-              (is (= (#'api.database-test/all-db-sync-triggers-name db)
-                     (#'api.database-test/query-all-db-sync-triggers-name db)))))
+              (is (= (#'task.sync-databases-test/all-db-sync-triggers-name db)
+                     (#'task.sync-databases-test/query-all-db-sync-triggers-name db)))))
 
           (migrate!)
           (testing "default options and scan with manual schedules should have scan field values"
             (doseq [db db-with-scan-fv]
-              (is (= (#'api.database-test/all-db-sync-triggers-name db)
-                     (#'api.database-test/query-all-db-sync-triggers-name db)))))
+              (is (= (#'task.sync-databases-test/all-db-sync-triggers-name db)
+                     (#'task.sync-databases-test/query-all-db-sync-triggers-name db)))))
 
           (testing "never scan and on demand should not have scan field values"
             (doseq [db (t2/select :model/Database :id [:in (map :id db-without-scan-fv)])]
               (is (= #{(#'api.database-test/sync-and-analyze-trigger-name db)}
-                     (#'api.database-test/query-all-db-sync-triggers-name db)))
+                     (#'task.sync-databases-test/query-all-db-sync-triggers-name db)))
               (is (nil? (:cache_field_values_schedule db))))))))))
 
 (deftest backfill-query-field-test

--- a/test/metabase/setup_test.clj
+++ b/test/metabase/setup_test.clj
@@ -70,7 +70,7 @@
       (t2/update! :model/Dashboard 1 {:archived true})
       (is (nil? (public-settings/example-dashboard-id))))))
 
-(deftest sample-content-privileges-test
+(deftest sample-content-permissions-test
   (mt/with-temp-empty-app-db [_conn :h2]
     (mdb/setup-db! :create-sample-content? true)
     (let [dashboard  (t2/select-one :model/Dashboard :creator_id config/internal-mb-user-id)

--- a/test/metabase/setup_test.clj
+++ b/test/metabase/setup_test.clj
@@ -57,13 +57,7 @@
     (mdb/setup-db! :create-sample-content? true)
     (testing "The example-dashboard-id setting should be set if the example content is loaded"
       (is (= 1
-             (public-settings/example-dashboard-id))))
-    (testing "Rasta (as a member of 'All Users') should have sufficient privileges to edit the example content"
-      (mt/with-current-user (mt/user->id :rasta)
-        (let [dashboard (t2/select-one :model/Dashboard (public-settings/example-dashboard-id))
-              collection (t2/select-one :model/Collection (:collection_id dashboard))]
-          (mi/can-write? dashboard)
-          (mi/can-write? collection)))))
+             (public-settings/example-dashboard-id)))))
   (testing "The example-dashboard-id setting should be nil if the example content isn't loaded"
     (mt/with-temp-empty-app-db [_conn :h2]
       (mdb/setup-db! :create-sample-content? false)
@@ -75,3 +69,31 @@
              (public-settings/example-dashboard-id)))
       (t2/update! :model/Dashboard 1 {:archived true})
       (is (nil? (public-settings/example-dashboard-id))))))
+
+(deftest sample-content-privileges-test
+  (mt/with-temp-empty-app-db [_conn :h2]
+    (mdb/setup-db! :create-sample-content? true)
+    (let [dashboard  (t2/select-one :model/Dashboard :creator_id config/internal-mb-user-id)
+          collection (t2/select-one :model/Collection (:collection_id dashboard))
+          card       (t2/select-one :model/Card :creator_id config/internal-mb-user-id)]
+      (testing "Rasta (as a member of 'All Users') should have sufficient privileges to edit the example content"
+        (mt/with-current-user (mt/user->id :rasta)
+          (is (true? (mi/can-write? dashboard)))
+          (is (true? (mi/can-write? card)))
+          (is (true? (mi/can-write? collection))))))
+    (let [sample-db       (t2/select-one :model/Database :is_sample true)
+          sample-db-table (t2/select-one :model/Table :db_id (:id sample-db))
+          sample-db-field (t2/select-one :model/Field :table_id (:id sample-db-table))]
+      (testing "Rasta (as a member of 'All Users') should have read but not write privileges to the sample database"
+        (mt/with-current-user (mt/user->id :rasta)
+          (is (true? (mi/can-read? sample-db)))
+          (is (true? (mi/can-read? sample-db-table)))
+          (is (true? (mi/can-read? sample-db-field)))
+          (is (false? (mi/can-write? sample-db)))
+          (is (false? (mi/can-write? sample-db-table)))
+          (is (false? (mi/can-write? sample-db-field)))))
+      (testing "Crowberto (as an admin member of 'All Users') should have write privileges to the sample database"
+        (mt/with-current-user (mt/user->id :crowberto)
+          (is (true? (mi/can-write? sample-db)))
+          (is (true? (mi/can-write? sample-db-table)))
+          (is (true? (mi/can-write? sample-db-field))))))))

--- a/test/metabase/task/sync_databases_test.clj
+++ b/test/metabase/task/sync_databases_test.clj
@@ -43,14 +43,14 @@
 
 (defn all-db-sync-triggers-name
   "Returns the name of trigger for DB.
-  This is all trigger names that a DB SHOULD have."
+  These are all the trigger names that a database SHOULD have."
   [db]
   (set (map #(.getName ^TriggerKey (#'task.sync-databases/trigger-key (t2/instance :model/Database db) %))
             @#'task.sync-databases/all-tasks)))
 
 (defn query-all-db-sync-triggers-name
   "Find the all triggers for DB \"db\".
-  This is all triger names that a DB HAVE in the scheduler."
+  These are all the trigger names that a database HAS in the scheduler."
   [db]
   (let [db (t2/instance :model/Database db)]
     (assert (some? (#'task/scheduler)) "makes sure the scheduler is initialized!")


### PR DESCRIPTION
Follow-up to https://github.com/metabase/metabase/issues/40066

This PR adds a test for the sample database getting its sync scheduled as if it were a normal database that was added after the initial metabase setup.

Previously this didn't really need test coverage because the sample database was being inserted using `t2/insert!`, and the sync tasks were scheduled in the `after-insert` hooks. Now we're inserting the sample database in a migration without using `t2/insert!`, we should test this specifically. The jobs are being scheduled because we're using `t2/update!` to update the sample database details outside of the migration, but that seems like a pretty shaky guarantee and could be changed in the future, so this PR adds the test coverage.