### PR TITLE
Fix backend tests

### DIFF
--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -687,13 +687,13 @@
   (->> (map-indexed (fn [i row] (vary-meta row assoc ::index i)) rows) ;; keep db sort order
        (map #(assoc % :collection_id (:id collection)))
        (maybe-check-permissions collection)
-       (map remove-unwanted-keys)
        (group-by :model)
        (into []
              (comp (map (fn [[model rows]]
                           (post-process-collection-children (keyword model) collection rows)))
                    cat
                    (map coalesce-edit-info)))
+       (map remove-unwanted-keys)
        (sort-by (comp ::index meta))))
 
 


### PR DESCRIPTION
`can_write` on collection items was wrong because we didn't have a `trashed_from_collection_id` - the refactor to ensure we didn't make that mistake worked! :tada: