### PR TITLE
Load card metadata recursively 

### DIFF
--- a/frontend/src/metabase/questions/actions.ts
+++ b/frontend/src/metabase/questions/actions.ts
@@ -11,22 +11,55 @@ export interface LoadMetadataOptions {
 }
 
 export const loadMetadataForCard =
-  (card: Card, options?: LoadMetadataOptions) =>
-  async (dispatch: Dispatch, getState: GetState) => {
-    const question = new Question(card, getMetadata(getState()));
-    const loadAdhocMetadata =
-      question.isSaved() && question.type() !== "question";
-    const dependencies = [...Lib.dependentMetadata(question.query())];
-    if (loadAdhocMetadata) {
-      const tableId = getQuestionVirtualTableId(question.id());
-      dependencies.push({ id: tableId, type: "table" });
-    }
-    await dispatch(loadMetadataForDependentItems(dependencies, options));
-
-    if (loadAdhocMetadata) {
-      const questionWithMetadata = new Question(card, getMetadata(getState()));
-      const adhocQuestion = questionWithMetadata.composeQuestionAdhoc();
-      const adhocDependencies = Lib.dependentMetadata(adhocQuestion.query());
-      await dispatch(loadMetadataForDependentItems(adhocDependencies, options));
+  (card: Card, options?: LoadMetadataOptions) => async (dispatch: Dispatch) => {
+    await dispatch(loadDependentMetadata(card, [], options));
+    if (shouldLoadAdhocMetadata(card)) {
+      await dispatch(loadDependentMetadata(card, [], options));
     }
   };
+
+const loadDependentMetadata =
+  (
+    card: Card,
+    prevDependencies: Lib.DependentItem[],
+    options?: LoadMetadataOptions,
+  ) =>
+  async (dispatch: Dispatch, getState: GetState) => {
+    const nextDependencies = getDependencies(card, getState);
+    const dependenciesDiff = getDependenciesDiff(
+      prevDependencies,
+      nextDependencies,
+    );
+    if (dependenciesDiff.length > 0) {
+      await dispatch(loadMetadataForDependentItems(dependenciesDiff, options));
+      const mergedDependencies = [...prevDependencies, ...dependenciesDiff];
+      await dispatch(loadDependentMetadata(card, mergedDependencies, options));
+    }
+  };
+
+function shouldLoadAdhocMetadata(card: Card) {
+  return card.id != null && card.type !== "question";
+}
+
+function getDependencies(card: Card, getState: GetState) {
+  const question = new Question(card, getMetadata(getState()));
+  const dependencies = [...Lib.dependentMetadata(question.query())];
+  if (shouldLoadAdhocMetadata(card)) {
+    const tableId = getQuestionVirtualTableId(question.id());
+    dependencies.push({ id: tableId, type: "table" });
+  }
+
+  return dependencies;
+}
+
+function getDependencyKey(dependency: Lib.DependentItem) {
+  return `${dependency.type}/${dependency.id}`;
+}
+
+function getDependenciesDiff(
+  prevDependencies: Lib.DependentItem[],
+  nextDependencies: Lib.DependentItem[],
+) {
+  const prevKeys = new Set(prevDependencies.map(getDependencyKey));
+  return nextDependencies.filter(dep => !prevKeys.has(getDependencyKey(dep)));
+}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/41520

This should be a no-op change for questions and models, but for metrics it would allow extra items to be loaded.

How to verify:
- CI is green