### PR TITLE
Put bulk actions above popovers in collections

### DIFF
--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionContent.styled.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionContent.styled.tsx
@@ -4,11 +4,6 @@ export const CollectionRoot = styled.div`
   height: 100%;
   overflow: hidden;
   position: relative;
-  container-name: ItemsTableContainer;
-  container-type: inline-size;
-  // NOTE: The BulkActionsToast is centered within this container.
-  // If this div ever ceases to be a container one day, let's restore the previously
-  // existing margin-left fix for the toast so it is still centered when the nav sidebar is open
 `;
 
 export const CollectionMain = styled.div`
@@ -24,6 +19,9 @@ export interface CollectionTableProps {
 
 export const CollectionTable = styled.div<CollectionTableProps>`
   margin-top: ${props => (props.hasPinnedItems ? "2rem" : "")};
+
+  container-name: ItemsTableContainer;
+  container-type: inline-size;
 `;
 
 export const CollectionEmptyContent = styled.div`

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionContentView.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionContentView.tsx
@@ -350,41 +350,43 @@ export const CollectionContentView = ({
                     }
 
                     return (
-                      <CollectionTable data-testid="collection-table">
-                        <ItemsTable
-                          databases={databases}
-                          bookmarks={bookmarks}
-                          createBookmark={createBookmark}
-                          deleteBookmark={deleteBookmark}
-                          items={unpinnedItems}
-                          collection={collection}
-                          sortingOptions={unpinnedItemsSorting}
-                          onSortingOptionsChange={
-                            handleUnpinnedItemsSortingChange
-                          }
-                          selectedItems={selected}
-                          hasUnselected={hasUnselected}
-                          getIsSelected={getIsSelected}
-                          onToggleSelected={toggleItem}
-                          onDrop={clear}
-                          onMove={handleMove}
-                          onCopy={handleCopy}
-                          onSelectAll={handleSelectAll}
-                          onSelectNone={clear}
-                        />
-                        <div className={cx(CS.flex, CS.justifyEnd, CS.my3)}>
-                          {hasPagination && (
-                            <PaginationControls
-                              showTotal
-                              page={page}
-                              pageSize={PAGE_SIZE}
-                              total={metadata.total}
-                              itemsLength={unpinnedItems.length}
-                              onNextPage={handleNextPage}
-                              onPreviousPage={handlePreviousPage}
-                            />
-                          )}
-                        </div>
+                      <>
+                        <CollectionTable data-testid="collection-table">
+                          <ItemsTable
+                            databases={databases}
+                            bookmarks={bookmarks}
+                            createBookmark={createBookmark}
+                            deleteBookmark={deleteBookmark}
+                            items={unpinnedItems}
+                            collection={collection}
+                            sortingOptions={unpinnedItemsSorting}
+                            onSortingOptionsChange={
+                              handleUnpinnedItemsSortingChange
+                            }
+                            selectedItems={selected}
+                            hasUnselected={hasUnselected}
+                            getIsSelected={getIsSelected}
+                            onToggleSelected={toggleItem}
+                            onDrop={clear}
+                            onMove={handleMove}
+                            onCopy={handleCopy}
+                            onSelectAll={handleSelectAll}
+                            onSelectNone={clear}
+                          />
+                          <div className={cx(CS.flex, CS.justifyEnd, CS.my3)}>
+                            {hasPagination && (
+                              <PaginationControls
+                                showTotal
+                                page={page}
+                                pageSize={PAGE_SIZE}
+                                total={metadata.total}
+                                itemsLength={unpinnedItems.length}
+                                onNextPage={handleNextPage}
+                                onPreviousPage={handlePreviousPage}
+                              />
+                            )}
+                          </div>
+                        </CollectionTable>
                         <CollectionBulkActions
                           selected={selected}
                           collection={collection}
@@ -396,7 +398,7 @@ export const CollectionContentView = ({
                           selectedItems={selectedItems}
                           selectedAction={selectedAction}
                         />
-                      </CollectionTable>
+                      </>
                     );
                   }}
                 </Search.ListLoader>

--- a/frontend/src/metabase/components/BulkActionBar/BulkActionBar.styled.tsx
+++ b/frontend/src/metabase/components/BulkActionBar/BulkActionBar.styled.tsx
@@ -2,6 +2,7 @@ import styled from "@emotion/styled";
 
 import Card from "metabase/components/Card";
 import { alpha, color } from "metabase/lib/colors";
+import { NAV_SIDEBAR_WIDTH } from "metabase/nav/constants";
 import { space } from "metabase/styled-components/theme";
 import { Button, DEFAULT_POPOVER_Z_INDEX } from "metabase/ui";
 
@@ -12,6 +13,8 @@ export const BulkActionsToast = styled.div<{ isNavbarOpen: boolean }>`
   position: fixed;
   bottom: 0;
   left: 50%;
+  margin-left: ${props =>
+    props.isNavbarOpen ? `${parseInt(NAV_SIDEBAR_WIDTH) / 2}px` : "0"};
   margin-bottom: ${space(2)};
   z-index: ${BULK_ACTIONS_Z_INDEX};
 `;


### PR DESCRIPTION
With the collection table now inside a `@container`, popovers were being created above the bulk actions toast (z-axis-wise). This branch fixes this by changing which element serves as the container (we'll use `CollectionTable`, not `CollectionRoot` - both are equally good), and moving the bulk actions toast just outside this container.

Now the toast appears above popovers:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/ac90ffc4-3207-4b97-8fcf-2736a6e90ee5.png)


This branch also restores the margin-left adjustment that is needed to correct the position of the bulk actions toast when the sidebar is open. This adjustment was recently removed because the @container query fixes this problem, but now that the toast is not inside the @container, we need to restore that solution.