### PR TITLE
remove google analytics

### DIFF
--- a/resources/frontend_client/index_template.html
+++ b/resources/frontend_client/index_template.html
@@ -45,12 +45,5 @@
 
   <body>
     <div id="root"></div>
-
-
-    <!-- Google Analytics -->
-    <!-- If you modify this script, make sure you update the whitelisted Content-Security-Policy hash in metabase.server.middleware.security -->
-    {{#enableAnonTracking}}
-      <script type="text/javascript">{{{googleAnalyticsJS}}}</script>
-    {{/enableAnonTracking}}
   </body>
 </html>

--- a/resources/frontend_client/inline_js/index_ganalytics.js
+++ b/resources/frontend_client/inline_js/index_ganalytics.js
@@ -1,3 +1,0 @@
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -32,8 +32,6 @@
                         (.update (.getBytes (slurp (io/resource resource-filename))))))))]
     (mapv file-hash [ ;; inline script in index.html that sets `MetabaseBootstrap` and the like
                      "frontend_client/inline_js/index_bootstrap.js"
-                     ;; inline script in index.html that loads Google Analytics
-                     "frontend_client/inline_js/index_ganalytics.js"
                      ;; inline script in init.html
                      "frontend_client/inline_js/init.js"])))
 

--- a/src/metabase/server/routes/index.clj
+++ b/src/metabase/server/routes/index.clj
@@ -80,7 +80,6 @@
    (str "frontend_client/" entrypoint-name ".html")
    (let [{:keys [anon-tracking-enabled google-auth-client-id], :as public-settings} (setting/user-readable-values-map #{:public})]
      {:bootstrapJS          (load-inline-js "index_bootstrap")
-      :googleAnalyticsJS    (load-inline-js "index_ganalytics")
       :bootstrapJSON        (escape-script (json/generate-string public-settings))
       :userLocalizationJSON (escape-script (load-localization (:locale params)))
       :siteLocalizationJSON (escape-script (load-localization (public-settings/site-locale)))


### PR DESCRIPTION

### Description

We haven't been using it for a while, and it was blocked by CSP anyway:
> analytics.js:24 Refused to load the script 'https://www.googletagmanager.com/gtag/js?id=xxxxx&cx=c&_slc=1' because it violates the following Content Security Policy directive: "script-src 'self' https://maps.google.com https://accounts.google.com https://www.google-analytics.com   'sha256-9uFLu5CG8mWlvx0LK6lgendCxUX57TuWk3wkgZpBeWU=' 'sha256-ib2/2v5zC6gGM6Ety7iYgBUvpy/caRX9xV/pzzV7hf0=' 'sha256-isH538cVBUY8IMlGYGbWtBwr+cGqkc4mN6nLcA7lUjE='". Note that 'script-src-elem' was not explicitly set, so 'script-src' is used as a fallback.