### PR TITLE
[wip] Improve performance of Browse models with various techniques

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyFormLauncher.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyFormLauncher.styled.tsx
@@ -17,6 +17,7 @@ export const PolicyToken = styled(Button)<
   border-width: 1px;
   border-style: solid;
   ${({ variant }) =>
+    // NOTE: emotion's css function can be a memory hog
     css`
       border-color: ${color(
         ["filled", "outline"].includes(variant || "") ? "brand" : "border",

--- a/frontend/src/metabase/browse/components/BrowseModels.tsx
+++ b/frontend/src/metabase/browse/components/BrowseModels.tsx
@@ -82,7 +82,17 @@ export const BrowseModelsBody = ({
       actualModelFilters,
       availableModelFilters,
     );
-    return filteredModels;
+    // FIXME: increased to test performance
+    const lots = Array(40)
+      .fill(null)
+      .flatMap((_, i) =>
+        filteredModels.map(model => ({
+          ...model,
+          // Ensure ids are distinct to avoid duplicate React keys
+          id: model.id + i * 1000,
+        })),
+      );
+    return lots;
   }, [data, actualModelFilters]);
 
   if (error || isLoading) {

--- a/frontend/src/metabase/browse/components/CollectionBreadcrumbsWithTooltip.styled.tsx
+++ b/frontend/src/metabase/browse/components/CollectionBreadcrumbsWithTooltip.styled.tsx
@@ -4,7 +4,7 @@ import type { AnchorHTMLAttributes } from "react";
 import { ResponsiveChild } from "metabase/components/ResponsiveContainer/ResponsiveContainer";
 import { color } from "metabase/lib/colors";
 import type { AnchorProps } from "metabase/ui";
-import { Anchor, FixedSizeIcon, Group } from "metabase/ui";
+import { Anchor, Group, FixedSizeIcon } from "metabase/ui";
 
 import type { RefProp } from "./types";
 
@@ -28,31 +28,6 @@ export const Breadcrumb = styled(Anchor)<
 
 export const CollectionBreadcrumbsWrapper = styled(ResponsiveChild)`
   line-height: 1;
-  ${props => {
-    const breakpoint = "10rem";
-    return `
-    .initial-ellipsis {
-      display: none;
-    }
-    @container ${props.containerName} (width < ${breakpoint}) {
-      .ellipsis-and-separator {
-        display: none;
-      }
-      .initial-ellipsis {
-        display: inline;
-      }
-      .for-index-0:not(.sole-breadcrumb) {
-        display: none;
-      }
-      .breadcrumb {
-        max-width: calc(95cqw - 3rem) ! important;
-      }
-      .sole-breadcrumb {
-        max-width: calc(95cqw - 1rem) ! important;
-      }
-    }
-    `;
-  }}
 `;
 
 export const BreadcrumbGroup = styled(Group)`

--- a/frontend/src/metabase/browse/components/EllipsifiedWithMarkdownTooltip.tsx
+++ b/frontend/src/metabase/browse/components/EllipsifiedWithMarkdownTooltip.tsx
@@ -1,11 +1,13 @@
 import { Ellipsified } from "metabase/core/components/Ellipsified";
+import type { EllipsifiedProps } from "metabase/core/components/Ellipsified/Ellipsified";
 import Markdown from "metabase/core/components/Markdown";
 
 export const EllipsifiedWithMarkdownTooltip = ({
   children,
+  ...props
 }: {
   children: string;
-}) => {
+} & Partial<EllipsifiedProps>) => {
   return (
     <Ellipsified
       tooltip={
@@ -13,6 +15,7 @@ export const EllipsifiedWithMarkdownTooltip = ({
           {children}
         </Markdown>
       }
+      {...props}
     >
       {children}
     </Ellipsified>

--- a/frontend/src/metabase/browse/components/ModelsTable.tsx
+++ b/frontend/src/metabase/browse/components/ModelsTable.tsx
@@ -73,17 +73,6 @@ export const ModelsTable = ({ models }: ModelsTableProps) => {
   const collectionWidth = 38.5;
   const descriptionWidth = 100 - collectionWidth;
 
-  // Motivation for the RenderGradually pattern:
-  // The table loads very slowly when there are 1K+ models.
-  // It should be able to handle that many, since in large enterprises
-  // a lot of users might use the CSV upload function to create a lot of models.
-  // With this pattern, initial page load are both fast and take O(1) time.
-  // Contrast with other approaches:
-  // * Virtualization and pagination:
-  //      These prevent searching with Cmd+F.
-  // * Simplifying the the table-row component when the model count is high:
-  //      Initial page load and sorting both are semi-slow and have worse than O(1) time.
-
   return (
     <Table>
       <colgroup>
@@ -140,8 +129,19 @@ export const ModelsTable = ({ models }: ModelsTableProps) => {
       </thead>
       <TBody>
         <RenderGradually
+          // Motivation for the RenderGradually pattern:
+          // The table loads very slowly when there are 1K+ models.
+          // It should be able to handle that many, since in large enterprises
+          // a lot of users might use the CSV upload function to create a lot of models.
+          // With this pattern, page load and sorting are fast and take O(1) time.
+          // Contrast with other approaches:
+          // * Virtualization and pagination:
+          //      These might be worth exploring even though they prevent searching with Cmd+F.
+          // * Simplifying the the table-row component when the model count is high:
+          //      Easy to maintain, though with this approach, page load and
+          //      sorting both are semi-slow and have worse than O(1) time.
           items={sortedModels}
-          Loader={ModelsLoadingIndicator}
+          Loading={ModelsLoadingIndicator}
           key={JSON.stringify(sortingOptions)}
           enabled={false}
         >

--- a/frontend/src/metabase/browse/components/ModelsTable.tsx
+++ b/frontend/src/metabase/browse/components/ModelsTable.tsx
@@ -146,14 +146,11 @@ export const ModelsTable = ({ models }: ModelsTableProps) => {
           enabled={false}
         >
           {items =>
-            items.map((model, i) => (
+            items.map(model => (
               <TBodyRow
                 model={model}
                 key={`model-${model.id}`}
                 collectionContainerName="collection-container"
-                // Rather than create a separate CSS container for each row,
-                // just create one in the first row and use it for all the rows
-                shouldCreateCollectionContainer={i === 0}
               />
             ))
           }
@@ -166,11 +163,9 @@ export const ModelsTable = ({ models }: ModelsTableProps) => {
 const TBodyRow = ({
   model,
   collectionContainerName,
-  shouldCreateCollectionContainer,
 }: {
   model: ModelResult;
   collectionContainerName: string;
-  shouldCreateCollectionContainer: boolean;
 }) => {
   const icon = getIcon(model);
   const dispatch = useDispatch();
@@ -212,9 +207,8 @@ const TBodyRow = ({
         >
           {model.collection && (
             <CollectionBreadcrumbsWithTooltip
-              containerName={collectionContainerName}
               collection={model.collection}
-              shouldCreateCollectionContainer={shouldCreateCollectionContainer}
+              containerName={collectionContainerName}
             />
           )}
         </ModelCell>

--- a/frontend/src/metabase/browse/components/ModelsTable.tsx
+++ b/frontend/src/metabase/browse/components/ModelsTable.tsx
@@ -185,43 +185,37 @@ const TBodyRow = ({
       key={model.id}
     >
       {/* Name */}
-      {
-        <NameCell
-          model={model}
-          icon={icon}
-          onClick={() => {
-            trackModelClick(model.id);
-          }}
-        />
-      }
+      <NameCell
+        model={model}
+        icon={icon}
+        onClick={() => {
+          trackModelClick(model.id);
+        }}
+      />
 
       {/* Collection */}
-      {
-        <ModelCell
-          data-testid={`path-for-collection: ${
-            model.collection
-              ? getCollectionName(model.collection)
-              : t`Untitled collection`
-          }`}
-          {...collectionProps}
-        >
-          {model.collection && (
-            <CollectionBreadcrumbsWithTooltip
-              collection={model.collection}
-              containerName={collectionContainerName}
-            />
-          )}
-        </ModelCell>
-      }
+      <ModelCell
+        data-testid={`path-for-collection: ${
+          model.collection
+            ? getCollectionName(model.collection)
+            : t`Untitled collection`
+        }`}
+        {...collectionProps}
+      >
+        {model.collection && (
+          <CollectionBreadcrumbsWithTooltip
+            collection={model.collection}
+            containerName={collectionContainerName}
+          />
+        )}
+      </ModelCell>
 
       {/* Description */}
-      {
-        <ModelCell {...descriptionProps}>
-          <EllipsifiedWithMarkdownTooltip lazy>
-            {getModelDescription(model) || ""}
-          </EllipsifiedWithMarkdownTooltip>
-        </ModelCell>
-      }
+      <ModelCell {...descriptionProps}>
+        <EllipsifiedWithMarkdownTooltip lazy>
+          {getModelDescription(model) || ""}
+        </EllipsifiedWithMarkdownTooltip>
+      </ModelCell>
 
       {/* Adds a border-radius to the table */}
       <Columns.RightEdge.Cell />

--- a/frontend/src/metabase/browse/components/RenderGradually.tsx
+++ b/frontend/src/metabase/browse/components/RenderGradually.tsx
@@ -1,0 +1,60 @@
+import type { FC, ReactNode } from "react";
+import { Fragment, useEffect, useState } from "react";
+
+const defaultIncreaseFunction = (prev: number) => {
+  const increasedValue = prev * 1.5;
+  return increasedValue > 300 ? prev + 300 : Math.floor(increasedValue);
+};
+
+type NoProps = Record<string, never>;
+
+/** Lazily render a list of items in chunks */
+export const RenderGradually = <T,>({
+  items,
+  children,
+  Loader,
+  key,
+  increaseFunction = defaultIncreaseFunction,
+  initialBatchSize = 30,
+  wait = 1000,
+  enabled = true,
+}: {
+  items: T[];
+  children: (items: T[]) => ReactNode;
+  Loader: FC<NoProps>;
+  key?: string;
+  initialBatchSize?: number;
+  increaseFunction?: (prev: number) => number;
+  wait?: number;
+  enabled?: boolean;
+}) => {
+  if (!enabled) {
+    initialBatchSize = items.length;
+  }
+  const [visibleItems, setVisibleItems] = useState([] as T[]);
+  useEffect(() => {
+    setVisibleItems(items.slice(0, initialBatchSize));
+  }, [items, initialBatchSize]);
+
+  useEffect(() => {
+    if (visibleItems.length >= items.length) {
+      return;
+    }
+    const timerId = setInterval(() => {
+      setVisibleItems(prev => {
+        if (prev.length >= items.length) {
+          return prev;
+        }
+        return items.slice(0, increaseFunction(prev.length));
+      });
+    }, wait);
+    return () => clearInterval(timerId);
+  }, [visibleItems.length, items, increaseFunction, wait]);
+
+  return (
+    <Fragment key={key}>
+      {children(visibleItems)}
+      {visibleItems.length < items.length && <Loader />}
+    </Fragment>
+  );
+};

--- a/frontend/src/metabase/browse/components/RenderGradually.tsx
+++ b/frontend/src/metabase/browse/components/RenderGradually.tsx
@@ -12,7 +12,7 @@ type NoProps = Record<string, never>;
 export const RenderGradually = <T,>({
   items,
   children,
-  Loader,
+  Loading,
   key,
   increaseFunction = defaultIncreaseFunction,
   initialBatchSize = 30,
@@ -21,7 +21,7 @@ export const RenderGradually = <T,>({
 }: {
   items: T[];
   children: (items: T[]) => ReactNode;
-  Loader: FC<NoProps>;
+  Loading: FC<NoProps>;
   key?: string;
   initialBatchSize?: number;
   increaseFunction?: (prev: number) => number;
@@ -54,7 +54,7 @@ export const RenderGradually = <T,>({
   return (
     <Fragment key={key}>
       {children(visibleItems)}
-      {visibleItems.length < items.length && <Loader />}
+      {visibleItems.length < items.length && <Loading />}
     </Fragment>
   );
 };

--- a/frontend/src/metabase/browse/components/utils.tsx
+++ b/frontend/src/metabase/browse/components/utils.tsx
@@ -84,6 +84,7 @@ export const sortModels = (
   sortingOptions: SortingOptions,
   localeCode: string = "en",
 ) => {
+  // FIXME: This is probably over-optimized
   const { sort_column: primarySortColumn, sort_direction } = sortingOptions;
 
   if (!isValidSortColumn(primarySortColumn)) {
@@ -115,7 +116,7 @@ export const sortModels = (
     secondaryValues.map((value, index) => [value, index]),
   );
 
-  // Use the pre-computed value orders for fast comparison
+  // Use pre-computed value orders for fast comparison
   const comparePrimary = (a: string, b: string) =>
     primaryOrderMap.get(a)! - primaryOrderMap.get(b)!;
   const compareSecondary = (a: string, b: string) =>

--- a/frontend/src/metabase/common/utils/lazy.tsx
+++ b/frontend/src/metabase/common/utils/lazy.tsx
@@ -1,0 +1,6 @@
+export const callNow = (func: () => void) => func();
+export const callLater = (callback: () => void) => {
+  "requestIdleCallback" in window
+    ? window.requestIdleCallback(callback)
+    : setTimeout(callback, 1);
+};

--- a/frontend/src/metabase/components/EntityItem/EntityItem.tsx
+++ b/frontend/src/metabase/components/EntityItem/EntityItem.tsx
@@ -103,7 +103,7 @@ function EntityItemName({ name, variant }: { name: string; variant?: string }) {
         [CS.textList]: variant === "list",
       })}
     >
-      <Ellipsified>{name}</Ellipsified>
+      <Ellipsified lazy>{name}</Ellipsified>
     </h3>
   );
 }

--- a/frontend/src/metabase/components/ItemsTable/BaseItemsTable.styled.tsx
+++ b/frontend/src/metabase/components/ItemsTable/BaseItemsTable.styled.tsx
@@ -1,5 +1,5 @@
-import { css } from "@emotion/react";
 import styled from "@emotion/styled";
+import _ from "underscore";
 
 import EntityItem from "metabase/components/EntityItem";
 import IconButtonWrapper from "metabase/components/IconButtonWrapper";
@@ -40,16 +40,15 @@ export const Table = styled.table<{ isInDragLayer?: boolean }>`
 
 Table.defaultProps = { className: AdminS.ContentTable };
 
-export const hideResponsively = ({
-  hideAtContainerBreakpoint,
-  containerName,
-}: ResponsiveProps) =>
-  css`
-    ${getContainerQuery({
+export const hideResponsively = _.memoize(
+  ({ hideAtContainerBreakpoint, containerName }: ResponsiveProps) =>
+    getContainerQuery({
       hideAtContainerBreakpoint,
       containerName,
-    })}
-  `;
+    }),
+  ({ hideAtContainerBreakpoint, containerName }: ResponsiveProps) =>
+    `${hideAtContainerBreakpoint}-${containerName}`,
+);
 
 export const ColumnHeader = styled.th<ResponsiveProps>`
   th& {

--- a/frontend/src/metabase/core/components/Ellipsified/Ellipsified.tsx
+++ b/frontend/src/metabase/core/components/Ellipsified/Ellipsified.tsx
@@ -6,7 +6,7 @@ import { useIsTruncated } from "metabase/hooks/use-is-truncated";
 
 import { EllipsifiedRoot } from "./Ellipsified.styled";
 
-interface EllipsifiedProps {
+export interface EllipsifiedProps {
   style?: CSSProperties;
   className?: string;
   showTooltip?: boolean;
@@ -18,6 +18,8 @@ interface EllipsifiedProps {
   placement?: Placement;
   "data-testid"?: string;
   id?: string;
+  /** Evaluate truncation lazily for the sake of performance? */
+  lazy?: boolean;
 }
 
 export const Ellipsified = ({
@@ -32,10 +34,12 @@ export const Ellipsified = ({
   placement = "top",
   "data-testid": dataTestId,
   id,
+  lazy = false,
 }: EllipsifiedProps) => {
   const canSkipTooltipRendering = !showTooltip && !alwaysShowTooltip;
   const { isTruncated, ref } = useIsTruncated<HTMLDivElement>({
     disabled: canSkipTooltipRendering,
+    lazy,
   });
 
   return (


### PR DESCRIPTION
This branch explores various methods for improving the performance of the Browse models table - specifically speeding up the initial page load, sorting, and resizing:
- rendering the first 30 rows right away and the others lazily - this makes the page load and sort very fast
- deprioritizing the work done in the truncation hooks that support the tooltips - this helps make resizing smoother
- memoizing the call to emotion's css function - this speeds up the page load
- optimizing the sort function

Closes #43014 