### PR TITLE
Add utm params to  link

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
@@ -192,10 +192,7 @@ describe("scenarios > embedding > smoke tests", { tags: "@OSS" }, () => {
           cy.findByRole("link")
             .should("have.text", "Powered by Metabase")
             .and("have.attr", "href")
-            .and(
-              "contain.text",
-              "https://www.metabase.com/powered-by-metabase",
-            );
+            .and("contain", "https://www.metabase.com/powered-by-metabase");
         });
 
         cy.log(

--- a/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
@@ -192,7 +192,10 @@ describe("scenarios > embedding > smoke tests", { tags: "@OSS" }, () => {
           cy.findByRole("link")
             .should("have.text", "Powered by Metabase")
             .and("have.attr", "href")
-            .and("eq", "https://metabase.com/");
+            .and(
+              "contain.text",
+              "https://www.metabase.com/powered-by-metabase",
+            );
         });
 
         cy.log(

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
@@ -51,7 +51,7 @@ import {
   Separator,
   TitleAndDescriptionContainer,
 } from "./EmbedFrame.styled";
-import LogoBadge from "./LogoBadge";
+import { LogoBadge } from "./LogoBadge";
 
 type ParameterValues = Record<ParameterId, ParameterValueOrArray>;
 

--- a/frontend/src/metabase/public/components/EmbedFrame/LogoBadge.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/LogoBadge.tsx
@@ -5,13 +5,13 @@ import LogoIcon from "metabase/components/LogoIcon";
 import type { Variant } from "./LogoBadge.styled";
 import { MetabaseLink, MetabaseName, Message } from "./LogoBadge.styled";
 
-function LogoBadge({
+export const LogoBadge = ({
   dark,
   variant = "default",
 }: {
   dark: boolean;
   variant?: Variant;
-}) {
+}) => {
   const logoSize = variant === "large" ? 42 : 28;
   const Metabase = (
     // eslint-disable-next-line no-literal-metabase-strings -- This embedding badge which we don't want to show the whitelabeled name
@@ -21,7 +21,7 @@ function LogoBadge({
   );
   return (
     <MetabaseLink
-      href="https://metabase.com/"
+      href="https://www.metabase.com/powered-by-metabase?utm_medium=referral&utm_source=product&utm_campaign=powered_by_metabase&utm_content=embedded_banner"
       target="_blank"
       variant={variant}
     >
@@ -29,7 +29,4 @@ function LogoBadge({
       <Message variant={variant}>{jt`Powered by ${Metabase}`}</Message>
     </MetabaseLink>
   );
-}
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default LogoBadge;
+};

--- a/frontend/src/metabase/public/components/EmbedFrame/LogoBadge.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/LogoBadge.tsx
@@ -13,15 +13,21 @@ export const LogoBadge = ({
   variant?: Variant;
 }) => {
   const logoSize = variant === "large" ? 42 : 28;
+
+  const utmContentValue = `embedded_banner_${encodeURIComponent(
+    getHostAppUrlDomain(),
+  )}`;
+
   const Metabase = (
     // eslint-disable-next-line no-literal-metabase-strings -- This embedding badge which we don't want to show the whitelabeled name
     <MetabaseName key="metabase" isDark={dark} variant={variant}>
       Metabase
     </MetabaseName>
   );
+
   return (
     <MetabaseLink
-      href="https://www.metabase.com/powered-by-metabase?utm_medium=referral&utm_source=product&utm_campaign=powered_by_metabase&utm_content=embedded_banner"
+      href={`https://www.metabase.com/powered-by-metabase?utm_medium=referral&utm_source=product&utm_campaign=powered_by_metabase&utm_content=${utmContentValue}`}
       target="_blank"
       variant={variant}
     >
@@ -30,3 +36,15 @@ export const LogoBadge = ({
     </MetabaseLink>
   );
 };
+
+function getHostAppUrlDomain() {
+  // based on https://stackoverflow.com/questions/3420004/access-parent-url-from-iframe
+  let referrerUrl =
+    parent !== window ? document.referrer : document.location.href;
+
+  // remove trailing slash
+  referrerUrl = referrerUrl.replace(/\/+$/, "");
+
+  // get domain value, based on https://stackoverflow.com/questions/569137/how-to-get-domain-name-from-url
+  return referrerUrl.replace(/.+\/\/|www.|\..+/g, "");
+}

--- a/frontend/src/metabase/public/components/EmbedFrame/LogoBadge.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/LogoBadge.unit.spec.tsx
@@ -15,7 +15,7 @@ describe("LogoBadge", () => {
 
     expect(screen.getByRole("link")).toHaveProperty(
       "href",
-      "https://www.metabase.com/powered-by-metabase?utm_medium=referral&utm_source=product&utm_campaign=powered_by_metabase&utm_content=embedded_banner",
+      "https://www.metabase.com/powered-by-metabase?utm_medium=referral&utm_source=product&utm_campaign=powered_by_metabase&utm_content=embedded_banner_localhost",
     );
   });
 });

--- a/frontend/src/metabase/public/components/EmbedFrame/LogoBadge.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/LogoBadge.unit.spec.tsx
@@ -1,0 +1,25 @@
+import { screen, render } from "__support__/ui";
+
+import { LogoBadge } from "./LogoBadge";
+
+describe("LogoBadge", () => {
+  it("should render Powered by Metabase footer", () => {
+    setup();
+
+    expect(screen.getByText("Powered by")).toBeInTheDocument();
+    expect(screen.getByText("Metabase")).toBeInTheDocument();
+  });
+
+  it("should render a link with valid utm parameters", () => {
+    setup();
+
+    expect(screen.getByRole("link")).toHaveProperty(
+      "href",
+      "https://www.metabase.com/powered-by-metabase?utm_medium=referral&utm_source=product&utm_campaign=powered_by_metabase&utm_content=embedded_banner",
+    );
+  });
+});
+
+function setup() {
+  render(<LogoBadge dark={false} />);
+}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/42889 and https://github.com/metabase/metabase/issues/42940

### Description

Add utm parameters to `Powered by Metabase` link used in static embedding

And now we also pass host app domain url to one of utms.

### How to verify


https://github.com/metabase/metabase/assets/7983744/001eabdf-995c-48ad-ab0c-9d675eaaae78



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
