### PR TITLE
Make Trash Usable: Add `can_restore` to API endpoints

### DIFF
--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -30,6 +30,7 @@ export interface Card<Q extends DatasetQuery = DatasetQuery>
   enable_embedding: boolean;
   embedding_params: EmbeddingParameters | null;
   can_write: boolean;
+  can_restore: boolean;
   initially_published_at: string | null;
 
   database_id?: DatabaseId;

--- a/frontend/src/metabase-types/api/collection.ts
+++ b/frontend/src/metabase-types/api/collection.ts
@@ -57,6 +57,7 @@ export interface Collection {
   entity_id?: string;
   description: string | null;
   can_write: boolean;
+  can_restore: boolean;
   archived: boolean;
   children?: Collection[];
   authority_level?: "official" | null;
@@ -111,6 +112,7 @@ export interface CollectionItem {
   here?: CollectionItemModel[];
   below?: CollectionItemModel[];
   can_write?: boolean;
+  can_restore?: boolean;
   "last-edit-info"?: LastEditInfo;
   location?: string;
   effective_location?: string;

--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -44,6 +44,7 @@ export interface Dashboard {
   point_of_interest?: string | null;
   collection_authority_level?: CollectionAuthorityLevel;
   can_write: boolean;
+  can_restore: boolean;
   cache_ttl: number | null;
   "last-edit-info": {
     id: number;

--- a/frontend/src/metabase-types/api/mocks/card.ts
+++ b/frontend/src/metabase-types/api/mocks/card.ts
@@ -28,6 +28,7 @@ export const createMockCard = (opts?: Partial<Card>): Card => ({
   result_metadata: [],
   type: "question",
   can_write: true,
+  can_restore: false,
   cache_ttl: null,
   collection: null,
   collection_id: null,

--- a/frontend/src/metabase-types/api/mocks/collection.ts
+++ b/frontend/src/metabase-types/api/mocks/collection.ts
@@ -8,6 +8,7 @@ export const createMockCollection = (
   description: null,
   location: "/",
   can_write: true,
+  can_restore: true,
   archived: false,
   is_personal: false,
   authority_level: null,

--- a/frontend/src/metabase-types/api/mocks/dashboard.ts
+++ b/frontend/src/metabase-types/api/mocks/dashboard.ts
@@ -17,6 +17,7 @@ export const createMockDashboard = (opts?: Partial<Dashboard>): Dashboard => ({
   name: "Dashboard",
   dashcards: [],
   can_write: true,
+  can_restore: true,
   description: "",
   cache_ttl: null,
   "last-edit-info": {

--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionContext/QueryActionContextProvider/QueryActionContextProvider.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionContext/QueryActionContextProvider/QueryActionContextProvider.tsx
@@ -67,6 +67,7 @@ function convertActionToQuestionCard(
 
     type: "question",
     can_write: true,
+    can_restore: false,
     public_uuid: null,
     collection_id: null,
     collection_position: null,

--- a/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
+++ b/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
@@ -18,7 +18,6 @@ import {
   canPreviewItem,
   isItemPinned,
   isPreviewEnabled,
-  canUnarchiveItem,
   canDeleteItem,
 } from "metabase/collections/utils";
 import { ConfirmDeleteModal } from "metabase/components/ConfirmDeleteModal";
@@ -98,7 +97,7 @@ function ActionMenu({
   const canPreview = canPreviewItem(item, collection);
   const canMove = canMoveItem(item, collection);
   const canArchive = canArchiveItem(item, collection);
-  const canUnarchive = canUnarchiveItem(item, collection);
+  const canRestore = item.can_restore;
   const canDelete = canDeleteItem(item, collection);
   const canCopy = canCopyItem(item);
   const canUseMetabot =
@@ -135,7 +134,7 @@ function ActionMenu({
     item?.setCollectionPreview?.(!isPreviewEnabled(item));
   }, [item]);
 
-  const handleUnarchive = useCallback(async () => {
+  const handleRestore = useCallback(async () => {
     const Entity = entityForObject(item);
     const result = await dispatch(
       Entity.actions.update({ id: item.id, archived: false }),
@@ -181,7 +180,7 @@ function ActionMenu({
           onArchive={canArchive ? handleArchive : undefined}
           onToggleBookmark={!item.archived ? handleToggleBookmark : undefined}
           onTogglePreview={canPreview ? handleTogglePreview : undefined}
-          onUnarchive={canUnarchive ? handleUnarchive : undefined}
+          onRestore={canRestore ? handleRestore : undefined}
           onDeletePermanently={
             canDelete ? handleStartDeletePermanently : undefined
           }

--- a/frontend/src/metabase/collections/components/CollectionBulkActions/ArchivedBulkActions.tsx
+++ b/frontend/src/metabase/collections/components/CollectionBulkActions/ArchivedBulkActions.tsx
@@ -6,7 +6,6 @@ import { BulkDeleteConfirmModal } from "metabase/archive/components/BulkDeleteCo
 import {
   canDeleteItem,
   canMoveItem,
-  canUnarchiveItem,
   isRootTrashCollection,
 } from "metabase/collections/utils";
 import { BulkActionButton } from "metabase/components/BulkActionBar";
@@ -54,8 +53,8 @@ export const ArchivedBulkActions = ({
   const showRestore = isRootTrashCollection(collection);
 
   const canRestore = useMemo(() => {
-    return selected.every(item => canUnarchiveItem(item, collection));
-  }, [selected, collection]);
+    return selected.every(item => item.can_restore);
+  }, [selected]);
 
   const handleBulkRestore = () => {
     const actions = selected.map(item => item.setArchived(false));

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionContentView.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionContentView.tsx
@@ -7,7 +7,6 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import ErrorBoundary from "metabase/ErrorBoundary";
-import { useGetCollectionQuery } from "metabase/api";
 import { deletePermanently } from "metabase/archive/actions";
 import { ArchivedEntityBanner } from "metabase/archive/components/ArchivedEntityBanner";
 import { CollectionBulkActions } from "metabase/collections/components/CollectionBulkActions";
@@ -112,9 +111,6 @@ export const CollectionContentView = ({
     { turnOn: openModelUploadModal, turnOff: closeModelUploadModal },
   ] = useToggle(false);
   const [uploadedFile, setUploadedFile] = useState<File | null>(null);
-
-  // TODO: temp fix until we have the type field on effective_ancestors
-  const { data: trashCollection } = useGetCollectionQuery("trash");
 
   const saveFile = (file: File) => {
     setUploadedFile(file);
@@ -250,14 +246,6 @@ export const CollectionContentView = ({
           list && !isRootTrashCollection(collection) ? list : [];
         const hasPinnedItems = pinnedItems.length > 0;
         const actionId = { id: collectionId };
-        const parentCollection =
-          collection.effective_ancestors &&
-          _.last(collection.effective_ancestors);
-        const canRestore =
-          // !!parentCollection && isRootTrashCollection(parentCollection);
-          // TODO: temporarily use the fetched trashCollection to check if this is the root trash collection
-          // as we don't currently have the "type" field on the effective_ancestors
-          !!parentCollection && parentCollection.id === trashCollection?.id;
 
         return (
           <CollectionRoot {...dropzoneProps}>
@@ -281,7 +269,7 @@ export const CollectionContentView = ({
                 name={collection.name}
                 entityType="collection"
                 canWrite={collection.can_write}
-                canRestore={canRestore}
+                canRestore={collection.can_restore}
                 onUnarchive={() => {
                   const input = { ...actionId, name: collection.name };
                   dispatch(Collections.actions.setArchived(input, false));

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.stories.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.stories.tsx
@@ -14,6 +14,7 @@ const collection = {
   name: "Collection Foo",
   description: null,
   archived: false,
+  can_restore: false,
   location: "/",
 };
 

--- a/frontend/src/metabase/collections/types.ts
+++ b/frontend/src/metabase/collections/types.ts
@@ -21,7 +21,7 @@ export type OnMoveWithSourceAndDestination = (
 export type OnMoveById = (id: CollectionId) => void;
 export type OnPin = () => void | null;
 export type OnArchive = (() => Promise<any> | void) | null;
-export type OnUnarchive = (() => Promise<any> | void) | null;
+export type OnRestore = (() => Promise<any> | void) | null;
 export type OnDeletePermanently = (() => Promise<any> | void) | null;
 export type OnTogglePreview = () => void | null;
 export type OnToggleBookmark = () => void | null;

--- a/frontend/src/metabase/collections/utils.ts
+++ b/frontend/src/metabase/collections/utils.ts
@@ -185,18 +185,6 @@ export function canArchiveItem(item: CollectionItem, collection?: Collection) {
   );
 }
 
-export function canUnarchiveItem(
-  item: CollectionItem,
-  collection?: Collection,
-) {
-  return (
-    item.archived &&
-    collection &&
-    isRootTrashCollection(collection) &&
-    (item.can_write ?? collection?.can_write ?? true)
-  );
-}
-
 export function canDeleteItem(item: CollectionItem, collection?: Collection) {
   return item.archived && (item.can_write ?? collection?.can_write ?? true);
 }

--- a/frontend/src/metabase/components/EntityItem/EntityItem.tsx
+++ b/frontend/src/metabase/components/EntityItem/EntityItem.tsx
@@ -5,7 +5,7 @@ import { c, t } from "ttag";
 
 import type {
   OnArchive,
-  OnUnarchive,
+  OnRestore,
   OnDeletePermanently,
   OnCopy,
   OnMove,
@@ -117,7 +117,7 @@ function EntityItemMenu({
   onMove,
   onCopy,
   onArchive,
-  onUnarchive,
+  onRestore,
   onDeletePermanently,
   onToggleBookmark,
   onTogglePreview,
@@ -131,7 +131,7 @@ function EntityItemMenu({
   onMove?: OnMove;
   onCopy?: OnCopy;
   onArchive?: OnArchive;
-  onUnarchive?: OnUnarchive;
+  onRestore?: OnRestore;
   onDeletePermanently?: OnDeletePermanently;
   onToggleBookmark?: OnToggleBookmark;
   onTogglePreview?: OnTogglePreview;
@@ -217,11 +217,11 @@ function EntityItemMenu({
       });
     }
 
-    if (onUnarchive) {
+    if (onRestore) {
       result.push({
         title: t`Restore`,
         icon: "revert",
-        action: onUnarchive,
+        action: onRestore,
       });
     }
 
@@ -252,7 +252,7 @@ function EntityItemMenu({
     onTogglePreview,
     onToggleBookmark,
     onDeletePermanently,
-    onUnarchive,
+    onRestore,
   ]);
   if (actions.length === 0) {
     return null;

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -7,7 +7,6 @@ import _ from "underscore";
 
 import { deletePermanently } from "metabase/archive/actions";
 import { ArchivedEntityBanner } from "metabase/archive/components/ArchivedEntityBanner";
-import { isRootTrashCollection } from "metabase/collections/utils";
 import {
   type NewDashCardOpts,
   type SetDashboardAttributesOpts,
@@ -267,12 +266,10 @@ function DashboardInner(props: DashboardProps) {
   );
 
   const canWrite = Boolean(dashboard?.can_write);
+  const canRestore = Boolean(dashboard?.can_restore);
   const tabHasCards = currentTabDashcards.length > 0;
   const dashboardHasCards = dashboard?.dashcards.length > 0;
   const hasVisibleParameters = visibleParameters.length > 0;
-  const canRestore =
-    !!dashboard?.collection_id &&
-    isRootTrashCollection({ type: dashboard?.collection?.type });
 
   const shouldRenderAsNightMode = isNightMode && isFullscreen;
 

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/test-utils.ts
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/test-utils.ts
@@ -30,6 +30,7 @@ export const TEST_DASHBOARD_STATE: DashboardState = {
       name: "",
       description: "",
       can_write: true,
+      can_restore: true,
       cache_ttl: null,
       auto_apply_filters: true,
       archived: false,

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -6,7 +6,6 @@ import _ from "underscore";
 
 import { deletePermanently } from "metabase/archive/actions";
 import { ArchivedEntityBanner } from "metabase/archive/components/ArchivedEntityBanner";
-import { isRootTrashCollection } from "metabase/collections/utils";
 import ExplicitSize from "metabase/components/ExplicitSize";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import Toaster from "metabase/components/Toaster";
@@ -238,8 +237,6 @@ class View extends Component {
     const { isNative } = Lib.queryDisplayInfo(query);
 
     const isNewQuestion = !isNative && Lib.sourceTableOrCardId(query) === null;
-    const canRestore =
-      !!card.collection && isRootTrashCollection(card.collection);
 
     return (
       <QueryBuilderViewHeaderContainer>
@@ -248,7 +245,7 @@ class View extends Component {
             name={card.name}
             entityType={card.type}
             canWrite={card.can_write}
-            canRestore={canRestore}
+            canRestore={card.can_restore}
             onUnarchive={() => onUnarchive(question)}
             onMove={id => onMove(card.id, id)}
             onDeletePermanently={() => onDeletePermanently(card.id)}

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -186,6 +186,7 @@
                     :average_query_time
                     :last_query_start
                     :parameter_usage_count
+                    :card/can_restore
                     [:collection :is_personal]
                     [:moderation_reviews :moderator_details])
         (cond->                                             ; card
@@ -202,8 +203,7 @@
                  hydrate-card-details
                  ;; Cal 2023-11-27: why is last-edit-info hydrated differently for GET vs PUT and POST
                  (last-edit/with-last-edit-info :card)
-                 collection.root/hydrate-root-collection
-                 (assoc :can_restore false))]
+                 collection.root/hydrate-root-collection)]
     (u/prog1 card
       (when-not ignore_view
         (events/publish-event! :event/card-read {:object <> :user-id api/*current-user-id*})))))

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -186,7 +186,7 @@
                     :average_query_time
                     :last_query_start
                     :parameter_usage_count
-                    :card/can_restore
+                    :can_restore
                     [:collection :is_personal]
                     [:moderation_reviews :moderator_details])
         (cond->                                             ; card

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -202,7 +202,8 @@
                  hydrate-card-details
                  ;; Cal 2023-11-27: why is last-edit-info hydrated differently for GET vs PUT and POST
                  (last-edit/with-last-edit-info :card)
-                 collection.root/hydrate-root-collection)]
+                 collection.root/hydrate-root-collection
+                 (assoc :can_restore false))]
     (u/prog1 card
       (when-not ignore_view
         (events/publish-event! :event/card-read {:object <> :user-id api/*current-user-id*})))))

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -484,7 +484,6 @@
       (update :archived api/bit->boolean)
       (t2/hydrate :can_write)
       (dissoc :authority_level :icon :personal_owner_id :dataset_query :table_id :query_type :is_upload)
-      (assoc :can_restore false)
       (assoc :fully_parameterized (fully-parameterized-query? row))))
 
 (defmethod post-process-collection-children :card
@@ -519,7 +518,7 @@
 (defn- post-process-dashboard [dashboard]
   (-> (t2/instance :model/Dashboard dashboard)
       (update :archived api/bit->boolean)
-      (t2/hydrate :can_write)
+      (t2/hydrate :can_write :can_restore)
       (dissoc :display :authority_level :moderated_status :icon :personal_owner_id :collection_preview
               :dataset_query :table_id :query_type :is_upload)))
 

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -482,7 +482,7 @@
   (-> (t2/instance :model/Card row)
       (update :collection_preview api/bit->boolean)
       (update :archived api/bit->boolean)
-      (t2/hydrate :can_write)
+      (t2/hydrate :can_write :card/can_restore)
       (dissoc :authority_level :icon :personal_owner_id :dataset_query :table_id :query_type :is_upload)
       (assoc :fully_parameterized (fully-parameterized-query? row))))
 

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -628,10 +628,9 @@
       (-> (t2/instance :model/Collection row)
           collection/maybe-localize-trash-name
           (update :archived api/bit->boolean)
-          (t2/hydrate :can_write :effective_location)
+          (t2/hydrate :can_write :effective_location :collection/can_restore)
           (dissoc :collection_position :display :moderated_status :icon
                   :collection_preview :dataset_query :table_id :query_type :is_upload)
-          (assoc :can_restore false)
           update-personal-collection))))
 
 (mu/defn ^:private coalesce-edit-info :- last-edit/MaybeAnnotated
@@ -871,8 +870,7 @@
   [collection :- collection/CollectionWithLocationAndIDOrRoot]
   (-> collection
       collection/personal-collection-with-ui-details
-      (assoc :can_restore false)
-      (t2/hydrate :parent_id :effective_location [:effective_ancestors :can_write] :can_write :is_personal)))
+      (t2/hydrate :parent_id :effective_location [:effective_ancestors :can_write] :can_write :is_personal :collection/can_restore)))
 
 (api/defendpoint GET "/:id"
   "Fetch a specific Collection with standard details added"

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -482,7 +482,7 @@
   (-> (t2/instance :model/Card row)
       (update :collection_preview api/bit->boolean)
       (update :archived api/bit->boolean)
-      (t2/hydrate :can_write :card/can_restore)
+      (t2/hydrate :can_write :can_restore)
       (dissoc :authority_level :icon :personal_owner_id :dataset_query :table_id :query_type :is_upload)
       (assoc :fully_parameterized (fully-parameterized-query? row))))
 

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -484,6 +484,7 @@
       (update :archived api/bit->boolean)
       (t2/hydrate :can_write)
       (dissoc :authority_level :icon :personal_owner_id :dataset_query :table_id :query_type :is_upload)
+      (assoc :can_restore false)
       (assoc :fully_parameterized (fully-parameterized-query? row))))
 
 (defmethod post-process-collection-children :card
@@ -631,6 +632,7 @@
           (t2/hydrate :can_write :effective_location)
           (dissoc :collection_position :display :moderated_status :icon
                   :collection_preview :dataset_query :table_id :query_type :is_upload)
+          (assoc :can_restore false)
           update-personal-collection))))
 
 (mu/defn ^:private coalesce-edit-info :- last-edit/MaybeAnnotated
@@ -870,6 +872,7 @@
   [collection :- collection/CollectionWithLocationAndIDOrRoot]
   (-> collection
       collection/personal-collection-with-ui-details
+      (assoc :can_restore false)
       (t2/hydrate :parent_id :effective_location [:effective_ancestors :can_write] :can_write :is_personal)))
 
 (api/defendpoint GET "/:id"

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -252,7 +252,8 @@
         hydrate-dashboard-details
         collection.root/hydrate-root-collection
         hide-unreadable-cards
-        add-query-average-durations)))
+        add-query-average-durations
+        (assoc :can_restore false))))
 
 (defn- cards-to-copy
   "Returns a map of which cards we need to copy and which are not to be copied. The `:copy` key is a map from id to

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -96,6 +96,7 @@
                            :series
                            :dashcard/action
                            :dashcard/linkcard-info]
+                :can_restore
                 :last_used_param_values
                 :tabs
                 :collection_authority_level
@@ -252,8 +253,7 @@
         hydrate-dashboard-details
         collection.root/hydrate-root-collection
         hide-unreadable-cards
-        add-query-average-durations
-        (assoc :can_restore false))))
+        add-query-average-durations)))
 
 (defn- cards-to-copy
   "Returns a map of which cards we need to copy and which are not to be copied. The `:copy` key is a map from id to

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -51,6 +51,7 @@
    [metabase.util.malli.schema :as ms]
    [methodical.core :as methodical]
    [toucan2.core :as t2]
+   [toucan2.instance :as t2.instance]
    [toucan2.tools.hydrate :as t2.hydrate])
   (:import
    (clojure.core.async.impl.channels ManyToManyChannel)))
@@ -980,3 +981,36 @@ saved later when it is ready."
   (merge (select-keys card [:name :description :database_id :table_id])
           ;; Use `model` instead of `dataset` to mirror product terminology
          {:model? (= (keyword card-type) :model)}))
+
+(mi/define-batched-hydration-method can-restore
+  :card/can_restore
+  "Efficiently hydrate the `:can_restore` of a sequence of cards."
+  [cards]
+  (when (seq cards)
+    (let [card-id->coll (into {}
+                              (map (juxt :card_id identity))
+                              (mdb.query/query {:select    [[:card.id :card_id]
+                                                            [:card.archived :card_archived]
+                                                            [:collection.archived :collection_archived]
+                                                            [:collection.id :collection_id]
+                                                            :collection.namespace
+                                                            :card.trashed_from_collection_id]
+                                                :from      [[:report_card :card]]
+                                                :left-join [[:collection :collection] [:= :collection.id :card.trashed_from_collection_id]]
+                                                :where     [:in :card.id (into #{} (map u/the-id) cards)]}))]
+      (for [card cards]
+        (assoc card :can_restore (let [coll-info (card-id->coll (u/the-id card))]
+                                        (and
+                                         ;; the card is archived
+                                         (:card_archived coll-info)
+                                         ;; the collection we'll restore to exists
+                                         (not (and (nil? (:collection_id coll-info))
+                                                   (not (nil? (:trashed_from_collection_id coll-info)))))
+                                         ;; the collection is NOT archived
+                                         (not (:collection_archived coll-info))
+                                         ;; we have perms on the collection
+                                         (mi/can-write? (t2.instance/instance :model/Collection
+                                                                              (if (nil? (:collection_id coll-info))
+                                                                                collection/root-collection
+                                                                                {:id        (:collection_id coll-info)
+                                                                                 :namespace (:namespace coll-info)}))))))))))

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -753,7 +753,7 @@
       (t2/query-one
        {:update :collection
         :set    {:location              [:replace :location orig-children-location new-children-location]
-                 :trashed_from_location (when archived? (:location collection))
+                 :trashed_from_location nil
                  :archived              archived?}
         :where  [:like :location (str orig-children-location "%")]})
       (doseq [model [:model/Card
@@ -809,9 +809,11 @@
     ;; the root-level ancestor is a Personal Collection (Personal Collections can only exist in the Root Collection.)
     ;; Note that if the collection is archived, we check this against the `trashed_from_location`.
     (t2/exists? Collection
-                :id                (first (location-path->ids (if (:archived collection)
-                                                                (:trashed_from_location collection)
-                                                                (:location collection))))
+                :id                (first (location-path->ids
+                                           (or
+                                            (when (:archived collection)
+                                              (:trashed_from_location collection))
+                                            (:location collection))))
                 :personal_owner_id [:not= nil]))))
 
 ;;; ----------------------------------------------------- INSERT -----------------------------------------------------

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -1474,7 +1474,7 @@
                            ;; EITHER:
                            (or
                             ;; the item was trashed from the root collection
-                            (nil? trashed-from-coll)
+                            (nil? (:trashed_from_collection_id item))
                             ;; or the collection we'll restore to actually exists.
                             (some? trashed-from-coll))
 

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -1454,3 +1454,39 @@
                         ;; nil sorts first, so we get instance-analytics at the end, which is what we want
                         (original-position coll-id))))))
      (annotate-collections child-type->parent-ids collections))))
+
+(mi/define-batched-hydration-method can-restore
+  :collection/can_restore
+  "Efficiently hydrate the `:can_restore` property of a sequence of Collections."
+  [colls]
+  (when (seq colls)
+    ;; efficiently create a map of [coll-id]->[collection it was trashed from]
+    (let [ids-to-fetch      (->> colls
+                            (remove collection.root/is-root-collection?)
+                            (filter :archived)
+                            (map u/the-id))
+          coll-id->to-coll* (if (seq ids-to-fetch)
+                              (into {}
+                                    (map (juxt :unarchiving_coll_id identity))
+                                    (t2/select :model/Collection
+                                               {:select    [:trashed_from_coll.*
+                                                            [:coll.id :unarchiving_coll_id]]
+                                                :from      [[:collection :coll]]
+                                                :left-join [[:collection :trashed_from_coll] [:=
+                                                                                              [:concat :trashed_from_coll.location :trashed_from_coll.id "/"]
+                                                                                              :coll.trashed_from_location]]
+                                                :where     [:in :coll.id (into #{} ids-to-fetch)]}))
+                              {})
+          ;; given a collection, return the collection we will be restoring TOO.
+          coll->to-coll  (fn [coll]
+                           (when (not (or (collection.root/is-root-collection? coll)
+                                          (not (:archived coll))))
+                             (let [restore-destination (coll-id->to-coll* (u/the-id coll))]
+                               (when (:id restore-destination)
+                                 restore-destination))))]
+      (for [coll colls]
+        (assoc coll :can_restore (if-let [restore-destination (coll->to-coll coll)]
+                                   (perms/set-has-full-permissions-for-set?
+                                    @api/*current-user-permissions-set*
+                                    (perms-for-moving coll restore-destination))
+                                   false))))))

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -37,6 +37,7 @@
    [metabase.xrays :as xrays]
    [methodical.core :as methodical]
    [toucan2.core :as t2]
+   [toucan2.instance :as t2.instance]
    [toucan2.realize :as t2.realize]))
 
 (def Dashboard
@@ -732,3 +733,36 @@
                                       (assoc :card_id card_id))))))
 
     {}))
+
+(mi/define-batched-hydration-method can-restore
+  :can_restore
+  "Efficiently hydrate the `:can_restore` of a sequence of dashboards."
+  [dashboards]
+  (when (seq dashboards)
+    (let [dash-id->coll (into {}
+                              (map (juxt :dashboard_id identity))
+                              (mdb.query/query {:select    [[:dashboard.id :dashboard_id]
+                                                            [:dashboard.archived :dashboard_archived]
+                                                            [:collection.archived :collection_archived]
+                                                            [:collection.id :collection_id]
+                                                            :collection.namespace
+                                                            :dashboard.trashed_from_collection_id]
+                                                :from      [[:report_dashboard :dashboard]]
+                                                :left-join [[:collection :collection] [:= :collection.id :dashboard.trashed_from_collection_id]]
+                                                :where     [:in :dashboard.id (into #{} (map u/the-id) dashboards)]}))]
+      (for [dashboard dashboards]
+        (assoc dashboard :can_restore (let [coll-info (dash-id->coll (u/the-id dashboard))]
+                                        (and
+                                         ;; the dashboard is archived
+                                         (:dashboard_archived coll-info)
+                                         ;; the collection we'll restore to exists
+                                         (not (and (nil? (:collection_id coll-info))
+                                                   (not (nil? (:trashed_from_collection_id coll-info)))))
+                                         ;; the collection is NOT archived
+                                         (not (:collection_archived coll-info))
+                                         ;; we have perms on the collection
+                                         (mi/can-write? (t2.instance/instance :model/Collection
+                                                                              (if (nil? (:collection_id coll-info))
+                                                                                collection/root-collection
+                                                                                {:id        (:collection_id coll-info)
+                                                                                 :namespace (:namespace coll-info)}))))))))))

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -3512,3 +3512,13 @@
                            :crowberto :post 200
                            (format "card/%s/query/%s?format_rows=%s" card-id (name export-format) apply-formatting?))
                           ((get output-helper export-format)))))))))))
+
+(deftest ^:parallel can-restore
+  (t2.with-temp/with-temp [:model/Collection collection-a {:name "A"}
+                           :model/Card {card-id :id} {:name "My Card"
+                                                      :collection_id (u/the-id collection-a)}]
+    ;; trash the card
+    (mt/user-http-request :crowberto :put 200 (str "card/" card-id) {:archived true})
+    ;; trash the parent collection
+    (mt/user-http-request :crowberto :put 200 (str "collection/" (u/the-id collection-a)) {:archived true})
+    (is (false? (:can_restore (mt/user-http-request :crowberto :get 200 (str "card/" card-id)))))))

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -2192,5 +2192,14 @@
         (mt/user-http-request :crowberto :put 200 (str "collection/" (u/the-id subcollection)) {:archived true})
         (is (false? (:can_restore (get-item-with-id-in-coll (collection/trash-collection-id) (u/the-id card))))))))
   (testing "can_restore is correctly populated for collection"
-    (testing "when I can actually restore it")
-    (testing "and when I can't")))
+    (testing "when I can actually restore it"
+      (t2.with-temp/with-temp [:model/Collection collection {:name "A"}
+                               :model/Collection subcollection {:name "sub-A" :location (collection/children-location collection)}]
+        (mt/user-http-request :crowberto :put 200 (str "collection/" (u/the-id subcollection)) {:archived true})
+        (is (true? (:can_restore (get-item-with-id-in-coll (collection/trash-collection-id) (u/the-id subcollection)))))))
+    (testing "and when I can't"
+      (t2.with-temp/with-temp [:model/Collection collection {:name "A"}
+                               :model/Collection subcollection {:name "sub-A" :location (collection/children-location collection)}]
+        (mt/user-http-request :crowberto :put 200 (str "collection/" (u/the-id subcollection)) {:archived true})
+        (mt/user-http-request :crowberto :put 200 (str "collection/" (u/the-id collection)) {:archived true})
+        (is (false? (:can_restore (get-item-with-id-in-coll (collection/trash-collection-id) (u/the-id subcollection)))))))))

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -2202,7 +2202,12 @@
                                :model/Collection subcollection {:name "sub-A" :location (collection/children-location collection)}]
         (mt/user-http-request :crowberto :put 200 (str "collection/" (u/the-id subcollection)) {:archived true})
         (mt/user-http-request :crowberto :put 200 (str "collection/" (u/the-id collection)) {:archived true})
-        (is (false? (:can_restore (get-item-with-id-in-coll (collection/trash-collection-id) (u/the-id subcollection))))))))
+        (is (false? (:can_restore (get-item-with-id-in-coll (collection/trash-collection-id) (u/the-id subcollection)))))))
+    (testing "and when I can't because its parent was the one that was trashed"
+      (t2.with-temp/with-temp [:model/Collection collection {:name "A"}
+                               :model/Collection subcollection {:name "sub-A" :location (collection/children-location collection)}]
+        (mt/user-http-request :crowberto :put 200 (str "collection/" (u/the-id collection)) {:archived true})
+        (is (false? (:can_restore (get-item-with-id-in-coll (u/the-id collection) (u/the-id subcollection))))))))
   (testing "can_restore is correctly populated for collections trashed from the root collection"
     (testing "when I can actually restore it"
       (t2.with-temp/with-temp [:model/Collection collection {:name "A"}]

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -2202,4 +2202,9 @@
                                :model/Collection subcollection {:name "sub-A" :location (collection/children-location collection)}]
         (mt/user-http-request :crowberto :put 200 (str "collection/" (u/the-id subcollection)) {:archived true})
         (mt/user-http-request :crowberto :put 200 (str "collection/" (u/the-id collection)) {:archived true})
-        (is (false? (:can_restore (get-item-with-id-in-coll (collection/trash-collection-id) (u/the-id subcollection)))))))))
+        (is (false? (:can_restore (get-item-with-id-in-coll (collection/trash-collection-id) (u/the-id subcollection))))))))
+  (testing "can_restore is correctly populated for collections trashed from the root collection"
+    (testing "when I can actually restore it"
+      (t2.with-temp/with-temp [:model/Collection collection {:name "A"}]
+        (mt/user-http-request :crowberto :put 200 (str "collection/" (u/the-id collection)) {:archived true})
+        (is (true? (:can_restore (get-item-with-id-in-coll (collection/trash-collection-id) (u/the-id collection)))))))))

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -2176,4 +2176,21 @@
                                :model/Dashboard dashboard {:name "Dashboard" :collection_id (u/the-id subcollection)}]
         (mt/user-http-request :crowberto :put 200 (str "dashboard/" (u/the-id dashboard)) {:archived true})
         (mt/user-http-request :crowberto :put 200 (str "collection/" (u/the-id subcollection)) {:archived true})
-        (is (false? (:can_restore (get-item-with-id-in-coll (collection/trash-collection-id) (u/the-id dashboard)))))))))
+        (is (false? (:can_restore (get-item-with-id-in-coll (collection/trash-collection-id) (u/the-id dashboard))))))))
+  (testing "can_restore is correctly populated for card"
+    (testing "when I can actually restore it"
+      (t2.with-temp/with-temp [:model/Collection collection {:name "A"}
+                               :model/Collection subcollection {:name "sub-A" :location (collection/children-location collection)}
+                               :model/Card card {:name "Card" :collection_id (u/the-id subcollection)}]
+        (mt/user-http-request :crowberto :put 200 (str "card/" (u/the-id card)) {:archived true})
+        (is (true? (:can_restore (get-item-with-id-in-coll (collection/trash-collection-id) (u/the-id card)))))))
+    (testing "and when I can't"
+      (t2.with-temp/with-temp [:model/Collection collection {:name "A"}
+                               :model/Collection subcollection {:name "sub-A" :location (collection/children-location collection)}
+                               :model/Card card {:name "Card" :collection_id (u/the-id subcollection)}]
+        (mt/user-http-request :crowberto :put 200 (str "card/" (u/the-id card)) {:archived true})
+        (mt/user-http-request :crowberto :put 200 (str "collection/" (u/the-id subcollection)) {:archived true})
+        (is (false? (:can_restore (get-item-with-id-in-coll (collection/trash-collection-id) (u/the-id card))))))))
+  (testing "can_restore is correctly populated for collection"
+    (testing "when I can actually restore it")
+    (testing "and when I can't")))

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -4453,3 +4453,14 @@
                            :crowberto :post 200
                            (format "/dashboard/%s/dashcard/%s/card/%s/query/%s?format_rows=%s"                                   dashboard-id dashcard-id card-id (name export-format) apply-formatting?))
                           ((get output-helper export-format)))))))))))
+
+
+(deftest ^:parallel can-restore
+  (t2.with-temp/with-temp [:model/Collection collection-a {:name "A"}
+                           :model/Dashboard {dash-id :id} {:name "My Dashboard"
+                                                      :collection_id (u/the-id collection-a)}]
+    ;; trash the dashboard
+    (mt/user-http-request :crowberto :put 200 (str "dashboard/" dash-id) {:archived true})
+    ;; trash the parent collection
+    (mt/user-http-request :crowberto :put 200 (str "collection/" (u/the-id collection-a)) {:archived true})
+    (is (false? (:can_restore (mt/user-http-request :crowberto :get 200 (str "dashboard/" dash-id)))))))

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -4453,14 +4453,35 @@
                            :crowberto :post 200
                            (format "/dashboard/%s/dashcard/%s/card/%s/query/%s?format_rows=%s"                                   dashboard-id dashcard-id card-id (name export-format) apply-formatting?))
                           ((get output-helper export-format)))))))))))
+(deftest can-restore
+  (let [can-restore? (fn [dash-id user]
+                       (:can_restore (mt/user-http-request user :get 200 (str "dashboard/" dash-id))))]
+    (testing "I can restore a simply trashed dashboard"
 
-
-(deftest ^:parallel can-restore
-  (t2.with-temp/with-temp [:model/Collection collection-a {:name "A"}
-                           :model/Dashboard {dash-id :id} {:name "My Dashboard"
-                                                      :collection_id (u/the-id collection-a)}]
-    ;; trash the dashboard
-    (mt/user-http-request :crowberto :put 200 (str "dashboard/" dash-id) {:archived true})
-    ;; trash the parent collection
-    (mt/user-http-request :crowberto :put 200 (str "collection/" (u/the-id collection-a)) {:archived true})
-    (is (false? (:can_restore (mt/user-http-request :crowberto :get 200 (str "dashboard/" dash-id)))))))
+      (t2.with-temp/with-temp [:model/Collection {coll-id :id} {:name "A"}
+                               :model/Dashboard {dash-id :id} {:name          "My Dashboard"
+                                                               :collection_id coll-id}]
+        (mt/user-http-request :crowberto :put 200 (str "dashboard/" dash-id) {:archived true})
+        (is (true? (can-restore? dash-id :rasta)))))
+    (testing "I can't restore a trashed dashboard if the coll it was from was trashed"
+      (t2.with-temp/with-temp [:model/Collection {coll-id :id} {:name "A"}
+                               :model/Dashboard {dash-id :id} {:name          "My Dashboard"
+                                                               :collection_id coll-id}]
+        (mt/user-http-request :crowberto :put 200 (str "dashboard/" dash-id) {:archived true})
+        (mt/user-http-request :crowberto :put 200 (str "collection/" coll-id) {:archived true})
+        (is (false? (can-restore? dash-id :rasta)))))
+    (testing "I can't restore a trashed dashboard if the collection it was from was deleted"
+      (t2.with-temp/with-temp [:model/Collection {coll-id :id} {:name "A"}
+                               :model/Dashboard {dash-id :id} {:name          "My Dashboard"
+                                                               :collection_id coll-id}]
+        (mt/user-http-request :crowberto :put 200 (str "dashboard/" dash-id) {:archived true})
+        (t2/delete! :model/Collection :id coll-id)
+        ;; rasta can no longer view the dashboard at all, because we can't check perms on it
+        (is (= "You don't have permissions to do that." (mt/user-http-request :rasta :get 403 (str "dashboard/" dash-id))))
+        ;; even the mighty crowberto can't restore it!
+        (is (false? (can-restore? dash-id :crowberto)))))
+    (testing "I can't restore a trashed dashboard if it isn't archived in the first place"
+      (t2.with-temp/with-temp [:model/Collection {coll-id :id} {:name "A"}
+                               :model/Dashboard {dash-id :id} {:name          "My Dashboard"
+                                                               :collection_id coll-id}]
+        (is (false? (can-restore? dash-id :crowberto)))))))

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -4484,4 +4484,4 @@
       (t2.with-temp/with-temp [:model/Collection {coll-id :id} {:name "A"}
                                :model/Dashboard {dash-id :id} {:name          "My Dashboard"
                                                                :collection_id coll-id}]
-        (is (false? (can-restore? dash-id :crowberto)))))))
+        (is (nil? (can-restore? dash-id :crowberto)))))))

--- a/test/metabase/models/collection_test.clj
+++ b/test/metabase/models/collection_test.clj
@@ -1076,37 +1076,6 @@
           (is (= false
                  (t2/select-one-fn :archived model :id (u/the-id object)))))))))
 
-(deftest archive-while-moving-test
-  (testing "Test that we cannot archive a Collection at the same time we are moving it"
-    (with-collection-hierarchy [{:keys [c], :as _collections}]
-      (is (thrown?
-           Exception
-           (t2/update! Collection (u/the-id c) {:archived true, :location "/"})))))
-
-  (testing "Test that we cannot unarchive a Collection at the same time we are moving it"
-    (with-collection-hierarchy [{:keys [c], :as _collections}]
-      (t2/update! Collection (u/the-id c) {:archived true})
-      (is (thrown?
-           Exception
-           (t2/update! Collection (u/the-id c) {:archived false, :location "/"})))))
-
-  (testing "Passing in a value of archived that is the same as the value in the DB shouldn't affect anything however!"
-    (with-collection-hierarchy [{:keys [c], :as _collections}]
-      (t2/update! Collection (u/the-id c) {:archived false, :location "/"})
-      (is (= "/"
-             (t2/select-one-fn :location Collection :id (u/the-id c)))))))
-
-(deftest archive-noop-shouldnt-affect-descendants-test
-  (testing "Check that attempting to unarchive a Card that's not archived doesn't affect archived descendants"
-    (with-collection-hierarchy [{:keys [c e], :as _collections}]
-      (t2/update! Collection (u/the-id e) {:archived true})
-      (t2/update! Collection (u/the-id c) {:archived false})
-      (is (= true
-             (t2/select-one-fn :archived Collection :id (u/the-id e)))))))
-
-;; TODO - can you unarchive a Card that is inside an archived Collection??
-
-
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                     Permissions Inheritance Upon Creation!                                     |
 ;;; +----------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
fixes #42700 

for the /collection/:id/items, /collection/:id, /dashboard/:id, and /card/:id endpoints.
