### PR TITLE
Do not suggest `Offset` in filters

### DIFF
--- a/frontend/src/metabase-lib/v1/expressions/suggest.ts
+++ b/frontend/src/metabase-lib/v1/expressions/suggest.ts
@@ -195,6 +195,12 @@ export function suggest({
         .filter(
           clause => clause && database?.hasFeature(clause.requiresFeature),
         )
+        .filter(function disableOffsetInFilterExpressions(clause) {
+          const isOffset = clause.name === "offset";
+          const isFilterExpression = startRule === "boolean";
+          const isOffsetInFilterExpression = isOffset && isFilterExpression;
+          return !isOffsetInFilterExpression;
+        })
         .map(func => ({
           type: "functions",
           name: func.displayName,


### PR DESCRIPTION
Closes #42753

### Description

Test coverage for it will come in #42511

### How to verify

1. New question -> Sample Dataset -> Orders
2. Try to add a custom expression filter
3. Type `off`
4. `Offset` function [**should not** be suggested](https://github.com/metabase/metabase/assets/6830683/7b27f9e1-2295-48d6-9c63-1111937d6157)
5. Try to add a custom expression column
6. Type `off`
7. `Offset` function [**should** be suggested](https://github.com/metabase/metabase/assets/6830683/768dbb8f-f0c0-4073-9ed2-3dd98c457439)
