### PR TITLE
Fix not allow using both react 17 and 18 in the SDK

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/package.template.json
+++ b/enterprise/frontend/src/embedding-sdk/package.template.json
@@ -9,7 +9,7 @@
   "main": "./dist/main.bundle.js",
   "types": "./dist/enterprise/frontend/src/embedding-sdk/index.d.ts",
   "peerDependencies": {
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": ">17.0.2 <=18",
+    "react-dom": ">17.0.2 <=18"
   }
 }

--- a/enterprise/frontend/src/embedding-sdk/package.template.json
+++ b/enterprise/frontend/src/embedding-sdk/package.template.json
@@ -9,7 +9,7 @@
   "main": "./dist/main.bundle.js",
   "types": "./dist/enterprise/frontend/src/embedding-sdk/index.d.ts",
   "peerDependencies": {
-    "react": ">17.0.2 <=18",
-    "react-dom": ">17.0.2 <=18"
+    "react": ">=17 <=18",
+    "react-dom": ">=17 <=18"
   }
 }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/42354

### Description

Our SDK supports both React 17 and 18 since we built our components with React 17 and React 18 is backward-compatible with React 17. This is only the package.json dependency version issue.

### How to verify

1. Create a React 18 application using:
    ```bash
    npx create-react-app my-app
    cd my-app
    ```
1. (in another shell) Build the Embedding SDK using `master` with these commands:
    ```bash
    yarn build-release:cljs && yarn build-embedding-sdk:watch
    ```
1. Go back to the React 18 application and install the SDK:
    ```bash
    # The location of the file might be different depending your folder structure
    npm install --install-links file:../metabase/resources/embedding-sdk
    ```
1. You should see an error that `react` versions are incompatible
1. (in another shell) Build the Embedding SDK using this PR with these commands:
    ```bash
    yarn build-release:cljs && yarn build-embedding-sdk:watch
    ```
1. Go back to the React 18 application and install the SDK:
    ```bash
    # The location of the file might be different depending your folder structure
    npm install --install-links file:../metabase/resources/embedding-sdk
    ```
1. You should not see any error
