### PR TITLE
Enable running tagged tests defined in TS

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -144,7 +144,7 @@ jobs:
         run: |
           yarn run test-cypress-run \
           --env grepTags=@OSS,grepOmitFiltered=true \
-          --spec './e2e/test/scenarios/**/*.cy.spec.js' \
+          --spec './e2e/test/scenarios/**/*.cy.spec.(js|ts)' \
           --browser 'replay-chromium'
 
       - name: Run slow and resource-intensive Cypress tests
@@ -152,7 +152,7 @@ jobs:
         run: |
           yarn run test-cypress-run \
           --env grepTags="@slow",grepOmitFiltered=true \
-          --spec './e2e/test/scenarios/**/*.cy.spec.js' \
+          --spec './e2e/test/scenarios/**/*.cy.spec.(js|ts)' \
           --browser 'replay-chromium'
 
       - name: Run Flaky Cypress tests
@@ -160,7 +160,7 @@ jobs:
         run: |
           yarn run test-cypress-run \
           --env grepTags="@flaky --@quarantine",grepOmitFiltered=true \
-          --spec './e2e/test/scenarios/**/*.cy.spec.js' \
+          --spec './e2e/test/scenarios/**/*.cy.spec.(js|ts)' \
           --browser 'replay-chromium'
 
       - name: Run EE Cypress tests on ${{ matrix.name }}
@@ -176,7 +176,7 @@ jobs:
         run: |
           yarn run test-cypress-run \
           --env grepTags="@mongo --@quarantine",grepOmitFiltered=true \
-          --spec './e2e/test/scenarios/**/*.cy.spec.js' \
+          --spec './e2e/test/scenarios/**/*.cy.spec.(js|ts)' \
           --browser 'replay-chromium'
         env:
           CYPRESS_QA_DB_MONGO: true

--- a/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
@@ -418,7 +418,7 @@ describe("scenarios > notebook > data source", () => {
   });
 });
 
-describeOSS("scenarios > notebook > data source", () => {
+describeOSS("scenarios > notebook > data source", { tags: "@OSS" }, () => {
   beforeEach(() => {
     restore("setup");
     cy.signInAsAdmin();
@@ -433,19 +433,12 @@ describeOSS("scenarios > notebook > data source", () => {
     });
 
     startNewQuestion();
-    popover().within(() => {
-      cy.findByPlaceholderText("Search for some data…");
-      cy.findAllByTestId("data-bucket-list-item")
-        .as("sources")
-        .should("have.length", 2);
-      cy.get("@sources")
-        .first()
-        .should("contain", "Models")
-        .and("have.attr", "aria-selected", "false");
-      cy.get("@sources")
-        .last()
-        .should("contain", "Raw Data")
-        .and("have.attr", "aria-selected", "false");
+    entityPickerModal().within(() => {
+      cy.findAllByRole("tab").should("have.length", 2);
+      entityPickerModalTab("Recents").should("not.exist");
+      entityPickerModalTab("Models").and("have.attr", "aria-selected", "true");
+      entityPickerModalTab("Tables").should("exist");
+      entityPickerModalTab("Saved questions").should("not.exist");
     });
   });
 });

--- a/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
@@ -26,6 +26,7 @@ import {
   expectGoodSnowplowEvents,
   expectNoBadSnowplowEvents,
   entityPickerModal,
+  entityPickerModalTab,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -281,8 +282,8 @@ describe(
 
     it("should work for both simple and nested questions based on previously converted GUI query", () => {
       startNewQuestion();
-      popover().within(() => {
-        cy.findByText("Raw Data").click();
+      entityPickerModal().within(() => {
+        entityPickerModalTab("Tables").click();
         cy.findByText(MONGO_DB_NAME).click();
         cy.findByText("Products").click();
       });


### PR DESCRIPTION
### Description

This PR makes sure that all TS e2e suites will actually run.
It also updates existing tests that didn't run because TS suites were excluded.

See [Slack](https://metaboat.slack.com/archives/C0645JP1W81/p1716567855206449).

### How to verify

CI is all green.

The updated tests run in CI:
- `notebook-data-source.cy.spec.ts` - [run](https://github.com/metabase/metabase/actions/runs/9252416023/job/25450435932?pr=43172)
- `notebook-native-preview-sidebar.cy.spec.ts` - [run](https://github.com/metabase/metabase/actions/runs/9252416023/job/25450436679?pr=43172)