### PR TITLE
Enumerate the current state of the world with regards to module namespaces

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -155,7 +155,10 @@
                                      metabase.analyze.fingerprint.fingerprinters
                                      metabase.analyze.fingerprint.schema
                                      metabase.analyze.query-results}                                ; TODO -- consolidate these into a real API namespace.
-    metabase.api                   #{metabase.api.common}
+    metabase.api                   #{metabase.api.common
+                                     metabase.api.dataset
+                                     metabase.api.permission-graph
+                                     metabase.api.routes}                                           ; TODO -- consolidate these into a real API namespace. I think the `*current-user*` type stuff might need to be moved into a separate module.
     metabase.async                 #{metabase.async.streaming-response
                                      metabase.async.streaming-response.thread-pool
                                      metabase.async.util}                                           ; TODO -- consolidate these into a real API namespace.

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,3 +1,4 @@
+;; -*- comment-column: 100; -*-
 {:config-paths ["macros"]
  :linters
  {:aliased-namespace-symbol     {:level :warning}
@@ -142,53 +143,121 @@
    ;;    module itself, e.g. the module namespace for `metabase.setup` would be `metabase.setup`.
    ;;
    ;; `nil` or an empty set  Otherwise this should be a set of namespace symbols.
+   ;;
+   ;; PRO TIP: Check out the `dev.deps-graph` namespace for helpful tools to see where a module is used externally.
    :api-namespaces
    {metabase.actions               #{metabase.actions.core}
-    metabase.analytics             :any
-    metabase.analyze               :any
-    metabase.api                   :any
-    metabase.async                 :any
-    metabase.automagic-dashboards  :any
+    metabase.analytics             #{metabase.analytics.prometheus
+                                     metabase.analytics.snowplow
+                                     metabase.analytics.stats}                                      ; TODO -- consolidate these into a real API namespace.
+    metabase.analyze               #{metabase.analyze.classifiers.core
+                                     metabase.analyze.classifiers.name
+                                     metabase.analyze.fingerprint.fingerprinters
+                                     metabase.analyze.fingerprint.schema
+                                     metabase.analyze.query-results}                                ; TODO -- consolidate these into a real API namespace.
+    metabase.api                   #{metabase.api.common}
+    metabase.async                 #{metabase.async.streaming-response
+                                     metabase.async.streaming-response.thread-pool
+                                     metabase.async.util}                                           ; TODO -- consolidate these into a real API namespace.
+    metabase.automagic-dashboards  #{metabase.automagic-dashboards.comparison
+                                     metabase.automagic-dashboards.core
+                                     metabase.automagic-dashboards.dashboard-templates
+                                     metabase.automagic-dashboards.populate}                        ; TODO -- consolidate these into a real API namespace.
     metabase.bootstrap             #{metabase.bootstrap}
-    metabase.cmd                   :any
+    metabase.cmd                   #{}                                                              ; there are no namespaces here since you shouldn't be using this in any other module.
     metabase.config                #{metabase.config}
-    metabase.core                  :any
+    metabase.core                  #{metabase.core.initialization-status}                           ; TODO -- only namespace used outside of EE, this probably belongs in `metabase.server` anyway since that's the only place it's used.
     metabase.db                    #{metabase.db
-                                     metabase.db.metadata-queries ; FIXME, this should probably be separate from metabase.db
-                                     metabase.db.query            ; FIXME, this is mostly util stuff like `metabase.db.query/query` that we don't even need anymore.
-                                     metabase.db.setup}           ; FIXME, these are only calling `metabase.db.setup/setup-db!` and there's a slightly different version in `metabase.db`
-    metabase.domain-entities       :any
-    metabase.driver                :any
-    metabase.email                 :any
-    metabase.embed                 :any
-    metabase.events                :any
-    metabase.formatter             :any
-    metabase.integrations          :any
-    metabase.legacy-mbql           :any
-    metabase.lib                   :any
+                                     metabase.db.metadata-queries                                   ; TODO this should probably be separate from metabase.db
+                                     metabase.db.query                                              ; TODO this is mostly util stuff like `metabase.db.query/query` that we don't even need anymore.
+                                     metabase.db.setup}                                             ; TODO these are only calling `metabase.db.setup/setup-db!` and there's a slightly different version in `metabase.db`
+    metabase.domain-entities       #{metabase.domain-entities.core
+                                     metabase.domain-entities.specs}                                ; TODO -- consolidate these into a real API namespace.
+    metabase.driver                :any                                                             ; TODO -- 19 namespaces!!!! CRY
+    metabase.email                 #{metabase.email
+                                     metabase.email.messages}                                       ; TODO -- consolidate these into a real API namespace.
+    metabase.embed                 #{metabase.embed.settings}
+    metabase.events                #{metabase.events}
+    metabase.formatter             #{metabase.formatter}
+    metabase.integrations          #{metabase.integrations.common
+                                     metabase.integrations.google
+                                     metabase.integrations.ldap
+                                     metabase.integrations.slack}                                   ; TODO -- consolidate these into a real API namespace.
+    metabase.legacy-mbql           #{metabase.legacy-mbql.normalize
+                                     metabase.legacy-mbql.predicates
+                                     metabase.legacy-mbql.schema
+                                     metabase.legacy-mbql.schema.helpers
+                                     metabase.legacy-mbql.util}                                     ; TODO -- consolidate these into a real API namespace.
+    metabase.lib                   :any                                                             ; TODO -- :cry: 34 externally referenced namespaces, but maybe half of them are schema namespaces which technically don't need to be required.
     metabase.logger                #{metabase.logger}
-    metabase.metabot               :any
-    metabase.models                :any
+    metabase.metabot               #{metabase.metabot
+                                     metabase.metabot.feedback
+                                     metabase.metabot.util}                                         ; TODO -- consolidate these into a real API namespace.
+    metabase.models                :any                                                             ; TODO -- scream, 62 namespaces used elsewhere, but to be fair a lot of these don't *need* to be required.
     metabase.moderation            #{metabase.moderation}
-    metabase.native-query-analyzer :any
-    metabase.permissions           :any
-    metabase.plugins               :any
-    metabase.public-settings       :any
-    metabase.pulse                 :any
-    metabase.query-processor       :any
+    metabase.native-query-analyzer #{metabase.native-query-analyzer}
+    metabase.permissions           #{metabase.permissions.util}                                     ; TODO -- this is currently the only namespace in this module. Give it a real API namespace?
+    metabase.plugins               #{metabase.plugins
+                                     metabase.plugins.classloader}                                  ; TODO -- not 100% sure the classloader belongs here
+    metabase.public-settings       #{metabase.public-settings
+                                     metabase.public-settings.premium-features}
+    metabase.pulse                 #{metabase.pulse
+                                     metabase.pulse.markdown
+                                     metabase.pulse.parameters
+                                     metabase.pulse.preview
+                                     metabase.pulse.render
+                                     metabase.pulse.render.image-bundle
+                                     metabase.pulse.render.js-svg
+                                     metabase.pulse.render.style}                                   ; TODO -- consolidate these into a real API namespace.
+    metabase.query-processor       :any                                                             ; TODO omg scream, 29 namespaces used outside of the module. WHAT THE HECC
     metabase.related               #{metabase.related}
     metabase.sample-data           #{metabase.sample-data}
-    metabase.search                :any
-    metabase.server                :any
+    metabase.search                #{metabase.search.config
+                                     metabase.search.filter
+                                     metabase.search.scoring
+                                     metabase.search.util}                                          ; TODO -- consolidate these into a real API namespace.
+    metabase.server                #{metabase.server
+                                     metabase.server.handler
+                                     metabase.server.middleware.auth
+                                     metabase.server.middleware.exceptions
+                                     metabase.server.middleware.json
+                                     metabase.server.middleware.misc
+                                     metabase.server.middleware.offset-paging
+                                     metabase.server.middleware.session
+                                     metabase.server.protocols
+                                     metabase.server.request.util}                                  ; TODO -- consolidate these into a real API namespace.
     metabase.setup                 #{metabase.setup}
-    metabase.shared                :any
-    metabase.sync                  :any
-    metabase.task                  :any
-    metabase.transforms            :any
+    metabase.shared                #{metabase.shared.dashboards.constants
+                                     metabase.shared.formatting.constants
+                                     metabase.shared.formatting.date
+                                     metabase.shared.formatting.numbers
+                                     metabase.shared.models.visualization-settings
+                                     metabase.shared.parameters.parameters
+                                     metabase.shared.util.currency
+                                     metabase.shared.util.i18n
+                                     metabase.shared.util.internal.time-common
+                                     metabase.shared.util.namespaces
+                                     metabase.shared.util.time}                                     ; TODO -- consolidate these into a real API namespace.
+    metabase.sync                  #{metabase.sync
+                                     metabase.sync.analyze
+                                     metabase.sync.concurrent
+                                     metabase.sync.field-values
+                                     metabase.sync.schedules
+                                     metabase.sync.sync-metadata
+                                     metabase.sync.sync-metadata.fields
+                                     metabase.sync.sync-metadata.tables
+                                     metabase.sync.util}                                            ; TODO -- consolidate these into a real API namespace.
+    metabase.task                  #{metabase.task
+                                     metabase.task.index-values
+                                     metabase.task.persist-refresh}                                 ; TODO -- consolidate these into a real API namespace.
+    metabase.transforms            #{metabase.transforms.core
+                                     metabase.transforms.dashboard
+                                     metabase.transforms.materialize
+                                     metabase.transforms.specs}                                     ; TODO -- consolidate these into a real API namespace.
     metabase.troubleshooting       #{metabase.troubleshooting}
     metabase.types                 #{metabase.types}
-    metabase.upload                :any
-    metabase.util                  :any}
+    metabase.upload                #{metabase.upload}
+    metabase.util                  :any}                                                            ; I think util being `:any` is actually something I am ok with. But this has 32 namespaces.
 
    ;; Map of module => other modules you're allowed to use there. You have two options here:
    ;;
@@ -251,11 +320,11 @@
    ;; this is mostly intended for excluding test namespaces or those rare 'glue' namespaces that glue multiple modules
    ;; together, e.g. `metabase.lib.metadata.jvm`.
    :ignored-namespace-patterns
-   #{"-test$"                     ; anything ending in `-test`
-     "test[-.]util"               ; anything that contains `test.util` or `test-util`
-     "test\\.impl"                ; anything that contains `test.impl`
-     "^metabase\\.test"           ; anything starting with `metabase.test`
-     "^metabase\\.http-client$"}} ; `metabase.http-client` which is a test-only namespace despite its name.
+   #{"-test$"                           ; anything ending in `-test`
+     "test[-.]util"                     ; anything that contains `test.util` or `test-util`
+     "test\\.impl"                      ; anything that contains `test.impl`
+     "^metabase\\.test"                 ; anything starting with `metabase.test`
+     "^metabase\\.http-client$"}}       ; `metabase.http-client` which is a test-only namespace despite its name.
 
   :consistent-alias
   {:aliases

--- a/dev/src/dev/deps_graph.clj
+++ b/dev/src/dev/deps_graph.clj
@@ -1,0 +1,58 @@
+(ns dev.deps-graph
+  (:require
+   [clojure.tools.namespace.dependency :as ns.deps]
+   [clojure.tools.namespace.find :as ns.find]
+   [clojure.tools.namespace.parse :as ns.parse]
+   [clojure.java.io :as io]))
+
+(set! *warn-on-reflection* true)
+
+(defn- project-root-directory ^java.io.File []
+  (.. (java.nio.file.Paths/get (.toURI (io/resource "dev/deps_graph.clj")))
+      toFile          ; /home/cam/metabase/dev/src/dev/deps_graph.clj
+      getParentFile   ; /home/cam/metabase/dev/src/dev/
+      getParentFile   ; /home/cam/metabase/dev/src/
+      getParentFile   ; /home/cam/metabase/dev/
+      getParentFile)) ; /home/cam/metabase/
+
+(defn- source-root
+  "This is basically a non-hardcoded version of
+
+    (io/file \"/home/cam/metabase/src/metabase\")"
+  ^java.io.File []
+  (io/file (str (.getAbsolutePath (project-root-directory)) "/src/metabase")))
+
+(defn- find-ns-decls []
+  (ns.find/find-ns-decls [(source-root)]))
+
+(defn- module [ns-symb]
+  (some-> (re-find #"^metabase\.[^.]+" (str ns-symb)) symbol))
+
+(defn- dependencies []
+  (for [decl (find-ns-decls)
+        :let [ns-symb (ns.parse/name-from-ns-decl decl)
+              deps    (ns.parse/deps-from-ns-decl decl)]]
+    {:namespace ns-symb
+     :module    (module ns-symb)
+     :deps      (into #{}
+                      (map (fn [dep-symb]
+                             {:namespace dep-symb
+                              :module    (module dep-symb)}))
+                      deps)}))
+
+(defn external-usages
+  "All usages of a module named by `module-symb` outside that module."
+  [module-symb]
+  (for [dep    (dependencies)
+        :when  (not= (:module dep) module-symb)
+        ns-dep (:deps dep)
+        :when  (= (:module ns-dep) module-symb)]
+    {:namespace            (:namespace dep)
+     :module               (:module dep)
+     :depends-on-namespace (:namespace ns-dep)
+     :depends-on-module    (:module ns-dep)}))
+
+(defn externally-used-namespaces
+  "All namespaces from a module that are used outside that module."
+  [module-symb]
+  (into (sorted-set) (map :depends-on-namespace) (external-usages module-symb)))

--- a/src/metabase/formatter.clj
+++ b/src/metabase/formatter.clj
@@ -14,6 +14,7 @@
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
    [metabase.util.ui-logic :as ui-logic]
+   [potemkin :as p]
    [potemkin.types :as p.types])
   (:import
    (java.math RoundingMode)
@@ -24,6 +25,11 @@
 
 ;; Fool Eastwood into thinking this namespace is used
 (comment hiccup.util/keep-me)
+
+(p/import-vars
+  [datetime
+   format-temporal-str
+   temporal-string?])
 
 (def RenderedPulseCard
   "Schema used for functions that operate on pulse card contents and their attachments"

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -4,7 +4,6 @@
    [hiccup.core :refer [h]]
    [medley.core :as m]
    [metabase.formatter :as formatter]
-   [metabase.formatter.datetime :as datetime]
    [metabase.models.timeline-event :as timeline-event]
    [metabase.public-settings :as public-settings]
    [metabase.pulse.render.color :as color]
@@ -71,7 +70,7 @@
   [timezone-id :- [:maybe :string] value col visualization-settings]
   (cond
     (types/temporal-field? col)
-    (datetime/format-temporal-str timezone-id value col)
+    (formatter/format-temporal-str timezone-id value col)
 
     (number? value)
     (formatter/format-number value col visualization-settings)
@@ -422,8 +421,8 @@
                  {:percentage (percentages (first row))
                   :color      (legend-colors (first row))
                   :label      (if (and (contains? label-viz-settings :date_style)
-                                       (datetime/temporal-string? label))
-                                (datetime/format-temporal-str
+                                       (formatter/temporal-string? label))
+                                (formatter/format-temporal-str
                                  timezone-id
                                  (first row)
                                  (x-axis-rowfn cols)


### PR DESCRIPTION
Added `dev.deps-graph` tools to figure out what's being used where; and filled out most of the rest of the Kondo config with the current state of the world to "stop the bleeding". The next step is to go in and fix all the modules that have multiple "API namespaces" and consolidate those into one each