### PR TITLE
Make Backports Automerge Again

### DIFF
--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -92,7 +92,7 @@ jobs:
         if: ${{ steps.create_backport_pull_request.outputs.has-conflicts == 'false' }}
         uses: peter-evans/enable-pull-request-automerge@v2
         with:
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
           pull-request-number: ${{ steps.create_backport_pull_request.outputs.backport_pr_number }}
           merge-method: squash
 


### PR DESCRIPTION
https://github.com/metabase/metabase/pull/43250 inadvertently broke the automerge function for backports. this uses the correct token for that action step

### Description

Makes successful backports turn on automerge so we don't have to worry about them 🤗 
