### PR TITLE
Revert "Load dashcard metadata in parallel with the query"

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-nested.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-nested.cy.spec.js
@@ -78,11 +78,8 @@ describe("scenarios > dashboard > filters > nested questions", () => {
     // Add multiple values (metabase#18113)
     filterWidget().click();
     popover().within(() => {
-      cy.findByPlaceholderText("Enter some text")
-        .type("Gizmo")
-        .blur()
-        .type("Gadget")
-        .blur();
+      cy.findByText("Gizmo").click();
+      cy.findByText("Gadget").click();
     });
 
     cy.button("Add filter").click();

--- a/frontend/src/metabase-lib/v1/parameters/utils/targets.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/targets.ts
@@ -45,6 +45,7 @@ export function getParameterTargetField(
   }
 
   const fieldRef = target[1];
+  const query = question.query();
   const metadata = question.metadata();
 
   // native queries
@@ -59,12 +60,8 @@ export function getParameterTargetField(
 
   if (isConcreteFieldReference(fieldRef)) {
     const fieldId = fieldRef[1];
-    const resultMetadata = question.getResultMetadata();
-    const fieldMetadata = resultMetadata.find(field => field.id === fieldId);
-    return (
-      metadata.field(fieldId, fieldMetadata?.table_id) ??
-      metadata.field(fieldId)
-    );
+    const tableId = Lib.sourceTableOrCardId(query);
+    return metadata.field(fieldId, tableId) ?? metadata.field(fieldId);
   }
 
   return null;

--- a/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.tsx
+++ b/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.tsx
@@ -498,7 +498,6 @@ export function FieldValuesWidgetInner({
             }}
             onInputChange={onInputChange}
             parseFreeformValue={parseFreeformValue}
-            updateOnInputBlur
           />
         )}
       </div>

--- a/frontend/src/metabase/dashboard/actions/cards-typed.ts
+++ b/frontend/src/metabase/dashboard/actions/cards-typed.ts
@@ -1,4 +1,3 @@
-import { loadMetadataForDashcards } from "metabase/dashboard/actions/metadata";
 import Questions from "metabase/entities/questions";
 import {
   DEFAULT_CARD_SIZE,
@@ -41,6 +40,7 @@ import {
   setDashCardAttributes,
 } from "./core";
 import { cancelFetchCardData, fetchCardData } from "./data-fetching";
+import { loadMetadataForDashboard } from "./metadata";
 import { getExistingDashCards } from "./utils";
 
 export type NewDashCardOpts = {
@@ -158,7 +158,7 @@ export const addCardToDashboard =
     );
 
     dispatch(fetchCardData(card, dashcard, { reload: true, clearCache: true }));
-    await dispatch(loadMetadataForDashcards([dashcard]));
+    await dispatch(loadMetadataForDashboard([dashcard]));
     dispatch(autoWireParametersToNewCard({ dashcard_id: dashcardId }));
   };
 
@@ -233,7 +233,7 @@ export const replaceCard =
     const dashcard = getDashCardById(getState(), dashcardId);
 
     dispatch(fetchCardData(card, dashcard, { reload: true, clearCache: true }));
-    await dispatch(loadMetadataForDashcards([dashcard]));
+    await dispatch(loadMetadataForDashboard([dashcard]));
     dispatch(autoWireParametersToNewCard({ dashcard_id: dashcardId }));
 
     dashboardId && trackQuestionReplaced(dashboardId);

--- a/frontend/src/metabase/dashboard/actions/data-fetching.js
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.js
@@ -33,18 +33,19 @@ import {
   getCurrentTabDashboardCards,
 } from "../utils";
 
-import { loadMetadataForDashcards } from "./metadata";
+import { loadMetadataForDashboard } from "./metadata";
 
 export const FETCH_DASHBOARD_CARD_DATA =
   "metabase/dashboard/FETCH_DASHBOARD_CARD_DATA";
 export const CANCEL_FETCH_DASHBOARD_CARD_DATA =
   "metabase/dashboard/CANCEL_FETCH_DASHBOARD_CARD_DATA";
 
+export const FETCH_DASHBOARD_CARD_METADATA =
+  "metabase/dashboard/FETCH_DASHBOARD_CARD_METADATA";
+
 export const FETCH_CARD_DATA = "metabase/dashboard/FETCH_CARD_DATA";
 export const FETCH_CARD_DATA_PENDING =
   "metabase/dashboard/FETCH_CARD_DATA/pending";
-
-export const FETCH_CARD_QUERY = "metabase/dashboard/FETCH_CARD_QUERY";
 
 export const CANCEL_FETCH_CARD_DATA =
   "metabase/dashboard/CANCEL_FETCH_CARD_DATA";
@@ -117,7 +118,7 @@ const loadingComplete = createThunkAction(
 
 export const fetchCardData = createThunkAction(
   FETCH_CARD_DATA,
-  function (card, dashcard, options) {
+  function (card, dashcard, { reload, clearCache, ignoreCache } = {}) {
     return async function (dispatch, getState) {
       dispatch({
         type: FETCH_CARD_DATA_PENDING,
@@ -127,28 +128,6 @@ export const fetchCardData = createThunkAction(
         },
       });
 
-      const requests = [dispatch(fetchCardQuery(card, dashcard, options))];
-
-      const dashboardType = getDashboardType(dashcard.dashboard_id);
-      if (dashboardType === "normal" || dashboardType === "transient") {
-        requests.push(dispatch(loadMetadataForDashcards([dashcard])));
-      }
-
-      const [{ payload }] = await Promise.all(requests);
-
-      return {
-        dashcard_id: dashcard.id,
-        card_id: card.id,
-        ...payload,
-      };
-    };
-  },
-);
-
-export const fetchCardQuery = createThunkAction(
-  FETCH_CARD_QUERY,
-  function (card, dashcard, { reload, clearCache, ignoreCache } = {}) {
-    return async function (dispatch, getState) {
       // If the dataset_query was filtered then we don't have permission to view this card, so
       // shortcircuit and return a fake 403
       if (!card.dataset_query) {
@@ -396,6 +375,20 @@ export const fetchDashboardCardData =
       });
     }
   };
+
+export const fetchDashboardCardMetadata = createThunkAction(
+  FETCH_DASHBOARD_CARD_METADATA,
+  () => async (dispatch, getState) => {
+    const allDashCards = getDashboardComplete(getState()).dashcards;
+    const selectedTabId = getSelectedTabId(getState());
+
+    const cards = allDashCards.filter(
+      dc =>
+        selectedTabId !== undefined && dc.dashboard_tab_id === selectedTabId,
+    );
+    await dispatch(loadMetadataForDashboard(cards));
+  },
+);
 
 export const reloadDashboardCards = () => async (dispatch, getState) => {
   const dashboard = getDashboardComplete(getState());

--- a/frontend/src/metabase/dashboard/actions/metadata.js
+++ b/frontend/src/metabase/dashboard/actions/metadata.js
@@ -4,14 +4,14 @@ import { loadMetadataForCard } from "metabase/questions/actions";
 
 import { isVirtualDashCard } from "../utils";
 
-export const loadMetadataForDashcards = dashcards => async dispatch => {
-  const cards = dashcards
+export const loadMetadataForDashboard = dashCards => async dispatch => {
+  const cards = dashCards
     .filter(dc => !isVirtualDashCard(dc)) // exclude text cards
     .flatMap(dc => [dc.card].concat(dc.series || []));
 
   await Promise.all([
     dispatch(loadMetadataForCards(cards)),
-    dispatch(loadMetadataForLinkedTargets(dashcards)),
+    dispatch(loadMetadataForLinkedTargets(dashCards)),
   ]);
 };
 

--- a/frontend/src/metabase/dashboard/actions/navigation.js
+++ b/frontend/src/metabase/dashboard/actions/navigation.js
@@ -1,4 +1,3 @@
-import { loadMetadataForDashcards } from "metabase/dashboard/actions/metadata";
 import { createThunkAction } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { getParametersMappedToDashcard } from "metabase/parameters/utils/dashboards";
@@ -44,9 +43,7 @@ export const NAVIGATE_TO_NEW_CARD = "metabase/dashboard/NAVIGATE_TO_NEW_CARD";
 export const navigateToNewCardFromDashboard = createThunkAction(
   NAVIGATE_TO_NEW_CARD,
   ({ nextCard, previousCard, dashcard, objectId }) =>
-    async (dispatch, getState) => {
-      await dispatch(loadMetadataForDashcards([dashcard]));
-
+    (dispatch, getState) => {
       const metadata = getMetadata(getState());
       const { dashboardId, dashboards, parameterValues } = getState().dashboard;
       const dashboard = dashboards[dashboardId];

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.styled.tsx
@@ -3,7 +3,7 @@ import styled from "@emotion/styled";
 import EntityMenu from "metabase/components/EntityMenu";
 import { color, lighten } from "metabase/lib/colors";
 
-export const CardEntityMenu = styled(EntityMenu)`
+export const CardMenuRoot = styled(EntityMenu)`
   display: flex;
   align-items: center;
   margin: 0 0 0 0.5rem;

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.unit.spec.tsx
@@ -18,10 +18,7 @@ import {
   ORDERS_ID,
   SAMPLE_DB_ID,
 } from "metabase-types/api/mocks/presets";
-import {
-  createMockDashboardState,
-  createMockState,
-} from "metabase-types/store/mocks";
+import { createMockState } from "metabase-types/store/mocks";
 
 import { DashCardMenuConnected } from "./DashCardMenu";
 
@@ -82,14 +79,6 @@ const setup = ({ card = TEST_CARD, result = TEST_RESULT }: SetupOpts = {}) => {
     entities: createMockEntitiesState({
       databases: [createSampleDatabase()],
       questions: [card],
-    }),
-    dashboard: createMockDashboardState({
-      loadingDashCards: {
-        loadingIds: [],
-        loadingStatus: "complete",
-        startTime: 100,
-        endTime: 200,
-      },
     }),
   });
 

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -196,6 +196,7 @@ export function DashCardVisualization({
     const mainSeries = series[0] as unknown as Dataset;
     const shouldShowDashCardMenu = DashCardMenuConnected.shouldRender({
       question,
+      result: mainSeries,
       isXray,
       isEmbed,
       isPublic,

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -116,6 +116,7 @@ type DashboardProps = {
   editingOnLoad?: string | string[];
 
   initialize: (opts?: { clearCache?: boolean }) => void;
+  fetchDashboardCardMetadata: () => Promise<void>;
   cancelFetchDashboardCardData: () => void;
   addCardToDashboard: (opts: {
     dashId: DashboardId;
@@ -196,6 +197,7 @@ function DashboardInner(props: DashboardProps) {
     editingParameter,
     fetchDashboard,
     fetchDashboardCardData,
+    fetchDashboardCardMetadata,
     initialize,
     isAutoApplyFilters,
     isEditing,
@@ -364,6 +366,7 @@ function DashboardInner(props: DashboardProps) {
     }
     if (previousTabId !== selectedTabId) {
       fetchDashboardCardData();
+      fetchDashboardCardMetadata();
       return;
     }
     const didDashboardLoad = !previousDashboard && dashboard;
@@ -378,6 +381,7 @@ function DashboardInner(props: DashboardProps) {
     dashboard,
     dashboardId,
     fetchDashboardCardData,
+    fetchDashboardCardMetadata,
     handleLoadDashboard,
     parameterValues,
     previousDashboard,

--- a/frontend/src/metabase/dashboard/hoc/DashboardData.jsx
+++ b/frontend/src/metabase/dashboard/hoc/DashboardData.jsx
@@ -110,6 +110,7 @@ export const DashboardData = ComposedComponent =>
 
         if (!_.isEqual(nextProps.selectedTabId, this.props.selectedTabId)) {
           this.props.fetchDashboardCardData();
+          this.props.fetchDashboardCardMetadata();
           return;
         }
       }

--- a/frontend/src/metabase/public/containers/PublicDashboard/PublicDashboard.tsx
+++ b/frontend/src/metabase/public/containers/PublicDashboard/PublicDashboard.tsx
@@ -15,6 +15,7 @@ import {
   setParameterValueToDefault,
   setParameterValue,
   cancelFetchDashboardCardData,
+  fetchDashboardCardMetadata,
   fetchDashboard,
   fetchDashboardCardData,
 } from "metabase/dashboard/actions";
@@ -78,6 +79,7 @@ const mapStateToProps = (state: State, props: OwnProps) => {
 const mapDispatchToProps = {
   initialize,
   cancelFetchDashboardCardData,
+  fetchDashboardCardMetadata,
   setParameterValueToDefault,
   setParameterValue,
   setErrorPage,
@@ -156,6 +158,7 @@ class PublicDashboardInner extends Component<PublicDashboardProps> {
 
     if (!_.isEqual(prevProps.selectedTabId, this.props.selectedTabId)) {
       this.props.fetchDashboardCardData();
+      this.props.fetchDashboardCardMetadata();
       return;
     }
 


### PR DESCRIPTION
Reverts metabase/metabase#42953

See [Slack thread](https://metaboat.slack.com/archives/C0645JP1W81/p1716464863124129?thread_ts=1716434842.768959&cid=C0645JP1W81).