### PR TITLE
Fix x-axis time series interval computation when x-values include nulls

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/utils/timeseries.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/utils/timeseries.ts
@@ -3,6 +3,7 @@ import dayjs from "dayjs";
 import _ from "underscore";
 
 import { parseTimestamp } from "metabase/lib/time-dayjs";
+import { isNotNull } from "metabase/lib/types";
 import type {
   TimeSeriesInterval,
   ShowWarning,
@@ -93,6 +94,8 @@ export function computeTimeseriesDataInverval(
   xValues: RowValue[],
   unit: DateTimeAbsoluteUnit | null,
 ) {
+  xValues = xValues.filter(isNotNull);
+
   if (unit && INTERVAL_INDEX_BY_UNIT[unit] != null) {
     return TIMESERIES_INTERVALS[INTERVAL_INDEX_BY_UNIT[unit]];
   }

--- a/frontend/src/metabase/visualizations/echarts/cartesian/utils/timeseries.unit.spec.js
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/utils/timeseries.unit.spec.js
@@ -127,6 +127,18 @@ describe("visualization.lib.timeseries", () => {
       expect(unit).toBe("month");
       expect(count).toBe(3);
     });
+
+    it("should should ignore null X values", () => {
+      const { unit, count } = computeTimeseriesDataInverval([
+        null,
+        new Date("2020-01-01").toISOString(),
+        null,
+        new Date("2020-03-01").toISOString(),
+        null,
+      ]);
+      expect(unit).toBe("month");
+      expect(count).toBe(1);
+    });
   });
 
   describe("getTimezone", () => {

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
@@ -52,7 +52,7 @@ function _CartesianChart(props: VisualizationProps) {
     height: chartSize.height,
     settings,
   });
-  useChartDebug({ isQueryBuilder, rawSeries, option });
+  useChartDebug({ isQueryBuilder, rawSeries, option, chartModel });
 
   const chartRef = useRef<EChartsType>();
 

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-debug.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-debug.ts
@@ -3,16 +3,19 @@ import type { EChartsOption } from "echarts";
 import { useEffect } from "react";
 
 import { isProduction } from "metabase/env";
+import type { BaseCartesianChartModel } from "metabase/visualizations/echarts/cartesian/model/types";
 import type { RawSeries } from "metabase-types/api";
 
 export function useChartDebug({
   isQueryBuilder,
   rawSeries,
   option,
+  chartModel,
 }: {
   isQueryBuilder: boolean;
   rawSeries: RawSeries;
   option: EChartsOption;
+  chartModel: BaseCartesianChartModel;
 }) {
   useEffect(() => {
     if (!isQueryBuilder || isProduction) {
@@ -21,6 +24,7 @@ export function useChartDebug({
     console.log("-------------- ECHARTS DEBUG INFO START --------------");
     console.log("rawSeries", rawSeries);
     console.log("option", option);
+    console.log("model", chartModel);
     console.log("-------------- ECHARTS DEBUG INFO END --------------");
-  }, [rawSeries, option, isQueryBuilder]);
+  }, [rawSeries, option, chartModel, isQueryBuilder]);
 }


### PR DESCRIPTION
### Description

On time series charts when x-axis column contains null values the time series interval is not computed correctly.

### How to verify

```sql
select DATE '2020-01-01' x, 10 y
union all select  null, 10
union all select DATE '2020-03-01', 10
```

Before the fix, the x-axis interval was computed as 1 ms instead of 1 month.

### Demo

Before
<img width="919" alt="Screenshot 2024-05-06 at 3 29 04 PM" src="https://github.com/metabase/metabase/assets/14301985/97ddd44f-2b7d-46a8-b62d-d40a2700d0f0">

After
<img width="933" alt="Screenshot 2024-05-06 at 3 28 47 PM" src="https://github.com/metabase/metabase/assets/14301985/5ea11938-49bc-4b2d-a1dc-00f6e68c0faa">


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
