### PR TITLE
Exclude view_count columns from serialized dashboard, card, and table

### DIFF
--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -972,7 +972,7 @@ saved later when it is ready."
         (update :parameter_mappings     serdes/export-parameter-mappings)
         (update :visualization_settings serdes/export-visualization-settings)
         (update :result_metadata        export-result-metadata)
-        (dissoc :cache_invalidated_at))
+        (dissoc :cache_invalidated_at :view_count))
     (catch Exception e
       (throw (ex-info (format "Failed to export Card: %s" (ex-message e)) {:card card} e)))))
 

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -620,7 +620,8 @@
         (update :parameters        serdes/export-parameters)
         (update :collection_id     serdes/*export-fk* Collection)
         (update :creator_id        serdes/*export-user*)
-        (update :made_public_by_id serdes/*export-user*))))
+        (update :made_public_by_id serdes/*export-user*)
+        (dissoc :view_count))))
 
 (defmethod serdes/load-xform "Dashboard"
   [dash]

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -275,6 +275,7 @@
 (defmethod serdes/extract-one "Table"
   [_model-name _opts {:keys [db_id] :as table}]
   (-> (serdes/extract-one-basics "Table" table)
+      (dissoc :view_count)
       (assoc :db_id (t2/select-one-fn :name :model/Database :id db_id))))
 
 (defmethod serdes/load-xform "Table"


### PR DESCRIPTION
New `view_count` columns are being included in exports https://github.com/metabase/metabase/pull/42799/files.

I tested this manually. As far as I know we don't have automated tests to verify that columns are _excluded_ from exports. We only have tests for _some_ columns to check that they are _included_, e.g. https://github.com/metabase/metabase/blob/f213ef2a85e46d006fc2a9d53403dc5d6537d87e/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj#L403-L432

I'm not sure there's a good reason for only testing some columns, and only inclusion. It does make developers lives easier because almost all columns are included in serialized dashboards and cards. In any case this PR is not going to introduce these stronger tests, yet.