### PR TITLE
Fix mysql with multiple most recent revision

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5810,13 +5810,20 @@ databaseChangeLog:
         - sql:
             dbms: mysql,mariadb
             sql: >-
-              UPDATE revision r
+              UPDATE revision AS r
               JOIN (
-                  SELECT id, ROW_NUMBER() OVER (PARTITION BY model, model_id ORDER BY timestamp DESC, id DESC) AS row_num
-                  FROM revision
-              ) AS subquery
-              ON r.id = subquery.id
-              SET r.most_recent = (subquery.row_num = 1);
+                  SELECT r.id,
+                        ROW_NUMBER() OVER (PARTITION BY r.model, r.model_id ORDER BY r.timestamp DESC, r.id DESC) AS row_num
+                    FROM revision AS r
+                    JOIN (
+                          SELECT model, model_id
+                          FROM revision
+                          WHERE most_recent = 't'
+                          GROUP BY model, model_id
+                          HAVING count(*) > 1
+                        ) AS i ON r.model = i.model AND r.model_id = i.model_id
+              ) AS n ON r.id = n.id
+              SET r.most_recent = (n.row_num = 1);
       rollback: # nothing
 
   - changeSet:

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5801,34 +5801,8 @@ databaseChangeLog:
   - changeSet:
       id: v49.2024-05-07T10:00:00
       author: qnkhuat
-      # a redo of v48.00-008
-      comment: Set revision.most_recent = true ensures that there is only one most recent revision per model_id
+      comment: Set revision.most_recent = true to latest revision and false to others. A redo of v48.00-008 for mysql
       changes:
-        - sql:
-            dbms: h2
-            sql: >-
-              UPDATE revision r
-              SET r.most_recent = (
-                  SELECT CASE WHEN row_num = 1 THEN TRUE ELSE FALSE END
-                  FROM (
-                      SELECT id, ROW_NUMBER() OVER (PARTITION BY model, model_id ORDER BY timestamp DESC, id DESC) AS row_num
-                      FROM revision
-                  ) AS subquery
-                  WHERE r.id = subquery.id
-              );
-        - sql:
-            dbms: postgresql
-            sql: >-
-              WITH max_timestamp_per_group AS (
-                  SELECT id, ROW_NUMBER() OVER (PARTITION BY model, model_id ORDER BY timestamp DESC, id DESC) AS row_num
-                  FROM revision
-              )
-              UPDATE revision r
-              SET most_recent = (subquery.row_num = 1)
-              FROM max_timestamp_per_group subquery
-              WHERE r.id = subquery.id;
-          # mysql and mariadb does not allow update on a table that is in the select part
-          # so it we join for them
         - sql:
             dbms: mysql,mariadb
             sql: >-
@@ -5839,7 +5813,7 @@ databaseChangeLog:
               ) AS subquery
               ON r.id = subquery.id
               SET r.most_recent = (subquery.row_num = 1);
-      rollback: # nothing to do since the most_recent will be dropped anyway
+      rollback: # nothing
 
   - changeSet:
       id: v50.2024-01-04T13:52:51

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -3394,19 +3394,36 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-008
-      validCheckSum: 8:c0a512701d6dfd5cc1c4a689919be074
+      validCheckSum: ANY
       author: qnkhuat
       comment: Set revision.most_recent = true for latest revisions
       changes:
         - sql:
-            dbms: postgresql,h2
+            dbms: h2
             sql: >-
               UPDATE revision r
-              SET most_recent = true
-              WHERE (model, model_id, timestamp) IN (
-                                 SELECT model, model_id, MAX(timestamp)
-                                 FROM revision
-                                 GROUP BY model, model_id);
+              SET most_recent = TRUE
+              WHERE (model, model_id, timestamp, id) IN (
+                  SELECT model, model_id, timestamp, id
+                  FROM (
+                      SELECT model, model_id, timestamp, id,
+                            ROW_NUMBER() OVER (PARTITION BY model, model_id ORDER BY timestamp DESC, id DESC) AS row_num
+                      FROM revision
+                  ) AS subquery
+                  WHERE row_num = 1
+              );
+        - sql:
+            dbms: postgresql
+            sql: >-
+              WITH max_timestamp_per_group AS (
+                  SELECT id, ROW_NUMBER() OVER (PARTITION BY model, model_id ORDER BY timestamp DESC, id DESC) AS row_num
+                  FROM revision
+              )
+              UPDATE revision r
+              SET most_recent = TRUE
+              FROM max_timestamp_per_group subquery
+              WHERE r.id = subquery.id
+                  AND subquery.row_num = 1;
           # mysql and mariadb does not allow update on a table that is in the select part
           # so it we join for them
         - sql:
@@ -3414,14 +3431,12 @@ databaseChangeLog:
             sql: >-
               UPDATE revision r
               JOIN (
-                  SELECT model, model_id, MAX(timestamp) AS max_timestamp
+                  SELECT id, ROW_NUMBER() OVER (PARTITION BY model, model_id ORDER BY timestamp DESC, id DESC) AS row_num
                   FROM revision
-                  GROUP BY model, model_id
               ) AS subquery
-              ON r.model = subquery.model AND r.model_id = subquery.model_id AND r.timestamp = subquery.max_timestamp
-              SET r.most_recent = true;
+              ON r.id = subquery.id
+              SET r.most_recent = (subquery.row_num = 1);
       rollback: # nothing to do since the most_recent will be dropped anyway
-
 
   - changeSet:
       id: v48.00-009

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -3394,34 +3394,19 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-008
-      validCheckSum: ANY
+      validCheckSum: 8:c0a512701d6dfd5cc1c4a689919be074
       author: qnkhuat
       comment: Set revision.most_recent = true for latest revisions
       changes:
         - sql:
-            dbms: h2
+            dbms: postgresql,h2
             sql: >-
               UPDATE revision r
-              SET most_recent = TRUE
-              WHERE (id) IN (
-                  SELECT id
-                  FROM (
-                      SELECT id, ROW_NUMBER() OVER (PARTITION BY model, model_id ORDER BY timestamp DESC, id DESC) AS row_num
-                      FROM revision
-                  ) AS subquery
-                  WHERE row_num = 1
-              );
-        - sql:
-            dbms: postgresql
-            sql: >-
-              WITH max_timestamp_per_group AS (
-                  SELECT id, ROW_NUMBER() OVER (PARTITION BY model, model_id ORDER BY timestamp DESC, id DESC) AS row_num
-                  FROM revision
-              )
-              UPDATE revision r
-              SET most_recent = TRUE
-              FROM max_timestamp_per_group subquery
-              WHERE r.id = subquery.id AND subquery.row_num = 1;
+              SET most_recent = true
+              WHERE (model, model_id, timestamp) IN (
+                                 SELECT model, model_id, MAX(timestamp)
+                                 FROM revision
+                                 GROUP BY model, model_id);
           # mysql and mariadb does not allow update on a table that is in the select part
           # so it we join for them
         - sql:
@@ -3429,11 +3414,12 @@ databaseChangeLog:
             sql: >-
               UPDATE revision r
               JOIN (
-                  SELECT id, ROW_NUMBER() OVER (PARTITION BY model, model_id ORDER BY timestamp DESC, id DESC) AS row_num
+                  SELECT model, model_id, MAX(timestamp) AS max_timestamp
                   FROM revision
+                  GROUP BY model, model_id
               ) AS subquery
-              ON r.id = subquery.id
-              SET r.most_recent = (subquery.row_num = 1);
+              ON r.model = subquery.model AND r.model_id = subquery.model_id AND r.timestamp = subquery.max_timestamp
+              SET r.most_recent = true;
       rollback: # nothing to do since the most_recent will be dropped anyway
 
   - changeSet:
@@ -5811,6 +5797,49 @@ databaseChangeLog:
       changes:
         - customChange:
             class: "metabase.db.custom_migrations.DeleteScanFieldValuesTriggerForDBThatTurnItOff"
+
+  - changeSet:
+      id: v49.2024-05-07T10:00:00
+      author: qnkhuat
+      # a redo of v48.00-008
+      comment: Set revision.most_recent = true ensures that there is only one most recent revision per model_id
+      changes:
+        - sql:
+            dbms: h2
+            sql: >-
+              UPDATE revision r
+              SET r.most_recent = (
+                  SELECT CASE WHEN row_num = 1 THEN TRUE ELSE FALSE END
+                  FROM (
+                      SELECT id, ROW_NUMBER() OVER (PARTITION BY model, model_id ORDER BY timestamp DESC, id DESC) AS row_num
+                      FROM revision
+                  ) AS subquery
+                  WHERE r.id = subquery.id
+              );
+        - sql:
+            dbms: postgresql
+            sql: >-
+              WITH max_timestamp_per_group AS (
+                  SELECT id, ROW_NUMBER() OVER (PARTITION BY model, model_id ORDER BY timestamp DESC, id DESC) AS row_num
+                  FROM revision
+              )
+              UPDATE revision r
+              SET most_recent = (subquery.row_num = 1)
+              FROM max_timestamp_per_group subquery
+              WHERE r.id = subquery.id;
+          # mysql and mariadb does not allow update on a table that is in the select part
+          # so it we join for them
+        - sql:
+            dbms: mysql,mariadb
+            sql: >-
+              UPDATE revision r
+              JOIN (
+                  SELECT id, ROW_NUMBER() OVER (PARTITION BY model, model_id ORDER BY timestamp DESC, id DESC) AS row_num
+                  FROM revision
+              ) AS subquery
+              ON r.id = subquery.id
+              SET r.most_recent = (subquery.row_num = 1);
+      rollback: # nothing to do since the most_recent will be dropped anyway
 
   - changeSet:
       id: v50.2024-01-04T13:52:51

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5812,16 +5812,16 @@ databaseChangeLog:
             sql: >-
               UPDATE revision AS r
               JOIN (
-                  SELECT r.id,
-                        ROW_NUMBER() OVER (PARTITION BY r.model, r.model_id ORDER BY r.timestamp DESC, r.id DESC) AS row_num
-                    FROM revision AS r
+                  SELECT inner_revision.id,
+                        ROW_NUMBER() OVER (PARTITION BY inner_revision.model, inner_revision.model_id ORDER BY inner_revision.timestamp DESC, inner_revision.id DESC) AS row_num
+                    FROM revision AS inner_revision
                     JOIN (
                           SELECT model, model_id
                           FROM revision
                           WHERE most_recent = true
                           GROUP BY model, model_id
                           HAVING count(*) > 1
-                        ) AS i ON r.model = i.model AND r.model_id = i.model_id
+                        ) AS infected_revision ON inner_revision.model = infected_revision.model AND inner_revision.model_id = infected_revision.model_id
               ) AS n ON r.id = n.id
               SET r.most_recent = (n.row_num = 1);
       rollback: # nothing

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5818,7 +5818,7 @@ databaseChangeLog:
                     JOIN (
                           SELECT model, model_id
                           FROM revision
-                          WHERE most_recent = 't'
+                          WHERE most_recent = true
                           GROUP BY model, model_id
                           HAVING count(*) > 1
                         ) AS i ON r.model = i.model AND r.model_id = i.model_id

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5802,6 +5802,10 @@ databaseChangeLog:
       id: v49.2024-05-07T10:00:00
       author: qnkhuat
       comment: Set revision.most_recent = true to latest revision and false to others. A redo of v48.00-008 for mysql
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
       changes:
         - sql:
             dbms: mysql,mariadb

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -3403,11 +3403,10 @@ databaseChangeLog:
             sql: >-
               UPDATE revision r
               SET most_recent = TRUE
-              WHERE (model, model_id, timestamp, id) IN (
-                  SELECT model, model_id, timestamp, id
+              WHERE (id) IN (
+                  SELECT id
                   FROM (
-                      SELECT model, model_id, timestamp, id,
-                            ROW_NUMBER() OVER (PARTITION BY model, model_id ORDER BY timestamp DESC, id DESC) AS row_num
+                      SELECT id, ROW_NUMBER() OVER (PARTITION BY model, model_id ORDER BY timestamp DESC, id DESC) AS row_num
                       FROM revision
                   ) AS subquery
                   WHERE row_num = 1
@@ -3422,8 +3421,7 @@ databaseChangeLog:
               UPDATE revision r
               SET most_recent = TRUE
               FROM max_timestamp_per_group subquery
-              WHERE r.id = subquery.id
-                  AND subquery.row_num = 1;
+              WHERE r.id = subquery.id AND subquery.row_num = 1;
           # mysql and mariadb does not allow update on a table that is in the select part
           # so it we join for them
         - sql:

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -420,8 +420,6 @@
         (is (= [{:id 1, :group_id 1, :table_id table-id, :card_id nil, :attribute_remappings "{\"foo\", 1}", :permission_id perm-id}]
                (mdb.query/query {:select [:*] :from [:sandboxes]})))))))
 
-
-(mt/set-test-drivers! #{:h2})
 (deftest add-revision-most-recent-test
   (testing "Migrations v48.00-008-v48.00-009: add `revision.most_recent`"
     (impl/test-migrations ["v48.00-007"] [migrate!]

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -832,17 +832,16 @@
                                                         :model_id    2
                                                         :user_id     user-id
                                                         :object      "{}"
-                                                        ;; both are most recent with the same timestamp,
-                                                        ;; the one that has higher id will be most_recent
+                                                        ;; both this and the previous one has most recent = true with the same timestamp,
+                                                        ;; the one that has higher id will be updated
                                                         :most_recent true
                                                         :timestamp   now})
+              ;; test case where there is only one migration per item
               rev-card-3-new  (t2/insert-returning-pk! (t2/table-name :model/Revision)
                                                        {:model       "card"
                                                         :model_id    3
                                                         :user_id     user-id
                                                         :object      "{}"
-                                                        ;; both are most recent with the same timestamp,
-                                                        ;; the one that has higher id will be most_recent
                                                         :most_recent true
                                                         :timestamp   now})]
          (migrate!)

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -420,50 +420,53 @@
         (is (= [{:id 1, :group_id 1, :table_id table-id, :card_id nil, :attribute_remappings "{\"foo\", 1}", :permission_id perm-id}]
                (mdb.query/query {:select [:*] :from [:sandboxes]})))))))
 
+
+(mt/set-test-drivers! #{:h2})
 (deftest add-revision-most-recent-test
   (testing "Migrations v48.00-008-v48.00-009: add `revision.most_recent`"
     (impl/test-migrations ["v48.00-007"] [migrate!]
-      (let [user-id          (:id (create-raw-user! (mt/random-email)))
-            old              (t/minus (t/local-date-time) (t/hours 1))
-            rev-dash-1-old (first (t2/insert-returning-pks! (t2/table-name :model/Revision)
-                                                            {:model       "dashboard"
-                                                             :model_id    1
-                                                             :user_id     user-id
-                                                             :object      "{}"
-                                                             :is_creation true
-                                                             :timestamp   old}))
-            rev-dash-1-new (first (t2/insert-returning-pks! (t2/table-name :model/Revision)
-                                                            {:model       "dashboard"
-                                                             :model_id    1
-                                                             :user_id     user-id
-                                                             :object      "{}"
-                                                             :timestamp   :%now}))
-            rev-dash-2-old (first (t2/insert-returning-pks! (t2/table-name :model/Revision)
-                                                            {:model       "dashboard"
-                                                             :model_id    2
-                                                             :user_id     user-id
-                                                             :object      "{}"
-                                                             :is_creation true
-                                                             :timestamp   old}))
-            rev-dash-2-new (first (t2/insert-returning-pks! (t2/table-name :model/Revision)
-                                                            {:model       "dashboard"
-                                                             :model_id    2
-                                                             :user_id     user-id
-                                                             :object      "{}"
-                                                             :timestamp   :%now}))
-            rev-card-1-old (first (t2/insert-returning-pks! (t2/table-name :model/Revision)
-                                                            {:model       "card"
-                                                             :model_id    1
-                                                             :user_id     user-id
-                                                             :object      "{}"
-                                                             :is_creation true
-                                                             :timestamp   old}))
-            rev-card-1-new (first (t2/insert-returning-pks! (t2/table-name :model/Revision)
-                                                            {:model       "card"
-                                                             :model_id    1
-                                                             :user_id     user-id
-                                                             :object      "{}"
-                                                             :timestamp   :%now}))]
+      (let [user-id         (:id (create-raw-user! (mt/random-email)))
+            old             (t/minus (t/local-date-time) (t/hours 1))
+            now             (t/local-date-time)
+            rev-dash-1-old  (t2/insert-returning-pk! (t2/table-name :model/Revision)
+                                                     {:model       "dashboard"
+                                                      :model_id    1
+                                                      :user_id     user-id
+                                                      :object      "{}"
+                                                      :is_creation true
+                                                      :timestamp   old})
+            rev-dash-1-new  (t2/insert-returning-pk! (t2/table-name :model/Revision)
+                                                     {:model       "dashboard"
+                                                      :model_id    1
+                                                      :user_id     user-id
+                                                      :object      "{}"
+                                                      :timestamp   now})
+            rev-dash-2-old  (t2/insert-returning-pk! (t2/table-name :model/Revision)
+                                                     {:model       "dashboard"
+                                                      :model_id    2
+                                                      :user_id     user-id
+                                                      :object      "{}"
+                                                      :is_creation true
+                                                      :timestamp   old})
+            rev-dash-2-new  (t2/insert-returning-pk! (t2/table-name :model/Revision)
+                                                     {:model       "dashboard"
+                                                      :model_id    2
+                                                      :user_id     user-id
+                                                      :object      "{}"
+                                                      :timestamp   now})
+            rev-card-1-old  (t2/insert-returning-pk! (t2/table-name :model/Revision)
+                                                     {:model       "card"
+                                                      :model_id    1
+                                                      :user_id     user-id
+                                                      :object      "{}"
+                                                      :is_creation true
+                                                      :timestamp   now})
+            rev-card-1-new  (t2/insert-returning-pk! (t2/table-name :model/Revision)
+                                                     {:model       "card"
+                                                      :model_id    1
+                                                      :user_id     user-id
+                                                      :object      "{}"
+                                                      :timestamp   now})]
         (migrate!)
         (is (= #{false} (t2/select-fn-set :most_recent (t2/table-name :model/Revision)
                                           :id [:in [rev-dash-1-old rev-dash-2-old rev-card-1-old]])))

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -775,80 +775,81 @@
 
 (deftest fix-multiple-revistion-most-recent-test
   (testing "Migrations v49.2024-05-07T10:00:00: Set revision.most_recent = true ensures that there is only one most recent revision per model_id"
-    (impl/test-migrations "v49.2024-05-07T10:00:00" [migrate!]
-      (let [user-id         (:id (create-raw-user! (mt/random-email)))
-            old             (t/minus (t/local-date-time) (t/hours 1))
-            now             (t/local-date-time)
-            rev-dash-1-old  (t2/insert-returning-pk! (t2/table-name :model/Revision)
-                                                     {:model       "dashboard"
-                                                      :model_id    1
-                                                      :user_id     user-id
-                                                      :object      "{}"
-                                                      :is_creation true
-                                                      :timestamp   old})
-            rev-dash-1-new  (t2/insert-returning-pk! (t2/table-name :model/Revision)
-                                                     {:model       "dashboard"
-                                                      :model_id    1
-                                                      :user_id     user-id
-                                                      :object      "{}"
-                                                      :timestamp   now})
-            rev-dash-2-old  (t2/insert-returning-pk! (t2/table-name :model/Revision)
-                                                     {:model       "dashboard"
-                                                      :model_id    2
-                                                      :user_id     user-id
-                                                      :object      "{}"
-                                                      :is_creation true
-                                                      :timestamp   old})
-            rev-dash-2-new  (t2/insert-returning-pk! (t2/table-name :model/Revision)
-                                                     {:model       "dashboard"
-                                                      :model_id    2
-                                                      :user_id     user-id
-                                                      :object      "{}"
-                                                      :timestamp   now})
-            rev-card-1-old  (t2/insert-returning-pk! (t2/table-name :model/Revision)
-                                                     {:model       "card"
-                                                      :model_id    1
-                                                      :user_id     user-id
-                                                      :object      "{}"
-                                                      :is_creation true
-                                                      :timestamp   now})
-            rev-card-1-new  (t2/insert-returning-pk! (t2/table-name :model/Revision)
-                                                     {:model       "card"
-                                                      :model_id    1
-                                                      :user_id     user-id
-                                                      :object      "{}"
-                                                      :timestamp   now})
-            rev-card-2-old  (t2/insert-returning-pk! (t2/table-name :model/Revision)
-                                                     {:model       "card"
-                                                      :model_id    2
-                                                      :user_id     user-id
-                                                      :object      "{}"
-                                                      :is_creation true
-                                                      :most_recent true
-                                                      :timestamp   now})
-            rev-card-2-new  (t2/insert-returning-pk! (t2/table-name :model/Revision)
-                                                     {:model       "card"
-                                                      :model_id    2
-                                                      :user_id     user-id
-                                                      :object      "{}"
-                                                      ;; both are most recent with the same timestamp,
-                                                      ;; the one that has higher id will be most_recent
-                                                      :most_recent true
-                                                      :timestamp   now})
-            rev-card-3-new  (t2/insert-returning-pk! (t2/table-name :model/Revision)
-                                                     {:model       "card"
-                                                      :model_id    3
-                                                      :user_id     user-id
-                                                      :object      "{}"
-                                                      ;; both are most recent with the same timestamp,
-                                                      ;; the one that has higher id will be most_recent
-                                                      :most_recent true
-                                                      :timestamp   now})]
-        (migrate!)
-        (is (= #{false} (t2/select-fn-set :most_recent (t2/table-name :model/Revision)
-                                          :id [:in [rev-dash-1-old rev-dash-2-old rev-card-1-old rev-card-2-old]])))
-        (is (= #{true} (t2/select-fn-set :most_recent (t2/table-name :model/Revision)
-                                         :id [:in [rev-dash-1-new rev-dash-2-new rev-card-1-new rev-card-2-new rev-card-3-new]])))))))
+    (mt/test-driver :mysql
+      (impl/test-migrations "v49.2024-05-07T10:00:00" [migrate!]
+        (let [user-id         (:id (create-raw-user! (mt/random-email)))
+              old             (t/minus (t/local-date-time) (t/hours 1))
+              now             (t/local-date-time)
+              rev-dash-1-old  (t2/insert-returning-pk! (t2/table-name :model/Revision)
+                                                       {:model       "dashboard"
+                                                        :model_id    1
+                                                        :user_id     user-id
+                                                        :object      "{}"
+                                                        :is_creation true
+                                                        :timestamp   old})
+              rev-dash-1-new  (t2/insert-returning-pk! (t2/table-name :model/Revision)
+                                                       {:model       "dashboard"
+                                                        :model_id    1
+                                                        :user_id     user-id
+                                                        :object      "{}"
+                                                        :timestamp   now})
+              rev-dash-2-old  (t2/insert-returning-pk! (t2/table-name :model/Revision)
+                                                       {:model       "dashboard"
+                                                        :model_id    2
+                                                        :user_id     user-id
+                                                        :object      "{}"
+                                                        :is_creation true
+                                                        :timestamp   old})
+              rev-dash-2-new  (t2/insert-returning-pk! (t2/table-name :model/Revision)
+                                                       {:model       "dashboard"
+                                                        :model_id    2
+                                                        :user_id     user-id
+                                                        :object      "{}"
+                                                        :timestamp   now})
+              rev-card-1-old  (t2/insert-returning-pk! (t2/table-name :model/Revision)
+                                                       {:model       "card"
+                                                        :model_id    1
+                                                        :user_id     user-id
+                                                        :object      "{}"
+                                                        :is_creation true
+                                                        :timestamp   now})
+              rev-card-1-new  (t2/insert-returning-pk! (t2/table-name :model/Revision)
+                                                       {:model       "card"
+                                                        :model_id    1
+                                                        :user_id     user-id
+                                                        :object      "{}"
+                                                        :timestamp   now})
+              rev-card-2-old  (t2/insert-returning-pk! (t2/table-name :model/Revision)
+                                                       {:model       "card"
+                                                        :model_id    2
+                                                        :user_id     user-id
+                                                        :object      "{}"
+                                                        :is_creation true
+                                                        :most_recent true
+                                                        :timestamp   now})
+              rev-card-2-new  (t2/insert-returning-pk! (t2/table-name :model/Revision)
+                                                       {:model       "card"
+                                                        :model_id    2
+                                                        :user_id     user-id
+                                                        :object      "{}"
+                                                        ;; both are most recent with the same timestamp,
+                                                        ;; the one that has higher id will be most_recent
+                                                        :most_recent true
+                                                        :timestamp   now})
+              rev-card-3-new  (t2/insert-returning-pk! (t2/table-name :model/Revision)
+                                                       {:model       "card"
+                                                        :model_id    3
+                                                        :user_id     user-id
+                                                        :object      "{}"
+                                                        ;; both are most recent with the same timestamp,
+                                                        ;; the one that has higher id will be most_recent
+                                                        :most_recent true
+                                                        :timestamp   now})]
+         (migrate!)
+         (is (= #{false} (t2/select-fn-set :most_recent (t2/table-name :model/Revision)
+                                           :id [:in [rev-dash-1-old rev-dash-2-old rev-card-1-old rev-card-2-old]])))
+         (is (= #{true} (t2/select-fn-set :most_recent (t2/table-name :model/Revision)
+                                          :id [:in [rev-dash-1-new rev-dash-2-new rev-card-1-new rev-card-2-new rev-card-3-new]]))))))))
 
 (defn- clear-permissions!
   []

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -786,12 +786,14 @@
                                                         :user_id     user-id
                                                         :object      "{}"
                                                         :is_creation true
+                                                        :most_recent false
                                                         :timestamp   old})
               rev-dash-1-new  (t2/insert-returning-pk! (t2/table-name :model/Revision)
                                                        {:model       "dashboard"
                                                         :model_id    1
                                                         :user_id     user-id
                                                         :object      "{}"
+                                                        :most_recent true
                                                         :timestamp   now})
               rev-dash-2-old  (t2/insert-returning-pk! (t2/table-name :model/Revision)
                                                        {:model       "dashboard"
@@ -799,12 +801,14 @@
                                                         :user_id     user-id
                                                         :object      "{}"
                                                         :is_creation true
+                                                        :most_recent true
                                                         :timestamp   old})
               rev-dash-2-new  (t2/insert-returning-pk! (t2/table-name :model/Revision)
                                                        {:model       "dashboard"
                                                         :model_id    2
                                                         :user_id     user-id
                                                         :object      "{}"
+                                                        :most_recent true
                                                         :timestamp   now})
               rev-card-1-old  (t2/insert-returning-pk! (t2/table-name :model/Revision)
                                                        {:model       "card"
@@ -812,12 +816,14 @@
                                                         :user_id     user-id
                                                         :object      "{}"
                                                         :is_creation true
+                                                        :most_recent false
                                                         :timestamp   now})
               rev-card-1-new  (t2/insert-returning-pk! (t2/table-name :model/Revision)
                                                        {:model       "card"
                                                         :model_id    1
                                                         :user_id     user-id
                                                         :object      "{}"
+                                                        :most_recent true
                                                         :timestamp   now})
               rev-card-2-old  (t2/insert-returning-pk! (t2/table-name :model/Revision)
                                                        {:model       "card"

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -851,10 +851,9 @@
                                                         :most_recent true
                                                         :timestamp   now})]
          (migrate!)
-         (is (= #{false} (t2/select-fn-set :most_recent (t2/table-name :model/Revision)
-                                           :id [:in [rev-dash-1-old rev-dash-2-old rev-card-1-old rev-card-2-old]])))
-         (is (= #{true} (t2/select-fn-set :most_recent (t2/table-name :model/Revision)
-                                          :id [:in [rev-dash-1-new rev-dash-2-new rev-card-1-new rev-card-2-new rev-card-3-new]]))))))))
+         (is (= {false #{rev-dash-1-old rev-dash-2-old rev-card-1-old rev-card-2-old}
+                 true  #{rev-dash-1-new rev-dash-2-new rev-card-1-new rev-card-2-new rev-card-3-new}}
+                (update-vals (group-by :most_recent (t2/select (t2/table-name :model/Revision))) #(set (map :id %))))))))))
 
 (defn- clear-permissions!
   []

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -425,7 +425,6 @@
     (impl/test-migrations ["v48.00-007"] [migrate!]
       (let [user-id         (:id (create-raw-user! (mt/random-email)))
             old             (t/minus (t/local-date-time) (t/hours 1))
-            now             (t/local-date-time)
             rev-dash-1-old  (t2/insert-returning-pk! (t2/table-name :model/Revision)
                                                      {:model       "dashboard"
                                                       :model_id    1
@@ -438,7 +437,7 @@
                                                       :model_id    1
                                                       :user_id     user-id
                                                       :object      "{}"
-                                                      :timestamp   now})
+                                                      :timestamp   :%now})
             rev-dash-2-old  (t2/insert-returning-pk! (t2/table-name :model/Revision)
                                                      {:model       "dashboard"
                                                       :model_id    2
@@ -451,20 +450,20 @@
                                                       :model_id    2
                                                       :user_id     user-id
                                                       :object      "{}"
-                                                      :timestamp   now})
+                                                      :timestamp   :%now})
             rev-card-1-old  (t2/insert-returning-pk! (t2/table-name :model/Revision)
                                                      {:model       "card"
                                                       :model_id    1
                                                       :user_id     user-id
                                                       :object      "{}"
                                                       :is_creation true
-                                                      :timestamp   now})
+                                                      :timestamp   old})
             rev-card-1-new  (t2/insert-returning-pk! (t2/table-name :model/Revision)
                                                      {:model       "card"
                                                       :model_id    1
                                                       :user_id     user-id
                                                       :object      "{}"
-                                                      :timestamp   now})]
+                                                      :timestamp   :%now})]
         (migrate!)
         (is (= #{false} (t2/select-fn-set :most_recent (t2/table-name :model/Revision)
                                           :id [:in [rev-dash-1-old rev-dash-2-old rev-card-1-old]])))
@@ -773,6 +772,83 @@
       (migrate!)
       (is (= "true"
              (t2/select-one-fn :value (t2/table-name :model/Setting) :key "enable-public-sharing"))))))
+
+(deftest fix-multiple-revistion-most-recent-test
+  (testing "Migrations v49.2024-05-07T10:00:00: Set revision.most_recent = true ensures that there is only one most recent revision per model_id"
+    (impl/test-migrations "v49.2024-05-07T10:00:00" [migrate!]
+      (let [user-id         (:id (create-raw-user! (mt/random-email)))
+            old             (t/minus (t/local-date-time) (t/hours 1))
+            now             (t/local-date-time)
+            rev-dash-1-old  (t2/insert-returning-pk! (t2/table-name :model/Revision)
+                                                     {:model       "dashboard"
+                                                      :model_id    1
+                                                      :user_id     user-id
+                                                      :object      "{}"
+                                                      :is_creation true
+                                                      :timestamp   old})
+            rev-dash-1-new  (t2/insert-returning-pk! (t2/table-name :model/Revision)
+                                                     {:model       "dashboard"
+                                                      :model_id    1
+                                                      :user_id     user-id
+                                                      :object      "{}"
+                                                      :timestamp   now})
+            rev-dash-2-old  (t2/insert-returning-pk! (t2/table-name :model/Revision)
+                                                     {:model       "dashboard"
+                                                      :model_id    2
+                                                      :user_id     user-id
+                                                      :object      "{}"
+                                                      :is_creation true
+                                                      :timestamp   old})
+            rev-dash-2-new  (t2/insert-returning-pk! (t2/table-name :model/Revision)
+                                                     {:model       "dashboard"
+                                                      :model_id    2
+                                                      :user_id     user-id
+                                                      :object      "{}"
+                                                      :timestamp   now})
+            rev-card-1-old  (t2/insert-returning-pk! (t2/table-name :model/Revision)
+                                                     {:model       "card"
+                                                      :model_id    1
+                                                      :user_id     user-id
+                                                      :object      "{}"
+                                                      :is_creation true
+                                                      :timestamp   now})
+            rev-card-1-new  (t2/insert-returning-pk! (t2/table-name :model/Revision)
+                                                     {:model       "card"
+                                                      :model_id    1
+                                                      :user_id     user-id
+                                                      :object      "{}"
+                                                      :timestamp   now})
+            rev-card-2-old  (t2/insert-returning-pk! (t2/table-name :model/Revision)
+                                                     {:model       "card"
+                                                      :model_id    2
+                                                      :user_id     user-id
+                                                      :object      "{}"
+                                                      :is_creation true
+                                                      :most_recent true
+                                                      :timestamp   now})
+            rev-card-2-new  (t2/insert-returning-pk! (t2/table-name :model/Revision)
+                                                     {:model       "card"
+                                                      :model_id    2
+                                                      :user_id     user-id
+                                                      :object      "{}"
+                                                      ;; both are most recent with the same timestamp,
+                                                      ;; the one that has higher id will be most_recent
+                                                      :most_recent true
+                                                      :timestamp   now})
+            rev-card-3-new  (t2/insert-returning-pk! (t2/table-name :model/Revision)
+                                                     {:model       "card"
+                                                      :model_id    3
+                                                      :user_id     user-id
+                                                      :object      "{}"
+                                                      ;; both are most recent with the same timestamp,
+                                                      ;; the one that has higher id will be most_recent
+                                                      :most_recent true
+                                                      :timestamp   now})]
+        (migrate!)
+        (is (= #{false} (t2/select-fn-set :most_recent (t2/table-name :model/Revision)
+                                          :id [:in [rev-dash-1-old rev-dash-2-old rev-card-1-old rev-card-2-old]])))
+        (is (= #{true} (t2/select-fn-set :most_recent (t2/table-name :model/Revision)
+                                         :id [:in [rev-dash-1-new rev-dash-2-new rev-card-1-new rev-card-2-new rev-card-3-new]])))))))
 
 (defn- clear-permissions!
   []


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/41374.

Some Metabase instances run on MySQL have `revision.timestamp` rounded to the second (I'm not sure why 🫣), which makes our migration set `most_recent=true` for more than one revision that was created at the same time second. 

The previous SQL to update `revision.most_recent` didn't consider this and updated to use `row_number` to rank the latest revision.

The fix is to add a new migration for 49 that sets `most_recent = true` to the latest revision and `false` to older ones. We add this to 49 because several migrations touch `revision.most_recent` in 49, and it's risky for us to backport a migration to an old version patch since order execution can mess things up. Also to reduce that risk, this fixes for only MySQL since postgres and h2 shouldn't have this issue.

For users running 48, we can ask them nicely to run the manual query.

