### PR TITLE
Allow hiding visualization for metrics in collections

### DIFF
--- a/e2e/test/scenarios/metrics/metrics-collection.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-collection.cy.spec.js
@@ -136,6 +136,29 @@ describe("scenarios > metrics > collection", () => {
       .should("not.exist");
   });
 
+  it("should be possible to hide the visualization for a pinned metric", () => {
+    createQuestion(ORDERS_SCALAR_METRIC);
+    cy.visit("/collection/root");
+    getPinnedSection().within(() => {
+      cy.findByText(ORDERS_SCALAR_METRIC.name).should("be.visible");
+      cy.findByTestId("scalar-container").should("be.visible");
+    });
+
+    openPinnedItemMenu(ORDERS_SCALAR_METRIC.name);
+    popover().findByText("Don’t show visualization").click();
+    getPinnedSection().within(() => {
+      cy.findByText(ORDERS_SCALAR_METRIC.name).should("be.visible");
+      cy.findByTestId("scalar-container").should("not.exist");
+    });
+
+    openPinnedItemMenu(ORDERS_SCALAR_METRIC.name);
+    popover().findByText("Show visualization").click();
+    getPinnedSection().within(() => {
+      cy.findByText(ORDERS_SCALAR_METRIC.name).should("be.visible");
+      cy.findByTestId("scalar-container").should("be.visible");
+    });
+  });
+
   it("should be possible to archive, unarchive, and delete a metric", () => {
     createQuestion(ORDERS_SCALAR_METRIC);
     createQuestion({ ...ORDERS_TIMESERIES_METRIC, collection_position: null });

--- a/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.unit.spec.tsx
@@ -4,7 +4,12 @@ import userEvent from "@testing-library/user-event";
 import { createMockEntitiesState } from "__support__/store";
 import { getIcon, renderWithProviders } from "__support__/ui";
 import { getMetadata } from "metabase/selectors/metadata";
-import type { Collection, CollectionItem, Database } from "metabase-types/api";
+import type {
+  Collection,
+  CollectionItem,
+  CollectionItemModel,
+  Database,
+} from "metabase-types/api";
 import {
   createMockCollection,
   createMockCollectionItem,
@@ -62,39 +67,45 @@ const setup = ({
 
 describe("ActionMenu", () => {
   describe("preview", () => {
-    it("should show an option to hide preview for a pinned question", async () => {
-      const item = createMockCollectionItem({
-        model: "card",
-        collection_position: 1,
-        collection_preview: true,
-        setCollectionPreview: jest.fn(),
-      });
+    it.each<CollectionItemModel>(["card", "metric"])(
+      "should show an option to hide preview for a pinned %s",
+      async model => {
+        const item = createMockCollectionItem({
+          model,
+          collection_position: 1,
+          collection_preview: true,
+          setCollectionPreview: jest.fn(),
+        });
 
-      setup({ item });
+        setup({ item });
 
-      await userEvent.click(getIcon("ellipsis"));
-      await userEvent.click(
-        await screen.findByText("Don’t show visualization"),
-      );
+        await userEvent.click(getIcon("ellipsis"));
+        await userEvent.click(
+          await screen.findByText("Don’t show visualization"),
+        );
 
-      expect(item.setCollectionPreview).toHaveBeenCalledWith(false);
-    });
+        expect(item.setCollectionPreview).toHaveBeenCalledWith(false);
+      },
+    );
 
-    it("should show an option to show preview for a pinned question", async () => {
-      const item = createMockCollectionItem({
-        model: "card",
-        collection_position: 1,
-        collection_preview: false,
-        setCollectionPreview: jest.fn(),
-      });
+    it.each<CollectionItemModel>(["card", "metric"])(
+      "should show an option to show preview for a pinned %s",
+      async model => {
+        const item = createMockCollectionItem({
+          model,
+          collection_position: 1,
+          collection_preview: false,
+          setCollectionPreview: jest.fn(),
+        });
 
-      setup({ item });
+        setup({ item });
 
-      await userEvent.click(getIcon("ellipsis"));
-      await userEvent.click(await screen.findByText("Show visualization"));
+        await userEvent.click(getIcon("ellipsis"));
+        await userEvent.click(await screen.findByText("Show visualization"));
 
-      expect(item.setCollectionPreview).toHaveBeenCalledWith(true);
-    });
+        expect(item.setCollectionPreview).toHaveBeenCalledWith(true);
+      },
+    );
 
     it("should not show an option to hide preview for a pinned model", async () => {
       setup({

--- a/frontend/src/metabase/collections/utils.ts
+++ b/frontend/src/metabase/collections/utils.ts
@@ -125,6 +125,10 @@ export function isItemModel(item: CollectionItem) {
   return item.model === "dataset";
 }
 
+export function isItemMetric(item: CollectionItem) {
+  return item.model === "metric";
+}
+
 export function isItemCollection(item: CollectionItem) {
   return item.model === "collection";
 }
@@ -138,7 +142,11 @@ export function canPinItem(item: CollectionItem, collection?: Collection) {
 }
 
 export function canPreviewItem(item: CollectionItem, collection?: Collection) {
-  return collection?.can_write && isItemPinned(item) && isItemQuestion(item);
+  return (
+    collection?.can_write &&
+    isItemPinned(item) &&
+    (isItemQuestion(item) || isItemMetric(item))
+  );
 }
 
 export function canMoveItem(item: CollectionItem, collection?: Collection) {


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/42618

How to verify:
- Open a collection with metrics
- Open the menu for a pinned metric and click "Don't show visualization"
- Visualization should not be shown
- It should be possible to select "Show visualization" and bring it back

<img width="713" alt="Screenshot 2024-05-15 at 17 07 57" src="https://github.com/metabase/metabase/assets/8542534/06d32adc-f327-4538-b1a8-b3a68c163904">
<img width="707" alt="Screenshot 2024-05-15 at 17 08 00" src="https://github.com/metabase/metabase/assets/8542534/2687044c-e052-413e-a545-9d5a372167f2">
<img width="703" alt="Screenshot 2024-05-15 at 17 08 03" src="https://github.com/metabase/metabase/assets/8542534/431ee820-cb70-43e6-8942-caf96c81b081">
