### PR TITLE
Recents Picker Tab

### DIFF
--- a/e2e/support/helpers/e2e-collection-helpers.js
+++ b/e2e/support/helpers/e2e-collection-helpers.js
@@ -84,7 +84,10 @@ export const moveOpenedCollectionTo = newParent => {
   entityPickerModal().should("not.exist");
 };
 
-export function pickEntity({ path, select }) {
+export function pickEntity({ path, select, tab = /Collections/ }) {
+  if (tab) {
+    cy.findByRole("tab", { name: tab }).click();
+  }
   if (path) {
     cy.findByTestId("nested-item-picker").within(() => {
       for (const [index, name] of path.entries()) {

--- a/e2e/support/helpers/e2e-collection-helpers.js
+++ b/e2e/support/helpers/e2e-collection-helpers.js
@@ -76,6 +76,7 @@ export const moveOpenedCollectionTo = newParent => {
   popover().within(() => cy.findByText("Move").click());
 
   entityPickerModal().within(() => {
+    cy.findByRole("tab", { name: /Collections/ }).click();
     cy.findByText(newParent).click();
     cy.button("Move").click();
   });

--- a/e2e/support/helpers/e2e-collection-helpers.js
+++ b/e2e/support/helpers/e2e-collection-helpers.js
@@ -84,7 +84,7 @@ export const moveOpenedCollectionTo = newParent => {
   entityPickerModal().should("not.exist");
 };
 
-export function pickEntity({ path, select, tab = /Collections/ }) {
+export function pickEntity({ path, select, tab }) {
   if (tab) {
     cy.findByRole("tab", { name: tab }).click();
   }

--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -400,9 +400,7 @@ describe("scenarios > collection defaults", () => {
       });
 
       entityPickerModal().within(() => {
-        entityPickerModal()
-          .findByRole("tab", { name: /Collections/ })
-          .click();
+        cy.findByRole("tab", { name: /Collections/ }).click();
         cy.findByText("Bobby Tables's Personal Collection").click();
         cy.findByText(COLLECTION).click();
         cy.button("Move").should("not.be.disabled");

--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -400,6 +400,9 @@ describe("scenarios > collection defaults", () => {
       });
 
       entityPickerModal().within(() => {
+        entityPickerModal()
+          .findByRole("tab", { name: /Collections/ })
+          .click();
         cy.findByText("Bobby Tables's Personal Collection").click();
         cy.findByText(COLLECTION).click();
         cy.button("Move").should("not.be.disabled");
@@ -425,13 +428,15 @@ describe("scenarios > collection defaults", () => {
       popover().findByText("Move").click();
 
       // we need to do this manually because we need to await the correct number of api requests to keep this from flaking
-      cy.wait([
-        "@getCollectionItems",
-        "@getCollectionItems",
-        "@getCollectionItems",
-      ]);
+
       entityPickerModal().within(() => {
         cy.findByTestId("loading-spinner").should("not.exist");
+        cy.findByRole("tab", { name: /Collections/ }).click();
+        cy.wait([
+          "@getCollectionItems",
+          "@getCollectionItems",
+          "@getCollectionItems",
+        ]);
         // make sure the first collection (current parent) is selected
         findPickerItem("First collection").should(
           "have.attr",
@@ -577,6 +582,7 @@ describe("scenarios > collection defaults", () => {
           popover().findByText("Move").click();
 
           entityPickerModal().within(() => {
+            cy.findByRole("tab", { name: /Collections/ }).click();
             cy.log("parent collection should be selected");
             findPickerItem("First collection").should(
               "have.attr",
@@ -599,6 +605,7 @@ describe("scenarios > collection defaults", () => {
 
           entityPickerModal().within(() => {
             cy.log("parent collection should be selected");
+            cy.findByRole("tab", { name: /Collections/ }).click();
             findPickerItem("Second collection").should(
               "have.attr",
               "data-active",
@@ -623,6 +630,7 @@ describe("scenarios > collection defaults", () => {
 
           entityPickerModal().within(() => {
             cy.log("should disable all moving collections");
+            cy.findByRole("tab", { name: /Collections/ }).click();
             findPickerItem("First collection").should("have.attr", "disabled");
             findPickerItem("Another collection").should(
               "have.attr",

--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -72,6 +72,7 @@ describe("scenarios > collection defaults", () => {
       pickEntity({
         path: ["Our analytics", `Collection ${COLLECTIONS_COUNT}`],
         select: true,
+        tab: /Collections/,
       });
 
       cy.findByTestId("new-collection-modal").button("Create").click();

--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -26,6 +26,7 @@ import {
   visitDashboard,
   visitEmbeddedPage,
   visitIframe,
+  entityPickerModal,
 } from "e2e/support/helpers";
 import { b64hash_to_utf8 } from "metabase/lib/encoding";
 import {
@@ -1311,6 +1312,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       cy.findAllByTestId("field-set")
         .should("have.length", 2)
         .should("contain.text", POINT_COUNT);
+
       cy.get("@targetDashboardId").then(targetDashboardId => {
         cy.location().should(({ pathname, search }) => {
           expect(pathname).to.equal(`/dashboard/${targetDashboardId}`);
@@ -2148,7 +2150,10 @@ const clickLineChartPoint = () => {
 const addDashboardDestination = () => {
   cy.get("aside").findByText("Go to a custom destination").click();
   cy.get("aside").findByText("Dashboard").click();
-  modal().findByText(TARGET_DASHBOARD.name).click();
+  entityPickerModal()
+    .findByRole("tab", { name: /Dashboards/ })
+    .click();
+  entityPickerModal().findByText(TARGET_DASHBOARD.name).click();
 };
 
 const addUrlDestination = () => {
@@ -2159,7 +2164,10 @@ const addUrlDestination = () => {
 const addSavedQuestionDestination = () => {
   cy.get("aside").findByText("Go to a custom destination").click();
   cy.get("aside").findByText("Saved question").click();
-  modal().findByText(TARGET_QUESTION.name).click();
+  entityPickerModal()
+    .findByRole("tab", { name: /Questions/ })
+    .click();
+  entityPickerModal().findByText(TARGET_QUESTION.name).click();
 };
 
 const addSavedQuestionCreatedAtParameter = () => {

--- a/e2e/test/scenarios/dashboard-cards/dashboard-drill.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-drill.cy.spec.js
@@ -21,6 +21,7 @@ import {
   queryBuilderMain,
   chartPathWithFillColor,
   echartsContainer,
+  entityPickerModal,
 } from "e2e/support/helpers";
 
 const {
@@ -243,8 +244,10 @@ describe("scenarios > dashboard > dashboard drill", () => {
       .parent()
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       .within(() => cy.findByText("Dashboard").click());
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    modal().within(() => cy.findByText("end dash").click());
+    entityPickerModal().within(() => {
+      cy.findByRole("tab", { name: /Dashboards/ }).click();
+      cy.findByText("end dash").click();
+    });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Available filters")
       .parent()

--- a/e2e/test/scenarios/dashboard-cards/dashboard-sections.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-sections.cy.spec.js
@@ -126,6 +126,9 @@ function selectQuestion(question) {
     .findAllByText("Select question")
     .first()
     .click({ force: true });
+  entityPickerModal()
+    .findByRole("tab", { name: /Questions/ })
+    .click();
   entityPickerModal().findByText(question).click();
   cy.wait("@cardQuery");
   dashboardGrid().findByText(question).should("exist");

--- a/e2e/test/scenarios/dashboard/dashboard-management.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-management.cy.spec.js
@@ -191,6 +191,14 @@ describe("managing dashboard from the dashboard's edit menu", () => {
                   );
                   cy.findByTestId("collection-picker-button").click();
                 });
+
+                if (user === "admin") {
+                  // admin has recents tab
+                  entityPickerModal()
+                    .findByRole("tab", { name: /Collections/ })
+                    .click();
+                }
+
                 entityPickerModal()
                   .findByText("Create a new collection")
                   .click();

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -128,6 +128,7 @@ describe("scenarios > dashboard", () => {
       });
 
       entityPickerModal().within(() => {
+        cy.findByRole("tab", { name: /Dashboards/ }).click();
         cy.findByText(dashboardName)
           .closest("button")
           .then($button => {
@@ -219,6 +220,9 @@ describe("scenarios > dashboard", () => {
         cy.button("Yes please!").click();
       });
 
+      entityPickerModal()
+        .findByRole("tab", { name: /Dashboards/ })
+        .click();
       entityPickerModal().findByText("Create a new dashboard").click();
       cy.findByTestId("create-dashboard-on-the-go").within(() => {
         cy.findByPlaceholderText("My new dashboard").type("Foo");
@@ -323,6 +327,9 @@ describe("scenarios > dashboard", () => {
         openDashboardMenu();
         popover().findByText("Move").click();
         entityPickerModal().within(() => {
+          entityPickerModal()
+            .findByRole("tab", { name: /Dashboards/ })
+            .click();
           cy.findByText("Bobby Tables's Personal Collection").click();
           cy.button("Move").click();
         });

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -327,9 +327,7 @@ describe("scenarios > dashboard", () => {
         openDashboardMenu();
         popover().findByText("Move").click();
         entityPickerModal().within(() => {
-          entityPickerModal()
-            .findByRole("tab", { name: /Dashboards/ })
-            .click();
+          cy.findByRole("tab", { name: /Collections/ }).click();
           cy.findByText("Bobby Tables's Personal Collection").click();
           cy.button("Move").click();
         });
@@ -348,6 +346,7 @@ describe("scenarios > dashboard", () => {
         openDashboardMenu();
         popover().findByText("Move").click();
         entityPickerModal().within(() => {
+          cy.findByRole("tab", { name: /Collections/ }).click();
           cy.findByText("Our analytics").click();
           cy.button("Move").click();
         });

--- a/e2e/test/scenarios/models/reproductions/19737-data-picker-not-showing-moved-model.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/19737-data-picker-not-showing-moved-model.cy.spec.js
@@ -88,9 +88,7 @@ function moveModel(modelName, collectionName) {
   popover().findByText("Move").click();
 
   entityPickerModal().within(() => {
-    entityPickerModal()
-      .findByRole("tab", { name: /Collections/ })
-      .click();
+    cy.findByRole("tab", { name: /Collections/ }).click();
     cy.findByText(collectionName).click();
     cy.button("Move").click();
   });

--- a/e2e/test/scenarios/models/reproductions/19737-data-picker-not-showing-moved-model.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/19737-data-picker-not-showing-moved-model.cy.spec.js
@@ -88,6 +88,9 @@ function moveModel(modelName, collectionName) {
   popover().findByText("Move").click();
 
   entityPickerModal().within(() => {
+    entityPickerModal()
+      .findByRole("tab", { name: /Collections/ })
+      .click();
     cy.findByText(collectionName).click();
     cy.button("Move").click();
   });

--- a/e2e/test/scenarios/native/data_ref.cy.spec.js
+++ b/e2e/test/scenarios/native/data_ref.cy.spec.js
@@ -57,9 +57,7 @@ describe("scenarios > native question > data reference sidebar", () => {
     popover().findByTestId("move-button").click();
 
     entityPickerModal().within(() => {
-      entityPickerModal()
-        .findByRole("tab", { name: /Collections/ })
-        .click();
+      cy.findByRole("tab", { name: /Collections/ }).click();
       cy.findByText("Bobby Tables's Personal Collection").click();
       cy.button("Move").click();
     });

--- a/e2e/test/scenarios/native/data_ref.cy.spec.js
+++ b/e2e/test/scenarios/native/data_ref.cy.spec.js
@@ -57,6 +57,9 @@ describe("scenarios > native question > data reference sidebar", () => {
     popover().findByTestId("move-button").click();
 
     entityPickerModal().within(() => {
+      entityPickerModal()
+        .findByRole("tab", { name: /Collections/ })
+        .click();
       cy.findByText("Bobby Tables's Personal Collection").click();
       cy.button("Move").click();
     });

--- a/e2e/test/scenarios/native/native_subquery.cy.spec.js
+++ b/e2e/test/scenarios/native/native_subquery.cy.spec.js
@@ -78,6 +78,7 @@ describe("scenarios > question > native subquery", () => {
         openQuestionActions();
         cy.findByTestId("move-button").click();
         entityPickerModal().within(() => {
+          cy.findByRole("tab", { name: /Collections/ }).click();
           cy.findByText("Bobby Tables's Personal Collection").click();
           cy.button("Move").click();
         });

--- a/e2e/test/scenarios/onboarding/search/recently-viewed.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/recently-viewed.cy.spec.js
@@ -9,6 +9,8 @@ import {
   openPeopleTable,
   describeEE,
   setTokenFeatures,
+  popover,
+  entityPickerModal,
 } from "e2e/support/helpers";
 
 describe("search > recently viewed", () => {
@@ -72,6 +74,56 @@ describe("search > recently viewed", () => {
     cy.wait("@recent");
 
     assertRecentlyViewedItem(0, "People", "Table");
+  });
+});
+
+describe("Recently Viewed > Entity Picker", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    cy.visit("/");
+  });
+
+  it("shows recently created collection in entity picker", () => {
+    cy.createCollection({
+      name: "My Fresh Collection",
+    });
+
+    cy.findByTestId("app-bar").button(/New/).click();
+    popover().findByText("Dashboard").click();
+    cy.findByTestId("collection-picker-button").click();
+
+    entityPickerModal().within(() => {
+      cy.findByText("Select a collection").click();
+      cy.findByRole("tab", { name: /Recents/ });
+      cy.findByRole("tab", { name: /Collections/ });
+
+      cy.findByText("Today");
+      cy.findByText("My Fresh Collection");
+    });
+  });
+
+  it("shows recently visited dashboard in entity picker", () => {
+    visitDashboard(ORDERS_DASHBOARD_ID);
+    visitQuestion(ORDERS_QUESTION_ID);
+
+    cy.findByTestId("qb-header").icon("ellipsis").click();
+    popover().findByText("Add to dashboard").click();
+
+    entityPickerModal().within(() => {
+      cy.findByText("Add this question to a dashboard").click();
+      cy.findByRole("tab", { name: /Recents/ });
+      cy.findByRole("tab", { name: /Dashboards/ });
+
+      cy.findByText("Today");
+      cy.findByText("Orders in a dashboard").click();
+      cy.button("Select").click();
+    });
+
+    cy.url().should("contain", `/dashboard/${ORDERS_DASHBOARD_ID}-`);
+    cy.get("#Dashboard-Header-Container").findByText(
+      /You're editing this dashboard/,
+    );
   });
 });
 

--- a/e2e/test/scenarios/organization/timelines-collection.cy.spec.js
+++ b/e2e/test/scenarios/organization/timelines-collection.cy.spec.js
@@ -466,6 +466,9 @@ describe("scenarios > organization > timelines > collection", () => {
       popover().findByText("Move timeline").click();
 
       entityPickerModal().within(() => {
+        entityPickerModal()
+          .findByRole("tab", { name: /Collections/ })
+          .click();
         cy.findByText("Bobby Tables's Personal Collection").click();
         cy.button("Move").click();
         cy.wait("@updateTimeline");

--- a/e2e/test/scenarios/organization/timelines-collection.cy.spec.js
+++ b/e2e/test/scenarios/organization/timelines-collection.cy.spec.js
@@ -466,9 +466,7 @@ describe("scenarios > organization > timelines > collection", () => {
       popover().findByText("Move timeline").click();
 
       entityPickerModal().within(() => {
-        entityPickerModal()
-          .findByRole("tab", { name: /Collections/ })
-          .click();
+        cy.findByRole("tab", { name: /Collections/ }).click();
         cy.findByText("Bobby Tables's Personal Collection").click();
         cy.button("Move").click();
         cy.wait("@updateTimeline");

--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -401,6 +401,9 @@ describe("scenarios > question > new", () => {
 
       entityPickerModal().within(() => {
         cy.findByText("Add this question to a dashboard").should("be.visible");
+        entityPickerModal()
+          .findByRole("tab", { name: /Dashboards/ })
+          .click();
         cy.findByText(/bobby tables's personal collection/i).should(
           "be.visible",
         );

--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -387,7 +387,11 @@ describe("scenarios > question > new", () => {
         .findByLabelText(/Which collection/)
         .click();
 
-      pickEntity({ path: [myPersonalCollectionName], select: true });
+      pickEntity({
+        path: [myPersonalCollectionName],
+        select: true,
+        tab: /Collections/,
+      });
 
       cy.findByTestId("save-question-modal").button("Save").click();
       cy.wait("@createQuestion");
@@ -401,9 +405,6 @@ describe("scenarios > question > new", () => {
 
       entityPickerModal().within(() => {
         cy.findByText("Add this question to a dashboard").should("be.visible");
-        entityPickerModal()
-          .findByRole("tab", { name: /Dashboards/ })
-          .click();
         cy.findByText(/bobby tables's personal collection/i).should(
           "be.visible",
         );

--- a/e2e/test/scenarios/question/question-management.cy.spec.js
+++ b/e2e/test/scenarios/question/question-management.cy.spec.js
@@ -336,26 +336,22 @@ describe(
 
                     cy.signInAsAdmin();
 
-                    // Let's revoke access to "Our analytics"
+                    // Let's revoke write access to "Our analytics"
                     cy.updateCollectionGraph({
-                      [USER_GROUPS.COLLECTION_GROUP]: { root: "none" },
+                      [USER_GROUPS.COLLECTION_GROUP]: { root: "read" },
                     });
                     cy.signOut();
+                    cy.reload();
                     cy.signIn(user);
+                    visitQuestion(ORDERS_QUESTION_ID);
 
                     openQuestionActions();
                     cy.findByTestId("add-to-dashboard-button").click();
 
                     cy.wait("@mostRecentlyViewedDashboard");
-                    entityPickerModal()
-                      .findByRole("tab", { name: /Dashboards/ })
-                      .click();
 
-                    // backend bug for can_write in root collection?
-
-                    // no access - no dashboard
                     entityPickerModal()
-                      .findByText(/Orders in a dashboard/)
+                      .button(/Orders in a dashboard/)
                       .should("be.disabled");
                   });
                 });

--- a/e2e/test/scenarios/question/question-management.cy.spec.js
+++ b/e2e/test/scenarios/question/question-management.cy.spec.js
@@ -92,7 +92,7 @@ describe(
                       .should("have.attr", "aria-selected", "false");
                   });
 
-                  moveQuestionTo(/Personal Collection/, true);
+                  moveQuestionTo(/Personal Collection/, user === "admin");
                   assertRequestNot403("updateQuestion");
 
                   cy.findAllByRole("status")
@@ -298,6 +298,10 @@ describe(
 
                     openQuestionActions();
                     cy.findByTestId("add-to-dashboard-button").click();
+
+                    entityPickerModal()
+                      .findByRole("tab", { name: /Dashboards/ })
+                      .click();
 
                     findActivePickerItem("Orders in a dashboard");
                   });

--- a/e2e/test/scenarios/question/question-management.cy.spec.js
+++ b/e2e/test/scenarios/question/question-management.cy.spec.js
@@ -92,7 +92,7 @@ describe(
                       .should("have.attr", "aria-selected", "false");
                   });
 
-                  moveQuestionTo(/Personal Collection/);
+                  moveQuestionTo(/Personal Collection/, true);
                   assertRequestNot403("updateQuestion");
 
                   cy.findAllByRole("status")
@@ -122,7 +122,9 @@ describe(
                   openQuestionActions();
                   cy.findByTestId("move-button").click();
                   entityPickerModal().within(() => {
-                    cy.findByRole("tab", { name: /Collections/ }).click();
+                    if (user === "admin") {
+                      cy.findByRole("tab", { name: /Collections/ }).click();
+                    }
                     cy.findByText(/Personal Collection/).click();
                     cy.findByText("Create a new collection").click();
                   });
@@ -156,7 +158,7 @@ describe(
                       .should("have.attr", "aria-selected", "false");
                   });
 
-                  moveQuestionTo(/Personal Collection/);
+                  moveQuestionTo(/Personal Collection/, user === "admin");
                   assertRequestNot403("updateQuestion");
 
                   cy.findAllByRole("status")
@@ -249,7 +251,7 @@ describe(
 
                   cy.log("Move the question to a personal collection");
 
-                  moveQuestionTo(/Personal Collection/);
+                  moveQuestionTo(/Personal Collection/, true);
 
                   cy.log("assert public collections are not visible");
                   openQuestionActions();
@@ -258,9 +260,6 @@ describe(
                     cy.findByText("Add this question to a dashboard").should(
                       "be.visible",
                     );
-                    entityPickerModal()
-                      .findByRole("tab", { name: /Dashboards/ })
-                      .click();
                     cy.findByText(/'s personal collection/i).should(
                       "be.visible",
                     );
@@ -269,7 +268,7 @@ describe(
                   });
 
                   cy.log("Move the question to the root collection");
-                  moveQuestionTo("Our analytics");
+                  moveQuestionTo("Our analytics", true);
 
                   cy.log("assert all collections are visible");
                   openQuestionActions();
@@ -278,6 +277,7 @@ describe(
                     cy.findByText("Add this question to a dashboard").should(
                       "be.visible",
                     );
+
                     cy.findByText(/'s personal collection/i).should(
                       "be.visible",
                     );
@@ -312,9 +312,6 @@ describe(
                     cy.findByTestId("add-to-dashboard-button").click();
 
                     cy.wait("@mostRecentlyViewedDashboard");
-                    entityPickerModal()
-                      .findByRole("tab", { name: /Dashboards/ })
-                      .click();
                     findInactivePickerItem("Orders in a dashboard");
 
                     // before visiting the dashboard, we don't have any history
@@ -346,11 +343,13 @@ describe(
                     cy.findByTestId("add-to-dashboard-button").click();
 
                     cy.wait("@mostRecentlyViewedDashboard");
-
-                    // no access - no dashboard
                     entityPickerModal()
                       .findByRole("tab", { name: /Dashboards/ })
                       .click();
+
+                    // backend bug for can_write in root collection?
+
+                    // no access - no dashboard
                     entityPickerModal()
                       .findByText(/Orders in a dashboard/)
                       .should("be.disabled");
@@ -506,11 +505,11 @@ function findInactivePickerItem(name) {
   });
 }
 
-function moveQuestionTo(newCollectionName) {
+function moveQuestionTo(newCollectionName, clickTab = false) {
   openQuestionActions();
   cy.findByTestId("move-button").click();
   entityPickerModal().within(() => {
-    cy.findByRole("tab", { name: /Collections/ }).click();
+    clickTab && cy.findByRole("tab", { name: /Collections/ }).click();
     cy.findByText(newCollectionName).click();
     cy.button("Move").click();
   });

--- a/e2e/test/scenarios/question/question-management.cy.spec.js
+++ b/e2e/test/scenarios/question/question-management.cy.spec.js
@@ -122,6 +122,7 @@ describe(
                   openQuestionActions();
                   cy.findByTestId("move-button").click();
                   entityPickerModal().within(() => {
+                    cy.findByRole("tab", { name: /Collections/ }).click();
                     cy.findByText(/Personal Collection/).click();
                     cy.findByText("Create a new collection").click();
                   });
@@ -257,6 +258,9 @@ describe(
                     cy.findByText("Add this question to a dashboard").should(
                       "be.visible",
                     );
+                    entityPickerModal()
+                      .findByRole("tab", { name: /Dashboards/ })
+                      .click();
                     cy.findByText(/'s personal collection/i).should(
                       "be.visible",
                     );
@@ -308,7 +312,9 @@ describe(
                     cy.findByTestId("add-to-dashboard-button").click();
 
                     cy.wait("@mostRecentlyViewedDashboard");
-
+                    entityPickerModal()
+                      .findByRole("tab", { name: /Dashboards/ })
+                      .click();
                     findInactivePickerItem("Orders in a dashboard");
 
                     // before visiting the dashboard, we don't have any history
@@ -319,6 +325,9 @@ describe(
                     cy.findByTestId("add-to-dashboard-button").click();
 
                     cy.wait("@mostRecentlyViewedDashboard");
+                    entityPickerModal()
+                      .findByRole("tab", { name: /Dashboards/ })
+                      .click();
 
                     findActivePickerItem("Orders in a dashboard");
 
@@ -340,8 +349,11 @@ describe(
 
                     // no access - no dashboard
                     entityPickerModal()
-                      .findByText("Orders in a dashboard")
-                      .should("not.exist");
+                      .findByRole("tab", { name: /Dashboards/ })
+                      .click();
+                    entityPickerModal()
+                      .findByText(/Orders in a dashboard/)
+                      .should("be.disabled");
                   });
                 });
               });
@@ -498,6 +510,7 @@ function moveQuestionTo(newCollectionName) {
   openQuestionActions();
   cy.findByTestId("move-button").click();
   entityPickerModal().within(() => {
+    cy.findByRole("tab", { name: /Collections/ }).click();
     cy.findByText(newCollectionName).click();
     cy.button("Move").click();
   });

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/components/EditSandboxingModal/EditSandboxingModal.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/components/EditSandboxingModal/EditSandboxingModal.unit.spec.tsx
@@ -5,6 +5,7 @@ import {
   setupCardsEndpoints,
   setupCollectionsEndpoints,
   setupDatabasesEndpoints,
+  setupRecentViewsEndpoints,
 } from "__support__/server-mocks";
 import {
   mockGetBoundingClientRect,
@@ -66,6 +67,7 @@ const setup = ({
     collections: [EDITABLE_ROOT_COLLECTION],
     rootCollection: EDITABLE_ROOT_COLLECTION,
   });
+  setupRecentViewsEndpoints([]);
 
   fetchMock.post("path:/api/mt/gtap/validate", 204);
   fetchMock.get("path:/api/permissions/group/1", {});

--- a/frontend/src/metabase-types/api/activity.ts
+++ b/frontend/src/metabase-types/api/activity.ts
@@ -30,6 +30,7 @@ export interface RecentTableItem extends BaseRecentItem {
 
 export interface RecentCollectionItem extends BaseRecentItem {
   model: "collection" | "dashboard" | "dataset" | "card";
+  can_write: boolean;
   parent_collection: {
     id: number | null;
     name: string;

--- a/frontend/src/metabase-types/api/mocks/activity.ts
+++ b/frontend/src/metabase-types/api/mocks/activity.ts
@@ -28,6 +28,7 @@ export const createMockRecentCollectionItem = (
   model: "card",
   name: "My Cool Question",
   timestamp: "2021-03-01T00:00:00.000Z",
+  can_write: true,
   parent_collection: {
     id: 1,
     name: "My Cool Collection",

--- a/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPicker.unit.spec.tsx
@@ -2,7 +2,10 @@ import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 import _ from "underscore";
 
-import { setupCollectionItemsEndpoint } from "__support__/server-mocks";
+import {
+  setupCollectionItemsEndpoint,
+  setupRecentViewsEndpoints,
+} from "__support__/server-mocks";
 import {
   mockGetBoundingClientRect,
   mockScrollBy,
@@ -157,6 +160,7 @@ interface SetupOpts {
 }
 
 const commonSetup = () => {
+  setupRecentViewsEndpoints([]);
   mockGetBoundingClientRect();
   mockScrollBy();
 

--- a/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPickerModal.tsx
+++ b/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPickerModal.tsx
@@ -3,7 +3,7 @@ import { t } from "ttag";
 
 import { useToggle } from "metabase/hooks/use-toggle";
 import { Button, Icon } from "metabase/ui";
-import type { SearchResult } from "metabase-types/api";
+import type { RecentItem, SearchResult } from "metabase-types/api";
 
 import type { CollectionPickerModel } from "../../CollectionPicker";
 import type { EntityTab } from "../../EntityPicker";
@@ -32,6 +32,7 @@ interface DashboardPickerModalProps {
   options?: DashboardPickerOptions;
   value?: DashboardPickerInitialValueItem;
   searchFilter?: (searchResults: SearchResult[]) => SearchResult[];
+  recentFilter?: (recents: RecentItem[]) => RecentItem[];
   shouldDisableItem?: (
     item: DashboardPickerItem,
     isReadOnlyCollection?: boolean,
@@ -57,6 +58,7 @@ export const DashboardPickerModal = ({
   options = defaultOptions,
   shouldDisableItem,
   searchFilter,
+  recentFilter,
 }: DashboardPickerModalProps) => {
   options = { ...defaultOptions, ...options };
 
@@ -139,6 +141,7 @@ export const DashboardPickerModal = ({
         tabs={tabs}
         options={options}
         searchResultFilter={searchFilter}
+        recentFilter={recentFilter}
         actionButtons={modalActions}
         searchParams={
           options.showRootCollection === false

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
@@ -12,6 +12,7 @@ import type {
   SearchResultId,
   SearchRequest,
   SearchResult,
+  RecentItem,
 } from "metabase-types/api";
 
 import type {
@@ -61,6 +62,7 @@ export interface EntityPickerModalProps<Model extends string, Item> {
   tabs: EntityTab<Model>[];
   options?: Partial<EntityPickerOptions>;
   searchResultFilter?: (results: SearchResult[]) => SearchResult[];
+  recentFilter?: (results: RecentItem[]) => RecentItem[];
   searchParams?: Partial<SearchRequest>;
   actionButtons?: JSX.Element[];
   trapFocus?: boolean;
@@ -82,6 +84,7 @@ export function EntityPickerModal<
   options,
   actionButtons = [],
   searchResultFilter,
+  recentFilter,
   trapFocus = true,
   searchParams,
 }: EntityPickerModalProps<Model, Item>) {
@@ -107,13 +110,16 @@ export function EntityPickerModal<
     [passedTabs],
   );
 
-  const filteredRecents = useMemo(
-    () =>
+  const filteredRecents = useMemo(() => {
+    const relevantModelRecents =
       recentItems?.filter(recentItem =>
         tabModels.includes(recentItem.model as Model),
-      ) || [],
-    [recentItems, tabModels],
-  );
+      ) || [];
+
+    return recentFilter
+      ? recentFilter(relevantModelRecents)
+      : relevantModelRecents;
+  }, [recentItems, tabModels, recentFilter]);
 
   const tabs: EntityTab<Model | "recents">[] = useMemo(
     () =>

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.unit.spec.tsx
@@ -1,6 +1,7 @@
 import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 
+import { setupRecentViewsEndpoints } from "__support__/server-mocks";
 import {
   mockGetBoundingClientRect,
   mockScrollBy,
@@ -9,7 +10,10 @@ import {
   within,
 } from "__support__/ui";
 import { Button } from "metabase/ui";
+import type { RecentItem } from "metabase-types/api";
 import {
+  createMockRecentCollectionItem,
+  createMockRecentTableItem,
   createMockSearchResult,
   createMockSearchResults,
 } from "metabase-types/api/mocks";
@@ -30,17 +34,26 @@ interface SetupOpts {
   options?: EntityPickerModalOptions;
   selectedItem?: null | TypeWithModel<number, SampleModelType>;
   actionButtons?: JSX.Element[];
+  recentFilter?: (item: RecentItem[]) => RecentItem[];
+  recentItems?: RecentItem[];
 }
 
 const TestPicker = ({ name }: { name: string }) => (
   <p>{`Test picker ${name}`}</p>
 );
 
-const TEST_TAB: EntityTab<SampleModelType> = {
+const TEST_CARD_TAB: EntityTab<SampleModelType> = {
   icon: "audit",
   displayName: "All the foo",
   model: "card",
   element: <TestPicker name="foo" />,
+};
+
+const TEST_TABLE_TAB: EntityTab<SampleModelType> = {
+  icon: "audit",
+  displayName: "All the bar",
+  model: "table",
+  element: <TestPicker name="bar" />,
 };
 
 const setup = ({
@@ -48,12 +61,15 @@ const setup = ({
   onItemSelect = jest.fn(),
   onClose = jest.fn(),
   onConfirm = jest.fn(),
-  tabs = [TEST_TAB],
+  tabs = [TEST_CARD_TAB],
   selectedItem = null,
+  recentItems = [],
+  recentFilter,
   ...rest
 }: SetupOpts = {}) => {
   mockGetBoundingClientRect();
   mockScrollBy();
+  setupRecentViewsEndpoints(recentItems);
 
   renderWithProviders(
     <EntityPickerModal
@@ -64,6 +80,7 @@ const setup = ({
       tabs={tabs}
       selectedItem={selectedItem}
       onConfirm={onConfirm}
+      recentFilter={recentFilter}
       {...rest}
     />,
   );
@@ -98,7 +115,7 @@ describe("EntityPickerModal", () => {
   it("should show a tab list when more than 1 tab is supplied", async () => {
     const tabs: [EntityTab<SampleModelType>, ...EntityTab<SampleModelType>[]] =
       [
-        TEST_TAB,
+        TEST_CARD_TAB,
         {
           icon: "folder",
           displayName: "All the bar",
@@ -193,5 +210,84 @@ describe("EntityPickerModal", () => {
     );
 
     expect(actionFn).toHaveBeenCalledTimes(1);
+  });
+
+  describe("Recents Tab", () => {
+    const recentItems = [
+      createMockRecentCollectionItem({
+        id: 100,
+        model: "card",
+        name: "Recent Question",
+        description: "A card",
+        timestamp: "2021-09-01T00:00:00",
+      }),
+      createMockRecentCollectionItem({
+        id: 200,
+        model: "card",
+        name: "Recent Question 2",
+        description: "sometimes invisible",
+        timestamp: "2021-09-01T00:00:00",
+      }),
+      createMockRecentCollectionItem({
+        id: 101,
+        model: "dashboard",
+        name: "Recent dashboard",
+        description: "A board",
+        timestamp: "2021-09-01T00:00:00",
+      }),
+      createMockRecentTableItem({
+        id: 102,
+        model: "table",
+        name: "Recent_Table",
+        display_name: "Recent Table",
+        description: "A tableau",
+        timestamp: "2021-09-01T00:00:00",
+      }),
+    ];
+
+    it("should not show a recents tab when there are no recent items", async () => {
+      setup({});
+
+      await screen.findByText("Test picker foo");
+
+      expect(screen.queryByText("Recents")).not.toBeInTheDocument();
+    });
+
+    it("should show a recents tab when there are recent items", async () => {
+      setup({ recentItems });
+
+      expect(
+        await screen.findByRole("tab", { name: /Recents/ }),
+      ).toBeInTheDocument();
+      expect(await screen.findByText("Recent Question")).toBeInTheDocument();
+    });
+
+    it("should group recents by time", async () => {
+      setup({ recentItems });
+
+      expect(await screen.findByText("Earlier")).toBeInTheDocument();
+    });
+
+    it("should filter out irrelevant models", async () => {
+      setup({
+        recentItems,
+        tabs: [TEST_CARD_TAB, TEST_TABLE_TAB],
+      });
+
+      expect(await screen.findByText("Recent Question")).toBeInTheDocument();
+      expect(await screen.findByText("Recent Table")).toBeInTheDocument();
+      expect(screen.queryByText("Recent Dashboard")).not.toBeInTheDocument();
+    });
+
+    it("should accept an arbitrary filter", async () => {
+      setup({
+        recentItems,
+        recentFilter: items =>
+          items.filter(item => !item.description?.includes("invisible")),
+      });
+
+      expect(await screen.findByText("Recent Question")).toBeInTheDocument();
+      expect(screen.queryByText("Recent Question 2")).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/TabsView.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/TabsView.tsx
@@ -35,14 +35,20 @@ export const TabsView = <
   searchParams?: Partial<SearchRequest>;
 }) => {
   const hasSearchTab = !!searchQuery;
+  const hasRecentsTab = tabs.some(tab => tab.model === "recents");
   const previousSearchQuery = usePrevious(searchQuery);
-  const defaultTab = hasSearchTab ? { model: "search" } : tabs[0];
+  const defaultTab = hasSearchTab
+    ? { model: "search" }
+    : hasRecentsTab
+    ? { model: "recents" }
+    : tabs[0];
   const [selectedTab, setSelectedTab] = useState<string>(defaultTab.model);
 
   useMount(() => {
     if (
       initialValue?.model &&
-      tabs.some(tab => tab.model === initialValue.model)
+      tabs.some(tab => tab.model === initialValue.model) &&
+      !hasRecentsTab
     ) {
       setSelectedTab(initialValue.model);
     }

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerSearch/EntityPickerSearch.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerSearch/EntityPickerSearch.tsx
@@ -6,6 +6,7 @@ import { useSearchQuery } from "metabase/api";
 import EmptyState from "metabase/components/EmptyState";
 import { VirtualizedList } from "metabase/components/VirtualizedList";
 import { NoObjectError } from "metabase/components/errors/NoObjectError";
+import { color } from "metabase/lib/colors";
 import { Box, Flex, Icon, Stack, Tabs, TextInput } from "metabase/ui";
 import type {
   SearchModel,
@@ -92,7 +93,7 @@ export const EntityPickerSearchResults = <
   return (
     <Box h="100%" bg="bg-light">
       {searchResults.length > 0 ? (
-        <Stack h="100%">
+        <Stack h="100%" bg="bg-light">
           <VirtualizedList
             Wrapper={({ children, ...props }) => (
               <Box p="xl" {...props}>

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerSearch/EntityPickerSearch.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerSearch/EntityPickerSearch.tsx
@@ -6,7 +6,6 @@ import { useSearchQuery } from "metabase/api";
 import EmptyState from "metabase/components/EmptyState";
 import { VirtualizedList } from "metabase/components/VirtualizedList";
 import { NoObjectError } from "metabase/components/errors/NoObjectError";
-import { color } from "metabase/lib/colors";
 import { Box, Flex, Icon, Stack, Tabs, TextInput } from "metabase/ui";
 import type {
   SearchModel,

--- a/frontend/src/metabase/common/components/EntityPicker/components/RecentsTab/GroupedRecentsList.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/RecentsTab/GroupedRecentsList.tsx
@@ -1,0 +1,68 @@
+import { useMemo } from "react";
+
+import { Box, Text } from "metabase/ui";
+import type { RecentItem } from "metabase-types/api";
+
+import { ResultItem, ChunkyList } from "../ResultItem";
+
+import { getRecentGroups, recentItemToResultItem } from "./utils";
+
+export function GroupedRecentsList({
+  items,
+  onItemSelect,
+  isSelectedItem,
+}: {
+  items: RecentItem[];
+  onItemSelect: (item: RecentItem) => void;
+  isSelectedItem: (item: RecentItem) => boolean;
+}) {
+  const recentGroups = useMemo(() => getRecentGroups(items), [items]);
+
+  return (
+    <Box style={{ overflowY: "auto" }} p="xl">
+      {recentGroups.map(group => (
+        <RecentSection
+          key={group.title}
+          title={group.title}
+          items={group.items}
+          onItemSelect={onItemSelect}
+          isSelectedItem={isSelectedItem}
+        />
+      ))}
+    </Box>
+  );
+}
+
+function RecentSection({
+  title,
+  items,
+  onItemSelect,
+  isSelectedItem,
+}: {
+  title: string;
+  items: RecentItem[];
+  onItemSelect: (item: RecentItem) => void;
+  isSelectedItem: (item: RecentItem) => boolean;
+}) {
+  if (!items?.length) {
+    return null;
+  }
+  return (
+    <Box pb="lg">
+      <Text fw="bold" color="text-light" mb="sm" pl="xs">
+        {title}
+      </Text>
+      <ChunkyList>
+        {items.map((item, index) => (
+          <ResultItem
+            key={item.model + item.id}
+            item={recentItemToResultItem(item)}
+            onClick={() => onItemSelect(item)}
+            isSelected={isSelectedItem(item)}
+            isLast={index === items.length - 1}
+          />
+        ))}
+      </ChunkyList>
+    </Box>
+  );
+}

--- a/frontend/src/metabase/common/components/EntityPicker/components/RecentsTab/RecentsTab.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/RecentsTab/RecentsTab.tsx
@@ -1,0 +1,54 @@
+import { t } from "ttag";
+
+import EmptyState from "metabase/components/EmptyState";
+import { NoObjectError } from "metabase/components/errors/NoObjectError";
+import { SearchLoadingSpinner } from "metabase/nav/components/search/SearchResults";
+import { Flex, Stack } from "metabase/ui";
+import type { RecentItem } from "metabase-types/api";
+
+import type { TypeWithModel } from "../../types";
+import { isSelectedItem } from "../../utils";
+
+import { GroupedRecentsList } from "./GroupedRecentsList";
+
+export const RecentsTab = <
+  Id,
+  Model extends string,
+  Item extends TypeWithModel<Id, Model>,
+>({
+  recentItems,
+  onItemSelect,
+  selectedItem,
+  isLoading,
+}: {
+  recentItems: RecentItem[] | null;
+  onItemSelect: (item: Item) => void;
+  selectedItem: Item | null;
+  isLoading: boolean;
+}) => {
+  if (isLoading || !recentItems) {
+    return <SearchLoadingSpinner />;
+  }
+
+  return (
+    <Stack h="100%" bg="bg-light">
+      {recentItems.length > 0 ? (
+        <GroupedRecentsList
+          items={recentItems}
+          onItemSelect={item => onItemSelect(item as unknown as Item)}
+          isSelectedItem={item =>
+            isSelectedItem(item as unknown as Item, selectedItem)
+          }
+        />
+      ) : (
+        <Flex direction="column" justify="center" h="100%">
+          <EmptyState
+            title={t`Didn't find anything`}
+            message={t`There weren't any recent items.`}
+            illustrationElement={<NoObjectError mb="-1.5rem" />}
+          />
+        </Flex>
+      )}
+    </Stack>
+  );
+};

--- a/frontend/src/metabase/common/components/EntityPicker/components/RecentsTab/RecentsTab.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/RecentsTab/RecentsTab.tsx
@@ -39,6 +39,7 @@ export const RecentsTab = <
           isSelectedItem={item =>
             isSelectedItem(item as unknown as Item, selectedItem)
           }
+          // TODO: handle disable/hide option
         />
       ) : (
         <Flex direction="column" justify="center" h="100%">

--- a/frontend/src/metabase/common/components/EntityPicker/components/RecentsTab/RecentsTab.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/RecentsTab/RecentsTab.tsx
@@ -39,7 +39,6 @@ export const RecentsTab = <
           isSelectedItem={item =>
             isSelectedItem(item as unknown as Item, selectedItem)
           }
-          // TODO: handle disable/hide option
         />
       ) : (
         <Flex direction="column" justify="center" h="100%">

--- a/frontend/src/metabase/common/components/EntityPicker/components/RecentsTab/index.ts
+++ b/frontend/src/metabase/common/components/EntityPicker/components/RecentsTab/index.ts
@@ -1,0 +1,1 @@
+export * from "./RecentsTab";

--- a/frontend/src/metabase/common/components/EntityPicker/components/RecentsTab/utils.ts
+++ b/frontend/src/metabase/common/components/EntityPicker/components/RecentsTab/utils.ts
@@ -1,0 +1,58 @@
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
+import { t } from "ttag";
+dayjs.extend(relativeTime);
+
+import type { RecentItem } from "metabase-types/api";
+
+import type { ResultItemType } from "../ResultItem";
+
+const dateBuckets = [
+  { title: t`Today`, days: 1 },
+  { title: t`Yesterday`, days: 2 },
+  { title: t`Last week`, days: 7 },
+  { title: t`Earlier`, days: Infinity },
+];
+
+type RecentsGroup = {
+  title: string;
+  days: number;
+  items: RecentItem[];
+};
+
+/**
+ * groups recent items into date buckets
+ */
+export function getRecentGroups(items: RecentItem[]) {
+  const now = dayjs();
+
+  const groups = items.reduce(
+    (groups: RecentsGroup[], item) => {
+      const itemDate = dayjs(item.timestamp);
+
+      for (const group of groups) {
+        if (now.diff(itemDate, "days") < group.days) {
+          group.items.push(item);
+          break;
+        }
+      }
+      return groups;
+    },
+    dateBuckets.map(bucket => ({ ...bucket, items: [] })),
+  );
+
+  return groups.filter(group => group.items.length > 0);
+}
+
+// put a recent item into the shape expected by ResultItem component
+export const recentItemToResultItem = (item: RecentItem): ResultItemType => ({
+  ...item,
+  ...("parent_collection" in item
+    ? {
+        collection: {
+          ...item.parent_collection,
+          id: item.parent_collection.id ?? "root",
+        },
+      }
+    : {}),
+});

--- a/frontend/src/metabase/common/components/EntityPicker/components/RecentsTab/utils.unit.spec.ts
+++ b/frontend/src/metabase/common/components/EntityPicker/components/RecentsTab/utils.unit.spec.ts
@@ -1,0 +1,76 @@
+import dayjs from "dayjs";
+
+import { createMockRecentCollectionItem } from "metabase-types/api/mocks";
+
+import { getRecentGroups } from "./utils";
+
+const items = [
+  createMockRecentCollectionItem({
+    name: "This Week Q",
+    timestamp: dayjs().subtract(2, "day").toISOString(),
+  }),
+  createMockRecentCollectionItem({
+    name: "This Week Q2",
+    timestamp: dayjs().subtract(6, "day").toISOString(),
+  }),
+
+  createMockRecentCollectionItem({
+    name: "Yesterday Q1",
+    timestamp: dayjs().subtract(25, "hour").toISOString(),
+  }),
+  createMockRecentCollectionItem({
+    name: "Yesterday Q2",
+    timestamp: dayjs().subtract(47, "hour").toISOString(),
+  }),
+
+  createMockRecentCollectionItem({
+    name: "Today Q1",
+    timestamp: dayjs().subtract(1, "hour").toISOString(),
+  }),
+  createMockRecentCollectionItem({
+    name: "Today Q2",
+    timestamp: dayjs().subtract(23, "hour").toISOString(),
+  }),
+
+  createMockRecentCollectionItem({
+    name: "Old Q1",
+    timestamp: dayjs().subtract(8, "day").toISOString(),
+  }),
+  createMockRecentCollectionItem({
+    name: "Old Q2",
+    timestamp: dayjs().subtract(12, "day").toISOString(),
+  }),
+  createMockRecentCollectionItem({
+    name: "Old Q3",
+    timestamp: dayjs().subtract(19, "day").toISOString(),
+  }),
+  createMockRecentCollectionItem({
+    name: "Old Q4",
+    timestamp: dayjs().subtract(400, "day").toISOString(),
+  }),
+];
+
+describe("EntityPicker -> RecentsTab -> utils", () => {
+  it("should group recent items into date buckets", () => {
+    const groups = getRecentGroups(items);
+
+    expect(groups).toEqual([
+      { title: "Today", days: 1, items: [items[4], items[5]] },
+      { title: "Yesterday", days: 2, items: [items[2], items[3]] },
+      { title: "Last week", days: 7, items: [items[0], items[1]] },
+      {
+        title: "Earlier",
+        days: Infinity,
+        items: [items[6], items[7], items[8], items[9]],
+      },
+    ]);
+  });
+
+  it("should omit empty groups", () => {
+    const groups = getRecentGroups(items.slice(2, 4));
+
+    expect(groups).toEqual([
+      { title: "Yesterday", days: 2, items: [items[2], items[3]] },
+    ]);
+  });
+});

--- a/frontend/src/metabase/common/components/EntityPicker/components/ResultItem/ResultItem.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/ResultItem/ResultItem.tsx
@@ -10,16 +10,17 @@ import { ENTITY_PICKER_Z_INDEX } from "../EntityPickerModal";
 
 import { ChunkyListItem } from "./ResultItem.styled";
 
-export type ResultItemType = Pick<
-  SearchResult,
-  | "model"
-  | "collection"
-  | "name"
-  | "description"
-  | "collection_authority_level"
-  | "moderated_status"
-  | "display"
->;
+export type ResultItemType = Pick<SearchResult, "model" | "name"> &
+  Partial<
+    Pick<
+      SearchResult,
+      | "collection"
+      | "description"
+      | "collection_authority_level"
+      | "moderated_status"
+      | "display"
+    >
+  >;
 
 export const ResultItem = ({
   item,

--- a/frontend/src/metabase/common/components/EntityPicker/components/ResultItem/ResultItem.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/ResultItem/ResultItem.tsx
@@ -3,6 +3,7 @@ import { t } from "ttag";
 import { Ellipsified } from "metabase/core/components/Ellipsified";
 import { color } from "metabase/lib/colors";
 import { getIcon } from "metabase/lib/icon";
+import { getName } from "metabase/lib/name";
 import { Icon, Flex, Tooltip } from "metabase/ui";
 import type { SearchResult } from "metabase-types/api";
 
@@ -50,7 +51,9 @@ export const ResultItem = ({
             flexShrink: 0,
           }}
         />
-        <Ellipsified style={{ fontWeight: "bold" }}>{item.name}</Ellipsified>
+        <Ellipsified style={{ fontWeight: "bold" }}>
+          {getName(item)}
+        </Ellipsified>
         {item.description && (
           <Tooltip
             maw="20rem"

--- a/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.unit.spec.tsx
@@ -4,6 +4,7 @@ import _ from "underscore";
 
 import {
   setupCollectionItemsEndpoint,
+  setupRecentViewsEndpoints,
   setupSearchEndpoints,
 } from "__support__/server-mocks";
 import {
@@ -159,6 +160,7 @@ interface SetupOpts {
 const commonSetup = () => {
   mockGetBoundingClientRect();
   mockScrollBy();
+  setupRecentViewsEndpoints([]);
 
   const allItems = flattenCollectionTree(collectionTree).map(
     createMockCollectionItem,

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.tsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.tsx
@@ -7,7 +7,11 @@ import * as Urls from "metabase/lib/urls";
 import type { Card, Dashboard } from "metabase-types/api";
 
 import { useMostRecentlyViewedDashboard } from "./hooks";
-import { shouldDisableItem, filterWritableDashboards } from "./utils";
+import {
+  shouldDisableItem,
+  filterWritableDashboards,
+  filterWritableRecents,
+} from "./utils";
 
 const getTitle = ({ type }: Card) => {
   if (type === "model") {
@@ -89,6 +93,7 @@ export const AddToDashSelectDashModal = ({
       }}
       shouldDisableItem={shouldDisableItem}
       searchFilter={filterWritableDashboards}
+      recentFilter={filterWritableRecents}
     />
   );
 };

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
@@ -8,6 +8,7 @@ import {
   setupMostRecentlyViewedDashboard,
   setupSearchEndpoints,
   setupCollectionItemsEndpoint,
+  setupRecentViewsEndpoints,
 } from "__support__/server-mocks";
 import {
   renderWithProviders,
@@ -229,6 +230,7 @@ const setup = async ({
 
   setupCollectionsEndpoints({ collections, rootCollection: ROOT_COLLECTION });
   setupCollectionByIdEndpoint({ collections, error });
+  setupRecentViewsEndpoints([]);
   setupMostRecentlyViewedDashboard(mostRecentlyViewedDashboard);
   setupSearchEndpoints(searchResults);
 

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal/utils.ts
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal/utils.ts
@@ -4,7 +4,12 @@ import {
 } from "metabase/collections/utils";
 import type { DashboardPickerItem } from "metabase/common/components/DashboardPicker";
 import { ROOT_COLLECTION } from "metabase/entities/collections";
-import type { CollectionId, Dashboard, SearchResult } from "metabase-types/api";
+import type {
+  CollectionId,
+  Dashboard,
+  RecentItem,
+  SearchResult,
+} from "metabase-types/api";
 
 interface GetInitialOpenCollectionIdProps {
   isQuestionInPersonalCollection: boolean;
@@ -41,4 +46,8 @@ export const filterWritableDashboards = (
   dashes: SearchResult[],
 ): SearchResult[] => {
   return dashes.filter(dash => dash.can_write);
+};
+
+export const filterWritableRecents = (dashes: RecentItem[]) => {
+  return dashes.filter(dash => dash.model !== "table" && dash.can_write);
 };

--- a/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.unit.spec.tsx
@@ -8,6 +8,7 @@ import {
   setupCollectionByIdEndpoint,
   setupCollectionsEndpoints,
   setupCollectionItemsEndpoint,
+  setupRecentViewsEndpoints,
 } from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
 import {
@@ -87,6 +88,8 @@ const setup = async (
       collectionItems: [],
     });
   }
+
+  setupRecentViewsEndpoints([]);
 
   const settings = mockSettings({ "enable-query-caching": isCachingEnabled });
 

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker/LinkedEntityPicker.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker/LinkedEntityPicker.unit.spec.tsx
@@ -5,6 +5,7 @@ import {
   setupCollectionByIdEndpoint,
   setupCollectionItemsEndpoint,
   setupCollectionsEndpoints,
+  setupRecentViewsEndpoints,
   setupSearchEndpoints,
 } from "__support__/server-mocks";
 import {
@@ -104,6 +105,7 @@ function setup({
     collection: PUBLIC_COLLECTION,
     collectionItems: [],
   });
+  setupRecentViewsEndpoints([]);
 
   fetchMock.get("path:/api/user/recipients", { data: [] });
 

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardModal.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardModal.unit.spec.tsx
@@ -5,6 +5,7 @@ import { setupEnterpriseTest } from "__support__/enterprise";
 import {
   setupCollectionsEndpoints,
   setupCollectionItemsEndpoint,
+  setupRecentViewsEndpoints,
 } from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
 import { createMockEntitiesState } from "__support__/store";
@@ -54,6 +55,7 @@ function setup({
 } = {}) {
   mockGetBoundingClientRect();
   mockScrollBy();
+  setupRecentViewsEndpoints([]);
   const onClose = jest.fn();
 
   const settings = mockSettings({ "enable-query-caching": isCachingEnabled });

--- a/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceModal.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceModal.unit.spec.tsx
@@ -12,6 +12,7 @@ import {
   setupSearchEndpoints,
   setupUnauthorizedCardsEndpoints,
   setupUnauthorizedCollectionsEndpoints,
+  setupRecentViewsEndpoints,
 } from "__support__/server-mocks";
 import {
   renderWithProviders,
@@ -434,6 +435,7 @@ const setup = async ({
 
   setupDatabasesEndpoints(databases);
   setupSearchEndpoints([]);
+  setupRecentViewsEndpoints([]);
 
   if (hasCollectionAccess) {
     setupCollectionsEndpoints({ collections });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39528

### Description

Adds a recents tab to the EntityPicker, which will show recent items of the relevant entity type.

**Dashboards (add question to dashboard modal)**

![Screen Shot 2024-05-14 at 6 33 04 AM](https://github.com/metabase/metabase/assets/30528226/4631bf9c-bf99-494c-94f9-a47014804f9c)

**Collections (new dashboard modal)**

![Screen Shot 2024-05-14 at 6 32 47 AM](https://github.com/metabase/metabase/assets/30528226/f67d2067-b2f2-4907-a344-cd7bbe08fa6c)


**Questions (while editing a dashboard - replace question modal)**

![Screen Shot 2024-05-14 at 7 13 09 AM](https://github.com/metabase/metabase/assets/30528226/1a591071-fa05-45ea-aaac-c125de239f67)


## Known Limitations
- the state of the recents api is such that we can't smartly disable invalid items when moving
- the create new button should be disabled on the recents tab, because the current UX is a little wonky.


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
