### PR TITLE
Update dead jetty docs links

### DIFF
--- a/docs/configuring-metabase/customizing-jetty-webserver.md
+++ b/docs/configuring-metabase/customizing-jetty-webserver.md
@@ -36,4 +36,4 @@ If you have an SSL certificate and would prefer to have Metabase run over HTTPS 
 
 Be sure to replace `path/to/keystore.jks` and `storepass` with the correct path to and password for your [Java KeyStore](https://www.digitalocean.com/community/tutorials/java-keytool-essentials-working-with-java-keystores). With the above settings applied you will be running Metabase on port 8443 over HTTPS using the supplied certificate.
 
-No idea how to generate a Java KeyStore yourself? This is sort of an advanced topic, but if you're feeling froggy you can read more about how to configure SSL in Jetty [in their own documentation](https://www.eclipse.org/jetty/documentation/jetty-9/index.html#configuring-ssl). Otherwise, you'll probably find it easiest to handle SSL termination outside of Metabase.
+No idea how to generate a Java KeyStore yourself? This is sort of an advanced topic, but if you're feeling froggy you can read more about how to configure SSL in Jetty [in their own documentation](https://jetty.org/docs/jetty/12/operations-guide/keystore/index.html). Otherwise, you'll probably find it easiest to handle SSL termination outside of Metabase.

--- a/docs/troubleshooting-guide/timeout.md
+++ b/docs/troubleshooting-guide/timeout.md
@@ -29,7 +29,7 @@ If you can’t solve your problem using the troubleshooting guides:
 - Search for [known bugs or limitations][known-issues].
 
 [app-engine-timeout]: https://cloud.google.com/appengine/articles/deadlineexceedederrors
-[configuring-jetty]: https://www.eclipse.org/jetty/documentation/current/#configuring-connectors
+[configuring-jetty]: https://jetty.org/docs/jetty/12/operations-guide/protocols/index.html
 [discourse]: https://discourse.metabase.com/
 [ec2-troubleshooting]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/TroubleshootingInstancesConnecting.html
 [elb-timeout]: https://aws.amazon.com/blogs/aws/elb-idle-timeout-control/


### PR DESCRIPTION
Example of a failed `markdown-link-check` job: [link](https://github.com/metabase/metabase/actions/runs/9363184012/job/25773407863?pr=43220)

Related Slack thread: [link](https://metaboat.slack.com/archives/C5XHN8GLW/p1717488857104699)

### Description

Looks like Jetty v9 docs are no longer available, see https://jetty.org/docs/index.html

Dead links:
1. https://www.eclipse.org/jetty/documentation/jetty-9/index.html#configuring-ssl ([archive.org](https://web.archive.org/web/20190330174612/http://www.eclipse.org/jetty/documentation/current/configuring-ssl.html))
2. https://www.eclipse.org/jetty/documentation/current/#configuring-connectors ([archive.org](https://web.archive.org/web/20190330174758/http://www.eclipse.org/jetty/documentation/current/configuring-connectors.html))

New links:
1. https://jetty.org/docs/jetty/12/operations-guide/keystore/index.html
2. https://jetty.org/docs/jetty/12/operations-guide/protocols/index.html

We'll need to backport this as far as v48.

### How to verify

New links make sense.
CI is green.