### PR TITLE
mark settings test flaky

### DIFF
--- a/e2e/test/scenarios/permissions/reproductions/39221-fetch-settings-only-if-admin.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/39221-fetch-settings-only-if-admin.cy.spec.js
@@ -16,14 +16,18 @@ describe("issue 39221", () => {
   });
 
   ["admin", "normal"].forEach(user => {
-    it(`${user.toUpperCase()}: updating user-specific setting should not result in fetching all site settings (metabase#39221)`, () => {
-      user === "normal" ? cy.signInAsNormalUser() : null;
+    it(
+      `${user.toUpperCase()}: updating user-specific setting should not result in fetching all site settings (metabase#39221)`,
+      { tags: "@flaky" },
+      () => {
+        user === "normal" ? cy.signInAsNormalUser() : null;
 
-      startNewNativeQuestion();
-      popover().findByText("Sample Database").click();
-      cy.wait("@sessionProperties");
+        startNewNativeQuestion();
+        popover().findByText("Sample Database").click();
+        cy.wait("@sessionProperties");
 
-      cy.get("@siteSettings").should("be.null");
-    });
+        cy.get("@siteSettings").should("be.null");
+      },
+    );
   });
 });


### PR DESCRIPTION
This test has a 32% flake rate and a 10% fail rate and is blocking PRs.

![Screen Shot 2024-04-25 at 5 17 14 PM](https://github.com/metabase/metabase/assets/30528226/b3ab137b-2c9d-4caf-a013-49b4519e3f1e)
![Screen Shot 2024-04-25 at 5 16 05 PM](https://github.com/metabase/metabase/assets/30528226/f47439c6-69a1-4b96-803f-bf23d8304e00)

[example failure](https://app.replay.io/recording/e2etestscenariospermissionsreproductions39221-fetch-settings-only-if-admincyspecjs--06b31333-8972-41dd-b10f-ea3c99304557?commentId=&focusWindow=eyJiZWdpbiI6eyJwb2ludCI6IjE5NDcxMTEzMjQ4MDk5MDE0OTk5MDA5NDk0NTI5MjE0ODk0IiwidGltZSI6MTE5ODB9LCJlbmQiOnsicG9pbnQiOiIzNjAyMTU1OTQ5NDQzMTIyMDAxNTY2MTc4NjQyOTY1OTgwOSIsInRpbWUiOjE4MzI4fX0%253D&point=23689854451506470854775611584416911&primaryPanel=cypress&secondaryPanel=console&time=14109&viewMode=non-dev)
