### PR TITLE
🍒 Fix remaining `tinyint` booleans in MySQL (Backport #43296 to v49)

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5877,6 +5877,621 @@ databaseChangeLog:
         - dbms:
             type: mysql,mariadb
 
+  - changeSet:
+      id: v49.2024-05-29T09:26:20
+      author: johnswanson
+      comment: >-
+        Modify type of report_card.dataset to ${boolean.type} on mysql,mariadb
+      dbms: mysql,mariadb
+      changes:
+        - modifyDataType:
+            tableName: report_card
+            columnName: dataset
+            newDataType: ${boolean.type}
+      rollback:
+        - modifyDataType:
+            tableName: report_card
+            columnName: dataset
+            newDataType: boolean
+            defaultValueBoolean: false
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.2024-05-29T09:27:15
+      author: johnswanson
+      dbms: mysql,mariadb
+      comment: Add NOT NULL constraint to report_card.dataset
+      changes:
+        - addNotNullConstraint:
+            columnDataType: ${boolean.type}
+            tableName: report_card
+            columnName: dataset
+            defaultNullValue: false
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.2024-05-29T09:28:25
+      author: johnswanson
+      dbms: mysql,mariadb
+      comment: Add default value to report_card.dataset
+      changes:
+        - addDefaultValue:
+            defaultValueBoolean: false
+            tableName: report_card
+            columnName: dataset
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.2024-06-05T09:01:01
+      author: johnswanson
+      comment: >-
+        Modify type of core_user.is_datasetnewb to ${boolean.type} on mysql,mariadb
+      dbms: mysql,mariadb
+      changes:
+        - modifyDataType:
+            tableName: core_user
+            columnName: is_datasetnewb
+            newDataType: ${boolean.type}
+      rollback:
+        - modifyDataType:
+            tableName: core_user
+            columnName: is_datasetnewb
+            newDataType: boolean
+            defaultValueBoolean: true
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.2024-06-05T09:01:02
+      author: johnswanson
+      comment: >-
+        Add NOT NULL constraint to core_user.is_datasetnewb on mysql,mariadb
+      dbms: mysql,mariadb
+      changes:
+        - addNotNullConstraint:
+            tableName: core_user
+            columnName: is_datasetnewb
+            columnDataType: ${boolean.type}
+            defaultNullValue: true
+      rollback:
+        - dropNotNullConstraint:
+            tableName: core_user
+            columnName: is_datasetnewb
+            columnDataType: boolean
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.2024-06-05T09:01:03
+      author: johnswanson
+      comment: >-
+        Add default value to core_user.is_datasetnewb on mysql,mariadb
+      changes:
+        - addDefaultValue:
+            tableName: core_user
+            columnName: is_datasetnewb
+            defaultValueBoolean: true
+      dbms: mysql,mariadb
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.2024-06-05T09:02:01
+      author: johnswanson
+      comment: >-
+        Modify type of metabase_field.database_required to ${boolean.type} on mysql,mariadb
+      dbms: mysql,mariadb
+      changes:
+        - modifyDataType:
+            tableName: metabase_field
+            columnName: database_required
+            newDataType: ${boolean.type}
+      rollback:
+        - modifyDataType:
+            tableName: metabase_field
+            columnName: database_required
+            newDataType: boolean
+            defaultValueBoolean: false
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.2024-06-05T09:02:02
+      author: johnswanson
+      comment: >-
+        Add NOT NULL constraint to metabase_field.database_required on mysql,mariadb
+      dbms: mysql,mariadb
+      changes:
+        - addNotNullConstraint:
+            tableName: metabase_field
+            columnName: database_required
+            columnDataType: ${boolean.type}
+            defaultNullValue: false
+      rollback:
+        - dropNotNullConstraint:
+            tableName: metabase_field
+            columnName: database_required
+            columnDataType: boolean
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.2024-06-05T09:02:03
+      author: johnswanson
+      comment: >-
+        Add default value to metabase_field.database_required on mysql,mariadb
+      changes:
+        - addDefaultValue:
+            tableName: metabase_field
+            columnName: database_required
+            defaultValueBoolean: false
+      dbms: mysql,mariadb
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.2024-06-05T09:03:01
+      author: johnswanson
+      comment: >-
+        Modify type of metabase_fieldvalues.has_more_values to ${boolean.type} on mysql,mariadb
+      dbms: mysql,mariadb
+      changes:
+        - modifyDataType:
+            tableName: metabase_fieldvalues
+            columnName: has_more_values
+            newDataType: ${boolean.type}
+      rollback:
+        - modifyDataType:
+            tableName: metabase_fieldvalues
+            columnName: has_more_values
+            newDataType: boolean
+            defaultValueBoolean: false
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.2024-06-05T09:03:03
+      author: johnswanson
+      comment: >-
+        Add default value to metabase_fieldvalues.has_more_values on mysql,mariadb
+      changes:
+        - addDefaultValue:
+            tableName: metabase_fieldvalues
+            columnName: has_more_values
+            defaultValueBoolean: false
+      dbms: mysql,mariadb
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.2024-06-05T09:04:01
+      author: johnswanson
+      comment: >-
+        Modify type of permissions_group_membership.is_group_manager to ${boolean.type} on mysql,mariadb
+      dbms: mysql,mariadb
+      changes:
+        - modifyDataType:
+            tableName: permissions_group_membership
+            columnName: is_group_manager
+            newDataType: ${boolean.type}
+      rollback:
+        - modifyDataType:
+            tableName: permissions_group_membership
+            columnName: is_group_manager
+            newDataType: boolean
+            defaultValueBoolean: false
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.2024-06-05T09:04:02
+      author: johnswanson
+      comment: >-
+        Add NOT NULL constraint to permissions_group_membership.is_group_manager on mysql,mariadb
+      dbms: mysql,mariadb
+      changes:
+        - addNotNullConstraint:
+            tableName: permissions_group_membership
+            columnName: is_group_manager
+            columnDataType: ${boolean.type}
+            defaultNullValue: false
+      rollback:
+        - dropNotNullConstraint:
+            tableName: permissions_group_membership
+            columnName: is_group_manager
+            columnDataType: boolean
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.2024-06-05T09:04:03
+      author: johnswanson
+      comment: >-
+        Add default value to permissions_group_membership.is_group_manager on mysql,mariadb
+      changes:
+        - addDefaultValue:
+            tableName: permissions_group_membership
+            columnName: is_group_manager
+            defaultValueBoolean: false
+      dbms: mysql,mariadb
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.2024-06-05T09:05:01
+      author: johnswanson
+      comment: >-
+        Modify type of persisted_info.active to ${boolean.type} on mysql,mariadb
+      dbms: mysql,mariadb
+      changes:
+        - modifyDataType:
+            tableName: persisted_info
+            columnName: active
+            newDataType: ${boolean.type}
+      rollback:
+        - modifyDataType:
+            tableName: persisted_info
+            columnName: active
+            newDataType: boolean
+            defaultValueBoolean: false
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.2024-06-05T09:05:02
+      author: johnswanson
+      comment: >-
+        Add NOT NULL constraint to persisted_info.active on mysql,mariadb
+      dbms: mysql,mariadb
+      changes:
+        - addNotNullConstraint:
+            tableName: persisted_info
+            columnName: active
+            columnDataType: ${boolean.type}
+            defaultNullValue: false
+      rollback:
+        - dropNotNullConstraint:
+            tableName: persisted_info
+            columnName: active
+            columnDataType: boolean
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.2024-06-05T09:05:03
+      author: johnswanson
+      comment: >-
+        Add default value to persisted_info.active on mysql,mariadb
+      changes:
+        - addDefaultValue:
+            tableName: persisted_info
+            columnName: active
+            defaultValueBoolean: false
+      dbms: mysql,mariadb
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.2024-06-05T09:06:01
+      author: johnswanson
+      comment: >-
+        Modify type of report_card.dataset to ${boolean.type} on mysql,mariadb
+      dbms: mysql,mariadb
+      changes:
+        - modifyDataType:
+            tableName: report_card
+            columnName: dataset
+            newDataType: ${boolean.type}
+      rollback:
+        - modifyDataType:
+            tableName: report_card
+            columnName: dataset
+            newDataType: boolean
+            defaultValueBoolean: false
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.2024-06-05T09:06:02
+      author: johnswanson
+      comment: >-
+        Add NOT NULL constraint to report_card.dataset on mysql,mariadb
+      dbms: mysql,mariadb
+      changes:
+        - addNotNullConstraint:
+            tableName: report_card
+            columnName: dataset
+            columnDataType: ${boolean.type}
+            defaultNullValue: false
+      rollback:
+        - dropNotNullConstraint:
+            tableName: report_card
+            columnName: dataset
+            columnDataType: boolean
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.2024-06-05T09:06:03
+      author: johnswanson
+      comment: >-
+        Add default value to report_card.dataset on mysql,mariadb
+      changes:
+        - addDefaultValue:
+            tableName: report_card
+            columnName: dataset
+            defaultValueBoolean: false
+      dbms: mysql,mariadb
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.2024-06-05T09:07:01
+      author: johnswanson
+      comment: >-
+        Modify type of timeline.archived to ${boolean.type} on mysql,mariadb
+      dbms: mysql,mariadb
+      changes:
+        - modifyDataType:
+            tableName: timeline
+            columnName: archived
+            newDataType: ${boolean.type}
+      rollback:
+        - modifyDataType:
+            tableName: timeline
+            columnName: archived
+            newDataType: boolean
+            defaultValueBoolean: false
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.2024-06-05T09:07:02
+      author: johnswanson
+      comment: >-
+        Add NOT NULL constraint to timeline.archived on mysql,mariadb
+      dbms: mysql,mariadb
+      changes:
+        - addNotNullConstraint:
+            tableName: timeline
+            columnName: archived
+            columnDataType: ${boolean.type}
+            defaultNullValue: false
+      rollback:
+        - dropNotNullConstraint:
+            tableName: timeline
+            columnName: archived
+            columnDataType: boolean
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.2024-06-05T09:07:03
+      author: johnswanson
+      comment: >-
+        Add default value to timeline.archived on mysql,mariadb
+      changes:
+        - addDefaultValue:
+            tableName: timeline
+            columnName: archived
+            defaultValueBoolean: false
+      dbms: mysql,mariadb
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.2024-06-05T09:08:01
+      author: johnswanson
+      comment: >-
+        Modify type of timeline.default to ${boolean.type} on mysql,mariadb
+      dbms: mysql,mariadb
+      changes:
+        - modifyDataType:
+            tableName: timeline
+            columnName: default
+            newDataType: ${boolean.type}
+      rollback:
+        - modifyDataType:
+            tableName: timeline
+            columnName: default
+            newDataType: boolean
+            defaultValueBoolean: false
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.2024-06-05T09:08:02
+      author: johnswanson
+      comment: >-
+        Add NOT NULL constraint to timeline.default on mysql,mariadb
+      dbms: mysql,mariadb
+      changes:
+        - addNotNullConstraint:
+            tableName: timeline
+            columnName: default
+            columnDataType: ${boolean.type}
+            defaultNullValue: false
+      rollback:
+        - dropNotNullConstraint:
+            tableName: timeline
+            columnName: default
+            columnDataType: boolean
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.2024-06-05T09:08:03
+      author: johnswanson
+      comment: >-
+        Add default value to timeline.default on mysql,mariadb
+      changes:
+        - addDefaultValue:
+            tableName: timeline
+            columnName: default
+            defaultValueBoolean: false
+      dbms: mysql,mariadb
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.2024-06-05T09:09:01
+      author: johnswanson
+      comment: >-
+        Modify type of timeline_event.archived to ${boolean.type} on mysql,mariadb
+      dbms: mysql,mariadb
+      changes:
+        - modifyDataType:
+            tableName: timeline_event
+            columnName: archived
+            newDataType: ${boolean.type}
+      rollback:
+        - modifyDataType:
+            tableName: timeline_event
+            columnName: archived
+            newDataType: boolean
+            defaultValueBoolean: false
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.2024-06-05T09:09:02
+      author: johnswanson
+      comment: >-
+        Add NOT NULL constraint to timeline_event.archived on mysql,mariadb
+      dbms: mysql,mariadb
+      changes:
+        - addNotNullConstraint:
+            tableName: timeline_event
+            columnName: archived
+            columnDataType: ${boolean.type}
+            defaultNullValue: false
+      rollback:
+        - dropNotNullConstraint:
+            tableName: timeline_event
+            columnName: archived
+            columnDataType: boolean
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.2024-06-05T09:09:03
+      author: johnswanson
+      comment: >-
+        Add default value to timeline_event.archived on mysql,mariadb
+      changes:
+        - addDefaultValue:
+            tableName: timeline_event
+            columnName: archived
+            defaultValueBoolean: false
+      dbms: mysql,mariadb
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.2024-06-05T09:10:01
+      author: johnswanson
+      comment: >-
+        Modify type of timeline_event.time_matters to ${boolean.type} on mysql,mariadb
+      dbms: mysql,mariadb
+      changes:
+        - modifyDataType:
+            tableName: timeline_event
+            columnName: time_matters
+            newDataType: ${boolean.type}
+      rollback:
+        - modifyDataType:
+            tableName: timeline_event
+            columnName: time_matters
+            newDataType: boolean
+            defaultValueBoolean: NULL
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.2024-06-05T09:10:02
+      author: johnswanson
+      comment: >-
+        Add NOT NULL constraint to timeline_event.time_matters on mysql,mariadb
+      dbms: mysql,mariadb
+      changes:
+        - addNotNullConstraint:
+            tableName: timeline_event
+            columnName: time_matters
+            columnDataType: ${boolean.type}
+            defaultNullValue: false
+      rollback:
+        - dropNotNullConstraint:
+            tableName: timeline_event
+            columnName: time_matters
+            columnDataType: boolean
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################


### PR DESCRIPTION
Liquibase changed their boolean type in MySQL from `bit(1)` to
`tinyint(4)` in version 4.25.1. Our JDBC driver does not recognize these
as booleans, so we needed to migrate them to `bit(1)`s.

As discussed [here](https://github.com/metabase/metabase/pull/36964), we
changed all existing `boolean` types that were in the
`001_update_migrations.yml` but not the SQL initialization file.

For new installations, this works: things in the SQL initialization file
get created with the `bit(1)` type.

However, for existing installations, there's a potential issue. Say I'm
on v42 and am upgrading to v49. In v43, a new `boolean` was added.

In this case, I'll get the `boolean` from the liquibase migration rather
than from the SQL initialization file, and it need to be changed to a
`bit(1)`.

I installed Metabase v41 with MySQL, migrated the database, and then
installed Metabase v49 and migrated again. I made a list of all the
columns that had the type `tinyint`:

```
mysql> SELECT TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, COLUMN_TYPE,        COLUMN_DEFAULT, IS_NULLABLE FROM INFORMATION_SCHEMA.COLUMNS WHERE COLUMN_TYPE = 'tinyint' AND TABLE_SCHEMA='metabase_test';
+---------------+------------------------------+-------------------+-------------+----------------+-------------+
| TABLE_SCHEMA  | TABLE_NAME                   | COLUMN_NAME       | COLUMN_TYPE | COLUMN_DEFAULT | IS_NULLABLE |
+---------------+------------------------------+-------------------+-------------+----------------+-------------+
| metabase_test | core_user                    | is_datasetnewb    | tinyint     | 1              | NO          |
| metabase_test | metabase_field               | database_required | tinyint     | 0              | NO          |
| metabase_test | metabase_fieldvalues         | has_more_values   | tinyint     | 0              | YES         |
| metabase_test | permissions_group_membership | is_group_manager  | tinyint     | 0              | NO          |
| metabase_test | persisted_info               | active            | tinyint     | 0              | NO          |
| metabase_test | report_card                  | dataset           | tinyint     | 0              | NO          |
| metabase_test | timeline                     | archived          | tinyint     | 0              | NO          |
| metabase_test | timeline                     | default           | tinyint     | 0              | NO          |
| metabase_test | timeline_event               | archived          | tinyint     | 0              | NO          |
| metabase_test | timeline_event               | time_matters      | tinyint     | NULL           | NO          |
+---------------+------------------------------+-------------------+-------------+----------------+-------------+
10 rows in set (0.01 sec)
```

Then wrote migrations. For each column, we:

- turn it into a `bit(1)`,

- re-set the previously existing default value, and

- re-add the NOT NULL constraint, if applicable.