### PR TITLE
Exclude jspdf and html2canvas from the bundle

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,6 @@ const HtmlWebpackPlugin = require("html-webpack-plugin");
 const TerserPlugin = require("terser-webpack-plugin");
 const WebpackNotifierPlugin = require("webpack-notifier");
 const ReactRefreshPlugin = require("@pmmmwh/react-refresh-webpack-plugin");
-const { RsdoctorWebpackPlugin } = require("@rsdoctor/webpack-plugin");
 
 const fs = require("fs");
 const path = require("path");
@@ -239,9 +238,6 @@ const config = (module.exports = {
   },
 
   plugins: [
-    new RsdoctorWebpackPlugin({
-      // plugin options
-    }),
     // Extracts initial CSS into a standard stylesheet that can be loaded in parallel with JavaScript
     new MiniCssExtractPlugin({
       filename: devMode ? "[name].css" : "[name].[contenthash].css",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,7 @@ const HtmlWebpackPlugin = require("html-webpack-plugin");
 const TerserPlugin = require("terser-webpack-plugin");
 const WebpackNotifierPlugin = require("webpack-notifier");
 const ReactRefreshPlugin = require("@pmmmwh/react-refresh-webpack-plugin");
+const { RsdoctorWebpackPlugin } = require("@rsdoctor/webpack-plugin");
 
 const fs = require("fs");
 const path = require("path");
@@ -207,7 +208,7 @@ const config = (module.exports = {
     splitChunks: {
       cacheGroups: {
         vendors: {
-          test: /[\\/]node_modules[\\/](?!sql-formatter[\\/])/,
+          test: /[\\/]node_modules[\\/](?!(sql-formatter|jspdf|html2canvas)[\\/])/,
           chunks: "all",
           name: "vendor",
         },
@@ -215,6 +216,16 @@ const config = (module.exports = {
           test: /[\\/]node_modules[\\/]sql-formatter[\\/]/,
           chunks: "all",
           name: "sql-formatter",
+        },
+        jspdf: {
+          test: /[\\/]node_modules[\\/]jspdf[\\/]/,
+          chunks: "all",
+          name: "jspdf",
+        },
+        html2canvas: {
+          test: /[\\/]node_modules[\\/]html2canvas[\\/]/,
+          chunks: "all",
+          name: "html2canvas",
         },
       },
     },
@@ -228,6 +239,9 @@ const config = (module.exports = {
   },
 
   plugins: [
+    new RsdoctorWebpackPlugin({
+      // plugin options
+    }),
     // Extracts initial CSS into a standard stylesheet that can be loaded in parallel with JavaScript
     new MiniCssExtractPlugin({
       filename: devMode ? "[name].css" : "[name].[contenthash].css",


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/42551

### Description

Create separate chunks for jspdf and html2canvas

### How to verify

Make sure export dashboard to pdf works as before

### Demo

Before 

<img width="626" alt="Screenshot 2024-05-13 at 10 12 06" src="https://github.com/metabase/metabase/assets/125459446/89384f42-e2a3-41cf-ad25-06ca2772a2d9">

After 
<img width="577" alt="Screenshot 2024-05-13 at 10 30 38" src="https://github.com/metabase/metabase/assets/125459446/65347853-e326-4e6f-af39-52cb4b4e9312">
<img width="668" alt="Screenshot 2024-05-13 at 10 30 45" src="https://github.com/metabase/metabase/assets/125459446/178c16c5-de9c-4a4c-8211-b479ca685484">