### PR TITLE
Use is-empty and not-empty for string columns in quick filter drill

### DIFF
--- a/src/metabase/lib/drill_thru/quick_filter.cljc
+++ b/src/metabase/lib/drill_thru/quick_filter.cljc
@@ -65,8 +65,11 @@
       []
 
       (= value :null)
-      [{:name "=" :filter (operator :is-null  field-ref)}
-       {:name "≠" :filter (operator :not-null field-ref)}]
+      (for [[op label] (if (or (lib.types.isa/string? column) (lib.types.isa/string-like? column))
+                         [[:is-empty "="] [:not-empty "≠"]]
+                         [[:is-null "="] [:not-null "≠"]])]
+        {:name   label
+         :filter (operator op field-ref)})
 
       (or (lib.types.isa/numeric? column)
           (lib.types.isa/temporal? column))

--- a/test/metabase/lib/drill_thru/quick_filter_test.cljc
+++ b/test/metabase/lib/drill_thru/quick_filter_test.cljc
@@ -139,6 +139,21 @@
                      :operators [{:name "="}
                                  {:name "≠"}]}})))
 
+(deftest ^:parallel returns-quick-filter-test-10
+  (testing "quick-filter should use is-empty and not-empty operators for string columns (#41783)"
+    (lib.drill-thru.tu/test-returns-drill
+      {:drill-type  :drill-thru/quick-filter
+       :click-type  :cell
+       :query-type  :unaggregated
+       :query-table "PRODUCTS"
+       :column-name "TITLE"
+       :custom-row  (assoc (get-in lib.drill-thru.tu/test-queries ["PRODUCTS" :unaggregated :row])
+                      "TITLE" nil)
+       :expected    {:type      :drill-thru/quick-filter
+                     :value     :null
+                     :operators [{:name "=", :filter [:is-empty {} [:field {} (meta/id :products :title)]]}
+                                 {:name "≠", :filter [:not-empty {} [:field {} (meta/id :products :title)]]}]}})))
+
 (deftest ^:parallel apply-quick-filter-on-correct-level-test
   (testing "quick-filter on an aggregation should introduce an new stage (#34346)"
     (lib.drill-thru.tu/test-drill-application


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/41783

The FE doesn't expect `is-null` and `not-null` for string column filters. This PR fixes the issue in MBQL lib so such operators are not used by quick filter drills. 

Expect another FE PR to not break the QB in this case as well.

How to verify:
- Open Sample DB -> Analytic Events
- Click on an empty cell in the "Button Label" column
- Click `Is null`
- Make sure that you can click on the filter in the QB header and change it
- 

I’ll update the labels on the FE to use “empty” separately as well.

<img width="904" alt="Screenshot 2024-05-16 at 17 53 45" src="https://github.com/metabase/metabase/assets/8542534/bad547b3-9e8d-4449-9e8d-e39bf6f1d8db">
<img width="436" alt="Screenshot 2024-05-16 at 17 55 04" src="https://github.com/metabase/metabase/assets/8542534/f745c67f-d146-4827-ba59-fbd51a5274ce">
