### PR TITLE
Omit checks for dashboard metadata when not needed

### DIFF
--- a/frontend/src/metabase/dashboard/actions/save.js
+++ b/frontend/src/metabase/dashboard/actions/save.js
@@ -4,7 +4,6 @@ import _ from "underscore";
 import {
   fetchDashboard,
   fetchDashboardCardData,
-  fetchDashboardCardMetadata,
 } from "metabase/dashboard/actions";
 import Dashboards from "metabase/entities/dashboards";
 import { createThunkAction } from "metabase/lib/redux";
@@ -153,7 +152,6 @@ export const updateDashboardAndCards = createThunkAction(
           clearCache: false,
         }),
       );
-      dispatch(fetchDashboardCardMetadata());
     };
   },
 );

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -312,28 +312,28 @@ function DashboardInner(props: DashboardProps) {
   );
 
   useEffect(() => {
-    if (previousDashboardId !== dashboardId) {
-      handleLoadDashboard(dashboardId).then(() => {
-        setIsInitialized(true);
-      });
+    const hasDashboardChanged = dashboardId !== previousDashboardId;
+    if (hasDashboardChanged) {
+      handleLoadDashboard(dashboardId).then(() => setIsInitialized(true));
       return;
     }
 
-    if (previousTabId !== selectedTabId && dashboard) {
-      fetchDashboardCardData();
-      fetchDashboardCardMetadata();
+    if (!dashboard) {
       return;
     }
-    const didDashboardLoad = !previousDashboard && dashboard;
-    const didParameterValuesChange = !_.isEqual(
-      previousParameterValues,
+
+    const hasDashboardLoaded = !previousDashboard;
+    const hasTabChanged = selectedTabId !== previousTabId;
+    const hasParameterValueChanged = !_.isEqual(
       parameterValues,
+      previousParameterValues,
     );
-    if (didDashboardLoad || didParameterValuesChange) {
+
+    if (hasDashboardLoaded) {
       fetchDashboardCardData({ reload: false, clearCache: true });
-    }
-    if (didDashboardLoad) {
       fetchDashboardCardMetadata();
+    } else if (hasTabChanged || hasParameterValueChanged) {
+      fetchDashboardCardData();
     }
   }, [
     dashboard,

--- a/frontend/src/metabase/dashboard/hoc/DashboardData.jsx
+++ b/frontend/src/metabase/dashboard/hoc/DashboardData.jsx
@@ -114,7 +114,6 @@ export const DashboardData = ComposedComponent =>
 
         if (!_.isEqual(nextProps.selectedTabId, this.props.selectedTabId)) {
           this.props.fetchDashboardCardData();
-          this.props.fetchDashboardCardMetadata();
           return;
         }
       }

--- a/frontend/src/metabase/dashboard/hooks/use-refresh-dashboard.ts
+++ b/frontend/src/metabase/dashboard/hooks/use-refresh-dashboard.ts
@@ -3,6 +3,7 @@ import { useCallback } from "react";
 import {
   fetchDashboard,
   fetchDashboardCardData,
+  fetchDashboardCardMetadata,
 } from "metabase/dashboard/actions";
 import { useDispatch } from "metabase/lib/redux";
 import type { DashboardId } from "metabase-types/api";
@@ -34,6 +35,7 @@ export const useRefreshDashboard = ({
           clearCache: false,
         }),
       );
+      dispatch(fetchDashboardCardMetadata());
     }
   }, [dashboardId, dispatch, queryParams]);
 

--- a/frontend/src/metabase/dashboard/hooks/use-refresh-dashboard.ts
+++ b/frontend/src/metabase/dashboard/hooks/use-refresh-dashboard.ts
@@ -3,7 +3,6 @@ import { useCallback } from "react";
 import {
   fetchDashboard,
   fetchDashboardCardData,
-  fetchDashboardCardMetadata,
 } from "metabase/dashboard/actions";
 import { useDispatch } from "metabase/lib/redux";
 import type { DashboardId } from "metabase-types/api";
@@ -35,7 +34,6 @@ export const useRefreshDashboard = ({
           clearCache: false,
         }),
       );
-      dispatch(fetchDashboardCardMetadata());
     }
   }, [dashboardId, dispatch, queryParams]);
 

--- a/frontend/src/metabase/public/containers/PublicDashboard/PublicDashboard.tsx
+++ b/frontend/src/metabase/public/containers/PublicDashboard/PublicDashboard.tsx
@@ -131,12 +131,14 @@ class PublicDashboardInner extends Component<PublicDashboardProps> {
     }
 
     try {
+      const requests = [];
       if (this.props.dashboard?.tabs?.length === 0) {
-        await Promise.all([
+        requests.push(
           fetchDashboardCardData({ reload: false, clearCache: true }),
-          fetchDashboardCardMetadata(),
-        ]);
+        );
       }
+      requests.push(fetchDashboardCardMetadata());
+      await Promise.all(requests);
     } catch (error) {
       console.error(error);
       setErrorPage(error);
@@ -158,7 +160,6 @@ class PublicDashboardInner extends Component<PublicDashboardProps> {
 
     if (!_.isEqual(prevProps.selectedTabId, this.props.selectedTabId)) {
       this.props.fetchDashboardCardData();
-      this.props.fetchDashboardCardMetadata();
       return;
     }
 


### PR DESCRIPTION
Improves performance by removing unneeded calls to check for metadata being up-to-date. In real dashboards each call can take > 500ms. 

CI is green