### PR TITLE
convert `SocketChannelEndpoint` to `SocketChannel`

### DIFF
--- a/src/metabase/async/streaming_response.clj
+++ b/src/metabase/async/streaming_response.clj
@@ -154,7 +154,6 @@
   immediately, returning `0`."
   [^Request request]
   (try
-    (log/fatal "--------------------------------------------------")
     (let [transport (.. request getHttpChannel getEndPoint getTransport)
           channel   (get-channel transport)
           buf       (ByteBuffer/allocate 1)


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/13771

During SSL, the getTransport method was returning a type that we didn't expect: `SocketChannelEndpoint`, and that type was unable to be cast into a `SocketChannel`. Calling `.getChannel` on the `SocketChannelEndpoint` returns a `SocketChannel`, so that is what we do.