### PR TITLE
Properly pass compatible metrics to MBQL lib

### DIFF
--- a/frontend/src/metabase-lib/v1/metadata/Table.ts
+++ b/frontend/src/metabase-lib/v1/metadata/Table.ts
@@ -20,13 +20,14 @@ import type Segment from "./Segment";
 interface Table
   extends Omit<
     NormalizedTable,
-    "db" | "schema" | "fields" | "fks" | "segments"
+    "db" | "schema" | "fields" | "fks" | "segments" | "metrics"
   > {
   db?: Database;
   schema?: Schema;
   fields?: Field[];
   fks?: ForeignKey[];
   segments?: Segment[];
+  metrics?: Question[];
   metadata?: Metadata;
 }
 

--- a/frontend/src/metabase-types/api/mocks/schema.ts
+++ b/frontend/src/metabase-types/api/mocks/schema.ts
@@ -42,6 +42,7 @@ export const createMockNormalizedTable = ({
   fields,
   fks,
   segments,
+  metrics,
   ...opts
 }: Partial<NormalizedTable> = {}): NormalizedTable => ({
   ...createMockTable(opts),
@@ -50,6 +51,7 @@ export const createMockNormalizedTable = ({
   fields,
   fks,
   segments,
+  metrics,
 });
 
 export const createMockNormalizedFieldDimension = ({

--- a/frontend/src/metabase-types/api/schema.ts
+++ b/frontend/src/metabase-types/api/schema.ts
@@ -1,6 +1,6 @@
 import type { WritebackAction } from "./actions";
 import type { Alert } from "./alert";
-import type { Card } from "./card";
+import type { Card, CardId } from "./card";
 import type { Collection, CollectionId, CollectionItemId } from "./collection";
 import type { Dashboard } from "./dashboard";
 import type { Database, DatabaseId } from "./database";
@@ -38,6 +38,7 @@ export interface NormalizedTable
   fields?: FieldId[];
   fks?: NormalizedForeignKey[];
   segments?: SegmentId[];
+  metrics?: CardId[];
   schema?: SchemaId;
   schema_name?: string;
 }

--- a/frontend/src/metabase-types/api/table.ts
+++ b/frontend/src/metabase-types/api/table.ts
@@ -1,3 +1,4 @@
+import type { Card } from "./card";
 import type { Database, DatabaseId, InitialSyncStatus } from "./database";
 import type { Field, FieldDimensionOption, FieldId } from "./field";
 import type { Segment } from "./segment";
@@ -34,6 +35,7 @@ export interface Table {
   fks?: ForeignKey[];
   fields?: Field[];
   segments?: Segment[];
+  metrics?: Card[];
   dimension_options?: Record<string, FieldDimensionOption>;
   field_order: TableFieldOrder;
 

--- a/frontend/src/metabase/schema.js
+++ b/frontend/src/metabase/schema.js
@@ -86,6 +86,7 @@ TableSchema.define({
   db: DatabaseSchema,
   fields: [FieldSchema],
   fks: [{ origin: FieldSchema, destination: FieldSchema }],
+  metrics: [QuestionSchema],
   segments: [SegmentSchema],
   schema: SchemaSchema,
 });

--- a/frontend/src/metabase/selectors/metadata.ts
+++ b/frontend/src/metabase/selectors/metadata.ts
@@ -140,6 +140,7 @@ export const getMetadata: (
       table.fields = hydrateTableFields(table, metadata);
       table.fks = hydrateTableForeignKeys(table, metadata);
       table.segments = hydrateTableSegments(table, metadata);
+      table.metrics = hydrateTableMetrics(table, metadata);
     });
     Object.values(metadata.databases).forEach(database => {
       database.schemas = hydrateDatabaseSchemas(database, metadata);
@@ -324,6 +325,11 @@ function hydrateTableForeignKeys(
 function hydrateTableSegments(table: Table, metadata: Metadata): Segment[] {
   const segmentIds = table.getPlainObject().segments ?? [];
   return segmentIds.map(id => metadata.segment(id)).filter(isNotNull);
+}
+
+function hydrateTableMetrics(table: Table, metadata: Metadata): Question[] {
+  const metricIds = table.getPlainObject().metrics ?? [];
+  return metricIds.map(id => metadata.question(id)).filter(isNotNull);
 }
 
 function hydrateFieldTable(


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/42742

We decided to keep metrics that are compatible with the current table in `query_metadata` response alongside segments. This PR brings "metrics" in `query_metadata` back and hydrates them when constructing metadata for MBQL lib. The only difference between this branch and master is that metrics are now questions and not separate entities.

How to verify:
- Create a metric based on the orders table
- Make sure it's available in table metadata for the orders table. You can do by inspecting `__MLv2_metadata` global variable (dev only) in the query builder

<img width="1416" alt="Screenshot 2024-05-16 at 09 57 35" src="https://github.com/metabase/metabase/assets/8542534/142bcf2e-7adb-4ebb-99ef-0248f7b18b8c">

