### PR TITLE
Fix breakout pivot tether

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/reproductions/43075-dropdown-overflows.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-charts/reproductions/43075-dropdown-overflows.cy.spec.ts
@@ -9,7 +9,6 @@ import {
 const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
 
 const questionDetails: StructuredQuestionDetails = {
-  name: "20548",
   query: {
     "source-table": PRODUCTS_ID,
     aggregation: [["count"]],

--- a/e2e/test/scenarios/visualizations-charts/reproductions/43075-dropdown-overflows.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-charts/reproductions/43075-dropdown-overflows.cy.spec.ts
@@ -28,7 +28,7 @@ describe("issue 43075", () => {
     createQuestion(questionDetails, { visitQuestion: true });
   });
 
-  it("the breakthrough popover should fit within the window (metabase#43075)", () => {
+  it("the breakout popover should fit within the window (metabase#43075)", () => {
     cy.get("[data-testid=cell-data]").contains("54").click();
     popover().findByText("Break out by…").click();
     popover().findByText("Category").click();

--- a/e2e/test/scenarios/visualizations-charts/reproductions/43075-dropdown-overflows.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-charts/reproductions/43075-dropdown-overflows.cy.spec.ts
@@ -19,7 +19,6 @@ const questionDetails: StructuredQuestionDetails = {
 describe("issue 43075", () => {
   beforeEach(() => {
     cy.viewport(1000, 300);
-    cy.intercept("POST", "/api/dataset").as("dataset");
 
     restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/visualizations-charts/reproductions/43075-dropdown-overflows.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-charts/reproductions/43075-dropdown-overflows.cy.spec.ts
@@ -29,7 +29,7 @@ describe("issue 43075", () => {
   });
 
   it("the breakout popover should fit within the window (metabase#43075)", () => {
-    cy.get("[data-testid=cell-data]").contains("54").click();
+    cy.findAllByTestId("cell-data").contains("54").click();
     popover().findByText("Break out by…").click();
     popover().findByText("Category").click();
 

--- a/e2e/test/scenarios/visualizations-charts/reproductions/43075-dropdown-overflows.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-charts/reproductions/43075-dropdown-overflows.cy.spec.ts
@@ -1,0 +1,42 @@
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import {
+  createQuestion,
+  popover,
+  restore,
+  type StructuredQuestionDetails,
+} from "e2e/support/helpers";
+
+const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
+
+const questionDetails: StructuredQuestionDetails = {
+  name: "20548",
+  query: {
+    "source-table": PRODUCTS_ID,
+    aggregation: [["count"]],
+    breakout: [["field", PRODUCTS.CATEGORY, null]],
+  },
+};
+
+describe("issue 43075", () => {
+  beforeEach(() => {
+    cy.viewport(1000, 300);
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
+    restore();
+    cy.signInAsAdmin();
+
+    createQuestion(questionDetails, { visitQuestion: true });
+  });
+
+  it("the breakthrough popover should fit within the window (metabase#43075)", () => {
+    cy.get("[data-testid=cell-data]").contains("54").click();
+    popover().findByText("Break out by…").click();
+    popover().findByText("Category").click();
+
+    cy.window().then(win => {
+      expect(win.document.documentElement.scrollHeight).to.be.lte(
+        win.document.documentElement.offsetHeight,
+      );
+    });
+  });
+});

--- a/frontend/src/metabase/querying/utils/drills/pivot-drill/pivot-drill.tsx
+++ b/frontend/src/metabase/querying/utils/drills/pivot-drill/pivot-drill.tsx
@@ -1,6 +1,7 @@
 import { t } from "ttag";
 
 import { QueryColumnPicker } from "metabase/common/components/QueryColumnPicker";
+import { Box } from "metabase/ui";
 import { ClickActionsView } from "metabase/visualizations/components/ClickActions";
 import type {
   ClickActionPopoverProps,
@@ -86,18 +87,20 @@ function getColumnPopover(
     onClose,
   }: ClickActionPopoverProps) {
     return (
-      <QueryColumnPicker
-        query={query}
-        stageIndex={stageIndex}
-        columnGroups={Lib.groupColumns(columns)}
-        checkIsColumnSelected={() => false}
-        onSelect={column => {
-          const nextQuestion = applyDrill(drill, column).setDefaultDisplay();
-          const nextCard = nextQuestion.card();
-          onChangeCardAndRun({ nextCard });
-        }}
-        onClose={onClose}
-      />
+      <Box mah="65vh">
+        <QueryColumnPicker
+          query={query}
+          stageIndex={stageIndex}
+          columnGroups={Lib.groupColumns(columns)}
+          checkIsColumnSelected={() => false}
+          onSelect={column => {
+            const nextQuestion = applyDrill(drill, column).setDefaultDisplay();
+            const nextCard = nextQuestion.card();
+            onChangeCardAndRun({ nextCard });
+          }}
+          onClose={onClose}
+        />
+      </Box>
     );
   };
 }

--- a/frontend/src/metabase/visualizations/components/ClickActions/ClickActionsPopover.tsx
+++ b/frontend/src/metabase/visualizations/components/ClickActions/ClickActionsPopover.tsx
@@ -169,6 +169,8 @@ export class ClickActionsPopover extends Component<
               name: "preventOverflow",
               options: {
                 padding: 16,
+                altAxis: true,
+                tether: false,
               },
             },
           ],


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/43075

Fixes an issue where the popover on the click actions in the visualization was placed with overflow on the window.

### Description

1. Adds a max height on the popover content 
2. Allow the click action popover to untether when necessary to prevent overflowing the viewport

### How to verify

1. New question -> Sample database -> People
2. Add an aggregation -> Count of rows -> Source
3. Visualize
4. Click on one of the visualization columns
5. Break out by
6. Time

The resulting popover should not overflow the screen.

### Demo
_Note: This demo artificially adds more content to the popover since we don't have big enough tables in the dev database for this to be a problem._

https://github.com/metabase/metabase/assets/1250185/2db06d8f-dde3-4edd-b6bf-dcfba31bbc21
 
