### PR TITLE
backported "Faster driver/describe-database for redshift"

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/driver/impersonation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/driver/impersonation_test.clj
@@ -127,7 +127,7 @@
                            mt/rows)))
                 (is (thrown-with-msg? clojure.lang.ExceptionInfo
                                       #"permission denied for relation table_without_access"
-                                      (-> {:query (format "SELECT * FROM %s.table_without_access;" schema)}
+                                      (-> {:query (format "SELECT * FROM \"%s\".table_without_access;" schema)}
                                           mt/native-query
                                           mt/process-query
                                           mt/rows)))))

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -2,7 +2,6 @@
   "Amazon Redshift Driver."
   (:require
    [cheshire.core :as json]
-   [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
    [honey.sql :as sql]
    [java-time.api :as t]
@@ -14,6 +13,7 @@
    [metabase.driver.sql-jdbc.execute.legacy-impl :as sql-jdbc.legacy]
    [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
    [metabase.driver.sql.query-processor :as sql.qp]
+   [metabase.driver.sync :as driver.s]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.mbql.util :as mbql.u]
    [metabase.public-settings :as public-settings]
@@ -51,6 +51,64 @@
   [& args]
   (apply (get-method driver/describe-table :sql-jdbc) args))
 
+(def ^:private get-tables-sql
+  ;; Cal 2024-04-09 This query uses tables that the JDBC redshift driver currently uses.
+  ;; It does not return tables from datashares, which is a relatively new feature of redshift.
+  ;; See https://github.com/dbt-labs/dbt-redshift/issues/742 for an implementation for DBT's integration with redshift
+  ;; for inspiration, and the JDBC driver itself:
+  ;; https://github.com/aws/amazon-redshift-jdbc-driver/blob/master/src/main/java/com/amazon/redshift/jdbc/RedshiftDatabaseMetaData.java#L1794
+  ;; This is a vector so adding parameters doesn't require a change to describe-database-tables in the future.
+  [(str/join
+    "\n"
+    ["select"
+     "  c.relname as name,"
+     "  n.nspname as schema,"
+     "  case c.relkind"
+     "    when 'r' then 'table'"
+     "    when 'p' then 'partitioned table'"
+     "    when 'v' then 'view'"
+     "    when 'f' then 'foreign table'"
+     "    when 'm' then 'materialized view'"
+     "    end as type,"
+     "  d.description"
+     "  from pg_catalog.pg_namespace n, pg_catalog.pg_class c"
+     "  left join pg_catalog.pg_description d on c.oid = d.objoid and d.objsubid = 0"
+     "  left join pg_catalog.pg_class dc on d.classoid=dc.oid and dc.relname='pg_class'"
+     "  left join pg_catalog.pg_namespace dn on dn.oid=dc.relnamespace and dn.nspname='pg_catalog'"
+     "  where c.relnamespace = n.oid"
+     "    and n.nspname !~ '^information_schema|catalog_history|pg_|metabase_cache_'"
+     "    and c.relkind in ('r', 'p', 'v', 'f', 'm')"
+     "    and pg_catalog.has_schema_privilege(n.nspname, 'USAGE')"
+     "    and (pg_catalog.has_table_privilege('\"'||n.nspname||'\".\"'||c.relname||'\"','SELECT')"
+     "         or pg_catalog.has_any_column_privilege('\"'||n.nspname||'\".\"'||c.relname||'\"','SELECT'))"
+     "union all"
+     "select"
+     "  tablename as name,"
+     "  schemaname as schema,"
+     "  'EXTERNAL TABLE' as type,"
+     ;; external tables don't have descriptions
+     "  null as description"
+     "from svv_external_tables t"
+     "where schemaname !~ '^information_schema|catalog_history|pg_|metabase_cache_'"
+     ;; for external tables, USAGE privileges on a schema is sufficient to select
+     "  and pg_catalog.has_schema_privilege(t.schemaname, 'USAGE')"])])
+
+(defn- describe-database-tables
+  [database]
+  (let [[inclusion-patterns
+         exclusion-patterns] (driver.s/db-details->schema-filter-patterns database)
+        syncable? (fn [schema]
+                    (driver.s/include-schema? inclusion-patterns exclusion-patterns schema))]
+    (eduction
+     (comp (filter (comp syncable? :schema))
+           (map #(dissoc % :type)))
+     (sql-jdbc.execute/reducible-query database get-tables-sql))))
+
+(defmethod driver/describe-database :redshift
+ [_driver database]
+  ;; TODO: change this to return a reducible so we don't have to hold 100k tables in memory in a set like this
+  {:tables (into #{} (describe-database-tables database))})
+
 (defmethod sql-jdbc.sync/describe-fks-sql :redshift
   [driver & {:keys [schema-names table-names]}]
   (sql/format {:select (vec
@@ -84,12 +142,13 @@
   [driver & {:keys [schema-names table-names]}]
   (sql/format {:select [[:c.column_name :name]
                         [:c.data_type :database-type]
-                        [[:- :c.ordinal_position 1] :database-position]
-                        [:c.schema_name :table-schema]
+                        [[:- :c.ordinal_position [:inline 1]] :database-position]
+                        [:c.table_schema :table-schema]
                         [:c.table_name :table-name]
                         [[:not= :pk.column_name nil] :pk?]
-                        [[:case [:not= :c.remarks ""] :c.remarks :else nil] :field-comment]]
-               :from [[:svv_all_columns :c]]
+                        [[:case [:not= :c.remarks [:inline ""]] :c.remarks :else nil] :field-comment]]
+               ;; svv_columns excludes columns from datashares, unlike svv_all_columns with includes them
+               :from [[:svv_columns :c]]
                :left-join [[{:select [:tc.table_schema
                                       :tc.table_name
                                       :kc.column_name]
@@ -99,15 +158,15 @@
                                      [:= :tc.constraint_name :kc.constraint_name]
                                      [:= :tc.table_schema :kc.table_schema]
                                      [:= :tc.table_name :kc.table_name]]]
-                             :where [:= :tc.constraint_type "PRIMARY KEY"]}
+                             :where [:= :tc.constraint_type [:inline "PRIMARY KEY"]]}
                             :pk]
                            [:and
-                            [:= :c.schema_name :pk.table_schema]
+                            [:= :c.table_schema :pk.table_schema]
                             [:= :c.table_name :pk.table_name]
                             [:= :c.column_name :pk.column_name]]]
                :where [:and
-                       [:raw "c.schema_name !~ '^information_schema|catalog_history|pg_'"]
-                       (when schema-names [:in :c.schema_name schema-names])
+                       [:raw "c.table_schema !~ '^information_schema|catalog_history|pg_'"]
+                       (when schema-names [:in :c.table_schema schema-names])
                        (when table-names [:in :c.table_name table-names])]
                :order-by [:table-schema :table-name :database-position]}
               :dialect (sql.qp/quote-style driver)))
@@ -400,38 +459,6 @@
        " */ "
        (qp.util/default-query->remark query)))
 
-(defn- reducible-schemas-with-usage-permissions
-  "Takes something `reducible` that returns a collection of string schema names (e.g. an `Eduction`) and returns an
-  `IReduceInit` that filters out schemas for which the DB user has no schema privileges."
-  [^Connection conn reducible]
-  (reify clojure.lang.IReduceInit
-    (reduce [_ rf init]
-      (with-open [stmt (prepare-statement conn "SELECT HAS_SCHEMA_PRIVILEGE(?, 'USAGE');")]
-        (reduce
-         rf
-         init
-         (eduction
-          (filter (fn [^String table-schema]
-                    (try
-                      (with-open [rs (.executeQuery (doto stmt (.setString 1 table-schema)))]
-                        (let [has-perm? (and (.next rs)
-                                             (.getBoolean rs 1))]
-                          (or has-perm?
-                              (log/tracef "Ignoring schema %s because no USAGE privilege on it" table-schema))))
-                      (catch Throwable e
-                        (log/error e (trs "Error checking schema permissions"))
-                        false))))
-          reducible))))))
-
-(defmethod sql-jdbc.sync/filtered-syncable-schemas :redshift
-  [driver conn metadata schema-inclusion-patterns schema-exclusion-patterns]
-  (let [parent-method (get-method sql-jdbc.sync/filtered-syncable-schemas :sql-jdbc)]
-    (reducible-schemas-with-usage-permissions conn (parent-method driver
-                                                                  conn
-                                                                  metadata
-                                                                  schema-inclusion-patterns
-                                                                  schema-exclusion-patterns))))
-
 (defmethod sql-jdbc.execute/set-parameter [:redshift java.time.ZonedDateTime]
   [driver ps i t]
   (sql-jdbc.execute/set-parameter driver ps i (t/sql-timestamp (t/with-zone-same-instant t (t/zone-id "UTC")))))
@@ -459,7 +486,9 @@
   [driver db-id table-name column-names values]
   ((get-method driver/insert-into! :sql-jdbc) driver db-id table-name column-names values))
 
-(defmethod sql-jdbc.sync/current-user-table-privileges :redshift
+;; Cal 2024-04-10: Commented this out instead of deleting it. We used to use this for `driver/describe-database` (see metabase#37439)
+;; This might be helpful for getting privileges for actions in the future.
+#_(defmethod sql-jdbc.sync/current-user-table-privileges :redshift
   [_driver conn-spec & {:as _options}]
   ;; KNOWN LIMITATION: this won't return privileges for external tables, calling has_table_privilege on an external table
   ;; result in an operation not supported error

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -4,14 +4,11 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.driver :as driver]
-   [metabase.driver.redshift :as redshift]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
-   [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
    [metabase.driver.sql-jdbc.sync.describe-database
     :as sql-jdbc.describe-database]
    [metabase.driver.sql.query-processor :as sql.qp]
-   [metabase.driver.sql.test-util.unique-prefix :as sql.tu.unique-prefix]
    [metabase.models.database :refer [Database]]
    [metabase.models.field :refer [Field]]
    [metabase.models.table :refer [Table]]
@@ -22,6 +19,7 @@
    [metabase.test :as mt]
    [metabase.test.data.interface :as tx]
    [metabase.test.data.redshift :as redshift.test]
+   [metabase.test.data.sql :as sql.tx]
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
    [metabase.util.honey-sql-2 :as h2x]
@@ -274,72 +272,72 @@
                       {:name "raw_var",                     :database_type "character varying", :base_type :type/Text}]
                      (t2/select [Field :name :database_type :base_type] :table_id table-id {:order-by [:name]}))))))))))
 
-(deftest filtered-syncable-schemas-test
+(deftest describe-database-privileges-test
   (mt/test-driver :redshift
-    (testing "Should filter out schemas for which the user has no perms"
-      ;; create a random username and random schema name, and grant the user USAGE permission for it
-      (let [temp-username (u/lower-case-en (mt/random-name))
-            random-schema (u/lower-case-en (mt/random-name))
-            user-pw       "Password1234"
-            db-det        (:details (mt/db))]
-        (execute! (str "CREATE SCHEMA %s;"
-                       "CREATE USER %s PASSWORD '%s';%n"
-                       "GRANT USAGE ON SCHEMA %s TO %s;%n")
-                  random-schema
-                  temp-username
-                  user-pw
-                  random-schema
-                  temp-username)
-        (try
-         (t2.with-temp/with-temp [Database db {:engine :redshift, :details (assoc db-det :user temp-username :password user-pw)}]
-           (sql-jdbc.execute/do-with-connection-with-options
-            :redshift
-            db
-            nil
-            (fn [^java.sql.Connection conn]
-              (let [schemas (reduce conj
-                                    #{}
-                                    (sql-jdbc.sync/filtered-syncable-schemas :redshift
-                                                                             conn
-                                                                             (.getMetaData conn)
-                                                                             nil
-                                                                             nil))]
-                (testing "filtered-syncable-schemas for the user should contain the newly created random schema"
-                  (is (contains? schemas random-schema)))
-                (testing "should not contain the current session-schema name (since that was never granted)"
-                  (is (not (contains? schemas (redshift.test/unique-session-schema)))))))))
-         (finally
-           (execute! (str "REVOKE USAGE ON SCHEMA %s FROM %s;%n"
-                          "DROP USER IF EXISTS %s;%n"
-                          "DROP SCHEMA IF EXISTS %s;%n")
-                     random-schema
-                     temp-username
-                     temp-username
-                     random-schema)))))
+    (testing "Should filter out schemas for which the user has insufficient select perms"
+      (let [user-name    (u/lower-case-en (mt/random-name))
+            schema       (sql.tx/session-schema :redshift)
+            table-name   (u/lower-case-en (mt/random-name))
+            schema+table (format "\"%s\".\"%s\"" schema table-name)
+            user-pw      "Password1234"
+            details      (assoc (:details (mt/db)) :user user-name, :password user-pw)
+            revoke-schema-usage (format "REVOKE USAGE ON SCHEMA \"%s\" FROM %s;%n" schema user-name)]
+        (try (execute! (str (format "CREATE USER %s PASSWORD '%s';%n" user-name user-pw)
+                            (format "CREATE TABLE %s (i INTEGER);%n" schema+table)))
+               (mt/with-temp [:model/Database db {:engine :redshift, :details details}]
+                 (let [table-is-in-results? (fn []
+                                              (binding [redshift.test/*override-describe-database-to-filter-by-db-name?* false]
+                                                (->> (:tables (driver/describe-database :redshift db))
+                                                     (map :name)
+                                                     (some #{table-name})
+                                                     boolean)))
+                       grant-schema-usage   (format "GRANT USAGE ON SCHEMA \"%s\" TO %s;%n" schema user-name)
+                       revoke-table-select  (format "REVOKE SELECT ON TABLE %s FROM %s;%n" schema+table user-name)
+                       grant-table-select   (format "GRANT SELECT ON TABLE %s TO %s;%n" schema+table user-name)]
+                   (testing "with schema usage and table select grants, table should be in results"
+                     (execute! (str grant-schema-usage grant-table-select))
+                     (is (true? (table-is-in-results?))))
+                   (testing "with no schema usage and no table select grants, table should not be in results"
+                     (execute! (str revoke-schema-usage revoke-table-select))
+                     (is (false? (table-is-in-results?))))
+                   (testing "with no schema usage but table select grants, table should not be in results"
+                     (execute! (str revoke-schema-usage grant-table-select))
+                     (is (false? (table-is-in-results?))))
+                   (testing "with schema usage but no table select grants, table should not be in results"
+                     (execute! (str grant-schema-usage revoke-table-select))
+                     (is (false? (table-is-in-results?))))))
+             (finally
+               (execute! (str revoke-schema-usage
+                              (format "DROP USER IF EXISTS %s;%n" user-name)))))))))
 
-    (testing "Should filter out non-existent schemas (for which nobody has permissions)"
-      (let [fake-schema-name (u/qualified-name ::fake-schema)]
-        (with-redefs [sql-jdbc.describe-database/all-schemas (let [orig sql-jdbc.describe-database/all-schemas]
-                                                               (fn [metadata]
-                                                                 (eduction
-                                                                  cat
-                                                                  [(orig metadata) [fake-schema-name]])))]
-          (sql-jdbc.execute/do-with-connection-with-options
-           :redshift
-           (mt/db)
-           nil
-           (fn [^java.sql.Connection conn]
-             (letfn [(schemas []
-                       (reduce
-                        conj
-                        #{}
-                        (sql-jdbc.sync/filtered-syncable-schemas :redshift conn (.getMetaData conn) nil nil)))]
-               (testing "if schemas-with-usage-permissions is disabled, the ::fake-schema should come back"
-                 (with-redefs [redshift/reducible-schemas-with-usage-permissions (fn [_ reducible]
-                                                                                   reducible)]
-                   (is (contains? (schemas) fake-schema-name))))
-               (testing "normally, ::fake-schema should be filtered out (because it does not exist)"
-                 (is (not (contains? (schemas) fake-schema-name))))))))))))
+(deftest describe-database-exclude-metabase-cache-test
+  (mt/test-driver :redshift
+    (testing "metabase_cache tables should be excluded from the describe-database results"
+      (mt/dataset avian-singles
+        (mt/with-persistence-enabled [persist-models!]
+          (let [details (assoc (:details (mt/db))
+                               :schema-filters-type "inclusion"
+                               :schema-filters-patterns "metabase_cache*,20*,pg_*")] ; 20* matches test session schemas
+            (mt/with-temp [:model/Card _      {:name          "model"
+                                               :type          :model
+                                               :dataset_query (mt/mbql-query users)
+                                               :database_id   (mt/id)}
+                           :model/Database db {:engine :redshift, :details details}]
+              (binding [redshift.test/*override-describe-database-to-filter-by-db-name?* false]
+                (persist-models!)
+                (let [synced-schemas (set (map :schema (:tables (driver/describe-database :redshift db))))]
+                  (testing "sense check: there are results matching some schemas in the schema-filters-patterns"
+                    (is (some #(re-matches #"20(.*)" %) synced-schemas)))
+                  (let [all-schemas (map :table_schema (jdbc/query (sql-jdbc.conn/db->pooled-connection-spec (mt/db))
+                                                                   "select distinct table_schema from information_schema.tables;"))]
+                    (testing "metabase_cache_ tables are excluded from results"
+                      (let [match? #(re-matches #"metabase_cache(.*)" %)]
+                        (is (some match? all-schemas))
+                        (is (not-any? match? synced-schemas))))
+                    (testing "system tables are excluded from results"
+                      (let [match? #(re-matches #"pg_(.*)" %)]
+                        (is (some match? all-schemas))
+                        (is (not-any? match? synced-schemas))))))))))))))
 
 (deftest sync-materialized-views-test
   (mt/test-driver :redshift
@@ -392,7 +390,9 @@
                (qp/process-query
                  (mt/native-query {:query "select interval '5 days'"}))))))))
 
-(deftest table-privileges-test
+;; Cal 2024-04-10: Commented this out instead of deleting it. We used to use this for `driver/describe-database` (see metabase#37439)
+;; We might use it again in the future for getting privileges for actions.
+#_(deftest table-privileges-test
   (mt/test-driver :redshift
     (testing "`table-privileges` should return the correct data for current_user and role privileges"
       (mt/with-temp [Database database {:engine :redshift :details (tx/dbdef->connection-details :redshift nil nil)}]

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -319,7 +319,7 @@
                                :schema-filters-type "inclusion"
                                :schema-filters-patterns "metabase_cache*,20*,pg_*")] ; 20* matches test session schemas
             (mt/with-temp [:model/Card _      {:name          "model"
-                                               :type          :model
+                                               :dataset       true
                                                :dataset_query (mt/mbql-query users)
                                                :database_id   (mt/id)}
                            :model/Database db {:engine :redshift, :details details}]

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -61,7 +61,6 @@
                               :datetime-diff            true
                               :now                      true
                               :persist-models           true
-                              :table-privileges         true
                               :schemas                  true
                               :uploads                  true
                               :connection-impersonation true}]
@@ -74,6 +73,7 @@
 ;; Features that are supported by postgres only
 (doseq [feature [:actions
                  :actions/custom
+                 :table-privileges
                  :index-info]]
   (defmethod driver/database-supports? [:postgres feature]
     [driver _feat _db]

--- a/src/metabase/driver/sql_jdbc/sync/describe_database.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_database.clj
@@ -138,7 +138,7 @@
       (fn [{schema :schema table :name ttype :type}]
         ;; driver/current-user-table-privileges does not return privileges for external table on redshift, and foreign
         ;; table on postgres, so we need to use the select method on them
-        (if (#{[:redshift "EXTERNAL TABLE"] [:postgres "FOREIGN TABLE"]}
+        (if (#{[:postgres "FOREIGN TABLE"]}
              [driver ttype])
           (sql-jdbc.sync.interface/have-select-privilege? driver conn schema table)
           (contains? schema+table-with-select-privileges [schema table]))))

--- a/test/metabase/sync/sync_metadata/sync_table_privileges_test.clj
+++ b/test/metabase/sync/sync_metadata/sync_table_privileges_test.clj
@@ -12,10 +12,8 @@
 (set! *warn-on-reflection* true)
 
 (deftest sync-table-privileges!-test
-  (mt/test-drivers (disj (set/intersection (mt/normal-drivers-with-feature :table-privileges)
-                                           (mt/normal-drivers-with-feature :schemas))
-                         ;; redshift supports it but we don't want to enable syncing table privileges for it for now
-                         :redshift)
+  (mt/test-drivers (set/intersection (mt/normal-drivers-with-feature :table-privileges)
+                                     (mt/normal-drivers-with-feature :schemas))
     (testing "`TablePrivileges` should store the correct data for current_user and role privileges for databases with schemas"
       (mt/with-empty-db
         (let [conn-spec (sql-jdbc.conn/db->pooled-connection-spec (mt/db))]


### PR DESCRIPTION
This is a clone of https://github.com/metabase/metabase/pull/42033, which I merged by mistake. It's exactly the same as before, but it shouldn't have been merged into the target branch.

It's now rebased on https://github.com/metabase/metabase/pull/42109's branch which needs to be merged into master first.

update: I made the same mistake _again_, and accidentally merged the branch into the upstream branch. So these changes went into https://github.com/metabase/metabase/pull/42109 and were merged into 49 from there.