### PR TITLE
Revert "Fix default font in mantine (#41858)"

### DIFF
--- a/frontend/src/metabase/ui/theme.ts
+++ b/frontend/src/metabase/ui/theme.ts
@@ -95,7 +95,7 @@ export const getThemeOverrides = (): MantineThemeOverride => ({
       },
     },
   },
-  fontFamily: "var(--mb-default-font-family)",
+  fontFamily: "var(--mb-default-font-family), Lato, sans-serif",
   fontFamilyMonospace: "Monaco, monospace",
   focusRingStyles: {
     styles: theme => ({

--- a/frontend/src/metabase/ui/theme.ts
+++ b/frontend/src/metabase/ui/theme.ts
@@ -95,6 +95,7 @@ export const getThemeOverrides = (): MantineThemeOverride => ({
       },
     },
   },
+  fontFamily: "var(--mb-default-font-family)",
   fontFamilyMonospace: "Monaco, monospace",
   focusRingStyles: {
     styles: theme => ({

--- a/frontend/src/metabase/ui/theme.ts
+++ b/frontend/src/metabase/ui/theme.ts
@@ -95,7 +95,7 @@ export const getThemeOverrides = (): MantineThemeOverride => ({
       },
     },
   },
-  fontFamily: "var(--mb-default-font-family), Lato, sans-serif",
+  fontFamily: "var(--mb-default-font-family), sans-serif",
   fontFamilyMonospace: "Monaco, monospace",
   focusRingStyles: {
     styles: theme => ({


### PR DESCRIPTION
https://metaboat.slack.com/archives/C06REDHM6BV/p1714407227918779?thread_ts=1714407019.313029&cid=C06REDHM6BV

This seems to have broken some fonts in master 😢   We still need to figure out how to make fonts not break with an incorrect site url
