### PR TITLE
bumping metabase/saml20-clj version

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -87,7 +87,7 @@
   lambdaisland/uri                          {:mvn/version "1.19.155"}           ; Used by openai-clojure
   medley/medley                             {:mvn/version "1.4.0"}              ; lightweight lib of useful functions
   metabase/connection-pool                  {:mvn/version "1.2.0"}              ; simple wrapper around C3P0. JDBC connection pools
-  metabase/saml20-clj                       {:mvn/version "2.2.7.170"
+  metabase/saml20-clj                       {:mvn/version "2.2.7.171"
                                              :exclusions [                      ; EE SAML integration TODO: bump version when we release the library
                                                           org.bouncycastle/bcpkix-jdk15on
                                                           org.bouncycastle/bcprov-jdk15on


### PR DESCRIPTION
resolves #41600

The new version of metabase/saml20-clj works with azure ad