### PR TITLE
Fix combine extract column drill icons

### DIFF
--- a/frontend/src/metabase/querying/utils/drills/column-extract-drill/column-extract-drill.tsx
+++ b/frontend/src/metabase/querying/utils/drills/column-extract-drill/column-extract-drill.tsx
@@ -57,7 +57,7 @@ export const columnExtractDrill: Drill<Lib.ColumnExtractDrillThruInfo> = ({
       name: "extract",
       title: drillInfo.displayName,
       section: "extract",
-      icon: "extract",
+      icon: "arrow_split",
       buttonType: "horizontal",
       popover: DrillPopover,
     },

--- a/frontend/src/metabase/querying/utils/drills/combine-columns-drill/combine-columns-drill.tsx
+++ b/frontend/src/metabase/querying/utils/drills/combine-columns-drill/combine-columns-drill.tsx
@@ -45,7 +45,7 @@ export const combineColumnsDrill: Drill<Lib.CombineColumnsDrillThruInfo> = ({
       name: "combine",
       title: t`Combine columns`,
       section: "combine",
-      icon: "add",
+      icon: "combine",
       buttonType: "horizontal",
       popover: DrillPopover,
     },


### PR DESCRIPTION
### Description

Make the combine column and extract column drillthru's more consistent with the similar shortcuts that are used elsewhere.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> Account
2. Click the `First name` column header: it should contain the correct icon for the `Combine Column` action
3. Click the `Created at` column header: it should contain the correct icon for the `Extract day, month...` action


### Demo

#### Before
<img width="262" alt="Screenshot 2024-05-06 at 22 44 43" src="https://github.com/metabase/metabase/assets/1250185/8a7f254b-e38b-4d93-8bb5-1f7a91bbaa5b">
<img width="251" alt="Screenshot 2024-05-06 at 22 44 48" src="https://github.com/metabase/metabase/assets/1250185/6ca9af06-4661-4e59-9df8-445e5516a14b">

#### After
<img width="281" alt="Screenshot 2024-05-06 at 22 44 22" src="https://github.com/metabase/metabase/assets/1250185/ede5ae9e-7430-4b07-a79f-27fbb07ebabc">
<img width="264" alt="Screenshot 2024-05-06 at 22 44 27" src="https://github.com/metabase/metabase/assets/1250185/b3458f8d-cae4-4a51-902b-ad2214a9a28b">

