### PR TITLE
[QP] Support `:temporal-unit` parameters on MBQL queries

### DIFF
--- a/src/metabase/lib/schema/parameter.cljc
+++ b/src/metabase/lib/schema/parameter.cljc
@@ -103,6 +103,12 @@
    ;; any date option above.
    :date/all-options {:type :date, :allowed-for #{:date/all-options}}
 
+   ;; `:temporal-unit` is a specialized type of parameter, and specialized widget. In MBQL queries, it maps only to
+   ;; breakout columns which have temporal bucketing set, and overrides the unit from the query.
+   ;; The value for this type of parameter is one of the temporal units from [[metabase.lib.schema.temporal-bucketing]].
+   ;; TODO: Document how this works for native queries.
+   :temporal-unit    {:allowed-for #{:temporal-unit}}
+
    ;; "operator" parameter types.
    :number/!=               {:type :numeric, :operator :variadic, :allowed-for #{:number/!=}}
    :number/<=               {:type :numeric, :operator :unary, :allowed-for #{:number/<=}}

--- a/src/metabase/query_processor/middleware/parameters.clj
+++ b/src/metabase/query_processor/middleware/parameters.clj
@@ -108,7 +108,8 @@
   `:template-tags` and removes those keys, splicing appropriate conditions into the queries they affect.
 
   A SQL query with a param like `{{param}}` will have that part of the query replaced with an appropriate snippet as
-  well as any prepared statement args needed. MBQL queries will have additional filter clauses added."
+  well as any prepared statement args needed. MBQL queries will have additional filter clauses added. (Or in a special
+  case, the temporal bucketing on a breakout altered by a `:temporal-unit` parameter.)"
   [query]
   (-> query
       hoist-database-for-snippet-tags

--- a/src/metabase/query_processor/middleware/parameters/mbql.clj
+++ b/src/metabase/query_processor/middleware/parameters/mbql.clj
@@ -88,6 +88,16 @@
      (mbql.u/wrap-field-id-if-needed field)
      (parse-param-value-for-type query param-type param-value (mbql.u/unwrap-field-or-expression-clause field))]))
 
+(defn- update-breakout-unit
+  [query
+   {[_dimension [_field target-field-id {:keys [temporal-unit]}]] :target
+    :keys [value] :as _param}]
+  (let [new-unit (keyword value)]
+    (lib.util.match/replace-in
+      query [:query :breakout]
+      [:field (_ :guard #(= target-field-id %)) (opts :guard #(= temporal-unit (:temporal-unit %)))]
+      [:field target-field-id (assoc opts :temporal-unit new-unit)])))
+
 (defn expand
   "Expand parameters for MBQL queries in `query` (replacing Dashboard or Card-supplied params with the appropriate
   values in the queries themselves)."
@@ -100,6 +110,10 @@
       (or (not target)
           (not param-value))
       (recur query rest)
+
+      (= (:type param) :temporal-unit)
+      (let [query (update-breakout-unit query (assoc param :value param-value))]
+        (recur query rest))
 
       :else
       (let [filter-clause (build-filter-clause query (assoc param :value param-value))

--- a/test/metabase/native_query_analyzer/parameter_substitution_test.clj
+++ b/test/metabase/native_query_analyzer/parameter_substitution_test.clj
@@ -22,6 +22,10 @@
      "created"       {:type         :date
                       :display-name "Genesis"
                       :name         "created"}
+     ;; Time granularity
+     "time_unit"     {:type         :temporal-unit
+                      :display-name "Unit"
+                      :name         "time_unit"}
      ;; Field Filters: Dates
      "created_range" {:type         :dimension,
                       :name         "created_range"
@@ -207,6 +211,8 @@
                     :id
                     :category
                     :boolean
+                    ;; no valid default for temporal-unit
+                    :temporal-unit
                     ;; no longer in use
                     :location/city
                     :location/state


### PR DESCRIPTION
This is a new parameter `:type` (and `:widget-type`) to choose a time
granularity (a `:temporal-unit`, eg. `month`, `day`, `day-of-week`)
which should replace the unit on the target field for the parameter.

The target field should be a breakout with a temporal type (date,
datetime) that's compatible with the input unit. The value of the
parameter should be a string or keyword naming one of the units:
`"month"`, `:month`.

