### PR TITLE
Effective location on collection recent items

### DIFF
--- a/src/metabase/models/recent_views.clj
+++ b/src/metabase/models/recent_views.clj
@@ -343,10 +343,7 @@
                                           [:in :id collection-ids]
                                           [:= :archived false]]})
           coll->parent-id (fn [c]
-                            (some-> c
-                                    collection/effective-location-path
-                                    collection/location-path->ids
-                                    last))
+                            (some-> c collection/effective-location-path collection/location-path->ids last))
           parent-ids (into #{} (keep coll->parent-id) collections)
           id->parent-coll (merge {nil (root-coll)}
                                  (when (seq parent-ids)
@@ -355,7 +352,7 @@
                                                       :where [:in :id parent-ids]})))]
       ;; replace the collection ids with their collection data:
       (map
-       (fn [c]
+       (fn effective-collection-assocer [c]
          (assoc c
                 :effective_parent (->> (coll->parent-id c) id->parent-coll)
                 :effective_location (collection/effective-location-path c)))

--- a/test/metabase/models/recent_views_test.clj
+++ b/test/metabase/models/recent_views_test.clj
@@ -79,15 +79,20 @@
              (mapv fixup
                    (recent-views/get-list (mt/user->id :rasta))))))))
 
+(defn- ->location
+  "Helper to turn some strings into a collection location path:"
+  [& parents]
+  (str/join "/" (concat [""] parents [""])))
+
 (deftest simple-get-list-collection-test
   (mt/with-temp
     [:model/Collection {coll-id :id} {:name "parent coll"}
-     :model/Collection {my-coll-id :id} {:name "name" :location (str "/" coll-id "/")}]
+     :model/Collection {my-coll-id :id} {:name "name" :location (->location coll-id)}]
     (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Collection my-coll-id)
     (is (= [{:description nil
              :can_write true
              :name "name"
-             :effective_location (str "/" coll-id "/")
+             :effective_location (->location coll-id)
              :parent_collection {:id coll-id, :name "parent coll", :authority_level nil}
              :id my-coll-id
              :timestamp String
@@ -96,11 +101,6 @@
            (mt/with-test-user :rasta
              (mapv fixup
                    (recent-views/get-list (mt/user->id :rasta))))))))
-
-(defn- ->location
-  "Helper to turn some strings into a collection location path:"
-  [& parents]
-  (str "/" (str/join "/" parents) "/"))
 
 (deftest nested-collections-get-list-collection-test
   (mt/with-temp
@@ -176,7 +176,7 @@
 
            :model/Dashboard  {dashboard-id :id} {:name "my dash" :description "this is my dash" :collection_id parent-coll-id}
 
-           :model/Collection {collection-id :id} {:name "my collection" :description "this is my collection" :location (str "/" parent-coll-id "/")}
+           :model/Collection {collection-id :id} {:name "my collection" :description "this is my collection" :location (->location parent-coll-id)}
 
            :model/Database   {db-id :id} {:name "My DB"} ;; just needed for these temp tables
            :model/Table      {table-id :id} {:name "tablet" :display_name "I am the table" :db_id db-id, :is_upload true}]
@@ -196,7 +196,7 @@
                   {:id "ID",
                    :name "my collection",
                    :description "this is my collection",
-                   :effective_location (str "/" parent-coll-id "/")
+                   :effective_location (->location parent-coll-id)
                    :model :collection,
                    :can_write true,
                    :authority_level nil,

--- a/test/metabase/models/recent_views_test.clj
+++ b/test/metabase/models/recent_views_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.models.recent-views-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer :all]
    [java-time.api :as t]
    [metabase.models.data-permissions :as data-perms]
@@ -86,8 +87,34 @@
     (is (= [{:description nil
              :can_write true
              :name "name"
+             :effective_location (str "/" coll-id "/")
              :parent_collection {:id coll-id, :name "parent coll", :authority_level nil}
              :id my-coll-id
+             :timestamp String
+             :authority_level nil
+             :model :collection}]
+           (mt/with-test-user :rasta
+             (mapv fixup
+                   (recent-views/get-list (mt/user->id :rasta))))))))
+
+(defn- ->location
+  "Helper to turn some strings into a collection location path:"
+  [& parents]
+  (str "/" (str/join "/" parents) "/"))
+
+(deftest nested-collections-get-list-collection-test
+  (mt/with-temp
+    [:model/Collection {coll-id-a :id} {:name "great grandparent coll"}
+     :model/Collection {coll-id-b :id} {:name "grandparent coll" :location (->location coll-id-a)}
+     :model/Collection {coll-id-c :id} {:name "parent coll" :location (->location coll-id-a coll-id-b)}
+     :model/Collection {coll-id-d :id} {:name "record scratch, yep that's me coll" :location (->location coll-id-a coll-id-b coll-id-c)}]
+    (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Collection coll-id-d)
+    (is (= [{:id coll-id-d
+             :description nil
+             :can_write true
+             :name "record scratch, yep that's me coll"
+             :effective_location (->location coll-id-a coll-id-b coll-id-c)
+             :parent_collection {:id coll-id-c, :name "parent coll", :authority_level nil}
              :timestamp String
              :authority_level nil
              :model :collection}]
@@ -169,6 +196,7 @@
                   {:id "ID",
                    :name "my collection",
                    :description "this is my collection",
+                   :effective_location (str "/" parent-coll-id "/")
                    :model :collection,
                    :can_write true,
                    :authority_level nil,


### PR DESCRIPTION
prerequisite for: #42980

Includes `effective_location` on recent items with model=`collection`. We were already calculating this in order to send back the `effective_parent`.