### PR TITLE
41901 command palette search view all

### DIFF
--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -78,8 +78,24 @@ describe("command palette", () => {
       commandPaletteSearch().clear().type("Uploads");
       cy.findByRole("option", { name: "Settings - Uploads" }).should("exist");
 
-      //Check that we are not filtering search results by action name
+      // When entering a query, if there are results that come before search results, highlight
+      // the first action, otherwise, highlight the first search result
+      commandPaletteSearch().clear().type("Or");
+      cy.findByRole("option", { name: "Performance" }).should(
+        "have.attr",
+        "aria-selected",
+        "true",
+      );
+      cy.findByRole("option", { name: /View and filter/ }).should("exist");
+
+      // Check that we are not filtering search results by action name
       commandPaletteSearch().clear().type("Company");
+      cy.findByRole("option", { name: /View and filter/ }).should("exist");
+      cy.findByRole("option", { name: "PEOPLE" }).should(
+        "have.attr",
+        "aria-selected",
+        "true",
+      );
       cy.findByRole("option", { name: "REVIEWS" }).should("exist");
       cy.findByRole("option", { name: "PRODUCTS" }).should("exist");
       commandPaletteSearch().clear();

--- a/frontend/src/metabase/lib/browser.js
+++ b/frontend/src/metabase/lib/browser.js
@@ -48,3 +48,5 @@ export function isMac() {
   const { platform = "" } = navigator;
   return Boolean(platform.match(/^Mac/));
 }
+
+export const METAKEY = isMac() ? "⌘" : "Ctrl";

--- a/frontend/src/metabase/nav/components/AppBar/AppBarLarge.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLarge.tsx
@@ -1,10 +1,10 @@
-import { SearchBar } from "metabase/nav/components/search/SearchBar";
 import type { CollectionId } from "metabase-types/api";
 
 import CollectionBreadcrumbs from "../../containers/CollectionBreadcrumbs";
 import QuestionLineage from "../../containers/QuestionLineage";
 import NewItemButton from "../NewItemButton";
 import { ProfileLink } from "../ProfileLink";
+import { SearchButton } from "../search/SearchButton";
 
 import {
   AppBarLeftContainer,
@@ -69,7 +69,7 @@ const AppBarLarge = ({
       </AppBarLeftContainer>
       {(isSearchVisible || isNewButtonVisible || isProfileLinkVisible) && (
         <AppBarRightContainer>
-          {isSearchVisible && <SearchBar />}
+          {isSearchVisible && <SearchButton />}
           {isNewButtonVisible && <NewItemButton collectionId={collectionId} />}
           {isProfileLinkVisible && (
             <AppBarProfileLinkContainer>

--- a/frontend/src/metabase/nav/components/AppBar/AppBarLarge.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLarge.tsx
@@ -4,7 +4,7 @@ import CollectionBreadcrumbs from "../../containers/CollectionBreadcrumbs";
 import QuestionLineage from "../../containers/QuestionLineage";
 import NewItemButton from "../NewItemButton";
 import { ProfileLink } from "../ProfileLink";
-import { SearchButton } from "../search/SearchButton";
+import { SearchBar } from "../search/SearchBar";
 
 import {
   AppBarLeftContainer,
@@ -69,7 +69,7 @@ const AppBarLarge = ({
       </AppBarLeftContainer>
       {(isSearchVisible || isNewButtonVisible || isProfileLinkVisible) && (
         <AppBarRightContainer>
-          {isSearchVisible && <SearchButton />}
+          {isSearchVisible && <SearchBar />}
           {isNewButtonVisible && <NewItemButton collectionId={collectionId} />}
           {isProfileLinkVisible && (
             <AppBarProfileLinkContainer>

--- a/frontend/src/metabase/nav/components/search/SearchBar/CommandPaletteTrigger.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchBar/CommandPaletteTrigger.tsx
@@ -1,7 +1,7 @@
 import type React from "react";
 import { t } from "ttag";
 
-import { isMac } from "metabase/lib/browser";
+import { METAKEY } from "metabase/lib/browser";
 import { color } from "metabase/lib/colors";
 import { Button, Tooltip } from "metabase/ui";
 
@@ -10,8 +10,6 @@ export const CommandPaletteTrigger = ({
 }: {
   onClick: (e: React.MouseEvent) => void;
 }) => {
-  const METAKEY = isMac() ? "⌘" : "Ctrl";
-
   return (
     <Tooltip label={t`Search and quickly jump to things`}>
       <Button

--- a/frontend/src/metabase/nav/components/search/SearchButton/SearchButton.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchButton/SearchButton.tsx
@@ -1,0 +1,24 @@
+import { useKBar, VisualState } from "kbar";
+import { useCallback } from "react";
+import { t } from "ttag";
+
+import { isMac } from "metabase/lib/browser";
+import { Button, Icon, Tooltip } from "metabase/ui";
+
+const METAKEY = isMac() ? "⌘" : "Ctrl";
+
+export const SearchButton = () => {
+  const { query } = useKBar();
+
+  const handleClick = useCallback(() => {
+    query.setVisualState(VisualState.showing);
+  }, [query]);
+
+  return (
+    <Tooltip label={`${t`Search...`} (${METAKEY}+k)`}>
+      <Button leftIcon={<Icon name="search" />} onClick={handleClick}>
+        Search
+      </Button>
+    </Tooltip>
+  );
+};

--- a/frontend/src/metabase/nav/components/search/SearchButton/SearchButton.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchButton/SearchButton.tsx
@@ -2,17 +2,16 @@ import { useKBar, VisualState } from "kbar";
 import { useCallback } from "react";
 import { t } from "ttag";
 
-import { isMac } from "metabase/lib/browser";
+import { METAKEY } from "metabase/lib/browser";
 import { Button, Icon, Tooltip } from "metabase/ui";
 
-const METAKEY = isMac() ? "⌘" : "Ctrl";
-
 export const SearchButton = () => {
-  const { query } = useKBar();
+  const kbar = useKBar();
+  const { setVisualState } = kbar.query;
 
   const handleClick = useCallback(() => {
-    query.setVisualState(VisualState.showing);
-  }, [query]);
+    setVisualState(VisualState.showing);
+  }, [setVisualState]);
 
   return (
     <Tooltip label={`${t`Search...`} (${METAKEY}+k)`}>

--- a/frontend/src/metabase/nav/components/search/SearchButton/index.ts
+++ b/frontend/src/metabase/nav/components/search/SearchButton/index.ts
@@ -1,0 +1,1 @@
+export * from "./SearchButton";

--- a/frontend/src/metabase/palette/components/PaletteResultItem.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResultItem.tsx
@@ -117,14 +117,7 @@ export const PaletteResultItem = ({
       </Flex>
       {/** Active container */}
       {active && (
-        <Flex
-          aria-hidden
-          gap="0.5rem"
-          fw={400}
-          style={{
-            flexBasis: 60,
-          }}
-        >
+        <Flex aria-hidden gap="0.5rem" fw={400}>
           {t`Open`} <Icon name="enter_or_return" />
         </Flex>
       )}

--- a/frontend/src/metabase/palette/components/PaletteResults.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResults.tsx
@@ -1,6 +1,7 @@
 import { useKBar, useMatches } from "kbar";
 import { useMemo, useEffect } from "react";
 import { useKeyPressEvent } from "react-use";
+import { t } from "ttag";
 import _ from "underscore";
 
 import { color } from "metabase/lib/colors";
@@ -29,7 +30,7 @@ export const PaletteResults = () => {
   );
 
   useEffect(() => {
-    if (processedResults[0] === "Search results") {
+    if (processedResults[0] === t`Search results`) {
       query.setActiveIndex(2);
     }
   }, [processedResults, query]);

--- a/frontend/src/metabase/palette/components/PaletteResults.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResults.tsx
@@ -1,5 +1,5 @@
 import { useKBar, useMatches } from "kbar";
-import { useMemo } from "react";
+import { useMemo, useEffect } from "react";
 import { useKeyPressEvent } from "react-use";
 import _ from "underscore";
 
@@ -27,6 +27,12 @@ export const PaletteResults = () => {
     () => processResults(results as (PaletteActionImpl | string)[]),
     [results],
   );
+
+  useEffect(() => {
+    if (processedResults[0] === "Search results") {
+      query.setActiveIndex(2);
+    }
+  }, [processedResults, query]);
 
   useKeyPressEvent("End", () => {
     const lastIndex = processedResults.length - 1;

--- a/frontend/src/metabase/palette/components/PaletteResults.unit.spec.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResults.unit.spec.tsx
@@ -13,6 +13,7 @@ import {
   within,
   waitFor,
   mockScrollTo,
+  mockScrollIntoView,
 } from "__support__/ui";
 import { getAdminPaths } from "metabase/admin/app/reducers";
 import {
@@ -94,6 +95,7 @@ const recents_2 = createMockRecentItem({
 });
 
 mockScrollTo();
+mockScrollIntoView();
 
 const setup = ({ query }: { query?: string } = {}) => {
   setupDatabasesEndpoints([DATABASE]);
@@ -165,6 +167,10 @@ describe("PaletteResults", () => {
     await waitFor(async () => {
       expect(await screen.findByText("Search results")).toBeInTheDocument();
     });
+
+    expect(
+      await screen.findByRole("option", { name: /View and filter/i }),
+    ).toBeInTheDocument();
 
     expect(
       await screen.findByRole("option", { name: "Bar Dashboard" }),

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -78,7 +78,7 @@ export const useCommandPalette = () => {
       {
         id: "search_docs",
         name: debouncedSearchText
-          ? `Search documentation for "${debouncedSearchText}"`
+          ? t`Search documentation for "${debouncedSearchText}"`
           : t`View documentation`,
         section: "docs",
         keywords: debouncedSearchText, // Always match the debouncedSearchText string
@@ -107,7 +107,7 @@ export const useCommandPalette = () => {
       return [
         {
           id: "search-is-loading",
-          name: "Loading...",
+          name: t`Loading...`,
           keywords: searchQuery,
           section: "search",
         },
@@ -125,10 +125,10 @@ export const useCommandPalette = () => {
         return [
           {
             id: `search-results-metadata`,
-            name: `View and filter all ${searchResults?.total} results`,
+            name: t`View and filter all ${searchResults?.total} results`,
             section: "search",
             keywords: debouncedSearchText,
-            icon: "link",
+            icon: "link" as const,
             perform: () => {
               dispatch(
                 push({
@@ -140,6 +140,14 @@ export const useCommandPalette = () => {
               );
             },
             priority: Priority.HIGH,
+            extra: {
+              href: {
+                pathname: "search",
+                query: {
+                  q: debouncedSearchText,
+                },
+              },
+            },
           },
         ].concat(
           searchResults.data.map(result => {

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -125,7 +125,7 @@ export const useCommandPalette = () => {
         return [
           {
             id: `search-results-metadata`,
-            name: `View all ${searchResults?.total} results for "${debouncedSearchText}"`,
+            name: `View and filter all ${searchResults?.total} results`,
             section: "search",
             keywords: debouncedSearchText,
             icon: "link",

--- a/frontend/src/metabase/palette/types.ts
+++ b/frontend/src/metabase/palette/types.ts
@@ -1,3 +1,4 @@
+import type { LocationDescriptor } from "history";
 import type { Action, ActionImpl } from "kbar";
 
 import type { IconName } from "metabase/ui";
@@ -14,7 +15,7 @@ interface PaletteActionExtras {
      * href: If defined, the palette item will be wrapped in a link. This allows for
      * browser interactions to open items in new tabs/windows
      */
-    href?: string | null;
+    href?: LocationDescriptor | null;
   };
 }
 

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -357,6 +357,13 @@ export const mockScrollTo = () => {
 };
 
 /**
+ * jsdom doesn't have scrollBy, so we need to mock it
+ */
+export const mockScrollIntoView = () => {
+  window.Element.prototype.scrollIntoView = jest.fn();
+};
+
+/**
  * jsdom doesn't have DataTransfer
  */
 export function createMockClipboardData(


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/41901
### Description
Adds a "view all results" action to the search results section. This should always appear at the top of the search section.

If the only items in the command palette are search results (and the docs action), the palette should highlight the 1st search result

### How to verify

1. Toggle the palette
2. Search for a few queries. You should see a "view and filter all x results" When there are only search results, the second result should be highlighted. Otherwise, things should behave as normal

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
