### PR TITLE
Don't throw an exception when a non-existent setting is in the config file

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file/settings.clj
@@ -4,9 +4,7 @@
    [metabase-enterprise.advanced-config.file.interface :as advanced-config.file.i]
    [metabase.models.setting :as setting]
    [metabase.util :as u]
-   [metabase.util.log :as log])
-  (:import
-   (clojure.lang ExceptionInfo)))
+   [metabase.util.log :as log]))
 
 (defmethod advanced-config.file.i/section-spec :settings
   [_section-name]
@@ -17,9 +15,6 @@
   (log/info "Setting setting values from config file")
   (doseq [[setting-name setting-value] settings]
     (log/infof "Setting value for Setting %s" setting-name)
-    (try
+    (if (setting/registered? setting-name)
       (setting/set! setting-name setting-value)
-      (catch ExceptionInfo e
-        (if (true? (:metabase.models.setting/unknown-setting-error (ex-data e)))
-          (log/warn (u/format-color :yellow "Ignoring unknown setting in config: %s." (name setting-name)))
-          (throw e))))))
+      (log/warn (u/format-color :yellow "Ignoring unknown setting in config: %s." (name setting-name))))))

--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file/settings.clj
@@ -3,7 +3,10 @@
    [clojure.spec.alpha :as s]
    [metabase-enterprise.advanced-config.file.interface :as advanced-config.file.i]
    [metabase.models.setting :as setting]
-   [metabase.util.log :as log]))
+   [metabase.util :as u]
+   [metabase.util.log :as log])
+  (:import
+   (clojure.lang ExceptionInfo)))
 
 (defmethod advanced-config.file.i/section-spec :settings
   [_section-name]
@@ -14,4 +17,9 @@
   (log/info "Setting setting values from config file")
   (doseq [[setting-name setting-value] settings]
     (log/infof "Setting value for Setting %s" setting-name)
-    (setting/set! setting-name setting-value)))
+    (try
+      (setting/set! setting-name setting-value)
+      (catch ExceptionInfo e
+        (if (true? (:metabase.models.setting/unknown-setting-error (ex-data e)))
+          (log/warn (u/format-color :yellow "Ignoring unknown setting in config: %s." (name setting-name)))
+          (throw e))))))

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/file/settings_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/file/settings_test.clj
@@ -3,7 +3,8 @@
    [clojure.test :refer :all]
    [metabase-enterprise.advanced-config.file :as advanced-config.file]
    [metabase.models.setting :refer [defsetting]]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.util :as u]))
 
 (use-fixtures :each (fn [thunk]
                       (binding [advanced-config.file/*supported-versions* {:min 1, :max 1}]
@@ -34,11 +35,12 @@
         (testing "value should not have been updated"
           (is (= "wow"
                  (config-from-file-settings-test-setting))))))
-    (testing "Invalid Setting (does not exist)"
+    (testing "Invalid Setting (does not exist) should log a warning and continue."
       (binding [advanced-config.file/*config* {:version 1
                                                :config  {:settings {:config-from-file-settings-test-setting-FAKE 1000}}}]
 
-        (is (thrown-with-msg?
-             clojure.lang.ExceptionInfo
-             #"Unknown setting: :config-from-file-settings-test-setting-FAKE"
-             (advanced-config.file/initialize!)))))))
+        (let [log-messages (mt/with-log-messages-for-level [metabase-enterprise.advanced-config.file.settings :warn]
+                             (is (= :ok
+                                    (advanced-config.file/initialize!))))]
+          (is (= [[:warn nil (u/colorize :yellow "Ignoring unknown setting in config: config-from-file-settings-test-setting-FAKE.")]]
+                 log-messages)))))))

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -332,6 +332,11 @@
                          :registered-settings
                          (sort (keys @registered-settings))})))))
 
+(defn registered?
+  "Returns true if a setting is registered with the given name."
+  [setting-keyword-or-name]
+  (contains? @registered-settings (keyword setting-keyword-or-name)))
+
 ;; The actual watch that triggers this happens in [[metabase.models.setting.cache/cache*]] because the cache might be
 ;; swapped out depending on which app DB we have in play
 ;;

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -818,9 +818,8 @@ See [fonts](../configuring-metabase/fonts.md).")
 ;;; Deprecated uploads settings begin
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; These settings were removed in 50.0 and will be erased from the code in 53.0. They are kept here for backwards compatibility
-;; to avoid breaking existing installations that may have set these values with environment variables, or via the config
-;; file.
+;; These settings were removed in 50.0 and will be erased from the code in 53.0. They have been left here to explain how
+;; to migrate to the new way to set uploads settings.
 
 (defsetting ^{:deprecated "0.50.0"} uploads-enabled
   (deferred-tru "Whether or not uploads are enabled")


### PR DESCRIPTION
This PR changes the behaviour when a setting in the config file doesn't exist. 

Currently whenever you remove or rename a setting, metabase_database column, or core_user column, Metabase will fail to start for any customers that have set its value via the config file. This makes it harder to refactor settings or database columns. To make the changes backwards compatible but we have to carefully deprecate columns or settings and remove them after a period of time.

With this PR, we don't throw an exception when a non-existent setting is set in the config file.

The desire for the new behaviour was checked [here on slack with the rest of the team](https://metaboat.slack.com/archives/CKZEMT1MJ/p1717081485713669?thread_ts=1716828710.408369&cid=CKZEMT1MJ).