### PR TITLE
Add recents to Browse models table

### DIFF
--- a/e2e/test/scenarios/onboarding/home/browse.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/browse.cy.spec.js
@@ -83,7 +83,7 @@ describeWithSnowplow("scenarios > browse", () => {
 
   it("on an open-source instance, the Browse models page has no controls for setting filters", () => {
     cy.visit("/");
-    cy.findByRole("listitem", { name: "Browse models" }).click();
+    navigationSidebar().findByLabelText("Browse models").click();
     cy.findByRole("button", { name: /filter icon/i }).should("not.exist");
     cy.findByRole("switch", { name: /Show verified models only/ }).should(
       "not.exist",

--- a/frontend/src/metabase-types/api/search.ts
+++ b/frontend/src/metabase-types/api/search.ts
@@ -142,6 +142,3 @@ export type SearchRequest = {
   collection?: CollectionId;
   namespace?: "snippets";
 } & PaginationRequest;
-
-/** Model retrieved through the search endpoint */
-export type ModelResult = SearchResult<number, "dataset">;

--- a/frontend/src/metabase/browse/components/BrowseModels.tsx
+++ b/frontend/src/metabase/browse/components/BrowseModels.tsx
@@ -2,13 +2,15 @@ import { useMemo } from "react";
 import { t } from "ttag";
 
 import NoResults from "assets/img/no_results.svg";
+import { useListRecentItemsQuery } from "metabase/api";
 import { useFetchModels } from "metabase/common/hooks/use-fetch-models";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import { color } from "metabase/lib/colors";
 import { PLUGIN_CONTENT_VERIFICATION } from "metabase/plugins";
 import { Box, Flex, Group, Icon, Stack, Title } from "metabase/ui";
-import type { ModelResult } from "metabase-types/api";
 
+import type { ModelResult } from "../types";
+import { isRecentModel } from "../types";
 import { filterModels } from "../utils";
 
 import {
@@ -20,22 +22,26 @@ import {
 } from "./BrowseContainer.styled";
 import { ModelExplanationBanner } from "./ModelExplanationBanner";
 import { ModelsTable } from "./ModelsTable";
+import { RecentModels } from "./RecentModels";
+import { getMaxRecentModelCount } from "./utils";
 
 const { availableModelFilters, useModelFilterSettings, ModelFilterControls } =
   PLUGIN_CONTENT_VERIFICATION;
 
 export const BrowseModels = () => {
+  /** Mapping of filter names to true if the filter is active or false if it is inactive */
   const [actualModelFilters, setActualModelFilters] = useModelFilterSettings();
 
-  const result = useFetchModels({ model_ancestors: true });
+  const modelsResult = useFetchModels({ model_ancestors: true });
 
   const { allModels, doVerifiedModelsExist } = useMemo(() => {
-    const allModels = (result.data?.data as ModelResult[] | undefined) ?? [];
+    const allModels =
+      (modelsResult.data?.data as ModelResult[] | undefined) ?? [];
     const doVerifiedModelsExist = allModels.some(
       model => model.moderated_status === "verified",
     );
     return { allModels, doVerifiedModelsExist };
-  }, [result]);
+  }, [modelsResult]);
 
   const { filteredModels } = useMemo(() => {
     // If no models are verified, don't filter them
@@ -44,6 +50,25 @@ export const BrowseModels = () => {
       : allModels;
     return { filteredModels };
   }, [allModels, actualModelFilters, doVerifiedModelsExist]);
+
+  const recentModelsResult = useListRecentItemsQuery(undefined, {
+    refetchOnMountOrArgChange: true,
+  });
+
+  const filteredRecentModels = useMemo(
+    () =>
+      filterModels(
+        recentModelsResult.data?.filter(isRecentModel),
+        actualModelFilters,
+        availableModelFilters,
+      ),
+    [recentModelsResult.data, actualModelFilters],
+  );
+
+  const recentModels = useMemo(() => {
+    const cap = getMaxRecentModelCount(allModels.length);
+    return filteredRecentModels.slice(0, cap);
+  }, [filteredRecentModels, allModels.length]);
 
   return (
     <BrowseContainer>
@@ -73,50 +98,33 @@ export const BrowseModels = () => {
       </BrowseHeader>
       <BrowseMain>
         <BrowseSection>
-          <BrowseModelsBody result={result} models={filteredModels} />
+          <LoadingAndErrorWrapper
+            error={modelsResult.error || recentModelsResult.error}
+            loading={modelsResult.isLoading || recentModelsResult.isLoading}
+            style={{ flex: 1 }}
+          >
+            {filteredModels.length ? (
+              <Stack mb="lg" spacing="md">
+                <ModelExplanationBanner />
+                <RecentModels models={recentModels} />
+                <ModelsTable models={filteredModels} />
+              </Stack>
+            ) : (
+              <CenteredEmptyState
+                title={<Box mb=".5rem">{t`No models here yet`}</Box>}
+                message={
+                  <Box maw="24rem">{t`Models help curate data to make it easier to find answers to questions all in one place.`}</Box>
+                }
+                illustrationElement={
+                  <Box mb=".5rem">
+                    <img src={NoResults} />
+                  </Box>
+                }
+              />
+            )}
+          </LoadingAndErrorWrapper>
         </BrowseSection>
       </BrowseMain>
     </BrowseContainer>
-  );
-};
-
-export const BrowseModelsBody = ({
-  models,
-  result,
-}: {
-  models: ModelResult[];
-  result: { error?: any; isLoading: boolean };
-}) => {
-  if (result.error || result.isLoading) {
-    return (
-      <LoadingAndErrorWrapper
-        error={result.error}
-        loading={result.isLoading}
-        style={{ flex: 1 }}
-      />
-    );
-  }
-
-  if (models.length) {
-    return (
-      <Stack mb="lg" spacing="md">
-        <ModelExplanationBanner />
-        <ModelsTable models={models} />
-      </Stack>
-    );
-  }
-
-  return (
-    <CenteredEmptyState
-      title={<Box mb=".5rem">{t`No models here yet`}</Box>}
-      message={
-        <Box maw="24rem">{t`Models help curate data to make it easier to find answers to questions all in one place.`}</Box>
-      }
-      illustrationElement={
-        <Box mb=".5rem">
-          <img src={NoResults} />
-        </Box>
-      }
-    />
   );
 };

--- a/frontend/src/metabase/browse/components/BrowseModels.unit.spec.tsx
+++ b/frontend/src/metabase/browse/components/BrowseModels.unit.spec.tsx
@@ -1,21 +1,31 @@
 import {
+  setupRecentViewsEndpoints,
   setupSearchEndpoints,
   setupSettingsEndpoints,
 } from "__support__/server-mocks";
-import { renderWithProviders, screen } from "__support__/ui";
+import { renderWithProviders, screen, within } from "__support__/ui";
 import { defaultRootCollection } from "metabase/admin/permissions/pages/CollectionPermissionsPage/tests/setup";
-import type { SearchResult } from "metabase-types/api";
-import { createMockCollection } from "metabase-types/api/mocks";
+import {
+  createMockCollection,
+  createMockSearchResult,
+} from "metabase-types/api/mocks";
 import { createMockSetupState } from "metabase-types/store/mocks";
 
-import { createMockModelResult } from "../test-utils";
+import { createMockModelResult, createMockRecentModel } from "../test-utils";
 
 import { BrowseModels } from "./BrowseModels";
 
-const setup = (modelCount: number) => {
-  const models = mockModels.slice(0, modelCount);
-  setupSearchEndpoints(models);
+const setup = (modelCount: number, recentModelCount = 5) => {
+  const mockModelResults = mockModels.map(model =>
+    createMockModelResult(model),
+  );
+  const mockRecentModels = mockModels
+    .slice(0, recentModelCount)
+    .map(model => createMockRecentModel(model));
+  const models = mockModelResults.slice(0, modelCount);
+  setupSearchEndpoints(models.map(model => createMockSearchResult(model)));
   setupSettingsEndpoints([]);
+  setupRecentViewsEndpoints(mockRecentModels);
   return renderWithProviders(<BrowseModels />, {
     storeInitialState: {
       setup: createMockSetupState({
@@ -88,7 +98,7 @@ const collectionGrande = createMockCollection({
   ],
 });
 
-const mockModels: SearchResult[] = [
+const mockModels = [
   {
     id: 0,
     name: "Model 0",
@@ -251,15 +261,15 @@ const mockModels: SearchResult[] = [
     last_edited_at: "2000-01-01T00:00:00.000Z",
   },
   ...new Array(100).fill(null).map((_, i) => {
-    return createMockModelResult({
+    return {
       id: i + 300,
       name: `Model ${i + 300}`,
       collection: collectionGrande,
       last_editor_common_name: "Bobby",
       last_edited_at: "2000-01-01T00:00:00.000Z",
-    });
+    };
   }),
-].map(model => createMockModelResult(model));
+];
 
 describe("BrowseModels", () => {
   it("displays a 'no models' message in the Models tab when no models exist", async () => {
@@ -269,20 +279,53 @@ describe("BrowseModels", () => {
 
   it("displays the Our Analytics collection if it has a model", async () => {
     setup(25);
-    expect(await screen.findByRole("table")).toBeInTheDocument();
+    const modelsTable = await screen.findByRole("table");
+    expect(modelsTable).toBeInTheDocument();
     expect(
       await screen.findAllByTestId("path-for-collection: Our analytics"),
     ).toHaveLength(2);
-    expect(await screen.findByText("Model 20")).toBeInTheDocument();
-    expect(await screen.findByText("Model 21")).toBeInTheDocument();
-    expect(await screen.findByText("Model 22")).toBeInTheDocument();
+    expect(
+      await within(modelsTable).findByText("Model 20"),
+    ).toBeInTheDocument();
+    expect(
+      await within(modelsTable).findByText("Model 21"),
+    ).toBeInTheDocument();
+    expect(
+      await within(modelsTable).findByText("Model 22"),
+    ).toBeInTheDocument();
   });
 
   it("displays collection breadcrumbs", async () => {
     setup(25);
-    expect(await screen.findByText("Model 1")).toBeInTheDocument();
+    const modelsTable = await screen.findByRole("table");
+    expect(await within(modelsTable).findByText("Model 1")).toBeInTheDocument();
     expect(
-      await screen.findAllByTestId("breadcrumbs-for-collection: Alpha"),
+      await within(modelsTable).findAllByTestId(
+        "breadcrumbs-for-collection: Alpha",
+      ),
     ).toHaveLength(3);
+  });
+
+  it("displays recently viewed models", async () => {
+    setup(25);
+    const recentModelsGrid = await screen.findByRole("grid", {
+      name: /Recents/,
+    });
+    expect(recentModelsGrid).toBeInTheDocument();
+    expect(
+      await within(recentModelsGrid).findByText("Model 1"),
+    ).toBeInTheDocument();
+    expect(
+      await within(recentModelsGrid).findByText("Model 2"),
+    ).toBeInTheDocument();
+    expect(
+      await within(recentModelsGrid).findByText("Model 3"),
+    ).toBeInTheDocument();
+    expect(
+      await within(recentModelsGrid).findByText("Model 4"),
+    ).toBeInTheDocument();
+    expect(
+      within(recentModelsGrid).queryByText("Model 5"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/browse/components/Ellipsis.tsx
+++ b/frontend/src/metabase/browse/components/Ellipsis.tsx
@@ -4,9 +4,10 @@ import { forwardRef } from "react";
 import type { FlexProps } from "metabase/ui";
 import { Text } from "metabase/ui";
 
+import type { RefProp } from "../types";
+
 import { EllipsisAndSeparator } from "./CollectionBreadcrumbsWithTooltip.styled";
 import { PathSeparator } from "./PathSeparator";
-import type { RefProp } from "./types";
 type EllipsisProps = {
   includeSep?: boolean;
 } & FlexProps;

--- a/frontend/src/metabase/browse/components/ModelsTable.tsx
+++ b/frontend/src/metabase/browse/components/ModelsTable.tsx
@@ -21,10 +21,10 @@ import { color } from "metabase/lib/colors";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { getLocale } from "metabase/setup/selectors";
-import { Icon, Flex, type IconProps } from "metabase/ui";
-import type { ModelResult } from "metabase-types/api";
+import { Flex, Icon, type IconProps } from "metabase/ui";
 
 import { trackModelClick } from "../analytics";
+import type { ModelResult } from "../types";
 import { getCollectionName, getIcon } from "../utils";
 
 import {
@@ -276,7 +276,7 @@ const TableLoader = () => (
   <tr>
     <td colSpan={4}>
       <Flex justify="center" color="text-light">
-        {t`Loading...`}
+        {t`Loading…`}
       </Flex>
     </td>
   </tr>

--- a/frontend/src/metabase/browse/components/RecentModels.styled.tsx
+++ b/frontend/src/metabase/browse/components/RecentModels.styled.tsx
@@ -1,0 +1,10 @@
+import styled from "@emotion/styled";
+
+export const RecentModelsGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(13rem, 1fr));
+  gap: 0.5rem;
+  margin: 0;
+  width: 100%;
+  margin-bottom: 0.5rem;
+`;

--- a/frontend/src/metabase/browse/components/RecentModels.tsx
+++ b/frontend/src/metabase/browse/components/RecentModels.tsx
@@ -1,0 +1,37 @@
+import { t } from "ttag";
+
+import PinnedItemCard from "metabase/collections/components/PinnedItemCard";
+import { Box, Text } from "metabase/ui";
+import type { RecentCollectionItem } from "metabase-types/api";
+
+import { trackModelClick } from "../analytics";
+
+import { RecentModelsGrid } from "./RecentModels.styled";
+
+export function RecentModels({ models }: { models: RecentCollectionItem[] }) {
+  if (models.length === 0) {
+    return null;
+  }
+
+  const headingId = "recently-viewed-models-heading";
+  return (
+    <Box my="lg" role="grid" aria-labelledby={headingId}>
+      <Text
+        id={headingId}
+        fw="bold"
+        size={16}
+        color="text-dark"
+        mb="lg"
+      >{t`Recents`}</Text>
+      <RecentModelsGrid>
+        {models.map(model => (
+          <PinnedItemCard
+            key={`model-${model.id}`}
+            item={model}
+            onClick={() => trackModelClick(model.id)}
+          />
+        ))}
+      </RecentModelsGrid>
+    </Box>
+  );
+}

--- a/frontend/src/metabase/browse/components/types.tsx
+++ b/frontend/src/metabase/browse/components/types.tsx
@@ -1,4 +1,0 @@
-import type { MutableRefObject } from "react";
-
-/** @template T: The type of the value the ref will hold */
-export type RefProp<T> = { ref: MutableRefObject<T> | ((el: T) => void) };

--- a/frontend/src/metabase/browse/components/utils.tsx
+++ b/frontend/src/metabase/browse/components/utils.tsx
@@ -2,12 +2,9 @@ import { t } from "ttag";
 
 import type { SortingOptions } from "metabase/components/ItemsTable/BaseItemsTable";
 import { SortDirection } from "metabase/components/ItemsTable/Columns";
-import type {
-  CollectionEssentials,
-  ModelResult,
-  SearchResult,
-} from "metabase-types/api";
+import type { CollectionEssentials, SearchResult } from "metabase-types/api";
 
+import type { ModelResult } from "../types";
 import { getCollectionName } from "../utils";
 
 import { pathSeparatorChar } from "./constants";
@@ -108,4 +105,20 @@ export const sortModels = (
 
     return sort_direction === SortDirection.Asc ? result : -result;
   });
+};
+
+/** Find the maximum number of recently viewed models to show.
+ * This is roughly proportional to the number of models the user
+ * has permission to see */
+export const getMaxRecentModelCount = (
+  /** How many models the user has permission to see */
+  modelCount: number,
+) => {
+  if (modelCount > 20) {
+    return 8;
+  }
+  if (modelCount > 9) {
+    return 4;
+  }
+  return 0;
 };

--- a/frontend/src/metabase/browse/components/utils.unit.spec.tsx
+++ b/frontend/src/metabase/browse/components/utils.unit.spec.tsx
@@ -1,10 +1,14 @@
 import { SortDirection } from "metabase/components/ItemsTable/Columns";
-import type { ModelResult } from "metabase-types/api";
 import { createMockCollection } from "metabase-types/api/mocks";
 
 import { createMockModelResult } from "../test-utils";
+import type { ModelResult } from "../types";
 
-import { getCollectionPathString, sortModels } from "./utils";
+import {
+  getCollectionPathString,
+  sortModels,
+  getMaxRecentModelCount,
+} from "./utils";
 
 describe("getCollectionPathString", () => {
   it("should return path for collection without ancestors", () => {
@@ -147,6 +151,24 @@ describe("sortModels", () => {
         modelMap["model named Bz, with collection path D / E / F"],
         modelMap["model named B, with collection path D / E / F"],
       ]);
+    });
+  });
+
+  describe("getMaxRecentModelCount", () => {
+    it("returns 8 for modelCount greater than 20", () => {
+      expect(getMaxRecentModelCount(21)).toBe(8);
+      expect(getMaxRecentModelCount(100)).toBe(8);
+    });
+
+    it("returns 4 for modelCount greater than 9 and less than or equal to 20", () => {
+      expect(getMaxRecentModelCount(10)).toBe(4);
+      expect(getMaxRecentModelCount(20)).toBe(4);
+    });
+
+    it("returns 0 for modelCount of 9 or less", () => {
+      expect(getMaxRecentModelCount(0)).toBe(0);
+      expect(getMaxRecentModelCount(5)).toBe(0);
+      expect(getMaxRecentModelCount(9)).toBe(0);
     });
   });
 });

--- a/frontend/src/metabase/browse/test-utils.ts
+++ b/frontend/src/metabase/browse/test-utils.ts
@@ -1,7 +1,17 @@
-import type { ModelResult } from "metabase-types/api";
-import { createMockSearchResult } from "metabase-types/api/mocks";
+import type { RecentCollectionItem } from "metabase-types/api";
+import {
+  createMockRecentCollectionItem,
+  createMockSearchResult,
+} from "metabase-types/api/mocks";
+
+import type { ModelResult, RecentModel } from "./types";
 
 export const createMockModelResult = (
   model: Partial<ModelResult> = {},
 ): ModelResult =>
   createMockSearchResult({ ...model, model: "dataset" }) as ModelResult;
+
+export const createMockRecentModel = (
+  model: Partial<RecentCollectionItem>,
+): RecentModel =>
+  createMockRecentCollectionItem({ ...model, model: "dataset" }) as RecentModel;

--- a/frontend/src/metabase/browse/types.tsx
+++ b/frontend/src/metabase/browse/types.tsx
@@ -1,0 +1,27 @@
+import type { MutableRefObject } from "react";
+
+import type {
+  RecentCollectionItem,
+  RecentItem,
+  SearchResult,
+} from "metabase-types/api";
+
+export type RefProp<RefValue> = {
+  ref: MutableRefObject<RefValue> | ((value: RefValue) => void);
+};
+
+/** Model retrieved through the search endpoint */
+export type ModelResult = SearchResult<number, "dataset">;
+
+/** Model retrieved through the recent views endpoint */
+export interface RecentModel extends RecentCollectionItem {
+  model: "dataset";
+}
+
+export const isRecentModel = (item: RecentItem): item is RecentModel =>
+  item.model === "dataset";
+
+/** A model retrieved through either endpoint.
+ * This type is needed so that our filtering functions can
+ * filter arrays of models retrieved from either endpoint. */
+export type FilterableModel = ModelResult | RecentModel;

--- a/frontend/src/metabase/browse/utils.ts
+++ b/frontend/src/metabase/browse/utils.ts
@@ -9,7 +9,9 @@ import {
 } from "metabase/collections/utils";
 import { entityForObject } from "metabase/lib/schema";
 import type { IconName } from "metabase/ui";
-import type { CollectionEssentials, ModelResult } from "metabase-types/api";
+import type { CollectionEssentials } from "metabase-types/api";
+
+import type { FilterableModel } from "./types";
 
 export const getCollectionName = (collection: CollectionEssentials) => {
   if (isRootCollection(collection)) {
@@ -27,7 +29,7 @@ export const getCollectionIdForSorting = (collection: CollectionEssentials) => {
 export type AvailableModelFilters = Record<
   string,
   {
-    predicate: (value: ModelResult) => boolean;
+    predicate: (value: FilterableModel) => boolean;
     activeByDefault: boolean;
   }
 >;
@@ -41,18 +43,18 @@ export type ModelFilterControlsProps = {
  * or false if it is inactive */
 export type ActualModelFilters = Record<string, boolean>;
 
-export const filterModels = (
-  unfilteredModels: ModelResult[],
+export const filterModels = <T extends FilterableModel>(
+  unfilteredModels: T[] | undefined,
   actualModelFilters: ActualModelFilters,
   availableModelFilters: AvailableModelFilters,
-) => {
+): T[] => {
   return _.reduce(
     actualModelFilters,
     (acc, shouldFilterBeActive, filterName) =>
       shouldFilterBeActive
         ? acc.filter(availableModelFilters[filterName].predicate)
         : acc,
-    unfilteredModels,
+    unfilteredModels || [],
   );
 };
 

--- a/frontend/src/metabase/browse/utils.unit.spec.ts
+++ b/frontend/src/metabase/browse/utils.unit.spec.ts
@@ -1,8 +1,9 @@
 import { defaultRootCollection } from "metabase/admin/permissions/pages/CollectionPermissionsPage/tests/setup";
-import type { SearchResult, ModelResult } from "metabase-types/api";
+import type { SearchResult } from "metabase-types/api";
 import { createMockCollection } from "metabase-types/api/mocks";
 
 import { createMockModelResult } from "./test-utils";
+import type { ModelResult } from "./types";
 import type { ActualModelFilters, AvailableModelFilters } from "./utils";
 import { filterModels } from "./utils";
 
@@ -186,17 +187,15 @@ describe("Browse utils", () => {
   }));
   const availableModelFilters: AvailableModelFilters = {
     onlyRed: {
-      predicate: (model: SearchResult) => model.name.startsWith("red"),
+      predicate: model => model.name.startsWith("red"),
       activeByDefault: false,
     },
     onlyGood: {
-      predicate: (model: SearchResult) =>
-        Boolean(model.moderated_status?.startsWith("good")),
+      predicate: model => Boolean(model.moderated_status?.startsWith("good")),
       activeByDefault: false,
     },
     onlyBig: {
-      predicate: (model: SearchResult) =>
-        Boolean(model.description?.startsWith("big")),
+      predicate: model => Boolean(model.description?.startsWith("big")),
       activeByDefault: true,
     },
   };

--- a/frontend/src/metabase/components/ResponsiveContainer/ResponsiveContainer.tsx
+++ b/frontend/src/metabase/components/ResponsiveContainer/ResponsiveContainer.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 
-import type { RefProp } from "metabase/browse/components/types";
+import type { RefProp } from "metabase/browse/types";
 import { Box, type BoxProps } from "metabase/ui";
 
 const doNotForwardProps = (...propNamesToBlock: string[]) => ({

--- a/frontend/src/metabase/lib/icon.ts
+++ b/frontend/src/metabase/lib/icon.ts
@@ -6,13 +6,14 @@ import type {
   CardDisplayType,
   Collection,
   SearchModel,
+  CollectionItemModel,
 } from "metabase-types/api";
 
-type IconModel = SearchModel | "schema";
+type IconModel = SearchModel | CollectionItemModel | "schema";
 
 export type ObjectWithModel = {
-  model: IconModel;
   id?: unknown;
+  model: IconModel;
   authority_level?: "official" | string | null;
   collection_authority_level?: "official" | string | null;
   moderated_status?: "verified" | string | null;
@@ -32,7 +33,8 @@ const modelIconMap: Record<IconModel, IconName> = {
   dashboard: "dashboard",
   card: "table",
   segment: "segment",
-  metric: "metric",
+  metric: "funnel",
+  snippet: "unknown",
 };
 
 export type IconData = {

--- a/frontend/src/metabase/models/components/ModelDetailLink/ModelDetailLink.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailLink/ModelDetailLink.tsx
@@ -4,7 +4,11 @@ import type { ButtonProps } from "metabase/core/components/Button";
 import Button from "metabase/core/components/Button";
 import Link from "metabase/core/components/Link";
 import * as Urls from "metabase/lib/urls";
-import type { Card, CollectionItem } from "metabase-types/api";
+import type {
+  Card,
+  CollectionItem,
+  RecentCollectionItem,
+} from "metabase-types/api";
 
 type ModelCard = Card & { type: "model" };
 
@@ -21,7 +25,7 @@ type ModelCollectionItem = Omit<
 >;
 
 interface Props extends ButtonProps {
-  model: ModelCard | ModelCollectionItem;
+  model: ModelCard | ModelCollectionItem | RecentCollectionItem;
 }
 
 function ModelDetailLink({ model, ...props }: Props) {

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.unit.spec.tsx
@@ -15,15 +15,10 @@ import {
   within,
 } from "__support__/ui";
 import { createMockModelResult } from "metabase/browse/test-utils";
+import type { ModelResult } from "metabase/browse/types";
 import { ROOT_COLLECTION } from "metabase/entities/collections";
 import * as Urls from "metabase/lib/urls";
-import type {
-  Card,
-  Dashboard,
-  DashboardId,
-  ModelResult,
-  User,
-} from "metabase-types/api";
+import type { Card, Dashboard, DashboardId, User } from "metabase-types/api";
 import {
   createMockCard,
   createMockCollection,


### PR DESCRIPTION
Adds a table of recently viewed models to the Browse models table

Currently only 5 models are shown, but this will change once the relevant endpoint changes (this work is currently ongoing).

![image](https://github.com/metabase/metabase/assets/130925/33a9b8ec-0cbf-4a88-963c-065c04dd0e66)

Note that the Recents table and the table below it use different loading wrappers.

Closes #42632 