### PR TITLE
Localize the name of the Trash

### DIFF
--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -626,6 +626,7 @@
               (dissoc row :personal_owner_id)))]
     (for [row (annotate-collections parent-collection rows)]
       (-> (t2/hydrate (t2/instance :model/Collection row) :can_write :effective_location)
+          collection/maybe-localize-trash-name
           (dissoc :collection_position :display :moderated_status :icon
                   :collection_preview :dataset_query :table_id :query_type :is_upload)
           (update :archived api/bit->boolean)

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -480,7 +480,11 @@
                                (for [item search-results
                                      :when (= (:model item) "dataset")]
                                  [(:collection_id item)
-                                  {:name (:collection_name item)
+                                  {:name (-> {:name (:collection_name item)
+                                              :id (:collection_id item)
+                                              :type (:collection_type item)}
+                                             collection/maybe-localize-trash-name
+                                             :name)
                                    :effective_location (result->loc item)}]))
         ;; the set of all collection IDs where we *don't* know the collection name. For example, if `col-id->name&loc`
         ;; contained `{1 {:effective_location "/2/" :name "Foo"}}`, we need to look up the name of collection `2`.
@@ -529,6 +533,7 @@
                             (map #(if (t2/instance-of? :model/Collection %)
                                     (t2/hydrate % :effective_location)
                                     (assoc % :effective_location nil)))
+                            (map #(cond-> % (t2/instance-of? :model/Collection %) collection/maybe-localize-trash-name))
                             (filter (partial check-permissions-for-model (:archived? search-ctx)))
                             ;; MySQL returns `:bookmark` and `:archived` as `1` or `0` so convert those to boolean as
                             ;; needed

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -273,6 +273,7 @@
   [_]
   (conj default-columns :collection_id :trashed_from_collection_id :collection_position :dataset_query :display :creator_id
         [:collection.name :collection_name]
+        [:collection.type :collection_type]
         [:collection.location :collection_location]
         [:collection.authority_level :collection_authority_level]
         bookmark-col dashboardcard-count-col))
@@ -283,6 +284,7 @@
    [:model-index.pk_ref         :pk_ref]
    [:model-index.id             :model_index_id]
    [:collection.name            :collection_name]
+   [:collection.type            :collection_type]
    [:model.collection_id        :collection_id]
    [:model.id                   :model_id]
    [:model.name                 :model_name]
@@ -292,6 +294,7 @@
   [_]
   (conj default-columns :trashed_from_collection_id :collection_id :collection_position :creator_id bookmark-col
         [:collection.name :collection_name]
+        [:collection.type :collection_type]
         [:collection.authority_level :collection_authority_level]))
 
 (defmethod columns-for-model "database"


### PR DESCRIPTION
Closes #42505 

There are at least two spots where we can't just rely on the
after-select hook, and select the collection name directly from the
database: the Search and Collection API.

In these cases we need to call `collection/maybe-localize-trash-name`,
which will localize the name if the passed Collection is the Trash
collection.