### PR TITLE
Fix axios security issue by updating the upstream library version

### DIFF
--- a/package.json
+++ b/package.json
@@ -261,7 +261,7 @@
     "jsonwebtoken": "^9.0.0",
     "knex": "^2.4.2",
     "lint-staged": "^13.1.2",
-    "loki": "^0.33.0",
+    "loki": "^0.35.0",
     "markdown-link-check": "^3.10.2",
     "mini-css-extract-plugin": "2.7.2",
     "mocha": "^10.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1985,18 +1985,6 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.2.tgz#30aa825f11d438671d585bd44e7fd564535fc210"
   integrity sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw==
 
-"@hapi/hoek@^9.0.0", "@hapi/hoek@^9.3.0":
-  version "9.3.0"
-  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.3.0.tgz#8368869dcb735be2e7f5cb7647de78e167a251fb"
-  integrity sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==
-
-"@hapi/topo@^5.1.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-5.1.0.tgz#dc448e332c6c6e37a4dc02fd84ba8d44b9afb012"
-  integrity sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==
-  dependencies:
-    "@hapi/hoek" "^9.0.0"
-
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.5.0.tgz#1407967d4c6eecd7388f83acf1eaf4d0c6e58ef9"
@@ -2466,172 +2454,172 @@
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
   integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
 
-"@loki/browser@^0.33.0":
-  version "0.33.0"
-  resolved "https://registry.yarnpkg.com/@loki/browser/-/browser-0.33.0.tgz#750dc13719786f9c14fb71bc13493a8748e114a6"
-  integrity sha512-PpgzttbfjLh2fkkObM1ljPd4guqwbMpuH+dDfSnIrIPONsMNrpDbja8Met51RB6xDYBIsCs8igfxpaB+qJBhwQ==
+"@loki/browser@^0.35.0":
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/@loki/browser/-/browser-0.35.0.tgz#81e233f76276ab70ae337c08ceeba25156c05280"
+  integrity sha512-VYSd3bx9dOQ/Wo2C1gdNdE2mcYPleVtGInRcZmCOJ01va14L9VEGzG2zL1dMcmMUuJ2cT3Ri1GR59vEO3vKWvQ==
   dependencies:
-    "@loki/integration-core" "^0.33.0"
+    "@loki/integration-core" "^0.35.0"
 
-"@loki/core@^0.33.0":
-  version "0.33.0"
-  resolved "https://registry.yarnpkg.com/@loki/core/-/core-0.33.0.tgz#c5a1bcd78683fb2ab7105ac2eb796783cc274407"
-  integrity sha512-TbgKfAfxYxQffRIwSYelhkC2y4/2QLYzP6HCQ8ZJaXH92TffJ7vOYt7KsePhNahwwYOlTZLc3N4GyEf8TAJI2g==
+"@loki/core@^0.35.0":
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/@loki/core/-/core-0.35.0.tgz#bfbdae6d801563014bc7ee5d0e05e655a2b4e534"
+  integrity sha512-AxFgo73juZ7XhmmFXMhtkpEwLBXraHEvqeQKtxmZ9V/PNWXR+yVmlMJ6HzM2WyL2ewmcaOqWX/EuuN/j24CwCA==
   dependencies:
     mime-types "^2.1.35"
     shelljs "^0.8.3"
 
-"@loki/diff-graphics-magick@^0.33.0":
-  version "0.33.0"
-  resolved "https://registry.yarnpkg.com/@loki/diff-graphics-magick/-/diff-graphics-magick-0.33.0.tgz#7d391fcc916c0b4d03e571c6242c53571d9fbf9c"
-  integrity sha512-ysjNtGhG4j1Bk54yoYrriAnTY7IJo1jPUHwBRdgOYeV90xRc/OMgXgYlD1wM5BdbMZvL0ng1c6KSUgs+s5j4gw==
+"@loki/diff-graphics-magick@^0.35.0":
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/@loki/diff-graphics-magick/-/diff-graphics-magick-0.35.0.tgz#328eb5eed978b56dc8d45df5ec5167e44809e36f"
+  integrity sha512-Rwt30i3jSPBS/6WPPhqQN1mWAys9viyKvRlhl+GQYcPoIrs70rNSYQaAB4/J54Vips/TGxJJAYZ6caq1Ey9s6w==
   dependencies:
     fs-extra "^9.1.0"
     gm "^1.23.1"
 
-"@loki/diff-looks-same@^0.33.0":
-  version "0.33.0"
-  resolved "https://registry.yarnpkg.com/@loki/diff-looks-same/-/diff-looks-same-0.33.0.tgz#7a396c011ac99492a9af72865e37becea6e9f373"
-  integrity sha512-lCtlIY4eZiZGGS+0wwgcNdRhALylIE1CVIQyfiNYHAoxMw3Ga59JPJRA/RmwONwLF+fEBBjwuokgoYWJYVsdzA==
+"@loki/diff-looks-same@^0.35.0":
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/@loki/diff-looks-same/-/diff-looks-same-0.35.0.tgz#b989411ae7ba07c70ebea3e8094be5aef3db7611"
+  integrity sha512-peIVLP7f+IFT9fp8B5wr4PJrWEE3h0aRFBe4yqZzMpqxrbxfXrfd9o1SnuBIf4mtiwdlWndDFVniRbxAgzUIJA==
   dependencies:
     fs-extra "^9.1.0"
     looks-same "^4.0.0"
 
-"@loki/diff-pixelmatch@^0.33.0":
-  version "0.33.0"
-  resolved "https://registry.yarnpkg.com/@loki/diff-pixelmatch/-/diff-pixelmatch-0.33.0.tgz#6bc02802bcbd8d3a660fd9826ee575bf20f18dc5"
-  integrity sha512-52VZt6CB4m1ykWnbnKkB1nWofgETZ/XcTEYQFMbNuodvZ9TLqMzPecoz3yi4r3vYZ7pSwfOVX4IHooYqHayE7Q==
+"@loki/diff-pixelmatch@^0.35.0":
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/@loki/diff-pixelmatch/-/diff-pixelmatch-0.35.0.tgz#910f4cdc01fefd02784426d0cbf6bec4b9078aee"
+  integrity sha512-QYaTkrDbIrfjxjuGiRRBufkAO7QNrmDy8RbRsk31HSTN/vFF3L9xJeNIeA95Xd1DP7DKMmorXRQtzv3qJnDKsQ==
   dependencies:
     fs-extra "^9.1.0"
     pixelmatch "^5.2.0"
     pngjs "^4.0.1"
 
-"@loki/integration-core@^0.33.0":
-  version "0.33.0"
-  resolved "https://registry.yarnpkg.com/@loki/integration-core/-/integration-core-0.33.0.tgz#4a796996de99d159066e60edef9674fe3a594ed4"
-  integrity sha512-zp9fxn5r7ysedfEXgLYo6mQUiSRfqc2Sf6fUodvpyJ2Qi8gVC/KY0I6Xidf0CSJXWkM5MRLtYcgt5FOThoIpCA==
+"@loki/integration-core@^0.35.0":
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/@loki/integration-core/-/integration-core-0.35.0.tgz#865b48b60cc03b53be5904389b2dd2577945508c"
+  integrity sha512-Zbi1O9au1WZOS7RXJTRykPl1843bTk58pzaNGvxDiH/XjdiPNemWRZNTC8uecpw9Cxr2l9hrzn1Dj6OO7P4XJg==
 
-"@loki/integration-react-native@^0.33.0":
-  version "0.33.0"
-  resolved "https://registry.yarnpkg.com/@loki/integration-react-native/-/integration-react-native-0.33.0.tgz#b9ca283af6c978427a2c31d6f2c97fe98a24e74d"
-  integrity sha512-tbbEgckxLv39YpeTOwNHOEpGglgZTMXyi4IcgeavkSFq5esGKYp6fEH3Spp1S+TTsbyj/To8avEfZtsHDwMV6Q==
+"@loki/integration-react-native@^0.35.0":
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/@loki/integration-react-native/-/integration-react-native-0.35.0.tgz#91f24a7fbdcfc43148d5913ce5b083d5057c551f"
+  integrity sha512-sgXPOVSI3I0uJtxbB4BnP8EHfBlnH7UKY8VWPlxWtEYRPvk52n5xfvlw1x9sycRxDyMhrtm3fGEQPXTnzDN2SA==
   dependencies:
-    "@loki/integration-core" "^0.33.0"
+    "@loki/integration-core" "^0.35.0"
     hoist-non-react-statics "*"
 
-"@loki/integration-react@^0.33.0":
-  version "0.33.0"
-  resolved "https://registry.yarnpkg.com/@loki/integration-react/-/integration-react-0.33.0.tgz#928a2940a1ddfabe6bb0359d6feb54cc4c71d976"
-  integrity sha512-iA3NLtWrwZWLPmNMBtcTEubT6uc5p7eYc76WNq5M2KzgPblL/6EoHoPOvzfURMv92rN+t3gAbkBFUHKrIiavyA==
+"@loki/integration-react@^0.35.0":
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/@loki/integration-react/-/integration-react-0.35.0.tgz#b8a3621b9263a11c64ff211e37dd985d6701da19"
+  integrity sha512-ZSeOfPc8RsCSC4QEu73F4d+bG1+J+RoJFgxt45ehRV/2K7k/cOZhHTHLxnPu5hFdM2dXX4KJsHiUVqRLtETVsw==
   dependencies:
-    "@loki/browser" "^0.33.0"
+    "@loki/browser" "^0.35.0"
 
-"@loki/integration-vue@^0.33.0":
-  version "0.33.0"
-  resolved "https://registry.yarnpkg.com/@loki/integration-vue/-/integration-vue-0.33.0.tgz#f94b39df1e3af7e096edf027d37bcc5f15843ef3"
-  integrity sha512-5iY34xO//T9m+YQCozF9GDDGoUhl1JMAH6tPyZOmf0ny9gLxlxxexL65VFrAZlcLYuxtAJh6kVl5aZv9IdA+1g==
+"@loki/integration-vue@^0.35.0":
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/@loki/integration-vue/-/integration-vue-0.35.0.tgz#a6697f65d6b892ef208cd3283d71bfc03ad97059"
+  integrity sha512-OPXlj7/vGd5XfNQCnFK+/K6fL5kk+hXpv77WqPnj60orWDhtPgl+wjbRS4VePXqy4iv6aqAINE7I5aCS0oiUNg==
   dependencies:
-    "@loki/browser" "^0.33.0"
+    "@loki/browser" "^0.35.0"
 
-"@loki/runner@^0.33.1":
-  version "0.33.1"
-  resolved "https://registry.yarnpkg.com/@loki/runner/-/runner-0.33.1.tgz#f231857aaa85a04d3181a360778ccaec225e5782"
-  integrity sha512-L7qoszyUN8/44CRLA3X1gaAQ3scl2LVjTdVPVrTfbimK5JfHFVdrUZ1QoZZ+7hfPCR+kiPlvnFn/JbM0Xt/jaA==
+"@loki/runner@^0.35.0":
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/@loki/runner/-/runner-0.35.0.tgz#0d5d0df4b87342c34fdc1bc02258ecef937141c0"
+  integrity sha512-tCVOA9P5IJSeXYcW68EeycYN68CHUpU2bWYVkAxxKXDhVHnBjI6W+lVMkJbky5WCF+ly2BuczjaJy7yIe8Ucvg==
   dependencies:
-    "@loki/core" "^0.33.0"
-    "@loki/diff-graphics-magick" "^0.33.0"
-    "@loki/diff-looks-same" "^0.33.0"
-    "@loki/diff-pixelmatch" "^0.33.0"
-    "@loki/target-chrome-app" "^0.33.1"
-    "@loki/target-chrome-aws-lambda" "^0.33.0"
-    "@loki/target-chrome-docker" "^0.33.1"
-    "@loki/target-native-android-emulator" "^0.33.0"
-    "@loki/target-native-ios-simulator" "^0.33.0"
+    "@loki/core" "^0.35.0"
+    "@loki/diff-graphics-magick" "^0.35.0"
+    "@loki/diff-looks-same" "^0.35.0"
+    "@loki/diff-pixelmatch" "^0.35.0"
+    "@loki/target-chrome-app" "^0.35.0"
+    "@loki/target-chrome-aws-lambda" "^0.35.0"
+    "@loki/target-chrome-docker" "^0.35.0"
+    "@loki/target-native-android-emulator" "^0.35.0"
+    "@loki/target-native-ios-simulator" "^0.35.0"
     async "^3.2.0"
     chalk "^4.1.0"
     ci-info "^2.0.0"
     cosmiconfig "^7.0.0"
     fs-extra "^9.1.0"
-    import-jsx "^4.0.0"
+    import-jsx "^4.0.1"
     ink "^3.2.0"
     minimist "^1.2.0"
     ramda "^0.27.1"
     react "^17.0.2"
     transliteration "^2.2.0"
 
-"@loki/target-chrome-app@^0.33.1":
-  version "0.33.1"
-  resolved "https://registry.yarnpkg.com/@loki/target-chrome-app/-/target-chrome-app-0.33.1.tgz#778bc22b26def0ff0dce3281ee3c9673951dd1f8"
-  integrity sha512-qrRxZ0CqZYOpjX7yn8oMQvp5Q/vGIVldOqGYxN3LtyIuJhuJCfqJtnIyFX/UP6C/1xWjMwPVxErEeVsmj/vnSw==
+"@loki/target-chrome-app@^0.35.0":
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/@loki/target-chrome-app/-/target-chrome-app-0.35.0.tgz#df90b414cb52cf633b6f5004f64a9a4e5bf443fe"
+  integrity sha512-P75JPKMISjqitPSsDMRbuXdQclbseezGTXmsuLQw/k+66I2gXsfAeQgXeHzgpXq1l5sPygnd2SHFjLJlm8wUzA==
   dependencies:
-    "@loki/core" "^0.33.0"
-    "@loki/target-chrome-core" "^0.33.0"
-    chrome-launcher "^0.14.1"
+    "@loki/core" "^0.35.0"
+    "@loki/target-chrome-core" "^0.35.0"
+    chrome-launcher "0.15.2"
     chrome-remote-interface "^0.32.1"
     debug "^4.1.1"
     find-free-port-sync "^1.0.0"
 
-"@loki/target-chrome-aws-lambda@^0.33.0":
-  version "0.33.0"
-  resolved "https://registry.yarnpkg.com/@loki/target-chrome-aws-lambda/-/target-chrome-aws-lambda-0.33.0.tgz#d35eebc57a849372e590b7c4709874d41fae118c"
-  integrity sha512-lCm19BkyvjRIS+koYEgrviYFYzv2x1hRDc2rugNZbpYFGBWxcrrdsG4d01iW664u7PqRBnSMc4PV1DfAP46Ewg==
+"@loki/target-chrome-aws-lambda@^0.35.0":
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/@loki/target-chrome-aws-lambda/-/target-chrome-aws-lambda-0.35.0.tgz#28b2698e2c7369939963fdd4fe0adac627b188c8"
+  integrity sha512-G4VAizeEEfdeslFH4VS9ULGkAtfkvfaQNtR8WLb2PkTv2NinIdio3ikGyeHrwRo40BGmZq+8WICG484c0OXSFw==
   dependencies:
-    "@loki/core" "^0.33.0"
+    "@loki/core" "^0.35.0"
     aws-sdk "^2.840.0"
     debug "^4.1.1"
 
-"@loki/target-chrome-core@^0.33.0":
-  version "0.33.0"
-  resolved "https://registry.yarnpkg.com/@loki/target-chrome-core/-/target-chrome-core-0.33.0.tgz#4e45a5ce3dace4fd93475ec85769a6b049efe83e"
-  integrity sha512-vmsWlmyelRDtcO9BjHib4OsquVqi0maXKGQ3BrsKh1t9cUa6q3NkSdpM6o2BgRXLpstv6nq0qI9ipHvtx6CbJA==
+"@loki/target-chrome-core@^0.35.0":
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/@loki/target-chrome-core/-/target-chrome-core-0.35.0.tgz#fd3816b548e568c3a88fae97f1892aace1fa7d48"
+  integrity sha512-uFZ34yy+D64ySxJVApoBHgZqwqs87ujvksw4/T4Uvmh0+5orI+6D9b1yq06a7CEUqgleTnMIO+f+ZM7+mhoKQQ==
   dependencies:
-    "@loki/browser" "^0.33.0"
-    "@loki/core" "^0.33.0"
-    "@loki/integration-core" "^0.33.0"
+    "@loki/browser" "^0.35.0"
+    "@loki/core" "^0.35.0"
+    "@loki/integration-core" "^0.35.0"
     debug "^4.1.1"
 
-"@loki/target-chrome-docker@^0.33.1":
-  version "0.33.1"
-  resolved "https://registry.yarnpkg.com/@loki/target-chrome-docker/-/target-chrome-docker-0.33.1.tgz#8a4d6a2a2168e42e27541aa2158fbc187d9fb94f"
-  integrity sha512-+rVimLlHzL2tZ2cl3x2tS4ipKEkB4f6alZnn0gj3FeJgli+n1PRJNw4JmgmO81px1ScyZCZw3ORTdeahvOyTRA==
+"@loki/target-chrome-docker@^0.35.0":
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/@loki/target-chrome-docker/-/target-chrome-docker-0.35.0.tgz#59e786233debe1fdfa40462b743c338e818d5eab"
+  integrity sha512-GDDP99BYEOgobuR2D0lYOCMwMb1n9VAUXtv1oXoV1q3nXh0xerqxFmEOqWFLhX+/hIWAqm7JXSKiCorMMwyctw==
   dependencies:
-    "@loki/core" "^0.33.0"
-    "@loki/target-chrome-core" "^0.33.0"
+    "@loki/core" "^0.35.0"
+    "@loki/target-chrome-core" "^0.35.0"
     chrome-remote-interface "^0.32.1"
     debug "^4.1.1"
     execa "^5.0.0"
     find-free-port-sync "^1.0.0"
     fs-extra "^9.1.0"
-    wait-on "^5.2.1"
+    wait-port "^1.1.0"
 
-"@loki/target-native-android-emulator@^0.33.0":
-  version "0.33.0"
-  resolved "https://registry.yarnpkg.com/@loki/target-native-android-emulator/-/target-native-android-emulator-0.33.0.tgz#944ff2e27774d986c581d343a5187eaecf6b83f9"
-  integrity sha512-AmHJy/MeB3WWrDvUeWTcjK0bN0Cm6chgQwTDYDNrFnk7m6CHywkgrMfILh4LJ1jYAHijnYPgoJYcoa8SbIbksQ==
+"@loki/target-native-android-emulator@^0.35.0":
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/@loki/target-native-android-emulator/-/target-native-android-emulator-0.35.0.tgz#9fea4b4d9d022f216dabd0575e287d5b220c602f"
+  integrity sha512-AETbsB24FTrYhyAObsKSJU29LD8hF0q74tiTTGHP6y3stDbs/7yIJGDIIzH5VN6ctVHFViNFeQakJYGdse4CTQ==
   dependencies:
     "@ferocia-oss/osnap" "^1.3.5"
-    "@loki/core" "^0.33.0"
-    "@loki/target-native-core" "^0.33.0"
+    "@loki/core" "^0.35.0"
+    "@loki/target-native-core" "^0.35.0"
     fs-extra "^9.1.0"
     tempy "^1.0.0"
 
-"@loki/target-native-core@^0.33.0":
-  version "0.33.0"
-  resolved "https://registry.yarnpkg.com/@loki/target-native-core/-/target-native-core-0.33.0.tgz#506a2ac549a6a50316fffe5755e192c98992bdb9"
-  integrity sha512-ouDgGVE6RVPBNGp8LhkyZjIE7wSXl5yRr2NBGrHzBmaf+KImyv5pM1qd7Ast44wim+iJ7gfbJGigRSgh93J3hw==
+"@loki/target-native-core@^0.35.0":
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/@loki/target-native-core/-/target-native-core-0.35.0.tgz#06c9cb46488aefe1cd4090943fe700ffdb7234dc"
+  integrity sha512-JxRGGEJ0/59vcuoC9WSNsgL/hjPAguwK3RNqOZha5S4fMSlkdU1eaDPX3YcGNogTrCMIcevLg5AvTw2CbVvnTA==
   dependencies:
-    "@loki/core" "^0.33.0"
+    "@loki/core" "^0.35.0"
     debug "^4.1.1"
     ws "^7.2.0"
 
-"@loki/target-native-ios-simulator@^0.33.0":
-  version "0.33.0"
-  resolved "https://registry.yarnpkg.com/@loki/target-native-ios-simulator/-/target-native-ios-simulator-0.33.0.tgz#5523d77b75018c5054b5a1bd93fcf9efe379f56c"
-  integrity sha512-mZ95v8TB7E9OWxBC+lI3O+u0hNz+/fGLAQB42FfMTXsv1JEN9S9SyZf4XLioXSJQYoGQ+yX31HQGFmXdcK+wDg==
+"@loki/target-native-ios-simulator@^0.35.0":
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/@loki/target-native-ios-simulator/-/target-native-ios-simulator-0.35.0.tgz#84e69fe0d72a3ffc29480787ffe555ba5f01fd61"
+  integrity sha512-KyN0vmDWr0elcOJJA97wS795zVA/R3WLqOip7rb2RvTt3Zb8gBigRFMHs8DZyXVL0uBMfeIYL9zcQNjH6eraHA==
   dependencies:
     "@ferocia-oss/osnap" "^1.3.5"
-    "@loki/core" "^0.33.0"
-    "@loki/target-native-core" "^0.33.0"
+    "@loki/core" "^0.35.0"
+    "@loki/target-native-core" "^0.35.0"
     fs-extra "^9.1.0"
     tempy "^1.0.0"
 
@@ -3149,23 +3137,6 @@
     debug "^4.3.4"
     node-fetch "^2.6.7"
     uuid "^8.3.2"
-
-"@sideway/address@^4.1.5":
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.5.tgz#4bc149a0076623ced99ca8208ba780d65a99b9d5"
-  integrity sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==
-  dependencies:
-    "@hapi/hoek" "^9.0.0"
-
-"@sideway/formula@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@sideway/formula/-/formula-3.0.1.tgz#80fcbcbaf7ce031e0ef2dd29b1bfc7c3f583611f"
-  integrity sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==
-
-"@sideway/pinpoint@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
-  integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
 "@sinclair/typebox@^0.24.1":
   version "0.24.44"
@@ -7439,13 +7410,6 @@ axe-core@^4.2.0:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.8.3.tgz#205df863dd9917d5979e9435dab4d47692759051"
   integrity sha512-d5ZQHPSPkF9Tw+yfyDcRoUOc4g/8UloJJe5J8m4L5+c7AtDdjDLRxew/knnI4CxvtdxEUVgWz4x3OIQUIFiMfw==
 
-axios@^0.21.1:
-  version "0.21.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
-  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
-  dependencies:
-    follow-redirects "^1.14.0"
-
 babel-eslint@10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.1.0.tgz#6968e568a910b78fb3779cdd8b6ac2f479943232"
@@ -8515,10 +8479,10 @@ chromatic@^10.2.0:
   resolved "https://registry.yarnpkg.com/chromatic/-/chromatic-10.2.0.tgz#04c96ce86c39a2ef54153bb5f98427912386c99b"
   integrity sha512-UDVGWa2Fx9CLCpwnyfvFHGr0vGF0ooB1TugUdgOcjC9pJXiFa67i7oaXMyTfVRIFxlt/QkqOJwdqDqqlLFffCw==
 
-chrome-launcher@^0.14.1:
-  version "0.14.2"
-  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.14.2.tgz#5cb334794b9e83fad7303c96c131a4ec9e9f83a6"
-  integrity sha512-Nk8DUCIfPR6p9WClPPFeP2ztpAdkT8xueoiDS03csea1uoJjm4w0p5Oy1hjykyjT1EQ0MMrEshLD3C8gHXyiZw==
+chrome-launcher@0.15.2:
+  version "0.15.2"
+  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.15.2.tgz#4e6404e32200095fdce7f6a1e1004f9bd36fa5da"
+  integrity sha512-zdLEwNo3aUVzIhKhTtXfxhdvZhUghrnmkvcAq2NoDd+LeOHKf03H5jwZ8T/STsAlzyALkBVK552iaG1fGf1xVQ==
   dependencies:
     "@types/node" "*"
     escape-string-regexp "^4.0.0"
@@ -8878,7 +8842,7 @@ commander@^8.3.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
   integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
 
-commander@^9.1.0:
+commander@^9.1.0, commander@^9.3.0:
   version "9.5.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-9.5.0.tgz#bc08d1eb5cedf7ccb797a96199d41c7bc3e60d30"
   integrity sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==
@@ -11893,7 +11857,7 @@ flux-standard-action@^0.6.1:
   dependencies:
     lodash.isplainobject "^3.2.0"
 
-follow-redirects@^1.0.0, follow-redirects@^1.14.0, follow-redirects@^1.15.5:
+follow-redirects@^1.0.0, follow-redirects@^1.15.5:
   version "1.15.6"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
   integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
@@ -13424,7 +13388,7 @@ import-fresh@^3.3.0:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
-import-jsx@^4.0.0:
+import-jsx@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/import-jsx/-/import-jsx-4.0.1.tgz#30d5d336f3f52ed32b62690997f26e23c252a258"
   integrity sha512-2Cj4nWRuAmvokFRU6UNo3xgzXKh+4nq/LBtD6mTp3V9c9nYV7O+dRvPChPOM34Qcj1+Ijz3oK6HqkixG0GP9Rg==
@@ -14981,17 +14945,6 @@ jmespath@0.16.0:
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.16.0.tgz#b15b0a85dfd4d930d43e69ed605943c802785076"
   integrity sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==
 
-joi@^17.3.0:
-  version "17.12.3"
-  resolved "https://registry.yarnpkg.com/joi/-/joi-17.12.3.tgz#944646979cd3b460178547b12ba37aca8482f63d"
-  integrity sha512-2RRziagf555owrm9IRVtdKynOBeITiDpuZqIpgwqXShPncPKNiRQoiGsl/T8SQdq+8ugRzH2LqY67irr2y/d+g==
-  dependencies:
-    "@hapi/hoek" "^9.3.0"
-    "@hapi/topo" "^5.1.0"
-    "@sideway/address" "^4.1.5"
-    "@sideway/formula" "^3.0.1"
-    "@sideway/pinpoint" "^2.0.0"
-
 jpeg-js@^0.4.0, jpeg-js@^0.4.2:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.4.4.tgz#a9f1c6f1f9f0fa80cdb3484ed9635054d28936aa"
@@ -15729,19 +15682,19 @@ log-update@^4.0.0:
     slice-ansi "^4.0.0"
     wrap-ansi "^6.2.0"
 
-loki@^0.33.0:
-  version "0.33.1"
-  resolved "https://registry.yarnpkg.com/loki/-/loki-0.33.1.tgz#d027837bf857603c24d2364a7be98f5ef1fd1c6f"
-  integrity sha512-U90KaWEbDtjVT02uUPJIa4CywjAVvtf94wOIqC7tLB4lPtWTP8FUW4fTKgm+M7wdvjoZXtFkkPnLkBQlvXBezg==
+loki@^0.35.0:
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/loki/-/loki-0.35.0.tgz#bb9454a15be2d899478463303b352b307c150edb"
+  integrity sha512-9al7gvZCvatnBLGjB8fcqrqlSRkwR+J+4d+Giwh0CgZKnBQcrd5/fX8NSCpZUKcoKuQ8r6ehOq+JvBJQr/M3lA==
   dependencies:
-    "@loki/integration-react" "^0.33.0"
-    "@loki/integration-react-native" "^0.33.0"
-    "@loki/integration-vue" "^0.33.0"
-    "@loki/runner" "^0.33.1"
-    "@loki/target-chrome-app" "^0.33.1"
-    "@loki/target-chrome-docker" "^0.33.1"
-    "@loki/target-native-android-emulator" "^0.33.0"
-    "@loki/target-native-ios-simulator" "^0.33.0"
+    "@loki/integration-react" "^0.35.0"
+    "@loki/integration-react-native" "^0.35.0"
+    "@loki/integration-vue" "^0.35.0"
+    "@loki/runner" "^0.35.0"
+    "@loki/target-chrome-app" "^0.35.0"
+    "@loki/target-chrome-docker" "^0.35.0"
+    "@loki/target-native-android-emulator" "^0.35.0"
+    "@loki/target-native-ios-simulator" "^0.35.0"
 
 long@^5.2.1:
   version "5.2.3"
@@ -20560,13 +20513,6 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-rxjs@^6.6.3:
-  version "6.6.7"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
-  integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
-  dependencies:
-    tslib "^1.9.0"
-
 rxjs@^7.0.0, rxjs@^7.8.0:
   version "7.8.0"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.0.tgz#90a938862a82888ff4c7359811a595e14e1e09a4"
@@ -22670,7 +22616,7 @@ tslib@2.3.0, tslib@^2.0.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
   integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
 
-tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -23568,16 +23514,14 @@ w3c-xmlserializer@^4.0.0:
   dependencies:
     xml-name-validator "^4.0.0"
 
-wait-on@^5.2.1:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-5.3.0.tgz#584e17d4b3fe7b46ac2b9f8e5e102c005c2776c7"
-  integrity sha512-DwrHrnTK+/0QFaB9a8Ol5Lna3k7WvUR4jzSKmz0YaPBpuN2sACyiPVKVfj6ejnjcajAcvn3wlbTyMIn9AZouOg==
+wait-port@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/wait-port/-/wait-port-1.1.0.tgz#e5d64ee071118d985e2b658ae7ad32b2ce29b6b5"
+  integrity sha512-3e04qkoN3LxTMLakdqeWth8nih8usyg+sf1Bgdf9wwUkp05iuK1eSY/QpLvscT/+F/gA89+LpUmmgBtesbqI2Q==
   dependencies:
-    axios "^0.21.1"
-    joi "^17.3.0"
-    lodash "^4.17.21"
-    minimist "^1.2.5"
-    rxjs "^6.6.3"
+    chalk "^4.1.2"
+    commander "^9.3.0"
+    debug "^4.3.4"
 
 walker@^1.0.7:
   version "1.0.7"


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/security/dependabot/144

### Description

Axios was used by loki@0.33.0 which is used for visual testing. Upgrading to 0.35.0 solved the problem because it doesn't require axios anymore

### How to verify

Run `yarn audit`, and there should not be axios in the result.

