### PR TITLE
docs - app db note

### DIFF
--- a/docs/installation-and-operation/backing-up-metabase-application-data.md
+++ b/docs/installation-and-operation/backing-up-metabase-application-data.md
@@ -43,8 +43,8 @@ Amazon has its own best practices on how to backup and restore RDS databases, so
 
 Instructions can be found in the [Amazon RDS User Guide](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithAutomatedBackups.html).
 
-## Self-hosted PostgreSQL or MySQL database
+## Self-hosted PostgreSQL database
 
-If you're hosting your own PostgreSQL or MySQL/MariaDB database, simply follow the same instructions you would use for making any normal database backup. For example, if you're using PostgreSQL for your application database, you should follow PostgreSQL's instructions for [backing up your database](https://www.postgresql.org/docs/current/backup.html).
+If you're hosting your own PostgreSQL database, simply follow PostgreSQL's instructions for [backing up your database](https://www.postgresql.org/docs/current/backup.html).
 
 As long as you have a dump of the Metabase database, you should be good to go.

--- a/docs/installation-and-operation/configuring-application-database.md
+++ b/docs/installation-and-operation/configuring-application-database.md
@@ -20,7 +20,7 @@ data needed to run the application. The default settings use an embedded H2 data
 
 ## [H2](https://www.h2database.com/) (default)
 
-> **For production installations of Metabase we recommend that users [replace the H2 database with PostgreSQL](./migrating-from-h2.md)**. Postgres offers a greater degree of performance and reliability when Metabase is running with many users.
+> **For production installations of Metabase we recommend that people [replace the H2 database with PostgreSQL](./migrating-from-h2.md)**. Postgres offers a greater degree of performance and reliability when Metabase is running with many users.
 
 To use the H2 database for your Metabase instance you don't need to do anything at all. When the application is first launched it will attempt to create a new H2 database in the same filesystem location the application is launched from.
 

--- a/docs/installation-and-operation/configuring-application-database.md
+++ b/docs/installation-and-operation/configuring-application-database.md
@@ -12,16 +12,15 @@ data needed to run the application. The default settings use an embedded H2 data
 ## Notes
 
 - Using Metabase with an H2 application database is not recommended for production deployments. For production
-  deployments, we highly recommend using Postgres, MySQL, or MariaDB instead. If you decide to continue to use H2,
-  please be sure to back up the database file regularly.
+  deployments, we highly recommend using PostgreSQL. If you decide to continue to use H2, please be sure to back up the database file regularly.
 - You cannot change the application database while the application is running. Connection configuration information is
   read only once when the application starts up and will remain constant throughout the running of the application.
-- Metabase provides limited support for migrating from H2 to Postgres or MySQL if you decide to upgrade to a more
-  production-ready database. See [Migrating from H2 to MySQL or Postgres](migrating-from-h2.md) for more details.
+- Metabase provides limited support for migrating from H2 to Postgres if you decide to upgrade to a more
+  production-ready database. See [Migrating from H2 to PostgreSQL](migrating-from-h2.md) for more details.
 
 ## [H2](https://www.h2database.com/) (default)
 
-**For production installations of Metabase we recommend that users [replace the H2 database with a more robust option](./migrating-from-h2.md) such as Postgres.** This offers a greater degree of performance and reliability when Metabase is running with many users.
+> **For production installations of Metabase we recommend that users [replace the H2 database with PostgreSQL](./migrating-from-h2.md)**. Postgres offers a greater degree of performance and reliability when Metabase is running with many users.
 
 To use the H2 database for your Metabase instance you don't need to do anything at all. When the application is first launched it will attempt to create a new H2 database in the same filesystem location the application is launched from.
 
@@ -118,7 +117,7 @@ see the [PostgreSQL SSL client documentation](https://jdbc.postgresql.org/docume
 
 ## [MySQL](https://www.mysql.com/) or [MariaDB](https://www.mariadb.org/)
 
-If you prefer to use MySQL or MariaDB we've got you covered. The minimum recommended version is MySQL 8.0.17 or MariaDB
+We recommend PostgreSQL, but you can also use MySQL or MariaDB. The minimum recommended version is MySQL 8.0.17 or MariaDB
 10.2.2, and the `utf8mb4` character set is required. You can change the application database to use MySQL using
 environment variables like this:
 

--- a/docs/installation-and-operation/creating-RDS-database-on-AWS.md
+++ b/docs/installation-and-operation/creating-RDS-database-on-AWS.md
@@ -6,7 +6,7 @@ redirect_from:
 
 # Creating an RDS database on AWS
 
-If you want to move from using Metabase just for testing to something that is ready for the big time, you need to use either PostgreSQL or MySQL/MariaDB for you application database. Here's a high-level view of Metabase deployed with a dedicated application database.
+If you want to move from using Metabase just for testing to something that is ready for the big time, you should use PostgreSQL for your application database. Here's a high-level view of Metabase deployed with a dedicated application database.
 
 ![high level architecture diagram](images/Metabase-AWS-SI.png)
 
@@ -14,7 +14,7 @@ If you want to move from using Metabase just for testing to something that is re
 
 In AWS, enter RDS in the search box or select RDS from the dropdown button on the top left of the page. Once inside RDS, click on the **Create database** button.
 
-Select PostgreSQL or MySQL as the engine type. For this example we will choose PostgreSQL on its latest version available in AWS at the time of writing (12.4-R1).
+Select PostgreSQL as the engine type. We'll choose the latest version available in AWS at the time of writing (12.4-R1).
 
 Templates: you can leave "Production" selected, or choose any other option that better suits your needs.
 

--- a/docs/installation-and-operation/migrating-from-h2.md
+++ b/docs/installation-and-operation/migrating-from-h2.md
@@ -7,7 +7,7 @@ redirect_from:
 
 # Migrating to a production application database
 
-This page covers how to convert a Metabase that's been using the built-in application database, H2, to a production-ready instance with either PostgreSQL or MySQL/MariaDB. For more on why you should do this, check out [How to run Metabase in production](https://www.metabase.com/learn/administration/metabase-in-production).
+This page covers how to convert a Metabase that's been using the built-in application database, H2, to a production-ready instance PostgreSQL. For more on why you should use Postgres as your app DB, check out [How to run Metabase in production](https://www.metabase.com/learn/administration/metabase-in-production).
 
 If you'd rather move to Metabase Cloud, check out [Migrate to Metabase Cloud](https://www.metabase.com/docs/latest/cloud/migrate/guide).
 
@@ -29,11 +29,11 @@ You could also choose to run Metabase on a [Metabase Cloud](https://www.metabase
 
 ## Supported databases for storing your Metabase application data
 
-- [PostgreSQL](https://www.postgresql.org/). Minimum version: `9.5`.
+We recommend using PostgreSQL for your application database.
+
+- [PostgreSQL](https://www.postgresql.org/). Minimum version: `9.5`. Postgres is our preferred choice for Metabase's application database.
 - [MySQL](https://www.mysql.com/). Minimum version: `8.0.17`. Required settings (which are the default): `utf8mb4_unicode_ci` collation, `utf8mb4` character set, and `innodb_large_prefix=ON`.
 - [MariaDB](https://mariadb.org/). Minimum version: `10.4.0`. Required settings (which are the default): `utf8mb4_unicode_ci` collation, `utf8mb4` character set, and `innodb_large_prefix=ON`.
-
-Go with whichever database you're familiar with. If you're not familiar with any of these, or not sure which to pick, go with Postgres.
 
 ## JAR: How to migrate from H2 to your production application database
 
@@ -49,7 +49,7 @@ Metabase provides a custom migration command for migrating to a new application 
 
 ### 1. Confirm that you can connect to your target application database
 
-You must be able to connect to the target Postgres or MySQL/MariaDB database in whatever environment you're running this migration command in. So, if you're attempting to move the data to a cloud database, make sure you can connect to that database.
+You must be able to connect to the target application database in whatever environment you're running this migration command in. So, if you're attempting to move the data to a cloud database, make sure you can connect to that database.
 
 ### 2. Shut down your Metabase instance
 
@@ -63,7 +63,7 @@ Safety first! See [Backing up Metabase Application Data](backing-up-metabase-app
 
 Run the migration command, `load-from-h2`, using the appropriate [environment variables](../configuring-metabase/environment-variables.md) for the target database you want to migrate to.
 
-You can find details about specifying MySQL and Postgres databases at [Configuring the application database](configuring-application-database.md).
+You can find details about specifying databases at [Configuring the application database](configuring-application-database.md).
 
 Here's an example command for migrating to a Postgres database:
 
@@ -111,7 +111,7 @@ Metabase provides a custom migration command for migrating to a new application 
 
 ### 1. Confirm that you can connect to your target application database
 
-You must be able to connect to the target Postgres or MySQL/MariaDB database in whatever environment you're running this migration command in. So, if you're attempting to move the data to a cloud database, make sure you can connect to that database.
+You must be able to connect to the target application database in whatever environment you're running this migration command in. So, if you're attempting to move the data to a cloud database, make sure you can connect to that database.
 
 ### 2. Back up your H2 application database
 
@@ -143,7 +143,7 @@ java -jar metabase.jar load-from-h2 /path/to/metabase.db # do not include .mv.db
 
 Metabase will start up, perform the migration (meaning, it'll take the data from the H2 file and put it into your new app db, in this a Postgres db), and then exit.
 
-You can find details about specifying MySQL and Postgres databases at [Configuring the application database](configuring-application-database.md).
+See [Configuring the application database](configuring-application-database.md).
 
 ### 5. Start a new Docker container that uses the new app db
 


### PR DESCRIPTION
Encourage people who are self-hosting Metabase to use PostgreSQL for their application database.