### PR TITLE
Use database-supports? instead of hard-coded driver in `dataset-with-custom-pk-test`

### DIFF
--- a/test/metabase/test/data/dataset_definition_test.clj
+++ b/test/metabase/test/data/dataset_definition_test.clj
@@ -30,7 +30,7 @@
                    :fk_target_field_id nil
                    :semantic_type      :type/PK}]
                  user-fields)))
-        (when-not (#{:sqlite} driver/*driver*) ;; our implement does not support adding fk for custom dataset yet
+        (when-not (driver/database-supports? driver/*driver* :foreign-keys (mt/db))
           (testing "user_custom_id is a FK non user.custom_id"
             (is (= #{{:name               (format-name "user_custom_id")
                       :fk_target_field_id (mt/id :user :custom_id)

--- a/test/metabase/test/data/dataset_definition_test.clj
+++ b/test/metabase/test/data/dataset_definition_test.clj
@@ -30,7 +30,7 @@
                    :fk_target_field_id nil
                    :semantic_type      :type/PK}]
                  user-fields)))
-        (when-not (driver/database-supports? driver/*driver* :foreign-keys (mt/db))
+        (when (driver/database-supports? driver/*driver* :foreign-keys (mt/db))
           (testing "user_custom_id is a FK non user.custom_id"
             (is (= #{{:name               (format-name "user_custom_id")
                       :fk_target_field_id (mt/id :user :custom_id)


### PR DESCRIPTION
This PR fixes an issue raised by the clickhouse driver team, where the test was failing because Clickhouse doesn't support FKs.