### PR TITLE
Rework Kondo `defendpoint` custom macro to be a custom hook instead

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -683,6 +683,9 @@
    metabase.api.card-test/with-temp-native-card!                                                                             hooks.common/with-two-bindings
    metabase.api.card-test/with-temp-native-card-with-params!                                                                 hooks.common/with-two-bindings
    metabase.api.collection-test/with-french-user-and-personal-collection                                                     hooks.common/with-two-top-level-bindings
+   metabase.api.common/defendpoint                                                                                           hooks.metabase.api.common/defendpoint
+   metabase.api.common/defendpoint-async                                                                                     hooks.metabase.api.common/defendpoint
+   metabase.api.common/defendpoint-async-schema                                                                              hooks.metabase.api.common/defendpoint
    metabase.api.dashboard-test/with-chain-filter-fixtures                                                                    hooks.common/let-one-with-optional-value
    metabase.api.dashboard-test/with-simple-dashboard-with-tabs                                                               hooks.common/with-one-binding
    metabase.api.card-test/with-card-param-values-fixtures                                                                    hooks.common/let-one-with-optional-value
@@ -781,9 +784,6 @@
    metabase.api.card-test/with-ordered-items                                    macros.metabase.api.card-test/with-ordered-items
    metabase.api.collection-test/with-collection-hierarchy                       macros.metabase.api.collection-test/with-collection-hierarchy
    metabase.api.collection-test/with-some-children-of-collection                macros.metabase.api.collection-test/with-some-children-of-collection
-   metabase.api.common/defendpoint                                              macros.metabase.api.common/defendpoint
-   metabase.api.common/defendpoint-async                                        macros.metabase.api.common/defendpoint
-   metabase.api.common/defendpoint-async-schema                                 macros.metabase.api.common/defendpoint
    metabase.api.common/define-routes                                            macros.metabase.api.common/define-routes
    metabase.api.embed-test/with-embedding-enabled-and-temp-card-referencing     macros.metabase.api.embed-test/with-embedding-enabled-and-temp-card-referencing
    metabase.api.embed-test/with-embedding-enabled-and-temp-dashcard-referencing macros.metabase.api.embed-test/with-embedding-enabled-and-temp-dashcard-referencing

--- a/.clj-kondo/hooks/metabase/api/common.clj
+++ b/.clj-kondo/hooks/metabase/api/common.clj
@@ -1,0 +1,45 @@
+(ns hooks.metabase.api.common
+  (:require
+   [clj-kondo.hooks-api :as api]
+   [clojure.string :as str]))
+
+(defn route-fn-name
+  "route fn hook"
+  [method route]
+  (let [route (if (vector? route) (first route) route)]
+    (-> (str (name method) route)
+        (str/replace #"/" "_")
+        symbol)))
+
+(defn defendpoint
+  [arg]
+  (letfn [(update-defendpoint [node]
+            (let [[_defendpoint method route & body] (:children node)]
+              (api/list-node
+               (list
+                (api/token-node 'do)
+                (api/token-node (symbol "compojure.core" (str (api/sexpr method))))
+                (-> (api/list-node
+                     (list*
+                      (api/token-node 'clojure.core/defn)
+                      (api/token-node (route-fn-name (api/sexpr method) (api/sexpr route)))
+                      body))
+                    (with-meta (meta node)))))))]
+    (update arg :node update-defendpoint)))
+
+(comment
+  (-> {:node (-> '(api/defendpoint POST "/:id/copy"
+                    "Copy a `Card`, with the new name 'Copy of _name_'"
+                    [id]
+                    {id [:maybe ms/PositiveInt]}
+                    (let [orig-card (api/read-check Card id)
+                          new-name  (str (trs "Copy of ") (:name orig-card))
+                          new-card  (assoc orig-card :name new-name)]
+                      (-> (card/create-card! new-card @api/*current-user*)
+                          hydrate-card-details
+                          (assoc :last-edit-info (last-edit/edit-information-for-user @api/*current-user*)))))
+                 pr-str
+                 api/parse-string)}
+      defendpoint
+      :node
+      api/sexpr))

--- a/.clj-kondo/macros/metabase/api/common.clj
+++ b/.clj-kondo/macros/metabase/api/common.clj
@@ -1,26 +1,7 @@
-(ns macros.metabase.api.common
-  (:require
-   [clojure.string :as str]))
+(ns macros.metabase.api.common)
 
 (defmacro define-routes
   "Macro for api.common/define-routes"
   [& args]
   `(do (def ~'routes "docstring" nil)
        ~@args))
-
-(defn route-fn-name
-  "route fn hook"
-  [method route]
-  (let [route (if (vector? route) (first route) route)]
-    (-> (str (name method) route)
-        (str/replace #"/" "_")
-        symbol)))
-
-(defmacro defendpoint
-  "Macro for api.common/defendpoint*"
-  [method route & body]
-  (let [method-fn  (symbol "compojure.core" (str method))
-        route-name (route-fn-name method route)]
-    `(do
-       ~method-fn
-       (defn ~route-name ~@body))))


### PR DESCRIPTION
Part of #43414

Just ran into something interesting with Kondo + LSP

`M-x lsp-find-definition` doesn't seem to work for me inside things that we use custom Kondo macros for. I was looking at the `defendpoint` for `POST /api/card/:id/copy` 

https://github.com/metabase/metabase/blob/f3ddcb66a700d8104b01c0b605383bcde285be19/src/metabase/api/card.clj#L478-L487

and hitting `M-.` on the `card/create-card!` call inside it and it didn't work... LSP just jumped me to the top of the `defendpoint` form itself. I looked at our Kondo config and we're using a custom macro there. I rewrote it as a custom hook instead and now my LSP jump-to-definition works as expected.

This PR replaces the `defendpoint` Kondo macro with a hook instead.