### PR TITLE
Allow replacing a card with a metric on a dashboard

### DIFF
--- a/e2e/test/scenarios/metrics/metrics-collection.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-collection.cy.spec.js
@@ -155,14 +155,14 @@ describe("scenarios > metrics > collection", () => {
     getUnpinnedSection()
       .findByText(ORDERS_TIMESERIES_METRIC.name)
       .should("not.exist");
-    undoToastList().findByText("Archived metric").should("be.visible");
+    undoToastList().last().findByText("Archived metric").should("be.visible");
 
     openArchive();
     unarchiveArchivedItem(ORDERS_TIMESERIES_METRIC.name);
     getArchivedList()
       .findByText(ORDERS_TIMESERIES_METRIC.name)
       .should("not.exist");
-    undoToastList().findByText("Unarchived metric").should("be.visible");
+    undoToastList().last().findByText("Unarchived metric").should("be.visible");
 
     navigationSidebar().findByText("Our analytics").click();
     openUnpinnedItemMenu(ORDERS_TIMESERIES_METRIC.name);

--- a/e2e/test/scenarios/metrics/metrics-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-dashboard.cy.spec.js
@@ -175,13 +175,19 @@ describe("scenarios > metrics > dashboard", () => {
       cy.findByText("Metrics").click();
       cy.findByText(ORDERS_SCALAR_METRIC.name).click();
     });
-    undoToastList().findByText("Question replaced").should("be.visible");
+    undoToastList().last().findByText("Question replaced").should("be.visible");
     getDashboardCard().within(() => {
       cy.findByText(ORDERS_SCALAR_METRIC.name).should("be.visible");
       cy.findByText("18,760").should("be.visible");
     });
     getDashboardCard().realHover().findByLabelText("Replace").click();
-    modal().findByText("Orders").click();
+    modal().within(() => {
+      cy.findByText(ORDERS_SCALAR_METRIC.name).should("be.visible");
+      cy.findByText("Questions").click();
+      cy.findByText("Orders").click();
+    });
+    undoToastList().last().findByText("Metric replaced").should("be.visible");
+    getDashboardCard().findByText("Orders").should("be.visible");
   });
 
   it("should be able to combine scalar metrics on a dashcard", () => {

--- a/e2e/test/scenarios/metrics/metrics-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-dashboard.cy.spec.js
@@ -18,6 +18,7 @@ import {
   restore,
   saveDashboard,
   sidebar,
+  undoToastList,
   visitDashboard,
 } from "e2e/support/helpers";
 
@@ -163,6 +164,24 @@ describe("scenarios > metrics > dashboard", () => {
     });
     popover().findByText("See these Orders").click();
     assertQueryBuilderRowCount(445);
+  });
+
+  it("should be able to replace a card with a metric", () => {
+    createQuestion(ORDERS_SCALAR_METRIC);
+    visitDashboard(ORDERS_DASHBOARD_ID);
+    editDashboard();
+    getDashboardCard().realHover().findByLabelText("Replace").click();
+    modal().within(() => {
+      cy.findByText("Metrics").click();
+      cy.findByText(ORDERS_SCALAR_METRIC.name).click();
+    });
+    undoToastList().findByText("Question replaced").should("be.visible");
+    getDashboardCard().within(() => {
+      cy.findByText(ORDERS_SCALAR_METRIC.name).should("be.visible");
+      cy.findByText("18,760").should("be.visible");
+    });
+    getDashboardCard().realHover().findByLabelText("Replace").click();
+    modal().findByText("Orders").click();
   });
 
   it("should be able to combine scalar metrics on a dashcard", () => {

--- a/e2e/test/scenarios/metrics/metrics-search.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-search.cy.spec.js
@@ -1,5 +1,3 @@
-import _ from "underscore";
-
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   appBar,

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/components/EditSandboxingModal/EditSandboxingModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/components/EditSandboxingModal/EditSandboxingModal.tsx
@@ -6,7 +6,10 @@ import { jt, t } from "ttag";
 import _ from "underscore";
 
 import { useGetCardQuery, skipToken } from "metabase/api";
-import { QuestionPickerModal } from "metabase/common/components/QuestionPicker";
+import {
+  getQuestionPickerValue,
+  QuestionPickerModal,
+} from "metabase/common/components/QuestionPicker";
 import ActionButton from "metabase/components/ActionButton";
 import QuestionLoader from "metabase/containers/QuestionLoader";
 import Radio from "metabase/core/components/Radio";
@@ -171,11 +174,7 @@ const EditSandboxingModal = ({
               <QuestionPickerModal
                 value={
                   currentQuestion && policy.card_id != null
-                    ? {
-                        id: policy.card_id,
-                        model:
-                          currentQuestion.type === "model" ? "dataset" : "card",
-                      }
+                    ? getQuestionPickerValue(currentQuestion)
                     : undefined
                 }
                 onChange={newCard => {

--- a/frontend/src/metabase/common/components/CollectionPicker/types.ts
+++ b/frontend/src/metabase/common/components/CollectionPicker/types.ts
@@ -19,7 +19,7 @@ export type CollectionItemId = CollectionId | CardId | DashboardId;
 // so that we can use its components for picking all of them
 export type CollectionPickerModel = Extract<
   CollectionItemModel,
-  "collection" | "card" | "dataset" | "dashboard"
+  "collection" | "card" | "dataset" | "metric" | "dashboard"
 >;
 
 // we can enforce type safety at the boundary of a collection-only picker with this type

--- a/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.tsx
+++ b/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.tsx
@@ -25,7 +25,7 @@ import {
 import type { QuestionPickerOptions, QuestionPickerItem } from "../types";
 import {
   getCollectionIdPath,
-  getQuestionPickerModel,
+  getQuestionPickerValueModel,
   getStateFromIdPath,
   isFolder,
 } from "../utils";
@@ -144,7 +144,7 @@ export const QuestionPicker = ({
           ? {
               id: currentQuestion.id,
               name: currentQuestion.name,
-              model: getQuestionPickerModel(currentQuestion.type),
+              model: getQuestionPickerValueModel(currentQuestion.type),
             }
           : {
               id: currentCollection.id,

--- a/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.tsx
+++ b/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.tsx
@@ -23,7 +23,12 @@ import {
   type PickerState,
 } from "../../EntityPicker";
 import type { QuestionPickerOptions, QuestionPickerItem } from "../types";
-import { getCollectionIdPath, getStateFromIdPath, isFolder } from "../utils";
+import {
+  getCollectionIdPath,
+  getQuestionPickerModel,
+  getStateFromIdPath,
+  isFolder,
+} from "../utils";
 
 export const defaultOptions: QuestionPickerOptions = {
   showPersonalCollections: true,
@@ -42,7 +47,7 @@ const useGetInitialCollection = (
   initialValue?: Pick<QuestionPickerItem, "model" | "id">,
 ) => {
   const isQuestion =
-    initialValue && ["card", "dataset"].includes(initialValue.model);
+    initialValue && ["card", "dataset", "metric"].includes(initialValue.model);
 
   const cardId = isQuestion ? Number(initialValue.id) : undefined;
 
@@ -139,7 +144,7 @@ export const QuestionPicker = ({
           ? {
               id: currentQuestion.id,
               name: currentQuestion.name,
-              model: currentQuestion.type === "model" ? "dataset" : "card",
+              model: getQuestionPickerModel(currentQuestion.type),
             }
           : {
               id: currentCollection.id,

--- a/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.unit.spec.tsx
@@ -280,7 +280,9 @@ describe("QuestionPickerModal", () => {
   it("should render the modal", async () => {
     await setupModal();
 
-    expect(await screen.findByText(/choose a question/i)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/choose a question or model/i),
+    ).toBeInTheDocument();
     expect(
       await screen.findByRole("button", { name: /Our Analytics/ }),
     ).toBeInTheDocument();
@@ -295,7 +297,9 @@ describe("QuestionPickerModal", () => {
       options: { ...defaultOptions, hasConfirmButtons: true },
     });
 
-    expect(await screen.findByText(/choose a question/i)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/choose a question or model/i),
+    ).toBeInTheDocument();
     expect(
       await screen.findByRole("button", { name: /Our Analytics/ }),
     ).toBeInTheDocument();
@@ -318,7 +322,9 @@ describe("QuestionPickerModal", () => {
   it("can render a single tab (which hides the tab bar)", async () => {
     await setupModal({ models: ["dataset"] });
 
-    expect(await screen.findByText(/choose a question/i)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/choose a question or model/i),
+    ).toBeInTheDocument();
     expect(screen.queryByRole("tablist")).not.toBeInTheDocument();
     expect(screen.queryByRole("tab")).not.toBeInTheDocument();
   });

--- a/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.unit.spec.tsx
@@ -280,9 +280,7 @@ describe("QuestionPickerModal", () => {
   it("should render the modal", async () => {
     await setupModal();
 
-    expect(
-      await screen.findByText(/choose a question or model/i),
-    ).toBeInTheDocument();
+    expect(await screen.findByText(/choose a question/i)).toBeInTheDocument();
     expect(
       await screen.findByRole("button", { name: /Our Analytics/ }),
     ).toBeInTheDocument();
@@ -297,9 +295,7 @@ describe("QuestionPickerModal", () => {
       options: { ...defaultOptions, hasConfirmButtons: true },
     });
 
-    expect(
-      await screen.findByText(/choose a question or model/i),
-    ).toBeInTheDocument();
+    expect(await screen.findByText(/choose a question/i)).toBeInTheDocument();
     expect(
       await screen.findByRole("button", { name: /Our Analytics/ }),
     ).toBeInTheDocument();
@@ -322,9 +318,7 @@ describe("QuestionPickerModal", () => {
   it("can render a single tab (which hides the tab bar)", async () => {
     await setupModal({ models: ["dataset"] });
 
-    expect(
-      await screen.findByText(/choose a question or model/i),
-    ).toBeInTheDocument();
+    expect(await screen.findByText(/choose a question/i)).toBeInTheDocument();
     expect(screen.queryByRole("tablist")).not.toBeInTheDocument();
     expect(screen.queryByRole("tab")).not.toBeInTheDocument();
   });

--- a/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.unit.spec.tsx
@@ -28,20 +28,36 @@ import { QuestionPickerModal } from "./QuestionPickerModal";
 type NestedCollectionItem = Partial<CollectionItem> & {
   id: any;
   is_personal?: boolean;
-  descendants: NestedCollectionItem[];
+  descendants?: NestedCollectionItem[];
 };
 
-const myQuestion = createMockCard({
-  id: 100,
-  name: "My Question",
-  collection_id: 3,
+const myQuestion = createMockCollectionItem({
+  ...createMockCard({
+    id: 100,
+    name: "My Question",
+    collection_id: 3,
+  }),
+  model: "card",
 });
 
-const myModel = createMockCard({
-  id: 101,
-  name: "My Model",
-  collection_id: 3,
-  type: "model",
+const myModel = createMockCollectionItem({
+  ...createMockCard({
+    id: 101,
+    name: "My Model",
+    collection_id: 3,
+    type: "model",
+  }),
+  model: "dataset",
+});
+
+const myMetric = createMockCollectionItem({
+  ...createMockCard({
+    id: 102,
+    name: "My Metric",
+    collection_id: 3,
+    type: "metric",
+  }),
+  model: "metric",
 });
 
 const collectionTree: NestedCollectionItem[] = [
@@ -63,18 +79,7 @@ const collectionTree: NestedCollectionItem[] = [
             id: 3,
             name: "Collection 3",
             model: "collection",
-            descendants: [
-              {
-                ...myQuestion,
-                model: "card",
-                descendants: [],
-              },
-              {
-                ...myModel,
-                model: "dataset",
-                descendants: [],
-              },
-            ],
+            descendants: [myQuestion, myModel, myMetric],
             location: "/4/",
             can_write: true,
             is_personal: false,
@@ -119,7 +124,7 @@ const flattenCollectionTree = (
   if (!nodes) {
     return [];
   }
-  return nodes.flatMap(({ descendants, ...node }) => [
+  return nodes.flatMap(({ descendants = [], ...node }) => [
     node,
     ...flattenCollectionTree(descendants),
   ]);
@@ -137,7 +142,6 @@ const setupCollectionTreeMocks = (node: NestedCollectionItem[]) => {
     setupCollectionItemsEndpoint({
       collection: createMockCollection({ id: node.id }),
       collectionItems,
-      models: ["collection", "dataset", "card"],
     });
 
     if (collectionItems.length > 0) {
@@ -149,7 +153,7 @@ const setupCollectionTreeMocks = (node: NestedCollectionItem[]) => {
 interface SetupOpts {
   initialValue?: {
     id: CollectionId;
-    model: "collection" | "card" | "dataset";
+    model: "collection" | "card" | "dataset" | "metric";
   };
   onChange?: (item: QuestionPickerItem) => void;
   models?: [QuestionPickerValueModel, ...QuestionPickerValueModel[]];
@@ -319,6 +323,20 @@ describe("QuestionPickerModal", () => {
     ).toBeInTheDocument();
   });
 
+  it("should render the metric tab if explicitly enabled", async () => {
+    await setupModal({ models: ["card", "dataset", "metric"] });
+
+    expect(
+      await screen.findByRole("tab", { name: /Questions/ }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("tab", { name: /Models/ }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("tab", { name: /Metrics/ }),
+    ).toBeInTheDocument();
+  });
+
   it("can render a single tab (which hides the tab bar)", async () => {
     await setupModal({ models: ["dataset"] });
 
@@ -362,6 +380,25 @@ describe("QuestionPickerModal", () => {
 
     expect(
       await screen.findByRole("button", { name: /My Model/ }),
+    ).toHaveAttribute("data-active", "true");
+  });
+
+  it("should auto-select the metric tab when a metric is selected", async () => {
+    await setupModal({
+      initialValue: { id: 102, model: "metric" },
+      models: ["card", "dataset", "metric"],
+    });
+
+    expect(
+      await screen.findByRole("tab", { name: /Questions/ }),
+    ).toHaveAttribute("aria-selected", "false");
+    expect(await screen.findByRole("tab", { name: /Metrics/ })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+
+    expect(
+      await screen.findByRole("button", { name: /My Metric/ }),
     ).toHaveAttribute("data-active", "true");
   });
 
@@ -420,5 +457,14 @@ describe("QuestionPickerModal", () => {
     expect(
       screen.queryByRole("tab", { name: /Search/ }),
     ).not.toBeInTheDocument();
+  });
+
+  it("should be able to search for metrics", async () => {
+    await setupSearchEndpoints([myQuestion, myModel, myMetric]);
+    await setupModal({ models: ["card", "dataset", "metric"] });
+    const searchInput = await screen.findByPlaceholderText(/search/i);
+    await userEvent.type(searchInput, myMetric.name);
+    expect(await screen.findByText(myMetric.name)).toBeInTheDocument();
+    expect(screen.queryByText(myQuestion.name)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPickerModal.tsx
+++ b/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPickerModal.tsx
@@ -47,7 +47,7 @@ const defaultOptions: QuestionPickerOptions = {
 };
 
 export const QuestionPickerModal = ({
-  title = t`Select a question or model`,
+  title = t`Choose a question or model`,
   onChange,
   onClose,
   value = { model: "collection", id: "root" },

--- a/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPickerModal.tsx
+++ b/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPickerModal.tsx
@@ -12,6 +12,7 @@ import type {
   QuestionPickerOptions,
   QuestionPickerModel,
   QuestionPickerValueItem,
+  QuestionPickerValue,
 } from "../types";
 
 import {
@@ -24,7 +25,7 @@ interface QuestionPickerModalProps {
   onChange: (item: QuestionPickerValueItem) => void;
   onClose: () => void;
   options?: QuestionPickerOptions;
-  value?: Pick<QuestionPickerItem, "id" | "model">;
+  value?: QuestionPickerValue;
   models?: QuestionPickerModel[];
 }
 
@@ -32,9 +33,11 @@ const canSelectItem = (
   item: QuestionPickerItem | null,
 ): item is QuestionPickerValueItem => {
   return (
-    !!item &&
+    item != null &&
     item.can_write !== false &&
-    (item.model === "card" || item.model === "dataset")
+    (item.model === "card" ||
+      item.model === "dataset" ||
+      item.model === "metric")
   );
 };
 
@@ -44,12 +47,12 @@ const defaultOptions: QuestionPickerOptions = {
 };
 
 export const QuestionPickerModal = ({
-  title = t`Choose a question or model`,
+  title = t`Select a question`,
   onChange,
   onClose,
   value = { model: "collection", id: "root" },
   options = defaultOptions,
-  models = ["card", "dataset"],
+  models = ["card", "dataset", "metric"],
 }: QuestionPickerModalProps) => {
   options = { ...defaultOptions, ...options };
   const [selectedItem, setSelectedItem] = useState<QuestionPickerItem | null>(
@@ -97,6 +100,19 @@ export const QuestionPickerModal = ({
           initialValue={value}
           options={options}
           models={["dataset"]}
+        />
+      ),
+    },
+    {
+      displayName: t`Metrics`,
+      model: "metric",
+      icon: "metric",
+      element: (
+        <QuestionPicker
+          onItemSelect={handleItemSelect}
+          initialValue={value}
+          options={options}
+          models={["metric"]}
         />
       ),
     },

--- a/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPickerModal.tsx
+++ b/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPickerModal.tsx
@@ -47,12 +47,12 @@ const defaultOptions: QuestionPickerOptions = {
 };
 
 export const QuestionPickerModal = ({
-  title = t`Select a question`,
+  title = t`Select a question or model`,
   onChange,
   onClose,
   value = { model: "collection", id: "root" },
   options = defaultOptions,
-  models = ["card", "dataset", "metric"],
+  models = ["card", "dataset"],
 }: QuestionPickerModalProps) => {
   options = { ...defaultOptions, ...options };
   const [selectedItem, setSelectedItem] = useState<QuestionPickerItem | null>(

--- a/frontend/src/metabase/common/components/QuestionPicker/index.ts
+++ b/frontend/src/metabase/common/components/QuestionPicker/index.ts
@@ -1,2 +1,3 @@
 export * from "./components";
 export * from "./types";
+export { getQuestionPickerValue } from "./utils";

--- a/frontend/src/metabase/common/components/QuestionPicker/types.ts
+++ b/frontend/src/metabase/common/components/QuestionPicker/types.ts
@@ -12,7 +12,7 @@ import type { EntityPickerModalOptions, ListProps } from "../EntityPicker";
 
 export type QuestionPickerModel = Extract<
   CollectionPickerItem["model"],
-  "card" | "dataset" | "collection"
+  "card" | "dataset" | "metric" | "collection"
 >;
 export type QuestionPickerValueModel = Extract<
   CollectionPickerItem["model"],
@@ -26,6 +26,7 @@ export type QuestionPickerValueItem = CollectionPickerItem & {
 
 // we could tighten this up in the future, but there's relatively little value to it
 export type QuestionPickerItem = CollectionPickerItem;
+export type QuestionPickerValue = Pick<QuestionPickerItem, "id" | "model">;
 
 export type QuestionPickerOptions = EntityPickerModalOptions & {
   showPersonalCollections?: boolean;

--- a/frontend/src/metabase/common/components/QuestionPicker/types.ts
+++ b/frontend/src/metabase/common/components/QuestionPicker/types.ts
@@ -16,7 +16,7 @@ export type QuestionPickerModel = Extract<
 >;
 export type QuestionPickerValueModel = Extract<
   CollectionPickerItem["model"],
-  "card" | "dataset"
+  "card" | "dataset" | "metric"
 >;
 
 export type QuestionPickerValueItem = CollectionPickerItem & {

--- a/frontend/src/metabase/common/components/QuestionPicker/utils.ts
+++ b/frontend/src/metabase/common/components/QuestionPicker/utils.ts
@@ -5,11 +5,12 @@ import type {
   CollectionId,
   ListCollectionItemsRequest,
   CollectionItemModel,
+  Card,
 } from "metabase-types/api";
 
 import type { PickerState } from "../EntityPicker";
 
-import type { QuestionPickerItem } from "./types";
+import type { QuestionPickerItem, QuestionPickerValue } from "./types";
 
 export const getCollectionIdPath = (
   collection: Pick<
@@ -102,4 +103,18 @@ export const isFolder = (
       _.intersection([...(item?.below ?? []), ...(item?.here ?? [])], models)
         .length > 0)
   );
+};
+
+export const getQuestionPickerValue = ({
+  id,
+  type,
+}: Pick<Card, "id" | "type">): QuestionPickerValue => {
+  switch (type) {
+    case "question":
+      return { id, model: "card" };
+    case "model":
+      return { id, model: "dataset" };
+    case "metric":
+      return { id, model: "metric" };
+  }
 };

--- a/frontend/src/metabase/common/components/QuestionPicker/utils.ts
+++ b/frontend/src/metabase/common/components/QuestionPicker/utils.ts
@@ -6,6 +6,7 @@ import type {
   ListCollectionItemsRequest,
   CollectionItemModel,
   Card,
+  CardType,
 } from "metabase-types/api";
 
 import type { PickerState } from "../EntityPicker";
@@ -105,16 +106,20 @@ export const isFolder = (
   );
 };
 
+export const getQuestionPickerModel = (type: CardType) => {
+  switch (type) {
+    case "question":
+      return "card" as const;
+    case "model":
+      return "dataset" as const;
+    case "metric":
+      return "metric" as const;
+  }
+};
+
 export const getQuestionPickerValue = ({
   id,
   type,
 }: Pick<Card, "id" | "type">): QuestionPickerValue => {
-  switch (type) {
-    case "question":
-      return { id, model: "card" };
-    case "model":
-      return { id, model: "dataset" };
-    case "metric":
-      return { id, model: "metric" };
-  }
+  return { id, model: getQuestionPickerModel(type) };
 };

--- a/frontend/src/metabase/common/components/QuestionPicker/utils.ts
+++ b/frontend/src/metabase/common/components/QuestionPicker/utils.ts
@@ -11,7 +11,11 @@ import type {
 
 import type { PickerState } from "../EntityPicker";
 
-import type { QuestionPickerItem, QuestionPickerValue } from "./types";
+import type {
+  QuestionPickerItem,
+  QuestionPickerValue,
+  QuestionPickerValueModel,
+} from "./types";
 
 export const getCollectionIdPath = (
   collection: Pick<
@@ -106,20 +110,22 @@ export const isFolder = (
   );
 };
 
-export const getQuestionPickerModel = (type: CardType) => {
-  switch (type) {
-    case "question":
-      return "card" as const;
-    case "model":
-      return "dataset" as const;
-    case "metric":
-      return "metric" as const;
-  }
-};
-
 export const getQuestionPickerValue = ({
   id,
   type,
 }: Pick<Card, "id" | "type">): QuestionPickerValue => {
-  return { id, model: getQuestionPickerModel(type) };
+  return { id, model: getQuestionPickerValueModel(type) };
+};
+
+export const getQuestionPickerValueModel = (
+  type: CardType,
+): QuestionPickerValueModel => {
+  switch (type) {
+    case "question":
+      return "card";
+    case "model":
+      return "dataset";
+    case "metric":
+      return "metric";
+  }
 };

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
@@ -443,6 +443,7 @@ class DashboardGrid extends Component<DashboardGridProps, DashboardGridState> {
             ? getQuestionPickerValue(replaceCardModalDashCard.card)
             : undefined
         }
+        models={["card", "dataset", "metric"]}
         onChange={handleSelect}
         onClose={handleClose}
       />

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
@@ -7,7 +7,10 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import type { QuestionPickerValueItem } from "metabase/common/components/QuestionPicker";
-import { QuestionPickerModal } from "metabase/common/components/QuestionPicker";
+import {
+  getQuestionPickerValue,
+  QuestionPickerModal,
+} from "metabase/common/components/QuestionPicker";
 import ExplicitSize from "metabase/components/ExplicitSize";
 import Modal from "metabase/components/Modal";
 import { ContentViewportContext } from "metabase/core/context/ContentViewportContext";
@@ -434,18 +437,13 @@ class DashboardGrid extends Component<DashboardGridProps, DashboardGridState> {
 
     return (
       <QuestionPickerModal
-        onChange={handleSelect}
+        title={t`Pick what you want to replace this with`}
         value={
           replaceCardModalDashCard.card.id
-            ? {
-                id: replaceCardModalDashCard.card.id,
-                model:
-                  replaceCardModalDashCard.card.type === "model"
-                    ? "dataset"
-                    : "card",
-              }
+            ? getQuestionPickerValue(replaceCardModalDashCard.card)
             : undefined
         }
+        onChange={handleSelect}
         onClose={handleClose}
       />
     );

--- a/frontend/src/metabase/models/containers/FormModelPicker/FormModelPicker.tsx
+++ b/frontend/src/metabase/models/containers/FormModelPicker/FormModelPicker.tsx
@@ -4,7 +4,10 @@ import { useState, useRef } from "react";
 import { t } from "ttag";
 
 import { skipToken, useGetCardQuery } from "metabase/api";
-import { QuestionPickerModal } from "metabase/common/components/QuestionPicker";
+import {
+  getQuestionPickerValue,
+  QuestionPickerModal,
+} from "metabase/common/components/QuestionPicker";
 import FormField from "metabase/core/components/FormField";
 import { useUniqueId } from "metabase/hooks/use-unique-id";
 import { Button, Icon } from "metabase/ui";
@@ -65,14 +68,7 @@ export function FormModelPicker({
         <QuestionPickerModal
           models={["dataset"]}
           title={t`Select a model`}
-          value={
-            model?.id
-              ? {
-                  id: model.id,
-                  model: model.type === "model" ? "dataset" : "card",
-                }
-              : undefined
-          }
+          value={model?.id ? getQuestionPickerValue(model) : undefined}
           onChange={newModel => {
             setValue(newModel.id);
             setIsPickerOpen(false);

--- a/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceCardModal.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceCardModal.tsx
@@ -1,11 +1,12 @@
 import { useCallback } from "react";
 import { t } from "ttag";
-import _ from "underscore";
 
 import type { QuestionPickerValueItem } from "metabase/common/components/QuestionPicker";
-import { QuestionPickerModal } from "metabase/common/components/QuestionPicker";
+import {
+  getQuestionPickerValue,
+  QuestionPickerModal,
+} from "metabase/common/components/QuestionPicker";
 import { useQuestionQuery } from "metabase/common/hooks";
-import type Question from "metabase-lib/v1/Question";
 import type { Parameter, ValuesSourceConfig } from "metabase-types/api";
 
 interface ValuesSourceCardModalProps {
@@ -25,7 +26,9 @@ export const ValuesSourceCardModal = ({
 }: ValuesSourceCardModalProps): JSX.Element => {
   const { data: question } = useQuestionQuery({ id: sourceConfig.card_id });
 
-  const initialValue = getInitialValue(question);
+  const initialValue =
+    question &&
+    getQuestionPickerValue({ id: question.id(), type: question.type() });
 
   const handleSubmit = useCallback(
     (newQuestion: QuestionPickerValueItem) => {
@@ -43,17 +46,4 @@ export const ValuesSourceCardModal = ({
       onClose={onClose}
     />
   );
-};
-
-const getInitialValue = (
-  question?: Question,
-): Pick<QuestionPickerValueItem, "id" | "model"> | undefined => {
-  if (!question) {
-    return undefined;
-  }
-
-  return {
-    id: question.id(),
-    model: question.type() === "model" ? "dataset" : "card",
-  };
 };

--- a/frontend/src/metabase/visualizations/visualizations/DashCardPlaceholder.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/DashCardPlaceholder.tsx
@@ -58,6 +58,7 @@ function DashCardPlaceholderInner({
       </Flex>
       {isQuestionPickerOpen && (
         <QuestionPickerModal
+          title={t`Pick what you want to replace this with`}
           value={
             dashboard.collection_id
               ? {

--- a/frontend/src/metabase/visualizations/visualizations/DashCardPlaceholder.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/DashCardPlaceholder.tsx
@@ -67,6 +67,7 @@ function DashCardPlaceholderInner({
                 }
               : undefined
           }
+          models={["card", "dataset", "metric"]}
           onChange={handleSelectQuestion}
           onClose={() => setQuestionPickerOpen(false)}
         />


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/42598

Adds "metric" tab to `QuestionPickerModal`. Currently this is an opt-in feature because we don't want to allow to pick metrics in arbitrary places. Please note that this PR targets a somewhat outdated integration branch and we won't merge soon.

How to verify:
- New -> Metric -> Orders -> Count -> Save
- Open a dashboard with cards
- Edit dashboard -> Hover over one of the dashcards -> Replace
- Select the metric
- It should properly replace the selected card

<img width="540" alt="Screenshot 2024-05-15 at 18 54 07" src="https://github.com/metabase/metabase/assets/8542534/d861f034-bb89-47b0-bfc5-ef846fd1816d">
<img width="1404" alt="Screenshot 2024-05-15 at 18 54 24" src="https://github.com/metabase/metabase/assets/8542534/2445fdde-a30a-4855-bb7c-975c086ae4f9">
<img width="869" alt="Screenshot 2024-05-15 at 18 54 31" src="https://github.com/metabase/metabase/assets/8542534/13273c2f-55c5-4988-925c-e11c8d197e76">
