### PR TITLE
Option to customize base font size in React embedding

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/private/AppInitializeController.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/AppInitializeController.tsx
@@ -1,10 +1,7 @@
 import type { ReactNode } from "react";
 import { t } from "ttag";
 
-import {
-  DEFAULT_FONT,
-  EMBEDDING_SDK_ROOT_ELEMENT_ID,
-} from "embedding-sdk/config";
+import { EMBEDDING_SDK_ROOT_ELEMENT_ID } from "embedding-sdk/config";
 import { useInitData } from "embedding-sdk/hooks";
 import { useSdkSelector } from "embedding-sdk/store";
 import { getIsInitialized } from "embedding-sdk/store/selectors";
@@ -15,11 +12,9 @@ import { SdkContentWrapper } from "./SdkContentWrapper";
 interface AppInitializeControllerProps {
   children: ReactNode;
   config: SDKConfig;
-  font?: string;
 }
 
 export const AppInitializeController = ({
-  font,
   config,
   children,
 }: AppInitializeControllerProps) => {
@@ -33,7 +28,6 @@ export const AppInitializeController = ({
     <SdkContentWrapper
       baseUrl={config.metabaseInstanceUrl}
       id={EMBEDDING_SDK_ROOT_ELEMENT_ID}
-      font={font ?? DEFAULT_FONT}
     >
       {!isInitialized ? <div>{t`Loading…`}</div> : children}
     </SdkContentWrapper>

--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkContentWrapper.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkContentWrapper.tsx
@@ -1,13 +1,16 @@
+import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 
+import { DEFAULT_FONT } from "embedding-sdk/config";
+import type { EmbeddingTheme } from "embedding-sdk/types/theme/private";
 import { getRootStyle } from "metabase/css/core/base.styled";
 import { defaultFontFiles } from "metabase/css/core/fonts.styled";
 import { alpha, color } from "metabase/lib/colors";
 import { aceEditorStyles } from "metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.styled";
 import { saveDomImageStyles } from "metabase/visualizations/lib/save-chart-image";
 
-export const SdkContentWrapper = styled.div<{ font: string; baseUrl?: string }>`
-  --mb-default-font-family: "${({ font }) => font}";
+export const SdkContentWrapper = styled.div<{ baseUrl?: string }>`
+  --mb-default-font-family: "${({ theme }) => getFontFamily(theme)}";
   --mb-color-brand: ${color("brand")};
   --mb-color-brand-alpha-04: ${alpha("brand", 0.04)};
   --mb-color-brand-alpha-88: ${alpha("brand", 0.88)};
@@ -16,10 +19,18 @@ export const SdkContentWrapper = styled.div<{ font: string; baseUrl?: string }>`
   ${aceEditorStyles}
   ${saveDomImageStyles}
   ${({ theme }) => getRootStyle(theme)}
+  ${({ theme }) => getWrapperStyle(theme)}
 
   ${({ baseUrl }) => defaultFontFiles({ baseUrl })}
 
   svg {
     display: inline;
   }
+`;
+
+const getFontFamily = (theme: EmbeddingTheme) =>
+  theme.fontFamily ?? DEFAULT_FONT;
+
+const getWrapperStyle = (theme: EmbeddingTheme) => css`
+  font-size: ${theme.other.fontSize ?? "0.875em"};
 `;

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabaseProvider.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabaseProvider.tsx
@@ -53,7 +53,7 @@ const MetabaseProviderInternal = ({
     <Provider store={store}>
       <EmotionCacheProvider>
         <ThemeProvider theme={themeOverride}>
-          <AppInitializeController config={config} font={theme?.fontFamily}>
+          <AppInitializeController config={config}>
             {children}
           </AppInitializeController>
         </ThemeProvider>

--- a/enterprise/frontend/src/embedding-sdk/hooks/private/use-embedding-theme.ts
+++ b/enterprise/frontend/src/embedding-sdk/hooks/private/use-embedding-theme.ts
@@ -1,0 +1,4 @@
+import type { EmbeddingTheme } from "embedding-sdk/types/theme/private";
+import { useMantineTheme } from "metabase/ui";
+
+export const useEmbeddingTheme: () => EmbeddingTheme = useMantineTheme;

--- a/enterprise/frontend/src/embedding-sdk/lib/theme/get-embedding-theme.ts
+++ b/enterprise/frontend/src/embedding-sdk/lib/theme/get-embedding-theme.ts
@@ -16,7 +16,7 @@ export function getEmbeddingThemeOverride(
 
     other: {
       ...theme.components,
-      fontSize: theme.fontSize,
+      ...(theme.fontSize && { fontSize: theme.fontSize }),
     },
   };
 

--- a/enterprise/frontend/src/embedding-sdk/lib/theme/get-embedding-theme.ts
+++ b/enterprise/frontend/src/embedding-sdk/lib/theme/get-embedding-theme.ts
@@ -12,8 +12,12 @@ export function getEmbeddingThemeOverride(
 ): EmbeddingThemeOverride {
   const override: EmbeddingThemeOverride = {
     ...(theme.lineHeight && { lineHeight: theme.lineHeight }),
-    ...(theme.components && { other: theme.components }),
     ...(theme.fontFamily && { fontFamily: theme.fontFamily }),
+
+    other: {
+      ...theme.components,
+      fontSize: theme.fontSize,
+    },
   };
 
   if (theme.colors) {

--- a/enterprise/frontend/src/embedding-sdk/lib/theme/get-embedding-theme.ts
+++ b/enterprise/frontend/src/embedding-sdk/lib/theme/get-embedding-theme.ts
@@ -1,8 +1,5 @@
-import type {
-  MetabaseTheme,
-  EmbeddingThemeOverride,
-  MetabaseColor,
-} from "embedding-sdk/types/theme";
+import type { MetabaseTheme, MetabaseColor } from "../../types/theme";
+import type { EmbeddingThemeOverride } from "../../types/theme/private";
 
 import { colorTuple } from "./color-tuple";
 
@@ -16,7 +13,6 @@ export function getEmbeddingThemeOverride(
   const override: EmbeddingThemeOverride = {
     ...(theme.lineHeight && { lineHeight: theme.lineHeight }),
     ...(theme.components && { other: theme.components }),
-    ...(theme.fontSize && { fontSizes: { md: theme.fontSize } }),
     ...(theme.fontFamily && { fontFamily: theme.fontFamily }),
   };
 

--- a/enterprise/frontend/src/embedding-sdk/lib/theme/get-embedding-theme.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk/lib/theme/get-embedding-theme.unit.spec.ts
@@ -21,6 +21,9 @@ describe("Transform Embedding Theme Override", () => {
         "text-dark": expect.arrayContaining(["yellow"]),
         "text-light": expect.arrayContaining(["green"]),
       },
+      other: {
+        fontSize: "2rem",
+      },
     });
   });
 });

--- a/enterprise/frontend/src/embedding-sdk/lib/theme/get-embedding-theme.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk/lib/theme/get-embedding-theme.unit.spec.ts
@@ -16,7 +16,6 @@ describe("Transform Embedding Theme Override", () => {
     expect(theme).toEqual({
       lineHeight: 1.5,
       fontFamily: "Roboto",
-      fontSizes: { md: "2rem" },
       colors: {
         brand: expect.arrayContaining(["hotpink"]),
         "text-dark": expect.arrayContaining(["yellow"]),

--- a/enterprise/frontend/src/embedding-sdk/types/theme/index.ts
+++ b/enterprise/frontend/src/embedding-sdk/types/theme/index.ts
@@ -1,6 +1,4 @@
-import type { MantineThemeOverride } from "@mantine/core";
-
-import type { MetabaseFontFamily } from "./fonts";
+import type { MetabaseFontFamily } from "../fonts";
 
 /**
  * Theme configuration for embedded Metabase components.
@@ -43,14 +41,3 @@ export type MetabaseColor = keyof MetabaseColors;
  * components and visualizations.
  */
 export interface MetabaseComponentTheme {}
-
-/**
- * Mantine theme overrides with theme options specific to React embedding.
- *
- * We use this type instead of declaration merging
- * to avoid polluting the metabase-ui Mantine type with
- * theme configuration that only applies to React embedding SDK.
- */
-export type EmbeddingThemeOverride = MantineThemeOverride & {
-  other?: MetabaseComponentTheme;
-};

--- a/enterprise/frontend/src/embedding-sdk/types/theme/private.ts
+++ b/enterprise/frontend/src/embedding-sdk/types/theme/private.ts
@@ -1,0 +1,29 @@
+import type { MantineThemeOverride, MantineTheme } from "@mantine/core";
+
+import type { MetabaseComponentTheme } from ".";
+
+/**
+ * Mantine theme overrides with theme options specific to React embedding.
+ *
+ * We use this type instead of declaration merging
+ * to avoid polluting the metabase-ui Mantine type with
+ * theme configuration that only applies to React embedding SDK.
+ */
+export type EmbeddingThemeOverride = MantineThemeOverride & {
+  other?: EmbeddingThemeOptions;
+};
+
+/**
+ * Mantine theme options specific to React embedding.
+ */
+export type EmbeddingThemeOptions = MetabaseComponentTheme & {
+  /** Base font size */
+  fontSize?: string;
+};
+
+/**
+ * Mantine theme for React embedding.
+ */
+export type EmbeddingTheme = MantineTheme & {
+  other?: EmbeddingThemeOptions;
+};

--- a/frontend/src/metabase/css/core/base.styled.ts
+++ b/frontend/src/metabase/css/core/base.styled.ts
@@ -3,7 +3,6 @@ import { css } from "@emotion/react";
 
 export const getRootStyle = (theme: Theme) => css`
   font-family: var(--mb-default-font-family), sans-serif;
-  font-size: 0.875em;
   font-weight: 400;
   font-style: normal;
   color: ${theme.fn.themeColor("text-dark")};

--- a/frontend/src/metabase/styled-components/containers/GlobalStyles/GlobalStyles.tsx
+++ b/frontend/src/metabase/styled-components/containers/GlobalStyles/GlobalStyles.tsx
@@ -41,6 +41,7 @@ export const GlobalStyles = (): JSX.Element => {
     ${aceEditorStyles}
     ${saveDomImageStyles}
     body {
+      font-size: 0.875em;
       ${getRootStyle(theme)}
     }
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/42321

### Description

Mantine does not provide an option to change the base font size. Rather, it exposes the `fontSizes` object which requires each individual font sizes (e.g. xs, sm, md, lg, xl) to be set independently - this would be confusing to SDK users if we expose those. Instead, we expose a single `fontSize` property in the theme object. We then apply the base font size to the SDK content wrapper.

### Caveat

- Even though the base font size is applied to the SDK container, certain elements still has a fixed pixel size (i.e. chart label is 12px, scalar value title) so they won't be affected. We should address them in their specific PRs, e.g. themeable scalar value PR.

### How to verify

- Go to the `main` branch in the demo app
- Change the `fontSize` theme property, e.g. to "18px"
- Remove every CSS from `product-list.css` and `product-detail.css`, as they are workarounds that shouldn't be necessary.
- The font size of the embedded components should change accordingly: Filter Panel, Popover, Scalar Value Comparison, etc.

### Demo

Using `fontSize: "1.18rem"`. Note that scalar value here is not affected as it is fixed.

<img src="https://github.com/metabase/metabase/assets/4714175/cc73e5db-8162-43dd-9d17-06748834607c" width="200">

<img src="https://github.com/metabase/metabase/assets/4714175/5c381ea1-4c52-4d28-a633-5dd5c0307496" width="200">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
