### PR TITLE
[Browse] Show Browse models link in nav only when there are models

### DIFF
--- a/frontend/src/metabase/browse/components/BrowseModels.tsx
+++ b/frontend/src/metabase/browse/components/BrowseModels.tsx
@@ -2,12 +2,12 @@ import { useMemo } from "react";
 import { t } from "ttag";
 
 import NoResults from "assets/img/no_results.svg";
-import { useSearchQuery } from "metabase/api";
+import { useFetchModels } from "metabase/common/hooks/use-fetch-models";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import { color } from "metabase/lib/colors";
 import { PLUGIN_CONTENT_VERIFICATION } from "metabase/plugins";
 import { Box, Flex, Group, Icon, Stack, Title } from "metabase/ui";
-import type { ModelResult, SearchRequest } from "metabase-types/api";
+import type { ModelResult } from "metabase-types/api";
 
 import { filterModels } from "../utils";
 
@@ -27,12 +27,7 @@ const { availableModelFilters, useModelFilterSettings, ModelFilterControls } =
 export const BrowseModels = () => {
   const [actualModelFilters, setActualModelFilters] = useModelFilterSettings();
 
-  const query: SearchRequest = {
-    models: ["dataset"], // 'model' in the sense of 'type of thing'
-    model_ancestors: true,
-    filter_items_in_personal_collection: "exclude",
-  };
-  const result = useSearchQuery(query);
+  const result = useFetchModels({ model_ancestors: true });
 
   const { allModels, doVerifiedModelsExist } = useMemo(() => {
     const allModels = (result.data?.data as ModelResult[] | undefined) ?? [];

--- a/frontend/src/metabase/browse/test-utils.ts
+++ b/frontend/src/metabase/browse/test-utils.ts
@@ -2,6 +2,6 @@ import type { ModelResult } from "metabase-types/api";
 import { createMockSearchResult } from "metabase-types/api/mocks";
 
 export const createMockModelResult = (
-  model: Partial<ModelResult>,
+  model: Partial<ModelResult> = {},
 ): ModelResult =>
   createMockSearchResult({ ...model, model: "dataset" }) as ModelResult;

--- a/frontend/src/metabase/common/hooks/use-fetch-models.tsx
+++ b/frontend/src/metabase/common/hooks/use-fetch-models.tsx
@@ -1,0 +1,12 @@
+import { useSearchQuery } from "metabase/api";
+import type { SearchRequest } from "metabase-types/api";
+
+export const useFetchModels = (req: Partial<SearchRequest> = {}) => {
+  const modelsResult = useSearchQuery({
+    models: ["dataset"], // 'model' in the sense of 'type of thing'
+    filter_items_in_personal_collection: "exclude",
+    model_ancestors: false,
+    ...req,
+  });
+  return modelsResult;
+};

--- a/frontend/src/metabase/common/hooks/use-has-models.tsx
+++ b/frontend/src/metabase/common/hooks/use-has-models.tsx
@@ -1,0 +1,18 @@
+import type { SearchRequest } from "metabase-types/api";
+
+import { useFetchModels } from "./use-fetch-models";
+
+/** NOTE: hasModels is undefined when the request is pending */
+export const useHasModels = (req: Partial<SearchRequest> = {}) => {
+  const modelsResult = useFetchModels({
+    limit: 1,
+    model_ancestors: false,
+    ...req,
+  });
+  const modelsLength = modelsResult.data?.data.length;
+  return {
+    hasModels: modelsLength === undefined ? undefined : modelsLength !== 0,
+    isLoading: modelsResult.isLoading,
+    error: modelsResult.error,
+  };
+};

--- a/frontend/src/metabase/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper.tsx
+++ b/frontend/src/metabase/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper.tsx
@@ -9,6 +9,8 @@ export type LoadingAndErrorWrapperProps = {
   className?: string;
   error: any;
   loading: any;
+  /** Component that indicates that data is loading, for example a spinner */
+  loader?: ReactNode;
   noBackground?: boolean;
   noWrapper?: boolean;
   children?: ReactNode;
@@ -30,6 +32,7 @@ export const DelayedLoadingAndErrorWrapper = ({
   loading,
   delay = 300,
   blankComponent = null,
+  loader,
   children,
   ...props
 }: {
@@ -37,7 +40,8 @@ export const DelayedLoadingAndErrorWrapper = ({
   /** This is shown during the delay if `loading` is true */
   blankComponent?: ReactNode;
 } & LoadingAndErrorWrapperProps) => {
-  const [showWrapper, setShowWrapper] = useState(false);
+  // If delay is zero show the wrapper immediately. Otherwise, apply a timeout
+  const [showWrapper, setShowWrapper] = useState(delay === 0);
 
   props.loadingMessages ??= [];
 
@@ -63,9 +67,11 @@ export const DelayedLoadingAndErrorWrapper = ({
     >
       {styles => (
         <div style={styles}>
-          <LoadingAndErrorWrapper error={error} loading={loading} {...props}>
-            {children}
-          </LoadingAndErrorWrapper>
+          {loader ?? (
+            <LoadingAndErrorWrapper error={error} loading={loading} {...props}>
+              {children}
+            </LoadingAndErrorWrapper>
+          )}
         </div>
       )}
     </Transition>

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.unit.spec.tsx
@@ -5,6 +5,7 @@ import {
   setupCardsEndpoints,
   setupCollectionsEndpoints,
   setupDatabasesEndpoints,
+  setupSearchEndpoints,
 } from "__support__/server-mocks";
 import { createMockEntitiesState } from "__support__/store";
 import {
@@ -13,9 +14,16 @@ import {
   waitForLoaderToBeRemoved,
   within,
 } from "__support__/ui";
+import { createMockModelResult } from "metabase/browse/test-utils";
 import { ROOT_COLLECTION } from "metabase/entities/collections";
 import * as Urls from "metabase/lib/urls";
-import type { Card, Dashboard, DashboardId, User } from "metabase-types/api";
+import type {
+  Card,
+  Dashboard,
+  DashboardId,
+  ModelResult,
+  User,
+} from "metabase-types/api";
 import {
   createMockCard,
   createMockCollection,
@@ -40,6 +48,7 @@ type SetupOpts = {
   hasOwnDatabase?: boolean;
   openQuestionCard?: Card;
   openDashboard?: Dashboard;
+  models?: ModelResult[];
 };
 
 const PERSONAL_COLLECTION_BASE = createMockCollection({
@@ -73,6 +82,7 @@ async function setup({
   hasOwnDatabase = true,
   openDashboard,
   openQuestionCard,
+  models = [],
 }: SetupOpts = {}) {
   const databases = [];
   const collections = [TEST_COLLECTION];
@@ -99,6 +109,7 @@ async function setup({
 
   setupCollectionsEndpoints({ collections });
   setupDatabasesEndpoints(databases);
+  setupSearchEndpoints(models);
   fetchMock.get("path:/api/bookmark", []);
 
   if (openQuestionCard) {
@@ -219,6 +230,36 @@ describe("nav > containers > MainNavbar", () => {
       await setup({ pathname: "/browse/databases/1" });
       const listItem = screen.getByRole("listitem", {
         name: /Browse databases/i,
+      });
+      expect(listItem).toHaveAttribute("aria-selected", "true");
+    });
+  });
+
+  describe("browse models link", () => {
+    it("should render when there are models", async () => {
+      await setup({ models: [createMockModelResult()] });
+      const listItem = screen.getByRole("listitem", {
+        name: /Browse models/i,
+      });
+      const link = within(listItem).getByRole("link");
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute("href", "/browse/models");
+    });
+
+    it("should not render when there are no models", async () => {
+      await setup({ models: [] });
+      expect(
+        screen.queryByRole("listitem", { name: /Browse models/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should be highlighted if selected", async () => {
+      await setup({
+        models: [createMockModelResult()],
+        pathname: "/browse/models",
+      });
+      const listItem = screen.getByRole("listitem", {
+        name: /Browse models/i,
       });
       expect(listItem).toHaveAttribute("aria-selected", "true");
     });

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BrowseNavSection.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BrowseNavSection.tsx
@@ -1,0 +1,87 @@
+import { c, t } from "ttag";
+
+import { useUserSetting } from "metabase/common/hooks";
+import { useHasModels } from "metabase/common/hooks/use-has-models";
+import CollapseSection from "metabase/components/CollapseSection";
+import { DelayedLoadingAndErrorWrapper } from "metabase/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
+import CS from "metabase/css/core/index.css";
+import { Flex, Loader } from "metabase/ui";
+
+import { PaddedSidebarLink, SidebarHeading } from "../MainNavbar.styled";
+import type { SelectedItem } from "../types";
+
+export const BrowseNavSection = ({
+  nonEntityItem,
+  onItemSelect,
+  hasDataAccess,
+}: {
+  nonEntityItem: SelectedItem;
+  onItemSelect: () => void;
+  hasDataAccess: boolean;
+}) => {
+  const BROWSE_MODELS_URL = "/browse/models";
+  const BROWSE_DATA_URL = "/browse/databases";
+
+  const {
+    hasModels,
+    isLoading: areModelsLoading,
+    error: modelsError,
+  } = useHasModels();
+  const noModelsExist = hasModels === false;
+
+  const [expandBrowse = true, setExpandBrowse] = useUserSetting(
+    "expand-browse-in-nav",
+  );
+
+  if (noModelsExist && !hasDataAccess) {
+    return null;
+  }
+
+  return (
+    <CollapseSection
+      header={
+        <SidebarHeading>{c("A verb, shown in the sidebar")
+          .t`Browse`}</SidebarHeading>
+      }
+      initialState={expandBrowse ? "expanded" : "collapsed"}
+      iconPosition="right"
+      iconSize={8}
+      headerClass={CS.mb1}
+      onToggle={setExpandBrowse}
+    >
+      <DelayedLoadingAndErrorWrapper
+        loading={areModelsLoading}
+        error={modelsError}
+        loader={
+          <Flex py="sm" px="md" h="32.67px" align="center">
+            <Loader size={14} style={{ paddingInlineStart: "2px" }} />
+          </Flex>
+        }
+        delay={0}
+      >
+        {!noModelsExist && (
+          <PaddedSidebarLink
+            icon="model"
+            url={BROWSE_MODELS_URL}
+            isSelected={nonEntityItem?.url?.startsWith(BROWSE_MODELS_URL)}
+            onClick={onItemSelect}
+            aria-label={t`Browse models`}
+          >
+            {t`Models`}
+          </PaddedSidebarLink>
+        )}
+      </DelayedLoadingAndErrorWrapper>
+      {hasDataAccess && (
+        <PaddedSidebarLink
+          icon="database"
+          url={BROWSE_DATA_URL}
+          isSelected={nonEntityItem?.url?.startsWith(BROWSE_DATA_URL)}
+          onClick={onItemSelect}
+          aria-label={t`Browse databases`}
+        >
+          {t`Databases`}
+        </PaddedSidebarLink>
+      )}
+    </CollapseSection>
+  );
+};

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
@@ -1,14 +1,14 @@
 import { useCallback } from "react";
-import { c, t } from "ttag";
+import { t } from "ttag";
 import _ from "underscore";
 
 import { useUserSetting } from "metabase/common/hooks";
-import CollapseSection from "metabase/components/CollapseSection";
 import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
 import { Tree } from "metabase/components/tree";
-import CS from "metabase/css/core/index.css";
-import { PERSONAL_COLLECTIONS } from "metabase/entities/collections/constants";
-import { getCollectionIcon } from "metabase/entities/collections/utils";
+import {
+  getCollectionIcon,
+  PERSONAL_COLLECTIONS,
+} from "metabase/entities/collections";
 import { isSmallScreen } from "metabase/lib/dom";
 import * as Urls from "metabase/lib/urls";
 import { WhatsNewNotification } from "metabase/nav/components/WhatsNewNotification";
@@ -30,6 +30,7 @@ import { SidebarCollectionLink, SidebarLink } from "../SidebarItems";
 import type { SelectedItem } from "../types";
 
 import BookmarkList from "./BookmarkList";
+import { BrowseNavSection } from "./BrowseNavSection";
 
 interface CollectionTreeItem extends Collection {
   icon: IconName | IconProps;
@@ -55,8 +56,6 @@ type Props = {
     oldIndex: number;
   }) => void;
 };
-const BROWSE_MODELS_URL = "/browse/models";
-const BROWSE_DATA_URL = "/browse/databases";
 const OTHER_USERS_COLLECTIONS_URL = Urls.otherUsersPersonalCollections();
 const ADD_YOUR_OWN_DATA_URL = "/admin/databases/create";
 
@@ -85,9 +84,6 @@ function MainNavbarView({
     }
   }, [handleCloseNavbar]);
 
-  const [expandBrowse = true, setExpandBrowse] = useUserSetting(
-    "expand-browse-in-nav",
-  );
   const [expandBookmarks = true, setExpandBookmarks] = useUserSetting(
     "expand-bookmarks-in-nav",
   );
@@ -106,38 +102,11 @@ function MainNavbarView({
           </PaddedSidebarLink>
         </SidebarSection>
         <SidebarSection>
-          <CollapseSection
-            header={
-              <SidebarHeading>{c("A verb, shown in the sidebar")
-                .t`Browse`}</SidebarHeading>
-            }
-            initialState={expandBrowse ? "expanded" : "collapsed"}
-            iconPosition="right"
-            iconSize={8}
-            headerClass={CS.mb1}
-            onToggle={setExpandBrowse}
-          >
-            <PaddedSidebarLink
-              icon="model"
-              url={BROWSE_MODELS_URL}
-              isSelected={nonEntityItem?.url?.startsWith(BROWSE_MODELS_URL)}
-              onClick={onItemSelect}
-              aria-label={t`Browse models`}
-            >
-              {t`Models`}
-            </PaddedSidebarLink>
-            {hasDataAccess && (
-              <PaddedSidebarLink
-                icon="database"
-                url={BROWSE_DATA_URL}
-                isSelected={nonEntityItem?.url?.startsWith(BROWSE_DATA_URL)}
-                onClick={onItemSelect}
-                aria-label={t`Browse databases`}
-              >
-                {t`Databases`}
-              </PaddedSidebarLink>
-            )}
-          </CollapseSection>
+          <BrowseNavSection
+            nonEntityItem={nonEntityItem}
+            onItemSelect={onItemSelect}
+            hasDataAccess={hasDataAccess}
+          />
           {hasDataAccess && (
             <>
               {!hasOwnDatabase && isAdmin && (

--- a/frontend/src/metabase/nav/containers/Navbar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.unit.spec.tsx
@@ -6,6 +6,7 @@ import { Route } from "react-router";
 import {
   setupCollectionsEndpoints,
   setupDatabasesEndpoints,
+  setupSearchEndpoints,
 } from "__support__/server-mocks";
 import {
   renderWithProviders,
@@ -46,6 +47,7 @@ async function setup({
 }: SetupOpts = {}) {
   setupCollectionsEndpoints({ collections: [] });
   setupDatabasesEndpoints([createMockDatabase()]);
+  setupSearchEndpoints([]);
   fetchMock.get("path:/api/bookmark", []);
 
   const storeInitialState = createMockState({


### PR DESCRIPTION
When there are no models, the Browse > Models link in the nav will not appear. 

On master, if the user also has no data access, the Browse > Databases link will not appear. On this branch, if both links are hidden then the whole Browse section of the nav will not appear.

Normally the API request that checks for the existence of models will be fast, but here's an illustration of the edge case where that one request takes several seconds longer than the others to complete:

![Kapture 2024-05-28 at 23 32 14](https://github.com/metabase/metabase/assets/130925/1fd6bb24-82e8-4b5d-8ab5-cd27bc41e771)

Closes #43253

