### PR TITLE
Fix Embedding SDK readme typo

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/README.md
+++ b/enterprise/frontend/src/embedding-sdk/README.md
@@ -120,7 +120,7 @@ app.listen(PORT, () => {
 
 ## Installation
 
-You can install Metabase Embedding SDK for react via npm:
+You can install Metabase Embedding SDK for React via npm:
 
 ```bash
 npm install @metabase/embedding-sdk-react


### PR DESCRIPTION
Fix a typo in Metabase Embedding SDK for React README file
