### PR TITLE
Tweak the Model explanation banner

### DIFF
--- a/e2e/test/scenarios/models/models-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/models-metadata.cy.spec.js
@@ -334,6 +334,7 @@ describe("scenarios > models metadata", () => {
           cy.findByText("68883"); // zip
           cy.findAllByText("Hudson Borer");
           cy.icon("close").click();
+          // FIXME: the problem occurs here
           cy.wait("@dataset");
         });
 

--- a/frontend/src/metabase/browse/components/ModelExplanationBanner.tsx
+++ b/frontend/src/metabase/browse/components/ModelExplanationBanner.tsx
@@ -1,32 +1,19 @@
-import { useState } from "react";
 import { t } from "ttag";
 
-import { useDispatch, useSelector } from "metabase/lib/redux";
-import { updateUserSetting } from "metabase/redux/settings";
-import { getSetting } from "metabase/selectors/settings";
-import { Flex, Paper, Icon, Text } from "metabase/ui";
+import { useUserSetting } from "metabase/common/hooks";
+import { Flex, Icon, Paper, Text } from "metabase/ui";
 
 import { BannerCloseButton, BannerModelIcon } from "./BrowseModels.styled";
 
 export const ModelExplanationBanner = () => {
-  const hasDismissedBanner = useSelector(state =>
-    getSetting(state, "dismissed-browse-models-banner"),
+  const [hasDismissedBanner, setHasDismissedBanner] = useUserSetting(
+    "dismissed-browse-models-banner",
   );
-  const dispatch = useDispatch();
-
-  const [shouldShowBanner, setShouldShowBanner] = useState(!hasDismissedBanner);
-
   const dismissBanner = () => {
-    setShouldShowBanner(false);
-    dispatch(
-      updateUserSetting({
-        key: "dismissed-browse-models-banner",
-        value: true,
-      }),
-    );
+    setHasDismissedBanner(true);
   };
 
-  if (!shouldShowBanner) {
+  if (hasDismissedBanner) {
     return null;
   }
 
@@ -42,7 +29,7 @@ export const ModelExplanationBanner = () => {
     >
       <Flex>
         <BannerModelIcon name="model" />
-        <Text size="md" lh="1rem" mr="1rem">
+        <Text size="md" lh="1rem" style={{ marginInlineEnd: "1rem" }}>
           {t`Models help curate data to make it easier to find answers to questions all in one place.`}
         </Text>
         <BannerCloseButton onClick={dismissBanner}>


### PR DESCRIPTION
This PR refactors the banner that appears on the Browse models page (the `ModelExplanationBanner` component) by replacing the existing code for dismissing the banner with the `useUserSetting` hook.

The previous implementation involved directly dispatching a Redux action. This has been replaced by the `useUserSetting` hook which simplifies the logic and makes the code cleaner.

Test the dismissal of the `ModelExplanationBanner` component by going to the Browse models page and dismissing the banner. It should not show up again on subsequent visits.