### PR TITLE
Fix default font in mantine

### DIFF
--- a/frontend/src/metabase/ui/theme.ts
+++ b/frontend/src/metabase/ui/theme.ts
@@ -95,7 +95,6 @@ export const getThemeOverrides = (): MantineThemeOverride => ({
       },
     },
   },
-  fontFamily: "var(--mb-default-font-family)",
   fontFamilyMonospace: "Monaco, monospace",
   focusRingStyles: {
     styles: theme => ({


### PR DESCRIPTION
### Description

As a result of #41574 , in my environment, i get all mantine components with serif fonts.  

Before | After
---|---
![Screen Shot 2024-04-25 at 4 34 56 PM](https://github.com/metabase/metabase/assets/30528226/17f2d8ed-d72e-4fc0-a3ce-b4a2ff50600c) | ![Screen Shot 2024-04-25 at 4 45 30 PM](https://github.com/metabase/metabase/assets/30528226/95709524-e980-444e-b5c1-9ff09ebc5324)


I'm not entirely sure this isn't an issue with just my environment, or if this is the correct fix, but this seems to fix it in my environment.