### PR TITLE
Remove location logic from DashboardTabs and use SyncedDashboardTabs

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderView.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderView.tsx
@@ -7,6 +7,7 @@ import { t } from "ttag";
 import EditBar from "metabase/components/EditBar";
 import CS from "metabase/css/core/index.css";
 import { updateDashboard } from "metabase/dashboard/actions";
+import { SyncedDashboardTabs } from "metabase/dashboard/components/DashboardTabs";
 import {
   getIsHeaderVisible,
   getIsSidebarOpen,
@@ -29,7 +30,6 @@ import {
   HeaderFixedWidthContainer,
   HeaderContainer,
 } from "../../components/DashboardHeaderView.styled";
-import { DashboardTabs } from "../../components/DashboardTabs/DashboardTabs";
 
 interface DashboardHeaderViewProps {
   editingTitle?: string;
@@ -179,7 +179,7 @@ export function DashboardHeaderComponent({
             isNavBarOpen={isNavBarOpen}
             isFixedWidth={dashboard?.width === "fixed"}
           >
-            <DashboardTabs
+            <SyncedDashboardTabs
               dashboardId={dashboard.id}
               location={location}
               isEditing={isEditing}

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.tsx
@@ -1,4 +1,3 @@
-import type { Location } from "history";
 import { t } from "ttag";
 
 import { Sortable } from "metabase/core/components/Sortable";
@@ -11,16 +10,14 @@ import type { SelectedTabId } from "metabase-types/store";
 import { Container, CreateTabButton } from "./DashboardTabs.styled";
 import { useDashboardTabs } from "./use-dashboard-tabs";
 
-interface DashboardTabsProps {
+export type DashboardTabsProps = {
   dashboardId: DashboardId;
-  location: Location;
   isEditing?: boolean;
   className?: string;
-}
+};
 
 export function DashboardTabs({
   dashboardId,
-  location,
   isEditing = false,
   className,
 }: DashboardTabsProps) {
@@ -33,7 +30,7 @@ export function DashboardTabs({
     selectTab,
     selectedTabId,
     moveTab,
-  } = useDashboardTabs({ location, dashboardId });
+  } = useDashboardTabs({ dashboardId });
   const hasMultipleTabs = tabs.length > 1;
   const showTabs = hasMultipleTabs || isEditing;
   const showPlaceholder = tabs.length === 0 && isEditing;

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.unit.spec.tsx
@@ -10,7 +10,7 @@ import { useSelector } from "metabase/lib/redux";
 import type { DashboardTab } from "metabase-types/api";
 import type { DashboardState, State } from "metabase-types/store";
 
-import { DashboardTabs } from "./DashboardTabs";
+import { SyncedDashboardTabs } from "./SyncedDashboardTabs";
 import { TEST_DASHBOARD_STATE } from "./test-utils";
 import { useDashboardTabs } from "./use-dashboard-tabs";
 import { getSlug } from "./use-sync-url-slug";
@@ -35,11 +35,11 @@ function setup({
   };
 
   const DashboardComponent = ({ location }: { location: Location }) => {
-    const { selectedTabId } = useDashboardTabs({ location, dashboardId: 1 });
+    const { selectedTabId } = useDashboardTabs({ dashboardId: 1 });
 
     return (
       <>
-        <DashboardTabs
+        <SyncedDashboardTabs
           dashboardId={1}
           location={location}
           isEditing={isEditing}

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/SyncedDashboardTabs.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/SyncedDashboardTabs.tsx
@@ -1,0 +1,34 @@
+import type { Location } from "history";
+import { useMount } from "react-use";
+
+import { initTabs } from "metabase/dashboard/actions";
+import {
+  parseSlug,
+  useSyncURLSlug,
+} from "metabase/dashboard/components/DashboardTabs/use-sync-url-slug";
+import { useDispatch } from "metabase/lib/redux";
+
+import type { DashboardTabsProps } from "./DashboardTabs";
+import { DashboardTabs } from "./DashboardTabs";
+
+export function SyncedDashboardTabs({
+  dashboardId,
+  location,
+  isEditing = false,
+  className,
+}: DashboardTabsProps & {
+  location: Location;
+}) {
+  const dispatch = useDispatch();
+
+  useSyncURLSlug({ location });
+  useMount(() => dispatch(initTabs({ slug: parseSlug({ location }) })));
+
+  return (
+    <DashboardTabs
+      dashboardId={dashboardId}
+      isEditing={isEditing}
+      className={className}
+    />
+  );
+}

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/index.ts
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/index.ts
@@ -1,2 +1,3 @@
 export * from "./DashboardTabs";
+export * from "./SyncedDashboardTabs";
 export * from "./use-dashboard-tabs";

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/use-dashboard-tabs.ts
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/use-dashboard-tabs.ts
@@ -1,13 +1,10 @@
 import type { UniqueIdentifier } from "@dnd-kit/core";
-import type { Location } from "history";
-import { useMount } from "react-use";
 import { t } from "ttag";
 
 import {
   createNewTab,
   renameTab,
   deleteTab as deleteTabAction,
-  initTabs,
   selectTab,
   undoDeleteTab,
   moveTab as moveTabAction,
@@ -20,8 +17,6 @@ import { addUndo } from "metabase/redux/undo";
 import type { DashboardId } from "metabase-types/api";
 import type { SelectedTabId } from "metabase-types/store";
 
-import { parseSlug, useSyncURLSlug } from "./use-sync-url-slug";
-
 let tabDeletionId = 1;
 
 function isTabIdType(id: unknown): id is SelectedTabId {
@@ -29,18 +24,13 @@ function isTabIdType(id: unknown): id is SelectedTabId {
 }
 
 export function useDashboardTabs({
-  location,
   dashboardId,
 }: {
-  location: Location;
   dashboardId: DashboardId;
 }) {
   const dispatch = useDispatch();
   const tabs = useSelector(getTabs);
   const selectedTabId = useSelector(getSelectedTabId);
-
-  useSyncURLSlug({ location });
-  useMount(() => dispatch(initTabs({ slug: parseSlug({ location }) })));
 
   const duplicateTab = (tabId: UniqueIdentifier | null) => {
     if (!isTabIdType(tabId)) {

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/use-sync-url-slug.ts
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/use-sync-url-slug.ts
@@ -66,8 +66,13 @@ export function useSyncURLSlug({ location }: { location: Location }) {
   const { updateURLSlug } = useUpdateURLSlug({ location });
 
   useEffect(() => {
+    if (!tabs || tabs.length === 0) {
+      return;
+    }
+
     const slugChanged = slug && slug !== prevSlug;
-    if (slugChanged) {
+
+    if (slugChanged || !prevTabs?.length) {
       dispatch(initTabs({ slug }));
       const slugId = getIdFromSlug(slug);
       const hasTabs = tabs.length > 0;

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/use-sync-url-slug.ts
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/use-sync-url-slug.ts
@@ -70,9 +70,9 @@ export function useSyncURLSlug({ location }: { location: Location }) {
       return;
     }
 
-    const slugChanged = slug && slug !== prevSlug;
+    const slugChanged = slug && prevSlug && slug !== prevSlug;
 
-    if (slugChanged || !prevTabs?.length) {
+    if (slugChanged) {
       dispatch(initTabs({ slug }));
       const slugId = getIdFromSlug(slug);
       const hasTabs = tabs.length > 0;
@@ -86,8 +86,9 @@ export function useSyncURLSlug({ location }: { location: Location }) {
 
     const tabSelected = selectedTabId !== prevSelectedTabId;
     const tabRenamed =
+      prevTabs &&
       tabs.find(t => t.id === selectedTabId)?.name !==
-      prevTabs?.find(t => t.id === selectedTabId)?.name;
+        prevTabs.find(t => t.id === selectedTabId)?.name;
     const penultimateTabDeleted = tabs.length === 1 && prevTabs?.length === 2;
 
     if (tabSelected || tabRenamed || penultimateTabDeleted) {

--- a/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx
@@ -28,7 +28,7 @@ import { Icon } from "metabase/ui";
 import { getValuePopulatedParameters } from "metabase-lib/v1/parameters/utils/parameter-values";
 
 import { FixedWidthContainer } from "../components/Dashboard/Dashboard.styled";
-import { DashboardTabs } from "../components/DashboardTabs";
+import { SyncedDashboardTabs } from "../components/DashboardTabs";
 
 import {
   ItemContent,
@@ -154,7 +154,7 @@ class AutomaticDashboardAppInner extends Component {
                   </div>
                   {this.props.tabs.length > 1 && (
                     <div className={cx(CS.wrapper, CS.flex, CS.alignCenter)}>
-                      <DashboardTabs location={this.props.location} />
+                      <SyncedDashboardTabs location={this.props.location} />
                     </div>
                   )}
                 </FixedWidthContainer>

--- a/frontend/src/metabase/public/containers/PublicDashboard/PublicDashboard.tsx
+++ b/frontend/src/metabase/public/containers/PublicDashboard/PublicDashboard.tsx
@@ -31,7 +31,7 @@ import {
 } from "metabase/dashboard/actions";
 import { getDashboardActions } from "metabase/dashboard/components/DashboardActions";
 import { DashboardGridConnected } from "metabase/dashboard/components/DashboardGrid";
-import { DashboardTabs } from "metabase/dashboard/components/DashboardTabs";
+import { SyncedDashboardTabs } from "metabase/dashboard/components/DashboardTabs";
 import { DashboardControls } from "metabase/dashboard/hoc/DashboardControls";
 import type {
   DashboardControlsPassedProps,
@@ -268,7 +268,7 @@ class PublicDashboardInner extends Component<PublicDashboardProps> {
         dashboardTabs={
           dashboard?.tabs &&
           dashboard.tabs.length > 1 && (
-            <DashboardTabs
+            <SyncedDashboardTabs
               dashboardId={this.props.dashboardId}
               location={this.props.location}
             />


### PR DESCRIPTION
Moving the location out of DashboardTabs will allow the static dashboards to work without changing the URL when it comes to using tabs. I then moved the URL logic to a wrapper component called `SyncedDashboardTabs`, which follows the same pattern as `SyncedParameterList` to use location data, but in a way that keeps it encapsulated in a different component.

This is in draft for now, since I need to make sure it still works independently before merging it with the other changes I've made