### PR TITLE
Silence `abs` warning on startup

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -244,7 +244,7 @@
     criterium/criterium          {:mvn/version "0.4.6"}                     ; benchmarking library
     lambdaisland/deep-diff2      {:mvn/version "2.11.216"}                  ; way better diffs
     methodical/methodical        {:mvn/version "0.15.1"}                    ; drop-in replacements for Clojure multimethods and adds several advanced features
-    org.clojure/algo.generic     {:mvn/version "1.0.0"}
+    org.clojure/algo.generic     {:mvn/version "1.0.1"}
     peridot/peridot              {:git/url "https://github.com/piranha/peridot.git"
                                   :sha "999d0a02425c906c35bace749654dc095ecf3e6a"} ; mocking Ring requests; waiting for upstream release of commit 0fc7c01 (explicit charset)
     pjstadig/humane-test-output  {:mvn/version "0.11.0"}


### PR DESCRIPTION
before:

```clojure
❯ clj -M:"$ALIASES"
Warning: environ value /Users/dan/.sdkman/candidates/java/current for key :java-home has been overwritten with /Users/dan/.sdkman/candidates/java/21.0.2-tem
WARNING: abs already refers to: #'clojure.core/abs in namespace: clojure.algo.generic.math-functions, being replaced by: #'clojure.algo.generic.math-functions/abs
2024-05-07 04:39:37,890 INFO metabase.util :: Maximum memory available to JVM: 8.0 GB
```

after:

```clojure
❯ clj -M:"$ALIASES"
Warning: environ value /Users/dan/.sdkman/candidates/java/current for key :java-home has been overwritten with /Users/dan/.sdkman/candidates/java/21.0.2-tem
2024-05-07 04:40:42,561 INFO metabase.util :: Maximum memory available to JVM: 8.0 GB
```

Now no warning about `abs`
