### PR TITLE
Nicer error messages for linting migrations

### DIFF
--- a/bin/lint-migrations-file/src/change_set/strict.clj
+++ b/bin/lint-migrations-file/src/change_set/strict.clj
@@ -35,7 +35,7 @@
   (s/keys :opt-un [::dbms]))
 
 (s/def ::preConditions
-  (s/coll-of ::preCondition))
+  (s/nilable (s/coll-of ::preCondition)))
 
 (s/def ::dbms
   (s/keys :req-un [::type]))
@@ -122,6 +122,30 @@
    (some change-types-supporting-rollback (mapcat keys changes))
    (contains? change-set :rollback)))
 
+(def ^:private change-types-requiring-preconditions
+  #{:createTable
+    :dropTable
+    :addColumn
+    :dropColumn
+    :createIndex
+    :dropIndex
+    :addForeignKeyConstraint
+    :dropForeignKeyConstraint})
+
+(defn- precondition-present-when-required?
+  "Ensures that certain changeSet types include a preCondition. The intent is for the preCondition to ensure that the changeSet is
+  idempotent by checking whether the table/column/index/etc does not exist before trying to create it. (Or inversely, that it does
+  exist before trying to drop it.)
+
+  We don't currently assert on the structure of the preCondition to provide flexibility if there are cases where idempotence is not
+  desired."
+  [{:keys [id changes] :as change-set}]
+  (or
+   (int? id)
+   (< (major-version id) 51)
+   (not-any? change-types-requiring-preconditions (mapcat keys changes))
+   (contains? change-set :preConditions)))
+
 (defn- disallow-delete-cascade-with-add-column
   "Returns false if addColumn changeSet uses deleteCascade. See Metabase issue #14321"
   [{:keys [changes]}]
@@ -133,6 +157,7 @@
 (s/def ::change-set
   (s/and
    rollback-present-when-required?
+   precondition-present-when-required?
    disallow-delete-cascade-with-add-column
    (s/keys :req-un [::id ::author ::changes ::comment]
            :opt-un [::preConditions])))

--- a/bin/lint-migrations-file/src/lint_migrations_file.clj
+++ b/bin/lint-migrations-file/src/lint_migrations_file.clj
@@ -4,97 +4,32 @@
    [clj-yaml.core :as yaml]
    [clojure.java.io :as io]
    [clojure.pprint :as pprint]
+   [clojure.set :as set]
    [clojure.spec.alpha :as s]
-   [clojure.string :as str]
-   [clojure.walk :as walk]))
+   [clojure.string :as str])
+  (:import
+   [clojure.lang ExceptionInfo]))
 
 (set! *warn-on-reflection* true)
 
 (comment change-set.strict/keep-me)
+
+(defmacro validation-error
+  "An exception with `::validation-error` in the data, for easy id later."
+  [msg & [data]]
+  `(ex-info ~msg (merge ~data {::validation-error true})))
+
+(defn- validation-error? [e]
+  (::validation-error (ex-data e)))
 
 ;; just print ordered maps like normal maps.
 (defmethod print-method flatland.ordered.map.OrderedMap
   [m writer]
   (print-method (into {} m) writer))
 
-(s/def ::migrations
-  (s/keys :req-un [::databaseChangeLog]))
-
-;; ================================= Error handling =================================================================
-;; When specs completely fail, the output is really painful. Instead of failing specs, let's conform all our inputs to
-;; *either* the input (if valid) or an error (if it's not). This way we can print out the error message and details in
-;; a more readable way.
-
-;; An error looks like `{:error/message ...}`, optionally with an `:error/details` map.
-;;
-;; When writing validation specs in this namespace, you *can* use any normal spec, like `(s/def ::foo even?)`,
-;; but preferably you'll instead write a function that returns an error in the invalid case, and use it like
-;; ```
-;; (s/def ::foo
-;;  (or-error-conformer
-;;   (fn [i]
-;;    (when-not (even? i)
-;;     (error "`i` is not even." :number-i i)))))
-;; ```
-;; This way, when the spec fails, the user sees nice errors like
-(s/def :error/message string?)
-(s/def :error/details (s/map-of keyword? any?))
-(s/def ::error (s/keys :req [:error/message]
-                       :opt [:error/details]))
-
-(s/def :error/errors (s/coll-of ::error :kind vector? :min-count 1))
-;; the input, so we can continue checking
-(s/def :error/in any?)
-(s/def ::errors (s/keys :req [:error/errors
-                              :error/in]))
-
-(defn- add-error [errors error]
-  (update errors :errors conj error))
-
-(defn- new-errors [input error]
-  {:error/errors [error]
-   :error/in input})
-
-(defn- error?
-  [x]
-  (s/valid? ::error x))
-
-(defn- errors?
-  [xs]
-  (s/valid? ::errors xs))
-
-(defn- error
-  "Make a new error"
-  [message & details]
-  {:error/message message
-   :error/details (apply hash-map details)})
-
-(defn- or-error-conformer
-  "Takes a function `f` that returns either an `error` or an arbitrary value.
-
-  Returns a function that conforms the input to either:
-  - an `::errors` value, or
-  - the input itself."
-  [f]
-  (s/conformer
-   (fn [x]
-     ;; in the error case, we continue checking specs against the *original* input
-     (let [in (if (errors? x)
-                (:error/in x)
-                x)
-           out (f in)]
-       (cond
-         ;; if we found an error and we already have errors, add the error to the existing errors
-         (and (errors? x)
-              (error? out))
-         (add-error x out)
-
-         ;; if we found an error and we don't already have errors, make a new `::errors`
-         (error? out)
-         (new-errors in out)
-
-         ;; return the input (either `::errors` if we already had them or the value to check)
-         :else x)))))
+(defn- require-database-change-log! [migrations]
+  (when-not (contains? migrations :databaseChangeLog)
+    (throw (validation-error "Missing `databaseChangeLog` key."))))
 
 (defn- change-set-ids
   "Returns all the change set ids given a change-log."
@@ -103,30 +38,26 @@
         :when id]
     id))
 
-(s/def ::distinct-change-set-ids
-  (or-error-conformer
-   (fn [change-log]
-     (let [ids (change-set-ids change-log)
-           ;; can't apply distinct? with so many IDs
-           duplicates (->> ids
-                           (group-by identity)
-                           (keep (fn [[k v]]
-                                   (when (< 1 (count v))
-                                     k))))]
-       (when (seq duplicates)
-         (error "Change set IDs are not distinct." :duplicates duplicates))))))
+(defn- require-distinct-change-set-ids! [change-log]
+  (let [ids (change-set-ids change-log)
+        duplicates (->> ids
+                        (group-by identity)
+                        (keep (fn [[k v]]
+                                (when (< 1 (count v))
+                                  k))))]
+    (when (seq duplicates)
+      (throw (validation-error "Change set IDs are not distinct." {:duplicates duplicates})))))
 
-(s/def ::change-set-ids-in-order
-  (or-error-conformer
-   (fn [change-log]
-     (when-let [out-of-order-ids (->> change-log
-                                      (change-set-ids)
-                                      (partition 2 1)
-                                      (filter (fn [[id1 id2]]
-                                                (pos? (compare id1 id2))))
-                                      seq)]
-       (error "Change set IDs are not in order"
-              :out-of-order-ids out-of-order-ids)))))
+(defn- require-change-set-ids-in-order! [change-log]
+  (let [ids (change-set-ids change-log)
+        out-of-order-ids (->> ids
+                             (partition 2 1)
+                             (filter (fn [[id1 id2]]
+                                       (pos? (compare id1 id2)))))]
+
+    (when (seq out-of-order-ids)
+      (throw (validation-error "Change set IDs are not in order"
+                              {:out-of-order-ids out-of-order-ids})))))
 
 (defn- check-change-use-types?
   "Return `true` if change use any type in `types`."
@@ -152,12 +83,12 @@
   [target-types change-set]
   (some #(check-change-use-types? target-types %) (get-in change-set [:changeSet :changes])))
 
-(defn- assert-no-types-in-change-log
+(defn- require-no-types-in-change-log!
   "Returns true if none of the changes in the change-log contain usage of any type specified in `target-types`.
 
   `id-filter-fn` is a function that takes an ID and return true if the changeset should be checked."
   ([target-types change-log]
-   (assert-no-types-in-change-log target-types change-log (constantly true)))
+   (require-no-types-in-change-log! target-types change-log (constantly true)))
   ([target-types change-log id-filter-fn]
    {:pre [(set? target-types)]}
    (when-let [using-types? (->> change-log
@@ -168,78 +99,60 @@
                                 (filter #(check-change-set-use-types? target-types %))
                                 (map #(get-in % [:changeSet :id]))
                                 seq)]
-     (error (format "Migration(s) [%s] uses invalid types (in %s)"
-                    (str/join "," (map #(str "'" % "'") using-types?))
-                    (str/join "," (map #(str "'" % "'") target-types)))
-            :invalid-ids using-types?
-            :target-types target-types))))
+     (throw (validation-error
+             (format "Migration(s) [%s] uses invalid types (in %s)"
+                     (str/join "," (map #(str "'" % "'") using-types?))
+                     (str/join "," (map #(str "'" % "'") target-types)))
+              {:invalid-ids using-types?
+               :target-types target-types})))))
 
-(defn no-bare-blob-or-text-types?
+(defn require-no-bare-blob-or-text-types!
   "Ensures that no \"text\" or \"blob\" type columns are added in any changesets."
   [change-log]
-  (assert-no-types-in-change-log #{"blob" "text"} change-log))
+  (require-no-types-in-change-log! #{"blob" "text"} change-log))
 
-(s/def ::no-bare-blob-or-text-types
-  (or-error-conformer
-   no-bare-blob-or-text-types?))
-
-(defn no-bare-boolean-types?
+(defn require-no-bare-boolean-types!
   "Ensures that no \"boolean\" type columns are added in changesets with id later than v49.00-032. From that point on,
   \"${boolean.type}\" should be used instead, so that we can consistently use `BIT(1)` for Boolean columns on MySQL."
   [change-log]
-  (assert-no-types-in-change-log #{"boolean"} change-log #(pos? (compare % "v49.00-032"))))
+  (require-no-types-in-change-log! #{"boolean"} change-log #(pos? (compare % "v49.00-032"))))
 
-(s/def ::no-bare-boolean-types (or-error-conformer no-bare-boolean-types?))
-
-(defn no-datetime-type?
+(defn require-no-datetime-type!
   "Ensures that no \"datetime\" or \"timestamp without time zone\".
   From that point on, \"${timestamp_type}\" should be used instead, so that all of our time related columsn are tz-aware."
   [change-log]
-  (assert-no-types-in-change-log
+  (require-no-types-in-change-log!
    #{"datetime" "timestamp" "timestamp without time zone"}
    change-log
    #(pos? (compare % "v49.00-000"))))
 
-(s/def ::no-datetime-type (or-error-conformer no-datetime-type?))
-
 (s/def ::changeSet
   (s/spec :change-set.strict/change-set))
 
-(s/def ::databaseChangeLog
-  (s/and (s/nonconforming
-          (s/+ (s/alt :property              (s/keys :req-un [::property])
-                      :objectQuotingStrategy (s/keys :req-un [::objectQuotingStrategy])
-                      :changeSet             (s/keys :req-un [::changeSet]))))
-         ::distinct-change-set-ids
-         ::change-set-ids-in-order
-         ::no-bare-blob-or-text-types
-         ::no-bare-boolean-types
-         ::no-datetime-type))
+(defn- only-key [m]
+  (let [keys (keys m)]
+    (when-not (= 1 (count keys))
+      (throw (validation-error "Expected exactly one key." {:keys keys})))
+    (first keys)))
 
-(defn- collect-errors [result]
-  ;; there's probably a way prettier way to do this, but ... this works.
-  (let [collector (atom [])]
-    (walk/postwalk #(do
-                      (when (error? %)
-                        (swap! collector conj %))
-                      %)
-                   result)
-    @collector))
+(defn- validate-database-change-log! [change-log]
+  (require-distinct-change-set-ids! change-log)
+  (require-change-set-ids-in-order! change-log)
+  (require-no-bare-blob-or-text-types! change-log)
+  (require-no-bare-boolean-types! change-log)
+  (require-no-datetime-type! change-log)
+  (let [{:keys [changeSet]
+         :as all} (group-by only-key change-log)]
+    (when-not (set/subset? (set (keys all)) #{:property :objectQuotingStrategy :changeSet})
+      (throw (validation-error "Expected exactly one of :property, :objectQuotingStrategy, or :changeSet."
+                               {:keys (keys all)})))
+    (doseq [{:keys [changeSet]} changeSet
+            :when (not (s/valid? ::changeSet changeSet))]
+      (throw (validation-error "Invalid change set." (s/explain-data ::changeSet changeSet))))))
 
-(defn- validate-migrations [migrations]
-  (let [result (s/conform ::migrations migrations)
-        errors (collect-errors result)]
-    (cond
-      (seq errors)
-      (throw (ex-info "Validation error"
-                      {::errors errors}))
-
-      (= ::s/invalid result)
-      (let [data (s/explain-data ::migrations migrations)]
-        (throw (ex-info (format "Validation failed: %s"
-                                (with-out-str (pprint/pprint (mapv #(dissoc % :val)
-                                                                   (::s/problems data)))))
-                        (or (dissoc data ::s/value) {}))))))
+(defn- validate-migrations! [migrations]
+  (require-database-change-log! migrations)
+  (validate-database-change-log! (:databaseChangeLog migrations))
   :ok)
 
 (def ^:private filename
@@ -256,7 +169,7 @@
       (fix-vals (yaml/parse-string (slurp file))))))
 
 (defn- validate-all []
-  (validate-migrations (migrations)))
+  (validate-migrations! (migrations)))
 
 (defn -main
   "Entry point for Clojure CLI task `lint-migrations-file`. Run it with
@@ -268,14 +181,18 @@
     (validate-all)
     (println "Ok.")
     (System/exit 0)
-    (catch Throwable e
-      (if-let [errors (::errors (ex-data e))]
-        (doseq [error errors]
+    (catch ExceptionInfo e
+      (if (validation-error? e)
+        (do
           (println)
-          (printf "Error:\t%s\n" (:error/message error))
-          (printf "Details:\n\n %s" (with-out-str (pprint/pprint (:error/details error))))
+          (printf "Error:\t%s\n" (.getMessage e))
+          (printf "Details:\n\n %s" (with-out-str (pprint/pprint (dissoc (ex-data e) ::validation-error))))
           (println))
         (do
           (pprint/pprint (Throwable->map e))
           (println (.getMessage e))))
+      (System/exit 1))
+    (catch Throwable e
+      (pprint/pprint (Throwable->map e))
+      (println (.getMessage e))
       (System/exit 1))))

--- a/bin/lint-migrations-file/src/lint_migrations_file.clj
+++ b/bin/lint-migrations-file/src/lint_migrations_file.clj
@@ -5,7 +5,8 @@
    [clojure.java.io :as io]
    [clojure.pprint :as pprint]
    [clojure.spec.alpha :as s]
-   [clojure.string :as str]))
+   [clojure.string :as str]
+   [clojure.walk :as walk]))
 
 (set! *warn-on-reflection* true)
 
@@ -19,6 +20,82 @@
 (s/def ::migrations
   (s/keys :req-un [::databaseChangeLog]))
 
+;; ================================= Error handling =================================================================
+;; When specs completely fail, the output is really painful. Instead of failing specs, let's conform all our inputs to
+;; *either* the input (if valid) or an error (if it's not). This way we can print out the error message and details in
+;; a more readable way.
+
+;; An error looks like `{:error/message ...}`, optionally with an `:error/details` map.
+;;
+;; When writing validation specs in this namespace, you *can* use any normal spec, like `(s/def ::foo even?)`,
+;; but preferably you'll instead write a function that returns an error in the invalid case, and use it like
+;; ```
+;; (s/def ::foo
+;;  (or-error-conformer
+;;   (fn [i]
+;;    (when-not (even? i)
+;;     (error "`i` is not even." :number-i i)))))
+;; ```
+;; This way, when the spec fails, the user sees nice errors like
+(s/def :error/message string?)
+(s/def :error/details (s/map-of keyword? any?))
+(s/def ::error (s/keys :req [:error/message]
+                       :opt [:error/details]))
+
+(s/def :error/errors (s/coll-of ::error :kind vector? :min-count 1))
+;; the input, so we can continue checking
+(s/def :error/in any?)
+(s/def ::errors (s/keys :req [:error/errors
+                              :error/in]))
+
+(defn- add-error [errors error]
+  (update errors :errors conj error))
+
+(defn- new-errors [input error]
+  {:error/errors [error]
+   :error/in input})
+
+(defn- error?
+  [x]
+  (s/valid? ::error x))
+
+(defn- errors?
+  [xs]
+  (s/valid? ::errors xs))
+
+(defn- error
+  "Make a new error"
+  [message & details]
+  {:error/message message
+   :error/details (apply hash-map details)})
+
+(defn- or-error-conformer
+  "Takes a function `f` that returns either an `error` or an arbitrary value.
+
+  Returns a function that conforms the input to either:
+  - an `::errors` value, or
+  - the input itself."
+  [f]
+  (s/conformer
+   (fn [x]
+     ;; in the error case, we continue checking specs against the *original* input
+     (let [in (if (errors? x)
+                (:error/in x)
+                x)
+           out (f in)]
+       (cond
+         ;; if we found an error and we already have errors, add the error to the existing errors
+         (and (errors? x)
+              (error? out))
+         (add-error x out)
+
+         ;; if we found an error and we don't already have errors, make a new `::errors`
+         (error? out)
+         (new-errors in out)
+
+         ;; return the input (either `::errors` if we already had them or the value to check)
+         :else x)))))
+
 (defn- change-set-ids
   "Returns all the change set ids given a change-log."
   [change-log]
@@ -26,14 +103,30 @@
         :when id]
     id))
 
-(defn- distinct-change-set-ids? [change-log]
-  (let [ids (change-set-ids change-log)]
-    ;; can't apply distinct? with so many IDs
-    (= (count ids) (count (set ids)))))
+(s/def ::distinct-change-set-ids
+  (or-error-conformer
+   (fn [change-log]
+     (let [ids (change-set-ids change-log)
+           ;; can't apply distinct? with so many IDs
+           duplicates (->> ids
+                           (group-by identity)
+                           (keep (fn [[k v]]
+                                   (when (< 1 (count v))
+                                     k))))]
+       (when (seq duplicates)
+         (error "Change set IDs are not distinct." :duplicates duplicates))))))
 
-(defn- change-set-ids-in-order? [change-log]
-  (let [ids (change-set-ids change-log)]
-    (= ids (sort-by identity compare ids))))
+(s/def ::change-set-ids-in-order
+  (or-error-conformer
+   (fn [change-log]
+     (when-let [out-of-order-ids (->> change-log
+                                      (change-set-ids)
+                                      (partition 2 1)
+                                      (filter (fn [[id1 id2]]
+                                                (pos? (compare id1 id2))))
+                                      seq)]
+       (error "Change set IDs are not in order"
+              :out-of-order-ids out-of-order-ids)))))
 
 (defn- check-change-use-types?
   "Return `true` if change use any type in `types`."
@@ -67,26 +160,36 @@
    (assert-no-types-in-change-log target-types change-log (constantly true)))
   ([target-types change-log id-filter-fn]
    {:pre [(set? target-types)]}
-   (->> change-log
-        (filter (fn [change-set]
-                  (let [id (get-in change-set [:changeSet :id])]
-                    (and (string? id)
-                         (id-filter-fn id)))))
-        (some #(check-change-set-use-types? target-types %))
-        not)))
+   (when-let [using-types? (->> change-log
+                                (filter (fn [change-set]
+                                          (let [id (get-in change-set [:changeSet :id])]
+                                            (and (string? id)
+                                                 (id-filter-fn id)))))
+                                (filter #(check-change-set-use-types? target-types %))
+                                (map #(get-in % [:changeSet :id]))
+                                seq)]
+     (error (format "Migration(s) [%s] uses invalid types (in %s)"
+                    (str/join "," (map #(str "'" % "'") using-types?))
+                    (str/join "," (map #(str "'" % "'") target-types)))
+            :invalid-ids using-types?
+            :target-types target-types))))
 
 (defn no-bare-blob-or-text-types?
-  "Ensures that no \"text\" or \"blob\" type columns are added in changesets with id later than 320 (i.e. version
-  0.42.0).  From that point on, \"${text.type}\" should be used instead, so that MySQL can handle it correctly (by using
-  `LONGTEXT`).  And similarly, from an earlier point, \"${blob.type}\" should be used instead of \"blob\"."
+  "Ensures that no \"text\" or \"blob\" type columns are added in any changesets."
   [change-log]
   (assert-no-types-in-change-log #{"blob" "text"} change-log))
+
+(s/def ::no-bare-blob-or-text-types
+  (or-error-conformer
+   no-bare-blob-or-text-types?))
 
 (defn no-bare-boolean-types?
   "Ensures that no \"boolean\" type columns are added in changesets with id later than v49.00-032. From that point on,
   \"${boolean.type}\" should be used instead, so that we can consistently use `BIT(1)` for Boolean columns on MySQL."
   [change-log]
   (assert-no-types-in-change-log #{"boolean"} change-log #(pos? (compare % "v49.00-032"))))
+
+(s/def ::no-bare-boolean-types (or-error-conformer no-bare-boolean-types?))
 
 (defn no-datetime-type?
   "Ensures that no \"datetime\" or \"timestamp without time zone\".
@@ -97,25 +200,46 @@
    change-log
    #(pos? (compare % "v49.00-000"))))
 
+(s/def ::no-datetime-type (or-error-conformer no-datetime-type?))
+
 (s/def ::changeSet
   (s/spec :change-set.strict/change-set))
 
 (s/def ::databaseChangeLog
-  (s/and distinct-change-set-ids?
-         change-set-ids-in-order?
-         no-bare-blob-or-text-types?
-         no-bare-boolean-types?
-         no-datetime-type?
-         (s/+ (s/alt :property              (s/keys :req-un [::property])
-                     :objectQuotingStrategy (s/keys :req-un [::objectQuotingStrategy])
-                     :changeSet             (s/keys :req-un [::changeSet])))))
+  (s/and (s/nonconforming
+          (s/+ (s/alt :property              (s/keys :req-un [::property])
+                      :objectQuotingStrategy (s/keys :req-un [::objectQuotingStrategy])
+                      :changeSet             (s/keys :req-un [::changeSet]))))
+         ::distinct-change-set-ids
+         ::change-set-ids-in-order
+         ::no-bare-blob-or-text-types
+         ::no-bare-boolean-types
+         ::no-datetime-type))
+
+(defn- collect-errors [result]
+  ;; there's probably a way prettier way to do this, but ... this works.
+  (let [collector (atom [])]
+    (walk/postwalk #(do
+                      (when (error? %)
+                        (swap! collector conj %))
+                      %)
+                   result)
+    @collector))
 
 (defn- validate-migrations [migrations]
-  (when (= (s/conform ::migrations migrations) ::s/invalid)
-    (let [data (s/explain-data ::migrations migrations)]
-      (throw (ex-info (str "Validation failed:\n" (with-out-str (pprint/pprint (mapv #(dissoc % :val)
-                                                                                     (::s/problems data)))))
-                      (or (dissoc data ::s/value) {})))))
+  (let [result (s/conform ::migrations migrations)
+        errors (collect-errors result)]
+    (cond
+      (seq errors)
+      (throw (ex-info "Validation error"
+                      {::errors errors}))
+
+      (= ::s/invalid result)
+      (let [data (s/explain-data ::migrations migrations)]
+        (throw (ex-info (format "Validation failed: %s"
+                                (with-out-str (pprint/pprint (mapv #(dissoc % :val)
+                                                                   (::s/problems data)))))
+                        (or (dissoc data ::s/value) {}))))))
   :ok)
 
 (def ^:private filename
@@ -145,6 +269,13 @@
     (println "Ok.")
     (System/exit 0)
     (catch Throwable e
-      (pprint/pprint (Throwable->map e))
-      (println (.getMessage e))
+      (if-let [errors (::errors (ex-data e))]
+        (doseq [error errors]
+          (println)
+          (printf "Error:\t%s\n" (:error/message error))
+          (printf "Details:\n\n %s" (with-out-str (pprint/pprint (:error/details error))))
+          (println))
+        (do
+          (pprint/pprint (Throwable->map e))
+          (println (.getMessage e))))
       (System/exit 1))))

--- a/bin/lint-migrations-file/src/lint_migrations_file.clj
+++ b/bin/lint-migrations-file/src/lint_migrations_file.clj
@@ -103,8 +103,8 @@
              (format "Migration(s) [%s] uses invalid types (in %s)"
                      (str/join "," (map #(str "'" % "'") using-types?))
                      (str/join "," (map #(str "'" % "'") target-types)))
-              {:invalid-ids using-types?
-               :target-types target-types})))))
+             {:invalid-ids using-types?
+              :target-types target-types})))))
 
 (defn require-no-bare-blob-or-text-types!
   "Ensures that no \"text\" or \"blob\" type columns are added in any changesets."

--- a/bin/lint-migrations-file/src/lint_migrations_file.clj
+++ b/bin/lint-migrations-file/src/lint_migrations_file.clj
@@ -38,7 +38,7 @@
         :when id]
     id))
 
-(defn- require-distinct-change-set-ids! [change-log]
+(defn- require-distinct-change-set-ids [change-log]
   (let [ids (change-set-ids change-log)
         duplicates (->> ids
                         (group-by identity)
@@ -48,7 +48,7 @@
     (when (seq duplicates)
       (throw (validation-error "Change set IDs are not distinct." {:duplicates duplicates})))))
 
-(defn- require-change-set-ids-in-order! [change-log]
+(defn- require-change-set-ids-in-order [change-log]
   (let [ids (change-set-ids change-log)
         out-of-order-ids (->> ids
                              (partition 2 1)
@@ -106,18 +106,18 @@
              {:invalid-ids using-types?
               :target-types target-types})))))
 
-(defn require-no-bare-blob-or-text-types!
+(defn require-no-bare-blob-or-text-types
   "Ensures that no \"text\" or \"blob\" type columns are added in any changesets."
   [change-log]
   (require-no-types-in-change-log! #{"blob" "text"} change-log))
 
-(defn require-no-bare-boolean-types!
+(defn require-no-bare-boolean-types
   "Ensures that no \"boolean\" type columns are added in changesets with id later than v49.00-032. From that point on,
   \"${boolean.type}\" should be used instead, so that we can consistently use `BIT(1)` for Boolean columns on MySQL."
   [change-log]
   (require-no-types-in-change-log! #{"boolean"} change-log #(pos? (compare % "v49.00-032"))))
 
-(defn require-no-datetime-type!
+(defn require-no-datetime-type
   "Ensures that no \"datetime\" or \"timestamp without time zone\".
   From that point on, \"${timestamp_type}\" should be used instead, so that all of our time related columsn are tz-aware."
   [change-log]
@@ -135,12 +135,12 @@
       (throw (validation-error "Expected exactly one key." {:keys keys})))
     (first keys)))
 
-(defn- validate-database-change-log! [change-log]
-  (require-distinct-change-set-ids! change-log)
-  (require-change-set-ids-in-order! change-log)
-  (require-no-bare-blob-or-text-types! change-log)
-  (require-no-bare-boolean-types! change-log)
-  (require-no-datetime-type! change-log)
+(defn- validate-database-change-log [change-log]
+  (require-distinct-change-set-ids change-log)
+  (require-change-set-ids-in-order change-log)
+  (require-no-bare-blob-or-text-types change-log)
+  (require-no-bare-boolean-types change-log)
+  (require-no-datetime-type change-log)
   (let [{:keys [changeSet]
          :as all} (group-by only-key change-log)]
     (when-not (set/subset? (set (keys all)) #{:property :objectQuotingStrategy :changeSet})
@@ -150,9 +150,9 @@
             :when (not (s/valid? ::changeSet changeSet))]
       (throw (validation-error "Invalid change set." (s/explain-data ::changeSet changeSet))))))
 
-(defn- validate-migrations! [migrations]
+(defn- validate-migrations [migrations]
   (require-database-change-log! migrations)
-  (validate-database-change-log! (:databaseChangeLog migrations))
+  (validate-database-change-log (:databaseChangeLog migrations))
   :ok)
 
 (def ^:private filename
@@ -169,7 +169,7 @@
       (fix-vals (yaml/parse-string (slurp file))))))
 
 (defn- validate-all []
-  (validate-migrations! (migrations)))
+  (validate-migrations (migrations)))
 
 (defn -main
   "Entry point for Clojure CLI task `lint-migrations-file`. Run it with

--- a/bin/lint-migrations-file/test/lint_migrations_file_test.clj
+++ b/bin/lint-migrations-file/test/lint_migrations_file_test.clj
@@ -345,7 +345,7 @@
                                   :changes [{:modifyDataType {:newDataType "datetime"}}]
                                   :rollback nil)))
 
-    (testing "but not if it's an older migration)"
+    (testing "(but not if it's an older migration)"
       (is (validate! (mock-change-set :id "v45.12-345"
                                       :changes [{:createTable {:tableName "my_table"
                                                                :remarks "meow"

--- a/bin/lint-migrations-file/test/lint_migrations_file_test.clj
+++ b/bin/lint-migrations-file/test/lint_migrations_file_test.clj
@@ -252,6 +252,35 @@
   (testing "change types with automatic rollback support are allowed"
     (is (= :ok (validate! (mock-change-set :id "v49.2024-01-01T10:30:00" :changes [(mock-add-column-changes)]))))))
 
+(deftest require-precondition-test
+  (testing "certain change types require preConditions"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"Invalid change set\."
+         (validate! (mock-change-set
+                     :id "v51.2024-01-01T10:30:00"
+                     :changes [(mock-create-table-changes)])))))
+
+  (testing "other change types are exempt"
+    (is (= :ok
+           (validate!
+            (mock-change-set
+             :changes
+             [{:sql {:dbms "h2", :sql "1"}}])))))
+
+  (testing "nil preConditions is allowed"
+    (is (= :ok
+           (validate! (mock-change-set
+                       :id "v51.2024-01-01T10:30:00"
+                       :changes [(mock-create-table-changes)]
+                       :preConditions nil)))))
+
+  (testing "changeSets prior to v51 are exempt"
+    (is (= :ok
+           (validate! (mock-change-set
+                       :id "v50.2024-01-01T10:30:00"
+                       :changes [(mock-create-table-changes)]))))))
+
 (deftest disallow-deletecascade-in-addcolumn-test
   (testing "addColumn with deleteCascade fails"
     (is (thrown-with-msg?

--- a/bin/lint-migrations-file/test/lint_migrations_file_test.clj
+++ b/bin/lint-migrations-file/test/lint_migrations_file_test.clj
@@ -30,12 +30,12 @@
                         :remarks   "Wow"}
                        (apply array-map keyvals))})
 
-(defn- validate! [& changes]
-  (#'lint-migrations-file/validate-migrations!
+(defn- validate [& changes]
+  (#'lint-migrations-file/validate-migrations
    {:databaseChangeLog changes}))
 
-(defn- validate-ex-info! [& changes]
-  (try (#'lint-migrations-file/validate-migrations! {:databaseChangeLog changes})
+(defn- validate-ex-info [& changes]
+  (try (#'lint-migrations-file/validate-migrations {:databaseChangeLog changes})
        (catch Exception e (ex-data e))))
 
 (defmacro is-thrown-with-error-info? [msg info & body]
@@ -62,41 +62,41 @@
 (deftest require-unique-ids-test
   (testing "Make sure all migration IDs are unique"
     (is-thrown-with-error-info?
-        "Change set IDs are not distinct."
-        {:duplicates ["v49.2024-01-01T10:30:00"]}
-      (validate!
-       (mock-change-set :id "v49.2024-01-01T10:30:00")
-       (mock-change-set :id "v49.2024-01-01T10:30:00")))))
+     "Change set IDs are not distinct."
+     {:duplicates ["v49.2024-01-01T10:30:00"]}
+     (validate
+      (mock-change-set :id "v49.2024-01-01T10:30:00")
+      (mock-change-set :id "v49.2024-01-01T10:30:00")))))
 
 (deftest require-migrations-in-order-test
   (testing "Migrations must be in order"
     (is-thrown-with-error-info?
-        "Change set IDs are not in order"
-        {:out-of-order-ids [["v45.00-002" "v45.00-001"]]}
-      (validate!
-       (mock-change-set :id "v45.00-002")
-       (mock-change-set :id "v45.00-001")))
+     "Change set IDs are not in order"
+     {:out-of-order-ids [["v45.00-002" "v45.00-001"]]}
+     (validate
+      (mock-change-set :id "v45.00-002")
+      (mock-change-set :id "v45.00-001")))
 
     (is-thrown-with-error-info?
-        "Change set IDs are not in order"
-        {:out-of-order-ids [["v49.2023-12-14T08:54:54"
-                             "v49.2023-12-14T08:54:53"]]}
-      (validate!
-       (mock-change-set :id "v49.2023-12-14T08:54:54")
-       (mock-change-set :id "v49.2023-12-14T08:54:53")))))
+     "Change set IDs are not in order"
+     {:out-of-order-ids [["v49.2023-12-14T08:54:54"
+                          "v49.2023-12-14T08:54:53"]]}
+     (validate
+      (mock-change-set :id "v49.2023-12-14T08:54:54")
+      (mock-change-set :id "v49.2023-12-14T08:54:53")))))
 
 (deftest only-one-column-per-add-column-test
   (testing "we should only allow one column per addColumn change"
     (doseq [id [1 200]]
       (is (= :ok
-             (validate!
+             (validate
               (mock-change-set
                :id (format "v45.00-%03d" id)
                :changes [(mock-add-column-changes)]))))
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo
            #"Invalid change set\."
-           (validate!
+           (validate
             (mock-change-set
              :id id
              :changes [(mock-add-column-changes :columns [(mock-column :name "A")
@@ -107,7 +107,7 @@
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo
          #"Invalid change set\."
-         (validate!
+         (validate
           (mock-change-set :changes [(mock-add-column-changes) (mock-add-column-changes)]))))))
 
 (deftest require-comment-test
@@ -115,9 +115,9 @@
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo
          #"Invalid change set\."
-         (validate! (update (mock-change-set) :changeSet dissoc :comment))))
+         (validate (update (mock-change-set) :changeSet dissoc :comment))))
     (is (= :ok
-           (validate! (mock-change-set :id "v49.2024-01-01T10:30:00", :comment "Added x.45.0"))))))
+           (validate (mock-change-set :id "v49.2024-01-01T10:30:00", :comment "Added x.45.0"))))))
 
 (deftest no-on-delete-in-constraints-test
   (testing "Make sure we don't use onDelete in constraints"
@@ -134,14 +134,14 @@
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
              #"Invalid change set\."
-             (validate! change-set)))))))
+             (validate change-set)))))))
 
 (deftest require-remarks-for-create-table-test
   (testing "require remarks for newly created tables"
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo
          #"Invalid change set\."
-         (validate!
+         (validate
           (mock-change-set
            :id 200
            :changes [(update (mock-create-table-changes) :createTable dissoc :remarks)]))))))
@@ -149,7 +149,7 @@
 (deftest allow-multiple-sql-changes-if-dbmses-are-different
   (testing "Allow multiple SQL changes if DBMSes are different"
     (is (= :ok
-           (validate!
+           (validate
             (mock-change-set
              :changes
              [{:sql {:dbms "h2", :sql "1"}}
@@ -160,7 +160,7 @@
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo
          #"Invalid change set\."
-         (validate!
+         (validate
           (mock-change-set
            :changes
            [{:sql {:dbms "h2", :sql "1"}}
@@ -170,7 +170,7 @@
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo
          #"Invalid change set\."
-         (validate!
+         (validate
           (mock-change-set
            :changes
            [{:sql {:dbms "h2", :sql "1"}}
@@ -178,7 +178,7 @@
 
 (deftest validate-id-test
   (letfn [(validate-id [id]
-            (validate! (mock-change-set :id id)))]
+            (validate (mock-change-set :id id)))]
     (testing "Valid old-style ID"
       (is (= :ok
              (validate-id "v42.00-000"))))
@@ -202,36 +202,36 @@
 (deftest prevent-text-types-test
   (testing "should allow \"${text.type}\" columns from being added"
     (is (= :ok
-           (validate!
+           (validate
             (mock-change-set
              :id "v49.2024-01-01T10:30:00"
              :changes [(mock-add-column-changes :columns [(mock-column :type "${text.type}")])]))))
     (doseq [problem-type ["blob" "text"]]
       (testing (format "should prevent \"%s\" columns from being added after ID 320" problem-type)
         (is-thrown-with-error-info?
-            "Migration(s) ['v49.2024-01-01T10:30:00'] uses invalid types (in 'blob','text')"
-            {:invalid-ids ["v49.2024-01-01T10:30:00"]
-             :target-types #{"blob" "text"}}
-          (validate!
-           (mock-change-set
-            :id "v49.2024-01-01T10:30:00"
-            :changes [(mock-add-column-changes :columns [(mock-column :type problem-type)])])))))))
+         "Migration(s) ['v49.2024-01-01T10:30:00'] uses invalid types (in 'blob','text')"
+         {:invalid-ids ["v49.2024-01-01T10:30:00"]
+          :target-types #{"blob" "text"}}
+         (validate
+          (mock-change-set
+           :id "v49.2024-01-01T10:30:00"
+           :changes [(mock-add-column-changes :columns [(mock-column :type problem-type)])])))))))
 
 (deftest prevent-bare-boolean-type-test
   (testing "should allow adding \"${boolean.type}\" columns"
     (is (= :ok
-           (validate!
+           (validate
             (mock-change-set
              :id "v49.00-033"
              :changes [(mock-add-column-changes :columns [(mock-column :type "${boolean.type}")])]))))
     (testing "should prevent \"boolean\" columns from being added after ID v49.00-033"
       (is-thrown-with-error-info?
-          "Migration(s) ['v49.00-033'] uses invalid types (in 'boolean')"
-          {:invalid-ids ["v49.00-033"]
-           :target-types #{"boolean"}}
-        (validate! (mock-change-set
-                    :id "v49.00-033"
-                    :changes [(mock-add-column-changes :columns [(mock-column :type "boolean")])]))))))
+       "Migration(s) ['v49.00-033'] uses invalid types (in 'boolean')"
+       {:invalid-ids ["v49.00-033"]
+        :target-types #{"boolean"}}
+       (validate (mock-change-set
+                  :id "v49.00-033"
+                  :changes [(mock-add-column-changes :columns [(mock-column :type "boolean")])]))))))
 
 (deftest require-rollback-test
   (testing "change types with no automatic rollback support"
@@ -239,75 +239,75 @@
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo
            #"Invalid change set\."
-           (validate! (update (mock-change-set :id "v49.2024-01-01T10:30:00" :changes [{:sql {:sql "select 1"}}])
-                              :changeSet dissoc :rollback)))))
+           (validate (update (mock-change-set :id "v49.2024-01-01T10:30:00" :changes [{:sql {:sql "select 1"}}])
+                             :changeSet dissoc :rollback)))))
     (testing "nil rollback is allowed"
-      (is (= :ok (validate! (mock-change-set :id "v49.2024-01-01T10:30:00"
-                                             :changes [{:sql {:sql "select 1"}}]
-                                             :rollback nil)))))
+      (is (= :ok (validate (mock-change-set :id "v49.2024-01-01T10:30:00"
+                                            :changes [{:sql {:sql "select 1"}}]
+                                            :rollback nil)))))
     (testing "rollback values are allowed"
-      (is (= :ok (validate! (mock-change-set :id "v49.2024-01-01T10:30:00"
-                                             :changes [{:sql {:sql "select 1"}}]
-                                             :rollback {:sql {:sql "select 1"}}))))))
+      (is (= :ok (validate (mock-change-set :id "v49.2024-01-01T10:30:00"
+                                            :changes [{:sql {:sql "select 1"}}]
+                                            :rollback {:sql {:sql "select 1"}}))))))
   (testing "change types with automatic rollback support are allowed"
-    (is (= :ok (validate! (mock-change-set :id "v49.2024-01-01T10:30:00" :changes [(mock-add-column-changes)]))))))
+    (is (= :ok (validate (mock-change-set :id "v49.2024-01-01T10:30:00" :changes [(mock-add-column-changes)]))))))
 
 (deftest require-precondition-test
   (testing "certain change types require preConditions"
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo
          #"Invalid change set\."
-         (validate! (mock-change-set
-                     :id "v51.2024-01-01T10:30:00"
-                     :changes [(mock-create-table-changes)])))))
+         (validate (mock-change-set
+                    :id "v51.2024-01-01T10:30:00"
+                    :changes [(mock-create-table-changes)])))))
 
   (testing "other change types are exempt"
     (is (= :ok
-           (validate!
+           (validate
             (mock-change-set
              :changes
              [{:sql {:dbms "h2", :sql "1"}}])))))
 
   (testing "nil preConditions is allowed"
     (is (= :ok
-           (validate! (mock-change-set
-                       :id "v51.2024-01-01T10:30:00"
-                       :changes [(mock-create-table-changes)]
-                       :preConditions nil)))))
+           (validate (mock-change-set
+                      :id "v51.2024-01-01T10:30:00"
+                      :changes [(mock-create-table-changes)]
+                      :preConditions nil)))))
 
   (testing "changeSets prior to v51 are exempt"
     (is (= :ok
-           (validate! (mock-change-set
-                       :id "v50.2024-01-01T10:30:00"
-                       :changes [(mock-create-table-changes)]))))))
+           (validate (mock-change-set
+                      :id "v50.2024-01-01T10:30:00"
+                      :changes [(mock-create-table-changes)]))))))
 
 (deftest disallow-deletecascade-in-addcolumn-test
   (testing "addColumn with deleteCascade fails"
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo
          #"Invalid change set."
-         (validate! (mock-change-set :id "v49.2024-01-01T10:30:00"
-                                     :changes [(mock-add-column-changes
-                                                :columns [(mock-column :constraints {:deleteCascade true})])]))))))
+         (validate (mock-change-set :id "v49.2024-01-01T10:30:00"
+                                    :changes [(mock-add-column-changes
+                                               :columns [(mock-column :constraints {:deleteCascade true})])]))))))
 
 (deftest custom-changes-test
   (let [change-set (mock-change-set
                     :changes
                     [{:customChange {:class "metabase.db.custom_migrations.ReversibleUppercaseCards"}}])]
     (is (= :ok
-           (validate! change-set))))
+           (validate change-set))))
   (testing "missing value"
     (let [change-set (mock-change-set
                       :changes
                       [{:customChange {}}])
-          ex-info    (validate-ex-info! change-set)]
+          ex-info    (validate-ex-info change-set)]
       (is (not= :ok ex-info))))
   (testing "invalid values"
     (doseq [bad-value [nil 3 ""]]
       (let [change-set (mock-change-set
                         :changes
                         [{:customChange {:class bad-value}}])
-            ex-info    (validate-ex-info! change-set)
+            ex-info    (validate-ex-info change-set)
             specific   (->> ex-info
                             ::s/problems
                             (some (fn [problem]
@@ -320,65 +320,65 @@
 (deftest forbidden-new-types-test
   (testing "should throw if changes contains text type"
     (is (is-thrown-with-error-info?
-            "Migration(s) ['v45.12-345'] uses invalid types (in 'blob','text')"
-            {:invalid-ids ["v45.12-345"]
-             :target-types #{"blob" "text"}}
-          (validate! (mock-change-set :id "v45.12-345"
-                                      :changes [{:modifyDataType {:newDataType "text"}}]
-                                      :rollback nil))))
+         "Migration(s) ['v45.12-345'] uses invalid types (in 'blob','text')"
+         {:invalid-ids ["v45.12-345"]
+          :target-types #{"blob" "text"}}
+         (validate (mock-change-set :id "v45.12-345"
+                                    :changes [{:modifyDataType {:newDataType "text"}}]
+                                    :rollback nil))))
     (is-thrown-with-error-info?
-        "Migration(s) ['v45.12-345'] uses invalid types (in 'blob','text')"
-        {:invalid-ids ["v45.12-345"]
-         :target-types #{"blob" "text"}}
-      (validate! (mock-change-set :id "v45.12-345"
-                                  :changes [{:createTable {:tableName "my_table"
-                                                           :remarks "meow"
-                                                           :columns [{:column {:name "foo"
-                                                                               :remarks "none"
-                                                                               :type "text"}}]}}]
-                                  :rollback nil))))
+     "Migration(s) ['v45.12-345'] uses invalid types (in 'blob','text')"
+     {:invalid-ids ["v45.12-345"]
+      :target-types #{"blob" "text"}}
+     (validate (mock-change-set :id "v45.12-345"
+                                :changes [{:createTable {:tableName "my_table"
+                                                         :remarks "meow"
+                                                         :columns [{:column {:name "foo"
+                                                                             :remarks "none"
+                                                                             :type "text"}}]}}]
+                                :rollback nil))))
 
   (testing "should throw if changes contains boolean type"
     (is-thrown-with-error-info?
-        "Migration(s) ['v49.00-033'] uses invalid types (in 'boolean')"
-        {:invalid-ids ["v49.00-033"]
-         :target-types #{"boolean"}}
-      (validate! (mock-change-set :id "v49.00-033"
-                                  :changes [{:modifyDataType {:newDataType "boolean"}}]
-                                  :rollback nil)))
+     "Migration(s) ['v49.00-033'] uses invalid types (in 'boolean')"
+     {:invalid-ids ["v49.00-033"]
+      :target-types #{"boolean"}}
+     (validate (mock-change-set :id "v49.00-033"
+                                :changes [{:modifyDataType {:newDataType "boolean"}}]
+                                :rollback nil)))
 
     (is-thrown-with-error-info?
-        "Migration(s) ['v49.00-033'] uses invalid types (in 'boolean')"
-        {:invalid-ids ["v49.00-033"]
-         :target-types #{"boolean"}}
-      (validate! (mock-change-set :id "v49.00-033"
-                                  :changes [{:createTable {:tableName "my_table"
-                                                           :remarks "meow"
-                                                           :columns [{:column {:name "foo"
-                                                                               :remarks "none"
-                                                                               :type "boolean"}}]}}])))
+     "Migration(s) ['v49.00-033'] uses invalid types (in 'boolean')"
+     {:invalid-ids ["v49.00-033"]
+      :target-types #{"boolean"}}
+     (validate (mock-change-set :id "v49.00-033"
+                                :changes [{:createTable {:tableName "my_table"
+                                                         :remarks "meow"
+                                                         :columns [{:column {:name "foo"
+                                                                             :remarks "none"
+                                                                             :type "boolean"}}]}}])))
     (testing "does not throw for older migrations"
-      (is (validate! (mock-change-set :id "v45.00-033"
-                                      :changes [{:createTable {:tableName "my_table"
-                                                               :remarks "meow"
-                                                               :columns [{:column {:name "foo"
-                                                                                   :remarks "none"
-                                                                                   :type "boolean"}}]}}])))))
+      (is (validate (mock-change-set :id "v45.00-033"
+                                     :changes [{:createTable {:tableName "my_table"
+                                                              :remarks "meow"
+                                                              :columns [{:column {:name "foo"
+                                                                                  :remarks "none"
+                                                                                  :type "boolean"}}]}}])))))
 
   (testing "should throw if changes contains datetime type"
     (is-thrown-with-error-info?
-        "Migration(s) ['v49.00-033'] uses invalid types (in 'timestamp','timestamp without time zone','datetime')"
-        {:invalid-ids ["v49.00-033"]
-         :target-types #{"timestamp" "timestamp without time zone" "datetime"}}
-      (validate! (mock-change-set :id "v49.00-033"
-                                  :changes [{:modifyDataType {:newDataType "datetime"}}]
-                                  :rollback nil)))
+     "Migration(s) ['v49.00-033'] uses invalid types (in 'timestamp','timestamp without time zone','datetime')"
+     {:invalid-ids ["v49.00-033"]
+      :target-types #{"timestamp" "timestamp without time zone" "datetime"}}
+     (validate (mock-change-set :id "v49.00-033"
+                                :changes [{:modifyDataType {:newDataType "datetime"}}]
+                                :rollback nil)))
 
     (testing "(but not if it's an older migration)"
-      (is (validate! (mock-change-set :id "v45.12-345"
-                                      :changes [{:createTable {:tableName "my_table"
-                                                               :remarks "meow"
-                                                               :columns [{:column {:name "foo"
-                                                                                   :remarks "none"
-                                                                                   :type "timestamp with time zone"}}]}}]
-                                      :rollback nil))))))
+      (is (validate (mock-change-set :id "v45.12-345"
+                                     :changes [{:createTable {:tableName "my_table"
+                                                              :remarks "meow"
+                                                              :columns [{:column {:name "foo"
+                                                                                  :remarks "none"
+                                                                                  :type "timestamp with time zone"}}]}}]
+                                     :rollback nil))))))

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -8206,6 +8206,7 @@ databaseChangeLog:
                   defaultValue: "view"
                   constraints:
                     nullable: false
+      preConditions:
 
   - changeSet:
       id: v51.2024-06-07T12:37:36
@@ -8235,6 +8236,7 @@ databaseChangeLog:
                   name: session_id
               - column:
                   name: device_id
+      preConditions:
 
   - changeSet:
       id: v51.2024-06-12T18:53:03
@@ -8253,6 +8255,7 @@ databaseChangeLog:
         - dropIndex:
             tableName: login_history
             indexName: idx_user_id_device_id
+      preConditions:
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -8181,6 +8181,7 @@ databaseChangeLog:
                   name: dataset_query_metrics_v2_migration_backup
                   remarks: The copy of dataset_query before the metrics v2 migration
                   type: ${text.type}
+      preConditions:
 
   - changeSet:
       id: v51.2024-05-13T16:00:00


### PR DESCRIPTION
When linting migrations, I found the output incredibly difficult to parse. It's difficult to even find the failing predicate, and if you've added a lot of migrations, it's difficult to find the one that failed.

~I've changed the migration linter a bit. Essentially, while you can use ordinary predicates and specs, you can also define a spec using `or-error-conformer`. It's used like this:~

```
(s/def ::my-spec
 (or-error-conformer
  (fn [value]
   (when (invalid-value? value)
    (error "Error message" :arbitrary "data" :goes "here")))))
```

~~In the failure case here, we aren't saying the item is invalid - we're just conforming it to a special `::errors` spec.~~

~~Then, when we check the validity of the migrations, we use `s/conform`. Then, we check to see whether the resulting conformed value has any errors, and if there were, print them nicely before exiting with an error code.~~

~~Of course, we also check whether the result of `s/conform` was `::s/invalid`, and the output is the same as before in that case.~~

**Edit: I decided not to do the approach described above.**  Instead...

In general, just throw exceptions instead of using clojure spec here.

You'll only get one error per run, but that seems fine.

I did keep some specs around, but run them slightly differently. Rather
than validating the whole collection of changeSets at once with `s/+`,
just `doseq` through the changeSets and validate each one separately.

That way, the value that's presented as erroneous is much smaller (a
single changeSet) and it's easier to see what went wrong.

The result: when you run `./bin/lint-migrations-file.sh`, you get output like

```
jds@arc metabase % ./bin/lint-migrations-file.sh
Clearing outdated .cpcache directories if needed...
.cpcache directories are up to date.
Check Liquibase migrations file...

Error:	Change set IDs are not distinct.
Details:

 {:duplicates ("v49.2024-05-20T20:37:55")}
```

rather than the previous huge blob of EDN.