### PR TITLE
Fix invalid input in the build for release action

### DIFF
--- a/.github/workflows/build-for-release.yml
+++ b/.github/workflows/build-for-release.yml
@@ -113,7 +113,7 @@ jobs:
       uses: actions/github-script@v7
       id: release_branch
       with:
-        result_encoding: string
+        result-encoding: string
         script: | # js
           const { getReleaseBranch } = require('${{ github.workspace }}/release/dist/index.cjs');
           const version = '${{ inputs.version }}';


### PR DESCRIPTION
The warning was displayed in "Annotations" section of https://github.com/iethree/metabase/actions/runs/9322372854

```
[check-commit](https://github.com/iethree/metabase/actions/runs/9322372854/job/25663307778#step:4:1)
Unexpected input(s) 'result_encoding', valid inputs are ['script', 'github-token', 'debug', 'user-agent', 'previews', 'result-encoding', 'retries', 'retry-exempt-status-codes', 'base-url']
```