### PR TITLE
[QP] Fix error with `:!=` "Is Not" filter on expression

### DIFF
--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -1254,7 +1254,8 @@
 (defn- correct-null-behaviour
   [driver [op & args :as clause]]
   (if-let [field-arg (lib.util.match/match-one args
-                       :field          &match)]
+                       :field          &match
+                       :expression     &match)]
     ;; We must not transform the head again else we'll have an infinite loop
     ;; (and we can't do it at the call-site as then it will be harder to fish out field references)
     [:or

--- a/test/metabase/driver/sql/query_processor_test.clj
+++ b/test/metabase/driver/sql/query_processor_test.clj
@@ -274,6 +274,7 @@
       :type     :query
       :query    (merge
                  {:source-query {:native "select 'foo' as a union select null as a union select 'bar' as a"}
+                  :expressions  {"initial" [:regex-match-first [:field "A" {:base-type :type/Text}] "(\\w)"]}
                   :order-by     [[:asc [:field "A" {:base-type :type/Text}]]]}
                  query)})))
 
@@ -287,7 +288,9 @@
     (is (= [[nil] ["bar"]]
            (query-on-dataset-with-nils {:filter [:not [:contains [:field "A" {:base-type :type/Text}] "f"]]})))
     (is (= [[nil] ["bar"]]
-           (query-on-dataset-with-nils {:filter [:!= [:field "A" {:base-type :type/Text}] "foo"]}))))
+           (query-on-dataset-with-nils {:filter [:!= [:field "A" {:base-type :type/Text}] "foo"]})))
+    (is (= [[nil] ["bar"]]
+           (query-on-dataset-with-nils {:filter [:!= [:expression "initial" {:base-type :type/Text}] "f"]}))))
   (testing "Null behaviour correction fix should work with joined fields (#13534)"
     (is (= [[1000]]
            (mt/rows


### PR DESCRIPTION
There was special handling for `:field` clauses but not `:expression`.
