### PR TITLE
Handle MySQL quotes when resolving analyzed fields

### DIFF
--- a/src/metabase/native_query_analyzer.clj
+++ b/src/metabase/native_query_analyzer.clj
@@ -70,8 +70,11 @@
   (if-let [quote-stripper (quote-strippers (first value))]
     [:= field (quote-stripper value)]
     ;; Technically speaking this is not correct for all databases.
-    ;; For some databases an unquoted reference is expected to mean an explicitly uppercase or lowercase name.
-    ;; i.e. if you created a column called "MixedCaseThing" then `SELECT MixedCaseThing` would *NOT* match it.
+    ;; For example Oracle treats non-quoted identifiers as uppercase, but still expects a case sensitive match.
+    ;; i.e. given a column called "MixedCaseThing" (i.e. it was defined using quotes)
+    ;;      and an unquoted reference like `SELECT MixedCaseThing FROM x`
+    ;;      the query is equivalent to `SELECT "MIXEDCASETHING" FROM x"
+    ;;      and will fail because "MixedCaseThing" != "MIXEDCASETHING"
     [:= [:lower field] (u/lower-case-en value)]))
 
 (defn- table-query

--- a/src/metabase/native_query_analyzer.clj
+++ b/src/metabase/native_query_analyzer.clj
@@ -70,11 +70,14 @@
   (if-let [quote-stripper (quote-strippers (first value))]
     [:= field (quote-stripper value)]
     ;; Technically speaking this is not correct for all databases.
-    ;; For example Oracle treats non-quoted identifiers as uppercase, but still expects a case sensitive match.
-    ;; i.e. given a column called "MixedCaseThing" (i.e. it was defined using quotes)
-    ;;      and an unquoted reference like `SELECT MixedCaseThing FROM x`
-    ;;      the query is equivalent to `SELECT "MIXEDCASETHING" FROM x"
-    ;;      and will fail because "MixedCaseThing" != "MIXEDCASETHING"
+    ;;
+    ;; For example Oracle treats non-quoted identifiers as uppercase, but still expects a case-sensitive match.
+    ;; Similarly, Postgres treat all non-quoted identifiers as lowercase, and again expects an exact match.
+    ;; H2 on the other hand will choose whether to cast it to uppercase or lowercase based on a system variable... T_T
+    ;;
+    ;; MySQL on the other hand is truly case-insensitive, and as the lowest common denominator it's what we cater for.
+    ;; In general, it's a huge anti-pattern to have any identifiers that differ only by case, so this extra leniency is
+    ;; unlikely to ever cause issues in practice.
     [:= [:lower field] (u/lower-case-en value)]))
 
 (defn- table-query

--- a/src/metabase/native_query_analyzer.clj
+++ b/src/metabase/native_query_analyzer.clj
@@ -52,7 +52,7 @@
 ;; NOTE: be careful when adding square braces, as the rules for nesting them are different.
 (def ^:private quotes "\"`")
 
-(defn- quote-stripper
+(defn- quote->stripper
   "Construct a function which unquotes values which use the given character as their quote."
   [quote-char]
   (let [doubled (str quote-char quote-char)
@@ -62,7 +62,7 @@
 
 (def ^:private quote-strippers
   "Pre-constructed lambdas, to save some memory allocations."
-  (zipmap quotes (map quote-stripper quotes)))
+  (zipmap quotes (map quote->stripper quotes)))
 
 (defn- field-query
   "Exact match for quoted fields, case-insensitive match for non-quoted fields"

--- a/src/metabase/native_query_analyzer.clj
+++ b/src/metabase/native_query_analyzer.clj
@@ -69,6 +69,9 @@
   [field value]
   (if-let [quote-stripper (quote-strippers (first value))]
     [:= field (quote-stripper value)]
+    ;; Technically speaking this is not correct for all databases.
+    ;; For some databases an unquoted reference is expected to mean an explicitly uppercase or lowercase name.
+    ;; i.e. if you created a column called "MixedCaseThing" then `SELECT MixedCaseThing` would *NOT* match it.
     [:= [:lower field] (u/lower-case-en value)]))
 
 (defn- table-query

--- a/src/metabase/native_query_analyzer.clj
+++ b/src/metabase/native_query_analyzer.clj
@@ -52,7 +52,7 @@
 ;; NOTE: be careful when adding square braces, as the rules for nesting them are different.
 (def ^:private quotes "\"`")
 
-(defn- quote->stripper
+(defn- quote-stripper
   "Construct a function which unquotes values which use the given character as their quote."
   [quote-char]
   (let [doubled (str quote-char quote-char)
@@ -60,15 +60,15 @@
     #(-> (subs % 1 (dec (count %)))
          (str/replace doubled single))))
 
-(def ^:private quote-strippers
+(def ^:private quote->stripper
   "Pre-constructed lambdas, to save some memory allocations."
-  (zipmap quotes (map quote->stripper quotes)))
+  (zipmap quotes (map quote-stripper quotes)))
 
 (defn- field-query
   "Exact match for quoted fields, case-insensitive match for non-quoted fields"
   [field value]
-  (if-let [quote-stripper (quote-strippers (first value))]
-    [:= field (quote-stripper value)]
+  (if-let [f (quote->stripper (first value))]
+    [:= field (f value)]
     ;; Technically speaking this is not correct for all databases.
     ;;
     ;; For example Oracle treats non-quoted identifiers as uppercase, but still expects a case-sensitive match.

--- a/src/metabase/native_query_analyzer.clj
+++ b/src/metabase/native_query_analyzer.clj
@@ -75,7 +75,7 @@
     ;; Similarly, Postgres treat all non-quoted identifiers as lowercase, and again expects an exact match.
     ;; H2 on the other hand will choose whether to cast it to uppercase or lowercase based on a system variable... T_T
     ;;
-    ;; MySQL on the other hand is truly case-insensitive, and as the lowest common denominator it's what we cater for.
+    ;; MySQL, by contrast, is truly case-insensitive, and as the lowest common denominator it's what we cater for.
     ;; In general, it's a huge anti-pattern to have any identifiers that differ only by case, so this extra leniency is
     ;; unlikely to ever cause issues in practice.
     [:= [:lower field] (u/lower-case-en value)]))

--- a/test/metabase/native_query_analyzer_test.clj
+++ b/test/metabase/native_query_analyzer_test.clj
@@ -49,7 +49,9 @@
                (q "select \"ID\" from venues"))))
       (testing "you can mix quoted and unquoted names"
         (is (= {:direct #{(mt/id :venues :id) (mt/id :venues :name)} :indirect nil}
-               (q "select v.\"ID\", v.name from venues"))))
+               (q "select v.\"ID\", v.name from venues")))
+        (is (= {:direct #{(mt/id :venues :id) (mt/id :venues :name)} :indirect nil}
+               (q "select v.`ID`, v.name from venues"))))
       (testing "It will find all relevant columns if query is not specific"
         (is (= {:direct #{(mt/id :venues :id) (mt/id :checkins :id)} :indirect nil}
                (q "select id from venues join checkins"))))


### PR DESCRIPTION
This fixes the linking up of quoted identifiers within MySQL queries to their corresponding fields.