### PR TITLE
Re-wire the `Collections` entity to use RTK Query under the hood

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionFormModal.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionFormModal.unit.spec.tsx
@@ -28,7 +28,6 @@ async function setup({ folder = {}, onClose = jest.fn() }: SetupOpts = {}) {
     fetchMock.get(
       {
         url: `path:/api/collection/${folder.id}`,
-        query: { namespace: "snippets" },
       },
       folder,
     );

--- a/frontend/src/metabase-types/api/collection.ts
+++ b/frontend/src/metabase-types/api/collection.ts
@@ -148,7 +148,7 @@ export interface UpdateCollectionRequest {
 export interface CreateCollectionRequest {
   name: string;
   description?: string;
-  parent_id?: RegularCollectionId | null;
+  parent_id?: CollectionId | null;
   namespace?: string;
   authority_level?: CollectionAuthorityLevel;
 }

--- a/frontend/src/metabase-types/api/collection.ts
+++ b/frontend/src/metabase-types/api/collection.ts
@@ -136,20 +136,33 @@ export type ListCollectionItemsResponse = {
   models: CollectionItemModel[] | null;
 } & PaginationResponse;
 
-export type CollectionRequest = {
-  id: CollectionId;
-};
+export interface UpdateCollectionRequest {
+  id: RegularCollectionId;
+  name?: string;
+  description?: string;
+  archived?: boolean;
+  parent_id?: RegularCollectionId | null;
+  authority_level?: CollectionAuthorityLevel;
+}
 
-export type ListCollectionsRequest = {
-  "personal-only"?: boolean;
-};
-
-export type ListCollectionsResponse = Collection[];
-
-export type CreateCollectionRequest = {
+export interface CreateCollectionRequest {
   name: string;
   description?: string;
-  color?: string; // deprecated
-  parent_id?: CollectionId | null;
+  parent_id?: RegularCollectionId | null;
+  namespace?: string;
   authority_level?: CollectionAuthorityLevel;
-};
+}
+
+export interface ListCollectionsRequest {
+  archived?: boolean;
+  namespace?: string;
+  "personal-only"?: boolean;
+  "exclude-other-user-collections"?: boolean;
+}
+export interface ListCollectionsTreeRequest {
+  "exclude-archived"?: boolean;
+  "exclude-other-user-collections"?: boolean;
+  namespace?: string;
+  shallow?: boolean;
+  "collection-id"?: RegularCollectionId | null;
+}

--- a/frontend/src/metabase/api/collection.ts
+++ b/frontend/src/metabase/api/collection.ts
@@ -21,10 +21,10 @@ import {
 export const collectionApi = Api.injectEndpoints({
   endpoints: builder => ({
     listCollections: builder.query<Collection[], ListCollectionsRequest>({
-      query: ({ ...body }) => ({
+      query: params => ({
         method: "GET",
         url: `/api/collection`,
-        body,
+        params,
       }),
       providesTags: (collections = []) =>
         provideCollectionListTags(collections),
@@ -33,9 +33,10 @@ export const collectionApi = Api.injectEndpoints({
       Collection[],
       ListCollectionsTreeRequest
     >({
-      query: () => ({
+      query: params => ({
         method: "GET",
         url: "/api/collection/tree",
+        params,
       }),
       providesTags: (collections = []) =>
         provideCollectionListTags(collections),
@@ -44,11 +45,10 @@ export const collectionApi = Api.injectEndpoints({
       ListCollectionItemsResponse,
       ListCollectionItemsRequest
     >({
-      query: ({ id, limit, offset, ...body }) => ({
+      query: ({ id, ...params }) => ({
         method: "GET",
         url: `/api/collection/${id}/items`,
-        params: { limit, offset },
-        body,
+        params,
       }),
       providesTags: (response, error, { models }) =>
         provideCollectionItemListTags(response?.data ?? [], models),

--- a/frontend/src/metabase/api/collection.ts
+++ b/frontend/src/metabase/api/collection.ts
@@ -1,11 +1,11 @@
 import type {
   ListCollectionItemsRequest,
   ListCollectionItemsResponse,
+  UpdateCollectionRequest,
   Collection,
-  CollectionRequest,
-  ListCollectionsRequest,
-  ListCollectionsResponse,
   CreateCollectionRequest,
+  ListCollectionsRequest,
+  ListCollectionsTreeRequest,
 } from "metabase-types/api";
 
 import { Api } from "./api";
@@ -20,6 +20,24 @@ import {
 
 export const collectionApi = Api.injectEndpoints({
   endpoints: builder => ({
+    listCollections: builder.query<Collection[], ListCollectionsRequest>({
+      query: ({ ...body }) => ({
+        method: "GET",
+        url: `/api/collection`,
+        body,
+      }),
+      providesTags: collections =>
+        collections ? provideCollectionListTags(collections) : [],
+    }),
+    listCollectionsTree: builder.query<
+      Collection[],
+      ListCollectionsTreeRequest
+    >({
+      query: () => ({
+        method: "GET",
+        url: "/api/collection/tree",
+      }),
+    }),
     listCollectionItems: builder.query<
       ListCollectionItemsResponse,
       ListCollectionItemsRequest
@@ -33,7 +51,7 @@ export const collectionApi = Api.injectEndpoints({
       providesTags: (response, error, { models }) =>
         provideCollectionItemListTags(response?.data ?? [], models),
     }),
-    getCollection: builder.query<Collection, CollectionRequest>({
+    getCollection: builder.query<Collection, { id: number | "root" }>({
       query: ({ id, ...body }) => ({
         method: "GET",
         url: `/api/collection/${id}`,
@@ -41,18 +59,6 @@ export const collectionApi = Api.injectEndpoints({
       }),
       providesTags: collection =>
         collection ? provideCollectionTags(collection) : [],
-    }),
-    listCollections: builder.query<
-      ListCollectionsResponse,
-      ListCollectionsRequest
-    >({
-      query: ({ ...body }) => ({
-        method: "GET",
-        url: `/api/collection`,
-        body,
-      }),
-      providesTags: collections =>
-        collections ? provideCollectionListTags(collections) : [],
     }),
     createCollection: builder.mutation<Collection, CreateCollectionRequest>({
       query: body => ({
@@ -70,12 +76,21 @@ export const collectionApi = Api.injectEndpoints({
             ]
           : [],
     }),
+    updateCollection: builder.mutation<Collection, UpdateCollectionRequest>({
+      query: ({ id, ...body }) => ({
+        method: "PUT",
+        url: `/api/collection/${id}`,
+        body,
+      }),
+    }),
   }),
 });
 
 export const {
-  useListCollectionItemsQuery,
   useListCollectionsQuery,
+  useListCollectionsTreeQuery,
+  useListCollectionItemsQuery,
   useGetCollectionQuery,
   useCreateCollectionMutation,
+  useUpdateCollectionMutation,
 } = collectionApi;

--- a/frontend/src/metabase/api/collection.ts
+++ b/frontend/src/metabase/api/collection.ts
@@ -6,6 +6,7 @@ import type {
   CreateCollectionRequest,
   ListCollectionsRequest,
   ListCollectionsTreeRequest,
+  CollectionId,
 } from "metabase-types/api";
 
 import { Api } from "./api";
@@ -53,7 +54,7 @@ export const collectionApi = Api.injectEndpoints({
       providesTags: (response, error, { models }) =>
         provideCollectionItemListTags(response?.data ?? [], models),
     }),
-    getCollection: builder.query<Collection, number | "root">({
+    getCollection: builder.query<Collection, CollectionId>({
       query: id => ({
         method: "GET",
         url: `/api/collection/${id}`,

--- a/frontend/src/metabase/api/collection.ts
+++ b/frontend/src/metabase/api/collection.ts
@@ -26,8 +26,8 @@ export const collectionApi = Api.injectEndpoints({
         url: `/api/collection`,
         body,
       }),
-      providesTags: collections =>
-        collections ? provideCollectionListTags(collections) : [],
+      providesTags: (collections = []) =>
+        provideCollectionListTags(collections),
     }),
     listCollectionsTree: builder.query<
       Collection[],
@@ -37,6 +37,8 @@ export const collectionApi = Api.injectEndpoints({
         method: "GET",
         url: "/api/collection/tree",
       }),
+      providesTags: (collections = []) =>
+        provideCollectionListTags(collections),
     }),
     listCollectionItems: builder.query<
       ListCollectionItemsResponse,
@@ -82,6 +84,8 @@ export const collectionApi = Api.injectEndpoints({
         url: `/api/collection/${id}`,
         body,
       }),
+      invalidatesTags: (_, error, { id }) =>
+        invalidateTags(error, [listTag("collection"), idTag("collection", id)]),
     }),
   }),
 });

--- a/frontend/src/metabase/api/collection.ts
+++ b/frontend/src/metabase/api/collection.ts
@@ -53,11 +53,10 @@ export const collectionApi = Api.injectEndpoints({
       providesTags: (response, error, { models }) =>
         provideCollectionItemListTags(response?.data ?? [], models),
     }),
-    getCollection: builder.query<Collection, { id: number | "root" }>({
-      query: ({ id, ...body }) => ({
+    getCollection: builder.query<Collection, number | "root">({
+      query: id => ({
         method: "GET",
         url: `/api/collection/${id}`,
-        body,
       }),
       providesTags: collection =>
         collection ? provideCollectionTags(collection) : [],

--- a/frontend/src/metabase/api/tags/utils.ts
+++ b/frontend/src/metabase/api/tags/utils.ts
@@ -150,6 +150,15 @@ export function provideCollectionItemTags(
   return [idTag(TAG_TYPE_MAPPING[item.model], item.id)];
 }
 
+export function provideCollectionListTags(
+  collections: Collection[],
+): TagDescription<TagType>[] {
+  return [
+    listTag("collection"),
+    ...collections.flatMap(collection => provideCollectionTags(collection)),
+  ];
+}
+
 export function provideCollectionTags(
   collection: Collection,
 ): TagDescription<TagType>[] {

--- a/frontend/src/metabase/api/tags/utils.ts
+++ b/frontend/src/metabase/api/tags/utils.ts
@@ -19,7 +19,6 @@ import type {
   ForeignKey,
   GroupListQuery,
   ListDashboardsResponse,
-  ListCollectionsResponse,
   Metric,
   NativeQuerySnippet,
   ModelCacheRefreshStatus,
@@ -163,15 +162,6 @@ export function provideCollectionTags(
   collection: Collection,
 ): TagDescription<TagType>[] {
   return [idTag("collection", collection.id)];
-}
-
-export function provideCollectionListTags(
-  collections: ListCollectionsResponse,
-): TagDescription<TagType>[] {
-  return [
-    listTag("collection"),
-    ...collections.map(collection => idTag("collection", collection.id)),
-  ];
 }
 
 export function provideDatabaseCandidateListTags(

--- a/frontend/src/metabase/common/components/CollectionPicker/components/RootItemList.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/RootItemList.tsx
@@ -43,9 +43,7 @@ export const RootItemList = ({
   const { data: personalCollection, isLoading: isLoadingPersonalCollecton } =
     useGetCollectionQuery(
       currentUser?.personal_collection_id
-        ? {
-            id: currentUser?.personal_collection_id,
-          }
+        ? currentUser?.personal_collection_id
         : skipToken,
     );
 
@@ -65,7 +63,7 @@ export const RootItemList = ({
     data: rootCollection,
     isLoading: isLoadingRootCollecton,
     error: rootCollectionError,
-  } = useGetCollectionQuery({ id: "root" });
+  } = useGetCollectionQuery("root");
 
   const data = useMemo(() => {
     const collectionsData: CollectionPickerItem[] = [];

--- a/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.tsx
+++ b/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.tsx
@@ -63,9 +63,7 @@ const useGetInitialCollection = (
   const { data: currentCollection, error: collectionError } =
     useGetCollectionQuery(
       !isQuestion || !!currentQuestion
-        ? {
-            id: (isValidCollectionId(collectionId) && collectionId) || "root",
-          }
+        ? (isValidCollectionId(collectionId) && collectionId) || "root"
         : skipToken,
     );
 

--- a/frontend/src/metabase/components/ArchiveCollectionModal/ArchiveCollectionModal.jsx
+++ b/frontend/src/metabase/components/ArchiveCollectionModal/ArchiveCollectionModal.jsx
@@ -29,7 +29,7 @@ class ArchiveCollectionModalInner extends Component {
     if (object.archived) {
       const parent =
         object.effective_ancestors.length > 0
-          ? object.effective_ancestors.pop()
+          ? object.effective_ancestors.at(-1)
           : null;
       push(Urls.collection(parent));
     }

--- a/frontend/src/metabase/entities/collections/collections.ts
+++ b/frontend/src/metabase/entities/collections/collections.ts
@@ -37,6 +37,9 @@ const Collections = createEntity({
       params?.tree
         ? listCollectionsTree(params, ...args)
         : listCollections(params, ...args),
+    delete: () => {
+      throw new TypeError("Collections.api.delete is not supported");
+    },
   },
 
   objectActions: {
@@ -61,8 +64,6 @@ const Collections = createEntity({
         { parent_id: canonicalCollectionId(collection?.id) },
         undo(opts, "collection", "moved"),
       ),
-
-    delete: null,
   },
 
   objectSelectors: {

--- a/frontend/src/metabase/entities/collections/collections.ts
+++ b/frontend/src/metabase/entities/collections/collections.ts
@@ -1,14 +1,23 @@
 import { createSelector } from "@reduxjs/toolkit";
 import { t } from "ttag";
 
+import { collectionApi } from "metabase/api";
 import { canonicalCollectionId } from "metabase/collections/utils";
 import { GET } from "metabase/lib/api";
-import { createEntity, undo } from "metabase/lib/entities";
+import {
+  createEntity,
+  undo,
+  entityCompatibleQuery,
+} from "metabase/lib/entities";
 import * as Urls from "metabase/lib/urls/collections";
 import { CollectionSchema } from "metabase/schema";
 import { getUserPersonalCollectionId } from "metabase/selectors/user";
-import type { Collection } from "metabase-types/api";
-import type { GetState, ReduxAction } from "metabase-types/store";
+import type {
+  Collection,
+  CreateCollectionRequest,
+  UpdateCollectionRequest,
+} from "metabase-types/api";
+import type { GetState, ReduxAction, Dispatch } from "metabase-types/store";
 
 import getExpandedCollectionsById from "./getExpandedCollectionsById";
 import getInitialCollectionId from "./getInitialCollectionId";
@@ -37,6 +46,24 @@ const Collections = createEntity({
       params?.tree
         ? listCollectionsTree(params, ...args)
         : listCollections(params, ...args),
+    get: (entityQuery: { id: number }, options: unknown, dispatch: Dispatch) =>
+      entityCompatibleQuery(
+        entityQuery.id,
+        dispatch,
+        collectionApi.endpoints.getCollection,
+      ),
+    create: (entityQuery: CreateCollectionRequest, dispatch: Dispatch) =>
+      entityCompatibleQuery(
+        entityQuery,
+        dispatch,
+        collectionApi.endpoints.createCollection,
+      ),
+    update: (entityQuery: UpdateCollectionRequest, dispatch: Dispatch) =>
+      entityCompatibleQuery(
+        entityQuery,
+        dispatch,
+        collectionApi.endpoints.updateCollection,
+      ),
     delete: () => {
       throw new TypeError("Collections.api.delete is not supported");
     },

--- a/frontend/src/metabase/nav/components/CollectionBreadcrumbs/CollectionBreadcrumbs.tsx
+++ b/frontend/src/metabase/nav/components/CollectionBreadcrumbs/CollectionBreadcrumbs.tsx
@@ -26,7 +26,8 @@ export const CollectionBreadcrumbs = ({
 
   const ancestors = collection.effective_ancestors || [];
   const hasRoot = ancestors[0] && isRootCollection(ancestors[0]);
-  const parts = hasRoot ? ancestors.splice(0, 1) : ancestors;
+  const [_, ...crumbsWithoutRoot] = ancestors;
+  const parts = hasRoot ? crumbsWithoutRoot : ancestors;
 
   const content =
     parts.length > 1 && !isExpanded ? (

--- a/frontend/test/__support__/server-mocks/collection.ts
+++ b/frontend/test/__support__/server-mocks/collection.ts
@@ -30,7 +30,7 @@ export function setupCollectionsEndpoints({
   fetchMock.get(
     {
       url: "path:/api/collection/tree",
-      query: { tree: true, "exclude-archived": true },
+      query: { "exclude-archived": true },
       overwriteRoutes: false,
     },
     collections.filter(collection => !collection.archived),
@@ -38,7 +38,6 @@ export function setupCollectionsEndpoints({
   fetchMock.get(
     {
       url: "path:/api/collection/tree",
-      query: { tree: true },
       overwriteRoutes: false,
     },
     collections,


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/41818, and with it https://github.com/metabase/metabase/issues/40806 because `SnippetCollections` entity is really only reusing the "regular" `Collections` entity under the hood.

This PR (together with the #41992) resolves the milestone one of https://github.com/metabase/metabase/issues/40788