### PR TITLE
update timeseries unit specs

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/utils/timeseries.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/utils/timeseries.ts
@@ -57,7 +57,7 @@ export const TIMESERIES_INTERVALS: (TimeSeriesInterval & {
   { unit: "month", count: 1, testFn: (d: Dayjs) => d.date() }, // (15) 1 month
   { unit: "month", count: 3, testFn: (d: Dayjs) => d.month() % 3 }, // (16) 3 months / 1 quarter
   { unit: "year", count: 1, testFn: (d: Dayjs) => d.month() }, // (17) 1 year
-  { unit: "year", count: 2, testFn: (d: Dayjs) => d.year() % 2 }, // (18) 5 year
+  { unit: "year", count: 2, testFn: (d: Dayjs) => d.year() % 2 }, // (18) 2 years
   { unit: "year", count: 5, testFn: (d: Dayjs) => d.year() % 5 }, // (19) 5 year
   { unit: "year", count: 10, testFn: (d: Dayjs) => d.year() % 10 }, // (20) 10 year
   { unit: "year", count: 50, testFn: (d: Dayjs) => d.year() % 50 }, // (21) 50 year

--- a/frontend/src/metabase/visualizations/echarts/cartesian/utils/timeseries.tz.unit.spec.js
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/utils/timeseries.tz.unit.spec.js
@@ -3,14 +3,6 @@ import moment from "moment-timezone"; // eslint-disable-line no-restricted-impor
 import testAcrossTimezones from "__support__/timezones";
 import { computeTimeseriesDataInverval } from "metabase/visualizations/echarts/cartesian/utils/timeseries";
 
-// jsdom doesn't support layout methods like getBBox, so we need to mock it.
-window.SVGElement.prototype.getBBox = () => ({
-  x: 0,
-  y: 0,
-  width: 1000,
-  height: 1000,
-});
-
 testAcrossTimezones(reportTz => {
   describe("computeTimeseriesDataInvervalIndex", () => {
     [
@@ -25,9 +17,9 @@ testAcrossTimezones(reportTz => {
         // parse timestamps in reporting timezone and serialize
         const xValues = data.map(d => moment.tz(d, reportTz).format());
 
-        const { interval, count } = computeTimeseriesDataInverval(xValues);
+        const { unit, count } = computeTimeseriesDataInverval(xValues);
 
-        expect(interval).toBe(expectedInterval);
+        expect(unit).toBe(expectedInterval);
         expect(count).toBe(expectedCount);
       });
     });

--- a/frontend/src/metabase/visualizations/echarts/cartesian/utils/timeseries.unit.spec.js
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/utils/timeseries.unit.spec.js
@@ -91,10 +91,10 @@ describe("visualization.lib.timeseries", () => {
 
     TEST_CASES.map(([expectedInterval, expectedCount, data]) => {
       it("should return " + expectedCount + " " + expectedInterval, () => {
-        const { interval, count } = computeTimeseriesDataInverval(
+        const { unit, count } = computeTimeseriesDataInverval(
           data.map(d => new Date(d)),
         );
-        expect(interval).toBe(expectedInterval);
+        expect(unit).toBe(expectedInterval);
         expect(count).toBe(expectedCount);
       });
     });
@@ -103,27 +103,27 @@ describe("visualization.lib.timeseries", () => {
 
     units.forEach(testUnit => {
       it(`should return one ${testUnit} when ${testUnit} interval is set`, () => {
-        const { interval, count } = computeTimeseriesDataInverval(
+        const { unit, count } = computeTimeseriesDataInverval(
           [
             new Date("2019-01-01").toISOString(),
             new Date("2020-01-01").toISOString(),
           ],
           testUnit,
         );
-        expect(interval).toBe(testUnit);
+        expect(unit).toBe(testUnit);
         expect(count).toBe(1);
       });
     });
 
     it("should return 3 months for quarter interval", () => {
-      const { interval, count } = computeTimeseriesDataInverval(
+      const { unit, count } = computeTimeseriesDataInverval(
         [
           new Date("2019-01-01").toISOString(),
           new Date("2020-01-01").toISOString(),
         ],
         "quarter",
       );
-      expect(interval).toBe("month");
+      expect(unit).toBe("month");
       expect(count).toBe(3);
     });
   });
@@ -214,13 +214,13 @@ describe("visualization.lib.timeseries", () => {
         { expectedInterval, expectedCount },
       ]) => {
         it("should return " + expectedCount + " " + expectedInterval, () => {
-          const { interval, count } = computeTimeseriesTicksInterval(
+          const { unit, count } = computeTimeseriesTicksInterval(
             xDomain,
             xInterval,
             chartWidth,
             tickFormat,
           );
-          expect(interval).toBe(expectedInterval);
+          expect(unit).toBe(expectedInterval);
           expect(count).toBe(expectedCount);
         });
       },


### PR DESCRIPTION
### Description

Fixes `fe-tests-timezones` CI check which runs timeseries unit specs.

### How to verify

Ensure `fe-tests-timezones` check is green
