### PR TITLE
Do not ignore icon prop on the Filter button

### DIFF
--- a/frontend/src/metabase/querying/components/FilterPanel/FilterPanelButton/FilterPanelButton.styled.tsx
+++ b/frontend/src/metabase/querying/components/FilterPanel/FilterPanelButton/FilterPanelButton.styled.tsx
@@ -1,4 +1,3 @@
-import isPropValid from "@emotion/is-prop-valid";
 import styled from "@emotion/styled";
 import type { ButtonHTMLAttributes } from "react";
 
@@ -11,8 +10,12 @@ type FilterButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
     isExpanded: boolean;
   };
 
+const shouldForwardProp = (propName: string) => {
+  return propName !== "isExpanded";
+};
+
 export const FilterButton = styled(Button, {
-  shouldForwardProp: isPropValid,
+  shouldForwardProp,
 })<FilterButtonProps>`
   color: ${({ isExpanded }) => (isExpanded ? color("white") : color("filter"))};
   background-color: ${({ isExpanded }) =>

--- a/frontend/src/metabase/querying/components/FilterPanel/FilterPanelButton/FilterPanelButton.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterPanel/FilterPanelButton/FilterPanelButton.unit.spec.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "__support__/ui";
+import type * as Lib from "metabase-lib";
+
+import { createQueryWithStringFilter } from "../../FilterPicker/test-utils";
+
+import { FilterPanelButton } from "./FilterPanelButton";
+
+const { query: initialQuery } = createQueryWithStringFilter();
+
+interface SetupOpts {
+  query: Lib.Query;
+  isExpanded?: boolean;
+  onExpand?: () => void;
+  onCollapse?: () => void;
+}
+
+const setup = (props: SetupOpts = { query: initialQuery }) => {
+  const { isExpanded = true } = props;
+  const onExpand = jest.fn();
+  const onCollapse = jest.fn();
+
+  render(
+    <FilterPanelButton
+      isExpanded={isExpanded}
+      onExpand={onExpand}
+      onCollapse={onCollapse}
+      {...props}
+    />,
+  );
+};
+
+describe("FilterPanelButton", () => {
+  it("should render icon on the left", () => {
+    setup();
+
+    expect(screen.getByLabelText("filter icon")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### Description

[Context](https://metaboat.slack.com/archives/C02H619CJ8K/p1716891600926989)


after https://github.com/metabase/metabase/pull/42819 not only `isExpanded`, but also `leftIcon` was filtered out, what broke filter button

### How to verify

Go to question, add a filter - there should be an icon close to the appeared filter button

### Demo

<img width="710" alt="image" src="https://github.com/metabase/metabase/assets/125459446/9eadf0cb-d3c5-4a6f-b483-ef92c4783805">


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
