### PR TITLE
fix alignment on setup items not completed and without a description

### DIFF
--- a/frontend/src/metabase/admin/settings/setup/components/SetupCheckList/SetupCheckList.jsx
+++ b/frontend/src/metabase/admin/settings/setup/components/SetupCheckList/SetupCheckList.jsx
@@ -82,7 +82,9 @@ const Task = ({ title, description, completed, link }) => (
         title={title}
         titleClassName={completed ? CS.textSuccess : CS.textBrand}
       />
-      {!completed ? <TaskDescription description={description} /> : null}
+      {!completed && description ? (
+        <TaskDescription description={description} />
+      ) : null}
     </div>
   </TaskLink>
 );


### PR DESCRIPTION

### Description

The P was rendered even if empty, making the item misaligned.

Reported [here](https://metaboat.slack.com/archives/C063Q3F1HPF/p1714527958479199?thread_ts=1714498386.014709&cid=C063Q3F1HPF)



### Demo

Before
<img width="621" alt="image" src="https://github.com/metabase/metabase/assets/1914270/3cf69fef-3357-4d24-a353-8e46510a002b">


After
<img width="613" alt="image" src="https://github.com/metabase/metabase/assets/1914270/fe56e3e3-ceef-497c-ba98-16e28c4a82ed">


### Checklist

