### PR TITLE
Fix unable to view questions and dashboards when users don't have view perms on any tables

### DIFF
--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -356,7 +356,8 @@
                              [:fields [:target :has_field_values] :dimensions :has_field_values]
                              :segments
                              :metrics)
-          dbs (t2/select-pk->fn identity Database :id [:in (into #{} (map :db_id) tables)])]
+          dbs    (when (seq tables)
+                   (t2/select-pk->fn identity Database :id [:in (into #{} (map :db_id) tables)]))]
       (for [table tables]
         (-> table
             (m/dissoc-in [:db :details])

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -3676,3 +3676,13 @@
                 (update :fields #(map (fn [x] (select-keys x [:id])) %))
                 (update :databases #(map (fn [x] (select-keys x [:id :engine])) %))
                 (update :tables #(map (fn [x] (select-keys x [:id :name])) %))))))))
+
+(deftest card-query-metadata-no-tables-test
+  (testing "Don't throw an error if users doesn't have access to any tables #44043"
+    (let [original-can-read? mi/can-read?]
+      (mt/with-temp [:model/Card card {:dataset_query (mt/mbql-query venues {:limit 1})}]
+       (with-redefs [mi/can-read? (fn [& args]
+                                    (if (= :model/Table (apply mi/dispatch-on-model args))
+                                      false
+                                      (apply original-can-read? args)))]
+         (is (map? (mt/user-http-request :crowberto :get 200 (format "card/%d/query_metadata" (:id card))))))))))


### PR DESCRIPTION
How to test:
0. Sign in as admin and create a question and a dashboard
1. Go to admin > permissions, remove all view tables permissions for All users group
2. Sign in as admin
3. Try opening a dashboard or a card, you should be able to view it

Fixes https://github.com/metabase/metabase/issues/44043
The bug was introduced by https://github.com/metabase/metabase/pull/43625