### PR TITLE
Update Popover.module.css to allow the resizing of the component

### DIFF
--- a/frontend/src/metabase/components/Popover/Popover.module.css
+++ b/frontend/src/metabase/components/Popover/Popover.module.css
@@ -23,6 +23,11 @@
   overflow: auto;
 }
 
+.PopoverBody > div:last-child {
+  /* allow the user to resize the popover when needed */
+  resize: horizontal;
+}
+
 /* Global classes from tippy.js */
 :global(.tippy-box),
 :global(.tippy-content) {


### PR DESCRIPTION
I would like to have this feature because in my use of Metabase, the Question names are way bigger than the popover component, so it's very hard to distinguish them.

> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label
> to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this
> PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71)
> in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not
> apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform) (unless it's a tiny documentation change). Also, if you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.

Closes https://github.com/metabase/metabase/issues/43939

### Description

The problem is that the Popover is sometimes too small for the items names. But it's also bad to have a fixed large popover if the items are not that big. So I think that the best solution is to keep it small and let the user to resize it.

### How to verify

1. New question -> Pick your starting data -> Saved Questions -> Search for a question
2. A resize button should appear at the bottom right of the list.

### Demo
Before
![image](https://github.com/metabase/metabase/assets/11581684/db948f58-28dc-40d5-9719-b0597cfced41)

After
![image](https://github.com/metabase/metabase/assets/11581684/d5c5d619-5c28-480f-b548-656080084995)
