### PR TITLE
[Blocked] FE metadata changes for metrics

### DIFF
--- a/frontend/src/metabase-lib/metadata.ts
+++ b/frontend/src/metabase-lib/metadata.ts
@@ -218,15 +218,22 @@ export function queryDisplayInfo(query: Query): QueryDisplayInfo {
 }
 
 export function dependentMetadata(
-  queryOrMetadataProvider: Query | MetadataProvider,
+  metadataProvider: MetadataProvider,
+  tableId: TableId,
+): DependentItem[];
+export function dependentMetadata(
+  query: Query,
   cardId: CardId | undefined,
   cardType: CardType,
-  tableId?: TableId,
+): DependentItem[];
+export function dependentMetadata(
+  queryOrMetadataProvider: Query | MetadataProvider,
+  cardOrTableId: TableId | CardId | undefined,
+  cardType?: CardType,
 ): DependentItem[] {
   return ML.dependent_metadata(
     queryOrMetadataProvider,
-    cardId,
+    cardOrTableId,
     cardType,
-    tableId,
   );
 }

--- a/frontend/src/metabase-lib/metadata.ts
+++ b/frontend/src/metabase-lib/metadata.ts
@@ -218,22 +218,16 @@ export function queryDisplayInfo(query: Query): QueryDisplayInfo {
 }
 
 export function dependentMetadata(
-  metadataProvider: MetadataProvider,
-  tableId: TableId,
-): DependentItem[];
-export function dependentMetadata(
   query: Query,
   cardId: CardId | undefined,
   cardType: CardType,
-): DependentItem[];
-export function dependentMetadata(
-  queryOrMetadataProvider: Query | MetadataProvider,
-  cardOrTableId: TableId | CardId | undefined,
-  cardType?: CardType,
 ): DependentItem[] {
-  return ML.dependent_metadata(
-    queryOrMetadataProvider,
-    cardOrTableId,
-    cardType,
-  );
+  return ML.dependent_metadata(query, cardId, cardType);
+}
+
+export function tableOrCardDependentMetadata(
+  metadataProvider: MetadataProvider,
+  tableId: TableId,
+): DependentItem[] {
+  return ML.table_or_card_dependent_metadata(metadataProvider, tableId);
 }

--- a/frontend/src/metabase-lib/metadata.ts
+++ b/frontend/src/metabase-lib/metadata.ts
@@ -1,6 +1,12 @@
 import * as ML from "cljs/metabase.lib.js";
 import * as ML_MetadataCalculation from "cljs/metabase.lib.metadata.calculation";
-import type { DatabaseId, DatasetColumn, TableId } from "metabase-types/api";
+import type {
+  CardId,
+  CardType,
+  DatabaseId,
+  DatasetColumn,
+  TableId,
+} from "metabase-types/api";
 
 import type {
   AggregationClause,
@@ -211,6 +217,16 @@ export function queryDisplayInfo(query: Query): QueryDisplayInfo {
   return ML.display_info(query, -1, query);
 }
 
-export function dependentMetadata(query: Query): DependentItem[] {
-  return ML.dependent_metadata(query);
+export function dependentMetadata(
+  queryOrMetadataProvider: Query | MetadataProvider,
+  cardId: CardId | undefined,
+  cardType: CardType,
+  tableId?: TableId,
+): DependentItem[] {
+  return ML.dependent_metadata(
+    queryOrMetadataProvider,
+    cardId,
+    cardType,
+    tableId,
+  );
 }

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.tsx
@@ -2,7 +2,9 @@ import { useMemo } from "react";
 import { t } from "ttag";
 
 import { FieldPicker } from "metabase/common/components/FieldPicker";
+import { useDispatch } from "metabase/lib/redux";
 import { DataSourceSelector } from "metabase/query_builder/components/DataSelector";
+import { loadMetadataForTable } from "metabase/questions/actions";
 import { Icon, Popover, Tooltip } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import type { DatabaseId, TableId } from "metabase-types/api";
@@ -26,6 +28,7 @@ export const DataStep = ({
   const databaseId = Lib.databaseID(query);
   const tableId = Lib.sourceTableOrCardId(query);
   const table = tableId ? Lib.tableOrCardMetadata(query, tableId) : null;
+  const dispatch = useDispatch();
 
   const pickerLabel = table
     ? Lib.displayInfo(query, stageIndex, table).displayName
@@ -40,7 +43,11 @@ export const DataStep = ({
 
   const canSelectTableColumns = table && isRaw && !readOnly;
 
-  const handleTableSelect = (tableId: TableId, databaseId: DatabaseId) => {
+  const handleTableSelect = async (
+    tableId: TableId,
+    databaseId: DatabaseId,
+  ) => {
+    await dispatch(loadMetadataForTable(databaseId, tableId));
     const metadata = question.metadata();
     const metadataProvider = Lib.metadataProvider(databaseId, metadata);
     const nextTable = Lib.tableOrCardMetadata(metadataProvider, tableId);

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.tsx
@@ -3,14 +3,14 @@ import { useMemo, useState } from "react";
 import { t } from "ttag";
 
 import { DATA_BUCKET } from "metabase/containers/DataPicker/constants";
-import Tables from "metabase/entities/tables";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { DataSourceSelector } from "metabase/query_builder/components/DataSelector";
+import { loadMetadataForTable } from "metabase/questions/actions";
 import { getMetadata } from "metabase/selectors/metadata";
 import { Icon, Popover, Tooltip } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import type Table from "metabase-lib/v1/metadata/Table";
-import type { TableId } from "metabase-types/api";
+import type { DatabaseId, TableId } from "metabase-types/api";
 
 import { NotebookCellItem } from "../../../NotebookCell";
 
@@ -60,8 +60,11 @@ export function JoinTablePicker({
   const tableFilter = (table: Table) => !tableId || table.db_id === databaseId;
   const isDisabled = isReadOnly;
 
-  const handleTableChange = async (tableId: TableId) => {
-    await dispatch(Tables.actions.fetchMetadata({ id: tableId }));
+  const handleTableChange = async (
+    tableId: TableId,
+    databaseId: DatabaseId,
+  ) => {
+    await dispatch(loadMetadataForTable(databaseId, tableId));
     onChange?.(Lib.tableOrCardMetadata(query, tableId));
   };
 

--- a/frontend/src/metabase/questions/actions.ts
+++ b/frontend/src/metabase/questions/actions.ts
@@ -31,7 +31,7 @@ export const loadMetadataForTable =
         databaseId,
         getMetadata(getState()),
       );
-      return Lib.dependentMetadata(metadataProvider, tableId);
+      return Lib.tableOrCardDependentMetadata(metadataProvider, tableId);
     };
     await dispatch(loadMetadata(getDependencies, [], options));
   };

--- a/frontend/src/metabase/questions/actions.ts
+++ b/frontend/src/metabase/questions/actions.ts
@@ -11,10 +11,10 @@ export interface LoadMetadataOptions {
 
 export const loadMetadataForCard =
   (card: Card, options?: LoadMetadataOptions) => async (dispatch: Dispatch) => {
-    await dispatch(loadDependentMetadata(card, [], options));
+    await dispatch(loadCardMetadata(card, [], options));
   };
 
-const loadDependentMetadata =
+const loadCardMetadata =
   (
     card: Card,
     prevDependencies: Lib.DependentItem[],
@@ -34,7 +34,7 @@ const loadDependentMetadata =
     if (newDependencies.length > 0) {
       const mergedDependencies = [...prevDependencies, ...newDependencies];
       await dispatch(loadMetadataForDependentItems(newDependencies, options));
-      await dispatch(loadDependentMetadata(card, mergedDependencies, options));
+      await dispatch(loadCardMetadata(card, mergedDependencies, options));
     }
   };
 

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -182,7 +182,8 @@
   dependent-metadata
   expression-clause
   expression-parts
-  filter-args-display-name]
+  filter-args-display-name
+  table-or-card-dependent-metadata]
  [lib.field
   add-field
   fieldable-columns

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -2196,8 +2196,17 @@
   Each entity is returned as a JS map `{type: \"database\"|\"schema\"|\"table\"|\"field\", id: number}`.
 
   > **Code health:** Healthy"
-  [a-query]
-  (to-array (map clj->js (lib.core/dependent-metadata a-query))))
+  [a-query card-id card-type]
+  (to-array (map clj->js (lib.core/dependent-metadata a-query card-id (keyword card-type)))))
+
+(defn ^:export table-or-card-dependent-metadata
+  "Return a JS array of entities which are needed upfront to create a new query based on a table/card.
+
+  Each entity is returned as a JS map `{type: \"database\"|\"schema\"|\"table\"|\"field\", id: number}`
+
+  > **Code health:** Healthy"
+  [metadata-provider table-id]
+  (to-array (map clj->js (lib.core/table-or-card-dependent-metadata metadata-provider table-id))))
 
 (defn ^:export can-run
   "Returns true if the query is runnable.

--- a/src/metabase/lib/js/metadata.cljs
+++ b/src/metabase/lib/js/metadata.cljs
@@ -380,6 +380,7 @@
       :visibility-type (keyword v)
       :dataset-query   (js->clj v :keywordize-keys true)
       :type            (keyword v)
+      :model           (keyword v)
       ;; this is not complete, add more stuff as needed.
       v)))
 

--- a/src/metabase/lib/query.cljc
+++ b/src/metabase/lib/query.cljc
@@ -194,7 +194,8 @@
         base-query (query-with-stages metadata-providerable
                                       [{:lib/type :mbql.stage/mbql
                                         :source-card card-id}])]
-    (if (= (:type card-metadata) :metric)
+    (if (or (= (:type card-metadata) :metric)
+            (= (:model card-metadata) :metric))
       (let [metric-query (query metadata-providerable (:dataset-query card-metadata))
             metric-breakouts (:breakout (lib.util/query-stage metric-query -1))
             base-query (reduce


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/42060
Blocked by https://github.com/metabase/metabase/issues/42056

Uses updated `dependentMetadata` and new `tableOrCardDependentMetadata` to load metadata when opening a question/model/metric and when creating a new one. Unifies and simplifies existing logic to load metadata.