### PR TITLE
[MBQL lib] Hide `:offset` exprs in `visibleColumns` (and therefore `filterableColumns` etc.)

### DIFF
--- a/src/metabase/lib/order_by.cljc
+++ b/src/metabase/lib/order_by.cljc
@@ -103,7 +103,7 @@
     stage-number :- :int]
    (not-empty (get (lib.util/query-stage query stage-number) :order-by))))
 
-(defn- orderable-column? [{:keys [base-type], :as _column-metadata}]
+(defn- orderable-column? [{:keys [base-type]}]
   (some (fn [orderable-base-type]
           (isa? base-type orderable-base-type))
         lib.schema.expression/orderable-types))

--- a/src/metabase/lib/stage.cljc
+++ b/src/metabase/lib/stage.cljc
@@ -15,6 +15,7 @@
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.util :as lib.util]
+   [metabase.lib.util.match :as lib.util.match]
    [metabase.shared.util.i18n :as i18n]
    [metabase.util :as u]
    [metabase.util.malli :as mu]))
@@ -161,16 +162,23 @@
       (not-empty (lib.metadata.calculation/visible-columns query stage-number card options)))))
 
 (mu/defn ^:private expressions-metadata :- [:maybe lib.metadata.calculation/ColumnsWithUniqueAliases]
-  [query          :- ::lib.schema/query
-   stage-number   :- :int
-   unique-name-fn :- ::lib.metadata.calculation/unique-name-fn]
+  [query                         :- ::lib.schema/query
+   stage-number                  :- :int
+   unique-name-fn                :- ::lib.metadata.calculation/unique-name-fn
+   {:keys [include-late-exprs?]} :- [:map [:include-late-exprs? {:optional true} :boolean]]]
   (not-empty
-   (for [expression (lib.expression/expressions-metadata query stage-number)]
-     (let [base-type (:base-type expression)]
-       (-> (assoc expression
+    (for [[clause metadata] (map vector
+                                 (:expressions (lib.util/query-stage query stage-number))
+                                 (lib.expression/expressions-metadata query stage-number))
+          ;; Only include "late" expressions when required.
+          ;; "Late" expressions those like :offset which can't be used within the same query stage, like aggregations.
+          :when (or include-late-exprs?
+                    (not (lib.util.match/match-one clause :offset)))]
+     (let [base-type (:base-type metadata)]
+       (-> (assoc metadata
                   :lib/source               :source/expressions
-                  :lib/source-column-alias  (:name expression)
-                  :lib/desired-column-alias (unique-name-fn (:name expression)))
+                  :lib/source-column-alias  (:name metadata)
+                  :lib/desired-column-alias (unique-name-fn (:name metadata)))
            (u/assoc-default :effective-type (or base-type :type/*)))))))
 
 ;;; Calculate the columns to return if `:aggregations`/`:breakout`/`:fields` are unspecified.
@@ -233,7 +241,7 @@
    (previous-stage-or-source-visible-columns query stage-number options)
    ;; 2: expressions (aka calculated columns) added in this stage
    (when include-expressions?
-     (expressions-metadata query stage-number unique-name-fn))
+     (expressions-metadata query stage-number unique-name-fn {}))
    ;; 3: columns added by joins at this stage
    (when include-joined?
      (lib.join/all-joins-visible-columns query stage-number unique-name-fn))))
@@ -279,7 +287,7 @@
         ;; we don't want to include all visible joined columns, so calculate that separately
         (previous-stage-or-source-visible-columns query stage-number {:include-implicitly-joinable? false
                                                                       :unique-name-fn               unique-name-fn})
-        (expressions-metadata query stage-number unique-name-fn)
+        (expressions-metadata query stage-number unique-name-fn {:include-late-exprs? true})
         (lib.join/all-joins-expected-columns query stage-number options))))))
 
 (defmethod lib.metadata.calculation/display-name-method :mbql.stage/native

--- a/test/metabase/lib/expression_test.cljc
+++ b/test/metabase/lib/expression_test.cljc
@@ -11,7 +11,9 @@
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.expression :as lib.schema.expression]
    [metabase.lib.test-metadata :as meta]
-   [metabase.lib.test-util :as lib.tu]))
+   [metabase.lib.test-util :as lib.tu]
+   [metabase.lib.util :as lib.util]
+   [metabase.util :as u]))
 
 (comment lib/keep-me)
 
@@ -300,6 +302,24 @@
     (is (= ["ID" "NAME" "a" "b"] (expressionable-expressions-for-position 2)))
     (is (= (lib/visible-columns query)
            (lib/expressionable-columns query nil)))))
+
+(deftest ^:parallel expressionable-columns-exclude-expressions-containing-offset
+  (testing "expressionable-columns should filter out expressions which contain :offset"
+    (let [query (-> lib.tu/venues-query
+                    (lib/order-by (meta/field-metadata :venues :id) :asc)
+                    (lib/expression "Offset col"    (lib/offset (meta/field-metadata :venues :price) -1))
+                    (lib/expression "Nested Offset"
+                                    (lib/* 100 (lib/offset (meta/field-metadata :venues :price) -1))))]
+      (testing (lib.util/format "Query =\n%s" (u/pprint-to-str query))
+        (is (=? [{:id (meta/id :venues :id) :name "ID"}
+                 {:id (meta/id :venues :name) :name "NAME"}
+                 {:id (meta/id :venues :category-id) :name "CATEGORY_ID"}
+                 {:id (meta/id :venues :latitude) :name "LATITUDE"}
+                 {:id (meta/id :venues :longitude) :name "LONGITUDE"}
+                 {:id (meta/id :venues :price) :name "PRICE"}
+                 {:id (meta/id :categories :id) :name "ID"}
+                 {:id (meta/id :categories :name) :name "NAME"}]
+                (lib/expressionable-columns query -1 2)))))))
 
 (deftest ^:parallel infix-display-name-with-expressions-test
   (testing "#32063"

--- a/test/metabase/lib/order_by_test.cljc
+++ b/test/metabase/lib/order_by_test.cljc
@@ -285,6 +285,24 @@
                  {:id (meta/id :categories :name) :name "NAME"}]
                 (lib/orderable-columns query)))))))
 
+(deftest ^:parallel orderable-columns-exclude-expressions-containing-offset
+  (testing "orderable-columns should filter out expressions which contain :offset"
+    (let [query (-> lib.tu/venues-query
+                    (lib/order-by (meta/field-metadata :venues :id) :asc)
+                    (lib/expression "Offset col"    (lib/offset (meta/field-metadata :venues :price) -1))
+                    (lib/expression "Nested Offset"
+                                    (lib/* 100 (lib/offset (meta/field-metadata :venues :price) -1))))]
+      (testing (lib.util/format "Query =\n%s" (u/pprint-to-str query))
+        (is (=? [{:id (meta/id :venues :id) :name "ID"}
+                 {:id (meta/id :venues :name) :name "NAME"}
+                 {:id (meta/id :venues :category-id) :name "CATEGORY_ID"}
+                 {:id (meta/id :venues :latitude) :name "LATITUDE"}
+                 {:id (meta/id :venues :longitude) :name "LONGITUDE"}
+                 {:id (meta/id :venues :price) :name "PRICE"}
+                 {:id (meta/id :categories :id) :name "ID"}
+                 {:id (meta/id :categories :name) :name "NAME"}]
+                (lib/orderable-columns query)))))))
+
 (deftest ^:parallel orderable-explicit-joins-test
   (testing "orderable-columns should include columns from explicit joins"
     (let [query (-> lib.tu/venues-query


### PR DESCRIPTION
Offset expressions are what we might call "late" expressions - they only make sense at aggregation time, at the end of a query stage.

This change hides `:offset` expressions in `visibleColumns` on a stage, which means they don't appear in `expressionableColumns`, `filterableColumns` or `orderableColumns`. Like aggregations, they aren't "visible" within a stage, though they are returned from it. (`:offset` expressions appear in `returnColumns`, of course.)

Fixes #42725.