### PR TITLE
Don't sync JWT registered claims as login attributes

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -40,13 +40,17 @@
 (def ^:private ^{:arglists '([])} jwt-attribute-lastname  (comp keyword sso-settings/jwt-attribute-lastname))
 (def ^:private ^{:arglists '([])} jwt-attribute-groups    (comp keyword sso-settings/jwt-attribute-groups))
 
+(def ^:private registered-claims
+  "Registered claims in the JWT standard which we should not interpret as login attributes"
+  [:iss :iat :sub :aud :exp :nbf :jti])
+
 (defn- jwt-data->login-attributes [jwt-data]
-  (dissoc jwt-data
-          (jwt-attribute-email)
-          (jwt-attribute-firstname)
-          (jwt-attribute-lastname)
-          :iat
-          :max_age))
+  (apply dissoc
+         jwt-data
+         (jwt-attribute-email)
+         (jwt-attribute-firstname)
+         (jwt-attribute-lastname)
+         registered-claims))
 
 ;; JWTs use seconds since Epoch, not milliseconds since Epoch for the `iat` and `max_age` time. 3 minutes is the time
 ;; used by Zendesk for their JWT SSO, so it seemed like a good place for us to start

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -159,7 +159,11 @@
                                                                   :first_name "Rasta"
                                                                   :last_name  "Toucan"
                                                                   :extra      "keypairs"
-                                                                  :are        "also present"}
+                                                                  :are        "also present"
+                                                                  ;; registerd claims should not be synced as login attributes
+                                                                  :iss        "issuer"
+                                                                  :exp        (+ (buddy-util/now) 3600)
+                                                                  :iat        (buddy-util/now)}
                                                                  default-jwt-secret))]
         (is (saml-test/successful-login? response))
         (testing "redirect URI"


### PR DESCRIPTION
Quick PR to exclude [registered claims](https://auth0.com/docs/secure/tokens/json-web-tokens/json-web-token-claims#registered-claims) from user attribute sync.

Closes https://github.com/metabase/metabase/issues/43971