### PR TITLE
Fix mariadb failed to migrate due to having deep nested revision

### DIFF
--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -1031,31 +1031,47 @@
   (unify-time-column-type! :up)
   (unify-time-column-type! :down))
 
+(defn- mariadb?
+  [ds]
+  (with-open [conn (.getConnection ds)]
+    (= "MariaDB" (.getDatabaseProductName (.getMetaData conn)))))
+
+(defn- db-type*
+  "Like [[metabase.connection/db-type]] but distinguishes between mysql and mariadb."
+  []
+  (let [db-type (mdb.connection/db-type)]
+    (if (= db-type :mysql)
+      (if (mariadb? (mdb.connection/data-source))
+        :mariadb
+        :mysql)
+      db-type)))
+
 (define-reversible-migration CardRevisionAddType
-  (case (mdb.connection/db-type)
+  (case (db-type*)
     :postgres
     ;; postgres doesn't allow `\u0000` in text when converting to jsonb, so we need to remove them before we can
     ;; parse the json. We use negative look behind to avoid matching `\\u0000` (metabase#40835)
     (t2/query ["UPDATE revision
                SET object = replace(jsonb_set(
-                  (regexp_replace(object, '(?<!\\\\)\\\\u0000', '286b707c-e895-4cd3-acfc-569147f54371', 'g'))::jsonb, '{type}',
-                  to_jsonb(CASE
-                              WHEN ((regexp_replace(object, '(?<!\\\\)\\\\u0000', '286b707c-e895-4cd3-acfc-569147f54371', 'g'))::jsonb->>'dataset')::boolean THEN 'model'
-                              ELSE 'question'
-                           END)::jsonb, true)::text, '286b707c-e895-4cd3-acfc-569147f54371', '\\u0000')
+               (regexp_replace(object, '(?<!\\\\)\\\\u0000', '286b707c-e895-4cd3-acfc-569147f54371', 'g'))::jsonb, '{type}',
+               to_jsonb(CASE
+               WHEN ((regexp_replace(object, '(?<!\\\\)\\\\u0000', '286b707c-e895-4cd3-acfc-569147f54371', 'g'))::jsonb->>'dataset')::boolean THEN 'model'
+               ELSE 'question'
+               END)::jsonb, true)::text, '286b707c-e895-4cd3-acfc-569147f54371', '\\u0000')
                WHERE model = 'Card' AND ((regexp_replace(object, '(?<!\\\\)\\\\u0000', '286b707c-e895-4cd3-acfc-569147f54371', 'g'))::jsonb->>'dataset') IS NOT NULL;"])
 
     :mysql
     (t2/query ["UPDATE revision
                SET object = JSON_SET(
-                   object,
-                   '$.type',
-                   CASE
-                       WHEN JSON_UNQUOTE(JSON_EXTRACT(object, '$.dataset')) = 'true' THEN 'model'
-                       ELSE 'question'
-                   END)
+               object,
+               '$.type',
+               CASE
+               WHEN JSON_UNQUOTE(JSON_EXTRACT(object, '$.dataset')) = 'true' THEN 'model'
+               ELSE 'question'
+               END)
                WHERE model = 'Card' AND JSON_UNQUOTE(JSON_EXTRACT(object, '$.dataset')) IS NOT NULL;;"])
-    :h2
+
+    (:h2 :mariadb)
     (let [migrate! (fn [revision]
                      (let [object     (json/parse-string (:object revision) keyword)
                            new-object (assoc object :type (if (:dataset object)
@@ -1067,35 +1083,36 @@
       (run! migrate! (t2/reducible-query {:select [:*]
                                           :from   [:revision]
                                           :where  [:= :model "Card"]}))))
-  (case (mdb.connection/db-type)
+
+  (case (db-type*)
     :postgres
     (t2/query ["UPDATE revision
-                SET object = jsonb_set(
-                    object::jsonb - 'type',
-                    '{dataset}',
-                    to_jsonb(CASE
-                                 WHEN (object::jsonb->>'type') = 'model'
-                                 THEN true ELSE false
-                             END)
-                )
-                WHERE model = 'Card' AND (object::jsonb->>'type') IS NOT NULL;"])
+               SET object = jsonb_set(
+               object::jsonb - 'type',
+               '{dataset}',
+               to_jsonb(CASE
+               WHEN (object::jsonb->>'type') = 'model'
+               THEN true ELSE false
+               END)
+               )
+               WHERE model = 'Card' AND (object::jsonb->>'type') IS NOT NULL;"])
 
     :mysql
     (do
-      (t2/query ["UPDATE revision
-                 SET object = JSON_SET(
-                     object,
-                     '$.dataset',
-                     CASE
-                         WHEN JSON_UNQUOTE(JSON_EXTRACT(object, '$.type')) = 'model'
-                         THEN true ELSE false
-                     END)
-                 WHERE model = 'Card' AND JSON_UNQUOTE(JSON_EXTRACT(object, '$.type')) IS NOT NULL;"])
-      (t2/query ["UPDATE revision
-                 SET object = JSON_REMOVE(object, '$.type')
-                 WHERE model = 'Card' AND JSON_UNQUOTE(JSON_EXTRACT(object, '$.type')) IS NOT NULL;"]))
+     (t2/query ["UPDATE revision
+                SET object = JSON_SET(
+                object,
+                '$.dataset',
+                CASE
+                WHEN JSON_UNQUOTE(JSON_EXTRACT(object, '$.type')) = 'model'
+                THEN true ELSE false
+                END)
+                WHERE model = 'Card' AND JSON_UNQUOTE(JSON_EXTRACT(object, '$.type')) IS NOT NULL;"])
+     (t2/query ["UPDATE revision
+                SET object = JSON_REMOVE(object, '$.type')
+                WHERE model = 'Card' AND JSON_UNQUOTE(JSON_EXTRACT(object, '$.type')) IS NOT NULL;"]))
 
-    :h2
+    (:h2 :mariadb)
     (let [rollback! (fn [revision]
                       (let [object     (json/parse-string (:object revision) keyword)
                             new-object (-> object
@@ -1349,7 +1366,7 @@
 (defn- area-bar-stacked-viz-migration
   [{display :display viz :visualization_settings :as card}]
   (if (and (#{:area :bar "area" "bar"} display)
-             (:stackable.stack_type viz))
+           (:stackable.stack_type viz))
     (let [actual-display (or (:stackable.stack_display viz) display)
           new-viz        (m/update-existing viz :series_settings update-vals (fn [m] (dissoc m :display)))]
       (assoc card

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -1071,6 +1071,8 @@
                END)
                WHERE model = 'Card' AND JSON_UNQUOTE(JSON_EXTRACT(object, '$.dataset')) IS NOT NULL;;"])
 
+    ;; json_extract on mariadb throws an error if the json is more than 32 levels nested. See #41924
+    ;; So we do this in clojure land for mariadb
     (:h2 :mariadb)
     (let [migrate! (fn [revision]
                      (let [object     (json/parse-string (:object revision) keyword)

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -32,6 +32,7 @@
    [toucan2.execute :as t2.execute])
   (:import
    (java.util Locale)
+   (javax.sql DataSource)
    (liquibase Scope)
    (liquibase.change Change)
    (liquibase.change.custom CustomTaskChange CustomTaskRollback)
@@ -1033,7 +1034,7 @@
 
 (defn- mariadb?
   [ds]
-  (with-open [conn (.getConnection ds)]
+  (with-open [conn (.getConnection ^DataSource ds)]
     (= "MariaDB" (.getDatabaseProductName (.getMetaData conn)))))
 
 (defn- db-type*

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -1581,12 +1581,20 @@
               (is (= (:created_at session)
                      (t2/select-one-fn :created_at :core_session :id (:id session))))))))))
 
+(def ^:private deep-nested-map
+  "A 35 level nested map to test for mariadb"
+  (reduce (fn [m _]
+            (hash-map "a" m))
+          {:a 1}
+          (range 35)))
+
 (deftest card-revision-add-type-test
   (impl/test-migrations "v49.2024-01-22T11:52:00" [migrate!]
     (let [user-id          (:id (new-instance-with-default :core_user))
           db-id            (:id (new-instance-with-default :metabase_database))
           card             (new-instance-with-default :report_card {:dataset false :creator_id user-id :database_id db-id})
           model            (new-instance-with-default :report_card {:dataset true :creator_id user-id :database_id db-id})
+          card-2           (new-instance-with-default :report_card {:dataset false :creator_id user-id :database_id db-id})
           card-revision-id (:id (new-instance-with-default :revision
                                                            {:object    (json/generate-string (dissoc card :type))
                                                             :model     "Card"
@@ -1596,7 +1604,13 @@
                                                             {:object    (json/generate-string (dissoc model :type))
                                                              :model     "Card"
                                                              :model_id  (:id card)
-                                                             :user_id   user-id}))]
+                                                             :user_id   user-id}))
+          ;; this is only here to test that the migration doesn't break when there's a deep nested map on mariadb see #41924
+          _                (:id (new-instance-with-default :revision
+                                                           {:object    (json/generate-string deep-nested-map)
+                                                            :model     "Card"
+                                                            :model_id  (:id card-2)
+                                                            :user_id   user-id}))]
       (testing "sanity check revision object"
         (let [card-revision-object (t2/select-one-fn (comp json/parse-string :object) :revision card-revision-id)]
           (testing "doesn't have type"


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/41924

MariaDB throws an error when json_extract on a nested json with more than 32 level deep. Even though I'm not sure how it's possible that a revision could be this nested, but it happens.

So we fix it by doing the migration in clojure land for mariadb like we do it for h2.