### PR TITLE
Populate Macaw options based on database type

### DIFF
--- a/src/metabase/native_query_analyzer.clj
+++ b/src/metabase/native_query_analyzer.clj
@@ -70,8 +70,11 @@
   (if-let [quote-stripper (quote-strippers (first value))]
     [:= field (quote-stripper value)]
     ;; Technically speaking this is not correct for all databases.
-    ;; For some databases an unquoted reference is expected to mean an explicitly uppercase or lowercase name.
-    ;; i.e. if you created a column called "MixedCaseThing" then `SELECT MixedCaseThing` would *NOT* match it.
+    ;; For example Oracle treats non-quoted identifiers as uppercase, but still expects a case sensitive match.
+    ;; i.e. given a column called "MixedCaseThing" (i.e. it was defined using quotes)
+    ;;      and an unquoted reference like `SELECT MixedCaseThing FROM x`
+    ;;      the query is equivalent to `SELECT "MIXEDCASETHING" FROM x"
+    ;;      and will fail because "MixedCaseThing" != "MIXEDCASETHING"
     [:= [:lower field] (u/lower-case-en value)]))
 
 (defn- table-query

--- a/src/metabase/native_query_analyzer.clj
+++ b/src/metabase/native_query_analyzer.clj
@@ -15,6 +15,7 @@
    [clojure.string :as str]
    [macaw.core :as macaw]
    [metabase.config :as config]
+   [metabase.driver.util :as driver.u]
    [metabase.native-query-analyzer.parameter-substitution :as nqa.sub]
    [metabase.native-query-analyzer.replacement :as nqa.replacement]
    [metabase.public-settings :as public-settings]
@@ -134,17 +135,41 @@
                                                     [:= :f.active true]
                                                     (into [:or] (map table-query tables))]}))))
 
+;; NOTE: In future we would want to replace [[considered-drivers]] and [[macaw-options]] with (a) driver method(s),
+;; but given that the interface with Macaw is still in a state of flux, and how simple the current configuration is,
+;; we defer extending the public interface and define the logic locally instead. Macaw itself is not battle tested
+;; outside this same narrow range of databases in any case.
+
+(def ^:private considered-drivers
+  "Since we are unable to ask basic questions of the driver hierarchy outside of that module, we need to repeat"
+  #{:mysql :sqlserver :h2 :sqlite :postgres :redshift})
+
 (defn- macaw-options
-  "Given blaha. The list of drivers that were considered when"
+  "Generate the options expected by Macaw based on the nature of the given driver."
   [driver]
-  ;; This is actually a gross simplification as for example MySQL is never case-sensitive for columns, but whether
-  ;; it is case-sensitive for tables depends on the file system and database configuration. Similarly, for SQL Server
-  ;; each level of the hierarchy can be configured for case sensitivity. For now, we make pragmatic simplifications
-  ;; based on the default configuration and hosting of these databases.
-  {:case-insensitive?     true
-   ;; For both MySQL and SQL Server, whether identifiers are case-sensitive depends on database configuration only,
-   ;; and quoting has no effect on this.
-   :quotes-preserve-case? (not (#{:mysql :sqlserver} driver))})
+  ;; If this isn't a driver we've considered, fallback to Macaw's conservative defaults.
+  (when (contains? considered-drivers driver)
+    ;; According to the SQL-92 specification, non-quoted identifiers should be case-insensitive, and the majority of
+    ;; engines are implemented this way.
+    ;;
+    ;; In practice there are exceptions, notably MySQL and SQL Server, where case sensitivity is a property of the
+    ;; underlying resource referenced by the identifier, and the case-sensitivity does not depend on whether the
+    ;; reference is quoted.
+    ;;
+    ;; For MySQL the case sensitivity of databases and tables depends on both the underlying
+    ;; file system, and a system variable used to initialize the database. For SQL Server it depends on the collation
+    ;; settings of the collection where the corresponding schema element is defined.
+    ;;
+    ;; For MySQL, columns and aliases can never be case-sensitive, and for SQL Server the default collation is case-
+    ;; insensitive too, so it makes sense to just treat all databases as case-insensitive as a whole.
+    ;;
+    ;; In future Macaw may support discriminating on the identifier type, in which case we could be more precise for
+    ;; these databases. Being 100% correct would require querying system variables and schema configuration however,
+    ;; which is likely a step too far in complexity.
+    {:case-insensitive?     true
+     ;; For both MySQL and SQL Server, whether identifiers are case-sensitive depends on database configuration only,
+     ;; and quoting has no effect on this, so we disable this option for consistency with `:case-insensitive?`.
+     :quotes-preserve-case? (not (#{:mysql :sqlserver} driver))}))
 
 (defn field-ids-for-sql
   "Returns a `{:direct #{...} :indirect #{...}}` map with field IDs that (may) be referenced in the given card's
@@ -158,9 +183,9 @@
              (:native query))
     (let [db-id        (:database query)
           sql-string   (:query (nqa.sub/replace-tags query))
-          ;; get the driver
-          ;; build options based on that
-          parsed-query (macaw/query->components (macaw/parsed-query sql-string))
+          driver       (driver.u/database->driver db-id)
+          macaw-opts   (macaw-options driver)
+          parsed-query (macaw/query->components (macaw/parsed-query sql-string) macaw-opts)
           direct-ids   (direct-field-ids-for-query parsed-query db-id)
           indirect-ids (set/difference
                         (indirect-field-ids-for-query parsed-query db-id)

--- a/src/metabase/native_query_analyzer.clj
+++ b/src/metabase/native_query_analyzer.clj
@@ -70,11 +70,14 @@
   (if-let [quote-stripper (quote-strippers (first value))]
     [:= field (quote-stripper value)]
     ;; Technically speaking this is not correct for all databases.
-    ;; For example Oracle treats non-quoted identifiers as uppercase, but still expects a case sensitive match.
-    ;; i.e. given a column called "MixedCaseThing" (i.e. it was defined using quotes)
-    ;;      and an unquoted reference like `SELECT MixedCaseThing FROM x`
-    ;;      the query is equivalent to `SELECT "MIXEDCASETHING" FROM x"
-    ;;      and will fail because "MixedCaseThing" != "MIXEDCASETHING"
+    ;;
+    ;; For example Oracle treats non-quoted identifiers as uppercase, but still expects a case-sensitive match.
+    ;; Similarly, Postgres treat all non-quoted identifiers as lowercase, and again expects an exact match.
+    ;; H2 on the other hand will choose whether to cast it to uppercase or lowercase based on a system variable... T_T
+    ;;
+    ;; MySQL on the other hand is truly case-insensitive, and as the lowest common denominator it's what we cater for.
+    ;; In general, it's a huge anti-pattern to have any identifiers that differ only by case, so this extra leniency is
+    ;; unlikely to ever cause issues in practice.
     [:= [:lower field] (u/lower-case-en value)]))
 
 (defn- table-query

--- a/src/metabase/native_query_analyzer.clj
+++ b/src/metabase/native_query_analyzer.clj
@@ -52,7 +52,7 @@
 ;; NOTE: be careful when adding square braces, as the rules for nesting them are different.
 (def ^:private quotes "\"`")
 
-(defn- quote-stripper
+(defn- quote->stripper
   "Construct a function which unquotes values which use the given character as their quote."
   [quote-char]
   (let [doubled (str quote-char quote-char)
@@ -62,7 +62,7 @@
 
 (def ^:private quote-strippers
   "Pre-constructed lambdas, to save some memory allocations."
-  (zipmap quotes (map quote-stripper quotes)))
+  (zipmap quotes (map quote->stripper quotes)))
 
 (defn- field-query
   "Exact match for quoted fields, case-insensitive match for non-quoted fields"

--- a/src/metabase/native_query_analyzer.clj
+++ b/src/metabase/native_query_analyzer.clj
@@ -69,6 +69,9 @@
   [field value]
   (if-let [quote-stripper (quote-strippers (first value))]
     [:= field (quote-stripper value)]
+    ;; Technically speaking this is not correct for all databases.
+    ;; For some databases an unquoted reference is expected to mean an explicitly uppercase or lowercase name.
+    ;; i.e. if you created a column called "MixedCaseThing" then `SELECT MixedCaseThing` would *NOT* match it.
     [:= [:lower field] (u/lower-case-en value)]))
 
 (defn- table-query

--- a/src/metabase/native_query_analyzer.clj
+++ b/src/metabase/native_query_analyzer.clj
@@ -52,7 +52,7 @@
 ;; NOTE: be careful when adding square braces, as the rules for nesting them are different.
 (def ^:private quotes "\"`")
 
-(defn- quote->stripper
+(defn- quote-stripper
   "Construct a function which unquotes values which use the given character as their quote."
   [quote-char]
   (let [doubled (str quote-char quote-char)
@@ -60,15 +60,15 @@
     #(-> (subs % 1 (dec (count %)))
          (str/replace doubled single))))
 
-(def ^:private quote-strippers
+(def ^:private quote->stripper
   "Pre-constructed lambdas, to save some memory allocations."
-  (zipmap quotes (map quote->stripper quotes)))
+  (zipmap quotes (map quote-stripper quotes)))
 
 (defn- field-query
   "Exact match for quoted fields, case-insensitive match for non-quoted fields"
   [field value]
-  (if-let [quote-stripper (quote-strippers (first value))]
-    [:= field (quote-stripper value)]
+  (if-let [f (quote->stripper (first value))]
+    [:= field (f value)]
     ;; Technically speaking this is not correct for all databases.
     ;;
     ;; For example Oracle treats non-quoted identifiers as uppercase, but still expects a case-sensitive match.

--- a/src/metabase/native_query_analyzer.clj
+++ b/src/metabase/native_query_analyzer.clj
@@ -75,7 +75,7 @@
     ;; Similarly, Postgres treat all non-quoted identifiers as lowercase, and again expects an exact match.
     ;; H2 on the other hand will choose whether to cast it to uppercase or lowercase based on a system variable... T_T
     ;;
-    ;; MySQL on the other hand is truly case-insensitive, and as the lowest common denominator it's what we cater for.
+    ;; MySQL, by contrast, is truly case-insensitive, and as the lowest common denominator it's what we cater for.
     ;; In general, it's a huge anti-pattern to have any identifiers that differ only by case, so this extra leniency is
     ;; unlikely to ever cause issues in practice.
     [:= [:lower field] (u/lower-case-en value)]))

--- a/test/metabase/native_query_analyzer_test.clj
+++ b/test/metabase/native_query_analyzer_test.clj
@@ -49,7 +49,9 @@
                (q "select \"ID\" from venues"))))
       (testing "you can mix quoted and unquoted names"
         (is (= {:direct #{(mt/id :venues :id) (mt/id :venues :name)} :indirect nil}
-               (q "select v.\"ID\", v.name from venues"))))
+               (q "select v.\"ID\", v.name from venues")))
+        (is (= {:direct #{(mt/id :venues :id) (mt/id :venues :name)} :indirect nil}
+               (q "select v.`ID`, v.name from venues"))))
       (testing "It will find all relevant columns if query is not specific"
         (is (= {:direct #{(mt/id :venues :id) (mt/id :checkins :id)} :indirect nil}
                (q "select id from venues join checkins"))))


### PR DESCRIPTION
Closes #43096

SQL standards are one thing, and production SQL engines are another. We've recently added some options to Macaw to handle some of these differences, and this PR is concerned with populating those options based on the database being queried.