### PR TITLE
Simplify custom font code

### DIFF
--- a/frontend/src/metabase/styled-components/containers/GlobalStyles/GlobalStyles.tsx
+++ b/frontend/src/metabase/styled-components/containers/GlobalStyles/GlobalStyles.tsx
@@ -30,7 +30,7 @@ export const GlobalStyles = (): JSX.Element => {
     ${fontFiles?.map(
       file => css`
         @font-face {
-          font-family: "${font}";
+          font-family: "Custom";
           src: url(${encodeURI(file.src)}) format("${file.fontFormat}");
           font-weight: ${file.fontWeight};
           font-style: normal;


### PR DESCRIPTION
This is a follow-up PR from #42342. I already [asked on Slack](https://metaboat.slack.com/archives/C505ZNNH4/p1715098187144839) that this should be possible.

#### How to verify

Test that the custom font is still working.
1. Go to Admin settings > Appearance > Font: Custom > Set custom font e.g. `https://fonts.gstatic.com/s/poetsenone/v3/ke8hOgIaMUB37xCgvCntWuIoofOzEqG8.woff2`
![image](https://github.com/metabase/metabase/assets/1937582/705feaad-8fed-4347-b618-43488157bc3d)

The custom font and other fonts should still work.