### PR TITLE
fix checking for charts existence for percy

### DIFF
--- a/e2e/support/helpers/e2e-visual-tests-helpers.js
+++ b/e2e/support/helpers/e2e-visual-tests-helpers.js
@@ -8,7 +8,11 @@ import {
 } from "metabase/visualizations/echarts/cartesian/timeline-events/option";
 
 export function echartsContainer() {
-  return cy.findByTestId("chart-container").should(root => {
+  return cy.findByTestId("chart-container");
+}
+
+export function ensureEchartsContainerHasSvg() {
+  return echartsContainer().should(root => {
     // Check if there's an SVG child within the element
     expect(root.find("svg").length, "SVG exists").to.be.equal(1);
   });

--- a/e2e/test/visual/visualizations/bar.cy.spec.js
+++ b/e2e/test/visual/visualizations/bar.cy.spec.js
@@ -3,7 +3,7 @@ import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   restore,
   visitQuestionAdhoc,
-  echartsContainer,
+  ensureEchartsContainerHasSvg,
 } from "e2e/support/helpers";
 
 const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -35,7 +35,7 @@ describe("visual tests > visualizations > bar", () => {
       },
     });
 
-    echartsContainer();
+    ensureEchartsContainerHasSvg();
     cy.createPercySnapshot();
   });
 
@@ -61,7 +61,7 @@ describe("visual tests > visualizations > bar", () => {
       },
     });
 
-    echartsContainer();
+    ensureEchartsContainerHasSvg();
     cy.createPercySnapshot();
   });
 

--- a/e2e/test/visual/visualizations/line.cy.spec.js
+++ b/e2e/test/visual/visualizations/line.cy.spec.js
@@ -3,7 +3,7 @@ import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   restore,
   visitQuestionAdhoc,
-  echartsContainer,
+  ensureEchartsContainerHasSvg,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PEOPLE } = SAMPLE_DATABASE;
@@ -41,7 +41,7 @@ describe("visual tests > visualizations > line", () => {
       },
     });
 
-    echartsContainer();
+    ensureEchartsContainerHasSvg();
     cy.createPercySnapshot();
   });
 
@@ -78,7 +78,7 @@ describe("visual tests > visualizations > line", () => {
       },
     });
 
-    echartsContainer();
+    ensureEchartsContainerHasSvg();
     cy.createPercySnapshot();
   });
 
@@ -115,7 +115,7 @@ describe("visual tests > visualizations > line", () => {
       },
     });
 
-    echartsContainer();
+    ensureEchartsContainerHasSvg();
     cy.createPercySnapshot();
   });
 
@@ -155,7 +155,7 @@ describe("visual tests > visualizations > line", () => {
       },
     });
 
-    echartsContainer();
+    ensureEchartsContainerHasSvg();
     cy.createPercySnapshot();
   });
 
@@ -196,7 +196,7 @@ describe("visual tests > visualizations > line", () => {
       },
     });
 
-    echartsContainer();
+    ensureEchartsContainerHasSvg();
     cy.createPercySnapshot();
   });
 });

--- a/e2e/test/visual/visualizations/scatter.cy.spec.js
+++ b/e2e/test/visual/visualizations/scatter.cy.spec.js
@@ -3,7 +3,7 @@ import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   restore,
   visitQuestionAdhoc,
-  echartsContainer,
+  ensureEchartsContainerHasSvg,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATABASE;
@@ -40,7 +40,7 @@ describe("visual tests > visualizations > scatter", () => {
       },
     });
 
-    echartsContainer();
+    ensureEchartsContainerHasSvg();
     cy.createPercySnapshot();
   });
 
@@ -68,7 +68,7 @@ describe("visual tests > visualizations > scatter", () => {
       },
     });
 
-    echartsContainer();
+    ensureEchartsContainerHasSvg();
     cy.createPercySnapshot();
   });
 
@@ -95,7 +95,7 @@ union all select 5, -20, 70`,
       },
     });
 
-    echartsContainer();
+    ensureEchartsContainerHasSvg();
     cy.createPercySnapshot();
   });
 });

--- a/e2e/test/visual/visualizations/waterfall.cy.spec.js
+++ b/e2e/test/visual/visualizations/waterfall.cy.spec.js
@@ -3,7 +3,7 @@ import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   restore,
   visitQuestionAdhoc,
-  echartsContainer,
+  ensureEchartsContainerHasSvg,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -43,7 +43,7 @@ describe("visual tests > visualizations > waterfall", () => {
       },
     });
 
-    echartsContainer();
+    ensureEchartsContainerHasSvg();
     cy.createPercySnapshot();
   });
 });


### PR DESCRIPTION
### Description

Updated `echartsContainer` helper that checked there is an svg inside broke some e2e tests, this PR fixes this. There is a separate helper for Percy specs now.

### How to verify

E2E specs are green
