### PR TITLE
Refresh on login when user locale is different from site locale

### DIFF
--- a/e2e/test/scenarios/onboarding/setup/user_settings.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/setup/user_settings.cy.spec.js
@@ -1,5 +1,11 @@
 import { USERS } from "e2e/support/cypress_data";
-import { restore, popover, getFullName } from "e2e/support/helpers";
+import { NORMAL_USER_ID } from "e2e/support/cypress_sample_instance_data";
+import {
+  restore,
+  popover,
+  getFullName,
+  entityPickerModal,
+} from "e2e/support/helpers";
 
 const { normal } = USERS;
 
@@ -150,6 +156,25 @@ describe("user > settings", () => {
         },
       );
     });
+  });
+
+  it("Should show correct translations when a user logs in with a locale that is different from the site locale", () => {
+    cy.intercept("GET", "/api/user/current").as("getUser");
+    cy.request("PUT", `/api/user/${NORMAL_USER_ID}`, { locale: "fr" });
+    cy.signOut();
+    cy.visit("/question/notebook");
+    cy.wait("@getUser");
+    cy.findByLabelText("Email address").type(email);
+    cy.findByLabelText("Password").type(password);
+    cy.button("Sign in").click();
+
+    // should be redirected to new question page
+    cy.wait("@getUser");
+    entityPickerModal().findByText("Orders Model").click();
+    cy.findByTestId("step-summarize-0-0")
+      .findByText("Summarize")
+      .should("not.exist");
+    cy.findByTestId("step-summarize-0-0").findByText("Résumer").should("exist");
   });
 
   describe("when user is authenticated via ldap", () => {

--- a/frontend/src/metabase-types/store/auth.ts
+++ b/frontend/src/metabase-types/store/auth.ts
@@ -1,3 +1,4 @@
 export interface AuthState {
   loginPending: boolean;
+  redirect: boolean;
 }

--- a/frontend/src/metabase-types/store/mocks/auth.ts
+++ b/frontend/src/metabase-types/store/mocks/auth.ts
@@ -2,5 +2,6 @@ import type { AuthState } from "metabase-types/store";
 
 export const createMockAuthState = (opts?: Partial<AuthState>): AuthState => ({
   loginPending: false,
+  redirect: true,
   ...opts,
 });

--- a/frontend/src/metabase/redux/auth.ts
+++ b/frontend/src/metabase/redux/auth.ts
@@ -1,9 +1,10 @@
 import { createReducer } from "@reduxjs/toolkit";
 
-import { login, loginGoogle } from "metabase/auth/actions";
+import { login, loginGoogle, pauseRedirect } from "metabase/auth/actions";
 
 const initialState = {
   loginPending: false,
+  redirect: true,
 };
 
 export const reducer = createReducer(initialState, builder => {
@@ -19,5 +20,8 @@ export const reducer = createReducer(initialState, builder => {
   });
   builder.addCase(loginGoogle.fulfilled, state => {
     state.loginPending = false;
+  });
+  builder.addCase(pauseRedirect.toString(), state => {
+    state.redirect = false;
   });
 });

--- a/frontend/src/metabase/route-guards.tsx
+++ b/frontend/src/metabase/route-guards.tsx
@@ -47,7 +47,8 @@ const UserIsNotAuthenticated = connectedReduxRedirect<Props, State>({
   wrapperDisplayName: "UserIsNotAuthenticated",
   redirectPath: () => getRedirectUrl(),
   allowRedirectBack: false,
-  authenticatingSelector: state => state.auth.loginPending,
+  authenticatingSelector: state =>
+    state.auth.loginPending || !state.auth.redirect,
   authenticatedSelector: state => !state.currentUser,
   redirectAction: routerActions.replace,
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/40342

### Description
We have an issue where translations that are computed and stored *before* a user logs in are not affected by the new locale. This change will cause the browser to refresh on login if the users locale is set, and does not equal the site locale. A flag is set in the store so that the user is not redirected to the home screen before the reload happens. Without it, the home screen (or redirect page) would appear before the reload, which didn't look great cosmetically.

### How to verify
1. As an admin user, set your users locale to something other than the site locale
2. log out
3. log back in
4. go to the admin app. All the text should be in the correct locale

### Demo
Before:
![image](https://github.com/metabase/metabase/assets/1328979/f286050b-3f64-4df1-b876-5d8557a43a98)

After:
![image](https://github.com/metabase/metabase/assets/1328979/97b19db7-aba1-4f55-bcf2-34f8fd99c372)


### Checklist
- [x] Tests have been added/updated to cover changes in this PR
