### PR TITLE
Fix the flaky "bookmark" E2E test

### DIFF
--- a/e2e/test/scenarios/organization/bookmarks-question.cy.spec.js
+++ b/e2e/test/scenarios/organization/bookmarks-question.cy.spec.js
@@ -39,7 +39,13 @@ describe("scenarios > question > bookmarks", () => {
       openQuestionActions();
       cy.findByRole("dialog").contains("Turn into a model").click();
       cy.findByRole("dialog").contains("Turn this into a model").click();
-      cy.findByRole("status").contains("This is a model now.").should("exist");
+      cy.findByRole("status")
+        .should("contain", "This is a model now.")
+        // Close this toast as soon we confim it exists!
+        // It lingers in the UI far too long which is causing flakiness later on
+        // when we assert on the next toast (when we turn the model back to the question).
+        .icon("close")
+        .click();
 
       navigationSidebar().within(() => {
         cy.findByLabelText(/Bookmarks/)
@@ -50,9 +56,7 @@ describe("scenarios > question > bookmarks", () => {
       cy.log("Turn the model back into a question");
       openQuestionActions();
       cy.findByRole("dialog").contains("Turn back to saved question").click();
-      cy.findByRole("status")
-        .contains("This is a question now.")
-        .should("exist");
+      cy.findByRole("status").should("contain", "This is a question now.");
 
       openNavigationSidebar();
       cy.log("Should not find bookmark");

--- a/e2e/test/scenarios/organization/bookmarks-question.cy.spec.js
+++ b/e2e/test/scenarios/organization/bookmarks-question.cy.spec.js
@@ -15,66 +15,62 @@ describe("scenarios > question > bookmarks", () => {
     cy.signInAsAdmin();
   });
 
-  it(
-    "should add, update bookmark name when question name is updated, then remove bookmark from question page",
-    { tags: "@flaky" },
-    () => {
-      visitQuestion(ORDERS_QUESTION_ID);
-      toggleBookmark();
+  it("should add, update bookmark name when question name is updated, then remove bookmark from question page", () => {
+    visitQuestion(ORDERS_QUESTION_ID);
+    toggleBookmark();
 
-      openNavigationSidebar();
-      navigationSidebar().within(() => {
-        getSectionTitle(/Bookmarks/);
-        cy.findByText("Orders");
-      });
+    openNavigationSidebar();
+    navigationSidebar().within(() => {
+      getSectionTitle(/Bookmarks/);
+      cy.findByText("Orders");
+    });
 
-      // Rename bookmarked question
-      cy.findByTestId("saved-question-header-title").click().type(" 2").blur();
+    // Rename bookmarked question
+    cy.findByTestId("saved-question-header-title").click().type(" 2").blur();
 
-      navigationSidebar().within(() => {
-        cy.findByText("Orders 2");
-      });
+    navigationSidebar().within(() => {
+      cy.findByText("Orders 2");
+    });
 
-      cy.log("Turn the question into a model");
-      openQuestionActions();
-      cy.findByRole("dialog").contains("Turn into a model").click();
-      cy.findByRole("dialog").contains("Turn this into a model").click();
-      cy.findByRole("status")
-        .should("contain", "This is a model now.")
-        // Close this toast as soon we confim it exists!
-        // It lingers in the UI far too long which is causing flakiness later on
-        // when we assert on the next toast (when we turn the model back to the question).
-        .icon("close")
-        .click();
+    cy.log("Turn the question into a model");
+    openQuestionActions();
+    cy.findByRole("dialog").contains("Turn into a model").click();
+    cy.findByRole("dialog").contains("Turn this into a model").click();
+    cy.findByRole("status")
+      .should("contain", "This is a model now.")
+      // Close this toast as soon we confim it exists!
+      // It lingers in the UI far too long which is causing flakiness later on
+      // when we assert on the next toast (when we turn the model back to the question).
+      .icon("close")
+      .click();
 
-      navigationSidebar().within(() => {
-        cy.findByLabelText(/Bookmarks/)
-          .icon("model")
-          .should("exist");
-      });
+    navigationSidebar().within(() => {
+      cy.findByLabelText(/Bookmarks/)
+        .icon("model")
+        .should("exist");
+    });
 
-      cy.log("Turn the model back into a question");
-      openQuestionActions();
-      cy.findByRole("dialog").contains("Turn back to saved question").click();
-      cy.findByRole("status").should("contain", "This is a question now.");
+    cy.log("Turn the model back into a question");
+    openQuestionActions();
+    cy.findByRole("dialog").contains("Turn back to saved question").click();
+    cy.findByRole("status").should("contain", "This is a question now.");
 
-      openNavigationSidebar();
-      cy.log("Should not find bookmark");
-      navigationSidebar().within(() => {
-        cy.findByLabelText(/Bookmarks/)
-          .icon("model")
-          .should("not.exist");
-      });
+    openNavigationSidebar();
+    cy.log("Should not find bookmark");
+    navigationSidebar().within(() => {
+      cy.findByLabelText(/Bookmarks/)
+        .icon("model")
+        .should("not.exist");
+    });
 
-      // Remove bookmark
-      toggleBookmark({ wasSelected: true });
+    // Remove bookmark
+    toggleBookmark({ wasSelected: true });
 
-      navigationSidebar().within(() => {
-        getSectionTitle(/Bookmarks/).should("not.exist");
-        cy.findByText("Orders 2").should("not.exist");
-      });
-    },
-  );
+    navigationSidebar().within(() => {
+      getSectionTitle(/Bookmarks/).should("not.exist");
+      cy.findByText("Orders 2").should("not.exist");
+    });
+  });
 });
 
 function toggleBookmark({ wasSelected = false } = {}) {


### PR DESCRIPTION
### What does this PR accomplish?

Resolves #43871 

### Explanation
The "This is a model now" toast lingers for far too long in the UI, which was causing the test failure during the nest "toast" assertion (when we turn the model back into the question). The mechanism was as follows:
1. the original selector + assertion looked like this: `cy.findByRole("status").contains("This is a question now.");`
2. the selector `cy.findByRole("status")` would still see the "model" toast first, so Cypress grabs that as the DOM element
3. shortly after, that question toast appears and the two toasts coexist for a brief moment
4. the model toast disappears, the DOM updates and the Cypress is now confused - it cannot assert that it contains "This is a question now" because that original DOM element doesn't exist anymore (even though human eyes can see that this toast is in the UI - to the machine, it's not)

![image](https://github.com/metabase/metabase/assets/31325167/36b7d586-e418-42a8-a774-a4fd2f985045)

### The Solution
Remove the "This is a model now." modal as soon as we assert that it exists. We don't need it lingering in the UI anymore. This way, we don't have the conflict down the line when Cypress needs to assert on the next toast.

> [!Note]
> The alternative solution would've been to initialize the `cy.clock()`, and to then "tick" the time after the first toast appeared. I've seen `TOAST_TIMEOUT=16000` in some other test. But I didn't like this approach because (1) there's no connection between the actual toast timeout in the FE source code and the timeout defined in the E2E spec. And more importantly (2) I didn't want to rely on the hacky mechanism when there'a s perfectly valid and simple solution available to us - just close the toast.

### Stress-test
30/30 ✅  https://github.com/metabase/metabase/actions/runs/9454315575/job/26041590482