### PR TITLE
Fix broken `filter` E2E test

### DIFF
--- a/e2e/test/scenarios/filters/filter.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter.cy.spec.js
@@ -315,23 +315,21 @@ describe("scenarios > question > filter", () => {
 
     enterCustomColumnDetails({ formula: "c", blur: false });
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.contains("case")
-      .closest("li")
+    cy.findAllByTestId("expression-suggestions-list-item")
+      .filter(":contains('case')")
       .should("have.css", "background-color")
       .and("not.eq", transparent);
 
     cy.get("@formula").type("{downarrow}");
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.contains("case")
-      .closest("li")
+    cy.findAllByTestId("expression-suggestions-list-item")
+      .filter(":contains('case')")
       .should("have.css", "background-color")
       .and("eq", transparent);
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.contains("ceil")
-      .closest("li")
+    cy.findAllByTestId("expression-suggestions-list-item")
+      .filter(":contains('ceil')")
       .should("have.css", "background-color")
       .and("not.eq", transparent);
   });

--- a/e2e/test/scenarios/filters/filter.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter.cy.spec.js
@@ -327,7 +327,6 @@ describe("scenarios > question > filter", () => {
       .should("have.css", "background-color")
       .and("eq", transparent);
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findAllByTestId("expression-suggestions-list-item")
       .filter(":contains('ceil')")
       .should("have.css", "background-color")


### PR DESCRIPTION
This PR fixes a legit broken E2E test, caused by https://github.com/metabase/metabase/pull/43995.

The HTML structure changed a bit so the test failed.
This only proves how fragile the test was.

So instead of this pattern: `cy.get("foo").closest("bar")`, we're now directly targeting the element by its test id, and then using filter.
https://docs.cypress.io/api/commands/filter

The test is now passing locally.
As a bonus, we got rid of the linter warnings 🎉 
![image](https://github.com/metabase/metabase/assets/31325167/2737ad5d-b52e-4921-bb1e-4b52f700983e)

### Stress-test
10/10 ✅  https://github.com/metabase/metabase/actions/runs/9482031138