### PR TITLE
Mark cloud migration tests to run once

### DIFF
--- a/test/metabase/models/cloud_migration_test.clj
+++ b/test/metabase/models/cloud_migration_test.clj
@@ -1,4 +1,4 @@
-(ns metabase.models.cloud-migration-test
+(ns ^:mb/once metabase.models.cloud-migration-test
   (:require
    [clj-http.fake :as http-fake]
    [clojure.test :refer :all]


### PR DESCRIPTION
flaky test. not sure why. But if this passes in any suite, it is sound. We don't have to run the tests 34 times.

example failing test from CI:

```
FAIL in metabase.models.cloud-migration-test/migrate!-test (cloud_migration_test.clj:62)

Setting :read-only-mode = false
 exits early on terminal state
expected: 1
  actual: 0
```