### PR TITLE
Prep unit tests for React 18 upgrade

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
@@ -10,6 +10,7 @@ import {
   setupUnauthorizedCardEndpoints,
 } from "__support__/server-mocks";
 import {
+  act,
   renderWithProviders,
   screen,
   waitForLoaderToBeRemoved,
@@ -113,12 +114,12 @@ describe("InteractiveQuestion", () => {
     await waitForLoaderToBeRemoved();
 
     expect(
-      within(screen.getByTestId("TableInteractive-root")).getByText(
+      await within(screen.getByTestId("TableInteractive-root")).findByText(
         TEST_COLUMN.display_name,
       ),
     ).toBeInTheDocument();
     expect(
-      within(screen.getByRole("gridcell")).getByText("Test Row"),
+      await within(screen.getByRole("gridcell")).findByText("Test Row"),
     ).toBeInTheDocument();
 
     expect(screen.queryByTestId("loading-spinner")).not.toBeInTheDocument();
@@ -128,8 +129,10 @@ describe("InteractiveQuestion", () => {
       void,
       AnyAction
     >;
-    storeDispatch(clearQueryResult());
-    storeDispatch(runQuestionQuery());
+    act(() => {
+      storeDispatch(clearQueryResult());
+      storeDispatch(runQuestionQuery());
+    });
 
     expect(screen.queryByText("Question not found")).not.toBeInTheDocument();
     expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForDatabases.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForDatabases.unit.spec.tsx
@@ -1,3 +1,4 @@
+import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 
 import { act, screen } from "__support__/ui";
@@ -63,65 +64,63 @@ describe("StrategyEditorForDatabases", () => {
     const editButton = await screen.findByLabelText(
       `Edit default policy (currently: Duration)`,
     );
-    editButton.click();
+    await userEvent.click(editButton);
     expect(
       screen.queryByRole("button", { name: "Save changes" }),
     ).not.toBeInTheDocument();
 
-    await act(async () => {
-      const durationStrategyRadioButton = await screen.findByRole("radio", {
-        name: /keep the cache for a number of hours/i,
-      });
-      expect(durationStrategyRadioButton).toBeChecked();
-
-      expect((await screen.findAllByRole("spinbutton")).length).toBe(1);
-
-      await changeInput(/Cache results for this many hours/, 24, 48);
+    const durationStrategyRadioButton = await screen.findByRole("radio", {
+      name: /keep the cache for a number of hours/i,
     });
+    expect(durationStrategyRadioButton).toBeChecked();
 
-    (await screen.findByTestId("strategy-form-submit-button")).click();
+    expect((await screen.findAllByRole("spinbutton")).length).toBe(1);
+
+    await changeInput(/Cache results for this many hours/, 24, 48);
+
+    await userEvent.click(
+      await screen.findByTestId("strategy-form-submit-button"),
+    );
 
     expect(
       await screen.findByLabelText(`Edit default policy (currently: Duration)`),
     ).toBeInTheDocument();
 
-    await act(async () => {
-      const noCacheStrategyRadioButton = await screen.findByRole("radio", {
-        name: /Don.t cache/i,
-      });
-      noCacheStrategyRadioButton.click();
-
-      expect(screen.queryByRole("spinbutton")).not.toBeInTheDocument();
-
-      (await screen.findByTestId("strategy-form-submit-button")).click();
+    const noCacheStrategyRadioButton = await screen.findByRole("radio", {
+      name: /Don.t cache/i,
     });
+    await userEvent.click(noCacheStrategyRadioButton);
+
+    expect(screen.queryByRole("spinbutton")).not.toBeInTheDocument();
+
+    await userEvent.click(
+      await screen.findByTestId("strategy-form-submit-button"),
+    );
 
     expect(
-      await screen.findByRole("button", { name: /Saved/i }),
-    ).toBeInTheDocument();
+      await screen.findByTestId("strategy-form-submit-button"),
+    ).toHaveTextContent(/Saved/i);
 
     expect(await screen.findByLabelText(/Edit default policy/)).toHaveAttribute(
       "aria-label",
       "Edit default policy (currently: No caching)",
     );
 
-    await act(async () => {
-      const adaptiveStrategyRadioButton = await screen.findByRole("radio", {
-        name: /Adaptive/i,
-      });
-      adaptiveStrategyRadioButton.click();
+    const adaptiveStrategyRadioButton = await screen.findByRole("radio", {
+      name: /Adaptive/i,
     });
+    await userEvent.click(adaptiveStrategyRadioButton);
 
     expect((await screen.findAllByRole("spinbutton")).length).toBe(2);
 
     expect(await getSaveButton()).toBeInTheDocument();
 
-    await act(async () => {
-      await changeInput(/minimum query duration/i, 1, 5);
-      await changeInput(/multiplier/i, 10, 3);
-    });
+    await changeInput(/minimum query duration/i, 1, 5);
+    await changeInput(/multiplier/i, 10, 3);
 
-    (await screen.findByTestId("strategy-form-submit-button")).click();
+    await userEvent.click(
+      await screen.findByTestId("strategy-form-submit-button"),
+    );
 
     expect(
       await screen.findByLabelText(`Edit default policy (currently: Adaptive)`),
@@ -132,22 +131,22 @@ describe("StrategyEditorForDatabases", () => {
     const editButton = await screen.findByLabelText(
       `Edit policy for database 'Database 1' (currently: Adaptive)`,
     );
-    editButton.click();
+    await userEvent.click(editButton);
 
     expect(
       screen.queryByRole("button", { name: "Save changes" }),
     ).not.toBeInTheDocument();
 
-    await act(async () => {
-      const noCacheStrategyRadioButton = await screen.findByRole("radio", {
-        name: /Don.t cache/i,
-      });
-      noCacheStrategyRadioButton.click();
-
-      expect(screen.queryByRole("spinbutton")).not.toBeInTheDocument();
+    const noCacheStrategyRadioButton = await screen.findByRole("radio", {
+      name: /Don.t cache/i,
     });
+    await userEvent.click(noCacheStrategyRadioButton);
 
-    (await screen.findByTestId("strategy-form-submit-button")).click();
+    expect(screen.queryByRole("spinbutton")).not.toBeInTheDocument();
+
+    await userEvent.click(
+      await screen.findByTestId("strategy-form-submit-button"),
+    );
 
     expect(
       await screen.findByLabelText(
@@ -155,20 +154,21 @@ describe("StrategyEditorForDatabases", () => {
       ),
     ).toBeInTheDocument();
 
-    await act(async () => {
-      const durationStrategyRadioButton = await screen.findByRole("radio", {
-        name: /keep the cache for a number of hours/i,
-      });
-      durationStrategyRadioButton.click();
-
-      expect((await screen.findAllByRole("spinbutton")).length).toBe(1);
-
-      await changeInput(/Cache results for this many hours/, 24, 48);
+    const durationStrategyRadioButton = await screen.findByRole("radio", {
+      name: /keep the cache for a number of hours/i,
     });
-    (await screen.findByTestId("strategy-form-submit-button")).click();
+    await userEvent.click(durationStrategyRadioButton);
+
+    expect((await screen.findAllByRole("spinbutton")).length).toBe(1);
+
+    await changeInput(/Cache results for this many hours/, 24, 48);
+
+    await userEvent.click(
+      await screen.findByTestId("strategy-form-submit-button"),
+    );
     expect(
-      await screen.findByRole("button", { name: /Saved/i }),
-    ).toBeInTheDocument();
+      await screen.findByTestId("strategy-form-submit-button"),
+    ).toHaveTextContent(/Saved/i);
 
     expect(
       await screen.findByLabelText(/Edit policy for database 'Database 1'/),
@@ -181,7 +181,7 @@ describe("StrategyEditorForDatabases", () => {
     const multiplierStrategyRadioButton = await screen.findByRole("radio", {
       name: /Adaptive/i,
     });
-    multiplierStrategyRadioButton.click();
+    await userEvent.click(multiplierStrategyRadioButton);
 
     expect((await screen.findAllByRole("spinbutton")).length).toBe(2);
 
@@ -190,7 +190,9 @@ describe("StrategyEditorForDatabases", () => {
       await changeInput(/multiplier/i, 10, 3);
     });
 
-    (await screen.findByTestId("strategy-form-submit-button")).click();
+    await userEvent.click(
+      await screen.findByTestId("strategy-form-submit-button"),
+    );
 
     expect(
       await screen.findByLabelText(

--- a/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-QueryActions.unit.spec.ts
+++ b/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-QueryActions.unit.spec.ts
@@ -143,7 +143,7 @@ describe("ActionCreator > Query Actions", () => {
 
       screen.getByLabelText("Action settings").click();
 
-      expect(screen.getByLabelText("Success message")).toBeDisabled();
+      expect(await screen.findByLabelText("Success message")).toBeDisabled();
     });
 
     it("blocks editing if actions are disabled for the database", async () => {
@@ -161,7 +161,7 @@ describe("ActionCreator > Query Actions", () => {
 
       screen.getByLabelText("Action settings").click();
 
-      expect(screen.getByLabelText("Success message")).toBeDisabled();
+      expect(await screen.findByLabelText("Success message")).toBeDisabled();
     });
   });
 });

--- a/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-Sharing.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-Sharing.unit.spec.tsx
@@ -46,9 +46,13 @@ describe("ActionCreator > Sharing", () => {
           isPublicSharingEnabled: true,
         });
 
-        screen.getByRole("button", { name: "Action settings" }).click();
+        await userEvent.click(
+          screen.getByRole("button", { name: "Action settings" }),
+        );
 
-        expect(screen.getByText("Action settings")).toBeInTheDocument();
+        const headerTitle = await screen.findByTestId("sidebar-header-title");
+        expect(headerTitle).toBeInTheDocument();
+        expect(headerTitle).toHaveTextContent("Action settings");
         const makePublicToggle = screen.getByRole("switch", {
           name: "Make public",
         });
@@ -57,7 +61,9 @@ describe("ActionCreator > Sharing", () => {
           screen.queryByRole("textbox", { name: "Public action form URL" }),
         ).not.toBeInTheDocument();
 
-        screen.getByRole("switch", { name: "Make public" }).click();
+        await userEvent.click(
+          screen.getByRole("switch", { name: "Make public" }),
+        );
 
         await waitFor(() => {
           expect(makePublicToggle).toBeChecked();
@@ -75,9 +81,13 @@ describe("ActionCreator > Sharing", () => {
           isAdmin: true,
           isPublicSharingEnabled: true,
         });
-        screen.getByRole("button", { name: "Action settings" }).click();
+        await userEvent.click(
+          screen.getByRole("button", { name: "Action settings" }),
+        );
 
-        expect(screen.getByText("Action settings")).toBeInTheDocument();
+        const headerTitle = await screen.findByTestId("sidebar-header-title");
+        expect(headerTitle).toBeInTheDocument();
+        expect(headerTitle).toHaveTextContent("Action settings");
         const makePublicToggle = screen.getByRole("switch", {
           name: "Make public",
         });
@@ -87,11 +97,11 @@ describe("ActionCreator > Sharing", () => {
           screen.getByRole("textbox", { name: "Public action form URL" }),
         ).toHaveValue(expectedPublicLinkUrl);
 
-        makePublicToggle.click();
+        await userEvent.click(makePublicToggle);
         expect(
           screen.getByRole("heading", { name: "Disable this public link?" }),
         ).toBeInTheDocument();
-        screen.getByRole("button", { name: "Yes" }).click();
+        await userEvent.click(screen.getByRole("button", { name: "Yes" }));
 
         await waitFor(() => {
           expect(makePublicToggle).not.toBeChecked();

--- a/frontend/src/metabase/actions/containers/ActionCreatorModal/ActionCreatorModal.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreatorModal/ActionCreatorModal.unit.spec.tsx
@@ -12,6 +12,7 @@ import {
   screen,
   waitFor,
   waitForLoaderToBeRemoved,
+  act,
 } from "__support__/ui";
 import { checkNotNull } from "metabase/lib/types";
 import type { Card, WritebackAction } from "metabase-types/api";
@@ -58,9 +59,7 @@ async function setup({
         component={routeProps => (
           <ActionCreatorModal
             {...routeProps}
-            onClose={() => {
-              history?.push(`/model/${MODEL.id}/detail/actions`);
-            }}
+            onClose={() => history?.push(`/model/${MODEL.id}/detail/actions`)}
           />
         )}
       />
@@ -123,13 +122,17 @@ describe("actions > containers > ActionCreatorModal", () => {
       const actionRoute = `/model/${MODEL.id}/detail/actions/action`;
       const { history } = await setup({ initialRoute, action: null });
 
-      history.push(actionRoute);
+      act(() => {
+        history.push(actionRoute);
+      });
 
       await waitFor(() => {
         expect(screen.getByTestId("action-creator")).toBeInTheDocument();
       });
 
-      history.goBack();
+      act(() => {
+        history.goBack();
+      });
 
       expect(
         screen.queryByTestId("leave-confirmation"),
@@ -141,7 +144,9 @@ describe("actions > containers > ActionCreatorModal", () => {
       const actionRoute = `/model/${MODEL.id}/detail/actions/new`;
       const { history } = await setup({ initialRoute, action: null });
 
-      history.push(actionRoute);
+      act(() => {
+        history.push(actionRoute);
+      });
 
       await waitFor(() => {
         expect(screen.getByTestId("action-creator")).toBeInTheDocument();
@@ -150,7 +155,9 @@ describe("actions > containers > ActionCreatorModal", () => {
       await userEvent.type(screen.getByDisplayValue("New Action"), "a change");
       await userEvent.tab(); // need to click away from the input to re-compute the isDirty flag
 
-      history.goBack();
+      act(() => {
+        history.goBack();
+      });
 
       expect(screen.getByTestId("leave-confirmation")).toBeInTheDocument();
     });
@@ -160,11 +167,11 @@ describe("actions > containers > ActionCreatorModal", () => {
       const actionRoute = `/model/${MODEL.id}/detail/actions/new`;
       const { history } = await setup({ initialRoute, action: null });
 
-      history.push(actionRoute);
-
-      await waitFor(() => {
-        expect(screen.getByTestId("action-creator")).toBeInTheDocument();
+      act(() => {
+        history.push(actionRoute);
       });
+
+      expect(await screen.findByTestId("action-creator")).toBeInTheDocument();
 
       const query = "select 1;";
 
@@ -215,7 +222,9 @@ describe("actions > containers > ActionCreatorModal", () => {
       const actionRoute = `/model/${MODEL.id}/detail/actions/${action.id}`;
       const { history } = await setup({ initialRoute, action });
 
-      history.push(actionRoute);
+      act(() => {
+        history.push(actionRoute);
+      });
 
       await waitFor(() => {
         expect(screen.getByTestId("action-creator")).toBeInTheDocument();
@@ -227,7 +236,9 @@ describe("actions > containers > ActionCreatorModal", () => {
       await userEvent.type(input, "{backspace}{backspace}");
       await userEvent.tab(); // need to click away from the input to re-compute the isDirty flag
 
-      history.goBack();
+      act(() => {
+        history.goBack();
+      });
 
       expect(
         screen.queryByTestId("leave-confirmation"),
@@ -240,7 +251,9 @@ describe("actions > containers > ActionCreatorModal", () => {
       const actionRoute = `/model/${MODEL.id}/detail/actions/${action.id}`;
       const { history } = await setup({ initialRoute, action });
 
-      history.push(actionRoute);
+      act(() => {
+        history.push(actionRoute);
+      });
 
       await waitFor(() => {
         expect(screen.getByTestId("action-creator")).toBeInTheDocument();
@@ -249,9 +262,13 @@ describe("actions > containers > ActionCreatorModal", () => {
       await userEvent.type(screen.getByDisplayValue(action.name), "a change");
       await userEvent.tab(); // need to click away from the input to re-compute the isDirty flag
 
-      history.goBack();
+      act(() => {
+        history.goBack();
+      });
 
-      expect(screen.getByTestId("leave-confirmation")).toBeInTheDocument();
+      expect(
+        await screen.findByTestId("leave-confirmation"),
+      ).toBeInTheDocument();
     });
 
     it("does not show custom warning modal when saving changes", async () => {
@@ -261,7 +278,9 @@ describe("actions > containers > ActionCreatorModal", () => {
       const actionRoute = `/model/${MODEL.id}/detail/actions/${action.id}`;
       const { history } = await setup({ initialRoute, action });
 
-      history.push(actionRoute);
+      act(() => {
+        history.push(actionRoute);
+      });
 
       await waitFor(() => {
         expect(screen.getByTestId("action-creator")).toBeInTheDocument();

--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.unit.spec.tsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.unit.spec.tsx
@@ -168,7 +168,9 @@ describe("DatabaseEditApp", () => {
 
       history.goBack();
 
-      expect(screen.getByTestId("leave-confirmation")).toBeInTheDocument();
+      expect(
+        await screen.findByTestId("leave-confirmation"),
+      ).toBeInTheDocument();
     });
 
     it("does not show custom warning modal after creating new database connection", async () => {

--- a/frontend/src/metabase/admin/datamodel/components/filters/pickers/BooleanPicker/BooleanPicker.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/filters/pickers/BooleanPicker/BooleanPicker.unit.spec.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import { createMockMetadata } from "__support__/metadata";
 import { checkNotNull } from "metabase/lib/types";
@@ -50,16 +51,16 @@ describe("BooleanPicker", () => {
   const invalidFilter = new Filter(["=", fieldRef], query);
 
   describe("BooleanPickerRadio", () => {
-    it("should hide empty options when empty options are not selected", () => {
+    it("should hide empty options when empty options are not selected", async () => {
       setup(filters.True);
 
       expect(screen.queryByLabelText("Empty")).not.toBeInTheDocument();
       expect(screen.queryByLabelText("Not empty")).not.toBeInTheDocument();
 
-      screen.getByText("More options").click();
+      await userEvent.click(screen.getByText("More options"));
 
-      expect(screen.getByLabelText("Empty")).toBeInTheDocument();
-      expect(screen.getByLabelText("Not empty")).toBeInTheDocument();
+      expect(await screen.findByLabelText("Empty")).toBeInTheDocument();
+      expect(await screen.findByLabelText("Not empty")).toBeInTheDocument();
     });
 
     it("should show empty options when given an empty filter", () => {
@@ -77,10 +78,10 @@ describe("BooleanPicker", () => {
         expect(screen.getByLabelText(label)).toBeChecked();
       });
 
-      it(`should correctly update the filter for the "${label}" option when it is selected`, () => {
+      it(`should correctly update the filter for the "${label}" option when it is selected`, async () => {
         setup(label === "True" ? filters.False : filters.True);
 
-        screen.getByText("More options").click();
+        await userEvent.click(screen.getByText("More options"));
 
         screen.getByLabelText(label).click();
         expect(mockOnFilterChange).toHaveBeenCalled();
@@ -127,7 +128,7 @@ describe("BooleanPicker", () => {
       });
     });
 
-    it("should toggle between true and false states", () => {
+    it("should toggle between true and false states", async () => {
       mockOnFilterChange.mockReset();
       render(
         <BooleanPickerCheckbox
@@ -136,13 +137,13 @@ describe("BooleanPicker", () => {
         />,
       );
 
-      screen.getByText("False").click();
+      await userEvent.click(screen.getByText("False"));
 
       const newFilter = mockOnFilterChange.mock.calls[0][0];
       expect(newFilter.raw()).toEqual(filters.False.raw());
     });
 
-    it("should remove true/false filter on deselect", () => {
+    it("should remove true/false filter on deselect", async () => {
       mockOnFilterChange.mockReset();
       render(
         <BooleanPickerCheckbox
@@ -151,7 +152,7 @@ describe("BooleanPicker", () => {
         />,
       );
 
-      screen.getByText("True").click();
+      await userEvent.click(screen.getByText("True"));
 
       const newFilter = mockOnFilterChange.mock.calls[0][0];
       expect(newFilter.raw()).toEqual(invalidFilter.raw());

--- a/frontend/src/metabase/admin/datamodel/containers/SegmentApp.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/containers/SegmentApp.unit.spec.tsx
@@ -8,6 +8,7 @@ import {
   setupSegmentsEndpoints,
 } from "__support__/server-mocks";
 import {
+  act,
   renderWithProviders,
   screen,
   waitFor,
@@ -84,9 +85,10 @@ describe("SegmentApp", () => {
   it("does not show custom warning modal when leaving with no changes via SPA navigation", () => {
     const { history } = setup({ initialRoute: "/" });
 
-    history.push(FORM_URL);
-
-    history.goBack();
+    act(() => {
+      history.push(FORM_URL);
+      history.goBack();
+    });
 
     expect(screen.queryByTestId("leave-confirmation")).not.toBeInTheDocument();
   });
@@ -94,13 +96,20 @@ describe("SegmentApp", () => {
   it("shows custom warning modal when leaving with unsaved changes via SPA navigation", async () => {
     const { history } = setup({ initialRoute: "/" });
 
-    history.push(FORM_URL);
+    act(() => {
+      history.push(FORM_URL);
+    });
 
-    await userEvent.type(screen.getByLabelText("Name Your Segment"), "Name");
+    await userEvent.type(
+      await screen.findByLabelText("Name Your Segment"),
+      "Name",
+    );
 
-    history.goBack();
+    act(() => {
+      history.goBack();
+    });
 
-    expect(screen.getByTestId("leave-confirmation")).toBeInTheDocument();
+    expect(await screen.findByTestId("leave-confirmation")).toBeInTheDocument();
   });
 
   it("does not show custom warning modal when saving changes", async () => {
@@ -110,7 +119,7 @@ describe("SegmentApp", () => {
 
     await waitForLoaderToBeRemoved();
 
-    await userEvent.click(screen.getByText("Orders"));
+    await userEvent.click(await screen.findByText("Orders"));
 
     await waitForLoaderToBeRemoved();
 

--- a/frontend/src/metabase/admin/datamodel/metadata/components/MetadataEditor/MetadataEditor.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/MetadataEditor/MetadataEditor.unit.spec.tsx
@@ -519,7 +519,7 @@ describe("MetadataEditor", () => {
 
       history?.goBack();
 
-      expect(screen.getByText("Link to Datamodel")).toBeInTheDocument();
+      expect(await screen.findByText("Link to Datamodel")).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/metabase/admin/performance/components/StrategyEditorForDatabases.unit.spec.tsx
+++ b/frontend/src/metabase/admin/performance/components/StrategyEditorForDatabases.unit.spec.tsx
@@ -1,4 +1,6 @@
-import { act, screen } from "__support__/ui";
+import userEvent from "@testing-library/user-event";
+
+import { screen } from "__support__/ui";
 
 import {
   changeInput,
@@ -18,28 +20,27 @@ describe("StrategyEditorForDatabases", () => {
     const ttlStrategyRadioButton = await screen.findByRole("radio", {
       name: /Adaptive/i,
     });
-    ttlStrategyRadioButton.click();
+
+    await userEvent.click(ttlStrategyRadioButton);
 
     expect((await screen.findAllByRole("spinbutton")).length).toBe(2);
 
     expect(await getSaveButton()).toBeInTheDocument();
 
-    await act(async () => {
-      await changeInput(/minimum query duration/i, 1, 5);
-      await changeInput(/multiplier/i, 10, 3);
-    });
+    await changeInput(/minimum query duration/i, 1, 5);
+    await changeInput(/multiplier/i, 10, 3);
 
-    (await screen.findByTestId("strategy-form-submit-button")).click();
+    await userEvent.click(
+      await screen.findByTestId("strategy-form-submit-button"),
+    );
 
     // NOTE: There is no need to check that the submission of the form was successful.
     // It doesn't meaningfully change the state of the component on OSS
 
-    await act(async () => {
-      const noCacheStrategyRadioButton = await screen.findByRole("radio", {
-        name: /Don.t cache/i,
-      });
-      noCacheStrategyRadioButton.click();
+    const noCacheStrategyRadioButton = await screen.findByRole("radio", {
+      name: /Don.t cache/i,
     });
+    noCacheStrategyRadioButton.click();
     expect(screen.queryByRole("spinbutton")).not.toBeInTheDocument();
 
     (await screen.findByTestId("strategy-form-submit-button")).click();

--- a/frontend/src/metabase/admin/performance/components/test-utils.tsx
+++ b/frontend/src/metabase/admin/performance/components/test-utils.tsx
@@ -3,7 +3,7 @@ import { setupDatabasesEndpoints } from "__support__/server-mocks";
 import { setupPerformanceEndpoints } from "__support__/server-mocks/performance";
 import { mockSettings } from "__support__/settings";
 import { createMockEntitiesState } from "__support__/store";
-import { fireEvent, renderWithProviders, screen } from "__support__/ui";
+import { act, fireEvent, renderWithProviders, screen } from "__support__/ui";
 import type { TokenFeatures } from "metabase-types/api";
 import { DurationUnit } from "metabase-types/api";
 import {
@@ -77,6 +77,8 @@ export const changeInput = async (
     name: new RegExp(label),
   })) as HTMLInputElement;
   expect(input).toHaveAttribute("placeholder", expectedPlaceholder.toString());
-  fireEvent.change(input, { target: { value } });
+  act(() => {
+    fireEvent.change(input, { target: { value } });
+  });
   expect(input).toHaveValue(value);
 };

--- a/frontend/src/metabase/admin/permissions/test/DatabasesPermissionsPage/DatabasesPermissionsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/test/DatabasesPermissionsPage/DatabasesPermissionsPage.unit.spec.tsx
@@ -1,3 +1,4 @@
+import { userEvent } from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 import { Route } from "react-router";
 
@@ -10,7 +11,6 @@ import {
 import {
   renderWithProviders,
   screen,
-  fireEvent,
   waitForLoaderToBeRemoved,
 } from "__support__/ui";
 import DataPermissionsPage from "metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage";
@@ -67,10 +67,10 @@ const editDatabasePermission = async () => {
   const permissionsSelectElem = (
     await screen.findAllByTestId("permissions-select")
   )[NATIVE_QUERIES_PERMISSION_INDEX];
-  fireEvent.click(permissionsSelectElem);
+  await userEvent.click(permissionsSelectElem);
 
   const clickElement = screen.getByLabelText(/close icon/);
-  fireEvent.click(clickElement);
+  await userEvent.click(clickElement);
 
   await delay(0);
 };

--- a/frontend/src/metabase/admin/permissions/test/DatabasesPermissionsPage/DatabasesPermissionsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/test/DatabasesPermissionsPage/DatabasesPermissionsPage.unit.spec.tsx
@@ -64,10 +64,9 @@ const setup = async () => {
 };
 
 const editDatabasePermission = async () => {
-  const permissionsSelectElem =
-    screen.getAllByTestId("permissions-select")[
-      NATIVE_QUERIES_PERMISSION_INDEX
-    ];
+  const permissionsSelectElem = (
+    await screen.findAllByTestId("permissions-select")
+  )[NATIVE_QUERIES_PERMISSION_INDEX];
   fireEvent.click(permissionsSelectElem);
 
   const clickElement = screen.getByLabelText(/close icon/);

--- a/frontend/src/metabase/admin/permissions/test/GroupsPermissionsPage/GroupsPermissionsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/test/GroupsPermissionsPage/GroupsPermissionsPage.unit.spec.tsx
@@ -1,3 +1,4 @@
+import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 import { Route } from "react-router";
 
@@ -10,7 +11,6 @@ import {
 import {
   renderWithProviders,
   screen,
-  fireEvent,
   waitForLoaderToBeRemoved,
 } from "__support__/ui";
 import DataPermissionsPage from "metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage";
@@ -65,14 +65,13 @@ const setup = async ({
 };
 
 const editDatabasePermission = async () => {
-  const permissionsSelectElem =
-    screen.getAllByTestId("permissions-select")[
-      NATIVE_QUERIES_PERMISSION_INDEX
-    ];
-  fireEvent.click(permissionsSelectElem);
+  const permissionsSelectElem = (
+    await screen.findAllByTestId("permissions-select")
+  )[NATIVE_QUERIES_PERMISSION_INDEX];
+  await userEvent.click(permissionsSelectElem);
 
-  const clickElement = screen.getByLabelText(/close icon/);
-  fireEvent.click(clickElement);
+  const clickElement = await screen.findByLabelText(/close icon/);
+  await userEvent.click(clickElement);
 
   await delay(0);
 };

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/common.embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/common.embedding.unit.spec.tsx
@@ -1,4 +1,4 @@
-import { screen } from "__support__/ui";
+import { act, screen } from "__support__/ui";
 
 import {
   goToStaticEmbeddingSettings,
@@ -19,7 +19,9 @@ describe("[OSS] embedding settings", () => {
 
         expect(screen.getByRole("button", { name: "Manage" })).toBeDisabled();
 
-        history.push(staticEmbeddingSettingsUrl);
+        act(() => {
+          history.push(staticEmbeddingSettingsUrl);
+        });
 
         expect(history.getCurrentLocation().pathname).toEqual(
           embeddingSettingsUrl,
@@ -48,7 +50,9 @@ describe("[OSS] embedding settings", () => {
           settingValues: { "enable-embedding": false },
         });
 
-        history.push(interactiveEmbeddingSettingsUrl);
+        act(() => {
+          history.push(interactiveEmbeddingSettingsUrl);
+        });
 
         expect(history.getCurrentLocation().pathname).toEqual(
           embeddingSettingsUrl,
@@ -120,7 +124,9 @@ describe("[OSS] embedding settings", () => {
         screen.getByRole("link", { name: "Learn More" }),
       ).toBeInTheDocument();
 
-      history.push(interactiveEmbeddingSettingsUrl);
+      act(() => {
+        history.push(interactiveEmbeddingSettingsUrl);
+      });
 
       expect(history.getCurrentLocation().pathname).toEqual(
         embeddingSettingsUrl,

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/enterprise.embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/enterprise.embedding.unit.spec.tsx
@@ -1,4 +1,4 @@
-import { screen } from "__support__/ui";
+import { act, screen } from "__support__/ui";
 
 import type { SetupOpts } from "./setup";
 import {
@@ -28,7 +28,9 @@ describe("[EE, no token] embedding settings", () => {
 
         expect(screen.getByRole("button", { name: "Manage" })).toBeDisabled();
 
-        history.push(staticEmbeddingSettingsUrl);
+        act(() => {
+          history.push(staticEmbeddingSettingsUrl);
+        });
 
         expect(history.getCurrentLocation().pathname).toEqual(
           embeddingSettingsUrl,
@@ -57,7 +59,9 @@ describe("[EE, no token] embedding settings", () => {
           settingValues: { "enable-embedding": false },
         });
 
-        history.push(interactiveEmbeddingSettingsUrl);
+        act(() => {
+          history.push(interactiveEmbeddingSettingsUrl);
+        });
 
         expect(history.getCurrentLocation().pathname).toEqual(
           embeddingSettingsUrl,
@@ -130,7 +134,9 @@ describe("[EE, no token] embedding settings", () => {
         screen.getByRole("link", { name: "Learn More" }),
       ).toBeInTheDocument();
 
-      history.push(interactiveEmbeddingSettingsUrl);
+      act(() => {
+        history.push(interactiveEmbeddingSettingsUrl);
+      });
 
       expect(history.getCurrentLocation().pathname).toEqual(
         embeddingSettingsUrl,

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/premium.embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/premium.embedding.unit.spec.tsx
@@ -1,4 +1,4 @@
-import { screen } from "__support__/ui";
+import { act, screen } from "__support__/ui";
 
 import type { SetupOpts } from "./setup";
 import {
@@ -31,7 +31,9 @@ describe("[EE, with token] embedding settings", () => {
           await screen.findByRole("button", { name: "Manage" }),
         ).toBeDisabled();
 
-        history.push(staticEmbeddingSettingsUrl);
+        act(() => {
+          history.push(staticEmbeddingSettingsUrl);
+        });
 
         expect(history.getCurrentLocation().pathname).toEqual(
           embeddingSettingsUrl,
@@ -59,7 +61,9 @@ describe("[EE, with token] embedding settings", () => {
           await screen.findByRole("button", { name: "Configure" }),
         ).toBeDisabled();
 
-        history.push(interactiveEmbeddingSettingsUrl);
+        act(() => {
+          history.push(interactiveEmbeddingSettingsUrl);
+        });
 
         expect(history.getCurrentLocation().pathname).toEqual(
           embeddingSettingsUrl,

--- a/frontend/src/metabase/components/LoadingAndErrorWrapper/LoadingAndErrorWrapper.unit.spec.js
+++ b/frontend/src/metabase/components/LoadingAndErrorWrapper/LoadingAndErrorWrapper.unit.spec.js
@@ -1,5 +1,4 @@
-import { render, screen } from "@testing-library/react";
-
+import { act, render, screen } from "__support__/ui";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 
 describe("LoadingAndErrorWrapper", () => {
@@ -56,13 +55,19 @@ describe("LoadingAndErrorWrapper", () => {
         );
 
         expect(screen.getByText("One")).toBeInTheDocument();
-        jest.advanceTimersByTime(interval);
+        act(() => {
+          jest.advanceTimersByTime(interval);
+        });
 
         expect(screen.getByText("Two")).toBeInTheDocument();
-        jest.advanceTimersByTime(interval);
+        act(() => {
+          jest.advanceTimersByTime(interval);
+        });
 
         expect(screen.getByText("Three")).toBeInTheDocument();
-        jest.advanceTimersByTime(interval);
+        act(() => {
+          jest.advanceTimersByTime(interval);
+        });
 
         expect(screen.getByText("One")).toBeInTheDocument();
       });

--- a/frontend/src/metabase/components/MetadataInfo/TableInfoIcon/TableInfoIcon.unit.spec.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/TableInfoIcon/TableInfoIcon.unit.spec.tsx
@@ -1,5 +1,5 @@
 import { createMockEntitiesState } from "__support__/store";
-import { fireEvent, renderWithProviders, screen } from "__support__/ui";
+import { act, fireEvent, renderWithProviders, screen } from "__support__/ui";
 import type { Table } from "metabase-types/api";
 import { createMockTable } from "metabase-types/api/mocks";
 import { createMockState } from "metabase-types/store/mocks";
@@ -36,7 +36,9 @@ describe("TableInfoIcon", () => {
     expect(screen.queryByText(description)).not.toBeInTheDocument();
 
     fireEvent.mouseEnter(icon);
-    jest.advanceTimersByTime(1000);
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
 
     expect(screen.getByText(description, { exact: false })).toBeInTheDocument();
   });

--- a/frontend/src/metabase/components/TokenField/TokenField.unit.spec.js
+++ b/frontend/src/metabase/components/TokenField/TokenField.unit.spec.js
@@ -1,7 +1,7 @@
 /* eslint-disable jest/expect-expect */
 /* eslint-disable react/prop-types */
 
-import { render, screen, fireEvent, within } from "@testing-library/react";
+import { act, render, screen, fireEvent, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Component } from "react";
 
@@ -286,7 +286,9 @@ describe("TokenField", () => {
       expect(input().value).toEqual("");
 
       // Reset search on focus (it was a separate test before)
-      input().focus();
+      act(() => {
+        input().focus();
+      });
       findWithinOptions(["Doohickey", "Gizmo", "Widget"]);
     });
 

--- a/frontend/src/metabase/containers/AdHocQuestionLoader.unit.spec.js
+++ b/frontend/src/metabase/containers/AdHocQuestionLoader.unit.spec.js
@@ -22,7 +22,7 @@ describe("AdHocQuestionLoader", () => {
     const q = Question.create({ databaseId: 1, tableId: 2 });
     const questionHash = ML_Urls.getUrl(q).match(/(#.*)/)[1];
 
-    render(
+    await render(
       <AdHocQuestionLoader
         questionHash={questionHash}
         loadMetadataForCard={loadMetadataSpy}

--- a/frontend/src/metabase/containers/AdHocQuestionLoader.unit.spec.js
+++ b/frontend/src/metabase/containers/AdHocQuestionLoader.unit.spec.js
@@ -22,7 +22,7 @@ describe("AdHocQuestionLoader", () => {
     const q = Question.create({ databaseId: 1, tableId: 2 });
     const questionHash = ML_Urls.getUrl(q).match(/(#.*)/)[1];
 
-    await render(
+    render(
       <AdHocQuestionLoader
         questionHash={questionHash}
         loadMetadataForCard={loadMetadataSpy}

--- a/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeSelector.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeSelector.unit.spec.tsx
@@ -36,7 +36,7 @@ describe("ColorRangeSelector", () => {
     screen.getByRole("button").click();
     expect(await screen.findByRole("tooltip")).toBeInTheDocument();
 
-    screen.getByLabelText(color("summarize")).click();
+    (await screen.findByLabelText(color("summarize"))).click();
     expect(onChange).toHaveBeenCalled();
 
     screen.getByLabelText(color("filter")).click();
@@ -49,13 +49,17 @@ describe("ColorRangeSelector", () => {
     screen.getByRole("button").click();
     expect(await screen.findByRole("tooltip")).toBeInTheDocument();
 
-    screen.getByLabelText(getColorRangeLabel(DEFAULT_VALUE)).click();
+    (await screen.findByLabelText(getColorRangeLabel(DEFAULT_VALUE))).click();
     expect(onChange).not.toHaveBeenCalled();
 
-    screen.getByLabelText(getColorRangeLabel(WHITE_COLOR_RANGE)).click();
+    (
+      await screen.findByLabelText(getColorRangeLabel(WHITE_COLOR_RANGE))
+    ).click();
     expect(onChange).toHaveBeenCalled();
 
-    screen.getByLabelText(getColorRangeLabel(WARNING_COLOR_RANGE)).click();
+    (
+      await screen.findByLabelText(getColorRangeLabel(WARNING_COLOR_RANGE))
+    ).click();
     expect(onChange).toHaveBeenCalled();
   });
 });

--- a/frontend/src/metabase/core/components/TabButton/TabButton.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.unit.spec.tsx
@@ -66,7 +66,7 @@ describe("TabButton", () => {
     (await renameOption()).click();
 
     const newLabel = "A new label";
-    const inputEl = screen.getByRole("textbox");
+    const inputEl = await screen.findByRole("textbox");
     await userEvent.clear(inputEl);
     await userEvent.type(inputEl, `${newLabel}{enter}`);
 
@@ -97,7 +97,7 @@ describe("TabButton", () => {
     const newLabel = "a".repeat(100);
     const expectedLabel = newLabel.slice(0, 75);
 
-    const inputEl = screen.getByRole("textbox");
+    const inputEl = await screen.findByRole("textbox");
     await userEvent.clear(inputEl);
     await userEvent.type(inputEl, `${newLabel}{enter}`);
 

--- a/frontend/src/metabase/core/components/Tooltip/Tooltip.unit.spec.js
+++ b/frontend/src/metabase/core/components/Tooltip/Tooltip.unit.spec.js
@@ -128,7 +128,7 @@ describe("Tooltip", () => {
     );
   });
 
-  it("should support using a reference element instead of a child target element", () => {
+  it("should support using a reference element instead of a child target element", async () => {
     function ReferenceTooltipTest() {
       const [eventTarget, setEventTarget] = useState();
       return (
@@ -149,7 +149,7 @@ describe("Tooltip", () => {
     render(<ReferenceTooltipTest />);
     expect(screen.queryByText("reference tooltip")).not.toBeInTheDocument();
 
-    screen.getByText("sibling element").click();
+    await userEvent.click(screen.getByText("sibling element"));
 
     expect(screen.getByText("reference tooltip")).toBeInTheDocument();
   });

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/tests/common.unit.spec.tsx
@@ -13,7 +13,9 @@ describe("DashboardHeader", () => {
       dashboard: TEST_DASHBOARD,
     });
 
-    await userEvent.click(screen.getByLabelText("dashboard-menu-button"));
+    await userEvent.click(
+      await screen.findByLabelText("dashboard-menu-button"),
+    );
     await screen.findByRole("dialog");
 
     const exportPdfButton = within(
@@ -27,7 +29,9 @@ describe("DashboardHeader", () => {
       dashboard: TEST_DASHBOARD_WITH_TABS,
     });
 
-    await userEvent.click(screen.getByLabelText("dashboard-menu-button"));
+    await userEvent.click(
+      await screen.findByLabelText("dashboard-menu-button"),
+    );
     await screen.findByRole("dialog");
 
     const exportPdfButton = within(
@@ -53,6 +57,6 @@ describe("DashboardHeader", () => {
       slack: false,
     });
 
-    expect(screen.getByLabelText("subscriptions")).toBeInTheDocument();
+    expect(await screen.findByLabelText("subscriptions")).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/tests/enterprise.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/tests/enterprise.unit.spec.ts
@@ -35,7 +35,9 @@ describe("DashboardHeader - enterprise", () => {
       dashboard: INSTANCE_ANALYTICS_DASHBOARD,
       collections: [INSTANCE_ANALYTICS_COLLECTION],
     });
-    expect(screen.getByRole("img", { name: /audit/i })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("img", { name: /audit/i }),
+    ).toBeInTheDocument();
     expect(screen.getByText("Make a copy")).toBeInTheDocument();
 
     //Other buttons

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.unit.spec.tsx
@@ -415,7 +415,7 @@ describe("DashboardTabs", () => {
       await selectTab(2);
       expect(screen.getByText("Selected tab id is 2")).toBeInTheDocument();
 
-      screen.getByText("Navigate away").click();
+      await userEvent.click(screen.getByText("Navigate away"));
       expect(screen.getByText("Another route")).toBeInTheDocument();
       expect(screen.getByText("Selected tab id is 2")).toBeInTheDocument();
     });

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.unit.spec.tsx
@@ -17,6 +17,7 @@ import {
 } from "__support__/server-mocks";
 import { createMockEntitiesState } from "__support__/store";
 import {
+  act,
   screen,
   renderWithProviders,
   waitForLoaderToBeRemoved,
@@ -129,7 +130,7 @@ describe("DashboardApp", () => {
     it("should have a beforeunload event when the user tries to leave a dirty dashboard", async function () {
       const { mockEventListener } = await setup();
 
-      await userEvent.click(screen.getByLabelText("Edit dashboard"));
+      await userEvent.click(await screen.findByLabelText("Edit dashboard"));
       await userEvent.click(screen.getByTestId("dashboard-name-heading"));
       await userEvent.type(screen.getByTestId("dashboard-name-heading"), "a");
       // need to click away from the input to trigger the isDirty flag
@@ -144,7 +145,7 @@ describe("DashboardApp", () => {
     it("should not have a beforeunload event when the dashboard is unedited", async function () {
       const { mockEventListener } = await setup();
 
-      await userEvent.click(screen.getByLabelText("Edit dashboard"));
+      await userEvent.click(await screen.findByLabelText("Edit dashboard"));
 
       const mockEvent = callMockEvent(mockEventListener, "beforeunload");
       expect(mockEvent.preventDefault).not.toHaveBeenCalled();
@@ -159,7 +160,7 @@ describe("DashboardApp", () => {
 
       await waitForLoaderToBeRemoved();
 
-      await userEvent.click(screen.getByLabelText("Edit dashboard"));
+      await userEvent.click(await screen.findByLabelText("Edit dashboard"));
 
       history.goBack();
 
@@ -171,8 +172,10 @@ describe("DashboardApp", () => {
     it("shows custom warning modal when leaving with unsaved changes via SPA navigation", async () => {
       const { dashboardId, history } = await setup();
 
-      history.push("/");
-      history.push(`/dashboard/${dashboardId}`);
+      act(() => {
+        history.push("/");
+        history.push(`/dashboard/${dashboardId}`);
+      });
 
       await waitForLoaderToBeRemoved();
 
@@ -181,7 +184,9 @@ describe("DashboardApp", () => {
       await userEvent.type(screen.getByTestId("dashboard-name-heading"), "a");
       await userEvent.tab(); // need to click away from the input to trigger the isDirty flag
 
-      history.goBack();
+      act(() => {
+        history.goBack();
+      });
 
       expect(screen.getByTestId("leave-confirmation")).toBeInTheDocument();
     });
@@ -189,7 +194,7 @@ describe("DashboardApp", () => {
     it("does not show custom warning modal when leaving with no changes via Cancel button", async () => {
       await setup();
 
-      await userEvent.click(screen.getByLabelText("Edit dashboard"));
+      await userEvent.click(await screen.findByLabelText("Edit dashboard"));
 
       await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
 
@@ -201,7 +206,7 @@ describe("DashboardApp", () => {
     it("shows custom warning modal when leaving with unsaved changes via Cancel button", async () => {
       await setup();
 
-      await userEvent.click(screen.getByLabelText("Edit dashboard"));
+      await userEvent.click(await screen.findByLabelText("Edit dashboard"));
       await userEvent.click(screen.getByTestId("dashboard-name-heading"));
       await userEvent.type(screen.getByTestId("dashboard-name-heading"), "a");
       await userEvent.tab(); // need to click away from the input to trigger the isDirty flag

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.unit.spec.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.unit.spec.tsx
@@ -70,7 +70,7 @@ describe("ModelActionDetails", () => {
   it("should leave ActionCreatorModal when clicking 'Cancel'", async () => {
     await setup({});
 
-    (await screen.findByText("Cancel")).click();
+    await userEvent.click(await screen.findByText("Cancel"));
 
     expect(
       screen.queryByTestId("mock-native-query-editor"),

--- a/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
@@ -41,7 +41,7 @@ describe("AppBar", () => {
         expect(await screen.findByText(/Our analytics/)).toBeVisible();
         expect(screen.getByTestId("main-logo")).toBeVisible();
 
-        screen.getByTestId("sidebar-toggle").click();
+        await userEvent.click(screen.getByTestId("sidebar-toggle"));
         expect(screen.getByText(/Our analytics/)).not.toBeVisible();
         expect(screen.getByTestId("main-logo")).toBeVisible();
       });
@@ -66,7 +66,7 @@ describe("AppBar", () => {
         expect(screen.queryByTestId("main-logo")).not.toBeInTheDocument();
         expect(screen.getByTestId("sidebar-toggle")).toBeVisible();
 
-        screen.getByTestId("sidebar-toggle").click();
+        await userEvent.click(screen.getByTestId("sidebar-toggle"));
         expect(screen.getByText(/Our analytics/)).not.toBeVisible();
         expect(screen.queryByTestId("main-logo")).not.toBeInTheDocument();
         expect(screen.getByTestId("sidebar-toggle")).toBeVisible();
@@ -108,7 +108,7 @@ describe("AppBar", () => {
 
         expect(await screen.findByText(/Our analytics/)).toBeVisible();
 
-        screen.getByTestId("sidebar-toggle").click();
+        await userEvent.click(screen.getByTestId("sidebar-toggle"));
         expect(screen.queryByText(/Our analytics/)).not.toBeInTheDocument();
         expect(screen.getByTestId("main-logo")).toBeVisible();
       });
@@ -133,7 +133,7 @@ describe("AppBar", () => {
         expect(screen.queryByTestId("main-logo")).not.toBeInTheDocument();
         expect(screen.getByTestId("sidebar-toggle")).toBeVisible();
 
-        screen.getByTestId("sidebar-toggle").click();
+        await userEvent.click(screen.getByTestId("sidebar-toggle"));
         expect(screen.queryByText(/Our analytics/)).not.toBeInTheDocument();
         expect(screen.queryByTestId("main-logo")).not.toBeInTheDocument();
         expect(screen.getByTestId("sidebar-toggle")).toBeVisible();

--- a/frontend/src/metabase/nav/containers/Navbar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.unit.spec.tsx
@@ -77,12 +77,12 @@ async function setup({
 describe("nav > containers > Navbar > Core App", () => {
   it("should be open when isOpen is true", async () => {
     await setup({ isOpen: true });
-    expectNavbarOpen();
+    await expectNavbarOpen();
   });
 
   it("should be hidden when isOpen is false", async () => {
     await setup({ isOpen: false });
-    expectNavbarClosed();
+    await expectNavbarClosed();
   });
 
   it("should not render when signed out", async () => {
@@ -98,44 +98,44 @@ describe("nav > containers > Navbar > Core App", () => {
   ["question", "model", "dashboard"].forEach(pathname => {
     it(`should be hidden on initial load for a ${pathname}`, async () => {
       await setup({ pathname: `/${pathname}/1` });
-      expectNavbarClosed();
+      await expectNavbarClosed();
     });
   });
 
   it("should hide when visiting a question", async () => {
     const store = await setup({ pathname: "/" });
-    expectNavbarOpen();
+    await expectNavbarOpen();
     dispatchLocationChange({ store, pathname: "/question/1" });
-    expectNavbarClosed();
+    await expectNavbarClosed();
   });
 
   it("should hide when visiting a question and stay hidden when returning to collection", async () => {
     const store = await setup({ pathname: "/collection/1" });
-    expectNavbarOpen();
+    await expectNavbarOpen();
     dispatchLocationChange({ store, pathname: "/question/1" });
-    expectNavbarClosed();
+    await expectNavbarClosed();
     dispatchLocationChange({ store, pathname: "/collection/1" });
-    expectNavbarClosed();
+    await expectNavbarClosed();
   });
 
   it("should preserve state when navigating collections", async () => {
     const store = await setup({ pathname: "/collection/1" });
-    expectNavbarOpen();
+    await expectNavbarOpen();
     dispatchLocationChange({ store, pathname: "/collection/2" });
-    expectNavbarOpen();
+    await expectNavbarOpen();
     dispatchLocationChange({ store, pathname: "/question/1" });
-    expectNavbarClosed();
+    await expectNavbarClosed();
     dispatchLocationChange({ store, pathname: "/collection/3" });
-    expectNavbarClosed();
+    await expectNavbarClosed();
     dispatchLocationChange({ store, pathname: "/collection/4" });
-    expectNavbarClosed();
+    await expectNavbarClosed();
     store.dispatch({ type: OPEN_NAVBAR });
-    expectNavbarOpen();
+    await expectNavbarOpen();
     dispatchLocationChange({ store, pathname: "/collection/5" });
-    expectNavbarOpen();
+    await expectNavbarOpen();
     store.dispatch({ type: CLOSE_NAVBAR });
     dispatchLocationChange({ store, pathname: "/collection/6" });
-    expectNavbarClosed();
+    await expectNavbarClosed();
   });
 
   describe("embedded", () => {
@@ -161,7 +161,7 @@ describe("nav > containers > Navbar > Core App", () => {
           isOpen: false, // this should be ignored and overridden by the embedding params
           embedOptions: { top_nav: false, side_nav: true },
         });
-        expectNavbarOpen();
+        await expectNavbarOpen();
       });
     });
 
@@ -172,7 +172,7 @@ describe("nav > containers > Navbar > Core App", () => {
           isOpen: true,
           embedOptions: { top_nav: true, side_nav: true },
         });
-        expectNavbarOpen();
+        await expectNavbarOpen();
       });
     });
 
@@ -183,7 +183,7 @@ describe("nav > containers > Navbar > Core App", () => {
           isOpen: false,
           embedOptions: { top_nav: true, side_nav: true },
         });
-        expectNavbarClosed();
+        await expectNavbarClosed();
       });
     });
 
@@ -194,7 +194,7 @@ describe("nav > containers > Navbar > Core App", () => {
           isOpen: false,
           embedOptions: { top_nav: true, side_nav: true },
         });
-        expectNavbarClosed();
+        await expectNavbarClosed();
       });
     });
 
@@ -207,20 +207,20 @@ describe("nav > containers > Navbar > Core App", () => {
           isOpen: false,
           embedOptions: { side_nav: false },
         });
-        expectNavbarClosed();
+        await expectNavbarClosed();
       });
     });
   });
 });
 
-function expectNavbarOpen() {
-  const navbar = screen.getByTestId("main-navbar-root");
+async function expectNavbarOpen() {
+  const navbar = await screen.findByTestId("main-navbar-root");
   expect(navbar).toBeVisible();
   expect(navbar).toHaveAttribute("aria-hidden", "false");
 }
 
-function expectNavbarClosed() {
-  const navbar = screen.getByTestId("main-navbar-root");
+async function expectNavbarClosed() {
+  const navbar = await screen.findByTestId("main-navbar-root");
   expect(navbar).not.toBeVisible();
   expect(navbar).toHaveAttribute("aria-hidden", "true");
 }

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.unit.spec.tsx
@@ -1,6 +1,6 @@
 import userEvent from "@testing-library/user-event";
 
-import { renderWithProviders, screen } from "__support__/ui";
+import { act, renderWithProviders, screen } from "__support__/ui";
 import { createMockUiParameter } from "metabase-lib/v1/parameters/mock";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
 
@@ -44,7 +44,9 @@ describe("ParameterSidebar", () => {
     await fillValue(labelInput, "");
     // expect there to be an error message with the text "Required"
     expect(screen.getByText(/required/i)).toBeInTheDocument();
-    labelInput.blur();
+    act(() => {
+      labelInput.blur();
+    });
     // when the input blurs, the value should have reverted to the original
     expect(onChangeName).not.toHaveBeenCalled();
     expect(labelInput).toHaveValue("foo");
@@ -53,7 +55,9 @@ describe("ParameterSidebar", () => {
 
     // sanity check with a non-blank value
     await fillValue(labelInput, "bar");
-    labelInput.blur();
+    act(() => {
+      labelInput.blur();
+    });
     expect(onChangeName).toHaveBeenCalledWith("bar");
     expect(labelInput).toHaveValue("bar");
   });
@@ -71,7 +75,9 @@ describe("ParameterSidebar", () => {
     await fillValue(labelInput, "tAb");
     // expect there to be an error message with the text "reserved"
     expect(screen.getByText(/reserved/i)).toBeInTheDocument();
-    labelInput.blur();
+    act(() => {
+      labelInput.blur();
+    });
     // when the input blurs, the value should have reverted to the original
     expect(onChangeName).not.toHaveBeenCalled();
     expect(labelInput).toHaveValue("foo");
@@ -80,7 +86,9 @@ describe("ParameterSidebar", () => {
 
     // sanity check with a non-blank value
     await fillValue(labelInput, "bar");
-    labelInput.blur();
+    act(() => {
+      labelInput.blur();
+    });
     expect(onChangeName).toHaveBeenCalledWith("bar");
     expect(labelInput).toHaveValue("bar");
   });

--- a/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.unit.spec.tsx
@@ -1,7 +1,7 @@
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 
-import { renderWithProviders, screen } from "__support__/ui";
+import { act, renderWithProviders, screen } from "__support__/ui";
 import { createMockUiParameter } from "metabase-lib/v1/parameters/mock";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
 
@@ -110,7 +110,9 @@ describe("ParameterSidebar", () => {
     // expect there to be an error message with the text "This label is already in use"
     const error = /this label is already in use/i;
     expect(screen.getByText(error)).toBeInTheDocument();
-    labelInput.blur();
+    act(() => {
+      labelInput.blur();
+    });
     // when the input blurs, the value should have reverted to the original
     expect(labelInput).toHaveValue("Foo");
     // the error message should disappear
@@ -118,7 +120,9 @@ describe("ParameterSidebar", () => {
 
     // sanity check with another value
     await fillValue(labelInput, "Bar");
-    labelInput.blur();
+    act(() => {
+      labelInput.blur();
+    });
     expect(labelInput).toHaveValue("Bar");
   });
 

--- a/frontend/src/metabase/parameters/components/ParameterValuePicker/ListPickerConnected/ListPickerConnected.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValuePicker/ListPickerConnected/ListPickerConnected.unit.spec.tsx
@@ -407,7 +407,7 @@ describe("ListPickerConnected", () => {
       });
 
       const input = screen.getByPlaceholderText("Start typing to filter…");
-      userEvent.click(input);
+      await userEvent.click(input);
       await waitFor(() => {
         expect(fetchValuesMock).toHaveBeenCalledTimes(1);
       });

--- a/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceModal.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceModal.unit.spec.tsx
@@ -66,7 +66,7 @@ describe("ValuesSourceModal", () => {
       });
 
       expect(
-        screen.getByText(/We don’t have any cached values/),
+        await screen.findByText(/We don’t have any cached values/),
       ).toBeInTheDocument();
     });
 
@@ -80,7 +80,7 @@ describe("ValuesSourceModal", () => {
         }),
       });
 
-      expect(screen.getByRole("textbox")).toHaveValue("A\nB\nC");
+      expect(await screen.findByRole("textbox")).toHaveValue("A\nB\nC");
     });
 
     it("should not show the connected fields option if parameter is not wired to any fields", async () => {
@@ -130,7 +130,7 @@ describe("ValuesSourceModal", () => {
           values: [["C"], ["D"]],
         }),
       });
-      expect(screen.getByRole("textbox")).toHaveValue("C\nD");
+      expect(await screen.findByRole("textbox")).toHaveValue("C\nD");
 
       await userEvent.click(screen.getByRole("radio", { name: "Custom list" }));
       expect(screen.getByRole("radio", { name: "Custom list" })).toBeChecked();
@@ -150,7 +150,7 @@ describe("ValuesSourceModal", () => {
         }),
       });
       expect(
-        screen.getByText(/We don’t have any cached values/),
+        await screen.findByText(/We don’t have any cached values/),
       ).toBeInTheDocument();
 
       await userEvent.click(screen.getByRole("radio", { name: "Custom list" }));

--- a/frontend/src/metabase/public/containers/PublicQuestion/PublicQuestion.unit.spec.tsx
+++ b/frontend/src/metabase/public/containers/PublicQuestion/PublicQuestion.unit.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Route } from "react-router";
 
 import {
@@ -81,14 +81,14 @@ async function setup() {
 describe("PublicQuestion", () => {
   it("should render data", async () => {
     await setup();
-    expect(screen.getByText("John W.")).toBeInTheDocument();
+    expect(await screen.findByText("John W.")).toBeInTheDocument();
   });
 
   it("should update card settings when visualization component changes them (metabase#37429)", async () => {
     await setup();
 
-    fireEvent.click(
-      screen.getByRole("button", {
+    await userEvent.click(
+      await screen.findByRole("button", {
         name: /update settings/i,
       }),
     );

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.unit.spec.js
@@ -2,13 +2,7 @@ import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 
 import { createMockMetadata } from "__support__/metadata";
-import {
-  fireEvent,
-  getIcon,
-  render,
-  renderWithProviders,
-  screen,
-} from "__support__/ui";
+import { getIcon, render, renderWithProviders, screen } from "__support__/ui";
 import { delay } from "metabase/lib/promise";
 import { UnconnectedDataSelector as DataSelector } from "metabase/query_builder/components/DataSelector";
 import {
@@ -133,7 +127,7 @@ describe("DataSelector", () => {
     expect(screen.getByText("Sample Empty Database")).toBeInTheDocument();
 
     // clicking reveals schemas
-    fireEvent.click(screen.getByText("Multi-schema Database"));
+    await userEvent.click(screen.getByText("Multi-schema Database"));
     expect(screen.getByText("First Schema")).toBeInTheDocument();
     expect(screen.getByText("Second Schema")).toBeInTheDocument();
 
@@ -143,7 +137,7 @@ describe("DataSelector", () => {
     expect(screen.getByText("Sample Empty Database")).toBeInTheDocument();
 
     // clicking shows the table
-    fireEvent.click(screen.getByText("First Schema"));
+    await userEvent.click(screen.getByText("First Schema"));
     expect(screen.getByText("Table in First Schema")).toBeInTheDocument();
 
     // db and schema are still visible
@@ -154,7 +148,7 @@ describe("DataSelector", () => {
     expect(screen.queryByText("Second Schema")).not.toBeInTheDocument();
 
     // clicking on the table
-    fireEvent.click(screen.getByText("Table in First Schema"));
+    await userEvent.click(screen.getByText("Table in First Schema"));
     const [tableId] = setTable.mock.calls[0];
     expect(tableId).toEqual(MULTI_SCHEMA_TABLE1_ID);
   });
@@ -204,7 +198,7 @@ describe("DataSelector", () => {
 
     expect(screen.getByText("Sample Database")).toBeInTheDocument();
     expect(screen.getByText("Multi-schema Database")).toBeInTheDocument();
-    fireEvent.click(screen.getByText("Multi-schema Database"));
+    await userEvent.click(screen.getByText("Multi-schema Database"));
 
     // that triggers fetching schemas
     await delay(1);
@@ -217,7 +211,7 @@ describe("DataSelector", () => {
     rerenderWith(nextMetadata);
     expect(screen.getByText("First Schema")).toBeInTheDocument();
     expect(screen.getByText("Second Schema")).toBeInTheDocument();
-    fireEvent.click(screen.getByText("Second Schema"));
+    await userEvent.click(screen.getByText("Second Schema"));
 
     // that triggers fetching tables
     await delay(1);
@@ -255,7 +249,7 @@ describe("DataSelector", () => {
       />,
     );
     expect(fetchDatabases).not.toHaveBeenCalled();
-    fireEvent.click(screen.getByText("button"));
+    await userEvent.click(screen.getByText("button"));
     await delay(1); // fetchDatabases hasn't been called until the next tick
     expect(fetchDatabases).toHaveBeenCalled();
   });
@@ -291,16 +285,16 @@ describe("DataSelector", () => {
       />,
     );
 
-    fireEvent.click(screen.getByText("Sample Database"));
+    await userEvent.click(screen.getByText("Sample Database"));
     await delay(1);
     // check that tables are listed
     expect(await screen.findByText("Orders")).toBeInTheDocument();
     // click header to return to db list
-    fireEvent.click(screen.getByText("Sample Database"));
+    await userEvent.click(screen.getByText("Sample Database"));
     // click on a multi-schema db
-    fireEvent.click(screen.getByText("Multi-schema Database"));
+    await userEvent.click(screen.getByText("Multi-schema Database"));
     // see schema appear and click to view tables for good measure
-    fireEvent.click(screen.getByText("First Schema"));
+    await userEvent.click(screen.getByText("First Schema"));
     await delay(1);
     expect(screen.getByText("Table in First Schema")).toBeInTheDocument();
   });
@@ -321,20 +315,20 @@ describe("DataSelector", () => {
     );
 
     // expand a multi-schema db to make sure it's schemas are loaded
-    fireEvent.click(screen.getByText("Multi-schema Database"));
+    await userEvent.click(screen.getByText("Multi-schema Database"));
     expect(screen.getByText("First Schema")).toBeInTheDocument();
     expect(screen.getByText("Second Schema")).toBeInTheDocument();
 
     // click into a single schema db, check for a table, and then return to db list
-    fireEvent.click(screen.getByText("Sample Database"));
+    await userEvent.click(screen.getByText("Sample Database"));
     await delay(1);
     expect(await screen.findByText("Orders")).toBeInTheDocument();
-    fireEvent.click(screen.getByText("Sample Database"));
+    await userEvent.click(screen.getByText("Sample Database"));
 
     // expand multi-schema db
-    fireEvent.click(screen.getByText("Multi-schema Database"));
+    await userEvent.click(screen.getByText("Multi-schema Database"));
     // see schema appear and click to view tables for good measure
-    fireEvent.click(screen.getByText("First Schema"));
+    await userEvent.click(screen.getByText("First Schema"));
     await delay(1);
     expect(screen.getByText("Table in First Schema")).toBeInTheDocument();
   });
@@ -352,7 +346,7 @@ describe("DataSelector", () => {
     );
 
     expect(screen.getByText("Sample Database")).toBeInTheDocument();
-    fireEvent.click(screen.getByText("Multi-schema Database"));
+    await userEvent.click(screen.getByText("Multi-schema Database"));
     // check that schemas are listed
     expect(screen.getByText("First Schema")).toBeInTheDocument();
     expect(screen.getByText("Second Schema")).toBeInTheDocument();
@@ -360,7 +354,7 @@ describe("DataSelector", () => {
     expect(getIcon("chevronup")).toBeInTheDocument();
 
     // collapse db
-    fireEvent.click(screen.getByText("Multi-schema Database"));
+    await userEvent.click(screen.getByText("Multi-schema Database"));
     // schemas are hidden, but databases are still shown
     expect(screen.queryByText("First Schema")).not.toBeInTheDocument();
     expect(screen.queryByText("Second Schema")).not.toBeInTheDocument();
@@ -398,11 +392,11 @@ describe("DataSelector", () => {
       />,
     );
 
-    fireEvent.click(screen.getByText("First Schema"));
+    await userEvent.click(screen.getByText("First Schema"));
     expect(screen.getByText("Table in First Schema")).toBeInTheDocument();
   });
 
-  it("should open database picker with correct database selected", async () => {
+  it("should open database picker with correct database selected", () => {
     render(
       <DataSelector
         steps={["DATABASE"]}
@@ -433,11 +427,11 @@ describe("DataSelector", () => {
       />,
     );
 
-    fireEvent.click(screen.getByText("Multi-schema Database"));
+    await userEvent.click(screen.getByText("Multi-schema Database"));
     expect(screen.getByText("First Schema")).toBeInTheDocument();
     expect(screen.getByText("Second Schema")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByText("Other Multi-schema Database"));
+    await userEvent.click(screen.getByText("Other Multi-schema Database"));
     expect(screen.getByText("Other First Schema")).toBeInTheDocument();
     expect(screen.getByText("Other Second Schema")).toBeInTheDocument();
   });
@@ -469,7 +463,7 @@ describe("DataSelector", () => {
     expect(screen.getByText("Orders")).toBeInTheDocument();
   });
 
-  it("shows an empty state without any databases", async () => {
+  it("shows an empty state without any databases", () => {
     render(
       <DataSelector
         steps={["DATABASE", "SCHEMA", "TABLE"]}
@@ -503,7 +497,7 @@ describe("DataSelector", () => {
     expect(screen.getByText("Saved Questions")).toBeInTheDocument();
   });
 
-  it("should not show 'Saved Questions' option when there are no saved questions (metabase#29760)", async () => {
+  it("should not show 'Saved Questions' option when there are no saved questions (metabase#29760)", () => {
     renderWithProviders(
       <DataSelector
         steps={["BUCKET", "DATABASE", "SCHEMA", "TABLE"]}

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.unit.spec.js
@@ -1,3 +1,4 @@
+import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 
 import { createMockMetadata } from "__support__/metadata";
@@ -110,7 +111,7 @@ describe("DataSelector", () => {
   );
   const SAVED_QUESTIONS_DATABASE = createMockSavedQuestionsDatabase();
 
-  it("should allow selecting db, schema, and table", () => {
+  it("should allow selecting db, schema, and table", async () => {
     const setTable = jest.fn();
     render(
       <DataSelector
@@ -125,7 +126,9 @@ describe("DataSelector", () => {
     );
 
     // displays dbs
-    expect(screen.getByText("Multi-schema Database")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Multi-schema Database"),
+    ).toBeInTheDocument();
     expect(screen.getByText("Sample Database")).toBeInTheDocument();
     expect(screen.getByText("Sample Empty Database")).toBeInTheDocument();
 
@@ -237,7 +240,7 @@ describe("DataSelector", () => {
       />,
     );
     await delay(1); // state isn't updated until the next tick
-    expect(screen.getByText("Orders")).toBeInTheDocument();
+    expect(await screen.findByText("Orders")).toBeInTheDocument();
   });
 
   it("shouldn't fetch databases until it's opened", async () => {
@@ -269,11 +272,11 @@ describe("DataSelector", () => {
       />,
     );
 
-    fireEvent.click(screen.getByText("Multi-schema Database"));
+    await userEvent.click(screen.getByText("Multi-schema Database"));
     expect(screen.getByText("First Schema")).toBeInTheDocument();
-    fireEvent.click(screen.getByText("Sample Database"));
+    await userEvent.click(screen.getByText("Sample Database"));
     await delay(1);
-    expect(screen.getByText("Orders")).toBeInTheDocument();
+    expect(await screen.findByText("Orders")).toBeInTheDocument();
   });
 
   it("should expand multi-schema after clicking into single-schema", async () => {
@@ -291,7 +294,7 @@ describe("DataSelector", () => {
     fireEvent.click(screen.getByText("Sample Database"));
     await delay(1);
     // check that tables are listed
-    expect(screen.getByText("Orders")).toBeInTheDocument();
+    expect(await screen.findByText("Orders")).toBeInTheDocument();
     // click header to return to db list
     fireEvent.click(screen.getByText("Sample Database"));
     // click on a multi-schema db
@@ -325,7 +328,7 @@ describe("DataSelector", () => {
     // click into a single schema db, check for a table, and then return to db list
     fireEvent.click(screen.getByText("Sample Database"));
     await delay(1);
-    expect(screen.getByText("Orders")).toBeInTheDocument();
+    expect(await screen.findByText("Orders")).toBeInTheDocument();
     fireEvent.click(screen.getByText("Sample Database"));
 
     // expand multi-schema db
@@ -336,7 +339,7 @@ describe("DataSelector", () => {
     expect(screen.getByText("Table in First Schema")).toBeInTheDocument();
   });
 
-  it("should collapse expanded list of db's schemas", () => {
+  it("should collapse expanded list of db's schemas", async () => {
     render(
       <DataSelector
         steps={["DATABASE", "SCHEMA", "TABLE"]}
@@ -380,10 +383,10 @@ describe("DataSelector", () => {
     );
     await delay(1);
 
-    expect(screen.getByText("Orders")).toBeInTheDocument();
+    expect(await screen.findByText("Orders")).toBeInTheDocument();
   });
 
-  it("should select schema in field picker", () => {
+  it("should select schema in field picker", async () => {
     render(
       <DataSelector
         steps={["SCHEMA", "TABLE", "FIELD"]}
@@ -399,7 +402,7 @@ describe("DataSelector", () => {
     expect(screen.getByText("Table in First Schema")).toBeInTheDocument();
   });
 
-  it("should open database picker with correct database selected", () => {
+  it("should open database picker with correct database selected", async () => {
     render(
       <DataSelector
         steps={["DATABASE"]}
@@ -418,7 +421,7 @@ describe("DataSelector", () => {
     ).toBeInTheDocument();
   });
 
-  it("should move between selected multi-schema dbs", () => {
+  it("should move between selected multi-schema dbs", async () => {
     render(
       <DataSelector
         steps={["DATABASE", "SCHEMA", "TABLE"]}
@@ -452,16 +455,16 @@ describe("DataSelector", () => {
     );
 
     // click into the first db
-    fireEvent.click(screen.getByText("Sample Database"));
+    await userEvent.click(screen.getByText("Sample Database"));
     await delay(1);
     expect(screen.getByText("Orders")).toBeInTheDocument();
 
     // click to go back
-    fireEvent.click(screen.getByText("Sample Database"));
+    await userEvent.click(screen.getByText("Sample Database"));
     expect(screen.getByText("Sample Empty Database")).toBeInTheDocument();
 
     // click back in
-    fireEvent.click(screen.getByText("Sample Database"));
+    await userEvent.click(screen.getByText("Sample Database"));
     await delay(1);
     expect(screen.getByText("Orders")).toBeInTheDocument();
   });

--- a/frontend/src/metabase/query_builder/components/QueryVisualization.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryVisualization.unit.spec.tsx
@@ -18,24 +18,28 @@ function setup({ customMessage }: SetupOpts = {}) {
 }
 
 describe("VisualizationRunningState", () => {
-  it("should render the different loading messages after a while", () => {
+  it("should render the different loading messages after a while", async () => {
     jest.useFakeTimers();
 
     setup();
-    expect(screen.getByText("Doing science...")).toBeInTheDocument();
+    expect(await screen.findByText("Doing science...")).toBeInTheDocument();
 
     jest.advanceTimersByTime(5000);
-    expect(screen.getByText("Waiting for results...")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Waiting for results..."),
+    ).toBeInTheDocument();
   });
 
-  it("should only render the custom loading message when it was customized", () => {
+  it("should only render the custom loading message when it was customized", async () => {
     const customMessage = (isSlow: boolean) =>
       isSlow ? `Custom message (slow)...` : `Custom message...`;
 
     setup({ customMessage });
-    expect(screen.getByText("Custom message...")).toBeInTheDocument();
+    expect(await screen.findByText("Custom message...")).toBeInTheDocument();
 
     jest.advanceTimersByTime(5000);
-    expect(screen.getByText("Custom message (slow)...")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Custom message (slow)..."),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.unit.spec.tsx
@@ -122,13 +122,13 @@ describe("DataStep", () => {
 
     const modal = await screen.findByTestId("entity-picker-modal");
     expect(
-      within(modal).getByText("Pick your starting data"),
+      await within(modal).findByText("Pick your starting data"),
     ).toBeInTheDocument();
 
     // Ensure the table picker not open
-    expect(within(modal).getByText("Orders")).toBeInTheDocument();
-    expect(within(modal).getByText("Products")).toBeInTheDocument();
-    expect(within(modal).getByText("People")).toBeInTheDocument();
+    expect(await within(modal).findByText("Orders")).toBeInTheDocument();
+    expect(await within(modal).findByText("Products")).toBeInTheDocument();
+    expect(await within(modal).findByText("People")).toBeInTheDocument();
   });
 
   it("should render with a selected table", () => {

--- a/frontend/src/metabase/query_builder/components/view/PreviewQueryModal/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/PreviewQueryModal/tests/common.unit.spec.tsx
@@ -8,7 +8,7 @@ describe("PreviewQueryModal (OSS)", () => {
 
     expect(await screen.findByText("Query preview")).toBeInTheDocument();
     expect(
-      screen.getByText("Learn how to debug SQL errors"),
+      await screen.findByText("Learn how to debug SQL errors"),
     ).toBeInTheDocument();
   });
 
@@ -17,7 +17,7 @@ describe("PreviewQueryModal (OSS)", () => {
 
     expect(await screen.findByText("Query preview")).toBeInTheDocument();
     expect(
-      screen.getByText("Learn how to debug SQL errors"),
+      await screen.findByText("Learn how to debug SQL errors"),
     ).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/query_builder/components/view/PreviewQueryModal/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/PreviewQueryModal/tests/enterprise.unit.spec.tsx
@@ -13,7 +13,7 @@ describe("PreviewQueryModal (EE without token)", () => {
 
     expect(await screen.findByText("Query preview")).toBeInTheDocument();
     expect(
-      screen.getByText("Learn how to debug SQL errors"),
+      await screen.findByText("Learn how to debug SQL errors"),
     ).toBeInTheDocument();
   });
 
@@ -22,7 +22,7 @@ describe("PreviewQueryModal (EE without token)", () => {
 
     expect(await screen.findByText("Query preview")).toBeInTheDocument();
     expect(
-      screen.getByText("Learn how to debug SQL errors"),
+      await screen.findByText("Learn how to debug SQL errors"),
     ).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/query_builder/components/view/PreviewQueryModal/tests/premium.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/PreviewQueryModal/tests/premium.unit.spec.tsx
@@ -17,7 +17,7 @@ describe("PreviewQueryModal (EE with token)", () => {
 
     expect(await screen.findByText("Query preview")).toBeInTheDocument();
     expect(
-      screen.getByText("Learn how to debug SQL errors"),
+      await screen.findByText("Learn how to debug SQL errors"),
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unsaved-changes-warning.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unsaved-changes-warning.unit.spec.tsx
@@ -6,6 +6,7 @@ import {
   setupCardEndpoints,
 } from "__support__/server-mocks";
 import {
+  act,
   screen,
   waitFor,
   waitForLoaderToBeRemoved,
@@ -66,7 +67,9 @@ describe("QueryBuilder - unsaved changes warning", () => {
 
       await startNewNotebookModel();
 
-      history.push("/redirect");
+      act(() => {
+        history.push("/redirect");
+      });
 
       expect(screen.getByTestId("leave-confirmation")).toBeInTheDocument();
     });
@@ -121,7 +124,9 @@ describe("QueryBuilder - unsaved changes warning", () => {
 
       await triggerNativeQueryChange();
 
-      history.push("/redirect");
+      act(() => {
+        history.push("/redirect");
+      });
 
       expect(screen.getByTestId("leave-confirmation")).toBeInTheDocument();
     });
@@ -153,7 +158,9 @@ describe("QueryBuilder - unsaved changes warning", () => {
           screen.queryByTestId("leave-confirmation"),
         ).not.toBeInTheDocument();
 
-        history.push("/redirect");
+        act(() => {
+          history.push("/redirect");
+        });
 
         expect(
           screen.queryByTestId("leave-confirmation"),
@@ -171,7 +178,9 @@ describe("QueryBuilder - unsaved changes warning", () => {
         await triggerNotebookQueryChange();
         await waitForSaveChangesToBeEnabled();
 
-        history.push("/redirect");
+        act(() => {
+          history.push("/redirect");
+        });
 
         expect(screen.getByTestId("leave-confirmation")).toBeInTheDocument();
       });
@@ -188,7 +197,9 @@ describe("QueryBuilder - unsaved changes warning", () => {
         await revertNotebookQueryChange();
         await waitForSaveChangesToBeDisabled();
 
-        history.push("/redirect");
+        act(() => {
+          history.push("/redirect");
+        });
 
         expect(
           screen.queryByTestId("leave-confirmation"),
@@ -254,7 +265,9 @@ describe("QueryBuilder - unsaved changes warning", () => {
           screen.queryByTestId("leave-confirmation"),
         ).not.toBeInTheDocument();
 
-        history.push("/redirect");
+        act(() => {
+          history.push("/redirect");
+        });
 
         expect(
           screen.queryByTestId("leave-confirmation"),
@@ -273,7 +286,9 @@ describe("QueryBuilder - unsaved changes warning", () => {
         await triggerMetadataChange();
         await waitForSaveChangesToBeEnabled();
 
-        history.push("/redirect");
+        act(() => {
+          history.push("/redirect");
+        });
 
         expect(screen.getByTestId("leave-confirmation")).toBeInTheDocument();
       });
@@ -285,7 +300,9 @@ describe("QueryBuilder - unsaved changes warning", () => {
           initialRoute: `/model/${TEST_MODEL_CARD.id}/metadata`,
         });
 
-        history.push("/redirect");
+        act(() => {
+          history.push("/redirect");
+        });
 
         expect(
           screen.queryByTestId("leave-confirmation"),
@@ -338,7 +355,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
          * the QueryBuilder gets incompletely intialized.
          * This seems to affect only tests.
          */
-        await userEvent.click(screen.getByText("Metadata"));
+        await userEvent.click(await screen.findByText("Metadata"));
 
         await triggerMetadataChange();
         await waitForSaveChangesToBeEnabled();
@@ -357,7 +374,9 @@ describe("QueryBuilder - unsaved changes warning", () => {
           screen.queryByTestId("leave-confirmation"),
         ).not.toBeInTheDocument();
 
-        history.push("/redirect");
+        act(() => {
+          history.push("/redirect");
+        });
 
         expect(
           screen.queryByTestId("leave-confirmation"),
@@ -431,7 +450,9 @@ describe("QueryBuilder - unsaved changes warning", () => {
       await triggerNativeQueryChange();
       await waitForSaveToBeEnabled();
 
-      history.push("/redirect");
+      act(() => {
+        history.push("/redirect");
+      });
 
       expect(screen.getByTestId("leave-confirmation")).toBeInTheDocument();
     });
@@ -448,7 +469,9 @@ describe("QueryBuilder - unsaved changes warning", () => {
       );
       await waitForLoaderToBeRemoved();
 
-      history.push("/redirect");
+      act(() => {
+        history.push("/redirect");
+      });
 
       expect(
         screen.queryByTestId("leave-confirmation"),
@@ -517,7 +540,9 @@ describe("QueryBuilder - unsaved changes warning", () => {
         screen.queryByTestId("leave-confirmation"),
       ).not.toBeInTheDocument();
 
-      history.push("/redirect");
+      act(() => {
+        history.push("/redirect");
+      });
 
       expect(
         screen.queryByTestId("leave-confirmation"),
@@ -535,7 +560,9 @@ describe("QueryBuilder - unsaved changes warning", () => {
       await triggerNativeQueryChange();
       await waitForSaveToBeEnabled();
 
-      history.push("/redirect");
+      act(() => {
+        history.push("/redirect");
+      });
 
       expect(screen.getByTestId("leave-confirmation")).toBeInTheDocument();
     });
@@ -552,7 +579,9 @@ describe("QueryBuilder - unsaved changes warning", () => {
       await userEvent.click(screen.getByTestId("Detail-button"));
       await waitForSaveToBeEnabled();
 
-      history.push("/redirect");
+      act(() => {
+        history.push("/redirect");
+      });
 
       expect(
         screen.queryByTestId("leave-confirmation"),
@@ -567,7 +596,9 @@ describe("QueryBuilder - unsaved changes warning", () => {
 
       await waitForNativeQueryEditorReady();
 
-      history.push("/redirect");
+      act(() => {
+        history.push("/redirect");
+      });
 
       expect(
         screen.queryByTestId("leave-confirmation"),
@@ -619,7 +650,9 @@ describe("QueryBuilder - unsaved changes warning", () => {
         screen.queryByTestId("leave-confirmation"),
       ).not.toBeInTheDocument();
 
-      history.push("/redirect");
+      act(() => {
+        history.push("/redirect");
+      });
 
       expect(
         screen.queryByTestId("leave-confirmation"),
@@ -660,7 +693,9 @@ describe("QueryBuilder - unsaved changes warning", () => {
         screen.queryByTestId("leave-confirmation"),
       ).not.toBeInTheDocument();
 
-      history.push("/redirect");
+      act(() => {
+        history.push("/redirect");
+      });
 
       expect(
         screen.queryByTestId("leave-confirmation"),
@@ -677,8 +712,9 @@ describe("QueryBuilder - unsaved changes warning", () => {
 
       await triggerNotebookQueryChange();
       await waitForSaveToBeEnabled();
-
-      history.push("/redirect");
+      act(() => {
+        history.push("/redirect");
+      });
 
       expect(screen.getByTestId("leave-confirmation")).toBeInTheDocument();
     });
@@ -692,7 +728,9 @@ describe("QueryBuilder - unsaved changes warning", () => {
       await triggerVisualizationQueryChange();
       await waitForSaveToBeEnabled();
 
-      history.push("/redirect");
+      act(() => {
+        history.push("/redirect");
+      });
 
       expect(
         screen.queryByTestId("leave-confirmation"),
@@ -705,7 +743,9 @@ describe("QueryBuilder - unsaved changes warning", () => {
         initialRoute: `/question/${TEST_STRUCTURED_CARD.id}/notebook`,
       });
 
-      history.push("/redirect");
+      act(() => {
+        history.push("/redirect");
+      });
 
       expect(
         screen.queryByTestId("leave-confirmation"),
@@ -763,7 +803,9 @@ describe("QueryBuilder - unsaved changes warning", () => {
         screen.queryByTestId("leave-confirmation"),
       ).not.toBeInTheDocument();
 
-      history.push("/redirect");
+      act(() => {
+        history.push("/redirect");
+      });
 
       expect(
         screen.queryByTestId("leave-confirmation"),
@@ -804,7 +846,9 @@ describe("QueryBuilder - unsaved changes warning", () => {
         screen.queryByTestId("leave-confirmation"),
       ).not.toBeInTheDocument();
 
-      history.push("/redirect");
+      act(() => {
+        history.push("/redirect");
+      });
 
       expect(
         screen.queryByTestId("leave-confirmation"),

--- a/frontend/src/metabase/query_builder/containers/test-utils.tsx
+++ b/frontend/src/metabase/query_builder/containers/test-utils.tsx
@@ -323,7 +323,7 @@ export const startNewNotebookModel = async () => {
 
   const modal = await screen.findByTestId("entity-picker-modal");
   await waitForLoaderToBeRemoved();
-  await userEvent.click(within(modal).getByText("Orders"));
+  await userEvent.click(await within(modal).findByText("Orders"));
 
   expect(screen.getByRole("button", { name: "Get Answer" })).toBeEnabled();
 };
@@ -365,7 +365,7 @@ export const triggerVisualizationQueryChange = async () => {
 };
 
 export const triggerNotebookQueryChange = async () => {
-  await userEvent.click(screen.getByText("Row limit"));
+  await userEvent.click(await screen.findByText("Row limit"));
 
   const rowLimitInput = await within(
     screen.getByTestId("step-limit-0-0"),

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.unit.spec.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.unit.spec.tsx
@@ -1,7 +1,7 @@
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 
-import { render, screen } from "__support__/ui";
+import { act, fireEvent, render, screen } from "__support__/ui";
 import { MultiAutocomplete, type MultiAutocompleteProps } from "metabase/ui";
 
 const EXAMPLE_DATA = [
@@ -41,7 +41,7 @@ describe("MultiAutocomplete", () => {
     await userEvent.type(input, "foo", {
       pointerEventsCheck: 0,
     });
-    input.blur();
+    fireEvent.blur(input);
 
     expect(onChange).toHaveBeenCalledWith(["foo"]);
     expect(input).toHaveValue("");
@@ -49,7 +49,7 @@ describe("MultiAutocomplete", () => {
     await userEvent.type(input, "bar", {
       pointerEventsCheck: 0,
     });
-    input.blur();
+    fireEvent.blur(input);
 
     expect(onChange).toHaveBeenCalledWith(["foo", "bar"]);
     expect(input).toHaveValue("");
@@ -65,7 +65,7 @@ describe("MultiAutocomplete", () => {
     await userEvent.type(input, "foo", {
       pointerEventsCheck: 0,
     });
-    input.blur();
+    fireEvent.blur(input);
 
     expect(onChange).toHaveBeenLastCalledWith(["foo"]);
     expect(input).toHaveValue("");
@@ -74,7 +74,7 @@ describe("MultiAutocomplete", () => {
     await userEvent.type(input, "bar", {
       pointerEventsCheck: 0,
     });
-    input.blur();
+    fireEvent.blur(input);
 
     expect(onChange).toHaveBeenLastCalledWith(["foo"]);
     expect(input).toHaveValue("");
@@ -140,7 +140,7 @@ describe("MultiAutocomplete", () => {
 
   it("should accept quote-delimited values containing commas when pasting", async () => {
     const { input, onChange } = setup({ data: EXAMPLE_DATA });
-    input.focus();
+    act(() => input.focus());
     await userEvent.paste('"foo bar",baz');
     expect(onChange).toHaveBeenLastCalledWith(["foo bar", "baz"]);
     expect(input).toHaveValue("");
@@ -148,7 +148,7 @@ describe("MultiAutocomplete", () => {
 
   it("should correctly parse escaped quotes when pasting", async () => {
     const { input, onChange } = setup({ data: EXAMPLE_DATA });
-    input.focus();
+    act(() => input.focus());
     await userEvent.paste('"foo \\"bar\\"",baz');
     expect(onChange).toHaveBeenLastCalledWith(['foo "bar"', "baz"]);
     expect(input).toHaveValue("");
@@ -186,7 +186,7 @@ describe("MultiAutocomplete", () => {
 
   it("should accept comma-separated values when pasting", async () => {
     const { input, onChange } = setup({ data: EXAMPLE_DATA });
-    input.focus();
+    act(() => input.focus());
     await userEvent.paste("foo,bar");
     expect(onChange).toHaveBeenLastCalledWith(["foo", "bar"]);
     expect(input).toHaveValue("");
@@ -194,7 +194,7 @@ describe("MultiAutocomplete", () => {
 
   it("should accept newline-separated values when pasting", async () => {
     const { input, onChange } = setup({ data: EXAMPLE_DATA });
-    input.focus();
+    act(() => input.focus());
     await userEvent.paste("foo\nbar");
     expect(onChange).toHaveBeenLastCalledWith(["foo", "bar"]);
     expect(input).toHaveValue("");
@@ -202,7 +202,7 @@ describe("MultiAutocomplete", () => {
 
   it("should accept tab-separated values when pasting", async () => {
     const { input, onChange } = setup({ data: EXAMPLE_DATA });
-    input.focus();
+    act(() => input.focus());
     await userEvent.paste("foo\tbar");
     expect(onChange).toHaveBeenLastCalledWith(["foo", "bar"]);
     expect(input).toHaveValue("");
@@ -215,7 +215,7 @@ describe("MultiAutocomplete", () => {
         return value === "foo" || value === "bar";
       },
     });
-    input.focus();
+    act(() => input.focus());
     await userEvent.paste("foo,bar,baz");
     expect(onChange).toHaveBeenLastCalledWith(["foo", "bar"]);
     expect(input).toHaveValue("");
@@ -229,7 +229,7 @@ describe("MultiAutocomplete", () => {
       pointerEventsCheck: 0,
     });
 
-    input.focus();
+    act(() => input.focus());
     // @ts-expect-error: input does have setSelectionRange, and testing-library does not provide a wrapper
     input.setSelectionRange(3, 3);
     await userEvent.paste("quu,xyz");
@@ -243,7 +243,7 @@ describe("MultiAutocomplete", () => {
       data: EXAMPLE_DATA,
     });
 
-    input.focus();
+    act(() => input.focus());
     await userEvent.paste('"quu');
 
     expect(input).toHaveValue('"quu');
@@ -254,7 +254,7 @@ describe("MultiAutocomplete", () => {
       data: EXAMPLE_DATA,
     });
 
-    input.focus();
+    act(() => input.focus());
     await userEvent.type(input, "a,a,b,b,a,a,", {
       pointerEventsCheck: 0,
     });
@@ -269,7 +269,7 @@ describe("MultiAutocomplete", () => {
       dir: "rtl",
     });
 
-    input.focus();
+    act(() => input.focus());
     await userEvent.type(input, "כּטקמ", {
       pointerEventsCheck: 0,
     });

--- a/frontend/src/metabase/ui/components/utils/DelayGroup/DelayGroup.unit.spec.tsx
+++ b/frontend/src/metabase/ui/components/utils/DelayGroup/DelayGroup.unit.spec.tsx
@@ -49,10 +49,12 @@ describe("DelayGroup", () => {
 
     act(function () {
       jest.advanceTimersByTime(timeout / 2);
-      expect(button).toHaveTextContent("delay: false");
-
-      jest.advanceTimersByTime(timeout / 2 + 1);
-      expect(button).toHaveTextContent("delay: true");
     });
+    expect(button).toHaveTextContent("delay: false");
+
+    act(function () {
+      jest.advanceTimersByTime(timeout / 2 + 1);
+    });
+    expect(button).toHaveTextContent("delay: true");
   });
 });

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailView.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailView.unit.spec.tsx
@@ -8,12 +8,7 @@ import {
   setupDatabasesEndpoints,
 } from "__support__/server-mocks";
 import { testDataset } from "__support__/testDataset";
-import {
-  renderWithProviders,
-  screen,
-  waitForLoaderToBeRemoved,
-  within,
-} from "__support__/ui";
+import { renderWithProviders, screen, within } from "__support__/ui";
 import { getNextId } from "__support__/utils";
 import { checkNotNull } from "metabase/lib/types";
 import type { WritebackAction } from "metabase-types/api";
@@ -464,14 +459,11 @@ describe("ObjectDetailView", () => {
 
     const action = await findActionInActionMenu(implicitUpdateAction);
     expect(action).toBeInTheDocument();
-    action?.click();
+    await userEvent.click(action!);
 
     expect(
       screen.queryByText("Choose a record to update"),
     ).not.toBeInTheDocument();
-    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
-
-    await waitForLoaderToBeRemoved();
 
     const modal = await screen.findByTestId("action-execute-modal");
     expect(modal).toBeInTheDocument();


### PR DESCRIPTION
Related to #43375

### Description

Pulls out all the changes required to make upgrading to React 18 + React Testing Library 15 possible but happen to be backwards compatible with React 17 + RTL 12. The changes were extracted from #41577 with the goal that we can backport this PR to minimize the diff between `master` and the current release branch, while also keeping our React 18 upgrade branch as small as possible.

Most changes fall into a few categories:
1. Use `await userEvent.click(el)` over `el.click()` (or similar event methods)
2. Use `act` where needed (generally for reacting to route changes or dispatched redux events)
3. Use `find` methods over `get` (I _think_ to account for async scheduling of the React 18 renderer)

### How to verify

- Unit tests should pass

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
