### PR TITLE
Restore icons in the new filter popup

### DIFF
--- a/frontend/src/metabase/dashboard/components/ParametersPopover.tsx
+++ b/frontend/src/metabase/dashboard/components/ParametersPopover.tsx
@@ -13,6 +13,7 @@ import {
   getDashboardParameterSections,
   getDefaultOptionForParameterSectionMap,
 } from "metabase/parameters/utils/dashboard-options";
+import { getParameterIconName } from "metabase/parameters/utils/ui";
 import { Icon } from "metabase/ui";
 import type { ParameterMappingOptions } from "metabase-types/api";
 
@@ -69,7 +70,11 @@ const ParameterOptionsSection = ({
       className={cx(CS.textBold, CS.flex, CS.alignCenter)}
       style={{ marginBottom: 4 }}
     >
-      <Icon size="16" name="label" className={CS.mr1} />
+      <Icon
+        size="16"
+        name={getParameterIconName(section.id)}
+        className={CS.mr1}
+      />
       {section.name}
     </OptionItemTitle>
     <OptionItemDescription>{section.description}</OptionItemDescription>

--- a/frontend/src/metabase/dashboard/components/ParametersPopover.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/ParametersPopover.unit.spec.tsx
@@ -31,12 +31,13 @@ const options = [
 ];
 
 describe("ParameterPopover", () => {
-  it("should render options with icons", () => {
-    render(
-      <ParametersPopover onClose={jest.fn()} onAddParameter={jest.fn()} />,
-    );
+  it.each(options)(
+    "should render '$title' option with icon '$icon'",
+    ({ title, subtitle, icon }) => {
+      render(
+        <ParametersPopover onClose={jest.fn()} onAddParameter={jest.fn()} />,
+      );
 
-    options.forEach(({ title, subtitle, icon }) => {
       expect(screen.getByText(title)).toBeInTheDocument();
 
       const section = screen.getByText(title).parentElement as HTMLElement;
@@ -45,6 +46,6 @@ describe("ParameterPopover", () => {
       expect(
         within(section).getByLabelText(`${icon} icon`),
       ).toBeInTheDocument();
-    });
-  });
+    },
+  );
 });

--- a/frontend/src/metabase/dashboard/components/ParametersPopover.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/ParametersPopover.unit.spec.tsx
@@ -1,0 +1,50 @@
+import { render, screen, within } from "__support__/ui";
+
+import { ParametersPopover } from "./ParametersPopover";
+
+const options = [
+  {
+    title: "Time",
+    subtitle: "Date range, relative date, time of day, etc.",
+    icon: "calendar",
+  },
+  {
+    title: "Location",
+    subtitle: "City, State, Country, ZIP code.",
+    icon: "location",
+  },
+  {
+    title: "ID",
+    subtitle: "User ID, Product ID, Event ID, etc.",
+    icon: "label",
+  },
+  {
+    title: "Number",
+    subtitle: "Subtotal, Age, Price, Quantity, etc.",
+    icon: "number",
+  },
+  {
+    title: "Text or Category",
+    subtitle: "Name, Rating, Description, etc.",
+    icon: "label",
+  },
+];
+
+describe("ParameterPopover", () => {
+  it("should render options with icons", () => {
+    render(
+      <ParametersPopover onClose={jest.fn()} onAddParameter={jest.fn()} />,
+    );
+
+    options.forEach(({ title, subtitle, icon }) => {
+      expect(screen.getByText(title)).toBeInTheDocument();
+
+      const section = screen.getByText(title).parentElement as HTMLElement;
+
+      expect(within(section).getByText(subtitle)).toBeInTheDocument();
+      expect(
+        within(section).getByLabelText(`${icon} icon`),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/metabase/parameters/utils/ui.ts
+++ b/frontend/src/metabase/parameters/utils/ui.ts
@@ -5,7 +5,7 @@ import type { UiParameter } from "metabase-lib/v1/parameters/types";
 import { deriveFieldOperatorFromParameter } from "metabase-lib/v1/parameters/utils/operators";
 import { getParameterType } from "metabase-lib/v1/parameters/utils/parameter-type";
 
-export function getParameterIconName(parameter: UiParameter) {
+export function getParameterIconName(parameter: UiParameter | string) {
   const type = getParameterType(parameter);
   switch (type) {
     case "date":


### PR DESCRIPTION
### Description

I accidentally replaced icons with the only `label` icon in https://github.com/metabase/metabase/pull/42107
this PR restores correct behaviour

### How to verify

open dashboard -> open "add new filter" popup -> options should have correct icons

### Demo

<img width="395" alt="image" src="https://github.com/metabase/metabase/assets/125459446/5965a8da-e6f3-4c8a-8a06-374ad50709c0">


version 0.49.5

<img width="413" alt="image" src="https://github.com/metabase/metabase/assets/125459446/3414a46f-c772-4657-afd1-0428f57a53d7">


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
