### PR TITLE
Disable Error Diagnostic Modal In Embedding

### DIFF
--- a/e2e/test/scenarios/admin-2/error-reporting.cy.spec.ts
+++ b/e2e/test/scenarios/admin-2/error-reporting.cy.spec.ts
@@ -4,6 +4,7 @@ import {
   modal,
   restore,
   visitDashboard,
+  visitFullAppEmbeddingUrl,
 } from "e2e/support/helpers";
 
 const downloadsFolder = Cypress.config("downloadsFolder");
@@ -39,6 +40,26 @@ describe("error reporting modal", () => {
       expect(fileContent).to.have.property("logs");
       expect(fileContent).to.have.property("bugReportDetails");
     });
+  });
+
+  it("should not show error reporting modal in embedding", () => {
+    restore();
+    cy.signInAsAdmin();
+    visitFullAppEmbeddingUrl({
+      url: "/",
+      qs: {
+        top_nav: true,
+      },
+      onBeforeLoad: undefined,
+    });
+
+    cy.findByTestId("home-page")
+      .findByText(/see what metabase can do/i)
+      .realClick();
+
+    cy.realPress(["Control", "F1"]);
+
+    modal().should("not.exist");
   });
 
   it("should include question-specific data when triggered on the question page", () => {

--- a/frontend/src/metabase/components/ErrorPages/ErrorDiagnosticModal.tsx
+++ b/frontend/src/metabase/components/ErrorPages/ErrorDiagnosticModal.tsx
@@ -13,6 +13,7 @@ import {
 } from "metabase/forms";
 import { useToggle } from "metabase/hooks/use-toggle";
 import { capitalize } from "metabase/lib/formatting";
+import { getIsEmbedded } from "metabase/selectors/embed";
 import {
   Button,
   Box,
@@ -157,6 +158,10 @@ export const ErrorDiagnosticModal = ({
 export const ErrorDiagnosticModalTrigger = () => {
   const [isModalOpen, setModalOpen] = useState(false);
 
+  if (getIsEmbedded()) {
+    return null;
+  }
+
   return (
     <ErrorBoundary>
       <Stack justify="center" my="lg">
@@ -284,6 +289,9 @@ export const KeyboardTriggeredErrorModal = () => {
   ] = useToggle(false);
 
   useEffect(() => {
+    if (getIsEmbedded()) {
+      return;
+    }
     const keyboardListener = (event: KeyboardEvent) => {
       if (
         event.key === "F1" &&

--- a/frontend/src/metabase/components/ErrorPages/ErrorPages.tsx
+++ b/frontend/src/metabase/components/ErrorPages/ErrorPages.tsx
@@ -9,6 +9,7 @@ import CS from "metabase/css/core/index.css";
 import QueryBuilderS from "metabase/css/query_builder.module.css";
 import { useToggle } from "metabase/hooks/use-toggle";
 import { color } from "metabase/lib/colors";
+import { getIsEmbedded } from "metabase/selectors/embed";
 import { Button, Icon, Tooltip } from "metabase/ui";
 
 import {
@@ -86,24 +87,34 @@ export const Archived = ({
 );
 
 export const SmallGenericError = ({
-  message = t`Something's gone wrong, click for more information`,
+  message = t`Something's gone wrong.`,
 }: {
   message?: string;
 }) => {
   const [isModalOpen, { turnOn: openModal, turnOff: closeModal }] =
     useToggle(false);
 
+  const isEmbedded = getIsEmbedded();
+
+  const tooltipMessage = isEmbedded
+    ? message
+    : message + t` Click for more information`;
+
   return (
     <ErrorPageRoot bordered>
-      <Tooltip label={message}>
-        <Button
-          leftIcon={
-            <Icon name="warning" size={32} color={color("text-light")} />
-          }
-          color="text-light"
-          onClick={openModal}
-          variant="unstyled"
-        />
+      <Tooltip label={tooltipMessage}>
+        {isEmbedded ? (
+          <Icon name="warning" size={32} color={color("text-light")} />
+        ) : (
+          <Button
+            leftIcon={
+              <Icon name="warning" size={32} color={color("text-light")} />
+            }
+            color="text-light"
+            onClick={openModal}
+            variant="unstyled"
+          />
+        )}
       </Tooltip>
       <ErrorExplanationModal isModalOpen={isModalOpen} onClose={closeModal} />
     </ErrorPageRoot>


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/40677

### Description

The error diagnostic modal should not be accessible in embedded contexts, either by keyboard, or via error components.

Embedded | Non-Embedded
---|---
![Screen Shot 2024-05-14 at 6 46 05 AM](https://github.com/metabase/metabase/assets/30528226/89886307-22de-4e10-b60b-d33b56cee8ba) | ![Screen Shot 2024-05-14 at 6 45 39 AM](https://github.com/metabase/metabase/assets/30528226/bed5651d-b70b-45c1-84a3-2d6ae7a7054e)
![Screen Shot 2024-05-14 at 6 44 05 AM](https://github.com/metabase/metabase/assets/30528226/f92ab74c-23a7-4475-bf5e-7d64ff3273a2) | ![Screen Shot 2024-05-14 at 6 44 35 AM](https://github.com/metabase/metabase/assets/30528226/8d7b0407-b92f-4419-b727-05f1c6eecb89)

Also, the `ctrl + F1` keyboard shortcut should not work when embedded.

The easiest way to test this is to modify the `getIsEmbedded` function to always return true;

- [x] Tests have been added/updated to cover changes in this PR
