### PR TITLE
Do not use MBQL lib for parameter fields in dashboards when possible

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/reproductions/22788-flter-cc-dropped-on-second-edit.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/22788-flter-cc-dropped-on-second-edit.cy.spec.js
@@ -7,7 +7,6 @@ import {
   saveDashboard,
   sidebar,
   getDashboardCard,
-  popover,
 } from "e2e/support/helpers";
 
 const { PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;
@@ -98,16 +97,11 @@ describe("issue 22788", () => {
 
 function addFilterAndAssert() {
   filterWidget().click();
-  popover().within(() => {
-    cy.findByText("Gizmo").click();
-    cy.button("Add filter").click();
-  });
+  cy.findByPlaceholderText("Enter some text").type("Gizmo{enter}");
+  cy.button("Add filter").click();
 
-  filterWidget()
-    .findByDisplayValue("Gizmo")
-    .should("not.exist")
-    .findByDisplayValue("Doohickey")
-    .should("not.exist");
+  cy.findAllByText("Gizmo");
+  cy.findAllByText("Doohickey").should("not.exist");
 }
 
 function openFilterSettings() {

--- a/e2e/test/scenarios/dashboard-filters/reproductions/27768-cc-filter-appears-disconnected.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/27768-cc-filter-appears-disconnected.cy.spec.js
@@ -55,7 +55,7 @@ describe("issue 27768", () => {
     saveDashboard();
 
     filterWidget().click();
-    popover().findByText("Gizmo").click();
+    cy.findByPlaceholderText("Enter some text").type("Gizmo").blur();
     cy.button("Add filter").click();
 
     cy.findAllByText("Doohickey").should("not.exist");

--- a/frontend/src/metabase-lib/v1/parameters/utils/targets.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/targets.ts
@@ -88,7 +88,7 @@ export function getParameterTargetField(
 
     if (columns.length === 0) {
       // query and metadata are not available: 1) no data permissions 2) embedding
-      // we cannot correctly find a field in all cases this way
+      // there is no way to find the correct field so pick the first one
       return fieldsWithName[0];
     }
 

--- a/frontend/src/metabase-lib/v1/parameters/utils/targets.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/targets.ts
@@ -63,19 +63,21 @@ export function getParameterTargetField(
     const [_, fieldIdOrName] = fieldRef;
     const fields = metadata.fieldsList();
     if (typeof fieldIdOrName === "number") {
-      // performance optimization 1:
+      // performance optimization:
       // we can match by id directly without finding this column via query
       return fields.find(field => field.id === fieldIdOrName);
     }
 
-    const fieldsWithName = fields.filter(field => field.name === fieldIdOrName);
+    const fieldsWithName = fields.filter(
+      field => typeof field.id === "number" && field.name === fieldIdOrName,
+    );
     if (fieldsWithName.length === 0) {
-      // performance optimization 2:
+      // performance optimization:
       // if there are no matching fields, do not call MBQL lib
       return null;
     }
     if (fieldsWithName.length === 1) {
-      // performance optimization 3:
+      // performance optimization:
       // if there is exactly 1 field, assume that it's related to this query and do not call MBQL lib
       return fieldsWithName[0];
     }
@@ -87,7 +89,7 @@ export function getParameterTargetField(
     if (columns.length === 0) {
       // query and metadata are not available: 1) no data permissions 2) embedding
       // we cannot correctly find a field in all cases this way
-      return fieldsWithName[0];
+      return fields.filter(field => field.name === fieldIdOrName);
     }
 
     const [columnIndex] = Lib.findColumnIndexesFromLegacyRefs(

--- a/frontend/src/metabase-lib/v1/parameters/utils/targets.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/targets.ts
@@ -89,7 +89,7 @@ export function getParameterTargetField(
     if (columns.length === 0) {
       // query and metadata are not available: 1) no data permissions 2) embedding
       // we cannot correctly find a field in all cases this way
-      return fields.filter(field => field.name === fieldIdOrName);
+      return fieldsWithName[0];
     }
 
     const [columnIndex] = Lib.findColumnIndexesFromLegacyRefs(

--- a/frontend/src/metabase-lib/v1/parameters/utils/targets.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/targets.ts
@@ -88,7 +88,7 @@ export function getParameterTargetField(
 
     if (columns.length === 0) {
       // query and metadata are not available: 1) no data permissions 2) embedding
-      // there is no way to find the correct field so pick the first one
+      // there is no way to find the correct field so pick the first one matching by name
       return fieldsWithName[0];
     }
 

--- a/frontend/src/metabase-lib/v1/parameters/utils/targets.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/targets.ts
@@ -60,38 +60,11 @@ export function getParameterTargetField(
   }
 
   if (isConcreteFieldReference(fieldRef)) {
-    const query = question.query();
-    const stageIndex = -1;
-    const columns = Lib.visibleColumns(query, stageIndex);
-
-    if (columns.length === 0) {
-      // query and metadata are not available: 1) no data permissions 2) embedding
-      // we cannot correctly find a field in all cases this way
-      const [_, fieldIdOrName] = fieldRef;
-      const fields = metadata.fieldsList();
-      return fields.find(
-        field => field.id === fieldIdOrName || field.name === fieldIdOrName,
-      );
-    }
-
-    const [columnIndex] = Lib.findColumnIndexesFromLegacyRefs(
-      query,
-      stageIndex,
-      columns,
-      [fieldRef],
+    const [_, fieldIdOrName] = fieldRef;
+    const fields = metadata.fieldsList();
+    return fields.find(
+      field => field.id === fieldIdOrName || field.name === fieldIdOrName,
     );
-    if (columnIndex < 0) {
-      return null;
-    }
-
-    const column = columns[columnIndex];
-    const fieldValuesInfo = Lib.fieldValuesSearchInfo(query, column);
-    if (fieldValuesInfo.fieldId == null) {
-      // the column does not represent to a database field, e.g. coming from an aggregation clause
-      return null;
-    }
-
-    return metadata.field(fieldValuesInfo.fieldId);
   }
 
   return null;

--- a/frontend/src/metabase-lib/v1/parameters/utils/targets.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/targets.ts
@@ -76,7 +76,7 @@ export function getParameterTargetField(
     }
     if (fieldsWithName.length === 1) {
       // performance optimization 3:
-      // if there is exactly 1 field, assume that metadata is correct and do not call MBQL lib
+      // if there is exactly 1 field, assume that it's related to this query and do not call MBQL lib
       return fieldsWithName[0];
     }
 


### PR DESCRIPTION
We've already removed many `parameter.fields` dependencies in favour of mappings, but parameter widgets need real database fields and this cannot be removed. This PR exploits the fact that we only care about database fields and optimizes field lookup in simple cases. I expect that these checks should cover 99% real world cases.

How to verify:
- CI is green