### PR TITLE
Preserve FK key metadata on native models

### DIFF
--- a/e2e/test/scenarios/models/models-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/models-metadata.cy.spec.js
@@ -385,7 +385,7 @@ describe("scenarios > models metadata", () => {
       });
     });
 
-    it.skip("should allow drills on FK columns from dashboards (metabase#42130)", () => {
+    it("should allow drills on FK columns from dashboards (metabase#42130)", () => {
       cy.get("@modelId").then(modelId => {
         cy.createDashboard().then(response => {
           const dashboardId = response.body.id;


### PR DESCRIPTION
Fixes #42130.

This PR assumes that the only way a native model can have columns with FK semantic types is if a user specified it by editing the metadata.

**TODO**
- [ ] unit test
