### PR TITLE
Do not use postcss-modules eslint plugin by default

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -124,7 +124,11 @@ module.exports = {
     "jest/globals": true,
   },
   parser: "babel-eslint",
-  plugins: ["react", "no-only-tests", "postcss-modules"],
+  plugins: [
+    "react",
+    "no-only-tests",
+    shouldLintCssModules && "postcss-modules",
+  ].filter(Boolean),
   extends: [
     "eslint:recommended",
     "plugin:react/recommended",


### PR DESCRIPTION
### Description

ESlint stopped working in my vscode, so this PR re-enables it again




https://github.com/metabase/metabase/assets/125459446/94f14065-1601-461a-afae-8f21aadbee1a

