### PR TITLE
add pdf export button to static embed and public sharing

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.tsx
@@ -12,8 +12,6 @@ import { FullWidthContainer } from "metabase/styled-components/layout/FullWidthC
 import { breakpointMaxSmall, space } from "metabase/styled-components/theme";
 import { SAVING_DOM_IMAGE_CLASS } from "metabase/visualizations/lib/save-chart-image";
 
-import { DashCard } from "../DashCard/DashCard";
-
 export const DashboardLoadingAndErrorWrapper = styled(
   ({
     isFullscreen,
@@ -162,11 +160,6 @@ export const ParametersAndCardsContainer = styled.div<{
 
     ${CardsContainer} {
       padding-bottom: 20px;
-    }
-
-    ${DashCard.root} {
-      box-shadow: none;
-      border: 1px solid var(--mb-color-border);
     }
   }
 `;

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.styled.tsx
@@ -3,6 +3,7 @@ import styled from "@emotion/styled";
 
 import DashboardS from "metabase/css/dashboard.module.css";
 import type { MantineTheme } from "metabase/ui";
+import { SAVING_DOM_IMAGE_CLASS } from "metabase/visualizations/lib/save-chart-image";
 
 import { FIXED_WIDTH } from "./Dashboard/Dashboard.styled";
 
@@ -38,6 +39,13 @@ export const DashboardCardContainer = styled.div<DashboardCardProps>`
     border-radius: 8px;
 
     ${({ theme }) => getDashboardCardShadowOrBorder(theme)}
+  }
+
+  .${SAVING_DOM_IMAGE_CLASS} & .${DashboardS.Card} {
+    // the renderer we use for saving to image/pdf doesn't support box-shadow
+    // so we replace it with a border
+    box-shadow: none;
+    border: 1px solid var(--mb-color-border);
   }
 
   ${props =>

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.tsx
@@ -53,7 +53,10 @@ import { dismissAllUndo } from "metabase/redux/undo";
 import { getIsNavbarOpen } from "metabase/selectors/app";
 import { getSetting } from "metabase/selectors/settings";
 import { Icon, Menu, Tooltip, Loader, Flex } from "metabase/ui";
-import { saveDashboardPdf } from "metabase/visualizations/lib/save-dashboard-pdf";
+import {
+  exportTabAsPdfButtonText,
+  saveDashboardPdf,
+} from "metabase/visualizations/lib/save-dashboard-pdf";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
 import type {
   Bookmark as IBookmark,
@@ -527,10 +530,7 @@ export const DashboardHeader = (props: DashboardHeaderProps) => {
       });
 
       extraButtons.push({
-        title:
-          Array.isArray(dashboard.tabs) && dashboard.tabs.length > 1
-            ? t`Export tab as PDF`
-            : t`Export as PDF`,
+        title: exportTabAsPdfButtonText(dashboard.tabs),
         icon: "document",
         testId: "dashboard-export-pdf-button",
         action: () => {

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.tsx
@@ -54,7 +54,7 @@ import { getIsNavbarOpen } from "metabase/selectors/app";
 import { getSetting } from "metabase/selectors/settings";
 import { Icon, Menu, Tooltip, Loader, Flex } from "metabase/ui";
 import {
-  exportTabAsPdfButtonText,
+  getExportTabAsPdfButtonText,
   saveDashboardPdf,
 } from "metabase/visualizations/lib/save-dashboard-pdf";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
@@ -530,7 +530,7 @@ export const DashboardHeader = (props: DashboardHeaderProps) => {
       });
 
       extraButtons.push({
-        title: exportTabAsPdfButtonText(dashboard.tabs),
+        title: getExportTabAsPdfButtonText(dashboard.tabs),
         icon: "document",
         testId: "dashboard-export-pdf-button",
         action: () => {

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.module.css
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.module.css
@@ -15,7 +15,7 @@ body {
 .ThemeNight.EmbedFrame,
 /* this is to make it work when exporting to pdfs,
 where the EmbedFrame is not part of the exported dom */
-.ThemeNight.EmbedFrame > div {
+.ThemeNight.EmbedFrame > .WithThemeBackground {
   background-color: var(--mb-color-bg-black);
   border-color: var(--mb-color-bg-dark);
 }

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.module.css
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.module.css
@@ -12,7 +12,10 @@ body {
   background-color: var(--mb-color-bg-dashboard);
 }
 
-.ThemeNight.EmbedFrame {
+.ThemeNight.EmbedFrame,
+/* this is to make it work when exporting to pdfs,
+where the EmbedFrame is not part of the exported dom */
+.ThemeNight.EmbedFrame > div {
   background-color: var(--mb-color-bg-black);
   border-color: var(--mb-color-bg-dark);
 }

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.styled.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.styled.tsx
@@ -1,6 +1,7 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 
+import { FixedWidthContainer } from "metabase/dashboard/components/Dashboard/Dashboard.styled";
 import { color } from "metabase/lib/colors";
 import type { DisplayTheme } from "metabase/public/lib/types";
 import { FullWidthContainer } from "metabase/styled-components/layout/FullWidthContainer";
@@ -170,4 +171,11 @@ export const Footer = styled.footer<{ variant: FooterVariant }>`
   ${breakpointMinLarge} {
     padding: 1.5rem;
   }
+`;
+
+export const TitleAndButtonsContainer = styled(FixedWidthContainer)`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
 `;

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
@@ -2,7 +2,6 @@ import cx from "classnames";
 import type { JSX, ReactNode } from "react";
 import { useEffect, useState } from "react";
 import { useMount } from "react-use";
-import { t } from "ttag";
 import _ from "underscore";
 
 import TitleAndDescription from "metabase/components/TitleAndDescription";
@@ -24,7 +23,10 @@ import { getIsEmbeddingSdk } from "metabase/selectors/embed";
 import { getSetting } from "metabase/selectors/settings";
 import { Box, Button, Icon } from "metabase/ui";
 import { SAVING_DOM_IMAGE_DISPLAY_NONE_CLASS } from "metabase/visualizations/lib/save-chart-image";
-import { saveDashboardPdf } from "metabase/visualizations/lib/save-dashboard-pdf";
+import {
+  exportTabAsPdfButtonText,
+  saveDashboardPdf,
+} from "metabase/visualizations/lib/save-dashboard-pdf";
 import type Question from "metabase-lib/v1/Question";
 import { getValuePopulatedParameters } from "metabase-lib/v1/parameters/utils/parameter-values";
 import type {
@@ -218,11 +220,7 @@ export const EmbedFrame = ({
                       color="text-dark"
                       onClick={saveAsPDF}
                     >
-                      {/* TODO: refactor into a util as it's duplicated logic */}
-                      {Array.isArray(dashboard.tabs) &&
-                      dashboard.tabs.length > 1
-                        ? t`Export tab as PDF`
-                        : t`Export as PDF`}
+                      {exportTabAsPdfButtonText(dashboard.tabs)}
                     </Button>
                   )}
                 </TitleAndButtonsContainer>

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
@@ -1,7 +1,8 @@
 import cx from "classnames";
-import type { ReactNode, JSX } from "react";
+import type { JSX, ReactNode } from "react";
 import { useEffect, useState } from "react";
 import { useMount } from "react-use";
+import { t } from "ttag";
 import _ from "underscore";
 
 import TitleAndDescription from "metabase/components/TitleAndDescription";
@@ -10,6 +11,7 @@ import {
   FixedWidthContainer,
   ParametersFixedWidthContainer,
 } from "metabase/dashboard/components/Dashboard/Dashboard.styled";
+import { DASHBOARD_PDF_EXPORT_ROOT_ID } from "metabase/dashboard/constants";
 import { initializeIframeResizer, isSmallScreen } from "metabase/lib/dom";
 import { useSelector } from "metabase/lib/redux";
 import { FilterApplyButton } from "metabase/parameters/components/FilterApplyButton";
@@ -20,6 +22,9 @@ import {
 import { getVisibleParameters } from "metabase/parameters/utils/ui";
 import { getIsEmbeddingSdk } from "metabase/selectors/embed";
 import { getSetting } from "metabase/selectors/settings";
+import { Box, Button, Icon } from "metabase/ui";
+import { SAVING_DOM_IMAGE_DISPLAY_NONE_CLASS } from "metabase/visualizations/lib/save-chart-image";
+import { saveDashboardPdf } from "metabase/visualizations/lib/save-dashboard-pdf";
 import type Question from "metabase-lib/v1/Question";
 import { getValuePopulatedParameters } from "metabase-lib/v1/parameters/utils/parameter-values";
 import type {
@@ -44,6 +49,7 @@ import {
   ParametersWidgetContainer,
   Root,
   Separator,
+  TitleAndButtonsContainer,
   TitleAndDescriptionContainer,
 } from "./EmbedFrame.styled";
 import { LogoBadge } from "./LogoBadge";
@@ -104,6 +110,8 @@ export const EmbedFrame = ({
   theme,
   hide_parameters,
   hide_download_button,
+  // TODO: merge `downloads` with `hide_download_button` on the higher level component?
+  downloads = true,
 }: EmbedFrameProps) => {
   const isEmbeddingSdk = useSelector(getIsEmbeddingSdk);
   const hasEmbedBranding = useSelector(
@@ -158,6 +166,15 @@ export const EmbedFrame = ({
     theme !== "transparent" && // https://github.com/metabase/metabase/pull/38766#discussion_r1491549200
     isParametersWidgetContainersSticky(visibleParameters.length);
 
+  // TODO: pass this as headerActions  from PublicDashboard ?
+  const saveAsPDF = async () => {
+    const cardNodeSelector = `#${DASHBOARD_PDF_EXPORT_ROOT_ID}`;
+    await saveDashboardPdf(cardNodeSelector, name!).then(() => {
+      // TODO: tracking
+      // trackExportDashboardToPDF(dashboard.id);
+    });
+  };
+
   return (
     <Root
       hasScroll={hasFrameScroll}
@@ -170,24 +187,45 @@ export const EmbedFrame = ({
       data-testid="embed-frame"
       data-embed-theme={theme}
     >
-      <ContentContainer>
+      <ContentContainer id={DASHBOARD_PDF_EXPORT_ROOT_ID}>
         {hasHeader && (
           <Header
-            className={EmbedFrameS.EmbedFrameHeader}
+            className={cx(
+              EmbedFrameS.EmbedFrameHeader,
+              SAVING_DOM_IMAGE_DISPLAY_NONE_CLASS,
+            )}
             data-testid="embed-frame-header"
           >
-            {finalName && (
+            {(finalName || downloads) && (
               <TitleAndDescriptionContainer>
-                <FixedWidthContainer
+                <TitleAndButtonsContainer
                   data-testid="fixed-width-dashboard-header"
                   isFixedWidth={dashboard?.width === "fixed"}
                 >
-                  <TitleAndDescription
-                    title={finalName}
-                    description={description}
-                    className={CS.my2}
-                  />
-                </FixedWidthContainer>
+                  {finalName && (
+                    <TitleAndDescription
+                      title={finalName}
+                      description={description}
+                      className={CS.my2}
+                    />
+                  )}
+                  <Box style={{ flex: 1 }} />
+                  {/* TODO: move this to a prop passed by PublicDashboard ? */}
+                  {dashboard && downloads && (
+                    <Button
+                      variant="subtle"
+                      leftIcon={<Icon name="document" />}
+                      color="text-dark"
+                      onClick={saveAsPDF}
+                    >
+                      {/* TODO: refactor into a util as it's duplicated logic */}
+                      {Array.isArray(dashboard.tabs) &&
+                      dashboard.tabs.length > 1
+                        ? t`Export tab as PDF`
+                        : t`Export as PDF`}
+                    </Button>
+                  )}
+                </TitleAndButtonsContainer>
               </TitleAndDescriptionContainer>
             )}
             {dashboardTabs && (

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
@@ -2,6 +2,7 @@ import cx from "classnames";
 import type { JSX, ReactNode } from "react";
 import { useEffect, useState } from "react";
 import { useMount } from "react-use";
+import { t } from "ttag";
 import _ from "underscore";
 
 import TitleAndDescription from "metabase/components/TitleAndDescription";
@@ -171,7 +172,10 @@ export const EmbedFrame = ({
   // TODO: pass this as headerActions  from PublicDashboard ?
   const saveAsPDF = async () => {
     const cardNodeSelector = `#${DASHBOARD_PDF_EXPORT_ROOT_ID}`;
-    await saveDashboardPdf(cardNodeSelector, name!).then(() => {
+    await saveDashboardPdf(
+      cardNodeSelector,
+      name ?? t`Exported dashboard`,
+    ).then(() => {
       // TODO: tracking
       // trackExportDashboardToPDF(dashboard.id);
     });

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
@@ -193,7 +193,10 @@ export const EmbedFrame = ({
       data-testid="embed-frame"
       data-embed-theme={theme}
     >
-      <ContentContainer id={DASHBOARD_PDF_EXPORT_ROOT_ID}>
+      <ContentContainer
+        id={DASHBOARD_PDF_EXPORT_ROOT_ID}
+        className={EmbedFrameS.WithThemeBackground}
+      >
         {hasHeader && (
           <Header
             className={cx(

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
@@ -25,7 +25,7 @@ import { getSetting } from "metabase/selectors/settings";
 import { Box, Button, Icon } from "metabase/ui";
 import { SAVING_DOM_IMAGE_DISPLAY_NONE_CLASS } from "metabase/visualizations/lib/save-chart-image";
 import {
-  exportTabAsPdfButtonText,
+  getExportTabAsPdfButtonText,
   saveDashboardPdf,
 } from "metabase/visualizations/lib/save-dashboard-pdf";
 import type Question from "metabase-lib/v1/Question";
@@ -224,7 +224,7 @@ export const EmbedFrame = ({
                       color="text-dark"
                       onClick={saveAsPDF}
                     >
-                      {exportTabAsPdfButtonText(dashboard.tabs)}
+                      {getExportTabAsPdfButtonText(dashboard.tabs)}
                     </Button>
                   )}
                 </TitleAndButtonsContainer>

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/config.ts
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/config.ts
@@ -9,5 +9,6 @@ export function getDefaultDisplayOptions(
     bordered: true,
     titled: true,
     hide_download_button: shouldShownDownloadData ? false : null,
+    downloads: null,
   };
 }

--- a/frontend/src/metabase/public/lib/types.ts
+++ b/frontend/src/metabase/public/lib/types.ts
@@ -31,7 +31,7 @@ export type EmbeddingDisplayOptions = {
   bordered: boolean;
   titled: boolean;
   hide_download_button: boolean | null;
-  downloads: boolean;
+  downloads: boolean | null;
 };
 
 export type CodeSampleParameters = {

--- a/frontend/src/metabase/public/lib/types.ts
+++ b/frontend/src/metabase/public/lib/types.ts
@@ -31,6 +31,7 @@ export type EmbeddingDisplayOptions = {
   bordered: boolean;
   titled: boolean;
   hide_download_button: boolean | null;
+  downloads: boolean;
 };
 
 export type CodeSampleParameters = {

--- a/frontend/src/metabase/visualizations/lib/save-chart-image.ts
+++ b/frontend/src/metabase/visualizations/lib/save-chart-image.ts
@@ -2,11 +2,16 @@ import { css } from "@emotion/react";
 
 export const SAVING_DOM_IMAGE_CLASS = "saving-dom-image";
 export const SAVING_DOM_IMAGE_HIDDEN_CLASS = "saving-dom-image-hidden";
+export const SAVING_DOM_IMAGE_DISPLAY_NONE_CLASS =
+  "saving-dom-image-display-none";
 
 export const saveDomImageStyles = css`
   .${SAVING_DOM_IMAGE_CLASS} {
     .${SAVING_DOM_IMAGE_HIDDEN_CLASS} {
       visibility: hidden;
+    }
+    .${SAVING_DOM_IMAGE_DISPLAY_NONE_CLASS} {
+      display: none;
     }
   }
 `;

--- a/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
+++ b/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
@@ -20,7 +20,7 @@ export const saveDashboardPdf = async (
       const title = doc.createElement("h2") as HTMLElement;
       title.innerHTML = dashboardName;
       title.style["borderBottom"] = "1px solid var(--mb-color-border)";
-      title.style["padding"] = "0 1rem 1rem 1rem";
+      title.style["padding"] = "2rem 1rem 1rem 1rem";
       node.insertBefore(title, node.firstChild);
     },
   });
@@ -39,7 +39,7 @@ export const saveDashboardPdf = async (
     orientation: pdfWidth > pdfHeight ? "l" : "p",
   });
 
-  pdf.addImage(image, "JPEG", 0, 60, imageWidth, imageHeight, "", "FAST", 0);
+  pdf.addImage(image, "JPEG", 0, 0, imageWidth, imageHeight, "", "FAST", 0);
 
   pdf.save(fileName);
 };

--- a/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
+++ b/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
@@ -48,7 +48,7 @@ export const saveDashboardPdf = async (
   pdf.save(fileName);
 };
 
-export const exportTabAsPdfButtonText = (tabs: Dashboard["tabs"]) => {
+export const getExportTabAsPdfButtonText = (tabs: Dashboard["tabs"]) => {
   return Array.isArray(tabs) && tabs.length > 1
     ? t`Export tab as PDF`
     : t`Export as PDF`;

--- a/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
+++ b/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
@@ -1,3 +1,7 @@
+import { t } from "ttag";
+
+import type { Dashboard } from "metabase-types/api";
+
 import { SAVING_DOM_IMAGE_CLASS } from "./save-chart-image";
 
 export const saveDashboardPdf = async (
@@ -42,4 +46,10 @@ export const saveDashboardPdf = async (
   pdf.addImage(image, "JPEG", 0, 0, imageWidth, imageHeight, "", "FAST", 0);
 
   pdf.save(fileName);
+};
+
+export const exportTabAsPdfButtonText = (tabs: Dashboard["tabs"]) => {
+  return Array.isArray(tabs) && tabs.length > 1
+    ? t`Export tab as PDF`
+    : t`Export as PDF`;
 };


### PR DESCRIPTION
closes #43605

### Description

This adds the export tab as pdf button to public links and static embeds.

The feature it's currently always on and can't bet yet disabled via the hash parameter.

It currently uses the theme, but it's not perfect. I think ideally we want the exports to always be with the light theme (as the pdf could be printed etc) but it's technically not easy at the moment, especially with the sdk theming. 

### How to verify

The button should show up in the header of static and public dashboard

### Demo


https://github.com/metabase/metabase/assets/1914270/6a40830d-ac03-47a9-9019-86a9f67f8f5f

