### PR TITLE
adds diagnostic info to troubleshooting for air gapping

### DIFF
--- a/src/metabase/public_settings/premium_features.clj
+++ b/src/metabase/public_settings/premium_features.clj
@@ -73,7 +73,7 @@
                 f
                 :ttl/threshold (u/minutes->ms 5))
       lock     (Object.)]
-  (defn- cached-active-users-count
+  (defn cached-active-users-count
     "Primarily used for the settings because we don't wish it to be 100%. (HUH?)"
     []
     (locking lock
@@ -133,7 +133,7 @@
 ;;;;;;;;;;;;;;;;;;;; Airgap Tokens ;;;;;;;;;;;;;;;;;;;;
 (declare decode-airgap-token)
 
-(mu/defn ^:private max-users-allowed
+(mu/defn max-users-allowed
   "Returns the max users value from an airgapped key, or nil indicating there is no limt."
   [] :- [:or pos-int? :nil]
   (when-let [token (premium-embedding-token)]
@@ -254,6 +254,7 @@
   :setter     :none
   :getter     (fn [] (some-> (premium-embedding-token) (fetch-token-status))))
 
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                             SETTING & RELATED FNS                                              |
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -280,6 +281,11 @@
         (throw (ex-info (.getMessage e) (merge
                                          {:message (.getMessage e), :status-code 400}
                                          (ex-data e)))))))) ; merge in error-details if present
+
+(defn is-airgapped?
+  "Returns true if the current instance is airgapped."
+  []
+  (mc/validate AirgapToken (premium-embedding-token)))
 
 (let [cached-logger (memoize/ttl
                      ^{::memoize/args-fn (fn [[token _e]] [token])}

--- a/src/metabase/troubleshooting.clj
+++ b/src/metabase/troubleshooting.clj
@@ -4,6 +4,7 @@
    [metabase.config :as config]
    [metabase.db :as mdb]
    [metabase.driver :as driver]
+   [metabase.public-settings.premium-features :as premium-features]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -28,15 +29,21 @@
 (defn metabase-info
   "Make it easy for the user to tell us what they're using"
   []
-  {:databases                    (->> (t2/select 'Database) (map :engine) distinct)
-   :hosting-env                  (stats/environment-type)
-   :application-database         (mdb/db-type)
-   :application-database-details (t2/with-connection [^java.sql.Connection conn]
-                                   (let [metadata (.getMetaData conn)]
-                                     {:database    {:name    (.getDatabaseProductName metadata)
-                                                    :version (.getDatabaseProductVersion metadata)}
-                                      :jdbc-driver {:name    (.getDriverName metadata)
-                                                    :version (.getDriverVersion metadata)}}))
-   :run-mode                     (config/config-kw :mb-run-mode)
-   :version                      config/mb-version-info
-   :settings                     {:report-timezone (driver/report-timezone)}})
+  (merge
+   {:databases                    (->> (t2/select :model/Database) (map :engine) distinct)
+    :hosting-env                  (stats/environment-type)
+    :application-database         (mdb/db-type)
+    :application-database-details (t2/with-connection [^java.sql.Connection conn]
+                                    (let [metadata (.getMetaData conn)]
+                                      {:database    {:name    (.getDatabaseProductName metadata)
+                                                     :version (.getDatabaseProductVersion metadata)}
+                                       :jdbc-driver {:name    (.getDriverName metadata)
+                                                     :version (.getDriverVersion metadata)}}))
+    :run-mode                     (config/config-kw :mb-run-mode)
+    :version                      config/mb-version-info
+    :settings                     {:report-timezone (driver/report-timezone)}}
+   (when (premium-features/is-airgapped?)
+     {:airgap-token :enabled
+      :max-users (premium-features/max-users-allowed)
+      :current-user-count (premium-features/cached-active-users-count)
+      :valid-thru (some-> (premium-features/premium-embedding-token) premium-features/fetch-token-status :valid-thru)})))


### PR DESCRIPTION
After a meeting with the success team, they mentioned that it'd be nice to have more info about the currently running metabase instance.

Iff airgap mode is setup we return these, otherwise it's elided:

- [x] that the airgap token is enabled
- [x] what the max users cap is
- [x] what the current user count is
- [x] when the expiration date is