### PR TITLE
🍒  Manual backport "Bump snowflake driver to 15.1"

### DIFF
--- a/backport.sh
+++ b/backport.sh
@@ -1,4 +1,0 @@
-git reset HEAD~1
-rm ./backport.sh
-git cherry-pick 7a6ef857779855aa463a649b890dbd153ef7a4ea
-echo 'Resolve conflicts and force push this branch'

--- a/modules/drivers/snowflake/deps.edn
+++ b/modules/drivers/snowflake/deps.edn
@@ -2,4 +2,4 @@
  ["src" "resources"]
 
  :deps
- {net.snowflake/snowflake-jdbc {:mvn/version "3.14.4"}}}
+ {net.snowflake/snowflake-jdbc {:mvn/version "3.15.1"}}}


### PR DESCRIPTION
Manual backport https://github.com/metabase/metabase/pull/41790
The automatic backport PR was merged incorrectly #41838.

This PR actually solve the conflict and remove the backport script which shouldn't be in the repo.
