### PR TITLE
Open the expression editor if all metrics are selected

### DIFF
--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -227,7 +227,7 @@ export type MetricDisplayInfo = {
   displayName: string;
   longDisplayName: string;
   description: string;
-  selected?: boolean;
+  aggregationPosition?: number;
 };
 
 export type ClauseDisplayInfo = Pick<

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -93,10 +93,12 @@ export function AggregationPicker({
     const databaseId = Lib.databaseID(query);
     const database = metadata.database(databaseId);
     const canUseExpressions = database?.hasFeature("expression-aggregations");
+    const isMetricBased = Lib.isMetricBased(query, stageIndex);
 
     if (metrics.length > 0) {
       sections.push({
         key: "metrics",
+        name: t`Metrics`,
         items: metrics.map(metric =>
           getMetricListItem(query, stageIndex, metric),
         ),
@@ -104,7 +106,7 @@ export function AggregationPicker({
       });
     }
 
-    if (operators.length > 0) {
+    if (operators.length > 0 && !(metrics.length > 0 && isMetricBased)) {
       sections.push({
         key: "operators",
         name: t`Basic Metrics`,

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -106,7 +106,7 @@ export function AggregationPicker({
       });
     }
 
-    if (operators.length > 0 && !(metrics.length > 0 && isMetricBased)) {
+    if (operators.length > 0 && !isMetricBased) {
       sections.push({
         key: "operators",
         name: t`Basic Metrics`,

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -22,8 +22,9 @@ import {
 interface AggregationPickerProps {
   className?: string;
   query: Lib.Query;
-  clause?: Lib.AggregationClause;
   stageIndex: number;
+  clause?: Lib.AggregationClause;
+  clauseIndex?: number;
   operators: Lib.AggregationOperator[];
   hasExpressionInput?: boolean;
   onSelect: (operator: Lib.Aggregable) => void;
@@ -36,6 +37,7 @@ type OperatorListItem = Lib.AggregationOperatorDisplayInfo & {
 
 type MetricListItem = Lib.MetricDisplayInfo & {
   metric: Lib.MetricMetadata;
+  selected: boolean;
 };
 
 type ListItem = OperatorListItem | MetricListItem;
@@ -55,8 +57,9 @@ function isOperatorListItem(item: ListItem): item is OperatorListItem {
 export function AggregationPicker({
   className,
   query,
-  clause,
   stageIndex,
+  clause,
+  clauseIndex,
   operators,
   hasExpressionInput = true,
   onSelect,
@@ -98,7 +101,7 @@ export function AggregationPicker({
       sections.push({
         key: "metrics",
         items: metrics.map(metric =>
-          getMetricListItem(query, stageIndex, metric),
+          getMetricListItem(query, stageIndex, metric, clauseIndex),
         ),
         icon: "metric",
       });
@@ -126,7 +129,7 @@ export function AggregationPicker({
     }
 
     return sections;
-  }, [metadata, query, stageIndex, operators, hasExpressionInput]);
+  }, [metadata, query, stageIndex, clauseIndex, operators, hasExpressionInput]);
 
   const checkIsItemSelected = useCallback(
     (item: ListItem) => item.selected,
@@ -305,7 +308,7 @@ function isExpressionEditorInitiallyOpen(
       Lib.isMetricBased(query, stageIndex) &&
       Lib.availableMetrics(query, stageIndex)
         .map(metric => Lib.displayInfo(query, stageIndex, metric))
-        .every(metricInfo => metricInfo.selected)
+        .every(metricInfo => metricInfo.aggregationPosition != null)
     );
   }
 
@@ -333,11 +336,14 @@ function getMetricListItem(
   query: Lib.Query,
   stageIndex: number,
   metric: Lib.MetricMetadata,
+  clauseIndex?: number,
 ): MetricListItem {
   const metricInfo = Lib.displayInfo(query, stageIndex, metric);
   return {
     ...metricInfo,
     metric,
+    selected:
+      clauseIndex != null && metricInfo.aggregationPosition === clauseIndex,
   };
 }
 

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -15,8 +15,8 @@ import { QueryColumnPicker } from "../QueryColumnPicker";
 import {
   ColumnPickerContainer,
   ColumnPickerHeaderContainer,
-  ColumnPickerHeaderTitleContainer,
   ColumnPickerHeaderTitle,
+  ColumnPickerHeaderTitleContainer,
 } from "./AggregationPicker.styled";
 
 interface AggregationPickerProps {
@@ -301,14 +301,11 @@ function isExpressionEditorInitiallyOpen(
   operators: Lib.AggregationOperator[],
 ): boolean {
   if (!clause) {
-    const metrics = Lib.availableMetrics(query, stageIndex);
-    const metricsInfo = metrics.map(metric =>
-      Lib.displayInfo(query, stageIndex, metric),
-    );
     return (
       Lib.isMetricBased(query, stageIndex) &&
-      metrics.length > 0 &&
-      metricsInfo.every(metricInfo => metricInfo.selected)
+      Lib.availableMetrics(query, stageIndex)
+        .map(metric => Lib.displayInfo(query, stageIndex, metric))
+        .every(metricInfo => metricInfo.selected)
     );
   }
 

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -301,7 +301,15 @@ function isExpressionEditorInitiallyOpen(
   operators: Lib.AggregationOperator[],
 ): boolean {
   if (!clause) {
-    return false;
+    const metrics = Lib.availableMetrics(query, stageIndex);
+    const metricsInfo = metrics.map(metric =>
+      Lib.displayInfo(query, stageIndex, metric),
+    );
+    return (
+      Lib.isMetricBased(query, stageIndex) &&
+      metrics.length > 0 &&
+      metricsInfo.every(metricInfo => metricInfo.selected)
+    );
   }
 
   const initialOperator = getInitialOperator(query, stageIndex, operators);

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
@@ -122,8 +122,9 @@ function AggregationPopover({
   return (
     <AggregationPicker
       query={query}
-      clause={clause}
       stageIndex={stageIndex}
+      clause={clause}
+      clauseIndex={clauseIndex}
       operators={operators}
       onSelect={aggregation => {
         if (isUpdate) {

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/AggregationItem/AggregationItem.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/AggregationItem/AggregationItem.tsx
@@ -12,6 +12,7 @@ const STAGE_INDEX = -1;
 interface AggregationItemProps {
   query: Lib.Query;
   aggregation: Lib.AggregationClause;
+  aggregationIndex: number;
   onUpdate: (nextAggregation: Lib.Aggregable) => void;
   onRemove: () => void;
 }
@@ -19,6 +20,7 @@ interface AggregationItemProps {
 export function AggregationItem({
   query,
   aggregation,
+  aggregationIndex,
   onUpdate,
   onRemove,
 }: AggregationItemProps) {
@@ -47,6 +49,7 @@ export function AggregationItem({
           query={query}
           stageIndex={STAGE_INDEX}
           clause={aggregation}
+          clauseIndex={aggregationIndex}
           operators={operators}
           hasExpressionInput={false}
           onSelect={nextAggregation => {

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.tsx
@@ -159,8 +159,11 @@ export function SummarizeSidebar({
 
 function getQuery(query: Lib.Query, isDefaultAggregationRemoved: boolean) {
   const hasAggregations = Lib.aggregations(query, STAGE_INDEX).length > 0;
+
   const shouldAddDefaultAggregation =
-    !hasAggregations && !isDefaultAggregationRemoved;
+    !hasAggregations &&
+    !Lib.isMetricBased(query, STAGE_INDEX) &&
+    !isDefaultAggregationRemoved;
 
   if (!shouldAddDefaultAggregation) {
     return query;

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.tsx
@@ -123,13 +123,14 @@ export function SummarizeSidebar({
       onDone={handleDoneClick}
     >
       <AggregationsContainer>
-        {aggregations.map(aggregation => (
+        {aggregations.map((aggregation, aggregationIndex) => (
           <AggregationItem
             key={
               Lib.displayInfo(query, STAGE_INDEX, aggregation).longDisplayName
             }
             query={query}
             aggregation={aggregation}
+            aggregationIndex={aggregationIndex}
             onUpdate={nextAggregation =>
               handleUpdateAggregation(aggregation, nextAggregation)
             }


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/42176

Also fixes the selected state of metric items in the picker.

How to verify:
- New -> Question -> Select metric
- The aggregation clause should be automatically added in the query
- Click + for a new aggregation
- The expression editor should be automatically opened

Please note that it suggests aggregation operators which is wrong, but this is a separate issue. 

<img width="626" alt="Screenshot 2024-05-03 at 17 03 29" src="https://github.com/metabase/metabase/assets/8542534/64eeaead-5540-4d92-8861-65c1642ea244">
<img width="618" alt="Screenshot 2024-05-03 at 17 05 06" src="https://github.com/metabase/metabase/assets/8542534/32d2be86-3371-434a-8f1b-369c896303fc">
<img width="942" alt="Screenshot 2024-05-03 at 17 05 28" src="https://github.com/metabase/metabase/assets/8542534/d2186163-5013-4f65-be57-65fdd4c479d6">
