### PR TITLE
[Drills] Only show "Extract" and "Combine" actions on MBQL stages

### DIFF
--- a/src/metabase/lib/drill_thru/column_extract.cljc
+++ b/src/metabase/lib/drill_thru/column_extract.cljc
@@ -11,6 +11,7 @@
 
   Extra constraints:
 
+  - MBQL stages only
   - Database must support `:regex` feature for the URL and Email extractions to work."
   (:require
    [medley.core :as m]
@@ -40,7 +41,9 @@
   [query                       :- ::lib.schema/query
    stage-number                :- :int
    {:keys [column column-ref value]} :- ::lib.schema.drill-thru/context]
-  (when (and column (nil? value))
+  (when (and column
+             (nil? value)
+             (lib.drill-thru.common/mbql-stage? query stage-number))
     (when-let [drill (column-extract-drill-for-column query column)]
       (merge drill
              {:lib/type :metabase.lib.drill-thru/drill-thru

--- a/src/metabase/lib/drill_thru/combine_columns.cljc
+++ b/src/metabase/lib/drill_thru/combine_columns.cljc
@@ -19,11 +19,12 @@
   "Column clicks on string columns.
 
   Might add a stage, like `:drill-thru/column-filter` does, if the current stage has aggregations."
-  [_query                 :- ::lib.schema/query
-   _stage-number          :- :int
+  [query                 :- ::lib.schema/query
+   stage-number          :- :int
    {:keys [column value]} :- ::lib.schema.drill-thru/context]
   (when (and column
              (nil? value)
+             (lib.drill-thru.common/mbql-stage? query stage-number)
              (lib.types.isa/string? column))
     {:lib/type :metabase.lib.drill-thru/drill-thru
      :type     :drill-thru/combine-columns


### PR DESCRIPTION
They don't work correctly on a native stage.

