### PR TITLE
docs - update filter docs

### DIFF
--- a/docs/data-modeling/metadata-editing.md
+++ b/docs/data-modeling/metadata-editing.md
@@ -146,11 +146,11 @@ To change a column's [filter widget](../dashboards/filters.md):
 
 The default behavior for the `Is` filter for the field.
 
-- **Search box**: Metabase will display a search box and suggest autocompletions for values in that column that match the search term(s).
-- **A list of all values**: Display a search box, as well as a list of checkboxes for values in a dropdown menu that people can select.
+- **Search box**: Display a search box and suggest autocompletions for values in that column that match the search term(s).
+- **A list of all values**: Display a search box, as well as a list of checkboxes for values in a dropdown menu that people can select as search terms.
 - **Plain input box**: Display a search box, but do NOT suggest autocompletions.
 
- For the `Is` filter option, Metabase will accept multiple search terms. The `Is` filter will return results that match any of the terms (e.g., "term 1" OR "term 2").
+For the `Is` filter option, Metabase will accept multiple search terms. The `Is` filter will return results that match any of the terms (e.g., "term 1" OR "term 2").
 
 ### Changing a search box filter to a dropdown filter
 

--- a/docs/data-modeling/metadata-editing.md
+++ b/docs/data-modeling/metadata-editing.md
@@ -144,14 +144,13 @@ To change a column's [filter widget](../dashboards/filters.md):
 
 #### Filter widget options
 
-- **Search box**: Enter a search term and Metabase will display checkboxes for column values that match the search.
-- **A list of all values**: dropdown menu with checkboxes for all column values.
-- **Plain input box**: Enter a search term and Metabase will make autocomplete suggestions for the search (no checkboxes).
+The default behavior for the `Is` filter for the field.
 
-#### Default filters
+- **Search box**: Metabase will display a search box and suggest autocompletions for values in that column that match the search term(s).
+- **A list of all values**: Display a search box, as well as a list of checkboxes for values in a dropdown menu that people can select.
+- **Plain input box**: Display a search box, but do NOT suggest autocompletions.
 
-- Columns with more than 100 unique values will default to a plain input box filter.
-- Columns with fewer values will display a search box filter.
+ For the `Is` filter option, Metabase will accept multiple search terms. The `Is` filter will return results that match any of the terms (e.g., "term 1" OR "term 2").
 
 ### Changing a search box filter to a dropdown filter
 

--- a/docs/data-modeling/metadata-editing.md
+++ b/docs/data-modeling/metadata-editing.md
@@ -150,8 +150,6 @@ The default behavior for the `Is` filter for the field.
 - **A list of all values**: Display a search box, as well as a list of checkboxes for values in a dropdown menu that people can select as search terms.
 - **Plain input box**: Display a search box, but do NOT suggest autocompletions.
 
-For the `Is` filter option, Metabase will accept multiple search terms. The `Is` filter will return results that match any of the terms (e.g., "term 1" OR "term 2").
-
 ### Changing a search box filter to a dropdown filter
 
 The dropdown filter widget can be finicky, because Metabase needs to run a [scan](../databases/sync-scan.md#how-database-scans-work) to get the list of values for the dropdown menu.


### PR DESCRIPTION
Clarifies filter options when editing table metadata.

Re: limiting search results in filters, looks like the limit is set here: https://github.com/metabase/metabase/blob/a9e0b014edeee0a4cfb00ab4f36f1b49a8023f28/src/metabase/api/field.clj#L39