### PR TITLE
[Fix flaky test] metabase.pulse.pulse-integration-test/skip-if-empty-test 

### DIFF
--- a/test/metabase/pulse/pulse_integration_test.clj
+++ b/test/metabase/pulse/pulse_integration_test.clj
@@ -209,7 +209,7 @@
                                                                 :card_id      question-card-id}
                      Pulse {pulse-id :id
                             :as      pulse} {:name         "Test Pulse"
-                            :dashboard_id dash-id}
+                                             :dashboard_id dash-id}
                      PulseCard _ {:pulse_id          pulse-id
                                   :card_id           base-card-id
                                   :dashboard_card_id base-dash-card-id}
@@ -693,11 +693,13 @@
                   PulseCard ~'_ {:pulse_id          ~'pulse-id
                                  :card_id           ~'base-card-id
                                  :dashboard_card_id ~'base-dash-card-id
-                                 :include_csv       true}
+                                 :include_csv       true
+                                 :position          1}
                   PulseCard ~'_ {:pulse_id          ~'pulse-id
                                  :card_id           ~'empty-card-id
                                  :dashboard_card_id ~'empty-dash-card-id
-                                 :include_csv       true}
+                                 :include_csv       true
+                                 :position          2}
                   PulseChannel {~'pulse-channel-id :id} {:channel_type :email
                                                          :pulse_id     ~'pulse-id
                                                          :enabled      true}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/43912

It was flaky because of dashboard card order in a pulse, so adding position to the card to ensure the order is consistent.