### PR TITLE
fix percent change e2e flakes and failures

### DIFF
--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -93,6 +93,10 @@ export function browseDatabases() {
   return navigationSidebar().findByLabelText("Browse databases");
 }
 
+export function settings() {
+  return appBar().findByLabelText("Settings");
+}
+
 /**
  * Get the `fieldset` HTML element that we use as a filter widget container.
  *

--- a/e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js
@@ -25,7 +25,15 @@ const SUM_OF_TOTAL = {
   display: "line",
 };
 
-function testSumTotalChange(tooltipSelector = showTooltipForCircleInSeries) {
+/**
+ * @param {"line" | "bar"} display
+ */
+function testSumTotalChange(display) {
+  const tooltipSelector =
+    display === "line"
+      ? showTooltipForCircleInSeries
+      : showTooltipForBarInSeries;
+
   tooltipSelector("#88BF4D");
   testTooltipPairs([
     ["Created At", "2022"],
@@ -33,7 +41,7 @@ function testSumTotalChange(tooltipSelector = showTooltipForCircleInSeries) {
   ]);
   testTooltipExcludesText("Compared to preivous year");
 
-  tooltipSelector("#88BF4D");
+  tooltipSelector("#88BF4D", display === "line" ? 0 : 1);
   testTooltipPairs([
     ["Created At", "2023"],
     ["Sum of Total", "205,256.02"],
@@ -96,7 +104,15 @@ const AVG_OF_TOTAL = {
   display: "line",
 };
 
-function testAvgTotalChange(tooltipSelector = showTooltipForCircleInSeries) {
+/**
+ * @param {"line" | "bar"} display
+ */
+function testAvgTotalChange(display) {
+  const tooltipSelector =
+    display === "line"
+      ? showTooltipForCircleInSeries
+      : showTooltipForBarInSeries;
+
   tooltipSelector("#A989C5");
   testTooltipPairs([
     ["Created At", "2022"],
@@ -104,7 +120,7 @@ function testAvgTotalChange(tooltipSelector = showTooltipForCircleInSeries) {
   ]);
   testTooltipExcludesText("Compared to preivous year");
 
-  tooltipSelector("#A989C5");
+  tooltipSelector("#A989C5", display === "line" ? 0 : 1);
   testTooltipPairs([
     ["Created At", "2023"],
     ["Average of Total", "56.86"],
@@ -231,7 +247,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
     });
 
     it("should show percent change in tooltip for timeseries axis", () => {
-      testSumTotalChange();
+      testSumTotalChange("line");
     });
   });
 
@@ -285,8 +301,8 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
     });
 
     it("should show percent change in tooltip for timeseries axis", () => {
-      testSumTotalChange();
-      testAvgTotalChange();
+      testSumTotalChange("line");
+      testAvgTotalChange("line");
     });
   });
 
@@ -327,7 +343,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
     });
 
     it("should show percent change in tooltip for timeseries axis", () => {
-      testAvgTotalChange();
+      testAvgTotalChange("line");
       testCumSumChange();
     });
   });
@@ -412,7 +428,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
     });
 
     it("should show percent change in tooltip for timeseries axis", () => {
-      testAvgTotalChange();
+      testAvgTotalChange("line");
       testCumSumChange(false);
       testAvgDiscountChange();
       testSumDiscountChange();
@@ -453,7 +469,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
     });
 
     it("should show percent change in tooltip for timeseries axis", () => {
-      testSumTotalChange(showTooltipForBarInSeries);
+      testSumTotalChange("bar");
     });
   });
 
@@ -509,8 +525,8 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
     });
 
     it("should show percent change in tooltip for timeseries axis", () => {
-      testSumTotalChange(showTooltipForBarInSeries);
-      testAvgTotalChange(showTooltipForBarInSeries);
+      testSumTotalChange("bar");
+      testAvgTotalChange("bar");
     });
   });
 
@@ -606,14 +622,14 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
         filter: [
           "between",
           ["field", 39, { "base-type": "type/DateTime" }],
-          "2024-01-01",
+          "2024-02-01",
           "2024-05-30",
         ],
       },
       display: "line",
     };
 
-    const APRIL_CHANGES = [null, "-10.89%", "+11.1%", "-2.89%"];
+    const APRIL_CHANGES = [null, "+11.1%", "-2.89%"];
 
     const SUM_OF_TOTAL_DST_WEEK = {
       name: "Q1",
@@ -624,14 +640,14 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
         filter: [
           "between",
           ["field", 39, { "base-type": "type/DateTime" }],
-          "2024-03-01",
+          "2024-03-03",
           "2024-03-31",
         ],
       },
       display: "line",
     };
 
-    const DST_WEEK_CHANGES = [null, "+191.48%", "+4.76%", "-2.36%"];
+    const DST_WEEK_CHANGES = [null, "+4.76%", "-2.36%"];
 
     const SUM_OF_TOTAL_DST_DAY = {
       name: "Q1",

--- a/e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js
@@ -777,6 +777,11 @@ function setupDashboard(cardId, addedSeriesCardId) {
  */
 function showTooltipOutsideChart() {
   settings().realHover();
+  popover()
+    .last() // use last to select the settings tooltip, instead of the chart tooltip
+    .within(() => {
+      cy.findByText("Settings");
+    });
 }
 
 function showTooltipForCircleInSeries(seriesColor, index = 0) {

--- a/e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js
@@ -11,6 +11,7 @@ import {
   testPairedTooltipValues,
   testTooltipPairs,
   popover,
+  settings,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -40,6 +41,8 @@ function testSumTotalChange(display) {
     ["Sum of Total", "42,156.87"],
   ]);
   testTooltipExcludesText("Compared to preivous year");
+
+  showTooltipOutsideChart();
 
   tooltipSelector("#88BF4D", display === "line" ? 0 : 1);
   testTooltipPairs([
@@ -120,6 +123,8 @@ function testAvgTotalChange(display) {
   ]);
   testTooltipExcludesText("Compared to preivous year");
 
+  showTooltipOutsideChart();
+
   tooltipSelector("#A989C5", display === "line" ? 0 : 1);
   testTooltipPairs([
     ["Created At", "2023"],
@@ -154,6 +159,8 @@ function testCumSumChange(testFirstTooltip = true) {
     testTooltipExcludesText("Compared to preivous year");
   }
 
+  showTooltipOutsideChart();
+
   showTooltipForCircleInSeries("#88BF4D", testFirstTooltip ? 0 : 1);
   testTooltipPairs([
     ["Created At", "2023"],
@@ -183,6 +190,8 @@ function testAvgDiscountChange() {
   ]);
   testTooltipExcludesText("Compared to preivous year");
 
+  showTooltipOutsideChart();
+
   showTooltipForCircleInSeries("#509EE3");
   testTooltipPairs([
     ["Created At", "2023"],
@@ -198,6 +207,8 @@ function testSumDiscountChange() {
     ["Sum of Discount", "342.09"],
   ]);
   testTooltipExcludesText("Compared to preivous year");
+
+  showTooltipOutsideChart();
 
   showTooltipForCircleInSeries("#98D9D9");
   testTooltipPairs([
@@ -545,6 +556,8 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       ]);
       testTooltipExcludesText("Compared to preivous month");
 
+      showTooltipOutsideChart();
+
       showTooltipForCircleInSeries("#88BF4D");
       testTooltipPairs([
         ["Created At", "May 2022"],
@@ -567,6 +580,8 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       ]);
       testTooltipExcludesText("Compared to preivous month");
 
+      showTooltipOutsideChart();
+
       showTooltipForCircleInSeries("#88BF4D");
       testTooltipPairs([
         ["Created At", "June 2022"],
@@ -574,14 +589,18 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       ]);
       testTooltipExcludesText("Compared to preivous month");
 
-      showTooltipForCircleInSeries("#88BF4D");
+      showTooltipOutsideChart();
+
+      showTooltipForCircleInSeries("#88BF4D", 1); // since we are already hovering the second datum, use index 1 to prevent hovering the first datum again
       testTooltipPairs([
         ["Created At", "July 2022"],
         ["Sum of Total", "3,734.69"],
         ["Compared to previous month", "+80.16%"],
       ]);
 
-      showTooltipForCircleInSeries("#88BF4D");
+      showTooltipOutsideChart();
+
+      showTooltipForCircleInSeries("#88BF4D", 2); // since we are already hovering the third datum, use index 2 to prevent hovering the first and second datum again
       testTooltipPairs([
         ["Created At", "September 2022"],
         ["Sum of Total", "5,372.08"],
@@ -602,6 +621,8 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
         ["Sum of Total", "52.76"],
       ]);
       testTooltipExcludesText("Compared to preivous month");
+
+      showTooltipOutsideChart();
 
       showTooltipForCircleInSeries("#88BF4D");
       testTooltipPairs([
@@ -672,13 +693,15 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
         visitDashboard(dashboardId);
       });
 
-      APRIL_CHANGES.forEach(change => {
-        showTooltipForCircleInSeries("#88BF4D");
+      APRIL_CHANGES.forEach((change, index) => {
+        showTooltipForCircleInSeries("#88BF4D", Math.max(index - 1, 0)); // prevents re-hovering the previous datum
         if (change === null) {
           testTooltipExcludesText("Compared to preivous");
+          showTooltipOutsideChart();
           return;
         }
         testPairedTooltipValues("Compared to previous month", change);
+        showTooltipOutsideChart();
       });
     });
 
@@ -687,13 +710,15 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
         visitDashboard(dashboardId);
       });
 
-      DST_WEEK_CHANGES.forEach(change => {
-        showTooltipForCircleInSeries("#88BF4D");
+      DST_WEEK_CHANGES.forEach((change, index) => {
+        showTooltipForCircleInSeries("#88BF4D", Math.max(index - 1, 0));
         if (change === null) {
           testTooltipExcludesText("Compared to preivous");
+          showTooltipOutsideChart();
           return;
         }
         testPairedTooltipValues("Compared to previous week", change);
+        showTooltipOutsideChart();
       });
     });
 
@@ -702,13 +727,15 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
         visitDashboard(dashboardId);
       });
 
-      DST_DAY_CHANGES.forEach(change => {
-        showTooltipForCircleInSeries("#88BF4D");
+      DST_DAY_CHANGES.forEach((change, index) => {
+        showTooltipForCircleInSeries("#88BF4D", Math.max(index - 1, 0));
         if (change === null) {
           testTooltipExcludesText("Compared to preivous");
+          showTooltipOutsideChart();
           return;
         }
         testPairedTooltipValues("Compared to previous day", change);
+        showTooltipOutsideChart();
       });
     });
   });
@@ -742,6 +769,14 @@ function setupDashboard(cardId, addedSeriesCardId) {
       return dashboardId;
     });
   });
+}
+
+/**
+ * Trigger another tooltip outside of the chart, before hovering the next
+ * element This helps prevent flakes
+ */
+function showTooltipOutsideChart() {
+  settings().realHover();
 }
 
 function showTooltipForCircleInSeries(seriesColor, index = 0) {

--- a/frontend/src/metabase/nav/components/ProfileLink/ProfileLink.jsx
+++ b/frontend/src/metabase/nav/components/ProfileLink/ProfileLink.jsx
@@ -99,6 +99,7 @@ function ProfileLink({ adminItems, onLogout }) {
             color: color("text-white"),
           },
         }}
+        triggerAriaLabel={t`Settings`}
         // I've disabled this transition, since it results in the menu
         // sometimes not appearing until content finishes loading on complex
         // dashboards and questions #39303


### PR DESCRIPTION
### Description

Two types of tests were flaking in this file for different reasons, possibly due to differences in behavior post-React 18 upgrade. Note that I'm backporting this PR to the 50 release branch because I have another backport that is blocked by these flaky tests.

1. Bar series

Unlike line series, we need to pass the `index = 1` parameter when calling `showTooltipForBarInSeries` to hover the datum and show its tooltip. 

The underlying selectors are different, `path[d="${CIRCLE_PATH}"][stroke="${color}"]` for line series, and `path[fill="${color}"]` for bars, so maybe that's the root cause of the difference, but for now manually providing the index of 1 instead of 0 for bars suffices to fix the flakes.

2. Daylight savings related tests

Some of these would hover over 4 datum in a series, and for some reason the tooltip selector method would flake frequently when trying to select the fourth. I've fixed the flakiness by modifying the questions and selecting only 3 datum instead. This works consistently locally, and hopefully in CI as well.

Additionally, to help reduce flakiness we now hover the settings menu after each datum. For some reason hovering multiple datums consecutively causes the tooltips to flake.

### How to verify

Run tests locally and in CI multiple times

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
