### PR TITLE
Add string like filtering capabilities to filter widget

### DIFF
--- a/e2e/test/scenarios/question/reproductions/42065-mongo-filter-by-id.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/42065-mongo-filter-by-id.cy.spec.js
@@ -20,27 +20,39 @@ describe(
     });
 
     it("should be possible to filter by Mongo _id column (metabase#42010)", () => {
-      cy.log("Check notebook editor");
-      cy.findByRole("button", { name: "Filter" }).click();
-      cy.get("[data-element-id=list-item-title]")
-        .eq(0)
-        .should("have.text", "ID");
-      cy.get("[data-element-id=list-item-title]").eq(0).click();
-      cy.findByPlaceholderText("Search by ID").type("663167e513bd481495a98bd0");
-      cy.get("button").contains("Add filter").click();
       cy.get("button").contains("Visualize").click();
-      cy.get("button").contains("Showing 1 row");
+      cy.get("[data-testid=cell-data]")
+        .eq(10)
+        .then(elm => {
+          // Get the id of some row and go back to notebook editor. I suppose it differs per snapshot, hence we are
+          // unable to hardcode the value.
+          const id = elm.text();
+          cy.go("back");
 
-      cy.log("Remove current filter");
-      cy.findByRole("button", { name: "Remove" }).click();
+          // Check the notebook editor
+          cy.log("Check notebook editor");
+          cy.findByRole("button", { name: "Filter" }).click();
+          // Following selects first item from filter column picker
+          cy.get("[data-element-id=list-item-title]")
+            .eq(0)
+            .should("have.text", "ID");
+          cy.get("[data-element-id=list-item-title]").eq(0).click();
+          cy.findByPlaceholderText("Search by ID").type(id);
+          cy.get("button").contains("Add filter").click();
+          cy.get("button").contains("Visualize").click();
+          cy.get("button").contains("Showing 1 row");
 
-      cy.log("Check chill mode");
-      cy.get("[data-testid=cell-data]").eq(0).should("have.text", "ID");
-      cy.get("[data-testid=cell-data]").eq(0).click();
-      cy.get("button").contains("Filter by this column").click();
-      cy.findByPlaceholderText("Search by ID").type("663167e513bd481495a98bd0");
-      cy.get("button").contains("Add filter").click();
-      cy.get("button").contains("Showing 1 row");
+          // Now remove the filter
+          cy.log("Remove current filter");
+          cy.findByRole("button", { name: "Remove" }).click();
+
+          // And add the filter through chill mode
+          cy.log("Check chill mode");
+          cy.get("button").contains("Filter").click();
+          cy.findByPlaceholderText("Search by ID").type(id);
+          cy.get("button").contains("Apply filter").click();
+          cy.get("button").contains("Showing 1 row");
+        });
     });
   },
 );

--- a/e2e/test/scenarios/question/reproductions/42065-mongo-filter-by-id.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/42065-mongo-filter-by-id.cy.spec.js
@@ -1,0 +1,46 @@
+import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
+import { restore, openTable } from "e2e/support/helpers";
+
+describe(
+  "issue 42010 -- Unable to filter by mongo id",
+  { tags: "@mongo" },
+  () => {
+    beforeEach(() => {
+      restore("mongo-5");
+      cy.signInAsAdmin();
+
+      cy.request(`/api/database/${WRITABLE_DB_ID}/schema/`).then(({ body }) => {
+        const tableId = body.find(table => table.name === "orders").id;
+        openTable({
+          database: WRITABLE_DB_ID,
+          table: tableId,
+          mode: "notebook",
+        });
+      });
+    });
+
+    it("should be possible to filter by Mongo _id column (metabase#42010)", () => {
+      cy.log("Check notebook editor");
+      cy.findByRole("button", { name: "Filter" }).click();
+      cy.get("[data-element-id=list-item-title]")
+        .eq(0)
+        .should("have.text", "ID");
+      cy.get("[data-element-id=list-item-title]").eq(0).click();
+      cy.findByPlaceholderText("Search by ID").type("66315368ba4a275f7a44c57d");
+      cy.get("button").contains("Add filter").click();
+      cy.get("button").contains("Visualize").click();
+      cy.get("button").contains("Showing 1 row");
+
+      cy.log("Remove current filter");
+      cy.findByRole("button", { name: "Remove" }).click();
+
+      cy.log("Check chill mode");
+      cy.get("[data-testid=cell-data]").eq(0).should("have.text", "ID");
+      cy.get("[data-testid=cell-data]").eq(0).click();
+      cy.get("button").contains("Filter by this column").click();
+      cy.findByPlaceholderText("Search by ID").type("66315368ba4a275f7a44c57d");
+      cy.get("button").contains("Add filter").click();
+      cy.get("button").contains("Showing 1 row");
+    });
+  },
+);

--- a/e2e/test/scenarios/question/reproductions/42065-mongo-filter-by-id.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/42065-mongo-filter-by-id.cy.spec.js
@@ -26,7 +26,7 @@ describe(
         .eq(0)
         .should("have.text", "ID");
       cy.get("[data-element-id=list-item-title]").eq(0).click();
-      cy.findByPlaceholderText("Search by ID").type("66315368ba4a275f7a44c57d");
+      cy.findByPlaceholderText("Search by ID").type("663167e513bd481495a98bd0");
       cy.get("button").contains("Add filter").click();
       cy.get("button").contains("Visualize").click();
       cy.get("button").contains("Showing 1 row");
@@ -38,7 +38,7 @@ describe(
       cy.get("[data-testid=cell-data]").eq(0).should("have.text", "ID");
       cy.get("[data-testid=cell-data]").eq(0).click();
       cy.get("button").contains("Filter by this column").click();
-      cy.findByPlaceholderText("Search by ID").type("66315368ba4a275f7a44c57d");
+      cy.findByPlaceholderText("Search by ID").type("663167e513bd481495a98bd0");
       cy.get("button").contains("Add filter").click();
       cy.get("button").contains("Showing 1 row");
     });

--- a/e2e/test/scenarios/question/reproductions/42065-mongo-filter-by-id.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/42065-mongo-filter-by-id.cy.spec.js
@@ -26,7 +26,7 @@ describe(
       });
     });
 
-    it("should be possible to filter by Mongo _id column (metabase#42010)", () => {
+    it("should be possible to filter by Mongo _id column (metabase#40770, metabase#42010)", () => {
       cy.get("#main-data-grid")
         .findAllByRole("gridcell")
         .first()
@@ -56,7 +56,7 @@ describe(
           removeFilter();
 
           cy.log(
-            "Scenario 2 - Make sure the simple mode filter is working correctly",
+            "Scenario 2 - Make sure the simple mode filter is working correctly (metabase#40770)",
           );
           filter();
 
@@ -72,7 +72,7 @@ describe(
           removeFilter();
 
           cy.log(
-            "Scenario 3 - Make sure filter is working in the notebook editor",
+            "Scenario 3 - Make sure filter is working in the notebook editor (metabase#42010)",
           );
           openNotebook();
           filter({ mode: "notebook" });

--- a/frontend/src/metabase-lib/column_types.ts
+++ b/frontend/src/metabase-lib/column_types.ts
@@ -36,6 +36,7 @@ export const isPrimaryKey: TypeFn = TYPES.primary_key_QMARK_;
 export const isScope: TypeFn = TYPES.scope_QMARK_;
 export const isState: TypeFn = TYPES.state_QMARK_;
 export const isString: TypeFn = TYPES.string_QMARK_;
+export const isStringLike: TypeFn = TYPES.string_like_QMARK_;
 export const isSummable: TypeFn = TYPES.summable_QMARK_;
 export const isTime: TypeFn = TYPES.time_QMARK_;
 export const isTitle: TypeFn = TYPES.title_QMARK_;

--- a/frontend/src/metabase-lib/column_types.ts
+++ b/frontend/src/metabase-lib/column_types.ts
@@ -37,6 +37,7 @@ export const isScope: TypeFn = TYPES.scope_QMARK_;
 export const isState: TypeFn = TYPES.state_QMARK_;
 export const isString: TypeFn = TYPES.string_QMARK_;
 export const isStringLike: TypeFn = TYPES.string_like_QMARK_;
+export const isStringOrStringLike: TypeFn = TYPES.string_or_string_like_QMARK_;
 export const isSummable: TypeFn = TYPES.summable_QMARK_;
 export const isTime: TypeFn = TYPES.time_QMARK_;
 export const isTitle: TypeFn = TYPES.title_QMARK_;

--- a/frontend/src/metabase-lib/filter.ts
+++ b/frontend/src/metabase-lib/filter.ts
@@ -137,6 +137,7 @@ export function stringFilterParts(
   if (
     !isColumnMetadata(column) ||
     !isString(column) ||
+    !isStringLike(column) ||
     !isStringLiteralArray(values)
   ) {
     return null;

--- a/frontend/src/metabase-lib/filter.ts
+++ b/frontend/src/metabase-lib/filter.ts
@@ -8,7 +8,7 @@ import {
   isTime,
   isDate,
   isCoordinate,
-  isString,
+  isStringOrStringLike,
   isNumeric,
 } from "./column_types";
 import {
@@ -136,8 +136,7 @@ export function stringFilterParts(
   const [column, ...values] = args;
   if (
     !isColumnMetadata(column) ||
-    !isString(column) ||
-    !isStringLike(column) ||
+    !isStringOrStringLike(column) ||
     !isStringLiteralArray(values)
   ) {
     return null;

--- a/frontend/src/metabase-lib/v1/parameters/utils/filters.js
+++ b/frontend/src/metabase-lib/v1/parameters/utils/filters.js
@@ -40,7 +40,8 @@ export function columnFilterForParameter(parameter) {
     case "number":
       return column => Lib.isNumber(column) && !Lib.isLocation(column);
     case "string":
-      return column => Lib.isString(column) && !Lib.isLocation(column);
+      return column =>
+        Lib.isStringOrStringLike(column) && !Lib.isLocation(column);
   }
 
   return () => false;

--- a/frontend/src/metabase/common/utils/columns.ts
+++ b/frontend/src/metabase/common/utils/columns.ts
@@ -30,7 +30,7 @@ export function getColumnIcon(column: Lib.ColumnMetadata): IconName {
   if (Lib.isBoolean(column)) {
     return "io";
   }
-  if (Lib.isString(column)) {
+  if (Lib.isStringOrStringLike(column)) {
     return "string";
   }
   if (Lib.isNumeric(column)) {

--- a/frontend/src/metabase/querying/components/FilterModal/ColumnFilterSection/ColumnFilterSection.tsx
+++ b/frontend/src/metabase/querying/components/FilterModal/ColumnFilterSection/ColumnFilterSection.tsx
@@ -61,7 +61,7 @@ function getFilterWidget(column: Lib.ColumnMetadata) {
   if (Lib.isNumeric(column)) {
     return NumberFilterEditor;
   }
-  if (Lib.isString(column) || Lib.isString(column)) {
+  if (Lib.isStringOrStringLike(column)) {
     return StringFilterEditor;
   }
   return EmptyFilterEditor;

--- a/frontend/src/metabase/querying/components/FilterModal/ColumnFilterSection/ColumnFilterSection.tsx
+++ b/frontend/src/metabase/querying/components/FilterModal/ColumnFilterSection/ColumnFilterSection.tsx
@@ -61,7 +61,7 @@ function getFilterWidget(column: Lib.ColumnMetadata) {
   if (Lib.isNumeric(column)) {
     return NumberFilterEditor;
   }
-  if (Lib.isString(column)) {
+  if (Lib.isString(column) || Lib.isString(column)) {
     return StringFilterEditor;
   }
   return EmptyFilterEditor;

--- a/frontend/src/metabase/querying/components/FilterModal/utils/sorting.ts
+++ b/frontend/src/metabase/querying/components/FilterModal/utils/sorting.ts
@@ -20,7 +20,7 @@ function isNumberAndNotCoordinate(column: Lib.ColumnMetadata) {
 }
 
 function isShortText(column: Lib.ColumnMetadata) {
-  return Lib.isString(column) && !isLongText(column);
+  return Lib.isStringOrStringLike(column) && !isLongText(column);
 }
 
 function isLongText(column: Lib.ColumnMetadata) {

--- a/frontend/src/metabase/querying/components/FilterPicker/FilterPickerBody/FilterPickerBody.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/FilterPickerBody/FilterPickerBody.tsx
@@ -60,7 +60,7 @@ function getFilterWidget(column: Lib.ColumnMetadata) {
   if (Lib.isNumeric(column)) {
     return NumberFilterPicker;
   }
-  if (Lib.isString(column) || Lib.isStringLike(column)) {
+  if (Lib.isStringOrStringLike(column) {
     return StringFilterPicker;
   }
   return null;

--- a/frontend/src/metabase/querying/components/FilterPicker/FilterPickerBody/FilterPickerBody.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/FilterPickerBody/FilterPickerBody.tsx
@@ -60,7 +60,7 @@ function getFilterWidget(column: Lib.ColumnMetadata) {
   if (Lib.isNumeric(column)) {
     return NumberFilterPicker;
   }
-  if (Lib.isStringOrStringLike(column) {
+  if (Lib.isStringOrStringLike(column)) {
     return StringFilterPicker;
   }
   return null;

--- a/frontend/src/metabase/querying/components/FilterPicker/FilterPickerBody/FilterPickerBody.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/FilterPickerBody/FilterPickerBody.tsx
@@ -60,7 +60,7 @@ function getFilterWidget(column: Lib.ColumnMetadata) {
   if (Lib.isNumeric(column)) {
     return NumberFilterPicker;
   }
-  if (Lib.isString(column)) {
+  if (Lib.isString(column) || Lib.isStringLike(column)) {
     return StringFilterPicker;
   }
   return null;

--- a/frontend/src/metabase/querying/utils/drills/quick-filter-drill/quick-filter-drill.tsx
+++ b/frontend/src/metabase/querying/utils/drills/quick-filter-drill/quick-filter-drill.tsx
@@ -58,7 +58,7 @@ function getActionOverrides(
     }
   }
 
-  if (Lib.isString(column) && typeof value === "string") {
+  if (Lib.isStringOrStringLike(column) && typeof value === "string") {
     const columnName = Lib.displayInfo(query, stageIndex, column).displayName;
     const valueTitle = getTextValueTitle(value);
     const action: Partial<ClickAction> = {

--- a/src/metabase/lib/types/isa.cljc
+++ b/src/metabase/lib/types/isa.cljc
@@ -85,6 +85,11 @@
   [column]
   (field-type? ::lib.types.constants/string_like column))
 
+(defn ^:export string-or-string-like?
+  "Is `column` of a temporal type?"
+  [column]
+  (or (string? column) (string-like? column)))
+
 (defn ^:export summable?
   "Is `column` of a summable type?"
   [column]

--- a/src/metabase/lib/types/isa.cljc
+++ b/src/metabase/lib/types/isa.cljc
@@ -80,6 +80,11 @@
   [column]
   (field-type? ::lib.types.constants/string column))
 
+(defn ^:export string-like?
+  "Is `column` of a temporal type?"
+  [column]
+  (field-type? ::lib.types.constants/string_like column))
+
 (defn ^:export summable?
   "Is `column` of a summable type?"
   [column]


### PR DESCRIPTION
Closes [#42010](https://github.com/metabase/metabase/issues/42010)
Closes [#40770](https://github.com/metabase/metabase/issues/40770)

The PR introduces E2E reproductions for both issues.

This PR enables string filtering widget for `string_like` columns.