### PR TITLE
Avoid unnecessary re-renderings in dashboard - dashboard controls

### DIFF
--- a/frontend/src/metabase/dashboard/hoc/DashboardControls.tsx
+++ b/frontend/src/metabase/dashboard/hoc/DashboardControls.tsx
@@ -1,4 +1,5 @@
 import type { ComponentType } from "react";
+import { memo } from "react";
 
 import { useSyncURLSlug } from "metabase/dashboard/components/DashboardTabs/use-sync-url-slug";
 import {
@@ -12,8 +13,9 @@ import type {
   DashboardControlsProps,
 } from "./types";
 
-/* This contains some state for dashboard controls on both private and embedded dashboards.
- * It should probably be in Redux?
+/**
+ * This contains some state for dashboard controls on both private and embedded
+ * dashboards. It should probably be in Redux?
  *
  * @deprecated HOCs are deprecated
  */
@@ -89,5 +91,5 @@ export const DashboardControls = <T extends DashboardControlsProps>(
     );
   }
 
-  return DashboardControlsInner;
+  return memo(DashboardControlsInner);
 };

--- a/frontend/src/metabase/dashboard/hooks/use-dashboard-fullscreen.ts
+++ b/frontend/src/metabase/dashboard/hooks/use-dashboard-fullscreen.ts
@@ -1,29 +1,32 @@
 import { useFullscreen } from "@mantine/hooks";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import type { DashboardFullscreenControls } from "../types";
 
 export const useDashboardFullscreen = (): DashboardFullscreenControls => {
   const { toggle, fullscreen } = useFullscreen();
 
-  const [isFullscreen, setIsFullscreen] = useState<boolean>(false);
+  const [isFullscreen, setIsFullscreen] = useState(false);
 
   useEffect(() => {
     setIsFullscreen(fullscreen);
   }, [fullscreen]);
 
-  const onFullscreenChange = (
-    nextIsFullscreen: boolean | null,
-    openInBrowserFullscreen: boolean = true,
-  ) => {
-    if (nextIsFullscreen === isFullscreen) {
-      return;
-    }
-    if (isFullscreen || (nextIsFullscreen && openInBrowserFullscreen)) {
-      toggle();
-    }
-    setIsFullscreen(nextIsFullscreen ?? false);
-  };
+  const onFullscreenChange = useCallback(
+    (
+      nextIsFullscreen: boolean | null,
+      openInBrowserFullscreen: boolean = true,
+    ) => {
+      if (nextIsFullscreen === isFullscreen) {
+        return;
+      }
+      if (isFullscreen || (nextIsFullscreen && openInBrowserFullscreen)) {
+        toggle();
+      }
+      setIsFullscreen(nextIsFullscreen ?? false);
+    },
+    [isFullscreen, toggle],
+  );
 
   return { isFullscreen, onFullscreenChange };
 };

--- a/frontend/src/metabase/dashboard/hooks/use-embed-theme.ts
+++ b/frontend/src/metabase/dashboard/hooks/use-embed-theme.ts
@@ -1,3 +1,5 @@
+import { useCallback } from "react";
+
 import { setDisplayTheme } from "metabase/dashboard/actions";
 import { getDisplayTheme } from "metabase/dashboard/selectors";
 import { useDispatch, useSelector } from "metabase/lib/redux";
@@ -9,11 +11,17 @@ export const useEmbedTheme = (): EmbedThemeControls => {
   const dispatch = useDispatch();
 
   const theme = useSelector(getDisplayTheme);
-  const setTheme = (theme: DisplayTheme) => dispatch(setDisplayTheme(theme));
+  const setTheme = useCallback(
+    (theme: DisplayTheme) => dispatch(setDisplayTheme(theme)),
+    [dispatch],
+  );
 
-  const onNightModeChange = (isNightMode: boolean) => {
-    setTheme(isNightMode ? "night" : "light");
-  };
+  const onNightModeChange = useCallback(
+    (isNightMode: boolean) => {
+      setTheme(isNightMode ? "night" : "light");
+    },
+    [setTheme],
+  );
 
   const isNightMode = theme === "night";
 

--- a/frontend/src/metabase/dashboard/hooks/use-interval.ts
+++ b/frontend/src/metabase/dashboard/hooks/use-interval.ts
@@ -1,5 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
+/**
+ * it's a copy of mantine's useInterval, but with memoization of the callbacks
+ */
 export function useInterval(fn: () => void, interval: number) {
   const [active, setActive] = useState(false);
   const intervalRef = useRef<number>();

--- a/frontend/src/metabase/dashboard/hooks/use-interval.ts
+++ b/frontend/src/metabase/dashboard/hooks/use-interval.ts
@@ -1,0 +1,36 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export function useInterval(fn: () => void, interval: number) {
+  const [active, setActive] = useState(false);
+  const intervalRef = useRef<number>();
+  const fnRef = useRef<() => void>();
+
+  useEffect(() => {
+    fnRef.current = fn;
+  }, [fn]);
+
+  const start = useCallback(() => {
+    setActive(old => {
+      if (!old && !intervalRef.current) {
+        intervalRef.current = window.setInterval(fnRef.current!, interval);
+      }
+      return true;
+    });
+  }, [interval, fnRef]);
+
+  const stop = useCallback(() => {
+    setActive(false);
+    window.clearInterval(intervalRef.current);
+    intervalRef.current = undefined;
+  }, []);
+
+  const toggle = useCallback(() => {
+    if (active) {
+      stop();
+    } else {
+      start();
+    }
+  }, [active, start, stop]);
+
+  return { start, stop, toggle, active };
+}

--- a/frontend/src/metabase/dashboard/hooks/use-refresh-dashboard.ts
+++ b/frontend/src/metabase/dashboard/hooks/use-refresh-dashboard.ts
@@ -1,3 +1,5 @@
+import { useCallback } from "react";
+
 import {
   fetchDashboard,
   fetchDashboardCardData,
@@ -17,7 +19,7 @@ export const useRefreshDashboard = ({
 } => {
   const dispatch = useDispatch();
 
-  const refreshDashboard = async () => {
+  const refreshDashboard = useCallback(async () => {
     if (dashboardId) {
       await dispatch(
         fetchDashboard({
@@ -35,7 +37,7 @@ export const useRefreshDashboard = ({
       );
       dispatch(fetchDashboardCardMetadata());
     }
-  };
+  }, [dashboardId, dispatch, queryParams]);
 
   return { refreshDashboard };
 };


### PR DESCRIPTION
### Description

After https://github.com/metabase/metabase/pull/42777 we have several unnecessary re-renderings related to the props which are re-created on DashboardControls level, this PR uses memoization to avoid having new references for the passed props


### Before
<img width="305" alt="image" src="https://github.com/metabase/metabase/assets/125459446/ccd004f4-abe1-4ec8-a8f1-eed7c30fdb09">

### After
<img width="322" alt="image" src="https://github.com/metabase/metabase/assets/125459446/2429b0b5-02c4-42eb-895a-0f99b86c283d">


### How to verify

CI is green

