### PR TITLE
Avoid scroll jump

### DIFF
--- a/frontend/src/metabase/browse/components/BrowseModels.tsx
+++ b/frontend/src/metabase/browse/components/BrowseModels.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useMemo, useState } from "react";
+import { useContext, useEffect, useMemo, useRef, useState } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
 import NoResults from "assets/img/no_results.svg";
 import { useSearchQuery } from "metabase/api";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
+import { ContentViewportContext } from "metabase/core/context/ContentViewportContext";
 import Search from "metabase/entities/search";
 import { color } from "metabase/lib/colors";
 import { useDispatch } from "metabase/lib/redux";
@@ -35,6 +36,29 @@ export const BrowseModels = () => {
   useEffect(() => {
     setActualModelFilters(initialModelFilters);
   }, [initialModelFilters, setActualModelFilters]);
+
+  const contentViewportElement = useContext(ContentViewportContext);
+  const cachedViewportOverflowYRef = useRef<string>();
+
+  // Set the content viewport to scroll to prevent the page from jumping a little when filters are toggled
+  useEffect(() => {
+    if (!contentViewportElement) {
+      return;
+    }
+    cachedViewportOverflowYRef.current = getComputedStyle(
+      contentViewportElement,
+    ).overflowY;
+    contentViewportElement.style.overflowY = "scroll";
+    return () => {
+      if (!contentViewportElement) {
+        return;
+      }
+      const cachedViewportOverflowY = cachedViewportOverflowYRef.current;
+      if (cachedViewportOverflowY) {
+        contentViewportElement.style.overflowY = cachedViewportOverflowY;
+      }
+    };
+  }, [contentViewportElement]);
 
   return (
     <BrowseContainer>


### PR DESCRIPTION
### TL;DR

This pull request addresses a visual issue related to toggling filters by adding a scrolling behavior to the 'BrowseModels' component.

### What changed?

Additional Hooks and Context were introduced to manage the scrollable state of the viewport. The overflowY style attribute of the viewport is saved when the component is rendered and then set to 'scroll'. This style setting is then restored to its original value when the component is unmounted. This stops the page from 'jumping' when filters are toggled.

### How to test?

Navigate to the component and toggle the filters to observe the updated behavior. The page should no longer 'jump' when filters are toggled.

### Why make this change?

The change improves the user experience by reducing visual disruptions that may disorient users while interacting with the component.