### PR TITLE
Fix width of save button in cache sidebar (tiny PR)

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/caching/components/SidebarCacheForm.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/SidebarCacheForm.styled.tsx
@@ -14,7 +14,4 @@ export const SidebarCacheFormBody = styled(Group)`
   .strategy-form-box {
     border-bottom: 0 !important;
   }
-  .strategy-form-submit-button {
-    flex-grow: 1;
-  }
 `;

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/SidebarCacheForm.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/SidebarCacheForm.tsx
@@ -89,6 +89,7 @@ const SidebarCacheForm_Base = ({
           shouldShowName={false}
           onReset={closeSidebar}
           buttonLabels={{ save: t`Save`, discard: t`Cancel` }}
+          isInSidebar
         />
       </DelayedLoadingAndErrorWrapper>
       {confirmationModal}


### PR DESCRIPTION
The save button is now small, in the bottom right corner of the sidebar of the dashboard and question pages. Previously it widened to fill the available horizontal space

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/cc2f24a5-7da5-472d-b1c3-4442a007a643.png)

