### PR TITLE
fix modal submit sending data while button says skip

### DIFF
--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.tsx
@@ -79,12 +79,12 @@ export const EmbedHomepage = () => {
     );
 
     setFeedbackModalOpened(false);
-    sendProductFeedback({
-      comment,
-      email: email,
-      source: "embedding-homepage-dismiss",
-    });
     if (comment || email) {
+      sendProductFeedback({
+        comment,
+        email: email,
+        source: "embedding-homepage-dismiss",
+      });
       dispatch(
         addUndo({ message: t`Your feedback was submitted, thank you.` }),
       );

--- a/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
@@ -159,7 +159,7 @@ describe("EmbedHomepage (OSS)", () => {
       await waitForElementToBeRemoved(() => queryFeedbackModal());
     });
 
-    it("should dismiss when submitting feedback - even if empty", async () => {
+    it("should dismiss when submitting feedback - even if empty, should not actually send the feedback", async () => {
       await setupForFeedbackModal();
 
       await userEvent.click(screen.getByText("Skip"));
@@ -169,13 +169,9 @@ describe("EmbedHomepage (OSS)", () => {
       const body = await lastCall?.request?.json();
       expect(body).toEqual({ value: "dismiss-run-into-issues" });
 
-      const feedbackBody = await getLastFeedbackCall()?.request?.json();
-
-      expect(feedbackBody).toEqual({
-        source: "embedding-homepage-dismiss",
-      });
-
       await waitForElementToBeRemoved(() => queryFeedbackModal());
+
+      expect(getLastFeedbackCall()).toBeUndefined();
 
       expect(
         screen.queryByText("Your feedback was submitted, thank you."),

--- a/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
@@ -171,6 +171,8 @@ describe("EmbedHomepage (OSS)", () => {
 
       await waitForElementToBeRemoved(() => queryFeedbackModal());
 
+      // when both fields are empty, the button says "Skip" and
+      // we should not make the http call
       expect(getLastFeedbackCall()).toBeUndefined();
 
       expect(


### PR DESCRIPTION
I probably got lost in all the changes, but it should not have sent the feedback if empty

See slack thread: https://metaboat.slack.com/archives/C063Q3F1HPF/p1712684011556149?thread_ts=1712319863.930869&cid=C063Q3F1HPF