### PR TITLE
Add tag type mapping for the `pulse`

### DIFF
--- a/frontend/src/metabase/api/tags/constants.ts
+++ b/frontend/src/metabase/api/tags/constants.ts
@@ -40,4 +40,5 @@ export const TAG_TYPE_MAPPING = {
   segment: "segment",
   metric: "metric",
   snippet: "snippet",
+  pulse: "subscription",
 } as const;


### PR DESCRIPTION
Resolves #41467

### Description
We previously didn't have the tag type mapping for the `pulse`, which resulted in the type error.

From the debugger
<img width="767" alt="image" src="https://github.com/metabase/metabase/assets/31325167/cfd62556-d3ab-4695-b457-2adeba8d769f">

@ranquild Should I add the `pulse` to the `COLLECTION_ITEM_MODELS` as well?


### Before
```
Tag type 'undefined' was used, but not specified in `tagTypes`!
```

### Now
This error should not exist in the console.
