### PR TITLE
Add kondo hook so LSP can jump to driver definition

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -527,6 +527,7 @@
    metabase.db.schema-migrations-test.impl/test-migrations                                                                   hooks.metabase.db.schema-migrations-test.impl/test-migrations
    metabase.dashboard-subscription-test/with-link-card-fixture-for-dashboard                                                 hooks.common/let-second
    metabase.driver.bigquery-cloud-sdk-test/calculate-bird-scarcity                                                           hooks.metabase.query-processor-test.expressions-test/calculate-bird-scarcity
+   metabase.driver/register!                                                                                                 hooks.metabase.driver/register!
    metabase.legacy-mbql.schema.macros/defclause                                                                              hooks.metabase.legacy-mbql.schemas.macros/defclause
    metabase.lib.schema.mbql-clause/define-mbql-clause                                                                        hooks.metabase.lib.schema.mbql-clause/define-mbql-clause
    metabase.lib.schema.mbql-clause/define-catn-mbql-clause                                                                   hooks.metabase.lib.schema.mbql-clause/define-mbql-clause

--- a/.clj-kondo/hooks/metabase/driver.clj
+++ b/.clj-kondo/hooks/metabase/driver.clj
@@ -1,0 +1,18 @@
+(ns hooks.metabase.driver
+  (:require
+   [clj-kondo.hooks-api :as api]))
+
+(defn register!
+  "Register the driver keyword so LSP can jump to it."
+  [x]
+  (letfn [(update-driver-keyword [k]
+            (api/reg-keyword! k 'metabase.driver/register!))
+          (update-children [[_register! k :as children]]
+            (if (api/keyword-node? k)
+              (update (vec children) 1 update-driver-keyword)
+              children))
+          (update-node [node]
+            (if (api/list-node? node)
+              (update node :children update-children)
+              node))]
+    (update x :node update-node)))


### PR DESCRIPTION
LSP can now jump to the place a driver like `:h2` or `:postgres` or `:metabase.driver.sql-jdbc.execute.legacy-impl/use-legacy-classes-for-read-and-set` gets registered