### PR TITLE
Allow license tokens that start with `airgap_`

### DIFF
--- a/frontend/src/metabase/setup/components/LicenseTokenStep/LicenseTokenForm.tsx
+++ b/frontend/src/metabase/setup/components/LicenseTokenStep/LicenseTokenForm.tsx
@@ -1,27 +1,21 @@
 import { t } from "ttag";
-import * as Yup from "yup";
 
 import FormSubmitButton from "metabase/core/components/FormSubmitButton";
 import {
-  FormProvider,
   Form,
-  FormTextInput,
   FormErrorMessage,
+  FormProvider,
+  FormTextInput,
 } from "metabase/forms";
-import * as Errors from "metabase/lib/errors";
 import { Box, Button, Flex } from "metabase/ui";
+
+import { LICENSE_TOKEN_SCHEMA } from "./constants";
 
 type LicenseTokenFormProps = {
   onSubmit: (token: string) => Promise<void>;
   onSkip: () => void;
   initialValue?: string;
 };
-
-const LICENSE_TOKEN_SCHEMA = Yup.object({
-  license_token: Yup.string()
-    .length(64, Errors.exactLength)
-    .required(Errors.required),
-});
 
 export const LicenseTokenForm = ({
   onSubmit,

--- a/frontend/src/metabase/setup/components/LicenseTokenStep/constants.tsx
+++ b/frontend/src/metabase/setup/components/LicenseTokenStep/constants.tsx
@@ -1,0 +1,11 @@
+import * as Yup from "yup";
+
+import * as Errors from "metabase/lib/errors";
+
+export const LICENSE_TOKEN_SCHEMA = Yup.object({
+  license_token: Yup.string()
+    .test("license-token-test", Errors.exactLength({ length: 64 }), value =>
+      Boolean(value?.length === 64 || value?.startsWith("airgap_")),
+    )
+    .required(Errors.required),
+});

--- a/frontend/src/metabase/setup/components/LicenseTokenStep/constants.unit.spec.tsx
+++ b/frontend/src/metabase/setup/components/LicenseTokenStep/constants.unit.spec.tsx
@@ -1,0 +1,45 @@
+import * as Errors from "metabase/lib/errors";
+
+import { LICENSE_TOKEN_SCHEMA } from "./constants";
+
+describe("LICENSE_TOKEN_SCHEMA", () => {
+  it("should validate a valid license token with the correct length", async () => {
+    const validLicenseToken = "a".repeat(64);
+    await expect(
+      LICENSE_TOKEN_SCHEMA.validate({ license_token: validLicenseToken }),
+    ).resolves.toEqual({ license_token: validLicenseToken });
+  });
+
+  it('should validate a valid license token that starts with "airgap_"', async () => {
+    const validLicenseTokenAirgap = "airgap_toucan";
+    await expect(
+      LICENSE_TOKEN_SCHEMA.validate({ license_token: validLicenseTokenAirgap }),
+    ).resolves.toEqual({ license_token: validLicenseTokenAirgap });
+  });
+
+  it("should show a length error for an invalid length license token", async () => {
+    const invalidLicenseToken = "a".repeat(63); // One character too short and does not start with "airgap_"
+    await expect(
+      LICENSE_TOKEN_SCHEMA.validate({ license_token: invalidLicenseToken }),
+    ).rejects.toThrow(Errors.exactLength({ length: 64 }));
+  });
+
+  it("should show the length error when license token is not provided", async () => {
+    await expect(LICENSE_TOKEN_SCHEMA.validate({})).rejects.toThrow(
+      Errors.exactLength({ length: 64 }),
+    );
+  });
+
+  it("should show an error when license token is undefined", async () => {
+    await expect(
+      LICENSE_TOKEN_SCHEMA.validate({ license_token: undefined }),
+    ).rejects.toThrow(Errors.exactLength({ length: 64 }));
+  });
+
+  it('should not validate a license token with invalid length that does not start with "airgap_"', async () => {
+    const invalidLicenseToken = "b".repeat(65); // Too long and does not start with "airgap_"
+    await expect(
+      LICENSE_TOKEN_SCHEMA.validate({ license_token: invalidLicenseToken }),
+    ).rejects.toThrow(Errors.exactLength({ length: 64 }));
+  });
+});


### PR DESCRIPTION
Accept license tokens with an `airgap_` prefix, besides the already accepted 64-character long tokens.

This weakens the validation in the FE. Rigorous validation of tokens beginning with `airgap_` occurs in the BE. See this [Slack message](https://metaboat.slack.com/archives/C064EB1UE5P/p1715813885703249?thread_ts=1715813614.437989&cid=C064EB1UE5P).