### PR TITLE
Fix metadata loading issues after tabs

### DIFF
--- a/frontend/src/metabase/dashboard/actions/data-fetching-typed.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching-typed.ts
@@ -4,6 +4,7 @@ import { loadMetadataForDashboard } from "metabase/dashboard/actions/metadata";
 import {
   getDashboardById,
   getDashCardById,
+  getInitialSelectedTabId,
   getParameterValues,
   getQuestions,
   getSelectedTabId,
@@ -126,7 +127,8 @@ export const fetchDashboard = createAsyncThunk(
       fetchDashboardCancellation = null;
 
       if (dashboardType === "normal" || dashboardType === "transient") {
-        const selectedTabId = getSelectedTabId(getState());
+        const selectedTabId =
+          getSelectedTabId(getState()) ?? getInitialSelectedTabId(result);
 
         const cards =
           selectedTabId === undefined

--- a/frontend/src/metabase/dashboard/actions/data-fetching-typed.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching-typed.ts
@@ -131,7 +131,7 @@ export const fetchDashboard = createAsyncThunk(
           getSelectedTabId(getState()) ?? getInitialSelectedTabId(result);
 
         const cards =
-          selectedTabId === undefined
+          selectedTabId == null
             ? result.dashcards
             : result.dashcards.filter(
                 (c: DashboardCard) => c.dashboard_tab_id === selectedTabId,

--- a/frontend/src/metabase/dashboard/actions/data-fetching.unit.spec.js
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.unit.spec.js
@@ -1,12 +1,23 @@
-import { configureStore } from "@reduxjs/toolkit";
+import fetchMock from "fetch-mock";
 
-import { setupDashboardsEndpoints } from "__support__/server-mocks";
-import { createMockEntitiesState } from "__support__/store";
+import { getStore } from "__support__/entities-store";
 import {
+  setupDashboardsEndpoints,
+  setupDatabaseEndpoints,
+} from "__support__/server-mocks";
+import { createMockEntitiesState } from "__support__/store";
+import { Api } from "metabase/api";
+import {
+  createMockCard,
   createMockDashboard,
-  createMockDatabase,
+  createMockDashboardCard,
   createMockSettings,
+  createMockStructuredDatasetQuery,
 } from "metabase-types/api/mocks";
+import {
+  createSampleDatabase,
+  ORDERS_ID,
+} from "metabase-types/api/mocks/presets";
 import { createMockDashboardState } from "metabase-types/store/mocks";
 
 import { dashboardReducers } from "../reducers";
@@ -14,29 +25,64 @@ import { dashboardReducers } from "../reducers";
 import { fetchDashboard } from "./data-fetching-typed";
 
 function setup({ dashboards = [] }) {
+  const database = createSampleDatabase();
   const state = {
     dashboard: createMockDashboardState(),
     entities: createMockEntitiesState({
-      databases: [createMockDatabase()],
+      databases: [database],
     }),
     settings: createMockSettings(),
   };
 
-  const store = configureStore({
-    reducer: {
+  const store = getStore(
+    {
+      [Api.reducerPath]: Api.reducer,
       dashboard: dashboardReducers,
       entities: (state = {}) => state,
       settings: (state = {}) => state,
     },
-    preloadedState: state,
-  });
+    state,
+    [Api.middleware],
+  );
 
+  setupDatabaseEndpoints(database);
   setupDashboardsEndpoints(dashboards);
 
   return store;
 }
 
 describe("fetchDashboard", () => {
+  it("should fetch card metadata upfront", async () => {
+    const dashboard = createMockDashboard({
+      dashcards: [
+        createMockDashboardCard({
+          card: createMockCard({
+            dataset_query: createMockStructuredDatasetQuery({
+              query: {
+                "source-table": ORDERS_ID,
+              },
+            }),
+          }),
+        }),
+      ],
+    });
+    const store = setup({
+      dashboards: [dashboard],
+    });
+
+    await store.dispatch(
+      fetchDashboard({
+        dashId: dashboard.id,
+        queryParams: {},
+        options: {},
+      }),
+    );
+
+    expect(
+      fetchMock.calls(`path:/api/table/${ORDERS_ID}/query_metadata`),
+    ).toHaveLength(1);
+  });
+
   it("should cancel previous dashboard fetch when a new one is initiated (metabase#35959)", async () => {
     const store = setup({
       dashboards: [

--- a/frontend/src/metabase/dashboard/actions/data-fetching.unit.spec.js
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.unit.spec.js
@@ -11,12 +11,14 @@ import {
   createMockCard,
   createMockDashboard,
   createMockDashboardCard,
+  createMockDashboardTab,
   createMockSettings,
   createMockStructuredDatasetQuery,
 } from "metabase-types/api/mocks";
 import {
   createSampleDatabase,
   ORDERS_ID,
+  PRODUCTS_ID,
 } from "metabase-types/api/mocks/presets";
 import { createMockDashboardState } from "metabase-types/store/mocks";
 
@@ -52,9 +54,18 @@ function setup({ dashboards = [] }) {
 }
 
 describe("fetchDashboard", () => {
-  it("should fetch card metadata upfront", async () => {
+  it("should fetch metadata for all cards when there are no tabs", async () => {
     const dashboard = createMockDashboard({
       dashcards: [
+        createMockDashboardCard({
+          card: createMockCard({
+            dataset_query: createMockStructuredDatasetQuery({
+              query: {
+                "source-table": PRODUCTS_ID,
+              },
+            }),
+          }),
+        }),
         createMockDashboardCard({
           card: createMockCard({
             dataset_query: createMockStructuredDatasetQuery({
@@ -79,8 +90,64 @@ describe("fetchDashboard", () => {
     );
 
     expect(
+      fetchMock.calls(`path:/api/table/${PRODUCTS_ID}/query_metadata`),
+    ).toHaveLength(1);
+    expect(
       fetchMock.calls(`path:/api/table/${ORDERS_ID}/query_metadata`),
     ).toHaveLength(1);
+  });
+
+  it("should fetch metadata for cards on the first tab when there are tabs", async () => {
+    const dashboard = createMockDashboard({
+      dashcards: [
+        createMockDashboardCard({
+          card: createMockCard({
+            dataset_query: createMockStructuredDatasetQuery({
+              query: {
+                "source-table": PRODUCTS_ID,
+              },
+            }),
+          }),
+          dashboard_tab_id: 1,
+        }),
+        createMockDashboardCard({
+          card: createMockCard({
+            dataset_query: createMockStructuredDatasetQuery({
+              query: {
+                "source-table": ORDERS_ID,
+              },
+            }),
+          }),
+          dashboard_tab_id: 2,
+        }),
+      ],
+      tabs: [
+        createMockDashboardTab({
+          id: 1,
+        }),
+        createMockDashboardTab({
+          id: 2,
+        }),
+      ],
+    });
+    const store = setup({
+      dashboards: [dashboard],
+    });
+
+    await store.dispatch(
+      fetchDashboard({
+        dashId: dashboard.id,
+        queryParams: {},
+        options: {},
+      }),
+    );
+
+    expect(
+      fetchMock.calls(`path:/api/table/${PRODUCTS_ID}/query_metadata`),
+    ).toHaveLength(1);
+    expect(
+      fetchMock.calls(`path:/api/table/${ORDERS_ID}/query_metadata`),
+    ).toHaveLength(0);
   });
 
   it("should cancel previous dashboard fetch when a new one is initiated (metabase#35959)", async () => {

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -22,11 +22,13 @@ import type {
   DashboardCard,
   DashboardParameterMapping,
   ParameterId,
+  Dashboard,
 } from "metabase-types/api";
 import type {
   ClickBehaviorSidebarState,
   EditParameterSidebarState,
   State,
+  StoreDashboard,
 } from "metabase-types/store";
 
 import { isQuestionCard, isQuestionDashCard } from "./utils";
@@ -423,12 +425,16 @@ export const getSelectedTabId = createSelector(
   [getDashboard, state => state.dashboard.selectedTabId],
   (dashboard, selectedTabId) => {
     if (dashboard && selectedTabId === null) {
-      return dashboard.tabs?.[0]?.id || null;
+      return getInitialSelectedTabId(dashboard);
     }
 
     return selectedTabId;
   },
 );
+
+export function getInitialSelectedTabId(dashboard: Dashboard | StoreDashboard) {
+  return dashboard.tabs?.[0]?.id || null;
+}
 
 export const getParameterMappingsBeforeEditing = createSelector(
   [getDashboardBeforeEditing],


### PR DESCRIPTION
Regression from https://github.com/metabase/metabase/pull/31578

The issue was that previously we used to load all metadata upfront before showing dashcards on the screen. With the PR above we no longer do that and instead show dashcards immediately; each dashcard is responsible for loading metadata. The problem is that this causes severe performance issues with MBQL lib as metadata keeps constantly changing for queries on the screen, leading to 15s+ UI thread locks.

How to verify:
- This change should be invisible to e2e tests. There are new unit tests for this case.

https://metaboat.slack.com/archives/C505ZNNH4/p1715690842065689
