### PR TITLE
Record Task History exception correctly during sync

### DIFF
--- a/src/metabase/sync/util.clj
+++ b/src/metabase/sync/util.clj
@@ -462,10 +462,13 @@
                             (name-for-logging database))
                     (fn [& args]
                       (try
-                        (task-history/with-task-history {:task            step-name
-                                                         :db_id           (u/the-id database)
-                                                         :on-success-info (fn [result]
-                                                                            {:task_details (dissoc result :start-time :end-time :log-summary-fn)})}
+                        (task-history/with-task-history
+                          {:task            step-name
+                           :db_id           (u/the-id database)
+                           :on-success-info (fn [result]
+                                              (if (instance? Throwable result)
+                                                (throw result)
+                                                {:task_details (dissoc result :start-time :end-time :log-summary-fn)}))}
                           (apply sync-fn database args))
                         (catch Throwable e
                           (if *log-exceptions-and-continue?*


### PR DESCRIPTION
Currently, if there is a failure during the sync processes, the exception in task_details is the exception that was thrown by the sync step [see](https://stats.metabase.com/question?objectId=9441777#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjoxMiwidHlwZSI6InF1ZXJ5IiwicXVlcnkiOnsic291cmNlLXRhYmxlIjo1NTUwLCJmaWx0ZXIiOlsiPSIsWyJmaWVsZCIsNjYxMDA2LHsiYmFzZS10eXBlIjoidHlwZS9UZXh0In1dLCJmYWlsZWQiXX19LCJkaXNwbGF5IjoidGFibGUiLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7fX0=).

The exception that's being recorded is the exception from 

https://github.com/metabase/metabase/blob/25c4cb0bd8c93201981e271fa722eb4929add23e/src/metabase/sync/util.clj#L468C95-L468C96

In here, `result` is an Exception because most sync steps are wrapped with `(sync-util/with-error-handling)`, which have a try catch and suppresses the exception.

And when we `(dissoc result ...)`, it throws a class error.

This fixes so that the `task_details` records the exception was thrown by the sync process, not the `dissoc` operation.

Before:
```clojure
(run-step-with-metadata (t2/select-one :model/Database)
                        (create-sync-step "sync-1"
                                          (fn [_]
                                              (with-error-handling "error runninng sync-1"
                                               (name nil)))))

(t2/select-one :model/TaskHistory :task "sync-1")
{:id 649,
  :task "sync-1",
  :db_id 13371337,
  :started_at #t "2024-06-07T12:25:19.950087Z",
  :ended_at #t "2024-06-07T12:25:19.957677Z",
  :duration 7,
  :task_details
  {:status "failed",
   :exception "class java.lang.ClassCastException",
   :message
   "class java.lang.NullPointerException cannot be cast to class clojure.lang.IPersistentMap (java.lang.NullPointerException is in module java.base of loader 'bootstrap'; clojure.lang.IPersistentMap is in unnamed module of loader 'app')",
   :stacktrace
   ["clojure.lang.RT.dissoc(RT.java:891)"
    "clojure.core$dissoc.invokeStatic(core.clj:1526)"
    "clojure.core$dissoc.invokeStatic(core.clj:1519)"
    "clojure.core$dissoc.doInvoke(core.clj:1519)"
    "clojure.lang.RestFn.invoke(RestFn.java:464)"
    "--> sync.util$fn__193340$_AMPERSAND_f__193342$fn__193344$fn__193345.invoke(NO_SOURCE_FILE:468)"
    "models.task_history$fn__190282$_AMPERSAND_f__190283.invoke(NO_SOURCE_FILE:119)"
    "models.task_history$fn__190282$fn__190286.invoke(NO_SOURCE_FILE:105)"
    "sync.util$fn__193340$_AMPERSAND_f__193342$fn__193344.doInvoke(NO_SOURCE_FILE:465)"
    "sync.util$with_start_and_finish_logging_STAR_.invokeStatic(NO_SOURCE_FILE:129)"
    "sync.util$with_start_and_finish_logging_STAR_.invoke(NO_SOURCE_FILE:123)"
    "sync.util$do_with_start_and_finish_debug_logging.invokeStatic(NO_SOURCE_FILE:147)"
    "sync.util$do_with_start_and_finish_debug_logging.invoke(NO_SOURCE_FILE:143)"
    "sync.util$fn__193340$_AMPERSAND_f__193342.invoke(NO_SOURCE_FILE:459)"
    "sync.util$fn__193340$fn__193353.invoke(NO_SOURCE_FILE:454)"
    "sync.util$eval193385.invokeStatic(NO_SOURCE_FILE:483)"
    "sync.util$eval193385.invoke(NO_SOURCE_FILE:483)"],
   :ex-data nil,
   :original-info nil},
  :status :failed}
```

After:

```clojure
(run-step-with-metadata (t2/select-one :model/Database)
                        (create-sync-step "sync-2"
                                          (fn [_]
                                              (with-error-handling "error runninng sync-1"
                                               (name nil)))))

(t2/select-one :model/TaskHistory :task "sync-2")
{:id 646,
  :task "sync-2",
  :db_id 13371337,
  :started_at #t "2024-06-07T12:17:35.757330Z",
  :ended_at #t "2024-06-07T12:17:35.767146Z",
  :duration 9,
  :task_details
  {:status "failed",
   :exception "class java.lang.NullPointerException",
   :message
   "Cannot invoke \"clojure.lang.Named.getName()\" because \"x\" is null",
   :stacktrace
   ["clojure.core$name.invokeStatic(core.clj:1610)"
    "clojure.core$name.invoke(core.clj:1604)"
    "--> sync.util$eval193321$fn__193322$fn__193323.invoke(NO_SOURCE_FILE:488)"
    "sync.util$do_with_error_handling.invokeStatic(NO_SOURCE_FILE:188)"
    "sync.util$do_with_error_handling.invoke(NO_SOURCE_FILE:181)"
    "sync.util$eval193321$fn__193322.invoke(NO_SOURCE_FILE:487)"
    "sync.util$fn__193305$_AMPERSAND_f__193307$fn__193309$fn__193312.invoke(NO_SOURCE_FILE:471)"
    "models.task_history$fn__190282$_AMPERSAND_f__190283.invoke(NO_SOURCE_FILE:116)"
    "models.task_history$fn__190282$fn__190286.invoke(NO_SOURCE_FILE:105)"
    "sync.util$fn__193305$_AMPERSAND_f__193307$fn__193309.doInvoke(NO_SOURCE_FILE:465)"
    "sync.util$with_start_and_finish_logging_STAR_.invokeStatic(NO_SOURCE_FILE:129)"
    "sync.util$with_start_and_finish_logging_STAR_.invoke(NO_SOURCE_FILE:123)"
    "sync.util$do_with_start_and_finish_debug_logging.invokeStatic(NO_SOURCE_FILE:147)"
    "sync.util$do_with_start_and_finish_debug_logging.invoke(NO_SOURCE_FILE:143)"
    "sync.util$fn__193305$_AMPERSAND_f__193307.invoke(NO_SOURCE_FILE:459)"
    "sync.util$fn__193305$fn__193318.invoke(NO_SOURCE_FILE:454)"
    "sync.util$eval193321.invokeStatic(NO_SOURCE_FILE:484)"
    "sync.util$eval193321.invoke(NO_SOURCE_FILE:484)"],
   :ex-data nil,
   :original-info nil},
  :status :failed}