### PR TITLE
Fix reflection on newer JVM versions

### DIFF
--- a/src/metabase/integrations/slack.clj
+++ b/src/metabase/integrations/slack.clj
@@ -320,7 +320,7 @@
 
 (defn- poll
   "Returns `(thunk)` if the result satisfies the `done?` predicate within the timeout and nil otherwise."
-  [{:keys [thunk done? timeout-ms interval-ms]}]
+  [{:keys [thunk done? timeout-ms ^long interval-ms]}]
   (let [start-time (System/currentTimeMillis)]
     (loop []
       (let [response (thunk)]


### PR DESCRIPTION
Java 19 adds a new 1-arity of `Thread.sleep` that takes a `Duration`, so this hint is required to avoid reflection.