### PR TITLE
Add SDK changelog

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/CHANGELOG.md
+++ b/enterprise/frontend/src/embedding-sdk/CHANGELOG.md
@@ -1,0 +1,13 @@
+## [0.1.5](https://github.com/metabase/metabase/compare/embedding-sdk-0.1.0...embedding-sdk-0.1.5) (2024-05-30)
+
+
+### Bug Fixes
+
+* **sdk:** Use theme font in charts and tooltips ([#42855](https://github.com/metabase/metabase/issues/42855)) ([0278b8d](https://github.com/metabase/metabase/commit/0278b8d22174a3555b212df73967a8582e8f3e88))
+* **sdk:** Various fixes for InteractiveQuestion theming ([#42932](https://github.com/metabase/metabase/issues/42932)) ([a3c3193](https://github.com/metabase/metabase/commit/a3c3193474d50c2a4726118cf844d8ed3bb8e974))
+
+
+### Features
+
+* **sdk:** apply user interface color overrides to the sdk ([#42834](https://github.com/metabase/metabase/issues/42834)) ([2e9a53a](https://github.com/metabase/metabase/commit/2e9a53a778cfc80b9e414efdcfad730d803a2849))
+* **sdk:** document theming options in readme ([#42784](https://github.com/metabase/metabase/issues/42784)) ([74ec3ee](https://github.com/metabase/metabase/commit/74ec3eeec76a6d99984f01f780ad3e816e0e9733))


### PR DESCRIPTION
This is required for #43364 to work. The file is generated with tag `embedding-sdk-0.1.5`

#### Explanation
The workflow in #43364 expects the changelog file to already exist, since this file has never been here before, it's not updating the file as you could see in this PR https://github.com/metabase/metabase/pull/43387 that it doesn't contain the changelog. The reason is that the I commit with `git commit -a` that will only include all modified and deleted files, but not the new files.

I could modify the script to always try to add the changelog like `git add changelog-path` but that might raise a question why we only need to add this file when we're changing the readme and the packge.json template files as well.

I want to keep things consistent, and expecting that the changelog file is already exist is reasonable.
