### PR TITLE
Fix icon colors in column picker

### DIFF
--- a/frontend/src/metabase/common/components/FieldPicker/FieldPicker.styled.tsx
+++ b/frontend/src/metabase/common/components/FieldPicker/FieldPicker.styled.tsx
@@ -13,7 +13,7 @@ export const ItemTitle = styled.div`
 export const ItemIcon = styled(QueryColumnInfoIcon)`
   margin: 0 0.5em;
   margin-left: 0.75em;
-  color: ${color("text-dark")};
+  color: ${color("text-light")};
 `;
 
 export const ItemList = styled.ul`

--- a/frontend/src/metabase/common/components/FieldPicker/FieldPicker.tsx
+++ b/frontend/src/metabase/common/components/FieldPicker/FieldPicker.tsx
@@ -92,7 +92,7 @@ export const FieldPicker = ({
                 stageIndex={stageIndex}
                 column={item.column}
                 position="top-start"
-                size={18}
+                size={16}
               />
               <ItemTitle>{item.columnInfo.displayName}</ItemTitle>
             </Label>


### PR DESCRIPTION
Implement some small visual fixes for the data picker.

From [this Slack thread](https://metaboat.slack.com/archives/C0645JP1W81/p1715971139521019):

> @maz: I just noticed that these icons should all be 16px, not 18px, and should be `text-light` to match the treatment of these icons in other column pickers.

<img width="339" alt="Screenshot 2024-05-21 at 13 44 48" src="https://github.com/metabase/metabase/assets/1250185/b200f8de-9e64-481d-953c-ae4e21a15152">
