### PR TITLE
Remove `classlist-polyfill`

### DIFF
--- a/frontend/src/metabase/app.js
+++ b/frontend/src/metabase/app.js
@@ -1,9 +1,5 @@
 import "regenerator-runtime/runtime";
 
-// Use of classList.add and .remove in Background and FitViewPort Hocs requires
-// this polyfill so that those work in older browsers
-import "classlist-polyfill";
-
 import "number-to-locale-string";
 
 // This is conditionally aliased in the webpack config.

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@visx/text": "1.7.0",
     "@visx/tooltip": "^2.10.0",
     "ace-builds": "^1.4.13",
-    "classlist-polyfill": "^1.2.0",
     "classnames": "^2.1.3",
     "color": "^4.2.3",
     "color-harmony": "^0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8538,11 +8538,6 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classlist-polyfill@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz#935bc2dfd9458a876b279617514638bcaa964a2e"
-  integrity sha1-k1vC39lFiodrJ5YXUUY4vKqWSi4=
-
 classnames@*, classnames@^2.1.3, classnames@^2.2.5, classnames@^2.3.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"


### PR DESCRIPTION
The library was last updated *seven* years ago.
I don't think there's any browser that we support which doesn't have the native support for the `classList` today.
https://caniuse.com/?search=classlist