### PR TITLE
[Browse] Unify breadcrumbs into one link

### DIFF
--- a/frontend/src/metabase/browse/components/CollectionBreadcrumbsWithTooltip.styled.tsx
+++ b/frontend/src/metabase/browse/components/CollectionBreadcrumbsWithTooltip.styled.tsx
@@ -1,18 +1,23 @@
 import styled from "@emotion/styled";
-import type { AnchorHTMLAttributes } from "react";
 
 import { ResponsiveChild } from "metabase/components/ResponsiveContainer/ResponsiveContainer";
+import Link from "metabase/core/components/Link";
 import { color } from "metabase/lib/colors";
-import type { AnchorProps } from "metabase/ui";
-import { Anchor, FixedSizeIcon, Group } from "metabase/ui";
+import { FixedSizeIcon, Flex, Group } from "metabase/ui";
 
-import type { RefProp } from "./types";
+import { Ellipsis } from "./Ellipsis";
 
-export const Breadcrumb = styled(Anchor)<
-  AnchorProps &
-    AnchorHTMLAttributes<HTMLAnchorElement> &
-    RefProp<HTMLAnchorElement>
->`
+/** When a cell is narrower than this width, breadcrumbs within it change significantly */
+const breadcrumbBreakpoint = "10rem";
+
+export const Breadcrumb = styled(ResponsiveChild)<{
+  maxWidth: string;
+  isSoleBreadcrumb: boolean;
+  index: number;
+}>`
+  ${({ maxWidth }) => {
+    return maxWidth ? `td & { max-width: ${maxWidth} };` : "";
+  }}
   color: ${color("text-dark")};
   line-height: 1;
   overflow: hidden;
@@ -20,35 +25,45 @@ export const Breadcrumb = styled(Anchor)<
   white-space: nowrap;
   padding-top: 1px;
   padding-bottom: 1px;
+  ${props => {
+    return `
+    @container ${props.containerName} (width < ${breadcrumbBreakpoint}) {
+      ${props.index === 0 && !props.isSoleBreadcrumb ? `display: none;` : ""}
+      max-width: calc(95cqw - ${props.isSoleBreadcrumb ? 1 : 3}rem) !important;
+    }`;
+  }}
+`;
+
+export const CollectionLink = styled(Link)`
   :hover {
-    color: ${color("brand")};
-    text-decoration: none;
+    &,
+    * {
+      color: var(--mb-color-brand);
+      .collection-path-separator {
+        color: var(--mb-color-brand-alpha-88);
+      }
+    }
   }
 `;
 
+export const InitialEllipsis = styled(Ellipsis)``;
+InitialEllipsis.defaultProps = {
+  includeSep: false,
+};
+
 export const CollectionBreadcrumbsWrapper = styled(ResponsiveChild)`
   line-height: 1;
+  ${InitialEllipsis} {
+    display: none;
+  }
   ${props => {
-    const breakpoint = "10rem";
     return `
-    .initial-ellipsis {
-      display: none;
-    }
-    @container ${props.containerName} (width < ${breakpoint}) {
-      .ellipsis-and-separator {
+    @container ${props.containerName} (width < ${breadcrumbBreakpoint}) {
+      ${EllipsisAndSeparator} {
         display: none;
       }
-      .initial-ellipsis {
+      ${InitialEllipsis} {
         display: inline;
-      }
-      .for-index-0:not(.sole-breadcrumb) {
-        display: none;
-      }
-      .breadcrumb {
-        max-width: calc(95cqw - 3rem) ! important;
-      }
-      .sole-breadcrumb {
-        max-width: calc(95cqw - 1rem) ! important;
       }
     }
     `;
@@ -62,3 +77,5 @@ export const BreadcrumbGroup = styled(Group)`
 export const CollectionsIcon = styled(FixedSizeIcon)`
   margin-inline-end: 0.5rem;
 `;
+
+export const EllipsisAndSeparator = styled(Flex)``;

--- a/frontend/src/metabase/browse/components/CollectionBreadcrumbsWithTooltip.styled.tsx
+++ b/frontend/src/metabase/browse/components/CollectionBreadcrumbsWithTooltip.styled.tsx
@@ -29,7 +29,7 @@ export const Breadcrumb = styled(ResponsiveChild)<{
     return `
     @container ${props.containerName} (width < ${breadcrumbBreakpoint}) {
       ${props.index === 0 && !props.isSoleBreadcrumb ? `display: none;` : ""}
-      max-width: calc(95cqw - ${props.isSoleBreadcrumb ? 1 : 3}rem) !important;
+      td & { max-width: calc(95cqw - ${props.isSoleBreadcrumb ? 1 : 3}rem); };
     }`;
   }}
 `;

--- a/frontend/src/metabase/browse/components/CollectionBreadcrumbsWithTooltip.tsx
+++ b/frontend/src/metabase/browse/components/CollectionBreadcrumbsWithTooltip.tsx
@@ -1,14 +1,11 @@
-import classNames from "classnames";
-import type { FC } from "react";
-import { forwardRef, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { ResponsiveContainer } from "metabase/components/ResponsiveContainer/ResponsiveContainer";
 import { Ellipsified } from "metabase/core/components/Ellipsified";
 import { useAreAnyTruncated } from "metabase/hooks/use-is-truncated";
 import resizeObserver from "metabase/lib/resize-observer";
 import * as Urls from "metabase/lib/urls";
-import type { FlexProps } from "metabase/ui";
-import { Flex, Text, Tooltip } from "metabase/ui";
+import { Flex, Tooltip } from "metabase/ui";
 import type { CollectionEssentials } from "metabase-types/api";
 
 import { getCollectionName } from "../utils";
@@ -17,10 +14,12 @@ import {
   Breadcrumb,
   BreadcrumbGroup,
   CollectionBreadcrumbsWrapper,
+  CollectionLink,
   CollectionsIcon,
+  InitialEllipsis,
 } from "./CollectionBreadcrumbsWithTooltip.styled";
-import { pathSeparatorChar } from "./constants";
-import type { RefProp } from "./types";
+import { Ellipsis } from "./Ellipsis";
+import { PathSeparator } from "./PathSeparator";
 import { getBreadcrumbMaxWidths, getCollectionPathString } from "./utils";
 
 export const CollectionBreadcrumbsWithTooltip = ({
@@ -40,7 +39,7 @@ export const CollectionBreadcrumbsWithTooltip = ({
     : collections;
   const justOneShown = shownCollections.length === 1;
 
-  const { areAnyTruncated, ref } = useAreAnyTruncated<HTMLAnchorElement>({
+  const { areAnyTruncated, ref } = useAreAnyTruncated<HTMLDivElement>({
     tolerance: 1,
   });
 
@@ -85,82 +84,60 @@ export const CollectionBreadcrumbsWithTooltip = ({
         name={containerName}
         w="auto"
       >
-        <Flex align="center" w="100%" lh="1" style={{ flexFlow: "row nowrap" }}>
-          <CollectionsIcon
-            name="folder"
-            // Stopping propagation so that the parent <tr>'s onclick won't fire
-            onClick={(e: React.MouseEvent) => e.stopPropagation()}
-          />
-          {shownCollections.map((collection, index) => {
-            const key = `collection${collection.id}`;
-            return (
-              <BreadcrumbGroup
-                spacing={0}
-                key={key}
-                // Stopping propagation so that the parent <tr>'s onclick won't fire
-                onClick={(e: React.MouseEvent) => e.stopPropagation()}
-              >
-                {index > 0 && <PathSeparator />}
-                <CollectionBreadcrumbsWrapper
-                  containerName={containerName}
-                  style={{ alignItems: "center" }}
-                  w="auto"
-                  display="flex"
+        <CollectionLink to={Urls.collection(collection)}>
+          <Flex
+            align="center"
+            w="100%"
+            lh="1"
+            style={{ flexFlow: "row nowrap" }}
+          >
+            <CollectionsIcon
+              name="folder"
+              // Stopping propagation so that the parent <tr>'s onclick won't fire
+              onClick={(e: React.MouseEvent) => e.stopPropagation()}
+            />
+            {shownCollections.map((collection, index) => {
+              const key = `collection${collection.id}`;
+              return (
+                <BreadcrumbGroup
+                  spacing={0}
+                  key={key}
+                  // Stopping propagation so that the parent <tr>'s onclick won't fire
+                  onClick={(e: React.MouseEvent) => e.stopPropagation()}
                 >
-                  {index === 0 && !justOneShown && (
-                    <Ellipsis
-                      ref={initialEllipsisRef}
-                      includeSep={false}
-                      className="initial-ellipsis"
-                    />
-                  )}
-                  {index > 0 && ellipsifyPath && <Ellipsis />}
-                  <Breadcrumb
-                    href={Urls.collection(collection)}
-                    className={classNames("breadcrumb", `for-index-${index}`, {
-                      "sole-breadcrumb": collections.length === 1,
-                    })}
-                    ref={(el: HTMLAnchorElement) => ref.current.set(key, el)}
-                    maw={maxWidths[index]}
-                    key={collection.id}
+                  {index > 0 && <PathSeparator />}
+                  <CollectionBreadcrumbsWrapper
+                    containerName={containerName}
+                    style={{ alignItems: "center" }}
+                    w="auto"
+                    display="flex"
                   >
-                    {getCollectionName(collection)}
-                  </Breadcrumb>
-                </CollectionBreadcrumbsWrapper>
-              </BreadcrumbGroup>
-            );
-          })}
-        </Flex>
+                    {index === 0 && !justOneShown && (
+                      <InitialEllipsis ref={initialEllipsisRef} />
+                    )}
+                    {index > 0 && ellipsifyPath && <Ellipsis />}
+                    <Breadcrumb
+                      maxWidth={maxWidths[index]}
+                      index={index}
+                      isSoleBreadcrumb={collections.length === 1}
+                      containerName={containerName}
+                      ref={(el: HTMLDivElement | null) =>
+                        el && ref.current.set(key, el)
+                      }
+                      key={collection.id}
+                    >
+                      {getCollectionName(collection)}
+                    </Breadcrumb>
+                  </CollectionBreadcrumbsWrapper>
+                </BreadcrumbGroup>
+              );
+            })}
+          </Flex>
+        </CollectionLink>
       </ResponsiveContainer>
     </Tooltip>
   );
 };
-
-type EllipsisProps = {
-  includeSep?: boolean;
-} & FlexProps;
-
-const Ellipsis: FC<EllipsisProps & Partial<RefProp<HTMLDivElement | null>>> =
-  forwardRef<HTMLDivElement, EllipsisProps>(
-    ({ includeSep = true, ...flexProps }, ref) => (
-      <Flex
-        ref={ref}
-        align="center"
-        className="ellipsis-and-separator"
-        {...flexProps}
-      >
-        <Text lh={1}>…</Text>
-        {includeSep && <PathSeparator />}
-      </Flex>
-    ),
-  );
-Ellipsis.displayName = "Ellipsis";
-
-const PathSeparator = () => (
-  <Text color="text-light" mx="xs" py={1}>
-    {pathSeparatorChar}
-  </Text>
-);
 
 export const SimpleCollectionDisplay = ({
   collection,

--- a/frontend/src/metabase/browse/components/Ellipsis.tsx
+++ b/frontend/src/metabase/browse/components/Ellipsis.tsx
@@ -1,0 +1,29 @@
+import type { FC } from "react";
+import { forwardRef } from "react";
+
+import type { FlexProps } from "metabase/ui";
+import { Text } from "metabase/ui";
+
+import { EllipsisAndSeparator } from "./CollectionBreadcrumbsWithTooltip.styled";
+import { PathSeparator } from "./PathSeparator";
+import type { RefProp } from "./types";
+type EllipsisProps = {
+  includeSep?: boolean;
+} & FlexProps;
+
+export const Ellipsis: FC<
+  EllipsisProps & Partial<RefProp<HTMLDivElement | null>>
+> = forwardRef<HTMLDivElement, EllipsisProps>(
+  ({ includeSep = true, ...flexProps }, ref) => (
+    <EllipsisAndSeparator
+      ref={ref}
+      align="center"
+      className="ellipsis-and-separator"
+      {...flexProps}
+    >
+      <Text lh={1}>…</Text>
+      {includeSep && <PathSeparator />}
+    </EllipsisAndSeparator>
+  ),
+);
+Ellipsis.displayName = "Ellipsis";

--- a/frontend/src/metabase/browse/components/PathSeparator.tsx
+++ b/frontend/src/metabase/browse/components/PathSeparator.tsx
@@ -1,0 +1,14 @@
+import { Text } from "metabase/ui";
+
+import { pathSeparatorChar } from "./constants";
+
+export const PathSeparator = () => (
+  <Text
+    className="collection-path-separator"
+    color="text-light"
+    mx=".2rem"
+    py={1}
+  >
+    {pathSeparatorChar}
+  </Text>
+);

--- a/frontend/src/metabase/components/ResponsiveContainer/ResponsiveContainer.tsx
+++ b/frontend/src/metabase/components/ResponsiveContainer/ResponsiveContainer.tsx
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
 
+import type { RefProp } from "metabase/browse/components/types";
 import { Box, type BoxProps } from "metabase/ui";
 
 const doNotForwardProps = (...propNamesToBlock: string[]) => ({
@@ -24,5 +25,5 @@ ResponsiveContainer.defaultProps = { type: "inline-size" };
 export const ResponsiveChild = styled(Box, doNotForwardProps("containerName"))<
   BoxProps & {
     containerName: string;
-  }
+  } & Partial<RefProp<HTMLDivElement | null>>
 >``;


### PR DESCRIPTION
On Browse models, take the distinct links to each collection in a path and turn them into a single link to the model's parent collection.

Closes #42951