### PR TITLE
Fix filters with `is-null` and `not-null` operators crashing the QB

### DIFF
--- a/frontend/src/metabase-lib/constants.ts
+++ b/frontend/src/metabase-lib/constants.ts
@@ -3,8 +3,6 @@ export const STRING_FILTER_OPERATORS = [
   "!=",
   "contains",
   "does-not-contain",
-  "is-null",
-  "not-null",
   "is-empty",
   "not-empty",
   "starts-with",

--- a/frontend/src/metabase-lib/filter.unit.spec.ts
+++ b/frontend/src/metabase-lib/filter.unit.spec.ts
@@ -206,12 +206,7 @@ describe("filter", () => {
       },
     );
 
-    it.each<Lib.StringFilterOperatorName>([
-      "is-null",
-      "not-null",
-      "is-empty",
-      "not-empty",
-    ])(
+    it.each<Lib.StringFilterOperatorName>(["is-empty", "not-empty"])(
       'should be able to create and destructure a string filter with "%s" operator without values',
       operator => {
         const { filterParts, columnInfo } = addStringFilter(
@@ -310,12 +305,7 @@ describe("filter", () => {
       },
     );
 
-    it.each<Lib.StringFilterOperatorName>([
-      "is-null",
-      "not-null",
-      "is-empty",
-      "not-empty",
-    ])(
+    it.each<Lib.StringFilterOperatorName>(["is-empty", "not-empty"])(
       'should ignore case sensitivity options as they are not supported by "%s" operator without values',
       operator => {
         const { filterParts, columnInfo } = addStringFilter(
@@ -338,17 +328,35 @@ describe("filter", () => {
       },
     );
 
-    it("should ignore expressions with not supported operators", () => {
-      const { filterParts } = addStringFilter(
-        query,
-        Lib.expressionClause("concat", [
-          findColumn(query, tableName, columnName),
-          "A",
-        ]),
-      );
+    it.each<Lib.ExpressionOperatorName>(["is-null", "not-null"])(
+      "should ignore expressions with unsupported %s operator without values",
+      operator => {
+        const { filterParts } = addStringFilter(
+          query,
+          Lib.expressionClause(operator, [
+            findColumn(query, tableName, columnName),
+            "A",
+          ]),
+        );
 
-      expect(filterParts).toBeNull();
-    });
+        expect(filterParts).toBeNull();
+      },
+    );
+
+    it.each<Lib.ExpressionOperatorName>(["concat"])(
+      "should ignore expressions with unsupported %s operator with a value",
+      operator => {
+        const { filterParts } = addStringFilter(
+          query,
+          Lib.expressionClause(operator, [
+            findColumn(query, tableName, columnName),
+            "A",
+          ]),
+        );
+
+        expect(filterParts).toBeNull();
+      },
+    );
 
     it("should ignore expressions without first column", () => {
       const { filterParts } = addStringFilter(

--- a/frontend/src/metabase/querying/components/FilterPicker/FilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/FilterPicker.unit.spec.tsx
@@ -58,9 +58,16 @@ function createQueryWithSegmentFilter() {
   return createFilteredQuery(query, segment);
 }
 
-function createQueryWithCustomFilter() {
+function createQueryWithCustomStringFilter() {
   const query = createQuery();
+  const column = findStringColumn(query);
+  const clause = Lib.expressionClause("is-null", [column], null);
 
+  return createFilteredQuery(query, clause);
+}
+
+function createQueryWithCustomNumberFilter() {
+  const query = createQuery();
   const column1 = findBooleanColumn(query);
   const column2 = findNumericColumn(query);
   const clause = Lib.expressionClause(">", [column1, column2], null);
@@ -426,8 +433,15 @@ describe("FilterPicker", () => {
       );
     });
 
-    it("should update a filter with a custom expression", async () => {
-      const { query, getNextFilter } = setup(createQueryWithCustomFilter());
+    it("should open the expression editor for unsupported expressions", async () => {
+      setup(createQueryWithCustomStringFilter());
+      expect(screen.getByLabelText("Expression")).toBeInTheDocument();
+    });
+
+    it("should update a filter with a numeric custom expression", async () => {
+      const { query, getNextFilter } = setup(
+        createQueryWithCustomNumberFilter(),
+      );
 
       await editExpressionAndSubmit("{selectall}{backspace}[[Total] > 100", {
         delay: 50,

--- a/frontend/src/metabase/querying/hooks/use-coordinate-filter/constants.ts
+++ b/frontend/src/metabase/querying/hooks/use-coordinate-filter/constants.ts
@@ -1,6 +1,11 @@
+import type * as Lib from "metabase-lib";
+
 import type { OperatorOption } from "./types";
 
-export const OPERATOR_OPTIONS: Record<string, OperatorOption> = {
+export const OPERATOR_OPTIONS: Record<
+  Lib.CoordinateFilterOperatorName,
+  OperatorOption
+> = {
   "=": {
     operator: "=",
     valueCount: 1,

--- a/frontend/src/metabase/querying/hooks/use-string-filter/constants.ts
+++ b/frontend/src/metabase/querying/hooks/use-string-filter/constants.ts
@@ -38,12 +38,4 @@ export const OPERATOR_OPTIONS: Record<
     operator: "not-empty",
     type: "empty",
   },
-  "is-null": {
-    operator: "is-null",
-    type: "empty",
-  },
-  "not-null": {
-    operator: "not-null",
-    type: "empty",
-  },
 };

--- a/frontend/src/metabase/querying/hooks/use-string-filter/constants.ts
+++ b/frontend/src/metabase/querying/hooks/use-string-filter/constants.ts
@@ -1,6 +1,11 @@
+import type * as Lib from "metabase-lib";
+
 import type { OperatorOption } from "./types";
 
-export const OPERATOR_OPTIONS: Record<string, OperatorOption> = {
+export const OPERATOR_OPTIONS: Record<
+  Lib.StringFilterOperatorName,
+  OperatorOption
+> = {
   "=": {
     operator: "=",
     type: "exact",
@@ -31,6 +36,14 @@ export const OPERATOR_OPTIONS: Record<string, OperatorOption> = {
   },
   "not-empty": {
     operator: "not-empty",
+    type: "empty",
+  },
+  "is-null": {
+    operator: "is-null",
+    type: "empty",
+  },
+  "not-null": {
+    operator: "not-null",
     type: "empty",
   },
 };

--- a/frontend/src/metabase/querying/hooks/use-string-filter/use-string-filter.unit.spec.ts
+++ b/frontend/src/metabase/querying/hooks/use-string-filter/use-string-filter.unit.spec.ts
@@ -105,6 +105,16 @@ describe("useStringFilter", () => {
       values: [],
       expectedDisplayName: "Category is not empty",
     },
+    {
+      operator: "is-null",
+      values: [],
+      expectedDisplayName: "Category is empty",
+    },
+    {
+      operator: "not-null",
+      values: [],
+      expectedDisplayName: "Category is not empty",
+    },
   ])(
     'should allow to create a filter for "$operator" operator',
     ({ operator: newOperator, values: newValues, expectedDisplayName }) => {

--- a/frontend/src/metabase/querying/hooks/use-string-filter/use-string-filter.unit.spec.ts
+++ b/frontend/src/metabase/querying/hooks/use-string-filter/use-string-filter.unit.spec.ts
@@ -105,16 +105,6 @@ describe("useStringFilter", () => {
       values: [],
       expectedDisplayName: "Category is not empty",
     },
-    {
-      operator: "is-null",
-      values: [],
-      expectedDisplayName: "Category is empty",
-    },
-    {
-      operator: "not-null",
-      values: [],
-      expectedDisplayName: "Category is not empty",
-    },
   ])(
     'should allow to create a filter for "$operator" operator',
     ({ operator: newOperator, values: newValues, expectedDisplayName }) => {


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/41783

We forgot to handle `is-null` and `not-null` string operators. The UI doesn't suggest them usually but it's possible to create such filters via drills.

How to verify:
- CI is green, new tests pass 