### PR TITLE
json unfolding: parse incrementally instead of using cheshire

### DIFF
--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -373,12 +373,13 @@
 
 (defn- number-type [t]
   (u/case-enum t
-    JsonParser$NumberType/INT Integer
-    JsonParser$NumberType/LONG Long
-    JsonParser$NumberType/FLOAT Float
-    JsonParser$NumberType/DOUBLE Double
-    JsonParser$NumberType/BIG_DECIMAL BigDecimal
-    JsonParser$NumberType/BIG_INTEGER clojure.lang.BigInt))
+    JsonParser$NumberType/INT         Long
+    JsonParser$NumberType/LONG        Long
+    JsonParser$NumberType/FLOAT       Double
+    JsonParser$NumberType/DOUBLE      Double
+    JsonParser$NumberType/BIG_INTEGER clojure.lang.BigInt
+    ;; there seem to be no way to encounter this, search in tests for `BigDecimal`
+    JsonParser$NumberType/BIG_DECIMAL BigDecimal))
 
 (defn- json->types
   "Parses given json (a string or a reader) into a map of paths to types, i.e. `{[\"bob\"} String}`.
@@ -396,8 +397,9 @@
           (persistent! res)
 
           ;; we could be more precise here and issue warning about nested fields (the one in `describe-json-fields`),
-          ;; but this limit could be hit by multiple json fields rather than only by this one. So for the sake of
-          ;; issuing only a single warning in logs we'll spill over limit by a single entry (instead of doing `<=`).
+          ;; but this limit could be hit by multiple json fields (fetched in `describe-json-fields`) rather than only
+          ;; by this one. So for the sake of issuing only a single warning in logs we'll spill over limit by a single
+          ;; entry (instead of doing `<=`).
           (< max-nested-field-columns (count res))
           (persistent! res)
 

--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -2,7 +2,6 @@
   "SQL JDBC impl for `describe-fields`, `describe-table`, `describe-fks`, `describe-table-fks`, and `describe-nested-field-columns`.
   `describe-table-fks` is deprecated and will be replaced by `describe-fks` in the future."
   (:require
-   [cheshire.core :as json]
    [clojure.java.jdbc :as jdbc]
    [clojure.set :as set]
    [clojure.string :as str]
@@ -24,6 +23,7 @@
    #_{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2])
   (:import
+   (com.fasterxml.jackson.core JsonFactory JsonParser JsonToken JsonParser$NumberType)
    (java.sql Connection DatabaseMetaData ResultSet)))
 
 (set! *warn-on-reflection* true)
@@ -349,22 +349,9 @@
                        :value index-name})))
             set)))))
 
-(def ^:dynamic *nested-field-column-max-row-length*
-  "Max string length for a row for nested field column before we just give up on parsing it.
-  Marked as mutable because we mutate it for tests."
-  50000)
-
-(defn- flattened-row [field-name row]
-  (letfn [(flatten-row [row path]
-            (lazy-seq
-              (when-let [[[k v] & xs] (seq row)]
-                (cond (and (map? v) (not-empty v))
-                      (into (flatten-row v (conj path k))
-                            (flatten-row xs path))
-                      :else
-                      (cons [(conj path k) v]
-                            (flatten-row xs path))))))]
-    (into {} (flatten-row row [field-name]))))
+(def ^:const max-nested-field-columns
+  "Maximum number of nested field columns."
+  100)
 
 (def ^:private ^{:arglists '([s])} can-parse-datetime?
   "Returns whether a string can be parsed to an ISO 8601 datetime or not."
@@ -372,33 +359,72 @@
 
 (defn- type-by-parsing-string
   "Mostly just (type member) but with a bit to suss out strings which are ISO8601 and say that they are datetimes"
-  [member]
-  (let [member-type (type member)]
-    (if (and (instance? String member)
-             (can-parse-datetime? member))
-      java.time.LocalDateTime
-      member-type)))
+  [value]
+  (if (and (string? value)
+           (can-parse-datetime? value))
+    java.time.LocalDateTime
+    (type value)))
 
-(defn- row->types [row]
-  (into {} (for [[field-name field-val] row
-                 ;; We put top-level array row type semantics on JSON roadmap but skip for now
-                 :when (map? field-val)]
-             (let [flat-row (flattened-row field-name field-val)]
-               (into {} (map (fn [[k v]] [k (type-by-parsing-string v)]) flat-row))))))
+(defn- json-parser ^JsonParser [v]
+  (let [f (JsonFactory.)]
+    (if (string? v)
+      (.createParser f ^String v)
+      (.createParser f ^java.io.Reader v))))
 
-(defn- describe-json-xform [member]
-  ((comp (map #(for [[k v] %
-                     :when (< (count v) *nested-field-column-max-row-length*)]
-                 [k (json/parse-string v)]))
-         (map #(into {} %))
-         (map row->types)) member))
+(defn- number-type [t]
+  (u/case-enum t
+    JsonParser$NumberType/INT Integer
+    JsonParser$NumberType/LONG Long
+    JsonParser$NumberType/FLOAT Float
+    JsonParser$NumberType/DOUBLE Double
+    JsonParser$NumberType/BIG_DECIMAL BigDecimal
+    JsonParser$NumberType/BIG_INTEGER clojure.lang.BigInt))
 
-(def ^:const max-nested-field-columns
-  "Maximum number of nested field columns."
-  100)
+(defn- json->types
+  "Parses given json (a string or a reader) into a map of paths to types, i.e. `{[\"bob\"} String}`.
+
+  Uses Jackson Streaming API to skip allocating data structures, eschews allocating values when possible.
+  Respects *nested-field-column-max-row-length*."
+  [v path]
+  (let [p (json-parser v)]
+    (loop [path (or path [])
+           key  nil
+           res  (transient {})]
+      (let [token (.nextToken p)]
+        (cond
+          (nil? token)
+          (persistent! res)
+
+          ;; we could be more precise here and issue warning about nested fields (the one in `describe-json-fields`),
+          ;; but this limit could be hit by multiple json fields rather than only by this one. So for the sake of
+          ;; issuing only a single warning in logs we'll spill over limit by a single entry (instead of doing `<=`).
+          (< max-nested-field-columns (count res))
+          (persistent! res)
+
+          :else
+          (u/case-enum token
+            JsonToken/VALUE_NUMBER_INT   (recur path key (assoc! res (conj path key) (number-type (.getNumberType p))))
+            JsonToken/VALUE_NUMBER_FLOAT (recur path key (assoc! res (conj path key) (number-type (.getNumberType p))))
+            JsonToken/VALUE_TRUE         (recur path key (assoc! res (conj path key) Boolean))
+            JsonToken/VALUE_FALSE        (recur path key (assoc! res (conj path key) Boolean))
+            JsonToken/VALUE_NULL         (recur path key (assoc! res (conj path key) nil))
+            JsonToken/VALUE_STRING       (recur path key (assoc! res (conj path key)
+                                                                 (type-by-parsing-string (.getText p))))
+            JsonToken/FIELD_NAME         (recur path (.getText p) res)
+            JsonToken/START_OBJECT       (recur (cond-> path key (conj key)) key res)
+            JsonToken/END_OBJECT         (recur (cond-> path (seq path) pop) key res)
+            ;; We put top-level array row type semantics on JSON roadmap but skip for now
+            JsonToken/START_ARRAY        (do (.skipChildren p)
+                                             (if key
+                                               (recur path key (assoc! res (conj path key) clojure.lang.PersistentVector))
+                                               (recur path key res)))
+            JsonToken/END_ARRAY          (recur path key res)))))))
+
+(defn- json-map->types [json-map]
+  (apply merge (map #(json->types (second %) [(first %)]) json-map)))
 
 (defn- describe-json-rf
-  "Reducing function that takes a bunch of maps from row->types,
+  "Reducing function that takes a bunch of maps from json-map->types,
   and gets them to conform to the type hierarchy,
   going through and taking the lowest common denominator type at each pass,
   ignoring the nils."
@@ -550,7 +576,7 @@
                           driver
                           (sample-json-row-honey-sql table-identifier json-field-identifiers pk-identifiers))
         query            (jdbc/reducible-query jdbc-spec sql-args {:identifiers identity})
-        field-types      (transduce describe-json-xform describe-json-rf query)
+        field-types      (transduce (map json-map->types) describe-json-rf query)
         fields           (field-types->fields field-types)]
     (if (> (count fields) max-nested-field-columns)
       (do

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -944,3 +944,16 @@
    (fn [acc x] (if (pred x) (reduced x) acc))
    nil
    coll))
+
+(defmacro case-enum
+  "Like `case`, but explicitly dispatch on Java enum ordinals."
+  [value & clauses]
+  (letfn [(enum-ordinal [e] `(let [^Enum e# ~e] (.ordinal e#)))]
+    `(case ~(enum-ordinal value)
+       ~@(concat
+          (mapcat (fn [[test result]]
+                    #_ {:clj-kondo/ignore [:discouraged-var]}
+                    [(eval (enum-ordinal test)) result])
+                  (partition 2 clauses))
+          (when (odd? (count clauses))
+            (list (last clauses)))))))

--- a/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
+++ b/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
@@ -190,32 +190,16 @@
 
 (deftest ^:parallel row->types-test
   (testing "array rows ignored properly in JSON row->types (#21752)"
-    (let [arr-row   {:bob [:bob :cob :dob 123 "blob"]}
-          obj-row   {:zlob {"blob" 1323}}]
-      (is (= {} (#'sql-jdbc.describe-table/row->types arr-row)))
-      (is (= {[:zlob "blob"] java.lang.Long} (#'sql-jdbc.describe-table/row->types obj-row)))))
-  (testing "JSON row->types handles bigint OK (#21752)"
-    (let [int-row   {:zlob {"blob" 123N}}
-          float-row {:zlob {"blob" 1234.02M}}]
-      (is (= {[:zlob "blob"] clojure.lang.BigInt} (#'sql-jdbc.describe-table/row->types int-row)))
-      (is (= {[:zlob "blob"] java.math.BigDecimal} (#'sql-jdbc.describe-table/row->types float-row))))))
-
-(deftest ^:parallel dont-parse-long-json-xform-test
-  (testing "obnoxiously long json should not even get parsed (#22636)"
-    ;; Generating an actually obnoxiously long json took too long,
-    ;; and actually copy-pasting an obnoxiously long string in there looks absolutely terrible,
-    ;; so this rebinding is what you get
-    (let [obnoxiously-long-json "{\"bob\": \"dobbs\"}"
-          json-map              {:somekey obnoxiously-long-json}]
-      (binding [sql-jdbc.describe-table/*nested-field-column-max-row-length* 3]
-        (is (= {}
-               (transduce
-                 #'sql-jdbc.describe-table/describe-json-xform
-                 #'sql-jdbc.describe-table/describe-json-rf [json-map]))))
-      (is (= {[:somekey "bob"] java.lang.String}
-             (transduce
-               #'sql-jdbc.describe-table/describe-json-xform
-               #'sql-jdbc.describe-table/describe-json-rf [json-map]))))))
+    (let [arr-row   {:bob (json/encode [:bob :cob :dob 123 "blob"])}
+          obj-row   {:zlob (json/encode {:blob Long/MAX_VALUE})}]
+      (is (= {} (#'sql-jdbc.describe-table/json-map->types arr-row)))
+      (is (= {[:zlob "blob"] java.lang.Long} (#'sql-jdbc.describe-table/json-map->types obj-row)))))
+  (testing "JSON json-map->types handles bigint OK (#22732)"
+    (let [int-row   {:zlob (json/encode {"blob" (inc (bigint Long/MAX_VALUE))})}
+          float-row {:zlob "{\"blob\": 12345678901234567890.12345678901234567890}"}]
+      (is (= {[:zlob "blob"] clojure.lang.BigInt} (#'sql-jdbc.describe-table/json-map->types int-row)))
+      ;; no idea how to force it to use BigDecimal here
+      (is (= {[:zlob "blob"] Double} (#'sql-jdbc.describe-table/json-map->types float-row))))))
 
 (deftest ^:parallel get-table-pks-test
   ;; FIXME: this should works for all sql drivers
@@ -249,18 +233,13 @@
                  (is (nil? (:visibility-type text-field))))))))))))
 
 (deftest ^:parallel describe-nested-field-columns-test
-  (testing "flattened-row"
-    (let [row       {:bob {:dobbs 123 :cobbs "boop"}}
-          flattened {[:mob :bob :dobbs] 123
-                     [:mob :bob :cobbs] "boop"}]
-      (is (= flattened (#'sql-jdbc.describe-table/flattened-row :mob row)))))
-  (testing "row->types"
-    (let [row   {:bob {:dobbs {:robbs 123} :cobbs [1 2 3]}}
-          types {[:bob :cobbs] clojure.lang.PersistentVector
-                 [:bob :dobbs :robbs] java.lang.Long}]
-      (is (= types (#'sql-jdbc.describe-table/row->types row)))))
-  (testing "JSON row->types handles bigint that comes in and gets interpreted as Java bigint OK (#22732)"
-    (let [int-row   {:zlob {"blob" (java.math.BigInteger. "123124124312134235234235345344324352")}}]
+  (testing "json-map->types"
+    (let [row   {:bob (json/encode {:dobbs {:robbs 123} :cobbs [1 2 3]})}
+          types {[:bob "cobbs"] clojure.lang.PersistentVector
+                 [:bob "dobbs" "robbs"] java.lang.Integer}]
+      (is (= types (#'sql-jdbc.describe-table/json-map->types row)))))
+  (testing "JSON json-map->types handles bigint that comes in and gets interpreted as Java bigint OK (#22732)"
+    (let [int-row   {:zlob (json/encode {"blob" (java.math.BigInteger. "123124124312134235234235345344324352")})}]
       (is (= #{{:name              "zlob → blob",
                 :database-type     "decimal",
                 :base-type         :type/BigInteger,
@@ -269,7 +248,7 @@
                 :visibility-type   :normal,
                 :nfc-path          [:zlob "blob"]}}
              (-> int-row
-                 (#'sql-jdbc.describe-table/row->types)
+                 (#'sql-jdbc.describe-table/json-map->types)
                  (#'sql-jdbc.describe-table/field-types->fields)))))))
 
 (deftest ^:parallel nested-field-column-test

--- a/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
+++ b/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
@@ -201,6 +201,14 @@
       ;; no idea how to force it to use BigDecimal here
       (is (= {[:zlob "blob"] Double} (#'sql-jdbc.describe-table/json-map->types float-row))))))
 
+(deftest ^:parallel key-limit-test
+  (testing "we don't read too many keys even from long jsons"
+    (let [data (into {} (for [i (range (* 2 @#'sql-jdbc.describe-table/max-nested-field-columns))]
+                          [(str "key" i) i]))]
+      ;; +2 to limit since we go 1 over the limit, see comment in `json->types`
+      (is (> (+ 2 @#'sql-jdbc.describe-table/max-nested-field-columns)
+             (count (#'sql-jdbc.describe-table/json-map->types {:k (json/encode data)})))))))
+
 (deftest ^:parallel get-table-pks-test
   ;; FIXME: this should works for all sql drivers
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-field-columns)

--- a/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
+++ b/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
@@ -205,8 +205,8 @@
   (testing "we don't read too many keys even from long jsons"
     (let [data (into {} (for [i (range (* 2 @#'sql-jdbc.describe-table/max-nested-field-columns))]
                           [(str "key" i) i]))]
-      ;; +2 to limit since we go 1 over the limit, see comment in `json->types`
-      (is (> (+ 2 @#'sql-jdbc.describe-table/max-nested-field-columns)
+      ;; inc the limit since we go 1 over the limit, see comment in `json->types`
+      (is (= (inc @#'sql-jdbc.describe-table/max-nested-field-columns)
              (count (#'sql-jdbc.describe-table/json-map->types {:k (json/encode data)})))))))
 
 (deftest ^:parallel get-table-pks-test
@@ -244,7 +244,7 @@
   (testing "json-map->types"
     (let [row   {:bob (json/encode {:dobbs {:robbs 123} :cobbs [1 2 3]})}
           types {[:bob "cobbs"] clojure.lang.PersistentVector
-                 [:bob "dobbs" "robbs"] java.lang.Integer}]
+                 [:bob "dobbs" "robbs"] java.lang.Long}]
       (is (= types (#'sql-jdbc.describe-table/json-map->types row)))))
   (testing "JSON json-map->types handles bigint that comes in and gets interpreted as Java bigint OK (#22732)"
     (let [int-row   {:zlob (json/encode {"blob" (java.math.BigInteger. "123124124312134235234235345344324352")})}]

--- a/test/metabase/util_test.cljc
+++ b/test/metabase/util_test.cljc
@@ -9,7 +9,8 @@
    [flatland.ordered.map :refer [ordered-map]]
    #_:clj-kondo/ignore
    [malli.generator :as mg]
-   [metabase.util :as u]))
+   [metabase.util :as u])
+  #?(:clj (:import [java.time Month DayOfWeek])))
 
 (deftest ^:parallel add-period-test
   (is (= "This sentence needs a period."
@@ -508,3 +509,21 @@
        (let [expected (reduce + (u/map-all (fnil + 0 0 0) xs ys zs))
              sum (+ (reduce + 0 xs) (reduce + 0 ys) (reduce + 0 zs))]
          (= expected sum)))))
+
+#?(:clj
+   (deftest ^:parallel case-enum-test
+     (testing "case does not work"
+       (is (not (case Month/MAY
+                  Month/APRIL false
+                  Month/MAY   true
+                  false))))
+     (testing "case-enum works"
+       (is (u/case-enum Month/MAY
+             Month/APRIL false
+             Month/MAY   true
+             false)))
+     (testing "checks for type"
+       (is (thrown? Exception #"`case-enum` only works.*"
+                    (u/case-enum Month/JANUARY
+                      Month/JANUARY    true
+                      DayOfWeek/SUNDAY true))))))

--- a/test/metabase/util_test.cljc
+++ b/test/metabase/util_test.cljc
@@ -12,6 +12,8 @@
    [metabase.util :as u])
   #?(:clj (:import [java.time Month DayOfWeek])))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 (deftest ^:parallel add-period-test
   (is (= "This sentence needs a period."
          (u/add-period "This sentence needs a period")))
@@ -513,17 +515,17 @@
 #?(:clj
    (deftest ^:parallel case-enum-test
      (testing "case does not work"
-       (is (not (case Month/MAY
-                  Month/APRIL false
-                  Month/MAY   true
-                  false))))
+       (is (= 3 (case Month/MAY
+                  Month/APRIL 1
+                  Month/MAY   2
+                  3))))
      (testing "case-enum works"
-       (is (u/case-enum Month/MAY
-             Month/APRIL false
-             Month/MAY   true
-             false)))
-     (testing "checks for type"
+       (is (= 2 (u/case-enum Month/MAY
+                  Month/APRIL 1
+                  Month/MAY   2
+                  3))))
+     (testing "checks for type of cases"
        (is (thrown? Exception #"`case-enum` only works.*"
                     (u/case-enum Month/JANUARY
-                      Month/JANUARY    true
-                      DayOfWeek/SUNDAY true))))))
+                      Month/JANUARY    1
+                      DayOfWeek/SUNDAY 2))))))


### PR DESCRIPTION
This lowers memory and time usage 100x for 50kb strings (our previous limit). For example, those are results for parsing 42kb JSON string (already in memory):

```
Before: Time per call: 6.32 ms    Alloc per call: 8,732,850b
After:  Time per call: 55.16 us   Alloc per call: 83,254b
```

Nuances:
- I've dropped 50k limit, but not 100 keys limit; so in theory some weird really big JSON with low amount of keys could take a bit of time; in practice, it takes about 455ms and 147mb of allocations to go through 13Mb JSON file. Seems acceptable.
- We could descend into (top-level only?) arrays, but I have no understanding on how to represent them in a resulting sequence; any pointers?
- It seems that outside of enabling this option specifically, there is no way for Jackson to read float from JSON as BigDecimal; OTOH I don't see cheshire reading them as such, so I'm not too sure which way to go.

Resolves #34798 