### PR TITLE
fix waterfall chart tooltip

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
@@ -143,6 +143,10 @@ export const getEventColumnsData = (
   return getSameCardDataKeys(datum, seriesModel)
     .map(dataKey => {
       const value = datum[dataKey];
+      const col = chartModel.columnByDataKey[dataKey];
+      if (!col) {
+        return null;
+      }
 
       const { breakoutValue } = parseDataKey(dataKey);
 
@@ -153,7 +157,6 @@ export const getEventColumnsData = (
         return null;
       }
 
-      const col = chartModel.columnByDataKey[dataKey];
       const columnSeriesModel = seriesModelsByDataKey[dataKey];
       const key =
         columnSeriesModel == null


### PR DESCRIPTION
### Description

When showing tooltip we need to exclude non-dataset values from datum, they do not have an associated column.

### How to verify

- Create any waterfall chart
- Ensure hovering bars shows tooltips

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
