### PR TITLE
Maybe fix custom homepage e2e flake

### DIFF
--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -179,7 +179,12 @@ describe("scenarios > home > custom homepage", () => {
 
     it("should give you the option to set a custom home page in settings", () => {
       cy.visit("/admin/settings/general");
-      cy.findByTestId("custom-homepage-setting").findByRole("switch").click();
+
+      cy.findByTestId("custom-homepage-setting").within(() => {
+        cy.findByText("Disabled").should("exist");
+        cy.findByRole("switch").click();
+        cy.findByText("Enabled").should("exist");
+      });
 
       cy.findByTestId("custom-homepage-dashboard-setting")
         .findByRole("button")
@@ -189,14 +194,29 @@ describe("scenarios > home > custom homepage", () => {
 
       undoToast().findByText("Changes saved").should("be.visible");
 
+      cy.findByTestId("custom-homepage-dashboard-setting").should(
+        "contain",
+        "Orders in a dashboard",
+      );
+
       cy.log(
         "disabling custom-homepge-setting should also remove custom-homepage-dashboard-setting",
       );
 
-      cy.findByTestId("custom-homepage-setting").findByRole("switch").click();
+      cy.findByTestId("custom-homepage-setting").within(() => {
+        cy.findByText("Enabled").should("exist");
+        cy.findByRole("switch").click();
+        cy.findByText("Disabled").should("exist");
+      });
+
       undoToast().findByText("Changes saved").should("be.visible");
 
-      cy.findByTestId("custom-homepage-setting").findByRole("switch").click();
+      cy.findByTestId("custom-homepage-setting").within(() => {
+        cy.findByText("Disabled").should("exist");
+        cy.findByRole("switch").click();
+        cy.findByText("Enabled").should("exist");
+      });
+
       cy.findByTestId("custom-homepage-dashboard-setting").should(
         "contain",
         "Select a dashboard",
@@ -207,6 +227,11 @@ describe("scenarios > home > custom homepage", () => {
         .click();
 
       entityPickerModal().findByText("Orders in a dashboard").click();
+
+      cy.findByTestId("custom-homepage-dashboard-setting").should(
+        "contain",
+        "Orders in a dashboard",
+      );
 
       cy.findByRole("navigation").findByText("Exit admin").click();
       cy.location("pathname").should(


### PR DESCRIPTION
The e2e test `should give you the option to set a custom home page in settings` in `homepage.cy.spec.js` is failing only in our sanity checks for the v50-RC1 builds. I'm not able to repro locally and it does no fail in our PRs, but has failed 90% of the time in the release checks.

I'm introducing a theoretical fix, I'm not 100% sure this will solve anything. What I've done is add assertions that the inputs match the current expected value. I'm hoping that if there is some kind of race condition from Cypress running through the steps too fast, that these asserts slow the test down until the UI matches our expected values.

Stress test on branch w/ 0 failures over 60 runs:
https://github.com/metabase/metabase/actions/runs/9162186115 (20x runs)
https://github.com/metabase/metabase/actions/runs/9162388068 (40x runs)

Stress tests on master w/ 2 failures over 20 runs:
https://github.com/metabase/metabase/actions/runs/9162194352