### PR TITLE
Use table2 icon for questions

### DIFF
--- a/e2e/test/scenarios/collections/permissions.cy.spec.js
+++ b/e2e/test/scenarios/collections/permissions.cy.spec.js
@@ -336,7 +336,7 @@ describe("collection permissions", () => {
               cy.findByText("Orders")
                 .closest("tr")
                 .within(() => {
-                  cy.icon("table").trigger("mouseover");
+                  cy.icon("table2").trigger("mouseover");
                   cy.findByRole("checkbox").should("not.exist");
                 });
 

--- a/e2e/test/scenarios/models/models.cy.spec.js
+++ b/e2e/test/scenarios/models/models.cy.spec.js
@@ -104,12 +104,8 @@ describe("scenarios > models", () => {
         .findAllByText("Our analytics")
         .first()
         .click();
-      getCollectionItemCard("Products Model").within(() => {
-        cy.icon("model");
-      });
-      getCollectionItemRow("Q1").within(() => {
-        cy.icon("table");
-      });
+      getCollectionItemCard("Products Model").icon("model");
+      getCollectionItemRow("Q1").icon("table2");
 
       cy.url().should("not.include", "/question/" + id);
     });
@@ -160,9 +156,7 @@ describe("scenarios > models", () => {
     getCollectionItemCard("Product Model").within(() => {
       cy.icon("model");
     });
-    getCollectionItemRow("Q1").within(() => {
-      cy.icon("table");
-    });
+    getCollectionItemRow("Q1").icon("table2");
 
     cy.location("pathname").should("eq", "/collection/root");
   });

--- a/e2e/test/scenarios/question/reproductions/18207-string-min-max.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/18207-string-min-max.cy.spec.js
@@ -91,7 +91,7 @@ describe("issue 18207", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Visualization").click();
     leftSidebar().within(() => {
-      cy.icon("table").click();
+      cy.icon("table2").click();
       cy.findByTestId("Table-button").realHover();
       cy.icon("gear").click();
     });

--- a/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
@@ -71,12 +71,13 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
     createTestQuestion();
 
     // Switch to "ordinary" table
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Visualization").click();
-    cy.icon("table").should("be.visible").click();
+    cy.findByTestId("view-footer").findByText("Visualization").click();
+    sidebar().icon("table2").should("be.visible").click();
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.contains(`Started from ${QUESTION_NAME}`);
+    cy.findByTestId("app-bar").within(() => {
+      cy.findByText("Started from");
+      cy.findByText(QUESTION_NAME);
+    });
 
     cy.log("Assertions on a table itself");
     cy.findByTestId("query-visualization-root").within(() => {

--- a/frontend/src/metabase/home/components/HomeModelCard/HomeModelCard.tsx
+++ b/frontend/src/metabase/home/components/HomeModelCard/HomeModelCard.tsx
@@ -12,7 +12,6 @@ interface HomeModelCardProps {
 
 export interface HomeModelIconProps {
   name: IconName;
-  variant?: "secondary";
 }
 
 export const HomeModelCard = ({

--- a/frontend/src/metabase/home/components/HomePopularSection/HomePopularSection.tsx
+++ b/frontend/src/metabase/home/components/HomePopularSection/HomePopularSection.tsx
@@ -33,7 +33,7 @@ export const HomePopularSection = (): JSX.Element => {
           <HomeModelCard
             key={index}
             title={getName(item)}
-            icon={getIcon(item, { variant: "secondary" })}
+            icon={getIcon(item)}
             url={Urls.modelToUrl(item) ?? ""}
           />
         ))}

--- a/frontend/src/metabase/home/components/HomeRecentSection/HomeRecentSection.tsx
+++ b/frontend/src/metabase/home/components/HomeRecentSection/HomeRecentSection.tsx
@@ -38,7 +38,7 @@ export const HomeRecentSection = () => {
           <HomeModelCard
             key={index}
             title={getName(item)}
-            icon={getIcon(item, { variant: "secondary" })}
+            icon={getIcon(item)}
             url={Urls.modelToUrl(item) ?? ""}
           />
         ))}

--- a/frontend/src/metabase/lib/icon.ts
+++ b/frontend/src/metabase/lib/icon.ts
@@ -29,38 +29,23 @@ const modelIconMap: Record<SearchModel, IconName> = {
   metric: "metric",
 };
 
-const secondaryModelIconMap: Partial<Record<SearchModel, IconName>> = {
-  table: "database",
-};
-
 export type IconData = {
   name: IconName;
   color?: string;
 };
 
-export type IconOptions = {
-  variant?: "primary" | "secondary";
-};
-
 /** get an Icon for any entity object, doesn't depend on the entity system */
-export const getIconBase = (
-  item: ObjectWithModel,
-  options: IconOptions = {},
-): IconData => {
+export const getIconBase = (item: ObjectWithModel): IconData => {
   if (item.model === "card" && item.display) {
     return { name: getIconForVisualizationType(item.display) };
-  }
-
-  if (options.variant === "secondary" && item.model in secondaryModelIconMap) {
-    return { name: secondaryModelIconMap[item.model] ?? "unknown" };
   }
 
   return { name: modelIconMap?.[item.model] ?? "unknown" };
 };
 
-export const getIcon = (item: ObjectWithModel, options: IconOptions = {}) => {
+export const getIcon = (item: ObjectWithModel) => {
   if (PLUGIN_COLLECTIONS) {
-    return PLUGIN_COLLECTIONS.getIcon(item, options);
+    return PLUGIN_COLLECTIONS.getIcon(item);
   }
-  return getIconBase(item, options);
+  return getIconBase(item);
 };

--- a/frontend/src/metabase/lib/icon.unit.spec.ts
+++ b/frontend/src/metabase/lib/icon.unit.spec.ts
@@ -37,18 +37,10 @@ describe("getIcon", () => {
     expect(getIcon({ model: "pikachu" })).toEqual({ name: "unknown" });
   });
 
-  describe("options", () => {
-    it("should return the correct icon for a table with the secondary variant", () => {
-      expect(getIcon({ model: "table" }, { variant: "secondary" })).toEqual({
-        name: "database",
-      });
-    });
-  });
-
   describe("card display types", () => {
     it("should return the default icon for an invalid display type", () => {
       expect(getIcon({ model: "card", display: "pikachu" })).toEqual({
-        name: "table",
+        name: "table2",
       });
     });
 
@@ -58,7 +50,7 @@ describe("getIcon", () => {
 
     it("should return the correct icon for a card with a table chare", () => {
       expect(getIcon({ model: "card", display: "table" })).toEqual({
-        name: "table",
+        name: "table2",
       });
     });
     it("should return the correct icon for a card with a bar chart", () => {

--- a/frontend/src/metabase/ui/components/icons/Icon/icons/index.ts
+++ b/frontend/src/metabase/ui/components/icons/Icon/icons/index.ts
@@ -1064,10 +1064,12 @@ export const Icons = {
     source: tab_source,
   },
   table: {
+    // for database tables
     component: table_component,
     source: table_source,
   },
   table2: {
+    // for questions with table visualizations
     component: table2_component,
     source: table2_source,
   },

--- a/frontend/src/metabase/visualizations/visualizations/Table.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table.tsx
@@ -60,7 +60,7 @@ interface TableState {
 class Table extends Component<TableProps, TableState> {
   static uiName = t`Table`;
   static identifier = "table";
-  static iconName = "table";
+  static iconName = "table2";
   static canSavePng = false;
 
   static minSize = getMinSize("table");


### PR DESCRIPTION

### Description

[discussion](https://metaboat.slack.com/archives/C064EB1UE5P/p1716486741247829?thread_ts=1716484925.374579&cid=C064EB1UE5P)

Makes database tables easier to differentiate from questions with a table visualization by using the `table2` icon for questions.

![Screen Shot 2024-05-23 at 3 03 49 PM](https://github.com/metabase/metabase/assets/30528226/ca74933a-ec00-4104-b434-804cde43acea)
![Screen Shot 2024-05-23 at 3 03 43 PM](https://github.com/metabase/metabase/assets/30528226/b79b1e94-9b1c-44b2-b810-0bc75a35b31e)

