### PR TITLE
use correct github api for CI

### DIFF
--- a/release/src/backports.ts
+++ b/release/src/backports.ts
@@ -14,7 +14,7 @@ export const checkOpenBackports = async ({ github, owner, repo, channelName }: {
   channelName: string,
 }) => {
 
-  const { data: openBackports } = await github.issues.listForRepo({
+  const { data: openBackports } = await github.rest.issues.listForRepo({
     owner,
     repo,
     labels: "was-backported",


### PR DESCRIPTION
Follow up to https://github.com/metabase/metabase/pull/43637

### Description

Apparently, octokit is pickier about how you access certain methods in CI than it is locally.


