### PR TITLE
Cleanup DataPicker initialization

### DIFF
--- a/frontend/src/metabase/common/components/DataPicker/utils.ts
+++ b/frontend/src/metabase/common/components/DataPicker/utils.ts
@@ -1,10 +1,8 @@
 import { humanize, titleize } from "metabase/lib/formatting";
 import { isNullOrUndefined } from "metabase/lib/types";
 import * as Lib from "metabase-lib";
-import TableEntity from "metabase-lib/v1/metadata/Table";
 import { getSchemaName } from "metabase-lib/v1/metadata/utils/schema";
 import type {
-  Card,
   CollectionItem,
   Database,
   DatabaseId,
@@ -33,41 +31,7 @@ export const generateKey = (
   return [dbItem?.id, schemaItem?.id, tableItem?.id].join("-");
 };
 
-export const dataPickerValueFromCard = (card: Card): DataPickerValue => {
-  return {
-    id: card.id,
-    name: card.name,
-    model:
-      card.type === "model"
-        ? "dataset"
-        : card.type === "metric"
-        ? "metric"
-        : "card",
-  };
-};
-
-export const dataPickerValueFromTable = (
-  table: Table | TableEntity | null,
-): TablePickerValue | undefined => {
-  if (table === null) {
-    return undefined;
-  }
-
-  // Temporary, for backward compatibility in DataStep, until entity framework is no more
-  if (table instanceof TableEntity) {
-    return tablePickerValueFromTableEntity(table);
-  }
-
-  return {
-    db_id: table.db_id,
-    id: table.id,
-    model: "table",
-    name: table.display_name,
-    schema: table.schema,
-  };
-};
-
-export const dataPickerValueFromJoinable = (
+export const getDataPickerValue = (
   query: Lib.Query,
   stageIndex: number,
   joinable: Lib.Joinable,
@@ -97,21 +61,6 @@ export const dataPickerValueFromJoinable = (
     model: "table",
     db_id: pickerInfo.databaseId,
     schema: getSchemaName(displayInfo.schema),
-  };
-};
-
-const tablePickerValueFromTableEntity = (
-  table: TableEntity,
-): TablePickerValue => {
-  // In DBs without schemas, API will use an empty string to indicate the default, virtual schema
-  const NO_SCHEMA_FALLBACK = "";
-
-  return {
-    db_id: table.db_id,
-    id: table.id,
-    model: "table",
-    name: table.display_name,
-    schema: table.schema_name ?? table.schema?.name ?? NO_SCHEMA_FALLBACK,
   };
 };
 

--- a/frontend/src/metabase/common/components/DataPicker/utils.ts
+++ b/frontend/src/metabase/common/components/DataPicker/utils.ts
@@ -43,7 +43,7 @@ export const getDataPickerValue = (
     return undefined;
   }
 
-  if (typeof pickerInfo.cardId === "number") {
+  if (pickerInfo.cardId != null) {
     return {
       id: pickerInfo.cardId,
       name: displayInfo.displayName,

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.tsx
@@ -7,13 +7,11 @@ import {
   getDataPickerValue,
 } from "metabase/common/components/DataPicker";
 import { FieldPicker } from "metabase/common/components/FieldPicker";
-import Questions from "metabase/entities/questions";
-import Tables from "metabase/entities/tables";
 import { useDispatch } from "metabase/lib/redux";
 import { checkNotNull } from "metabase/lib/types";
+import { loadMetadataForTable } from "metabase/questions/actions";
 import { Icon, Popover, Tooltip } from "metabase/ui";
 import * as Lib from "metabase-lib";
-import { getQuestionIdFromVirtualTableId } from "metabase-lib/v1/metadata/utils/saved-questions";
 import type { TableId } from "metabase-types/api";
 
 import { NotebookCell, NotebookCellItem } from "../../NotebookCell";
@@ -50,18 +48,8 @@ export const DataStep = ({
   const canSelectTableColumns = table && isRaw && !readOnly;
 
   const handleTableChange = async (tableId: TableId) => {
-    // we need to populate question metadata with selected table
-    await dispatch(Tables.actions.fetchMetadata({ id: tableId }));
-
-    if (typeof tableId === "string") {
-      await dispatch(
-        Questions.actions.fetch({
-          id: getQuestionIdFromVirtualTableId(tableId),
-        }),
-      );
-    }
-
-    // using questionRef because question is most likely stale by now
+    await dispatch(loadMetadataForTable(tableId));
+    // using questionRef to access up-to-date metadata
     const metadata = questionRef.current.metadata();
     const table = checkNotNull(metadata.table(tableId));
     const metadataProvider = Lib.metadataProvider(table.db_id, metadata);

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.tsx
@@ -5,7 +5,7 @@ import { t } from "ttag";
 
 import {
   DataPickerModal,
-  dataPickerValueFromJoinable,
+  getDataPickerValue,
 } from "metabase/common/components/DataPicker";
 import Questions from "metabase/entities/questions";
 import Tables from "metabase/entities/tables";
@@ -72,7 +72,7 @@ export function JoinTablePicker({
       return undefined;
     }
 
-    return dataPickerValueFromJoinable(query, stageIndex, joinable);
+    return getDataPickerValue(query, stageIndex, joinable);
   }, [query, stageIndex, joinable]);
 
   return (

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.tsx
@@ -7,12 +7,10 @@ import {
   DataPickerModal,
   getDataPickerValue,
 } from "metabase/common/components/DataPicker";
-import Questions from "metabase/entities/questions";
-import Tables from "metabase/entities/tables";
 import { useDispatch } from "metabase/lib/redux";
+import { loadMetadataForTable } from "metabase/questions/actions";
 import { Icon, Popover, Tooltip } from "metabase/ui";
 import * as Lib from "metabase-lib";
-import { getQuestionIdFromVirtualTableId } from "metabase-lib/v1/metadata/utils/saved-questions";
 import type { TableId } from "metabase-types/api";
 
 import { NotebookCellItem } from "../../../NotebookCell";
@@ -53,26 +51,14 @@ export function JoinTablePicker({
   const isDisabled = isReadOnly;
 
   const handleTableChange = async (tableId: TableId) => {
-    // we need to populate query metadata with selected table
-    await dispatch(Tables.actions.fetchMetadata({ id: tableId }));
-
-    if (typeof tableId === "string") {
-      await dispatch(
-        Questions.actions.fetch({
-          id: getQuestionIdFromVirtualTableId(tableId),
-        }),
-      );
-    }
-
+    await dispatch(loadMetadataForTable(tableId));
     onChangeRef.current?.(Lib.tableOrCardMetadata(queryRef.current, tableId));
   };
 
   const value = useMemo(() => {
-    if (!joinable) {
-      return undefined;
-    }
-
-    return getDataPickerValue(query, stageIndex, joinable);
+    return joinable
+      ? getDataPickerValue(query, stageIndex, joinable)
+      : undefined;
   }, [query, stageIndex, joinable]);
 
   return (

--- a/frontend/src/metabase/questions/actions.ts
+++ b/frontend/src/metabase/questions/actions.ts
@@ -26,7 +26,7 @@ export const loadMetadataForCard =
 export const loadMetadataForTable =
   (tableId: TableId, options?: LoadMetadataOptions) =>
   async (dispatch: Dispatch, getState: GetState) => {
-    const dependencies = [{ type: "table", id: tableId }];
+    const dependencies: Lib.DependentItem[] = [{ type: "table", id: tableId }];
     await dispatch(loadMetadataForDependentItems(dependencies));
     const metadata = getMetadata(getState());
     const table = metadata.table(tableId);
@@ -41,7 +41,7 @@ export const loadMetadataForTable =
       );
       return Lib.tableOrCardDependentMetadata(metadataProvider, tableId);
     };
-    await dispatch(loadMetadata(getDependencies, [], options));
+    await dispatch(loadMetadata(getDependencies, dependencies, options));
   };
 
 const loadMetadata =

--- a/frontend/src/metabase/questions/actions.ts
+++ b/frontend/src/metabase/questions/actions.ts
@@ -26,7 +26,8 @@ export const loadMetadataForCard =
 export const loadMetadataForTable =
   (tableId: TableId, options?: LoadMetadataOptions) =>
   async (dispatch: Dispatch, getState: GetState) => {
-    await dispatch(Tables.actions.fetchMetadata({ id: tableId }));
+    const dependencies = [{ type: "table", id: tableId }];
+    await dispatch(loadMetadataForDependentItems(dependencies));
     const metadata = getMetadata(getState());
     const table = metadata.table(tableId);
     if (!table?.db_id) {


### PR DESCRIPTION
Simplifies DataPicker initialization:
- In all cases a MBQL lib entity is passed
- Metadata is loaded via a common helper and MBQL lib and not with the entity framework directly 

How to verify:
- CI is green