### PR TITLE
Fix column widths in Browse models

### DIFF
--- a/frontend/src/metabase/browse/components/BrowseModels.tsx
+++ b/frontend/src/metabase/browse/components/BrowseModels.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { t } from "ttag";
+import { c, t } from "ttag";
 
 import NoResults from "assets/img/no_results.svg";
 import { useSearchQuery } from "metabase/api";
@@ -42,7 +42,8 @@ export const BrowseModels = () => {
             <Title order={1} color="text-dark">
               <Group spacing="sm">
                 <Icon size={24} color={color("brand")} name="model" />
-                {t`Models`}
+                {c("The title of a page where you can view all the models")
+                  .t`Browsing models`}
               </Group>
             </Title>
             <ModelFilterControls

--- a/frontend/src/metabase/browse/components/ModelsTable.styled.tsx
+++ b/frontend/src/metabase/browse/components/ModelsTable.styled.tsx
@@ -1,10 +1,39 @@
 import styled from "@emotion/styled";
 
+import {
+  ItemLink,
+  TableColumn,
+  hideResponsively,
+} from "metabase/components/ItemsTable/BaseItemsTable.styled";
+import type { ResponsiveProps } from "metabase/components/ItemsTable/utils";
 import { color } from "metabase/lib/colors";
+import { breakpoints } from "metabase/ui/theme";
 
 export const ModelTableRow = styled.tr`
   cursor: pointer;
   :outline {
     outline: 2px solid ${color("brand")};
+  }
+`;
+
+export const ModelNameLink = styled(ItemLink)`
+  padding-inline-start: 0.6rem;
+  padding-block: 0.5rem;
+`;
+
+export const ModelCell = styled.td<ResponsiveProps>`
+  td& {
+    padding: 0.25em 0.5rem 0.25em 0.5rem;
+  }
+  ${hideResponsively}
+`;
+
+export const ModelNameColumn = styled(TableColumn)`
+  width: 356px;
+  @container ${props => props.containerName} (max-width: ${breakpoints.md}) {
+    width: 280px;
+  }
+  @container ${props => props.containerName} (max-width: ${breakpoints.sm}) {
+    width: 200px;
   }
 `;

--- a/frontend/src/metabase/browse/components/ModelsTable.tsx
+++ b/frontend/src/metabase/browse/components/ModelsTable.tsx
@@ -2,18 +2,17 @@ import { useState } from "react";
 import { push } from "react-router-redux";
 import { t } from "ttag";
 
-import type { ModelResult } from "metabase-types/api";
 import EntityItem from "metabase/components/EntityItem";
 import {
   SortableColumnHeader,
-  type SortingOptions
+  type SortingOptions,
 } from "metabase/components/ItemsTable/BaseItemsTable";
 import {
   ItemLink,
   ItemNameCell,
   Table,
   TableColumn,
-  TBody
+  TBody,
 } from "metabase/components/ItemsTable/BaseItemsTable.styled";
 import { Columns, SortDirection } from "metabase/components/ItemsTable/Columns";
 import type { ResponsiveProps } from "metabase/components/ItemsTable/utils";
@@ -23,6 +22,7 @@ import { useDispatch, useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { getLocale } from "metabase/setup/selectors";
 import { Icon, type IconProps } from "metabase/ui";
+import type { ModelResult } from "metabase-types/api";
 
 import { trackModelClick } from "../analytics";
 import { getCollectionName, getIcon } from "../utils";
@@ -31,7 +31,8 @@ import { CollectionBreadcrumbsWithTooltip } from "./CollectionBreadcrumbsWithToo
 import { EllipsifiedWithMarkdownTooltip } from "./EllipsifiedWithMarkdownTooltip";
 import {
   ModelCell,
-  ModelNameColumn, ModelTableRow
+  ModelNameColumn,
+  ModelTableRow,
 } from "./ModelsTable.styled";
 import { getModelDescription, sortModels } from "./utils";
 
@@ -179,11 +180,11 @@ const TBodyRow = ({ model }: { model: ModelResult }) => {
       </ModelCell>
 
       {/* Description */}
-      <ItemCell {...descriptionProps}>
+      <ModelCell {...descriptionProps}>
         <EllipsifiedWithMarkdownTooltip>
           {getModelDescription(model) || ""}
         </EllipsifiedWithMarkdownTooltip>
-      </ItemCell>
+      </ModelCell>
 
       {/* Adds a border-radius to the table */}
       <Columns.RightEdge.Cell />

--- a/frontend/src/metabase/components/ItemsTable/BaseItemsTable.styled.tsx
+++ b/frontend/src/metabase/components/ItemsTable/BaseItemsTable.styled.tsx
@@ -40,7 +40,7 @@ export const Table = styled.table<{ isInDragLayer?: boolean }>`
 
 Table.defaultProps = { className: AdminS.ContentTable };
 
-const hideResponsively = ({
+export const hideResponsively = ({
   hideAtContainerBreakpoint,
   containerName,
 }: ResponsiveProps) =>
@@ -52,7 +52,9 @@ const hideResponsively = ({
   `;
 
 export const ColumnHeader = styled.th<ResponsiveProps>`
-  padding: 0.75em 1em 0.75em !important;
+  th& {
+    padding: 0.75em 1em 0.75em;
+  }
   font-weight: bold;
   color: ${color("text-medium")};
   ${hideResponsively}

--- a/frontend/src/metabase/components/ItemsTable/BaseItemsTable.tsx
+++ b/frontend/src/metabase/components/ItemsTable/BaseItemsTable.tsx
@@ -37,6 +37,7 @@ export type SortableColumnHeaderProps = {
   name?: string;
   sortingOptions?: SortingOptions;
   onSortingOptionsChange?: (newSortingOptions: SortingOptions) => void;
+  columnHeaderProps?: Partial<HTMLAttributes<HTMLTableHeaderCellElement>>;
 } & PropsWithChildren<Partial<HTMLAttributes<HTMLDivElement>>>;
 
 export const SortableColumnHeader = ({
@@ -46,6 +47,7 @@ export const SortableColumnHeader = ({
   children,
   hideAtContainerBreakpoint,
   containerName,
+  columnHeaderProps,
   ...props
 }: SortableColumnHeaderProps & ResponsiveProps) => {
   const isSortable = !!onSortingOptionsChange && !!name;
@@ -76,6 +78,7 @@ export const SortableColumnHeader = ({
     <ColumnHeader
       hideAtContainerBreakpoint={hideAtContainerBreakpoint}
       containerName={containerName}
+      {...columnHeaderProps}
     >
       <SortingControlContainer
         {...props}


### PR DESCRIPTION
Fixes the column widths and padding in Browse models to match Maz's spec, below:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/1f3c71f1-f00c-43a1-b18c-c05b33b15104.png)

Here's how the columns look in this branch:
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/410087e4-30db-427d-9ac4-d0d97ed6124b.png)


This branch also retitles the page "Browsing models" per Dawei's request

