### PR TITLE
[Cache] Fix save button bug and several smaller issues

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/caching/components/ModelPersistenceConfiguration.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/ModelPersistenceConfiguration.tsx
@@ -4,6 +4,7 @@ import { c, t } from "ttag";
 
 import { ModelCachingScheduleWidget } from "metabase/admin/settings/components/widgets/ModelCachingScheduleWidget/ModelCachingScheduleWidget";
 import { useSetting } from "metabase/common/hooks";
+import { DelayedLoadingAndErrorWrapper } from "metabase/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
 import ExternalLink from "metabase/core/components/ExternalLink";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import MetabaseSettings from "metabase/lib/settings";
@@ -16,14 +17,46 @@ import {
 import { PersistedModelsApi } from "metabase/services";
 import { Stack, Switch, Text } from "metabase/ui";
 
+const modelCachingOptions = [
+  {
+    value: "0 0 0/1 * * ? *",
+    name: t`Hour`,
+  },
+  {
+    value: "0 0 0/2 * * ? *",
+    name: t`2 hours`,
+  },
+  {
+    value: "0 0 0/3 * * ? *",
+    name: t`3 hours`,
+  },
+  {
+    value: "0 0 0/6 * * ? *",
+    name: t`6 hours`,
+  },
+  {
+    value: "0 0 0/12 * * ? *",
+    name: t`12 hours`,
+  },
+  {
+    value: "0 0 0 ? * * *",
+    name: t`24 hours`,
+  },
+  {
+    value: "custom",
+    name: t`Custom…`,
+  },
+];
+
 export const ModelPersistenceConfiguration = () => {
   const showMetabaseLinks = useSelector(getShowMetabaseLinks);
-  const persistenceEnabledInAPI = useSetting("persisted-models-enabled");
 
-  const [persistenceEnabled, setPersistenceEnabled] = useState(false);
+  const modelPersistenceEnabledInAPI = useSetting("persisted-models-enabled");
+
+  const [modelPersistenceEnabled, setModelPersistenceEnabled] = useState(false);
   useEffect(() => {
-    setPersistenceEnabled(persistenceEnabledInAPI);
-  }, [persistenceEnabledInAPI]);
+    setModelPersistenceEnabled(modelPersistenceEnabledInAPI);
+  }, [modelPersistenceEnabledInAPI]);
 
   const modelCachingSchedule = useSetting(
     "persisted-model-refresh-cron-schedule",
@@ -31,36 +64,7 @@ export const ModelPersistenceConfiguration = () => {
 
   const modelCachingSetting = {
     value: modelCachingSchedule,
-    options: [
-      {
-        value: "0 0 0/1 * * ? *",
-        name: t`Hour`,
-      },
-      {
-        value: "0 0 0/2 * * ? *",
-        name: t`2 hours`,
-      },
-      {
-        value: "0 0 0/3 * * ? *",
-        name: t`3 hours`,
-      },
-      {
-        value: "0 0 0/6 * * ? *",
-        name: t`6 hours`,
-      },
-      {
-        value: "0 0 0/12 * * ? *",
-        name: t`12 hours`,
-      },
-      {
-        value: "0 0 0 ? * * *",
-        name: t`24 hours`,
-      },
-      {
-        value: "custom",
-        name: t`Custom…`,
-      },
-    ],
+    options: modelCachingOptions,
   };
   const dispatch = useDispatch();
 
@@ -118,13 +122,14 @@ export const ModelPersistenceConfiguration = () => {
   const onSwitchChanged = useCallback<ChangeEventHandler<HTMLInputElement>>(
     async e => {
       const shouldEnable = e.target.checked;
-      setPersistenceEnabled(shouldEnable);
+      setModelPersistenceEnabled(shouldEnable);
       const promise = shouldEnable
         ? PersistedModelsApi.enablePersistence()
         : PersistedModelsApi.disablePersistence();
       await resolveWithToasts([promise]);
+      dispatch(refreshSiteSettings({}));
     },
-    [resolveWithToasts, setPersistenceEnabled],
+    [resolveWithToasts, setModelPersistenceEnabled, dispatch],
   );
 
   return (
@@ -151,18 +156,23 @@ export const ModelPersistenceConfiguration = () => {
             </>
           )}
         </p>
-        <Switch
-          mt="sm"
-          label={
-            <Text fw="bold">
-              {persistenceEnabled ? t`Enabled` : t`Disabled`}
-            </Text>
-          }
-          onChange={onSwitchChanged}
-          checked={persistenceEnabled}
-        />
+        <DelayedLoadingAndErrorWrapper
+          error={null}
+          loading={modelPersistenceEnabled === undefined}
+        >
+          <Switch
+            mt="sm"
+            label={
+              <Text fw="bold">
+                {modelPersistenceEnabled ? t`Enabled` : t`Disabled`}
+              </Text>
+            }
+            onChange={onSwitchChanged}
+            checked={modelPersistenceEnabled}
+          />
+        </DelayedLoadingAndErrorWrapper>
       </div>
-      {persistenceEnabled && (
+      {modelPersistenceEnabled && (
         <div>
           <ModelCachingScheduleWidget
             setting={modelCachingSetting}

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/ModelPersistenceTab.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/ModelPersistenceTab.tsx
@@ -1,11 +1,11 @@
 import { t } from "ttag";
 
-import { TabId } from "metabase/admin/performance/components/PerformanceApp";
 import { Tab } from "metabase/admin/performance/components/PerformanceApp.styled";
+import { PerformanceTabId } from "metabase/admin/performance/types";
 
 export const ModelPersistenceTab = () => {
   return (
-    <Tab key="ModelPersistence" value={TabId.ModelPersistence}>
+    <Tab key="ModelPersistence" value={PerformanceTabId.ModelPersistence}>
       {t`Model persistence`}
     </Tab>
   );

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyFormLauncherPanel.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyFormLauncherPanel.styled.tsx
@@ -1,0 +1,27 @@
+import { css } from "@emotion/react";
+import styled from "@emotion/styled";
+
+import { breakpointMaxSmall } from "metabase/styled-components/theme";
+import { Box, Stack } from "metabase/ui";
+
+const sectionStyle = css`
+  padding: 1.5rem;
+  ${breakpointMaxSmall} {
+    padding: 0.75rem;
+  }
+`;
+
+export const StrategyFormLauncherPanelBox = styled(Box)<
+  React.PropsWithChildren<any>
+>`
+  ${sectionStyle}
+  border-bottom: 1px solid var(--mb-color-border);
+`;
+
+export const StrategyFormLauncherPanelStack = styled(Stack)`
+  ${sectionStyle}
+  gap: 1rem;
+  ${breakpointMaxSmall} {
+    gap: 0.5rem;
+  }
+`;

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyFormLauncherPanel.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyFormLauncherPanel.tsx
@@ -6,7 +6,6 @@ import { rootId } from "metabase/admin/performance/constants/simple";
 import type { UpdateTargetId } from "metabase/admin/performance/types";
 import { FormProvider } from "metabase/forms";
 import { color } from "metabase/lib/colors";
-import { Box, Stack } from "metabase/ui";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type { Config } from "metabase-types/api";
 
@@ -14,6 +13,10 @@ import { useResetToDefaultForm } from "../hooks/useResetToDefaultForm";
 
 import { ResetButtonContainer } from "./ResetButtonContainer";
 import { StrategyFormLauncher } from "./StrategyFormLauncher";
+import {
+  StrategyFormLauncherPanelBox,
+  StrategyFormLauncherPanelStack,
+} from "./StrategyFormLauncherPanel.styled";
 
 export const StrategyFormLauncherPanel = ({
   configs,
@@ -46,7 +49,7 @@ export const StrategyFormLauncherPanel = ({
 
   return (
     <Panel role="group" style={{ backgroundColor: color("bg-light") }}>
-      <Box p="lg" style={{ borderBottom: "1px solid var(--mb-color-border)" }}>
+      <StrategyFormLauncherPanelBox>
         <StrategyFormLauncher
           forId={rootId}
           title={t`Default policy`}
@@ -55,8 +58,8 @@ export const StrategyFormLauncherPanel = ({
           updateTargetId={updateTargetId}
           isFormDirty={isStrategyFormDirty}
         />
-      </Box>
-      <Stack p="lg" spacing="md">
+      </StrategyFormLauncherPanelBox>
+      <StrategyFormLauncherPanelStack>
         {databases?.map(db => (
           <StrategyFormLauncher
             forId={db.id}
@@ -68,7 +71,7 @@ export const StrategyFormLauncherPanel = ({
             key={`database_${db.id}`}
           />
         ))}
-      </Stack>
+      </StrategyFormLauncherPanelStack>
       <FormProvider
         initialValues={{}}
         onSubmit={resetAllToDefault}

--- a/frontend/src/metabase/admin/performance/components/PerformanceApp.styled.tsx
+++ b/frontend/src/metabase/admin/performance/components/PerformanceApp.styled.tsx
@@ -2,6 +2,8 @@ import styled from "@emotion/styled";
 
 import { Tabs } from "metabase/ui";
 
+import { PerformanceTabId } from "../types";
+
 export const TabsList = styled(Tabs.List)`
   padding: 0 2.5rem;
   background-color: var(--mb-color-bg-light);
@@ -22,10 +24,12 @@ export const Tab = styled(Tabs.Tab)`
   }
 `;
 
-export const TabsPanel = styled(Tabs.Panel)`
+export const TabsPanel = styled(Tabs.Panel)<{ value: string }>`
   display: flex;
   flex-flow: column nowrap;
   flex: 1;
-  overflow: hidden;
   justify-content: stretch;
+  padding: 1rem 2.5rem;
+  ${props =>
+    props.value === PerformanceTabId.DataCachingSettings && `overflow: hidden;`}
 `;

--- a/frontend/src/metabase/admin/performance/components/PerformanceApp.tsx
+++ b/frontend/src/metabase/admin/performance/components/PerformanceApp.tsx
@@ -6,19 +6,19 @@ import { PLUGIN_CACHING } from "metabase/plugins";
 import type { TabsValue } from "metabase/ui";
 import { Flex, Tabs } from "metabase/ui";
 
+import { PerformanceTabId } from "../types";
+
 import { Tab, TabsList, TabsPanel } from "./PerformanceApp.styled";
 import { StrategyEditorForDatabases } from "./StrategyEditorForDatabases";
 
-export enum TabId {
-  DataCachingSettings = "dataCachingSettings",
-  ModelPersistence = "modelPersistence",
-}
-const validTabIds = new Set(Object.values(TabId).map(String));
-const isValidTabId = (tab: TabsValue): tab is TabId =>
+const validTabIds = new Set(Object.values(PerformanceTabId).map(String));
+const isValidTabId = (tab: TabsValue): tab is PerformanceTabId =>
   !!tab && validTabIds.has(tab);
 
 export const PerformanceApp = ({ route }: { route: Route }) => {
-  const [tabId, setTabId] = useState<TabId>(TabId.DataCachingSettings);
+  const [tabId, setTabId] = useState<PerformanceTabId>(
+    PerformanceTabId.DataCachingSettings,
+  );
   const [tabsHeight, setTabsHeight] = useState<number>(300);
   const tabsRef = useRef<HTMLDivElement>(null);
 
@@ -55,18 +55,21 @@ export const PerformanceApp = ({ route }: { route: Route }) => {
       h={tabsHeight}
     >
       <TabsList>
-        <Tab key="DataCachingSettings" value={TabId.DataCachingSettings}>
-          {t`Data caching settings`}
+        <Tab
+          key={PerformanceTabId.DataCachingSettings}
+          value={PerformanceTabId.DataCachingSettings}
+        >
+          {t`Database caching settings`}
         </Tab>
         <PLUGIN_CACHING.ModelPersistenceTab />
       </TabsList>
-      <TabsPanel key={tabId} value={tabId} p="1rem 2.5rem">
-        {tabId === TabId.DataCachingSettings && (
-          <Flex style={{ flex: 1 }} bg="bg-light" h="100%">
+      <TabsPanel key={tabId} value={tabId}>
+        {tabId === PerformanceTabId.DataCachingSettings && (
+          <Flex style={{ flex: 1, overflow: "hidden" }} bg="bg-light" h="100%">
             <StrategyEditorForDatabases route={route} />
           </Flex>
         )}
-        {tabId === TabId.ModelPersistence && (
+        {tabId === PerformanceTabId.ModelPersistence && (
           <Flex style={{ flex: 1 }} bg="bg-light" h="100%">
             <PLUGIN_CACHING.ModelPersistenceConfiguration />
           </Flex>

--- a/frontend/src/metabase/admin/performance/components/StrategyEditorForDatabases.styled.tsx
+++ b/frontend/src/metabase/admin/performance/components/StrategyEditorForDatabases.styled.tsx
@@ -31,6 +31,5 @@ export const RoundedBox = styled.div<{ twoColumns?: boolean }>`
 export const TabWrapper = styled.div`
   display: grid;
   grid-template-rows: auto 1fr;
-  min-width: calc(min(50rem, 100vw));
   width: calc(min(65rem, 100vw));
 `;

--- a/frontend/src/metabase/admin/performance/components/StrategyEditorForDatabases.tsx
+++ b/frontend/src/metabase/admin/performance/components/StrategyEditorForDatabases.tsx
@@ -135,7 +135,7 @@ const StrategyEditorForDatabases_Base = ({
         </aside>
       </Stack>
       {confirmationModal}
-      <Flex gap="xl">
+      <Flex gap="xl" style={{ overflow: "hidden" }}>
         <RoundedBox twoColumns={canOverrideRootStrategy}>
           {canOverrideRootStrategy && (
             <PLUGIN_CACHING.StrategyFormLauncherPanel

--- a/frontend/src/metabase/admin/performance/components/StrategyForm.styled.tsx
+++ b/frontend/src/metabase/admin/performance/components/StrategyForm.styled.tsx
@@ -2,7 +2,7 @@ import styled from "@emotion/styled";
 
 import { Form } from "metabase/forms";
 import type { BoxProps } from "metabase/ui";
-import { Box, FixedSizeIcon, Loader } from "metabase/ui";
+import { Box, FixedSizeIcon, Group, Loader } from "metabase/ui";
 
 export const LoaderInButton = styled(Loader)`
   position: relative;
@@ -31,7 +31,6 @@ export const FormBox = styled(Box)<
     isInSidebar?: boolean;
   }
 >`
-  border-bottom: 1px solid var(--mb-color-border);
   overflow: auto;
   flex-grow: 1;
   padding-bottom: 2.5rem;
@@ -44,4 +43,21 @@ export const FormBox = styled(Box)<
       : `
   padding-inline: 2.5rem;
 `}
+`;
+
+export const StyledFormButtonsGroup = styled(Group)<{ isInSidebar?: boolean }>`
+  padding-block: 1rem;
+  gap: 1rem;
+  background-color: var(--mb-color-bg-white);
+  border-top: 1px solid var(--mb-color-border);
+  ${({ isInSidebar }) =>
+    isInSidebar
+      ? `
+  justify-content: flex-end;
+  padding-inline-start: 2rem;
+  padding-inline-end: 1rem;
+  `
+      : `
+  padding-inline: 2.5rem;
+  `}
 `;

--- a/frontend/src/metabase/admin/performance/components/StrategyForm.tsx
+++ b/frontend/src/metabase/admin/performance/components/StrategyForm.tsx
@@ -52,6 +52,7 @@ import {
   FormWrapper,
   LoaderInButton,
   StyledForm,
+  StyledFormButtonsGroup,
 } from "./StrategyForm.styled";
 
 interface ButtonLabels {
@@ -240,19 +241,12 @@ const FormButtonsGroup = ({
   isInSidebar?: boolean;
 }) => {
   return (
-    <Group
-      py="md"
-      spacing="md"
-      bg="bg-white"
+    <StyledFormButtonsGroup
+      isInSidebar={isInSidebar}
       className="form-buttons-group"
-      style={{
-        justifyContent: isInSidebar ? undefined : "flex-end",
-        paddingInlineStart: isInSidebar ? "2rem" : "2.5rem",
-        paddingInlineEnd: isInSidebar ? "1rem" : "2.5rem",
-      }}
     >
       {children}
-    </Group>
+    </StyledFormButtonsGroup>
   );
 };
 

--- a/frontend/src/metabase/admin/performance/types.ts
+++ b/frontend/src/metabase/admin/performance/types.ts
@@ -16,3 +16,8 @@ export type StrategyData = {
   shortLabel?: StrategyLabel;
   validateWith: AnySchema;
 };
+
+export enum PerformanceTabId {
+  DataCachingSettings = "dataCachingSettings",
+  ModelPersistence = "modelPersistence",
+}

--- a/frontend/src/metabase/components/Schedule/components.tsx
+++ b/frontend/src/metabase/components/Schedule/components.tsx
@@ -69,7 +69,7 @@ export const SelectTime = ({
   const amPm = hourIn24HourFormat >= 12 ? 1 : 0;
   const hourIndex = isClock12Hour && hour === 12 ? 0 : hour;
   return (
-    <Group spacing={isClock12Hour ? "xs" : "sm"}>
+    <Group spacing={isClock12Hour ? "xs" : "sm"} style={{ rowGap: ".5rem" }}>
       <AutoWidthSelect
         value={hourIndex.toString()}
         data={getHours()}


### PR DESCRIPTION
Fixes #43813, a serious bug: In Admin / Performance / Data caching settings, the Save button is inaccessible when pushed offscreen by a long list of databases 

Also fixes a few smaller issues:
* In Admin / Performance / Data caching settings, there's too much padding in the left panel (which has the buttons for the different databases) when viewport is narrow
* In dashboard/question sidebar, in the Schedule component, there is too little padding between the time and AM/PM when these are stacked vertically
* On master, when you change something on Model persistence, tab away, then return, the component's state is out of date

## Screenshots

#### On master, in Admin / Performance / Data caching settings, the save button can become impossible to scroll to:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/8f3673fc-d512-4945-915e-90ed66df3f90.png)

#### On this branch, the save button is kept in view

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/b4cf4e61-7723-4294-b7ea-560945e8c413.png)