### PR TITLE
[MBQL lib] Add native queries to the shared tests for all drills

### DIFF
--- a/src/metabase/lib/drill_thru/zoom.cljc
+++ b/src/metabase/lib/drill_thru/zoom.cljc
@@ -52,11 +52,12 @@
 (mu/defn zoom-drill :- [:maybe ::lib.schema.drill-thru/drill-thru.zoom]
   "Return a `:zoom` drill when clicking on the value of a PK column in a Table that has only one PK column."
   [query                                   :- ::lib.schema/query
-   _stage-number                           :- :int
+   stage-number                            :- :int
    {:keys [column value row] :as _context} :- ::lib.schema.drill-thru/context]
   (when (and
          ;; ignore clicks on headers (value = nil rather than :null)
          (some? value)
+         (lib.drill-thru.common/mbql-stage? query stage-number)
          ;; if this table has more than one PK we should be returning a [[metabase.lib.drill-thru.pk]] instead.
          (not (lib.drill-thru.common/many-pks? query)))
     (if (lib.types.isa/primary-key? column)

--- a/test/metabase/lib/drill_thru/automatic_insights_test.cljc
+++ b/test/metabase/lib/drill_thru/automatic_insights_test.cljc
@@ -50,12 +50,13 @@
     (testing "available for cell clicks subject to at least one breakout; and any pivot or legend click"
       (canned/canned-test
         :drill-thru/automatic-insights
-        (fn [_test-case context {:keys [click]}]
-          (or ;; Any pivot or legend click is good.
-              (#{:pivot :legend} click)
-              ;; As are cell clicks with at least 1 breakout.
-              (and (= click :cell)
-                   (seq (:dimensions context)))))))
+        (fn [test-case context {:keys [click]}]
+          (and (not (:native? test-case))
+               (or ;; Any pivot or legend click is good.
+                   (#{:pivot :legend} click)
+                   ;; As are cell clicks with at least 1 breakout.
+                   (and (= click :cell)
+                        (seq (:dimensions context))))))))
     (testing "not available at all with xrays disabled"
       (canned/canned-test
         :drill-thru/automatic-insights

--- a/test/metabase/lib/drill_thru/column_extract_test.cljc
+++ b/test/metabase/lib/drill_thru/column_extract_test.cljc
@@ -30,8 +30,9 @@
   (testing "column-extract is available for column clicks on temporal, URL and Email columns"
     (canned/canned-test
       :drill-thru/column-extract
-      (fn [_test-case {:keys [column] :as _context} {:keys [click column-type]}]
+      (fn [test-case {:keys [column] :as _context} {:keys [click column-type]}]
         (and (= click :header)
+             (not (:native? test-case))
              (or (= column-type :datetime)
                  (#{:type/URL :type/Email} (:semantic-type column))))))))
 

--- a/test/metabase/lib/drill_thru/column_filter_test.cljc
+++ b/test/metabase/lib/drill_thru/column_filter_test.cljc
@@ -17,8 +17,9 @@
   (testing "column-filter is available for any header click, and nothing else"
     (canned/canned-test
       :drill-thru/column-filter
-      (fn [_test-case context {:keys [click]}]
+      (fn [test-case context {:keys [click]}]
         (and (= click :header)
+             (not (:native? test-case))
              (not (lib.types.isa/structured? (:column context))))))))
 
 (def ^:private key-ops

--- a/test/metabase/lib/drill_thru/distribution_test.cljc
+++ b/test/metabase/lib/drill_thru/distribution_test.cljc
@@ -17,8 +17,9 @@
   (testing "distribution is available only for header clicks on non-aggregate, non-breakout columns which are not PKs, JSON, comments or descriptions"
     (canned/canned-test
       :drill-thru/distribution
-      (fn [_test-case context {:keys [click column-kind column-type]}]
+      (fn [test-case context {:keys [click column-kind column-type]}]
         (and (= click :header)
+             (not (:native? test-case))
              (not (#{:aggregation :breakout} column-kind))
              (not= column-type :pk)
              (not (#{:type/Comment :type/Description} (:semantic-type (:column context))))

--- a/test/metabase/lib/drill_thru/fk_details_test.cljc
+++ b/test/metabase/lib/drill_thru/fk_details_test.cljc
@@ -16,9 +16,10 @@
   (testing "FK details is available for cell clicks on non-NULL FKs"
     (canned/canned-test
       :drill-thru/fk-details
-      (fn [_test-case context {:keys [click column-type]}]
+      (fn [test-case context {:keys [click column-type]}]
         (and (= click :cell)
              (= column-type :fk)
+             (not (:native? test-case))
              (not= (:value context) :null))))))
 
 (deftest ^:parallel returns-fk-details-test-1

--- a/test/metabase/lib/drill_thru/quick_filter_test.cljc
+++ b/test/metabase/lib/drill_thru/quick_filter_test.cljc
@@ -16,8 +16,9 @@
   (testing "quick-filter is avaiable for cell clicks on non-PK/FK columns"
     (canned/canned-test
       :drill-thru/quick-filter
-      (fn [_test-case {:keys [column dimensions] :as _context} {:keys [click column-kind column-type]}]
+      (fn [test-case {:keys [column dimensions] :as _context} {:keys [click column-kind column-type]}]
         (and (= click :cell)
+             (not (:native? test-case))
              (not (#{:pk :fk} column-type))
              (not (lib.types.isa/structured? column))
              (or (not= column-kind :aggregation)

--- a/test/metabase/lib/drill_thru/sort_test.cljc
+++ b/test/metabase/lib/drill_thru/sort_test.cljc
@@ -18,8 +18,9 @@
   (testing "sort is available on column headers only"
     (canned/canned-test
       :drill-thru/sort
-      (fn [_test-case context {:keys [click]}]
+      (fn [test-case context {:keys [click]}]
         (and (= click :header)
+             (not (:native? test-case))
              (not (lib.types.isa/structured? (:column context))))))))
 
 (deftest ^:parallel sort-e2e-test

--- a/test/metabase/lib/drill_thru/summarize_column_by_time_test.cljc
+++ b/test/metabase/lib/drill_thru/summarize_column_by_time_test.cljc
@@ -20,6 +20,7 @@
       (fn [test-case _context {:keys [click column-type]}]
         (and (= click :header)
              (= column-type :number)
+             (not (:native? test-case))
              (zero? (:aggregations test-case))
              (zero? (:breakouts test-case))
              (some #(or (isa? (:effective-type %) :type/Date)

--- a/test/metabase/lib/drill_thru/summarize_column_test.cljc
+++ b/test/metabase/lib/drill_thru/summarize_column_test.cljc
@@ -13,6 +13,7 @@
       :drill-thru/summarize-column
       (fn [test-case context {:keys [click]}]
         (and (= click :header)
+             (not (:native? test-case))
              (zero? (:aggregations test-case))
              (zero? (:breakouts test-case))
              (not (lib.types.isa/structured? (:column context))))))))

--- a/test/metabase/lib/drill_thru/test_util/canned.cljc
+++ b/test/metabase/lib/drill_thru/test_util/canned.cljc
@@ -164,6 +164,26 @@
      :aggregations    0
      :breakouts       0}
 
+    :test.query/products-native
+    {:query          (-> (lib/native-query metadata-provider "SELECT * FROM products")
+                         (assoc-in [:stages 0 :lib/stage-metadata]
+                                   {:columns (->> (meta/fields :products)
+                                                  (map #(meta/field-metadata :products %))
+                                                  (sort-by :position)
+                                                  (map #(select-keys % [:lib/type :name :display-name :field-ref
+                                                                        :base-type :effective-type :semantic-type])))}))
+     :native?        true
+     :row            {"ID"         "3"
+                      "EAN"        "4966277046676"
+                      "TITLE"      "Synergistic Granite Chair"
+                      "CATEGORY"   "Doohickey"
+                      "VENDOR"     "Murray, Watsica and Wunsch"
+                      "PRICE"      35.38
+                      "RATING"     4
+                      "CREATED_AT" "2024-09-08T22:03:20.239+03:00"}
+     :aggregations    0
+     :breakouts       0}
+
     :test.query/reviews
     {:query          (lib/query metadata-provider (meta/table-metadata :reviews))
      :row            {"ID"         "301"
@@ -297,6 +317,22 @@
 
          ;; Simple query against Products.
          (let [tc (test-case metadata-provider :test.query/products)]
+           [(click tc :cell "ID"         :basic :pk)
+            (click tc :cell "EAN"        :basic :string)
+            (click tc :cell "TITLE"      :basic :string)
+            (click tc :cell "PRICE"      :basic :number)
+            (click tc :cell "RATING"     :basic :number)
+            (click tc :cell "CREATED_AT" :basic :datetime)
+
+            (click tc :header "ID"         :basic :pk)
+            (click tc :header "EAN"        :basic :string)
+            (click tc :header "TITLE"      :basic :string)
+            (click tc :header "PRICE"      :basic :number)
+            (click tc :header "RATING"     :basic :number)
+            (click tc :header "CREATED_AT" :basic :datetime)])
+
+         ;; Native query against products
+         (let [tc (test-case metadata-provider :test.query/products-native)]
            [(click tc :cell "ID"         :basic :pk)
             (click tc :cell "EAN"        :basic :string)
             (click tc :cell "TITLE"      :basic :string)

--- a/test/metabase/lib/drill_thru/underlying_records_test.cljc
+++ b/test/metabase/lib/drill_thru/underlying_records_test.cljc
@@ -22,7 +22,7 @@
   (testing "underlying-records is available for non-header clicks with at least one breakout"
     (canned/canned-test
       :drill-thru/underlying-records
-      (fn [_test-case context {:keys [click column-kind]}]
+      (fn [test-case context {:keys [click column-kind]}]
         ;; TODO: The docs claim that underlying-records works on pivot cells, and so it does, but the so-called pivot case
         ;; never occurs in actual pivot tables!
         ;; - Clicks on row/column "headers", (that is, breakout values like a month or product category) look like regular
@@ -33,6 +33,7 @@
         ;; code that should be setting the aggregation :value for cell clicks?
         ;; Tech debt issue: #39380
         (and (#{:cell #_:pivot :legend} click)
+             (not (:native? test-case))
              (or (seq (:dimensions context))
                  (= column-kind :aggregation)))))))
 

--- a/test/metabase/lib/drill_thru/zoom_in_bins_test.cljc
+++ b/test/metabase/lib/drill_thru/zoom_in_bins_test.cljc
@@ -14,8 +14,9 @@
   (testing "zoom-in for bins is available for cells, pivots and legends on numeric columns which have binning set"
     (canned/canned-test
       :drill-thru/zoom-in.binning
-      (fn [_test-case context {:keys [click]}]
+      (fn [test-case context {:keys [click]}]
         (and (#{:cell :pivot :legend} click)
+             (not (:native? test-case))
              (seq (for [dim (:dimensions context)
                         :when (and (isa? (:effective-type (:column dim)) :type/Number)
                                    (lib/binning (:column dim)))]

--- a/test/metabase/lib/drill_thru/zoom_in_timeseries_test.cljc
+++ b/test/metabase/lib/drill_thru/zoom_in_timeseries_test.cljc
@@ -16,8 +16,9 @@
   (testing "zoom-in for bins is available for cells, pivots and legends on numeric columns which have binning set"
     (canned/canned-test
       :drill-thru/zoom-in.timeseries
-      (fn [_test-case context {:keys [click]}]
+      (fn [test-case context {:keys [click]}]
         (and (#{:cell :pivot :legend} click)
+             (not (:native? test-case))
              (seq (for [dim (:dimensions context)
                         :when (and (isa? (:effective-type (:column dim)) :type/DateTime)
                                    (lib/temporal-bucket (:column dim)))]

--- a/test/metabase/lib/drill_thru/zoom_test.cljc
+++ b/test/metabase/lib/drill_thru/zoom_test.cljc
@@ -13,6 +13,7 @@
       :drill-thru/zoom
       (fn [test-case {:keys [value]} {:keys [click column-type]}]
         (and (= click :cell)
+             (not (:native? test-case))
              ;; With an FK column and a non-NULL value, this will be an fk-filter drill instead.
              ;; So we don't expect a zoom drill in that case.
              (not (and (= column-type :fk)


### PR DESCRIPTION
Follow up to #42424.

This enforces that all drills do not appear on native stages.
Also fixes one more drill on top of the two in #42424 that were wrongly
showing up for native queries.
