### PR TITLE
Static viz get background color thread safe

### DIFF
--- a/src/metabase/pulse/render/color.clj
+++ b/src/metabase/pulse/render/color.clj
@@ -16,7 +16,7 @@
 (def ^:private js-file-path "frontend_shared/color_selector.js")
 
 (def ^:private ^{:arglists '([])} js-engine
-  ;; As of 2024/05/13, a single js-engine takes 3.5 MiB of memory
+  ;; As of 2024/05/13, a single color selector js engine takes 3.5 MiB of memory
   (js/threadlocal-fifo-memoizer
    (fn []
      (let [file-url (io/resource js-file-path)]

--- a/src/metabase/pulse/render/color.clj
+++ b/src/metabase/pulse/render/color.clj
@@ -16,6 +16,7 @@
 (def ^:private js-file-path "frontend_shared/color_selector.js")
 
 (def ^:private ^{:arglists '([])} js-engine
+  ;; As of 2024/05/13, a single js-engine takes 3.5 MiB of memory
   (js/threadlocal-fifo-memoizer
    (fn []
      (let [file-url (io/resource js-file-path)]

--- a/src/metabase/pulse/render/js_engine.clj
+++ b/src/metabase/pulse/render/js_engine.clj
@@ -7,12 +7,21 @@
 
   Javadocs: https://www.graalvm.org/truffle/javadoc/overview-summary.html"
   (:require
+   [clojure.core.memoize :as memoize]
    [clojure.java.io :as io]
    [metabase.util.i18n :refer [trs]])
   (:import
    (org.graalvm.polyglot Context HostAccess Source Value)))
 
 (set! *warn-on-reflection* true)
+
+(defn threadlocal-fifo-memoizer
+  "Returns a memoizer that is unique to each thread."
+  [thunk threshold]
+  (memoize/fifo
+   (with-meta thunk {::memoize/args-fn (fn [_]
+                                        [(.getId (Thread/currentThread))])})
+   :fifo/threshold threshold))
 
 (defn context
   "Create a new org.graalvm.polyglot.Context suitable to evaluate javascript"

--- a/test/metabase/db/query_test.clj
+++ b/test/metabase/db/query_test.clj
@@ -84,16 +84,6 @@
         (verify-same-query q)))))
 
 
-(defn- repeat-concurrently [n f]
-  ;; Use a latch to ensure that the functions start as close to simultaneously as possible.
-  (let [latch   (CountDownLatch. n)
-        futures (atom [])]
-    (dotimes [_ n]
-      (swap! futures conj (future (.countDown latch)
-                                  (.await latch)
-                                  (f))))
-    (into #{} (map deref) @futures)))
-
 (deftest select-or-insert!-test
   ;; We test both a case where the database protects against duplicates, and where it does not.
   ;; Using Setting is perfect because it has only two required fields - (the primary) key & value (with no constraint).
@@ -121,7 +111,7 @@
                                                            (.countDown latch)
                                                            (.await latch)
                                                            {other-col (str (random-uuid))})))
-                  results (repeat-concurrently threads thunk)
+                  results (mt/repeat-concurrently threads thunk)
                   n       (count results)
                   latest  (t2/select-one Setting search-col search-value)]
 
@@ -181,7 +171,7 @@
                                                                   (.countDown latch)
                                                                   (.await latch)
                                                                   {other-col <>}))))
-                    values-set (repeat-concurrently threads thunk)
+                    values-set (mt/repeat-concurrently threads thunk)
                     latest     (get (t2/select-one Setting search-col search-value) other-col)]
 
                 (testing "each update tried to set a different value"
@@ -199,7 +189,7 @@
                 (testing "After the database is created, it does not create further duplicates"
                   (let [count (t2/count Setting search-col search-value)]
                     (is (pos? count))
-                    (is (empty? (set/intersection values-set (repeat-concurrently threads thunk))))
+                    (is (empty? (set/intersection values-set (mt/repeat-concurrently threads thunk))))
                     (is (= count (t2/count Setting search-col search-value))))))
 
               ;; Since we couldn't use with-temp, we need to clean up manually.

--- a/test/metabase/db/query_test.clj
+++ b/test/metabase/db/query_test.clj
@@ -111,7 +111,7 @@
                                                            (.countDown latch)
                                                            (.await latch)
                                                            {other-col (str (random-uuid))})))
-                  results (mt/repeat-concurrently threads thunk)
+                  results (set (mt/repeat-concurrently threads thunk))
                   n       (count results)
                   latest  (t2/select-one Setting search-col search-value)]
 
@@ -171,7 +171,7 @@
                                                                   (.countDown latch)
                                                                   (.await latch)
                                                                   {other-col <>}))))
-                    values-set (mt/repeat-concurrently threads thunk)
+                    values-set (set (mt/repeat-concurrently threads thunk))
                     latest     (get (t2/select-one Setting search-col search-value) other-col)]
 
                 (testing "each update tried to set a different value"
@@ -189,7 +189,7 @@
                 (testing "After the database is created, it does not create further duplicates"
                   (let [count (t2/count Setting search-col search-value)]
                     (is (pos? count))
-                    (is (empty? (set/intersection values-set (mt/repeat-concurrently threads thunk))))
+                    (is (empty? (set/intersection values-set (set (mt/repeat-concurrently threads thunk)))))
                     (is (= count (t2/count Setting search-col search-value))))))
 
               ;; Since we couldn't use with-temp, we need to clean up manually.

--- a/test/metabase/pulse/render/color_test.clj
+++ b/test/metabase/pulse/render/color_test.clj
@@ -2,7 +2,8 @@
   (:require
    [clojure.test :refer :all]
    [metabase.pulse.render.color :as color]
-   [metabase.pulse.render.js-engine :as js]))
+   [metabase.pulse.render.js-engine :as js]
+   [metabase.test :as mt]))
 
 (def ^:private red "#ff0000")
 (def ^:private green "#00ff00")
@@ -50,3 +51,18 @@
         (is (= [red green red green]
                (for [row-index (range 0 4)]
                  (color/get-background-color color-selector "any value" "any column" row-index))))))))
+
+(deftest render-color-is-thread-safe-test
+  (is (every? some?
+              (mt/repeat-concurrently
+               3
+               (fn []
+                 (color/get-background-color (color/make-color-selector {:cols [{:name "test"}]
+                                                                         :rows [[5] [5]]}
+                                                                        {:table.column_formatting[{:columns ["test"],
+                                                                                                   :type :single,
+                                                                                                   :operator "=",
+                                                                                                   :value 5,
+                                                                                                   :color "#ff0000",
+                                                                                                   :highlight_row true}]})
+                                             "any value" "test" 1))))))

--- a/test/metabase/pulse/render/js_engine_test.clj
+++ b/test/metabase/pulse/render/js_engine_test.clj
@@ -1,8 +1,8 @@
 (ns metabase.pulse.render.js-engine-test
   (:require
    [clojure.test :refer :all]
-   [metabase.pulse.render.body-test :as body-test]
-   [metabase.pulse.render.js-engine :as js]))
+   [metabase.pulse.render.js-engine :as js]
+   [metabase.test :as mt]))
 
 (set! *warn-on-reflection* true)
 
@@ -23,6 +23,5 @@
     (let [context (js/context)]
       (js/load-js-string context "function plus (x, y) { return x + y }" "plus test")
       (is (= (repeat 10 2)
-             (body-test/execute-n-times-in-parallel
-              #(.asLong (js/execute-fn-name context "plus" 1 1))
-              10))))))
+             (mt/repeat-concurrently 10
+              #(.asLong (js/execute-fn-name context "plus" 1 1))))))))

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -243,6 +243,7 @@
   secret-value-equals?
   select-keys-sequentially
   throw-if-called!
+  repeat-concurrently
   with-all-users-permission
   with-column-remappings
   with-discarded-collections-perms-changes


### PR DESCRIPTION
Follow up of https://github.com/metabase/metabase/pull/42494

The previous fixes thread-safe issues for rendering svg, but it didn't fully fix cases with generating table, which calls to `metabase.pulse.render.color/get-background-color`, in turn, calls to `metabase.pulse.render.js-engine/execute-fn`, this function does not take a context so we couldn't synchronize like how we do in `execute-fn-name`.

I'm not very fond of the solution, but I think this is a step toward a "resource pool" for static viz context.

The static viz we're pooling here takes only ~ 3MiB of memory, so I'm giving it a pool of 5, which seems sufficient.

How to test:
- create a simple question with visualization type is table
- create an alert
- then running this script shouldn't throw any error

```clojure
(def alert (t2/select-one :model/Pulse YOUR_PULSE_ID))
(mt/repeat-concurrently 3
                        #(metabase.pulse/send-pulse! alert))
```