### PR TITLE
Bump snowflake driver to 15.1

### DIFF
--- a/modules/drivers/snowflake/deps.edn
+++ b/modules/drivers/snowflake/deps.edn
@@ -2,4 +2,4 @@
  ["src" "resources"]
 
  :deps
- {net.snowflake/snowflake-jdbc {:mvn/version "3.15.0"}}}
+ {net.snowflake/snowflake-jdbc {:mvn/version "3.15.1"}}}


### PR DESCRIPTION
I need to test a bugfix with a customer (Fixed an issue with parsing large responses (greater than 16MB)) in 49.7