### PR TITLE
Drop the "frozen" frontend install during build when in CI

### DIFF
--- a/bin/build/src/build.clj
+++ b/bin/build/src/build.clj
@@ -27,11 +27,8 @@
                      :ee "ee"
                      :oss "oss")]
     (u/step (format "Build frontend with MB_EDITION=%s" mb-edition)
-      (u/step "Run 'yarn' to download javascript dependencies"
-        (if (env/env :ci)
-          (do
-            (u/announce "CI run: enforce the lockfile")
-            (u/sh {:dir u/project-root-directory} "yarn" "--frozen-lockfile"))
+      (when-not (env/env :ci)
+        (u/step "Run 'yarn' to download JavaScript dependencies"
           (u/sh {:dir u/project-root-directory} "yarn")))
       (u/step "Build frontend"
         (u/sh {:dir u/project-root-directory


### PR DESCRIPTION
### What does this PR accomplish?
This PR drops the "frozen" `yarn` install when doing the `:frontend` build step in the CI.

**Why?**
Every time we build the uberjar in the CI, we are always running the [`prepare-frontend`](https://github.com/metabase/metabase/blob/master/.github/actions/prepare-frontend/action.yml) composite action that already includes `yarn install --frozen-lockfile` so there's no need to repeat this step again during the build process.

Furthermore, `prepare-frontend` will respect if commit message contains `[ci nocache]` whereas the related Clojure code didn't have this distinction.

Nothing changes for the local build process.

### Additional Info
Slightly related to #37576, even though this will not "buy us" more than a couple of seconds in the CI. This is more of a correctness fix.