### PR TITLE
Bump nippy to 3.4.2

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -49,7 +49,7 @@
   com.snowplowanalytics/snowplow-java-tracker
                                             {:mvn/version "1.0.1"               ; Snowplow analytics
                                              :exclusions [com.fasterxml.jackson.core/jackson-databind]}
-  com.taoensso/nippy                        {:mvn/version "3.3.0"}              ; Fast serialization (i.e., GZIP) library for Clojure
+  com.taoensso/nippy                        {:mvn/version "3.4.2"}              ; Fast serialization (i.e., GZIP) library for Clojure
   com.vladsch.flexmark/flexmark             {:mvn/version "0.64.8"}             ; Markdown parsing
   com.vladsch.flexmark/flexmark-ext-autolink
                                             {:mvn/version "0.64.8"}             ; Flexmark extension for auto-linking bare URLs


### PR DESCRIPTION
Bump nippy to 3.4.2 to fix https://github.com/taoensso/nippy/security/advisories/GHSA-vw78-267v-588h