### PR TITLE
Hide "Basic metrics" when the query is entirely metric-based

### DIFF
--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -93,10 +93,12 @@ export function AggregationPicker({
     const databaseId = Lib.databaseID(query);
     const database = metadata.database(databaseId);
     const canUseExpressions = database?.hasFeature("expression-aggregations");
+    const isMetricBased = Lib.isMetricBased(query, stageIndex);
 
     if (metrics.length > 0) {
       sections.push({
         key: "metrics",
+        name: t`Metrics`,
         items: metrics.map(metric =>
           getMetricListItem(query, stageIndex, metric),
         ),
@@ -104,7 +106,7 @@ export function AggregationPicker({
       });
     }
 
-    if (operators.length > 0) {
+    if (operators.length > 0 && !(metrics.length > 0 && isMetricBased)) {
       sections.push({
         key: "operators",
         name: t`Basic Metrics`,

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -106,7 +106,7 @@ export function AggregationPicker({
       });
     }
 
-    if (operators.length > 0 && !(metrics.length > 0 && isMetricBased)) {
+    if (operators.length > 0 && !isMetricBased) {
       sections.push({
         key: "operators",
         name: t`Basic Metrics`,


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/42168

For first stage of the query which is based entirely on metrics, hide "Basic metrics" in the aggregation picker.

Single metric
<img width="624" alt="Screenshot 2024-05-03 at 14 10 52" src="https://github.com/metabase/metabase/assets/8542534/a4825ff4-44e3-44e5-bd83-ee126c36880e">

Metric + joined metric
<img width="1308" alt="Screenshot 2024-05-03 at 14 11 10" src="https://github.com/metabase/metabase/assets/8542534/fa0c9764-e872-4346-ae75-ad2214c3eef2">

Metric + joined table
<img width="1303" alt="Screenshot 2024-05-03 at 14 11 24" src="https://github.com/metabase/metabase/assets/8542534/617f7621-ba4a-42ee-97c2-499fd23aa9cd">

Second stage
<img width="1309" alt="Screenshot 2024-05-03 at 14 11 34" src="https://github.com/metabase/metabase/assets/8542534/9ff6c8c8-6704-43cc-aa83-e742cf9c3370">

