### PR TITLE
[MBQL lib] Move the `field_ref` matching hack from #43848

### DIFF
--- a/frontend/src/metabase-lib/comparison.ts
+++ b/frontend/src/metabase-lib/comparison.ts
@@ -26,20 +26,6 @@ export function findColumnIndexesFromLegacyRefs(
   columns: ColumnMetadata[],
   fieldRefs: DimensionReference[],
 ): number[] {
-  // FIXME hack to fix #43799
-  const columnIndexByLegacyRef = new Map(
-    columns.map((column, columnIndex) => [
-      JSON.stringify(ML.legacy_ref(query, stageIndex, column)),
-      columnIndex,
-    ]),
-  );
-  const columnIndexes = fieldRefs.map(
-    fieldRef => columnIndexByLegacyRef.get(JSON.stringify(fieldRef)) ?? -1,
-  );
-  if (columnIndexes.every(columnIndex => columnIndex >= 0)) {
-    return columnIndexes;
-  }
-
   return ML.find_column_indexes_from_legacy_refs(
     query,
     stageIndex,

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -1252,10 +1252,24 @@
   ;; Set up this query stage's `:aggregation` list as the context for [[lib.convert/->pMBQL]] to convert legacy
   ;; `[:aggregation 0]` refs into pMBQL `[:aggregation uuid]` refs.
   (lib.convert/with-aggregation-list (:aggregation (lib.util/query-stage a-query stage-number))
-    (let [haystack (mapv ->column-or-ref legacy-columns)
-          needles  (map legacy-ref->pMBQL legacy-refs)]
-      #_{:clj-kondo/ignore [:discouraged-var]}
-      (to-array (lib.equality/find-column-indexes-for-refs a-query stage-number needles haystack)))))
+    (let [haystack      (mapv ->column-or-ref legacy-columns)
+          needles       (map legacy-ref->pMBQL legacy-refs)
+          column-refs   (into {} (keep-indexed (fn [i col]
+                                                 [(-> col
+                                                      lib.core/ref
+                                                      lib.convert/->legacy-MBQL
+                                                      normalize-legacy-ref)
+                                                  i]))
+                              legacy-columns)
+          exact-matches (map #(-> %
+                                  (js->clj :keywordize-keys true)
+                                  (update 0 keyword)
+                                  column-refs)
+                             legacy-refs)]
+      (if (every? #(and % (>= % 0)) exact-matches)
+        (to-array exact-matches)
+        #_{:clj-kondo/ignore [:discouraged-var]}
+        (to-array (lib.equality/find-column-indexes-for-refs a-query stage-number needles haystack))))))
 
 (defn ^:export source-table-or-card-id
   "Returns the ID of the source table (as a number) or the ID of the source card (as a string prefixed


### PR DESCRIPTION
I'm not sure it's any less hacky in the CLJS but it keeps the TS
wrappers thin.

Context:
- #43799 is the original issue
- #43848 added the hack being removed here

