### PR TITLE
Fix duplicate filter panels in fullscreen dashboards

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.tsx
@@ -71,7 +71,6 @@ import type {
 } from "metabase-types/store";
 
 import { DASHBOARD_PDF_EXPORT_ROOT_ID, SIDEBAR_NAME } from "../../constants";
-import { DashboardParameterList } from "../DashboardParameterList";
 import { ExtraEditButtonsMenu } from "../ExtraEditButtonsMenu/ExtraEditButtonsMenu";
 
 import {
@@ -359,10 +358,6 @@ export const DashboardHeader = (props: DashboardHeaderProps) => {
 
     const buttons = [];
     const extraButtons = [];
-
-    if (isFullscreen) {
-      buttons.push(<DashboardParameterList isFullscreen={isFullscreen} />);
-    }
 
     if (isEditing) {
       const activeSidebarName = sidebar.name;


### PR DESCRIPTION
In fullscreen dashboards, we used to display the filter panel inside the header. We stopped at some point, but didn't remove the code for that. Some recent changes brought them back while also keeping the main panel in place. This PR fixes the issue, so we always show the filters right below the header and nowhere else

### To verify

1. Open a dashboard with filters
2. Open the "More" menu in the top right ("..." icon) and select "Enter fullscreen"
3. Ensure filters are not duplicated

### Demo

**Before**

<img alt="Before" width="600px" src="https://github.com/metabase/metabase/assets/17258145/90c2e499-0aee-46ba-b057-326d48778469" />

**After**

<img alt="After" width="600px" src="https://github.com/metabase/metabase/assets/17258145/892425bd-5d9f-4263-a784-f88ee1c1a371" />
