### PR TITLE
Fix InteractiveQuestion loader show no question before loaded

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.tsx
@@ -78,7 +78,7 @@ export const _InteractiveQuestion = ({
 
     const { location, params } = getQuestionParameters(questionId);
     try {
-      dispatch(initializeQBRaw(location, params));
+      await dispatch(initializeQBRaw(location, params));
     } catch (e) {
       console.error(`Failed to get question`, e);
       setLoading(false);

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.tsx
@@ -78,10 +78,9 @@ export const _InteractiveQuestion = ({
 
     const { location, params } = getQuestionParameters(questionId);
     try {
-      await dispatch(initializeQBRaw(location, params));
+      dispatch(initializeQBRaw(location, params));
     } catch (e) {
       console.error(`Failed to get question`, e);
-    } finally {
       setLoading(false);
     }
   };

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
@@ -100,6 +100,15 @@ describe("InteractiveQuestion", () => {
     ).toBeInTheDocument();
   });
 
+  it("should not render an error if a question isn't found before the question loaded", async () => {
+    setup();
+
+    await waitForLoaderToBeRemoved();
+
+    expect(screen.queryByText("Error")).not.toBeInTheDocument();
+    expect(screen.queryByText("Question not found")).not.toBeInTheDocument();
+  });
+
   it("should render an error if a question isn't found", async () => {
     setup({ isValidCard: false });
 

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
@@ -83,9 +83,7 @@ describe("InteractiveQuestion", () => {
     expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
   });
 
-  // TODO [Oisin]: fix failing test in "Fix Interactive Question" PR
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip("should render when question is valid", async () => {
+  it("should render when question is valid", async () => {
     setup();
 
     await waitForLoaderToBeRemoved();


### PR DESCRIPTION
### Description

Reported on [Slack](https://metaboat.slack.com/archives/C063Q3F1HPF/p1714723290124359)

The problem occurred because how we set `loading` state to false. We do that after we wait for `initializeQBRaw` action to be finished which isn't enough. A lot of downstream functions aren't even `await`ed. So we can only rely on `queryResults` to be there.

### How to verify

Use customer zero with this the SDK built with this PR, when going to the product detail page (clicking on a product on the product list page). The first bar chart shouldn't show `no question` error before it's actually loaded.

### Demo

#### Before
https://github.com/metabase/metabase/assets/1937582/9226cbed-d78a-4a9d-903c-923d9fd21a3a

#### After
https://github.com/metabase/metabase/assets/1937582/b5c0223f-0074-47b2-9f82-8fc7af193e6b

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
