### PR TITLE
fix line chart e2e specs hover does not trigger tooltip

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
@@ -648,5 +648,5 @@ function testPairedTooltipValues(val1, val2) {
 }
 
 function showTooltipForFirstCircleInSeries(seriesColor) {
-  cartesianChartCircleWithColor(seriesColor).realHover();
+  cartesianChartCircleWithColor(seriesColor).eq(0).trigger("mousemove");
 }


### PR DESCRIPTION
### Description

After https://github.com/metabase/metabase/pull/41762 hover triggers the option update which leads to rerender which broke `realHover` triggering the tooltip appearance. However, `mousemove` works fine.

### How to verify

`e2e-tests-visualizations-charts-ee` check should be green
