### PR TITLE
Backport #43331 - collection search results with effectve_parent

### DIFF
--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -22,6 +22,7 @@ import {
   getSettings,
 } from "metabase/selectors/settings";
 import { getShowMetabaseLinks } from "metabase/selectors/whitelabel";
+import type { IconName } from "metabase/ui";
 
 import type { PaletteAction } from "../types";
 import { filterRecentItems } from "../utils";
@@ -126,7 +127,7 @@ export const useCommandPalette = ({
           name: t`View search results for "${debouncedSearchText}"`,
           section: "search",
           keywords: debouncedSearchText,
-          icon: "link" as const,
+          icon: "link" as IconName,
           perform: () => {
             dispatch(push(searchLocation));
           },

--- a/frontend/src/metabase/search/components/SearchResult/components/CollectionIcon.tsx
+++ b/frontend/src/metabase/search/components/SearchResult/components/CollectionIcon.tsx
@@ -1,33 +1,22 @@
 import { color } from "metabase/lib/colors";
 import { getIcon } from "metabase/lib/icon";
-import { PLUGIN_COLLECTIONS } from "metabase/plugins";
-import { DEFAULT_ICON_SIZE } from "metabase/search/components/SearchResult/components";
-import type { WrappedResult } from "metabase/search/types";
+import {
+  DEFAULT_ICON_SIZE,
+  LARGE_ICON_SIZE,
+} from "metabase/search/components/SearchResult/components";
 import { Icon } from "metabase/ui";
 
 import type { IconComponentProps } from "./ItemIcon";
 
-const isWrappedResult = (
-  item: IconComponentProps["item"],
-): item is WrappedResult => item && "getIcon" in item;
-
 export function CollectionIcon({ item }: { item: IconComponentProps["item"] }) {
-  const iconData = isWrappedResult(item) ? item?.getIcon?.() : getIcon(item);
+  const icon = getIcon(item);
 
-  const iconProps = { ...iconData, tooltip: null };
-  const isRegular =
-    "collection" in item &&
-    PLUGIN_COLLECTIONS.isRegularCollection(item.collection);
+  icon.color = icon.color ? color(icon.color) : color("text-light");
 
-  if (isRegular) {
-    return (
-      <Icon
-        {...iconProps}
-        size={DEFAULT_ICON_SIZE}
-        color={color("text-light")}
-      />
-    );
-  }
-
-  return <Icon {...iconProps} width={20} height={24} />;
+  return (
+    <Icon
+      {...icon}
+      size={icon.name === "folder" ? DEFAULT_ICON_SIZE : LARGE_ICON_SIZE}
+    />
+  );
 }

--- a/frontend/src/metabase/search/components/SearchResult/components/constants.ts
+++ b/frontend/src/metabase/search/components/SearchResult/components/constants.ts
@@ -1,1 +1,2 @@
 export const DEFAULT_ICON_SIZE = 16;
+export const LARGE_ICON_SIZE = 20;

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -371,6 +371,37 @@
   ([real-location-path allowed-collection-ids]
    (effective-location-path* real-location-path allowed-collection-ids)))
 
+(def ^:private effective-parent-fields
+  "Fields that should be included when hydrating the `:effective_parent` of a collection. Used for displaying recent views
+  and collection search results."
+  [:id :name :authority_level :type])
+
+(defn- effective-parent-root []
+  (select-keys
+   (collection.root/root-collection-with-ui-details {})
+   effective-parent-fields))
+
+(mi/define-batched-hydration-method effective-parent
+  :effective_parent
+  "Given a seq of `collections`, batch hydrates them with their `:effective_parent`, their parent collection in their
+  effective location. (i.e. the most recent ancestor the current user has read access to). If :effective_location is not
+  present on any collections, it is hydrated as well, as it is needed to compute the effective parent."
+  [collections]
+  (let [collections     (map #(t2/hydrate % :effective_location) collections)
+        parent-ids      (->> collections
+                             (map :effective_location)
+                             (keep location-path->parent-id))
+        id->parent-coll (merge {nil (effective-parent-root)}
+                               (when (seq parent-ids)
+                                 (t2/select-pk->fn identity :model/Collection
+                                                   {:select effective-parent-fields
+                                                    :where [:in :id parent-ids]})))]
+    (map
+     (fn [collection]
+       (let [parent-id (-> collection :effective_location location-path->parent-id)]
+         (assoc collection :effective_parent (id->parent-coll parent-id))))
+     collections)))
+
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                          Nested Collections: Ancestors, Childrens, Child Collections                           |

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -304,7 +304,7 @@
 (defn serialize
   "Massage the raw result from the DB and match data into something more useful for the client"
   [{:as result :keys [all-scores relevant-scores name display_name collection_id collection_name
-                      collection_authority_level collection_type collection_effective_ancestors]}]
+                      collection_authority_level collection_type collection_effective_ancestors effective_parent]}]
   (let [matching-columns    (into #{} (remove nil? (map :column relevant-scores)))
         match-context-thunk (first (keep :match-context-thunk relevant-scores))]
     (-> result
@@ -320,6 +320,8 @@
                                  :name            collection_name
                                  :authority_level collection_authority_level
                                  :type            collection_type}
+                                (when effective_parent
+                                  effective_parent)
                                 (when collection_effective_ancestors
                                   {:effective_ancestors collection_effective_ancestors}))
          :scores          all-scores)
@@ -332,7 +334,8 @@
          :collection_location
          :collection_name
          :collection_type
-         :display_name))))
+         :display_name
+         :effective_parent))))
 
 (defn weights-and-scores
   "Default weights and scores for a given result."

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -1656,6 +1656,34 @@
                (set (mt/user-http-request :crowberto :get 200 "search/models" :q search-term
                                           :filter_items_in_personal_collection "exclude"))))))))
 
+(deftest collection-effective-parent-test
+  (mt/with-temp [:model/Collection coll-1  {:name "Collection 1"}
+                 :model/Collection coll-2  {:name "Collection 2", :location (collection/location-path coll-1)}
+                 :model/Collection _coll-3 {:name "Collection 3", :location (collection/location-path coll-1 coll-2)}]
+    (testing "Collection search results are properly hydrated with their effective parent in the :collection field"
+      (let [result (mt/user-http-request :rasta :get 200 "search" :q "Collection 3" :models ["collection"])]
+        (is (= {:id              (u/the-id coll-2)
+                :name            "Collection 2"
+                :authority_level nil
+                :type            nil}
+               (-> result :data first :collection))))
+
+      (perms/revoke-collection-permissions! (perms-group/all-users) coll-2)
+      (let [result (mt/user-http-request :rasta :get 200 "search" :q "Collection 3" :models ["collection"])]
+        (is (= {:id              (u/the-id coll-1)
+                :name            "Collection 1"
+                :authority_level nil
+                :type            nil}
+               (-> result :data first :collection))))
+
+      (perms/revoke-collection-permissions! (perms-group/all-users) coll-1)
+      (let [result (mt/user-http-request :rasta :get 200 "search" :q "Collection 3" :models ["collection"])]
+        (is (= {:id              "root"
+                :name            "Our analytics"
+                :authority_level nil
+                :type            nil}
+               (-> result :data first :collection)))))))
+
 (deftest archived-search-results-with-no-write-perms-test
   (testing "Results which the searching user has no write permissions for are filtered out. #33602"
     (mt/with-temp [Collection  {collection-id :id} (archived {:name "collection test collection"})


### PR DESCRIPTION
Manual backport of #43331 since a bunch of search code was reorganized in master that's not in the 50 release branch, so there were a lot of merge conflicts. Was easier to recreate the relevant bits manually.