### PR TITLE
[QP] Include column aliases on `data.cols` and `result_metadata`

### DIFF
--- a/src/metabase/lib/metadata/cached_provider.cljc
+++ b/src/metabase/lib/metadata/cached_provider.cljc
@@ -72,7 +72,7 @@
         metadata-ids))
 
 (defn- tables [metadata-provider cache]
-  (let [fetched-tables #(lib.metadata.protocols/tables metadata-provider)]
+  (let [fetched-tables (lib.metadata.protocols/tables metadata-provider)]
     (doseq [table fetched-tables]
       (store-in-cache! cache [:metadata/table (:id table)] table))
     fetched-tables))

--- a/src/metabase/lib/metadata/jvm.clj
+++ b/src/metabase/lib/metadata/jvm.clj
@@ -340,7 +340,9 @@
   (t2/select :metadata/table
              :db_id           database-id
              :active          true
-             :visibility_type [:not-in #{"hidden" "technical" "cruft"}]))
+             {:where [:or
+                      [:= :visibility_type nil]
+                      [:not-in :visibility_type #{"hidden" "technical" "cruft"}]]}))
 
 (defn- metadatas-for-table [metadata-type table-id]
   (case metadata-type
@@ -348,8 +350,9 @@
     (t2/select :metadata/column
                :table_id        table-id
                :active          true
-               :visibility_type [:not-in #{"sensitive" "retired"}])
-
+               {:where [:or
+                        [:= :field/visibility_type nil]
+                        [:not-in :field/visibility_type #{"sensitive" "retired"}]]})
 
     :metadata/metric
     (t2/select :metadata/metric :table_id table-id, :type :metric, :archived false)

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -486,10 +486,8 @@
                             [[(:name col) (:metabase.lib.join/join-alias col)]
                              (:lib/desired-column-alias col)]))]
     (mapv (fn [col]
-            (let [k     [(:name col) (:source_alias col)]
-                  alias (get aliases k)]
-              (cond-> col
-                alias (assoc :desired_column_alias alias))))
+            (let [k [(:name col) (:source_alias col)]]
+              (m/assoc-some col :desired_column_alias (get aliases k))))
           cols)))
 
 (defn mbql-cols

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -480,23 +480,36 @@
                         (mbql-cols source-query results))]
     (qp.util/combine-metadata columns source-metadata)))
 
+(defn- add-aliases-to-legacy-cols [inner-query cols]
+  (let [returned (lib.metadata.calculation/returned-columns (mlv2-query inner-query))
+        aliases  (into {} (for [col returned]
+                            [[(:name col) (:metabase.lib.join/join-alias col)]
+                             (:lib/desired-column-alias col)]))]
+    (mapv (fn [col]
+            (let [k     [(:name col) (:source_alias col)]
+                  alias (get aliases k)]
+              (cond-> col
+                alias (assoc :desired_column_alias alias))))
+          cols)))
+
 (defn mbql-cols
   "Return the `:cols` result metadata for an 'inner' MBQL query based on the fields/breakouts/aggregations in the
   query."
   [{:keys [source-metadata source-query :source-query/model? fields], :as inner-query}, results]
-  (let [cols (cols-for-mbql-query inner-query)]
-    (cond
-      (and (empty? cols) source-query)
-      (cols-for-source-query inner-query results)
+  (let [cols     (cols-for-mbql-query inner-query)]
+    (->> (cond
+           (and (empty? cols) source-query)
+           (cols-for-source-query inner-query results)
 
-      source-query
-      (flow-field-metadata (cols-for-source-query inner-query results) cols model?)
+           source-query
+           (flow-field-metadata (cols-for-source-query inner-query results) cols model?)
 
-      (every? #(lib.util.match/match-one % [:field (field-name :guard string?) _] field-name) fields)
-      (maybe-merge-source-metadata source-metadata cols)
+           (every? #(lib.util.match/match-one % [:field (field-name :guard string?) _] field-name) fields)
+           (maybe-merge-source-metadata source-metadata cols)
 
-      :else
-      cols)))
+           :else
+           cols)
+         (add-aliases-to-legacy-cols inner-query))))
 
 (defn- restore-cumulative-aggregations
   [{aggregations :aggregation breakouts :breakout :as inner-query} replaced-indexes]

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -441,13 +441,14 @@
                         "Sum of Quantity"
                         "test-expr"]
                        (map :display_name cols)))
-                (is (= {:base_type       "type/Integer"
-                        :effective_type  "type/Integer"
-                        :name            "pivot-grouping"
-                        :display_name    "pivot-grouping"
-                        :expression_name "pivot-grouping"
-                        :field_ref       ["expression" "pivot-grouping"]
-                        :source          "breakout"}
+                (is (= {:base_type            "type/Integer"
+                        :effective_type       "type/Integer"
+                        :name                 "pivot-grouping"
+                        :desired_column_alias "pivot-grouping"
+                        :display_name         "pivot-grouping"
+                        :expression_name      "pivot-grouping"
+                        :field_ref            ["expression" "pivot-grouping"]
+                        :source               "breakout"}
                        (nth cols 3))))
               (is (= [nil nil nil 7 18760 69540 "wheeee"] (last rows))))))))))
 

--- a/test/metabase/query_processor_test/native_test.clj
+++ b/test/metabase/query_processor_test/native_test.clj
@@ -38,15 +38,6 @@
            (mt/native-query
             {:query "select name from users;"}))))))
 
-(comment
-  (qp/process-query {:native {:query "select id, id from orders"}
-                     :database (mt/id)
-                     :type :native})
-  ;; START HERE: Duplicate `:name` in the `:result_metadata` is not how it really gets returned.
-  ;; But trying to run this test even with the de-duplicated name throws a different error.
-  ;; This might just be an MLv2 bug, if MLv2 is failing to de-dupe the aliases in `returned-columns` for native queries.
-  )
-
 (deftest ^:parallel native-with-duplicate-column-names
   (testing "Should be able to run native query referring a question referring a question (#25988)"
     (mt/with-test-drivers (sql.qp-test-util/sql-drivers)
@@ -65,7 +56,7 @@
                                                                     :effective_type :type/BigInteger,
                                                                     :field_ref [:field "ID_2" {:base-type :type/BigInteger}],
                                                                     :fingerprint nil,
-                                                                    :name "ID_2",
+                                                                    :name "ID",
                                                                     :semantic_type :type/PK}]}]
         (is (=? {:columns ["ID" "ID_2"]}
                 (mt/rows+column-names

--- a/test/metabase/query_processor_test/native_test.clj
+++ b/test/metabase/query_processor_test/native_test.clj
@@ -38,6 +38,15 @@
            (mt/native-query
             {:query "select name from users;"}))))))
 
+(comment
+  (qp/process-query {:native {:query "select id, id from orders"}
+                     :database (mt/id)
+                     :type :native})
+  ;; START HERE: Duplicate `:name` in the `:result_metadata` is not how it really gets returned.
+  ;; But trying to run this test even with the de-duplicated name throws a different error.
+  ;; This might just be an MLv2 bug, if MLv2 is failing to de-dupe the aliases in `returned-columns` for native queries.
+  )
+
 (deftest ^:parallel native-with-duplicate-column-names
   (testing "Should be able to run native query referring a question referring a question (#25988)"
     (mt/with-test-drivers (sql.qp-test-util/sql-drivers)
@@ -56,7 +65,7 @@
                                                                     :effective_type :type/BigInteger,
                                                                     :field_ref [:field "ID_2" {:base-type :type/BigInteger}],
                                                                     :fingerprint nil,
-                                                                    :name "ID",
+                                                                    :name "ID_2",
                                                                     :semantic_type :type/PK}]}]
         (is (=? {:columns ["ID" "ID_2"]}
                 (mt/rows+column-names

--- a/test/metabase/xrays/automagic_dashboards/core_test.clj
+++ b/test/metabase/xrays/automagic_dashboards/core_test.clj
@@ -468,11 +468,13 @@
                                                                         &u.people.source
                                                                         &u.people.longitude
                                                                         &u.people.latitude]
+                                                         :alias        "u"
                                                          :source-table $$people
                                                          :condition    [:= $orders.user_id &u.people.id]}
                                                         {:fields       [&p.products.category
                                                                         &p.products.price]
                                                          :source-table $$products
+                                                         :alias        "p"
                                                          :condition    [:= $orders.product_id &p.products.id]}]
                                          :fields       [$orders.created_at]})}]
           (mt/with-temp


### PR DESCRIPTION
This is the first part of the branch for #43306.

Fixes #43307.
