### PR TITLE
remove unused ts-expect-error in ChartCaption

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartCaption.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartCaption.tsx
@@ -46,7 +46,6 @@ const ChartCaption = ({
       title={title}
       description={description}
       icon={icon}
-      // @ts-expect-error will be fixed when LegendCaption gets converted to TypeScript
       actionButtons={actionButtons}
       onSelectTitle={canSelectTitle ? handleSelectTitle : undefined}
       width={width}


### PR DESCRIPTION
### Description

Fixes the only type error in ChartCaption.

### How to verify

CI + `yarn type-check`