### PR TITLE
attempt to type the return value of actions created by createThunkAction

### DIFF
--- a/frontend/src/metabase/admin/app/actions.ts
+++ b/frontend/src/metabase/admin/app/actions.ts
@@ -1,6 +1,5 @@
-import { createAsyncThunk } from "@reduxjs/toolkit";
-
 import { updateSetting } from "metabase/admin/settings/settings";
+import { createAsyncThunk } from "metabase/lib/redux";
 import Settings from "metabase/lib/settings";
 
 export const disableNotice = createAsyncThunk(

--- a/frontend/src/metabase/dashboard/actions/cards-typed.ts
+++ b/frontend/src/metabase/dashboard/actions/cards-typed.ts
@@ -239,23 +239,33 @@ export const replaceCard =
     dashboardId && trackQuestionReplaced(dashboardId);
   };
 
-export const removeCardFromDashboard = createThunkAction<
-  [{ dashcardId: DashCardId; cardId: CardId }]
->(REMOVE_CARD_FROM_DASH, ({ dashcardId, cardId }) => dispatch => {
-  // @ts-expect-error — data-fetching.js actions must be converted to TypeScript
-  dispatch(cancelFetchCardData(cardId, dashcardId));
-  return { dashcardId };
-});
+export const removeCardFromDashboard = createThunkAction(
+  REMOVE_CARD_FROM_DASH,
+  ({
+      dashcardId,
+      cardId,
+    }: {
+      dashcardId: DashCardId;
+      cardId: DashboardCard["card_id"];
+    }) =>
+    dispatch => {
+      // @ts-expect-error — data-fetching.js actions must be converted to TypeScript
+      dispatch(cancelFetchCardData(cardId, dashcardId));
+      return { dashcardId };
+    },
+);
 
-export const undoRemoveCardFromDashboard = createThunkAction<
-  [{ dashcardId: DashCardId }]
->(UNDO_REMOVE_CARD_FROM_DASH, ({ dashcardId }) => (dispatch, getState) => {
-  const dashcard = getDashCardById(getState(), dashcardId);
-  const card = dashcard.card;
+export const undoRemoveCardFromDashboard = createThunkAction(
+  UNDO_REMOVE_CARD_FROM_DASH,
+  ({ dashcardId }) =>
+    (dispatch, getState) => {
+      const dashcard = getDashCardById(getState(), dashcardId);
+      const card = dashcard.card;
 
-  if (!isVirtualDashCard(dashcard)) {
-    dispatch(fetchCardData(card, dashcard));
-  }
+      if (!isVirtualDashCard(dashcard)) {
+        dispatch(fetchCardData(card, dashcard));
+      }
 
-  return { dashcardId };
-});
+      return { dashcardId };
+    },
+);

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
@@ -1,6 +1,7 @@
 import cx from "classnames";
 import type { LocationDescriptor } from "history";
 import { Component } from "react";
+import type { ConnectedProps } from "react-redux";
 import { connect } from "react-redux";
 import { t } from "ttag";
 import _ from "underscore";
@@ -52,6 +53,8 @@ import type {
   DashboardCard,
 } from "metabase-types/api";
 
+import { removeCardFromDashboard } from "../actions";
+
 import { AddSeriesModal } from "./AddSeriesModal/AddSeriesModal";
 import { DashCard } from "./DashCard/DashCard";
 import type { DashCardOnChangeCardAndRunHandler } from "./DashCard/types";
@@ -80,7 +83,7 @@ type DashboardChangeItem = {
   attributes: Partial<BaseDashboardCard>;
 };
 
-interface DashboardGridProps {
+type DashboardGridProps = ConnectedProps<typeof connector> & {
   dashboard: Dashboard;
   dashcardData: DashCardDataMap;
   selectedTabId: DashboardTabId;
@@ -117,10 +120,6 @@ interface DashboardGridProps {
     dashcards: Array<DashboardChangeItem>;
   }) => void;
 
-  removeCardFromDashboard: (options: {
-    dashcardId: DashCardId;
-    cardId?: CardId | null;
-  }) => void;
   undoRemoveCardFromDashboard: (options: { dashcardId: DashCardId }) => void;
 
   onReplaceAllDashCardVisualizationSettings: (
@@ -142,7 +141,7 @@ interface DashboardGridProps {
     undo: boolean;
     action: () => void;
   }) => void;
-}
+};
 
 interface DashboardGridState {
   visibleCardIds: Set<number>;
@@ -154,7 +153,7 @@ interface DashboardGridState {
   isAnimationPaused: boolean;
 }
 
-const mapDispatchToProps = { addUndo };
+const mapDispatchToProps = { addUndo, removeCardFromDashboard };
 
 class DashboardGrid extends Component<DashboardGridProps, DashboardGridState> {
   static contextType = ContentViewportContext;
@@ -468,6 +467,7 @@ class DashboardGrid extends Component<DashboardGridProps, DashboardGridState> {
       dashcardId: dc.id,
       cardId: dc.card_id,
     });
+
     this.props.addUndo({
       message: t`Removed card`,
       undo: true,
@@ -673,7 +673,9 @@ const getUndoReplaceCardMessage = ({ type }: Card) => {
   throw new Error(`Unknown card.type: ${type}`);
 };
 
+const connector = connect(null, mapDispatchToProps);
+
 export const DashboardGridConnected = _.compose(
   ExplicitSize(),
-  connect(null, mapDispatchToProps),
+  connector,
 )(DashboardGrid);

--- a/frontend/src/metabase/lib/redux/typed-utils.ts
+++ b/frontend/src/metabase/lib/redux/typed-utils.ts
@@ -1,6 +1,7 @@
+import type { ThunkDispatch } from "@reduxjs/toolkit";
 import { createAsyncThunk as createAsyncThunkOriginal } from "@reduxjs/toolkit";
 
-import type { State, Dispatch, GetState } from "metabase-types/store";
+import type { State, GetState } from "metabase-types/store";
 
 import { withAction } from "./utils";
 
@@ -11,13 +12,26 @@ interface ThunkConfig {
 export const createAsyncThunk =
   createAsyncThunkOriginal.withTypes<ThunkConfig>();
 
+type AwaitedIfPromise<T> = T extends Promise<infer R> ? R : T;
+
 // similar to createAction but accepts a (redux-thunk style) thunk and dispatches based on whether
 // the promise returned from the thunk resolves or rejects, similar to redux-promise
-export function createThunkAction<TArgs extends any[]>(
-  actionType: string,
+export function createThunkAction<
+  TArgs extends any[],
+  TResult,
+  TActionType extends string,
+>(
+  actionType: TActionType,
   thunkCreator: (
     ...args: TArgs
-  ) => (dispatch: Dispatch, getState: GetState) => any,
-): (...args: TArgs) => any {
+  ) => (dispatch: ThunkDispatch<any, any, any>, getState: GetState) => TResult,
+): (
+  ...args: TArgs
+) => (
+  dispatch: ThunkDispatch<any, any, any>,
+  getState: GetState,
+) => Promise<{ type: TActionType; payload: AwaitedIfPromise<TResult> }> {
+  // @ts-expect-error - withAction is too hard to type correctly as it can accept both the payload or a thunk creator
+  // this function only uses it with a thunk creator
   return withAction(actionType)(thunkCreator);
 }

--- a/frontend/src/metabase/lib/redux/typed-utils.ts
+++ b/frontend/src/metabase/lib/redux/typed-utils.ts
@@ -12,8 +12,6 @@ interface ThunkConfig {
 export const createAsyncThunk =
   createAsyncThunkOriginal.withTypes<ThunkConfig>();
 
-type AwaitedIfPromise<T> = T extends Promise<infer R> ? R : T;
-
 // similar to createAction but accepts a (redux-thunk style) thunk and dispatches based on whether
 // the promise returned from the thunk resolves or rejects, similar to redux-promise
 export function createThunkAction<
@@ -30,7 +28,7 @@ export function createThunkAction<
 ) => (
   dispatch: ThunkDispatch<any, any, any>,
   getState: GetState,
-) => Promise<{ type: TActionType; payload: AwaitedIfPromise<TResult> }> {
+) => Promise<{ type: TActionType; payload: Awaited<TResult> }> {
   // @ts-expect-error - withAction is too hard to type correctly as it can accept both the payload or a thunk creator
   // this function only uses it with a thunk creator
   return withAction(actionType)(thunkCreator);

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionActions.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionActions.tsx
@@ -244,12 +244,14 @@ export const QuestionActions = ({
   const handleFileUpload = (event: ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (file && question._card.based_on_upload) {
-      uploadFile({
-        file,
-        tableId: question._card.based_on_upload,
-        reloadQuestionData: true,
-        uploadMode,
-      })(dispatch);
+      dispatch(
+        uploadFile({
+          file,
+          tableId: question._card.based_on_upload,
+          reloadQuestionData: true,
+          uploadMode,
+        }),
+      );
 
       // reset the file input so that subsequent uploads of the same file trigger the change handler
       if (fileInputRef.current?.value) {

--- a/frontend/src/metabase/redux/undo.unit.spec.ts
+++ b/frontend/src/metabase/redux/undo.unit.spec.ts
@@ -1,5 +1,7 @@
 import { configureStore } from "@reduxjs/toolkit";
 
+import type { Dispatch } from "metabase-types/store";
+
 import undoReducer, {
   addUndo,
   dismissAllUndo,
@@ -77,8 +79,9 @@ describe("metabase/redux/undo", () => {
 });
 
 const createMockStore = () => {
-  return configureStore({
+  const store = configureStore({
     // @ts-expect-error undo is still not converted to TS
     reducer: { undo: undoReducer },
   });
+  return store as typeof store & { dispatch: Dispatch };
 };


### PR DESCRIPTION
## Description

This is an attempt to make `createThunkAction` return thunks with a return type.

I initially thought this was not worth doing, but we're using `createThunkAction` in a lot of places and it basically acts as a black hole for types. Typing things manually would probably take more time and would be more error prone.

I left many inline comments in the PR to explain some gotchas and our reasoning.

Note:
I'll soon open an RFC to propose the deprecation of `createThunkAction`, I think having two ways to create thunks (`createThunkAction` and `createAsyncAction` from rtk) will cause many unnecessary headaches as they have very similar names, very similar goals but different implementations with some gotchas.
With that said, we'll most likely have some `createThunkAction` arounds for a while so some typing will help us