### PR TITLE
Fix schema error in recent views query

### DIFF
--- a/src/metabase/models/recent_views.clj
+++ b/src/metabase/models/recent_views.clj
@@ -133,7 +133,7 @@
   [:and {:registry {::pc [:map
                           [:id [:or [:int {:min 1}] [:= "root"]]]
                           [:name :string]
-                          [:authority_level [:enum :official nil]]]}}
+                          [:authority_level [:enum :official "official" nil]]]}}
    [:map
     [:id [:int {:min 1}]]
     [:name :string]
@@ -157,7 +157,7 @@
                          [:name :string]]]]]
     [:collection [:map
                   [:parent_collection ::pc]
-                  [:authority_level [:enum :official nil]]]]]])
+                  [:authority_level [:enum :official "official" nil]]]]]])
 
 (defmulti fill-recent-view-info
   "Fills in additional information for a recent view, such as the display name of the object.
@@ -353,14 +353,14 @@
                   :initial_sync_status (:initial-sync-status table)}})))
 
 (defn ^:private do-query [user-id]  (t2/select :model/RecentViews {:select [:rv.* [:rc.type :card_type]]
-                                 :from [[:recent_views :rv]]
-                                 :where [:and [:= :rv.user_id user-id]]
-                                 :left-join [[:report_card :rc]
-                                             [:and
-                                              ;; only want to join on card_type if it's a card
-                                              [:= :rv.model "card"]
-                                              [:= :rc.id :rv.model_id]]]
-                                 :order-by [[:rv.timestamp :desc]]}))
+                                                                   :from [[:recent_views :rv]]
+                                                                   :where [:and [:= :rv.user_id user-id]]
+                                                                   :left-join [[:report_card :rc]
+                                                                               [:and
+                                                                                ;; only want to join on card_type if it's a card
+                                                                                [:= :rv.model "card"]
+                                                                                [:= :rc.id :rv.model_id]]]
+                                                                   :order-by [[:rv.timestamp :desc]]}))
 
 (mu/defn ^:private model->return-model [model :- :keyword]
   (if (= :question model) :card model))


### PR DESCRIPTION
See here for a description of the root cause: https://metaboat.slack.com/archives/C064EB1UE5P/p1715966517900699?thread_ts=1715959326.862959&cid=C064EB1UE5P

Basically the way the DB query works, `:authority_level` is ending up as the string `"official"` rather than a keyword, which results in a malli error. But this doesn't make any difference to the FE so I'm relaxing the schema as a quick fix.