### PR TITLE
Fix broken E2E reproduction for #39221

### DIFF
--- a/e2e/test/scenarios/permissions/reproductions/39221-fetch-settings-only-if-admin.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/39221-fetch-settings-only-if-admin.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, startNewNativeQuestion, popover } from "e2e/support/helpers";
+import { restore, openReviewsTable } from "e2e/support/helpers";
 
 describe("issue 39221", () => {
   beforeEach(() => {
@@ -6,21 +6,15 @@ describe("issue 39221", () => {
     cy.intercept("GET", "/api/session/properties").as("sessionProperties");
 
     restore();
-    cy.signInAsAdmin();
-
-    cy.request("POST", "/api/database", {
-      engine: "sqlite",
-      name: "sqlite",
-      details: { db: "./resources/sqlite-fixture.db" },
-    });
   });
 
   ["admin", "normal"].forEach(user => {
     it(`${user.toUpperCase()}: updating user-specific setting should not result in fetching all site settings (metabase#39221)`, () => {
-      user === "normal" ? cy.signInAsNormalUser() : null;
+      cy.signIn(user);
+      openReviewsTable({ mode: "notebook" });
+      // Opening a SQL preview sidebar will trigger a user-local setting update
+      cy.findByLabelText("View the SQL").click();
 
-      startNewNativeQuestion();
-      popover().findByText("Sample Database").click();
       cy.wait("@sessionProperties");
 
       cy.get("@siteSettings").should("be.null");

--- a/e2e/test/scenarios/permissions/reproductions/39221-fetch-settings-only-if-admin.cy.spec.ts
+++ b/e2e/test/scenarios/permissions/reproductions/39221-fetch-settings-only-if-admin.cy.spec.ts
@@ -10,7 +10,8 @@ describe("issue 39221", () => {
 
   ["admin", "normal"].forEach(user => {
     it(`${user.toUpperCase()}: updating user-specific setting should not result in fetching all site settings (metabase#39221)`, () => {
-      cy.signIn(user);
+      cy.signOut();
+      cy.signIn(user as "admin" | "normal");
       openReviewsTable({ mode: "notebook" });
       // Opening a SQL preview sidebar will trigger a user-local setting update
       cy.findByLabelText("View the SQL").click();


### PR DESCRIPTION
This test has been flaking so badly that it had to be re-run every single time. Sometimes even multiple times in a row.

## Cause
Not sure what exactly changed in the source code that caused this test to fail, but it seems related to the syncing. The original idea was to add a small SQLite database before each test so that each user could pick the database for their respective native queries. That triggers `last-used-native-database-id` user setting update. But the database never appeared in the databases list for the "normal" user. Hence why I think it's a sync problem. The database picker would appear for a few milliseconds, but then the "Sample Database" would get "chosen" automatically as it is the only database available. This caused the re-render (which is why Cypress failed) 

![image](https://github.com/metabase/metabase/assets/31325167/bf3a5317-f2e9-407c-b2d4-912d900dcadc)

## Solution
I've simplified the test by skipping the "add new database" and simply used another action that also triggers user-local setting update (this time it's `notebook-native-preview-shown`). We really only needed ANY action that updates the local setting in order to see which requests fire after it.

Local run
![image](https://github.com/metabase/metabase/assets/31325167/9a11f466-6527-499c-b2fa-e507c11c456a)

The stress-test run x 20 ✅ 
https://github.com/metabase/metabase/actions/runs/8845783621

### Additional notes
This PR also converts the spec to TS.