### PR TITLE
Fix CloudPanel unit flake

### DIFF
--- a/frontend/src/metabase/admin/settings/components/CloudPanel/CloudPanel.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/CloudPanel/CloudPanel.unit.spec.tsx
@@ -78,7 +78,6 @@ describe("CloudPanel", () => {
       UNINITIALIZED_RESPONSE,
       INIT_RESPONSE,
       SETUP_RESPONSE,
-      CANCELED_RESPONSE,
     ]);
 
     await expectProgressState(metabaseStoreLink);
@@ -103,6 +102,10 @@ describe("CloudPanel", () => {
       ).toBeTruthy();
     });
     expect((store.getState() as any).undo).toHaveLength(1);
+
+    fetchMockCloudMigrationGetSequence([CANCELED_RESPONSE]);
+
+    await expectInitState();
   });
 
   it("should show user error if something fails", async () => {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/43699

### Description

Fixes a flake in the CloudPanel unit test where the `CANCELED_RESPONSE` would get returned from the API before the user had completed the cancelation flow when tests were run too slowly in CI (this feature polls, i was able to confirm the polling was happening faster than the component was updating). This ultimately is a logical mistake on my end and both fails the test but defeats the purpose of the test. Removing that response will keep the test in an in progress state and then only after the cancelation request has been observed do we start mocking a canceled response.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
