### PR TITLE
Fix failing offset tests

### DIFF
--- a/e2e/support/helpers/e2e-custom-column-helpers.js
+++ b/e2e/support/helpers/e2e-custom-column-helpers.js
@@ -2,19 +2,17 @@ export function expressionEditorWidget() {
   return cy.findByTestId("expression-editor");
 }
 
+export function getAceEditor() {
+  return cy.get(".ace_text-input").first().should("exist");
+}
+
 /**
  * @param {Object} option
  * @param {string} option.formula
  * @param {string=} option.name
  */
 export function enterCustomColumnDetails({ formula, name }) {
-  cy.get(".ace_text-input")
-    .first()
-    .as("formula")
-    .should("exist")
-    .focus()
-    .clear()
-    .type(formula);
+  getAceEditor().as("formula").focus().clear().type(formula);
 
   if (name) {
     cy.findByPlaceholderText("Something nice and descriptive")

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -25,6 +25,7 @@ import {
   createQuestion,
   entityPickerModal,
   entityPickerModalTab,
+  getAceEditor,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PEOPLE, PEOPLE_ID, PRODUCTS, PRODUCTS_ID } =
@@ -175,8 +176,8 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
 
-    enterCustomColumnDetails({ formula: "[Price] > 1" });
-    cy.get("@formula").blur();
+    getAceEditor().type("[Price] > 1");
+    getAceEditor().blur();
 
     cy.button("Done").click();
 
@@ -187,9 +188,8 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
 
-    cy.get("@formula")
-      .invoke("val", "") // this is a more reliable .clear()
-      .type("[Price] > 1 AND [Price] < 5{enter}");
+    getAceEditor().invoke("val", ""); // this is a more reliable .clear()
+    getAceEditor().type("[Price] > 1 AND [Price] < 5{enter}");
 
     // In case it does exist, it usually is an error in expression (caused by not clearing
     // the input properly before typing), and this check helps to highlight that.

--- a/e2e/test/scenarios/question/offset.cy.spec.ts
+++ b/e2e/test/scenarios/question/offset.cy.spec.ts
@@ -6,6 +6,7 @@ import {
   enterCustomColumnDetails,
   entityPickerModal,
   entityPickerModalTab,
+  getAceEditor,
   getNotebookStep,
   modal,
   openNotebook,
@@ -82,14 +83,14 @@ describe("scenarios > question > offset", () => {
       createQuestion({ query }, { visitQuestion: true });
       openNotebook();
       cy.button("Custom column").click();
-      enterCustomColumnDetails({ formula: prefix });
+      getAceEditor().type(prefix);
 
       cy.log("suggests offset() in custom column expressions");
       cy.findByTestId("expression-suggestions-list-item")
         .should("exist")
         .and("have.text", "Offset");
 
-      enterCustomColumnDetails({ formula: suffix });
+      getAceEditor().type(suffix);
       cy.realPress("Tab");
 
       popover().within(() => {
@@ -101,7 +102,7 @@ describe("scenarios > question > offset", () => {
       cy.button("Sort").click();
       popover().findByText("ID").click();
       getNotebookStep("expression").icon("add").click();
-      enterCustomColumnDetails({ formula: expression });
+      getAceEditor().type(expression);
       cy.realPress("Tab");
 
       popover().within(() => {
@@ -200,12 +201,12 @@ describe("scenarios > question > offset", () => {
       openNotebook();
       cy.button("Filter").click();
       popover().findByText("Custom Expression").click();
-      enterCustomColumnDetails({ formula: prefix });
+      getAceEditor().type(prefix);
 
       cy.log("does not suggest offset() in filter expressions");
       cy.findByTestId("expression-suggestions-list-item").should("not.exist");
 
-      enterCustomColumnDetails({ formula: suffix });
+      getAceEditor().type(suffix);
       cy.realPress("Tab");
 
       popover().within(() => {
@@ -235,14 +236,14 @@ describe("scenarios > question > offset", () => {
         .findByText("Pick the metric you want to see")
         .click();
       popover().findByText("Custom Expression").click();
-      enterCustomColumnDetails({ formula: prefix });
+      getAceEditor().type(prefix);
 
       cy.log("suggests offset() in aggregation expressions");
       cy.findByTestId("expression-suggestions-list-item")
         .should("exist")
         .and("have.text", "Offset");
 
-      enterCustomColumnDetails({ formula: suffix });
+      getAceEditor().type(suffix);
       cy.realPress("Tab");
 
       popover().within(() => {
@@ -575,10 +576,10 @@ function verifyInvalidColumnName(
   prefix: string,
   suffix: string,
 ) {
-  enterCustomColumnDetails({ formula: prefix });
+  getAceEditor().type(prefix);
   cy.findByTestId("expression-suggestions-list-item").should("not.exist");
 
-  enterCustomColumnDetails({ formula: suffix });
+  getAceEditor().type(suffix);
   cy.realPress("Tab");
   popover().within(() => {
     cy.findByText(`Unknown Field: ${columnName}`).should("be.visible");


### PR DESCRIPTION
### Description

The tests were failing because #38457 added `clear()` call to `enterCustomColumnDetails` and it got merged to `master` after #42756 has been submitted for review, so CI didn't catch this.

`release-x.50.x` is safe because #38457 was not merged to it.

----

See [Slack thread](https://metaboat.slack.com/archives/C5XHN8GLW/p1716289518525529)

Example failures:
- https://github.com/metabase/metabase/actions/runs/9172578557
- https://github.com/metabase/metabase/actions/runs/9170036603
- https://github.com/metabase/metabase/actions/runs/9170030131

