### PR TITLE
Fix metabase.api.search-test/permissions-test

### DIFF
--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -536,12 +536,12 @@
                                     (t2/hydrate % :effective_location)
                                     (assoc % :effective_location nil)))
                             (map #(cond-> % (t2/instance-of? :model/Collection %) collection/maybe-localize-trash-name))
-                            (filter (partial check-permissions-for-model (:archived? search-ctx)))
                             ;; MySQL returns `:bookmark` and `:archived` as `1` or `0` so convert those to boolean as
                             ;; needed
                             (map #(update % :bookmark api/bit->boolean))
 
                             (map #(update % :archived api/bit->boolean))
+                            (filter (partial check-permissions-for-model (:archived? search-ctx)))
 
                             (map #(update % :pk_ref json/parse-string))
                             (map add-can-write)

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -472,16 +472,16 @@
             (mt/with-full-data-perms-for-all-users!
               (perms/grant-collection-read-permissions! group (u/the-id collection))
               (is (=? (->> (default-results-with-collection)
-                          (map #(cond-> %
-                                  (contains? #{"collection" "dashboard" "card" "dataset" "metric"} (:model %))
-                                  (assoc :can_write false)))
-                          (concat (map #(merge default-search-row % (table-search-results))
-                                       [{:name "segment test2 segment", :description "Lookin' for a blueberry",
-                                         :model "segment" :creator_id true :creator_common_name "Rasta Toucan"}]))
-                          ;; This reverse is hokey; it's because the test2 results happen to come first in the API response
-                          reverse
-                          sorted-results)
-                     (search-request-data :rasta :q "test")))))))))
+                           (map #(cond-> %
+                                   (contains? #{"collection" "dashboard" "card" "dataset" "metric"} (:model %))
+                                   (assoc :can_write false)))
+                           (concat (map #(merge default-search-row % (table-search-results))
+                                        [{:name "segment test2 segment", :description "Lookin' for a blueberry",
+                                          :model "segment" :creator_id true :creator_common_name "Rasta Toucan"}]))
+                           ;; This reverse is hokey; it's because the test2 results happen to come first in the API response
+                           reverse
+                           sorted-results)
+                      (search-request-data :rasta :q "test")))))))))
 
   (testing (str "Users with root collection permissions should be able to search root collection data long with "
                 "collections they have access to")


### PR DESCRIPTION
Makes sure the mariadb numeric bit flag is converted to a boolean before checking permissions.