### PR TITLE
(2/3) refactor scatter plot option to separate function

### DIFF
--- a/frontend/src/metabase/static-viz/components/ScatterPlot/ScatterPlot.tsx
+++ b/frontend/src/metabase/static-viz/components/ScatterPlot/ScatterPlot.tsx
@@ -6,8 +6,8 @@ import { sanitizeSvgForBatik } from "metabase/static-viz/lib/svg";
 import { registerEChartsModules } from "metabase/visualizations/echarts";
 import { getChartMeasurements } from "metabase/visualizations/echarts/cartesian/chart-measurements";
 import { getLegendItems } from "metabase/visualizations/echarts/cartesian/model/legend";
-import { getCartesianChartOption } from "metabase/visualizations/echarts/cartesian/option";
 import { getScatterPlotModel } from "metabase/visualizations/echarts/cartesian/scatter/model";
+import { getScatterPlotOption } from "metabase/visualizations/echarts/cartesian/scatter/option";
 
 import { computeStaticComboChartSettings } from "../ComboChart/settings";
 import { Legend } from "../Legend";
@@ -59,7 +59,7 @@ export function ScatterPlot({
     renderingContext,
   );
 
-  const option = getCartesianChartOption(
+  const option = getScatterPlotOption(
     chartModel,
     chartMeasurements,
     null,

--- a/frontend/src/metabase/static-viz/components/ScatterPlot/ScatterPlot.tsx
+++ b/frontend/src/metabase/static-viz/components/ScatterPlot/ScatterPlot.tsx
@@ -67,7 +67,6 @@ export function ScatterPlot({
     computedVisualizationSettings,
     width,
     false,
-    null,
     renderingContext,
   );
   chart.setOption(option);

--- a/frontend/src/metabase/visualizations/echarts/cartesian/chart-measurements/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/chart-measurements/index.ts
@@ -3,7 +3,7 @@ import { X_AXIS_DATA_KEY } from "metabase/visualizations/echarts/cartesian/const
 import { CHART_STYLE } from "metabase/visualizations/echarts/cartesian/constants/style";
 import type {
   AxisFormatter,
-  BaseCartesianChartModel,
+  CartesianChartModel,
   ChartDataset,
   NumericAxisScaleTransforms,
   XAxisModel,
@@ -200,7 +200,7 @@ const X_LABEL_ROTATE_45_THRESHOLD_FACTOR = 2.1;
 const X_LABEL_ROTATE_90_THRESHOLD_FACTOR = 1.2;
 
 const getAutoAxisEnabledSetting = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   settings: ComputedVisualizationSettings,
   boundaryWidth: number,
   maxXTickWidth: number,
@@ -250,7 +250,7 @@ const getAutoAxisEnabledSetting = (
 };
 
 const getTicksDimensions = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   chartWidth: number,
   outerHeight: number,
   settings: ComputedVisualizationSettings,
@@ -348,7 +348,7 @@ const getTicksDimensions = (
 const TICK_OVERFLOW_BUFFER = 4;
 
 export const getChartPadding = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   settings: ComputedVisualizationSettings,
   ticksDimensions: TicksDimensions,
   axisEnabledSetting: ComputedVisualizationSettings["graph.x_axis.axis_enabled"],
@@ -478,7 +478,7 @@ export const getChartBounds = (
 };
 
 const getDimensionWidth = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   boundaryWidth: number,
 ) => {
   const { xAxisModel } = chartModel;
@@ -525,7 +525,7 @@ const areHorizontalXAxisTicksOverlapping = (
 };
 
 export const getChartMeasurements = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   settings: ComputedVisualizationSettings,
   hasTimelineEvents: boolean,
   width: number,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
@@ -185,7 +185,6 @@ export const getCartesianChartModel = (
     leftAxisModel,
     rightAxisModel,
     trendLinesModel,
-    bubbleSizeDomain: null,
     seriesLabelsFormatters,
     stackedLabelsFormatters,
   };

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
@@ -192,7 +192,7 @@ export type StackModel = {
   seriesKeys: DataKey[];
 };
 
-export type BaseCartesianChartModel = {
+export type CartesianChartModel = {
   dimensionModel: DimensionModel;
   seriesModels: SeriesModel[];
   dataset: ChartDataset;
@@ -213,11 +213,14 @@ export type BaseCartesianChartModel = {
   trendLinesModel?: TrendLinesModel;
   seriesLabelsFormatters?: SeriesFormatters;
   stackedLabelsFormatters?: StackedSeriesFormatters;
-  waterfallLabelFormatter?: LabelFormatter;
 };
 
-export type CartesianChartModel = BaseCartesianChartModel & {
+export type ScatterPlotModel = CartesianChartModel & {
   bubbleSizeDomain: Extent | null;
+};
+
+export type WaterfallChartModel = CartesianChartModel & {
+  waterfallLabelFormatter: LabelFormatter | undefined;
 };
 
 export type ShowWarning = (warning: string) => void;

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
@@ -4,7 +4,7 @@ import type { AxisBaseOptionCommon } from "echarts/types/src/coord/axisCommonTyp
 import { parseNumberValue } from "metabase/lib/number";
 import { CHART_STYLE } from "metabase/visualizations/echarts/cartesian/constants/style";
 import type {
-  BaseCartesianChartModel,
+  CartesianChartModel,
   DataKey,
   Extent,
   NumericAxisScaleTransforms,
@@ -107,7 +107,7 @@ export const getDimensionTicksDefaultOption = (
 };
 
 const getHistogramTicksOptions = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   settings: ComputedVisualizationSettings,
   chartMeasurements: ChartMeasurements,
 ) => {
@@ -185,7 +185,7 @@ const getCommonDimensionAxisOptions = (
 };
 
 export const buildDimensionAxis = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   width: number,
   settings: ComputedVisualizationSettings,
   chartMeasurements: ChartMeasurements,
@@ -308,7 +308,7 @@ export const buildTimeSeriesDimensionAxis = (
 };
 
 export const buildCategoricalDimensionAxis = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   originalSettings: ComputedVisualizationSettings,
   chartMeasurements: ChartMeasurements,
   renderingContext: RenderingContext,
@@ -411,7 +411,7 @@ export const buildMetricAxis = (
 };
 
 const buildMetricsAxes = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   chartMeasurements: ChartMeasurements,
   settings: ComputedVisualizationSettings,
   hoveredSeriesDataKey: DataKey | null,
@@ -455,7 +455,7 @@ const buildMetricsAxes = (
 };
 
 export const buildAxes = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   width: number,
   chartMeasurements: ChartMeasurements,
   settings: ComputedVisualizationSettings,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/goal-line.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/goal-line.ts
@@ -8,7 +8,7 @@ import type {
 import type { EChartsCartesianCoordinateSystem } from "../../types";
 import { GOAL_LINE_SERIES_ID, X_AXIS_DATA_KEY } from "../constants/dataset";
 import { CHART_STYLE } from "../constants/style";
-import type { CartesianChartModel, ChartDataset } from "../model/types";
+import type { ChartDataset, CartesianChartModel } from "../model/types";
 
 export const GOAL_LINE_DASH = [3, 4];
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
@@ -7,8 +7,8 @@ import {
   X_AXIS_DATA_KEY,
 } from "metabase/visualizations/echarts/cartesian/constants/dataset";
 import type {
-  CartesianChartModel,
   DataKey,
+  CartesianChartModel,
 } from "metabase/visualizations/echarts/cartesian/model/types";
 import { buildAxes } from "metabase/visualizations/echarts/cartesian/option/axis";
 import { buildEChartsSeries } from "metabase/visualizations/echarts/cartesian/option/series";

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -16,7 +16,6 @@ import {
 } from "metabase/visualizations/echarts/cartesian/constants/style";
 import type {
   SeriesModel,
-  CartesianChartModel,
   DataKey,
   StackTotalDataKey,
   ChartDataset,
@@ -27,6 +26,7 @@ import type {
   NumericAxisScaleTransforms,
   LabelFormatter,
   StackModel,
+  CartesianChartModel,
 } from "metabase/visualizations/echarts/cartesian/model/types";
 import type { EChartsSeriesOption } from "metabase/visualizations/echarts/cartesian/option/types";
 import type {

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -42,7 +42,6 @@ import {
   isTimeSeriesAxis,
 } from "../model/guards";
 import { getStackTotalValue } from "../model/series";
-import { buildEChartsScatterSeries } from "../scatter/option/series";
 
 import { getSeriesYAxisIndex } from "./utils";
 
@@ -614,13 +613,6 @@ export const buildEChartsSeries = (
             chartModel?.seriesLabelsFormatters?.[seriesModel.dataKey],
             renderingContext,
           );
-        case "scatter":
-          return buildEChartsScatterSeries(
-            seriesModel,
-            chartModel.bubbleSizeDomain,
-            yAxisIndex,
-            renderingContext,
-          );
       }
     })
     .flat()
@@ -635,11 +627,7 @@ export const buildEChartsSeries = (
         chartModel,
         chartModel.yAxisScaleTransforms,
         settings,
-        // It's guranteed that no series here will be scatter, since with
-        // scatter plots the `stackable.stack_type` is undefined. We can maybe
-        // remove this later after refactoring the scatter implementation to a
-        // separate codepath.
-        series as (LineSeriesOption | BarSeriesOption)[],
+        series,
       ),
     );
   }

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -42,7 +42,7 @@ import {
   isTimeSeriesAxis,
 } from "../model/guards";
 import { getStackTotalValue } from "../model/series";
-import { buildEChartsScatterSeries } from "../scatter/series";
+import { buildEChartsScatterSeries } from "../scatter/option/series";
 
 import { getSeriesYAxisIndex } from "./utils";
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/utils.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/utils.ts
@@ -1,4 +1,4 @@
-import type { CartesianChartModel, DataKey } from "../model/types";
+import type { DataKey, CartesianChartModel } from "../model/types";
 
 export function getSeriesYAxisIndex(
   dataKey: DataKey,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/scatter/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/scatter/model/index.ts
@@ -23,7 +23,7 @@ import {
 import { getAxisTransforms } from "../../model/transforms";
 import { getTrendLines } from "../../model/trend-line";
 import type {
-  CartesianChartModel,
+  ScatterPlotModel,
   ChartDataset,
   Extent,
   SeriesModel,
@@ -62,7 +62,7 @@ export function getScatterPlotModel(
   settings: ComputedVisualizationSettings,
   renderingContext: RenderingContext,
   showWarning?: ShowWarning,
-): CartesianChartModel {
+): ScatterPlotModel {
   // rawSeries has more than one element when two or more cards are combined on a dashboard
   const hasMultipleCards = rawSeries.length > 1;
   const cardsColumns = getCardsColumns(rawSeries, settings);

--- a/frontend/src/metabase/visualizations/echarts/cartesian/scatter/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/scatter/option/index.ts
@@ -13,10 +13,13 @@ import type { CartesianChartModel, DataKey } from "../../model/types";
 import { getSharedEChartsOptions } from "../../option";
 import { buildAxes } from "../../option/axis";
 import { getGoalLineSeriesOption } from "../../option/goal-line";
-import { buildEChartsSeries } from "../../option/series";
 import { getTrendLinesOption } from "../../option/trend-line";
+import type { EChartsSeriesOption } from "../../option/types";
+import { getSeriesYAxisIndex } from "../../option/utils";
 import { getTimelineEventsSeries } from "../../timeline-events/option";
 import type { TimelineEventsModel } from "../../timeline-events/types";
+
+import { buildEChartsScatterSeries } from "./series";
 
 export function getScatterPlotOption(
   chartModel: CartesianChartModel,
@@ -38,13 +41,14 @@ export function getScatterPlotOption(
       )
     : null;
 
-  const dataSeriesOptions = buildEChartsSeries(
-    // TODO refactor
-    chartModel,
-    settings,
-    chartWidth,
-    chartMeasurements,
-    renderingContext,
+  const dataSeriesOptions: EChartsSeriesOption[] = chartModel.seriesModels.map(
+    seriesModel =>
+      buildEChartsScatterSeries(
+        seriesModel,
+        chartModel.bubbleSizeDomain,
+        getSeriesYAxisIndex(seriesModel.dataKey, chartModel),
+        renderingContext,
+      ),
   );
   const goalSeriesOption = getGoalLineSeriesOption(
     chartModel,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/scatter/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/scatter/option/index.ts
@@ -1,47 +1,24 @@
 import type { EChartsCoreOption } from "echarts/core";
 import type { OptionSourceData } from "echarts/types/src/util/types";
 
-import {
-  NEGATIVE_STACK_TOTAL_DATA_KEY,
-  POSITIVE_STACK_TOTAL_DATA_KEY,
-  X_AXIS_DATA_KEY,
-} from "metabase/visualizations/echarts/cartesian/constants/dataset";
-import type {
-  CartesianChartModel,
-  DataKey,
-} from "metabase/visualizations/echarts/cartesian/model/types";
-import { buildAxes } from "metabase/visualizations/echarts/cartesian/option/axis";
-import { buildEChartsSeries } from "metabase/visualizations/echarts/cartesian/option/series";
-import { getTimelineEventsSeries } from "metabase/visualizations/echarts/cartesian/timeline-events/option";
-import type { TimelineEventsModel } from "metabase/visualizations/echarts/cartesian/timeline-events/types";
 import type {
   ComputedVisualizationSettings,
   RenderingContext,
 } from "metabase/visualizations/types";
 import type { TimelineEventId } from "metabase-types/api";
 
-import type { ChartMeasurements } from "../chart-measurements/types";
+import type { ChartMeasurements } from "../../chart-measurements/types";
+import { X_AXIS_DATA_KEY } from "../../constants/dataset";
+import type { CartesianChartModel, DataKey } from "../../model/types";
+import { getSharedEChartsOptions } from "../../option";
+import { buildAxes } from "../../option/axis";
+import { getGoalLineSeriesOption } from "../../option/goal-line";
+import { buildEChartsSeries } from "../../option/series";
+import { getTrendLinesOption } from "../../option/trend-line";
+import { getTimelineEventsSeries } from "../../timeline-events/option";
+import type { TimelineEventsModel } from "../../timeline-events/types";
 
-import { getGoalLineSeriesOption } from "./goal-line";
-import { getTrendLinesOption } from "./trend-line";
-
-export const getSharedEChartsOptions = (isPlaceholder: boolean) => ({
-  useUTC: true,
-  animation: !isPlaceholder,
-  animationDuration: 0,
-  animationDurationUpdate: 1, // by setting this to 1ms we visually eliminate shape transitions while preserving opacity transitions
-  toolbox: {
-    show: false,
-  },
-  brush: {
-    toolbox: ["lineX" as const],
-    xAxisIndex: 0,
-    throttleType: "debounce" as const,
-    throttleDelay: 200,
-  },
-});
-
-export const getCartesianChartOption = (
+export function getScatterPlotOption(
   chartModel: CartesianChartModel,
   chartMeasurements: ChartMeasurements,
   timelineEventsModel: TimelineEventsModel | null,
@@ -51,7 +28,7 @@ export const getCartesianChartOption = (
   isPlaceholder: boolean,
   hoveredSeriesDataKey: DataKey | null,
   renderingContext: RenderingContext,
-): EChartsCoreOption => {
+): EChartsCoreOption {
   const hasTimelineEvents = timelineEventsModel != null;
   const timelineEventsSeries = hasTimelineEvents
     ? getTimelineEventsSeries(
@@ -62,6 +39,7 @@ export const getCartesianChartOption = (
     : null;
 
   const dataSeriesOptions = buildEChartsSeries(
+    // TODO refactor
     chartModel,
     settings,
     chartWidth,
@@ -84,17 +62,10 @@ export const getCartesianChartOption = (
     timelineEventsSeries,
   ].flatMap(option => option ?? []);
 
-  // dataset option
   const dimensions = [
     X_AXIS_DATA_KEY,
     ...chartModel.seriesModels.map(seriesModel => seriesModel.dataKey),
   ];
-
-  if (settings["stackable.stack_type"] != null) {
-    dimensions.push(
-      ...[POSITIVE_STACK_TOTAL_DATA_KEY, NEGATIVE_STACK_TOTAL_DATA_KEY],
-    );
-  }
 
   const echartsDataset = [
     {
@@ -134,4 +105,4 @@ export const getCartesianChartOption = (
       renderingContext,
     ),
   };
-};
+}

--- a/frontend/src/metabase/visualizations/echarts/cartesian/scatter/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/scatter/option/index.ts
@@ -9,7 +9,7 @@ import type { TimelineEventId } from "metabase-types/api";
 
 import type { ChartMeasurements } from "../../chart-measurements/types";
 import { X_AXIS_DATA_KEY } from "../../constants/dataset";
-import type { CartesianChartModel, DataKey } from "../../model/types";
+import type { CartesianChartModel } from "../../model/types";
 import { getSharedEChartsOptions } from "../../option";
 import { buildAxes } from "../../option/axis";
 import { getGoalLineSeriesOption } from "../../option/goal-line";
@@ -29,7 +29,6 @@ export function getScatterPlotOption(
   settings: ComputedVisualizationSettings,
   chartWidth: number,
   isPlaceholder: boolean,
-  hoveredSeriesDataKey: DataKey | null,
   renderingContext: RenderingContext,
 ): EChartsCoreOption {
   const hasTimelineEvents = timelineEventsModel != null;
@@ -105,7 +104,7 @@ export function getScatterPlotOption(
       chartMeasurements,
       settings,
       hasTimelineEvents,
-      hoveredSeriesDataKey,
+      null,
       renderingContext,
     ),
   };

--- a/frontend/src/metabase/visualizations/echarts/cartesian/scatter/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/scatter/option/index.ts
@@ -9,7 +9,7 @@ import type { TimelineEventId } from "metabase-types/api";
 
 import type { ChartMeasurements } from "../../chart-measurements/types";
 import { X_AXIS_DATA_KEY } from "../../constants/dataset";
-import type { CartesianChartModel } from "../../model/types";
+import type { ScatterPlotModel } from "../../model/types";
 import { getSharedEChartsOptions } from "../../option";
 import { buildAxes } from "../../option/axis";
 import { getGoalLineSeriesOption } from "../../option/goal-line";
@@ -22,7 +22,7 @@ import type { TimelineEventsModel } from "../../timeline-events/types";
 import { buildEChartsScatterSeries } from "./series";
 
 export function getScatterPlotOption(
-  chartModel: CartesianChartModel,
+  chartModel: ScatterPlotModel,
   chartMeasurements: ChartMeasurements,
   timelineEventsModel: TimelineEventsModel | null,
   selectedTimelineEventsIds: TimelineEventId[],

--- a/frontend/src/metabase/visualizations/echarts/cartesian/scatter/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/scatter/option/series.ts
@@ -4,8 +4,8 @@ import type { ScatterSeriesOption } from "echarts/charts";
 import { X_AXIS_DATA_KEY } from "metabase/visualizations/echarts/cartesian/constants/dataset";
 import type { RenderingContext } from "metabase/visualizations/types";
 
-import { CHART_STYLE } from "../constants/style";
-import type { DataKey, Datum, Extent, SeriesModel } from "../model/types";
+import { CHART_STYLE } from "../../constants/style";
+import type { DataKey, Datum, Extent, SeriesModel } from "../../model/types";
 
 const MIN_BUBBLE_DIAMETER = 15;
 const MAX_BUBBLE_DIAMETER = 75;

--- a/frontend/src/metabase/visualizations/echarts/cartesian/timeline-events/model.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/timeline-events/model.ts
@@ -4,7 +4,7 @@ import _ from "underscore";
 
 import { CHART_STYLE } from "metabase/visualizations/echarts/cartesian/constants/style";
 import type {
-  BaseCartesianChartModel,
+  CartesianChartModel,
   DateRange,
 } from "metabase/visualizations/echarts/cartesian/model/types";
 import type { TimelineEventGroup } from "metabase/visualizations/echarts/cartesian/timeline-events/types";
@@ -132,7 +132,7 @@ const getTimelineEventsInsideRange = (
 };
 
 export const getTimelineEventsModel = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   chartMeasurements: ChartMeasurements,
   timelineEvents: TimelineEvent[],
   renderingContext: RenderingContext,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/index.ts
@@ -11,8 +11,8 @@ import {
   getWaterfallLabelFormatter,
 } from "metabase/visualizations/echarts/cartesian/model/series";
 import type {
-  BaseCartesianChartModel,
   ShowWarning,
+  WaterfallChartModel,
 } from "metabase/visualizations/echarts/cartesian/model/types";
 import { getCartesianChartColumns } from "metabase/visualizations/lib/graph/columns";
 import type {
@@ -35,7 +35,7 @@ export const getWaterfallChartModel = (
   settings: ComputedVisualizationSettings,
   renderingContext: RenderingContext,
   showWarning?: ShowWarning,
-): BaseCartesianChartModel => {
+): WaterfallChartModel => {
   // Waterfall chart support one card only
   const [singleRawSeries] = rawSeries;
   const { data } = singleRawSeries;

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/option/index.ts
@@ -4,9 +4,10 @@ import type { LabelLayoutOptionCallback } from "echarts/types/src/util/types";
 import { X_AXIS_DATA_KEY } from "metabase/visualizations/echarts/cartesian/constants/dataset";
 import { CHART_STYLE } from "metabase/visualizations/echarts/cartesian/constants/style";
 import type {
-  BaseCartesianChartModel,
+  CartesianChartModel,
   ChartDataset,
   LabelFormatter,
+  WaterfallChartModel,
 } from "metabase/visualizations/echarts/cartesian/model/types";
 import {
   buildEChartsLabelOptions,
@@ -74,7 +75,7 @@ const getLabelLayoutFn = (
 };
 
 const computeWaterfallBarWidth = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   boundaryWidth: number,
 ) => {
   if (isCategoryAxis(chartModel.xAxisModel)) {
@@ -93,7 +94,7 @@ const computeWaterfallBarWidth = (
 };
 
 export const buildEChartsWaterfallSeries = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   settings: ComputedVisualizationSettings,
   chartMeasurements: ChartMeasurements,
   labelFormatter: LabelFormatter | undefined,
@@ -202,7 +203,7 @@ export const buildEChartsWaterfallSeries = (
 };
 
 export const getWaterfallChartOption = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: WaterfallChartModel,
   chartWidth: number,
   chartMeasurements: ChartMeasurements,
   timelineEventsModel: TimelineEventsModel | null,
@@ -224,7 +225,7 @@ export const getWaterfallChartOption = (
     chartModel,
     settings,
     chartMeasurements,
-    chartModel?.waterfallLabelFormatter,
+    chartModel.waterfallLabelFormatter,
     renderingContext,
   );
 

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
@@ -18,7 +18,7 @@ import {
   isTimeSeriesAxis,
 } from "metabase/visualizations/echarts/cartesian/model/guards";
 import type {
-  BaseCartesianChartModel,
+  CartesianChartModel,
   ChartDataset,
   DataKey,
   Datum,
@@ -76,7 +76,7 @@ export const parseDataKey = (dataKey: DataKey) => {
 };
 
 const findSeriesModelIndexById = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   seriesId?: string,
 ) => {
   if (seriesId == null) {
@@ -105,7 +105,7 @@ const getSameCardDataKeys = (
 };
 
 export const getEventDimensions = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   datum: Datum,
   dimensionModel: DimensionModel,
   seriesModel: SeriesModel,
@@ -143,7 +143,7 @@ export const getEventDimensions = (
 };
 
 const getEventColumnsData = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   seriesIndex: number,
   dataIndex: number,
 ): DataPoint[] => {
@@ -192,7 +192,7 @@ const getEventColumnsData = (
 };
 
 const getTooltipFooterData = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   display: string,
   seriesIndex: number,
   dataIndex: number,
@@ -261,7 +261,7 @@ const getTooltipFooterData = (
 };
 
 const getStackedTooltipModel = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   settings: ComputedVisualizationSettings,
   seriesIndex: number,
   dataIndex: number,
@@ -378,7 +378,7 @@ const isValidDatumElement = (
 };
 
 export const getSeriesHoverData = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   settings: ComputedVisualizationSettings,
   display: string,
   event: EChartsSeriesMouseEvent,
@@ -488,7 +488,7 @@ export const getGoalLineHoverData = (
 };
 
 export const getSeriesClickData = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   settings: ComputedVisualizationSettings,
   event: EChartsSeriesMouseEvent,
 ): ClickObject | undefined => {
@@ -528,7 +528,7 @@ export const getSeriesClickData = (
 export const getBrushData = (
   rawSeries: RawSeries,
   metadata: Metadata,
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   event: EChartsSeriesBrushEndEvent,
 ) => {
   const range = event.areas[0].coordRange;

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-debug.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-debug.ts
@@ -3,7 +3,7 @@ import type { EChartsCoreOption } from "echarts/core";
 import { useEffect } from "react";
 
 import { isChartsDebugLoggingEnabled } from "metabase/env";
-import type { BaseCartesianChartModel } from "metabase/visualizations/echarts/cartesian/model/types";
+import type { CartesianChartModel } from "metabase/visualizations/echarts/cartesian/model/types";
 import type { RawSeries } from "metabase-types/api";
 
 export function useChartDebug({
@@ -15,7 +15,7 @@ export function useChartDebug({
   isQueryBuilder: boolean;
   rawSeries: RawSeries;
   option: EChartsCoreOption;
-  chartModel: BaseCartesianChartModel;
+  chartModel: CartesianChartModel;
 }) {
   useEffect(() => {
     if (!isQueryBuilder || !isChartsDebugLoggingEnabled) {

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
@@ -8,7 +8,7 @@ import {
   TIMELINE_EVENT_DATA_NAME,
 } from "metabase/visualizations/echarts/cartesian/constants/dataset";
 import type {
-  BaseCartesianChartModel,
+  CartesianChartModel,
   ChartDataset,
 } from "metabase/visualizations/echarts/cartesian/model/types";
 import type { TimelineEventsModel } from "metabase/visualizations/echarts/cartesian/timeline-events/types";
@@ -34,7 +34,7 @@ import { getHoveredEChartsSeriesIndex } from "./utils";
 
 export const useChartEvents = (
   chartRef: React.MutableRefObject<EChartsType | undefined>,
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   timelineEventsModel: TimelineEventsModel | null,
   option: EChartsCoreOption,
   {

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-models-and-option.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-models-and-option.ts
@@ -10,6 +10,7 @@ import { getCartesianChartModel } from "metabase/visualizations/echarts/cartesia
 import type { CartesianChartModel } from "metabase/visualizations/echarts/cartesian/model/types";
 import { getCartesianChartOption } from "metabase/visualizations/echarts/cartesian/option";
 import { getScatterPlotModel } from "metabase/visualizations/echarts/cartesian/scatter/model";
+import { getScatterPlotOption } from "metabase/visualizations/echarts/cartesian/scatter/option";
 import { getTimelineEventsModel } from "metabase/visualizations/echarts/cartesian/timeline-events/model";
 import { getWaterfallChartModel } from "metabase/visualizations/echarts/cartesian/waterfall/model";
 import { getWaterfallChartOption } from "metabase/visualizations/echarts/cartesian/waterfall/option";
@@ -148,6 +149,18 @@ export function useModelsAndOption({
           selectedOrHoveredTimelineEventIds,
           settings,
           isPlaceholder ?? false,
+          renderingContext,
+        );
+      case "scatter":
+        return getScatterPlotOption(
+          chartModel as CartesianChartModel,
+          chartMeasurements,
+          timelineEventsModel,
+          selectedOrHoveredTimelineEventIds,
+          settings,
+          width,
+          isPlaceholder ?? false,
+          hoveredSeriesDataKey,
           renderingContext,
         );
       default:

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-models-and-option.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-models-and-option.ts
@@ -160,7 +160,6 @@ export function useModelsAndOption({
           settings,
           width,
           isPlaceholder ?? false,
-          hoveredSeriesDataKey,
           renderingContext,
         );
       default:

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-models-and-option.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-models-and-option.ts
@@ -7,7 +7,10 @@ import { measureTextWidth } from "metabase/lib/measure-text";
 import { extractRemappings } from "metabase/visualizations";
 import { getChartMeasurements } from "metabase/visualizations/echarts/cartesian/chart-measurements";
 import { getCartesianChartModel } from "metabase/visualizations/echarts/cartesian/model";
-import type { CartesianChartModel } from "metabase/visualizations/echarts/cartesian/model/types";
+import type {
+  ScatterPlotModel,
+  WaterfallChartModel,
+} from "metabase/visualizations/echarts/cartesian/model/types";
 import { getCartesianChartOption } from "metabase/visualizations/echarts/cartesian/option";
 import { getScatterPlotModel } from "metabase/visualizations/echarts/cartesian/scatter/model";
 import { getScatterPlotOption } from "metabase/visualizations/echarts/cartesian/scatter/option";
@@ -67,29 +70,15 @@ export function useModelsAndOption({
     : false;
 
   const chartModel = useMemo(() => {
-    switch (card.display) {
-      case "waterfall":
-        return getWaterfallChartModel(
-          seriesToRender,
-          settings,
-          renderingContext,
-          showWarning,
-        );
-      case "scatter":
-        return getScatterPlotModel(
-          seriesToRender,
-          settings,
-          renderingContext,
-          showWarning,
-        );
-      default:
-        return getCartesianChartModel(
-          seriesToRender,
-          settings,
-          renderingContext,
-          showWarning,
-        );
+    let getModel = getCartesianChartModel;
+
+    if (card.display === "waterfall") {
+      getModel = getWaterfallChartModel;
+    } else if (card.display === "scatter") {
+      getModel = getScatterPlotModel;
     }
+
+    return getModel(seriesToRender, settings, renderingContext, showWarning);
   }, [card.display, seriesToRender, settings, renderingContext, showWarning]);
 
   const chartMeasurements = useMemo(
@@ -142,7 +131,7 @@ export function useModelsAndOption({
     switch (card.display) {
       case "waterfall":
         return getWaterfallChartOption(
-          chartModel,
+          chartModel as WaterfallChartModel,
           width,
           chartMeasurements,
           timelineEventsModel,
@@ -153,7 +142,7 @@ export function useModelsAndOption({
         );
       case "scatter":
         return getScatterPlotOption(
-          chartModel as CartesianChartModel,
+          chartModel as ScatterPlotModel,
           chartMeasurements,
           timelineEventsModel,
           selectedOrHoveredTimelineEventIds,
@@ -164,7 +153,7 @@ export function useModelsAndOption({
         );
       default:
         return getCartesianChartOption(
-          chartModel as CartesianChartModel,
+          chartModel,
           chartMeasurements,
           timelineEventsModel,
           selectedOrHoveredTimelineEventIds,

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/utils.ts
@@ -3,7 +3,7 @@ import { t } from "ttag";
 
 import { isNotNull } from "metabase/lib/types";
 import type {
-  BaseCartesianChartModel,
+  CartesianChartModel,
   DataKey,
   SeriesModel,
 } from "metabase/visualizations/echarts/cartesian/model/types";
@@ -57,7 +57,7 @@ export const getGridSizeAdjustedSettings = (
 
 export const MAX_SERIES = 100;
 
-export const validateChartModel = (chartModel: BaseCartesianChartModel) => {
+export const validateChartModel = (chartModel: CartesianChartModel) => {
   if (chartModel.seriesModels.length > MAX_SERIES) {
     throw new Error(
       t`This chart type doesn't support more than ${MAX_SERIES} series of data.`,


### PR DESCRIPTION
Part of https://github.com/metabase/metabase/issues/36825

### Description

Moves scatter plot option computation into its own function, so it's not conflated with the combo chart option computation in `getCartesianChartOption`

### How to verify

CI
