### PR TITLE
Remove the custom resize handle from the notebook native query preview sidebar

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
@@ -66,7 +66,7 @@ export const NotebookContainer = ({
 
   const Handle = forwardRef<HTMLDivElement, Partial<ResizableBoxProps>>(
     function Handle(props, ref) {
-      const handleWidth = 6;
+      const handleWidth = 10;
       const borderWidth = 1;
       const left = rem(-((handleWidth + borderWidth) / 2));
 

--- a/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
@@ -4,7 +4,7 @@ import type { ResizeCallbackData, ResizableBoxProps } from "react-resizable";
 import { ResizableBox } from "react-resizable";
 import { useWindowSize } from "react-use";
 
-import { color, darken } from "metabase/lib/colors";
+import { color } from "metabase/lib/colors";
 import { useSelector, useDispatch } from "metabase/lib/redux";
 import {
   setNotebookNativePreviewSidebarWidth,
@@ -79,14 +79,11 @@ export const NotebookContainer = ({
           top={0}
           bottom={0}
           m="auto 0"
-          h={rem(100)}
           w={rem(handleWidth)}
           left={left}
-          bg={darken("border", 0.03)}
           style={{
             zIndex: 5,
             cursor: "ew-resize",
-            borderRadius: rem(8),
           }}
         ></Box>
       );


### PR DESCRIPTION
### Description
This PR removes the custom (visible) resize handle that existed on the notebook native query preview sidebar. It resembled a scrollbar too much, which contributed to a confusion when it gets crowded in the UI. The design/product decision was to make the whole left edge of the sidebar resizable, and this PR achieves exactly that.

I've increased the width of the resize handle to 10px to make it easier to find it, and to press it. It is transparent so this really doesn't affect anything visually.

### How to verify
Open a notebook view of any table and open a native query preview on a desktop. You shouldn't see a custom grey resize handle. Clicking anywhere along the left sidebar edge should allow you to resize it.

### Demo
Before
https://github.com/metabase/metabase/assets/31325167/78486263-277c-40a1-ab06-0d0f9f846fc4

Now
https://github.com/metabase/metabase/assets/31325167/c7d587ce-bf30-45cb-a852-017c12e21d8f

### Checklist
The existing tests should suffice.
