### PR TITLE
Remove cartesian chart padding when in React embedding environment

### DIFF
--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
@@ -14,6 +14,7 @@ import * as MetabaseAnalytics from "metabase/lib/analytics";
 import { formatNumber } from "metabase/lib/formatting";
 import { equals } from "metabase/lib/utils";
 import { getIsShowingRawTable } from "metabase/query_builder/selectors";
+import { getIsEmbeddingSdk } from "metabase/selectors/embed";
 import { getFont } from "metabase/styled-components/selectors";
 import {
   extractRemappings,
@@ -55,6 +56,7 @@ const defaultProps = {
   isEditing: false,
   isSettings: false,
   isQueryBuilder: false,
+  isEmbeddingSdk: false,
   onUpdateVisualizationSettings: () => {},
   // prefer passing in a function that doesn't cause the application to reload
   onChangeLocation: location => {
@@ -65,6 +67,7 @@ const defaultProps = {
 const mapStateToProps = state => ({
   fontFamily: getFont(state),
   isRawTable: getIsShowingRawTable(state),
+  isEmbeddingSdk: getIsEmbeddingSdk(state),
 });
 
 const SMALL_CARD_WIDTH_THRESHOLD = 150;

--- a/frontend/src/metabase/visualizations/types/visualization.ts
+++ b/frontend/src/metabase/visualizations/types/visualization.ts
@@ -65,6 +65,7 @@ export interface VisualizationProps {
   isPlaceholder?: boolean;
   isFullscreen: boolean;
   isQueryBuilder: boolean;
+  isEmbeddingSdk: boolean;
   showTitle: boolean;
   isDashboard: boolean;
   isEditing: boolean;

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.styled.tsx
@@ -3,9 +3,27 @@ import styled from "@emotion/styled";
 import { ResponsiveEChartsRenderer } from "metabase/visualizations/components/EChartsRenderer";
 import LegendLayout from "metabase/visualizations/components/legend/LegendLayout";
 
-export const CartesianChartRoot = styled.div<{ isQueryBuilder: boolean }>`
-  padding: ${({ isQueryBuilder }) =>
-    isQueryBuilder ? "1rem 1rem 1rem 2rem" : "0.5rem 1rem"};
+type CartesianChartRootProps = {
+  isQueryBuilder?: boolean;
+  isEmbeddingSdk?: boolean;
+};
+
+const getChartPadding = ({
+  isEmbeddingSdk,
+  isQueryBuilder,
+}: CartesianChartRootProps) => {
+  if (isEmbeddingSdk) {
+    return "0rem";
+  }
+  if (isQueryBuilder) {
+    return "1rem 1rem 1rem 2rem";
+  }
+
+  return "0.5rem 1rem";
+};
+
+export const CartesianChartRoot = styled.div<CartesianChartRootProps>`
+  padding: ${getChartPadding};
   height: 100%;
   display: flex;
   flex-direction: column;

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
@@ -32,6 +32,7 @@ function _CartesianChart(props: VisualizationProps) {
     headerIcon,
     actionButtons,
     isQueryBuilder,
+    isEmbeddingSdk,
     isFullscreen,
     hovered,
     onChangeCardAndRun,
@@ -88,7 +89,10 @@ function _CartesianChart(props: VisualizationProps) {
   const canSelectTitle = !!onChangeCardAndRun;
 
   return (
-    <CartesianChartRoot isQueryBuilder={isQueryBuilder}>
+    <CartesianChartRoot
+      isQueryBuilder={isQueryBuilder}
+      isEmbeddingSdk={isEmbeddingSdk}
+    >
       {hasTitle && (
         <LegendCaption
           title={title}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/42157

### Description

We currently add some extraneous padding in the cartesian chart root.

```ts
  padding: ${({ isQueryBuilder }) =>
    isQueryBuilder ? "1rem 1rem 1rem 2rem" : "0.5rem 1rem"};
```

This affects layout when we are building apps.

<img src="https://github.com/metabase/metabase/assets/4714175/60766fa0-9d13-4c3f-96ee-510b8bf784e9" width="200" />

### How to verify

- Navigate to `/admin/internal/kitchen-sink` in the demo app, using the `basic-theming` branch.
- There shouldn't be any extraneous padding, compared to the above image.

<img src="https://github.com/metabase/metabase/assets/4714175/3469c869-0067-405a-8bb0-5d29eed24ba9" width="200" />