### PR TITLE
fix(sdk): apply full width to static dashboard component

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/public/StaticDashboard/StaticDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/StaticDashboard/StaticDashboard.tsx
@@ -62,7 +62,7 @@ const _StaticDashboard = ({
   const { font } = useEmbedFont();
 
   return (
-    <Box ref={ref} style={{ overflow: "auto" }}>
+    <Box w="100%" ref={ref} style={{ overflow: "auto" }}>
       <PublicOrEmbeddedDashboard
         dashboardId={dashboardId}
         parameterQueryParams={parameterQueryParams}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/43820

### Description

Makes the static dashboard full-width.

### How to verify

- Go to the `test-static-dashboard-flex-parent` branch of demo app. This changes the parent container from Box to Flex
- The dashboard should render now under a flex container. Box works as well.

### Demo

![CleanShot 2567-06-11 at 00 48 32@2x](https://github.com/metabase/metabase/assets/4714175/b700a56a-2f06-4bc7-9536-bb8db158de37)