### PR TITLE
Add null checks to `getCanShowAutoApplyFiltersToast`

### DIFF
--- a/frontend/src/metabase/dashboard/selectors/selectors.js
+++ b/frontend/src/metabase/dashboard/selectors/selectors.js
@@ -187,8 +187,8 @@ export const getCanShowAutoApplyFiltersToast = createSelector(
     isParameterValuesEmpty,
   ) => {
     return (
-      dashboard.can_write &&
-      dashboard.id !== toastDashboardId &&
+      dashboard?.can_write &&
+      dashboard?.id !== toastDashboardId &&
       isAutoApply &&
       isSlowDashboard &&
       !isParameterValuesEmpty


### PR DESCRIPTION
"Backports" a tiny refactoring from #37664, adding `dashboard` null checks to the `getCanShowAutoApplyFiltersToast`

Apparently, in v48 it's possible to reach a state where the `dashboard` value is null when opening a dashboard question (more in [this internal thread](https://metaboat.slack.com/archives/C505ZNNH4/p1714136446444389))