### PR TITLE
fix bar normalized stacking breaks line charts

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
@@ -117,6 +117,36 @@ describe("scenarios > visualizations > line chart", () => {
     cartesianChartCircleWithColor("#509EE3");
   });
 
+  it("should reset stacking settings when switching to line chart (metabase#43538)", () => {
+    visitQuestionAdhoc({
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        query: {
+          "source-table": PRODUCTS_ID,
+          aggregation: [["avg", ["field", PRODUCTS.PRICE, null]]],
+          breakout: [
+            ["field", PRODUCTS.CREATED_AT, { "temporal-unit": "year" }],
+            ["field", PRODUCTS.CATEGORY, null],
+          ],
+        },
+        type: "query",
+      },
+      display: "bar",
+      visualization_settings: {
+        "stackable.stack_type": "normalized",
+      },
+    });
+
+    cy.findByTestId("viz-type-button").click();
+
+    cy.icon("line").click();
+
+    cartesianChartCircleWithColor("#A989C5");
+
+    // Y-axis scale should not be normalized
+    echartsContainer().findByText("100%").should("not.exist");
+  });
+
   it("should be able to format data point values style independently on multi-series chart (metabase#13095)", () => {
     visitQuestionAdhoc({
       dataset_query: {

--- a/frontend/src/metabase/visualizations/visualizations/AreaChart/AreaChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/AreaChart/AreaChart.tsx
@@ -5,20 +5,11 @@ import {
   getMinSize,
 } from "metabase/visualizations/shared/utils/sizes";
 import { CartesianChart } from "metabase/visualizations/visualizations/CartesianChart";
-import { getCartesianChartDefinition } from "metabase/visualizations/visualizations/CartesianChart/chart-definition";
-
-import { GRAPH_GOAL_SETTINGS } from "../../lib/settings/goal";
 import {
-  GRAPH_DATA_SETTINGS,
-  LINE_SETTINGS,
-  GRAPH_TREND_SETTINGS,
-  GRAPH_COLORS_SETTINGS,
-  GRAPH_AXIS_SETTINGS,
-  GRAPH_DISPLAY_VALUES_SETTINGS,
-  STACKABLE_SETTINGS,
-  TOOLTIP_SETTINGS,
-  LEGEND_SETTINGS,
-} from "../../lib/settings/graph";
+  COMBO_CHARTS_SETTINGS_DEFINITIONS,
+  getCartesianChartDefinition,
+} from "metabase/visualizations/visualizations/CartesianChart/chart-definition";
+
 import type {
   VisualizationProps,
   VisualizationSettingsDefinitions,
@@ -34,16 +25,7 @@ Object.assign(
     minSize: getMinSize("area"),
     defaultSize: getDefaultSize("area"),
     settings: {
-      ...LINE_SETTINGS,
-      ...STACKABLE_SETTINGS,
-      ...GRAPH_GOAL_SETTINGS,
-      ...GRAPH_TREND_SETTINGS,
-      ...GRAPH_COLORS_SETTINGS,
-      ...GRAPH_AXIS_SETTINGS,
-      ...GRAPH_DISPLAY_VALUES_SETTINGS,
-      ...GRAPH_DATA_SETTINGS,
-      ...TOOLTIP_SETTINGS,
-      ...LEGEND_SETTINGS,
+      ...COMBO_CHARTS_SETTINGS_DEFINITIONS,
     } as any as VisualizationSettingsDefinitions,
   }),
 );

--- a/frontend/src/metabase/visualizations/visualizations/BarChart/BarChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/BarChart/BarChart.tsx
@@ -5,19 +5,11 @@ import {
   getMinSize,
 } from "metabase/visualizations/shared/utils/sizes";
 import { CartesianChart } from "metabase/visualizations/visualizations/CartesianChart";
-import { getCartesianChartDefinition } from "metabase/visualizations/visualizations/CartesianChart/chart-definition";
-
-import { GRAPH_GOAL_SETTINGS } from "../../lib/settings/goal";
 import {
-  GRAPH_DATA_SETTINGS,
-  GRAPH_TREND_SETTINGS,
-  GRAPH_COLORS_SETTINGS,
-  GRAPH_AXIS_SETTINGS,
-  GRAPH_DISPLAY_VALUES_SETTINGS,
-  STACKABLE_SETTINGS,
-  TOOLTIP_SETTINGS,
-  LEGEND_SETTINGS,
-} from "../../lib/settings/graph";
+  COMBO_CHARTS_SETTINGS_DEFINITIONS,
+  getCartesianChartDefinition,
+} from "metabase/visualizations/visualizations/CartesianChart/chart-definition";
+
 import type {
   VisualizationProps,
   VisualizationSettingsDefinitions,
@@ -33,15 +25,7 @@ Object.assign(
     minSize: getMinSize("bar"),
     defaultSize: getDefaultSize("bar"),
     settings: {
-      ...STACKABLE_SETTINGS,
-      ...GRAPH_GOAL_SETTINGS,
-      ...GRAPH_TREND_SETTINGS,
-      ...GRAPH_COLORS_SETTINGS,
-      ...GRAPH_AXIS_SETTINGS,
-      ...GRAPH_DISPLAY_VALUES_SETTINGS,
-      ...GRAPH_DATA_SETTINGS,
-      ...TOOLTIP_SETTINGS,
-      ...LEGEND_SETTINGS,
+      ...COMBO_CHARTS_SETTINGS_DEFINITIONS,
     } as any as VisualizationSettingsDefinitions,
   }),
 );

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/chart-definition.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/chart-definition.ts
@@ -1,13 +1,28 @@
 import { t } from "ttag";
 import _ from "underscore";
 
+import { GRAPH_GOAL_SETTINGS } from "metabase/visualizations/lib/settings/goal";
+import {
+  GRAPH_AXIS_SETTINGS,
+  GRAPH_COLORS_SETTINGS,
+  GRAPH_DATA_SETTINGS,
+  GRAPH_DISPLAY_VALUES_SETTINGS,
+  GRAPH_TREND_SETTINGS,
+  LEGEND_SETTINGS,
+  LINE_SETTINGS,
+  STACKABLE_SETTINGS,
+  TOOLTIP_SETTINGS,
+} from "metabase/visualizations/lib/settings/graph";
 import {
   validateChartDataSettings,
   validateDatasetRows,
   validateStacking,
 } from "metabase/visualizations/lib/settings/validation";
 import { SERIES_SETTING_KEY } from "metabase/visualizations/shared/settings/series";
-import type { Visualization } from "metabase/visualizations/types";
+import type {
+  Visualization,
+  VisualizationSettingsDefinitions,
+} from "metabase/visualizations/types";
 import { isDimension, isMetric } from "metabase-lib/v1/types/utils/isa";
 import type { RawSeries, SeriesSettings } from "metabase-types/api";
 
@@ -97,3 +112,16 @@ export const getCartesianChartDefinition = (
     ...props,
   };
 };
+
+export const COMBO_CHARTS_SETTINGS_DEFINITIONS = {
+  ...LINE_SETTINGS,
+  ...GRAPH_GOAL_SETTINGS,
+  ...GRAPH_TREND_SETTINGS,
+  ...GRAPH_COLORS_SETTINGS,
+  ...GRAPH_AXIS_SETTINGS,
+  ...GRAPH_DISPLAY_VALUES_SETTINGS,
+  ...GRAPH_DATA_SETTINGS,
+  ...TOOLTIP_SETTINGS,
+  ...STACKABLE_SETTINGS,
+  ...LEGEND_SETTINGS,
+} as any as VisualizationSettingsDefinitions;

--- a/frontend/src/metabase/visualizations/visualizations/ComboChart/ComboChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/ComboChart/ComboChart.tsx
@@ -5,19 +5,11 @@ import {
   getMinSize,
 } from "metabase/visualizations/shared/utils/sizes";
 import { CartesianChart } from "metabase/visualizations/visualizations/CartesianChart";
-import { getCartesianChartDefinition } from "metabase/visualizations/visualizations/CartesianChart/chart-definition";
-
-import { GRAPH_GOAL_SETTINGS } from "../../lib/settings/goal";
 import {
-  GRAPH_DATA_SETTINGS,
-  LINE_SETTINGS,
-  GRAPH_TREND_SETTINGS,
-  GRAPH_COLORS_SETTINGS,
-  GRAPH_AXIS_SETTINGS,
-  GRAPH_DISPLAY_VALUES_SETTINGS,
-  TOOLTIP_SETTINGS,
-  STACKABLE_SETTINGS,
-} from "../../lib/settings/graph";
+  COMBO_CHARTS_SETTINGS_DEFINITIONS,
+  getCartesianChartDefinition,
+} from "metabase/visualizations/visualizations/CartesianChart/chart-definition";
+
 import type {
   VisualizationProps,
   VisualizationSettingsDefinitions,
@@ -33,15 +25,7 @@ Object.assign(
     minSize: getMinSize("combo"),
     defaultSize: getDefaultSize("combo"),
     settings: {
-      ...LINE_SETTINGS,
-      ...GRAPH_GOAL_SETTINGS,
-      ...GRAPH_TREND_SETTINGS,
-      ...GRAPH_COLORS_SETTINGS,
-      ...GRAPH_AXIS_SETTINGS,
-      ...GRAPH_DISPLAY_VALUES_SETTINGS,
-      ...GRAPH_DATA_SETTINGS,
-      ...TOOLTIP_SETTINGS,
-      ...STACKABLE_SETTINGS,
+      ...COMBO_CHARTS_SETTINGS_DEFINITIONS,
     } as any as VisualizationSettingsDefinitions,
   }),
 );

--- a/frontend/src/metabase/visualizations/visualizations/LineChart/LineChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LineChart/LineChart.tsx
@@ -5,18 +5,11 @@ import {
   getMinSize,
 } from "metabase/visualizations/shared/utils/sizes";
 import { CartesianChart } from "metabase/visualizations/visualizations/CartesianChart";
-import { getCartesianChartDefinition } from "metabase/visualizations/visualizations/CartesianChart/chart-definition";
-
-import { GRAPH_GOAL_SETTINGS } from "../../lib/settings/goal";
 import {
-  GRAPH_DATA_SETTINGS,
-  LINE_SETTINGS,
-  GRAPH_TREND_SETTINGS,
-  GRAPH_COLORS_SETTINGS,
-  GRAPH_AXIS_SETTINGS,
-  GRAPH_DISPLAY_VALUES_SETTINGS,
-  TOOLTIP_SETTINGS,
-} from "../../lib/settings/graph";
+  COMBO_CHARTS_SETTINGS_DEFINITIONS,
+  getCartesianChartDefinition,
+} from "metabase/visualizations/visualizations/CartesianChart/chart-definition";
+
 import type {
   VisualizationProps,
   VisualizationSettingsDefinitions,
@@ -32,14 +25,7 @@ Object.assign(
     minSize: getMinSize("line"),
     defaultSize: getDefaultSize("line"),
     settings: {
-      ...LINE_SETTINGS,
-      ...GRAPH_GOAL_SETTINGS,
-      ...GRAPH_TREND_SETTINGS,
-      ...GRAPH_COLORS_SETTINGS,
-      ...GRAPH_AXIS_SETTINGS,
-      ...GRAPH_DISPLAY_VALUES_SETTINGS,
-      ...GRAPH_DATA_SETTINGS,
-      ...TOOLTIP_SETTINGS,
+      ...COMBO_CHARTS_SETTINGS_DEFINITIONS,
     } as any as VisualizationSettingsDefinitions,
   }),
 );


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/43538

### Description

When switching from a normalized bar chart to line chart it was not rendering correctly. `stackable.stack_type` setting definition in `frontend/src/metabase/visualizations/lib/settings/graph.js` has validation that would reset it from `normalized` to `null` but the settings definition was not included in line charts settings.

### How to verify

1. New question -> Sample Dataset -> Orders -> Count by Created at and Product: Category
2. Switch the chart display type to "Bar"
3. Make it a normalized stacked chart
4. Switch display type back to "Line"
5. Ensure it renders the line chart correctly

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
