### PR TITLE
Fix LegacyMetric/Segment macroexpansion with definitions using ancient MBQL

### DIFF
--- a/src/metabase/lib/convert.cljc
+++ b/src/metabase/lib/convert.cljc
@@ -157,7 +157,6 @@
 (defn do-with-aggregation-list
   "Impl for [[with-aggregation-list]]."
   [aggregations thunk]
-  (println "aggregations:" aggregations) ; NOCOMMIT
   (let [legacy->pMBQL (into {}
                             (map-indexed (fn [idx [_tag {ag-uuid :lib/uuid}]]
                                            [idx ag-uuid]))

--- a/src/metabase/query_processor/middleware/expand_macros.clj
+++ b/src/metabase/query_processor/middleware/expand_macros.clj
@@ -4,6 +4,7 @@
   (`:metric` forms are expanded into aggregations and sometimes filter clauses, while `:segment` forms are expanded
   into filter clauses.)"
   (:require
+   [metabase.legacy-mbql.normalize :as mbql.normalize]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.filter :as lib.filter]
    [metabase.lib.metadata :as lib.metadata]
@@ -60,10 +61,12 @@
   [metadata-providerable                            :- ::lib.schema.metadata/metadata-providerable
    {:keys [definition table-id], :as _legacy-macro} :- ::legacy-macro]
   (log/tracef "Converting legacy MBQL for macro definition from\n%s" (u/pprint-to-str definition))
-  (u/prog1 (-> (lib.convert/->pMBQL {:type     :query
-                                     :query    (merge {:source-table table-id}
-                                                      definition)
-                                     :database (u/the-id (lib.metadata/database metadata-providerable))})
+  (u/prog1 (-> {:type     :query
+                :query    (merge {:source-table table-id}
+                                 definition)
+                :database (u/the-id (lib.metadata/database metadata-providerable))}
+               mbql.normalize/normalize
+               lib.convert/->pMBQL
                (lib.util/query-stage -1))
     (log/tracef "to pMBQL\n%s" (u/pprint-to-str <>))))
 

--- a/test/metabase/query_processor/middleware/expand_macros_test.clj
+++ b/test/metabase/query_processor/middleware/expand_macros_test.clj
@@ -433,3 +433,23 @@
                                                            {:lib/uuid "7fb46618-622c-40f3-b0d4-4a779179f055"}
                                                            "0c586819-5288-4da9-adba-1ae904a34d5e"]]]}]
                 :database               (meta/id)}))))))
+
+(deftest ^:parallel mbql-2-macro-expansion-test
+  (testing "If the Macro is using super-legacy MBQL 2 can we still expand it?"
+    (is (=? {:aggregation [[:sum-where
+                            {}
+                            [:field {} (meta/id :venues :price)]
+                            [:<
+                             {}
+                             [:field {} (meta/id :venues :price)]
+                             4]]]}
+            (#'expand-macros/legacy-macro-definition->pMBQL
+             meta/metadata-provider
+             {:lib/type   :metadata/legacy-metric
+              :id         1
+              :name       "Metric 1"
+              :table-id   (meta/id :venues)
+              :definition {:source-table (meta/id :venues)
+                           :aggregation  [:sum-where
+                                          [:field (meta/id :venues :price) nil]
+                                          [:< [:field (meta/id :venues :price) nil] 4]]}})))))

--- a/test/metabase/query_processor/middleware/expand_macros_test.clj
+++ b/test/metabase/query_processor/middleware/expand_macros_test.clj
@@ -450,6 +450,9 @@
               :name       "Metric 1"
               :table-id   (meta/id :venues)
               :definition {:source-table (meta/id :venues)
+                           ;; note that `:aggregation` here is a single aggregation rather than a sequence of
+                           ;; aggregations, which is how we did things in MBQL 1 and 2. Also `:field` clauses are don't
+                           ;; have options map or `nil` which wasn't added until MBQL 4
                            :aggregation  [:sum-where
-                                          [:field (meta/id :venues :price) nil]
-                                          [:< [:field (meta/id :venues :price) nil] 4]]}})))))
+                                          [:field (meta/id :venues :price)]
+                                          [:< [:field (meta/id :venues :price)] 4]]}})))))

--- a/test/metabase/query_processor/reducible_test.clj
+++ b/test/metabase/query_processor/reducible_test.clj
@@ -1,4 +1,4 @@
-(ns metabase.query-processor.reducible-test
+(ns ^:mb/once metabase.query-processor.reducible-test
   "Some basic tests around very-low-level QP logic, and some of the new features of the QP (such as support for
   different reducing functions.)"
   (:require

--- a/test/metabase/query_processor_test/sum_where_test.clj
+++ b/test/metabase/query_processor_test/sum_where_test.clj
@@ -1,10 +1,10 @@
 (ns metabase.query-processor-test.sum-where-test
   (:require
    [clojure.test :refer :all]
-   [metabase.models.legacy-metric :refer [LegacyMetric]]
-   [metabase.models.segment :refer [Segment]]
-   [metabase.test :as mt]
-   [toucan2.tools.with-temp :as t2.with-temp]))
+   [metabase.lib.metadata.jvm :as lib.metadata.jvm]
+   [metabase.lib.test-util :as lib.tu]
+   [metabase.query-processor.store :as qp.store]
+   [metabase.test :as mt]))
 
 (deftest ^:parallel basic-test
   (mt/test-drivers (mt/normal-drivers-with-feature :basic-aggregations)
@@ -81,27 +81,35 @@
                 ffirst
                 double)))))
 
-(deftest segment-test
+(deftest ^:parallel segment-test
   (mt/test-drivers (mt/normal-drivers-with-feature :basic-aggregations)
-    (t2.with-temp/with-temp [Segment {segment-id :id} {:table_id   (mt/id :venues)
-                                                       :definition {:source-table (mt/id :venues)
-                                                                    :filter       [:< [:field (mt/id :venues :price) nil] 4]}}]
+    (qp.store/with-metadata-provider (lib.tu/mock-metadata-provider
+                                      (lib.metadata.jvm/application-database-metadata-provider (mt/id))
+                                      {:segments [{:id         1
+                                                   :name       "Segment 1"
+                                                   :table-id   (mt/id :venues)
+                                                   :definition {:source-table (mt/id :venues)
+                                                                :filter       [:< [:field (mt/id :venues :price) nil] 4]}}]})
       (is (= 179.0
-             (->> {:aggregation [[:sum-where [:field (mt/id :venues :price) nil] [:segment segment-id]]]}
+             (->> {:aggregation [[:sum-where [:field (mt/id :venues :price) nil] [:segment 1]]]}
                   (mt/run-mbql-query venues)
                   mt/rows
                   ffirst
                   double))))))
 
-(deftest metric-test
+(deftest ^:parallel legacy-metric-test
   (mt/test-drivers (mt/normal-drivers-with-feature :basic-aggregations)
-    (t2.with-temp/with-temp [LegacyMetric {metric-id :id} {:table_id   (mt/id :venues)
-                                                     :definition {:source-table (mt/id :venues)
-                                                                  :aggregation  [:sum-where
-                                                                                 [:field (mt/id :venues :price) nil]
-                                                                                 [:< [:field (mt/id :venues :price) nil] 4]]}}]
+    (qp.store/with-metadata-provider (lib.tu/mock-metadata-provider
+                                      (lib.metadata.jvm/application-database-metadata-provider (mt/id))
+                                      {:metrics [{:id         1
+                                                  :name       "Metric 1"
+                                                  :table-id   (mt/id :venues)
+                                                  :definition {:source-table (mt/id :venues)
+                                                               :aggregation  [:sum-where
+                                                                              [:field (mt/id :venues :price) nil]
+                                                                              [:< [:field (mt/id :venues :price) nil] 4]]}}]})
       (is (= 179.0
-             (->> {:aggregation [[:metric metric-id]]}
+             (->> {:aggregation [[:metric 1]]}
                   (mt/run-mbql-query venues)
                   mt/rows
                   ffirst


### PR DESCRIPTION
The `expand-macros` middleware wasn't calling normalize on LegacyMetric/Segment definitions, which could lead to errors if the definitions were super legacy MBQL e.g. MBQL 2 or MBQL 3.

IRL I don't think this affected anything since the JVM metadata provider should have been calling normalize on these columns, but it did break in tests using mock metadata providers.