### PR TITLE
[Dashcard] Calculate href lazily

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartCaption.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartCaption.tsx
@@ -17,7 +17,7 @@ interface ChartCaptionProps {
   icon?: IconProps;
   actionButtons?: ReactNode;
   width?: number;
-  href?: string;
+  getHref?: () => string;
   onChangeCardAndRun: OnChangeCardAndRun;
 }
 
@@ -27,7 +27,7 @@ const ChartCaption = ({
   icon,
   actionButtons,
   onChangeCardAndRun,
-  href,
+  getHref,
   width,
 }: ChartCaptionProps) => {
   const title = settings["card.title"] ?? series[0].card.name;
@@ -47,7 +47,7 @@ const ChartCaption = ({
     <ChartCaptionRoot
       title={title}
       description={description}
-      href={href}
+      getHref={getHref}
       icon={icon}
       actionButtons={actionButtons}
       onSelectTitle={canSelectTitle ? handleSelectTitle : undefined}

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
@@ -489,8 +489,6 @@ class Visualization extends PureComponent {
         (loading || error || noResults || isHeaderEnabled)) ||
       (replacementContent && (dashcard.size_y !== 1 || isMobile) && !isAction);
 
-    const href = this.getHref();
-
     return (
       <ErrorBoundary onError={this.onErrorBoundaryError}>
         <VisualizationRoot
@@ -506,7 +504,7 @@ class Visualization extends PureComponent {
                 icon={headerIcon}
                 actionButtons={extra}
                 width={width}
-                href={href}
+                getHref={this.getHref}
                 onChangeCardAndRun={
                   this.props.onChangeCardAndRun && !replacementContent
                     ? this.handleOnChangeCardAndRun
@@ -559,7 +557,7 @@ class Visualization extends PureComponent {
                 onRender={this.onRender}
                 onActionDismissal={this.hideActions}
                 gridSize={gridSize}
-                href={href}
+                getHref={this.getHref}
                 onChangeCardAndRun={
                   this.props.onChangeCardAndRun
                     ? this.handleOnChangeCardAndRun

--- a/frontend/src/metabase/visualizations/components/legend/LegendCaption.jsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendCaption.jsx
@@ -21,7 +21,7 @@ const propTypes = {
   className: PropTypes.string,
   title: PropTypes.string,
   description: PropTypes.string,
-  href: PropTypes.string,
+  getHref: PropTypes.func,
   icon: PropTypes.object,
   actionButtons: PropTypes.node,
   onSelectTitle: PropTypes.func,
@@ -37,7 +37,7 @@ const LegendCaption = ({
   className,
   title,
   description,
-  href,
+  getHref,
   icon,
   actionButtons,
   onSelectTitle,
@@ -52,7 +52,7 @@ const LegendCaption = ({
           DashboardS.fullscreenNightText,
           EmbedFrameS.fullscreenNightText,
         )}
-        href={href}
+        getHref={getHref}
         onClick={onSelectTitle}
       >
         <Ellipsified data-testid="legend-caption-title">{title}</Ellipsified>

--- a/frontend/src/metabase/visualizations/components/legend/LegendLabel.tsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendLabel.tsx
@@ -8,6 +8,7 @@ import {
 } from "react";
 import type { LinkProps } from "react-router";
 import { Link } from "react-router";
+import { useEffectOnce } from "react-use";
 
 import S from "./LegendLabel.module.css";
 
@@ -33,15 +34,15 @@ export const LegendLabel = ({
     },
     [onClick],
   );
-  const [href, setHref] = useState<LinkProps["to"]>("");
+  const [href, setHref] = useState<LinkProps["to"]>();
 
-  const handleMouseEnter = () => {
-    if (!href && getHref) {
+  useEffectOnce(() => {
+    if (getHref) {
       setHref(getHref());
     }
-  };
+  });
 
-  if (!getHref) {
+  if (!href) {
     return (
       <div
         className={cx(S.text, className, {
@@ -59,7 +60,6 @@ export const LegendLabel = ({
       className={cx(S.text, S.link, className)}
       to={href}
       onClick={handleLinkClick}
-      onMouseEnter={handleMouseEnter}
     >
       {children}
     </Link>

--- a/frontend/src/metabase/visualizations/components/legend/LegendLabel.tsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendLabel.tsx
@@ -1,6 +1,7 @@
 import cx from "classnames";
 import {
   useCallback,
+  useState,
   type MouseEvent,
   type MouseEventHandler,
   type ReactNode,
@@ -13,11 +14,16 @@ import S from "./LegendLabel.module.css";
 interface Props {
   children: ReactNode;
   className?: string;
-  href?: LinkProps["to"];
+  getHref?: () => LinkProps["to"];
   onClick: MouseEventHandler;
 }
 
-export const LegendLabel = ({ children, className, href, onClick }: Props) => {
+export const LegendLabel = ({
+  children,
+  className,
+  getHref,
+  onClick,
+}: Props) => {
   const handleLinkClick = useCallback(
     (event: MouseEvent) => {
       // Prefer programmatic onClick handling over native browser's href handling.
@@ -27,8 +33,15 @@ export const LegendLabel = ({ children, className, href, onClick }: Props) => {
     },
     [onClick],
   );
+  const [href, setHref] = useState<LinkProps["to"]>("");
 
-  if (!href) {
+  const handleMouseEnter = () => {
+    if (!href && getHref) {
+      setHref(getHref());
+    }
+  };
+
+  if (!getHref) {
     return (
       <div
         className={cx(S.text, className, {
@@ -46,6 +59,7 @@ export const LegendLabel = ({ children, className, href, onClick }: Props) => {
       className={cx(S.text, S.link, className)}
       to={href}
       onClick={handleLinkClick}
+      onMouseEnter={handleMouseEnter}
     >
       {children}
     </Link>

--- a/frontend/src/metabase/visualizations/types/visualization.ts
+++ b/frontend/src/metabase/visualizations/types/visualization.ts
@@ -54,7 +54,7 @@ export interface StaticVisualizationProps {
 export interface VisualizationProps {
   series: Series;
   card: Card;
-  href: string | undefined;
+  getHref: (() => string) | undefined;
   data: DatasetData;
   metadata: Metadata;
   rawSeries: RawSeries;

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
@@ -26,7 +26,7 @@ function _CartesianChart(props: VisualizationProps) {
     rawSeries,
     settings: originalSettings,
     card,
-    href,
+    getHref,
     gridSize,
     width,
     showTitle,
@@ -100,7 +100,7 @@ function _CartesianChart(props: VisualizationProps) {
           description={description}
           icon={headerIcon}
           actionButtons={actionButtons}
-          href={canSelectTitle ? href : undefined}
+          getHref={canSelectTitle ? getHref : undefined}
           onSelectTitle={canSelectTitle ? onOpenQuestion : undefined}
           width={width}
         />

--- a/frontend/src/metabase/visualizations/visualizations/Funnel/Funnel.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Funnel/Funnel.tsx
@@ -201,7 +201,7 @@ export function Funnel(props: VisualizationProps) {
     onChangeCardAndRun,
     rawSeries,
     fontFamily,
-    href,
+    getHref,
   } = props;
   const hasTitle = showTitle && settings["card.title"];
 
@@ -225,7 +225,7 @@ export function Funnel(props: VisualizationProps) {
           series={rawSeries}
           settings={settings}
           icon={headerIcon}
-          href={href}
+          getHref={getHref}
           actionButtons={actionButtons}
           onChangeCardAndRun={onChangeCardAndRun}
         />

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
@@ -110,7 +110,7 @@ const RowChartVisualization = ({
   series: multipleSeries,
   fontFamily,
   width,
-  href,
+  getHref,
 }: VisualizationProps) => {
   const formatColumnValue = useMemo(() => {
     return getColumnValueFormatter();
@@ -276,7 +276,7 @@ const RowChartVisualization = ({
           actionButtons={actionButtons}
           onSelectTitle={canSelectTitle ? openQuestion : undefined}
           width={width}
-          href={href}
+          getHref={getHref}
         />
       )}
       <RowChartLegendLayout


### PR DESCRIPTION
### Description

This PR should provide a workaround the issue with slow rendering of dashcards because of heavy `getHref` calculation

[context](https://metaboat.slack.com/archives/C0645JP1W81/p1717011281885879)

### How to verify

CI is green, app resize is smoother


### Demo

### Before
<img width="697" alt="Screenshot 2024-06-03 at 14 10 29" src="https://github.com/metabase/metabase/assets/125459446/d9d875d6-e912-4a95-b80f-c2e2a2d004cf">

### After

<img width="597" alt="Screenshot 2024-06-03 at 14 10 45" src="https://github.com/metabase/metabase/assets/125459446/87d5a5dd-f7dd-4acf-90ca-f0b138e97581">


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
