### PR TITLE
[serdes] do not output exceptions used only for api tests

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/api.clj
@@ -26,6 +26,10 @@
 
 (set! *warn-on-reflection* true)
 
+(def ^:dynamic *additive-logging*
+  "If custom loggers should pass logs to parent loggers (to system Metabase logs), used to clean up test output."
+  true)
+
 ;;; Storage
 
 (def parent-dir "Dir for storing serialization API export-in-progress and archives."
@@ -69,7 +73,8 @@
         dst      (io/file (str (.getPath path) ".tar.gz"))
         log-file (io/file path "export.log")
         err      (atom nil)
-        report   (with-open [_logger (logger/for-ns 'metabase-enterprise.serialization log-file)]
+        report   (with-open [_logger (logger/for-ns 'metabase-enterprise.serialization log-file
+                                                    {:additive *additive-logging*})]
                    (try                 ; try/catch inside logging to log errors
                      (let [report (serdes/with-cache
                                     (-> (extract/extract opts)
@@ -96,7 +101,8 @@
   (let [dst      (io/file parent-dir (u.random/random-name))
         log-file (io/file dst "import.log")
         err      (atom nil)
-        report   (with-open [_logger (logger/for-ns 'metabase-enterprise.serialization log-file)]
+        report   (with-open [_logger (logger/for-ns 'metabase-enterprise.serialization log-file
+                                                    {:additive *additive-logging*})]
                    (try                 ; try/catch inside logging to log errors
                      (log/infof "Serdes import, size %s" size)
                      (let [path (u.compress/untgz file dst)]

--- a/src/metabase/logger.clj
+++ b/src/metabase/logger.clj
@@ -119,7 +119,7 @@
   "Create separate logger for a given namespace to fork out some logs."
   ^AutoCloseable [ns out & [{:keys [additive level]
                              :or   {additive true
-                                    level Level/INFO}}]]
+                                    level    Level/INFO}}]]
   (let [config        (configuration)
         parent-logger (effective-ns-logger ns)
         appender      (make-appender out (logger-name ns) (find-logger-layout parent-logger))


### PR DESCRIPTION
makes for a cleaner and less confusing test output