### PR TITLE
Persist sorting in Browse models

### DIFF
--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -324,6 +324,8 @@ export type UserSettings = {
   "expand-browse-in-nav"?: boolean;
   "expand-bookmarks-in-nav"?: boolean;
   "browse-filter-only-verified-models"?: boolean;
+  "browse-models-sort-column"?: string;
+  "browse-models-sort-direction"?: string;
 };
 
 export type Settings = InstanceSettings &

--- a/frontend/src/metabase/browse/components/ModelsTable.tsx
+++ b/frontend/src/metabase/browse/components/ModelsTable.tsx
@@ -141,7 +141,7 @@ export const ModelsTable = ({ models }: ModelsTableProps) => {
           <SortableColumnHeader
             name="name"
             sortingOptions={sortingOptions}
-            onSortingOptionsChange={setSortingOptions}
+            onSortingOptionsChange={updateSortingOptions}
             style={{ paddingInlineStart: ".625rem" }}
             columnHeaderProps={{
               style: { paddingInlineEnd: ".5rem" },

--- a/frontend/src/metabase/browse/components/utils.tsx
+++ b/frontend/src/metabase/browse/components/utils.tsx
@@ -68,9 +68,15 @@ const getValueForSorting = (
 };
 
 export const isValidSortColumn = (
-  sort_column: string,
+  sort_column: string | undefined,
 ): sort_column is keyof ModelResult => {
-  return ["name", "collection"].includes(sort_column);
+  return !!sort_column && ["name", "collection"].includes(sort_column);
+};
+
+export const isValidSortDirection = (
+  direction: string | undefined,
+): direction is SortDirection => {
+  return !!direction && ["asc", "desc"].includes(direction);
 };
 
 export const getSecondarySortColumn = (

--- a/frontend/src/metabase/common/hooks/use-setting/use-setting.ts
+++ b/frontend/src/metabase/common/hooks/use-setting/use-setting.ts
@@ -20,6 +20,7 @@ export const useUserSetting = <T extends keyof UserSettings>(
     debounceTimeout = 200,
     debounceOnLeadingEdge,
   }: {
+    /** Should all settings be retrieved again from the API? */
     shouldRefresh?: boolean;
     shouldDebounce?: boolean;
     debounceTimeout?: number;

--- a/frontend/src/metabase/components/ItemsTable/BaseItemsTable.tsx
+++ b/frontend/src/metabase/components/ItemsTable/BaseItemsTable.tsx
@@ -87,6 +87,7 @@ export const SortableColumnHeader = ({
         onClick={onSortingControlClick}
         role="button"
         isSortable={isSortable}
+        aria-label={isSortable ? `Sort by ${name}` : undefined}
       >
         {children}
         {isSortable && (

--- a/frontend/src/metabase/redux/settings.ts
+++ b/frontend/src/metabase/redux/settings.ts
@@ -19,9 +19,10 @@ export const refreshSiteSettings = createAsyncThunk(
   },
 );
 
-interface UpdateUserSettingProps<K extends keyof UserSettings> {
+export interface UpdateUserSettingProps<K extends keyof UserSettings> {
   key: K;
   value: UserSettings[K];
+  /** Should all settings be retrieved again from the API? */
   shouldRefresh?: boolean;
 }
 

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -518,6 +518,22 @@
   :type       :boolean
   :default    true)
 
+(defsetting browse-models-sort-column
+  (deferred-tru "User preference for the sort column for the 'Browse models' table")
+  :user-local :only
+  :export?    false
+  :visibility :authenticated
+  :type       :string
+  :default    "collection")
+
+(defsetting browse-models-sort-direction
+  (deferred-tru "User preference for the sort direction for the 'Browse models' table")
+  :user-local :only
+  :export?    false
+  :visibility :authenticated
+  :type       :string
+  :default    "asc")
+
 ;;; ## ------------------------------------------ AUDIT LOG ------------------------------------------
 
 (defmethod audit-log/model-details :model/User


### PR DESCRIPTION
This branch persists sorting of Browse models table in the API and adds an e2e test

Closes #42952