### PR TITLE
Fix Line or bar chart not rendering in SDK

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/index.ts
+++ b/enterprise/frontend/src/embedding-sdk/index.ts
@@ -1,3 +1,5 @@
+import "metabase/lib/dayjs";
+
 export * from "./hooks/public";
 export * from "./components/public";
 export * from "./lib/plugins";


### PR DESCRIPTION
### Description

We [encountered this problem](https://metaboat.slack.com/archives/C063Q3F1HPF/p1714400201561839?thread_ts=1714396268.771749&cid=C063Q3F1HPF) after the ECharts migration. [Adding dayjs plugin](https://metaboat.slack.com/archives/C063Q3F1HPF/p1714400923798239?thread_ts=1714396268.771749&cid=C063Q3F1HPF) seemed to fix this problem.

### How to verify

Using the SDK built before this PR and compare it to the SDK built with this PR. then render the `InteractiveQuestion` to render the line or bar chart. There should be no error with the SDK built with this PR.

### Demo

#### Before
- ![image](https://github.com/metabase/metabase/assets/1937582/97f73355-b44c-4774-8e19-f0586c9437ca)
- ![image](https://github.com/metabase/metabase/assets/1937582/01d09ef0-27f4-4280-bf66-2f7ff25cf004)


#### After
![image](https://github.com/metabase/metabase/assets/1937582/404649ca-6c3b-470a-bb5f-da252b12e80b)


### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
