### PR TITLE
Do not allow cy.pause() to go into commit

### DIFF
--- a/e2e/.eslintrc
+++ b/e2e/.eslintrc
@@ -6,6 +6,7 @@
     "no-console": 0,
     "@typescript-eslint/no-namespace": "off",
     "cypress/no-async-tests": "error",
+    "cypress/no-pause": "error",
     "quotes": ["error", "double", { "avoidEscape": true }],
     "no-restricted-imports": [
       "error",


### PR DESCRIPTION
Do not allow `cy.pause()` to go into commit

<img width="796" alt="image" src="https://github.com/metabase/metabase/assets/125459446/5be742fa-be10-4a6b-910e-e3a2690f7819">
