### PR TITLE
use `:secure true` for cookies on localhost, even if not https

### DIFF
--- a/src/metabase/server/middleware/session.clj
+++ b/src/metabase/server/middleware/session.clj
@@ -126,7 +126,10 @@
     :path      "/" #_(site-path)}
    ;; If the authentication request request was made over HTTPS (hopefully always except for
    ;; local dev instances) add `Secure` attribute so the cookie is only sent over HTTPS.
-   (when (req.util/https? request)
+   (when
+    (or
+     (req.util/https? request)
+     (req.util/localhost? request))
      {:secure true})))
 
 (defmethod default-session-cookie-attributes :full-app-embed

--- a/src/metabase/server/request/util.clj
+++ b/src/metabase/server/request/util.clj
@@ -72,6 +72,11 @@
     scheme
     (= scheme :https)))
 
+(defn localhost?
+  "Checks if the request comes from localhost."
+  [request]
+  (= "localhost" (:server-name request)))
+
 (defn embedded?
   "Whether this frontend client that made this request is embedded inside an `<iframe>`."
   [request]


### PR DESCRIPTION

### Description

This seems to be needed when using JWT SSO from localhost:xxx to localhost:xxx, with samesite=none

https://metaboat.slack.com/archives/C063Q3F1HPF/p1716995056972319