### PR TITLE
Expose `attached-dwh` token feature flag to frontend

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/api/session_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/api/session_test.clj
@@ -8,6 +8,7 @@
 
 (deftest properties-token-features-test
   (mt/with-premium-features #{:advanced-permissions
+                              :attached-dwh
                               :audit-app
                               :cache-granular-controls
                               :config-text-file
@@ -32,6 +33,7 @@
                               :upload_management
                               :whitelabel}
           (is (= {:advanced_permissions           true
+                  :attached_dwh                   true
                   :audit_app                      true
                   :cache_granular_controls        true
                   :config_text_file               true

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -728,6 +728,7 @@ See [fonts](../configuring-metabase/fonts.md).")
   :visibility :public
   :setter     :none
   :getter     (fn [] {:advanced_permissions           (premium-features/enable-advanced-permissions?)
+                      :attached_dwh                   (premium-features/has-attached-dwh?)
                       :audit_app                      (premium-features/enable-audit-app?)
                       :cache_granular_controls        (premium-features/enable-cache-granular-controls?)
                       :config_text_file               (premium-features/enable-config-text-file?)

--- a/src/metabase/public_settings/premium_features.clj
+++ b/src/metabase/public_settings/premium_features.clj
@@ -474,6 +474,10 @@
   "Should we allow admins to clean up tables created from uploads?"
   :upload-management)
 
+(define-premium-feature has-attached-dwh?
+  "Does the Metabase Cloud instance have an internal data warehouse attached?"
+  :attached-dwh)
+
 (defsetting is-hosted?
   "Is the Metabase instance running in the cloud?"
   :type       :boolean


### PR DESCRIPTION
This allows frontend code to conveniently check whether the feature
flag is enabled or disabled.  This is in addition to the raw flag's
presence (or absence) in `(:features token-status)`.

References: https://github.com/metabase/metabase/issues/42381
References: https://github.com/metabase/metabase/pull/43511