### PR TITLE
Remove dead props in getButtonOverrides

### DIFF
--- a/frontend/src/metabase/ui/components/buttons/Button/Button.styled.tsx
+++ b/frontend/src/metabase/ui/components/buttons/Button/Button.styled.tsx
@@ -5,8 +5,6 @@ import type {
 } from "@mantine/core";
 import { getStylesRef, rem } from "@mantine/core";
 
-import type { ExtraButtonProps } from ".";
-
 export const getButtonOverrides = (): MantineThemeOverride["components"] => ({
   Button: {
     defaultProps: {
@@ -17,10 +15,7 @@ export const getButtonOverrides = (): MantineThemeOverride["components"] => ({
         color: "currentColor",
       },
     },
-    styles: (
-      theme: MantineTheme,
-      { compact, animate }: ButtonStylesParams & ExtraButtonProps,
-    ) => {
+    styles: (theme: MantineTheme, { compact }: ButtonStylesParams) => {
       return {
         root: {
           height: "auto",
@@ -37,7 +32,6 @@ export const getButtonOverrides = (): MantineThemeOverride["components"] => ({
               marginLeft: 0,
             },
           },
-          ...(animate ? {} : { "&:active": { transform: "none" } }),
         },
         label: {
           ref: getStylesRef("label"),


### PR DESCRIPTION
Removes two unused props in getButtonOverrides: `animate` and `highlightOnHover`

Closes #44026