### PR TITLE
Fix flaky dashboard subscription test

### DIFF
--- a/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
@@ -216,36 +216,30 @@ describe("scenarios > dashboard > subscriptions", () => {
     });
 
     describe("let non-users unsubscribe from subscriptions", () => {
-      it(
-        "should allow non-user to unsubscribe from subscription",
-        { tags: "@flaky" },
-        () => {
-          const nonUserEmail = "non-user@example.com";
-          const otherUserEmail = "other-user@example.com";
-          const dashboardName = "Orders in a dashboard";
+      it("should allow non-user to unsubscribe from subscription", () => {
+        const nonUserEmail = "non-user@example.com";
+        const dashboardName = "Orders in a dashboard";
 
-          visitDashboard(ORDERS_DASHBOARD_ID);
+        visitDashboard(ORDERS_DASHBOARD_ID);
 
-          setupSubscriptionWithRecipients([nonUserEmail, otherUserEmail]);
+        setupSubscriptionWithRecipients([nonUserEmail]);
 
-          emailSubscriptionRecipients();
+        emailSubscriptionRecipients();
 
-          openEmailPage(dashboardName).then(() => {
-            cy.intercept("/api/session/pulse/unsubscribe").as("unsubscribe");
-            cy.findByText("Unsubscribe").click();
-            cy.wait("@unsubscribe");
-            cy.contains(
-              `You've unsubscribed ${nonUserEmail} from the "${dashboardName}" alert.`,
-            ).should("exist");
-          });
+        openEmailPage(dashboardName).then(() => {
+          cy.intercept("/api/session/pulse/unsubscribe").as("unsubscribe");
+          cy.findByText("Unsubscribe").click();
+          cy.wait("@unsubscribe");
+          cy.contains(
+            `You've unsubscribed ${nonUserEmail} from the "${dashboardName}" alert.`,
+          ).should("exist");
+        });
 
-          openDashboardSubscriptions();
-          openPulseSubscription();
+        openDashboardSubscriptions();
+        openPulseSubscription();
 
-          sidebar().findByText(nonUserEmail).should("not.exist");
-          sidebar().findByText(otherUserEmail).should("exist");
-        },
-      );
+        sidebar().findByText(nonUserEmail).should("not.exist");
+      });
 
       it("should allow non-user to undo-unsubscribe from subscription", () => {
         const nonUserEmail = "non-user@example.com";


### PR DESCRIPTION
Fixes a flaky test in the dashboard subscription e2e test suite.

The test creates a dashboard subscription for two users, sends a subscription email, opens the maildev client, and unsubscribes a user from the subscription. The test asserts that the "non-user@example.com" user is always the one who gets unsubscribed, but sometimes, the test fails as it actually unsubscribes the other user. It happens because we're just opening the first email in maildev, but the order of emails sent isn't deterministic: sometimes user A's email is first, and sometimes it's vice versa. I couldn't find a simple way to distinguish the two emails in maildev without adding way more logic to the test, so the PR just removes the other user

[Stress tested (20 times)](https://github.com/metabase/metabase/actions/runs/8898302129)