### PR TITLE
Add patches to `package.json`

### DIFF
--- a/bin/embedding-sdk/generate-sdk-package-files.js
+++ b/bin/embedding-sdk/generate-sdk-package-files.js
@@ -46,13 +46,17 @@ function generateSdkPackage() {
 
   const mergedContent = {
     ...sdkPackageTemplateJsonContent,
-    dependencies: filterOutReactDependencies(
-      mainPackageJsonContent.dependencies,
-    ),
+    dependencies: {
+      ...filterOutReactDependencies(mainPackageJsonContent.dependencies),
+      "patch-package": "^8.0.0",
+    },
     resolutions: filterOutReactDependencies(mainPackageJsonContent.resolutions),
     version: maybeCommitHash
       ? `${sdkPackageTemplateJsonContent.version}-${todayDate}-${maybeCommitHash}`
       : sdkPackageTemplateJsonContent.version,
+    scripts: {
+      postinstall: "patch-package",
+    },
   };
 
   const mergedContentString = JSON.stringify(mergedContent, null, 2);

--- a/bin/embedding-sdk/generate-sdk-package-files.js
+++ b/bin/embedding-sdk/generate-sdk-package-files.js
@@ -48,7 +48,7 @@ function generateSdkPackage() {
     ...sdkPackageTemplateJsonContent,
     dependencies: {
       ...filterOutReactDependencies(mainPackageJsonContent.dependencies),
-      "patch-package": "^8.0.0",
+      "patch-package": mainPackageJsonContent.devDependencies["patch-package"],
     },
     resolutions: filterOutReactDependencies(mainPackageJsonContent.resolutions),
     version: maybeCommitHash

--- a/package.json
+++ b/package.json
@@ -363,7 +363,7 @@
     "dev-ee": "yarn && yarn clean:cljs && concurrently -n 'backend,frontend,cljs,static-viz' -c 'blue,green,yellow,magenta,red' 'clojure -M:run:ee' 'MB_EDITION=ee yarn build-hot:js-wait' 'MB_EDITION=ee yarn build-hot:cljs' 'yarn build-static-viz:watch-wait'",
     "docs-lint-links": "find docs -type f -name '*.md' -print0 | xargs -0 markdown-link-check --quiet --config .mlc_config.json",
     "embedding-sdk:fixup-types-imports": "node ./bin/embedding-sdk/fixup-types-after-compilation.js",
-    "embedding-sdk:generate-package": "node ./bin/embedding-sdk/generate-sdk-package-files.js",
+    "embedding-sdk:generate-package": "cp -r patches resources/embedding-sdk/ && node ./bin/embedding-sdk/generate-sdk-package-files.js",
     "embedding-sdk:publish": "cd ./resources/embedding-sdk && npm publish",
     "eslint-fix": "yarn lint-eslint --fix",
     "generate-cypress-html-report": "mochawesome-merge cypress/reports/mochareports/*.json > cypress/reports/cypress-test-report.json && marge cypress/reports/cypress-test-report.json -o cypress/reports/mochareports --inline",


### PR DESCRIPTION
### Description

Adds patch `postinstall` script to the Embedding SDK package.json

### How to verify

Setup the SDK with a client app. 

Go to `DevTools > Sources`. Go to `localhost:[whatever your client app port is]`.

In the file directory, go to `node_modules/echarts/lib/chart/line/helper.js` .

On line 110, see that the function is now:

```
export function getStackedOnPoint(dataCoordInfo, coordSys, data, idx) {
  let stackedOverValue = NaN;
  let stackResultValue = NaN;
  if (dataCoordInfo.stacked) {
    stackedOverValue = data.get(data.getCalculationInfo('stackedOverDimension'), idx);
    stackResultValue = data.get(data.getCalculationInfo('stackResultDimension'), idx);
  }
  if (isNaN(stackedOverValue) && !(dataCoordInfo.stacked && isNaN(stackResultValue))) {
    stackedOverValue = dataCoordInfo.valueStart;
}
  var baseDataOffset = dataCoordInfo.baseDataOffset;
  var stackedData = [];
  stackedData[baseDataOffset] = data.get(dataCoordInfo.baseDim, idx);
  stackedData[1 - baseDataOffset] = stackedOverValue;
  return coordSys.dataToPoint(stackedData);
}
```

Then, on `node_modules/echarts/lib/data/helper/dataStackHelper.js`, see that on line 87:
```
var yCoordDimension = dimensionDefineList.find(
    dimensionInfo => !isString(dimensionInfo) && dimensionInfo.coordDim === 'y'
  );
  var isYCoordDimensionStackable = yCoordDimension != null
    && yCoordDimension.type !== 'ordinal' && yCoordDimension.type !== 'time';
```

and on line 113:
```
  if (stackedDimInfo && !byIndex && !stackedByDimInfo) {
    // Compatible with previous design, value axis (time axis) only stack by index.
    // It may make sense if the user provides elaborately constructed data.
    byIndex = true;
  }
```

If you want to verify the patch manually, the diff can be found at:
```
metabase/patches/echarts+5.5.0.patch
```