### PR TITLE
Fix broken metric revision API call

### DIFF
--- a/e2e/test/scenarios/onboarding/reference/metrics.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/reference/metrics.cy.spec.js
@@ -20,66 +20,78 @@ describe("scenarios > reference > metrics", () => {
       name: METRIC_NAME,
       description: METRIC_DESCRIPTION,
       table_id: ORDERS_ID,
+    }).then(({ body: { id } }) => {
+      cy.wrap(id).as("metricId");
     });
   });
 
   it("should let an admin edit details about the metric", () => {
-    cy.log("Should see the listing");
-    cy.visit("/reference/metrics");
-    cy.location("pathname").should("eq", "/reference/metrics");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText(METRIC_DESCRIPTION);
+    cy.get("@metricId").then(id => {
+      cy.log("Should see the listing");
+      cy.visit("/reference/metrics");
+      cy.location("pathname").should("eq", "/reference/metrics");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText(METRIC_DESCRIPTION);
 
-    cy.log("Should let the user navigate to details");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText(METRIC_NAME).click();
-    cy.location("pathname").should("eq", "/reference/metrics/1");
+      cy.log("Should let the user navigate to details");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText(METRIC_NAME).click();
+      cy.location("pathname").should("eq", `/reference/metrics/${id}`);
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Edit").click();
-    cy.location("pathname").should("eq", "/reference/metrics/1/edit");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Description")
-      .parent()
-      .parent()
-      .find("textarea")
-      .clear()
-      .type("Count of orders under $100");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Save").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText("Edit").click();
+      cy.location("pathname").should("eq", `/reference/metrics/${id}/edit`);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText("Description")
+        .parent()
+        .parent()
+        .find("textarea")
+        .clear()
+        .type("Count of orders under $100");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText("Save").click();
 
-    modal().find("textarea").type("Renaming the description");
+      modal().find("textarea").type("Renaming the description");
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Save changes").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText("Save changes").click();
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Count of orders under $100");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText("Count of orders under $100");
 
-    cy.log(
-      "Make sure this is reflected in the revision history (metabase#42633)",
-    );
-    cy.findAllByRole("listitem")
-      .filter(':contains("Revision history for orders < 100")')
-      .click();
+      cy.log(
+        "Make sure this is reflected in the revision history (metabase#42633)",
+      );
+      cy.findAllByRole("listitem")
+        .filter(':contains("Revision history for orders < 100")')
+        .click();
 
-    cy.location("pathname").should("eq", "/reference/metrics/1/revisions");
-    cy.findAllByRole("listitem").should("contain", "Renaming the description");
+      cy.location("pathname").should(
+        "eq",
+        `/reference/metrics/${id}/revisions`,
+      );
+      cy.findAllByRole("listitem").should(
+        "contain",
+        "Renaming the description",
+      );
+    });
   });
 
   it("should let an admin start to edit and cancel without saving", () => {
-    cy.visit("/reference/metrics/1/edit");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Why this metric is interesting")
-      .parent()
-      .parent()
-      .find("textarea")
-      .type("Because it's very nice");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Cancel").click();
+    cy.get("@metricId").then(id => {
+      cy.visit(`/reference/metrics/${id}/edit`);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText("Why this metric is interesting")
+        .parent()
+        .parent()
+        .find("textarea")
+        .type("Because it's very nice");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText("Cancel").click();
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Because it's very nice").should("not.exist");
-    cy.location("pathname").should("eq", "/reference/metrics/1");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText("Because it's very nice").should("not.exist");
+      cy.location("pathname").should("eq", `/reference/metrics/${id}`);
+    });
   });
 });

--- a/e2e/test/scenarios/onboarding/reference/metrics.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/reference/metrics.cy.spec.js
@@ -63,6 +63,16 @@ describe("scenarios > reference > metrics", () => {
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Count of orders under $100");
+
+    cy.log(
+      "Make sure this is reflected in the revision history (metabase#42633)",
+    );
+    cy.findAllByRole("listitem")
+      .filter(':contains("Revision history for orders < 100")')
+      .click();
+
+    cy.location("pathname").should("eq", "/reference/metrics/1/revisions");
+    cy.findAllByRole("listitem").should("contain", "Renaming the description");
   });
 
   it("should let an admin start to edit and cancel without saving", () => {

--- a/e2e/test/scenarios/onboarding/reference/metrics.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/reference/metrics.cy.spec.js
@@ -30,33 +30,30 @@ describe("scenarios > reference > metrics", () => {
       cy.log("Should see the listing");
       cy.visit("/reference/metrics");
       cy.location("pathname").should("eq", "/reference/metrics");
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+
       cy.findByText(METRIC_DESCRIPTION);
 
       cy.log("Should let the user navigate to details");
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+
       cy.findByText(METRIC_NAME).click();
       cy.location("pathname").should("eq", `/reference/metrics/${id}`);
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Edit").click();
       cy.location("pathname").should("eq", `/reference/metrics/${id}/edit`);
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+
       cy.findByText("Description")
         .parent()
         .parent()
         .find("textarea")
         .clear()
         .type("Count of orders under $100");
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+
       cy.findByText("Save").click();
 
       modal().find("textarea").type("Renaming the description");
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Save changes").click();
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count of orders under $100");
 
       cy.log(
@@ -80,16 +77,15 @@ describe("scenarios > reference > metrics", () => {
   it("should let an admin start to edit and cancel without saving", () => {
     cy.get("@metricId").then(id => {
       cy.visit(`/reference/metrics/${id}/edit`);
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+
       cy.findByText("Why this metric is interesting")
         .parent()
         .parent()
         .find("textarea")
         .type("Because it's very nice");
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+
       cy.findByText("Cancel").click();
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Because it's very nice").should("not.exist");
       cy.location("pathname").should("eq", `/reference/metrics/${id}`);
     });

--- a/e2e/test/scenarios/onboarding/reference/metrics.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/reference/metrics.cy.spec.js
@@ -23,29 +23,21 @@ describe("scenarios > reference > metrics", () => {
     });
   });
 
-  it("should see the listing", () => {
+  it("should let an admin edit details about the metric", () => {
+    cy.log("Should see the listing");
     cy.visit("/reference/metrics");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText(METRIC_NAME);
+    cy.location("pathname").should("eq", "/reference/metrics");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(METRIC_DESCRIPTION);
-  });
 
-  it("should let the user navigate to details", () => {
-    cy.visit("/reference/metrics");
+    cy.log("Should let the user navigate to details");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(METRIC_NAME).click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Why this metric is interesting");
-  });
-
-  it("should let an admin edit details about the metric", () => {
-    cy.visit("/reference/metrics");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText(METRIC_NAME).click();
+    cy.location("pathname").should("eq", "/reference/metrics/1");
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Edit").click();
+    cy.location("pathname").should("eq", "/reference/metrics/1/edit");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Description")
       .parent()
@@ -76,12 +68,7 @@ describe("scenarios > reference > metrics", () => {
   });
 
   it("should let an admin start to edit and cancel without saving", () => {
-    cy.visit("/reference/metrics");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText(METRIC_NAME).click();
-
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Edit").click();
+    cy.visit("/reference/metrics/1/edit");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Why this metric is interesting")
       .parent()
@@ -92,17 +79,7 @@ describe("scenarios > reference > metrics", () => {
     cy.findByText("Cancel").click();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Because it's very nice").should("have.length", 0);
-  });
-
-  it("should have different URI while editing the metric", () => {
-    cy.visit("/reference/metrics");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText(METRIC_NAME).click();
-
-    cy.url().should("match", /\/reference\/metrics\/\d+$/);
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Edit").click();
-    cy.url().should("match", /\/reference\/metrics\/\d+\/edit$/);
+    cy.findByText("Because it's very nice").should("not.exist");
+    cy.location("pathname").should("eq", "/reference/metrics/1");
   });
 });

--- a/frontend/src/metabase/admin/datamodel/containers/RevisionHistoryApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/RevisionHistoryApp.jsx
@@ -21,7 +21,10 @@ const mapDispatchToProps = { fetchRevisions };
 class RevisionHistoryApp extends Component {
   componentDidMount() {
     const { id, objectType } = this.props;
-    this.props.fetchRevisions({ entity: objectType, id });
+    this.props.fetchRevisions({
+      entity: objectType === "metric" ? "legacy-metric" : objectType,
+      id,
+    });
   }
 
   render() {

--- a/frontend/src/metabase/redux/metadata.js
+++ b/frontend/src/metabase/redux/metadata.js
@@ -141,7 +141,10 @@ export const fetchRevisions = createThunkAction(
         return {
           type,
           id,
-          revisions: await RevisionsApi.get({ id, entity: type }),
+          revisions: await RevisionsApi.get({
+            id,
+            entity: type === "metric" ? "legacy-metric" : type,
+          }),
         };
       };
 


### PR DESCRIPTION
### Description
This PR Fixes #42633 that broke in two places:
1. Table metada (datamodel)
2. Data reference page

It adds E2E reproductions for both cases.
It also consolidates some of the existing tests (but this was just a boy scout cleanup)

### How to verify
- Follow the steps from the original issue.
- E2E tests should pass


### Checklist
-  [x] Tests have been added/updated to cover changes in this PR
