### PR TITLE
Allow recent command palette items with the same name

### DIFF
--- a/frontend/src/metabase/palette/components/PaletteResults.unit.spec.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResults.unit.spec.tsx
@@ -18,12 +18,13 @@ import {
   mockScrollIntoView,
 } from "__support__/ui";
 import { getAdminPaths } from "metabase/admin/app/reducers";
-import type { Settings } from "metabase-types/api";
+import type { RecentItem, Settings } from "metabase-types/api";
 import {
   createMockCollection,
   createMockCollectionItem,
   createMockDatabase,
   createMockRecentCollectionItem,
+  createMockRecentTableItem,
 } from "metabase-types/api/mocks";
 import {
   createMockAdminAppState,
@@ -104,10 +105,15 @@ mockScrollIntoView();
 const setup = ({
   query,
   settings = {},
-}: { query?: string; settings?: Partial<Settings> } = {}) => {
+  recents = [recents_1, recents_2],
+}: {
+  query?: string;
+  settings?: Partial<Settings>;
+  recents?: RecentItem[];
+} = {}) => {
   setupDatabasesEndpoints([DATABASE]);
   setupSearchEndpoints([model_1, model_2, dashboard]);
-  setupRecentViewsEndpoints([recents_1, recents_2]);
+  setupRecentViewsEndpoints(recents);
 
   renderWithProviders(
     <Route path="/" component={() => <TestComponent q={query} isLoggedIn />} />,
@@ -163,6 +169,27 @@ describe("PaletteResults", () => {
         await screen.findByRole("option", { name: "Foo Question" }),
       ).findByRole("img", { name: /verified_filled/ }),
     ).toBeInTheDocument();
+  });
+
+  it("should show recent items with the same name", async () => {
+    setup({
+      recents: [
+        createMockRecentCollectionItem({
+          model: "dataset",
+          name: "My Awesome Data",
+        }),
+        createMockRecentTableItem({
+          model: "table",
+          display_name: "My Awesome Data",
+        }),
+      ],
+    });
+
+    expect(await screen.findByText("Recent items")).toBeInTheDocument();
+
+    expect(
+      await screen.findAllByRole("option", { name: "My Awesome Data" }),
+    ).toHaveLength(2);
   });
 
   it("should allow you to search entities, and provide a docs link", async () => {

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -221,7 +221,7 @@ export const useCommandPalette = ({
   const recentItemsActions = useMemo<PaletteAction[]>(() => {
     return (
       filterRecentItems(recentItems ?? []).map(item => ({
-        id: `recent-item-${getName(item)}`,
+        id: `recent-item-${getName(item)}-${item.model}-${item.id}`,
         name: getName(item),
         icon: getIcon(item).name,
         section: "recent",


### PR DESCRIPTION

Closes [bug](https://metaboat.slack.com/archives/C05MPF0TM3L/p1716501391373629?thread_ts=1716498078.961359&cid=C05MPF0TM3L)

### Description

Due to a quirk of our underlying command palette library, it wouldn't show two items with identical ids. We were using names as ids for recent items. This was causing us to lose recent items if a user had visited a table and a model with the same name. Search results use model + id, so they are safe.

Before | After
---|---
![Screen Shot 2024-05-23 at 4 14 31 PM](https://github.com/metabase/metabase/assets/30528226/bd5ad222-0d5e-4252-8d80-9348088e7d12) | ![Screen Shot 2024-05-23 at 4 14 07 PM](https://github.com/metabase/metabase/assets/30528226/cc99d6b1-d581-4f1a-8326-4fac97a2e240)



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
