### PR TITLE
Make `resolve-private-key` include `private-key-options` in database details

### DIFF
--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -110,8 +110,11 @@
           private-key-file (handle-conn-uri user account private-key-file)))
 
       :else
-      ;; get-secret-string should get the right value (using private-key-value or private-key-id) and decode it automatically
-      (let [decoded (secret/get-secret-string details "private-key")
+      ;; Why setting `:private-key-options` to "uploaded"? To fix the issue #41852. Snowflake's database edit gui
+      ;; is designed in a way, that `:private-key-options` are not sent if `hosting` enterprise feature is enabled.
+      ;; The option must be set to "uploaded" for base64 decoding to happen. Setting that option at this point is fine
+      ;; because the alternative ("local") is ruled out already in this `cond` branch.
+      (let [decoded (secret/get-secret-string (assoc details :private-key-options "uploaded") "private-key")
             file    (secret/value->file! {:connection-property-name "private-key-file"
                                           :value                    decoded})]
         (assoc (handle-conn-uri base-details user account file)

--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -321,7 +321,7 @@
 
 (defn- format-env-key ^String [env-key]
   (let [[_ header body footer]
-        (re-find #"(-----BEGIN (?:\p{Alnum}+ )?PRIVATE KEY-----)(.*)(-----END (?:\p{Alnum}+ )?PRIVATE KEY-----)" env-key)]
+        (re-find #"(?s)(-----BEGIN (?:\p{Alnum}+ )?PRIVATE KEY-----)(.*)(-----END (?:\p{Alnum}+ )?PRIVATE KEY-----)" env-key)]
     (str header (str/replace body #"\s+|\\n" "\n") footer)))
 
 (deftest can-connect-test
@@ -356,6 +356,20 @@
                                   (dissoc :password)
                                   (merge {:db pk-db :user pk-user} to-merge))]
                   (is (can-connect? details)))))))))))
+
+(deftest can-connect-pk-no-options-test
+  (mt/test-driver
+   :snowflake
+   (testing "Can connect with base64 encoded `:private-key-value` and no `:private-key-options` set (#41852)"
+     (let [pk-key (format-env-key (tx/db-test-env-var-or-throw :snowflake :pk-private-key))
+           pk-user (tx/db-test-env-var :snowflake :pk-user)
+           pk-db "SNOWFLAKE_SAMPLE_DATA"
+           details (-> (:details (mt/db))
+                       (dissoc :password)
+                       (assoc :dbname pk-db
+                              :private-key-value (u/encode-base64 pk-key)
+                              :user pk-user))]
+       (is (driver/can-connect? :snowflake details))))))
 
 (deftest report-timezone-test
   (mt/test-driver :snowflake

--- a/src/metabase/models/secret.clj
+++ b/src/metabase/models/secret.clj
@@ -217,15 +217,15 @@
                   (when id
                     (String. ^bytes (:value (latest-for-id id)) "UTF-8")))]
     (case (options-kw details)
+      "uploaded" (try
+                   ;; When a secret is updated, the value has already been decoded
+                   ;; instead of checking if the string is base64 encoded, we just
+                   ;; try to decoded it and leave it as is if the attempt fails.
+                   (String. ^bytes (driver.u/decode-uploaded value) "UTF-8")
+                   (catch IllegalArgumentException _
+                     value))
       "local" (slurp (if id value (path-kw details)))
-      ;; Attempt to decode when value of options is _"uploaded" or anything else_.
-      (try
-        ;; When a secret is updated, the value has already been decoded
-        ;; instead of checking if the string is base64 encoded, we just
-        ;; try to decoded it and leave it as is if the attempt fails.
-        (String. ^bytes (driver.u/decode-uploaded value) "UTF-8")
-        (catch IllegalArgumentException _
-          value)))))
+      value)))
 
 (def
   ^{:doc "The attributes of a secret which, if changed, will result in a version bump" :private true}

--- a/src/metabase/models/secret.clj
+++ b/src/metabase/models/secret.clj
@@ -217,15 +217,15 @@
                   (when id
                     (String. ^bytes (:value (latest-for-id id)) "UTF-8")))]
     (case (options-kw details)
-      "uploaded" (try
-                   ;; When a secret is updated, the value has already been decoded
-                   ;; instead of checking if the string is base64 encoded, we just
-                   ;; try to decoded it and leave it as is if the attempt fails.
-                   (String. ^bytes (driver.u/decode-uploaded value) "UTF-8")
-                   (catch IllegalArgumentException _
-                     value))
       "local" (slurp (if id value (path-kw details)))
-      value)))
+      ;; Attempt to decode when value of options is _"uploaded" or anything else_.
+      (try
+        ;; When a secret is updated, the value has already been decoded
+        ;; instead of checking if the string is base64 encoded, we just
+        ;; try to decoded it and leave it as is if the attempt fails.
+        (String. ^bytes (driver.u/decode-uploaded value) "UTF-8")
+        (catch IllegalArgumentException _
+          value)))))
 
 (def
   ^{:doc "The attributes of a secret which, if changed, will result in a version bump" :private true}


### PR DESCRIPTION
Closes #41852

When `hosting` feature is enabled, database edit GUI does not send `private-key-options` as part of request. `secret/get-secrect-string` depends on that value to determine if value should base64 decoded. This PR ensures the value of the key is set correctly in `resolve-private-key`.