### PR TITLE
Remove `crc-32`

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "classnames": "^2.1.3",
     "color": "^4.2.3",
     "color-harmony": "^0.3.0",
-    "crc-32": "^1.2.2",
     "cron-expression-validator": "^1.0.20",
     "cronstrue": "^2.11.0",
     "crossfilter": "^1.3.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9174,11 +9174,6 @@ cpy@^8.1.2:
     p-filter "^2.1.0"
     p-map "^3.0.0"
 
-crc-32@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.2.tgz#3cad35a934b8bf71f25ca524b6da51fb7eace2ff"
-  integrity sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==
-
 create-ecdh@^4.0.0:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.4.tgz#d6e7f4bffa66736085a0762fd3a632684dabcc4e"


### PR DESCRIPTION
Doesn't seem to be used anywhere.

```
❯ yarn why crc-32
yarn why v1.22.19
[1/4] 🤔  Why do we have the module "crc-32"...?
[2/4] 🚚  Initialising dependency graph...
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "crc-32@1.2.2"
info Has been hoisted to "crc-32"
info This module exists because it's specified in "dependencies".
info Disk size without dependencies: "56KB"
info Disk size with unique dependencies: "56KB"
info Disk size with transitive dependencies: "56KB"
info Number of shared dependencies: 0
✨  Done in 0.50s.
```