### PR TITLE
remove percent change tooltip from waterfall chart

### DIFF
--- a/frontend/src/metabase/lib/time-dayjs.ts
+++ b/frontend/src/metabase/lib/time-dayjs.ts
@@ -18,9 +18,7 @@ const DAYLIGHT_SAVINGS_CHANGE_TOLERANCE: Record<string, number> = {
 
 /**
  * This function is used to get a tolerance for the difference between two dates
- * across the daylight savings time change, using dayjs' date.diff method. For
- * example between March 10th (when daylight savings beigns) and March 11th, the
- * .diff method will return
+ * across the daylight savings time change, using dayjs' date.diff method.
  */
 export function getDaylightSavingsChangeTolerance(unit: string) {
   return unit in DAYLIGHT_SAVINGS_CHANGE_TOLERANCE

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
@@ -197,7 +197,11 @@ const getTooltipFooterData = (
   seriesIndex: number,
   dataIndex: number,
 ): DataPoint[] => {
-  if (display === "scatter" || !isTimeSeriesAxis(chartModel.xAxisModel)) {
+  if (
+    display === "scatter" ||
+    display === "waterfall" ||
+    !isTimeSeriesAxis(chartModel.xAxisModel)
+  ) {
     return [];
   }
 


### PR DESCRIPTION
Thread: https://metaboat.slack.com/archives/C064QMXEV9N/p1715713861630869?thread_ts=1715713368.007149&cid=C064QMXEV9N

### Description

We decided not to show the percent change tooltip and waterfall charts, so I'm removing it here.

### Demo

![Screenshot 2024-05-14 at 12.17.33 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/eff5a6f0-c51d-4d7d-a0e9-9ca2aceb0c5c.png)