### PR TITLE
Allow multiple values for string operators in the dashboard

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-text-category.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-text-category.cy.spec.js
@@ -1,3 +1,5 @@
+import _ from "underscore";
+
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   restore,
@@ -26,6 +28,8 @@ import { DASHBOARD_TEXT_FILTERS } from "./shared/dashboard-filters-text-category
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
 
+const operators = _.uniq(DASHBOARD_TEXT_FILTERS.map(f => f.operator));
+
 describe("scenarios > dashboard > filters > text/category", () => {
   beforeEach(() => {
     restore();
@@ -47,24 +51,23 @@ describe("scenarios > dashboard > filters > text/category", () => {
   });
 
   it("should work when set through the filter widget", () => {
-    Object.entries(DASHBOARD_TEXT_FILTERS).forEach(([filter]) => {
-      cy.log(`Make sure we can connect ${filter} filter`);
-      setFilter("Text or Category", filter);
+    operators.forEach(operator => {
+      cy.log(`Make sure we can connect ${operator} filter`);
+      setFilter("Text or Category", operator);
 
       cy.findByText("Select…").click();
       popover().contains("Source").click();
     });
-
     saveDashboard();
     waitDashboardCardQuery();
 
-    Object.entries(DASHBOARD_TEXT_FILTERS).forEach(
-      ([filter, { value, representativeResult }], index) => {
+    DASHBOARD_TEXT_FILTERS.forEach(
+      ({ operator, value, representativeResult }, index) => {
         filterWidget().eq(index).click();
-        applyFilterByType(filter, value);
+        applyFilterByType(operator, value);
         waitDashboardCardQuery();
 
-        cy.log(`Make sure ${filter} filter returns correct result`);
+        cy.log(`Make sure ${operator} filter returns correct result`);
         cy.findByTestId("dashcard").within(() => {
           cy.contains(representativeResult);
         });

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-text-category.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-text-category.cy.spec.js
@@ -1,7 +1,4 @@
-import {
-  ORDERS_DASHBOARD_ID,
-  ORDERS_DASHBOARD_DASHCARD_ID,
-} from "e2e/support/cypress_sample_instance_data";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   restore,
   popover,
@@ -27,14 +24,26 @@ import {
 
 import { DASHBOARD_TEXT_FILTERS } from "./shared/dashboard-filters-text-category";
 
+const { ORDERS_ID } = SAMPLE_DATABASE;
+
 describe("scenarios > dashboard > filters > text/category", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
 
-    visitDashboard(ORDERS_DASHBOARD_ID);
-
-    editDashboard();
+    cy.createQuestionAndDashboard({
+      questionDetails: {
+        query: { "source-table": ORDERS_ID, limit: 5 },
+      },
+      cardDetails: {
+        size_x: 24,
+        size_y: 8,
+      },
+    }).then(({ body: { id, dashboard_id } }) => {
+      cy.wrap(id).as("dashCardId");
+      visitDashboard(dashboard_id);
+      editDashboard();
+    });
   });
 
   it("should work when set through the filter widget", () => {
@@ -47,11 +56,13 @@ describe("scenarios > dashboard > filters > text/category", () => {
     });
 
     saveDashboard();
+    waitDashboardCardQuery();
 
     Object.entries(DASHBOARD_TEXT_FILTERS).forEach(
       ([filter, { value, representativeResult }], index) => {
         filterWidget().eq(index).click();
         applyFilterByType(filter, value);
+        waitDashboardCardQuery();
 
         cy.log(`Make sure ${filter} filter returns correct result`);
         cy.findByTestId("dashcard").within(() => {
@@ -59,7 +70,7 @@ describe("scenarios > dashboard > filters > text/category", () => {
         });
 
         clearFilterWidget(index);
-        cy.wait(`@dashcardQuery${ORDERS_DASHBOARD_DASHCARD_ID}`);
+        waitDashboardCardQuery();
       },
     );
   });
@@ -75,9 +86,11 @@ describe("scenarios > dashboard > filters > text/category", () => {
     popover().contains("Source").click();
 
     saveDashboard();
-    filterWidget().click();
+    waitDashboardCardQuery();
 
+    filterWidget().click();
     applyFilterByType(filterType, filterValue);
+    waitDashboardCardQuery();
 
     filterWidget().click();
     cy.log("uncheck all values");
@@ -85,6 +98,7 @@ describe("scenarios > dashboard > filters > text/category", () => {
     popover().within(() => {
       cy.findByText(filterValue).click();
       cy.button("Update filter").click();
+      waitDashboardCardQuery();
     });
 
     filterWidget().within(() => {
@@ -111,29 +125,27 @@ describe("scenarios > dashboard > filters > text/category", () => {
     popover().contains("User ID").click();
 
     saveDashboard();
-    cy.wait(`@dashcardQuery${ORDERS_DASHBOARD_DASHCARD_ID}`);
+    waitDashboardCardQuery();
 
     cy.location("search").should("eq", "?text=Organic&id=");
-    cy.findByTestId("dashcard").within(() => {
-      cy.contains("39.58");
-    });
+    cy.findByTestId("dashcard").contains("39.58");
 
     // This part reproduces metabase#13960
     // Remove default filter (category)
     cy.get("fieldset .Icon-close").click();
-    cy.wait(`@dashcardQuery${ORDERS_DASHBOARD_DASHCARD_ID}`);
+    waitDashboardCardQuery();
 
     cy.location("search").should("eq", "?text=&id=");
 
     filterWidget().contains("ID").click();
     cy.findByPlaceholderText("Enter an ID").type("4{enter}").blur();
     cy.button("Add filter").click();
-    cy.wait(`@dashcardQuery${ORDERS_DASHBOARD_DASHCARD_ID}`);
+    waitDashboardCardQuery();
 
     cy.location("search").should("eq", "?text=&id=4");
 
     cy.reload();
-    cy.wait(`@dashcardQuery${ORDERS_DASHBOARD_DASHCARD_ID}`);
+    waitDashboardCardQuery();
 
     cy.location("search").should("eq", "?text=&id=4");
     filterWidget().contains("Text");
@@ -164,13 +176,16 @@ describe("scenarios > dashboard > filters > text/category", () => {
     // Updates the filter value
     selectDefaultValueFromPopover("Twitter", { buttonLabel: "Update filter" });
     saveDashboard();
+    waitDashboardCardQuery();
     ensureDashboardCardHasText("37.65");
 
     // Resets the value back by clicking widget icon
     toggleFilterWidgetValues(["Google", "Organic"], {
       buttonLabel: "Update filter",
     });
+    waitDashboardCardQuery();
     resetFilterWidgetToDefault();
+    waitDashboardCardQuery();
     filterWidget().findByText("Twitter");
 
     // Removing value resets back to default
@@ -180,3 +195,9 @@ describe("scenarios > dashboard > filters > text/category", () => {
     filterWidget().findByText("Twitter");
   });
 });
+
+function waitDashboardCardQuery() {
+  cy.get("@dashCardId").then(id => {
+    cy.wait(`@dashcardQuery${id}`);
+  });
+}

--- a/e2e/test/scenarios/dashboard-filters/shared/dashboard-filters-text-category.js
+++ b/e2e/test/scenarios/dashboard-filters/shared/dashboard-filters-text-category.js
@@ -1,11 +1,13 @@
 export const DASHBOARD_TEXT_FILTERS = [
   {
     operator: "Is",
+    single: true,
     value: "Organic",
     representativeResult: "39.58",
   },
   {
     operator: "Is not",
+    single: true,
     value: "Organic",
     representativeResult: "37.65",
   },
@@ -14,20 +16,52 @@ export const DASHBOARD_TEXT_FILTERS = [
     operator: "Contains",
     value: "oo,aa",
     representativeResult: "148.23",
+    negativeAssertion: "37.65",
+  },
+  {
+    operator: "Contains",
+    single: true,
+    value: "oo,aa",
+    representativeResult: "No results!",
+    negativeAssertion: "148.23",
   },
   {
     operator: "Does not contain",
-    value: "oo,aa",
+    value: "oo,tt",
+    representativeResult: "39.58",
+    negativeASsertion: "37.65",
+  },
+  {
+    operator: "Does not contain",
+    single: true,
+    value: "oo,tt",
     representativeResult: "37.65",
+    negativeASsertion: "39.58",
   },
   {
     operator: "Starts with",
     value: "A,b",
     representativeResult: "85.72",
+    negativeASsertion: "70.15",
+  },
+  {
+    operator: "Starts with",
+    single: true,
+    value: "A,b",
+    representativeResult: "No results!",
+    negativeASsertion: "85.72",
   },
   {
     operator: "Ends with",
     value: "e,s",
     representativeResult: "47.68",
+    negativeASsertion: "127.88",
+  },
+  {
+    operator: "Ends with",
+    single: true,
+    value: "e,s",
+    representativeResult: "No results!",
+    negativeASsertion: "47.68",
   },
 ];

--- a/e2e/test/scenarios/dashboard-filters/shared/dashboard-filters-text-category.js
+++ b/e2e/test/scenarios/dashboard-filters/shared/dashboard-filters-text-category.js
@@ -1,27 +1,33 @@
-export const DASHBOARD_TEXT_FILTERS = {
-  Is: {
+export const DASHBOARD_TEXT_FILTERS = [
+  {
+    operator: "Is",
     value: "Organic",
     representativeResult: "39.58",
   },
-  "Is not": {
+  {
+    operator: "Is not",
     value: "Organic",
     representativeResult: "37.65",
   },
   // It is important to keep multiple values as a single string in the value field.
-  Contains: {
+  {
+    operator: "Contains",
     value: "oo,aa",
     representativeResult: "148.23",
   },
-  "Does not contain": {
+  {
+    operator: "Does not contain",
     value: "oo,aa",
     representativeResult: "37.65",
   },
-  "Starts with": {
+  {
+    operator: "Starts with",
     value: "A,b",
     representativeResult: "85.72",
   },
-  "Ends with": {
+  {
+    operator: "Ends with",
     value: "e,s",
     representativeResult: "47.68",
   },
-};
+];

--- a/e2e/test/scenarios/dashboard-filters/shared/dashboard-filters-text-category.js
+++ b/e2e/test/scenarios/dashboard-filters/shared/dashboard-filters-text-category.js
@@ -29,7 +29,7 @@ export const DASHBOARD_TEXT_FILTERS = [
     operator: "Does not contain",
     value: "oo,tt",
     representativeResult: "39.58",
-    negativeASsertion: "37.65",
+    negativeAssertion: "37.65",
   },
   {
     operator: "Does not contain",

--- a/e2e/test/scenarios/dashboard-filters/shared/dashboard-filters-text-category.js
+++ b/e2e/test/scenarios/dashboard-filters/shared/dashboard-filters-text-category.js
@@ -7,20 +7,21 @@ export const DASHBOARD_TEXT_FILTERS = {
     value: "Organic",
     representativeResult: "37.65",
   },
+  // It is important to keep multiple values as a single string in the value field.
   Contains: {
-    value: "oo",
+    value: "oo,aa",
     representativeResult: "148.23",
   },
   "Does not contain": {
-    value: "oo",
+    value: "oo,aa",
     representativeResult: "37.65",
   },
   "Starts with": {
-    value: "A",
+    value: "A,b",
     representativeResult: "85.72",
   },
   "Ends with": {
-    value: "e",
+    value: "e,s",
     representativeResult: "47.68",
   },
 };

--- a/frontend/src/metabase-lib/v1/operators/constants.js
+++ b/frontend/src/metabase-lib/v1/operators/constants.js
@@ -169,21 +169,25 @@ export const FIELD_FILTER_OPERATORS = {
     validArgumentsFilters: [comparableArgument, comparableArgument],
   },
   "starts-with": {
+    multi: true,
     validArgumentsFilters: [freeformArgument],
     options: CASE_SENSITIVE_OPTION,
     optionsDefaults: { "case-sensitive": false },
   },
   "ends-with": {
+    multi: true,
     validArgumentsFilters: [freeformArgument],
     options: CASE_SENSITIVE_OPTION,
     optionsDefaults: { "case-sensitive": false },
   },
   contains: {
+    multi: true,
     validArgumentsFilters: [freeformArgument],
     options: CASE_SENSITIVE_OPTION,
     optionsDefaults: { "case-sensitive": false },
   },
   "does-not-contain": {
+    multi: true,
     validArgumentsFilters: [freeformArgument],
     options: CASE_SENSITIVE_OPTION,
     optionsDefaults: { "case-sensitive": false },

--- a/frontend/src/metabase-lib/v1/parameters/constants.ts
+++ b/frontend/src/metabase-lib/v1/parameters/constants.ts
@@ -138,7 +138,14 @@ export const SINGLE_OR_MULTI_SELECTABLE_TYPES: Record<
   string,
   string | string[]
 > = {
-  string: ["=", "!="],
+  string: [
+    "=",
+    "!=",
+    "contains",
+    "does-not-contain",
+    "starts-with",
+    "ends-with",
+  ],
   category: "any",
   id: "any",
   location: ["=", "!="],

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.unit.spec.tsx
@@ -137,21 +137,25 @@ describe("ParameterSidebar", () => {
   });
 
   describe("string", () => {
-    beforeEach(() => {
-      setup({
-        parameter: createMockUiParameter({
-          type: "string/=",
-          sectionId: "string",
-        }),
+    describe("smoke test", () => {
+      beforeEach(() => {
+        setup({
+          parameter: createMockUiParameter({
+            type: "string/=",
+            sectionId: "string",
+          }),
+        });
       });
-    });
 
-    it("should render type", () => {
-      expect(screen.getByDisplayValue("Text or Category")).toBeInTheDocument();
-    });
+      it("should render type", () => {
+        expect(
+          screen.getByDisplayValue("Text or Category"),
+        ).toBeInTheDocument();
+      });
 
-    it("should render operator", () => {
-      expect(screen.getByDisplayValue("Is")).toBeInTheDocument();
+      it("should render operator", () => {
+        expect(screen.getByDisplayValue("Is")).toBeInTheDocument();
+      });
     });
   });
 

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.unit.spec.tsx
@@ -157,6 +157,34 @@ describe("ParameterSidebar", () => {
         expect(screen.getByDisplayValue("Is")).toBeInTheDocument();
       });
     });
+
+    it.each([
+      "string/=",
+      "string/!=",
+      "string/contains",
+      "string/does-not-contain",
+      "string/starts-with",
+      "string/ends-with",
+    ])(
+      "should be able to toggle multiple values settings for `%s` operator",
+      async type => {
+        const { onChangeIsMultiSelect } = setup({
+          parameter: createMockUiParameter({
+            type,
+            sectionId: "string",
+          }),
+        });
+
+        expect(screen.getByText("People can pick")).toBeInTheDocument();
+        expect(
+          screen.getByRole("radio", { name: "Multiple values" }),
+        ).toBeChecked();
+        await userEvent.click(
+          screen.getByRole("radio", { name: "A single value" }),
+        );
+        expect(onChangeIsMultiSelect).toHaveBeenCalledWith(false);
+      },
+    );
   });
 
   describe("date", () => {
@@ -201,6 +229,7 @@ describe("ParameterSidebar", () => {
 const setup = ({ parameter = createMockUiParameter() }: SetupOpts = {}) => {
   const onChangeQueryType = jest.fn();
   const onChangeName = jest.fn();
+  const onChangeIsMultiSelect = jest.fn();
 
   renderWithProviders(
     <ParameterSettings
@@ -210,7 +239,7 @@ const setup = ({ parameter = createMockUiParameter() }: SetupOpts = {}) => {
       onChangeName={onChangeName}
       onChangeType={jest.fn()}
       onChangeDefaultValue={jest.fn()}
-      onChangeIsMultiSelect={jest.fn()}
+      onChangeIsMultiSelect={onChangeIsMultiSelect}
       onChangeQueryType={onChangeQueryType}
       onChangeSourceType={jest.fn()}
       onChangeSourceConfig={jest.fn()}
@@ -219,5 +248,5 @@ const setup = ({ parameter = createMockUiParameter() }: SetupOpts = {}) => {
     />,
   );
 
-  return { onChangeQueryType, onChangeName };
+  return { onChangeQueryType, onChangeName, onChangeIsMultiSelect };
 };


### PR DESCRIPTION
This PR is a part of the milestone 2 of https://github.com/metabase/metabase/issues/41956.

It expands the multi-select filter capabilities for the dashboard filters to the "contains", "does not contain", "starts with" and "ends with" operators. This behavior was previously possible only for "is" and "is not" operators.

### Testing
- [x] Unit tests partial coverage
- [x] E2E tests (expanded the existing coverage)


Resolves #41956 
