### PR TITLE
Force loading metadata before queries

### DIFF
--- a/frontend/src/metabase-types/store/dashboard.ts
+++ b/frontend/src/metabase-types/store/dashboard.ts
@@ -85,10 +85,6 @@ export type DashboardCardsLoadingState = {
   endTime: number | null;
 };
 
-export type DashboardMetadataLoadingState = {
-  loadingStatus: DashboardLoadingStatus;
-};
-
 export type DashboardLoadingControls = {
   documentTitle?: string;
   showLoadCompleteFavicon?: boolean;
@@ -106,7 +102,6 @@ export interface DashboardState {
   draftParameterValues: Record<ParameterId, ParameterValueOrArray | null>;
 
   loadingDashCards: DashboardCardsLoadingState;
-  loadingMetadata: DashboardMetadataLoadingState;
   loadingControls: DashboardLoadingControls;
 
   editingDashboard: Dashboard | null;

--- a/frontend/src/metabase-types/store/mocks/dashboard.ts
+++ b/frontend/src/metabase-types/store/mocks/dashboard.ts
@@ -15,9 +15,6 @@ export const createMockDashboardState = (
     startTime: null,
     endTime: null,
   },
-  loadingMetadata: {
-    loadingStatus: "idle",
-  },
   loadingControls: {},
   editingDashboard: null,
   isAddParameterPopoverOpen: false,

--- a/frontend/src/metabase/dashboard/actions/data-fetching-typed.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching-typed.ts
@@ -1,6 +1,10 @@
 import { denormalize, normalize, schema } from "normalizr";
 
 import {
+  loadMetadataForDashcards,
+  loadMetadataForLinkedTargets,
+} from "metabase/dashboard/actions/metadata";
+import {
   getDashboardById,
   getDashCardById,
   getParameterValues,
@@ -10,6 +14,7 @@ import {
   expandInlineDashboard,
   getDashboardType,
 } from "metabase/dashboard/utils";
+import Dashboards from "metabase/entities/dashboards";
 import type { Deferred } from "metabase/lib/promise";
 import { defer } from "metabase/lib/promise";
 import { createAsyncThunk } from "metabase/lib/redux";
@@ -18,7 +23,7 @@ import { getParameterValuesByIdFromQueryParams } from "metabase/parameters/utils
 import { addFields, addParamValues } from "metabase/redux/metadata";
 import { getMetadata } from "metabase/selectors/metadata";
 import { AutoApi, DashboardApi, EmbedApi, PublicApi } from "metabase/services";
-import type { DashboardCard, DashboardId } from "metabase-types/api";
+import type { Dashboard, DashboardCard, DashboardId } from "metabase-types/api";
 
 // normalizr schemas
 const dashcard = new schema.Entity("dashcard");
@@ -123,6 +128,8 @@ export const fetchDashboard = createAsyncThunk(
 
       fetchDashboardCancellation = null;
 
+      await dispatch(fetchDashboardCardMetadata(result));
+
       const isUsingCachedResults = entities != null;
       if (!isUsingCachedResults) {
         // copy over any virtual cards from the dashcard to the underlying card/question
@@ -137,10 +144,10 @@ export const fetchDashboard = createAsyncThunk(
       }
 
       if (result.param_values) {
-        dispatch(addParamValues(result.param_values));
+        await dispatch(addParamValues(result.param_values));
       }
       if (result.param_fields) {
-        dispatch(addFields(result.param_fields));
+        await dispatch(addFields(result.param_fields));
       }
 
       const metadata = getMetadata(getState());
@@ -176,6 +183,24 @@ export const fetchDashboard = createAsyncThunk(
         console.error(error);
       }
       return rejectWithValue(error);
+    }
+  },
+);
+
+export const fetchDashboardCardMetadata = createAsyncThunk(
+  "metabase/dashboard/FETCH_DASHBOARD_METADATA",
+  async (dashboard: Dashboard, { dispatch }) => {
+    const dashboardType = getDashboardType(dashboard.id);
+    if (dashboardType === "normal") {
+      await dispatch(
+        Dashboards.actions.fetchMetadata({ id: dashboard.id }),
+      ).catch((error: unknown) => {
+        console.error("Failed dashboard loading metadata", error);
+      });
+      await dispatch(loadMetadataForLinkedTargets(dashboard.dashcards));
+    }
+    if (dashboardType === "transient") {
+      await dispatch(loadMetadataForDashcards(dashboard.dashcards));
     }
   },
 );

--- a/frontend/src/metabase/dashboard/actions/data-fetching.js
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.js
@@ -1,12 +1,7 @@
 import { getIn } from "icepick";
 import { t } from "ttag";
 
-import {
-  loadMetadataForDashcards,
-  loadMetadataForLinkedTargets,
-} from "metabase/dashboard/actions/metadata";
 import { showAutoApplyFiltersToast } from "metabase/dashboard/actions/parameters";
-import Dashboards from "metabase/entities/dashboards";
 import { defer } from "metabase/lib/promise";
 import { createAction, createThunkAction } from "metabase/lib/redux";
 import { equals } from "metabase/lib/utils";
@@ -42,9 +37,6 @@ export const FETCH_DASHBOARD_CARD_DATA =
   "metabase/dashboard/FETCH_DASHBOARD_CARD_DATA";
 export const CANCEL_FETCH_DASHBOARD_CARD_DATA =
   "metabase/dashboard/CANCEL_FETCH_DASHBOARD_CARD_DATA";
-
-export const FETCH_DASHBOARD_CARD_METADATA =
-  "metabase/dashboard/FETCH_DASHBOARD_CARD_METADATA";
 
 export const FETCH_CARD_DATA = "metabase/dashboard/FETCH_CARD_DATA";
 export const FETCH_CARD_DATA_PENDING =
@@ -378,25 +370,6 @@ export const fetchDashboardCardData =
       });
     }
   };
-
-export const fetchDashboardCardMetadata = createThunkAction(
-  FETCH_DASHBOARD_CARD_METADATA,
-  () => async (dispatch, getState) => {
-    const dashboard = getDashboardComplete(getState());
-    const dashboardType = getDashboardType(dashboard.id);
-    if (dashboardType === "normal") {
-      await dispatch(
-        Dashboards.actions.fetchMetadata({ id: dashboard.id }),
-      ).catch(error => {
-        console.error("Failed dashboard loading metadata", error);
-      });
-      await dispatch(loadMetadataForLinkedTargets(dashboard.dashcards));
-    }
-    if (dashboardType === "transient") {
-      await dispatch(loadMetadataForDashcards(dashboard.dashcards));
-    }
-  },
-);
 
 export const reloadDashboardCards = () => async (dispatch, getState) => {
   const dashboard = getDashboardComplete(getState());

--- a/frontend/src/metabase/dashboard/actions/revisions.js
+++ b/frontend/src/metabase/dashboard/actions/revisions.js
@@ -1,7 +1,6 @@
 import {
   fetchDashboard,
   fetchDashboardCardData,
-  fetchDashboardCardMetadata,
 } from "metabase/dashboard/actions";
 import Revision from "metabase/entities/revisions";
 import { createThunkAction } from "metabase/lib/redux";
@@ -18,10 +17,9 @@ export const revertToRevision = createThunkAction(
           queryParams: null,
         }),
       );
-      await Promise.all([
-        dispatch(fetchDashboardCardMetadata()),
-        dispatch(fetchDashboardCardData({ reload: false, clearCache: true })),
-      ]);
+      await dispatch(
+        fetchDashboardCardData({ reload: false, clearCache: true }),
+      );
     };
   },
 );

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -17,14 +17,13 @@ import {
 import { DashboardHeader } from "metabase/dashboard/components/DashboardHeader";
 import { DashboardControls } from "metabase/dashboard/hoc/DashboardControls";
 import type { DashboardControlsPassedProps } from "metabase/dashboard/hoc/types";
-import { getIsMetadataLoaded } from "metabase/dashboard/selectors";
 import type {
   FetchDashboardResult,
   SuccessfulFetchDashboardResult,
 } from "metabase/dashboard/types";
 import Dashboards from "metabase/entities/dashboards";
 import { getMainElement } from "metabase/lib/dom";
-import { useDispatch, useSelector } from "metabase/lib/redux";
+import { useDispatch } from "metabase/lib/redux";
 import type {
   Dashboard as IDashboard,
   DashboardCard,
@@ -93,7 +92,6 @@ export type DashboardProps = {
   editingOnLoad?: string | string[];
 
   initialize: (opts?: { clearCache?: boolean }) => void;
-  fetchDashboardCardMetadata: () => Promise<void>;
   cancelFetchDashboardCardData: () => void;
   addCardToDashboard: (opts: {
     dashId: DashboardId;
@@ -180,7 +178,6 @@ function DashboardInner(props: DashboardProps) {
     editingOnLoad,
     fetchDashboard,
     fetchDashboardCardData,
-    fetchDashboardCardMetadata,
     initialize,
     isEditing,
     isFullscreen,
@@ -209,7 +206,6 @@ function DashboardInner(props: DashboardProps) {
   const previousDashboardId = usePrevious(dashboardId);
   const previousTabId = usePrevious(selectedTabId);
   const previousParameterValues = usePrevious(parameterValues);
-  const isMetadataLoaded = useSelector(getIsMetadataLoaded);
 
   const currentTabDashcards = useMemo(() => {
     if (!dashboard || !Array.isArray(dashboard.dashcards)) {
@@ -330,7 +326,6 @@ function DashboardInner(props: DashboardProps) {
     );
 
     if (hasDashboardLoaded) {
-      fetchDashboardCardMetadata();
       fetchDashboardCardData({ reload: false, clearCache: true });
     } else if (hasTabChanged || hasParameterValueChanged) {
       fetchDashboardCardData();
@@ -339,7 +334,6 @@ function DashboardInner(props: DashboardProps) {
     dashboard,
     dashboardId,
     fetchDashboardCardData,
-    fetchDashboardCardMetadata,
     handleLoadDashboard,
     isInitialized,
     parameterValues,
@@ -423,7 +417,7 @@ function DashboardInner(props: DashboardProps) {
       isFullHeight={isEditing || isSharing}
       isFullscreen={isFullscreen}
       isNightMode={shouldRenderAsNightMode}
-      loading={!dashboard || !isMetadataLoaded}
+      loading={!dashboard}
       error={error}
     >
       {() => {

--- a/frontend/src/metabase/dashboard/constants.ts
+++ b/frontend/src/metabase/dashboard/constants.ts
@@ -28,9 +28,6 @@ export const INITIAL_DASHBOARD_STATE: DashboardState = {
     startTime: null,
     endTime: null,
   },
-  loadingMetadata: {
-    loadingStatus: "idle",
-  },
   loadingControls: {},
   isAddParameterPopoverOpen: false,
   isNavigatingBackToDashboard: false,

--- a/frontend/src/metabase/dashboard/containers/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/containers/Dashboard.jsx
@@ -6,17 +6,13 @@ import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import CS from "metabase/css/core/index.css";
 import DashboardS from "metabase/css/dashboard.module.css";
 import { DashboardGridConnected } from "metabase/dashboard/components/DashboardGrid";
-import { getIsMetadataLoaded } from "metabase/dashboard/selectors";
-import { useSelector } from "metabase/lib/redux";
 
 export function Dashboard({ dashboard, className, style, ...props }) {
-  const isMetadataLoaded = useSelector(getIsMetadataLoaded);
-
   return (
     <LoadingAndErrorWrapper
       className={cx(DashboardS.Dashboard, CS.p1, CS.flexFull, className)}
       style={style}
-      loading={!dashboard || !isMetadataLoaded}
+      loading={!dashboard}
       noBackground
     >
       {() => (

--- a/frontend/src/metabase/dashboard/hoc/DashboardData.jsx
+++ b/frontend/src/metabase/dashboard/hoc/DashboardData.jsx
@@ -48,7 +48,6 @@ export const DashboardData = ComposedComponent =>
           initialize,
           fetchDashboard,
           fetchDashboardCardData,
-          fetchDashboardCardMetadata,
           setErrorPage,
           location,
           dashboardId,
@@ -71,13 +70,10 @@ export const DashboardData = ComposedComponent =>
         }
 
         try {
-          await Promise.all([
-            fetchDashboardCardMetadata(),
-            fetchDashboardCardData({
-              reload: false,
-              clearCache: !isNavigatingBackToDashboard,
-            }),
-          ]);
+          await fetchDashboardCardData({
+            reload: false,
+            clearCache: !isNavigatingBackToDashboard,
+          });
         } catch (error) {
           console.error(error);
           setErrorPage(error);

--- a/frontend/src/metabase/dashboard/hooks/use-refresh-dashboard.ts
+++ b/frontend/src/metabase/dashboard/hooks/use-refresh-dashboard.ts
@@ -3,7 +3,6 @@ import { useCallback } from "react";
 import {
   fetchDashboard,
   fetchDashboardCardData,
-  fetchDashboardCardMetadata,
 } from "metabase/dashboard/actions";
 import { useDispatch } from "metabase/lib/redux";
 import type { DashboardId } from "metabase-types/api";
@@ -28,7 +27,6 @@ export const useRefreshDashboard = ({
           options: { preserveParameters: true },
         }),
       );
-      dispatch(fetchDashboardCardMetadata());
       dispatch(
         fetchDashboardCardData({
           isRefreshing: true,

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -48,7 +48,6 @@ import {
   FETCH_CARD_DATA_PENDING,
   SET_DISPLAY_THEME,
   fetchDashboard,
-  FETCH_DASHBOARD_CARD_METADATA,
 } from "./actions";
 import { INITIAL_DASHBOARD_STATE } from "./constants";
 import {
@@ -465,30 +464,6 @@ const loadingDashCards = handleActions(
   INITIAL_DASHBOARD_STATE.loadingDashCards,
 );
 
-const loadingMetadata = handleActions(
-  {
-    [INITIALIZE]: {
-      next: state => ({
-        ...state,
-        loadingStatus: "idle",
-      }),
-    },
-    [FETCH_DASHBOARD_CARD_METADATA]: {
-      next: state => ({
-        ...state,
-        loadingStatus: "complete",
-      }),
-    },
-    [RESET]: {
-      next: state => ({
-        ...state,
-        loadingStatus: "idle",
-      }),
-    },
-  },
-  INITIAL_DASHBOARD_STATE.loadingMetadata,
-);
-
 const DEFAULT_SIDEBAR = { props: {} };
 const sidebar = handleActions(
   {
@@ -559,7 +534,6 @@ export const dashboardReducers = reduceReducers(
     parameterValues,
     draftParameterValues,
     loadingDashCards,
-    loadingMetadata,
     isAddParameterPopoverOpen,
     isNavigatingBackToDashboard,
     sidebar,

--- a/frontend/src/metabase/dashboard/reducers.unit.spec.js
+++ b/frontend/src/metabase/dashboard/reducers.unit.spec.js
@@ -37,9 +37,6 @@ describe("dashboard reducers", () => {
         endTime: null,
         loadingStatus: "idle",
       },
-      loadingMetadata: {
-        loadingStatus: "idle",
-      },
       parameterValues: {},
       draftParameterValues: {},
       sidebar: { props: {} },

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -89,9 +89,6 @@ export const getLoadingStartTime = (state: State) =>
 export const getLoadingEndTime = (state: State) =>
   state.dashboard.loadingDashCards.endTime;
 
-export const getIsMetadataLoaded = (state: State) =>
-  state.dashboard.loadingMetadata.loadingStatus === "complete";
-
 export const getIsSlowDashboard = createSelector(
   [getLoadingStartTime, getLoadingEndTime],
   (startTime, endTime) => {

--- a/frontend/src/metabase/public/containers/PublicDashboard/PublicDashboard.tsx
+++ b/frontend/src/metabase/public/containers/PublicDashboard/PublicDashboard.tsx
@@ -15,7 +15,6 @@ import {
   cancelFetchDashboardCardData,
   fetchDashboard,
   fetchDashboardCardData,
-  fetchDashboardCardMetadata,
   initialize,
   setParameterValue,
   setParameterValueToDefault,
@@ -67,7 +66,6 @@ const mapStateToProps = (state: State) => {
 const mapDispatchToProps = {
   initialize,
   cancelFetchDashboardCardData,
-  fetchDashboardCardMetadata,
   setParameterValueToDefault,
   setParameterValue,
   setErrorPage,
@@ -107,7 +105,6 @@ class PublicDashboardInner extends Component<PublicDashboardProps> {
       initialize,
       fetchDashboard,
       fetchDashboardCardData,
-      fetchDashboardCardMetadata,
       setErrorPage,
       parameterQueryParams,
       dashboardId,
@@ -126,7 +123,6 @@ class PublicDashboardInner extends Component<PublicDashboardProps> {
     }
 
     try {
-      await fetchDashboardCardMetadata();
       if (this.props.dashboard?.tabs?.length === 0) {
         await fetchDashboardCardData({ reload: false, clearCache: true });
       }


### PR DESCRIPTION
https://metaboat.slack.com/archives/C0645JP1W81/p1717073476748389

The browser tries to be too smart and delays the metadata request even when it's sent first. As we block everything on metadata we need to load it before the cards. This PR mostly reverts previous changes in this area and uses the single BE endpoint for metadata.