### PR TITLE
[docs] surface dashboard width in toc

### DIFF
--- a/docs/dashboards/introduction.md
+++ b/docs/dashboards/introduction.md
@@ -163,9 +163,9 @@ Sections include:
 
 ![KPIs with large chart below](./images/kpis-with-large-chart-below.png)
 
-### Dashboard width
+## Dashboard width
 
-You can change the width of a dashboard.
+You can change the width of a dashboard by going into the three dots menu in the upper right:
 
 ![Change dashboard width](./images/toggle-width.png)
 


### PR DESCRIPTION
Tiny change: lots of people got surprised by changes to dashboard width. This just surfaces the section in the dashboard doc ToC -- previously it was in "arranging cards", and it's not really about cards.