### PR TITLE
Use official version of Marginalia

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -334,7 +334,7 @@
   ;; clojure -M:marginalia
   :marginalia
   {:extra-deps
-   {com.github.tsmacdonald/marginalia {:mvn/version "0.9.2"}}
+   {marginalia/marginalia {:mvn/version "0.9.2"}}
    :main-opts ["-m" "marginalia.main" "-n" "Metabase" "-d" "backend-docs" "-D"
                "The simplest, fastest way to get business intelligence and analytics to everyone in your company 😋"
                "dev" "src" "enterprise/backend/src"]}
@@ -344,7 +344,7 @@
   ;; which creates `backend-docs/metabase.some.namespace.html`
   :marginalia/one
   {:extra-deps
-   {com.github.tsmacdonald/marginalia {:mvn/version "0.9.2"}}
+   {marginalia/marginalia {:mvn/version "0.9.2"}}
    :main-opts ["-m" "marginalia.main" "-m" "-n" "Metabase" "-d" "backend-docs" "-D"
                "The simplest, fastest way to get business intelligence and analytics to everyone in your company 😋"]}
 


### PR DESCRIPTION
For Reasons™ we had been using my fork, but now that I've taken over the project the officially-deployed version does what we need.
