### PR TITLE
Exclude native query matches in search scoring when the search should exclude native queries

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/search/scoring_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/search/scoring_test.clj
@@ -25,12 +25,12 @@
 (defn- ee-score
   [search-string item]
   (mt/with-premium-features #{:official-collections :content-verification}
-    (-> (scoring/score-and-result search-string item) :score)))
+    (-> (scoring/score-and-result item {:search-string search-string}) :score)))
 
 (defn- oss-score
   [search-string item]
   (mt/with-premium-features #{}
-    (-> (scoring/score-and-result search-string item) :score)))
+    (-> (scoring/score-and-result item {:search-string search-string}) :score)))
 
 (deftest official-collection-tests
   (testing "it should bump up the value of items in official collections"
@@ -121,7 +121,7 @@
              (-> (scoring/top-results
                   results
                   1
-                  (map #(scoring/score-and-result search-string %)))
+                  (map #(scoring/score-and-result % {:search-string search-string})))
                  first
                  :name))))))
 

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -186,65 +186,60 @@
   "All of the result components that by default are displayed by the frontend."
   #{:name :display_name :collection_name :description})
 
-(defmulti searchable-columns-for-model
-  "The columns that can be searched for the query."
-  {:arglists '([model])}
-  (fn [model] model))
+(defmulti searchable-columns
+  "The columns that can be searched for each model."
+  {:arglists '([model search-native-query])}
+  (fn [model _] model))
 
-(defmethod searchable-columns-for-model :default
-  [_]
+(defmethod searchable-columns :default
+  [_ _]
   [:name])
 
-(defmethod searchable-columns-for-model "action"
-  [_]
-  [:name
-   :dataset_query
-   :description])
+(defmethod searchable-columns "action"
+  [_ search-native-query]
+  (cond-> [:name
+           :description]
+    search-native-query
+    (conj :dataset_query)))
 
-(defmethod searchable-columns-for-model "card"
-  [_]
-  [:name
-   :dataset_query
-   :description])
+(defmethod searchable-columns "card"
+  [_ search-native-query]
+  (cond-> [:name
+           :description]
+    search-native-query
+    (conj :dataset_query)))
 
-(defmethod searchable-columns-for-model "dataset"
-  [_]
-  (searchable-columns-for-model "card"))
+(defmethod searchable-columns "dataset"
+  [_ search-native-query]
+  (searchable-columns "card" search-native-query))
 
-(defmethod searchable-columns-for-model "metric"
-  [_]
-  (searchable-columns-for-model "card"))
+(defmethod searchable-columns "metric"
+  [_ search-native-query]
+  (searchable-columns "card" search-native-query))
 
-(defmethod searchable-columns-for-model "dashboard"
-  [_]
-  [:name
-   :description])
-
-(defmethod searchable-columns-for-model "page"
-  [_]
-  (searchable-columns-for-model "dashboard"))
-
-(defmethod searchable-columns-for-model "database"
-  [_]
+(defmethod searchable-columns "dashboard"
+  [_ _]
   [:name
    :description])
 
-(defmethod searchable-columns-for-model "table"
-  [_]
+(defmethod searchable-columns "page"
+  [_ search-native-query]
+  (searchable-columns "dashboard" search-native-query))
+
+(defmethod searchable-columns "database"
+  [_ _]
+  [:name
+   :description])
+
+(defmethod searchable-columns "table"
+  [_ _]
   [:name
    :display_name
    :description])
 
-(defmethod searchable-columns-for-model "indexed-entity"
-  [_]
+(defmethod searchable-columns "indexed-entity"
+  [_ _]
   [:name])
-
-(defn searchable-columns
-  "The columns that will be searched for the query."
-  [model search-native-query]
-  (cond->> (searchable-columns-for-model model)
-    (not search-native-query)
-    (remove #{:dataset_query})))
 
 (def ^:private default-columns
   "Columns returned for all models."

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -187,7 +187,7 @@
   #{:name :display_name :collection_name :description})
 
 (defmulti searchable-columns-for-model
-  "The columns that will be searched for the query."
+  "The columns that can be searched for the query."
   {:arglists '([model])}
   (fn [model] model))
 
@@ -238,6 +238,13 @@
 (defmethod searchable-columns-for-model "indexed-entity"
   [_]
   [:name])
+
+(defn searchable-columns
+  "The columns that will be searched for the query."
+  [model search-native-query]
+  (cond->> (searchable-columns-for-model model)
+    (not search-native-query)
+    (remove #{:dataset_query})))
 
 (def ^:private default-columns
   "Columns returned for all models."

--- a/src/metabase/search/filter.clj
+++ b/src/metabase/search/filter.clj
@@ -80,12 +80,8 @@
   (when-let [query (:search-string search-context)]
     (into
      [:or]
-     (for [column           (cond->> (search.config/searchable-columns-for-model model)
-                              (not search-native-query?)
-                              (remove #{:dataset_query})
-
-                              true
-                              (map #(search.config/column-with-model-alias model %)))
+     (for [column           (->> (search.config/searchable-columns model search-native-query?)
+                                 (map #(search.config/column-with-model-alias model %)))
            wildcarded-token (->> (search.util/normalize query)
                                  search.util/tokenize
                                  (map search.util/wildcard-match))]

--- a/src/metabase/search/filter.clj
+++ b/src/metabase/search/filter.clj
@@ -252,7 +252,7 @@
   This is function instead of a def so that optional-filter-clause can be defined anywhere in the codebase."
   []
   (merge
-   ;; models support search-native-query if there is additional columns to search when the `search-native-query`
+   ;; models support search-native-query if there are additional columns to search when the `search-native-query`
    ;; argument is true
    {:search-native-query (->> (dissoc (methods search.config/searchable-columns) :default)
                               (filter (fn [[model f]]

--- a/src/metabase/search/filter.clj
+++ b/src/metabase/search/filter.clj
@@ -252,10 +252,11 @@
   This is function instead of a def so that optional-filter-clause can be defined anywhere in the codebase."
   []
   (merge
-   ;; models support search-native-query if dataset_query is one of the searchable columns
+   ;; models support search-native-query if there is additional columns to search when the `search-native-query`
+   ;; argument is true
    {:search-native-query (->> (dissoc (methods search.config/searchable-columns) :default)
-                              (filter (fn [[k v]]
-                                        (contains? (set (v k true)) :dataset_query)))
+                              (filter (fn [[model f]]
+                                        (seq (set/difference (set (f model true)) (set (f model false))))))
                               (map first)
                               set)}
    (->> (dissoc (methods build-optional-filter-query) :default)

--- a/src/metabase/search/filter.clj
+++ b/src/metabase/search/filter.clj
@@ -76,11 +76,11 @@
 (mu/defn ^:private search-string-clause-for-model
   [model                :- SearchableModel
    search-context       :- SearchContext
-   search-native-query? :- [:maybe :boolean]]
+   search-native-query  :- [:maybe true?]]
   (when-let [query (:search-string search-context)]
     (into
      [:or]
-     (for [column           (->> (search.config/searchable-columns model search-native-query?)
+     (for [column           (->> (search.config/searchable-columns model search-native-query)
                                  (map #(search.config/column-with-model-alias model %)))
            wildcarded-token (->> (search.util/normalize query)
                                  search.util/tokenize

--- a/src/metabase/search/filter.clj
+++ b/src/metabase/search/filter.clj
@@ -253,9 +253,9 @@
   []
   (merge
    ;; models support search-native-query if dataset_query is one of the searchable columns
-   {:search-native-query (->> (dissoc (methods search.config/searchable-columns-for-model) :default)
+   {:search-native-query (->> (dissoc (methods search.config/searchable-columns) :default)
                               (filter (fn [[k v]]
-                                        (contains? (set (v k)) :dataset_query)))
+                                        (contains? (set (v k true)) :dataset_query)))
                               (map first)
                               set)}
    (->> (dissoc (methods build-optional-filter-query) :default)

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -620,7 +620,7 @@
 
                             (map #(update % :pk_ref json/parse-string))
                             (map add-can-write)
-                            (map (partial scoring/score-and-result (:search-string search-ctx) (:search-native-query search-ctx)))
+                            (map #(scoring/score-and-result % (select-keys search-ctx [:search-string :search-native-query])))
 
                             (filter #(pos? (:score %))))
         total-results       (cond->> (scoring/top-results reducible-results search.config/max-filtered-results xf)

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -620,7 +620,7 @@
 
                             (map #(update % :pk_ref json/parse-string))
                             (map add-can-write)
-                            (map (partial scoring/score-and-result (:search-string search-ctx)))
+                            (map (partial scoring/score-and-result (:search-string search-ctx) (:search-native-query search-ctx)))
 
                             (filter #(pos? (:score %))))
         total-results       (cond->> (scoring/top-results reducible-results search.config/max-filtered-results xf)

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -661,7 +661,7 @@
    [:limit                               {:optional true} [:maybe ms/Int]]
    [:offset                              {:optional true} [:maybe ms/Int]]
    [:table-db-id                         {:optional true} [:maybe ms/PositiveInt]]
-   [:search-native-query                 {:optional true} [:maybe boolean?]]
+   [:search-native-query                 {:optional true} [:maybe true?]]
    [:model-ancestors?                    {:optional true} [:maybe boolean?]]
    [:verified                            {:optional true} [:maybe true?]]])
 

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -156,9 +156,9 @@
 (defn- text-scores-with
   "Scores a search result. Returns a vector of score maps, each containing `:weight`, `:score`, and other info about
   the text match, if there is one. If there is no match, the score is 0."
-  [weighted-scorers query-tokens search-result]
+  [search-native-query weighted-scorers query-tokens search-result]
   ;; TODO is pmap over search-result worth it?
-  (let [scores (for [column      (search.config/searchable-columns-for-model (:model search-result))
+  (let [scores (for [column      (search.config/searchable-columns (:model search-result) search-native-query)
                      {:keys [scorer name weight]
                       :as   _ws} weighted-scorers
                      :let        [matched-text (-> search-result
@@ -256,9 +256,10 @@
      (count model->sort-position)))
 
 (defn- text-scores-with-match
-  [raw-search-string result]
+  [raw-search-string search-native-query result]
   (if (seq raw-search-string)
-    (text-scores-with match-based-scorers
+    (text-scores-with search-native-query
+                      match-based-scorers
                       (search.util/tokenize (search.util/normalize raw-search-string))
                       result)
     [{:score 0 :weight 0}]))
@@ -353,9 +354,9 @@
 
 (defn score-and-result
   "Returns a map with the normalized, combined score from relevant-scores as `:score` and `:result`."
-  [raw-search-string result]
+  [raw-search-string search-native-query result]
   (let [text-matches     (-> raw-search-string
-                             (text-scores-with-match result)
+                             (text-scores-with-match search-native-query result)
                              (force-weight text-scores-weight))
         all-scores       (into (vec (score-result result)) text-matches)
         relevant-scores  (remove #(= 0 (:score %)) all-scores)

--- a/test/metabase/search/filter_test.clj
+++ b/test/metabase/search/filter_test.clj
@@ -404,8 +404,10 @@
       (testing "search in both name, description and dataset_query if is enabled"
         (is (= [:and [:or
                       [:like [:lower :card.name] "%foo%"]
-                      [:and [:= :card.query_type "native"] [:like [:lower :card.dataset_query] "%foo%"]]
-                      [:like [:lower :card.description] "%foo%"]]
+                      [:like [:lower :card.description] "%foo%"]
+                      [:and
+                       [:= :card.query_type "native"]
+                       [:like [:lower :card.dataset_query] "%foo%"]]]
                 [:= :card.archived false]]
                (:where (search.filter/build-filters
                         base-search-query
@@ -429,8 +431,8 @@
       (is (= [:and
               [:or
                [:like [:lower :action.name] "%foo%"]
-               [:like [:lower :query_action.dataset_query] "%foo%"]
-               [:like [:lower :action.description] "%foo%"]]
+               [:like [:lower :action.description] "%foo%"]
+               [:like [:lower :query_action.dataset_query] "%foo%"]]
               [:= :action.archived false]]
              (:where (search.filter/build-filters
                       base-search-query

--- a/test/metabase/search/filter_test.clj
+++ b/test/metabase/search/filter_test.clj
@@ -6,7 +6,7 @@
    [metabase.search.filter :as search.filter]
    [metabase.test :as mt]))
 
-(def ^:private default-search-ctx
+(def default-search-ctx
   {:search-string       nil
    :archived?           false
    :models             search.config/all-models

--- a/test/metabase/search/scoring_test.clj
+++ b/test/metabase/search/scoring_test.clj
@@ -16,7 +16,7 @@
   [scorer]
   (comp :score
         first
-        (partial #'scoring/text-scores-with [{:weight 1 :scorer scorer}])))
+        (partial #'scoring/text-scores-with nil [{:weight 1 :scorer scorer}])))
 
 (deftest ^:parallel consecutivity-scorer-test
   (let [score (scorer->score #'scoring/consecutivity-scorer)]
@@ -243,7 +243,7 @@
                        d])              ; middling text match, no other signal
            (->> labeled-results
                 vals
-                (map (partial scoring/score-and-result search-string))
+                (map (partial scoring/score-and-result search-string nil))
                 (sort-by :score)
                 reverse
                 (map :result)
@@ -258,7 +258,7 @@
     (is (= (map :name [b c a])
            (->> labeled-results
                 vals
-                (map (partial scoring/score-and-result search-string))
+                (map (partial scoring/score-and-result search-string nil))
                 (sort-by :score)
                 reverse
                 (map :result)
@@ -270,7 +270,7 @@
                   (fn [_]
                     [{:weight 100 :score 0 :name "Some score type"}
                      {:weight 100 :score 0 :name "Some other score type"}])]
-      (is (= 0 (:score (scoring/score-and-result "" {:name "racing yo" :model "card"})))))))
+      (is (= 0 (:score (scoring/score-and-result "" nil {:name "racing yo" :model "card"})))))))
 
 
 (deftest ^:parallel force-weight-test

--- a/test/metabase/search/scoring_test.clj
+++ b/test/metabase/search/scoring_test.clj
@@ -3,7 +3,11 @@
    [clojure.test :refer :all]
    [java-time.api :as t]
    [metabase.search.config :as search.config]
-   [metabase.search.scoring :as scoring]))
+   [metabase.search.filter-test :as search.filter-test]
+   [metabase.search.impl :as search.impl]
+   [metabase.search.scoring :as scoring]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
 
 (defn- result-row
   ([name]
@@ -226,6 +230,28 @@
                     (sort-by score)
                     (map :id))))))))
 
+(defn search-results
+  "Returns search results as they are returned from the search query before scoring"
+  [search-ctx]
+  (mt/with-current-user (mt/user->id :crowberto)
+    (let [search-ctx (merge search.filter-test/default-search-ctx search-ctx)]
+      (t2/query (#'search.impl/full-search-query search-ctx)))))
+
+(deftest search-native-query-scoring-test
+  (testing "Exclude native query matches in search scoring when the search should exclude native queries"
+    (mt/dataset test-data
+      (mt/with-temp [:model/Card card-1 {:name "matching", :dataset_query (mt/native-query {:query "also matching"})}
+                     :model/Card card-2 {:name "matching", :dataset_query (mt/native-query {:query "doesn't"})}]
+        (let [search-string       "matching"
+              search-native-query false
+              results             (search-results {:search-string search-string}) ;; note, no search-native-query
+              score               (fn [model id]
+                                    (let [result (first (filter #(= [(:model %) (:id %)] [model id]) results))]
+                                      (float (:score (scoring/score-and-result result {:search-string       search-string
+                                                                                       :search-native-query search-native-query})))))
+              [scores-1 scores-2] (map #(score "card" %) [(:id card-1) (:id card-2)])]
+          (is (= scores-1 scores-2)))))))
+
 (deftest ^:parallel combined-test
   (let [search-string     "custom expression examples"
         labeled-results   {:a {:name "custom expression examples" :model "dashboard"}
@@ -243,7 +269,7 @@
                        d])              ; middling text match, no other signal
            (->> labeled-results
                 vals
-                (map (partial scoring/score-and-result search-string nil))
+                (map #(scoring/score-and-result % {:search-string search-string :search-native-query nil}))
                 (sort-by :score)
                 reverse
                 (map :result)
@@ -258,7 +284,7 @@
     (is (= (map :name [b c a])
            (->> labeled-results
                 vals
-                (map (partial scoring/score-and-result search-string nil))
+                (map #(scoring/score-and-result % {:search-string search-string :search-native-query nil}))
                 (sort-by :score)
                 reverse
                 (map :result)
@@ -270,7 +296,8 @@
                   (fn [_]
                     [{:weight 100 :score 0 :name "Some score type"}
                      {:weight 100 :score 0 :name "Some other score type"}])]
-      (is (= 0 (:score (scoring/score-and-result "" nil {:name "racing yo" :model "card"})))))))
+      (is (= 0 (:score (scoring/score-and-result {:name "racing yo" :model "card"}
+                                                 {:search-string "" :search-native-query nil})))))))
 
 
 (deftest ^:parallel force-weight-test

--- a/test/metabase/search/scoring_test.clj
+++ b/test/metabase/search/scoring_test.clj
@@ -240,17 +240,18 @@
 (deftest search-native-query-scoring-test
   (testing "Exclude native query matches in search scoring when the search should exclude native queries"
     (mt/dataset test-data
-      (mt/with-temp [:model/Card card-1 {:name "matching", :dataset_query (mt/native-query {:query "also matching"})}
+      (mt/with-temp [;; card-1 has a match in the native query, card-2 does not
+                     :model/Card card-1 {:name "matching", :dataset_query (mt/native-query {:query "also matching"})}
                      :model/Card card-2 {:name "matching", :dataset_query (mt/native-query {:query "doesn't"})}]
         (let [search-string       "matching"
               search-native-query false
-              results             (search-results {:search-string search-string}) ;; note, no search-native-query
+              results             (search-results {:search-string search-string}) ; note :search-native-query is not enabled
               score               (fn [model id]
                                     (let [result (first (filter #(= [(:model %) (:id %)] [model id]) results))]
                                       (float (:score (scoring/score-and-result result {:search-string       search-string
                                                                                        :search-native-query search-native-query})))))
-              [scores-1 scores-2] (map #(score "card" %) [(:id card-1) (:id card-2)])]
-          (is (= scores-1 scores-2)))))))
+              [score-1 score-2]   (map #(score "card" %) [(:id card-1) (:id card-2)])]
+          (is (= score-1 score-2)))))))
 
 (deftest ^:parallel combined-test
   (let [search-string     "custom expression examples"


### PR DESCRIPTION
This fixes a bug I found with search scoring where we were considering native query matches in the scoring of search results, even if native query search was toggled off. This has been the case since the native query search toggle was added.

Here's a demonstration of the issue on master:

```clojure
(ns metabase.search.scoring-test
  (:require
   [clojure.test :refer :all]
   [java-time.api :as t]
   [metabase.search.config :as search.config]
   [metabase.search.filter-test :as search.filter-test]
   [metabase.search.impl :as search.impl]
   [metabase.search.scoring :as scoring]
   [metabase.test :as mt]
   [toucan2.core :as t2]))

(defn search-results 
  "Returns search results as they are returned from the search query before scoring"
  [search-ctx]
  (mt/with-current-user (mt/user->id :crowberto)
    (let [search-ctx (merge search.filter-test/default-search-ctx search-ctx)]
      (t2/query (#'search.impl/full-search-query search-ctx)))))

(mt/dataset test-data
  (mt/with-temp [:model/Card card-1 {:name          "matching"
                                     :dataset_query (mt/native-query {:query "also matching"})}
                 :model/Card card-2 {:name          "matching"
                                     :dataset_query (mt/native-query {:query "doesn't"})}]
    (let [search-string "matching"
          results (search-results {:search-string search-string}) ; note no :search-native-query in the search-context
          score (fn [model id]
                  (let [result (first (filter #(= [(:model %) (:id %)] [model id]) results))]
                    (float (:score (scoring/score-and-result search-string result)))))
          [scores-1 scores-2] (map #(score "card" %) [(:id card-1) (:id card-2)])]
      (is (= scores-1 scores-2)
          "Scores should be equal if the only difference is in the dataset query."))))
; (0.6756966 0.6911765)
;   actual: 0.6911765
;     diff: - 0.6756966
;           + 0.6911765
```
(You might be confused that in the above example, card 2's score is higher than card 1's, even though card 1 has more matches. That's a different issue, and applies in the case where there are matching name and description too)