### PR TITLE
Correctly place "Add column" button and allow using it when summarizing

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/column-shortcuts/column-shortcuts.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-tabular/column-shortcuts/column-shortcuts.cy.spec.ts
@@ -17,7 +17,7 @@ import {
   expectNoBadSnowplowEvents,
 } from "e2e/support/helpers";
 
-const { PEOPLE, PEOPLE_ID } = SAMPLE_DATABASE;
+const { PEOPLE, PEOPLE_ID, ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
 const DATE_CASES = [
   {
@@ -263,6 +263,32 @@ describeWithSnowplow("extract shortcut", () => {
 
     // ID should still be visible (ie. no scrolling to the end should have happened)
     cy.findAllByRole("columnheader", { name: "ID" }).should("be.visible");
+  });
+
+  it("should be possible to extract columns from a summarized table", () => {
+    createQuestion(
+      {
+        query: {
+          "source-table": ORDERS_ID,
+          limit: 1,
+          aggregation: [["count"]],
+          breakout: [
+            ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+          ],
+        },
+      },
+      {
+        visitQuestion: true,
+      },
+    );
+    extractColumnAndCheck({
+      column: "Created At: Month",
+      option: "Month of year",
+    });
+
+    cy.findAllByRole("columnheader", { name: "Month of year" }).should(
+      "be.visible",
+    );
   });
 });
 

--- a/e2e/test/scenarios/visualizations-tabular/column-shortcuts/combine-column-shortcut.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-tabular/column-shortcuts/combine-column-shortcut.cy.spec.ts
@@ -56,11 +56,12 @@ describeWithSnowplow("scenarios > visualizations > combine shortcut", () => {
     });
   });
 
-  it("should not show the shortcut button when the table is raw", function () {
+  it("should allow combining columns when aggregating", function () {
     createQuestion(
       {
         query: {
           "source-table": ORDERS_ID,
+          limit: 1,
           aggregation: [["count"]],
           breakout: [
             ["field", ORDERS.CREATED_AT, { "temporal-unit": "hour-of-day" }],
@@ -73,7 +74,12 @@ describeWithSnowplow("scenarios > visualizations > combine shortcut", () => {
     );
 
     cy.findByTestId("TableInteractive-root").should("exist");
-    cy.findByLabelText("Add column").should("not.exist");
+    combineColumns({
+      columns: ["Created At: Hour of day", "Count"],
+      newColumn: "Combined Created At: Hour of day, Count",
+      example: "2042-01-01 12:34:56.789 123",
+      newValue: "0 766",
+    });
   });
 });
 

--- a/e2e/test/scenarios/visualizations-tabular/column-shortcuts/combine-column-shortcut.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-tabular/column-shortcuts/combine-column-shortcut.cy.spec.ts
@@ -12,7 +12,7 @@ import {
   expectGoodSnowplowEvent,
 } from "e2e/support/helpers";
 
-const { PEOPLE, PEOPLE_ID } = SAMPLE_DATABASE;
+const { PEOPLE, PEOPLE_ID, ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
 
 describeWithSnowplow("scenarios > visualizations > combine shortcut", () => {
   beforeEach(() => {
@@ -54,6 +54,26 @@ describeWithSnowplow("scenarios > visualizations > combine shortcut", () => {
       custom_expressions_used: ["concat"],
       database_id: SAMPLE_DB_ID,
     });
+  });
+
+  it("should not show the shortcut button when the table is raw", function () {
+    createQuestion(
+      {
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+          breakout: [
+            ["field", ORDERS.CREATED_AT, { "temporal-unit": "hour-of-day" }],
+          ],
+        },
+      },
+      {
+        visitQuestion: true,
+      },
+    );
+
+    cy.findByTestId("TableInteractive-root").should("exist");
+    cy.findByLabelText("Add column").should("not.exist");
   });
 });
 

--- a/frontend/src/metabase/visualizations/click-actions/actions/CombineColumnsAction/CombineColumnsAction.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/CombineColumnsAction/CombineColumnsAction.tsx
@@ -9,14 +9,19 @@ import type { ClickActionPopoverProps } from "metabase/visualizations/types/clic
 import * as Lib from "metabase-lib";
 
 export const CombineColumnsAction: LegacyDrill = ({ question, clicked }) => {
-  const { isEditable } = Lib.queryDisplayInfo(question.query());
+  const { query, stageIndex } = Lib.asReturned(question.query(), -1);
+
+  const { isEditable } = Lib.queryDisplayInfo(query);
+  const isExpressionable =
+    Lib.expressionableColumns(query, stageIndex).length > 0;
 
   if (
     !clicked ||
     clicked.value !== undefined ||
     !clicked.columnShortcuts ||
     clicked.extraData?.isRawTable ||
-    !isEditable
+    !isEditable ||
+    !isExpressionable
   ) {
     return [];
   }

--- a/frontend/src/metabase/visualizations/click-actions/actions/CombineColumnsAction/CombineColumnsAction.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/CombineColumnsAction/CombineColumnsAction.tsx
@@ -19,7 +19,6 @@ export const CombineColumnsAction: LegacyDrill = ({ question, clicked }) => {
     !clicked ||
     clicked.value !== undefined ||
     !clicked.columnShortcuts ||
-    clicked.extraData?.isRawTable ||
     !isEditable ||
     !isExpressionable
   ) {

--- a/frontend/src/metabase/visualizations/click-actions/actions/CombineColumnsAction/CombineColumnsAction.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/CombineColumnsAction/CombineColumnsAction.tsx
@@ -30,8 +30,6 @@ export const CombineColumnsAction: LegacyDrill = ({ question, clicked }) => {
     onChangeCardAndRun,
     onClose,
   }: ClickActionPopoverProps) => {
-    const query = question.query();
-    const stageIndex = -1;
     const dispatch = useDispatch();
 
     function handleSubmit(name: string, clause: Lib.ExpressionClause) {

--- a/frontend/src/metabase/visualizations/click-actions/actions/ExtractColumn/ExtractColumn.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/ExtractColumn/ExtractColumn.tsx
@@ -10,14 +10,22 @@ import type { ClickActionPopoverProps } from "metabase/visualizations/types/clic
 import * as Lib from "metabase-lib";
 
 export const ExtractColumnAction: LegacyDrill = ({ question, clicked }) => {
-  const { isEditable } = Lib.queryDisplayInfo(question.query());
+  const { query, stageIndex } = Lib.asReturned(question.query(), -1);
+
+  const { isEditable } = Lib.queryDisplayInfo(query);
+  const expressionableColumns = Lib.expressionableColumns(query, stageIndex);
+  const isExtractable =
+    expressionableColumns.reduce(function (sum, column) {
+      return sum + Lib.columnExtractions(query, column).length;
+    }, 0) > 0;
 
   if (
     !clicked ||
     clicked.value !== undefined ||
     !clicked.columnShortcuts ||
     clicked?.extraData?.isRawTable ||
-    !isEditable
+    !isEditable ||
+    !isExtractable
   ) {
     return [];
   }

--- a/frontend/src/metabase/visualizations/click-actions/actions/ExtractColumn/ExtractColumn.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/ExtractColumn/ExtractColumn.tsx
@@ -23,7 +23,6 @@ export const ExtractColumnAction: LegacyDrill = ({ question, clicked }) => {
     !clicked ||
     clicked.value !== undefined ||
     !clicked.columnShortcuts ||
-    clicked?.extraData?.isRawTable ||
     !isEditable ||
     !isExtractable
   ) {

--- a/frontend/src/metabase/visualizations/click-actions/actions/ExtractColumn/ExtractColumn.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/ExtractColumn/ExtractColumn.tsx
@@ -34,8 +34,6 @@ export const ExtractColumnAction: LegacyDrill = ({ question, clicked }) => {
     onChangeCardAndRun,
     onClose,
   }: ClickActionPopoverProps) => {
-    const query = question.query();
-    const stageIndex = -1;
     const dispatch = useDispatch();
 
     function handleSubmit(

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -24,6 +24,7 @@ import {
   getRowIndexToPKMap,
   getQueryBuilderMode,
   getUiControls,
+  getIsShowingRawTable,
 } from "metabase/query_builder/selectors";
 import { getIsEmbeddingSdk } from "metabase/selectors/embed";
 import { EmotionCacheProvider } from "metabase/styled-components/components/EmotionCacheProvider";
@@ -86,6 +87,7 @@ const mapStateToProps = state => ({
   rowIndexToPkMap: getRowIndexToPKMap(state),
   isEmbeddingSdk: getIsEmbeddingSdk(state),
   scrollToLastColumn: getUiControls(state).scrollToLastColumn,
+  isRawTable: getIsShowingRawTable(state),
 });
 
 const mapDispatchToProps = dispatch => ({
@@ -1055,6 +1057,7 @@ class TableInteractive extends Component {
       height,
       data: { cols, rows },
       className,
+      isRawTable,
       scrollToColumn,
       scrollToLastColumn,
       theme,
@@ -1147,6 +1150,7 @@ class TableInteractive extends Component {
                   <ColumnShortcut
                     height={headerHeight - 1}
                     isEditable={info?.isEditable}
+                    isRawTable={isRawTable}
                     onClick={evt => {
                       this.onVisualizationClick(
                         { columnShortcuts: true },
@@ -1321,8 +1325,8 @@ const DetailShortcut = forwardRef((_props, ref) => (
 
 DetailShortcut.displayName = "DetailShortcut";
 
-function ColumnShortcut({ height, onClick, isEditable }) {
-  if (!isEditable) {
+function ColumnShortcut({ height, onClick, isEditable, isRawTable }) {
+  if (!isEditable || isRawTable) {
     return null;
   }
 

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -1074,6 +1074,8 @@ class TableInteractive extends Component {
     const query = question?.query();
     const info = query && Lib.queryDisplayInfo(query);
 
+    const hasAggregation = cols.some(column => column.source === "aggregation");
+
     const tableTheme = theme?.other?.table;
     const backgroundColor = tableTheme?.cell?.backgroundColor;
 
@@ -1151,6 +1153,7 @@ class TableInteractive extends Component {
                     height={headerHeight - 1}
                     isEditable={info?.isEditable}
                     isRawTable={isRawTable}
+                    hasAggregation={hasAggregation}
                     onClick={evt => {
                       this.onVisualizationClick(
                         { columnShortcuts: true },
@@ -1325,8 +1328,14 @@ const DetailShortcut = forwardRef((_props, ref) => (
 
 DetailShortcut.displayName = "DetailShortcut";
 
-function ColumnShortcut({ height, onClick, isEditable, isRawTable }) {
-  if (!isEditable || isRawTable) {
+function ColumnShortcut({
+  height,
+  onClick,
+  isEditable,
+  isRawTable,
+  hasAggregation,
+}) {
+  if (!isEditable || isRawTable || hasAggregation) {
     return null;
   }
 

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -1331,12 +1331,14 @@ const DetailShortcut = forwardRef((_props, ref) => (
 
 DetailShortcut.displayName = "DetailShortcut";
 
+const COLUMN_SHORTCUT_PADDING = 4;
+
 function ColumnShortcut({ height, pageWidth, totalWidth, onClick }) {
   if (!totalWidth) {
     return null;
   }
 
-  const width = height + 4;
+  const width = height + COLUMN_SHORTCUT_PADDING;
   const isOverflowing = totalWidth > pageWidth;
   const left = (isOverflowing ? pageWidth : totalWidth) - width;
 

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -1075,19 +1075,20 @@ class TableInteractive extends Component {
     const headerHeight = this.props.tableHeaderHeight || HEADER_HEIGHT;
     const gutterColumn = this.state.showDetailShortcut ? 1 : 0;
 
-    const shortcutActions = question
-      ? mode.clickActions.flatMap(action =>
-          action({
-            question,
-            clicked: {
-              columnShortcuts: true,
-              extraData: {
-                isRawTable,
+    const shortcutActions =
+      question && mode?.clickActions
+        ? mode.clickActions.flatMap(action =>
+            action({
+              question,
+              clicked: {
+                columnShortcuts: true,
+                extraData: {
+                  isRawTable,
+                },
               },
-            },
-          }),
-        )
-      : [];
+            }),
+          )
+        : [];
     const shortcutColumn = shortcutActions.length > 0;
 
     const tableTheme = theme?.other?.table;

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -1072,17 +1072,19 @@ class TableInteractive extends Component {
     const headerHeight = this.props.tableHeaderHeight || HEADER_HEIGHT;
     const gutterColumn = this.state.showDetailShortcut ? 1 : 0;
 
-    const shortcutActions = mode.clickActions.flatMap(action =>
-      action({
-        question,
-        clicked: {
-          columnShortcuts: true,
-          extraData: {
-            isRawTable,
-          },
-        },
-      }),
-    );
+    const shortcutActions = question
+      ? mode.clickActions.flatMap(action =>
+          action({
+            question,
+            clicked: {
+              columnShortcuts: true,
+              extraData: {
+                isRawTable,
+              },
+            },
+          }),
+        )
+      : [];
     const shortcutColumn = shortcutActions.length > 0;
 
     const tableTheme = theme?.other?.table;

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -1070,11 +1070,15 @@ class TableInteractive extends Component {
 
     const headerHeight = this.props.tableHeaderHeight || HEADER_HEIGHT;
     const gutterColumn = this.state.showDetailShortcut ? 1 : 0;
-    const shortcutColumn = Number(!question?.isArchived());
     const query = question?.query();
     const info = query && Lib.queryDisplayInfo(query);
-
     const hasAggregation = cols.some(column => column.source === "aggregation");
+
+    const shortcutColumn =
+      info?.isEditable &&
+      Number(!question?.isArchived()) &&
+      !hasAggregation &&
+      !isRawTable;
 
     const tableTheme = theme?.other?.table;
     const backgroundColor = tableTheme?.cell?.backgroundColor;
@@ -1151,9 +1155,6 @@ class TableInteractive extends Component {
                 {shortcutColumn && (
                   <ColumnShortcut
                     height={headerHeight - 1}
-                    isEditable={info?.isEditable}
-                    isRawTable={isRawTable}
-                    hasAggregation={hasAggregation}
                     onClick={evt => {
                       this.onVisualizationClick(
                         { columnShortcuts: true },
@@ -1328,17 +1329,7 @@ const DetailShortcut = forwardRef((_props, ref) => (
 
 DetailShortcut.displayName = "DetailShortcut";
 
-function ColumnShortcut({
-  height,
-  onClick,
-  isEditable,
-  isRawTable,
-  hasAggregation,
-}) {
-  if (!isEditable || isRawTable || hasAggregation) {
-    return null;
-  }
-
+function ColumnShortcut({ height, onClick }) {
   return (
     <div className={TableS.shortcutsWrapper} style={{ height }}>
       <UIButton

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -1155,6 +1155,8 @@ class TableInteractive extends Component {
                 {shortcutColumn && (
                   <ColumnShortcut
                     height={headerHeight - 1}
+                    pageWidth={width}
+                    totalWidth={this.header?.getTotalColumnsWidth()}
                     onClick={evt => {
                       this.onVisualizationClick(
                         { columnShortcuts: true },
@@ -1329,9 +1331,27 @@ const DetailShortcut = forwardRef((_props, ref) => (
 
 DetailShortcut.displayName = "DetailShortcut";
 
-function ColumnShortcut({ height, onClick }) {
+function ColumnShortcut({ height, pageWidth, totalWidth, onClick }) {
+  if (!totalWidth) {
+    return null;
+  }
+
+  const width = height + 4;
+  const isOverflowing = totalWidth > pageWidth;
+  const left = (isOverflowing ? pageWidth : totalWidth) - width;
+
   return (
-    <div className={TableS.shortcutsWrapper} style={{ height }}>
+    <div
+      className={cx(
+        TableS.shortcutsWrapper,
+        isOverflowing && TableS.isOverflowing,
+      )}
+      style={{
+        height,
+        width,
+        left,
+      }}
+    >
       <UIButton
         variant="filled"
         compact

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -404,10 +404,7 @@ class TableInteractive extends Component {
     this.props.onUpdateVisualizationSettings({
       "table.column_widths": columnWidthsSetting,
     });
-    setTimeout(() => {
-      this.recomputeGridSize();
-      this._measure();
-    }, 1);
+    setTimeout(() => this.recomputeGridSize(), 1);
   }
 
   onColumnReorder(columnIndex, newColumnIndex) {

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -1076,7 +1076,7 @@ class TableInteractive extends Component {
 
     const shortcutColumn =
       info?.isEditable &&
-      Number(!question?.isArchived()) &&
+      !question?.isArchived() &&
       !hasAggregation &&
       !isRawTable;
 

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -1366,7 +1366,7 @@ function ColumnShortcut({ height, pageWidth, totalWidth, onClick }) {
       }}
     >
       <UIButton
-        variant="filled"
+        variant="outline"
         compact
         leftIcon={<Icon name="add" />}
         title={t`Add column`}

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -1051,18 +1051,40 @@ class TableInteractive extends Component {
     document.body.style.overscrollBehaviorX = this._previousOverscrollBehaviorX;
   };
 
+  _shouldShowShorcutButton() {
+    const { question, mode, isRawTable } = this.props;
+
+    if (!question || !mode?.clickActions) {
+      return false;
+    }
+
+    for (const action of mode.clickActions) {
+      const res = action({
+        question,
+        clicked: {
+          columnShortcuts: true,
+          extraData: {
+            isRawTable,
+          },
+        },
+      });
+      if (res?.length > 0) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   render() {
     const {
       width,
       height,
       data: { cols, rows },
       className,
-      isRawTable,
       scrollToColumn,
       scrollToLastColumn,
       theme,
-      question,
-      mode,
     } = this.props;
 
     if (!width || !height) {
@@ -1071,22 +1093,7 @@ class TableInteractive extends Component {
 
     const headerHeight = this.props.tableHeaderHeight || HEADER_HEIGHT;
     const gutterColumn = this.state.showDetailShortcut ? 1 : 0;
-
-    const shortcutActions =
-      question && mode?.clickActions
-        ? mode.clickActions.flatMap(action =>
-            action({
-              question,
-              clicked: {
-                columnShortcuts: true,
-                extraData: {
-                  isRawTable,
-                },
-              },
-            }),
-          )
-        : [];
-    const shortcutColumn = shortcutActions.length > 0;
+    const shortcutColumn = this._shouldShowShorcutButton();
 
     const tableTheme = theme?.other?.table;
     const backgroundColor = tableTheme?.cell?.backgroundColor;

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -1062,6 +1062,7 @@ class TableInteractive extends Component {
       scrollToLastColumn,
       theme,
       question,
+      mode,
     } = this.props;
 
     if (!width || !height) {
@@ -1070,15 +1071,19 @@ class TableInteractive extends Component {
 
     const headerHeight = this.props.tableHeaderHeight || HEADER_HEIGHT;
     const gutterColumn = this.state.showDetailShortcut ? 1 : 0;
-    const query = question?.query();
-    const info = query && Lib.queryDisplayInfo(query);
-    const hasAggregation = cols.some(column => column.source === "aggregation");
 
-    const shortcutColumn =
-      info?.isEditable &&
-      !question?.isArchived() &&
-      !hasAggregation &&
-      !isRawTable;
+    const shortcutActions = mode.clickActions.flatMap(action =>
+      action({
+        question,
+        clicked: {
+          columnShortcuts: true,
+          extraData: {
+            isRawTable,
+          },
+        },
+      }),
+    );
+    const shortcutColumn = shortcutActions.length > 0;
 
     const tableTheme = theme?.other?.table;
     const backgroundColor = tableTheme?.cell?.backgroundColor;

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -404,7 +404,10 @@ class TableInteractive extends Component {
     this.props.onUpdateVisualizationSettings({
       "table.column_widths": columnWidthsSetting,
     });
-    setTimeout(() => this.recomputeGridSize(), 1);
+    setTimeout(() => {
+      this.recomputeGridSize();
+      this._measure();
+    }, 1);
   }
 
   onColumnReorder(columnIndex, newColumnIndex) {
@@ -1091,8 +1094,10 @@ class TableInteractive extends Component {
     const backgroundColor = tableTheme?.cell?.backgroundColor;
 
     const totalWidth =
-      this.state.columnWidths?.reduce((sum, width) => sum + width, 0) +
-      (gutterColumn ? SIDEBAR_WIDTH : 0);
+      this.state.columnWidths?.reduce(
+        (sum, _c, index) => sum + this.getColumnWidth({ index }),
+        0,
+      ) + (gutterColumn ? SIDEBAR_WIDTH : 0);
 
     return (
       <DelayGroup>

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -1088,6 +1088,10 @@ class TableInteractive extends Component {
     const tableTheme = theme?.other?.table;
     const backgroundColor = tableTheme?.cell?.backgroundColor;
 
+    const totalWidth =
+      this.state.columnWidths?.reduce((sum, width) => sum + width, 0) +
+      (gutterColumn ? SIDEBAR_WIDTH : 0);
+
     return (
       <DelayGroup>
         <ScrollSync>
@@ -1161,7 +1165,7 @@ class TableInteractive extends Component {
                   <ColumnShortcut
                     height={headerHeight - 1}
                     pageWidth={width}
-                    totalWidth={this.header?.getTotalColumnsWidth()}
+                    totalWidth={totalWidth}
                     onClick={evt => {
                       this.onVisualizationClick(
                         { columnShortcuts: true },
@@ -1344,8 +1348,7 @@ function ColumnShortcut({ height, pageWidth, totalWidth, onClick }) {
   }
 
   const isOverflowing = totalWidth > pageWidth;
-  const width = height + (isOverflowing ? COLUMN_SHORTCUT_PADDING : 0);
-  const left = (isOverflowing ? pageWidth : totalWidth) - width;
+  const width = HEADER_HEIGHT + (isOverflowing ? COLUMN_SHORTCUT_PADDING : 0);
 
   return (
     <div
@@ -1356,7 +1359,8 @@ function ColumnShortcut({ height, pageWidth, totalWidth, onClick }) {
       style={{
         height,
         width,
-        left,
+        left: isOverflowing ? undefined : totalWidth,
+        right: isOverflowing ? 0 : undefined,
       }}
     >
       <UIButton

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -1343,8 +1343,8 @@ function ColumnShortcut({ height, pageWidth, totalWidth, onClick }) {
     return null;
   }
 
-  const width = height + COLUMN_SHORTCUT_PADDING;
   const isOverflowing = totalWidth > pageWidth;
+  const width = height + (isOverflowing ? COLUMN_SHORTCUT_PADDING : 0);
   const left = (isOverflowing ? pageWidth : totalWidth) - width;
 
   return (

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.module.css
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.module.css
@@ -97,13 +97,14 @@
 
 .shortcutsWrapper {
   position: absolute;
-  top: 0;
-  right: 0;
   z-index: 50;
+  top: 0;
   background: var(--mb-color-bg-white);
-  padding: 0 0.5em;
-  box-sizing: border-box;
-  border-left: 1px solid var(--mb-color-border);
   display: flex;
+  justify-content: center;
   align-items: center;
+}
+
+.isOverflowing {
+  border-left: 1px solid var(--mb-color-border);
 }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/43173
Closes https://github.com/metabase/metabase/issues/43118

### Description

- Hide the "Add column" shortcut for questions it does not apply to.
- Make the "Add column" shortcut work for questions with aggregations.
- Make the "Add column" shortcut stick to the last column if there is space.
- Update the button to use the outline variant (https://github.com/metabase/metabase/issues/43118)

### How to verify

1. New question -> Sample Dataset -> Orders
2. On a wide screen the "Add column" button should sit next to the last column, on a smaller screen it should be sticky at in the top right of the header
3. Add a summarization (ie. count by Created At)
4. The "Add column" actions should continue to work.

### Demo

<img width="157" alt="Screenshot 2024-05-28 at 10 35 20" src="https://github.com/metabase/metabase/assets/1250185/cef80492-2651-4fae-acd8-21b0941f6497">


https://github.com/metabase/metabase/assets/1250185/78ee46a3-3f3e-43cf-9f0d-d925d66f160f



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
