### PR TITLE
Remove fixed height on popover

### DIFF
--- a/frontend/src/metabase/visualizations/click-actions/actions/ExtractColumn/ExtractColumn.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/ExtractColumn/ExtractColumn.tsx
@@ -53,7 +53,7 @@ export const ExtractColumnAction: LegacyDrill = ({ question, clicked }) => {
     }
 
     return (
-      <Box h="65vh" mah={rem(550)}>
+      <Box mah={rem(550)}>
         <ExtractColumn
           query={query}
           stageIndex={stageIndex}


### PR DESCRIPTION
Remove the fixed height on the actions popover which was causing a visual bug.

### Before
![image](https://github.com/metabase/metabase/assets/1250185/0274d511-7f1a-4510-a117-236b527439dd)

### After
<img width="329" alt="Screenshot 2024-05-23 at 12 16 10" src="https://github.com/metabase/metabase/assets/1250185/3ed0672e-29d9-4677-8761-61fd6f6a4c46">
