### PR TITLE
Use item.displayName for pinned items

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/BreakoutColumnList/BreakoutColumnListItem/BreakoutColumnListItem.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/BreakoutColumnList/BreakoutColumnListItem/BreakoutColumnListItem.tsx
@@ -34,7 +34,6 @@ export function BreakoutColumnListItem({
   query,
   item,
   breakout,
-  isPinned = false,
   onAddColumn,
   onUpdateColumn,
   onRemoveColumn,
@@ -58,8 +57,6 @@ export function BreakoutColumnListItem({
     [item.column, onRemoveColumn],
   );
 
-  const displayName = isPinned ? item.longDisplayName : item.displayName;
-
   return (
     <HoverParent
       as={Root}
@@ -77,7 +74,9 @@ export function BreakoutColumnListItem({
             position="left"
             size={18}
           />
-          <Title data-testid="dimension-list-item-name">{displayName}</Title>
+          <Title data-testid="dimension-list-item-name">
+            {item.displayName}
+          </Title>
           <BucketPickerPopover
             query={query}
             stageIndex={STAGE_INDEX}


### PR DESCRIPTION
Fix duplicate name that appears when pinning a bucket in the summarize sidebar.

I'm not sure I fully understand why the `longDisplayName` was chosen in the first place, so I might be missing something here.


![image](https://github.com/metabase/metabase/assets/1250185/c19ecbd8-1ffb-46d7-9b73-0c9ba1579376)
