### PR TITLE
Make Z-indexes a bit more sane

### DIFF
--- a/frontend/src/metabase/common/components/CollectionPicker/components/NewCollectionDialog.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/NewCollectionDialog.tsx
@@ -12,6 +12,7 @@ import {
 import { Button, Flex, Modal } from "metabase/ui";
 import type { CollectionId } from "metabase-types/api";
 
+import { ENTITY_PICKER_Z_INDEX } from "../../EntityPicker";
 import type { CollectionPickerItem } from "../types";
 
 interface NewCollectionDialogProps {
@@ -52,7 +53,7 @@ export const NewCollectionDialog = ({
           padding: "1rem",
         },
       }}
-      zIndex={400} // needs to be above the EntityPickerModal at 400
+      zIndex={ENTITY_PICKER_Z_INDEX}
     >
       <FormProvider
         initialValues={{ name: "" }}

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
@@ -3,6 +3,7 @@ import { useMemo, useState } from "react";
 import { t } from "ttag";
 
 import ErrorBoundary from "metabase/ErrorBoundary";
+import { BULK_ACTIONS_Z_INDEX } from "metabase/collections/components/BulkActions.styled";
 import { useModalOpen } from "metabase/hooks/use-modal-open";
 import { Modal } from "metabase/ui";
 import type {
@@ -40,6 +41,9 @@ export const defaultOptions: EntityPickerModalOptions = {
   hasConfirmButtons: true,
   allowCreateNew: true,
 };
+
+// needs to be above popovers and bulk actions
+export const ENTITY_PICKER_Z_INDEX = BULK_ACTIONS_Z_INDEX;
 
 export interface EntityPickerModalProps<Model extends string, Item> {
   title?: string;
@@ -109,10 +113,10 @@ export function EntityPickerModal<
       onClose={onClose}
       data-testid="entity-picker-modal"
       trapFocus={trapFocus}
-      zIndex={400} // needed to put this above the BulkActionsToast
       closeOnEscape={false} // we're doing this manually in useWindowEvent
       xOffset="10vw"
       yOffset="10dvh"
+      zIndex={ENTITY_PICKER_Z_INDEX} // needs to be above popovers and bulk actions
     >
       <Modal.Overlay />
       <ModalContent h="100%">

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
@@ -3,7 +3,7 @@ import { useMemo, useState } from "react";
 import { t } from "ttag";
 
 import ErrorBoundary from "metabase/ErrorBoundary";
-import { BULK_ACTIONS_Z_INDEX } from "metabase/collections/components/BulkActions.styled";
+import { BULK_ACTIONS_Z_INDEX } from "metabase/components/BulkActionBar";
 import { useModalOpen } from "metabase/hooks/use-modal-open";
 import { Modal } from "metabase/ui";
 import type {

--- a/frontend/src/metabase/common/components/EntityPicker/components/ResultItem/ResultItem.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/ResultItem/ResultItem.tsx
@@ -6,6 +6,8 @@ import { getIcon } from "metabase/lib/icon";
 import { Icon, Flex, Tooltip } from "metabase/ui";
 import type { SearchResult } from "metabase-types/api";
 
+import { ENTITY_PICKER_Z_INDEX } from "../EntityPickerModal";
+
 import { ChunkyListItem } from "./ResultItem.styled";
 
 export type ResultItemType = Pick<
@@ -53,12 +55,7 @@ export const ResultItem = ({
             maw="20rem"
             multiline
             label={item.description}
-            styles={{
-              tooltip: {
-                // required to get the tooltip to show up over the entity picker modal 😢
-                zIndex: "450 !important" as any,
-              },
-            }}
+            zIndex={ENTITY_PICKER_Z_INDEX}
           >
             <Icon color="brand" name="info" />
           </Tooltip>

--- a/frontend/src/metabase/common/components/EntityPicker/components/ResultItem/ResultItem.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/ResultItem/ResultItem.tsx
@@ -3,7 +3,7 @@ import { t } from "ttag";
 import { Ellipsified } from "metabase/core/components/Ellipsified";
 import { color } from "metabase/lib/colors";
 import { getIcon } from "metabase/lib/icon";
-import { Icon, Flex } from "metabase/ui";
+import { Icon, Flex, Tooltip } from "metabase/ui";
 import type { SearchResult } from "metabase-types/api";
 
 import { ChunkyListItem } from "./ResultItem.styled";
@@ -48,6 +48,21 @@ export const ResultItem = ({
           }}
         />
         <Ellipsified style={{ fontWeight: "bold" }}>{item.name}</Ellipsified>
+        {item.description && (
+          <Tooltip
+            maw="20rem"
+            multiline
+            label={item.description}
+            styles={{
+              tooltip: {
+                // required to get the tooltip to show up over the entity picker modal 😢
+                zIndex: "450 !important" as any,
+              },
+            }}
+          >
+            <Icon color="brand" name="info" />
+          </Tooltip>
+        )}
       </Flex>
 
       {item.model !== "collection" && ( // we don't hydrate parent info for collections right now

--- a/frontend/src/metabase/common/components/EntityPicker/components/ResultItem/ResultItem.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/ResultItem/ResultItem.unit.spec.tsx
@@ -1,6 +1,11 @@
 import { setupEnterprisePlugins } from "__support__/enterprise";
 import { mockSettings } from "__support__/settings";
-import { getIcon, renderWithProviders, screen } from "__support__/ui";
+import {
+  getIcon,
+  queryIcon,
+  renderWithProviders,
+  screen,
+} from "__support__/ui";
 import register from "metabase/visualizations/register";
 import {
   createMockSettings,
@@ -128,6 +133,22 @@ describe("EntityPicker > ResultItem", () => {
 
     expect(getIcon("dashboard")).toBeInTheDocument();
     expect(screen.getByText("in My parent collection")).toBeInTheDocument();
+  });
+
+  it("should render an info icon when an item lacks a description", () => {
+    setup({
+      item: dashboardItem,
+    });
+
+    expect(getIcon("info")).toBeInTheDocument();
+  });
+
+  it("should not render an info icon when an item has a description", () => {
+    setup({
+      item: questionItem,
+    });
+
+    expect(queryIcon("info")).not.toBeInTheDocument();
   });
 
   it("should render a line chart item in an official collection", () => {

--- a/frontend/src/metabase/components/BulkActionBar/BulkActionBar.styled.tsx
+++ b/frontend/src/metabase/components/BulkActionBar/BulkActionBar.styled.tsx
@@ -3,14 +3,17 @@ import styled from "@emotion/styled";
 import Card from "metabase/components/Card";
 import { alpha, color } from "metabase/lib/colors";
 import { space } from "metabase/styled-components/theme";
-import { Button } from "metabase/ui";
+import { Button, DEFAULT_POPOVER_Z_INDEX } from "metabase/ui";
+
+// needed to put this over popovers (z-index: 300)
+export const BULK_ACTIONS_Z_INDEX = DEFAULT_POPOVER_Z_INDEX + 1;
 
 export const BulkActionsToast = styled.div<{ isNavbarOpen: boolean }>`
   position: fixed;
   bottom: 0;
   left: 50%;
   margin-bottom: ${space(2)};
-  z-index: 400; // needed to put this over popovers (z-index: 300)
+  z-index: ${BULK_ACTIONS_Z_INDEX};
 `;
 
 export const ToastCard = styled(Card)`

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText/ExpressionEditorHelpText.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText/ExpressionEditorHelpText.tsx
@@ -6,6 +6,7 @@ import TippyPopover from "metabase/components/Popover/TippyPopover";
 import { useSelector } from "metabase/lib/redux";
 import MetabaseSettings from "metabase/lib/settings";
 import { getShowMetabaseLinks } from "metabase/selectors/whitelabel";
+import { DEFAULT_POPOVER_Z_INDEX } from "metabase/ui";
 import { getHelpDocsUrl } from "metabase-lib/v1/expressions/helper-text-strings";
 import type { HelpText } from "metabase-lib/v1/expressions/types";
 
@@ -111,7 +112,7 @@ export const ExpressionEditorHelpText = ({
       reference={target}
       placement="bottom-start"
       visible
-      zIndex={300}
+      zIndex={DEFAULT_POPOVER_Z_INDEX}
       content={<ExpressionEditorHelpTextContent helpText={helpText} />}
     />
   );

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.tsx
@@ -14,7 +14,13 @@ import { Popover as InfoPopover } from "metabase/components/MetadataInfo/Popover
 import CS from "metabase/css/core/index.css";
 import { color } from "metabase/lib/colors";
 import { isObscured } from "metabase/lib/dom";
-import { DelayGroup, Icon, type IconName, Popover } from "metabase/ui";
+import {
+  DelayGroup,
+  Icon,
+  type IconName,
+  Popover,
+  DEFAULT_POPOVER_Z_INDEX,
+} from "metabase/ui";
 import type * as Lib from "metabase-lib";
 import type {
   Suggestion,
@@ -93,7 +99,7 @@ export function ExpressionEditorSuggestions({
       opened={open && suggestions.length > 0}
       radius="xs"
       withinPortal
-      zIndex={300}
+      zIndex={DEFAULT_POPOVER_Z_INDEX}
     >
       <Popover.Target>{children}</Popover.Target>
       <Popover.Dropdown>

--- a/frontend/src/metabase/ui/components/overlays/Popover/Popover.styled.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Popover/Popover.styled.tsx
@@ -1,6 +1,8 @@
 import type { MantineThemeOverride } from "@mantine/core";
 import type { SyntheticEvent } from "react";
 
+export const DEFAULT_POPOVER_Z_INDEX = 300;
+
 export const getPopoverOverrides = (): MantineThemeOverride["components"] => ({
   Popover: {
     defaultProps: {

--- a/frontend/src/metabase/ui/components/overlays/Popover/index.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Popover/index.tsx
@@ -41,3 +41,4 @@ const Popover: typeof MantinePopover & {
 } = MantinePopover;
 
 export { Popover };
+export { DEFAULT_POPOVER_Z_INDEX } from "./Popover.styled";


### PR DESCRIPTION
Follow up to <a href="https://github.com/metabase/metabase/pull/42009" target="_blank">[Entity picker/new search item component](https://github.com/metabase/metabase/pull/42009)</a>

### Description

Moves various Z-indexes to contstants so that they can be a bit more sane:

1. Popover z-index: 300
2. Bulk actions toast above popovers
3. Entity picker above bulk actions popovers
4. New item modal above the entity picker
5. popovers in the entity picker should also be above the entity picker. (added back from #42009)

![tangled web of zs](https://github.com/metabase/metabase/assets/30528226/cca60649-5c58-4817-a136-324395da5bb5)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
