### PR TITLE
Properly show parent DBs in entity picker recents and search

### DIFF
--- a/frontend/src/metabase/common/components/EntityPicker/components/RecentsTab/utils.ts
+++ b/frontend/src/metabase/common/components/EntityPicker/components/RecentsTab/utils.ts
@@ -54,5 +54,7 @@ export const recentItemToResultItem = (item: RecentItem): ResultItemType => ({
           id: item.parent_collection.id ?? "root",
         },
       }
-    : {}),
+    : {
+        database_name: item.database.name,
+      }),
 });

--- a/frontend/src/metabase/common/components/EntityPicker/components/ResultItem/ResultItem.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/ResultItem/ResultItem.unit.spec.tsx
@@ -47,11 +47,23 @@ function setup({
   );
 }
 
-const collectionItem: ResultItemType = {
+const collectionItemWithInvalidParent: ResultItemType = {
+  id: 301,
   model: "collection",
   name: "Foo Collection",
   description: "",
-  collection: { name: "should not show this collection", id: 0 },
+  collection: { name: "should not show this collection", id: 301 },
+  collection_authority_level: null,
+  moderated_status: null,
+  display: null,
+};
+
+const collectionItemWithValidParent: ResultItemType = {
+  id: 302,
+  model: "collection",
+  name: "Foo Collection",
+  description: "",
+  collection: { name: "should show this collection", id: 303 },
   collection_authority_level: null,
   moderated_status: null,
   display: null,
@@ -101,18 +113,33 @@ const verifiedModelItem: ResultItemType = {
   display: null,
 };
 
+const tableItem: ResultItemType = {
+  model: "table",
+  name: "My Flat Table",
+  database_name: "My Database",
+};
+
 describe("EntityPicker > ResultItem", () => {
   beforeAll(() => {
     register();
   });
 
-  it("should render a collection item", () => {
+  it("should render a collection item ignoring an invalid parent", () => {
     setup({
-      item: collectionItem,
+      item: collectionItemWithInvalidParent,
     });
     expect(screen.getByText("Foo Collection")).toBeInTheDocument();
     expect(screen.queryByText(/should not show/i)).not.toBeInTheDocument();
     expect(getIcon("folder")).toBeInTheDocument();
+  });
+
+  it("should render a collection item with parent", () => {
+    setup({
+      item: collectionItemWithValidParent,
+    });
+    expect(screen.getByText("Foo Collection")).toBeInTheDocument();
+    expect(screen.getByText(/should show/i)).toBeInTheDocument();
+    expect(screen.getAllByLabelText("folder icon")).toHaveLength(2);
   });
 
   it("should render a bar chart item", () => {
@@ -175,5 +202,18 @@ describe("EntityPicker > ResultItem", () => {
 
     expect(getIcon("model_with_badge")).toBeInTheDocument();
     expect(screen.getByText("in My parent collection")).toBeInTheDocument();
+  });
+
+  it("should render a table model item", () => {
+    setup({
+      item: tableItem,
+    });
+    expect(screen.getByText(tableItem.name)).toBeInTheDocument();
+
+    expect(getIcon("table")).toBeInTheDocument();
+    expect(getIcon("database")).toBeInTheDocument();
+    expect(
+      screen.getByText(`in ${tableItem.database_name}`),
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION

Closes https://github.com/metabase/metabase/issues/42978

### Description

Tables were showing up in recents and search as part of "our analytics" which is ... not true.

Before | After
---|---
![332575086-3fcc27a7-644e-4d14-b629-366eeb5199cb](https://github.com/metabase/metabase/assets/30528226/30899b7c-1be4-4893-8ec0-cbf5fced901a) |  ![Screen Shot 2024-05-22 at 8 26 41 AM](https://github.com/metabase/metabase/assets/30528226/8a457e48-0cab-4be6-a139-f391240a9a12) ![Screen Shot 2024-05-22 at 8 26 32 AM](https://github.com/metabase/metabase/assets/30528226/f1fdbf3e-8cf6-4c19-8528-88093e101b16)


This also allows recent collection items to show their parent collection. This was previously disabled because search collection items have themselves populated as their parent 🥴. This adds a more sophisticated check and hides only non-sensical collection parents (from the search API). see: https://github.com/metabase/metabase/issues/42979



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
