### PR TITLE
Fix collection data for trashed items

### DIFF
--- a/src/metabase/api/activity.clj
+++ b/src/metabase/api/activity.clj
@@ -22,11 +22,13 @@
      "card"      [Card
                   :id :name :collection_id :description :display
                   :dataset_query :type :archived
-                  :collection.authority_level [:collection.name :collection_name]]
+                  :collection.authority_level [:collection.name :collection_name]
+                  :trashed_from_collection_id]
      "dashboard" [Dashboard
                   :id :name :collection_id :description
                   :archived
-                  :collection.authority_level [:collection.name :collection_name]]
+                  :collection.authority_level [:collection.name :collection_name]
+                  :trashed_from_collection_id]
      "table"     [Table
                   :id :name :db_id
                   :display_name :initial_sync_status

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -80,6 +80,7 @@
    :type                   mi/transform-keyword})
 
 (doto :model/Card
+  (derive ::mi/has-trashed-from-collection-id)
   (derive :metabase/model)
   ;; You can read/write a Card if you can read/write its parent Collection
   (derive ::perms/use-parent-collection-perms)

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -47,6 +47,7 @@
 (methodical/defmethod t2/table-name :model/Dashboard [_model] :report_dashboard)
 
 (doto :model/Dashboard
+  (derive ::mi/has-trashed-from-collection-id)
   (derive :metabase/model)
   (derive ::perms/use-parent-collection-perms)
   (derive :hook/timestamped?)

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -491,7 +491,6 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                             New Permissions Stuff                                              |
 ;;; +----------------------------------------------------------------------------------------------------------------+
-
 (def ^{:arglists '([x & _args])} dispatch-on-model
   "Helper dispatch function for multimethods. Dispatches on the first arg, using [[models.dispatch/model]]."
   t2.u/dispatch-on-first-arg)
@@ -732,3 +731,34 @@
 (defmethod exclude-internal-content-hsql :default
   [_model & _]
   [:= [:inline 1] [:inline 1]])
+
+(defmulti parent-collection-id-for-perms
+  "What is the ID of the parent collection that should determine the perms objects set for this object?"
+  {:arglists '([instance])}
+  dispatch-on-model)
+
+(defmethod parent-collection-id-for-perms ::has-trashed-from-collection-id
+  [instance]
+  (cond
+    (not (:archived instance)) (:collection_id instance)
+    (contains? instance :trashed_from_collection_id) (:trashed_from_collection_id instance)
+    ;; If we're supposed to get permissions from the `trashed_from_collection_id` but it isn't present, we can't check
+    ;; permissions correctly.
+    :else (throw (ex-info "Missing trashed_from_collection_id" {:instance instance}))))
+
+(defmethod parent-collection-id-for-perms :default
+  [instance]
+  (:collection_id instance))
+
+(defmulti parent-collection-id-column-for-perms
+  "What column should we use to determine the perms for this model?"
+  {:arglists '([model])}
+  identity)
+
+(defmethod parent-collection-id-column-for-perms :default
+  [_model]
+  :collection_id)
+
+(defmethod parent-collection-id-column-for-perms ::has-trashed-from-collection-id
+  [_model]
+  [:coalesce :trashed_from_collection_id :collection_id])

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -324,10 +324,7 @@
    (let [path-fn (case read-or-write
                    :read  collection-read-path
                    :write collection-readwrite-path)
-         collection-id (if (and (contains? this :trashed_from_collection_id)
-                                (:archived this))
-                         (:trashed_from_collection_id this)
-                         (:collection_id this))]
+         collection-id (mi/parent-collection-id-for-perms this)]
      ;; now pass that function our collection_id if we have one, or if not, pass it an object representing the Root
      ;; Collection
      #{(path-fn (or collection-id

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -141,6 +141,7 @@
    :collection_type     :text
    :collection_location :text
    :collection_authority_level :text
+   :trashed_from_collection_id :integer
    ;; returned for Card and Dashboard
    :collection_position :integer
    :creator_id          :integer
@@ -270,7 +271,7 @@
 
 (defmethod columns-for-model "card"
   [_]
-  (conj default-columns :collection_id :collection_position :dataset_query :display :creator_id
+  (conj default-columns :collection_id :trashed_from_collection_id :collection_position :dataset_query :display :creator_id
         [:collection.name :collection_name]
         [:collection.location :collection_location]
         [:collection.authority_level :collection_authority_level]
@@ -289,7 +290,7 @@
 
 (defmethod columns-for-model "dashboard"
   [_]
-  (conj default-columns :collection_id :collection_position :creator_id bookmark-col
+  (conj default-columns :trashed_from_collection_id :collection_id :collection_position :creator_id bookmark-col
         [:collection.name :collection_name]
         [:collection.authority_level :collection_authority_level]))
 

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -328,6 +328,7 @@
          :all-scores
          :relevant-scores
          :collection_effective_ancestors
+         :trashed_from_collection_id
          :collection_id
          :collection_location
          :collection_name

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -6,7 +6,6 @@
    [java-time.api :as t]
    [metabase.analytics.snowplow-test :as snowplow-test]
    [metabase.api.search :as api.search]
-   [metabase.config :as config]
    [metabase.legacy-mbql.normalize :as mbql.normalize]
    [metabase.models
     :refer [Action Card CardBookmark Collection Dashboard DashboardBookmark
@@ -433,7 +432,7 @@
                    (set (map :id (:data (mt/user-http-request :crowberto :get 200 "/search"
                                                               :archived true :q search-name)))))))
           (testing "the collection ID is correct - the Trash ID"
-            (is (= #{config/trash-collection-id}
+            (is (= #{(collection/trash-collection-id)}
                    (set (map (comp :id :collection) (:data (mt/user-http-request :crowberto :get 200 "/search"
                                                                                  :archived true :q search-name)))))))
           (testing "if we are granted permissions on the original collection, we can see the trashed items"
@@ -748,7 +747,7 @@
   (assoc m
          :archived true
          :trashed_from_collection_id (:collection_id m)
-         :collection_id config/trash-collection-id))
+         :collection_id (collection/trash-collection-id)))
 
 (deftest archived-results-test
   (testing "Should return unarchived results by default"


### PR DESCRIPTION
When something is in the trash, we need to check permissions on the `trashed_from_collection_id` rather than the `collection_id`. We were doing this. However, we want the actual collection data on the search result to represent the actual collection it's in (the trash). I added the code to do this, a test to make sure it works as intended, and a comment to explain what we're doing here and why.