### PR TITLE
Task history sorted by started at

### DIFF
--- a/src/metabase/models/task_history.clj
+++ b/src/metabase/models/task_history.clj
@@ -73,7 +73,7 @@
   "Return all TaskHistory entries, applying `limit` and `offset` if not nil"
   [limit  :- [:maybe ms/PositiveInt]
    offset :- [:maybe ms/IntGreaterThanOrEqualToZero]]
-  (t2/select TaskHistory (merge {:order-by [[:ended_at :desc]]}
+  (t2/select TaskHistory (merge {:order-by [[:started_at :desc]]}
                                 (when limit
                                   {:limit limit})
                                 (when offset

--- a/test/metabase/api/task_test.clj
+++ b/test/metabase/api/task_test.clj
@@ -44,11 +44,19 @@
                           :when  (contains? task-names (:task result))]
                       (mt/boolean-ids-and-timestamps result)))))))))
 
-(deftest sort-by-ended-at-test
-  (testing (str "Multiple results should be sorted via `:ended_at`. Below creates two tasks, the second one has a "
-                "later `:ended_at` date and should be returned first")
-    (let [[task-hist-1 task-hist-2 :as task-histories] (generate-tasks 2)
-          task-names                                   (set (map :task task-histories))]
+(deftest sort-by-started-at-test
+  (testing (str "Multiple results should be sorted via `:started_at`. Below creates two tasks, the second one has a "
+                "later `:started_at` date and should be returned first")
+    (let [now             (t/zoned-date-time)
+          now-1s          (t/minus now (t/seconds 1))
+          now-2s          (t/minus now (t/seconds 2))
+          task-hist-1     {:task (mt/random-name)
+                           :started_at now-2s
+                           :ended_at   now}
+          task-hist-2     {:task (mt/random-name)
+                           :started_at now-1s
+                           :ended_at   now-1s}
+          task-names      (set (map :task [task-hist-1 task-hist-2]))]
       (mt/with-temp [TaskHistory _ task-hist-1
                      TaskHistory _ task-hist-2]
         (is (= (map (fn [{:keys [task]}]

--- a/test/metabase/api/task_test.clj
+++ b/test/metabase/api/task_test.clj
@@ -15,13 +15,13 @@
   "Creates `n` task history maps with guaranteed increasing `:ended_at` times. This means that when stored and queried
   via the GET `/` endpoint, will return in reverse order from how this function returns the task history maps."
   [n]
-  (let [now        (t/zoned-date-time)
-        task-names (repeatedly n mt/random-name)]
+  (let [task-names (repeatedly n mt/random-name)]
     (map-indexed (fn [idx task-name]
-                   {:status     :success
-                    :task       task-name
-                    :started_at now
-                    :ended_at   (t/plus now (t/seconds idx))})
+                   (let [now (t/zoned-date-time)]
+                    {:status     :success
+                     :task       task-name
+                     :started_at now
+                     :ended_at   (t/plus now (t/seconds idx))}))
                  task-names)))
 
 (deftest list-perms-test
@@ -86,13 +86,13 @@
         (is (= {:total 4, :limit 2, :offset 0
                 :data  (map (fn [{:keys [task]}]
                               (assoc default-task-history :task task))
-                            [task-hist-1 task-hist-2])}
+                        [task-hist-4 task-hist-3])}
                (mt/boolean-ids-and-timestamps
                 (mt/user-http-request :crowberto :get 200 "task/" :limit 2 :offset 0))))
         (is (= {:total 4, :limit 2, :offset 2
                 :data  (map (fn [{:keys [task]}]
                               (assoc default-task-history :task task))
-                            [task-hist-3 task-hist-4])}
+                            [task-hist-2 task-hist-1])}
                (mt/boolean-ids-and-timestamps
                 (mt/user-http-request :crowberto :get 200 "task/" :limit 2 :offset 2))))))))
 

--- a/test/metabase/api/task_test.clj
+++ b/test/metabase/api/task_test.clj
@@ -86,13 +86,13 @@
         (is (= {:total 4, :limit 2, :offset 0
                 :data  (map (fn [{:keys [task]}]
                               (assoc default-task-history :task task))
-                            [task-hist-4 task-hist-3])}
+                            [task-hist-1 task-hist-2])}
                (mt/boolean-ids-and-timestamps
                 (mt/user-http-request :crowberto :get 200 "task/" :limit 2 :offset 0))))
         (is (= {:total 4, :limit 2, :offset 2
                 :data  (map (fn [{:keys [task]}]
                               (assoc default-task-history :task task))
-                            [task-hist-2 task-hist-1])}
+                            [task-hist-3 task-hist-4])}
                (mt/boolean-ids-and-timestamps
                 (mt/user-http-request :crowberto :get 200 "task/" :limit 2 :offset 2))))))))
 


### PR DESCRIPTION
In https://github.com/metabase/metabase/pull/42372, we record task history when a task is started and update it once it's done.

This means some tasks will have `ended_at = nil`. Currently, the Tasks page in admin is sorted by `ended_at,` which makes tasks that are started without finished shown first. 

Why are some tasks started without finishing? There are many reasons for this, but one common one is that MB is stopped while the tasks are executing.

So this PR makes it so that this page is sorted by started_at instead.