### PR TITLE
Add case for boolean columns in example

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/CombineColumns/util.ts
+++ b/frontend/src/metabase/query_builder/components/expressions/CombineColumns/util.ts
@@ -121,6 +121,10 @@ const getColumnExample = (
     return "https://www.example.com";
   }
 
+  if (Lib.isBoolean(column)) {
+    return "true";
+  }
+
   if (Lib.isID(column)) {
     return "12345";
   }


### PR DESCRIPTION
### Description

Fixes a small issue where boolean columns where written as `text` in the example of the combine column expression shortcut.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample dataset -> Accounts
2. Add column
3. Click the combine columns shortcut
4. Select the `trial converted` column
5. Verify the example says `true`, not `text

### Demo
<img width="540" alt="Screenshot 2024-04-26 at 16 51 31" src="https://github.com/metabase/metabase/assets/1250185/23790847-61e1-4149-8d3c-04531162b47f">

