### PR TITLE
Fix editing an existing metric

### DIFF
--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -352,18 +352,19 @@ export const getQuestion = createSelector(
     if (!question) {
       return;
     }
-    if (question.type() === "model" && queryBuilderMode === "dataset") {
-      return question.lockDisplay();
-    }
 
-    const type = question.type();
-    const { isEditable } = Lib.queryDisplayInfo(question.query());
+    const isModel = question.type() === "model";
+    const isMetric = question.type() === "metric";
+    if ((isModel || isMetric) && queryBuilderMode === "dataset") {
+      return isModel ? question.lockDisplay() : question;
+    }
 
     // When opening a model or a metric, we construct a question
     // with a clean, ad-hoc, query.
     // This has to be skipped for users without data permissions.
     // See https://github.com/metabase/metabase/issues/20042
-    return type !== "question" && isEditable
+    const { isEditable } = Lib.queryDisplayInfo(question.query());
+    return (isModel || isMetric) && isEditable
       ? question.composeQuestion()
       : question;
   },


### PR DESCRIPTION
Currently you cannot edit the query definition of a metric because of a bug. This PR fixes the issue.

How to verify:
- Open a metric
- Click Edit metric definition
- You would see the metric query instead of a query based on the metric 

<img width="1686" alt="Screenshot 2024-05-03 at 14 01 04" src="https://github.com/metabase/metabase/assets/8542534/f39758d1-9c81-4dbf-a272-dbe5419aed79">
