### PR TITLE
Use the correct icon for the extract column shortcut

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.tsx
@@ -312,7 +312,7 @@ function colorForIcon(icon: string | undefined | null) {
       return { normal: color("accent1"), highlighted: color("brand-white") };
     case "function":
     case "combine":
-    case "split":
+    case "arrow_split":
       return { normal: color("brand"), highlighted: color("brand-white") };
     default:
       return {

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.tsx
@@ -221,7 +221,7 @@ export const ExpressionWidget = <Clause extends object = Lib.ExpressionClause>(
             !startRule && {
               shortcut: true,
               name: t`Extract columns`,
-              icon: "split",
+              icon: "arrow_split",
               group: "shortcuts",
               action: () => setIsExtractingColumn(true),
             },


### PR DESCRIPTION
Fixes a bug where the incorrect icon was displaying for the extract column shortcut.

1. New question -> Sample data -> Orders
2. Add new column
3. The suggestion dropdown should show the correct icon for `extract column`

<img width="297" alt="Screenshot 2024-05-08 at 20 05 26" src="https://github.com/metabase/metabase/assets/1250185/6c973d84-11f6-4f55-80cf-dfbd70e066ae">
