### PR TITLE
fix edit hash is not removed after editing a dashboard

### DIFF
--- a/frontend/src/metabase/dashboard/actions/actions.unit.spec.js
+++ b/frontend/src/metabase/dashboard/actions/actions.unit.spec.js
@@ -1,4 +1,5 @@
 import { DashboardApi } from "metabase/services";
+import { createMockRoutingState } from "metabase-types/store/mocks/index";
 
 import { SIDEBAR_NAME } from "../constants";
 
@@ -14,6 +15,7 @@ import {
   removeParameter,
   SET_DASHBOARD_ATTRIBUTES,
   updateDashboardAndCards,
+  setEditingDashboard,
 } from "./index";
 
 DashboardApi.parameterSearch = jest.fn();
@@ -187,6 +189,39 @@ describe("dashboard actions", () => {
 
       // if this is called only once, it means that the dashboard was not saved
       expect(dispatch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("setEditingDashboard", () => {
+    const getState = () => ({
+      routing: createMockRoutingState({
+        locationBeforeTransitions: {
+          pathname: "/dashboard/1",
+          hash: "#hashparam",
+        },
+      }),
+    });
+
+    it("should remove any hash parameters from url when not editing", () => {
+      setEditingDashboard(null)(dispatch, getState);
+
+      expect(dispatch).toHaveBeenCalledWith({
+        payload: {
+          args: [
+            {
+              action: "POP",
+              hash: "",
+              key: "",
+              pathname: "/dashboard/1",
+              query: {},
+              search: "",
+              state: undefined,
+            },
+          ],
+          method: "push",
+        },
+        type: "@@router/CALL_HISTORY_METHOD",
+      });
     });
   });
 });

--- a/frontend/src/metabase/dashboard/actions/core.ts
+++ b/frontend/src/metabase/dashboard/actions/core.ts
@@ -1,4 +1,7 @@
+import { push } from "react-router-redux";
+
 import { createAction } from "metabase/lib/redux";
+import { getLocation } from "metabase/selectors/routing";
 import type {
   DashCardId,
   DashCardVisualizationSettings,
@@ -6,7 +9,7 @@ import type {
   DashboardCard,
   DashboardId,
 } from "metabase-types/api";
-import type { Dispatch } from "metabase-types/store";
+import type { Dispatch, GetState } from "metabase-types/store";
 
 export const INITIALIZE = "metabase/dashboard/INITIALIZE";
 export const initialize = createAction(INITIALIZE);
@@ -15,9 +18,21 @@ export const RESET = "metabase/dashboard/RESET";
 export const reset = createAction(RESET);
 
 export const SET_EDITING_DASHBOARD = "metabase/dashboard/SET_EDITING_DASHBOARD";
-export const setEditingDashboard = createAction<Dashboard | null>(
-  SET_EDITING_DASHBOARD,
-);
+export const setEditingDashboard = (dashboard: Dashboard | null) => {
+  return (dispatch: Dispatch, getState: GetState) => {
+    if (dashboard === null) {
+      const location = getLocation(getState());
+      const locationWithoutEditHash = { ...location, hash: "" };
+
+      dispatch(push(locationWithoutEditHash));
+    }
+
+    dispatch({
+      type: SET_EDITING_DASHBOARD,
+      payload: dashboard,
+    });
+  };
+};
 
 export const CANCEL_EDITING_DASHBOARD =
   "metabase/dashboard/CANCEL_EDITING_DASHBOARD";


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/43192

### Description

Fixes #edit hash is not removed after quitting dashboard edit mode by saving or cancelling.

### How to verify

1. New dashboard -> Save/Cancel
2. Ensure the URL does not have #edit hash

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
