### PR TITLE
Realize DB transient rows in after-select hook before calling `driver.u/features`

### DIFF
--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -181,7 +181,7 @@
     (cond-> database
       ;; TODO - this is only really needed for API responses. This should be a `hydrate` thing instead!
       (driver.impl/registered? driver)
-      (assoc :features (driver.u/features driver database))
+      (assoc :features (driver.u/features driver (t2.realize/realize database)))
 
       (and (driver.impl/registered? driver)
            (:details database)


### PR DESCRIPTION
This PR fixes an issue where a driver implementation of `driver/database-supports?`  cannot use `sql-jdbc.execute/do-with-connection-with-options` or `sql-jdbc.connection/db->pooled-connection-spec`.

The toucan after-select hook for a database executes [`(driver.u/features driver database)`](https://github.com/metabase/metabase/blob/ad41c5c241935d3e5a72895ba5a3593bdfaebd25/src/metabase/models/database.clj#L184), which calls `driver/database-supports?`. But the `database` argument is of type `toucan2.jdbc.row.TransientRow`, so `(mi/instance-of? :model/Database db-or-id-or-spec)` will evaluate to false [here](https://github.com/metabase/metabase/blob/ad41c5c241935d3e5a72895ba5a3593bdfaebd25/src/metabase/driver/sql_jdbc/connection.clj#L240) in `db->pooled-connection-spec` when it should evaluate to true. The problem is `db->pooled-connection-spec` doesn't expect its `db` argument to be a TransientRow type. The PR ensures that the transient row is realized before calling `driver/database-supports?`, eliminating this possibility.

I discovered this case while implementing `driver/database-supports?` for uploads for clickhouse.