### PR TITLE
Fix Embedding SDK calling admin endpoint

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/hooks/private/use-init-data.ts
+++ b/enterprise/frontend/src/embedding-sdk/hooks/private/use-init-data.ts
@@ -13,8 +13,8 @@ import type {
   SdkDispatch,
 } from "embedding-sdk/store/types";
 import type { SDKConfig } from "embedding-sdk/types";
-import { reloadSettings } from "metabase/admin/settings/settings";
 import api from "metabase/lib/api";
+import { refreshSiteSettings } from "metabase/redux/settings";
 import { refreshCurrentUser } from "metabase/redux/user";
 import registerVisualizations from "metabase/visualizations/register";
 
@@ -71,9 +71,9 @@ export const useInitData = ({ config }: InitDataLoaderParameters) => {
         dispatch(setLoginStatus({ status: "loading" }));
 
         try {
-          const [userResponse, [_, siteSettingsResponse]] = await Promise.all([
+          const [userResponse, siteSettingsResponse] = await Promise.all([
             dispatch(refreshCurrentUser()),
-            dispatch(reloadSettings()),
+            dispatch(refreshSiteSettings()),
           ]);
 
           if (


### PR DESCRIPTION
I stumbled on this problem while troubleshooting Embedding SDK setup with @albertoperdomo .

This endpoint always returns 401 for non-admin users, and it seems unnecessary to include it here.
https://github.com/metabase/metabase/blob/274807fdae1f6a0528498c933cc152543ed6a5f1/src/metabase/api/setting.clj#L27-L29

#### Before
![Screenshot 2024-05-07 at 6 45 38 PM](https://github.com/metabase/metabase/assets/1937582/20fd5191-32b5-49c6-adcd-10623f682ac2)

#### After
![Screenshot 2024-05-07 at 6 45 42 PM](https://github.com/metabase/metabase/assets/1937582/df35685f-f82d-4656-8097-75336cb0d053)


