### PR TITLE
fix(sdk): Fix static dashboard API

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/public/StaticDashboard/StaticDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/StaticDashboard/StaticDashboard.tsx
@@ -9,34 +9,33 @@ import {
   useEmbedTheme,
   useRefreshDashboard,
 } from "metabase/dashboard/hooks";
+import { useEmbedFont } from "metabase/dashboard/hooks/use-embed-font";
 import type { EmbedDisplayParams } from "metabase/dashboard/types";
 import { isNotNull } from "metabase/lib/types";
 import { PublicOrEmbeddedDashboard } from "metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboard";
 import { Box } from "metabase/ui";
 import type { DashboardId } from "metabase-types/api";
 
+type StaticDashboardProps = {
+  dashboardId: DashboardId;
+  withTitle: boolean;
+  withDownloads: boolean;
+  hideParameters: string[];
+  initialParameterValues: Query;
+};
+
 const _StaticDashboard = ({
   dashboardId,
-  parameterQueryParams = {},
-  bordered,
-  titled,
-  theme: userTheme,
-  font,
-  hideDownloadButton,
+  initialParameterValues: parameterQueryParams = {},
+  withTitle: titled,
+  withDownloads: hideDownloadButton,
   hideParameters,
-}: {
-  dashboardId: DashboardId;
-  parameterQueryParams?: Query;
-  hideParameters?: string[];
-} & Partial<Omit<EmbedDisplayParams, "hideParameters">>) => {
+}: StaticDashboardProps) => {
   const options: EmbedDisplayParams = {
     ...DEFAULT_EMBED_DISPLAY_OPTIONS,
     ...pick(
       {
-        bordered,
         titled,
-        theme: userTheme,
-        font,
         hideDownloadButton,
         hideParameters: hideParameters ? hideParameters.join(",") : null,
       },
@@ -55,27 +54,29 @@ const _StaticDashboard = ({
     });
 
   const { hasNightModeToggle, isNightMode, onNightModeChange, theme } =
-    useEmbedTheme(options.theme);
+    useEmbedTheme();
+
+  const { font } = useEmbedFont();
 
   return (
     <Box ref={ref} style={{ overflow: "auto" }}>
       <PublicOrEmbeddedDashboard
         dashboardId={dashboardId}
         parameterQueryParams={parameterQueryParams}
-        bordered={options.bordered}
-        font={options.font}
         hasNightModeToggle={hasNightModeToggle}
         hideDownloadButton={options.hideDownloadButton}
         hideParameters={options.hideParameters}
         isNightMode={isNightMode}
         onNightModeChange={onNightModeChange}
-        theme={theme}
         titled={options.titled}
+        theme={theme}
         isFullscreen={isFullscreen}
         onFullscreenChange={onFullscreenChange}
         refreshPeriod={refreshPeriod}
         onRefreshPeriodChange={onRefreshPeriodChange}
         setRefreshElapsedHook={setRefreshElapsedHook}
+        font={font}
+        bordered={options.bordered}
       />
     </Box>
   );

--- a/enterprise/frontend/src/embedding-sdk/components/public/StaticDashboard/StaticDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/StaticDashboard/StaticDashboard.tsx
@@ -18,26 +18,29 @@ import type { DashboardId } from "metabase-types/api";
 
 type StaticDashboardProps = {
   dashboardId: DashboardId;
-  withTitle: boolean;
-  withDownloads: boolean;
-  hideParameters: string[];
-  initialParameterValues: Query;
+  withTitle?: boolean;
+  withDownloads?: boolean;
+  hiddenParameters?: string[];
+  initialParameterValues?: Query;
 };
 
 const _StaticDashboard = ({
   dashboardId,
   initialParameterValues: parameterQueryParams = {},
-  withTitle: titled,
-  withDownloads: hideDownloadButton,
-  hideParameters,
+  withTitle: titled = true,
+  withDownloads = true,
+  hiddenParameters = [],
 }: StaticDashboardProps) => {
+  // temporary name until we change `hideDownloadButton` to `downloads`
+  const hideDownloadButton = !withDownloads;
+
   const options: EmbedDisplayParams = {
     ...DEFAULT_EMBED_DISPLAY_OPTIONS,
     ...pick(
       {
         titled,
         hideDownloadButton,
-        hideParameters: hideParameters ? hideParameters.join(",") : null,
+        hideParameters: hiddenParameters.join(",") ?? null,
       },
       isNotNull,
     ),

--- a/frontend/src/metabase/dashboard/hoc/DashboardControls.tsx
+++ b/frontend/src/metabase/dashboard/hoc/DashboardControls.tsx
@@ -1,5 +1,5 @@
 import type { ComponentType } from "react";
-import { memo, useEffect } from "react";
+import { memo } from "react";
 
 import { useSyncURLSlug } from "metabase/dashboard/components/DashboardTabs/use-sync-url-slug";
 import {
@@ -7,8 +7,6 @@ import {
   useDashboardUrlParams,
   useRefreshDashboard,
 } from "metabase/dashboard/hooks";
-import { useDispatch } from "metabase/lib/redux";
-import { setOptions } from "metabase/redux/embed";
 
 import type {
   DashboardControlsPassedProps,
@@ -29,8 +27,6 @@ export const DashboardControls = <T extends DashboardControlsProps>(
     location,
     ...props
   }: DashboardControlsProps) {
-    const dispatch = useDispatch();
-
     const parameterQueryParams = location.query;
 
     const { refreshDashboard } = useRefreshDashboard({
@@ -64,14 +60,6 @@ export const DashboardControls = <T extends DashboardControlsProps>(
     useDashboardNav({ isFullscreen });
 
     useSyncURLSlug({ location });
-
-    useEffect(() => {
-      dispatch(
-        setOptions({
-          font: font ?? undefined,
-        }),
-      );
-    }, [dispatch, font, location]);
 
     return (
       <ComposedComponent

--- a/frontend/src/metabase/dashboard/hooks/use-embed-display-options.ts
+++ b/frontend/src/metabase/dashboard/hooks/use-embed-display-options.ts
@@ -1,5 +1,6 @@
 import { useState } from "react";
 
+import { useEmbedFont } from "metabase/dashboard/hooks/use-embed-font";
 import { useEmbedTheme } from "metabase/dashboard/hooks/use-embed-theme";
 import { isWithinIframe } from "metabase/lib/dom";
 
@@ -22,10 +23,12 @@ export const useEmbedDisplayOptions = (): EmbedDisplayControls => {
   const [hideDownloadButton, setHideDownloadButton] = useState(
     DEFAULT_EMBED_DISPLAY_OPTIONS.hideDownloadButton,
   );
-  const [font, setFont] = useState(DEFAULT_EMBED_DISPLAY_OPTIONS.font);
   const [hideParameters, setHideParameters] = useState(
     DEFAULT_EMBED_DISPLAY_OPTIONS.hideParameters,
   );
+
+  const { font, setFont } = useEmbedFont();
+
   const {
     hasNightModeToggle,
     isNightMode,

--- a/frontend/src/metabase/dashboard/hooks/use-embed-font.ts
+++ b/frontend/src/metabase/dashboard/hooks/use-embed-font.ts
@@ -1,0 +1,28 @@
+import { useCallback, useEffect } from "react";
+
+import type { EmbedFont } from "metabase/dashboard/types";
+import { useDispatch, useSelector } from "metabase/lib/redux";
+import { setOptions } from "metabase/redux/embed";
+import { getFont } from "metabase/styled-components/selectors";
+
+export const useEmbedFont = () => {
+  const font = useSelector(getFont);
+
+  const dispatch = useDispatch();
+  const setFont = useCallback(
+    (font: EmbedFont) => {
+      dispatch(
+        setOptions({
+          font: font ?? undefined,
+        }),
+      );
+    },
+    [dispatch],
+  );
+
+  useEffect(() => {
+    setFont(font);
+  }, [font, setFont]);
+
+  return { font, setFont };
+};


### PR DESCRIPTION
Closes #43463

Changes Static Dashboard props to:
```
type StaticDashboardProps = {
  dashboardId: DashboardId;
  withTitle?: boolean; // = true
  withDownloads?: boolean; // = true
  hiddenParameters?: string[]; // = []
  initialParameterValues?: Query; // = {}
};
```


Also changes `font` usage to use the value from the redux store, rather than a user-passed prop. This will help us with using fonts with global theming.