### PR TITLE
temporarily removes the SameSite=None suggestion box

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/embedding/components/EmbeddingAppSameSiteCookieDescription/EmbeddingAppSameSiteCookieDescription.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding/components/EmbeddingAppSameSiteCookieDescription/EmbeddingAppSameSiteCookieDescription.tsx
@@ -59,6 +59,11 @@ function AuthorizedOriginsNote() {
 function authorizedOriginsContainsNonInstanceDomain(
   authorizedOriginsString: string,
 ): boolean {
+  // temporarily disabled because it suggest wrong SameSite value
+  // for local development, where the origin is localhost and when the protocol is not specified
+  // metabase#43523
+  return false;
+
   if (isEmpty(authorizedOriginsString)) {
     return false;
   }

--- a/enterprise/frontend/src/metabase-enterprise/embedding/components/EmbeddingAppSameSiteCookieDescription/EmbeddingAppSameSiteCookieDescription.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding/components/EmbeddingAppSameSiteCookieDescription/EmbeddingAppSameSiteCookieDescription.tsx
@@ -31,7 +31,7 @@ export const EmbeddingAppSameSiteCookieDescription = () => {
       {shouldDisplayNote && <AuthorizedOriginsNote />}
       {/* eslint-disable-next-line no-literal-metabase-strings -- Metabase settings */}
       <Text>{t`Determines whether or not cookies are allowed to be sent on cross-site requests. You’ll likely need to change this to None if your embedding application is hosted under a different domain than Metabase. Otherwise, leave it set to Lax, as it's more secure.`}</Text>
-      <Text>{jt`If you set this to None, you'll have to use HTTPS (unless you're just embedding locally), or browsers will reject the request. ${(
+      <Text>{jt`If you set this to None, you'll have to use HTTPS, or browsers will reject the request. ${(
         <ExternalLink key="learn-more" href={docsUrl}>
           {t`Learn more`}
         </ExternalLink>

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding.unit.spec.tsx
@@ -46,7 +46,8 @@ describe("SettingsEditor", () => {
     ).not.toBeInTheDocument();
   });
 
-  describe("SameSite cookie note check with authorized origins", () => {
+  // eslint-disable-next-line jest/no-disabled-tests -- disabled until metabase#43523
+  describe.skip("SameSite cookie note check with authorized origins", () => {
     it("should display a note if any authorized origins do not match the instance domain", async () => {
       await setupEmbedding({
         settings: [


### PR DESCRIPTION
### Description

[Slack thread](https://metaboat.slack.com/archives/C063Q3F1HPF/p1717429725205379?thread_ts=1717422303.389629&cid=C063Q3F1HPF).
<img width="496" alt="image" src="https://github.com/metabase/metabase/assets/1914270/2d6804ce-900d-4b3c-9cba-4156876f807d">

The box is suggesting to use SameSite=None even when that will not work, for example when MB is running on localhost:3000 and the authorized origins is localhost:9000 (see https://github.com/metabase/metabase/issues/43462)
We're temporarily removing the suggestion box until we come up with a proper solution.

I created https://github.com/metabase/metabase/issues/43523 to not forget about it and to leave a reference in the code