### PR TITLE
Return card type in GET /api/table/card__:id/query_metadata

### DIFF
--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -160,7 +160,8 @@
            xform)
      (completing conj #(t2/hydrate % :collection))
      []
-     (t2/reducible-query {:select   [:name :description :database_id :dataset_query :id :collection_id :result_metadata
+     (t2/reducible-query {:select   [:name :description :database_id :dataset_query :id :collection_id
+                                     :result_metadata :type
                                      [{:select   [:status]
                                        :from     [:moderation_review]
                                        :where    [:and

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -402,7 +402,8 @@
   'virtual' fields as well."
   [{:keys [database_id] :as card} & {:keys [include-fields?]}]
   ;; if collection isn't already hydrated then do so
-  (let [card (t2/hydrate card :collection)]
+  (let [card (t2/hydrate card :collection)
+        dataset-query (:dataset_query card)]
     (cond-> {:id               (str "card__" (u/the-id card))
              :db_id            (:database_id card)
              :display_name     (:name card)
@@ -410,6 +411,7 @@
              :moderated_status (:moderated_status card)
              :description      (:description card)
              :type             (:type card)}
+      dataset-query   (assoc :dataset_query dataset-query)
       include-fields? (assoc :fields (card-result-metadata->virtual-fields (u/the-id card)
                                                                            database_id
                                                                            (:result_metadata card))))))
@@ -434,7 +436,7 @@
   {id ms/PositiveInt}
   (let [{:keys [database_id] :as card} (api/check-404
                                         (t2/select-one [Card :id :dataset_query :result_metadata :name :description
-                                                        :collection_id :database_id :type]
+                                                        :collection_id :database_id :type :dataset_query]
                                                        :id id))
         moderated-status              (->> (mdb.query/query {:select   [:status]
                                                              :from     [:moderation_review]

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -408,7 +408,8 @@
              :display_name     (:name card)
              :schema           (get-in card [:collection :name] (root-collection-schema-name))
              :moderated_status (:moderated_status card)
-             :description      (:description card)}
+             :description      (:description card)
+             :type             (:type card)}
       include-fields? (assoc :fields (card-result-metadata->virtual-fields (u/the-id card)
                                                                            database_id
                                                                            (:result_metadata card))))))

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -403,6 +403,7 @@
   [{:keys [database_id] :as card} & {:keys [include-fields?]}]
   ;; if collection isn't already hydrated then do so
   (let [card (t2/hydrate card :collection)
+        card-type (:type card)
         dataset-query (:dataset_query card)]
     (cond-> {:id               (str "card__" (u/the-id card))
              :db_id            (:database_id card)
@@ -410,11 +411,15 @@
              :schema           (get-in card [:collection :name] (root-collection-schema-name))
              :moderated_status (:moderated_status card)
              :description      (:description card)
-             :type             (:type card)}
-      dataset-query   (assoc :dataset_query dataset-query)
-      include-fields? (assoc :fields (card-result-metadata->virtual-fields (u/the-id card)
-                                                                           database_id
-                                                                           (:result_metadata card))))))
+             :type             card-type}
+      (and (= card-type :metric)
+           dataset-query)
+      (assoc :dataset_query dataset-query)
+
+      include-fields?
+      (assoc :fields (card-result-metadata->virtual-fields (u/the-id card)
+                                                           database_id
+                                                           (:result_metadata card))))))
 
 (defn- remove-nested-pk-fk-semantic-types
   "This method clears the semantic_type attribute for PK/FK fields of nested queries. Those fields having a semantic

--- a/src/metabase/lib/fe_util.cljc
+++ b/src/metabase/lib/fe_util.cljc
@@ -184,8 +184,7 @@
      (when-let [card-id (:source-card base-stage)]
        (let [card (lib.metadata/card metadata-providerable card-id)
              definition (:dataset-query card)]
-         (concat [{:type :table, :id (str "card__" card-id)}
-                  {:type :card, :id card-id}]
+         (concat [{:type :table, :id (str "card__" card-id)}]
                  (when-let [card-columns (lib.card/saved-question-metadata metadata-providerable card-id)]
                    (query-dependents-foreign-keys metadata-providerable card-columns))
                  (when (and (= (:type card) :metric) definition)
@@ -208,7 +207,6 @@
     [:database [:map [:id ::lib.schema.id/database]]]
     [:schema   [:map [:id ::lib.schema.id/database]]]
     [:table    [:map [:id [:or ::lib.schema.id/table :string]]]]
-    [:card     [:map [:id ::lib.schema.id/card]]]
     [:field    [:map [:id ::lib.schema.id/field]]]]])
 
 (mu/defn dependent-metadata :- [:sequential DependentItem]
@@ -235,6 +233,4 @@
   "Return the IDs and types of entities which are needed upfront to create a new query based on a table/card."
   [_metadata-providerable :- ::lib.schema.metadata/metadata-providerable
    table-id               :- [:or ::lib.schema.id/table :string]]
-  (cons {:type :table, :id table-id}
-        (when-let [card-id (lib.util/legacy-string-table-id->card-id table-id)]
-          [{:type :card, :id card-id}])))
+  [{:type :table, :id table-id}])

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -132,7 +132,8 @@
     :display_name     (:name card)
     :schema           "Everything else"
     :moderated_status nil
-    :description      nil}
+    :description      nil
+    :type             "question"}
    kvs))
 
 (defn- ok-mbql-card []
@@ -1640,7 +1641,8 @@
                    :moderated_status nil
                    :display_name     "Card 1"
                    :schema           "My Collection"
-                   :description      nil}]
+                   :description      nil
+                   :type             "question"}]
                  (mt/user-http-request :lucky :get 200
                                        (format "database/%d/schema/%s" lib.schema.id/saved-questions-virtual-database-id "My Collection")))))
 
@@ -1664,7 +1666,8 @@
                             :display_name     "Card 2"
                             :moderated_status nil
                             :schema           (api.table/root-collection-schema-name)
-                            :description      nil}))))
+                            :description      nil
+                            :type             "question"}))))
 
         (testing "Should throw 404 if the schema/Collection doesn't exist"
           (is (= "Not found."
@@ -1690,7 +1693,8 @@
                    :moderated_status nil
                    :display_name     "Card 1"
                    :schema           "My Collection"
-                   :description      nil}]
+                   :description      nil
+                   :type             "model"}]
                  (mt/user-http-request :lucky :get 200
                                        (format "database/%d/datasets/%s" lib.schema.id/saved-questions-virtual-database-id "My Collection")))))
 
@@ -1713,7 +1717,8 @@
                             :display_name     "Card 2"
                             :moderated_status nil
                             :schema           (api.table/root-collection-schema-name)
-                            :description      nil}))))
+                            :description      nil
+                            :type             "model"}))))
 
         (testing "Should throw 404 if the schema/Collection doesn't exist"
           (is (= "Not found."

--- a/test/metabase/lib/fe_util_test.cljc
+++ b/test/metabase/lib/fe_util_test.cljc
@@ -171,7 +171,6 @@
     (are [query] (=? [{:type :database, :id (meta/id)}
                       {:type :schema,   :id (meta/id)}
                       {:type :table,    :id "card__1"}
-                      {:type :card,     :id 1}
                       {:type :table,    :id (meta/id :users)}]
                      (lib/dependent-metadata query nil :question))
       lib.tu/query-with-source-card
@@ -180,7 +179,6 @@
     (are [query] (=? [{:type :database, :id (meta/id)}
                       {:type :schema,   :id (meta/id)}
                       {:type :table,    :id "card__1"}
-                      {:type :card,     :id 1}
                       {:type :table,    :id (meta/id :users)}]
                      (lib/dependent-metadata query nil :question))
       lib.tu/query-with-source-card-with-result-metadata
@@ -190,7 +188,6 @@
       (are [query] (=? [{:type :database, :id (meta/id)}
                         {:type :schema,   :id (meta/id)}
                         {:type :table,    :id "card__1"}
-                        {:type :card,     :id 1}
                         {:type :table,    :id (meta/id :users)}]
                        (lib/dependent-metadata query nil :question))
         query
@@ -200,7 +197,6 @@
       (are [query] (=? [{:type :database, :id (meta/id)}
                         {:type :schema,   :id (meta/id)}
                         {:type :table,    :id "card__1"}
-                        {:type :card,     :id 1}
                         {:type :table,    :id (meta/id :users)}
                         {:type :table,    :id (meta/id :checkins)}
                         {:type :table,    :id (meta/id :venues)}]
@@ -217,8 +213,7 @@
                         {:type :table,    :id (meta/id :checkins)}
                         {:type :table,    :id (meta/id :users)}
                         {:type :table,    :id (meta/id :venues)}
-                        {:type :table,    :id "card__1"}
-                        {:type :card,     :id 1}]
+                        {:type :table,    :id "card__1"}]
                        (lib/dependent-metadata query 1 :model))
         query
         (lib/append-stage query))))
@@ -232,8 +227,7 @@
                         {:type :table,    :id (meta/id :checkins)}
                         {:type :table,    :id (meta/id :users)}
                         {:type :table,    :id (meta/id :venues)}
-                        {:type :table,    :id "card__1"}
-                        {:type :card,     :id 1}]
+                        {:type :table,    :id "card__1"}]
                        (lib/dependent-metadata query 1 :metric))
         query
         (lib/append-stage query)))))
@@ -243,8 +237,7 @@
     (is (= [{:type :table, :id (meta/id :checkins)}]
            (lib/table-or-card-dependent-metadata meta/metadata-provider (meta/id :checkins)))))
   (testing "start from card"
-    (is (= [{:type :table, :id "card__1"}
-            {:type :card,  :id 1}]
+    (is (= [{:type :table, :id "card__1"}]
            (lib/table-or-card-dependent-metadata lib.tu/metadata-provider-with-card "card__1")))))
 
 (deftest ^:parallel maybe-expand-temporal-expression-test


### PR DESCRIPTION
Fixes  #43151.

Also stops requesting card metadata in dependent-metadata.
