### PR TITLE
Remove last traces of buildjet from the CI

### DIFF
--- a/.github/actions/build-e2e-matrix/action.yml
+++ b/.github/actions/build-e2e-matrix/action.yml
@@ -16,7 +16,6 @@ runs:
           const java = 11;
 
           const defaultRunner = "ubuntu-22.04";
-          const beefierRunner = "buildjet-2vcpu-ubuntu-2204";
 
           const defaultOptions = {
             "java-version": java,

--- a/.github/workflows/percy-issue-comment.yml
+++ b/.github/workflows/percy-issue-comment.yml
@@ -53,7 +53,7 @@ jobs:
 
   percy:
     timeout-minutes: 30
-    runs-on: buildjet-4vcpu-ubuntu-2004
+    runs-on: ubuntu-22.04
     needs: [pr_info]
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/percy-visual-label.yml
+++ b/.github/workflows/percy-visual-label.yml
@@ -9,7 +9,7 @@ jobs:
   percy:
     if: contains(github.event.pull_request.labels.*.name, 'visual')
     timeout-minutes: 30
-    runs-on: buildjet-4vcpu-ubuntu-2004
+    runs-on: ubuntu-22.04
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We stopped using BuildJet.
These were the last, forgotten, references to its runners.