### PR TITLE
[Manual backport] Backfill :effective-type for coerced fields (#43144)

### DIFF
--- a/src/metabase/lib/convert.cljc
+++ b/src/metabase/lib/convert.cljc
@@ -323,7 +323,13 @@
          (comp (disqualify)
                (remove (fn [[k _v]]
                          (= k :effective-type))))
-         m)))
+         ;; Following construct ensures that transformation mbql -> pmbql -> mbql, does not add base-type where those
+         ;; were not present originally. Base types are adeed in [[metabase.lib.query/add-types-to-fields]].
+         (if (contains? m :metabase.lib.query/transformation-added-base-type)
+           (dissoc m
+                   :metabase.lib.query/transformation-added-base-type
+                   :base-type)
+           m))))
 
 (defn- aggregation->legacy-MBQL [[tag options & args]]
   (let [inner (into [tag] (map ->legacy-MBQL) args)

--- a/src/metabase/lib/filter.cljc
+++ b/src/metabase/lib/filter.cljc
@@ -95,6 +95,9 @@
       [:= _ (a :guard (unit-is lib.schema.temporal-bucketing/datetime-truncation-units)) (b :guard string?)]
       (i18n/tru "{0} is {1}" (->unbucketed-display-name a) (shared.ut/format-relative-date-range b 0 (:temporal-unit (second a)) nil nil {:include-current true}))
 
+      [:= _ (a :guard (unit-is :day-of-week)) (b :guard (some-fn int? string?))]
+      (i18n/tru "{0} is {1}" (->display-name a) (->temporal-name a b))
+
       [:= _ (a :guard temporal?) (b :guard (some-fn int? string?))]
       (i18n/tru "{0} is on {1}" (->display-name a) (->temporal-name a b))
 

--- a/src/metabase/lib/query.cljc
+++ b/src/metabase/lib/query.cljc
@@ -86,7 +86,7 @@
    x
    [:field
     (options :guard (every-pred map? (complement (every-pred :base-type :effective-type))))
-    (id :guard integer? pos?)]
+    (id :guard (every-pred integer? pos?))]
    (if (some #{:mbql/stage-metadata} &parents)
      &match
      (update &match 1 merge

--- a/src/metabase/lib/query.cljc
+++ b/src/metabase/lib/query.cljc
@@ -9,6 +9,7 @@
    [metabase.lib.hierarchy :as lib.hierarchy]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
+   [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.lib.normalize :as lib.normalize]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.common :as lib.schema.common]
@@ -78,6 +79,42 @@
   [query :- ::lib.schema/query]
   (can-run query))
 
+(defn add-types-to-fields
+  "Add `:base-type` and `:effective-type` to options of fields in `x` using `metadata-provider`. Works on pmbql fields.
+  `:effective-type` is required for coerced fields to pass schema checks."
+  [x metadata-provider]
+  (if-let [field-ids (mbql.u/match x
+                       [:field
+                        (_options :guard (every-pred map? (complement (every-pred :base-type :effective-type))))
+                        (id :guard integer? pos?)]
+                       (when-not (some #{:mbql/stage-metadata} &parents)
+                         id))]
+    ;; "pre-warm" the metadata provider
+    ;; lib.metadata.protocols/bulk-metadata
+    (do (lib.metadata.protocols/bulk-metadata metadata-provider :metadata/column field-ids)
+        ;; mbql.u/replace
+        (mbql.u/replace
+         x
+         [:field
+          (options :guard (every-pred map? (complement (every-pred :base-type :effective-type))))
+          (id :guard integer? pos?)]
+         (if (some #{:mbql/stage-metadata} &parents)
+           &match
+           (update &match 1 merge
+                   ;; TODO: For brush filters, query with different base type as in metadata is sent from FE. In that
+                   ;;       case no change is performed. Find a way how to handle this properly!
+                   (when-not (and (some? (:base-type options))
+                                  (not= (:base-type options)
+                                        (:base-type (lib.metadata/field metadata-provider id))))
+                     ;; Following key is used to track which base-types we added during `query` call. It is used in
+                     ;; [[metabase.lib.convert/options->legacy-MBQL]] to remove those, so query after conversion
+                     ;; as legacy -> pmbql -> legacy looks closer to the original.
+                     (merge (when-not (contains? options :base-type)
+                              {::transformation-added-base-type true})
+                            (-> (lib.metadata/field metadata-provider id)
+                                (select-keys [:base-type :effective-type]))))))))
+    x))
+
 (mu/defn query-with-stages :- ::lib.schema/query
   "Create a query from a sequence of stages."
   ([metadata-providerable stages]
@@ -104,7 +141,9 @@
 (mu/defn ^:private query-from-existing :- ::lib.schema/query
   [metadata-providerable :- lib.metadata/MetadataProviderable
    query                 :- lib.util/LegacyOrPMBQLQuery]
-  (let [query (lib.convert/->pMBQL query)]
+  (let [query (-> (binding [lib.schema.expression/*suppress-expression-type-check?* true]
+                    (lib.convert/->pMBQL query))
+                  (add-types-to-fields metadata-providerable))]
     (query-with-stages metadata-providerable (:stages query))))
 
 (defmulti ^:private query-method
@@ -132,32 +171,26 @@
     (cond-> query
       converted?
       (assoc
-        :stages
-        (into []
-              (map (fn [[stage-number stage]]
-                     (mbql.u/replace stage
-                       [:field
-                        (opts :guard (every-pred map? (complement (some-fn :base-type :effective-type))))
-                        (field-id :guard (every-pred number? pos?))]
-                       (let [found-ref (-> (lib.metadata/field metadata-provider field-id)
-                                           (select-keys [:base-type :effective-type]))]
-                         ;; Fallback if metadata is missing
-                         [:field (merge found-ref opts) field-id])
-                       [:expression
-                        (opts :guard (every-pred map? (complement (some-fn :base-type :effective-type))))
-                        expression-name]
-                       (let [found-ref (try
-                                         (m/remove-vals
-                                           #(= :type/* %)
-                                           (-> (lib.expression/expression-ref query stage-number expression-name)
-                                               second
-                                               (select-keys [:base-type :effective-type])))
-                                         (catch #?(:clj Exception :cljs :default) _
-                                           ;; This currently does not find expressions defined in join stages
-                                           nil))]
-                         ;; Fallback if metadata is missing
-                         [:expression (merge found-ref opts) expression-name]))))
-              (m/indexed stages))))))
+       :stages
+       (mapv (fn [[stage-number stage]]
+               (-> stage
+                   (add-types-to-fields metadata-provider)
+                   (mbql.u/replace
+                    [:expression
+                     (opts :guard (every-pred map? (complement (every-pred :base-type :effective-type))))
+                     expression-name]
+                    (let [found-ref (try
+                                      (m/remove-vals
+                                       #(= :type/* %)
+                                       (-> (lib.expression/expression-ref query stage-number expression-name)
+                                           second
+                                           (select-keys [:base-type :effective-type])))
+                                      (catch #?(:clj Exception :cljs :default) _
+                                        ;; This currently does not find expressions defined in join stages
+                                        nil))]
+                      ;; Fallback if metadata is missing
+                      [:expression (merge found-ref opts) expression-name]))))
+             (m/indexed stages))))))
 
 (defmethod query-method :metadata/table
   [metadata-providerable table-metadata]

--- a/src/metabase/query_processor/util.clj
+++ b/src/metabase/query_processor/util.clj
@@ -88,7 +88,6 @@
   [query :- :map]
   (buddy-hash/sha3-256 (json/generate-string (select-keys-for-hashing query))))
 
-
 ;;; --------------------------------------------- Query Source Card IDs ----------------------------------------------
 
 (defn query->source-card-id

--- a/test/metabase/lib/query_test.cljc
+++ b/test/metabase/lib/query_test.cljc
@@ -10,7 +10,9 @@
    [metabase.lib.query :as lib.query]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
+   [metabase.lib.test-util.metadata-providers.merged-mock :as merged-mock]
    [metabase.lib.util :as lib.util]
+   [metabase.types :as types]
    [metabase.util.malli :as mu]))
 
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
@@ -167,3 +169,31 @@
 
 (deftest ^:parallel can-save-mbql-test
   (is (lib.query/can-save lib.tu/venues-query)))
+
+(deftest ^:parallel coerced-fields-effective-type-test
+  (let [effective-type (types/effective-type-for-coercion :Coercion/UNIXSeconds->DateTime)
+        mp (merged-mock/merged-mock-metadata-provider
+            meta/metadata-provider
+            {:fields [{:id                (meta/id :people :id)
+                       :coercion-strategy :Coercion/UNIXSeconds->DateTime
+                       :effective-type    effective-type}]})
+        ;; Query of a following form is input to `lib/query` in the wild.
+        query {:database (meta/id)
+               :type     "query"
+               :query    {:source-table (meta/id :people)
+                          :filter       ["and"
+                                         ["between"
+                                          ["field" (meta/id :people :id) {:base-type "type/BigInteger"}]
+                                          "1969-10-12"
+                                          "1971-10-12"]]}}]
+    (testing "Effective type is added to coerced fields during legacy query transformation (part of issue #42931)"
+      (is (=? {:stages [{:filters [[:between
+                                    {:lib/uuid string?}
+                                    [:field
+                                     {:lib/uuid       string?
+                                      :base-type      :type/BigInteger
+                                      :effective-type effective-type}
+                                     (meta/id :people :id)]
+                                    "1969-10-12"
+                                    "1971-10-12"]]}]}
+              (lib/query mp query))))))

--- a/test/metabase/lib/query_test.cljc
+++ b/test/metabase/lib/query_test.cljc
@@ -177,13 +177,12 @@
             {:fields [{:id                (meta/id :people :id)
                        :coercion-strategy :Coercion/UNIXSeconds->DateTime
                        :effective-type    effective-type}]})
-        ;; Query of a following form is input to `lib/query` in the wild.
         query {:database (meta/id)
-               :type     "query"
+               :type     :query
                :query    {:source-table (meta/id :people)
-                          :filter       ["and"
-                                         ["between"
-                                          ["field" (meta/id :people :id) {:base-type "type/BigInteger"}]
+                          :filter       [:and
+                                         [:between
+                                          [:field (meta/id :people :id) {:base-type :type/BigInteger}]
                                           "1969-10-12"
                                           "1971-10-12"]]}}]
     (testing "Effective type is added to coerced fields during legacy query transformation (part of issue #42931)"


### PR DESCRIPTION
Manual backport of `Backfill :effective-type for coerced fields` (#43144).