### PR TITLE
Don't use the slugify util for filenames

### DIFF
--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -380,7 +380,7 @@
     {:type         :attachment
      :content-type content-type
      :file-name    (format "%s_%s.%s"
-                           (or (u/slugify card-name) "query_result")
+                           (or card-name "query_result")
                            (u.date/format (t/zoned-date-time))
                            (name export-type))
      :content      (-> attachment-file .toURI .toURL)

--- a/test/metabase/dashboard_subscription_test.clj
+++ b/test/metabase/dashboard_subscription_test.clj
@@ -939,3 +939,9 @@
                          (->> (mapv #(str/split % #",")))
                          first
                          count))))))))))
+
+(deftest attachment-filenames-stay-readable-test
+  (testing "Filenames remain human-readable (#41669)"
+    (let [tmp (#'messages/create-temp-file ".tmp")
+          {:keys [file-name]} (#'messages/create-result-attachment-map :csv "テストSQL質問" tmp)]
+      (is (= "テストSQL質問" (first (str/split file-name #"_")))))))

--- a/test/metabase/pulse/test_util.clj
+++ b/test/metabase/pulse/test_util.clj
@@ -84,14 +84,14 @@
 (def csv-attachment
   {:type         :attachment
    :content-type "text/csv"
-   :file-name    "test_card.csv",
+   :file-name    "Test card.csv",
    :content      java.net.URL
    :description  "More results for 'Test card'"
    :content-id   false})
 
 (def xls-attachment
   {:type         :attachment
-   :file-name    "test_card.xlsx"
+   :file-name    "Test card.xlsx"
    :content-type "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
    :content      java.net.URL
    :description  "More results for 'Test card'"


### PR DESCRIPTION
Fixes: #41669

Since PR #39120 , the slugify util was used to make card names URL safe. This was done for turning things like spaces into underscores. But, it unfortunately encoded many characters into URL safe codes, which doesn't make for a nice filename.

This PR just removes the use of slugify when creating filenames, so that the characters can remain readable. 