### PR TITLE
Prevent the suggestion popover from flipping to the top

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.tsx
@@ -100,6 +100,11 @@ export function ExpressionEditorSuggestions({
       radius="xs"
       withinPortal
       zIndex={DEFAULT_POPOVER_Z_INDEX}
+      middlewares={{
+        flip: false,
+        shift: false,
+        inline: false,
+      }}
     >
       <Popover.Target>{children}</Popover.Target>
       <Popover.Dropdown>


### PR DESCRIPTION

Closes https://github.com/metabase/metabase/issues/42623

### Description

Prevents the suggestion popover from flipping to the top of the input.

### How to verify


1. New question -> Sample Dataset -> Orders
2. Click `New column`, the expression editor should display
3. Resize the window (vertically) and make sure that at no point the suggestion popover flips to above the expression editor input. The expression editor itself will flip, but that is ok.

### Demo

https://github.com/metabase/metabase/assets/1250185/46f14685-7c16-4962-a2b5-c3d514fee225


