### PR TITLE
[Browse] Don't show filter icon when no models have been verified

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/content_verification/ModelFilterControls.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/content_verification/ModelFilterControls.tsx
@@ -47,7 +47,7 @@ export const ModelFilterControls = ({
             <Text
               align="end"
               weight="bold"
-            >{t`Only show verified models`}</Text>
+            >{t`Show verified models only`}</Text>
           }
           role="switch"
           checked={checked}

--- a/frontend/src/metabase/browse/components/BrowseModels.tsx
+++ b/frontend/src/metabase/browse/components/BrowseModels.tsx
@@ -9,7 +9,6 @@ import { PLUGIN_CONTENT_VERIFICATION } from "metabase/plugins";
 import { Box, Flex, Group, Icon, Stack, Title } from "metabase/ui";
 import type { ModelResult, SearchRequest } from "metabase-types/api";
 
-import type { ActualModelFilters } from "../utils";
 import { filterModels } from "../utils";
 
 import {
@@ -28,6 +27,29 @@ const { availableModelFilters, useModelFilterSettings, ModelFilterControls } =
 export const BrowseModels = () => {
   const [actualModelFilters, setActualModelFilters] = useModelFilterSettings();
 
+  const query: SearchRequest = {
+    models: ["dataset"], // 'model' in the sense of 'type of thing'
+    model_ancestors: true,
+    filter_items_in_personal_collection: "exclude",
+  };
+  const result = useSearchQuery(query);
+
+  const { allModels, doVerifiedModelsExist } = useMemo(() => {
+    const allModels = (result.data?.data as ModelResult[] | undefined) ?? [];
+    const doVerifiedModelsExist = allModels.some(
+      model => model.moderated_status === "verified",
+    );
+    return { allModels, doVerifiedModelsExist };
+  }, [result]);
+
+  const { filteredModels } = useMemo(() => {
+    // If no models are verified, don't filter them
+    const filteredModels = doVerifiedModelsExist
+      ? filterModels(allModels, actualModelFilters, availableModelFilters)
+      : allModels;
+    return { filteredModels };
+  }, [allModels, actualModelFilters, doVerifiedModelsExist]);
+
   return (
     <BrowseContainer>
       <BrowseHeader>
@@ -45,16 +67,18 @@ export const BrowseModels = () => {
                 {t`Models`}
               </Group>
             </Title>
-            <ModelFilterControls
-              actualModelFilters={actualModelFilters}
-              setActualModelFilters={setActualModelFilters}
-            />
+            {doVerifiedModelsExist && (
+              <ModelFilterControls
+                actualModelFilters={actualModelFilters}
+                setActualModelFilters={setActualModelFilters}
+              />
+            )}
           </Flex>
         </BrowseSection>
       </BrowseHeader>
       <BrowseMain>
         <BrowseSection>
-          <BrowseModelsBody actualModelFilters={actualModelFilters} />
+          <BrowseModelsBody result={result} models={filteredModels} />
         </BrowseSection>
       </BrowseMain>
     </BrowseContainer>
@@ -62,44 +86,27 @@ export const BrowseModels = () => {
 };
 
 export const BrowseModelsBody = ({
-  actualModelFilters,
+  models,
+  result,
 }: {
-  /** Mapping of filter names to true if the filter is active
-   * or false if it is inactive */
-  actualModelFilters: ActualModelFilters;
+  models: ModelResult[];
+  result: { error?: any; isLoading: boolean };
 }) => {
-  const query: SearchRequest = {
-    models: ["dataset"], // 'model' in the sense of 'type of thing'
-    model_ancestors: true,
-    filter_items_in_personal_collection: "exclude",
-  };
-  const { data, error, isLoading } = useSearchQuery(query);
-
-  const filteredModels = useMemo(() => {
-    const unfilteredModels = (data?.data as ModelResult[]) ?? [];
-    const filteredModels = filterModels(
-      unfilteredModels,
-      actualModelFilters,
-      availableModelFilters,
-    );
-    return filteredModels;
-  }, [data, actualModelFilters]);
-
-  if (error || isLoading) {
+  if (result.error || result.isLoading) {
     return (
       <LoadingAndErrorWrapper
-        error={error}
-        loading={isLoading}
+        error={result.error}
+        loading={result.isLoading}
         style={{ flex: 1 }}
       />
     );
   }
 
-  if (filteredModels.length) {
+  if (models.length) {
     return (
       <Stack mb="lg" spacing="md">
         <ModelExplanationBanner />
-        <ModelsTable models={filteredModels} />
+        <ModelsTable models={models} />
       </Stack>
     );
   }

--- a/frontend/src/metabase/browse/components/ModelsTable.tsx
+++ b/frontend/src/metabase/browse/components/ModelsTable.tsx
@@ -245,8 +245,12 @@ const NameCell = ({
   icon: IconProps;
 }) => {
   const { id, name } = model;
+  const headingId = `model-${id}-heading`;
   return (
-    <ItemNameCell data-testid={`${testIdPrefix}-name`}>
+    <ItemNameCell
+      data-testid={`${testIdPrefix}-name`}
+      aria-labelledby={headingId}
+    >
       <ItemLink
         to={Urls.model({ id, name })}
         onClick={onClick}
@@ -262,7 +266,7 @@ const NameCell = ({
           color={color("brand")}
           style={{ flexShrink: 0 }}
         />
-        <EntityItem.Name name={model.name} variant="list" />
+        <EntityItem.Name name={model.name} variant="list" id={headingId} />
       </ItemLink>
     </ItemNameCell>
   );

--- a/frontend/src/metabase/components/EntityItem/EntityItem.tsx
+++ b/frontend/src/metabase/components/EntityItem/EntityItem.tsx
@@ -96,12 +96,20 @@ const EntityIconCheckBox = ({
   );
 };
 
-function EntityItemName({ name, variant }: { name: string; variant?: string }) {
+function EntityItemName({
+  name,
+  variant,
+  ...props
+}: {
+  name: string;
+  variant?: string;
+} & React.HTMLAttributes<HTMLHeadingElement>) {
   return (
     <h3
       className={cx(CS.overflowHidden, {
         [CS.textList]: variant === "list",
       })}
+      {...props}
     >
       <Ellipsified>{name}</Ellipsified>
     </h3>


### PR DESCRIPTION
On the Browse models page we have a filter icon which opens a popover with a switch that toggles "Show only verified models". On this branch, the icon is not rendered if there are no verified models at all.

Closes https://github.com/metabase/metabase/issues/43262.