### PR TITLE
Fix metric-based drills in dashboards

### DIFF
--- a/e2e/test/scenarios/metrics/metrics-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-dashboard.cy.spec.js
@@ -150,7 +150,7 @@ describe("scenarios > metrics > dashboard", () => {
       .should("be.visible");
   });
 
-  it.skip("should be able to add a filter and drill thru without the metric aggregation clause (metabase#42656)", () => {
+  it("should be able to add a filter and drill thru without the metric aggregation clause (metabase#42656)", () => {
     cy.createDashboardWithQuestions({
       questions: [ORDERS_TIMESERIES_METRIC],
     }).then(({ dashboard }) => {

--- a/frontend/src/metabase/visualizations/lib/utils.js
+++ b/frontend/src/metabase/visualizations/lib/utils.js
@@ -248,6 +248,7 @@ export function getCardAfterVisualizationClick(nextCard, previousCard) {
 
     return {
       ...nextCard,
+      type: "question",
       // Original card id is needed for showing the "started from" lineage in dirty cards.
       original_card_id: alreadyHadLineage
         ? // Just recycle the original card id of previous card if there was one


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/42656

QB has logic to turn models & metrics to ad-hoc question after change https://github.com/metabase/metabase/blob/6cf25f4003886d8f168986757a27a2785dbdba2b/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts#L130. We need to a similar thing in dashboards. Each time when we navigate to a card and it became dirty, we need to convert this card to a an-doc `question`.

How to verify:
- CI is green