### PR TITLE
Fix drill FK test flake by removing unneeded wait for /api/dataset

### DIFF
--- a/e2e/test/scenarios/models/models-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/models-metadata.cy.spec.js
@@ -334,8 +334,6 @@ describe("scenarios > models metadata", () => {
           cy.findByText("68883"); // zip
           cy.findAllByText("Hudson Borer");
           cy.icon("close").click();
-          // FIXME: the problem occurs here
-          cy.wait("@dataset");
         });
 
         cy.go("back"); // navigate away from drilled table


### PR DESCRIPTION
A test in `e2e/test/scenarios/models/models-metadata.cy.spec.js` waits for a call to `/api/dataset` after closing a modal, but closing the modal does not trigger such a call, so the test was frequently failing.

I am assuming the closing of the modal is not supposed to trigger an API call. That would be pretty unusual.

This branch also removes a FIXME message I accidentally committed into master yesterday.