### PR TITLE
Fix data source E2E test

### DIFF
--- a/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
@@ -12,6 +12,7 @@ import {
 import type { StructuredQuestionDetails } from "e2e/support/helpers";
 import {
   createQuestion,
+  describeOSS,
   entityPickerModal,
   isEE,
   isOSS,
@@ -86,31 +87,6 @@ describe("scenarios > notebook > data source", () => {
           .each(table => {
             cy.wrap(table).should("have.attr", "aria-selected", "false");
           });
-      });
-    });
-
-    it("should not show saved questions if only models exist (metabase#25142)", () => {
-      createQuestion({
-        name: "GUI Model",
-        query: { "source-table": REVIEWS_ID, limit: 1 },
-        display: "table",
-        type: "model",
-      });
-
-      startNewQuestion();
-      popover().within(() => {
-        cy.findByPlaceholderText("Search for some data…");
-        cy.findAllByTestId("data-bucket-list-item")
-          .as("sources")
-          .should("have.length", 2);
-        cy.get("@sources")
-          .first()
-          .should("contain", "Models")
-          .and("have.attr", "aria-selected", "false");
-        cy.get("@sources")
-          .last()
-          .should("contain", "Raw Data")
-          .and("have.attr", "aria-selected", "false");
       });
     });
 
@@ -326,6 +302,38 @@ describe("scenarios > notebook > data source", () => {
       openDataSelector();
       assertSourceCollection("First collection");
       assertDataSource(sourceQuestionName);
+    });
+  });
+});
+
+describeOSS("scenarios > notebook > data source", () => {
+  beforeEach(() => {
+    restore("setup");
+    cy.signInAsAdmin();
+  });
+
+  it("should not show saved questions if only models exist (metabase#25142)", () => {
+    createQuestion({
+      name: "GUI Model",
+      query: { "source-table": REVIEWS_ID, limit: 1 },
+      display: "table",
+      type: "model",
+    });
+
+    startNewQuestion();
+    popover().within(() => {
+      cy.findByPlaceholderText("Search for some data…");
+      cy.findAllByTestId("data-bucket-list-item")
+        .as("sources")
+        .should("have.length", 2);
+      cy.get("@sources")
+        .first()
+        .should("contain", "Models")
+        .and("have.attr", "aria-selected", "false");
+      cy.get("@sources")
+        .last()
+        .should("contain", "Raw Data")
+        .and("have.attr", "aria-selected", "false");
     });
   });
 });


### PR DESCRIPTION
Fixes a E2E test failure from https://app.replay.io/team/dzoyNTM4ZjRmOC05YmFlLTRiYjYtYjljYi1jOGYzOWUyMjRhZWY=/runs?testRunId=626f055a-eefb-4146-96b5-140dc39cf2ff

The test only makes sense for OSS because in EE there are always instance analytics questions. It works accidentally in `master` and if you run it locally you see that `Saved Questions` there is added just a moment after the test finishes.

How to verify:
- `should not show saved questions if only models exist (metabase#25142)` should not fail 
- Link to the last run https://app.replay.io/team/dzoyNTM4ZjRmOC05YmFlLTRiYjYtYjljYi1jOGYzOWUyMjRhZWY=/runs?testRunId=e78677cd-a4d3-4683-9930-d5ea3535bc3d. The dashboard test still fails for a different reason. 