### PR TITLE
Minor design updates to multi select

### DIFF
--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.module.css
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.module.css
@@ -1,3 +1,0 @@
-.icon {
-  fill: var(--color-text-light);
-}

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
@@ -150,7 +150,7 @@ export function MultiAutocomplete({
     }
   };
 
-  const info = (
+  const info = isFocused ? (
     <Tooltip
       label={
         <>
@@ -162,6 +162,8 @@ export function MultiAutocomplete({
     >
       <Icon name="info_filled" fill={color("text-light")} />
     </Tooltip>
+  ) : (
+    <span />
   );
 
   return (

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
@@ -188,6 +188,9 @@ export function MultiAutocomplete({
         input: {
           padding: 0,
         },
+        searchInput: {
+          marginLeft: "0.35rem",
+        },
         values: {
           padding: "0.35em",
           gap: "0.35em",

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
@@ -5,9 +5,9 @@ import type { ClipboardEvent, FocusEvent } from "react";
 import { useMemo, useState } from "react";
 import { t } from "ttag";
 
+import { color } from "metabase/lib/colors";
 import { Icon } from "metabase/ui";
 
-import styles from "./MultiAutocomplete.module.css";
 import { parseValues, unique } from "./utils";
 
 export type MultiAutocompleteProps = Omit<MultiSelectProps, "shouldCreate"> & {
@@ -160,7 +160,7 @@ export function MultiAutocomplete({
         </>
       }
     >
-      <Icon name="info_filled" className={styles.icon} />
+      <Icon name="info_filled" fill={color("text-light")} />
     </Tooltip>
   );
 

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
@@ -198,6 +198,7 @@ export function MultiAutocomplete({
           height: "2em",
           color: color("brand"),
           background: color("bg-medium"),
+          fontWeight: "bold",
         },
         defaultValueRemove: {
           color: color("brand"),

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
@@ -181,6 +181,15 @@ export function MultiAutocomplete({
       onSearchChange={handleSearchChange}
       onPaste={handlePaste}
       rightSection={info}
+      styles={{
+        defaultValue: {
+          color: color("brand"),
+          background: color("bg-medium"),
+        },
+        defaultValueRemove: {
+          color: color("brand"),
+        },
+      }}
     />
   );
 }

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
@@ -181,32 +181,6 @@ export function MultiAutocomplete({
       onSearchChange={handleSearchChange}
       onPaste={handlePaste}
       rightSection={info}
-      styles={{
-        wrapper: {
-          fontSize: "14px",
-        },
-        input: {
-          padding: 0,
-        },
-        searchInput: {
-          marginLeft: "0.35rem",
-        },
-        values: {
-          padding: "0.35em",
-          gap: "0.35em",
-          minHeight: "2.7em",
-        },
-        defaultValue: {
-          fontSize: "1em",
-          height: "2em",
-          color: color("brand"),
-          background: color("bg-medium"),
-          fontWeight: "bold",
-        },
-        defaultValueRemove: {
-          color: color("brand"),
-        },
-      }}
     />
   );
 }

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
@@ -182,7 +182,20 @@ export function MultiAutocomplete({
       onPaste={handlePaste}
       rightSection={info}
       styles={{
+        wrapper: {
+          fontSize: "14px",
+        },
+        input: {
+          padding: 0,
+        },
+        values: {
+          padding: "0.35em",
+          gap: "0.35em",
+          minHeight: "2.7em",
+        },
         defaultValue: {
+          fontSize: "1em",
+          height: "2em",
           color: color("brand"),
           background: color("bg-medium"),
         },

--- a/frontend/src/metabase/ui/components/inputs/MultiSelect/MultiSelect.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiSelect/MultiSelect.styled.tsx
@@ -12,8 +12,13 @@ import { SelectDropdown } from "../Select/SelectDropdown";
 import { SelectItem } from "../Select/SelectItem";
 
 const SIZES = {
-  xs: rem(16),
-  md: rem(24),
+  xs: rem(30),
+  md: rem(38),
+};
+
+const VALUE_SIZES = {
+  xs: rem(20),
+  md: rem(28),
 };
 
 export const getMultiSelectOverrides =
@@ -37,14 +42,24 @@ export const getMultiSelectOverrides =
         ...getSelectInputOverrides(theme),
         ...getSelectItemsOverrides(theme, size),
         values: {
+          boxSizing: "border-box",
           minHeight: getSize({ size, sizes: SIZES }),
           marginLeft: 0,
-          gap: theme.spacing.sm,
+          gap: theme.spacing.xs,
+          padding: theme.spacing.xs,
+          alignItems: "center",
+        },
+        input: {
+          padding: 0,
+          boxSizing: "border-box",
         },
         value: {
           margin: 0,
         },
         searchInput: {
+          minHeight: getSize({ size, sizes: VALUE_SIZES }),
+          padding: 0,
+          marginLeft: theme.spacing.sm,
           "&::placeholder": {
             color: invalid
               ? theme.fn.themeColor("error")
@@ -55,17 +70,17 @@ export const getMultiSelectOverrides =
           },
         },
         defaultValue: {
-          height: getSize({ size, sizes: SIZES }),
-          paddingLeft: theme.spacing.sm,
-          paddingRight: theme.spacing.sm,
-          fontWeight: "normal",
-          fontSize: theme.fontSizes.xs,
+          padding: 0,
+          paddingInline: theme.spacing.sm,
+          height: getSize({ size, sizes: VALUE_SIZES }),
+          fontWeight: "bold",
+          fontSize: getSize({ size, sizes: theme.fontSizes }),
           borderRadius: theme.radius.xs,
-          color: theme.fn.themeColor("text-dark"),
+          color: theme.fn.themeColor("brand"),
           backgroundColor: theme.fn.themeColor("bg-medium"),
         },
         defaultValueRemove: {
-          color: theme.fn.themeColor("text-dark"),
+          color: theme.fn.themeColor("brand"),
           width: rem(12),
           height: rem(12),
           minWidth: rem(12),


### PR DESCRIPTION
This PR fixes all the design feedback from [Slack](https://metaboat.slack.com/archives/C0645JP1W81/p1716938901194639?thread_ts=1716793316.573389&cid=C0645JP1W81):

> @maz: 
> - The font size in the new component’s tokens looks really small to me. I think it’s 11px instead of the expected 14px. (See screenshot)
> - I wish that the new component’s tokens had that light blue background color with brand blue text: I think it adds some nice color and personality.
> -  I saw on Stats that the info icons here on the far right are too dark — I assume they should either be text-dark to match the icon on the left, or should be light like in your second screenshot.
> - should this info-tooltip icon maybe only show up when the input has focus.

### Demo

<img width="451" alt="Screenshot 2024-05-29 at 14 26 30" src="https://github.com/metabase/metabase/assets/1250185/bf47c576-85a6-4e72-bde0-f39585022973">
