### PR TITLE
certain settings should be decrypted for cache config migration to run

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -7227,25 +7227,6 @@ databaseChangeLog:
                   defaultValue: false
 
   - changeSet:
-      id: v50.2024-04-12T12:33:09
-      author: piranha
-      comment: 'Copy old cache configurations to cache_config table'
-      changes:
-        - sqlFile:
-            dbms: postgresql
-            path: custom_sql/fill_cache_config.pg.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: custom_sql/fill_cache_config.my.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: h2
-            path: custom_sql/fill_cache_config.h2.sql
-            relativeToChangelogFile: true
-      rollback: # no rollback necessary, we're not removing the columns yet
-
-  - changeSet:
       id: v50.2024-04-15T16:30:35
       author: qnkhuat
       comment: Add report_card.last_used_at
@@ -7871,6 +7852,35 @@ databaseChangeLog:
             path: trash/mariadb.sql
             relativeToChangelogFile: true
       rollback: # not needed, columns will be deleted
+
+  - changeSet:
+      id: v50.2024-06-12T12:33:08
+      author: piranha
+      comment: 'Decrypt some settings so the next migration runs well'
+      changes:
+        - customChange:
+            class: "metabase.db.custom_migrations.DecryptCacheSettings"
+      rollback: # no rollback necessary, they'll be encrypted if you downgrade and touch them
+
+  - changeSet:
+      # this had id `v50.2024-04-12T12:33:09` before #44048
+      id: v50.2024-06-12T12:33:09
+      author: piranha
+      comment: 'Copy old cache configurations to cache_config table'
+      changes:
+        - sqlFile:
+            dbms: postgresql
+            path: custom_sql/fill_cache_config.pg.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: mysql,mariadb
+            path: custom_sql/fill_cache_config.my.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: h2
+            path: custom_sql/fill_cache_config.h2.sql
+            relativeToChangelogFile: true
+      rollback: # no rollback necessary, we're not removing the columns yet
 
   - changeSet:
       id: v51.2024-05-13T15:30:57

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -7854,7 +7854,7 @@ databaseChangeLog:
       rollback: # not needed, columns will be deleted
 
   - changeSet:
-      id: v50.2024-06-12T12:33:08
+      id: v50.2024-06-12T12:33:07
       author: piranha
       comment: 'Decrypt some settings so the next migration runs well'
       changes:
@@ -7864,7 +7864,7 @@ databaseChangeLog:
 
   - changeSet:
       # this had id `v50.2024-04-12T12:33:09` before #44048
-      id: v50.2024-06-12T12:33:09
+      id: v50.2024-06-12T12:33:08
       author: piranha
       comment: 'Copy old cache configurations to cache_config table'
       changes:
@@ -7881,6 +7881,17 @@ databaseChangeLog:
             path: custom_sql/fill_cache_config.h2.sql
             relativeToChangelogFile: true
       rollback: # no rollback necessary, we're not removing the columns yet
+
+  - changeSet:
+      id: v50.2024-06-12T12:33:09
+      author: piranha
+      comment: 'Fix root cache config for mysql if it is wrong'
+      dbms: mysql,mariadb
+      changes:
+        - sqlFile:
+            path: custom_sql/fill_cache_config_root_fix.my.sql
+            relativeToChangelogFile: true
+      rollback: # no rollback necessary here too
 
   - changeSet:
       id: v51.2024-05-13T15:30:57

--- a/resources/migrations/custom_sql/fill_cache_config_root_fix.my.sql
+++ b/resources/migrations/custom_sql/fill_cache_config_root_fix.my.sql
@@ -1,0 +1,10 @@
+UPDATE cache_config
+   SET config = json_object(
+           'multiplier', coalesce((select cast(`value` as unsigned) from setting where `key` = 'query-caching-ttl-ratio'), 10),
+           'min_duration_ms', coalesce((select cast(`value` as unsigned) from setting where `key` = 'query-caching-min-ttl'), 60000)
+         )
+ WHERE model = 'root' AND
+       model_id = 0 AND
+       strategy = 'ttl' AND
+       (json_extract(config, '$.multiplier') = 0 OR
+        json_extract(config, '$.min_duration_ms') = 0);

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -1458,3 +1458,10 @@
       (->> settings
            (filter :value)
            (t2/insert! :setting)))))
+
+(define-migration DecryptCacheSettings
+  (let [decrypt! (fn [k]
+                   (t2/update! :setting :key k {:value (raw-setting-value k)}))]
+    (run! decrypt! ["query-caching-ttl-ratio"
+                    "query-caching-min-ttl"
+                    "enable-query-caching"])))

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -1998,19 +1998,19 @@
         (is (false? (sample-content-created?)))))))
 
 (deftest decrypt-cache-settings-test
-  (impl/test-migrations "v50.2024-06-12T12:33:08" [migrate!]
+  (impl/test-migrations "v50.2024-06-12T12:33:07" [migrate!]
     (encryption-test/with-secret-key "whateverwhatever"
       (mdb.query/update-or-insert! :model/Setting {:key "enable-query-caching"} (constantly {:value "true"}))
       (mdb.query/update-or-insert! :model/Setting {:key "query-caching-ttl-ratio"} (constantly {:value "100"}))
       (mdb.query/update-or-insert! :model/Setting {:key "query-caching-min-ttl"} (constantly {:value "123"})))
 
     (testing "Values were indeed encrypted"
-      (is (not= "true" (t2/select-one-fn :value :model/Setting :key "enable-query-caching"))))
+      (is (not= "true" (t2/select-one-fn :value :setting :key "enable-query-caching"))))
 
     (encryption-test/with-secret-key "whateverwhatever"
       (migrate!))
 
     (testing "But not anymore"
-      (is (= "true" (t2/select-one-fn :value :model/Setting :key "enable-query-caching")))
-      (is (= "100" (t2/select-one-fn :value :model/Setting :key "query-caching-ttl-ratio")))
-      (is (= "123" (t2/select-one-fn :value :model/Setting :key "query-caching-min-ttl"))))))
+      (is (= "true" (t2/select-one-fn :value :setting :key "enable-query-caching")))
+      (is (= "100" (t2/select-one-fn :value :setting :key "query-caching-ttl-ratio")))
+      (is (= "123" (t2/select-one-fn :value :setting :key "query-caching-min-ttl"))))))

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -16,7 +16,6 @@
    [metabase.db :as mdb]
    [metabase.db.connection :as mdb.connection]
    [metabase.db.custom-migrations :as custom-migrations]
-   [metabase.db.query :as mdb.query]
    [metabase.db.schema-migrations-test.impl :as impl]
    [metabase.driver :as driver]
    [metabase.models.database :as database]
@@ -2000,9 +1999,9 @@
 (deftest decrypt-cache-settings-test
   (impl/test-migrations "v50.2024-06-12T12:33:07" [migrate!]
     (encryption-test/with-secret-key "whateverwhatever"
-      (mdb.query/update-or-insert! :model/Setting {:key "enable-query-caching"} (constantly {:value "true"}))
-      (mdb.query/update-or-insert! :model/Setting {:key "query-caching-ttl-ratio"} (constantly {:value "100"}))
-      (mdb.query/update-or-insert! :model/Setting {:key "query-caching-min-ttl"} (constantly {:value "123"})))
+      (t2/insert! :setting [{:key "enable-query-caching", :value (encryption/maybe-encrypt "true")}
+                            {:key "query-caching-ttl-ratio", :value (encryption/maybe-encrypt "100")}
+                            {:key "query-caching-min-ttl", :value (encryption/maybe-encrypt "123")}]))
 
     (testing "Values were indeed encrypted"
       (is (not= "true" (t2/select-one-fn :value :setting :key "enable-query-caching"))))

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -33,6 +33,7 @@
    [metabase.models.collection :as collection]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
+   [metabase.util.encryption :as encryption]
    [metabase.util.encryption-test :as encryption-test]
    [toucan2.core :as t2]))
 
@@ -1498,10 +1499,10 @@
     (impl/test-migrations ["v50.2024-06-12T12:33:07"] [migrate!]
       ;; this peculiar setup is to reproduce #44012, `enable-query-caching` should be unencrypted for the condition
       ;; to hit it
-      (mdb.query/update-or-insert! :model/Setting {:key "enable-query-caching"} (constantly {:value "true"}))
+      (t2/insert! :setting [{:key "enable-query-caching", :value (encryption/maybe-encrypt "true")}])
       (encryption-test/with-secret-key "whateverwhatever"
-        (mdb.query/update-or-insert! :model/Setting {:key "query-caching-ttl-ratio"} (constantly {:value "100"}))
-        (mdb.query/update-or-insert! :model/Setting {:key "query-caching-min-ttl"} (constantly {:value "123"})))
+        (t2/insert! :setting [{:key "query-caching-ttl-ratio", :value (encryption/maybe-encrypt "100")}
+                              {:key "query-caching-min-ttl", :value (encryption/maybe-encrypt "123")}]))
 
       (let [user (create-raw-user! (mt/random-email))
             db   (t2/insert-returning-pk! :metabase_database (-> (mt/with-temp-defaults Database)
@@ -1531,27 +1532,28 @@
 
         (is (=? [{:model    "root"
                   :model_id 0
-                  :strategy :ttl
+                  :strategy "ttl"
                   :config   {:multiplier      100
                              :min_duration_ms 123}}
                  {:model    "database"
                   :model_id db
-                  :strategy :duration
+                  :strategy "duration"
                   :config   {:duration 10 :unit "hours"}}
                  {:model    "dashboard"
                   :model_id dash
-                  :strategy :duration
+                  :strategy "duration"
                   :config   {:duration 20 :unit "hours"}}
                  {:model    "question"
                   :model_id card
-                  :strategy :duration
+                  :strategy "duration"
                   :config   {:duration 30 :unit "hours"}}]
-                (t2/select :model/CacheConfig))))))
+                (->> (t2/select :cache_config)
+                     (mapv #(update % :config json/decode true))))))))
   (testing "And not copied if caching is disabled"
     (impl/test-migrations ["v50.2024-04-12T12:33:07"] [migrate!]
-      (mdb.query/update-or-insert! :model/Setting {:key "enable-query-caching"} (constantly {:value "false"}))
-      (mdb.query/update-or-insert! :model/Setting {:key "query-caching-ttl-ratio"} (constantly {:value "100"}))
-      (mdb.query/update-or-insert! :model/Setting {:key "query-caching-min-ttl"} (constantly {:value "123"}))
+      (t2/insert! :setting [{:key "enable-query-caching", :value (encryption/maybe-encrypt "false")}
+                            {:key "query-caching-ttl-ratio", :value (encryption/maybe-encrypt "100")}
+                            {:key "query-caching-min-ttl", :value (encryption/maybe-encrypt "123")}])
 
       ;; this one to have custom configuration to check they are not copied over
       (t2/insert-returning-pk! :metabase_database (-> (mt/with-temp-defaults Database)
@@ -1560,33 +1562,35 @@
                                                       (assoc :cache_ttl 10)))
       (migrate!)
       (is (= []
-             (t2/select :model/CacheConfig))))))
+             (t2/select :cache_config))))))
 
 (deftest cache-config-mysql-update-test
   (when (= (mdb/db-type) :mysql)
     (testing "Root cache config for mysql is updated with correct values"
-      (impl/test-migrations ["v50.2024-06-12T12:33:07"] [migrate!]
-        (mdb.query/update-or-insert! :model/Setting {:key "enable-query-caching"} (constantly {:value "true"}))
-        (mdb.query/update-or-insert! :model/Setting {:key "query-caching-ttl-ratio"} (constantly {:value "100"}))
-        (mdb.query/update-or-insert! :model/Setting {:key "query-caching-min-ttl"} (constantly {:value "123"}))
+      (encryption-test/with-secret-key "whateverwhatever"
+        (impl/test-migrations ["v50.2024-06-12T12:33:07"] [migrate!]
+          (t2/insert! :setting [{:key "enable-query-caching", :value (encryption/maybe-encrypt "true")}
+                                {:key "query-caching-ttl-ratio", :value (encryption/maybe-encrypt "100")}
+                                {:key "query-caching-min-ttl", :value (encryption/maybe-encrypt "123")}])
 
-        ;; the idea here is that `v50.2024-04-12T12:33:09` during execution with partially encrypted data (see
-        ;; `cache-config-migration-test`) instead of throwing an error just silently put zeros in config. If config
-        ;; contains zeros, we assume human did not touch it yet and update with existing (decrypted thanks to
-        ;; `v50.2024-06-12T12:33:07`) settings
-        (mdb.query/update-or-insert! :model/CacheConfig {:model "root" :model_id 0}
-                                     (constantly {:strategy "ttl"
-                                                  :config   {:multiplier      0
-                                                             :min_duration_ms 0}}))
+          ;; the idea here is that `v50.2024-04-12T12:33:09` during execution with partially encrypted data (see
+          ;; `cache-config-migration-test`) instead of throwing an error just silently put zeros in config. If config
+          ;; contains zeros, we assume human did not touch it yet and update with existing (decrypted thanks to
+          ;; `v50.2024-06-12T12:33:07`) settings
+          (t2/insert! :cache_config {:model    "root"
+                                     :model_id 0
+                                     :strategy "ttl"
+                                     :config   (json/encode {:multiplier      0
+                                                             :min_duration_ms 0})})
+          (migrate!)
 
-        (migrate!)
-
-        (is (=? [{:model    "root"
-                  :model_id 0
-                  :strategy :ttl
-                  :config   {:multiplier      100
-                             :min_duration_ms 123}}]
-                (t2/select :model/CacheConfig)))))))
+          (is (=? {:model    "root"
+                   :model_id 0
+                   :strategy "ttl"
+                   :config {:multiplier      100
+                            :min_duration_ms 123}}
+                  (-> (t2/select-one :cache_config)
+                      (update :config json/decode true)))))))))
 
 (deftest split-data-permissions-migration-test
   (testing "View Data and Create Query permissions are created correctly based on existing data permissions"


### PR DESCRIPTION
Fixes #44012

We did not trigger that error during testing since when `enable-query-caching` setting is encrypted, then migration is a no-op effectively. This means we need to decrypt those settings before running migration - it doesn't matter that much since they will be removed in the next version anyway.

We need original migration to run once again for everyone who had `enable-query-caching` encrypted, which is why I moved it to a new id. Why moved instead of copying: I think a stale entry in `databasechangelog` is preferential to a duplication in migrations.yaml, which is often read by people and could be confusing.

There is also a new migration for MySQL, for those people who had same partially-encrypted settings table. MySQL, encountering invalid integer value, returns 0 in some versions. This migration update config with correct values *if* the config was not updated by a human yet.