### PR TITLE
Use `actions/checkout@v4` everywhere

### DIFF
--- a/.github/workflows/build-for-release.yml
+++ b/.github/workflows/build-for-release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           sparse-checkout: release
       - name: Prepare build scripts

--- a/.github/workflows/loki-update.yml
+++ b/.github/workflows/loki-update.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
           ref: ${{ github.head_ref }}

--- a/.github/workflows/loki.yml
+++ b/.github/workflows/loki.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Prepare frontend environment
         uses: ./.github/actions/prepare-frontend


### PR DESCRIPTION
`actions/checkout@v3` are using NodeJS 16, which has been deprecated in CI.
So every time this version of the action is used, it will generate a warning, like the one displayed here:
https://github.com/iethree/metabase/actions/runs/9322372854

```
[start-message](https://github.com/iethree/metabase/actions/runs/9322372854/job/25663307940)
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/github-script@v6. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

Furthermore, we have been using v3 and v4 in the same file/action.
This PR unifies the version of the action and sets is to the currently supported v4.