### PR TITLE
Use dayjs instead of moment-timezone in a filter test

### DIFF
--- a/frontend/src/metabase-lib/filter.unit.spec.ts
+++ b/frontend/src/metabase-lib/filter.unit.spec.ts
@@ -1,4 +1,4 @@
-import moment from "moment-timezone"; // eslint-disable-line no-restricted-imports -- deprecated usage
+import dayjs from "dayjs";
 
 import { createMockMetadata } from "__support__/metadata";
 import * as Lib from "metabase-lib";
@@ -772,6 +772,8 @@ describe("filter", () => {
   describe.each(["en", "ja", "ar", "th", "ko", "vi", "zh"])(
     "specific date filters for locale %s",
     locale => {
+      require(`dayjs/locale/${locale}`);
+
       const tableName = "PRODUCTS";
       const columnName = "CREATED_AT";
       const column = findColumn(query, tableName, columnName);
@@ -779,7 +781,7 @@ describe("filter", () => {
       beforeEach(() => {
         jest.useFakeTimers();
         jest.setSystemTime(new Date(2020, 0, 1));
-        moment.locale(locale);
+        dayjs.locale(locale);
       });
 
       it.each<Lib.SpecificDateFilterOperatorName>(["=", ">", "<"])(
@@ -795,6 +797,8 @@ describe("filter", () => {
             }),
           );
 
+          // verifies locale is specified correctly
+          expect(dayjs.locale()).toBe(locale);
           expect(filterParts).toMatchObject({
             operator,
             column: expect.anything(),
@@ -806,7 +810,9 @@ describe("filter", () => {
       );
 
       it('should be able to create and destructure a specific date filter with "between" operator and 2 values', () => {
-        moment.locale("ja");
+        require("dayjs/locale/ja");
+        dayjs.locale("ja");
+
         const values = [new Date(2018, 2, 10), new Date(2019, 10, 20)];
         const { filterParts, columnInfo, bucketInfo } = addSpecificDateFilter(
           query,
@@ -817,6 +823,8 @@ describe("filter", () => {
           }),
         );
 
+        // verifies locale is specified correctly
+        expect(dayjs.locale()).toBe("ja");
         expect(filterParts).toMatchObject({
           operator: "between",
           column: expect.anything(),


### PR DESCRIPTION
> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label
> to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this
> PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71)
> in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not
> apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform) (unless it's a tiny documentation change). Also, if you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.

Closes https://github.com/metabase/metabase/issues/[issue_number]

### Description

Describe the overall approach and the problem being solved.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> ...
2. ...

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
