### PR TITLE
Remove the custom resize handle from the notebook native query preview sidebar (again)

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
@@ -4,7 +4,6 @@ import type { ResizeCallbackData, ResizableBoxProps } from "react-resizable";
 import { ResizableBox } from "react-resizable";
 import { useWindowSize } from "react-use";
 
-import { darken } from "metabase/lib/colors";
 import { useSelector, useDispatch } from "metabase/lib/redux";
 import {
   setNotebookNativePreviewSidebarWidth,
@@ -81,14 +80,11 @@ export const NotebookContainer = ({
         top={0}
         bottom={0}
         m="auto 0"
-        h={rem(100)}
         w={rem(handleWidth)}
         left={left}
-        bg={darken("border", 0.03)}
         style={{
           zIndex: 5,
           cursor: "ew-resize",
-          borderRadius: rem(8),
         }}
       ></Box>
     );


### PR DESCRIPTION
This was originally done in #41877, where you might find some more context behind the decision.

But the handle mistakenly came back to life as a result of an erroneous merge-conflict resolution in the [React 18 commit](https://github.com/metabase/metabase/pull/41975/files#diff-f5aa0f65e76aee920d8ee677d54df9fad372ca1c1db95e8d0afd3a9aa46a6d36L69).

This PR removes the custom styling of the handle again.
Resolves #44022