### PR TITLE
[Metrics v2] Drop stage metadata after manipulating metric stage

### DIFF
--- a/src/metabase/query_processor/middleware/metrics.clj
+++ b/src/metabase/query_processor/middleware/metrics.clj
@@ -55,7 +55,7 @@
             last-metric-stage (last pre-transition-stages)
             metric-aggregation (-> last-metric-stage :aggregation first)
             new-metric-stage (cond-> last-metric-stage
-                                 :always (dissoc :aggregation :fields)
+                                 :always (dissoc :aggregation :fields :lib/stage-metadata)
                                  (seq following-stages) (dissoc :breakout :order-by :limit))
             ;; Store lookup for metric references created in this set of stages.
             ;; These will be adjusted later if these stages are in a join

--- a/test/metabase/query_processor/middleware/metrics_test.clj
+++ b/test/metabase/query_processor/middleware/metrics_test.clj
@@ -212,8 +212,13 @@
                                               :type :metric}]
       (let [query (as-> (lib/query mp (lib.metadata/card mp (:id source-metric))) $q
                     (lib/remove-clause $q (first (lib/aggregations $q)))
-                    (lib/limit $q 10))]
-        (qp/process-query (lib.convert/->legacy-MBQL query))))))
+                    (lib/limit $q 1))]
+        (is (=?
+              (mt/rows
+                (qp/process-query (-> (lib/query mp (lib.metadata/table mp (mt/id :products)))
+                                      (lib/limit 1))))
+              (mt/rows
+                (qp/process-query query))))))))
 
 
 (deftest ^:parallel e2e-join-to-table-test

--- a/test/metabase/query_processor/middleware/metrics_test.clj
+++ b/test/metabase/query_processor/middleware/metrics_test.clj
@@ -202,6 +202,19 @@
              (mt/rows (qp/process-query source-query))
              (mt/rows (qp/process-query query))))))))
 
+(deftest ^:parallel e2e-source-card-test
+  (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))
+        source-query (-> (lib/query mp (lib.metadata/table mp (mt/id :products)))
+                         (lib/aggregate (lib/count)))]
+    (mt/with-temp [:model/Card source-metric {:dataset_query (lib.convert/->legacy-MBQL source-query)
+                                              :database_id (mt/id)
+                                              :name "new_metric"
+                                              :type :metric}]
+      (let [query (as-> (lib/query mp (lib.metadata/card mp (:id source-metric))) $q
+                    (lib/remove-clause $q (first (lib/aggregations $q)))
+                    (lib/limit $q 10))]
+        (qp/process-query (lib.convert/->legacy-MBQL query))))))
+
 
 (deftest ^:parallel e2e-join-to-table-test
   (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))


### PR DESCRIPTION
Fixes #41917

We can simply drop `lib/stage-metadata` from a metric stage after dropping the aggregation. Not doing so, made QP assume that the aggregation was the only field in that stage and make an explicit select for it.
