### PR TITLE
Serialize trash correctly

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
@@ -2,6 +2,7 @@
   (:refer-clojure :exclude [load])
   (:require
    [clojure.java.io :as io]
+   [clojure.set :as set]
    [clojure.string :as str]
    [metabase-enterprise.serialization.dump :as dump]
    [metabase-enterprise.serialization.load :as load]
@@ -14,7 +15,7 @@
    [metabase.analytics.snowplow :as snowplow]
    [metabase.db :as mdb]
    [metabase.models.card :refer [Card]]
-   [metabase.models.collection :refer [Collection]]
+   [metabase.models.collection :as collection :refer [Collection]]
    [metabase.models.dashboard :refer [Dashboard]]
    [metabase.models.database :refer [Database]]
    [metabase.models.field :as field :refer [Field]]
@@ -236,12 +237,16 @@
     (when-not (.canWrite f)
       (throw (ex-info (format "Destination path is not writeable: %s" path) {:filename path}))))
   (let [start  (System/nanoTime)
+        ;; we _ALWAYS_ export the Trash. Its descendants are empty, so we won't export anything extra as a result, but
+        ;; we will export items that are currently in the Trash, assuming they were trashed *from* a place we're
+        ;; exporting.
+        collection-ids+trash (set/union collection-ids #{(collection/trash-collection-id)})
         err    (atom nil)
         report (try
                  (serdes/with-cache
                    (-> (cond-> opts
                          (seq collection-ids)
-                         (assoc :targets (v2.extract/make-targets-of-type "Collection" collection-ids)))
+                         (assoc :targets (v2.extract/make-targets-of-type "Collection" collection-ids+trash)))
                        v2.extract/extract
                        (v2.storage/store! path)))
                  (catch Exception e

--- a/enterprise/backend/test/metabase_enterprise/audit_app/api/collection_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/api/collection_test.clj
@@ -38,7 +38,7 @@
                         last
                         :type))))
           (testing "GET /api/collection/test"
-            (is (= nil
+            (is (= collection/trash-collection-type
                    (->> (mt/user-http-request :crowberto :get 200 "collection/tree")
                         last
                         :type)))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/cmd_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/cmd_test.clj
@@ -149,17 +149,18 @@
 
 (deftest premium-features-test
   (testing "without a premium token"
-    (ts/with-random-dump-dir [dump-dir "serdes-"]
-      (testing "dump should fail"
-        (is (thrown-with-msg? Exception #"Please upgrade"
-                              (cmd/dump dump-dir "--user" "crowberto@metabase.com"))))
-
-      (testing "load should fail"
-        (mt/with-empty-h2-app-db
+    (mt/with-premium-features #{}
+      (ts/with-random-dump-dir [dump-dir "serdes-"]
+        (testing "dump should fail"
           (is (thrown-with-msg? Exception #"Please upgrade"
-                                (cmd/load dump-dir
-                                          "--mode"     "update"
-                                          "--on-error" "abort"))))))))
+                                (cmd/dump dump-dir "--user" "crowberto@metabase.com"))))
+
+        (testing "load should fail"
+          (mt/with-empty-h2-app-db
+            (is (thrown-with-msg? Exception #"Please upgrade"
+                                  (cmd/load dump-dir
+                                            "--mode"     "update"
+                                            "--on-error" "abort")))))))))
 
 (deftest dump-readonly-dir-test
   (testing "command exits early when destination is not writable"
@@ -189,7 +190,7 @@
                          "settings"        true
                          "field_values"    false
                          "duration_ms"     pos?
-                         "count"           3
+                         "count"           4
                          "source"          "cli"
                          "secrets"         false
                          "success"         true
@@ -204,7 +205,7 @@
                          "duration_ms"   pos?
                          "source"        "cli"
                          "models"        "Card,Collection,Setting"
-                         "count"         3
+                         "count"         4
                          "success"       true
                          "error_message" nil}
                         (-> (snowplow-test/pop-event-data-and-user-id!) first :data))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/backfill_ids_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/backfill_ids_test.clj
@@ -38,7 +38,7 @@
       (testing "deleting the entity_id for one of them"
         (t2/update! Collection c2-id {:entity_id nil})
         (is (= #{c1-eid nil}
-               (t2/select-fn-set :entity_id Collection))))
+               (t2/select-fn-set :entity_id Collection :type nil))))
 
       (testing "backfill"
         (serdes.backfill/backfill-ids-for! Collection)
@@ -54,14 +54,14 @@
       (testing "deleting the entity_id for one of them"
         (t2/update! Collection c2-id {:entity_id nil})
         (is (= #{c1-eid nil}
-               (t2/select-fn-set :entity_id Collection))))
+               (t2/select-fn-set :entity_id Collection :type nil))))
 
       (testing "backfilling twice"
         (serdes.backfill/backfill-ids-for! Collection)
         (let [first-eid (t2/select-one-fn :entity_id Collection :id c2-id)]
           (t2/update! Collection c2-id {:entity_id nil})
           (is (= #{c1-eid nil}
-                 (t2/select-fn-set :entity_id Collection)))
+                 (t2/select-fn-set :entity_id Collection :type nil)))
           (serdes.backfill/backfill-ids-for! Collection)
           (testing "produces the same entity_id both times"
             (is (= first-eid (t2/select-one-fn :entity_id Collection :id c2-id)))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -230,7 +230,8 @@
                                          (update m (-> entity :serdes/meta last :model)
                                                  (fnil conj []) entity))
                                        {} @extraction))
-            (is (= 110 (-> @entities (get "Collection") count))))
+            ;; +1 for the Trash collection
+            (is (= 111 (-> @entities (get "Collection") count))))
 
           (testing "storage"
             (storage/store! (seq @extraction) dump-dir)
@@ -239,7 +240,8 @@
               (is (= 30 (count (dir->file-set (io/file dump-dir "actions"))))))
 
             (testing "for Collections"
-              (is (= 110 (count (for [f (file-set (io/file dump-dir))
+              ;; +1 for the Trash collection
+              (is (= 111 (count (for [f (file-set (io/file dump-dir))
                                       :when (and (= (first f) "collections")
                                                  (let [[a b] (take-last 2 f)]
                                                    (= b (str a ".yaml"))))]

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -483,13 +483,13 @@
                   ;; card1s has no parameters, card2s does.
                   (is (= #{[]
                            [{:id                   "abc",
-                           :name                 "CATEGORY",
-                           :type                 :category,
-                           :values_source_config {:card_id     (:entity_id card1s),
-                                                  :value_field [:field
-                                                                ["my-db" nil "CUSTOMERS" "NAME"]
-                                                                nil]},
-                           :values_source_type   "card"}]}
+                             :name                 "CATEGORY",
+                             :type                 :category,
+                             :values_source_config {:card_id     (:entity_id card1s),
+                                                    :value_field [:field
+                                                                  ["my-db" nil "CUSTOMERS" "NAME"]
+                                                                  nil]},
+                             :values_source_type   "card"}]}
                          (set (map :parameters (by-model extraction "Card")))))
 
                   (storage/store! (seq extraction) dump-dir)))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -480,15 +480,17 @@
                            :values_source_type   "card"}]
                          (:parameters (first (by-model extraction "Dashboard")))))
 
-                  (is (= [{:id                   "abc",
+                  ;; card1s has no parameters, card2s does.
+                  (is (= #{[]
+                           [{:id                   "abc",
                            :name                 "CATEGORY",
                            :type                 :category,
                            :values_source_config {:card_id     (:entity_id card1s),
                                                   :value_field [:field
                                                                 ["my-db" nil "CUSTOMERS" "NAME"]
                                                                 nil]},
-                           :values_source_type   "card"}]
-                         (:parameters (first (by-model extraction "Card")))))
+                           :values_source_type   "card"}]}
+                         (set (map :parameters (by-model extraction "Card")))))
 
                   (storage/store! (seq extraction) dump-dir)))
 

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -45,7 +45,7 @@
        (map :id)
        set))
 
-(def trash-eid (delay (:entity_id (collection/trash-collection))))
+(def ^:private trash-eid (delay (:entity_id (collection/trash-collection))))
 
 (deftest fundamentals-test
   (mt/with-empty-h2-app-db

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -55,7 +55,7 @@
       (ts/with-dbs [source-db dest-db]
         (testing "extraction succeeds"
           (ts/with-db source-db
-            (ts/create! Collection :name "Basic Collection" :entity_id eid1)
+            (ts/create! :model/Collection :name "Basic Collection" :entity_id eid1)
             (reset! serialized (into [] (serdes.extract/extract {})))
             (is (some (fn [{[{:keys [model id]}] :serdes/meta}]
                         (and (= model "Collection") (= id eid1)))
@@ -64,7 +64,8 @@
         (testing "loading into an empty database succeeds"
           (ts/with-db dest-db
             (serdes.load/load-metabase! (ingestion-in-memory @serialized))
-            (let [colls (t2/select Collection)]
+            ;; the trash is serialized and loaded, so restrict to nil type
+            (let [colls (t2/select :model/Collection :type nil)]
               (is (= 1 (count colls)))
               (is (= "Basic Collection" (:name (first colls))))
               (is (= eid1               (:entity_id (first colls)))))))
@@ -72,7 +73,7 @@
         (testing "loading again into the same database does not duplicate"
           (ts/with-db dest-db
             (serdes.load/load-metabase! (ingestion-in-memory @serialized))
-            (let [colls (t2/select Collection)]
+            (let [colls (t2/select :model/Collection :type nil)]
               (is (= 1 (count colls)))
               (is (= "Basic Collection" (:name (first colls))))
               (is (= eid1               (:entity_id (first colls)))))))))))
@@ -107,7 +108,7 @@
               (is (some? child-dest))
               (is (some? grandchild-dest))
               (is (not= (:id parent-dest) (:id @parent)) "should have different primary keys")
-              (is (= 4 (t2/count Collection)))
+              (is (= 4 (t2/count Collection :type nil)))
               (is (= "/"
                      (:location parent-dest)))
               (is (= (format "/%d/" (:id parent-dest))
@@ -1222,4 +1223,4 @@
             (is (thrown? clojure.lang.ExceptionInfo
                          (serdes.load/load-metabase! (ingestion-in-memory @serialized))))
             (is (= (str "qwe_" (:name coll))
-                   (t2/select-one-fn :name Collection :id (:id card))))))))))
+                   (t2/select-one-fn :name Collection :id (:id coll))))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/storage_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/storage_test.clj
@@ -10,6 +10,7 @@
    [metabase-enterprise.serialization.v2.storage :as storage]
    [metabase.models :refer [Card Collection Dashboard DashboardCard Database Field FieldValues NativeQuerySnippet
                             Table]]
+   [metabase.models.collection :as collection]
    [metabase.models.serialization :as serdes]
    [metabase.test :as mt]
    [metabase.util.date-2 :as u.date]
@@ -25,6 +26,8 @@
                :let               [rel (.relativize base (.toPath file))]]
            (mapv str rel)))))
 
+(def trash-dir (delay (str (:entity_id (collection/trash-collection)) "_trash")))
+
 (deftest basic-dump-test
   (ts/with-random-dump-dir [dump-dir "serdesv2-"]
     (mt/with-empty-h2-app-db
@@ -36,7 +39,8 @@
           (storage/store! export dump-dir)
           (testing "the right files in the right places"
             (is (= #{[parent-filename (str parent-filename ".yaml")]
-                     [parent-filename child-filename (str child-filename ".yaml")]}
+                     [parent-filename child-filename (str child-filename ".yaml")]
+                     [@trash-dir (str @trash-dir ".yaml")]}
                    (file-set (io/file dump-dir "collections")))
                 "collections form a tree, with same-named files")
             (is (contains? (file-set (io/file dump-dir))
@@ -47,6 +51,7 @@
             (is (= (-> (into {} (t2/select-one Collection :id (:id parent)))
                        (dissoc :id :location)
                        (assoc :parent_id nil)
+                       (assoc :trashed_from_parent_id nil)
                        (update :created_at t/offset-date-time))
                    (-> (yaml/from-file (io/file dump-dir "collections" parent-filename (str parent-filename ".yaml")))
                        (dissoc :serdes/meta)
@@ -55,6 +60,7 @@
             (is (= (-> (into {} (t2/select-one Collection :id (:id child)))
                        (dissoc :id :location)
                        (assoc :parent_id (:entity_id parent))
+                       (assoc :trashed_from_parent_id nil)
                        (update :created_at t/offset-date-time))
                    (-> (yaml/from-file (io/file dump-dir "collections" parent-filename
                                                 child-filename (str child-filename ".yaml")))
@@ -70,18 +76,19 @@
                                                   :location (str "/" (:id grandparent) "/")}
                          Collection  child       {:name     "Child Collection"
                                                   :location (str "/" (:id grandparent) "/" (:id parent) "/")}
-                         Card        c1          {:name "root card"        :collection_id nil}
+                         Card        c1          {:name "root card" :collection_id nil}
                          Card        c2          {:name "grandparent card" :collection_id (:id grandparent)}
-                         Card        c3          {:name "parent card"      :collection_id (:id parent)}
-                         Card        c4          {:name "child card"       :collection_id (:id child)}
-                         Dashboard   d1          {:name "parent dash"      :collection_id (:id parent)}]
+                         Card        c3          {:name "parent card" :collection_id (:id parent)}
+                         Card        c4          {:name "child card" :collection_id (:id child)}
+                         Dashboard   d1          {:name "parent dash" :collection_id (:id parent)}]
         (let [export (into [] (extract/extract nil))]
           (storage/store! export dump-dir)
           (testing "the right files in the right places"
-            (let [gp-dir (str (:entity_id grandparent) "_grandparent_collection")
-                  p-dir  (str (:entity_id parent)      "_parent_collection")
-                  c-dir  (str (:entity_id child)       "_child_collection")]
-              (is (= #{[gp-dir (str gp-dir ".yaml")]                                          ; Grandparent collection
+            (let [gp-dir    (str (:entity_id grandparent) "_grandparent_collection")
+                  p-dir     (str (:entity_id parent)      "_parent_collection")
+                  c-dir     (str (:entity_id child)       "_child_collection")]
+              (is (= #{[@trash-dir (str @trash-dir ".yaml")]                                  ; Trash collection, always included
+                       [gp-dir (str gp-dir ".yaml")]                                          ; Grandparent collection
                        [gp-dir p-dir (str p-dir ".yaml")]                                     ; Parent collection
                        [gp-dir p-dir c-dir (str c-dir ".yaml")]                               ; Child collection
                        ["cards" (str (:entity_id c1) "_root_card.yaml")]                      ; Root card
@@ -104,19 +111,20 @@
                          Collection         child       {:name      "Child Collection"
                                                          :namespace :snippets
                                                          :location  (str "/" (:id grandparent) "/" (:id parent) "/")}
-                         NativeQuerySnippet c1          {:name "root snippet"        :collection_id nil}
+                         NativeQuerySnippet c1          {:name "root snippet" :collection_id nil}
                          NativeQuerySnippet c2          {:name "grandparent snippet" :collection_id (:id grandparent)}
-                         NativeQuerySnippet c3          {:name "parent snippet"      :collection_id (:id parent)}
-                         NativeQuerySnippet c4          {:name "child snippet"       :collection_id (:id child)}]
-        (let [export          (into [] (extract/extract nil))]
+                         NativeQuerySnippet c3          {:name "parent snippet" :collection_id (:id parent)}
+                         NativeQuerySnippet c4          {:name "child snippet" :collection_id (:id child)}]
+        (let [export (into [] (extract/extract nil))]
           (storage/store! export dump-dir)
-          (let [gp-dir (str (:entity_id grandparent) "_grandparent_collection")
-                p-dir  (str (:entity_id parent)      "_parent_collection")
-                c-dir  (str (:entity_id child)       "_child_collection")]
+          (let [gp-dir    (str (:entity_id grandparent) "_grandparent_collection")
+                p-dir     (str (:entity_id parent)      "_parent_collection")
+                c-dir     (str (:entity_id child)       "_child_collection")]
             (testing "collections under collections/"
               (is (= #{[gp-dir (str gp-dir ".yaml")]                                          ; Grandparent collection
                        [gp-dir p-dir (str p-dir ".yaml")]                                     ; Parent collection
-                       [gp-dir p-dir c-dir (str c-dir ".yaml")]}                              ; Child collection
+                       [gp-dir p-dir c-dir (str c-dir ".yaml")]                               ; Child collection
+                       [@trash-dir (str @trash-dir ".yaml")]}
                      (file-set (io/file dump-dir "collections")))))
             (testing "snippets under snippets/"
               (is (= #{
@@ -208,20 +216,21 @@
             (storage/store! export dump-dir)))))))
 
 (deftest store-error-test
-  (testing "destination not writable"
-    (ts/with-random-dump-dir [parent-dir "serdesv2-"]
-      (let [dump-dir (str parent-dir "/test")]
-        (testing "parent is not writable, cannot create own directory"
-          (.mkdirs (io/file parent-dir))
-          (.setWritable (io/file parent-dir) false)
-          (is (thrown-with-msg? Exception #"Destination path is not writeable: "
-                                (storage/store! [{:serdes/meta [{:model "A" :id "B"}]}]
-                                                dump-dir))))
-        (testing "directory exists but is not writable"
-          (.setWritable (io/file parent-dir) true)
-          (.mkdirs (io/file dump-dir))
-          (io/make-parents dump-dir "inner")
-          (.setWritable (io/file dump-dir) false)
-          (is (thrown-with-msg? Exception #"Destination path is not writeable: "
-                                (storage/store! [{:serdes/meta [{:model "A" :id "B"}]}]
-                                                dump-dir))))))))
+  (mt/with-empty-h2-app-db
+    (testing "destination not writable"
+      (ts/with-random-dump-dir [parent-dir "serdesv2-"]
+        (let [dump-dir (str parent-dir "/test")]
+          (testing "parent is not writable, cannot create own directory"
+            (.mkdirs (io/file parent-dir))
+            (.setWritable (io/file parent-dir) false)
+            (is (thrown-with-msg? Exception #"Destination path is not writeable: "
+                                  (storage/store! [{:serdes/meta [{:model "A" :id "B"}]}]
+                                                  dump-dir))))
+          (testing "directory exists but is not writable"
+            (.setWritable (io/file parent-dir) true)
+            (.mkdirs (io/file dump-dir))
+            (io/make-parents dump-dir "inner")
+            (.setWritable (io/file dump-dir) false)
+            (is (thrown-with-msg? Exception #"Destination path is not writeable: "
+                                  (storage/store! [{:serdes/meta [{:model "A" :id "B"}]}]
+                                                  dump-dir)))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/storage_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/storage_test.clj
@@ -26,7 +26,7 @@
                :let               [rel (.relativize base (.toPath file))]]
            (mapv str rel)))))
 
-(def trash-dir (delay (str (:entity_id (collection/trash-collection)) "_trash")))
+(def ^:private trash-dir (delay (str (:entity_id (collection/trash-collection)) "_trash")))
 
 (deftest basic-dump-test
   (ts/with-random-dump-dir [dump-dir "serdesv2-"]
@@ -84,9 +84,9 @@
         (let [export (into [] (extract/extract nil))]
           (storage/store! export dump-dir)
           (testing "the right files in the right places"
-            (let [gp-dir    (str (:entity_id grandparent) "_grandparent_collection")
-                  p-dir     (str (:entity_id parent)      "_parent_collection")
-                  c-dir     (str (:entity_id child)       "_child_collection")]
+            (let [gp-dir (str (:entity_id grandparent) "_grandparent_collection")
+                  p-dir  (str (:entity_id parent)      "_parent_collection")
+                  c-dir  (str (:entity_id child)       "_child_collection")]
               (is (= #{[@trash-dir (str @trash-dir ".yaml")]                                  ; Trash collection, always included
                        [gp-dir (str gp-dir ".yaml")]                                          ; Grandparent collection
                        [gp-dir p-dir (str p-dir ".yaml")]                                     ; Parent collection
@@ -117,9 +117,9 @@
                          NativeQuerySnippet c4          {:name "child snippet" :collection_id (:id child)}]
         (let [export (into [] (extract/extract nil))]
           (storage/store! export dump-dir)
-          (let [gp-dir    (str (:entity_id grandparent) "_grandparent_collection")
-                p-dir     (str (:entity_id parent)      "_parent_collection")
-                c-dir     (str (:entity_id child)       "_child_collection")]
+          (let [gp-dir (str (:entity_id grandparent) "_grandparent_collection")
+                p-dir  (str (:entity_id parent)      "_parent_collection")
+                c-dir  (str (:entity_id child)       "_child_collection")]
             (testing "collections under collections/"
               (is (= #{[gp-dir (str gp-dir ".yaml")]                                          ; Grandparent collection
                        [gp-dir p-dir (str p-dir ".yaml")]                                     ; Parent collection
@@ -142,7 +142,7 @@
                          Field       website {:name "Company/organization website" :table_id (:id table)}
                          FieldValues _       {:field_id (:id website)}
                          Table       _       {:name "Orders/Invoices" :db_id (:id db)}]
-        (let [export          (into [] (extract/extract {:include-field-values true}))]
+        (let [export (into [] (extract/extract {:include-field-values true}))]
           (storage/store! export dump-dir)
           (testing "the right files in the right places"
             (is (= #{["Company__SLASH__organization website.yaml"]

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -6946,11 +6946,11 @@ databaseChangeLog:
       rollback:
         - sql:
             sql: >-
-              DELETE p
-              FROM permissions p
-              JOIN collection c ON p.object = CONCAT('/collection/', c.id, '/')
-              WHERE c.type = 'trash';
-
+              DELETE
+              FROM permissions
+              WHERE permissions.object IN (
+                SELECT CONCAT('/collection/', collection.id, '/') FROM collection WHERE collection.type = 'trash'
+              );
               DELETE FROM collection WHERE type = 'trash';
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -6941,7 +6941,7 @@ databaseChangeLog:
               SELECT CONCAT('/collection/', c.id, '/'), pg.id
               FROM collection c
               CROSS JOIN permissions_group pg
-              WHERE c.type = 'trash';
+              WHERE c.type = 'trash' AND pg.name != 'Administrators';
 
       rollback:
         - sql:

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -6929,6 +6929,30 @@ databaseChangeLog:
             constraintName: fk_dashboard_collection_id
             onDelete: CASCADE
 
+  - changeSet:
+      id: v50.2024-05-03T16:29:53
+      author: johnswanson
+      comment: Create the Trash collection
+      changes:
+        - sql:
+            sql: >-
+              INSERT INTO collection (name, slug, entity_id, type) VALUES ('Trash', 'trash', 'trashtrashtrashtrasht', 'trash');
+              INSERT INTO permissions (object, group_id)
+              SELECT CONCAT('/collection/', c.id, '/'), pg.id
+              FROM collection c
+              CROSS JOIN permissions_group pg
+              WHERE c.type = 'trash';
+
+      rollback:
+        - sql:
+            sql: >-
+              DELETE p
+              FROM permissions p
+              JOIN collection c ON p.object = CONCAT('/collection/', c.id, '/')
+              WHERE c.type = 'trash';
+
+              DELETE FROM collection WHERE type = 'trash';
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -499,7 +499,7 @@
    collection_preview     [:maybe :boolean]}
   (let [card-before-update     (t2/hydrate (api/write-check Card id)
                                            [:moderation_reviews :moderator_details])
-        card-updates           (api/move-on-archive-or-unarchive card-before-update card-updates)
+        card-updates           (api/move-on-archive-or-unarchive card-before-update card-updates (collection/trash-collection-id))
         is-model-after-update? (if (nil? type)
                                  (card/model? card-before-update)
                                  (card/model? card-updates))]

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -12,7 +12,6 @@
    [malli.transform :as mtx]
    [medley.core :as m]
    [metabase.api.common :as api]
-   [metabase.config :as config]
    [metabase.db :as mdb]
    [metabase.db.query :as mdb.query]
    [metabase.driver.common.parameters :as params]
@@ -88,10 +87,10 @@
                        (case archived
                          nil nil
                          false [:and
-                                [:not= :id config/trash-collection-id]
+                                [:not= :id (collection/trash-collection-id)]
                                 [:not :archived]]
                          true [:or
-                               [:= :id config/trash-collection-id]
+                               [:= :id (collection/trash-collection-id)]
                                :archived])
                        (when shallow
                          (location-from-collection-id-clause collection-id))
@@ -535,8 +534,8 @@
   (-> (assoc (collection/effective-children-query
               collection
               (if archived?
-                [:or [:= :archived true] [:= :id config/trash-collection-id]]
-                [:and [:= :archived false] [:not= :id config/trash-collection-id]])
+                [:or [:= :archived true] [:= :id (collection/trash-collection-id)]]
+                [:and [:= :archived false] [:not= :id (collection/trash-collection-id)]])
               (perms/audit-namespace-clause :namespace (u/qualified-name collection-namespace))
               (snippets-collection-filter-clause))
              ;; We get from the effective-children-query a normal set of columns selected:

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -104,7 +104,10 @@
                         (collection/permissions-set->visible-collection-ids permissions-set))]
                ;; Order NULL collection types first so that audit collections are last
                :order-by [[[[:case [:= :authority_level "official"] 0 :else 1]] :asc]
-                          [[[:case [:= :type nil] 0 :else 1]] :asc]
+                          [[[:case
+                             [:= :type nil] 0
+                             [:= :type collection/trash-collection-type] 1
+                             :else 2]] :asc]
                           [:%lower.name :asc]]})
    exclude-other-user-collections (remove-other-users-personal-subcollections api/*current-user-id*)))
 
@@ -753,7 +756,10 @@
   [sort-info db-type]
   ;; always put "Metabase Analytics" last
   (into [[[[:case [:= :authority_level "official"] 0 :else 1]] :asc]
-         [[[:case [:= :collection_type nil] 0 :else 1]] :asc]]
+         [[[:case
+            [:= :collection_type nil] 0
+            [:= :collection_type collection/trash-collection-type] 1
+            :else 2]] :asc]]
         (case sort-info
           nil                     [[:%lower.name :asc]]
           [:name :asc]            [[:%lower.name :asc]]

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -664,11 +664,11 @@
   "Given a current instance with a `collection_id` and `trashed_from_collection_id` and a set of updates to that
   instance, return a possibly modified version of the updates reflecting the fact that archiving or unarchiving also
   moves the instance to/from the Trash."
-  [current-obj obj-updates]
+  [current-obj obj-updates trash-collection-id]
   (cond-> obj-updates
     (column-will-change? :archived current-obj obj-updates)
     (assoc :collection_id (cond
-                            (:archived obj-updates) config/trash-collection-id
+                            (:archived obj-updates) trash-collection-id
 
                             (column-will-change? :collection_id current-obj obj-updates)
                             (:collection_id obj-updates)

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -702,7 +702,7 @@
           ;; tabs are always sent in production as well when dashcards are updated, but there are lots of
           ;; tests that exclude it. so this only checks for dashcards
           update-dashcards-and-tabs?         (contains? dash-updates :dashcards)
-          dash-updates                       (api/move-on-archive-or-unarchive current-dash dash-updates)]
+          dash-updates                       (api/move-on-archive-or-unarchive current-dash dash-updates (collection/trash-collection-id))]
       (collection/check-allowed-to-change-collection current-dash dash-updates)
       (check-allowed-to-change-embedding current-dash dash-updates)
       (api/check-500

--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -149,10 +149,6 @@
   "ID of Audit DB which is loaded when running an EE build. ID is placed in OSS code to facilitate permission checks."
   13371337)
 
-(def ^:const trash-collection-id
-  "ID of the Trash collection."
-  13371339)
-
 (def ^:const internal-mb-user-id
   "The user-id of the internal metabase user.
    This is needed in the OSS edition to filter out users for setup/has-user-setup."

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -13,7 +13,6 @@
    [metabase.driver.postgres]
    [metabase.events :as events]
    [metabase.logger :as logger]
-   [metabase.models.collection :as collection]
    [metabase.models.setting :as settings]
    [metabase.plugins :as plugins]
    [metabase.plugins.classloader :as classloader]
@@ -146,7 +145,6 @@
         (sample-data/update-sample-database-if-needed!)))
     (init-status/set-progress! 0.9))
 
-  (collection/ensure-trash-collection-created!)
   (ensure-audit-db-installed!)
   (init-status/set-progress! 0.95)
 

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -938,7 +938,7 @@ saved later when it is ready."
 
 (defmethod serdes/dependencies "Card"
   [{:keys [collection_id database_id dataset_query parameters parameter_mappings
-           result_metadata table_id visualization_settings]}]
+           result_metadata table_id visualization_settings trashed_from_collection_id]}]
   (->> (map serdes/mbql-deps parameter_mappings)
        (reduce set/union #{})
        (set/union (serdes/parameters-deps parameters))
@@ -946,6 +946,7 @@ saved later when it is ready."
        ; table_id and collection_id are nullable.
        (set/union (when table_id #{(serdes/table->path table_id)}))
        (set/union (when collection_id #{[{:model "Collection" :id collection_id}]}))
+       (set/union (when trashed_from_collection_id #{[{:model "Collection" :id trashed_from_collection_id}]}))
        (set/union (result-metadata-deps result_metadata))
        (set/union (serdes/mbql-deps dataset_query))
        (set/union (serdes/visualization-settings-deps visualization_settings))

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -1034,11 +1034,16 @@
   "The value of the `:type` field for the `instance-analytics` Collection created in [[metabase-enterprise.audit-db]]"
   "instance-analytics")
 
+(def trash-collection-type
+  "The value of the `:type` field for the Trash collection that holds archived items."
+  "trash")
+
 (defmethod mi/exclude-internal-content-hsql :model/Collection
   [_model & {:keys [table-alias]}]
   (let [maybe-alias #(h2x/identifier :field (some-> table-alias name) %)]
     [:and
      [:not= (maybe-alias :type) [:inline instance-analytics-collection-type]]
+     [:not= (maybe-alias :type) [:inline trash-collection-type]]
      [:not (maybe-alias :is_sample)]]))
 
 (defn- parent-identity-hash [coll]

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -841,7 +841,8 @@
 
   For newly created Collections at the root-level, copy the existing permissions for the Root Collection."
   [{:keys [location id], collection-namespace :namespace, :as collection}]
-  (when-not (is-personal-collection-or-descendant-of-one? collection)
+  (when-not (or (is-personal-collection-or-descendant-of-one? collection)
+                (is-trash-or-descendant? collection))
     (let [parent-collection-id (location-path->parent-id location)]
       (copy-collection-permissions! (or parent-collection-id (assoc root-collection :namespace collection-namespace))
                                     [id]))))

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -46,8 +46,7 @@
   510)
 
 (defn- trash-collection* []
-  (t2/select-one :model/Collection :type "trash")
-  )
+  (t2/select-one :model/Collection :type "trash"))
 
 (def ^{:arglists '([])} trash-collection
   "Memoized copy of the Trash collection from the DB."
@@ -1065,13 +1064,13 @@
   ;; Use the :slug as the human-readable label.
   [_model-name _opts coll]
   (let [fetch-collection       (fn [id]
-                              (t2/select-one Collection :id id))
+                                 (t2/select-one Collection :id id))
         {:keys [trashed_from_parent_id
                 parent_id]}    (some-> coll :id fetch-collection (t2/hydrate :parent_id :trashed_from_parent_id))
         parent                 (some-> parent_id fetch-collection)
         trashed-from-parent    (some-> trashed_from_parent_id fetch-collection)
         parent-id              (when parent
-                              (or (:entity_id parent) (serdes/identity-hash parent)))
+                                 (or (:entity_id parent) (serdes/identity-hash parent)))
         trashed-from-parent-id (when trashed-from-parent
                                  (or (:entity_id trashed-from-parent) (serdes/identity-hash trashed-from-parent)))
         owner-email            (when (:personal_owner_id coll)

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -462,7 +462,8 @@
 (methodical/defmethod t2/simple-hydrate [:default :trashed_from_parent_id]
   "Get the immediate parent `collection` id this collection was *trashed* from, if set."
   [_model k collection]
-  (assoc collection k (trashed-from-parent-id* collection)))
+  (cond-> collection
+    (:archived collection) (assoc k (trashed-from-parent-id* collection))))
 
 (methodical/defmethod t2/simple-hydrate [:default :parent_id]
   "Get the immediate parent `collection` id, if set."
@@ -1082,7 +1083,7 @@
                :trashed_from_parent_id trashed-from-parent-id)
         (assoc-in [:serdes/meta 0 :label] (:slug coll)))))
 
-(defmethod serdes/load-xform "Collection" [{:keys [parent_id trashed_from_parent_id] :as contents}]
+(defmethod serdes/load-xform "Collection" [{:keys [parent_id trashed_from_parent_id archived] :as contents}]
   (let [loc (fn [col-id]
               (if col-id
                 (let [{:keys [id location]} (serdes/lookup-by-id Collection col-id)]
@@ -1092,7 +1093,7 @@
         (dissoc :parent_id)
         (dissoc :trashed_from_parent_id)
         (assoc :location (loc parent_id)
-               :trashed_from_location (loc trashed_from_parent_id))
+               :trashed_from_location (when archived (loc trashed_from_parent_id)))
         (update :personal_owner_id serdes/*import-user*)
         serdes/load-xform-basics)))
 

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -77,12 +77,6 @@
   [collection]
   (str/starts-with? (:location collection) (trash-path)))
 
-(defn ensure-trash-collection-created!
-  "Creates the trash collection if it does not already exist."
-  []
-  ;; just call `trash-collection`
-  (trash-collection))
-
 (def Collection
   "Used to be the toucan1 model name defined using [[toucan.models/defmodel]], no2 it's a reference to the toucan2 model name.
   We'll keep this till we replace all the Card symbol in our codebase."
@@ -693,7 +687,6 @@
    ;; between specifying a `nil` parent_id (move to the root) and not specifying a parent_id.
    updates :- [:map [:parent_id {:optional true} [:maybe ms/PositiveInt]
                      :archived :boolean]]]
-  (ensure-trash-collection-created!)
   (let [namespaced?   (some? (:namespace collection))
         archived? (:archived updates)
         new-parent-id (cond

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -680,10 +680,11 @@
        set))
 
 (defmethod serdes/dependencies "Dashboard"
-  [{:keys [collection_id dashcards parameters]}]
+  [{:keys [collection_id dashcards parameters trashed_from_collection_id]}]
   (->> (map serdes-deps-dashcard dashcards)
        (reduce set/union #{})
        (set/union (when collection_id #{[{:model "Collection" :id collection_id}]}))
+       (set/union (when trashed_from_collection_id #{[{:model "Collection" :id trashed_from_collection_id}]}))
        (set/union (serdes/parameters-deps parameters))))
 
 (defmethod serdes/descendants "Dashboard" [_model-name id]

--- a/src/metabase/models/revision/diff.clj
+++ b/src/metabase/models/revision/diff.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.core.match :refer [match]]
    [clojure.data :as data]
-   [metabase.config :as config]
+   [metabase.models.collection :as collection]
    [metabase.util.i18n :refer [deferred-tru]]
    [toucan2.core :as t2]))
 
@@ -51,14 +51,14 @@
 
     [:collection_id nil coll-id]
     ;; trash/untrash is handled by `archived`
-    (when-not (= coll-id config/trash-collection-id)
+    (when-not (= coll-id (collection/trash-collection-id))
       (deferred-tru "moved {0} to {1}" identifier (if coll-id
                                                     (t2/select-one-fn :name 'Collection coll-id)
                                                     (deferred-tru "Our analytics"))))
 
     [:collection_id (prev-coll-id :guard int?) coll-id]
     ;; trash/untrash is handled by `archived`
-    (when-not (or (= prev-coll-id config/trash-collection-id) (= coll-id config/trash-collection-id))
+    (when-not (or (= prev-coll-id (collection/trash-collection-id)) (= coll-id (collection/trash-collection-id)))
       (deferred-tru "moved {0} from {1} to {2}"
         identifier
         (t2/select-one-fn :name 'Collection prev-coll-id)

--- a/test/metabase/api/bookmark_test.clj
+++ b/test/metabase/api/bookmark_test.clj
@@ -77,7 +77,6 @@
 
 (deftest bookmarks-on-archived-items-test
   (testing "POST /api/bookmark/:model/:model-id"
-    (collection/ensure-trash-collection-created!)
     (mt/with-temp [Collection archived-collection {:name "Test Collection"
                                                    :archived true
                                                    :location (collection/trash-path)

--- a/test/metabase/api/bookmark_test.clj
+++ b/test/metabase/api/bookmark_test.clj
@@ -80,7 +80,7 @@
     (collection/ensure-trash-collection-created!)
     (mt/with-temp [Collection archived-collection {:name "Test Collection"
                                                    :archived true
-                                                   :location collection/trash-path
+                                                   :location (collection/trash-path)
                                                    :trashed_from_location "/"}
                    Card       archived-card {:name "Test Card" :archived true}
                    Dashboard  archived-dashboard {:name "Test Dashboard" :archived true}]

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -23,7 +23,6 @@
     :refer [Card CardBookmark Collection Dashboard Database ModerationReview
             Pulse PulseCard PulseChannel PulseChannelRecipient Table Timeline
             TimelineEvent]]
-   [metabase.models.collection :as collection]
    [metabase.models.moderation-review :as moderation-review]
    [metabase.models.permissions :as perms]
    [metabase.models.permissions-group :as perms-group]
@@ -276,7 +275,6 @@
 
 (deftest filter-by-archived-test
   (testing "GET /api/card?f=archived"
-    (collection/ensure-trash-collection-created!)
     (mt/with-temp [:model/Card card-1 {:name "Card 1"}
                    :model/Card card-2 {:name "Card 2"}
                    :model/Card card-3 {:name "Card 3"}]

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -155,7 +155,6 @@
                   (into #{})))))))
 
 (deftest list-collections-archived-test
-  (collection/ensure-trash-collection-created!)
   (testing "GET /api/collection"
     (t2.with-temp/with-temp [Collection {archived-col-id :id} {:name "Archived Collection"}
                              Collection _ {:name "Regular Collection"}]
@@ -1394,7 +1393,6 @@
                       (api-get-collection-children a)))))))
 
 (deftest effective-ancestors-and-children-archived-test
-  (collection/ensure-trash-collection-created!)
   (testing "Let's make sure the 'archived` option works on Collections, nested or not"
     (with-collection-hierarchy [a b c]
       (mt/user-http-request :crowberto :put 200 (str "collection/" (u/the-id b))

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -6,7 +6,6 @@
    [clojure.test :refer :all]
    [metabase.api.card-test :as api.card-test]
    [metabase.api.collection :as api.collection]
-   [metabase.config :as config]
    [metabase.models
     :refer [Card Collection Dashboard DashboardCard ModerationReview
             NativeQuerySnippet PermissionsGroup PermissionsGroupMembership Pulse
@@ -158,11 +157,9 @@
 (deftest list-collections-archived-test
   (collection/ensure-trash-collection-created!)
   (testing "GET /api/collection"
-    (t2.with-temp/with-temp [Collection _ {:name "Archived Collection"
-                                           :location collection/trash-path
-                                           :archived true
-                                           :trashed_from_location "/"}
+    (t2.with-temp/with-temp [Collection {archived-col-id :id} {:name "Archived Collection"}
                              Collection _ {:name "Regular Collection"}]
+      (mt/user-http-request :rasta :put 200 (str "/collection/" archived-col-id) {:archived true})
       (letfn [(remove-other-collections [collections]
                 (filter (fn [{collection-name :name}]
                           (or (#{"Our analytics" "Archived Collection" "Regular Collection"} collection-name)
@@ -798,16 +795,16 @@
         (perms/grant-collection-read-permissions! (perms-group/all-users) collection)
         (mt/user-http-request :crowberto :put 200 (str "collection/" (u/the-id collection)) {:archived true})
         (is (partial= [{:name "Art Collection", :description nil, :model "collection", :entity_id true}]
-                      (get-items :crowberto config/trash-collection-id)))
+                      (get-items :crowberto (collection/trash-collection-id))))
         (is (partial= [{:name "Baby Collection", :model "collection" :entity_id true}]
                       (get-items :crowberto collection)))))
     (testing "I can untrash something by marking it as not archived"
       (t2.with-temp/with-temp [Collection collection {:name "A"}]
         (perms/grant-collection-read-permissions! (perms-group/all-users) collection)
         (mt/user-http-request :crowberto :put 200 (str "collection/" (u/the-id collection)) {:archived true})
-        (is (= 1 (count (:data (mt/user-http-request :rasta :get 200 (str "collection/" config/trash-collection-id "/items"))))))
+        (is (= 1 (count (:data (mt/user-http-request :rasta :get 200 (str "collection/" (collection/trash-collection-id) "/items"))))))
         (mt/user-http-request :crowberto :put 200 (str "collection/" (u/the-id collection)) {:archived false})
-        (is (zero? (count (:data (mt/user-http-request :rasta :get 200 (str "collection/" config/trash-collection-id "/items"))))))))
+        (is (zero? (count (:data (mt/user-http-request :rasta :get 200 (str "collection/" (collection/trash-collection-id) "/items"))))))))
     (testing "I can untrash something to a specific location if desired"
       (t2.with-temp/with-temp [Collection collection-a {:name "A"}
                                Collection collection-b {:name "B" :location (collection/children-location collection-a)}
@@ -816,7 +813,7 @@
         (perms/grant-collection-read-permissions! (perms-group/all-users) collection-b)
         (perms/grant-collection-read-permissions! (perms-group/all-users) destination)
         (mt/user-http-request :crowberto :put 200 (str "collection/" (u/the-id collection-a)) {:archived true})
-        (is (= #{"A"} (set-of-item-names :crowberto config/trash-collection-id)))
+        (is (= #{"A"} (set-of-item-names :crowberto (collection/trash-collection-id))))
         (is (= #{} (set-of-item-names :crowberto destination)))
         ;; both A and B are marked as `archived`
         (is (:archived (mt/user-http-request :crowberto :get 200 (str "collection/" (u/the-id collection-b)))))
@@ -826,7 +823,7 @@
 
         (mt/user-http-request :crowberto :put 200 (str "collection/" (u/the-id collection-b)) {:archived false :parent_id (u/the-id destination)})
         ;; collection A is still here!
-        (is (= #{"A"} (set-of-item-names :crowberto config/trash-collection-id)))
+        (is (= #{"A"} (set-of-item-names :crowberto (collection/trash-collection-id))))
         ;; collection B got moved correctly
         (is (= #{"B"} (set-of-item-names :crowberto destination)))
 
@@ -878,7 +875,7 @@
                  "sub-C"
                  "sub-B"
                  ;; can see the dashboard in Collection C, because Rasta has read/write permissions on Collection C
-                 "dashboard-C"} (set-of-item-names config/trash-collection-id))))
+                 "dashboard-C"} (set-of-item-names (collection/trash-collection-id)))))
       (testing "if the collections themselves are trashed, subcollection checks still work the same way"
         (doseq [coll [collection-a collection-b collection-c]]
           (mt/user-http-request :crowberto :put 200 (str "collection/" (u/the-id coll)) {:archived true}))
@@ -887,7 +884,7 @@
                  "sub-C"
                  "C"
                  "dashboard-C"}
-               (set-of-item-names config/trash-collection-id))))
+               (set-of-item-names (collection/trash-collection-id)))))
       (testing "after hard deletion of a collection, only admins can see things trashed from them"
         (doseq [coll [collection-a collection-b collection-c]]
           (mt/user-http-request :crowberto :delete 200 (str "collection/" (u/the-id coll))))
@@ -895,10 +892,10 @@
         ;; - Collection C because it's deleted
         ;; - dashboard C because permissions records are deleted along with the collection
         (is (= #{"sub-A" "sub-B" "sub-C"}
-               (set-of-item-names config/trash-collection-id)))
+               (set-of-item-names (collection/trash-collection-id))))
         ;; Crowberto can see all of the still-existent things.
         (is (= #{"sub-A" "sub-B" "sub-C" "dashboard-A" "dashboard-B" "dashboard-C"}
-               (->> (get-items :crowberto config/trash-collection-id)
+               (->> (get-items :crowberto (collection/trash-collection-id))
                     (map :name)
                     set)))))))
 
@@ -1109,25 +1106,37 @@
   (testing "Default sort"
     (doseq [app-db [:mysql :h2 :postgres]]
       (is (= [[[[:case [:= :authority_level "official"] 0 :else 1]] :asc]
-              [[[:case [:= :collection_type nil] 0 :else 1]] :asc]
+              [[[:case
+                 [:= :collection_type nil] 0
+                 [:= :collection_type collection/trash-collection-type] 1
+                 :else 2]] :asc]
               [:%lower.name :asc]]
              (api.collection/children-sort-clause nil app-db)))))
   (testing "Sorting by last-edited-at"
     (is (= [[[[:case [:= :authority_level "official"] 0 :else 1]] :asc]
-            [[[:case [:= :collection_type nil] 0 :else 1]] :asc]
+            [[[:case
+               [:= :collection_type nil] 0
+               [:= :collection_type collection/trash-collection-type] 1
+               :else 2]] :asc]
             [:%isnull.last_edit_timestamp]
             [:last_edit_timestamp :asc]
             [:%lower.name :asc]]
            (api.collection/children-sort-clause [:last-edited-at :asc] :mysql)))
     (is (= [[[[:case [:= :authority_level "official"] 0 :else 1]] :asc]
-            [[[:case [:= :collection_type nil] 0 :else 1]] :asc]
+            [[[:case
+               [:= :collection_type nil] 0
+               [:= :collection_type collection/trash-collection-type] 1
+               :else 2]] :asc]
             [:last_edit_timestamp :nulls-last]
             [:last_edit_timestamp :asc]
             [:%lower.name :asc]]
            (api.collection/children-sort-clause [:last-edited-at :asc] :postgres))))
   (testing "Sorting by last-edited-by"
     (is (= [[[[:case [:= :authority_level "official"] 0 :else 1]] :asc]
-            [[[:case [:= :collection_type nil] 0 :else 1]] :asc]
+            [[[:case
+                 [:= :collection_type nil] 0
+                 [:= :collection_type collection/trash-collection-type] 1
+                 :else 2]] :asc]
             [:last_edit_last_name :nulls-last]
             [:last_edit_last_name :asc]
             [:last_edit_first_name :nulls-last]
@@ -1135,7 +1144,10 @@
             [:%lower.name :asc]]
            (api.collection/children-sort-clause [:last-edited-by :asc] :postgres)))
     (is (= [[[[:case [:= :authority_level "official"] 0 :else 1]] :asc]
-            [[[:case [:= :collection_type nil] 0 :else 1]] :asc]
+            [[[:case
+               [:= :collection_type nil] 0
+               [:= :collection_type collection/trash-collection-type] 1
+               :else 2]] :asc]
             [:%isnull.last_edit_last_name]
             [:last_edit_last_name :asc]
             [:%isnull.last_edit_first_name]
@@ -1144,12 +1156,18 @@
            (api.collection/children-sort-clause [:last-edited-by :asc] :mysql))))
   (testing "Sorting by model"
     (is (= [[[[:case [:= :authority_level "official"] 0 :else 1]] :asc]
-            [[[:case [:= :collection_type nil] 0 :else 1]] :asc]
+            [[[:case
+               [:= :collection_type nil] 0
+               [:= :collection_type collection/trash-collection-type] 1
+               :else 2]] :asc]
             [:model_ranking :asc]
             [:%lower.name :asc]]
            (api.collection/children-sort-clause [:model :asc] :postgres)))
     (is (= [[[[:case [:= :authority_level "official"] 0 :else 1]] :asc]
-            [[[:case [:= :collection_type nil] 0 :else 1]] :asc]
+            [[[:case
+               [:= :collection_type nil] 0
+               [:= :collection_type collection/trash-collection-type] 1
+               :else 2]] :asc]
             [:model_ranking :desc]
             [:%lower.name :asc]]
            (api.collection/children-sort-clause [:model :desc] :mysql)))))
@@ -2110,13 +2128,13 @@
                    (filter #(= (:name %) "Trash"))))))
   (testing "We can optionally request to include the Trash"
     (is (= [{:name "Trash"
-             :id config/trash-collection-id}]
+             :id (collection/trash-collection-id)}]
            (->> (:data (mt/user-http-request :crowberto :get 200 "collection/root/items" :archived true))
-                (filter #(= (:id %) config/trash-collection-id))
+                (filter #(= (:id %) (collection/trash-collection-id)))
                 (map #(select-keys % [:name :id])))))))
 
 (deftest collection-tree-includes-trash-if-requested
   (testing "Trash collection is included by default"
-    (is (some #(= (:id %) config/trash-collection-id) (mt/user-http-request :crowberto :get 200 "collection/tree"))))
+    (is (some #(= (:id %) (collection/trash-collection-id)) (mt/user-http-request :crowberto :get 200 "collection/tree"))))
   (testing "Trash collection is NOT included if `exclude-archived` is passed"
-    (is (not (some #(= (:id %) config/trash-collection-id) (mt/user-http-request :crowberto :get 200 "collection/tree" :exclude-archived "true"))))))
+    (is (not (some #(= (:id %) (collection/trash-collection-id)) (mt/user-http-request :crowberto :get 200 "collection/tree" :exclude-archived "true"))))))

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -133,8 +133,8 @@
         :when (false? (:archived result))]
     (cond-> result
       true (assoc :archived true)
-      (= (:model result) "collection") (assoc :location collection/trash-path
-                                              :effective_location collection/trash-path))))
+      (= (:model result) "collection") (assoc :location (collection/trash-path)
+                                              :effective_location (collection/trash-path)))))
 
 (defn- on-search-types [model-set f coll]
   (for [search-item coll]
@@ -708,7 +708,7 @@
   (assoc m
          :archived true
          :trashed_from_location "/"
-         :location collection/trash-path))
+         :location (collection/trash-path)))
 
 (deftest archived-results-test
   (testing "Should return unarchived results by default"


### PR DESCRIPTION
Two major changes here.

First, don't set the trash ID to a constant 13371339. Instead, just add it like a normal collection (in a migration), with an appropriate `type`, and cache that so we're not constantly fetching the ID when needed.

Second, serialize the Trash correctly. If we're serializing a set of collections, serialize any items that were _trashed from_ one of those collections, as well as items that are still in the collection. However, hardcode the `descendants` of the Trash collection itself to the empty set. This way, even though we're serializing the Trash, we won't cascade down and serialize all of its descendants - just those that are being otherwise included in the export.

Fixes #42301 