### PR TITLE
42934 entity picker create collection root

### DIFF
--- a/frontend/src/metabase/common/components/CollectionPicker/components/NewCollectionDialog.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/NewCollectionDialog.tsx
@@ -18,7 +18,7 @@ import type { CollectionPickerItem } from "../types";
 interface NewCollectionDialogProps {
   isOpen: boolean;
   onClose: () => void;
-  parentCollectionId: CollectionId;
+  parentCollectionId: CollectionId | null;
   onNewCollection: (item: CollectionPickerItem) => void;
 }
 
@@ -33,7 +33,7 @@ export const NewCollectionDialog = ({
   const onCreateNewCollection = async ({ name }: { name: string }) => {
     const newCollection = await createCollection({
       name,
-      parent_id: parentCollectionId === "root" ? "root" : parentCollectionId,
+      parent_id: parentCollectionId === "root" ? null : parentCollectionId,
     }).unwrap();
 
     onNewCollection({ ...newCollection, model: "collection" });

--- a/frontend/src/metabase/common/components/CollectionPicker/components/NewCollectionDialog.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/NewCollectionDialog.unit.spec.tsx
@@ -1,0 +1,77 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+
+import { renderWithProviders, screen } from "__support__/ui";
+import type { CollectionId } from "metabase-types/api";
+
+import { NewCollectionDialog } from "./NewCollectionDialog";
+
+const setup = (
+  params: {
+    parentCollectionId: CollectionId | null;
+  } = {
+    parentCollectionId: "root",
+  },
+) => {
+  const onClose = jest.fn();
+  const onNewCollection = jest.fn();
+  fetchMock.post("path:/api/collection", { id: 2 });
+  renderWithProviders(
+    <NewCollectionDialog
+      isOpen
+      onClose={onClose}
+      onNewCollection={onNewCollection}
+      {...params}
+    />,
+  );
+};
+
+describe("new collection dialog", () => {
+  it("should handle a parentCollectionId of root", async () => {
+    setup();
+    await userEvent.type(
+      screen.getByPlaceholderText("My new collection"),
+      "Test collection",
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    const apiCalls = fetchMock.calls("path:/api/collection");
+    expect(apiCalls).toHaveLength(1);
+
+    const [_, options] = apiCalls[0];
+    const body = JSON.parse((await options?.body) as string);
+    expect(body.parent_id).toBe(null);
+  });
+
+  it("should handle a normal parentCollectionId", async () => {
+    setup({ parentCollectionId: 12 });
+    await userEvent.type(
+      screen.getByPlaceholderText("My new collection"),
+      "Test collection",
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    const apiCalls = fetchMock.calls("path:/api/collection");
+    expect(apiCalls).toHaveLength(1);
+
+    const [_, options] = apiCalls[0];
+    const body = JSON.parse((await options?.body) as string);
+    expect(body.parent_id).toBe(12);
+  });
+
+  it("should handle a parentCollectionId of null", async () => {
+    setup({ parentCollectionId: null });
+    await userEvent.type(
+      screen.getByPlaceholderText("My new collection"),
+      "Test collection",
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    const apiCalls = fetchMock.calls("path:/api/collection");
+    expect(apiCalls).toHaveLength(1);
+
+    const [_, options] = apiCalls[0];
+    const body = JSON.parse((await options?.body) as string);
+    expect(body.parent_id).toBe(null);
+  });
+});

--- a/frontend/src/metabase/common/components/DashboardPicker/components/NewDashboardDialog.tsx
+++ b/frontend/src/metabase/common/components/DashboardPicker/components/NewDashboardDialog.tsx
@@ -17,7 +17,7 @@ import type { DashboardPickerItem } from "../types";
 interface NewDashboardDialogProps {
   isOpen: boolean;
   onClose: () => void;
-  parentCollectionId: CollectionId;
+  parentCollectionId: CollectionId | null;
   onNewDashboard: (item: DashboardPickerItem) => void;
 }
 
@@ -29,7 +29,7 @@ export const NewDashboardDialog = ({
 }: NewDashboardDialogProps) => {
   const [createDashboard] = useCreateDashboardMutation();
 
-  const onCreateNewCollection = async ({ name }: { name: string }) => {
+  const onCreateNewDashboard = async ({ name }: { name: string }) => {
     const newDashboard = await createDashboard({
       name,
       collection_id: parentCollectionId === "root" ? null : parentCollectionId,
@@ -60,7 +60,7 @@ export const NewDashboardDialog = ({
     >
       <FormProvider
         initialValues={{ name: "" }}
-        onSubmit={onCreateNewCollection}
+        onSubmit={onCreateNewDashboard}
       >
         {({ dirty }: { dirty: boolean }) => (
           <Form>

--- a/frontend/src/metabase/common/components/DashboardPicker/components/NewDashboardDialog.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/DashboardPicker/components/NewDashboardDialog.unit.spec.tsx
@@ -4,7 +4,7 @@ import fetchMock from "fetch-mock";
 import { renderWithProviders, screen } from "__support__/ui";
 import type { CollectionId } from "metabase-types/api";
 
-import { NewCollectionDialog } from "./NewCollectionDialog";
+import { NewDashboardDialog } from "./NewDashboardDialog";
 
 const setup = (
   params: {
@@ -15,12 +15,12 @@ const setup = (
 ) => {
   const onClose = jest.fn();
   const onNewCollection = jest.fn();
-  fetchMock.post("path:/api/collection", { id: 2 });
+  fetchMock.post("path:/api/dashboard", { id: 2 });
   renderWithProviders(
-    <NewCollectionDialog
+    <NewDashboardDialog
       isOpen
       onClose={onClose}
-      onNewCollection={onNewCollection}
+      onNewDashboard={onNewCollection}
       {...params}
     />,
   );
@@ -32,48 +32,48 @@ describe("new collection dialog", () => {
       parentCollectionId: "root",
     });
     await userEvent.type(
-      screen.getByPlaceholderText("My new collection"),
+      screen.getByPlaceholderText("My new dashboard"),
       "Test collection",
     );
     await userEvent.click(screen.getByRole("button", { name: "Create" }));
 
-    const apiCalls = fetchMock.calls("path:/api/collection");
+    const apiCalls = fetchMock.calls("path:/api/dashboard");
     expect(apiCalls).toHaveLength(1);
 
     const [_, options] = apiCalls[0];
     const body = JSON.parse((await options?.body) as string);
-    expect(body.parent_id).toBe(null);
+    expect(body.collection_id).toBe(null);
   });
 
   it("should handle a normal parentCollectionId", async () => {
     setup({ parentCollectionId: 12 });
     await userEvent.type(
-      screen.getByPlaceholderText("My new collection"),
+      screen.getByPlaceholderText("My new dashboard"),
       "Test collection",
     );
     await userEvent.click(screen.getByRole("button", { name: "Create" }));
 
-    const apiCalls = fetchMock.calls("path:/api/collection");
+    const apiCalls = fetchMock.calls("path:/api/dashboard");
     expect(apiCalls).toHaveLength(1);
 
     const [_, options] = apiCalls[0];
     const body = JSON.parse((await options?.body) as string);
-    expect(body.parent_id).toBe(12);
+    expect(body.collection_id).toBe(12);
   });
 
   it("should handle a parentCollectionId of null", async () => {
     setup({ parentCollectionId: null });
     await userEvent.type(
-      screen.getByPlaceholderText("My new collection"),
+      screen.getByPlaceholderText("My new dashboard"),
       "Test collection",
     );
     await userEvent.click(screen.getByRole("button", { name: "Create" }));
 
-    const apiCalls = fetchMock.calls("path:/api/collection");
+    const apiCalls = fetchMock.calls("path:/api/dashboard");
     expect(apiCalls).toHaveLength(1);
 
     const [_, options] = apiCalls[0];
     const body = JSON.parse((await options?.body) as string);
-    expect(body.parent_id).toBe(null);
+    expect(body.collection_id).toBe(null);
   });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/42934

### Description
When creating new entities, if we want something to belong to `Our Analytics`, we need to set the parent collection id of the new entity to `null`. This can be a bit awkward for the collection picker, which uses the identifier `root` instead. Within the `Create New Collection` and `Create New Dashboard` dialogs we check for "root" and replace it with null. This wasn't happening in `<NewCollectionDialog/>`

This PR fixes that, as well as adds unit tests for both modals 

### How to verify
1. New -> Collection
2. Open the collection picker, and click on a collection, then click "Our Analytics" (clicking away initially is important)
3. Click the "Create a new Collection" button on the bottom of the modal. You should be able to create a new collection under our analytics

### Demo
![chrome_EIhgOk8Wzb](https://github.com/metabase/metabase/assets/1328979/a2bef39a-38b6-4ec5-bbc8-2c8e6dae4c70)

### Checklist
- [x] Tests have been added/updated to cover changes in this PR
