### PR TITLE
Fix typo in French localization file fr.po

### DIFF
--- a/locales/fr.po
+++ b/locales/fr.po
@@ -21123,7 +21123,7 @@ msgstr "Impossible d'inviter l'utilisateur, l'email n'est pas configuré"
 
 #: metabase/api/setup.clj:199
 msgid "Does your team use Slack? If so, you can send automated updates via dashboard subscriptions."
-msgstr "Votre équipe utilise Slack ? Vous pouvez envoyer des mises à jour automatiques vis les abonnements aux tableaux de bord."
+msgstr "Votre équipe utilise Slack ? Vous pouvez envoyer des mises à jour automatiques via les abonnements aux tableaux de bord."
 
 #: metabase/api/slack.clj:29
 msgid "invalid token"


### PR DESCRIPTION
Corrected a typo in the French localization file (fr.po). The word "via" was misspelled as "vis".

This change ensures accurate translation and improves the user experience for French-speaking users.

> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label
> to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this
> PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71)
> in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not
> apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform) (unless it's a tiny documentation change). Also, if you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.

Closes https://github.com/metabase/metabase/issues/[issue_number]

### Description

Describe the overall approach and the problem being solved.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> ...
2. ...

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
