### PR TITLE
Fix Trash rollbacks

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -7062,7 +7062,13 @@ databaseChangeLog:
               WHERE permissions.object IN (
                 SELECT CONCAT('/collection/', collection.id, '/') FROM collection WHERE collection.type = 'trash'
               );
-              DELETE FROM collection WHERE type = 'trash';
+              UPDATE collection
+              SET
+                entity_id = NULL,
+                archived = true,
+                name = 'Trash (Auto-Generated)',
+                type = NULL
+              WHERE type = 'trash';
 
   - changeSet:
       id: v50.2024-05-14T12:42:44
@@ -7080,12 +7086,7 @@ databaseChangeLog:
                   location = CONCAT('/', c2.id, '/')
               FROM (SELECT id FROM collection WHERE type = 'trash') AS c2
               WHERE c1.archived = true AND c1.namespace IS NULL;
-      rollback:
-        - sql:
-            sql: >-
-              UPDATE collection
-              SET trashed_from_location = NULL, location = trashed_from_location
-              WHERE archived = true AND namespace IS NULL;
+      rollback: # not needed. See above: `Trash` becomes a normal collection
 
   - changeSet:
       id: v50.2024-05-14T12:42:46
@@ -7102,12 +7103,7 @@ databaseChangeLog:
               SET trashed_from_location = c1.location,
                   location = CONCAT('/', (SELECT id FROM collection WHERE type = 'trash'), '/')
               WHERE c1.archived = true AND c1.namespace IS NULL;
-      rollback:
-        - sql:
-            sql: >-
-              UPDATE collection
-              SET trashed_from_location = NULL, location = trashed_from_location
-              WHERE archived = true AND namespace IS NULL;
+      rollback: # Not needed.
 
   - changeSet:
       id: v50.2024-05-14T12:42:48
@@ -7127,12 +7123,7 @@ databaseChangeLog:
               SET c1.trashed_from_location = c1.location,
                   c1.location = CONCAT('/', c2.id, '/')
               WHERE c1.archived = true AND c1.namespace IS NULL;
-      rollback:
-        - sql:
-            sql: >-
-              UPDATE collection
-              SET trashed_from_location = NULL, location = trashed_from_location
-              WHERE archived = true AND namespace IS NULL;
+      rollback: # Not needed
 
   - changeSet:
       id: v50.2024-05-14T12:42:50
@@ -7144,12 +7135,7 @@ databaseChangeLog:
               UPDATE report_dashboard
               SET trashed_from_collection_id = collection_id, collection_id = (SELECT id FROM collection WHERE type = 'trash')
               WHERE archived = true;
-      rollback:
-        - sql:
-            sql: >-
-              UPDATE report_dashboard
-              SET trashed_from_collection_id = NULL, collection_id = trashed_from_collection_id
-              WHERE archived = true;
+      rollback: # Not needed
 
   - changeSet:
       id: v50.2024-05-14T12:42:52
@@ -7161,12 +7147,7 @@ databaseChangeLog:
               UPDATE report_card
               SET trashed_from_collection_id = collection_id, collection_id = (SELECT id FROM collection WHERE type = 'trash')
               WHERE archived = true;
-      rollback:
-        - sql:
-            sql: >-
-              UPDATE report_card
-              SET trashed_from_collection_id = NULL, collection_id = trashed_from_collection_id
-              WHERE archived = true;
+      rollback: # Not needed
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 


### PR DESCRIPTION
There were a few errors in my initial implementation.

First, we can't simply assume that `trashed_from_location` and `trashed_from_collection_id` are set for anything in the archive. They should be set for things *directly* trashed, but not for things trashed as part of a collection.

Therefore, we need to set `location` and `collection_id` to something like "if the item is in the trash, then the `trashed_from` - otherwise, don't modify it".

Second, because `trashed_from_collection_id` is not a foreign key but `collection_id` is, we have a potential problem. If someone upgrades, Trashes a dashboard, then Trashes and permanently deletes the collection that dashboard _was_ in, then downgrades, how do we move the dashboard "back"? What do we set the dashboard's `collection_id` to?

The solution here is that when we downgrade, we don't actually move dashboards, collections, or cards out of the Trash collection. Instead we just make Trash a normal collection and leave everything in it.
