### PR TITLE
Skip flaky test

### DIFF
--- a/e2e/test/scenarios/question/reproductions/42065-mongo-filter-by-id.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/42065-mongo-filter-by-id.cy.spec.js
@@ -26,7 +26,8 @@ describe(
       });
     });
 
-    it("should be possible to filter by Mongo _id column (metabase#40770, metabase#42010)", () => {
+    // TODO: Analyze why this intermittently fails in master and fix it before unskipping!
+    it.skip("should be possible to filter by Mongo _id column (metabase#40770, metabase#42010)", () => {
       cy.get("#main-data-grid")
         .findAllByRole("gridcell")
         .first()


### PR DESCRIPTION
The test was added as part of PR #42065. We should examine intermittent failures first and re-enable then.