### PR TITLE
Add a note about perms graph changes to the API changelog

### DIFF
--- a/docs/developers-guide/api-changelog.md
+++ b/docs/developers-guide/api-changelog.md
@@ -10,6 +10,10 @@ title: API changelog
 
    The `/api/metric` endpoints has been renamed to `/api/legacy-metric` to reflect that fact it will not be used for the new version of metrics. The new version uses the `/api/card` endpoints.
 
+- `GET /api/permissions/graph` and `PUT /api/permissions/graph`
+
+   The `data` key has been removed from the permissions graph. It has been replaced with `view-data` and `create-queries`.
+
 ## Metabase 0.49.0
 - `POST /api/card` and `PUT /api/card/:id`
 

--- a/docs/developers-guide/api-changelog.md
+++ b/docs/developers-guide/api-changelog.md
@@ -13,6 +13,8 @@ title: API changelog
 - `GET /api/permissions/graph` and `PUT /api/permissions/graph`
 
    The `data` key has been removed from the permissions graph. It has been replaced with `view-data` and `create-queries`.
+   Valid permission values for `view-data` are `unrestricted`, `blocked`, `sandboxed` or `restricted`. Valid permission values
+   for `create-queries` are `query-builder-and-native`, `query-builder`, and `no`.
 
 ## Metabase 0.49.0
 - `POST /api/card` and `PUT /api/card/:id`


### PR DESCRIPTION
Adds a note that the keys in the permissions graph are changing in v50. 

I could add a lot more detail here, like how the new permissions are different from the old ones and what the valid permission values are, but I'm not sure if it's worth it. I figured we can keep the API changelog concise so it's easy to skim, and folks can refer to the docs for more details about the product change if they need it.