### PR TITLE
focus on y-axis of hovered series

### DIFF
--- a/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.tsx
+++ b/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.tsx
@@ -72,6 +72,7 @@ export const ComboChart = ({
     computedVisualizationSettings,
     WIDTH,
     false,
+    null,
     renderingContext,
   );
 

--- a/frontend/src/metabase/static-viz/components/ScatterPlot/ScatterPlot.tsx
+++ b/frontend/src/metabase/static-viz/components/ScatterPlot/ScatterPlot.tsx
@@ -64,6 +64,7 @@ export function ScatterPlot({
     computedVisualizationSettings,
     width,
     false,
+    null,
     renderingContext,
   );
   chart.setOption(option);

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
@@ -5,7 +5,10 @@ import {
   POSITIVE_STACK_TOTAL_DATA_KEY,
   X_AXIS_DATA_KEY,
 } from "metabase/visualizations/echarts/cartesian/constants/dataset";
-import type { CartesianChartModel } from "metabase/visualizations/echarts/cartesian/model/types";
+import type {
+  CartesianChartModel,
+  DataKey,
+} from "metabase/visualizations/echarts/cartesian/model/types";
 import { buildAxes } from "metabase/visualizations/echarts/cartesian/option/axis";
 import { buildEChartsSeries } from "metabase/visualizations/echarts/cartesian/option/series";
 import { getTimelineEventsSeries } from "metabase/visualizations/echarts/cartesian/timeline-events/option";
@@ -45,6 +48,7 @@ export const getCartesianChartOption = (
   settings: ComputedVisualizationSettings,
   chartWidth: number,
   isPlaceholder: boolean,
+  hoveredSeriesDataKey: DataKey | null,
   renderingContext: RenderingContext,
 ): EChartsOption => {
   const hasTimelineEvents = timelineEventsModel != null;
@@ -120,6 +124,7 @@ export const getCartesianChartOption = (
       chartMeasurements,
       settings,
       hasTimelineEvents,
+      hoveredSeriesDataKey,
       renderingContext,
     ),
   } as EChartsOption;

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/option/index.ts
@@ -252,6 +252,7 @@ export const getWaterfallChartOption = (
       chartMeasurements,
       settings,
       hasTimelineEvents,
+      null,
       renderingContext,
     ),
   } as EChartsOption;

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
@@ -91,7 +91,6 @@ function _CartesianChart(props: VisualizationProps) {
           title={title}
           description={description}
           icon={headerIcon}
-          // @ts-expect-error will be fixed when LegendCaption gets converted to TypeScript
           actionButtons={actionButtons}
           onSelectTitle={canSelectTitle ? onOpenQuestion : undefined}
           width={width}

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
@@ -1,5 +1,4 @@
 import type { EChartsOption, EChartsType } from "echarts";
-import type { LineSeriesOption } from "echarts/types/dist/echarts";
 import type * as React from "react";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 
@@ -29,6 +28,8 @@ import {
   hasSelectedTimelineEvents,
 } from "metabase/visualizations/visualizations/CartesianChart/events";
 import type { CardId } from "metabase-types/api";
+
+import { getHoveredEChartsSeriesIndex } from "./utils";
 
 export const useChartEvents = (
   chartRef: React.MutableRefObject<EChartsType | undefined>,
@@ -206,21 +207,17 @@ export const useChartEvents = (
         return;
       }
 
-      if (hovered?.index == null) {
+      const eChartsSeriesIndex = getHoveredEChartsSeriesIndex(
+        chartModel.seriesModels,
+        option,
+        hovered,
+      );
+
+      if (hovered == null || eChartsSeriesIndex == null) {
         return;
       }
 
-      const { datumIndex: originalDatumIndex, index } = hovered;
-      const hoveredSeries = chartModel.seriesModels[index];
-      if (!hoveredSeries) {
-        return;
-      }
-
-      // ECharts series contain goal line, trend lines, and timeline events so the series index
-      // is different from one in chartModel.seriesModels
-      const eChartsSeriesIndex = (
-        option?.series as LineSeriesOption[]
-      ).findIndex(series => series.id === hoveredSeries.dataKey);
+      const { datumIndex: originalDatumIndex } = hovered;
 
       let dataIndex: number | undefined;
 
@@ -255,7 +252,7 @@ export const useChartEvents = (
       chartModel.transformedDataset,
       chartRef,
       hovered,
-      option?.series,
+      option,
     ],
   );
 

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
@@ -207,13 +207,13 @@ export const useChartEvents = (
         return;
       }
 
-      const eChartsSeriesIndex = getHoveredEChartsSeriesIndex(
+      const hoveredEChartsSeriesIndex = getHoveredEChartsSeriesIndex(
         chartModel.seriesModels,
         option,
         hovered,
       );
 
-      if (hovered == null || eChartsSeriesIndex == null) {
+      if (hovered == null || hoveredEChartsSeriesIndex == null) {
         return;
       }
 
@@ -236,14 +236,14 @@ export const useChartEvents = (
       chart.dispatchAction({
         type: "highlight",
         dataIndex,
-        seriesIndex: eChartsSeriesIndex,
+        seriesIndex: hoveredEChartsSeriesIndex,
       });
 
       return () => {
         chart.dispatchAction({
           type: "downplay",
           dataIndex,
-          seriesIndex: eChartsSeriesIndex,
+          seriesIndex: hoveredEChartsSeriesIndex,
         });
       };
     },

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-models-and-option.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-models-and-option.ts
@@ -15,6 +15,8 @@ import type {
   VisualizationProps,
 } from "metabase/visualizations/types";
 
+import { getHoveredSeriesDataKey } from "./utils";
+
 export function useModelsAndOption({
   rawSeries,
   series: transformedSeries,
@@ -27,6 +29,7 @@ export function useModelsAndOption({
   timelineEvents,
   selectedTimelineEventIds,
   onRender,
+  hovered,
 }: VisualizationProps) {
   const seriesToRender = useMemo(
     () => (isPlaceholder ? transformedSeries : rawSeries),
@@ -95,6 +98,11 @@ export function useModelsAndOption({
     [chartModel, chartMeasurements, timelineEvents, renderingContext],
   );
 
+  const hoveredSeriesDataKey = useMemo(
+    () => getHoveredSeriesDataKey(chartModel.seriesModels, hovered),
+    [chartModel.seriesModels, hovered],
+  );
+
   const option = useMemo(() => {
     if (width === 0 || height === 0) {
       return {};
@@ -121,6 +129,7 @@ export function useModelsAndOption({
           settings,
           width,
           isPlaceholder ?? false,
+          hoveredSeriesDataKey,
           renderingContext,
         );
     }
@@ -132,6 +141,7 @@ export function useModelsAndOption({
     selectedTimelineEventIds,
     settings,
     timelineEventsModel,
+    hoveredSeriesDataKey,
     width,
     height,
     isPlaceholder,

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/utils.ts
@@ -1,8 +1,15 @@
+import type { EChartsOption } from "echarts";
 import { t } from "ttag";
 
-import type { BaseCartesianChartModel } from "metabase/visualizations/echarts/cartesian/model/types";
+import { isNotNull } from "metabase/lib/types";
+import type {
+  BaseCartesianChartModel,
+  DataKey,
+  SeriesModel,
+} from "metabase/visualizations/echarts/cartesian/model/types";
 import type {
   ComputedVisualizationSettings,
+  HoveredObject,
   VisualizationGridSize,
 } from "metabase/visualizations/types";
 
@@ -56,4 +63,36 @@ export const validateChartModel = (chartModel: BaseCartesianChartModel) => {
       t`This chart type doesn't support more than ${MAX_SERIES} series of data.`,
     );
   }
+};
+
+export const getHoveredSeriesDataKey = (
+  seriesModels: SeriesModel[],
+  hovered: HoveredObject | undefined,
+): DataKey | null => {
+  const seriesIndex = hovered?.index;
+  if (seriesIndex == null) {
+    return null;
+  }
+
+  return seriesModels[seriesIndex]?.dataKey ?? null;
+};
+
+export const getHoveredEChartsSeriesIndex = (
+  seriesModels: SeriesModel[],
+  option: EChartsOption,
+  hovered: HoveredObject | undefined,
+): number | null => {
+  const hoveredSeriesDataKey = getHoveredSeriesDataKey(seriesModels, hovered);
+
+  const seriesOptions = Array.isArray(option?.series)
+    ? option?.series
+    : [option?.series].filter(isNotNull);
+
+  // ECharts series contain goal line, trend lines, and timeline events so the series index
+  // is different from one in chartModel.seriesModels
+  const eChartsSeriesIndex = seriesOptions.findIndex(
+    series => series.id === hoveredSeriesDataKey,
+  );
+
+  return eChartsSeriesIndex;
 };


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/41217

### Description

When a chart has two y-axis and a series is hovered, we need to hide the axis that the series is not measured against.

### How to verify

- Create a chart with two Y-axes
- Hover series that belong to the left axis: ensure the right axis is hidden
- Hover series that belong to the right axis: ensure the left axis is hidden

### Demo

https://github.com/metabase/metabase/assets/14301985/16d5b3d0-813c-429e-85a0-e1a898f17b8b

