### PR TITLE
Remove flaky / redundant e2e test

### DIFF
--- a/e2e/test/scenarios/question/question-management.cy.spec.js
+++ b/e2e/test/scenarios/question/question-management.cy.spec.js
@@ -24,8 +24,6 @@ import {
   expectGoodSnowplowEvents,
   modal,
   entityPickerModal,
-  openCommandPalette,
-  commandPalette,
 } from "e2e/support/helpers";
 
 const PERMISSIONS = {
@@ -183,39 +181,6 @@ describe(
                       .should("have.attr", "aria-selected", "true");
                   });
                 });
-              });
-
-              it("should be able to archive the question (metabase#11719-3, metabase#16512, metabase#20133)", () => {
-                cy.intercept("GET", "/api/collection/root/items**").as(
-                  "getItems",
-                );
-                openQuestionActions();
-                cy.findByTestId("archive-button").click();
-                // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-                cy.findByText(
-                  "It will also be removed from the filter that uses it to populate values.",
-                ).should("not.exist");
-                clickButton("Move to trash");
-                assertRequestNot403("updateQuestion");
-                assertNoPermissionsError();
-
-                cy.visit("/collection/root");
-                cy.wait("@getItems"); // pinned items
-                cy.wait("@getItems"); // unpinned items
-                // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-                cy.findByText("Orders").should("not.exist");
-
-                openCommandPalette();
-                commandPalette().within(() => {
-                  cy.findByRole("option", { name: /recent/i }).should(
-                    "not.exist",
-                  );
-                });
-
-                // Check page for archived questions
-                cy.visit("/question/" + ORDERS_QUESTION_ID);
-                // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-                cy.findByText("This question is in the trash.");
               });
 
               describe("Add to Dashboard", () => {
@@ -464,10 +429,6 @@ describeWithSnowplow("send snowplow question events", () => {
     );
   });
 });
-
-function clickButton(name) {
-  cy.button(name).should("not.be.disabled").click();
-}
 
 function assertRequestNot403(xhr_alias) {
   cy.wait("@" + xhr_alias).then(xhr => {


### PR DESCRIPTION
resolves https://github.com/metabase/metabase/issues/42917

This functionality is already covered in the `trash.cy.spec.js` suite. The flake is on functionality that the test isn't trying to cover which I think we should solve seperately.