### PR TITLE
fix single series bar hover

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
@@ -231,8 +231,10 @@ export const useChartEvents = (
           ? settings.series(seriesModel.legacySeriesSettingsObjectKey)
               .display === "bar"
           : false;
+      const shouldHighlightEntireSeries =
+        isBarSeries && chartModel.seriesModels.length > 1;
 
-      if (originalDatumIndex != null && !isBarSeries) {
+      if (originalDatumIndex != null && !shouldHighlightEntireSeries) {
         // (issue #40215)
         // since some transformed datasets have indexes differing from
         // the original datasets indexes and ECharts uses the transformedDataset

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-models-and-option.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-models-and-option.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from "react";
 
-import { isCypressActive } from "metabase/env";
+import { isReducedMotionPreferred } from "metabase/lib/dom";
 import { extractRemappings } from "metabase/visualizations";
 import { getChartMeasurements } from "metabase/visualizations/echarts/cartesian/chart-measurements";
 import { getCartesianChartModel } from "metabase/visualizations/echarts/cartesian/model";
@@ -115,7 +115,7 @@ export function useModelsAndOption({
       return {};
     }
 
-    const shouldAnimate = !isPlaceholder && !isCypressActive;
+    const shouldAnimate = !isPlaceholder && !isReducedMotionPreferred();
 
     switch (card.display) {
       case "waterfall":


### PR DESCRIPTION
### Description

Fixes single series bar chart hover does not focusing on the hovered bar by blurring others as it was with the dc.js implementation.

### How to verify

- Create a single series bar chart
- Hover bars and ensure not hovered gets blurred
- 
### Demo

Before
<img width="1709" alt="Screenshot 2024-06-10 at 9 34 09 PM" src="https://github.com/metabase/metabase/assets/14301985/442d7f3f-1600-487c-aaf9-61466d10cbfe">

After
<img width="1359" alt="Screenshot 2024-06-10 at 9 33 42 PM" src="https://github.com/metabase/metabase/assets/14301985/1f065211-1656-4e28-a308-3a92075e61c4">

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR
