### PR TITLE
Use breadcrumbs to display collection paths in Browse models

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/content_verification/ModelFilterControls.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/content_verification/ModelFilterControls.tsx
@@ -1,46 +1,81 @@
+import { useCallback } from "react";
 import { t } from "ttag";
+import _ from "underscore";
 
-import type { ModelFilterControlsProps } from "metabase/browse/utils";
-import { Switch, Text } from "metabase/ui";
+import type {
+  ActualModelFilters,
+  ModelFilterControlsProps,
+} from "metabase/browse/utils";
+import { useUserSetting } from "metabase/common/hooks";
+import { Button, Icon, Popover, Switch, Text } from "metabase/ui";
 
 export const ModelFilterControls = ({
   actualModelFilters,
-  handleModelFilterChange,
+  setActualModelFilters,
 }: ModelFilterControlsProps) => {
+  const [__, setVerifiedFilterStatus] = useUserSetting(
+    "browse-filter-only-verified-models",
+    { shouldRefresh: false },
+  );
+  const setVerifiedFilterStatusDebounced = _.debounce(
+    setVerifiedFilterStatus,
+    200,
+  );
+
+  const handleModelFilterChange = useCallback(
+    (modelFilterName: string, active: boolean) => {
+      // For now, only one filter is supported
+      setVerifiedFilterStatusDebounced(active);
+      setActualModelFilters((prev: ActualModelFilters) => {
+        return { ...prev, [modelFilterName]: active };
+      });
+    },
+    [setActualModelFilters, setVerifiedFilterStatusDebounced],
+  );
+
   const checked = actualModelFilters.onlyShowVerifiedModels;
   return (
-    <Switch
-      label={
-        <Text
-          align="end"
-          weight="bold"
-          lh="1rem"
-          px=".75rem"
-        >{t`Only show verified models`}</Text>
-      }
-      role="switch"
-      checked={checked}
-      aria-checked={checked}
-      onChange={e => {
-        handleModelFilterChange("onlyShowVerifiedModels", e.target.checked);
-      }}
-      size="sm"
-      labelPosition="left"
-      styles={{
-        root: {
-          marginInlineStart: "auto",
-          display: "flex",
-          alignItems: "center",
-        },
-        body: {
-          alignItems: "center",
-          // Align with tab labels:
-          position: "relative",
-          top: "-.5px",
-        },
-        labelWrapper: { justifyContent: "center", padding: 0 },
-        track: { marginTop: "-1.5px" },
-      }}
-    />
+    <Popover position="bottom-end">
+      <Popover.Target>
+        <Button p="sm" variant="subtle" color="text-dark">
+          <Icon name="filter" />
+        </Button>
+      </Popover.Target>
+      <Popover.Dropdown p="lg">
+        <Switch
+          label={
+            <Text
+              align="end"
+              weight="bold"
+              lh="1rem"
+              px=".75rem"
+            >{t`Only show verified models`}</Text>
+          }
+          role="switch"
+          checked={checked}
+          aria-checked={checked}
+          onChange={e => {
+            handleModelFilterChange("onlyShowVerifiedModels", e.target.checked);
+          }}
+          size="sm"
+          labelPosition="left"
+          styles={{
+            root: {
+              marginInlineStart: "auto",
+              display: "flex",
+              alignItems: "center",
+            },
+            body: {
+              alignItems: "center",
+              // Align with tab labels:
+              position: "relative",
+              top: "-.5px",
+            },
+            labelWrapper: { justifyContent: "center", padding: 0 },
+            track: { marginTop: "-1.5px" },
+          }}
+        />
+      </Popover.Dropdown>
+    </Popover>
   );
 };

--- a/enterprise/frontend/src/metabase-enterprise/content_verification/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/content_verification/index.ts
@@ -7,6 +7,7 @@ import {
   availableModelFilters,
   sortCollectionsByVerification,
   sortModelsByVerification,
+  useModelFilterSettings,
 } from "./utils";
 
 if (hasPremiumFeature("content_verification")) {
@@ -16,5 +17,6 @@ if (hasPremiumFeature("content_verification")) {
     availableModelFilters,
     sortModelsByVerification,
     sortCollectionsByVerification,
+    useModelFilterSettings,
   });
 }

--- a/enterprise/frontend/src/metabase-enterprise/content_verification/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/content_verification/utils.ts
@@ -1,4 +1,10 @@
-import type { AvailableModelFilters } from "metabase/browse/utils";
+import { useMemo } from "react";
+
+import type {
+  ActualModelFilters,
+  AvailableModelFilters,
+} from "metabase/browse/utils";
+import { useUserSetting } from "metabase/common/hooks";
 import type { CollectionEssentials, SearchResult } from "metabase-types/api";
 
 export const sortCollectionsByVerification = (
@@ -33,4 +39,17 @@ export const availableModelFilters: AvailableModelFilters = {
     predicate: model => model.moderated_status === "verified",
     activeByDefault: true,
   },
+};
+
+export const useModelFilterSettings = (): ActualModelFilters => {
+  const [initialVerifiedFilterStatus, __] = useUserSetting(
+    "browse-filter-only-verified-models",
+    { shouldRefresh: false },
+  );
+  return useMemo(
+    () => ({
+      onlyShowVerifiedModels: initialVerifiedFilterStatus ?? false,
+    }),
+    [initialVerifiedFilterStatus],
+  );
 };

--- a/frontend/src/metabase/browse/components/BrowseModels.tsx
+++ b/frontend/src/metabase/browse/components/BrowseModels.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -31,49 +31,18 @@ import { ModelGrid } from "./BrowseModels.styled";
 import { ModelExplanationBanner } from "./ModelExplanationBanner";
 import { ModelGroup } from "./ModelGroup";
 
-const { availableModelFilters } = PLUGIN_CONTENT_VERIFICATION;
+const { availableModelFilters, useModelFilterSettings } =
+  PLUGIN_CONTENT_VERIFICATION;
 
 export const BrowseModels = () => {
-  const getInitialModelFilters = useCallback(() => {
-    return _.reduce(
-      availableModelFilters,
-      (acc, filter, filterName) => {
-        const storedFilterStatus = localStorage.getItem(
-          `browseFilters.${filterName}`,
-        );
-        const shouldFilterBeActive =
-          storedFilterStatus === null
-            ? filter.activeByDefault
-            : storedFilterStatus === "on";
-        return {
-          ...acc,
-          [filterName]: shouldFilterBeActive,
-        };
-      },
-      {},
-    );
-  }, []);
+  const initialModelFilters = useModelFilterSettings();
 
   const [actualModelFilters, setActualModelFilters] =
-    useState<ActualModelFilters>({});
+    useState<ActualModelFilters>(initialModelFilters);
 
   useEffect(() => {
-    const initialModelFilters = getInitialModelFilters();
     setActualModelFilters(initialModelFilters);
-  }, [getInitialModelFilters, setActualModelFilters]);
-
-  const handleModelFilterChange = useCallback(
-    (modelFilterName: string, active: boolean) => {
-      localStorage.setItem(
-        `browseFilters.${modelFilterName}`,
-        active ? "on" : "off",
-      );
-      setActualModelFilters((prev: ActualModelFilters) => {
-        return { ...prev, [modelFilterName]: active };
-      });
-    },
-    [setActualModelFilters],
-  );
+  }, [initialModelFilters, setActualModelFilters]);
 
   return (
     <BrowseContainer>
@@ -88,7 +57,7 @@ export const BrowseModels = () => {
             </Title>
             <PLUGIN_CONTENT_VERIFICATION.ModelFilterControls
               actualModelFilters={actualModelFilters}
-              handleModelFilterChange={handleModelFilterChange}
+              setActualModelFilters={setActualModelFilters}
             />
           </Flex>
         </BrowseSection>

--- a/frontend/src/metabase/browse/components/CollectionBreadcrumbsWithTooltip.styled.tsx
+++ b/frontend/src/metabase/browse/components/CollectionBreadcrumbsWithTooltip.styled.tsx
@@ -1,0 +1,56 @@
+import styled from "@emotion/styled";
+import type { AnchorHTMLAttributes } from "react";
+
+import { ResponsiveChild } from "metabase/components/ResponsiveContainer/ResponsiveContainer";
+import { color } from "metabase/lib/colors";
+import type { AnchorProps } from "metabase/ui";
+import { Anchor } from "metabase/ui";
+
+import type { RefProp } from "./types";
+
+export const Breadcrumb = styled(Anchor)<
+  AnchorProps &
+    AnchorHTMLAttributes<HTMLAnchorElement> &
+    RefProp<HTMLAnchorElement>
+>`
+  color: ${color("text-dark")};
+  line-height: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding-top: 1px;
+  padding-bottom: 1px;
+  :hover {
+    color: ${color("brand")};
+    text-decoration: none;
+  }
+`;
+
+export const CollectionBreadcrumbsWrapper = styled(ResponsiveChild)`
+  line-height: 1;
+  ${props => {
+    const breakpoint = "10rem";
+    return `
+    .initial-ellipsis {
+      display: none;
+    }
+    @container ${props.containerName} (width < ${breakpoint}) {
+      .ellipsis-and-separator {
+        display: none;
+      }
+      .initial-ellipsis {
+        display: inline;
+      }
+      .for-index-0:not(.sole-breadcrumb) {
+        display: none;
+      }
+      .breadcrumb {
+        max-width: calc(95cqw - 3rem) ! important;
+      }
+      .sole-breadcrumb {
+        max-width: calc(95cqw - 1rem) ! important;
+      }
+    }
+    `;
+  }}
+`;

--- a/frontend/src/metabase/browse/components/CollectionBreadcrumbsWithTooltip.tsx
+++ b/frontend/src/metabase/browse/components/CollectionBreadcrumbsWithTooltip.tsx
@@ -41,7 +41,9 @@ export const CollectionBreadcrumbsWithTooltip = ({
     : collections;
   const justOneShown = shownCollections.length === 1;
 
-  const { areAnyTruncated, ref } = useAreAnyTruncated<HTMLAnchorElement>();
+  const { areAnyTruncated, ref } = useAreAnyTruncated<HTMLAnchorElement>({
+    tolerance: 1,
+  });
 
   const initialEllipsisRef = useRef<HTMLDivElement | null>(null);
   const [

--- a/frontend/src/metabase/browse/components/CollectionBreadcrumbsWithTooltip.tsx
+++ b/frontend/src/metabase/browse/components/CollectionBreadcrumbsWithTooltip.tsx
@@ -21,7 +21,7 @@ import type { RefProp } from "./types";
 import { getBreadcrumbMaxWidths } from "./utils";
 
 const separatorCharacter = c(
-  "Character that separates the names of collections in a path, as in 'Europe / Belgium / Antwerp' or 'Products / Prototypes / Alice's Prototypes'",
+  "Character that separates the names of collections in a path, as in Europe / Belgium / Antwerp",
 ).t`/`;
 
 export const CollectionBreadcrumbsWithTooltip = ({

--- a/frontend/src/metabase/browse/components/CollectionBreadcrumbsWithTooltip.tsx
+++ b/frontend/src/metabase/browse/components/CollectionBreadcrumbsWithTooltip.tsx
@@ -1,0 +1,152 @@
+import classNames from "classnames";
+import type { FC } from "react";
+import { forwardRef, useLayoutEffect, useRef, useState } from "react";
+import { c } from "ttag";
+
+import { ResponsiveContainer } from "metabase/components/ResponsiveContainer/ResponsiveContainer";
+import { useAreAnyTruncated } from "metabase/hooks/use-is-truncated";
+import resizeObserver from "metabase/lib/resize-observer";
+import * as Urls from "metabase/lib/urls";
+import type { FlexProps } from "metabase/ui";
+import { FixedSizeIcon, Flex, Group, Text, Tooltip } from "metabase/ui";
+import type { Collection } from "metabase-types/api";
+
+import { getCollectionName } from "../utils";
+
+import {
+  Breadcrumb,
+  CollectionBreadcrumbsWrapper,
+} from "./CollectionBreadcrumbsWithTooltip.styled";
+import type { RefProp } from "./types";
+import { getBreadcrumbMaxWidths } from "./utils";
+
+const separatorCharacter = c(
+  "Character that separates the names of collections in a path, as in 'Europe / Belgium / Antwerp' or 'Products / Prototypes / Alice's Prototypes'",
+).t`/`;
+
+export const CollectionBreadcrumbsWithTooltip = ({
+  collection,
+  containerName,
+}: {
+  collection: Collection;
+  containerName: string;
+}) => {
+  const collections = (collection.effective_ancestors || []).concat(collection);
+  const pathString = collections
+    .map(coll => getCollectionName(coll))
+    .join(` ${separatorCharacter} `);
+  const ellipsifyPath = collections.length > 2;
+  const shownCollections = ellipsifyPath
+    ? [collections[0], collections[collections.length - 1]]
+    : collections;
+  const justOneShown = shownCollections.length === 1;
+
+  const { areAnyTruncated, ref } = useAreAnyTruncated<HTMLAnchorElement>();
+
+  const initialEllipsisRef = useRef<HTMLDivElement | null>(null);
+  const [
+    isFirstCollectionDisplayedAsEllipsis,
+    setIsFirstCollectionDisplayedAsEllipsis,
+  ] = useState(false);
+
+  useLayoutEffect(() => {
+    const initialEllipsis = initialEllipsisRef.current;
+    if (!initialEllipsis) {
+      return;
+    }
+    const handleResize = () => {
+      // The initial ellipsis might be hidden via CSS,
+      // so we need to check whether it is displayed via getComputedStyle
+      const style = window.getComputedStyle(initialEllipsis);
+      setIsFirstCollectionDisplayedAsEllipsis(style.display !== "none");
+    };
+    resizeObserver.subscribe(initialEllipsis, handleResize);
+    return () => {
+      resizeObserver.unsubscribe(initialEllipsis, handleResize);
+    };
+  }, [initialEllipsisRef]);
+
+  const isTooltipEnabled =
+    areAnyTruncated || ellipsifyPath || isFirstCollectionDisplayedAsEllipsis;
+
+  const maxWidths = getBreadcrumbMaxWidths(shownCollections, 96, ellipsifyPath);
+
+  return (
+    <Tooltip
+      disabled={!isTooltipEnabled}
+      variant="multiline"
+      label={pathString}
+    >
+      <ResponsiveContainer
+        aria-label={pathString}
+        data-testid={`breadcrumbs-for-collection: ${collection.name}`}
+        name={containerName}
+        w="auto"
+      >
+        <Flex align="center" w="100%" lh="1" style={{ flexFlow: "row nowrap" }}>
+          <FixedSizeIcon name="folder" style={{ marginInlineEnd: ".5rem" }} />
+          {shownCollections.map((collection, index) => {
+            const key = `collection${collection.id}`;
+            return (
+              <Group spacing={0} style={{ flexFlow: "row nowrap" }} key={key}>
+                {index > 0 && <PathSeparator />}
+                <CollectionBreadcrumbsWrapper
+                  containerName={containerName}
+                  style={{ alignItems: "center" }}
+                  w="auto"
+                  display="flex"
+                >
+                  {index === 0 && !justOneShown && (
+                    <Ellipsis
+                      ref={initialEllipsisRef}
+                      includeSep={false}
+                      className="initial-ellipsis"
+                    />
+                  )}
+                  {index > 0 && ellipsifyPath && <Ellipsis />}
+                  <Breadcrumb
+                    href={Urls.collection(collection)}
+                    className={classNames("breadcrumb", `for-index-${index}`, {
+                      "sole-breadcrumb": collections.length === 1,
+                    })}
+                    ref={(el: HTMLAnchorElement) => ref.current.set(key, el)}
+                    maw={maxWidths[index]}
+                    key={collection.id}
+                  >
+                    {getCollectionName(collection)}
+                  </Breadcrumb>
+                </CollectionBreadcrumbsWrapper>
+              </Group>
+            );
+          })}
+        </Flex>
+      </ResponsiveContainer>
+    </Tooltip>
+  );
+};
+
+type EllipsisProps = {
+  includeSep?: boolean;
+} & FlexProps;
+
+const Ellipsis: FC<EllipsisProps & Partial<RefProp<HTMLDivElement | null>>> =
+  forwardRef<HTMLDivElement, EllipsisProps>(
+    ({ includeSep = true, ...flexProps }, ref) => (
+      <Flex
+        ref={ref}
+        align="center"
+        className="ellipsis-and-separator"
+        {...flexProps}
+      >
+        <Text lh={1}>…</Text>
+        {includeSep && <PathSeparator />}
+      </Flex>
+    ),
+  );
+Ellipsis.displayName = "Ellipsis";
+
+const PathSeparator = () => (
+  <Text color="text-light" mx="xs" py={1}>
+    {separatorCharacter}
+  </Text>
+);

--- a/frontend/src/metabase/browse/components/ModelsTable.tsx
+++ b/frontend/src/metabase/browse/components/ModelsTable.tsx
@@ -1,0 +1,114 @@
+import { t } from "ttag";
+
+import {
+  ColumnHeader,
+  ItemCell,
+  Table,
+  TableColumn,
+  TBody,
+} from "metabase/components/ItemsTable/BaseItemsTable.styled";
+import { Columns } from "metabase/components/ItemsTable/Columns";
+import type { ResponsiveProps } from "metabase/components/ItemsTable/utils";
+import { color } from "metabase/lib/colors";
+import type { CollectionItem } from "metabase-types/api";
+
+import { getCollectionName } from "../utils";
+
+import { CollectionBreadcrumbsWithTooltip } from "./CollectionBreadcrumbsWithTooltip";
+import { EllipsifiedWithMarkdown } from "./EllipsifiedWithMarkdown";
+import { getModelDescription } from "./utils";
+
+export interface ModelsTableProps {
+  items: CollectionItem[];
+}
+
+const descriptionProps: ResponsiveProps = {
+  hideAtContainerBreakpoint: "sm",
+  containerName: "ItemsTableContainer",
+};
+
+const collectionProps: ResponsiveProps = {
+  hideAtContainerBreakpoint: "xs",
+  containerName: "ItemsTableContainer",
+};
+
+export const ModelsTable = ({ items }: ModelsTableProps) => {
+  return (
+    <Table>
+      <colgroup>
+        <Columns.Type.Col />
+
+        {/* <col> for Name column */}
+        <TableColumn style={{ width: "10rem" }} />
+
+        {/* <col> for Description column */}
+        <TableColumn {...descriptionProps} />
+
+        {/* <col> for Collection column */}
+        <TableColumn {...collectionProps} />
+
+        <Columns.RightEdge.Col />
+      </colgroup>
+      <thead>
+        <tr>
+          <Columns.Type.Header title="" />
+          <Columns.Name.Header />
+          <ColumnHeader {...descriptionProps}>{t`Description`}</ColumnHeader>
+          <ColumnHeader {...collectionProps}>{t`Collection`}</ColumnHeader>
+          <Columns.RightEdge.Header />
+        </tr>
+      </thead>
+      <TBody>
+        {items.map((item: CollectionItem) => (
+          <TBodyRow item={item} key={`${item.model}-${item.id}`} />
+        ))}
+      </TBody>
+    </Table>
+  );
+};
+
+const TBodyRow = ({ item }: { item: CollectionItem }) => {
+  const icon = item.getIcon();
+  if (item.model === "card") {
+    icon.color = color("text-light");
+  }
+
+  const containerName = `collections-path-for-${item.id}`;
+
+  return (
+    <tr>
+      {/* Type */}
+      <Columns.Type.Cell icon={icon} />
+
+      {/* Name */}
+      <Columns.Name.Cell item={item} includeDescription={false} />
+
+      {/* Description */}
+      <ItemCell {...descriptionProps}>
+        <EllipsifiedWithMarkdown>
+          {getModelDescription(item) || ""}
+        </EllipsifiedWithMarkdown>
+      </ItemCell>
+
+      {/* Collection */}
+      <ItemCell
+        data-testid={`path-for-collection: ${
+          item.collection
+            ? getCollectionName(item.collection)
+            : t`Untitled collection`
+        }`}
+        {...collectionProps}
+      >
+        {item.collection && (
+          <CollectionBreadcrumbsWithTooltip
+            containerName={containerName}
+            collection={item.collection}
+          />
+        )}
+      </ItemCell>
+
+      {/* Adds a border-radius to the table */}
+      <Columns.RightEdge.Cell />
+    </tr>
+  );
+};

--- a/frontend/src/metabase/browse/components/types.tsx
+++ b/frontend/src/metabase/browse/components/types.tsx
@@ -1,0 +1,4 @@
+import type { MutableRefObject } from "react";
+
+/** @template T: The type of the value the ref will hold */
+export type RefProp<T> = { ref: MutableRefObject<T> | ((el: T) => void) };

--- a/frontend/src/metabase/browse/components/utils.tsx
+++ b/frontend/src/metabase/browse/components/utils.tsx
@@ -1,0 +1,45 @@
+import { t } from "ttag";
+
+import { isRootCollection } from "metabase/collections/utils";
+import type { CollectionItem, Collection } from "metabase-types/api";
+
+import { getCollectionName } from "../utils";
+
+export const getBreadcrumbMaxWidths = (
+  collections: Collection["effective_ancestors"],
+  totalUnitsOfWidthAvailable: number,
+  isPathEllipsified: boolean,
+) => {
+  if (!collections || collections.length < 2) {
+    return [];
+  }
+  const lengths = collections.map(
+    collection => getCollectionName(collection).length,
+  );
+  const ratio = lengths[0] / (lengths[0] + lengths[1]);
+  const firstWidth = Math.max(
+    Math.round(ratio * totalUnitsOfWidthAvailable),
+    25,
+  );
+  const secondWidth = totalUnitsOfWidthAvailable - firstWidth;
+  const padding = isPathEllipsified ? "2rem" : "1rem";
+  return [
+    `calc(${firstWidth}cqw - ${padding})`,
+    `calc(${secondWidth}cqw - ${padding})`,
+  ];
+};
+
+export const isModel = (item: CollectionItem) => item.model === "dataset";
+
+export const getModelDescription = (item: CollectionItem) => {
+  if (
+    item.collection &&
+    isRootCollection(item.collection) &&
+    isModel(item) &&
+    !item.description?.trim()
+  ) {
+    return t`A model`;
+  } else {
+    return item.description;
+  }
+};

--- a/frontend/src/metabase/browse/utils.ts
+++ b/frontend/src/metabase/browse/utils.ts
@@ -1,3 +1,4 @@
+import type { Dispatch, SetStateAction } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -95,7 +96,7 @@ export type AvailableModelFilters = Record<
 
 export type ModelFilterControlsProps = {
   actualModelFilters: ActualModelFilters;
-  handleModelFilterChange: (filterName: string, active: boolean) => void;
+  setActualModelFilters: Dispatch<SetStateAction<ActualModelFilters>>;
 };
 
 export const sortModels = (

--- a/frontend/src/metabase/common/hooks/entity-framework/use-search-list-query/use-search-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/entity-framework/use-search-list-query/use-search-list-query.unit.spec.tsx
@@ -10,6 +10,7 @@ import {
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import { checkNotNull } from "metabase/lib/types";
 import {
+  createMockCollection,
   createMockCollectionItem,
   createMockSearchResult,
   createMockSearchResults,
@@ -18,10 +19,13 @@ import {
 import { useSearchListQuery } from "./use-search-list-query";
 
 const TEST_ITEM = createMockCollectionItem();
+const TEST_COLLECTION = createMockCollection();
 
 const TEST_TABLE_DB_ID = 1;
 const TEST_SEARCH_RESULTS = createMockSearchResults({
-  items: [createMockSearchResult({ collection: { ...TEST_ITEM, type: null } })],
+  items: [
+    createMockSearchResult({ collection: { ...TEST_COLLECTION, type: null } }),
+  ],
   options: { table_db_id: TEST_TABLE_DB_ID },
 });
 

--- a/frontend/src/metabase/hooks/use-is-truncated.ts
+++ b/frontend/src/metabase/hooks/use-is-truncated.ts
@@ -39,7 +39,6 @@ export const useIsTruncated = <E extends Element>({
 };
 
 const getIsTruncated = (element: Element, tolerance: number): boolean => {
-  tolerance = 0;
   return (
     element.scrollHeight > element.clientHeight + tolerance ||
     element.scrollWidth > element.clientWidth + tolerance
@@ -51,7 +50,7 @@ export const useAreAnyTruncated = <E extends Element>({
   tolerance = 0,
 }: UseIsTruncatedProps = {}) => {
   const ref = useRef(new Map<string, E>());
-  const [truncatedStatuses, setTruncatedStatuses] = useState<
+  const [truncationStatusByKey, setTruncationStatusByKey] = useState<
     Map<string, boolean>
   >(new Map());
 
@@ -66,7 +65,7 @@ export const useAreAnyTruncated = <E extends Element>({
     [...elementsMap.entries()].forEach(([elementKey, element]) => {
       const handleResize = () => {
         const isTruncated = getIsTruncated(element, tolerance);
-        setTruncatedStatuses(statuses => {
+        setTruncationStatusByKey(statuses => {
           const newStatuses = new Map(statuses);
           newStatuses.set(elementKey, isTruncated);
           return newStatuses;
@@ -84,6 +83,6 @@ export const useAreAnyTruncated = <E extends Element>({
     };
   }, [disabled, tolerance]);
 
-  const areAnyTruncated = [...truncatedStatuses.values()].some(Boolean);
+  const areAnyTruncated = [...truncationStatusByKey.values()].some(Boolean);
   return { areAnyTruncated, ref };
 };

--- a/frontend/src/metabase/hooks/use-is-truncated.ts
+++ b/frontend/src/metabase/hooks/use-is-truncated.ts
@@ -1,10 +1,18 @@
 import { useLayoutEffect, useRef, useState } from "react";
+import _ from "underscore";
 
 import resizeObserver from "metabase/lib/resize-observer";
 
+type UseIsTruncatedProps = {
+  disabled?: boolean;
+  /** To avoid rounding errors, we can require that the truncation is at least a certain number of pixels */
+  tolerance?: number;
+};
+
 export const useIsTruncated = <E extends Element>({
   disabled = false,
-}: { disabled?: boolean } = {}) => {
+  tolerance = 0,
+}: UseIsTruncatedProps = {}) => {
   const ref = useRef<E | null>(null);
   const [isTruncated, setIsTruncated] = useState(false);
 
@@ -16,7 +24,7 @@ export const useIsTruncated = <E extends Element>({
     }
 
     const handleResize = () => {
-      setIsTruncated(getIsTruncated(element));
+      setIsTruncated(getIsTruncated(element, tolerance));
     };
 
     handleResize();
@@ -25,14 +33,57 @@ export const useIsTruncated = <E extends Element>({
     return () => {
       resizeObserver.unsubscribe(element, handleResize);
     };
-  }, [disabled]);
+  }, [disabled, tolerance]);
 
   return { isTruncated, ref };
 };
 
-const getIsTruncated = (element: Element): boolean => {
+const getIsTruncated = (element: Element, tolerance: number): boolean => {
+  tolerance = 0;
   return (
-    element.scrollHeight > element.clientHeight ||
-    element.scrollWidth > element.clientWidth
+    element.scrollHeight > element.clientHeight + tolerance ||
+    element.scrollWidth > element.clientWidth + tolerance
   );
+};
+
+export const useAreAnyTruncated = <E extends Element>({
+  disabled = false,
+  tolerance = 0,
+}: UseIsTruncatedProps = {}) => {
+  const ref = useRef(new Map<string, E>());
+  const [truncatedStatuses, setTruncatedStatuses] = useState<
+    Map<string, boolean>
+  >(new Map());
+
+  useLayoutEffect(() => {
+    const elementsMap = ref.current;
+
+    if (!elementsMap.size || disabled) {
+      return;
+    }
+    const unsubscribeFns: (() => void)[] = [];
+
+    [...elementsMap.entries()].forEach(([elementKey, element]) => {
+      const handleResize = () => {
+        const isTruncated = getIsTruncated(element, tolerance);
+        setTruncatedStatuses(statuses => {
+          const newStatuses = new Map(statuses);
+          newStatuses.set(elementKey, isTruncated);
+          return newStatuses;
+        });
+      };
+      const handleResizeDebounced = _.debounce(handleResize, 200);
+      resizeObserver.subscribe(element, handleResizeDebounced);
+      unsubscribeFns.push(() =>
+        resizeObserver.unsubscribe(element, handleResizeDebounced),
+      );
+    });
+
+    return () => {
+      unsubscribeFns.forEach(fn => fn());
+    };
+  }, [disabled, tolerance]);
+
+  const areAnyTruncated = [...truncatedStatuses.values()].some(Boolean);
+  return { areAnyTruncated, ref };
 };

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -13,6 +13,7 @@ import {
 } from "metabase/admin/permissions/types";
 import type { ADMIN_SETTINGS_SECTIONS } from "metabase/admin/settings/selectors";
 import type {
+  ActualModelFilters,
   AvailableModelFilters,
   ModelFilterControlsProps,
 } from "metabase/browse/utils";
@@ -426,6 +427,7 @@ export const PLUGIN_CONTENT_VERIFICATION = {
     _a: CollectionEssentials,
     _b: CollectionEssentials,
   ) => 0,
+  useModelFilterSettings: () => ({} as ActualModelFilters),
 };
 
 export const PLUGIN_DASHBOARD_HEADER = {

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -510,6 +510,14 @@
   :type       :boolean
   :default    true)
 
+(defsetting browse-filter-only-verified-models
+  (deferred-tru "User preference for whether the 'Browse models' page should be filtered to show only verified models.")
+  :user-local :only
+  :export?    false
+  :visibility :authenticated
+  :type       :boolean
+  :default    true)
+
 ;;; ## ------------------------------------------ AUDIT LOG ------------------------------------------
 
 (defmethod audit-log/model-details :model/User


### PR DESCRIPTION
Before:

![image](https://github.com/metabase/metabase/assets/130925/3043ed98-5afa-409c-9e1f-fd90d7dcd489)

After:

![image](https://github.com/metabase/metabase/assets/130925/2fd09448-7697-44bd-840c-fd174cb99c3e)

When there is less space available, the first container becomes "...":

![image](https://github.com/metabase/metabase/assets/130925/80cf2184-af7e-409e-8884-8567e3d4ff93)
