### PR TITLE
fix(sdk): Fix map visualizations breaking

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabaseProvider.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabaseProvider.tsx
@@ -9,6 +9,7 @@ import { store } from "embedding-sdk/store";
 import {
   setErrorComponent,
   setLoaderComponent,
+  setMetabaseClientUrl,
   setPlugins,
 } from "embedding-sdk/store/reducer";
 import type { SDKConfig } from "embedding-sdk/types";
@@ -53,6 +54,10 @@ const MetabaseProviderInternal = ({
   useEffect(() => {
     store.dispatch(setErrorComponent(config.errorComponent ?? null));
   }, [config.errorComponent]);
+
+  useEffect(() => {
+    store.dispatch(setMetabaseClientUrl(config.metabaseInstanceUrl));
+  }, [config.metabaseInstanceUrl]);
 
   return (
     <Provider store={store}>

--- a/enterprise/frontend/src/embedding-sdk/store/reducer.ts
+++ b/enterprise/frontend/src/embedding-sdk/store/reducer.ts
@@ -12,10 +12,14 @@ import { createAsyncThunk } from "metabase/lib/redux";
 import { getSessionTokenState } from "./selectors";
 
 const SET_LOGIN_STATUS = "sdk/SET_LOGIN_STATUS";
+const SET_METABASE_CLIENT_URL = "sdk/SET_METABASE_CLIENT_URL";
 const SET_LOADER_COMPONENT = "sdk/SET_LOADER_COMPONENT";
 const SET_ERROR_COMPONENT = "sdk/SET_ERROR_COMPONENT";
 
 export const setLoginStatus = createAction<LoginStatus>(SET_LOGIN_STATUS);
+export const setMetabaseClientUrl = createAction<string>(
+  SET_METABASE_CLIENT_URL,
+);
 export const setLoaderComponent = createAction<null | (() => JSX.Element)>(
   SET_LOADER_COMPONENT,
 );
@@ -57,6 +61,7 @@ const SET_PLUGINS = "sdk/SET_PLUGINS";
 export const setPlugins = createAction<SdkPluginsConfig | null>(SET_PLUGINS);
 
 const initialState: SdkState = {
+  metabaseInstanceUrl: "",
   token: {
     token: null,
     loading: false,
@@ -113,5 +118,10 @@ export const sdk = createReducer(initialState, builder => {
   builder.addCase(setErrorComponent, (state, action) => ({
     ...state,
     errorComponent: action.payload,
+  }));
+
+  builder.addCase(setMetabaseClientUrl, (state, action) => ({
+    ...state,
+    metabaseInstanceUrl: action.payload,
   }));
 });

--- a/enterprise/frontend/src/embedding-sdk/store/selectors.ts
+++ b/enterprise/frontend/src/embedding-sdk/store/selectors.ts
@@ -19,4 +19,4 @@ export const getErrorComponent = (state: SdkStoreState) =>
   state.sdk.errorComponent;
 
 export const getMetabaseInstanceUrl = (state: SdkStoreState) =>
-  state.sdk.metabaseInstanceUrl;
+  state.sdk?.metabaseInstanceUrl;

--- a/enterprise/frontend/src/embedding-sdk/store/selectors.ts
+++ b/enterprise/frontend/src/embedding-sdk/store/selectors.ts
@@ -17,3 +17,6 @@ export const getLoaderComponent = (state: SdkStoreState) =>
 
 export const getErrorComponent = (state: SdkStoreState) =>
   state.sdk.errorComponent;
+
+export const getMetabaseInstanceUrl = (state: SdkStoreState) =>
+  state.sdk.metabaseInstanceUrl;

--- a/enterprise/frontend/src/embedding-sdk/store/types.ts
+++ b/enterprise/frontend/src/embedding-sdk/store/types.ts
@@ -5,6 +5,7 @@ import type {
 } from "@reduxjs/toolkit";
 import type { JSX } from "react";
 
+import type { SDKConfig } from "embedding-sdk";
 import type { SdkPluginsConfig } from "embedding-sdk/lib/plugins";
 import type { State } from "metabase-types/store";
 
@@ -44,6 +45,7 @@ export type LoginStatus =
 export type SdkDispatch = ThunkDispatch<SdkStoreState, void, AnyAction>;
 
 export type SdkState = {
+  metabaseInstanceUrl: SDKConfig["metabaseInstanceUrl"];
   token: EmbeddingSessionTokenState;
   loginStatus: LoginStatus;
   plugins: null | SdkPluginsConfig;

--- a/enterprise/frontend/src/embedding-sdk/test/mocks/state.ts
+++ b/enterprise/frontend/src/embedding-sdk/test/mocks/state.ts
@@ -27,6 +27,7 @@ export const createMockSdkState = ({
   ...opts
 }: Partial<SdkState> = {}): SdkState => {
   return {
+    metabaseInstanceUrl: "",
     loginStatus: createMockLoginStatusState(),
     token: createMockTokenState(),
     plugins: {},

--- a/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
+++ b/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
@@ -113,7 +113,7 @@ const connector = connect(mapStateToProps, null);
 
 function getMapUrl(details, { isSdk, sdkMetabaseInstanceUrl, settings }) {
   if (details.builtin) {
-    if (isSdk) {
+    if (isSdk && sdkMetabaseInstanceUrl) {
       return new URL(details.url, sdkMetabaseInstanceUrl).href;
     }
     return details.url;

--- a/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
+++ b/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
@@ -109,14 +109,14 @@ const mapStateToProps = state => ({
 
 const connector = connect(mapStateToProps, null);
 
-function getMapUrl(details, { isSdk, sdkMetabaseInstanceUrl, settings }) {
+function getMapUrl(details, props) {
   if (details.builtin) {
-    if (isSdk && sdkMetabaseInstanceUrl) {
-      return new URL(details.url, sdkMetabaseInstanceUrl).href;
+    if (props?.isSdk && props?.sdkMetabaseInstanceUrl) {
+      return new URL(details.url, props.sdkMetabaseInstanceUrl).href;
     }
     return details.url;
   }
-  return "api/geojson/" + settings["map.region"];
+  return "api/geojson/" + props.settings["map.region"];
 }
 
 class ChoroplethMapInner extends Component {

--- a/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
+++ b/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
@@ -14,7 +14,6 @@ import CS from "metabase/css/core/index.css";
 import { formatValue } from "metabase/lib/formatting";
 import MetabaseSettings from "metabase/lib/settings";
 import { getIsEmbeddingSdk } from "metabase/selectors/embed";
-import { getSetting } from "metabase/selectors/settings";
 import { MinColumnsError } from "metabase/visualizations/lib/errors";
 import {
   computeMinimalBounds,
@@ -106,7 +105,6 @@ function shouldUseCompactFormatting(groups, formatMetric) {
 const mapStateToProps = state => ({
   isSdk: getIsEmbeddingSdk(state),
   sdkMetabaseInstanceUrl: getMetabaseInstanceUrl(state),
-  isDefaultMapsEnabled: getSetting(state, "default-maps-enabled"),
 });
 
 const connector = connect(mapStateToProps, null);


### PR DESCRIPTION
Closes #42767

This PR adds a `metabaseInstanceUrl` key to the SDK slice of the store which we can then pass to the `ChoroplethMap` visualization component. We can then inject the instance URL to the link to the map visualizations.