### PR TITLE
Revert "Store fields used in MBQL cards in QueryField (#41821)"

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -6543,6 +6543,14 @@ databaseChangeLog:
             class: "metabase.db.custom_migrations.CreateSampleContent"
 
   - changeSet:
+      id: v50.2024-04-09T15:55:23
+      author: piranha
+      comment: Backfill query_field for native queries
+      changes:
+        - customChange:
+            class: "metabase.db.custom_migrations.BackfillQueryField"
+
+  - changeSet:
       id: v50.2024-04-12T12:33:09
       author: piranha
       comment: 'Copy old cache configurations to cache_config table'
@@ -6560,14 +6568,6 @@ databaseChangeLog:
             path: custom_sql/fill_cache_config.h2.sql
             relativeToChangelogFile: true
       rollback: # no rollback necessary, we're not removing the columns yet
-
-  - changeSet:
-      id: v50.2024-04-18T14:33:19
-      author: piranha
-      comment: Backfill query_field
-      changes:
-        - customChange:
-            class: "metabase.db.custom_migrations.BackfillQueryField"
 
   - changeSet:
       id: v50.2024-04-19T17:04:04

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -541,7 +541,7 @@
 
 (defn- do-update-dashcards!
   [dashboard current-cards new-cards]
-  (let [{:keys [to-create to-update to-delete]} (u/row-diff current-cards new-cards)]
+  (let [{:keys [to-create to-update to-delete]} (u/classify-changes current-cards new-cards)]
     (when (seq to-update)
       (update-dashcards! dashboard to-update))
     {:deleted-dashcards (when (seq to-delete)

--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -584,10 +584,7 @@
       (when (#{:mbql/query :query :native :internal} query-type)
         query-type))))
 
-(mu/defn referenced-field-ids :- [:maybe [:set ::lib.schema.id/field]]
-  "Find all the integer field IDs in `coll`, Which can arbitrarily be anything that is part of MLv2 query schema."
+(mu/defn referenced-field-ids :- [:maybe [:sequential ::lib.schema.id/field]]
+  "Find all the integer field IDs in ``, Which can arbitrarily be anything that is part of MLv2 query schema."
   [coll]
-  (not-empty
-   (into #{}
-         (comp cat (filter some?))
-         (lib.util.match/match coll [:field opts (id :guard int?)] [id (:source-field opts)]))))
+  (lib.util.match/match coll [:field _ (id :guard int?)] id))

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -29,10 +29,10 @@
    [metabase.models.permissions :as perms]
    [metabase.models.pulse :as pulse]
    [metabase.models.query :as query]
-   [metabase.models.query-field :as query-field]
    [metabase.models.revision :as revision]
    [metabase.models.serialization :as serdes]
    [metabase.moderation :as moderation]
+   [metabase.native-query-analyzer :as query-analyzer]
    [metabase.public-settings :as public-settings]
    [metabase.public-settings.premium-features
     :as premium-features
@@ -527,7 +527,7 @@
       (log/info "Card references Fields in params:" field-ids)
       (field-values/update-field-values-for-on-demand-dbs! field-ids))
     (parameter-card/upsert-or-delete-from-parameters! "card" (:id card) (:parameters card))
-    (query-field/update-query-fields-for-card! card)))
+    (query-analyzer/update-query-fields-for-card! card)))
 
 (t2/define-before-update :model/Card
   [{:keys [verified-result-metadata?] :as card}]
@@ -555,7 +555,7 @@
   [card]
   (u/prog1 card
     (when (contains? (t2/changes card) :dataset_query)
-      (query-field/update-query-fields-for-card! card))))
+      (query-analyzer/update-query-fields-for-card! card))))
 
 ;; Cards don't normally get deleted (they get archived instead) so this mostly affects tests
 (t2/define-before-delete :model/Card

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -268,7 +268,7 @@
                                            :model/DashboardCard
                                            :dashboard_id dashboard-id)
         id->current-card (zipmap (map :id current-cards) current-cards)
-        {:keys [to-create to-update to-delete]} (u/row-diff current-cards serialized-cards)]
+        {:keys [to-create to-update to-delete]} (u/classify-changes current-cards serialized-cards)]
     (when (seq to-delete)
       (dashboard-card/delete-dashboard-cards! (map :id to-delete)))
     (when (seq to-create)

--- a/src/metabase/models/dashboard_tab.clj
+++ b/src/metabase/models/dashboard_tab.clj
@@ -118,7 +118,7 @@
   [dashboard-id current-tabs new-tabs]
   (let [{:keys [to-create
                 to-update
-                to-delete]} (u/row-diff current-tabs new-tabs)
+                to-delete]} (u/classify-changes current-tabs new-tabs)
         to-delete-ids       (map :id to-delete)
         _                   (when-let [to-delete-ids (seq to-delete-ids)]
                               (delete-tabs! to-delete-ids))

--- a/src/metabase/models/field_usage.clj
+++ b/src/metabase/models/field_usage.clj
@@ -56,8 +56,8 @@
         :breakout_binning_num_bins  (:num-bins binning-option)}))))
 
 (defn- expression->field-usage
-  [expression-clause]
-  (when-let [field-ids (seq (lib.util/referenced-field-ids expression-clause))]
+  [expresison-clause]
+  (when-let [field-ids (seq (lib.util/referenced-field-ids expresison-clause))]
     (for [field-id field-ids]
       {:field_id field-id
        :used_in  :expression})))
@@ -66,7 +66,7 @@
 
 (defn- join->field-usages
   [query join]
-  (let [join-query (fetch-source-query/resolve-source-cards (assoc query :stages (:stages join)))]
+  (let [join-query (fetch-source-query/resolve-source-cards (assoc query :stages (get join :stages)))]
     ;; treat the source query as a :mbql/query
     (pmbql->field-usages join-query)))
 

--- a/src/metabase/models/query_field.clj
+++ b/src/metabase/models/query_field.clj
@@ -1,9 +1,5 @@
 (ns metabase.models.query-field
   (:require
-   [metabase.legacy-mbql.util :as mbql.u]
-   [metabase.native-query-analyzer :as query-analyzer]
-   [metabase.util :as u]
-   [metabase.util.log :as log]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
@@ -11,61 +7,3 @@
 
 (doto :model/QueryField
   (derive :metabase/model))
-
-;;; Updating QueryField from card
-
-(defn- field-ids-for-mbql
-  "Find out ids of all fields used in a query. Conforms to the same protocol as [[query-analyzer/field-ids-for-sql]],
-  so returns `{:direct #{...int ids}}` map.
-
-  Does not track wildcards for queries rendered as tables afterwards."
-  [query]
-  {:direct (mbql.u/referenced-field-ids query)})
-
-(defn update-query-fields-for-card!
-  "Clears QueryFields associated with this card and creates fresh, up-to-date-ones.
-
-  Any card is accepted, but this functionality only works for ones with a native query.
-
-  If you're invoking this from a test, be sure to turn on [[*parse-queries-in-test?*]].
-
-  Returns `nil` (and logs the error) if there was a parse error."
-  [{card-id :id, query :dataset_query}]
-  (when query
-    (try
-      (let [{:keys [direct indirect] :as res} (case (:type query)
-                                                :native (try
-                                                          (query-analyzer/field-ids-for-sql query)
-                                                          (catch Exception e
-                                                            (log/error e "Error parsing SQL" query)))
-                                                :query  (field-ids-for-mbql query)
-                                                nil     nil)
-            id->row                           (fn [direct? field-id]
-                                                {:card_id          card-id
-                                                 :field_id         field-id
-                                                 :direct_reference direct?})
-            query-field-rows                  (concat
-                                               (map (partial id->row true) direct)
-                                               (map (partial id->row false) indirect))]
-        ;; when response is `nil`, it's a disabled parser, not unknown columns
-        (when (some? res)
-          (t2/with-transaction [_conn]
-            (let [existing            (t2/select :model/QueryField :card_id card-id)
-                  {:keys [to-update
-                          to-create
-                          to-delete]} (u/row-diff existing query-field-rows
-                                                  {:id-fn      :field_id
-                                                   :to-compare #(dissoc % :id :card_id :field_id)})]
-              (when (seq to-delete)
-                ;; this delete seems to break transaction (implicit commit or something) on MySQL, and this `diff`
-                ;; algo drops its frequency by a lot - which should help with transactions affecting each other a
-                ;; lot. Parallel tests in `metabase.models.query.permissions-test` were breaking when delete was
-                ;; executed unconditionally on every query change.
-                (t2/delete! :model/QueryField :card_id card-id :field_id [:in (map :field_id to-delete)]))
-              (when (seq to-create)
-                (t2/insert! :model/QueryField to-create))
-              (doseq [item to-update]
-                (t2/update! :model/QueryField {:card_id card-id :field_id (:field_id item)}
-                            (select-keys item [:direct_reference])))))))
-      (catch Exception e
-        (log/error e "Error parsing native query")))))

--- a/src/metabase/native_query_analyzer.clj
+++ b/src/metabase/native_query_analyzer.clj
@@ -18,6 +18,7 @@
    [metabase.native-query-analyzer.parameter-substitution :as nqa.sub]
    [metabase.public-settings :as public-settings]
    [metabase.util :as u]
+   [metabase.util.log :as log]
    [toucan2.core :as t2]))
 
 (def ^:dynamic *parse-queries-in-test?*
@@ -106,25 +107,53 @@
       ;; limit to the named tables
       (seq table-wildcards)            (active-fields-from-tables table-wildcards))))
 
-(defn field-ids-for-sql
+(defn- field-ids-for-card
   "Returns a `{:direct #{...} :indirect #{...}}` map with field IDs that (may) be referenced in the given cards's
   query. Errs on the side of optimism: i.e., it may return fields that are *not* in the query, and is unlikely to fail
   to return fields that are in the query.
 
   Direct references are columns that are named in the query; indirect ones are from wildcards. If a field could be
   both direct and indirect, it will *only* show up in the `:direct` set."
-  [query]
+  [card]
+  (let [query        (:dataset_query card)
+        db-id        (:database query)
+        sql-string   (:query (nqa.sub/replace-tags query))
+        parsed-query (macaw/query->components (macaw/parsed-query sql-string))
+        direct-ids   (direct-field-ids-for-query parsed-query db-id)
+        indirect-ids (set/difference
+                      (indirect-field-ids-for-query parsed-query db-id)
+                      direct-ids)]
+    {:direct   direct-ids
+     :indirect indirect-ids}))
+
+(defn update-query-fields-for-card!
+  "Clears QueryFields associated with this card and creates fresh, up-to-date-ones.
+
+  Any card is accepted, but this functionality only works for ones with a native query.
+
+  If you're invoking this from a test, be sure to turn on [[*parse-queries-in-test?*]].
+
+  Returns `nil` (and logs the error) if there was a parse error."
+  [{card-id :id, query :dataset_query :as card}]
   (when (and (active?)
-             (:native query))
-    (let [db-id        (:database query)
-          sql-string   (:query (nqa.sub/replace-tags query))
-          parsed-query (macaw/query->components (macaw/parsed-query sql-string))
-          direct-ids   (direct-field-ids-for-query parsed-query db-id)
-          indirect-ids (set/difference
-                        (indirect-field-ids-for-query parsed-query db-id)
-                        direct-ids)]
-      {:direct   direct-ids
-       :indirect indirect-ids})))
+             (= :native (:type query)))
+    (try
+      (let [{:keys [direct indirect]} (field-ids-for-card card)
+            id->record                (fn [direct? field-id]
+                                        {:card_id          card-id
+                                         :field_id         field-id
+                                         :direct_reference direct?})
+            query-field-records       (concat
+                                       (map (partial id->record true) direct)
+                                       (map (partial id->record false) indirect))]
+        ;; This feels inefficient at first glance, but the number of records should be quite small and doing some sort
+        ;; of upsert-or-delete would involve comparisons in Clojure-land that are more expensive than just "killing and
+        ;; filling" the records.
+        (t2/with-transaction [_conn]
+          (t2/delete! :model/QueryField :card_id card-id)
+          (t2/insert! :model/QueryField query-field-records)))
+      (catch Exception e
+        (log/error e "Error parsing native query")))))
 
 ;; TODO: does not support template tags
 (defn replace-names

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -841,38 +841,20 @@
                          {:kvs kvs})))
        ret))))
 
-(defn row-diff
+(defn classify-changes
   "Given 2 lists of seq maps of changes, where each map an has an `id` key,
   return a map of 3 keys: `:to-create`, `:to-update`, `:to-delete`.
 
   Where:
-  - `:to-create` is a list of maps that ids in `new-rows`
-  - `:to-delete` is a list of maps that has ids only in `current-rows`
-  - `:to-skip`   is a list of identical maps that has ids in both lists
-  - `:to-update` is a list of different maps that has ids in both lists
-
-  Optional arguments:
-  - `id-fn` - function to get row-matching identifiers
-  - `to-compare` - function to get rows into a comparable state
-  "
-  [current-rows new-rows & {:keys [id-fn to-compare]
-                            :or   {id-fn   :id
-                                   to-compare identity}}]
-  (let [[delete-ids
-         create-ids
-         update-ids]     (diff (set (map id-fn current-rows))
-                               (set (map id-fn new-rows)))
-        known-map        (m/index-by id-fn current-rows)
-        {to-update false
-         to-skip   true} (when (seq update-ids)
-                           (group-by (fn [x]
-                                       (let [y (get known-map (id-fn x))]
-                                         (= (to-compare x) (to-compare y))))
-                                     (filter #(update-ids (id-fn %)) new-rows)))]
-    {:to-create (when (seq create-ids) (filter #(create-ids (id-fn %)) new-rows))
-     :to-delete (when (seq delete-ids) (filter #(delete-ids (id-fn %)) current-rows))
-     :to-update to-update
-     :to-skip   to-skip}))
+  :to-create is a list of maps that ids in `new-items`
+  :to-update is a list of maps that has ids in both `current-items` and `new-items`
+  :to delete is a list of maps that has ids only in `current-items`"
+  [current-items new-items]
+  (let [[delete-ids create-ids update-ids] (diff (set (map :id current-items))
+                                                 (set (map :id new-items)))]
+    {:to-create (when (seq create-ids) (filter #(create-ids (:id %)) new-items))
+     :to-delete (when (seq delete-ids) (filter #(delete-ids (:id %)) current-items))
+     :to-update (when (seq update-ids) (filter #(update-ids (:id %)) new-items))}))
 
 (defn empty-or-distinct?
   "True if collection `xs` is either [[empty?]] or all values are [[distinct?]]."

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -1683,22 +1683,16 @@
               (is (nil? (:cache_field_values_schedule db))))))))))
 
 (deftest backfill-query-field-test
-  (impl/test-migrations "v50.2024-04-18T14:33:19" [migrate!]
+  (impl/test-migrations "v50.2024-04-09T15:55:23" [migrate!]
     (let [user-id     (:id (new-instance-with-default :core_user))
-          c1-id       (:id (new-instance-with-default
-                            :report_card
-                            {:creator_id    user-id
-                             :database_id   (mt/id)
-                             :query_type    "native"
-                             :dataset_query (json/generate-string
-                                             (mt/native-query {:query "SELECT id FROM venues"}))}))
-          c2-id       (:id (new-instance-with-default
-                            :report_card
-                            {:creator_id    user-id
-                             :database_id   (mt/id)
-                             :query_type    "query"
-                             :dataset_query (json/generate-string
-                                             (mt/mbql-query venues {:aggregation [[:distinct $name]]}))}))
+          ;; it is already `false`, but binding it anyway to indicate it's important
+          card-id     (binding [query-analyzer/*parse-queries-in-test?* false]
+                        (:id (new-instance-with-default
+                              :report_card
+                              {:creator_id    user-id
+                               :database_id   (mt/id)
+                               :query_type    "native"
+                               :dataset_query (json/generate-string (mt/native-query {:query "SELECT id FROM venues"}))})))
           archived-id (binding [query-analyzer/*parse-queries-in-test?* false]
                         (:id (new-instance-with-default
                               :report_card
@@ -1706,20 +1700,15 @@
                                :creator_id    user-id
                                :database_id   (mt/id)
                                :query_type    "native"
-                               :dataset_query (json/generate-string
-                                               (mt/native-query {:query "SELECT id FROM venues"}))})))
+                               :dataset_query (json/generate-string (mt/native-query {:query "SELECT id FROM venues"}))})))
           ;; (first (vals %)) are necessary since h2 generates :count(id) as name for column
           get-count   #(t2/select-one-fn (comp first vals) [:model/QueryField [[:count :id]]] :card_id %)]
       (testing "QueryField is empty - queries weren't analyzed"
-        ;; they were not analyzed since `new-instance-with-default` inserts directly into the table, omitting model
-        ;; hooks
-        (is (zero? (get-count c1-id)))
-        (is (zero? (get-count c2-id)))
+        (is (zero? (get-count card-id)))
         (is (zero? (get-count archived-id))))
       (binding [query-analyzer/*parse-queries-in-test?* true]
         (migrate!))
       (testing "QueryField is filled now"
-        (is (pos? (get-count c1-id)))
-        (is (pos? (get-count c2-id)))
+        (is (pos? (get-count card-id)))
         (testing "but not for archived card"
           (is (zero? (get-count archived-id))))))))

--- a/test/metabase/models/query_field_test.clj
+++ b/test/metabase/models/query_field_test.clj
@@ -2,8 +2,6 @@
   (:require
    [clojure.set :as set]
    [clojure.test :refer :all]
-   [metabase.models :refer [Card]]
-   [metabase.models.query-field :as query-field]
    [metabase.native-query-analyzer :as query-analyzer]
    [metabase.test :as mt]
    [toucan2.core :as t2]
@@ -129,24 +127,3 @@
           ;; subset since it also includes the PKs/FKs
           (is (set/subset? #{total-qf tax-qf}
                            (t2/select-fn-set qf->map :model/QueryField :card_id card-id :direct_reference true))))))))
-
-(deftest parse-mbql-test
-  (testing "Parsing MBQL query returns correct used fields"
-    (mt/with-temp [Card c1 {:dataset_query (mt/mbql-query venues
-                                             {:aggregation [[:distinct $name]
-                                                            [:distinct $price]]
-                                              :limit       5})}
-                   Card c2 {:dataset_query {:query    {:source-table (str "card__" (:id c1))}
-                                            :database (:id (mt/db))
-                                            :type     :query}}
-                   Card c3 {:dataset_query (mt/mbql-query checkins
-                                             {:joins [{:source-table (str "card__" (:id c2))
-                                                       :alias "Venues"
-                                                       :condition [:= $checkins.venue_id $venues.id]}]})}]
-      (mt/$ids
-        (is (= {:direct #{%venues.name %venues.price}}
-               (#'query-field/field-ids-for-mbql (:dataset_query c1))))
-        (is (= {:direct nil}
-               (#'query-field/field-ids-for-mbql (:dataset_query c2))))
-        (is (= {:direct #{%venues.id %checkins.venue_id}}
-               (#'query-field/field-ids-for-mbql (:dataset_query c3))))))))

--- a/test/metabase/native_query_analyzer_test.clj
+++ b/test/metabase/native_query_analyzer_test.clj
@@ -1,7 +1,7 @@
 (ns metabase.native-query-analyzer-test
   (:require
    [clojure.test :refer :all]
-   [metabase.db.connection :as mdb.connection]
+   #_[metabase.db.connection :as mdb.connection]
    [metabase.native-query-analyzer :as query-analyzer]
    [metabase.public-settings :as public-settings]
    [metabase.test :as mt]))
@@ -30,6 +30,8 @@
            ;; this is "Perv""e""rse"
            (#'query-analyzer/field-query :f.name "\"Perv\"\"e\"\"rse\"")))))
 
+;; commented out in revert https://github.com/metabase/metabase/pull/42005
+#_
 (deftest ^:parallel field-matching-test
   (binding [query-analyzer/*parse-queries-in-test?* true]
     (let [q (fn [sql]

--- a/test/metabase/pulse/pulse_integration_test.clj
+++ b/test/metabase/pulse/pulse_integration_test.clj
@@ -292,7 +292,7 @@
   [date-str n]
   (format
     "WITH T AS (SELECT CAST('%s' AS TIMESTAMP) AS example_timestamp),
-          \"SAMPLE\" AS (SELECT T.example_timestamp                                   AS full_datetime_utc,
+          SAMPLE AS (SELECT T.example_timestamp                                   AS full_datetime_utc,
                             T.example_timestamp AT TIME ZONE 'US/Pacific'         AS full_datetime_pacific,
                             CAST(T.example_timestamp AS TIMESTAMP)                AS example_timestamp,
                             CAST(T.example_timestamp AS TIMESTAMP WITH TIME ZONE) AS example_timestamp_with_time_zone,
@@ -308,7 +308,7 @@
                             EXTRACT(SECOND FROM T.example_timestamp)              AS example_second
                      FROM T)
      SELECT *
-     FROM \"SAMPLE\"
+     FROM SAMPLE
               CROSS JOIN
           generate_series(1, %s);"
     date-str n))

--- a/test/metabase/util_test.cljc
+++ b/test/metabase/util_test.cljc
@@ -426,27 +426,14 @@
     (is (= {:m true}
            (meta (u/assoc-default ^:m {:x 0} :y 1 :z 2 :a nil))))))
 
-(deftest ^:parallel row-diff-test
+(deftest ^:parallel classify-changes-test
   (testing "classify correctly"
-    (is (= {:to-update [{:id 2 :name "c3"}]
+    (is (= {:to-update [{:id 2 :name "c3"} {:id 4 :name "c4"}]
             :to-delete [{:id 1 :name "c1"} {:id 3 :name "c3"}]
-            :to-create [{:id -1 :name "-c1"}]
-            :to-skip   [{:id 4 :name "c4"}]}
-           (u/row-diff
-            [{:id 1 :name "c1"}   {:id 2 :name "c2"} {:id 3 :name "c3"} {:id 4 :name "c4"}]
-            [{:id -1 :name "-c1"} {:id 2 :name "c3"} {:id 4 :name "c4"}])))
-    (is (= {:to-skip   [{:god_id 10, :name "Zeus", :job "God of Thunder"}]
-            :to-delete [{:id 2, :god_id 20, :name "Odin", :job "God of Thunder"}]
-            :to-update [{:god_id 30, :name "Osiris", :job "God of Afterlife"}]
-            :to-create [{:god_id 40, :name "Perun", :job "God of Thunder"}]}
-           (u/row-diff [{:id 1 :god_id 10 :name "Zeus" :job "God of Thunder"}
-                        {:id 2 :god_id 20 :name "Odin" :job "God of Thunder"}
-                        {:id 3 :god_id 30 :name "Osiris" :job "God of Fertility"}]
-                       [{:god_id 10 :name "Zeus" :job "God of Thunder"}
-                        {:god_id 30 :name "Osiris" :job "God of Afterlife"}
-                        {:god_id 40 :name "Perun" :job "God of Thunder"}]
-                       {:id-fn   :god_id
-                        :to-compare #(dissoc % :id :god_id)})))))
+            :to-create [{:id -1 :name "-c1"}]}
+           (u/classify-changes
+             [{:id 1 :name "c1"}   {:id 2 :name "c2"} {:id 3 :name "c3"} {:id 4 :name "c4"}]
+             [{:id -1 :name "-c1"} {:id 2 :name "c3"} {:id 4 :name "c4"}])))))
 
 (deftest ^:parallel empty-or-distinct?-test
   (are [xs expected] (= expected


### PR DESCRIPTION
This reverts commit 0da8100558340c745e6dfdc48a11eb48190ca170.

Reverts https://github.com/metabase/metabase/pull/41821

Custom migration was getting field ids from queries. If there were nested mbql queries (`select * from {{#1}}`) it would have to expand those queries in

```clojure
(defn replace-tags
  "Given a native dataset_query, return a `{:query \"<SQL string>\"}` where the SQL no longer has Metabase-specific
  template tags."
  [query]
  (if-let [name->tag (seq (get-in query [:native :template-tags]))]
    ;; this call below requires the app-db to be setup
    (qp.compile/compile (assoc-in query [:native :template-tags] (update-vals name->tag tag-default)))
    (:native query)))
```

And can't do all that while we are migrating the app-db in order to set the app db up.