### PR TITLE
Fix invalid reducer key warning in frontend unit test's initial state

### DIFF
--- a/frontend/src/metabase-types/store/mocks/state.ts
+++ b/frontend/src/metabase-types/store/mocks/state.ts
@@ -1,7 +1,7 @@
 import type { SdkStoreState } from "embedding-sdk/store/types";
 import type { EnterpriseState } from "metabase-enterprise/settings/types";
 import { createMockUser } from "metabase-types/api/mocks";
-import type { State, StateWithSdk } from "metabase-types/store";
+import type { State } from "metabase-types/store";
 
 import { createMockAdminState } from "./admin";
 import { createMockAppState } from "./app";
@@ -20,7 +20,7 @@ import { createMockUploadState } from "./upload";
 
 export function createMockState<S extends Pick<SdkStoreState, "sdk">>(
   opts?: S,
-): StateWithSdk;
+): SdkStoreState;
 export function createMockState(
   opts?: Partial<State> | Partial<EnterpriseState>,
 ): State;

--- a/frontend/src/metabase-types/store/mocks/state.ts
+++ b/frontend/src/metabase-types/store/mocks/state.ts
@@ -1,8 +1,7 @@
 import type { SdkStoreState } from "embedding-sdk/store/types";
-import { createMockSdkState } from "embedding-sdk/test/mocks/state";
 import type { EnterpriseState } from "metabase-enterprise/settings/types";
 import { createMockUser } from "metabase-types/api/mocks";
-import type { State } from "metabase-types/store";
+import type { State, StateWithSdk } from "metabase-types/store";
 
 import { createMockAdminState } from "./admin";
 import { createMockAppState } from "./app";
@@ -19,25 +18,30 @@ import { createMockSettingsState } from "./settings";
 import { createMockSetupState } from "./setup";
 import { createMockUploadState } from "./upload";
 
-export const createMockState = (
-  opts?: Partial<State> | Partial<EnterpriseState> | Partial<SdkStoreState>,
-): State => ({
-  admin: createMockAdminState(),
-  app: createMockAppState(),
-  auth: createMockAuthState(),
-  currentUser: createMockUser(),
-  dashboard: createMockDashboardState(),
-  embed: createMockEmbedState(),
-  entities: createMockNormalizedEntitiesState(),
-  metabot: createMockMetabotState(),
-  parameters: createMockParametersState(),
-  qb: createMockQueryBuilderState(),
-  requests: createMockRequestsState(),
-  routing: createMockRoutingState(),
-  settings: createMockSettingsState(),
-  setup: createMockSetupState(),
-  upload: createMockUploadState(),
-  modal: null,
-  sdk: createMockSdkState(),
-  ...opts,
-});
+export function createMockState<S extends Pick<SdkStoreState, "sdk">>(
+  opts?: S,
+): StateWithSdk;
+export function createMockState(
+  opts?: Partial<State> | Partial<EnterpriseState>,
+): State;
+export function createMockState(opts: any) {
+  return {
+    admin: createMockAdminState(),
+    app: createMockAppState(),
+    auth: createMockAuthState(),
+    currentUser: createMockUser(),
+    dashboard: createMockDashboardState(),
+    embed: createMockEmbedState(),
+    entities: createMockNormalizedEntitiesState(),
+    metabot: createMockMetabotState(),
+    parameters: createMockParametersState(),
+    qb: createMockQueryBuilderState(),
+    requests: createMockRequestsState(),
+    routing: createMockRoutingState(),
+    settings: createMockSettingsState(),
+    setup: createMockSetupState(),
+    upload: createMockUploadState(),
+    modal: null,
+    ...opts,
+  };
+}

--- a/frontend/src/metabase-types/store/state.ts
+++ b/frontend/src/metabase-types/store/state.ts
@@ -1,6 +1,5 @@
 import type { RouterState } from "react-router-redux";
 
-import type { SdkState } from "embedding-sdk/store/types";
 import type { User } from "metabase-types/api";
 
 import type { AdminState } from "./admin";
@@ -35,10 +34,6 @@ export interface State {
   setup: SetupState;
   upload: FileUploadState;
   modal: modalName;
-}
-
-export interface StateWithSdk extends State {
-  sdk: SdkState;
 }
 
 export type Dispatch<T = any> = (action: T) => unknown | Promise<unknown>;

--- a/frontend/src/metabase-types/store/state.ts
+++ b/frontend/src/metabase-types/store/state.ts
@@ -35,6 +35,9 @@ export interface State {
   setup: SetupState;
   upload: FileUploadState;
   modal: modalName;
+}
+
+export interface StateWithSdk extends State {
   sdk: SdkState;
 }
 

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -14,6 +14,8 @@ import _ from "underscore";
 
 import { AppInitializeController } from "embedding-sdk/components/private/AppInitializeController";
 import { sdkReducers } from "embedding-sdk/store";
+import type { SdkStoreState } from "embedding-sdk/store/types";
+import { createMockSdkState } from "embedding-sdk/test/mocks/state";
 import type { SDKConfig } from "embedding-sdk/types";
 import { Api } from "metabase/api";
 import { UndoListing } from "metabase/containers/UndoListing";
@@ -72,7 +74,10 @@ export function renderWithProviders(
     initialState = _.pick(initialState, ...publicReducerNames) as State;
   } else if (mode === "sdk") {
     const sdkReducerNames = Object.keys(sdkReducers);
-    initialState = _.pick(initialState, ...sdkReducerNames) as State;
+    initialState = _.pick(
+      { sdk: createMockSdkState(), ...initialState },
+      ...sdkReducerNames,
+    ) as SdkStoreState;
   }
 
   // We need to call `useRouterHistory` to ensure the history has a `query` object,


### PR DESCRIPTION
[Reported on Slack](https://metaboat.slack.com/archives/C505ZNNH4/p1714408885110209)

### Description

Frontend unit tests currently returns this warning. This is caused by the initial state not matching the testing mode.

```sh
    > 15 |   return configureStore({
         |                        ^
      16 |     reducer,
      17 |     preloadedState: initialState,
      18 |     middleware: getDefaultMiddleware =>

      at warning (node_modules/redux/lib/redux.js:434:13)
      at combination (node_modules/redux/lib/redux.js:557:9)
      at dispatch (node_modules/redux/lib/redux.js:296:22)
      at createStore (node_modules/redux/lib/redux.js:382:3)
      at node_modules/redux/lib/redux.js:690:31
      at createStore (node_modules/redux/lib/redux.js:162:33)
      at configureStore (node_modules/@reduxjs/toolkit/src/configureStore.ts:210:10)
      at getStore (frontend/test/__support__/entities-store.js:15:24)
      at renderWithProviders (frontend/test/__support__/ui.tsx:109:25)
      at setup (frontend/src/metabase/containers/DataPicker/tests/common.tsx:255:22)
      at Object.<anonymous> (frontend/src/metabase/containers/DataPicker/tests/DataPicker-Questions.unit.spec.ts:167:37)

  console.error
    Unexpected key "sdk" found in preloadedState argument passed to createStore. Expected to find one of the known reducer keys instead: "entities", "requests", "app", "embed", "currentUser", "settings", "undo", "upload", "auth", "metabase-api", "modal", "alert", "dashboard", "parameters", "metabot", "pulse", "qb", "reference", "revisions", "setup", "admin", "plugins". Unexpected keys will be ignored.
```

### How to verify

Run the frontend unit test again, such as `frontend/src/metabase/containers/DataPicker/tests/DataPicker-Questions.unit.spec.ts`. There shouldn't be such warning again.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

