### PR TITLE
Apply mantine color palette to cartesian chart labels

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/types/theme.ts
+++ b/enterprise/frontend/src/embedding-sdk/types/theme.ts
@@ -1,7 +1,7 @@
 import type { MantineThemeOverride } from "@mantine/core";
 
 export type MetabaseTheme = MantineThemeOverride & {
-  other: MetabaseThemeOptions;
+  other?: MetabaseThemeOptions;
 };
 
 /**

--- a/frontend/src/metabase/hooks/use-palette.ts
+++ b/frontend/src/metabase/hooks/use-palette.ts
@@ -1,0 +1,23 @@
+import { useMemo } from "react";
+
+import type { ColorPalette } from "metabase/lib/colors/types";
+
+import { useMantineTheme } from "../ui";
+
+/**
+ * Gets a color palette from the current Mantine theme.
+ *
+ * Allows palettes to be overridden by the user, primarily via the React embedding SDK.
+ */
+export function usePalette(): ColorPalette {
+  const theme = useMantineTheme();
+
+  return useMemo(() => {
+    return {
+      white: theme.colors["white"]?.[0],
+      border: theme.colors["border"]?.[0],
+      "text-dark": theme.colors["text-dark"]?.[0],
+      "text-white": theme.colors["text-white"]?.[0],
+    };
+  }, [theme.colors]);
+}

--- a/frontend/src/metabase/hooks/use-palette.ts
+++ b/frontend/src/metabase/hooks/use-palette.ts
@@ -2,10 +2,10 @@ import { useMemo } from "react";
 
 import type { ColorPalette } from "metabase/lib/colors/types";
 
-import { useMantineTheme, type MantineColor } from "../ui";
+import { useMantineTheme } from "../ui";
 
 /**
- * Gets a color palette from the current Mantine theme.
+ * Extracts a color palette from a subset of colors in the Mantine theme.
  *
  * Allows palettes to be overridden by the user, primarily via the React embedding SDK.
  */
@@ -13,13 +13,11 @@ export function usePalette(): ColorPalette {
   const theme = useMantineTheme();
 
   return useMemo(() => {
-    const color = (name: MantineColor) => theme.colors[name]?.[0];
-
     return {
-      white: color("white"),
-      border: color("border"),
-      "text-dark": color("text-dark"),
-      "text-white": color("text-white"),
+      white: theme.fn.themeColor("white"),
+      border: theme.fn.themeColor("border"),
+      "text-dark": theme.fn.themeColor("text-dark"),
+      "text-white": theme.fn.themeColor("text-white"),
     };
-  }, [theme.colors]);
+  }, [theme.fn]);
 }

--- a/frontend/src/metabase/hooks/use-palette.ts
+++ b/frontend/src/metabase/hooks/use-palette.ts
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 
 import type { ColorPalette } from "metabase/lib/colors/types";
 
-import { useMantineTheme } from "../ui";
+import { useMantineTheme, type MantineColor } from "../ui";
 
 /**
  * Gets a color palette from the current Mantine theme.
@@ -13,11 +13,13 @@ export function usePalette(): ColorPalette {
   const theme = useMantineTheme();
 
   return useMemo(() => {
+    const color = (name: MantineColor) => theme.colors[name]?.[0];
+
     return {
-      white: theme.colors["white"]?.[0],
-      border: theme.colors["border"]?.[0],
-      "text-dark": theme.colors["text-dark"]?.[0],
-      "text-white": theme.colors["text-white"]?.[0],
+      white: color("white"),
+      border: color("border"),
+      "text-dark": color("text-dark"),
+      "text-white": color("text-white"),
     };
   }, [theme.colors]);
 }

--- a/frontend/src/metabase/ui/index.ts
+++ b/frontend/src/metabase/ui/index.ts
@@ -1,4 +1,4 @@
 export { rem, useMantineTheme } from "@mantine/core";
-export type { TabsValue } from "@mantine/core";
+export type { TabsValue, MantineColor } from "@mantine/core";
 export { useHover } from "@mantine/hooks";
 export * from "./components";

--- a/frontend/src/metabase/ui/index.ts
+++ b/frontend/src/metabase/ui/index.ts
@@ -1,4 +1,4 @@
 export { rem, useMantineTheme } from "@mantine/core";
-export type { TabsValue, MantineColor } from "@mantine/core";
+export type { TabsValue } from "@mantine/core";
 export { useHover } from "@mantine/hooks";
 export * from "./components";

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization-themed.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization-themed.unit.spec.tsx
@@ -1,0 +1,38 @@
+import { renderWithProviders, screen } from "__support__/ui";
+import { NumberColumn, StringColumn } from "__support__/visualizations";
+import { delay } from "metabase/lib/promise";
+import registerVisualizations from "metabase/visualizations/register";
+import { createMockCard } from "metabase-types/api/mocks";
+
+import Visualization from ".";
+
+registerVisualizations();
+
+describe("Themed Visualization", () => {
+  const TEST_COLOR = "rgb(44, 55, 66)";
+
+  const renderViz = async (series: any) => {
+    renderWithProviders(<Visualization rawSeries={series} />, {
+      theme: { colors: { "text-dark": [TEST_COLOR] } },
+    });
+
+    // The chart isn't rendered until the next tick. This is due to ExplicitSize
+    // not setting the dimensions until after mounting.
+    await delay(0);
+  };
+
+  it("inherits the chart labels from the theme", async () => {
+    await renderViz([
+      {
+        card: createMockCard({ name: "Card", display: "bar" }),
+        data: {
+          cols: [StringColumn({ name: "Foo" }), NumberColumn({ name: "Bar" })],
+          rows: [["Baz", 1]],
+        },
+      },
+    ]);
+
+    expect(screen.getByText("Foo")).toHaveAttribute("fill", TEST_COLOR);
+    expect(screen.getByText("Baz")).toHaveAttribute("fill", TEST_COLOR);
+  });
+});

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization-themed.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization-themed.unit.spec.tsx
@@ -9,7 +9,7 @@ import Visualization from ".";
 registerVisualizations();
 
 describe("Themed Visualization", () => {
-  it("inherits the chart labels from the theme", async () => {
+  it("inherits the chart label color from the theme", async () => {
     const TEST_COLOR = "rgb(44, 55, 66)";
 
     const series = [

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization-themed.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization-themed.unit.spec.tsx
@@ -9,20 +9,10 @@ import Visualization from ".";
 registerVisualizations();
 
 describe("Themed Visualization", () => {
-  const TEST_COLOR = "rgb(44, 55, 66)";
-
-  const renderViz = async (series: any) => {
-    renderWithProviders(<Visualization rawSeries={series} />, {
-      theme: { colors: { "text-dark": [TEST_COLOR] } },
-    });
-
-    // The chart isn't rendered until the next tick. This is due to ExplicitSize
-    // not setting the dimensions until after mounting.
-    await delay(0);
-  };
-
   it("inherits the chart labels from the theme", async () => {
-    await renderViz([
+    const TEST_COLOR = "rgb(44, 55, 66)";
+
+    const series = [
       {
         card: createMockCard({ name: "Card", display: "bar" }),
         data: {
@@ -30,8 +20,13 @@ describe("Themed Visualization", () => {
           rows: [["Baz", 1]],
         },
       },
-    ]);
+    ];
 
+    renderWithProviders(<Visualization rawSeries={series} />, {
+      theme: { colors: { "text-dark": [TEST_COLOR] } },
+    });
+
+    await delay(0);
     expect(screen.getByText("Foo")).toHaveAttribute("fill", TEST_COLOR);
     expect(screen.getByText("Baz")).toHaveAttribute("fill", TEST_COLOR);
   });

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-models-and-option.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-models-and-option.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from "react";
 
+import { usePalette } from "metabase/hooks/use-palette";
 import { color } from "metabase/lib/colors";
 import { formatValue } from "metabase/lib/formatting";
 import { measureTextWidth } from "metabase/lib/measure-text";
@@ -32,6 +33,8 @@ export function useModelsAndOption({
   onRender,
   hovered,
 }: VisualizationProps) {
+  const palette = usePalette();
+
   const rawSeriesWithRemappings = useMemo(
     () => extractRemappings(rawSeries),
     [rawSeries],
@@ -49,12 +52,12 @@ export function useModelsAndOption({
 
   const renderingContext: RenderingContext = useMemo(
     () => ({
-      getColor: color,
+      getColor: name => color(name, palette),
       formatValue: (value, options) => String(formatValue(value, options)),
       measureText: measureTextWidth,
       fontFamily,
     }),
-    [fontFamily],
+    [fontFamily, palette],
   );
 
   const hasTimelineEvents = timelineEvents

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -1,3 +1,4 @@
+import type { MantineThemeOverride } from "@mantine/core";
 import type { Store, Reducer } from "@reduxjs/toolkit";
 import type { MatcherFunction } from "@testing-library/dom";
 import type { ByRoleMatcher } from "@testing-library/react";
@@ -45,6 +46,7 @@ export interface RenderWithProvidersOptions {
   withUndos?: boolean;
   customReducers?: ReducerObject;
   sdkConfig?: SDKConfig | null;
+  theme?: MantineThemeOverride;
 }
 
 /**
@@ -63,6 +65,7 @@ export function renderWithProviders(
     withUndos = false,
     customReducers,
     sdkConfig = null,
+    theme,
     ...options
   }: RenderWithProvidersOptions = {},
 ) {
@@ -119,7 +122,9 @@ export function renderWithProviders(
 
   const wrapper = (props: any) => {
     if (mode === "sdk") {
-      return <SdkWrapper {...props} config={sdkConfig} store={store} />;
+      return (
+        <SdkWrapper {...props} config={sdkConfig} store={store} theme={theme} />
+      );
     }
 
     return (
@@ -130,6 +135,7 @@ export function renderWithProviders(
         withRouter={withRouter}
         withDND={withDND}
         withUndos={withUndos}
+        theme={theme}
       />
     );
   };
@@ -153,6 +159,7 @@ function Wrapper({
   withRouter,
   withDND,
   withUndos,
+  theme,
 }: {
   children: React.ReactElement;
   store: any;
@@ -160,11 +167,12 @@ function Wrapper({
   withRouter: boolean;
   withDND: boolean;
   withUndos?: boolean;
+  theme?: MantineThemeOverride;
 }): JSX.Element {
   return (
     <Provider store={store}>
       <MaybeDNDProvider hasDND={withDND}>
-        <ThemeProvider>
+        <ThemeProvider theme={theme}>
           <MaybeRouter hasRouter={withRouter} history={history}>
             {children}
           </MaybeRouter>


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/41949

### Description

Cartesian charts currently get their color from the `color` function from `lib/colors/palette.ts`, but these colors are hard-coded and not overrideable by users. This PR adds the `use-palette` hook that extracts a subset of color palettes from a Mantine theme, and apply the palette into the cartesian chart.

### How to verify

1. Go to the `basic-theming` branch in the demo app
2. Go to the `/admin/internal/kitchen-sink` page
3. Verify that the theme color in `AppProvider` is set to a custom value, e.g. text-dark is hotpink:

```ts
  colors: {
    brand: colorTuple("hotpink"),
    "text-dark": colorTuple("hotpink"),
    "text-light": colorTuple("hotpink"),
  },
```

4. The 3 chart labels should now be in hotpink, instead of black.

### Screenshot

Labels used to use the hard-coded text-dark color, but now it becomes hotpink as defined above.

![CleanShot 2567-05-02 at 19 01 08@2x](https://github.com/metabase/metabase/assets/4714175/82fdb5a4-0ae7-4362-96e6-737a688e109d)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR