### PR TITLE
Fix disabled state for bulk actions buttons

### DIFF
--- a/frontend/src/metabase/components/BulkActionBar/BulkActionBar.styled.tsx
+++ b/frontend/src/metabase/components/BulkActionBar/BulkActionBar.styled.tsx
@@ -39,4 +39,8 @@ export const BulkActionButton = styled(Button)`
     border-color: ${alpha(color("bg-white"), 0)};
     background-color: ${alpha(color("bg-white"), 0.3)};
   }
+  :disabled {
+    border-color: ${alpha(color("bg-white"), 0)};
+    background-color: ${alpha(color("bg-white"), 0.1)};
+  }
 ` as unknown as typeof Button;


### PR DESCRIPTION
follow up to https://github.com/metabase/metabase/pull/42296


### Description

Fixes disabled styling that was broken as a result of moving these to mantine buttons

Before | After
---|---
![Screen Shot 2024-05-10 at 1 22 05 PM](https://github.com/metabase/metabase/assets/30528226/2e58a5cc-2584-4ca1-823b-3b8cb38eca10) | ![Screen Shot 2024-05-10 at 1 21 54 PM](https://github.com/metabase/metabase/assets/30528226/3ba133f9-a77e-4b46-a025-44e7d13703ba)

(you can test this by selecting the metabase analytics collection which cannot be moved)


