### PR TITLE
[drivers] Enable `:regex` feature for MySQL (and MariaDB)

### DIFF
--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -64,7 +64,6 @@
                               :now                                    true
                               :percentile-aggregations                false
                               :persist-models                         true
-                              :regex                                  false
                               :schemas                                false
                               :uploads                                true
                               ;; MySQL doesn't let you have lag/lead in the same part of a query as a `GROUP BY`; to


### PR DESCRIPTION
These databases previously had impoverished support for regular
expressions. The `:regex` driver feature requires advanced,
"Perl-compatible" regular expressions that can do things like lookahead
assertions.

- MySQL supports this from 8.0.4; we recommend 8.0.33+.
- MariaDB supports this from 10.0.5; we recommend 10.4+.

Fixes #43180.

