### PR TITLE
Add table view count column and increment it on views

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -6665,6 +6665,49 @@ databaseChangeLog:
               );
       rollback: # nothing to do, since view_count didn't exist in v49
 
+  - changeSet:
+      id: v50.2024-04-25T16:29:35
+      author: calherries
+      comment: Add metabase_table.view_count
+      changes:
+        - addColumn:
+            columns:
+              - column:
+                  name: view_count
+                  type: integer
+                  defaultValueNumeric: 0
+                  remarks: Keeps a running count of card views
+                  constraints:
+                    nullable: false
+            tableName: metabase_table
+
+  - changeSet:
+      id: v50.2024-04-25T16:29:36
+      author: calherries
+      comment: Populate metabase_table.view_count
+      changes:
+        - sql:
+            dbms: mysql,mariadb
+            sql: >-
+              UPDATE metabase_table t
+              SET t.view_count = (
+                  SELECT count(*)
+                  FROM view_log v
+                  WHERE t.model = 'table'
+                  AND v.model_id = t.id
+              );
+        - sql:
+            dbms: postgresql,h2
+            sql: >-
+              UPDATE metabase_table t
+              SET view_count = (
+                  SELECT count(*)
+                  FROM view_log v
+                  WHERE v.model = 'table'
+                  AND v.model_id = t.id
+              );
+      rollback: # nothing to do, since view_count didn't exist in v49
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -6693,7 +6693,7 @@ databaseChangeLog:
               SET t.view_count = (
                   SELECT count(*)
                   FROM view_log v
-                  WHERE t.model = 'table'
+                  WHERE v.model = 'table'
                   AND v.model_id = t.id
               );
         - sql:

--- a/src/metabase/events/view_log.clj
+++ b/src/metabase/events/view_log.clj
@@ -133,6 +133,7 @@
      :topic topic
      :user-id user-id}
     (try
+      (increment-view-counts! :model/Table (:id object))
       (let [table-id    (u/id object)
             database-id (:db_id object)
             has-access? (when (= api/*current-user-id* user-id)

--- a/src/metabase/integrations/slack.clj
+++ b/src/metabase/integrations/slack.clj
@@ -324,6 +324,8 @@
    filename   :- ms/NonBlankString
    channel-id :- ms/NonBlankString]
   {:pre [(slack-configured?)]}
+  ;; see the python
+  ;; https://github.com/slackapi/python-slack-sdk/pull/1272/files#diff-43db19ac0a29454cd1da520664806b266d75a54632e9661cc131406b3270b040R3066
   (let [request  {:multipart [{:name "file",     :content file}
                               {:name "filename", :content filename}
                               {:name "channels", :content channel-id}]}

--- a/src/metabase/integrations/slack.clj
+++ b/src/metabase/integrations/slack.clj
@@ -324,8 +324,6 @@
    filename   :- ms/NonBlankString
    channel-id :- ms/NonBlankString]
   {:pre [(slack-configured?)]}
-  ;; see the python
-  ;; https://github.com/slackapi/python-slack-sdk/pull/1272/files#diff-43db19ac0a29454cd1da520664806b266d75a54632e9661cc131406b3270b040R3066
   (let [request  {:multipart [{:name "file",     :content file}
                               {:name "filename", :content filename}
                               {:name "channels", :content channel-id}]}

--- a/test/metabase/api/field_test.clj
+++ b/test/metabase/api/field_test.clj
@@ -43,7 +43,7 @@
                 {:table_id         (mt/id :users)
                  :table            (merge
                                     (mt/obj->json->obj (mt/object-defaults Table))
-                                    (t2/select-one [Table :created_at :updated_at :initial_sync_status] :id (mt/id :users))
+                                    (t2/select-one [Table :created_at :updated_at :initial_sync_status :view_count] :id (mt/id :users))
                                     {:description             nil
                                      :entity_type             "entity/UserTable"
                                      :visibility_type         nil

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -56,6 +56,7 @@
    {:db          (db-details)
     :entity_type "entity/GenericTable"
     :field_order "database"
+    :view_count  0
     :metrics     []
     :segments    []}))
 

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -206,7 +206,7 @@
     (testing "Sensitive fields are included"
       (is (= (merge
               (query-metadata-defaults)
-              (t2/select-one [Table :created_at :updated_at :initial_sync_status] :id (mt/id :users))
+              (t2/select-one [Table :created_at :updated_at :initial_sync_status :view_count] :id (mt/id :users))
               {:schema       "PUBLIC"
                :name         "USERS"
                :display_name "Users"
@@ -278,7 +278,7 @@
     (testing "Sensitive fields should not be included"
       (is (= (merge
               (query-metadata-defaults)
-              (t2/select-one [Table :created_at :updated_at :initial_sync_status] :id (mt/id :users))
+              (t2/select-one [Table :created_at :updated_at :initial_sync_status :view_count] :id (mt/id :users))
               {:schema       "PUBLIC"
                :name         "USERS"
                :display_name "Users"

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -149,7 +149,9 @@
   (testing "GET /api/table/:id"
     (is (= (merge
             (dissoc (table-defaults) :segments :field_values :metrics)
-            (t2/hydrate (t2/select-one [Table :id :created_at :updated_at :initial_sync_status] :id (mt/id :venues)) :pk_field)
+            (t2/hydrate (t2/select-one [Table :id :created_at :updated_at :initial_sync_status :view_count]
+                                       :id (mt/id :venues))
+                        :pk_field)
             {:schema       "PUBLIC"
              :name         "VENUES"
              :display_name "Venues"
@@ -165,7 +167,9 @@
                                                  :schema       nil}]
         (is (= (merge
                  (dissoc (table-defaults) :segments :field_values :metrics :db)
-                 (t2/hydrate (t2/select-one [Table :id :created_at :updated_at :initial_sync_status] :id table-id) :pk_field)
+                 (t2/hydrate (t2/select-one [Table :id :created_at :updated_at :initial_sync_status :view_count]
+                                            :id table-id)
+                             :pk_field)
                  {:schema       ""
                   :name         "schemaless_table"
                   :display_name "Schemaless"
@@ -475,7 +479,9 @@
                                             :database_indexed  true
                                             :table         (merge
                                                             (dissoc (table-defaults) :segments :field_values :metrics)
-                                                            (t2/select-one [Table :id :created_at :updated_at :initial_sync_status]
+                                                            (t2/select-one [Table
+                                                                            :id :created_at :updated_at
+                                                                            :initial_sync_status :view_count]
                                                               :id (mt/id :checkins))
                                                             {:schema       "PUBLIC"
                                                              :name         "CHECKINS"
@@ -493,14 +499,15 @@
                                             :database_indexed true
                                             :table            (merge
                                                                (dissoc (table-defaults) :db :segments :field_values :metrics)
-                                                               (t2/select-one [Table :id :created_at :updated_at :initial_sync_status]
+                                                               (t2/select-one [Table
+                                                                               :id :created_at :updated_at
+                                                                               :initial_sync_status :view_count]
                                                                  :id (mt/id :users))
                                                                {:schema       "PUBLIC"
                                                                 :name         "USERS"
                                                                 :display_name "Users"
                                                                 :entity_type  "entity/UserTable"})))}]
                (mt/user-http-request :rasta :get 200 (format "table/%d/fks" (mt/id :users)))))))
-
     (testing "should just return nothing for 'virtual' tables"
       (is (= []
              (mt/user-http-request :crowberto :get 200 "table/card__1000/fks"))))))

--- a/test/metabase/events/view_log_test.clj
+++ b/test/metabase/events/view_log_test.clj
@@ -135,6 +135,19 @@
         (is (= 2 (t2/select-one-fn :view_count :model/Card (:id card)))
             "view_count for cards on the dashboard be incremented too")))))
 
+(deftest table-read-view-count-test
+  (mt/with-temp [:model/User  user  {}
+                 :model/Table table {}]
+    (testing "A card read events are recorded by a card's view_count"
+      (is (= 0 (:view_count table))
+          "view_count should be 0 before the event is published")
+      (events/publish-event! :event/table-read {:object table :user-id (u/the-id user)})
+      (is (= 1 (t2/select-one-fn :view_count :model/Table (:id table)))
+          "view_count should be incremented")
+      (events/publish-event! :event/table-read {:object table :user-id (u/the-id user)})
+      (is (= 2 (t2/select-one-fn :view_count :model/Table (:id table)))
+          "view_count should be incremented"))))
+
 
 ;;; ---------------------------------------- API tests begin -----------------------------------------
 


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/38229
[Technical doc](https://www.notion.so/metabase/e12aa6ef472c4d6ab871f60d1947327b?v=fd15329da9594408807fc38c3a4edb7a&p=086dec987ce84759baca325399c43da5&pm=s)

Does the same as part 1 and 2 but for tables. Tables was omitted from the original spec, but we decided to include it.
Part 1: https://github.com/metabase/metabase/pull/41840
Part 2: https://github.com/metabase/metabase/pull/41882

With this PR, we add a new column `metabase_table.view_count` and increment it on a table view, following the same criteria for a view as we do for adding new entries to `view_log`.