### PR TITLE
[Drivers] New `features` to replace hard-coded driver lists in tests

### DIFF
--- a/modules/drivers/athena/src/metabase/driver/athena.clj
+++ b/modules/drivers/athena/src/metabase/driver/athena.clj
@@ -32,10 +32,12 @@
 ;;; |                                          metabase.driver method impls                                          |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(doseq [[feature supported?] {:datetime-diff             true
-                              :foreign-keys              true
-                              :nested-fields             false
-                              :test/jvm-timezone-setting false}]
+(doseq [[feature supported?] {:datetime-diff                 true
+                              :foreign-keys                  true
+                              :nested-fields                 false
+                              :connection/multiple-databases true
+                              :metadata/key-constraints      false
+                              :test/jvm-timezone-setting     false}]
   (defmethod driver/database-supports? [:athena feature] [_driver _feature _db] supported?))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/modules/drivers/presto-jdbc/src/metabase/driver/presto_jdbc.clj
+++ b/modules/drivers/presto-jdbc/src/metabase/driver/presto_jdbc.clj
@@ -51,7 +51,8 @@
                               :native-parameters               true
                               :now                             true
                               :set-timezone                    true
-                              :standard-deviation-aggregations true}]
+                              :standard-deviation-aggregations true
+                              :metadata/key-constraints        false}]
   (defmethod driver/database-supports? [:presto-jdbc feature] [_driver _feature _db] supported?))
 
 ;;; Presto API helpers

--- a/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
+++ b/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
@@ -209,6 +209,7 @@
                               :native-parameters               true
                               :nested-queries                  true
                               :standard-deviation-aggregations true
+                              :metadata/key-constraints        false
                               :test/jvm-timezone-setting       false
                               ;; disabled for now, see issue #40991 to fix this.
                               :window-functions/cumulative     false}]

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -460,8 +460,14 @@
 
 (def features
   "Set of all features a driver can support."
-  #{;; Does this database support foreign key relationships?
+  #{;; Does this database support following foreign key relationships while querying?
+    ;; Note that this is different from supporting primary key and foreign key constraints in the schema; see below.
     :foreign-keys
+
+    ;; Does this database track and enforce primary key and foreign key constraints in the schema?
+    ;; SQL query engines like Presto and Athena do not track these, though they can query across FKs.
+    ;; See :foreign-keys above.
+    :metadata/key-constraints
 
     ;; Does this database support nested fields for any and every field except primary key (e.g. Mongo)?
     :nested-fields
@@ -591,6 +597,12 @@
 
     ;; Does the driver support fingerprint the fields. Default is true
     :fingerprint
+
+    ;; Does a connection to this driver correspond to a single database (false), or to multiple databases (true)?
+    ;; Default is false; ie. a single database. This is common for classic relational DBs and some cloud databases.
+    ;; Some have access to many databases from one connection; eg. Athena connects to an S3 bucket which might have
+    ;; many databases in it.
+    :connection/multiple-databases
 
     ;; Does this driver support window functions like cumulative count and cumulative sum? (default: false)
     :window-functions/cumulative

--- a/src/metabase/driver/sql.clj
+++ b/src/metabase/driver/sql.clj
@@ -27,6 +27,7 @@
                  :percentile-aggregations
                  :regex
                  :standard-deviation-aggregations
+                 :metadata/key-constraints
                  :window-functions/cumulative
                  :window-functions/offset]]
   (defmethod driver/database-supports? [:sql feature] [_driver _feature _db] true))

--- a/test/metabase/driver_test.clj
+++ b/test/metabase/driver_test.clj
@@ -84,10 +84,7 @@
 
 (deftest can-connect-with-destroy-db-test
   (testing "driver/can-connect? should fail or throw after destroying a database"
-    (mt/test-drivers (->> (mt/normal-drivers)
-                          ;; athena is a special case because connections aren't made with a single database,
-                          ;; but to an S3 bucket that may contain many databases
-                          (remove #{:athena}))
+    (mt/test-drivers (mt/normal-drivers-without-feature :connection/multiple-databases)
       (let [database-name (mt/random-name)
             dbdef         (basic-db-definition database-name)]
         (mt/dataset dbdef
@@ -119,10 +116,7 @@
 
 (deftest check-can-connect-before-sync-test
   (testing "Database sync should short-circuit and fail if the database at the connection has been deleted (metabase#7526)"
-    (mt/test-drivers (->> (mt/normal-drivers)
-                          ;; athena is a special case because connections aren't made with a single database,
-                          ;; but to an S3 bucket that may contain many databases
-                          (remove #{:athena}))
+    (mt/test-drivers (mt/normal-drivers-without-feature :connection/multiple-databases)
       (let [database-name (mt/random-name)
             dbdef         (basic-db-definition database-name)]
         (mt/dataset dbdef

--- a/test/metabase/test/data/dataset_definition_test.clj
+++ b/test/metabase/test/data/dataset_definition_test.clj
@@ -8,17 +8,10 @@
    [toucan2.core :as t2]))
 
 (deftest dataset-with-custom-pk-test
-  (mt/test-drivers (apply disj (mt/sql-jdbc-drivers)
-                          ;; presto doesn't create PK for test data :) not sure why
-                          :presto-jdbc
-                          ;; creating db for athena is expensive and require some extra steps,
-                          ;; so it's not worth testing against, see
-                          ;; the[[metabase.test.data.athena/*allow-database-creation*]]
-                          :athena
-                          ;; there is no PK in sparksql
-                          :sparksql
-                          ;; Timeseries drivers currently support only testing with pre-loaded dataset
-                          (tqpt/timeseries-drivers))
+  (mt/test-drivers (->> (mt/normal-drivers-with-feature :metadata/key-constraints)
+                        (filter (mt/sql-jdbc-drivers))
+                        ;; Timeseries drivers currently support only testing with pre-loaded dataset
+                        (remove (tqpt/timeseries-drivers)))
     (mt/dataset (mt/dataset-definition "custom-pk"
                   ["user"
                    [{:field-name "custom_id" :base-type :type/Integer :pk? true}]
@@ -51,17 +44,10 @@
     [[1 2]]]])
 
 (deftest dataset-with-custom-composite-pk-test
-  (mt/test-drivers (apply disj (mt/sql-jdbc-drivers)
-                          ;; presto doesn't create PK for test data :) not sure why
-                          :presto-jdbc
-                          ;; creating db for athena is expensive and require some extra steps,
-                          ;; so it's not worth testing against, see
-                          ;; the [[metabase.test.data.athena/*allow-database-creation*]]
-                          :athena
-                          ;; there is no PK in sparksql
-                          :sparksql
-                          ;; Timeseries drivers currently support only testing with pre-loaded dataset
-                          (tqpt/timeseries-drivers))
+  (mt/test-drivers (->> (mt/normal-drivers-with-feature :metadata/key-constraints)
+                        (filter (mt/sql-jdbc-drivers))
+                        ;; Timeseries drivers currently support only testing with pre-loaded dataset
+                        (remove (tqpt/timeseries-drivers)))
     (mt/dataset composite-pk
       (let [format-name #(ddl.i/format-name driver/*driver* %)]
         (testing "(artist_id, song_id) is a PK"


### PR DESCRIPTION
- `:metadata/key-constraints` for those databases which formally track
  PK and FK key constraints. Some databases (eg. Presto/Athena/Starburst
  family) don't support constraints like that, but do support querying
  based on foreign keys (which is the `:foreign-keys` feature).
- `:connection/multiple-databases` for databases where a single
  connection can connect to many databases. This is the case for Athena,
  since it connects to an S3 bucket and exposes all files in the bucket
  as databases through that single connection.
- Also removed a troublesome "all DBs except a huge list" case in the
  SSH tunnel tests with a shorter list of supported drivers.

