### PR TITLE
Improve haveDashboardCardsChanged util performance

### DIFF
--- a/frontend/src/metabase/dashboard/actions/utils.ts
+++ b/frontend/src/metabase/dashboard/actions/utils.ts
@@ -52,12 +52,22 @@ export function haveDashboardCardsChanged(
   newCards: QuestionDashboardCard[],
   oldCards: QuestionDashboardCard[],
 ) {
+  const newCardsWithMatchingOldCard = new Set();
+
   return (
-    !newCards.every(newCard =>
-      oldCards.some(oldCard => _.isEqual(oldCard, newCard)),
-    ) ||
+    !newCards.every(newCard => {
+      const hasMatch = oldCards.some(oldCard => _.isEqual(oldCard, newCard));
+      if (hasMatch) {
+        newCardsWithMatchingOldCard.add(newCard);
+      }
+      return hasMatch;
+    }) ||
     !oldCards.every(oldCard =>
-      newCards.some(newCard => _.isEqual(oldCard, newCard)),
+      newCards.some(
+        newCard =>
+          newCardsWithMatchingOldCard.has(newCard) ||
+          _.isEqual(oldCard, newCard),
+      ),
     )
   );
 }

--- a/frontend/src/metabase/dashboard/actions/utils.ts
+++ b/frontend/src/metabase/dashboard/actions/utils.ts
@@ -52,22 +52,10 @@ export function haveDashboardCardsChanged(
   newCards: QuestionDashboardCard[],
   oldCards: QuestionDashboardCard[],
 ) {
-  const newCardsWithMatchingOldCard = new Set();
-
   return (
-    !newCards.every(newCard => {
-      const hasMatch = oldCards.some(oldCard => _.isEqual(oldCard, newCard));
-      if (hasMatch) {
-        newCardsWithMatchingOldCard.add(newCard);
-      }
-      return hasMatch;
-    }) ||
-    !oldCards.every(oldCard =>
-      newCards.some(
-        newCard =>
-          newCardsWithMatchingOldCard.has(newCard) ||
-          _.isEqual(oldCard, newCard),
-      ),
+    newCards.length !== oldCards.length ||
+    !newCards.every(newCard =>
+      oldCards.some(oldCard => _.isEqual(oldCard, newCard)),
     )
   );
 }


### PR DESCRIPTION
### Description

A performance based unit test is failing in master for `haveDashboardCardsChanged` which expects a comparison of two 1000 card sets to be determined as equal in under 100ms  (example: https://github.com/metabase/metabase/actions/runs/9306286700/job/25616198364). 

This function was O^2(n *m) and this refactors it to O^(n*m). The refactor in testing reflects this with 48% reduction in time  over 5000 iterations of the failing test. **This refactor however assumes that there would be no duplicate `QuestionDashboardCard`s within one of the inputs _which I'm not sure is a valid assumption_.**


### Checklist

- [x] Tests have been added/updated to cover changes in this PR