### PR TITLE
Bump `screenfull` version to 6.0.2

### DIFF
--- a/frontend/src/metabase/dashboard/hoc/DashboardControls.jsx
+++ b/frontend/src/metabase/dashboard/hoc/DashboardControls.jsx
@@ -41,7 +41,7 @@ export const DashboardControls = ComposedComponent =>
       };
 
       UNSAFE_componentWillMount() {
-        if (screenfull.enabled) {
+        if (screenfull.isEnabled) {
           document.addEventListener(
             screenfull.raw.fullscreenchange,
             this._fullScreenChanged,
@@ -62,7 +62,7 @@ export const DashboardControls = ComposedComponent =>
       componentWillUnmount() {
         this._showNav(true);
         this._clearRefreshInterval();
-        if (screenfull.enabled) {
+        if (screenfull.isEnabled) {
           document.removeEventListener(
             screenfull.raw.fullscreenchange,
             this._fullScreenChanged,
@@ -158,7 +158,7 @@ export const DashboardControls = ComposedComponent =>
       setFullscreen = async (isFullscreen, browserFullscreen = true) => {
         isFullscreen = !!isFullscreen;
         if (isFullscreen !== this.state.isFullscreen) {
-          if (screenfull.enabled && browserFullscreen) {
+          if (screenfull.isEnabled && browserFullscreen) {
             if (isFullscreen) {
               try {
                 // Some browsers block this unless it was initiated by user
@@ -222,7 +222,7 @@ export const DashboardControls = ComposedComponent =>
       }
 
       _fullScreenChanged = () => {
-        this.setState({ isFullscreen: !!screenfull.isFullscreen });
+        this.setState({ isFullscreen: screenfull.isFullscreen });
       };
 
       setRefreshElapsedHook = hook => {

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,7 +17,7 @@ const config = {
       "<rootDir>/frontend/test/__mocks__/svgMock.jsx",
   },
   transformIgnorePatterns: [
-    "<rootDir>/node_modules/(?!(echarts|zrender|rehype-external-links|hast.*|devlop|property-information|comma-separated-tokens|space-separated-tokens|vfile|vfile-message|html-void-elements|stringify-entities|character-entities-html4)/)",
+    "<rootDir>/node_modules/(?!(screenfull|echarts|zrender|rehype-external-links|hast.*|devlop|property-information|comma-separated-tokens|space-separated-tokens|vfile|vfile-message|html-void-elements|stringify-entities|character-entities-html4)/)",
   ],
   testPathIgnorePatterns: [
     "<rootDir>/frontend/.*/.*.tz.unit.spec.{js,jsx,ts,tsx}",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "rehype-external-links": "^2.0.1",
     "remark-gfm": "1.0.0",
     "reselect": "^5.1.0",
-    "screenfull": "^4.2.1",
+    "screenfull": "^6.0.2",
     "scroll-into-view-if-needed": "^3.1.0",
     "server-text-width": "^1.0.2",
     "simple-statistics": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20616,15 +20616,15 @@ schema-utils@^4.0.0:
     ajv-formats "^2.1.1"
     ajv-keywords "^5.0.0"
 
-screenfull@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/screenfull/-/screenfull-4.2.1.tgz#3245b7bc73d2b7c9a15bd8caaf6965db7cbc7f04"
-  integrity sha512-PLSp6f5XdhvjCCCO8OjavRfzkSGL3Qmdm7P82bxyU8HDDDBhDV3UckRaYcRa/NDNTYt8YBpzjoLWHUAejmOjLg==
-
 screenfull@^5.1.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/screenfull/-/screenfull-5.2.0.tgz#6533d524d30621fc1283b9692146f3f13a93d1ba"
   integrity sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==
+
+screenfull@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/screenfull/-/screenfull-6.0.2.tgz#3dbe4b8c4f8f49fb8e33caa8f69d0bca730ab238"
+  integrity sha512-AQdy8s4WhNvUZ6P8F6PB21tSPIYKniic+Ogx0AacBMjKP1GUHN2E9URxQHtCusiwxudnCKkdy4GrHXPPJSkCCw==
 
 scroll-into-view-if-needed@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
Bumps the version of `screenfull` to 6.0.2. This version provides less confusing types for typescript (the current version we're at thinks `screenfull` can be `false | Screenfull | [something complicated]`). This is another thing that will help me complete the Static Dashboard PR.