### PR TITLE
Fix broken pivot table questions that had out of date viz settings

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/reproductions/42697-pivot-new-breakout.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/reproductions/42697-pivot-new-breakout.cy.spec.js
@@ -66,12 +66,10 @@ describe("issue 42697", () => {
     restore();
     cy.signInAsNormalUser();
     cy.intercept("PUT", "/api/card/*").as("updateCard");
-    cy.intercept("POST", "/api/card/pivot/*/query").as("cardPivotQuery");
   });
 
   it("should display a pivot table when a new breakout is added to the query (metabase#42697)", () => {
     createQuestion(PIVOT_QUESTION, { visitQuestion: true });
-    cy.wait("@cardPivotQuery");
     openNotebook();
     getNotebookStep("summarize")
       .findByTestId("breakout-step")

--- a/e2e/test/scenarios/visualizations-tabular/reproductions/42697-pivot-new-breakout.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/reproductions/42697-pivot-new-breakout.cy.spec.js
@@ -1,0 +1,92 @@
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import {
+  createQuestion,
+  getNotebookStep,
+  modal,
+  openNotebook,
+  popover,
+  queryBuilderHeader,
+  restore,
+} from "e2e/support/helpers";
+
+const { ORDERS, ORDERS_ID, PEOPLE } = SAMPLE_DATABASE;
+
+const PIVOT_QUESTION = {
+  display: "pivot",
+  query: {
+    "source-table": ORDERS_ID,
+    aggregation: [
+      ["count"],
+      ["sum", ["field", ORDERS.TOTAL, { "base-type": "type/Float" }]],
+    ],
+    breakout: [
+      [
+        "field",
+        PEOPLE.STATE,
+        { "base-type": "type/Text", "source-field": ORDERS.USER_ID },
+      ],
+      [
+        "field",
+        ORDERS.CREATED_AT,
+        { "base-type": "type/DateTime", "temporal-unit": "year" },
+      ],
+    ],
+  },
+  visualization_settings: {
+    "pivot_table.column_split": {
+      rows: [
+        [
+          "field",
+          ORDERS.CREATED_AT,
+          { "base-type": "type/DateTime", "temporal-unit": "year" },
+        ],
+      ],
+      columns: [
+        [
+          "field",
+          PEOPLE.STATE,
+          { "base-type": "type/Text", "source-field": ORDERS.USER_ID },
+        ],
+      ],
+      values: [
+        ["aggregation", 0],
+        ["aggregation", 1],
+      ],
+    },
+    "pivot_table.column_widths": {
+      leftHeaderWidths: [156],
+      totalLeftHeaderWidths: 156,
+      valueHeaderWidths: {},
+    },
+  },
+};
+
+describe("issue 42697", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+    cy.intercept("PUT", "/api/card/*").as("updateCard");
+    cy.intercept("POST", "/api/card/pivot/*/query").as("cardPivotQuery");
+  });
+
+  it("should display a pivot table when a new breakout is added to the query (metabase#42697)", () => {
+    createQuestion(PIVOT_QUESTION, { visitQuestion: true });
+    cy.wait("@cardPivotQuery");
+    openNotebook();
+    getNotebookStep("summarize")
+      .findByTestId("breakout-step")
+      .icon("add")
+      .click();
+    popover().within(() => {
+      cy.findByText("Product").click();
+      cy.findByText("Category").click();
+    });
+    queryBuilderHeader().findByText("Save").click();
+    modal().button("Save").click();
+    cy.wait("@updateCard");
+    cy.button("Visualize").click();
+    cy.findByTestId("pivot-table")
+      .findByText("Product → Category")
+      .should("be.visible");
+  });
+});

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
@@ -176,7 +176,9 @@ function PivotTable({
   ].every(Boolean);
   const columnsChanged =
     !hasColumnWidths ||
-    (previousRowIndexes && !_.isEqual(pivoted?.rowIndexes, previousRowIndexes));
+    (previousRowIndexes &&
+      !_.isEqual(pivoted?.rowIndexes, previousRowIndexes)) ||
+    leftHeaderWidths?.length !== pivoted?.rowIndexes?.length;
 
   // In cases where there are horizontal scrollbars are visible AND the data grid has to scroll vertically as well,
   // the left sidebar and the main grid can get out of ScrollSync due to slightly differing heights


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/42697
Started from https://metaboat.slack.com/archives/C05MPF0TM3L/p1715724408732989

If `leftHeaderWidths` viz setting goes out of sync with the query, reset the setting to the default value and do not break the chart.

Before
<img width="1329" alt="Screenshot 2024-05-15 at 14 34 49" src="https://github.com/metabase/metabase/assets/8542534/0213b38d-10d0-4664-b6c4-53ddc9773505">

After
<img width="1323" alt="Screenshot 2024-05-15 at 14 34 18" src="https://github.com/metabase/metabase/assets/8542534/b0ace68e-6009-4c12-892f-a88fdf4b0899">
