### PR TITLE
defaultToRecentsTab added

### DIFF
--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
@@ -66,6 +66,10 @@ export interface EntityPickerModalProps<Model extends string, Item> {
   searchParams?: Partial<SearchRequest>;
   actionButtons?: JSX.Element[];
   trapFocus?: boolean;
+  /**defaultToRecentTab: If set to true, will initially show the recent tab when the modal appears. If set to false, it will show the tab
+   * with the same model as the initialValue. Defaults to true.
+   */
+  defaultToRecentTab?: boolean;
 }
 
 export function EntityPickerModal<
@@ -87,6 +91,7 @@ export function EntityPickerModal<
   recentFilter,
   trapFocus = true,
   searchParams,
+  defaultToRecentTab = true,
 }: EntityPickerModalProps<Model, Item>) {
   const [searchQuery, setSearchQuery] = useState<string>("");
   const { data: recentItems, isLoading: isLoadingRecentItems } =
@@ -203,6 +208,7 @@ export function EntityPickerModal<
                 searchResults={searchResults}
                 selectedItem={selectedItem}
                 initialValue={initialValue}
+                defaultToRecentTab={defaultToRecentTab}
               />
             ) : (
               <SinglePickerView>{tabs[0].element}</SinglePickerView>

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.unit.spec.tsx
@@ -36,6 +36,8 @@ interface SetupOpts {
   actionButtons?: JSX.Element[];
   recentFilter?: (item: RecentItem[]) => RecentItem[];
   recentItems?: RecentItem[];
+  defaultToRecentTab?: boolean;
+  initialValue?: { model: SampleModelType };
 }
 
 const TestPicker = ({ name }: { name: string }) => (
@@ -260,6 +262,19 @@ describe("EntityPickerModal", () => {
         await screen.findByRole("tab", { name: /Recents/ }),
       ).toBeInTheDocument();
       expect(await screen.findByText("Recent Question")).toBeInTheDocument();
+    });
+
+    it("should not default to the recent tab if defaultToRecents is false", async () => {
+      setup({
+        recentItems,
+        defaultToRecentTab: false,
+        initialValue: { model: "card" },
+      });
+
+      expect(
+        await screen.findByRole("tab", { name: /Recents/ }),
+      ).toBeInTheDocument();
+      expect(await screen.findByText("Test picker foo")).toBeInTheDocument();
     });
 
     it("should group recents by time", async () => {

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/TabsView.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/TabsView.tsx
@@ -1,5 +1,4 @@
-import { useState, useEffect } from "react";
-import { useMount, usePrevious } from "react-use";
+import { useState, useEffect, useMemo } from "react";
 
 import { Icon, Tabs } from "metabase/ui";
 import type {
@@ -14,6 +13,33 @@ import {
   EntityPickerSearchTab,
 } from "../EntityPickerSearch";
 
+const computeInitialTab = <
+  Item extends TypeWithModel<SearchResultId, Model>,
+  Model extends string,
+>({
+  initialValue,
+  tabs,
+  hasRecents,
+  defaultToRecentTab,
+}: {
+  initialValue?: Partial<Item>;
+  tabs: EntityTab<Model>[];
+  hasRecents: boolean;
+  defaultToRecentTab: boolean;
+}) => {
+  if (hasRecents && defaultToRecentTab) {
+    return { model: "recents" };
+  }
+  if (
+    initialValue?.model &&
+    tabs.some(tab => tab.model === initialValue.model)
+  ) {
+    return { model: initialValue.model };
+  } else {
+    return { model: tabs[0].model };
+  }
+};
+
 export const TabsView = <
   Id extends SearchResultId,
   Model extends string,
@@ -25,6 +51,7 @@ export const TabsView = <
   searchResults,
   selectedItem,
   initialValue,
+  defaultToRecentTab,
 }: {
   tabs: EntityTab<Model>[];
   onItemSelect: (item: Item) => void;
@@ -33,39 +60,35 @@ export const TabsView = <
   selectedItem: Item | null;
   initialValue?: Partial<Item>;
   searchParams?: Partial<SearchRequest>;
+  defaultToRecentTab: boolean;
 }) => {
   const hasSearchTab = !!searchQuery;
   const hasRecentsTab = tabs.some(tab => tab.model === "recents");
-  const previousSearchQuery = usePrevious(searchQuery);
-  const defaultTab = hasSearchTab
-    ? { model: "search" }
-    : hasRecentsTab
-    ? { model: "recents" }
-    : tabs[0];
-  const [selectedTab, setSelectedTab] = useState<string>(defaultTab.model);
 
-  useMount(() => {
-    if (
-      initialValue?.model &&
-      tabs.some(tab => tab.model === initialValue.model) &&
-      !hasRecentsTab
-    ) {
-      setSelectedTab(initialValue.model);
-    }
-  });
+  const defaultTab = useMemo(
+    () =>
+      computeInitialTab({
+        initialValue,
+        tabs,
+        hasRecents: hasRecentsTab,
+        defaultToRecentTab,
+      }),
+    [initialValue, tabs, hasRecentsTab, defaultToRecentTab],
+  );
+
+  const [selectedTab, setSelectedTab] = useState<string>(defaultTab.model);
 
   useEffect(() => {
     // when the searchQuery changes, switch to the search tab
-    if (!!searchQuery && searchQuery !== previousSearchQuery) {
+    if (searchQuery) {
       setSelectedTab("search");
-    } else if (selectedTab === "search") {
+    } else {
       setSelectedTab(defaultTab.model);
     }
-  }, [searchQuery, previousSearchQuery, selectedTab, defaultTab.model]);
+  }, [searchQuery, defaultTab.model]);
 
   return (
     <Tabs
-      defaultValue={defaultTab.model}
       value={selectedTab}
       style={{
         flexGrow: 1,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/42774

### Description
Adds the ability to tell the`EntityPickerModal` to show the tab with the corresponding model to the initial value as the default, rather than always defaulting to the `Recents` tab

### How to verify
This isn't used in master yet, so we'll need to trust the unit test 😬 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
