### PR TITLE
Add `metabase.actions.core` module API namespace

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -143,7 +143,7 @@
    ;;
    ;; `nil` or an empty set  Otherwise this should be a set of namespace symbols.
    :api-namespaces
-   {metabase.actions               :any
+   {metabase.actions               #{metabase.actions.core}
     metabase.analytics             :any
     metabase.analyze               :any
     metabase.api                   :any

--- a/src/metabase/actions/core.clj
+++ b/src/metabase/actions/core.clj
@@ -1,0 +1,32 @@
+(ns metabase.actions.core
+  "API namespace for the `metabase.actions` module."
+  (:require
+   [metabase.actions :as actions]
+   [metabase.actions.error :as actions.error]
+   [metabase.actions.execution :as actions.execution]
+   [metabase.actions.http-action :as actions.http-action]
+   [potemkin :as p]))
+
+(comment
+  actions/keep-me
+  actions.error/keep-me
+  actions.execution/keep-me
+  actions.http-action/keep-me)
+
+(p/import-vars
+  [actions
+   cached-value
+   check-actions-enabled!
+   check-actions-enabled-for-database!
+   perform-action!*]
+  [actions.error
+   incorrect-value-type
+   violate-foreign-key-constraint
+   violate-not-null-constraint
+   violate-unique-constraint]
+  [actions.execution
+   execute-action!
+   execute-dashcard!
+   fetch-values]
+  [actions.http-action
+   apply-json-query])

--- a/src/metabase/api/action.clj
+++ b/src/metabase/api/action.clj
@@ -3,9 +3,7 @@
   (:require
    [cheshire.core :as json]
    [compojure.core :as compojure :refer [POST]]
-   [metabase.actions :as actions]
-   [metabase.actions.execution :as actions.execution]
-   [metabase.actions.http-action :as http-action]
+   [metabase.actions.core :as actions]
    [metabase.analytics.snowplow :as snowplow]
    [metabase.api.common :as api]
    [metabase.api.common.validation :as validation]
@@ -25,7 +23,7 @@
   [:and
    string?
    (mu/with-api-error-message
-     [:fn #(http-action/apply-json-query {} %)]
+    [:fn #(actions/apply-json-query {} %)]
      (deferred-tru "must be a valid json-query, something like ''.item.title''"))])
 
 (def ^:private supported-action-type
@@ -207,7 +205,7 @@
   (actions/check-actions-enabled! action-id)
   (-> (action/select-action :id action-id :archived false)
       api/read-check
-      (actions.execution/fetch-values (json/parse-string parameters))))
+      (actions/fetch-values (json/parse-string parameters))))
 
 (api/defendpoint POST "/:id/execute"
   "Execute the Action.
@@ -220,6 +218,6 @@
     (snowplow/track-event! ::snowplow/action-executed api/*current-user-id* {:source    :model_detail
                                                                              :type      type
                                                                              :action_id id})
-    (actions.execution/execute-action! action (update-keys parameters name))))
+    (actions/execute-action! action (update-keys parameters name))))
 
 (api/define-routes)

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -5,7 +5,7 @@
    [clojure.set :as set]
    [compojure.core :refer [DELETE GET POST PUT]]
    [medley.core :as m]
-   [metabase.actions.execution :as actions.execution]
+   [metabase.actions.core :as actions]
    [metabase.analytics.snowplow :as snowplow]
    [metabase.api.common :as api]
    [metabase.api.common.validation :as validation]
@@ -1122,7 +1122,7 @@
    dashcard-id  ms/PositiveInt
    parameters   ms/JSONString}
   (api/read-check :model/Dashboard dashboard-id)
-  (actions.execution/fetch-values
+  (actions/fetch-values
    (api/check-404 (action/dashcard->action dashcard-id))
    (json/parse-string parameters)))
 
@@ -1137,7 +1137,7 @@
    parameters  [:maybe [:map-of :string :any]]}
   (api/read-check :model/Dashboard dashboard-id)
   ;; Undo middleware string->keyword coercion
-  (actions.execution/execute-dashcard! dashboard-id dashcard-id parameters))
+  (actions/execute-dashcard! dashboard-id dashcard-id parameters))
 
 ;;; ---------------------------------- Running the query associated with a Dashcard ----------------------------------
 

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -4,8 +4,7 @@
    [cheshire.core :as json]
    [compojure.core :refer [GET]]
    [medley.core :as m]
-   [metabase.actions :as actions]
-   [metabase.actions.execution :as actions.execution]
+   [metabase.actions.core :as actions]
    [metabase.analytics.snowplow :as snowplow]
    [metabase.api.card :as api.card]
    [metabase.api.common :as api]
@@ -301,7 +300,7 @@
    parameters  ms/JSONString}
   (validation/check-public-sharing-enabled)
   (api/check-404 (t2/select-one-pk Dashboard :public_uuid uuid :archived false))
-  (actions.execution/fetch-values
+  (actions/fetch-values
    (api/check-404 (action/dashcard->action dashcard-id))
    (json/parse-string parameters)))
 
@@ -334,7 +333,7 @@
           ;; you're by definition allowed to run it without a perms check anyway
           (binding [api/*current-user-permissions-set* (delay #{"/"})]
             ;; Undo middleware string->keyword coercion
-            (actions.execution/execute-dashcard! dashboard-id dashcard-id (update-keys parameters name))))))))
+            (actions/execute-dashcard! dashboard-id dashcard-id (update-keys parameters name))))))))
 
 (api/defendpoint GET "/oembed"
   "oEmbed endpoint used to retreive embed code and metadata for a (public) Metabase URL."
@@ -654,7 +653,7 @@
                                                                                      :type      (:type action)
                                                                                      :action_id (:id action)})
             ;; Undo middleware string->keyword coercion
-            (actions.execution/execute-action! action (update-keys parameters name))))))))
+            (actions/execute-action! action (update-keys parameters name))))))))
 
 
 ;;; ----------------------------------------- Route Definitions & Complaints -----------------------------------------

--- a/src/metabase/driver/mysql/actions.clj
+++ b/src/metabase/driver/mysql/actions.clj
@@ -3,7 +3,7 @@
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
-   [metabase.actions.error :as actions.error]
+   [metabase.actions.core :as actions]
    [metabase.driver.sql-jdbc.actions :as sql-jdbc.actions]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
@@ -48,7 +48,7 @@
       [[] nil nil]
       (jdbc/reducible-query jdbc-spec sql-args {:identifers identity, :transaction? false})))))
 
-(defmethod sql-jdbc.actions/maybe-parse-sql-error [:mysql actions.error/violate-not-null-constraint]
+(defmethod sql-jdbc.actions/maybe-parse-sql-error [:mysql actions/violate-not-null-constraint]
   [_driver error-type _database _action-type error-message]
   (or
    (when-let [[_ column]
@@ -62,7 +62,7 @@
       :message (tru "{0} must have values." (str/capitalize column))
       :errors  {column (tru "You must provide a value.")}})))
 
-(defmethod sql-jdbc.actions/maybe-parse-sql-error [:mysql actions.error/violate-unique-constraint]
+(defmethod sql-jdbc.actions/maybe-parse-sql-error [:mysql actions/violate-unique-constraint]
   [_driver error-type database _action-type error-message]
   (when-let [[_match constraint]
              (re-find #"Duplicate entry '.+' for key '(.+)'" error-message)]
@@ -75,7 +75,7 @@
                         {}
                         columns)})))
 
-(defmethod sql-jdbc.actions/maybe-parse-sql-error [:mysql actions.error/violate-foreign-key-constraint]
+(defmethod sql-jdbc.actions/maybe-parse-sql-error [:mysql actions/violate-foreign-key-constraint]
   [_driver error-type _database action-type error-message]
   (or
    (when-let [[_match _ref-table _constraint _fkey-cols column _key-cols]
@@ -102,7 +102,7 @@
                    (tru "Unable to update the record."))
         :errors  {(remove-backticks column) (tru "This {0} does not exist." (str/capitalize (remove-backticks column)))}}))))
 
-(defmethod sql-jdbc.actions/maybe-parse-sql-error [:mysql actions.error/incorrect-value-type]
+(defmethod sql-jdbc.actions/maybe-parse-sql-error [:mysql actions/incorrect-value-type]
   [_driver error-type _database _action-type error-message]
   (when-let [[_ expected-type _value _database _table column _row]
              (re-find #"Incorrect (.+?) value: '(.+)' for column (?:(.+)\.)??(?:(.+)\.)?(.+) at row (\d+)"  error-message)]

--- a/src/metabase/driver/sql_jdbc/actions.clj
+++ b/src/metabase/driver/sql_jdbc/actions.clj
@@ -5,7 +5,7 @@
    [clojure.string :as str]
    [flatland.ordered.set :as ordered-set]
    [medley.core :as m]
-   [metabase.actions :as actions]
+   [metabase.actions.core :as actions]
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.sql.query-processor :as sql.qp]


### PR DESCRIPTION
Consolidate all external usage of the `metabase.actions` module into a new `metabase.actions.core` namespace. There was already a `metabase.actions` namespace that was used as a dependency by other namespaces in the module so for now I created a new namespace rather than turn this into a giant refactor