### PR TITLE
Port CollapseSection to ts

### DIFF
--- a/frontend/src/metabase/components/CollapseSection/CollapseSection.styled.tsx
+++ b/frontend/src/metabase/components/CollapseSection/CollapseSection.styled.tsx
@@ -4,7 +4,7 @@ import styled from "@emotion/styled";
 import type { IconName, IconProps } from "metabase/ui";
 import { Icon } from "metabase/ui";
 
-export const HeaderContainer = styled.div<{ role: string; tabIndex?: number }>`
+export const HeaderContainer = styled.div<{ role?: string; tabIndex?: number }>`
   display: flex;
   align-items: center;
   cursor: pointer;
@@ -43,9 +43,8 @@ export const ToggleIcon = styled(
     isExpanded,
     variant,
     size = 12,
-    name: _,
     ...props
-  }: ToggleIconProps & IconProps) => {
+  }: ToggleIconProps & Omit<IconProps, "name">) => {
     const { collapsed, expanded } = ICON_VARIANTS[variant];
     const name = isExpanded ? expanded : collapsed;
     return <Icon name={name as IconName} size={size} {...props} />;

--- a/frontend/src/metabase/components/CollapseSection/CollapseSection.tsx
+++ b/frontend/src/metabase/components/CollapseSection/CollapseSection.tsx
@@ -1,22 +1,26 @@
-import PropTypes from "prop-types";
-import { useCallback, useState } from "react";
+import {
+  useCallback,
+  useState,
+  type HTMLAttributes,
+  type KeyboardEvent,
+} from "react";
 
-import { HeaderContainer, Header, ToggleIcon } from "./CollapseSection.styled";
+import { Header, HeaderContainer, ToggleIcon } from "./CollapseSection.styled";
 
-const propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-  header: PropTypes.node,
-  headerClass: PropTypes.string,
-  bodyClass: PropTypes.string,
-  initialState: PropTypes.oneOf(["expanded", "collapsed"]),
-  iconVariant: PropTypes.oneOf(["right-down", "up-down"]),
-  iconPosition: PropTypes.oneOf(["left", "right"]),
-  iconSize: PropTypes.number,
-  onToggle: PropTypes.func,
-};
+type CollapseSectionProps = {
+  children?: React.ReactNode;
+  className?: string;
+  header?: React.ReactNode;
+  headerClass?: string;
+  bodyClass?: string;
+  initialState?: "expanded" | "collapsed";
+  iconVariant?: "right-down" | "up-down";
+  iconPosition?: "left" | "right";
+  iconSize?: number;
+  onToggle?: (nextState: boolean) => void;
+} & HTMLAttributes<HTMLDivElement>;
 
-function CollapseSection({
+const CollapseSection = ({
   initialState = "collapsed",
   iconVariant = "right-down",
   iconPosition = "left",
@@ -27,7 +31,8 @@ function CollapseSection({
   bodyClass,
   children,
   onToggle,
-}) {
+  ...props
+}: CollapseSectionProps) => {
   const [isExpanded, setIsExpanded] = useState(initialState === "expanded");
 
   const toggle = useCallback(() => {
@@ -37,7 +42,7 @@ function CollapseSection({
   }, [isExpanded, onToggle]);
 
   const onKeyDown = useCallback(
-    e => {
+    (e: KeyboardEvent<HTMLDivElement>) => {
       if (e.key === "Enter") {
         toggle();
       }
@@ -55,7 +60,7 @@ function CollapseSection({
   );
 
   return (
-    <div className={className} role="tab" aria-expanded={isExpanded}>
+    <div className={className} role="tab" aria-expanded={isExpanded} {...props}>
       <HeaderContainer
         className={headerClass}
         onClick={toggle}
@@ -70,8 +75,7 @@ function CollapseSection({
       </div>
     </div>
   );
-}
+};
 
-CollapseSection.propTypes = propTypes;
-
+// eslint-disable-next-line import/no-default-export
 export default CollapseSection;

--- a/frontend/src/metabase/components/CollapseSection/CollapseSection.unit.spec.tsx
+++ b/frontend/src/metabase/components/CollapseSection/CollapseSection.unit.spec.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import CollapseSection from "./CollapseSection";
 
@@ -6,6 +7,10 @@ function setup({
   header = "Collapse Header",
   initialState = "collapsed",
   ...props
+}: {
+  header?: string | React.ReactNode;
+  initialState?: "collapsed" | "expanded";
+  [key: string]: any;
 } = {}) {
   return render(
     <CollapseSection header={header} initialState={initialState} {...props}>
@@ -66,10 +71,10 @@ describe("CollapseSection", () => {
     expect(screen.getByText("Custom Header")).toBeInTheDocument();
   });
 
-  it("uses different icons for 'up-down' icon variant", () => {
+  it("uses different icons for 'up-down' icon variant", async () => {
     setup({ iconVariant: "up-down" });
     expect(screen.getByLabelText("chevrondown icon")).toBeInTheDocument();
-    fireEvent.click(screen.queryByLabelText("chevrondown icon"));
+    await userEvent.click(screen.getByLabelText("chevrondown icon"));
     expect(screen.getByLabelText("chevronup icon")).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/components/CollapseSection/index.js
+++ b/frontend/src/metabase/components/CollapseSection/index.js
@@ -1,1 +1,0 @@
-export { default } from "./CollapseSection";

--- a/frontend/src/metabase/components/CollapseSection/index.ts
+++ b/frontend/src/metabase/components/CollapseSection/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/no-default-export -- legacy usage
+export { default } from "./CollapseSection";


### PR DESCRIPTION
Ports `CollapseSection` to typescript. This is the component used for making sections able to expand and collapse in the main navigation bar.

![Kapture 2024-05-08 at 10 22 23](https://github.com/metabase/metabase/assets/130925/279921e2-d5ee-443e-bc8b-d943a4433de1)
