### PR TITLE
Change utm tags for embedding homepage links

### DIFF
--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.tsx
@@ -47,7 +47,7 @@ export const EmbedHomepage = () => {
     getPlan(getSetting(state, "token-features")),
   );
 
-  const utmTags = `?utm_source=${plan}&utm_media=embedding-homepage`;
+  const utmTags = `?utm_source=product&source_plan=${plan}&utm_media=embedding-homepage`;
 
   const initialTab = useMemo(() => {
     // we want to show the interactive tab for EE builds

--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.tsx
@@ -47,7 +47,7 @@ export const EmbedHomepage = () => {
     getPlan(getSetting(state, "token-features")),
   );
 
-  const utmTags = `?utm_source=product&source_plan=${plan}&utm_media=embedding-homepage`;
+  const utmTags = `?utm_source=product&source_plan=${plan}&utm_content=embedding-homepage`;
 
   const initialTab = useMemo(() => {
     // we want to show the interactive tab for EE builds

--- a/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
@@ -27,7 +27,7 @@ describe("EmbedHomepage (OSS)", () => {
     setup();
     expect(screen.getByText("Learn more")).toHaveAttribute(
       "href",
-      "https://www.metabase.com/docs/latest/embedding/static-embedding.html?utm_source=product&source_plan=oss&utm_media=embedding-homepage",
+      "https://www.metabase.com/docs/latest/embedding/static-embedding.html?utm_source=product&source_plan=oss&utm_content=embedding-homepage",
     );
   });
 

--- a/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
@@ -27,7 +27,7 @@ describe("EmbedHomepage (OSS)", () => {
     setup();
     expect(screen.getByText("Learn more")).toHaveAttribute(
       "href",
-      "https://www.metabase.com/docs/latest/embedding/static-embedding.html?utm_source=oss&utm_media=embedding-homepage",
+      "https://www.metabase.com/docs/latest/embedding/static-embedding.html?utm_source=product&source_plan=oss&utm_media=embedding-homepage",
     );
   });
 


### PR DESCRIPTION
Part of MS4 of [[Epic] Initial homepage experience for embedding admins](https://github.com/metabase/metabase/issues/40005)

[UTM spec](https://www.notion.so/metabase/Upsell-System-Guidelines-72ce6f7402fb4c93a165e904dcf7a93c?pvs=4#39beb2823d5e40c394e45ec122098cc5)

# Description
This PR updates the utm tags after the discussion on this slack thread: https://metaboat.slack.com/archives/C063Q3F1HPF/p1713357720005299