### PR TITLE
Fix "CC typing suggestion" E2E flake

### DIFF
--- a/e2e/test/scenarios/custom-column/cc-typing-suggestion.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/cc-typing-suggestion.cy.spec.js
@@ -55,10 +55,10 @@ describe("scenarios > question > custom column > typing suggestion", () => {
     { tags: "@flaky" },
     () => {
       addCustomColumn();
-      enterCustomColumnDetails({ formula: "LOW{enter}" });
+      enterCustomColumnDetails({ formula: "BET{enter}" });
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.contains("lower(");
+      cy.contains("between(");
     },
   );
 

--- a/e2e/test/scenarios/custom-column/cc-typing-suggestion.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/cc-typing-suggestion.cy.spec.js
@@ -54,8 +54,10 @@ describe("scenarios > question > custom column > typing suggestion", () => {
     addCustomColumn();
     enterCustomColumnDetails({ formula: "BET{enter}" });
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.contains("between(");
+    cy.findByTestId("expression-editor-textfield").should(
+      "contain",
+      "between(",
+    );
   });
 
   it("should show expression function helper if a proper function is typed", () => {

--- a/e2e/test/scenarios/custom-column/cc-typing-suggestion.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/cc-typing-suggestion.cy.spec.js
@@ -50,17 +50,13 @@ describe("scenarios > question > custom column > typing suggestion", () => {
     cy.contains("length([Title])");
   });
 
-  it(
-    "should correctly insert function suggestion with the opening parenthesis",
-    { tags: "@flaky" },
-    () => {
-      addCustomColumn();
-      enterCustomColumnDetails({ formula: "BET{enter}" });
+  it("should correctly insert function suggestion with the opening parenthesis", () => {
+    addCustomColumn();
+    enterCustomColumnDetails({ formula: "BET{enter}" });
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.contains("between(");
-    },
-  );
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+    cy.contains("between(");
+  });
 
   it("should show expression function helper if a proper function is typed", () => {
     addCustomColumn();


### PR DESCRIPTION
### What does this PR accomplish?

Resolves #43872 

### Explanation
The source of this flake was the typing timing. Cypress was supposed to type `LOW + enter`, but what was submitted was `LO + enter`. This resulted in the `log(` as the autocomplete function suggestion instead of the `lower(`.

![image](https://github.com/metabase/metabase/assets/31325167/56405e93-87e9-48f6-a875-357b13a54966)

You can replicate this manually in a local instance by typing LO + enter, and you should indeed see `log(`

### The solution
Find a function that cannot produce ambiguous results even if Cypress mistypes. I settled on `between`. To make sure this works, try typing both these things locally:
- `BE + enter`
- `BET + enter`

They should both result in the autocomplete function suggestion `between(`.

### Stress-tests
- 20x ✅ https://github.com/metabase/metabase/actions/runs/9453253743
- 50x ✅ https://github.com/metabase/metabase/actions/runs/9453316294
- 30x ✅ https://github.com/metabase/metabase/actions/runs/9453389633