### PR TITLE
Remove snippets from search types

### DIFF
--- a/frontend/src/metabase-types/api/search.ts
+++ b/frontend/src/metabase-types/api/search.ts
@@ -23,7 +23,6 @@ export const SEARCH_MODELS = [
   ...ENABLED_SEARCH_MODELS,
   "segment",
   "metric",
-  "snippet",
 ] as const;
 
 export type EnabledSearchModel = typeof ENABLED_SEARCH_MODELS[number];

--- a/frontend/src/metabase/common/hooks/entity-framework/use-search-list-query/use-search-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/entity-framework/use-search-list-query/use-search-list-query.unit.spec.tsx
@@ -17,7 +17,8 @@ import {
 
 import { useSearchListQuery } from "./use-search-list-query";
 
-const TEST_ITEM = createMockCollectionItem();
+const TEST_ITEM_MODEL = "card";
+const TEST_ITEM = createMockCollectionItem({ model: TEST_ITEM_MODEL });
 
 const TEST_TABLE_DB_ID = 1;
 const TEST_SEARCH_RESULTS = createMockSearchResults({
@@ -35,7 +36,7 @@ const TestComponent = () => {
     error,
   } = useSearchListQuery({
     query: {
-      models: [TEST_ITEM.model],
+      models: [TEST_ITEM_MODEL],
       limit: TEST_SEARCH_METADATA.limit,
       offset: TEST_SEARCH_METADATA.offset,
       table_db_id: TEST_TABLE_DB_ID,

--- a/frontend/src/metabase/lib/icon.ts
+++ b/frontend/src/metabase/lib/icon.ts
@@ -27,7 +27,6 @@ const modelIconMap: Record<SearchModel, IconName> = {
   card: "table",
   segment: "segment",
   metric: "funnel",
-  snippet: "snippet",
 };
 
 const secondaryModelIconMap: Partial<Record<SearchModel, IconName>> = {


### PR DESCRIPTION
### Description

Snippets are not supported in search API, see:

https://github.com/metabase/metabase/blob/a536c2d7bf24d111cace04abeedff5f33ac751d5/src/metabase/search/config.clj#L48-L59

### How to verify

TS check is all green.
