### PR TITLE
Fix OSS tests in CI

### DIFF
--- a/e2e/support/helpers/e2e-enterprise-helpers.js
+++ b/e2e/support/helpers/e2e-enterprise-helpers.js
@@ -8,10 +8,10 @@ export const isEE = Cypress.env("IS_ENTERPRISE");
 export const isOSS = !isEE;
 
 /** run only if the test is running on an EE jar */
-export const onlyEE = () => cy.onlyOn(isEE);
+export const onlyOnEE = () => cy.onlyOn(isEE);
 
 /** run only if the test is running on an OSS jar */
-export const onlyOSS = () => cy.onlyOn(isOSS);
+export const onlyOnOSS = () => cy.onlyOn(isOSS);
 
 /**
  *

--- a/e2e/support/helpers/e2e-enterprise-helpers.js
+++ b/e2e/support/helpers/e2e-enterprise-helpers.js
@@ -3,15 +3,15 @@
  * doesn't mean that the token is active or that it has all feature flags enabled.
  *
  * `isEE` means enterprise instance without a token and `isOSS` means open-source instance.
- * In the same way, custom `describe` blocks `describeEE` and `describeOSS` are used to
- * conditionally run tests only against a corresponding Metabase instance.
- *
- * There is a subset of UI elements that appear only in an open-source instance. Test those
- * using a `describeOSS` block, and vice-versa.
- *
  */
 export const isEE = Cypress.env("IS_ENTERPRISE");
 export const isOSS = !isEE;
+
+/** run only if the test is running on an EE jar */
+export const onlyEE = () => cy.onlyOn(isEE);
+
+/** run only if the test is running on an OSS jar */
+export const onlyOSS = () => cy.onlyOn(isOSS);
 
 /**
  *
@@ -20,7 +20,6 @@ export const isOSS = !isEE;
 const conditionalDescribe = cond => (cond ? describe : describe.skip);
 
 export const describeEE = conditionalDescribe(isEE);
-export const describeOSS = conditionalDescribe(isOSS);
 
 /**
  *

--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -306,7 +306,7 @@ export function saveQuestion(
   { wrapId = false, idAlias = "questionId" } = {},
 ) {
   cy.intercept("POST", "/api/card").as("saveQuestion");
-  cy.findByText("Save").click();
+  cy.findByTestId("qb-header").button("Save").click();
 
   cy.findByTestId("save-question-modal").within(modal => {
     if (name) {
@@ -322,7 +322,8 @@ export function saveQuestion(
   });
 
   cy.get("#QuestionSavedModal").within(() => {
-    cy.button("Not now").click();
+    cy.findByText(/add this to a dashboard/i);
+    cy.findByText("Not now").click();
   });
 }
 

--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -255,12 +255,10 @@ export function tableHeaderClick(headerString) {
  * @returns
  */
 export function newButton(menuItem) {
-  const btn = cy.findByTestId("app-bar").button("New");
-
   if (menuItem) {
-    btn.click();
+    cy.findByTestId("app-bar").button("New").click();
     return popover().findByText(menuItem);
-  } else {
-    return btn;
   }
+
+  return cy.findByTestId("app-bar").button("New");
 }

--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -249,3 +249,18 @@ export function tableHeaderClick(headerString) {
     cy.findByTextEnsureVisible(headerString).trigger("mouseup");
   });
 }
+/**
+ * selects the global new button
+ * @param {*} menuItem optional, if provided, will click the New button and return the menu item with the text provided
+ * @returns
+ */
+export function newButton(menuItem) {
+  const btn = cy.findByTestId("app-bar").button("New");
+
+  if (menuItem) {
+    btn.click();
+    return popover().findByText(menuItem);
+  } else {
+    return btn;
+  }
+}

--- a/e2e/test/scenarios/admin-2/tools/erroring-questions.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/tools/erroring-questions.cy.spec.js
@@ -1,6 +1,6 @@
 import {
   restore,
-  isEE,
+  onlyEE,
   setTokenFeatures,
   appBar,
   main,
@@ -37,7 +37,7 @@ const brokenQuestionDetails = {
 describe("admin > tools > erroring questions ", { tags: "@quarantine" }, () => {
   describe.skip("when feature enabled", () => {
     beforeEach(() => {
-      cy.onlyOn(isEE);
+      onlyEE();
 
       restore();
       cy.signInAsAdmin();
@@ -125,7 +125,7 @@ describe("admin > tools > erroring questions ", { tags: "@quarantine" }, () => {
 
   describe("when feature disabled", () => {
     beforeEach(() => {
-      cy.onlyOn(isEE);
+      onlyEE();
 
       restore();
       cy.signInAsAdmin();

--- a/e2e/test/scenarios/admin-2/tools/erroring-questions.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/tools/erroring-questions.cy.spec.js
@@ -1,6 +1,6 @@
 import {
   restore,
-  onlyEE,
+  onlyOnEE,
   setTokenFeatures,
   appBar,
   main,
@@ -37,7 +37,7 @@ const brokenQuestionDetails = {
 describe("admin > tools > erroring questions ", { tags: "@quarantine" }, () => {
   describe.skip("when feature enabled", () => {
     beforeEach(() => {
-      onlyEE();
+      onlyOnEE();
 
       restore();
       cy.signInAsAdmin();
@@ -125,7 +125,7 @@ describe("admin > tools > erroring questions ", { tags: "@quarantine" }, () => {
 
   describe("when feature disabled", () => {
     beforeEach(() => {
-      onlyEE();
+      onlyOnEE();
 
       restore();
       cy.signInAsAdmin();

--- a/e2e/test/scenarios/admin/settings/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin/settings/settings.cy.spec.js
@@ -6,8 +6,9 @@ import {
   popover,
   describeEE,
   setupMetabaseCloud,
-  isOSS,
+  onlyOSS,
   isEE,
+  isOSS,
   setTokenFeatures,
   undoToast,
   describeWithSnowplow,
@@ -29,7 +30,7 @@ describeWithSnowplow("scenarios > admin > settings", () => {
     "should prompt admin to migrate to a hosted instance",
     { tags: "@OSS" },
     () => {
-      cy.onlyOn(isOSS);
+      onlyOSS();
       cy.visit("/admin/settings/setup");
 
       cy.findByTestId("upsell-card").findByText(/Migrate to Metabase Cloud/);
@@ -344,7 +345,7 @@ describeWithSnowplow("scenarios > admin > settings", () => {
 
 describe("scenarios > admin > settings (OSS)", { tags: "@OSS" }, () => {
   beforeEach(() => {
-    cy.onlyOn(isOSS);
+    onlyOSS();
     restore();
     cy.signInAsAdmin();
   });

--- a/e2e/test/scenarios/admin/settings/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin/settings/settings.cy.spec.js
@@ -6,7 +6,7 @@ import {
   popover,
   describeEE,
   setupMetabaseCloud,
-  onlyOSS,
+  onlyOnOSS,
   isEE,
   isOSS,
   setTokenFeatures,
@@ -30,7 +30,7 @@ describeWithSnowplow("scenarios > admin > settings", () => {
     "should prompt admin to migrate to a hosted instance",
     { tags: "@OSS" },
     () => {
-      onlyOSS();
+      onlyOnOSS();
       cy.visit("/admin/settings/setup");
 
       cy.findByTestId("upsell-card").findByText(/Migrate to Metabase Cloud/);
@@ -345,7 +345,7 @@ describeWithSnowplow("scenarios > admin > settings", () => {
 
 describe("scenarios > admin > settings (OSS)", { tags: "@OSS" }, () => {
   beforeEach(() => {
-    onlyOSS();
+    onlyOnOSS();
     restore();
     cy.signInAsAdmin();
   });

--- a/e2e/test/scenarios/admin/troubleshooting/help.cy.spec.js
+++ b/e2e/test/scenarios/admin/troubleshooting/help.cy.spec.js
@@ -1,5 +1,5 @@
 import {
-  isOSS,
+  onlyOSS,
   describeEE,
   restore,
   setupMetabaseCloud,
@@ -26,7 +26,7 @@ describe("scenarios > admin > troubleshooting > help", () => {
 
 describe("scenarios > admin > troubleshooting > help", { tags: "@OSS" }, () => {
   beforeEach(() => {
-    cy.onlyOn(isOSS);
+    onlyOSS();
 
     restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/admin/troubleshooting/help.cy.spec.js
+++ b/e2e/test/scenarios/admin/troubleshooting/help.cy.spec.js
@@ -1,5 +1,5 @@
 import {
-  onlyOSS,
+  onlyOnOSS,
   describeEE,
   restore,
   setupMetabaseCloud,
@@ -26,7 +26,7 @@ describe("scenarios > admin > troubleshooting > help", () => {
 
 describe("scenarios > admin > troubleshooting > help", { tags: "@OSS" }, () => {
   beforeEach(() => {
-    onlyOSS();
+    onlyOnOSS();
 
     restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/collections/instance-analytics.cy.spec.js
+++ b/e2e/test/scenarios/collections/instance-analytics.cy.spec.js
@@ -11,8 +11,9 @@ import {
   visitDashboard,
   visitModel,
   visitQuestion,
-  describeOSS,
   tableHeaderClick,
+  onlyOSS,
+  onlyEE,
 } from "e2e/support/helpers";
 
 const ANALYTICS_COLLECTION_NAME = "Metabase analytics";
@@ -261,6 +262,7 @@ describeEE("scenarios > Metabase Analytics Collection (AuditV2) ", () => {
 describe("question and dashboard links", () => {
   describeEE("ee", () => {
     beforeEach(() => {
+      onlyEE();
       restore();
       cy.signInAsAdmin();
       setTokenFeatures("all");
@@ -339,8 +341,9 @@ describe("question and dashboard links", () => {
       popover().findByText("Usage insights").should("not.exist");
     });
   });
-  describeOSS("oss", { tags: "@OSS" }, () => {
+  describe("oss", { tags: "@OSS" }, () => {
     beforeEach(() => {
+      onlyOSS();
       restore();
       cy.signInAsAdmin();
     });

--- a/e2e/test/scenarios/collections/instance-analytics.cy.spec.js
+++ b/e2e/test/scenarios/collections/instance-analytics.cy.spec.js
@@ -12,8 +12,8 @@ import {
   visitModel,
   visitQuestion,
   tableHeaderClick,
-  onlyOSS,
-  onlyEE,
+  onlyOnOSS,
+  onlyOnEE,
 } from "e2e/support/helpers";
 
 const ANALYTICS_COLLECTION_NAME = "Metabase analytics";
@@ -262,7 +262,7 @@ describeEE("scenarios > Metabase Analytics Collection (AuditV2) ", () => {
 describe("question and dashboard links", () => {
   describeEE("ee", () => {
     beforeEach(() => {
-      onlyEE();
+      onlyOnEE();
       restore();
       cy.signInAsAdmin();
       setTokenFeatures("all");
@@ -343,7 +343,7 @@ describe("question and dashboard links", () => {
   });
   describe("oss", { tags: "@OSS" }, () => {
     beforeEach(() => {
-      onlyOSS();
+      onlyOnOSS();
       restore();
       cy.signInAsAdmin();
     });

--- a/e2e/test/scenarios/models/reproductions.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.js
@@ -50,7 +50,7 @@ import {
   visualize,
   focusNativeEditor,
   tableHeaderClick,
-  onlyOSS,
+  onlyOnOSS,
 } from "e2e/support/helpers";
 import {
   createMockActionParameter,
@@ -201,7 +201,7 @@ describe("issue 19776", { tags: "@OSS" }, () => {
     cy.findByText(item).closest("tr").find(".Icon-ellipsis").click();
   }
   beforeEach(() => {
-    onlyOSS();
+    onlyOnOSS();
     restore();
     cy.signInAsAdmin();
   });

--- a/e2e/test/scenarios/models/reproductions.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.js
@@ -11,7 +11,6 @@ import {
   openNavigationSidebar,
   popover,
   restore,
-  describeOSS,
   modal,
   openNativeEditor,
   saveQuestion,
@@ -51,6 +50,7 @@ import {
   visualize,
   focusNativeEditor,
   tableHeaderClick,
+  onlyOSS,
 } from "e2e/support/helpers";
 import {
   createMockActionParameter,
@@ -195,12 +195,13 @@ describe("issue 19737", () => {
 });
 
 // this is only testable in OSS because EE always has models from auditv2
-describeOSS("issue 19776", { tags: "@OSS" }, () => {
+describe("issue 19776", { tags: "@OSS" }, () => {
   const modelName = "Orders Model";
   function openEllipsisMenuFor(item) {
     cy.findByText(item).closest("tr").find(".Icon-ellipsis").click();
   }
   beforeEach(() => {
+    onlyOSS();
     restore();
     cy.signInAsAdmin();
   });

--- a/e2e/test/scenarios/models/reproductions.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.js
@@ -206,26 +206,28 @@ describe("issue 19776", { tags: "@OSS" }, () => {
     cy.signInAsAdmin();
   });
 
-  it("should show moved model in the data picker without refreshing (metabase#19776)", () => {
-    cy.visit("/collection/root");
+  it("should reflect archived model in the data picker without refreshing (metabase#19776)", () => {
+    cy.visit("/");
 
-    openEllipsisMenuFor(modelName);
+    cy.findByTestId("app-bar").button("New").click();
+    popover().findByText("Question").click();
+    entityPickerModalTab("Models").should("be.visible"); // now you see it
+    entityPickerModal().findByLabelText("Close").click();
+
+    // navigate without a page load
+    cy.findByTestId("sidebar-toggle").click();
+    navigationSidebar().findByText("Our analytics").click();
+
+    // archive the only model
+    cy.findByTestId("collection-table").within(() => {
+      openEllipsisMenuFor(modelName);
+    });
     popover().contains("Move to trash").click();
+    cy.findByTestId("undo-list").findByText("Trashed model");
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Archived model");
-
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("New").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Question").should("be.visible").click();
-
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Sample Database");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Saved Questions");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Models").should("not.exist");
+    cy.findByTestId("app-bar").button("New").click();
+    popover().findByText("Question").click();
+    entityPickerModalTab("Models").should("not.exist"); // now you don't
   });
 });
 

--- a/e2e/test/scenarios/native/snippets/snippet-permissions.cy.spec.js
+++ b/e2e/test/scenarios/native/snippets/snippet-permissions.cy.spec.js
@@ -7,7 +7,7 @@ import {
   openNativeEditor,
   rightSidebar,
   setTokenFeatures,
-  isOSS,
+  onlyOSS,
   entityPickerModal,
 } from "e2e/support/helpers";
 
@@ -15,7 +15,7 @@ const { ALL_USERS_GROUP } = USER_GROUPS;
 
 describe("scenarios > question > snippets (OSS)", { tags: "@OSS" }, () => {
   beforeEach(() => {
-    cy.onlyOn(isOSS);
+    onlyOSS();
     restore();
   });
 

--- a/e2e/test/scenarios/native/snippets/snippet-permissions.cy.spec.js
+++ b/e2e/test/scenarios/native/snippets/snippet-permissions.cy.spec.js
@@ -7,7 +7,7 @@ import {
   openNativeEditor,
   rightSidebar,
   setTokenFeatures,
-  onlyOSS,
+  onlyOnOSS,
   entityPickerModal,
 } from "e2e/support/helpers";
 
@@ -15,7 +15,7 @@ const { ALL_USERS_GROUP } = USER_GROUPS;
 
 describe("scenarios > question > snippets (OSS)", { tags: "@OSS" }, () => {
   beforeEach(() => {
-    onlyOSS();
+    onlyOnOSS();
     restore();
   });
 

--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -7,7 +7,7 @@ import {
   restore,
   modal,
   describeEE,
-  isOSS,
+  onlyOSS,
   assertPermissionTable,
   assertPermissionOptions,
   modifyPermission,
@@ -27,7 +27,7 @@ const NATIVE_QUERIES_PERMISSION_INDEX = 0;
 
 describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
   beforeEach(() => {
-    cy.onlyOn(isOSS);
+    onlyOSS();
 
     restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -7,7 +7,7 @@ import {
   restore,
   modal,
   describeEE,
-  onlyOSS,
+  onlyOnOSS,
   assertPermissionTable,
   assertPermissionOptions,
   modifyPermission,
@@ -27,7 +27,7 @@ const NATIVE_QUERIES_PERMISSION_INDEX = 0;
 
 describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
   beforeEach(() => {
-    onlyOSS();
+    onlyOnOSS();
 
     restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/permissions/permissions-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/permissions-reproductions.cy.spec.js
@@ -13,7 +13,7 @@ import {
   visitQuestion,
   setTokenFeatures,
   popover,
-  isEE,
+  onlyEE,
   setupSMTP,
   sidebar,
   modal,
@@ -371,7 +371,7 @@ describe("UI elements that make no sense for users without data permissions (met
   });
 
   it("should not show visualization or question settings to users with block data permissions", () => {
-    cy.onlyOn(isEE);
+    onlyEE();
 
     cy.signInAsAdmin();
     setTokenFeatures("all");

--- a/e2e/test/scenarios/permissions/permissions-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/permissions-reproductions.cy.spec.js
@@ -13,7 +13,7 @@ import {
   visitQuestion,
   setTokenFeatures,
   popover,
-  onlyEE,
+  onlyOnEE,
   setupSMTP,
   sidebar,
   modal,
@@ -371,7 +371,7 @@ describe("UI elements that make no sense for users without data permissions (met
   });
 
   it("should not show visualization or question settings to users with block data permissions", () => {
-    onlyEE();
+    onlyOnEE();
 
     cy.signInAsAdmin();
     setTokenFeatures("all");

--- a/e2e/test/scenarios/question-reproductions/reproductions-2.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-2.cy.spec.js
@@ -23,7 +23,7 @@ import {
   queryBuilderHeader,
   saveQuestion,
   tableHeaderClick,
-  onlyOSS,
+  onlyOnOSS,
   entityPickerModalItem,
   newButton,
 } from "e2e/support/helpers";
@@ -278,7 +278,7 @@ describe("issue 25016", () => {
 // this is only testable in OSS because EE always has models from auditv2
 describe("issue 25144", { tags: "@OSS" }, () => {
   beforeEach(() => {
-    onlyOSS();
+    onlyOnOSS();
     restore("setup");
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/card").as("createCard");

--- a/e2e/test/scenarios/question-reproductions/reproductions-2.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-2.cy.spec.js
@@ -21,9 +21,9 @@ import {
   chartPathWithFillColor,
   openQuestionActions,
   queryBuilderHeader,
-  describeOSS,
   saveQuestion,
   tableHeaderClick,
+  onlyOSS,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID, PEOPLE } = SAMPLE_DATABASE;
@@ -274,8 +274,9 @@ describe("issue 25016", () => {
 });
 
 // this is only testable in OSS because EE always has models from auditv2
-describeOSS("issue 25144", { tags: "@OSS" }, () => {
+describe("issue 25144", { tags: "@OSS" }, () => {
   beforeEach(() => {
+    onlyOSS();
     restore("setup");
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/card").as("createCard");

--- a/e2e/test/scenarios/question-reproductions/reproductions-2.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-2.cy.spec.js
@@ -24,6 +24,8 @@ import {
   saveQuestion,
   tableHeaderClick,
   onlyOSS,
+  entityPickerModalItem,
+  newButton,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID, PEOPLE } = SAMPLE_DATABASE;
@@ -283,53 +285,51 @@ describe("issue 25144", { tags: "@OSS" }, () => {
     cy.intercept("PUT", "/api/card/*").as("updateCard");
   });
 
-  it("should show Saved Questions section after creating the first question (metabase#25144)", () => {
+  it("should show Saved Questions tab after creating the first question (metabase#25144)", () => {
     cy.visit("/");
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("New").click();
-    popover().findByText("Question").click();
-    popover().findByText("Orders").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Save").click();
-    modal().findByLabelText("Name").clear().type("Orders question");
-    modal().button("Save").click();
-    cy.wait("@createCard");
-    cy.wait(100);
-    modal().button("Not now").click();
+    newButton("Question").click();
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("New").click();
-    popover().findByText("Question").click();
-    popover().findByText("Saved Questions").click();
-    popover().findByText("Orders question").should("be.visible");
+    entityPickerModal().within(() => {
+      cy.findByText("Saved questions").should("not.exist");
+      entityPickerModalItem(2, "Orders").click();
+    });
+
+    saveQuestion("Orders question");
+
+    newButton("Question").click();
+
+    entityPickerModal().within(() => {
+      entityPickerModalTab("Saved questions").should("be.visible").click();
+      entityPickerModalItem(1, "Orders question").should("be.visible");
+    });
   });
 
-  it("should show Models section after creation the first model (metabase#24878)", () => {
+  it("should show Models tab after creation the first model (metabase#24878)", () => {
     cy.visit("/");
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("New").click();
-    popover().findByText("Question").click();
-    popover().findByText("Orders").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Save").click();
-    modal().findByLabelText("Name").clear().type("Orders model");
-    modal().button("Save").click();
+    newButton("Model").click();
+    cy.findByTestId("new-model-options")
+      .findByText(/use the notebook/i)
+      .click();
+    entityPickerModal().within(() => {
+      entityPickerModalItem(2, "Orders").click();
+    });
+
+    cy.findByTestId("dataset-edit-bar").button("Save").click();
+
+    modal().within(() => {
+      cy.findByLabelText("Name").clear().type("Orders model");
+      cy.button("Save").click();
+    });
     cy.wait("@createCard");
-    cy.wait(100);
-    modal().button("Not now").click();
 
-    cy.findByLabelText("Move, archive, and more...").click();
-    popover().findByText("Turn into a model").click();
-    modal().button("Turn this into a model").click();
-    cy.wait("@updateCard");
+    newButton("Question").click();
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("New").click();
-    popover().findByText("Question").click();
-    popover().findByText("Models").click();
-    popover().findByText("Orders model").should("be.visible");
+    entityPickerModal().within(() => {
+      entityPickerModalTab("Models").should("be.visible").click();
+      entityPickerModalItem(1, "Orders model").should("be.visible");
+    });
   });
 });
 

--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -26,6 +26,7 @@ import {
   visitQuestion,
   tableHeaderClick,
   onlyOSS,
+  createQuestion,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -466,15 +467,16 @@ describe(
     it("can create a question from the sample database", () => {
       cy.visit("/question/new");
 
-      cy.get("#DataPopover").within(() => {
-        cy.findByText("Saved Questions").should("be.visible");
-        cy.findByText("Models").should("not.exist");
-        cy.findByText("Sample Database").click();
-        cy.findByText("Products").click();
+      entityPickerModal().within(() => {
+        entityPickerModalTab("Saved questions").should("be.visible");
+        entityPickerModalTab("Models").should("not.exist");
+        entityPickerModalTab("Tables").click();
+
+        entityPickerModalItem(2, "Products").click();
       });
-      cy.get("main")
-        .findByText(/Doing Science/)
-        .should("not.exist");
+
+      // strange: we get different behavior when we go to question/new
+      cy.findAllByTestId("run-button").first().click();
 
       cy.findByTestId("TableInteractive-root").within(() => {
         cy.findByText("Rustic Paper Wallet").should("be.visible");
@@ -484,14 +486,13 @@ describe(
     it("can create a question from a saved question", () => {
       cy.visit("/question/new");
 
-      cy.get("#DataPopover").within(() => {
-        cy.findByText("Saved Questions").click();
-        cy.findByText("Models").should("not.exist");
-        cy.findByText("Orders").click();
+      entityPickerModal().within(() => {
+        entityPickerModalTab("Saved questions").click();
+        entityPickerModalItem(1, "Orders").click();
       });
-      cy.get("main")
-        .findByText(/Doing Science/)
-        .should("not.exist");
+
+      // strange: we get different behavior when we go to question/new
+      cy.findAllByTestId("run-button").first().click();
 
       cy.findByTestId("TableInteractive-root").within(() => {
         cy.findByText(39.72).should("be.visible");
@@ -499,7 +500,7 @@ describe(
     });
 
     it("shows models and raw data options after creating a model", () => {
-      cy.createQuestion({
+      createQuestion({
         name: "Orders Model",
         query: { "source-table": ORDERS_ID },
         type: "model",
@@ -507,10 +508,10 @@ describe(
 
       cy.visit("/question/new");
 
-      cy.get("#DataPopover").within(() => {
-        cy.findByText("Raw Data").should("be.visible");
-        cy.findByText("Saved Questions").should("be.visible");
-        cy.findByText("Models").should("be.visible");
+      entityPickerModal().within(() => {
+        entityPickerModalTab("Saved questions").should("be.visible");
+        entityPickerModalTab("Models").should("be.visible");
+        entityPickerModalTab("Tables").should("be.visible");
       });
     });
   },

--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -16,8 +16,6 @@ import {
   saveQuestion,
   getPersonalCollectionName,
   visitCollection,
-  setTokenFeatures,
-  describeOSS,
   queryBuilderHeader,
   entityPickerModal,
   entityPickerModalItem,
@@ -27,6 +25,7 @@ import {
   pickEntity,
   visitQuestion,
   tableHeaderClick,
+  onlyOSS,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -454,14 +453,14 @@ describe("scenarios > question > new", () => {
 // the data picker has different behavior if there are no models in the instance
 // the default instance image has a model in it, so we need to separately test the
 // model-less behavior
-describeOSS(
+describe(
   "scenarios > question > new > data picker > without models",
   { tags: "@OSS" },
   () => {
     beforeEach(() => {
+      onlyOSS();
       restore("without-models");
       cy.signInAsAdmin();
-      setTokenFeatures("none");
     });
 
     it("can create a question from the sample database", () => {

--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -25,7 +25,7 @@ import {
   pickEntity,
   visitQuestion,
   tableHeaderClick,
-  onlyOSS,
+  onlyOnOSS,
   createQuestion,
 } from "e2e/support/helpers";
 
@@ -459,7 +459,7 @@ describe(
   { tags: "@OSS" },
   () => {
     beforeEach(() => {
-      onlyOSS();
+      onlyOnOSS();
       restore("without-models");
       cy.signInAsAdmin();
     });

--- a/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
@@ -1,7 +1,3 @@
-// TypeScript doesn't recognize `onlyOn` on the `cy` object.
-// Hence, we have to import it as a standalone helper.
-import { onlyOn } from "@cypress/skip-test";
-
 import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
@@ -12,13 +8,10 @@ import {
 import type { StructuredQuestionDetails } from "e2e/support/helpers";
 import {
   createQuestion,
-  describeOSS,
   entityPickerModal,
   entityPickerModalItem,
   entityPickerModalLevel,
   entityPickerModalTab,
-  isEE,
-  isOSS,
   openNotebook,
   openQuestionActions,
   openReviewsTable,
@@ -27,6 +20,8 @@ import {
   restore,
   resyncDatabase,
   saveQuestion,
+  onlyOSS,
+  onlyEE,
   startNewQuestion,
   tabsShouldBe,
   visitModel,
@@ -48,7 +43,7 @@ describe("scenarios > notebook > data source", () => {
       "should display tables from the only existing database by default",
       { tags: "@OSS" },
       () => {
-        onlyOn(isOSS);
+        onlyOSS();
         cy.visit("/");
         cy.findByTestId("app-bar").findByText("New").click();
         popover().findByTextEnsureVisible("Question").click();
@@ -79,7 +74,7 @@ describe("scenarios > notebook > data source", () => {
     );
 
     it.skip("should display tables from the only existing database by default on an enterprise instance without token activation (metabase#40223)", () => {
-      onlyOn(isEE);
+      onlyEE();
       cy.visit("/");
       cy.findByTestId("app-bar").findByText("New").click();
       popover().findByTextEnsureVisible("Question").click();
@@ -413,8 +408,9 @@ describe("scenarios > notebook > data source", () => {
   });
 });
 
-describeOSS("scenarios > notebook > data source", { tags: "@OSS" }, () => {
+describe("scenarios > notebook > data source", { tags: "@OSS" }, () => {
   beforeEach(() => {
+    onlyOSS();
     restore("setup");
     cy.signInAsAdmin();
   });

--- a/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
@@ -20,8 +20,8 @@ import {
   restore,
   resyncDatabase,
   saveQuestion,
-  onlyOSS,
-  onlyEE,
+  onlyOnOSS,
+  onlyOnEE,
   startNewQuestion,
   tabsShouldBe,
   visitModel,
@@ -43,7 +43,7 @@ describe("scenarios > notebook > data source", () => {
       "should display tables from the only existing database by default",
       { tags: "@OSS" },
       () => {
-        onlyOSS();
+        onlyOnOSS();
         cy.visit("/");
         cy.findByTestId("app-bar").findByText("New").click();
         popover().findByTextEnsureVisible("Question").click();
@@ -74,7 +74,7 @@ describe("scenarios > notebook > data source", () => {
     );
 
     it.skip("should display tables from the only existing database by default on an enterprise instance without token activation (metabase#40223)", () => {
-      onlyEE();
+      onlyOnEE();
       cy.visit("/");
       cy.findByTestId("app-bar").findByText("New").click();
       popover().findByTextEnsureVisible("Question").click();
@@ -410,7 +410,7 @@ describe("scenarios > notebook > data source", () => {
 
 describe("scenarios > notebook > data source", { tags: "@OSS" }, () => {
   beforeEach(() => {
-    onlyOSS();
+    onlyOnOSS();
     restore("setup");
     cy.signInAsAdmin();
   });

--- a/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
@@ -8,7 +8,7 @@ import {
   popover,
   sidebar,
   mockSlackConfigured,
-  onlyOSS,
+  onlyOnOSS,
   visitDashboard,
   editDashboard,
   sendEmailAndAssert,
@@ -520,7 +520,7 @@ describe("scenarios > dashboard > subscriptions", () => {
 
   describe("OSS email subscriptions", { tags: ["@OSS", "external"] }, () => {
     beforeEach(() => {
-      onlyOSS();
+      onlyOnOSS();
       cy.visit(`/dashboard/${ORDERS_DASHBOARD_ID}`);
       setupSMTP();
     });

--- a/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
@@ -8,7 +8,7 @@ import {
   popover,
   sidebar,
   mockSlackConfigured,
-  isOSS,
+  onlyOSS,
   visitDashboard,
   editDashboard,
   sendEmailAndAssert,
@@ -520,7 +520,7 @@ describe("scenarios > dashboard > subscriptions", () => {
 
   describe("OSS email subscriptions", { tags: ["@OSS", "external"] }, () => {
     beforeEach(() => {
-      cy.onlyOn(isOSS);
+      onlyOSS();
       cy.visit(`/dashboard/${ORDERS_DASHBOARD_ID}`);
       setupSMTP();
     });


### PR DESCRIPTION
### Description

It appears that a handful of OSS-only tests were not running properly in CI. Something about the `describeOSS()` wrapper was making some (but not all!) of these OSS tests never run. Removing the describeOSS block and using `onlyOSS` in the beforeEach hook gives us the intended behavior.

Since these hadn't been run in a while, they needed to be rewritten to reflect changes in the app

Before 😢  | After 🎉 
---|---
![Screen Shot 2024-06-05 at 12 50 58 PM](https://github.com/metabase/metabase/assets/30528226/472a6830-5a6e-427b-9a6b-7c87300620e2) | ![Screen Shot 2024-06-05 at 12 50 09 PM](https://github.com/metabase/metabase/assets/30528226/3bdc0983-dc7b-4a74-bf03-80d64964b94d)

