### PR TITLE
Quartz: auto delete jobs without a class during scheduler initialization

### DIFF
--- a/test/metabase/task_test.clj
+++ b/test/metabase/task_test.clj
@@ -5,10 +5,12 @@
    [clojurewerkz.quartzite.schedule.cron :as cron]
    [clojurewerkz.quartzite.scheduler :as qs]
    [clojurewerkz.quartzite.triggers :as triggers]
+   [metabase.db.connection :as mdb.connection]
    [metabase.task :as task]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.test.util :as tu]
+   [metabase.util :as u]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2])
   (:import
@@ -123,6 +125,12 @@
         (task/start-scheduler!)
         (is (qs/started? (#'task/scheduler))))))))
 
+(defn- capitalize-if-mysql [s]
+  (cond-> (name s)
+    (= :mysql (mdb.connection/db-type))
+    u/upper-case-en
+    true keyword))
+
 (deftest start-scheduler-will-cleanup-jobs-without-class-test
   ;; we can't use the temp scheduler in this test because the temp scheduler use an in-memory jobstore
   ;; and we need update the job class in the database to trigger the cleanup
@@ -132,15 +140,16 @@
        (task/start-scheduler!))
      (task/schedule-task! (job) (trigger-1))
      (testing "make sure the job is in the database before we start the scheduler"
-       (is (t2/exists? :qrtz_job_details :job_name "metabase.task-test.job")))
+       (is (t2/exists? (capitalize-if-mysql :qrtz_job_details) (capitalize-if-mysql :job_name) "metabase.task-test.job")))
 
      ;; update the job class to a non-existent class
-     (t2/update! :qrtz_job_details :job_name "metabase.task-test.job" {:job_class_name "NOT_A_REAL_CLASS"})
+     (t2/update! (capitalize-if-mysql :qrtz_job_details) (capitalize-if-mysql :job_name) "metabase.task-test.job"
+                 {(capitalize-if-mysql :job_class_name) "NOT_A_REAL_CLASS"})
      ;; stop the scheduler then restart so [[task/delete-jobs-with-no-class!]] is triggered
      (task/stop-scheduler!)
      (task/start-scheduler!)
      (testing "the job should be removed from the database when the scheduler starts"
-       (is (not (t2/exists? :qrtz_job_details :job_name "metabase.task-test.job"))))
+       (is (not (t2/exists? (capitalize-if-mysql :qrtz_job_details) (capitalize-if-mysql :job_name) "metabase.task-test.job"))))
      (finally
        ;; restore the state of scheduler before we start the test
        (if scheduler-initialized?

--- a/test/metabase/task_test.clj
+++ b/test/metabase/task_test.clj
@@ -9,7 +9,8 @@
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.test.util :as tu]
-   [metabase.util.malli.schema :as ms])
+   [metabase.util.malli.schema :as ms]
+   [toucan2.core :as t2])
   (:import
    (org.quartz CronTrigger JobDetail)))
 
@@ -121,3 +122,25 @@
       (mt/with-temp-env-var-value! ["MB_DISABLE_SCHEDULER" "FALSE"]
         (task/start-scheduler!)
         (is (qs/started? (#'task/scheduler))))))))
+
+(deftest start-scheduler-will-cleanup-jobs-without-class-test
+  (let [scheduler-initialized? (some? (#'task/scheduler))]
+    (try
+      (when-not scheduler-initialized?
+        (task/start-scheduler!))
+      (task/schedule-task! (job) (trigger-1))
+      (testing "make sure the job is in the database before we start the scheduler"
+        (is (t2/exists? :qrtz_job_details :job_name "metabase.task-test.job")))
+
+      ;; update the job class to a non-existent class
+      (t2/update! :qrtz_job_details :job_name "metabase.task-test.job" {:job_class_name "NOT_A_REAL_CLASS"})
+      ;; stop the scheduler then restart so [[task/delete-jobs-with-no-class!]] is triggered
+      (task/stop-scheduler!)
+      (task/start-scheduler!)
+      (testing "the job should be removed from the database when the scheduler starts"
+        (is (not (t2/exists? :qrtz_job_details :job_name "metabase.task-test.job"))))
+      (finally
+        ;; restore the state of scheduler before we start the test
+        (if scheduler-initialized?
+          (task/start-scheduler!)
+          (task/stop-scheduler!))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/36184

Whenever we delete a Quartz Job we have to write a custom migration to delete it, see `DeleteTruncateAuditLogTask` for example. 

This makes it so on initialization of task scheduler, we will automatically delete any jobs that can't find a class.

I don't know how to write a test that involves making a class disappear, but any ideas are welcome!

But here is how I manually tested it.
1. Start MB normally
2. Comment out the `(delete-jobs-with-no-class!)` call in `init-scheduler!`
3. Comment out all the code in `metabase.task.follow-up-emails` to make the `FollowUpEmail` disappear
4. Restart MB, eval `(metabase.task/scheduler-info)` in the reply will print out an exception saying `FollowUpEmail` not found
5. Uncomment `(delete-jobs-with-no-class!)` in step 2, and restart MB
6. Eval `(metabase.task/scheduler-info)`, this time there should be no errors because the `metabase.task.follow-up-emails.job` has been deleted.


This will also prevent us from having situations like this: https://github.com/metabase/metabase/pull/41772#issuecomment-2100263983