### PR TITLE
Minor refactoring in JWT/SAML tests

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -9,6 +9,7 @@
    [metabase-enterprise.sso.integrations.saml-test :as saml-test]
    [metabase-enterprise.sso.integrations.sso-settings :as sso-settings]
    [metabase.config :as config]
+   [metabase.http-client :as client]
    [metabase.models.permissions-group :refer [PermissionsGroup]]
    [metabase.models.permissions-group-membership
     :refer [PermissionsGroupMembership]]
@@ -30,16 +31,16 @@
 
 (use-fixtures :each disable-other-sso-types)
 
+(defn- disable-api-url-prefix
+  [thunk]
+  (binding [client/*url-prefix* ""]
+    (thunk)))
+
+(use-fixtures :each disable-api-url-prefix)
+
 (def ^:private default-idp-uri      "http://test.idp.metabase.com")
 (def ^:private default-redirect-uri "/")
 (def ^:private default-jwt-secret   (crypto-random/hex 32))
-
-(defmacro with-sso-jwt-token
-  "Stubs the [[premium-features/*token-features*]] function to simulate a premium token with the `:sso-jwt` feature.
-   This needs to be included to test any of the JWT features."
-  [& body]
-  `(mt/with-additional-premium-features #{:sso-jwt}
-     ~@body))
 
 (defn- call-with-default-jwt-config [f]
   (let [current-features (premium-features/*token-features*)]
@@ -61,7 +62,7 @@
      (mt/with-premium-features #{:audit-app}
        (disable-other-sso-types
         (fn []
-          (with-sso-jwt-token
+          (mt/with-additional-premium-features #{:sso-jwt}
             (saml-test/call-with-login-attributes-cleared!
              (fn []
                (call-with-default-jwt-config
@@ -69,55 +70,55 @@
                   ~@body))))))))))
 
 (deftest sso-prereqs-test
-  (with-sso-jwt-token
+  (mt/with-additional-premium-features #{:sso-jwt}
     (testing "SSO requests fail if JWT hasn't been configured or enabled"
       (mt/with-temporary-setting-values [jwt-enabled               false
                                          jwt-identity-provider-uri nil
                                          jwt-shared-secret         nil]
         (is (= "SSO has not been enabled and/or configured"
-               (saml-test/client :get 400 "/auth/sso")))
+               (client/client :get 400 "/auth/sso")))
 
         (testing "SSO requests fail if they don't have a valid premium-features token"
           (with-default-jwt-config
             (mt/with-premium-features #{}
               (is (= "SSO has not been enabled and/or configured"
-                     (saml-test/client :get 400 "/auth/sso"))))))))
+                     (client/client :get 400 "/auth/sso"))))))))
 
     (testing "SSO requests fail if JWT is enabled but hasn't been configured"
       (mt/with-temporary-setting-values [jwt-enabled               true
                                          jwt-identity-provider-uri nil]
         (is (= "SSO has not been enabled and/or configured"
-               (saml-test/client :get 400 "/auth/sso")))))
+               (client/client :get 400 "/auth/sso")))))
 
     (testing "SSO requests fail if JWT is configured but hasn't been enabled"
       (mt/with-temporary-setting-values [jwt-enabled               false
                                          jwt-identity-provider-uri default-idp-uri
                                          jwt-shared-secret         default-jwt-secret]
         (is (= "SSO has not been enabled and/or configured"
-               (saml-test/client :get 400 "/auth/sso")))))
+               (client/client :get 400 "/auth/sso")))))
 
     (testing "The JWT Shared Secret must also be included for SSO to be configured"
       (mt/with-temporary-setting-values [jwt-enabled               true
                                          jwt-identity-provider-uri default-idp-uri
                                          jwt-shared-secret         nil]
         (is (= "SSO has not been enabled and/or configured"
-               (saml-test/client :get 400 "/auth/sso")))))))
+               (client/client :get 400 "/auth/sso")))))))
 
 (deftest redirect-test
   (testing "with JWT configured, a GET request should result in a redirect to the IdP"
     (with-jwt-default-setup
-      (let [result       (saml-test/client-full-response :get 302 "/auth/sso"
-                                                         {:request-options {:redirect-strategy :none}}
-                                                         :redirect default-redirect-uri)
+      (let [result       (client/client-full-response :get 302 "/auth/sso"
+                                                      {:request-options {:redirect-strategy :none}}
+                                                      :redirect default-redirect-uri)
             redirect-url (get-in result [:headers "Location"])]
         (is (str/starts-with? redirect-url default-idp-uri)))))
   (testing (str "JWT configured with a redirect-uri containing query params, "
                 "a GET request should result in a redirect to the IdP as a correctly formatted URL (#13078)")
     (with-jwt-default-setup
       (mt/with-temporary-setting-values [jwt-identity-provider-uri "http://test.idp.metabase.com/login?some_param=yes"]
-        (let [result       (saml-test/client-full-response :get 302 "/auth/sso"
-                                                           {:request-options {:redirect-strategy :none}}
-                                                           :redirect default-redirect-uri)
+        (let [result       (client/client-full-response :get 302 "/auth/sso"
+                                                        {:request-options {:redirect-strategy :none}}
+                                                        :redirect default-redirect-uri)
               redirect-url (get-in result [:headers "Location"])]
           (is (str/includes? redirect-url "&return_to=")))))))
 
@@ -125,15 +126,15 @@
   (with-jwt-default-setup
     (saml-test/with-saml-default-setup
       (testing "with SAML and JWT configured, a GET request with JWT params should sign in correctly"
-        (let [response (saml-test/client-full-response :get 302 "/auth/sso"
-                                                       {:request-options {:redirect-strategy :none}}
-                                                       :return_to default-redirect-uri
-                                                       :jwt (jwt/sign {:email      "rasta@metabase.com"
-                                                                       :first_name "Rasta"
-                                                                       :last_name  "Toucan"
-                                                                       :extra      "keypairs"
-                                                                       :are        "also present"}
-                                                                      default-jwt-secret))]
+        (let [response (client/client-real-response :get 302 "/auth/sso"
+                                                    {:request-options {:redirect-strategy :none}}
+                                                    :return_to default-redirect-uri
+                                                    :jwt (jwt/sign {:email      "rasta@metabase.com"
+                                                                    :first_name "Rasta"
+                                                                    :last_name  "Toucan"
+                                                                    :extra      "keypairs"
+                                                                    :are        "also present"}
+                                                                   default-jwt-secret))]
           (is (saml-test/successful-login? response))
           (testing "redirect URI"
             (is (= default-redirect-uri
@@ -143,23 +144,23 @@
                    (t2/select-one-fn :login_attributes User :email "rasta@metabase.com"))))))
 
       (testing "with SAML and JWT configured, a GET request without JWT params should redirect to SAML IdP"
-        (let [response (saml-test/client-full-response :get 302 "/auth/sso"
-                                                       {:request-options {:redirect-strategy :none}}
-                                                       :return_to default-redirect-uri)]
+        (let [response (client/client-full-response :get 302 "/auth/sso"
+                                                    {:request-options {:redirect-strategy :none}}
+                                                    :return_to default-redirect-uri)]
           (is (not (saml-test/successful-login? response))))))))
 
 (deftest happy-path-test
   (testing (str "Happy path login, valid JWT, checks to ensure the user was logged in successfully and the redirect to "
                 "the right location")
     (with-jwt-default-setup
-      (let [response (saml-test/client-full-response :get 302 "/auth/sso" {:request-options {:redirect-strategy :none}}
-                                                     :return_to default-redirect-uri
-                                                     :jwt (jwt/sign {:email      "rasta@metabase.com"
-                                                                     :first_name "Rasta"
-                                                                     :last_name  "Toucan"
-                                                                     :extra      "keypairs"
-                                                                     :are        "also present"}
-                                                                    default-jwt-secret))]
+      (let [response (client/client-real-response :get 302 "/auth/sso" {:request-options {:redirect-strategy :none}}
+                                                  :return_to default-redirect-uri
+                                                  :jwt (jwt/sign {:email      "rasta@metabase.com"
+                                                                  :first_name "Rasta"
+                                                                  :last_name  "Toucan"
+                                                                  :extra      "keypairs"
+                                                                  :are        "also present"}
+                                                                 default-jwt-secret))]
         (is (saml-test/successful-login? response))
         (testing "redirect URI"
           (is (= default-redirect-uri
@@ -174,7 +175,7 @@
       (doseq [redirect-uri ["https://badsite.com"
                             "//badsite.com"]]
         (is (= "Invalid redirect URL"
-               (-> (saml-test/client
+               (-> (client/client
                     :get 400 "/auth/sso" {:request-options {:redirect-strategy :none}}
                     :return_to redirect-uri
                     :jwt (jwt/sign {:email      "rasta@metabase.com"
@@ -189,11 +190,11 @@
   (testing "Check an expired JWT"
     (with-jwt-default-setup
       (is (= "Token is older than max-age (180)"
-             (:message (saml-test/client :get 401 "/auth/sso" {:request-options {:redirect-strategy :none}}
-                                         :return_to default-redirect-uri
-                                         :jwt (jwt/sign {:email "test@metabase.com", :first_name "Test" :last_name "User"
-                                                         :iat   (- (buddy-util/now) (u/minutes->seconds 5))}
-                                                        default-jwt-secret))))))))
+             (:message (client/client :get 401 "/auth/sso" {:request-options {:redirect-strategy :none}}
+                                      :return_to default-redirect-uri
+                                      :jwt (jwt/sign {:email "test@metabase.com", :first_name "Test" :last_name "User"
+                                                      :iat   (- (buddy-util/now) (u/minutes->seconds 5))}
+                                                     default-jwt-secret))))))))
 
 (defmacro with-users-with-email-deleted {:style/indent 1} [user-email & body]
   `(try
@@ -208,15 +209,15 @@
         (letfn [(new-user-exists? []
                   (boolean (seq (t2/select User :%lower.email "newuser@metabase.com"))))]
           (is (false? (new-user-exists?)))
-          (let [response (saml-test/client-full-response :get 302 "/auth/sso"
-                                                         {:request-options {:redirect-strategy :none}}
-                                                         :return_to default-redirect-uri
-                                                         :jwt (jwt/sign {:email      "newuser@metabase.com"
-                                                                         :first_name "New"
-                                                                         :last_name  "User"
-                                                                         :more       "stuff"
-                                                                         :for        "the new user"}
-                                                                        default-jwt-secret))]
+          (let [response (client/client-real-response :get 302 "/auth/sso"
+                                                      {:request-options {:redirect-strategy :none}}
+                                                      :return_to default-redirect-uri
+                                                      :jwt (jwt/sign {:email      "newuser@metabase.com"
+                                                                      :first_name "New"
+                                                                      :last_name  "User"
+                                                                      :more       "stuff"
+                                                                      :for        "the new user"}
+                                                                     default-jwt-secret))]
             (is (saml-test/successful-login? response))
             (let [new-user (t2/select-one User :email "newuser@metabase.com")]
               (testing "new user"
@@ -248,11 +249,11 @@
                   (boolean (seq (t2/select User :%lower.email "newuser@metabase.com"))))]
           (is (= false
                  (new-user-exists?)))
-          (let [response (saml-test/client-full-response :get 302 "/auth/sso"
-                                                         {:request-options {:redirect-strategy :none}}
-                                                         :return_to default-redirect-uri
-                                                         :jwt (jwt/sign {:email      "newuser@metabase.com"}
-                                                                        default-jwt-secret))]
+          (let [response (client/client-real-response :get 302 "/auth/sso"
+                                                      {:request-options {:redirect-strategy :none}}
+                                                      :return_to default-redirect-uri
+                                                      :jwt (jwt/sign {:email      "newuser@metabase.com"}
+                                                                     default-jwt-secret))]
             (is (saml-test/successful-login? response))
             (testing "new user with no first or last name"
               (is (= [{:email        "newuser@metabase.com"
@@ -265,13 +266,13 @@
                        :common_name  "newuser@metabase.com"}]
                      (->> (mt/boolean-ids-and-timestamps (t2/select User :email "newuser@metabase.com"))
                           (map #(dissoc % :last_login)))))))
-          (let [response (saml-test/client-full-response :get 302 "/auth/sso"
-                                                           {:request-options {:redirect-strategy :none}}
-                                                           :return_to default-redirect-uri
-                                                           :jwt (jwt/sign {:email      "newuser@metabase.com"
-                                                                           :first_name "New"
-                                                                           :last_name  "User"}
-                                                                          default-jwt-secret))]
+          (let [response (client/client-real-response :get 302 "/auth/sso"
+                                                      {:request-options {:redirect-strategy :none}}
+                                                      :return_to default-redirect-uri
+                                                      :jwt (jwt/sign {:email      "newuser@metabase.com"
+                                                                      :first_name "New"
+                                                                      :last_name  "User"}
+                                                                     default-jwt-secret))]
             (is (saml-test/successful-login? response))
             (testing "update user first and last name"
               (is (= [{:email        "newuser@metabase.com"
@@ -287,7 +288,7 @@
 
 (deftest group-mappings-test
   (testing "make sure our setting for mapping group names -> IDs works"
-    (with-sso-jwt-token
+    (mt/with-additional-premium-features #{:sso-jwt}
       (mt/with-temporary-setting-values [jwt-group-mappings {"group_1" [1 2 3]
                                                              "group_2" [3 4]
                                                              "group_3" [5]}]
@@ -310,16 +311,16 @@
                                            jwt-group-mappings   {"my_group" [(u/the-id my-group)]}
                                            jwt-attribute-groups "GrOuPs"]
           (with-users-with-email-deleted "newuser@metabase.com"
-            (let [response    (saml-test/client-full-response :get 302 "/auth/sso"
-                                                              {:request-options {:redirect-strategy :none}}
-                                                              :return_to default-redirect-uri
-                                                              :jwt (jwt/sign {:email      "newuser@metabase.com"
-                                                                              :first_name "New"
-                                                                              :last_name  "User"
-                                                                              :more       "stuff"
-                                                                              :GrOuPs     ["my_group"]
-                                                                              :for        "the new user"}
-                                                                             default-jwt-secret))]
+            (let [response    (client/client-real-response :get 302 "/auth/sso"
+                                                           {:request-options {:redirect-strategy :none}}
+                                                           :return_to default-redirect-uri
+                                                           :jwt (jwt/sign {:email      "newuser@metabase.com"
+                                                                           :first_name "New"
+                                                                           :last_name  "User"
+                                                                           :more       "stuff"
+                                                                           :GrOuPs     ["my_group"]
+                                                                           :for        "the new user"}
+                                                                          default-jwt-secret))]
               (is (saml-test/successful-login? response))
               (is (= #{"All Users"
                        ":metabase-enterprise.sso.integrations.jwt-test/my-group"}
@@ -350,9 +351,9 @@
                                       :iat        jwt-iat-time
                                       :exp        jwt-exp-time}
                                      default-jwt-secret)
-              result       (saml-test/client-full-response :get 200 "/auth/sso"
-                                                           :token true
-                                                           :jwt jwt-payload)]
+              result       (client/client-real-response :get 200 "/auth/sso"
+                                                        :token true
+                                                        :jwt jwt-payload)]
           (is (=? {:id  (mt/malli=? ms/NonBlankString)
                    :iat jwt-iat-time
                    :exp jwt-exp-time}
@@ -371,9 +372,9 @@
                                       :iat        jwt-iat-time
                                       :exp        jwt-exp-time}
                                      default-jwt-secret)
-              result       (saml-test/client-full-response :get 400 "/auth/sso"
-                                                           :token true
-                                                           :jwt jwt-payload)]
+              result       (client/client-real-response :get 400 "/auth/sso"
+                                                        :token true
+                                                        :jwt jwt-payload)]
           (is result nil)))))
 
   (testing "should not return a session token when token=false"
@@ -389,8 +390,8 @@
                                       :iat        jwt-iat-time
                                       :exp        jwt-exp-time}
                                      default-jwt-secret)
-              result       (saml-test/client-full-response :get 302 "/auth/sso"
-                                                           {:request-options {:redirect-strategy :none}}
-                                                           :return_to default-redirect-uri
-                                                           :jwt jwt-payload)]
+              result       (client/client-real-response :get 302 "/auth/sso"
+                                                        {:request-options {:redirect-strategy :none}}
+                                                        :return_to default-redirect-uri
+                                                        :jwt jwt-payload)]
           (is result nil))))))

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -50,7 +50,7 @@
   (binding [client/*url-prefix* ""]
     (thunk)))
 
-(use-fixtures :each disable-api-url-prefix)
+(use-fixtures :once disable-api-url-prefix)
 
 (def ^:private default-idp-uri            "http://test.idp.metabase.com")
 (def ^:private default-redirect-uri       "http://localhost:3000/test")

--- a/src/metabase/api/setup.clj
+++ b/src/metabase/api/setup.clj
@@ -183,18 +183,18 @@
                                                :from   [[(t2/table-name :model/Table) :t]]
                                                :join   [[(t2/table-name :model/Database) :d] [:= :d.id :t.db_id]]
                                                :where  (mi/exclude-internal-content-hsql :model/Database :table-alias :d)})))}
-   :exists     {:non-sample-db (t2/exists? :model/Database {:where (mi/exclude-internal-content-hsql :model/Database)})
-                :dashboard     (t2/exists? :model/Dashboard {:where (mi/exclude-internal-content-hsql :model/Dashboard)})
-                :pulse         (t2/exists? :model/Pulse)
-                :hidden-table  (t2/exists? :model/Table {:where [:and
-                                                                 [:not= :visibility_type nil]
-                                                                 (mi/exclude-internal-content-hsql :model/Table)]})
-                :collection    (t2/exists? :model/Collection {:where (mi/exclude-internal-content-hsql :model/Collection)})
-                :model         (t2/exists? :model/Card {:where [:and
-                                                                [:= :type "model"]
-                                                                (mi/exclude-internal-content-hsql :model/Card)]})
+   :exists     {:non-sample-db     (t2/exists? :model/Database {:where (mi/exclude-internal-content-hsql :model/Database)})
+                :dashboard         (t2/exists? :model/Dashboard {:where (mi/exclude-internal-content-hsql :model/Dashboard)})
+                :pulse             (t2/exists? :model/Pulse)
+                :hidden-table      (t2/exists? :model/Table {:where [:and
+                                                                     [:not= :visibility_type nil]
+                                                                     (mi/exclude-internal-content-hsql :model/Table)]})
+                :collection        (t2/exists? :model/Collection {:where (mi/exclude-internal-content-hsql :model/Collection)})
+                :model             (t2/exists? :model/Card {:where [:and
+                                                                    [:= :type "model"]
+                                                                    (mi/exclude-internal-content-hsql :model/Card)]})
                 :embedded-resource (or (t2/exists? :model/Card :enable_embedding true)
-                          (t2/exists? :model/Dashboard :enable_embedding true))}})
+                                       (t2/exists? :model/Dashboard :enable_embedding true))}})
 
 (defn- get-connected-tasks
   [{:keys [configured counts exists embedding] :as _info}]


### PR DESCRIPTION
Couple of small simplifications in the SSO tests that I noticed were possible while poking around this code. Everything is a no-op.
* The custom `with-sso-jwt-token` macro wasn't doing much — changed it to just use `with-additional-premium-features` directly.
* We had custom `client` and `client-full-response` macros which just wrapped the normal client functions but cleared the default URL prefix. Easier to just use a test fixture to bind the prefix once in each test namespace and then use the normal functions.

Also one random indentation fix. 
