### PR TITLE
[MBQL lib] Reject `offset` in expressions with no sort order

### DIFF
--- a/frontend/src/metabase-lib/expression.ts
+++ b/frontend/src/metabase-lib/expression.ts
@@ -15,6 +15,7 @@ import type {
 
 type ErrorWithMessage = {
   message: string;
+  friendly?: boolean;
 };
 
 export function expression(

--- a/frontend/src/metabase-lib/v1/expressions/diagnostics.ts
+++ b/frontend/src/metabase-lib/v1/expressions/diagnostics.ts
@@ -155,9 +155,11 @@ export function diagnose({
   if (possibleError) {
     console.warn("diagnostic error", possibleError.message);
 
-    // diagnoseExpression should return a user friendly message, which we'll be
-    // able to return directly
-    return { message: t`Invalid expression` };
+    // diagnoseExpression returns some messages which are user-friendly and some which are not.
+    // If the `friendly` flag is true, we can use the possibleError as-is; if not then use a generic message.
+    return possibleError.friendly
+      ? possibleError
+      : { message: t`Invalid expression` };
   }
 
   return null;

--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -225,7 +225,8 @@
     expression-name :- ::lib.schema.common/non-blank-string
     expressionable
     options         :- [:maybe ::add-expression-options]]
-   (let [stage-number (or stage-number -1)]
+   (let [stage-number   (or stage-number -1)
+         expressionable (lib.common/->op-arg expressionable)]
      ;; TODO: This logic was removed as part of fixing #39059. We might want to bring it back for collisions with other
      ;; expressions in the same stage; probably not with tables or earlier stages. De-duplicating names is supported by
      ;; the QP code, and it should be powered by MLv2 in due course.
@@ -235,8 +236,7 @@
      (lib.util/update-query-stage
        query stage-number
        add-expression-to-stage
-       (-> (lib.common/->op-arg expressionable)
-           (lib.util/top-level-expression-clause expression-name))
+       (lib.util/top-level-expression-clause expressionable expression-name)
        options))))
 
 (lib.common/defop + [x y & more])
@@ -450,12 +450,12 @@
   `expression-position` is provided, for cyclic references with other expressions.
 
   - `expr` is a pMBQL expression usually created from a legacy MBQL expression created
-    using the custom column editor in the FE. It is expected to have been normalized and
-    converted using [[metabase.lib.convert/->pMBQL]].
+  using the custom column editor in the FE. It is expected to have been normalized and
+  converted using [[metabase.lib.convert/->pMBQL]].
   - `expression-mode` specifies what type of thing `expr` is: an :expression (custom column),
-    an :aggregation expression, or a :filter condition.
+  an :aggregation expression, or a :filter condition.
   - `expression-position` is only defined when editing an existing custom column, and in that case
-    it is the index of that expression in (expressions query stage-number).
+  it is the index of that expression in (expressions query stage-number).
 
   The function returns nil, if the expression is valid, otherwise it returns a map with
   an i18n message describing the problem under the key :message."
@@ -468,17 +468,27 @@
                                 :expression [expression-validator expression-explainer]
                                 :aggregation [aggregation-validator aggregation-explainer]
                                 :filter [filter-validator filter-explainer])]
-    (if (not (validator expr))
-      (let [error (explainer expr)
-            humanized (str/join ", " (me/humanize error))]
-        {:message (i18n/tru "Type error: {0}" humanized)})
-      (when-let [path (and (= expression-mode :expression)
-                           expression-position
-                           (let [exprs (expressions query stage-number)
-                                 edited-expr (nth exprs expression-position)
-                                 edited-name (expression->name edited-expr)
-                                 deps (-> (m/index-by expression->name exprs)
-                                          (assoc edited-name expr)
-                                          (update-vals referred-expressions))]
-                             (cyclic-definition deps)))]
-        {:message (i18n/tru "Cycle detected: {0}" (str/join " → " path))}))))
+    (or (when-not (validator expr)
+          (let [error (explainer expr)
+                humanized (str/join ", " (me/humanize error))]
+            {:message (i18n/tru "Type error: {0}" humanized)}))
+        (when-let [path (and (= expression-mode :expression)
+                             expression-position
+                             (let [exprs (expressions query stage-number)
+                                   edited-expr (nth exprs expression-position)
+                                   edited-name (expression->name edited-expr)
+                                   deps (-> (m/index-by expression->name exprs)
+                                            (assoc edited-name expr)
+                                            (update-vals referred-expressions))]
+                               (cyclic-definition deps)))]
+          {:message  (i18n/tru "Cycle detected: {0}" (str/join " → " path))
+           :friendly true})
+        (when (and (= expression-mode :expression)
+                   (lib.util.match/match-one expr :offset)
+                   (empty? (:order-by (lib.util/query-stage query stage-number))))
+          {:message  (i18n/tru "OFFSET in a custom expression requires a sort order")
+           :friendly true})
+        (when (and (= expression-mode :filter)
+                   (lib.util.match/match-one expr :offset))
+          {:message  (i18n/tru "OFFSET is not supported in custom filters")
+           :friendly true}))))

--- a/test/metabase/lib/expression_test.cljc
+++ b/test/metabase/lib/expression_test.cljc
@@ -490,7 +490,32 @@
                              (assoc 3 (lib/count)))
             :filter      (assoc (get exprs "circular-c") 0 :=)))
         (testing "circular definition"
-          (is (= {:message "Cycle detected: c → x → b → c"}
-                 (lib.expression/diagnose-expression query 0 :expression
-                                                     (get exprs "circular-c")
-                                                     c-pos))))))))
+          (is (=? {:message "Cycle detected: c → x → b → c"}
+                  (lib.expression/diagnose-expression query 0 :expression
+                                                      (get exprs "circular-c")
+                                                      c-pos))))))))
+
+(deftest ^:parallel diagnose-expression-test-4-offset-requires-order
+  (testing "adding/editing an offset expression"
+    (let [query (lib/query meta/metadata-provider (meta/table-metadata :orders))]
+      (testing "returns a message when there is no ordering"
+        (is (=? {:message "OFFSET in a custom expression requires a sort order"}
+                (lib.expression/diagnose-expression query 0 :expression
+                                                    (lib/offset (meta/field-metadata :orders :subtotal) -1)
+                                                    nil))))
+      (testing "works with a defined order"
+        (is (nil? (-> query
+                      (lib/order-by (meta/field-metadata :orders :created-at))
+                      (lib.expression/diagnose-expression 0 :expression
+                                                          (lib/offset (meta/field-metadata :orders :subtotal) -1)
+                                                          nil))))))))
+
+(deftest ^:parallel diagnose-expression-test-5-offset-not-allowed-in-filters
+  (testing "adding/editing a filter using offset is not allowed"
+    (let [query (lib/query meta/metadata-provider (meta/table-metadata :orders))]
+      (is (=? {:message  "OFFSET is not supported in custom filters"
+               :friendly true}
+              (lib.expression/diagnose-expression query 0 :filter
+                                                  (lib/< (lib/offset (meta/field-metadata :orders :subtotal) -1)
+                                                         100)
+                                                  nil))))))


### PR DESCRIPTION
Using `offset` as an aggregation is fine, but it doesn't work as an
expression unless the query has an order-by.

Part of #42318.
