### PR TITLE
Bump published SDK version

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/package.template.json
+++ b/enterprise/frontend/src/embedding-sdk/package.template.json
@@ -1,6 +1,6 @@
 {
   "name": "@metabase/embedding-sdk-react",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Metabase Embedding SDK for React",
   "repository": {
     "url": "git+https://github.com/metabase/metabase.git"


### PR DESCRIPTION
We released 0.1.0 and 0.1.1 without updating this template file. It could be confusing what's the latest version is. This is to ensure we reduce human error.

Published npm package is located at https://www.npmjs.com/package/@metabase/embedding-sdk-react
