### PR TITLE
Add data source specific icons to data and join steps in the notebook editor

### DIFF
--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -133,6 +133,7 @@ export type TableDisplayInfo = {
   isFromJoin: boolean;
   isImplicitlyJoinable: boolean;
   schema: SchemaId;
+  isQuestion?: boolean;
   isModel?: boolean;
   isMetric?: boolean;
 };

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookDataPicker/NotebookDataPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookDataPicker/NotebookDataPicker.tsx
@@ -1,6 +1,5 @@
 import { useMemo, useState } from "react";
 import { useLatest } from "react-use";
-import { t } from "ttag";
 
 import {
   DataPickerModal,
@@ -84,7 +83,7 @@ export function NotebookDataPicker({
       </UnstyledButton>
       {isOpen && (
         <DataPickerModal
-          title={t`Pick data to join`}
+          title={title}
           value={tableValue}
           databaseId={databaseId}
           models={[

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookDataPicker/NotebookDataPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookDataPicker/NotebookDataPicker.tsx
@@ -1,0 +1,115 @@
+import { useMemo, useState } from "react";
+import { useLatest } from "react-use";
+import { t } from "ttag";
+
+import {
+  DataPickerModal,
+  getDataPickerValue,
+} from "metabase/common/components/DataPicker";
+import { useDispatch, useStore } from "metabase/lib/redux";
+import { checkNotNull } from "metabase/lib/types";
+import { loadMetadataForTable } from "metabase/questions/actions";
+import { getMetadata } from "metabase/selectors/metadata";
+import type { IconName } from "metabase/ui";
+import { Group, Icon, UnstyledButton } from "metabase/ui";
+import * as Lib from "metabase-lib";
+import type { DatabaseId, TableId } from "metabase-types/api";
+
+import { NotebookCell } from "../NotebookCell";
+
+interface NotebookPickerButtonProps {
+  title: string;
+  query: Lib.Query;
+  stageIndex: number;
+  table?: Lib.TableMetadata | Lib.CardMetadata;
+  databaseId?: DatabaseId | null;
+  placeholder?: string;
+  hasMetrics?: boolean;
+  isDisabled?: boolean;
+  onChange: (
+    table: Lib.TableMetadata | Lib.CardMetadata,
+    metadataProvider: Lib.MetadataProvider,
+  ) => void;
+}
+
+export function NotebookDataPicker({
+  title,
+  query,
+  stageIndex,
+  table,
+  databaseId,
+  placeholder = title,
+  hasMetrics,
+  isDisabled,
+  onChange,
+}: NotebookPickerButtonProps) {
+  const [isOpen, setIsOpen] = useState(!table);
+  const store = useStore();
+  const dispatch = useDispatch();
+  const onChangeRef = useLatest(onChange);
+
+  const tableInfo = useMemo(
+    () => table && Lib.displayInfo(query, stageIndex, table),
+    [query, stageIndex, table],
+  );
+
+  const tableValue = useMemo(
+    () => table && getDataPickerValue(query, stageIndex, table),
+    [query, stageIndex, table],
+  );
+
+  const handleChange = async (tableId: TableId) => {
+    await dispatch(loadMetadataForTable(tableId));
+    const metadata = getMetadata(store.getState());
+    const databaseId = checkNotNull(metadata.table(tableId)).db_id;
+    const metadataProvider = Lib.metadataProvider(databaseId, metadata);
+    const table = Lib.tableOrCardMetadata(metadataProvider, tableId);
+    onChangeRef.current?.(table, metadataProvider);
+  };
+
+  return (
+    <>
+      <UnstyledButton
+        c="inherit"
+        fz="inherit"
+        fw="inherit"
+        p={NotebookCell.CONTAINER_PADDING}
+        disabled={isDisabled}
+        onClick={() => setIsOpen(true)}
+      >
+        <Group spacing="xs">
+          {tableInfo && <Icon name={getTableIcon(tableInfo)} />}
+          {tableInfo?.displayName ?? placeholder}
+        </Group>
+      </UnstyledButton>
+      {isOpen && (
+        <DataPickerModal
+          title={t`Pick data to join`}
+          value={tableValue}
+          databaseId={databaseId ?? undefined}
+          models={[
+            "table",
+            "card",
+            "dataset",
+            ...(hasMetrics ? ["metric" as const] : []),
+          ]}
+          onChange={handleChange}
+          onClose={() => setIsOpen(false)}
+        />
+      )}
+    </>
+  );
+}
+
+function getTableIcon(tableInfo: Lib.TableDisplayInfo): IconName {
+  switch (true) {
+    case tableInfo.isQuestion:
+      return "table2";
+    case tableInfo.isModel:
+      return "model";
+    case tableInfo.isMetric:
+      return "metric";
+    default:
+      return "table";
+  }
+}

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookDataPicker/NotebookDataPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookDataPicker/NotebookDataPicker.tsx
@@ -17,7 +17,7 @@ import type { DatabaseId, TableId } from "metabase-types/api";
 
 import { NotebookCell } from "../NotebookCell";
 
-interface NotebookPickerButtonProps {
+interface NotebookDataPickerProps {
   title: string;
   query: Lib.Query;
   stageIndex: number;
@@ -42,7 +42,7 @@ export function NotebookDataPicker({
   hasMetrics,
   isDisabled,
   onChange,
-}: NotebookPickerButtonProps) {
+}: NotebookDataPickerProps) {
   const [isOpen, setIsOpen] = useState(!table);
   const store = useStore();
   const dispatch = useDispatch();

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookDataPicker/NotebookDataPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookDataPicker/NotebookDataPicker.tsx
@@ -22,7 +22,7 @@ interface NotebookDataPickerProps {
   query: Lib.Query;
   stageIndex: number;
   table?: Lib.TableMetadata | Lib.CardMetadata;
-  databaseId?: DatabaseId | null;
+  databaseId?: DatabaseId;
   placeholder?: string;
   hasMetrics?: boolean;
   isDisabled?: boolean;
@@ -86,7 +86,7 @@ export function NotebookDataPicker({
         <DataPickerModal
           title={t`Pick data to join`}
           value={tableValue}
-          databaseId={databaseId ?? undefined}
+          databaseId={databaseId}
           models={[
             "table",
             "card",

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookDataPicker/index.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookDataPicker/index.ts
@@ -1,0 +1,1 @@
+export * from "./NotebookDataPicker";

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.styled.tsx
@@ -5,10 +5,6 @@ import { color } from "metabase/lib/colors";
 
 import { NotebookCell } from "../../NotebookCell";
 
-export const DataStepCell = styled.div`
-  padding: ${NotebookCell.CONTAINER_PADDING};
-`;
-
 export const DataStepIconButton = styled(IconButtonWrapper)`
   color: ${color("white")};
   padding: ${NotebookCell.CONTAINER_PADDING};

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.tsx
@@ -10,7 +10,8 @@ import { FieldPicker } from "metabase/common/components/FieldPicker";
 import { useDispatch } from "metabase/lib/redux";
 import { checkNotNull } from "metabase/lib/types";
 import { loadMetadataForTable } from "metabase/questions/actions";
-import { Group, Icon, IconName, Popover, Tooltip } from "metabase/ui";
+import type { IconName } from "metabase/ui";
+import { Group, Icon, Popover, Tooltip } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import type { TableId } from "metabase-types/api";
 
@@ -187,7 +188,7 @@ function DataFieldPicker({
 function getDataSourceIcon(displayInfo: Lib.TableDisplayInfo): IconName {
   switch (true) {
     case displayInfo.isQuestion:
-      return "table";
+      return "table2";
     case displayInfo.isModel:
       return "model";
     case displayInfo.isMetric:

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.tsx
@@ -10,7 +10,7 @@ import { FieldPicker } from "metabase/common/components/FieldPicker";
 import { useDispatch } from "metabase/lib/redux";
 import { checkNotNull } from "metabase/lib/types";
 import { loadMetadataForTable } from "metabase/questions/actions";
-import { Group, Icon, Popover, Tooltip } from "metabase/ui";
+import { Group, Icon, IconName, Popover, Tooltip } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import type { TableId } from "metabase-types/api";
 
@@ -81,7 +81,7 @@ export const DataStep = ({
           spacing="xs"
           onClick={() => setIsDataPickerOpen(true)}
         >
-          {tableInfo?.isMetric && <Icon name="metric" />}
+          {tableInfo && <Icon name={getDataSourceIcon(tableInfo)} />}
           {tableInfo?.displayName ?? t`Pick your starting data`}
         </Group>
 
@@ -182,4 +182,17 @@ function DataFieldPicker({
       onSelectNone={handleSelectNone}
     />
   );
+}
+
+function getDataSourceIcon(displayInfo: Lib.TableDisplayInfo): IconName {
+  switch (true) {
+    case displayInfo.isQuestion:
+      return "table";
+    case displayInfo.isModel:
+      return "model";
+    case displayInfo.isMetric:
+      return "metric";
+    default:
+      return "table";
+  }
 }

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.tsx
@@ -1,19 +1,10 @@
-import { useMemo, useState } from "react";
-import { useLatest } from "react-use";
+import { useMemo } from "react";
 import { t } from "ttag";
 
-import {
-  DataPickerModal,
-  getDataPickerValue,
-} from "metabase/common/components/DataPicker";
 import { FieldPicker } from "metabase/common/components/FieldPicker";
-import { useDispatch } from "metabase/lib/redux";
-import { checkNotNull } from "metabase/lib/types";
-import { loadMetadataForTable } from "metabase/questions/actions";
-import type { IconName } from "metabase/ui";
-import { Group, Icon, Popover, Tooltip } from "metabase/ui";
+import { NotebookDataPicker } from "metabase/query_builder/components/notebook/NotebookDataPicker";
+import { Icon, Popover, Tooltip } from "metabase/ui";
 import * as Lib from "metabase-lib";
-import type { TableId } from "metabase-types/api";
 
 import { NotebookCell, NotebookCellItem } from "../../NotebookCell";
 import type { NotebookStepUiComponentProps } from "../../types";
@@ -27,14 +18,9 @@ export const DataStep = ({
   color,
   updateQuery,
 }: NotebookStepUiComponentProps) => {
-  const dispatch = useDispatch();
   const { stageIndex } = step;
-  const question = step.question;
-  const questionRef = useLatest(question);
   const tableId = Lib.sourceTableOrCardId(query);
-  const table = tableId ? Lib.tableOrCardMetadata(query, tableId) : null;
-  const tableInfo = table ? Lib.displayInfo(query, stageIndex, table) : null;
-  const [isDataPickerOpen, setIsDataPickerOpen] = useState(!table);
+  const table = tableId ? Lib.tableOrCardMetadata(query, tableId) : undefined;
 
   const isRaw = useMemo(() => {
     return (
@@ -45,19 +31,12 @@ export const DataStep = ({
 
   const canSelectTableColumns = table && isRaw && !readOnly;
 
-  const handleTableChange = async (tableId: TableId) => {
-    await dispatch(loadMetadataForTable(tableId));
-    // using questionRef to access up-to-date metadata
-    const metadata = questionRef.current.metadata();
-    const table = checkNotNull(metadata.table(tableId));
-    const metadataProvider = Lib.metadataProvider(table.db_id, metadata);
-    const nextTable = Lib.tableOrCardMetadata(metadataProvider, tableId);
-    updateQuery(Lib.queryFromTableOrCardMetadata(metadataProvider, nextTable));
+  const handleTableChange = (
+    table: Lib.TableMetadata | Lib.CardMetadata,
+    metadataProvider: Lib.MetadataProvider,
+  ) => {
+    updateQuery(Lib.queryFromTableOrCardMetadata(metadataProvider, table));
   };
-
-  const value = useMemo(() => {
-    return table ? getDataPickerValue(query, stageIndex, table) : undefined;
-  }, [query, stageIndex, table]);
 
   return (
     <NotebookCell color={color}>
@@ -77,24 +56,14 @@ export const DataStep = ({
         rightContainerStyle={{ width: 37, height: 37, padding: 0 }}
         data-testid="data-step-cell"
       >
-        <Group
-          p={NotebookCell.CONTAINER_PADDING}
-          spacing="xs"
-          onClick={() => setIsDataPickerOpen(true)}
-        >
-          {tableInfo && <Icon name={getDataSourceIcon(tableInfo)} />}
-          {tableInfo?.displayName ?? t`Pick your starting data`}
-        </Group>
-
-        {isDataPickerOpen && (
-          <DataPickerModal
-            title={t`Pick your starting data`}
-            value={value}
-            models={["table", "card", "dataset", "metric"]}
-            onChange={handleTableChange}
-            onClose={() => setIsDataPickerOpen(false)}
-          />
-        )}
+        <NotebookDataPicker
+          title={t`Pick your starting data`}
+          query={query}
+          stageIndex={stageIndex}
+          table={table}
+          hasMetrics
+          onChange={handleTableChange}
+        />
       </NotebookCellItem>
     </NotebookCell>
   );
@@ -183,17 +152,4 @@ function DataFieldPicker({
       onSelectNone={handleSelectNone}
     />
   );
-}
-
-function getDataSourceIcon(displayInfo: Lib.TableDisplayInfo): IconName {
-  switch (true) {
-    case displayInfo.isQuestion:
-      return "table2";
-    case displayInfo.isModel:
-      return "model";
-    case displayInfo.isMetric:
-      return "metric";
-    default:
-      return "table";
-  }
 }

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.tsx
@@ -10,14 +10,14 @@ import { FieldPicker } from "metabase/common/components/FieldPicker";
 import { useDispatch } from "metabase/lib/redux";
 import { checkNotNull } from "metabase/lib/types";
 import { loadMetadataForTable } from "metabase/questions/actions";
-import { Icon, Popover, Tooltip } from "metabase/ui";
+import { Group, Icon, Popover, Tooltip } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import type { TableId } from "metabase-types/api";
 
 import { NotebookCell, NotebookCellItem } from "../../NotebookCell";
 import type { NotebookStepUiComponentProps } from "../../types";
 
-import { DataStepCell, DataStepIconButton } from "./DataStep.styled";
+import { DataStepIconButton } from "./DataStep.styled";
 
 export const DataStep = ({
   query,
@@ -32,11 +32,8 @@ export const DataStep = ({
   const questionRef = useLatest(question);
   const tableId = Lib.sourceTableOrCardId(query);
   const table = tableId ? Lib.tableOrCardMetadata(query, tableId) : null;
+  const tableInfo = table ? Lib.displayInfo(query, stageIndex, table) : null;
   const [isDataPickerOpen, setIsDataPickerOpen] = useState(!table);
-
-  const pickerLabel = table
-    ? Lib.displayInfo(query, stageIndex, table).displayName
-    : t`Pick your starting data`;
 
   const isRaw = useMemo(() => {
     return (
@@ -79,9 +76,14 @@ export const DataStep = ({
         rightContainerStyle={{ width: 37, height: 37, padding: 0 }}
         data-testid="data-step-cell"
       >
-        <DataStepCell onClick={() => setIsDataPickerOpen(true)}>
-          {pickerLabel}
-        </DataStepCell>
+        <Group
+          p={NotebookCell.CONTAINER_PADDING}
+          spacing="xs"
+          onClick={() => setIsDataPickerOpen(true)}
+        >
+          {tableInfo?.isMetric && <Icon name="metric" />}
+          {tableInfo?.displayName ?? t`Pick your starting data`}
+        </Group>
 
         {isDataPickerOpen && (
           <DataPickerModal

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.unit.spec.tsx
@@ -146,7 +146,7 @@ describe("DataStep", () => {
   });
 
   it.each<{ type: CardType; icon: IconName }>([
-    { type: "question", icon: "table" },
+    { type: "question", icon: "table2" },
     { type: "model", icon: "model" },
     { type: "metric", icon: "metric" },
   ])("should render with a selected card", ({ type, icon }) => {

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinComplete/JoinComplete.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinComplete/JoinComplete.tsx
@@ -113,7 +113,6 @@ export function JoinComplete({
             query={query}
             stageIndex={stageIndex}
             table={rhsTable}
-            tableName={rhsTableName}
             color={color}
             isReadOnly={isReadOnly}
             columnPicker={

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinDraft/JoinDraft.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinDraft/JoinDraft.tsx
@@ -103,7 +103,6 @@ export function JoinDraft({
             query={query}
             stageIndex={stageIndex}
             table={rhsTable}
-            tableName={rhsTableName}
             color={color}
             isReadOnly={isReadOnly}
             columnPicker={

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.styled.tsx
@@ -5,13 +5,6 @@ import { color } from "metabase/lib/colors";
 
 import { NotebookCell } from "../../../NotebookCell";
 
-export const TablePickerButton = styled.button`
-  color: inherit;
-  font-weight: inherit;
-  cursor: ${props => (props.disabled ? "auto" : "pointer")};
-  padding: ${NotebookCell.CONTAINER_PADDING};
-`;
-
 export const ColumnPickerButton = styled(IconButtonWrapper)`
   padding: ${NotebookCell.CONTAINER_PADDING};
   opacity: 0.5;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.tsx
@@ -52,7 +52,7 @@ export function JoinTablePicker({
         query={query}
         stageIndex={stageIndex}
         table={table}
-        databaseId={databaseId}
+        databaseId={databaseId ?? undefined}
         placeholder={t`Pick data…`}
         isDisabled={isDisabled}
         onChange={onChange}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.tsx
@@ -1,74 +1,45 @@
 import type { ReactNode } from "react";
 import { useMemo, useState } from "react";
-import { useLatest } from "react-use";
 import { t } from "ttag";
 
-import {
-  DataPickerModal,
-  getDataPickerValue,
-} from "metabase/common/components/DataPicker";
-import { useDispatch } from "metabase/lib/redux";
-import { loadMetadataForTable } from "metabase/questions/actions";
 import { Icon, Popover, Tooltip } from "metabase/ui";
 import * as Lib from "metabase-lib";
-import type { TableId } from "metabase-types/api";
 
 import { NotebookCellItem } from "../../../NotebookCell";
+import { NotebookDataPicker } from "../../../NotebookDataPicker";
 
-import {
-  ColumnPickerButton,
-  TablePickerButton,
-} from "./JoinTablePicker.styled";
+import { ColumnPickerButton } from "./JoinTablePicker.styled";
 
 interface JoinTablePickerProps {
   query: Lib.Query;
   stageIndex: number;
   table: Lib.Joinable | undefined;
-  tableName: string | undefined;
   color: string;
   isReadOnly: boolean;
   columnPicker: ReactNode;
-  onChange?: (table: Lib.Joinable) => void;
+  onChange: (table: Lib.Joinable) => void;
 }
 
 export function JoinTablePicker({
   query,
   stageIndex,
-  table: joinable,
-  tableName,
+  table,
   color,
   isReadOnly,
   columnPicker,
   onChange,
 }: JoinTablePickerProps) {
-  const dispatch = useDispatch();
-  const onChangeRef = useLatest(onChange);
-  const queryRef = useLatest(query);
-
-  const [isDataPickerOpen, setIsDataPickerOpen] = useState(!joinable);
   const databaseId = useMemo(() => Lib.databaseID(query), [query]);
-
   const isDisabled = isReadOnly;
-
-  const handleTableChange = async (tableId: TableId) => {
-    await dispatch(loadMetadataForTable(tableId));
-    onChangeRef.current?.(Lib.tableOrCardMetadata(queryRef.current, tableId));
-  };
-
-  const value = useMemo(() => {
-    return joinable
-      ? getDataPickerValue(query, stageIndex, joinable)
-      : undefined;
-  }, [query, stageIndex, joinable]);
 
   return (
     <NotebookCellItem
-      inactive={!joinable}
+      inactive={!table}
       readOnly={isReadOnly}
       disabled={isDisabled}
       color={color}
       right={
-        joinable != null && !isReadOnly ? (
+        table != null && !isReadOnly ? (
           <JoinTableColumnPicker columnPicker={columnPicker} />
         ) : null
       }
@@ -76,23 +47,16 @@ export function JoinTablePicker({
       rightContainerStyle={RIGHT_CONTAINER_STYLE}
       aria-label={t`Right table`}
     >
-      <TablePickerButton
-        disabled={isDisabled}
-        onClick={() => setIsDataPickerOpen(true)}
-      >
-        {tableName || t`Pick data…`}
-      </TablePickerButton>
-
-      {isDataPickerOpen && (
-        <DataPickerModal
-          databaseId={databaseId ?? undefined}
-          title={t`Pick data to join`}
-          value={value}
-          models={["table", "card", "dataset"]}
-          onChange={handleTableChange}
-          onClose={() => setIsDataPickerOpen(false)}
-        />
-      )}
+      <NotebookDataPicker
+        title={t`Pick data to join`}
+        query={query}
+        stageIndex={stageIndex}
+        table={table}
+        databaseId={databaseId}
+        placeholder={t`Pick data…`}
+        isDisabled={isDisabled}
+        onChange={onChange}
+      />
     </NotebookCellItem>
   );
 }

--- a/frontend/src/metabase/query_builder/components/notebook/steps/SummarizeStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/SummarizeStep.tsx
@@ -13,14 +13,8 @@ function SummarizeStep({
   step,
   ...props
 }: NotebookStepUiComponentProps) {
-  const isMetric = step.question.type() === "metric";
-
   return (
-    <Flex
-      align="center"
-      direction={{ base: "column", md: "row" }}
-      gap={isMetric ? "md" : "sm"}
-    >
+    <Flex align="center" direction={{ base: "column", md: "row" }} gap="sm">
       <Box w={{ base: "100%", md: "50%" }}>
         <AggregateStep
           step={step}
@@ -29,7 +23,7 @@ function SummarizeStep({
           {...props}
         />
       </Box>
-      {!isMetric && <Box c={color} fw="bold">{t`by`}</Box>}
+      <Box c={color} fw="bold">{t`by`}</Box>
       <Box w={{ base: "100%", md: "50%" }}>
         <BreakoutStep
           step={step}

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/QuestionDataSource.jsx
@@ -61,7 +61,7 @@ export function QuestionDataSource({
   if (originalQuestion?.id() === sourceQuestionId) {
     return (
       <SourceDatasetBreadcrumbs
-        model={originalQuestion}
+        question={originalQuestion}
         variant={variant}
         {...props}
       />
@@ -85,7 +85,7 @@ export function QuestionDataSource({
             ) {
               return (
                 <SourceDatasetBreadcrumbs
-                  model={sourceQuestion}
+                  question={sourceQuestion}
                   collection={collection}
                   variant={variant}
                   {...props}
@@ -122,11 +122,11 @@ function DataSourceCrumbs({ question, variant, isObjectDetail, ...props }) {
 }
 
 SourceDatasetBreadcrumbs.propTypes = {
-  model: PropTypes.object.isRequired,
+  question: PropTypes.object.isRequired,
   collection: PropTypes.object.isRequired,
 };
 
-function SourceDatasetBreadcrumbs({ model, collection, ...props }) {
+function SourceDatasetBreadcrumbs({ question, collection, ...props }) {
   return (
     <HeadBreadcrumbs
       {...props}
@@ -134,12 +134,12 @@ function SourceDatasetBreadcrumbs({ model, collection, ...props }) {
         <HeadBreadcrumbs.Badge
           key="dataset-collection"
           to={Urls.collection(collection)}
-          icon="model"
+          icon={question.type() === "metric" ? "metric" : "model"}
           inactiveColor="text-light"
         >
           {collection?.name || t`Our analytics`}
         </HeadBreadcrumbs.Badge>,
-        model.isArchived() ? (
+        question.isArchived() ? (
           <Tooltip
             key="dataset-name"
             tooltip={t`This model is archived and shouldn't be used.`}
@@ -150,15 +150,15 @@ function SourceDatasetBreadcrumbs({ model, collection, ...props }) {
               inactiveColor="text-light"
               icon={{ name: "warning", color: color("danger") }}
             >
-              {model.displayName()}
+              {question.displayName()}
             </HeadBreadcrumbs.Badge>
           </Tooltip>
         ) : (
           <HeadBreadcrumbs.Badge
-            to={Urls.question(model.card())}
+            to={Urls.question(question.card())}
             inactiveColor="text-light"
           >
-            {model.displayName()}
+            {question.displayName()}
           </HeadBreadcrumbs.Badge>
         ),
       ]}

--- a/frontend/src/metabase/ui/components/buttons/UnstyledButton/index.ts
+++ b/frontend/src/metabase/ui/components/buttons/UnstyledButton/index.ts
@@ -1,0 +1,2 @@
+export { UnstyledButton } from "@mantine/core";
+export type { UnstyledButtonProps } from "@mantine/core";

--- a/frontend/src/metabase/ui/components/buttons/index.ts
+++ b/frontend/src/metabase/ui/components/buttons/index.ts
@@ -1,3 +1,4 @@
 export * from "./ActionIcon";
 export * from "./Button";
 export * from "./PopoverBackButton";
+export * from "./UnstyledButton";

--- a/src/metabase/lib/card.cljc
+++ b/src/metabase/lib/card.cljc
@@ -26,6 +26,7 @@
 (defmethod lib.metadata.calculation/display-info-method :metadata/card
   [query stage-number card-metadata]
   (cond-> ((get-method lib.metadata.calculation/display-info-method :default) query stage-number card-metadata)
+    (= (:type card-metadata) :question) (assoc :question? true)
     (= (:type card-metadata) :model) (assoc :model? true)
     (= (:type card-metadata) :metric) (assoc :metric? true)))
 


### PR DESCRIPTION
How to verify:
- New -> Question
- Select a table/question/model/metric
- There should be an icon next to the data source name in DataStep

<img width="1315" alt="Screenshot 2024-05-21 at 17 18 48" src="https://github.com/metabase/metabase/assets/8542534/0171f776-223d-4cf3-8e0b-586665296b2f">
