### PR TITLE
Fix missing closing bracket in documentation SQL query

### DIFF
--- a/docs/questions/native-editor/sql-parameters.md
+++ b/docs/questions/native-editor/sql-parameters.md
@@ -375,7 +375,7 @@ FROM
   products
 WHERE
   TRUE
-  [[AND id = {{id}}]
+  [[AND id = {{id}}]]
   [[AND {{category}}]]
 {% endraw %}
 ```


### PR DESCRIPTION
> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label
> to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this
> PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71)
> in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not
> apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform) (unless it's a tiny documentation change). Also, if you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.

Closes https://github.com/metabase/metabase/issues/[issue_number]

### Description

This merge request corrects a minor syntax error in the SQL query template example provided in the Metabase documentation. Specifically, it adds a missing closing bracket to the condition checking the id 

#### Changes made:

Added the missing closing bracket in the SQL query template example in the documentation:
```
Before:
  [[AND id = {{id}}]
After:
  [[AND id = {{id}}]]
```

### How to verify

To verify this change, follow these steps:

1. Open Metabase.
2. Create a new question and use the Sample Dataset.
3. Switch to the native query editor and run the following query

```
SELECT
  count(*)
FROM
  products
WHERE
  TRUE
  [[AND id = {{id}}]]
  [[AND {{category}}]]
```

### Demo

No demo video or screenshots are necessary for this change as it is a simple documentation correction.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
