### PR TITLE
fix percy specs echarts

### DIFF
--- a/e2e/support/helpers/e2e-visual-tests-helpers.js
+++ b/e2e/support/helpers/e2e-visual-tests-helpers.js
@@ -8,7 +8,10 @@ import {
 } from "metabase/visualizations/echarts/cartesian/timeline-events/option";
 
 export function echartsContainer() {
-  return cy.findByTestId("chart-container");
+  return cy.findByTestId("chart-container").should(root => {
+    // Check if there's an SVG child within the element
+    expect(root.find("svg").length, "SVG exists").to.be.equal(1);
+  });
 }
 
 export function goalLine() {

--- a/e2e/test/visual/static-visualizations/waterfall.cy.spec.js
+++ b/e2e/test/visual/static-visualizations/waterfall.cy.spec.js
@@ -46,6 +46,8 @@ function createWaterfallQuestion({ showTotal } = {}) {
       "template-tags": {},
     },
     visualization_settings: {
+      "graph.dimensions": ["C1"],
+      "graph.metrics": ["C2"],
       "graph.show_values": true,
     },
     display: "waterfall",


### PR DESCRIPTION
### Description

Fixes percy failures on the ECharts branch to verify we did not break charts.

### How to verify

Percy [rendered](https://percy.io/6a8dd5c9/metabase/builds/33907852/changed/1856482049?browser=chrome&browser_ids=56&subcategories=approved&viewLayout=side-by-side&viewMode=new&width=1280&widths=1280) broken/missing charts:
<img width="651" alt="Screenshot 2024-04-26 at 10 52 27 AM" src="https://github.com/metabase/metabase/assets/14301985/b4d70a76-d04d-46ec-a274-845177ac7a60">
