### PR TITLE
Bump react embedding sdk version to 0.1.1

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/package.template.json
+++ b/enterprise/frontend/src/embedding-sdk/package.template.json
@@ -1,6 +1,6 @@
 {
   "name": "@metabase/embedding-sdk-react",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Metabase Embedding SDK for React",
   "repository": {
     "url": "git+https://github.com/metabase/metabase.git"


### PR DESCRIPTION
Bumps version to 0.1.1 - published to NPM at https://www.npmjs.com/package/@metabase/embedding-sdk-react