### PR TITLE
Fix new collection modal auto-focus moving

### DIFF
--- a/frontend/src/metabase/collections/components/CreateCollectionForm/CreateCollectionForm.tsx
+++ b/frontend/src/metabase/collections/components/CreateCollectionForm/CreateCollectionForm.tsx
@@ -117,7 +117,7 @@ function CreateCollectionForm({
             name="name"
             title={t`Name`}
             placeholder={t`My new fantastic collection`}
-            autoFocus
+            data-autofocus
           />
           <FormTextArea
             name="description"


### PR DESCRIPTION
Fixes #41241

### Description

This PR solves a bug where the name input on the create collection modal was getting validated on mount (see related issue for repo).

The issue was due to this logic in the Mantine Modal component:
> If you do not add data-autofocus attribute and do not use FocusTrap.InitialFocus, modal will focus the first focusable element inside it which is usually the close button.
> \- [mantine docs](https://mantine.dev/core/modal/)

Since `autoFocus` was set on the name input. it was getting focused first. Then mantine was moving focus to the close button, thus causing the name input to be `touched`. This triggers Formik to validate the form which results in the error appearing without the user interacting with the form.

The fix is to not use `autoFocus` but instead use `data-autofocus`

### Demo

https://github.com/metabase/metabase/assets/7104357/12798683-9d9d-40b8-9feb-a358107aec3e