### PR TITLE
Fix bulk action delete button hover contrast

### DIFF
--- a/frontend/src/metabase/collections/components/CollectionBulkActions/ArchivedBulkActions.tsx
+++ b/frontend/src/metabase/collections/components/CollectionBulkActions/ArchivedBulkActions.tsx
@@ -8,11 +8,12 @@ import {
   canMoveItem,
   isRootTrashCollection,
 } from "metabase/collections/utils";
-import { BulkActionButton } from "metabase/components/BulkActionBar";
-import { color } from "metabase/lib/colors";
+import {
+  BulkActionButton,
+  BulkActionDangerButton,
+} from "metabase/components/BulkActionBar";
 import { useDispatch } from "metabase/lib/redux";
 import { addUndo } from "metabase/redux/undo";
-import { Box } from "metabase/ui";
 import type { Collection, CollectionItem } from "metabase-types/api";
 
 type ArchivedBulkActionsProps = {
@@ -108,12 +109,12 @@ export const ArchivedBulkActions = ({
       <BulkActionButton onClick={handleBulkMoveStart} disabled={!canMove}>
         {t`Move`}
       </BulkActionButton>
-      <BulkActionButton
+      <BulkActionDangerButton
         onClick={handleBulkDeletePermanentlyStart}
         disabled={!canDelete}
       >
-        <Box c={color("danger")}>{t`Delete permanently`}</Box>
-      </BulkActionButton>
+        {t`Delete permanently`}
+      </BulkActionDangerButton>
 
       {hasSelectedItems && selectedAction === "delete" && (
         <BulkDeleteConfirmModal

--- a/frontend/src/metabase/components/BulkActionBar/BulkActionBar.styled.tsx
+++ b/frontend/src/metabase/components/BulkActionBar/BulkActionBar.styled.tsx
@@ -44,3 +44,12 @@ export const BulkActionButton = styled(Button)`
     background-color: ${alpha(color("bg-white"), 0.1)};
   }
 ` as unknown as typeof Button;
+
+export const BulkActionDangerButton = styled(BulkActionButton)`
+  color: ${color("danger")};
+
+  :hover {
+    color: ${color("white")};
+    background-color: ${color("danger")};
+  }
+` as unknown as typeof Button;


### PR DESCRIPTION
Closes #43136

### Description

The "Delete permanently" bulk action button had bad contrast on hover. This change modifies the background color / font color on hover to help with visibility.

### How to verify

1. Go to /trash
2. Use the select checkbox to select an item in the trash for a bulk action
3. Hover over the delete option

### Demo

Default
<img width="512" alt="Screenshot 2024-06-03 at 11 14 11 AM" src="https://github.com/metabase/metabase/assets/7104357/86c350e1-6fa2-4d8b-8599-640437148f23">


Hovered
<img width="527" alt="Screenshot 2024-06-03 at 10 20 22 AM" src="https://github.com/metabase/metabase/assets/7104357/51b30476-2252-4d37-8c06-54a5d81bd2e9">

Disabled
<img width="511" alt="Screenshot 2024-06-03 at 10 20 01 AM" src="https://github.com/metabase/metabase/assets/7104357/ba1694df-cb46-4504-9bc2-13109f1e18e0">

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
Not needed
