### PR TITLE
Fix broken line/area/bar charts after adding a second stage filter

### DIFF
--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -26,6 +26,7 @@ import {
   resyncDatabase,
   createQuestion,
   saveQuestion,
+  echartsContainer,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATABASE;
@@ -628,6 +629,58 @@ describe("issue 42957", () => {
       entityPickerModalTab("Models").click();
 
       cy.findByText("Collection without models").should("not.exist");
+    });
+  });
+});
+
+describe("issue 10493", () => {
+  beforeEach(() => {
+    restore();
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    cy.signInAsAdmin();
+  });
+
+  it("should not reset chart axes after adding a new query stage (metabase#10493)", () => {
+    visitQuestionAdhoc({
+      display: "bar",
+      dataset_query: {
+        type: "query",
+        database: SAMPLE_DB_ID,
+        query: {
+          aggregation: [["count"]],
+          breakout: [
+            [
+              "field",
+              ORDERS.QUANTITY,
+              { "base-type": "type/Integer", binning: { strategy: "default" } },
+            ],
+          ],
+          "source-table": ORDERS_ID,
+        },
+      },
+    });
+
+    filter();
+    modal().within(() => {
+      cy.findByText("Summaries").click();
+      cy.findByTestId("filter-column-Count").within(() => {
+        cy.findByPlaceholderText("Min").type("0");
+        cy.findByPlaceholderText("Max").type("30000");
+      });
+      cy.button("Apply filters").click();
+    });
+    cy.wait("@dataset");
+
+    echartsContainer().within(() => {
+      // y axis
+      cy.findByText("Count").should("exist");
+      cy.findByText("21,000").should("exist");
+      cy.findByText("3,000").should("exist");
+
+      // x axis
+      cy.findByText("Quantity").should("exist");
+      cy.findByText("25").should("exist");
+      cy.findByText("75").should("exist");
     });
   });
 });

--- a/frontend/src/metabase/query_builder/actions/core/core.js
+++ b/frontend/src/metabase/query_builder/actions/core/core.js
@@ -34,7 +34,6 @@ import {
   isBasedOnExistingQuestion,
   getParameters,
   getSubmittableQuestion,
-  getQueryResults,
 } from "../../selectors";
 import { updateUrl } from "../navigation";
 import { zoomInRow } from "../object-detail";
@@ -112,10 +111,7 @@ export const reloadCard = createThunkAction(RELOAD_CARD, () => {
  *     - `navigateToNewCardInsideQB` is being called (see below)
  */
 export const SET_CARD_AND_RUN = "metabase/qb/SET_CARD_AND_RUN";
-export const setCardAndRun = (
-  nextCard,
-  { shouldUpdateUrl = true, prevQueryResults } = {},
-) => {
+export const setCardAndRun = (nextCard, { shouldUpdateUrl = true } = {}) => {
   return async (dispatch, getState) => {
     // clone
     const card = copy(nextCard);
@@ -131,12 +127,7 @@ export const setCardAndRun = (
 
     // Update the card and originalCard before running the actual query
     dispatch({ type: SET_CARD_AND_RUN, payload: { card, originalCard } });
-    dispatch(
-      runQuestionQuery({
-        shouldUpdateUrl,
-        prevQueryResults,
-      }),
-    );
+    dispatch(runQuestionQuery({ shouldUpdateUrl }));
 
     // Load table & database metadata for the current question
     dispatch(loadMetadataForCard(card));
@@ -175,16 +166,13 @@ export const navigateToNewCardInsideQB = createThunkAction(
           dispatch(openUrl(url));
         } else {
           dispatch(onCloseSidebars());
-          const prevQueryResults = getQueryResults(getState());
           if (!cardQueryIsEquivalent(previousCard, nextCard)) {
             // clear the query result so we don't try to display the new visualization before running the new query
             dispatch(clearQueryResult());
           }
           // When the dataset query changes, we should change the type,
           // to start building a new ad-hoc question based on a dataset
-          dispatch(
-            setCardAndRun({ ...card, type: "question" }, { prevQueryResults }),
-          );
+          dispatch(setCardAndRun({ ...card, type: "question" }));
         }
         if (objectId !== undefined) {
           dispatch(zoomInRow({ objectId }));

--- a/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
+++ b/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
@@ -6,7 +6,7 @@ import Questions from "metabase/entities/questions";
 import { createThunkAction } from "metabase/lib/redux";
 import { loadMetadataForCard } from "metabase/questions/actions";
 import { addUndo } from "metabase/redux/undo";
-import { syncVizSettingsWithQueryResults } from "metabase/visualizations/lib/sync-settings";
+import { syncVizSettingsWithSeries } from "metabase/visualizations/lib/sync-settings";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
 import { getTemplateTagParametersFromCard } from "metabase-lib/v1/parameters/utils/template-tags";
@@ -139,7 +139,13 @@ export const updateQuestion = (
 
     const queryResult = getFirstQueryResult(getState());
     newQuestion = newQuestion.setSettings(
-      syncVizSettingsWithQueryResults(newQuestion.settings(), queryResult),
+      syncVizSettingsWithSeries(newQuestion.settings(), [
+        {
+          card: newQuestion.card(),
+          data: queryResult?.data,
+          error: queryResult?.error,
+        },
+      ]),
     );
 
     if (!newQuestion.canAutoRun()) {

--- a/frontend/src/metabase/visualizations/index.ts
+++ b/frontend/src/metabase/visualizations/index.ts
@@ -128,6 +128,15 @@ export function getDefaultSize(display: string) {
   return visualization?.defaultSize;
 }
 
+export function hasGraphDataSettings(display: string) {
+  const visualization = visualizations.get(display);
+  const settingDefinitions = visualization?.settings ?? {};
+  return (
+    "graph.dimensions" in settingDefinitions &&
+    "graph.metrics" in settingDefinitions
+  );
+}
+
 // removes columns with `remapped_from` property and adds a `remapping` to the appropriate column
 export const extractRemappedColumns = (data: DatasetData) => {
   const cols: RemappingHydratedDatasetColumn[] = data.cols.map(col => ({

--- a/frontend/src/metabase/visualizations/lib/sync-settings.ts
+++ b/frontend/src/metabase/visualizations/lib/sync-settings.ts
@@ -3,23 +3,30 @@ import {
   findColumnSettingIndexesForColumns,
 } from "metabase-lib/v1/queries/utils/dataset";
 import { getColumnKey } from "metabase-lib/v1/queries/utils/get-column-key";
-import type { Dataset, VisualizationSettings } from "metabase-types/api";
+import type {
+  Series,
+  SingleSeries,
+  VisualizationSettings,
+} from "metabase-types/api";
 
-export function syncVizSettingsWithQueryResults(
+export function syncVizSettingsWithSeries(
   settings: VisualizationSettings,
-  queryResults?: Dataset,
-  prevQueryResults?: Dataset,
+  _series?: Series | null,
+  _previousSeries?: Series | null,
 ): VisualizationSettings {
   let newSettings = settings;
 
-  if (queryResults && !queryResults.error) {
-    newSettings = syncTableColumnSettings(newSettings, queryResults);
+  const series = _series?.[0];
+  const previousSeries = _previousSeries?.[0];
 
-    if (prevQueryResults && !prevQueryResults.error) {
+  if (series && !series.error) {
+    newSettings = syncTableColumnSettings(newSettings, series);
+
+    if (previousSeries && !previousSeries.error) {
       newSettings = syncGraphMetricSettings(
         newSettings,
-        queryResults,
-        prevQueryResults,
+        series,
+        previousSeries,
       );
     }
   }
@@ -29,7 +36,7 @@ export function syncVizSettingsWithQueryResults(
 
 function syncTableColumnSettings(
   settings: VisualizationSettings,
-  { data }: Dataset,
+  { data }: SingleSeries,
 ): VisualizationSettings {
   // "table.columns" receive a value only if there are custom settings
   // e.g. some columns are hidden. If it's empty, it means everything is visible
@@ -77,8 +84,8 @@ function syncTableColumnSettings(
 
 function syncGraphMetricSettings(
   settings: VisualizationSettings,
-  { data: { cols } }: Dataset,
-  { data: { cols: prevCols } }: Dataset,
+  { data: { cols } }: SingleSeries,
+  { data: { cols: prevCols } }: SingleSeries,
 ): VisualizationSettings {
   const graphMetrics = settings["graph.metrics"];
   if (!graphMetrics) {

--- a/frontend/src/metabase/visualizations/lib/sync-settings.ts
+++ b/frontend/src/metabase/visualizations/lib/sync-settings.ts
@@ -1,3 +1,9 @@
+import { isNotNull } from "metabase/lib/types";
+import {
+  getMaxDimensionsSupported,
+  getMaxMetricsSupported,
+  hasGraphDataSettings,
+} from "metabase/visualizations";
 import {
   findColumnIndexesForColumnSettings,
   findColumnSettingIndexesForColumns,
@@ -8,6 +14,8 @@ import type {
   SingleSeries,
   VisualizationSettings,
 } from "metabase-types/api";
+
+import { getSingleSeriesDimensionsAndMetrics } from "./utils";
 
 export function syncVizSettingsWithSeries(
   settings: VisualizationSettings,
@@ -28,10 +36,69 @@ export function syncVizSettingsWithSeries(
         series,
         previousSeries,
       );
+
+      if (hasGraphDataSettings(series.card.display)) {
+        newSettings = ensureMetricsAndDimensions(
+          newSettings,
+          series,
+          previousSeries,
+        );
+      }
     }
   }
 
   return newSettings;
+}
+
+function ensureMetricsAndDimensions(
+  settings: VisualizationSettings,
+  series: SingleSeries,
+  previousSeries: SingleSeries,
+) {
+  const hasExplicitGraphDataSettings =
+    "graph.dimensions" in settings || "graph.metrics" in settings;
+
+  if (hasExplicitGraphDataSettings) {
+    return settings;
+  }
+
+  const nextSettings = { ...settings };
+
+  const availableColumnNames = series.data.cols.map(col => col.name);
+  const maxDimensions = getMaxDimensionsSupported(series.card.display);
+  const maxMetrics = getMaxMetricsSupported(series.card.display);
+
+  const { dimensions: currentDimensions, metrics: currentMetrics } =
+    getSingleSeriesDimensionsAndMetrics(series, maxDimensions, maxMetrics);
+  const { dimensions: previousDimensions, metrics: previousMetrics } =
+    getSingleSeriesDimensionsAndMetrics(
+      previousSeries,
+      maxDimensions,
+      maxMetrics,
+    );
+
+  const dimensions =
+    currentDimensions.filter(isNotNull).length > 0
+      ? currentDimensions
+      : previousDimensions.filter((columnName: string) =>
+          availableColumnNames.includes(columnName),
+        );
+
+  const metrics =
+    currentMetrics.filter(isNotNull).length > 0
+      ? currentMetrics
+      : previousMetrics.filter((columnName: string) =>
+          availableColumnNames.includes(columnName),
+        );
+
+  if (dimensions.length > 0) {
+    nextSettings["graph.dimensions"] = dimensions;
+  }
+  if (metrics.length > 0) {
+    nextSettings["graph.metrics"] = metrics;
+  }
+
+  return nextSettings;
 }
 
 function syncTableColumnSettings(


### PR DESCRIPTION
Fixes #10493, based on #44074

Fixes an issue when adding an n-th query stage would drop `graph.dimensions` and `graph.metrics` viz settings (by default selected by [`getSingleSeriesDimensionsAndMetrics` function](https://github.com/metabase/metabase/blob/8659846f0b011af29f92719ac9273c63df76e0d3/frontend/src/metabase/visualizations/lib/utils.js#L283)) and put a chart into unexpected state.

This happens in some cases after adding a new query stage. When a new stage is added, some column metadata becomes opaque (e.g., which columns come from aggregations or breakouts). In certain cases, there are no columns to auto-pick instead, and the chart "breaks" (it's still possible to select x/y axis columns manually; it's just annoying).

The PR has two main changes. Firstly, the `syncVizSettingsWithQueryResults` (previously known as `Lib.syncColumnSettings`) is reworked to accept `Series` objects instead of `DatasetData`. This is done mostly because we need the card `display` for the actual fix. Secondly, the function is extended, and we'll now try to use the previous `graph.dimensions` and `graph.metrics` values if they're still present in the latest query results. 

### To verify

1. New > Question > Orders > Visualize
2. Click the "Quantity" column header and select "Distribution"
3. Add a filter on the "Count" column
4. Ensure the x and y axis didn't change

### Demo

**Before**

https://github.com/metabase/metabase/assets/17258145/772115f7-54c7-4631-85d6-1d9554ec0dd4

**After**

https://github.com/metabase/metabase/assets/17258145/ee679f8b-b321-4dfb-9017-f34f88ef0328



