### PR TITLE
Fix failed to upgrade when instances have obsolete 3rd party drivers

### DIFF
--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -1080,9 +1080,9 @@
   ;; this migraiton to remove triggers for any existing DB that have this option on.
   ;; See #40715
   (when-let [;; find all dbs which are configured not to scan field values
-             dbs (seq (filter #(and (-> % :details :let-user-control-scheduling)
+             dbs (seq (filter #(and (-> % :details json/parse-string :let-user-control-scheduling)
                                     (false? (:is_full_sync %)))
-                              (t2/select :model/Database)))]
+                              (t2/select :metabase_database)))]
     (classloader/the-classloader)
     (set-jdbc-backend-properties!)
     (let [scheduler (qs/initialize)]

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -1080,7 +1080,7 @@
   ;; this migraiton to remove triggers for any existing DB that have this option on.
   ;; See #40715
   (when-let [;; find all dbs which are configured not to scan field values
-             dbs (seq (filter #(and (-> % :details json/parse-string :let-user-control-scheduling)
+             dbs (seq (filter #(and (-> % :details (json/parse-string keyword) :let-user-control-scheduling)
                                     (false? (:is_full_sync %)))
                               (t2/select :metabase_database)))]
     (classloader/the-classloader)


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/42319

Users will fail to upgrade if they have a database connected to 3rd party drivers and run an obsolete version. This is because in our `DeleteScanFieldValuesTriggerForDBThatTurnItOff` migration, we use toucan2 to find metabase by using toucan2 models `:model/Database`, this model has an after-select hook that try to initialize that driver. 

And if users have an obsolete driver => initialize, failed => migration failed => fail to upgrade.

Even though those databases are unusable, we shouldn't block users from upgrading.

How to test:
- Download clickhouse driver version 1.2.3 : https://github.com/ClickHouse/metabase-clickhouse-driver/releases/tag/1.2.3 
- Starts metabase version 47(which is compatible with clickhouse v 1.2.3) and add a click house db
- Stop the instance and upgrade to 49.8, and you'll see the failure.