### PR TITLE
fix type errors in `echarts` directory

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/constants/dataset.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/constants/dataset.ts
@@ -1,19 +1,22 @@
 // We prefix misc data keys we add to avoid possible collisions with series data
 // keys
-export const NULL_CHAR = "\0";
+export const NULL_CHAR = "\0" as const;
 
 // On stacked charts we show labels with the total value of stacks that are
 // grouped by sign
-export const POSITIVE_STACK_TOTAL_DATA_KEY = `${NULL_CHAR}_positiveStackTotal`;
-export const NEGATIVE_STACK_TOTAL_DATA_KEY = `${NULL_CHAR}_negativeStackTotal`;
+export const POSITIVE_STACK_TOTAL_DATA_KEY =
+  `${NULL_CHAR}_positiveStackTotal` as const;
+export const NEGATIVE_STACK_TOTAL_DATA_KEY =
+  `${NULL_CHAR}_negativeStackTotal` as const;
 
 // Key of x-axis values
-export const X_AXIS_DATA_KEY = `${NULL_CHAR}_x`;
+export const X_AXIS_DATA_KEY = `${NULL_CHAR}_x` as const;
 
 // In some cases a datum in `chartModel.transformedDataset` may include this
 // key, its value is equal to the index of that same datum in the original
 // dataset (e.g. `chartModel.dataset`)
-export const ORIGINAL_INDEX_DATA_KEY = `${NULL_CHAR}_original_dataset_key`;
+export const ORIGINAL_INDEX_DATA_KEY =
+  `${NULL_CHAR}_original_dataset_key` as const;
 
 // For ticks we want to pick the largest interval that exist 3 times in the
 // range. For example, if data has week granularity but the range is more than 3
@@ -23,6 +26,6 @@ export const TICKS_INTERVAL_THRESHOLD = 3;
 // ECharts replaces null valeus with empty strings which makes it impossible to
 // distinguish between null and empty string so we have to use another special
 // value for nulls.
-export const ECHARTS_CATEGORY_AXIS_NULL_VALUE = `${NULL_CHAR}_NULL`;
+export const ECHARTS_CATEGORY_AXIS_NULL_VALUE = `${NULL_CHAR}_NULL` as const;
 
-export const GOAL_LINE_SERIES_ID = `${NULL_CHAR}_goal_line`;
+export const GOAL_LINE_SERIES_ID = `${NULL_CHAR}_goal_line` as const;

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
@@ -86,8 +86,10 @@ export type DimensionModel = {
   columnByCardId: Record<CardId, DatasetColumn>;
 };
 
-export type Datum = Record<DataKey, RowValue> & {
-  [X_AXIS_DATA_KEY]: RowValue;
+type DatumValue = string | number | null;
+
+export type Datum = Record<DataKey, DatumValue> & {
+  [X_AXIS_DATA_KEY]: DatumValue;
   [ORIGINAL_INDEX_DATA_KEY]?: number;
 };
 export type ChartDataset<D extends Datum = Datum> = D[];

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
@@ -86,10 +86,8 @@ export type DimensionModel = {
   columnByCardId: Record<CardId, DatasetColumn>;
 };
 
-type DatumValue = string | number | null;
-
-export type Datum = Record<DataKey, DatumValue> & {
-  [X_AXIS_DATA_KEY]: DatumValue;
+export type Datum = Record<DataKey, RowValue> & {
+  [X_AXIS_DATA_KEY]: RowValue;
   [ORIGINAL_INDEX_DATA_KEY]?: number;
 };
 export type ChartDataset<D extends Datum = Datum> = D[];

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
@@ -1,6 +1,5 @@
-import type { XAXisOption } from "echarts/types/dist/shared";
+import type { XAXisOption, YAXisOption } from "echarts/types/dist/shared";
 import type { AxisBaseOptionCommon } from "echarts/types/src/coord/axisCommonTypes";
-import type { CartesianAxisOption } from "echarts/types/src/coord/cartesian/AxisModel";
 
 import { parseNumberValue } from "metabase/lib/number";
 import { CHART_STYLE } from "metabase/visualizations/echarts/cartesian/constants/style";
@@ -345,7 +344,7 @@ export const buildMetricAxis = (
   hasSplitLine: boolean,
   hoveredSeriesDataKey: DataKey | null,
   renderingContext: RenderingContext,
-): CartesianAxisOption => {
+): YAXisOption => {
   const shouldFlipAxisName = position === "right";
   const nameGap = getAxisNameGap(ticksWidth);
 
@@ -404,8 +403,8 @@ const buildMetricsAxes = (
   settings: ComputedVisualizationSettings,
   hoveredSeriesDataKey: DataKey | null,
   renderingContext: RenderingContext,
-): CartesianAxisOption[] => {
-  const axes: CartesianAxisOption[] = [];
+): YAXisOption[] => {
+  const axes: YAXisOption[] = [];
   const { leftAxisModel, rightAxisModel } = chartModel;
 
   if (leftAxisModel != null) {

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
@@ -1,10 +1,5 @@
-import type {
-  AxisBaseOption,
-  AxisBaseOptionCommon,
-  CategoryAxisBaseOption,
-  TimeAxisBaseOption,
-  ValueAxisBaseOption,
-} from "echarts/types/src/coord/axisCommonTypes";
+import type { XAXisOption } from "echarts/types/dist/shared";
+import type { AxisBaseOptionCommon } from "echarts/types/src/coord/axisCommonTypes";
 import type { CartesianAxisOption } from "echarts/types/src/coord/cartesian/AxisModel";
 
 import { parseNumberValue } from "metabase/lib/number";
@@ -161,6 +156,7 @@ const getCommonDimensionAxisOptions = (
         ? settings["graph.x_axis.title_text"]
         : undefined,
     ),
+    mainType: "xAxis" as const,
     axisTick: {
       show: false,
     },
@@ -183,7 +179,7 @@ export const buildDimensionAxis = (
   chartMeasurements: ChartMeasurements,
   hasTimelineEvents: boolean,
   renderingContext: RenderingContext,
-): AxisBaseOption => {
+): XAXisOption => {
   const xAxisModel = chartModel.xAxisModel;
 
   if (isNumericAxis(xAxisModel)) {
@@ -219,7 +215,7 @@ export const buildNumericDimensionAxis = (
   settings: ComputedVisualizationSettings,
   chartMeasurements: ChartMeasurements,
   renderingContext: RenderingContext,
-): ValueAxisBaseOption => {
+): XAXisOption => {
   const {
     fromEChartsAxisValue,
     isPadded,
@@ -268,7 +264,7 @@ export const buildTimeSeriesDimensionAxis = (
   settings: ComputedVisualizationSettings,
   chartMeasurements: ChartMeasurements,
   renderingContext: RenderingContext,
-): TimeAxisBaseOption => {
+): XAXisOption => {
   const { formatter, maxInterval, minInterval, canRender, xDomainPadded } =
     getTicksOptions(xAxisModel, width);
 
@@ -304,7 +300,7 @@ export const buildCategoricalDimensionAxis = (
   originalSettings: ComputedVisualizationSettings,
   chartMeasurements: ChartMeasurements,
   renderingContext: RenderingContext,
-): CategoryAxisBaseOption => {
+): XAXisOption => {
   const {
     xAxisModel: { formatter },
     dimensionModel: { column },

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
@@ -1,4 +1,5 @@
 import type { EChartsOption } from "echarts";
+import type { OptionSourceData } from "echarts/types/src/util/types";
 
 import {
   NEGATIVE_STACK_TOTAL_DATA_KEY,
@@ -97,12 +98,19 @@ export const getCartesianChartOption = (
   }
 
   const echartsDataset = [
-    { source: chartModel.transformedDataset, dimensions },
+    {
+      // Type cast is needed here because echarts' internal types are incorrect.
+      // Their types do not allow booleans, but in reality booleans do work as
+      // data values, see this example
+      // https://echarts.apache.org/examples/en/editor.html?c=line-simple&code=PYBwLglsB2AEC8sDeAoWsAmBDMWDOApmAFzJrqx7ACuATgMYGkDaSARFm6QGZYA2hADSw2AIy6wAjAF9h7TqTC1qBYWIkAmaQF1ys8gA8AggYh5SqCrDABPEE1gByejgIBzYLRuPBe3-hsTMwtydFt7UkcAN34VRz9yQloIAnNYZlCyKzC7B0c-CGgCH0z0Amh6YAwHS2z0A1IONn862BtG8VLYaUye9F1pAG4gA
+      source: chartModel.transformedDataset as OptionSourceData,
+      dimensions,
+    },
   ];
 
   if (chartModel.trendLinesModel) {
     echartsDataset.push({
-      source: chartModel.trendLinesModel?.dataset,
+      source: chartModel.trendLinesModel?.dataset as OptionSourceData,
       dimensions: [
         X_AXIS_DATA_KEY,
         ...chartModel.trendLinesModel?.seriesModels.map(s => s.dataKey),

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
@@ -126,5 +126,5 @@ export const getCartesianChartOption = (
       hoveredSeriesDataKey,
       renderingContext,
     ),
-  } as EChartsOption;
+  };
 };

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
@@ -33,9 +33,9 @@ export const getSharedEChartsOptions = (isPlaceholder: boolean) => ({
     show: false,
   },
   brush: {
-    toolbox: ["lineX"],
+    toolbox: ["lineX" as const],
     xAxisIndex: 0,
-    throttleType: "debounce",
+    throttleType: "debounce" as const,
     throttleDelay: 200,
   },
 });

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/types.ts
@@ -3,4 +3,5 @@ import type { RegisteredSeriesOption } from "echarts";
 export type EChartsSeriesOption =
   | RegisteredSeriesOption["line"]
   | RegisteredSeriesOption["bar"]
-  | RegisteredSeriesOption["scatter"];
+  | RegisteredSeriesOption["scatter"]
+  | RegisteredSeriesOption["custom"];

--- a/frontend/src/metabase/visualizations/echarts/cartesian/scatter/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/scatter/series.ts
@@ -1,5 +1,5 @@
 import d3 from "d3";
-import type { RegisteredSeriesOption } from "echarts/types/dist/shared";
+import type { RegisteredSeriesOption } from "echarts";
 
 import { X_AXIS_DATA_KEY } from "metabase/visualizations/echarts/cartesian/constants/dataset";
 import type { RenderingContext } from "metabase/visualizations/types";

--- a/frontend/src/metabase/visualizations/echarts/cartesian/utils/timeseries.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/utils/timeseries.ts
@@ -12,7 +12,6 @@ import {
   unexpectedTimezoneWarning,
 } from "metabase/visualizations/lib/warnings";
 import type { ContinuousDomain } from "metabase/visualizations/shared/types/scale";
-import type { Formatter } from "metabase/visualizations/types";
 import type {
   DateTimeAbsoluteUnit,
   RawSeries,
@@ -200,7 +199,10 @@ function timeseriesTicksInterval(
 }
 
 /// return the maximum number of ticks to show for a timeseries chart of a given width
-function maxTicksForChartWidth(chartWidth: number, tickFormat: Formatter) {
+function maxTicksForChartWidth(
+  chartWidth: number,
+  tickFormat: (value: RowValue) => string,
+) {
   const PIXELS_PER_CHARACTER = 7;
   // if there isn't enough buffer, the labels are hidden by ECharts
   const TICK_BUFFER_PIXELS = 10;


### PR DESCRIPTION
### Description

Fixes all the remaining type errors in the `frontend/src/metabase/visualizations/echarts` directory

### How to verify

CI - confirm visual specs do not change

`yarn type-check`, confirm no more errors in `echarts` directory