### PR TITLE
Drop unsupported locales from moment

### DIFF
--- a/frontend/src/metabase/search/components/InfoText/InfoText.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/InfoText/InfoText.unit.spec.tsx
@@ -1,5 +1,5 @@
 import { waitFor } from "@testing-library/react";
-import moment from "moment"; // eslint-disable-line no-restricted-imports -- deprecated usage
+import moment from "moment-timezone"; // eslint-disable-line no-restricted-imports -- deprecated usage
 
 import {
   setupCollectionByIdEndpoint,

--- a/frontend/src/metabase/static-viz/lib/format.ts
+++ b/frontend/src/metabase/static-viz/lib/format.ts
@@ -1,6 +1,6 @@
 import type { NumberLike, StringLike } from "@visx/scale";
-import moment from "moment"; // eslint-disable-line no-restricted-imports -- deprecated usage
 import type { Moment } from "moment-timezone"; // eslint-disable-line no-restricted-imports -- deprecated usage
+import moment from "moment-timezone"; // eslint-disable-line no-restricted-imports -- deprecated usage
 
 import {
   formatDateTimeWithUnit,

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.js
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.js
@@ -1,4 +1,4 @@
-import moment from "moment"; // eslint-disable-line no-restricted-imports -- deprecated usage
+import moment from "moment-timezone"; // eslint-disable-line no-restricted-imports -- deprecated usage
 import { t } from "ttag";
 import _ from "underscore";
 

--- a/package.json
+++ b/package.json
@@ -270,6 +270,7 @@
     "mochawesome-merge": "^4.2.1",
     "mochawesome-report-generator": "^6.2.0",
     "mockdate": "^2.0.2",
+    "moment-locales-webpack-plugin": "^1.2.0",
     "mutationobserver-shim": "^0.3.7",
     "mysql2": "^3.9.7",
     "node-polyfill-webpack-plugin": "2.0.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,7 @@ const HtmlWebpackPlugin = require("html-webpack-plugin");
 const TerserPlugin = require("terser-webpack-plugin");
 const WebpackNotifierPlugin = require("webpack-notifier");
 const ReactRefreshPlugin = require("@pmmmwh/react-refresh-webpack-plugin");
+const MomentLocalesPlugin = require("moment-locales-webpack-plugin");
 
 const fs = require("fs");
 const path = require("path");
@@ -228,6 +229,39 @@ const config = (module.exports = {
   },
 
   plugins: [
+    // strip locales, except supported at
+    // https://www.metabase.com/docs/latest/configuring-metabase/localization
+    new MomentLocalesPlugin({
+      localesToKeep: [
+        "sq",
+        "ar",
+        "bg",
+        "ca",
+        "zh-cn",
+        "cs",
+        "nl",
+        "fa",
+        "fi",
+        "fr",
+        "de",
+        "id",
+        "it",
+        "ja",
+        "ko",
+        "lv",
+        "nb",
+        "pl",
+        "pt",
+        "ru",
+        "sr",
+        "sk",
+        "es",
+        "sv",
+        "tr",
+        "uk",
+        "vi",
+      ],
+    }),
     // Extracts initial CSS into a standard stylesheet that can be loaded in parallel with JavaScript
     new MiniCssExtractPlugin({
       filename: devMode ? "[name].css" : "[name].[contenthash].css",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15564,6 +15564,11 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
 
+lodash.difference@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c"
+  integrity sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==
+
 lodash.get@^3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-3.7.0.tgz#3ce68ae2c91683b281cc5394128303cbf75e691f"
@@ -16881,6 +16886,13 @@ mockdate@^2.0.2:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-2.0.5.tgz#70c6abf9ed4b2dae65c81dfc170dd1a5cec53620"
   integrity sha512-ST0PnThzWKcgSLyc+ugLVql45PvESt3Ul/wrdV/OPc/6Pr8dbLAIJsN1cIp41FLzbN+srVTNIRn+5Cju0nyV6A==
+
+moment-locales-webpack-plugin@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/moment-locales-webpack-plugin/-/moment-locales-webpack-plugin-1.2.0.tgz#9af83876a44053706b868ceece5119584d10d7aa"
+  integrity sha512-QAi5v0OlPUP7GXviKMtxnpBAo8WmTHrUNN7iciAhNOEAd9evCOvuN0g1N7ThIg3q11GLCkjY1zQ2saRcf/43nQ==
+  dependencies:
+    lodash.difference "^4.5.0"
 
 moment-timezone@^0.5.38:
   version "0.5.38"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/42552

### Description

moment includes all locales by default, increasing bundle size, but we don't need some of them

### How to verify

verify the list of supported locales and try to change locale in admin settings

### Demo

#### Before
<img width="626" alt="Screenshot 2024-05-13 at 10 12 06" src="https://github.com/metabase/metabase/assets/125459446/cd356652-0ae2-4a86-88e4-b0bd92bc5758">


#### After

<img width="630" alt="Screenshot 2024-05-13 at 10 09 32" src="https://github.com/metabase/metabase/assets/125459446/9f7a1863-6387-473f-9c93-3708d09b3935">
