### PR TITLE
handle RecentViews for non-existant entites

### DIFF
--- a/src/metabase/models/recent_views.clj
+++ b/src/metabase/models/recent_views.clj
@@ -195,6 +195,10 @@
   (cond
     (false? (:archived model)) model
 
+    ;; The model for this recent view doesn't exist in the database, so we can't check if it's archived, so just
+    ;; filter it out.
+    (not model) nil
+
     (true? (:archived model)) nil
 
     (nil? (:archived model))
@@ -260,12 +264,12 @@
     ;; if we don't have the :active key, we need to do a query for it:
     (let [table (t2/select-one :model/Table model-id)]
       (if (nil? table)
-        (throw (ex-info "Table not found" {:table-id model-id}))
+        [nil nil]
         [table (:active table)]))))
 
 (defmethod fill-recent-view-info :table [{:keys [_model model_id timestamp model_object]}]
   (let [[table is-active?] (ellide-inactive model_object model_id)]
-    (when is-active?
+    (when (and table is-active?)
       {:id model_id
        :name (:name table)
        :description (:description table)

--- a/test/metabase/models/recent_views_test.clj
+++ b/test/metabase/models/recent_views_test.clj
@@ -243,3 +243,23 @@
           (is (= ids-to-prune
                  (vec (sort (map #(- % 1337000)
                                  (#'recent-views/ids-to-prune (mt/user->id :rasta))))))))))))
+
+(deftest recent-views-for-non-existent-entity-test
+  (testing "If a user views a model that doesn't exist, it should not be added to recent views"
+    (mt/with-temp [:model/Card       {card-id         :id} {:type "question"}]
+      (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Card card-id)
+      (let [before-ghosts (recent-views/get-list (mt/user->id :rasta))
+            missing-card-id (inc (apply max (t2/select-pks-vec :model/Card)))
+            missing-dashboard-id (inc (apply max (t2/select-pks-vec :model/Dashboard)))
+            missing-collection-id (inc (apply max (t2/select-pks-vec :model/Collection)))
+            missing-table-id (inc (apply max (t2/select-pks-vec :model/Table)))]
+        (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Card missing-card-id)
+        (is (= before-ghosts (recent-views/get-list (mt/user->id :rasta)))
+            "If a user views a model that doesn't exist, it should not be added to recent views")
+        (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Dashboard missing-dashboard-id)
+
+        (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Collection missing-collection-id)
+
+        (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Table missing-table-id)
+
+        ))))

--- a/test/metabase/models/recent_views_test.clj
+++ b/test/metabase/models/recent_views_test.clj
@@ -246,7 +246,11 @@
 
 (deftest recent-views-for-non-existent-entity-test
   (testing "If a user views a model that doesn't exist, it should not be added to recent views"
-    (mt/with-temp [:model/Card       {card-id         :id} {:type "question"}]
+    (mt/with-temp [:model/Database   a-db          {}
+                   :model/Table      _             {:db_id (:id a-db)}
+                   :model/Collection _             {}
+                   :model/Dashboard  _             {}
+                   :model/Card       {card-id :id} {:type "question"}]
       (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Card card-id)
       (let [before-ghosts (recent-views/get-list (mt/user->id :rasta))
             missing-card-id (inc (apply max (t2/select-pks-vec :model/Card)))
@@ -257,9 +261,11 @@
         (is (= before-ghosts (recent-views/get-list (mt/user->id :rasta)))
             "If a user views a model that doesn't exist, it should not be added to recent views")
         (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Dashboard missing-dashboard-id)
-
+        (is (= before-ghosts (recent-views/get-list (mt/user->id :rasta)))
+            "If a user views a model that doesn't exist, it should not be added to recent views")
         (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Collection missing-collection-id)
-
+        (is (= before-ghosts (recent-views/get-list (mt/user->id :rasta)))
+            "If a user views a model that doesn't exist, it should not be added to recent views")
         (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Table missing-table-id)
-
-        ))))
+        (is (= before-ghosts (recent-views/get-list (mt/user->id :rasta)))
+            "If a user views a model that doesn't exist, it should not be added to recent views")))))


### PR DESCRIPTION
Due to the way we store recent views (ids happen to line up, but aren't fks) we can't easily use cascading deletes to delete RecentViews, so there are rare occurances of RecentView records that map to non-existant entites (e.g. a `dashboard`).

This tweak just doesn't show those RecentView records, instead of throwing (which breaks the api).

I considered deleting the RecentView records when this is detected, but the current bucket-filling pruning system will delete these entries on its own, so I don't think the added complexity is worth it.