### PR TITLE
create chartModel for pie chart

### DIFF
--- a/frontend/src/metabase/lib/arrays.ts
+++ b/frontend/src/metabase/lib/arrays.ts
@@ -6,3 +6,19 @@ export function moveElement<T>(array: T[], oldIndex: number, newIndex: number) {
 
 export const sumArray = (values: number[]) =>
   values.reduce((acc, value) => acc + value, 0);
+
+export const findWithIndex = <T>(
+  arr: T[],
+  predicate: (value: T, index: number, arr: T[]) => boolean,
+) => {
+  for (let i = 0; i < arr.length; i++) {
+    const item = arr[i];
+    if (predicate(item, i, arr)) {
+      return { item, index: i };
+    }
+  }
+  return {
+    index: -1,
+    item: undefined,
+  };
+};

--- a/frontend/src/metabase/static-viz/components/PieChart/PieChart.tsx
+++ b/frontend/src/metabase/static-viz/components/PieChart/PieChart.tsx
@@ -1,13 +1,22 @@
+import { Group } from "@visx/group";
+import { init } from "echarts";
+
+import { sanitizeSvgForBatik } from "metabase/static-viz/lib/svg";
+import { DIMENSIONS } from "metabase/visualizations/echarts/pie/constants";
+import { getPieChartFormatters } from "metabase/visualizations/echarts/pie/format";
 import { getPieChartModel } from "metabase/visualizations/echarts/pie/model";
+import { getPieChartOption } from "metabase/visualizations/echarts/pie/option";
 
 import type { StaticChartProps } from "../StaticVisualization";
 
+import { getPieChartLegend } from "./legend";
 import { computeStaticPieChartSettings } from "./settings";
 
 export function PieChart({
   rawSeries,
   dashcardSettings,
   renderingContext,
+  isStorybook,
 }: StaticChartProps) {
   const computedVizSettings = computeStaticPieChartSettings(
     rawSeries,
@@ -18,18 +27,48 @@ export function PieChart({
     computedVizSettings,
     renderingContext,
   );
-  console.log("chartModel", chartModel);
+  const formatters = getPieChartFormatters(
+    chartModel,
+    computedVizSettings,
+    renderingContext,
+  );
+  const option = getPieChartOption(
+    chartModel,
+    formatters,
+    computedVizSettings,
+    renderingContext,
+  );
+  const { legendHeight, Legend } = getPieChartLegend(
+    chartModel,
+    formatters,
+    computedVizSettings,
+    DIMENSIONS.sideLen,
+    DIMENSIONS.paddingTop,
+  );
+
+  const chart = init(null, null, {
+    renderer: "svg",
+    ssr: true,
+    width: DIMENSIONS.sideLen,
+    height: DIMENSIONS.sideLen,
+  });
+  chart.setOption(option);
+  const chartSvg = sanitizeSvgForBatik(
+    chart.renderToSVGString(),
+    isStorybook ?? false,
+  );
 
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" width={500} height={500}>
-      <text
-        id="outer-text"
-        fill="black"
-        dominantBaseline="central"
-        transform="translate(50 50)"
-      >
-        Placeholder
-      </text>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={DIMENSIONS.sideLen}
+      height={DIMENSIONS.sideLen + DIMENSIONS.paddingTop + legendHeight}
+    >
+      <Legend />
+      <Group
+        top={DIMENSIONS.paddingTop + legendHeight}
+        dangerouslySetInnerHTML={{ __html: chartSvg }}
+      ></Group>
     </svg>
   );
 }

--- a/frontend/src/metabase/static-viz/components/PieChart/PieChart.tsx
+++ b/frontend/src/metabase/static-viz/components/PieChart/PieChart.tsx
@@ -1,13 +1,24 @@
+import { getPieChartModel } from "metabase/visualizations/echarts/pie/model";
+
 import type { StaticChartProps } from "../StaticVisualization";
 
 import { computeStaticPieChartSettings } from "./settings";
 
-export function PieChart({ rawSeries, dashcardSettings }: StaticChartProps) {
+export function PieChart({
+  rawSeries,
+  dashcardSettings,
+  renderingContext,
+}: StaticChartProps) {
   const computedVizSettings = computeStaticPieChartSettings(
     rawSeries,
     dashcardSettings,
   );
-  console.log("computedVizSettings", computedVizSettings);
+  const chartModel = getPieChartModel(
+    rawSeries,
+    computedVizSettings,
+    renderingContext,
+  );
+  console.log("chartModel", chartModel);
 
   return (
     <svg xmlns="http://www.w3.org/2000/svg" width={500} height={500}>

--- a/frontend/src/metabase/static-viz/components/PieChart/legend.tsx
+++ b/frontend/src/metabase/static-viz/components/PieChart/legend.tsx
@@ -1,0 +1,56 @@
+import type { PieChartFormatters } from "metabase/visualizations/echarts/pie/format";
+import type { PieChartModel } from "metabase/visualizations/echarts/pie/model/types";
+import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
+
+import { Legend } from "../Legend";
+import { calculateLegendRows } from "../Legend/utils";
+
+const FONT = {
+  lineHeight: 20,
+  size: 14,
+  weight: 700,
+};
+
+export function getPieChartLegend(
+  chartModel: PieChartModel,
+  formatters: PieChartFormatters,
+  settings: ComputedVisualizationSettings,
+  width: number,
+  top: number,
+) {
+  if (!settings["pie.show_legend"] || chartModel.slices.length <= 1) {
+    return { legendHeight: 0, Legend: () => null };
+  }
+
+  const legendRows = calculateLegendRows({
+    items: chartModel.slices.map(s => ({
+      name:
+        settings["pie.percent_visibility"] === "legend"
+          ? `${s.key} - ${formatters.formatPercent(s.normalizedPercentage)}`
+          : s.key,
+      color: s.color,
+      key: s.key,
+    })),
+    width,
+    lineHeight: FONT.lineHeight,
+    fontSize: FONT.size,
+    fontWeight: FONT.weight,
+  });
+  if (!legendRows) {
+    throw Error("Error calculating legend rows");
+  }
+
+  const { height: legendHeight, items } = legendRows;
+
+  return {
+    legendHeight,
+    Legend: () => (
+      <Legend
+        items={items}
+        top={top}
+        fontSize={FONT.size}
+        fontWeight={FONT.weight}
+      />
+    ),
+  };
+}

--- a/frontend/src/metabase/visualizations/echarts/pie/constants.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/constants.ts
@@ -1,0 +1,22 @@
+export const DIMENSIONS = {
+  paddingTop: 16,
+  sideLen: 540,
+  margin: 20,
+  slice: {
+    thickness: 100,
+    borderWidth: 4,
+  },
+  // placeholders, real values computed below
+  innerSideLen: 0,
+  outerRadius: 0,
+  innerRadius: 0,
+};
+
+DIMENSIONS.innerSideLen = DIMENSIONS.sideLen - DIMENSIONS.margin * 2;
+DIMENSIONS.outerRadius = DIMENSIONS.innerSideLen / 2;
+DIMENSIONS.innerRadius = DIMENSIONS.outerRadius - DIMENSIONS.slice.thickness;
+
+// TODO use this for settings, dynamic
+export const SLICE_THRESHOLD = 0.025; // approx 1 degree in percentage
+
+export const OTHER_SLICE_MIN_PERCENTAGE = 0.003;

--- a/frontend/src/metabase/visualizations/echarts/pie/format.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/format.ts
@@ -1,0 +1,47 @@
+import { computeMaxDecimalsForValues } from "metabase/visualizations/lib/utils";
+import type {
+  ComputedVisualizationSettings,
+  RenderingContext,
+} from "metabase/visualizations/types";
+
+import type { PieChartModel } from "./model/types";
+
+export interface PieChartFormatters {
+  formatMetric: (value: unknown) => string;
+  formatPercent: (value: unknown) => string;
+}
+
+export function getPieChartFormatters(
+  chartModel: PieChartModel,
+  settings: ComputedVisualizationSettings,
+  renderingContext: RenderingContext,
+): PieChartFormatters {
+  const { column: getColumnSettings } = settings;
+  if (!getColumnSettings) {
+    throw Error(`"settings.column" is undefined`);
+  }
+  const metricColSettings = getColumnSettings(
+    chartModel.colDescs.metricDesc.column,
+  );
+
+  const formatMetric = (value: unknown) =>
+    renderingContext.formatValue(value, {
+      ...metricColSettings,
+    });
+
+  const formatPercent = (value: unknown) =>
+    renderingContext.formatValue(value, {
+      column: metricColSettings.column,
+      number_separators: metricColSettings.number_separators as string,
+      number_style: "percent",
+      decimals: computeMaxDecimalsForValues(
+        chartModel.slices.map(s => s.normalizedPercentage),
+        {
+          style: "percent",
+          maximumSignificantDigits: 2,
+        },
+      ),
+    });
+
+  return { formatMetric, formatPercent };
+}

--- a/frontend/src/metabase/visualizations/echarts/pie/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/model/index.ts
@@ -1,0 +1,131 @@
+import { t } from "ttag";
+import _ from "underscore";
+
+import { findWithIndex } from "metabase/lib/arrays";
+import { NULL_DISPLAY_VALUE } from "metabase/lib/constants";
+import type {
+  ComputedVisualizationSettings,
+  RenderingContext,
+} from "metabase/visualizations/types";
+import type { RawSeries, RowValue } from "metabase-types/api";
+
+import { OTHER_SLICE_MIN_PERCENTAGE } from "../constants";
+
+import type { PieColumnDescriptors, PieChartModel, PieSlice } from "./types";
+
+function getColDescs(
+  rawSeries: RawSeries,
+  settings: ComputedVisualizationSettings,
+): PieColumnDescriptors {
+  const [
+    {
+      data: { cols },
+    },
+  ] = rawSeries;
+
+  const dimension = findWithIndex(
+    cols,
+    c => c.name === settings["pie.dimension"],
+  );
+  const metric = findWithIndex(cols, c => c.name === settings["pie.metric"]);
+
+  if (!dimension.item || !metric.item) {
+    throw new Error(
+      `Could not find columns based on "pie.dimension" (${settings["pie.dimension"]}) and "pie.metric" (${settings["pie.metric"]}) settings.`,
+    );
+  }
+
+  return {
+    dimensionDesc: {
+      index: dimension.index,
+      column: dimension.item,
+    },
+    metricDesc: {
+      index: metric.index,
+      column: metric.item,
+    },
+  };
+}
+
+export function getRowValues(row: RowValue[], colDescs: PieColumnDescriptors) {
+  const { dimensionDesc, metricDesc } = colDescs;
+
+  // dimension val needs to be string to use as key for objects, such as "pie.colors" setting
+  const dimensionValue = String(row[dimensionDesc.index] ?? NULL_DISPLAY_VALUE);
+
+  const metricValue = row[metricDesc.index] ?? 0;
+  if (typeof metricValue !== "number") {
+    throw new Error(
+      `Pie chart metric value (${metricValue}) should be a number`,
+    );
+  }
+
+  return { dimensionValue, metricValue };
+}
+
+export function getPieChartModel(
+  rawSeries: RawSeries,
+  settings: ComputedVisualizationSettings,
+  renderingContext: RenderingContext,
+): PieChartModel {
+  const [
+    {
+      data: { rows },
+    },
+  ] = rawSeries;
+  const colDescs = getColDescs(rawSeries, settings);
+
+  const total = rows.reduce(
+    (currTotal, row) => currTotal + getRowValues(row, colDescs).metricValue,
+    0,
+  );
+
+  const [slices, others] = _.chain(rows)
+    .map((row, index): PieSlice => {
+      const { dimensionValue, metricValue } = getRowValues(row, colDescs);
+
+      if (!settings["pie.colors"]) {
+        throw Error(`"pie.colors" setting is not defined`);
+      }
+
+      return {
+        key: dimensionValue,
+        value: metricValue,
+        tooltipDisplayValue: metricValue,
+        normalizedPercentage: metricValue / total, // slice percentage values are normalized to 0-1 scale
+        rowIndex: index,
+        color: settings["pie.colors"][dimensionValue],
+      };
+    })
+    .partition(
+      slice =>
+        slice.normalizedPercentage >=
+        (settings["pie.slice_threshold"] ?? 0) / 100, // stored setting for "pie.slice_threshold" is on 0-100 scale to match user input
+    )
+    .value();
+
+  // Only add "other" slice if there are slices below threshold with non-zero total
+  const otherTotal = others.reduce((currTotal, o) => currTotal + o.value, 0);
+  if (otherTotal === 0) {
+    return { slices, total, colDescs };
+  }
+
+  const otherSlice: PieSlice = {
+    key: t`Other`,
+    value: otherTotal,
+    tooltipDisplayValue: otherTotal,
+    normalizedPercentage: otherTotal / total,
+    color: renderingContext.getColor("text-light"),
+  };
+
+  // Increase "other" slice so it's barely visible
+  if (otherSlice.normalizedPercentage < OTHER_SLICE_MIN_PERCENTAGE) {
+    otherSlice.value = total * OTHER_SLICE_MIN_PERCENTAGE;
+  }
+
+  return {
+    slices: [...slices, otherSlice],
+    total,
+    colDescs,
+  };
+}

--- a/frontend/src/metabase/visualizations/echarts/pie/model/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/model/types.ts
@@ -1,0 +1,21 @@
+import type { ColumnDescriptor } from "metabase/visualizations/lib/graph/columns";
+
+export interface PieColumnDescriptors {
+  metricDesc: ColumnDescriptor;
+  dimensionDesc: ColumnDescriptor;
+}
+
+export interface PieSlice {
+  key: string;
+  value: number; // size of the slice used for rendering
+  tooltipDisplayValue: number; // real value of the slice displayed in tooltip
+  normalizedPercentage: number;
+  rowIndex?: number;
+  color: string;
+}
+
+export interface PieChartModel {
+  slices: PieSlice[];
+  total: number;
+  colDescs: PieColumnDescriptors;
+}

--- a/frontend/src/metabase/visualizations/echarts/pie/option/constants.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/option/constants.ts
@@ -1,0 +1,50 @@
+import type { RegisteredSeriesOption } from "echarts";
+import { t } from "ttag";
+
+import { DIMENSIONS } from "../constants";
+
+export const SUNBURST_SERIES_OPTION: RegisteredSeriesOption["sunburst"] = {
+  type: "sunburst",
+  sort: undefined,
+  radius: [DIMENSIONS.innerRadius, DIMENSIONS.outerRadius],
+  label: {
+    rotate: 0,
+    overflow: "none",
+    fontSize: 20,
+    fontWeight: 700,
+  },
+  itemStyle: {
+    borderWidth: DIMENSIONS.slice.borderWidth,
+  },
+};
+
+export const TOTAL_GRAPHIC_OPTION = {
+  type: "group",
+  top: "center",
+  left: "center",
+  children: [
+    {
+      type: "text",
+      cursor: "text",
+      style: {
+        fontSize: "22px",
+        fontWeight: "700",
+        textAlign: "center",
+        // placeholder values to keep typescript happy
+        fontFamily: "",
+        fill: "",
+      },
+    },
+    {
+      type: "text",
+      cursor: "text",
+      top: 26,
+      style: {
+        fontSize: "14px",
+        fontWeight: "700",
+        textAlign: "center",
+        text: t`Total`.toUpperCase(),
+      },
+    },
+  ],
+};

--- a/frontend/src/metabase/visualizations/echarts/pie/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/option/index.ts
@@ -1,0 +1,96 @@
+import type { EChartsOption } from "echarts";
+import cloneDeep from "lodash.clonedeep";
+
+import { getTextColorForBackground } from "metabase/lib/colors";
+import type {
+  ComputedVisualizationSettings,
+  Formatter,
+  RenderingContext,
+} from "metabase/visualizations/types";
+
+import type { PieChartFormatters } from "../format";
+import type { PieChartModel, PieSlice } from "../model/types";
+
+import { SUNBURST_SERIES_OPTION, TOTAL_GRAPHIC_OPTION } from "./constants";
+
+function getSliceByKey(key: string, slices: PieSlice[]) {
+  const slice = slices.find(s => s.key === key);
+  if (!slice) {
+    throw Error(
+      `Could not find slice with key ${key} in slices: ${JSON.stringify(
+        slices,
+      )}`,
+    );
+  }
+
+  return slice;
+}
+
+function getTotalGraphicOption(
+  total: number,
+  formatMetric: Formatter,
+  renderingContext: RenderingContext,
+) {
+  const graphicOption = cloneDeep(TOTAL_GRAPHIC_OPTION);
+
+  graphicOption.children.forEach(child => {
+    child.style.fontFamily = renderingContext.fontFamily;
+  });
+
+  graphicOption.children[0].style.text = formatMetric(Math.round(total));
+  graphicOption.children[0].style.fill = renderingContext.getColor("text-dark");
+
+  graphicOption.children[1].style.fill =
+    renderingContext.getColor("text-light");
+
+  return graphicOption;
+}
+
+export function getPieChartOption(
+  chartModel: PieChartModel,
+  formatters: PieChartFormatters,
+  settings: ComputedVisualizationSettings,
+  renderingContext: RenderingContext,
+): EChartsOption {
+  // "Show total" setting
+  const graphicOption = settings["pie.show_total"]
+    ? getTotalGraphicOption(
+        chartModel.total,
+        formatters.formatMetric,
+        renderingContext,
+      )
+    : undefined;
+
+  // "Show percentages: On the chart" setting
+  const seriesOption = cloneDeep(SUNBURST_SERIES_OPTION); // deep clone to avoid sharing label.formatter with other instances
+  if (!seriesOption.label) {
+    throw Error(`"seriesOption.label" is undefined`);
+  }
+  seriesOption.label.formatter = ({ name }) => {
+    if (settings["pie.percent_visibility"] !== "inside") {
+      return " ";
+    }
+
+    return formatters.formatPercent(
+      getSliceByKey(name, chartModel.slices).normalizedPercentage,
+    );
+  };
+
+  return {
+    textStyle: {
+      fontFamily: renderingContext.fontFamily,
+    },
+    graphic: graphicOption,
+    series: {
+      ...seriesOption,
+      data: chartModel.slices.map(s => ({
+        value: s.value,
+        name: s.key,
+        itemStyle: { color: s.color },
+        label: {
+          color: getTextColorForBackground(s.color, renderingContext.getColor),
+        },
+      })),
+    },
+  };
+}

--- a/frontend/src/metabase/visualizations/shared/constants.ts
+++ b/frontend/src/metabase/visualizations/shared/constants.ts
@@ -1,1 +1,0 @@
-export const DEFAULT_PIE_SLICE_THRESHOLD = 0.025; // approx 1 degree in percentage

--- a/frontend/src/metabase/visualizations/shared/settings/pie.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/pie.ts
@@ -1,8 +1,7 @@
 import { getColorsForValues } from "metabase/lib/colors/charts";
+import { SLICE_THRESHOLD } from "metabase/visualizations/echarts/pie/constants";
 import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
 import type { RawSeries } from "metabase-types/api";
-
-import { DEFAULT_PIE_SLICE_THRESHOLD } from "../constants";
 
 export const getDefaultShowLegend = () => true;
 
@@ -10,7 +9,7 @@ export const getDefaultShowTotal = () => true;
 
 export const getDefaultPercentVisibility = () => "legend";
 
-export const getDefaultSliceThreshold = () => DEFAULT_PIE_SLICE_THRESHOLD * 100;
+export const getDefaultSliceThreshold = () => SLICE_THRESHOLD * 100;
 
 export function getDefaultColors(
   rawSeries: RawSeries,

--- a/frontend/src/metabase/visualizations/visualizations/PieChart/PieChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/PieChart.jsx
@@ -11,6 +11,7 @@ import { color } from "metabase/lib/colors";
 import { getColorsForValues } from "metabase/lib/colors/charts";
 import { formatValue } from "metabase/lib/formatting";
 import EmbedFrameS from "metabase/public/components/EmbedFrame/EmbedFrame.module.css";
+import { SLICE_THRESHOLD } from "metabase/visualizations/echarts/pie/constants";
 import {
   ChartSettingsError,
   MinRowsError,
@@ -24,7 +25,6 @@ import {
   getFriendlyName,
   computeMaxDecimalsForValues,
 } from "metabase/visualizations/lib/utils";
-import { DEFAULT_PIE_SLICE_THRESHOLD } from "metabase/visualizations/shared/constants";
 import {
   getDefaultShowLegend,
   getDefaultPercentVisibility,
@@ -339,7 +339,7 @@ export default class PieChart extends Component {
     const sliceThreshold =
       typeof settings["pie.slice_threshold"] === "number"
         ? settings["pie.slice_threshold"] / 100
-        : DEFAULT_PIE_SLICE_THRESHOLD;
+        : SLICE_THRESHOLD;
 
     const [slices, others] = _.chain(rows)
       .map((row, index) => ({

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "leaflet": "^1.2.0",
     "leaflet-draw": "^0.4.9",
     "leaflet.heat": "^0.2.0",
+    "lodash.clonedeep": "^4.5.0",
     "lodash.debounce": "^4.0.8",
     "lodash.orderby": "^4.6.0",
     "moment-timezone": "^0.5.38",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15484,6 +15484,11 @@ lodash._topath@^3.0.0:
   dependencies:
     lodash.isarray "^3.0.0"
 
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==
+
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"


### PR DESCRIPTION
### Description

Creates the `chartModel` for the pie chart. Right now it's just logged, it will be used to render the chart in the next PR.

### Demo

![Screenshot 2024-06-03 at 2.37.55 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/d2a8f7fb-be04-4ed7-8e2f-c9ab7388d682.png)


![Screenshot 2024-06-03 at 3.07.32 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/b71f84e2-941c-4c68-949e-45bab3c84571.png)

