### PR TITLE
bump methodical

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -243,7 +243,7 @@
                                   [org.ow2.asm/asm-all]}
     criterium/criterium          {:mvn/version "0.4.6"}                     ; benchmarking library
     lambdaisland/deep-diff2      {:mvn/version "2.11.216"}                  ; way better diffs
-    methodical/methodical        {:mvn/version "0.15.1"}                    ; drop-in replacements for Clojure multimethods and adds several advanced features
+    methodical/methodical        {:mvn/version "1.0.111"}                   ; drop-in replacements for Clojure multimethods and adds several advanced features
     org.clojure/algo.generic     {:mvn/version "1.0.1"}
     peridot/peridot              {:git/url "https://github.com/piranha/peridot.git"
                                   :sha "999d0a02425c906c35bace749654dc095ecf3e6a"} ; mocking Ring requests; waiting for upstream release of commit 0fc7c01 (explicit charset)


### PR DESCRIPTION
now:

```clojure
❯ clj -M:"$ALIASES"
Warning: environ value /Users/dan/.sdkman/candidates/java/current for key :java-home has been overwritten with /Users/dan/.sdkman/candidates/java/21.0.2-tem
2024-05-07 19:55:25,167 INFO metabase.util :: Maximum memory available to JVM: 8.0 GB
```

no logs about recur targets unboxing

related:
- https://github.com/metabase/metabase/pull/42311
- https://github.com/camsaul/methodical/pull/147 (these changes are what this version bump brings in)