### PR TITLE
Fix flaky question management e2e test

### DIFF
--- a/e2e/test/scenarios/question/question-management.cy.spec.js
+++ b/e2e/test/scenarios/question/question-management.cy.spec.js
@@ -154,13 +154,10 @@ describe(
 
                   moveQuestionTo(/Personal Collection/);
                   assertOnRequest("updateQuestion");
-                  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-                  cy.contains("37.65");
-
-                  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-                  cy.contains(
+                  cy.findAllByRole("status").contains(
                     `Model moved to ${getPersonalCollectionName(USERS[user])}`,
                   );
+                  cy.findAllByRole("gridcell").contains("37.65");
 
                   navigationSidebar().within(() => {
                     // Highlight "Your personal collection" after move
@@ -452,6 +449,10 @@ function assertOnRequest(xhr_alias) {
     expect(xhr.status).not.to.eq(403);
   });
 
+  cy.findByTestId("query-builder-main")
+    .findByText("Doing science...")
+    .should("not.exist");
+
   cy.findByText("Sorry, you don’t have permission to see that.").should(
     "not.exist",
   );
@@ -459,8 +460,10 @@ function assertOnRequest(xhr_alias) {
 
 function turnIntoModel() {
   openQuestionActions();
-  cy.findByText("Turn into a model").click();
-  cy.findByText("Turn this into a model").click();
+  cy.findByRole("dialog").contains("Turn into a model").click();
+  cy.findByRole("dialog").contains("Turn this into a model").click();
+  assertOnRequest("updateQuestion");
+  cy.findAllByRole("status").contains("This is a model now.").should("exist");
 }
 
 function findPickerItem(name) {

--- a/e2e/test/scenarios/question/question-management.cy.spec.js
+++ b/e2e/test/scenarios/question/question-management.cy.spec.js
@@ -153,7 +153,7 @@ describe(
                   });
 
                   moveQuestionTo(/Personal Collection/);
-                  assertOnRequest("updateQuestion");
+                  cy.wait("@updateQuestion");
                   cy.findAllByRole("status")
                     .contains(
                       `Model moved to ${getPersonalCollectionName(
@@ -161,6 +161,9 @@ describe(
                       )}`,
                     )
                     .should("exist");
+                  cy.findAllByRole("status")
+                    .contains("Sorry, you don’t have permission to see that.")
+                    .should("not.exist");
                   cy.findAllByRole("gridcell").contains("37.65");
 
                   navigationSidebar().within(() => {
@@ -466,8 +469,11 @@ function turnIntoModel() {
   openQuestionActions();
   cy.findByRole("dialog").contains("Turn into a model").click();
   cy.findByRole("dialog").contains("Turn this into a model").click();
-  assertOnRequest("updateQuestion");
+  cy.wait("@updateQuestion");
   cy.findAllByRole("status").contains("This is a model now.").should("exist");
+  cy.findAllByRole("status")
+    .contains("Sorry, you don’t have permission to see that.")
+    .should("not.exist");
 }
 
 function findPickerItem(name) {

--- a/e2e/test/scenarios/question/question-management.cy.spec.js
+++ b/e2e/test/scenarios/question/question-management.cy.spec.js
@@ -93,11 +93,13 @@ describe(
                   moveQuestionTo(/Personal Collection/);
                   assertOnRequest("updateQuestion");
 
-                  cy.findAllByRole("status").contains(
-                    `Question moved to ${getPersonalCollectionName(
-                      USERS[user],
-                    )}`,
-                  );
+                  cy.findAllByRole("status")
+                    .contains(
+                      `Question moved to ${getPersonalCollectionName(
+                        USERS[user],
+                      )}`,
+                    )
+                    .should("exist");
                   cy.findAllByRole("gridcell").contains("37.65");
 
                   navigationSidebar().within(() => {
@@ -152,9 +154,13 @@ describe(
 
                   moveQuestionTo(/Personal Collection/);
                   assertOnRequest("updateQuestion");
-                  cy.findAllByRole("status").contains(
-                    `Model moved to ${getPersonalCollectionName(USERS[user])}`,
-                  );
+                  cy.findAllByRole("status")
+                    .contains(
+                      `Model moved to ${getPersonalCollectionName(
+                        USERS[user],
+                      )}`,
+                    )
+                    .should("exist");
                   cy.findAllByRole("gridcell").contains("37.65");
 
                   navigationSidebar().within(() => {

--- a/e2e/test/scenarios/question/question-management.cy.spec.js
+++ b/e2e/test/scenarios/question/question-management.cy.spec.js
@@ -92,15 +92,13 @@ describe(
 
                   moveQuestionTo(/Personal Collection/);
                   assertOnRequest("updateQuestion");
-                  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-                  cy.contains("37.65");
 
-                  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-                  cy.contains(
+                  cy.findAllByRole("status").contains(
                     `Question moved to ${getPersonalCollectionName(
                       USERS[user],
                     )}`,
                   );
+                  cy.findAllByRole("gridcell").contains("37.65");
 
                   navigationSidebar().within(() => {
                     // Highlight "Your personal collection" after move


### PR DESCRIPTION
See [Slack thread](https://metaboat.slack.com/archives/C5XHN8GLW/p1715242891189679).

Examples of failed runs:
- https://github.com/metabase/metabase/actions/runs/9009583063
- https://github.com/metabase/metabase/actions/runs/9009971427
- https://github.com/metabase/metabase/actions/runs/9013749033

### Description

When I run the stress test with 50 burn-in (which means 100 runs because the test is defined in a loop) it starts to flake at the end (after 80+ runs) - I suspect it's due to Cypress giving up (out of memory or something alike).
So I decided to run it 25x twice, and it looks green now.

Stress tests (this PR):
- https://github.com/metabase/metabase/actions/runs/9016541427 (25x)
- https://github.com/metabase/metabase/actions/runs/9016541785 (25x)

Stress test on `master`, for comparison: https://github.com/metabase/metabase/actions/runs/9015446311