### PR TITLE
Move createMockModelResult to browse folder

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/content_verification/utils.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/content_verification/utils.unit.spec.ts
@@ -1,5 +1,5 @@
+import { createMockModelResult } from "metabase/browse/test-utils";
 import type { CollectionEssentials } from "metabase-types/api";
-import { createMockModelResult } from "metabase-types/api/mocks";
 
 import { availableModelFilters, sortCollectionsByVerification } from "./utils";
 

--- a/frontend/src/metabase-types/api/mocks/search.ts
+++ b/frontend/src/metabase-types/api/mocks/search.ts
@@ -1,7 +1,6 @@
 import _ from "underscore";
 
 import type {
-  ModelResult,
   SearchResponse,
   SearchResult,
   SearchScore,
@@ -81,8 +80,3 @@ export const createMockSearchResults = ({
     ...options,
   };
 };
-
-export const createMockModelResult = (
-  model: Partial<ModelResult>,
-): ModelResult =>
-  createMockSearchResult({ ...model, model: "dataset" }) as ModelResult;

--- a/frontend/src/metabase/browse/components/BrowseModels.unit.spec.tsx
+++ b/frontend/src/metabase/browse/components/BrowseModels.unit.spec.tsx
@@ -5,11 +5,10 @@ import {
 import { renderWithProviders, screen } from "__support__/ui";
 import { defaultRootCollection } from "metabase/admin/permissions/pages/CollectionPermissionsPage/tests/setup";
 import type { SearchResult } from "metabase-types/api";
-import {
-  createMockCollection,
-  createMockModelResult,
-} from "metabase-types/api/mocks";
+import { createMockCollection } from "metabase-types/api/mocks";
 import { createMockSetupState } from "metabase-types/store/mocks";
+
+import { createMockModelResult } from "../test-utils";
 
 import { BrowseModels } from "./BrowseModels";
 

--- a/frontend/src/metabase/browse/components/utils.unit.spec.tsx
+++ b/frontend/src/metabase/browse/components/utils.unit.spec.tsx
@@ -1,9 +1,8 @@
 import { SortDirection } from "metabase/components/ItemsTable/Columns";
 import type { ModelResult } from "metabase-types/api";
-import {
-  createMockCollection,
-  createMockModelResult,
-} from "metabase-types/api/mocks";
+import { createMockCollection } from "metabase-types/api/mocks";
+
+import { createMockModelResult } from "../test-utils";
 
 import { getCollectionPathString, sortModels } from "./utils";
 

--- a/frontend/src/metabase/browse/test-utils.ts
+++ b/frontend/src/metabase/browse/test-utils.ts
@@ -1,0 +1,8 @@
+import { createMockSearchResult } from "metabase-types/api/mocks";
+
+import type { ModelResult } from "./types";
+
+export const createMockModelResult = (
+  model: Partial<ModelResult>,
+): ModelResult =>
+  createMockSearchResult({ ...model, model: "dataset" }) as ModelResult;

--- a/frontend/src/metabase/browse/test-utils.ts
+++ b/frontend/src/metabase/browse/test-utils.ts
@@ -1,6 +1,5 @@
+import type { ModelResult } from "metabase-types/api";
 import { createMockSearchResult } from "metabase-types/api/mocks";
-
-import type { ModelResult } from "./types";
 
 export const createMockModelResult = (
   model: Partial<ModelResult>,

--- a/frontend/src/metabase/browse/utils.unit.spec.ts
+++ b/frontend/src/metabase/browse/utils.unit.spec.ts
@@ -1,10 +1,8 @@
 import { defaultRootCollection } from "metabase/admin/permissions/pages/CollectionPermissionsPage/tests/setup";
 import type { SearchResult, ModelResult } from "metabase-types/api";
-import {
-  createMockCollection,
-  createMockModelResult,
-} from "metabase-types/api/mocks";
+import { createMockCollection } from "metabase-types/api/mocks";
 
+import { createMockModelResult } from "./test-utils";
 import type { ActualModelFilters, AvailableModelFilters } from "./utils";
 import { filterModels } from "./utils";
 


### PR DESCRIPTION
Small refactor: move a test helper function, `createMockModelResult`, to the `browse` folder since it's specific to that part of the app.