### PR TITLE
[ParseSQL] Find-and-replace for variables and field filters

### DIFF
--- a/src/metabase/native_query_analyzer.clj
+++ b/src/metabase/native_query_analyzer.clj
@@ -16,9 +16,16 @@
    [macaw.core :as macaw]
    [metabase.config :as config]
    [metabase.native-query-analyzer.parameter-substitution :as nqa.sub]
+   [metabase.native-query-analyzer.replacement :as nqa.replacement]
    [metabase.public-settings :as public-settings]
    [metabase.util :as u]
+   [potemkin :as p]
    [toucan2.core :as t2]))
+
+(comment nqa.replacement/keep-me)
+
+(p/import-vars
+ [nqa.replacement replace-names])
 
 (def ^:dynamic *parse-queries-in-test?*
   "Normally, a native card's query is parsed on every create/update. For most tests, this is an unnecessary
@@ -125,15 +132,3 @@
                         direct-ids)]
       {:direct   direct-ids
        :indirect indirect-ids})))
-
-;; TODO: does not support template tags
-(defn replace-names
-  "Returns a modified query with the given table and column renames applied. `renames` is expected to be a map with
-  `:tables` and `:columns` keys, and values of the shape `old-name -> new-name`:
-
-  (replace-names \"SELECT o.id, o.total FROM orders o\" {:columns {\"id\" \"pk\"
-                                                                   \"total\" \"amount\"}
-                                                         :tables {\"orders\" \"purchases\"}})
- ;; => \"SELECT o.pk, o.amount FROM purchases o\""
-  [sql-query renames]
-  (macaw/replace-names sql-query renames))

--- a/src/metabase/native_query_analyzer/replacement.clj
+++ b/src/metabase/native_query_analyzer/replacement.clj
@@ -74,8 +74,8 @@
           replacements))
 
 (defn replace-names
-  "Given a query and a map of renames (with keys `:tables` and `:colums`, as in Macaw), return a new one with the
-  appropriate replacements made."
+  "Given a dataset_query and a map of renames (with keys `:tables` and `:columns`, as in Macaw), return a new inner query
+  with the appropriate replacements made."
   [query renames]
   (let [raw-query    (get-in query [:native :query])
         parsed-query (params.parse/parse raw-query)

--- a/src/metabase/native_query_analyzer/replacement.clj
+++ b/src/metabase/native_query_analyzer/replacement.clj
@@ -74,11 +74,9 @@
           replacements))
 
 (defn replace-names
-  "Given a card and a map of renames (with keys `:tables` and `:colums`, as in Macaw), return a new _query_ with the
+  "Given a query and a map of renames (with keys `:tables` and `:colums`, as in Macaw), return a new one with the
   appropriate replacements made."
-  [{query :dataset_query :as card} renames]
-  (when-not (= :native (:type query))
-    (throw (ex-info "Expected a native query" {:card card})))
+  [query renames]
   (let [raw-query    (get-in query [:native :query])
         parsed-query (params.parse/parse raw-query)
         {clean-query :query

--- a/src/metabase/native_query_analyzer/replacement.clj
+++ b/src/metabase/native_query_analyzer/replacement.clj
@@ -73,6 +73,18 @@
           the-string
           replacements))
 
+;; remove this once Macaw#32 is fixed
+(defn- clean-renames-macaw-issue-32
+  [{:keys [tables columns]}]
+  (let [clean-column (fn [c] (or (:column c) c))
+        clean-table  (fn [t] (or (:table t) t))]
+    {:columns (-> columns
+                  (update-keys clean-column)
+                  (update-vals clean-column))
+     :tables  (-> tables
+                  (update-keys clean-table)
+                  (update-vals clean-table))}))
+
 (defn replace-names
   "Given a dataset_query and a map of renames (with keys `:tables` and `:columns`, as in Macaw), return a new inner query
   with the appropriate replacements made."
@@ -81,5 +93,5 @@
         parsed-query (params.parse/parse raw-query)
         {clean-query :query
          tt-subs     :substitutions} (parse-tree->clean-query raw-query parsed-query)
-        renamed-query (macaw/replace-names clean-query renames)]
+        renamed-query (macaw/replace-names clean-query (clean-renames-macaw-issue-32 renames))]
     (replace-all renamed-query tt-subs)))

--- a/src/metabase/native_query_analyzer/replacement.clj
+++ b/src/metabase/native_query_analyzer/replacement.clj
@@ -1,0 +1,87 @@
+(ns metabase.native-query-analyzer.replacement
+  (:require
+   [clojure.string :as str]
+   [macaw.core :as macaw]
+   [metabase.driver.common.parameters :as params]
+   [metabase.driver.common.parameters.parse :as params.parse]))
+
+(defn- first-unique
+  [raw-query f]
+  (first (filter #(not (str/includes? raw-query %))
+                 (repeatedly f))))
+
+(defn- gensymed-string
+  []
+  (format "'%s'" (gensym "metabase_sentinel_")))
+
+(defn- sentinel-variable
+  [raw-query]
+  (first-unique raw-query gensymed-string))
+
+(defn- sentinel-field-filter
+  [raw-query]
+  (first-unique raw-query #(apply format "(%s = %s)" (repeat 2 (gensymed-string)))))
+
+(defn- braceify
+  [s]
+  (format "{{%s}}" s))
+
+(defn- add-tag
+  [all-subs new-sub token]
+  (assoc all-subs new-sub (braceify (:k token))))
+
+(defn- parse-tree->clean-query
+  [raw-query tokens]
+  (loop
+      [[token & rest] tokens
+       query-so-far   ""
+       substitutions  {}]
+    (cond
+      (nil? token)
+      {:query         query-so-far
+       :substitutions substitutions}
+
+      (string? token)
+      (recur rest (str query-so-far token) substitutions)
+
+      (params/Param? token)
+      (let [sub (sentinel-variable raw-query)]
+        (recur rest
+               (str query-so-far sub)
+               (add-tag substitutions sub token)))
+
+      (params/FieldFilter? token)
+      (let [sub (sentinel-field-filter raw-query)]
+        (recur rest
+               (str query-so-far sub)
+               (add-tag substitutions sub token)))
+
+      :else
+      ;; will be addressed by #42582, etc.
+      (throw (ex-info "Unsupported token in native query" {:token token})))))
+
+(defn- replace-all
+  "Return `the-string` with all the keys of `replacements` replaced by their values.
+
+  (replace-all \"foo bar baz\" {\"foo\" \"quux\"
+                                \"ba\"  \"xx\"})
+  ;; =>
+  \"quux xxr xxz\""
+  [the-string replacements]
+  (reduce (fn [s [from to]]
+            (str/replace s from to))
+          the-string
+          replacements))
+
+(defn replace-names
+  "Given a card and a map of renames (with keys `:tables` and `:colums`, as in Macaw), return a new _query_ with the
+  appropriate replacements made."
+  [{query :dataset_query :as card} renames]
+  (when-not (= :native (:type query))
+    (throw (ex-info "Expected a native query" {:card card})))
+  (let [raw-query    (get-in query [:native :query])
+        parsed-query (params.parse/parse raw-query)
+        {clean-query :query
+         tt-subs     :substitutions} (parse-tree->clean-query raw-query parsed-query)
+        renamed-query (macaw/replace-names clean-query renames)]
+    (replace-all renamed-query tt-subs)))

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -188,6 +188,14 @@
           (is (= 2 (t2/count :model/Action :id [:in [action-id-1 action-id-2]])))
           (is (= 2 (t2/count :model/ImplicitAction :action_id [:in [action-id-1 action-id-2]]))))))))
 
+(deftest replace-fields-and-tables!-test
+  (testing "fields and tables in a native card can be replaced"
+    (t2.with-temp/with-temp [:model/Card {card-id :id :as card} {:dataset_query (mt/native-query {:query "SELECT TOTAL FROM ORDERS"})}]
+      (card/replace-fields-and-tables! card {:fields {(mt/id :orders :total) (mt/id :people :name)}
+                                             :tables {(mt/id :orders) (mt/id :people)}})
+      (is (= "SELECT NAME FROM PEOPLE"
+             (:query (:native (t2/select-one-fn :dataset_query :model/Card :id card-id))))))))
+
 ;;; ------------------------------------------ Circular Reference Detection ------------------------------------------
 
 (defn- card-with-source-table

--- a/test/metabase/native_query_analyzer/replacement_test.clj
+++ b/test/metabase/native_query_analyzer/replacement_test.clj
@@ -5,9 +5,9 @@
    [metabase.test :as mt]))
 
 (defn- q
-  "Make a card-like whose native query is the concatenation of the args"
+  "Make a native query from the concatenation of the args"
   [& args]
-  {:dataset_query (mt/native-query {:query (apply str args)})})
+  (mt/native-query {:query (apply str args)}))
 
 (deftest ^:parallel replace-names-simple-test
   (testing "columns can be renamed"

--- a/test/metabase/native_query_analyzer/replacement_test.clj
+++ b/test/metabase/native_query_analyzer/replacement_test.clj
@@ -1,0 +1,53 @@
+(ns metabase.native-query-analyzer.replacement-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.native-query-analyzer.replacement :refer [replace-names]]
+   [metabase.test :as mt]))
+
+(defn- q
+  "Make a card-like whose native query is the concatenation of the args"
+  [& args]
+  {:dataset_query (mt/native-query {:query (apply str args)})})
+
+(deftest ^:parallel replace-names-simple-test
+  (testing "columns can be renamed"
+    (is (= "select cost from orders"
+           (replace-names (q "select amount from orders") {:columns {"amount" "cost"}})) ))
+  (testing "tables can be renamed"
+    (is (= "select amount from purchases"
+           (replace-names (q "select amount from orders") {:tables {"orders" "purchases"}})) ))
+  (testing "many things can be renamed at once"
+    (is (= "select cost, tax from purchases"
+           (replace-names (q "select amount, fee from orders") {:columns {"amount" "cost"
+                                                                          "fee"    "tax"}
+                                                              :tables {"orders" "purchases"}})) )))
+
+(deftest ^:parallel replace-names-whitespace-test
+  (testing "comments, whitespace, etc. are preserved"
+    (is (= (str "select cost, tax -- from orders\n"
+                "from purchases")
+           (replace-names (q "select amount, fee -- from orders\n"
+                             "from orders")
+                          {:columns {"amount" "cost"
+                                     "fee"    "tax"}
+                           :tables {"orders" "purchases"}})) )))
+
+(deftest ^:parallel variables-test
+  (testing "with variables (template tags)"
+    (is (= (str "\n\nSELECT *\nFROM folk\nWHERE\n  referral = {{source}}\n  OR \n  id = {{id}}\n  OR \n  birthday = "
+                "{{birthday}}\n  OR\n  zip = {{zipcode}}")
+           (replace-names (q "\n\nSELECT *\nFROM people\nWHERE\n  source = {{source}}\n  OR \n  id = {{id}}\n  OR \n"
+                             "  birth_date = {{birthday}}\n  OR\n  zip = {{zipcode}}")
+                          {:columns {"source"     "referral"
+                                     "birth_date" "birthday"}
+                           :tables  {"people" "folk"}})))))
+
+(deftest ^:parallel field-filter-test
+  (testing "with variables *and* field filters"
+    (is (= (str "\n\nSELECT *\nFROM folk\nWHERE\n  referral = {{source}}\n   OR \n  id = {{id}} \n  OR \n"
+                "  {{birthday}}\n  OR\n  {{zipcode}}\n  OR\n  {{city}} ")
+           (replace-names (q "\n\nSELECT *\nFROM people\nWHERE\n  source = {{source}}\n   OR \n  id = {{id}} \n  OR \n"
+                             "  {{birthday}}\n  OR\n  {{zipcode}}\n  OR\n  {{city}} ")
+                          {:columns {"source" "referral"
+                                     "city"   "town"}  ; make sure FFs aren't replaced
+                           :tables  {"people" "folk"}})))))

--- a/test/metabase/native_query_analyzer_test.clj
+++ b/test/metabase/native_query_analyzer_test.clj
@@ -63,22 +63,3 @@
         (is (= 6
                (-> (q "select v.* from venues v join checkins")
                    :indirect count)))))))
-
-(deftest ^:parallel replace-names-simple-test
-  (testing "columns can be renamed"
-    (is (= "select cost from orders"
-           (query-analyzer/replace-names "select amount from orders" {:columns {"amount" "cost"}})) ))
-  (testing "tables can be renamed"
-    (is (= "select amount from purchases"
-           (query-analyzer/replace-names "select amount from orders" {:tables {"orders" "purchases"}})) ))
-  (testing "many things can be renamed at once"
-    (is (= "select cost, tax from purchases"
-           (query-analyzer/replace-names "select amount, fee from orders" {:columns {"amount" "cost"
-                                                                                     "fee" "tax"}
-                                                                           :tables {"orders" "purchases"}})) ))
-  (testing "comments, whitespace, etc. are preserved"
-    (is (= (str"select cost, tax -- from orders\n" "from purchases")
-           (query-analyzer/replace-names (str "select amount, fee -- from orders\n" "from orders")
-                                         {:columns {"amount" "cost"
-                                                    "fee" "tax"}
-                                          :tables {"orders" "purchases"}})) )))

--- a/test/metabase/native_query_analyzer_test.clj
+++ b/test/metabase/native_query_analyzer_test.clj
@@ -63,3 +63,22 @@
         (is (= 6
                (-> (q "select v.* from venues v join checkins")
                    :indirect count)))))))
+
+(deftest ^:parallel replace-names-simple-test
+  (testing "columns can be renamed"
+    (is (= "select cost from orders"
+           (query-analyzer/replace-names "select amount from orders" {:columns {"amount" "cost"}})) ))
+  (testing "tables can be renamed"
+    (is (= "select amount from purchases"
+           (query-analyzer/replace-names "select amount from orders" {:tables {"orders" "purchases"}})) ))
+  (testing "many things can be renamed at once"
+    (is (= "select cost, tax from purchases"
+           (query-analyzer/replace-names "select amount, fee from orders" {:columns {"amount" "cost"
+                                                                                     "fee" "tax"}
+                                                                           :tables {"orders" "purchases"}})) ))
+  (testing "comments, whitespace, etc. are preserved"
+    (is (= (str"select cost, tax -- from orders\n" "from purchases")
+           (query-analyzer/replace-names (str "select amount, fee -- from orders\n" "from orders")
+                                         {:columns {"amount" "cost"
+                                                    "fee" "tax"}
+                                          :tables {"orders" "purchases"}})) )))


### PR DESCRIPTION
[Fixes #42580] (find-and-replace for variables)

[Fixes #42581] (find-and-replace for field filters: it seemed like an absolute lay-up to just handle that while I was at it)

I also added that monster fn to the card model, which is one step closer to the API that other people should use, I think. I was debating writing it at all, but I kind of like the idea of me writing it first to be like "Hey folks, this is how to use the query-analyzer API" and then leaving maintenance to Admin Webapp.