### PR TITLE
Add font fallbacks to charts rendering context

### DIFF
--- a/frontend/src/metabase/visualizations/hooks/use-browser-rendering-context.ts
+++ b/frontend/src/metabase/visualizations/hooks/use-browser-rendering-context.ts
@@ -16,7 +16,7 @@ export const useBrowserRenderingContext = (
       getColor: name => color(name, palette),
       formatValue: (value, options) => String(formatValue(value, options)),
       measureText: measureTextWidth,
-      fontFamily,
+      fontFamily: `${fontFamily}, Arial, sans-serif`,
     }),
     [fontFamily, palette],
   );

--- a/frontend/src/metabase/visualizations/hooks/use-browser-rendering-context.ts
+++ b/frontend/src/metabase/visualizations/hooks/use-browser-rendering-context.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 
+import { usePalette } from "metabase/hooks/use-palette";
 import { color } from "metabase/lib/colors";
 import { formatValue } from "metabase/lib/formatting/value";
 import { measureTextWidth } from "metabase/lib/measure-text";
@@ -7,13 +8,16 @@ import type { RenderingContext } from "metabase/visualizations/types";
 
 export const useBrowserRenderingContext = (
   fontFamily: string,
-): RenderingContext =>
-  useMemo(
+): RenderingContext => {
+  const palette = usePalette();
+
+  return useMemo(
     () => ({
-      getColor: color,
+      getColor: name => color(name, palette),
       formatValue: (value, options) => String(formatValue(value, options)),
       measureText: measureTextWidth,
-      fontFamily: fontFamily,
+      fontFamily,
     }),
-    [fontFamily],
+    [fontFamily, palette],
   );
+};

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-models-and-option.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-models-and-option.ts
@@ -1,9 +1,5 @@
 import { useCallback, useMemo } from "react";
 
-import { usePalette } from "metabase/hooks/use-palette";
-import { color } from "metabase/lib/colors";
-import { formatValue } from "metabase/lib/formatting";
-import { measureTextWidth } from "metabase/lib/measure-text";
 import { extractRemappings } from "metabase/visualizations";
 import { getChartMeasurements } from "metabase/visualizations/echarts/cartesian/chart-measurements";
 import { getCartesianChartModel } from "metabase/visualizations/echarts/cartesian/model";
@@ -17,10 +13,8 @@ import { getScatterPlotOption } from "metabase/visualizations/echarts/cartesian/
 import { getTimelineEventsModel } from "metabase/visualizations/echarts/cartesian/timeline-events/model";
 import { getWaterfallChartModel } from "metabase/visualizations/echarts/cartesian/waterfall/model";
 import { getWaterfallChartOption } from "metabase/visualizations/echarts/cartesian/waterfall/option";
-import type {
-  RenderingContext,
-  VisualizationProps,
-} from "metabase/visualizations/types";
+import { useBrowserRenderingContext } from "metabase/visualizations/hooks/use-browser-rendering-context";
+import type { VisualizationProps } from "metabase/visualizations/types";
 
 import { getHoveredSeriesDataKey } from "./utils";
 
@@ -38,8 +32,6 @@ export function useModelsAndOption({
   onRender,
   hovered,
 }: VisualizationProps) {
-  const palette = usePalette();
-
   const rawSeriesWithRemappings = useMemo(
     () => extractRemappings(rawSeries),
     [rawSeries],
@@ -55,15 +47,7 @@ export function useModelsAndOption({
     [onRender],
   );
 
-  const renderingContext: RenderingContext = useMemo(
-    () => ({
-      getColor: name => color(name, palette),
-      formatValue: (value, options) => String(formatValue(value, options)),
-      measureText: measureTextWidth,
-      fontFamily,
-    }),
-    [fontFamily, palette],
-  );
+  const renderingContext = useBrowserRenderingContext(fontFamily);
 
   const hasTimelineEvents = timelineEvents
     ? timelineEvents.length !== 0


### PR DESCRIPTION
Closes #43175

After the charts migration, axis labels and ticks were rendered with the wrong font when exporting as PNG. This seems to be a limitation of the `html2canvas` library we're using for exports (related issue https://github.com/niklasvh/html2canvas/issues/1463). Apparently, dc.js charts didn't use Lato either, but were using Arial as a fallback. This PR brings the fallback back to echarts until we find a better solution

### To verify

1. Open any line/area/bar chart
2. Click the "Download" button at the bottom right
3. Select "PNG"
4. Ensure the text isn't serif