### PR TITLE
Fix `report_card.collection_preview` in v49

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5827,6 +5827,56 @@ databaseChangeLog:
       rollback: # nothing
 
   - changeSet:
+      id: v49.2024-05-20T19:10:34
+      author: johnswanson
+      comment: >-
+        Modify type of report_card.collection_preview to ${boolean.type} on mysql,mariadb
+      dbms: mysql,mariadb
+      changes:
+        - modifyDataType:
+            tableName: report_card
+            columnName: collection_preview
+            newDataType: ${boolean.type}
+      rollback:
+        - modifyDataType:
+            tableName: report_card
+            columnName: collection_preview
+            newDataType: boolean
+            defaultValueBoolean: true
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.2024-05-20T20:37:55
+      author: johnswanson
+      comment: Add NOT NULL constraint to report_card.collection_preview
+      changes:
+        - addNotNullConstraint:
+            columnDataType: ${boolean.type}
+            tableName: report_card
+            columnName: collection_preview
+            defaultNullValue: true
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+  - changeSet:
+      id: v49.2024-05-20T20:38:34
+      author: johnswanson
+      comment: Add default value to report_card.collection_preview
+      changes:
+        - addDefaultValue:
+            defaultValueBoolean: true
+            tableName: report_card
+            columnName: collection_preview
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
       id: v50.2024-01-04T13:52:51
       author: noahmoss
       comment: Data permissions table
@@ -7334,57 +7384,6 @@ databaseChangeLog:
       changes:
         - customChange:
             class: "metabase.db.custom_migrations.MigrateMetricsToV2"
-
-  - changeSet:
-      id: v51.2024-05-20T19:10:34
-      author: johnswanson
-      comment: >-
-        Modify type of report_card.collection_preview to ${boolean.type} on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: report_card
-            columnName: collection_preview
-            newDataType: ${boolean.type}
-      rollback:
-        - modifyDataType:
-            tableName: report_card
-            columnName: collection_preview
-            newDataType: boolean
-            defaultValueBoolean: true
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v51.2024-05-20T20:37:55
-      author: johnswanson
-      comment: Add NOT NULL constraint to report_card.collection_preview
-      changes:
-        - addNotNullConstraint:
-            columnDataType: ${boolean.type}
-            tableName: report_card
-            columnName: collection_preview
-            defaultNullValue: true
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
-  - changeSet:
-      id: v51.2024-05-20T20:38:34
-      author: johnswanson
-      comment: Add default value to report_card.collection_preview
-      changes:
-        - addDefaultValue:
-            defaultValueBoolean: true
-            tableName: report_card
-            columnName: collection_preview
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 


### PR DESCRIPTION
This is a bit painful. I merged this change, but realized we need to backport the fix to v49. However:

- we don't want to have two versions of the migration (one with a v49 id, one with a v50 id) because then if someone upgrades to 50, then downgrades to 49, the `rollback` will run and change the type back, leading to a bug.

- we don't want to push a v51 changeSet ID to v49 or v50, because we give the user a helpful notice when their database needs a downgrade. We do this by checking for the latest *executed* migration in the database and comparing it to the latest migration that Liquibase knows about, and making sure the executed isn't bigger than the known (e.g. you can't have executed a v51 migration if it isn't in the local migration yaml). That would all work fine, except that then we want to tell you how to downgrade your database, and we use the latest-executed version for that. So if, for example, someone upgraded from 48 to 49 and got a v51 changeset, then downgraded back to 48, they would get an error telling them to run the *v51* jar to roll back their DB.

In this case though, I think it's fine to just move the migration around to v49, then we can backport it to 49 and 50.