### PR TITLE
Replace automatic wiring of the cards with opt-in variant via toast button

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/dashcard-replace-question.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashcard-replace-question.cy.spec.js
@@ -17,6 +17,7 @@ import {
   expectGoodSnowplowEvent,
   expectNoBadSnowplowEvents,
   entityPickerModal,
+  undoToastList,
 } from "e2e/support/helpers";
 import {
   createMockDashboardCard,
@@ -192,8 +193,8 @@ describeWithSnowplow("scenarios > dashboard cards > replace question", () => {
       nextQuestionName: "Next question",
     });
 
-    // There're two toasts: "Undo replace" and "Undo parameters auto-wiring"
-    cy.findAllByTestId("toast-undo").eq(0).button("Undo").click();
+    // There're two toasts: "Undo replace" and "Auto-connect"
+    undoToastList().eq(0).button("Undo").click();
 
     // Ensure we kept viz settings and parameter mapping changes from before
     findTargetDashcard().within(() => {

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-wiring.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-wiring.cy.spec.js
@@ -23,6 +23,7 @@ import {
   dashboardParametersContainer,
   openQuestionActions,
   entityPickerModal,
+  findDashCardAction,
 } from "e2e/support/helpers";
 
 const { ORDERS_ID, PRODUCTS_ID, REVIEWS_ID } = SAMPLE_DATABASE;
@@ -51,7 +52,7 @@ describe("dashboard filters auto-wiring", () => {
     cy.intercept("GET", "/api/dashboard/**").as("dashboard");
   });
 
-  describe("when wiring parameter to all cards for a filter", () => {
+  describe("parameter mapping", () => {
     it("should wire parameters to cards with matching fields", () => {
       createDashboardWithCards({ cards }).then(dashboardId => {
         visitDashboard(dashboardId);
@@ -69,8 +70,18 @@ describe("dashboard filters auto-wiring", () => {
 
       getDashboardCard(1).findByText("User.Name").should("not.exist");
 
-      undoToast().findByText("Auto-connect").click();
-      undoToast().should("contain", "User.Name");
+      undoToast()
+        .should(
+          "contain",
+          "Auto-connect this filter to all questions containing “User.Name”?",
+        )
+        .should("not.contain", "in the current tab")
+        .findByText("Auto-connect")
+        .click();
+      undoToast().should(
+        "contain",
+        "The filter was auto-connected to all questions containing “User.Name”.",
+      );
     });
 
     it("should not wire parameters to cards that already have a parameter, despite matching fields", () => {
@@ -91,7 +102,7 @@ describe("dashboard filters auto-wiring", () => {
       undoToast()
         .should(
           "contain",
-          "Auto-connect this filter to all questions containing",
+          "Auto-connect this filter to all questions containing “User.Name”?",
         )
         .findByRole("button", { name: "Auto-connect" })
         .click();
@@ -149,32 +160,6 @@ describe("dashboard filters auto-wiring", () => {
       undoToast().should("not.exist");
     });
 
-    it("should not autowire parameters to cards in different tabs", () => {
-      createDashboardWithCards({ cards }).then(dashboardId => {
-        visitDashboardAndCreateTab({
-          dashboardId,
-          save: false,
-        });
-      });
-
-      setFilter("Text or Category", "Is");
-
-      addCardToDashboard();
-      goToFilterMapping();
-
-      selectDashboardFilter(getDashboardCard(0), "Name");
-
-      getDashboardCard(0).findByText("User.Name").should("exist");
-
-      undoToast().should("not.exist");
-
-      goToTab("Tab 1");
-
-      for (let i = 0; i < cards.length; i++) {
-        getDashboardCard(i).findByText("User.Name").should("not.exist");
-      }
-    });
-
     it("should undo parameter wiring when 'Undo' is clicked", () => {
       createDashboardWithCards({ cards }).then(dashboardId => {
         visitDashboard(dashboardId);
@@ -204,8 +189,8 @@ describe("dashboard filters auto-wiring", () => {
       }
     });
 
-    it("in case of two autowiring undo toast, the second one should last the default timeout of 12s", () => {
-      // The autowiring undo toasts use the same id, a bug in the undo logic caused the second toast to be dismissed by the
+    it("in case of two auto-wiring undo toast, the second one should last the default timeout of 12s", () => {
+      // The auto-wiring undo toasts use the same id, a bug in the undo logic caused the second toast to be dismissed by the
       // timeout set by the first. See https://github.com/metabase/metabase/pull/35461#pullrequestreview-1731776862
       const cardTemplate = {
         card_id: ORDERS_BY_YEAR_QUESTION_ID,
@@ -255,9 +240,45 @@ describe("dashboard filters auto-wiring", () => {
       cy.tick(2000);
       undoToast().should("not.exist");
     });
+
+    describe("multiple tabs", () => {
+      it("should not wire parameters to cards in different tabs", () => {
+        createDashboardWithCards({ cards }).then(dashboardId => {
+          visitDashboardAndCreateTab({
+            dashboardId,
+            save: false,
+          });
+        });
+
+        setFilter("Text or Category", "Is");
+
+        addCardToDashboard();
+        goToFilterMapping();
+
+        selectDashboardFilter(getDashboardCard(0), "Name");
+
+        getDashboardCard(0).findByText("User.Name").should("exist");
+
+        undoToast().should("not.exist");
+
+        goToTab("Tab 1");
+
+        for (let i = 0; i < cards.length; i++) {
+          getDashboardCard(i).findByText("User.Name").should("not.exist");
+        }
+
+        selectDashboardFilter(getDashboardCard(0), "Name");
+
+        cy.log("verify prefix 'in the current tab'");
+        undoToast().should(
+          "contain",
+          "Auto-connect this filter to all questions containing “User.Name”, in the current tab?",
+        );
+      });
+    });
   });
 
-  describe("wiring parameters when adding a card", () => {
+  describe("add a card", () => {
     it("should wire parameters to cards that are added to the dashboard", () => {
       createDashboardWithCards({ cards }).then(dashboardId => {
         visitDashboard(dashboardId);
@@ -275,10 +296,21 @@ describe("dashboard filters auto-wiring", () => {
       }
 
       addCardToDashboard();
+
+      cy.log("verify toast text and enable auto-connect");
+
       undoToastList()
         .eq(1)
+        .should("contain", "Auto-connect “Orders Model” to “Text”?")
         .findByRole("button", { name: "Auto-connect" })
         .click();
+
+      cy.log("verify toast text after auto-connect");
+
+      undoToastList()
+        .eq(1)
+        .should("contain", "“Orders Model” was auto-connected to “Text”.");
+
       goToFilterMapping();
 
       for (let i = 0; i < cards.length + 1; i++) {
@@ -289,45 +321,6 @@ describe("dashboard filters auto-wiring", () => {
         .eq(1)
         .findByText("“Orders Model” was auto-connected to “Text”.")
         .should("be.visible");
-    });
-
-    it("should not wire parameters to cards that are added to the dashboard in a different tab", () => {
-      createDashboardWithCards({ cards }).then(dashboardId => {
-        visitDashboard(dashboardId);
-      });
-
-      editDashboard();
-
-      setFilter("Text or Category", "Is");
-
-      selectDashboardFilter(getDashboardCard(0), "Name");
-
-      undoToast()
-        .should(
-          "contain",
-          "Auto-connect this filter to all questions containing",
-        )
-        .findByRole("button", { name: "Auto-connect" })
-        .click();
-
-      for (let i = 0; i < cards.length; i++) {
-        getDashboardCard(i).findByText("User.Name").should("exist");
-      }
-
-      createNewTab();
-      addCardToDashboard();
-      goToFilterMapping();
-
-      getDashboardCard(0).findByText("User.Name").should("not.exist");
-
-      cy.log("verify that no new toast with suggestion to auto-wire appeared");
-
-      undoToastList()
-        .should("have.length", 1)
-        .should(
-          "contain",
-          "The filter was auto-connected to all questions containing “User.Name”",
-        );
     });
 
     it("should undo parameter wiring when 'Undo' is clicked", () => {
@@ -365,6 +358,96 @@ describe("dashboard filters auto-wiring", () => {
       getDashboardCard(0).findByText("User.Name").should("exist");
       getDashboardCard(1).findByText("User.Name").should("exist");
       getDashboardCard(2).findByText("Select…").should("exist");
+    });
+
+    describe("multiple tabs", () => {
+      it("should not wire parameters to cards that are added to the dashboard in a different tab", () => {
+        createDashboardWithCards({ cards }).then(dashboardId => {
+          visitDashboard(dashboardId);
+        });
+
+        editDashboard();
+
+        setFilter("Number", "Equal to");
+        setFilter("Text or Category", "Is");
+
+        selectDashboardFilter(getDashboardCard(0), "Name");
+
+        undoToast()
+          .should(
+            "contain",
+            "Auto-connect this filter to all questions containing",
+          )
+          .findByRole("button", { name: "Auto-connect" })
+          .click();
+
+        for (let i = 0; i < cards.length; i++) {
+          getDashboardCard(i).findByText("User.Name").should("exist");
+        }
+
+        createNewTab();
+        addCardToDashboard();
+        goToFilterMapping();
+
+        getDashboardCard(0).findByText("User.Name").should("not.exist");
+
+        cy.log(
+          "verify that no new toast with suggestion to auto-wire appeared",
+        );
+
+        undoToastList()
+          .should("have.length", 1)
+          .should(
+            "contain",
+            "The filter was auto-connected to all questions containing “User.Name”",
+          );
+
+        selectDashboardFilter(getDashboardCard(0), "Name");
+        goToFilterMapping("Equal to");
+        selectDashboardFilter(getDashboardCard(0), "Total");
+
+        addCardToDashboard();
+
+        undoToastList().eq(1).findByText("Auto-connect").click();
+
+        cy.log("verify that toast shows number of filters that were connected");
+
+        undoToastList()
+          .eq(1)
+          .should("contain", "“Orders Model” was auto-connected to 2 filters.");
+      });
+    });
+  });
+
+  describe("replace a card", () => {
+    it("should show auto-wire suggestion toast when a card is replaced", () => {
+      createDashboardWithCards({ cards }).then(dashboardId => {
+        visitDashboard(dashboardId);
+      });
+
+      editDashboard();
+
+      setFilter("Text or Category", "Is");
+
+      selectDashboardFilter(getDashboardCard(0), "Name");
+
+      undoToast().findByText("Auto-connect").click();
+
+      goToFilterMapping();
+
+      findDashCardAction(getDashboardCard(1), "Replace").click();
+
+      modal().findByText("Orders, Count").click();
+
+      undoToastList()
+        .eq(2)
+        .should("contain", "Auto-connect “Orders, Count” to “Text”?")
+        .button("Auto-connect")
+        .click();
+
+      undoToastList()
+        .eq(2)
+        .should("contain", "“Orders, Count” was auto-connected to “Text”.");
     });
   });
 
@@ -408,7 +491,7 @@ describe("dashboard filters auto-wiring", () => {
       });
     });
 
-    it("should autowire and filter cards with foreign keys when added to the dashboard via the sidebar", () => {
+    it("should auto-wire and filter cards with foreign keys when added to the dashboard via the sidebar", () => {
       visitDashboard("@dashboardId");
       editDashboard();
       setFilter("ID");
@@ -460,7 +543,7 @@ describe("dashboard filters auto-wiring", () => {
       });
     });
 
-    it("should autowire and filter cards with foreign keys when added to the dashboard via the query builder", () => {
+    it("should auto-wire and filter cards with foreign keys when added to the dashboard via the query builder", () => {
       visitDashboard("@dashboardId");
       editDashboard();
       setFilter("ID");
@@ -511,6 +594,7 @@ describe("dashboard filters auto-wiring", () => {
     });
   });
 });
+
 function createDashboardWithCards({
   dashboardName = "my dash",
   cards = [],

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-wiring.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-wiring.cy.spec.js
@@ -70,9 +70,7 @@ describe("dashboard filters auto-wiring", () => {
       getDashboardCard(1).findByText("User.Name").should("not.exist");
 
       undoToast().findByText("Auto-connect").click();
-      // currently is broken
-      // undoToast().should("contain", "User.Name");
-      undoToast().should("contain", "Undo");
+      undoToast().should("contain", "User.Name");
     });
 
     it("should not wire parameters to cards that already have a parameter, despite matching fields", () => {

--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -72,19 +72,9 @@ describe("scenarios > dashboard > parameters", () => {
     // (this doesn't make sense to do, but it illustrates the feature)
     selectDashboardFilter(getDashboardCard(0), "Name");
 
-    getDashboardCard(1).within(() => {
-      cy.findByLabelText("close icon").click();
-    });
     selectDashboardFilter(getDashboardCard(1), "Category");
 
-    // finish editing filter and save dashboard
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.contains("Save").click();
-
-    // wait for saving to finish
-    cy.wait("@dashboard");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.contains("You're editing this dashboard.").should("not.exist");
+    saveDashboard();
 
     // confirm that typing searches both fields
     filterWidget().contains("Text").click();
@@ -638,28 +628,34 @@ describe("scenarios > dashboard > parameters", () => {
         .click();
 
       selectDashboardFilter(getDashboardCard(0), "Created At");
+      selectDashboardFilter(getDashboardCard(1), "Created At");
+
       saveDashboard();
 
       cy.get("@dashcardRequestSpy").should("have.callCount", 2);
     });
 
     it("should fetch dashcard data when parameter mapping is removed", () => {
-      // Connect filter to 1 card only
+      cy.log("Connect filter to 1 card only");
+
       editDashboard();
       cy.findByTestId("edit-dashboard-parameters-widget-container")
         .findByText("Date Filter")
         .click();
       selectDashboardFilter(getDashboardCard(0), "Created At");
-      disconnectDashboardFilter(getDashboardCard(1));
+
       saveDashboard();
 
       cy.get("@dashcardRequestSpy").should("have.callCount", 1);
 
-      // Disconnect filter from the 1st card
+      cy.log("Disconnect filter from the 1st card");
+
       editDashboard();
+
       cy.findByTestId("edit-dashboard-parameters-widget-container")
         .findByText("Date Filter")
         .click();
+
       disconnectDashboardFilter(getDashboardCard(0));
       saveDashboard();
 

--- a/e2e/test/scenarios/dashboard/tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/tabs.cy.spec.js
@@ -672,7 +672,6 @@ describe("scenarios > dashboard > tabs", () => {
 
     setFilter("Time", "Relative Date");
 
-    // Auto-connection happens here
     selectDashboardFilter(getDashboardCard(0), "Created At");
     saveDashboard();
 
@@ -692,11 +691,11 @@ describe("scenarios > dashboard > tabs", () => {
       cy.findAllByTestId("table-row").should("exist");
     });
 
-    // Loader in the 1st tab
+    // we do not auto-wire automatically in different tabs anymore, so first tab
+    // should not show a loader and re-run query
     goToTab("Tab 1");
     getDashboardCard(0).within(() => {
-      cy.findByTestId("loading-spinner").should("exist");
-      cy.wait("@saveCard");
+      cy.findByTestId("loading-spinner").should("not.exist");
       cy.findAllByTestId("table-row").should("exist");
     });
   });

--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -210,6 +210,9 @@ describe("issue 8030 + 32444", () => {
 
         setFilter("Text or Category", "Is");
         selectDashboardFilter(cy.findAllByTestId("dashcard").first(), "Title");
+
+        undoToast().findByRole("button", { name: "Auto-connect" }).click();
+
         cy.findAllByTestId("dashcard")
           .eq(1)
           .findByLabelText("Disconnect")
@@ -922,21 +925,19 @@ describe("issue 19494", () => {
 
     connectFilterToCard({ filterName: "Card 1 Filter", cardPosition: 0 });
     setDefaultFilter("Doohickey");
-    undoToast().findByText("Undo auto-connection").click();
 
     connectFilterToCard({ filterName: "Card 2 Filter", cardPosition: -1 });
     setDefaultFilter("Gizmo");
-    undoToast().findByText("Undo auto-connection").click();
 
     saveDashboard();
 
     checkAppliedFilter("Card 1 Filter", "Doohickey");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("148.23");
+
+    getDashboardCard(0).should("contain", "148.23");
 
     checkAppliedFilter("Card 2 Filter", "Gizmo");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("110.93");
+
+    getDashboardCard(1).should("contain", "110.93");
   });
 });
 

--- a/frontend/src/metabase/dashboard/actions/auto-wire-parameters/actions.ts
+++ b/frontend/src/metabase/dashboard/actions/auto-wire-parameters/actions.ts
@@ -92,14 +92,14 @@ export function showAutoWireToast(
       showAutoWireParametersToast({
         dashcardAttributes,
         originalDashcardAttributes,
-        fieldName: formatMappingOption(mappingOption),
-        multipleTabs: tabs.length > 1,
+        columnName: formatMappingOption(mappingOption),
+        hasMultipleTabs: tabs.length > 1,
       }),
     );
   };
 }
 
-export function autoWireParametersToNewCard({
+export function showAutoWireToastNewCard({
   dashcard_id,
 }: {
   dashcard_id: DashCardId;
@@ -151,7 +151,7 @@ export function autoWireParametersToNewCard({
       targetDashcard,
     );
 
-    const parametersToAutoApply: DashboardParameterMapping[] = [];
+    const parametersMappingsToApply: DashboardParameterMapping[] = [];
     const processedParameterIds = new Set();
 
     for (const dashcard of dashcards) {
@@ -168,7 +168,7 @@ export function autoWireParametersToNewCard({
           targetDashcard.card_id &&
           !processedParameterIds.has(mapping.parameter_id)
         ) {
-          parametersToAutoApply.push(
+          parametersMappingsToApply.push(
             ...(getParameterMappings(
               targetDashcard,
               mapping.parameter_id,
@@ -181,11 +181,11 @@ export function autoWireParametersToNewCard({
       }
     }
 
-    if (parametersToAutoApply.length === 0) {
+    if (parametersMappingsToApply.length === 0) {
       return;
     }
 
-    const parameters = dashboard.parameters.filter(p =>
+    const parametersToMap = dashboard.parameters.filter(p =>
       processedParameterIds.has(p.id),
     );
 
@@ -193,8 +193,8 @@ export function autoWireParametersToNewCard({
       showAddedCardAutoWireParametersToast({
         targetDashcard,
         dashcard_id,
-        parametersToAutoApply,
-        parameters,
+        parametersMappingsToApply,
+        parametersToMap,
       }),
     );
   };

--- a/frontend/src/metabase/dashboard/actions/auto-wire-parameters/actions.ts
+++ b/frontend/src/metabase/dashboard/actions/auto-wire-parameters/actions.ts
@@ -169,12 +169,12 @@ export function autoWireParametersToNewCard({
           !processedParameterIds.has(mapping.parameter_id)
         ) {
           parametersToAutoApply.push(
-            ...getParameterMappings(
+            ...(getParameterMappings(
               targetDashcard,
               mapping.parameter_id,
               targetDashcard.card_id,
               option.target,
-            ),
+            ) as DashboardParameterMapping[]),
           );
           processedParameterIds.add(mapping.parameter_id);
         }

--- a/frontend/src/metabase/dashboard/actions/auto-wire-parameters/toasts.ts
+++ b/frontend/src/metabase/dashboard/actions/auto-wire-parameters/toasts.ts
@@ -130,7 +130,7 @@ export const showAddedCardAutoWireParametersToast =
 
       dispatch(
         addUndo({
-          id: AUTO_WIRE_UNDO_TOAST_ID,
+          id: _.uniqueId(),
           message,
           actionLabel: t`Undo`,
           timeout: 12000,
@@ -138,6 +138,10 @@ export const showAddedCardAutoWireParametersToast =
           action: revertAutoWireParametersToNewCard,
         }),
       );
+    }
+
+    function hideAutoConnectToast(toastId: string) {
+      dispatch(dismissUndo(toastId, false));
     }
 
     let message = "";
@@ -148,16 +152,17 @@ export const showAddedCardAutoWireParametersToast =
       message = t`Auto-connect “${targetDashcard.card.name}” to ${parametersToAutoApply.length} filters with the same field?`;
     }
 
+    const toastId = _.uniqueId();
     dispatch(
       addUndo({
-        id: AUTO_WIRE_TOAST_ID,
+        id: toastId,
         message,
-        actionLabel: t`Auto-connect ...`,
+        actionLabel: t`Auto-connect`,
         undo: true,
         timeout: 12000,
         action: () => {
+          hideAutoConnectToast(toastId);
           autoWireParametersToNewCard();
-
           showUndoToast();
         },
       }),

--- a/frontend/src/metabase/dashboard/actions/auto-wire-parameters/toasts.ts
+++ b/frontend/src/metabase/dashboard/actions/auto-wire-parameters/toasts.ts
@@ -7,30 +7,81 @@ import {
   setMultipleDashCardAttributes,
 } from "metabase/dashboard/actions";
 import { addUndo, dismissUndo } from "metabase/redux/undo";
-import type { QuestionDashboardCard, DashCardId } from "metabase-types/api";
+import type {
+  QuestionDashboardCard,
+  DashCardId,
+  DashboardParameterMapping,
+  Parameter,
+} from "metabase-types/api";
 import type { Dispatch } from "metabase-types/store";
 
 export const AUTO_WIRE_TOAST_ID = _.uniqueId();
+const AUTO_WIRE_UNDO_TOAST_ID = _.uniqueId();
 
+// TODO:
+// 1. generate correct toast messages for same tab
+// 2. generate correct toast messages for multiple tabs
 export const showAutoWireParametersToast =
   ({
     dashcardAttributes,
+    originalDashcardAttributes,
+    fieldName,
+    multipleTabs,
   }: {
     dashcardAttributes: SetMultipleDashCardAttributesOpts;
+    originalDashcardAttributes: SetMultipleDashCardAttributesOpts;
+    fieldName: string;
+    multipleTabs: boolean;
   }) =>
   (dispatch: Dispatch) => {
+    let msg = "";
+
+    if (multipleTabs) {
+      msg = t`Auto-connect this filter to all questions containing “${fieldName}”, in the current tab?`;
+    } else {
+      msg = t`Auto-connect this filter to all questions containing “${fieldName}”?`;
+    }
+
+    function connectAll() {
+      dispatch(
+        setMultipleDashCardAttributes({
+          dashcards: dashcardAttributes,
+        }),
+      );
+    }
+
+    function revertConnectAll() {
+      dispatch(
+        setMultipleDashCardAttributes({
+          dashcards: originalDashcardAttributes,
+        }),
+      );
+    }
+
+    function showUndoToast() {
+      dispatch(
+        addUndo({
+          id: AUTO_WIRE_UNDO_TOAST_ID,
+          message: t`The filter was auto-connected to all questions containing “${fieldName}”.`,
+          actionLabel: t`Undo`,
+          timeout: 12000,
+          undo: true,
+          action: revertConnectAll,
+        }),
+      );
+    }
+
     dispatch(
       addUndo({
         id: AUTO_WIRE_TOAST_ID,
-        message: t`This filter has been auto-connected with questions with the same field.`,
-        actionLabel: t`Undo auto-connection`,
-        undo: true,
+        message: msg,
+        actionLabel: t`Auto-connect`,
+        timeout: 12000,
+        undo: false,
         action: () => {
-          dispatch(
-            setMultipleDashCardAttributes({
-              dashcards: dashcardAttributes,
-            }),
-          );
+          connectAll();
+
+          showUndoToast();
         },
       }),
     );
@@ -40,26 +91,77 @@ export const showAddedCardAutoWireParametersToast =
   ({
     targetDashcard,
     dashcard_id,
+    parametersToAutoApply,
+    parameters,
   }: {
     targetDashcard: QuestionDashboardCard;
     dashcard_id: DashCardId;
+    parametersToAutoApply: DashboardParameterMapping[];
+    parameters: Parameter[];
   }) =>
   (dispatch: Dispatch) => {
+    function autoWireParametersToNewCard() {
+      dispatch(
+        setDashCardAttributes({
+          id: dashcard_id,
+          attributes: {
+            parameter_mappings: parametersToAutoApply,
+          },
+        }),
+      );
+    }
+
+    function revertAutoWireParametersToNewCard() {
+      dispatch(
+        setDashCardAttributes({
+          id: dashcard_id,
+          attributes: {
+            parameter_mappings: [],
+          },
+        }),
+      );
+    }
+
+    function showUndoToast() {
+      let message = "";
+
+      if (parametersToAutoApply.length === 1) {
+        message = t`“${targetDashcard.card.name}” was auto-connected to “${parameters[0].name}”.`;
+      } else {
+        message = t`“${targetDashcard.card.name}” was auto-connected to ${parametersToAutoApply.length} filters.`;
+      }
+
+      dispatch(
+        addUndo({
+          id: AUTO_WIRE_UNDO_TOAST_ID,
+          message,
+          actionLabel: t`Undo`,
+          timeout: 12000,
+          undo: true,
+          action: revertAutoWireParametersToNewCard,
+        }),
+      );
+    }
+
+    let message = "";
+
+    if (parametersToAutoApply.length === 1) {
+      message = t`Auto-connect “${targetDashcard.card.name}” to “${parameters[0].name}”?`;
+    } else {
+      message = t`Auto-connect “${targetDashcard.card.name}” to ${parametersToAutoApply.length} filters with the same field?`;
+    }
+
     dispatch(
       addUndo({
         id: AUTO_WIRE_TOAST_ID,
-        message: t`${targetDashcard.card.name} has been auto-connected with filters with the same field.`,
-        actionLabel: t`Undo auto-connection`,
+        message,
+        actionLabel: t`Auto-connect ...`,
         undo: true,
+        timeout: 12000,
         action: () => {
-          dispatch(
-            setDashCardAttributes({
-              id: dashcard_id,
-              attributes: {
-                parameter_mappings: [],
-              },
-            }),
-          );
+          autoWireParametersToNewCard();
+
+          showUndoToast();
         },
       }),
     );

--- a/frontend/src/metabase/dashboard/actions/auto-wire-parameters/toasts.ts
+++ b/frontend/src/metabase/dashboard/actions/auto-wire-parameters/toasts.ts
@@ -18,9 +18,6 @@ import type { Dispatch } from "metabase-types/store";
 export const AUTO_WIRE_TOAST_ID = _.uniqueId();
 const AUTO_WIRE_UNDO_TOAST_ID = _.uniqueId();
 
-// TODO:
-// 1. generate correct toast messages for same tab
-// 2. generate correct toast messages for multiple tabs
 export const showAutoWireParametersToast =
   ({
     dashcardAttributes,

--- a/frontend/src/metabase/dashboard/actions/auto-wire-parameters/toasts.ts
+++ b/frontend/src/metabase/dashboard/actions/auto-wire-parameters/toasts.ts
@@ -22,22 +22,18 @@ export const showAutoWireParametersToast =
   ({
     dashcardAttributes,
     originalDashcardAttributes,
-    fieldName,
-    multipleTabs,
+    columnName,
+    hasMultipleTabs,
   }: {
     dashcardAttributes: SetMultipleDashCardAttributesOpts;
     originalDashcardAttributes: SetMultipleDashCardAttributesOpts;
-    fieldName: string;
-    multipleTabs: boolean;
+    columnName: string;
+    hasMultipleTabs: boolean;
   }) =>
   (dispatch: Dispatch) => {
-    let message = "";
-
-    if (multipleTabs) {
-      message = t`Auto-connect this filter to all questions containing “${fieldName}”, in the current tab?`;
-    } else {
-      message = t`Auto-connect this filter to all questions containing “${fieldName}”?`;
-    }
+    const message = hasMultipleTabs
+      ? t`Auto-connect this filter to all questions containing “${columnName}”, in the current tab?`
+      : t`Auto-connect this filter to all questions containing “${columnName}”?`;
 
     dispatch(
       addUndo({
@@ -74,7 +70,7 @@ export const showAutoWireParametersToast =
       dispatch(
         addUndo({
           id: AUTO_WIRE_UNDO_TOAST_ID,
-          message: t`The filter was auto-connected to all questions containing “${fieldName}”.`,
+          message: t`The filter was auto-connected to all questions containing “${columnName}”.`,
           actionLabel: t`Undo`,
           timeout: 12000,
           undo: true,
@@ -88,22 +84,19 @@ export const showAddedCardAutoWireParametersToast =
   ({
     targetDashcard,
     dashcard_id,
-    parametersToAutoApply,
-    parameters,
+    parametersMappingsToApply,
+    parametersToMap,
   }: {
     targetDashcard: QuestionDashboardCard;
     dashcard_id: DashCardId;
-    parametersToAutoApply: DashboardParameterMapping[];
-    parameters: Parameter[];
+    parametersMappingsToApply: DashboardParameterMapping[];
+    parametersToMap: Parameter[];
   }) =>
   (dispatch: Dispatch) => {
-    let message = "";
-
-    if (parametersToAutoApply.length === 1) {
-      message = t`Auto-connect “${targetDashcard.card.name}” to “${parameters[0].name}”?`;
-    } else {
-      message = t`Auto-connect “${targetDashcard.card.name}” to ${parametersToAutoApply.length} filters with the same field?`;
-    }
+    const shouldShowParameterName = parametersMappingsToApply.length === 1;
+    const message = shouldShowParameterName
+      ? t`Auto-connect “${targetDashcard.card.name}” to “${parametersToMap[0].name}”?`
+      : t`Auto-connect “${targetDashcard.card.name}” to ${parametersMappingsToApply.length} filters with the same field?`;
 
     const toastId = _.uniqueId();
 
@@ -128,7 +121,7 @@ export const showAddedCardAutoWireParametersToast =
         setDashCardAttributes({
           id: dashcard_id,
           attributes: {
-            parameter_mappings: parametersToAutoApply,
+            parameter_mappings: parametersMappingsToApply,
           },
         }),
       );
@@ -146,13 +139,9 @@ export const showAddedCardAutoWireParametersToast =
     }
 
     function showUndoToast() {
-      let message = "";
-
-      if (parametersToAutoApply.length === 1) {
-        message = t`“${targetDashcard.card.name}” was auto-connected to “${parameters[0].name}”.`;
-      } else {
-        message = t`“${targetDashcard.card.name}” was auto-connected to ${parametersToAutoApply.length} filters.`;
-      }
+      const message = shouldShowParameterName
+        ? t`“${targetDashcard.card.name}” was auto-connected to “${parametersToMap[0].name}”.`
+        : t`“${targetDashcard.card.name}” was auto-connected to ${parametersToMap.length} filters.`;
 
       dispatch(
         addUndo({

--- a/frontend/src/metabase/dashboard/actions/auto-wire-parameters/utils.ts
+++ b/frontend/src/metabase/dashboard/actions/auto-wire-parameters/utils.ts
@@ -18,6 +18,7 @@ import type {
   ParameterId,
   ParameterTarget,
   DashboardTabId,
+  DashboardCard,
 } from "metabase-types/api";
 import type { DashboardState } from "metabase-types/store";
 
@@ -119,7 +120,7 @@ export function getAutoWiredMappingsForDashcards(
 }
 
 export function getParameterMappings(
-  dashcard: QuestionDashboardCard,
+  dashcard: DashboardCard,
   parameter_id: ParameterId,
   card_id: CardId,
   target: ParameterTarget | null,
@@ -132,6 +133,7 @@ export function getParameterMappings(
   // allow mapping the same parameter to multiple action targets
   if (!isAction) {
     parameter_mappings = parameter_mappings.filter(
+      // @ts-expect-error action and virtual dashcards do not have card_id
       m => m.card_id !== card_id || m.parameter_id !== parameter_id,
     );
   }
@@ -144,6 +146,7 @@ export function getParameterMappings(
         m => !_.isEqual(m.target, target),
       );
     }
+    // @ts-expect-error action and virtual dashcards do not have card_id
     parameter_mappings = parameter_mappings.concat({
       parameter_id,
       card_id,

--- a/frontend/src/metabase/dashboard/actions/auto-wire-parameters/utils.ts
+++ b/frontend/src/metabase/dashboard/actions/auto-wire-parameters/utils.ts
@@ -141,8 +141,9 @@ export function getParameterMappings(
   // allow mapping the same parameter to multiple action targets
   if (!isAction) {
     parameter_mappings = parameter_mappings.filter(
-      // @ts-expect-error action and virtual dashcards do not have card_id
-      m => m.card_id !== card_id || m.parameter_id !== parameter_id,
+      m =>
+        ("card_id" in m && m.card_id !== card_id) ||
+        m.parameter_id !== parameter_id,
     );
   }
 

--- a/frontend/src/metabase/dashboard/actions/auto-wire-parameters/utils.ts
+++ b/frontend/src/metabase/dashboard/actions/auto-wire-parameters/utils.ts
@@ -19,6 +19,9 @@ import type {
   ParameterTarget,
   DashboardTabId,
   DashboardCard,
+  DashboardParameterMapping,
+  ActionParametersMapping,
+  VirtualDashCardParameterMapping,
 } from "metabase-types/api";
 import type { DashboardState } from "metabase-types/store";
 
@@ -118,7 +121,8 @@ export function getAutoWiredMappingsForDashcards(
   }
   return targetDashcardMappings;
 }
-
+// TODO: this function should automatically calculate return type based on the
+// type of dashcard
 export function getParameterMappings(
   dashcard: DashboardCard,
   parameter_id: ParameterId,
@@ -128,7 +132,11 @@ export function getParameterMappings(
   const isVirtual = isVirtualDashCard(dashcard);
   const isAction = isActionDashCard(dashcard);
 
-  let parameter_mappings = dashcard.parameter_mappings || [];
+  let parameter_mappings: (
+    | DashboardParameterMapping
+    | ActionParametersMapping
+    | VirtualDashCardParameterMapping
+  )[] = dashcard.parameter_mappings || [];
 
   // allow mapping the same parameter to multiple action targets
   if (!isAction) {
@@ -146,7 +154,6 @@ export function getParameterMappings(
         m => !_.isEqual(m.target, target),
       );
     }
-    // @ts-expect-error action and virtual dashcards do not have card_id
     parameter_mappings = parameter_mappings.concat({
       parameter_id,
       card_id,

--- a/frontend/src/metabase/dashboard/actions/auto-wire-parameters/utils.ts
+++ b/frontend/src/metabase/dashboard/actions/auto-wire-parameters/utils.ts
@@ -95,9 +95,11 @@ export function getAutoWiredMappingsForDashcards(
   const targetDashcardMappings: SetMultipleDashCardAttributesOpts = [];
 
   for (const targetDashcard of targetDashcards) {
-    const selectedMappingOption: {
-      target: ParameterTarget;
-    } | null = getMatchingParameterOption(targetDashcard, target, questions);
+    const selectedMappingOption = getMatchingParameterOption(
+      targetDashcard,
+      target,
+      questions,
+    );
 
     if (selectedMappingOption && targetDashcard.card_id) {
       targetDashcardMappings.push({

--- a/frontend/src/metabase/dashboard/actions/cards-typed.ts
+++ b/frontend/src/metabase/dashboard/actions/cards-typed.ts
@@ -32,7 +32,7 @@ import {
   isVirtualDashCard,
 } from "../utils";
 
-import { autoWireParametersToNewCard } from "./auto-wire-parameters/actions";
+import { showAutoWireToastNewCard } from "./auto-wire-parameters/actions";
 import {
   ADD_CARD_TO_DASH,
   ADD_MANY_CARDS_TO_DASH,
@@ -53,7 +53,7 @@ type NewDashboardCard = Omit<
   "entity_id" | "created_at" | "updated_at"
 >;
 
-type AddDashCardOpts = NewDashCardOpts & {
+export type AddDashCardOpts = NewDashCardOpts & {
   dashcardOverrides: Partial<NewDashboardCard> & {
     card: Card | VirtualCard;
   };
@@ -136,7 +136,7 @@ export const addSectionToDashboard =
     trackSectionAdded(dashId, sectionLayout.id);
   };
 
-type AddCardToDashboardOpts = NewDashCardOpts & {
+export type AddCardToDashboardOpts = NewDashCardOpts & {
   cardId: CardId;
 };
 
@@ -159,7 +159,7 @@ export const addCardToDashboard =
 
     dispatch(fetchCardData(card, dashcard, { reload: true, clearCache: true }));
     await dispatch(loadMetadataForCard(card));
-    dispatch(autoWireParametersToNewCard({ dashcard_id: dashcardId }));
+    dispatch(showAutoWireToastNewCard({ dashcard_id: dashcardId }));
   };
 
 export const addHeadingDashCardToDashboard =
@@ -234,7 +234,7 @@ export const replaceCard =
 
     dispatch(fetchCardData(card, dashcard, { reload: true, clearCache: true }));
     await dispatch(loadMetadataForCard(card));
-    dispatch(autoWireParametersToNewCard({ dashcard_id: dashcardId }));
+    dispatch(showAutoWireToastNewCard({ dashcard_id: dashcardId }));
 
     dashboardId && trackQuestionReplaced(dashboardId);
   };

--- a/frontend/src/metabase/dashboard/actions/cards.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/actions/cards.unit.spec.ts
@@ -44,7 +44,7 @@ import {
 
 import type { SectionLayout } from "../sections";
 import { layoutOptions } from "../sections";
-import { getDashCardById, getDashcards } from "../selectors";
+import { getDashboardById, getDashCardById, getDashcards } from "../selectors";
 
 import type { AddCardToDashboardOpts } from "./cards-typed";
 import {
@@ -361,7 +361,10 @@ async function runAddCardToDashboard({
   })(store.dispatch, store.getState);
   const nextState = store.getState();
 
-  const tempDashCardId = -1;
+  const tempDashCardId =
+    getDashboardById(nextState, dashId).dashcards.find(
+      dashcardId => dashcardId < 0,
+    ) ?? -1;
 
   return {
     nextDashCard: getDashCardById(nextState, tempDashCardId),

--- a/frontend/src/metabase/dashboard/actions/cards.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/actions/cards.unit.spec.ts
@@ -9,7 +9,6 @@ import {
   setupCardQueryMetadataEndpoint,
 } from "__support__/server-mocks";
 import { Api } from "metabase/api";
-import { checkNotNull } from "metabase/lib/types";
 import mainReducers from "metabase/reducers-main";
 import { CardApi } from "metabase/services";
 import type {
@@ -47,7 +46,12 @@ import type { SectionLayout } from "../sections";
 import { layoutOptions } from "../sections";
 import { getDashCardById, getDashcards } from "../selectors";
 
-import { addSectionToDashboard, replaceCard } from "./cards-typed";
+import type { AddCardToDashboardOpts } from "./cards-typed";
+import {
+  addCardToDashboard,
+  addSectionToDashboard,
+  replaceCard,
+} from "./cards-typed";
 
 const DATE_PARAMETER = createMockParameter({
   id: "1",
@@ -264,19 +268,8 @@ describe("dashboard/actions/cards", () => {
       );
     });
 
-    // TODO: it should only show a toast about auto-connection
-    // eslint-disable-next-line jest/no-disabled-tests
-    it.skip("should auto-wire parameters", async () => {
+    it("should not auto-wire parameters", async () => {
       const nextCardId = ORDERS_LINE_CHART_CARD.id;
-      const otherCardParameterMappings = checkNotNull(
-        PIE_CHART_DASHCARD.parameter_mappings,
-      );
-      const expectedParameterMappings = otherCardParameterMappings.map(
-        mapping => ({
-          ...mapping,
-          card_id: nextCardId,
-        }),
-      );
 
       const { nextDashCard } = await runReplaceCardAction({
         dashcardId: TABLE_DASHCARD.id,
@@ -284,9 +277,21 @@ describe("dashboard/actions/cards", () => {
         dashcards: [...DASHCARDS, PIE_CHART_DASHCARD],
       });
 
-      expect(nextDashCard.parameter_mappings).toEqual(
-        expectedParameterMappings,
-      );
+      expect(nextDashCard.parameter_mappings).toEqual([]);
+    });
+  });
+
+  describe("addCardToDashboard", () => {
+    it("should not auto-wire parameters", async () => {
+      const { nextDashCard } = await runAddCardToDashboard({
+        dashId: DASHBOARD.id,
+        cardId: ORDERS_LINE_CHART_CARD.id,
+        tabId: null,
+        // for auto-wiring
+        dashcards: [...DASHCARDS, PIE_CHART_DASHCARD],
+      });
+
+      expect(nextDashCard.parameter_mappings).toEqual([]);
     });
   });
 });
@@ -338,5 +343,27 @@ async function runReplaceCardAction({
     nextDashCard: getDashCardById(nextState, dashcardId),
     dispatchSpy,
     cardQueryEndpointSpy,
+  };
+}
+
+async function runAddCardToDashboard({
+  dashId,
+  tabId,
+  cardId,
+  ...opts
+}: SetupOpts & AddCardToDashboardOpts) {
+  const { store } = setup(opts);
+
+  await addCardToDashboard({
+    dashId,
+    tabId,
+    cardId,
+  })(store.dispatch, store.getState);
+  const nextState = store.getState();
+
+  const tempDashCardId = -1;
+
+  return {
+    nextDashCard: getDashCardById(nextState, tempDashCardId),
   };
 }

--- a/frontend/src/metabase/dashboard/actions/cards.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/actions/cards.unit.spec.ts
@@ -264,7 +264,9 @@ describe("dashboard/actions/cards", () => {
       );
     });
 
-    it("should auto-wire parameters", async () => {
+    // TODO: it should only show a toast about auto-connection
+    // eslint-disable-next-line jest/no-disabled-tests
+    it.skip("should auto-wire parameters", async () => {
       const nextCardId = ORDERS_LINE_CHART_CARD.id;
       const otherCardParameterMappings = checkNotNull(
         PIE_CHART_DASHCARD.parameter_mappings,

--- a/frontend/src/metabase/dashboard/actions/parameters.ts
+++ b/frontend/src/metabase/dashboard/actions/parameters.ts
@@ -167,12 +167,7 @@ export const setParameterMapping = createThunkAction(
 
       const dashcard = getDashCardById(getState(), dashcardId);
 
-      if (!isQuestionDashCard(dashcard)) {
-        // proceed only with question dashcards
-        return;
-      }
-
-      if (target !== null) {
+      if (target !== null && isQuestionDashCard(dashcard)) {
         const selectedTabId = getSelectedTabId(getState());
 
         dispatch(


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/43184

[figma](https://www.figma.com/design/mcmJekuToH3AyvL8cDhlo9/Make-Dashboard-filter-auto-wire-less-presumptuous?node-id=1-286&t=Vx8Lg8AQ2WfBKE5p-0)

### Description

This PR changes the behaviour of auto-wiring during mapping, adding new card and replacing a card in the dashboard.

Main changes:
- auto-wiring works only in the current tab
- we stop automatic wiring, instead we show a toast with the message to click a button to enable auto-wiring
- toast text is updated - it depends on the number of tabs and includes filter name and dashcard name
- toast timer is updated to 12s (a new progress bar will be added in a separate PR)
- e2e tests updated accordingly with the new default behaviour (no auto-wiring)

quick demo

1. Multi-tab

### mapping + new card

https://github.com/metabase/metabase/assets/125459446/25ed663d-eb0b-48e5-ace4-b51696e68ddb

### replace card


https://github.com/metabase/metabase/assets/125459446/78f29d56-6616-48c6-9e61-5f689ee65708


### several filters are connected


https://github.com/metabase/metabase/assets/125459446/01bb52a4-9d2c-4caf-bcbf-8a3e83fa889e




2. Single Tab


https://github.com/metabase/metabase/assets/125459446/e2f09613-5c1f-417f-886a-2db023960b98

