### PR TITLE
Migrate embedding SDK reducers to use redux toolkit's builder callback

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/store/reducer.ts
+++ b/enterprise/frontend/src/embedding-sdk/store/reducer.ts
@@ -1,6 +1,4 @@
-import type { PayloadAction } from "@reduxjs/toolkit";
-import { createReducer } from "@reduxjs/toolkit";
-import { createAction } from "redux-actions";
+import { createReducer, createAction } from "@reduxjs/toolkit";
 
 import type { SdkPluginsConfig } from "embedding-sdk/lib/plugins";
 import type {
@@ -70,69 +68,50 @@ const initialState: SdkState = {
   errorComponent: null,
 };
 
-export const sdk = createReducer(initialState, {
-  [refreshTokenAsync.pending.type]: state => {
-    return {
-      ...state,
-      token: {
-        ...state.token,
-        loading: true,
-      },
-    };
-  },
-  [refreshTokenAsync.fulfilled.type]: (state, action) => {
-    return {
-      ...state,
-      token: {
-        ...state.token,
-        token: action.payload,
-        error: null,
-        loading: false,
-      },
-    };
-  },
-  [refreshTokenAsync.rejected.type]: (state, action) => {
-    return {
-      ...state,
-      isLoggedIn: false,
-      token: {
-        ...state.token,
-        token: null,
-        error: action.error,
-        loading: false,
-      },
-    };
-  },
-  [SET_LOGIN_STATUS]: (state, action: PayloadAction<LoginStatus>) => {
-    return {
-      ...state,
-      loginStatus: action.payload,
-    };
-  },
-  [SET_PLUGINS]: (state, action: PayloadAction<SdkPluginsConfig | null>) => {
-    return {
-      ...state,
-      plugins: action.payload,
-    };
-  },
-  [SET_LOADER_COMPONENT]: (
-    state,
-    action: PayloadAction<null | (() => JSX.Element)>,
-  ) => {
-    return {
-      ...state,
-      loaderComponent: action.payload,
-    };
-  },
-  [SET_ERROR_COMPONENT]: (
-    state,
-    action: PayloadAction<
-      null | (({ message }: { message: string }) => JSX.Element)
-    >,
-  ) => {
-    return {
-      ...state,
-      errorComponent: action.payload,
-    };
-  },
+export const sdk = createReducer(initialState, builder => {
+  builder.addCase(refreshTokenAsync.pending, state => ({
+    ...state,
+    token: { ...state.token, loading: true },
+  }));
+
+  builder.addCase(refreshTokenAsync.fulfilled, (state, action) => ({
+    ...state,
+    token: {
+      ...state.token,
+      token: action.payload,
+      error: null,
+      loading: false,
+    },
+  }));
+
+  builder.addCase(refreshTokenAsync.rejected, (state, action) => ({
+    ...state,
+    isLoggedIn: false,
+    token: {
+      ...state.token,
+      token: null,
+      error: action.error,
+      loading: false,
+    },
+  }));
+
+  builder.addCase(setLoginStatus, (state, action) => ({
+    ...state,
+    loginStatus: action.payload,
+  }));
+
+  builder.addCase(setLoaderComponent, (state, action) => ({
+    ...state,
+    loaderComponent: action.payload,
+  }));
+
+  builder.addCase(setPlugins, (state, action) => ({
+    ...state,
+    plugins: action.payload,
+  }));
+
+  builder.addCase(setErrorComponent, (state, action) => ({
+    ...state,
+    errorComponent: action.payload,
+  }));
 });


### PR DESCRIPTION
### Description

The following warning regarding reducer object notation is shown in the console. This PR migrates the reducer to use the builder callback notion.

```bash
  console.warn
    The object notation for `createReducer` is deprecated, and will be removed in RTK 2.0. Please use the 'builder callback' notation instead: https://redux-toolkit.js.org/api/createReducer

      71 | };
      72 |
    > 73 | export const sdk = createReducer(initialState, {
         |                                 ^
      74 |   [refreshTokenAsync.pending.type]: state => {
      75 |     return {
      76 |       ...state,

      at createReducer (node_modules/@reduxjs/toolkit/src/createReducer.ts:228:17)
      at Object.<anonymous> (enterprise/frontend/src/embedding-sdk/store/reducer.ts:73:33)
      at Object.require (enterprise/frontend/src/embedding-sdk/store/index.ts:14:1)
      at Object.require (enterprise/frontend/src/embedding-sdk/hooks/public/use-question-search.ts:3:1)
      at Object.require (enterprise/frontend/src/embedding-sdk/hooks/public/index.ts:3:1)
      at Object.require (enterprise/frontend/src/embedding-sdk/hooks/index.ts:1:1)
      at Object.require (enterprise/frontend/src/embedding-sdk/components/private/AppInitializeController.tsx:8:1)
      at Object.require (frontend/test/__support__/ui.tsx:15:1)
      at Object.require (enterprise/frontend/src/embedding-sdk/components/private/PublicComponentWrapper/PublicComponentWrapper.unit.spec.tsx:1:1)
```

### How to verify

- Running tests such as `yarn jest PublicComponentWrapper` should no longer show the above error.