### PR TITLE
Hide creation buttons on search and recents tabs

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -173,6 +173,10 @@ describe("scenarios > dashboard", () => {
             .should("have.text", "Our analytics")
             .click();
         });
+
+        entityPickerModal()
+          .findByRole("tab", { name: /Collections/ })
+          .click();
         entityPickerModal()
           .findByText("Create a new collection")
           .click({ force: true });

--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -299,6 +299,11 @@ describe("scenarios > question > new", () => {
     cy.findByTestId("save-question-modal")
       .findByLabelText(/Which collection/)
       .click();
+
+    entityPickerModal()
+      .findByRole("tab", { name: /Collections/ })
+      .click();
+
     entityPickerModal().findByText("Create a new collection").click();
 
     const NEW_COLLECTION = "Foo";

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
@@ -98,6 +98,10 @@ export function EntityPickerModal<
     null,
   );
 
+  const [showActionButtons, setShowActionButtons] = useState<boolean>(
+    !!actionButtons.length,
+  );
+
   const hydratedOptions = useMemo(
     () => ({ ...defaultOptions, ...options }),
     [options],
@@ -206,6 +210,7 @@ export function EntityPickerModal<
                 selectedItem={selectedItem}
                 initialValue={initialValue}
                 defaultToRecentTab={defaultToRecentTab}
+                setShowActionButtons={setShowActionButtons}
               />
             ) : (
               <SinglePickerView>{tabs[0].element}</SinglePickerView>
@@ -215,7 +220,7 @@ export function EntityPickerModal<
                 onConfirm={onConfirm}
                 onCancel={onClose}
                 canConfirm={canSelectItem}
-                actionButtons={actionButtons}
+                actionButtons={showActionButtons ? actionButtons : []}
                 confirmButtonText={options?.confirmButtonText}
                 cancelButtonText={options?.cancelButtonText}
               />

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/TabsView.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/TabsView.tsx
@@ -52,6 +52,7 @@ export const TabsView = <
   selectedItem,
   initialValue,
   defaultToRecentTab,
+  setShowActionButtons,
 }: {
   tabs: EntityTab<Model>[];
   onItemSelect: (item: Item) => void;
@@ -61,6 +62,7 @@ export const TabsView = <
   initialValue?: Partial<Item>;
   searchParams?: Partial<SearchRequest>;
   defaultToRecentTab: boolean;
+  setShowActionButtons: (showActionButtons: boolean) => void;
 }) => {
   const hasSearchTab = !!searchQuery;
   const hasRecentsTab = tabs.some(tab => tab.model === "recents");
@@ -86,6 +88,15 @@ export const TabsView = <
       setSelectedTab(defaultTab.model);
     }
   }, [searchQuery, defaultTab.model]);
+
+  useEffect(() => {
+    // we don't want to show bonus actions on recents or search tabs
+    if (["search", "recents"].includes(selectedTab)) {
+      setShowActionButtons(false);
+    } else {
+      setShowActionButtons(true);
+    }
+  }, [selectedTab, setShowActionButtons]);
 
   return (
     <Tabs


### PR DESCRIPTION

Closes #42976

### Description

The "Create a dashboard" and "Create a collection" buttons were pretty confusing on the recents and search screens (they would create items in the root collection), this hides those buttons on the recents and search tabs.

![noNewOnSearchOrRecent](https://github.com/metabase/metabase/assets/30528226/b54d4434-b161-41f4-add5-31f1fb296796)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
