### PR TITLE
Skip fingerprinting or scanning field values for fields with base_type=type/*

### DIFF
--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -235,6 +235,7 @@
         (not (isa? base-type :type/field-values-unsupported))
         (not (contains? #{:retired :sensitive :hidden :details-only} (keyword visibility-type)))
         (not (isa? (keyword base-type) :type/Temporal))
+        (not (= (keyword base-type) :type/*))
         (#{:list :auto-list} (keyword has-field-values)))))))
 
 (defn take-by-length

--- a/src/metabase/sync/analyze/fingerprint.clj
+++ b/src/metabase/sync/analyze/fingerprint.clj
@@ -161,6 +161,7 @@
     [:not (mdb.query/isa :semantic_type :type/PK)]
     [:= :semantic_type nil]]
    [:not-in :visibility_type ["retired" "sensitive"]]
+   [:not= :base_type (u/qualified-name :type/*)]
    [:not (mdb.query/isa :base_type :type/Structured)]])
 
 (def ^:dynamic *refingerprint?*

--- a/src/metabase/sync/analyze/fingerprint.clj
+++ b/src/metabase/sync/analyze/fingerprint.clj
@@ -61,9 +61,10 @@
 (mu/defn ^:private fingerprint-table!
   [table  :- i/TableInstance
    fields :- [:maybe [:sequential i/FieldInstance]]]
-  (let [rff (fn [_metadata]
+  (let [known-type-fields (filter #(not= (:base_type %) :type/*) fields)
+        rff (fn [_metadata]
               (redux/post-complete
-               (analyze/fingerprint-fields fields)
+               (analyze/fingerprint-fields known-type-fields)
                (fn [fingerprints]
                  (reduce (fn [count-info [field fingerprint]]
                            (cond
@@ -78,10 +79,10 @@
                              (save-fingerprint! field fingerprint)
                              (update count-info :updated-fingerprints inc))))
                          (empty-stats-map (count fingerprints))
-                         (map vector fields fingerprints)))))
+                         (map vector known-type-fields fingerprints)))))
         driver (driver.u/database->driver (table/database table))
         opts {:truncation-size *truncation-size*}]
-    (driver/table-rows-sample driver table fields rff opts)))
+    (driver/table-rows-sample driver table known-type-fields rff opts)))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                    WHICH FIELDS NEED UPDATED FINGERPRINTS?                                     |

--- a/src/metabase/sync/analyze/fingerprint.clj
+++ b/src/metabase/sync/analyze/fingerprint.clj
@@ -61,10 +61,9 @@
 (mu/defn ^:private fingerprint-table!
   [table  :- i/TableInstance
    fields :- [:maybe [:sequential i/FieldInstance]]]
-  (let [known-type-fields (filter #(not= (:base_type %) :type/*) fields)
-        rff (fn [_metadata]
+  (let [rff (fn [_metadata]
               (redux/post-complete
-               (analyze/fingerprint-fields known-type-fields)
+               (analyze/fingerprint-fields fields)
                (fn [fingerprints]
                  (reduce (fn [count-info [field fingerprint]]
                            (cond
@@ -79,10 +78,10 @@
                              (save-fingerprint! field fingerprint)
                              (update count-info :updated-fingerprints inc))))
                          (empty-stats-map (count fingerprints))
-                         (map vector known-type-fields fingerprints)))))
+                         (map vector fields fingerprints)))))
         driver (driver.u/database->driver (table/database table))
         opts {:truncation-size *truncation-size*}]
-    (driver/table-rows-sample driver table known-type-fields rff opts)))
+    (driver/table-rows-sample driver table fields rff opts)))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                    WHICH FIELDS NEED UPDATED FINGERPRINTS?                                     |

--- a/test/metabase/models/field_values_test.clj
+++ b/test/metabase/models/field_values_test.clj
@@ -90,6 +90,12 @@
                                     {:base_type        :type/Time
                                      :has_field_values :list
                                      :visibility_type  :normal}
+                                    false}
+
+                                   "type/* fields should be excluded"
+                                   {{:has_field_values :list
+                                     :visibility_type  :normal
+                                     :base_type        :type/*}
                                     false}}
           [input expected] input->expected]
     (testing (str group "\n")

--- a/test/metabase/sync/analyze/fingerprint_test.clj
+++ b/test/metabase/sync/analyze/fingerprint_test.clj
@@ -36,6 +36,7 @@
               [:not (mdb.query/isa :semantic_type :type/PK)]
               [:= :semantic_type nil]]
              [:not-in :visibility_type ["retired" "sensitive"]]
+             [:not= :base_type "type/*"]
              [:not (mdb.query/isa :base_type :type/Structured)]
              [:or
               [:and
@@ -52,6 +53,7 @@
             [:not (mdb.query/isa :semantic_type :type/PK)]
             [:= :semantic_type nil]]
            [:not-in :visibility_type ["retired" "sensitive"]]
+           [:not= :base_type "type/*"]
            [:not (mdb.query/isa :base_type :type/Structured)]
            [:or
             [:and
@@ -74,6 +76,7 @@
               [:not (mdb.query/isa :semantic_type :type/PK)]
               [:= :semantic_type nil]]
              [:not-in :visibility_type ["retired" "sensitive"]]
+             [:not= :base_type "type/*"]
              [:not (mdb.query/isa :base_type :type/Structured)]
              [:or
               [:and
@@ -97,6 +100,7 @@
               [:not (mdb.query/isa :semantic_type :type/PK)]
               [:= :semantic_type nil]]
              [:not-in :visibility_type ["retired" "sensitive"]]
+             [:not= :base_type "type/*"]
              [:not (mdb.query/isa :base_type :type/Structured)]
              [:or
               [:and
@@ -125,6 +129,7 @@
                      [:not (mdb.query/isa :semantic_type :type/PK)]
                      [:= :semantic_type nil]]
                     [:not-in :visibility_type ["retired" "sensitive"]]
+                    [:not= :base_type "type/*"]
                     [:not (mdb.query/isa :base_type :type/Structured)]]}
            (binding [sync.fingerprint/*refingerprint?* true]
              (#'sync.fingerprint/honeysql-for-fields-that-need-fingerprint-updating))))))


### PR DESCRIPTION
Fixes the escalation https://github.com/metabase/metabase/issues/43461

Fingerprinting and scanning field values for fields with `base_type=type/*` are costly in time and resources and have little value.

A field will typically have `base_type=type/*` if either: (a) the database type has not been mapped to a base type by the driver or (b) the database type is such that its value should not be inspected (e.g. [the geometry type in postgres](https://github.com/metabase/metabase/blob/ba6c96493a108ad2fc49f72f1a7bfde91515523f/src/metabase/driver/postgres.clj#L681)).

We already skip fingerprinting and scanning field values for some fields, such as JSON fields. So excluding fields with `base_type=type/*` is an extension of this behaviour.

One downside of this PR is that we will omit fingerprinting and scanning field values for fields where base_type=type/* but actually make sense to fingerprint or scan field values. But that can and should be remedied by correctly classifying the column with a more granular `base_type`. Driver authors can use a type deriving from `:type/TextLike` instead of `:type/*` if a database type should still be fingerprinted and scanned, and displayed as text but should not be treated exactly as text. I've reclassified the MySQL ENUM type to be `type/TextLike` in this PR: https://github.com/metabase/metabase/pull/43533