### PR TITLE
[backport] Bump snowflake driver

### DIFF
--- a/backport.sh
+++ b/backport.sh
@@ -1,4 +1,0 @@
-git reset HEAD~1
-rm ./backport.sh
-git cherry-pick 7a6ef857779855aa463a649b890dbd153ef7a4ea
-echo 'Resolve conflicts and force push this branch'

--- a/modules/drivers/snowflake/deps.edn
+++ b/modules/drivers/snowflake/deps.edn
@@ -2,4 +2,4 @@
  ["src" "resources"]
 
  :deps
- {net.snowflake/snowflake-jdbc {:mvn/version "3.14.4"}}}
+ {net.snowflake/snowflake-jdbc {:mvn/version "3.15.1"}}}

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -110,8 +110,11 @@
           private-key-file (handle-conn-uri user account private-key-file)))
 
       :else
-      ;; get-secret-string should get the right value (using private-key-value or private-key-id) and decode it automatically
-      (let [decoded (secret/get-secret-string details "private-key")
+      ;; Why setting `:private-key-options` to "uploaded"? To fix the issue #41852. Snowflake's database edit gui
+      ;; is designed in a way, that `:private-key-options` are not sent if `hosting` enterprise feature is enabled.
+      ;; The option must be set to "uploaded" for base64 decoding to happen. Setting that option at this point is fine
+      ;; because the alternative ("local") is ruled out already in this `cond` branch.
+      (let [decoded (secret/get-secret-string (assoc details :private-key-options "uploaded") "private-key")
             file    (secret/value->file! {:connection-property-name "private-key-file"
                                           :value                    decoded})]
         (assoc (handle-conn-uri base-details user account file)

--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -321,7 +321,7 @@
 
 (defn- format-env-key ^String [env-key]
   (let [[_ header body footer]
-        (re-find #"(-----BEGIN (?:\p{Alnum}+ )?PRIVATE KEY-----)(.*)(-----END (?:\p{Alnum}+ )?PRIVATE KEY-----)" env-key)]
+        (re-find #"(?s)(-----BEGIN (?:\p{Alnum}+ )?PRIVATE KEY-----)(.*)(-----END (?:\p{Alnum}+ )?PRIVATE KEY-----)" env-key)]
     (str header (str/replace body #"\s+|\\n" "\n") footer)))
 
 (deftest can-connect-test
@@ -356,6 +356,20 @@
                                   (dissoc :password)
                                   (merge {:db pk-db :user pk-user} to-merge))]
                   (is (can-connect? details)))))))))))
+
+(deftest can-connect-pk-no-options-test
+  (mt/test-driver
+   :snowflake
+   (testing "Can connect with base64 encoded `:private-key-value` and no `:private-key-options` set (#41852)"
+     (let [pk-key (format-env-key (tx/db-test-env-var-or-throw :snowflake :pk-private-key))
+           pk-user (tx/db-test-env-var :snowflake :pk-user)
+           pk-db "SNOWFLAKE_SAMPLE_DATA"
+           details (-> (:details (mt/db))
+                       (dissoc :password)
+                       (assoc :dbname pk-db
+                              :private-key-value (u/encode-base64 pk-key)
+                              :user pk-user))]
+       (is (driver/can-connect? :snowflake details))))))
 
 (deftest report-timezone-test
   (mt/test-driver :snowflake


### PR DESCRIPTION
I need to test a bugfix with a customer (Fixed an issue with parsing large responses (greater than 16MB)) in 49.7

References #41790

---

It's a weird PR, since `backport.sh` got merged into `release-x.49.x`, and I'm trying to finish what was intended to happen.