### PR TITLE
Fix LDAP admin settings form not allowing modification if a custom port is set

### DIFF
--- a/frontend/src/metabase/admin/settings/components/SettingsLdapForm.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsLdapForm.tsx
@@ -244,7 +244,7 @@ const getAttributeValues = (
     // ldap port is number | null, we need to edit as a string if it is a number
     "ldap-port":
       typeof attributeValues["ldap-port"] === "number"
-        ? "" + attributeValues["ldap-port"]
+        ? String(attributeValues["ldap-port"])
         : attributeValues["ldap-port"],
   };
 };

--- a/frontend/src/metabase/admin/settings/components/SettingsLdapForm.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsLdapForm.tsx
@@ -226,11 +226,11 @@ export const SettingsLdapFormView = ({
 
 const getAttributeValues = (
   ldapAttributes: SettingKey[],
-  settings: Record<string, LdapFormSettingElement>,
+  settings: Record<SettingKey, LdapFormSettingElement>,
   values: SettingValues,
   defaultableAttrs: Set<string>,
 ): LdapFormValues => {
-  return Object.fromEntries(
+  const attributeValues = Object.fromEntries(
     ldapAttributes.map(key => [
       key,
       defaultableAttrs.has(key)
@@ -238,6 +238,15 @@ const getAttributeValues = (
         : values[key],
     ]),
   );
+
+  return {
+    ...attributeValues,
+    // ldap port is number | null, we need to edit as a string if it is a number
+    "ldap-port":
+      typeof attributeValues["ldap-port"] === "number"
+        ? "" + attributeValues["ldap-port"]
+        : attributeValues["ldap-port"],
+  };
 };
 
 const mapDispatchToProps = {

--- a/frontend/src/metabase/admin/settings/components/SettingsLdapForm.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsLdapForm.tsx
@@ -226,7 +226,7 @@ export const SettingsLdapFormView = ({
 
 const getAttributeValues = (
   ldapAttributes: SettingKey[],
-  settings: Record<SettingKey, LdapFormSettingElement>,
+  settings: Record<string, LdapFormSettingElement>,
   values: SettingValues,
   defaultableAttrs: Set<string>,
 ): LdapFormValues => {


### PR DESCRIPTION
Closes #41494

### Description

Our TS types weren't matching reality if the user didn't change the port number and tries to modify + save the LDAP form after having already configured it. This was due to the server providing a number and the client wanting a string, which resulted in our `.trim` call during submission to fail. If the user re-enters the exact same port number that is already configured, the form would work as expected.

### How to verify

- setup a ldap locally via the admin settings
- refresh the page
- change something like the host from localhost to 0.0.0.0
- you should have seen an error before, but not with these changes

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
I don't have a good way to test this given our e2e LDAP host is configured on the default port of 389, which ends up nulling out this value / avoiding the issue we're noticing (notice related issue has a different port number configured). I can spend more time there, but I think it would be better to spend the effort on converting some of our admin settings to typescript which would have surfaced this error via the type system.
