### PR TITLE
Remove utm from source plan in upsell links

### DIFF
--- a/frontend/src/metabase/admin/upsells/components/use-upsell-link.ts
+++ b/frontend/src/metabase/admin/upsells/components/use-upsell-link.ts
@@ -16,5 +16,5 @@ interface UpsellLinkProps {
 export const useUpsellLink = ({ url, campaign, source }: UpsellLinkProps) => {
   const plan = getPlan(useSetting("token-features"));
 
-  return `${url}?utm_source=product&utm_medium=upsell&utm_campaign=${campaign}&utm_content=${source}&utm_source_plan=${plan}`;
+  return `${url}?utm_source=product&utm_medium=upsell&utm_campaign=${campaign}&utm_content=${source}&source_plan=${plan}`;
 };

--- a/frontend/src/metabase/admin/upsells/components/use-upsell-link.unit.spec.tsx
+++ b/frontend/src/metabase/admin/upsells/components/use-upsell-link.unit.spec.tsx
@@ -62,7 +62,7 @@ describe("Upsells > useUpsellLink", () => {
     const link = screen.getByText("Link");
     expect(link).toHaveAttribute(
       "href",
-      `${props.url}?utm_source=product&utm_medium=upsell&utm_campaign=${props.campaign}&utm_content=${props.source}&utm_source_plan=oss`,
+      `${props.url}?utm_source=product&utm_medium=upsell&utm_campaign=${props.campaign}&utm_content=${props.source}&source_plan=oss`,
     );
   });
 
@@ -78,7 +78,7 @@ describe("Upsells > useUpsellLink", () => {
     const link = screen.getByText("Link");
     expect(link).toHaveAttribute(
       "href",
-      expect.stringContaining("utm_source_plan=oss"),
+      expect.stringContaining("source_plan=oss"),
     );
   });
 
@@ -94,7 +94,7 @@ describe("Upsells > useUpsellLink", () => {
     const link = screen.getByText("Link");
     expect(link).toHaveAttribute(
       "href",
-      expect.stringContaining("utm_source_plan=pro-cloud"),
+      expect.stringContaining("source_plan=pro-cloud"),
     );
   });
 });


### PR DESCRIPTION

### Description

I misunderstood the dark magic of utms here. Source plan should not have the `utm_` prefix

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
