### PR TITLE
remove echarts branch from the uberjar workflow

### DIFF
--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "master"
-      - "echarts"
     paths-ignore:
       # config files
       - ".**"


### PR DESCRIPTION
### Description

We added `echarts` branch to the `uberjar` workflow to get docker images for our staging environment but now we don't need it.

