### PR TITLE
Improve db connection setup test

### DIFF
--- a/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
@@ -230,6 +230,8 @@ describe("scenarios > setup", () => {
 
     selectPreferredLanguageAndContinue();
 
+    cy.findByLabelText(/What should we call you/);
+
     cy.findByTestId("setup-forms").within(() => {
       const strongPassword = "QJbHYJN3tPW[";
       cy.findByLabelText(/^Create a password/)
@@ -239,11 +241,20 @@ describe("scenarios > setup", () => {
         .clear()
         .type(strongPassword, { delay: 0 })
         .blur();
-
-      cy.findByText("Next").click();
     });
 
-    cy.button("Next").click();
+    cy.findByLabelText(/What should we call you/)
+      .button("Next")
+      .click();
+
+    // make sure this bit of the form loads before clicking next
+    cy.findByLabelText(/What will you use Metabase for/).findByText(
+      /Let us know your plans/,
+    );
+
+    cy.findByLabelText(/What will you use Metabase for/)
+      .button("Next")
+      .click();
 
     cy.findByTestId("database-form").within(() => {
       cy.findByPlaceholderText("Search for a database…").type("lite").blur();


### PR DESCRIPTION
### Description

Found this flake during RC1 release. My leading theory is that it was double-clicking the same "next" button multiple times before the next step as able to load and it was getting stuck. This adds more asssertions to ensure that wer're loading the right thing.

Works consistently locally with 6x slowdown.

🤞 stress test: https://github.com/metabase/metabase/actions/runs/9131186340
- [x] ✅  [x 20 ](https://github.com/metabase/metabase/actions/runs/9131186340/job/25109823079#step:9:217)
