### PR TITLE
[Browse] Improve model sorting

### DIFF
--- a/frontend/src/metabase/browse/components/ModelsTable.tsx
+++ b/frontend/src/metabase/browse/components/ModelsTable.tsx
@@ -45,14 +45,18 @@ const collectionProps: ResponsiveProps = {
   containerName: "ItemsTableContainer",
 };
 
+const DEFAULT_SORTING_OPTIONS: SortingOptions = {
+  sort_column: "collection",
+  sort_direction: SortDirection.Asc,
+};
+
 export const ModelsTable = ({ models }: ModelsTableProps) => {
   const locale = useSelector(getLocale);
   const localeCode: string | undefined = locale?.code;
 
-  const [sortingOptions, setSortingOptions] = useState<SortingOptions>({
-    sort_column: "name",
-    sort_direction: SortDirection.Asc,
-  });
+  const [sortingOptions, setSortingOptions] = useState<SortingOptions>(
+    DEFAULT_SORTING_OPTIONS,
+  );
 
   const sortedModels = sortModels(models, sortingOptions, localeCode);
 

--- a/frontend/src/metabase/browse/components/utils.tsx
+++ b/frontend/src/metabase/browse/components/utils.tsx
@@ -98,7 +98,6 @@ export const sortModels = (
     const a = getValueForSorting(modelA, sort_column);
     const b = getValueForSorting(modelB, sort_column);
 
-    const ascending = sort_direction === SortDirection.Asc;
     let result = compare(a, b);
     if (result === 0) {
       const sort_column2 = getSecondarySortColumn(sort_column);
@@ -106,6 +105,7 @@ export const sortModels = (
       const b2 = getValueForSorting(modelB, sort_column2);
       result = compare(a2, b2);
     }
-    return ascending ? result : -result;
+
+    return sort_direction === SortDirection.Asc ? result : -result;
   });
 };

--- a/frontend/src/metabase/browse/components/utils.tsx
+++ b/frontend/src/metabase/browse/components/utils.tsx
@@ -100,7 +100,7 @@ export const sortModels = (
 
     const ascending = sort_direction === SortDirection.Asc;
     let result = compare(a, b);
-    if (result !== 0) {
+    if (result === 0) {
       const sort_column2 = getSecondarySortColumn(sort_column);
       const a2 = getValueForSorting(modelA, sort_column2);
       const b2 = getValueForSorting(modelB, sort_column2);

--- a/frontend/src/metabase/browse/components/utils.tsx
+++ b/frontend/src/metabase/browse/components/utils.tsx
@@ -73,6 +73,12 @@ export const isValidSortColumn = (
   return ["name", "collection"].includes(sort_column);
 };
 
+export const getSecondarySortColumn = (
+  sort_column: string,
+): keyof ModelResult => {
+  return sort_column === "name" ? "collection" : "name";
+};
+
 export const sortModels = (
   models: ModelResult[],
   sortingOptions: SortingOptions,
@@ -85,15 +91,21 @@ export const sortModels = (
     return models;
   }
 
-  return [...models].sort((a, b) => {
-    const aValue = getValueForSorting(a, sort_column);
-    const bValue = getValueForSorting(b, sort_column);
-    const [firstValue, secondValue] =
-      sort_direction === SortDirection.Asc
-        ? [aValue, bValue]
-        : [bValue, aValue];
-    return firstValue.localeCompare(secondValue, localeCode, {
-      sensitivity: "base",
-    });
+  const compare = (a: string, b: string) =>
+    a.localeCompare(b, localeCode, { sensitivity: "base" });
+
+  return [...models].sort((modelA, modelB) => {
+    const a = getValueForSorting(modelA, sort_column);
+    const b = getValueForSorting(modelB, sort_column);
+
+    const ascending = sort_direction === SortDirection.Asc;
+    let result = compare(a, b);
+    if (result !== 0) {
+      const sort_column2 = getSecondarySortColumn(sort_column);
+      const a2 = getValueForSorting(modelA, sort_column2);
+      const b2 = getValueForSorting(modelB, sort_column2);
+      result = compare(a2, b2);
+    }
+    return ascending ? result : -result;
   });
 };

--- a/frontend/src/metabase/browse/components/utils.unit.spec.tsx
+++ b/frontend/src/metabase/browse/components/utils.unit.spec.tsx
@@ -7,16 +7,6 @@ import {
 
 import { getCollectionPathString, sortModels } from "./utils";
 
-//
-// TODO:
-// Make collections the second column
-// Even out the spacing around the icon, left and right
-// Increase name to 240 or 280px
-// Ensure that the gap between the collection icon and the collection path is the same as the gap to the right
-// Let's make the whole collection path a single link
-// Remove Metabase analytics
-// Change the heading to Browsing models (to make clear that this is not a collection)
-
 describe("getCollectionPathString", () => {
   it("should return path for collection without ancestors", () => {
     const collection = createMockCollection({

--- a/frontend/src/metabase/browse/components/utils.unit.spec.tsx
+++ b/frontend/src/metabase/browse/components/utils.unit.spec.tsx
@@ -1,10 +1,21 @@
 import { SortDirection } from "metabase/components/ItemsTable/Columns";
+import type { ModelResult } from "metabase-types/api";
 import {
   createMockCollection,
   createMockModelResult,
 } from "metabase-types/api/mocks";
 
 import { getCollectionPathString, sortModels } from "./utils";
+
+//
+// TODO:
+// Make collections the second column
+// Even out the spacing around the icon, left and right
+// Increase name to 240 or 280px
+// Ensure that the gap between the collection icon and the collection path is the same as the gap to the right
+// Let's make the whole collection path a single link
+// Remove Metabase analytics
+// Change the heading to Browsing models (to make clear that this is not a collection)
 
 describe("getCollectionPathString", () => {
   it("should return path for collection without ancestors", () => {
@@ -33,10 +44,11 @@ describe("getCollectionPathString", () => {
 });
 
 describe("sortModels", () => {
-  const mockSearchResults = [
-    createMockModelResult({
+  let id = 0;
+  const modelMap: Record<string, ModelResult> = {
+    "model named A, with collection path X / Y / Z": createMockModelResult({
+      id: id++,
       name: "A",
-      // This model has collection path X / Y / Z
       collection: createMockCollection({
         name: "Z",
         effective_ancestors: [
@@ -45,13 +57,14 @@ describe("sortModels", () => {
         ],
       }),
     }),
-    createMockModelResult({
+    "model named C, with collection path Y": createMockModelResult({
+      id: id++,
       name: "C",
-      collection: createMockCollection({ name: "Z" }),
+      collection: createMockCollection({ name: "Y" }),
     }),
-    createMockModelResult({
+    "model named B, with collection path D / E / F": createMockModelResult({
+      id: id++,
       name: "B",
-      // This model has collection path D / E / F
       collection: createMockCollection({
         name: "F",
         effective_ancestors: [
@@ -60,9 +73,10 @@ describe("sortModels", () => {
         ],
       }),
     }),
-  ];
+  };
+  const mockSearchResults = Object.values(modelMap);
 
-  it("should sort by name in ascending order", () => {
+  it("can sort by name in ascending order", () => {
     const sortingOptions = {
       sort_column: "name",
       sort_direction: SortDirection.Asc,
@@ -71,7 +85,7 @@ describe("sortModels", () => {
     expect(sorted?.map(model => model.name)).toEqual(["A", "B", "C"]);
   });
 
-  it("should sort by name in descending order", () => {
+  it("can sort by name in descending order", () => {
     const sortingOptions = {
       sort_column: "name",
       sort_direction: SortDirection.Desc,
@@ -80,7 +94,7 @@ describe("sortModels", () => {
     expect(sorted?.map(model => model.name)).toEqual(["C", "B", "A"]);
   });
 
-  it("should sort by collection path in ascending order", () => {
+  it("can sort by collection path in ascending order", () => {
     const sortingOptions = {
       sort_column: "collection",
       sort_direction: SortDirection.Asc,
@@ -89,12 +103,61 @@ describe("sortModels", () => {
     expect(sorted?.map(model => model.name)).toEqual(["B", "A", "C"]);
   });
 
-  it("should sort by collection path in descending order", () => {
+  it("can sort by collection path in descending order", () => {
     const sortingOptions = {
       sort_column: "collection",
       sort_direction: SortDirection.Desc,
     };
     const sorted = sortModels(mockSearchResults, sortingOptions);
     expect(sorted?.map(model => model.name)).toEqual(["C", "A", "B"]);
+  });
+
+  describe("secondary sort", () => {
+    modelMap["model named C, with collection path Z"] = createMockModelResult({
+      name: "C",
+      collection: createMockCollection({ name: "Z" }),
+    });
+    modelMap["model named Bz, with collection path D / E / F"] =
+      createMockModelResult({
+        name: "Bz",
+        collection: createMockCollection({
+          name: "F",
+          effective_ancestors: [
+            createMockCollection({ name: "D" }),
+            createMockCollection({ name: "E" }),
+          ],
+        }),
+      });
+    const mockSearchResults = Object.values(modelMap);
+
+    it("can sort by collection path, ascending, and then does a secondary sort by name", () => {
+      const sortingOptions = {
+        sort_column: "collection",
+        sort_direction: SortDirection.Asc,
+      };
+      const sorted = sortModels(mockSearchResults, sortingOptions);
+      expect(sorted).toEqual([
+        modelMap["model named B, with collection path D / E / F"],
+        modelMap["model named Bz, with collection path D / E / F"],
+        modelMap["model named A, with collection path X / Y / Z"],
+        modelMap["model named C, with collection path Y"],
+        modelMap["model named C, with collection path Z"],
+      ]);
+    });
+
+    it("can sort by collection path, descending, and then does a secondary sort by name", () => {
+      const sortingOptions = {
+        sort_column: "collection",
+        sort_direction: SortDirection.Desc,
+      };
+      const sorted = sortModels(mockSearchResults, sortingOptions);
+      expect(sorted).toEqual([
+        modelMap["model named C, with collection path Z"],
+        modelMap["model named C, with collection path Y"],
+        modelMap["model named A, with collection path X / Y / Z"],
+        modelMap["model named Bz, with collection path D / E / F"],
+        modelMap["model named B, with collection path D / E / F"],
+      ]);
+    });
   });
 });


### PR DESCRIPTION
Ensures that models are sorted as follows in Browse models:

* Models are sorted by collection, by default
* When models are sorted by collection, they are secondarily sorted by name (so that models with the same collection path appear in alphabetic order)