### PR TITLE
Use github automation user PAT on CI

### DIFF
--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -11,11 +11,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: tibdex/github-app-token@v2.1.0
-        id: generate-token
-        with:
-          app_id: ${{ secrets.METABASE_BOT_APP_ID }}
-          private_key: ${{ secrets.METABASE_BOT_APP_PRIVATE_KEY }}
+          token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
       - uses: ./.github/actions/find-squashed-commit
         name: Find commit
         id: find_commit
@@ -82,7 +78,7 @@ jobs:
           TARGET_BRANCH: ${{ steps.get_latest_release_branch.outputs.branch-name }}
           ORIGINAL_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
           ORIGINAL_TITLE: ${{ github.event.pull_request.title }}
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
           COMMIT: ${{ steps.find_commit.outputs.commit }}
 
       - name: Auto approve backport PR

--- a/.github/workflows/loki-update.yml
+++ b/.github/workflows/loki-update.yml
@@ -12,6 +12,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
         with:
+          token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
           ref: ${{ github.head_ref }}
 
       - name: Prepare frontend environment
@@ -44,25 +45,19 @@ jobs:
       - name: Update Loki Snapshots
         run: yarn test-visual:loki-update
 
-      - uses: tibdex/github-app-token@v2.1.0
-        id: generate-token
-        with:
-          app_id: ${{ secrets.METABASE_BOT_APP_ID }}
-          private_key: ${{ secrets.METABASE_BOT_APP_PRIVATE_KEY }}
-
       - name: Commit and Push Changes
         run: |
-          git config --global user.name "Metabase bot"
-          git config --global user.email "metabase-bot@metabase.com"
+          git config --global user.name "Metabase Automation"
+          git config --global user.email "github-automation@metabase.com"
           git add .loki/**
           git commit -m "Update Loki Snapshots"
           git push
         env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
       - name: Remove 'loki-update' label
         uses: actions/github-script@v3
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{secrets.METABASE_AUTOMATION_USER_TOKEN}}
           script: |
             github.issues.removeLabel({
               issue_number: context.issue.number,


### PR DESCRIPTION
The CLA bot was not happy with commits created by our bot user. Recently, we created a separate github-automation user which have signed CLA. `METABASE_AUTOMATION_USER_TOKEN` secret contains PAT of this user.

As you can see, its commit passed CLA check and triggered CI jobs:
<img width="939" alt="Screenshot 2024-05-28 at 4 24 26 PM" src="https://github.com/metabase/metabase/assets/14301985/4be1089a-d715-46b8-b62e-cfdf8ca3d3d8">
