### PR TITLE
Add view_count for cards and dashboards and populate it from view_log

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -6577,7 +6577,94 @@ databaseChangeLog:
       changes:
         - sql:
             sql: >
-              DELETE FROM data_permissions where perm_type = 'perms/data-access' OR perm_type = 'perms/native-query-editing';
+              DELETE FROM data_permissions where perm_type = 'perms/data-access' OR perm_type =
+              'perms/native-query-editing';
+
+  - changeSet:
+      id: v50.2024-04-25T16:29:31
+      author: calherries
+      comment: Add report_card.view_count
+      changes:
+        - addColumn:
+            columns:
+              - column:
+                  name: view_count
+                  type: integer
+                  defaultValueNumeric: 0
+                  remarks: Count of views the card has had
+                  constraints:
+                    nullable: false
+            tableName: report_card
+
+  - changeSet:
+      id: v50.2024-04-25T16:29:32
+      author: calherries
+      comment: Add report_dashboard.view_count
+      changes:
+        - addColumn:
+            columns:
+              - column:
+                  name: view_count
+                  type: integer
+                  defaultValueNumeric: 0
+                  remarks: Count of views the card has had
+                  constraints:
+                    nullable: false
+            tableName: report_dashboard
+
+  - changeSet:
+      id: v50.2024-04-25T16:29:32
+      author: calherries
+      comment: Populate report_card.view_count
+      changes:
+        - sql:
+            dbms: postgresql,h2
+            sql: >-
+              UPDATE report_card c
+              SET c.view_count = (
+                  SELECT COUNT(*)
+                  FROM view_log v
+                  WHERE v.model = 'card'
+                  AND v.model_id = c.id
+              );
+        - sql:
+            dbms: postgresql,h2
+            sql: >-
+              UPDATE report_card c
+              SET view_count = (
+                  SELECT count(*)
+                  FROM view_log v
+                  WHERE v.model = 'card'
+                  AND v.model_id = c.id
+              );
+      rollback: # nothing to do, since view_count didn't exist in v49
+
+  - changeSet:
+      id: v50.2024-04-25T16:29:33
+      author: calherries
+      comment: Populate report_dashboard.view_count
+      changes:
+        - sql:
+            dbms: postgresql,h2
+            sql: >-
+              UPDATE report_dashboard c
+              SET c.view_count = (
+                  SELECT COUNT(*)
+                  FROM view_log v
+                  WHERE v.model = 'card'
+                  AND v.model_id = c.id
+              );
+        - sql:
+            dbms: postgresql,h2
+            sql: >-
+              UPDATE report_dashboard c
+              SET view_count = (
+                  SELECT count(*)
+                  FROM view_log v
+                  WHERE v.model = 'card'
+                  AND v.model_id = c.id
+              );
+      rollback: # nothing to do, since view_count didn't exist in v49
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -6599,26 +6599,10 @@ databaseChangeLog:
   - changeSet:
       id: v50.2024-04-25T16:29:32
       author: calherries
-      comment: Add report_dashboard.view_count
-      changes:
-        - addColumn:
-            columns:
-              - column:
-                  name: view_count
-                  type: integer
-                  defaultValueNumeric: 0
-                  remarks: Count of views the card has had
-                  constraints:
-                    nullable: false
-            tableName: report_dashboard
-
-  - changeSet:
-      id: v50.2024-04-25T16:29:32
-      author: calherries
       comment: Populate report_card.view_count
       changes:
         - sql:
-            dbms: postgresql,h2
+            dbms: mysql,mariadb
             sql: >-
               UPDATE report_card c
               SET c.view_count = (
@@ -6642,16 +6626,32 @@ databaseChangeLog:
   - changeSet:
       id: v50.2024-04-25T16:29:33
       author: calherries
+      comment: Add report_dashboard.view_count
+      changes:
+        - addColumn:
+            columns:
+              - column:
+                  name: view_count
+                  type: integer
+                  defaultValueNumeric: 0
+                  remarks: Count of views the card has had
+                  constraints:
+                    nullable: false
+            tableName: report_dashboard
+
+  - changeSet:
+      id: v50.2024-04-25T16:29:34
+      author: calherries
       comment: Populate report_dashboard.view_count
       changes:
         - sql:
-            dbms: postgresql,h2
+            dbms: mysql,mariadb
             sql: >-
               UPDATE report_dashboard c
               SET c.view_count = (
                   SELECT COUNT(*)
                   FROM view_log v
-                  WHERE v.model = 'card'
+                  WHERE v.model = 'dashboard'
                   AND v.model_id = c.id
               );
         - sql:
@@ -6661,7 +6661,7 @@ databaseChangeLog:
               SET view_count = (
                   SELECT count(*)
                   FROM view_log v
-                  WHERE v.model = 'card'
+                  WHERE v.model = 'dashboard'
                   AND v.model_id = c.id
               );
       rollback: # nothing to do, since view_count didn't exist in v49

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -6577,8 +6577,7 @@ databaseChangeLog:
       changes:
         - sql:
             sql: >
-              DELETE FROM data_permissions where perm_type = 'perms/data-access' OR perm_type =
-              'perms/native-query-editing';
+              DELETE FROM data_permissions where perm_type = 'perms/data-access' OR perm_type = 'perms/native-query-editing';
 
   - changeSet:
       id: v50.2024-04-25T16:29:31

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -6590,7 +6590,7 @@ databaseChangeLog:
                   name: view_count
                   type: integer
                   defaultValueNumeric: 0
-                  remarks: Count of views the card has had
+                  remarks: Keeps a running count of card views
                   constraints:
                     nullable: false
             tableName: report_card
@@ -6633,7 +6633,7 @@ databaseChangeLog:
                   name: view_count
                   type: integer
                   defaultValueNumeric: 0
-                  remarks: Count of views the card has had
+                  remarks: Keeps a running count of dashboard views
                   constraints:
                     nullable: false
             tableName: report_dashboard

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -191,7 +191,7 @@
 
 (def ^:private excluded-columns-for-card-revision
   [:id :created_at :updated_at :entity_id :creator_id :public_uuid :made_public_by_id :metabase_version
-   :initially_published_at :cache_invalidated_at])
+   :initially_published_at :cache_invalidated_at :view_count])
 
 (defmethod revision/revert-to-revision! :model/Card
   [model id user-id serialized-card]

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -238,7 +238,7 @@
    ;;   lower-numbered positions appearing before higher numbered ones.
    ;; TODO: querying on stats we don't have any dashboard that has a position, maybe we could just drop it?
    :public_uuid :made_public_by_id
-   :position :initially_published_at])
+   :position :initially_published_at :view_count])
 
 (def ^:private excluded-columns-for-dashcard-revision
   [:entity_id :created_at :updated_at :collection_authority_level])

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -83,7 +83,8 @@
    :average_query_time     nil
    :last_query_start       nil
    :result_metadata        nil
-   :cache_invalidated_at   nil})
+   :cache_invalidated_at   nil
+   :view_count             0})
 
 ;; Used in dashboard tests
 (def card-defaults-no-hydrate

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -220,7 +220,8 @@
    :public_uuid             nil
    :auto_apply_filters      true
    :show_in_getting_started false
-   :updated_at              true})
+   :updated_at              true
+   :view_count              0})
 
 (deftest create-dashboard-test
   (testing "POST /api/dashboard"


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/38229
[Technical doc](https://www.notion.so/metabase/e12aa6ef472c4d6ab871f60d1947327b?v=fd15329da9594408807fc38c3a4edb7a&p=086dec987ce84759baca325399c43da5&pm=s)

This is the first PR of two for Milestone 4 in the epic. It adds a new column `view_count` to `report_card` and `report_dashboard`. The columns are not included in revision history objects, but they are serialized in serialization. 

A PR following this one will modify `:event/card-read` and `:event/dashboard-read` event handlers to increment the column when a user views the card or dashboard.

The use case for Milestone 4 is TBD, but most likely this would be shown in collections to help users find relevant content or help rank search results.