### PR TITLE
Tidy api-changelog.md

### DIFF
--- a/docs/developers-guide/api-changelog.md
+++ b/docs/developers-guide/api-changelog.md
@@ -41,26 +41,3 @@ title: API changelog
 - all endpoints that return data (e.g. exports in JSON, XLSX, CSV, endpoints that end in "/query")
 
    Starting from v49, we respond to the API calls with values formatted according to the instance localization options
-
-# Additions to the API interface
-
-## Metabase 0.50.0
-
-- `GET /api/collection/:id/items`
-
-  An additional boolean column, `archived`, has been added to results.
-
-## Metabase 0.49.5
-NOTE: These endpoint changes were added in 0.49.3, and a bug in `GET /api/embed/card/:token/query/:export-format` was fixed in 0.49.5.
-
-- `POST /api/card/:card-id/query/:export-format`
-- `POST /api/:dashboard-id/dashcard/:dashcard-id/card/:card-id/query/:export-format`
-- `POST /api/dataset/:export-format`
-- `GET /api/embed/card/:token/query/:export-format`
-- `GET /api/embed/dashboard/:token/dashcard/:dashcard-id/card/:card-id/:export-format`
-
-    The above endpoints now accept the `format_rows` query parameter. It is an optional boolean parameter that will default to `true` if not included in the request.
-    When `format_rows` is `true`, the export will have formatting applied such that the values match what they appear as in the app.
-    When `format_rows` is `false`, formatting is not applied and exports will behave as they did prior to 0.49.0.
-
-    The value of `format_rows` has no effect when exporting xlsx files.

--- a/docs/developers-guide/api-changelog.md
+++ b/docs/developers-guide/api-changelog.md
@@ -33,6 +33,21 @@ title: API changelog
 - `GET /api/transform/:db-id/:schema/:transform-name`, which hasn't been used internally by Metabase for ages, has
   been removed.
 
+## Metabase 0.49.5
+NOTE: These endpoint changes were added in 0.49.3, and a bug in `GET /api/embed/card/:token/query/:export-format` was fixed in 0.49.5.
+
+- `POST /api/card/:card-id/query/:export-format`
+- `POST /api/:dashboard-id/dashcard/:dashcard-id/card/:card-id/query/:export-format`
+- `POST /api/dataset/:export-format`
+- `GET /api/embed/card/:token/query/:export-format`
+- `GET /api/embed/dashboard/:token/dashcard/:dashcard-id/card/:card-id/:export-format`
+
+    The above endpoints now accept the `format_rows` query parameter. It is an optional boolean parameter that will default to `true` if not included in the request.
+    When `format_rows` is `true`, the export will have formatting applied such that the values match what they appear as in the app.
+    When `format_rows` is `false`, formatting is not applied and exports will behave as they did prior to 0.49.0.
+
+    The value of `format_rows` has no effect when exporting xlsx files.
+
 ## Metabase 0.49.0
 - `POST /api/card` and `PUT /api/card/:id`
 


### PR DESCRIPTION
The `api-changelog.md` includes non-breaking changes so I removed them and rearranged some things ahead of the 50 gold release. See the comments below for the actual changes.