### PR TITLE
Remove unused `db_candidates` endpoint reference from the `services.js`

### DIFF
--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -253,7 +253,6 @@ export const AutoApi = {
     // this prevents the `subPath` parameter from being URL encoded
     raw: { subPath: true },
   }),
-  db_candidates: GET("/api/automagic-dashboards/database/:id/candidates"),
 };
 
 export const EmailApi = {


### PR DESCRIPTION
### Description
This PR removes (now unused) endpoint reference from the `services.js`

### How to check?
Search the whole codebase for `AutoApi`. You should not find `AutoApi.db_candidates`.
Or search for `db_candidates` directly.