### PR TITLE
Remove trailing slash from API route

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/upload_management/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/upload_management/api.clj
@@ -9,7 +9,7 @@
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
 
-(api/defendpoint GET "/tables/"
+(api/defendpoint GET "/tables"
   "Get all `Tables` visible to the current user which were created by uploading a file."
   []
   (as-> (t2/select :model/Table, :active true, :is_upload true, {:order-by [[:name :asc]]}) tables

--- a/enterprise/backend/test/metabase_enterprise/upload_management/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/upload_management/api_test.clj
@@ -8,7 +8,7 @@
    [metabase.upload :as upload]
    [toucan2.tools.with-temp :as t2.with-temp]))
 
-(def list-url "ee/upload-management/tables/")
+(def list-url "ee/upload-management/tables")
 
 (deftest list-uploaded-tables-test
   (testing "GET ee/upload-management/tables"


### PR DESCRIPTION
See https://metaboat.slack.com/archives/C04S696LRUM/p1714586224549889?thread_ts=1713427700.332719&cid=C04S696LRUM

### Description

Snips off an idiosyncratic URL ending.
