### PR TITLE
Do not require `onConfirm` prop in `EntityPickerModal`

### DIFF
--- a/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
+++ b/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
@@ -126,7 +126,6 @@ export const DataPickerModal = ({ value, onChange, onClose }: Props) => {
       tabs={tabs}
       title={t`Pick your starting data`}
       onClose={onClose}
-      onConfirm={_.noop} // onConfirm is unused when options.hasConfirmButtons is falsy
       onItemSelect={handleChange}
     />
   );

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
@@ -43,7 +43,7 @@ export interface EntityPickerModalProps<Model extends string, Item> {
   title?: string;
   selectedItem: Item | null;
   initialValue?: Partial<Item>;
-  onConfirm: () => void;
+  onConfirm?: () => void;
   onItemSelect: (item: Item) => void;
   canSelectItem: boolean;
   onClose: () => void;
@@ -78,12 +78,11 @@ export function EntityPickerModal<
   );
 
   const hydratedOptions = useMemo(
-    () => ({
-      ...defaultOptions,
-      ...options,
-    }),
+    () => ({ ...defaultOptions, ...options }),
     [options],
   );
+
+  assertValidProps(hydratedOptions, onConfirm);
 
   const { open } = useModalOpen();
 
@@ -143,7 +142,7 @@ export function EntityPickerModal<
             ) : (
               <SinglePickerView>{tabs[0].element}</SinglePickerView>
             )}
-            {!!hydratedOptions.hasConfirmButtons && (
+            {!!hydratedOptions.hasConfirmButtons && onConfirm && (
               <ButtonBar
                 onConfirm={onConfirm}
                 onCancel={onClose}
@@ -159,3 +158,14 @@ export function EntityPickerModal<
     </Modal.Root>
   );
 }
+
+const assertValidProps = (
+  options: EntityPickerModalOptions,
+  onConfirm: (() => void) | undefined,
+) => {
+  if (options.hasConfirmButtons && !onConfirm) {
+    throw new Error(
+      "onConfirm prop is required when hasConfirmButtons is true",
+    );
+  }
+};

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.unit.spec.tsx
@@ -47,7 +47,6 @@ const setup = ({
   title = "Pick a thing",
   onItemSelect = jest.fn(),
   onClose = jest.fn(),
-  onConfirm = jest.fn(),
   tabs = [TEST_TAB],
   selectedItem = null,
   ...rest
@@ -63,7 +62,6 @@ const setup = ({
       onClose={onClose}
       tabs={tabs}
       selectedItem={selectedItem}
-      onConfirm={onConfirm}
       {...rest}
     />,
   );
@@ -73,13 +71,31 @@ describe("EntityPickerModal", () => {
   afterAll(() => {
     jest.restoreAllMocks();
   });
+
+  it("should throw when options.hasConfirmButtons is true but onConfirm prop is missing", async () => {
+    expect(() => {
+      setup({
+        options: {
+          hasConfirmButtons: true,
+        },
+        onConfirm: undefined,
+      });
+    }).toThrow("onConfirm prop is required when hasConfirmButtons is true");
+  });
+
   it("should render a picker", async () => {
-    setup({});
+    setup({
+      onConfirm: jest.fn(),
+    });
+
     expect(await screen.findByText("Test picker foo")).toBeInTheDocument();
   });
 
   it("should render a search bar by default and show confirmation button", async () => {
-    setup();
+    setup({
+      onConfirm: jest.fn(),
+    });
+
     expect(await screen.findByPlaceholderText("Search…")).toBeInTheDocument();
     expect(
       await screen.findByRole("button", { name: "Select" }),
@@ -91,22 +107,24 @@ describe("EntityPickerModal", () => {
       options: {
         showSearch: false,
       },
+      onConfirm: jest.fn(),
     });
+
     expect(screen.queryByPlaceholderText("Search…")).not.toBeInTheDocument();
   });
 
   it("should show a tab list when more than 1 tab is supplied", async () => {
-    const tabs: EntityTab<SampleModelType>[] = [
-      TEST_TAB,
-      {
-        icon: "folder",
-        displayName: "All the bar",
-        model: "table",
-        element: <TestPicker name="bar" />,
-      },
-    ];
     setup({
-      tabs,
+      tabs: [
+        TEST_TAB,
+        {
+          icon: "folder",
+          displayName: "All the bar",
+          model: "table",
+          element: <TestPicker name="bar" />,
+        },
+      ],
+      onConfirm: jest.fn(),
     });
 
     const tabList = await screen.findByRole("tablist");
@@ -151,10 +169,10 @@ describe("EntityPickerModal", () => {
     fetchMock.get("path:/api/user/recipients", { data: [] });
 
     const onItemSelect = jest.fn();
-    const onConfirm = jest.fn();
+
     setup({
       onItemSelect,
-      onConfirm,
+      onConfirm: jest.fn(),
     });
 
     await userEvent.type(await screen.findByPlaceholderText("Search…"), "My ", {
@@ -182,7 +200,10 @@ describe("EntityPickerModal", () => {
       </Button>,
     ];
 
-    setup({ actionButtons });
+    setup({
+      actionButtons,
+      onConfirm: jest.fn(),
+    });
 
     expect(
       await screen.findByRole("button", { name: "Click Me" }),


### PR DESCRIPTION
Closes #41172

### Description

`EntityPickerModal` required `onConfirm` prop to be present despite it not being used when `options.hasConfirmButtons` was `false`. We had to awkwardly pass `onConfirm={_.noop}` to work around it.

This PR makes `onConfirm` prop optional and adds a runtime assertion that this prop needs to be present when `options.hasConfirmButtons` is `true`.
I chose runtime assertion (KISS) over conditional TS types which are already quite complex in this component.

### How to verify

The new unit test passes.

(lots of other tests are expected to fail though)