### PR TITLE
[QP] Drop last stage aggregations for questions in chain filtering

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/reproductions/43154-model-parameter-target.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/43154-model-parameter-target.cy.spec.js
@@ -64,7 +64,7 @@ describe("issue 43154", () => {
     verifyNestedFilter(questionDetails);
   });
 
-  it.skip("should be able to see field values with a model-based question with aggregation (metabase#43154)", () => {
+  it("should be able to see field values with a model-based question with aggregation (metabase#43154)", () => {
     verifyNestedFilter(questionWithAggregationDetails);
   });
 });

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -443,6 +443,7 @@
   (t2.with-temp/with-temp
     [:model/Card {card-id :id} {:name          "Card"
                                 :display       "line"
+                                :dataset_query (mt/mbql-query venues)
                                 :collection_id (t2/select-one-pk Collection :personal_owner_id (mt/user->id :crowberto))}]
     (is (= "You don't have permissions to do that."
            (mt/user-http-request :rasta :get 403 (format "card/%d/series" card-id))))
@@ -3163,16 +3164,13 @@
   (testing "getting values"
     (with-card-param-values-fixtures [{:keys [card param-keys]}]
       (testing "GET /api/card/:card-id/params/:param-key/values"
-        (is (=? {:values          [["Brite Spot Family Restaurant"]
-                                   ["Red Medicine"]
-                                   ["Stout Burgers & Beers"]
-                                   ["The Apple Pan"]
-                                   ["Wurstküche"]]
+        (is (=? {:values          [["20th Century Cafe"] ["25°"] ["33 Taps"]
+                                   ["800 Degrees Neapolitan Pizzeria"] ["BCD Tofu House"]]
                  :has_more_values false}
                 (mt/user-http-request :rasta :get 200 (param-values-url card (:card param-keys))))))
 
       (testing "GET /api/card/:card-id/params/:param-key/search/:query"
-        (is (= {:values          [["Red Medicine"]]
+        (is (= {:values          [["Fred 62"] ["Red Medicine"]]
                 :has_more_values false}
                (mt/user-http-request :rasta :get 200 (param-values-url card (:card param-keys) "red"))))))))
 

--- a/test/metabase/api/embed_test.clj
+++ b/test/metabase/api/embed_test.clj
@@ -1052,13 +1052,13 @@
                      response))))
           (testing "card based param"
             (let [response (dropdown card (:card param-keys))]
-              (is (= {:values          [["Brite Spot Family Restaurant"] ["Red Medicine"]
-                                        ["Stout Burgers & Beers"] ["The Apple Pan"] ["Wurstküche"]]
+              (is (= {:values          [["20th Century Cafe"] ["25°"] ["33 Taps"]
+                                        ["800 Degrees Neapolitan Pizzeria"] ["BCD Tofu House"]]
                       :has_more_values false}
                      response)))
             (let [response (search card (:card param-keys) "red")]
               (is (= {:has_more_values false,
-                      :values          [["Red Medicine"]]}
+                      :values          [["Fred 62"] ["Red Medicine"]]}
                      response)))))))))
 
 ;;; ----------------------------- GET /api/embed/dashboard/:token/field/:field/values nil -----------------------------

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -1416,7 +1416,7 @@
             (testing "parameter with source is card"
               (is (= {:values          [["African"]]
                       :has_more_values false}
-                     (client/client :get 200 (param-values-url :dashboard uuid (:card param-keys) "af")))))
+                     (client/client :get 200 (param-values-url :dashboard uuid (:card param-keys) "afr")))))
 
             (testing "parameter with source is a chain filter"
               (is (= {:values          [["Fast Food"] ["Food Truck"] ["Seafood"]]
@@ -1441,8 +1441,8 @@
                      (client/client :get 200 (param-values-url :card card-uuid (:static-list param-keys))))))
 
             (testing "parameter with source is a card"
-              (is (= {:values          [["Brite Spot Family Restaurant"] ["Red Medicine"]
-                                        ["Stout Burgers & Beers"] ["The Apple Pan"] ["Wurstküche"]]
+              (is (= {:values          [["20th Century Cafe"] ["25°"] ["33 Taps"]
+                                        ["800 Degrees Neapolitan Pizzeria"] ["BCD Tofu House"]]
                       :has_more_values false}
                      (client/client :get 200 (param-values-url :card card-uuid (:card param-keys))))))
 
@@ -1463,7 +1463,7 @@
                      (client/client :get 200 (param-values-url :card card-uuid (:static-list param-keys) "af")))))
 
             (testing "parameter with source is a card"
-              (is (= {:values          [["Red Medicine"]]
+              (is (= {:values          [["Fred 62"] ["Red Medicine"]]
                       :has_more_values false}
                      (client/client :get 200 (param-values-url :card card-uuid (:card param-keys) "red")))))
 
@@ -1512,17 +1512,17 @@
                           :has_more_values false}
                          (client/client :get 200 (param-values-url :card uuid (:static-list param-keys)))))
 
-                  (is (= {:values          [["Brite Spot Family Restaurant"] ["Red Medicine"]
-                                            ["Stout Burgers & Beers"] ["The Apple Pan"] ["Wurstküche"]]
+                  (is (= {:values          [["20th Century Cafe"] ["25°"] ["33 Taps"]
+                                            ["800 Degrees Neapolitan Pizzeria"] ["BCD Tofu House"]]
                           :has_more_values false}
                          (client/client :get 200 (param-values-url :card uuid (:card param-keys))))))
 
                 (testing "GET /api/public/card/:uuid/params/:param-key/search/:query"
                   (is (= {:values          [["African"]]
                           :has_more_values false}
-                         (client/client :get 200 (param-values-url :card uuid (:static-list param-keys) "af"))))
+                         (client/client :get 200 (param-values-url :card uuid (:static-list param-keys) "afr"))))
 
-                  (is (= {:values          [["Red Medicine"]]
+                  (is (= {:values          [["Fred 62"] ["Red Medicine"]]
                           :has_more_values false}
                          (client/client :get 200 (param-values-url :card uuid (:card param-keys) "red")))))))))))))
 

--- a/test/metabase/models/params/custom_values_test.clj
+++ b/test/metabase/models/params/custom_values_test.clj
@@ -34,44 +34,68 @@
                       "bakery"))))))))))
 
 (deftest ^:parallel with-mbql-card-test-2
-  (doseq [model? [true false]]
-    (testing (format "source card is a %s" (if model? "model" "question"))
-      (binding [custom-values/*max-rows* 3]
-        (testing "has aggregation column"
-          (mt/with-temp
-            [Card {card-id :id} (merge (mt/card-with-source-metadata-for-query
-                                        (mt/mbql-query venues
-                                                       {:aggregation [[:sum $venues.price]]
-                                                        :breakout    [[:field %categories.name {:source-field %venues.category_id}]]}))
-                                       {:database_id     (mt/id)
-                                        :type            (if model? :model :question)
-                                        :table_id        (mt/id :venues)})]
-            (testing "get values from breakout columns"
-              (is (= {:has_more_values true
-                      :values          [["American"] ["Artisan"] ["Asian"]]}
-                     (custom-values/values-from-card
-                      (t2/select-one Card :id card-id)
-                      (mt/$ids $categories.name)))))
-            (testing "get values from aggregation column"
-              (is (= {:has_more_values true
-                      :values          [[1] [2] [3]]}
-                     (custom-values/values-from-card
-                      (t2/select-one Card :id card-id)
-                      [:field "sum" {:base-type :type/Float}]))))
-            (testing "can search on aggregation column"
-              (is (= {:has_more_values false
-                      :values          [[2]]}
-                     (custom-values/values-from-card
-                      (t2/select-one Card :id card-id)
-                      [:field "sum" {:base-type :type/Float}]
-                      2))))
-            (testing "doing case in-sensitve search on breakout columns"
-              (is (= {:has_more_values false
-                      :values          [["Bakery"]]}
-                     (custom-values/values-from-card
-                      (t2/select-one Card :id card-id)
-                      [:field (mt/id :categories :name) {:source-field (mt/id :venues :category_id)}]
-                      "bakery"))))))))))
+  (testing "source card is a model" ; Models are opaque, so this sees the post-aggregation columns.
+    (binding [custom-values/*max-rows* 3]
+      (testing "has aggregation column"
+        (mt/with-temp
+          [Card {card-id :id} (merge (mt/card-with-source-metadata-for-query
+                                       (mt/mbql-query venues
+                                                      {:aggregation [[:sum $venues.price]]
+                                                       :breakout    [[:field %categories.name {:source-field %venues.category_id}]]}))
+                                     {:database_id     (mt/id)
+                                      :type            :model
+                                      :table_id        (mt/id :venues)})]
+          (testing "get values from breakout columns"
+            (is (= {:has_more_values true
+                    :values          [["American"] ["Artisan"] ["Asian"]]}
+                   (custom-values/values-from-card
+                     (t2/select-one Card :id card-id)
+                     [:field "NAME" {:base-type :type/Text}]))))
+          (testing "get values from aggregation column"
+            (is (= {:has_more_values true
+                    :values          [[1] [2] [3]]}
+                   (custom-values/values-from-card
+                     (t2/select-one Card :id card-id)
+                     [:field "sum" {:base-type :type/Float}]))))
+          (testing "can search on aggregation column"
+            (is (= {:has_more_values false
+                    :values          [[2]]}
+                   (custom-values/values-from-card
+                     (t2/select-one Card :id card-id)
+                     [:field "sum" {:base-type :type/Float}]
+                     2))))
+          (testing "doing case in-sensitve search on breakout columns"
+            (is (= {:has_more_values false
+                    :values          [["Bakery"]]}
+                   (custom-values/values-from-card
+                     (t2/select-one Card :id card-id)
+                     [:field "NAME" {:base-type :type/Text}]
+                     "bakery"))))))))
+
+  (testing "source card is a question" ; Questions are transparent, so this can drop the aggregations and filter the original.
+    (binding [custom-values/*max-rows* 3]
+      (testing "has aggregation column"
+        (mt/with-temp
+          [Card {card-id :id} (merge (mt/card-with-source-metadata-for-query
+                                       (mt/mbql-query venues
+                                                      {:aggregation [[:sum $venues.price]]
+                                                       :breakout    [[:field %categories.name {:source-field %venues.category_id}]]}))
+                                     {:database_id     (mt/id)
+                                      :type            :question
+                                      :table_id        (mt/id :venues)})]
+          (testing "get values from breakout columns"
+            (is (= {:has_more_values true
+                    :values          [["American"] ["Artisan"] ["Asian"]]}
+                   (custom-values/values-from-card
+                     (t2/select-one Card :id card-id)
+                     [:field (mt/id :categories :name) {:source-field (mt/id :venues :category_id)}]))))
+          (testing "doing case in-sensitve search on breakout columns"
+            (is (= {:has_more_values false
+                    :values          [["Bakery"]]}
+                   (custom-values/values-from-card
+                     (t2/select-one Card :id card-id)
+                     [:field (mt/id :categories :name) {:source-field (mt/id :venues :category_id)}]
+                     "bakery")))))))))
 
 (deftest ^:parallel with-mbql-card-test-3
   (doseq [model? [true false]]


### PR DESCRIPTION
Models are treated as opaque here, but for a saved question we expose
filters on the query before its final aggregation step.

This drops the aggregation clauses and gets the possible values for the
column of interest.

Fixes #43154.

