### PR TITLE
Flaky test issue automation

### DIFF
--- a/.github/workflows/flake-issue-creator.yml
+++ b/.github/workflows/flake-issue-creator.yml
@@ -1,0 +1,34 @@
+name: Flake Issue Creator
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1-5' # every weekday at 1am US eastern time
+
+jobs:
+  flake-issue-creator:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        sparse-checkout: release
+    - name: Prepare build scripts
+      run: cd ${{ github.workspace }}/release && yarn --frozen-lockfile && yarn build
+    - name: Update flake issues
+      uses: actions/github-script@v7
+      env:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      with:
+        script: | # js
+          const { checkFlakes } = require('${{ github.workspace }}/release/dist/index.cjs');
+
+          if (!process.env.SLACK_BOT_TOKEN) {
+            throw new Error('SLACK_BOT_TOKEN is required');
+          }
+
+          await checkFlakes({
+            github,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+          });

--- a/.github/workflows/flake-issue-creator.yml
+++ b/.github/workflows/flake-issue-creator.yml
@@ -21,13 +21,13 @@ jobs:
         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       with:
         script: | # js
-          const { checkFlakes } = require('${{ github.workspace }}/release/dist/index.cjs');
+          const { updateFlakeIssues } = require('${{ github.workspace }}/release/dist/index.cjs');
 
           if (!process.env.SLACK_BOT_TOKEN) {
             throw new Error('SLACK_BOT_TOKEN is required');
           }
 
-          await checkFlakes({
+          await updateFlakeIssues({
             github,
             owner: context.repo.owner,
             repo: context.repo.repo,

--- a/.github/workflows/flake-status.yml
+++ b/.github/workflows/flake-status.yml
@@ -1,0 +1,35 @@
+name: Flake Status Report
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 2,5' # tuesdays and fridays at 6am US eastern time
+
+jobs:
+  flake-status-report:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        sparse-checkout: release
+    - name: Prepare build scripts
+      run: cd ${{ github.workspace }}/release && yarn --frozen-lockfile && yarn build
+    - name: Post Flake Status Report
+      uses: actions/github-script@v7
+      env:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      with:
+        script: | # js
+          const { summarizeFlakes } = require('${{ github.workspace }}/release/dist/index.cjs');
+
+          if (!process.env.SLACK_BOT_TOKEN) {
+            throw new Error('SLACK_BOT_TOKEN is required');
+          }
+
+          await summarizeFlakes({
+            github,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            channelName: 'engineering-ci'
+          });

--- a/.github/workflows/flake-status.yml
+++ b/.github/workflows/flake-status.yml
@@ -3,7 +3,7 @@ name: Flake Status Report
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 6 * * 2,5' # tuesdays and fridays at 6am US eastern time
+    - cron: '0 6 * * 2,5' # Tuesdays and Fridays at 1am US eastern time
 
 jobs:
   flake-status-report:

--- a/release/src/flakes-helpers.ts
+++ b/release/src/flakes-helpers.ts
@@ -1,0 +1,197 @@
+// note: this file really isn't release-related, but the build tooling here is helpful for it
+import type { Octokit } from '@octokit/rest';
+import dayjs from 'dayjs';
+import { match, P } from 'ts-pattern';
+import _ from 'underscore';
+import "dotenv/config";
+import "zx/globals";
+
+import { slackLink } from './slack';
+import type { Issue } from './types';
+
+export interface GithubProps {
+  owner: string;
+  repo: string;
+  github: Octokit;
+}
+
+export type FlakeData = {
+  suite_name: string;
+  test_name: string;
+  workflow_run_name: 'E2E Tests' | 'Frontend' | 'Backend' | 'Driver Tests';
+  workflow_job_name: string;
+  count: number; // last 7d
+  count_1d: number;
+  count_3d: number;
+  max: string; // last error run
+  max_2: string; // last error time
+  branch?: string;
+};
+
+const flakiestTestsQuestionId = 18032;
+const flakiestTestsOnMasterQuestionId = 18107;
+
+function getFlakeIssueTitle(testName: string) {
+  return `[Flaky Test]: ${testName}`;
+}
+
+async function getCardData(cardId: number): Promise<FlakeData[]> {
+  const cardData = await (await fetch(`https://stats.metabase.com/api/card/${cardId}/query`, {
+    method: 'POST',
+    // @ts-expect-error - ts doesn't know about custom headers 🙄
+    headers: {
+      'x-api-key': process.env.METABASE_API_KEY,
+    }
+  })).json();
+  const colNames = cardData.data.cols.map((col: any) => col.name);
+
+  const data: FlakeData[] = cardData.data.rows.map((row: any) => _.object(
+    colNames,
+    row,
+  ));
+
+  return data;
+}
+
+export async function getFlakeData() {
+  console.log('🔍 Fetching flake data');
+  const flakiestTests = await getCardData(flakiestTestsQuestionId).catch((err) => { console.error(err); return [] });
+  const flakiestTestsOnMaster = await getCardData(flakiestTestsOnMasterQuestionId);
+
+  const flakyTests = _.uniq([...flakiestTests, ...flakiestTestsOnMaster], false, (test) => test.test_name);
+  console.log(`  Found ${flakyTests.length} flaky tests`)
+  return flakyTests;
+}
+
+export function checkIfFlakeIssueExists({ flakeIssues, test }:  { flakeIssues: Issue[], test: FlakeData }) {
+  const expectedTitle = getFlakeIssueTitle(test.test_name);
+  return flakeIssues.find((issue) => issue.title === expectedTitle);
+}
+
+export async function getOpenFlakeIssues({github, owner, repo}: GithubProps) {
+  console.log(`🔍 Fetching flake issues`);
+
+  const issues = await github.paginate(github.rest.issues.listForRepo, {
+    owner,
+    repo,
+    labels: 'flaky-test-fix',
+    state: 'open',
+  });
+
+  console.log(`    Found ${issues.length} flake issues`);
+  return issues as Issue[];
+}
+
+export async function getRecentlyClosedFlakeIssues({github, owner, repo}: GithubProps) {
+  console.log(`🔍 Fetching recently closed flake issues`);
+
+  const issues = await github.paginate(github.rest.issues.listForRepo, {
+    owner,
+    repo,
+    since: dayjs().subtract(7, 'day').toISOString(),
+    labels: 'flaky-test-fix',
+    state: 'closed',
+  });
+
+  console.log(`    Found ${issues.length} recently closed flake issues`);
+  return issues as Issue[];
+}
+
+export function createFlakeIssue({ test, github, owner, repo }: GithubProps & { test: FlakeData }) {
+  const teamTag = assignToTeam(test);
+
+  console.log(`✅ Creating flake issue for${teamTag}\n    ${test.test_name}`)
+
+  return github.rest.issues.create({
+    owner,
+    repo,
+    title: getFlakeIssueTitle(test.test_name),
+    labels: ['flaky-test-fix', teamTag],
+    body: getFlakeInfoString({ test }),
+  });
+}
+
+export function updateFlakeIssue({ test, issue, github, owner, repo }: GithubProps & { test: FlakeData, issue: Issue }) {
+  // don't update issue if we haven't encountered new flakes in the last day
+  if (test.count_1d === 0) {
+    return;
+  }
+  const teamTag = assignToTeam(test);
+
+  console.log(`💁 Updating flake issue for${teamTag}\n    ${test.test_name}`);
+
+  return github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: issue.number,
+    body: `This test is still flaky\n\n${getFlakeInfoString({ test })}`,
+  });
+}
+
+function getFlakeInfoString({ test }: { test: FlakeData }) {
+  return `Last Flake: ${test.max}\nLast Flake Time: ${test.max_2}\nFlakes in the last day: ${test.count_1d}\nFlakes in the last 3d: ${test.count_3d}\nFlakes in the last 7d: ${test.count}`
+}
+
+const vizRegex = /dash|\bviz\b|visualization|chart/i;
+const queryRegex = /question|card|quer|notebook|model|metadata|filter/i;
+const adminRegex = /admin|permission|collection/i;
+const embedRegex = /embed|iframe/i;
+
+export function assignToTeam(test: FlakeData): string {
+  return match(test)
+    .with({ workflow_run_name: 'Driver Tests',  }, () => '.Team/QueryProcessor')
+    .with({ workflow_run_name: 'Backend' }, () => '.Team/BackendComponents')
+    .with({ suite_name: P.string.regex(embedRegex) }, () => '.Team/Embedding')
+    .with({ test_name: P.string.regex(embedRegex) }, () => '.Team/Embedding')
+    .with({ suite_name: P.string.regex(vizRegex) }, () => ".Team/DashViz")
+    .with({ test_name: P.string.regex(vizRegex) }, () => ".Team/DashViz")
+    .with({ suite_name: P.string.regex(adminRegex) }, () => ".Team/AdminWebapp")
+    .with({ test_name: P.string.regex(adminRegex) }, () => ".Team/AdminWebapp")
+    .with({ suite_name: P.string.regex(queryRegex) }, () => ".Team/QueryingComponents")
+    .with({ test_name: P.string.regex(queryRegex) }, () => ".Team/QueryingComponents")
+    .otherwise(() => '.Team/AdminWebapp');
+}
+
+export function countIssuesByTeam(issues: Issue[]): [string, number][] {
+  const flakeIssuesByTeam =  _.groupBy(issues, (issue: Issue) => {
+    if (Array.isArray(issue.labels)) {
+      const teamTag = issue.labels.find((label) => label.name?.startsWith('.Team/'));
+      return teamTag?.name || '.Team/Unknown Team';
+    }
+    return '.Team/Unknown Team';
+  });
+
+  return Object.entries(flakeIssuesByTeam)
+    .map(([team, issues]) => [team, issues.length])
+    .sort((a, b) => Number(b[1]) - Number(a[1])) as [string, number][];
+}
+
+export const summarizeOpenFlakes = async ({ owner, repo, github }: GithubProps) => {
+  const flakeIssues = await getOpenFlakeIssues({ github, owner, repo });
+
+  return countIssuesByTeam(flakeIssues)
+    .map(([team, issueCount]) => (
+      `${issueCount} flake issues open for ${flakyTestListLink(String(team))}`)
+    )
+    .filter(m => !m.includes('Unknown'))
+    .join('\n');
+}
+
+export const summarizeClosedFlakes = async ({ owner, repo, github }: GithubProps) => {
+  const flakeIssues = await getRecentlyClosedFlakeIssues({ github, owner, repo });
+
+  return countIssuesByTeam(flakeIssues)
+    .map(([team, issueCount]) => (
+      `${issueCount} flake issues closed by ${team.replace('.Team/', '')}`)
+    )
+    .filter(m => !m.includes('Unknown'))
+    .join('\n');
+}
+
+function flakyTestListLink(teamTag: string) {
+  const teamName = teamTag.replace('.Team/', '');
+  return slackLink(
+    teamName,
+    `https://github.com/metabase/metabase/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Aflaky-test-fix+label%3A.Team%2F${teamName}`
+  );
+}

--- a/release/src/flakes.ts
+++ b/release/src/flakes.ts
@@ -1,0 +1,134 @@
+// note: this file really isn't release-related, but the build tooling here is helpful for it
+import { Octokit } from '@octokit/rest';
+import { match, P } from 'ts-pattern';
+import _ from 'underscore';
+import "dotenv/config";
+import "zx/globals";
+
+interface GithubProps {
+  owner: string;
+  repo: string;
+  github: Octokit;
+}
+
+const github = new Octokit({
+  auth: process.env.GITHUB_TOKEN,
+});
+
+export type FlakeData = {
+  suite_name: string;
+  test_name: string;
+  workflow_run_name: 'E2E Tests' | 'Frontend' | 'Backend' | 'Driver Tests';
+  workflow_job_name: string;
+  count: number; // last 7d
+  count_1d: number;
+  count_3d: number;
+  max: string; // last error run
+  max_2: string; // last error time
+  branch?: string;
+};
+
+const flakiestTestsQuestionId = 18032;
+const flakiestTestsOnMasterQuestionId = 18107;
+
+export async function checkFlakes({
+  owner,
+  repo,
+  github
+}: GithubProps) {
+  const flakeData = await getFlakeData();
+  const flakeIssues = await getFlakeIssues({ github, owner, repo });
+
+  for (const flake of flakeData) { // use a for loop to avoid rate limiting
+    const issue = checkIfFlakeIssueExists({ test: flake, flakeIssues });
+    // TODO check if issue recently closed
+
+    if (!issue) {
+      await createFlakeIssue({ test: flake, github, owner, repo });
+    } else {
+      console.log(`🤫 Flake issue already exists for\n    ${flake.test_name}`);
+      // maybe comment that it's still flaky?
+    }
+  }
+}
+
+function getFlakeIssueTitle(testName: string) {
+  return `[Flaky Test]: ${testName}`;
+}
+
+async function getCardData(cardId: number): Promise<FlakeData[]> {
+  const cardData = await (await fetch(`https://stats.metabase.com/api/card/${cardId}/query`, {
+    method: 'POST',
+    // @ts-expect-error - ts doesn't know about custom headers
+    headers: {
+      'x-api-key': process.env.METABASE_API_KEY,
+    }
+  })).json();
+  const colNames = cardData.data.cols.map((col: any) => col.name);
+
+  const data: FlakeData[] = cardData.data.rows.map((row: any) => _.object(
+    colNames,
+    row,
+  ));
+
+  return data;
+}
+
+async function getFlakeData() {
+  const flakiestTests = await getCardData(flakiestTestsQuestionId);
+  const flakiestTestsOnMaster = await getCardData(flakiestTestsOnMasterQuestionId);
+
+  return _.uniq([...flakiestTests, ...flakiestTestsOnMaster], false, (test) => test.test_name);
+}
+
+function checkIfFlakeIssueExists({ flakeIssues, test }:  { flakeIssues: { title: string; }[], test: FlakeData }) {
+  const expectedTitle = getFlakeIssueTitle(test.test_name);
+  return flakeIssues.some((issue) => issue.title === expectedTitle);
+}
+
+async function getFlakeIssues({github, owner, repo}: GithubProps) {
+  const title = getFlakeIssueTitle('');
+  const { data: { items } } = await github.rest.search.issuesAndPullRequests({
+    q: `repo:${owner}/${repo} type:issue is:open in:title ${title}`,
+    per_page: 100,
+  });
+
+  return items.filter((issue) => issue.title.includes(title));
+}
+
+function createFlakeIssue({ test, github, owner, repo }: GithubProps & { test: FlakeData }) {
+  const teamTag = assignToTeam(test);
+
+  console.log(`✅ Creating flake issue for${teamTag}\n    ${test.test_name}`)
+
+  return github.issues.create({
+    owner,
+    repo,
+    title: getFlakeIssueTitle(test.test_name),
+    labels: ['flaky-test-fix', teamTag],
+    body: `Last Flake: ${test.max}\nLast Flake Time: ${test.max_2}\nFlakes in the last day: ${test.count_1d}\nFlakes in the last 3d: ${test.count_3d}\nFlakes in the last 7d: ${test.count}`
+  });
+}
+
+const vizRegex = /dash|\bviz\b|visualization|chart/i;
+const queryRegex = /question|card|quer|notebook|model|metadata|filter/i;
+const adminRegex = /admin|permission|collection/i;
+const embedRegex = /embed|iframe/i;
+
+export function assignToTeam(test: FlakeData): string {
+  return match(test)
+    .with({ workflow_run_name: 'Driver Tests',  }, () => '.Team/QueryProcessor')
+    .with({ workflow_run_name: 'Backend' }, () => '.Team/BackendComponents')
+    .with({ suite_name: P.string.regex(embedRegex) }, () => '.Team/Embedding')
+    .with({ test_name: P.string.regex(embedRegex) }, () => '.Team/Embedding')
+    .with({ suite_name: P.string.regex(vizRegex) }, () => ".Team/DashViz")
+    .with({ test_name: P.string.regex(vizRegex) }, () => ".Team/DashViz")
+    .with({ suite_name: P.string.regex(adminRegex) }, () => ".Team/AdminWebapp")
+    .with({ test_name: P.string.regex(adminRegex) }, () => ".Team/AdminWebapp")
+    .with({ suite_name: P.string.regex(queryRegex) }, () => ".Team/QueryingComponents")
+    .with({ test_name: P.string.regex(queryRegex) }, () => ".Team/QueryingComponents")
+    .otherwise(() => '.Team/AdminWebapp');
+}
+
+// Test Code
+// checkFlakes({ owner: 'metabase', repo: 'metabase', github })

--- a/release/src/flakes.ts
+++ b/release/src/flakes.ts
@@ -127,7 +127,7 @@ async function getRecentlyClosedFlakeIssues({github, owner, repo}: GithubProps) 
   const issues = await github.paginate(github.rest.issues.listForRepo, {
     owner,
     repo,
-    since: dayjs().subtract(3, 'day').toISOString(),
+    since: dayjs().subtract(7, 'day').toISOString(), // is 1 week too long?
     labels: 'flaky-test-fix',
     state: 'closed',
   });

--- a/release/src/flakes.ts
+++ b/release/src/flakes.ts
@@ -1,61 +1,47 @@
 // note: this file really isn't release-related, but the build tooling here is helpful for it
-import { Octokit } from '@octokit/rest';
-import dayjs from 'dayjs';
-import { match, P } from 'ts-pattern';
 import _ from 'underscore';
 import "dotenv/config";
 import "zx/globals";
 
-import { sendFlakeStatusReport, slackLink } from './slack';
-import type { Issue } from './types';
+import type { GithubProps } from './flakes-helpers';
+import {
+  getFlakeData,
+  getOpenFlakeIssues,
+  createFlakeIssue,
+  updateFlakeIssue,
+  getRecentlyClosedFlakeIssues,
+  checkIfFlakeIssueExists,
+  summarizeOpenFlakes,
+  summarizeClosedFlakes,
+} from './flakes-helpers';
+import { sendFlakeStatusReport } from './slack';
 
-interface GithubProps {
-  owner: string;
-  repo: string;
-  github: Octokit;
-}
-
-const github = new Octokit({
-  auth: process.env.GITHUB_TOKEN,
-});
-
-export type FlakeData = {
-  suite_name: string;
-  test_name: string;
-  workflow_run_name: 'E2E Tests' | 'Frontend' | 'Backend' | 'Driver Tests';
-  workflow_job_name: string;
-  count: number; // last 7d
-  count_1d: number;
-  count_3d: number;
-  max: string; // last error run
-  max_2: string; // last error time
-  branch?: string;
-};
-
-const flakiestTestsQuestionId = 18032;
-const flakiestTestsOnMasterQuestionId = 18107;
-
-export async function checkFlakes({
+/**
+ * Creates new github issues for newly-appearing flakes, updates github issues for persistent flakes,
+ * should skip creating issues for recently closed flakes
+ */
+export async function updateFlakeIssues({
   owner,
   repo,
   github
 }: GithubProps) {
   const flakeData = await getFlakeData();
-  const flakeIssues = await getOpenFlakeIssues({ github, owner, repo });
+  const openFlakeIssues = await getOpenFlakeIssues({ github, owner, repo });
   const recentlyClosedFlakeIssues = await getRecentlyClosedFlakeIssues({ github, owner, repo });
 
   for (const flake of flakeData) { // use a for loop to avoid rate limiting
-    const flakeIssue = checkIfFlakeIssueExists({ test: flake, flakeIssues });
-    const flakeIssueRecentlyClosed = checkIfFlakeIssueRecentlyClosed({ test: flake, flakeIssues: recentlyClosedFlakeIssues });
+    const flakeIssueRecentlyClosed = checkIfFlakeIssueExists({ test: flake, flakeIssues: recentlyClosedFlakeIssues });
 
     if (flakeIssueRecentlyClosed) {
       console.log(`🙈 Flake issue was recently closed for\n    ${flake.test_name}`);
       continue;
     }
 
-    if (flakeIssue) {
+    const openFlakeIssue = checkIfFlakeIssueExists({ test: flake, flakeIssues: openFlakeIssues });
+
+    if (openFlakeIssue) {
       console.log(`🤫 Flake issue already exists for\n    ${flake.test_name}`);
-      await updateFlakeIssue({ test: flake, issue: flakeIssue, github, owner, repo });
+      await updateFlakeIssue({ test: flake, issue: openFlakeIssue, github, owner, repo });
       continue;
     }
 
@@ -63,177 +49,10 @@ export async function checkFlakes({
   }
 }
 
-function getFlakeIssueTitle(testName: string) {
-  return `[Flaky Test]: ${testName}`;
-}
-
-async function getCardData(cardId: number): Promise<FlakeData[]> {
-  const cardData = await (await fetch(`https://stats.metabase.com/api/card/${cardId}/query`, {
-    method: 'POST',
-    // @ts-expect-error - ts doesn't know about custom headers
-    headers: {
-      'x-api-key': process.env.METABASE_API_KEY,
-    }
-  })).json();
-  const colNames = cardData.data.cols.map((col: any) => col.name);
-
-  const data: FlakeData[] = cardData.data.rows.map((row: any) => _.object(
-    colNames,
-    row,
-  ));
-
-  return data;
-}
-
-async function getFlakeData() {
-  console.log('🔍 Fetching flake data');
-  const flakiestTests = await getCardData(flakiestTestsQuestionId).catch((err) => { console.error(err); return [] });
-  const flakiestTestsOnMaster = await getCardData(flakiestTestsOnMasterQuestionId);
-
-  const flakyTests = _.uniq([...flakiestTests, ...flakiestTestsOnMaster], false, (test) => test.test_name);
-  console.log(`  Found ${flakyTests.length} flaky tests`)
-  return flakyTests;
-}
-
-function checkIfFlakeIssueExists({ flakeIssues, test }:  { flakeIssues: Issue[], test: FlakeData }) {
-  const expectedTitle = getFlakeIssueTitle(test.test_name);
-  return flakeIssues.find((issue) => issue.title === expectedTitle);
-}
-
-function checkIfFlakeIssueRecentlyClosed({ flakeIssues, test }:  { flakeIssues: Issue[], test: FlakeData }) {
-  const expectedTitle = getFlakeIssueTitle(test.test_name);
-  return flakeIssues.find((issue) => issue.title === expectedTitle);
-}
-
-async function getOpenFlakeIssues({github, owner, repo}: GithubProps) {
-  console.log(`🔍 Fetching flake issues`);
-
-  // we have to use paginate function or the issues will be truncated to 100
-  const issues = await github.paginate(github.rest.issues.listForRepo, {
-    owner,
-    repo,
-    labels: 'flaky-test-fix',
-    state: 'open',
-  });
-
-  console.log(`    Found ${issues.length} flake issues`);
-  return issues as Issue[];
-}
-
-async function getRecentlyClosedFlakeIssues({github, owner, repo}: GithubProps) {
-  console.log(`🔍 Fetching recently closed flake issues`);
-
-  //we have to use paginate function or the issues will be truncated to 100
-  const issues = await github.paginate(github.rest.issues.listForRepo, {
-    owner,
-    repo,
-    since: dayjs().subtract(7, 'day').toISOString(), // is 1 week too long?
-    labels: 'flaky-test-fix',
-    state: 'closed',
-  });
-
-  console.log(`    Found ${issues.length} recently closed flake issues`);
-  return issues as Issue[];
-}
-
-function createFlakeIssue({ test, github, owner, repo }: GithubProps & { test: FlakeData }) {
-  const teamTag = assignToTeam(test);
-
-  console.log(`✅ Creating flake issue for${teamTag}\n    ${test.test_name}`)
-
-  return github.issues.create({
-    owner,
-    repo,
-    title: getFlakeIssueTitle(test.test_name),
-    labels: ['flaky-test-fix', teamTag],
-    body: getFlakeInfoString({ test }),
-  });
-}
-
-function updateFlakeIssue({ test, issue, github, owner, repo }: GithubProps & { test: FlakeData, issue: Issue }) {
-  if (test.count_1d === 0) {
-    return;
-  }
-  const teamTag = assignToTeam(test);
-
-  console.log(`💁 Updating flake issue for${teamTag}\n    ${test.test_name}`);
-
-  return github.rest.issues.createComment({
-    owner,
-    repo,
-    issue_number: issue.number,
-    body: `This test is still flaky\n\n${getFlakeInfoString({ test })}`,
-  });
-}
-
-function getFlakeInfoString({ test }: { test: FlakeData }) {
-  return `Last Flake: ${test.max}\nLast Flake Time: ${test.max_2}\nFlakes in the last day: ${test.count_1d}\nFlakes in the last 3d: ${test.count_3d}\nFlakes in the last 7d: ${test.count}`
-}
-
-const vizRegex = /dash|\bviz\b|visualization|chart/i;
-const queryRegex = /question|card|quer|notebook|model|metadata|filter/i;
-const adminRegex = /admin|permission|collection/i;
-const embedRegex = /embed|iframe/i;
-
-export function assignToTeam(test: FlakeData): string {
-  return match(test)
-    .with({ workflow_run_name: 'Driver Tests',  }, () => '.Team/QueryProcessor')
-    .with({ workflow_run_name: 'Backend' }, () => '.Team/BackendComponents')
-    .with({ suite_name: P.string.regex(embedRegex) }, () => '.Team/Embedding')
-    .with({ test_name: P.string.regex(embedRegex) }, () => '.Team/Embedding')
-    .with({ suite_name: P.string.regex(vizRegex) }, () => ".Team/DashViz")
-    .with({ test_name: P.string.regex(vizRegex) }, () => ".Team/DashViz")
-    .with({ suite_name: P.string.regex(adminRegex) }, () => ".Team/AdminWebapp")
-    .with({ test_name: P.string.regex(adminRegex) }, () => ".Team/AdminWebapp")
-    .with({ suite_name: P.string.regex(queryRegex) }, () => ".Team/QueryingComponents")
-    .with({ test_name: P.string.regex(queryRegex) }, () => ".Team/QueryingComponents")
-    .otherwise(() => '.Team/AdminWebapp');
-}
-
-const summarizeOpenFlakes = async ({ owner, repo, github }: GithubProps) => {
-  const flakeIssues = await getOpenFlakeIssues({ github, owner, repo });
-
-  const flakeIssuesByTeam = _.groupBy(flakeIssues, (issue) => {
-    const teamTag = issue.labels.find((label) => label.name.startsWith('.Team/'));
-    return teamTag?.name || '.Team/Unknown Team';
-  });
-
-  return Object.entries(flakeIssuesByTeam)
-    .map(([team, issues]) => [team, issues.length])
-    .sort((a: [string, number], b: [string, number]) => b[1] - a[1])
-    .map(([team, issueCount]) => (
-      `${issueCount} flake issues open for ${flakyTestListLink(team)}`)
-    )
-    .filter(m => !m.includes('Unknown'))
-    .join('\n');
-}
-
-const summarizeClosedFlakes = async ({ owner, repo, github }: GithubProps) => {
-  const flakeIssues = await getRecentlyClosedFlakeIssues({ github, owner, repo });
-
-  const flakeIssuesByTeam = _.groupBy(flakeIssues, (issue) => {
-    const teamTag = issue.labels.find((label) => label.name.startsWith('.Team/'));
-    return teamTag?.name || '.Team/Unknown Team';
-  });
-
-  return Object.entries(flakeIssuesByTeam)
-    .map(([team, issues]) => [team, issues.length])
-    .sort((a, b) => b[1] - a[1])
-    .map(([team, issueCount]) => (
-      `${issueCount} flake issues closed by ${team.replace('.Team/', '')}`)
-    )
-    .filter(m => !m.includes('Unknown'))
-    .join('\n');
-}
-
-function flakyTestListLink(teamTag: string) {
-  const teamName = teamTag.replace('.Team/', '');
-  return slackLink(
-    teamName,
-    `https://github.com/metabase/metabase/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Aflaky-test-fix+label%3A.Team%2F${teamName}`
-  );
-}
-
+/**
+ * Sends a slack message summarizing all open flake issues by team and commending the brave souls who have
+ * recently closed flake issues
+ */
 export async function summarizeFlakes({ owner, repo, github, channelName }: GithubProps & { channelName: string}) {
   const openFlakeInfo = await summarizeOpenFlakes({ owner, repo, github });
   const closedFlakeInfo = await summarizeClosedFlakes({ owner, repo, github });
@@ -244,8 +63,3 @@ export async function summarizeFlakes({ owner, repo, github, channelName }: Gith
     closedFlakeInfo,
   });
 }
-
-// Test Code
-// checkFlakes({ owner: 'metabase', repo: 'metabase', github })
-// summarizeFlakes({ owner: 'metabase', repo: 'metabase', github, channelName: 'bot-testing' })
-

--- a/release/src/flakes.unit.spec.ts
+++ b/release/src/flakes.unit.spec.ts
@@ -1,0 +1,37 @@
+import type { FlakeData} from './flakes';
+import { assignToTeam } from './flakes';
+
+const createFlakeIssue = (data: Partial<FlakeData>): FlakeData => {
+  return {
+    test_name: '',
+    suite_name: '',
+    workflow_run_name: 'E2E Tests',
+    workflow_job_name: '',
+    max: '',
+    max_2: '',
+    count: 0,
+    count_1d: 0,
+    count_3d: 0,
+    ...data,
+  }
+}
+
+describe('flake issue creator', () => {
+  describe('team assigner', () => {
+    const testData: [Partial<FlakeData>, string][] = [
+      [{ test_name: 'foo' }, '.Team/AdminWebapp'],
+      [{ workflow_run_name: 'Driver Tests' }, '.Team/QueryProcessor'],
+      [{ workflow_run_name: 'Backend' }, '.Team/BackendComponents'],
+      [{ test_name: 'should fix all the viz problems' }, '.Team/DashViz'],
+      [{ test_name: 'should make dashboards go vroom' }, '.Team/DashViz'],
+      [{ test_name: 'questions should have data' }, '.Team/QueryingComponents'],
+      [{ test_name: 'queries should finish in a reasonable amount of time' }, '.Team/QueryingComponents'],
+      [{ test_name: 'collections should not delete themselves' }, '.Team/AdminWebapp'],
+      [{ test_name: 'permissions should let people in' }, '.Team/AdminWebapp'],
+    ];
+
+    it.each(testData)('should assign the flake to the correct team: %s : %s', (data, team) => {
+      expect(assignToTeam(createFlakeIssue(data))).toEqual(team);
+    });
+  })
+})

--- a/release/src/index.ts
+++ b/release/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./backports";
+export * from "./flakes";
 export * from "./github";
 export * from "./linked-issues";
 export * from "./milestones";

--- a/release/src/slack.ts
+++ b/release/src/slack.ts
@@ -208,7 +208,7 @@ async function sendSlackReply({ channelName, message, messageId, broadcast }: {c
 const getReleaseTitle = (version: string) =>
   `:rocket: *${getGenericVersion(version)} Release* :rocket:`;
 
-function slackLink(text: string, url: string) {
+export function slackLink(text: string, url: string) {
   return `<${url}|${text}>`;
 }
 
@@ -340,4 +340,53 @@ export async function sendPublishCompleteMessage({
     message: `:partydeploy: *Metabase ${getGenericVersion(version)} has been released!* :partydeploy:\n\nSee the ${slackLink('full release notes here', `https://github.com/${owner}/${repo}/releases`)}.`,
     channelName: generalChannelName,
   });
+}
+
+export async function sendFlakeStatusReport({
+  channelName, openFlakeInfo, closedFlakeInfo,
+}: {
+  channelName: string,
+  openFlakeInfo: string,
+  closedFlakeInfo: string,
+}) {
+    const blocks = [
+      {
+        "type": "header",
+        "text": {
+          "type": "plain_text",
+          "text": `:croissant: Flaky Tests Status :croissant:`,
+          "emoji": true
+        }
+      },
+    ];
+
+    const attachments = [
+      {
+        "color": "#46ad1a",
+        "blocks": [{
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": `:muscle: *Recently Closed Flakes*\n ${closedFlakeInfo}`,
+          }
+        }],
+      },
+      {
+        "color": "#d9bb34",
+        "blocks": [{
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": `:clipboard: *Open Flakes*\n ${openFlakeInfo}`,
+          }
+        }],
+      },
+    ];
+
+    return slack.chat.postMessage({
+      channel: channelName,
+      blocks,
+      attachments,
+      text: `Flaky issue summary`,
+    });
 }

--- a/release/src/types.ts
+++ b/release/src/types.ts
@@ -41,7 +41,7 @@ export type Issue = {
   number: number;
   title: string;
   html_url: string;
-  labels: string | { name?: string }[];
+  labels: string | ({ name?: string }[]);
   assignee: null |  { login: string };
   created_at: string;
 };


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/43594

### Description

### Flake Issue Creator

This script is intended to be run nightly, and pulls data from our metabase instance on flaky tests, and uses that to create github issues to fix those flaky tests, if none already exist for that test. 

![Screen Shot 2024-06-07 at 4 09 54 PM](https://github.com/metabase/metabase/assets/30528226/6a8abb69-db7b-4226-a8a8-9c2d751478ba)

If it finds an issue that remains flaky, it will post update comments with updated flake information.

![Screen Shot 2024-06-07 at 4 10 16 PM](https://github.com/metabase/metabase/assets/30528226/274ac05b-c802-4ac9-bf1c-68f7d1e40fe9)

### Flake Summary Message

Probably weekly, send a message showing numbers of recentlly fixed flakes and open flake issues to bring visibility to the flake situation.

![Screen Shot 2024-06-07 at 3 44 52 PM](https://github.com/metabase/metabase/assets/30528226/5b5a75a1-6add-4746-89af-71d9fbb10b5f)

