### PR TITLE
Fix Interactive Question Loading state

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.tsx
@@ -11,7 +11,7 @@ import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import CS from "metabase/css/core/index.css";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import {
-  initializeQB,
+  initializeQBRaw,
   navigateToNewCardInsideQB,
   updateQuestion,
 } from "metabase/query_builder/actions";
@@ -56,11 +56,21 @@ export const _InteractiveQuestion = ({
   useEffect(() => {
     const fetchQBData = async () => {
       const { location, params } = getQuestionParameters(questionId);
-      dispatch(initializeQB(location, params));
+      try {
+        await dispatch(initializeQBRaw(location, params));
+      } catch (error) {
+        setLoading(false);
+      }
     };
 
-    fetchQBData().then(() => setLoading(false));
+    fetchQBData();
   }, [dispatch, questionId]);
+
+  useEffect(() => {
+    if (queryResults) {
+      setLoading(false);
+    }
+  }, [queryResults]);
 
   if (!loading && !queryResults) {
     return <SdkError message={t`Question not found`} />;

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.tsx
@@ -7,7 +7,6 @@ import { SdkError } from "embedding-sdk/components/private/SdkError";
 import type { SdkClickActionPluginsConfig } from "embedding-sdk/lib/plugins";
 import { useSdkSelector } from "embedding-sdk/store";
 import { getPlugins } from "embedding-sdk/store/selectors";
-import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import CS from "metabase/css/core/index.css";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import {
@@ -24,7 +23,7 @@ import {
   getQuestion,
   getUiControls,
 } from "metabase/query_builder/selectors";
-import { Group, Stack } from "metabase/ui";
+import { Group, Stack, Box, Loader } from "metabase/ui";
 import { getEmbeddingMode } from "metabase/visualizations/click-actions/lib/modes";
 import type { CardId } from "metabase-types/api";
 
@@ -72,54 +71,47 @@ export const _InteractiveQuestion = ({
     }
   }, [queryResults]);
 
-  if (!loading && !queryResults) {
+  if (loading) {
+    return <Loader data-testid="loading-spinner" />;
+  }
+
+  if (!queryResults || !question) {
     return <SdkError message={t`Question not found`} />;
   }
 
   return (
-    <LoadingAndErrorWrapper
-      className={cx(CS.flexFull, CS.fullWidth)}
-      loading={!result}
-      error={typeof result === "string" ? result : null}
-      noWrapper
-    >
-      {() =>
-        !question ? (
-          <SdkError message={t`Question not found`} />
-        ) : (
-          <Stack h="100%">
-            {FilterHeader.shouldRender({
-              question,
-              queryBuilderMode: uiControls.queryBuilderMode,
-              isObjectDetail: false,
-            }) && (
-              <FilterHeader
-                expanded
-                question={question}
-                updateQuestion={(...args) => dispatch(updateQuestion(...args))}
-              />
-            )}
-            <Group h="100%" pos="relative" align="flex-start">
-              <QueryVisualization
-                className={cx(CS.flexFull, CS.fullWidth)}
-                question={question}
-                rawSeries={[{ card, data: result && result.data }]}
-                isRunning={isRunning}
-                isObjectDetail={false}
-                isResultDirty={false}
-                isNativeEditorOpen={false}
-                result={result}
-                noHeader
-                mode={mode}
-                navigateToNewCardInsideQB={(props: any) => {
-                  dispatch(navigateToNewCardInsideQB(props));
-                }}
-              />
-            </Group>
-          </Stack>
-        )
-      }
-    </LoadingAndErrorWrapper>
+    <Box className={cx(CS.flexFull, CS.fullWidth, CS.fullHeight)}>
+      <Stack h="100%">
+        {FilterHeader.shouldRender({
+          question,
+          queryBuilderMode: uiControls.queryBuilderMode,
+          isObjectDetail: false,
+        }) && (
+          <FilterHeader
+            expanded
+            question={question}
+            updateQuestion={(...args) => dispatch(updateQuestion(...args))}
+          />
+        )}
+        <Group h="100%" pos="relative" align="flex-start">
+          <QueryVisualization
+            className={cx(CS.flexFull, CS.fullWidth)}
+            question={question}
+            rawSeries={[{ card, data: result && result.data }]}
+            isRunning={isRunning}
+            isObjectDetail={false}
+            isResultDirty={false}
+            isNativeEditorOpen={false}
+            result={result}
+            noHeader
+            mode={mode}
+            navigateToNewCardInsideQB={(props: any) => {
+              dispatch(navigateToNewCardInsideQB(props));
+            }}
+          />
+        </Group>
+      </Stack>
+    </Box>
   );
 };
 

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -403,6 +403,9 @@ async function handleQBInit(
   }
 }
 
+// Does the same thing as initializeQB, but doesn't catch errors.
+// This function is used for the SDK, and we want to use the errors
+// to determine loading states and show error messages
 export const initializeQBRaw =
   (location: LocationDescriptorObject, params: QueryParams) =>
   async (dispatch: Dispatch, getState: GetState) => {

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -403,11 +403,17 @@ async function handleQBInit(
   }
 }
 
-export const initializeQB =
+export const initializeQBRaw =
   (location: LocationDescriptorObject, params: QueryParams) =>
   async (dispatch: Dispatch, getState: GetState) => {
+    await handleQBInit(dispatch, getState, { location, params });
+  };
+
+export const initializeQB =
+  (location: LocationDescriptorObject, params: QueryParams) =>
+  async (dispatch: Dispatch) => {
     try {
-      await handleQBInit(dispatch, getState, { location, params });
+      await dispatch(initializeQBRaw(location, params));
     } catch (error) {
       console.warn("initializeQB failed because of an error:", error);
       dispatch(setErrorPage(error));

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -411,9 +411,9 @@ export const initializeQBRaw =
 
 export const initializeQB =
   (location: LocationDescriptorObject, params: QueryParams) =>
-  async (dispatch: Dispatch) => {
+  async (dispatch: Dispatch, getState: GetState) => {
     try {
-      await dispatch(initializeQBRaw(location, params));
+      await handleQBInit(dispatch, getState, { location, params });
     } catch (error) {
       console.warn("initializeQB failed because of an error:", error);
       dispatch(setErrorPage(error));


### PR DESCRIPTION
### Description

Fixes the problems with the loading state in the SDK Interactive question, which was showing an error before everything was loaded.

_What I did_
* Refactor `initializeQB` to give us more control over error states
* Uses `queryResults` instead of `result` to determine whether the component is loaded, and uses the refactored `initalizeQB` to present an error state if a problem comes up
