### PR TITLE
Fix alert archived email

### DIFF
--- a/src/metabase/email/alert_archived.mustache
+++ b/src/metabase/email/alert_archived.mustache
@@ -1,4 +1,4 @@
 {{> metabase/email/_header }}
-  <p>Alerts about {{questionName}} have stopped because the question was archived by {{archiverName}}.</p>
+  <p>Alerts about {{questionName}} have stopped because the question was trashed by {{archiverName}}.</p>
   <p>If you want to restore the alert, go to the <a href="{{archiveURL}}">archive</a>, unarchive the question and re-create the alert.</p>
 {{> metabase/email/_footer}}

--- a/src/metabase/util/urls.clj
+++ b/src/metabase/util/urls.clj
@@ -16,7 +16,7 @@
 (defn archive-url
   "Return an appropriate URL to view the archive page."
   []
-  (str (site-url) "/archive"))
+  (str (site-url) "/trash"))
 
 (defn dashboard-url
   "Return an appropriate URL for a `Dashboard` with ID.

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -1723,7 +1723,7 @@
   (doseq [{:keys [message card deleted? expected-email-re f]}
           [{:message           "Archiving a Card should trigger Alert deletion"
             :deleted?          true
-            :expected-email-re #"Alerts about [A-Za-z]+ \(#\d+\) have stopped because the question was archived by Rasta Toucan"
+            :expected-email-re #"Alerts about [A-Za-z]+ \(#\d+\) have stopped because the question was trashed by Rasta Toucan"
             :f                 (fn [{:keys [card]}]
                                  (mt/user-http-request :rasta :put 200 (str "card/" (u/the-id card)) {:archived true}))}
            {:message           "Validate changing a display type triggers alert deletion"


### PR DESCRIPTION
This had the wrong URL and said the item was archived rather than trashed (same thing, but we're moving to "trashed" as the verb here).