### PR TITLE
"Combine columns" drill thru

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/combine-column.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/combine-column.cy.spec.js
@@ -1,0 +1,71 @@
+import { openPeopleTable, popover, restore } from "e2e/support/helpers";
+
+describe("scenarios > visualizations > drillthroughs > table_drills > combine columns", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should be possible to combine columns from the a table header", () => {
+    openPeopleTable({ limit: 3, mode: "notebook" });
+
+    cy.findByLabelText("Pick columns").click();
+    popover().within(() => {
+      cy.findByText("Select none").click();
+      cy.findByLabelText("Email").click();
+    });
+
+    cy.findByLabelText("Pick columns").click();
+    cy.button("Visualize").click();
+
+    cy.findAllByTestId("header-cell").contains("Email").click();
+    popover().findByText("Combine columns").click();
+
+    popover().within(() => {
+      cy.findByTestId("combine-column-example").should(
+        "contain",
+        "email@example.com12345",
+      );
+      cy.findByText("ID").click();
+    });
+
+    popover()
+      .last()
+      .within(() => {
+        cy.findByText("Name").click();
+      });
+
+    popover().within(() => {
+      cy.findByText("Separated by (empty)").click();
+      cy.findByLabelText("Separator").type("__");
+      cy.findByTestId("combine-column-example").should(
+        "have.text",
+        "email@example.com__text",
+      );
+
+      cy.findByText("Add column").click();
+      cy.findByTestId("combine-column-example").should(
+        "have.text",
+        "email@example.com__text__12345",
+      );
+
+      cy.findAllByRole("textbox").last().clear();
+      cy.findByTestId("combine-column-example").should(
+        "have.text",
+        "email@example.com__text12345",
+      );
+
+      cy.findAllByRole("textbox").last().clear().type("+");
+      cy.findByTestId("combine-column-example").should(
+        "have.text",
+        "email@example.com__text+12345",
+      );
+
+      cy.findByText("Done").click();
+    });
+
+    cy.findAllByTestId("header-cell")
+      .last()
+      .should("have.text", "Email Name ID");
+  });
+});

--- a/frontend/src/metabase-lib/drills.ts
+++ b/frontend/src/metabase-lib/drills.ts
@@ -2,13 +2,13 @@ import * as ML from "cljs/metabase.lib.js";
 import type { DatasetColumn, RowValue } from "metabase-types/api";
 
 import type {
-  FilterDrillDetails,
-  ColumnMetadata,
   ClickObjectDataRow,
   ClickObjectDimension,
+  ColumnMetadata,
   DrillThru,
-  Query,
+  FilterDrillDetails,
   PivotType,
+  Query,
 } from "./types";
 
 // NOTE: value might be null or undefined, and they mean different things!

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -430,6 +430,7 @@ export type DrillThruType =
   | "drill-thru/automatic-insights"
   | "drill-thru/column-extract"
   | "drill-thru/column-filter"
+  | "drill-thru/combine-columns"
   | "drill-thru/distribution"
   | "drill-thru/fk-details"
   | "drill-thru/fk-filter"
@@ -462,6 +463,9 @@ export type ColumnExtractDrillThruInfo =
     displayName: string;
     extractions: ColumnExtractionInfo[];
   };
+
+export type CombineColumnsDrillThruInfo =
+  BaseDrillThruInfo<"drill-thru/combine-columns">;
 
 export type QuickFilterDrillThruOperator =
   | "="
@@ -528,6 +532,7 @@ export type ZoomTimeseriesDrillThruInfo =
 
 export type DrillThruDisplayInfo =
   | ColumnExtractDrillThruInfo
+  | CombineColumnsDrillThruInfo
   | QuickFilterDrillThruInfo
   | PKDrillThruInfo
   | ZoomDrillThruInfo

--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
@@ -64,8 +64,8 @@ export function QueryColumnPicker({
   checkIsColumnSelected,
   onSelect,
   onClose,
-  "data-testid": dataTestId,
   width,
+  "data-testid": dataTestId,
   hasInitialFocus = true,
 }: QueryColumnPickerProps) {
   const sections: Sections[] = useMemo(

--- a/frontend/src/metabase/querying/utils/drills/combine-columns-drill/combine-columns-drill.tsx
+++ b/frontend/src/metabase/querying/utils/drills/combine-columns-drill/combine-columns-drill.tsx
@@ -1,0 +1,50 @@
+import { t } from "ttag";
+
+import type {
+  ClickActionPopoverProps,
+  Drill,
+} from "metabase/visualizations/types/click-actions";
+import * as Lib from "metabase-lib";
+
+import { CombineColumnsDrill } from "./components";
+
+export const combineColumnsDrill: Drill<Lib.CombineColumnsDrillThruInfo> = ({
+  question,
+  query,
+  stageIndex,
+  clicked,
+}) => {
+  if (!clicked.column) {
+    return [];
+  }
+
+  const column = Lib.fromLegacyColumn(query, stageIndex, clicked.column);
+
+  const DrillPopover = ({
+    onChangeCardAndRun,
+    onClose,
+  }: ClickActionPopoverProps) => (
+    <CombineColumnsDrill
+      column={column}
+      query={query}
+      stageIndex={stageIndex}
+      onSubmit={newQuery => {
+        const nextQuestion = question.setQuery(newQuery);
+        const nextCard = nextQuestion.card();
+        onChangeCardAndRun({ nextCard });
+        onClose();
+      }}
+    />
+  );
+
+  return [
+    {
+      name: "combine",
+      title: t`Combine columns`,
+      section: "combine",
+      icon: "add",
+      buttonType: "horizontal",
+      popover: DrillPopover,
+    },
+  ];
+};

--- a/frontend/src/metabase/querying/utils/drills/combine-columns-drill/components/ColumnAndSeparatorRow/ColumnAndSeparatorRow.module.css
+++ b/frontend/src/metabase/querying/utils/drills/combine-columns-drill/components/ColumnAndSeparatorRow/ColumnAndSeparatorRow.module.css
@@ -1,0 +1,17 @@
+.separator {
+  flex: 0 0 auto;
+}
+
+.column {
+  flex: 1;
+}
+
+button.remove {
+  flex: 0 0 auto;
+  border-color: transparent;
+}
+
+.whitespacePlaceholder {
+  pointer-events: none;
+  user-select: none;
+}

--- a/frontend/src/metabase/querying/utils/drills/combine-columns-drill/components/ColumnAndSeparatorRow/ColumnAndSeparatorRow.tsx
+++ b/frontend/src/metabase/querying/utils/drills/combine-columns-drill/components/ColumnAndSeparatorRow/ColumnAndSeparatorRow.tsx
@@ -1,0 +1,118 @@
+import { useState, type FocusEvent } from "react";
+import { t } from "ttag";
+
+import { Box, Button, Flex, Icon, Text, TextInput } from "metabase/ui";
+import { getThemeOverrides } from "metabase/ui/theme";
+import type * as Lib from "metabase-lib";
+
+import type { ColumnAndSeparator } from "../../types";
+import { formatSeparator } from "../../utils";
+import { ColumnPicker } from "../ColumnPicker";
+
+import S from "./ColumnAndSeparatorRow.module.css";
+
+interface Props {
+  query: Lib.Query;
+  stageIndex: number;
+  column: Lib.ColumnMetadata;
+  columns: Lib.ColumnMetadata[];
+  index: number;
+  separator: string;
+  showLabels: boolean;
+  showRemove: boolean;
+  showSeparator: boolean;
+  onChange: (index: number, change: Partial<ColumnAndSeparator>) => void;
+  onRemove: (index: number) => void;
+}
+
+const { fontFamilyMonospace } = getThemeOverrides();
+
+export const ColumnAndSeparatorRow = ({
+  query,
+  stageIndex,
+  column,
+  columns,
+  index,
+  separator,
+  showLabels,
+  showRemove,
+  showSeparator,
+  onChange,
+  onRemove,
+}: Props) => {
+  const [isFocused, setIsFocused] = useState(false);
+
+  function handleFocus(event: FocusEvent<HTMLInputElement>) {
+    setIsFocused(true);
+    event.target.select();
+  }
+
+  return (
+    <Flex align="flex-end" gap={12}>
+      {showSeparator && (
+        <Box pos="relative">
+          <TextInput
+            className={S.separator}
+            label={showLabels ? t`Separator` : undefined}
+            placeholder={formatSeparator("")}
+            value={separator}
+            w={110}
+            onChange={event => {
+              const separator = event.target.value;
+              onChange(index, { separator });
+            }}
+            onBlur={() => setIsFocused(false)}
+            onFocus={handleFocus}
+            styles={{
+              input: {
+                fontFamily: fontFamilyMonospace as string,
+              },
+            }}
+          />
+
+          {separator === " " && !isFocused && (
+            <Text
+              bottom={8} // using bottom instead of top because the input does not always have a label
+              className={S.whitespacePlaceholder}
+              color="text-light"
+              left={1} // account for TextInput border
+              pos="absolute"
+              px="0.6875rem" // same as TextInput
+              size="md"
+              unselectable="on"
+            >
+              {formatSeparator(separator)}
+            </Text>
+          )}
+        </Box>
+      )}
+
+      <Box className={S.column}>
+        <ColumnPicker
+          query={query}
+          stageIndex={stageIndex}
+          columns={columns}
+          label={showLabels ? t`Column` : undefined}
+          value={column}
+          onChange={column => {
+            onChange(index, { column });
+          }}
+        />
+      </Box>
+
+      {showRemove && (
+        <Button
+          classNames={{
+            root: S.remove,
+          }}
+          aria-label={t`Remove column`}
+          leftIcon={<Icon name="close" />}
+          variant="default"
+          onClick={() => {
+            onRemove(index);
+          }}
+        />
+      )}
+    </Flex>
+  );
+};

--- a/frontend/src/metabase/querying/utils/drills/combine-columns-drill/components/ColumnAndSeparatorRow/index.ts
+++ b/frontend/src/metabase/querying/utils/drills/combine-columns-drill/components/ColumnAndSeparatorRow/index.ts
@@ -1,0 +1,1 @@
+export * from "./ColumnAndSeparatorRow";

--- a/frontend/src/metabase/querying/utils/drills/combine-columns-drill/components/ColumnPicker/ColumnPicker.module.css
+++ b/frontend/src/metabase/querying/utils/drills/combine-columns-drill/components/ColumnPicker/ColumnPicker.module.css
@@ -1,0 +1,20 @@
+div.button {
+  justify-content: space-between;
+  font-weight: normal;
+}
+
+button.root {
+  &:hover {
+    background: none;
+  }
+
+  &:hover .button {
+    color: var(--color-text-dark);
+  }
+
+  &.open,
+  &:focus-visible {
+    border-color: var(--color-brand);
+    outline: none;
+  }
+}

--- a/frontend/src/metabase/querying/utils/drills/combine-columns-drill/components/ColumnPicker/ColumnPicker.tsx
+++ b/frontend/src/metabase/querying/utils/drills/combine-columns-drill/components/ColumnPicker/ColumnPicker.tsx
@@ -1,0 +1,153 @@
+import classNames from "classnames";
+import type { FocusEvent, MouseEvent, KeyboardEvent, ReactNode } from "react";
+import { useRef, useState, useMemo, useEffect } from "react";
+import { t } from "ttag";
+
+import { QueryColumnPicker } from "metabase/common/components/QueryColumnPicker";
+import useSequencedContentCloseHandler from "metabase/hooks/use-sequenced-content-close-handler";
+import { color } from "metabase/lib/colors";
+import { Button, Icon, Input, Popover, FocusTrap } from "metabase/ui";
+import { getThemeOverrides } from "metabase/ui/theme";
+import * as Lib from "metabase-lib";
+
+import styles from "./ColumnPicker.module.css";
+
+type ColumnInputProps = {
+  query: Lib.Query;
+  stageIndex: number;
+  columns: Lib.ColumnMetadata[];
+  label?: string;
+  value: Lib.ColumnMetadata;
+  onChange: (column: Lib.ColumnMetadata) => void;
+};
+
+const theme = getThemeOverrides();
+
+export function ColumnPicker({
+  query,
+  stageIndex,
+  columns,
+  label,
+  value,
+  onChange,
+}: ColumnInputProps) {
+  const columnGroups = useMemo(() => Lib.groupColumns(columns), [columns]);
+
+  const [open, setOpen] = useState(false);
+  const button = useRef<HTMLButtonElement>(null);
+
+  function handleOpen() {
+    setOpen(true);
+  }
+
+  function handleClose() {
+    setOpen(false);
+    button.current?.focus();
+  }
+
+  function handleBlur(evt: FocusEvent<HTMLDivElement>) {
+    if (!evt.currentTarget || !evt.relatedTarget) {
+      return;
+    }
+    if (!evt.currentTarget.contains(evt.relatedTarget as Node)) {
+      setTimeout(() => setOpen(false), 100);
+    }
+  }
+
+  function handleButtonClick(evt: MouseEvent<HTMLButtonElement>) {
+    evt.preventDefault();
+    evt.stopPropagation();
+    setOpen(open => !open);
+  }
+
+  function handleKeyDown(evt: KeyboardEvent<HTMLButtonElement>) {
+    if (evt.key === "Enter") {
+      setOpen(true);
+    }
+  }
+
+  const dropdown = (
+    <FocusTrap active={open}>
+      <Dropdown onBlur={handleBlur}>
+        <QueryColumnPicker
+          query={query}
+          stageIndex={stageIndex}
+          columnGroups={columnGroups}
+          onSelect={onChange}
+          onClose={handleClose}
+          checkIsColumnSelected={item => item.column === value}
+          width="100%"
+        />
+      </Dropdown>
+    </FocusTrap>
+  );
+
+  const text = useMemo(() => {
+    if (!value) {
+      return t`Select a column...`;
+    }
+    const info = Lib.displayInfo(query, stageIndex, value);
+    return info.longDisplayName;
+  }, [value, query, stageIndex]);
+
+  return (
+    <Input.Wrapper
+      label={label}
+      styles={{
+        root: { width: "100%" },
+        label: {
+          marginBottom: theme.spacing?.xs,
+          fontSize: theme.fontSizes?.md,
+          color: color("text-medium"),
+        },
+      }}
+    >
+      <Popover
+        opened={open}
+        onClose={handleClose}
+        onOpen={handleOpen}
+        closeOnEscape
+        closeOnClickOutside
+        width="target"
+        returnFocus
+      >
+        <Popover.Target>
+          <Button
+            ref={button}
+            onMouseDownCapture={handleButtonClick}
+            onKeyDown={handleKeyDown}
+            fullWidth
+            classNames={{
+              root: classNames(styles.root, open && styles.open),
+              inner: styles.button,
+            }}
+            rightIcon={<Icon name="chevrondown" style={{ height: 14 }} />}
+          >
+            {text}
+          </Button>
+        </Popover.Target>
+        <Popover.Dropdown>{dropdown}</Popover.Dropdown>
+      </Popover>
+    </Input.Wrapper>
+  );
+}
+
+// Hack to prevent parent TippyPopover from closing when selecting an item
+// TODO: remove when TippyPopover is no longer used
+function Dropdown({
+  children,
+  onBlur,
+}: {
+  children: ReactNode;
+  onBlur: (evt: FocusEvent<HTMLDivElement>) => void;
+}) {
+  const { setupCloseHandler, removeCloseHandler } =
+    useSequencedContentCloseHandler();
+
+  useEffect(() => {
+    setupCloseHandler(document.body, () => undefined);
+    return () => removeCloseHandler();
+  }, [setupCloseHandler, removeCloseHandler]);
+
+  return <div onBlur={onBlur}>{children}</div>;
+}

--- a/frontend/src/metabase/querying/utils/drills/combine-columns-drill/components/ColumnPicker/index.ts
+++ b/frontend/src/metabase/querying/utils/drills/combine-columns-drill/components/ColumnPicker/index.ts
@@ -1,0 +1,1 @@
+export * from "./ColumnPicker";

--- a/frontend/src/metabase/querying/utils/drills/combine-columns-drill/components/CombineColumnsDrill/CombineColumnsDrill.tsx
+++ b/frontend/src/metabase/querying/utils/drills/combine-columns-drill/components/CombineColumnsDrill/CombineColumnsDrill.tsx
@@ -1,0 +1,181 @@
+import type { FormEventHandler } from "react";
+import { useMemo, useState } from "react";
+import { jt, t } from "ttag";
+
+import {
+  Box,
+  Button,
+  Card,
+  Flex,
+  Icon,
+  ScrollArea,
+  Stack,
+  Title,
+} from "metabase/ui";
+import * as Lib from "metabase-lib";
+
+import type { ColumnAndSeparator } from "../../types";
+import {
+  formatSeparator,
+  getDefaultSeparator,
+  getDrillExpressionClause,
+  getExample,
+  getExpressionName,
+  getNextColumnAndSeparator,
+} from "../../utils";
+import { ColumnAndSeparatorRow } from "../ColumnAndSeparatorRow";
+import { Example } from "../Example";
+
+/**
+ * Required to not cut off the outline of focused "x" button
+ */
+const OVERFLOW_SAFETY_MARGIN = 16;
+
+interface Props {
+  column: Lib.ColumnMetadata;
+  query: Lib.Query;
+  stageIndex: number;
+  onSubmit: (query: Lib.Query) => void;
+}
+
+export const CombineColumnsDrill = ({
+  column,
+  query: originalQuery,
+  stageIndex: originalStageIndex,
+  onSubmit,
+}: Props) => {
+  const columnInfo = Lib.displayInfo(originalQuery, originalStageIndex, column);
+  const { query, stageIndex } = Lib.asReturned(
+    originalQuery,
+    originalStageIndex,
+  );
+  const expressionableColumns = Lib.expressionableColumns(query, stageIndex);
+  const defaultSeparator = getDefaultSeparator(column);
+  const [isUsingDefaultSeparator, setIsUsingDefaultSeparator] = useState(true);
+  const [columnsAndSeparators, setColumnsAndSeparators] = useState([
+    {
+      column: expressionableColumns[0],
+      separator: defaultSeparator,
+    },
+  ]);
+  const expressionClause = useMemo(
+    () => getDrillExpressionClause(column, columnsAndSeparators),
+    [column, columnsAndSeparators],
+  );
+  const example = useMemo(() => {
+    return getExample(column, columnsAndSeparators);
+  }, [column, columnsAndSeparators]);
+
+  const handleChange = (index: number, change: Partial<ColumnAndSeparator>) => {
+    setColumnsAndSeparators(value => [
+      ...value.slice(0, index),
+      { ...value[index], ...change },
+      ...value.slice(index + 1),
+    ]);
+  };
+
+  const handleAdd = () => {
+    setColumnsAndSeparators(value => [
+      ...value,
+      getNextColumnAndSeparator(
+        expressionableColumns,
+        defaultSeparator,
+        columnsAndSeparators,
+      ),
+    ]);
+  };
+
+  const handleRemove = (index: number) => {
+    setColumnsAndSeparators(value => [
+      ...value.slice(0, index),
+      ...value.slice(index + 1),
+    ]);
+  };
+
+  const handleEditSeparators = () => {
+    setIsUsingDefaultSeparator(false);
+  };
+
+  const handleSubmit: FormEventHandler = event => {
+    event.preventDefault();
+
+    const name = getExpressionName(
+      query,
+      stageIndex,
+      column,
+      columnsAndSeparators,
+    );
+    const newQuery = Lib.expression(query, stageIndex, name, expressionClause);
+
+    onSubmit(newQuery);
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <Card maw="100vw" w={474} p="lg">
+        <Title
+          mb="lg"
+          order={4}
+        >{jt`Combine “${columnInfo.displayName}” with other columns`}</Title>
+
+        <Stack spacing="lg">
+          <Stack spacing={12}>
+            <ScrollArea mx={-OVERFLOW_SAFETY_MARGIN}>
+              <Box mah="50vh" px={OVERFLOW_SAFETY_MARGIN}>
+                <Stack spacing="sm">
+                  {columnsAndSeparators.map(({ column, separator }, index) => (
+                    <ColumnAndSeparatorRow
+                      query={query}
+                      stageIndex={stageIndex}
+                      column={column}
+                      columns={expressionableColumns}
+                      index={index}
+                      key={index}
+                      separator={separator}
+                      showLabels={index === 0}
+                      showRemove={columnsAndSeparators.length > 1}
+                      showSeparator={!isUsingDefaultSeparator}
+                      onChange={handleChange}
+                      onRemove={handleRemove}
+                    />
+                  ))}
+                </Stack>
+              </Box>
+            </ScrollArea>
+
+            <Flex
+              align="center"
+              gap="md"
+              justify={isUsingDefaultSeparator ? "space-between" : "end"}
+            >
+              {isUsingDefaultSeparator && (
+                <Box>
+                  <Button p={0} variant="subtle" onClick={handleEditSeparators}>
+                    {jt`Separated by ${formatSeparator(defaultSeparator)}`}
+                  </Button>
+                </Box>
+              )}
+
+              <Button
+                leftIcon={<Icon name="add" />}
+                p={0}
+                variant="subtle"
+                onClick={handleAdd}
+              >
+                {t`Add column`}
+              </Button>
+            </Flex>
+          </Stack>
+
+          <Example example={example} />
+
+          <Flex align="center" gap="md" justify="end">
+            <Button type="submit" variant="filled">
+              {t`Done`}
+            </Button>
+          </Flex>
+        </Stack>
+      </Card>
+    </form>
+  );
+};

--- a/frontend/src/metabase/querying/utils/drills/combine-columns-drill/components/CombineColumnsDrill/index.ts
+++ b/frontend/src/metabase/querying/utils/drills/combine-columns-drill/components/CombineColumnsDrill/index.ts
@@ -1,0 +1,1 @@
+export * from "./CombineColumnsDrill";

--- a/frontend/src/metabase/querying/utils/drills/combine-columns-drill/components/Example/Example.module.css
+++ b/frontend/src/metabase/querying/utils/drills/combine-columns-drill/components/Example/Example.module.css
@@ -1,0 +1,3 @@
+.scrollArea {
+  white-space: pre;
+}

--- a/frontend/src/metabase/querying/utils/drills/combine-columns-drill/components/Example/Example.tsx
+++ b/frontend/src/metabase/querying/utils/drills/combine-columns-drill/components/Example/Example.tsx
@@ -1,0 +1,35 @@
+import { t } from "ttag";
+
+import { Card, ScrollArea, Stack, Text } from "metabase/ui";
+
+import S from "./Example.module.css";
+
+interface Props {
+  example: string;
+}
+
+export const Example = ({ example }: Props) => {
+  return (
+    <Stack spacing="sm">
+      <Text color="text-medium" lh={1} weight="bold">{t`Example`}</Text>
+
+      <Card
+        bg="bg-light"
+        className={S.scrollArea}
+        component={ScrollArea}
+        p="sm"
+        radius="xs"
+        shadow="none"
+        withBorder
+      >
+        <Text
+          size="sm"
+          data-testid="combine-column-example"
+          variant="monospace"
+        >
+          {example}
+        </Text>
+      </Card>
+    </Stack>
+  );
+};

--- a/frontend/src/metabase/querying/utils/drills/combine-columns-drill/components/Example/index.ts
+++ b/frontend/src/metabase/querying/utils/drills/combine-columns-drill/components/Example/index.ts
@@ -1,0 +1,1 @@
+export * from "./Example";

--- a/frontend/src/metabase/querying/utils/drills/combine-columns-drill/components/index.ts
+++ b/frontend/src/metabase/querying/utils/drills/combine-columns-drill/components/index.ts
@@ -1,0 +1,4 @@
+export * from "./ColumnAndSeparatorRow";
+export * from "./ColumnPicker";
+export * from "./CombineColumnsDrill";
+export * from "./Example";

--- a/frontend/src/metabase/querying/utils/drills/combine-columns-drill/index.ts
+++ b/frontend/src/metabase/querying/utils/drills/combine-columns-drill/index.ts
@@ -1,0 +1,1 @@
+export * from "./combine-columns-drill";

--- a/frontend/src/metabase/querying/utils/drills/combine-columns-drill/types.ts
+++ b/frontend/src/metabase/querying/utils/drills/combine-columns-drill/types.ts
@@ -1,0 +1,6 @@
+import type * as Lib from "metabase-lib";
+
+export type ColumnAndSeparator = {
+  separator: string;
+  column: Lib.ColumnMetadata;
+};

--- a/frontend/src/metabase/querying/utils/drills/combine-columns-drill/utils.ts
+++ b/frontend/src/metabase/querying/utils/drills/combine-columns-drill/utils.ts
@@ -1,0 +1,147 @@
+import { t } from "ttag";
+
+import * as Lib from "metabase-lib";
+import type { Dataset, RowValues } from "metabase-types/api";
+
+import type { ColumnAndSeparator } from "./types";
+
+export const getNextColumnAndSeparator = (
+  expressionableColumns: Lib.ColumnMetadata[],
+  defaultSeparator: string,
+  columnsAndSeparators: ColumnAndSeparator[],
+): ColumnAndSeparator => {
+  const lastSeparator = columnsAndSeparators.at(-1)?.separator;
+  const separator = lastSeparator ?? defaultSeparator;
+
+  const nextUnusedColumn = expressionableColumns.find(candidate =>
+    columnsAndSeparators.every(({ column }) => candidate !== column),
+  );
+
+  const result = nextUnusedColumn ?? expressionableColumns[0];
+  return { column: result, separator };
+};
+
+export const formatSeparator = (separator: string): string => {
+  if (separator.length === 0) {
+    return `(${t`empty`})`;
+  }
+
+  if (separator === " ") {
+    return `(${t`space`})`;
+  }
+
+  return separator;
+};
+
+export const extractQueryResults = (
+  query: Lib.Query,
+  stageIndex: number,
+  datasets: Dataset[] | null,
+): {
+  columns: Lib.ColumnMetadata[];
+  rows: RowValues[];
+} => {
+  if (!datasets || datasets.length === 0) {
+    return { columns: [], rows: [] };
+  }
+
+  const data = datasets[0].data;
+  const rows = data.rows;
+
+  const columns = data.results_metadata.columns.map(column => {
+    return Lib.fromLegacyColumn(query, stageIndex, column);
+  });
+
+  return { rows, columns };
+};
+
+export const getExample = (
+  column: Lib.ColumnMetadata,
+  columnsAndSeparators: ColumnAndSeparator[],
+): string => {
+  return [
+    getColumnExample(column),
+    ...columnsAndSeparators.flatMap(({ column, separator }) => [
+      separator,
+      getColumnExample(column),
+    ]),
+  ].join("");
+};
+
+const getColumnExample = (column: Lib.ColumnMetadata): string => {
+  if (Lib.isURL(column)) {
+    return "https://www.example.com";
+  }
+
+  if (Lib.isEmail(column)) {
+    return "email@example.com";
+  }
+
+  if (Lib.isID(column)) {
+    return "12345";
+  }
+
+  if (Lib.isBoolean(column)) {
+    return "true";
+  }
+
+  if (Lib.isNumeric(column)) {
+    return "123.45678901234567";
+  }
+
+  if (Lib.isDateWithoutTime(column)) {
+    return "2042-01-01";
+  }
+
+  if (Lib.isDate(column)) {
+    return "2042-01-01 12:34:56.789";
+  }
+
+  if (Lib.isTime(column)) {
+    return "12:34:56.789";
+  }
+
+  if (Lib.isLatitude(column) || Lib.isLongitude(column)) {
+    return "-12.34567";
+  }
+
+  return "text";
+};
+
+export const getDefaultSeparator = (column: Lib.ColumnMetadata): string => {
+  if (Lib.isURL(column)) {
+    return "/";
+  }
+
+  if (Lib.isEmail(column)) {
+    return "";
+  }
+
+  return " ";
+};
+
+export const getDrillExpressionClause = (
+  column: Lib.ColumnMetadata,
+  columnsAndSeparators: ColumnAndSeparator[],
+) => {
+  return Lib.expressionClause("concat", [
+    column,
+    ...columnsAndSeparators.flatMap(({ column, separator }) => [
+      separator,
+      column,
+    ]),
+  ]);
+};
+
+export const getExpressionName = (
+  query: Lib.Query,
+  stageIndex: number,
+  column: Lib.ColumnMetadata,
+  columnsAndSeparators: ColumnAndSeparator[],
+): string => {
+  const columns = [column, ...columnsAndSeparators.map(({ column }) => column)];
+  const names = columns.map(
+    column => Lib.displayInfo(query, stageIndex, column).displayName,
+  );
+  return names.join(" ");
+};

--- a/frontend/src/metabase/querying/utils/drills/constants.ts
+++ b/frontend/src/metabase/querying/utils/drills/constants.ts
@@ -4,6 +4,7 @@ import type * as Lib from "metabase-lib";
 import { automaticInsightsDrill } from "./automatic-insights-drill";
 import { columnExtractDrill } from "./column-extract-drill";
 import { columnFilterDrill } from "./column-filter-drill";
+import { combineColumnsDrill } from "./combine-columns-drill";
 import { distributionDrill } from "./distribution-drill";
 import { fkDetailsDrill } from "./fk-details-drill";
 import { fkFilterDrill } from "./fk-filter-drill";
@@ -23,6 +24,7 @@ export const DRILLS: Record<Lib.DrillThruType, Drill<any>> = {
   "drill-thru/automatic-insights": automaticInsightsDrill,
   "drill-thru/column-extract": columnExtractDrill,
   "drill-thru/column-filter": columnFilterDrill,
+  "drill-thru/combine-columns": combineColumnsDrill,
   "drill-thru/distribution": distributionDrill,
   "drill-thru/fk-details": fkDetailsDrill,
   "drill-thru/fk-filter": fkFilterDrill,

--- a/frontend/src/metabase/visualizations/components/ClickActions/utils.ts
+++ b/frontend/src/metabase/visualizations/components/ClickActions/utils.ts
@@ -21,6 +21,8 @@ export const SECTIONS: Record<ClickActionSection, Section> = {
   sum: {},
   extract: {},
   "extract-popover": {},
+  combine: {},
+  "combine-popover": {},
   auto: {},
   "auto-popover": {},
   info: {},

--- a/frontend/src/metabase/visualizations/types/click-actions.ts
+++ b/frontend/src/metabase/visualizations/types/click-actions.ts
@@ -27,6 +27,8 @@ export type ClickActionSection =
   | "auto-popover"
   | "breakout"
   | "breakout-popover"
+  | "combine"
+  | "combine-popover"
   | "details"
   | "extract"
   | "extract-popover"


### PR DESCRIPTION
_The changeset from https://github.com/metabase/metabase/pull/40082, but into merges into `master` instead_

Closes #39980

### Description
Adds combine column drill through to the chill mode header columns.


### How to verify

- Open the `Accounts` table in chill mode
- Click the header of a string column (eg. `Email`, `First Name` or `Plan`)
- Click `+ Combine columns`
- Play around with the column editor
- Click `Done`
- Verify the new column is added as the last column


### Demo

See video attached to [this Slack message](https://metaboat.slack.com/archives/C0645JP1W81/p1710427151050319)

<img width="361" alt="Screenshot 2024-04-19 at 14 52 22" src="https://github.com/metabase/metabase/assets/1250185/e57de922-897d-4446-8f23-8e77fe283435">
<img width="528" alt="Screenshot 2024-04-19 at 14 52 26" src="https://github.com/metabase/metabase/assets/1250185/d546f3df-efcd-49b7-bfbc-1df67b81b5d3">
<img width="502" alt="Screenshot 2024-04-19 at 14 52 34" src="https://github.com/metabase/metabase/assets/1250185/029e83a1-830e-483b-af46-f05dccf4cc21">
