### PR TITLE
Load metadata before queries

### DIFF
--- a/frontend/src/metabase/dashboard/actions/revisions.js
+++ b/frontend/src/metabase/dashboard/actions/revisions.js
@@ -19,8 +19,8 @@ export const revertToRevision = createThunkAction(
         }),
       );
       await Promise.all([
-        dispatch(fetchDashboardCardData({ reload: false, clearCache: true })),
         dispatch(fetchDashboardCardMetadata()),
+        dispatch(fetchDashboardCardData({ reload: false, clearCache: true })),
       ]);
     };
   },

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -330,8 +330,8 @@ function DashboardInner(props: DashboardProps) {
     );
 
     if (hasDashboardLoaded) {
-      fetchDashboardCardData({ reload: false, clearCache: true });
       fetchDashboardCardMetadata();
+      fetchDashboardCardData({ reload: false, clearCache: true });
     } else if (hasTabChanged || hasParameterValueChanged) {
       fetchDashboardCardData();
     }

--- a/frontend/src/metabase/dashboard/hoc/DashboardData.jsx
+++ b/frontend/src/metabase/dashboard/hoc/DashboardData.jsx
@@ -72,11 +72,11 @@ export const DashboardData = ComposedComponent =>
 
         try {
           await Promise.all([
+            fetchDashboardCardMetadata(),
             fetchDashboardCardData({
               reload: false,
               clearCache: !isNavigatingBackToDashboard,
             }),
-            fetchDashboardCardMetadata(),
           ]);
         } catch (error) {
           console.error(error);

--- a/frontend/src/metabase/dashboard/hooks/use-refresh-dashboard.ts
+++ b/frontend/src/metabase/dashboard/hooks/use-refresh-dashboard.ts
@@ -28,6 +28,7 @@ export const useRefreshDashboard = ({
           options: { preserveParameters: true },
         }),
       );
+      dispatch(fetchDashboardCardMetadata());
       dispatch(
         fetchDashboardCardData({
           isRefreshing: true,
@@ -35,7 +36,6 @@ export const useRefreshDashboard = ({
           clearCache: false,
         }),
       );
-      dispatch(fetchDashboardCardMetadata());
     }
   }, [dashboardId, dispatch, parameterQueryParams]);
 

--- a/frontend/src/metabase/public/containers/PublicDashboard/PublicDashboard.tsx
+++ b/frontend/src/metabase/public/containers/PublicDashboard/PublicDashboard.tsx
@@ -126,14 +126,10 @@ class PublicDashboardInner extends Component<PublicDashboardProps> {
     }
 
     try {
-      const requests = [];
+      await fetchDashboardCardMetadata();
       if (this.props.dashboard?.tabs?.length === 0) {
-        requests.push(
-          fetchDashboardCardData({ reload: false, clearCache: true }),
-        );
+        await fetchDashboardCardData({ reload: false, clearCache: true });
       }
-      requests.push(fetchDashboardCardMetadata());
-      await Promise.all(requests);
     } catch (error) {
       console.error(error);
       setErrorPage(error);


### PR DESCRIPTION
Based on stats, calling metadata after `query` is bad for performance because with many cards the browser doesn't send the metadata request until most of `query` requests are resolved. As we block rendering of the dashboard until metadata is loaded, it makes sense to send this request before `query`.