### PR TITLE
Add `can_write` to /collection/:id/items

### DIFF
--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -470,7 +470,8 @@
       true)))
 
 (defn- post-process-card-row [row]
-  (-> (t2/hydrate (t2/instance :model/Card row) :can_write)
+  (-> (t2/instance :model/Card row)
+      (t2/hydrate :can_write)
       (dissoc :authority_level :icon :personal_owner_id :dataset_query :table_id :query_type :is_upload)
       (update :collection_preview api/bit->boolean)
       (assoc :fully_parameterized (fully-parameterized-query? row))))
@@ -503,7 +504,8 @@
   (dashboard-query collection options))
 
 (defn- post-process-dashboard [dashboard]
-  (-> (t2/hydrate (t2/instance :model/Dashboard dashboard) :can_write)
+  (-> (t2/instance :model/Dashboard dashboard)
+      (t2/hydrate :can_write)
       (dissoc :display :authority_level :moderated_status :icon :personal_owner_id :collection_preview
               :dataset_query :table_id :query_type :is_upload)))
 

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -470,7 +470,7 @@
       true)))
 
 (defn- post-process-card-row [row]
-  (-> row
+  (-> (t2/hydrate (t2/instance :model/Card row) :can_write)
       (dissoc :authority_level :icon :personal_owner_id :dataset_query :table_id :query_type :is_upload)
       (update :collection_preview api/bit->boolean)
       (assoc :fully_parameterized (fully-parameterized-query? row))))
@@ -502,12 +502,14 @@
   [_ collection options]
   (dashboard-query collection options))
 
+(defn- post-process-dashboard [dashboard]
+  (-> (t2/hydrate (t2/instance :model/Dashboard dashboard) :can_write)
+      (dissoc :display :authority_level :moderated_status :icon :personal_owner_id :collection_preview
+              :dataset_query :table_id :query_type :is_upload)))
+
 (defmethod post-process-collection-children :dashboard
   [_ _ rows]
-  (map #(dissoc %
-                :display :authority_level :moderated_status :icon :personal_owner_id :collection_preview
-                :dataset_query :table_id :query_type :is_upload)
-       rows))
+  (map post-process-dashboard rows))
 
 (defenterprise snippets-collection-filter-clause
   "Clause to filter out snippet collections from the collection query on OSS instances, and instances without the


### PR DESCRIPTION
For dashboards and cards/models only.

Fixes #41827 