### PR TITLE
Show task status in admin

### DIFF
--- a/frontend/src/metabase-types/api/task.ts
+++ b/frontend/src/metabase-types/api/task.ts
@@ -9,6 +9,7 @@ export interface Task {
   ended_at: string;
   task: string;
   task_details: Record<string, unknown> | null;
+  status: "success" | "started" | "failed" | "unknown";
 }
 export type ListTasksRequest = PaginationRequest;
 

--- a/frontend/src/metabase/admin/tasks/containers/TasksApp.tsx
+++ b/frontend/src/metabase/admin/tasks/containers/TasksApp.tsx
@@ -96,6 +96,7 @@ export const TasksApp = ({ children }: TasksAppProps) => {
             <th>{t`Started at`}</th>
             <th>{t`Ended at`}</th>
             <th>{t`Duration (ms)`}</th>
+            <th>{t`Status`}</th>
             <th>{t`Details`}</th>
           </tr>
         </thead>
@@ -113,6 +114,7 @@ export const TasksApp = ({ children }: TasksAppProps) => {
                 <td>{task.started_at}</td>
                 <td>{task.ended_at}</td>
                 <td>{task.duration}</td>
+                <td>{task.status}</td>
                 <td>
                   <Link
                     className={cx(CS.link, CS.textBold)}


### PR DESCRIPTION
We added the status column in https://github.com/metabase/metabase/pull/42372, this PR adds the column to the Admin Tasks tab.
![Screenshot 2024-05-14 at 18 25 32](https://github.com/metabase/metabase/assets/25661381/c3a7a0f7-5e80-41a9-983b-2f68a1a5ccbf)
