### PR TITLE
Fix use of guard in match and replace

### DIFF
--- a/src/metabase/lib/query.cljc
+++ b/src/metabase/lib/query.cljc
@@ -113,7 +113,7 @@
   (if-let [field-ids (lib.util.match/match x
                        [:field
                         (_options :guard (every-pred map? (complement (every-pred :base-type :effective-type))))
-                        (id :guard integer? pos?)]
+                        (id :guard (every-pred integer? pos?))]
                        (when-not (some #{:mbql/stage-metadata} &parents)
                          id))]
     ;; "pre-warm" the metadata provider
@@ -122,7 +122,7 @@
          x
          [:field
           (options :guard (every-pred map? (complement (every-pred :base-type :effective-type))))
-          (id :guard integer? pos?)]
+          (id :guard (every-pred integer? pos?))]
          (if (some #{:mbql/stage-metadata} &parents)
            &match
            (update &match 1 merge


### PR DESCRIPTION
During backport review (PR #43358) it turned out that that use of `:guard` in match and replace was incorrect. This PR fixes that in master.

WIP kondo linter