### PR TITLE
42701 search type ahead cp

### DIFF
--- a/e2e/test/scenarios/onboarding/search/search-typeahead.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/search-typeahead.cy.spec.js
@@ -1,5 +1,11 @@
 import { USERS } from "e2e/support/cypress_data";
-import { restore, visitFullAppEmbeddingUrl } from "e2e/support/helpers";
+import {
+  commandPalette,
+  commandPaletteButton,
+  commandPaletteInput,
+  restore,
+  visitFullAppEmbeddingUrl,
+} from "e2e/support/helpers";
 
 ["admin", "normal"].forEach(user => {
   describe(`search > ${user} user`, () => {
@@ -26,5 +32,24 @@ import { restore, visitFullAppEmbeddingUrl } from "e2e/support/helpers";
         );
       });
     });
+  });
+});
+
+describe("command palette", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    cy.request("PUT", "/api/setting/search-typeahead-enabled", {
+      value: false,
+    });
+    cy.visit("/");
+  });
+
+  it("should not display search results in the palette when search-typeahead-enabled is false", () => {
+    commandPaletteButton().click();
+    commandPaletteInput().type("ord");
+    commandPalette()
+      .findByRole("option", { name: /View search results/ })
+      .should("exist");
   });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/42701

### Description
Updating the command palette to respect the `search-typeahead-enabled` setting. If set to true, we should not perform searches 

### How to verify
1. Start metabase with `MB_SEARCH_TYPEAHEAD_ENABLED=false`
2. Open the command palette and enter a search query
3. You should see the command palette show you a link to the search page, instead of showing you any search results 

### Demo
![image](https://github.com/metabase/metabase/assets/1328979/6e7cb5df-b1a5-4a21-99c8-d4905ad73fbb)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
