### PR TITLE
43475 command palette icon tweaks

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/collections/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/collections/utils.ts
@@ -66,7 +66,6 @@ export const getIcon = (item: ObjectWithModel): IconData => {
   if (item.model === "dataset" && item.moderated_status === "verified") {
     return {
       name: "model_with_badge",
-      color: OFFICIAL_COLLECTION.color,
     };
   }
 

--- a/enterprise/frontend/src/metabase-enterprise/collections/utils.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/collections/utils.unit.spec.ts
@@ -88,7 +88,7 @@ describe("Collections plugin utils", () => {
       it("should return the correct icon for an official model", () => {
         expect(
           getIcon({ model: "dataset", moderated_status: "verified" }),
-        ).toEqual({ name: "model_with_badge", color: "saturated-yellow" });
+        ).toEqual({ name: "model_with_badge" });
       });
     });
   });

--- a/frontend/src/metabase/palette/components/PaletteResultItem.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResultItem.tsx
@@ -14,7 +14,7 @@ interface PaletteResultItemProps {
 }
 
 export const PaletteResultItem = ({ item, active }: PaletteResultItemProps) => {
-  const icon = getCommandPaletteIcon(item, active);
+  const icon = item.icon ? getCommandPaletteIcon(item, active) : null;
 
   const parentName =
     item.extra?.parentCollection || item.extra?.database || null;
@@ -43,9 +43,8 @@ export const PaletteResultItem = ({ item, active }: PaletteResultItemProps) => {
       aria-label={item.name}
     >
       {/** Icon Container */}
-      {item.icon && (
+      {icon && (
         <Icon
-          aria-hidden
           {...icon}
           style={{
             flexBasis: "16px",

--- a/frontend/src/metabase/palette/components/PaletteResultItem.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResultItem.tsx
@@ -6,6 +6,7 @@ import { color } from "metabase/lib/colors";
 import { Flex, Text, Icon, Box } from "metabase/ui";
 
 import type { PaletteActionImpl } from "../types";
+import { getCommandPaletteIcon } from "../utils";
 
 interface PaletteResultItemProps {
   item: PaletteActionImpl;
@@ -13,7 +14,7 @@ interface PaletteResultItemProps {
 }
 
 export const PaletteResultItem = ({ item, active }: PaletteResultItemProps) => {
-  const iconColor = active ? color("brand-light") : color("text-light");
+  const icon = getCommandPaletteIcon(item, active);
 
   const parentName =
     item.extra?.parentCollection || item.extra?.database || null;
@@ -27,7 +28,7 @@ export const PaletteResultItem = ({ item, active }: PaletteResultItemProps) => {
       p=".75rem"
       mx="1.5rem"
       miw="0"
-      align="center"
+      align="start"
       justify="space-between"
       gap="0.5rem"
       fw={700}
@@ -45,8 +46,7 @@ export const PaletteResultItem = ({ item, active }: PaletteResultItemProps) => {
       {item.icon && (
         <Icon
           aria-hidden
-          name={item.icon || "click"}
-          color={iconColor}
+          {...icon}
           style={{
             flexBasis: "16px",
           }}
@@ -86,7 +86,7 @@ export const PaletteResultItem = ({ item, active }: PaletteResultItemProps) => {
             <Text
               component="span"
               ml="0.25rem"
-              c={iconColor}
+              c={active ? color("brand-light") : color("text-light")}
               fz="0.75rem"
               lh="1rem"
               fw="normal"

--- a/frontend/src/metabase/palette/components/PaletteResultItem.unit.spec.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResultItem.unit.spec.tsx
@@ -21,13 +21,8 @@ const setup = ({
   active?: boolean;
   item?: Partial<PaletteActionImpl>;
 }) => {
-  const togglePalette = jest.fn();
   render(
-    <PaletteResultItem
-      togglePalette={togglePalette}
-      item={mockPaletteActionImpl(item)}
-      active={active}
-    />,
+    <PaletteResultItem item={mockPaletteActionImpl(item)} active={active} />,
   );
 };
 

--- a/frontend/src/metabase/palette/components/PaletteResultItem.unit.spec.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResultItem.unit.spec.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "__support__/ui";
+import { color } from "metabase/lib/colors";
+
+import type { PaletteActionImpl } from "../types";
+
+import { PaletteResultItem } from "./PaletteResultItem";
+
+const mockPaletteActionImpl = (opts: Partial<PaletteActionImpl>) =>
+  ({
+    name: "test action",
+    id: "action-1",
+    ancestors: [],
+    children: [],
+    ...opts,
+  } as PaletteActionImpl);
+
+const setup = ({
+  active = false,
+  item = {},
+}: {
+  active?: boolean;
+  item?: Partial<PaletteActionImpl>;
+}) => {
+  const togglePalette = jest.fn();
+  render(
+    <PaletteResultItem
+      togglePalette={togglePalette}
+      item={mockPaletteActionImpl(item)}
+      active={active}
+    />,
+  );
+};
+
+describe("PaletteResultItem", () => {
+  it("icons should default to brand color", async () => {
+    setup({ item: { icon: "model" } });
+
+    expect(await screen.findByRole("img", { name: /model/ })).toHaveAttribute(
+      "color",
+      color("brand"),
+    );
+  });
+
+  it("icons should use provided colors when available", async () => {
+    setup({ item: { icon: "model", extra: { iconColor: "green" } } });
+
+    expect(await screen.findByRole("img", { name: /model/ })).toHaveAttribute(
+      "color",
+      color("green"),
+    );
+  });
+
+  it("if active, icon color should always be white", async () => {
+    setup({
+      item: { icon: "model", extra: { iconColor: "green" } },
+      active: true,
+    });
+
+    expect(await screen.findByRole("img", { name: /model/ })).toHaveAttribute(
+      "color",
+      color("white"),
+    );
+  });
+
+  it("should not render an icon if none is provided", async () => {
+    setup({});
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -222,8 +222,6 @@ export const useCommandPalette = ({
     isSearchTypeaheadEnabled,
   ]);
 
-  console.log(searchResultActions);
-
   useRegisterActions(searchResultActions, [searchResultActions]);
 
   const recentItemsActions = useMemo<PaletteAction[]>(() => {

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -176,11 +176,12 @@ export const useCommandPalette = ({
         ].concat(
           searchResults.data.map((result, index) => {
             const wrappedResult = Search.wrapEntity(result, dispatch);
+            const icon = getIcon(wrappedResult);
             return {
               id: `search-result-${result.model}-${result.id}`,
               name: result.name,
               subtitle: result.description || "",
-              icon: getIcon(result).name,
+              icon: icon.name,
               section: "search",
               keywords: debouncedSearchText,
               priority: Priority.NORMAL,
@@ -193,6 +194,7 @@ export const useCommandPalette = ({
                 isVerified: result.moderated_status === "verified",
                 database: result.database_name,
                 href: wrappedResult.getUrl(),
+                iconColor: icon.color,
               },
             };
           }),
@@ -220,37 +222,44 @@ export const useCommandPalette = ({
     isSearchTypeaheadEnabled,
   ]);
 
+  console.log(searchResultActions);
+
   useRegisterActions(searchResultActions, [searchResultActions]);
 
   const recentItemsActions = useMemo<PaletteAction[]>(() => {
     return (
-      filterRecentItems(recentItems ?? []).map(item => ({
-        id: `recent-item-${getName(item)}-${item.model}-${item.id}`,
-        name: getName(item),
-        icon: getIcon(item).name,
-        section: "recent",
-        perform: () => {
-          // Need to keep this logic here for when user selects via keyboard
-          const href = Urls.modelToUrl(item);
-          if (href) {
-            dispatch(push(href));
-          }
-        },
-        extra:
-          item.model === "table"
-            ? {
-                database: item.database.name,
-                href: Urls.modelToUrl(item),
-              }
-            : {
-                parentCollection:
-                  item.parent_collection.id === null
-                    ? ROOT_COLLECTION.name
-                    : item.parent_collection.name,
-                isVerified: item.moderated_status === "verified",
-                href: Urls.modelToUrl(item),
-              },
-      })) || []
+      filterRecentItems(recentItems ?? []).map(item => {
+        const icon = getIcon(item);
+        return {
+          id: `recent-item-${getName(item)}-${item.model}-${item.id}`,
+          name: getName(item),
+          icon: icon.name,
+          section: "recent",
+          perform: () => {
+            // Need to keep this logic here for when user selects via keyboard
+            const href = Urls.modelToUrl(item);
+            if (href) {
+              dispatch(push(href));
+            }
+          },
+          extra:
+            item.model === "table"
+              ? {
+                  database: item.database.name,
+                  href: Urls.modelToUrl(item),
+                  iconColor: icon.color,
+                }
+              : {
+                  parentCollection:
+                    item.parent_collection.id === null
+                      ? ROOT_COLLECTION.name
+                      : item.parent_collection.name,
+                  isVerified: item.moderated_status === "verified",
+                  href: Urls.modelToUrl(item),
+                  iconColor: icon.color,
+                },
+        };
+      }) || []
     );
   }, [dispatch, recentItems]);
 

--- a/frontend/src/metabase/palette/types.ts
+++ b/frontend/src/metabase/palette/types.ts
@@ -17,7 +17,7 @@ interface PaletteActionExtras {
      */
     href?: LocationDescriptor | null;
     /** iconColor: Color of the icon in the  */
-    iconColor?: string
+    iconColor?: string;
   };
 }
 

--- a/frontend/src/metabase/palette/types.ts
+++ b/frontend/src/metabase/palette/types.ts
@@ -16,6 +16,8 @@ interface PaletteActionExtras {
      * browser interactions to open items in new tabs/windows
      */
     href?: LocationDescriptor | null;
+    /** iconColor: Color of the icon in the  */
+    iconColor?: string
   };
 }
 

--- a/frontend/src/metabase/palette/utils.ts
+++ b/frontend/src/metabase/palette/utils.ts
@@ -4,6 +4,8 @@ import _ from "underscore";
 import type { RecentItem } from "metabase-types/api";
 
 import type { PaletteActionImpl } from "./types";
+import { color } from "metabase/lib/colors";
+import type { IconName } from "metabase/ui";
 
 export const processResults = (
   results: (string | PaletteActionImpl)[],
@@ -55,3 +57,23 @@ export const findClosestActionIndex = (
 
 export const filterRecentItems: (items: RecentItem[]) => RecentItem[] = items =>
   items.filter(item => item.model !== "collection").slice(0, 5);
+
+
+export const getCommandPaletteIcon = (item: PaletteActionImpl, isActive: boolean): {name: IconName, color: string} => {
+
+  const icon = {
+    name: item.icon as IconName,
+    color: item.extra?.iconColor ? color(item.extra.iconColor) : color("brand")
+  };
+
+  if(isActive && !item.extra?.iconColor){
+    icon.color = color("white")
+  }
+
+  if(isActive && (item.icon === "folder" || item.icon === "collection")){
+    icon.name = "folder_filled";
+  }
+
+  return icon;
+
+}

--- a/frontend/src/metabase/palette/utils.ts
+++ b/frontend/src/metabase/palette/utils.ts
@@ -1,11 +1,11 @@
 import { t } from "ttag";
 import _ from "underscore";
 
+import { color } from "metabase/lib/colors";
+import type { IconName } from "metabase/ui";
 import type { RecentItem } from "metabase-types/api";
 
 import type { PaletteActionImpl } from "./types";
-import { color } from "metabase/lib/colors";
-import type { IconName } from "metabase/ui";
 
 export const processResults = (
   results: (string | PaletteActionImpl)[],
@@ -58,22 +58,22 @@ export const findClosestActionIndex = (
 export const filterRecentItems: (items: RecentItem[]) => RecentItem[] = items =>
   items.filter(item => item.model !== "collection").slice(0, 5);
 
-
-export const getCommandPaletteIcon = (item: PaletteActionImpl, isActive: boolean): {name: IconName, color: string} => {
-
+export const getCommandPaletteIcon = (
+  item: PaletteActionImpl,
+  isActive: boolean,
+): { name: IconName; color: string } => {
   const icon = {
     name: item.icon as IconName,
-    color: item.extra?.iconColor ? color(item.extra.iconColor) : color("brand")
+    color: item.extra?.iconColor ? color(item.extra.iconColor) : color("brand"),
   };
 
-  if(isActive && !item.extra?.iconColor){
-    icon.color = color("white")
+  if (isActive) {
+    icon.color = color("white");
   }
 
-  if(isActive && (item.icon === "folder" || item.icon === "collection")){
+  if (isActive && (item.icon === "folder" || item.icon === "collection")) {
     icon.name = "folder_filled";
   }
 
   return icon;
-
-}
+};


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/43475

### Description
Small change to how Icons defined for search results and recent items. We now use the `getIcon` function to determine the name and the color of the icon. If no color is returned, we default to brand.

### How to verify

1. Open the command palette and observe icon colors. Icons should be brand color by default, but official collections (and verified models?) should be yellow
2. Searching should yield consistent icon colors

### Demo
![image](https://github.com/metabase/metabase/assets/1328979/74caf8c4-5dbf-42f1-87e7-ef5f8e33f653)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
