### PR TITLE
42078 palette search links

### DIFF
--- a/frontend/src/metabase/palette/components/PaletteResultItem.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResultItem.tsx
@@ -1,3 +1,5 @@
+import { useCallback } from "react";
+import { Link } from "react-router";
 import { t } from "ttag";
 
 import { color } from "metabase/lib/colors";
@@ -8,15 +10,28 @@ import type { PaletteActionImpl } from "../types";
 interface PaletteResultItemProps {
   item: PaletteActionImpl;
   active: boolean;
+  togglePalette: () => void;
 }
 
-export const PaletteResultItem = ({ item, active }: PaletteResultItemProps) => {
+export const PaletteResultItem = ({
+  item,
+  active,
+  togglePalette,
+}: PaletteResultItemProps) => {
   const iconColor = active ? color("brand-light") : color("text-light");
 
   const parentName =
     item.extra?.parentCollection || item.extra?.database || null;
 
-  return (
+  const handleLinkClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      togglePalette();
+    },
+    [togglePalette],
+  );
+
+  const content = (
     <Flex
       p=".75rem"
       mx="1.5rem"
@@ -115,4 +130,19 @@ export const PaletteResultItem = ({ item, active }: PaletteResultItemProps) => {
       )}
     </Flex>
   );
+
+  if (item.extra?.href) {
+    return (
+      <Box
+        component={Link}
+        to={item.extra.href}
+        onClick={handleLinkClick}
+        w="100%"
+      >
+        {content}
+      </Box>
+    );
+  } else {
+    return content;
+  }
 };

--- a/frontend/src/metabase/palette/components/PaletteResults.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResults.tsx
@@ -84,7 +84,11 @@ export const PaletteResults = () => {
                   {item}
                 </Box>
               ) : (
-                <PaletteResultItem item={item} active={active} />
+                <PaletteResultItem
+                  item={item}
+                  active={active}
+                  togglePalette={query.toggle}
+                />
               )}
             </Flex>
           );

--- a/frontend/src/metabase/palette/components/PaletteResults.unit.spec.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResults.unit.spec.tsx
@@ -1,6 +1,6 @@
-import { KBarProvider, useKBar } from "kbar";
+import { useKBar } from "kbar";
 import { useEffect } from "react";
-import { withRouter, type WithRouterProps } from "react-router";
+import { Route, withRouter, type WithRouterProps } from "react-router";
 
 import {
   setupDatabasesEndpoints,
@@ -101,10 +101,10 @@ const setup = ({ query }: { query?: string } = {}) => {
   setupRecentViewsEndpoints([recents_1, recents_2]);
 
   renderWithProviders(
-    <KBarProvider>
-      <TestComponent q={query} isLoggedIn />
-    </KBarProvider>,
+    <Route path="/" component={() => <TestComponent q={query} isLoggedIn />} />,
     {
+      withKBar: true,
+      withRouter: true,
       storeInitialState: {
         admin: createMockAdminState({
           app: createMockAdminAppState({
@@ -142,6 +142,11 @@ describe("PaletteResults", () => {
     expect(
       await screen.findByRole("option", { name: "Bar Dashboard" }),
     ).toHaveTextContent("lame collection");
+
+    expect(
+      await screen.findByRole("link", { name: "Bar Dashboard" }),
+    ).toHaveAttribute("href", "/dashboard/1-bar-dashboard");
+
     expect(
       await screen.findByRole("option", { name: "Foo Question" }),
     ).toHaveTextContent("Our analytics");
@@ -164,6 +169,10 @@ describe("PaletteResults", () => {
     expect(
       await screen.findByRole("option", { name: "Bar Dashboard" }),
     ).toBeInTheDocument();
+
+    expect(
+      await screen.findByRole("link", { name: "Bar Dashboard" }),
+    ).toHaveAttribute("href", "/dashboard/1-bar-dashboard");
 
     expect(
       await screen.findByRole("option", { name: "Bar Dashboard" }),

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -122,7 +122,7 @@ export const useCommandPalette = () => {
       ];
     } else if (debouncedSearchText) {
       if (searchResults?.data?.length) {
-        return searchResults.data.map(result => {
+        return searchResults.data.map<PaletteAction>(result => {
           const wrappedResult = Search.wrapEntity(result, dispatch);
           return {
             id: `search-result-${result.model}-${result.id}`,

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -14,7 +14,6 @@ import { getIcon } from "metabase/lib/icon";
 import { getName } from "metabase/lib/name";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
-import { closeModal } from "metabase/redux/ui";
 import {
   getDocsSearchUrl,
   getDocsUrl,
@@ -133,13 +132,14 @@ export const useCommandPalette = () => {
             keywords: debouncedSearchText,
             subtitle: result.description || "",
             perform: () => {
-              dispatch(closeModal());
+              // Need to keep this logic here for when user selects via keyboard
               dispatch(push(wrappedResult.getUrl()));
             },
             extra: {
               parentCollection: wrappedResult.getCollection().name,
               isVerified: result.moderated_status === "verified",
               database: result.database_name,
+              href: wrappedResult.getUrl(),
             },
           };
         });
@@ -174,12 +174,17 @@ export const useCommandPalette = () => {
         icon: getIcon(item).name,
         section: "recent",
         perform: () => {
-          dispatch(push(Urls.modelToUrl(item) ?? ""));
+          // Need to keep this logic here for when user selects via keyboard
+          const href = Urls.modelToUrl(item);
+          if (href) {
+            dispatch(push(href));
+          }
         },
         extra:
           item.model === "table"
             ? {
                 database: item.model_object.database_name,
+                href: Urls.modelToUrl(item),
               }
             : {
                 parentCollection:
@@ -187,6 +192,7 @@ export const useCommandPalette = () => {
                     ? ROOT_COLLECTION.name
                     : item.model_object.collection_name,
                 isVerified: item.model_object.moderated_status === "verified",
+                href: Urls.modelToUrl(item),
               },
       })) || []
     );

--- a/frontend/src/metabase/palette/types.ts
+++ b/frontend/src/metabase/palette/types.ts
@@ -7,6 +7,7 @@ interface PaletteActionExtras {
     parentCollection?: string | null;
     isVerified?: boolean;
     database?: string | null;
+    href?: string | null;
   };
 }
 

--- a/frontend/src/metabase/palette/types.ts
+++ b/frontend/src/metabase/palette/types.ts
@@ -4,9 +4,16 @@ import type { IconName } from "metabase/ui";
 
 interface PaletteActionExtras {
   extra?: {
+    /** parentCollection: Name of the collection to show in the palette item */
     parentCollection?: string | null;
+    /** isVerified: If true, will show a verified badge next to the item name */
     isVerified?: boolean;
+    /** database: Name of the database to show next the name in the palette item. */
     database?: string | null;
+    /**
+     * href: If defined, the palette item will be wrapped in a link. This allows for
+     * browser interactions to open items in new tabs/windows
+     */
     href?: string | null;
   };
 }

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -5,6 +5,7 @@ import type { ByRoleMatcher } from "@testing-library/react";
 import { render, screen, waitFor } from "@testing-library/react";
 import type { History } from "history";
 import { createMemoryHistory } from "history";
+import { KBarProvider } from "kbar";
 import type * as React from "react";
 import { DragDropContextProvider } from "react-dnd";
 import HTML5Backend from "react-dnd-html5-backend";
@@ -42,6 +43,8 @@ export interface RenderWithProvidersOptions {
   initialRoute?: string;
   storeInitialState?: Partial<State>;
   withRouter?: boolean;
+  /** Renders children wrapped with kbar provider */
+  withKBar?: boolean;
   withDND?: boolean;
   withUndos?: boolean;
   customReducers?: ReducerObject;
@@ -61,6 +64,7 @@ export function renderWithProviders(
     initialRoute = "/",
     storeInitialState = {},
     withRouter = false,
+    withKBar = false,
     withDND = false,
     withUndos = false,
     customReducers,
@@ -136,6 +140,7 @@ export function renderWithProviders(
         withDND={withDND}
         withUndos={withUndos}
         theme={theme}
+        withKBar={withKBar}
       />
     );
   };
@@ -157,6 +162,7 @@ function Wrapper({
   store,
   history,
   withRouter,
+  withKBar,
   withDND,
   withUndos,
   theme,
@@ -165,6 +171,7 @@ function Wrapper({
   store: any;
   history?: History;
   withRouter: boolean;
+  withKBar: boolean;
   withDND: boolean;
   withUndos?: boolean;
   theme?: MantineThemeOverride;
@@ -173,9 +180,11 @@ function Wrapper({
     <Provider store={store}>
       <MaybeDNDProvider hasDND={withDND}>
         <ThemeProvider theme={theme}>
-          <MaybeRouter hasRouter={withRouter} history={history}>
-            {children}
-          </MaybeRouter>
+          <MaybeKBar hasKBar={withKBar}>
+            <MaybeRouter hasRouter={withRouter} history={history}>
+              {children}
+            </MaybeRouter>
+          </MaybeKBar>
           {withUndos && <UndoListing />}
         </ThemeProvider>
       </MaybeDNDProvider>
@@ -221,6 +230,19 @@ function MaybeRouter({
     return children;
   }
   return <Router history={history}>{children}</Router>;
+}
+
+function MaybeKBar({
+  children,
+  hasKBar,
+}: {
+  children: React.ReactElement;
+  hasKBar: boolean;
+}): JSX.Element {
+  if (!hasKBar) {
+    return children;
+  }
+  return <KBarProvider>{children}</KBarProvider>;
 }
 
 function MaybeDNDProvider({


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/42078

### Description
Wraps search results and recent items in the command palette with a Link component. This allows for right click -> open in new tab type interactions that the browsers natively support for links

### How to verify

1. Open the command palette
2. Right click on an item in recents and open in a new tab. `ctrl + click` also works

### Demo
![chrome_s9lNWnqBVF](https://github.com/metabase/metabase/assets/1328979/bdd0d287-d3e8-4a61-9134-5e03e35614b5)

### Checklist
Tests are a bit spotty... it doesn't seem like cypress supports context menu navigation. Currently I updated unit tests to ensure that links are rendered, but there may be room for more here
- [x] Tests have been added/updated to cover changes in this PR
