### PR TITLE
[Dashboard] Optimize rendering by reducing the number of props passing down to from the very top

### DIFF
--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.tsx
@@ -15,9 +15,7 @@ import type {
   Dashboard,
   QuestionDashboardCard,
   DashCardId,
-  CardId,
   ClickBehavior,
-  DatasetData,
   DatasetColumn,
 } from "metabase-types/api";
 
@@ -34,7 +32,6 @@ type VizSettings = Record<string, unknown>;
 interface Props {
   dashboard: Dashboard;
   dashcard: QuestionDashboardCard;
-  dashcardData: Record<DashCardId, Record<CardId, DatasetData>>;
   parameters: UiParameter[];
   hideClickBehaviorSidebar: () => void;
   onUpdateDashCardColumnSettings: (
@@ -55,7 +52,6 @@ interface Props {
 export function ClickBehaviorSidebar({
   dashboard,
   dashcard,
-  dashcardData,
   parameters,
   hideClickBehaviorSidebar,
   onUpdateDashCardColumnSettings,
@@ -213,7 +209,6 @@ export function ClickBehaviorSidebar({
         <ClickBehaviorSidebarContent
           dashboard={dashboard}
           dashcard={dashcard}
-          dashcardData={dashcardData}
           parameters={parameters}
           clickBehavior={clickBehavior}
           isTypeSelectorVisible={isTypeSelectorVisible}

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarContent.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarContent.tsx
@@ -1,15 +1,14 @@
 import { getIn } from "icepick";
 import { useMemo } from "react";
 
+import { getDashcardData } from "metabase/dashboard/selectors";
 import { isTableDisplay } from "metabase/lib/click-behavior";
+import { useSelector } from "metabase/lib/redux";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
 import type {
   Dashboard,
   QuestionDashboardCard,
-  DashCardId,
-  CardId,
   ClickBehavior,
-  DatasetData,
   DatasetColumn,
 } from "metabase-types/api";
 
@@ -22,7 +21,6 @@ import { getClickBehaviorForColumn } from "./utils";
 interface Props {
   dashboard: Dashboard;
   dashcard: QuestionDashboardCard;
-  dashcardData: Record<DashCardId, Record<CardId, DatasetData>>;
   parameters: UiParameter[];
   clickBehavior?: ClickBehavior;
   isTypeSelectorVisible: boolean | null;
@@ -35,7 +33,6 @@ interface Props {
 export function ClickBehaviorSidebarContent({
   dashboard,
   dashcard,
-  dashcardData,
   parameters,
   clickBehavior,
   isTypeSelectorVisible,
@@ -51,6 +48,9 @@ export function ClickBehaviorSidebarContent({
     // drill-through menu
     return { type: "actionMenu" };
   }, [clickBehavior]);
+  const dashcardData = useSelector(state =>
+    getDashcardData(state, dashcard.id),
+  );
 
   if (isTableDisplay(dashcard) && !hasSelectedColumn && dashcard.card_id) {
     const columns = getIn(dashcardData, [dashcard.card_id, "data", "cols"]);

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
@@ -22,7 +22,6 @@ import { PLUGIN_COLLECTIONS } from "metabase/plugins";
 import EmbedFrameS from "metabase/public/components/EmbedFrame/EmbedFrame.module.css";
 import type { Mode } from "metabase/visualizations/click-actions/Mode";
 import { mergeSettings } from "metabase/visualizations/lib/settings";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type {
   Card,
   CardId,
@@ -53,7 +52,6 @@ export interface DashCardProps {
   gridItemWidth: number;
   totalNumGridCols: number;
   slowCards: Record<CardId, boolean>;
-  metadata: Metadata;
   mode?: Mode;
 
   clickBehaviorSidebarDashcard?: DashboardCard | null;
@@ -89,7 +87,6 @@ function DashCardInner({
   dashcard,
   dashboard,
   slowCards,
-  metadata,
   gridItemWidth,
   totalNumGridCols,
   mode,
@@ -324,7 +321,6 @@ function DashCardInner({
           dashboard={dashboard}
           dashcard={dashcard}
           series={series}
-          metadata={metadata}
           mode={mode}
           gridSize={gridSize}
           gridItemWidth={gridItemWidth}

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -10,12 +10,13 @@ import {
   isQuestionCard,
   isVirtualDashCard,
 } from "metabase/dashboard/utils";
+import { useSelector } from "metabase/lib/redux";
+import { getMetadata } from "metabase/selectors/metadata";
 import type { IconName, IconProps } from "metabase/ui";
 import { getVisualizationRaw } from "metabase/visualizations";
 import type { Mode } from "metabase/visualizations/click-actions/Mode";
 import Visualization from "metabase/visualizations/components/Visualization";
 import Question from "metabase-lib/v1/Question";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type {
   Dashboard,
   DashCardId,
@@ -43,7 +44,6 @@ interface DashCardVisualizationProps {
   dashboard: Dashboard;
   dashcard: DashboardCard;
   series: Series;
-  metadata: Metadata;
   mode?: Mode;
 
   gridSize: {
@@ -87,7 +87,6 @@ export function DashCardVisualization({
   dashboard,
   series,
   mode,
-  metadata,
   gridSize,
   gridItemWidth,
   totalNumGridCols,
@@ -113,6 +112,7 @@ export function DashCardVisualization({
   onChangeLocation,
   onUpdateVisualizationSettings,
 }: DashCardVisualizationProps) {
+  const metadata = useSelector(getMetadata);
   const question = useMemo(() => {
     return isQuestionCard(dashcard.card)
       ? new Question(dashcard.card, metadata)

--- a/frontend/src/metabase/dashboard/components/DashCard/Dashcard.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/Dashcard.unit.spec.tsx
@@ -1,4 +1,3 @@
-import { createMockMetadata } from "__support__/metadata";
 import { queryIcon, renderWithProviders, screen } from "__support__/ui";
 import registerVisualizations from "metabase/visualizations/register";
 import type { DashCardDataMap } from "metabase-types/api";
@@ -62,8 +61,6 @@ const erroringDashcardData = {
   },
 };
 
-const metadata = createMockMetadata({});
-
 function setup({
   dashboard = testDashboard,
   dashcard = tableDashcard,
@@ -79,7 +76,6 @@ function setup({
       gridItemWidth={4}
       totalNumGridCols={24}
       slowCards={{}}
-      metadata={metadata}
       isEditing={false}
       isEditingParameter={false}
       {...props}

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -388,7 +388,6 @@ function DashboardInner(props: DashboardProps) {
         isFullscreen={props.isFullscreen}
         isEditingParameter={props.isEditingParameter}
         isEditing={props.isEditing}
-        dashcardData={props.dashcardData}
         dashboard={props.dashboard}
         slowCards={props.slowCards}
         navigateToNewCardFromDashboard={props.navigateToNewCardFromDashboard}
@@ -520,7 +519,6 @@ function DashboardInner(props: DashboardProps) {
                 props.setParameterFilteringParameters
               }
               setParameterRequired={props.setParameterRequired}
-              dashcardData={props.dashcardData}
               isFullscreen={props.isFullscreen}
               params={props.params}
               sidebar={props.sidebar}

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -92,7 +92,6 @@ type DashboardProps = {
   clickBehaviorSidebarDashcard: StoreDashcard | null;
   isAddParameterPopoverOpen: boolean;
   sidebar: State["dashboard"]["sidebar"];
-  isLoadingComplete: boolean;
   isHeaderVisible: boolean;
   isAdditionalInfoVisible: boolean;
   selectedTabId: SelectedTabId;

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -24,7 +24,6 @@ import type {
 import Dashboards from "metabase/entities/dashboards";
 import { getMainElement } from "metabase/lib/dom";
 import { useDispatch } from "metabase/lib/redux";
-import type { EmbeddingParameterVisibility } from "metabase/public/lib/types";
 import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type {
   Dashboard as IDashboard,
@@ -160,9 +159,6 @@ type DashboardProps = {
     columnKey: string,
     settings?: Record<string, unknown> | null,
   ) => void;
-  getEmbeddedParameterVisibility: (
-    slug: string,
-  ) => EmbeddingParameterVisibility | null;
   updateDashboardAndCards: () => void;
 
   setSidebar: (opts: { name: DashboardSidebarName }) => void;
@@ -541,9 +537,6 @@ function DashboardInner(props: DashboardProps) {
               sidebar={props.sidebar}
               closeSidebar={props.closeSidebar}
               selectedTabId={props.selectedTabId}
-              getEmbeddedParameterVisibility={
-                props.getEmbeddedParameterVisibility
-              }
               setDashboardAttribute={handleSetDashboardAttribute}
               onCancel={() => setSharing(false)}
             />

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -92,9 +92,6 @@ type DashboardProps = {
   clickBehaviorSidebarDashcard: StoreDashcard | null;
   isAddParameterPopoverOpen: boolean;
   sidebar: State["dashboard"]["sidebar"];
-  pageFavicon: string | null;
-  documentTitle: string | undefined;
-  isRunning: boolean;
   isLoadingComplete: boolean;
   isHeaderVisible: boolean;
   isAdditionalInfoVisible: boolean;

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -24,14 +24,11 @@ import type {
 import Dashboards from "metabase/entities/dashboards";
 import { getMainElement } from "metabase/lib/dom";
 import { useDispatch } from "metabase/lib/redux";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type {
   Dashboard as IDashboard,
   DashboardId,
   DashCardDataMap,
   DashCardId,
-  Database,
-  DatabaseId,
   ParameterId,
   ParameterValueOrArray,
   CardId,
@@ -84,10 +81,8 @@ type DashboardProps = {
   dashboard: IDashboard;
   dashcardData: DashCardDataMap;
   slowCards: Record<DashCardId, boolean>;
-  databases: Record<DatabaseId, Database>;
   parameterValues: Record<ParameterId, ParameterValueOrArray>;
   draftParameterValues: Record<ParameterId, ParameterValueOrArray | null>;
-  metadata: Metadata;
   loadingStartTime: number | null;
   clickBehaviorSidebarDashcard: StoreDashcard | null;
   isAddParameterPopoverOpen: boolean;
@@ -389,7 +384,6 @@ function DashboardInner(props: DashboardProps) {
     return (
       <DashboardGridConnected
         clickBehaviorSidebarDashcard={props.clickBehaviorSidebarDashcard}
-        metadata={props.metadata}
         isNightMode={shouldRenderAsNightMode}
         isFullscreen={props.isFullscreen}
         isEditingParameter={props.isEditingParameter}
@@ -469,7 +463,6 @@ function DashboardInner(props: DashboardProps) {
               sidebar={props.sidebar}
               setSidebar={props.setSidebar}
               closeSidebar={props.closeSidebar}
-              databases={props.databases}
               isAddParameterPopoverOpen={props.isAddParameterPopoverOpen}
               showAddParameterPopover={props.showAddParameterPopover}
               hideAddParameterPopover={props.hideAddParameterPopover}

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
@@ -39,7 +39,6 @@ import {
   MOBILE_HEIGHT_BY_DISPLAY_TYPE,
   MOBILE_DEFAULT_CARD_HEIGHT,
 } from "metabase/visualizations/shared/utils/sizes";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type {
   BaseDashboardCard,
   Card,
@@ -131,8 +130,6 @@ type OwnProps = {
   isNightMode: boolean;
   clickBehaviorSidebarDashcard: DashboardCard | null;
   mode?: Mode;
-  // TODO: only passed down, remove it
-  metadata: Metadata;
   // public dashboard passes it explicitly
   width?: number;
   // public dashboard passes it as noop
@@ -510,8 +507,6 @@ class DashboardGrid extends Component<DashboardGridProps, DashboardGridState> {
           this.props.navigateToNewCardFromDashboard
         }
         onChangeLocation={this.props.onChangeLocation}
-        // TODO: get metadata in dashcard
-        metadata={this.props.metadata}
         dashboard={this.props.dashboard}
         showClickBehaviorSidebar={this.props.showClickBehaviorSidebar}
         clickBehaviorSidebarDashcard={this.props.clickBehaviorSidebarDashcard}

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
@@ -42,12 +42,12 @@ import {
 import type {
   BaseDashboardCard,
   Card,
-  DashCardDataMap,
   DashCardId,
   Dashboard,
   DashboardTabId,
   DashboardCard,
 } from "metabase-types/api";
+import type { State } from "metabase-types/store";
 
 import type { SetDashCardAttributesOpts } from "../actions";
 import {
@@ -62,6 +62,7 @@ import {
   onUpdateDashCardVisualizationSettings,
   fetchCardData,
 } from "../actions";
+import { getDashcardDataMap } from "../selectors";
 
 import { AddSeriesModal } from "./AddSeriesModal/AddSeriesModal";
 import { DashCard } from "./DashCard/DashCard";
@@ -99,6 +100,10 @@ interface DashboardGridState {
   isAnimationPaused: boolean;
 }
 
+const mapStateToProps = (state: State) => ({
+  dashcardData: getDashcardDataMap(state),
+});
+
 const mapDispatchToProps = {
   addUndo,
   removeCardFromDashboard,
@@ -113,13 +118,12 @@ const mapDispatchToProps = {
   onUpdateDashCardVisualizationSettings,
   fetchCardData,
 };
-const connector = connect(null, mapDispatchToProps);
+const connector = connect(mapStateToProps, mapDispatchToProps);
 
 type DashboardGridReduxProps = ConnectedProps<typeof connector>;
 
 type OwnProps = {
   dashboard: Dashboard;
-  dashcardData: DashCardDataMap;
   selectedTabId: DashboardTabId | null;
   slowCards: Record<DashCardId, boolean>;
   isEditing: boolean;

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.tsx
@@ -45,6 +45,7 @@ import { fetchPulseFormInput } from "metabase/pulse/actions";
 import { getPulseFormInput } from "metabase/pulse/selectors";
 import { dismissAllUndo } from "metabase/redux/undo";
 import { getIsNavbarOpen } from "metabase/selectors/app";
+import { getMetadata } from "metabase/selectors/metadata";
 import { getSetting } from "metabase/selectors/settings";
 import { Icon, Menu, Tooltip, Loader, Flex } from "metabase/ui";
 import { saveDashboardPdf } from "metabase/visualizations/lib/save-dashboard-pdf";
@@ -80,7 +81,6 @@ interface DashboardHeaderProps {
   dashboardId: DashboardId;
   dashboard: Dashboard;
   dashboardBeforeEditing?: Dashboard | null;
-  databases: Record<DatabaseId, Database>;
   sidebar: DashboardSidebarState;
   location: Location;
   refreshPeriod: number | null;
@@ -153,7 +153,6 @@ export const DashboardHeader = (props: DashboardHeaderProps) => {
     sidebar,
     setSidebar,
     closeSidebar,
-    databases,
     isAddParameterPopoverOpen,
     showAddParameterPopover,
     hideAddParameterPopover,
@@ -172,6 +171,10 @@ export const DashboardHeader = (props: DashboardHeaderProps) => {
 
   const formInput = useSelector(getPulseFormInput);
   const isNavBarOpen = useSelector(getIsNavbarOpen);
+  const databases = useSelector(getMetadata).databases as Record<
+    DatabaseId,
+    Database
+  >;
   const isShowingDashboardInfoSidebar = useSelector(
     getIsShowDashboardInfoSidebar,
   );

--- a/frontend/src/metabase/dashboard/components/DashboardSidebars.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardSidebars.jsx
@@ -47,7 +47,6 @@ DashboardSidebars.propTypes = {
   closeSidebar: PropTypes.func.isRequired,
   setDashboardAttribute: PropTypes.func,
   selectedTabId: PropTypes.number,
-  getEmbeddedParameterVisibility: PropTypes.func.isRequired,
 };
 
 export function DashboardSidebars({
@@ -76,7 +75,6 @@ export function DashboardSidebars({
   closeSidebar,
   setDashboardAttribute,
   selectedTabId,
-  getEmbeddedParameterVisibility,
 }) {
   const parameters = useSelector(getParameters);
   const editingParameter = useSelector(getEditingParameter);
@@ -141,7 +139,6 @@ export function DashboardSidebars({
       );
       return (
         <ParameterSidebar
-          getEmbeddedParameterVisibility={getEmbeddedParameterVisibility}
           parameter={parameter}
           otherParameters={otherParameters}
           onChangeName={setParameterName}

--- a/frontend/src/metabase/dashboard/components/DashboardSidebars.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardSidebars.jsx
@@ -36,7 +36,6 @@ DashboardSidebars.propTypes = {
   setParameterSourceConfig: PropTypes.func.isRequired,
   setParameterFilteringParameters: PropTypes.func.isRequired,
   setParameterRequired: PropTypes.func.isRequired,
-  dashcardData: PropTypes.object,
   isFullscreen: PropTypes.bool.isRequired,
   onCancel: PropTypes.func.isRequired,
   params: PropTypes.object,
@@ -67,7 +66,6 @@ export function DashboardSidebars({
   setParameterSourceConfig,
   setParameterFilteringParameters,
   setParameterRequired,
-  dashcardData,
   isFullscreen,
   onCancel,
   params,
@@ -120,7 +118,6 @@ export function DashboardSidebars({
           dashboard={dashboard}
           dashcard={clickBehaviorSidebarDashcard}
           parameters={parameters}
-          dashcardData={dashcardData[clickBehaviorSidebarDashcard.id]}
           onUpdateDashCardVisualizationSettings={
             onUpdateDashCardVisualizationSettings
           }

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
@@ -31,7 +31,6 @@ import {
 import type {
   Dashboard as IDashboard,
   DashboardId,
-  DashCardDataMap,
   DashCardId,
   ParameterId,
   ParameterValueOrArray,
@@ -41,7 +40,6 @@ import type { SelectedTabId, State, StoreDashcard } from "metabase-types/store";
 import * as dashboardActions from "../../actions";
 import { DASHBOARD_SLOW_TIMEOUT } from "../../constants";
 import {
-  getDashcardDataMap,
   getClickBehaviorSidebarDashcard,
   getDashboardBeforeEditing,
   getDashboardComplete,
@@ -81,7 +79,6 @@ type StateProps = {
   isEditingParameter: boolean;
   isDirty: boolean;
   dashboard: IDashboard | null;
-  dashcardData: DashCardDataMap;
   slowCards: Record<DashCardId, unknown>;
   parameterValues: Record<ParameterId, ParameterValueOrArray>;
   loadingStartTime: number | null;
@@ -117,7 +114,6 @@ const mapStateToProps = (state: State): StateProps => {
     isEditingParameter: getIsEditingParameter(state),
     isDirty: getIsDirty(state),
     dashboard: getDashboardComplete(state),
-    dashcardData: getDashcardDataMap(state),
     slowCards: getSlowCards(state),
     parameterValues: getParameterValues(state),
     loadingStartTime: getLoadingStartTime(state),

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
@@ -224,6 +224,7 @@ const DashboardApp = (props: DashboardAppProps) => {
     documentTitle: _documentTitle,
     pageFavicon: _pageFavicon,
     isRunning: _isRunning,
+    isLoadingComplete: _isLoadingComplete,
     children,
     ...dashboardProps
   } = props;

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
@@ -21,7 +21,6 @@ import { useWebNotification } from "metabase/hooks/use-web-notification";
 import { parseHashOptions } from "metabase/lib/browser";
 import { useDispatch } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
-import type { EmbeddingParameterVisibility } from "metabase/public/lib/types";
 import { closeNavbar, setErrorPage } from "metabase/redux/app";
 import { addUndo, dismissUndo } from "metabase/redux/undo";
 import { getIsNavbarOpen } from "metabase/selectors/app";
@@ -67,7 +66,6 @@ import {
   getSelectedTabId,
   getSidebar,
   getSlowCards,
-  getEmbeddedParameterVisibility,
 } from "../../selectors";
 
 type OwnProps = {
@@ -104,9 +102,6 @@ type StateProps = {
   isAdditionalInfoVisible: boolean;
   selectedTabId: SelectedTabId;
   isNavigatingBackToDashboard: boolean;
-  getEmbeddedParameterVisibility: (
-    slug: string,
-  ) => EmbeddingParameterVisibility | null;
 };
 
 type DispatchProps = {
@@ -147,8 +142,6 @@ const mapStateToProps = (state: State): StateProps => {
     isAdditionalInfoVisible: getIsAdditionalInfoVisible(state),
     selectedTabId: getSelectedTabId(state),
     isNavigatingBackToDashboard: getIsNavigatingBackToDashboard(state),
-    getEmbeddedParameterVisibility: (slug: string) =>
-      getEmbeddedParameterVisibility(state, slug),
   };
 };
 

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
@@ -220,6 +220,14 @@ const DashboardApp = (props: DashboardAppProps) => {
     onTimeout,
   });
 
+  const {
+    documentTitle: _documentTitle,
+    pageFavicon: _pageFavicon,
+    isRunning: _isRunning,
+    children,
+    ...dashboardProps
+  } = props;
+
   return (
     <div className={cx(CS.shrinkBelowContentSize, CS.fullHeight)}>
       <LeaveConfirmationModal isEnabled={isEditing && isDirty} route={route} />
@@ -228,7 +236,7 @@ const DashboardApp = (props: DashboardAppProps) => {
         dashboardId={getDashboardId(props)}
         editingOnLoad={editingOnLoad}
         addCardOnLoad={addCardOnLoad}
-        {...props}
+        {...dashboardProps}
       />
       {/* For rendering modal urls */}
       {props.children}

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
@@ -24,19 +24,15 @@ import * as Urls from "metabase/lib/urls";
 import { closeNavbar, setErrorPage } from "metabase/redux/app";
 import { addUndo, dismissUndo } from "metabase/redux/undo";
 import { getIsNavbarOpen } from "metabase/selectors/app";
-import { getMetadata } from "metabase/selectors/metadata";
 import {
   canManageSubscriptions,
   getUserIsAdmin,
 } from "metabase/selectors/user";
-import type Database from "metabase-lib/v1/metadata/Database";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type {
   Dashboard as IDashboard,
   DashboardId,
   DashCardDataMap,
   DashCardId,
-  DatabaseId,
   ParameterId,
   ParameterValueOrArray,
 } from "metabase-types/api";
@@ -87,9 +83,7 @@ type StateProps = {
   dashboard: IDashboard | null;
   dashcardData: DashCardDataMap;
   slowCards: Record<DashCardId, unknown>;
-  databases: Record<DatabaseId, Database>;
   parameterValues: Record<ParameterId, ParameterValueOrArray>;
-  metadata: Metadata;
   loadingStartTime: number | null;
   clickBehaviorSidebarDashcard: StoreDashcard | null;
   isAddParameterPopoverOpen: boolean;
@@ -113,7 +107,6 @@ type DispatchProps = {
 type DashboardAppProps = OwnProps & StateProps & DispatchProps;
 
 const mapStateToProps = (state: State): StateProps => {
-  const metadata = getMetadata(state);
   return {
     canManageSubscriptions: canManageSubscriptions(state),
     isAdmin: getUserIsAdmin(state),
@@ -126,10 +119,7 @@ const mapStateToProps = (state: State): StateProps => {
     dashboard: getDashboardComplete(state),
     dashcardData: getDashcardDataMap(state),
     slowCards: getSlowCards(state),
-    databases: metadata.databases,
     parameterValues: getParameterValues(state),
-
-    metadata,
     loadingStartTime: getLoadingStartTime(state),
     clickBehaviorSidebarDashcard: getClickBehaviorSidebarDashcard(state),
     isAddParameterPopoverOpen: getIsAddParameterPopoverOpen(state),

--- a/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.tsx
@@ -3,8 +3,9 @@ import { usePrevious } from "react-use";
 import { t } from "ttag";
 
 import { Sidebar } from "metabase/dashboard/components/Sidebar";
+import { getEmbeddedParameterVisibility } from "metabase/dashboard/selectors";
 import { slugify } from "metabase/lib/formatting";
-import type { EmbeddingParameterVisibility } from "metabase/public/lib/types";
+import { useSelector } from "metabase/lib/redux";
 import { Tabs, Text } from "metabase/ui";
 import { parameterHasNoDisplayValue } from "metabase-lib/v1/parameters/utils/parameter-values";
 import type {
@@ -54,9 +55,6 @@ export interface ParameterSidebarProps {
   onRemoveParameter: (parameterId: ParameterId) => void;
   onShowAddParameterPopover: () => void;
   onClose: () => void;
-  getEmbeddedParameterVisibility: (
-    slug: string,
-  ) => EmbeddingParameterVisibility | null;
 }
 
 export const ParameterSidebar = ({
@@ -74,13 +72,16 @@ export const ParameterSidebar = ({
   onRemoveParameter,
   onShowAddParameterPopover,
   onClose,
-  getEmbeddedParameterVisibility,
   hasMapping,
 }: ParameterSidebarProps): JSX.Element => {
   const parameterId = parameter.id;
   const tabs = useMemo(() => getTabs(parameter), [parameter]);
   const [tab, setTab] = useState<"filters" | "settings">(tabs[0].value);
   const prevParameterId = usePrevious(parameterId);
+
+  const embeddedParameterVisibility = useSelector(state =>
+    getEmbeddedParameterVisibility(state, parameter.slug),
+  );
 
   useEffect(() => {
     if (prevParameterId !== parameterId) {
@@ -216,9 +217,7 @@ export const ParameterSidebar = ({
         <Tabs.Panel pr="md" pl="md" value="settings" key="settings">
           <ParameterSettings
             parameter={parameter}
-            embeddedParameterVisibility={getEmbeddedParameterVisibility(
-              parameter.slug,
-            )}
+            embeddedParameterVisibility={embeddedParameterVisibility}
             isParameterSlugUsed={isParameterSlugUsed}
             onChangeName={handleNameChange}
             onChangeType={handleTypeChange}

--- a/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.unit.spec.tsx
@@ -59,7 +59,6 @@ const setup = ({
           onShowAddParameterPopover={jest.fn()}
           onClose={jest.fn()}
           onChangeRequired={jest.fn()}
-          getEmbeddedParameterVisibility={() => null}
           hasMapping={hasMapping}
         />
       </div>

--- a/frontend/src/metabase/public/containers/PublicDashboard/PublicDashboard.tsx
+++ b/frontend/src/metabase/public/containers/PublicDashboard/PublicDashboard.tsx
@@ -45,7 +45,6 @@ import title from "metabase/hoc/Title";
 import { isWithinIframe } from "metabase/lib/dom";
 import ParametersS from "metabase/parameters/components/ParameterValueWidget.module.css";
 import { setErrorPage } from "metabase/redux/app";
-import { getMetadata } from "metabase/selectors/metadata";
 import {
   setPublicDashboardEndpoints,
   setEmbedDashboardEndpoints,
@@ -65,7 +64,6 @@ const mapStateToProps = (state: State, props: OwnProps) => {
     dashboardId: String(
       props.params.dashboardId || props.params.uuid || props.params.token,
     ),
-    metadata: getMetadata(state),
     dashboard: getDashboardComplete(state),
     dashcardData: getDashcardDataMap(state),
     slowCards: getSlowCards(state),
@@ -271,7 +269,6 @@ class PublicDashboardInner extends Component<PublicDashboardProps> {
                   dashboard={assoc(dashboard, "dashcards", visibleDashcards)}
                   isPublic
                   mode={PublicMode as unknown as Mode}
-                  metadata={this.props.metadata}
                   navigateToNewCardFromDashboard={() => {}}
                   dashcardData={this.props.dashcardData}
                   selectedTabId={this.props.selectedTabId}

--- a/frontend/src/metabase/public/containers/PublicDashboard/PublicDashboard.tsx
+++ b/frontend/src/metabase/public/containers/PublicDashboard/PublicDashboard.tsx
@@ -29,7 +29,6 @@ import type {
 } from "metabase/dashboard/hoc/types";
 import {
   getDashboardComplete,
-  getDashcardDataMap,
   getSlowCards,
   getParameters,
   getParameterValues,
@@ -65,7 +64,6 @@ const mapStateToProps = (state: State, props: OwnProps) => {
       props.params.dashboardId || props.params.uuid || props.params.token,
     ),
     dashboard: getDashboardComplete(state),
-    dashcardData: getDashcardDataMap(state),
     slowCards: getSlowCards(state),
     parameters: getParameters(state),
     parameterValues: getParameterValues(state),
@@ -270,7 +268,6 @@ class PublicDashboardInner extends Component<PublicDashboardProps> {
                   isPublic
                   mode={PublicMode as unknown as Mode}
                   navigateToNewCardFromDashboard={() => {}}
-                  dashcardData={this.props.dashcardData}
                   selectedTabId={this.props.selectedTabId}
                   slowCards={this.props.slowCards}
                   isEditing={false}


### PR DESCRIPTION
### Description

This PR attempts to optimize rendering of the dashboard by using changing props as close as possible to the actual components where props are required. It allows to reduce the number of renderings of dashboard itself from 30+ to 4 on a dashboard with 2 cards and 2 filters

includes
- `getEmbeddedParameterVisibility` has a stable reference
- pageFavicon, documentTitle and other unnecessary for dashboard props are not passed down
- `dashcardData` is used in dashcard visuzliation only
- metadata and databases are calculated only in dashcards and dashboard header (databases can be reworked to a selector to optimize further)

### How to verify

The best way to test it is to merge and check `customer 360` dashboard from stats,

make sure CI is green



### Demo

### Before
<img width="300" alt="Screenshot 2024-05-24 at 16 50 55" src="https://github.com/metabase/metabase/assets/125459446/c1d09c5d-00ec-4861-845a-3a30da3c11ee">

### After
<img width="303" alt="Screenshot 2024-05-24 at 16 49 41" src="https://github.com/metabase/metabase/assets/125459446/9fe0ee9f-05c3-49d4-bf0d-ba14fc28eb09">

