### PR TITLE
Use the metric icon for metrics

### DIFF
--- a/frontend/src/metabase/lib/icon.ts
+++ b/frontend/src/metabase/lib/icon.ts
@@ -33,7 +33,7 @@ const modelIconMap: Record<IconModel, IconName> = {
   dashboard: "dashboard",
   card: "table",
   segment: "segment",
-  metric: "funnel",
+  metric: "metric",
   snippet: "unknown",
 };
 


### PR DESCRIPTION
I accidentally set the metric icon to "funnel". Let's change that back to "metric"

Closes #43894 