### PR TITLE
Use default display for metrics

### DIFF
--- a/frontend/src/metabase/lib/icon.ts
+++ b/frontend/src/metabase/lib/icon.ts
@@ -24,7 +24,7 @@ const modelIconMap: Record<SearchModel, IconName> = {
   dashboard: "dashboard",
   card: "table",
   segment: "segment",
-  metric: "funnel",
+  metric: "metric",
   snippet: "snippet",
 };
 

--- a/frontend/src/metabase/lib/urls/misc.js
+++ b/frontend/src/metabase/lib/urls/misc.js
@@ -28,6 +28,8 @@ export function modelToUrl(item) {
       return question(modelData);
     case "dataset":
       return model(modelData);
+    case "metric":
+      return question(modelData);
     case "dashboard":
       return dashboard(modelData);
     case "pulse":

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -351,8 +351,7 @@ export const getQuestion = createSelector(
     if (!question) {
       return;
     }
-    const isEditingModel = queryBuilderMode === "dataset";
-    if (isEditingModel) {
+    if (question.type() === "model" && queryBuilderMode === "dataset") {
       return question.lockDisplay();
     }
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/42028

How to verify:
- New -> Metric -> Orders -> Count
- Click play or save
- You should see a scalar

<img width="1728" alt="Screenshot 2024-04-30 at 10 13 50" src="https://github.com/metabase/metabase/assets/8542534/e9ed2434-8b7d-4042-a52f-efda8c461351">
