### PR TITLE
Disable popular items e2e home page test in OSS

### DIFF
--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -4,6 +4,7 @@ import {
   ORDERS_DASHBOARD_ID,
 } from "e2e/support/cypress_sample_instance_data";
 import {
+  describeEE,
   popover,
   restore,
   visitDashboard,
@@ -103,9 +104,6 @@ describe("scenarios > home > homepage", () => {
     beforeEach(() => {
       restore("default");
       cy.signInAsAdmin();
-      // Setting this to true so that displaying popular items for new users works.
-      // This requires the audit-app feature to be enabled
-      setTokenFeatures("all");
     });
 
     it("should display recent items", () => {
@@ -127,24 +125,30 @@ describe("scenarios > home > homepage", () => {
       cy.findByText("Orders");
     });
 
-    it("should display popular items for a new user", () => {
-      cy.signInAsAdmin();
+    // TODO: popular items endpoint is currently broken in OSS. Renable test once endpoint has been fixed.
+    describeEE("EE", () => {
+      it("should display popular items for a new user", () => {
+        cy.signInAsAdmin();
+        // Setting this to true so that displaying popular items for new users works.
+        // This requires the audit-app feature to be enabled
+        setTokenFeatures("all");
 
-      visitDashboard(ORDERS_DASHBOARD_ID);
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Orders in a dashboard");
-      cy.signOut();
+        visitDashboard(ORDERS_DASHBOARD_ID);
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+        cy.findByText("Orders in a dashboard");
+        cy.signOut();
 
-      cy.signInAsNormalUser();
-      cy.visit("/");
-      cy.wait("@getPopularItems");
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Here are some popular dashboards");
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Orders in a dashboard").click();
-      cy.wait("@getDashboard");
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Orders");
+        cy.signInAsNormalUser();
+        cy.visit("/");
+        cy.wait("@getPopularItems");
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+        cy.findByText("Here are some popular dashboards");
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+        cy.findByText("Orders in a dashboard").click();
+        cy.wait("@getDashboard");
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+        cy.findByText("Orders");
+      });
     });
 
     it("should not show pinned questions in recent items when viewed in a collection", () => {

--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -125,7 +125,7 @@ describe("scenarios > home > homepage", () => {
       cy.findByText("Orders");
     });
 
-    // TODO: popular items endpoint is currently broken in OSS. Renable test once endpoint has been fixed.
+    // TODO: popular items endpoint is currently broken in OSS. Re-enable test once endpoint has been fixed.
     describeEE("EE", () => {
       it("should display popular items for a new user", () => {
         cy.signInAsAdmin();


### PR DESCRIPTION
We've broken the popular items endpoint in OSS. We have plans to get this fixed before the gold v50 release, but currently this test failing in OSS is blocking v50-RC1.

The `beforeEach` in the same block as this test was recently modified to set EE features while in OSS which throws an error. This feature setting was only needed for the popular items test, so the code has been reorganized accordingly.

<img width="857" alt="Screenshot 2024-05-20 at 9 36 37 AM" src="https://github.com/metabase/metabase/assets/7104357/4054eba2-edbb-4813-89f6-ca739955515a">
