### PR TITLE
Enable Clojure logging in the browser

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -16,6 +16,7 @@
                 :compiler-options {:reader-features #{:cljs-dev}}}
    :compiler-options {:reader-features #{:cljs-release}
                       :source-map      true}
+   :closure-defines {goog.debug.LOGGING_ENABLED true}
    :entries    [metabase.lib.column-group
                 metabase.lib.js
                 metabase.lib.limit


### PR DESCRIPTION
Fixes #41090.

Messages at INFO level and higher will appear in the browser console.
