### PR TITLE
docs - release list 50.1

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -107,6 +107,7 @@ Metabase's reference documentation.
 
 - [Data modeling overview](./data-modeling/start.md)
 - [Models](./data-modeling/models.md)
+- [Model persistence](./data-modeling/model-persistence.md)
 - [Table metadata admin settings](./data-modeling/metadata-editing.md)
 - [Field types](./data-modeling/field-types.md)
 - [Formatting defaults](./data-modeling/formatting.md)

--- a/docs/data-modeling/start.md
+++ b/docs/data-modeling/start.md
@@ -10,6 +10,10 @@ Metabase provides tools for organizing your data and making it easier for people
 
 Models curate data from another table or tables from the same database to anticipate the kinds of questions people will ask of the data. You can think of them as derived tables, or a special kind of saved question meant to be used as the starting point for new questions.
 
+## [Model persistence](./model-persistence.md)
+
+Persist model results for faster loading times.
+
 ## [Table metadata admin settings](./metadata-editing.md)
 
 Guide people to the right data by adding display names, hiding outdated tables, configuring filter types, and more.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -19,7 +19,7 @@ To see what's new, check out all the [major release announcements](https://www.m
 
 ## Metabase Enterprise Edition releases
 
-- [v1.50.0](https://github.com/metabase/metabase/releases/tag/v1.50.0)
+- [v1.50.1](https://github.com/metabase/metabase/releases/tag/v1.50.1)
 - [v1.49.15](https://github.com/metabase/metabase/releases/tag/v1.49.15)
 - [v1.49.14](https://github.com/metabase/metabase/releases/tag/v1.49.14)
 - [v1.49.13](https://github.com/metabase/metabase/releases/tag/v1.49.13)
@@ -170,7 +170,7 @@ To see what's new, check out all the [major release announcements](https://www.m
 
 ## Metabase Open Source Edition releases
 
-- [v0.50.0](https://github.com/metabase/metabase/releases/tag/v0.50.0)
+- [v0.50.1](https://github.com/metabase/metabase/releases/tag/v0.50.1)
 - [v0.49.15](https://github.com/metabase/metabase/releases/tag/v0.49.15)
 - [v0.49.14](https://github.com/metabase/metabase/releases/tag/v0.49.14)
 - [v0.49.13](https://github.com/metabase/metabase/releases/tag/v0.49.13)


### PR DESCRIPTION
- Updates list of releases. 
- Tacks on some links to model persistence docs.