### PR TITLE
Remove the ace editor gutter line number highlight

### DIFF
--- a/frontend/src/metabase/query_builder/components/notebook/NotebookNativePreview/NotebookNativePreview.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookNativePreview/NotebookNativePreview.tsx
@@ -108,6 +108,9 @@ export const NotebookNativePreview = (): JSX.Element => {
               fontSize={12}
               style={{ backgroundColor: color("bg-light") }}
               showPrintMargin={false}
+              setOptions={{
+                highlightGutterLine: false,
+              }}
             />
           </NativeQueryEditorRoot>
         )}


### PR DESCRIPTION
This should be pretty non-controversial PR to review.
The design/product team requested we get rid of the annoying gutter line number highlight in the notebook native query preview sidebar.

When I created this component initially, I thought that the prop `highlightActiveLine` set to `false` would be enough, so I couldn't figure out why do we still have this leftover highlight in the gutter. After some digging I found this:
https://ace.c9.io/api/interfaces/ace.Ace.EditorOptions.html#highlightGutterLine

This saved us from having to mess with the CSS overrides 🎉 

## Demo
Before
![image](https://github.com/metabase/metabase/assets/31325167/66905850-f71c-493e-8fe2-be98d8032266)

Now
![image](https://github.com/metabase/metabase/assets/31325167/d3671c36-e466-421c-9be6-0a0313510608)
