### PR TITLE
Check for canRun before showing the run button

### DIFF
--- a/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import cx from "classnames";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useTimeout } from "react-use";
 import { t } from "ttag";
 
@@ -9,6 +9,7 @@ import CS from "metabase/css/core/index.css";
 import QueryBuilderS from "metabase/css/query_builder.module.css";
 import { useSelector } from "metabase/lib/redux";
 import { getWhiteLabeledLoadingMessageFactory } from "metabase/selectors/whitelabel";
+import * as Lib from "metabase-lib";
 import { HARD_ROW_LIMIT } from "metabase-lib/v1/queries/utils";
 
 import RunButtonWithTooltip from "./RunButtonWithTooltip";
@@ -30,6 +31,7 @@ export default function QueryVisualization(props) {
     maxTableRows = HARD_ROW_LIMIT,
   } = props;
 
+  const canRun = useMemo(() => Lib.canRun(question.query()), [question]);
   const [warnings, setWarnings] = useState([]);
 
   return (
@@ -41,7 +43,7 @@ export default function QueryVisualization(props) {
       ) : null}
       <VisualizationDirtyState
         {...props}
-        hidden={!isResultDirty || isRunning || isNativeEditorOpen}
+        hidden={!canRun || !isResultDirty || isRunning || isNativeEditorOpen}
         className={cx(CS.spread, CS.z2)}
       />
       {!isObjectDetail && (

--- a/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import cx from "classnames";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { useTimeout } from "react-use";
 import { t } from "ttag";
 
@@ -31,7 +31,7 @@ export default function QueryVisualization(props) {
     maxTableRows = HARD_ROW_LIMIT,
   } = props;
 
-  const canRun = useMemo(() => Lib.canRun(question.query()), [question]);
+  const canRun = Lib.canRun(question.query());
   const [warnings, setWarnings] = useState([]);
 
   return (


### PR DESCRIPTION
FE part of https://github.com/metabase/metabase/issues/41928

Makes sure we call `canRun` before showing the run button in query results. `canRun` method needs to be updated to check for metrics.