### PR TITLE
Add an /api/collections/trash endpoint

### DIFF
--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -876,6 +876,12 @@
   {id ms/PositiveInt}
   (collection-detail (api/read-check Collection id)))
 
+(api/defendpoint GET "/trash"
+  "Fetch the trash collection, as in `/api/collection/:trash-id`"
+  []
+  {}
+  (collection-detail (api/read-check (collection/trash-collection))))
+
 (api/defendpoint GET "/root/timelines"
   "Fetch the root Collection's timelines."
   [include archived]


### PR DESCRIPTION
This fetches the Trash in exactly the same way as if we'd fetched it
with `/api/collection/:id` with the Trash ID. I hadn't realized that the
frontend was doing this with the previously hardcoded Trash ID.