### PR TITLE
feat(sdk): theme option to customize the dashboard card border

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/types/theme/index.ts
+++ b/enterprise/frontend/src/embedding-sdk/types/theme/index.ts
@@ -84,6 +84,13 @@ export interface MetabaseComponentTheme {
 
     card: {
       backgroundColor: string;
+
+      /**
+       * Add custom borders to dashboard cards when set.
+       * Value is the same as the border property in CSS, such as "1px solid #ff0000".
+       * This will replace the card's drop shadow.
+       **/
+      border?: string;
     };
   };
 

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.styled.tsx
@@ -2,6 +2,7 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 
 import DashboardS from "metabase/css/dashboard.module.css";
+import type { MantineTheme } from "metabase/ui";
 
 import { FIXED_WIDTH } from "./Dashboard/Dashboard.styled";
 
@@ -35,7 +36,8 @@ export const DashboardCardContainer = styled.div<DashboardCardProps>`
     bottom: 0;
     right: 0;
     border-radius: 8px;
-    box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.13);
+
+    ${getDashboardCardShadowOrBorder}
   }
 
   ${props =>
@@ -81,3 +83,17 @@ export const DashboardGridContainer = styled.div<{
       max-width: ${FIXED_WIDTH};
     `}
 `;
+
+function getDashboardCardShadowOrBorder({ theme }: { theme: MantineTheme }) {
+  const { border } = theme.other.dashboard.card;
+
+  if (border) {
+    return css`
+      border: ${border};
+    `;
+  }
+
+  return css`
+    box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.13);
+  `;
+}

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.styled.tsx
@@ -94,6 +94,6 @@ function getDashboardCardShadowOrBorder({ theme }: { theme: MantineTheme }) {
   }
 
   return css`
-    box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.13);
+    box-shadow: 0px 1px 3px var(--mb-color-shadow);
   `;
 }

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.styled.tsx
@@ -37,7 +37,7 @@ export const DashboardCardContainer = styled.div<DashboardCardProps>`
     right: 0;
     border-radius: 8px;
 
-    ${getDashboardCardShadowOrBorder}
+    ${({theme}) => getDashboardCardShadowOrBorder(theme)}
   }
 
   ${props =>

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.styled.tsx
@@ -37,7 +37,7 @@ export const DashboardCardContainer = styled.div<DashboardCardProps>`
     right: 0;
     border-radius: 8px;
 
-    ${({theme}) => getDashboardCardShadowOrBorder(theme)}
+    ${({ theme }) => getDashboardCardShadowOrBorder(theme)}
   }
 
   ${props =>
@@ -84,7 +84,7 @@ export const DashboardGridContainer = styled.div<{
     `}
 `;
 
-function getDashboardCardShadowOrBorder({ theme }: { theme: MantineTheme }) {
+function getDashboardCardShadowOrBorder(theme: MantineTheme) {
   const { border } = theme.other.dashboard.card;
 
   if (border) {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/43918

### Description

Add a theme option `theme.components.dashboard.card.border` to customize the dashboard card border. When unset, the usual card drop shadow applies. When set to a value such as `1px solid #ff0000` the border applies.

I've decided to allow passing in the CSS `border` property so they can also customize the border width (e.g. to be 2px). 

### How to verify

- Go to the `static-dashboard-border-theme-option` branch in the demo app.
- Go to `AppProvider.tsx` and verify that the `card.border` property is set.
- Go to Analytics. You should see the purple border in the UI, in place of the drop shadow.

### Demo

![CleanShot 2567-06-11 at 02 16 07@2x](https://github.com/metabase/metabase/assets/4714175/9f96af79-8821-41ad-8f17-5d7c11774b49)

### Alternative Ideas

Alternatively, the API could be one of these instead - less customizable but more straightforward. Let me know if these makes more sense to you.

- `border: true` sets the border to `1px solid var(--mb-color-border)`
- `border: "#ff0000"` sets the border to `1px solid #ff0000`