### PR TITLE
Remove `number-to-locale-string`

### DIFF
--- a/frontend/src/metabase/app.js
+++ b/frontend/src/metabase/app.js
@@ -1,7 +1,5 @@
 import "regenerator-runtime/runtime";
 
-import "number-to-locale-string";
-
 // This is conditionally aliased in the webpack config.
 // If EE isn't enabled, it loads an empty file.
 // Should be imported before any other metabase import

--- a/frontend/test/metabase-bootstrap.js
+++ b/frontend/test/metabase-bootstrap.js
@@ -1,5 +1,4 @@
 import "regenerator-runtime/runtime";
-import "number-to-locale-string";
 import "metabase/css/vendor.css";
 import "metabase/css/index.module.css";
 

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "moment-timezone": "^0.5.38",
     "mustache": "^2.3.2",
     "normalizr": "^3.0.2",
-    "number-to-locale-string": "^1.0.1",
     "password-generator": "^2.0.1",
     "postcss-discard-comments": "^6.0.1",
     "prop-types": "^15.5.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17387,11 +17387,6 @@ num2fraction@^1.2.2:
   resolved "https://registry.yarnpkg.com/num2fraction/-/num2fraction-1.2.2.tgz#6f682b6a027a4e9ddfa4564cd2589d1d4e669ede"
   integrity sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=
 
-number-to-locale-string@^1.0.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/number-to-locale-string/-/number-to-locale-string-1.2.0.tgz#6c5030fb47e9c9ad14bf59a1ae81b33cc84b4038"
-  integrity sha512-q2BNrXwz250d/FR/wwHIr26oFx5eQiXfKxniS3V31TsSR1rJnYwKPfi7SaHRZYlMIOQTaXkAynjv9Pr/+vfyFQ==
-
 nwsapi@^2.2.4:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.5.tgz#a52744c61b3889dd44b0a158687add39b8d935e2"


### PR DESCRIPTION
The library was last updated *six* years ago!

Do we really need it anymore given that this method exists on the `Number` prototype natively?
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString

```
❯ yarn why number-to-locale-string
yarn why v1.22.19
[1/4] 🤔  Why do we have the module "number-to-locale-string"...?
[2/4] 🚚  Initialising dependency graph...
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "number-to-locale-string@1.2.0"
info Has been hoisted to "number-to-locale-string"
info This module exists because it's specified in "dependencies".
info Disk size without dependencies: "192KB"
info Disk size with unique dependencies: "192KB"
info Disk size with transitive dependencies: "192KB"
info Number of shared dependencies: 0
✨  Done in 0.51s.
```