### PR TITLE
Use a more obvious test error message

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
@@ -79,7 +79,7 @@
                          (tar-file-types f)))))
 
               (testing "On exception API returns log"
-                (with-redefs [u.compress/tgz (fn [& _] (throw (ex-info "Just an error" {})))]
+                (with-redefs [u.compress/tgz (fn [& _] (throw (ex-info "[test] deliberate error message" {})))]
                   (let [res   (mt/user-http-request :crowberto :post 500 "ee/serialization/export" {}
                                                     :collection (:id coll) :data_model false :settings false)
                         lines (str/split-lines (slurp (io/input-stream res)))]
@@ -166,7 +166,7 @@
                               (-> (snowplow-test/pop-event-data-and-user-id!) first :data)))))))
 
               (testing "ERROR /api/ee/serialization/export"
-                (with-redefs [u.compress/tgz (fn [& _] (throw (ex-info "Just an error" {})))]
+                (with-redefs [u.compress/tgz (fn [& _] (throw (ex-info "[test] deliberate error message" {})))]
                   (is (-> (mt/user-http-request :crowberto :post 500 "ee/serialization/export"
                                                 :collection (:id coll) :data_model false :settings false)
                           ;; consume response to remove on-disk data
@@ -184,7 +184,7 @@
                              "field_values"    false
                              "secrets"         false
                              "success"         false
-                             "error_message"   "clojure.lang.ExceptionInfo: Just an error {}"}
+                             "error_message"   "clojure.lang.ExceptionInfo: [test] deliberate error message {}"}
                            (-> (snowplow-test/pop-event-data-and-user-id!) first :data))))))
 
               (testing "Only admins can export/import"


### PR DESCRIPTION
(When scrolling through CI logs I always do a double-take when I see a huge stack trace with "Just an error". I think this is a little clearer?)
