### PR TITLE
(3/n) update legend for other series grouping

### DIFF
--- a/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.tsx
+++ b/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.tsx
@@ -47,7 +47,10 @@ export const ComboChart = ({
     renderingContext,
   );
 
-  const legendItems = getLegendItems(chartModel.seriesModels);
+  const legendItems = getLegendItems(
+    chartModel.seriesModels,
+    chartModel.otherSeriesModel,
+  );
   const isReversed = computedVisualizationSettings["legend.is_reversed"];
   const { height: legendHeight, items: legendLayoutItems } =
     calculateLegendRows({

--- a/frontend/src/metabase/static-viz/components/ScatterPlot/ScatterPlot.tsx
+++ b/frontend/src/metabase/static-viz/components/ScatterPlot/ScatterPlot.tsx
@@ -41,7 +41,10 @@ export function ScatterPlot({
     renderingContext,
   );
 
-  const legendItems = getLegendItems(chartModel.seriesModels);
+  const legendItems = getLegendItems(
+    chartModel.seriesModels,
+    chartModel.otherSeriesModel,
+  );
   const { height: legendHeight, items: legendLayoutItems } =
     calculateLegendRows({
       items: legendItems,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/guards.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/guards.ts
@@ -1,8 +1,8 @@
 import type {
+  BaseSeriesModel,
   BreakoutSeriesModel,
   CategoryXAxisModel,
   NumericXAxisModel,
-  SeriesModel,
   TimeSeriesInterval,
   TimeSeriesXAxisModel,
   XAxisModel,
@@ -27,7 +27,7 @@ export const isCategoryAxis = (
 };
 
 export const isBreakoutSeries = (
-  seriesModel: SeriesModel,
+  seriesModel: BaseSeriesModel,
 ): seriesModel is BreakoutSeriesModel => {
   return "breakoutColumn" in seriesModel;
 };

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/legend.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/legend.ts
@@ -1,19 +1,27 @@
 import { isBreakoutSeries } from "./guards";
-import type { LegendItem, SeriesModel } from "./types";
+import type { LegendItem, OtherSeriesModel, SeriesModel } from "./types";
 
 export const getLegendItems = (
   seriesModels: SeriesModel[],
-  showAllLegendItems: boolean = false,
+  otherSeriesModel?: OtherSeriesModel,
+  showAllLegendItems?: boolean,
 ): LegendItem[] => {
+  const legendSeriesModels: (SeriesModel | OtherSeriesModel)[] = [
+    ...seriesModels,
+  ];
+  if (otherSeriesModel) {
+    legendSeriesModels.push(otherSeriesModel);
+  }
+
   if (
-    seriesModels.length === 1 &&
-    !isBreakoutSeries(seriesModels[0]) &&
+    legendSeriesModels.length === 1 &&
+    !isBreakoutSeries(legendSeriesModels[0]) &&
     !showAllLegendItems
   ) {
     return [];
   }
 
-  return seriesModels.map(seriesModel => ({
+  return legendSeriesModels.map(seriesModel => ({
     key: seriesModel.dataKey,
     name: seriesModel.name,
     color: seriesModel.color,

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
@@ -61,7 +61,12 @@ function _CartesianChart(props: VisualizationProps) {
   const description = settings["card.description"];
 
   const legendItems = useMemo(
-    () => getLegendItems(chartModel.seriesModels, showAllLegendItems),
+    () =>
+      getLegendItems(
+        chartModel.seriesModels,
+        chartModel.otherSeriesModel,
+        showAllLegendItems,
+      ),
     [chartModel, showAllLegendItems],
   );
   const hasLegend = legendItems.length > 0;

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
@@ -207,6 +207,7 @@ export const useChartEvents = (
 
       const hoveredEChartsSeriesIndex = getHoveredEChartsSeriesIndex(
         chartModel.seriesModels,
+        chartModel.otherSeriesModel,
         option,
         hovered,
       );
@@ -247,6 +248,7 @@ export const useChartEvents = (
     },
     [
       chartModel.seriesModels,
+      chartModel.otherSeriesModel,
       chartModel.transformedDataset,
       chartRef,
       hovered,

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-models-and-option.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-models-and-option.ts
@@ -108,8 +108,13 @@ export function useModelsAndOption({
   );
 
   const hoveredSeriesDataKey = useMemo(
-    () => getHoveredSeriesDataKey(chartModel.seriesModels, hovered),
-    [chartModel.seriesModels, hovered],
+    () =>
+      getHoveredSeriesDataKey(
+        chartModel.seriesModels,
+        chartModel.otherSeriesModel,
+        hovered,
+      ),
+    [chartModel.seriesModels, chartModel.otherSeriesModel, hovered],
   );
 
   const option = useMemo(() => {

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/utils.ts
@@ -2,9 +2,11 @@ import type { EChartsCoreOption } from "echarts/core";
 import { t } from "ttag";
 
 import { isNotNull } from "metabase/lib/types";
+import { OTHER_DATA_KEY } from "metabase/visualizations/echarts/cartesian/constants/dataset";
 import type {
   BaseCartesianChartModel,
   DataKey,
+  OtherSeriesModel,
   SeriesModel,
 } from "metabase/visualizations/echarts/cartesian/model/types";
 import type {
@@ -67,11 +69,15 @@ export const validateChartModel = (chartModel: BaseCartesianChartModel) => {
 
 export const getHoveredSeriesDataKey = (
   seriesModels: SeriesModel[],
+  otherSeriesModel: OtherSeriesModel | undefined,
   hovered: HoveredObject | undefined,
 ): DataKey | null => {
   const seriesIndex = hovered?.index;
   if (seriesIndex == null) {
     return null;
+  }
+  if (seriesIndex >= seriesModels.length && otherSeriesModel) {
+    return OTHER_DATA_KEY;
   }
 
   return seriesModels[seriesIndex]?.dataKey ?? null;
@@ -79,17 +85,22 @@ export const getHoveredSeriesDataKey = (
 
 export const getHoveredEChartsSeriesIndex = (
   seriesModels: SeriesModel[],
+  otherSeriesModel: OtherSeriesModel | undefined,
   option: EChartsCoreOption,
   hovered: HoveredObject | undefined,
 ): number | null => {
-  const hoveredSeriesDataKey = getHoveredSeriesDataKey(seriesModels, hovered);
+  const hoveredSeriesDataKey = getHoveredSeriesDataKey(
+    seriesModels,
+    otherSeriesModel,
+    hovered,
+  );
 
   const seriesOptions = Array.isArray(option?.series)
     ? option?.series
     : [option?.series].filter(isNotNull);
 
-  // ECharts series contain goal line, trend lines, and timeline events so the series index
-  // is different from one in chartModel.seriesModels
+  // ECharts series contain goal line, trend lines, timeline events, so the
+  // series index is different from one in chartModel.seriesModels
   const eChartsSeriesIndex = seriesOptions.findIndex(
     series => series.id === hoveredSeriesDataKey,
   );


### PR DESCRIPTION
Part of https://github.com/metabase/metabase/issues/41986

### Description

Updates the legend to correctly display the other series, and to highlight it upon hover.

Note that the click actions menu for breakouts on the other series hasn't been implemented yet, I'll revisit that in a later PR.

### How to verify

![Screenshot 2024-05-13 at 6.25.20 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/9138f428-1bbe-407e-a304-b458e1cb46c9.png)

![Screenshot 2024-05-13 at 6.30.35 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/28890474-be74-4cb7-aaf3-0e1d9c39a4b1.png)
