### PR TITLE
Move around audit content to make perm checks more consistent + general cleanup

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -136,7 +136,7 @@
    ;;    namespace(s). This is mostly a temporary placeholder until we go in and create module namespaces, which means
    ;;    you should go create one.
    ;;
-   ;; 2. A set of namespace symbols. All namespaces in other modules will only be allowed ;; to use namespaces from
+   ;; 2. A set of namespace symbols. All namespaces in other modules will only be allowed to use namespaces from
    ;;    this set. Ideally this set should only have one namespace, but restricting it to a set of several is still
    ;;    better than `:any`.
    ;;
@@ -159,6 +159,7 @@
     metabase.async                 #{metabase.async.streaming-response
                                      metabase.async.streaming-response.thread-pool
                                      metabase.async.util}                                           ; TODO -- consolidate these into a real API namespace.
+    metabase.audit                 #{metabase.audit}
     metabase.bootstrap             #{metabase.bootstrap}
     metabase.cmd                   #{}                                                              ; there are no namespaces here since you shouldn't be using this in any other module.
     metabase.config                #{metabase.config}
@@ -260,6 +261,7 @@
     metabase.analyze               :any
     metabase.api                   :any
     metabase.async                 :any
+    metabase.audit                 :any
     metabase.bootstrap             #{}
     metabase.cmd                   :any
     metabase.compatibility         :any
@@ -851,11 +853,11 @@
     :metabase/defsetting-must-specify-export {:level :off}
     :discouraged-var                         {metabase.driver/database-supports? {:level :off}}}
 
-  :hooks
-  {:analyze-call
-   {clojure.core/defmacro hooks.clojure.core/non-thread-safe-form-should-end-with-exclamation
-    clojure.core/defn     hooks.clojure.core/non-thread-safe-form-should-end-with-exclamation
-    clojure.core/defn-    hooks.clojure.core/non-thread-safe-form-should-end-with-exclamation}}}
+   :hooks
+   {:analyze-call
+    {clojure.core/defmacro hooks.clojure.core/non-thread-safe-form-should-end-with-exclamation
+     clojure.core/defn     hooks.clojure.core/non-thread-safe-form-should-end-with-exclamation
+     clojure.core/defn-    hooks.clojure.core/non-thread-safe-form-should-end-with-exclamation}}}
 
   source-namespaces
   {:linters

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/connection_impersonation.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/connection_impersonation.clj
@@ -3,7 +3,7 @@
   certain permission groups when running queries."
   (:require
    [medley.core :as m]
-   [metabase.config :as config]
+   [metabase.audit :as audit]
    [metabase.models.interface :as mi]
    [metabase.public-settings.premium-features :refer [defenterprise]]
    [metabase.util.log :as log]
@@ -28,7 +28,7 @@
                                    {:where [:and
                                             (when db-id [:= :db_id db-id])
                                             (when group-id [:= :group_id group-id])
-                                            (when-not audit-db? [:not [:= :db_id config/audit-db-id]])]})]
+                                            (when-not audit-db? [:not [:= :db_id audit/audit-db-id]])]})]
      (reduce (fn [acc {:keys [db_id group_id]}]
                 (assoc-in acc [group_id db_id :view-data] :impersonated))
              {}

--- a/enterprise/backend/src/metabase_enterprise/audit_app/api/user.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/api/user.clj
@@ -2,9 +2,10 @@
   "`/api/ee/audit-app/user` endpoints. These only work if you have a premium token with the `:audit-app` feature."
   (:require
    [compojure.core :refer [DELETE GET]]
-   [metabase-enterprise.audit-db :as audit-db]
+   [metabase-enterprise.audit-app.audit :as ee-audit]
    [metabase.api.common :as api]
    [metabase.api.user :as api.user]
+   [metabase.audit :as audit]
    [metabase.models.interface :as mi]
    [metabase.models.pulse :refer [Pulse]]
    [metabase.models.pulse-channel-recipient :refer [PulseChannelRecipient]]
@@ -16,14 +17,14 @@
   "Gets audit info for the current user if he has permissions to access the audit collection.
   Otherwise return an empty map."
   []
-  (let [custom-reports     (audit-db/default-custom-reports-collection)
-        question-overview  (audit-db/memoized-select-audit-entity :model/Dashboard audit-db/default-question-overview-entity-id)
-        dashboard-overview (audit-db/memoized-select-audit-entity :model/Dashboard audit-db/default-dashboard-overview-entity-id)]
+  (let [custom-reports     (audit/default-custom-reports-collection)
+        question-overview  (audit/memoized-select-audit-entity :model/Dashboard ee-audit/default-question-overview-entity-id)
+        dashboard-overview (audit/memoized-select-audit-entity :model/Dashboard ee-audit/default-dashboard-overview-entity-id)]
     (merge
      {}
-     (when (mi/can-read? (audit-db/default-custom-reports-collection))
+     (when (mi/can-read? (audit/default-custom-reports-collection))
        {(:slug custom-reports) (:id custom-reports)})
-     (when (mi/can-read? (audit-db/default-audit-collection))
+     (when (mi/can-read? (audit/default-audit-collection))
        {(u/slugify (:name question-overview)) (:id question-overview)
         (u/slugify (:name dashboard-overview)) (:id dashboard-overview)}))))
 

--- a/enterprise/backend/src/metabase_enterprise/audit_app/audit.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/audit.clj
@@ -1,12 +1,12 @@
-(ns metabase-enterprise.audit-db
+(ns metabase-enterprise.audit-app.audit
   (:require
    [babashka.fs :as fs]
    [clojure.java.io :as io]
    [clojure.string :as str]
    [metabase-enterprise.serialization.cmd :as serialization.cmd]
+   [metabase.audit :as audit]
    [metabase.db :as mdb]
    [metabase.models.database :refer [Database]]
-   [metabase.models.permissions :as perms]
    [metabase.models.setting :refer [defsetting]]
    [metabase.plugins :as plugins]
    [metabase.public-settings.premium-features :refer [defenterprise]]
@@ -20,15 +20,6 @@
    (java.nio.file Path)))
 
 (set! *warn-on-reflection* true)
-
-(defsetting last-analytics-checksum
-  "A place to save the analytics-checksum, to check between app startups. If set to -1, skips the checksum process
-  entirely to avoid calculating checksums in environments (e2e tests) where we don't care."
-  :type       :integer
-  :visibility :internal
-  :audit      :never
-  :doc        false
-  :export?    false)
 
 (defn- running-from-jar?
   "Returns true iff we are running from a jar.
@@ -75,14 +66,6 @@
                        out (io/output-stream (str out-file))]
              (io/copy in out)))))))
 
-(def ^:private default-audit-collection-entity-id
-  "Default audit collection entity (instance analytics) id."
-  "vG58R8k-QddHWA7_47umn")
-
-(def ^:private default-custom-reports-entity-id
-  "Default custom reports entity id."
-  "okNLSZKdSxaoG58JSQY54")
-
 (def default-question-overview-entity-id
   "Default Question Overview (this is a dashboard) entity id."
   "jm7KgY6IuS6pQjkBZ7WUI")
@@ -90,31 +73,6 @@
 (def default-dashboard-overview-entity-id
   "Default Dashboard Overview (this is a dashboard) entity id."
   "bJEYb0o5CXlfWFcIztDwJ")
-
-(def ^{:arglists '([checksum model entity-id])
-       :private  true} memoized-select-audit-entity*
-  (mdb/memoize-for-application-db
-   (fn [checksum model entity-id]
-     (when checksum
-       (t2/select-one model :entity_id entity-id)))))
-
-(defn memoized-select-audit-entity
-  "Returns the object from entity id and model. Memoizes from entity id.
-  Should only be used for audit/pre-loaded objects."
-  [model entity-id]
-  (memoized-select-audit-entity* (last-analytics-checksum) model entity-id))
-
-(defenterprise default-custom-reports-collection
-  "Default custom reports collection."
-  :feature :none
-  []
-  (memoized-select-audit-entity :model/Collection default-custom-reports-entity-id))
-
-(defenterprise default-audit-collection
-  "Default audit collection (instance analytics) collection."
-  :feature :none
-  []
-  (memoized-select-audit-entity :model/Collection default-audit-collection-entity-id))
 
 (defn- install-database!
   "Creates the audit db, a clone of the app db used for auditing purposes.
@@ -239,7 +197,7 @@
 (defn- get-last-and-current-checksum
   "Gets the previous and current checksum for the analytics directory, respecting the `-1` flag for skipping checksums entirely."
   []
-  (let [last-checksum (last-analytics-checksum)]
+  (let [last-checksum (audit/last-analytics-checksum)]
     (if (should-skip-checksum? last-checksum)
       [SKIP_CHECKSUM_FLAG SKIP_CHECKSUM_FLAG]
       [last-checksum (analytics-checksum)])))
@@ -261,7 +219,7 @@
             (log/info (str "Error Loading Analytics Content: " (pr-str report)))
             (do
               (log/info (str "Loading Analytics Content Complete (" (count (:seen report)) ") entities loaded."))
-              (last-analytics-checksum! current-checksum))))))
+              (audit/last-analytics-checksum! current-checksum))))))
     (when-let [audit-db (t2/select-one :model/Database :is_audit true)]
       (adjust-audit-db-to-host! audit-db))))
 
@@ -272,7 +230,7 @@
       (nil? audit-db)
       (u/prog1 ::installed
        (log/info "Installing Audit DB...")
-       (install-database! (mdb/db-type) perms/audit-db-id))
+       (install-database! (mdb/db-type) audit/audit-db-id))
 
       (not= (mdb/db-type) (:engine audit-db))
       (u/prog1 ::updated

--- a/enterprise/backend/src/metabase_enterprise/audit_app/pages/queries.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/pages/queries.clj
@@ -3,8 +3,8 @@
    [metabase-enterprise.audit-app.interface :as audit.i]
    [metabase-enterprise.audit-app.pages.common :as common]
    [metabase-enterprise.audit-app.pages.common.cards :as cards]
-   [metabase.db :as mdb]
-   [metabase.models.permissions :as perms]))
+   [metabase.audit :as audit]
+   [metabase.db :as mdb]))
 
 ;; List of all failing questions
 (defmethod audit.i/internal-query ::bad-table
@@ -73,7 +73,7 @@
                   :where     [:and
                               [:= :card.archived false]
                               [:<> :latest_qe.error nil]
-                              [:not= :card.database_id perms/audit-db-id]]}
+                              [:not= :card.database_id audit/audit-db-id]]}
                  (common/add-search-clause error-filter :latest_qe.error)
                  (common/add-search-clause db-filter :db.name)
                  (common/add-search-clause collection-filter coll-name)

--- a/enterprise/backend/src/metabase_enterprise/audit_app/permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/permissions.clj
@@ -1,10 +1,10 @@
 (ns metabase-enterprise.audit-app.permissions
   (:require
-   [metabase-enterprise.audit-db :refer [default-audit-collection]]
+   [metabase-enterprise.audit.audit-db :refer [default-audit-collection]]
+   [metabase.audit :as audit]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.models.data-permissions :as data-perms]
    [metabase.models.interface :as mi]
-   [metabase.models.permissions :as perms]
    [metabase.models.query.permissions :as query-perms]
    [metabase.public-settings.premium-features :refer [defenterprise]]
    [metabase.query-processor.store :as qp.store]
@@ -39,7 +39,7 @@
   [{query-type :type, database-id :database, query :query :as outer-query}]
   ;; Check if the user has access to the analytics collection, since this should be coupled with access to the
   ;; audit database in general.
-  (when-not (mi/can-read? (default-audit-collection))
+  (when-not (mi/can-read? (audit/default-audit-collection))
     (throw (ex-info (tru "You do not have access to the audit database") outer-query)))
   ;; query->source-table-ids returns a set of table IDs and/or the ::query-perms/native keyword
   (when (= query-type :native)
@@ -69,6 +69,6 @@
                                      :none  :no
                                      :write (throw (ex-info (tru (str "Unable to make audit collections writable."))
                                                             {:status-code 400})))
-              view-tables         (t2/select :model/Table :db_id perms/audit-db-id :name [:in audit-db-view-names])]
+              view-tables         (t2/select :model/Table :db_id audit/audit-db-id :name [:in audit-db-view-names])]
           (doseq [table view-tables]
             (data-perms/set-table-permission! group-id table :perms/create-queries create-queries-value))))))

--- a/enterprise/backend/src/metabase_enterprise/audit_app/permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/permissions.clj
@@ -1,6 +1,5 @@
 (ns metabase-enterprise.audit-app.permissions
   (:require
-   [metabase-enterprise.audit.audit-db :refer [default-audit-collection]]
    [metabase.audit :as audit]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.models.data-permissions :as data-perms]
@@ -62,7 +61,7 @@
   But it's cleaner to keep the audit DB permission paths in the database consistent."
   :feature :audit-app
   [group-id changes]
-  (let [[change-id tyype] (first (filter #(= (first %) (:id (default-audit-collection))) changes))]
+  (let [[change-id tyype] (first (filter #(= (first %) (:id (audit/default-audit-collection))) changes))]
       (when change-id
         (let [create-queries-value (case tyype
                                      :read  :query-builder

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
@@ -6,7 +6,7 @@
   See documentation in [[metabase.models.permissions]] for more information about the Metabase permissions system."
   (:require
    [medley.core :as m]
-   [metabase.config :as config]
+   [metabase.audit :as audit]
    [metabase.legacy-mbql.normalize :as mbql.normalize]
    [metabase.models.card :refer [Card]]
    [metabase.models.data-permissions :as data-perms]
@@ -128,7 +128,7 @@
                               :where [:and
                                       (when group-id [:= :s.group_id group-id])
                                       (when db-id [:= :t.db_id db-id])
-                                      (when-not audit? [:not [:= :t.db_id config/audit-db-id]])]})]
+                                      (when-not audit? [:not [:= :t.db_id audit/audit-db-id]])]})]
     ;; Incorporate each sandbox policy into the permissions graph.
     (reduce (fn [acc {:keys [group_id table_id db_id schema]}]
               (merge-sandbox-into-graph acc group_id table_id db_id schema [:view-data] :sandboxed))

--- a/enterprise/backend/test/metabase_enterprise/analytics/stats_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/analytics/stats_test.clj
@@ -1,7 +1,7 @@
 (ns metabase-enterprise.analytics.stats-test
   (:require
    [clojure.test :refer :all]
-   [metabase-enterprise.audit-db :as audit-db]
+   [metabase-enterprise.audit-app.audit :as ee-audit]
    [metabase.analytics.stats :as stats]
    [metabase.db :as mdb]
    [metabase.test :as mt]
@@ -11,7 +11,7 @@
   (testing "Metabase Analytics doesn't contribute to stats"
     (mt/with-temp-empty-app-db [_conn :h2]
       (mdb/setup-db! :create-sample-content? false)
-      (is (= ::audit-db/installed (audit-db/ensure-audit-db-installed!)))
+      (is (= ::ee-audit/installed (ee-audit/ensure-audit-db-installed!)))
       (testing "sense check: Collection, Dashboard, and Cards exist"
         (is (true? (t2/exists? :model/Collection)))
         (is (true? (t2/exists? :model/Dashboard)))

--- a/enterprise/backend/test/metabase_enterprise/audit_app/api/collection_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/api/collection_test.clj
@@ -3,7 +3,7 @@
    [clojure.test :refer :all]
    [clojure.walk :as walk]
    [medley.core :as m]
-   [metabase-enterprise.audit.audit-test :as audit-test]
+   [metabase-enterprise.audit-app.audit-test :as audit-test]
    [metabase.config :as config]
    [metabase.models :refer [Collection]]
    [metabase.models.collection :as collection]

--- a/enterprise/backend/test/metabase_enterprise/audit_app/api/collection_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/api/collection_test.clj
@@ -3,7 +3,7 @@
    [clojure.test :refer :all]
    [clojure.walk :as walk]
    [medley.core :as m]
-   [metabase-enterprise.audit-db-test :as audit-db-test]
+   [metabase-enterprise.audit.audit-test :as audit-test]
    [metabase.config :as config]
    [metabase.models :refer [Collection]]
    [metabase.models.collection :as collection]
@@ -15,7 +15,7 @@
 
 (deftest list-collections-instance-analytics-test
   (mt/with-premium-features #{:audit-app}
-    (audit-db-test/with-audit-db-restoration
+    (audit-test/with-audit-db-restoration
       (t2.with-temp/with-temp [Collection _ {:name "Zippy"}]
         (testing "Instance Analytics Collection should be the last collection."
           (testing "GET /api/collection"
@@ -29,7 +29,7 @@
                         last
                         :type))))))))
   (mt/with-premium-features #{}
-    (audit-db-test/with-audit-db-restoration
+    (audit-test/with-audit-db-restoration
       (t2.with-temp/with-temp [Collection _ {:name "Zippy"}]
         (testing "Instance Analytics Collection should not show up when audit-app isn't enabled."
           (testing "GET /api/collection"
@@ -72,7 +72,7 @@
     (testing "You should only see your collection and public collections"
       ;; Set audit-app feature so that we can assert that audit collections are also visible when running EE
       (mt/with-premium-features #{:audit-app}
-        (audit-db-test/with-audit-db-restoration
+        (audit-test/with-audit-db-restoration
           (let [admin-user-id  (u/the-id (test.users/fetch-user :crowberto))
                 crowberto-root (t2/select-one Collection :personal_owner_id admin-user-id)]
             (t2.with-temp/with-temp [Collection collection          {}

--- a/enterprise/backend/test/metabase_enterprise/audit_app/api/database_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/api/database_test.clj
@@ -1,7 +1,7 @@
 (ns metabase-enterprise.audit-app.api.database-test
   (:require
    [clojure.test :refer :all]
-   [metabase-enterprise.audit.audit-test :as audit-test]
+   [metabase-enterprise.audit-app.audit-test :as audit-test]
    [metabase.audit :as audit]
    [metabase.test :as mt]))
 

--- a/enterprise/backend/test/metabase_enterprise/audit_app/api/database_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/api/database_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.audit-db-test :as audit-db-test]
-   [metabase.models.permissions :as perms]
+   [metabase.audit :as audit]
    [metabase.test :as mt]))
 
 (deftest audit-db-unmodifiable-test
@@ -15,4 +15,4 @@
                              [:delete "database/%d"]]
                 user [:crowberto :lucky]]
           (is (= "You don't have permissions to do that."
-                 (mt/user-http-request user verb 403 (format path perms/audit-db-id)))))))))
+                 (mt/user-http-request user verb 403 (format path audit/audit-db-id)))))))))

--- a/enterprise/backend/test/metabase_enterprise/audit_app/api/database_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/api/database_test.clj
@@ -1,13 +1,13 @@
 (ns metabase-enterprise.audit-app.api.database-test
   (:require
    [clojure.test :refer :all]
-   [metabase-enterprise.audit-db-test :as audit-db-test]
+   [metabase-enterprise.audit.audit-test :as audit-test]
    [metabase.audit :as audit]
    [metabase.test :as mt]))
 
 (deftest audit-db-unmodifiable-test
   (mt/with-premium-features #{:audit-app}
-    (audit-db-test/with-audit-db-restoration
+    (audit-test/with-audit-db-restoration
       (testing "Neither admin nor regular users can modify the audit database"
         (doseq [[verb path] [[:post "database/%d/unpersist"]
                              [:put "database/%d"]

--- a/enterprise/backend/test/metabase_enterprise/audit_app/api/user_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/api/user_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.audit-app.permissions-test :as ee-perms-test]
-   [metabase-enterprise.audit-db :as audit-db]
+   [metabase.audit :as audit]
    [metabase.models :refer [Card Dashboard DashboardCard Pulse PulseCard
                             PulseChannel PulseChannelRecipient User]]
    [metabase.models.permissions :as perms]
@@ -97,22 +97,22 @@
     (mt/with-premium-features #{:audit-app}
       (ee-perms-test/install-audit-db-if-needed!)
       (testing "None of the ids show up when perms aren't given"
-        (perms/revoke-collection-permissions! (perms-group/all-users) (audit-db/default-custom-reports-collection))
-        (perms/revoke-collection-permissions! (perms-group/all-users) (audit-db/default-audit-collection))
+        (perms/revoke-collection-permissions! (perms-group/all-users) (audit/default-custom-reports-collection))
+        (perms/revoke-collection-permissions! (perms-group/all-users) (audit/default-audit-collection))
         (is (= #{}
                (->>
                 (mt/user-http-request :rasta :get 200 "/ee/audit-app/user/audit-info")
                 keys
                 (into #{})))))
       (testing "Custom reports collection shows up when perms are given"
-        (perms/grant-collection-read-permissions! (perms-group/all-users) (audit-db/default-custom-reports-collection))
+        (perms/grant-collection-read-permissions! (perms-group/all-users) (audit/default-custom-reports-collection))
         (is (= #{:custom_reports}
                (->>
                 (mt/user-http-request :rasta :get 200 "/ee/audit-app/user/audit-info")
                 keys
                 (into #{})))))
       (testing "Everything shows up when all perms are given"
-        (perms/grant-collection-read-permissions! (perms-group/all-users) (audit-db/default-audit-collection))
+        (perms/grant-collection-read-permissions! (perms-group/all-users) (audit/default-audit-collection))
         (is (= #{:question_overview :dashboard_overview :custom_reports}
                (->>
                 (mt/user-http-request :rasta :get 200 "/ee/audit-app/user/audit-info")

--- a/enterprise/backend/test/metabase_enterprise/audit_app/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/permissions_test.clj
@@ -2,9 +2,8 @@
   (:require
    [clojure.set :as set]
    [clojure.test :refer :all]
+   [metabase-enterprise.audit-app.audit-test :as audit-test]
    [metabase-enterprise.audit-app.permissions :as audit-app.permissions]
-   [metabase-enterprise.audit-db :as audit-db]
-   [metabase-enterprise.audit-db-test :as audit-db-test]
    [metabase.api.common :as api]
    [metabase.audit :as audit]
    [metabase.core :as mbc]
@@ -35,7 +34,7 @@
 
 (deftest audit-db-basic-query-test
   (mt/test-drivers #{:postgres :h2 :mysql}
-    (audit-db-test/with-audit-db-restoration
+    (audit-test/with-audit-db-restoration
       (mt/with-premium-features #{:audit-app}
         (mt/with-test-user :crowberto
           (testing "A query using a saved audit model as the source table runs succesfully"
@@ -58,7 +57,7 @@
 
 (deftest audit-db-disallowed-queries-test
   (mt/test-drivers #{:postgres :h2 :mysql}
-    (audit-db-test/with-audit-db-restoration
+    (audit-test/with-audit-db-restoration
       (mt/with-premium-features #{:audit-app}
         (mt/with-test-user :crowberto
           (testing "Native queries are not allowed to be run on audit DB views, even by admins"
@@ -105,7 +104,7 @@
                    Table            view-table        {:db_id database-id :name "v_users"}
                    Collection       collection        {}]
       (with-redefs [audit/audit-db-id                 database-id
-                    audit-db/default-audit-collection (constantly collection)]
+                    audit/default-audit-collection (constantly collection)]
         (testing "Updating permissions for the audit collection also updates audit DB permissions"
           ;; Audit DB starts with full data access but no query builder access
           (is (= :unrestricted (data-perms/table-permission-for-group group-id :perms/view-data database-id (:id view-table))))

--- a/enterprise/backend/test/metabase_enterprise/audit_app/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/permissions_test.clj
@@ -6,6 +6,7 @@
    [metabase-enterprise.audit-db :as audit-db]
    [metabase-enterprise.audit-db-test :as audit-db-test]
    [metabase.api.common :as api]
+   [metabase.audit :as audit]
    [metabase.core :as mbc]
    [metabase.models.collection :refer [Collection]]
    [metabase.models.collection.graph :refer [update-graph!]]
@@ -13,7 +14,6 @@
    [metabase.models.data-permissions :as data-perms]
    [metabase.models.database :refer [Database]]
    [metabase.models.interface :as mi]
-   [metabase.models.permissions :as perms]
    [metabase.models.permissions-group :refer [PermissionsGroup]]
    [metabase.models.table :refer [Table]]
    [metabase.query-processor :as qp]
@@ -39,20 +39,20 @@
       (mt/with-premium-features #{:audit-app}
         (mt/with-test-user :crowberto
           (testing "A query using a saved audit model as the source table runs succesfully"
-            (let [audit-card (t2/select-one :model/Card :database_id perms/audit-db-id :type :model)]
+            (let [audit-card (t2/select-one :model/Card :database_id audit/audit-db-id :type :model)]
               (is (partial=
                    {:status :completed}
                    (qp/process-query
-                    {:database perms/audit-db-id
+                    {:database audit/audit-db-id
                      :type     :query
                      :query    {:source-table (str "card__" (u/the-id audit-card))}})))))
 
           (testing "A non-native query can be run on views in the audit DB"
-            (let [audit-view (t2/select-one :model/Table :db_id perms/audit-db-id)]
+            (let [audit-view (t2/select-one :model/Table :db_id audit/audit-db-id)]
               (is (partial=
                    {:status :completed}
                    (qp/process-query
-                    {:database perms/audit-db-id
+                    {:database audit/audit-db-id
                      :type     :query
                      :query    {:source-table (u/the-id audit-view)}}))))))))))
 
@@ -66,7 +66,7 @@
                  clojure.lang.ExceptionInfo
                  #"Native queries are not allowed on the audit database"
                  (qp/process-query
-                  {:database perms/audit-db-id
+                  {:database audit/audit-db-id
                    :type     :native
                    :native   {:query "SELECT * FROM v_audit_log;"}}))))
 
@@ -74,13 +74,13 @@
             ;; Nothing should be synced directly from the audit DB, just loaded via serialization, so only the views
             ;; should have metadata present in the app DB in the first place. But in case this changes, we want to
             ;; explicitly block other tables from being queried.
-            (t2.with-temp/with-temp [:model/Table table {:db_id perms/audit-db-id}
+            (t2.with-temp/with-temp [:model/Table table {:db_id audit/audit-db-id}
                                      :model/Field _     {:table_id (u/the-id table)}]
               (is (thrown-with-msg?
                    clojure.lang.ExceptionInfo
                    #"Audit queries are only allowed on audit views"
                    (qp/process-query
-                    {:database perms/audit-db-id
+                    {:database audit/audit-db-id
                      :type     :query
                      :query   {:source-table (u/the-id table)}})))))
 
@@ -89,12 +89,12 @@
             (mt/with-full-data-perms-for-all-users!
               (mt/with-test-user :rasta
                 (binding [api/*current-user-permissions-set* (delay #{})]
-                  (let [audit-view (t2/select-one :model/Table :db_id perms/audit-db-id)]
+                  (let [audit-view (t2/select-one :model/Table :db_id audit/audit-db-id)]
                     (is (thrown-with-msg?
                          clojure.lang.ExceptionInfo
                          #"You do not have access to the audit database"
                          (qp/process-query
-                          {:database perms/audit-db-id
+                          {:database audit/audit-db-id
                            :type     :query
                            :query    {:source-table (u/the-id audit-view)}})))))))))))))
 
@@ -104,7 +104,7 @@
                    Database         {database-id :id} {}
                    Table            view-table        {:db_id database-id :name "v_users"}
                    Collection       collection        {}]
-      (with-redefs [perms/audit-db-id                 database-id
+      (with-redefs [audit/audit-db-id                 database-id
                     audit-db/default-audit-collection (constantly collection)]
         (testing "Updating permissions for the audit collection also updates audit DB permissions"
           ;; Audit DB starts with full data access but no query builder access
@@ -125,8 +125,8 @@
   "Checks if there's an audit-db. if not, it will create it and serialize audit content, including the
   `default-audit-collection`. If the audit-db is there, this does nothing."
   []
-  (let [coll (boolean (perms/default-audit-collection))
-        default-audit-id (:id (perms/default-audit-collection))
+  (let [coll (boolean (audit/default-audit-collection))
+        default-audit-id (:id (audit/default-audit-collection))
         cards (t2/exists? :model/Card :collection_id default-audit-id)
         dashboards (t2/exists? :model/Dashboard :collection_id default-audit-id)]
     (when-not (and coll cards dashboards)
@@ -137,7 +137,7 @@
 
 (deftest can-write-false-for-audit-card-content-test
   (install-audit-db-if-needed!)
-  (t2.with-temp/with-temp [:model/Card audit-child-card {:collection_id (:id (perms/default-audit-collection))}
+  (t2.with-temp/with-temp [:model/Card audit-child-card {:collection_id (:id (audit/default-audit-collection))}
                            :model/Card root-child-card {:collection_id nil}]
     (is (false? (mi/can-write? audit-child-card)))
     (binding [api/*current-user-permissions-set* (delay #{"/collection/root/"})]
@@ -147,18 +147,18 @@
 
 (deftest can-write-is-false-for-audit-content-cards-test
   (install-audit-db-if-needed!)
-  (let [audit-cards (t2/select :model/Card :collection_id (:id (perms/default-audit-collection)))]
+  (let [audit-cards (t2/select :model/Card :collection_id (:id (audit/default-audit-collection)))]
     (is (= #{false} (set (map mi/can-write? audit-cards))))))
 
 (deftest cannot-edit-audit-content-cards-over-api
   (install-audit-db-if-needed!)
-  (let [card (t2/select-one :model/Card :collection_id (:id (perms/default-audit-collection)))]
+  (let [card (t2/select-one :model/Card :collection_id (:id (audit/default-audit-collection)))]
     (is (= "You don't have permissions to do that."
            (mt/user-http-request :rasta :put 403 (str "card/" (u/the-id card)) {:name "My new title"})))))
 
 (deftest can-write-false-for-audit-dashboard-content-test
   (install-audit-db-if-needed!)
-  (t2.with-temp/with-temp [:model/Dashboard audit-child-dashboard {:collection_id (:id (perms/default-audit-collection))}
+  (t2.with-temp/with-temp [:model/Dashboard audit-child-dashboard {:collection_id (:id (audit/default-audit-collection))}
                            :model/Dashboard root-child-dashboard {:collection_id nil}]
     (is (false? (mi/can-write? audit-child-dashboard)))
     (binding [api/*current-user-permissions-set* (delay #{"/collection/root/"})]
@@ -168,11 +168,11 @@
 
 (deftest can-write-is-false-for-audit-content-dashboards-test
   (install-audit-db-if-needed!)
-  (let [audit-dashboards (t2/select :model/Dashboard :collection_id (:id (perms/default-audit-collection)))]
+  (let [audit-dashboards (t2/select :model/Dashboard :collection_id (:id (audit/default-audit-collection)))]
     (is (= #{false} (set (map mi/can-write? audit-dashboards))))))
 
 (deftest cannot-edit-audit-content-dashboards-over-api
   (install-audit-db-if-needed!)
-  (let [dashboard (t2/select-one :model/Dashboard :collection_id (:id (perms/default-audit-collection)))]
+  (let [dashboard (t2/select-one :model/Dashboard :collection_id (:id (audit/default-audit-collection)))]
     (is (= "You don't have permissions to do that."
            (mt/user-http-request :rasta :put 403 (str "dashboard/" (u/the-id dashboard)) {:name "My new title"})))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -5,9 +5,9 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [java-time.api :as t]
-   [metabase-enterprise.audit-db :as audit-db]
    [metabase-enterprise.serialization.test-util :as ts]
    [metabase-enterprise.serialization.v2.extract :as extract]
+   [metabase.audit :as audit]
    [metabase.core :as mbc]
    [metabase.models
     :refer [Action
@@ -1624,15 +1624,15 @@
                        Table      {no-schema-id   :id}        {:name "Schemaless Table" :db_id db-id}
                        Field      {some-field-id  :id}        {:name "Some Field" :table_id no-schema-id}
                        Table      {schema-id      :id}        {:name        "Schema'd Table"
-                                                              :db_id       db-id
-                                                              :schema      "PUBLIC"}
+                                                               :db_id       db-id
+                                                               :schema      "PUBLIC"}
                        Field      {other-field-id :id}        {:name "Other Field" :table_id schema-id}
                        Field      {fk-id          :id}        {:name     "Foreign Key"
-                                                              :table_id schema-id
-                                                              :fk_target_field_id some-field-id}
+                                                               :table_id schema-id
+                                                               :fk_target_field_id some-field-id}
                        Field      {nested-id      :id}        {:name "Nested Field"
-                                                              :table_id schema-id
-                                                              :parent_id other-field-id}]
+                                                               :table_id schema-id
+                                                               :parent_id other-field-id}]
 
       (testing "fields that reference foreign keys are properly exported as Field references"
         (is (= ["My Database" nil "Schemaless Table" "Some Field"]
@@ -1702,8 +1702,8 @@
     (mt/with-empty-h2-app-db
       (mbc/ensure-audit-db-installed!)
       (testing "sanity check that the audit collection exists"
-        (is (some? (audit-db/default-audit-collection)))
-        (is (some? (audit-db/default-custom-reports-collection))))
+        (is (some? (audit/default-audit-collection)))
+        (is (some? (audit/default-custom-reports-collection))))
       (let [ser (extract/extract {:no-settings   true
                                   :no-data-model true})]
         (is (= #{@trash-eid} (by-model "Collection" ser)))))))

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -340,7 +340,6 @@
                                          ;; => we assume all native queries are compatible and FE will figure it out later
                                          (= (:query_type %) :native)
                                          (series-are-compatible? card % database-id->metadata-provider))))]
-
     (if page-size
       [database-id->metadata-provider (take page-size compatible-cards)]
       [database-id->metadata-provider compatible-cards])))
@@ -392,12 +391,12 @@
   (let [exclude_ids  (when exclude_ids (api/parse-multi-values-param exclude_ids parse-long))
         card         (-> (t2/select-one :model/Card :id id) api/check-404 api/read-check)
         card-display (:display card)]
-   (when-not (supported-series-display-type card-display)
-             (throw (ex-info (tru "Card with type {0} is not compatible to have series" (name card-display))
-                             {:display         card-display
-                              :allowed-display (map name supported-series-display-type)
-                              :status-code     400})))
-   (fetch-compatible-series
+    (when-not (supported-series-display-type card-display)
+      (throw (ex-info (tru "Card with type {0} is not compatible to have series" (name card-display))
+                      {:display         card-display
+                       :allowed-display (map name supported-series-display-type)
+                       :status-code     400})))
+    (fetch-compatible-series
      card
      {:exclude-ids exclude_ids
       :query       query

--- a/src/metabase/audit.clj
+++ b/src/metabase/audit.clj
@@ -1,0 +1,66 @@
+(ns metabase.audit
+  "Namespace for anything related to the Audit subsystem (aka Metabase Analytics) which needs to be accessible in the
+  OSS product. EE-only code is located in `metabase-enterprise.audit-app.audit`."
+  (:require
+   [metabase.db :as mdb]
+   [metabase.models.setting :refer [defsetting]]
+   [toucan2.core :as t2]))
+
+;; NOTE: Constants like `audit-db-id` and the entity IDs of audit collections are placed in OSS code because audit
+;; content may be loaded on an OSS build in the case of an EE->OSS downgrade. In these situations, we still need
+;; access to audit identifiers in order to enforce permission checks properly.
+
+(def audit-db-id
+  "ID of Audit DB which is loaded when running an EE build."
+  13371337)
+
+(defsetting last-analytics-checksum
+  "A place to save the analytics-checksum, to check between app startups. If set to -1, skips the checksum process
+  entirely to avoid calculating checksums in environments (e2e tests) where we don't care."
+  :type       :integer
+  :visibility :internal
+  :audit      :never
+  :doc        false
+  :export?    false)
+
+(def ^:private default-audit-collection-entity-id
+  "Default audit collection entity (instance analytics) id."
+  "vG58R8k-QddHWA7_47umn")
+
+(def ^:private default-custom-reports-entity-id
+  "Default custom reports entity id."
+  "okNLSZKdSxaoG58JSQY54")
+
+(def ^{:arglists '([checksum model entity-id])
+       :private  true} memoized-select-audit-entity*
+  (mdb/memoize-for-application-db
+   (fn [checksum model entity-id]
+     (when checksum
+       (t2/select-one model :entity_id entity-id)))))
+
+(defn memoized-select-audit-entity
+  "Returns the object from entity id and model. Memoizes from entity id.
+  Should only be used for audit/pre-loaded objects."
+  [model entity-id]
+  (memoized-select-audit-entity* (last-analytics-checksum) model entity-id))
+
+(defn default-custom-reports-collection
+  "Default custom reports collection."
+  []
+  (memoized-select-audit-entity :model/Collection default-custom-reports-entity-id))
+
+(defn default-audit-collection
+  "Default audit collection (instance analytics) collection."
+  []
+  (memoized-select-audit-entity :model/Collection default-audit-collection-entity-id))
+
+(defn is-collection-id-audit?
+  "Check if an id is one of the audit collection ids."
+  [id]
+  (contains? (set [(:id (default-audit-collection)) (:id (default-custom-reports-collection))]) id))
+
+(defn is-parent-collection-audit?
+  "Check if an instance's parent collection is the audit collection."
+  [instance]
+  (let [parent-id (:collection_id instance)]
+    (and (some? parent-id) (is-collection-id-audit? parent-id))))

--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -145,10 +145,6 @@
   (when-let [user-json (env/env :mb-user-defaults)]
     (json/parse-string user-json true)))
 
-(def ^:const audit-db-id
-  "ID of Audit DB which is loaded when running an EE build. ID is placed in OSS code to facilitate permission checks."
-  13371337)
-
 (def ^:const internal-mb-user-id
   "The user-id of the internal metabase user.
    This is needed in the OSS edition to filter out users for setup/has-user-setup."

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -93,7 +93,7 @@
 (defenterprise ensure-audit-db-installed!
   "OSS implementation of `audit-db/ensure-db-installed!`, which is an enterprise feature, so does nothing in the OSS
   version."
-  metabase-enterprise.audit-db [] ::noop)
+  metabase-enterprise.audit-app.audit [] ::noop)
 
 (defn- init!*
   "General application initialization function which should be run once at application startup."

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -11,6 +11,7 @@
    [medley.core :as m]
    [metabase.analyze :as analyze]
    [metabase.api.common :as api]
+   [metabase.audit :as audit]
    [metabase.compatibility :as compatibility]
    [metabase.config :as config]
    [metabase.db.query :as mdb.query]
@@ -96,9 +97,9 @@
    (if (and
         ;; We want to make sure there's an existing audit collection before doing the equality check below.
         ;; If there is no audit collection, this will be nil:
-        (some? (:id (perms/default-audit-collection)))
+        (some? (:id (audit/default-audit-collection)))
         ;; Is a direct descendant of audit collection
-        (= (:collection_id instance) (:id (perms/default-audit-collection))))
+        (= (:collection_id instance) (:id (audit/default-audit-collection))))
      false
      (mi/current-user-has-full-permissions? (perms/perms-objects-set-for-parent-collection instance :write))))
   ([_ pk]

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -10,6 +10,7 @@
    [metabase.api.common
     :as api
     :refer [*current-user-id* *current-user-permissions-set*]]
+   [metabase.audit :as audit]
    [metabase.db :as mdb]
    [metabase.events :as events]
    [metabase.models.collection.root :as collection.root]
@@ -120,7 +121,7 @@
 
 (defn- default-audit-collection?
   [{:keys [id] :as _col}]
-  (= id (:id (perms/default-audit-collection))))
+  (= id (:id (audit/default-audit-collection))))
 
 (defmethod mi/can-write? Collection
   ([instance]
@@ -680,7 +681,7 @@
   (when (collection.root/is-root-collection? collection)
     (throw (Exception. (tru "You cannot archive the Root Collection."))))
   ;; Make sure we're not trying to archive the Custom Reports Collection...
-  (when (= (perms/default-custom-reports-collection) collection)
+  (when (= (audit/default-custom-reports-collection) collection)
     (throw (Exception. (tru "You cannot archive the Custom Reports Collection."))))
   ;; also make sure we're not trying to archive a PERSONAL Collection
   (when (t2/exists? Collection :id (u/the-id collection), :personal_owner_id [:not= nil])

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -1080,7 +1080,7 @@
           :write (perms/collection-readwrite-path collection-or-id))})))
 
 (def ^:private instance-analytics-collection-type
-  "The value of the `:type` field for the `instance-analytics` Collection created in [[metabase-enterprise.audit-db]]"
+  "The value of the `:type` field for the `instance-analytics` Collection created in [[metabase-enterprise.audit-app.audit]]"
   "instance-analytics")
 
 (defmethod mi/exclude-internal-content-hsql :model/Collection

--- a/src/metabase/models/collection/graph.clj
+++ b/src/metabase/models/collection/graph.clj
@@ -3,6 +3,7 @@
   details and for the code for generating and updating the *data* permissions graph."
   (:require
    [clojure.data :as data]
+   [metabase.audit :as audit]
    [metabase.db.query :as mdb.query]
    [metabase.models.collection :as collection :refer [Collection]]
    [metabase.models.collection-permission-graph-revision
@@ -10,7 +11,9 @@
     :refer [CollectionPermissionGraphRevision]]
    [metabase.models.data-permissions.graph :as data-perms.graph]
    [metabase.models.permissions :as perms :refer [Permissions]]
-   [metabase.models.permissions-group :as perms-group :as perms-group :refer [PermissionsGroup]]
+   [metabase.models.permissions-group
+    :as perms-group
+    :refer [PermissionsGroup]]
    [metabase.public-settings.premium-features :refer [defenterprise]]
    [metabase.util :as u]
    [metabase.util.honey-sql-2 :as h2x]
@@ -91,7 +94,7 @@
   "In the graph, override the instance analytics collection within the admin group to read."
   [graph]
   (let [admin-group-id      (:id (perms-group/admin))
-        audit-collection-id (:id (perms/default-audit-collection))]
+        audit-collection-id (:id (audit/default-audit-collection))]
     (if (nil? audit-collection-id)
       graph
       (assoc-in graph [:groups admin-group-id audit-collection-id] :read))))

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -5,6 +5,7 @@
    [clojure.set :as set]
    [clojure.string :as str]
    [medley.core :as m]
+   [metabase.audit :as audit]
    [metabase.config :as config]
    [metabase.db.query :as mdb.query]
    [metabase.events :as events]
@@ -59,9 +60,9 @@
    (if (and
         ;; We want to make sure there's an existing audit collection before doing the equality check below.
         ;; If there is no audit collection, this will be nil:
-        (some? (:id (perms/default-audit-collection)))
+        (some? (:id (audit/default-audit-collection)))
         ;; Is a direct descendant of audit collection
-        (= (:collection_id instance) (:id (perms/default-audit-collection))))
+        (= (:collection_id instance) (:id (audit/default-audit-collection))))
      false
      (mi/current-user-has-full-permissions? (perms/perms-objects-set-for-parent-collection instance :write))))
   ([_ pk]

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -5,7 +5,7 @@
    [malli.core :as mc]
    [medley.core :as m]
    [metabase.api.common :as api]
-   [metabase.config :as config]
+   [metabase.audit :as audit]
    [metabase.models.interface :as mi]
    [metabase.public-settings.premium-features :refer [defenterprise]]
    [metabase.util :as u]
@@ -553,7 +553,7 @@
                                        (when perm-type [:= :perm_type (u/qualified-name perm-type)])
                                        (when db-id [:= :db_id db-id])
                                        (when group-id [:= :group_id group-id])
-                                       (when-not audit? [:not= :db_id config/audit-db-id])]})]
+                                       (when-not audit? [:not= :db_id audit/audit-db-id])]})]
     (reduce
      (fn [graph {group-id  :group-id
                  perm-type :type

--- a/src/metabase/models/data_permissions/graph.clj
+++ b/src/metabase/models/data_permissions/graph.clj
@@ -12,11 +12,13 @@
    [medley.core :as m]
    [metabase.api.common :as api]
    [metabase.api.permission-graph :as api.permission-graph]
-   [metabase.config :as config]
+   [metabase.audit :as audit]
    [metabase.models.data-permissions :as data-perms]
    [metabase.models.permissions-group :as perms-group]
    [metabase.models.permissions-revision :as perms-revision]
-   [metabase.public-settings.premium-features :as premium-features :refer [defenterprise]]
+   [metabase.public-settings.premium-features
+    :as premium-features
+    :refer [defenterprise]]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
@@ -137,7 +139,7 @@
   (let [admin-group-id (u/the-id (perms-group/admin))
         db-ids         (if db-id [db-id] (t2/select-pks-vec :model/Database
                                                             {:where [:and
-                                                                     (when-not audit? [:not= :id config/audit-db-id])]}))]
+                                                                     (when-not audit? [:not= :id audit/audit-db-id])]}))]
     (if (and group-id (not= group-id admin-group-id))
       ;; Don't add admin perms when we're fetching the perms for a specific non-admin group
       api-graph
@@ -362,7 +364,7 @@
                          vals
                          (map keys)
                          (apply concat))]
-    (when (some #{config/audit-db-id} changes-ids)
+    (when (some #{audit/audit-db-id} changes-ids)
       (throw (ex-info (tru
                        (str "Audit database permissions can only be changed by updating audit collection permissions."))
                       {:status-code 400})))))

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -3,7 +3,7 @@
    [clojure.core.match :refer [match]]
    [medley.core :as m]
    [metabase.api.common :as api]
-   [metabase.config :as config]
+   [metabase.audit :as audit]
    [metabase.db :as mdb]
    [metabase.db.query :as mdb.query]
    [metabase.driver :as driver]
@@ -68,7 +68,7 @@
 (defn- should-read-audit-db?
   "Audit Database should only be fetched if audit app is enabled."
   [database-id]
-  (and (not (premium-features/enable-audit-app?)) (= database-id config/audit-db-id)))
+  (and (not (premium-features/enable-audit-app?)) (= database-id audit/audit-db-id)))
 
 (defmethod mi/can-read? Database
   ([instance]
@@ -96,7 +96,7 @@
   ([instance]
    (mi/can-write? :model/Database (u/the-id instance)))
   ([_model pk]
-   (and (not= pk config/audit-db-id)
+   (and (not= pk audit/audit-db-id)
         (current-user-can-write-db? pk))))
 
 (defn- infer-db-schedules

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -169,14 +169,13 @@
     /                                               ; full root perms"
   (:require
    [clojure.string :as str]
+   [metabase.audit :as audit]
    [metabase.config :as config]
    [metabase.models.interface :as mi]
    [metabase.models.permissions-group :as perms-group]
    [metabase.permissions.util :as perms.u]
    [metabase.plugins.classloader :as classloader]
-   [metabase.public-settings.premium-features
-    :as premium-features
-    :refer [defenterprise]]
+   [metabase.public-settings.premium-features :as premium-features]
    [metabase.util :as u]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.i18n :refer [tru]]
@@ -424,20 +423,6 @@
 
 ; Audit Permissions helper fns
 
-(def audit-db-id
-  "ID of Audit DB which is loaded when running an EE build. ID is placed in OSS code to facilitate permission checks."
-  13371337)
-
-(defenterprise default-audit-collection
-  "OSS implementation of `audit-db/default-audit-collection`, which is an enterprise feature, so does nothing in the OSS
-  version."
-  metabase-enterprise.audit-db [] nil)
-
-(defenterprise default-custom-reports-collection
-  "OSS implementation of `audit-db/default-custom-reports-collection`, which is an enterprise feature, so does nothing in the OSS
-  version."
-  metabase-enterprise.audit-db [] ::noop)
-
 (defn check-audit-db-permissions
   "Check that the changes coming in does not attempt to change audit database permission. Admins should
   change these permissions in application monitoring permissions."
@@ -446,7 +431,7 @@
                          vals
                          (map keys)
                          (apply concat))]
-    (when (some #{audit-db-id} changes-ids)
+    (when (some #{audit/audit-db-id} changes-ids)
       (throw (ex-info (tru
                        (str "Audit database permissions can only be changed by updating audit collection permissions."))
                       {:status-code 400})))))
@@ -458,24 +443,13 @@
     [:or [:= namespace-keyword nil] [:= namespace-keyword "analytics"]]
     [:= namespace-keyword namespace-val]))
 
-(defn is-collection-id-audit?
-  "Check if an id is one of the audit collection ids."
-  [id]
-  (contains? (set [(:id (default-audit-collection)) (:id (default-custom-reports-collection))]) id))
-
-(defn is-parent-collection-audit?
-  "Check if an instance's parent collection is the audit collection."
-  [instance]
-  (let [parent-id (:collection_id instance)]
-    (and (some? parent-id) (is-collection-id-audit? parent-id))))
-
 (defn can-read-audit-helper
-  "Audit instances should only be fetched if audit app is enabled."
+  "Audit instances should only be readable if audit app is enabled."
   [model instance]
   (if (and (not (premium-features/enable-audit-app?))
            (case model
-             :model/Collection (is-collection-id-audit? (:id instance))
-             (is-parent-collection-audit? instance)))
+             :model/Collection (audit/is-collection-id-audit? (:id instance))
+             (audit/is-parent-collection-audit? instance)))
     false
     (case model
       :model/Collection (mi/current-user-has-full-permissions? :read instance)

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -1,7 +1,7 @@
 (ns metabase.models.table
   (:require
    [metabase.api.common :as api]
-   [metabase.config :as config]
+   [metabase.audit :as audit]
    [metabase.db.query :as mdb.query]
    [metabase.driver :as driver]
    [metabase.models.audit-log :as audit-log]
@@ -10,8 +10,7 @@
    [metabase.models.interface :as mi]
    [metabase.models.permissions-group :as perms-group]
    [metabase.models.serialization :as serdes]
-   [metabase.public-settings.premium-features
-    :refer [defenterprise]]
+   [metabase.public-settings.premium-features :refer [defenterprise]]
    [metabase.util :as u]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
@@ -69,7 +68,7 @@
           non-magic-groups (perms-group/non-magic-groups)
           non-admin-groups (conj non-magic-groups all-users-group)]
       ;; Data access permissions
-      (if (= (:db_id table) config/audit-db-id)
+      (if (= (:db_id table) audit/audit-db-id)
         (do
          ;; Tables in audit DB should start out with no query access in all groups
          (data-perms/set-new-table-permissions! non-admin-groups table :perms/view-data :unrestricted)

--- a/src/metabase/query_processor/middleware/permissions.clj
+++ b/src/metabase/query_processor/middleware/permissions.clj
@@ -3,12 +3,12 @@
   (:require
    [metabase.api.common
     :refer [*current-user-id* *current-user-permissions-set*]]
+   [metabase.audit :as audit]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.models.data-permissions :as data-perms]
    [metabase.models.interface :as mi]
-   [metabase.models.permissions :as perms]
    [metabase.models.query.permissions :as query-perms]
    [metabase.public-settings.premium-features :refer [defenterprise]]
    [metabase.query-processor.error-type :as qp.error-type]
@@ -82,7 +82,7 @@
   (when *current-user-id*
     (log/tracef "Checking query permissions. Current user permissions = %s"
                 (pr-str (data-perms/permissions-for-user *current-user-id*)))
-    (when (= perms/audit-db-id database-id)
+    (when (= audit/audit-db-id database-id)
       (check-audit-db-permissions outer-query))
     (let [card-id (or *card-id* (:qp/source-card-id outer-query))
           required-perms (query-perms/required-perms outer-query :already-preprocessed? true)]

--- a/src/metabase/search/filter.clj
+++ b/src/metabase/search/filter.clj
@@ -13,10 +13,12 @@
    [clojure.set :as set]
    [clojure.string :as str]
    [honey.sql.helpers :as sql.helpers]
+   [metabase.audit :as audit]
    [metabase.driver.common.parameters.dates :as params.dates]
-   [metabase.models.permissions :as perms]
    [metabase.public-settings.premium-features :as premium-features]
-   [metabase.search.config :as search.config :refer [SearchableModel SearchContext]]
+   [metabase.search.config
+    :as search.config
+    :refer [SearchableModel SearchContext]]
    [metabase.search.util :as search.util]
    [metabase.util.date-2 :as u.date]
    [metabase.util.i18n :refer [tru]]
@@ -329,4 +331,4 @@
 
       (= "table" model)
       (sql.helpers/where
-       [:not [:= (search.config/column-with-model-alias "table" :db_id) perms/audit-db-id]]))))
+       [:not [:= (search.config/column-with-model-alias "table" :db_id) audit/audit-db-id]]))))

--- a/test/metabase/driver/sql_jdbc/connection_test.clj
+++ b/test/metabase/driver/sql_jdbc/connection_test.clj
@@ -3,6 +3,7 @@
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [metabase-enterprise.audit-app.audit :as ee-audit]
    [metabase.config :as config]
    [metabase.core :as mbc]
    [metabase.db :as mdb]
@@ -206,7 +207,7 @@
       (t2/delete! 'Database {:where [:= :is_audit true]})
       (let [status (mbc/ensure-audit-db-installed!)
             audit-db-id (t2/select-one-fn :id 'Database {:where [:= :is_audit true]})
-            _ (is (= :metabase-enterprise.audit-db/installed status))
+            _ (is (= ::ee-audit/installed status))
             _ (is (= 13371337 audit-db-id))
             first-pool (sql-jdbc.conn/db->pooled-connection-spec audit-db-id)
             second-pool (sql-jdbc.conn/db->pooled-connection-spec audit-db-id)]
@@ -304,24 +305,24 @@
               (mt/with-db db
                 (sync/sync-database! db)
                 (is (= {:cols [{:base_type    :type/Text
-                                  :effective_type :type/Text
-                                  :display_name "COL1"
-                                  :field_ref    [:field "COL1" {:base-type :type/Text}]
-                                  :name         "COL1"
-                                  :source       :native}
-                                 {:base_type    :type/Decimal
-                                  :effective_type :type/Decimal
-                                  :display_name "COL2"
-                                  :field_ref    [:field "COL2" {:base-type :type/Decimal}]
-                                  :name         "COL2"
-                                  :source       :native}]
-                          :rows [["First Row"  19.10M]
-                                 ["Second Row" 100.40M]
-                                 ["Third Row"  91884.10M]]}
-                         (-> {:query "SELECT col1, col2 FROM my_tbl;"}
-                             (mt/native-query)
-                             (qp/process-query)
-                             (qp.test-util/rows-and-cols))))))
+                                :effective_type :type/Text
+                                :display_name "COL1"
+                                :field_ref    [:field "COL1" {:base-type :type/Text}]
+                                :name         "COL1"
+                                :source       :native}
+                               {:base_type    :type/Decimal
+                                :effective_type :type/Decimal
+                                :display_name "COL2"
+                                :field_ref    [:field "COL2" {:base-type :type/Decimal}]
+                                :name         "COL2"
+                                :source       :native}]
+                        :rows [["First Row"  19.10M]
+                               ["Second Row" 100.40M]
+                               ["Third Row"  91884.10M]]}
+                       (-> {:query "SELECT col1, col2 FROM my_tbl;"}
+                           (mt/native-query)
+                           (qp/process-query)
+                           (qp.test-util/rows-and-cols))))))
             (finally (.stop ^Server server))))))))
 
 (deftest test-ssh-tunnel-reconnection-h2

--- a/test/metabase/driver/sql_jdbc/connection_test.clj
+++ b/test/metabase/driver/sql_jdbc/connection_test.clj
@@ -3,7 +3,6 @@
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [metabase-enterprise.audit-app.audit :as ee-audit]
    [metabase.config :as config]
    [metabase.core :as mbc]
    [metabase.db :as mdb]
@@ -207,7 +206,7 @@
       (t2/delete! 'Database {:where [:= :is_audit true]})
       (let [status (mbc/ensure-audit-db-installed!)
             audit-db-id (t2/select-one-fn :id 'Database {:where [:= :is_audit true]})
-            _ (is (= ::ee-audit/installed status))
+            _ (is (= :metabase-enterprise.audit-app.audit/installed status))
             _ (is (= 13371337 audit-db-id))
             first-pool (sql-jdbc.conn/db->pooled-connection-spec audit-db-id)
             second-pool (sql-jdbc.conn/db->pooled-connection-spec audit-db-id)]

--- a/test/metabase/lib/filter_test.cljc
+++ b/test/metabase/lib/filter_test.cljc
@@ -217,7 +217,7 @@
             [:ends-with
              {:lib/uuid "953597df-a96d-4453-a57b-665e845abc69"}
              [:field {:lib/uuid "be28f393-538a-406b-90da-bac5f8ef565e"} (meta/id :venues :name)]
-             "t"]))) ))
+             "t"])))))
 
 (deftest ^:parallel filterable-columns-test
   (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :users))
@@ -651,8 +651,8 @@
                  (lib/expression-clause :+
                                         [created-at
                                          (lib/expression-clause :interval [1 :month] nil)] nil)
-                  (lib/expression-clause :relative-datetime [-1 :month] nil)
-                  (lib/expression-clause :relative-datetime [0 :month] nil)],
+                 (lib/expression-clause :relative-datetime [-1 :month] nil)
+                 (lib/expression-clause :relative-datetime [0 :month] nil)],
         :name "Created At is in the previous month, starting 1 month ago"}
        {:clause [:time-interval created-at :current :day], :name "Created At is today"}
        {:clause [:time-interval created-at :current :week], :name "Created At is this week"}

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -5,11 +5,13 @@
    [clojure.test :refer :all]
    [java-time.api :as t]
    [metabase.api.common :as api]
+   [metabase.audit :as audit]
    [metabase.config :as config]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.jvm :as lib.metadata.jvm]
    [metabase.models.card :as card]
+   [metabase.models.interface :as mi]
    [metabase.models.revision :as revision]
    [metabase.models.serialization :as serdes]
    [metabase.query-processor.card-test :as qp.card-test]
@@ -1010,3 +1012,20 @@
                 (t2/hydrate card :can_run_adhoc_query)))
         (is (=? {:can_run_adhoc_query false}
                 (t2/hydrate no-query :can_run_adhoc_query)))))))
+
+(deftest audit-card-permisisons-test
+  (testing "Cards in audit collections are not readable or writable on OSS, even if they exist (#42645)"
+    ;; Here we're testing the specific scenario where an EE instance is downgraded to OSS, but still has the audit
+    ;; collections and cards installed. Since we can't load audit content on OSS, let's just redef the audit collection
+    ;; to a temp collection and ensure permission checks work properly.
+    (mt/with-premium-features #{}
+      (mt/with-temp [:model/Collection collection {}
+                     :model/Card       card       {:collection_id (:id collection)}]
+        (with-redefs [audit/default-audit-collection (constantly collection)]
+          (mt/with-test-user :rasta
+            (is (false? (mi/can-read? card)))
+            (is (false? (mi/can-write? card))))
+
+          (mt/with-test-user :crowberto
+            (is (false? (mi/can-read? card)))
+            (is (false? (mi/can-write? card)))))))))

--- a/test/metabase/models/collection/graph_test.clj
+++ b/test/metabase/models/collection/graph_test.clj
@@ -3,6 +3,7 @@
    [clojure.test :refer :all]
    [medley.core :as m]
    [metabase.api.common :refer [*current-user-id*]]
+   [metabase.audit :as audit]
    [metabase.models :refer [User]]
    [metabase.models.collection :as collection :refer [Collection]]
    [metabase.models.collection-permission-graph-revision
@@ -96,7 +97,7 @@
   (testing "Check that the audit collection has :read for admins."
     (mt/with-non-admin-groups-no-root-collection-perms
       (t2.with-temp/with-temp [Collection collection {}]
-        (with-redefs [perms/default-audit-collection (constantly collection)]
+        (with-redefs [audit/default-audit-collection (constantly collection)]
           (is (= {:revision 0
                   :groups   {(u/the-id (perms-group/all-users)) {:root :none,  :COLLECTION :none}
                              (u/the-id (perms-group/admin))     {:root :write, :COLLECTION :read}}}

--- a/test/metabase/models/collection_test.clj
+++ b/test/metabase/models/collection_test.clj
@@ -6,9 +6,16 @@
    [clojure.test :refer :all]
    [clojure.walk :as walk]
    [metabase.api.common :refer [*current-user-permissions-set*]]
+   [metabase.audit :as audit]
    [metabase.models
-    :refer [Card Collection Dashboard NativeQuerySnippet Permissions
-            PermissionsGroup Pulse User]]
+    :refer [Card
+            Collection
+            Dashboard
+            NativeQuerySnippet
+            Permissions
+            PermissionsGroup
+            Pulse
+            User]]
    [metabase.models.collection :as collection]
    [metabase.models.interface :as mi]
    [metabase.models.permissions :as perms]
@@ -748,7 +755,7 @@
 
   (testing "Let's make sure we get an Exception when we try to archive the Custom Reports Collection"
     (t2.with-temp/with-temp [Collection cr-collection {}]
-      (with-redefs [perms/default-custom-reports-collection (constantly cr-collection)]
+      (with-redefs [audit/default-custom-reports-collection (constantly cr-collection)]
         (is (thrown-with-msg?
              Exception
              #"You cannot archive the Custom Reports Collection."
@@ -1672,8 +1679,8 @@
                              Collection cr-collection    {}
                              Card       cr-card          {:collection_id (:id cr-collection)}
                              Dashboard  cr-dashboard     {:collection_id (:id cr-collection)}]
-      (with-redefs [perms/default-audit-collection          (constantly audit-collection)
-                    perms/default-custom-reports-collection (constantly cr-collection)]
+      (with-redefs [audit/default-audit-collection          (constantly audit-collection)
+                    audit/default-custom-reports-collection (constantly cr-collection)]
         (mt/with-current-user (mt/user->id :crowberto)
           (mt/with-additional-premium-features #{:audit-app}
             (is (not (mi/can-write? audit-collection))

--- a/test/metabase/models/data_permissions/graph_test.clj
+++ b/test/metabase/models/data_permissions/graph_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [clojure.walk :as walk]
-   [metabase.config :as config]
+   [metabase.audit :as audit]
    [metabase.models.data-permissions :as data-perms]
    [metabase.models.data-permissions.graph :as data-perms.graph]
    [metabase.models.permissions-group :as perms-group]
@@ -446,7 +446,7 @@
       (is (thrown-with-msg?
            Exception
            #"Audit database permissions can only be changed by updating audit collection permissions."
-           (data-perms.graph/update-data-perms-graph! [(u/the-id group) config/audit-db-id :data :schemas] :all))))))
+           (data-perms.graph/update-data-perms-graph! [(u/the-id group) audit/audit-db-id :data :schemas] :all))))))
 
 (deftest update-graph-validate-db-perms-test
   (testing "Check that validation of native query perms doesn't fail if only one of them changes"

--- a/test/metabase/search/filter_test.clj
+++ b/test/metabase/search/filter_test.clj
@@ -1,7 +1,7 @@
 (ns ^:mb/once metabase.search.filter-test
   (:require
    [clojure.test :refer :all]
-   [metabase.models.permissions :as perms]
+   [metabase.audit :as audit]
    [metabase.search.config :as search.config]
    [metabase.search.filter :as search.filter]
    [metabase.test :as mt]))
@@ -134,7 +134,7 @@
     (is (= [:and
             [:= :table.active true]
             [:= :table.visibility_type nil]
-            [:not [:= :table.db_id perms/audit-db-id]]]
+            [:not [:= :table.db_id audit/audit-db-id]]]
            (:where (search.filter/build-filters
                     base-search-query "table"  default-search-ctx))))))
 
@@ -142,7 +142,7 @@
   (is (contains?
          (set (:where (search.filter/build-filters
                        base-search-query "table"  default-search-ctx)))
-         [:not [:= :table.db_id perms/audit-db-id]])))
+         [:not [:= :table.db_id audit/audit-db-id]])))
 
 (deftest ^:parallel build-filter-with-search-string-test
   (testing "with search string"

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -12,6 +12,7 @@
    [environ.core :as env]
    [java-time.api :as t]
    [mb.hawk.parallel]
+   [metabase.audit :as audit]
    [metabase.config :as config]
    [metabase.db.query :as mdb.query]
    [metabase.models
@@ -688,7 +689,7 @@
 (defmethod with-model-cleanup-additional-conditions :model/Database
   [_]
   ;; Don't delete the audit database
-  [:not= :id perms/audit-db-id])
+  [:not= :id audit/audit-db-id])
 
 (defmulti with-max-model-id-additional-conditions
   "Additional conditions applied to the query to find the max ID for a model prior to a test run. This can be used to
@@ -706,7 +707,7 @@
 
 (defmethod with-max-model-id-additional-conditions :model/Database
   [_]
-  [:not= :id perms/audit-db-id])
+  [:not= :id audit/audit-db-id])
 
 (defn- model->model&pk [model]
   (if (vector? model)


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/42645

Permission checks for audit cards (i.e. `can-read?`) rely on having access to the audit collection IDs to tell whether a card is an audit card. But these collection IDs were in an EE namespace behind a `defenterprise`, and the OSS versions returned `nil` or `::noop`. This was fine for most cases, but if you installed audit content on an EE instance then downgraded to OSS, the perm check wouldn't work anymore. (There's still QP checks to prevent running queries against the audit DB on OSS instances, but this resulted in audit cards incorrectly appearing in the "add series" modal).

Changes in this PR:
* I've moved a number of vars & helper functions from `metabase.models.permissions` and `metabase-enterprise.audit-db` into a new `metabase.audit` namespace. We can also treat this as the API namespace for the audit submodule going forward. 
* I've moved `metabase-enterprise.audit-db` to `metabase-enterprise.audit-app.audit` since it's not only code related to the audit DB but also audit content loading. And we're supposed to be grouping EE code in directories by feature flag.
* Added a unit test for the specific permission checks that weren't working correctly in the original issue.
* Some misc cleanup/indentation fixes