### PR TITLE
(3/3) improve chart model types

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/chart-measurements/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/chart-measurements/index.ts
@@ -3,7 +3,7 @@ import { X_AXIS_DATA_KEY } from "metabase/visualizations/echarts/cartesian/const
 import { CHART_STYLE } from "metabase/visualizations/echarts/cartesian/constants/style";
 import type {
   AxisFormatter,
-  BaseCartesianChartModel,
+  CartesianChartModel,
   ChartDataset,
   NumericAxisScaleTransforms,
   XAxisModel,
@@ -200,7 +200,7 @@ const X_LABEL_ROTATE_45_THRESHOLD_FACTOR = 2.1;
 const X_LABEL_ROTATE_90_THRESHOLD_FACTOR = 1.2;
 
 const getAutoAxisEnabledSetting = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   settings: ComputedVisualizationSettings,
   boundaryWidth: number,
   maxXTickWidth: number,
@@ -250,7 +250,7 @@ const getAutoAxisEnabledSetting = (
 };
 
 const getTicksDimensions = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   chartWidth: number,
   outerHeight: number,
   settings: ComputedVisualizationSettings,
@@ -348,7 +348,7 @@ const getTicksDimensions = (
 const TICK_OVERFLOW_BUFFER = 4;
 
 export const getChartPadding = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   settings: ComputedVisualizationSettings,
   ticksDimensions: TicksDimensions,
   axisEnabledSetting: ComputedVisualizationSettings["graph.x_axis.axis_enabled"],
@@ -478,7 +478,7 @@ export const getChartBounds = (
 };
 
 const getDimensionWidth = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   boundaryWidth: number,
 ) => {
   const { xAxisModel } = chartModel;
@@ -525,7 +525,7 @@ const areHorizontalXAxisTicksOverlapping = (
 };
 
 export const getChartMeasurements = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   settings: ComputedVisualizationSettings,
   hasTimelineEvents: boolean,
   width: number,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
@@ -16,7 +16,7 @@ import {
   getStackedLabelsFormatters,
 } from "metabase/visualizations/echarts/cartesian/model/series";
 import type {
-  CartesianChartModel,
+  BaseCartesianChartModel,
   ShowWarning,
 } from "metabase/visualizations/echarts/cartesian/model/types";
 import { getCartesianChartColumns } from "metabase/visualizations/lib/graph/columns";
@@ -81,7 +81,7 @@ export const getCartesianChartModel = (
   settings: ComputedVisualizationSettings,
   renderingContext: RenderingContext,
   showWarning?: ShowWarning,
-): CartesianChartModel => {
+): BaseCartesianChartModel => {
   // rawSeries has more than one element when two or more cards are combined on a dashboard
   const hasMultipleCards = rawSeries.length > 1;
   const cardsColumns = getCardsColumns(rawSeries, settings);
@@ -185,7 +185,6 @@ export const getCartesianChartModel = (
     leftAxisModel,
     rightAxisModel,
     trendLinesModel,
-    bubbleSizeDomain: null,
     seriesLabelsFormatters,
     stackedLabelsFormatters,
   };

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
@@ -16,7 +16,7 @@ import {
   getStackedLabelsFormatters,
 } from "metabase/visualizations/echarts/cartesian/model/series";
 import type {
-  BaseCartesianChartModel,
+  CartesianChartModel,
   ShowWarning,
 } from "metabase/visualizations/echarts/cartesian/model/types";
 import { getCartesianChartColumns } from "metabase/visualizations/lib/graph/columns";
@@ -81,7 +81,7 @@ export const getCartesianChartModel = (
   settings: ComputedVisualizationSettings,
   renderingContext: RenderingContext,
   showWarning?: ShowWarning,
-): BaseCartesianChartModel => {
+): CartesianChartModel => {
   // rawSeries has more than one element when two or more cards are combined on a dashboard
   const hasMultipleCards = rawSeries.length > 1;
   const cardsColumns = getCardsColumns(rawSeries, settings);

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
@@ -213,11 +213,14 @@ export type BaseCartesianChartModel = {
   trendLinesModel?: TrendLinesModel;
   seriesLabelsFormatters?: SeriesFormatters;
   stackedLabelsFormatters?: StackedSeriesFormatters;
-  waterfallLabelFormatter?: LabelFormatter;
 };
 
 export type CartesianChartModel = BaseCartesianChartModel & {
   bubbleSizeDomain: Extent | null;
+};
+
+export type WaterfallChartModel = BaseCartesianChartModel & {
+  waterfallLabelFormatter: LabelFormatter | undefined;
 };
 
 export type ShowWarning = (warning: string) => void;

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
@@ -192,7 +192,7 @@ export type StackModel = {
   seriesKeys: DataKey[];
 };
 
-export type BaseCartesianChartModel = {
+export type CartesianChartModel = {
   dimensionModel: DimensionModel;
   seriesModels: SeriesModel[];
   dataset: ChartDataset;
@@ -215,11 +215,11 @@ export type BaseCartesianChartModel = {
   stackedLabelsFormatters?: StackedSeriesFormatters;
 };
 
-export type ScatterPlotModel = BaseCartesianChartModel & {
+export type ScatterPlotModel = CartesianChartModel & {
   bubbleSizeDomain: Extent | null;
 };
 
-export type WaterfallChartModel = BaseCartesianChartModel & {
+export type WaterfallChartModel = CartesianChartModel & {
   waterfallLabelFormatter: LabelFormatter | undefined;
 };
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
@@ -215,7 +215,7 @@ export type BaseCartesianChartModel = {
   stackedLabelsFormatters?: StackedSeriesFormatters;
 };
 
-export type CartesianChartModel = BaseCartesianChartModel & {
+export type ScatterPlotModel = BaseCartesianChartModel & {
   bubbleSizeDomain: Extent | null;
 };
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
@@ -4,7 +4,7 @@ import type { AxisBaseOptionCommon } from "echarts/types/src/coord/axisCommonTyp
 import { parseNumberValue } from "metabase/lib/number";
 import { CHART_STYLE } from "metabase/visualizations/echarts/cartesian/constants/style";
 import type {
-  BaseCartesianChartModel,
+  CartesianChartModel,
   DataKey,
   Extent,
   NumericAxisScaleTransforms,
@@ -107,7 +107,7 @@ export const getDimensionTicksDefaultOption = (
 };
 
 const getHistogramTicksOptions = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   settings: ComputedVisualizationSettings,
   chartMeasurements: ChartMeasurements,
 ) => {
@@ -185,7 +185,7 @@ const getCommonDimensionAxisOptions = (
 };
 
 export const buildDimensionAxis = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   width: number,
   settings: ComputedVisualizationSettings,
   chartMeasurements: ChartMeasurements,
@@ -308,7 +308,7 @@ export const buildTimeSeriesDimensionAxis = (
 };
 
 export const buildCategoricalDimensionAxis = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   originalSettings: ComputedVisualizationSettings,
   chartMeasurements: ChartMeasurements,
   renderingContext: RenderingContext,
@@ -411,7 +411,7 @@ export const buildMetricAxis = (
 };
 
 const buildMetricsAxes = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   chartMeasurements: ChartMeasurements,
   settings: ComputedVisualizationSettings,
   hoveredSeriesDataKey: DataKey | null,
@@ -455,7 +455,7 @@ const buildMetricsAxes = (
 };
 
 export const buildAxes = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   width: number,
   chartMeasurements: ChartMeasurements,
   settings: ComputedVisualizationSettings,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/goal-line.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/goal-line.ts
@@ -8,7 +8,7 @@ import type {
 import type { EChartsCartesianCoordinateSystem } from "../../types";
 import { GOAL_LINE_SERIES_ID, X_AXIS_DATA_KEY } from "../constants/dataset";
 import { CHART_STYLE } from "../constants/style";
-import type { CartesianChartModel, ChartDataset } from "../model/types";
+import type { ChartDataset, BaseCartesianChartModel } from "../model/types";
 
 export const GOAL_LINE_DASH = [3, 4];
 
@@ -27,7 +27,7 @@ function getFirstNonNullXValue(dataset: ChartDataset) {
 }
 
 export function getGoalLineSeriesOption(
-  chartModel: CartesianChartModel,
+  chartModel: BaseCartesianChartModel,
   settings: ComputedVisualizationSettings,
   renderingContext: RenderingContext,
 ): CustomSeriesOption | null {

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/goal-line.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/goal-line.ts
@@ -8,7 +8,7 @@ import type {
 import type { EChartsCartesianCoordinateSystem } from "../../types";
 import { GOAL_LINE_SERIES_ID, X_AXIS_DATA_KEY } from "../constants/dataset";
 import { CHART_STYLE } from "../constants/style";
-import type { ChartDataset, BaseCartesianChartModel } from "../model/types";
+import type { ChartDataset, CartesianChartModel } from "../model/types";
 
 export const GOAL_LINE_DASH = [3, 4];
 
@@ -27,7 +27,7 @@ function getFirstNonNullXValue(dataset: ChartDataset) {
 }
 
 export function getGoalLineSeriesOption(
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   settings: ComputedVisualizationSettings,
   renderingContext: RenderingContext,
 ): CustomSeriesOption | null {

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
@@ -8,7 +8,7 @@ import {
 } from "metabase/visualizations/echarts/cartesian/constants/dataset";
 import type {
   DataKey,
-  BaseCartesianChartModel,
+  CartesianChartModel,
 } from "metabase/visualizations/echarts/cartesian/model/types";
 import { buildAxes } from "metabase/visualizations/echarts/cartesian/option/axis";
 import { buildEChartsSeries } from "metabase/visualizations/echarts/cartesian/option/series";
@@ -42,7 +42,7 @@ export const getSharedEChartsOptions = (isPlaceholder: boolean) => ({
 });
 
 export const getCartesianChartOption = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   chartMeasurements: ChartMeasurements,
   timelineEventsModel: TimelineEventsModel | null,
   selectedTimelineEventsIds: TimelineEventId[],

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
@@ -7,8 +7,8 @@ import {
   X_AXIS_DATA_KEY,
 } from "metabase/visualizations/echarts/cartesian/constants/dataset";
 import type {
-  CartesianChartModel,
   DataKey,
+  BaseCartesianChartModel,
 } from "metabase/visualizations/echarts/cartesian/model/types";
 import { buildAxes } from "metabase/visualizations/echarts/cartesian/option/axis";
 import { buildEChartsSeries } from "metabase/visualizations/echarts/cartesian/option/series";
@@ -42,7 +42,7 @@ export const getSharedEChartsOptions = (isPlaceholder: boolean) => ({
 });
 
 export const getCartesianChartOption = (
-  chartModel: CartesianChartModel,
+  chartModel: BaseCartesianChartModel,
   chartMeasurements: ChartMeasurements,
   timelineEventsModel: TimelineEventsModel | null,
   selectedTimelineEventsIds: TimelineEventId[],

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -16,7 +16,6 @@ import {
 } from "metabase/visualizations/echarts/cartesian/constants/style";
 import type {
   SeriesModel,
-  CartesianChartModel,
   DataKey,
   StackTotalDataKey,
   ChartDataset,
@@ -27,6 +26,7 @@ import type {
   NumericAxisScaleTransforms,
   LabelFormatter,
   StackModel,
+  BaseCartesianChartModel,
 } from "metabase/visualizations/echarts/cartesian/model/types";
 import type { EChartsSeriesOption } from "metabase/visualizations/echarts/cartesian/option/types";
 import type {
@@ -444,7 +444,7 @@ function getStackedDataLabelFormatter(
 }
 
 export const getStackTotalsSeries = (
-  chartModel: CartesianChartModel,
+  chartModel: BaseCartesianChartModel,
   yAxisScaleTransforms: NumericAxisScaleTransforms,
   settings: ComputedVisualizationSettings,
   seriesOptions: (LineSeriesOption | BarSeriesOption)[],
@@ -515,7 +515,7 @@ const getDisplaySeriesSettingsByDataKey = (
 };
 
 export const buildEChartsSeries = (
-  chartModel: CartesianChartModel,
+  chartModel: BaseCartesianChartModel,
   settings: ComputedVisualizationSettings,
   chartWidth: number,
   chartMeasurements: ChartMeasurements,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -26,7 +26,7 @@ import type {
   NumericAxisScaleTransforms,
   LabelFormatter,
   StackModel,
-  BaseCartesianChartModel,
+  CartesianChartModel,
 } from "metabase/visualizations/echarts/cartesian/model/types";
 import type { EChartsSeriesOption } from "metabase/visualizations/echarts/cartesian/option/types";
 import type {
@@ -444,7 +444,7 @@ function getStackedDataLabelFormatter(
 }
 
 export const getStackTotalsSeries = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   yAxisScaleTransforms: NumericAxisScaleTransforms,
   settings: ComputedVisualizationSettings,
   seriesOptions: (LineSeriesOption | BarSeriesOption)[],
@@ -515,7 +515,7 @@ const getDisplaySeriesSettingsByDataKey = (
 };
 
 export const buildEChartsSeries = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   settings: ComputedVisualizationSettings,
   chartWidth: number,
   chartMeasurements: ChartMeasurements,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/trend-line.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/trend-line.ts
@@ -4,14 +4,14 @@ import _ from "underscore";
 import { X_AXIS_DATA_KEY } from "metabase/visualizations/echarts/cartesian/constants/dataset";
 
 import { CHART_STYLE } from "../constants/style";
-import type { CartesianChartModel } from "../model/types";
+import type { BaseCartesianChartModel } from "../model/types";
 
 import { getSeriesYAxisIndex } from "./utils";
 
 export const TREND_LINE_DASH = [5, 5];
 
 export function getTrendLinesOption(
-  chartModel: CartesianChartModel,
+  chartModel: BaseCartesianChartModel,
 ): LineSeriesOption[] {
   return (
     chartModel.trendLinesModel?.seriesModels.map(trendSeries => ({

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/trend-line.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/trend-line.ts
@@ -4,14 +4,14 @@ import _ from "underscore";
 import { X_AXIS_DATA_KEY } from "metabase/visualizations/echarts/cartesian/constants/dataset";
 
 import { CHART_STYLE } from "../constants/style";
-import type { BaseCartesianChartModel } from "../model/types";
+import type { CartesianChartModel } from "../model/types";
 
 import { getSeriesYAxisIndex } from "./utils";
 
 export const TREND_LINE_DASH = [5, 5];
 
 export function getTrendLinesOption(
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
 ): LineSeriesOption[] {
   return (
     chartModel.trendLinesModel?.seriesModels.map(trendSeries => ({

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/utils.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/utils.ts
@@ -1,8 +1,8 @@
-import type { CartesianChartModel, DataKey } from "../model/types";
+import type { DataKey, BaseCartesianChartModel } from "../model/types";
 
 export function getSeriesYAxisIndex(
   dataKey: DataKey,
-  chartModel: CartesianChartModel,
+  chartModel: BaseCartesianChartModel,
 ): number {
   const { leftAxisModel, rightAxisModel } = chartModel;
   const hasSingleYAxis = leftAxisModel == null || rightAxisModel == null;

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/utils.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/utils.ts
@@ -1,8 +1,8 @@
-import type { DataKey, BaseCartesianChartModel } from "../model/types";
+import type { DataKey, CartesianChartModel } from "../model/types";
 
 export function getSeriesYAxisIndex(
   dataKey: DataKey,
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
 ): number {
   const { leftAxisModel, rightAxisModel } = chartModel;
   const hasSingleYAxis = leftAxisModel == null || rightAxisModel == null;

--- a/frontend/src/metabase/visualizations/echarts/cartesian/scatter/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/scatter/model/index.ts
@@ -23,7 +23,7 @@ import {
 import { getAxisTransforms } from "../../model/transforms";
 import { getTrendLines } from "../../model/trend-line";
 import type {
-  CartesianChartModel,
+  ScatterPlotModel,
   ChartDataset,
   Extent,
   SeriesModel,
@@ -62,7 +62,7 @@ export function getScatterPlotModel(
   settings: ComputedVisualizationSettings,
   renderingContext: RenderingContext,
   showWarning?: ShowWarning,
-): CartesianChartModel {
+): ScatterPlotModel {
   // rawSeries has more than one element when two or more cards are combined on a dashboard
   const hasMultipleCards = rawSeries.length > 1;
   const cardsColumns = getCardsColumns(rawSeries, settings);

--- a/frontend/src/metabase/visualizations/echarts/cartesian/scatter/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/scatter/option/index.ts
@@ -9,7 +9,7 @@ import type { TimelineEventId } from "metabase-types/api";
 
 import type { ChartMeasurements } from "../../chart-measurements/types";
 import { X_AXIS_DATA_KEY } from "../../constants/dataset";
-import type { CartesianChartModel } from "../../model/types";
+import type { ScatterPlotModel } from "../../model/types";
 import { getSharedEChartsOptions } from "../../option";
 import { buildAxes } from "../../option/axis";
 import { getGoalLineSeriesOption } from "../../option/goal-line";
@@ -22,7 +22,7 @@ import type { TimelineEventsModel } from "../../timeline-events/types";
 import { buildEChartsScatterSeries } from "./series";
 
 export function getScatterPlotOption(
-  chartModel: CartesianChartModel,
+  chartModel: ScatterPlotModel,
   chartMeasurements: ChartMeasurements,
   timelineEventsModel: TimelineEventsModel | null,
   selectedTimelineEventsIds: TimelineEventId[],

--- a/frontend/src/metabase/visualizations/echarts/cartesian/timeline-events/model.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/timeline-events/model.ts
@@ -4,7 +4,7 @@ import _ from "underscore";
 
 import { CHART_STYLE } from "metabase/visualizations/echarts/cartesian/constants/style";
 import type {
-  BaseCartesianChartModel,
+  CartesianChartModel,
   DateRange,
 } from "metabase/visualizations/echarts/cartesian/model/types";
 import type { TimelineEventGroup } from "metabase/visualizations/echarts/cartesian/timeline-events/types";
@@ -132,7 +132,7 @@ const getTimelineEventsInsideRange = (
 };
 
 export const getTimelineEventsModel = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   chartMeasurements: ChartMeasurements,
   timelineEvents: TimelineEvent[],
   renderingContext: RenderingContext,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/index.ts
@@ -11,8 +11,8 @@ import {
   getWaterfallLabelFormatter,
 } from "metabase/visualizations/echarts/cartesian/model/series";
 import type {
-  BaseCartesianChartModel,
   ShowWarning,
+  WaterfallChartModel,
 } from "metabase/visualizations/echarts/cartesian/model/types";
 import { getCartesianChartColumns } from "metabase/visualizations/lib/graph/columns";
 import type {
@@ -35,7 +35,7 @@ export const getWaterfallChartModel = (
   settings: ComputedVisualizationSettings,
   renderingContext: RenderingContext,
   showWarning?: ShowWarning,
-): BaseCartesianChartModel => {
+): WaterfallChartModel => {
   // Waterfall chart support one card only
   const [singleRawSeries] = rawSeries;
   const { data } = singleRawSeries;

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/option/index.ts
@@ -4,7 +4,7 @@ import type { LabelLayoutOptionCallback } from "echarts/types/src/util/types";
 import { X_AXIS_DATA_KEY } from "metabase/visualizations/echarts/cartesian/constants/dataset";
 import { CHART_STYLE } from "metabase/visualizations/echarts/cartesian/constants/style";
 import type {
-  BaseCartesianChartModel,
+  CartesianChartModel,
   ChartDataset,
   LabelFormatter,
   WaterfallChartModel,
@@ -75,7 +75,7 @@ const getLabelLayoutFn = (
 };
 
 const computeWaterfallBarWidth = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   boundaryWidth: number,
 ) => {
   if (isCategoryAxis(chartModel.xAxisModel)) {
@@ -94,7 +94,7 @@ const computeWaterfallBarWidth = (
 };
 
 export const buildEChartsWaterfallSeries = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   settings: ComputedVisualizationSettings,
   chartMeasurements: ChartMeasurements,
   labelFormatter: LabelFormatter | undefined,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/option/index.ts
@@ -7,6 +7,7 @@ import type {
   BaseCartesianChartModel,
   ChartDataset,
   LabelFormatter,
+  WaterfallChartModel,
 } from "metabase/visualizations/echarts/cartesian/model/types";
 import {
   buildEChartsLabelOptions,
@@ -202,7 +203,7 @@ export const buildEChartsWaterfallSeries = (
 };
 
 export const getWaterfallChartOption = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: WaterfallChartModel,
   chartWidth: number,
   chartMeasurements: ChartMeasurements,
   timelineEventsModel: TimelineEventsModel | null,
@@ -224,7 +225,7 @@ export const getWaterfallChartOption = (
     chartModel,
     settings,
     chartMeasurements,
-    chartModel?.waterfallLabelFormatter,
+    chartModel.waterfallLabelFormatter,
     renderingContext,
   );
 

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
@@ -18,7 +18,7 @@ import {
   isTimeSeriesAxis,
 } from "metabase/visualizations/echarts/cartesian/model/guards";
 import type {
-  BaseCartesianChartModel,
+  CartesianChartModel,
   ChartDataset,
   DataKey,
   Datum,
@@ -76,7 +76,7 @@ export const parseDataKey = (dataKey: DataKey) => {
 };
 
 const findSeriesModelIndexById = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   seriesId?: string,
 ) => {
   if (seriesId == null) {
@@ -105,7 +105,7 @@ const getSameCardDataKeys = (
 };
 
 export const getEventDimensions = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   datum: Datum,
   dimensionModel: DimensionModel,
   seriesModel: SeriesModel,
@@ -143,7 +143,7 @@ export const getEventDimensions = (
 };
 
 const getEventColumnsData = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   seriesIndex: number,
   dataIndex: number,
 ): DataPoint[] => {
@@ -192,7 +192,7 @@ const getEventColumnsData = (
 };
 
 const getTooltipFooterData = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   display: string,
   seriesIndex: number,
   dataIndex: number,
@@ -261,7 +261,7 @@ const getTooltipFooterData = (
 };
 
 const getStackedTooltipModel = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   settings: ComputedVisualizationSettings,
   seriesIndex: number,
   dataIndex: number,
@@ -378,7 +378,7 @@ const isValidDatumElement = (
 };
 
 export const getSeriesHoverData = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   settings: ComputedVisualizationSettings,
   display: string,
   event: EChartsSeriesMouseEvent,
@@ -488,7 +488,7 @@ export const getGoalLineHoverData = (
 };
 
 export const getSeriesClickData = (
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   settings: ComputedVisualizationSettings,
   event: EChartsSeriesMouseEvent,
 ): ClickObject | undefined => {
@@ -528,7 +528,7 @@ export const getSeriesClickData = (
 export const getBrushData = (
   rawSeries: RawSeries,
   metadata: Metadata,
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   event: EChartsSeriesBrushEndEvent,
 ) => {
   const range = event.areas[0].coordRange;

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-debug.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-debug.ts
@@ -3,7 +3,7 @@ import type { EChartsCoreOption } from "echarts/core";
 import { useEffect } from "react";
 
 import { isChartsDebugLoggingEnabled } from "metabase/env";
-import type { BaseCartesianChartModel } from "metabase/visualizations/echarts/cartesian/model/types";
+import type { CartesianChartModel } from "metabase/visualizations/echarts/cartesian/model/types";
 import type { RawSeries } from "metabase-types/api";
 
 export function useChartDebug({
@@ -15,7 +15,7 @@ export function useChartDebug({
   isQueryBuilder: boolean;
   rawSeries: RawSeries;
   option: EChartsCoreOption;
-  chartModel: BaseCartesianChartModel;
+  chartModel: CartesianChartModel;
 }) {
   useEffect(() => {
     if (!isQueryBuilder || !isChartsDebugLoggingEnabled) {

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
@@ -8,7 +8,7 @@ import {
   TIMELINE_EVENT_DATA_NAME,
 } from "metabase/visualizations/echarts/cartesian/constants/dataset";
 import type {
-  BaseCartesianChartModel,
+  CartesianChartModel,
   ChartDataset,
 } from "metabase/visualizations/echarts/cartesian/model/types";
 import type { TimelineEventsModel } from "metabase/visualizations/echarts/cartesian/timeline-events/types";
@@ -34,7 +34,7 @@ import { getHoveredEChartsSeriesIndex } from "./utils";
 
 export const useChartEvents = (
   chartRef: React.MutableRefObject<EChartsType | undefined>,
-  chartModel: BaseCartesianChartModel,
+  chartModel: CartesianChartModel,
   timelineEventsModel: TimelineEventsModel | null,
   option: EChartsCoreOption,
   {

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-models-and-option.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-models-and-option.ts
@@ -8,7 +8,7 @@ import { extractRemappings } from "metabase/visualizations";
 import { getChartMeasurements } from "metabase/visualizations/echarts/cartesian/chart-measurements";
 import { getCartesianChartModel } from "metabase/visualizations/echarts/cartesian/model";
 import type {
-  CartesianChartModel,
+  ScatterPlotModel,
   WaterfallChartModel,
 } from "metabase/visualizations/echarts/cartesian/model/types";
 import { getCartesianChartOption } from "metabase/visualizations/echarts/cartesian/option";
@@ -156,7 +156,7 @@ export function useModelsAndOption({
         );
       case "scatter":
         return getScatterPlotOption(
-          chartModel as CartesianChartModel,
+          chartModel as ScatterPlotModel,
           chartMeasurements,
           timelineEventsModel,
           selectedOrHoveredTimelineEventIds,
@@ -167,7 +167,7 @@ export function useModelsAndOption({
         );
       default:
         return getCartesianChartOption(
-          chartModel as CartesianChartModel,
+          chartModel,
           chartMeasurements,
           timelineEventsModel,
           selectedOrHoveredTimelineEventIds,

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-models-and-option.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-models-and-option.ts
@@ -70,29 +70,15 @@ export function useModelsAndOption({
     : false;
 
   const chartModel = useMemo(() => {
-    switch (card.display) {
-      case "waterfall":
-        return getWaterfallChartModel(
-          seriesToRender,
-          settings,
-          renderingContext,
-          showWarning,
-        );
-      case "scatter":
-        return getScatterPlotModel(
-          seriesToRender,
-          settings,
-          renderingContext,
-          showWarning,
-        );
-      default:
-        return getCartesianChartModel(
-          seriesToRender,
-          settings,
-          renderingContext,
-          showWarning,
-        );
+    let getModel = getCartesianChartModel;
+
+    if (card.display === "waterfall") {
+      getModel = getWaterfallChartModel;
+    } else if (card.display === "scatter") {
+      getModel = getScatterPlotModel;
     }
+
+    return getModel(seriesToRender, settings, renderingContext, showWarning);
   }, [card.display, seriesToRender, settings, renderingContext, showWarning]);
 
   const chartMeasurements = useMemo(

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-models-and-option.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-models-and-option.ts
@@ -7,7 +7,10 @@ import { measureTextWidth } from "metabase/lib/measure-text";
 import { extractRemappings } from "metabase/visualizations";
 import { getChartMeasurements } from "metabase/visualizations/echarts/cartesian/chart-measurements";
 import { getCartesianChartModel } from "metabase/visualizations/echarts/cartesian/model";
-import type { CartesianChartModel } from "metabase/visualizations/echarts/cartesian/model/types";
+import type {
+  CartesianChartModel,
+  WaterfallChartModel,
+} from "metabase/visualizations/echarts/cartesian/model/types";
 import { getCartesianChartOption } from "metabase/visualizations/echarts/cartesian/option";
 import { getScatterPlotModel } from "metabase/visualizations/echarts/cartesian/scatter/model";
 import { getScatterPlotOption } from "metabase/visualizations/echarts/cartesian/scatter/option";
@@ -142,7 +145,7 @@ export function useModelsAndOption({
     switch (card.display) {
       case "waterfall":
         return getWaterfallChartOption(
-          chartModel,
+          chartModel as WaterfallChartModel,
           width,
           chartMeasurements,
           timelineEventsModel,

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/utils.ts
@@ -3,7 +3,7 @@ import { t } from "ttag";
 
 import { isNotNull } from "metabase/lib/types";
 import type {
-  BaseCartesianChartModel,
+  CartesianChartModel,
   DataKey,
   SeriesModel,
 } from "metabase/visualizations/echarts/cartesian/model/types";
@@ -57,7 +57,7 @@ export const getGridSizeAdjustedSettings = (
 
 export const MAX_SERIES = 100;
 
-export const validateChartModel = (chartModel: BaseCartesianChartModel) => {
+export const validateChartModel = (chartModel: CartesianChartModel) => {
   if (chartModel.seriesModels.length > MAX_SERIES) {
     throw new Error(
       t`This chart type doesn't support more than ${MAX_SERIES} series of data.`,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/36825

### Description

After refactoring the scatter plot to use separate code paths, we finally update the chart model types to have better separation.

Since there's a lot of files changed, it'll be easiest to start reviewing `echarts/cartesian/model/types.ts`

### How to verify

CI