### PR TITLE
Update API Changelog for trash

### DIFF
--- a/docs/developers-guide/api-changelog.md
+++ b/docs/developers-guide/api-changelog.md
@@ -6,6 +6,17 @@ title: API changelog
 
 ## Metabase 0.50.0
 
+- `PUT /api/dashboard/:id`, `PUT /api/card/:id`, and `PUT /api/collection/:id`
+
+  When setting `archived` to `true`, the Dashboard, Card, or Collection will be automatically moved to the Trash
+  collection, a special collection that holds all archived items.
+
+  When setting `archived` to `false`, you may optionally also provide a `collection_id` (for Dashboards or Cards) or a
+  `parent_id` (for Collections). In this case, the entity will be re-parented to the specified Collection when it is
+  moved from the Trash. If a new `collection_id` or `parent_id` is not provided, the entity will be moved back to its
+  original location if possible. If this is not possible (for example, the original location is also in the Trash) an
+  error will occur.
+
 - `/api/metric`
 
    The `/api/metric` endpoints has been renamed to `/api/legacy-metric` to reflect that fact it will not be used for the new version of metrics. The new version uses the `/api/card` endpoints.
@@ -29,6 +40,12 @@ title: API changelog
    Starting from v49, we respond to the API calls with values formatted according to the instance localization options
 
 # Additions to the API interface
+
+## Metabase 0.50.0
+
+- `GET /api/collection/:id/items`
+
+  An additional boolean column, `archived`, has been added to results.
 
 ## Metabase 0.49.5
 NOTE: These endpoint changes were added in 0.49.3, and a bug in `GET /api/embed/card/:token/query/:export-format` was fixed in 0.49.5.


### PR DESCRIPTION
Adding the following to the Changelog:
---

# Breaking changes to the API interface

## Metabase 0.50.0

- `PUT /api/dashboard/:id`, `PUT /api/card/:id`, and `PUT /api/collection/:id`

  When setting `archived` to `true`, the Dashboard, Card, or Collection will be automatically moved to the Trash
  collection, a special collection that holds all archived items.

  When setting `archived` to `false`, you may optionally also provide a `collection_id` (for Dashboards or Cards) or a
  `parent_id` (for Collections). In this case, the entity will be re-parented to the specified Collection when it is
  moved from the Trash. If a new `collection_id` or `parent_id` is not provided, the entity will be moved back to its
  original location if possible. If this is not possible (for example, the original location is also in the Trash) an
  error will occur.

## Metabase 0.50.0

- `GET /api/collection/:id/items`

  An additional boolean column, `archived`, has been added to results.