### PR TITLE
feat(admin/performance): Add tab for dashboard and questions overrides

### DIFF
--- a/docs/configuring-metabase/caching.md
+++ b/docs/configuring-metabase/caching.md
@@ -83,7 +83,7 @@ _* Denotes [Pro](https://www.metabase.com/product/pro) and [Enterprise](https://
 
 ### Default caching policy
 
-To set a default caching policy for your Metabase: Hit Cmd/Ctrl + k to bring up the command palette and search for **Performance**. Or, click through **Gear** settings icon > **Admin settings** > **Performance** > **Database caching settings**.
+To set a default caching policy for your Metabase: Hit Cmd/Ctrl + k to bring up the command palette and search for **Performance**. Or, click through **Gear** settings icon > **Admin settings** > **Performance** > **Database caching**.
 
 Click on the button next to **Default policy**, and select a [cache invalidation policy](#cache-invalidation-policies).
 
@@ -137,7 +137,7 @@ A question policy overrides a dashboard policy, which overrides a database polic
 To clear the cache and refresh the results:
 
 - **Questions and dashboards**: Visit the item and click through the **Info > Caching policy > Clear cache** (the "Clear cache" button is at the bottom of the sidebar).
-- **Database**: Click the **Gear** icon and click through **Admin settings** > **Performance** > **Database caching settings**. Select your database and click the **Clear cache** button (at the bottom of the page).
+- **Database**: Click the **Gear** icon and click through **Admin settings** > **Performance** > **Database caching**. Select your database and click the **Clear cache** button (at the bottom of the page).
 
 ## Caching location
 

--- a/e2e/test/scenarios/admin/performance/helpers/e2e-performance-helpers.ts
+++ b/e2e/test/scenarios/admin/performance/helpers/e2e-performance-helpers.ts
@@ -6,7 +6,7 @@ dayjs.extend(duration);
 dayjs.extend(relativeTime);
 
 /** Intercept routes for caching tests */
-export const interceptRoutes = () => {
+export const interceptPerformanceRoutes = () => {
   cy.intercept("POST", "/api/dataset").as("dataset");
   cy.intercept("POST", "/api/card/*/query").as("cardQuery");
   cy.intercept("PUT", "/api/cache").as("putCacheConfig");
@@ -28,5 +28,14 @@ export const log = (message: string) => {
   console.log(message);
 };
 
-export const databaseCachingSettingsPage = () =>
-  cy.findByRole("main", { name: "Database caching settings" });
+export const databaseCachingPage = () =>
+  cy.findByRole("tabpanel", { name: "Database caching" });
+
+export const visitDashboardAndQuestionCachingTab = () => {
+  cy.visit("/admin/performance");
+  cy.findByRole("tablist")
+    .get("[aria-selected]")
+    .contains("Database caching")
+    .should("be.visible");
+  cy.findByRole("tab", { name: "Dashboard and question caching" }).click();
+};

--- a/e2e/test/scenarios/admin/performance/helpers/e2e-strategy-form-helpers.ts
+++ b/e2e/test/scenarios/admin/performance/helpers/e2e-strategy-form-helpers.ts
@@ -1,10 +1,11 @@
+import { modal } from "e2e/support/helpers";
 import {
   type ScheduleComponentType,
   getScheduleComponentLabel,
 } from "metabase/components/Schedule/constants";
 import type { CacheStrategyType, CacheableModel } from "metabase-types/api";
 
-import { databaseCachingSettingsPage } from "./e2e-performance-helpers";
+import { databaseCachingPage } from "./e2e-performance-helpers";
 
 /** Save the cache strategy form and wait for a response from the relevant endpoint */
 export const saveCacheStrategyForm = (options?: {
@@ -29,7 +30,7 @@ export const saveCacheStrategyForm = (options?: {
 };
 
 export const cacheStrategyForm = () =>
-  cy.findByLabelText("Select the cache invalidation policy");
+  cy.findByRole("form", { name: "Select the cache invalidation policy" });
 
 export const cacheStrategyRadioButton = (name: RegExp) =>
   cacheStrategyForm().findByRole("radio", { name });
@@ -50,21 +51,21 @@ export const formLauncher = (
     | "currently inheriting the default policy",
   strategyLabel = "",
 ) => {
-  databaseCachingSettingsPage().should("exist");
   const regExp = new RegExp(`Edit.*${itemName}.*${preface}.*${strategyLabel}`);
   cy.log(`Finding strategy for launcher for regular expression: ${regExp}`);
-  const launcher = databaseCachingSettingsPage().findByLabelText(regExp);
+  const launcher = databaseCachingPage().findByLabelText(regExp);
   launcher.should("exist");
   return launcher;
 };
 
+/** Opens the strategy form on 'Database caching' tab */
 export const openStrategyFormForDatabaseOrDefaultPolicy = (
   /** To open the form for the default policy, set this parameter to "default policy" */
   databaseNameOrDefaultPolicy: string,
   currentStrategyLabel?: string,
 ) => {
   cy.visit("/admin/performance");
-  cy.findByRole("tab", { name: "Database caching settings" }).click();
+  cy.findByRole("tablist").get("[aria-selected]").contains("Database caching");
   cy.log(`Open strategy form for ${databaseNameOrDefaultPolicy}`);
   formLauncher(
     databaseNameOrDefaultPolicy,
@@ -90,4 +91,11 @@ export const openSidebarCacheStrategyForm = () => {
   openSidebar();
   cy.wait("@getCacheConfig");
   cy.findByLabelText("Caching policy").click();
+};
+
+export const cancelConfirmationModal = () => {
+  modal().within(() => {
+    cy.findByText("Discard your changes?");
+    cy.button("Cancel").click();
+  });
 };

--- a/e2e/test/scenarios/admin/performance/performance.cy.spec.ts
+++ b/e2e/test/scenarios/admin/performance/performance.cy.spec.ts
@@ -1,317 +1,406 @@
-import { describeEE, restore, setTokenFeatures } from "e2e/support/helpers";
+import {
+  ORDERS_COUNT_QUESTION_ID,
+  ORDERS_QUESTION_ID,
+} from "e2e/support/cypress_sample_instance_data";
+import {
+  describeEE,
+  restore,
+  setTokenFeatures,
+  visitQuestion,
+} from "e2e/support/helpers";
 
+import {
+  interceptPerformanceRoutes,
+  visitDashboardAndQuestionCachingTab,
+} from "./helpers/e2e-performance-helpers";
 import {
   adaptiveRadioButton,
   cacheStrategyForm,
   cacheStrategyRadioButton,
+  cancelConfirmationModal,
   dontCacheResultsRadioButton,
   durationRadioButton,
   formLauncher,
+  openSidebarCacheStrategyForm,
   openStrategyFormForDatabaseOrDefaultPolicy,
   saveCacheStrategyForm,
   scheduleRadioButton,
   useDefaultRadioButton,
 } from "./helpers/e2e-strategy-form-helpers";
 
-// NOTE: These tests just check that the form can be saved. They do not test
-// whether the cache is actually invalidated at the specified times.
+/** NOTE: These do not test whether caches are actually invalidated at the specified times. */
+describe("scenarios > admin > performance", () => {
+  describe("oss", { tags: "@OSS" }, () => {
+    beforeEach(() => {
+      restore();
+      interceptPerformanceRoutes();
+      cy.signInAsAdmin();
 
-describe("scenarios > admin > performance", { tags: "@OSS" }, () => {
-  beforeEach(() => {
-    restore();
-    cy.intercept("PUT", "/api/cache").as("putCacheConfig");
-    cy.intercept("DELETE", "/api/cache").as("deleteCacheConfig");
-    cy.intercept("POST", "/api/persist/enable").as("enablePersistence");
-    cy.intercept("POST", "/api/persist/disable").as("disablePersistence");
-    cy.signInAsAdmin();
-
-    cy.visit("/admin");
-    cy.findByRole("link", { name: "Performance" }).click();
-  });
-
-  it("can enable and disable model persistence", () => {
-    cy.findByRole("tab", { name: "Model persistence" }).click();
-    cy.findByRole("checkbox", { name: "Disabled" }).next("label").click();
-    cy.wait("@enablePersistence");
-    cy.findByTestId("toast-undo").contains("Saved");
-    cy.findByTestId("toast-undo")
-      .findByRole("img", { name: /close icon/ })
-      .click();
-
-    cy.findByRole("checkbox", { name: "Enabled" }).next("label").click();
-    cy.wait("@disablePersistence");
-    cy.findByTestId("toast-undo").contains("Saved");
-  });
-
-  it("can change when models are refreshed", () => {
-    cy.findByRole("tab", { name: "Model persistence" }).click();
-    cy.findByRole("checkbox", { name: "Disabled" }).next("label").click();
-    cy.wait("@enablePersistence");
-    cy.findByTestId("toast-undo").contains("Saved");
-    cy.findByTestId("toast-undo")
-      .findByRole("img", { name: /close icon/ })
-      .click();
-    cy.findByRole("combobox").click();
-    cy.findByRole("listbox").findByText("2 hours").click();
-    cy.findByTestId("toast-undo").contains("Saved");
-  });
-
-  it("there are two policy options for the default policy, Adaptive and Don't cache results", () => {
-    cacheStrategyForm().findAllByRole("radio").should("have.length", 2);
-    adaptiveRadioButton().should("exist");
-    dontCacheResultsRadioButton().should("exist");
-  });
-
-  it("can set default policy to Don't cache results", () => {
-    const model = "root";
-    cy.log("Set default policy to Adaptive first");
-    adaptiveRadioButton().click();
-    saveCacheStrategyForm({ strategyType: "ttl", model });
-    adaptiveRadioButton().should("be.checked");
-
-    cy.log("Then set default policy to Don't cache results");
-    dontCacheResultsRadioButton().click();
-    saveCacheStrategyForm({ strategyType: "nocache", model });
-    dontCacheResultsRadioButton().should("be.checked");
-  });
-
-  describe("adaptive strategy", () => {
-    it("can set default policy to adaptive", () => {
-      adaptiveRadioButton().click();
-      saveCacheStrategyForm({ strategyType: "ttl", model: "root" });
-      adaptiveRadioButton().should("be.checked");
+      cy.visit("/admin");
+      cy.findByRole("link", { name: "Performance" }).click();
     });
-
-    it("can configure a minimum query duration for the default adaptive policy", () => {
-      adaptiveRadioButton().click();
-      cy.findByLabelText(/Minimum query duration/).type("1000");
-      saveCacheStrategyForm({ strategyType: "ttl", model: "root" });
-      adaptiveRadioButton().should("be.checked");
-      cy.findByLabelText(/Minimum query duration/).should("have.value", "1000");
-    });
-
-    it("can configure a multiplier for the default adaptive policy", () => {
-      adaptiveRadioButton().click();
-      cy.findByLabelText(/Multiplier/).type("3");
-      saveCacheStrategyForm({ strategyType: "ttl", model: "root" });
-      adaptiveRadioButton().should("be.checked");
-      cy.findByLabelText(/Multiplier/).should("have.value", "3");
-    });
-
-    it("can configure both a minimum query duration and a multiplier for the default adaptive policy", () => {
-      adaptiveRadioButton().click();
-      cy.findByLabelText(/Minimum query duration/).type("1234");
-      cy.findByLabelText(/Multiplier/).type("4");
-      saveCacheStrategyForm({ strategyType: "ttl", model: "root" });
-      adaptiveRadioButton().should("be.checked");
-      cy.findByLabelText(/Minimum query duration/).should("have.value", "1234");
-      cy.findByLabelText(/Multiplier/).should("have.value", "4");
-    });
-  });
-});
-
-describeEE("EE", () => {
-  beforeEach(() => {
-    restore();
-    cy.intercept("PUT", "/api/cache").as("putCacheConfig");
-    cy.intercept("DELETE", "/api/cache").as("deleteCacheConfig");
-    cy.intercept(
-      "POST",
-      "/api/cache/invalidate?include=overrides&database=1",
-    ).as("invalidateCacheForSampleDatabase");
-    cy.intercept("POST", "/api/persist/enable").as("enablePersistence");
-    cy.intercept("POST", "/api/persist/disable").as("disablePersistence");
-    cy.signInAsAdmin();
-    setTokenFeatures("all");
-  });
-
-  const checkInheritanceIfNeeded = (itemName: string, strategyName: string) => {
-    if (itemName === "default policy") {
-      cy.log(
-        `Sample Database is now inheriting a default policy of ${strategyName}`,
+    it("has the right tabs", () => {
+      cy.findByRole("main")
+        .findByRole("tablist")
+        .findAllByRole("tab")
+        .should("have.length", 2);
+      cy.findByRole("tab", { name: "Database caching" }).should("be.visible");
+      cy.findByRole("tab", { name: "Model persistence" }).should("be.visible");
+      cy.findByRole("tab", { name: "Dashboard and question caching" }).should(
+        "not.exist",
       );
-      formLauncher(
-        "Sample Database",
-        "currently inheriting the default policy",
-        strategyName,
-      );
-    }
-  };
+    });
 
-  it("can call cache invalidation endpoint for Sample Database", () => {
-    openStrategyFormForDatabaseOrDefaultPolicy("default policy", "No caching");
-    cy.log('A "Clear cache" button is not present for the default policy');
-    cy.button(/Clear cache/).should("not.exist");
+    describe("model persistence tab", () => {
+      it("can enable and disable model persistence", () => {
+        cy.findByRole("tab", { name: "Model persistence" }).click();
+        cy.findByRole("checkbox", { name: "Disabled" }).next("label").click();
+        cy.wait("@enablePersistence");
+        cy.findByTestId("toast-undo").contains("Saved");
+        cy.findByTestId("toast-undo")
+          .findByRole("img", { name: /close icon/ })
+          .click();
 
-    openStrategyFormForDatabaseOrDefaultPolicy("Sample Database", "No caching");
-    cy.log(
-      'A "Clear cache" button is not yet present because the database does not use a cache',
-    );
-    cy.button(/Clear cache/).should("not.exist");
+        cy.findByRole("checkbox", { name: "Enabled" }).next("label").click();
+        cy.wait("@disablePersistence");
+        cy.findByTestId("toast-undo").contains("Saved");
+      });
 
-    cy.log("Set Sample Database's caching policy to Duration");
-    durationRadioButton().click();
+      it("can change when models are refreshed", () => {
+        cy.findByRole("tab", { name: "Model persistence" }).click();
+        cy.findByRole("checkbox", { name: "Disabled" }).next("label").click();
+        cy.wait("@enablePersistence");
+        cy.findByTestId("toast-undo").contains("Saved");
+        cy.findByTestId("toast-undo")
+          .findByRole("img", { name: /close icon/ })
+          .click();
+        cy.findByRole("combobox").click();
+        cy.findByRole("listbox").findByText("2 hours").click();
+        cy.findByTestId("toast-undo").contains("Saved");
+      });
+    });
 
-    cy.log("Save the caching strategy form");
-    saveCacheStrategyForm({ strategyType: "duration", model: "database" });
+    describe("database caching tab", () => {
+      it("there are two policy options for the default policy, Adaptive and Don't cache results", () => {
+        cacheStrategyForm().findAllByRole("radio").should("have.length", 2);
+        adaptiveRadioButton().should("exist");
+        dontCacheResultsRadioButton().should("exist");
+      });
 
-    cy.log("Now there's a 'Clear cache' button. Click it");
-    cy.button(/Clear cache/).click();
+      it("can set default policy to Don't cache results", () => {
+        const model = "root";
+        cy.log("Set default policy to Adaptive first");
+        adaptiveRadioButton().click();
+        saveCacheStrategyForm({ strategyType: "ttl", model });
+        adaptiveRadioButton().should("be.checked");
 
-    cy.log('Confirm via the "Clear cache" dialog');
-    cy.findByRole("dialog")
-      .button(/Clear cache/)
-      .click();
+        cy.log("Then set default policy to Don't cache results");
+        dontCacheResultsRadioButton().click();
+        saveCacheStrategyForm({ strategyType: "nocache", model });
+        dontCacheResultsRadioButton().should("be.checked");
+      });
 
-    cy.wait("@invalidateCacheForSampleDatabase");
+      describe("adaptive strategy", () => {
+        it("can set default policy to adaptive", () => {
+          adaptiveRadioButton().click();
+          saveCacheStrategyForm({ strategyType: "ttl", model: "root" });
+          adaptiveRadioButton().should("be.checked");
+        });
 
-    cy.log("The cache has been cleared");
-    cy.button(/Cache cleared/);
+        it("can configure a minimum query duration for the default adaptive policy", () => {
+          adaptiveRadioButton().click();
+          cy.findByLabelText(/Minimum query duration/).type("1000");
+          saveCacheStrategyForm({ strategyType: "ttl", model: "root" });
+          adaptiveRadioButton().should("be.checked");
+          cy.findByLabelText(/Minimum query duration/).should(
+            "have.value",
+            "1000",
+          );
+        });
+
+        it("can configure a multiplier for the default adaptive policy", () => {
+          adaptiveRadioButton().click();
+          cy.findByLabelText(/Multiplier/).type("3");
+          saveCacheStrategyForm({ strategyType: "ttl", model: "root" });
+          adaptiveRadioButton().should("be.checked");
+          cy.findByLabelText(/Multiplier/).should("have.value", "3");
+        });
+
+        it("can configure both a minimum query duration and a multiplier for the default adaptive policy", () => {
+          adaptiveRadioButton().click();
+          cy.findByLabelText(/Minimum query duration/).type("1234");
+          cy.findByLabelText(/Multiplier/).type("4");
+          saveCacheStrategyForm({ strategyType: "ttl", model: "root" });
+          adaptiveRadioButton().should("be.checked");
+          cy.findByLabelText(/Minimum query duration/).should(
+            "have.value",
+            "1234",
+          );
+          cy.findByLabelText(/Multiplier/).should("have.value", "4");
+        });
+      });
+    });
   });
 
-  [/Duration/, /Schedule/, /Adaptive/].forEach(strategy => {
-    const strategyAsString = strategy.toString().replace(/\//g, "");
-    it(`can configure Sample Database to use a default policy of ${strategyAsString}`, () => {
-      cy.log(`Set default policy to ${strategy}`);
+  describeEE("ee", () => {
+    beforeEach(() => {
+      restore();
+      interceptPerformanceRoutes();
+      cy.signInAsAdmin();
+      setTokenFeatures("all");
+    });
+
+    const checkInheritanceIfNeeded = (
+      itemName: string,
+      strategyName: string,
+    ) => {
+      if (itemName === "default policy") {
+        cy.log(
+          `Sample Database is now inheriting a default policy of ${strategyName}`,
+        );
+        formLauncher(
+          "Sample Database",
+          "currently inheriting the default policy",
+          strategyName,
+        );
+      }
+    };
+
+    it("has the right tabs", () => {
+      cy.visit("/admin");
+      cy.findByRole("link", { name: "Performance" }).click();
+      cy.findByRole("main")
+        .findByRole("tablist")
+        .findAllByRole("tab")
+        .should("have.length", 3);
+      cy.findByRole("tab", { name: "Database caching" }).should("be.visible");
+      cy.findByRole("tab", { name: "Dashboard and question caching" }).should(
+        "be.visible",
+      );
+      cy.findByRole("tab", { name: "Model persistence" }).should("be.visible");
+    });
+
+    it("can call cache invalidation endpoint for Sample Database", () => {
       openStrategyFormForDatabaseOrDefaultPolicy(
         "default policy",
         "No caching",
       );
-      cacheStrategyRadioButton(strategy).click();
-      saveCacheStrategyForm();
+      cy.log('A "Clear cache" button is not present for the default policy');
+      cy.button(/Clear cache/).should("not.exist");
 
-      cy.log("Open strategy form for Sample Database");
       openStrategyFormForDatabaseOrDefaultPolicy(
         "Sample Database",
-        strategyAsString,
+        "No caching",
       );
+      cy.log(
+        'A "Clear cache" button is not yet present because the database does not use a cache',
+      );
+      cy.button(/Clear cache/).should("not.exist");
 
-      cy.log("Set Sample Database to Duration first");
+      cy.log("Set Sample Database's caching policy to Duration");
       durationRadioButton().click();
+
+      cy.log("Save the caching strategy form");
       saveCacheStrategyForm({ strategyType: "duration", model: "database" });
-      formLauncher("Sample Database", "currently", "Duration");
 
-      cy.log("Then configure Sample Database to use the default policy");
-      useDefaultRadioButton().click();
-      saveCacheStrategyForm({ strategyType: "inherit", model: "database" });
-      formLauncher("Sample Database", "currently inheriting", strategyAsString);
-    });
-  });
+      cy.log("Now there's a 'Clear cache' button. Click it");
+      cy.button(/Clear cache/).click();
 
-  ["default policy", "Sample Database"].forEach(itemName => {
-    const model = itemName === "default policy" ? "root" : "database";
-    const expectedNumberOfOptions = itemName === "default policy" ? 4 : 5;
-    it(`there are ${expectedNumberOfOptions} policy options for ${itemName}`, () => {
-      openStrategyFormForDatabaseOrDefaultPolicy(itemName, "No caching");
-      cacheStrategyForm()
-        .findAllByRole("radio")
-        .should("have.length", expectedNumberOfOptions);
+      cy.log('Confirm via the "Clear cache" dialog');
+      cy.findByRole("dialog")
+        .button(/Clear cache/)
+        .click();
+
+      cy.wait("@invalidateCacheForSampleDatabase");
+
+      cy.log("The cache has been cleared");
+      cy.button(/Cache cleared/);
     });
 
-    it(`can set ${itemName} to Don't cache results`, () => {
-      openStrategyFormForDatabaseOrDefaultPolicy(itemName, "No caching");
-      cy.log(`Set ${itemName} to Duration first`);
-      durationRadioButton().click();
-      saveCacheStrategyForm({ strategyType: "duration", model });
-      formLauncher(itemName, "currently", "Duration");
-
-      cy.log(`Then set ${itemName} to Don't cache results`);
-      dontCacheResultsRadioButton().click();
-      saveCacheStrategyForm({ strategyType: "nocache", model });
-      formLauncher(itemName, "currently", "No caching");
-      checkInheritanceIfNeeded(itemName, "No caching");
-    });
-
-    it(`can set ${itemName} to a duration-based cache invalidation policy`, () => {
-      openStrategyFormForDatabaseOrDefaultPolicy(itemName, "No caching");
-      cy.log(`Set ${itemName} to Duration`);
-      durationRadioButton().click();
-      saveCacheStrategyForm({ strategyType: "duration", model });
-      cy.log(`${itemName} is now set to Duration`);
-      formLauncher(itemName, "currently", "Duration");
-      checkInheritanceIfNeeded(itemName, "Duration");
-    });
-
-    describe("adaptive strategy", () => {
-      beforeEach(() => {
-        openStrategyFormForDatabaseOrDefaultPolicy(itemName, "No caching");
-        adaptiveRadioButton().click();
-      });
-
-      it(`can set ${itemName} to adaptive`, () => {
-        saveCacheStrategyForm({ strategyType: "ttl", model });
-        formLauncher(itemName, "currently", "Adaptive");
-        checkInheritanceIfNeeded(itemName, "Adaptive");
-      });
-
-      it(`can configure a minimum query duration for ${itemName}'s adaptive policy`, () => {
-        cy.findByLabelText(/Minimum query duration/).type("1000");
-        saveCacheStrategyForm({ strategyType: "ttl", model });
-        formLauncher(itemName, "currently", "Adaptive");
-        cy.findByLabelText(/Minimum query duration/).should(
-          "have.value",
-          "1000",
-        );
-      });
-
-      it(`can configure a multiplier for ${itemName}'s adaptive policy`, () => {
-        cy.findByLabelText(/Multiplier/).type("3");
-        saveCacheStrategyForm({ strategyType: "ttl", model });
-        formLauncher(itemName, "currently", "Adaptive");
-        cy.findByLabelText(/Multiplier/).should("have.value", "3");
-      });
-
-      it(`can configure both a minimum query duration and a multiplier for ${itemName}'s adaptive policy`, () => {
-        cy.findByLabelText(/Minimum query duration/).type("1234");
-        cy.findByLabelText(/Multiplier/).type("4");
-        saveCacheStrategyForm({ strategyType: "ttl", model });
-        formLauncher(itemName, "currently", "Adaptive");
-        cy.findByLabelText(/Minimum query duration/).should(
-          "have.value",
-          "1234",
-        );
-        cy.findByLabelText(/Multiplier/).should("have.value", "4");
-      });
-    });
-
-    describe(`can set ${itemName} to a schedule-based cache invalidation policy`, () => {
-      beforeEach(() => {
-        cy.visit("/admin");
-        cy.findByRole("link", { name: "Performance" }).click();
-        cy.log(`Open caching strategy form for ${itemName}`);
-        formLauncher(
-          itemName,
-          itemName === "default policy"
-            ? "currently"
-            : "currently inheriting the default policy",
+    [/Duration/, /Schedule/, /Adaptive/].forEach(strategy => {
+      const strategyAsString = strategy.toString().replace(/\//g, "");
+      it(`can configure Sample Database to use a default policy of ${strategyAsString}`, () => {
+        cy.log(`Set default policy to ${strategy}`);
+        openStrategyFormForDatabaseOrDefaultPolicy(
+          "default policy",
           "No caching",
-        ).click();
-        cy.log("View schedule options");
-        scheduleRadioButton().click();
+        );
+        cacheStrategyRadioButton(strategy).click();
+        saveCacheStrategyForm();
+
+        cy.log("Open strategy form for Sample Database");
+        openStrategyFormForDatabaseOrDefaultPolicy(
+          "Sample Database",
+          strategyAsString,
+        );
+
+        cy.log("Set Sample Database to Duration first");
+        durationRadioButton().click();
+        saveCacheStrategyForm({ strategyType: "duration", model: "database" });
+        formLauncher("Sample Database", "currently", "Duration");
+
+        cy.log("Then configure Sample Database to use the default policy");
+        useDefaultRadioButton().click();
+        saveCacheStrategyForm({ strategyType: "inherit", model: "database" });
+        formLauncher(
+          "Sample Database",
+          "currently inheriting",
+          strategyAsString,
+        );
+      });
+    });
+
+    ["default policy", "Sample Database"].forEach(itemName => {
+      const model = itemName === "default policy" ? "root" : "database";
+      const expectedNumberOfOptions = itemName === "default policy" ? 4 : 5;
+      it(`there are ${expectedNumberOfOptions} policy options for ${itemName}`, () => {
+        openStrategyFormForDatabaseOrDefaultPolicy(itemName, "No caching");
+        cacheStrategyForm()
+          .findAllByRole("radio")
+          .should("have.length", expectedNumberOfOptions);
       });
 
-      const selectScheduleType = (type: string) => {
-        cy.log(`Set schedule to "${type}"`);
-        cy.findByRole("searchbox").click();
-        cy.findByRole("listbox").findByText(type).click();
-      };
+      it(`can set ${itemName} to Don't cache results`, () => {
+        openStrategyFormForDatabaseOrDefaultPolicy(itemName, "No caching");
+        cy.log(`Set ${itemName} to Duration first`);
+        durationRadioButton().click();
+        saveCacheStrategyForm({ strategyType: "duration", model });
+        formLauncher(itemName, "currently", "Duration");
 
-      it(`can save a new hourly schedule policy for ${itemName}`, () => {
-        selectScheduleType("hourly");
-        saveCacheStrategyForm({ strategyType: "schedule", model });
-        formLauncher(itemName, "currently", "Scheduled: hourly");
+        cy.log(`Then set ${itemName} to Don't cache results`);
+        dontCacheResultsRadioButton().click();
+        saveCacheStrategyForm({ strategyType: "nocache", model });
+        formLauncher(itemName, "currently", "No caching");
+        checkInheritanceIfNeeded(itemName, "No caching");
       });
 
-      it(`can save a new daily schedule policy - for ${itemName}`, () => {
-        [12, 1, 11].forEach(time => {
-          ["AM", "PM"].forEach(amPm => {
-            cy.log(`Test daily at ${time} ${amPm}`);
-            selectScheduleType("daily");
+      it(`can set ${itemName} to a duration-based cache invalidation policy`, () => {
+        openStrategyFormForDatabaseOrDefaultPolicy(itemName, "No caching");
+        cy.log(`Set ${itemName} to Duration`);
+        durationRadioButton().click();
+        saveCacheStrategyForm({ strategyType: "duration", model });
+        cy.log(`${itemName} is now set to Duration`);
+        formLauncher(itemName, "currently", "Duration");
+        checkInheritanceIfNeeded(itemName, "Duration");
+      });
+
+      describe("adaptive strategy", () => {
+        beforeEach(() => {
+          openStrategyFormForDatabaseOrDefaultPolicy(itemName, "No caching");
+          adaptiveRadioButton().click();
+        });
+
+        it(`can set ${itemName} to adaptive`, () => {
+          saveCacheStrategyForm({ strategyType: "ttl", model });
+          formLauncher(itemName, "currently", "Adaptive");
+          checkInheritanceIfNeeded(itemName, "Adaptive");
+        });
+
+        it(`can configure a minimum query duration for ${itemName}'s adaptive policy`, () => {
+          cy.findByLabelText(/Minimum query duration/).type("1000");
+          saveCacheStrategyForm({ strategyType: "ttl", model });
+          formLauncher(itemName, "currently", "Adaptive");
+          cy.findByLabelText(/Minimum query duration/).should(
+            "have.value",
+            "1000",
+          );
+        });
+
+        it(`can configure a multiplier for ${itemName}'s adaptive policy`, () => {
+          cy.findByLabelText(/Multiplier/).type("3");
+          saveCacheStrategyForm({ strategyType: "ttl", model });
+          formLauncher(itemName, "currently", "Adaptive");
+          cy.findByLabelText(/Multiplier/).should("have.value", "3");
+        });
+
+        it(`can configure both a minimum query duration and a multiplier for ${itemName}'s adaptive policy`, () => {
+          cy.findByLabelText(/Minimum query duration/).type("1234");
+          cy.findByLabelText(/Multiplier/).type("4");
+          saveCacheStrategyForm({ strategyType: "ttl", model });
+          formLauncher(itemName, "currently", "Adaptive");
+          cy.findByLabelText(/Minimum query duration/).should(
+            "have.value",
+            "1234",
+          );
+          cy.findByLabelText(/Multiplier/).should("have.value", "4");
+        });
+      });
+
+      describe(`can set ${itemName} to a schedule-based cache invalidation policy`, () => {
+        beforeEach(() => {
+          cy.visit("/admin");
+          cy.findByRole("link", { name: "Performance" }).click();
+          cy.log(`Open caching strategy form for ${itemName}`);
+          formLauncher(
+            itemName,
+            itemName === "default policy"
+              ? "currently"
+              : "currently inheriting the default policy",
+            "No caching",
+          ).click();
+          cy.log("View schedule options");
+          scheduleRadioButton().click();
+        });
+
+        const selectScheduleType = (type: string) => {
+          cy.log(`Set schedule to "${type}"`);
+          cy.findByRole("searchbox").click();
+          cy.findByRole("listbox").findByText(type).click();
+        };
+
+        it(`can save a new hourly schedule policy for ${itemName}`, () => {
+          selectScheduleType("hourly");
+          saveCacheStrategyForm({ strategyType: "schedule", model });
+          formLauncher(itemName, "currently", "Scheduled: hourly");
+        });
+
+        it(`can save a new daily schedule policy - for ${itemName}`, () => {
+          [12, 1, 11].forEach(time => {
+            ["AM", "PM"].forEach(amPm => {
+              cy.log(`Test daily at ${time} ${amPm}`);
+              selectScheduleType("daily");
+              cy.findAllByRole("searchbox").eq(1).click();
+              cy.findByRole("listbox").findByText(`${time}:00`).click();
+              cy.findByLabelText(amPm).next().click();
+              saveCacheStrategyForm({ strategyType: "schedule", model });
+              formLauncher("Sample Database", "currently", "Scheduled: daily");
+
+              // reset for next iteration of loop
+              dontCacheResultsRadioButton().click();
+              saveCacheStrategyForm({ strategyType: "nocache", model });
+              scheduleRadioButton().click();
+            });
+          });
+        });
+
+        it(`can save a new weekly schedule policy - for ${itemName}`, () => {
+          [
+            ["Sunday", "12:00 AM"],
+            ["Monday", "1:00 AM"],
+            ["Tuesday", "11:00 AM"],
+            ["Wednesday", "12:00 PM"],
+            ["Thursday", "1:00 PM"],
+            ["Friday", "7:00 PM"],
+            ["Saturday", "11:00 PM"],
+          ].forEach(([day, time]) => {
+            cy.log(`testing on ${day} at ${time}`);
+            selectScheduleType("weekly");
             cy.findAllByRole("searchbox").eq(1).click();
-            cy.findByRole("listbox").findByText(`${time}:00`).click();
+            cy.findByRole("listbox").findByText(day).click();
+            cy.findAllByRole("searchbox").eq(2).click();
+            const [hour, amPm] = time.split(" ");
+            cy.findByRole("listbox").findByText(hour).click();
             cy.findByLabelText(amPm).next().click();
             saveCacheStrategyForm({ strategyType: "schedule", model });
-            formLauncher("Sample Database", "currently", "Scheduled: daily");
+            formLauncher(itemName, "currently", "Scheduled: weekly");
+            cy.findAllByRole("searchbox").then(searchBoxes => {
+              const values = Cypress._.map(
+                searchBoxes,
+                box => (box as HTMLInputElement).value,
+              );
+              expect(values).to.deep.equal(["weekly", day, hour]);
+            });
+            cy.findByRole("radio", { name: amPm }).should("be.checked");
 
             // reset for next iteration of loop
             dontCacheResultsRadioButton().click();
@@ -320,41 +409,95 @@ describeEE("EE", () => {
           });
         });
       });
+    });
 
-      it(`can save a new weekly schedule policy - for ${itemName}`, () => {
-        [
-          ["Sunday", "12:00 AM"],
-          ["Monday", "1:00 AM"],
-          ["Tuesday", "11:00 AM"],
-          ["Wednesday", "12:00 PM"],
-          ["Thursday", "1:00 PM"],
-          ["Friday", "7:00 PM"],
-          ["Saturday", "11:00 PM"],
-        ].forEach(([day, time]) => {
-          cy.log(`testing on ${day} at ${time}`);
-          selectScheduleType("weekly");
-          cy.findAllByRole("searchbox").eq(1).click();
-          cy.findByRole("listbox").findByText(day).click();
-          cy.findAllByRole("searchbox").eq(2).click();
-          const [hour, amPm] = time.split(" ");
-          cy.findByRole("listbox").findByText(hour).click();
-          cy.findByLabelText(amPm).next().click();
-          saveCacheStrategyForm({ strategyType: "schedule", model });
-          formLauncher(itemName, "currently", "Scheduled: weekly");
-          cy.findAllByRole("searchbox").then(searchBoxes => {
-            const values = Cypress._.map(
-              searchBoxes,
-              box => (box as HTMLInputElement).value,
-            );
-            expect(values).to.deep.equal(["weekly", day, hour]);
+    describe("Dashboard and question caching tab", () => {
+      it("can configure Sample Database on the 'Dashboard and question caching' tab", () => {
+        interceptPerformanceRoutes();
+        visitDashboardAndQuestionCachingTab();
+        const table = () =>
+          cy.findByRole("table", {
+            name: /Here are the dashboards and questions/,
           });
-          cy.findByRole("radio", { name: amPm }).should("be.checked");
+        table()
+          .should("be.visible")
+          .contains(
+            "No dashboards or questions have their own caching policies yet.",
+          );
+        visitQuestion(ORDERS_QUESTION_ID);
+        openSidebarCacheStrategyForm();
+        durationRadioButton().click();
+        cy.findByLabelText(/Cache results for this many hours/).type("99");
+        saveCacheStrategyForm({ strategyType: "duration", model: "database" });
+        visitDashboardAndQuestionCachingTab();
+        table()
+          .contains("Duration: 99h")
+          .within(() => {
+            cy.findByText("Duration: 99h").click();
+          });
+        adaptiveRadioButton().click();
+        saveCacheStrategyForm({ strategyType: "ttl", model: "database" });
+      });
 
-          // reset for next iteration of loop
-          dontCacheResultsRadioButton().click();
-          saveCacheStrategyForm({ strategyType: "nocache", model });
-          scheduleRadioButton().click();
+      it("confirmation modal appears before dirty form is abandoned", () => {
+        interceptPerformanceRoutes();
+        visitDashboardAndQuestionCachingTab();
+        const table = () =>
+          cy.findByRole("table", {
+            name: /Here are the dashboards and questions/,
+          });
+        table()
+          .should("be.visible")
+          .contains(
+            "No dashboards or questions have their own caching policies yet.",
+          );
+        visitQuestion(ORDERS_QUESTION_ID);
+        openSidebarCacheStrategyForm();
+        durationRadioButton().click();
+        cy.findByLabelText(/Cache results for this many hours/).type("99");
+        saveCacheStrategyForm({ strategyType: "duration", model: "database" });
+        visitDashboardAndQuestionCachingTab();
+        table()
+          .contains("Duration: 99h")
+          .within(() => {
+            cy.findByText("Duration: 99h").click();
+          });
+        adaptiveRadioButton().click();
+        saveCacheStrategyForm({ strategyType: "ttl", model: "database" });
+
+        visitQuestion(ORDERS_COUNT_QUESTION_ID);
+        openSidebarCacheStrategyForm();
+        durationRadioButton().click();
+        cy.findByLabelText(/Cache results for this many hours/).type("24");
+        saveCacheStrategyForm({ strategyType: "duration", model: "database" });
+        visitDashboardAndQuestionCachingTab();
+        table().contains("Adaptive");
+        table()
+          .contains("Duration: 24h")
+          .within(() => {
+            cy.findByText("Duration: 24h").click();
+          });
+
+        cy.log("Make form dirty");
+        scheduleRadioButton().click();
+
+        cy.log("Modal appears when another row's form launcher is clicked");
+        table()
+          .contains("Adaptive")
+          .within(() => {
+            cy.findByText("Adaptive").click();
+          });
+        cancelConfirmationModal();
+
+        cy.log("Modal appears when another admin nav item is clicked");
+        cy.findByLabelText("Navigation bar").within(() => {
+          cy.findByText("Settings").click();
         });
+        cancelConfirmationModal();
+
+        cy.log("Modal appears when another Performance tab is clicked");
+        cy.findByRole("tab", { name: "Database caching" }).click();
+        cancelConfirmationModal();
       });
     });
   });

--- a/e2e/test/scenarios/admin/performance/schedule.cy.spec.ts
+++ b/e2e/test/scenarios/admin/performance/schedule.cy.spec.ts
@@ -9,7 +9,7 @@ import {
 import type { ScheduleComponentType } from "metabase/components/Schedule/constants";
 import type { CacheableModel } from "metabase-types/api";
 
-import { interceptRoutes } from "./helpers/e2e-performance-helpers";
+import { interceptPerformanceRoutes } from "./helpers/e2e-performance-helpers";
 import {
   cacheStrategyForm,
   getScheduleComponent,
@@ -26,7 +26,7 @@ import {
 describeEE("scenarios > admin > performance > schedule strategy", () => {
   beforeEach(() => {
     restore();
-    interceptRoutes();
+    interceptPerformanceRoutes();
     cy.signInAsAdmin();
     setTokenFeatures("all");
   });

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -58,7 +58,7 @@ import {
   createMockVirtualDashCard,
 } from "metabase-types/api/mocks";
 
-import { interceptRoutes as interceptPerformanceRoutes } from "../admin/performance/helpers/e2e-performance-helpers";
+import { interceptPerformanceRoutes } from "../admin/performance/helpers/e2e-performance-helpers";
 import {
   adaptiveRadioButton,
   durationRadioButton,

--- a/e2e/test/scenarios/question/caching.cy.spec.js
+++ b/e2e/test/scenarios/question/caching.cy.spec.js
@@ -7,7 +7,7 @@ import {
   visitQuestion,
 } from "e2e/support/helpers";
 
-import { interceptRoutes as interceptPerformanceRoutes } from "../admin/performance/helpers/e2e-performance-helpers";
+import { interceptPerformanceRoutes } from "../admin/performance/helpers/e2e-performance-helpers";
 import {
   adaptiveRadioButton,
   durationRadioButton,

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/DashboardAndQuestionCachingTab.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/DashboardAndQuestionCachingTab.tsx
@@ -1,0 +1,16 @@
+import P from "metabase/admin/performance/components/PerformanceApp.module.css";
+import { PerformanceTabId } from "metabase/admin/performance/types";
+import { getPerformanceTabName } from "metabase/admin/performance/utils";
+import { Tabs } from "metabase/ui";
+
+export const DashboardAndQuestionCachingTab = () => {
+  return (
+    <Tabs.Tab
+      className={P.Tab}
+      key="DashboardAndQuestionCaching"
+      value={PerformanceTabId.DashboardsAndQuestions}
+    >
+      {getPerformanceTabName(PerformanceTabId.DashboardsAndQuestions)}
+    </Tabs.Tab>
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.module.css
@@ -20,6 +20,10 @@
   tbody > tr:hover {
     background-color: var(--mb-color-brand-alpha-04) !important;
   }
+
+  tbody > tr.currentTarget {
+    background-color: var(--mb-color-brand-lighter) !important;
+  }
 }
 
 .StrategyFormPanel {

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.module.css
@@ -1,0 +1,37 @@
+.NoResultsTableRow,
+.SkeletonTableRow {
+  &:hover {
+    background-color: transparent !important;
+  }
+}
+
+.SkeletonTableRow {
+  height: 3rem;
+}
+
+.CacheableItemTable {
+  table-layout: fixed;
+  background-color: var(--mb-color-text-white);
+
+  td {
+    padding: 0.75rem;
+  }
+
+  tbody > tr:hover {
+    background-color: var(--mb-color-brand-alpha-04) !important;
+  }
+}
+
+.StrategyFormPanel {
+  border-left: 1px solid var(--mb-color-border);
+  position: relative;
+  max-width: 30rem;
+
+  @media screen and (--breakpoint-max-lg) {
+    max-width: 25rem;
+  }
+}
+
+.ItemLink {
+  font-size: inherit !important;
+}

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.module.css
@@ -14,7 +14,7 @@
   background-color: var(--mb-color-text-white);
 
   td {
-    padding: 0.75rem;
+    padding: 0.75rem !important;
   }
 
   tbody > tr:hover {

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.module.css
@@ -7,11 +7,18 @@
 
 .SkeletonTableRow {
   height: 3rem;
+  td {
+    width: 20rem;
+  }
 }
 
 .CacheableItemTable {
   table-layout: fixed;
   background-color: var(--mb-color-text-white);
+
+  col {
+    width: 30%;
+  }
 
   td {
     padding: 0.75rem !important;

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.module.css
@@ -7,6 +7,7 @@
 
 .SkeletonTableRow {
   height: 3rem;
+
   td {
     width: 20rem;
   }
@@ -45,4 +46,15 @@
 
 .ItemLink {
   font-size: inherit !important;
+
+  &:hover {
+    color: var(--mb-color-brand);
+  }
+}
+
+.ItemLink,
+.CollectionLink {
+  :hover {
+    color: var(--mb-color-brand);
+  }
 }

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.tsx
@@ -29,7 +29,7 @@ import type {
   UpdateTarget,
 } from "../types";
 
-import C from "./StrategyEditorForQuestionsAndDashboards.module.css";
+import StrategyEditorForQuestionsAndDashboardsC from "./StrategyEditorForQuestionsAndDashboards.module.css";
 import { TableRowForCacheableItem } from "./TableRowForCacheableItem";
 import { getConstants } from "./constants";
 import { formatValueForSorting } from "./utils";
@@ -86,6 +86,7 @@ const _StrategyEditorForQuestionsAndDashboards = ({
       ? {
           models: ["dashboard"],
           ids: dashboardIds,
+          ancestors: true,
         }
       : skipToken,
   );
@@ -276,7 +277,9 @@ const _StrategyEditorForQuestionsAndDashboards = ({
           >
             <Flex align="flex-start">
               <ClientSortableTable<CacheableItem>
-                className={C.CacheableItemTable}
+                className={
+                  StrategyEditorForQuestionsAndDashboardsC.CacheableItemTable
+                }
                 columns={tableColumns}
                 rows={cacheableItems}
                 rowRenderer={rowRenderer}
@@ -300,7 +303,9 @@ const _StrategyEditorForQuestionsAndDashboards = ({
       </Stack>
 
       {targetId !== null && targetModel !== null && (
-        <Panel className={C.StrategyFormPanel}>
+        <Panel
+          className={StrategyEditorForQuestionsAndDashboardsC.StrategyFormPanel}
+        >
           <Button
             variant="subtle"
             pos="absolute"
@@ -340,7 +345,7 @@ const TableSkeleton = ({ columns }: { columns: ColumnItem[] }) => (
     columns={columns}
     rows={[{ id: 0 }, { id: 1 }, { id: 2 }]}
     rowRenderer={() => (
-      <tr className={C.SkeletonTableRow}>
+      <tr className={StrategyEditorForQuestionsAndDashboardsC.SkeletonTableRow}>
         <Repeat times={3}>
           <td style={{ width: "20rem" }}>
             <Skeleton h="1rem" natural />
@@ -348,12 +353,12 @@ const TableSkeleton = ({ columns }: { columns: ColumnItem[] }) => (
         </Repeat>
       </tr>
     )}
-    className={C.CacheableItemTable}
+    className={StrategyEditorForQuestionsAndDashboardsC.CacheableItemTable}
   />
 );
 
 const NoResultsTableRow = () => (
-  <tr className={C.NoResultsTableRow}>
+  <tr className={StrategyEditorForQuestionsAndDashboardsC.NoResultsTableRow}>
     <td colSpan={3}>
       <Center fw="bold" c="text-light">
         {t`No dashboards or questions have their own caching policies yet.`}

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.tsx
@@ -37,7 +37,7 @@ import type {
   UpdateTarget,
 } from "../types";
 
-import StrategyEditorForQuestionsAndDashboardsC from "./StrategyEditorForQuestionsAndDashboards.module.css";
+import Styles from "./StrategyEditorForQuestionsAndDashboards.module.css";
 import { TableRowForCacheableItem } from "./TableRowForCacheableItem";
 import { getConstants } from "./constants";
 import { formatValueForSorting } from "./utils";
@@ -286,9 +286,7 @@ const _StrategyEditorForQuestionsAndDashboards = ({
           >
             <Flex align="flex-start">
               <ClientSortableTable<CacheableItem>
-                className={
-                  StrategyEditorForQuestionsAndDashboardsC.CacheableItemTable
-                }
+                className={Styles.CacheableItemTable}
                 columns={tableColumns}
                 rows={cacheableItems}
                 rowRenderer={rowRenderer}
@@ -312,9 +310,7 @@ const _StrategyEditorForQuestionsAndDashboards = ({
       </Stack>
 
       {targetId !== null && targetModel !== null && (
-        <Panel
-          className={StrategyEditorForQuestionsAndDashboardsC.StrategyFormPanel}
-        >
+        <Panel className={Styles.StrategyFormPanel}>
           <Button
             variant="subtle"
             pos="absolute"
@@ -354,7 +350,7 @@ const TableSkeleton = ({ columns }: { columns: ColumnItem[] }) => (
     columns={columns}
     rows={[{ id: 0 }, { id: 1 }, { id: 2 }]}
     rowRenderer={() => (
-      <tr className={StrategyEditorForQuestionsAndDashboardsC.SkeletonTableRow}>
+      <tr className={Styles.SkeletonTableRow}>
         <Repeat times={3}>
           <td>
             <Skeleton h="1rem" natural />
@@ -362,13 +358,13 @@ const TableSkeleton = ({ columns }: { columns: ColumnItem[] }) => (
         </Repeat>
       </tr>
     )}
-    className={StrategyEditorForQuestionsAndDashboardsC.CacheableItemTable}
+    className={Styles.CacheableItemTable}
     locale="en-US"
   />
 );
 
 const NoResultsTableRow = () => (
-  <tr className={StrategyEditorForQuestionsAndDashboardsC.NoResultsTableRow}>
+  <tr className={Styles.NoResultsTableRow}>
     <td colSpan={3}>
       <Center fw="bold" c="text-light">
         {t`No dashboards or questions have their own caching policies yet.`}

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.tsx
@@ -94,7 +94,7 @@ const _StrategyEditorForQuestionsAndDashboards = ({
       ? {
           models: ["dashboard"],
           ids: dashboardIds,
-          ancestors: true,
+          //FIXME: Add `ancestors: true` once jds/ancestors-for-all-the-things is merged
         }
       : skipToken,
   );
@@ -103,6 +103,7 @@ const _StrategyEditorForQuestionsAndDashboards = ({
       ? {
           models: ["card"],
           ids: questionIds,
+          //FIXME: Add `ancestors: true` once jds/ancestors-for-all-the-things is merged
         }
       : skipToken,
   );

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.tsx
@@ -1,0 +1,363 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { InjectedRouter, Route } from "react-router";
+import { withRouter } from "react-router";
+import { t } from "ttag";
+import _ from "underscore";
+
+import { Panel } from "metabase/admin/performance/components/StrategyEditorForDatabases.styled";
+import { StrategyForm } from "metabase/admin/performance/components/StrategyForm";
+import { rootId } from "metabase/admin/performance/constants/simple";
+import { useCacheConfigs } from "metabase/admin/performance/hooks/useCacheConfigs";
+import { useConfirmIfFormIsDirty } from "metabase/admin/performance/hooks/useConfirmIfFormIsDirty";
+import { useSaveStrategy } from "metabase/admin/performance/hooks/useSaveStrategy";
+import { skipToken, useSearchQuery } from "metabase/api";
+import { Table } from "metabase/common/components/Table";
+import { ClientSortableTable } from "metabase/common/components/Table/ClientSortableTable";
+import type { ColumnItem } from "metabase/common/components/Table/types";
+import { useLocale } from "metabase/common/hooks/use-locale/use-locale";
+import { DelayedLoadingAndErrorWrapper } from "metabase/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
+import { Button, Center, Flex, Icon, Skeleton, Stack, Text } from "metabase/ui";
+import { Repeat } from "metabase/ui/components/feedback/Skeleton/Repeat";
+import type { CacheableModel } from "metabase-types/api";
+import { CacheDurationUnit } from "metabase-types/api";
+import { SortDirection } from "metabase-types/api/sorting";
+
+import type {
+  CacheableItem,
+  DashboardResult,
+  QuestionResult,
+  UpdateTarget,
+} from "../types";
+
+import C from "./StrategyEditorForQuestionsAndDashboards.module.css";
+import { TableRowForCacheableItem } from "./TableRowForCacheableItem";
+import { getConstants } from "./constants";
+import { formatValueForSorting } from "./utils";
+
+type CacheableItemResult = DashboardResult | QuestionResult;
+
+const _StrategyEditorForQuestionsAndDashboards = ({
+  router,
+  route,
+}: {
+  router: InjectedRouter;
+  route?: Route;
+}) => {
+  const [
+    // The targetId is the id of the object that is currently being edited
+    targetId,
+    setTargetId,
+  ] = useState<number | null>(null);
+
+  const { tableColumns } = useMemo(() => getConstants(), []);
+
+  const [targetModel, setTargetModel] = useState<CacheableModel | null>(null);
+
+  const configurableModels: CacheableModel[] = useMemo(
+    () => ["dashboard", "question"],
+    [],
+  );
+
+  const {
+    configs,
+    setConfigs,
+    error: configsError,
+    loading: configsAreLoading,
+  } = useCacheConfigs({ configurableModels });
+
+  const dashboardIds = useMemo(
+    () =>
+      configs
+        .filter(config => config.model === "dashboard")
+        .map(c => c.model_id),
+    [configs],
+  );
+
+  const questionIds = useMemo(
+    () =>
+      configs
+        .filter(config => config.model === "question")
+        .map(c => c.model_id),
+    [configs],
+  );
+
+  const dashboardsResult = useSearchQuery(
+    dashboardIds.length
+      ? {
+          models: ["dashboard"],
+          ids: dashboardIds,
+        }
+      : skipToken,
+  );
+  const questionsResult = useSearchQuery(
+    questionIds.length
+      ? {
+          models: ["card"],
+          ids: questionIds,
+        }
+      : skipToken,
+  );
+
+  const dashboardsAndQuestions = useMemo(
+    () =>
+      (dashboardsResult.data?.data || []).concat(
+        questionsResult.data?.data || [],
+      ) as CacheableItemResult[],
+    [dashboardsResult.data, questionsResult.data],
+  );
+
+  const cacheableItems = useMemo(() => {
+    const items = new Map<string, CacheableItem>();
+    for (const config of configs) {
+      items.set(`${config.model}${config.model_id}`, {
+        ..._.omit(config, "model_id"),
+        id: config.model_id,
+      });
+    }
+
+    // Hydrate data from the search results into the cacheable items
+    for (const result of dashboardsAndQuestions ?? []) {
+      const normalizedModel =
+        result.model === "card" ? "question" : result.model;
+      const item = items.get(`${normalizedModel}${result.id}`);
+      if (item) {
+        item.name = result.name;
+        item.collection = result.collection;
+        item.iconModel = result.model;
+      }
+    }
+    // Filter out items that have no match in the dashboard and question list
+    const hydratedCacheableItems: CacheableItem[] = [...items.values()].filter(
+      item => item.name !== undefined,
+    );
+
+    return hydratedCacheableItems;
+  }, [configs, dashboardsAndQuestions]);
+
+  useEffect(
+    /** When the user configures an item to 'Use default' and that item
+     * disappears from the table, it should no longer be the target */
+    function removeTargetIfNoLongerInTable() {
+      const isTargetIdInTable = cacheableItems.some(
+        item => item.id === targetId,
+      );
+      if (targetId !== null && !isTargetIdInTable) {
+        setTargetId(null);
+        setTargetModel(null);
+      }
+    },
+    [targetId, cacheableItems],
+  );
+
+  /** The config for the object currently being edited */
+  const targetConfig = targetModel
+    ? _.findWhere(configs, {
+        model_id: targetId ?? undefined,
+        model: targetModel,
+      })
+    : undefined;
+  const savedStrategy = targetConfig?.strategy;
+
+  const targetName = useMemo(() => {
+    if (targetId === null || targetModel === null) {
+      return;
+    }
+    const item = _.findWhere(cacheableItems, {
+      id: targetId,
+      model: targetModel,
+    });
+    return item?.name;
+  }, [targetId, targetModel, cacheableItems]);
+
+  if (savedStrategy?.type === "duration") {
+    savedStrategy.unit = CacheDurationUnit.Hours;
+  }
+
+  const {
+    askBeforeDiscardingChanges,
+    confirmationModal,
+    isStrategyFormDirty,
+    setIsStrategyFormDirty,
+  } = useConfirmIfFormIsDirty(router, route);
+
+  /** Change the target, but first confirm if the form is unsaved */
+  const updateTarget: UpdateTarget = useCallback(
+    ({ id: newTargetId, model: newTargetModel }, isFormDirty) => {
+      if (targetId !== newTargetId || targetModel !== newTargetModel) {
+        const update = () => {
+          setTargetId(newTargetId);
+          setTargetModel(newTargetModel);
+          setIsStrategyFormDirty(false);
+        };
+        isFormDirty ? askBeforeDiscardingChanges(update) : update();
+      }
+    },
+    [
+      targetId,
+      targetModel,
+      setTargetId,
+      setTargetModel,
+      setIsStrategyFormDirty,
+      askBeforeDiscardingChanges,
+    ],
+  );
+
+  const saveStrategy = useSaveStrategy(
+    targetId,
+    configs,
+    setConfigs,
+    targetModel,
+  );
+
+  const cacheableItemsAreLoading = configs.length > 0 && !cacheableItems.length;
+
+  const error = configsError || dashboardsResult.error || questionsResult.error;
+  const loading =
+    configsAreLoading ||
+    dashboardsResult.isLoading ||
+    questionsResult.isLoading ||
+    cacheableItemsAreLoading;
+
+  const rowRenderer = useCallback(
+    (item: CacheableItem) => (
+      <TableRowForCacheableItem
+        updateTarget={updateTarget}
+        currentTargetId={targetId}
+        currentTargetModel={targetModel}
+        forId={item.id}
+        item={item}
+        isFormDirty={isStrategyFormDirty}
+      />
+    ),
+    [updateTarget, targetId, targetModel, isStrategyFormDirty],
+  );
+
+  const explanatoryAsideId = "mb-explanatory-aside";
+
+  const closeForm = useCallback(() => {
+    updateTarget({ id: null, model: null }, isStrategyFormDirty);
+  }, [updateTarget, isStrategyFormDirty]);
+
+  const locale = useLocale();
+
+  return (
+    <Flex
+      role="region"
+      aria-label={t`Dashboard and question caching`}
+      w="100%"
+      direction="row"
+      justify="space-between"
+      onKeyDown={e => {
+        if (e.key === "Escape" && !e.ctrlKey && !e.metaKey) {
+          closeForm();
+        }
+      }}
+    >
+      <Stack
+        spacing="sm"
+        lh="1.5rem"
+        pt="md"
+        pb="md"
+        px="2.5rem"
+        style={{
+          flex: 1,
+          overflowY: "auto",
+        }}
+      >
+        <aside style={{ maxWidth: "32rem" }} id={explanatoryAsideId}>
+          {t`Here are the dashboards and questions that have their own caching policies, which override any default or database policies you’ve set.`}
+        </aside>
+        {confirmationModal}
+        <Flex maw="60rem">
+          <DelayedLoadingAndErrorWrapper
+            error={error}
+            loading={loading}
+            loader={<TableSkeleton columns={tableColumns} />}
+          >
+            <Flex align="flex-start">
+              <ClientSortableTable<CacheableItem>
+                className={C.CacheableItemTable}
+                columns={tableColumns}
+                rows={cacheableItems}
+                rowRenderer={rowRenderer}
+                defaultSortColumn="name"
+                defaultSortDirection={SortDirection.Asc}
+                locale={locale}
+                formatValueForSorting={formatValueForSorting}
+                emptyBody={<NoResultsTableRow />}
+                aria-labelledby={explanatoryAsideId}
+                cols={
+                  <>
+                    <col style={{ width: "30%" }} />
+                    <col style={{ width: "30%" }} />
+                    <col style={{ width: "30%" }} />
+                  </>
+                }
+              />
+            </Flex>
+          </DelayedLoadingAndErrorWrapper>
+        </Flex>
+      </Stack>
+
+      {targetId !== null && targetModel !== null && (
+        <Panel className={C.StrategyFormPanel}>
+          <Button
+            variant="subtle"
+            pos="absolute"
+            p="1rem"
+            top="1rem"
+            style={{ insetInlineEnd: "1rem" }}
+            onClick={() => {
+              closeForm();
+            }}
+          >
+            <Text color="var(--mb-color-text-dark)">
+              <Icon name="close" />
+            </Text>
+          </Button>
+          <StrategyForm
+            targetId={targetId}
+            targetModel={targetModel}
+            targetName={targetName ?? `Untitled ${targetModel}`}
+            setIsDirty={setIsStrategyFormDirty}
+            saveStrategy={saveStrategy}
+            savedStrategy={savedStrategy}
+            shouldAllowInvalidation={true}
+            shouldShowName={targetId !== rootId}
+          />
+        </Panel>
+      )}
+    </Flex>
+  );
+};
+
+export const StrategyEditorForQuestionsAndDashboards = withRouter(
+  _StrategyEditorForQuestionsAndDashboards,
+);
+
+const TableSkeleton = ({ columns }: { columns: ColumnItem[] }) => (
+  <Table<{ id: number }>
+    columns={columns}
+    rows={[{ id: 0 }, { id: 1 }, { id: 2 }]}
+    rowRenderer={() => (
+      <tr className={C.SkeletonTableRow}>
+        <Repeat times={3}>
+          <td style={{ width: "20rem" }}>
+            <Skeleton h="1rem" natural />
+          </td>
+        </Repeat>
+      </tr>
+    )}
+    className={C.CacheableItemTable}
+  />
+);
+
+const NoResultsTableRow = () => (
+  <tr className={C.NoResultsTableRow}>
+    <td colSpan={3}>
+      <Center fw="bold" c="text-light">
+        {t`No dashboards or questions have their own caching policies yet.`}
+      </Center>
+    </td>
+  </tr>
+);

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.tsx
@@ -11,7 +11,6 @@ import { useCacheConfigs } from "metabase/admin/performance/hooks/useCacheConfig
 import { useConfirmIfFormIsDirty } from "metabase/admin/performance/hooks/useConfirmIfFormIsDirty";
 import { useSaveStrategy } from "metabase/admin/performance/hooks/useSaveStrategy";
 import { skipToken, useSearchQuery } from "metabase/api";
-import { Table } from "metabase/common/components/Table";
 import { ClientSortableTable } from "metabase/common/components/Table/ClientSortableTable";
 import type { ColumnItem } from "metabase/common/components/Table/types";
 import { useLocale } from "metabase/common/hooks/use-locale/use-locale";
@@ -341,7 +340,7 @@ export const StrategyEditorForQuestionsAndDashboards = withRouter(
 );
 
 const TableSkeleton = ({ columns }: { columns: ColumnItem[] }) => (
-  <Table<{ id: number }>
+  <ClientSortableTable<{ id: number }>
     columns={columns}
     rows={[{ id: 0 }, { id: 1 }, { id: 2 }]}
     rowRenderer={() => (
@@ -354,6 +353,7 @@ const TableSkeleton = ({ columns }: { columns: ColumnItem[] }) => (
       </tr>
     )}
     className={StrategyEditorForQuestionsAndDashboardsC.CacheableItemTable}
+    locale="en-US"
   />
 );
 

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.tsx
@@ -15,7 +15,16 @@ import { ClientSortableTable } from "metabase/common/components/Table/ClientSort
 import type { ColumnItem } from "metabase/common/components/Table/types";
 import { useLocale } from "metabase/common/hooks/use-locale/use-locale";
 import { DelayedLoadingAndErrorWrapper } from "metabase/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
-import { Button, Center, Flex, Icon, Skeleton, Stack, Text } from "metabase/ui";
+import {
+  Box,
+  Button,
+  Center,
+  Flex,
+  Icon,
+  Skeleton,
+  Stack,
+  Text,
+} from "metabase/ui";
 import { Repeat } from "metabase/ui/components/feedback/Skeleton/Repeat";
 import type { CacheableModel } from "metabase-types/api";
 import { CacheDurationUnit } from "metabase-types/api";
@@ -264,9 +273,9 @@ const _StrategyEditorForQuestionsAndDashboards = ({
           overflowY: "auto",
         }}
       >
-        <aside style={{ maxWidth: "32rem" }} id={explanatoryAsideId}>
+        <Box component="aside" maw="32rem" id={explanatoryAsideId}>
           {t`Here are the dashboards and questions that have their own caching policies, which override any default or database policies you’ve set.`}
-        </aside>
+        </Box>
         {confirmationModal}
         <Flex maw="60rem">
           <DelayedLoadingAndErrorWrapper
@@ -290,9 +299,9 @@ const _StrategyEditorForQuestionsAndDashboards = ({
                 aria-labelledby={explanatoryAsideId}
                 cols={
                   <>
-                    <col style={{ width: "30%" }} />
-                    <col style={{ width: "30%" }} />
-                    <col style={{ width: "30%" }} />
+                    <col />
+                    <col />
+                    <col />
                   </>
                 }
               />
@@ -346,7 +355,7 @@ const TableSkeleton = ({ columns }: { columns: ColumnItem[] }) => (
     rowRenderer={() => (
       <tr className={StrategyEditorForQuestionsAndDashboardsC.SkeletonTableRow}>
         <Repeat times={3}>
-          <td style={{ width: "20rem" }}>
+          <td>
             <Skeleton h="1rem" natural />
           </td>
         </Repeat>

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/TableRowForCacheableItem.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/TableRowForCacheableItem.styled.tsx
@@ -1,0 +1,7 @@
+import styled from "@emotion/styled";
+
+import { Ellipsified } from "metabase/core/components/Ellipsified";
+
+export const CacheableItemName = styled(Ellipsified)`
+  font-weight: bold;
+`;

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/TableRowForCacheableItem.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/TableRowForCacheableItem.tsx
@@ -71,7 +71,7 @@ export const TableRowForCacheableItem = ({
             ) : (
               <Box h="sm" w="md" />
             )}
-            <Ellipsified fw="bold">{name}</Ellipsified>
+            <Ellipsified style={{ fontWeight: "bold" }}>{name}</Ellipsified>
           </Flex>
         </MaybeLink>
       </td>

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/TableRowForCacheableItem.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/TableRowForCacheableItem.tsx
@@ -15,6 +15,7 @@ import StrategyEditorForQuestionsAndDashboardsS from "./StrategyEditorForQuestio
 
 export const TableRowForCacheableItem = ({
   item,
+  forId,
   currentTargetId,
   currentTargetModel,
   updateTarget,
@@ -43,8 +44,15 @@ export const TableRowForCacheableItem = ({
       updateTarget({ id, model }, isFormDirty);
     }
   };
+
   return (
-    <tr>
+    <tr
+      className={
+        currentTargetId !== null && currentTargetId === forId
+          ? StrategyEditorForQuestionsAndDashboardsS.currentTarget
+          : undefined
+      }
+    >
       <td>
         <MaybeLink
           className={StrategyEditorForQuestionsAndDashboardsS.ItemLink}

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/TableRowForCacheableItem.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/TableRowForCacheableItem.tsx
@@ -4,7 +4,9 @@ import { getShortStrategyLabel } from "metabase/admin/performance/utils";
 import { EllipsifiedCollectionPath } from "metabase/common/components/EllipsifiedPath/EllipsifiedCollectionPath";
 import { MaybeLink } from "metabase/components/Badge/Badge.styled";
 import { Ellipsified } from "metabase/core/components/Ellipsified";
+import Link from "metabase/core/components/Link";
 import { getIcon } from "metabase/lib/icon";
+import * as Urls from "metabase/lib/urls";
 import { Box, Button, FixedSizeIcon, Flex } from "metabase/ui";
 import type { CacheableModel } from "metabase-types/api";
 
@@ -74,7 +76,14 @@ export const TableRowForCacheableItem = ({
         </MaybeLink>
       </td>
       <td>
-        {collection && <EllipsifiedCollectionPath collection={collection} />}
+        {collection && (
+          <Link
+            className={StrategyEditorForQuestionsAndDashboardsS.CollectionLink}
+            to={Urls.collection(collection)}
+          >
+            <EllipsifiedCollectionPath collection={collection} />
+          </Link>
+        )}
       </td>
       <td>
         <Button

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/TableRowForCacheableItem.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/TableRowForCacheableItem.tsx
@@ -1,0 +1,84 @@
+import { useMemo } from "react";
+
+import { getShortStrategyLabel } from "metabase/admin/performance/utils";
+import { EllipsifiedCollectionPath } from "metabase/common/components/EllipsifiedPath/EllipsifiedCollectionPath";
+import { MaybeLink } from "metabase/components/Badge/Badge.styled";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
+import { getIcon } from "metabase/lib/icon";
+import { Box, Button, FixedSizeIcon, Flex } from "metabase/ui";
+import type { CacheableModel } from "metabase-types/api";
+
+import type { CacheableItem, UpdateTarget } from "../types";
+import { getItemUrl } from "../utils";
+
+import StrategyEditorForQuestionsAndDashboardsS from "./StrategyEditorForQuestionsAndDashboards.module.css";
+
+export const TableRowForCacheableItem = ({
+  item,
+  currentTargetId,
+  currentTargetModel,
+  updateTarget,
+  isFormDirty,
+}: {
+  item: CacheableItem;
+  forId: number;
+  currentTargetId: number | null;
+  currentTargetModel: CacheableModel | null;
+  updateTarget: UpdateTarget;
+  isFormDirty: boolean;
+}) => {
+  const { name, id, collection, model, strategy, iconModel } = item;
+
+  const iconName = iconModel
+    ? getIcon({ model: iconModel || "card" }).name
+    : null;
+
+  const url = useMemo(
+    () => getItemUrl(model, item as { id: number; name: string }) || undefined,
+    [model, item],
+  );
+
+  const launchForm = () => {
+    if (currentTargetId !== item.id || currentTargetModel !== item.model) {
+      updateTarget({ id, model }, isFormDirty);
+    }
+  };
+  return (
+    <tr>
+      <td>
+        <MaybeLink
+          className={StrategyEditorForQuestionsAndDashboardsS.ItemLink}
+          to={url}
+        >
+          <Flex
+            align="center"
+            wrap="nowrap"
+            gap="sm"
+            style={{ overflow: "hidden" }}
+          >
+            {iconName ? (
+              <FixedSizeIcon name={iconName} />
+            ) : (
+              <Box h="sm" w="md" />
+            )}
+            <Ellipsified fw="bold">{name}</Ellipsified>
+          </Flex>
+        </MaybeLink>
+      </td>
+      <td>
+        {collection && <EllipsifiedCollectionPath collection={collection} />}
+      </td>
+      <td>
+        <Button
+          variant="subtle"
+          onClick={() => launchForm()}
+          p={0}
+          fw="bold"
+          c="var(--mb-color-brand)"
+        >
+          {getShortStrategyLabel(strategy)}
+        </Button>
+      </td>
+    </tr>
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/constants.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/constants.tsx
@@ -1,0 +1,15 @@
+import { t } from "ttag";
+
+import type { ColumnItem } from "metabase/common/components/Table/types";
+
+/** Retrieve constants for the dashboard and question caching table
+ *
+ * Some constants need to be defined within the component's scope so that ttag.t knows the current locale */
+export const getConstants = () => {
+  const tableColumns: ColumnItem[] = [
+    { key: "name", name: t`Name`, sortable: true },
+    { key: "collection", name: t`Collection`, sortable: true },
+    { key: "policy", name: t`Policy`, sortable: true },
+  ];
+  return { tableColumns };
+};

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/utils.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/utils.tsx
@@ -1,0 +1,30 @@
+import { t } from "ttag";
+import _ from "underscore";
+
+import { getShortStrategyLabel } from "metabase/admin/performance/utils";
+import { getCollectionPathAsString } from "metabase/collections/utils";
+
+import type { CacheableItem } from "../types";
+
+export const formatValueForSorting = (
+  row: CacheableItem,
+  columnName: string,
+) => {
+  if (columnName === "policy") {
+    const label = getShortStrategyLabel(row.strategy, row.model);
+    if (row.strategy.type === "duration") {
+      // Sort durations in ascending order of length
+      return label?.replace(/(\d+)h/, (_, num) => {
+        const paddedNumber = num.padStart(5, "0");
+        return `${t`Duration`} ${paddedNumber}`;
+      });
+    } else {
+      return label;
+    }
+  }
+  if (columnName === "collection") {
+    return row.collection ? getCollectionPathAsString(row.collection) : "";
+  } else {
+    return _.get(row, columnName);
+  }
+};

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/utils.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/utils.unit.spec.tsx
@@ -1,0 +1,174 @@
+import { strategies } from "metabase/admin/performance/constants/complex";
+import { getShortStrategyLabel } from "metabase/admin/performance/utils";
+import { getCollectionPathAsString } from "metabase/collections/utils";
+import { PLUGIN_CACHING } from "metabase/plugins";
+import { enterpriseOnlyCachingStrategies } from "metabase-enterprise/caching/constants";
+import {
+  type AdaptiveStrategy,
+  CacheDurationUnit,
+  type ScheduleStrategy,
+} from "metabase-types/api";
+import { createMockCollection } from "metabase-types/api/mocks";
+
+import type { CacheableItem } from "../types";
+
+import { formatValueForSorting } from "./utils";
+
+const hourlyScheduleStrategy: ScheduleStrategy = {
+  type: "schedule",
+  schedule: "0 0 * * * ?",
+};
+const dailyScheduleStrategy: ScheduleStrategy = {
+  type: "schedule",
+  schedule: "0 0 8 * * ?",
+};
+const weeklyScheduleStrategy: ScheduleStrategy = {
+  type: "schedule",
+  schedule: "0 0 8 ? * 2",
+};
+const monthlyScheduleStrategy: ScheduleStrategy = {
+  type: "schedule",
+  schedule: "0 0 8 ? * 2#1",
+};
+const adaptiveStrategy: AdaptiveStrategy = {
+  type: "ttl",
+  multiplier: 10,
+  min_duration_ms: 1000,
+};
+
+const a = createMockCollection({ id: 2, name: "A" });
+const b = createMockCollection({ id: 3, name: "B" });
+const c = createMockCollection({ id: 4, name: "C" });
+const d = createMockCollection({ id: 5, name: "D" });
+const e = createMockCollection({ id: 6, name: "E" });
+const f = createMockCollection({ id: 7, name: "F" });
+const g = createMockCollection({ id: 8, name: "G" });
+const h = createMockCollection({ id: 9, name: "H" });
+
+const unsortedRows: CacheableItem[] = [
+  {
+    model: "question",
+    id: 0,
+    strategy: monthlyScheduleStrategy,
+    collection: createMockCollection({
+      ...c,
+      effective_ancestors: [a, b],
+    }),
+  },
+  {
+    model: "question",
+    id: 1,
+    strategy: {
+      type: "duration",
+      duration: 100,
+      unit: CacheDurationUnit.Hours,
+    },
+    collection: createMockCollection({
+      ...b,
+      effective_ancestors: [h, a],
+    }),
+  },
+  {
+    model: "question",
+    id: 2,
+    strategy: hourlyScheduleStrategy,
+    collection: createMockCollection({
+      ...a,
+      effective_ancestors: [g, h],
+    }),
+  },
+  {
+    model: "question",
+    id: 3,
+    strategy: { type: "duration", duration: 10, unit: CacheDurationUnit.Hours },
+    collection: createMockCollection({
+      ...d,
+      effective_ancestors: [b, c],
+    }),
+  },
+  {
+    model: "question",
+    id: 4,
+    strategy: weeklyScheduleStrategy,
+    collection: createMockCollection({
+      ...h,
+      effective_ancestors: [f, g],
+    }),
+  },
+  {
+    model: "question",
+    id: 5,
+    strategy: { type: "duration", duration: 1, unit: CacheDurationUnit.Hours },
+    collection: createMockCollection({
+      ...f,
+      effective_ancestors: [d, e],
+    }),
+  },
+  {
+    model: "question",
+    id: 6,
+    strategy: dailyScheduleStrategy,
+    collection: createMockCollection({
+      ...e,
+      effective_ancestors: [c, d],
+    }),
+  },
+  {
+    model: "question",
+    id: 7,
+    strategy: adaptiveStrategy,
+    collection: createMockCollection({
+      ...g,
+      effective_ancestors: [e, f],
+    }),
+  },
+];
+
+describe("StrategyEditorForQuestionsAndDashboards utilities", () => {
+  describe("formatValueForSorting", () => {
+    beforeAll(() => {
+      PLUGIN_CACHING.strategies = {
+        ...strategies,
+        ...enterpriseOnlyCachingStrategies,
+      };
+    });
+    it("sorts by policy correctly", () => {
+      const sorted = unsortedRows.sort((rowA, rowB) => {
+        const a = formatValueForSorting(rowA, "policy") as string;
+        const b = formatValueForSorting(rowB, "policy") as string;
+        return a.localeCompare(b);
+      });
+      const strategies = sorted.map(row => getShortStrategyLabel(row.strategy));
+      expect(strategies).toEqual([
+        "Adaptive",
+        "Duration: 1h",
+        "Duration: 10h",
+        "Duration: 100h",
+        "Scheduled: daily",
+        "Scheduled: hourly",
+        "Scheduled: monthly",
+        "Scheduled: weekly",
+      ]);
+    });
+    it("sorts by collection correctly", () => {
+      const sorted = unsortedRows.sort((rowA, rowB) => {
+        const a = formatValueForSorting(rowA, "collection") as string;
+        const b = formatValueForSorting(rowB, "collection") as string;
+        return a.localeCompare(b);
+      });
+      const collections = sorted.map(row =>
+        row.collection ? getCollectionPathAsString(row.collection) : null,
+      );
+      expect(collections).toEqual([
+        "A / B / C",
+        "B / C / D",
+        "C / D / E",
+        "D / E / F",
+        "E / F / G",
+        "F / G / H",
+        "G / H / A",
+        "H / A / B",
+      ]);
+    });
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/types.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/types.tsx
@@ -1,0 +1,26 @@
+import type {
+  CacheConfig,
+  CacheStrategy,
+  CacheableModel,
+  CollectionEssentials,
+  SearchModel,
+  SearchResult,
+} from "metabase-types/api";
+
+/** Something with a configurable cache strategy */
+export type CacheableItem = Omit<CacheConfig, "model_id"> & {
+  id: number;
+  name?: string;
+  collection?: CollectionEssentials;
+  strategy?: CacheStrategy;
+  /** In the sense of 'type of object' */
+  iconModel?: SearchModel;
+};
+
+export type DashboardResult = SearchResult<number, "dashboard">;
+export type QuestionResult = SearchResult<number, "card">;
+
+export type UpdateTarget = (
+  newValues: { id: number | null; model: CacheableModel | null },
+  isFormDirty: boolean,
+) => void;

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/utils.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/utils.tsx
@@ -1,5 +1,7 @@
+import { match } from "ts-pattern";
 import { t } from "ttag";
 
+import * as Urls from "metabase/lib/urls";
 import type Question from "metabase-lib/v1/Question";
 import type { CacheableDashboard, CacheableModel } from "metabase-types/api";
 
@@ -18,3 +20,12 @@ export const getItemName = (
   model === "dashboard"
     ? (item as CacheableDashboard).name
     : (item as Question).displayName() ?? t`Untitled question`;
+
+export const getItemUrl = (
+  model: CacheableModel,
+  item: { id: number; name: string },
+) =>
+  match(model)
+    .with("dashboard", () => Urls.dashboard(item))
+    .with("question", () => Urls.question(item))
+    .otherwise(() => null);

--- a/enterprise/frontend/src/metabase-enterprise/caching/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/caching/constants.ts
@@ -1,10 +1,17 @@
 import { t } from "ttag";
 import * as Yup from "yup";
 
-import { getPositiveIntegerSchema } from "metabase/admin/performance/constants/complex";
-import type { StrategyData } from "metabase/admin/performance/types";
+import {
+  getPerformanceTabMetadata,
+  getPositiveIntegerSchema,
+} from "metabase/admin/performance/constants/complex";
+import {
+  PerformanceTabId,
+  type StrategyData,
+} from "metabase/admin/performance/types";
 import { defaultCron } from "metabase/admin/performance/utils";
 import { CacheDurationUnit } from "metabase-types/api";
+import type { AdminPath } from "metabase-types/store";
 
 export const durationUnits = new Set(
   Object.values(CacheDurationUnit).map(String),
@@ -39,4 +46,20 @@ export const enterpriseOnlyCachingStrategies: Record<string, StrategyData> = {
     validationSchema: durationStrategyValidationSchema,
     shortLabel: t`Duration`,
   },
+};
+
+export const getEnterprisePerformanceTabMetadata = () => {
+  const metadata = getPerformanceTabMetadata();
+  // On EE there is an additional tab in between the "Database caching" and
+  // "Model persistence" tabs
+  return [
+    metadata.find(({ key }) => key === "performance-databases"),
+    {
+      name: t`Dashboard and question caching`,
+      path: "/admin/performance/dashboards-and-questions",
+      key: "performance-dashboards-and-questions",
+      tabId: PerformanceTabId.DashboardsAndQuestions,
+    },
+    metadata.find(({ key }) => key === "performance-models"),
+  ] as (AdminPath & { tabId: string })[];
 };

--- a/enterprise/frontend/src/metabase-enterprise/caching/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/index.tsx
@@ -1,13 +1,18 @@
 import { PLUGIN_CACHING } from "metabase/plugins";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
+import { DashboardAndQuestionCachingTab } from "./components/DashboardAndQuestionCachingTab";
 import { DashboardStrategySidebar } from "./components/DashboardStrategySidebar";
 import { GranularControlsExplanation } from "./components/GranularControlsExplanation";
 import { InvalidateNowButton } from "./components/InvalidateNowButton";
 import { SidebarCacheForm } from "./components/SidebarCacheForm";
 import { SidebarCacheSection } from "./components/SidebarCacheSection";
+import { StrategyEditorForQuestionsAndDashboards } from "./components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards";
 import { StrategyFormLauncherPanel } from "./components/StrategyFormLauncherPanel";
-import { enterpriseOnlyCachingStrategies } from "./constants";
+import {
+  enterpriseOnlyCachingStrategies,
+  getEnterprisePerformanceTabMetadata,
+} from "./constants";
 import { hasQuestionCacheSection } from "./utils";
 
 if (hasPremiumFeature("cache_granular_controls")) {
@@ -27,4 +32,9 @@ if (hasPremiumFeature("cache_granular_controls")) {
     ttl: PLUGIN_CACHING.strategies.ttl,
     nocache: PLUGIN_CACHING.strategies.nocache,
   };
+  PLUGIN_CACHING.DashboardAndQuestionCachingTab =
+    DashboardAndQuestionCachingTab;
+  PLUGIN_CACHING.StrategyEditorForQuestionsAndDashboards =
+    StrategyEditorForQuestionsAndDashboards;
+  PLUGIN_CACHING.getTabMetadata = getEnterprisePerformanceTabMetadata;
 }

--- a/enterprise/frontend/src/metabase-enterprise/upload_management/UploadManagementTable.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/upload_management/UploadManagementTable.tsx
@@ -2,11 +2,8 @@ import { useCallback, useMemo, useState } from "react";
 import { msgid, ngettext, t } from "ttag";
 
 import SettingHeader from "metabase/admin/settings/components/SettingHeader";
-import {
-  ClientSortableTable,
-  Table,
-} from "metabase/common/components/Table";
-import { useLocale } from "metabase/common/hooks/use-locale/use-locale";
+import { ClientSortableTable } from "metabase/common/components/Table";
+import { useLocale } from "metabase/common/hooks";
 import {
   BulkActionBar,
   BulkActionButton,
@@ -39,7 +36,6 @@ export function UploadManagementTable() {
   const [deleteTableRequest] = useDeleteUploadTableMutation();
   const [showDeleteConfirmModal, setShowDeleteConfirmModal] = useState(false);
   const dispatch = useDispatch();
-
   const locale = useLocale();
 
   // TODO: once we have uploads running through RTK Query, we can remove the force update

--- a/enterprise/frontend/src/metabase-enterprise/upload_management/UploadManagementTable.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/upload_management/UploadManagementTable.tsx
@@ -4,7 +4,7 @@ import { msgid, ngettext, t } from "ttag";
 import SettingHeader from "metabase/admin/settings/components/SettingHeader";
 import {
   ClientSortableTable,
-  type Table,
+  Table,
 } from "metabase/common/components/Table";
 import { useLocale } from "metabase/common/hooks/use-locale/use-locale";
 import {

--- a/enterprise/frontend/src/metabase-enterprise/upload_management/UploadManagementTable.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/upload_management/UploadManagementTable.tsx
@@ -2,7 +2,11 @@ import { useCallback, useMemo, useState } from "react";
 import { msgid, ngettext, t } from "ttag";
 
 import SettingHeader from "metabase/admin/settings/components/SettingHeader";
-import { ClientSortableTable } from "metabase/common/components/Table";
+import {
+  ClientSortableTable,
+  type Table,
+} from "metabase/common/components/Table";
+import { useLocale } from "metabase/common/hooks/use-locale/use-locale";
 import {
   BulkActionBar,
   BulkActionButton,
@@ -35,6 +39,8 @@ export function UploadManagementTable() {
   const [deleteTableRequest] = useDeleteUploadTableMutation();
   const [showDeleteConfirmModal, setShowDeleteConfirmModal] = useState(false);
   const dispatch = useDispatch();
+
+  const locale = useLocale();
 
   // TODO: once we have uploads running through RTK Query, we can remove the force update
   // because we can properly invalidate the tables tag
@@ -154,6 +160,7 @@ export function UploadManagementTable() {
         columns={columns}
         rows={uploadTables}
         rowRenderer={row => renderRow(row)}
+        locale={locale}
       />
     </Box>
   );

--- a/frontend/src/metabase-types/api/search.ts
+++ b/frontend/src/metabase-types/api/search.ts
@@ -128,6 +128,7 @@ export type SearchRequest = {
   archived?: boolean;
   table_db_id?: DatabaseId;
   models?: SearchModel[];
+  ids?: SearchResultId[];
   filter_items_in_personal_collection?: "only" | "exclude";
   context?: SearchContext;
   created_at?: string | null;

--- a/frontend/src/metabase-types/api/search.ts
+++ b/frontend/src/metabase-types/api/search.ts
@@ -137,7 +137,7 @@ export type SearchRequest = {
   last_edited_by?: UserId[];
   search_native_query?: boolean | null;
   verified?: boolean | null;
-  ancestors?: boolean | null;
+  model_ancestors?: boolean | null;
 
   // this should be in ListCollectionItemsRequest but legacy code expects them here
   collection?: CollectionId;

--- a/frontend/src/metabase-types/api/search.ts
+++ b/frontend/src/metabase-types/api/search.ts
@@ -137,7 +137,7 @@ export type SearchRequest = {
   last_edited_by?: UserId[];
   search_native_query?: boolean | null;
   verified?: boolean | null;
-  model_ancestors?: boolean | null;
+  ancestors?: boolean | null;
 
   // this should be in ListCollectionItemsRequest but legacy code expects them here
   collection?: CollectionId;

--- a/frontend/src/metabase-types/store/admin.ts
+++ b/frontend/src/metabase-types/store/admin.ts
@@ -14,7 +14,10 @@ export type AdminPathKey =
   | "troubleshooting"
   | "audit"
   | "tools"
-  | "performance";
+  | "performance"
+  | "performance-models"
+  | "performance-dashboards-and-questions"
+  | "performance-databases";
 
 export type AdminPath = {
   key: AdminPathKey;

--- a/frontend/src/metabase/admin/performance/components/ModelPersistenceConfiguration.module.css
+++ b/frontend/src/metabase/admin/performance/components/ModelPersistenceConfiguration.module.css
@@ -1,0 +1,4 @@
+.Explanation p {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}

--- a/frontend/src/metabase/admin/performance/components/ModelPersistenceConfiguration.tsx
+++ b/frontend/src/metabase/admin/performance/components/ModelPersistenceConfiguration.tsx
@@ -15,7 +15,9 @@ import {
   getShowMetabaseLinks,
 } from "metabase/selectors/whitelabel";
 import { PersistedModelsApi } from "metabase/services";
-import { Stack, Switch, Text } from "metabase/ui";
+import { Box, Stack, Switch, Text } from "metabase/ui";
+
+import ModelPersistenceConfigurationS from "./ModelPersistenceConfiguration.module.css";
 
 const modelCachingOptions = [
   {
@@ -134,7 +136,11 @@ export const ModelPersistenceConfiguration = () => {
 
   return (
     <Stack spacing="xl" maw="40rem">
-      <div>
+      <Box
+        mb="sm"
+        lh="1.5rem"
+        className={ModelPersistenceConfigurationS.Explanation}
+      >
         <p>
           {t`Enable model persistence to make your models (and the queries that use them) load faster.`}
         </p>
@@ -170,7 +176,7 @@ export const ModelPersistenceConfiguration = () => {
             checked={modelPersistenceEnabled}
           />
         </DelayedLoadingAndErrorWrapper>
-      </div>
+      </Box>
       {modelPersistenceEnabled && (
         <div>
           <ModelCachingScheduleWidget

--- a/frontend/src/metabase/admin/performance/components/PerformanceApp.module.css
+++ b/frontend/src/metabase/admin/performance/components/PerformanceApp.module.css
@@ -1,17 +1,12 @@
-import styled from "@emotion/styled";
-
-import { Tabs } from "metabase/ui";
-
-import { PerformanceTabId } from "../types";
-
-export const TabsList = styled(Tabs.List)`
+.TabsList {
   padding: 0 2.5rem;
   background-color: var(--mb-color-bg-light);
   border-bottom-width: 1px;
   margin-top: 1.5rem;
-`;
+  border-bottom-color: var(--mb-color-border);
+}
 
-export const Tab = styled(Tabs.Tab)`
+.Tab {
   top: 1px;
   margin-bottom: 1px;
   border-bottom-width: 3px !important;
@@ -23,13 +18,30 @@ export const Tab = styled(Tabs.Tab)`
     background-color: inherit;
     border-color: transparent;
   }
-`;
+}
 
-export const TabsPanel = styled(Tabs.Panel)<{ value: string }>`
+.TabsPanel {
   display: flex;
   flex-flow: column nowrap;
   flex: 1;
   justify-content: stretch;
+}
+
+.hideOverflow {
+  overflow: hidden;
+}
+
+.TabBody {
+  flex: 1;
+  background-color: var(--mb-color-bg-light);
+  height: 100%;
+}
+
+.DatabasesTabBody {
   padding: 1rem 2.5rem;
-  ${props => props.value === PerformanceTabId.Databases && `overflow: hidden;`}
-`;
+  overflow: hidden;
+}
+
+.ModelPersistenceConfigurationTabBody {
+  padding: 1rem 2.5rem;
+}

--- a/frontend/src/metabase/admin/performance/components/PerformanceApp.tsx
+++ b/frontend/src/metabase/admin/performance/components/PerformanceApp.tsx
@@ -1,16 +1,18 @@
+import classNames from "classnames";
 import { useLayoutEffect, useRef, useState } from "react";
 import type { Route } from "react-router";
 import { push } from "react-router-redux";
-import { t } from "ttag";
 
 import { useDispatch } from "metabase/lib/redux";
+import { PLUGIN_CACHING } from "metabase/plugins";
 import type { TabsValue } from "metabase/ui";
 import { Flex, Tabs } from "metabase/ui";
 
 import { PerformanceTabId } from "../types";
+import { getPerformanceTabName } from "../utils";
 
 import { ModelPersistenceConfiguration } from "./ModelPersistenceConfiguration";
-import { Tab, TabsList, TabsPanel } from "./PerformanceApp.styled";
+import P from "./PerformanceApp.module.css";
 import { StrategyEditorForDatabases } from "./StrategyEditorForDatabases";
 
 const validTabIds = new Set(Object.values(PerformanceTabId).map(String));
@@ -62,34 +64,60 @@ export const PerformanceApp = ({
           console.error("Invalid tab value", value);
         }
       }}
-      style={{ display: "flex", flexDirection: "column" }}
+      style={{ height: tabsHeight, display: "flex", flexDirection: "column" }}
       ref={tabsRef}
-      bg="bg-light"
-      h={tabsHeight}
+      bg="var(--mb-color-bg-light)"
     >
-      <TabsList>
-        <Tab
+      <Tabs.List className={P.TabsList}>
+        <Tabs.Tab
+          className={P.Tab}
           key={PerformanceTabId.Databases}
           value={PerformanceTabId.Databases}
         >
-          {t`Database caching settings`}
-        </Tab>
-        <Tab key={PerformanceTabId.Models} value={PerformanceTabId.Models}>
-          {t`Model persistence`}
-        </Tab>
-      </TabsList>
-      <TabsPanel key={tabId} value={tabId}>
+          {getPerformanceTabName(PerformanceTabId.Databases)}
+        </Tabs.Tab>
+        <PLUGIN_CACHING.DashboardAndQuestionCachingTab />
+        <Tabs.Tab
+          className={P.Tab}
+          key={PerformanceTabId.Models}
+          value={PerformanceTabId.Models}
+        >
+          {getPerformanceTabName(PerformanceTabId.Models)}
+        </Tabs.Tab>
+      </Tabs.List>
+      <Tabs.Panel
+        key={tabId}
+        value={tabId}
+        className={classNames(P.TabsPanel, {
+          [P.hideOverflow]: [
+            PerformanceTabId.Databases,
+            PerformanceTabId.DashboardsAndQuestions,
+          ].includes(tabId),
+        })}
+      >
         {tabId === PerformanceTabId.Databases && (
-          <Flex style={{ flex: 1, overflow: "hidden" }} bg="bg-light" h="100%">
+          <Flex className={classNames(P.TabBody, P.DatabasesTabBody)}>
             <StrategyEditorForDatabases route={route} />
           </Flex>
         )}
+        {tabId === PerformanceTabId.DashboardsAndQuestions && (
+          <Flex className={classNames(P.TabBody, P.hideOverflow)}>
+            <PLUGIN_CACHING.StrategyEditorForQuestionsAndDashboards
+              route={route}
+            />
+          </Flex>
+        )}
         {tabId === PerformanceTabId.Models && (
-          <Flex style={{ flex: 1 }} bg="bg-light" h="100%">
+          <Flex
+            className={classNames(
+              P.TabBody,
+              P.ModelPersistenceConfigurationTabBody,
+            )}
+          >
             <ModelPersistenceConfiguration />
           </Flex>
         )}
-      </TabsPanel>
+      </Tabs.Panel>
     </Tabs>
   );
 };

--- a/frontend/src/metabase/admin/performance/components/StrategyEditorForDatabases.tsx
+++ b/frontend/src/metabase/admin/performance/components/StrategyEditorForDatabases.tsx
@@ -127,7 +127,7 @@ const StrategyEditorForDatabases_Base = ({
   }
 
   return (
-    <TabWrapper aria-label={t`Database caching settings`}>
+    <TabWrapper role="region" aria-label={t`Data caching settings`}>
       <Stack spacing="xl" lh="1.5rem" maw="32rem" mb="1.5rem">
         <aside>
           {t`Speed up queries by caching their results.`}

--- a/frontend/src/metabase/admin/performance/constants/complex.ts
+++ b/frontend/src/metabase/admin/performance/constants/complex.ts
@@ -2,8 +2,9 @@ import { t } from "ttag";
 import * as Yup from "yup";
 
 import type { CacheableModel } from "metabase-types/api";
+import type { AdminPath } from "metabase-types/store";
 
-import type { StrategyData } from "../types";
+import { PerformanceTabId, type StrategyData } from "../types";
 import { getStrategyValidationSchema, isValidStrategyName } from "../utils";
 
 import { defaultMinDurationMs } from "./simple";
@@ -98,3 +99,22 @@ export const strategies = {
     validationSchema: doNotCacheStrategyValidationSchema,
   },
 } as Record<string, StrategyData>;
+
+export const getPerformanceTabMetadata = () =>
+  [
+    {
+      name: t`Database caching`,
+      path: "/admin/performance/databases",
+      key: "performance-databases",
+      tabId: PerformanceTabId.Databases,
+    },
+    {
+      name: t`Model persistence`,
+      path: "/admin/performance/models",
+      key: "performance-models",
+      tabId: PerformanceTabId.Models,
+    },
+  ] as (AdminPath & { tabId: string })[];
+
+export const getPerformanceAdminPaths = (metadata: AdminPath[]) =>
+  metadata.map(tab => ({ ...tab, name: `${t`Performance`} - ${tab.name}` }));

--- a/frontend/src/metabase/admin/performance/hooks/useSaveStrategy.tsx
+++ b/frontend/src/metabase/admin/performance/hooks/useSaveStrategy.tsx
@@ -22,11 +22,11 @@ export const useSaveStrategy = (
   targetId: number | null,
   configs: CacheConfig[],
   setConfigs: Dispatch<SetStateAction<CacheConfig[]>>,
-  model: CacheableModel,
+  model: CacheableModel | null,
 ) => {
   const saveStrategy = useCallback(
     async (values: CacheStrategy) => {
-      if (targetId === null) {
+      if (targetId === null || model === null) {
         return;
       }
       const { strategies } = PLUGIN_CACHING;

--- a/frontend/src/metabase/admin/performance/types.ts
+++ b/frontend/src/metabase/admin/performance/types.ts
@@ -21,4 +21,5 @@ export type StrategyData = {
 export enum PerformanceTabId {
   Databases = "databases",
   Models = "models",
+  DashboardsAndQuestions = "dashboards-and-questions",
 }

--- a/frontend/src/metabase/admin/performance/utils.tsx
+++ b/frontend/src/metabase/admin/performance/utils.tsx
@@ -22,7 +22,7 @@ import type {
 } from "metabase-types/api";
 
 import { defaultMinDurationMs, rootId } from "./constants/simple";
-import type { StrategyData, StrategyLabel } from "./types";
+import type { PerformanceTabId, StrategyData, StrategyLabel } from "./types";
 
 const AM = 0;
 const PM = 1;
@@ -315,3 +315,8 @@ export const translateConfigFromAPI = (config: CacheConfig): CacheConfig =>
 /** Translate a config from the frontend's format into the API's preferred format */
 export const translateConfigToAPI = (config: CacheConfig): CacheConfig =>
   translateConfig(config, "toAPI");
+
+export const getPerformanceTabName = (tabId: PerformanceTabId) =>
+  PLUGIN_CACHING.getTabMetadata().find(
+    ({ key }) => key === `performance-${tabId}`,
+  )?.name;

--- a/frontend/src/metabase/admin/routes.jsx
+++ b/frontend/src/metabase/admin/routes.jsx
@@ -48,6 +48,7 @@ import {
   PLUGIN_ADMIN_ROUTES,
   PLUGIN_ADMIN_TOOLS,
   PLUGIN_ADMIN_USER_MENU_ROUTES,
+  PLUGIN_CACHING,
 } from "metabase/plugins";
 import { getSetting } from "metabase/selectors/settings";
 
@@ -164,18 +165,16 @@ const getRoutes = (store, CanAccessSettings, IsAdmin) => (
       >
         <Route title={t`Performance`}>
           <IndexRedirect to={PerformanceTabId.Databases} />
-          <Route
-            title={t`Database caching`}
-            path={PerformanceTabId.Databases}
-            component={() => (
-              <PerformanceApp tabId={PerformanceTabId.Databases} />
-            )}
-          />
-          <Route
-            title={t`Model persistence`}
-            path={PerformanceTabId.Models}
-            component={() => <PerformanceApp tabId={PerformanceTabId.Models} />}
-          />
+          {PLUGIN_CACHING.getTabMetadata().map(({ name, key, tabId }) => (
+            <Route
+              component={routeProps => (
+                <PerformanceApp {...routeProps} tabId={tabId} />
+              )}
+              title={name}
+              path={tabId}
+              key={key}
+            />
+          ))}
         </Route>
       </Route>
       <Route

--- a/frontend/src/metabase/admin/settings/components/ApiKeys/ManageApiKeys.tsx
+++ b/frontend/src/metabase/admin/settings/components/ApiKeys/ManageApiKeys.tsx
@@ -3,6 +3,7 @@ import { t } from "ttag";
 
 import { useListApiKeysQuery } from "metabase/api";
 import { ClientSortableTable } from "metabase/common/components/Table";
+import { useLocale } from "metabase/common/hooks/use-locale/use-locale";
 import { DelayedLoadingAndErrorWrapper } from "metabase/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
 import { Ellipsified } from "metabase/core/components/Ellipsified";
 import CS from "metabase/css/core/index.css";
@@ -66,6 +67,7 @@ function ApiKeysTable({
   error?: unknown;
 }) {
   const flatApiKeys = useMemo(() => apiKeys?.map(flattenApiKey), [apiKeys]);
+  const locale = useLocale();
 
   if (loading || error) {
     return <DelayedLoadingAndErrorWrapper loading={loading} error={error} />;
@@ -80,6 +82,7 @@ function ApiKeysTable({
       data-testid="api-keys-table"
       columns={columns}
       rows={flatApiKeys}
+      locale={locale}
       rowRenderer={row => (
         <ApiKeyRow
           apiKey={row}

--- a/frontend/src/metabase/browse/components/BrowseModels.tsx
+++ b/frontend/src/metabase/browse/components/BrowseModels.tsx
@@ -34,7 +34,7 @@ export const BrowseModels = () => {
   /** Mapping of filter names to true if the filter is active or false if it is inactive */
   const [actualModelFilters, setActualModelFilters] = useModelFilterSettings();
 
-  const modelsResult = useFetchModels({ model_ancestors: true });
+  const modelsResult = useFetchModels({ ancestors: true });
 
   const { models, doVerifiedModelsExist } = useMemo(() => {
     const unfilteredModels =

--- a/frontend/src/metabase/browse/components/BrowseModels.tsx
+++ b/frontend/src/metabase/browse/components/BrowseModels.tsx
@@ -34,7 +34,7 @@ export const BrowseModels = () => {
   /** Mapping of filter names to true if the filter is active or false if it is inactive */
   const [actualModelFilters, setActualModelFilters] = useModelFilterSettings();
 
-  const modelsResult = useFetchModels({ ancestors: true });
+  const modelsResult = useFetchModels({ model_ancestors: true });
 
   const { models, doVerifiedModelsExist } = useMemo(() => {
     const unfilteredModels =

--- a/frontend/src/metabase/browse/components/ModelsTable.tsx
+++ b/frontend/src/metabase/browse/components/ModelsTable.tsx
@@ -3,7 +3,7 @@ import { push } from "react-router-redux";
 import { t } from "ttag";
 
 import { getCollectionName } from "metabase/collections/utils";
-import { EllipsifiedPath } from "metabase/common/components/EllipsifiedPath";
+import { EllipsifiedCollectionPath } from "metabase/common/components/EllipsifiedPath/EllipsifiedCollectionPath";
 import { useLocale } from "metabase/common/hooks/use-locale/use-locale";
 import EntityItem from "metabase/components/EntityItem";
 import { SortableColumnHeader } from "metabase/components/ItemsTable/BaseItemsTable";
@@ -43,11 +43,7 @@ import {
   ModelNameColumn,
   ModelTableRow,
 } from "./ModelsTable.styled";
-import {
-  getCollectionPathString,
-  getModelDescription,
-  sortModels,
-} from "./utils";
+import { getModelDescription, sortModels } from "./utils";
 
 export interface ModelsTableProps {
   models?: ModelResult[];
@@ -220,13 +216,7 @@ const TBodyRow = ({
           <Flex gap="sm">
             <FixedSizeIcon name="folder" />
             <Box w="calc(100% - 1.5rem)">
-              <EllipsifiedPath
-                tooltip={getCollectionPathString(model.collection)}
-                items={[
-                  ...(model.collection?.effective_ancestors || []),
-                  model.collection,
-                ].map(c => getCollectionName(c))}
-              />
+              <EllipsifiedCollectionPath collection={model.collection} />
             </Box>
           </Flex>
         </Link>

--- a/frontend/src/metabase/browse/components/constants.tsx
+++ b/frontend/src/metabase/browse/components/constants.tsx
@@ -1,1 +1,0 @@
-export const pathSeparatorChar = "/";

--- a/frontend/src/metabase/browse/components/utils.tsx
+++ b/frontend/src/metabase/browse/components/utils.tsx
@@ -1,12 +1,10 @@
 import { t } from "ttag";
 
-import type { CollectionEssentials, SearchResult } from "metabase-types/api";
+import { getCollectionPathAsString } from "metabase/collections/utils";
+import type { SearchResult } from "metabase-types/api";
 import { SortDirection, type SortingOptions } from "metabase-types/api/sorting";
 
 import type { ModelResult } from "../types";
-import { getCollectionName } from "../utils";
-
-import { pathSeparatorChar } from "./constants";
 
 export const isModel = (item: SearchResult) => item.model === "dataset";
 
@@ -18,22 +16,12 @@ export const getModelDescription = (item: SearchResult) => {
   }
 };
 
-export const getCollectionPathString = (collection: CollectionEssentials) => {
-  const ancestors: CollectionEssentials[] =
-    collection.effective_ancestors || [];
-  const collections = ancestors.concat(collection);
-  const pathString = collections
-    .map(coll => getCollectionName(coll))
-    .join(` ${pathSeparatorChar} `);
-  return pathString;
-};
-
 const getValueForSorting = (
   model: ModelResult,
   sort_column: keyof ModelResult,
 ): string => {
   if (sort_column === "collection") {
-    return getCollectionPathString(model.collection);
+    return getCollectionPathAsString(model.collection);
   } else {
     return model[sort_column];
   }

--- a/frontend/src/metabase/browse/components/utils.unit.spec.tsx
+++ b/frontend/src/metabase/browse/components/utils.unit.spec.tsx
@@ -4,37 +4,7 @@ import { SortDirection } from "metabase-types/api/sorting";
 import { createMockModelResult } from "../test-utils";
 import type { ModelResult } from "../types";
 
-import {
-  getCollectionPathString,
-  getMaxRecentModelCount,
-  sortModels,
-} from "./utils";
-
-describe("getCollectionPathString", () => {
-  it("should return path for collection without ancestors", () => {
-    const collection = createMockCollection({
-      id: 0,
-      name: "Documents",
-      effective_ancestors: [],
-    });
-    const pathString = getCollectionPathString(collection);
-    expect(pathString).toBe("Documents");
-  });
-
-  it("should return path for collection with multiple ancestors", () => {
-    const ancestors = [
-      createMockCollection({ name: "Home" }),
-      createMockCollection({ name: "User" }),
-      createMockCollection({ name: "Files" }),
-    ];
-    const collection = createMockCollection({
-      name: "Documents",
-      effective_ancestors: ancestors,
-    });
-    const pathString = getCollectionPathString(collection);
-    expect(pathString).toBe("Home / User / Files / Documents");
-  });
-});
+import { getMaxRecentModelCount, sortModels } from "./utils";
 
 describe("sortModels", () => {
   let id = 0;

--- a/frontend/src/metabase/browse/types.tsx
+++ b/frontend/src/metabase/browse/types.tsx
@@ -1,14 +1,8 @@
-import type { MutableRefObject } from "react";
-
 import type {
   RecentCollectionItem,
   RecentItem,
   SearchResult,
 } from "metabase-types/api";
-
-export type RefProp<RefValue> = {
-  ref: MutableRefObject<RefValue> | ((value: RefValue) => void);
-};
 
 /** Model retrieved through the search endpoint */
 export type ModelResult = SearchResult<number, "dataset">;

--- a/frontend/src/metabase/collections/utils.ts
+++ b/frontend/src/metabase/collections/utils.ts
@@ -3,6 +3,7 @@ import { t } from "ttag";
 import { PLUGIN_COLLECTIONS } from "metabase/plugins";
 import type {
   Collection,
+  CollectionEssentials,
   CollectionId,
   CollectionItem,
 } from "metabase-types/api";
@@ -246,3 +247,19 @@ export const getCollectionName = (
   }
   return collection?.name || t`Untitled collection`;
 };
+
+export const getCollectionPath = (collection: CollectionEssentials) => {
+  const ancestors: CollectionEssentials[] =
+    collection.effective_ancestors || [];
+  const collections = ancestors.concat(collection);
+  return collections;
+};
+
+export const getCollectionPathAsString = (collection: CollectionEssentials) => {
+  const collections = getCollectionPath(collection);
+  return collections
+    .map(coll => getCollectionName(coll))
+    .join(` ${collectionPathSeparator} `);
+};
+
+export const collectionPathSeparator = "/";

--- a/frontend/src/metabase/collections/utils.unit.spec.ts
+++ b/frontend/src/metabase/collections/utils.unit.spec.ts
@@ -1,5 +1,6 @@
 import {
   canonicalCollectionId,
+  getCollectionPathAsString,
   isItemCollection,
   isReadOnlyCollection,
   isRootCollection,
@@ -123,6 +124,32 @@ describe("Collections > utils", () => {
           createMockCollectionItem({ model: "card", can_write: false }),
         ),
       ).toBe(false);
+    });
+  });
+
+  describe("getCollectionPathAsString", () => {
+    it("should return path for collection without ancestors", () => {
+      const collection = createMockCollection({
+        id: 0,
+        name: "Documents",
+        effective_ancestors: [],
+      });
+      const pathString = getCollectionPathAsString(collection);
+      expect(pathString).toBe("Documents");
+    });
+
+    it("should return path for collection with multiple ancestors", () => {
+      const ancestors = [
+        createMockCollection({ name: "Home" }),
+        createMockCollection({ name: "User" }),
+        createMockCollection({ name: "Files" }),
+      ];
+      const collection = createMockCollection({
+        name: "Documents",
+        effective_ancestors: ancestors,
+      });
+      const pathString = getCollectionPathAsString(collection);
+      expect(pathString).toBe("Home / User / Files / Documents");
     });
   });
 });

--- a/frontend/src/metabase/common/components/EllipsifiedPath/EllipsifiedCollectionPath.tsx
+++ b/frontend/src/metabase/common/components/EllipsifiedPath/EllipsifiedCollectionPath.tsx
@@ -1,0 +1,21 @@
+import {
+  getCollectionName,
+  getCollectionPath,
+  getCollectionPathAsString,
+} from "metabase/collections/utils";
+import type { CollectionEssentials } from "metabase-types/api";
+
+import { EllipsifiedPath } from "./EllipsifiedPath";
+
+export const EllipsifiedCollectionPath = ({
+  collection,
+}: {
+  collection: CollectionEssentials;
+}) => {
+  return (
+    <EllipsifiedPath
+      tooltip={getCollectionPathAsString(collection)}
+      items={getCollectionPath(collection).map(c => getCollectionName(c))}
+    />
+  );
+};

--- a/frontend/src/metabase/common/components/Table/ClientSortableTable.tsx
+++ b/frontend/src/metabase/common/components/Table/ClientSortableTable.tsx
@@ -1,3 +1,5 @@
+import cx from "classnames";
+
 import type { SortDirection } from "metabase-types/api/sorting";
 
 import { type BaseRow, Table, type TableProps } from "./Table";
@@ -9,17 +11,14 @@ export type ClientSortableTableProps<T extends BaseRow> = TableProps<T> & {
   formatValueForSorting?: (row: T, columnName: string) => any;
   defaultSortColumn?: string;
   defaultSortDirection?: SortDirection;
+  className?: string;
 };
 
 /**
  * A basic reusable table component that supports client-side sorting by a column
- *
- * @param columns     - an array of objects with name and key properties
- * @param rows        - an array of objects with keys that match the column keys
- * @param rowRenderer - a function that takes a row object and returns a <tr> element
- * @param tableProps  - additional props to pass to the <table> element
  */
 export function ClientSortableTable<Row extends BaseRow>({
+  className,
   columns,
   rows,
   rowRenderer,
@@ -44,17 +43,16 @@ export function ClientSortableTable<Row extends BaseRow>({
 
   return (
     <Table
-      className={TableS.Table}
+      className={cx(className, TableS.Table)}
       rows={sortedRows}
       columns={columns}
       rowRenderer={rowRenderer}
-      onSort={({ name, direction }) => {
+      onSort={(name, direction) => {
         setSortColumn(name);
         setSortDirection(direction);
       }}
-      sortColumn={
-        sortColumn ? { name: sortColumn, direction: sortDirection } : undefined
-      }
+      sortColumnName={sortColumn}
+      sortDirection={sortDirection}
       {...rest}
     />
   );

--- a/frontend/src/metabase/common/components/Table/Table.tsx
+++ b/frontend/src/metabase/common/components/Table/Table.tsx
@@ -4,7 +4,7 @@ import {
   PaginationControls,
   type PaginationControlsProps,
 } from "metabase/components/PaginationControls";
-import { Box, Flex, FlexProps, Icon } from "metabase/ui";
+import { Box, Flex, type FlexProps, Icon } from "metabase/ui";
 import { SortDirection } from "metabase-types/api/sorting";
 
 import CS from "./Table.module.css";
@@ -25,7 +25,7 @@ export type TableProps<Row extends BaseRow> = {
   > & { onPageChange: (page: number) => void };
   emptyBody?: React.ReactNode;
   cols?: React.ReactNode;
-};
+} & Omit<React.HTMLProps<HTMLTableElement>, "rows" | "cols">;
 
 /**
  * A basic reusable table component
@@ -55,7 +55,7 @@ export function Table<Row extends BaseRow>({
 }: TableProps<Row>) {
   return (
     <>
-      <table {...rest} className={CS.Table}>
+      <table className={CS.Table} {...rest}>
         {cols && <colgroup>{cols}</colgroup>}
         <thead>
           <tr>

--- a/frontend/src/metabase/common/components/Table/Table.tsx
+++ b/frontend/src/metabase/common/components/Table/Table.tsx
@@ -42,8 +42,8 @@ export type TableProps<Row extends BaseRow> = {
  * @note All other props are passed to the <table> element
  */
 export function Table<Row extends BaseRow>({
-  rows,
   columns,
+  rows,
   rowRenderer,
   sortColumnName,
   sortDirection,

--- a/frontend/src/metabase/common/components/Table/Table.tsx
+++ b/frontend/src/metabase/common/components/Table/Table.tsx
@@ -1,3 +1,4 @@
+import cx from "classnames";
 import React from "react";
 
 import {
@@ -51,11 +52,12 @@ export function Table<Row extends BaseRow>({
   paginationProps,
   emptyBody,
   cols,
+  className,
   ...rest
 }: TableProps<Row>) {
   return (
     <>
-      <table className={CS.Table} {...rest}>
+      <table className={cx(CS.Table, className)} {...rest}>
         {cols && <colgroup>{cols}</colgroup>}
         <thead>
           <tr>

--- a/frontend/src/metabase/common/components/Table/Table.tsx
+++ b/frontend/src/metabase/common/components/Table/Table.tsx
@@ -4,7 +4,7 @@ import {
   PaginationControls,
   type PaginationControlsProps,
 } from "metabase/components/PaginationControls";
-import { Box, Flex, Icon } from "metabase/ui";
+import { Box, Flex, FlexProps, Icon } from "metabase/ui";
 import { SortDirection } from "metabase-types/api/sorting";
 
 import CS from "./Table.module.css";
@@ -16,7 +16,6 @@ export type TableProps<Row extends BaseRow> = {
   columns: ColumnItem[];
   rows: Row[];
   rowRenderer: (row: Row) => React.ReactNode;
-  tableProps?: React.HTMLAttributes<HTMLTableElement>;
   sortColumnName?: string | null;
   sortDirection?: SortDirection;
   onSort?: (columnName: string, direction: SortDirection) => void;
@@ -120,7 +119,7 @@ function ColumnHeader({
   sortColumn?: string | null;
   sortDirection?: SortDirection;
   onSort: (column: string, direction: SortDirection) => void;
-}) {
+} & FlexProps) {
   return (
     <Flex
       gap="sm"

--- a/frontend/src/metabase/common/components/Table/Table.tsx
+++ b/frontend/src/metabase/common/components/Table/Table.tsx
@@ -8,19 +8,15 @@ import { Box, Flex, Icon } from "metabase/ui";
 import { SortDirection } from "metabase-types/api/sorting";
 
 import CS from "./Table.module.css";
+import type { ColumnItem } from "./types";
 
 export type BaseRow = Record<string, unknown> & { id: number | string };
-
-type ColumnItem = {
-  name: string;
-  key: string;
-  sortable?: boolean;
-};
 
 export type TableProps<Row extends BaseRow> = {
   columns: ColumnItem[];
   rows: Row[];
   rowRenderer: (row: Row) => React.ReactNode;
+  tableProps?: React.HTMLAttributes<HTMLTableElement>;
   sortColumnName?: string | null;
   sortDirection?: SortDirection;
   onSort?: (columnName: string, direction: SortDirection) => void;
@@ -44,11 +40,11 @@ export type TableProps<Row extends BaseRow> = {
  * @param props.sortDirection   - The direction of the sort. Can be "asc" or "desc"
  * @param props.onSort          - a callback containing updated sort info for when a header is clicked
  * @param props.paginationProps - a map of information used to render pagination controls.
+ * @note All other props are passed to the <table> element
  */
-
 export function Table<Row extends BaseRow>({
-  columns,
   rows,
+  columns,
   rowRenderer,
   sortColumnName,
   sortDirection,
@@ -118,6 +114,7 @@ function ColumnHeader({
   sortColumn,
   sortDirection,
   onSort,
+  ...rest
 }: {
   column: ColumnItem;
   sortColumn?: string | null;
@@ -137,6 +134,7 @@ function ColumnHeader({
             : SortDirection.Asc,
         )
       }
+      {...rest}
     >
       {column.name}
       {

--- a/frontend/src/metabase/common/components/Table/Table.tsx
+++ b/frontend/src/metabase/common/components/Table/Table.tsx
@@ -34,12 +34,13 @@ export type TableProps<Row extends BaseRow> = {
  * @param props.columns         - an array of objects with name and key properties
  * @param props.rows            - an array of objects with keys that match the column keys
  * @param props.rowRenderer     - a function that takes a row object and returns a <tr> element
- * @param props.emptyBody       - content to be displayed when the row count is 0
- * @param props.cols            - a ReactNode that is inserted in the table element before <thead>. Useful for defining <colgroups> and <cols>
  * @param props.sortColumnName  - ID of the column currently used in row sorting
  * @param props.sortDirection   - The direction of the sort. Can be "asc" or "desc"
  * @param props.onSort          - a callback containing updated sort info for when a header is clicked
  * @param props.paginationProps - a map of information used to render pagination controls.
+ * @param props.emptyBody       - content to be displayed when the row count is 0
+ * @param props.cols            - a ReactNode that is inserted in the table element before <thead>. Useful for defining <colgroups> and <cols>
+ * @param props.className       - this will be added to the <table> element along with the default classname
  * @note All other props are passed to the <table> element
  */
 export function Table<Row extends BaseRow>({
@@ -61,22 +62,25 @@ export function Table<Row extends BaseRow>({
         {cols && <colgroup>{cols}</colgroup>}
         <thead>
           <tr>
-            {columns.map(column => (
-              <th key={String(column.key)}>
-                {onSort && column.sortable !== false ? (
-                  <ColumnHeader
-                    column={column}
-                    sortColumn={sortColumnName}
-                    sortDirection={sortDirection}
-                    onSort={(columnKey: string, direction: SortDirection) => {
-                      onSort(columnKey, direction);
-                    }}
-                  />
-                ) : (
-                  column.name
-                )}
-              </th>
-            ))}
+            {columns.map(column => {
+              const { sortable = true } = column;
+              return (
+                <th key={String(column.key)}>
+                  {onSort && sortable ? (
+                    <ColumnHeader
+                      column={column}
+                      sortColumn={sortColumnName}
+                      sortDirection={sortDirection}
+                      onSort={(columnKey: string, direction: SortDirection) => {
+                        onSort(columnKey, direction);
+                      }}
+                    />
+                  ) : (
+                    column.name
+                  )}
+                </th>
+              );
+            })}
           </tr>
         </thead>
         <tbody>

--- a/frontend/src/metabase/common/components/Table/Table.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/Table/Table.unit.spec.tsx
@@ -282,7 +282,7 @@ describe("common > components > Table", () => {
 
     await userEvent.click(screen.getByText("Type"));
 
-    expect(onSort).toHaveBeenCalledWith({ name: "type", direction: "asc" });
+    expect(onSort).toHaveBeenCalledWith("type", "asc");
   });
 
   it("should render the pagination controller if pagination props are passed", async () => {

--- a/frontend/src/metabase/common/components/Table/Table.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/Table/Table.unit.spec.tsx
@@ -1,7 +1,6 @@
-import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import { getIcon, queryIcon } from "__support__/ui";
+import { getIcon, queryIcon, render, screen, within } from "__support__/ui";
 
 import { ClientSortableTable } from "./ClientSortableTable";
 import { Table } from "./Table";
@@ -94,6 +93,7 @@ describe("common > components > ClientSortableTable", () => {
         columns={sampleColumns}
         rows={sampleData}
         rowRenderer={renderRow}
+        locale="en-US"
       />,
     );
     expect(screen.getByText("Name")).toBeInTheDocument();
@@ -108,6 +108,7 @@ describe("common > components > ClientSortableTable", () => {
         columns={sampleColumns}
         rows={sampleData}
         rowRenderer={renderRow}
+        locale="en-US"
       />,
     );
     expect(screen.getByText("Bulbasaur")).toBeInTheDocument();
@@ -125,6 +126,7 @@ describe("common > components > ClientSortableTable", () => {
         columns={sampleColumns}
         rows={sampleData}
         rowRenderer={renderRow}
+        locale="en-US"
       />,
     );
     const sortButton = screen.getByText("Name");
@@ -188,6 +190,7 @@ describe("common > components > ClientSortableTable", () => {
         columns={sampleColumns}
         rows={sampleData}
         rowRenderer={renderRow}
+        locale="en-US"
       />,
     );
     const sortNameButton = screen.getByText("Name");
@@ -221,6 +224,7 @@ describe("common > components > ClientSortableTable", () => {
             <td colSpan={3}>No Results</td>
           </tr>
         }
+        locale="en-US"
       />,
     );
     expect(screen.getByText("Name")).toBeInTheDocument();
@@ -229,12 +233,13 @@ describe("common > components > ClientSortableTable", () => {
     expect(screen.getByText("No Results")).toBeInTheDocument();
   });
 
-  it("should allow you provide a format values when sorting", async () => {
+  it("should let you provide format values when sorting", async () => {
     render(
       <ClientSortableTable
         columns={sampleColumns}
         rows={sampleData}
         rowRenderer={renderRow}
+        locale="en-US"
         formatValueForSorting={(row, colName) => {
           if (colName === "type") {
             if (row.type === "Water") {
@@ -277,10 +282,10 @@ describe("common > components > Table", () => {
 
     await userEvent.click(screen.getByText("Type"));
 
-    expect(onSort).toHaveBeenCalledWith("type", "asc");
+    expect(onSort).toHaveBeenCalledWith({ name: "type", direction: "asc" });
   });
 
-  it("if pageination props are passed, it should render the pagination controller.", async () => {
+  it("should render the pagination controller if pagination props are passed", async () => {
     const onPageChange = jest.fn();
 
     render(
@@ -303,6 +308,36 @@ describe("common > components > Table", () => {
     expect(
       screen.getByRole("navigation", { name: /pagination/ }),
     ).toBeInTheDocument();
+  });
+
+  it("should accept a format value function when sorting", async () => {
+    render(
+      <ClientSortableTable
+        columns={sampleColumns}
+        rows={sampleData}
+        rowRenderer={renderRow}
+        formatValueForSorting={(row, colName) => {
+          if (colName === "type") {
+            if (row.type === "Water") {
+              return 10;
+            }
+            return 1;
+          }
+          return row[colName as keyof Pokemon];
+        }}
+        locale="en-US"
+      />,
+    );
+    expect(screen.getByText("Name")).toBeInTheDocument();
+    expect(screen.getByText("Type")).toBeInTheDocument();
+    expect(screen.getByText("Generation")).toBeInTheDocument();
+
+    const sortNameButton = screen.getByText("Type");
+    // Ascending
+    await userEvent.click(sortNameButton);
+    // Descending
+    await userEvent.click(sortNameButton);
+    firstRowShouldHaveText("Squirtle");
   });
 });
 

--- a/frontend/src/metabase/common/components/Table/Table.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/Table/Table.unit.spec.tsx
@@ -309,36 +309,6 @@ describe("common > components > Table", () => {
       screen.getByRole("navigation", { name: /pagination/ }),
     ).toBeInTheDocument();
   });
-
-  it("should accept a format value function when sorting", async () => {
-    render(
-      <ClientSortableTable
-        columns={sampleColumns}
-        rows={sampleData}
-        rowRenderer={renderRow}
-        formatValueForSorting={(row, colName) => {
-          if (colName === "type") {
-            if (row.type === "Water") {
-              return 10;
-            }
-            return 1;
-          }
-          return row[colName as keyof Pokemon];
-        }}
-        locale="en-US"
-      />,
-    );
-    expect(screen.getByText("Name")).toBeInTheDocument();
-    expect(screen.getByText("Type")).toBeInTheDocument();
-    expect(screen.getByText("Generation")).toBeInTheDocument();
-
-    const sortNameButton = screen.getByText("Type");
-    // Ascending
-    await userEvent.click(sortNameButton);
-    // Descending
-    await userEvent.click(sortNameButton);
-    firstRowShouldHaveText("Squirtle");
-  });
 });
 
 function firstRowShouldHaveText(text: string) {

--- a/frontend/src/metabase/common/components/Table/types.ts
+++ b/frontend/src/metabase/common/components/Table/types.ts
@@ -1,0 +1,7 @@
+export type BaseRow = Record<string, any> & { id: number | string };
+
+export type ColumnItem = {
+  name: string;
+  key: string;
+  sortable?: boolean;
+};

--- a/frontend/src/metabase/common/components/Table/useTableSorting.tsx
+++ b/frontend/src/metabase/common/components/Table/useTableSorting.tsx
@@ -1,0 +1,65 @@
+import { useCallback, useMemo, useState } from "react";
+
+import { SortDirection } from "metabase-types/api/sorting";
+
+import type { BaseRow } from "./types";
+
+const compareNumbers = (a: number, b: number) => a - b;
+
+export const useTableSorting = <Row extends BaseRow>({
+  rows,
+  defaultSortColumn,
+  defaultSortDirection = SortDirection.Asc,
+  formatValueForSorting,
+  locale,
+}: {
+  rows: Row[];
+  defaultSortColumn?: string;
+  defaultSortDirection?: SortDirection;
+  formatValueForSorting: (row: Row, columnName: string) => any;
+  locale: string;
+}) => {
+  const [sortColumn, setSortColumn] = useState<string | undefined>(
+    defaultSortColumn,
+  );
+  const [sortDirection, setSortDirection] =
+    useState<SortDirection>(defaultSortDirection);
+
+  const compareStrings = useCallback(
+    (a: string, b: string) =>
+      a.localeCompare(b, locale, { sensitivity: "base" }),
+    [locale],
+  );
+
+  const sortedRows = useMemo(() => {
+    if (sortColumn) {
+      return [...rows].sort((rowA, rowB) => {
+        const a = formatValueForSorting(rowA, sortColumn);
+        const b = formatValueForSorting(rowB, sortColumn);
+
+        if (!isSortableValue(a) || !isSortableValue(b)) {
+          return 0;
+        }
+
+        const result =
+          typeof a === "string"
+            ? compareStrings(a, b as string)
+            : compareNumbers(a, b as number);
+        return sortDirection === SortDirection.Asc ? result : -result;
+      });
+    }
+    return rows;
+  }, [rows, sortColumn, sortDirection, formatValueForSorting, compareStrings]);
+
+  return {
+    sortColumn,
+    sortDirection,
+    setSortColumn,
+    setSortDirection,
+    sortedRows,
+  };
+};
+
+function isSortableValue(value: unknown): value is string | number {
+  return typeof value === "string" || typeof value === "number";
+}

--- a/frontend/src/metabase/common/components/types.ts
+++ b/frontend/src/metabase/common/components/types.ts
@@ -1,0 +1,5 @@
+import type { Ref } from "react";
+
+export type RefProp<RefValue> = {
+  ref: Ref<RefValue>;
+};

--- a/frontend/src/metabase/common/hooks/use-fetch-models.tsx
+++ b/frontend/src/metabase/common/hooks/use-fetch-models.tsx
@@ -5,7 +5,7 @@ export const useFetchModels = (req: Partial<SearchRequest> = {}) => {
   const modelsResult = useSearchQuery({
     models: ["dataset"], // 'model' in the sense of 'type of thing'
     filter_items_in_personal_collection: "exclude",
-    ancestors: false,
+    model_ancestors: false,
     ...req,
   });
   return modelsResult;

--- a/frontend/src/metabase/common/hooks/use-fetch-models.tsx
+++ b/frontend/src/metabase/common/hooks/use-fetch-models.tsx
@@ -5,7 +5,7 @@ export const useFetchModels = (req: Partial<SearchRequest> = {}) => {
   const modelsResult = useSearchQuery({
     models: ["dataset"], // 'model' in the sense of 'type of thing'
     filter_items_in_personal_collection: "exclude",
-    model_ancestors: false,
+    ancestors: false,
     ...req,
   });
   return modelsResult;

--- a/frontend/src/metabase/components/ResponsiveContainer/ResponsiveContainer.tsx
+++ b/frontend/src/metabase/components/ResponsiveContainer/ResponsiveContainer.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
+import type { Ref } from "react";
 
-import type { RefProp } from "metabase/browse/types";
 import { doNotForwardProps } from "metabase/common/utils/doNotForwardProps";
 import { Box, type BoxProps } from "metabase/ui";
 
@@ -22,5 +22,5 @@ ResponsiveContainer.defaultProps = { type: "inline-size" };
 export const ResponsiveChild = styled(Box, doNotForwardProps("containerName"))<
   BoxProps & {
     containerName: string;
-  } & Partial<RefProp<HTMLDivElement | null>>
+  } & { ref?: Ref<HTMLDivElement | null> }
 >``;

--- a/frontend/src/metabase/components/Schedule/constants.ts
+++ b/frontend/src/metabase/components/Schedule/constants.ts
@@ -54,7 +54,9 @@ export type Weekday = {
 /** These strings are created in a function, rather than in module scope, so that ttag is not called until the locale is set */
 export const getScheduleStrings = () => {
   const scheduleOptionNames = {
-    // The context is needed because 'hourly' can be an adjective ('hourly rate') or adverb ('update hourly'). Same with 'daily', 'weekly', and 'monthly'.
+    // The context is needed because 'hourly' can be an adjective ('hourly
+    // rate') or adverb ('update hourly'). Same with 'daily', 'weekly', and
+    // 'monthly'.
     hourly: c("adverb").t`hourly`,
     daily: c("adverb").t`daily`,
     weekly: c("adverb").t`weekly`,

--- a/frontend/src/metabase/core/components/Ellipsified/Ellipsified.styled.tsx
+++ b/frontend/src/metabase/core/components/Ellipsified/Ellipsified.styled.tsx
@@ -1,9 +1,5 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import type { HTMLAttributes, Ref } from "react";
-
-import { doNotForwardProps } from "metabase/common/utils/doNotForwardProps";
-import { Box, type BoxProps } from "metabase/ui";
 
 const ellipsifyCss = css`
   overflow: hidden;
@@ -19,16 +15,11 @@ const clampCss = (lines: number) => css`
   overflow-wrap: break-word;
 `;
 
-type EllipsifiedRootProps = {
+interface EllipsifiedRootProps {
   lines: number;
   "data-testid"?: string;
-} & BoxProps & {
-    ref?: Ref<HTMLDivElement | null>;
-  } & HTMLAttributes<HTMLDivElement>;
+}
 
-export const EllipsifiedRoot = styled(
-  Box,
-  doNotForwardProps("lines"),
-)<EllipsifiedRootProps>`
+export const EllipsifiedRoot = styled.div<EllipsifiedRootProps>`
   ${({ lines }) => (lines > 1 ? clampCss(lines) : ellipsifyCss)};
 `;

--- a/frontend/src/metabase/core/components/Ellipsified/Ellipsified.styled.tsx
+++ b/frontend/src/metabase/core/components/Ellipsified/Ellipsified.styled.tsx
@@ -1,5 +1,9 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
+import type { HTMLAttributes, Ref } from "react";
+
+import { doNotForwardProps } from "metabase/common/utils/doNotForwardProps";
+import { Box, type BoxProps } from "metabase/ui";
 
 const ellipsifyCss = css`
   overflow: hidden;
@@ -15,11 +19,16 @@ const clampCss = (lines: number) => css`
   overflow-wrap: break-word;
 `;
 
-interface EllipsifiedRootProps {
+type EllipsifiedRootProps = {
   lines: number;
   "data-testid"?: string;
-}
+} & BoxProps & {
+    ref?: Ref<HTMLDivElement | null>;
+  } & HTMLAttributes<HTMLDivElement>;
 
-export const EllipsifiedRoot = styled.div<EllipsifiedRootProps>`
+export const EllipsifiedRoot = styled(
+  Box,
+  doNotForwardProps("lines"),
+)<EllipsifiedRootProps>`
   ${({ lines }) => (lines > 1 ? clampCss(lines) : ellipsifyCss)};
 `;

--- a/frontend/src/metabase/core/components/Ellipsified/Ellipsified.tsx
+++ b/frontend/src/metabase/core/components/Ellipsified/Ellipsified.tsx
@@ -1,12 +1,12 @@
 import type { FloatingPosition } from "@mantine/core/lib/Floating";
-import type { CSSProperties, HTMLAttributes, ReactNode, Ref } from "react";
+import type { CSSProperties, ReactNode } from "react";
 
 import { useIsTruncated } from "metabase/hooks/use-is-truncated";
-import { type BoxProps, Tooltip } from "metabase/ui";
+import { Tooltip } from "metabase/ui";
 
 import { EllipsifiedRoot } from "./Ellipsified.styled";
 
-type EllipsifiedProps = {
+interface EllipsifiedProps {
   style?: CSSProperties;
   className?: string;
   showTooltip?: boolean;
@@ -19,9 +19,7 @@ type EllipsifiedProps = {
   placement?: FloatingPosition;
   "data-testid"?: string;
   id?: string;
-} & BoxProps & {
-    ref?: Ref<HTMLDivElement | null>;
-  } & HTMLAttributes<HTMLDivElement>;
+}
 
 export const Ellipsified = ({
   style,
@@ -36,7 +34,6 @@ export const Ellipsified = ({
   placement = "top",
   "data-testid": dataTestId,
   id,
-  ...boxProps
 }: EllipsifiedProps) => {
   const canSkipTooltipRendering = !showTooltip && !alwaysShowTooltip;
   const { isTruncated, ref } = useIsTruncated<HTMLDivElement>({
@@ -61,7 +58,6 @@ export const Ellipsified = ({
         style={style}
         data-testid={dataTestId}
         id={id}
-        {...boxProps}
       >
         {children}
       </EllipsifiedRoot>

--- a/frontend/src/metabase/core/components/Ellipsified/Ellipsified.tsx
+++ b/frontend/src/metabase/core/components/Ellipsified/Ellipsified.tsx
@@ -1,12 +1,12 @@
 import type { FloatingPosition } from "@mantine/core/lib/Floating";
-import type { CSSProperties, ReactNode } from "react";
+import type { CSSProperties, HTMLAttributes, ReactNode, Ref } from "react";
 
 import { useIsTruncated } from "metabase/hooks/use-is-truncated";
-import { Tooltip } from "metabase/ui";
+import { type BoxProps, Tooltip } from "metabase/ui";
 
 import { EllipsifiedRoot } from "./Ellipsified.styled";
 
-interface EllipsifiedProps {
+type EllipsifiedProps = {
   style?: CSSProperties;
   className?: string;
   showTooltip?: boolean;
@@ -19,7 +19,9 @@ interface EllipsifiedProps {
   placement?: FloatingPosition;
   "data-testid"?: string;
   id?: string;
-}
+} & BoxProps & {
+    ref?: Ref<HTMLDivElement | null>;
+  } & HTMLAttributes<HTMLDivElement>;
 
 export const Ellipsified = ({
   style,
@@ -34,6 +36,7 @@ export const Ellipsified = ({
   placement = "top",
   "data-testid": dataTestId,
   id,
+  ...boxProps
 }: EllipsifiedProps) => {
   const canSkipTooltipRendering = !showTooltip && !alwaysShowTooltip;
   const { isTruncated, ref } = useIsTruncated<HTMLDivElement>({
@@ -58,6 +61,7 @@ export const Ellipsified = ({
         style={style}
         data-testid={dataTestId}
         id={id}
+        {...boxProps}
       >
         {children}
       </EllipsifiedRoot>

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -6,6 +6,7 @@ import { useDebounce } from "react-use";
 import { jt, t } from "ttag";
 
 import { getAdminPaths } from "metabase/admin/app/selectors";
+import { getPerformanceAdminPaths } from "metabase/admin/performance/constants/complex";
 import { getSectionsWithPlugins } from "metabase/admin/settings/selectors";
 import { useListRecentsQuery, useSearchQuery } from "metabase/api";
 import { useSetting } from "metabase/common/hooks";
@@ -16,6 +17,7 @@ import { getIcon } from "metabase/lib/icon";
 import { getName } from "metabase/lib/name";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
+import { PLUGIN_CACHING } from "metabase/plugins";
 import { trackSearchClick } from "metabase/search/analytics";
 import {
   getDocsSearchUrl,
@@ -263,7 +265,13 @@ export const useCommandPalette = ({
   ]);
 
   const adminActions = useMemo<PaletteAction[]>(() => {
-    return adminPaths.map(adminPath => ({
+    // Subpaths - i.e. paths to items within the main Admin tabs - are needed
+    // in the command palette but are not part of the main list of admin paths
+    const adminSubpaths = getPerformanceAdminPaths(
+      PLUGIN_CACHING.getTabMetadata(),
+    );
+    const paths = [...adminPaths, ...adminSubpaths];
+    return paths.map(adminPath => ({
       id: `admin-page-${adminPath.key}`,
       name: `${adminPath.name}`,
       icon: "gear",

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -10,7 +10,10 @@ import _ from "underscore";
 import type { AnySchema } from "yup";
 
 import noResultsSource from "assets/img/no_results.svg";
-import { strategies } from "metabase/admin/performance/constants/complex";
+import {
+  getPerformanceTabMetadata,
+  strategies,
+} from "metabase/admin/performance/constants/complex";
 import { UNABLE_TO_CHANGE_ADMIN_PERMISSIONS } from "metabase/admin/permissions/constants/messages";
 import {
   type DataPermission,
@@ -403,6 +406,9 @@ export const PLUGIN_CACHING = {
   canOverrideRootStrategy: false,
   /** Metadata describing the different kinds of strategies */
   strategies: strategies,
+  DashboardAndQuestionCachingTab: PluginPlaceholder as any,
+  StrategyEditorForQuestionsAndDashboards: PluginPlaceholder as any,
+  getTabMetadata: getPerformanceTabMetadata,
 };
 
 export const PLUGIN_REDUCERS: {


### PR DESCRIPTION
This PR adds a table listing the dashboard and questions that have their own caching policies (which override other, more general policies that would otherwise be applied). Here's what it looks like:

![image](https://github.com/user-attachments/assets/c86ff82f-f098-4bab-b125-a2e860410af3)

Closes #42567