### PR TITLE
Remove old repro for 39150

### DIFF
--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -171,50 +171,6 @@ describe("issue 35711", () => {
   });
 });
 
-// TODO: unskip once 39150 is fixed
-describe.skip("issue 39150", () => {
-  beforeEach(() => {
-    restore();
-    cy.signInAsAdmin();
-  });
-
-  ["model" as const, "question" as const].forEach(type => {
-    it(`should render results if a ${type} depends on a ${type} and both have the same custom column name (metabase#39150)`, () => {
-      createQuestion({
-        type,
-        name: `${type} 39150`,
-        query: {
-          "source-table": ORDERS_ID,
-          expressions: {
-            Total: ["+", ["field", ORDERS.TOTAL, null], 1],
-          },
-          limit: 5,
-        },
-      }).then(({ body: { id: questionId } }) => {
-        createQuestion(
-          {
-            type,
-            name: `${type} 39150 Child`,
-            query: {
-              "source-table": `card__${questionId}`,
-              expressions: {
-                Total: ["+", ["field", ORDERS.TOTAL, null], 1],
-              },
-            },
-          },
-          { visitQuestion: true },
-        );
-      });
-
-      cy.log("verify that rendered result has 3 'Total' columns");
-
-      cy.findAllByTestId("header-cell")
-        .filter(":contains('Total')")
-        .should("have.length", 3);
-    });
-  });
-});
-
 describe("issues 25884 and 34349", () => {
   const ID_DESCRIPTION =
     "This is a unique ID for the product. It is also called the “Invoice number” or “Confirmation number” in customer facing emails and screens.";


### PR DESCRIPTION
This PR removes the old repro for 39150 introduced in #40851. I didn't realize it exists when I was adding https://github.com/metabase/metabase/pull/43610, which turned out to be more comprehensive.