### PR TITLE
Fix fields from Amazon Athena Tables failing to sync if there is not an underscore in the Table Name

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -40,6 +40,9 @@ jobs:
       MB_ATHENA_TEST_ACCESS_KEY: ${{ secrets.MB_ATHENA_TEST_ACCESS_KEY }}
       MB_ATHENA_TEST_SECRET_KEY: ${{ secrets.MB_ATHENA_TEST_SECRET_KEY }}
       MB_ATHENA_TEST_S3_STAGING_DIR: ${{ secrets.MB_ATHENA_TEST_S3_STAGING_DIR }}
+      # These credentials are used to test the driver when the user does not have the athena:GetTableMetadata permission
+      MB_ATHENA_TEST_WITHOUT_GET_TABLE_METADATA_ACCESS_KEY: ${{ secrets.MB_ATHENA_TEST_WITHOUT_GET_TABLE_METADATA_ACCESS_KEY }}
+      MB_ATHENA_TEST_WITHOUT_GET_TABLE_METADATA_SECRET_KEY: ${{ secrets.MB_ATHENA_TEST_WITHOUT_GET_TABLE_METADATA_SECRET_KEY }}
     steps:
     - uses: actions/checkout@v4
     - name: Test Athena driver

--- a/modules/drivers/athena/test/metabase/driver/athena_test.clj
+++ b/modules/drivers/athena/test/metabase/driver/athena_test.clj
@@ -231,12 +231,12 @@
   (testing "`describe-table` works if the AWS user's IAM policy doesn't include athena:GetTableMetadata permissions")
     (mt/test-driver :athena
       (mt/dataset airports
-        (let [catalog "AwsDataCatalog" ; The bug only happens when :Catalog is not nil
+        (let [catalog "AwsDataCatalog" ; The bug only happens when :catalog is not nil
               details (assoc (:details (mt/db))
                              ;; these credentials are for a user that doesn't have athena:GetTableMetadata permissions
                              :access_key (tx/db-test-env-var-or-throw :athena :without-get-table-metadata-access-key)
                              :secret_key (tx/db-test-env-var-or-throw :athena :without-get-table-metadata-secret-key)
-                             :Catalog catalog)]
+                             :catalog catalog)]
           (mt/with-temp [:model/Database db {:engine :athena, :details details}]
             (sync/sync-database! db {:scan :schema})
             (let [table (t2/select-one :model/Table :db_id (:id db) :name "airport")]

--- a/modules/drivers/athena/test/metabase/driver/athena_test.clj
+++ b/modules/drivers/athena/test/metabase/driver/athena_test.clj
@@ -227,12 +227,13 @@
             (is (string? result))
             (is (str/starts-with? result "SELECT"))))))))
 
-(deftest describe-table-works-without-get-columns-test
-  (testing "`describe-table` still works when the JDBC .getColumns method returns no results (metabase#43980)")
+(deftest describe-table-works-without-get-table-metadata-permission-test
+  (testing "`describe-table` works if the AWS user's IAM policy doesn't include athena:GetTableMetadata permissions")
     (mt/test-driver :athena
       (mt/dataset airports
         (let [catalog "AwsDataCatalog" ; The bug only happens when :Catalog is not nil
               details (assoc (:details (mt/db))
+                             ;; these credentials are for a user that doesn't have athena:GetTableMetadata permissions
                              :access_key (tx/db-test-env-var-or-throw :athena :without-get-table-metadata-access-key)
                              :secret_key (tx/db-test-env-var-or-throw :athena :without-get-table-metadata-secret-key)
                              :Catalog catalog)]


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/43980

The root cause of the problem is described here in [the issue](https://github.com/metabase/metabase/issues/43980#issuecomment-2166965880). The `java.sql.DatabaseMetadata` `getColumns` method returns an empty list in the scenario where the AWS user has no `GetTableMetadata` permissions. With this PR, in this scenario we will use a `DESCRIBE ...` query to get the column metadata, which doesn't suffer from the same bug but is slower.

Each `DESCRIBE` query takes about a second, so this has the potential to substantially slow down sync if there are many tables with such issues (~1 second per table). But I think we care more about fixing the bug than making athena sync that much slower. To make sync faster, we could implement something like step 4 in [this proposal](https://www.notion.so/metabase/Faster-sync-for-more-drivers-d5b657aba7354a19bf89d62f1038a8ff?pvs=4#01fed4c9f4c34b8199a481e82deb8b8a) but for nested fields, which would avoid the need to do a query per table.

To test this locally, make sure you've set the appropriate env variables for all the settings below. Use the credentials [here](https://start.1password.com/open/i?a=AEO4BXOSHNFCJLK26XA7AD522E&v=fbhwdxcon6hj77du2c5cc7wvaa&i=xhozcstrujjwm7n5thraqbvwl4&h=my.1password.com) and [here](https://start.1password.com/open/i?a=AEO4BXOSHNFCJLK26XA7AD522E&v=fbhwdxcon6hj77du2c5cc7wvaa&i=y3hco6kbtooqhdonm5p23vamwi&h=my.1password.com) to configure the athena test users to match CI. https://github.com/metabase/metabase/blob/6899f3cccb34a4c3cb8152e8bb3a3a60c677fa66/.github/workflows/drivers.yml#L40-L45
`MB_ATHENA_TEST_REGION` should be `us-east-1`