### PR TITLE
[WIP] — Fix broken line/area/bar charts after adding a second stage filter

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/waterfall.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/waterfall.cy.spec.js
@@ -9,6 +9,7 @@ import {
   summarize,
   echartsContainer,
   chartPathWithFillColor,
+  queryBuilderMain,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATABASE;
@@ -154,21 +155,14 @@ describe("scenarios > visualizations > waterfall", () => {
       display: "line",
     });
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Visualization").click();
+    cy.findByTestId("view-footer").button("Visualization").click();
     switchToWaterfallDisplay();
-
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.contains("Select a field").click();
-    cy.get("[data-element-id=list-item]").contains("Created At").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.contains("Select a field").click();
-    cy.get("[data-element-id=list-item]").contains("Count").click();
 
     echartsContainer().should("exist"); // Chart renders after adding a metric
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText(/Add another/).should("not.exist");
+    queryBuilderMain()
+      .findByText(/Add another/)
+      .should("not.exist");
   });
 
   it("should work for unaggregated data (metabase#15465)", () => {

--- a/e2e/test/scenarios/visualizations-charts/waterfall.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/waterfall.cy.spec.js
@@ -137,34 +137,6 @@ describe("scenarios > visualizations > waterfall", () => {
     echartsContainer().get("text").contains("Total").should("not.exist");
   });
 
-  it("should show error for multi-series questions (metabase#15152)", () => {
-    visitQuestionAdhoc({
-      dataset_query: {
-        type: "query",
-        query: {
-          "source-table": ORDERS_ID,
-          aggregation: [["count"], ["sum", ["field-id", ORDERS.TOTAL]]],
-          breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "year" }]],
-        },
-        database: SAMPLE_DB_ID,
-      },
-      display: "line",
-    });
-
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Visualization").click();
-    switchToWaterfallDisplay();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Waterfall chart does not support multiple series");
-
-    echartsContainer().should("not.exist");
-    cy.findByTestId("remove-count").click();
-    echartsContainer().should("exist"); // Chart renders after removing the second metric
-
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText(/Add another/).should("not.exist");
-  });
-
   it("should not allow you to choose X-axis breakout", () => {
     visitQuestionAdhoc({
       dataset_query: {

--- a/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
+++ b/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
@@ -148,9 +148,8 @@ export const updateQuestion = (
     const wasPivot = currentQuestion?.display() === "pivot";
     const isPivot = newQuestion.display() === "pivot";
 
-    const hasGraphSettings =
+    const hasGraphDataSettings =
       "graph.dimensions" in vizSettings || "graph.metrics" in vizSettings;
-    const wasWaterfall = currentQuestion?.display() === "waterfall";
     const isWaterfall = newQuestion.display() === "waterfall";
 
     const isCurrentQuestionNative =
@@ -188,7 +187,7 @@ export const updateQuestion = (
       });
     }
 
-    if (hasGraphSettings && !wasWaterfall && isWaterfall) {
+    if (hasGraphDataSettings && isWaterfall) {
       const dimensions = vizSettings["graph.dimensions"] ?? [];
       const metrics = vizSettings["graph.metrics"] ?? [];
       const isMultiSeries = dimensions.length > 1 || metrics.length > 1;

--- a/frontend/src/metabase/query_builder/actions/querying.js
+++ b/frontend/src/metabase/query_builder/actions/querying.js
@@ -23,6 +23,7 @@ import {
   getTimeoutId,
 } from "../selectors";
 
+import { getQuestionWithDefaultVisualizationSettings } from "./core/utils";
 import { updateUrl } from "./navigation";
 
 export const SET_DOCUMENT_TITLE = "metabase/qb/SET_DOCUMENT_TITLE";
@@ -200,6 +201,29 @@ export const queryCompleted = (
         getSensibleDisplays(data),
         prevData && getSensibleDisplays(prevData),
       );
+    }
+
+    const previousQuestion = getQuestion(getState());
+    const previousVizSettings = previousQuestion?.settings() ?? {};
+
+    const series = [{ card: question.card(), data }];
+    const vizSettings = getQuestionWithDefaultVisualizationSettings(
+      question,
+      series,
+    ).settings();
+
+    const isLineAreaBar = ["line", "area", "bar"].includes(question.display());
+    if (isLineAreaBar) {
+      question = question.updateSettings({
+        "graph.dimensions":
+          vizSettings["graph.dimensions"].length > 0
+            ? vizSettings["graph.dimensions"]
+            : previousVizSettings["graph.dimensions"],
+        "graph.metrics":
+          vizSettings["graph.metrics"].length > 0
+            ? vizSettings["graph.metrics"]
+            : previousVizSettings["graph.metrics"],
+      });
     }
 
     const card = question.card();

--- a/frontend/src/metabase/query_builder/actions/querying.js
+++ b/frontend/src/metabase/query_builder/actions/querying.js
@@ -218,7 +218,6 @@ export const queryCompleted = (
       "bar",
       "row",
       "combo",
-      "pie",
       "waterfall",
       "scatter",
     ].includes(question.display());

--- a/frontend/src/metabase/query_builder/actions/querying.js
+++ b/frontend/src/metabase/query_builder/actions/querying.js
@@ -215,6 +215,9 @@ export const queryCompleted = (
       series,
     ).settings();
 
+    // Try using old dimension/metric settings when new ones are empty
+    // (for cases like metabase#10493 when metadata is different between reruns)
+    // If columns are actually missing, the viz settings layer should take care of that
     if (hasGraphDataSettings(question.display())) {
       const dimensions =
         vizSettings["graph.dimensions"].length > 0

--- a/frontend/src/metabase/query_builder/actions/querying.js
+++ b/frontend/src/metabase/query_builder/actions/querying.js
@@ -7,7 +7,10 @@ import { defer } from "metabase/lib/promise";
 import { createThunkAction } from "metabase/lib/redux";
 import { getWhiteLabeledLoadingMessageFactory } from "metabase/selectors/whitelabel";
 import { runQuestionQuery as apiRunQuestionQuery } from "metabase/services";
-import { getSensibleDisplays } from "metabase/visualizations";
+import {
+  getSensibleDisplays,
+  hasGraphDataSettings,
+} from "metabase/visualizations";
 import * as Lib from "metabase-lib";
 import { isAdHocModelQuestion } from "metabase-lib/v1/metadata/utils/models";
 import { isSameField } from "metabase-lib/v1/queries/utils/field-ref";
@@ -212,17 +215,7 @@ export const queryCompleted = (
       series,
     ).settings();
 
-    const hasGraphSettings = [
-      "line",
-      "area",
-      "bar",
-      "row",
-      "combo",
-      "waterfall",
-      "scatter",
-    ].includes(question.display());
-
-    if (hasGraphSettings) {
+    if (hasGraphDataSettings(question.display())) {
       const dimensions =
         vizSettings["graph.dimensions"].length > 0
           ? vizSettings["graph.dimensions"]

--- a/frontend/src/metabase/query_builder/actions/querying.js
+++ b/frontend/src/metabase/query_builder/actions/querying.js
@@ -212,17 +212,31 @@ export const queryCompleted = (
       series,
     ).settings();
 
-    const isLineAreaBar = ["line", "area", "bar"].includes(question.display());
-    if (isLineAreaBar) {
+    const hasGraphSettings = [
+      "line",
+      "area",
+      "bar",
+      "row",
+      "combo",
+      "pie",
+      "waterfall",
+      "scatter",
+    ].includes(question.display());
+
+    if (hasGraphSettings) {
+      const dimensions =
+        vizSettings["graph.dimensions"].length > 0
+          ? vizSettings["graph.dimensions"]
+          : previousVizSettings["graph.dimensions"];
+
+      const metrics =
+        vizSettings["graph.metrics"].length > 0
+          ? vizSettings["graph.metrics"]
+          : previousVizSettings["graph.metrics"];
+
       question = question.updateSettings({
-        "graph.dimensions":
-          vizSettings["graph.dimensions"].length > 0
-            ? vizSettings["graph.dimensions"]
-            : previousVizSettings["graph.dimensions"],
-        "graph.metrics":
-          vizSettings["graph.metrics"].length > 0
-            ? vizSettings["graph.metrics"]
-            : previousVizSettings["graph.metrics"],
+        "graph.dimensions": dimensions,
+        "graph.metrics": metrics,
       });
     }
 

--- a/frontend/src/metabase/query_builder/actions/querying.js
+++ b/frontend/src/metabase/query_builder/actions/querying.js
@@ -206,19 +206,19 @@ export const queryCompleted = (
       );
     }
 
-    const previousQuestion = getQuestion(getState());
-    const previousVizSettings = previousQuestion?.settings() ?? {};
-
-    const series = [{ card: question.card(), data }];
-    const vizSettings = getQuestionWithDefaultVisualizationSettings(
-      question,
-      series,
-    ).settings();
-
     // Try using old dimension/metric settings when new ones are empty
     // (for cases like metabase#10493 when metadata is different between reruns)
     // If columns are actually missing, the viz settings layer should take care of that
     if (hasGraphDataSettings(question.display())) {
+      const previousQuestion = getQuestion(getState());
+      const previousVizSettings = previousQuestion?.settings() ?? {};
+
+      const series = [{ card: question.card(), data }];
+      const vizSettings = getQuestionWithDefaultVisualizationSettings(
+        question,
+        series,
+      ).settings();
+
       const dimensions =
         vizSettings["graph.dimensions"].length > 0
           ? vizSettings["graph.dimensions"]

--- a/frontend/src/metabase/visualizations/index.ts
+++ b/frontend/src/metabase/visualizations/index.ts
@@ -128,6 +128,15 @@ export function getDefaultSize(display: string) {
   return visualization?.defaultSize;
 }
 
+export function hasGraphDataSettings(display: string) {
+  const visualization = visualizations.get(display);
+  const settingDefinitions = visualization?.settings ?? {};
+  return (
+    "graph.dimensions" in settingDefinitions &&
+    "graph.metrics" in settingDefinitions
+  );
+}
+
 // removes columns with `remapped_from` property and adds a `remapping` to the appropriate column
 export const extractRemappedColumns = (data: DatasetData) => {
   const cols: RemappingHydratedDatasetColumn[] = data.cols.map(col => ({


### PR DESCRIPTION
Closes #10493

Fixes an issue when adding an n-th query stage would drop `graph.dimensions` and `graph.metrics` viz settings (by default selected by [`getSingleSeriesDimensionsAndMetrics` function](https://github.com/metabase/metabase/blob/8659846f0b011af29f92719ac9273c63df76e0d3/frontend/src/metabase/visualizations/lib/utils.js#L283)) and put a chart into unexpected state.

This happens in some cases after adding a new query stage. When a new stage is added, some column metadata becomes opaque (e.g., which columns come from aggregations or breakouts). In certain cases, there are no columns to auto-pick instead, and the chart "breaks" (it's still possible to select x/y axis columns manually; it's just annoying).

The fix is implemented on the QB level. Each time a query is completed, we calculate the default `graph.dimensions` and `default.metrics`, and if they appear empty, we will try to use the previous value instead. If the last value is actually irrelevant (e.g., a column is no longer there), the viz settings layer should invalidate and recalculate them again.

I've considered making a fix closer to the viz settings layer, but we'd need to make viz settings aware of their previous value if we do something similar. Another idea is to port `graph.dimensions` and `graph.metrics` calculation to MBQL lib, but that'd require passing `metadata` down to the viz layer which we're not really doing AFAIK. Would appreciate feedback on the solution 🙏 

### To verify

1. New > Question > Orders > Visualize
2. Click the "Quantity" column header and select "Distribution"
3. Add a filter on the "Count" column
4. Ensure the x and y axis didn't change

### Demo

**Before**

https://github.com/metabase/metabase/assets/17258145/772115f7-54c7-4631-85d6-1d9554ec0dd4

**After**

https://github.com/metabase/metabase/assets/17258145/ee679f8b-b321-4dfb-9017-f34f88ef0328



