### PR TITLE
[sync] parse naked json values

### DIFF
--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -391,7 +391,8 @@
     (loop [path (or path [])
            key  nil
            res  (transient {})]
-      (let [token (.nextToken p)]
+      (let [token     (.nextToken p)
+            next-path (cond-> path key (conj key))]
         (cond
           (nil? token)
           (persistent! res)
@@ -405,21 +406,18 @@
 
           :else
           (u/case-enum token
-            JsonToken/VALUE_NUMBER_INT   (recur path key (assoc! res (conj path key) (number-type (.getNumberType p))))
-            JsonToken/VALUE_NUMBER_FLOAT (recur path key (assoc! res (conj path key) (number-type (.getNumberType p))))
-            JsonToken/VALUE_TRUE         (recur path key (assoc! res (conj path key) Boolean))
-            JsonToken/VALUE_FALSE        (recur path key (assoc! res (conj path key) Boolean))
-            JsonToken/VALUE_NULL         (recur path key (assoc! res (conj path key) nil))
-            JsonToken/VALUE_STRING       (recur path key (assoc! res (conj path key)
-                                                                 (type-by-parsing-string (.getText p))))
+            JsonToken/VALUE_NUMBER_INT   (recur path key (assoc! res next-path (number-type (.getNumberType p))))
+            JsonToken/VALUE_NUMBER_FLOAT (recur path key (assoc! res next-path (number-type (.getNumberType p))))
+            JsonToken/VALUE_TRUE         (recur path key (assoc! res next-path Boolean))
+            JsonToken/VALUE_FALSE        (recur path key (assoc! res next-path Boolean))
+            JsonToken/VALUE_NULL         (recur path key (assoc! res next-path nil))
+            JsonToken/VALUE_STRING       (recur path key (assoc! res next-path (type-by-parsing-string (.getText p))))
             JsonToken/FIELD_NAME         (recur path (.getText p) res)
-            JsonToken/START_OBJECT       (recur (cond-> path key (conj key)) key res)
+            JsonToken/START_OBJECT       (recur next-path key res)
             JsonToken/END_OBJECT         (recur (cond-> path (seq path) pop) key res)
             ;; We put top-level array row type semantics on JSON roadmap but skip for now
             JsonToken/START_ARRAY        (do (.skipChildren p)
-                                             (if key
-                                               (recur path key (assoc! res (conj path key) clojure.lang.PersistentVector))
-                                               (recur path key res)))
+                                             (recur path key (assoc! res next-path clojure.lang.PersistentVector)))
             JsonToken/END_ARRAY          (recur path key res)))))))
 
 (defn- json-map->types [json-map]


### PR DESCRIPTION
Right now a json value which is not an object causes invalid row description to be generated, which causes NPE down the line.

This fixes it.