### PR TITLE
Only do SQL parsing for supported drivers

### DIFF
--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -4,6 +4,11 @@ title: Driver interface changelog
 
 # Driver Interface Changelog
 
+## Metabase 0.50.1
+
+- New feature `:native-parsing` has been added, defaulting to disabled. Drivers that enable it are expected to work with
+  the `metabase.native-query-analyzer` machinery.
+
 ## Metabase 0.50.0
 
 - The Metabase `metabase.mbql.*` namespaces have been moved to `metabase.legacy-mbql.*`. You probably didn't need to

--- a/modules/drivers/sqlite/src/metabase/driver/sqlite.clj
+++ b/modules/drivers/sqlite/src/metabase/driver/sqlite.clj
@@ -29,19 +29,20 @@
 (driver/register! :sqlite, :parent :sql-jdbc)
 
 ;; SQLite does not support a lot of features, so do not show the options in the interface
-(doseq [[feature supported?] {:right-join                             false
-                              :full-join                              false
-                              :regex                                  false
-                              :percentile-aggregations                false
-                              :advanced-math-expressions              false
-                              :standard-deviation-aggregations        false
-                              :schemas                                false
-                              :datetime-diff                          true
-                              :now                                    true
+(doseq [[feature supported?] {:advanced-math-expressions              false
                               ;; SQLite `LIKE` clauses are case-insensitive by default, and thus cannot be made case-sensitive. So let people know
                               ;; we have this 'feature' so the frontend doesn't try to present the option to you.
                               :case-sensitivity-string-filter-options false
-                              :index-info                             true}]
+                              :datetime-diff                          true
+                              :full-join                              false
+                              :index-info                             true
+                              :native-parsing                         true
+                              :now                                    true
+                              :percentile-aggregations                false
+                              :regex                                  false
+                              :right-join                             false
+                              :schemas                                false
+                              :standard-deviation-aggregations        false}]
   (defmethod driver/database-supports? [:sqlite feature] [_driver _feature _db] supported?))
 
 ;; HACK SQLite doesn't support ALTER TABLE ADD CONSTRAINT FOREIGN KEY and I don't have all day to work around this so

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -36,6 +36,7 @@
                               :convert-timezone                       true
                               :datetime-diff                          true
                               :index-info                             true
+                              :native-parsing                         true
                               :now                                    true
                               :regex                                  false
                               :test/jvm-timezone-setting              false}]

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -608,6 +608,10 @@
     ;; DEFAULTS TO TRUE
     :upload-with-auto-pk
 
+    ;; Can we parse native queries to power the query validator, find-and-replace, etc?
+    ;; DEFAULTS TO FALSE
+    :native-parsing
+
     ;; Does the driver support fingerprint the fields. Default is true
     :fingerprint
 
@@ -653,14 +657,15 @@
 (defmethod database-supports?
   :default [_driver _feature _] false)
 
-(doseq [[feature supported?] {:convert-timezone                       false
-                              :basic-aggregations                     true
+(doseq [[feature supported?] {:basic-aggregations                     true
                               :case-sensitivity-string-filter-options true
+                              :convert-timezone                       false
                               :date-arithmetics                       true
-                              :temporal-extract                       true
-                              :schemas                                true
-                              :test/jvm-timezone-setting              true
                               :fingerprint                            true
+                              :native-parsing                         false
+                              :schemas                                true
+                              :temporal-extract                       true
+                              :test/jvm-timezone-setting              true
                               :upload-with-auto-pk                    true}]
   (defmethod database-supports? [::driver feature] [_driver _feature _db] supported?))
 

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -71,6 +71,7 @@
                               :full-join                 false
                               :index-info                true
                               :now                       true
+                              :native-parsing            true
                               :percentile-aggregations   false
                               :regex                     true
                               :test/jvm-timezone-setting false

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -61,6 +61,7 @@
                               :datetime-diff                          true
                               :full-join                              false
                               :index-info                             true
+                              :native-parsing                         true
                               :now                                    true
                               :percentile-aggregations                false
                               :persist-models                         true

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -64,6 +64,7 @@
 (doseq [[feature supported?] {:connection-impersonation true
                               :convert-timezone         true
                               :datetime-diff            true
+                              :native-parsing           true
                               :now                      true
                               :persist-models           true
                               :schemas                  true

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -14,7 +14,7 @@
    [metabase.compatibility :as compatibility]
    [metabase.config :as config]
    [metabase.db.query :as mdb.query]
-   [metabase.driver :as driver]
+   [metabase.driver.util :as driver.u]
    [metabase.email.messages :as messages]
    [metabase.events :as events]
    [metabase.legacy-mbql.normalize :as mbql.normalize]
@@ -949,7 +949,7 @@ saved later when it is ready."
                     {:card card :replacements replacements}))
     (let [db (t2/select-one :model/Database :id db-id)]
       (if (or (nil? db)
-              (not (driver/database-supports? (:engine db) :native-parsing db)))
+              (not (driver.u/supports? (:engine db) :native-parsing db)))
         (throw (ex-info "Attempted to replace fields in a card using an unspported engine" {:card card :engine (:engine db)}))
         (let [new-query (assoc-in q [:native :query]
                                   (replaced-inner-query-for-native-card q replacements))]

--- a/src/metabase/models/query_field.clj
+++ b/src/metabase/models/query_field.clj
@@ -1,6 +1,6 @@
 (ns metabase.models.query-field
   (:require
-   [metabase.driver :as driver]
+   [metabase.driver.util :as driver.u]
    [metabase.legacy-mbql.util :as mbql.u]
    [metabase.lib.core :as lib]
    [metabase.lib.util :as lib.util]
@@ -26,7 +26,7 @@
   (case (lib/normalized-query-type query)
     :native     (try
                   (when-let [db (t2/select-one :model/Database :id db-id)]
-                    (when (driver/database-supports? (:engine db) :native-parsing db)
+                    (when (driver.u/supports? (:engine db) :native-parsing db)
                       (query-analyzer/field-ids-for-sql query)))
                   (catch Exception e
                     (log/error e "Error parsing SQL" query)))

--- a/src/metabase/native_query_analyzer.clj
+++ b/src/metabase/native_query_analyzer.clj
@@ -142,7 +142,7 @@
 
 (def ^:private considered-drivers
   "Since we are unable to ask basic questions of the driver hierarchy outside of that module, we need to repeat"
-  #{:mysql :sqlserver :h2 :sqlite :postgres :redshift})
+  #{:h2 :mysql :postgres :redshift :sqlite :sqlserver})
 
 (defn- macaw-options
   "Generate the options expected by Macaw based on the nature of the given driver."

--- a/test/metabase/models/query_field_test.clj
+++ b/test/metabase/models/query_field_test.clj
@@ -153,11 +153,11 @@
                                                        :condition    [:= $checkins.venue_id $venues.id]}]})}]
       (mt/$ids
         (is (= {:direct #{%venues.name %venues.price}}
-               (#'query-field/query-field-ids (:dataset_query c1))))
+               (#'query-field/query-field-ids c1)))
         (is (= {:direct nil}
-               (#'query-field/query-field-ids (:dataset_query c2))))
+               (#'query-field/query-field-ids c2)))
         (is (= {:direct #{%venues.id %checkins.venue_id}}
-               (#'query-field/query-field-ids (:dataset_query c3)))))))
+               (#'query-field/query-field-ids c3))))))
   (testing "Parsing pMBQL query returns correct used fields"
     (let [metadata-provider (lib.metadata.jvm/application-database-metadata-provider (mt/id))
           venues            (lib.metadata/table metadata-provider (mt/id :venues))
@@ -165,4 +165,4 @@
           mlv2-query        (-> (lib/query metadata-provider venues)
                                 (lib/aggregate (lib/distinct venues-name)))]
       (is (= {:direct #{(mt/id :venues :name)}}
-               (#'query-field/query-field-ids mlv2-query))))))
+             (#'query-field/query-field-ids {:dataset_query mlv2-query}))))))

--- a/test/metabase/native_query_analyzer_test.clj
+++ b/test/metabase/native_query_analyzer_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase.db.connection :as mdb.connection]
+   [metabase.driver :as driver]
    [metabase.native-query-analyzer :as query-analyzer]
    [metabase.public-settings :as public-settings]
    [metabase.test :as mt]))
@@ -65,3 +66,10 @@
         (is (= 6
                (-> (q "select v.* from venues v join checkins")
                    :indirect count)))))))
+
+(deftest ^:parallel driver-support-test
+  (testing "We only support parsing queries for certain drivers"
+    (doseq [supported-driver #{:h2 :mysql :postgres :redshift :sqlite :sqlserver}]
+      (is (driver/database-supports? supported-driver :native-parsing nil)))
+    (doseq [unsupported-driver #{:mongo :snowflake}]
+      (is (not (driver/database-supports? unsupported-driver :native-parsing nil))))))


### PR DESCRIPTION
[Fixes #43516]

I had the debate of whether I put this in the "client" code (QueryField/Card/whatever) or in native-query-analyzer. I opted for the former since I don't want NQA calling driver methods?