### PR TITLE
DB perms page runtime error fix

### DIFF
--- a/frontend/src/metabase/admin/permissions/pages/DatabasePermissionsPage/DatabasesPermissionsPage.jsx
+++ b/frontend/src/metabase/admin/permissions/pages/DatabasePermissionsPage/DatabasesPermissionsPage.jsx
@@ -127,7 +127,7 @@ function DatabasesPermissionsPage({
 
   const showLegacyNoSelfServiceWarning =
     PLUGIN_ADVANCED_PERMISSIONS.shouldShowViewDataColumn &&
-    permissionEditor.hasLegacyNoSelfServiceValueInPermissionGraph;
+    !!permissionEditor?.hasLegacyNoSelfServiceValueInPermissionGraph;
 
   return (
     <Fragment>

--- a/frontend/src/metabase/admin/permissions/pages/GroupDataPermissionsPage/GroupsPermissionsPage.jsx
+++ b/frontend/src/metabase/admin/permissions/pages/GroupDataPermissionsPage/GroupsPermissionsPage.jsx
@@ -146,6 +146,7 @@ function GroupsPermissionsPage({
   const showLegacyNoSelfServiceWarning =
     PLUGIN_ADVANCED_PERMISSIONS.shouldShowViewDataColumn &&
     !!permissionEditor?.hasLegacyNoSelfServiceValueInPermissionGraph;
+
   return (
     <Fragment>
       <PermissionsSidebar


### PR DESCRIPTION
### Description

When viewing the database permissions page in admin on stats, you'll get a "Something went wrong page". This is due to a race condition of metadata not loading fast enough. I has caught this issue before release for the groups permissions page, but forgot to replicate the fix to the database page

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
not really needed, these pages should just be ported to Typescript