### PR TITLE
Make Trash Usable - Bug Bash 1

### DIFF
--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionContentView.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionContentView.tsx
@@ -23,6 +23,7 @@ import type {
 import {
   isRootTrashCollection,
   isPersonalCollectionChild,
+  isTrashedCollection,
 } from "metabase/collections/utils";
 import { ItemsTable } from "metabase/components/ItemsTable";
 import type { SortingOptions } from "metabase/components/ItemsTable/BaseItemsTable";
@@ -205,7 +206,11 @@ export const CollectionContentView = ({
     deleteBookmark(collectionId.toString(), "collection");
   };
 
-  const canUpload = uploadsEnabled && canUploadToDb && collection.can_write;
+  const canUpload =
+    uploadsEnabled &&
+    canUploadToDb &&
+    collection.can_write &&
+    !isTrashedCollection(collection);
 
   const dropzoneProps = canUpload ? getComposedDragProps(getRootProps()) : {};
 

--- a/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
+++ b/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
@@ -1,6 +1,6 @@
 import { useField } from "formik";
 import type { HTMLAttributes } from "react";
-import { useState, useRef, useMemo, useCallback } from "react";
+import { useEffect, useState, useRef, useMemo, useCallback } from "react";
 import { t } from "ttag";
 
 import {
@@ -58,7 +58,9 @@ function FormCollectionPicker({
   filterPersonalCollections,
 }: FormCollectionPickerProps) {
   const id = useUniqueId();
+
   const [{ value }, { error, touched }, { setValue }] = useField(name);
+
   const formFieldRef = useRef<HTMLDivElement>(null);
   const [isPickerOpen, setIsPickerOpen] = useState(false);
 
@@ -68,6 +70,21 @@ function FormCollectionPicker({
     Collections.selectors.getObject(state, {
       entityId: openCollectionId,
     }),
+  );
+
+  const selectedCollection = useSelector(state =>
+    Collections.selectors.getObject(state, {
+      entityId: value,
+    }),
+  );
+
+  useEffect(
+    function preventUsingArchivedCollection() {
+      if (selectedCollection?.archived) {
+        setValue("root", false);
+      }
+    },
+    [setValue, selectedCollection?.archived],
   );
 
   const isOpenCollectionInPersonalCollection = openCollection?.is_personal;

--- a/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
@@ -32,7 +32,9 @@ const canSelectItem = (
 };
 
 const searchFilter = (searchResults: SearchResult[]): SearchResult[] => {
-  return searchResults.filter(result => result.can_write);
+  return searchResults.filter(
+    result => result.can_write && result.collection.type !== "trash",
+  );
 };
 
 export const CollectionPickerModal = ({

--- a/frontend/src/metabase/components/EntityMenuItem/EntityMenuItem.styled.tsx
+++ b/frontend/src/metabase/components/EntityMenuItem/EntityMenuItem.styled.tsx
@@ -23,10 +23,9 @@ export const MenuItemContent = styled.div<MenuItemProps>`
   padding: 0.85em 1.45em;
   text-decoration: none;
   :hover {
-    color: ${props =>
-      (!props.disabled && props.hoverBgColor) || color("brand")};
+    color: ${props => color((!props.disabled && props.hoverColor) || "brand")};
     background-color: ${props =>
-      (!props.disabled && props.hoverBgColor) || color("bg-light")};
+      color((!props.disabled && props.hoverBgColor) || "bg-light")};
   }
   > .Icon {
     color: ${props =>
@@ -34,8 +33,7 @@ export const MenuItemContent = styled.div<MenuItemProps>`
     margin-right: 0.65em;
   }
   :hover > .Icon {
-    color: ${props =>
-      (!props.disabled && props.hoverBgColor) || color("brand")};
+    color: ${props => color((!props.disabled && props.hoverColor) || "brand")};
   },
   /* icon specific tweaks
      the alert icon should be optically aligned  with the x-height of the text */

--- a/frontend/src/metabase/components/ItemsTable/Columns.tsx
+++ b/frontend/src/metabase/components/ItemsTable/Columns.tsx
@@ -279,7 +279,9 @@ export const Columns = {
               createBookmark={createBookmark}
               deleteBookmark={deleteBookmark}
             />
-            {item.model === "dataset" && <ModelDetailLink model={item} />}
+            {item.model === "dataset" && !item.archived && (
+              <ModelDetailLink model={item} />
+            )}
           </RowActionsContainer>
         </ItemCell>
       );

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardInfoSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardInfoSidebar.tsx
@@ -91,7 +91,7 @@ export function DashboardInfoSidebar({
         />
       </ContentSection>
 
-      {canWrite && (
+      {!dashboard.archived && (
         <ContentSection>
           <Switch
             disabled={!canWrite}

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardInfoSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardInfoSidebar.tsx
@@ -91,18 +91,21 @@ export function DashboardInfoSidebar({
         />
       </ContentSection>
 
-      <ContentSection>
-        <Switch
-          disabled={!canWrite}
-          label={t`Auto-apply filters`}
-          labelPosition="left"
-          variant="stretch"
-          size="sm"
-          id={autoApplyFilterToggleId}
-          checked={dashboard.auto_apply_filters}
-          onChange={e => handleToggleAutoApplyFilters(e.target.checked)}
-        />
-      </ContentSection>
+      {canWrite && (
+        <ContentSection>
+          <Switch
+            disabled={!canWrite}
+            label={t`Auto-apply filters`}
+            labelPosition="left"
+            variant="stretch"
+            size="sm"
+            id={autoApplyFilterToggleId}
+            checked={dashboard.auto_apply_filters}
+            onChange={e => handleToggleAutoApplyFilters(e.target.checked)}
+          />
+        </ContentSection>
+      )}
+
       {showCaching && (
         <ContentSection>
           <PLUGIN_CACHING.DashboardCacheSection

--- a/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
+++ b/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
@@ -27,7 +27,7 @@ import {
 import { setIsShowingTemplateTagsEditor } from "../native";
 import { updateUrl } from "../navigation";
 import { runQuestionQuery } from "../querying";
-import { onCloseQuestionInfo, setQueryBuilderMode } from "../ui";
+import { onCloseQuestionInfo, setQueryBuilderMode, setUIControls } from "../ui";
 
 import { getQuestionWithDefaultVisualizationSettings } from "./utils";
 
@@ -258,6 +258,10 @@ export const setArchivedQuestion = createThunkAction(
           shouldStartAdHocQuestion: false,
         }),
       );
+
+      if (archived) {
+        dispatch(setUIControls({ isNativeEditorOpen: false }));
+      }
 
       if (!undoing) {
         dispatch(

--- a/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.jsx
+++ b/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.jsx
@@ -14,7 +14,7 @@ function SavedQuestionHeaderButton({ question, onSave }) {
   return (
     <HeaderRoot>
       <HeaderTitle
-        isDisabled={!question.canWrite()}
+        isDisabled={!question.canWrite() || question.isArchived()}
         initialValue={question.displayName()}
         placeholder={t`Add title`}
         onChange={onSave}

--- a/frontend/src/metabase/visualizations/click-actions/lib/modes.ts
+++ b/frontend/src/metabase/visualizations/click-actions/lib/modes.ts
@@ -2,11 +2,13 @@ import type { SdkClickActionPluginsConfig } from "embedding-sdk/lib/plugins";
 import type Question from "metabase-lib/v1/Question";
 
 import { Mode } from "../Mode";
+import { ArchivedMode } from "../modes/ArchivedMode";
 import { DefaultMode } from "../modes/DefaultMode";
 import { EmbeddingSdkMode } from "../modes/EmbeddingSdkMode";
 
 export function getMode(question: Question): Mode | null {
-  return new Mode(question, DefaultMode);
+  const queryMode = question.isArchived() ? ArchivedMode : DefaultMode;
+  return new Mode(question, queryMode);
 }
 
 export function getEmbeddingMode(

--- a/frontend/src/metabase/visualizations/click-actions/modes/ArchivedMode.ts
+++ b/frontend/src/metabase/visualizations/click-actions/modes/ArchivedMode.ts
@@ -1,0 +1,7 @@
+import type { QueryClickActionsMode } from "../../types";
+
+export const ArchivedMode: QueryClickActionsMode = {
+  name: "default",
+  hasDrills: false,
+  clickActions: [],
+};

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -721,6 +721,7 @@ class TableInteractive extends Component {
   // We should maybe rethink the approach to measurements or render a very basic table header, without react-draggable
   tableHeaderRenderer = ({ key, style, columnIndex, isVirtual = false }) => {
     const {
+      card,
       data,
       isPivoted,
       hasMetadataPopovers,
@@ -734,7 +735,7 @@ class TableInteractive extends Component {
 
     const columnTitle = getColumnTitle(columnIndex);
     const clicked = this.getHeaderClickedObject(data, columnIndex, isPivoted);
-    const isDraggable = !isPivoted;
+    const isDraggable = !isPivoted && !card.archived;
     const isDragging = dragColIndex === columnIndex;
     const isClickable = this.visualizationIsClickable(clicked);
     const isSortable = isClickable && column.source && !isPivoted;


### PR DESCRIPTION
### Description

Squashes the following bugs that were highlighted in our initial bug bash of trash:
- users able to reorder / filter columns in trashed questions
- users able to modify names of trashed questions
- collection picker defaulting to trashed collection if user was currently within a trashed collection
- trash appearing in search results of collection picker
- large empty area in info sidebar of trashed dashboards
- users editing a question then archiving was leaving the editor open
- users able to upload csvs to trash/trashed collections