### PR TITLE
Fix migration fail with encryption key

### DIFF
--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -22,9 +22,9 @@
    [medley.core :as m]
    [metabase.config :as config]
    [metabase.db.connection :as mdb.connection]
-   [metabase.models.interface :as mi]
    [metabase.plugins.classloader :as classloader]
    [metabase.util.date-2 :as u.date]
+   [metabase.util.encryption :as encryption]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.log :as log]
    [toucan2.core :as t2]
@@ -104,6 +104,38 @@
   ^String [s]
   (when s
     (.toLowerCase (str s) Locale/US)))
+
+(defn json-in
+  "Default in function for columns given a Toucan type `:json`. Serializes object as JSON."
+  [obj]
+  (if (string? obj)
+    obj
+    (json/generate-string obj)))
+
+(defn- json-out [s keywordize-keys?]
+  (if (string? s)
+    (try
+      (json/parse-string s keywordize-keys?)
+      (catch Throwable e
+        (log/error e "Error parsing JSON")
+        s))
+    s))
+
+(def ^:private encrypted-json-in
+  (comp encryption/maybe-encrypt json-in))
+
+(defn- encrypted-json-out
+  [v]
+  (let [decrypted (encryption/maybe-decrypt v)]
+    (try
+      (json/parse-string decrypted true)
+      (catch Throwable e
+        (if (or (encryption/possibly-encrypted-string? decrypted)
+                (encryption/possibly-encrypted-bytes? decrypted))
+          (log/error e "Could not decrypt encrypted field! Have you forgot to set MB_ENCRYPTION_SECRET_KEY?")
+          (log/error e "Error parsing JSON"))  ; same message as in `json-out`
+        v))))
+
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                  MIGRATIONS                                                    |
@@ -716,9 +748,9 @@
 
 (define-reversible-migration MigrateDatabaseOptionsToSettings
   (let [update-one! (fn [{:keys [id settings options]}]
-                      (let [settings     (mi/encrypted-json-out settings)
-                            options      (mi/json-out-with-keywordization options)
-                            new-settings (mi/encrypted-json-in (merge settings options))]
+                      (let [settings     (encrypted-json-out settings)
+                            options      (json-out options true)
+                            new-settings (encrypted-json-in (merge settings options))]
                         (t2/query {:update :metabase_database
                                    :set    {:settings new-settings}
                                    :where  [:= :id id]})))]
@@ -729,12 +761,12 @@
                                                     [:not= :options "{}"]
                                                     [:not= :options nil]]})))
   (let [rollback-one! (fn [{:keys [id settings options]}]
-                        (let [settings (mi/encrypted-json-out settings)
-                              options  (mi/json-out-with-keywordization options)]
+                        (let [settings (encrypted-json-out settings)
+                              options  (json-out options true)]
                           (when (some? (:persist-models-enabled settings))
                             (t2/query {:update :metabase_database
                                        :set    {:options (json/generate-string (select-keys settings [:persist-models-enabled]))
-                                                :settings (mi/encrypted-json-in (dissoc settings :persist-models-enabled))}
+                                                :settings (encrypted-json-in (dissoc settings :persist-models-enabled))}
                                        :where  [:= :id id]}))))]
     (run! rollback-one! (t2/reducible-query {:select [:id :settings :options]
                                              :from   [:metabase_database]}))))
@@ -1080,7 +1112,7 @@
   ;; this migraiton to remove triggers for any existing DB that have this option on.
   ;; See #40715
   (when-let [;; find all dbs which are configured not to scan field values
-             dbs (seq (filter #(and (-> % :details (json/parse-string keyword) :let-user-control-scheduling)
+             dbs (seq (filter #(and (-> % :details encrypted-json-out :let-user-control-scheduling)
                                     (false? (:is_full_sync %)))
                               (t2/select :metabase_database)))]
     (classloader/the-classloader)

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -122,9 +122,11 @@
     s))
 
 (def ^:private encrypted-json-in
+  "Should mirror [[metabase.models.interface/encrypted-json-in]]"
   (comp encryption/maybe-encrypt json-in))
 
 (defn- encrypted-json-out
+  "Should mirror [[metabase.models.interface/encrypted-json-out]]"
   [v]
   (let [decrypted (encryption/maybe-decrypt v)]
     (try
@@ -135,7 +137,6 @@
           (log/error e "Could not decrypt encrypted field! Have you forgot to set MB_ENCRYPTION_SECRET_KEY?")
           (log/error e "Error parsing JSON"))  ; same message as in `json-out`
         v))))
-
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                  MIGRATIONS                                                    |

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -13,7 +13,6 @@
    [clojurewerkz.quartzite.triggers :as triggers]
    [medley.core :as m]
    [metabase.api.database-test :as api.database-test]
-   [metabase.config :as config]
    [metabase.db :as mdb]
    [metabase.db.custom-migrations :as custom-migrations]
    [metabase.db.schema-migrations-test.impl :as impl]
@@ -1706,6 +1705,6 @@
           (migrate!)
           (is (true? (encryption/possibly-encrypted-string? (db-detail)))))
 
-        (migrate! :down (dec (config/current-major-version)))
+        (migrate! :down 48)
         (testing "after migrate down, db details should still be encrypted"
           (is (true? (encryption/possibly-encrypted-string? (db-detail)))))))))

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -1683,7 +1683,7 @@
                         (is (nil? (:cache_field_values_schedule db))))))))]
         (testing "without encryption key"
           (do-test))
-        (testing "without encryption key"
+        (testing "with encryption key"
           (encryption-test/with-secret-key "dont-tell-anyone-about-this"
             (do-test)))))))
 

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -13,6 +13,7 @@
    [clojurewerkz.quartzite.triggers :as triggers]
    [medley.core :as m]
    [metabase.api.database-test :as api.database-test]
+   [metabase.config :as config]
    [metabase.db :as mdb]
    [metabase.db.custom-migrations :as custom-migrations]
    [metabase.db.schema-migrations-test.impl :as impl]
@@ -1637,46 +1638,74 @@
 (deftest delete-scan-field-values-trigger-test
   (testing "We should delete the triggers for DBs that are configured not to scan their field values\n"
     (impl/test-migrations "v49.2024-04-09T10:00:03" [migrate!]
-      (api.database-test/with-db-scheduler-setup
-        (let [db-with-full-schedules (new-instance-with-default :metabase_database
-                                                                {:metadata_sync_schedule      "0 0 * * * ? *"
-                                                                 :cache_field_values_schedule "0 0 1 * * ? *"
-                                                                 :is_full_sync                true
-                                                                 :is_on_demand                false})
-              db-manual-schedule     (new-instance-with-default :metabase_database
-                                                                {:details                     (json/generate-string {:let-user-control-scheduling true})
-                                                                 :is_full_sync                true
-                                                                 :is_on_demand                false
-                                                                 :metadata_sync_schedule      "0 0 * * * ? *"
-                                                                 :cache_field_values_schedule "0 0 2 * * ? *"})
-              db-on-demand           (new-instance-with-default :metabase_database
-                                                                {:details                     (json/generate-string {:let-user-control-scheduling true})
-                                                                 :is_full_sync                false
-                                                                 :is_on_demand                true
-                                                                 :metadata_sync_schedule      "0 0 * * * ? *"
-                                                                 :cache_field_values_schedule "0 0 2 * * ? *"})
-              db-never-scan          (new-instance-with-default :metabase_database
-                                                                {:details                     (json/generate-string {:let-user-control-scheduling true})
-                                                                 :is_full_sync                false
-                                                                 :is_on_demand                false
-                                                                 :metadata_sync_schedule      "0 0 * * * ? *"
-                                                                 :cache_field_values_schedule "0 0 2 * * ? *"})
-              db-with-scan-fv        [db-with-full-schedules db-manual-schedule]
-              db-without-scan-fv     [db-on-demand db-never-scan]]
-          (doseq [db (concat db-with-scan-fv db-without-scan-fv)]
-            (#'database/check-and-schedule-tasks-for-db! (t2/instance :model/Database db))
-            (testing "sanity check that the schedule exists"
-              (is (= (#'task.sync-databases-test/all-db-sync-triggers-name db)
-                     (#'task.sync-databases-test/query-all-db-sync-triggers-name db)))))
+      (letfn [(do-test []
+                (api.database-test/with-db-scheduler-setup
+                  (let [db-with-full-schedules (new-instance-with-default :metabase_database
+                                                                          {:metadata_sync_schedule      "0 0 * * * ? *"
+                                                                           :cache_field_values_schedule "0 0 1 * * ? *"
+                                                                           :is_full_sync                true
+                                                                           :is_on_demand                false})
+                        db-manual-schedule     (new-instance-with-default :metabase_database
+                                                                          {:details                     (json/generate-string {:let-user-control-scheduling true})
+                                                                           :is_full_sync                true
+                                                                           :is_on_demand                false
+                                                                           :metadata_sync_schedule      "0 0 * * * ? *"
+                                                                           :cache_field_values_schedule "0 0 2 * * ? *"})
+                        db-on-demand           (new-instance-with-default :metabase_database
+                                                                          {:details                     (json/generate-string {:let-user-control-scheduling true})
+                                                                           :is_full_sync                false
+                                                                           :is_on_demand                true
+                                                                           :metadata_sync_schedule      "0 0 * * * ? *"
+                                                                           :cache_field_values_schedule "0 0 2 * * ? *"})
+                        db-never-scan          (new-instance-with-default :metabase_database
+                                                                          {:details                     (json/generate-string {:let-user-control-scheduling true})
+                                                                           :is_full_sync                false
+                                                                           :is_on_demand                false
+                                                                           :metadata_sync_schedule      "0 0 * * * ? *"
+                                                                           :cache_field_values_schedule "0 0 2 * * ? *"})
+                        db-with-scan-fv        [db-with-full-schedules db-manual-schedule]
+                        db-without-scan-fv     [db-on-demand db-never-scan]]
+                    (doseq [db (concat db-with-scan-fv db-without-scan-fv)]
+                      (#'database/check-and-schedule-tasks-for-db! (t2/instance :model/Database db))
+                      (testing "sanity check that the schedule exists"
+                        (is (= (#'task.sync-databases-test/all-db-sync-triggers-name db)
+                               (#'task.sync-databases-test/query-all-db-sync-triggers-name db)))))
 
+                    (migrate!)
+                    (testing "default options and scan with manual schedules should have scan field values"
+                      (doseq [db db-with-scan-fv]
+                        (is (= (#'task.sync-databases-test/all-db-sync-triggers-name db)
+                               (#'task.sync-databases-test/query-all-db-sync-triggers-name db)))))
+
+                    (testing "never scan and on demand should not have scan field values"
+                      (doseq [db (t2/select :model/Database :id [:in (map :id db-without-scan-fv)])]
+                        (is (= #{(#'api.database-test/sync-and-analyze-trigger-name db)}
+                               (#'task.sync-databases-test/query-all-db-sync-triggers-name db)))
+                        (is (nil? (:cache_field_values_schedule db))))))))]
+        (testing "without encryption key"
+          (do-test))
+        (testing "without encryption key"
+          (encryption-test/with-secret-key "dont-tell-anyone-about-this"
+            (do-test)))))))
+
+(deftest migration-works-when-have-encryption-key-test
+  ;; this test is here to warn developers that they should test their migrations with and without encryption key
+  (encryption-test/with-secret-key "dont-tell-anyone-about-this"
+    ;; run migration to the latest migration
+    (impl/test-migrations ["v49.2024-04-09T10:00:03"] [migrate!]
+      ;; create a db because db.details should be encrypted
+      (let [db-id     (:id (new-instance-with-default :metabase_database {:details (encryption/maybe-encrypt "{}")}))
+            db-detail (fn []
+                        (:details (t2/query-one {:select [:details]
+                                                 :from   [:metabase_database]
+                                                 :where  [:= :id db-id]})))]
+        (testing "sanity check that db details is encrypted"
+          (is (true? (encryption/possibly-encrypted-string? (db-detail)))))
+
+        (testing "after migrate up, db details should still be encrypted"
           (migrate!)
-          (testing "default options and scan with manual schedules should have scan field values"
-            (doseq [db db-with-scan-fv]
-              (is (= (#'task.sync-databases-test/all-db-sync-triggers-name db)
-                     (#'task.sync-databases-test/query-all-db-sync-triggers-name db)))))
+          (is (true? (encryption/possibly-encrypted-string? (db-detail)))))
 
-          (testing "never scan and on demand should not have scan field values"
-            (doseq [db (t2/select :model/Database :id [:in (map :id db-without-scan-fv)])]
-              (is (= #{(#'api.database-test/sync-and-analyze-trigger-name db)}
-                     (#'task.sync-databases-test/query-all-db-sync-triggers-name db)))
-              (is (nil? (:cache_field_values_schedule db))))))))))
+        (migrate! :down (dec (config/current-major-version)))
+        (testing "after migrate down, db details should still be encrypted"
+          (is (true? (encryption/possibly-encrypted-string? (db-detail)))))))))


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/42612 and https://github.com/metabase/metabase/issues/42611

The custom migration was getting raw `db.details`, but it didn't take into account cases where db-details are encrypted.

This PR fixes that and also:
- Added a test so that future migrations that touch encrypted entities will be caught, this should prevent these types of bug from appearing
- Removed the dependency for `metabase.models.interface` for custom migration; instead, it adds dependency on `metabase.util.encryption` but I think this ns is less likely to change and safe to use in migration.