### PR TITLE
Followed-up tasks for changelog generation

### DIFF
--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -230,7 +230,7 @@ jobs:
         run: |
           cd sdk
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
-          npm publish --dry-run
+          npm publish
 
   git-tag:
     needs: publish-npm

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: check tags
         run: |
-          if [ $(git tag -l | grep $tag) ]
+          if [ $(git tag -l | grep $tag$) ]
           then
             echo "::error::Tag '${{ env.tag }}' already exists. If you expect to run this workflow with the same tag, please remove the tag first and rerun this workflow again."
             exit 1

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -205,7 +205,7 @@ jobs:
                        --assignee "${GITHUB_ACTOR}"\
                        --title "Update SDK version to ${{ inputs.sdk_version }}"\
                        --body "Update Readme version references and published npm package version to ${{ inputs.sdk_version }}"
-          gh pr edit --add-reviewer @metabase/embedding
+          gh pr edit --add-reviewer @metabase/embedding --add-label no-backport
         env:
           GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
 

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -205,9 +205,20 @@ jobs:
                        --assignee "${GITHUB_ACTOR}"\
                        --title "Update SDK version to ${{ inputs.sdk_version }}"\
                        --body "Update Readme version references and published npm package version to ${{ inputs.sdk_version }}"
-          gh pr edit --add-reviewer @metabase/embedding --add-label no-backport
         env:
           GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.METABASE_BOT_APP_ID }}
+          private-key: ${{ secrets.METABASE_BOT_APP_PRIVATE_KEY }}
+
+      - name: Edit PR adding useful information
+        run: |
+          gh pr edit --add-reviewer @metabase/embedding --add-label no-backport
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Retrieve build SDK package artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -233,11 +233,7 @@ jobs:
         with:
           ref: ${{ inputs.git_ref }}
 
-      - name: Setup git user
-        run: |
-          git config --global user.email "github-automation@metabase.com"
-          git config --global user.name "Metabase Automation"
-
+      # Lightweight tags don't need committer name and email
       - name: Create a new git tag
         run: |
           git tag ${{ env.tag }}

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -225,7 +225,7 @@ jobs:
         run: |
           cd sdk
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
-          npm publish
+          npm publish --dry-run
 
   git-tag:
     needs: publish-npm

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -168,8 +168,8 @@ jobs:
 
       - name: Setup git user
         run: |
-          git config --global user.email "metabase-bot@metabase.com"
-          git config --global user.name "Metabase bot"
+          git config --global user.email "github-automation@metabase.com"
+          git config --global user.name "Metabase Automation"
 
       # TODO: Remove this step after the build utils script is merged to master
       - name: Download release utils script
@@ -196,12 +196,6 @@ jobs:
         run: |
           mv CHANGELOG.md ./enterprise/frontend/src/embedding-sdk/CHANGELOG.md
 
-      - uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ secrets.METABASE_BOT_APP_ID }}
-          private-key: ${{ secrets.METABASE_BOT_APP_PRIVATE_KEY }}
-
       - name: Create a PR updating readme + published version, and changelog
         run: |
           git checkout -b update-sdk-version-${{ inputs.sdk_version }}
@@ -213,7 +207,7 @@ jobs:
                        --body "Update Readme version references and published npm package version to ${{ inputs.sdk_version }}"
           gh pr edit --add-reviewer @metabase/embedding
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
 
       - name: Retrieve build SDK package artifact
         uses: actions/download-artifact@v4
@@ -241,8 +235,8 @@ jobs:
 
       - name: Setup git user
         run: |
-          git config --global user.email "metabase-bot@metabase.com"
-          git config --global user.name "Metabase bot"
+          git config --global user.email "github-automation@metabase.com"
+          git config --global user.name "Metabase Automation"
 
       - name: Create a new git tag
         run: |


### PR DESCRIPTION
Closes #43583

[Here's the full run with `npm publish --dry-run`](https://github.com/metabase/metabase/actions/runs/9386504546)
