### PR TITLE
Extract column shortcut

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/column-shortcuts/column-shortcuts.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-tabular/column-shortcuts/column-shortcuts.cy.spec.ts
@@ -215,7 +215,7 @@ function extractColumnAndCheck({
   cy.intercept("POST", "/api/dataset").as(requestAlias);
   cy.findByLabelText("Add column").click();
 
-  popover().findByText("Extract column").click();
+  popover().findByText("Extract part of column").click();
   popover().findAllByText(column).first().click();
 
   if (example) {

--- a/e2e/test/scenarios/visualizations-tabular/column-shortcuts/column-shortcuts.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-tabular/column-shortcuts/column-shortcuts.cy.spec.ts
@@ -1,0 +1,233 @@
+import _ from "underscore";
+
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import {
+  describeWithSnowplow,
+  enterCustomColumnDetails,
+  getNotebookStep,
+  openNotebook,
+  openOrdersTable,
+  popover,
+  restore,
+  visualize,
+  createQuestion,
+} from "e2e/support/helpers";
+
+const { PEOPLE, PEOPLE_ID } = SAMPLE_DATABASE;
+
+const DATE_CASES = [
+  {
+    option: "Hour of day",
+    value: "21",
+    example: "0, 1",
+  },
+  {
+    option: "Day of month",
+    value: "11",
+    example: "1, 2",
+  },
+  {
+    option: "Day of week",
+    value: "Tuesday",
+    example: "Monday, Tuesday",
+  },
+  {
+    option: "Month of year",
+    value: "Feb",
+    example: "Jan, Feb",
+  },
+  {
+    option: "Quarter of year",
+    value: "Q1",
+    example: "Q1, Q2",
+  },
+  {
+    option: "Year",
+    value: "2,025",
+    example: "2023, 2024",
+  },
+];
+
+const EMAIL_CASES = [
+  {
+    option: "Domain",
+    value: "yahoo",
+    example: "example, online",
+  },
+  {
+    option: "Host",
+    value: "yahoo.com",
+    example: "example.com, online.com",
+  },
+];
+
+const URL_CASES = [
+  {
+    option: "Domain",
+    value: "yahoo",
+    example: "example, online",
+  },
+  {
+    option: "Subdomain",
+    value: "",
+    example: "www, maps",
+  },
+  {
+    option: "Host",
+    value: "yahoo.com",
+    example: "example.com, online.com",
+  },
+];
+
+describeWithSnowplow("extract shortcut", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  describe("date columns", () => {
+    describe("should add a date expression for each option", () => {
+      DATE_CASES.forEach(({ option, value, example }) => {
+        it(option, () => {
+          openOrdersTable({ limit: 1 });
+          extractColumnAndCheck({
+            column: "Created At",
+            option,
+            value,
+            example,
+          });
+        });
+      });
+    });
+
+    it("should handle duplicate expression names", () => {
+      openOrdersTable({ limit: 1 });
+      extractColumnAndCheck({
+        column: "Created At",
+        option: "Hour of day",
+        newColumn: "Hour of day",
+      });
+      extractColumnAndCheck({
+        column: "Created At",
+        option: "Hour of day",
+        newColumn: "Hour of day_2",
+      });
+    });
+
+    it("should be able to modify the expression in the notebook editor", () => {
+      openOrdersTable({ limit: 1 });
+      extractColumnAndCheck({
+        column: "Created At",
+        option: "Year",
+        value: "2,025",
+      });
+      openNotebook();
+      getNotebookStep("expression").findByText("Year").click();
+      enterCustomColumnDetails({ name: "custom formula", formula: "+ 2" });
+      popover().button("Update").click();
+      visualize();
+      cy.findByRole("gridcell", { name: "2,027" }).should("be.visible");
+    });
+  });
+
+  describe("email columns", () => {
+    beforeEach(() => {
+      restore();
+      cy.signInAsAdmin();
+    });
+
+    EMAIL_CASES.forEach(({ option, value, example }) => {
+      it(option, () => {
+        createQuestion(
+          {
+            query: {
+              "source-table": PEOPLE_ID,
+              limit: 1,
+              fields: [["field", PEOPLE.EMAIL, null]],
+            },
+          },
+          {
+            visitQuestion: true,
+          },
+        );
+
+        extractColumnAndCheck({
+          column: "Email",
+          option,
+          value,
+          example,
+        });
+      });
+    });
+  });
+
+  describe("url columns", () => {
+    beforeEach(() => {
+      restore();
+      cy.signInAsAdmin();
+
+      // Make the Email column a URL column for these tests, to avoid having to create a new model
+      cy.request("PUT", `/api/field/${PEOPLE.EMAIL}`, {
+        semantic_type: "type/URL",
+      });
+    });
+
+    URL_CASES.forEach(({ option, value, example }) => {
+      it(option, () => {
+        createQuestion(
+          {
+            query: {
+              "source-table": PEOPLE_ID,
+              limit: 1,
+              fields: [["field", PEOPLE.EMAIL, { "base-type": "type/String" }]],
+            },
+          },
+          {
+            visitQuestion: true,
+          },
+        );
+
+        extractColumnAndCheck({
+          column: "Email",
+          option,
+          value,
+          example,
+        });
+      });
+    });
+  });
+});
+
+function extractColumnAndCheck({
+  column,
+  option,
+  newColumn = option,
+  value,
+  example,
+}: {
+  column: string;
+  option: string;
+  value?: string;
+  example?: string;
+  newColumn?: string;
+}) {
+  const requestAlias = _.uniqueId("dataset");
+  cy.intercept("POST", "/api/dataset").as(requestAlias);
+  cy.findByLabelText("Add column").click();
+
+  popover().findByText("Extract column").click();
+  popover().findAllByText(column).first().click();
+
+  if (example) {
+    popover().findByText(option).parent().should("contain", example);
+  }
+
+  popover().findByText(option).click();
+
+  cy.wait(`@${requestAlias}`);
+
+  cy.findByRole("columnheader", { name: newColumn }).should("be.visible");
+  if (value) {
+    cy.findByRole("gridcell", { name: value }).should("be.visible");
+  }
+}

--- a/e2e/test/scenarios/visualizations-tabular/table-column-settings.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table-column-settings.cy.spec.js
@@ -619,12 +619,14 @@ describe("scenarios > visualizations > table column settings", () => {
         column: "Products → Category",
         columnName: "Products → Category",
         table: "test question",
+        scrollTimes: 3,
       };
 
       const testData2 = {
         column: "Ean",
         columnName: "Product → Ean",
         table: "product",
+        scrollTimes: 3,
       };
 
       _hideColumn(testData);

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -575,6 +575,7 @@ export interface ClickObject {
   seriesIndex?: number;
   cardId?: CardId;
   settings?: Record<string, unknown>;
+  columnShortcuts?: boolean;
   origin?: {
     row: RowValue;
     cols: DatasetColumn[];

--- a/frontend/src/metabase/query_builder/components/expressions/ExtractColumn/ExtractColumn.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExtractColumn/ExtractColumn.tsx
@@ -22,12 +22,17 @@ type Props = {
 };
 
 export function ExtractColumn({
-  query,
-  stageIndex,
+  query: originalQuery,
+  stageIndex: originalStageIndex,
   onCancel,
   onSubmit,
 }: Props) {
   const [column, setColumn] = useState<Lib.ColumnMetadata | null>(null);
+
+  const { query, stageIndex } = Lib.asReturned(
+    originalQuery,
+    originalStageIndex,
+  );
 
   function handleSelect(column: Lib.ColumnMetadata) {
     setColumn(column);

--- a/frontend/src/metabase/query_builder/components/expressions/ExtractColumn/ExtractColumn.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExtractColumn/ExtractColumn.tsx
@@ -18,7 +18,7 @@ type Props = {
     name: string,
     extraction: Lib.ColumnExtraction,
   ) => void;
-  onCancel: () => void;
+  onCancel?: () => void;
 };
 
 export function ExtractColumn({
@@ -81,7 +81,7 @@ function ColumnPicker({
   stageIndex: number;
   column: Lib.ColumnMetadata | null;
   onSelect: (column: Lib.ColumnMetadata) => void;
-  onCancel: () => void;
+  onCancel?: () => void;
 }) {
   const extractableColumns = useMemo(
     () =>
@@ -94,10 +94,12 @@ function ColumnPicker({
 
   return (
     <>
-      <ExpressionWidgetHeader
-        title={t`Select column to extract from`}
-        onBack={onCancel}
-      />
+      {onCancel && (
+        <ExpressionWidgetHeader
+          title={t`Select column to extract from`}
+          onBack={onCancel}
+        />
+      )}
       <Box py="sm">
         <QueryColumnPicker
           query={query}

--- a/frontend/src/metabase/query_builder/components/expressions/ExtractColumn/ExtractColumn.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExtractColumn/ExtractColumn.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo } from "react";
 import { t } from "ttag";
 
 import { QueryColumnPicker } from "metabase/common/components/QueryColumnPicker";
-import { Text, Box, Stack, Button } from "metabase/ui";
+import { Text, Box, Stack, Button, Title } from "metabase/ui";
 import * as Lib from "metabase-lib";
 
 import { ExpressionWidgetHeader } from "../ExpressionWidgetHeader";
@@ -101,6 +101,11 @@ function ColumnPicker({
         />
       )}
       <Box py="sm">
+        {!onCancel && (
+          <Title p="md" pt="sm" pb={0} order={6}>
+            {t`Select column to extract from`}
+          </Title>
+        )}
         <QueryColumnPicker
           query={query}
           stageIndex={stageIndex}

--- a/frontend/src/metabase/visualizations/click-actions/actions/ExtractColumn/ExtractColumn.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/ExtractColumn/ExtractColumn.tsx
@@ -51,10 +51,10 @@ export const ExtractColumnAction: LegacyDrill = ({ question, clicked }) => {
   return [
     {
       name: "column-extract",
-      title: t`Extract column`,
+      title: t`Extract part of column`,
+      tooltip: t`Extract part of column`,
       buttonType: "horizontal",
       icon: "arrow_split",
-      tooltip: t`Extract column`,
       default: true,
       section: "extract",
       popover: Popover,

--- a/frontend/src/metabase/visualizations/click-actions/actions/ExtractColumn/ExtractColumn.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/ExtractColumn/ExtractColumn.tsx
@@ -53,7 +53,7 @@ export const ExtractColumnAction: LegacyDrill = ({ question, clicked }) => {
       name: "column-extract",
       title: t`Extract column`,
       buttonType: "horizontal",
-      icon: "extract",
+      icon: "arrow_split",
       tooltip: t`Extract column`,
       default: true,
       section: "extract",

--- a/frontend/src/metabase/visualizations/click-actions/actions/ExtractColumn/ExtractColumn.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/ExtractColumn/ExtractColumn.tsx
@@ -44,6 +44,7 @@ export const ExtractColumnAction: LegacyDrill = ({ question, clicked }) => {
         query={query}
         stageIndex={stageIndex}
         onSubmit={handleSubmit}
+        onCancel={onClose}
       />
     );
   };

--- a/frontend/src/metabase/visualizations/click-actions/actions/ExtractColumn/ExtractColumn.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/ExtractColumn/ExtractColumn.tsx
@@ -1,0 +1,63 @@
+import { t } from "ttag";
+
+import { ExtractColumn } from "metabase/query_builder/components/expressions/ExtractColumn";
+import type { LegacyDrill } from "metabase/visualizations/types";
+import type { ClickActionPopoverProps } from "metabase/visualizations/types/click-actions";
+import * as Lib from "metabase-lib";
+
+export const ExtractColumnAction: LegacyDrill = ({ question, clicked }) => {
+  const { isEditable } = Lib.queryDisplayInfo(question.query());
+
+  if (
+    !clicked ||
+    clicked.value !== undefined ||
+    !clicked.columnShortcuts ||
+    clicked?.extraData?.isRawTable ||
+    !isEditable
+  ) {
+    return [];
+  }
+
+  const Popover = ({
+    onChangeCardAndRun,
+    onClose,
+  }: ClickActionPopoverProps) => {
+    const query = question.query();
+    const stageIndex = -1;
+
+    function handleSubmit(
+      _clause: Lib.Clause,
+      _name: string,
+      extraction: Lib.ColumnExtraction,
+    ) {
+      const newQuery = Lib.extract(query, stageIndex, extraction);
+
+      const nextQuestion = question.setQuery(newQuery);
+      const nextCard = nextQuestion.card();
+
+      onChangeCardAndRun({ nextCard });
+      onClose();
+    }
+
+    return (
+      <ExtractColumn
+        query={query}
+        stageIndex={stageIndex}
+        onSubmit={handleSubmit}
+      />
+    );
+  };
+
+  return [
+    {
+      name: "column-extract",
+      title: t`Extract column`,
+      buttonType: "horizontal",
+      icon: "extract",
+      tooltip: t`Extract column`,
+      default: true,
+      section: "extract",
+      popover: Popover,
+    },
+  ];
+};

--- a/frontend/src/metabase/visualizations/click-actions/actions/ExtractColumn/ExtractColumn.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/ExtractColumn/ExtractColumn.tsx
@@ -56,7 +56,7 @@ export const ExtractColumnAction: LegacyDrill = ({ question, clicked }) => {
       buttonType: "horizontal",
       icon: "arrow_split",
       default: true,
-      section: "extract",
+      section: "new-column",
       popover: Popover,
     },
   ];

--- a/frontend/src/metabase/visualizations/click-actions/actions/ExtractColumn/index.ts
+++ b/frontend/src/metabase/visualizations/click-actions/actions/ExtractColumn/index.ts
@@ -1,0 +1,1 @@
+export { ExtractColumnAction } from "./ExtractColumn";

--- a/frontend/src/metabase/visualizations/click-actions/modes/DefaultMode.ts
+++ b/frontend/src/metabase/visualizations/click-actions/modes/DefaultMode.ts
@@ -1,6 +1,7 @@
 import type { QueryClickActionsMode } from "../../types";
 import { ColumnFormattingAction } from "../actions/ColumnFormattingAction";
 import { DashboardClickAction } from "../actions/DashboardClickAction";
+import { ExtractColumnAction } from "../actions/ExtractColumn/ExtractColumn";
 import { HideColumnAction } from "../actions/HideColumnAction";
 import { NativeQueryClickFallback } from "../actions/NativeQueryClickFallback";
 
@@ -11,6 +12,7 @@ export const DefaultMode: QueryClickActionsMode = {
     HideColumnAction,
     ColumnFormattingAction,
     DashboardClickAction,
+    ExtractColumnAction,
   ],
   fallback: NativeQueryClickFallback,
 };

--- a/frontend/src/metabase/visualizations/click-actions/modes/DefaultMode.ts
+++ b/frontend/src/metabase/visualizations/click-actions/modes/DefaultMode.ts
@@ -1,7 +1,7 @@
 import type { QueryClickActionsMode } from "../../types";
 import { ColumnFormattingAction } from "../actions/ColumnFormattingAction";
 import { DashboardClickAction } from "../actions/DashboardClickAction";
-import { ExtractColumnAction } from "../actions/ExtractColumn/ExtractColumn";
+import { ExtractColumnAction } from "../actions/ExtractColumn";
 import { HideColumnAction } from "../actions/HideColumnAction";
 import { NativeQueryClickFallback } from "../actions/NativeQueryClickFallback";
 

--- a/frontend/src/metabase/visualizations/click-actions/modes/EmbeddingSdkMode.ts
+++ b/frontend/src/metabase/visualizations/click-actions/modes/EmbeddingSdkMode.ts
@@ -1,5 +1,6 @@
 import type { QueryClickActionsMode } from "../../types";
 import { DashboardClickAction } from "../actions/DashboardClickAction";
+import { ExtractColumnAction } from "../actions/ExtractColumn/ExtractColumn";
 import { HideColumnAction } from "../actions/HideColumnAction";
 import { NativeQueryClickFallback } from "../actions/NativeQueryClickFallback";
 
@@ -23,6 +24,6 @@ export const EmbeddingSdkMode: QueryClickActionsMode = {
     "drill-thru/zoom-in.geographic",
     "drill-thru/zoom-in.timeseries",
   ],
-  clickActions: [HideColumnAction, DashboardClickAction],
+  clickActions: [HideColumnAction, DashboardClickAction, ExtractColumnAction],
   fallback: NativeQueryClickFallback,
 };

--- a/frontend/src/metabase/visualizations/click-actions/modes/EmbeddingSdkMode.ts
+++ b/frontend/src/metabase/visualizations/click-actions/modes/EmbeddingSdkMode.ts
@@ -1,6 +1,6 @@
 import type { QueryClickActionsMode } from "../../types";
 import { DashboardClickAction } from "../actions/DashboardClickAction";
-import { ExtractColumnAction } from "../actions/ExtractColumn/ExtractColumn";
+import { ExtractColumnAction } from "../actions/ExtractColumn";
 import { HideColumnAction } from "../actions/HideColumnAction";
 import { NativeQueryClickFallback } from "../actions/NativeQueryClickFallback";
 

--- a/frontend/src/metabase/visualizations/components/ClickActions/utils.ts
+++ b/frontend/src/metabase/visualizations/components/ClickActions/utils.ts
@@ -29,6 +29,7 @@ export const SECTIONS: Record<ClickActionSection, Section> = {
   filter: {},
   details: {},
   custom: {},
+  "new-column": {},
 };
 Object.values(SECTIONS).map((section, index) => {
   section.index = index;
@@ -82,6 +83,9 @@ export const getSectionTitle = (
 
     case "extract-popover":
       return t`Select a part to extract`;
+
+    case "new-column":
+      return t`New column`;
   }
 
   return null;

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -1092,7 +1092,17 @@ class TableInteractive extends Component {
                     </div>
                   </>
                 )}
-                {shortcutColumn && <ColumnShortcut height={headerHeight - 1} />}
+                {shortcutColumn && (
+                  <ColumnShortcut
+                    height={headerHeight - 1}
+                    onClick={evt => {
+                      this.onVisualizationClick(
+                        { columnShortcuts: true },
+                        evt.target,
+                      );
+                    }}
+                  />
+                )}
                 <Grid
                   ref={ref => (this.header = ref)}
                   style={{
@@ -1258,7 +1268,7 @@ const DetailShortcut = forwardRef((_props, ref) => (
 
 DetailShortcut.displayName = "DetailShortcut";
 
-function ColumnShortcut({ height }) {
+function ColumnShortcut({ height, onClick }) {
   return (
     <div className={TableS.shortcutsWrapper} style={{ height }}>
       <UIButton
@@ -1267,6 +1277,7 @@ function ColumnShortcut({ height }) {
         leftIcon={<Icon name="add" />}
         title={t`Add column`}
         aria-label={t`Add column`}
+        onClick={onClick}
       />
     </div>
   );

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -25,7 +25,7 @@ import {
 } from "metabase/query_builder/selectors";
 import { getIsEmbeddingSdk } from "metabase/selectors/embed";
 import { EmotionCacheProvider } from "metabase/styled-components/components/EmotionCacheProvider";
-import { Icon, DelayGroup } from "metabase/ui";
+import { Button as UIButton, Icon, DelayGroup } from "metabase/ui";
 import {
   getTableCellClickedObject,
   getTableHeaderClickedObject,
@@ -1025,6 +1025,7 @@ class TableInteractive extends Component {
 
     const headerHeight = this.props.tableHeaderHeight || HEADER_HEIGHT;
     const gutterColumn = this.state.showDetailShortcut ? 1 : 0;
+    const shortcutColumn = 1;
 
     return (
       <DelayGroup>
@@ -1091,6 +1092,7 @@ class TableInteractive extends Component {
                     </div>
                   </>
                 )}
+                {shortcutColumn && <ColumnShortcut height={headerHeight - 1} />}
                 <Grid
                   ref={ref => (this.header = ref)}
                   style={{
@@ -1110,16 +1112,24 @@ class TableInteractive extends Component {
                   height={headerHeight}
                   rowCount={1}
                   rowHeight={headerHeight}
-                  columnCount={cols.length + gutterColumn}
+                  columnCount={cols.length + gutterColumn + shortcutColumn}
                   columnWidth={this.getDisplayColumnWidth}
-                  cellRenderer={props =>
-                    gutterColumn && props.columnIndex === 0
-                      ? null // we need a phantom cell to properly offset columns
-                      : this.tableHeaderRenderer({
-                          ...props,
-                          columnIndex: props.columnIndex - gutterColumn,
-                        })
-                  }
+                  cellRenderer={props => {
+                    if (props.columnIndex === 0 && gutterColumn) {
+                      // we need a phantom cell to properly offset gutter columns
+                      return null;
+                    }
+
+                    if (props.columnIndex === cols.length + gutterColumn) {
+                      // we need a phantom cell to properly offset the shortcut column
+                      return null;
+                    }
+
+                    return this.tableHeaderRenderer({
+                      ...props,
+                      columnIndex: props.columnIndex - gutterColumn,
+                    });
+                  }}
                   onScroll={({ scrollLeft }) => onScroll({ scrollLeft })}
                   scrollLeft={scrollLeft}
                   tabIndex={null}
@@ -1137,18 +1147,26 @@ class TableInteractive extends Component {
                   }}
                   width={width}
                   height={height - headerHeight}
-                  columnCount={cols.length + gutterColumn}
+                  columnCount={cols.length + gutterColumn + shortcutColumn}
                   columnWidth={this.getDisplayColumnWidth}
                   rowCount={rows.length}
                   rowHeight={ROW_HEIGHT}
-                  cellRenderer={props =>
-                    gutterColumn && props.columnIndex === 0
-                      ? null // we need a phantom cell to properly offset columns
-                      : this.cellRenderer({
-                          ...props,
-                          columnIndex: props.columnIndex - gutterColumn,
-                        })
-                  }
+                  cellRenderer={props => {
+                    if (props.columnIndex === 0 && gutterColumn) {
+                      // we need a phantom cell to properly offset gutter columns
+                      return null;
+                    }
+
+                    if (props.columnIndex === cols.length + gutterColumn) {
+                      // we need a phantom cell to properly offset the shortcut column
+                      return null;
+                    }
+
+                    return this.cellRenderer({
+                      ...props,
+                      columnIndex: props.columnIndex - gutterColumn,
+                    });
+                  }}
                   scrollTop={scrollTop}
                   onScroll={({ scrollLeft, scrollTop }) => {
                     this.props.onActionDismissal();
@@ -1239,3 +1257,17 @@ const DetailShortcut = forwardRef((_props, ref) => (
 ));
 
 DetailShortcut.displayName = "DetailShortcut";
+
+function ColumnShortcut({ height }) {
+  return (
+    <div className={TableS.shortcutsWrapper} style={{ height }}>
+      <UIButton
+        variant="filled"
+        compact
+        leftIcon={<Icon name="add" />}
+        title={t`Add column`}
+        aria-label={t`Add column`}
+      />
+    </div>
+  );
+}

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -1017,6 +1017,7 @@ class TableInteractive extends Component {
       data: { cols, rows },
       className,
       scrollToColumn,
+      question,
     } = this.props;
 
     if (!width || !height) {
@@ -1026,6 +1027,7 @@ class TableInteractive extends Component {
     const headerHeight = this.props.tableHeaderHeight || HEADER_HEIGHT;
     const gutterColumn = this.state.showDetailShortcut ? 1 : 0;
     const shortcutColumn = 1;
+    const info = Lib.queryDisplayInfo(question.query());
 
     return (
       <DelayGroup>
@@ -1095,6 +1097,7 @@ class TableInteractive extends Component {
                 {shortcutColumn && (
                   <ColumnShortcut
                     height={headerHeight - 1}
+                    isEditable={info.isEditable}
                     onClick={evt => {
                       this.onVisualizationClick(
                         { columnShortcuts: true },
@@ -1268,7 +1271,11 @@ const DetailShortcut = forwardRef((_props, ref) => (
 
 DetailShortcut.displayName = "DetailShortcut";
 
-function ColumnShortcut({ height, onClick }) {
+function ColumnShortcut({ height, onClick, isEditable }) {
+  if (!isEditable) {
+    return null;
+  }
+
   return (
     <div className={TableS.shortcutsWrapper} style={{ height }}>
       <UIButton

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -1027,7 +1027,8 @@ class TableInteractive extends Component {
     const headerHeight = this.props.tableHeaderHeight || HEADER_HEIGHT;
     const gutterColumn = this.state.showDetailShortcut ? 1 : 0;
     const shortcutColumn = 1;
-    const info = Lib.queryDisplayInfo(question.query());
+    const query = question?.query();
+    const info = query && Lib.queryDisplayInfo(query);
 
     return (
       <DelayGroup>
@@ -1097,7 +1098,7 @@ class TableInteractive extends Component {
                 {shortcutColumn && (
                   <ColumnShortcut
                     height={headerHeight - 1}
-                    isEditable={info.isEditable}
+                    isEditable={info?.isEditable}
                     onClick={evt => {
                       this.onVisualizationClick(
                         { columnShortcuts: true },

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.module.css
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.module.css
@@ -105,3 +105,16 @@
 .TableInteractiveGutter {
   background-color: var(--color-bg-white);
 }
+
+.shortcutsWrapper {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 50;
+  background: white;
+  padding: 0 0.5em;
+  box-sizing: border-box;
+  border-left: 1px solid var(--color-border);
+  display: flex;
+  align-items: center;
+}

--- a/frontend/src/metabase/visualizations/types/click-actions.ts
+++ b/frontend/src/metabase/visualizations/types/click-actions.ts
@@ -35,6 +35,7 @@ export type ClickActionSection =
   | "filter"
   | "info"
   | "records"
+  | "new-column"
   | "sort"
   | "standalone_filter"
   | "sum"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/42151


### Description

Implements the `Add column` button for the table viz, and adds an extract column shortcut there.

### How to verify
1. Browse data -> Sample database -> Orders
2. Click the `+` icon in the table header (on the right)
3. Click `Extract column`
4. Select a column and an extraction
5. Verify that a column has been added and that the data matches the selected extraction

### Demo

<img width="1474" alt="Screenshot 2024-05-05 at 18 42 06" src="https://github.com/metabase/metabase/assets/1250185/869646d4-76a9-4a9c-96d8-d8bf81bc36b8">


https://github.com/metabase/metabase/assets/1250185/945f64b3-1f90-4921-94f7-47e40799437d




### Checklist

- [x] Tests have been added/updated to cover changes in this PR
