### PR TITLE
Fix unmounted node error on ExplicitSize

### DIFF
--- a/frontend/src/metabase/components/ExplicitSize.tsx
+++ b/frontend/src/metabase/components/ExplicitSize.tsx
@@ -77,11 +77,16 @@ function ExplicitSize<T extends BaseInnerProps>({
       }
 
       _getElement() {
-        let element = ReactDOM.findDOMNode(this);
-        if (selector && element instanceof Element) {
-          element = element.querySelector(selector) || element;
+        try {
+          let element = ReactDOM.findDOMNode(this);
+          if (selector && element instanceof Element) {
+            element = element.querySelector(selector) || element;
+          }
+          return element instanceof Element ? element : null;
+        } catch (e) {
+          console.error(e);
+          return null;
         }
-        return element instanceof Element ? element : null;
       }
 
       componentDidMount() {


### PR DESCRIPTION
This fix is mainly for the embedding SDK. When double-clicking on parameter popovers on embedded dashboards, we run into an error where the popover element unmounts while ExplicitSize is still trying to calculate its size, and React.findDOMNode breaks when attempting to find the now-unmounted popover element. This try/catch stops those errors.