### PR TITLE
Disable metric joins & revert join-related changes

### DIFF
--- a/e2e/test/scenarios/metrics/metrics-editing.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/metrics-editing.cy.spec.ts
@@ -94,7 +94,7 @@ describe("scenarios > metrics", () => {
       startNewMetric();
       popover().findByText("Raw Data").click();
       popover().findByText("Orders").click();
-      addCategoryFilter({
+      addStringCategoryFilter({
         tableName: "Product",
         columnName: "Category",
         values: ["Gadget"],
@@ -109,7 +109,7 @@ describe("scenarios > metrics", () => {
       startNewMetric();
       popover().findByText("Saved Questions").click();
       popover().findByText("Orders").click();
-      addCategoryFilter({
+      addStringCategoryFilter({
         tableName: "Product",
         columnName: "Category",
         values: ["Gadget"],
@@ -125,17 +125,22 @@ describe("scenarios > metrics", () => {
       startNewMetric();
       popover().findByText("Saved Questions").click();
       popover().findByText(MULTI_STAGE_QUESTION.name).click();
+      addNumberBetweenFilter({
+        columnName: "Count",
+        minValue: 5,
+        maxValue: 100,
+      });
       addAggregation({ operatorName: "Count of rows" });
       saveMetric();
       runQuery();
-      verifyScalarValue("48");
+      verifyScalarValue("5");
     });
 
     it("should create a metric based on a model", () => {
       startNewMetric();
       popover().findByText("Models").click();
       popover().findByText("Orders Model").click();
-      addCategoryFilter({
+      addStringCategoryFilter({
         tableName: "Product",
         columnName: "Category",
         values: ["Gadget"],
@@ -151,10 +156,15 @@ describe("scenarios > metrics", () => {
       startNewMetric();
       popover().findByText("Models").click();
       popover().findByText(MULTI_STAGE_QUESTION.name).click();
+      addNumberBetweenFilter({
+        columnName: "Count",
+        minValue: 5,
+        maxValue: 100,
+      });
       addAggregation({ operatorName: "Count of rows" });
       saveMetric();
       runQuery();
-      verifyScalarValue("48");
+      verifyScalarValue("5");
     });
 
     it("should create a metric based on a single-stage metric", () => {
@@ -162,7 +172,7 @@ describe("scenarios > metrics", () => {
       startNewMetric();
       popover().findByText("Metrics").click();
       popover().findByText(SINGLE_STAGE_METRIC.name).click();
-      addCategoryFilter({
+      addStringCategoryFilter({
         tableName: "Product",
         columnName: "Category",
         values: ["Gadget"],
@@ -177,9 +187,14 @@ describe("scenarios > metrics", () => {
       startNewMetric();
       popover().findByText("Metrics").click();
       popover().findByText(MULTI_STAGE_METRIC.name).click();
+      addDateBetweenFilter({
+        columnName: "Created At: Month",
+        minValue: "May 7, 2020",
+        maxValue: "October 20, 2022",
+      });
       saveMetric();
       runQuery();
-      verifyScalarValue("48");
+      verifyScalarValue("6");
     });
   });
 
@@ -441,7 +456,7 @@ function startNewBreakout({ stageIndex }: StartNewClauseOpts = {}) {
     .within(() => getPlusButton().click());
 }
 
-function addCategoryFilter({
+function addStringCategoryFilter({
   tableName,
   columnName,
   values,
@@ -457,6 +472,53 @@ function addCategoryFilter({
     }
     cy.findByText(columnName).click();
     values.forEach(value => cy.findByText(value).click());
+    cy.button("Add filter").click();
+  });
+}
+
+function addNumberBetweenFilter({
+  tableName,
+  columnName,
+  minValue,
+  maxValue,
+}: {
+  tableName?: string;
+  columnName: string;
+  minValue: number;
+  maxValue: number;
+}) {
+  startNewFilter();
+  popover().within(() => {
+    if (tableName) {
+      cy.findByText(tableName).click();
+    }
+    cy.findByText(columnName).click();
+    cy.findByPlaceholderText("Min").type(String(minValue));
+    cy.findByPlaceholderText("Max").type(String(maxValue));
+    cy.button("Add filter").click();
+  });
+}
+
+function addDateBetweenFilter({
+  tableName,
+  columnName,
+  minValue,
+  maxValue,
+}: {
+  tableName?: string;
+  columnName: string;
+  minValue: string;
+  maxValue: string;
+}) {
+  startNewFilter();
+  popover().within(() => {
+    if (tableName) {
+      cy.findByText(tableName).click();
+    }
+    cy.findByText(columnName).click();
+    cy.findByText("Specific dates…").click();
+    cy.findByLabelText("Start date").clear().type(minValue);
+    cy.findByLabelText("End date").clear().type(maxValue);
     cy.button("Add filter").click();
   });
 }

--- a/e2e/test/scenarios/metrics/metrics-editing.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/metrics-editing.cy.spec.ts
@@ -94,20 +94,30 @@ describe("scenarios > metrics", () => {
       startNewMetric();
       popover().findByText("Raw Data").click();
       popover().findByText("Orders").click();
+      addCategoryFilter({
+        tableName: "Product",
+        columnName: "Category",
+        values: ["Gadget"],
+      });
       addAggregation({ operatorName: "Count of rows" });
       saveMetric();
       runQuery();
-      verifyScalarValue("18,760");
+      verifyScalarValue("4,939");
     });
 
     it("should create a metric based on a saved question", () => {
       startNewMetric();
       popover().findByText("Saved Questions").click();
       popover().findByText("Orders").click();
+      addCategoryFilter({
+        tableName: "Product",
+        columnName: "Category",
+        values: ["Gadget"],
+      });
       addAggregation({ operatorName: "Count of rows" });
       saveMetric();
       runQuery();
-      verifyScalarValue("18,760");
+      verifyScalarValue("4,939");
     });
 
     it("should create a metric based on a multi-stage saved question", () => {
@@ -125,10 +135,15 @@ describe("scenarios > metrics", () => {
       startNewMetric();
       popover().findByText("Models").click();
       popover().findByText("Orders Model").click();
+      addCategoryFilter({
+        tableName: "Product",
+        columnName: "Category",
+        values: ["Gadget"],
+      });
       addAggregation({ operatorName: "Count of rows" });
       saveMetric();
       runQuery();
-      verifyScalarValue("18,760");
+      verifyScalarValue("4,939");
     });
 
     it("should create a metric based on a multi-stage model", () => {
@@ -147,9 +162,14 @@ describe("scenarios > metrics", () => {
       startNewMetric();
       popover().findByText("Metrics").click();
       popover().findByText(SINGLE_STAGE_METRIC.name).click();
+      addCategoryFilter({
+        tableName: "Product",
+        columnName: "Category",
+        values: ["Gadget"],
+      });
       saveMetric();
       runQuery();
-      verifyScalarValue("18,760");
+      verifyScalarValue("4,939");
     });
 
     it("should create a metric based on a multi-stage metric", () => {
@@ -419,6 +439,26 @@ function startNewBreakout({ stageIndex }: StartNewClauseOpts = {}) {
   getNotebookStep("summarize", { stage: stageIndex })
     .findByTestId("breakout-step")
     .within(() => getPlusButton().click());
+}
+
+function addCategoryFilter({
+  tableName,
+  columnName,
+  values,
+}: {
+  tableName?: string;
+  columnName: string;
+  values: string[];
+}) {
+  startNewFilter();
+  popover().within(() => {
+    if (tableName) {
+      cy.findByText(tableName).click();
+    }
+    cy.findByText(columnName).click();
+    values.forEach(value => cy.findByText(value).click());
+    cy.button("Add filter").click();
+  });
 }
 
 function addAggregation({

--- a/e2e/test/scenarios/metrics/metrics-editing.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/metrics-editing.cy.spec.ts
@@ -18,7 +18,7 @@ const { ORDERS_ID } = SAMPLE_DATABASE;
 
 type QuestionDetails = StructuredQuestionDetails & { name: string };
 
-const ORDER_COUNT_DETAILS: QuestionDetails = {
+const ORDER_COUNT_METRIC: QuestionDetails = {
   name: "Orders metric",
   type: "metric",
   query: {
@@ -80,10 +80,10 @@ describe("scenarios > metrics", () => {
     });
 
     it("should create a metric for another metric", () => {
-      createQuestion(ORDER_COUNT_DETAILS);
+      createQuestion(ORDER_COUNT_METRIC);
       startNewMetric();
       popover().findByText("Metrics").click();
-      popover().findByText(ORDER_COUNT_DETAILS.name).click();
+      popover().findByText(ORDER_COUNT_METRIC.name).click();
       saveMetric();
       runQuery();
       verifyScalarValue("18,760");
@@ -111,10 +111,10 @@ describe("scenarios > metrics", () => {
     });
 
     it("should not be possible to join data on the first stage of a metric-based query", () => {
-      createQuestion(ORDER_COUNT_DETAILS);
+      createQuestion(ORDER_COUNT_METRIC);
       startNewQuestion();
       popover().findByText("Metrics").click();
-      popover().findByText(ORDER_COUNT_DETAILS.name).click();
+      popover().findByText(ORDER_COUNT_METRIC.name).click();
       getNotebookStep("data").within(() => {
         getActionButton("Custom column").should("be.visible");
         getActionButton("Join data").should("not.exist");
@@ -128,6 +128,22 @@ describe("scenarios > metrics", () => {
       });
       visualize();
       assertQueryBuilderRowCount(200);
+    });
+
+    it("should not be possible to join a metric", () => {
+      createQuestion(ORDER_COUNT_METRIC);
+      startNewMetric();
+      popover().findByText("Raw Data").click();
+      popover().findByText("Orders").click();
+      startNewJoin();
+      popover().within(() => {
+        cy.findByText("Sample Database").click();
+        cy.findByText("Raw Data").click();
+        cy.findByText("Raw Data").should("be.visible");
+        cy.findByText("Saved Questions").should("be.visible");
+        cy.findByText("Models").should("be.visible");
+        cy.findByText("Metrics").should("not.exist");
+      });
     });
   });
 
@@ -197,13 +213,13 @@ describe("scenarios > metrics", () => {
 
   describe("aggregations", () => {
     it("should create a metric with a custom aggregation expression based on 1 metric", () => {
-      createQuestion(ORDER_COUNT_DETAILS);
+      createQuestion(ORDER_COUNT_METRIC);
       startNewMetric();
       popover().findByText("Metrics").click();
-      popover().findByText(ORDER_COUNT_DETAILS.name).click();
-      getNotebookStep("summarize").findByText(ORDER_COUNT_DETAILS.name).click();
+      popover().findByText(ORDER_COUNT_METRIC.name).click();
+      getNotebookStep("summarize").findByText(ORDER_COUNT_METRIC.name).click();
       enterCustomColumnDetails({
-        formula: `[${ORDER_COUNT_DETAILS.name}] / 2`,
+        formula: `[${ORDER_COUNT_METRIC.name}] / 2`,
         name: "",
       });
       popover().button("Update").click();

--- a/e2e/test/scenarios/metrics/metrics-editing.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/metrics-editing.cy.spec.ts
@@ -134,7 +134,7 @@ describe("scenarios > metrics", () => {
     it("should create a metric based on a multi-stage model", () => {
       createQuestion({ ...MULTI_STAGE_QUESTION, type: "model" });
       startNewMetric();
-      popover().findByText("Saved Questions").click();
+      popover().findByText("Models").click();
       popover().findByText(MULTI_STAGE_QUESTION.name).click();
       addAggregation({ operatorName: "Count of rows" });
       saveMetric();

--- a/e2e/test/scenarios/metrics/metrics-editing.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/metrics-editing.cy.spec.ts
@@ -110,26 +110,6 @@ describe("scenarios > metrics", () => {
       verifyScalarValue("613");
     });
 
-    it("should not be possible to join data on the first stage of a metric-based query", () => {
-      createQuestion(ORDER_COUNT_METRIC);
-      startNewQuestion();
-      popover().findByText("Metrics").click();
-      popover().findByText(ORDER_COUNT_METRIC.name).click();
-      getNotebookStep("data").within(() => {
-        getActionButton("Custom column").should("be.visible");
-        getActionButton("Join data").should("not.exist");
-      });
-      addBreakout({ columnName: "Product ID" });
-      startNewJoin({ isPostAggregation: true });
-      popover().findByText("Products").click();
-      getNotebookStep("join", { stage: 1 }).within(() => {
-        cy.findByText("ID").should("be.visible");
-        cy.findByText("Product ID").should("be.visible");
-      });
-      visualize();
-      assertQueryBuilderRowCount(200);
-    });
-
     it("should not be possible to join a metric", () => {
       createQuestion(ORDER_COUNT_METRIC);
       startNewMetric();
@@ -144,6 +124,33 @@ describe("scenarios > metrics", () => {
         cy.findByText("Models").should("be.visible");
         cy.findByText("Metrics").should("not.exist");
       });
+    });
+
+    it("should not be possible to join data on the first stage of a metric-based query", () => {
+      createQuestion(ORDER_COUNT_METRIC);
+      startNewQuestion();
+      popover().findByText("Metrics").click();
+      popover().findByText(ORDER_COUNT_METRIC.name).click();
+      getNotebookStep("data").within(() => {
+        getActionButton("Custom column").should("be.visible");
+        getActionButton("Join data").should("not.exist");
+      });
+    });
+
+    it("should a join in the second stage of a metric query", () => {
+      createQuestion(ORDER_COUNT_METRIC);
+      startNewQuestion();
+      popover().findByText("Metrics").click();
+      popover().findByText(ORDER_COUNT_METRIC.name).click();
+      addBreakout({ columnName: "Product ID" });
+      startNewJoin({ isPostAggregation: true });
+      popover().findByText("Products").click();
+      getNotebookStep("join", { stage: 1 }).within(() => {
+        cy.findByText("ID").should("be.visible");
+        cy.findByText("Product ID").should("be.visible");
+      });
+      visualize();
+      assertQueryBuilderRowCount(200);
     });
   });
 

--- a/e2e/test/scenarios/metrics/metrics-editing.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/metrics-editing.cy.spec.ts
@@ -28,11 +28,10 @@ const SINGLE_STAGE_METRIC: QuestionDetails = {
   display: "scalar",
 };
 
-const MULTI_STAGE_QUESTION: QuestionDetails = {
-  name: "Multi-stage orders",
-  type: "question",
+const MULTI_STAGE_METRIC: QuestionDetails = {
+  name: "Orders metric",
+  type: "metric",
   query: {
-    filter: [">", ["field", "count", { "base-type": "type/Integer" }], 10],
     "source-query": {
       "source-table": ORDERS_ID,
       aggregation: [["count"]],
@@ -44,6 +43,28 @@ const MULTI_STAGE_QUESTION: QuestionDetails = {
         ],
       ],
     },
+    filter: [">", ["field", "count", { "base-type": "type/Integer" }], 10],
+    aggregation: [["count"]],
+  },
+  display: "scalar",
+};
+
+const MULTI_STAGE_QUESTION: QuestionDetails = {
+  name: "Multi-stage orders",
+  type: "question",
+  query: {
+    "source-query": {
+      "source-table": ORDERS_ID,
+      aggregation: [["count"]],
+      breakout: [
+        [
+          "field",
+          ORDERS.CREATED_AT,
+          { "base-type": "type/DateTime", "temporal-unit": "month" },
+        ],
+      ],
+    },
+    filter: [">", ["field", "count", { "base-type": "type/Integer" }], 10],
   },
   display: "table",
 };
@@ -129,6 +150,16 @@ describe("scenarios > metrics", () => {
       saveMetric();
       runQuery();
       verifyScalarValue("18,760");
+    });
+
+    it("should create a metric based on a multi-stage metric", () => {
+      createQuestion(MULTI_STAGE_METRIC);
+      startNewMetric();
+      popover().findByText("Metrics").click();
+      popover().findByText(MULTI_STAGE_METRIC.name).click();
+      saveMetric();
+      runQuery();
+      verifyScalarValue("48");
     });
   });
 

--- a/e2e/test/scenarios/metrics/metrics-editing.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/metrics-editing.cy.spec.ts
@@ -289,6 +289,15 @@ describe("scenarios > metrics", () => {
       runQuery();
       verifyScalarValue("755,310.84");
     });
+
+    it("should open the expression editor automatically when the source metric is already used in an aggregation expression", () => {
+      createQuestion(ORDERS_COUNT_METRIC);
+      startNewMetric();
+      popover().findByText("Metrics").click();
+      popover().findByText(ORDERS_COUNT_METRIC.name).click();
+      startNewAggregation();
+      cy.findByTestId("expression-editor").should("be.visible");
+    });
   });
 
   describe("filters", () => {

--- a/e2e/test/scenarios/metrics/metrics-editing.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/metrics-editing.cy.spec.ts
@@ -69,7 +69,7 @@ describe("scenarios > metrics", () => {
   });
 
   describe("data source", () => {
-    it("should create a metric for a table", () => {
+    it("should create a metric based on a table", () => {
       startNewMetric();
       popover().findByText("Raw Data").click();
       popover().findByText("Orders").click();
@@ -79,7 +79,7 @@ describe("scenarios > metrics", () => {
       verifyScalarValue("18,760");
     });
 
-    it("should create a metric for a saved question", () => {
+    it("should create a metric based on a saved question", () => {
       startNewMetric();
       popover().findByText("Saved Questions").click();
       popover().findByText("Orders").click();
@@ -89,7 +89,7 @@ describe("scenarios > metrics", () => {
       verifyScalarValue("18,760");
     });
 
-    it("should create a metric for a multi-stage saved question", () => {
+    it("should create a metric based on a multi-stage saved question", () => {
       createQuestion(MULTI_STAGE_QUESTION);
       startNewMetric();
       popover().findByText("Saved Questions").click();
@@ -100,7 +100,7 @@ describe("scenarios > metrics", () => {
       verifyScalarValue("48");
     });
 
-    it("should create a metric for a model", () => {
+    it("should create a metric based on a model", () => {
       startNewMetric();
       popover().findByText("Models").click();
       popover().findByText("Orders Model").click();
@@ -110,7 +110,7 @@ describe("scenarios > metrics", () => {
       verifyScalarValue("18,760");
     });
 
-    it("should create a metric for another metric", () => {
+    it("should create a metric based on a single-stage metric", () => {
       createQuestion(ORDER_COUNT_METRIC);
       startNewMetric();
       popover().findByText("Metrics").click();
@@ -168,7 +168,7 @@ describe("scenarios > metrics", () => {
       });
     });
 
-    it("should a join on the second stage of a metric query", () => {
+    it("should join on the second stage of a metric query", () => {
       createQuestion(ORDER_COUNT_METRIC);
       startNewQuestion();
       popover().findByText("Metrics").click();

--- a/e2e/test/scenarios/metrics/metrics-editing.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/metrics-editing.cy.spec.ts
@@ -18,7 +18,7 @@ const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
 
 type QuestionDetails = StructuredQuestionDetails & { name: string };
 
-const ORDER_COUNT_METRIC: QuestionDetails = {
+const SINGLE_STAGE_METRIC: QuestionDetails = {
   name: "Orders metric",
   type: "metric",
   query: {
@@ -110,11 +110,22 @@ describe("scenarios > metrics", () => {
       verifyScalarValue("18,760");
     });
 
+    it("should create a metric based on a multi-stage model", () => {
+      createQuestion({ ...MULTI_STAGE_QUESTION, type: "model" });
+      startNewMetric();
+      popover().findByText("Saved Questions").click();
+      popover().findByText(MULTI_STAGE_QUESTION.name).click();
+      addAggregation({ operatorName: "Count of rows" });
+      saveMetric();
+      runQuery();
+      verifyScalarValue("48");
+    });
+
     it("should create a metric based on a single-stage metric", () => {
-      createQuestion(ORDER_COUNT_METRIC);
+      createQuestion(SINGLE_STAGE_METRIC);
       startNewMetric();
       popover().findByText("Metrics").click();
-      popover().findByText(ORDER_COUNT_METRIC.name).click();
+      popover().findByText(SINGLE_STAGE_METRIC.name).click();
       saveMetric();
       runQuery();
       verifyScalarValue("18,760");
@@ -142,7 +153,7 @@ describe("scenarios > metrics", () => {
     });
 
     it("should not be possible to join a metric", () => {
-      createQuestion(ORDER_COUNT_METRIC);
+      createQuestion(SINGLE_STAGE_METRIC);
       startNewMetric();
       popover().findByText("Raw Data").click();
       popover().findByText("Orders").click();
@@ -158,10 +169,10 @@ describe("scenarios > metrics", () => {
     });
 
     it("should not be possible to join data on the first stage of a metric-based query", () => {
-      createQuestion(ORDER_COUNT_METRIC);
+      createQuestion(SINGLE_STAGE_METRIC);
       startNewQuestion();
       popover().findByText("Metrics").click();
-      popover().findByText(ORDER_COUNT_METRIC.name).click();
+      popover().findByText(SINGLE_STAGE_METRIC.name).click();
       getNotebookStep("data").within(() => {
         getActionButton("Custom column").should("be.visible");
         getActionButton("Join data").should("not.exist");
@@ -169,10 +180,10 @@ describe("scenarios > metrics", () => {
     });
 
     it("should join on the second stage of a metric query", () => {
-      createQuestion(ORDER_COUNT_METRIC);
+      createQuestion(SINGLE_STAGE_METRIC);
       startNewQuestion();
       popover().findByText("Metrics").click();
-      popover().findByText(ORDER_COUNT_METRIC.name).click();
+      popover().findByText(SINGLE_STAGE_METRIC.name).click();
       addBreakout({ columnName: "Product ID" });
       startNewJoin({ isPostAggregation: true });
       popover().findByText("Products").click();
@@ -251,13 +262,13 @@ describe("scenarios > metrics", () => {
 
   describe("aggregations", () => {
     it("should create a metric with a custom aggregation expression based on 1 metric", () => {
-      createQuestion(ORDER_COUNT_METRIC);
+      createQuestion(SINGLE_STAGE_METRIC);
       startNewMetric();
       popover().findByText("Metrics").click();
-      popover().findByText(ORDER_COUNT_METRIC.name).click();
-      getNotebookStep("summarize").findByText(ORDER_COUNT_METRIC.name).click();
+      popover().findByText(SINGLE_STAGE_METRIC.name).click();
+      getNotebookStep("summarize").findByText(SINGLE_STAGE_METRIC.name).click();
       enterCustomColumnDetails({
-        formula: `[${ORDER_COUNT_METRIC.name}] / 2`,
+        formula: `[${SINGLE_STAGE_METRIC.name}] / 2`,
         name: "",
       });
       popover().button("Update").click();

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -157,7 +157,7 @@ export class UnconnectedDataSelector extends Component {
     hasTableSearch: PropTypes.bool,
     canChangeDatabase: PropTypes.bool,
     containerClassName: PropTypes.string,
-    hasMetrics: PropTypes.bool,
+    canSelectMetric: PropTypes.bool,
 
     // from search entity list loader
     allError: PropTypes.bool,
@@ -189,7 +189,7 @@ export class UnconnectedDataSelector extends Component {
     hasTriggerExpandControl: true,
     isPopover: true,
     isMantine: false,
-    hasMetrics: false,
+    canSelectMetric: false,
   };
 
   // computes selected metadata objects (`selectedDatabase`, etc) and options (`databases`, etc)
@@ -444,8 +444,8 @@ export class UnconnectedDataSelector extends Component {
   };
 
   hasMetrics = () => {
-    const { metrics, loaded, hasMetrics } = this.props;
-    return loaded && metrics && metrics.length > 0 && hasMetrics;
+    const { metrics, loaded, canSelectMetric } = this.props;
+    return loaded && metrics && metrics.length > 0 && canSelectMetric;
   };
 
   hasUsableMetrics = () => {

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -157,6 +157,7 @@ export class UnconnectedDataSelector extends Component {
     hasTableSearch: PropTypes.bool,
     canChangeDatabase: PropTypes.bool,
     containerClassName: PropTypes.string,
+    hasMetrics: PropTypes.bool,
 
     // from search entity list loader
     allError: PropTypes.bool,
@@ -188,6 +189,7 @@ export class UnconnectedDataSelector extends Component {
     hasTriggerExpandControl: true,
     isPopover: true,
     isMantine: false,
+    hasMetrics: false,
   };
 
   // computes selected metadata objects (`selectedDatabase`, etc) and options (`databases`, etc)
@@ -442,8 +444,8 @@ export class UnconnectedDataSelector extends Component {
   };
 
   hasMetrics = () => {
-    const { metrics, loaded } = this.props;
-    return loaded && metrics && metrics.length > 0;
+    const { metrics, loaded, hasMetrics } = this.props;
+    return loaded && metrics && metrics.length > 0 && hasMetrics;
   };
 
   hasUsableMetrics = () => {

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -970,7 +970,12 @@ export class UnconnectedDataSelector extends Component {
       return isSavedEntityPickerShown ? ["card"] : ["card", "table"];
     }
     if (!selectedDataBucketId) {
-      return ["card", "dataset", "table", "metric"];
+      return [
+        "card",
+        "dataset",
+        "table",
+        ...(this.props.canSelectMetric ? ["metric"] : []),
+      ];
     }
     return {
       [DATA_BUCKET.MODELS]: ["dataset"],

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.tsx
@@ -66,7 +66,7 @@ function NotebookStep({
     actions.push(
       ...step.actions.map(action => {
         const stepUi = STEP_UI[action.type];
-        const title = stepUi.getTitle(step.question.type());
+        const title = stepUi.title;
         return {
           priority: stepUi.priority,
           button: (
@@ -90,7 +90,7 @@ function NotebookStep({
     actions.sort((a, b) => (b.priority || 0) - (a.priority || 0));
 
     return actions.map(action => action.button);
-  }, [step.actions, step.question, isLastStep, openStep]);
+  }, [step.actions, isLastStep, openStep]);
 
   const handleClickRevert = useCallback(() => {
     if (step.revert) {
@@ -104,12 +104,11 @@ function NotebookStep({
   }, [step, updateQuery]);
 
   const {
-    getTitle,
+    title,
     color,
     component: NotebookStepComponent,
   } = STEP_UI[step.type] || {};
 
-  const title = getTitle(step.question.type());
   const canPreview =
     Lib.canRun(step.query, step.question.type()) && step.active && step.visible;
   const hasPreviewButton = !isPreviewOpen && canPreview;

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep/steps.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep/steps.ts
@@ -3,7 +3,6 @@ import { t } from "ttag";
 
 import { color } from "metabase/lib/colors";
 import type { IconName } from "metabase/ui";
-import type { CardType } from "metabase-types/api";
 
 import { AggregateStep } from "../steps/AggregateStep";
 import BreakoutStep from "../steps/BreakoutStep";
@@ -17,7 +16,7 @@ import SummarizeStep from "../steps/SummarizeStep";
 import type { NotebookStepUiComponentProps } from "../types";
 
 export type StepUIItem = {
-  getTitle: (type: CardType) => string;
+  title: string;
   icon?: IconName;
   priority?: number;
   transparent?: boolean;
@@ -28,55 +27,54 @@ export type StepUIItem = {
 
 export const STEP_UI: Record<string, StepUIItem> = {
   data: {
-    getTitle: () => t`Data`,
+    title: t`Data`,
     component: DataStep,
     color: color("brand"),
   },
   join: {
-    getTitle: () => t`Join data`,
+    title: t`Join data`,
     icon: "join_left_outer",
     priority: 1,
     color: color("brand"),
     component: JoinStep,
   },
   expression: {
-    getTitle: () => t`Custom column`,
+    title: t`Custom column`,
     icon: "add_data",
     component: ExpressionStep,
     transparent: true,
     color: color("bg-dark"),
   },
   filter: {
-    getTitle: type => (type === "metric" ? t`Filter (optional)` : t`Filter`),
+    title: t`Filter`,
     icon: "filter",
     component: FilterStep,
     priority: 10,
     color: color("filter"),
   },
   summarize: {
-    getTitle: type =>
-      type === "metric" ? t`Measure calculation` : t`Summarize`,
+    title: t`Summarize`,
     icon: "sum",
     component: SummarizeStep,
     priority: 5,
     color: color("summarize"),
   },
   aggregate: {
-    getTitle: () => t`Aggregate`,
+    title: t`Aggregate`,
     icon: "sum",
     component: AggregateStep,
     priority: 5,
     color: color("summarize"),
   },
   breakout: {
-    getTitle: () => t`Breakout`,
+    title: t`Breakout`,
     icon: "segment",
     component: BreakoutStep,
     priority: 1,
     color: color("accent4"),
   },
   sort: {
-    getTitle: () => t`Sort`,
+    title: t`Sort`,
     icon: "sort",
     component: SortStep,
     compact: true,
@@ -84,7 +82,7 @@ export const STEP_UI: Record<string, StepUIItem> = {
     color: color("bg-dark"),
   },
   limit: {
-    getTitle: () => t`Row limit`,
+    title: t`Row limit`,
     icon: "list",
     component: LimitStep,
     compact: true,

--- a/frontend/src/metabase/query_builder/components/notebook/lib/steps.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/lib/steps.ts
@@ -29,9 +29,13 @@ const STEPS: NotebookStepDef[] = [
   },
   {
     type: "join",
-    valid: (query, _stageIndex, metadata) => {
+    valid: (query, stageIndex, metadata) => {
       const database = metadata.database(Lib.databaseID(query));
-      return hasData(query) && Boolean(database?.hasFeature("join"));
+      return (
+        hasData(query) &&
+        Boolean(database?.hasFeature("join")) &&
+        !Lib.isMetricBased(query, stageIndex)
+      );
     },
     subSteps: (query, stageIndex) => {
       return Lib.joins(query, stageIndex).length;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.tsx
@@ -79,7 +79,7 @@ export const DataStep = ({
       >
         <DataSourceSelector
           hasTableSearch
-          hasMetrics
+          canSelectMetric
           collectionId={collectionId}
           databaseQuery={{ saved: true }}
           selectedDatabaseId={databaseId}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.tsx
@@ -79,6 +79,7 @@ export const DataStep = ({
       >
         <DataSourceSelector
           hasTableSearch
+          hasMetrics
           collectionId={collectionId}
           databaseQuery={{ saved: true }}
           selectedDatabaseId={databaseId}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinComplete/JoinComplete.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinComplete/JoinComplete.tsx
@@ -48,8 +48,8 @@ export function JoinComplete({
     [query, stageIndex, join],
   );
 
-  const rhsTableInfo = useMemo(
-    () => Lib.displayInfo(query, stageIndex, rhsTable),
+  const rhsTableName = useMemo(
+    () => Lib.displayInfo(query, stageIndex, rhsTable).displayName,
     [query, stageIndex, rhsTable],
   );
 
@@ -114,7 +114,7 @@ export function JoinComplete({
           <JoinTablePicker
             query={query}
             table={rhsTable}
-            tableInfo={rhsTableInfo}
+            tableName={rhsTableName}
             color={color}
             isReadOnly={isReadOnly}
             isModelDataSource={isModelDataSource}
@@ -146,7 +146,7 @@ export function JoinComplete({
                 join={join}
                 condition={condition}
                 lhsTableName={lhsTableName}
-                rhsTableName={rhsTableInfo.displayName}
+                rhsTableName={rhsTableName}
                 isReadOnly={isReadOnly}
                 isRemovable={conditions.length > 1}
                 onChange={newCondition =>
@@ -172,7 +172,7 @@ export function JoinComplete({
               stageIndex={stageIndex}
               joinable={join}
               lhsTableName={lhsTableName}
-              rhsTableName={rhsTableInfo.displayName}
+              rhsTableName={rhsTableName}
               isReadOnly={isReadOnly}
               isRemovable={true}
               onChange={handleAddCondition}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinDraft/JoinDraft.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinDraft/JoinDraft.tsx
@@ -52,8 +52,11 @@ export function JoinDraft({
     [query, stageIndex, rhsTable, lhsColumn],
   );
 
-  const rhsTableInfo = useMemo(
-    () => (rhsTable ? Lib.displayInfo(query, stageIndex, rhsTable) : undefined),
+  const rhsTableName = useMemo(
+    () =>
+      rhsTable
+        ? Lib.displayInfo(query, stageIndex, rhsTable).displayName
+        : undefined,
     [query, stageIndex, rhsTable],
   );
 
@@ -101,7 +104,7 @@ export function JoinDraft({
           <JoinTablePicker
             query={query}
             table={rhsTable}
-            tableInfo={rhsTableInfo}
+            tableName={rhsTableName}
             color={color}
             isReadOnly={isReadOnly}
             isModelDataSource={isModelDataSource}
@@ -129,7 +132,7 @@ export function JoinDraft({
               stageIndex={stageIndex}
               joinable={rhsTable}
               lhsTableName={lhsTableName}
-              rhsTableName={rhsTableInfo?.displayName}
+              rhsTableName={rhsTableName}
               isReadOnly={isReadOnly}
               isRemovable={false}
               onChange={handleConditionChange}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.styled.tsx
@@ -6,8 +6,6 @@ import { color } from "metabase/lib/colors";
 import { NotebookCell } from "../../../NotebookCell";
 
 export const TablePickerButton = styled.button`
-  display: flex;
-  gap: 0.25rem;
   color: inherit;
   font-weight: inherit;
   cursor: ${props => (props.disabled ? "auto" : "pointer")};

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.tsx
@@ -23,7 +23,7 @@ import {
 interface JoinTablePickerProps {
   query: Lib.Query;
   table: Lib.Joinable | undefined;
-  tableInfo: Lib.TableDisplayInfo | undefined;
+  tableName: string | undefined;
   color: string;
   isReadOnly: boolean;
   isModelDataSource: boolean;
@@ -34,7 +34,7 @@ interface JoinTablePickerProps {
 export function JoinTablePicker({
   query,
   table,
-  tableInfo,
+  tableName,
   color,
   isReadOnly,
   isModelDataSource,
@@ -101,8 +101,7 @@ export function JoinTablePicker({
         setSourceTableFn={handleTableChange}
         triggerElement={
           <TablePickerButton disabled={isDisabled}>
-            {tableInfo?.isMetric && <Icon name="metric" />}
-            {tableInfo?.displayName ?? t`Pick data…`}
+            {tableName || t`Pick data…`}
           </TablePickerButton>
         }
       />

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSelector/QuestionDataSelector.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSelector/QuestionDataSelector.tsx
@@ -26,6 +26,7 @@ export const QuestionDataSelector = ({
     <DataSourceSelector
       containerClassName={CS.z2}
       hasTableSearch
+      hasMetrics
       databaseQuery={{ saved: true }}
       setSourceTableFn={handleTableChange}
       triggerElement={triggerElement}


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/42463
Related https://github.com/metabase/metabase/issues/42278

- Removes joins for the first stage of metric-based queries
- Removes metrics from the join source picker
- Reverts step title changes

<img width="1336" alt="Screenshot 2024-05-09 at 15 21 45" src="https://github.com/metabase/metabase/assets/8542534/c7c8760f-9e8b-4320-96a0-7631764dcd40">
<img width="566" alt="Screenshot 2024-05-09 at 15 22 35" src="https://github.com/metabase/metabase/assets/8542534/1dee30a0-4902-425e-874d-73b4dd10f346">
