### PR TITLE
[Metrics V2] Backfill viz settings for compatible-series

### DIFF
--- a/e2e/test/scenarios/metrics/metrics-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-dashboard.cy.spec.js
@@ -194,7 +194,7 @@ describe("scenarios > metrics > dashboard", () => {
     combineAndVerifyMetrics(ORDERS_SCALAR_METRIC, PRODUCTS_SCALAR_METRIC);
   });
 
-  it.skip("should be able to combine timeseries metrics on a dashcard (metabase#42575)", () => {
+  it("should be able to combine timeseries metrics on a dashcard (metabase#42575)", () => {
     combineAndVerifyMetrics(
       ORDERS_TIMESERIES_METRIC,
       PRODUCTS_TIMESERIES_METRIC,

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -209,6 +209,10 @@
       (when-not ignore_view
         (events/publish-event! :event/card-read {:object <> :user-id api/*current-user-id*})))))
 
+(defn- dataset-query->query [metadata-provider dataset-query]
+  (let [pMBQL-query (-> dataset-query compatibility/normalize-dataset-query lib.convert/->pMBQL)]
+    (lib/query metadata-provider pMBQL-query)))
+
 (defn- card-columns-from-names
   [card names]
   (when-let [names (set names)]
@@ -218,21 +222,21 @@
   [cols]
   (map #(update-keys % u/->kebab-case-en) cols))
 
+(defn- source-cols [card source database-id->metadata-provider]
+  (if-let [names (get-in card [:visualization_settings (case source
+                                                         :source/breakouts :graph.dimensions
+                                                         :source/aggregations :graph.metrics)])]
+    (cols->kebab-case (card-columns-from-names card names))
+    (->> (dataset-query->query (get database-id->metadata-provider (:database_id card)) (:dataset_query card))
+         lib/returned-columns
+         (filter (comp #{source} :lib/source)))))
+
 (defn- area-bar-line-series-are-compatible?
-  [first-card second-card]
+  [first-card second-card database-id->metadata-provider]
   (and (#{:area :line :bar} (:display second-card))
-       (let [initial-dimensions (cols->kebab-case
-                                  (card-columns-from-names
-                                    first-card
-                                    (get-in first-card [:visualization_settings :graph.dimensions])))
-             new-dimensions     (cols->kebab-case
-                                  (card-columns-from-names
-                                    second-card
-                                    (get-in second-card [:visualization_settings :graph.dimensions])))
-             new-metrics        (cols->kebab-case
-                                  (card-columns-from-names
-                                    second-card
-                                    (get-in second-card [:visualization_settings :graph.metrics])))]
+       (let [initial-dimensions (source-cols first-card :source/breakouts database-id->metadata-provider)
+             new-dimensions     (source-cols second-card :source/breakouts database-id->metadata-provider)
+             new-metrics        (source-cols second-card :source/aggregations database-id->metadata-provider)]
          (cond
            ;; must have at least one dimension and one metric
            (or (zero? (count new-dimensions))
@@ -261,23 +265,23 @@
 
 (defmulti series-are-compatible?
   "Check if the `second-card` is compatible to be used as series of `card`."
-  (fn [card _second-card]
+  (fn [card _second-card _database-id->metadata-provider]
    (:display card)))
 
 (defmethod series-are-compatible? :area
-  [first-card second-card]
-  (area-bar-line-series-are-compatible? first-card second-card))
+  [first-card second-card database-id->metadata-provider]
+  (area-bar-line-series-are-compatible? first-card second-card database-id->metadata-provider))
 
 (defmethod series-are-compatible? :line
-  [first-card second-card]
-  (area-bar-line-series-are-compatible? first-card second-card))
+  [first-card second-card database-id->metadata-provider]
+  (area-bar-line-series-are-compatible? first-card second-card database-id->metadata-provider))
 
 (defmethod series-are-compatible? :bar
-  [first-card second-card]
-  (area-bar-line-series-are-compatible? first-card second-card))
+  [first-card second-card database-id->metadata-provider]
+  (area-bar-line-series-are-compatible? first-card second-card database-id->metadata-provider))
 
 (defmethod series-are-compatible? :scalar
-  [first-card second-card]
+  [first-card second-card _database-id->metadata-provider]
   (and (= :scalar (:display second-card))
        (= 1
           (count (:result_metadata first-card))
@@ -290,7 +294,7 @@
 
   Provide `page-size` to limit the number of cards returned, it does not guaranteed to return exactly `page-size` cards.
   Use `fetch-compatible-series` for that."
-  [card {:keys [query last-cursor page-size exclude-ids] :as _options}]
+  [card database-id->metadata-provider {:keys [query last-cursor page-size exclude-ids] :as _options}]
   (let [matching-cards  (t2/select Card
                                    :archived false
                                    :display [:in supported-series-display-type]
@@ -311,7 +315,15 @@
                                      ;; this is just a heuristic, but it should be good enough
                                      page-size
                                      (assoc :limit (+ 10 page-size))))
-
+        database-ids (set (keys database-id->metadata-provider))
+        database-id->metadata-provider (->> matching-cards
+                                            (filter #(or (nil? (get-in % [:visualization_settings :graph.metrics]))
+                                                       (nil? (get-in % [:visualization_settings :graph.dimensions]))))
+                                            (keep :database_id)
+                                            (set)
+                                            (remove #(contains? database-ids %))
+                                            (into database-id->metadata-provider
+                                                  (map (juxt identity lib.metadata.jvm/application-database-metadata-provider))))
         compatible-cards (->> matching-cards
                               (filter mi/can-read?)
                               (filter #(or
@@ -319,10 +331,11 @@
                                          ;; so we can't use series-are-compatible? to filter out incompatible native cards.
                                          ;; => we assume all native queries are compatible and FE will figure it out later
                                          (= (:query_type %) :native)
-                                         (series-are-compatible? card %))))]
+                                         (series-are-compatible? card % database-id->metadata-provider))))]
+
     (if page-size
-      (take page-size compatible-cards)
-      compatible-cards)))
+      [database-id->metadata-provider (take page-size compatible-cards)]
+      [database-id->metadata-provider compatible-cards])))
 
 (defn- fetch-compatible-series
   "Fetch a list of compatible series for `card`.
@@ -333,10 +346,14 @@
   - last-cursor: the id of the last card from the previous page
   - page-size:   is nullable, it'll try to fetches exactly `page-size` cards if there are enough cards."
   ([card options]
-   (fetch-compatible-series card options []))
+   (fetch-compatible-series
+     card
+     options
+     {(:database_id card) (lib.metadata.jvm/application-database-metadata-provider (:database_id card))}
+     []))
 
-  ([card {:keys [page-size] :as options} current-cards]
-   (let [cards     (fetch-compatible-series* card options)
+  ([card {:keys [page-size] :as options} database-id->metadata-provider current-cards]
+   (let [[database-id->metadata-provider cards] (fetch-compatible-series* card database-id->metadata-provider options)
          new-cards (concat current-cards cards)]
      ;; if the total card fetches is less than page-size and there are still more, continue fetching
      (if (and (some? page-size)
@@ -346,6 +363,7 @@
                                 (merge options
                                        {:page-size   (- page-size (count cards))
                                         :last-cursor (:id (last cards))})
+                                database-id->metadata-provider
                                 new-cards)
        new-cards))))
 
@@ -425,12 +443,11 @@
 (defn- check-if-card-can-be-saved
   [dataset-query card-type]
   (when (and dataset-query (= card-type :metric))
-    (let [pMBQL-query (-> dataset-query compatibility/normalize-dataset-query lib.convert/->pMBQL)
-          metadata-provider (lib.metadata.jvm/application-database-metadata-provider (:database pMBQL-query))]
-      (when-not (lib/can-save (lib/query metadata-provider pMBQL-query) card-type)
-        (throw (ex-info (tru "Card of type {0} is invalid, cannot be saved." (clojure.core/name card-type))
-                        {:type        card-type
-                         :status-code 400}))))))
+    (when-not (lib/can-save (dataset-query->query (lib.metadata.jvm/application-database-metadata-provider (:database dataset-query))
+                                                  dataset-query) card-type)
+      (throw (ex-info (tru "Card of type {0} is invalid, cannot be saved." (clojure.core/name card-type))
+                      {:type        card-type
+                       :status-code 400})))))
 
 (api/defendpoint POST "/"
   "Create a new `Card`."


### PR DESCRIPTION
Fixes #42575

The BE should rely on the query when there is no corresponding viz setting.
If there is no graph.metrics setting, assume that all last-stage aggregations are used.
No graph.dimensions -> use breakouts.