### PR TITLE
Remove classnames

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/caching/components/DashboardStrategySidebar.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/DashboardStrategySidebar.styled.tsx
@@ -1,17 +1,21 @@
 import styled from "@emotion/styled";
 
+import {
+  FormBox,
+  StyledFormButtonsGroup,
+} from "metabase/admin/performance/components/StrategyForm.styled";
 import { Group } from "metabase/ui";
 
 export const DashboardStrategySidebarBody = styled(Group)`
   display: flex;
   flex-flow: column nowrap;
   height: 100%;
-  .form-buttons-group {
+  ${StyledFormButtonsGroup} {
     border-top: 1px solid var(--mb-color-border);
     position: sticky;
     bottom: 0;
   }
-  .strategy-form-box {
+  ${FormBox} {
     border-bottom: 0 !important;
   }
 `;

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/SidebarCacheForm.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/SidebarCacheForm.styled.tsx
@@ -1,17 +1,21 @@
 import styled from "@emotion/styled";
 
+import {
+  StyledFormButtonsGroup,
+  FormBox,
+} from "metabase/admin/performance/components/StrategyForm.styled";
 import { Group } from "metabase/ui";
 
 export const SidebarCacheFormBody = styled(Group)`
   display: flex;
   flex-flow: column nowrap;
   height: 100%;
-  .form-buttons-group {
+  ${StyledFormButtonsGroup} {
     border-top: 1px solid var(--mb-color-border);
     position: sticky;
     bottom: 0;
   }
-  .strategy-form-box {
+  ${FormBox} {
     border-bottom: 0 !important;
   }
 `;

--- a/frontend/src/metabase/admin/performance/components/StrategyForm.tsx
+++ b/frontend/src/metabase/admin/performance/components/StrategyForm.tsx
@@ -166,7 +166,7 @@ const StrategyFormBody = ({
   return (
     <FormWrapper>
       <StyledForm style={{ overflow: isInSidebar ? undefined : "auto" }}>
-        <FormBox className="strategy-form-box">
+        <FormBox>
           {shouldShowName && (
             <Box lh="1rem" pt="md" color="text-medium">
               <Group spacing="sm">
@@ -241,10 +241,7 @@ const FormButtonsGroup = ({
   isInSidebar?: boolean;
 }) => {
   return (
-    <StyledFormButtonsGroup
-      isInSidebar={isInSidebar}
-      className="form-buttons-group"
-    >
+    <StyledFormButtonsGroup isInSidebar={isInSidebar}>
       {children}
     </StyledFormButtonsGroup>
   );


### PR DESCRIPTION
Removes the use of classNames from performance-related code. These can interfere with users' proprietary classnames in embedding contexts