### PR TITLE
Populate collection search results with effective parent

### DIFF
--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -22,6 +22,7 @@ import {
   getSettings,
 } from "metabase/selectors/settings";
 import { getShowMetabaseLinks } from "metabase/selectors/whitelabel";
+import type { IconName } from "metabase/ui";
 
 import type { PaletteAction } from "../types";
 import { filterRecentItems } from "../utils";
@@ -161,7 +162,7 @@ export const useCommandPalette = ({
             name: t`View and filter all ${searchResults?.total} results`,
             section: "search",
             keywords: debouncedSearchText,
-            icon: "link" as const,
+            icon: "link" as IconName,
             perform: () => {
               dispatch(push(searchLocation));
             },
@@ -177,7 +178,7 @@ export const useCommandPalette = ({
               id: `search-result-${result.model}-${result.id}`,
               name: result.name,
               subtitle: result.description || "",
-              icon: wrappedResult.getIcon().name,
+              icon: getIcon(result).name,
               section: "search",
               keywords: debouncedSearchText,
               priority: Priority.NORMAL,

--- a/frontend/src/metabase/search/components/SearchResult/components/CollectionIcon.tsx
+++ b/frontend/src/metabase/search/components/SearchResult/components/CollectionIcon.tsx
@@ -1,33 +1,22 @@
 import { color } from "metabase/lib/colors";
 import { getIcon } from "metabase/lib/icon";
-import { PLUGIN_COLLECTIONS } from "metabase/plugins";
-import { DEFAULT_ICON_SIZE } from "metabase/search/components/SearchResult/components";
-import type { WrappedResult } from "metabase/search/types";
+import {
+  DEFAULT_ICON_SIZE,
+  LARGE_ICON_SIZE,
+} from "metabase/search/components/SearchResult/components";
 import { Icon } from "metabase/ui";
 
 import type { IconComponentProps } from "./ItemIcon";
 
-const isWrappedResult = (
-  item: IconComponentProps["item"],
-): item is WrappedResult => item && "getIcon" in item;
-
 export function CollectionIcon({ item }: { item: IconComponentProps["item"] }) {
-  const iconData = isWrappedResult(item) ? item?.getIcon?.() : getIcon(item);
+  const icon = getIcon(item);
 
-  const iconProps = { ...iconData, tooltip: null };
-  const isRegular =
-    "collection" in item &&
-    PLUGIN_COLLECTIONS.isRegularCollection(item.collection);
+  icon.color = icon.color ? color(icon.color) : color("text-light");
 
-  if (isRegular) {
-    return (
-      <Icon
-        {...iconProps}
-        size={DEFAULT_ICON_SIZE}
-        color={color("text-light")}
-      />
-    );
-  }
-
-  return <Icon {...iconProps} width={20} height={24} />;
+  return (
+    <Icon
+      {...icon}
+      size={icon.name === "folder" ? DEFAULT_ICON_SIZE : LARGE_ICON_SIZE}
+    />
+  );
 }

--- a/frontend/src/metabase/search/components/SearchResult/components/constants.ts
+++ b/frontend/src/metabase/search/components/SearchResult/components/constants.ts
@@ -1,1 +1,2 @@
 export const DEFAULT_ICON_SIZE = 16;
+export const LARGE_ICON_SIZE = 20;

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -428,7 +428,7 @@
 (def ^:private effective-parent-fields
   "Fields that should be included when hydrating the `:effective_parent` of a collection. Used for displaying recent views
   and collection search results."
-  [:id :name :authority_level])
+  [:id :name :authority_level :type])
 
 (defn- effective-parent-root []
   (select-keys
@@ -439,7 +439,7 @@
   :effective_parent
   "Given a seq of `collections`, batch hydrates them with their `:effective_parent`, their parent collection in their
   effective location. (i.e. the most recent ancestor the current user has read access to). If :effective_location is not
-  present on any collections, it is hydrated first."
+  present on any collections, it is hydrated as well, as it is needed to compute the effective parent."
   [collections]
   (let [collections     (map #(t2/hydrate % :effective_location) collections)
         parent-ids      (->> collections

--- a/src/metabase/models/recent_views.clj
+++ b/src/metabase/models/recent_views.clj
@@ -342,7 +342,9 @@
                                   :where [:and
                                           [:in :id collection-ids]
                                           [:= :archived false]]})]
-      (t2/hydrate collections :effective_parent))))
+      (->> (t2/hydrate collections :effective_parent)
+
+           (map #(m/dissoc-in % [:effective_parent :type]))))))
 
 (defmethod fill-recent-view-info :collection [{:keys [_model model_id timestamp model_object]}]
   (when-let [collection (and

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -5,6 +5,8 @@
    [medley.core :as m]
    [metabase.db :as mdb]
    [metabase.db.query :as mdb.query]
+   [metabase.legacy-mbql.normalize :as mbql.normalize]
+   [metabase.lib.core :as lib]
    [metabase.models.collection :as collection]
    [metabase.models.data-permissions :as data-perms]
    [metabase.models.database :as database]
@@ -12,7 +14,9 @@
    [metabase.models.permissions :as perms]
    [metabase.permissions.util :as perms.u]
    [metabase.public-settings.premium-features :as premium-features]
-   [metabase.search.config :as search.config :refer [SearchableModel SearchContext]]
+   [metabase.search.config
+    :as search.config
+    :refer [SearchableModel SearchContext]]
    [metabase.search.filter :as search.filter]
    [metabase.search.scoring :as scoring]
    [metabase.search.util :as search.util]
@@ -499,9 +503,9 @@
         ;; the set of all collection IDs where we *don't* know the collection name. For example, if `col-id->info`
         ;; contained `{1 {:effective_location "/2/" :name "Foo"}}`, we need to look up the name of collection `2`.
         to-fetch     (into #{} (comp (keep :effective_location)
-                                      (mapcat collection/location-path->ids)
+                                     (mapcat collection/location-path->ids)
                                       ;; already have these names
-                                      (remove col-id->info))
+                                     (remove col-id->info))
                             (vals col-id->info))
         ;; the now COMPLETE map of collection IDs to info
         col-id->info (merge (if (seq to-fetch)
@@ -517,6 +521,47 @@
                                         (map col-id->info))
                                    []))))]
     (map annotate search-results)))
+
+;;; TODO OMG mix of kebab-case and snake_case here going to make me throw up, we should use all kebab-case in Clojure
+;;; land and then convert the stuff that actually gets sent over the wire in the REST API to snake_case in the API
+;;; endpoint itself, not in the search impl.
+(defn serialize
+  "Massage the raw result from the DB and match data into something more useful for the client"
+  [{:as result :keys [all-scores relevant-scores name display_name collection_id collection_name
+                      collection_authority_level collection_type collection_effective_ancestors]}]
+  (let [matching-columns    (into #{} (remove nil? (map :column relevant-scores)))
+        match-context-thunk (first (keep :match-context-thunk relevant-scores))]
+    (-> result
+        (assoc
+         :name           (if (and (contains? matching-columns :display_name) display_name)
+                           display_name
+                           name)
+         :context        (when (and match-context-thunk
+                                    (empty?
+                                     (remove matching-columns search.config/displayed-columns)))
+                           (match-context-thunk))
+         :collection     (merge {:id              collection_id
+                                 :name            collection_name
+                                 :authority_level collection_authority_level
+                                 :type            collection_type}
+                                (when collection_effective_ancestors
+                                  {:effective_ancestors collection_effective_ancestors}))
+         :scores          all-scores)
+        (update :dataset_query (fn [dataset-query]
+                                 (when-let [query (some-> dataset-query json/parse-string)]
+                                   (if (get query "type")
+                                      (mbql.normalize/normalize query)
+                                      (not-empty (lib/normalize query))))))
+        (dissoc
+         :all-scores
+         :relevant-scores
+         :collection_effective_ancestors
+         :trashed_from_collection_id
+         :collection_id
+         :collection_location
+         :collection_name
+         :collection_type
+         :display_name))))
 
 (defn- add-can-write [row]
   (if (some #(mi/instance-of? % row) [:model/Dashboard :model/Card])
@@ -568,7 +613,7 @@
         total-results       (cond->> (scoring/top-results reducible-results search.config/max-filtered-results xf)
                               true hydrate-user-metadata
                               (:model-ancestors? search-ctx) (add-dataset-collection-hierarchy)
-                              true (map scoring/serialize))
+                              true (map serialize))
         add-perms-for-col  (fn [item]
                              (cond-> item
                                (mi/instance-of? :model/Collection item)

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -111,11 +111,8 @@
 
   Some of the scorers can be tweaked with configuration in [[metabase.search.config]]."
   (:require
-   [cheshire.core :as json]
    [clojure.string :as str]
    [java-time.api :as t]
-   [metabase.legacy-mbql.normalize :as mbql.normalize]
-   [metabase.lib.core :as lib]
    [metabase.public-settings.premium-features :refer [defenterprise]]
    [metabase.search.config :as search.config]
    [metabase.search.util :as search.util]
@@ -301,47 +298,6 @@
     (/
      (max (- stale-time days-ago) 0)
      stale-time)))
-
-;;; TODO OMG mix of kebab-case and snake_case here going to make me throw up, we should use all kebab-case in Clojure
-;;; land and then convert the stuff that actually gets sent over the wire in the REST API to snake_case in the API
-;;; endpoint itself, not in the search impl.
-(defn serialize
-  "Massage the raw result from the DB and match data into something more useful for the client"
-  [{:as result :keys [all-scores relevant-scores name display_name collection_id collection_name
-                      collection_authority_level collection_type collection_effective_ancestors]}]
-  (let [matching-columns    (into #{} (remove nil? (map :column relevant-scores)))
-        match-context-thunk (first (keep :match-context-thunk relevant-scores))]
-    (-> result
-        (assoc
-         :name           (if (and (contains? matching-columns :display_name) display_name)
-                           display_name
-                           name)
-         :context        (when (and match-context-thunk
-                                    (empty?
-                                     (remove matching-columns search.config/displayed-columns)))
-                           (match-context-thunk))
-         :collection     (merge {:id              collection_id
-                                 :name            collection_name
-                                 :authority_level collection_authority_level
-                                 :type            collection_type}
-                                (when collection_effective_ancestors
-                                  {:effective_ancestors collection_effective_ancestors}))
-         :scores          all-scores)
-        (update :dataset_query (fn [dataset-query]
-                                 (when-let [query (some-> dataset-query json/parse-string)]
-                                   (if (get query "type")
-                                      (mbql.normalize/normalize query)
-                                      (not-empty (lib/normalize query))))))
-        (dissoc
-         :all-scores
-         :relevant-scores
-         :collection_effective_ancestors
-         :trashed_from_collection_id
-         :collection_id
-         :collection_location
-         :collection_name
-         :collection_type
-         :display_name))))
 
 (defn weights-and-scores
   "Default weights and scores for a given result."

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -785,8 +785,8 @@
 
 (deftest collections-are-moved-to-trash-when-archived
   (let [set-of-item-names (fn [user coll] (->> (get-items user coll)
-                                          (map :name)
-                                          set))]
+                                           (map :name)
+                                           set))]
     (testing "I can trash something by marking it as archived"
       (t2.with-temp/with-temp [Collection collection {:name "Art Collection"}
                                Collection _ {:name "Baby Collection"

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -1,5 +1,5 @@
 (ns ^:mb/once metabase.api.search-test
-  "There are  more tests around search in [[metabase.search.impl-test]]. TODO: we should move more of the tests
+  "There are more tests around search in [[metabase.search.impl-test]]. TODO: we should move more of the tests
   below into that namespace."
   (:require
    [clojure.set :as set]
@@ -134,7 +134,8 @@
     (cond-> result
       true (assoc :archived true)
       (= (:model result) "collection") (assoc :location (collection/trash-path)
-                                              :effective_location (collection/trash-path)))))
+                                              :effective_location (collection/trash-path)
+                                              :collection (assoc default-collection :id true :name true :type "trash")))))
 
 (defn- on-search-types [model-set f coll]
   (for [search-item coll]
@@ -1587,12 +1588,12 @@
         (testing "the collection data includes the type under `item.type` for collections"
           (is (every? #(contains? % :type)
                       (->> (mt/user-http-request :crowberto :get 200 "/search" :q search-name)
-                              :data
-                              (filter #(= (:model %) "collection")))))
+                           :data
+                           (filter #(= (:model %) "collection")))))
           (is (not-any? #(contains? % :type)
                         (->> (mt/user-http-request :crowberto :get 200 "/search" :q search-name)
-                              :data
-                              (remove #(= (:model %) "collection"))))))
+                             :data
+                             (remove #(= (:model %) "collection"))))))
         (testing "`item.type` is correct for collections"
           (is (= #{"meow mix"} (->> (mt/user-http-request :crowberto :get 200 "/search" :q search-name)
                                  :data

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -1499,6 +1499,34 @@
                (set (mt/user-http-request :crowberto :get 200 "search/models" :q search-term
                                           :filter_items_in_personal_collection "exclude"))))))))
 
+(deftest collection-effective-parent-test
+  (mt/with-temp [:model/Collection coll-1  {:name "Collection 1"}
+                 :model/Collection coll-2  {:name "Collection 2", :location (collection/location-path coll-1)}
+                 :model/Collection _coll-3 {:name "Collection 3", :location (collection/location-path coll-1 coll-2)}]
+    (testing "Collection search results are properly hydrated with their effective parent in the :collection field"
+      (let [result (mt/user-http-request :rasta :get 200 "search" :q "Collection 3" :models ["collection"])]
+        (is (= {:id              (u/the-id coll-2)
+                :name            "Collection 2"
+                :authority_level nil
+                :type            nil}
+               (-> result :data first :collection))))
+
+      (perms/revoke-collection-permissions! (perms-group/all-users) coll-2)
+      (let [result (mt/user-http-request :rasta :get 200 "search" :q "Collection 3" :models ["collection"])]
+        (is (= {:id              (u/the-id coll-1)
+                :name            "Collection 1"
+                :authority_level nil
+                :type            nil}
+               (-> result :data first :collection))))
+
+      (perms/revoke-collection-permissions! (perms-group/all-users) coll-1)
+      (let [result (mt/user-http-request :rasta :get 200 "search" :q "Collection 3" :models ["collection"])]
+        (is (= {:id              "root"
+                :name            "Our analytics"
+                :authority_level nil
+                :type            nil}
+               (-> result :data first :collection)))))))
+
 (deftest archived-search-results-with-no-write-perms-test
   (testing "Results which the searching user has no write permissions for are filtered out. (#24018, #33602)"
     ;; note that the collection does not start out archived, so that we can revoke/grant permissions on it

--- a/test/metabase/search/impl_test.clj
+++ b/test/metabase/search/impl_test.clj
@@ -1,7 +1,8 @@
 (ns metabase.search.impl-test
-  "There are a lot more tests around search in [[metabase.search.impl-test]]. TODO: we should move more of those tests
+  "There are a lot more tests around search in [[metabase.api.search-test]]. TODO: we should move more of those tests
   into this namespace."
   (:require
+   [cheshire.core :as json]
    [clojure.set :as set]
    [clojure.test :refer :all]
    [java-time.api :as t]
@@ -247,3 +248,19 @@
           (test-search "thisyear" new-result)
           (test-search "past1years-from-12months" old-result)
           (test-search "today" new-result))))))
+
+(deftest ^:parallel serialize-test
+  (testing "It normalizes dataset queries from strings"
+    (let [query  {:type     :query
+                  :query    {:source-query {:source-table 1}}
+                  :database 1}
+          result {:name          "card"
+                  :model         "card"
+                  :dataset_query (json/generate-string query)
+                  :all-scores {}
+                  :relevant-scores {}}]
+      (is (= query (-> result search.impl/serialize :dataset_query)))))
+  (testing "Doesn't error on other models without a query"
+    (is (nil? (-> {:name "dash" :model "dashboard" :all-scores {} :relevant-scores {}}
+                  search.impl/serialize
+                  :dataset_query)))))

--- a/test/metabase/search/scoring_test.clj
+++ b/test/metabase/search/scoring_test.clj
@@ -1,6 +1,5 @@
 (ns metabase.search.scoring-test
   (:require
-   [cheshire.core :as json]
    [clojure.test :refer :all]
    [java-time.api :as t]
    [metabase.search.config :as search.config]
@@ -273,21 +272,6 @@
                      {:weight 100 :score 0 :name "Some other score type"}])]
       (is (= 0 (:score (scoring/score-and-result "" {:name "racing yo" :model "card"})))))))
 
-(deftest ^:parallel serialize-test
-  (testing "It normalizes dataset queries from strings"
-    (let [query  {:type     :query
-                  :query    {:source-query {:source-table 1}}
-                  :database 1}
-          result {:name          "card"
-                  :model         "card"
-                  :dataset_query (json/generate-string query)
-                  :all-scores {}
-                  :relevant-scores {}}]
-      (is (= query (-> result scoring/serialize :dataset_query)))))
-  (testing "Doesn't error on other models without a query"
-    (is (nil? (-> {:name "dash" :model "dashboard" :all-scores {} :relevant-scores {}}
-                  (#'scoring/serialize)
-                  :dataset_query)))))
 
 (deftest ^:parallel force-weight-test
   (is (= [{:weight 10}]


### PR DESCRIPTION
Pursuant to https://github.com/metabase/metabase/issues/42979

Fixes the `:collection` field on collection search results so that it contains details about the collection's effective parent, rather than the collection itself, which was the prior behavior.