### PR TITLE
Use official docker images for Postgres/Mongo

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -378,7 +378,7 @@ jobs:
             image: metabase/qa-databases:mongo-sample-5.0
           - name: MongoDB Latest
             junit-name: be-tests-mongo-latest-ee
-            image: circleci/mongo:latest
+            image: mongo:latest
     env:
       CI: 'true'
       DRIVERS: mongo


### PR DESCRIPTION
The `circleci/*` images were deprecated in late 2021 and replaced by `cimg/*` images. But I think we can just use the official images.