### PR TITLE
reset series displays when changing card display

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
@@ -99,6 +99,24 @@ describe("scenarios > visualizations > line chart", () => {
     });
   });
 
+  it("should reset series settings when switching to line chart", () => {
+    visitQuestionAdhoc({
+      dataset_query: testQuery,
+      display: "area",
+    });
+
+    cy.findByTestId("viz-settings-button").click();
+    openSeriesSettings("Count");
+    cy.icon("bar").click();
+
+    cy.findByTestId("viz-type-button").click();
+
+    cy.icon("line").click();
+
+    // should be a line chart
+    cartesianChartCircleWithColor("#509EE3");
+  });
+
   it("should be able to format data point values style independently on multi-series chart (metabase#13095)", () => {
     visitQuestionAdhoc({
       dataset_query: {

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.tsx
@@ -107,7 +107,7 @@ const ChartTypeSidebar = ({
           const updatedSettings = visualization.onDisplayUpdate(
             newQuestion.settings(),
           );
-          newQuestion = newQuestion.updateSettings(updatedSettings);
+          newQuestion = newQuestion.setSettings(updatedSettings);
         }
 
         updateQuestion(newQuestion, {

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/chart-definition.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/chart-definition.ts
@@ -6,9 +6,10 @@ import {
   validateDatasetRows,
   validateStacking,
 } from "metabase/visualizations/lib/settings/validation";
+import { SERIES_SETTING_KEY } from "metabase/visualizations/shared/settings/series";
 import type { Visualization } from "metabase/visualizations/types";
 import { isDimension, isMetric } from "metabase-lib/v1/types/utils/isa";
-import type { RawSeries } from "metabase-types/api";
+import type { RawSeries, SeriesSettings } from "metabase-types/api";
 
 import { transformSeries } from "./chart-definition-legacy";
 
@@ -67,6 +68,31 @@ export const getCartesianChartDefinition = (
     ] as RawSeries,
 
     transformSeries,
+
+    onDisplayUpdate: settings => {
+      if (settings[SERIES_SETTING_KEY] == null) {
+        return settings;
+      }
+
+      const newSettings = _.omit(settings, SERIES_SETTING_KEY);
+      const newSeriesSettings: Record<string, SeriesSettings> = {};
+
+      Object.entries(settings[SERIES_SETTING_KEY]).forEach(
+        ([key, seriesSettings]) => {
+          const newSingleSeriesSettings = _.omit(seriesSettings, "display");
+
+          if (!_.isEmpty(newSingleSeriesSettings)) {
+            newSeriesSettings[key] = newSingleSeriesSettings;
+          }
+        },
+      );
+
+      if (!_.isEmpty(newSeriesSettings)) {
+        newSettings[SERIES_SETTING_KEY] = newSeriesSettings;
+      }
+
+      return newSettings;
+    },
 
     ...props,
   };

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/chart-definition.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/chart-definition.unit.spec.ts
@@ -1,0 +1,59 @@
+import { SERIES_SETTING_KEY } from "metabase/visualizations/shared/settings/series";
+
+import { getCartesianChartDefinition } from "./chart-definition";
+
+describe("chart-definition", () => {
+  describe("onDisplayUpdate", () => {
+    const onDisplayUpdate = getCartesianChartDefinition({}).onDisplayUpdate!;
+
+    it("should reset individual series display", () => {
+      const settings = {
+        "graph.y_axis.min": 50,
+        [SERIES_SETTING_KEY]: {
+          foo: {
+            title: "revenue",
+            display: "bar",
+          },
+          bar: {
+            display: "line",
+          },
+        },
+      };
+
+      expect(onDisplayUpdate(settings)).toStrictEqual({
+        "graph.y_axis.min": 50,
+        [SERIES_SETTING_KEY]: {
+          foo: {
+            title: "revenue",
+          },
+        },
+      });
+    });
+
+    it("should remove series settings when they contain only series displays", () => {
+      const settings = {
+        "graph.y_axis.min": 50,
+        [SERIES_SETTING_KEY]: {
+          foo: {
+            display: "bar",
+          },
+          bar: {
+            display: "line",
+          },
+        },
+      };
+      expect(onDisplayUpdate(settings)).toStrictEqual({
+        "graph.y_axis.min": 50,
+      });
+    });
+
+    it("should return unchanged settings when no series settings", () => {
+      const settings = {
+        "graph.y_axis.min": 50,
+      };
+      expect(onDisplayUpdate(settings)).toStrictEqual({
+        "graph.y_axis.min": 50,
+      });
+    });
+  });
+});


### PR DESCRIPTION
[Slack convo](https://metaboat.slack.com/archives/C064QMXEV9N/p1717779370442169)

### Description

When changing individual series displays and then switching to the other viz type we did not reset series displays.

### How to verify

1. New -> Orders -> Summarize Count by Created At
2. Go to "Count" series settings and make it a bar series
3. Change the question display to area
4. Ensure it shows the "Count" series as an area, not bar

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
