### PR TITLE
Fix multiple origins support by handling invalid origins

### DIFF
--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -169,10 +169,10 @@
 
 (defn approved-origin?
   "Returns true if `origin` should be allowed for CORS based on the `approved-origins`"
-  [raw-origin approved-origins]
+  [raw-origin approved-origins-raw]
   (boolean
-   (when (and (seq raw-origin) (seq approved-origins))
-     (let [approved-list (parse-approved-origins approved-origins)
+   (when (and (seq raw-origin) (seq approved-origins-raw))
+     (let [approved-list (parse-approved-origins approved-origins-raw)
            origin        (parse-url raw-origin)]
        (some (fn [approved-origin]
                            (and

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -124,11 +124,65 @@
           "Content-Security-Policy"
           #(format "%s frame-ancestors %s;" % (if allow-iframes? "*" (or (embedding-app-origin) "'none'")))))
 
+(defn parse-url
+  "Returns an object with protocol, domain and port for the given url"
+  [url]
+  (let [pattern #"^(?:(https?)://)?([^:/]+)(?::(\d+|\*))?$"
+        matches (re-matches pattern url)]
+    (if matches
+      (let [[_ protocol domain port] matches]
+        {:protocol protocol
+         :domain domain
+         :port port})
+      (throw (IllegalArgumentException. "Invalid URL")))))
+
+(defn approved-domain?
+  "Checks if the domain is compatible with the reference one"
+  [domain reference-domain]
+  (if (str/starts-with? reference-domain "*.")
+    (str/ends-with? domain (str/replace-first reference-domain "*." "."))
+    (= domain reference-domain)))
+
+(defn approved-protocol?
+  "Checks if the protocol is compatible with the reference one"
+  [protocol reference-protocol]
+  (or (nil? reference-protocol)
+      (= protocol reference-protocol)))
+
+(defn approved-port?
+  "Checks if the port is compatible with the reference one"
+  [port reference-port]
+  (or
+   (= reference-port "*")
+   (= port reference-port)))
+
+(defn approved-origin?
+  "Returns true if `origin` should be allowed for CORS based on the `approved-origins`"
+  [raw-origin approved-origins]
+  (boolean
+   (when (and (seq raw-origin) (seq approved-origins))
+     (let [approved-list (str/split approved-origins #" ")
+           origin        (parse-url raw-origin)]
+       (boolean (some (fn [approved-origin-raw]
+                        (or
+                         (= approved-origin-raw "*")
+                         (let [approved-origin (parse-url approved-origin-raw)]
+                           (and
+                            (approved-domain? (:domain origin) (:domain approved-origin))
+                            (approved-protocol? (:protocol origin) (:protocol approved-origin))
+                            (approved-port? (:port origin) (:port approved-origin))))))
+                      approved-list))))))
+
 (defn- access-control-headers
-  []
-  {"Access-Control-Allow-Origin"    (embedding-app-origin)
-   "Access-Control-Allow-Headers"   "*"
-   "Access-Control-Expose-Headers"  "X-Metabase-Anti-CSRF-Token"})
+  [origin]
+  (merge
+   (when
+    (approved-origin? origin (embedding-app-origin))
+     {"Access-Control-Allow-Origin" origin
+      "Vary"                        "Origin"})
+
+   {"Access-Control-Allow-Headers"   "*"
+    "Access-Control-Expose-Headers"  "X-Metabase-Anti-CSRF-Token"}))
 
 (defn- first-embedding-app-origin
   "Return only the first embedding app origin."
@@ -139,7 +193,7 @@
 
 (defn security-headers
   "Fetch a map of security headers that should be added to a response based on the passed options."
-  [& {:keys [nonce allow-iframes? allow-cache?]
+  [& {:keys [origin nonce allow-iframes? allow-cache?]
       :or   {allow-iframes? false, allow-cache? false}}]
   (merge
    (if allow-cache?
@@ -147,7 +201,7 @@
      (cache-prevention-headers))
    strict-transport-security-header
    (content-security-policy-header-with-frame-ancestors allow-iframes? nonce)
-   (when (embedding-app-origin) (access-control-headers))
+   (when (embedding-app-origin) (access-control-headers origin))
    (when-not allow-iframes?
      ;; Tell browsers not to render our site as an iframe (prevent clickjacking)
      {"X-Frame-Options"                 (if (embedding-app-origin)
@@ -163,6 +217,7 @@
 (defn- add-security-headers* [request response]
   ;; merge is other way around so that handler can override headers
   (update response :headers #(merge %2 %1) (security-headers
+                                            :origin         ((:headers request) "origin")
                                             :nonce          (:nonce request)
                                             :allow-iframes? ((some-fn req.util/public? req.util/embed?) request)
                                             :allow-cache?   (req.util/cacheable? request))))

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -174,12 +174,12 @@
    (when (and (seq raw-origin) (seq approved-origins))
      (let [approved-list (parse-approved-origins approved-origins)
            origin        (parse-url raw-origin)]
-       (boolean (some (fn [approved-origin]
+       (some (fn [approved-origin]
                            (and
                             (approved-domain? (:domain origin) (:domain approved-origin))
                             (approved-protocol? (:protocol origin) (:protocol approved-origin))
                             (approved-port? (:port origin) (:port approved-origin))))
-                      approved-list))))))
+                      approved-list)))))
 
 (defn- access-control-headers
   [origin]

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -144,9 +144,9 @@
   "Checks if the domain is compatible with the reference one"
   [domain reference-domain]
   (or (= reference-domain "*")
-   (if (str/starts-with? reference-domain "*.")
-     (str/ends-with? domain (str/replace-first reference-domain "*." "."))
-     (= domain reference-domain))))
+      (if (str/starts-with? reference-domain "*.")
+        (str/ends-with? domain (str/replace-first reference-domain "*." "."))
+        (= domain reference-domain))))
 
 (defn approved-protocol?
   "Checks if the protocol is compatible with the reference one"

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -132,12 +132,12 @@
     {:protocol nil :domain "*" :port "*"}
     (let [pattern #"^(?:(https?)://)?([^:/]+)(?::(\d+|\*))?$"
           matches (re-matches pattern url)]
-      (if matches
+      (if-not matches
+        (do (log/errorf "Invalid URL: %s" url) nil)
         (let [[_ protocol domain port] matches]
           {:protocol protocol
            :domain domain
-           :port port})
-        (throw (IllegalArgumentException. (str "Invalid URL '" url "'")))))))
+           :port port})))))
 
 
 (defn approved-domain?
@@ -165,12 +165,7 @@
     "Parses the space separated string of approved origins"
     [approved-origins-raw]
     (let [urls (filter seq (str/split approved-origins-raw #" "))]
-     (remove nil? (map
-      (fn [url]
-        (try
-          (parse-url url)
-          (catch Exception e (log/error e) nil)))
-      urls))))
+     (keep parse-url urls)))
 
 (defn approved-origin?
   "Returns true if `origin` should be allowed for CORS based on the `approved-origins`"

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -163,7 +163,7 @@
   (defn parse-approved-origins
     "Parses the space separated string of approved origins"
     [approved-origins-raw]
-      (str/split approved-origins-raw #" "))
+     (filter seq (str/split approved-origins-raw #" ")))
 
 (defn approved-origin?
   "Returns true if `origin` should be allowed for CORS based on the `approved-origins`"

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -164,7 +164,7 @@
 (defn parse-approved-origins
     "Parses the space separated string of approved origins"
     [approved-origins-raw]
-    (let [urls (filter seq (str/split approved-origins-raw #" "))]
+    (let [urls (str/split approved-origins-raw #" +")]
      (keep parse-url urls)))
 
 (defn approved-origin?

--- a/test/metabase/server/middleware/security_test.clj
+++ b/test/metabase/server/middleware/security_test.clj
@@ -105,6 +105,11 @@
     (is (thrown-with-msg? IllegalArgumentException #"Invalid URL" (mw.security/parse-url "://example.com")))
     (is (thrown-with-msg? IllegalArgumentException #"Invalid URL" (mw.security/parse-url "example:com")))))
 
+(deftest test-parse-approved-origins
+  (testing "Should not break on multiple spaces in a row"
+    (is (= (count (mw.security/parse-approved-origins "example.com      example.org")) 2 ))
+    (is (= (count (mw.security/parse-approved-origins "   example.com      example.org   ")) 2))))
+
 (deftest test-approved-domain?
   (testing "Exact match"
     (is (true? (mw.security/approved-domain? "example.com" "example.com")))

--- a/test/metabase/server/middleware/security_test.clj
+++ b/test/metabase/server/middleware/security_test.clj
@@ -107,11 +107,11 @@
 
 (deftest test-parse-approved-origins
   (testing "Should not break on multiple spaces in a row"
-    (is (= (count (mw.security/parse-approved-origins "example.com      example.org")) 2))
-    (is (= (count (mw.security/parse-approved-origins "   example.com      example.org   ")) 2)))
+    (is (= 2 (count (mw.security/parse-approved-origins "example.com      example.org"))))
+    (is (= 2 (count (mw.security/parse-approved-origins "   example.com      example.org   ")))))
   (testing "Should filter out invalid origins without throwing"
-    (is (= (count (mw.security/parse-approved-origins "example.org ://example.com")) 1))
-    (is (= (count (mw.security/parse-approved-origins "example.org http:/example.com")) 1))))
+    (is (= 1 (count (mw.security/parse-approved-origins "example.org ://example.com"))))
+    (is (= 1 (count (mw.security/parse-approved-origins "example.org http:/example.com"))))))
 
 (deftest test-approved-domain?
   (testing "Exact match"

--- a/test/metabase/server/middleware/security_test.clj
+++ b/test/metabase/server/middleware/security_test.clj
@@ -91,3 +91,82 @@
            (is (str/includes? style-src (str "nonce-" nonce))))
           (testing "The same nonce is in the body of the rendered page"
             (is (str/includes? (:body response) nonce))))))))
+
+(deftest test-parse-url
+  (testing "Should parse valid urls"
+    (is (= (mw.security/parse-url "http://example.com") {:protocol "http" :domain "example.com" :port nil}))
+    (is (= (mw.security/parse-url "https://example.com") {:protocol "https" :domain "example.com" :port nil}))
+    (is (= (mw.security/parse-url "http://example.com:8080") {:protocol "http" :domain "example.com" :port "8080"}))
+    (is (= (mw.security/parse-url "example.com:80") {:protocol nil :domain "example.com" :port "80"}))
+    (is (= (mw.security/parse-url "example.com:*") {:protocol nil :domain "example.com" :port "*"})))
+
+  (testing "Should throw for invalid urls"
+    (is (thrown-with-msg? IllegalArgumentException #"Invalid URL" (mw.security/parse-url "ftp://example.com")))
+    (is (thrown-with-msg? IllegalArgumentException #"Invalid URL" (mw.security/parse-url "://example.com")))
+    (is (thrown-with-msg? IllegalArgumentException #"Invalid URL" (mw.security/parse-url "example:com")))))
+
+(deftest test-approved-domain?
+  (testing "Exact match"
+    (is (true? (mw.security/approved-domain? "example.com" "example.com")))
+    (is (false? (mw.security/approved-domain? "example.com" "example.org"))))
+
+  (testing "Should support wildcards for subdomains"
+    (is (true? (mw.security/approved-domain? "sub.example.com" "*.example.com")))
+    (is (false? (mw.security/approved-domain? "example.com" "*.example.com")))
+    (is (false? (mw.security/approved-domain? "sub.example.org" "*.example.com"))))
+
+  (testing "Should not allow subdomains if no wildcard is present"
+    (is (false? (mw.security/approved-domain? "sub.example.com" "example.com")))))
+
+(deftest test-approved-protocol?
+  (testing "Exact protocol match"
+    (is (true? (mw.security/approved-protocol? "http" "http")))
+    (is (true? (mw.security/approved-protocol? "https" "https")))
+    (is (false? (mw.security/approved-protocol? "http" "https"))))
+
+  (testing "Nil reference should allow any protocol"
+    (is (true? (mw.security/approved-protocol? "http" nil)))
+    (is (true? (mw.security/approved-protocol? "https" nil)))))
+
+(deftest test-approved-port?
+  (testing "Exact port match"
+    (is (true? (mw.security/approved-port? "80" "80")))
+    (is (false? (mw.security/approved-port? "80" "8080"))))
+
+  (testing "Wildcard port match"
+    (is (true? (mw.security/approved-port? "80" "*")))
+    (is (true? (mw.security/approved-port? "8080" "*")))))
+
+(deftest test-approved-origin?
+  (testing "Should return false if parameters are nil"
+    (is (false? (mw.security/approved-origin? nil "example.com")))
+    (is (false? (mw.security/approved-origin? "example.com" nil))))
+
+  (testing "Approved origins with exact protocol and port match"
+    (let [approved "http://example1.com http://example2.com:3000 https://example3.com"]
+      (is (true? (mw.security/approved-origin? "http://example1.com" approved)))
+      (is (true? (mw.security/approved-origin? "http://example2.com:3000" approved)))
+      (is (true? (mw.security/approved-origin? "https://example3.com" approved)))))
+
+  (testing "Different protocol should fail"
+    (is (false? (mw.security/approved-origin? "https://example1.com" "http://example1.com"))))
+
+  (testing "Origins without protocol should accept both http and https"
+    (let [approved "example.com"]
+      (is (true? (mw.security/approved-origin? "http://example.com" approved)))
+      (is (true? (mw.security/approved-origin? "https://example.com" approved)))))
+
+  (testing "Different ports should fail"
+    (is (false? (mw.security/approved-origin? "http://example.com:3000" "http://example.com:3003"))))
+
+  (testing "Should allow anything with *"
+    (is (true? (mw.security/approved-origin? "http://example.com" "*")))
+    (is (true? (mw.security/approved-origin? "http://example.com" "http://somethingelse.com *"))))
+
+  (testing "Should allow subdomains when *.example.com"
+    (is (true? (mw.security/approved-origin? "http://subdomain.example.com" "*.example.com")))
+    (is (false? (mw.security/approved-origin? "http://subdomain.example.com" "*.somethingelse.com"))))
+
+  (testing "Should allow any port with example.com:*"
+    (is (true? (mw.security/approved-origin? "http://example.com" "example.com:*")))
+    (is (true? (mw.security/approved-origin? "http://example.com:8080" "example.com:*")))))

--- a/test/metabase/server/middleware/security_test.clj
+++ b/test/metabase/server/middleware/security_test.clj
@@ -107,8 +107,11 @@
 
 (deftest test-parse-approved-origins
   (testing "Should not break on multiple spaces in a row"
-    (is (= (count (mw.security/parse-approved-origins "example.com      example.org")) 2 ))
-    (is (= (count (mw.security/parse-approved-origins "   example.com      example.org   ")) 2))))
+    (is (= (count (mw.security/parse-approved-origins "example.com      example.org")) 2))
+    (is (= (count (mw.security/parse-approved-origins "   example.com      example.org   ")) 2)))
+  (testing "Should filter out invalid origins without throwing"
+    (is (= (count (mw.security/parse-approved-origins "example.org ://example.com")) 1))
+    (is (= (count (mw.security/parse-approved-origins "example.org http:/example.com")) 1))))
 
 (deftest test-approved-domain?
   (testing "Exact match"
@@ -174,4 +177,7 @@
 
   (testing "Should allow any port with example.com:*"
     (is (true? (mw.security/approved-origin? "http://example.com" "example.com:*")))
-    (is (true? (mw.security/approved-origin? "http://example.com:8080" "example.com:*")))))
+    (is (true? (mw.security/approved-origin? "http://example.com:8080" "example.com:*"))))
+
+  (testing "Should handle invalid origins"
+    (is (true? (mw.security/approved-origin? "http://example.com" "  fpt://something http://example.com ://123  4")))))

--- a/test/metabase/server/middleware/security_test.clj
+++ b/test/metabase/server/middleware/security_test.clj
@@ -100,10 +100,10 @@
     (is (= (mw.security/parse-url "example.com:80") {:protocol nil :domain "example.com" :port "80"}))
     (is (= (mw.security/parse-url "example.com:*") {:protocol nil :domain "example.com" :port "*"})))
 
-  (testing "Should throw for invalid urls"
-    (is (thrown-with-msg? IllegalArgumentException #"Invalid URL" (mw.security/parse-url "ftp://example.com")))
-    (is (thrown-with-msg? IllegalArgumentException #"Invalid URL" (mw.security/parse-url "://example.com")))
-    (is (thrown-with-msg? IllegalArgumentException #"Invalid URL" (mw.security/parse-url "example:com")))))
+  (testing "Should return nil for invalid urls"
+    (is (nil? (mw.security/parse-url "ftp://example.com")))
+    (is (nil? (mw.security/parse-url "://example.com")))
+    (is (nil? (mw.security/parse-url "example:com")))))
 
 (deftest test-parse-approved-origins
   (testing "Should not break on multiple spaces in a row"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/42631

### Description

This fixes https://github.com/metabase/metabase/pull/42888 which was reverted because it broke staging.
The issue was caused by the logic not supporting "invalid" input, such as multiple spaces in the authorized origins. This caused parse-url to be called on "" which caused the "Invalid URL" exception.

`approved-origin?` now never throws, to make sure this won't break the BE for an invalid input.
It will instead log an error if it gets an invalid input.


- 6337f67f557bc8652af84e82780c83a57ec08d84 reverts the revert, to put back the original code in the PR
- 2eb30b1c8dfcfe9c20f0aead631b5909548fb6f7 extracts a `parse-approved-origins` function that will be tested and improved in the other commits
- 26b02220bc1814b8dabda3d9d0a1c0cb347973e1 implements the fix for the multiple spaces
- 0052ec8795c820d648d2d834c7ae9b24348f0e71 moves the calls of `parse-url` for the approved origins inside `parse-approved-origins` and filters out invalid origins, to make the code more robust

