### PR TITLE
Repro #37380 - Users with no self-service access may update pivot tables and leave them in a non-working state

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
@@ -1,4 +1,4 @@
-import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   restore,
@@ -15,6 +15,7 @@ import {
   openPublicLinkPopoverFromMenu,
   openStaticEmbeddingModal,
   modal,
+  createQuestion,
 } from "e2e/support/helpers";
 
 const {
@@ -1140,6 +1141,74 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
       );
     },
   );
+
+  describe("issue 37380", () => {
+    beforeEach(() => {
+      const categoryField = [
+        "field",
+        PRODUCTS.CATEGORY,
+        { "base-type": "type/Text" },
+      ];
+
+      const createdAtField = [
+        "field",
+        PRODUCTS.CREATED_AT,
+        {
+          "base-type": "type/DateTime",
+          "temporal-unit": "month",
+        },
+      ];
+
+      // to reproduce metabase#37380 it's important that user has access to the database, but not to the table
+      cy.updatePermissionsGraph({
+        [USER_GROUPS.DATA_GROUP]: {
+          [SAMPLE_DB_ID]: {
+            "create-queries": {
+              PUBLIC: {
+                [PRODUCTS_ID]: "no",
+              },
+            },
+          },
+        },
+      });
+
+      createQuestion(
+        {
+          query: {
+            "source-table": PRODUCTS_ID,
+            aggregation: ["count"],
+            breakout: [categoryField, createdAtField],
+          },
+          display: "pivot",
+          visualization_settings: {
+            "pivot_table.column_split": {
+              rows: [createdAtField],
+              columns: [categoryField],
+              values: [["aggregation", 0]],
+            },
+            "pivot_table.column_widths": {
+              leftHeaderWidths: [141],
+              totalLeftHeaderWidths: 141,
+              valueHeaderWidths: {},
+            },
+          },
+        },
+        {
+          wrapId: true,
+          idAlias: "questionId",
+        },
+      );
+    });
+
+    it("does not allow users with no table access to update pivot questions (metabase#37380)", () => {
+      cy.signInAsNormalUser();
+      visitQuestion("@questionId");
+      cy.findByTestId("viz-settings-button").click();
+      cy.findByLabelText("Show row totals").click();
+
+      cy.button("Save").should("have.attr", "disabled");
+    });
+  });
 });
 
 const testQuery = {

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
@@ -195,10 +195,14 @@ export const settings = {
         return hasOnlyFormattableColumns && !columnFormat.highlight_row;
       });
     },
-    getProps: (series: Series) => ({
-      canHighlightRow: false,
-      cols: series[0].data?.cols.filter(isFormattablePivotColumn),
-    }),
+    getProps: (series: Series) => {
+      const cols = series[0].data?.cols ?? [];
+
+      return {
+        canHighlightRow: false,
+        cols: cols.filter(isFormattablePivotColumn),
+      };
+    },
     getHidden: ([{ data }]: [{ data: DatasetData }]) =>
       !data?.cols.some(col => isFormattablePivotColumn(col)),
   },

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
@@ -197,9 +197,7 @@ export const settings = {
     },
     getProps: (series: Series) => ({
       canHighlightRow: false,
-      cols: (series[0].data.cols as DatasetColumn[]).filter(
-        isFormattablePivotColumn,
-      ),
+      cols: series[0].data?.cols.filter(isFormattablePivotColumn),
     }),
     getHidden: ([{ data }]: [{ data: DatasetData }]) =>
       !data?.cols.some(col => isFormattablePivotColumn(col)),


### PR DESCRIPTION
Closes #37380

### Description

This is just a repro, the issue has been fixed by using [`Lib.canSave`](https://github.com/metabase/metabase/blob/fb4b8ca2a60fede819fff9362956941ccccadbcb/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewHeader.jsx#L467-L468) in 0.49.

Adding the test in an existing file instead of a dedicated one (see [Slack discussion](https://metaboat.slack.com/archives/C5XHN8GLW/p1717022207142969)).

### How to verify

Stress test: https://github.com/metabase/metabase/actions/runs/9317550626