### PR TITLE
Performance fix for getUrlWithParameters when there are no parameters

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -28,6 +28,7 @@ import {
   visitIframe,
   entityPickerModal,
   filterWidget,
+  queryBuilderHeader,
 } from "e2e/support/helpers";
 import { b64hash_to_utf8 } from "metabase/lib/encoding";
 import {
@@ -671,7 +672,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
     });
 
     it("allows setting saved question as custom destination and changing it back to default click behavior", () => {
-      cy.createQuestion(TARGET_QUESTION);
+      cy.createQuestion(TARGET_QUESTION, { wrapId: true });
       cy.createQuestionAndDashboard({ questionDetails }).then(
         ({ body: card }) => {
           visitDashboard(card.dashboard_id);
@@ -694,13 +695,14 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       cy.intercept("GET", "/api/collection", cy.spy().as("collections"));
 
       clickLineChartPoint();
-      cy.location().should(({ hash, pathname }) => {
-        expect(pathname).to.equal("/question");
-        const card = deserializeCardFromUrl(hash);
-        expect(card.name).to.deep.equal(TARGET_QUESTION.name);
-        expect(card.display).to.deep.equal(TARGET_QUESTION.display);
-        expect(card.dataset_query.query).to.deep.equal(TARGET_QUESTION.query);
+      cy.get("@questionId").then(questionId => {
+        cy.location()
+          .its("pathname")
+          .should("contain", `/question/${questionId}`);
       });
+      queryBuilderHeader()
+        .findByDisplayValue(TARGET_QUESTION.name)
+        .should("be.visible");
 
       cy.log("Should navigate to question using router (metabase#33379)");
       cy.findByTestId("view-footer").should("contain", "Showing 5 rows");

--- a/e2e/test/scenarios/dashboard-cards/reproductions/23137-click-behavior-not-working-for-gauge-and-progress.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/reproductions/23137-click-behavior-not-working-for-gauge-and-progress.cy.spec.js
@@ -2,6 +2,7 @@ import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 import {
   addOrUpdateDashboardCard,
+  queryBuilderHeader,
   restore,
   visitDashboard,
 } from "e2e/support/helpers";
@@ -28,7 +29,7 @@ describe("issue 23137", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-    cy.intercept("POST", "/api/dataset").as("dataset");
+    cy.intercept("POST", "/api/card/*/query").as("cardQuery");
   });
 
   it("should navigate to a target from a gauge card (metabase#23137)", () => {
@@ -57,9 +58,8 @@ describe("issue 23137", () => {
     });
 
     cy.findByTestId("gauge-arc-1").click();
-    cy.wait("@dataset");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Orders");
+    cy.wait("@cardQuery");
+    queryBuilderHeader().findByDisplayValue("Orders").should("be.visible");
   });
 
   it("should navigate to a target from a progress card (metabase#23137)", () => {
@@ -88,8 +88,7 @@ describe("issue 23137", () => {
     });
 
     cy.findByTestId("progress-bar").click();
-    cy.wait("@dataset");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Orders");
+    cy.wait("@cardQuery");
+    queryBuilderHeader().findByDisplayValue("Orders").should("be.visible");
   });
 });

--- a/frontend/src/metabase-lib/v1/Question.ts
+++ b/frontend/src/metabase-lib/v1/Question.ts
@@ -722,7 +722,11 @@ class Question {
       collection_id: this._card.collection_id,
       dataset_query: Lib.toLegacyQuery(query),
       display: this._card.display,
-      parameters: this._card.parameters,
+      ...(_.isEmpty(this._card.parameters)
+        ? undefined
+        : {
+            parameters: this._card.parameters,
+          }),
       type: this._card.type,
       ...(_.isEmpty(this._parameterValues)
         ? undefined

--- a/frontend/src/metabase-lib/v1/urls.ts
+++ b/frontend/src/metabase-lib/v1/urls.ts
@@ -51,7 +51,7 @@ export function getUrlWithParameters(
   { objectId }: { objectId?: string | number } = {},
 ): string {
   const includeDisplayIsLocked = true;
-  if (parameters.length === 0) {
+  if (parameters.length === 0 && objectId == null) {
     return getUrl(question, { includeDisplayIsLocked });
   }
 

--- a/frontend/src/metabase-lib/v1/urls.ts
+++ b/frontend/src/metabase-lib/v1/urls.ts
@@ -51,10 +51,11 @@ export function getUrlWithParameters(
   { objectId }: { objectId?: string | number } = {},
 ): string {
   const includeDisplayIsLocked = true;
-  const { isEditable } = Lib.queryDisplayInfo(question.query());
+  if (parameters.length === 0) {
+    return getUrl(question, { includeDisplayIsLocked });
+  }
 
-  const { isNative } = Lib.queryDisplayInfo(question.query());
-
+  const { isNative, isEditable } = Lib.queryDisplayInfo(question.query());
   if (!isNative) {
     let questionWithParameters = question.setParameters(parameters);
 


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/43330

Optimizes the most common case when there are no mapped parameters for this card. In this case we omit calling (and parsing) `.query()`.