### PR TITLE
Use `actions/github-script@v7` everywhere

### DIFF
--- a/.github/workflows/build-for-release.yml
+++ b/.github/workflows/build-for-release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Prepare build scripts
         run: cd ${{ github.workspace }}/release && yarn && yarn build
       - name: Send build start message
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         env:
           SLACK_RELEASE_CHANNEL: ${{ vars.SLACK_RELEASE_CHANNEL }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/loki-update.yml
+++ b/.github/workflows/loki-update.yml
@@ -55,7 +55,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
       - name: Remove 'loki-update' label
-        uses: actions/github-script@v3
+        uses: actions/github-script@v7
         with:
           github-token: ${{secrets.METABASE_AUTOMATION_USER_TOKEN}}
           script: |


### PR DESCRIPTION
Same like #43525 but this time for the `actions/github-script` action.