### PR TITLE
Use `db` argument in `driver/database-supports?` for uploads

### DIFF
--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -294,7 +294,7 @@
       (ex-info (tru "Uploads are not permitted for sandboxed users.")
                {:status-code 403})
 
-      (not (driver/database-supports? driver :uploads nil))
+      (not (driver/database-supports? driver :uploads db))
       (ex-info (tru "Uploads are not supported on {0} databases." (str/capitalize (name driver)))
                {:status-code 422}))))
 


### PR DESCRIPTION
This is required for ClickHouse uploads to work correctly. Previously the support for uploads didn't depend on the `db` for any officially supported driver, but for ClickHouse Cloud it [does](https://github.com/ClickHouse/metabase-clickhouse-driver/pull/236).