### PR TITLE
Catch exceptions from driver/database-supports? outside driver code

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -107,6 +107,7 @@
    malli.core/explainer                               {:message "Use metabase.util.malli.registry/explainer instead of malli.core/explainer"}
    me.flowthing.pp/pprint                             {:message "Use metabase.util.log instead of me.flowthing.pp/pprint"}
    medley.core/random-uuid                            {:message "Use clojure.core/random-uuid instead of medley.core/random-uuid"}
+   metabase.driver/database-supports?                 {:message "Use metabase.driver.util/supports? instead of metabase.driver/database-supports?"}
    metabase.lib.equality/find-column-indexes-for-refs {:message "Use lib.equality/closest-matches-in-metadata or lib.equality/find-closest-matches-for-refs instead of lib.equality/find-column-indexes-for-refs"}
    metabase.test/with-temp*                           {:message "Use mt/with-temp instead of mt/with-temp*"}
    toucan2.tools.with-temp                            {:message "Use mt/with-temp instead of t2.with-temp/with-temp"}}
@@ -835,7 +836,11 @@
   ;; `metabase.driver.*`, excluding `-test` namespaces.
   ;;
   {:pattern "metabase(?:(?:(?:-enterprise\\.sandbox)?\\.query-processor\\.)|(?:\\.driver\\.)).*(?<!-test)$"
-   :name    qp-and-driver-source-namespaces}]
+   :name    qp-and-driver-source-namespaces}
+
+  ;; driver namespaces
+  {:pattern "metabase\\.driver.*$"
+   :name    driver-namespaces}]
 
  :config-in-ns
  {test-namespaces
@@ -843,12 +848,14 @@
    {:inline-def                              {:level :off}
     :missing-docstring                       {:level :off}
     :private-call                            {:level :off}
-    :metabase/defsetting-must-specify-export {:level :off}}
-   :hooks
-   {:analyze-call
-    {clojure.core/defmacro hooks.clojure.core/non-thread-safe-form-should-end-with-exclamation
-     clojure.core/defn     hooks.clojure.core/non-thread-safe-form-should-end-with-exclamation
-     clojure.core/defn-    hooks.clojure.core/non-thread-safe-form-should-end-with-exclamation}}}
+    :metabase/defsetting-must-specify-export {:level :off}
+    :discouraged-var                         {metabase.driver/database-supports? {:level :off}}}
+
+  :hooks
+  {:analyze-call
+   {clojure.core/defmacro hooks.clojure.core/non-thread-safe-form-should-end-with-exclamation
+    clojure.core/defn     hooks.clojure.core/non-thread-safe-form-should-end-with-exclamation
+    clojure.core/defn-    hooks.clojure.core/non-thread-safe-form-should-end-with-exclamation}}}
 
   source-namespaces
   {:linters
@@ -892,6 +899,11 @@
      toucan.models              {:message "Don't use application database inside MLv2 code"}
      toucan.util.test           {:message "Don't use application database inside MLv2 code"}
      toucan2.core               {:message "Don't use application database inside MLv2 code"}}}}
+
+  driver-namespaces
+  {:linters
+   {:discouraged-var
+    {metabase.driver/database-supports? {:level :off}}}}
 
   qp-and-driver-source-namespaces
   {:linters

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/driver/impersonation.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/driver/impersonation.clj
@@ -5,6 +5,7 @@
    [metabase.api.common :as api]
    [metabase.driver :as driver]
    [metabase.driver.sql :as driver.sql]
+   [metabase.driver.util :as driver.u]
    [metabase.models.field :as field]
    [metabase.models.permissions-group-membership
     :refer [PermissionsGroupMembership]]
@@ -90,7 +91,7 @@
   support connection impersonation, or for non-EE instances."
   :feature :advanced-permissions
   [driver ^Connection conn database]
-  (when (driver/database-supports? driver :connection-impersonation database)
+  (when (driver.u/supports? driver :connection-impersonation database)
     (try
       (let [enabled?           (impersonation-enabled-for-db? database)
             default-role       (driver.sql/default-database-role driver database)

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
@@ -12,6 +12,7 @@
    [metabase.api.common :as api]
    [metabase.driver :as driver]
    [metabase.driver.sql.query-processor :as sql.qp]
+   [metabase.driver.util :as driver.u]
    [metabase.legacy-mbql.normalize :as mbql.normalize]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.models :refer [Card Collection Field Table]]
@@ -88,7 +89,7 @@
 
 (defn- venues-category-native-gtap-def []
   (driver/with-driver (or driver/*driver* :h2)
-    (assert (driver/database-supports? driver/*driver* :native-parameters (mt/db)))
+    (assert (driver.u/supports? driver/*driver* :native-parameters (mt/db)))
     {:query (mt/native-query
               {:query
                (format-honeysql
@@ -105,7 +106,7 @@
 
 (defn- parameterized-sql-with-join-gtap-def []
   (driver/with-driver (or driver/*driver* :h2)
-    (assert (driver/database-supports? driver/*driver* :native-parameters (mt/db)))
+    (assert (driver.u/supports? driver/*driver* :native-parameters (mt/db)))
     {:query (mt/native-query
               {:query
                (format-honeysql

--- a/src/metabase/actions.clj
+++ b/src/metabase/actions.clj
@@ -4,6 +4,7 @@
    [clojure.spec.alpha :as s]
    [metabase.api.common :as api]
    [metabase.driver :as driver]
+   [metabase.driver.util :as driver.u]
    [metabase.legacy-mbql.normalize :as mbql.normalize]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema.actions :as lib.schema.actions]
@@ -118,7 +119,7 @@
 (defn check-actions-enabled-for-database!
   "Throws an appropriate error if actions are unsupported or disabled for a database, otherwise returns nil."
   [{db-settings :settings db-id :id driver :engine db-name :name :as db}]
-  (when-not (driver/database-supports? driver :actions db)
+  (when-not (driver.u/supports? driver :actions db)
     (throw (ex-info (i18n/tru "{0} Database {1} does not support actions."
                               (u/qualified-name driver)
                               (format "%d %s" db-id (pr-str db-name)))

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -12,14 +12,15 @@
    [metabase.api.dataset :as api.dataset]
    [metabase.api.field :as api.field]
    [metabase.compatibility :as compatibility]
-   [metabase.driver :as driver]
+   [metabase.driver.util :as driver.u]
    [metabase.events :as events]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata.jvm :as lib.metadata.jvm]
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.lib.util.match :as lib.util.match]
-   [metabase.models :refer [Card CardBookmark Collection Database PersistedInfo Table]]
+   [metabase.models :refer [Card CardBookmark Collection Database
+                            PersistedInfo Table]]
    [metabase.models.card :as card]
    [metabase.models.collection :as collection]
    [metabase.models.collection.root :as collection.root]
@@ -767,12 +768,12 @@
   (api/let-404 [{:keys [database_id] :as card} (t2/select-one Card :id card-id)]
     (let [database (t2/select-one Database :id database_id)]
       (api/write-check database)
-      (when-not (driver/database-supports? (:engine database)
+      (when-not (driver.u/supports? (:engine database)
                                            :persist-models database)
         (throw (ex-info (tru "Database does not support persisting")
                         {:status-code 400
                          :database    (:name database)})))
-      (when-not (driver/database-supports? (:engine database)
+      (when-not (driver.u/supports? (:engine database)
                                            :persist-models-enabled database)
         (throw (ex-info (tru "Persisting models not enabled for database")
                         {:status-code 400

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -19,8 +19,7 @@
    [metabase.lib.metadata.jvm :as lib.metadata.jvm]
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.lib.util.match :as lib.util.match]
-   [metabase.models :refer [Card CardBookmark Collection Database
-                            PersistedInfo Table]]
+   [metabase.models :refer [Card CardBookmark Collection Database PersistedInfo Table]]
    [metabase.models.card :as card]
    [metabase.models.collection :as collection]
    [metabase.models.collection.root :as collection.root]
@@ -768,13 +767,11 @@
   (api/let-404 [{:keys [database_id] :as card} (t2/select-one Card :id card-id)]
     (let [database (t2/select-one Database :id database_id)]
       (api/write-check database)
-      (when-not (driver.u/supports? (:engine database)
-                                           :persist-models database)
+      (when-not (driver.u/supports? (:engine database) :persist-models database)
         (throw (ex-info (tru "Database does not support persisting")
                         {:status-code 400
                          :database    (:name database)})))
-      (when-not (driver.u/supports? (:engine database)
-                                           :persist-models-enabled database)
+      (when-not (driver.u/supports? (:engine database) :persist-models-enabled database)
         (throw (ex-info (tru "Persisting models not enabled for database")
                         {:status-code 400
                          :database    (:name database)})))

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -104,7 +104,7 @@
 (defn- card-database-supports-nested-queries? [{{database-id :database, :as database} :dataset_query, :as _card}]
   (when database-id
     (when-let [driver (driver.u/database->driver database-id)]
-      (driver/database-supports? driver :nested-queries database))))
+      (driver.u/supports? driver :nested-queries database))))
 
 (defn- card-has-ambiguous-columns?
   "We know a card has ambiguous columns if any of the columns that come back end in `_2` (etc.) because that's what
@@ -144,7 +144,7 @@
   (set (filter (fn [db-id]
                  (try
                    (when-let [db (t2/select-one Database :id db-id)]
-                     (driver/database-supports? (:engine db) :nested-queries db))
+                     (driver.u/supports? (:engine db) :nested-queries db))
                    (catch Throwable e
                      (log/error e "Error determining whether Database supports nested queries"))))
                (t2/select-pks-set Database))))
@@ -243,7 +243,7 @@
 (defn- uploadable-db?
   "Are uploads supported for this database?"
   [db]
-  (driver/database-supports? (driver.u/database->driver db) :uploads db))
+  (driver.u/supports? (driver.u/database->driver db) :uploads db))
 
 (defn- add-can-upload
   "Adds :can_upload boolean, which is true if the user can create a new upload to this DB."

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -280,7 +280,7 @@
   (dimension-index-for-type :type/Coordinate #(.contains ^String (str (:name %)) (str auto-bin-str))))
 
 (defn- supports-numeric-binning? [db]
-  (and db (driver/database-supports? (:engine db) :binning db)))
+  (and db (driver.u/supports? (:engine db) :binning db)))
 
 ;; TODO: Remove all this when the FE is fully ported to [[metabase.lib.binning/available-binning-strategies]].
 (defn- assoc-field-dimension-options [{:keys [base_type semantic_type fingerprint] :as field} db]

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -6,7 +6,6 @@
    [medley.core :as m]
    [metabase.api.common :as api]
    [metabase.db.query :as mdb.query]
-   [metabase.driver :as driver]
    [metabase.driver.h2 :as h2]
    [metabase.driver.util :as driver.u]
    [metabase.events :as events]

--- a/src/metabase/db/metadata_queries.clj
+++ b/src/metabase/db/metadata_queries.clj
@@ -176,7 +176,7 @@
   (let [database           (t2/select-one :model/Database (:db_id table))
         driver             (driver.u/database->driver database)
         text-fields        (filter text-field? fields)
-        field->expressions (when (and truncation-size (driver/database-supports? driver :expressions database))
+        field->expressions (when (and truncation-size (driver.u/supports? driver :expressions database))
                              (into {} (for [field text-fields]
                                         [field [(str (gensym "substring"))
                                                 [:substring [:field (u/the-id field) nil]

--- a/src/metabase/driver/sql.clj
+++ b/src/metabase/driver/sql.clj
@@ -9,7 +9,6 @@
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.driver.sql.util :as sql.u]
    [metabase.driver.sql.util.unprepare :as unprepare]
-   [metabase.driver.util :as driver.u]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.util.malli :as mu]
    [potemkin :as p]))
@@ -39,12 +38,12 @@
                       :full-join]]
   (defmethod driver/database-supports? [:sql join-feature]
     [driver _feature db]
-    (driver.u/supports? driver :foreign-keys db)))
+    (driver/database-supports? driver :foreign-keys db)))
 
 (defmethod driver/database-supports? [:sql :persist-models-enabled]
   [driver _feat db]
   (and
-    (driver.u/supports? driver :persist-models db)
+    (driver/database-supports? driver :persist-models db)
     (-> db :settings :persist-models-enabled)))
 
 (defmethod driver/mbql->native :sql

--- a/src/metabase/driver/sql.clj
+++ b/src/metabase/driver/sql.clj
@@ -9,6 +9,7 @@
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.driver.sql.util :as sql.u]
    [metabase.driver.sql.util.unprepare :as unprepare]
+   [metabase.driver.util :as driver.u]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.util.malli :as mu]
    [potemkin :as p]))
@@ -38,12 +39,12 @@
                       :full-join]]
   (defmethod driver/database-supports? [:sql join-feature]
     [driver _feature db]
-    (driver/database-supports? driver :foreign-keys db)))
+    (driver.u/supports? driver :foreign-keys db)))
 
 (defmethod driver/database-supports? [:sql :persist-models-enabled]
   [driver _feat db]
   (and
-    (driver/database-supports? driver :persist-models db)
+    (driver.u/supports? driver :persist-models db)
     (-> db :settings :persist-models-enabled)))
 
 (defmethod driver/mbql->native :sql

--- a/src/metabase/driver/sql_jdbc/sync/describe_database.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_database.clj
@@ -139,7 +139,7 @@
   [driver conn]
   ;; `sql-jdbc.sync.interface/have-select-privilege?` is slow because we're doing a SELECT query on each table
   ;; It's basically a N+1 operation where N is the number of tables in the database
-  (if (driver.u/supports? driver :table-privileges nil)
+  (if (driver/database-supports? driver :table-privileges nil)
     (let [schema+table-with-select-privileges (schema+table-with-select-privileges driver conn)]
       (fn [{schema :schema table :name ttype :type}]
         ;; driver/current-user-table-privileges does not return privileges for external table on redshift, and foreign

--- a/src/metabase/driver/sql_jdbc/sync/describe_database.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_database.clj
@@ -139,7 +139,7 @@
   [driver conn]
   ;; `sql-jdbc.sync.interface/have-select-privilege?` is slow because we're doing a SELECT query on each table
   ;; It's basically a N+1 operation where N is the number of tables in the database
-  (if (driver/database-supports? driver :table-privileges nil)
+  (if (driver.u/supports? driver :table-privileges nil)
     (let [schema+table-with-select-privileges (schema+table-with-select-privileges driver conn)]
       (fn [{schema :schema table :name ttype :type}]
         ;; driver/current-user-table-privileges does not return privileges for external table on redshift, and foreign

--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -13,7 +13,6 @@
    [metabase.driver.sql-jdbc.sync.common :as sql-jdbc.sync.common]
    [metabase.driver.sql-jdbc.sync.interface :as sql-jdbc.sync.interface]
    [metabase.driver.sql.query-processor :as sql.qp]
-   [metabase.driver.util :as driver.u]
    [metabase.lib.schema.literal :as lib.schema.literal]
    [metabase.models :refer [Field]]
    [metabase.models.table :as table]
@@ -24,11 +23,7 @@
    #_{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2])
   (:import
-   (com.fasterxml.jackson.core
-    JsonFactory
-    JsonParser
-    JsonParser$NumberType
-    JsonToken)
+   (com.fasterxml.jackson.core JsonFactory JsonParser JsonToken JsonParser$NumberType)
    (java.sql Connection DatabaseMetaData ResultSet)))
 
 (set! *warn-on-reflection* true)
@@ -193,7 +188,7 @@
              :json-unfolding    json?}
             (when semantic-type
               {:semantic-type semantic-type})
-            (when (and json? (driver.u/supports? driver :nested-field-columns db))
+            (when (and json? (driver/database-supports? driver :nested-field-columns db))
               {:visibility-type :details-only}))))))
 
 (defn describe-table-fields-xf

--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -21,6 +21,7 @@
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.log :as log]
    [metabase.util.malli.registry :as mr]
+   #_{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2])
   (:import
    (com.fasterxml.jackson.core

--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -13,6 +13,7 @@
    [metabase.driver.sql-jdbc.sync.common :as sql-jdbc.sync.common]
    [metabase.driver.sql-jdbc.sync.interface :as sql-jdbc.sync.interface]
    [metabase.driver.sql.query-processor :as sql.qp]
+   [metabase.driver.util :as driver.u]
    [metabase.lib.schema.literal :as lib.schema.literal]
    [metabase.models :refer [Field]]
    [metabase.models.table :as table]
@@ -20,10 +21,13 @@
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.log :as log]
    [metabase.util.malli.registry :as mr]
-   #_{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2])
   (:import
-   (com.fasterxml.jackson.core JsonFactory JsonParser JsonToken JsonParser$NumberType)
+   (com.fasterxml.jackson.core
+    JsonFactory
+    JsonParser
+    JsonParser$NumberType
+    JsonToken)
    (java.sql Connection DatabaseMetaData ResultSet)))
 
 (set! *warn-on-reflection* true)
@@ -188,7 +192,7 @@
              :json-unfolding    json?}
             (when semantic-type
               {:semantic-type semantic-type})
-            (when (and json? (driver/database-supports? driver :nested-field-columns db))
+            (when (and json? (driver.u/supports? driver :nested-field-columns db))
               {:visibility-type :details-only}))))))
 
 (defn describe-table-fields-xf

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -220,7 +220,6 @@
   [driver feature database]
   (try
     (u/with-timeout supports?-timeout-ms
-      ;; clj-kondo this
       (driver/database-supports? driver feature database))
     (catch Throwable e
       (log/error e (u/format-color 'red "Failed to check feature '%s' for database '%s'" (name feature) (:name database)))

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -206,16 +206,31 @@
 ;;; |                                             Available Drivers Info                                             |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
+(def supports?-timeout-ms
+  "The maximum time in milliseconds that [[supports?]] should take to execute. This should be enough for a driver to
+   query the database and check if it supports a feature under normal circumstances, but not so high that it delays
+   critical metabase features that use this check."
+  5000)
+
+(defn supports?
+  "A defensive wrapper around [[database-supports?]]. It adds logging and error handling to avoid crashing the app if this
+   method takes a long time to execute or throws an exception. This is useful because `supports?` is used in so many critical
+   places in the app, and we don't want a single driver to crash the app if it throws an exception, or delay the user if it
+   takes a long time to execute."
+  [driver feature database]
+  (try
+    (u/with-timeout supports?-timeout-ms
+      ;; clj-kondo this
+      (driver/database-supports? driver feature database))
+    (catch Throwable e
+      (log/error e (u/format-color 'red "Failed to check feature '%s' for database '%s'" (name feature) (:name database)))
+      false)))
+
 (defn features
   "Return a set of all features supported by `driver` with respect to `database`."
   [driver database]
   (set (for [feature driver/features
-             :when (try
-                     ;; catch any exceptions thrown by the driver to avoid crashing the app
-                     (driver/database-supports? driver feature database)
-                     (catch Throwable e
-                       (log/error e (u/format-color 'red "failed to check feature '%s' for database '%s'" (name feature) (:name database)))
-                       false))]
+             :when (supports? driver feature database)]
          feature)))
 
 (defn available-drivers

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -210,7 +210,12 @@
   "Return a set of all features supported by `driver` with respect to `database`."
   [driver database]
   (set (for [feature driver/features
-             :when (driver/database-supports? driver feature database)]
+             :when (try
+                     ;; catch any exceptions thrown by the driver to avoid crashing the app
+                     (driver/database-supports? driver feature database)
+                     (catch Throwable e
+                       (log/error e (u/format-color 'red "failed to check feature '%s' for database '%s'" (name feature) (:name database)))
+                       false))]
          feature)))
 
 (defn available-drivers

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -282,7 +282,7 @@
       (u/prog1 (cond-> database
                  ;; If the engine doesn't support nested field columns, `json_unfolding` must be nil
                  (and (some? (:details changes))
-                      (not (driver/database-supports? (or new-engine existing-engine) :nested-field-columns database)))
+                      (not (driver.u/supports? (or new-engine existing-engine) :nested-field-columns database)))
                  (update :details dissoc :json_unfolding)
 
                  (or
@@ -302,7 +302,7 @@
         ;; This maintains a constraint that if a driver doesn't support actions, it can never be enabled
         ;; If we drop support for actions for a driver, we'd need to add a migration to disable actions for all databases
         (when (and (:database-enable-actions (or new-settings existing-settings))
-                   (not (driver/database-supports? (or new-engine existing-engine) :actions database)))
+                   (not (driver.u/supports? (or new-engine existing-engine) :actions database)))
           (throw (ex-info (trs "The database does not support actions.")
                           {:status-code     400
                            :existing-engine existing-engine

--- a/src/metabase/query_processor/middleware/add_implicit_joins.clj
+++ b/src/metabase/query_processor/middleware/add_implicit_joins.clj
@@ -7,6 +7,7 @@
    [clojure.walk :as walk]
    [medley.core :as m]
    [metabase.driver :as driver]
+   [metabase.driver.util :as driver.u]
    [metabase.legacy-mbql.schema :as mbql.s]
    [metabase.legacy-mbql.util :as mbql.u]
    [metabase.lib.metadata :as lib.metadata]
@@ -290,7 +291,7 @@
   [query]
   (if (lib.util.match/match-one (:query query) [:field _ (_ :guard (every-pred :source-field (complement :join-alias)))])
     (do
-      (when-not (driver/database-supports? driver/*driver* :foreign-keys (lib.metadata/database (qp.store/metadata-provider)))
+      (when-not (driver.u/supports? driver/*driver* :foreign-keys (lib.metadata/database (qp.store/metadata-provider)))
         (throw (ex-info (tru "{0} driver does not support foreign keys." driver/*driver*)
                         {:driver driver/*driver*
                          :type   qp.error-type/unsupported-feature})))

--- a/src/metabase/query_processor/middleware/check_features.clj
+++ b/src/metabase/query_processor/middleware/check_features.clj
@@ -1,6 +1,7 @@
 (ns metabase.query-processor.middleware.check-features
   (:require
    [metabase.driver :as driver]
+   [metabase.driver.util :as driver.u]
    [metabase.legacy-mbql.schema :as mbql.s]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.util.match :as lib.util.match]
@@ -13,7 +14,7 @@
   "Assert that the driver/database supports keyword `feature`."
   [feature]
   (let [database (lib.metadata/database (qp.store/metadata-provider))]
-    (when-not (driver/database-supports? driver/*driver* feature database)
+    (when-not (driver.u/supports? driver/*driver* feature database)
       (throw (ex-info (tru "{0} is not supported by {1} driver." (name feature) (name driver/*driver*))
                       {:type    qp.error-type/unsupported-feature
                        :feature feature

--- a/src/metabase/query_processor/middleware/cumulative_aggregations.clj
+++ b/src/metabase/query_processor/middleware/cumulative_aggregations.clj
@@ -52,8 +52,8 @@
   (cond
     ;; no need to rewrite `:cum-sum` and `:cum-count` functions, this driver supports native window function versions
     (driver.u/supports? driver/*driver*
-                               :window-functions/cumulative
-                               (lib.metadata/database (qp.store/metadata-provider)))
+                        :window-functions/cumulative
+                        (lib.metadata/database (qp.store/metadata-provider)))
     query
 
     ;; nothing to rewrite

--- a/src/metabase/query_processor/middleware/cumulative_aggregations.clj
+++ b/src/metabase/query_processor/middleware/cumulative_aggregations.clj
@@ -18,6 +18,7 @@
   information."
   (:require
    [metabase.driver :as driver]
+   [metabase.driver.util :as driver.u]
    [metabase.legacy-mbql.schema :as mbql.s]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.util.match :as lib.util.match]
@@ -50,7 +51,7 @@
   [{{breakouts :breakout, aggregations :aggregation} :query, :as query}]
   (cond
     ;; no need to rewrite `:cum-sum` and `:cum-count` functions, this driver supports native window function versions
-    (driver/database-supports? driver/*driver*
+    (driver.u/supports? driver/*driver*
                                :window-functions/cumulative
                                (lib.metadata/database (qp.store/metadata-provider)))
     query

--- a/src/metabase/query_processor/middleware/parameters/native.clj
+++ b/src/metabase/query_processor/middleware/parameters/native.clj
@@ -27,6 +27,7 @@
   (:require
    [clojure.set :as set]
    [metabase.driver :as driver]
+   [metabase.driver.util :as driver.u]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.query-processor.store :as qp.store]))
 
@@ -34,7 +35,7 @@
   "Expand parameters inside an *inner* native `query`. Not recursive -- recursive transformations are handled in
   the `middleware.parameters` functions that invoke this function."
   [inner-query]
-  (if-not (driver/database-supports? driver/*driver* :native-parameters (lib.metadata/database (qp.store/metadata-provider)))
+  (if-not (driver.u/supports? driver/*driver* :native-parameters (lib.metadata/database (qp.store/metadata-provider)))
     inner-query
     ;; Totally ridiculous, but top-level native queries use the key `:query` for SQL or equivalent, while native
     ;; source queries use `:native`. So we need to handle either case.

--- a/src/metabase/query_processor/middleware/results_metadata.clj
+++ b/src/metabase/query_processor/middleware/results_metadata.clj
@@ -5,13 +5,13 @@
   (:require
    [metabase.analyze :as analyze]
    [metabase.driver :as driver]
+   [metabase.driver.util :as driver.u]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.query-processor.reducible :as qp.reducible]
    [metabase.query-processor.schema :as qp.schema]
    [metabase.query-processor.store :as qp.store]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   #_{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2]))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -31,7 +31,7 @@
     ;; if its DB doesn't support nested queries in the first place
     (when (and metadata
                driver/*driver*
-               (driver/database-supports? driver/*driver* :nested-queries (lib.metadata/database (qp.store/metadata-provider)))
+               (driver.u/supports? driver/*driver* :nested-queries (lib.metadata/database (qp.store/metadata-provider)))
                card-id
                ;; don't want to update metadata when we use a Card as a source Card.
                (not (:qp/source-card-id query)))

--- a/src/metabase/query_processor/middleware/results_metadata.clj
+++ b/src/metabase/query_processor/middleware/results_metadata.clj
@@ -12,6 +12,7 @@
    [metabase.query-processor.store :as qp.store]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
+   #_{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2]))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/src/metabase/query_processor/timezone.clj
+++ b/src/metabase/query_processor/timezone.clj
@@ -4,6 +4,7 @@
    [java-time.api :as t]
    [metabase.config :as config]
    [metabase.driver :as driver]
+   [metabase.driver.util :as driver.u]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.query-processor.store :as qp.store]
    [metabase.util.log :as log])
@@ -45,7 +46,7 @@
    (report-timezone-id-if-supported driver/*driver* (lib.metadata/database (qp.store/metadata-provider))))
 
   (^String [driver database]
-   (when (driver/database-supports? driver :set-timezone database)
+   (when (driver.u/supports? driver :set-timezone database)
      (valid-timezone-id (report-timezone-id*)))))
 
 (defn database-timezone-id

--- a/src/metabase/sync/analyze/fingerprint.clj
+++ b/src/metabase/sync/analyze/fingerprint.clj
@@ -233,7 +233,7 @@
   [database        :- i/DatabaseInstance
    tables          :- [:maybe [:sequential i/TableInstance]]
    log-progress-fn :- LogProgressFn]
-  (if (driver/database-supports? (:engine database) :fingerprint database)
+  (if (driver.u/supports? (:engine database) :fingerprint database)
     (fingerprint-fields-for-db!* database tables log-progress-fn)
     (empty-stats-map 0)))
 

--- a/src/metabase/sync/fetch_metadata.clj
+++ b/src/metabase/sync/fetch_metadata.clj
@@ -38,14 +38,14 @@
    table    :- i/TableInstance]
   (log-if-error "table-fields-metadata"
     (let [driver (driver.u/database->driver database)
-          result (if (driver/database-supports? driver :describe-fields database)
+          result (if (driver.u/supports? driver :describe-fields database)
                    (set (driver/describe-fields driver
                                                 database
                                                 :table-names [(:name table)]
                                                 :schema-names [(:schema table)]))
                    (:fields (driver/describe-table driver database table)))]
       (cond-> result
-        (driver/database-supports? driver :nested-field-columns database)
+        (driver.u/supports? driver :nested-field-columns database)
         ;; TODO: decouple nested field columns sync from field sync. This will allow
         ;; describe-fields to be used for field sync for databases with nested field columns
         ;; Also this should be a driver method, not a sql-jdbc.sync method
@@ -69,7 +69,7 @@
   [database :- i/DatabaseInstance & {:as args}]
   (log-if-error "fields-metadata"
     (let [driver             (driver.u/database->driver database)
-          describe-fields-fn (if (driver/database-supports? driver :describe-fields database)
+          describe-fields-fn (if (driver.u/supports? driver :describe-fields database)
                                driver/describe-fields
                                ;; In a future version we may remove [[driver/describe-table]]
                                ;; and we'll just use [[driver/describe-fields]] here
@@ -103,8 +103,8 @@
   [database :- i/DatabaseInstance & {:as args}]
   (log-if-error "fk-metadata"
     (let [driver (driver.u/database->driver database)]
-      (when (driver/database-supports? driver :foreign-keys database)
-        (let [describe-fks-fn (if (driver/database-supports? driver :describe-fks database)
+      (when (driver.u/supports? driver :foreign-keys database)
+        (let [describe-fks-fn (if (driver.u/supports? driver :describe-fks database)
                                 driver/describe-fks
                                 ;; In version 52 we'll remove [[driver/describe-table-fks]]
                                 ;; and we'll just use [[driver/describe-fks]] here

--- a/src/metabase/sync/sync_metadata/fields.clj
+++ b/src/metabase/sync/sync_metadata/fields.clj
@@ -39,7 +39,6 @@
   * In general the methods in these namespaces return the number of rows updated; these numbers are summed and used
     for logging purposes by higher-level sync logic."
   (:require
-   [metabase.driver :as driver]
    [metabase.driver.util :as driver.u]
    [metabase.models.table :as table]
    [metabase.sync.fetch-metadata :as fetch-metadata]
@@ -76,7 +75,7 @@
   [database :- i/DatabaseInstance]
   (sync-util/with-error-handling (format "Error syncing Fields for Database ''%s''" (sync-util/name-for-logging database))
     (let [driver          (driver.u/database->driver database)
-          schemas?        (driver/database-supports? driver :schemas database)
+          schemas?        (driver.u/supports? driver :schemas database)
           fields-metadata (if schemas?
                             (fetch-metadata/fields-metadata database :schema-names (sync-util/db->sync-schemas database))
                             (fetch-metadata/fields-metadata database))]

--- a/src/metabase/sync/sync_metadata/fks.clj
+++ b/src/metabase/sync/sync_metadata/fks.clj
@@ -3,7 +3,6 @@
   (:require
    [honey.sql :as sql]
    [metabase.db :as mdb]
-   [metabase.driver :as driver]
    [metabase.driver.util :as driver.u]
    [metabase.models.table :as table]
    [metabase.sync.fetch-metadata :as fetch-metadata]
@@ -100,7 +99,7 @@
   ([database :- i/DatabaseInstance
     table    :- i/TableInstance]
    (sync-util/with-error-handling (format "Error syncing FKs for %s" (sync-util/name-for-logging table))
-     (let [schema-names (when (driver/database-supports? (driver.u/database->driver database) :schemas database)
+     (let [schema-names (when (driver.u/supports? (driver.u/database->driver database) :schemas database)
                           [(:schema table)])
            fk-metadata  (into [] (fetch-metadata/fk-metadata database :schema-names schema-names :table-names [(:name table)]))]
        {:total-fks   (count fk-metadata)
@@ -116,7 +115,7 @@
   [database :- i/DatabaseInstance]
   (u/prog1 (sync-util/with-error-handling (format "Error syncing FKs for %s" (sync-util/name-for-logging database))
              (let [driver       (driver.u/database->driver database)
-                   schema-names (when (driver/database-supports? driver :schemas database)
+                   schema-names (when (driver.u/supports? driver :schemas database)
                                   (sync-util/db->sync-schemas database))
                    fk-metadata  (fetch-metadata/fk-metadata database :schema-names schema-names)]
                (transduce (map (fn [x]

--- a/src/metabase/sync/sync_metadata/indexes.clj
+++ b/src/metabase/sync/sync_metadata/indexes.clj
@@ -1,7 +1,6 @@
 (ns metabase.sync.sync-metadata.indexes
   (:require
    [clojure.data :as data]
-   [metabase.driver :as driver]
    [metabase.driver.util :as driver.u]
    [metabase.models.field :as field]
    [metabase.sync.fetch-metadata :as fetch-metadata]
@@ -27,7 +26,7 @@
 (defn maybe-sync-indexes-for-table!
   "Sync the indexes for `table` if the driver supports storing index info."
   [database table]
-  (if (driver/database-supports? (driver.u/database->driver database) :index-info database)
+  (if (driver.u/supports? (driver.u/database->driver database) :index-info database)
     (sync-util/with-error-handling (format "Error syncing Indexes for %s" (sync-util/name-for-logging table))
       (let [indexes                    (fetch-metadata/index-metadata database table)
             indexed-field-ids          (indexes->field-ids (:id table) indexes)
@@ -51,7 +50,7 @@
 (defn maybe-sync-indexes!
   "Sync the indexes for all tables in `database` if the driver supports storing index info."
   [database]
-  (if (driver/database-supports? (driver.u/database->driver database) :index-info database)
+  (if (driver.u/supports? (driver.u/database->driver database) :index-info database)
     (apply merge-with + empty-stats
            (map #(maybe-sync-indexes-for-table! database %) (sync-util/db->sync-tables database)))
     empty-stats))

--- a/src/metabase/sync/sync_metadata/sync_table_privileges.clj
+++ b/src/metabase/sync/sync_metadata/sync_table_privileges.clj
@@ -14,7 +14,7 @@
    This is a cache of the data returned from `driver/table-privileges`, but it's stored in the database for performance."
   [database :- (ms/InstanceOf :model/Database)]
   (let [driver (driver.u/database->driver database)]
-    (when (driver/database-supports? driver :table-privileges database)
+    (when (driver.u/supports? driver :table-privileges database)
       (let [rows               (driver/current-user-table-privileges driver database)
             schema+table->id   (t2/select-fn->pk (fn [t] {:schema (:schema t), :table (:name t)}) :model/Table :db_id (:id database))
             rows-with-table-id (keep (fn [row]

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -231,7 +231,7 @@
   "Returns true if there should be an auto-incrementing primary key column in any table created or updated from an
    upload."
   [driver db]
-  (driver/database-supports? driver :upload-with-auto-pk db))
+  (driver.u/supports? driver :upload-with-auto-pk db))
 
 (defn- create-from-csv!
   "Creates a table from a CSV file. If the table already exists, it will throw an error.
@@ -301,7 +301,7 @@
       (ex-info (tru "Uploads are not permitted for sandboxed users.")
                {:status-code 403})
 
-      (not (driver/database-supports? driver :uploads db))
+      (not (driver.u/supports? driver :uploads db))
       (ex-info (tru "Uploads are not supported on {0} databases." (str/capitalize (name driver)))
                {:status-code 422}))))
 
@@ -313,7 +313,7 @@
         (ex-info (tru "Uploads are not enabled.")
                  {:status-code 422})
         (and (str/blank? schema-name)
-             (driver/database-supports? (driver.u/database->driver db) :schemas db))
+             (driver.u/supports? (driver.u/database->driver db) :schemas db))
         (ex-info (tru "A schema has not been set.")
                  {:status-code 422})
         (not

--- a/src/metabase/xrays/automagic_dashboards/combination.clj
+++ b/src/metabase/xrays/automagic_dashboards/combination.clj
@@ -20,7 +20,7 @@
    [clojure.string :as str]
    [clojure.walk :as walk]
    [medley.core :as m]
-   [metabase.driver :as driver]
+   [metabase.driver.util :as driver.u]
    [metabase.models.interface :as mi]
    [metabase.query-processor.util :as qp.util]
    [metabase.util :as u]
@@ -164,7 +164,7 @@
   [{:keys [base_type db fingerprint aggregation]}]
   (or (nil? aggregation)
       (not (isa? base_type :type/Number))
-      (and (driver/database-supports? (:engine db) :binning db)
+      (and (driver.u/supports? (:engine db) :binning db)
            (-> fingerprint :type :type/Number :min))))
 
 (defn- valid-bindings? [{:keys [root]} satisfied-dimensions bindings]

--- a/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
+++ b/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
@@ -27,11 +27,11 @@
 
 (defn- uses-default-describe-table? [driver]
   (and (identical? (get-method driver/describe-table :sql-jdbc) (get-method driver/describe-table driver))
-       (not (driver/database-supports? driver :describe-fields nil))))
+       (not (driver.u/supports? driver :describe-fields nil))))
 
 (defn- uses-default-describe-fields? [driver]
   (and (identical? (get-method driver/describe-fields :sql-jdbc) (get-method driver/describe-fields driver))
-       (driver/database-supports? driver :describe-fields nil)))
+       (driver.u/supports? driver :describe-fields nil)))
 
 (defn- sql-jdbc-drivers-using-default-describe-table-or-fields-impl
   "All SQL JDBC drivers that use the default SQL JDBC implementation of `describe-table`, or `describe-fields`."
@@ -46,7 +46,7 @@
 (deftest ^:parallel describe-fields-nested-field-columns-test
   (testing (str "Drivers that support describe-fields should not support the nested field columns feature."
                 "It is possible to support both in the future but this has not been implemented yet.")
-    (is (empty? (filter #(driver/database-supports? % :describe-fields nil)
+    (is (empty? (filter #(driver.u/supports? % :describe-fields nil)
                         (mt/normal-drivers-with-feature :nested-field-columns))))))
 
 (deftest ^:parallel describe-table-test
@@ -141,7 +141,7 @@
 (defn- describe-fields-for-table [db table]
   (let [driver (driver.u/database->driver db)]
     (sort-by :database-position
-             (if (driver/database-supports? driver :describe-fields db)
+             (if (driver.u/supports? driver :describe-fields db)
                (vec (driver/describe-fields driver
                                             db
                                             :schema-names [(:schema table)]

--- a/test/metabase/driver/util_test.clj
+++ b/test/metabase/driver/util_test.clj
@@ -290,18 +290,18 @@
       (with-redefs [driver/database-supports? (fn [_ _ _] (throw (Exception. "test exception message")))]
         (let [log-messages (mt/with-log-messages-for-level [metabase.driver.util :error]
                              (is (false? (driver.u/supports? :test-driver :test-feature fake-test-db))))]
-          (is (some (fn [[level exception message]]
+          (is (some (fn [[level ^Throwable exception message]]
                       (and (= level :error)
                            (= (.getMessage exception) "test exception message")
-                           (= message (u/format-color 'red "failed to check feature 'test-feature' for database 'test-data'"))))
+                           (= message (u/format-color 'red "Failed to check feature 'test-feature' for database 'test-data'"))))
                     log-messages)))))
     (testing "supports? returns false when `driver/database-supports?` takes longer than the timeout"
       (with-redefs [driver.u/supports?-timeout-ms 100
                     driver/database-supports?     (fn [_ _ _] (Thread/sleep 200) true)]
         (let [log-messages (mt/with-log-messages-for-level [metabase.driver.util :error]
                              (is (false? (driver.u/supports? :test-driver :test-feature fake-test-db))))]
-          (is (some (fn [[level exception message]]
+          (is (some (fn [[level ^Throwable exception message]]
                       (and (= level :error)
                            (= (.getMessage exception) "Timed out after 100.0 ms")
-                           (= message (u/format-color 'red "failed to check feature 'test-feature' for database 'test-data'"))))
+                           (= message (u/format-color 'red "Failed to check feature 'test-feature' for database 'test-data'"))))
                     log-messages)))))))

--- a/test/metabase/driver/util_test.clj
+++ b/test/metabase/driver/util_test.clj
@@ -3,13 +3,15 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [metabase.driver :as driver]
    [metabase.driver.h2 :as h2]
    [metabase.driver.util :as driver.u]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
    [metabase.query-processor.store :as qp.store]
    [metabase.test :as mt]
-   [metabase.test.fixtures :as fixtures])
+   [metabase.test.fixtures :as fixtures]
+   [metabase.util :as u])
   (:import
    (java.nio.charset StandardCharsets)
    (java.util Base64)
@@ -276,8 +278,30 @@
    (is (=? {:driver-name "H2", :superseded-by :deprecated}
            (:h2 (driver.u/available-drivers-info))))))
 
-(deftest ^:paralell database-id->driver-use-qp-store-test
+(deftest ^:parallel database-id->driver-use-qp-store-test
   (qp.store/with-metadata-provider (lib.tu/mock-metadata-provider
                                     {:database (assoc meta/database :id Integer/MAX_VALUE, :engine :wow)})
     (is (= :wow
            (driver.u/database->driver Integer/MAX_VALUE)))))
+
+(deftest supports?-failure-test
+  (let [fake-test-db (mt/db)]
+    (testing "supports? returns false when `driver/database-supports?` throws an exception"
+      (with-redefs [driver/database-supports? (fn [_ _ _] (throw (Exception. "test exception message")))]
+        (let [log-messages (mt/with-log-messages-for-level [metabase.driver.util :error]
+                             (is (false? (driver.u/supports? :test-driver :test-feature fake-test-db))))]
+          (is (some (fn [[level exception message]]
+                      (and (= level :error)
+                           (= (.getMessage exception) "test exception message")
+                           (= message (u/format-color 'red "failed to check feature 'test-feature' for database 'test-data'"))))
+                    log-messages)))))
+    (testing "supports? returns false when `driver/database-supports?` takes longer than the timeout"
+      (with-redefs [driver.u/supports?-timeout-ms 100
+                    driver/database-supports?     (fn [_ _ _] (Thread/sleep 200) true)]
+        (let [log-messages (mt/with-log-messages-for-level [metabase.driver.util :error]
+                             (is (false? (driver.u/supports? :test-driver :test-feature fake-test-db))))]
+          (is (some (fn [[level exception message]]
+                      (and (= level :error)
+                           (= (.getMessage exception) "Timed out after 100.0 ms")
+                           (= message (u/format-color 'red "failed to check feature 'test-feature' for database 'test-data'"))))
+                    log-messages)))))))

--- a/test/metabase/models/database_test.clj
+++ b/test/metabase/models/database_test.clj
@@ -89,7 +89,7 @@
   (mt/test-drivers #{:sqlite}
     (testing "Updating database-enable-actions to true should fail if the engine doesn't support actions"
       (t2.with-temp/with-temp [Database database {:engine :sqlite}]
-        (is (= false (driver/database-supports? :sqlite :actions database)))
+        (is (= false (driver.u/supports? :sqlite :actions database)))
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
              #"The database does not support actions."

--- a/test/metabase/models/model_index_test.clj
+++ b/test/metabase/models/model_index_test.clj
@@ -5,7 +5,7 @@
    [clojurewerkz.quartzite.scheduler :as qs]
    [malli.core :as mc]
    [malli.error :as me]
-   [metabase.driver :as driver]
+   [metabase.driver.util :as driver.u]
    [metabase.models.card :refer [Card]]
    [metabase.models.model-index
     :as model-index
@@ -186,7 +186,7 @@
                        [:native (mt/native-query
                                  (qp.compile/compile
                                   (mt/mbql-query products {:fields [$id $title]})))]
-                       (when (driver/database-supports? (:engine (mt/db)) :left-join (mt/db))
+                       (when (driver.u/supports? (:engine (mt/db)) :left-join (mt/db))
                          [:join (mt/$ids
                                  {:type     :query,
                                   :query    {:source-table $$people,

--- a/test/metabase/query_processor/middleware/parameters/mbql_test.clj
+++ b/test/metabase/query_processor/middleware/parameters/mbql_test.clj
@@ -4,6 +4,7 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.driver :as driver]
+   [metabase.driver.util :as driver.u]
    [metabase.legacy-mbql.normalize :as mbql.normalize]
    [metabase.query-processor :as qp]
    [metabase.query-processor.compile :as qp.compile]
@@ -320,7 +321,7 @@
 (deftest ^:parallel handle-fk-forms-test
   (mt/test-drivers (params-test-drivers)
     (qp.store/with-metadata-provider (mt/id)
-      (when (driver/database-supports? driver/*driver* :foreign-keys (mt/db))
+      (when (driver.u/supports? driver/*driver* :foreign-keys (mt/db))
         (testing "Make sure we properly handle paramters that have `fk->` forms in `:dimension` targets (#9017)"
           (is (= [[31 "Bludso's BBQ" 5 33.8894 -118.207 2]
                   [32 "Boneyard Bistro" 5 34.1477 -118.428 3]

--- a/test/metabase/query_processor/test_util.clj
+++ b/test/metabase/query_processor/test_util.clj
@@ -14,6 +14,7 @@
    [metabase.db :as mdb]
    [metabase.driver :as driver]
    [metabase.driver.test-util :as driver.tu]
+   [metabase.driver.util :as driver.u]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.jvm :as lib.metadata.jvm]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
@@ -30,7 +31,6 @@
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   #_{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -60,7 +60,7 @@
                :let   [driver (tx/the-driver-with-test-extensions driver)]
                :when  (driver/with-driver driver
                         (let [db (data/db)]
-                          (every? #(driver/database-supports? driver % db) features)))]
+                          (every? #(driver.u/supports? driver % db) features)))]
            driver))))
 
 (alter-meta! #'normal-drivers-with-feature assoc :arglists (list (into ['&] (sort driver/features))))
@@ -353,7 +353,7 @@
 (defn supports-report-timezone?
   "Returns truthy if `driver` supports setting a timezone"
   [driver]
-  (driver/database-supports? driver :set-timezone (data/db)))
+  (driver.u/supports? driver :set-timezone (data/db)))
 
 (defn cols
   "Return the result `:cols` from query `results`, or throw an Exception if they're missing."

--- a/test/metabase/query_processor/test_util.clj
+++ b/test/metabase/query_processor/test_util.clj
@@ -31,6 +31,7 @@
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
+   #_{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)

--- a/test/metabase/query_processor_test/advanced_math_test.clj
+++ b/test/metabase/query_processor_test/advanced_math_test.clj
@@ -80,7 +80,7 @@
                (ffirst
                 (mt/formatted-rows [1.0]
                   (mt/process-query query))))))))
-  (when (driver/database-supports? driver/*driver* :expression-aggregations (mt/db))
+  (when (driver.u/supports? driver/*driver* :expression-aggregations (mt/db))
     (testing "Inside an expression aggregation"
       (let [query (mt/mbql-query venues
                     {:aggregation [[:+ agg 1]]})]

--- a/test/metabase/query_processor_test/date_bucketing_test.clj
+++ b/test/metabase/query_processor_test/date_bucketing_test.clj
@@ -23,6 +23,7 @@
    [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.driver.sql.query-processor-test-util :as sql.qp-test-util]
+   [metabase.driver.util :as driver.u]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
@@ -81,7 +82,7 @@
                                       [id (u.date/format-sql (t/local-date-time (u.date/parse s))) cnt])
 
                                     (or (= timezone :utc)
-                                        (not (driver/database-supports? driver/*driver* :set-timezone (mt/db))))
+                                        (not (driver.u/supports? driver/*driver* :set-timezone (mt/db))))
                                     utc-results
 
                                     :else

--- a/test/metabase/query_processor_test/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor_test/date_time_zone_functions_test.clj
@@ -4,6 +4,7 @@
    [clojure.test :refer :all]
    [java-time.api :as t]
    [metabase.driver :as driver]
+   [metabase.driver.util :as driver.u]
    [metabase.models :refer [Card]]
    [metabase.query-processor :as qp]
    [metabase.query-processor.test-util :as qp.test-util]
@@ -182,7 +183,7 @@
                                           :limit       1})]
           (mt/with-native-query-testing-context query
             (is (= (if (or (#{:sqlserver :h2} driver/*driver*)
-                           (driver/database-supports? driver/*driver* :set-timezone (mt/db)))
+                           (driver.u/supports? driver/*driver* :set-timezone (mt/db)))
                      {:get-year        2004
                       :get-quarter     1
                       :get-month       1
@@ -568,7 +569,7 @@
                                 $times.dt
                                 [:convert-timezone [:field (mt/id :times :dt) nil] "Asia/Seoul"]))))))
 
-          (when (driver/database-supports? driver/*driver* :set-timezone (mt/db))
+          (when (driver.u/supports? driver/*driver* :set-timezone (mt/db))
             (mt/with-report-timezone-id! "Europe/Rome"
               (testing "results should be displayed in the converted timezone, not report-tz"
                 (is (= ["2004-03-19T09:19:09+01:00" "2004-03-19T17:19:09+09:00"]
@@ -594,7 +595,7 @@
                                  "Asia/Seoul"
                                  "UTC"]))))))
 
-          (when (driver/database-supports? driver/*driver* :set-timezone (mt/db))
+          (when (driver.u/supports? driver/*driver* :set-timezone (mt/db))
             (mt/with-report-timezone-id! "Europe/Rome"
               (testing "the base timezone should be the timezone of column (Asia/Ho_Chi_Minh)"
                 (is (= ["2004-03-19T03:19:09+01:00" "2004-03-19T11:19:09+09:00"]
@@ -967,7 +968,7 @@
                            "2022-10-03T00:00:00Z"))))) ; 2022-10-03T00:00:00Z
   (testing "hour under a day"
     (mt/with-temporary-setting-values [driver/report-timezone "Atlantic/Cape_Verde"]
-      (is (partial= (if (driver/database-supports? driver/*driver* :set-timezone (mt/db))
+      (is (partial= (if (driver.u/supports? driver/*driver* :set-timezone (mt/db))
                       {:second 82800 :minute 1380 :hour 23 :day 1}
                       {:second 82800 :minute 1380 :hour 23 :day 0})
                     (diffs "2022-10-02T00:00:00Z"          ; 2022-10-01T23:00:00-01:00
@@ -978,7 +979,7 @@
                            "2022-10-03T00:00:00+01:00"))))) ; 2022-10-02T23:00:00Z
   (testing "hour under a week"
     (mt/with-temporary-setting-values [driver/report-timezone "Atlantic/Cape_Verde"]
-      (is (partial= (if (driver/database-supports? driver/*driver* :set-timezone (mt/db))
+      (is (partial= (if (driver.u/supports? driver/*driver* :set-timezone (mt/db))
                       {:hour 167 :day 7 :week 1}
                       {:hour 167 :day 6 :week 0})
                     (diffs "2022-10-02T00:00:00Z"          ; 2022-10-01T23:00:00-01:00
@@ -998,7 +999,7 @@
                            "2022-10-09T00:00:00Z"))))) ; 2022-10-09T00:00:00Z
   (testing "hour under a month"
     (mt/with-temporary-setting-values [driver/report-timezone "Atlantic/Cape_Verde"]
-      (is (partial= (if (driver/database-supports? driver/*driver* :set-timezone (mt/db))
+      (is (partial= (if (driver.u/supports? driver/*driver* :set-timezone (mt/db))
                       {:hour 743 :day 31 :week 4 :month 1}
                       {:hour 743 :day 30 :week 4 :month 0})
                     (diffs "2022-10-02T00:00:00Z"          ; 2022-10-01T23:00:00-01:00
@@ -1018,7 +1019,7 @@
                            "2022-11-02T00:00:00Z"))))) ; 2022-11-02T00:00:00Z
   (testing "hour under a quarter"
     (mt/with-temporary-setting-values [driver/report-timezone "Atlantic/Cape_Verde"]
-      (is (partial= (if (driver/database-supports? driver/*driver* :set-timezone (mt/db))
+      (is (partial= (if (driver.u/supports? driver/*driver* :set-timezone (mt/db))
                       {:month 3 :quarter 1}
                       {:month 2 :quarter 0})
                     (diffs "2022-10-02T00:00:00Z"          ; 2022-10-01T23:00:00-01:00
@@ -1047,7 +1048,7 @@
                            "2023-10-02T00:00:00Z"))))) ; 2023-10-02T00:00:00Z
   (testing "hour under a year"
     (mt/with-temporary-setting-values [driver/report-timezone "Atlantic/Cape_Verde"]
-      (is (partial= (if (driver/database-supports? driver/*driver* :set-timezone (mt/db))
+      (is (partial= (if (driver.u/supports? driver/*driver* :set-timezone (mt/db))
                       {:day 365 :month 12 :year 1}
                       {:day 364 :month 11 :year 0})
                     (diffs "2022-10-02T00:00:00Z"          ; 2022-10-01T23:00:00-01:00

--- a/test/metabase/query_processor_test/timezones_test.clj
+++ b/test/metabase/query_processor_test/timezones_test.clj
@@ -6,6 +6,7 @@
    [java-time.api :as t]
    [metabase.driver :as driver]
    [metabase.driver.sql.query-processor :as sql.qp]
+   [metabase.driver.util :as driver.u]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.query-processor :as qp]
    [metabase.query-processor.store :as qp.store]
@@ -260,7 +261,7 @@
   (mt/dataset all-dates-leap-year
     (mt/test-drivers (set-timezone-drivers)
       (let [extract-units (cond-> (disj u.date/extract-units :day-of-year)
-                            (not (driver/database-supports? driver/*driver* ::extract-week-of-year-us (mt/db)))
+                            (not (driver.u/supports? driver/*driver* ::extract-week-of-year-us (mt/db)))
                             (disj :week-of-year))
             ;; :week-of-year-instance is the behavior of u.date/extract (based on public-settings start-of-week)
             extract-translate {:year :year-of-era :week-of-year :week-of-year-us}

--- a/test/metabase/test/data/dataset_definition_test.clj
+++ b/test/metabase/test/data/dataset_definition_test.clj
@@ -3,6 +3,7 @@
    [clojure.test :refer :all]
    [metabase.driver :as driver]
    [metabase.driver.ddl.interface :as ddl.i]
+   [metabase.driver.util :as driver.u]
    [metabase.test :as mt]
    [metabase.timeseries-query-processor-test.util :as tqpt]
    [toucan2.core :as t2]))
@@ -27,7 +28,7 @@
                    :fk_target_field_id nil
                    :semantic_type      :type/PK}]
                  user-fields)))
-        (when (driver/database-supports? driver/*driver* :foreign-keys (mt/db))
+        (when (driver.u/supports? driver/*driver* :foreign-keys (mt/db))
           (testing "user_custom_id is a FK non user.custom_id"
             (is (= #{{:name               (format-name "user_custom_id")
                       :fk_target_field_id (mt/id :user :custom_id)

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -876,30 +876,29 @@
           _                    (t2/update! :model/Database db-id {:is_on_demand false
                                                                   :is_full_sync false})]
       (try
-        (binding [upload/*auxiliary-sync-steps* :synchronous]
-          (testing "Happy path with schema, and without table-prefix"
-            (with-upload-table!
-              [new-table (card->table (upload-example-csv! :schema-name schema-name :auxiliary-sync-steps :asynchronous))]
-              (is (=? {:display          :table
-                       :database_id      db-id
-                       :dataset_query    {:database db-id
-                                          :query    {:source-table (:id new-table)}
-                                          :type     :query}
-                       :creator_id       (mt/user->id :rasta)
-                       :name             #"(?i)example csv file(.*)"
-                       :collection_id    nil}
-                      (t2/select-one :model/Card :table_id (:id new-table)))
-                  "A new model is created")
-              (is (=? {:name      #"(?i)example(.*)"
-                       :schema    (re-pattern (str "(?i)" schema-name))
-                       :is_upload true}
-                      new-table)
-                  "A new table is created")
-              (is (= "complete"
-                     (:initial_sync_status new-table))
-                  "The table is synced and marked as complete")
-              (is (t2/exists? Field :table_id (:id new-table) :%lower.name "name" :semantic_type :type/Name)
-                  "The sync actually runs"))))
+        (testing "Happy path with schema, and without table-prefix"
+          (with-upload-table!
+            [new-table (card->table (upload-example-csv! :schema-name schema-name :auxiliary-sync-steps :synchronous))]
+            (is (=? {:display          :table
+                     :database_id      db-id
+                     :dataset_query    {:database db-id
+                                        :query    {:source-table (:id new-table)}
+                                        :type     :query}
+                     :creator_id       (mt/user->id :rasta)
+                     :name             #"(?i)example csv file(.*)"
+                     :collection_id    nil}
+                    (t2/select-one :model/Card :table_id (:id new-table)))
+                "A new model is created")
+            (is (=? {:name      #"(?i)example(.*)"
+                     :schema    (re-pattern (str "(?i)" schema-name))
+                     :is_upload true}
+                    new-table)
+                "A new table is created")
+            (is (= "complete"
+                   (:initial_sync_status (t2/select-one :model/Table (:id new-table))))
+                "The table is synced and marked as complete")
+            (is (t2/exists? Field :table_id (:id new-table) :%lower.name "name" :semantic_type :type/Name)
+                "The sync actually runs")))
         (finally
           (t2/update! :model/Database db-id original-sync-values))))))
 

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -415,17 +415,17 @@
 
 (defn- columns-with-auto-pk [columns]
   (cond-> columns
-    (driver/database-supports? driver/*driver* :upload-with-auto-pk (mt/db))
+    (driver.u/supports? driver/*driver* :upload-with-auto-pk (mt/db))
     (#'upload/columns-with-auto-pk)))
 
 (defn- header-with-auto-pk [header]
   (cond->> header
-    (driver/database-supports? driver/*driver* :upload-with-auto-pk (mt/db))
+    (driver.u/supports? driver/*driver* :upload-with-auto-pk (mt/db))
     (cons @#'upload/auto-pk-column-name)))
 
 (defn- rows-with-auto-pk [rows]
   (cond->> rows
-    (driver/database-supports? driver/*driver* :upload-with-auto-pk (mt/db))
+    (driver.u/supports? driver/*driver* :upload-with-auto-pk (mt/db))
     (map-indexed (fn [i row] (cons (inc i) row)))))
 
 (defn- column-position [table column-name]
@@ -449,7 +449,7 @@
                                 ["number" {:base_type :type/Float}]
                                 ["date" {:base_type :type/Date}]
                                 ["datetime" {:base_type :type/DateTime}]]
-                        (driver/database-supports? driver/*driver* :upload-with-auto-pk (mt/db))
+                        (driver.u/supports? driver/*driver* :upload-with-auto-pk (mt/db))
                         (cons ["_mb_row_id" {:semantic_type     :type/PK
                                              :base_type         :type/BigInteger}]))
                       (->> (t2/select :model/Field :table_id (:id table))
@@ -912,7 +912,7 @@
 (deftest create-csv-upload!-table-prefix-test
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
     (testing "Happy path with table prefix, and without schema"
-      (if (driver/database-supports? driver/*driver* :schemas (mt/db))
+      (if (driver.u/supports? driver/*driver* :schemas (mt/db))
         (is (thrown-with-msg?
               java.lang.Exception
               #"^A schema has not been set."
@@ -1221,7 +1221,7 @@
                               - extra_1")
 
                      ["_mb_row_id,id, extra 2"]
-                     (if (driver/database-supports? driver/*driver* :upload-with-auto-pk (mt/db))
+                     (if (driver.u/supports? driver/*driver* :upload-with-auto-pk (mt/db))
                        (trim-lines "The CSV file is missing columns that are in the table:
                                    - name
 
@@ -1685,7 +1685,7 @@
             ;; for drivers that insert rows in chunks, we change the chunk size to 1 so that we can test that the
             ;; inserted rows are rolled back
             (binding [driver/*insert-chunk-rows* 1]
-              (doseq [auto-pk-column? (if (driver/database-supports? driver/*driver* :upload-with-auto-pk (mt/db))
+              (doseq [auto-pk-column? (if (driver.u/supports? driver/*driver* :upload-with-auto-pk (mt/db))
                                         [true false]
                                         [false])]
                 (testing (str "\nFor a table that has " (if auto-pk-column? "an" " no") " automatically generated PK already")


### PR DESCRIPTION
This PR prevents issues like [this](https://github.com/ClickHouse/metabase-clickhouse-driver/issues/242) happening again by logging errors instead of throwing exceptions when a call to `driver/database-supports?` throws an exception.

One reason why exceptions thrown in `driver/database-supports?` has a huge blast radius is the exception will bubble up the call stack every time we call `t2/select` on a database entity using toucan. We call `driver.u/features` on the database in the after-select hook, which calls the driver/database-supports? method:
https://github.com/metabase/metabase/blob/6979c8869fb820c97e0ccbed8c9d63d3f7d1c138/src/metabase/models/database.clj#L184

We also call `driver/database-supports?` in many other important places, for example in the `GET /api/database` handler to check whether the database supports the `:schemas` feature. It's therefore really important that any exceptions thrown during its execution are handled gracefully.

### Linter changes

I've added a lint rule to discourage the use of `driver/database-supports?` outside tests and namespaces matching `metabase.driver*`. Instead, we should use `driver.u/supports?` from now on, which wraps `driver/database-supports?` with timeout and error handling.