### PR TITLE
feat(sdk): SDK theming part 3 - brand, brand-light, brand-lighter

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -12,5 +12,7 @@
     --mb-color-bg-night: #42484e;
     --mb-color-bg-white: #fff;
     --mb-color-border: #eeecec;
+    --mb-color-brand-light: #f9fbfc;
+    --mb-color-brand-lighter: #eef6fc;
   }
 </style>

--- a/docs/developers-guide/frontend.md
+++ b/docs/developers-guide/frontend.md
@@ -362,7 +362,7 @@ When dealing with business logic you don't want to be concerned with the specifi
 
 ```css
 .Button.Button--primary {
-  color: -var(--color-brand);
+  color: -var(--mb-olor-brand);
 }
 ```
 
@@ -370,7 +370,7 @@ When dealing with business logic you don't want to be concerned with the specifi
 
 ```css
 .text-brand {
-  color: -var(--color-brand);
+  color: -var(--mb-color-brand);
 }
 ```
 
@@ -389,7 +389,7 @@ const Foo = ({ color ) =>
 
 ```css
 :local(.primary) {
-  color: -var(--color-brand);
+  color: -var(--mb-color-brand);
 }
 ```
 

--- a/docs/developers-guide/frontend.md
+++ b/docs/developers-guide/frontend.md
@@ -362,7 +362,7 @@ When dealing with business logic you don't want to be concerned with the specifi
 
 ```css
 .Button.Button--primary {
-  color: -var(--mb-olor-brand);
+  color: -var(--mb-color-brand);
 }
 ```
 

--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkContentWrapper.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkContentWrapper.tsx
@@ -37,6 +37,8 @@ const SdkContentWrapperInner = styled.div<
   --mb-color-bg-light: ${({ theme }) => theme.fn.themeColor("bg-light")};
   --mb-color-bg-dark: ${({ theme }) => theme.fn.themeColor("bg-dark")};
   --mb-color-brand: ${({ theme }) => theme.fn.themeColor("brand")};
+  --mb-color-brand-light: ${({ theme }) =>
+    lighten(theme.fn.themeColor("brand"), 0.532)};
   --mb-color-brand-lighter: ${({ theme }) =>
     lighten(theme.fn.themeColor("brand"), 0.598)};
   --mb-color-brand-alpha-04: ${({ theme }) =>

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditTableVisualization/AuditTableVisualization.styled.tsx
@@ -11,12 +11,12 @@ interface HeaderCellProps {
 
 export const HeaderCell = styled.th<HeaderCellProps>`
   cursor: ${props => props.isSortable && "pointer"};
-  color: ${props => props.isSortedByColumn && color("brand")};
+  color: ${props => props.isSortedByColumn && "var(--mb-color-brand)"};
   text-align: ${props => props.isRightAligned && "right"};
   white-space: nowrap;
 
   &:hover {
-    color: ${props => props.isSortable && color("brand")};
+    color: ${props => props.isSortable && "var(--mb-color-brand)"};
   }
 `;
 
@@ -26,7 +26,7 @@ interface RowCellProps {
 }
 
 export const RowCell = styled.td<RowCellProps>`
-  color: ${props => props.isClickable && color("brand")};
+  color: ${props => props.isClickable && "var(--mb-color-brand)"};
   cursor: ${props => props.isClickable && "pointer"};
   text-align: ${props => props.isRightAligned && "right"};
 `;

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/CacheTTLField/CacheTTLField.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/CacheTTLField/CacheTTLField.styled.tsx
@@ -28,7 +28,7 @@ export const Input = styled(NumericInput)`
 
   :focus,
   :hover {
-    border-color: ${color("brand")};
+    border-color: var(--mb-color-brand);
   }
 
   transition: border 300ms ease-in-out;

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/SidebarCacheSection.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/SidebarCacheSection.styled.tsx
@@ -1,7 +1,6 @@
 import styled from "@emotion/styled";
 import type { AnchorHTMLAttributes } from "react";
 
-import { color } from "metabase/lib/colors";
 import type { AnchorProps } from "metabase/ui";
 import { Anchor } from "metabase/ui";
 
@@ -11,7 +10,7 @@ export const FormLauncher = styled(Anchor)<
   font-weight: bold;
   &:hover,
   &:active {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
     text-decoration: none;
   }
 `;

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyFormLauncher.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyFormLauncher.styled.tsx
@@ -21,7 +21,7 @@ export const PolicyToken = styled(Button)<
   ${({ variant }) =>
     css`
       border-color: ${["filled", "outline"].includes(variant || "")
-        ? color("brand")
+        ? "var(--mb-color-brand)"
         : "var(--mb-color-border)"} !important;
     `};
   span {
@@ -53,7 +53,7 @@ export const StyledLauncher = styled(Flex)<
   ${({ variant }) =>
     css`
       border-color: ${["filled", "outline"].includes(variant || "")
-        ? color("brand")
+        ? "var(--mb-color-brand)"
         : "var(--mb-color-border)"} !important;
     `};
   font-weight: ${({ forRoot, inheritsRootStrategy }) =>

--- a/enterprise/frontend/src/metabase-enterprise/hosting/components/SettingsCloudStoreLink/SettingsCloudStoreLink.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/hosting/components/SettingsCloudStoreLink/SettingsCloudStoreLink.styled.tsx
@@ -14,7 +14,7 @@ export const Link = styled(ExternalLink)`
   align-items: center;
   color: ${color("text-white")};
   font-weight: bold;
-  background-color: ${color("brand")};
+  background-color: var(--mb-color-brand);
   padding: 12px 18px;
   border-radius: 6px;
 

--- a/enterprise/frontend/src/metabase-enterprise/license/components/BillingInfo/BillingInfo.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/license/components/BillingInfo/BillingInfo.styled.tsx
@@ -25,7 +25,7 @@ export const BillingInfoRowContainer = styled.div<{ extraPadding?: boolean }>`
 const linkStyles = css`
   display: inline-flex;
   align-items: center;
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
 `;
 
 export const BillingInternalLink = styled(Link)(linkStyles);
@@ -38,7 +38,7 @@ export const BillingExternalLinkIcon = styled(Icon)`
 
 export const StoreButtonLink = styled(ExternalLink)`
   display: inline-flex;
-  background-color: ${color("brand")};
+  background-color: var(--mb-color-brand);
   color: ${color("text-white")};
   align-items: center;
   font-weight: bold;

--- a/enterprise/frontend/src/metabase-enterprise/llm_autodescription/LLMSuggestQuestionInfo.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/llm_autodescription/LLMSuggestQuestionInfo.tsx
@@ -45,7 +45,7 @@ export const LLMSuggestQuestionInfo = ({
     : t`Description generated. Click to auto-fill.`;
 
   const className = loading ? "llm-pulse-icon" : undefined;
-  const iconColor = loading ? color("text-medium") : color("brand");
+  const iconColor = loading ? color("text-medium") : "var(--mb-color-brand)";
 
   return (
     <Tooltip label={tooltip} position="top-end">

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ChartColorSettings/ChartColorSettings.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ChartColorSettings/ChartColorSettings.styled.tsx
@@ -24,12 +24,12 @@ export const TableTitle = styled.div`
 
 export const TableLink = styled.div`
   display: inline-block;
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   font-weight: bold;
   cursor: pointer;
 
   &:hover {
-    color: ${darken("brand", 0.12)};
+    color: ${() => darken("brand", 0.12)};
   }
 `;
 

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ImageUpload/ImageUpload.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ImageUpload/ImageUpload.styled.tsx
@@ -16,7 +16,7 @@ export const FileInput = styled.input`
   }
 
   &::file-selector-button:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
     background-color: var(--mb-color-bg-light);
   }
 `;

--- a/frontend/src/metabase/actions/components/ActionViz/ExplainerText/ExplainerText.styled.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ExplainerText/ExplainerText.styled.tsx
@@ -13,5 +13,5 @@ export const ExplainerTextContainer = styled.p`
 
 export const BrandLinkWithLeftMargin = styled(ExternalLink)`
   margin-left: ${space(1)};
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
 `;

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/EmptyFormPlaceholder/EmptyFormPlaceholder.styled.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/EmptyFormPlaceholder/EmptyFormPlaceholder.styled.tsx
@@ -40,10 +40,10 @@ export const ExplainerLink = styled(ExternalLink)`
   font-weight: 700;
   margin-top: ${space(2)};
 
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
 
   &:hover {
-    color: ${lighten("brand", 0.1)};
+    color: ${() => lighten("brand", 0.1)};
   }
 `;
 
@@ -51,7 +51,7 @@ export const IconContainer = styled.div`
   display: inline-block;
   padding: 1.25rem;
   position: relative;
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   align-self: center;
 `;
 

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.styled.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.styled.tsx
@@ -36,6 +36,6 @@ export const ToggleContainer = styled.div`
 export const SettingsTriggerIcon = styled(Icon)`
   color: ${color("text-medium")};
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/actions/containers/ActionPicker/ActionOptionItem.styled.tsx
+++ b/frontend/src/metabase/actions/containers/ActionPicker/ActionOptionItem.styled.tsx
@@ -12,7 +12,7 @@ export const ActionOptionListItem = styled.div<ActionOptionProps>`
   color: ${props =>
     props.isSelected ? color("text-white") : color("text-normal")};
   background-color: ${props =>
-    props.isSelected ? color("brand") : color("white")};
+    props.isSelected ? "var(--mb-color-brand)" : color("white")};
   cursor: pointer;
 
   display: flex;
@@ -26,7 +26,7 @@ export const ActionOptionListItem = styled.div<ActionOptionProps>`
   margin: ${space(1)} ${space(0)};
 
   &:hover {
-    background-color: ${lighten("brand", 0.1)};
+    background-color: ${() => lighten("brand", 0.1)};
     color: ${color("text-white")};
   }
 `;

--- a/frontend/src/metabase/actions/containers/ActionPicker/ActionPicker.styled.tsx
+++ b/frontend/src/metabase/actions/containers/ActionPicker/ActionPicker.styled.tsx
@@ -18,7 +18,7 @@ export const ActionsList = styled.ul`
 export const ActionItem = styled.li<{ isSelected?: boolean }>`
   display: flex;
   font-weight: bold;
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   justify-content: space-between;
   padding: 0.5rem 0.75rem;
   margin-bottom: 1px;
@@ -26,10 +26,10 @@ export const ActionItem = styled.li<{ isSelected?: boolean }>`
   cursor: pointer;
 
   ${({ isSelected }) =>
-    isSelected ? `background-color: ${alpha("brand", 0.2)};` : ""}
+    isSelected ? `background-color: ${() => alpha("brand", 0.2)};` : ""}
 
   &:hover {
-    background-color: ${alpha("brand", 0.35)};
+    background-color: ${() => alpha("brand", 0.35)};
   }
 `;
 

--- a/frontend/src/metabase/actions/containers/ActionPicker/ActionPicker.styled.tsx
+++ b/frontend/src/metabase/actions/containers/ActionPicker/ActionPicker.styled.tsx
@@ -1,3 +1,4 @@
+import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 
 import CollapseSection from "metabase/components/CollapseSection";
@@ -25,8 +26,11 @@ export const ActionItem = styled.li<{ isSelected?: boolean }>`
   border-radius: ${space(0)};
   cursor: pointer;
 
-  ${({ isSelected }) =>
-    isSelected ? `background-color: ${() => alpha("brand", 0.2)};` : ""}
+  ${({ isSelected, theme }) =>
+    isSelected &&
+    css`
+      background-color: ${alpha(theme.fn.themeColor("brand"), 0.2)};
+    `}
 
   &:hover {
     background-color: ${() => alpha("brand", 0.35)};

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/ModelCachingControl/ModelCachingControl.styled.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/ModelCachingControl/ModelCachingControl.styled.tsx
@@ -13,7 +13,7 @@ export const ControlContainer = styled.div`
 export const HoverableIcon = styled(Icon)`
   cursor: pointer;
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 

--- a/frontend/src/metabase/admin/databases/containers/DatabaseListApp.styled.tsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseListApp.styled.tsx
@@ -10,7 +10,7 @@ export const TableCellContent = styled.div`
 `;
 
 export const TableCellSpinner = styled(LoadingSpinner)`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   margin-right: ${space(1)};
 `;
 
@@ -19,6 +19,6 @@ export const AddSampleDatabaseLink = styled.a`
   text-decoration: none;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/admin/datamodel/components/FilterPopover/FilterPopover.styled.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/FilterPopover/FilterPopover.styled.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 
 import BaseButton from "metabase/core/components/Button";
-import { color, alpha } from "metabase/lib/colors";
+import { alpha } from "metabase/lib/colors";
 
 type Props = {
   primaryColor?: string;

--- a/frontend/src/metabase/admin/datamodel/components/FilterPopover/FilterPopover.styled.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/FilterPopover/FilterPopover.styled.tsx
@@ -9,14 +9,16 @@ type Props = {
 
 export const Button = styled(BaseButton)<Props>`
   color: white;
-  border-color: ${({ primaryColor = color("brand") }) => primaryColor};
-  background-color: ${({ primaryColor = color("brand") }) => primaryColor};
+  border-color: ${({ primaryColor = "var(--mb-color-brand)" }) => primaryColor};
+  background-color: ${({ primaryColor = "var(--mb-color-brand)" }) =>
+    primaryColor};
 
   &:hover,
   &:focus {
     color: white;
-    border-color: ${({ primaryColor = color("brand") }) => primaryColor};
-    background-color: ${({ primaryColor = color("brand") }) =>
+    border-color: ${({ primaryColor = "var(--mb-color-brand)" }) =>
+      primaryColor};
+    background-color: ${({ primaryColor = "var(--mb-color-brand)" }) =>
       alpha(primaryColor, 0.8)};
   }
 `;

--- a/frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.styled.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.styled.tsx
@@ -11,7 +11,7 @@ export const ActionLink = styled(Link)`
 
   &:hover {
     color: ${color("white")};
-    background-color: ${color("brand")};
+    background-color: var(--mb-color-brand);
   }
 `;
 
@@ -19,6 +19,6 @@ export const TriggerIconContainer = styled.span`
   color: ${color("text-light")};
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/DatePickerFooter.styled.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/DatePickerFooter.styled.tsx
@@ -26,7 +26,7 @@ export const ToggleButton = styled(Button)<ToggleButtonProps>`
   font-weight: normal;
 
   &:hover {
-    color: ${props => `${props.primaryColor || color("brand")}`};
+    color: ${props => `${props.primaryColor || "var(--mb-color-brand)"}`};
     background: none;
   }
 `;

--- a/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/DatePickerHeader.styled.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/DatePickerHeader.styled.tsx
@@ -23,16 +23,17 @@ export const TabButton = styled(Button)<TabButtonProps>`
   padding-right: 0;
   margin-left: ${space(2)};
   margin-right: ${space(2)};
-  border-bottom: ${({ primaryColor = color("brand"), selected }) =>
+  border-bottom: ${({ primaryColor = "var(--mb-color-brand)", selected }) =>
     selected ? `2px solid ${primaryColor}` : "2px solid transparent"};
 
-  color: ${({ primaryColor = color("brand"), selected }) =>
+  color: ${({ primaryColor = "var(--mb-color-brand)", selected }) =>
     selected ? primaryColor : color("text-medium")};
 
   &:hover {
     background: none;
-    color: ${({ primaryColor = color("brand") }) => primaryColor};
-    border-color: ${({ primaryColor = color("brand") }) => primaryColor};
+    color: ${({ primaryColor = "var(--mb-color-brand)" }) => primaryColor};
+    border-color: ${({ primaryColor = "var(--mb-color-brand)" }) =>
+      primaryColor};
   }
 `;
 

--- a/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/DatePickerShortcuts.styled.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/DatePickerShortcuts.styled.tsx
@@ -11,7 +11,7 @@ export const ShortcutButton = styled(Button)<ShortcutButtonProps>`
   display: block;
   border: none;
   &:hover {
-    color: ${props => props.primaryColor || color("brand")};
+    color: ${props => props.primaryColor || "var(--mb-color-brand)"};
     background: none;
   }
 `;

--- a/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/ExcludeDatePicker.styled.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/ExcludeDatePicker.styled.tsx
@@ -12,11 +12,11 @@ type OptionButtonProps = {
 
 export const OptionButton = styled(Button)<OptionButtonProps>`
   display: block;
-  color: ${({ primaryColor = color("brand"), selected }) =>
+  color: ${({ primaryColor = "var(--mb-color-brand)", selected }) =>
     selected ? primaryColor : undefined};
   border: none;
   &:hover {
-    color: ${props => props.primaryColor || color("brand")};
+    color: ${props => props.primaryColor || "var(--mb-color-brand)"};
     background: none;
   }
 `;

--- a/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/HoursMinutesInput.styled.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/HoursMinutesInput.styled.tsx
@@ -1,13 +1,11 @@
 import styled from "@emotion/styled";
 
-import { color } from "metabase/lib/colors";
-
 export interface AmPmLabelProps {
   isSelected: boolean;
 }
 
 export const AmPmLabel = styled.span<AmPmLabelProps>`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   font-weight: 900;
   margin-right: 0.5rem;
   cursor: pointer;

--- a/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/SpecificDatePicker.styled.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/SpecificDatePicker.styled.tsx
@@ -1,7 +1,5 @@
 import styled from "@emotion/styled";
 
-import { color } from "metabase/lib/colors";
-
 interface DateInputContainerProps {
   isActive?: boolean;
 }
@@ -13,6 +11,6 @@ export const DateInputContainer = styled.div<DateInputContainerProps>`
   margin-bottom: 1rem;
 
   &:focus-within {
-    border-color: ${color("brand")};
+    border-color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/admin/datamodel/components/revisions/RevisionDiff.styled.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/revisions/RevisionDiff.styled.tsx
@@ -4,7 +4,7 @@ import { color } from "metabase/lib/colors";
 import { Icon } from "metabase/ui";
 
 export const EditIcon = styled(Icon)`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
 `;
 
 export const ErrorIcon = styled(Icon)`

--- a/frontend/src/metabase/admin/datamodel/metadata/components/MetadataBackButton/MetadataBackButton.styled.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/MetadataBackButton/MetadataBackButton.styled.tsx
@@ -13,6 +13,6 @@ export const BackButtonLink = styled(Link)`
   background-color: var(--mb-color-bg-dark);
 
   &:hover {
-    background-color: ${color("brand")};
+    background-color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/admin/datamodel/metadata/components/MetadataHeader/MetadataHeader.styled.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/MetadataHeader/MetadataHeader.styled.tsx
@@ -1,10 +1,8 @@
 import styled from "@emotion/styled";
 import { Link } from "react-router";
 
-import { color } from "metabase/lib/colors";
-
 export const TableSettingsLink = styled(Link)`
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/admin/datamodel/metadata/components/MetadataTable/MetadataTable.styled.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/MetadataTable/MetadataTable.styled.tsx
@@ -53,6 +53,6 @@ export const VisibilityBadge = styled.span<VisibilityBadgeProps>`
   color: ${props => (props.isChecked ? color("brand") : color("text-dark"))};
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/admin/datamodel/metadata/components/MetadataTableColumn/MetadataTableColumn.styled.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/MetadataTableColumn/MetadataTableColumn.styled.tsx
@@ -26,6 +26,6 @@ export const FieldSettingsLink = styled(Link)`
   margin-right: 0.5rem;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/admin/datamodel/metadata/components/MetadataTableList/MetadataTableList.styled.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/MetadataTableList/MetadataTableList.styled.tsx
@@ -18,7 +18,7 @@ export const AdminListItem = styled.a<AdminListItemProps>`
 `;
 
 export const BackIconContainer = styled.span`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   cursor: pointer;
 `;
 

--- a/frontend/src/metabase/admin/people/components/AddMemberRow.styled.tsx
+++ b/frontend/src/metabase/admin/people/components/AddMemberRow.styled.tsx
@@ -1,7 +1,5 @@
 import styled from "@emotion/styled";
 
-import { color } from "metabase/lib/colors";
-
 interface AddMemberAutocompleteSuggestionRootProps {
   isSelected?: boolean;
 }
@@ -9,5 +7,5 @@ interface AddMemberAutocompleteSuggestionRootProps {
 export const AddMemberAutocompleteSuggestionRoot = styled.div<AddMemberAutocompleteSuggestionRootProps>`
   padding: 0.5rem 1rem;
   cursor: pointer;
-  background-color: ${props => props.isSelected && color("brand")};
+  background-color: ${props => props.isSelected && "var(--mb-color-brand)"};
 `;

--- a/frontend/src/metabase/admin/people/components/GroupsListing.styled.tsx
+++ b/frontend/src/metabase/admin/people/components/GroupsListing.styled.tsx
@@ -8,7 +8,7 @@ export const EditGroupButton = styled.li`
 
   &:hover {
     color: ${color("white")};
-    background-color: ${color("brand")};
+    background-color: var(--mb-color-brand);
   }
 `;
 
@@ -19,6 +19,6 @@ export const DeleteModalTrigger = styled.li`
 
   &:hover {
     color: ${color("white")};
-    background-color: ${color("brand")};
+    background-color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/admin/people/components/NudgeToPro.styled.tsx
+++ b/frontend/src/metabase/admin/people/components/NudgeToPro.styled.tsx
@@ -25,13 +25,13 @@ export const ProLink = styled(ExternalLink)`
   margin-top: 1rem;
   font-weight: 700;
   padding: 0.75rem 1rem;
-  border: 1px solid ${color("brand")};
+  border: 1px solid var(--mb-color-brand);
   border-radius: 0.5rem;
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   width: fit-content;
 
   &:hover {
     color: ${color("white")};
-    background-color: ${color("brand")};
+    background-color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/admin/people/components/PeopleListRow.styled.tsx
+++ b/frontend/src/metabase/admin/people/components/PeopleListRow.styled.tsx
@@ -8,6 +8,6 @@ export const RefreshLink = styled(Link)`
   cursor: pointer;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/admin/performance/components/PerformanceApp.styled.tsx
+++ b/frontend/src/metabase/admin/performance/components/PerformanceApp.styled.tsx
@@ -1,6 +1,5 @@
 import styled from "@emotion/styled";
 
-import { color } from "metabase/lib/colors";
 import { Tabs } from "metabase/ui";
 
 export const TabsList = styled(Tabs.List)`
@@ -17,7 +16,7 @@ export const Tab = styled(Tabs.Tab)`
   padding: 0.625rem 0px;
   margin-inline-end: 1.25rem;
   :hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
     background-color: inherit;
     border-color: transparent;
   }

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/SettingsEditor.styled.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/SettingsEditor.styled.tsx
@@ -7,6 +7,6 @@ export const NewVersionIndicator = styled.span`
   color: ${color("white")};
   font-size: 0.75em;
   font-weight: bold;
-  background-color: ${color("brand")};
+  background-color: var(--mb-color-brand);
   border-radius: 0.5rem;
 `;

--- a/frontend/src/metabase/admin/settings/auth/components/AuthCard/AuthCard.styled.tsx
+++ b/frontend/src/metabase/admin/settings/auth/components/AuthCard/AuthCard.styled.tsx
@@ -39,7 +39,9 @@ export const CardBadge = styled.div<CardBadgeProps>`
   color: ${props =>
     props.isEnabled ? "var(--mb-color-brand)" : color("danger")};
   background-color: ${props =>
-    props.isEnabled ? color("brand-lighter") : "var(--mb-color-bg-light)"};
+    props.isEnabled
+      ? "var(--mb-color-brand-lighter)"
+      : "var(--mb-color-bg-light)"};
   padding: 0.25rem 0.375rem;
   border-radius: 0.25rem;
   font-weight: bold;

--- a/frontend/src/metabase/admin/settings/auth/components/AuthCard/AuthCard.styled.tsx
+++ b/frontend/src/metabase/admin/settings/auth/components/AuthCard/AuthCard.styled.tsx
@@ -36,7 +36,8 @@ interface CardBadgeProps {
 }
 
 export const CardBadge = styled.div<CardBadgeProps>`
-  color: ${props => color(props.isEnabled ? "brand" : "danger")};
+  color: ${props =>
+    props.isEnabled ? "var(--mb-color-brand)" : color("danger")};
   background-color: ${props =>
     props.isEnabled ? color("brand-lighter") : "var(--mb-color-bg-light)"};
   padding: 0.25rem 0.375rem;

--- a/frontend/src/metabase/admin/settings/components/SettingsSetting.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsSetting.jsx
@@ -5,7 +5,7 @@ import scrollIntoView from "scroll-into-view-if-needed";
 import { jt } from "ttag";
 
 import ExternalLink from "metabase/core/components/ExternalLink";
-import { alpha, color } from "metabase/lib/colors";
+import { alpha } from "metabase/lib/colors";
 
 import { settingToFormFieldId, getEnvVarDocsUrl } from "../utils";
 
@@ -55,7 +55,7 @@ export const SettingsSetting = props => {
 
       setFancyStyle({
         background: alpha("brand", 0.1),
-        boxShadow: `0 0 0 1px ${color("brand")}`,
+        boxShadow: `0 0 0 1px var(--mb-color-brand)`,
       });
 
       setTimeout(() => {

--- a/frontend/src/metabase/admin/settings/components/SettingsSetting.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsSetting.unit.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "__support__/ui";
+import { renderWithProviders, screen } from "__support__/ui";
 
 import { SettingsSetting } from "./SettingsSetting";
 
@@ -9,7 +9,7 @@ const SETTING = {
 };
 
 const setup = () => {
-  render(<SettingsSetting setting={SETTING} />);
+  renderWithProviders(<SettingsSetting setting={SETTING} />);
 };
 
 describe("SettingsSetting", () => {
@@ -24,7 +24,7 @@ describe("SettingsSetting", () => {
     setup();
 
     expect(screen.getByTestId("site-name-setting")).toHaveStyle(
-      "box-shadow: 0 0 0 1px #509EE3",
+      "box-shadow: 0 0 0 1px var(--mb-color-brand)",
     );
     window.location.hash = "";
   });

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/VersionUpdateNotice/VersionUpdateNotice.styled.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/VersionUpdateNotice/VersionUpdateNotice.styled.tsx
@@ -10,7 +10,7 @@ export const OnLatestVersionMessage = styled.div`
   padding: 1rem;
   color: ${color("white")};
   font-weight: bold;
-  border: 1px solid ${color("brand")};
+  border: 1px solid var(--mb-color-brand);
   border-radius: 0.5rem;
-  background-color: ${color("brand")};
+  background-color: var(--mb-color-brand);
 `;

--- a/frontend/src/metabase/admin/settings/components/widgets/EmbeddingOption/EmbeddingOption.styled.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/EmbeddingOption/EmbeddingOption.styled.tsx
@@ -21,10 +21,10 @@ export const Label = styled.span`
   border-radius: 0.25rem;
   text-transform: uppercase;
   color: ${color("white")};
-  background: ${color("brand")};
+  background: var(--mb-color-brand);
 `;
 
 export const BoldExternalLink = styled(ExternalLink)`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   font-weight: bold;
 `;

--- a/frontend/src/metabase/admin/settings/components/widgets/HostingInfoLink/HostingInfoLink.styled.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/HostingInfoLink/HostingInfoLink.styled.tsx
@@ -7,11 +7,11 @@ export const HostingLink = styled(ExternalLink)`
   font-weight: bold;
   white-space: nowrap;
   padding: 0.5rem 1rem;
-  border: 1px solid ${color("brand")};
+  border: 1px solid var(--mb-color-brand);
   border-radius: 0.5rem;
 
   &:hover {
     color: ${color("white")};
-    background-color: ${color("brand")};
+    background-color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/admin/settings/components/widgets/ModelCachingScheduleWidget/CronExpressionInput.styled.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/ModelCachingScheduleWidget/CronExpressionInput.styled.tsx
@@ -37,7 +37,7 @@ export const InfoIcon = styled(Icon)`
   color: ${color("text-medium")};
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 

--- a/frontend/src/metabase/admin/settings/setup/components/SetupCheckList/SetupCheckList.styled.tsx
+++ b/frontend/src/metabase/admin/settings/setup/components/SetupCheckList/SetupCheckList.styled.tsx
@@ -3,7 +3,6 @@ import styled from "@emotion/styled";
 import { Link } from "react-router";
 
 import ExternalLink from "metabase/core/components/ExternalLink";
-import { color } from "metabase/lib/colors";
 
 export const SetupListRoot = styled.div`
   display: flex;

--- a/frontend/src/metabase/admin/settings/setup/components/SetupCheckList/SetupCheckList.styled.tsx
+++ b/frontend/src/metabase/admin/settings/setup/components/SetupCheckList/SetupCheckList.styled.tsx
@@ -20,7 +20,7 @@ const linkStyles = css`
   text-decoration: none;
 
   &:hover {
-    border-color: ${color("brand")};
+    border-color: var(--mb-color-brand);
   }
 `;
 

--- a/frontend/src/metabase/admin/settings/slack/components/SlackSetup/SlackSetup.styled.tsx
+++ b/frontend/src/metabase/admin/settings/slack/components/SlackSetup/SlackSetup.styled.tsx
@@ -48,7 +48,7 @@ export const SectionHeader = styled.header`
 export const SectionTitle = styled.h3`
   flex: 1 1 auto;
   margin: 0 1rem 0 0;
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   font-size: 1rem;
   font-weight: bold;
   line-height: 1.5rem;
@@ -56,7 +56,7 @@ export const SectionTitle = styled.h3`
 
 export const SectionToggle = styled(Button)`
   flex: 0 0 auto;
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   width: 2.5rem;
   height: 2.5rem;
 `;

--- a/frontend/src/metabase/admin/tasks/components/Help/Help.styled.tsx
+++ b/frontend/src/metabase/admin/tasks/components/Help/Help.styled.tsx
@@ -1,7 +1,6 @@
 import styled from "@emotion/styled";
 
 import ExternalLink from "metabase/core/components/ExternalLink";
-import { color } from "metabase/lib/colors";
 
 export const HelpRoot = styled.div`
   padding-left: 1rem;

--- a/frontend/src/metabase/admin/tasks/components/Help/Help.styled.tsx
+++ b/frontend/src/metabase/admin/tasks/components/Help/Help.styled.tsx
@@ -28,7 +28,7 @@ export const InfoBlockButton = styled.div`
   cursor: pointer;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 
@@ -41,6 +41,6 @@ export const HelpExternalLink = styled(ExternalLink)`
   text-decoration: none;
 
   &:hover {
-    border-color: ${color("brand")};
+    border-color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/admin/tasks/containers/TasksApp.styled.tsx
+++ b/frontend/src/metabase/admin/tasks/containers/TasksApp.styled.tsx
@@ -30,6 +30,6 @@ export const InfoIcon = styled(Icon)`
   color: ${color("text-medium")};
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/auth/components/AuthButton/AuthButton.styled.tsx
+++ b/frontend/src/metabase/auth/components/AuthButton/AuthButton.styled.tsx
@@ -8,7 +8,7 @@ export const TextLink = styled(Link)`
   color: ${color("text-dark")};
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 

--- a/frontend/src/metabase/auth/components/ForgotPassword/ForgotPassword.styled.tsx
+++ b/frontend/src/metabase/auth/components/ForgotPassword/ForgotPassword.styled.tsx
@@ -20,7 +20,7 @@ export const InfoIcon = styled(Icon)`
 export const InfoIconContainer = styled.div`
   padding: 1.25rem;
   border-radius: 50%;
-  background-color: ${color("brand-light")};
+  background-color: var(--mb-color-brand-light);
   margin-bottom: 1.5rem;
 `;
 

--- a/frontend/src/metabase/auth/components/ForgotPassword/ForgotPassword.styled.tsx
+++ b/frontend/src/metabase/auth/components/ForgotPassword/ForgotPassword.styled.tsx
@@ -12,7 +12,7 @@ export const InfoBody = styled.div`
 
 export const InfoIcon = styled(Icon)`
   display: block;
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   width: 1.5rem;
   height: 1.5rem;
 `;
@@ -44,6 +44,6 @@ export const InfoLink = styled(Link)`
   margin-top: 2.5rem;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/auth/components/ForgotPasswordForm/ForgotPasswordForm.styled.tsx
+++ b/frontend/src/metabase/auth/components/ForgotPasswordForm/ForgotPasswordForm.styled.tsx
@@ -23,6 +23,6 @@ export const PasswordFormLink = styled(Link)`
   color: ${color("text-dark")};
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/auth/components/GoogleButton/GoogleButton.styled.tsx
+++ b/frontend/src/metabase/auth/components/GoogleButton/GoogleButton.styled.tsx
@@ -24,6 +24,6 @@ export const TextLink = styled(Link)`
   color: ${color("text-dark")};
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/browse/components/BrowseDatabases.styled.tsx
+++ b/frontend/src/metabase/browse/components/BrowseDatabases.styled.tsx
@@ -2,7 +2,6 @@ import styled from "@emotion/styled";
 import { Link } from "react-router";
 
 import Card from "metabase/components/Card";
-import { color } from "metabase/lib/colors";
 
 import { BrowseGrid } from "./BrowseContainer.styled";
 
@@ -13,12 +12,12 @@ export const DatabaseCard = styled(Card)`
   margin-bottom: 1rem;
   box-shadow: none;
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 
 export const DatabaseCardLink = styled(Link)`
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/browse/components/BrowseHeader.styled.tsx
+++ b/frontend/src/metabase/browse/components/BrowseHeader.styled.tsx
@@ -14,6 +14,6 @@ export const BrowseHeaderIconContainer = styled.div`
   color: ${color("text-medium")};
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/browse/components/BrowseModels.styled.tsx
+++ b/frontend/src/metabase/browse/components/BrowseModels.styled.tsx
@@ -29,7 +29,7 @@ export const ModelCard = styled(Card)`
   box-shadow: none;
   &:hover {
     h1 {
-      color: ${color("brand")};
+      color: var(--mb-color-brand);
     }
   }
   transition: box-shadow 0.15s;
@@ -66,7 +66,7 @@ export const CollectionHeaderContainer = styled.button`
   cursor: pointer;
   color: ${color("text-dark")};
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
   :first-of-type {
     margin-top: 1rem;
@@ -78,7 +78,7 @@ export const CollectionHeaderLink = styled(Link)`
   display: flex;
   align-items: center;
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 
@@ -121,7 +121,7 @@ export const CollectionHeaderToggleContainer = styled.div`
     background-color: inherit;
     div,
     svg {
-      color: ${color("brand")};
+      color: var(--mb-color-brand);
     }
   }
 `;

--- a/frontend/src/metabase/browse/components/ModelsTable.styled.tsx
+++ b/frontend/src/metabase/browse/components/ModelsTable.styled.tsx
@@ -6,13 +6,12 @@ import {
   hideResponsively,
 } from "metabase/components/ItemsTable/BaseItemsTable.styled";
 import type { ResponsiveProps } from "metabase/components/ItemsTable/utils";
-import { color } from "metabase/lib/colors";
 import { breakpoints } from "metabase/ui/theme";
 
 export const ModelTableRow = styled.tr`
   cursor: pointer;
   :outline {
-    outline: 2px solid ${color("brand")};
+    outline: 2px solid var(--mb-color-brand);
   }
 `;
 

--- a/frontend/src/metabase/collections/components/CollectionEmptyState/CollectionEmptyState.styled.tsx
+++ b/frontend/src/metabase/collections/components/CollectionEmptyState/CollectionEmptyState.styled.tsx
@@ -19,10 +19,10 @@ export const EmptyStateTitle = styled.div`
 
 export const EmptyStateIconForeground = styled.path`
   fill: var(--mb-color-bg-light);
-  stroke: ${color("brand")};
+  stroke: var(--mb-color-brand);
 `;
 
 export const EmptyStateIconBackground = styled.path`
   fill: ${color("brand-light")};
-  stroke: ${color("brand")};
+  stroke: var(--mb-color-brand);
 `;

--- a/frontend/src/metabase/collections/components/CollectionEmptyState/CollectionEmptyState.styled.tsx
+++ b/frontend/src/metabase/collections/components/CollectionEmptyState/CollectionEmptyState.styled.tsx
@@ -23,6 +23,6 @@ export const EmptyStateIconForeground = styled.path`
 `;
 
 export const EmptyStateIconBackground = styled.path`
-  fill: ${color("brand-light")};
+  fill: var(--mb-color-brand-light);
   stroke: var(--mb-color-brand);
 `;

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.styled.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.styled.tsx
@@ -37,7 +37,7 @@ export const CollectionHeaderButton = styled(
   width: 2rem;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
     background-color: var(--mb-color-bg-medium);
   }
 

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.styled.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.styled.tsx
@@ -1,7 +1,6 @@
 import styled from "@emotion/styled";
 
 import Button from "metabase/core/components/Button";
-import { color } from "metabase/lib/colors";
 import { breakpointMinSmall } from "metabase/styled-components/theme";
 
 export const HeaderRoot = styled.div`

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionUpload.styled.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionUpload.styled.tsx
@@ -28,7 +28,7 @@ export const NewBadge = styled.div`
   font-size: 0.875rem;
   font-weight: 700;
   color: var(--mb-color-brand);
-  background-color: ${color("brand-lighter")};
+  background-color: var(--mb-color-brand-lighter);
   margin: 0 auto;
   border-radius: 6px;
 `;

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionUpload.styled.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionUpload.styled.tsx
@@ -11,7 +11,7 @@ export const LoadingStateContainer = styled.div`
   transform: translateY(10px);
   align-items: center;
   height: 16px;
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
 `;
 
 export const InfoModalTitle = styled.h2`
@@ -27,7 +27,7 @@ export const NewBadge = styled.div`
   padding: 5px 10px;
   font-size: 0.875rem;
   font-weight: 700;
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   background-color: ${color("brand-lighter")};
   margin: 0 auto;
   border-radius: 6px;

--- a/frontend/src/metabase/collections/components/EmptyPinnedItemsBanner/EmptyPinnedItemsBanner.styled.tsx
+++ b/frontend/src/metabase/collections/components/EmptyPinnedItemsBanner/EmptyPinnedItemsBanner.styled.tsx
@@ -5,8 +5,8 @@ import { color, lighten } from "metabase/lib/colors";
 import { Icon } from "metabase/ui";
 
 export const EmptyBanner = styled(Banner)`
-  border: 1px solid ${color("brand")};
-  background-color: ${lighten("brand", 0.6)};
+  border: 1px solid var(--mb-color-brand);
+  background-color: ${() => lighten("brand", 0.6)};
   display: flex;
   align-items: center;
   color: ${color("text-dark")};
@@ -16,5 +16,5 @@ export const EmptyBanner = styled(Banner)`
 `;
 
 export const ColoredIcon = styled(Icon)`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
 `;

--- a/frontend/src/metabase/collections/components/PinDropZone/PinDropZone.styled.tsx
+++ b/frontend/src/metabase/collections/components/PinDropZone/PinDropZone.styled.tsx
@@ -1,7 +1,6 @@
 import styled from "@emotion/styled";
 
 import PinDropTarget from "metabase/containers/dnd/PinDropTarget";
-import { color } from "metabase/lib/colors";
 
 export type PinDropTargetProps = {
   variant: "pin" | "unpin";
@@ -39,7 +38,7 @@ export const PinDropTargetIndicator = styled.div<PinDropTargetRenderArgs>`
   right: 0;
   border-left: ${props =>
     `4px solid ${
-      props.hovered ? color("brand") : "var(--mb-color-bg-medium)"
+      props.hovered ? "var(--mb-color-brand)" : "var(--mb-color-bg-medium)"
     }`};
   display: ${props => !(props.hovered || props.highlighted) && "none"};
   min-height: 2rem;

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.styled.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.styled.tsx
@@ -14,7 +14,7 @@ export const ItemLink = styled(Link)`
 `;
 
 export const ItemIcon = styled(Icon)`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   height: 1.5rem;
   width: 1.5rem;
 `;
@@ -50,7 +50,7 @@ export const Body = styled.div`
 
   &:hover {
     ${Title} {
-      color: ${color("brand")};
+      color: var(--mb-color-brand);
     }
 
     ${ActionsContainer} {

--- a/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionCard.styled.tsx
+++ b/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionCard.styled.tsx
@@ -43,11 +43,11 @@ export const CardRoot = styled(Link)<CardRootProps>`
     }
 
     ${LegendLabel} {
-      color: ${color("brand")};
+      color: var(--mb-color-brand);
     }
 
     ${ChartSkeleton.Title} {
-      color: ${color("brand")};
+      color: var(--mb-color-brand);
     }
 
     ${ChartSkeleton.Description} {

--- a/frontend/src/metabase/collections/components/UploadOverlay/UploadOverlay.styled.tsx
+++ b/frontend/src/metabase/collections/components/UploadOverlay/UploadOverlay.styled.tsx
@@ -1,7 +1,5 @@
 import styled from "@emotion/styled";
 
-import { color } from "metabase/lib/colors";
-
 export const DragOverlay = styled.div<{ isDragActive: boolean }>`
   position: absolute;
   top: 0;
@@ -15,7 +13,7 @@ export const DragOverlay = styled.div<{ isDragActive: boolean }>`
   align-items: center;
   gap: 1rem;
 
-  background-color: ${color("brand-lighter")};
+  background-color: var(--mb-color-brand-lighter);
   opacity: ${props => (props.isDragActive ? 0.9 : 0)};
   transition: opacity 0.2s;
   border: 1px dashed var(--mb-color-brand);

--- a/frontend/src/metabase/collections/components/UploadOverlay/UploadOverlay.styled.tsx
+++ b/frontend/src/metabase/collections/components/UploadOverlay/UploadOverlay.styled.tsx
@@ -18,12 +18,12 @@ export const DragOverlay = styled.div<{ isDragActive: boolean }>`
   background-color: ${color("brand-lighter")};
   opacity: ${props => (props.isDragActive ? 0.9 : 0)};
   transition: opacity 0.2s;
-  border: 1px dashed ${color("brand")};
+  border: 1px dashed var(--mb-color-brand);
   border-radius: 0.5rem;
   margin: 0.5rem 4%;
   padding: 4rem;
 
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   font-size: 1.125rem;
   font-weight: bold;
 

--- a/frontend/src/metabase/common/components/EntityPicker/components/ResultItem/ResultItem.styled.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/ResultItem/ResultItem.styled.tsx
@@ -20,7 +20,7 @@ export const ChunkyListItem = styled.button<{
     ${({ isSelected }) =>
       !isSelected &&
       css`
-        background-color: ${color("brand-lighter")};
+        background-color: var(--mb-color-brand-lighter);
         color: ${color("text-dark")};
       `}
   }

--- a/frontend/src/metabase/common/components/EntityPicker/components/ResultItem/ResultItem.styled.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/ResultItem/ResultItem.styled.tsx
@@ -11,7 +11,7 @@ export const ChunkyListItem = styled.button<{
   cursor: pointer;
 
   background-color: ${({ isSelected }) =>
-    isSelected ? color("brand") : "white"};
+    isSelected ? "var(--mb-color-brand)" : color("white")};
 
   color: ${({ isSelected }) =>
     isSelected ? color("white") : color("text-dark")};

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.styled.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.styled.tsx
@@ -79,7 +79,7 @@ export const MoreButton = styled(Button)`
   }
 
   &:hover {
-    background-color: ${color("brand-lighter")};
+    background-color: var(--mb-color-brand-lighter);
   }
 `;
 

--- a/frontend/src/metabase/common/components/Table/Table.styled.tsx
+++ b/frontend/src/metabase/common/components/Table/Table.styled.tsx
@@ -1,7 +1,5 @@
 import styled from "@emotion/styled";
 
-import { color } from "metabase/lib/colors";
-
 import { Table } from "./Table";
 
 export const StyledTable = styled(Table)`

--- a/frontend/src/metabase/common/components/Table/Table.styled.tsx
+++ b/frontend/src/metabase/common/components/Table/Table.styled.tsx
@@ -26,7 +26,7 @@ export const StyledTable = styled(Table)`
   }
 
   tbody > tr:hover {
-    background-color: ${color("brand-lighter")};
+    background-color: var(--mb-color-brand-lighter);
   }
 
   td {

--- a/frontend/src/metabase/components/BrowserCrumbs/BrowserCrumbs.styled.tsx
+++ b/frontend/src/metabase/components/BrowserCrumbs/BrowserCrumbs.styled.tsx
@@ -18,7 +18,7 @@ export const BrowserCrumbsLink = styled(Link)`
   cursor: pointer;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 

--- a/frontend/src/metabase/components/Calendar/Calendar.styled.tsx
+++ b/frontend/src/metabase/components/Calendar/Calendar.styled.tsx
@@ -45,6 +45,6 @@ export const CalendarIconContainer = styled.div`
   cursor: pointer;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/components/CollectionItem/CollectionItem.styled.tsx
+++ b/frontend/src/metabase/components/CollectionItem/CollectionItem.styled.tsx
@@ -12,7 +12,7 @@ export const ItemLink = styled(Link)`
   border-radius: 8px;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 

--- a/frontend/src/metabase/components/CopyTextInput/CopyTextInput.styled.tsx
+++ b/frontend/src/metabase/components/CopyTextInput/CopyTextInput.styled.tsx
@@ -14,12 +14,12 @@ export const CopyWidgetButton = styled(CopyButton)`
   border-left: 1px solid var(--mb-color-border);
   border-top-right-radius: 4px;
   border-bottom-right-radius: 4px;
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   outline: none;
   cursor: pointer;
 
   &:hover {
     color: ${color("white")};
-    background-color: ${color("brand")};
+    background-color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/components/CopyWidget/CopyWidget.styled.tsx
+++ b/frontend/src/metabase/components/CopyWidget/CopyWidget.styled.tsx
@@ -14,11 +14,11 @@ export const CopyWidgetButton = styled(CopyButton)`
   border-left: 1px solid var(--mb-color-border);
   border-top-right-radius: 0.5rem;
   border-bottom-right-radius: 0.5rem;
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   outline: none;
 
   &:hover {
     color: ${color("white")};
-    background-color: ${color("brand")};
+    background-color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/components/DateMonthYearWidget/DateMonthYearWidget.styled.tsx
+++ b/frontend/src/metabase/components/DateMonthYearWidget/DateMonthYearWidget.styled.tsx
@@ -29,7 +29,7 @@ export const MonthRoot = styled.div<MonthRootProps>`
   padding: 0.5rem 1rem;
   border-radius: 99px;
   color: ${props => props.isSelected && color("white")};
-  background-color: ${props => props.isSelected && color("brand")};
+  background-color: ${props => props.isSelected && "var(--mb-color-brand)"};
 
   &:hover {
     background-color: ${props =>

--- a/frontend/src/metabase/components/DateQuarterYearWidget/DateQuarterYearWidget.styled.tsx
+++ b/frontend/src/metabase/components/DateQuarterYearWidget/DateQuarterYearWidget.styled.tsx
@@ -17,13 +17,13 @@ export const QuarterRoot = styled.li<QuarterRootProps>`
 
   &:hover {
     color: ${color("white")};
-    background-color: ${color("brand")};
+    background-color: var(--mb-color-brand);
   }
 
   ${({ isSelected }) =>
     isSelected &&
     css`
       color: ${color("white")};
-      background-color: ${color("brand")};
+      background-color: var(--mb-color-brand);
     `}
 `;

--- a/frontend/src/metabase/components/EntityItem/EntityItem.styled.tsx
+++ b/frontend/src/metabase/components/EntityItem/EntityItem.styled.tsx
@@ -60,7 +60,7 @@ export const EntityItemSpinner = styled(LoadingSpinner)`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
 `;
 
 export const EntityMenuContainer = styled.div`

--- a/frontend/src/metabase/components/HelpCard/HelpCard.styled.tsx
+++ b/frontend/src/metabase/components/HelpCard/HelpCard.styled.tsx
@@ -44,14 +44,14 @@ export const CardHeaderLink = styled(ExternalLink)`
 export const CardTitle = styled.span`
   display: block;
   flex: 1 1 auto;
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   font-weight: bold;
   margin: 0 0.5rem;
 `;
 
 export const CardIcon = styled(Icon)`
   flex: 0 0 auto;
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
 `;
 
 export const CardMessage = styled.div`
@@ -68,7 +68,7 @@ export const CardMessage = styled.div`
   }
 
   a {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
     cursor: pointer;
     font-weight: bold;
   }

--- a/frontend/src/metabase/components/ItemsTable/BaseItemsTable.styled.tsx
+++ b/frontend/src/metabase/components/ItemsTable/BaseItemsTable.styled.tsx
@@ -85,7 +85,7 @@ export const ItemLink = styled(Link)`
   align-items: center;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 
@@ -98,7 +98,7 @@ export const ItemNameCell = styled.td`
 
   &:hover {
     ${ItemLink} {
-      color: ${color("brand")};
+      color: var(--mb-color-brand);
     }
 
     cursor: pointer;

--- a/frontend/src/metabase/components/ListItem/ListItem.styled.tsx
+++ b/frontend/src/metabase/components/ListItem/ListItem.styled.tsx
@@ -3,7 +3,6 @@ import styled from "@emotion/styled";
 import { Link } from "react-router";
 
 import { Ellipsified } from "metabase/core/components/Ellipsified";
-import { color } from "metabase/lib/colors";
 
 interface Props {
   disabled?: boolean;
@@ -22,7 +21,7 @@ export const Root = styled.li<Props>`
 
 export const ListItemLink = styled(Link)`
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 
@@ -30,6 +29,6 @@ export const ListItemName = styled(Ellipsified)`
   max-width: 100%;
   overflow: hidden;
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/components/MetadataInfo/ColumnFingerprintInfo/CategoryFingerprint.styled.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/ColumnFingerprintInfo/CategoryFingerprint.styled.tsx
@@ -30,7 +30,7 @@ export const LoadingSpinner = styled(_LoadingSpinner)`
   flex-grow: 1;
   align-self: center;
   justify-content: center;
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
 `;
 
 LoadingSpinner.defaultProps = {

--- a/frontend/src/metabase/components/MetadataInfo/ColumnFingerprintInfo/CategoryFingerprint.styled.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/ColumnFingerprintInfo/CategoryFingerprint.styled.tsx
@@ -1,7 +1,6 @@
 import styled from "@emotion/styled";
 
 import _LoadingSpinner from "metabase/components/LoadingSpinner";
-import { color } from "metabase/lib/colors";
 import { isReducedMotionPreferred } from "metabase/lib/dom";
 
 const TRANSITION_DURATION = () => (isReducedMotionPreferred() ? "0" : "0.25s");

--- a/frontend/src/metabase/components/MetadataInfo/MetadataInfo.styled.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/MetadataInfo.styled.tsx
@@ -63,7 +63,7 @@ export const RelativeSizeIcon = styled(Icon)`
 `;
 
 export const InvertedColorRelativeSizeIcon = styled(RelativeSizeIcon)`
-  background-color: ${color("brand")};
+  background-color: var(--mb-color-brand);
   color: ${color("white")};
   border-radius: 0.3em;
   padding: 0.3em;
@@ -88,7 +88,7 @@ export const LoadingSpinner = styled(_LoadingSpinner)`
   flex-grow: 1;
   align-self: center;
   justify-content: center;
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
 `;
 
 export const Table = styled.table`

--- a/frontend/src/metabase/components/MetadataInfo/TableInfo/ConnectedTables.styled.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/TableInfo/ConnectedTables.styled.tsx
@@ -16,7 +16,7 @@ export const LabelButton = styled.button`
   &:hover,
   &:focus {
     ${InteractiveTableLabel} {
-      color: ${color("brand")};
+      color: var(--mb-color-brand);
     }
   }
 `;
@@ -25,7 +25,7 @@ export const LabelLink = styled(Link)`
   &:hover,
   &:focus {
     ${InteractiveTableLabel} {
-      color: ${color("brand")};
+      color: var(--mb-color-brand);
     }
   }
 `;

--- a/frontend/src/metabase/components/ModalContent/ModalContent.styled.ts
+++ b/frontend/src/metabase/components/ModalContent/ModalContent.styled.ts
@@ -58,7 +58,7 @@ export const ModalHeaderBackIcon = styled(ModalContentActionIcon)`
   margin: -0.5rem 0 -0.5rem -0.5rem;
 
   :hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 
@@ -74,7 +74,7 @@ export const HeaderTextContainer = styled.div<{
     onClick &&
     css`
       &:hover > * {
-        color: ${color("brand")};
+        color: var(--mb-color-brand);
         cursor: pointer;
       }
     `}

--- a/frontend/src/metabase/components/PasswordReveal/PasswordReveal.styled.tsx
+++ b/frontend/src/metabase/components/PasswordReveal/PasswordReveal.styled.tsx
@@ -1,12 +1,11 @@
 import styled from "@emotion/styled";
 
 import { CopyButton } from "metabase/components/CopyButton";
-import { color } from "metabase/lib/colors";
 
 export const PasswordCopyButton = styled(CopyButton)`
   cursor: pointer;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/components/SelectList/SelectListItem.styled.tsx
+++ b/frontend/src/metabase/components/SelectList/SelectListItem.styled.tsx
@@ -16,7 +16,7 @@ export const ItemIcon = styled(Icon)<{ color?: string | null }>`
 `;
 
 const activeItemCss = css`
-  background-color: ${color("brand")};
+  background-color: var(--mb-color-brand);
 
   ${ItemIcon},
   ${ItemTitle} {

--- a/frontend/src/metabase/components/TextEditor/TextEditor.styled.tsx
+++ b/frontend/src/metabase/components/TextEditor/TextEditor.styled.tsx
@@ -8,7 +8,7 @@ export const TextEditorRoot = styled.div`
 
   .ace_gutter {
     background: rgb(220, 236, 249);
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
     font-weight: bold;
   }
   .ace_keyword {

--- a/frontend/src/metabase/components/TokenFieldItem/TokenFieldItem.styled.ts
+++ b/frontend/src/metabase/components/TokenFieldItem/TokenFieldItem.styled.ts
@@ -12,7 +12,7 @@ export const TokenFieldItem = styled.li<{
   height: 46px;
   border-radius: 0.5rem;
   color: ${({ isValid }) => (isValid ? color("brand") : color("error"))};
-  background-color: ${alpha("brand", 0.2)};
+  background-color: ${() => alpha("brand", 0.2)};
 `;
 
 export const TokenFieldAddon = styled.a<{
@@ -24,6 +24,6 @@ export const TokenFieldAddon = styled.a<{
   color: ${({ isValid }) => (isValid ? "" : color("error"))};
 
   &:hover {
-    color: ${darken("brand", 0.2)};
+    color: ${() => darken("brand", 0.2)};
   }
 `;

--- a/frontend/src/metabase/containers/DataPicker/DataTypePicker/DataTypePicker.styled.tsx
+++ b/frontend/src/metabase/containers/DataPicker/DataTypePicker/DataTypePicker.styled.tsx
@@ -8,7 +8,7 @@ import { Icon } from "metabase/ui";
 export const List = styled(SelectList)`
   ${SelectList.BaseItem.Root} {
     &:hover {
-      background-color: ${color("brand")};
+      background-color: var(--mb-color-brand);
     }
   }
 `;

--- a/frontend/src/metabase/containers/DataPicker/LoadingState/LoadingState.styled.tsx
+++ b/frontend/src/metabase/containers/DataPicker/LoadingState/LoadingState.styled.tsx
@@ -1,11 +1,9 @@
 import styled from "@emotion/styled";
 
-import { color } from "metabase/lib/colors";
-
 export const LoadingStateContainer = styled.div`
   display: flex;
   flex: 1;
   align-items: center;
   justify-content: center;
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
 `;

--- a/frontend/src/metabase/containers/DataPicker/PanePicker/PanePicker.styled.tsx
+++ b/frontend/src/metabase/containers/DataPicker/PanePicker/PanePicker.styled.tsx
@@ -44,7 +44,7 @@ export const BackButton = styled.button`
   padding-bottom: 1rem;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 

--- a/frontend/src/metabase/containers/Unsubscribe.styled.tsx
+++ b/frontend/src/metabase/containers/Unsubscribe.styled.tsx
@@ -30,7 +30,6 @@ export const LayoutIllustration = styled.div<{
   left: 0;
   width: 100%;
   height: 100%;
-  background-size: ;
   filter: ${({ isDefault }) =>
     isDefault && `hue-rotate(${hueRotate("brand")}deg)`};
   background-image: ${({ backgroundImageSrc }) =>
@@ -64,6 +63,6 @@ export const LayoutCard = styled.div`
 export const CheckmarkIcon = styled(Icon)`
   border-radius: 100%;
   padding: 1rem;
-  color: ${color("brand")};
-  background: ${alpha(color("brand"), 0.3)};
+  color: var(--mb-color-brand);
+  background: ${() => alpha(color("brand"), 0.3)};
 `;

--- a/frontend/src/metabase/containers/UserCollectionList.styled.tsx
+++ b/frontend/src/metabase/containers/UserCollectionList.styled.tsx
@@ -1,7 +1,6 @@
 import styled from "@emotion/styled";
 
 import { GridItem } from "metabase/components/Grid";
-import { color } from "metabase/lib/colors";
 
 export const ListRoot = styled.div`
   padding: 0 4rem;
@@ -15,7 +14,7 @@ export const ListGridItem = styled(GridItem)`
   width: 33.33%;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 

--- a/frontend/src/metabase/core/components/Alert/Alert.styled.tsx
+++ b/frontend/src/metabase/core/components/Alert/Alert.styled.tsx
@@ -56,7 +56,7 @@ export const AlertIcon = styled(Icon)<AlertIconProps>`
 `;
 
 export const AlertLink = styled.a`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   cursor: pointer;
   font-weight: bold;
 `;

--- a/frontend/src/metabase/core/components/BookmarkToggle/BookmarkToggle.styled.tsx
+++ b/frontend/src/metabase/core/components/BookmarkToggle/BookmarkToggle.styled.tsx
@@ -42,7 +42,7 @@ export const BookmarkButton = styled(Button)<BookmarkButtonProps>`
   width: 2rem;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
     background-color: var(--mb-color-bg-medium);
   }
 

--- a/frontend/src/metabase/core/components/Button/Button.styled.tsx
+++ b/frontend/src/metabase/core/components/Button/Button.styled.tsx
@@ -39,7 +39,7 @@ export const ButtonRoot = styled.button<ButtonRootProps>`
       border: none;
       padding: 0;
 
-      color: ${color("brand")};
+      color: var(--mb-color-brand);
 
       &:hover {
         background-color: unset;
@@ -54,7 +54,7 @@ export const ButtonRoot = styled.button<ButtonRootProps>`
       line-height: 1.5rem;
       padding: 0.5rem;
 
-      color: ${color("brand")};
+      color: var(--mb-color-brand);
 
       &:hover {
         background-color: var(--mb-color-bg-light);

--- a/frontend/src/metabase/core/components/FormField/FormField.styled.tsx
+++ b/frontend/src/metabase/core/components/FormField/FormField.styled.tsx
@@ -70,7 +70,7 @@ export const FieldInfoIcon = styled(Icon)`
   height: 0.75rem;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 

--- a/frontend/src/metabase/core/components/Link/Link.styled.tsx
+++ b/frontend/src/metabase/core/components/Link/Link.styled.tsx
@@ -4,7 +4,6 @@ import styled from "@emotion/styled";
 import { Link } from "react-router";
 
 import { focusOutlineStyle } from "metabase/core/style/input";
-import { color as metabaseColor } from "metabase/lib/colors";
 
 import type { LinkProps } from "./types";
 
@@ -27,13 +26,13 @@ export const LinkRoot = styled(Link, {
 export const variants = {
   default: "",
   brand: css`
-    color: ${metabaseColor("brand")};
+    color: var(--mb-color-brand);
     &:hover {
       text-decoration: underline;
     }
   `,
   brandBold: css`
-    color: ${metabaseColor("brand")};
+    color: var(--mb-color-brand);
     font-weight: bold;
     &:hover {
       text-decoration: underline;

--- a/frontend/src/metabase/core/components/MetabotLogo/MetabotLogo.styled.tsx
+++ b/frontend/src/metabase/core/components/MetabotLogo/MetabotLogo.styled.tsx
@@ -3,5 +3,5 @@ import styled from "@emotion/styled";
 import { hueRotate } from "metabase/lib/colors";
 
 export const LogoRoot = styled.img`
-  filter: hue-rotate(${hueRotate("brand")}deg);
+  filter: hue-rotate(${() => hueRotate("brand")}deg);
 `;

--- a/frontend/src/metabase/core/components/Select/Select.styled.tsx
+++ b/frontend/src/metabase/core/components/Select/Select.styled.tsx
@@ -1,9 +1,8 @@
 import styled from "@emotion/styled";
 
 import AccordionList from "metabase/core/components/AccordionList";
-import { color } from "metabase/lib/colors";
 
 export const SelectAccordionList = styled(AccordionList)`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   outline: none;
 `;

--- a/frontend/src/metabase/core/components/SelectButton/SelectButton.styled.tsx
+++ b/frontend/src/metabase/core/components/SelectButton/SelectButton.styled.tsx
@@ -37,7 +37,7 @@ export const SelectButtonRoot = styled.button<SelectButtonRootProps>`
   color: ${getColor};
 
   &:focus {
-    border-color: ${color("brand")};
+    border-color: var(--mb-color-brand);
     outline: 2px solid ${color("focus")};
   }
 

--- a/frontend/src/metabase/core/components/Slider/Slider.styled.tsx
+++ b/frontend/src/metabase/core/components/Slider/Slider.styled.tsx
@@ -5,7 +5,7 @@ import { space } from "metabase/styled-components/theme";
 
 export const THUMB_SIZE = "1.2rem";
 
-const activeThumbStyle = `box-shadow: 0 0 4px 1px ${color("brand")}`;
+const activeThumbStyle = `box-shadow: 0 0 4px 1px var(--mb-color-brand)`;
 
 export const SliderContainer = styled.div`
   position: relative;
@@ -19,11 +19,11 @@ const thumbStyles = `
   width: ${THUMB_SIZE};
   height: ${THUMB_SIZE};
   border-radius: 50%;
-  border: 2px solid ${color("brand")};
+  border: 2px solid var(--mb-color-brand);
   box-sizing: border-box;
   background-color: ${color("white")};
   cursor: pointer;
-  box-shadow: 0 0 2px 1px ${color("brand")};
+  box-shadow: 0 0 2px 1px var(--mb-color-brand);
   pointer-events: all;
   &:active {
     ${activeThumbStyle}
@@ -58,14 +58,14 @@ export const SliderInput = styled.input`
 export const SliderTrack = styled.span`
   width: calc(100% - ${THUMB_SIZE});
   margin-left: calc(${THUMB_SIZE} / 2);
-  background-color: ${alpha("brand", 0.5)};
+  background-color: ${() => alpha("brand", 0.5)};
   height: 0.2rem;
   border-radius: 0.2rem;
 `;
 
 export const ActiveTrack = styled.span`
   position: absolute;
-  background-color: ${color("brand")};
+  background-color: var(--mb-color-brand);
   height: 0.2rem;
 `;
 

--- a/frontend/src/metabase/core/components/Slider/Slider.styled.tsx
+++ b/frontend/src/metabase/core/components/Slider/Slider.styled.tsx
@@ -1,3 +1,4 @@
+import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 
 import { color, alpha } from "metabase/lib/colors";
@@ -5,7 +6,9 @@ import { space } from "metabase/styled-components/theme";
 
 export const THUMB_SIZE = "1.2rem";
 
-const activeThumbStyle = `box-shadow: 0 0 4px 1px var(--mb-color-brand)`;
+const activeThumbStyle = css`
+  box-shadow: 0 0 4px 1px var(--mb-color-brand);
+`;
 
 export const SliderContainer = styled.div`
   position: relative;

--- a/frontend/src/metabase/core/components/Tab/Tab.styled.tsx
+++ b/frontend/src/metabase/core/components/Tab/Tab.styled.tsx
@@ -27,7 +27,7 @@ export const TabRoot = styled.button<TabProps>`
   border-radius: ${space(0)};
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 
   ${focusOutlineStyle("brand")};

--- a/frontend/src/metabase/core/components/TabButton/TabButton.styled.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.styled.tsx
@@ -71,7 +71,7 @@ export const TabButtonRoot = styled.div<TabButtonProps>`
     ${props =>
       !props.disabled &&
       css`
-        color: ${color("brand")};
+        color: var(--mb-color-brand);
       `}
   }
 `;
@@ -91,7 +91,7 @@ export const MenuButton = styled(Button)<TabButtonProps & { isOpen: boolean }>`
     props.isOpen &&
     !props.disabled &&
     css`
-      color: ${color("brand")};
+      color: var(--mb-color-brand);
       background-color: var(--mb-color-bg-medium);
     `}
   &:hover,:focus {
@@ -101,7 +101,7 @@ export const MenuButton = styled(Button)<TabButtonProps & { isOpen: boolean }>`
             color: ${color("text-dark")};
           `
         : css`
-            color: ${color("brand")};
+            color: var(--mb-color-brand);
             background-color: var(--mb-color-bg-medium);
           `}
   }
@@ -124,7 +124,7 @@ export const MenuItem = styled.li`
   cursor: pointer;
   &:focus,
   :hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
     background-color: var(--mb-color-bg-light);
   }
 `;

--- a/frontend/src/metabase/core/components/TabButton/TabButton.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.tsx
@@ -1,6 +1,6 @@
 import type { UniqueIdentifier } from "@dnd-kit/core";
 import { useSortable } from "@dnd-kit/sortable";
-import { css } from "@emotion/react";
+import { css, type Theme } from "@emotion/react";
 import styled from "@emotion/styled";
 import type {
   HTMLAttributes,
@@ -20,7 +20,7 @@ import {
 import { t } from "ttag";
 
 import ControlledPopoverWithTrigger from "metabase/components/PopoverWithTrigger/ControlledPopoverWithTrigger";
-import { color, lighten } from "metabase/lib/colors";
+import { lighten } from "metabase/lib/colors";
 
 import type { TabContextType } from "../Tab";
 import {
@@ -189,9 +189,9 @@ export interface RenameableTabButtonProps
 }
 
 // These styles need to be here instead of .styled to avoid circular dependency
-const borderStyle = css`
-  border: 1px solid ${color("brand")};
-  box-shadow: 0px 0px 0px 1px ${lighten(color("brand"), 0.28)};
+const getBorderStyle = (theme: Theme) => css`
+  border: 1px solid var(--mb-color-brand);
+  box-shadow: 0px 0px 0px 1px ${lighten(theme.fn.themeColor("brand"), 0.28)};
 `;
 export const RenameableTabButtonStyled = styled(_TabButton)<{
   isRenaming: boolean;
@@ -199,9 +199,10 @@ export const RenameableTabButtonStyled = styled(_TabButton)<{
   canRename: boolean;
 }>`
   ${TabButtonInputWrapper} {
-    ${props => props.isRenaming && borderStyle}
+    ${props => props.isRenaming && getBorderStyle(props.theme)}
     :hover {
-      ${props => props.canRename && props.isSelected && borderStyle}
+      ${props =>
+        props.canRename && props.isSelected && getBorderStyle(props.theme)}
     }
   }
 `;

--- a/frontend/src/metabase/core/components/TabButton/TabButton.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.unit.spec.tsx
@@ -1,7 +1,7 @@
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import { getIcon } from "__support__/ui";
+import { getIcon, renderWithProviders } from "__support__/ui";
 
 import { TabRow } from "../TabRow";
 
@@ -13,7 +13,7 @@ function setup(props?: Partial<RenameableTabButtonProps>) {
   const onRename = jest.fn();
   const value = "some_value";
 
-  render(
+  renderWithProviders(
     <TabRow>
       <TabButton.Renameable
         label="Tab 1"

--- a/frontend/src/metabase/core/components/TabRow/TabRow.styled.tsx
+++ b/frontend/src/metabase/core/components/TabRow/TabRow.styled.tsx
@@ -49,7 +49,7 @@ export const ScrollButton = styled.button<ScrollButtonProps>`
   text-align: ${props => props.direction};
   color: ${color("text-light")};
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
   ${props => props.direction}: 0;
   background: linear-gradient(

--- a/frontend/src/metabase/core/components/TextArea/TextArea.styled.tsx
+++ b/frontend/src/metabase/core/components/TextArea/TextArea.styled.tsx
@@ -25,12 +25,11 @@ export const TextAreaRoot = styled.textarea<TextAreaRootProps>`
 
   &:focus,
   &:hover {
-    border-color: ${color("brand")};
+    border-color: var(--mb-color-brand);
     transition: border 300ms ease-in-out;
   }
-  ${css`
-    ${focusOutlineStyle("brand")}
-  `};
+
+  ${focusOutlineStyle("brand")};
 
   &:disabled {
     pointer-events: none;

--- a/frontend/src/metabase/css/core/colors.module.css
+++ b/frontend/src/metabase/css/core/colors.module.css
@@ -8,6 +8,8 @@
 :root {
   --color-white: #fff;
   --mb-color-brand: #509ee3;
+  --mb-color-brand-light: #f9fbfc;
+  --mb-color-brand-lighter: #eef6fc;
   --color-success: #84bb4c;
   --mb-color-summarize: #88bf4d;
   --color-error: #ed6e6e;

--- a/frontend/src/metabase/css/core/colors.module.css
+++ b/frontend/src/metabase/css/core/colors.module.css
@@ -7,6 +7,7 @@
  */
 :root {
   --color-white: #fff;
+  --mb-color-brand: #509ee3;
   --color-success: #84bb4c;
   --mb-color-summarize: #88bf4d;
   --color-error: #ed6e6e;

--- a/frontend/src/metabase/dashboard/components/AddSeriesModal/QuestionList.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/AddSeriesModal/QuestionList.styled.tsx
@@ -2,7 +2,6 @@ import styled from "@emotion/styled";
 
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import Input from "metabase/core/components/Input";
-import { color } from "metabase/lib/colors";
 
 export const QuestionListWrapper = styled(LoadingAndErrorWrapper)`
   flex: 1;

--- a/frontend/src/metabase/dashboard/components/AddSeriesModal/QuestionList.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/AddSeriesModal/QuestionList.styled.tsx
@@ -19,7 +19,7 @@ export const QuestionListContainer = styled.ul`
 
 export const LoadMoreButton = styled.button`
   align-items: center;
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   cursor: pointer;
   display: flex;
   font-family: var(--mb-default-font-family);

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarHeader/ClickBehaviorSidebarHeader.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarHeader/ClickBehaviorSidebarHeader.styled.tsx
@@ -1,7 +1,5 @@
 import styled from "@emotion/styled";
 
-import { color } from "metabase/lib/colors";
-
 export const ItemName = styled.span`
   color: var(--mb-color-brand);
 `;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarHeader/ClickBehaviorSidebarHeader.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarHeader/ClickBehaviorSidebarHeader.styled.tsx
@@ -3,7 +3,7 @@ import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 
 export const ItemName = styled.span`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
 `;
 
 export const ColumnClickBehaviorHeader = styled.div`
@@ -12,7 +12,7 @@ export const ColumnClickBehaviorHeader = styled.div`
   cursor: pointer;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/ValuesYouCanReference.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/ValuesYouCanReference.styled.tsx
@@ -10,6 +10,6 @@ export const PopoverTrigger = styled.div`
   color: ${color("text-medium")};
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/SidebarItem/SidebarItem.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/SidebarItem/SidebarItem.styled.tsx
@@ -31,7 +31,7 @@ export const BaseSidebarItemRoot = styled.div<{
   ${({ padded = true }) => padded && sidebarItemPaddingStyle}
 
   &:hover {
-    border-color: ${color("brand")};
+    border-color: var(--mb-color-brand);
   }
 `;
 
@@ -71,5 +71,5 @@ export const CloseIconContainer = styled.span`
   align-items: center;
   margin-left: auto;
   padding: 1rem;
-  border-left: 1px solid ${darken("brand", 0.2)};
+  border-left: 1px solid ${() => darken("brand", 0.2)};
 `;

--- a/frontend/src/metabase/dashboard/components/ClickMappings.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickMappings.styled.tsx
@@ -1,7 +1,5 @@
 import styled from "@emotion/styled";
 
-import { color } from "metabase/lib/colors";
-
 export const TargetTrigger = styled.div`
   display: flex;
   padding: 0.5rem;
@@ -11,7 +9,7 @@ export const TargetTrigger = styled.div`
   font-weight: bold;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
     background-color: var(--mb-color-bg-light);
   }
 `;

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.styled.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 
 import EntityMenu from "metabase/components/EntityMenu";
-import { color, lighten } from "metabase/lib/colors";
+import { lighten } from "metabase/lib/colors";
 
 export const CardMenuRoot = styled(EntityMenu)`
   display: flex;
@@ -11,6 +11,6 @@ export const CardMenuRoot = styled(EntityMenu)`
   color: ${lighten("text-light", 0.1)};
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.styled.tsx
@@ -47,7 +47,7 @@ export const TargetButton = styled.div<{ variant: string }>`
   justify-content: space-between;
   background-color: ${color("white")};
   cursor: pointer;
-  border: 2px solid ${color("brand")};
+  border: 2px solid var(--mb-color-brand);
   border-radius: 8px;
   min-height: 30px;
   padding: 0.25em 0.5em;
@@ -65,8 +65,8 @@ export const TargetButton = styled.div<{ variant: string }>`
   ${({ variant }) =>
     variant === "mapped" &&
     css`
-      border-color: ${color("brand")};
-      background-color: ${color("brand")};
+      border-color: var(--mb-color-brand);
+      background-color: var(--mb-color-brand);
       color: ${color("white")};
     `}
 

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DisabledNativeCardHelpText/DisabledNativeCardHelpText.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DisabledNativeCardHelpText/DisabledNativeCardHelpText.styled.tsx
@@ -25,7 +25,7 @@ export const NativeCardText = styled.div`
 `;
 
 export const NativeCardLink = styled(ExternalLink)`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   font-weight: bold;
   margin-top: 0.5rem;
 `;

--- a/frontend/src/metabase/dashboard/components/DashboardActions.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardActions.styled.tsx
@@ -20,7 +20,7 @@ export const ShareButton = styled(DashboardHeaderButton)<ShareButtonProps>`
 
 export const FullScreenButtonIcon = styled(FullscreenIcon)`
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 
@@ -28,12 +28,12 @@ export const NightModeButtonIcon = styled(NightModeIcon)`
   cursor: pointer;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 
 export const RefreshWidgetButton = styled(RefreshWidget)`
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.styled.tsx
@@ -34,7 +34,7 @@ export const DashboardHeaderButton = styled(Button)<{
   font-size: 1rem;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
     background: ${({ hasBackground }) =>
       hasBackground ? "var(--mb-color-bg-medium)" : "transparent"};
   }
@@ -63,6 +63,6 @@ export const SectionMenuItem = styled(Menu.Item)`
   background-color: ${() => darken(color("bg-medium"), 0.1)};
 
   &:hover {
-    background-color: ${color("brand")};
+    background-color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/dashboard/components/ParametersPopover.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/ParametersPopover.styled.tsx
@@ -3,7 +3,7 @@ import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 
 export const OptionItemTitle = styled.div`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
 `;
 
 export const OptionItemDescription = styled.div`
@@ -16,7 +16,7 @@ export const OptionItemRoot = styled.li`
 
   &:hover {
     color: ${color("white")};
-    background-color: ${color("brand")};
+    background-color: var(--mb-color-brand);
 
     ${OptionItemTitle}, ${OptionItemDescription} {
       color: ${color("white")};

--- a/frontend/src/metabase/dashboard/components/PublicLinkPopover/PublicLinkCopyPanel.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/PublicLinkPopover/PublicLinkCopyPanel.styled.tsx
@@ -10,7 +10,7 @@ export const PublicLinkCopyButton = styled(CopyButton)`
   cursor: pointer;
 
   &:hover {
-    color: ${({ theme }) => theme.fn.themeColor("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 

--- a/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.styled.tsx
+++ b/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.styled.tsx
@@ -13,7 +13,7 @@ export const ItemLink = styled(Link)`
   display: block;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 

--- a/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal/DashboardSharingEmbeddingModal.styled.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal/DashboardSharingEmbeddingModal.styled.tsx
@@ -1,9 +1,7 @@
 import styled from "@emotion/styled";
 
-import { color } from "metabase/lib/colors";
-
 export const ModalTrigger = styled.a`
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/databases/components/DatabaseConnectionSectionField/DatabaseConnectionSectionField.styled.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseConnectionSectionField/DatabaseConnectionSectionField.styled.tsx
@@ -1,10 +1,9 @@
 import styled from "@emotion/styled";
 
 import Button from "metabase/core/components/Button";
-import { color } from "metabase/lib/colors";
 
 export const SectionButton = styled(Button)`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   padding: 0;
   border: none;
   border-radius: 0;

--- a/frontend/src/metabase/databases/components/DatabaseEngineField/DatabaseEngineWidget.styled.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseEngineField/DatabaseEngineWidget.styled.tsx
@@ -40,8 +40,8 @@ export const EngineCardRoot = styled.li<EngineCardRootProps>`
   outline: ${props => (props.isActive ? `2px solid ${color("focus")}` : "")};
 
   &:hover {
-    border-color: ${color("brand")};
-    background-color: ${lighten("brand", 0.6)};
+    border-color: var(--mb-color-brand);
+    background-color: ${() => lighten("brand", 0.6)};
   }
 `;
 

--- a/frontend/src/metabase/databases/components/DatabaseEngineWarning/DatabaseEngineWarning.styled.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseEngineWarning/DatabaseEngineWarning.styled.tsx
@@ -1,14 +1,13 @@
 import styled from "@emotion/styled";
 
 import Alert from "metabase/core/components/Alert";
-import { color } from "metabase/lib/colors";
 
 export const Warning = styled(Alert)`
   margin-bottom: 2rem;
 `;
 
 export const WarningLink = styled.a`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   cursor: pointer;
   font-weight: bold;
 `;

--- a/frontend/src/metabase/databases/components/DatabaseForm/DatabaseForm.styled.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseForm/DatabaseForm.styled.tsx
@@ -1,14 +1,13 @@
 import styled from "@emotion/styled";
 
 import Button from "metabase/core/components/Button/Button";
-import { color } from "metabase/lib/colors";
 
 export const LinkFooter = styled.div`
   margin-top: 1rem;
 `;
 
 export const LinkButton = styled(Button)`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   font-weight: normal;
   padding: 0;
   border: none;

--- a/frontend/src/metabase/databases/components/DatabaseHostnameSectionField/DatabaseHostameSectionField.styled.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseHostnameSectionField/DatabaseHostameSectionField.styled.tsx
@@ -1,10 +1,9 @@
 import styled from "@emotion/styled";
 
 import Button from "metabase/core/components/Button";
-import { color } from "metabase/lib/colors";
 
 export const SectionButton = styled(Button)`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   padding: 0;
   border: none;
   border-radius: 0;

--- a/frontend/src/metabase/databases/components/DatabaseSectionField/DatabaseSectionField.styled.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseSectionField/DatabaseSectionField.styled.tsx
@@ -1,10 +1,9 @@
 import styled from "@emotion/styled";
 
 import Button from "metabase/core/components/Button";
-import { color } from "metabase/lib/colors";
 
 export const SectionButton = styled(Button)`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   padding: 0;
   border: none;
   border-radius: 0;

--- a/frontend/src/metabase/forms/components/FormSection/FormSection.styled.tsx
+++ b/frontend/src/metabase/forms/components/FormSection/FormSection.styled.tsx
@@ -1,7 +1,5 @@
 import styled from "@emotion/styled";
 
-import { color } from "metabase/lib/colors";
-
 export const CollapsibleSectionContent = styled.div`
   display: flex;
   align-items: center;
@@ -9,6 +7,6 @@ export const CollapsibleSectionContent = styled.div`
   margin-bottom: 1rem;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/forms/components/FormTextInput/FormTextInput.styled.tsx
+++ b/frontend/src/metabase/forms/components/FormTextInput/FormTextInput.styled.tsx
@@ -14,11 +14,11 @@ export const CopyWidgetButton = styled(CopyButton)`
   border-left: 1px solid var(--mb-color-border);
   border-top-right-radius: 4px;
   border-bottom-right-radius: 4px;
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   outline: none;
 
   &:hover {
     color: ${color("white")};
-    background-color: ${color("brand")};
+    background-color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/home/components/HomeLayout/HomeLayout.styled.tsx
+++ b/frontend/src/metabase/home/components/HomeLayout/HomeLayout.styled.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 
 import Button from "metabase/core/components/Button/Button";
-import { color, hueRotate, lighten } from "metabase/lib/colors";
+import { hueRotate, lighten } from "metabase/lib/colors";
 import {
   breakpointMinExtraLarge,
   breakpointMinLarge,
@@ -65,7 +65,7 @@ export const LayoutEditButton = styled(Button)`
   right: 1rem;
 
   &:hover {
-    color: ${color("brand")};
-    background: ${lighten("brand", 0.6)};
+    color: var(--mb-color-brand);
+    background: ${() => lighten("brand", 0.6)};
   }
 `;

--- a/frontend/src/metabase/home/components/HomeModelCard/HomeModelCard.styled.tsx
+++ b/frontend/src/metabase/home/components/HomeModelCard/HomeModelCard.styled.tsx
@@ -7,7 +7,7 @@ import { Icon } from "metabase/ui";
 export const CardIcon = styled(Icon)`
   display: block;
   flex: 0 0 auto;
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
 `;
 
 export const CardTitle = styled(Ellipsified)`

--- a/frontend/src/metabase/home/components/HomeXraySection/HomeXraySection.styled.tsx
+++ b/frontend/src/metabase/home/components/HomeXraySection/HomeXraySection.styled.tsx
@@ -24,7 +24,7 @@ export const DatabaseLinkIcon = styled(Icon)`
 `;
 
 export const DatabaseLinkText = styled.span`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   font-weight: bold;
 `;
 
@@ -36,13 +36,13 @@ export const SchemaTrigger = styled.span`
 `;
 
 export const SchemaTriggerIcon = styled(Icon)`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   width: 0.625rem;
   height: 0.625rem;
   margin-left: 0.25rem;
 `;
 
 export const SchemaTriggerText = styled.span`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   font-weight: bold;
 `;

--- a/frontend/src/metabase/lib/colors/palette.ts
+++ b/frontend/src/metabase/lib/colors/palette.ts
@@ -63,7 +63,7 @@ const aliases: Record<string, (palette: ColorPalette) => string> = {
   database: palette => color("accent2", palette),
   pulse: palette => color("accent4", palette),
 
-  "brand-light": palette => lighten(color("brand", palette), 0.532),
+  "brand-light": palette => lighten(color("brand", palette), 0.532), // #F9FBFC
   "brand-lighter": palette => lighten(color("brand", palette), 0.598), // #EEF6FC for brand
   focus: palette => getFocusColor("brand", palette),
 

--- a/frontend/src/metabase/metabot/components/ModelLink/ModelLink.styled.tsx
+++ b/frontend/src/metabase/metabot/components/ModelLink/ModelLink.styled.tsx
@@ -1,11 +1,10 @@
 import styled from "@emotion/styled";
 
 import Link from "metabase/core/components/Link/Link";
-import { color } from "metabase/lib/colors";
 
 export const ModelLinkRoot = styled(Link)`
   display: inline-flex;
   align-items: center;
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   font-weight: bold;
 `;

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionListItem.styled.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionListItem.styled.tsx
@@ -45,7 +45,7 @@ export const MenuIcon = styled(Icon)`
   cursor: pointer;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelInfoSidePanel/ModelInfoSidePanel.styled.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelInfoSidePanel/ModelInfoSidePanel.styled.tsx
@@ -46,5 +46,5 @@ export const ModelDescription = styled(EditableText)`
 
 export const ModelInfoLink = styled(Link)`
   ${commonInfoTextStyle}
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
 `;

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelInfoSidePanel/ModelRelationships.styled.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelInfoSidePanel/ModelRelationships.styled.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 
 import Link from "metabase/core/components/Link";
-import { color, darken } from "metabase/lib/colors";
+import { darken } from "metabase/lib/colors";
 
 import { valueBlockStyle } from "./ModelInfoSidePanel.styled";
 
@@ -21,13 +21,13 @@ export const ListItemLink = styled(Link)`
   display: flex;
   align-items: center;
 
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
 
   ${ListItemName} {
     margin-left: 4px;
   }
 
   &:hover {
-    color: ${darken("brand")};
+    color: ${() => darken("brand")};
   }
 `;

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelSchemaDetails/ModelSchemaDetails.styled.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelSchemaDetails/ModelSchemaDetails.styled.tsx
@@ -1,6 +1,5 @@
 import styled from "@emotion/styled";
 
-import { color } from "metabase/lib/colors";
 import { Icon } from "metabase/ui";
 
 export const SchemaHeader = styled.div`
@@ -34,6 +33,6 @@ export const FieldListItem = styled.li`
   }
 
   &:hover {
-    background-color: ${color("brand-light")};
+    background-color: var(--mb-color-brand-light);
   }
 `;

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelUsageDetails/ModelUsageDetails.styled.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelUsageDetails/ModelUsageDetails.styled.tsx
@@ -1,7 +1,6 @@
 import styled from "@emotion/styled";
 
 import Link from "metabase/core/components/Link";
-import { color } from "metabase/lib/colors";
 
 export const CardTitle = styled.span`
   font-weight: 700;
@@ -21,6 +20,6 @@ export const CardListItem = styled(Link)`
   }
 
   &:hover {
-    background-color: ${color("brand-light")};
+    background-color: var(--mb-color-brand-light);
   }
 `;

--- a/frontend/src/metabase/models/containers/NewModelOptions/NewModelOptions.styled.tsx
+++ b/frontend/src/metabase/models/containers/NewModelOptions/NewModelOptions.styled.tsx
@@ -31,14 +31,14 @@ export const OptionsRoot = styled.div`
 export const EducationalButton = styled(ExternalLink)`
   background-color: var(--mb-color-bg-medium);
   border-radius: 0.5rem;
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   font-weight: bold;
   padding: 1em;
   transition: all 0.3s;
 
   &:hover {
     color: ${color("white")};
-    background-color: ${color("brand")};
+    background-color: var(--mb-color-brand);
   }
 `;
 

--- a/frontend/src/metabase/nav/components/AppBar/AppBarToggle.styled.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarToggle.styled.tsx
@@ -24,7 +24,7 @@ interface SidebarIconProps {
 }
 
 export const SidebarIcon = styled(Icon)<SidebarIconProps>`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   display: block;
 
   ${props =>
@@ -33,7 +33,7 @@ export const SidebarIcon = styled(Icon)<SidebarIconProps>`
       color: ${color("text-medium")};
 
       &:hover {
-        color: ${color("brand")};
+        color: var(--mb-color-brand);
       }
     `}
 `;

--- a/frontend/src/metabase/nav/components/CollectionBreadcrumbs/CollectionBreadcrumbs.styled.tsx
+++ b/frontend/src/metabase/nav/components/CollectionBreadcrumbs/CollectionBreadcrumbs.styled.tsx
@@ -30,6 +30,6 @@ export const ExpandButton = styled(Button)`
 
   &:hover {
     color: ${color("text-white")};
-    background-color: ${color("brand")};
+    background-color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/nav/components/search/SearchResultsDropdown/SearchResultsDropdown.styled.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchResultsDropdown/SearchResultsDropdown.styled.tsx
@@ -1,4 +1,3 @@
-import type { Theme } from "@emotion/react";
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 
@@ -23,9 +22,9 @@ export const SearchResultsContainer = styled(Paper)<PaperProps>`
   }
 `;
 
-const selectedStyles = ({ theme }: { theme: Theme }) => css`
+const selectedStyles = css`
   color: var(--mb-color-brand);
-  background-color: ${theme.fn.themeColor("brand-lighter")};
+  background-color: var(--mb-color-brand-lighter);
   cursor: pointer;
   transition: all 0.2s ease-in-out;
 `;
@@ -35,8 +34,8 @@ export const SearchDropdownFooter = styled(Group, {
 })<{ isSelected?: boolean } & GroupProps>`
   border-top: 1px solid var(--mb-color-border);
 
-  ${({ theme, isSelected }) => isSelected && selectedStyles({ theme })}
+  ${({ isSelected }) => isSelected && selectedStyles}
   &:hover {
-    ${({ theme }) => selectedStyles({ theme })}
+    ${selectedStyles}
   }
 `;

--- a/frontend/src/metabase/nav/components/search/SearchResultsDropdown/SearchResultsDropdown.styled.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchResultsDropdown/SearchResultsDropdown.styled.tsx
@@ -24,7 +24,7 @@ export const SearchResultsContainer = styled(Paper)<PaperProps>`
 `;
 
 const selectedStyles = ({ theme }: { theme: Theme }) => css`
-  color: ${theme.fn.themeColor("brand")};
+  color: var(--mb-color-brand);
   background-color: ${theme.fn.themeColor("brand-lighter")};
   cursor: pointer;
   transition: all 0.2s ease-in-out;

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
@@ -150,7 +150,7 @@ export const AddYourOwnDataLink = styled(SidebarLink)`
   margin: ${space(1)};
   padding: 2px 6px;
   svg {
-    color: ${color("brand-light")};
+    color: var(--mb-color-brand-light);
   }
   transition: background-color 0.3s linear;
 
@@ -163,7 +163,7 @@ export const AddYourOwnDataLink = styled(SidebarLink)`
     color: ${color("white")};
 
     svg {
-      color: ${color("brand-light")} !important;
+      color: var(--mb-color-brand-light) !important;
     }
   }
 `;

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
@@ -129,7 +129,7 @@ export const LoadingAndErrorContent = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   text-align: center;
 `;
 
@@ -144,7 +144,7 @@ export const PaddedSidebarLink = styled(SidebarLink)`
 `;
 
 export const AddYourOwnDataLink = styled(SidebarLink)`
-  background: ${color("brand")};
+  background: var(--mb-color-brand);
   border-radius: 8px;
   color: ${color("white")};
   margin: ${space(1)};
@@ -159,7 +159,7 @@ export const AddYourOwnDataLink = styled(SidebarLink)`
   }
 
   &:hover {
-    background: ${lighten("brand", 0.12)};
+    background: ${() => lighten("brand", 0.12)};
     color: ${color("white")};
 
     svg {

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BookmarkList/BookmarkList.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BookmarkList/BookmarkList.styled.tsx
@@ -9,7 +9,7 @@ export const SidebarBookmarkItem = styled(DraggableSidebarLink)`
 
   &:hover {
     button {
-      color: ${color("brand")};
+      color: var(--mb-color-brand);
       opacity: 0.5;
 
       > svg:focus {

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/DraggableSidebarLink.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/DraggableSidebarLink.styled.tsx
@@ -32,7 +32,7 @@ export const StyledSidebarLink = styled(SidebarLink)<{ isDragging: boolean }>`
         background: var(--mb-color-bg-white);
 
         ${SidebarLink.Icon}, ${DragIcon} {
-          color: ${color("brand-light")} !important;
+          color: var(--mb-color-brand-light) !important;
         }
 
         ${SidebarLink.RightElement} {

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/DraggableSidebarLink.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/DraggableSidebarLink.styled.tsx
@@ -1,7 +1,6 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 
-import { color } from "metabase/lib/colors";
 import { Icon } from "metabase/ui";
 
 import SidebarLink from "./SidebarLink";

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarItems.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarItems.styled.tsx
@@ -15,7 +15,7 @@ export const SidebarIcon = styled(Icon)<{
   ${props =>
     !props.color &&
     css`
-      color: ${color("brand")};
+      color: var(--mb-color-brand);
     `}
 `;
 
@@ -25,11 +25,11 @@ SidebarIcon.defaultProps = {
 
 export const ExpandToggleButton = styled(TreeNode.ExpandToggleButton)`
   padding: 4px 0 4px 2px;
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
 `;
 
 const activeColorCSS = css`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
 `;
 
 function getTextColor(isSelected: boolean) {
@@ -52,11 +52,11 @@ export const NodeRoot = styled(TreeNode.Root)<{
   }
 
   &:hover {
-    background-color: ${alpha("brand", 0.35)};
-    color: ${color("brand")};
+    background-color: ${() => alpha("brand", 0.35)};
+    color: var(--mb-color-brand);
 
     ${ExpandToggleButton} {
-      color: ${color("brand")};
+      color: var(--mb-color-brand);
     }
 
     ${SidebarIcon} {
@@ -71,7 +71,7 @@ NodeRoot.defaultProps = {
 
 export const collectionDragAndDropHoverStyle = css`
   color: ${color("text-white")};
-  background-color: ${color("brand")};
+  background-color: var(--mb-color-brand);
 `;
 
 export const CollectionNodeRoot = styled(NodeRoot)<{ hovered?: boolean }>`
@@ -105,7 +105,7 @@ export const FullWidthButton = styled.button<{ isSelected: boolean }>`
     text-align: start;
 
     &:hover {
-      color: ${color("brand")};
+      color: var(--mb-color-brand);
     }
   }
 `;

--- a/frontend/src/metabase/palette/components/Palette.styled.tsx
+++ b/frontend/src/metabase/palette/components/Palette.styled.tsx
@@ -14,6 +14,6 @@ export const PaletteInput = styled(KBarSearch)`
   line-height: 1rem;
 
   &:focus {
-    outline: 1px solid ${color("brand")};
+    outline: 1px solid var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/parameters/components/ParameterLinkedFilters/ParameterLinkedFilters.styled.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterLinkedFilters/ParameterLinkedFilters.styled.tsx
@@ -16,7 +16,7 @@ export const SectionMessage = styled.p`
 `;
 
 export const SectionMessageLink = styled.span`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   cursor: pointer;
 `;
 
@@ -49,7 +49,7 @@ export const FieldListHeader = styled.div`
 `;
 
 export const FieldListTitle = styled.div`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   width: 50%;
   padding: 0.5rem 1rem 0;
 `;

--- a/frontend/src/metabase/parameters/components/ValuesSourceSettings/ValuesSourceSettings.styled.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceSettings/ValuesSourceSettings.styled.tsx
@@ -17,7 +17,7 @@ export const RadioLabelButton = styled(IconButtonWrapper)`
   font-weight: bold;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 

--- a/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/InteractiveEmbeddingCTA/InteractiveEmbeddingCTA.styled.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/InteractiveEmbeddingCTA/InteractiveEmbeddingCTA.styled.tsx
@@ -11,12 +11,12 @@ export const CTAContainer = styled(Paper)<PaperProps>``;
 
 export const ClickIcon = styled(Icon)`
   ${CTAContainer}:hover & {
-    color: ${({ theme }) => theme.fn.themeColor("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 
 export const CTAHeader = styled(Title)`
   ${CTAContainer}:hover & {
-    color: ${({ theme }) => theme.fn.themeColor("brand")};
+    color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SharingPaneButton/SharingPaneButton.styled.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SharingPaneButton/SharingPaneButton.styled.tsx
@@ -20,7 +20,7 @@ export const SharingPaneButtonTitle = styled(Title)<SharingPaneElementProps>`
     !disabled
       ? css`
           ${SharingPaneButtonContent}:hover & {
-            color: ${theme.fn.themeColor("brand")};
+            color: var(--mb-color-brand);
           }
         `
       : css`
@@ -31,11 +31,11 @@ export const SharingPaneButtonTitle = styled(Title)<SharingPaneElementProps>`
 export const SharingPaneActionButton = styled(Button)<
   ButtonProps & HTMLAttributes<HTMLButtonElement> & SharingPaneElementProps
 >`
-  ${({ disabled, theme }) =>
+  ${({ disabled }) =>
     !disabled &&
     css`
       ${SharingPaneButtonContent}:hover & {
-        background-color: ${theme.fn.themeColor("brand")};
+        background-color: var(--mb-color-brand);
         color: white;
       }
     `}

--- a/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/icons/PublicEmbedIcon/PublicEmbedIcon.styled.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/icons/PublicEmbedIcon/PublicEmbedIcon.styled.tsx
@@ -19,14 +19,14 @@ export const PublicEmbedIconRoot = styled.svg<PublicEmbedIconRootProps>`
     }
   `}
 
-  ${({ disabled, theme }) =>
+  ${({ disabled }) =>
     !disabled &&
     css`
       ${SharingPaneButtonContent}:hover & {
         color: var(--mb-color-bg-dark);
 
         .innerFill {
-          stroke: ${theme.fn.themeColor("brand")};
+          stroke: var(--mb-color-brand);
         }
       }
     `}

--- a/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/icons/StaticEmbedIcon/StaticEmbedIcon.styled.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/icons/StaticEmbedIcon/StaticEmbedIcon.styled.tsx
@@ -17,7 +17,7 @@ export const StaticEmbedIconRoot = styled.svg`
         color: ${theme.fn.themeColor("focus")};
 
         .innerFill {
-          fill: ${theme.fn.themeColor("brand")};
+          fill: var(--mb-color-brand);
           fill-opacity: 1;
         }
       }

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/CodeSample.styled.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/CodeSample.styled.tsx
@@ -8,6 +8,6 @@ export const CopyButtonContainer = styled.div`
   z-index: 2;
 
   &:hover {
-    color: ${({ theme }) => theme.fn.themeColor("brand")};
+    color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.styled.tsx
@@ -37,7 +37,7 @@ const BackButtonLabel = styled.span`
   word-wrap: anywhere;
 
   :hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 

--- a/frontend/src/metabase/query_builder/components/DataSelector/saved-entity-picker/SavedEntityPicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/saved-entity-picker/SavedEntityPicker.styled.tsx
@@ -39,7 +39,7 @@ export const BackButton = styled.a`
   padding: 1rem;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.styled.tsx
@@ -20,7 +20,7 @@ export const TabHintToastContainer = styled.div<{ isVisible: boolean }>`
 `;
 
 export const DatasetEditBar = styled(EditBar)`
-  background-color: ${color("brand")};
+  background-color: var(--mb-color-brand);
 `;
 
 export const TableHeaderColumnName = styled.div<{ isSelected: boolean }>`
@@ -36,12 +36,12 @@ export const TableHeaderColumnName = styled.div<{ isSelected: boolean }>`
   text-overflow: ellipsis;
   overflow-x: hidden;
 
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   background-color: transparent;
   font-weight: bold;
   cursor: pointer;
 
-  border: 1px solid ${color("brand")};
+  border: 1px solid var(--mb-color-brand);
   border-radius: 8px;
 
   transition: all 0.25s;
@@ -50,7 +50,7 @@ export const TableHeaderColumnName = styled.div<{ isSelected: boolean }>`
     props.isSelected &&
     css`
       color: ${color("text-white")};
-      background-color: ${color("brand")};
+      background-color: var(--mb-color-brand);
     `}
 
   .Icon {
@@ -60,11 +60,11 @@ export const TableHeaderColumnName = styled.div<{ isSelected: boolean }>`
 
   &:hover {
     color: ${color("white")};
-    background-color: ${color("brand")};
+    background-color: var(--mb-color-brand);
 
     .Icon {
       background-color: ${color("white")};
-      color: ${color("brand")};
+      color: var(--mb-color-brand);
     }
   }
 `;

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.styled.tsx
@@ -18,7 +18,7 @@ const FormContainer = styled.div`
   }
 
   ${SelectButton.Root}:focus {
-    border-color: ${color("brand")};
+    border-color: var(--mb-color-brand);
   }
 `;
 

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/MappedFieldPicker/MappedFieldPicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/MappedFieldPicker/MappedFieldPicker.styled.tsx
@@ -9,8 +9,8 @@ export const StyledSelectButton = styled(SelectButton)`
     props.hasValue &&
     css`
       color: ${color("text-white")} !important;
-      background-color: ${color("brand")};
-      border-color: ${color("brand")};
+      background-color: var(--mb-color-brand);
+      border-color: var(--mb-color-brand);
 
       .Icon {
         color: ${color("text-white")};

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.styled.tsx
@@ -61,7 +61,7 @@ const aceEditorStyle = css`
   }
 
   .ace_editor .ace_templateTag {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 
   .react-resizable {
@@ -114,7 +114,7 @@ export const aceEditorStyles = css`
   }
 
   .ace_completion-highlight {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 
   .ace_editor.ace_autocomplete .ace_line {

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.styled.tsx
@@ -108,7 +108,7 @@ export const aceEditorStyles = css`
 
   .ace_editor.ace_autocomplete .ace_marker-layer .ace_active-line,
   .ace_editor.ace_autocomplete .ace_marker-layer .ace_line-hover {
-    background-color: ${color("brand-light")};
+    background-color: var(--mb-color-brand-light);
     border: none;
     outline: none;
   }

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/VisibilityToggler/VisibilityToggler.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/VisibilityToggler/VisibilityToggler.styled.tsx
@@ -29,7 +29,7 @@ export const ToggleContent = styled.a<ToggleContentProps>`
   transition: all 0.2s linear;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 

--- a/frontend/src/metabase/query_builder/components/QueryDownloadPopover/QueryDownloadPopover.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryDownloadPopover/QueryDownloadPopover.styled.tsx
@@ -34,7 +34,7 @@ export const DownloadButtonRoot = styled.button`
   cursor: pointer;
 
   &:hover {
-    background-color: ${color("brand")};
+    background-color: var(--mb-color-brand);
   }
 `;
 

--- a/frontend/src/metabase/query_builder/components/QueryDownloadWidget/QueryDownloadWidget.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryDownloadWidget/QueryDownloadWidget.styled.tsx
@@ -7,7 +7,7 @@ export const DownloadIcon = styled(Icon)`
   color: ${color("text-medium")};
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
     cursor: pointer;
   }
 `;

--- a/frontend/src/metabase/query_builder/components/QuestionEmbedWidget/QuestionEmbedWidget.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionEmbedWidget/QuestionEmbedWidget.styled.tsx
@@ -1,6 +1,5 @@
 import styled from "@emotion/styled";
 
-import { color } from "metabase/lib/colors";
 import { breakpointMinSmall } from "metabase/styled-components/theme";
 import { Icon } from "metabase/ui";
 
@@ -10,7 +9,7 @@ export const TriggerIcon = styled(Icon)`
   cursor: pointer;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 
   ${breakpointMinSmall} {

--- a/frontend/src/metabase/query_builder/components/ResponsiveParametersList.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/ResponsiveParametersList.styled.tsx
@@ -2,7 +2,6 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 
 import Button from "metabase/core/components/Button";
-import { color } from "metabase/lib/colors";
 
 import { SyncedParametersList } from "../../parameters/components/ParametersList";
 

--- a/frontend/src/metabase/query_builder/components/ResponsiveParametersList.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/ResponsiveParametersList.styled.tsx
@@ -7,7 +7,7 @@ import { color } from "metabase/lib/colors";
 import { SyncedParametersList } from "../../parameters/components/ParametersList";
 
 export const FilterButton = styled(Button)`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   margin: 0.5rem;
 `;
 

--- a/frontend/src/metabase/query_builder/components/SidebarHeader/SidebarHeader.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/SidebarHeader/SidebarHeader.styled.tsx
@@ -16,7 +16,7 @@ export const HeaderIcon = styled(Icon)`
 const backButtonStyle = () => css`
   cursor: pointer;
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 
@@ -66,6 +66,6 @@ export const CloseButton = styled.a`
   margin-left: auto;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/query_builder/components/VisualizationError/VisualizationError.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/VisualizationError/VisualizationError.styled.tsx
@@ -46,14 +46,14 @@ export const QueryErrorMessage = styled.div`
   font-family: ${monospaceFontFamily};
   font-size: 0.75rem;
   line-height: 1.125rem;
-  border: 1px solid ${color("brand")};
+  border: 1px solid var(--mb-color-brand);
   border-radius: 0.5rem;
   background-color: var(--mb-color-bg-light);
   overflow-wrap: break-word;
 `;
 
 export const QueryErrorLink = styled(ExternalLink)`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   margin: 1rem 0;
   font-size: 0.75rem;
   line-height: 1rem;

--- a/frontend/src/metabase/query_builder/components/dataref/NodeList.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/dataref/NodeList.styled.tsx
@@ -33,7 +33,7 @@ export const NodeListItemLink = styled.a<NodeListItemLinkProps>`
   border-radius: 8px;
   display: flex;
   align-items: center;
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   font-weight: 700;
   overflow-wrap: anywhere;
   word-break: break-word;

--- a/frontend/src/metabase/query_builder/components/dataref/QuestionPane/QuestionPane.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/dataref/QuestionPane/QuestionPane.styled.tsx
@@ -19,7 +19,7 @@ export const QuestionPaneDetailLinkText = styled.span`
 export const QuestionPaneDetailLink = styled.a`
   display: flex;
   align-items: center;
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
 `;
 
 export const QuestionPaneDetailText = styled.span`

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText/ExpressionEditorHelpText.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText/ExpressionEditorHelpText.styled.tsx
@@ -70,7 +70,7 @@ export const DocumentationLink = styled(ExternalLink)`
   align-items: center;
   margin-top: 1rem;
 
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   font-weight: 700;
 `;
 

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.styled.tsx
@@ -17,7 +17,7 @@ export const SuggestionMatch = styled.span`
 
 const highlighted = css`
   color: ${color("white")};
-  background-color: ${color("brand")};
+  background-color: var(--mb-color-brand);
 `;
 
 export const ExpressionListItem = styled.li<{ isHighlighted: boolean }>`

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.styled.tsx
@@ -21,7 +21,7 @@ export const EditorContainer = styled.div<{
   ${({ isFocused }) =>
     isFocused &&
     css`
-      border-color: ${color("brand")};
+      border-color: var(--mb-color-brand);
     `}
 
   ${({ hasError }) =>
@@ -57,7 +57,7 @@ export const EditorContainer = styled.div<{
   }
 
   .ace-tm .ace_variable {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 
   .ace-tm .ace_string {

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidgetInfo/ExpressionWidgetInfo.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidgetInfo/ExpressionWidgetInfo.styled.tsx
@@ -1,7 +1,6 @@
 import styled from "@emotion/styled";
 
 import ExternalLink from "metabase/core/components/ExternalLink";
-import { color } from "metabase/lib/colors";
 import { Icon } from "metabase/ui";
 
 export const InfoLink = styled(ExternalLink)`
@@ -9,7 +8,7 @@ export const InfoLink = styled(ExternalLink)`
 
   &:hover,
   :focus {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinCondition/JoinCondition.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinCondition/JoinCondition.styled.tsx
@@ -1,9 +1,8 @@
 import styled from "@emotion/styled";
 
-import { color } from "metabase/lib/colors";
 import { Flex } from "metabase/ui";
 
 export const JoinConditionRoot = styled(Flex)`
   border-radius: 0.5rem;
-  background-color: ${color("brand")};
+  background-color: var(--mb-color-brand);
 `;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionColumnPicker/JoinConditionColumnPicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionColumnPicker/JoinConditionColumnPicker.styled.tsx
@@ -1,23 +1,23 @@
-import { css } from "@emotion/react";
+import { css, type Theme } from "@emotion/react";
 import styled from "@emotion/styled";
 
 import { QueryColumnPicker } from "metabase/common/components/QueryColumnPicker/QueryColumnPicker";
 import { alpha, color, lighten } from "metabase/lib/colors";
 
-const noColumnStyle = (isOpen = false) => css`
+const getNoColumnStyle = (theme: Theme, isOpen = false) => css`
   min-height: 34px;
   padding: 8px 20px;
-  color: ${alpha("brand", 0.45)};
-  border: 2px solid ${isOpen ? color("brand") : alpha("brand", 0.45)};
+  color: ${alpha(theme.fn.themeColor("brand"), 0.45)};
+  border: 2px solid ${isOpen ? "var(--mb-color-brand)" : alpha("brand", 0.45)};
   border-radius: 4px;
 
   &:hover,
   &:focus {
-    border-color: ${color("brand")};
+    border-color: var(--mb-color-brand);
   }
 `;
 
-const hasColumnStyle = (isOpen = false) => css`
+const getHasColumnStyle = (theme: Theme, isOpen = false) => css`
   min-height: 39px;
   padding: 6px 16px 6px 10px;
   border-radius: 6px;
@@ -26,7 +26,7 @@ const hasColumnStyle = (isOpen = false) => css`
 
   &:hover,
   &:focus {
-    background-color: ${lighten("brand", 0.1)};
+    background-color: ${lighten(theme.fn.themeColor("brand"), 0.1)};
   }
 `;
 
@@ -40,15 +40,15 @@ export const JoinCellItem = styled.button<{
   justify-content: center;
   gap: 2px;
 
-  ${props =>
-    props.isColumnSelected
-      ? hasColumnStyle(props.isOpen)
-      : noColumnStyle(props.isOpen)};
+  ${({ isColumnSelected, isOpen, theme }) =>
+    isColumnSelected
+      ? getHasColumnStyle(theme, isOpen)
+      : getNoColumnStyle(theme, isOpen)};
 
   cursor: ${props => (props.isReadOnly ? "default" : "pointer")};
   transition: background 300ms linear, border 300ms linear, color 300ms linear;
 `;
 
 export const JoinColumnPicker = styled(QueryColumnPicker)`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
 `;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionDraft/JoinConditionDraft.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionDraft/JoinConditionDraft.styled.tsx
@@ -6,5 +6,5 @@ import { Flex } from "metabase/ui";
 export const JoinConditionRoot = styled(Flex)`
   border-radius: 0.5rem;
   transition: background-color 300ms linear;
-  background-color: ${alpha("brand", 0.15)};
+  background-color: ${() => alpha("brand", 0.15)};
 `;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionOperatorPicker/JoinConditionOperatorPicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionOperatorPicker/JoinConditionOperatorPicker.styled.tsx
@@ -1,26 +1,26 @@
-import { css } from "@emotion/react";
+import { css, type Theme } from "@emotion/react";
 import styled from "@emotion/styled";
 
 import SelectList from "metabase/components/SelectList";
 import { color, lighten } from "metabase/lib/colors";
 
-const completeConditionStyle = (isOpened = false) => css`
+const getCompleteConditionStyle = (theme: Theme, isOpened = false) => css`
   color: ${color("white")};
   background-color: ${isOpened ? lighten("brand", 0.1) : "transparent"};
 
   &:hover,
   &:focus {
-    background-color: ${lighten("brand", 0.1)};
+    background-color: ${lighten(theme.fn.themeColor("brand"), 0.1)};
   }
 `;
 
-const incompleteConditionStyle = (isOpened = false) => css`
-  color: ${color("brand")};
+const getIncompleteConditionStyle = (isOpened = false) => css`
+  color: var(--mb-color-brand);
   border: 2px solid ${isOpened ? color("brand") : "transparent"};
 
   &:hover,
   &:focus {
-    border: 2px solid ${color("brand")};
+    border: 2px solid var(--mb-color-brand);
   }
 `;
 
@@ -30,8 +30,8 @@ export const OperatorPickerButton = styled.button<{
 }>`
   ${props =>
     props.isConditionComplete
-      ? completeConditionStyle(props.isOpened)
-      : incompleteConditionStyle(props.isOpened)}
+      ? getCompleteConditionStyle(props.theme, props.isOpened)
+      : getIncompleteConditionStyle(props.isOpened)}
 
   font-size: 16px;
   padding: 4px 8px;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStrategyPicker/JoinStrategyPicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStrategyPicker/JoinStrategyPicker.styled.tsx
@@ -1,11 +1,10 @@
 import styled from "@emotion/styled";
 
 import SelectList from "metabase/components/SelectList";
-import { color } from "metabase/lib/colors";
 import { Icon } from "metabase/ui";
 
 export const JoinStrategyIcon = styled(Icon)`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
 `;
 
 export const JoinStrategyList = styled(SelectList)`

--- a/frontend/src/metabase/query_builder/components/template_tags/SnippetRow/SnippetRow.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/SnippetRow/SnippetRow.styled.tsx
@@ -4,13 +4,13 @@ import Button from "metabase/core/components/Button";
 import { color } from "metabase/lib/colors";
 
 export const SnippetButton = styled(Button)`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   background-color: var(--mb-color-bg-light);
   margin-top: 0.5rem;
 
   &:hover {
     color: ${color("white")};
-    background-color: ${color("brand")};
+    background-color: var(--mb-color-brand);
   }
 `;
 
@@ -18,6 +18,6 @@ export const SnippetContent = styled.div`
   display: flex;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar/SnippetSidebar.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar/SnippetSidebar.styled.tsx
@@ -16,10 +16,10 @@ export const SidebarFooter = styled.div`
   cursor: pointer;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
 
     ${SidebarIcon} {
-      color: ${color("brand")};
+      color: var(--mb-color-brand);
     }
   }
 `;
@@ -28,7 +28,7 @@ export const SnippetTitle = styled.span`
   cursor: pointer;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 
@@ -42,7 +42,7 @@ export const SearchSnippetIcon = styled(Icon)<SearchSnippetIconProps>`
   margin-right: 0.5rem;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 
@@ -52,7 +52,7 @@ interface AddSnippetIconProps {
 
 export const AddSnippetIcon = styled(Icon)<AddSnippetIconProps>`
   display: ${props => props.isHidden && "none"};
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   cursor: pointer;
   padding: 0.5rem;
   border-radius: 0.5rem;
@@ -68,7 +68,7 @@ export const MenuIconContainer = styled.div`
   cursor: pointer;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
     background-color: var(--mb-color-bg-medium);
   }
 `;
@@ -83,6 +83,6 @@ export const HideSearchIcon = styled(Icon)<HideSearchIconProps>`
   padding: 0.5rem;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/TagEditorParam.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/TagEditorParam.styled.tsx
@@ -12,7 +12,7 @@ export const TagName = styled.h3`
   font-weight: 900;
   margin-bottom: 2rem;
   align-self: flex-end;
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
 `;
 
 interface ContainerLabelProps {

--- a/frontend/src/metabase/query_builder/components/view/DataReferenceButton/DataReferenceButton.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/DataReferenceButton/DataReferenceButton.styled.tsx
@@ -11,6 +11,6 @@ export const ButtonRoot = styled.a<ButtonRootProps>`
   transition: color 0.3s linear;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/query_builder/components/view/NativeCodePanel/NativeCodePanel.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/NativeCodePanel/NativeCodePanel.styled.tsx
@@ -43,7 +43,7 @@ export const CodeCopyButton = styled(IconButtonWrapper)<CodeCopyButtonProps>`
   right: 1rem;
   width: 1rem;
   height: 1rem;
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   background-color: ${props =>
     props.isHighlighted ? color("brand-light") : "var(--mb-color-bg-light)"};
   visibility: hidden;

--- a/frontend/src/metabase/query_builder/components/view/NativeCodePanel/NativeCodePanel.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/NativeCodePanel/NativeCodePanel.styled.tsx
@@ -19,7 +19,9 @@ export const CodeContainer = styled.pre<CodeContainerProps>`
       props.isHighlighted ? color("brand") : "var(--mb-color-border)"};
   border-radius: 0.5rem;
   background-color: ${props =>
-    props.isHighlighted ? color("brand-light") : "var(--mb-color-bg-light)"};
+    props.isHighlighted
+      ? "var(--mb-color-brand-light)"
+      : "var(--mb-color-bg-light)"};
   overflow: auto;
 `;
 
@@ -45,7 +47,9 @@ export const CodeCopyButton = styled(IconButtonWrapper)<CodeCopyButtonProps>`
   height: 1rem;
   color: var(--mb-color-brand);
   background-color: ${props =>
-    props.isHighlighted ? color("brand-light") : "var(--mb-color-bg-light)"};
+    props.isHighlighted
+      ? "var(--mb-color-brand-light)"
+      : "var(--mb-color-bg-light)"};
   visibility: hidden;
 `;
 

--- a/frontend/src/metabase/query_builder/components/view/NativeVariablesButton/NativeVariablesButton.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/NativeVariablesButton/NativeVariablesButton.styled.tsx
@@ -11,6 +11,6 @@ export const ButtonRoot = styled.a<ButtonRootProps>`
   transition: color 0.3s linear;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/query_builder/components/view/PreviewQueryButton/PreviewQueryButton.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/PreviewQueryButton/PreviewQueryButton.styled.tsx
@@ -9,7 +9,7 @@ export const PreviewButton = styled(IconButtonWrapper)`
   color: ${color("text-dark")};
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 

--- a/frontend/src/metabase/query_builder/components/view/PreviewQueryModal/PreviewQueryModal.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/PreviewQueryModal/PreviewQueryModal.styled.tsx
@@ -1,10 +1,9 @@
 import styled from "@emotion/styled";
 
 import ExternalLink from "metabase/core/components/ExternalLink";
-import { color } from "metabase/lib/colors";
 
 export const ModalExternalLink = styled(ExternalLink)`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   font-size: 0.75rem;
   line-height: 1rem;
   font-weight: bold;

--- a/frontend/src/metabase/query_builder/components/view/QuestionAlertWidget.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionAlertWidget.styled.tsx
@@ -1,12 +1,11 @@
 import styled from "@emotion/styled";
 
-import { color } from "metabase/lib/colors";
 import { Icon } from "metabase/ui";
 
 export const AlertIcon = styled(Icon)`
   cursor: pointer;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.styled.tsx
@@ -10,7 +10,7 @@ export const RowCountButton = styled.button<{ highlighted?: boolean }>`
   cursor: pointer;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 

--- a/frontend/src/metabase/query_builder/components/view/QuestionTimelineWidget/QuestionTimelineWidget.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionTimelineWidget/QuestionTimelineWidget.styled.tsx
@@ -1,6 +1,5 @@
 import styled from "@emotion/styled";
 
-import { color } from "metabase/lib/colors";
 import { Icon } from "metabase/ui";
 
 export const TimelineIcon = styled(Icon)`
@@ -9,6 +8,6 @@ export const TimelineIcon = styled(Icon)`
   cursor: pointer;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/query_builder/components/view/SnippetSidebarButton/SnippetSidebarButton.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/SnippetSidebarButton/SnippetSidebarButton.styled.tsx
@@ -11,6 +11,6 @@ export const ButtonRoot = styled.a<ButtonRootProps>`
   transition: color 0.3s linear;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewHeader.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewHeader.styled.tsx
@@ -52,7 +52,7 @@ export const AdHocViewHeading = styled(ViewHeading)`
 `;
 
 export const BackButton = styled(Button)`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   padding: 0.75rem;
 `;
 
@@ -61,7 +61,7 @@ export const BackButtonContainer = styled.span`
 `;
 
 export const SaveButton = styled(Link)`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   font-weight: bold;
   padding: 0.5rem 1rem;
   border-radius: 8px;
@@ -197,7 +197,7 @@ export const ViewHeaderIconButtonContainer = styled.div`
     width: 2rem;
 
     &:hover {
-      color: ${color("brand")};
+      color: var(--mb-color-brand);
       background-color: var(--mb-color-bg-medium);
     }
   }

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/ToggleNativeQueryPreview/ToggleNativeQueryPreview.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/ToggleNativeQueryPreview/ToggleNativeQueryPreview.styled.tsx
@@ -15,9 +15,9 @@ export const SqlButton = styled(IconButtonWrapper)<SqlButtonProps>`
   width: 2rem;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
     background-color: var(--mb-color-bg-medium);
-    border: 1px solid ${color("brand")};
+    border: 1px solid var(--mb-color-brand);
     transition: all 200ms linear;
   }
 `;

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.styled.tsx
@@ -25,14 +25,14 @@ export const OptionRoot = styled.div<OptionRootProps>`
     `
     ${OptionIconContainer} {
       &, &:hover {
-      background-color: ${color("brand")};
+      background-color: var(--mb-color-brand);
       color: ${getOptionIconColor(props)};
       border: 1px solid transparent;
       }
     }
 
     ${OptionText} {
-      color: ${color("brand")};
+      color: var(--mb-color-brand);
     }
   `}
 `;
@@ -73,8 +73,8 @@ export const OptionIconContainer = styled.div<OptionIconContainerProps>`
   cursor: pointer;
   padding: 0.875rem;
   &:hover {
-    color: ${color("brand")};
-    background-color: ${alpha("brand", 0.15)};
+    color: var(--mb-color-brand);
+    background-color: ${() => alpha("brand", 0.15)};
     border: 1px solid transparent;
 
     ${SettingsButton} {

--- a/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetManagementSection.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetManagementSection.styled.tsx
@@ -23,7 +23,7 @@ export const Row = styled.div`
 
 export const Button = styled(DefaultButton)`
   padding: 8px;
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   font-weight: 700;
   border: none;
 `;

--- a/frontend/src/metabase/querying/components/FilterModal/DateFilterEditor/DateFilterEditor.styled.tsx
+++ b/frontend/src/metabase/querying/components/FilterModal/DateFilterEditor/DateFilterEditor.styled.tsx
@@ -1,8 +1,7 @@
 import styled from "@emotion/styled";
 
-import { color } from "metabase/lib/colors";
 import { Icon } from "metabase/ui";
 
 export const ClearIcon = styled(Icon)`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
 `;

--- a/frontend/src/metabase/questions/components/QuestionMoveToast/QuestionMoveToast.styled.tsx
+++ b/frontend/src/metabase/questions/components/QuestionMoveToast/QuestionMoveToast.styled.tsx
@@ -16,6 +16,6 @@ export const StyledIcon = styled(Icon)`
 `;
 
 export const CollectionLink = styled(Collections.Link)`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   margin-left: ${space(0)};
 `;

--- a/frontend/src/metabase/search/components/CollectionBadge.styled.tsx
+++ b/frontend/src/metabase/search/components/CollectionBadge.styled.tsx
@@ -1,7 +1,6 @@
 import styled from "@emotion/styled";
 
 import Link from "metabase/core/components/Link";
-import { color } from "metabase/lib/colors";
 
 export const CollectionBadgeRoot = styled.div`
   display: inline-block;
@@ -13,6 +12,6 @@ export const CollectionLink = styled(Link)`
   text-decoration: dashed;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/search/components/DropdownSidebarFilter/DropdownSidebarFilter.styled.tsx
+++ b/frontend/src/metabase/search/components/DropdownSidebarFilter/DropdownSidebarFilter.styled.tsx
@@ -12,9 +12,9 @@ export const DropdownFieldSet = styled(FieldSet)<{
   overflow: hidden;
 
   border: 2px solid
-    ${({ theme, fieldHasValueOrFocus }) =>
+    ${({ fieldHasValueOrFocus }) =>
       fieldHasValueOrFocus
-        ? theme.fn.themeColor("brand")
+        ? "var(--mb-color-brand)"
         : "var(--mb-color-border)"};
 
   margin: 0;
@@ -38,8 +38,8 @@ export const DropdownFieldSet = styled(FieldSet)<{
 
   &,
   legend {
-    color: ${({ theme, fieldHasValueOrFocus }) =>
-      fieldHasValueOrFocus && theme.fn.themeColor("brand")};
+    color: ${({ fieldHasValueOrFocus }) =>
+      fieldHasValueOrFocus && "var(--mb-color-brand)"};
   }
 `;
 

--- a/frontend/src/metabase/search/components/InfoText/InfoTextEditedInfo.styled.tsx
+++ b/frontend/src/metabase/search/components/InfoText/InfoTextEditedInfo.styled.tsx
@@ -15,7 +15,7 @@ export const LastEditedInfoText = styled(LastEditInfoLabel)`
       cursor: pointer;
 
       &:hover {
-        color: ${theme.fn.themeColor("brand")};
+        color: var(--mb-color-brand);
       }
     `;
   }}

--- a/frontend/src/metabase/search/components/SearchResult/SearchResult.styled.tsx
+++ b/frontend/src/metabase/search/components/SearchResult/SearchResult.styled.tsx
@@ -34,7 +34,7 @@ export const ResultTitle = styled(Anchor)<
   &:focus-visible,
   &:focus {
     text-decoration: none;
-    color: ${({ theme }) => theme.fn.themeColor("brand")};
+    color: var(--mb-color-brand);
     outline: 0;
   }
 `;
@@ -62,11 +62,11 @@ export const SearchResultContainer = styled(Box, {
     isActive &&
     css`
       border-radius: ${theme.radius.md};
-      color: ${isSelected && theme.fn.themeColor("brand")};
+      color: ${isSelected && "var(--mb-color-brand)"};
       background-color: ${isSelected && theme.fn.themeColor("brand-lighter")};
 
       ${ResultTitle} {
-        color: ${isSelected && theme.fn.themeColor("brand")};
+        color: ${isSelected && "var(--mb-color-brand)"};
       }
 
       &:hover {
@@ -74,7 +74,7 @@ export const SearchResultContainer = styled(Box, {
         cursor: pointer;
 
         ${ResultTitle} {
-          color: ${theme.fn.themeColor("brand")};
+          color: var(--mb-color-brand);
         }
       }
 

--- a/frontend/src/metabase/search/components/SearchResult/SearchResult.styled.tsx
+++ b/frontend/src/metabase/search/components/SearchResult/SearchResult.styled.tsx
@@ -63,14 +63,14 @@ export const SearchResultContainer = styled(Box, {
     css`
       border-radius: ${theme.radius.md};
       color: ${isSelected && "var(--mb-color-brand)"};
-      background-color: ${isSelected && theme.fn.themeColor("brand-lighter")};
+      background-color: ${isSelected && "var(--mb-color-brand-lighter)"};
 
       ${ResultTitle} {
         color: ${isSelected && "var(--mb-color-brand)"};
       }
 
       &:hover {
-        background-color: ${theme.fn.themeColor("brand-lighter")};
+        background-color: var(--mb-color-brand-lighter);
         cursor: pointer;
 
         ${ResultTitle} {
@@ -79,7 +79,7 @@ export const SearchResultContainer = styled(Box, {
       }
 
       &:focus-within {
-        background-color: ${theme.fn.themeColor("brand-lighter")};
+        background-color: var(--mb-color-brand-lighter);
       }
     `}
 `;

--- a/frontend/src/metabase/search/components/SearchResultLink/SearchResultLink.styled.tsx
+++ b/frontend/src/metabase/search/components/SearchResultLink/SearchResultLink.styled.tsx
@@ -9,14 +9,14 @@ type ResultLinkProps = AnchorProps | TextProps;
 export const ResultLink = styled.a<ResultLinkProps>`
   line-height: unset;
 
-  ${({ theme, href }) => {
+  ${({ href }) => {
     return (
       href &&
       css`
         &:hover,
         &:focus,
         &:focus-within {
-          color: ${theme.fn.themeColor("brand")};
+          color: var(--mb-color-brand);
           outline: 0;
         }
       `

--- a/frontend/src/metabase/search/components/UserListElement/UserListElement.styled.tsx
+++ b/frontend/src/metabase/search/components/UserListElement/UserListElement.styled.tsx
@@ -10,7 +10,7 @@ export const UserElement = styled(Button)<
   flex-shrink: 0;
 
   &:hover {
-    background-color: ${({ theme }) => theme.fn.themeColor("brand-lighter")};
+    background-color: var(--mb-color-brand-lighter);
   }
 
   & > div {

--- a/frontend/src/metabase/setup/components/ActiveStep/ActiveStep.styled.tsx
+++ b/frontend/src/metabase/setup/components/ActiveStep/ActiveStep.styled.tsx
@@ -17,7 +17,7 @@ export const StepRoot = styled.section`
 `;
 
 export const StepTitle = styled.div`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   font-size: 1.3125rem;
   font-weight: 700;
   margin-bottom: 0.5rem;
@@ -39,7 +39,7 @@ export const StepLabel = styled.div`
 `;
 
 export const StepLabelText = styled.span`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   font-weight: 700;
   line-height: 1;
 `;

--- a/frontend/src/metabase/setup/components/InactiveStep/InactiveStep.styled.tsx
+++ b/frontend/src/metabase/setup/components/InactiveStep/InactiveStep.styled.tsx
@@ -18,7 +18,8 @@ export const StepRoot = styled.section<Props>`
 `;
 
 export const StepTitle = styled.div<Props>`
-  color: ${props => color(props.isCompleted ? "success" : "brand")};
+  color: ${props =>
+    props.isCompleted ? color("success") : "var(--mb-color-brand)"};
   font-size: 1rem;
   font-weight: 700;
   margin: 0.5rem 0;
@@ -43,7 +44,7 @@ export const StepLabel = styled.div<Props>`
 `;
 
 export const StepLabelText = styled.span`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   font-weight: 700;
   line-height: 1;
 `;

--- a/frontend/src/metabase/setup/components/LanguageStep/LanguageStep.styled.tsx
+++ b/frontend/src/metabase/setup/components/LanguageStep/LanguageStep.styled.tsx
@@ -36,12 +36,13 @@ export const LocaleButton = styled.span<LocaleContainerProps>`
   padding: 0.5rem;
   color: ${props => color(props.checked ? "white" : "text-dark")};
   border-radius: 0.25rem;
-  background-color: ${props => color(props.checked ? "brand" : "white")};
+  background-color: ${props =>
+    props.checked ? "var(--mb-color-brand)" : color("white")};
   font-weight: 700;
 
   &:hover {
     color: ${color("white")};
-    background-color: ${color("brand")};
+    background-color: var(--mb-color-brand);
   }
 
   ${LocaleInput}:focus + & {

--- a/frontend/src/metabase/setup/components/SetupSection/SetupSection.styled.tsx
+++ b/frontend/src/metabase/setup/components/SetupSection/SetupSection.styled.tsx
@@ -31,7 +31,7 @@ export const SectionDescription = styled.div`
 `;
 
 export const SectionButton = styled(Button)`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   width: 2.5rem;
   height: 2.5rem;
 `;

--- a/frontend/src/metabase/setup/components/WelcomePage/WelcomePage.styled.tsx
+++ b/frontend/src/metabase/setup/components/WelcomePage/WelcomePage.styled.tsx
@@ -21,7 +21,7 @@ export const PageMain = styled.main`
 `;
 
 export const PageTitle = styled.h1`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   font-size: 2.2rem;
 `;
 

--- a/frontend/src/metabase/sharing/components/NewPulseSidebar.styled.tsx
+++ b/frontend/src/metabase/sharing/components/NewPulseSidebar.styled.tsx
@@ -16,7 +16,7 @@ export const ChannelCard = styled(Card)<SlackCardProps>`
 
       &:hover {
         color: ${color("white")};
-        background-color: ${color("brand")};
+        background-color: var(--mb-color-brand);
       }
     `}
 `;

--- a/frontend/src/metabase/sharing/components/PulsesListSidebar.styled.tsx
+++ b/frontend/src/metabase/sharing/components/PulsesListSidebar.styled.tsx
@@ -2,7 +2,6 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 
 import Card from "metabase/components/Card";
-import { color } from "metabase/lib/colors";
 
 export interface PulesCardProps {
   canEdit: boolean;
@@ -17,7 +16,7 @@ export const PulseCard = styled(Card)<PulesCardProps>`
       cursor: pointer;
 
       &:hover {
-        background-color: ${color("brand")};
+        background-color: var(--mb-color-brand);
       }
     `}
 `;

--- a/frontend/src/metabase/status/components/StatusLarge/StatusLarge.styled.tsx
+++ b/frontend/src/metabase/status/components/StatusLarge/StatusLarge.styled.tsx
@@ -17,7 +17,7 @@ export const StatusHeader = styled.div`
   display: flex;
   align-items: center;
   padding: 0.625rem 1rem;
-  background-color: ${color("brand")};
+  background-color: var(--mb-color-brand);
 `;
 
 export const StatusTitle = styled.div`
@@ -58,7 +58,7 @@ export const StatusCardIcon = styled.div`
   width: 2rem;
   height: 2rem;
   border-radius: 1rem;
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   background-color: ${color("brand-light")};
 `;
 
@@ -82,7 +82,7 @@ export const StatusCardSpinner = styled(LoadingSpinner)`
   display: flex;
   align-items: center;
   justify-content: center;
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
 `;
 
 interface StatusCardIconContainerProps {

--- a/frontend/src/metabase/status/components/StatusLarge/StatusLarge.styled.tsx
+++ b/frontend/src/metabase/status/components/StatusLarge/StatusLarge.styled.tsx
@@ -59,7 +59,7 @@ export const StatusCardIcon = styled.div`
   height: 2rem;
   border-radius: 1rem;
   color: var(--mb-color-brand);
-  background-color: ${color("brand-light")};
+  background-color: var(--mb-color-brand-light);
 `;
 
 export const StatusCardTitle = styled.div`

--- a/frontend/src/metabase/status/components/StatusSmall/StatusSmall.styled.tsx
+++ b/frontend/src/metabase/status/components/StatusSmall/StatusSmall.styled.tsx
@@ -63,7 +63,7 @@ export const StatusContainer = styled.div<Props>`
   color: ${getIconColor};
   border: 0.25rem solid ${getBorderColor};
   border-radius: 50%;
-  background-color: ${lighten("brand", 0.6)};
+  background-color: ${() => lighten("brand", 0.6)};
   box-shadow: 0 1px 12px ${color("shadow")};
 `;
 
@@ -86,5 +86,5 @@ export const StatusSpinner = styled(LoadingSpinner)`
   position: absolute;
   top: 0;
   left: 0;
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
 `;

--- a/frontend/src/metabase/styled-components/containers/GlobalStyles/GlobalStyles.tsx
+++ b/frontend/src/metabase/styled-components/containers/GlobalStyles/GlobalStyles.tsx
@@ -23,6 +23,7 @@ export const GlobalStyles = (): JSX.Element => {
       --mb-color-brand: ${color("brand")};
       --mb-color-brand-alpha-04: ${alpha("brand", 0.04)};
       --mb-color-brand-alpha-88: ${alpha("brand", 0.88)};
+      --mb-color-brand-light: ${lighten("brand", 0.532)};
       --mb-color-brand-lighter: ${lighten("brand", 0.598)};
       --mb-color-focus: ${color("focus")};
       --mb-color-bg-dark: ${color("bg-dark")};

--- a/frontend/src/metabase/timelines/collections/components/EventCard/EventCard.styled.tsx
+++ b/frontend/src/metabase/timelines/collections/components/EventCard/EventCard.styled.tsx
@@ -19,7 +19,7 @@ export const CardThread = styled.div`
 `;
 
 export const CardThreadIcon = styled(Icon)`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   width: 1rem;
   height: 1rem;
 `;
@@ -51,7 +51,7 @@ export interface CardTitleProps {
 
 const cardTitleHoverStyles = css`
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 
@@ -71,7 +71,7 @@ export const CardDescription = styled(Markdown)`
 `;
 
 export const CardDateInfo = styled.div`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   font-size: 0.75rem;
   line-height: 1.5rem;
   font-weight: bold;

--- a/frontend/src/metabase/timelines/collections/components/TimelineCard/TimelineCard.styled.tsx
+++ b/frontend/src/metabase/timelines/collections/components/TimelineCard/TimelineCard.styled.tsx
@@ -51,14 +51,14 @@ export const CardMenu = styled.span`
 
 const cardRootHoverStyles = css`
   &:hover {
-    border-color: ${color("brand")};
+    border-color: var(--mb-color-brand);
 
     ${CardIcon} {
-      color: ${color("brand")};
+      color: var(--mb-color-brand);
     }
 
     ${CardTitle} {
-      color: ${color("brand")};
+      color: var(--mb-color-brand);
     }
   }
 `;

--- a/frontend/src/metabase/timelines/collections/components/TimelineEmptyState/TimelineEmptyState.styled.tsx
+++ b/frontend/src/metabase/timelines/collections/components/TimelineEmptyState/TimelineEmptyState.styled.tsx
@@ -18,7 +18,7 @@ export const EmptyStateBody = styled.div`
 `;
 
 export const EmptyStateChart = styled.div`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   margin-bottom: -1rem;
 `;
 
@@ -65,7 +65,7 @@ export const EmptyStateThreadLine = styled.div`
   margin: 0 0.5rem;
   width: 11.75rem;
   height: 1px;
-  background-color: ${alpha("brand", 0.2)};
+  background-color: ${() => alpha("brand", 0.2)};
 `;
 
 export const EmptyStateThreadIcon = styled(Icon)`
@@ -81,7 +81,7 @@ export const EmptyStateThreadIconContainer = styled.div`
   width: 2rem;
   height: 2rem;
   border-radius: 1rem;
-  background-color: ${color("brand")};
+  background-color: var(--mb-color-brand);
 `;
 
 export const EmptyStateMessage = styled.div`

--- a/frontend/src/metabase/timelines/common/components/TimelinePicker/TimelinePicker.styled.tsx
+++ b/frontend/src/metabase/timelines/common/components/TimelinePicker/TimelinePicker.styled.tsx
@@ -56,14 +56,14 @@ export interface CardProps {
 }
 
 const selectedStyles = css`
-  background-color: ${color("brand")};
+  background-color: var(--mb-color-brand);
 
   ${CardTitle}, ${CardDescription}, ${CardAside} {
     color: ${color("white")};
   }
 
   ${CardIcon} {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 
   ${CardIconContainer} {

--- a/frontend/src/metabase/timelines/questions/components/EventCard/EventCard.styled.tsx
+++ b/frontend/src/metabase/timelines/questions/components/EventCard/EventCard.styled.tsx
@@ -12,13 +12,13 @@ export const CardRoot = styled.div<CardRootProps>`
   display: flex;
   padding: 0.25rem 0.75rem;
   border-left: 0.25rem solid
-    ${props => (props.isSelected ? color("brand") : "transparent")};
+    ${props => (props.isSelected ? "var(--mb-color-brand)" : "transparent")};
   background-color: ${props =>
     props.isSelected ? alpha("brand", 0.03) : "transparent"};
   cursor: pointer;
 
   &:hover {
-    background-color: ${alpha("brand", 0.03)};
+    background-color: ${() => alpha("brand", 0.03)};
   }
 `;
 

--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidget.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidget.styled.tsx
@@ -1,7 +1,6 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 
-import { color } from "metabase/lib/colors";
 import { Icon } from "metabase/ui";
 
 type VariantProp = { variant?: "default" | "form-field" };

--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidget.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidget.styled.tsx
@@ -65,7 +65,7 @@ export const Root = styled.div<{
 
     &:hover {
       transition: border 0.3s;
-      border-color: ${color("brand")};
+      border-color: var(--mb-color-brand);
     }
   }
 `;
@@ -100,7 +100,7 @@ export const InfoIcon = styled(Icon)<VariantProp>`
       color: var(--mb-color-bg-dark);
 
       &:hover {
-        color: ${color("brand")};
+        color: var(--mb-color-brand);
       }
     `}
 `;

--- a/frontend/src/metabase/visualizations/components/ClickActions/ClickActionControl.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ClickActions/ClickActionControl.styled.tsx
@@ -6,7 +6,7 @@ import { Icon, rem } from "metabase/ui";
 
 export const ClickActionButtonIcon = styled(Icon)`
   margin-right: 0.2rem;
-  color: ${({ theme }) => theme.fn.themeColor("brand")};
+  color: var(--mb-color-brand);
   transition: all 200ms linear;
 `;
 
@@ -16,7 +16,7 @@ export const ClickActionButtonTextIcon = styled.span`
   text-align: center;
   font-weight: 700;
   font-size: 1.25rem;
-  color: ${({ theme }) => theme.fn.themeColor("brand")};
+  color: var(--mb-color-brand);
   transition: all 200ms linear;
 `;
 
@@ -27,7 +27,7 @@ export const Subtitle = styled.div`
 `;
 
 export const TokenFilterActionButton = styled(Button)`
-  color: ${({ theme }) => theme.fn.themeColor("brand")};
+  color: var(--mb-color-brand);
   font-size: 1.25rem;
   line-height: 1rem;
   padding: 0.125rem 0.85rem 0.25rem;
@@ -36,13 +36,13 @@ export const TokenFilterActionButton = styled(Button)`
 
   &:hover {
     color: ${({ theme }) => theme.fn.themeColor("white")};
-    background-color: ${({ theme }) => theme.fn.themeColor("brand")};
-    border-color: ${({ theme }) => theme.fn.themeColor("brand")};
+    background-color: var(--mb-color-brand);
+    border-color: var(--mb-color-brand);
   }
 `;
 
 export const TokenActionButton = styled(Button)`
-  color: ${({ theme }) => theme.fn.themeColor("brand")};
+  color: var(--mb-color-brand);
   font-size: 0.875em;
   line-height: 1rem;
   padding: 0.3125rem 0.875rem;
@@ -51,13 +51,13 @@ export const TokenActionButton = styled(Button)`
 
   &:hover {
     color: ${({ theme }) => theme.fn.themeColor("white")};
-    background-color: ${({ theme }) => theme.fn.themeColor("brand")};
-    border-color: ${({ theme }) => theme.fn.themeColor("brand")};
+    background-color: var(--mb-color-brand);
+    border-color: var(--mb-color-brand);
   }
 `;
 
 export const SortControl = styled(Button)`
-  color: ${({ theme }) => theme.fn.themeColor("brand")};
+  color: var(--mb-color-brand);
   border: 1px solid ${({ theme }) => alpha(theme.fn.themeColor("brand"), 0.35)};
   line-height: 1;
 
@@ -68,8 +68,8 @@ export const SortControl = styled(Button)`
 
   &:hover {
     color: ${({ theme }) => theme.fn.themeColor("white")};
-    background-color: ${({ theme }) => theme.fn.themeColor("brand")};
-    border-color: ${({ theme }) => theme.fn.themeColor("brand")};
+    background-color: var(--mb-color-brand);
+    border-color: var(--mb-color-brand);
   }
 `;
 
@@ -82,7 +82,7 @@ export const FormattingControl = styled(Button)`
   padding: 0.125rem 0.25rem;
 
   &:hover {
-    color: ${({ theme }) => theme.fn.themeColor("brand")};
+    color: var(--mb-color-brand);
     background-color: transparent;
   }
 `;

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectRelationships.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectRelationships.styled.tsx
@@ -23,6 +23,6 @@ export const ObjectRelationContent = styled.div<ObjectRelationshipContentProps>`
   cursor: ${props => props.isClickable && "pointer"};
 
   &:hover {
-    color: ${props => props.isClickable && color("brand")};
+    color: ${props => props.isClickable && "var(--mb-color-brand)"};
   }
 `;

--- a/frontend/src/metabase/visualizations/components/ScalarValue/ScalarValue.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ScalarValue/ScalarValue.styled.tsx
@@ -55,7 +55,7 @@ export const ScalarTitleContent = styled.h3`
   font-size: 14px;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 
@@ -76,6 +76,6 @@ export const ScalarDescriptionIcon = styled(Icon)`
   color: ${color("text-light")};
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.styled.tsx
@@ -44,11 +44,11 @@ export const TableDraggable = styled(Draggable)<TableDraggableProps>`
 
 export const ResizeHandle = styled.div`
   &:active {
-    background-color: ${({ theme }) => theme.fn?.themeColor("brand")};
+    background-color: var(--mb-color-brand);
   }
 
   &:hover {
-    background-color: ${({ theme }) => theme.fn?.themeColor("brand")};
+    background-color: var(--mb-color-brand);
   }
 `;
 
@@ -57,12 +57,12 @@ export const ExpandButton = styled(Button)`
     ${({ theme }) => lighten(theme.fn?.themeColor("brand"), 0.3)};
   padding: 0.125rem 0.25rem;
   border-radius: 0.25rem;
-  color: ${({ theme }) => theme.fn?.themeColor("brand")};
+  color: var(--mb-color-brand);
   margin-right: 0.5rem;
   margin-left: auto;
 
   &:hover {
     color: ${({ theme }) => theme.fn?.themeColor("text-white")};
-    background-color: ${({ theme }) => theme.fn?.themeColor("brand")};
+    background-color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/visualizations/components/TableSimple/TableCell.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/TableSimple/TableCell.styled.tsx
@@ -28,7 +28,7 @@ export const CellContent = styled.span<{ isClickable: boolean }>`
     css`
       cursor: pointer;
       &:hover {
-        color: ${props.theme.fn.themeColor("brand")};
+        color: var(--mb-color-brand);
       }
     `}
 `;

--- a/frontend/src/metabase/visualizations/components/TableSimple/TableSimple.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/TableSimple/TableSimple.styled.tsx
@@ -84,7 +84,7 @@ export const TableHeaderCellContent = styled.button<{
   }
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 
@@ -110,7 +110,7 @@ export const PaginationButton = styled.button<{
   cursor: pointer;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 
   ${props =>

--- a/frontend/src/metabase/visualizations/components/Visualization/LoadingView/LoadingView.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/LoadingView/LoadingView.styled.tsx
@@ -13,7 +13,7 @@ export const Root = styled.div`
 
   padding: 0.5rem;
 
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
 `;
 
 export const SlowQueryMessageContainer = styled.div`

--- a/frontend/src/metabase/visualizations/components/legend/Legend.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/legend/Legend.styled.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 
-import { color, darken } from "metabase/lib/colors";
+import { darken } from "metabase/lib/colors";
 
 export const LegendRoot = styled.div<{ isVertical: boolean }>`
   display: flex;
@@ -10,11 +10,11 @@ export const LegendRoot = styled.div<{ isVertical: boolean }>`
 
 export const LegendLink = styled.div`
   cursor: pointer;
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   font-weight: bold;
 
   &:hover {
-    color: ${darken("brand")};
+    color: ${() => darken("brand")};
   }
 `;
 

--- a/frontend/src/metabase/visualizations/components/legend/LegendCaption.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendCaption.styled.tsx
@@ -17,7 +17,7 @@ export const LegendLabel = styled.div`
   margin-top: 2px;
 
   &:hover {
-    color: ${({ onClick }) => (onClick ? color("brand") : "")};
+    color: ${({ onClick }) => (onClick ? "var(--mb-color-brand)" : "")};
   }
 `;
 

--- a/frontend/src/metabase/visualizations/components/legend/LegendCaption.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendCaption.styled.tsx
@@ -17,7 +17,7 @@ export const LegendLabel = styled.div`
   margin-top: 2px;
 
   &:hover {
-    color: ${({ onClick }) => (onClick ? "var(--mb-color-brand)" : "")};
+    color: ${({ onClick }) => onClick && "var(--mb-color-brand)"};
   }
 `;
 

--- a/frontend/src/metabase/visualizations/components/legend/LegendItem.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendItem.styled.tsx
@@ -24,7 +24,8 @@ export const LegendItemLabel = styled.div<{ isMuted: boolean }>`
   transition: opacity 0.25s linear;
 
   &:hover {
-    color: ${({ onMouseEnter }) => (onMouseEnter ? color("brand") : "")};
+    color: ${({ onMouseEnter }) =>
+      onMouseEnter ? "var(--mb-color-brand)" : ""};
   }
 `;
 

--- a/frontend/src/metabase/visualizations/components/legend/LegendItem.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendItem.styled.tsx
@@ -24,8 +24,7 @@ export const LegendItemLabel = styled.div<{ isMuted: boolean }>`
   transition: opacity 0.25s linear;
 
   &:hover {
-    color: ${({ onMouseEnter }) =>
-      onMouseEnter ? "var(--mb-color-brand)" : ""};
+    color: ${({ onMouseEnter }) => onMouseEnter && "var(--mb-color-brand)"};
   }
 `;
 

--- a/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeries.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeries.styled.tsx
@@ -10,7 +10,7 @@ export const OptionsIcon = styled(Icon)`
   cursor: pointer;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.styled.tsx
@@ -75,7 +75,7 @@ export const SettingsIcon = styled(Icon)<SettingsIconProps>`
   cursor: ${props => (props.noPointer ? "inherit" : "pointer")};
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.styled.tsx
@@ -2,10 +2,9 @@ import styled from "@emotion/styled";
 
 import Select from "metabase/core/components/Select";
 import SelectButton from "metabase/core/components/SelectButton";
-import { color } from "metabase/lib/colors";
 
 export const SelectWithHighlightingIcon = styled(Select)`
   ${SelectButton.Icon}:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/visualizations/components/settings/ColumnItem/ColumnItem.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ColumnItem/ColumnItem.styled.tsx
@@ -32,7 +32,7 @@ export const ColumnItemRoot = styled.div<ColumnItemRootProps>`
     cursor: grab;
     &:hover {
       ${ColumnItemDragHandle} {
-        color: ${color("brand")};
+        color: var(--mb-color-brand);
       }
     }
     `}

--- a/frontend/src/metabase/visualizations/visualizations/Heading/Heading.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Heading/Heading.styled.tsx
@@ -26,11 +26,11 @@ export const InputContainer = styled.div<InputContainerProps>`
 
   .${DashboardS.DashCard}:hover &,
   .${DashboardS.DashCard}:focus-within & {
-    border: 1px solid ${color("brand")};
+    border: 1px solid var(--mb-color-brand);
   }
 
   .${DashboardS.DashCard}.resizing & {
-    border: 1px solid ${color("brand")};
+    border: 1px solid var(--mb-color-brand);
   }
 
   ${({ isPreviewing, isEmpty }) =>
@@ -41,7 +41,7 @@ export const InputContainer = styled.div<InputContainerProps>`
   ${({ isEmpty }) =>
     isEmpty &&
     css`
-      border: 1px solid ${color("brand")};
+      border: 1px solid var(--mb-color-brand);
       color: ${color("text-light")};
     `}
 `;

--- a/frontend/src/metabase/visualizations/visualizations/Heading/Heading.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Heading/Heading.unit.spec.tsx
@@ -106,7 +106,7 @@ describe("Text", () => {
           screen.getByTestId("editing-dashboard-heading-preview"),
         ).toHaveTextContent("Heading");
         expect(screen.getByTestId("editing-dashboard-heading-container"))
-          .toHaveStyle(`border: 1px solid ${color("brand")};
+          .toHaveStyle(`border: 1px solid var(--mb-color-brand);
                         color: ${color("text-light")};`);
       });
 

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.styled.tsx
@@ -39,7 +39,7 @@ export const CardLink = styled(Link)`
   font-weight: bold;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 
@@ -54,12 +54,12 @@ export const ExternalLink = styled(BaseExternalLink)`
   font-weight: bold;
 
   &:hover {
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
 `;
 
 export const BrandIconWithHorizontalMargin = styled(Icon)`
-  color: ${color("brand")};
+  color: var(--mb-color-brand);
   margin: 0 0.5rem;
 `;
 

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.styled.tsx
@@ -184,10 +184,10 @@ export const ResizeHandle = styled.div`
   cursor: ew-resize;
 
   &:active {
-    background-color: ${color("brand")};
+    background-color: var(--mb-color-brand);
   }
 
   &:hover {
-    background-color: ${color("brand")};
+    background-color: var(--mb-color-brand);
   }
 `;

--- a/frontend/src/metabase/visualizations/visualizations/Scalar/Scalar.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Scalar/Scalar.styled.tsx
@@ -20,7 +20,7 @@ export const ScalarContainer = styled(Ellipsified)<ScalarContainerProps>`
       cursor: pointer;
 
       &:hover {
-        color: ${color("brand")};
+        color: var(--mb-color-brand);
       }
     `}
 `;

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/MenuItem.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/MenuItem.styled.tsx
@@ -1,3 +1,4 @@
+import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import type { HTMLAttributes } from "react";
 
@@ -9,7 +10,8 @@ type MenuItemStyledProps = MenuItemProps & HTMLAttributes<HTMLButtonElement>;
 export const MenuItemStyled = styled(Menu.Item)<MenuItemStyledProps>`
   ${({ theme, "aria-selected": isSelected }) =>
     isSelected &&
-    `
-    color: ${theme.fn.themeColor("brand")};
-    background-color: ${theme.fn.themeColor("brand-lighter")};`}
+    css`
+      color: var(--mb-color-brand);
+      background-color: ${theme.fn.themeColor("brand-lighter")};
+    `}
 `;

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/MenuItem.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/MenuItem.styled.tsx
@@ -8,10 +8,10 @@ import { Menu } from "metabase/ui";
 type MenuItemStyledProps = MenuItemProps & HTMLAttributes<HTMLButtonElement>;
 
 export const MenuItemStyled = styled(Menu.Item)<MenuItemStyledProps>`
-  ${({ theme, "aria-selected": isSelected }) =>
+  ${({ "aria-selected": isSelected }) =>
     isSelected &&
     css`
       color: var(--mb-color-brand);
-      background-color: ${theme.fn.themeColor("brand-lighter")};
+      background-color: var(--mb-color-brand-lighter);
     `}
 `;

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.styled.tsx
@@ -41,7 +41,7 @@ export const ComparisonPickerButton = styled(Button)<ButtonProps>`
 
   &:hover {
     ${ComparisonPickerSecondaryText} {
-      color: ${color("brand")};
+      color: var(--mb-color-brand);
     }
   }
 `;

--- a/frontend/src/metabase/visualizations/visualizations/Text/Text.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Text/Text.styled.tsx
@@ -62,17 +62,17 @@ export const EditModeContainer = styled(TextCardWrapper)<EditModeProps>`
 
   .${DashboardS.DashCard}:hover &,
   .${DashboardS.DashCard}:focus-within & {
-    border: 1px solid ${color("brand")};
+    border: 1px solid var(--mb-color-brand);
   }
 
   .${DashboardS.DashCard}.resizing & {
-    border: 1px solid ${color("brand")};
+    border: 1px solid var(--mb-color-brand);
   }
 
   ${({ isEmpty }) =>
     isEmpty &&
     css`
-      border: 1px solid ${color("brand")};
+      border: 1px solid var(--mb-color-brand);
       color: ${color("text-light")};
     `}
 
@@ -227,7 +227,7 @@ export const ReactMarkdownStyleWrapper = styled.div`
     font-weight: bold;
     cursor: pointer;
     text-decoration: none;
-    color: ${color("brand")};
+    color: var(--mb-color-brand);
   }
   .text-card-markdown a:hover {
     text-decoration: underline;

--- a/frontend/src/metabase/visualizations/visualizations/Text/Text.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Text/Text.unit.spec.tsx
@@ -112,7 +112,7 @@ describe("Text", () => {
           "You can use Markdown here, and include variables {{like_this}}",
         );
         expect(screen.getByTestId("editing-dashboard-text-container"))
-          .toHaveStyle(`border: 1px solid ${color("brand")};
+          .toHaveStyle(`border: 1px solid var(--mb-color-brand);
                         color: ${color("text-light")};`);
       });
 


### PR DESCRIPTION
Relates to https://github.com/metabase/metabase/issues/42694
Also is a small part of https://www.notion.so/metabase/100-Align-approach-to-Mantine-styles-customization-1066f77c43694c36a6e90a3d2374b731

### Description

Migrate hardcoded colors used in emotion styles:

- brand `${color("brand")}` -> `var(--mb-color-brand)`
- brand-light `${color("brand-light")}` -> `var(--mb-color-brand-light)`
- brand-lighter `${color("brand-lighter")}` -> `var(--mb-color-brand-lighter)`

### How to verify

1. CI should pass
2. Visual tests should return same results
