### PR TITLE
Amend stack values labels control copy

### DIFF
--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -369,7 +369,7 @@ export const GRAPH_DISPLAY_VALUES_SETTINGS = {
     props: {
       options: [
         { name: t`Total`, value: "total" },
-        { name: t`Insides`, value: "series" },
+        { name: t`Segments`, value: "series" },
         { name: t`Both`, value: "all" },
       ],
     },


### PR DESCRIPTION
https://metaboat.slack.com/archives/C064QMXEV9N/p1717425690572739

Changes copy of the viz setting control that lets users select which labels on stacked bar charts should be visible.

<img width="1127" alt="Screenshot 2024-06-03 at 8 31 41 PM" src="https://github.com/metabase/metabase/assets/14301985/9a353db3-cfbb-41ee-a48f-453b640f106d">
