### PR TITLE
Fix format-rfc3339 uses 12 hour format

### DIFF
--- a/src/metabase/util/date_2.clj
+++ b/src/metabase/util/date_2.clj
@@ -113,8 +113,11 @@
     (instance? LocalDate t)
     (recur (t/zoned-date-time t (t/local-time 0) (t/zone-id)))
 
+    (nil? t)
+    nil
+
     :else
-    (t/format "yyyy-MM-dd'T'hh:mm:ss.SSXXX" t)))
+    (t/format "yyyy-MM-dd'T'HH:mm:ss.SSXXX" t)))
 
 (defn format-sql
   "Format a temporal value `t` as a SQL-style literal string (for most SQL databases). This is the same as ISO-8601 but

--- a/test/metabase/analytics/snowplow_test.clj
+++ b/test/metabase/analytics/snowplow_test.clj
@@ -80,13 +80,13 @@
 
 (defn valid-datetime-for-snowplow?
   "Check if a datetime string has the format that snowplow accepts.
-  The string should have the format yyyy-mm-dd'T'hh:mm:ss.SSXXX which is a RFC3339 format.
+  The string should have the format yyyy-mm-dd'T'HH:mm:ss.SSXXX which is a RFC3339 format.
   Reference: https://json-schema.org/understanding-json-schema/reference/string.html#dates-and-times"
   [t]
   (try
     (java.time.LocalDate/parse
       t
-      (java.time.format.DateTimeFormatter/ofPattern "yyyy-MM-dd'T'hh:mm:ss.SSXXX"))
+      (java.time.format.DateTimeFormatter/ofPattern "yyyy-MM-dd'T'HH:mm:ss.SSXXX"))
     true
     (catch Exception _e
       false)))
@@ -105,7 +105,7 @@
                      :application_database_version (#'snowplow/app-db-version)}}
              (:context (first @*snowplow-collector*))))
 
-      (testing "the created_at should have the format yyyy-MM-dd'T'hh:mm:ss.SSXXX"
+      (testing "the created_at should have the format be formatted as RFC3339"
         (is (valid-datetime-for-snowplow?
               (get-in (first @*snowplow-collector*) [:context :data :created_at])))))))
 

--- a/test/metabase/util/date_2_test.clj
+++ b/test/metabase/util/date_2_test.clj
@@ -143,20 +143,31 @@
 
 ;; TODO - more tests!
 (deftest ^:parallel format-test
-  (testing "ZonedDateTime"
-    (testing "should get formatted as the same way as an OffsetDateTime"
-      (is (= "2019-11-01T18:39:00-07:00"
-             (u.date/format (t/zoned-date-time "2019-11-01T18:39:00-07:00[US/Pacific]")))))
-    (testing "make sure it can handle different DST offsets correctly"
-      (is (= "2020-02-13T16:31:00-08:00"
-             (u.date/format (t/zoned-date-time "2020-02-13T16:31:00-08:00[US/Pacific]"))))))
-  (testing "Instant"
-    (is (= "1970-01-01T00:00:00Z"
-           (u.date/format (t/instant "1970-01-01T00:00:00Z")))))
-  (testing "nil"
-    (is (= nil
-           (u.date/format nil))
-        "Passing `nil` should return `nil`")))
+  (are
+    [expected input]
+    (= expected (u.date/format input))
+    "2019-06-05T18:39:00-07:00" (t/zoned-date-time "2019-06-05T18:39:00-07:00[US/Pacific]")
+    "2019-11-05T18:39:00-08:00" (t/zoned-date-time "2019-11-05T18:39:00-08:00[US/Pacific]")
+    "2019-06-05T18:39:00-07:00" (t/offset-date-time "2019-06-05T18:39:00-07:00")
+    "18:39:00-07:00"            (t/offset-time "18:39:00-07:00")
+    "2019-06-05T19:27:00"       (t/local-date-time "2019-06-05T19:27")
+    "2019-06-05"                (t/local-date "2019-06-05")
+    "2019-06-30"                (t/local-date "2019-06-30")
+    "14:30:30"                  (t/local-time "14:30:30")
+    "2019-06-05T00:00:00Z"      (t/instant "2019-06-05T00:00:00Z")
+    nil                         nil))
+
+(deftest ^:parallel format-rfc3339-test
+  (are
+    [expected input]
+    (= expected (u.date/format-rfc3339 input))
+    "2019-06-05T18:39:00.00-07:00" (t/zoned-date-time "2019-06-05T18:39:00-07:00[US/Pacific]")
+    "2019-11-05T18:39:00.00-08:00" (t/zoned-date-time "2019-11-05T18:39:00-08:00[US/Pacific]")
+    "2019-06-05T18:39:00.00-07:00" (t/offset-date-time "2019-06-05T18:39:00-07:00")
+    "2019-06-05T19:27:00.00Z"      (t/local-date-time "2019-06-05T19:27")
+    "2019-06-05T00:00:00.00Z"      (t/local-date "2019-06-05")
+    "2019-06-05T00:00:00.00Z"      (t/instant "2019-06-05T00:00:00Z")
+    nil                            nil))
 
 (deftest ^:parallel format-human-readable-test
   ;; strings are localized slightly differently on different JVMs. For places where there are multiple possible


### PR DESCRIPTION
Fix the bug that the `format-rfc3339` function used the 12-hour format instead of 24-hour.

It was used only to format the `instance-creation` time for snowplow events, and those timestamps will definitely be off :(.
The silver lining is that the data will get corrected once this fix is shipped and instances start to resend snowplow events.

Lucky for us, it doesn't affect the event time (aka root timestamp on snowplow) because it's created during the snowplow's ingestion. 