### PR TITLE
docs - update upload setting metadata

### DIFF
--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -829,7 +829,7 @@ See [fonts](../configuring-metabase/fonts.md).")
 
 (defsetting ^{:deprecated "0.50.0"} uploads-enabled
   (deferred-tru "Whether or not uploads are enabled")
-  :deprecated true
+  :deprecated "0.50.0"
   :visibility :authenticated
   :export?    false
   :type       :boolean
@@ -839,7 +839,7 @@ See [fonts](../configuring-metabase/fonts.md).")
 
 (defsetting ^{:deprecated "0.50.0"} uploads-database-id
   (deferred-tru "Database ID for uploads")
-  :deprecated true
+  :deprecated "0.50.0"
   :visibility :internal
   :export?    false
   :type       :integer
@@ -848,7 +848,7 @@ See [fonts](../configuring-metabase/fonts.md).")
 
 (defsetting ^{:deprecated "0.50.0"} uploads-schema-name
   (deferred-tru "Schema name for uploads")
-  :deprecated true
+  :deprecated "0.50.0"
   :visibility :internal
   :export?    false
   :type       :string
@@ -857,7 +857,7 @@ See [fonts](../configuring-metabase/fonts.md).")
 
 (defsetting ^{:deprecated "0.50.0"} uploads-table-prefix
   (deferred-tru "Prefix for upload table names")
-  :deprecated true
+  :deprecated "0.50.0"
   :visibility :internal
   :export?    false
   :type       :string

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -829,6 +829,7 @@ See [fonts](../configuring-metabase/fonts.md).")
 
 (defsetting ^{:deprecated "0.50.0"} uploads-enabled
   (deferred-tru "Whether or not uploads are enabled")
+  :deprecated true
   :visibility :authenticated
   :export?    false
   :type       :boolean
@@ -838,6 +839,7 @@ See [fonts](../configuring-metabase/fonts.md).")
 
 (defsetting ^{:deprecated "0.50.0"} uploads-database-id
   (deferred-tru "Database ID for uploads")
+  :deprecated true
   :visibility :internal
   :export?    false
   :type       :integer
@@ -846,6 +848,7 @@ See [fonts](../configuring-metabase/fonts.md).")
 
 (defsetting ^{:deprecated "0.50.0"} uploads-schema-name
   (deferred-tru "Schema name for uploads")
+  :deprecated true
   :visibility :internal
   :export?    false
   :type       :string
@@ -854,6 +857,7 @@ See [fonts](../configuring-metabase/fonts.md).")
 
 (defsetting ^{:deprecated "0.50.0"} uploads-table-prefix
   (deferred-tru "Prefix for upload table names")
+  :deprecated true
   :visibility :internal
   :export?    false
   :type       :string

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -827,7 +827,7 @@ See [fonts](../configuring-metabase/fonts.md).")
 ;; These settings were removed in 50.0 and will be erased from the code in 53.0. They have been left here to explain how
 ;; to migrate to the new way to set uploads settings.
 
-(defsetting ^{:deprecated "0.50.0"} uploads-enabled
+(defsetting uploads-enabled
   (deferred-tru "Whether or not uploads are enabled")
   :deprecated "0.50.0"
   :visibility :authenticated
@@ -837,7 +837,7 @@ See [fonts](../configuring-metabase/fonts.md).")
   :getter     (fn []  (log/warn "'uploads-enabled' has been removed; use 'uploads_enabled' on the database instead"))
   :setter     (fn [_] (log/warn "'uploads-enabled' has been removed; use 'uploads_enabled' on the database instead")))
 
-(defsetting ^{:deprecated "0.50.0"} uploads-database-id
+(defsetting uploads-database-id
   (deferred-tru "Database ID for uploads")
   :deprecated "0.50.0"
   :visibility :internal
@@ -846,7 +846,7 @@ See [fonts](../configuring-metabase/fonts.md).")
   :getter     (fn []  (log/warn "'uploads-database-id' has been removed; use 'uploads_enabled' on the database instead"))
   :setter     (fn [_] (log/warn "'uploads-database-id' has been removed; use 'uploads_enabled' on the database instead")))
 
-(defsetting ^{:deprecated "0.50.0"} uploads-schema-name
+(defsetting uploads-schema-name
   (deferred-tru "Schema name for uploads")
   :deprecated "0.50.0"
   :visibility :internal
@@ -855,7 +855,7 @@ See [fonts](../configuring-metabase/fonts.md).")
   :getter     (fn []  (log/warn "'uploads-schema-name' has been removed; use 'uploads_schema_name' on the database instead"))
   :setter     (fn [_] (log/warn "'uploads-schema-name' has been removed; use 'uploads_schema_name' on the database instead")))
 
-(defsetting ^{:deprecated "0.50.0"} uploads-table-prefix
+(defsetting uploads-table-prefix
   (deferred-tru "Prefix for upload table names")
   :deprecated "0.50.0"
   :visibility :internal


### PR DESCRIPTION
Adds `:deprecated` keys to old upload defsettings.