### PR TITLE
Fix "Manage database" perms incorrectly show up on the schema-level permissions page

### DIFF
--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.ts
@@ -22,13 +22,13 @@ import type {
   RawGroupRouteParams,
   PermissionSectionConfig,
   EntityId,
+  PermissionSubject,
 } from "../../types";
 import { DataPermissionValue, DataPermission } from "../../types";
 import {
   getTableEntityId,
   getSchemaEntityId,
   getDatabaseEntityId,
-  getPermissionSubject,
 } from "../../utils/data-entity-id";
 import { hasPermissionValueInEntityGraphs } from "../../utils/graph";
 
@@ -189,15 +189,16 @@ export const getDatabasesPermissionEditor = createSelector(
       databaseId != null &&
       metadata.database(databaseId)?.getSchemas().length === 1;
 
-    let entities: EntityWithPermissions[] = [];
-
     const database = metadata?.database(databaseId);
+
+    let entities: EntityWithPermissions[] = [];
+    let permissionSubject: PermissionSubject | null = null;
 
     if (database && (schemaName != null || hasSingleSchema)) {
       const schema: Schema = hasSingleSchema
         ? database.getSchemas()[0]
         : (database.schema(schemaName) as Schema);
-
+      permissionSubject = "fields";
       entities = schema
         .getTables()
         .sort((a, b) => a.display_name.localeCompare(b.display_name))
@@ -241,9 +242,11 @@ export const getDatabasesPermissionEditor = createSelector(
           };
         });
       if (maybeDbEntities) {
+        permissionSubject = "tables";
         entities = maybeDbEntities;
       }
     } else if (groupId != null) {
+      permissionSubject = "schemas";
       entities = metadata
         .databasesList({ savedQuestions: false })
         .map(database => {
@@ -266,18 +269,15 @@ export const getDatabasesPermissionEditor = createSelector(
         });
     }
 
-    const permissionSubject = getPermissionSubject(
-      { databaseId, schemaName },
-      hasSingleSchema,
-    );
-
     const showViewDataColumn = hasViewDataOptions(entities);
 
     const columns = _.compact([
       { name: getEditorEntityName(params, hasSingleSchema) },
       showViewDataColumn && { name: t`View data` },
       { name: t`Create queries` },
-      ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.getDataColumns(permissionSubject),
+      ...(permissionSubject
+        ? PLUGIN_FEATURE_LEVEL_PERMISSIONS.getDataColumns(permissionSubject)
+        : []),
     ]);
 
     const breadcrumbs = getDatabasesEditorBreadcrumbs(params, metadata, group);
@@ -364,6 +364,9 @@ export const getGroupsDataPermissionEditor: GetGroupsDataPermissionEditorSelecto
         throw new Error("No default group found");
       }
 
+      const permissionSubject =
+        tableId != null ? "fields" : schemaName != null ? "tables" : "schemas";
+
       const entities = sortedGroups.map(group => {
         const isAdmin = isAdminGroup(group);
         let groupPermissions;
@@ -418,8 +421,6 @@ export const getGroupsDataPermissionEditor: GetGroupsDataPermissionEditorSelecto
           permissions: groupPermissions,
         };
       });
-
-      const permissionSubject = getPermissionSubject(params);
 
       const showViewDataColumn = hasViewDataOptions(entities);
 

--- a/frontend/src/metabase/admin/permissions/utils/data-entity-id.ts
+++ b/frontend/src/metabase/admin/permissions/utils/data-entity-id.ts
@@ -4,7 +4,7 @@ import type Schema from "metabase-lib/v1/metadata/Schema";
 import type Table from "metabase-lib/v1/metadata/Table";
 import type { ConcreteTableId } from "metabase-types/api";
 
-import type { EntityId, PermissionSubject } from "../types";
+import type { EntityId } from "../types";
 
 export const getDatabaseEntityId = (databaseEntity: Database) => ({
   databaseId: databaseEntity.id,
@@ -29,18 +29,3 @@ export const isDatabaseEntityId = (entityId: Partial<EntityId>) =>
   entityId.databaseId != null &&
   !isSchemaEntityId(entityId) &&
   !isTableEntityId(entityId);
-
-export const getPermissionSubject = (
-  entityId: Partial<EntityId>,
-  hasSingleSchema?: boolean,
-): PermissionSubject => {
-  if (isTableEntityId(entityId)) {
-    return "fields";
-  }
-
-  if (isSchemaEntityId(entityId) || hasSingleSchema) {
-    return "tables";
-  }
-
-  return "schemas";
-};


### PR DESCRIPTION
Closes #37998

### Description

Fixes "Manage database" column from incorrectly appearing at the schema-level view of the group permissions editor.

This was a result of a miscalculation of the current permission level being edited. We were calculating
- db level -> "schemas" (correct)
- schema level -> "schemas" (incorrect - should be "tables")
- table level -> "tables" (incorrect - should be "fields")

This resulted in the schema-level view being interpreted as the db-level view when deciding which columns to render. This PR updates the code to use the same logic used to decide which permissions graphs to generate, as the logic needed to do this differs between the database permissions editor and the group permissions editor (which also accounts for why this bug did not appear in the database permissions editor).

### How to verify

- Have a database with multiple schemas
- Go to admin settings -> permissions
- From the group permissions view, select your database w/ multiple schemas
- Validate that the "Manage database" is no longer there