### PR TITLE
replace search bar with command palette toggle

### DIFF
--- a/e2e/support/helpers/e2e-command-palette-helpers.js
+++ b/e2e/support/helpers/e2e-command-palette-helpers.js
@@ -5,5 +5,19 @@ export const pressPageUp = () => cy.get("body").type("{pageup}");
 export const pressPageDown = () => cy.get("body").type("{pagedown}");
 export const pressHome = () => cy.get("body").type("{home}");
 export const pressEnd = () => cy.get("body").type("{end}");
-export const commandPaletteSearch = () =>
-  cy.findByPlaceholderText("Jump to...");
+export const commandPaletteInput = () => cy.findByPlaceholderText("Jump to...");
+
+export const commandPaletteSearch = (query, viewAll = true) => {
+  cy.intercept("GET", "/api/search?q=*").as("paletteSearch");
+  cy.findByTestId("app-bar")
+    .findByRole("button", { name: /Search/ })
+    .click();
+  commandPaletteInput().type(query);
+  cy.wait("@paletteSearch");
+
+  if (viewAll) {
+    commandPalette()
+      .findByRole("option", { name: /View and filter/ })
+      .click();
+  }
+};

--- a/e2e/support/helpers/e2e-command-palette-helpers.js
+++ b/e2e/support/helpers/e2e-command-palette-helpers.js
@@ -1,5 +1,7 @@
 export const commandPalette = () => cy.findByTestId("command-palette");
 export const openCommandPalette = () => cy.get("body").type("{ctrl+k}{cmd+k}");
+export const commandPaletteButton = () =>
+  cy.findByTestId("app-bar").findByRole("button", { name: /Search/ });
 export const closeCommandPalette = () => cy.get("body").type("{esc}");
 export const pressPageUp = () => cy.get("body").type("{pageup}");
 export const pressPageDown = () => cy.get("body").type("{pagedown}");

--- a/e2e/test/scenarios/admin/datamodel/reproductions.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/reproductions.cy.spec.js
@@ -5,6 +5,8 @@ import {
   openReviewsTable,
   popover,
   summarize,
+  commandPaletteButton,
+  commandPalette,
 } from "e2e/support/helpers";
 
 const { PEOPLE_ID, PEOPLE, REVIEWS, REVIEWS_ID } = SAMPLE_DATABASE;
@@ -98,11 +100,9 @@ describe("issue 21984", () => {
       cy.findByText("Pick up where you left off").should("not.exist");
     });
 
-    cy.findByTestId("app-bar").findByPlaceholderText("Search…").click();
-
-    cy.findByTestId("search-results-floating-container").within(() => {
-      cy.findByText("Recently viewed");
-      cy.findByText("Nothing here");
+    commandPaletteButton().click();
+    commandPalette().within(() => {
+      cy.findByText("Recent items").should("not.exist");
     });
   });
 });

--- a/e2e/test/scenarios/dashboard-filters/reproductions/16663-filters-can-stay-in-url.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/16663-filters-can-stay-in-url.cy.spec.js
@@ -1,6 +1,8 @@
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   addOrUpdateDashboardCard,
+  commandPalette,
+  commandPaletteSearch,
   restore,
   visitDashboard,
 } from "e2e/support/helpers";
@@ -66,11 +68,10 @@ describe("issue 16663", () => {
 
     cy.url().should("include", queryParam);
 
-    cy.findByPlaceholderText("Search…").type(dashboardToRedirect);
-
-    cy.findByTestId("search-results-floating-container")
-      .findByText(dashboardToRedirect)
-      .click();
+    commandPaletteSearch(dashboardToRedirect, false);
+    commandPalette().within(() => {
+      cy.findByRole("option", { name: dashboardToRedirect }).click();
+    });
 
     cy.url().should("include", "orders-in-a-dashboard");
     cy.url().should("not.include", queryParam);

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -44,6 +44,8 @@ import {
   entityPickerModal,
   collectionOnTheGoModal,
   setFilter,
+  commandPaletteButton,
+  commandPalette,
 } from "e2e/support/helpers";
 import { GRID_WIDTH } from "metabase/lib/dashboard_grid";
 import {
@@ -235,12 +237,12 @@ describe("scenarios > dashboard", () => {
       cy.log(
         "Find the originally visited (unrelated) dashboard in search and go to it",
       );
-      appBar()
-        .findByPlaceholderText(/^Search/)
-        .click();
-      cy.findAllByTestId("recently-viewed-item-title")
-        .contains("Orders in a dashboard")
-        .click();
+
+      commandPaletteButton().click();
+      commandPalette().within(() => {
+        cy.findByText("Recent items").should("exist");
+        cy.findByRole("option", { name: "Orders in a dashboard" }).click();
+      });
 
       cy.log("It should not contain an alien card from the other dashboard");
       getDashboardCards().should("have.length", 1).and("contain", "37.65");

--- a/e2e/test/scenarios/models/model-indexes.cy.spec.js
+++ b/e2e/test/scenarios/models/model-indexes.cy.spec.js
@@ -5,6 +5,8 @@ import {
   popover,
   sidebar,
   openColumnOptions,
+  commandPaletteSearch,
+  commandPalette,
 } from "e2e/support/helpers";
 import { createModelIndex } from "e2e/support/helpers/e2e-model-index-helper";
 
@@ -122,13 +124,11 @@ describe("scenarios > model indexes", () => {
     cy.wait("@cardUpdate");
 
     // search should fail
-    cy.findByTestId("app-bar")
-      .findByPlaceholderText("Search…")
-      .type("marble shoes");
+    commandPaletteSearch("marble shoes", false);
 
-    cy.wait("@searchQuery");
-
-    cy.findByTestId("search-results-empty-state").should("be.visible");
+    commandPalette()
+      .findByRole("option", { name: /No results for/ })
+      .should("exist");
   });
 
   it("should be able to search model index values and visit detail records", () => {
@@ -136,14 +136,9 @@ describe("scenarios > model indexes", () => {
 
     cy.visit("/");
 
-    cy.findByTestId("app-bar")
-      .findByPlaceholderText("Search…")
-      .type("marble shoes");
-
-    cy.wait("@searchQuery");
-
-    cy.findByTestId("search-results-list")
-      .findByText("Small Marble Shoes")
+    commandPaletteSearch("marble shoes", false);
+    commandPalette()
+      .findByRole("option", { name: "Small Marble Shoes" })
       .click();
 
     cy.wait("@dataset");
@@ -178,11 +173,8 @@ describe("scenarios > model indexes", () => {
 
     cy.visit("/");
 
-    cy.findByTestId("app-bar").findByPlaceholderText("Search…").type("anais");
-
-    cy.wait("@searchQuery");
-
-    cy.findByTestId("search-results-list").findByText("Anais Zieme").click();
+    commandPaletteSearch("anais", false);
+    commandPalette().findByRole("option", { name: "Anais Zieme" }).click();
 
     cy.wait("@dataset");
     cy.wait("@dataset"); // second query gets the additional record
@@ -198,14 +190,9 @@ describe("scenarios > model indexes", () => {
 
     cy.visit("/");
 
-    cy.findByTestId("app-bar")
-      .findByPlaceholderText("Search…")
-      .type("marble shoes");
-
-    cy.wait("@searchQuery");
-
-    cy.findByTestId("search-results-list")
-      .findByText("Small Marble Shoes")
+    commandPaletteSearch("marble shoes", false);
+    commandPalette()
+      .findByRole("option", { name: "Small Marble Shoes" })
       .click();
 
     cy.wait("@dataset");
@@ -220,13 +207,9 @@ describe("scenarios > model indexes", () => {
 
     cy.get("body").type("{esc}");
 
-    cy.findByTestId("app-bar")
-      .findByPlaceholderText("Search…")
-      .clear()
-      .type("silk coat");
-
-    cy.findByTestId("search-results-list")
-      .findByText("Ergonomic Silk Coat")
+    commandPaletteSearch("silk coat", false);
+    commandPalette()
+      .findByRole("option", { name: "Ergonomic Silk Coat" })
       .click();
 
     cy.findByTestId("object-detail").within(() => {

--- a/e2e/test/scenarios/models/reproductions/29378-actions-search-crash.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/29378-actions-search-crash.cy.spec.js
@@ -1,6 +1,9 @@
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 import {
+  closeCommandPalette,
+  commandPalette,
+  commandPaletteSearch,
   createAction,
   restore,
   setActionsEnabledForDB,
@@ -46,9 +49,11 @@ describe("issue 29378", () => {
     );
 
     cy.findByRole("tab", { name: "Used by" }).click();
-    cy.findByPlaceholderText("Search…").type(ACTION_DETAILS.name);
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText(ACTION_DETAILS.name).should("be.visible");
+    commandPaletteSearch(ACTION_DETAILS.name, false);
+    commandPalette()
+      .findByRole("option", { name: ACTION_DETAILS.name })
+      .should("exist");
+    closeCommandPalette();
 
     cy.findByRole("tab", { name: "Actions" }).click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage

--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -7,7 +7,7 @@ import {
   restore,
   openCommandPalette,
   commandPalette,
-  commandPaletteSearch,
+  commandPaletteInput,
   closeCommandPalette,
   visitFullAppEmbeddingUrl,
   pressPageDown,
@@ -34,19 +34,13 @@ describe("command palette", () => {
     cy.request(`/api/dashboard/${ORDERS_DASHBOARD_ID}`);
     cy.visit("/");
 
-    cy.findByPlaceholderText("Search…").click();
-
-    //Not sure if this is the best way to target this button
-    cy.findByRole("button", { name: / \+ K/ }).should("exist").click();
-
-    cy.findByTestId("search-results-floating-container").should("not.exist");
-    commandPalette().should("exist");
+    cy.findByRole("button", { name: /Search/ }).click();
     closeCommandPalette();
 
     cy.log("open the command palette with keybinding");
     openCommandPalette();
     commandPalette().within(() => {
-      commandPaletteSearch().should("exist");
+      commandPaletteInput().should("exist");
 
       cy.log("limit to 5 basic actions");
       cy.findByText("New question");
@@ -62,7 +56,7 @@ describe("command palette", () => {
       );
 
       cy.log("Should search entities and docs");
-      commandPaletteSearch().type("Orders, Count");
+      commandPaletteInput().type("Orders, Count");
 
       cy.findByRole("option", { name: "Orders, Count" })
         .should("contain.text", "Our analytics")
@@ -72,15 +66,15 @@ describe("command palette", () => {
 
       // Since the command palette list is virtualized, we will search for a few
       // to ensure they're reachable
-      commandPaletteSearch().clear().type("People");
+      commandPaletteInput().clear().type("People");
       cy.findByRole("option", { name: "People" }).should("exist");
 
-      commandPaletteSearch().clear().type("Uploads");
+      commandPaletteInput().clear().type("Uploads");
       cy.findByRole("option", { name: "Settings - Uploads" }).should("exist");
 
       // When entering a query, if there are results that come before search results, highlight
       // the first action, otherwise, highlight the first search result
-      commandPaletteSearch().clear().type("Or");
+      commandPaletteInput().clear().type("Or");
       cy.findByRole("option", { name: "Performance" }).should(
         "have.attr",
         "aria-selected",
@@ -89,7 +83,7 @@ describe("command palette", () => {
       cy.findByRole("option", { name: /View and filter/ }).should("exist");
 
       // Check that we are not filtering search results by action name
-      commandPaletteSearch().clear().type("Company");
+      commandPaletteInput().clear().type("Company");
       cy.findByRole("option", { name: /View and filter/ }).should("exist");
       cy.findByRole("option", { name: "PEOPLE" }).should(
         "have.attr",
@@ -98,7 +92,7 @@ describe("command palette", () => {
       );
       cy.findByRole("option", { name: "REVIEWS" }).should("exist");
       cy.findByRole("option", { name: "PRODUCTS" }).should("exist");
-      commandPaletteSearch().clear();
+      commandPaletteInput().clear();
     });
 
     cy.log("We can close the command palette using escape");
@@ -149,7 +143,7 @@ describe("command palette", () => {
     openCommandPalette();
 
     commandPalette().within(() => {
-      commandPaletteSearch().type("Nested");
+      commandPaletteInput().type("Nested");
       cy.findByRole("option", { name: "Enable Nested Queries" }).click();
     });
 
@@ -161,7 +155,7 @@ describe("command palette", () => {
     openCommandPalette();
 
     commandPalette().within(() => {
-      commandPaletteSearch().clear().type("Week");
+      commandPaletteInput().clear().type("Week");
       cy.findByRole("option", { name: "First day of the week" }).click();
     });
 

--- a/e2e/test/scenarios/onboarding/search/recently-viewed.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/recently-viewed.cy.spec.js
@@ -11,6 +11,9 @@ import {
   setTokenFeatures,
   popover,
   entityPickerModal,
+  visitFullAppEmbeddingUrl,
+  openCommandPalette,
+  commandPalette,
 } from "e2e/support/helpers";
 
 describe("search > recently viewed", () => {
@@ -32,7 +35,8 @@ describe("search > recently viewed", () => {
     // which elicits a ViewLog entry
 
     cy.intercept("/api/activity/recent_views").as("recent");
-    cy.visit("/");
+    //Because this is testing keyboard navigation, these tests can run in embedded mode
+    visitFullAppEmbeddingUrl({ url: "/", qs: { top_nav: true, search: true } });
     cy.wait("@recent");
 
     cy.findByPlaceholderText("Search…").click();
@@ -145,9 +149,9 @@ describeEE("search > recently viewed > enterprise features", () => {
   });
 
   it("should show verified badge in the 'Recently viewed' list (metabase#18021)", () => {
-    cy.findByPlaceholderText("Search…").click();
+    openCommandPalette();
 
-    cy.findByTestId("recently-viewed-item").within(() => {
+    commandPalette().within(() => {
       cy.icon("verified_filled").should("be.visible");
     });
   });

--- a/e2e/test/scenarios/onboarding/search/reproductions/28788-search-results-overflow.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/reproductions/28788-search-results-overflow.cy.spec.js
@@ -1,5 +1,9 @@
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { isScrollableHorizontally, restore } from "e2e/support/helpers";
+import {
+  isScrollableHorizontally,
+  restore,
+  visitFullAppEmbeddingUrl,
+} from "e2e/support/helpers";
 
 const { PEOPLE_ID } = SAMPLE_DATABASE;
 const LONG_STRING = "01234567890ABCDEFGHIJKLMNOPQRSTUVXYZ0123456789";
@@ -30,7 +34,7 @@ describe("issue 28788", () => {
       });
     });
 
-    cy.visit("/");
+    visitFullAppEmbeddingUrl({ url: "/", qs: { top_nav: true, search: true } });
     cy.findByPlaceholderText("Search…").type(questionDetails.name);
     cy.wait("@search");
     cy.icon("hourglass").should("not.exist");

--- a/e2e/test/scenarios/onboarding/search/search-filters.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/search-filters.cy.spec.js
@@ -9,12 +9,12 @@ import {
   createAction,
   describeEE,
   expectSearchResultContent,
-  getSearchBar,
   popover,
   restore,
   setActionsEnabledForDB,
   setTokenFeatures,
   summarize,
+  commandPaletteSearch,
 } from "e2e/support/helpers";
 import { createModelIndex } from "e2e/support/helpers/e2e-model-index-helper";
 
@@ -98,8 +98,6 @@ describe("scenarios > search", () => {
       it("hydrating search from URL", () => {
         cy.visit("/search?q=orders");
         cy.wait("@search");
-
-        getSearchBar().should("have.value", "orders");
         cy.findByTestId("search-app").within(() => {
           cy.findByText('Results for "orders"').should("exist");
         });
@@ -158,8 +156,6 @@ describe("scenarios > search", () => {
           cy.visit(`/search?q=e&type=${type}`);
           cy.wait("@search");
 
-          getSearchBar().should("have.value", "e");
-
           cy.findByTestId("search-app").within(() => {
             cy.findByText('Results for "e"').should("exist");
           });
@@ -180,7 +176,7 @@ describe("scenarios > search", () => {
         it(`should filter results by ${label}`, () => {
           cy.visit("/");
 
-          getSearchBar().clear().type("e{enter}");
+          commandPaletteSearch("e");
           cy.wait("@search");
 
           cy.findByTestId("type-search-filter").click();
@@ -268,8 +264,7 @@ describe("scenarios > search", () => {
       it("should filter results by one user", () => {
         cy.visit("/");
 
-        getSearchBar().clear();
-        getSearchBar().type("reviews{enter}");
+        commandPaletteSearch("reviews");
         cy.wait("@search");
 
         expectSearchResultItemNameContent({
@@ -302,7 +297,7 @@ describe("scenarios > search", () => {
       it("should filter results by more than one user", () => {
         cy.visit("/");
 
-        getSearchBar().clear().type("reviews{enter}");
+        commandPaletteSearch("reviews");
         cy.wait("@search");
 
         expectSearchResultItemNameContent({
@@ -406,8 +401,7 @@ describe("scenarios > search", () => {
           cy.signIn(userType);
           cy.visit("/");
 
-          getSearchBar().clear();
-          getSearchBar().type("reviews{enter}");
+          commandPaletteSearch("reviews");
           cy.wait("@search");
 
           expectSearchResultItemNameContent(
@@ -504,7 +498,7 @@ describe("scenarios > search", () => {
       it("should filter last_edited results by one user", () => {
         cy.visit("/");
 
-        getSearchBar().clear().type("reviews{enter}");
+        commandPaletteSearch("reviews");
         cy.wait("@search");
 
         cy.findByTestId("last_edited_by-search-filter").click();
@@ -537,7 +531,7 @@ describe("scenarios > search", () => {
       it("should filter last_edited results by more than user", () => {
         cy.visit("/");
 
-        getSearchBar().clear().type("reviews{enter}");
+        commandPaletteSearch("reviews");
         cy.wait("@search");
 
         cy.findByTestId("last_edited_by-search-filter").click();
@@ -654,8 +648,7 @@ describe("scenarios > search", () => {
           cy.signIn(userType);
           cy.visit("/");
 
-          getSearchBar().clear();
-          getSearchBar().type("reviews{enter}");
+          commandPaletteSearch("reviews");
           cy.wait("@search");
 
           expectSearchResultItemNameContent(
@@ -888,8 +881,6 @@ describe("scenarios > search", () => {
         cy.visit("/search?q=orders&verified=true");
         cy.wait("@search");
 
-        getSearchBar().should("have.value", "orders");
-
         cy.findByTestId("search-app").within(() => {
           cy.findByText('Results for "orders"').should("exist");
         });
@@ -904,7 +895,7 @@ describe("scenarios > search", () => {
       it("should filter results by verified items", () => {
         cy.visit("/");
 
-        getSearchBar().clear().type("e{enter}");
+        commandPaletteSearch("e");
         cy.wait("@search");
 
         cy.findByTestId("verified-search-filter")
@@ -970,8 +961,6 @@ describe("scenarios > search", () => {
           `/search?q=${TEST_NATIVE_QUESTION_NAME}&search_native_query=true`,
         );
         cy.wait("@search");
-
-        getSearchBar().should("have.value", TEST_NATIVE_QUESTION_NAME);
 
         cy.findByTestId("search-app").within(() => {
           cy.findByText(`Results for "${TEST_NATIVE_QUESTION_NAME}"`).should(
@@ -1055,7 +1044,8 @@ describe("scenarios > search", () => {
         ],
       });
 
-      getSearchBar().clear().type("count{enter}");
+      //getSearchBar().clear().type("count{enter}");
+      commandPaletteSearch("count");
 
       expectSearchResultItemNameContent({
         itemNames: [

--- a/e2e/test/scenarios/onboarding/search/search-pagination.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/search-pagination.cy.spec.js
@@ -1,7 +1,12 @@
 import _ from "underscore";
 
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { restore } from "e2e/support/helpers";
+import {
+  commandPaletteSearch,
+  getSearchBar,
+  restore,
+  visitFullAppEmbeddingUrl,
+} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
@@ -18,15 +23,15 @@ describe("scenarios > search", () => {
     cy.intercept("/api/search", req => {
       expect("Unexpected call to /api/search").to.be.false;
     });
-    cy.visit("/");
-    cy.findByPlaceholderText("Search…").type(" ");
+    visitFullAppEmbeddingUrl({ url: "/", qs: { top_nav: true, search: true } });
+    getSearchBar().type(" ");
   });
 
   it("should allow users to paginate results", () => {
     generateQuestions(TOTAL_ITEMS);
 
     cy.visit("/");
-    cy.findByPlaceholderText("Search…").type("generated_question{enter}");
+    commandPaletteSearch("generated_question");
     cy.findByLabelText("Previous page").should("be.disabled");
 
     // First page

--- a/e2e/test/scenarios/onboarding/search/search-snowplow.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/search-snowplow.cy.spec.js
@@ -1,10 +1,10 @@
 import {
+  commandPaletteSearch,
   describeEE,
   describeWithSnowplow,
   enableTracking,
   expectGoodSnowplowEvent,
   expectNoBadSnowplowEvents,
-  getSearchBar,
   popover,
   resetSnowplow,
   restore,
@@ -28,7 +28,7 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
 
   it("should send snowplow events for global search queries", () => {
     cy.visit("/");
-    getSearchBar().type("Orders").blur();
+    commandPaletteSearch("Orders", false);
     expectGoodSnowplowEvent({ event: NEW_SEARCH_QUERY_EVENT_NAME }, 1);
   });
 

--- a/e2e/test/scenarios/onboarding/search/search-typeahead.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/search-typeahead.cy.spec.js
@@ -6,7 +6,6 @@ import { restore, visitFullAppEmbeddingUrl } from "e2e/support/helpers";
     beforeEach(() => {
       restore();
       cy.signIn(user);
-      // cy.visit("/");
       visitFullAppEmbeddingUrl({
         url: "/",
         qs: { top_nav: true, search: true },

--- a/e2e/test/scenarios/onboarding/search/search-typeahead.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/search-typeahead.cy.spec.js
@@ -1,12 +1,16 @@
 import { USERS } from "e2e/support/cypress_data";
-import { restore } from "e2e/support/helpers";
+import { restore, visitFullAppEmbeddingUrl } from "e2e/support/helpers";
 
 ["admin", "normal"].forEach(user => {
   describe(`search > ${user} user`, () => {
     beforeEach(() => {
       restore();
       cy.signIn(user);
-      cy.visit("/");
+      // cy.visit("/");
+      visitFullAppEmbeddingUrl({
+        url: "/",
+        qs: { top_nav: true, search: true },
+      });
     });
 
     // There was no issue for this, but it was implemented in pull request #15614

--- a/e2e/test/scenarios/onboarding/search/search.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/search.cy.spec.js
@@ -9,9 +9,20 @@ import {
   getSearchBar,
   main,
   restore,
+  visitFullAppEmbeddingUrl,
 } from "e2e/support/helpers";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
+
+const visitEmbeddingWithSearch = (url = "/") => {
+  visitFullAppEmbeddingUrl({
+    url: url,
+    qs: {
+      top_nav: true,
+      search: true,
+    },
+  });
+};
 
 describe("scenarios > search", () => {
   beforeEach(() => {
@@ -22,7 +33,7 @@ describe("scenarios > search", () => {
 
   describe("universal search", () => {
     it("should work for admin (metabase#20018)", () => {
-      cy.visit("/");
+      visitEmbeddingWithSearch("/");
       getSearchBar().as("searchBox").clear().type("orders count").blur();
 
       expectSearchResultContent({
@@ -68,7 +79,7 @@ describe("scenarios > search", () => {
 
     it("should work for user with permissions (metabase#12332)", () => {
       cy.signInAsNormalUser();
-      cy.visit("/");
+      visitEmbeddingWithSearch("/");
       getSearchBar().type("product{enter}");
       cy.wait("@search");
       cy.findByTestId("search-app").within(() => {
@@ -78,7 +89,7 @@ describe("scenarios > search", () => {
 
     it("should work for user without data permissions (metabase#16855)", () => {
       cy.signIn("nodata");
-      cy.visit("/");
+      visitEmbeddingWithSearch("/");
       getSearchBar().type("product{enter}");
       cy.wait("@search");
       cy.findByTestId("search-app").within(() => {
@@ -88,7 +99,7 @@ describe("scenarios > search", () => {
 
     it("allows to select a search result using keyboard", () => {
       cy.signInAsNormalUser();
-      cy.visit("/");
+      visitEmbeddingWithSearch("/");
       getSearchBar().type("ord");
 
       cy.wait("@search");
@@ -126,7 +137,7 @@ describe("scenarios > search", () => {
         Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. `,
       }).then(() => {
         cy.signInAsNormalUser();
-        cy.visit("/");
+        visitEmbeddingWithSearch("/");
         getSearchBar().type("Test");
       });
 
@@ -149,7 +160,7 @@ describe("scenarios > search", () => {
           "testingtestingtestingtestingtestingtestingtestingtesting testingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtesting testingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtesting",
       }).then(() => {
         cy.signInAsNormalUser();
-        cy.visit("/");
+        visitEmbeddingWithSearch("/");
         getSearchBar().type("Test");
       });
 
@@ -170,7 +181,7 @@ describe("scenarios > search", () => {
     });
 
     it("should not dismiss when a dashboard finishes loading (metabase#35009)", () => {
-      cy.visit(`/dashboard/${ORDERS_DASHBOARD_ID}`);
+      visitEmbeddingWithSearch(`/dashboard/${ORDERS_DASHBOARD_ID}`);
 
       // Type as soon as possible, before the dashboard has finished loading
       getSearchBar().type("ord");
@@ -198,7 +209,7 @@ describe("scenarios > search", () => {
           });
         },
       );
-      cy.visit("/");
+      visitEmbeddingWithSearch("/");
 
       // Type as soon as possible, before the dashboard has finished loading
       getSearchBar().type("ord");
@@ -214,7 +225,7 @@ describe("scenarios > search", () => {
     it("should not render full page search if user has not entered a text query", () => {
       cy.intercept("GET", "/api/activity/recent_views").as("getRecentViews");
 
-      cy.visit("/");
+      visitEmbeddingWithSearch("/");
 
       getSearchBar().click().type("{enter}");
 
@@ -227,7 +238,7 @@ describe("scenarios > search", () => {
     });
 
     it("should render full page search when search text is present and user clicks 'Enter'", () => {
-      cy.visit("/");
+      visitEmbeddingWithSearch("/");
 
       getSearchBar().click().type("orders{enter}");
       cy.wait("@search");

--- a/e2e/test/scenarios/organization/content-verification.cy.spec.js
+++ b/e2e/test/scenarios/organization/content-verification.cy.spec.js
@@ -7,6 +7,10 @@ import {
   questionInfoButton,
   setTokenFeatures,
   popover,
+  openCommandPalette,
+  commandPalette,
+  closeCommandPalette,
+  commandPaletteSearch,
 } from "e2e/support/helpers";
 
 describeEE("scenarios > premium > content verification", () => {
@@ -83,13 +87,14 @@ describeEE("scenarios > premium > content verification", () => {
         });
 
         // 3. Recently viewed list
-        cy.findByPlaceholderText("Search…").click();
-        cy.findByTestId("recently-viewed-item")
-          .should("contain", "Orders, Count")
+        openCommandPalette();
+        commandPalette()
+          .findByRole("option", { name: "Orders, Count" })
           .find(".Icon-verified_filled");
+        closeCommandPalette();
 
         // 4. Search results
-        cy.findByPlaceholderText("Search…").type("orders{enter}");
+        commandPaletteSearch("orders");
         cy.findAllByTestId("search-result-item")
           .contains("Orders, Count")
           .siblings(".Icon-verified_filled");
@@ -120,14 +125,15 @@ describeEE("scenarios > premium > content verification", () => {
         });
 
         // 3. Recently viewed list
-        cy.findByPlaceholderText("Search…").click();
-        cy.findByTestId("recently-viewed-item")
-          .should("contain", "Orders, Count")
-          .find(".Icon-verified_filed")
+        openCommandPalette();
+        commandPalette()
+          .findByRole("option", { name: "Orders, Count" })
+          .find(".Icon-verified_filled")
           .should("not.exist");
+        closeCommandPalette();
 
         // 4. Search results
-        cy.findByPlaceholderText("Search…").type("orders{enter}");
+        commandPaletteSearch("orders");
         cy.findAllByTestId("search-result-item")
           .contains("Orders, Count")
           .siblings(".Icon-verified_filed")
@@ -173,7 +179,7 @@ describeEE("scenarios > premium > content verification", () => {
           .findAllByText("A moderator verified this")
           .should("have.length", 2);
 
-        cy.findByPlaceholderText("Search…").type("orders{enter}");
+        commandPaletteSearch("orders");
         cy.log("Verified content should show up higher in search results");
         cy.findAllByTestId("search-result-item")
           .first()
@@ -217,7 +223,7 @@ describeEE("scenarios > premium > content verification", () => {
         cy.contains(/verified this/).should("not.exist");
       });
 
-      cy.findByPlaceholderText("Search…").type("orders{enter}");
+      commandPaletteSearch("orders");
       cy.log(
         "The question lost the verification status and does not appear high in search results anymore",
       );

--- a/e2e/test/scenarios/organization/official-collections.cy.spec.js
+++ b/e2e/test/scenarios/organization/official-collections.cy.spec.js
@@ -3,12 +3,12 @@ import {
   restore,
   describeEE,
   openNewCollectionItemFlowFor,
-  appBar,
   navigationSidebar,
   getCollectionActions,
   popover,
   openCollectionMenu,
   setTokenFeatures,
+  commandPaletteSearch,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -202,9 +202,11 @@ function testOfficialBadgeInSearch({
   question,
   expectBadge,
 }) {
-  appBar().findByPlaceholderText("Search…").as("searchBar").type(searchQuery);
+  // appBar().findByPlaceholderText("Search…").as("searchBar").type(searchQuery);
 
-  cy.findByTestId("search-results-list").within(() => {
+  commandPaletteSearch(searchQuery);
+
+  cy.findByTestId("search-app").within(() => {
     assertSearchResultBadge(collection, {
       expectBadge,
       selector: "[data-testid='search-result-item-name']",

--- a/e2e/test/scenarios/organization/official-collections.cy.spec.js
+++ b/e2e/test/scenarios/organization/official-collections.cy.spec.js
@@ -202,8 +202,6 @@ function testOfficialBadgeInSearch({
   question,
   expectBadge,
 }) {
-  // appBar().findByPlaceholderText("Search…").as("searchBar").type(searchQuery);
-
   commandPaletteSearch(searchQuery);
 
   cy.findByTestId("search-app").within(() => {

--- a/e2e/test/scenarios/permissions/reproductions/22695-search-databases-no-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/22695-search-databases-no-permissions.cy.spec.js
@@ -1,5 +1,10 @@
 import { USER_GROUPS, SAMPLE_DB_ID } from "e2e/support/cypress_data";
-import { restore, describeEE, setTokenFeatures } from "e2e/support/helpers";
+import {
+  restore,
+  describeEE,
+  setTokenFeatures,
+  commandPaletteSearch,
+} from "e2e/support/helpers";
 
 const { ALL_USERS_GROUP, DATA_GROUP } = USER_GROUPS;
 
@@ -40,7 +45,7 @@ describeEE("issue 22695 ", () => {
 function assert() {
   cy.visit("/");
 
-  cy.findByPlaceholderText("Search…").click().type("S");
+  commandPaletteSearch("S");
   cy.wait("@searchResults");
 
   cy.findAllByTestId("search-result-item-name")

--- a/e2e/test/scenarios/question/question-management.cy.spec.js
+++ b/e2e/test/scenarios/question/question-management.cy.spec.js
@@ -24,6 +24,8 @@ import {
   expectGoodSnowplowEvents,
   modal,
   entityPickerModal,
+  openCommandPalette,
+  commandPalette,
 } from "e2e/support/helpers";
 
 const PERMISSIONS = {
@@ -202,11 +204,12 @@ describe(
                 // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
                 cy.findByText("Orders").should("not.exist");
 
-                cy.findByPlaceholderText("Search…").click();
-                // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-                cy.findByText("Recently viewed");
-                // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-                cy.findByText("Nothing here");
+                openCommandPalette();
+                commandPalette().within(() => {
+                  cy.findByRole("option", { name: /recent/i }).should(
+                    "not.exist",
+                  );
+                });
 
                 // Check page for archived questions
                 cy.visit("/question/" + ORDERS_QUESTION_ID);

--- a/frontend/src/metabase-types/api/search.ts
+++ b/frontend/src/metabase-types/api/search.ts
@@ -126,7 +126,7 @@ export type SearchRequest = {
   table_db_id?: DatabaseId;
   models?: SearchModel[];
   filter_items_in_personal_collection?: "only" | "exclude";
-  context?: "search-bar" | "search-app";
+  context?: "search-bar" | "search-app" | "command-palette";
   created_at?: string | null;
   created_by?: UserId[] | null;
   last_edited_at?: string | null;

--- a/frontend/src/metabase/api/search.ts
+++ b/frontend/src/metabase/api/search.ts
@@ -6,10 +6,10 @@ import { provideSearchItemListTags } from "./tags";
 export const searchApi = Api.injectEndpoints({
   endpoints: builder => ({
     search: builder.query<SearchResponse, SearchRequest>({
-      query: ({ limit, offset, ...body }) => ({
+      query: ({ limit, offset, context, ...body }) => ({
         method: "GET",
         url: "/api/search",
-        params: { limit, offset },
+        params: { limit, offset, context },
         body,
       }),
       providesTags: (response, error, { models }) =>

--- a/frontend/src/metabase/nav/components/AppBar/AppBar.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBar.tsx
@@ -15,6 +15,7 @@ export interface AppBarProps {
   isNavBarEnabled?: boolean;
   isLogoVisible?: boolean;
   isSearchVisible?: boolean;
+  isEmbedded?: boolean;
   isNewButtonVisible?: boolean;
   isProfileLinkVisible?: boolean;
   isCollectionPathVisible?: boolean;

--- a/frontend/src/metabase/nav/components/AppBar/AppBar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBar.unit.spec.tsx
@@ -7,11 +7,15 @@ import AppBar from "./AppBar";
 
 const NewItemButtonMock = () => <div data-testid="new-button" />;
 const SearchBarMock = () => <div data-testid="search-bar" />;
+const SearchButtonMock = {
+  SearchButton: () => <div data-testid="search-button" />,
+};
 const BreadcrumbsMock = () => <div data-testid="collection-path" />;
 const QuestionLineageMock = () => <div data-testid="question-lineage" />;
 
 jest.mock("../NewItemButton", () => NewItemButtonMock);
 jest.mock("../search/SearchBar/SearchBar", () => SearchBarMock);
+jest.mock("../search/SearchButton/SearchButton", () => SearchButtonMock);
 jest.mock("../../containers/CollectionBreadcrumbs", () => BreadcrumbsMock);
 jest.mock("../../containers/QuestionLineage", () => QuestionLineageMock);
 
@@ -44,7 +48,7 @@ describe("AppBar", () => {
 
       expect(screen.getByTestId("main-logo")).toBeInTheDocument();
       expect(screen.getByTestId("sidebar-toggle")).toBeInTheDocument();
-      expect(screen.getByTestId("search-bar")).toBeInTheDocument();
+      expect(screen.getByTestId("search-button")).toBeInTheDocument();
       expect(screen.getByTestId("new-button")).toBeInTheDocument();
     });
 
@@ -70,6 +74,22 @@ describe("AppBar", () => {
       expect(screen.getByTestId("question-lineage")).toBeInTheDocument();
       expect(screen.queryByTestId("collection-path")).not.toBeInTheDocument();
     });
+
+    it("should render the search bar when embedded", () => {
+      const props = getProps({
+        isNavBarEnabled: true,
+        isCollectionPathVisible: true,
+        isSearchVisible: true,
+        isEmbedded: true,
+        isNewButtonVisible: true,
+        isLogoVisible: true,
+      });
+
+      render(<AppBar {...props} />);
+
+      expect(screen.getByTestId("search-bar")).toBeInTheDocument();
+      expect(screen.queryByTestId("search-button")).not.toBeInTheDocument();
+    });
   });
 
   describe("small screens", () => {
@@ -90,7 +110,7 @@ describe("AppBar", () => {
 
       expect(screen.getByTestId("main-logo")).toBeInTheDocument();
       expect(screen.getByTestId("sidebar-toggle")).toBeInTheDocument();
-      expect(screen.getByTestId("search-bar")).toBeInTheDocument();
+      expect(screen.getByTestId("search-button")).toBeInTheDocument();
       expect(screen.queryByTestId("new-button")).not.toBeInTheDocument();
     });
 
@@ -115,6 +135,22 @@ describe("AppBar", () => {
 
       expect(screen.getByTestId("question-lineage")).toBeInTheDocument();
       expect(screen.queryByTestId("collection-path")).not.toBeInTheDocument();
+    });
+
+    it("should render the search bar when embedded", () => {
+      const props = getProps({
+        isNavBarEnabled: true,
+        isCollectionPathVisible: true,
+        isSearchVisible: true,
+        isEmbedded: true,
+        isNewButtonVisible: true,
+        isLogoVisible: true,
+      });
+
+      render(<AppBar {...props} />);
+
+      expect(screen.getByTestId("search-bar")).toBeInTheDocument();
+      expect(screen.queryByTestId("search-button")).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/metabase/nav/components/AppBar/AppBarLarge.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLarge.tsx
@@ -5,6 +5,7 @@ import QuestionLineage from "../../containers/QuestionLineage";
 import NewItemButton from "../NewItemButton";
 import { ProfileLink } from "../ProfileLink";
 import { SearchBar } from "../search/SearchBar";
+import { SearchButton } from "../search/SearchButton";
 
 import {
   AppBarLeftContainer,
@@ -22,6 +23,7 @@ export interface AppBarLargeProps {
   isNavBarEnabled?: boolean;
   isLogoVisible?: boolean;
   isSearchVisible?: boolean;
+  isEmbedded?: boolean;
   isNewButtonVisible?: boolean;
   isProfileLinkVisible?: boolean;
   isCollectionPathVisible?: boolean;
@@ -36,6 +38,7 @@ const AppBarLarge = ({
   isNavBarEnabled,
   isLogoVisible,
   isSearchVisible,
+  isEmbedded,
   isNewButtonVisible,
   isProfileLinkVisible,
   isCollectionPathVisible,
@@ -69,7 +72,7 @@ const AppBarLarge = ({
       </AppBarLeftContainer>
       {(isSearchVisible || isNewButtonVisible || isProfileLinkVisible) && (
         <AppBarRightContainer>
-          {isSearchVisible && <SearchBar />}
+          {isSearchVisible && (isEmbedded ? <SearchBar /> : <SearchButton />)}
           {isNewButtonVisible && <NewItemButton collectionId={collectionId} />}
           {isProfileLinkVisible && (
             <AppBarProfileLinkContainer>

--- a/frontend/src/metabase/nav/components/AppBar/AppBarSmall.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarSmall.tsx
@@ -1,10 +1,12 @@
 import { useCallback, useState } from "react";
 
 import { SearchBar } from "metabase/nav/components/search/SearchBar";
+import { Flex } from "metabase/ui";
 
 import CollectionBreadcrumbs from "../../containers/CollectionBreadcrumbs";
 import QuestionLineage from "../../containers/QuestionLineage";
 import { ProfileLink } from "../ProfileLink";
+import { SearchButton } from "../search/SearchButton";
 
 import { AppBarLogo } from "./AppBarLogo";
 import {
@@ -24,6 +26,7 @@ export interface AppBarSmallProps {
   isNavBarEnabled?: boolean;
   isLogoVisible?: boolean;
   isSearchVisible?: boolean;
+  isEmbedded?: boolean;
   isProfileLinkVisible?: boolean;
   isCollectionPathVisible?: boolean;
   isQuestionLineageVisible?: boolean;
@@ -37,6 +40,7 @@ const AppBarSmall = ({
   isNavBarEnabled,
   isLogoVisible,
   isSearchVisible,
+  isEmbedded,
   isProfileLinkVisible,
   isCollectionPathVisible,
   isQuestionLineageVisible,
@@ -75,12 +79,17 @@ const AppBarSmall = ({
               />
             </AppBarToggleContainer>
             <AppBarSearchContainer>
-              {isSearchVisible && (
-                <SearchBar
-                  onSearchActive={handleSearchActive}
-                  onSearchInactive={handleSearchInactive}
-                />
-              )}
+              {isSearchVisible &&
+                (isEmbedded ? (
+                  <SearchBar
+                    onSearchActive={handleSearchActive}
+                    onSearchInactive={handleSearchInactive}
+                  />
+                ) : (
+                  <Flex justify="end">
+                    <SearchButton />
+                  </Flex>
+                ))}
             </AppBarSearchContainer>
             {isProfileLinkVisible && (
               <AppBarProfileLinkContainer>

--- a/frontend/src/metabase/nav/containers/AppBar/AppBar.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar/AppBar.tsx
@@ -16,6 +16,7 @@ import {
   getIsQuestionLineageVisible,
   getIsSearchVisible,
 } from "metabase/selectors/app";
+import { getIsEmbedded } from "metabase/selectors/embed";
 import { getUser } from "metabase/selectors/user";
 import type { State } from "metabase-types/store";
 
@@ -28,6 +29,7 @@ const mapStateToProps = (state: State, props: RouterProps) => ({
   isNavBarEnabled: getIsNavBarEnabled(state, props),
   isLogoVisible: getIsLogoVisible(state),
   isSearchVisible: getIsSearchVisible(state),
+  isEmbedded: getIsEmbedded(state),
   isNewButtonVisible: getIsNewButtonVisible(state),
   isProfileLinkVisible: getIsProfileLinkVisible(state),
   isCollectionPathVisible: getIsCollectionPathVisible(state, props),

--- a/frontend/src/metabase/palette/components/PaletteResults.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResults.tsx
@@ -1,5 +1,7 @@
+import type { Location } from "history";
 import { useKBar, useMatches } from "kbar";
 import { useMemo, useEffect } from "react";
+import { withRouter } from "react-router";
 import { useKeyPressEvent } from "react-use";
 import { t } from "ttag";
 import _ from "underscore";
@@ -16,91 +18,93 @@ import { PaletteResultList } from "./PaletteResultsList";
 
 const PAGE_SIZE = 4;
 
-export const PaletteResults = () => {
-  // Used for finding actions within the list
-  const { query } = useKBar();
+export const PaletteResults = withRouter(
+  ({ location }: { location: Location }) => {
+    // Used for finding actions within the list
+    const { query } = useKBar();
 
-  useCommandPalette();
+    useCommandPalette({ locationQuery: location.query });
 
-  const { results } = useMatches();
+    const { results } = useMatches();
 
-  const processedResults = useMemo(
-    () => processResults(results as (PaletteActionImpl | string)[]),
-    [results],
-  );
-
-  useEffect(() => {
-    if (processedResults[0] === t`Search results`) {
-      query.setActiveIndex(2);
-    }
-  }, [processedResults, query]);
-
-  useKeyPressEvent("End", () => {
-    const lastIndex = processedResults.length - 1;
-    query.setActiveIndex(lastIndex);
-  });
-
-  useKeyPressEvent("Home", () => {
-    query.setActiveIndex(1);
-  });
-
-  useKeyPressEvent("PageDown", () => {
-    query.setActiveIndex(i =>
-      findClosestActionIndex(processedResults, i, PAGE_SIZE),
+    const processedResults = useMemo(
+      () => processResults(results as (PaletteActionImpl | string)[]),
+      [results],
     );
-  });
 
-  useKeyPressEvent("PageUp", () => {
-    query.setActiveIndex(i =>
-      findClosestActionIndex(processedResults, i, -PAGE_SIZE),
+    useEffect(() => {
+      if (processedResults[0] === t`Search results`) {
+        query.setActiveIndex(2);
+      }
+    }, [processedResults, query]);
+
+    useKeyPressEvent("End", () => {
+      const lastIndex = processedResults.length - 1;
+      query.setActiveIndex(lastIndex);
+    });
+
+    useKeyPressEvent("Home", () => {
+      query.setActiveIndex(1);
+    });
+
+    useKeyPressEvent("PageDown", () => {
+      query.setActiveIndex(i =>
+        findClosestActionIndex(processedResults, i, PAGE_SIZE),
+      );
+    });
+
+    useKeyPressEvent("PageUp", () => {
+      query.setActiveIndex(i =>
+        findClosestActionIndex(processedResults, i, -PAGE_SIZE),
+      );
+    });
+
+    return (
+      <Flex align="stretch" direction="column" p="0.75rem 0">
+        <PaletteResultList
+          items={processedResults} // items needs to be a stable reference, otherwise the activeIndex will constantly be hijacked
+          maxHeight={530}
+          onRender={({
+            item,
+            active,
+          }: {
+            item: string | PaletteActionImpl;
+            active: boolean;
+          }) => {
+            const isFirst = processedResults[0] === item;
+
+            return (
+              <Flex lh="1rem" pb="2px">
+                {typeof item === "string" ? (
+                  <Box
+                    px="1.5rem"
+                    fz="14px"
+                    pt="1rem"
+                    pb="0.5rem"
+                    style={
+                      isFirst
+                        ? undefined
+                        : {
+                            borderTop: `1px solid ${color("border")}`,
+                            marginTop: "1rem",
+                          }
+                    }
+                    w="100%"
+                  >
+                    {item}
+                  </Box>
+                ) : (
+                  <PaletteResultItem
+                    item={item}
+                    active={active}
+                    togglePalette={query.toggle}
+                  />
+                )}
+              </Flex>
+            );
+          }}
+        />
+      </Flex>
     );
-  });
-
-  return (
-    <Flex align="stretch" direction="column" p="0.75rem 0">
-      <PaletteResultList
-        items={processedResults} // items needs to be a stable reference, otherwise the activeIndex will constantly be hijacked
-        maxHeight={530}
-        onRender={({
-          item,
-          active,
-        }: {
-          item: string | PaletteActionImpl;
-          active: boolean;
-        }) => {
-          const isFirst = processedResults[0] === item;
-
-          return (
-            <Flex lh="1rem" pb="2px">
-              {typeof item === "string" ? (
-                <Box
-                  px="1.5rem"
-                  fz="14px"
-                  pt="1rem"
-                  pb="0.5rem"
-                  style={
-                    isFirst
-                      ? undefined
-                      : {
-                          borderTop: `1px solid ${color("border")}`,
-                          marginTop: "1rem",
-                        }
-                  }
-                  w="100%"
-                >
-                  {item}
-                </Box>
-              ) : (
-                <PaletteResultItem
-                  item={item}
-                  active={active}
-                  togglePalette={query.toggle}
-                />
-              )}
-            </Flex>
-          );
-        }}
-      />
-    </Flex>
-  );
-};
+  },
+);

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -60,6 +60,7 @@ export const useCommandPalette = ({
   } = useSearchQuery(
     {
       q: debouncedSearchText,
+      context: "command-palette",
       limit: 20,
     },
     {

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -1,3 +1,4 @@
+import type { Query } from "history";
 import { useRegisterActions, useKBar, Priority } from "kbar";
 import { useMemo, useState } from "react";
 import { push } from "react-router-redux";
@@ -24,7 +25,11 @@ import { getShowMetabaseLinks } from "metabase/selectors/whitelabel";
 import type { PaletteAction } from "../types";
 import { filterRecentItems } from "../utils";
 
-export const useCommandPalette = () => {
+export const useCommandPalette = ({
+  locationQuery,
+}: {
+  locationQuery: Query;
+}) => {
   const dispatch = useDispatch();
   const docsUrl = useSelector(state => getDocsUrl(state, {}));
   const showMetabaseLinks = useSelector(getShowMetabaseLinks);
@@ -123,6 +128,13 @@ export const useCommandPalette = () => {
       ];
     } else if (debouncedSearchText) {
       if (searchResults?.data.length) {
+        const searchLocation = {
+          pathname: "search",
+          query: {
+            ...locationQuery,
+            q: debouncedSearchText,
+          },
+        };
         return [
           {
             id: `search-results-metadata`,
@@ -131,23 +143,11 @@ export const useCommandPalette = () => {
             keywords: debouncedSearchText,
             icon: "link" as const,
             perform: () => {
-              dispatch(
-                push({
-                  pathname: "search",
-                  query: {
-                    q: debouncedSearchText,
-                  },
-                }),
-              );
+              dispatch(push(searchLocation));
             },
             priority: Priority.HIGH,
             extra: {
-              href: {
-                pathname: "search",
-                query: {
-                  q: debouncedSearchText,
-                },
-              },
+              href: searchLocation,
             },
           },
         ].concat(
@@ -192,6 +192,7 @@ export const useCommandPalette = () => {
     isSearchLoading,
     searchError,
     searchResults,
+    locationQuery,
   ]);
 
   useRegisterActions(searchResultActions, [searchResultActions]);

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -650,7 +650,7 @@
    table_db_id                         [:maybe ms/PositiveInt]
    models                              [:maybe (ms/QueryVectorOf SearchableModel)]
    filter_items_in_personal_collection [:maybe [:enum "only" "exclude"]]
-   context                             [:maybe [:enum "search-bar" "search-app"]]
+   context                             [:maybe [:enum "search-bar" "search-app" "command-palette"]]
    created_at                          [:maybe ms/NonBlankString]
    created_by                          [:maybe (ms/QueryVectorOf ms/PositiveInt)]
    last_edited_at                      [:maybe ms/NonBlankString]
@@ -682,7 +682,7 @@
         has-advanced-filters (some some?
                                    [models created_by created_at last_edited_by
                                     last_edited_at search_native_query verified])]
-    (when (contains? #{"search-app" "search-bar"} context)
+    (when (contains? #{"search-app" "search-bar" "command-palette"} context)
       (snowplow/track-event! ::snowplow/new-search-query api/*current-user-id*
                              {:runtime-milliseconds duration
                               :context              context})


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/42346

### Description
PR swaps out the search bar for a button in the `AppBar` component when we are not embedded. Button should toggle the command palette. Tests were updated to either
1) Test in embedding mode when we were testing functionality of the floating search results or
2) Perform the search via the command palette

### How to verify
1. click the Search button on the top of the screen. It should open the command palette
2. should also work in mobile view
3. test that embedding still shows original search bar

### Demo
![chrome_bFHMwf0qUl](https://github.com/metabase/metabase/assets/1328979/0d900f03-6616-42ea-ada3-ee0b1d171a33)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
