### PR TITLE
Allow disabling health check logging via env var

### DIFF
--- a/src/metabase/server/middleware/log.clj
+++ b/src/metabase/server/middleware/log.clj
@@ -206,10 +206,8 @@
 (defn- logging-disabled-uris
   "The set of URIs that should not be logged."
   []
-  (->> ["/api/util/logs"
-        (when-not (health-check-logging-enabled) "/api/health")]
-       (remove nil?)
-       set))
+  (cond-> #{"/api/util/logs"}
+    (not (health-check-logging-enabled)) (conj "/api/health")))
 
 (defn- should-log-request? [{:keys [uri], :as request}]
   ;; don't log calls to /health or /util/logs because they clutter up the logs (especially the window in admin) with

--- a/src/metabase/server/middleware/log.clj
+++ b/src/metabase/server/middleware/log.clj
@@ -10,10 +10,11 @@
    [metabase.db :as mdb]
    [metabase.driver.sql-jdbc.execute.diagnostic
     :as sql-jdbc.execute.diagnostic]
+   [metabase.models.setting :refer [defsetting]]
    [metabase.server :as server]
    [metabase.server.request.util :as req.util]
    [metabase.util :as u]
-   [metabase.util.i18n :refer [trs]]
+   [metabase.util.i18n :as i18n :refer [deferred-tru trs]]
    [metabase.util.log :as log]
    [toucan2.core :as t2])
   (:import
@@ -195,11 +196,26 @@
 ;; Actual middleware. Determines whether request should be logged, and, if so, creates the info dictionary and hands
 ;; off to functions above.
 
+(defsetting health-check-logging-enabled
+  (deferred-tru "Whether to log health check requests from session middleware.")
+  :type       :boolean
+  :default    true
+  :visibility :internal
+  :export?    false)
+
+(defn- logging-disabled-uris
+  "The set of URIs that should not be logged."
+  []
+  (->> ["/api/util/logs"
+        (when-not (health-check-logging-enabled) "/api/health")]
+       (remove nil?)
+       set))
+
 (defn- should-log-request? [{:keys [uri], :as request}]
   ;; don't log calls to /health or /util/logs because they clutter up the logs (especially the window in admin) with
   ;; useless lines
   (and (req.util/api-call? request)
-       (not (#{"/api/util/logs"} uri))))
+       (not ((logging-disabled-uris) uri))))
 
 (defn log-api-call
   "Logs info about request such as status code, number of DB calls, and time taken to complete."

--- a/test/metabase/server/middleware/log_test.clj
+++ b/test/metabase/server/middleware/log_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase.server.middleware.log :as mw.log]
+   [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]))
 
 (use-fixtures :once (fixtures/initialize :db))
@@ -20,3 +21,11 @@
   (testing `log/stats
     (is (re= #"^App DB connections:.*"
              (#'mw.log/stats (fn [] {:info true}))))))
+
+(deftest should-log-request?-test
+  (testing "Health check logging can be disabled via env var"
+    (mt/with-temp-env-var-value! [mb-health-check-logging-enabled true]
+      (is (#'mw.log/should-log-request? {:uri "/api/health"})))
+
+    (mt/with-temp-env-var-value! [mb-health-check-logging-enabled false]
+      (is (not (#'mw.log/should-log-request? {:uri "/api/health"}))))))


### PR DESCRIPTION
Pursuant to title, adds a `MB_HEALTH_CHECK_LOGGING_ENABLED` env var which can be set to `false` to omit these logs. Env var name & boolean direction is arbitrary, can change it if requested.

Closes https://github.com/metabase/metabase/issues/35338