### PR TITLE
Enforce module encapsulation via a linter

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -22,6 +22,7 @@
   :metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests {:level :warning}
   :metabase/mbql-query-first-arg                                       {:level :warning}
   :metabase/missing-test-expr-requires-in-cljs                         {:level :warning}
+  :metabase/module-encapsulation-broken                                {:level :warning}
   :metabase/test-helpers-use-non-thread-safe-functions                 {:level :warning}
   :metabase/validate-deftest                                           {:level :warning}
   :metabase/validate-logging                                           {:level :warning}
@@ -494,6 +495,7 @@
   {cljs.test/deftest                                                                                                         hooks.clojure.test/deftest
    cljs.test/is                                                                                                              hooks.clojure.test/is
    cljs.test/use-fixtures                                                                                                    hooks.clojure.test/use-fixtures
+   clojure.core/ns                                                                                                           hooks.clojure.core/module-internals-should-be-encapsulated
    clojure.test/deftest                                                                                                      hooks.clojure.test/deftest
    clojure.test/is                                                                                                           hooks.clojure.test/is
    clojure.test/use-fixtures                                                                                                 hooks.clojure.test/use-fixtures

--- a/.clj-kondo/hooks/clojure/core.clj
+++ b/.clj-kondo/hooks/clojure/core.clj
@@ -186,7 +186,7 @@
   "Global module namespaces can be imported anywhere, but their (non-module) internal namespaces are private.
   We can nest global modules, in which case each module hides its internal even from its parent module, but is itself
   importable even outside its parent module(s)."
-  ;; We keep this map sorted so parents precede their children. For legibility please keep them listed that way too..
+  ;; We keep this map sorted so parents precede their children. For legibility please keep them listed that way too.
   (sorted-set
    'metabase.db
    ;; We may aspire to encapsulating more of these - either through refactoring or ^:clj-kondo/ignore.

--- a/.clj-kondo/hooks/clojure/core.clj
+++ b/.clj-kondo/hooks/clojure/core.clj
@@ -213,7 +213,7 @@
    'metabase.db.liquibase))
 
 (def ^:private modules
-  "A sorted list, from outside in of all modules and submodules, both global and internal."
+  "A sorted list, from outside in, of all modules and submodules, both global and internal."
   (into global-modules internal-modules))
 
 (defn- module->child-detector

--- a/.clj-kondo/hooks/clojure/core.clj
+++ b/.clj-kondo/hooks/clojure/core.clj
@@ -287,9 +287,7 @@
          ;; Support the module.core convention used by metabase.lib
          (some-> (remove-suffix ns-s ".core") symbol modules)
          ;; We treat modules and their test namespaces synonymously
-         (some-> (remove-suffix ns-s "-test") symbol modules)
-         (when (modules ns-sym)
-           (symbol (str ns-s "-test")))]))
+         (some-> (remove-suffix ns-s "-test") symbol modules)]))
 
 (defn module-internals-should-be-encapsulated
   "Test whether a namespace violates the encapsulation of any modules. Does not lint dynamic references, yet."

--- a/.clj-kondo/hooks/clojure/core.clj
+++ b/.clj-kondo/hooks/clojure/core.clj
@@ -213,7 +213,7 @@
    'metabase.db.liquibase))
 
 (def ^:private modules
-  "A sorted list, from outside in of all modules and submodules, both global and private."
+  "A sorted list, from outside in of all modules and submodules, both global and internal."
   (into global-modules internal-modules))
 
 (defn- module->child-detector

--- a/.clj-kondo/hooks/clojure/core.clj
+++ b/.clj-kondo/hooks/clojure/core.clj
@@ -278,11 +278,13 @@
     (subs s 0 (- (count s)
                  (count suffix)))))
 
-(defn- allowed-parents [{ns-sym :value ns-s :string-value}]
+(defn- allowed-parents
+  "The modules whose internals the given namespace is allowed to depend on."
+  [{ns-sym :value ns-s :string-value}]
   (into #{} (remove nil?)
         [;; Modules can depend on their own internals.
          (modules ns-sym)
-         ;; We can to depend on our siblings.
+         ;; We can depend on our siblings.
          (parent-module ns-sym)
          ;; Support the module.core convention used by metabase.lib
          (some-> (remove-suffix ns-s ".core") symbol modules)


### PR DESCRIPTION
### Description

This introduces a linter against importing a module's internals from outside that module.

Uses `metabase.upload` and `metabase.db` as test cases, which motivate the need to supporting nested and internal modules.