### PR TITLE
Fix flaky perms EE to OSS downgrade test

### DIFF
--- a/e2e/test/scenarios/permissions/downgrade-ee-to-oss.cy.spec.js
+++ b/e2e/test/scenarios/permissions/downgrade-ee-to-oss.cy.spec.js
@@ -41,36 +41,38 @@ describeEE("scenarios > admin > permissions > downgrade ee to oss", () => {
       cy.button("Yes").click();
     });
 
-    setTokenFeatures("none");
-    cy.reload();
+    setTokenFeatures("none").then(() => {
+      cy.reload();
 
-    assertPermissionTable([["Sample Database", "No"]]);
-    isPermissionDisabled(OSS_NATIVE_QUERIES_PERMISSION_INDEX, "No", false);
+      assertPermissionTable([["Sample Database", "No"]]);
+      isPermissionDisabled(OSS_NATIVE_QUERIES_PERMISSION_INDEX, "No", false);
 
-    modifyPermission(
-      "Sample Database",
-      OSS_NATIVE_QUERIES_PERMISSION_INDEX,
-      "Query builder and native",
-    );
-    cy.button("Save changes").click();
-    modal().within(() => {
-      cy.findByText("Save permissions?");
-      cy.button("Yes").click();
-    });
-
-    setTokenFeatures("all");
-    cy.reload();
-
-    assertPermissionTable([
-      [
+      modifyPermission(
         "Sample Database",
-        "Can view",
+        OSS_NATIVE_QUERIES_PERMISSION_INDEX,
         "Query builder and native",
-        "No",
-        "No",
-        "No",
-      ],
-    ]);
+      );
+      cy.button("Save changes").click();
+      modal().within(() => {
+        cy.findByText("Save permissions?");
+        cy.button("Yes").click();
+      });
+
+      setTokenFeatures("all").then(() => {
+        cy.reload();
+
+        assertPermissionTable([
+          [
+            "Sample Database",
+            "Can view",
+            "Query builder and native",
+            "No",
+            "No",
+            "No",
+          ],
+        ]);
+      });
+    });
   });
 
   // same context as other test, but also make sure that other rows with EE values are


### PR DESCRIPTION
### Description

Fixes a race condition where the token reset doesn't always happen fast enough before the test continues. Can be seen here (you'll noticed the HTTP request for sending the token change never goes out in this case as the page reloads before it does):
https://app.replay.io/recording/e2etestscenariospermissionsdowngrade-ee-to-osscyspecjs--114062e6-4299-4b82-89b7-32fe0854186b?commentId=&focusWindow=eyJiZWdpbiI6eyJwb2ludCI6IjYxNjU4NTI1MjQxMDYyNTE2MzgzODAxOTg3NzI5MjAzMjczIiwidGltZSI6MzQ2ODh9LCJlbmQiOnsicG9pbnQiOiI5NzAzMTA0NzY0MTIxMzQ1NTIzNzIwNTAzNDE3ODQ2MTI2NSIsInRpbWUiOjQ4NjQ5fX0%253D&point=80805119950263979432096870994818389&primaryPanel=cypress&secondaryPanel=console&time=42918&viewMode=dev

### How to verify

I've successfully run a stress test on the problematic tests here:
https://github.com/metabase/metabase/actions/runs/8807297112/job/24174031413

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
