### PR TITLE
Rename 'direct' fields references to 'explicit'

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -8053,6 +8053,18 @@ databaseChangeLog:
         - customChange:
             class: "metabase.db.custom_migrations.MigrateMetricsToV2"
 
+
+  - changeSet:
+      id: v50.2024-06-07T12:37:36
+      author: crisptrutski
+      comment: Rename query_field.direct_reference to query_field.indirect_reference
+      changes:
+        - renameColumn:
+            tableName: query_field
+            columnDataType: ${boolean.type}
+            oldColumnName: direct_reference
+            newColumnName: explicit_reference
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -8055,7 +8055,7 @@ databaseChangeLog:
 
 
   - changeSet:
-      id: v50.2024-06-07T12:37:36
+      id: v51.2024-06-07T12:37:36
       author: crisptrutski
       comment: Rename query_field.direct_reference to query_field.indirect_reference
       changes:

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -8053,7 +8053,6 @@ databaseChangeLog:
         - customChange:
             class: "metabase.db.custom_migrations.MigrateMetricsToV2"
 
-
   - changeSet:
       id: v51.2024-06-07T12:37:36
       author: crisptrutski
@@ -8064,6 +8063,7 @@ databaseChangeLog:
             columnDataType: ${boolean.type}
             oldColumnName: direct_reference
             newColumnName: explicit_reference
+
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/src/metabase/models/query_field.clj
+++ b/src/metabase/models/query_field.clj
@@ -18,7 +18,7 @@
 
 (defn- query-field-ids
   "Find out ids of all fields used in a query. Conforms to the same protocol as [[query-analyzer/field-ids-for-sql]],
-  so returns `{:direct #{...int ids}}` map.
+  so returns `{:explicit #{...int ids}}` map.
 
   Does not track wildcards for queries rendered as tables afterwards."
   [query]
@@ -27,8 +27,8 @@
                   (query-analyzer/field-ids-for-sql query)
                   (catch Exception e
                     (log/error e "Error parsing SQL" query)))
-    :query      {:direct (mbql.u/referenced-field-ids query)}
-    :mbql/query {:direct (lib.util/referenced-field-ids query)}
+    :query      {:explicit (mbql.u/referenced-field-ids query)}
+    :mbql/query {:explicit (lib.util/referenced-field-ids query)}
     nil))
 
 (defn update-query-fields-for-card!
@@ -39,14 +39,14 @@
   Returns `nil` (and logs the error) if there was a parse error."
   [{card-id :id, query :dataset_query}]
   (try
-    (let [{:keys [direct indirect] :as res} (query-field-ids query)
-          id->row                           (fn [direct? field-id]
-                                              {:card_id          card-id
-                                               :field_id         field-id
-                                               :direct_reference direct?})
-          query-field-rows                  (concat
-                                             (map (partial id->row true) direct)
-                                             (map (partial id->row false) indirect))]
+    (let [{:keys [explicit implicit] :as res} (query-field-ids query)
+          id->row                             (fn [explicit? field-id]
+                                                {:card_id            card-id
+                                                 :field_id           field-id
+                                                 :explicit_reference explicit?})
+          query-field-rows                    (concat
+                                               (map (partial id->row true) explicit)
+                                               (map (partial id->row false) implicit))]
       ;; when response is `nil`, it's a disabled parser, not unknown columns
       (when (some? res)
         (t2/with-transaction [_conn]
@@ -66,6 +66,6 @@
               (t2/insert! :model/QueryField to-create))
             (doseq [item to-update]
               (t2/update! :model/QueryField {:card_id card-id :field_id (:field_id item)}
-                          (select-keys item [:direct_reference])))))))
+                          (select-keys item [:explicit_reference])))))))
     (catch Exception e
       (log/error e "Error updating query fields"))))

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -1761,7 +1761,7 @@
           (is (= 0 (count (pulse-channel-test/send-pulse-triggers pulse-id)))))
         (testing "the init-send-pulse-triggers job should be re-run after migrate up"
           (migrate!)
-          ;; we need to redef this so quarzt trigger that run on a different thread use the same db connection as this test
+          ;; we need to redef this so quartz trigger that run on a different thread use the same db connection as this test
           (with-redefs [mdb.connection/*application-db* mdb.connection/*application-db*]
             ;; simulate starting MB after migrate up, which will trigger this function
             (task/init! ::task.send-pulses/SendPulses)

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -312,8 +312,8 @@
 
 (deftest downgrade-dashboard-tabs-test
   (testing "Migrations v47.00-029: downgrade dashboard tab test"
-    ;; it's "v47.00-030" but not "v47.00-029" because for some reasons,
-    ;; SOMETIMES the rollback of custom migration doens't get triggered on mysql and this test got flaky.
+    ;; it's "v47.00-030" but not "v47.00-029" for some reason,
+    ;; SOMETIMES the rollback of custom migration doesn't get triggered on mysql and this test got flaky.
     (impl/test-migrations "v47.00-030" [migrate!]
       (migrate!)
       (let [user-id      (first (t2/insert-returning-pks! (t2/table-name :model/User) {:first_name  "Howard"

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -1761,7 +1761,7 @@
           (is (= 0 (count (pulse-channel-test/send-pulse-triggers pulse-id)))))
         (testing "the init-send-pulse-triggers job should be re-run after migrate up"
           (migrate!)
-          ;; we need to redef this so quartz trigger that run on a different thread use the same db connection as this test
+          ;; we need to redef this so quarz trigger that run on a different thread use the same db connection as this test
           (with-redefs [mdb.connection/*application-db* mdb.connection/*application-db*]
             ;; simulate starting MB after migrate up, which will trigger this function
             (task/init! ::task.send-pulses/SendPulses)

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -1761,7 +1761,7 @@
           (is (= 0 (count (pulse-channel-test/send-pulse-triggers pulse-id)))))
         (testing "the init-send-pulse-triggers job should be re-run after migrate up"
           (migrate!)
-          ;; we need to redef this so quarz trigger that run on a different thread use the same db connection as this test
+          ;; we redefine this so quartz triggers that run on different threads use the same db connection as this test
           (with-redefs [mdb.connection/*application-db* mdb.connection/*application-db*]
             ;; simulate starting MB after migrate up, which will trigger this function
             (task/init! ::task.send-pulses/SendPulses)

--- a/test/metabase/db/schema_migrations_test/impl.clj
+++ b/test/metabase/db/schema_migrations_test/impl.clj
@@ -237,7 +237,9 @@
                      (assert (int? version), "Downgrade requires a version")
                      (mdb/migrate! (mdb/data-source) :down version)
                      ;; We may have rolled back migrations prior to start-id, so its no longer safe to start from there.
-                     (reset! restart-id (t2/select-one-pk :databasechangelog {:order-by [[:orderexecuted :desc]]}))))))]
+                     (liquibase/with-liquibase [liquibase conn]
+                       (let [table-name (.getDatabaseChangeLogTableName (.getDatabase liquibase))]
+                         (reset! restart-id (t2/select-one-pk table-name {:order-by [[:orderexecuted :desc]]}))))))))]
         (f migrate))))
   (log/debug (u/format-color 'green "Done testing migrations for driver %s." driver)))
 

--- a/test/metabase/native_query_analyzer_test.clj
+++ b/test/metabase/native_query_analyzer_test.clj
@@ -35,33 +35,33 @@
     (let [q (fn [sql]
               (#'query-analyzer/field-ids-for-sql (mt/native-query {:query sql})))]
       (testing "simple query matches"
-        (is (= {:direct #{(mt/id :venues :id)} :indirect nil}
+        (is (= {:explicit #{(mt/id :venues :id)} :implicit nil}
                (q "select id from venues"))))
       (testing "quotes stop case matching"
         ;; MySQL does case-insensitive string comparisons by default; quoting does not make it consider case
         ;; in field names either, so it's consistent behavior
         (if (= (mdb.connection/db-type) :mysql)
-          (is (= {:direct #{(mt/id :venues :id)} :indirect nil}
+          (is (= {:explicit #{(mt/id :venues :id)} :implicit nil}
                  (q "select \"id\" from venues")))
-          (is (= {:direct nil :indirect nil}
+          (is (= {:explicit nil :implicit nil}
                  (q "select \"id\" from venues"))))
-        (is (= {:direct #{(mt/id :venues :id)} :indirect nil}
+        (is (= {:explicit #{(mt/id :venues :id)} :implicit nil}
                (q "select \"ID\" from venues"))))
       (testing "you can mix quoted and unquoted names"
-        (is (= {:direct #{(mt/id :venues :id) (mt/id :venues :name)} :indirect nil}
+        (is (= {:explicit #{(mt/id :venues :id) (mt/id :venues :name)} :implicit nil}
                (q "select v.\"ID\", v.name from venues")))
-        (is (= {:direct #{(mt/id :venues :id) (mt/id :venues :name)} :indirect nil}
+        (is (= {:explicit #{(mt/id :venues :id) (mt/id :venues :name)} :implicit nil}
                (q "select v.`ID`, v.name from venues"))))
       (testing "It will find all relevant columns if query is not specific"
-        (is (= {:direct #{(mt/id :venues :id) (mt/id :checkins :id)} :indirect nil}
+        (is (= {:explicit #{(mt/id :venues :id) (mt/id :checkins :id)} :implicit nil}
                (q "select id from venues join checkins"))))
       (testing "But if you are specific - then it's a concrete field"
-        (is (= {:direct #{(mt/id :venues :id)} :indirect nil}
+        (is (= {:explicit #{(mt/id :venues :id)} :implicit nil}
                (q "select v.id from venues v join checkins"))))
       (testing "And wildcards are matching everything"
         (is (= 10
                (-> (q "select * from venues v join checkins")
-                   :indirect count)))
+                   :implicit count)))
         (is (= 6
                (-> (q "select v.* from venues v join checkins")
-                   :indirect count)))))))
+                   :implicit count)))))))


### PR DESCRIPTION
Refs #43725

### Description

This renames `:model/QueryField` `direct_reference` to `explicit_reference`, and renames the corresponding in-memory keys as well:

- `:direct` → `:explicit`
- `:indirect` → `:implicit`

This naming is slightly less ambiguous semantically, but more importantly it makes "direct" and "indirect" available as terminology for a new concept: whether we are directly referencing a table, or we are getting it indirectly via another card or a snippet.

This distinction will be important for knowing whether to rename particular fields, and whether there are other cards that need to be updated in order for the card to still work.