### PR TITLE
Allow duplicate "combine column" columns in chill mode

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/combine-column.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/combine-column.cy.spec.js
@@ -1,4 +1,5 @@
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   describeWithSnowplow,
   expectGoodSnowplowEvent,
@@ -8,6 +9,8 @@ import {
   resetSnowplow,
   restore,
 } from "e2e/support/helpers";
+
+const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
 
 describeWithSnowplow(
   "scenarios > visualizations > drillthroughs > table_drills > combine columns",
@@ -88,16 +91,16 @@ describeWithSnowplow(
     });
 
     it("should handle duplicate column names", () => {
-      openPeopleTable({ limit: 3, mode: "notebook" });
-
-      cy.findByLabelText("Pick columns").click();
-      popover().within(() => {
-        cy.findByText("Select none").click();
-        cy.findByLabelText("Email").click();
-      });
-
-      cy.findByLabelText("Pick columns").click();
-      cy.button("Visualize").click();
+      createQuestion(
+        {
+          query: {
+            "source-table": PRODUCTS_ID,
+            fields: [["field", PRODUCTS.EMAIL, { "base-type": "type/Text" }]],
+            limit: 3,
+          },
+        },
+        { visitQuestion: true },
+      );
 
       // first combine (email + ID)
       cy.findAllByTestId("header-cell").contains("Email").click();

--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/combine-column.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/combine-column.cy.spec.js
@@ -86,5 +86,31 @@ describeWithSnowplow(
         database_id: SAMPLE_DB_ID,
       });
     });
+
+    it("should handle duplicate column names", () => {
+      openPeopleTable({ limit: 3, mode: "notebook" });
+
+      cy.findByLabelText("Pick columns").click();
+      popover().within(() => {
+        cy.findByText("Select none").click();
+        cy.findByLabelText("Email").click();
+      });
+
+      cy.findByLabelText("Pick columns").click();
+      cy.button("Visualize").click();
+
+      // first combine (email + ID)
+      cy.findAllByTestId("header-cell").contains("Email").click();
+      popover().findByText("Combine columns").click();
+      popover().findByText("Done").click();
+
+      // second combine (email + ID)
+      cy.findAllByTestId("header-cell").contains("Email").click();
+      popover().findByText("Combine columns").click();
+      popover().findByText("Done").click();
+
+      cy.findAllByTestId("header-cell").contains("Email ID").should("exist");
+      cy.findAllByTestId("header-cell").contains("Email ID_2").should("exist");
+    });
   },
 );

--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/combine-column.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/combine-column.cy.spec.js
@@ -5,7 +5,6 @@ import {
   describeWithSnowplow,
   expectGoodSnowplowEvent,
   expectNoBadSnowplowEvents,
-  openPeopleTable,
   popover,
   resetSnowplow,
   restore,
@@ -27,16 +26,16 @@ describeWithSnowplow(
     });
 
     it("should be possible to combine columns from the a table header", () => {
-      openPeopleTable({ limit: 3, mode: "notebook" });
-
-      cy.findByLabelText("Pick columns").click();
-      popover().within(() => {
-        cy.findByText("Select none").click();
-        cy.findByLabelText("Email").click();
-      });
-
-      cy.findByLabelText("Pick columns").click();
-      cy.button("Visualize").click();
+      createQuestion(
+        {
+          query: {
+            "source-table": PRODUCTS_ID,
+            fields: [["field", PRODUCTS.EMAIL, { "base-type": "type/Text" }]],
+            limit: 3,
+          },
+        },
+        { visitQuestion: true },
+      );
 
       cy.findAllByTestId("header-cell").contains("Email").click();
       popover().findByText("Combine columns").click();

--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/combine-column.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/combine-column.cy.spec.js
@@ -10,7 +10,7 @@ import {
   restore,
 } from "e2e/support/helpers";
 
-const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
+const { PEOPLE, PEOPLE_ID } = SAMPLE_DATABASE;
 
 describeWithSnowplow(
   "scenarios > visualizations > drillthroughs > table_drills > combine columns",
@@ -29,8 +29,11 @@ describeWithSnowplow(
       createQuestion(
         {
           query: {
-            "source-table": PRODUCTS_ID,
-            fields: [["field", PRODUCTS.EMAIL, { "base-type": "type/Text" }]],
+            "source-table": PEOPLE_ID,
+            fields: [
+              ["field", PEOPLE.ID, { "base-type": "type/Number" }],
+              ["field", PEOPLE.EMAIL, { "base-type": "type/Text" }],
+            ],
             limit: 3,
           },
         },
@@ -94,8 +97,11 @@ describeWithSnowplow(
       createQuestion(
         {
           query: {
-            "source-table": PRODUCTS_ID,
-            fields: [["field", PRODUCTS.EMAIL, { "base-type": "type/Text" }]],
+            "source-table": PEOPLE_ID,
+            fields: [
+              ["field", PEOPLE.ID, { "base-type": "type/Number" }],
+              ["field", PEOPLE.EMAIL, { "base-type": "type/Text" }],
+            ],
             limit: 3,
           },
         },

--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/combine-column.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/combine-column.cy.spec.js
@@ -1,6 +1,7 @@
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
+  createQuestion,
   describeWithSnowplow,
   expectGoodSnowplowEvent,
   expectNoBadSnowplowEvents,

--- a/frontend/src/metabase/querying/utils/drills/combine-columns-drill/components/CombineColumnsDrill/CombineColumnsDrill.tsx
+++ b/frontend/src/metabase/querying/utils/drills/combine-columns-drill/components/CombineColumnsDrill/CombineColumnsDrill.tsx
@@ -105,6 +105,7 @@ export const CombineColumnsDrill = ({
       column,
       columnsAndSeparators,
     );
+
     const newQuery = Lib.expression(query, stageIndex, name, expressionClause);
 
     onSubmit(newQuery);

--- a/frontend/src/metabase/querying/utils/drills/combine-columns-drill/utils.ts
+++ b/frontend/src/metabase/querying/utils/drills/combine-columns-drill/utils.ts
@@ -139,9 +139,37 @@ export const getExpressionName = (
   column: Lib.ColumnMetadata,
   columnsAndSeparators: ColumnAndSeparator[],
 ): string => {
+  const columnNames = Lib.returnedColumns(query, stageIndex).map(
+    column => Lib.displayInfo(query, stageIndex, column).displayName,
+  );
+
+  const name = getCombinedColumnName(
+    query,
+    stageIndex,
+    column,
+    columnsAndSeparators,
+  );
+
+  return getNextName(columnNames, name, 1);
+};
+
+function getNextName(names: string[], name: string, index: number): string {
+  const suffixed = index === 1 ? name : `${name}_${index}`;
+  if (!names.includes(suffixed)) {
+    return suffixed;
+  }
+  return getNextName(names, name, index + 1);
+}
+
+function getCombinedColumnName(
+  query: Lib.Query,
+  stageIndex: number,
+  column: Lib.ColumnMetadata,
+  columnsAndSeparators: ColumnAndSeparator[],
+) {
   const columns = [column, ...columnsAndSeparators.map(({ column }) => column)];
   const names = columns.map(
     column => Lib.displayInfo(query, stageIndex, column).displayName,
   );
   return names.join(" ");
-};
+}


### PR DESCRIPTION
### Description

This PR fixes an issue where selecting the same settings in the combine columns drill thru wasn't working.


### How to verify

Describe the steps to verify that the changes are working as expected.

1. Browse data -> Accounts
2. Click the `First name` header and select combine columns
3. Click `Done`
4. Click the `First name` header again and select combine columns again
5. Click `Done`
6. You should now have two extra columns: `First name ID` and `First name ID_2`


### Demo

https://github.com/metabase/metabase/assets/1250185/51d78b55-9b8f-4973-b4c3-942c7ed3bc13

