### PR TITLE
New Recents + Popular API Format - Frontend

### DIFF
--- a/frontend/src/metabase-types/api/activity.ts
+++ b/frontend/src/metabase-types/api/activity.ts
@@ -1,6 +1,5 @@
 import type { CardDisplayType } from "./card";
-import type { CollectionId } from "./collection";
-import type { DatabaseId, InitialSyncStatus } from "./database";
+import type { InitialSyncStatus } from "./database";
 
 export const ACTIVITY_MODELS = [
   "table",
@@ -10,17 +9,6 @@ export const ACTIVITY_MODELS = [
   "collection",
 ] as const;
 export type ActivityModel = typeof ACTIVITY_MODELS[number];
-export type ActivityModelId = number;
-
-export interface ActivityModelObject {
-  name: string;
-  display_name?: string;
-  moderated_status?: string;
-  collection_id?: CollectionId | null;
-  collection_name?: string;
-  database_name?: string;
-  db_id?: DatabaseId;
-}
 
 export interface BaseRecentItem {
   id: number;

--- a/frontend/src/metabase-types/api/activity.ts
+++ b/frontend/src/metabase-types/api/activity.ts
@@ -14,6 +14,7 @@ export interface BaseRecentItem {
   id: number;
   name: string;
   model: ActivityModel;
+  description?: string | null;
   timestamp: string;
 }
 

--- a/frontend/src/metabase-types/api/activity.ts
+++ b/frontend/src/metabase-types/api/activity.ts
@@ -1,12 +1,13 @@
+import type { CardDisplayType } from "./card";
 import type { CollectionId } from "./collection";
-import type { DatabaseId } from "./database";
-import type { UserId } from "./user";
+import type { DatabaseId, InitialSyncStatus } from "./database";
 
 export const ACTIVITY_MODELS = [
   "table",
   "card",
   "dataset",
   "dashboard",
+  "collection",
 ] as const;
 export type ActivityModel = typeof ACTIVITY_MODELS[number];
 export type ActivityModelId = number;
@@ -21,17 +22,43 @@ export interface ActivityModelObject {
   db_id?: DatabaseId;
 }
 
-export interface RecentItem {
-  cnt: number;
-  max_ts: string;
-  user_id: UserId;
+export interface BaseRecentItem {
+  id: number;
+  name: string;
   model: ActivityModel;
-  model_id: ActivityModelId;
-  model_object: ActivityModelObject;
+  timestamp: string;
 }
 
-export interface PopularItem {
-  model: ActivityModel;
-  model_id: ActivityModelId;
-  model_object: ActivityModelObject;
+export interface RecentTableItem extends BaseRecentItem {
+  model: "table";
+  display_name: string;
+  database: {
+    id: number;
+    name: string;
+    initial_sync_status: InitialSyncStatus;
+  };
+}
+
+export interface RecentCollectionItem extends BaseRecentItem {
+  model: "collection" | "dashboard" | "dataset" | "card";
+  parent_collection: {
+    id: number | null;
+    name: string;
+    authority_level?: "official" | null;
+  };
+  authority_level?: "official" | null; // for collections
+  moderated_status?: "verified" | null; // for models
+  display?: CardDisplayType; // for questions
+}
+
+export type RecentItem = RecentTableItem | RecentCollectionItem;
+
+export interface RecentItemsResponse {
+  recent_views: RecentItem[];
+}
+
+export type PopularItem = RecentItem;
+
+export interface PopularItemsResponse {
+  popular_items: PopularItem[];
 }

--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -184,7 +184,7 @@ export type UnrestrictedLinkEntity = {
   model: SearchModel;
   name: string;
   display_name?: string;
-  description?: string;
+  description?: string | null;
   display?: CardDisplayType;
 };
 

--- a/frontend/src/metabase-types/api/mocks/activity.ts
+++ b/frontend/src/metabase-types/api/mocks/activity.ts
@@ -1,33 +1,44 @@
 import type {
-  ActivityModelObject,
   PopularItem,
   RecentItem,
+  RecentTableItem,
+  RecentCollectionItem,
 } from "metabase-types/api";
 
-export const createMockModelObject = (
-  opts?: Partial<ActivityModelObject>,
-): ActivityModelObject => ({
-  name: "Orders",
-  ...opts,
-});
-
-export const createMockRecentItem = (
-  opts?: Partial<RecentItem>,
+export const createMockRecentTableItem = (
+  opts?: Partial<RecentTableItem>,
 ): RecentItem => ({
+  id: 1,
   model: "table",
-  model_id: 1,
-  model_object: createMockModelObject(),
-  cnt: 1,
-  max_ts: "2021-03-01T00:00:00.000Z",
-  user_id: 1,
+  name: "my_cool_table",
+  display_name: "My Cool Table",
+  timestamp: "2021-03-01T00:00:00.000Z",
+  database: {
+    id: 1,
+    name: "My Cool Collection",
+    initial_sync_status: "complete",
+  },
   ...opts,
 });
 
-export const createMockPopularItem = (
-  opts?: Partial<PopularItem>,
-): PopularItem => ({
-  model: "table",
-  model_id: 1,
-  model_object: createMockModelObject(),
+export const createMockRecentCollectionItem = (
+  opts?: Partial<RecentCollectionItem>,
+): RecentItem => ({
+  id: 1,
+  model: "card",
+  name: "My Cool Question",
+  timestamp: "2021-03-01T00:00:00.000Z",
+  parent_collection: {
+    id: 1,
+    name: "My Cool Collection",
+  },
   ...opts,
 });
+
+export const createMockPopularTableItem = (
+  opts?: Partial<RecentTableItem>,
+): PopularItem => createMockRecentTableItem(opts);
+
+export const createMockPopularCollectionItem = (
+  opts?: Partial<RecentCollectionItem>,
+): PopularItem => createMockRecentCollectionItem(opts);

--- a/frontend/src/metabase/api/activity.ts
+++ b/frontend/src/metabase/api/activity.ts
@@ -1,4 +1,9 @@
-import type { PopularItem, RecentItem } from "metabase-types/api";
+import type {
+  RecentItem,
+  PopularItem,
+  RecentItemsResponse,
+  PopularItemsResponse,
+} from "metabase-types/api";
 
 import { Api } from "./api";
 import { provideActivityItemListTags } from "./tags";
@@ -10,14 +15,18 @@ export const activityApi = Api.injectEndpoints({
         method: "GET",
         url: "/api/activity/recent_views",
       }),
-      providesTags: (items = []) => provideActivityItemListTags(items),
+      transformResponse: (response: RecentItemsResponse) =>
+        response?.recent_views,
+      providesTags: items => provideActivityItemListTags(items ?? []),
     }),
     listPopularItems: builder.query<PopularItem[], void>({
       query: () => ({
         method: "GET",
         url: "/api/activity/popular_items",
       }),
-      providesTags: (items = []) => provideActivityItemListTags(items),
+      transformResponse: (response: PopularItemsResponse) =>
+        response?.popular_items,
+      providesTags: items => provideActivityItemListTags(items ?? []),
     }),
   }),
 });

--- a/frontend/src/metabase/api/tags/utils.ts
+++ b/frontend/src/metabase/api/tags/utils.ts
@@ -81,7 +81,7 @@ export function provideActivityItemListTags(
 export function provideActivityItemTags(
   item: RecentItem | PopularItem,
 ): TagDescription<TagType>[] {
-  return [idTag(TAG_TYPE_MAPPING[item.model], item.model_id)];
+  return [idTag(TAG_TYPE_MAPPING[item.model], item.id)];
 }
 
 export function provideAlertListTags(

--- a/frontend/src/metabase/home/components/HomeContent/HomeContent.tsx
+++ b/frontend/src/metabase/home/components/HomeContent/HomeContent.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from "react";
+
 import {
   useListRecentItemsQuery,
   useListPopularItemsQuery,
@@ -14,7 +16,7 @@ import { getIsXrayEnabled } from "../../selectors";
 import { isWithinWeeks } from "../../utils";
 import { EmbedHomepage } from "../EmbedHomepage";
 import { HomePopularSection } from "../HomePopularSection";
-import { HomeRecentSection } from "../HomeRecentSection";
+import { HomeRecentSection, recentsFilter } from "../HomeRecentSection";
 import { HomeXraySection } from "../HomeXraySection";
 
 export const HomeContent = (): JSX.Element | null => {
@@ -22,11 +24,16 @@ export const HomeContent = (): JSX.Element | null => {
   const embeddingHomepage = useSetting("embedding-homepage");
   const isXrayEnabled = useSelector(getIsXrayEnabled);
   const { data: databases, error: databasesError } = useDatabaseListQuery();
-  const { data: recentItems, error: recentItemsError } =
+  const { data: recentItemsRaw, error: recentItemsError } =
     useListRecentItemsQuery(undefined, { refetchOnMountOrArgChange: true });
   const { data: popularItems, error: popularItemsError } =
     useListPopularItemsQuery(undefined, { refetchOnMountOrArgChange: true });
   const error = databasesError || recentItemsError || popularItemsError;
+
+  const recentItems = useMemo(
+    () => (recentItemsRaw && recentsFilter(recentItemsRaw)) ?? [],
+    [recentItemsRaw],
+  );
 
   if (error) {
     return <LoadingAndErrorWrapper error={error} />;

--- a/frontend/src/metabase/home/components/HomeContent/HomeContent.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/HomeContent/HomeContent.unit.spec.tsx
@@ -18,8 +18,8 @@ import type {
 } from "metabase-types/api";
 import {
   createMockDatabase,
-  createMockPopularItem,
-  createMockRecentItem,
+  createMockPopularTableItem,
+  createMockRecentTableItem,
   createMockUser,
 } from "metabase-types/api/mocks";
 import {
@@ -86,8 +86,8 @@ describe("HomeContent", () => {
         first_login: "2020-01-05T00:00:00Z",
       }),
       databases: [createMockDatabase()],
-      recentItems: [createMockRecentItem()],
-      popularItems: [createMockPopularItem()],
+      recentItems: [createMockRecentTableItem()],
+      popularItems: [createMockPopularTableItem()],
     });
 
     expect(
@@ -103,7 +103,7 @@ describe("HomeContent", () => {
         first_login: "2020-01-05T00:00:00Z",
       }),
       databases: [createMockDatabase()],
-      popularItems: [createMockPopularItem()],
+      popularItems: [createMockPopularTableItem()],
     });
 
     expect(
@@ -119,7 +119,7 @@ describe("HomeContent", () => {
         first_login: "2020-01-01T00:00:00Z",
       }),
       databases: [createMockDatabase()],
-      recentItems: [createMockRecentItem()],
+      recentItems: [createMockRecentTableItem()],
     });
 
     expect(screen.getByText("Pick up where you left off")).toBeInTheDocument();
@@ -146,7 +146,7 @@ describe("HomeContent", () => {
         first_login: "2020-01-10T00:00:00Z",
       }),
       databases: [createMockDatabase()],
-      recentItems: [createMockRecentItem()],
+      recentItems: [createMockRecentTableItem()],
     });
 
     expect(screen.getByText(/Here are some explorations/)).toBeInTheDocument();
@@ -160,7 +160,7 @@ describe("HomeContent", () => {
         first_login: "2020-01-10T00:00:00Z",
       }),
       databases: [createMockDatabase()],
-      recentItems: [createMockRecentItem()],
+      recentItems: [createMockRecentTableItem()],
       isXrayEnabled: false,
     });
 

--- a/frontend/src/metabase/home/components/HomePopularSection/HomePopularSection.tsx
+++ b/frontend/src/metabase/home/components/HomePopularSection/HomePopularSection.tsx
@@ -32,11 +32,8 @@ export const HomePopularSection = (): JSX.Element => {
         {popularItems.map((item, index) => (
           <HomeModelCard
             key={index}
-            title={getName(item.model_object)}
-            icon={getIcon(
-              { ...item.model_object, model: item.model },
-              { variant: "secondary" },
-            )}
+            title={getName(item)}
+            icon={getIcon(item, { variant: "secondary" })}
             url={Urls.modelToUrl(item) ?? ""}
           />
         ))}

--- a/frontend/src/metabase/home/components/HomePopularSection/HomePopularSection.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/HomePopularSection/HomePopularSection.unit.spec.tsx
@@ -3,7 +3,7 @@ import { screen } from "@testing-library/react";
 import { setupPopularItemsEndpoints } from "__support__/server-mocks";
 import { renderWithProviders, waitForLoaderToBeRemoved } from "__support__/ui";
 import type { PopularItem } from "metabase-types/api";
-import { createMockPopularItem } from "metabase-types/api/mocks";
+import { createMockPopularCollectionItem } from "metabase-types/api/mocks";
 
 import { HomePopularSection } from "./HomePopularSection";
 
@@ -11,6 +11,20 @@ interface SetupOpts {
   popularItems: PopularItem[];
 }
 
+const samplePopularItems = [
+  createMockPopularCollectionItem({
+    model: "dashboard",
+    name: "Metrics",
+  }),
+  createMockPopularCollectionItem({
+    model: "dashboard",
+    name: "Revenue",
+  }),
+  createMockPopularCollectionItem({
+    model: "card",
+    name: "Orders",
+  }),
+];
 const setup = async ({ popularItems }: SetupOpts) => {
   setupPopularItemsEndpoints(popularItems);
   renderWithProviders(<HomePopularSection />);
@@ -20,20 +34,7 @@ const setup = async ({ popularItems }: SetupOpts) => {
 describe("HomePopularSection", () => {
   it("should render a list of items of the same type", async () => {
     await setup({
-      popularItems: [
-        createMockPopularItem({
-          model: "dashboard",
-          model_object: {
-            name: "Metrics",
-          },
-        }),
-        createMockPopularItem({
-          model: "dashboard",
-          model_object: {
-            name: "Revenue",
-          },
-        }),
-      ],
+      popularItems: samplePopularItems.slice(0, 2),
     });
 
     expect(screen.getByText(/popular dashboards/)).toBeInTheDocument();
@@ -41,20 +42,7 @@ describe("HomePopularSection", () => {
 
   it("should render a list of items of different types", async () => {
     await setup({
-      popularItems: [
-        createMockPopularItem({
-          model: "dashboard",
-          model_object: {
-            name: "Metrics",
-          },
-        }),
-        createMockPopularItem({
-          model: "card",
-          model_object: {
-            name: "Revenue",
-          },
-        }),
-      ],
+      popularItems: samplePopularItems,
     });
 
     expect(screen.getByText(/popular items/)).toBeInTheDocument();

--- a/frontend/src/metabase/home/components/HomeRecentSection/HomeRecentSection.tsx
+++ b/frontend/src/metabase/home/components/HomeRecentSection/HomeRecentSection.tsx
@@ -7,6 +7,7 @@ import { getName } from "metabase/lib/name";
 import { useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { getUser } from "metabase/selectors/user";
+import type { RecentItem } from "metabase-types/api";
 
 import { isWithinWeeks } from "../../utils";
 import { HomeCaption } from "../HomeCaption";
@@ -33,14 +34,11 @@ export const HomeRecentSection = () => {
     <div>
       <HomeCaption>{t`Pick up where you left off`}</HomeCaption>
       <SectionBody>
-        {recentItems.map((item, index) => (
+        {resultsFilter(recentItems).map((item, index) => (
           <HomeModelCard
             key={index}
-            title={getName(item.model_object)}
-            icon={getIcon(
-              { ...item.model_object, model: item.model },
-              { variant: "secondary" },
-            )}
+            title={getName(item)}
+            icon={getIcon(item, { variant: "secondary" })}
             url={Urls.modelToUrl(item) ?? ""}
           />
         ))}
@@ -48,4 +46,8 @@ export const HomeRecentSection = () => {
       </SectionBody>
     </div>
   );
+};
+
+export const resultsFilter = (results: RecentItem[]): RecentItem[] => {
+  return results.filter(item => item.model !== "collection").slice(0, 5);
 };

--- a/frontend/src/metabase/home/components/HomeRecentSection/HomeRecentSection.tsx
+++ b/frontend/src/metabase/home/components/HomeRecentSection/HomeRecentSection.tsx
@@ -34,7 +34,7 @@ export const HomeRecentSection = () => {
     <div>
       <HomeCaption>{t`Pick up where you left off`}</HomeCaption>
       <SectionBody>
-        {resultsFilter(recentItems).map((item, index) => (
+        {recentsFilter(recentItems).map((item, index) => (
           <HomeModelCard
             key={index}
             title={getName(item)}
@@ -48,6 +48,6 @@ export const HomeRecentSection = () => {
   );
 };
 
-export const resultsFilter = (results: RecentItem[]): RecentItem[] => {
+export const recentsFilter = (results: RecentItem[]): RecentItem[] => {
   return results.filter(item => item.model !== "collection").slice(0, 5);
 };

--- a/frontend/src/metabase/home/components/HomeRecentSection/HomeRecentSection.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/HomeRecentSection/HomeRecentSection.unit.spec.tsx
@@ -3,7 +3,10 @@ import { screen } from "@testing-library/react";
 import { setupRecentViewsEndpoints } from "__support__/server-mocks";
 import { renderWithProviders, waitForLoaderToBeRemoved } from "__support__/ui";
 import type { User } from "metabase-types/api";
-import { createMockRecentItem, createMockUser } from "metabase-types/api/mocks";
+import {
+  createMockRecentTableItem,
+  createMockUser,
+} from "metabase-types/api/mocks";
 
 import { HomeRecentSection } from "./HomeRecentSection";
 
@@ -13,11 +16,10 @@ interface SetupOpts {
 
 const setup = async ({ user = createMockUser() }: SetupOpts = {}) => {
   setupRecentViewsEndpoints([
-    createMockRecentItem({
+    createMockRecentTableItem({
       model: "table",
-      model_object: {
-        name: "Orders",
-      },
+      name: "ORDERS",
+      display_name: "Orders",
     }),
   ]);
 

--- a/frontend/src/metabase/lib/urls/index.ts
+++ b/frontend/src/metabase/lib/urls/index.ts
@@ -7,6 +7,7 @@ export * from "./collections";
 export * from "./dashboards";
 export * from "./indexed-entities";
 export * from "./metabot";
+export * from "./modelToUrl";
 export * from "./misc";
 export * from "./models";
 export * from "./pulses";

--- a/frontend/src/metabase/lib/urls/misc.js
+++ b/frontend/src/metabase/lib/urls/misc.js
@@ -1,40 +1,6 @@
-import { dashboard } from "./dashboards";
-import { model } from "./models";
-import { pulse } from "./pulses";
-import { question, tableRowsQuery } from "./questions";
-
 export const exportFormats = ["csv", "xlsx", "json"];
 export const exportFormatPng = "png";
 
 export function accountSettings() {
   return "/account/profile";
-}
-
-function prepareModel(item) {
-  if (item.model_object) {
-    return item.model_object;
-  }
-  return {
-    id: item.model_id,
-    ...item.details,
-  };
-}
-
-export function modelToUrl(item) {
-  const modelData = prepareModel(item);
-
-  switch (item.model) {
-    case "card":
-      return question(modelData);
-    case "dataset":
-      return model(modelData);
-    case "dashboard":
-      return dashboard(modelData);
-    case "pulse":
-      return pulse(modelData.id);
-    case "table":
-      return tableRowsQuery(modelData.db_id, modelData.id);
-    default:
-      return null;
-  }
 }

--- a/frontend/src/metabase/lib/urls/modelToUrl.ts
+++ b/frontend/src/metabase/lib/urls/modelToUrl.ts
@@ -1,0 +1,29 @@
+import type { RecentItem } from "metabase-types/api";
+
+import { collection } from "./collections";
+import { dashboard } from "./dashboards";
+import { model } from "./models";
+import { question, tableRowsQuery } from "./questions";
+
+export function modelToUrl(item: RecentItem) {
+  switch (item.model) {
+    case "card":
+      return question({
+        ...item,
+        model: "card", // somehow typescript is not smart enough to infer this
+      });
+    case "dataset":
+      return model(item);
+    case "dashboard":
+      return dashboard(item);
+    case "table":
+      if (item?.database) {
+        return tableRowsQuery(item?.database?.id, item.id);
+      }
+      return null;
+    case "collection":
+      return collection(item);
+    default:
+      return null;
+  }
+}

--- a/frontend/src/metabase/lib/urls/modelToUrl.unit.spec.ts
+++ b/frontend/src/metabase/lib/urls/modelToUrl.unit.spec.ts
@@ -1,0 +1,88 @@
+import { modelToUrl } from "./modelToUrl";
+describe("urls > modelToUrl", () => {
+  it("should return null for unknown model", () => {
+    expect(
+      modelToUrl({
+        // @ts-expect-error - testing the error case
+        model: "pikachu",
+      }),
+    ).toBeNull();
+  });
+
+  it("should return a question URL for a card", () => {
+    expect(
+      modelToUrl({
+        model: "card",
+        name: "My Cool Question",
+        id: 101,
+        parent_collection: {
+          id: 1,
+          name: "My Cool Collection",
+        },
+        timestamp: "2021-01-01T00:00:00.000Z",
+      }),
+    ).toBe("/question/101-my-cool-question");
+  });
+
+  it("should return a model URL for a dataset", () => {
+    expect(
+      modelToUrl({
+        model: "dataset",
+        name: "My Cool Dataset",
+        parent_collection: {
+          id: 1,
+          name: "My Cool Collection",
+        },
+        id: 101,
+        timestamp: "2021-01-01T00:00:00.000Z",
+      }),
+    ).toBe("/model/101-my-cool-dataset");
+  });
+
+  it("should return a dashboard URL for a dashboard", () => {
+    expect(
+      modelToUrl({
+        model: "dashboard",
+        name: "My Cool Dashboard",
+        parent_collection: {
+          id: 1,
+          name: "My Cool Collection",
+        },
+        id: 101,
+        timestamp: "2021-01-01T00:00:00.000Z",
+      }),
+    ).toBe("/dashboard/101-my-cool-dashboard");
+  });
+
+  it("should return a collection URL for a collection", () => {
+    expect(
+      modelToUrl({
+        model: "collection",
+        name: "My Cool Collection",
+        id: 1,
+        parent_collection: {
+          id: 1,
+          name: "My Cool Collection",
+        },
+        timestamp: "2021-01-01T00:00:00.000Z",
+      }),
+    ).toBe("/collection/1-my-cool-collection");
+  });
+
+  it("should return a table URL for a table", () => {
+    expect(
+      modelToUrl({
+        model: "table",
+        name: "MY_COOL_TABLE",
+        display_name: "My Cool Table",
+        id: 33,
+        database: {
+          id: 22,
+          name: "My Cool Database",
+          initial_sync_status: "complete",
+        },
+        timestamp: "2021-01-01T00:00:00.000Z",
+      }),
+    ).toBe("/question/#?db=22&table=33");
+  });
+});

--- a/frontend/src/metabase/lib/urls/modelToUrl.unit.spec.ts
+++ b/frontend/src/metabase/lib/urls/modelToUrl.unit.spec.ts
@@ -83,6 +83,6 @@ describe("urls > modelToUrl", () => {
         },
         timestamp: "2021-01-01T00:00:00.000Z",
       }),
-    ).toBe("/question/#?db=22&table=33");
+    ).toBe("/question#?db=22&table=33");
   });
 });

--- a/frontend/src/metabase/lib/urls/modelToUrl.unit.spec.ts
+++ b/frontend/src/metabase/lib/urls/modelToUrl.unit.spec.ts
@@ -83,6 +83,6 @@ describe("urls > modelToUrl", () => {
         },
         timestamp: "2021-01-01T00:00:00.000Z",
       }),
-    ).toBe("/question#?db=22&table=33");
+    ).toBe("/question/#?db=22&table=33");
   });
 });

--- a/frontend/src/metabase/lib/urls/questions.ts
+++ b/frontend/src/metabase/lib/urls/questions.ts
@@ -22,7 +22,9 @@ export type QuestionUrlBuilderParams = {
 };
 
 export function question(
-  card: Card | null,
+  card: Partial<
+    Pick<Card, "id" | "name" | "type" | "card_id" | "model">
+  > | null,
   {
     mode = "view",
     hash = "",

--- a/frontend/src/metabase/nav/components/search/RecentsList/RecentsList.tsx
+++ b/frontend/src/metabase/nav/components/search/RecentsList/RecentsList.tsx
@@ -29,10 +29,8 @@ export const RecentsList = ({ onClick, className }: RecentsListProps) => {
   const onContainerClick = (item: RecentItem) => {
     if (onClick) {
       onClick({
-        ...item.model_object,
-        model: item.model,
-        name: getName(item.model_object),
-        id: item.model_id,
+        ...item,
+        name: getName(item),
       });
     } else {
       onChangeLocation(item);

--- a/frontend/src/metabase/nav/components/search/RecentsList/RecentsList.tsx
+++ b/frontend/src/metabase/nav/components/search/RecentsList/RecentsList.tsx
@@ -4,9 +4,10 @@ import { useListRecentItemsQuery } from "metabase/api";
 import { getName } from "metabase/lib/name";
 import { useDispatch } from "metabase/lib/redux";
 import { RecentsListContent } from "metabase/nav/components/search/RecentsList/RecentsListContent";
-import { getItemUrl } from "metabase/nav/components/search/RecentsList/util";
 import { Paper } from "metabase/ui";
 import type { RecentItem, UnrestrictedLinkEntity } from "metabase-types/api";
+
+import { getItemUrl, recentsFilter } from "./util";
 
 type RecentsListProps = {
   onClick?: (elem: UnrestrictedLinkEntity) => void;
@@ -30,6 +31,7 @@ export const RecentsList = ({ onClick, className }: RecentsListProps) => {
     if (onClick) {
       onClick({
         ...item,
+        description: item.description ?? undefined,
         name: getName(item),
       });
     } else {
@@ -41,7 +43,7 @@ export const RecentsList = ({ onClick, className }: RecentsListProps) => {
     <Paper withBorder className={className}>
       <RecentsListContent
         isLoading={isRecentsListLoading}
-        results={data}
+        results={recentsFilter(data)}
         onClick={onContainerClick}
       />
     </Paper>

--- a/frontend/src/metabase/nav/components/search/RecentsList/RecentsList.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/search/RecentsList/RecentsList.unit.spec.tsx
@@ -1,53 +1,37 @@
-import fetchMock from "fetch-mock";
-
+import { setupRecentViewsEndpoints } from "__support__/server-mocks";
 import { renderWithProviders, screen } from "__support__/ui";
+import {
+  createMockRecentTableItem,
+  createMockRecentCollectionItem,
+} from "metabase-types/api/mocks";
 
 import { RecentsList } from "./RecentsList";
 
 const recentsData = [
-  {
-    user_id: 1,
+  createMockRecentCollectionItem({
     model: "card",
-    model_id: 83,
-    cnt: 9,
-    max_ts: "2021-08-24T23:50:21.077",
-    model_object: {
-      id: 83,
-      name: "Question I visited",
-      display: "table",
-    },
-  },
-  {
-    user_id: 1,
+    id: 83,
+    timestamp: "2021-08-24T23:50:21.077",
+    name: "Question I visited",
+    display: "table",
+  }),
+  createMockRecentCollectionItem({
     model: "dashboard",
-    model_id: 1,
-    cnt: 164,
-    max_ts: "2021-08-24T23:49:34.577",
-    model_object: {
-      id: 1,
-      name: "Dashboard I visited",
-    },
-  },
-  {
-    user_id: 1,
+    id: 1,
+    name: "Dashboard I visited",
+    timestamp: "2021-08-24T23:49:34.577",
+  }),
+  createMockRecentTableItem({
     model: "table",
-    model_id: 4,
-    cnt: 164,
-    max_ts: "2021-08-24T23:49:34.577",
-    model_object: {
-      id: 1,
-      name: "table_i_visited",
-      display_name: "Table I visited",
-    },
-  },
+    id: 4,
+    timestamp: "2021-08-24T23:49:34.577",
+    name: "table_i_visited",
+    display_name: "Table I visited",
+  }),
 ];
 
-function mockRecentsEndpoint(recents) {
-  fetchMock.get("path:/api/activity/recent_views", recents);
-}
-
 async function setup(recents = recentsData) {
-  mockRecentsEndpoint(recents);
+  setupRecentViewsEndpoints(recents);
 
   renderWithProviders(<RecentsList />);
 

--- a/frontend/src/metabase/nav/components/search/RecentsList/RecentsListContent.tsx
+++ b/frontend/src/metabase/nav/components/search/RecentsList/RecentsListContent.tsx
@@ -21,7 +21,7 @@ import { SearchResultLink } from "metabase/search/components/SearchResultLink";
 import { Group, Loader, Stack, Title } from "metabase/ui";
 import type { RecentItem } from "metabase-types/api";
 
-import { getItemUrl, isItemActive, resultsFilter } from "./util";
+import { getItemUrl, isItemActive } from "./util";
 
 type RecentsListContentProps = {
   isLoading: boolean;
@@ -67,7 +67,7 @@ export const RecentsListContent = ({
     >
       <Title order={4} px="sm">{t`Recently viewed`}</Title>
       <Stack spacing={0}>
-        {resultsFilter(results).map((item, index) => {
+        {results.map((item, index) => {
           const isActive = isItemActive(item);
 
           return (

--- a/frontend/src/metabase/nav/components/search/RecentsList/RecentsListContent.tsx
+++ b/frontend/src/metabase/nav/components/search/RecentsList/RecentsListContent.tsx
@@ -21,7 +21,7 @@ import { SearchResultLink } from "metabase/search/components/SearchResultLink";
 import { Group, Loader, Stack, Title } from "metabase/ui";
 import type { RecentItem } from "metabase-types/api";
 
-import { getItemUrl, isItemActive } from "./util";
+import { getItemUrl, isItemActive, resultsFilter } from "./util";
 
 type RecentsListContentProps = {
   isLoading: boolean;
@@ -67,7 +67,7 @@ export const RecentsListContent = ({
     >
       <Title order={4} px="sm">{t`Recently viewed`}</Title>
       <Stack spacing={0}>
-        {results.map((item, index) => {
+        {resultsFilter(results).map((item, index) => {
           const isActive = isItemActive(item);
 
           return (
@@ -89,7 +89,7 @@ export const RecentsListContent = ({
                     truncate
                     href={onClick ? undefined : getItemUrl(item)}
                   >
-                    {getName(item.model_object)}
+                    {getName(item)}
                   </ResultTitle>
                   <PLUGIN_MODERATION.ModerationStatusIcon
                     status={getModeratedStatus(item)}
@@ -114,17 +114,20 @@ export const RecentsListContent = ({
   );
 };
 
-const getItemKey = ({ model, model_id }: RecentItem) => {
-  return `${model}:${model_id}`;
+const getItemKey = ({ model, id }: RecentItem) => {
+  return `${model}:${id}`;
 };
 
-const getModeratedStatus = ({ model_object }: RecentItem) => {
-  return model_object.moderated_status;
+const getModeratedStatus = (item: RecentItem) => {
+  return item.model !== "table" && item.moderated_status;
 };
 
-const isItemLoading = ({ model, model_object }: RecentItem) => {
-  if (model !== "table") {
+const isItemLoading = (item: RecentItem) => {
+  if (item.model !== "table") {
     return false;
   }
-  return !isSyncCompleted(model_object);
+  if (!item.database) {
+    return false;
+  }
+  return !isSyncCompleted(item.database);
 };

--- a/frontend/src/metabase/nav/components/search/RecentsList/util.ts
+++ b/frontend/src/metabase/nav/components/search/RecentsList/util.ts
@@ -14,6 +14,6 @@ export const getItemUrl = (item: RecentItem) => {
   return url || undefined;
 };
 
-export const resultsFilter = (results: RecentItem[]): RecentItem[] => {
+export const recentsFilter = (results: RecentItem[]): RecentItem[] => {
   return results.filter(item => item.model !== "collection").slice(0, 5);
 };

--- a/frontend/src/metabase/nav/components/search/RecentsList/util.ts
+++ b/frontend/src/metabase/nav/components/search/RecentsList/util.ts
@@ -2,14 +2,18 @@ import { isSyncCompleted } from "metabase/lib/syncing";
 import * as Urls from "metabase/lib/urls";
 import type { RecentItem } from "metabase-types/api";
 
-export const isItemActive = ({ model, model_object }: RecentItem) => {
-  if (model !== "table") {
+export const isItemActive = (item: RecentItem) => {
+  if (item.model !== "table") {
     return true;
   }
-  return isSyncCompleted(model_object);
+  return isSyncCompleted(item.database);
 };
 
 export const getItemUrl = (item: RecentItem) => {
   const url = isItemActive(item) && Urls.modelToUrl(item);
   return url || undefined;
+};
+
+export const resultsFilter = (results: RecentItem[]): RecentItem[] => {
+  return results.filter(item => item.model !== "collection").slice(0, 5);
 };

--- a/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.unit.spec.tsx
@@ -19,8 +19,7 @@ import { SearchBar } from "metabase/nav/components/search/SearchBar";
 import type { CollectionItem, RecentItem } from "metabase-types/api";
 import {
   createMockCollectionItem,
-  createMockModelObject,
-  createMockRecentItem,
+  createMockRecentTableItem,
   createMockUser,
 } from "metabase-types/api/mocks";
 import {
@@ -47,9 +46,10 @@ const TEST_RECENT_VIEWS_RESULTS: RecentItem[] = [
   "Recents CDE",
   "Recents DEF",
 ].map((name, index) =>
-  createMockRecentItem({
-    model_object: createMockModelObject({ name }),
-    model_id: index + 1,
+  createMockRecentTableItem({
+    name,
+    display_name: name,
+    id: index + 1,
   }),
 );
 

--- a/frontend/src/metabase/palette/components/PaletteResults.unit.spec.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResults.unit.spec.tsx
@@ -1,6 +1,7 @@
 import { useKBar } from "kbar";
 import { useEffect } from "react";
 import { Route, withRouter, type WithRouterProps } from "react-router";
+import _ from "underscore";
 
 import {
   setupDatabasesEndpoints,
@@ -20,8 +21,7 @@ import {
   createMockCollection,
   createMockCollectionItem,
   createMockDatabase,
-  createMockModelObject,
-  createMockRecentItem,
+  createMockRecentCollectionItem,
 } from "metabase-types/api/mocks";
 import {
   createMockAdminAppState,
@@ -77,21 +77,22 @@ const dashboard = createMockCollectionItem({
   description: "Such Bar. Much Wow.",
 });
 
-const recents_1 = createMockRecentItem({
+const recents_1 = createMockRecentCollectionItem({
+  ..._.pick(model_1, "id", "name"),
   model: "dataset",
-  model_object: createMockModelObject({
-    ...model_1,
-    collection_id: null,
-  }),
+  moderated_status: "verified",
+  parent_collection: {
+    id: null,
+    name: "Our analytics",
+  },
 });
-
-const recents_2 = createMockRecentItem({
+const recents_2 = createMockRecentCollectionItem({
+  ..._.pick(dashboard, "id", "name"),
   model: "dashboard",
-  model_object: createMockModelObject({
-    ...dashboard,
-    collection_id: dashboard.collection?.id,
-    collection_name: dashboard.collection?.name,
-  }),
+  parent_collection: {
+    id: dashboard.collection?.id as number,
+    name: dashboard.collection?.name as string,
+  },
 });
 
 mockScrollTo();

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -213,7 +213,7 @@ export const useCommandPalette = () => {
         extra:
           item.model === "table"
             ? {
-                database: item.model_object.database_name,
+                database: item.database.name,
                 href: Urls.modelToUrl(item),
               }
             : {

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -198,8 +198,8 @@ export const useCommandPalette = () => {
   const recentItemsActions = useMemo<PaletteAction[]>(() => {
     return (
       recentItems?.map(item => ({
-        id: `recent-item-${getName(item.model_object)}`,
-        name: getName(item.model_object),
+        id: `recent-item-${getName(item)}`,
+        name: getName(item),
         icon: getIcon(item).name,
         section: "recent",
         perform: () => {
@@ -217,10 +217,10 @@ export const useCommandPalette = () => {
               }
             : {
                 parentCollection:
-                  item.model_object.collection_id === null
+                  item.parent_collection.id === null
                     ? ROOT_COLLECTION.name
-                    : item.model_object.collection_name,
-                isVerified: item.model_object.moderated_status === "verified",
+                    : item.parent_collection.name,
+                isVerified: item.moderated_status === "verified",
                 href: Urls.modelToUrl(item),
               },
       })) || []

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -22,6 +22,7 @@ import {
 import { getShowMetabaseLinks } from "metabase/selectors/whitelabel";
 
 import type { PaletteAction } from "../types";
+import { filterRecentItems } from "../utils";
 
 export const useCommandPalette = () => {
   const dispatch = useDispatch();
@@ -197,7 +198,7 @@ export const useCommandPalette = () => {
 
   const recentItemsActions = useMemo<PaletteAction[]>(() => {
     return (
-      recentItems?.map(item => ({
+      filterRecentItems(recentItems ?? []).map(item => ({
         id: `recent-item-${getName(item)}`,
         name: getName(item),
         icon: getIcon(item).name,

--- a/frontend/src/metabase/palette/utils.ts
+++ b/frontend/src/metabase/palette/utils.ts
@@ -1,6 +1,7 @@
 import { t } from "ttag";
 import _ from "underscore";
 
+import type { RecentItem } from "metabase-types/api";
 import type { PaletteActionImpl } from "./types";
 
 export const processResults = (
@@ -50,3 +51,6 @@ export const findClosestActionIndex = (
 
   return index + diff;
 };
+
+export const filterRecentItems: (items: RecentItem[]) => RecentItem[] = items =>
+  items.filter(item => item.model !== "collection").slice(0, 5);

--- a/frontend/src/metabase/palette/utils.ts
+++ b/frontend/src/metabase/palette/utils.ts
@@ -2,6 +2,7 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import type { RecentItem } from "metabase-types/api";
+
 import type { PaletteActionImpl } from "./types";
 
 export const processResults = (

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
@@ -275,7 +275,7 @@ describe("QB Actions > initializeQB", () => {
 
         it("does not run question query in notebook mode", async () => {
           const runQuestionQuerySpy = jest.spyOn(querying, "runQuestionQuery");
-          const baseUrl = Urls.question(card);
+          const baseUrl = Urls.question(card as Card);
           const location = getLocationForCard(card, {
             pathname: `${baseUrl}/notebook`,
           });
@@ -310,7 +310,7 @@ describe("QB Actions > initializeQB", () => {
         });
 
         it("sets QB mode to notebook if opening /notebook route", async () => {
-          const baseUrl = Urls.question(card);
+          const baseUrl = Urls.question(card as Card);
           const location = getLocationForCard(card, {
             pathname: `${baseUrl}/notebook`,
           });

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.unit.spec.tsx
@@ -22,9 +22,8 @@ import type {
 import {
   createMockCollectionItem,
   createMockCollection,
-  createMockRecentItem,
-  createMockTable,
-  createMockDashboard,
+  createMockRecentTableItem,
+  createMockRecentCollectionItem,
   createMockUser,
   createMockLinkDashboardCard,
 } from "metabase-types/api/mocks";
@@ -284,28 +283,26 @@ describe("LinkViz", () => {
     });
 
     it("clicking a recent item should update the entity", async () => {
-      const recentTableItem = createMockRecentItem({
-        cnt: 20,
-        user_id: 20,
+      const recentTableItem = createMockRecentTableItem({
         model: "table",
-        model_id: 121,
-        model_object: createMockTable({
-          id: 121,
-          name: "Table Uno",
-          display_name: "Table Uno",
-          db_id: 20,
-        }),
+        id: 121,
+        name: "Table Uno",
+        display_name: "Table Uno",
+        database: {
+          id: 20,
+          name: "Database Uno",
+          initial_sync_status: "complete",
+        },
       });
 
-      const recentDashboardItem = createMockRecentItem({
-        cnt: 20,
-        user_id: 20,
+      const recentDashboardItem = createMockRecentCollectionItem({
+        id: 131,
+        name: "Dashboard Uno",
         model: "dashboard",
-        model_id: 131,
-        model_object: createMockDashboard({
-          id: 131,
-          name: "Dashboard Uno",
-        }),
+        parent_collection: {
+          id: 1,
+          name: "Collection Uno",
+        },
       });
 
       setupRecentViewsEndpoints([recentTableItem, recentDashboardItem]);

--- a/frontend/test/__support__/server-mocks/activity.ts
+++ b/frontend/test/__support__/server-mocks/activity.ts
@@ -3,11 +3,15 @@ import fetchMock from "fetch-mock";
 import type { PopularItem, RecentItem, Dashboard } from "metabase-types/api";
 
 export function setupRecentViewsEndpoints(recentlyViewedItems: RecentItem[]) {
-  fetchMock.get("path:/api/activity/recent_views", recentlyViewedItems);
+  fetchMock.get("path:/api/activity/recent_views", {
+    recent_views: recentlyViewedItems,
+  });
 }
 
 export function setupPopularItemsEndpoints(popularItems: PopularItem[]) {
-  fetchMock.get("path:/api/activity/popular_items", popularItems);
+  fetchMock.get("path:/api/activity/popular_items", {
+    popular_items: popularItems,
+  });
 }
 
 export function setupMostRecentlyViewedDashboard(

--- a/test/metabase/models/recent_views_test.clj
+++ b/test/metabase/models/recent_views_test.clj
@@ -4,230 +4,210 @@
    [java-time.api :as t]
    [metabase.models.recent-views :as recent-views]
    [metabase.test :as mt]
+   [metabase.util.log :as log]
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp]))
 
+(def test-user :rasta)
+
 (defn- clear-test-user-recent-views
-  [test-user]
+  []
+  (log/infof "Clearing %s's recent views" (pr-str test-user))
   (t2/delete! :model/RecentViews :user_id (mt/user->id test-user)))
+
+;; use fixtures, each:
+;; call clear-test-user-recent-views
+(use-fixtures
+  :each (fn [f]
+          (clear-test-user-recent-views)
+          (f)))
 
 (deftest user-recent-views-dedupe-test
   (testing "The `user-recent-views` table should dedupe views of the same model"
-    (clear-test-user-recent-views :rasta)
     (t2.with-temp/with-temp [:model/Card      {model-id     :id} {:type "model"}
                              :model/Card      {model-id-2   :id} {:type "model"}
                              :model/Dashboard {dashboard-id :id} {}]
-      (let [t1 #t "2000-05-09T00:00:00.000000Z"
-            t2 #t "2001-05-09T00:00:00.000000Z"
-            t3 #t "2002-05-09T00:00:00.000000Z"]
+      ;; insert 6
+      (recent-views/update-users-recent-views! (mt/user->id test-user) :model/Card model-id)
+      (recent-views/update-users-recent-views! (mt/user->id test-user) :model/Card model-id)
+      (recent-views/update-users-recent-views! (mt/user->id test-user) :model/Card model-id-2)
+      (recent-views/update-users-recent-views! (mt/user->id test-user) :model/Card model-id-2)
+      (recent-views/update-users-recent-views! (mt/user->id test-user) :model/Dashboard dashboard-id)
+      (recent-views/update-users-recent-views! (mt/user->id test-user) :model/Dashboard dashboard-id)
+      ;; only see 3
+      (is (= 3 (count (recent-views/get-list (mt/user->id test-user))))))))
 
-        ;; For some reason, the `update-users-recent-views!` function gives all of these the same timestamp.
-        (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Card model-id)
-        (Thread/sleep 100)
-        #_(t2/update! :model/RecentViews {:model_id model-id :model "card"} {:timestamp t1})
-
-        (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Card model-id-2)
-        (Thread/sleep 100)
-        #_(t2/update! :model/RecentViews {:model_id model-id-2 :model "card"} {:timestamp t2})
-
-        (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Dashboard dashboard-id)
-        (Thread/sleep 100)
-        #_(t2/update! :model/RecentViews {:model_id dashboard-id :model "dashboard"} {:timestamp t3})
-        (def my-recents (t2/select :model/RecentViews :user_id (mt/user->id :rasta)))
-
-        ;; (set (map :timestamp my-recents)) is now: #{#t "2024-05-10T14:47:08.034664Z"}
-        ;; (def wat (set (mapv :timestamp (recent-views/get-list (mt/user->id :rasta)))))
-        ;; ;; wat is now: #{"2024-05-10T14:46:25.753502Z"}
-
-        ))))
-
-#_(deftest most-recently-viewed-dashboard-id-test
+(deftest most-recently-viewed-dashboard-id-test
   (testing "`most-recently-viewed-dashboard-id` returns the ID of the most recently viewed dashboard in the last 24 hours"
-    (clear-test-user-recent-views :rasta)
     (t2.with-temp/with-temp [:model/Dashboard {dash-id :id} {}
                              :model/Dashboard {dash-id-2 :id} {}
                              :model/Dashboard {dash-id-3 :id} {}]
 
-      (is (nil? (recent-views/most-recently-viewed-dashboard-id (mt/user->id :rasta))))
+      (is (nil? (recent-views/most-recently-viewed-dashboard-id (mt/user->id test-user))))
 
-      (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Dashboard dash-id)
-      (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Dashboard dash-id)
-      (is (= dash-id (recent-views/most-recently-viewed-dashboard-id (mt/user->id :rasta))))
+      (recent-views/update-users-recent-views! (mt/user->id test-user) :model/Dashboard dash-id)
+      (recent-views/update-users-recent-views! (mt/user->id test-user) :model/Dashboard dash-id)
+      (is (= dash-id (recent-views/most-recently-viewed-dashboard-id (mt/user->id test-user))))
 
-      (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Dashboard dash-id)
-      (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Dashboard dash-id-2)
-      (is (= dash-id-2 (recent-views/most-recently-viewed-dashboard-id (mt/user->id :rasta))))
+      (recent-views/update-users-recent-views! (mt/user->id test-user) :model/Dashboard dash-id)
+      (recent-views/update-users-recent-views! (mt/user->id test-user) :model/Dashboard dash-id-2)
+      (is (= dash-id-2 (recent-views/most-recently-viewed-dashboard-id (mt/user->id test-user))))
 
-      (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Dashboard dash-id)
-      (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Dashboard dash-id-3)
-      (is (= dash-id-3 (recent-views/most-recently-viewed-dashboard-id (mt/user->id :rasta)))))))
+      (recent-views/update-users-recent-views! (mt/user->id test-user) :model/Dashboard dash-id)
+      (recent-views/update-users-recent-views! (mt/user->id test-user) :model/Dashboard dash-id-3)
+      (is (= dash-id-3 (recent-views/most-recently-viewed-dashboard-id (mt/user->id test-user)))))))
 
-;; for a card model:
-;; a card:
-;; [:model/Card {card-id :id} {:type "question"}]
-;; a dataset:
-;; [:model/Card {card-id :id} {:type "model"}]
+(deftest update-users-recent-views!-duplicates-test
+  (testing "`update-users-recent-views!` prunes duplicates of a certain model.`"
+    (mt/with-temp [:model/Card {card-id :id} {:type "question"}]
+      ;; twenty five views
+      (dotimes [_ 25] (recent-views/update-users-recent-views! (mt/user->id test-user) :model/Card card-id))
+      (is (= 0 (count (filter (comp #{:dataset} :model) (recent-views/get-list (mt/user->id test-user))))))
+      (is (= 1 (count (filter (comp #{:card} :model) (recent-views/get-list (mt/user->id test-user)))))))))
 
-(deftest update-users-recent-views!-test
-  (clear-test-user-recent-views :rasta)
+(deftest update-users-recent-views!-bucket-filling-test
   (binding [recent-views/*recent-views-stored-per-user-per-model* 2]
-    (testing "`update-users-recent-views!` prunes duplicates of a certain model.`"
-        (mt/with-temp [:model/Card {card-id :id} {:type "question"}]
-          ;; twenty five views
-          (dotimes [_ 25] (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Card card-id))
-          (is (= 0 (count (filter (comp #{:dataset} :model) (recent-views/get-list (mt/user->id :rasta))))))
-          (is (= 1 (count (filter (comp #{:card} :model) (recent-views/get-list (mt/user->id :rasta))))))))
+    (testing "`update-users-recent-views!` prunes duplicates of all models.`"
+      (mt/with-temp
+        [:model/Card       {card-id         :id} {:type "question"}
+         :model/Card       {card-id-2       :id} {:type "question"}
+         :model/Card       {card-id-3       :id} {:type "question"}
 
-      (testing "`update-users-recent-views!` prunes duplicates of all models.`"
-        (mt/with-temp
-          [:model/Database   {db-id           :id} {} ;; just needed for my temp table
+         :model/Card       {model-id        :id} {:type "model"}
+         :model/Card       {model-id-2      :id} {:type "model"}
+         :model/Card       {model-id-3      :id} {:type "model"}
 
-           :model/Card       {card-id         :id} {:type "question"}
-           :model/Card       {model-id        :id} {:type "model"}
-           :model/Dashboard  {dashboard-id    :id} {}
-           :model/Collection {collection-id   :id} {}
-           :model/Table      {table-id        :id} {:db_id db-id, :is_upload true}
+         :model/Dashboard  {dashboard-id    :id} {}
+         :model/Dashboard  {dashboard-id-2  :id} {}
+         :model/Dashboard  {dashboard-id-3  :id} {}
 
-           :model/Card       {card-id-2       :id} {:type "question"}
-           :model/Card       {model-id-2      :id} {:type "model"}
-           :model/Dashboard  {dashboard-id-2  :id} {}
-           :model/Collection {collection-id-2 :id} {}
-           :model/Table      {table-id-2      :id} {:db_id db-id, :is_upload true}
+         :model/Collection {collection-id   :id} {}
+         :model/Collection {collection-id-2 :id} {}
+         :model/Collection {collection-id-3 :id} {}
 
-           :model/Card       {card-id-3       :id} {:type "question"}
-           :model/Card       {model-id-3      :id} {:type "model"}
-           :model/Dashboard  {dashboard-id-3  :id} {}
-           :model/Collection {collection-id-3 :id} {}
-           :model/Table      {table-id-3      :id} {:db_id db-id, :is_upload true}]
-          (doseq [[model out-model model-ids] [[:model/Card :card [card-id card-id-2 card-id-3]]
-                                               [:model/Card :dataset [model-id model-id-2 model-id-3]]
-                                               [:model/Dashboard :dashboard [dashboard-id dashboard-id-2 dashboard-id-3]]
-                                               [:model/Collection :collection [collection-id collection-id-2 collection-id-3]]
-                                               [:model/Table :table [table-id table-id-2 table-id-3]]]]
-            (doseq [model-id model-ids] (recent-views/update-users-recent-views! (mt/user->id :rasta) model model-id))
-            (testing (format "When user views %s %ss, the latest %s per model are kept. "
-                             (count model-ids) model recent-views/*recent-views-stored-per-user-per-model*)
-              (is (= 2 (count (filter (comp #{out-model} :model) (recent-views/get-list (mt/user->id :rasta))))))))
-
-          ))))
-
-
-
-      ;; #_#_#_#_#_#_#_(recent-views/update-users-recent-views! user-id :model/Card 3)
-      ;; (is (=  {:id                3,
-      ;;          :name              "Content",
-      ;;          :model             :dataset,
-      ;;          :can_write         false,
-      ;;          :timestamp         java.lang.String,
-      ;;          :moderated_status  nil,
-      ;;          :parent_collection {:id 1, :name "Metabase analytics", :authority_level nil}}
-      ;;         (update (first (recent-views/get-list user-id))
-      ;;                 :timestamp type)))
-
-      ;; (recent-views/update-users-recent-views! user-id :model/Card 4)
-      ;; (is (= [{:can_write         false,
-      ;;          :name              "Last queries",
-      ;;          :parent_collection {:id 1, :name "Metabase analytics", :authority_level nil},
-      ;;          :moderated_status  nil,
-      ;;          :id                4,
-      ;;          :display           "table",
-      ;;          :model             :card}
-      ;;         {:id                3,
-      ;;          :name              "Content",
-      ;;          :model             :dataset,
-      ;;          :can_write         false,
-      ;;          :moderated_status  nil,
-      ;;          :parent_collection {:id 1, :name "Metabase analytics", :authority_level nil},}]
-      ;;        (->> (recent-views/get-list user-id)
-      ;;             (take 2)
-      ;;             (mapv #(dissoc % :timestamp)))))
-
-      ;; (testing "The most recent dashboard view is not pruned"
-      ;;   (recent-views/update-users-recent-views! user-id :model/Dashboard 1)
-      ;;   (recent-views/update-users-recent-views! user-id :model/Card 5)
-      ;;   (recent-views/update-users-recent-views! user-id :model/Card 6)
-      ;;   (recent-views/update-users-recent-views! user-id :model/Card 7)
-      ;;   (recent-views/update-users-recent-views! user-id :model/Card 8)
-      ;;   (recent-views/update-users-recent-views! user-id :model/Card 9)
-      ;;   (is (= {:id                1,
-      ;;           :name              "Performance overview",
-      ;;           :model             :dashboard,
-      ;;           :can_write         false,
-      ;;           ;;:timestamp "2024-05-09T15:50:55.589867Z",
-      ;;           :parent_collection {:id 1, :name "Metabase analytics", :authority_level nil}}
-      ;;          (-> (recent-views/get-list user-id)
-      ;;              (->> (u/seek (comp #{:dashboard} :model)))
-      ;;              (dissoc :timestamp)))))
-
-      ;; (binding [recent-views/*recent-views-stored-per-user-per-model* 1]
-      ;;   (testing "If another dashboard view occurs, the old one can be pruned"
-      ;;     (recent-views/update-users-recent-views! user-id :model/Dashboard 2)
-      ;;     (is (= [{:id                2,
-      ;;              :name              "Person overview",
-      ;;              :model             :dashboard,
-      ;;              :can_write         false,
-      ;;              ;; :timestamp "2024-05-09T15:55:32.702813Z",
-      ;;              :parent_collection {:id 1, :name "Metabase analytics", :authority_level nil}}]
-      ;;            (->> (recent-views/get-list user-id)
-      ;;                 (filter (comp #{:dashboard} :model))
-      ;;                 (mapv #(dissoc % :timestamp)))))))
-
-      ;; (testing "If `*recent-views-stored-per-user*` changes, the table expands or shrinks appropriately"
-      ;;   (binding [recent-views/*recent-views-stored-per-user-per-model* 1]
-      ;;     (recent-views/update-users-recent-views! user-id :model/Table 1)
-      ;;     (is (= {:table 1, :dashboard 1, :dataset 1, :card 1, :collection 1}
-      ;;            (frequencies (map :model (recent-views/get-list user-id))))))
-
-      ;;   (binding [recent-views/*recent-views-stored-per-user-per-model* 2]
-      ;;     (recent-views/update-users-recent-views! user-id :model/Table 2)
-      ;;     (recent-views/update-users-recent-views! user-id :model/Card 2)
-      ;;     (recent-views/update-users-recent-views! user-id :model/Card 1)
-      ;;     (recent-views/update-users-recent-views! user-id :model/Card 5)
-      ;;     (recent-views/update-users-recent-views! user-id :model/Card 6)
-      ;;     (recent-views/update-users-recent-views! user-id :model/Card 7)
-      ;;     (recent-views/update-users-recent-views! user-id :model/Card 8)
-      ;;     (recent-views/update-users-recent-views! user-id :model/Card 9)
-      ;;     (recent-views/update-users-recent-views! user-id :model/Dashboard 2)
-      ;;     (recent-views/update-users-recent-views! user-id :model/Dashboard 1)
-      ;;     (recent-views/update-users-recent-views! user-id :model/Collection 2)
-      ;;     (is (= {:collection 2, :dashboard 2, :dataset 2, :card 2, :table 2}
-      ;;            (frequencies (map :model (recent-views/get-list user-id))))))
-      ;;)
+         :model/Database   {db-id           :id} {} ;; just needed for these temp tables
+         :model/Table      {table-id        :id} {:db_id db-id, :is_upload true}
+         :model/Table      {table-id-2      :id} {:db_id db-id, :is_upload true}
+         :model/Table      {table-id-3      :id} {:db_id db-id, :is_upload true}]
+        (doseq [[model out-model model-ids] [[:model/Card :card [card-id card-id-2 card-id-3]]
+                                             [:model/Card :dataset [model-id model-id-2 model-id-3]]
+                                             [:model/Dashboard :dashboard [dashboard-id dashboard-id-2 dashboard-id-3]]
+                                             [:model/Collection :collection [collection-id collection-id-2 collection-id-3]]
+                                             [:model/Table :table [table-id table-id-2 table-id-3]]]]
+          (doseq [model-id model-ids]
+            (recent-views/update-users-recent-views! (mt/user->id test-user) model model-id))
+          (testing (format "When user views %s %ss, the latest %s per model are kept. "
+                           (count model-ids) model recent-views/*recent-views-stored-per-user-per-model*)
+            (is (= 2 (count (filter (comp #{out-model} :model) (recent-views/get-list (mt/user->id test-user))))))))
+        (is
+         (= {:card recent-views/*recent-views-stored-per-user-per-model*,
+             :dataset recent-views/*recent-views-stored-per-user-per-model*,
+             :dashboard recent-views/*recent-views-stored-per-user-per-model*,
+             :collection recent-views/*recent-views-stored-per-user-per-model*,
+             :table recent-views/*recent-views-stored-per-user-per-model*}
+            (frequencies (map :model (recent-views/get-list (mt/user->id test-user)))))
+         "After inserting 3 views of each model, we should have 2 views PER each model.")))))
 
 
+(deftest most-recent-dashboard-view-test
+  (testing "The most recent dashboard view is never pruned"
+    (binding [recent-views/*recent-views-stored-per-user-per-model* 1]
+      (mt/with-temp
+        [:model/Dashboard  {dashboard-id    :id} {}
+
+         :model/Card       {card-id         :id} {:type "question"}
+         :model/Card       {card-id-2       :id} {:type "question"}
+         :model/Card       {card-id-3       :id} {:type "question"}
+         :model/Card       {model-id        :id} {:type "model"}
+         :model/Card       {model-id-2      :id} {:type "model"}
+         :model/Card       {model-id-3      :id} {:type "model"}
+         :model/Collection {collection-id   :id} {}
+         :model/Collection {collection-id-2 :id} {}
+         :model/Collection {collection-id-3 :id} {}
+         :model/Database   {db-id           :id} {} ;; just needed for these temp tables
+         :model/Table      {table-id        :id} {:db_id db-id, :is_upload true}
+         :model/Table      {table-id-2      :id} {:db_id db-id, :is_upload true}
+         :model/Table      {table-id-3      :id} {:db_id db-id, :is_upload true}]
+        (recent-views/update-users-recent-views! (mt/user->id test-user) :model/Dashboard dashboard-id)
+        (doseq [[model model-ids] [[:model/Card       [card-id card-id-2 card-id-3]]
+                                   [:model/Card       [model-id model-id-2 model-id-3]]
+                                   [:model/Collection [collection-id collection-id-2 collection-id-3]]
+                                   [:model/Table      [table-id table-id-2 table-id-3]]]]
+          (doseq [model-id model-ids]
+            (recent-views/update-users-recent-views! (mt/user->id test-user) model model-id)
+            (is (= [dashboard-id]
+                   (keep #(when ((comp #{:dashboard} :model) %) (:id %))
+                         (recent-views/get-list (mt/user->id test-user)))))))))))
+
+(deftest table-per-user-size-shrinks-or-grows-test
+  (binding [recent-views/*recent-views-stored-per-user-per-model* 30]
+    (testing "`update-users-recent-views!` prunes duplicates of all models.`"
+      (mt/with-temp
+        [:model/Card       {card-id         :id} {:type "question"}
+         :model/Card       {card-id-2       :id} {:type "question"}
+         :model/Card       {card-id-3       :id} {:type "question"}
+         :model/Card       {card-id-4       :id} {:type "question"}
+
+         :model/Card       {model-id        :id} {:type "model"}
+         :model/Card       {model-id-2      :id} {:type "model"}
+         :model/Card       {model-id-3      :id} {:type "model"}
+
+         :model/Dashboard  {dashboard-id    :id} {}
+         :model/Dashboard  {dashboard-id-2  :id} {}
+         :model/Dashboard  {dashboard-id-3  :id} {}
+
+         :model/Collection {collection-id   :id} {}
+         :model/Collection {collection-id-2 :id} {}
+         :model/Collection {collection-id-3 :id} {}
+
+         :model/Database   {db-id           :id} {} ;; just needed for these temp tables
+         :model/Table      {table-id        :id} {:db_id db-id, :is_upload true}
+         :model/Table      {table-id-2      :id} {:db_id db-id, :is_upload true}
+         :model/Table      {table-id-3      :id} {:db_id db-id, :is_upload true}]
+        (doseq [[model model-ids] [[:model/Card       [card-id card-id-2 card-id-3]]
+                                   [:model/Card       [model-id model-id-2 model-id-3]]
+                                   [:model/Dashboard  [dashboard-id dashboard-id-2 dashboard-id-3]]
+                                   [:model/Collection [collection-id collection-id-2 collection-id-3]]
+                                   [:model/Table      [table-id table-id-2 table-id-3]]]]
+          (doseq [model-id model-ids]
+            (recent-views/update-users-recent-views! (mt/user->id test-user) model model-id)))
+        (is (= {:card 3, :dataset 3, :dashboard 3, :collection 3, :table 3}
+               (frequencies (map :model (recent-views/get-list (mt/user->id test-user))))))
+        (binding [recent-views/*recent-views-stored-per-user-per-model* 2]
+          (is (= 5
+                 (count (set (recent-views/ids-to-prune (mt/user->id test-user))))))
+          (recent-views/update-users-recent-views! (mt/user->id test-user) :model/Card card-id-4)
+          (is (= {:card 2, :dataset 2, :dashboard 2, :collection 2, :table 2}
+                 (frequencies (map :model (recent-views/get-list (mt/user->id test-user)))))))))))
 
 (deftest id-pruning-test
   (mt/with-temp [:model/Database a-db     {}
                  :model/Table a-table     {:db_id (:id a-db)}
                  :model/Collection a-coll {}
                  :model/Card a-card       {:type "question" :table_id (mt/id :reviews)}
-                 :model/Card a-model      {:type "model" :table_id (mt/id :reviews)}
-                 :model/Dashboard a-dash  {};;]
-                 ;; oldest first:
+                 :model/Card a-model      {:type "model"    :table_id (mt/id :reviews)}
+                 :model/Dashboard a-dash  {}
 
-                 ;;[
-                 :model/RecentViews rv15  {:id 1336998, :user_id (mt/user->id :rasta), :model "card",       :model_id (:id a-model), :timestamp #t "1971-01-01T08:00+08:00"}
-                 :model/RecentViews rv14  {:id 1336999, :user_id (mt/user->id :rasta), :model "card",       :model_id (:id a-model), :timestamp #t "1971-01-01T08:01+08:00"}
-                 :model/RecentViews _rv13 {:id 1337000, :user_id (mt/user->id :rasta), :model "card",       :model_id (:id a-model), :timestamp #t "1971-01-01T08:02+08:00"}
-                 :model/RecentViews rv12  {:id 1337001, :user_id (mt/user->id :rasta), :model "dashboard",  :model_id (:id a-dash),  :timestamp #t "1971-01-01T08:03+08:00"}
-                 :model/RecentViews rv11  {:id 1337002, :user_id (mt/user->id :rasta), :model "dashboard",  :model_id (:id a-dash),  :timestamp #t "1972-11-31T18:02:00.001-06:00"}
-                 :model/RecentViews _rv10 {:id 1337003, :user_id (mt/user->id :rasta), :model "dashboard",  :model_id (:id a-dash),  :timestamp #t "1973-01-01T01:01:00.003+01:00"}
-                 :model/RecentViews rv9   {:id 1337004, :user_id (mt/user->id :rasta), :model "collection", :model_id (:id a-coll),  :timestamp #t "1974-01-01T06:22:59.999+06:30"}
-                 :model/RecentViews _rv8  {:id 1337005, :user_id (mt/user->id :rasta), :model "collection", :model_id (:id a-coll),  :timestamp #t "1975-01-01T06:22:59.999+06:30"}
-                 :model/RecentViews rv7   {:id 1337006, :user_id (mt/user->id :rasta), :model "table",      :model_id (:id a-table), :timestamp #t "1976-01-01T06:29:59.999+06:30"}
-                 :model/RecentViews rv6   {:id 1337007, :user_id (mt/user->id :rasta), :model "table",      :model_id (:id a-table), :timestamp #t "1977-01-01T09:00+09:00"}
-                 :model/RecentViews rv5   {:id 1337008, :user_id (mt/user->id :rasta), :model "table",      :model_id (:id a-table), :timestamp #t "1978-01-01T01:00:00.001+01:00"}
-                 :model/RecentViews rv4   {:id 1337009, :user_id (mt/user->id :rasta), :model "table",      :model_id (:id a-table), :timestamp #t "1979-01-01T04:59:59.998+05:00"}
-                 :model/RecentViews rv3   {:id 1337010, :user_id (mt/user->id :rasta), :model "table",      :model_id (:id a-table), :timestamp #t "1980-01-01T00:00Z"}
-                 :model/RecentViews _rv2  {:id 1337011, :user_id (mt/user->id :rasta), :model "table",      :model_id (:id a-table), :timestamp #t "1981-01-01T05:59:59.999+06:00"}
-                 :model/RecentViews rv1   {:id 1337012, :user_id (mt/user->id :rasta), :model "card",       :model_id (:id a-card),  :timestamp #t "1982-01-01T00:00Z"}
-                 :model/RecentViews _rv0  {:id 1337013, :user_id (mt/user->id :rasta), :model "card",       :model_id (:id a-card),  :timestamp #t "1983-10-01T00:00Z"}]
-    (def card-id-a (:id a-model))
-    (def qr (#'recent-views/do-query (mt/user->id :rasta)))
-    (let [query-result (recent-views/get-list (mt/user->id :rasta))]
-      ;; everything should be in chronological order, newest first:
-      (is (apply t/after? (map (comp t/zoned-date-time :timestamp) query-result))))
-    (let [ids-to-prune (#'recent-views/duplicate-model-ids (mt/user->id :rasta))]
+                 :model/RecentViews rv15  {:id 1336998, :user_id (mt/user->id test-user), :model "card",       :model_id (:id a-model), :timestamp #t "1971-01-01T08:00+08:00"}
+                 :model/RecentViews rv14  {:id 1336999, :user_id (mt/user->id test-user), :model "card",       :model_id (:id a-model), :timestamp #t "1971-01-01T08:01+08:00"}
+                 :model/RecentViews _rv13 {:id 1337000, :user_id (mt/user->id test-user), :model "card",       :model_id (:id a-model), :timestamp #t "1971-01-01T08:02+08:00"}
+                 :model/RecentViews rv12  {:id 1337001, :user_id (mt/user->id test-user), :model "dashboard",  :model_id (:id a-dash),  :timestamp #t "1971-01-01T08:03+08:00"}
+                 :model/RecentViews rv11  {:id 1337002, :user_id (mt/user->id test-user), :model "dashboard",  :model_id (:id a-dash),  :timestamp #t "1972-11-31T18:02:00.001-06:00"}
+                 :model/RecentViews _rv10 {:id 1337003, :user_id (mt/user->id test-user), :model "dashboard",  :model_id (:id a-dash),  :timestamp #t "1973-01-01T01:01:00.003+01:00"}
+                 :model/RecentViews rv9   {:id 1337004, :user_id (mt/user->id test-user), :model "collection", :model_id (:id a-coll),  :timestamp #t "1974-01-01T06:22:59.999+06:30"}
+                 :model/RecentViews _rv8  {:id 1337005, :user_id (mt/user->id test-user), :model "collection", :model_id (:id a-coll),  :timestamp #t "1975-01-01T06:22:59.999+06:30"}
+                 :model/RecentViews rv7   {:id 1337006, :user_id (mt/user->id test-user), :model "table",      :model_id (:id a-table), :timestamp #t "1976-01-01T06:29:59.999+06:30"}
+                 :model/RecentViews rv6   {:id 1337007, :user_id (mt/user->id test-user), :model "table",      :model_id (:id a-table), :timestamp #t "1977-01-01T09:00+09:00"}
+                 :model/RecentViews rv5   {:id 1337008, :user_id (mt/user->id test-user), :model "table",      :model_id (:id a-table), :timestamp #t "1978-01-01T01:00:00.001+01:00"}
+                 :model/RecentViews rv4   {:id 1337009, :user_id (mt/user->id test-user), :model "table",      :model_id (:id a-table), :timestamp #t "1979-01-01T04:59:59.998+05:00"}
+                 :model/RecentViews rv3   {:id 1337010, :user_id (mt/user->id test-user), :model "table",      :model_id (:id a-table), :timestamp #t "1980-01-01T00:00Z"}
+                 :model/RecentViews _rv2  {:id 1337011, :user_id (mt/user->id test-user), :model "table",      :model_id (:id a-table), :timestamp #t "1981-01-01T05:59:59.999+06:00"}
+                 :model/RecentViews rv1   {:id 1337012, :user_id (mt/user->id test-user), :model "card",       :model_id (:id a-card),  :timestamp #t "1982-01-01T00:00Z"}
+                 :model/RecentViews _rv0  {:id 1337013, :user_id (mt/user->id test-user), :model "card",       :model_id (:id a-card),  :timestamp #t "1983-10-01T00:00Z"}]
+    (let [query-result (recent-views/get-list (mt/user->id test-user))]
+      (is (apply t/after? (map (comp t/zoned-date-time :timestamp) query-result))
+          "recent-views/get-list should be in chronological order, newest first:"))
+    (let [ids-to-prune (#'recent-views/duplicate-model-ids (mt/user->id test-user))]
       (is (= #{(:id rv1)                                         ;; dupe cards
                (:id rv3) (:id rv4) (:id rv5) (:id rv6) (:id rv7) ;; dupe tables
                (:id rv9)                                         ;; dupe collections
@@ -236,29 +216,28 @@
              ids-to-prune)))))
 
 (deftest test-recent-views-garbage-collection
-  (clear-test-user-recent-views :rasta)
   (mt/with-temp [:model/Card a-card {:type "question" :table_id (mt/id :reviews)}
                  :model/Card b-card {:type "question" :table_id (mt/id :reviews)}
                  :model/Card c-card {:type "question" :table_id (mt/id :reviews)}
                  :model/Card d-card {:type "question" :table_id (mt/id :reviews)}
                  :model/Card e-card {:type "question" :table_id (mt/id :reviews)}
                  :model/Card f-card {:type "question" :table_id (mt/id :reviews)}
-                 :model/RecentViews _ {:id 1337000 :user_id (mt/user->id :rasta), :model "card", :model_id (:id a-card),  :timestamp #t "2000-10-01T00:00Z"}
-                 :model/RecentViews _ {:id 1337001 :user_id (mt/user->id :rasta), :model "card", :model_id (:id b-card),  :timestamp #t "2001-10-01T00:00Z"}
-                 :model/RecentViews _ {:id 1337002 :user_id (mt/user->id :rasta), :model "card", :model_id (:id c-card),  :timestamp #t "2002-10-01T00:00Z"}
-                 :model/RecentViews _ {:id 1337003 :user_id (mt/user->id :rasta), :model "card", :model_id (:id d-card),  :timestamp #t "2003-10-01T00:00Z"}
-                 :model/RecentViews _ {:id 1337004 :user_id (mt/user->id :rasta), :model "card", :model_id (:id e-card),  :timestamp #t "2004-10-01T00:00Z"}
-                 :model/RecentViews _ {:id 1337005 :user_id (mt/user->id :rasta), :model "card", :model_id (:id f-card),  :timestamp #t "2005-10-01T00:00Z"}]
-    (doseq [{:keys [ids-to-prune bucket-size]} [{:bucket-size 0 :ids-to-prune [0 1 2 3 4 5]} ;; delete them all!
-                                                {:bucket-size 1 :ids-to-prune [0 1 2 3 4]}
-                                                {:bucket-size 2 :ids-to-prune [0 1 2 3]}
-                                                {:bucket-size 3 :ids-to-prune [0 1 2]}
-                                                {:bucket-size 4 :ids-to-prune [0 1]}
-                                                {:bucket-size 5 :ids-to-prune [0]}
-                                                {:bucket-size 6 :ids-to-prune []}
-                                                {:bucket-size 7 :ids-to-prune []}]]
+                 :model/RecentViews _ {:id 1337000 :user_id (mt/user->id test-user), :model "card", :model_id (:id a-card), :timestamp #t "2000-10-01T00:00Z"}
+                 :model/RecentViews _ {:id 1337001 :user_id (mt/user->id test-user), :model "card", :model_id (:id b-card), :timestamp #t "2001-10-01T00:00Z"}
+                 :model/RecentViews _ {:id 1337002 :user_id (mt/user->id test-user), :model "card", :model_id (:id c-card), :timestamp #t "2002-10-01T00:00Z"}
+                 :model/RecentViews _ {:id 1337003 :user_id (mt/user->id test-user), :model "card", :model_id (:id d-card), :timestamp #t "2003-10-01T00:00Z"}
+                 :model/RecentViews _ {:id 1337004 :user_id (mt/user->id test-user), :model "card", :model_id (:id e-card), :timestamp #t "2004-10-01T00:00Z"}
+                 :model/RecentViews _ {:id 1337005 :user_id (mt/user->id test-user), :model "card", :model_id (:id f-card), :timestamp #t "2005-10-01T00:00Z"}]
+    (doseq [{:keys [ids-to-prune bucket-size]} [{:ids-to-prune [0 1 2 3 4 5] :bucket-size 0} ;; delete them all!
+                                                {:ids-to-prune [0 1 2 3 4]   :bucket-size 1}
+                                                {:ids-to-prune [0 1 2 3]     :bucket-size 2}
+                                                {:ids-to-prune [0 1 2]       :bucket-size 3}
+                                                {:ids-to-prune [0 1]         :bucket-size 4}
+                                                {:ids-to-prune [0]           :bucket-size 5}
+                                                {:ids-to-prune []            :bucket-size 6}
+                                                {:ids-to-prune []            :bucket-size 7}]]
       (binding [recent-views/*recent-views-stored-per-user-per-model* bucket-size]
         (testing (str "Bucket size: " bucket-size)
           (is (= ids-to-prune
                  (vec (sort (map #(- % 1337000)
-                                 (#'recent-views/ids-to-prune (mt/user->id :rasta))))))))))))
+                                 (#'recent-views/ids-to-prune (mt/user->id test-user))))))))))))


### PR DESCRIPTION
> [!Note]
> The frontend code here is ready for review, but there is one little piece missing in the backend: models should return with `model: dataset`, but currently they have `model: card`


> [!Important]
> I highly recommend looking at this PR by commit, rather than all at once. The first few commits have all the substance, and the bulk of the PR is just cleaning up types and test mocks

Closes https://github.com/metabase/metabase/issues/41957

### Description

Uses a better, beefier recents format from the backend, and handles a larger number of recent items.

Recents appear in:

. | .
--|--
Homepage | ![Screen Shot 2024-05-07 at 4 49 01 PM](https://github.com/metabase/metabase/assets/30528226/f8315636-39d7-49d4-ac5b-8b59542660ae)
Search Results | ![Screen Shot 2024-05-07 at 4 48 55 PM](https://github.com/metabase/metabase/assets/30528226/89989837-7f01-48cd-84a9-7d9dd9793c47)
Command Palette | ![Screen Shot 2024-05-07 at 4 48 51 PM](https://github.com/metabase/metabase/assets/30528226/97d6ccdd-b527-4980-a1a5-6aa8a6b5a81d)

Popular items only appear on the home page for brand new users. 

![Screen Shot 2024-05-07 at 3 58 20 PM](https://github.com/metabase/metabase/assets/30528226/59de16e3-f9ea-4a4b-97fc-b0876179e4dd)

To test this component, i'd recommend just modifying the if statement in `HomeContent.tsx` like so:

![Screen Shot 2024-05-07 at 4 52 09 PM](https://github.com/metabase/metabase/assets/30528226/ac504cec-0c7a-44c1-a2dd-a402f298cdef)




### Checklist

- [x] Tests have been added/updated to cover changes in this PR
