### PR TITLE
Upgrade to TypeScript v5.4

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -16,6 +16,9 @@ module.exports = {
     "@storybook/addon-a11y",
   ],
   babel: () => {},
+  typescript: {
+    reactDocgen: "react-docgen-typescript-plugin",
+  },
   webpackFinal: storybookConfig => ({
     ...storybookConfig,
     plugins: [

--- a/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentWrapper/withPublicComponentWrapper.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentWrapper/withPublicComponentWrapper.tsx
@@ -2,7 +2,7 @@ import type { ComponentType } from "react";
 
 import { PublicComponentWrapper } from "./PublicComponentWrapper";
 
-export function withPublicComponentWrapper<P>(
+export function withPublicComponentWrapper<P extends object>(
   WrappedComponent: ComponentType<P>,
 ): React.FC<P> {
   const WithPublicComponentWrapper: React.FC<P> = props => {

--- a/enterprise/frontend/src/embedding-sdk/hooks/private/use-init-data.ts
+++ b/enterprise/frontend/src/embedding-sdk/hooks/private/use-init-data.ts
@@ -73,7 +73,7 @@ export const useInitData = ({ config }: InitDataLoaderParameters) => {
         try {
           const [userResponse, siteSettingsResponse] = await Promise.all([
             dispatch(refreshCurrentUser()),
-            dispatch(refreshSiteSettings()),
+            dispatch(refreshSiteSettings({})),
           ]);
 
           if (

--- a/frontend/src/metabase-lib/filter.ts
+++ b/frontend/src/metabase-lib/filter.ts
@@ -379,8 +379,14 @@ export function relativeDateFilterClause({
       columnWithoutBucket,
       expressionClause("interval", [-offsetValue, offsetBucket]),
     ]),
-    expressionClause("relative-datetime", [value < 0 ? value : 0, bucket]),
-    expressionClause("relative-datetime", [value > 0 ? value : 0, bucket]),
+    expressionClause("relative-datetime", [
+      value !== "current" && value < 0 ? value : 0,
+      bucket,
+    ]),
+    expressionClause("relative-datetime", [
+      value !== "current" && value > 0 ? value : 0,
+      bucket,
+    ]),
   ]);
 }
 

--- a/frontend/src/metabase/admin/people/containers/AdminPeopleApp.tsx
+++ b/frontend/src/metabase/admin/people/containers/AdminPeopleApp.tsx
@@ -10,7 +10,8 @@ import { useSelector } from "metabase/lib/redux";
 import { LeftNavWrapper } from "./AdminPeopleApp.styled";
 
 export const AdminPeopleApp = ({ children }: { children: React.ReactNode }) => {
-  const shouldNudge = useSelector(shouldNudgeToPro);
+  const shouldNudge = useSelector(shouldNudgeToPro) as boolean;
+
   return (
     <AdminLayout
       sidebar={

--- a/frontend/src/metabase/core/components/TabRow/TabRow.tsx
+++ b/frontend/src/metabase/core/components/TabRow/TabRow.tsx
@@ -64,7 +64,6 @@ function TabRowInner<T>({
         return;
       }
       const left = width * (direction === "left" ? -1 : 1);
-      // @ts-expect-error — https://github.com/Microsoft/TypeScript/issues/28755
       tabListRef.current.scrollBy?.({ left, behavior: "instant" });
     },
     [width],

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarLink.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarLink.tsx
@@ -19,7 +19,7 @@ import {
 interface SidebarLinkProps {
   children: string;
   url?: string;
-  icon?: IconName | IconProps | React.ReactElement;
+  icon?: IconName | IconProps;
   isSelected?: boolean;
   hasDefaultIconStyle?: boolean;
   left?: React.ReactNode;
@@ -31,9 +31,7 @@ type ContentProps = {
   children: React.ReactNode;
 };
 
-function isIconPropsObject(
-  icon: string | IconProps | React.ReactNode,
-): icon is IconProps {
+function isIconPropsObject(icon: string | IconProps): icon is IconProps {
   return _.isObject(icon);
 }
 

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "tether": "^1.2.0",
     "tippy.js": "^6.3.5",
     "ttag": "1.7.21",
+    "typescript": "^5.4.5",
     "underscore": "~1.13.3",
     "use-debounce": "^10.0.0",
     "yup": "^0.32.11"
@@ -286,7 +287,6 @@
     "stylelint-config-css-modules": "^4.4.0",
     "stylelint-config-standard": "^36.0.0",
     "terser-webpack-plugin": "^5.3.9",
-    "typescript": "^4.7.2",
     "webpack": "^5.85.0",
     "webpack-bundle-analyzer": "^4.10.1",
     "webpack-cli": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -279,6 +279,7 @@
     "prettier": "^2.7.1",
     "promise-loader": "^1.0.0",
     "raf": "^3.4.0",
+    "react-docgen-typescript-plugin": "^1.0.6",
     "react-refresh": "^0.13.0",
     "reg-cli": "^0.17.7",
     "shadow-cljs": "2.27.4",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,6 +5,7 @@
     "allowSyntheticDefaultImports": true,
     "module": "commonjs",
     "isolatedModules": true,
+    "ignoreDeprecations": "5.0",
     "importsNotUsedAsValues": "error",
     "strict": true,
     "moduleResolution": "node",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19323,7 +19323,20 @@ react-dnd@4:
     lodash "^4.17.10"
     shallowequal "^1.0.2"
 
-react-docgen-typescript@^2.1.1:
+react-docgen-typescript-plugin@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/react-docgen-typescript-plugin/-/react-docgen-typescript-plugin-1.0.6.tgz#bd036cd22ca437ddce253f212861e2253401a6f1"
+  integrity sha512-01ju9lihtH9G+q1jhyi2HEhNfPeQwmNe6zxrSQCGnL3fiBGUZve5Ll4voxIExMhsjEcmJtpmNr1J3FeBd+6PBw==
+  dependencies:
+    debug "^4.1.1"
+    endent "^2.0.1"
+    find-cache-dir "^3.3.1"
+    flat-cache "^3.0.4"
+    micromatch "^4.0.2"
+    react-docgen-typescript "^2.2.2"
+    tslib "^2.6.2"
+
+react-docgen-typescript@^2.1.1, react-docgen-typescript@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-2.2.2.tgz#4611055e569edc071204aadb20e1c93e1ab1659c"
   integrity sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==
@@ -22585,6 +22598,11 @@ tslib@^2.1.0, tslib@^2.4.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
+
+tslib@^2.6.2:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.3.tgz#0438f810ad7a9edcde7a241c3d80db693c8cbfe0"
+  integrity sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==
 
 tsutils@^3.21.0:
   version "3.21.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -22758,10 +22758,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.7.2:
-  version "4.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.2.tgz#1f9aa2ceb9af87cca227813b4310fff0b51593c4"
-  integrity sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==
+typescript@^5.4.5:
+  version "5.4.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.5.tgz#42ccef2c571fdbd0f6718b1d1f5e6e5ef006f611"
+  integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==
 
 uglify-js@^3.1.4:
   version "3.14.1"


### PR DESCRIPTION
### Description

Upgrades us to TypeScript v5.4. 

I have kicked a can down the road by adding `"ignoreDeprecations": "5.0"` to the tsconfig. `importsNotUsedAsValues` has been deprecated and will be removed in v5.5 (currently in beta), however it remains available in v5.0-5.4. We will at some point need use [verbatimModuleSyntax](https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax) instead of `importsNotUsedAsValues`, but avoiding that change made this upgrade pretty painless. More details about `verbatimModuleSyntax` can be found here https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax.

This upgrade also required that I make a modification to the storybook config due to this issue: https://github.com/storybookjs/storybook/issues/21642
Followed the fix here to solve: https://github.com/hipstersmoothie/react-docgen-typescript-plugin/issues/78#issuecomment-1409224863

