### PR TITLE
Remove "dataset duration" endpoint

### DIFF
--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -329,7 +329,6 @@ export const MetabaseApi = {
   field_remapping: GET("/api/field/:fieldId/remapping/:remappedFieldId"),
   dataset: POST("/api/dataset"),
   dataset_pivot: POST("/api/dataset/pivot"),
-  dataset_duration: POST("/api/dataset/duration"),
   native: POST("/api/dataset/native"),
 
   // to support audit app  allow the endpoint to be provided in the query

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -16,7 +16,6 @@
    [metabase.models.database :as database :refer [Database]]
    [metabase.models.params.custom-values :as custom-values]
    [metabase.models.persisted-info :as persisted-info]
-   [metabase.models.query :as query]
    [metabase.models.table :refer [Table]]
    [metabase.query-processor :as qp]
    [metabase.query-processor.compile :as qp.compile]
@@ -150,19 +149,6 @@
 
 
 ;;; ------------------------------------------------ Other Endpoints -------------------------------------------------
-
-;; TODO - this is no longer used. Should we remove it?
-(api/defendpoint POST "/duration"
-  "Get historical query execution duration."
-  [:as {{:keys [database], :as query} :body}]
-  (api/read-check Database database)
-  ;; try calculating the average for the query as it was given to us, otherwise with the default constraints if
-  ;; there's no data there. If we still can't find relevant info, just default to 0
-  {:average (or
-             (some (comp query/average-execution-time-ms qp.util/query-hash)
-                   [query
-                    (assoc query :constraints (qp.constraints/default-query-constraints))])
-             0)})
 
 (api/defendpoint POST "/native"
   "Fetch a native version of an MBQL query."


### PR DESCRIPTION
This PR removes an endpoint which was marked as unused *seven* years ago.

I would've left the endpoint on the backend and only remove the unused frontend part, but I decided to remove it for two reasons:
- It has been unused for seven years
- There are no tests for it