### PR TITLE
fix pie chart tooltip

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/PieChart/PieChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/PieChart.jsx
@@ -360,6 +360,7 @@ export default class PieChart extends Component {
         : {
             key: t`Other`,
             value: otherTotal,
+            displayValue: otherTotal,
             percentage: otherTotal / total,
             color: color("text-light"),
           };
@@ -443,8 +444,10 @@ export default class PieChart extends Component {
           event: event && event.nativeEvent,
           stackedTooltipModel: getTooltipModel(
             others.map(o => ({
+              ...o,
               key: formatDimension(o.key, false),
               value: o.displayValue,
+              color: undefined,
             })),
             null,
             getFriendlyName(cols[dimensionIndex]),

--- a/frontend/src/metabase/visualizations/visualizations/PieChart/utils.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/utils.unit.spec.ts
@@ -19,6 +19,33 @@ const slices = [
   },
 ];
 
+const slicesWithOther = [
+  {
+    key: "foo",
+    value: 100,
+    displayValue: 100,
+    percentage: 0.28571429,
+    rowIndex: 0,
+    color: "green",
+  },
+  {
+    key: "bar",
+    value: 200,
+    displayValue: 200,
+    percentage: 0.57142857,
+    rowIndex: 1,
+    color: "red",
+  },
+  {
+    key: "Other",
+    value: 50,
+    displayValue: 50,
+    percentage: 0.14285714,
+    rowIndex: 2,
+    color: "grey",
+  },
+];
+
 const stateSlices = [
   {
     key: "AK",
@@ -144,6 +171,20 @@ describe("utils", () => {
       ]);
       expect(showTotal).toBe(true);
       expect(showPercentages).toBe(true);
+    });
+
+    it("should return a `value` for the `other` slice #42458", () => {
+      const { bodyRows } = getTooltipModel(
+        slicesWithOther,
+        0,
+        dimensionColumnName,
+        dimensionFormatter,
+        metricFormatter,
+      );
+
+      expect(bodyRows?.[bodyRows.length - 1].value).toBe(
+        slicesWithOther[slicesWithOther.length - 1].displayValue,
+      );
     });
 
     it("is not affected by minimum slice percentage setting #32430 #33342", () => {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/42458

### Description

Fixes the issue by ensuring the pie chart slices in the `others` variable have `displayValue`s. 

### How to verify

1. New question -> Products count by price auto binned
2. Set minimum slice percentage in viz settings to 10
3. Hover over other slice, confirm tooltip is correct
4. Confirm other tooltips are correct

### Demo

https://github.com/metabase/metabase/assets/37751258/91497bc7-c571-4fac-aa65-9109a58f2041

| 47.8 | This PR |
|--------|--------|
| <img width="1075" alt="other_tooltip_47" src="https://github.com/metabase/metabase/assets/37751258/93259c69-274a-4fe9-b10f-abb9ab202a88"> | <img width="1152" alt="other_tooltip_now" src="https://github.com/metabase/metabase/assets/37751258/a7be071c-d971-4f59-87f2-427d45738523"> |

Note that pie charts with negative slice values will have weird percentage values in the other slice tooltip. This is an existing issue that was present in previous versions, it's not fixed by this PR since it's unrelated to the issue we are closing here. We should revisit the concept of negative values in pie charts later, likely when we migrate the chart to echarts.


| 47.8 | This PR |
|--------|--------|
| <img width="1096" alt="negative_other_tooltip_47" src="https://github.com/metabase/metabase/assets/37751258/a0de0677-5a57-4cd6-97cc-a210d55c1aaa"> |  <img width="1107" alt="negative_other_tooltip_now" src="https://github.com/metabase/metabase/assets/37751258/7ecc773e-314e-439e-b015-4bc30be294dd"> |

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
