### PR TITLE
Bump react-embedding-sdk version and copy README to output

### DIFF
--- a/bin/embedding-sdk/generate-sdk-package-files.js
+++ b/bin/embedding-sdk/generate-sdk-package-files.js
@@ -67,14 +67,18 @@ function generateSdkPackage() {
   );
 }
 
-function generateLicenseFile() {
+/**
+ * @param {string} source
+ * @param {string} target
+ */
+function copyFileToOutput(source, target = source) {
   const licenseContent = fs.readFileSync(
-    path.resolve(`./enterprise/LICENSE.txt`),
+    path.resolve(`./enterprise/${source}`),
     "utf-8",
   );
 
   fs.writeFileSync(
-    path.resolve(path.join(SDK_DIST_DIR), "LICENSE.txt"),
+    path.resolve(path.join(SDK_DIST_DIR), target),
     licenseContent,
     "utf-8",
   );
@@ -85,4 +89,5 @@ if (!fs.existsSync(SDK_DIST_DIR)) {
 }
 
 generateSdkPackage();
-generateLicenseFile();
+copyFileToOutput("LICENSE.txt");
+copyFileToOutput("frontend/src/embedding-sdk/README.md", "README.md");

--- a/bin/embedding-sdk/generate-sdk-package-files.js
+++ b/bin/embedding-sdk/generate-sdk-package-files.js
@@ -72,7 +72,7 @@ function generateSdkPackage() {
  * @param {string} target
  */
 function copyFileToOutput(source, target = source) {
-  const licenseContent = fs.readFileSync(
+  const fileContent = fs.readFileSync(
     path.resolve(`./enterprise/${source}`),
     "utf-8",
   );

--- a/bin/embedding-sdk/generate-sdk-package-files.js
+++ b/bin/embedding-sdk/generate-sdk-package-files.js
@@ -79,7 +79,7 @@ function copyFileToOutput(source, target = source) {
 
   fs.writeFileSync(
     path.resolve(path.join(SDK_DIST_DIR), target),
-    licenseContent,
+    fileContent,
     "utf-8",
   );
 }

--- a/enterprise/frontend/src/embedding-sdk/package.template.json
+++ b/enterprise/frontend/src/embedding-sdk/package.template.json
@@ -1,6 +1,6 @@
 {
-  "name": "metabase-embedding-sdk-react",
-  "version": "0.1.1",
+  "name": "@metabase/embedding-sdk-react",
+  "version": "0.1.0",
   "description": "Metabase React Embedding SDK",
   "repository": {
     "url": "git+https://github.com/metabase/metabase.git"

--- a/enterprise/frontend/src/embedding-sdk/package.template.json
+++ b/enterprise/frontend/src/embedding-sdk/package.template.json
@@ -1,7 +1,7 @@
 {
   "name": "@metabase/embedding-sdk-react",
   "version": "0.1.0",
-  "description": "Metabase React Embedding SDK",
+  "description": "Metabase Embedding SDK for React",
   "repository": {
     "url": "git+https://github.com/metabase/metabase.git"
   },

--- a/enterprise/frontend/src/embedding-sdk/package.template.json
+++ b/enterprise/frontend/src/embedding-sdk/package.template.json
@@ -1,7 +1,7 @@
 {
   "name": "@metabase/embedding-sdk-react",
-  "version": "0.0.3",
-  "description": "Metabase Embedding SDK",
+  "version": "0.1.0",
+  "description": "Metabase React Embedding SDK",
   "repository": {
     "url": "git+https://github.com/metabase/metabase.git"
   },

--- a/enterprise/frontend/src/embedding-sdk/package.template.json
+++ b/enterprise/frontend/src/embedding-sdk/package.template.json
@@ -1,6 +1,6 @@
 {
-  "name": "@metabase/embedding-sdk-react",
-  "version": "0.1.0",
+  "name": "metabase-embedding-sdk-react",
+  "version": "0.1.1",
   "description": "Metabase React Embedding SDK",
   "repository": {
     "url": "git+https://github.com/metabase/metabase.git"


### PR DESCRIPTION
Bumps the version of `@metabase/embedding-sdk-react` to `0.1.0`, and copy the README.md file to the output bundle for display in NPM registry. 🚀 