### PR TITLE
[Metrics V2] Return metrics in table query-metadata

### DIFF
--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -221,7 +221,11 @@
   [tables]
   (with-objects :metrics
     (fn [table-ids]
-      (t2/select :model/LegacyMetric :table_id [:in table-ids], :archived false, {:order-by [[:name :asc]]}))
+      (t2/select :model/Card
+                 :table_id [:in table-ids],
+                 :archived false,
+                 :type :metric,
+                 {:order-by [[:name :asc]]}))
     tables))
 
 (defn with-fields

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -552,6 +552,28 @@
              :id           (mt/id :categories)})
            (mt/user-http-request :rasta :get 200 (format "table/%d/query_metadata" (mt/id :categories)))))))
 
+(deftest table-metric-query-metadata-test
+  (testing "GET /api/table/:id/query_metadata"
+    (mt/with-temp [:model/Card metric {:type :metric
+                                       :name "Category metric"
+                                       :database_id (mt/id)
+                                       :table_id (mt/id :categories)}
+                   :model/Card _      {:type :metric
+                                       :name "Venues metric"
+                                       :database_id (mt/id)
+                                       :table_id (mt/id :venues)}
+                   :model/Card _      {:type :question
+                                       :name "Category question"
+                                       :database_id (mt/id)
+                                       :table_id (mt/id :categories)}
+                   :model/Card _      {:type :metric
+                                       :name "Archived metric"
+                                       :archived true
+                                       :database_id (mt/id)
+                                       :table_id (mt/id :categories)}]
+      (is (=? {:metrics [(assoc metric :type "metric" :display "table")]}
+              (mt/user-http-request :rasta :get 200 (format "table/%d/query_metadata" (mt/id :categories))))))))
+
 (defn- with-field-literal-id [{field-name :name, base-type :base_type :as field}]
   (assoc field :id ["field" field-name {:base-type base-type}]))
 


### PR DESCRIPTION
Fixes #42668
Part of https://github.com/metabase/metabase/issues/42462
Returns metric card definitions instead of legacy metrics from /api/table/:id/query_metadata
