### PR TITLE
remove modified padding on ellipsifyed sidebar items

### DIFF
--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarItems.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarItems.styled.tsx
@@ -119,7 +119,6 @@ const ITEM_NAME_LABEL_WIDTH = Math.round(parseInt(NAV_SIDEBAR_WIDTH, 10) * 0.7);
 
 export const ItemName = styled(TreeNode.NameContainer)`
   width: ${ITEM_NAME_LABEL_WIDTH}px;
-  padding: 6px 3px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/42877

### Description
Removes overwritten padding on sidebar items that have tooltips, making them consistent with other items in the list

### How to verify

1. Add 2 items to your bookmark list, one with a short name, and one with a long enough name to be ellipsisified (over 35 characters).
2. Hover over each and examine their heights

### Demo
![chrome_22zPgq7lZa](https://github.com/metabase/metabase/assets/1328979/3510b678-67ae-4189-922e-2c161ffe8eb5)

