### PR TITLE
Enable Mongo tests to run in the stress-test action

### DIFF
--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -45,6 +45,7 @@ jobs:
     env:
       DISPLAY: ""
       QA_DB_ENABLED: true
+      CYPRESS_QA_DB_MONGO: true
       CYPRESS_REPLAYIO_ENABLED: 1
       CYPRESS_ALL_FEATURES_TOKEN: ${{ secrets.ENTERPRISE_TOKEN }}
       CYPRESS_NO_FEATURES_TOKEN: ${{ secrets.E2E_STARTER_TOKEN }}


### PR DESCRIPTION
This PR makes it possible for Mongo related E2E tests to run in the stress-test scenario.

The downside could be adding of overhead in the "snapshot" creation phase.
Also, if Mongo starts acting up, we might see the failure to create snapshots in the first place.

The alternative would be to add another input to the action that explicitly controls the Mongo env.

P.S. I used this exact variable when testing Mongo E2E test in this run:
https://github.com/metabase/metabase/actions/runs/8924913940/job/24512349673