### PR TITLE
Fix the flake in add-required-filter-if-needed-test due to field order

### DIFF
--- a/test/metabase/db/metadata_queries_test.clj
+++ b/test/metabase/db/metadata_queries_test.clj
@@ -100,7 +100,7 @@
                    {:base_type :type/Text :semantic_type :type/XML}]]
       (is (not (#'metadata-queries/text-field? field))))))
 
-(defn- oredered-filter [query]
+(defn- ordered-filter [query]
   ;; sort by id [:field id option]
   (update query :filter (fn [filter-clause]
                           (if (#{:and :or} (first filter-clause))
@@ -147,10 +147,10 @@
                      (assoc :filter [:and
                                      [:> [:field (:id buyer-id) {:base-type :type/Integer}] -9223372036854775808]
                                      [:> [:field (:id order-product-id) {:base-type :type/Integer}] -9223372036854775808]])
-                     oredered-filter)
+                     ordered-filter)
                  (-> query
                      metadata-queries/add-required-filters-if-needed
-                     oredered-filter)))))
+                     ordered-filter)))))
 
       (testing "Should add an and clause for existing filter"
         (let [query (:query (mt/mbql-query order {:filter [:> $order.id 1]}))]
@@ -158,7 +158,7 @@
                      (assoc :filter [:and
                                      [:> [:field (:id order-id) nil] 1]
                                      [:> [:field (:id order-product-id) {:base-type :type/Integer}] -9223372036854775808]])
-                     oredered-filter)
+                     ordered-filter)
                  (-> query
                      metadata-queries/add-required-filters-if-needed
-                     oredered-filter))))))))
+                     ordered-filter))))))))

--- a/test/metabase/db/metadata_queries_test.clj
+++ b/test/metabase/db/metadata_queries_test.clj
@@ -100,6 +100,13 @@
                    {:base_type :type/Text :semantic_type :type/XML}]]
       (is (not (#'metadata-queries/text-field? field))))))
 
+(defn- oredered-filter [query]
+  ;; sort by id [:field id option]
+  (update query :filter (fn [filter-clause]
+                          (if (#{:and :or} (first filter-clause))
+                            (into [(first filter-clause)] (sort-by second (rest filter-clause)))
+                            filter-clause))))
+
 (deftest add-required-filter-if-needed-test
   (mt/with-temp
     [:model/Database db               {:engine :h2}
@@ -113,40 +120,45 @@
      :model/Field    _order-buyer-id  {:name "BUYER_ID" :table_id (:id order) :base_type :type/Integer}
      :model/Field    order-product-id {:name "PRODUCT_ID" :table_id (:id order) :base_type :type/Integer :database_partitioned true}]
     (mt/with-db db
-      (mt/$ids
-       (testing "no op for tables that do not require filter"
-         (let [query (:query (mt/mbql-query product))]
-           (is (= query
-                  (metadata-queries/add-required-filter-if-needed query)))))
+      (testing "no op for tables that do not require filter"
+        (let [query (:query (mt/mbql-query product))]
+          (is (= query
+                 (metadata-queries/add-required-filters-if-needed query)))))
 
-       (testing "if the source table requires a filter, add the partitioned filter"
-         (let [query (:query (mt/mbql-query order))]
-           (is (= (assoc query
-                         :filter [:> [:field (:id order-product-id) {:base-type :type/Integer}] -9223372036854775808])
-                  (metadata-queries/add-required-filters-if-needed query)))))
+      (testing "if the source table requires a filter, add the partitioned filter"
+        (let [query (:query (mt/mbql-query order))]
+          (is (= (assoc query
+                        :filter [:> [:field (:id order-product-id) {:base-type :type/Integer}] -9223372036854775808])
+                 (metadata-queries/add-required-filters-if-needed query)))))
 
-       (testing "if a joined table require a filter, add the partitioned filter"
-         (let [query (:query (mt/mbql-query product {:joins [{:source-table (:id order)
-                                                              :condition    [:= $order.product_id $product.id]
-                                                              :alias        "Product"}]}))]
-           (is (= (assoc query
-                         :filter [:> [:field (:id order-product-id) {:base-type :type/Integer}] -9223372036854775808])
-                  (metadata-queries/add-required-filters-if-needed query)))))
+      (testing "if a joined table require a filter, add the partitioned filter"
+        (let [query (:query (mt/mbql-query product {:joins [{:source-table (:id order)
+                                                             :condition    [:= $order.product_id $product.id]
+                                                             :alias        "Product"}]}))]
+          (is (= (assoc query
+                        :filter [:> [:field (:id order-product-id) {:base-type :type/Integer}] -9223372036854775808])
+                 (metadata-queries/add-required-filters-if-needed query)))))
 
-       (testing "if both source tables and joined table require a filter, add both"
-         (let [query (:query (mt/mbql-query order {:joins [{:source-table (:id buyer)
-                                                            :condition    [:= $order.buyer_id $buyer.id]
-                                                            :alias        "BUYER"}]}))]
-           (is (= (assoc query
-                         :filter [:and
-                                  [:> [:field (:id buyer-id) {:base-type :type/Integer}] -9223372036854775808]
-                                  [:> [:field (:id order-product-id) {:base-type :type/Integer}] -9223372036854775808]])
-                  (metadata-queries/add-required-filters-if-needed query)))))
+      (testing "if both source tables and joined table require a filter, add both"
+        (let [query (:query (mt/mbql-query order {:joins [{:source-table (:id buyer)
+                                                           :condition    [:= $order.buyer_id $buyer.id]
+                                                           :alias        "BUYER"}]}))]
+          (is (= (-> query
+                     (assoc :filter [:and
+                                     [:> [:field (:id buyer-id) {:base-type :type/Integer}] -9223372036854775808]
+                                     [:> [:field (:id order-product-id) {:base-type :type/Integer}] -9223372036854775808]])
+                     oredered-filter)
+                 (-> query
+                     metadata-queries/add-required-filters-if-needed
+                     oredered-filter)))))
 
-       (testing "Should add an and clause for existing filter"
-         (let [query (:query (mt/mbql-query order {:filter [:> $order.id 1]}))]
-           (is (= (assoc query
-                         :filter [:and
-                                  [:> [:field (:id order-id) nil] 1]
-                                  [:> [:field (:id order-product-id) {:base-type :type/Integer}] -9223372036854775808]])
-                  (metadata-queries/add-required-filters-if-needed query)))))))))
+      (testing "Should add an and clause for existing filter"
+        (let [query (:query (mt/mbql-query order {:filter [:> $order.id 1]}))]
+          (is (= (-> query
+                     (assoc :filter [:and
+                                     [:> [:field (:id order-id) nil] 1]
+                                     [:> [:field (:id order-product-id) {:base-type :type/Integer}] -9223372036854775808]])
+                     oredered-filter)
+                 (-> query
+                     metadata-queries/add-required-filters-if-needed
+                     oredered-filter))))))))


### PR DESCRIPTION
CI failure: https://github.com/metabase/metabase/actions/runs/8820946154/job/24215707741?pr=41792
the test was flaking because of filter order, I updated the test so that it's order agnostic