### PR TITLE
Athena jdbc driver upgrade to 3.2

### DIFF
--- a/modules/drivers/athena/deps.edn
+++ b/modules/drivers/athena/deps.edn
@@ -5,6 +5,5 @@
  {"athena" {:url "https://s3.amazonaws.com/maven-athena"}}
 
  :deps
- #_{com.amazonaws/aws-java-sdk-core {:mvn/version "1.12.683"}
-  com.metabase/athena-jdbc        {:mvn/version "2.0.35"}}
+ ;; TODO: Following driver contains sdk. Verify that image size with this driver in place.
  {com.metabase/athena-jdbc {:mvn/version "3.2.0"}}}

--- a/modules/drivers/athena/deps.edn
+++ b/modules/drivers/athena/deps.edn
@@ -7,7 +7,4 @@
  :deps
  #_{com.amazonaws/aws-java-sdk-core {:mvn/version "1.12.683"}
   com.metabase/athena-jdbc        {:mvn/version "2.0.35"}}
- {;; At the current stage I use locally downloaded uber jar from:
-  ;; https://downloads.athena.us-east-1.amazonaws.com/drivers/JDBC/3.2.0/athena-jdbc-3.2.0-with-dependencies.jar
-  ;; Link can be found on https://docs.aws.amazon.com/athena/latest/ug/jdbc-v3-driver.html#jdbc-v3-driver-download
-  com.metabase/athena-jdbc {:local/root "<ADD DOWNLOAD ROOT>/athena-jdbc-3.2.0-with-dependencies.jar"}}}
+ {com.metabase/athena-jdbc {:mvn/version "3.2.0"}}}

--- a/modules/drivers/athena/deps.edn
+++ b/modules/drivers/athena/deps.edn
@@ -5,5 +5,9 @@
  {"athena" {:url "https://s3.amazonaws.com/maven-athena"}}
 
  :deps
- {com.amazonaws/aws-java-sdk-core {:mvn/version "1.12.683"}
-  com.metabase/athena-jdbc {:mvn/version "2.0.35"}}}
+ #_{com.amazonaws/aws-java-sdk-core {:mvn/version "1.12.683"}
+  com.metabase/athena-jdbc        {:mvn/version "2.0.35"}}
+ {;; At the current stage I use locally downloaded uber jar from:
+  ;; https://downloads.athena.us-east-1.amazonaws.com/drivers/JDBC/3.2.0/athena-jdbc-3.2.0-with-dependencies.jar
+  ;; Link can be found on https://docs.aws.amazon.com/athena/latest/ug/jdbc-v3-driver.html#jdbc-v3-driver-download
+  com.metabase/athena-jdbc {:local/root "<ADD DOWNLOAD ROOT>/athena-jdbc-3.2.0-with-dependencies.jar"}}}

--- a/modules/drivers/athena/resources/metabase-plugin.yaml
+++ b/modules/drivers/athena/resources/metabase-plugin.yaml
@@ -50,4 +50,6 @@ init:
   - step: load-namespace
     namespace: metabase.driver.athena
   - step: register-jdbc-driver
-    class: com.simba.athena.jdbc.Driver
+    #class: com.simba.athena.jdbc.Driver
+    # https://docs.aws.amazon.com/athena/latest/ug/jdbc-v3-driver-getting-started.html#jdbc-v3-driver-upgrading-from-the-athena-jdbc-v2-driver-to-v3 -- Driver class
+    class: com.amazon.athena.jdbc.AthenaDriver

--- a/modules/drivers/athena/resources/metabase-plugin.yaml
+++ b/modules/drivers/athena/resources/metabase-plugin.yaml
@@ -50,6 +50,5 @@ init:
   - step: load-namespace
     namespace: metabase.driver.athena
   - step: register-jdbc-driver
-    #class: com.simba.athena.jdbc.Driver
     # https://docs.aws.amazon.com/athena/latest/ug/jdbc-v3-driver-getting-started.html#jdbc-v3-driver-upgrading-from-the-athena-jdbc-v2-driver-to-v3 -- Driver class
     class: com.amazon.athena.jdbc.AthenaDriver

--- a/modules/drivers/athena/src/metabase/driver/athena.clj
+++ b/modules/drivers/athena/src/metabase/driver/athena.clj
@@ -172,6 +172,14 @@
      (.getObject ^java.sql.ResultSet rs ^int i)
      (qp.timezone/results-timezone-id))))
 
+(defmethod sql-jdbc.execute/read-column-thunk [:athena java.sql.Types/TIMESTAMP]
+  [_driver rs _rs-meta i]
+  (fn []
+    (t/local-date-time
+     (.getObject ^java.sql.ResultSet rs ^int i java.sql.Timestamp)
+     #_(t/zone-id "UTC")
+     #_(qp.timezone/results-timezone-id))))
+
 ;; TODO: Handle time values as well ie. `read-time-and-timestamp-with-time-zone-columns-test`
 
 ;;; ------------------------------------------------- date functions -------------------------------------------------

--- a/modules/drivers/athena/src/metabase/driver/athena.clj
+++ b/modules/drivers/athena/src/metabase/driver/athena.clj
@@ -169,8 +169,9 @@
   [_driver rs _rs-meta i]
   (fn []
     (t/offset-date-time
-     (.getObject ^java.sql.ResultSet rs ^int i)
-     (qp.timezone/results-timezone-id))))
+       (.getObject ^java.sql.ResultSet rs ^int i String)
+       (qp.timezone/results-timezone-id))
+    #_(.getObject ^java.sql.ResultSet rs ^int i String)))
 
 (defmethod sql-jdbc.execute/read-column-thunk [:athena java.sql.Types/TIMESTAMP]
   [_driver rs _rs-meta i]
@@ -179,6 +180,28 @@
      (.getObject ^java.sql.ResultSet rs ^int i java.sql.Timestamp)
      #_(t/zone-id "UTC")
      #_(qp.timezone/results-timezone-id))))
+
+(defmethod sql-jdbc.execute/read-column-thunk [:athena java.sql.Types/DATE]
+  [_driver rs _rs-meta i]
+  (fn []
+    (t/local-date-time
+     (.getObject ^java.sql.ResultSet rs ^int i java.sql.Timestamp)
+     #_(t/zone-id "UTC")
+     #_(qp.timezone/results-timezone-id))))
+
+;; [[date-time-zone-functions-test/datetime-math-tests-mongodb]]
+(defmethod sql-jdbc.execute/read-column-thunk [:athena java.sql.Types/DATE]
+  [_driver rs _rs-meta i]
+  (fn []
+    (t/local-date
+     (.getObject ^java.sql.ResultSet rs ^int i java.sql.Date))))
+
+;; [[metabase.query-processor-test.date-time-zone-functions-test/datetime-diff-mixed-types-test]]
+(defmethod sql-jdbc.execute/read-column-thunk [:athena java.sql.Types/TIME]
+  [_driver rs _rs-meta i]
+  (fn []
+    (t/local-time
+     (.getObject ^java.sql.ResultSet rs ^int i java.sql.Time))))
 
 ;; TODO: Handle time values as well ie. `read-time-and-timestamp-with-time-zone-columns-test`
 

--- a/modules/drivers/athena/src/metabase/driver/athena.clj
+++ b/modules/drivers/athena/src/metabase/driver/athena.clj
@@ -372,18 +372,27 @@
 (defn- table-has-nested-fields? [columns]
   (some #(= "struct" (:type_name %)) columns))
 
+(defn- get-columns
+  [^DatabaseMetaData metadata catalog schema table-name]
+  (try
+    (with-open [rs (.getColumns metadata catalog schema table-name nil)]
+      (jdbc/metadata-result rs))
+    (catch Throwable e
+      (log/warnf "`.getColumns` failed for catalog `%s`, schema `%s`, table name `%s` with message: `%s`"
+                 catalog schema table-name (ex-message e))
+      #{})))
+
 (defn describe-table-fields
   "Returns a set of column metadata for `schema` and `table-name` using `metadata`. "
   [^DatabaseMetaData metadata database driver {^String schema :schema, ^String table-name :name} catalog]
   (try
-    (with-open [rs (.getColumns metadata catalog schema table-name nil)]
-      (let [columns (jdbc/metadata-result rs)]
-        (if (or (table-has-nested-fields? columns)
-                ; If `.getColumns` returns an empty result, try to use DESCRIBE, which is slower
-                ; but doesn't suffer from the bug in the JDBC driver as metabase#43980
-                (empty? columns))
-          (describe-table-fields-with-nested-fields database schema table-name)
-          (describe-table-fields-without-nested-fields driver columns))))
+    (let [columns (get-columns metadata catalog schema table-name)]
+      (if (or (table-has-nested-fields? columns)
+               ; If `.getColumns` returns an empty result, try to use DESCRIBE, which is slower
+               ; but doesn't suffer from the bug in the JDBC driver as metabase#43980
+              (empty? columns))
+        (describe-table-fields-with-nested-fields database schema table-name)
+        (describe-table-fields-without-nested-fields driver columns)))
     (catch Throwable e
       (log/errorf e "Error retreiving fields for DB %s.%s" schema table-name)
       (throw e))))

--- a/modules/drivers/athena/test/metabase/driver/athena_test.clj
+++ b/modules/drivers/athena/test/metabase/driver/athena_test.clj
@@ -4,6 +4,7 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [honey.sql :as sql]
+   [java-time.api :as t]
    [metabase.driver :as driver]
    [metabase.driver.athena :as athena]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
@@ -22,9 +23,11 @@
 
 (set! *warn-on-reflection* true)
 
+(set! *warn-on-reflection* true)
+
 (def ^:private nested-schema
-  [{:col_name "key", :data_type "int"}
-   {:col_name "data", :data_type "struct<name:string>"}])
+  [{:_col0 "key    \tint   \t     "}
+   {:_col0 "data    \tstruct<name:string>   \t     "}])
 
 (def ^:private flat-schema-columns
   [{:column_name "id", :type_name  "string"}
@@ -81,8 +84,6 @@
 (deftest ^:parallel read-time-and-timestamp-with-time-zone-columns-test
   (mt/test-driver :athena
     (testing "We should return TIME and TIMESTAMP WITH TIME ZONE columns correctly"
-      ;; these both come back as `java.sql.type/VARCHAR` for some wacko reason from the JDBC driver, so let's make sure
-      ;; we have code in place to work around that.
       (let [timestamp-tz [:raw "timestamp '2022-11-16 04:21:00 US/Pacific'"]
             time         [:raw "time '5:03:00'"]
             [sql & args] (sql/format {:select [[timestamp-tz :timestamp-tz]
@@ -91,27 +92,24 @@
                              (assoc-in [:middleware :format-rows?] false))]
         (mt/with-native-query-testing-context query
           (let [[ts t] (mt/first-row (qp/process-query query))]
-            (is (#{#t "2022-11-16T04:21:00.000-08:00[America/Los_Angeles]"
-                   #t "2022-11-16T04:21:00.000-08:00[US/Pacific]"}
-                 ts))
-            (is (= #t "05:03"
-                   t))))))))
+            (is (= (t/offset-date-time 2022 11 16 12 21 0 0) ts))
+            (is (= #t "05:03" t))))))))
 
-;; Following no longer holds for the 3.2 driver. timestamp with tz is returned as Timestamp hence
-;; we are short of timezone info
-#_(deftest ^:parallel set-time-and-timestamp-with-time-zone-test
+(deftest ^:parallel set-time-and-timestamp-with-time-zone-test
   (mt/test-driver :athena
     (testing "We should be able to handle TIME and TIMESTAMP WITH TIME ZONE parameters correctly"
       (let [timestamp-tz #t "2022-11-16T04:21:00.000-08:00[America/Los_Angeles]"
             time         #t "05:03"
             [sql & args] (sql/format {:select [[timestamp-tz :timestamp-tz]
-                                               #_[:cast [timestamp-tz :timestamp-tz] :string]
                                                [time :time]]})
             query        (-> (mt/native-query {:query sql, :params args})
                              (assoc-in [:middleware :format-rows?] false))]
         (mt/with-native-query-testing-context query
-          (is (= [#t "2022-11-16T04:21:00.000-08:00[America/Los_Angeles]" #t "05:03"]
-                 (mt/first-row @(def qqq (qp/process-query query))))))))))
+          ;; TIMESTAMP WITH TIMEZONE is read (read-column-thunk...) as OffsetDateTime in results timezone id.
+          ;; Timezone on testing instances is UTC.
+          (is (= [(t/offset-date-time 2022 11 16 12 21 0 0)
+                  #t "05:03"]
+                 (mt/first-row (qp/process-query query)))))))))
 
 (deftest ^:parallel add-interval-to-timestamp-with-time-zone-test
   (mt/test-driver :athena

--- a/modules/drivers/athena/test/metabase/driver/athena_test.clj
+++ b/modules/drivers/athena/test/metabase/driver/athena_test.clj
@@ -136,21 +136,21 @@
       (testing "Specifying access-key will not use credential chain"
         (is (not (contains?
                    (sql-jdbc.conn/connection-details->spec :athena {:region "us-west-2" :access_key "abc123"})
-                   :AwsCredentialsProviderClass))))
+                   :CredentialsProvider))))
       (testing "Not specifying access-key will use credential chain"
         (is (contains?
               (sql-jdbc.conn/connection-details->spec :athena {:region "us-west-2"})
-              :AwsCredentialsProviderClass)))))
+              :CredentialsProvider)))))
   (testing "When hosted"
     (with-redefs [premium-features/is-hosted? (constantly true)]
       (testing "Specifying access-key will not use credential chain"
         (is (not (contains?
                    (sql-jdbc.conn/connection-details->spec :athena {:region "us-west-2" :access_key "abc123"})
-                   :AwsCredentialsProviderClass))))
+                   :CredentialsProvider))))
       (testing "Not specifying access-key will still not use credential chain"
         (is (not (contains?
                    (sql-jdbc.conn/connection-details->spec :athena {:region "us-west-2"})
-                   :AwsCredentialsProviderClass)))))))
+                   :CredentialsProvider)))))))
 
 (deftest ^:parallel page-test
   (testing ":page clause places OFFSET *before* LIMIT"

--- a/modules/drivers/athena/test/metabase/driver/athena_test.clj
+++ b/modules/drivers/athena/test/metabase/driver/athena_test.clj
@@ -1,6 +1,5 @@
 (ns metabase.driver.athena-test
   (:require
-   [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [honey.sql :as sql]
@@ -252,7 +251,6 @@
                              nil
                              (fn [^Connection conn]
                                (let [metadata (.getMetaData conn)]
-                                 (with-open [rs (.getColumns metadata catalog (:schema table) (:name table) nil)]
-                                   (jdbc/metadata-result rs))))))))
+                                 (#'athena/get-columns metadata catalog (:schema table) (:name table))))))))
               (testing "`describe-table` returns the fields anyway"
                 (is (not-empty (:fields (driver/describe-table :athena db table)))))))))))

--- a/modules/drivers/athena/test/metabase/driver/athena_test.clj
+++ b/modules/drivers/athena/test/metabase/driver/athena_test.clj
@@ -97,18 +97,21 @@
             (is (= #t "05:03"
                    t))))))))
 
-(deftest ^:parallel set-time-and-timestamp-with-time-zone-test
+;; Following no longer holds for the 3.2 driver. timestamp with tz is returned as Timestamp hence
+;; we are short of timezone info
+#_(deftest ^:parallel set-time-and-timestamp-with-time-zone-test
   (mt/test-driver :athena
     (testing "We should be able to handle TIME and TIMESTAMP WITH TIME ZONE parameters correctly"
       (let [timestamp-tz #t "2022-11-16T04:21:00.000-08:00[America/Los_Angeles]"
             time         #t "05:03"
             [sql & args] (sql/format {:select [[timestamp-tz :timestamp-tz]
+                                               #_[:cast [timestamp-tz :timestamp-tz] :string]
                                                [time :time]]})
             query        (-> (mt/native-query {:query sql, :params args})
                              (assoc-in [:middleware :format-rows?] false))]
         (mt/with-native-query-testing-context query
           (is (= [#t "2022-11-16T04:21:00.000-08:00[America/Los_Angeles]" #t "05:03"]
-                 (mt/first-row (qp/process-query query)))))))))
+                 (mt/first-row @(def qqq (qp/process-query query))))))))))
 
 (deftest ^:parallel add-interval-to-timestamp-with-time-zone-test
   (mt/test-driver :athena

--- a/modules/drivers/athena/test/metabase/driver/athena_test.clj
+++ b/modules/drivers/athena/test/metabase/driver/athena_test.clj
@@ -25,6 +25,8 @@
 
 (set! *warn-on-reflection* true)
 
+(set! *warn-on-reflection* true)
+
 (def ^:private nested-schema
   [{:_col0 "key    \tint   \t     "}
    {:_col0 "data    \tstruct<name:string>   \t     "}])

--- a/modules/drivers/athena/test/metabase/test/data/athena.clj
+++ b/modules/drivers/athena/test/metabase/test/data/athena.clj
@@ -217,7 +217,11 @@
    (server-connection-spec)
    nil
    (fn [^java.sql.Connection conn]
-     (let [dbs (into #{} (map :database_name) (jdbc/query {:connection conn} ["SHOW DATABASES;"]))]
+     ;; 3.2 driver returns
+     ;; ({:_col0 "airports"}
+     ;; {:_col0 "avian_singles"}...)
+     ;; So no :database_name anymore!
+     (let [dbs (into #{} (map :_col0 #_:database_name) (jdbc/query {:connection conn} ["SHOW DATABASES;"]))]
        (log/infof "The following Athena databases have already been created: %s" (pr-str (sort dbs)))
        dbs))))
 

--- a/modules/drivers/athena/test/metabase/test/data/athena.clj
+++ b/modules/drivers/athena/test/metabase/test/data/athena.clj
@@ -217,11 +217,11 @@
    (server-connection-spec)
    nil
    (fn [^java.sql.Connection conn]
-     ;; 3.2 driver returns
+     ;; JDBC driver of version 3.2 result in following shape:
      ;; ({:_col0 "airports"}
-     ;; {:_col0 "avian_singles"}...)
+     ;;  {:_col0 "avian_singles"}...)
      ;; So no :database_name anymore!
-     (let [dbs (into #{} (map :_col0 #_:database_name) (jdbc/query {:connection conn} ["SHOW DATABASES;"]))]
+     (let [dbs (into #{} (map :_col0) (jdbc/query {:connection conn} ["SHOW DATABASES;"]))]
        (log/infof "The following Athena databases have already been created: %s" (pr-str (sort dbs)))
        dbs))))
 

--- a/test/metabase/driver/sql_jdbc/connection_test.clj
+++ b/test/metabase/driver/sql_jdbc/connection_test.clj
@@ -115,6 +115,9 @@
               :redshift
               (assoc details :additional-options "defaultRowFetchSize=1000")
 
+              :athena
+              (assoc details :additional-options "some=value")
+
               (cond-> details
                 ;; swap localhost and 127.0.0.1
                 (and (string? (:host details))

--- a/test/metabase/driver/sql_jdbc/connection_test.clj
+++ b/test/metabase/driver/sql_jdbc/connection_test.clj
@@ -126,7 +126,7 @@
                 (update :host str/replace "127.0.0.1" "localhost")
 
                 :else
-                (assoc :new-config "something"))))))
+                (assoc :additional-options "some=value"))))))
 
 (deftest connection-pool-invalidated-on-details-change
   (mt/test-drivers (sql-jdbc.tu/sql-jdbc-drivers)

--- a/test/metabase/driver/sql_jdbc/connection_test.clj
+++ b/test/metabase/driver/sql_jdbc/connection_test.clj
@@ -129,7 +129,7 @@
                 (update :host str/replace "127.0.0.1" "localhost")
 
                 :else
-                (assoc :additional-options "some=value"))))))
+                (assoc :new-config "something"))))))
 
 (deftest connection-pool-invalidated-on-details-change
   (mt/test-drivers (sql-jdbc.tu/sql-jdbc-drivers)

--- a/test/metabase/driver/sql_jdbc/sync/describe_database_test.clj
+++ b/test/metabase/driver/sql_jdbc/sync/describe_database_test.clj
@@ -206,7 +206,10 @@
                    (mt/db)
                    nil
                    (fn [^java.sql.Connection conn]
-                     (.setAutoCommit conn auto-commit)
+                     ;; Athena supports only autoCommit connections.
+                     (try
+                       (.setAutoCommit conn auto-commit)
+                       (catch Throwable _))
                      (is (false? (sql-jdbc.sync.interface/have-select-privilege?
                                   driver/*driver* conn schema (str table-name "_should_not_exist"))))
                      (is (true? (sql-jdbc.sync.interface/have-select-privilege?


### PR DESCRIPTION
Closes #35965

This PR upgrades Athena jdbc driver to 3.2. Changes:
- TIMESTAMP WITH TIMEZONE is returned as Timestamp instead of VARCHAR, 
- different shape of DESCRIBE results,
- differences in getTables results,
- differences in connection properties.