### PR TITLE
Remove unusued code paths for automagic filtering

### DIFF
--- a/src/metabase/api/automagic_dashboards.clj
+++ b/src/metabase/api/automagic_dashboards.clj
@@ -62,7 +62,7 @@
     (deferred-tru "value couldn''t be parsed as base64 encoded JSON")))
 
 (api/defendpoint GET "/database/:id/candidates"
-  "Return a list of candidates for automagic dashboards orderd by interestingness."
+  "Return a list of candidates for automagic dashboards ordered by interestingness."
   [id]
   {id ms/PositiveInt}
   (-> (t2/select-one Database :id id)

--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -755,16 +755,16 @@
     (-> dashboard
         (populate/create-dashboard show)
         (assoc
-          :related (related
-                     root grounded-dimensions
-                     dashboard-template)
-          :more (when (and (not= show :all)
-                           (-> dashboard :cards count (> show)))
-                  (format "%s#show=all" url))
-          :transient_filters query-filter
-          :param_fields (filter-referenced-fields root query-filter)
-          :auto_apply_filters true
-          :width "fixed"))))
+         :related (related
+                   root grounded-dimensions
+                   dashboard-template)
+         :more (when (and (not= show :all)
+                          (-> dashboard :cards count (> show)))
+                 (format "%s#show=all" url))
+         :transient_filters query-filter
+         :param_fields (filter-referenced-fields root query-filter)
+         :auto_apply_filters true
+         :width "fixed"))))
 
 (defn- automagic-dashboard
   "Create dashboards for table `root` using the best matching heuristics."

--- a/src/metabase/automagic_dashboards/filters.clj
+++ b/src/metabase/automagic_dashboards/filters.clj
@@ -36,7 +36,7 @@
   [fields]
   (->> fields
        (map #(assoc % :interestingness (interestingness %)))
-       (sort-by interestingness >)
+       (sort-by :interestingness >)
        (partition-by :interestingness)
        (mapcat (fn [fields]
                  (->> fields
@@ -98,8 +98,8 @@
                     (some-> fingerprint :global :distinct-count (< 2)))))
 
 (defn add-filters
-  "Add up to `max-filters` filters to dashboard `dashboard`. Takes an optional argument `dimensions` which is a list of
-  fields for which to create filters, else it tries to infer by which fields it would be useful to filter."
+  "Add up to `max-filters` filters to dashboard `dashboard`. The `dimensions` argument is a list of fields for which to
+  create filters."
   [dashboard dimensions max-filters]
   (let [fks (when-let [table-ids (not-empty (set (keep (comp :table_id :card)
                                                        (:dashcards dashboard))))]

--- a/src/metabase/models/dashboard_tab.clj
+++ b/src/metabase/models/dashboard_tab.clj
@@ -30,7 +30,7 @@
   [:dashboard_tab_id])
 
 (methodical/defmethod t2.hydrate/batched-hydrate [:default :tab-cards]
-  "Given a list of tabs, return a seq of ordered tabs, in which each tabs contain a seq of orderd cards."
+  "Given a list of tabs, return a seq of ordered tabs, in which each tabs contain a seq of ordered cards."
   [_model _k tabs]
   (assert (= 1 (count (set (map :dashboard_id tabs)))), "All tabs must belong to the same dashboard")
   (let [dashboard-id      (:dashboard_id (first tabs))


### PR DESCRIPTION
All the way from 2018!

Set out to fix a typo, realized the entire branch wasn't used. That fn is only used in automagic-dashboards.populate, which uses the 3-arity version.

[Fixes #42099]