### PR TITLE
allow description columns to be dimensions of charts

### DIFF
--- a/frontend/src/metabase-lib/v1/types/utils/isa.js
+++ b/frontend/src/metabase-lib/v1/types/utils/isa.js
@@ -111,8 +111,7 @@ export const isScope = isFieldType.bind(null, SCOPE);
 export const isCategory = isFieldType.bind(null, CATEGORY);
 export const isLocation = isFieldType.bind(null, LOCATION);
 
-export const isDimension = col =>
-  col && col.source !== "aggregation" && !isDescription(col);
+export const isDimension = col => col && col.source !== "aggregation";
 export const isMetric = col =>
   col && col.source !== "breakout" && isSummable(col);
 

--- a/frontend/src/metabase-lib/v1/types/utils/isa.unit.spec.js
+++ b/frontend/src/metabase-lib/v1/types/utils/isa.unit.spec.js
@@ -13,9 +13,25 @@ import {
   getFieldType,
   isString,
   isInteger,
+  isDimension,
 } from "metabase-lib/v1/types/utils/isa";
+import { createMockColumn } from "metabase-types/api/mocks";
 
 describe("isa", () => {
+  describe("isDimension", () => {
+    it("should should return false for aggregation columns", () => {
+      expect(isDimension(createMockColumn({ source: "aggregation" }))).toBe(
+        false,
+      );
+    });
+
+    it("should should return true for description column types", () => {
+      expect(
+        isDimension(createMockColumn({ semantic_type: TYPE.Description })),
+      ).toBe(true);
+    });
+  });
+
   describe("getFieldType", () => {
     it("should know a date", () => {
       expect(getFieldType({ base_type: TYPE.Date })).toEqual(TEMPORAL);


### PR DESCRIPTION
### Description

This PR allows columns with "Description" semantic types to be used as chart dimensions for x-axis.

### How to verify

- In the Table Metadata editor change the Product -> Category semantic type to "Description"
- Create a new question from the Product table -> Summarize Count by Created At and Category
- Ensure you can use Category as a breakout dimension

### Demo

<img width="1728" alt="Screenshot 2024-05-10 at 6 56 38 PM" src="https://github.com/metabase/metabase/assets/14301985/b8cb5b13-bf33-4d9a-9193-b3a3f678dc69">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
