### PR TITLE
Add Advanced Cache Upsell

### DIFF
--- a/frontend/src/metabase/admin/performance/components/StrategyEditorForDatabases.tsx
+++ b/frontend/src/metabase/admin/performance/components/StrategyEditorForDatabases.tsx
@@ -142,13 +142,10 @@ const StrategyEditorForDatabases_Base = ({
               configs={configs}
               setConfigs={setConfigs}
               targetId={targetId}
-              targetModel="database"
-              targetName={targetDatabase?.name || t`Untitled database`}
-              setIsDirty={setIsStrategyFormDirty}
-              saveStrategy={saveStrategy}
-              savedStrategy={savedStrategy}
-              shouldAllowInvalidation={shouldAllowInvalidation}
-              shouldShowName={targetId !== rootId}
+              updateTargetId={updateTargetId}
+              databases={databases}
+              isStrategyFormDirty={isStrategyFormDirty}
+              shouldShowResetButton={shouldShowResetButton}
             />
           )}
           <Panel hasLeftBorder={canOverrideRootStrategy}>
@@ -161,7 +158,6 @@ const StrategyEditorForDatabases_Base = ({
                 saveStrategy={saveStrategy}
                 savedStrategy={savedStrategy}
                 shouldAllowInvalidation={shouldAllowInvalidation}
-                formStyle={{ overflow: "auto" }}
                 shouldShowName={targetId !== rootId}
               />
             )}

--- a/frontend/src/metabase/admin/performance/components/StrategyEditorForDatabases.tsx
+++ b/frontend/src/metabase/admin/performance/components/StrategyEditorForDatabases.tsx
@@ -4,10 +4,11 @@ import { withRouter } from "react-router";
 import { t } from "ttag";
 import { findWhere } from "underscore";
 
+import { UpsellCacheConfig } from "metabase/admin/upsells";
 import { useListDatabasesQuery } from "metabase/api";
 import { DelayedLoadingAndErrorWrapper } from "metabase/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
 import { PLUGIN_CACHING } from "metabase/plugins";
-import { Stack } from "metabase/ui";
+import { Stack, Flex } from "metabase/ui";
 import type { CacheableModel } from "metabase-types/api";
 import { DurationUnit } from "metabase-types/api";
 
@@ -134,21 +135,12 @@ const StrategyEditorForDatabases_Base = ({
         </aside>
       </Stack>
       {confirmationModal}
-      <RoundedBox twoColumns={canOverrideRootStrategy}>
-        {canOverrideRootStrategy && (
-          <PLUGIN_CACHING.StrategyFormLauncherPanel
-            configs={configs}
-            setConfigs={setConfigs}
-            targetId={targetId}
-            updateTargetId={updateTargetId}
-            databases={databases}
-            isStrategyFormDirty={isStrategyFormDirty}
-            shouldShowResetButton={shouldShowResetButton}
-          />
-        )}
-        <Panel hasLeftBorder={canOverrideRootStrategy}>
-          {targetId !== null && (
-            <StrategyForm
+      <Flex gap="xl">
+        <RoundedBox twoColumns={canOverrideRootStrategy}>
+          {canOverrideRootStrategy && (
+            <PLUGIN_CACHING.StrategyFormLauncherPanel
+              configs={configs}
+              setConfigs={setConfigs}
               targetId={targetId}
               targetModel="database"
               targetName={targetDatabase?.name || t`Untitled database`}
@@ -159,8 +151,24 @@ const StrategyEditorForDatabases_Base = ({
               shouldShowName={targetId !== rootId}
             />
           )}
-        </Panel>
-      </RoundedBox>
+          <Panel hasLeftBorder={canOverrideRootStrategy}>
+            {targetId !== null && (
+              <StrategyForm
+                targetId={targetId}
+                targetModel="database"
+                targetName={targetDatabase?.name || t`Untitled database`}
+                setIsDirty={setIsStrategyFormDirty}
+                saveStrategy={saveStrategy}
+                savedStrategy={savedStrategy}
+                shouldAllowInvalidation={shouldAllowInvalidation}
+                formStyle={{ overflow: "auto" }}
+                shouldShowName={targetId !== rootId}
+              />
+            )}
+          </Panel>
+        </RoundedBox>
+        <UpsellCacheConfig source="performance-data_cache" />
+      </Flex>
     </TabWrapper>
   );
 };

--- a/frontend/src/metabase/admin/upsells/UpsellCacheConfig.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellCacheConfig.tsx
@@ -1,0 +1,30 @@
+import { t, jt } from "ttag";
+
+import { useHasTokenFeature } from "metabase/common/hooks/use-has-token-feature";
+import { Box } from "metabase/ui";
+
+import { UpsellCard } from "./components";
+
+export const UpsellCacheConfig = ({ source }: { source: string }) => {
+  const hasCache = useHasTokenFeature("cache_granular_controls");
+
+  if (hasCache) {
+    return null;
+  }
+
+  return (
+    <Box>
+      <UpsellCard
+        title={t`Control your caching`}
+        campaign="cache-granular-controls"
+        buttonText={t`Try Metabase Pro`}
+        buttonLink="https://www.metabase.com/upgrade"
+        source={source}
+      >
+        {jt`Get granular caching controls for each database, dashboard, and query with ${(
+          <strong>{t`Metabase Pro.`}</strong>
+        )}`}
+      </UpsellCard>
+    </Box>
+  );
+};

--- a/frontend/src/metabase/admin/upsells/components/Upsells.styled.tsx
+++ b/frontend/src/metabase/admin/upsells/components/Upsells.styled.tsx
@@ -64,4 +64,5 @@ export const UpsellCardComponent = styled.div`
   border-radius: 0.5rem;
   overflow: hidden;
   border: 1px solid ${upsellColors.secondary};
+  background-color: ${color("white")};
 `;

--- a/frontend/src/metabase/admin/upsells/index.ts
+++ b/frontend/src/metabase/admin/upsells/index.ts
@@ -1,1 +1,2 @@
+export * from "./UpsellCacheConfig";
 export * from "./UpsellHosting";

--- a/frontend/src/metabase/common/hooks/use-has-token-feature/index.ts
+++ b/frontend/src/metabase/common/hooks/use-has-token-feature/index.ts
@@ -1,0 +1,1 @@
+export * from "./use-has-token-feature";

--- a/frontend/src/metabase/common/hooks/use-has-token-feature/use-has-token-feature.ts
+++ b/frontend/src/metabase/common/hooks/use-has-token-feature/use-has-token-feature.ts
@@ -1,0 +1,7 @@
+import { useSelector } from "metabase/lib/redux";
+import { getTokenFeature } from "metabase/setup/selectors";
+import type { TokenFeature } from "metabase-types/api";
+
+export const useHasTokenFeature = (settingName: TokenFeature) => {
+  return useSelector(state => getTokenFeature(state, settingName));
+};

--- a/frontend/src/metabase/common/hooks/use-has-token-feature/use-has-token-feature.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-has-token-feature/use-has-token-feature.unit.spec.tsx
@@ -1,0 +1,47 @@
+import { renderWithProviders, screen } from "__support__/ui";
+import type { TokenFeature } from "metabase-types/api";
+import { createMockTokenFeatures } from "metabase-types/api/mocks";
+import { createMockSettingsState } from "metabase-types/store/mocks";
+
+import { useHasTokenFeature } from "./use-has-token-feature";
+
+const TestComponent = ({ feature }: { feature: TokenFeature }) => {
+  const hasFeature = useHasTokenFeature(feature);
+
+  return (
+    <div>
+      feature {feature} is {hasFeature ? "on" : "off"}
+    </div>
+  );
+};
+
+const setup = ({ feature }: { feature: TokenFeature }) => {
+  const mockSettings = createMockSettingsState({
+    "token-features": createMockTokenFeatures({
+      audit_app: true,
+      embedding: false,
+    }),
+  });
+
+  renderWithProviders(<TestComponent feature={feature} />, {
+    storeInitialState: { settings: mockSettings },
+  });
+};
+
+describe("useHasTokenFeature", () => {
+  it("should get a present feature", async () => {
+    setup({ feature: "audit_app" });
+    expect(screen.getByText("feature audit_app is on")).toBeInTheDocument();
+  });
+
+  it("should get an absent feature", async () => {
+    setup({ feature: "embedding" });
+    expect(screen.getByText("feature embedding is off")).toBeInTheDocument();
+  });
+
+  it("should get an invalid feature", async () => {
+    // @ts-expect-error testing invalid feature
+    setup({ feature: "surfing" });
+    expect(screen.getByText("feature surfing is off")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/common/hooks/use-setting/use-setting.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-setting/use-setting.unit.spec.tsx
@@ -16,7 +16,7 @@ const TestComponent = ({ settingName }: { settingName: keyof Settings }) => {
   );
 };
 
-describe("useTableListQuery", () => {
+describe("useSetting", () => {
   it("should get a string setting", async () => {
     renderWithProviders(<TestComponent settingName={"admin-email"} />);
     expect(screen.getByText('"admin@metabase.test"')).toBeInTheDocument();

--- a/frontend/src/metabase/setup/selectors.ts
+++ b/frontend/src/metabase/setup/selectors.ts
@@ -1,6 +1,10 @@
 import { isEEBuild } from "metabase/lib/utils";
 import { getSetting } from "metabase/selectors/settings";
-import type { DatabaseData, LocaleData } from "metabase-types/api";
+import type {
+  DatabaseData,
+  LocaleData,
+  TokenFeature,
+} from "metabase-types/api";
 import type { InviteInfo, Locale, State, UserInfo } from "metabase-types/store";
 
 import { isNotFalsy } from "./../lib/types";
@@ -69,6 +73,11 @@ export const getSetupToken = (state: State) => {
 
 export const getIsHosted = (state: State): boolean => {
   return getSetting(state, "is-hosted?");
+};
+
+export const getTokenFeature = (state: State, feature: TokenFeature) => {
+  const tokenFeatures = getSetting(state, "token-features");
+  return tokenFeatures[feature];
 };
 
 export const getAvailableLocales = (state: State): LocaleData[] => {


### PR DESCRIPTION
closes https://github.com/metabase/metabase/issues/41119

see [discussion](https://metaboat.slack.com/archives/C06KX7QECN4/p1716475479960519)

### Description

- Adds a `useHasTokenFeature` hook
- Adds an upsell for advanced caching for admins that don't  have it
- Displays that upsell on the performance tab


![Screen Shot 2024-05-24 at 7 50 39 AM](https://github.com/metabase/metabase/assets/30528226/db785a43-c46f-4988-8068-1062c3a4bd43)



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
