### PR TITLE
Fix overflow problem in Filter Modal sidebar

### DIFF
--- a/frontend/src/metabase/querying/components/FilterModal/FilterModal.styled.tsx
+++ b/frontend/src/metabase/querying/components/FilterModal/FilterModal.styled.tsx
@@ -43,3 +43,8 @@ export const ModalBody = styled(Modal.Body)`
 export const ModalFooter = styled(Flex)`
   border-top: 1px solid ${color("border")};
 `;
+
+export const TabsListSidebar = styled(Tabs.List)`
+  overflow-y: auto;
+  flex-wrap: nowrap;
+`;

--- a/frontend/src/metabase/querying/components/FilterModal/FilterModal.tsx
+++ b/frontend/src/metabase/querying/components/FilterModal/FilterModal.tsx
@@ -20,6 +20,7 @@ import {
   ModalFooter,
   ModalHeader,
   TabPanelRoot,
+  TabsListSidebar,
 } from "./FilterModal.styled";
 import { FilterSearchInput } from "./FilterSearchInput";
 import { SegmentFilterEditor } from "./SegmentFilterEditor";
@@ -198,7 +199,7 @@ interface TabListProps {
 
 function TabList({ groupItems }: TabListProps) {
   return (
-    <Tabs.List w="25%" pt="sm" pl="md">
+    <TabsListSidebar w="25%" pt="sm" pl="md">
       {groupItems.map(groupItem => (
         <Tabs.Tab
           key={groupItem.key}
@@ -209,7 +210,7 @@ function TabList({ groupItems }: TabListProps) {
           {groupItem.displayName}
         </Tabs.Tab>
       ))}
-    </Tabs.List>
+    </TabsListSidebar>
   );
 }
 


### PR DESCRIPTION
### Description

Filter modal has a broken layout when many columns from joins are available on the left sidebar.


![image](https://github.com/metabase/metabase/assets/125459446/890f53ca-0d57-4cea-b62f-72ba41eb0bf3)


### How to verify

- Create a question with several joins, save it
- go to the question, open filter modal
- verify that left sidebar has more elements than rendered on the screen and there is scroll bar

### Demo
<img width="852" alt="Screenshot 2024-05-08 at 16 06 13" src="https://github.com/metabase/metabase/assets/125459446/92e1d875-51b3-448e-808d-a83e723a1b7a">

<img width="825" alt="Screenshot 2024-05-08 at 16 06 06" src="https://github.com/metabase/metabase/assets/125459446/87b484c3-ace2-4c3c-9d60-644556159fbe">


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
