### PR TITLE
fix timeline events covers series

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/constants/style.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/constants/style.ts
@@ -9,11 +9,11 @@ export const LINE_SIZE: Record<LineSize, number> = {
 export const Z_INDEXES = {
   // Note: timeline events use echarts' markline option, which has a fixed z
   // value of 5.
-  dataLabels: 3,
-  goalLine: 2,
-  trendLine: 2,
-  lineAreaSeries: 2,
-  series: 1, // Bars needs to have a lower z value than line/area series, see issue #40209
+  dataLabels: 8,
+  goalLine: 7,
+  trendLine: 7,
+  lineAreaSeries: 7,
+  series: 6, // Bars needs to have a lower z value than line/area series, see issue #40209
 };
 
 export const CHART_STYLE = {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/43738

### Description

Timeline events started rendering on top of series, this PR fixes it.

### How to verify

- Create a time series line/area/bar/combo chart with timeline events.
- Ensure timeline events are rendered behind series

### Demo

Dc.js
<img width="1387" alt="Screenshot 2024-06-06 at 5 02 27 PM" src="https://github.com/metabase/metabase/assets/14301985/6900b585-a96a-4ee0-b7a7-c734d858a50f">

ECharts (this PR):
<img width="1352" alt="Screenshot 2024-06-06 at 5 03 08 PM" src="https://github.com/metabase/metabase/assets/14301985/12ba25f9-0ec9-40c6-8578-a2b8a583348b">

### Checklist

- [-] Tests have been added/updated to cover changes in this PR — going to add them separately since it will update all the snapshots
