### PR TITLE
[cache] config should be editable if entity is accessible

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/cache/cache_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cache/cache_test.clj
@@ -31,9 +31,14 @@
                                                       :collection_id (:id col1)}
                          :model/Card          card3  {:name "card3"}]
 
-            (testing "No access from regular users"
-              (is (= "You don't have permissions to do that."
-                     (mt/user-http-request :rasta :get 403 "cache/"))))
+            (testing "Access from regular users"
+              (testing "No general access"
+                (is (= "You don't have permissions to do that."
+                       (mt/user-http-request :rasta :get 403 "cache/"))))
+              (testing "But have access to a separate (accessible to them) entities"
+                (is (= {:data []}
+                       (mt/user-http-request :rasta :get 200 "cache/"
+                                             :model "question" :id (:id card1))))))
 
             (testing "Can configure root"
               (is (mt/user-http-request :crowberto :put 200 "cache/"

--- a/test/metabase/api/cache_test.clj
+++ b/test/metabase/api/cache_test.clj
@@ -14,7 +14,7 @@
           (is (= "Granular Caching is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/"
                  (mt/user-http-request :crowberto :put 402 "cache/"
                                        {:model    "question"
-                                        :model_id 1
+                                        :model_id 123456789
                                         :strategy {:type "nocache"}})))
           (is (= "Granular Caching is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/"
                  (mt/user-http-request :crowberto :get 402 "cache/"
@@ -23,7 +23,7 @@
           (is (mt/user-http-request :crowberto :put 200 "cache/"
                                     {:model    "root"
                                      :model_id 0
-                                     :strategy {:type "nocache" :name "root"}}))
+                                     :strategy {:type "nocache"}}))
           (is (=? {:data [{:model "root" :model_id 0}]}
                   (mt/user-http-request :crowberto :get 200 "cache/"
                                         :model "root")))


### PR DESCRIPTION
According to [that Slack thread](https://metaboat.slack.com/archives/C06KX7QECN4/p1716497021301599) we should give access to cache configuration to everyone who can write to a given entity.

New logic: you can edit cache settings if you're able to access the entity. For root cache configuration and for lists of entities - you have to have access to settings to see/edit them.