### PR TITLE
Remove code related to GoogleAnalytics tracking

### DIFF
--- a/.clj-kondo/hooks/metabase/models/setting.clj
+++ b/.clj-kondo/hooks/metabase/models/setting.clj
@@ -38,8 +38,6 @@
      engines
      enum-cardinality-threshold
      follow-up-email-sent
-     ga-code
-     ga-enabled
      google-auth-auto-create-accounts-domain
      google-auth-client-id
      google-auth-configured

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -178,7 +178,6 @@ export const createMockSettings = (
   "has-user-setup": true,
   "hide-embed-branding?": true,
   "show-static-embed-terms": true,
-  "ga-enabled": false,
   "google-auth-auto-create-accounts-domain": null,
   "google-auth-client-id": null,
   "google-auth-configured": false,

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -281,7 +281,6 @@ interface PublicSettings {
   "enable-enhancements?": boolean;
   "enable-password-login": boolean;
   engines: Record<string, Engine>;
-  "ga-enabled": boolean;
   "google-auth-client-id": string | null;
   "google-auth-enabled": boolean;
   "has-user-setup": boolean;

--- a/frontend/src/metabase/lib/analytics.js
+++ b/frontend/src/metabase/lib/analytics.js
@@ -5,15 +5,9 @@ import Settings from "metabase/lib/settings";
 import { getUserId } from "metabase/selectors/user";
 
 export const createTracker = store => {
-  if (Settings.googleAnalyticsEnabled()) {
-    createGoogleAnalyticsTracker();
-  }
-
   if (Settings.snowplowEnabled()) {
     createSnowplowTracker(store);
-  }
 
-  if (Settings.googleAnalyticsEnabled() || Settings.snowplowEnabled()) {
     document.body.addEventListener("click", handleStructEventClick, true);
   }
 };
@@ -21,10 +15,6 @@ export const createTracker = store => {
 export const trackPageView = url => {
   if (!url || !Settings.trackingEnabled()) {
     return;
-  }
-
-  if (Settings.googleAnalyticsEnabled()) {
-    trackGoogleAnalyticsPageView(getSanitizedUrl(url));
   }
 
   if (Settings.snowplowEnabled()) {
@@ -38,10 +28,6 @@ export const trackPageView = url => {
 export const trackStructEvent = (category, action, label, value) => {
   if (!category || !label || !Settings.trackingEnabled()) {
     return;
-  }
-
-  if (Settings.googleAnalyticsEnabled()) {
-    trackGoogleAnalyticsStructEvent(category, action, label, value);
   }
 };
 
@@ -64,28 +50,6 @@ export const trackSchemaEvent = (schema, version, data) => {
   if (Settings.snowplowEnabled()) {
     trackSnowplowSchemaEvent(schema, version, data);
   }
-};
-
-const createGoogleAnalyticsTracker = () => {
-  const code = Settings.get("ga-code");
-  window.ga?.("create", code, "auto");
-
-  Settings.on("anon-tracking-enabled", enabled => {
-    window[`ga-disable-${code}`] = enabled ? null : true;
-  });
-};
-
-const trackGoogleAnalyticsPageView = url => {
-  const version = Settings.get("version", {});
-  window.ga?.("set", "dimension1", version.tag);
-  window.ga?.("set", "page", url);
-  window.ga?.("send", "pageview", url);
-};
-
-const trackGoogleAnalyticsStructEvent = (category, action, label, value) => {
-  const version = Settings.get("version", {});
-  window.ga?.("set", "dimension1", version.tag);
-  window.ga?.("send", "event", category, action, label, value);
 };
 
 const createSnowplowTracker = store => {

--- a/frontend/src/metabase/lib/settings.ts
+++ b/frontend/src/metabase/lib/settings.ts
@@ -221,13 +221,6 @@ class MetabaseSettings {
   }
 
   /**
-   * @deprecated use getSetting(state, "ga-enabled")
-   */
-  googleAnalyticsEnabled() {
-    return this.get("ga-enabled") || false;
-  }
-
-  /**
    * @deprecated use getSetting(state, "snowplow-enabled")
    */
   snowplowEnabled() {

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -214,21 +214,6 @@
   :visibility :public
   :audit      :getter)
 
-(defsetting ga-code
-  (deferred-tru "Google Analytics tracking code.")
-  :default    "UA-60817802-1"
-  :visibility :public
-  :doc        false)
-
-(defsetting ga-enabled
-  (deferred-tru "Boolean indicating whether analytics data should be sent to Google Analytics on the frontend")
-  :type       :boolean
-  :setter     :none
-  :getter     (fn [] (and config/is-prod? (anon-tracking-enabled)))
-  :visibility :public
-  :audit      :never
-  :doc        false)
-
 (defsetting map-tile-server-url
   (deferred-tru "The map tile server URL template used in map visualizations, for example from OpenStreetMaps or MapBox.")
   :default    "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"


### PR DESCRIPTION
This PR removes the code related to GoogleAnalytics tracking that's left after https://github.com/metabase/metabase/pull/42515.

It DOES NOT remove the GA driver.
More context: https://github.com/metabase/metabase/issues/32096#issuecomment-1620627141