### PR TITLE
[backport] Skip fingerprinting or scanning field values for fields with base_type=type/*

### DIFF
--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -214,6 +214,7 @@
        (and
         (not (contains? #{:retired :sensitive :hidden :details-only} (keyword visibility-type)))
         (not (isa? (keyword base-type) :type/Temporal))
+        (not (= (keyword base-type) :type/*))
         (#{:list :auto-list} (keyword has-field-values)))))))
 
 (defn take-by-length

--- a/src/metabase/sync/analyze/fingerprint.clj
+++ b/src/metabase/sync/analyze/fingerprint.clj
@@ -160,6 +160,7 @@
     [:not (mdb.u/isa :semantic_type :type/PK)]
     [:= :semantic_type nil]]
    [:not-in :visibility_type ["retired" "sensitive"]]
+   [:not= :base_type (u/qualified-name :type/*)]
    [:not (mdb.u/isa :base_type :type/Structured)]])
 
 (def ^:dynamic *refingerprint?*

--- a/test/metabase/models/field_values_test.clj
+++ b/test/metabase/models/field_values_test.clj
@@ -89,6 +89,12 @@
                                     {:base_type        :type/Time
                                      :has_field_values :list
                                      :visibility_type  :normal}
+                                    false}
+
+                                   "type/* fields should be excluded"
+                                   {{:has_field_values :list
+                                     :visibility_type  :normal
+                                     :base_type        :type/*}
                                     false}}
           [input expected] input->expected]
     (testing (str group "\n")

--- a/test/metabase/sync/analyze/fingerprint_test.clj
+++ b/test/metabase/sync/analyze/fingerprint_test.clj
@@ -38,6 +38,7 @@
               [:not (mdb.u/isa :semantic_type :type/PK)]
               [:= :semantic_type nil]]
              [:not-in :visibility_type ["retired" "sensitive"]]
+             [:not= :base_type "type/*"]
              [:not (mdb.u/isa :base_type :type/Structured)]
              [:or
               [:and
@@ -54,6 +55,7 @@
             [:not (mdb.u/isa :semantic_type :type/PK)]
             [:= :semantic_type nil]]
            [:not-in :visibility_type ["retired" "sensitive"]]
+           [:not= :base_type "type/*"]
            [:not (mdb.u/isa :base_type :type/Structured)]
            [:or
             [:and
@@ -76,6 +78,7 @@
               [:not (mdb.u/isa :semantic_type :type/PK)]
               [:= :semantic_type nil]]
              [:not-in :visibility_type ["retired" "sensitive"]]
+             [:not= :base_type "type/*"]
              [:not (mdb.u/isa :base_type :type/Structured)]
              [:or
               [:and
@@ -99,6 +102,7 @@
               [:not (mdb.u/isa :semantic_type :type/PK)]
               [:= :semantic_type nil]]
              [:not-in :visibility_type ["retired" "sensitive"]]
+             [:not= :base_type "type/*"]
              [:not (mdb.u/isa :base_type :type/Structured)]
              [:or
               [:and
@@ -127,6 +131,7 @@
                      [:not (mdb.u/isa :semantic_type :type/PK)]
                      [:= :semantic_type nil]]
                     [:not-in :visibility_type ["retired" "sensitive"]]
+                    [:not= :base_type "type/*"]
                     [:not (mdb.u/isa :base_type :type/Structured)]]}
            (binding [fingerprint/*refingerprint?* true]
              (#'fingerprint/honeysql-for-fields-that-need-fingerprint-updating))))))


### PR DESCRIPTION
Manual backport of https://github.com/metabase/metabase/pull/43483

Resolves this escalation: https://github.com/metabase/metabase/issues/43461

The merge conflicts were trivial name changes.