### PR TITLE
Update macaw for qualified rename support

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -76,7 +76,7 @@
   io.github.eerohele/pp                     {:git/tag "2024-01-04.60"           ; super fast pretty-printing library
                                              :git/sha "a428751"
                                              :git/url "https://github.com/eerohele/pp"}
-  io.github.metabase/macaw                  {:mvn/version "0.1.29"}             ; Parse native SQL queries
+  io.github.metabase/macaw                  {:mvn/version "0.1.39"}             ; Parse native SQL queries
   ;; The 2.X line of Resilience4j requires Java 17, so we cannot upgrade this dependency until that is our minimum JVM version
   io.github.resilience4j/resilience4j-retry {:mvn/version "1.7.1" #_ "must be 1.7.1"} ; Support for retrying operations
   io.prometheus/simpleclient_hotspot        {:mvn/version "0.16.0"}             ; prometheus jvm collector

--- a/deps.edn
+++ b/deps.edn
@@ -76,7 +76,7 @@
   io.github.eerohele/pp                     {:git/tag "2024-01-04.60"           ; super fast pretty-printing library
                                              :git/sha "a428751"
                                              :git/url "https://github.com/eerohele/pp"}
-  io.github.metabase/macaw                  {:mvn/version "0.1.42"}             ; Parse native SQL queries
+  io.github.metabase/macaw                  {:mvn/version "0.1.44"}             ; Parse native SQL queries
   ;; The 2.X line of Resilience4j requires Java 17, so we cannot upgrade this dependency until that is our minimum JVM version
   io.github.resilience4j/resilience4j-retry {:mvn/version "1.7.1" #_ "must be 1.7.1"} ; Support for retrying operations
   io.prometheus/simpleclient_hotspot        {:mvn/version "0.16.0"}             ; prometheus jvm collector

--- a/deps.edn
+++ b/deps.edn
@@ -76,7 +76,7 @@
   io.github.eerohele/pp                     {:git/tag "2024-01-04.60"           ; super fast pretty-printing library
                                              :git/sha "a428751"
                                              :git/url "https://github.com/eerohele/pp"}
-  io.github.metabase/macaw                  {:mvn/version "0.1.39"}             ; Parse native SQL queries
+  io.github.metabase/macaw                  {:mvn/version "0.1.42"}             ; Parse native SQL queries
   ;; The 2.X line of Resilience4j requires Java 17, so we cannot upgrade this dependency until that is our minimum JVM version
   io.github.resilience4j/resilience4j-retry {:mvn/version "1.7.1" #_ "must be 1.7.1"} ; Support for retrying operations
   io.prometheus/simpleclient_hotspot        {:mvn/version "0.16.0"}             ; prometheus jvm collector

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -900,8 +900,10 @@ saved later when it is ready."
         get-or-throw-from   (fn [m] (fn [k] (if (contains? m k)
                                               (remove-id (get m k))
                                               (throw (ex-info "ID not found" {:id k :available m})))))
-        column-replacements (u/update-keys-vals fields (get-or-throw-from id->field))
-        table-replacements  (u/update-keys-vals tables (get-or-throw-from id->table))]
+        ids->replacements   (fn [id->replacement-id id->row]
+                              (u/update-keys-vals id->replacement-id (get-or-throw-from id->row)))
+        column-replacements (ids->replacements fields id->field)
+        table-replacements  (ids->replacements tables id->table)]
     (query-analyzer/replace-names query {:columns column-replacements
                                          :tables  table-replacements})))
 

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -900,10 +900,14 @@ saved later when it is ready."
         get-or-throw-from   (fn [m] (fn [k] (if (contains? m k)
                                               (remove-id (get m k))
                                               (throw (ex-info "ID not found" {:id k :available m})))))
-        ids->replacements   (fn [id->replacement-id id->row]
-                              (u/update-keys-vals id->replacement-id (get-or-throw-from id->row)))
-        column-replacements (ids->replacements fields id->field)
-        table-replacements  (ids->replacements tables id->table)]
+        ids->replacements   (fn [id->replacement-id id->row row->identifier]
+                              (-> id->replacement-id
+                                  (u/update-keys-vals (get-or-throw-from id->row))
+                                  (update-vals row->identifier)))
+        ;; Note: we are naively providing unqualified new identifier names as the replacements.
+        ;; this will break if previously unambiguous identifiers become ambiguous due to the replacements
+        column-replacements (ids->replacements fields id->field :column)
+        table-replacements  (ids->replacements tables id->table :table)]
     (query-analyzer/replace-names query {:columns column-replacements
                                          :tables  table-replacements})))
 

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -876,8 +876,8 @@ saved later when it is ready."
 
 (defn- replaced-inner-query-for-native-card
   [query {:keys [fields tables] :as _replacement-ids}]
-  (let [keyvals-set         #(set/union (into #{} (keys %))
-                                        (into #{} (vals %)))
+  (let [keyvals-set         #(set/union (set (keys %))
+                                        (set (vals %)))
         id->field           (if (empty? fields)
                               {}
                               (m/index-by :id
@@ -900,11 +900,8 @@ saved later when it is ready."
         get-or-throw-from   (fn [m] (fn [k] (if (contains? m k)
                                               (remove-id (get m k))
                                               (throw (ex-info "ID not found" {:id k :available m})))))
-        update-keyvals      (fn [m f] (-> m
-                                          (update-keys f)
-                                          (update-vals f)))
-        column-replacements (update-keyvals fields (get-or-throw-from id->field))
-        table-replacements  (update-keyvals tables (get-or-throw-from id->table))]
+        column-replacements (u/update-keys-vals fields (get-or-throw-from id->field))
+        table-replacements  (u/update-keys-vals tables (get-or-throw-from id->table))]
     (query-analyzer/replace-names query {:columns column-replacements
                                          :tables  table-replacements})))
 

--- a/src/metabase/native_query_analyzer/replacement.clj
+++ b/src/metabase/native_query_analyzer/replacement.clj
@@ -147,5 +147,5 @@
         param->value                 (param-values query)
         {clean-query :query
          tt-subs     :substitutions} (parse-tree->clean-query raw-query parsed-query param->value)
-        renamed-query                (macaw/replace-names clean-query renames)]
+        renamed-query                (macaw/replace-names clean-query renames :allow-unused? true)]
     (replace-all renamed-query tt-subs)))

--- a/src/metabase/native_query_analyzer/replacement.clj
+++ b/src/metabase/native_query_analyzer/replacement.clj
@@ -131,18 +131,6 @@
           the-string
           replacements))
 
-;; remove this once Macaw#32 is fixed
-(defn- clean-renames-macaw-issue-32
-  [{:keys [tables columns]}]
-  (let [clean-column (fn [c] (or (:column c) c))
-        clean-table  (fn [t] (or (:table t) t))]
-    {:columns (-> columns
-                  (update-keys clean-column)
-                  (update-vals clean-column))
-     :tables  (-> tables
-                  (update-keys clean-table)
-                  (update-vals clean-table))}))
-
 (defn- param-values
   [query]
   (if (qp.store/initialized?)
@@ -159,5 +147,5 @@
         param->value                 (param-values query)
         {clean-query :query
          tt-subs     :substitutions} (parse-tree->clean-query raw-query parsed-query param->value)
-        renamed-query                (macaw/replace-names clean-query (clean-renames-macaw-issue-32 renames))]
+        renamed-query                (macaw/replace-names clean-query renames)]
     (replace-all renamed-query tt-subs)))

--- a/src/metabase/native_query_analyzer/replacement.clj
+++ b/src/metabase/native_query_analyzer/replacement.clj
@@ -147,5 +147,5 @@
         param->value                 (param-values query)
         {clean-query :query
          tt-subs     :substitutions} (parse-tree->clean-query raw-query parsed-query param->value)
-        renamed-query                (macaw/replace-names clean-query renames :allow-unused? true)]
+        renamed-query                (macaw/replace-names clean-query renames {:allow-unused? true})]
     (replace-all renamed-query tt-subs)))

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -972,3 +972,15 @@
                          (partition 2 clauses))
                  (when (odd? (count clauses))
                    (list (last clauses))))))))))
+
+(defn update-keys-vals
+  "A combination of [[update-keys]] and [[update-vals]], which simultaneously re-maps keys and values."
+  ([m f]
+   (update-keys-vals m f f))
+  ([m key-f val-f]
+   (let [ret (persistent!
+              (reduce-kv (fn [acc k v]
+                           (assoc! acc (key-f k) (val-f v)))
+                         (transient {})
+                         m))]
+     (with-meta ret (meta m)))))

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -3,7 +3,8 @@
    [cheshire.core :as json]
    [clojure.set :as set]
    [clojure.test :refer :all]
-   [java-time :as t]
+   [java-time.api :as t]
+   [metabase.api.common :as api]
    [metabase.config :as config]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
@@ -181,11 +182,13 @@
 
 (deftest replace-fields-and-tables!-test
   (testing "fields and tables in a native card can be replaced"
-    (t2.with-temp/with-temp [:model/Card {card-id :id :as card} {:dataset_query (mt/native-query {:query "SELECT TOTAL FROM ORDERS"})}]
-      (card/replace-fields-and-tables! card {:fields {(mt/id :orders :total) (mt/id :people :name)}
-                                             :tables {(mt/id :orders) (mt/id :people)}})
-      (is (= "SELECT NAME FROM PEOPLE"
-             (:query (:native (t2/select-one-fn :dataset_query :model/Card :id card-id))))))))
+    ;; We need the user to be defined in order to population the new revision related to the card update
+    (binding [api/*current-user-id* (mt/user->id :crowberto)]
+      (t2.with-temp/with-temp [:model/Card {card-id :id :as card} {:dataset_query (mt/native-query {:query "SELECT TOTAL FROM ORDERS"})}]
+        (card/replace-fields-and-tables! card {:fields {(mt/id :orders :total) (mt/id :people :name)}
+                                               :tables {(mt/id :orders) (mt/id :people)}})
+        (is (= "SELECT NAME FROM PEOPLE"
+               (:query (:native (t2/select-one-fn :dataset_query :model/Card :id card-id)))))))))
 
 ;;; ------------------------------------------ Circular Reference Detection ------------------------------------------
 

--- a/test/metabase/native_query_analyzer_test.clj
+++ b/test/metabase/native_query_analyzer_test.clj
@@ -38,7 +38,7 @@
         (is (= {:direct #{(mt/id :venues :id)} :indirect nil}
                (q "select id from venues"))))
       (testing "quotes stop case matching"
-        ;; MySQL does case-insensitive string comparisons by default; quoting does not make it conside case
+        ;; MySQL does case-insensitive string comparisons by default; quoting does not make it consider case
         ;; in field names either, so it's consistent behavior
         (if (= (mdb.connection/db-type) :mysql)
           (is (= {:direct #{(mt/id :venues :id)} :indirect nil}


### PR DESCRIPTION
This updates our Macaw dependency to bring in qualified name support for renames. This version in fact requires all columns to be qualified, and all table names to be in a map, so it also updates the corresponding test cases.

This change is blocked on [this new flag being added](https://github.com/metabase/macaw/pull/41), which will require bumping our version yet again once that merges.