### PR TITLE
Native Query Analyzer cleanup

### DIFF
--- a/src/metabase/native_query_analyzer.clj
+++ b/src/metabase/native_query_analyzer.clj
@@ -6,7 +6,8 @@
   2. Contain Metabase-specific business logic.
 
   The primary way of interacting with parsed queries is through their associated QueryFields (see model
-  file). QueryFields are maintained through the `update-query-fields-for-card!` function.
+  file). QueryFields are maintained through the `update-query-fields-for-card!` function. This is invoked as part of
+  the lifecycle of a card (see Card model).
 
   Query rewriting happens with the `replace-names` function."
   (:require

--- a/test/metabase/native_query_analyzer/parameter_substitution_test.clj
+++ b/test/metabase/native_query_analyzer/parameter_substitution_test.clj
@@ -166,6 +166,11 @@
          (->sql (mt/native-query {:template-tags (tags "num_between")
                                   :query         "SELECT * FROM orders WHERE {{num_between}}"})))))
 
+(deftest optional-field-filter-test
+    (is (= "SELECT * FROM orders WHERE \"PUBLIC\".\"ORDERS\".\"TOTAL\" BETWEEN 1 AND 2 AND (\"PUBLIC\".\"ORDERS\".\"TOTAL\" = 1)"
+         (->sql (mt/native-query {:template-tags (tags "num_between" "num_eq")
+                                  :query         "SELECT * FROM orders WHERE {{num_between}} [[AND {{num_eq}}]]"})))))
+
 (deftest field-filter-string-test
   (is (= "SELECT * FROM people WHERE ((\"PUBLIC\".\"PEOPLE\".\"NAME\" <> ?) OR (\"PUBLIC\".\"PEOPLE\".\"NAME\" IS NULL))"
          (->sql (mt/native-query {:template-tags (tags "str_not_eq")


### PR DESCRIPTION
I found a sentence that didn't make it into #41830, and while looking into {[variable}} stuff realized we didn't have a test for an optional field filter.

Neither of these are huge deals, but I figured they may as well go in.