### PR TITLE
allow scientific notation (`e`) in `ChartSettingInputNumeric.tsx`

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingInputNumeric.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingInputNumeric.tsx
@@ -17,6 +17,7 @@ const ALLOWED_CHARS = [
   "9",
   ".",
   "-",
+  "e",
 ];
 
 interface ChartSettingInputProps {

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingInputNumeric.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingInputNumeric.unit.spec.tsx
@@ -61,10 +61,37 @@ describe("ChartSettingInputNumber", () => {
     expect(onChange).toHaveBeenCalledWith(undefined);
   });
 
-  it("does not allow non-alphanumeric values", async () => {
+  it("allows scientific notation", async () => {
+    const { input, onChange } = setup();
+
+    await type({ input, value: "1.5e3" });
+    expect(input).toHaveDisplayValue("1.5e3");
+    expect(onChange).toHaveBeenCalledWith(1.5e3);
+  });
+
+  it("does not allow non-numeric values", async () => {
     const { input, onChange } = setup();
 
     await type({ input, value: "asdf" });
+    expect(input).toHaveDisplayValue("");
+    expect(onChange).toHaveBeenCalledWith(undefined);
+
+    // Inputs with `e` that are not valid scientific notation are invalid, so
+    // the onChange method will be called with `undefined`. However, since `e`
+    // itself is a valid input character the input field will not be reset.
+    type({ input, value: "e123" });
+    expect(input).toHaveDisplayValue("");
+    expect(onChange).toHaveBeenCalledWith(undefined);
+
+    type({ input, value: "e123e" });
+    expect(input).toHaveDisplayValue("");
+    expect(onChange).toHaveBeenCalledWith(undefined);
+
+    type({ input, value: "1e23e" });
+    expect(input).toHaveDisplayValue("");
+    expect(onChange).toHaveBeenCalledWith(undefined);
+
+    type({ input, value: "e1e23e" });
     expect(input).toHaveDisplayValue("");
     expect(onChange).toHaveBeenCalledWith(undefined);
   });

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingInputNumeric.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingInputNumeric.unit.spec.tsx
@@ -76,9 +76,7 @@ describe("ChartSettingInputNumber", () => {
     expect(input).toHaveDisplayValue("");
     expect(onChange).toHaveBeenCalledWith(undefined);
 
-    // Inputs with `e` that are not valid scientific notation are invalid, so
-    // the onChange method will be called with `undefined`. However, since `e`
-    // itself is a valid input character the input field will not be reset.
+    // Inputs with `e` that are not valid scientific notation
     type({ input, value: "e123" });
     expect(input).toHaveDisplayValue("");
     expect(onChange).toHaveBeenCalledWith(undefined);


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/29974

Slack thread: https://metaboat.slack.com/archives/C01LQQ2UW03/p1713865041378179

### Description

In https://github.com/metabase/metabase/pull/33056 we inadvertently removed support for scientific notation in viz settings. This PR restores the functionality.

### How to verify

1. Create a new question with a line chart (e.g. count of orders group by created at: month)
2. Go to series settings for the y-axis series, input a number with scientific notation for the multiplier setting
3. Confirm it works

### Demo

https://github.com/metabase/metabase/assets/37751258/bf0ed24d-f06a-4b27-a952-ed4226b44a2c

Accepts valid inputs

https://github.com/metabase/metabase/assets/37751258/a0fe4a96-a5b3-42a9-911e-13483ade6b40

Rejects invalid inputs

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
