### PR TITLE
fix type error in NativeQueryEditor

### DIFF
--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.styled.tsx
@@ -1,5 +1,6 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
+import type { ResizableBoxProps } from "react-resizable";
 import { ResizableBox } from "react-resizable";
 
 import QueryBuilderS from "metabase/css/query_builder.module.css";
@@ -162,9 +163,11 @@ export const EditorRoot = styled.div`
   flex: 1 0 auto;
 `;
 
-export const StyledResizableBox = styled(ResizableBox)<{
-  isOpen: boolean;
-}>`
+export const StyledResizableBox = styled(ResizableBox)<
+  ResizableBoxProps & {
+    isOpen: boolean;
+  }
+>`
   display: ${props => (props.isOpen ? "flex" : "none")};
   border-top: 1px solid ${color("border")};
 `;

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -112,7 +112,7 @@ type OwnProps = typeof NativeQueryEditor.defaultProps & {
   hasEditingSidebar?: boolean;
   sidebarFeatures?: SidebarFeatures;
   resizable?: boolean;
-  resizableBoxProps?: Partial<ResizableBoxProps>;
+  resizableBoxProps?: Partial<Omit<ResizableBoxProps, "axis">>;
 
   editorContext?: "question";
 


### PR DESCRIPTION
### Description

The type check CI check was still failing on https://github.com/metabase/metabase/pull/41395 due to a type error in `NativeQueryEditor`. This PR fixes that type error.

### How to verify

CI + `yarn type-check`

```
$ tsc --noEmit
✨  Done in 37.27s.
```

No remaining type errors.

### Demo

![Screenshot 2024-04-25 at 1.59.33 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/a3a4da4c-d4b4-4fb7-9ca9-0da8925e0b75.png)

Confirmed SQL editor still works
