### PR TITLE
Actually validate `view_log.context` matches `::view-log/context` on insert

### DIFF
--- a/src/metabase/events/schema.clj
+++ b/src/metabase/events/schema.clj
@@ -35,20 +35,20 @@
 
 ;; card events
 
-(let [view-only      (mc/schema
-                      [:map {:closed true}
-                       [:context ::view-log/context]
-                       [:user-id [:maybe pos-int?]]
-                       [:object-id [:maybe pos-int?]]])
-      default-schema (mc/schema
+(let [default-schema (mc/schema
                       [:map {:closed true}
                        [:user-id  [:maybe pos-int?]]
                        [:object   [:fn #(t2/instance-of? :model/Card %)]]])]
   (def ^:private card-events-schemas
     {:event/card-create default-schema
-     :event/card-read   view-only
      :event/card-update default-schema
      :event/card-delete default-schema
+     :event/card-read   (mc/schema
+                         [:map {:closed true}
+                          ;; context is deliberately coupled to view-log's context
+                          [:context [:and :some ::view-log/context]]
+                          [:user-id [:maybe pos-int?]]
+                          [:object-id [:maybe pos-int?]]])
      :event/card-query  [:map {:closed true}
                          [:card-id pos-int?]
                          [:user-id [:maybe pos-int?]]

--- a/src/metabase/models/view_log.clj
+++ b/src/metabase/models/view_log.clj
@@ -2,6 +2,7 @@
   "The ViewLog is used to log an event where a given User views a given object such as a Table or Card (Question)."
   (:require
    [metabase.models.interface :as mi]
+   [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [methodical.core :as m]
    [toucan2.core :as t2]))
@@ -18,14 +19,19 @@
   (derive ::mi/read-policy.always-allow)
   (derive ::mi/write-policy.always-allow))
 
+(mr/def ::context
+  [:enum :dashboard :question])
+
+(mu/defn ^:private validate
+  [_log-entry :- [:map [:context ::context]]]
+  :no-op)
+
 (t2/define-before-insert :model/ViewLog
   [log-entry]
+  (validate log-entry)
   (let [defaults {:timestamp :%now}]
     (merge defaults log-entry)))
 
 (t2/deftransforms :model/ViewLog
   {:metadata mi/transform-json
    :context  mi/transform-keyword})
-
-(mr/def ::context
-  [:enum :dashboard :question])

--- a/src/metabase/models/view_log.clj
+++ b/src/metabase/models/view_log.clj
@@ -23,7 +23,7 @@
   [:maybe [:enum :dashboard :question]])
 
 (mu/defn ^:private validate
-  [_log-entry :- [:map [:context ::context]]]
+  [_log-entry :- [:map [:context {:optional true} ::context]]]
   :no-op)
 
 (t2/define-before-insert :model/ViewLog

--- a/src/metabase/models/view_log.clj
+++ b/src/metabase/models/view_log.clj
@@ -3,6 +3,7 @@
   (:require
    [metabase.models.interface :as mi]
    [metabase.util.malli :as mu]
+   [metabase.util.malli.fn :as mu.fn]
    [metabase.util.malli.registry :as mr]
    [methodical.core :as m]
    [toucan2.core :as t2]))
@@ -22,13 +23,10 @@
 (mr/def ::context
   [:maybe [:enum :dashboard :question]])
 
-(mu/defn ^:private validate
-  [_log-entry :- [:map [:context {:optional true} ::context]]]
-  :no-op)
-
 (t2/define-before-insert :model/ViewLog
   [log-entry]
-  (validate log-entry)
+  (when (mu.fn/instrument-ns? *ns*)
+    (mu/validate-throw [:map [:context {:optional true} ::context]] log-entry))
   (let [defaults {:timestamp :%now}]
     (merge defaults log-entry)))
 

--- a/src/metabase/models/view_log.clj
+++ b/src/metabase/models/view_log.clj
@@ -20,7 +20,7 @@
   (derive ::mi/write-policy.always-allow))
 
 (mr/def ::context
-  [:enum :dashboard :question])
+  [:maybe [:enum :dashboard :question]])
 
 (mu/defn ^:private validate
   [_log-entry :- [:map [:context ::context]]]


### PR DESCRIPTION
This PR validates that `view_log.context` matches `[:maybe [:enum :dashboard :question]]` on write.

The goal of this is to force devs to update `::view-log/context` if the set of possible values grows, to keep an up-to-date document of what's in `view_log.context`. Currently there's nothing stopping us from making a change that inserts another value that violates the schema. One example where this actually happened is here: https://github.com/metabase/metabase/pull/43478#discussion_r1629796313. We allowed `:collection` to be inserted without updating the `::view-log/context` schema.

I chose to do the validation on `insert` because we're more likely to insert rather than select in tests, so it's more likely to be caught in development