### PR TITLE
Change MySQL ENUM columns to have base_type=type/TextLike

### DIFF
--- a/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
@@ -793,9 +793,11 @@ const MODEL_NAME = "Test Action Model";
             cy.findByPlaceholderText("JSONB").should("not.exist");
             cy.findByPlaceholderText("Binary").should("not.exist");
 
-            if (dialect === "mysql") {
-              // we only have enums in postgres as of Feb 2023
+            if (dialect === "postgres") {
+              // Cal 2024-05-04: why don't we allow enums in implicit actions for postgres?
               cy.findByPlaceholderText("Enum").should("not.exist");
+            } else if (dialect === "mysql") {
+              cy.findByPlaceholderText("Enum").should("be.visible");
             }
           });
         });

--- a/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
@@ -792,13 +792,7 @@ const MODEL_NAME = "Test Action Model";
             cy.findByPlaceholderText("JSON").should("not.exist");
             cy.findByPlaceholderText("JSONB").should("not.exist");
             cy.findByPlaceholderText("Binary").should("not.exist");
-
-            if (dialect === "postgres") {
-              // Cal 2024-05-04: why don't we allow enums in implicit actions for postgres?
-              cy.findByPlaceholderText("Enum").should("not.exist");
-            } else if (dialect === "mysql") {
-              cy.findByPlaceholderText("Enum").should("be.visible");
-            }
+            cy.findByPlaceholderText("Enum").should("exist");
           });
         });
 

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -480,7 +480,7 @@
     :DATETIME   :type/DateTime
     :DECIMAL    :type/Decimal
     :DOUBLE     :type/Float
-    :ENUM       :type/Text
+    :ENUM       :type/MySQLEnum
     :FLOAT      :type/Float
     :INT        :type/Integer
     :INTEGER    :type/Integer

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -480,7 +480,7 @@
     :DATETIME   :type/DateTime
     :DECIMAL    :type/Decimal
     :DOUBLE     :type/Float
-    :ENUM       :type/*
+    :ENUM       :type/Text
     :FLOAT      :type/Float
     :INT        :type/Integer
     :INTEGER    :type/Integer

--- a/src/metabase/lib/schema/expression.cljc
+++ b/src/metabase/lib/schema/expression.cljc
@@ -161,15 +161,16 @@
 (def equality-comparable-types
   "Set of base types that can be compared with equality."
   ;; TODO: Adding :type/* here was necessary to prevent type errors for queries where a field's type in the DB could not
-  ;; be determined better than :type/*. See #36841, where a MySQL enum field gets `:base-type :type/*`, and this check
+  ;; be determined better than :type/*. See #36841, where a MySQL enum field used to get `:base-type :type/*`, and this check
   ;; would fail on `[:= {} [:field ...] "enum-str"]` without `:type/*` here.
   ;; This typing of each input should be replaced with an alternative scheme that checks that it's plausible to compare
   ;; all the args to an `:=` clause. Eg. comparing `:type/*` and `:type/String` is cool. Comparing `:type/IPAddress` to
   ;; `:type/Boolean` should fail; we can prove it's the wrong thing to do.
-  #{:type/Boolean :type/Text :type/Number :type/Temporal :type/IPAddress :type/MongoBSONID :type/Array :type/*})
+  #{:type/Boolean :type/Text :type/Number :type/Temporal :type/IPAddress :type/MySQLEnum :type/MongoBSONID :type/Array :type/*})
 
 (derive :type/Text        ::emptyable)
 (derive :type/MongoBSONID ::emptyable)
+(derive :type/MySQLEnum   ::emptyable)
 
 (mr/def ::emptyable
   (expression-schema ::emptyable "expression returning something emptyable (e.g. a string or BSON ID)"))

--- a/src/metabase/types.cljc
+++ b/src/metabase/types.cljc
@@ -258,6 +258,7 @@
 
 (derive :type/TextLike :type/*)
 (derive :type/MongoBSONID :type/TextLike)
+(derive :type/MySQLEnum :type/TextLike)
 ;; IP address can be either a data type e.g. Postgres `inet` or a semantic type e.g. a `text` column that has IP
 ;; addresses
 (derive :type/IPAddress :type/TextLike)


### PR DESCRIPTION
Solves https://github.com/metabase/metabase/issues/37638

This should be backported with https://github.com/metabase/metabase/pull/43483, because otherwise fingerprinting and scanning won't happen anymore with ENUM columns.

MySQL ENUM columns have always had `base_type=type/*`, even though they are _mostly_ indistinguishable from other TEXT columns. This PR changes that so ENUM columns have `base_type=type/TextLike`.

After a discussion with Braden and Dan [on slack](https://metaboat.slack.com/archives/CKZEMT1MJ/p1717443858196669) we decided that `type/TextLike` was more appropriate for these columns like this. Unlike `type/Text`, `type/TextLike` disallows the application of text operations like "contains" or "starts-with" filters, or using functions like "concat". See [this code](https://github.com/metabase/metabase/blob/2a21cf2ea2e1708ce4f4b4fdea77ea96189a852c/src/metabase/lib/schema/expression/string.cljc#L1) for how this works in the QP.

For more information on ENUM columns, see the [MySQL docs](https://dev.mysql.com/doc/refman/8.4/en/enum.html). tl;dr is they are mostly similar to TEXT columns but differ in a few ways. For example, an `ORDER BY` clause will order the column by the integer values that back the string values, not the string values themselves.

To test this manually, create a table in a MySQL DB with the following SQL:
```
-- Create the table
CREATE TABLE colors (
    id INT AUTO_INCREMENT PRIMARY KEY,
    color ENUM('red', 'green', '1')
);

-- Insert values into the table
INSERT INTO colors (color) VALUES ('red');
INSERT INTO colors (color) VALUES ('green');
INSERT INTO colors (color) VALUES ('1');
INSERT INTO colors (color) VALUES (NULL);
```