### PR TITLE
Mitigate redshift flakes by not dropping view in test

### DIFF
--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -255,29 +255,25 @@
         (t2.with-temp/with-temp [Database database {:engine :redshift, :details db-details}]
           (let [view-nm      (tx/db-qualified-table-name (:name database) "lbv")
                 qual-view-nm (format "\"%s\".\"%s\"" (redshift.test/unique-session-schema) view-nm)]
-            (try
-              (execute!
-               (str "CREATE OR REPLACE VIEW %1$s AS ("
-                    "WITH test_data AS (SELECT 'open' AS shop_status UNION ALL SELECT 'closed' AS shop_status) "
-                    "SELECT NULL as raw_null, "
-                    "'hello' as raw_var, "
-                    "CASE WHEN shop_status = 'open' THEN 11387.133 END AS case_when_numeric_inc_nulls "
-                    "FROM test_data) WITH NO SCHEMA BINDING;")
-               qual-view-nm)
-              (binding [sync-util/*log-exceptions-and-continue?* false]
-                (sync/sync-database! database {:scan :schema}))
-              (is (contains?
-                   (t2/select-fn-set :name Table :db_id (u/the-id database)) ; the new view should have been synced without errors
-                   view-nm))
-              (let [table-id (t2/select-one-pk Table :db_id (u/the-id database), :name view-nm)]
+            (execute!
+             (str "CREATE OR REPLACE VIEW %1$s AS ("
+                  "WITH test_data AS (SELECT 'open' AS shop_status UNION ALL SELECT 'closed' AS shop_status) "
+                  "SELECT NULL as raw_null, "
+                  "'hello' as raw_var, "
+                  "CASE WHEN shop_status = 'open' THEN 11387.133 END AS case_when_numeric_inc_nulls "
+                  "FROM test_data) WITH NO SCHEMA BINDING;")
+             qual-view-nm)
+            (binding [sync-util/*log-exceptions-and-continue?* false]
+              (sync/sync-database! database {:scan :schema}))
+            (is (contains?
+                 (t2/select-fn-set :name Table :db_id (u/the-id database)) ; the new view should have been synced without errors
+                 view-nm))
+            (let [table-id (t2/select-one-pk Table :db_id (u/the-id database), :name view-nm)]
                 ;; and its columns' :base_type should have been identified correctly
-                (is (= [{:name "case_when_numeric_inc_nulls", :database_type "numeric",           :base_type :type/Decimal}
-                        {:name "raw_null",                    :database_type "character varying", :base_type :type/Text}
-                        {:name "raw_var",                     :database_type "character varying", :base_type :type/Text}]
-                       (t2/select [Field :name :database_type :base_type] :table_id table-id {:order-by [:name]}))))
-              (finally
-                (execute! (str "DROP VIEW IF EXISTS %s;")
-                          qual-view-nm)))))))))
+              (is (= [{:name "case_when_numeric_inc_nulls", :database_type "numeric",           :base_type :type/Decimal}
+                      {:name "raw_null",                    :database_type "character varying", :base_type :type/Text}
+                      {:name "raw_var",                     :database_type "character varying", :base_type :type/Text}]
+                     (t2/select [Field :name :database_type :base_type] :table_id table-id {:order-by [:name]}))))))))))
 
 (deftest describe-database-privileges-test
   (mt/test-driver :redshift


### PR DESCRIPTION
I just came across [this](https://github.com/metabase/metabase/actions/runs/8844894760/job/24287698335?pr=41840#step:3:1279) redshift flake. This PR prevents it from happening again.

Similar to https://github.com/metabase/metabase/pull/41191

Dropping tables causes flakes in redshift. It's okay to not drop tables anymore in redshift tests with databases created with `with-temp`, because we have fake database isolation using the table name prefix.