### PR TITLE
Run sanity check on bigger runner

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -108,7 +108,7 @@ jobs:
         run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
 
   run-sanity-check:
-    runs-on: ubuntu-22.04
+    runs-on: buildjet-4vcpu-ubuntu-2004
     timeout-minutes: 30
     needs: [release-artifact, check-uberjar-health]
     strategy:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -108,7 +108,7 @@ jobs:
         run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
 
   run-sanity-check:
-    runs-on: buildjet-4vcpu-ubuntu-2004
+    runs-on: buildjet-8vcpu-ubuntu-2204
     timeout-minutes: 30
     needs: [release-artifact, check-uberjar-health]
     strategy:


### PR DESCRIPTION


### Description

We're running out of memory on our pre-release cypress job. Also, it would be nice if this job finished faster to speed up the release process.

see [discussion](https://metaboat.slack.com/archives/C864UT5CZ/p1715276785834919)


