### PR TITLE
Improve models table performance

### DIFF
--- a/frontend/src/metabase/browse/components/CollectionBreadcrumbsWithTooltip.tsx
+++ b/frontend/src/metabase/browse/components/CollectionBreadcrumbsWithTooltip.tsx
@@ -3,6 +3,7 @@ import type { FC } from "react";
 import { forwardRef, useEffect, useRef, useState } from "react";
 
 import { ResponsiveContainer } from "metabase/components/ResponsiveContainer/ResponsiveContainer";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 import { useAreAnyTruncated } from "metabase/hooks/use-is-truncated";
 import resizeObserver from "metabase/lib/resize-observer";
 import * as Urls from "metabase/lib/urls";
@@ -160,3 +161,16 @@ const PathSeparator = () => (
     {pathSeparatorChar}
   </Text>
 );
+
+export const SimpleCollectionDisplay = ({
+  collection,
+}: {
+  collection: CollectionEssentials;
+}) => {
+  return (
+    <Flex align="center" gap="sm">
+      <CollectionsIcon name="folder" />
+      <Ellipsified>{getCollectionName(collection)}</Ellipsified>
+    </Flex>
+  );
+};

--- a/frontend/src/metabase/browse/components/CollectionBreadcrumbsWithTooltip.tsx
+++ b/frontend/src/metabase/browse/components/CollectionBreadcrumbsWithTooltip.tsx
@@ -168,7 +168,7 @@ export const SimpleCollectionDisplay = ({
   collection: CollectionEssentials;
 }) => {
   return (
-    <Flex align="center" gap="sm">
+    <Flex align="center">
       <CollectionsIcon name="folder" />
       <Ellipsified>{getCollectionName(collection)}</Ellipsified>
     </Flex>

--- a/frontend/src/metabase/browse/components/ModelsTable.tsx
+++ b/frontend/src/metabase/browse/components/ModelsTable.tsx
@@ -27,7 +27,10 @@ import type { ModelResult } from "metabase-types/api";
 import { trackModelClick } from "../analytics";
 import { getCollectionName, getIcon } from "../utils";
 
-import { CollectionBreadcrumbsWithTooltip } from "./CollectionBreadcrumbsWithTooltip";
+import {
+  CollectionBreadcrumbsWithTooltip,
+  SimpleCollectionDisplay,
+} from "./CollectionBreadcrumbsWithTooltip";
 import { EllipsifiedWithMarkdownTooltip } from "./EllipsifiedWithMarkdownTooltip";
 import {
   ModelCell,
@@ -70,6 +73,9 @@ export const ModelsTable = ({ models }: ModelsTableProps) => {
   /** The name column has an explicitly set width. The remaining columns divide the remaining width. This is the percentage allocated to the collection column */
   const collectionWidth = 38.5;
   const descriptionWidth = 100 - collectionWidth;
+
+  // for large datasets, we need to simplify the display to avoid performance issues
+  const isLargeDataset = models.length > 500;
 
   return (
     <Table>
@@ -127,14 +133,24 @@ export const ModelsTable = ({ models }: ModelsTableProps) => {
       </thead>
       <TBody>
         {sortedModels.map((model: ModelResult) => (
-          <TBodyRow model={model} key={`${model.model}-${model.id}`} />
+          <TBodyRow
+            model={model}
+            key={`${model.model}-${model.id}`}
+            simpleDisplay={isLargeDataset}
+          />
         ))}
       </TBody>
     </Table>
   );
 };
 
-const TBodyRow = ({ model }: { model: ModelResult }) => {
+const TBodyRow = ({
+  model,
+  simpleDisplay,
+}: {
+  model: ModelResult;
+  simpleDisplay: boolean;
+}) => {
   const icon = getIcon(model);
   const containerName = `collections-path-for-${model.id}`;
   const dispatch = useDispatch();
@@ -171,7 +187,9 @@ const TBodyRow = ({ model }: { model: ModelResult }) => {
         }`}
         {...collectionProps}
       >
-        {model.collection && (
+        {simpleDisplay ? (
+          <SimpleCollectionDisplay collection={model.collection} />
+        ) : (
           <CollectionBreadcrumbsWithTooltip
             containerName={containerName}
             collection={model.collection}


### PR DESCRIPTION
resolves https://github.com/metabase/metabase/issues/43014 

> [!Note]
> Long term, we really need a good virtualization solution for this table, but with these optimizations we can provide a great experience for users with small (<300) sets of models (over 99% of instances), and an acceptable experience for instances with up to 1000 models.

### Description

![Screen Shot 2024-05-24 at 2 44 15 PM](https://github.com/metabase/metabase/assets/30528226/f33f36c6-5739-4f67-9d70-d63ec2f77fee)

The Models table is very slow on instances with large numbers of models. In the real world, 99% of metabase instances [have fewer than 100 models](https://metaboat.slack.com/archives/C064EB1UE5P/p1714587584628579?thread_ts=1714560307.962039&cid=C064EB1UE5P). However, our product team is increasingly encouraging the creation of models, and features like CSV upload make it easy to create hundreds of new models, so this feature should be usable with up to 1000 models (the max returned by the API currently).

Currently, on an instance with 1000 models, the browse models table takes 10+ seconds to render (even after data is fetched).

![Screen Shot 2024-05-24 at 2 27 15 PM](https://github.com/metabase/metabase/assets/30528226/d5006391-b1fa-42dd-b527-8dd5ee10f345)

The biggest culprit here is the collection path column which does some very cool and fancy measurement logic to show you as much of the collection path as possible given your screen size. These calculations are fairly CPU intensive, though this is trivial on small sets of data.

## 1. Simplify collection display on large datasets

This introduces one very simple performance optimization: it uses a simpler collection column component for instances with more than 500 models.

![Screen Shot 2024-05-24 at 2 38 18 PM](https://github.com/metabase/metabase/assets/30528226/6a1163a9-2c66-4c8f-ab48-452110e0ef98)

This improves performance by about 4x, which is still not great, but is much closer to being usable.

![Screen Shot 2024-05-24 at 2 37 29 PM](https://github.com/metabase/metabase/assets/30528226/68db499a-b2df-4dcc-aa58-4fcfa3e320c6)

## 2. Introduce loading state on large datasets

The most significant way this hurts user experience is by making the application feel unresponsive when clicking on the browse models tab. 

Before: nothing happens for a long time when you click the models tab
![nothingHappens](https://github.com/metabase/metabase/assets/30528226/0a0d95a8-a52c-493d-b720-cbbd0478aa2a)

After: the browse tab appears instantly, and you get not-awesome, but also not-broken loading text, which makes the app feel much more responsive. 

![loading behavior](https://github.com/metabase/metabase/assets/30528226/922ef2de-a16f-4d15-99fc-19396ddaa308)


### How to verify

- set up 1000+ models in your metabase instance
- click on the browse models tab
- wait for things to hang
