### PR TITLE
add description to the checklist setup step

### DIFF
--- a/src/metabase/api/setup.clj
+++ b/src/metabase/api/setup.clj
@@ -216,6 +216,7 @@
     :triggered   :always}
    {:title       (tru "Setup embedding")
     :group       (tru "Get connected")
+    :description (tru "Get customizable, flexible, and scalable customer-facing analytics in no time")
     :link        "/admin/settings/embedding-in-other-applications"
     :completed   (or (embedding :done?)
                      (and (configured :sso) (embedding :app-origin))


### PR DESCRIPTION
### Description

Part of [[Epic] Initial homepage experience for embedding admins](https://github.com/metabase/metabase/issues/40005)

All the other steps in the checklist have a description, this adds it to the setup item too.
[slack thread](https://metaboat.slack.com/archives/C063Q3F1HPF/p1714684617077029?thread_ts=1714498386.014709&cid=C063Q3F1HPF)

