### PR TITLE
Change the `uploads-enabled` setting's visibility to internal

### DIFF
--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -829,7 +829,7 @@ See [fonts](../configuring-metabase/fonts.md).")
 
 (defsetting ^{:deprecated "0.50.0"} uploads-enabled
   (deferred-tru "Whether or not uploads are enabled")
-  :visibility :authenticated
+  :visibility :internal
   :export?    false
   :type       :boolean
   :default    false

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -833,7 +833,7 @@ See [fonts](../configuring-metabase/fonts.md).")
   :export?    false
   :type       :boolean
   :default    false
-  :getter     (fn []  (log/warn "'uploads-enabled' has been removed; use 'uploads_enabled' on the database instead"))
+  :getter     (fn [])
   :setter     (fn [_] (log/warn "'uploads-enabled' has been removed; use 'uploads_enabled' on the database instead")))
 
 (defsetting ^{:deprecated "0.50.0"} uploads-database-id
@@ -841,7 +841,7 @@ See [fonts](../configuring-metabase/fonts.md).")
   :visibility :internal
   :export?    false
   :type       :integer
-  :getter     (fn []  (log/warn "'uploads-database-id' has been removed; use 'uploads_enabled' on the database instead"))
+  :getter     (fn [])
   :setter     (fn [_] (log/warn "'uploads-database-id' has been removed; use 'uploads_enabled' on the database instead")))
 
 (defsetting ^{:deprecated "0.50.0"} uploads-schema-name
@@ -849,7 +849,7 @@ See [fonts](../configuring-metabase/fonts.md).")
   :visibility :internal
   :export?    false
   :type       :string
-  :getter     (fn []  (log/warn "'uploads-schema-name' has been removed; use 'uploads_schema_name' on the database instead"))
+  :getter     (fn [])
   :setter     (fn [_] (log/warn "'uploads-schema-name' has been removed; use 'uploads_schema_name' on the database instead")))
 
 (defsetting ^{:deprecated "0.50.0"} uploads-table-prefix
@@ -857,7 +857,7 @@ See [fonts](../configuring-metabase/fonts.md).")
   :visibility :internal
   :export?    false
   :type       :string
-  :getter     (fn []  (log/warn "'uploads-table-prefix' has been removed; use 'uploads_table_prefix' on the database instead"))
+  :getter     (fn [])
   :setter     (fn [_] (log/warn "'uploads-table-prefix' has been removed; use 'uploads_table_prefix' on the database instead")))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -833,7 +833,7 @@ See [fonts](../configuring-metabase/fonts.md).")
   :export?    false
   :type       :boolean
   :default    false
-  :getter     (fn [])
+  :getter     (fn [] (throw (Exception. "uploads-enabled has been removed; use 'uploads_enabled' on the database instead")))
   :setter     (fn [_] (log/warn "'uploads-enabled' has been removed; use 'uploads_enabled' on the database instead")))
 
 (defsetting ^{:deprecated "0.50.0"} uploads-database-id
@@ -841,7 +841,7 @@ See [fonts](../configuring-metabase/fonts.md).")
   :visibility :internal
   :export?    false
   :type       :integer
-  :getter     (fn [])
+  :getter     (fn [] (throw (Exception. "uploads-database-id has been removed; use 'uploads_enabled' on the database instead")))
   :setter     (fn [_] (log/warn "'uploads-database-id' has been removed; use 'uploads_enabled' on the database instead")))
 
 (defsetting ^{:deprecated "0.50.0"} uploads-schema-name
@@ -849,7 +849,7 @@ See [fonts](../configuring-metabase/fonts.md).")
   :visibility :internal
   :export?    false
   :type       :string
-  :getter     (fn [])
+  :getter     (fn [] (throw (Exception. "uploads-schema-name has been removed; use 'uploads_schema_name' on the database instead")))
   :setter     (fn [_] (log/warn "'uploads-schema-name' has been removed; use 'uploads_schema_name' on the database instead")))
 
 (defsetting ^{:deprecated "0.50.0"} uploads-table-prefix
@@ -857,7 +857,7 @@ See [fonts](../configuring-metabase/fonts.md).")
   :visibility :internal
   :export?    false
   :type       :string
-  :getter     (fn [])
+  :getter     (fn [] (throw (Exception. "uploads-table-prefix has been removed; use 'uploads_table_prefix' on the database instead")))
   :setter     (fn [_] (log/warn "'uploads-table-prefix' has been removed; use 'uploads_table_prefix' on the database instead")))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/43756

The problem was that the `uploads-enabled` setting had `visibility=authenticated`, when it should have had `visibility=internal`. Settings with `visibility=authenticated` get their values called in request handlers like for `GET /api/settings`. There is not any code that iterates over all settings with `visibility=internal` calling their getters. That's a stable guarantee because this is used for env vars and we shouldn't have any reason for iterating over all env vars anywhere: they are not sent to the FE and do not need to be cached.

I've also changed the getters from logging an error to throwing an exception to make sure that they're not being called in the future. If they were being called our tests would surely catch it.