### PR TITLE
Support importing testing utilities in SDK builds

### DIFF
--- a/tsconfig.sdk.json
+++ b/tsconfig.sdk.json
@@ -5,7 +5,12 @@
     "emitDeclarationOnly": true,
     "outDir": "./resources/embedding-sdk/dist",
     "paths": {
-      "*": ["./frontend/src/*", "./enterprise/frontend/src/*"],
+      "*": [
+        "./frontend/src/*",
+        "./frontend/test/*",
+        "./enterprise/frontend/src/*",
+        "./enterprise/frontend/test/*"
+      ],
       "cljs/*": ["./target/cljs_release/*"]
     }
   },


### PR DESCRIPTION
The embedding SDK build is failing in `master` due to use of `__support__/*` imports in testing utilities. This PR adds support for importing testing utilities in SDK's `tsconfig.sdk.json` - this uses the same value as `tsconfig.json` in our main app.

## How to test
- Run `yarn build-embedding-sdk:watch`. The type checking step should no longer fail with errors related to importing `__support__`.