### PR TITLE
Snowplow event for extract action via notebook shortcut

### DIFF
--- a/e2e/test/scenarios/custom-column/cc-shortcuts-extract.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/cc-shortcuts-extract.cy.spec.js
@@ -185,7 +185,7 @@ describeWithSnowplow(
 
       expectGoodSnowplowEvent({
         event: "column_extract_via_shortcut",
-        custom_expressions_used: ["hour"],
+        custom_expressions_used: ["get-hour"],
         database_id: SAMPLE_DB_ID,
         question_id: 0,
       });

--- a/frontend/src/metabase/query_builder/analytics.js
+++ b/frontend/src/metabase/query_builder/analytics.js
@@ -42,10 +42,19 @@ export const trackColumnCombineViaShortcut = (query, question) => {
   });
 };
 
-export const trackColumnExtractViaShortcut = (query, tag, question) => {
+export const trackColumnExtractViaShortcut = (
+  query,
+  stageIndex,
+  extraction,
+  question,
+) => {
   trackSchemaEvent("question", "1-0-4", {
     event: "column_extract_via_shortcut",
-    custom_expressions_used: Lib.functionsUsedByExtraction(tag),
+    custom_expressions_used: Lib.functionsUsedByExtraction(
+      query,
+      stageIndex,
+      extraction,
+    ),
     database_id: Lib.databaseID(query),
     question_id: question?.id() ?? 0,
   });

--- a/frontend/src/metabase/query_builder/analytics.js
+++ b/frontend/src/metabase/query_builder/analytics.js
@@ -41,3 +41,12 @@ export const trackColumnCombineViaShortcut = (query, question) => {
     question_id: question?.id() ?? 0,
   });
 };
+
+export const trackColumnExtractViaShortcut = (query, tag, question) => {
+  trackSchemaEvent("question", "1-0-4", {
+    event: "column_extract_via_shortcut",
+    custom_expressions_used: Lib.functionsUsedByExtraction(tag),
+    database_id: Lib.databaseID(query),
+    question_id: question?.id() ?? 0,
+  });
+};

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.tsx
@@ -9,7 +9,10 @@ import * as Lib from "metabase-lib";
 import { isExpression } from "metabase-lib/v1/expressions";
 import type { Expression } from "metabase-types/api";
 
-import { trackColumnCombineViaShortcut } from "../../analytics";
+import {
+  trackColumnCombineViaShortcut,
+  trackColumnExtractViaShortcut,
+} from "../../analytics";
 
 import { CombineColumns } from "./CombineColumns/CombineColumns";
 import { ExpressionEditorTextfield } from "./ExpressionEditorTextfield";
@@ -158,7 +161,12 @@ export const ExpressionWidget = <Clause extends object = Lib.ExpressionClause>(
   }
 
   if (isExtractingColumn) {
-    const handleSubmit = (clause: Lib.ExpressionClause, name: string) => {
+    const handleSubmit = (
+      clause: Lib.ExpressionClause,
+      name: string,
+      tag: Lib.ColumnExtractionTag,
+    ) => {
+      trackColumnExtractViaShortcut(query, tag);
       const expression = Lib.legacyExpressionForExpressionClause(
         query,
         stageIndex,

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.tsx
@@ -164,9 +164,9 @@ export const ExpressionWidget = <Clause extends object = Lib.ExpressionClause>(
     const handleSubmit = (
       clause: Lib.ExpressionClause,
       name: string,
-      tag: Lib.ColumnExtractionTag,
+      extraction: Lib.ColumnExtraction,
     ) => {
-      trackColumnExtractViaShortcut(query, tag);
+      trackColumnExtractViaShortcut(query, stageIndex, extraction);
       const expression = Lib.legacyExpressionForExpressionClause(
         query,
         stageIndex,

--- a/frontend/src/metabase/query_builder/components/expressions/ExtractColumn/ExtractColumn.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExtractColumn/ExtractColumn.tsx
@@ -16,7 +16,7 @@ type Props = {
   onSubmit: (
     clause: Lib.ExpressionClause,
     name: string,
-    tag: Lib.ColumnExtractionTag,
+    extraction: Lib.ColumnExtraction,
   ) => void;
   onCancel: () => void;
 };
@@ -55,7 +55,7 @@ export function ExtractColumn({
     const name = getName(query, stageIndex, info);
     const lastExpression = expressions.at(-1);
     if (lastExpression) {
-      onSubmit(lastExpression, name, info.tag);
+      onSubmit(lastExpression, name, extraction);
     }
   }
 

--- a/frontend/src/metabase/query_builder/components/expressions/ExtractColumn/ExtractColumn.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExtractColumn/ExtractColumn.tsx
@@ -13,7 +13,11 @@ import { getExample, getName } from "./util";
 type Props = {
   query: Lib.Query;
   stageIndex: number;
-  onSubmit: (clause: Lib.ExpressionClause, name: string) => void;
+  onSubmit: (
+    clause: Lib.ExpressionClause,
+    name: string,
+    tag: Lib.ColumnExtractionTag,
+  ) => void;
   onCancel: () => void;
 };
 
@@ -51,7 +55,7 @@ export function ExtractColumn({
     const name = getName(query, stageIndex, info);
     const lastExpression = expressions.at(-1);
     if (lastExpression) {
-      onSubmit(lastExpression, name);
+      onSubmit(lastExpression, name, info.tag);
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/42093

Depends on code from, https://github.com/metabase/metabase/pull/41774, so review that first.

### Description

Adds an analytics event that fires when the custom column is created from the expression editor in the notebook via the extract shortcut.

### To reproduce

1. New question -> Sample data -> Orders
2. Add new column
3. Select `Extract column` shortcut
4. pick an extraction
5. Verify the snowplow event was triggered
