### PR TITLE
fix SmartScalar type errors

### DIFF
--- a/frontend/src/metabase-types/api/insight.ts
+++ b/frontend/src/metabase-types/api/insight.ts
@@ -1,4 +1,4 @@
-import type { DatetimeUnit } from "./query";
+import type { DateTimeAbsoluteUnit } from "./query";
 
 export type InsightExpressionOperator =
   | "+"
@@ -21,7 +21,7 @@ export type InsightExpression =
 
 export interface Insight {
   col: string;
-  unit: DatetimeUnit;
+  unit: DateTimeAbsoluteUnit;
 
   // Used for trend line on line/area/bar/combo charts.
   // Will try to use "best-fit" expression if it exsits,

--- a/frontend/src/metabase-types/api/query.ts
+++ b/frontend/src/metabase-types/api/query.ts
@@ -123,14 +123,6 @@ type Value = null | boolean | StringLiteral | NumericLiteral | DatetimeLiteral;
 type OrderableValue = NumericLiteral | DatetimeLiteral;
 
 type RelativeDatetimePeriod = "current" | "last" | "next" | number;
-export type RelativeDatetimeUnit =
-  | "minute"
-  | "hour"
-  | "day"
-  | "week"
-  | "month"
-  | "quarter"
-  | "year";
 
 // "card__4" like syntax meaning a query is using card 4 as a data source
 type NestedQueryTableId = string;
@@ -260,13 +252,13 @@ type TimeIntervalFilter =
       "time-interval",
       ConcreteFieldReference,
       RelativeDatetimePeriod,
-      RelativeDatetimeUnit,
+      DateTimeAbsoluteUnit,
     ]
   | [
       "time-interval",
       ConcreteFieldReference,
       RelativeDatetimePeriod,
-      RelativeDatetimeUnit,
+      DateTimeAbsoluteUnit,
       TimeIntervalFilterOptions,
     ];
 

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.ts
@@ -8,7 +8,7 @@ import { uuid } from "metabase/lib/utils";
 import { isEmpty } from "metabase/lib/validate";
 import { isDate, isNumeric } from "metabase-lib/v1/types/utils/isa";
 import type {
-  RelativeDatetimeUnit,
+  DateTimeAbsoluteUnit,
   SmartScalarComparison,
   VisualizationSettings,
 } from "metabase-types/api";
@@ -154,9 +154,11 @@ export function getComparisonOptions(
 ) {
   const [
     {
-      data: { cols, insights = [], rows },
+      data: { cols, rows },
     },
   ] = series;
+
+  const insights = series[0].data.insights ?? [];
 
   const options: ComparisonMenuOption[] = [
     createComparisonMenuOption({ type: COMPARISON_TYPES.PREVIOUS_VALUE }),
@@ -279,7 +281,7 @@ export function getComparisons(
 type getMaxPeriodsAgoParameters = {
   cols: DatasetColumn[];
   rows: RowValues[];
-  dateUnit: RelativeDatetimeUnit;
+  dateUnit: DateTimeAbsoluteUnit;
 };
 
 function getMaxPeriodsAgo({
@@ -324,12 +326,12 @@ type GetComparisonMenuOptionParameters =
     }
   | {
       type: typeof COMPARISON_TYPES.PREVIOUS_PERIOD;
-      dateUnit: RelativeDatetimeUnit;
+      dateUnit: DateTimeAbsoluteUnit;
     }
   | {
       type: typeof COMPARISON_TYPES.PERIODS_AGO;
       maxValue: number;
-      dateUnit: RelativeDatetimeUnit;
+      dateUnit: DateTimeAbsoluteUnit;
     }
   | {
       type: typeof COMPARISON_TYPES.STATIC_NUMBER;
@@ -370,7 +372,7 @@ function createComparisonMenuOption(
   return COMPARISON_SELECTOR_OPTIONS.PREVIOUS_VALUE;
 }
 
-function formatPreviousPeriodOptionName(dateUnit: RelativeDatetimeUnit) {
+function formatPreviousPeriodOptionName(dateUnit: DateTimeAbsoluteUnit) {
   switch (dateUnit) {
     case "minute":
       return t`Previous minute`;
@@ -390,7 +392,7 @@ function formatPreviousPeriodOptionName(dateUnit: RelativeDatetimeUnit) {
   return "";
 }
 
-function formatPeriodsAgoOptionName(dateUnit: RelativeDatetimeUnit) {
+function formatPeriodsAgoOptionName(dateUnit: DateTimeAbsoluteUnit) {
   switch (dateUnit) {
     case "minute":
       return t`minutes ago`;

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.unit.spec.ts
@@ -3,14 +3,14 @@ import * as measureText from "metabase/lib/measure-text";
 import type { FontStyle } from "metabase/visualizations/shared/types/measure-text";
 import type {
   DatasetColumn,
-  Insight,
-  RelativeDatetimeUnit,
+  DateTimeAbsoluteUnit,
   RowValues,
   SmartScalarComparison,
   SmartScalarComparisonAnotherColumn,
   SmartScalarComparisonStaticNumber,
   VisualizationSettings,
 } from "metabase-types/api";
+import type { Insight } from "metabase-types/api/insight";
 import {
   createMockColumn,
   createMockSingleSeries,
@@ -43,8 +43,16 @@ const getAutoPrecisionOptions = (width: number) => {
 describe("SmartScalar > utils", () => {
   describe("scalar.comparisons", () => {
     const FIELD_NAME = "Count";
-    const createInsights = (dateUnit: RelativeDatetimeUnit) => [
-      { unit: dateUnit, col: FIELD_NAME },
+    const createInsights = (dateUnit: DateTimeAbsoluteUnit): Insight[] => [
+      {
+        unit: dateUnit,
+        col: FIELD_NAME,
+        offset: 0,
+        slope: 0,
+        "last-change": 0,
+        "last-value": 0,
+        "previous-value": 0,
+      },
     ];
     const cols = [
       createMockColumn(DateTimeColumn({ name: "Month" })),


### PR DESCRIPTION
### Description

Fixes the type errors in the `SmartScalar` directory, which are the last remaining type errors on the `echarts` branch.

### How to verify

CI + `yarn type-check`. The only remaining type error now is in `NativeQueryEditor.tsx`, which is not related to our branch.

### Demo

![Screenshot 2024-04-25 at 10.56.46 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/2dcd7185-7171-4237-a417-20505eb1a99c.png)

All settings in trend chart sill work

