### PR TITLE
[UI] Fix styles for disabled Switch

### DIFF
--- a/frontend/src/metabase/ui/components/inputs/Switch/Switch.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Switch/Switch.styled.tsx
@@ -1,5 +1,5 @@
 import type { MantineThemeOverride, SwitchStylesParams } from "@mantine/core";
-import { rem, getSize, getStylesRef } from "@mantine/core";
+import { rem, getSize } from "@mantine/core";
 
 import { color } from "metabase/lib/colors";
 
@@ -98,7 +98,7 @@ export const getSwitchOverrides = (): MantineThemeOverride["components"] => ({
           height: getSize({ size, sizes: TRACK_HEIGHTS }),
           width: getSize({ size, sizes: TRACK_WIDTHS }),
           cursor: "pointer",
-          [`${getStylesRef("input")}:disabled + &`]: {
+          "input:disabled + &": {
             backgroundColor: theme.fn.themeColor("bg-medium"),
           },
           marginTop: getSize({ size, sizes: TRACK_PADDING_TOP }),
@@ -109,7 +109,7 @@ export const getSwitchOverrides = (): MantineThemeOverride["components"] => ({
           borderRadius: rem(22),
           height: getSize({ size, sizes: THUMB_SIZES }),
           width: getSize({ size, sizes: THUMB_SIZES }),
-          [`${getStylesRef("input")}:disabled + * > &`]: {
+          "input:disabled + * > &": {
             backgroundColor: theme.fn.themeColor("bg-light"),
           },
         },


### PR DESCRIPTION
### Description

Fix styles for disabled Switch


[Figma](https://www.figma.com/design/xdNKMROC99J6Z4Sqg6V3JI/Input-%2F-Switch?node-id=5-70&t=0VTQJPi2JCFTaCON-11)


### Before
<img width="697" alt="Screenshot 2024-05-23 at 22 24 42" src="https://github.com/metabase/metabase/assets/125459446/96bfce51-eab7-4c5b-b7b6-53618da73d30">

### After
<img width="545" alt="Screenshot 2024-05-23 at 22 26 42" src="https://github.com/metabase/metabase/assets/125459446/e5188c56-6981-4d73-b88d-8eaa36bb1090">
<img width="417" alt="Screenshot 2024-05-23 at 22 27 18" src="https://github.com/metabase/metabase/assets/125459446/80015ef3-c894-44ca-8c7c-0ef06f29e04f">

