### PR TITLE
ci(sdk): Remind SDK PR author to use conventional commits PR title

### DIFF
--- a/.github/workflows/conventional-commit-pr-title-reminder.yml
+++ b/.github/workflows/conventional-commit-pr-title-reminder.yml
@@ -14,9 +14,24 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      - name: Check if the PR title is already following Conventional Commits style
+        uses: actions/github-script@v7
+        id: is-conventional-commit
+        with:
+          result-encoding: string
+          script: | # js
+            const pullRequestTitle = context.payload.pull_request.title
+            const conventionalCommitRegex = /^(?<type>\w+)\((?<scope>\w+)\):/
+            const match = pullRequestTitle.match(conventionalCommitRegex)
+            if (match) {
+              const { type, scope } = match.groups
+              return ['feat', 'fix', 'perf'].includes(type) && scope === 'sdk'
+            }
+
       - name: Remind PR authors to use conventional commit in the title
+        if: ${{ steps.is-conventional-commit.outputs.result != 'true' }}
         run: |
-          gh pr pr comment -b '@{{ github.pull_request.user.login }} You have modified embedding SDK code. Please make sure the PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style.
+          gh pr pr comment -b '@${{ github.pull_request.user.login }} You have modified embedding SDK code. Please make sure the PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style.
 
           Here are all the supported types that will be shown in the changelog:
           - feat

--- a/.github/workflows/conventional-commit-pr-title-reminder.yml
+++ b/.github/workflows/conventional-commit-pr-title-reminder.yml
@@ -40,9 +40,9 @@ jobs:
           comment='@${{ github.event.pull_request.user.login }} You have modified embedding SDK code. Please make sure the PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style.
 
           Here are all the supported types that will be shown in the changelog:
-          - feat
-          - fix
-          - perf
+          - `feat`
+          - `fix`
+          - `perf`
 
           Please also make sure to include `sdk` scope, otherwise, the changelog will not include this change.
 

--- a/.github/workflows/conventional-commit-pr-title-reminder.yml
+++ b/.github/workflows/conventional-commit-pr-title-reminder.yml
@@ -46,7 +46,7 @@ jobs:
 
           These types `docs`, `style`, `refactor`, `test`, `build`, and `ci` are also encouraged for non-changelog related tasks.
 
-          Please also make sure to include `sdk` scope, otherwise, the changelog will not include this change.
+          Please also make sure to include `sdk` scope, otherwise, the changelog will not include this task.
 
           For example, these are valid PR titles:
           - `feat(sdk): Add interactive dashboard component`

--- a/.github/workflows/conventional-commit-pr-title-reminder.yml
+++ b/.github/workflows/conventional-commit-pr-title-reminder.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Remind PR authors to use conventional commit in the title
         if: ${{ steps.is-conventional-commit.outputs.result != 'true' }}
         run: |
-          gh pr comment -b '@${{ github.pull_request.user.login }} You have modified embedding SDK code. Please make sure the PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style.
+          comment='@${{ github.event.pull_request.user.login }} You have modified embedding SDK code. Please make sure the PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style.
 
           Here are all the supported types that will be shown in the changelog:
           - feat

--- a/.github/workflows/conventional-commit-pr-title-reminder.yml
+++ b/.github/workflows/conventional-commit-pr-title-reminder.yml
@@ -26,7 +26,7 @@ jobs:
             const match = pullRequestTitle.match(conventionalCommitRegex)
             if (match) {
               const { type, scope } = match.groups
-              return ['feat', 'fix', 'perf'].includes(type) && scope === 'sdk'
+              return ['feat', 'fix', 'perf', 'docs', 'style', 'refactor', 'test', 'build', 'ci'].includes(type) && scope === 'sdk'
             }
 
       - name: Checkout repository so `gh` CLI works

--- a/.github/workflows/conventional-commit-pr-title-reminder.yml
+++ b/.github/workflows/conventional-commit-pr-title-reminder.yml
@@ -1,0 +1,31 @@
+name: Conventional commit PR Title Reminder
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - enterprise/frontend/src/embedding-sdk/**
+
+jobs:
+  pr-title-reminder:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Remind PR authors to use conventional commit in the title
+        run: |
+          gh pr pr comment -b '@{{ github.pull_request.user.login }} You have modified embedding SDK code. Please make sure the PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style.
+
+          Here are all the supported types that will be shown in the changelog:
+          - feat
+          - fix
+          - perf
+
+          Please also make sure to include `sdk` scope, otherwise, the changelog will not include this change.
+
+          For example, these are valid PR titles:
+          - `feat(sdk): Add interactive dashboard component`
+          - `feat(sdk): Support theming pie chart`
+          - `fix(sdk): Fix static dashboard crash`'

--- a/.github/workflows/conventional-commit-pr-title-reminder.yml
+++ b/.github/workflows/conventional-commit-pr-title-reminder.yml
@@ -44,6 +44,8 @@ jobs:
           - `fix`
           - `perf`
 
+          These types `docs`, `style`, `refactor`, `test`, `build`, and `ci` are also encouraged for non-changelog related tasks.
+
           Please also make sure to include `sdk` scope, otherwise, the changelog will not include this change.
 
           For example, these are valid PR titles:

--- a/.github/workflows/conventional-commit-pr-title-reminder.yml
+++ b/.github/workflows/conventional-commit-pr-title-reminder.yml
@@ -29,10 +29,15 @@ jobs:
               return ['feat', 'fix', 'perf'].includes(type) && scope === 'sdk'
             }
 
+      - name: Checkout repository so `gh` CLI works
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+
       - name: Remind PR authors to use conventional commit in the title
         if: ${{ steps.is-conventional-commit.outputs.result != 'true' }}
         run: |
-          gh pr pr comment -b '@${{ github.pull_request.user.login }} You have modified embedding SDK code. Please make sure the PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style.
+          gh pr comment -b '@${{ github.pull_request.user.login }} You have modified embedding SDK code. Please make sure the PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style.
 
           Here are all the supported types that will be shown in the changelog:
           - feat
@@ -45,3 +50,5 @@ jobs:
           - `feat(sdk): Add interactive dashboard component`
           - `feat(sdk): Support theming pie chart`
           - `fix(sdk): Fix static dashboard crash`'
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/conventional-commit-pr-title-reminder.yml
+++ b/.github/workflows/conventional-commit-pr-title-reminder.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - master
-      - 43850-remind-sdk-dev-to-use-conventional-commits
     paths:
       - enterprise/frontend/src/embedding-sdk/**
 

--- a/.github/workflows/conventional-commit-pr-title-reminder.yml
+++ b/.github/workflows/conventional-commit-pr-title-reminder.yml
@@ -50,5 +50,7 @@ jobs:
           - `feat(sdk): Add interactive dashboard component`
           - `feat(sdk): Support theming pie chart`
           - `fix(sdk): Fix static dashboard crash`'
+
+          gh pr comment -b "$comment" --edit-last || gh pr comment -b "$comment"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/conventional-commit-pr-title-reminder.yml
+++ b/.github/workflows/conventional-commit-pr-title-reminder.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+      - 43850-remind-sdk-dev-to-use-conventional-commits
     paths:
       - enterprise/frontend/src/embedding-sdk/**
 


### PR DESCRIPTION
Closes #43850

This PR adds a new workflow that will remind PR author if they have modified embedding SDK directory that they need to follow conventional commits style. The comment will only be posted if the PR title not already following the conventional commits style.

Here's [the PR](https://github.com/metabase/metabase/pull/43933) for testing this workflow. I've commented inline how to reason about the result.