### PR TITLE
Convert `nest-query` query transformation logic to MLv2 (new PR)

### DIFF
--- a/.clj-kondo/hooks/clojure/test.clj
+++ b/.clj-kondo/hooks/clojure/test.clj
@@ -31,7 +31,6 @@
      metabase.test.util.log/with-log-messages-for-level
      metabase.test.util.misc/with-single-admin-user
      metabase.test.util/with-all-users-permission
-     metabase.test.util/with-column-remappings
      metabase.test.util/with-discarded-collections-perms-changes
      metabase.test.util/with-env-keys-renamed-by
      metabase.test.util/with-locale
@@ -49,7 +48,6 @@
      metabase.test/with-actions-test-data-and-actions-enabled
      metabase.test/with-actions-test-data-tables
      metabase.test/with-all-users-permission
-     metabase.test/with-column-remappings
      metabase.test/with-discarded-collections-perms-changes
      metabase.test/with-env-keys-renamed-by
      metabase.test/with-expected-messages

--- a/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
+++ b/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
@@ -12,6 +12,7 @@
    [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.driver.util :as driver.u]
+   [metabase.lib.test-util :as lib.tu]
    [metabase.models.database :refer [Database]]
    [metabase.models.field :refer [Field]]
    [metabase.models.table :refer [Table]]
@@ -229,46 +230,49 @@
   (testing "Don't try to generate queries with SELECT (...) AS source, Oracle hates `AS`"
     ;; TODO -- seems WACK that we actually have to create objects for this to work and can't just stick them in the QP
     ;; store.
-    (t2.with-temp/with-temp [Database db {:name   "db"
-                                          :engine :oracle}
-                             Table table {:db_id  (:id db)
-                                          :schema "public"
-                                          :name   "table"}
-                             Field field {:table_id      (:id table)
-                                          :name          "field"
-                                          :display_name  "Field"
-                                          :database_type "char"
-                                          :base_type     :type/Text}]
-      (qp.store/with-metadata-provider (u/the-id db)
-        (let [hsql (sql.qp/mbql->honeysql :oracle
-                                          {:query {:source-query {:source-table (:id table)
-                                                                  :expressions  {"s" [:substring [:field (:id field) nil] 2]}
-                                                                  :fields       [[:field (:id field) nil]
-                                                                                 [:expression "s"]]}
-                                                   :fields       [[:field "s" {:base-type :type/Text}]]
-                                                   :limit        3}})]
-          (testing (format "Honey SQL =\n%s" (u/pprint-to-str hsql))
-            (is (= [["SELECT"
-                     "  *"
-                     "FROM"
-                     "  ("
-                     "    SELECT"
-                     "      \"source\".\"s\" \"s\""
-                     "    FROM"
-                     "      ("
-                     "        SELECT"
-                     "          \"public\".\"table\".\"field\" \"field\","
-                     "          SUBSTR(\"public\".\"table\".\"field\", 2) \"s\""
-                     "        FROM"
-                     "          \"public\".\"table\""
-                     "      ) \"source\""
-                     "  )"
-                     "WHERE"
-                     "  rownum <= 3"]]
-                   (-> (sql.qp/format-honeysql :oracle hsql)
-                       vec
-                       (update 0 (partial driver/prettify-native-form :oracle))
-                       (update 0 str/split-lines))))))))))
+    (qp.store/with-metadata-provider (lib.tu/mock-metadata-provider
+                                      {:database {:id     1
+                                                  :name   "db"
+                                                  :engine :oracle}
+                                       :tables   [{:id     1
+                                                   :db-id  1
+                                                   :schema "public"
+                                                   :name   "table"}]
+                                       :fields   [{:id            1
+                                                   :table-id      1
+                                                   :name          "field"
+                                                   :display-name  "Field"
+                                                   :database-type "char"
+                                                   :base-type     :type/Text}]})
+      (let [hsql (sql.qp/mbql->honeysql :oracle
+                                        {:query {:source-query {:source-table 1
+                                                                :expressions  {"s" [:substring [:field 1 nil] 2]}
+                                                                :fields       [[:field 1 nil]
+                                                                               [:expression "s"]]}
+                                                 :fields       [[:field "s" {:base-type :type/Text}]]
+                                                 :limit        3}})]
+        (testing (format "Honey SQL =\n%s" (u/pprint-to-str hsql))
+          (is (= [["SELECT"
+                   "  *"
+                   "FROM"
+                   "  ("
+                   "    SELECT"
+                   "      \"source\".\"s\" \"s\""
+                   "    FROM"
+                   "      ("
+                   "        SELECT"
+                   "          \"public\".\"table\".\"field\" \"field\","
+                   "          SUBSTR(\"public\".\"table\".\"field\", 2) \"s\""
+                   "        FROM"
+                   "          \"public\".\"table\""
+                   "      ) \"source\""
+                   "  )"
+                   "WHERE"
+                   "  rownum <= 3"]]
+                 (-> (sql.qp/format-honeysql :oracle hsql)
+                     vec
+                     (update 0 (partial driver/prettify-native-form :oracle))
+                     (update 0 str/split-lines)))))))))
 
 (deftest return-clobs-as-text-test
   (mt/test-driver :oracle

--- a/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
+++ b/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
@@ -225,7 +225,7 @@
   [[username-binding & [username]] & body]
   `(do-with-temp-user ~username (fn [~username-binding] ~@body)))
 
-(deftest subselect-test
+(deftest ^:parallel subselect-test
   (testing "Don't try to generate queries with SELECT (...) AS source, Oracle hates `AS`"
     ;; TODO -- seems WACK that we actually have to create objects for this to work and can't just stick them in the QP
     ;; store.
@@ -241,9 +241,11 @@
                                           :base_type     :type/Text}]
       (qp.store/with-metadata-provider (u/the-id db)
         (let [hsql (sql.qp/mbql->honeysql :oracle
-                                          {:query {:source-table (:id table)
-                                                   :expressions  {"s" [:substring [:field (:id field) nil] 2]}
-                                                   :fields       [[:expression "s"]]
+                                          {:query {:source-query {:source-table (:id table)
+                                                                  :expressions  {"s" [:substring [:field (:id field) nil] 2]}
+                                                                  :fields       [[:field (:id field) nil]
+                                                                                 [:expression "s"]]}
+                                                   :fields       [[:field "s" {:base-type :type/Text}]]
                                                    :limit        3}})]
           (testing (format "Honey SQL =\n%s" (u/pprint-to-str hsql))
             (is (= [["SELECT"

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -1630,8 +1630,8 @@
   [_driver inner-query]
   (-> inner-query
       maybe-nest-breakouts-in-queries-with-window-fn-aggregations
-      add/add-alias-info
-      nest-query/nest-expressions))
+      nest-query/nest-expressions
+      add/add-alias-info))
 
 (defn mbql->honeysql
   "Build the HoneySQL form we will compile to SQL and execute."

--- a/src/metabase/query_processor/util/nest_query.clj
+++ b/src/metabase/query_processor/util/nest_query.clj
@@ -6,175 +6,24 @@
    (This namespace is here rather than in the shared MBQL lib because it relies on other QP-land utils like the QP
   refs stuff.)"
   (:require
-   [clojure.walk :as walk]
-   [medley.core :as m]
-   [metabase.api.common :as api]
-   [metabase.legacy-mbql.util :as mbql.u]
+   [metabase.legacy-mbql.schema :as mbql.s]
+   [metabase.lib.convert :as lib.convert]
    [metabase.lib.metadata :as lib.metadata]
-   [metabase.lib.util.match :as lib.util.match]
-   [metabase.query-processor.middleware.annotate :as annotate]
-   [metabase.query-processor.middleware.resolve-joins :as qp.middleware.resolve-joins]
+   [metabase.lib.query :as lib.query]
    [metabase.query-processor.store :as qp.store]
-   [metabase.query-processor.util.add-alias-info :as add]
+   [metabase.query-processor.util.transformations.nest-expressions :as transformations.nest-expressions]
    [metabase.util :as u]
-   [metabase.util.log :as log]))
+   [metabase.util.malli :as mu]))
 
-(defn- joined-fields [inner-query]
-  (m/distinct-by
-   add/normalize-clause
-   (lib.util.match/match (walk/prewalk (fn [x]
-                                 (if (map? x)
-                                   (dissoc x :source-query :source-metadata)
-                                   x))
-                               inner-query)
-     [:field _ (_ :guard :join-alias)]
-     &match)))
-
-(defn- keep-source+alias-props [field]
-  (update field 2 select-keys [::add/source-alias ::add/source-table :join-alias]))
-
-(defn- nfc-root [[_ field-id]]
-  (when-let [field (and (int? field-id)
-                        (lib.metadata/field (qp.store/metadata-provider) field-id))]
-    (when-let [nfc-root (first (:nfc-path field))]
-      {:table_id (:table-id field)
-       :name nfc-root})))
-
-(defn- field-id-props [[_ field-id]]
-  (when-let [field (and (int? field-id)
-                        (lib.metadata/field (qp.store/metadata-provider) field-id))]
-    {:table_id (:table-id field)
-     :name     (:name field)}))
-
-(defn- remove-unused-fields [inner-query source]
-  (let [used-fields (into #{}
-                          (map keep-source+alias-props)
-                          (lib.util.match/match inner-query #{:field :expression}))
-        nfc-roots (into #{} (keep nfc-root) used-fields)]
-    (log/debugf "Used fields:\n%s" (u/pprint-to-str used-fields))
-    (letfn [(used? [[_tag id-or-name {::add/keys [desired-alias], :as opts}, :as field]]
-              (or (contains? used-fields (keep-source+alias-props field))
-                  ;; we should also consider a Field to be used if we're referring to it with a nominal field literal
-                  ;; ref in the next stage -- that's actually how you're supposed to be doing it anyway.
-                  (when (integer? id-or-name)
-                    (let [nominal-ref (keep-source+alias-props [:field desired-alias opts])]
-                      (contains? used-fields nominal-ref)))
-                  (contains? nfc-roots (field-id-props field))))
-            (used?* [field]
-              (u/prog1 (used? field)
-                (if <>
-                  (log/debugf "Keeping used field:\n%s" (u/pprint-to-str field))
-                  (log/debugf "Removing unused field:\n%s" (u/pprint-to-str (keep-source+alias-props field))))))
-            (remove-unused [fields]
-              (filterv used?* fields))]
-      (update source :fields remove-unused))))
-
-(defn- nest-source [inner-query]
-  (let [filter-clause (:filter inner-query)
-        keep-filter? (nil? (lib.util.match/match-one filter-clause :expression))
-        source (as-> (select-keys inner-query [:source-table :source-query :source-metadata :joins :expressions]) source
-                 ;; preprocess this without a current user context so it's not subject to permissions checks. To get
-                 ;; here in the first place we already had to do perms checks to make sure the query we're transforming
-                 ;; is itself ok, so we don't need to run another check
-                 (binding [api/*current-user-id* nil]
-                   ((requiring-resolve 'metabase.query-processor.preprocess/preprocess)
-                    {:database (u/the-id (lib.metadata/database (qp.store/metadata-provider)))
-                     :type     :query
-                     :query    source}))
-                 (add/add-alias-info source)
-                 (:query source)
-                 (dissoc source :limit)
-                 (qp.middleware.resolve-joins/append-join-fields-to-fields source (joined-fields inner-query))
-                 (remove-unused-fields inner-query source)
-                 (cond-> source
-                   keep-filter? (assoc :filter filter-clause)))]
-    (-> inner-query
-        (dissoc :source-table :source-metadata :joins)
-        (assoc :source-query source)
-        (cond-> keep-filter? (dissoc :filter)))))
-
-(defn- raise-source-query-expression-ref
-  "Convert an `:expression` reference from a source query into an appropriate `:field` clause for use in the surrounding
-  query."
-  [{:keys [source-query], :as query} [_ expression-name opts :as _clause]]
-  (let [expression-definition        (mbql.u/expression-with-name query expression-name)
-        {base-type :base_type}       (some-> expression-definition annotate/infer-expression-type)
-        {::add/keys [desired-alias]} (lib.util.match/match-one source-query
-                                       [:expression (_ :guard (partial = expression-name)) source-opts]
-                                       source-opts)
-        source-alias                 (or desired-alias expression-name)]
-    [:field
-     source-alias
-     (-> opts
-         (assoc :base-type          (or base-type :type/*)
-                ::add/source-table  ::add/source
-                ::add/source-alias  source-alias))]))
-
-(defn- rewrite-fields-and-expressions [query]
-  (lib.util.match/replace query
-    ;; don't rewrite anything inside any source queries or source metadata.
-    (_ :guard (constantly (some (partial contains? (set &parents))
-                                [:source-query :source-metadata])))
-    &match
-
-    :expression
-    (raise-source-query-expression-ref query &match)
-
-    ;; mark all Fields at the new top level as `:qp/ignore-coercion` so QP implementations know not to apply coercion or
-    ;; whatever to them a second time.
-    [:field _id-or-name (_opts :guard (every-pred :temporal-unit (complement :qp/ignore-coercion)))]
-    (recur (mbql.u/update-field-options &match assoc :qp/ignore-coercion true))
-
-    [:field id-or-name (opts :guard :join-alias)]
-    (let [{::add/keys [desired-alias]} (lib.util.match/match-one (:source-query query)
-                                         [:field
-                                          (_ :guard (partial = id-or-name))
-                                          (matching-opts :guard #(= (:join-alias %) (:join-alias opts)))]
-                                         matching-opts)]
-      [:field id-or-name (cond-> opts
-                           desired-alias (assoc ::add/source-alias desired-alias
-                                                ::add/desired-alias desired-alias))])
-
-    ;; when recursing into joins use the refs from the parent level.
-    (m :guard (every-pred map? :joins))
-    (let [{:keys [joins]} m]
-      (-> (dissoc m :joins)
-          rewrite-fields-and-expressions
-          (assoc :joins (mapv (fn [join]
-                                (assoc join :qp/refs (:qp/refs query)))
-                              joins))))))
-
-(defn- should-nest-expressions?
-  "Whether we should nest the expressions in a inner query; true if
-
-  1. there are some expression definitions in the inner query, AND
-
-  2. there are some breakouts OR some aggregations in the inner query
-
-  3. AND the breakouts/aggregations contain at least `:expression` reference."
-  [{:keys [expressions], breakouts :breakout, aggregations :aggregation, :as _inner-query}]
-  (and
-   ;; 1. has some expression definitions
-   (seq expressions)
-   ;; 2. has some breakouts or aggregations
-   (or (seq breakouts)
-       (seq aggregations))
-   ;; 3. contains an `:expression` ref
-   (lib.util.match/match-one (concat breakouts aggregations)
-                             :expression)))
-
-(defn nest-expressions
+(mu/defn nest-expressions :- mbql.s/MBQLQuery
   "Pushes the `:source-table`/`:source-query`, `:expressions`, and `:joins` in the top-level of the query into a
   `:source-query` and updates `:expression` references and `:field` clauses with `:join-alias`es accordingly. See
   tests for examples. This is used by the SQL QP to make sure expressions happen in a subselect."
-  [inner-query]
-  (let [{:keys [expressions], :as inner-query} (m/update-existing inner-query :source-query nest-expressions)]
-    (if-not (should-nest-expressions? inner-query)
-      inner-query
-      (let [{:keys [source-query], :as inner-query} (nest-source inner-query)
-            inner-query                                   (rewrite-fields-and-expressions inner-query)
-            source-query                            (assoc source-query :expressions expressions)]
-        (-> inner-query
-            (dissoc :source-query :expressions)
-            (assoc :source-query source-query)
-            add/add-alias-info)))))
+  [inner-query :- mbql.s/MBQLQuery]
+  (let [mlv2-query (lib.query/query-from-legacy-inner-query
+                    (qp.store/metadata-provider)
+                    (u/the-id (lib.metadata/database (qp.store/metadata-provider)))
+                    inner-query)]
+    (-> (transformations.nest-expressions/nest-expressions mlv2-query)
+        lib.convert/->legacy-MBQL
+        :query)))

--- a/src/metabase/query_processor/util/transformations/nest_expressions.clj
+++ b/src/metabase/query_processor/util/transformations/nest_expressions.clj
@@ -1,0 +1,176 @@
+(ns metabase.query-processor.util.transformations.nest-expressions
+  (:require
+   [medley.core :as m]
+   [metabase.lib.core :as lib]
+   [metabase.lib.equality :as lib.equality]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.options :as lib.options]
+   [metabase.lib.schema :as lib.schema]
+   [metabase.lib.schema.metadata :as lib.schema.metadata]
+   [metabase.lib.util.match :as lib.util.match]
+   [metabase.lib.walk :as lib.walk]
+   [metabase.util :as u]
+   [metabase.util.log :as log]
+   [metabase.util.malli :as mu]))
+
+(def ^:private first-stage-keys
+  "Keys from the original stage to keep in the new first stage. Other keys will get moved to the second stage."
+  #{:joins :expressions :source-table :source-card :sources :filters})
+
+(mu/defn ^:private first-stage-ref :- [:maybe [:or :mbql.clause/field :mbql.clause/expression]]
+  [column-metadata :- ::lib.schema.metadata/column]
+  (when-not (#{:source/aggregations} (:lib/source column-metadata))
+    (-> column-metadata
+        lib/ref
+        (lib.options/update-options
+         merge
+         ;; make sure we specify default date bucketing here so QP preprocessing doesn't try to switch this to day
+         ;; bucketing without our knowledge.
+         (when (isa? ((some-fn :effective-type :base-type) column-metadata) :type/Temporal)
+           {:temporal-unit :default})))))
+
+(mu/defn ^:private new-first-stage :- ::lib.schema/stage
+  [stage        :- ::lib.schema/stage
+   used-columns :- [:sequential {:min 1} ::lib.schema.metadata/column]]
+  (-> stage
+      (select-keys (conj first-stage-keys :lib/type))
+      (assoc :fields (into []
+                           (keep first-stage-ref)
+                           used-columns))))
+
+(mu/defn ^:private second-stage-ref :- :mbql.clause/field
+  [[_tag opts :as original-ref] :- [:or :mbql.clause/field :mbql.clause/expression]
+   column-metadata              :- ::lib.schema.metadata/column
+   options                      :- [:maybe :map]]
+  (u/prog1 (-> column-metadata
+               (assoc :lib/source              :source/previous-stage
+                      :lib/source-column-alias (:lib/desired-column-alias column-metadata))
+               (lib/with-join-alias nil)
+               lib/ref
+               (lib.options/update-options merge
+                                           (dissoc opts
+                                                   :lib/uuid
+                                                   :join-alias
+                                                   ;; throw out the add-alias info stuff so it has to be recalculated if
+                                                   ;; it's present.
+                                                   :metabase.query-processor.util.add-alias-info/source-table
+                                                   :metabase.query-processor.util.add-alias-info/source-alias
+                                                   :metabase.query-processor.util.add-alias-info/desired-alias
+                                                   :metabase.query-processor.util.add-alias-info/position)))
+    (when (:log? options true)
+      (log/tracef "Rewrote\n%s=>\n%s" (u/pprint-to-str original-ref) (u/pprint-to-str <>)))))
+
+(mu/defn ^:private second-stage-ref-using-visible-columns :- [:or :mbql.clause/field :mbql.clause/expression]
+  [metadata-providerable   :- ::lib.schema.metadata/metadata-providerable
+   [tag, :as original-ref] :- [:or :mbql.clause/field :mbql.clause/expression]
+   visible-columns         :- [:sequential ::lib.schema.metadata/column]
+   options                 :- [:maybe :map]]
+  (if-let [col (or (lib.equality/find-matching-column original-ref visible-columns)
+                   ;; workaround busted queries using `:field` clauses with Field ID even when there are source
+                   ;; query stages.
+                   (do
+                     (log/warnf "Failed to find matching column for ref %s, fetching metadata using Field ID"
+                                (pr-str original-ref))
+                     (when (= tag :field)
+                       (let [[_tag _opts id-or-name] original-ref]
+                         (when (pos-int? id-or-name)
+                           (lib.metadata/field metadata-providerable id-or-name))))))]
+    (second-stage-ref original-ref col options)
+    (do
+      (log/warnf "Error nesting expressions: cannot find match for clause:\n\n%s" (u/pprint-to-str original-ref))
+      (log/debugf "Candidates:\n%s" (u/pprint-to-str visible-columns))
+      original-ref)))
+
+(mu/defn ^:private new-second-stage :- ::lib.schema/stage
+  [metadata-providerable :- ::lib.schema.metadata/metadata-providerable
+   stage                 :- ::lib.schema/stage
+   visible-columns       :- [:sequential ::lib.schema.metadata/column]
+   options               :- [:maybe :map]]
+  (let [stage                 (apply dissoc stage first-stage-keys)
+        visible-expressions   (filter #(= (:lib/source %) :source/expressions)
+                                      visible-columns)
+        other-visible-columns (remove #(= (:lib/source %) :source/expressions)
+                                      visible-columns)]
+    (merge
+     (select-keys stage [:lib/stage-metadata])
+     (lib.util.match/replace (dissoc stage :lib/stage-metadata)
+       #{:expression :field}
+       (let [[tag] &match
+             cols  (case tag
+                     :expression visible-expressions
+                     :field      other-visible-columns)]
+         (second-stage-ref-using-visible-columns metadata-providerable &match cols options))))))
+
+(defn- should-nest-expressions?
+  "Whether we should nest the expressions in a stage; true if
+
+  1. there are some expression definitions in the stage, AND
+
+  2. there are some breakouts OR some aggregations in the stage
+
+  3. AND the breakouts/aggregations contain at least `:expression` reference."
+  [query stage-path]
+  (let [expressions (lib.walk/apply-f-for-stage-at-path lib/expressions query stage-path)]
+    (and
+     ;; 1. has some expression definitions
+     (seq expressions)
+     (let [breakouts    (lib.walk/apply-f-for-stage-at-path lib/breakouts query stage-path)
+           aggregations (lib.walk/apply-f-for-stage-at-path lib/aggregations query stage-path)]
+       (and
+        ;; 2. has some breakouts or aggregations
+        (or (seq breakouts)
+            (seq aggregations))
+        ;; 3. contains an `:expression` ref
+        (lib.util.match/match-one (concat breakouts aggregations)
+          :expression))))))
+
+(mu/defn ^:private nest-expressions-in-stage :- [:maybe [:sequential {:min 2, :max 2} ::lib.schema/stage]]
+  [query :- ::lib.schema/query
+   path  :- ::lib.walk/stage-path
+   stage :- ::lib.schema/stage]
+  (when (should-nest-expressions? query path)
+    (let [visible-columns-with-dupes   (lib.walk/apply-f-for-stage-at-path lib/visible-columns query path)
+          visible-columns              visible-columns-with-dupes
+          ;; do an initial calculation of the second stage so we can determine what we're using in it.
+          second-stage                 (new-second-stage query stage visible-columns {:log? false})
+          ;; calculate the first stage, but only return stuff used in the second stage.
+          used-column-names            (into #{} (lib.util.match/match second-stage
+                                                   [:field _opts (field-name :guard string?)]
+                                                   field-name))
+          _                            (log/debugf "Columns used in second stage: %s" (pr-str used-column-names))
+          used-columns                 (filter #(contains? used-column-names (:lib/desired-column-alias %))
+                                               visible-columns)
+          _                            (when-not (= (count used-column-names)
+                                                    (count used-columns))
+                                         (log/warn (str "Error determining used columns: could not match up some used column names.\n"
+                                                        "This query may not return the correct columns.\n"
+                                                        "original stage:\n"
+                                                        (u/pprint-to-str (get-in query path)) \newline
+                                                        "visible columns:\n"
+                                                        (u/pprint-to-str visible-columns) \newline
+                                                        "new second stage:\n"
+                                                        (u/pprint-to-str second-stage) \newline
+                                                        "used column names:\n"
+                                                        (u/pprint-to-str used-column-names) \newline
+                                                        "reconciled used columns:\n"
+                                                        (u/pprint-to-str used-columns))))
+          first-stage                  (new-first-stage stage used-columns)
+          ;; recalculate the second stage using the correct returned columns for the first stage so the column aliases
+          ;; line up. Ignore the `:fields` from `:joins`, since the relevant stuff should already be copied over into
+          ;; `:fields` -- if we don't ignore them we can end up with duplicates.
+          first-stage-returned-columns (let [first-stage (m/update-existing first-stage :joins (fn [joins]
+                                                                                                 (mapv (fn [join]
+                                                                                                         (assoc join :fields :none))
+                                                                                                       joins)))
+                                             query       (assoc-in query path first-stage)]
+                                         (lib.walk/apply-f-for-stage-at-path lib/returned-columns query path))
+          second-stage                 (new-second-stage query stage first-stage-returned-columns {:log? true})]
+      (log/debugf "New first stage:\n%s" (u/pprint-to-str first-stage))
+      (log/debugf "New second stage:\n%s" (u/pprint-to-str second-stage))
+      [first-stage second-stage])))
+
+(mu/defn nest-expressions :- ::lib.schema/query
+  "If any `:expressions` appear in a query stage, introduce another stage including just the `:expressions` and any
+  `:joins`; update `:fields`, `:aggregation`, and `:breakout` to refer to updated references."
+  [query :- ::lib.schema/query]
+  (lib.walk/walk-stages query nest-expressions-in-stage))

--- a/src/metabase/util/malli/schema.clj
+++ b/src/metabase/util/malli/schema.clj
@@ -161,8 +161,9 @@
                  (isa? k :Relation/*))))]
     (deferred-tru "value must be a valid field semantic or relation type (keyword or string).")))
 
-(def Field
-  "Schema for a valid Field for API usage."
+(def LegacyFieldOrExpressionReference
+  "Schema for a valid legacy `:field` or `:expression` reference for API usage. TODO -- why are these passed into the
+  REST API at all? MBQL clauses are not things we should ask for as API parameters."
   (mu/with-api-error-message
     [:fn (fn [k]
            ((comp (mc/validator mbql.s/Field)
@@ -271,8 +272,8 @@
     [:map
      [:values {:optional true} [:* :any]]
      [:card_id {:optional true} PositiveInt]
-     [:value_field {:optional true} Field]
-     [:label_field {:optional true} Field]]))
+     [:value_field {:optional true} LegacyFieldOrExpressionReference]
+     [:label_field {:optional true} LegacyFieldOrExpressionReference]]))
 
 (def RemappedFieldValue
   "Has two components:

--- a/test/metabase/driver/sql/query_processor_test.clj
+++ b/test/metabase/driver/sql/query_processor_test.clj
@@ -373,22 +373,14 @@
                     source.LONGITUDE   AS LONGITUDE
                     source.PRICE       AS PRICE
                     source.double_id   AS double_id]
-           :from   [{:select [source.ID          AS ID
-                              source.NAME        AS NAME
-                              source.CATEGORY_ID AS CATEGORY_ID
-                              source.LATITUDE    AS LATITUDE
-                              source.LONGITUDE   AS LONGITUDE
-                              source.PRICE       AS PRICE
-                              source.double_id   AS double_id]
-                     :from   [{:select [VENUES.ID AS ID
-                                        VENUES.NAME AS NAME
-                                        VENUES.CATEGORY_ID AS CATEGORY_ID
-                                        VENUES.LATITUDE    AS LATITUDE
-                                        VENUES.LONGITUDE   AS LONGITUDE
-                                        VENUES.PRICE       AS PRICE
-                                        VENUES.ID * 2      AS double_id]
-                               :from   [VENUES]}
-                              AS source]}
+           :from   [{:select [VENUES.ID          AS ID
+                              VENUES.NAME        AS NAME
+                              VENUES.CATEGORY_ID AS CATEGORY_ID
+                              VENUES.LATITUDE    AS LATITUDE
+                              VENUES.LONGITUDE   AS LONGITUDE
+                              VENUES.PRICE       AS PRICE
+                              VENUES.ID * 2      AS double_id]
+                     :from   [VENUES]}
                     AS source]
            :limit  [1]}
          (-> (lib.tu.macros/mbql-query venues
@@ -479,42 +471,30 @@
                sql.qp-test-util/sql->sql-map)))))
 
 (def ^:private reference-aggregation-expressions-in-joins-test-expected-sql
-  '{:select [source.ID                           AS ID
-             source.NAME                         AS NAME
-             source.CATEGORY_ID                  AS CATEGORY_ID
-             source.LATITUDE                     AS LATITUDE
-             source.LONGITUDE                    AS LONGITUDE
-             source.PRICE                        AS PRICE
-             source.RelativePrice                AS RelativePrice
-             source.CategoriesStats__CATEGORY_ID AS CategoriesStats__CATEGORY_ID
-             source.CategoriesStats__MaxPrice    AS CategoriesStats__MaxPrice
-             source.CategoriesStats__AvgPrice    AS CategoriesStats__AvgPrice
-             source.CategoriesStats__MinPrice    AS CategoriesStats__MinPrice]
-    :from   [{:select    [VENUES.ID          AS ID
-                          VENUES.NAME        AS NAME
-                          VENUES.CATEGORY_ID AS CATEGORY_ID
-                          VENUES.LATITUDE    AS LATITUDE
-                          VENUES.LONGITUDE   AS LONGITUDE
-                          VENUES.PRICE       AS PRICE
-                          CAST (VENUES.PRICE AS float)
-                          /
-                          CASE WHEN CategoriesStats.AvgPrice = 0 THEN NULL
-                          ELSE CategoriesStats.AvgPrice END AS RelativePrice
-                          CategoriesStats.CATEGORY_ID AS CategoriesStats__CATEGORY_ID
-                          CategoriesStats.MaxPrice    AS CategoriesStats__MaxPrice
-                          CategoriesStats.AvgPrice    AS CategoriesStats__AvgPrice
-                          CategoriesStats.MinPrice    AS CategoriesStats__MinPrice]
-              :from      [VENUES]
-              :left-join [{:select   [VENUES.CATEGORY_ID AS CATEGORY_ID
-                                      MAX (VENUES.PRICE) AS MaxPrice
-                                      AVG (VENUES.PRICE) AS AvgPrice
-                                      MIN (VENUES.PRICE) AS MinPrice]
-                           :from     [VENUES]
-                           :group-by [VENUES.CATEGORY_ID]
-                           :order-by [VENUES.CATEGORY_ID ASC]} AS CategoriesStats
-                          ON VENUES.CATEGORY_ID = CategoriesStats.CATEGORY_ID]}
-             AS source]
-    :limit  [3]})
+  '{:select    [VENUES.ID          AS ID
+                VENUES.NAME        AS NAME
+                VENUES.CATEGORY_ID AS CATEGORY_ID
+                VENUES.LATITUDE    AS LATITUDE
+                VENUES.LONGITUDE   AS LONGITUDE
+                VENUES.PRICE       AS PRICE
+                CAST (VENUES.PRICE AS float)
+                /
+                CASE WHEN CategoriesStats.AvgPrice = 0 THEN NULL
+                ELSE CategoriesStats.AvgPrice END AS RelativePrice
+                CategoriesStats.CATEGORY_ID AS CategoriesStats__CATEGORY_ID
+                CategoriesStats.MaxPrice    AS CategoriesStats__MaxPrice
+                CategoriesStats.AvgPrice    AS CategoriesStats__AvgPrice
+                CategoriesStats.MinPrice    AS CategoriesStats__MinPrice]
+    :from      [VENUES]
+    :left-join [{:select   [VENUES.CATEGORY_ID AS CATEGORY_ID
+                            MAX (VENUES.PRICE) AS MaxPrice
+                            AVG (VENUES.PRICE) AS AvgPrice
+                            MIN (VENUES.PRICE) AS MinPrice]
+                 :from     [VENUES]
+                 :group-by [VENUES.CATEGORY_ID]
+                 :order-by [VENUES.CATEGORY_ID ASC]} AS CategoriesStats
+                ON VENUES.CATEGORY_ID = CategoriesStats.CATEGORY_ID]
+    :limit     [3]})
 
 (deftest ^:parallel reference-aggregation-expressions-in-joins-test
   (testing "See if we can correctly compile a query that references expressions that come from a join"
@@ -588,12 +568,9 @@
                                    [:expression "test"]]
                      :limit       1})]
         (testing "Generated SQL"
-          (is (= '{:select [source.PRICE AS PRICE
-                            source.test  AS test]
-                   :from   [{:select [TIMESTAMPADD ("second" VENUES.PRICE timestamp "1970-01-01T00:00:00Z") AS PRICE
-                                      1 * 1 AS test]
-                             :from   [VENUES]}
-                            AS source]
+          (is (= '{:select [TIMESTAMPADD ("second" VENUES.PRICE timestamp "1970-01-01T00:00:00Z") AS PRICE
+                            1 * 1 AS test]
+                   :from   [VENUES]
                    :limit  [1]}
                  (-> query mbql->native sql.qp-test-util/sql->sql-map)))
           (testing "Results"
@@ -804,19 +781,14 @@
 
 (deftest ^:parallel floating-point-division-test
   (testing "Make sure FLOATING POINT division is done when dividing by expressions/fields"
-    (is (= '{:select   [source.my_cool_new_field AS my_cool_new_field]
-             :from     [{:select [VENUES.ID          AS ID
-                                  VENUES.PRICE       AS PRICE
-                                  VENUES.PRICE + 2   AS big_price
-                                  CAST
-                                  (VENUES.PRICE AS float)
-                                  /
-                                  CASE WHEN (VENUES.PRICE + 2) = 0 THEN NULL
-                                  ELSE VENUES.PRICE + 2
-                                  END AS my_cool_new_field]
-                         :from   [VENUES]}
-                        AS source]
-             :order-by [source.ID ASC]
+    (is (= '{:select   [CAST
+                        (VENUES.PRICE AS float)
+                        /
+                        CASE WHEN (VENUES.PRICE + 2) = 0 THEN NULL
+                        ELSE VENUES.PRICE + 2
+                        END AS my_cool_new_field]
+             :from     [VENUES]
+             :order-by [VENUES.ID ASC]
              :limit    [3]}
            (-> (lib.tu.macros/mbql-query venues
                  {:expressions {:big_price         [:+ $price 2]
@@ -829,10 +801,8 @@
 
 (deftest ^:parallel floating-point-division-test-2
   (testing "Don't generate unneeded casts to FLOAT for the numerator if it is a number literal"
-    (is (= '{:select [source.my_cool_new_field AS my_cool_new_field]
-             :from   [{:select [2.0 / 4.0 AS my_cool_new_field]
-                       :from   [VENUES]}
-                      AS source]
+    (is (= '{:select [2.0 / 4.0 AS my_cool_new_field]
+             :from   [VENUES]
              :limit  [1]}
            (-> (lib.tu.macros/mbql-query venues
                  {:expressions {:my_cool_new_field [:/ 2 4]}
@@ -900,30 +870,22 @@
                            Q1.CC           AS Q1__CC]
                :from      [{:select [source.CATEGORY AS CATEGORY
                                      source.count    AS count
-                                     source.CC       AS CC]
-                            :from   [{:select [source.CATEGORY AS CATEGORY
-                                               source.count    AS count
-                                               1 + 1           AS CC]
-                                      :from   [{:select   [PRODUCTS.CATEGORY AS CATEGORY
-                                                           COUNT (*)         AS count]
-                                                :from     [PRODUCTS]
-                                                :group-by [PRODUCTS.CATEGORY]
-                                                :order-by [PRODUCTS.CATEGORY ASC]}
-                                               AS source]}
+                                     1 + 1           AS CC]
+                            :from   [{:select   [PRODUCTS.CATEGORY AS CATEGORY
+                                                 COUNT (*)         AS count]
+                                      :from     [PRODUCTS]
+                                      :group-by [PRODUCTS.CATEGORY]
+                                      :order-by [PRODUCTS.CATEGORY ASC]}
                                      AS source]}
                            AS source]
                :left-join [{:select [source.CATEGORY AS CATEGORY
                                      source.count    AS count
-                                     source.CC       AS CC]
-                            :from   [{:select [source.CATEGORY AS CATEGORY
-                                               source.count    AS count
-                                               1 + 1           AS CC]
-                                      :from   [{:select   [PRODUCTS.CATEGORY AS CATEGORY
-                                                           COUNT (*)         AS count]
-                                                :from     [PRODUCTS]
-                                                :group-by [PRODUCTS.CATEGORY]
-                                                :order-by [PRODUCTS.CATEGORY ASC]}
-                                               AS source]}
+                                     1 + 1           AS CC]
+                            :from   [{:select   [PRODUCTS.CATEGORY AS CATEGORY
+                                                 COUNT (*)         AS count]
+                                      :from     [PRODUCTS]
+                                      :group-by [PRODUCTS.CATEGORY]
+                                      :order-by [PRODUCTS.CATEGORY ASC]}
                                      AS source]}
                            AS Q1 ON source.CC = Q1.CC]
                :limit     [1]}

--- a/test/metabase/models/params/custom_values_test.clj
+++ b/test/metabase/models/params/custom_values_test.clj
@@ -9,7 +9,7 @@
 
 ;;; --------------------------------------------- source=card ----------------------------------------------
 
-(deftest with-mbql-card-test
+(deftest ^:parallel with-mbql-card-test
   (doseq [model? [true false]]
     (testing (format "source card is a %s" (if model? "model" "question"))
       (binding [custom-values/*max-rows* 3]
@@ -33,7 +33,7 @@
                       (mt/$ids $venues.name)
                       "bakery"))))))))))
 
-(deftest with-mbql-card-test-2
+(deftest ^:parallel with-mbql-card-test-2
   (doseq [model? [true false]]
     (testing (format "source card is a %s" (if model? "model" "question"))
       (binding [custom-values/*max-rows* 3]
@@ -73,7 +73,7 @@
                       [:field (mt/id :categories :name) {:source-field (mt/id :venues :category_id)}]
                       "bakery"))))))))))
 
-(deftest with-mbql-card-test-3
+(deftest ^:parallel with-mbql-card-test-3
   (doseq [model? [true false]]
     (testing (format "source card is a %s" (if model? "model" "question"))
       (binding [custom-values/*max-rows* 3]
@@ -100,7 +100,7 @@
                         (mt/$ids $venues.category_id)
                         2)))))))))))
 
-(deftest with-native-card-test
+(deftest ^:parallel with-native-card-test
   (doseq [model? [true false]]
     (testing (format "source card is a %s with native question" (if model? "model" "question"))
       (binding [custom-values/*max-rows* 3]

--- a/test/metabase/query_processor/util/transformations/nest_expressions_test.clj
+++ b/test/metabase/query_processor/util/transformations/nest_expressions_test.clj
@@ -1,0 +1,101 @@
+(ns metabase.query-processor.util.transformations.nest-expressions-test
+  "Additional tests are in [[metabase.query-processor.util.nest-query-test]]."
+  (:require
+   [clojure.test :refer :all]
+   [metabase.lib.core :as lib]
+   [metabase.lib.query :as lib.query]
+   [metabase.lib.test-metadata :as meta]
+   [metabase.lib.test-util.macros :as lib.tu.macros]
+   [metabase.query-processor.middleware.deduplicate-expression-names :as qp.deduplicate-expression-names]
+   [metabase.query-processor.util.transformations.nest-expressions :as nest-expressions]))
+
+(deftest ^:parallel nest-expressions-with-joins-test
+  (let [query (lib.query/query
+               meta/metadata-provider
+               (lib.tu.macros/mbql-query orders
+                 {:aggregation [[:aggregation-options [:count] {:name "count"}]]
+                  :breakout    [&PRODUCTS__via__PRODUCT_ID.products.category
+                                !year.created-at
+                                [:expression "pivot-grouping"]]
+                  :expressions {"pivot-grouping" [:abs 0]}
+                  :order-by    [[:asc &PRODUCTS__via__PRODUCT_ID.products.category]
+                                [:asc !year.created-at]
+                                [:asc [:expression "pivot-grouping"]]]
+                  :joins       [{:source-table $$products
+                                 :strategy     :left-join
+                                 :alias        "PRODUCTS__via__PRODUCT_ID"
+                                 :fk-field-id  %product-id
+                                 :condition    [:= $product-id &PRODUCTS__via__PRODUCT_ID.products.id]
+                                 :fields       :all}]}))]
+    (is (=? {:stages [{:lib/type     :mbql.stage/mbql
+                       :joins        [{:strategy    :left-join
+                                       :alias       "PRODUCTS__via__PRODUCT_ID"
+                                       :conditions  [[:=
+                                                      {}
+                                                      [:field {} (meta/id :orders :product-id)]
+                                                      [:field {:join-alias "PRODUCTS__via__PRODUCT_ID"} (meta/id :products :id)]]]
+                                       :stages      [{:source-table (meta/id :products)}]
+                                       :lib/options {}}]
+                       :expressions  [[:abs {:lib/expression-name "pivot-grouping"} 0]]
+                       :fields       [[:field {} (meta/id :orders :created-at)]
+                                      [:expression {} "pivot-grouping"]
+                                      [:field {:join-alias "PRODUCTS__via__PRODUCT_ID"} (meta/id :products :category)]]}
+                      {:aggregation [[:count {:name "count"}]]
+                       :breakout    [[:field {} "PRODUCTS__via__PRODUCT_ID__CATEGORY"]
+                                     [:field {} "CREATED_AT"]
+                                     [:field {} "pivot-grouping"]]
+                       :order-by [[:asc {} [:field {} "PRODUCTS__via__PRODUCT_ID__CATEGORY"]]
+                                  [:asc {} [:field {} "CREATED_AT"]]
+                                  [:asc {} [:field {} "pivot-grouping"]]]}]}
+            (nest-expressions/nest-expressions query)))))
+
+(deftest ^:parallel nested-expressions-with-existing-names-test
+  (testing "Expressions with the same name as existing columns should work correctly in nested queries (#21131)"
+    ;; (when combined with [[qp.deduplicate-expression-names/deduplicate-expression-names]] middleware)
+    (let [query (lib.query/query
+                 meta/metadata-provider
+                 (lib.tu.macros/mbql-query products
+                   {:source-query {:source-table $$products
+                                   :expressions  {"PRICE" [:+ $price 2]}
+                                   :breakout     [$id $price [:expression "PRICE"]]
+                                   :order-by     [[:asc $id]]
+                                   :limit        2}}))]
+      (is (=? {:stages [{:expressions [[:+
+                                        {:lib/expression-name "PRICE_2"} ; expression needs to get renamed to fix conflict
+                                        [:field {} (meta/id :products :price)]
+                                        2]]
+                         :fields      [[:field {} (meta/id :products :id)]
+                                       [:field {} (meta/id :products :price)]
+                                       [:expression {} "PRICE_2"]]}
+                        {:lib/type :mbql.stage/mbql
+                         :breakout [[:field {} "ID"]
+                                    [:field {} "PRICE"]
+                                    [:field {} "PRICE_2"]]
+                         :order-by [[:asc {} [:field {} "ID"]]]
+                         :limit 2}
+                        {:lib/type :mbql.stage/mbql}]}
+              (-> query
+                  qp.deduplicate-expression-names/deduplicate-expression-names
+                  nest-expressions/nest-expressions))))))
+
+(deftest ^:parallel nested-expressions-with-existing-names-test-2
+  (testing "Expressions with the same name as existing columns but different case should work as well (#21131)"
+    (let [query (lib.tu.macros/mbql-query products
+                  {:source-query {:source-table $$products
+                                  :expressions  {"price" [:+ $price 2]}
+                                  :breakout     [$id $price [:expression "price"]]}})
+          query (lib/query meta/metadata-provider query)]
+      (is (=? {:stages [{:expressions [[:+
+                                        {:lib/expression-name "price_2"}
+                                        [:field {} (meta/id :products :price)]
+                                        2]]
+                         :fields [[:field {} (meta/id :products :id)]
+                                  [:field {} (meta/id :products :price)]
+                                  [:expression {} "price_2"]]}
+                        {:breakout [[:field {} "ID"]
+                                    [:field {} "PRICE"]
+                                    [:field {} "price_2"]]}
+                        {}]}
+              (-> query
+                  qp.deduplicate-expression-names/deduplicate-expression-names
+                  nest-expressions/nest-expressions))))))

--- a/test/metabase/query_processor/util/transformations/nest_expressions_test.clj
+++ b/test/metabase/query_processor/util/transformations/nest_expressions_test.clj
@@ -6,7 +6,6 @@
    [metabase.lib.query :as lib.query]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util.macros :as lib.tu.macros]
-   [metabase.query-processor.middleware.deduplicate-expression-names :as qp.deduplicate-expression-names]
    [metabase.query-processor.util.transformations.nest-expressions :as nest-expressions]))
 
 (deftest ^:parallel nest-expressions-with-joins-test
@@ -51,51 +50,29 @@
 
 (deftest ^:parallel nested-expressions-with-existing-names-test
   (testing "Expressions with the same name as existing columns should work correctly in nested queries (#21131)"
-    ;; (when combined with [[qp.deduplicate-expression-names/deduplicate-expression-names]] middleware)
-    (let [query (lib.query/query
-                 meta/metadata-provider
-                 (lib.tu.macros/mbql-query products
-                   {:source-query {:source-table $$products
-                                   :expressions  {"PRICE" [:+ $price 2]}
-                                   :breakout     [$id $price [:expression "PRICE"]]
-                                   :order-by     [[:asc $id]]
-                                   :limit        2}}))]
-      (is (=? {:stages [{:expressions [[:+
-                                        {:lib/expression-name "PRICE_2"} ; expression needs to get renamed to fix conflict
-                                        [:field {} (meta/id :products :price)]
-                                        2]]
-                         :fields      [[:field {} (meta/id :products :id)]
-                                       [:field {} (meta/id :products :price)]
-                                       [:expression {} "PRICE_2"]]}
-                        {:lib/type :mbql.stage/mbql
-                         :breakout [[:field {} "ID"]
-                                    [:field {} "PRICE"]
-                                    [:field {} "PRICE_2"]]
-                         :order-by [[:asc {} [:field {} "ID"]]]
-                         :limit 2}
-                        {:lib/type :mbql.stage/mbql}]}
-              (-> query
-                  qp.deduplicate-expression-names/deduplicate-expression-names
-                  nest-expressions/nest-expressions))))))
-
-(deftest ^:parallel nested-expressions-with-existing-names-test-2
-  (testing "Expressions with the same name as existing columns but different case should work as well (#21131)"
-    (let [query (lib.tu.macros/mbql-query products
-                  {:source-query {:source-table $$products
-                                  :expressions  {"price" [:+ $price 2]}
-                                  :breakout     [$id $price [:expression "price"]]}})
-          query (lib/query meta/metadata-provider query)]
-      (is (=? {:stages [{:expressions [[:+
-                                        {:lib/expression-name "price_2"}
-                                        [:field {} (meta/id :products :price)]
-                                        2]]
-                         :fields [[:field {} (meta/id :products :id)]
-                                  [:field {} (meta/id :products :price)]
-                                  [:expression {} "price_2"]]}
-                        {:breakout [[:field {} "ID"]
-                                    [:field {} "PRICE"]
-                                    [:field {} "price_2"]]}
-                        {}]}
-              (-> query
-                  qp.deduplicate-expression-names/deduplicate-expression-names
-                  nest-expressions/nest-expressions))))))
+    (doseq [expression-name ["PRICE"
+                             "price"]]
+      (let [query (lib.query/query
+                   meta/metadata-provider
+                    (lib.tu.macros/mbql-query products
+                      {:source-query {:source-table $$products
+                                      :expressions  {expression-name [:+ $price 2]}
+                                      :breakout     [$id $price [:expression expression-name]]
+                                      :order-by     [[:asc $id]]
+                                      :limit        2}}))]
+        (is (=? {:stages [{:expressions [[:+
+                                          {:lib/expression-name expression-name} ; expression needs to get renamed to fix conflict
+                                          [:field {} (meta/id :products :price)]
+                                          2]]
+                           :fields      [[:field {} (meta/id :products :id)]
+                                         [:field {} (meta/id :products :price)]
+                                         [:expression {} expression-name]]}
+                          {:lib/type :mbql.stage/mbql
+                           :breakout [[:field {} "ID"]
+                                      [:field {} "PRICE"]    ; the original field
+                                      [:field {} (str expression-name "_2")]] ; the expression
+                           :order-by [[:asc {} [:field {} "ID"]]]
+                           :limit 2}
+                          {:lib/type :mbql.stage/mbql}]}
+                (-> query
+                    nest-expressions/nest-expressions)))))))

--- a/test/metabase/query_processor/util/transformations/nest_expressions_test.clj
+++ b/test/metabase/query_processor/util/transformations/nest_expressions_test.clj
@@ -2,7 +2,6 @@
   "Additional tests are in [[metabase.query-processor.util.nest-query-test]]."
   (:require
    [clojure.test :refer :all]
-   [metabase.lib.core :as lib]
    [metabase.lib.query :as lib.query]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util.macros :as lib.tu.macros]

--- a/test/metabase/util/malli/schema_test.clj
+++ b/test/metabase/util/malli/schema_test.clj
@@ -42,7 +42,7 @@
            {:schema        ms/FieldSemanticTypeKeywordOrString
             :failed-cases  [1 :type/FK]
             :success-cases [:type/Category "type/Category"]}
-           {:schema        ms/Field
+           {:schema        ms/LegacyFieldOrExpressionReference
             :failed-cases  [[:aggregation 0] [:field "name" {}]]
             :success-cases [[:field 3 nil] ["field" "name" {:base-type :type/Float}]]}
            {:schema        ms/Map


### PR DESCRIPTION
Convert `nest-query` query transformation logic to MLv2

This is a simplified version of PR #40988

The logic here is simpler and easier to follow/test compared to the old stuff, and has the added benefit of not including columns in the new first stage that we don't end up using in the new second stage, as you can see in the test changes

Fixes #42205