### PR TITLE
Fix `c` method of `ttag` not showing strings as tagged in debug mode

### DIFF
--- a/frontend/src/metabase/lib/i18n-debug.js
+++ b/frontend/src/metabase/lib/i18n-debug.js
@@ -36,9 +36,12 @@ const obfuscateString = (original, string) => {
 
 export function enableTranslatedStringReplacement() {
   const c3po = require("ttag");
+
   const _t = c3po.t;
   const _jt = c3po.jt;
   const _ngettext = c3po.ngettext;
+  const _c = c3po.c;
+
   c3po.t = (...args) => {
     return obfuscateString(args[0][0], _t(...args));
   };
@@ -48,6 +51,13 @@ export function enableTranslatedStringReplacement() {
   c3po.jt = (...args) => {
     const elements = _jt(...args);
     return <span style={{ backgroundColor: "currentcolor" }}>{elements}</span>;
+  };
+  c3po.c = (...args) => {
+    return Object.assign(_c(...args), {
+      t: c3po.t,
+      jt: c3po.jt,
+      ngettext: c3po.ngettext,
+    });
   };
 }
 


### PR DESCRIPTION
When setting `localStorage["metabase-i18n-debug"] = true;`, strings tagged with context via the `c` method were not showing up a tagged strings.

Before:
<img width="1728" alt="Screenshot 2024-05-21 at 12 07 38 PM" src="https://github.com/metabase/metabase/assets/7104357/46636cec-a435-4360-b072-6c3aed84291f">

After:
<img width="1491" alt="Screenshot 2024-05-21 at 12 07 52 PM" src="https://github.com/metabase/metabase/assets/7104357/017c21c8-65c3-4e6e-9213-2932185a939e">
