### PR TITLE
minimal support for multiple values for Access-Control-Allow-Origin

### DIFF
--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -164,11 +164,10 @@
 (defn- access-control-headers
   [origin]
   (merge
-   (if
+   (when
     (approved-origin? origin (embedding-app-origin))
      {"Access-Control-Allow-Origin" origin
-      "Vary"                        "Origin"}
-     nil)
+      "Vary"                        "Origin"})
 
    {"Access-Control-Allow-Headers"   "*"
     "Access-Control-Expose-Headers"  "X-Metabase-Anti-CSRF-Token"}))

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -137,27 +137,27 @@
 (defn approved-origin?
   "Returns true if `origin` should be allowed for CORS based on the `approved-origins`"
   [raw-origin approved-origins]
-  (if (or (empty? raw-origin) (empty? approved-origins))
-    false
-    (let [approved-list (str/split approved-origins #" ")
-          origin        (parse-url raw-origin)]
-      (boolean (some (fn [approved-origin-raw]
-                       (or
-                        (= approved-origin-raw "*")
-                        (let [approved-origin (parse-url approved-origin-raw)]
-                          (and
+  (boolean
+   (when (and (seq raw-origin) (seq approved-origins))
+     (let [approved-list (str/split approved-origins #" ")
+           origin        (parse-url raw-origin)]
+       (boolean (some (fn [approved-origin-raw]
+                        (or
+                         (= approved-origin-raw "*")
+                         (let [approved-origin (parse-url approved-origin-raw)]
+                           (and
                         ;;  domain check
-                           (if (str/starts-with? (:domain approved-origin) "*.")
-                             (str/ends-with? (:domain origin) (str/replace-first (:domain approved-origin) "*." "."))
-                             (= (:domain origin) (:domain approved-origin)))
+                            (if (str/starts-with? (:domain approved-origin) "*.")
+                              (str/ends-with? (:domain origin) (str/replace-first (:domain approved-origin) "*." "."))
+                              (= (:domain origin) (:domain approved-origin)))
                         ;;  protocol check
-                           (or (nil? (:protocol approved-origin))
-                               (= (:protocol origin) (:protocol approved-origin)))
+                            (or (nil? (:protocol approved-origin))
+                                (= (:protocol origin) (:protocol approved-origin)))
                         ;;  port check
-                           (or
-                            (= (:port approved-origin) "*")
-                            (= (:port origin) (:port approved-origin)))))))
-                     approved-list)))))
+                            (or
+                             (= (:port approved-origin) "*")
+                             (= (:port origin) (:port approved-origin)))))))
+                      approved-list))))))
 
 (defn- access-control-headers
   [origin]

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -136,6 +136,26 @@
          :port port})
       (throw (IllegalArgumentException. "Invalid URL")))))
 
+(defn approved-domain?
+  "Checks if the domain is compatible with the reference one"
+  [domain reference-domain]
+  (if (str/starts-with? reference-domain "*.")
+    (str/ends-with? domain (str/replace-first reference-domain "*." "."))
+    (= domain reference-domain)))
+
+(defn approved-protocol?
+  "Checks if the protocol is compatible with the reference one"
+  [protocol reference-protocol]
+  (or (nil? reference-protocol)
+      (= protocol reference-protocol)))
+
+(defn approved-port?
+  "Checks if the port is compatible with the reference one"
+  [port reference-port]
+  (or
+   (= reference-port "*")
+   (= port reference-port)))
+
 (defn approved-origin?
   "Returns true if `origin` should be allowed for CORS based on the `approved-origins`"
   [raw-origin approved-origins]
@@ -148,17 +168,9 @@
                          (= approved-origin-raw "*")
                          (let [approved-origin (parse-url approved-origin-raw)]
                            (and
-                        ;;  domain check
-                            (if (str/starts-with? (:domain approved-origin) "*.")
-                              (str/ends-with? (:domain origin) (str/replace-first (:domain approved-origin) "*." "."))
-                              (= (:domain origin) (:domain approved-origin)))
-                        ;;  protocol check
-                            (or (nil? (:protocol approved-origin))
-                                (= (:protocol origin) (:protocol approved-origin)))
-                        ;;  port check
-                            (or
-                             (= (:port approved-origin) "*")
-                             (= (:port origin) (:port approved-origin)))))))
+                            (approved-domain? (:domain origin) (:domain approved-origin))
+                            (approved-protocol? (:protocol origin) (:protocol approved-origin))
+                            (approved-port? (:port origin) (:port approved-origin))))))
                       approved-list))))))
 
 (defn- access-control-headers

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -124,7 +124,9 @@
           "Content-Security-Policy"
           #(format "%s frame-ancestors %s;" % (if allow-iframes? "*" (or (embedding-app-origin) "'none'")))))
 
-(defn- parse-url [url]
+(defn parse-url
+  "Returns an object with protocol, domain and port for the given url"
+  [url]
   (let [pattern #"^(?:(https?)://)?([^:/]+)(?::(\d+|\*))?$"
         matches (re-matches pattern url)]
     (if matches

--- a/test/metabase/server/middleware/security_test.clj
+++ b/test/metabase/server/middleware/security_test.clj
@@ -110,6 +110,7 @@
   (testing "Should return false if parameters are nil"
     (is (false? (approved-origin? nil "example.com")))
     (is (false? (approved-origin? "example.com" nil))))
+
   (testing "Approved origins with exact protocol and port match"
     (let [approved "http://example1.com http://example2.com:3000 https://example3.com"]
       (is (true? (approved-origin? "http://example1.com" approved)))


### PR DESCRIPTION
Closes #42631

### Description

More context on the original issue: https://github.com/metabase/metabase/issues/42631

`Access-Control-Allow-Origin` only supports returning one origin, a common way to work around this is for the backend to check if the origin of the request is valid, and if so returning that origin.

This adds a `approved-origin?` function that returns true if the origin should be allowed for CORS requests, based on the values we store in the `embedding-app-origin` setting.


In the UI for `embedding-app-origin` we mention https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors for the specific format to use.
![image](https://github.com/metabase/metabase/assets/1914270/cad61786-2b15-4237-bd12-7681253a9f3e)

I tried to make CORS work from the same domains that are allowed to embed using iframes, but it's possible there are some differences.
