### PR TITLE
Set `can_delete` to `false` for unarchived items

### DIFF
--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -1635,7 +1635,8 @@
   [items]
   (when (seq items)
     (for [item items]
-      (assoc item :can_delete (if (or (= :model/Collection (t2/model item))
-                                      (collection.root/is-root-collection? item))
-                                false
-                                (mi/can-write? item))))))
+      (assoc item :can_delete (and
+                               (not (or (= :model/Collection (t2/model item))
+                                        (collection.root/is-root-collection? item)))
+                               (:archived item)
+                               (mi/can-write? item))))))

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -639,7 +639,7 @@
         (is (= (mt/obj->json->obj
                 [{:collection_id       (:id collection)
                   :can_write           true
-                  :can_delete          true
+                  :can_delete          false
                   :id                  card-id
                   :archived            false
                   :location            nil


### PR DESCRIPTION
Although a user may have the necessary permissions to delete an item, if we're not going to allow deleting unarchived items, `can_delete` should be false for them too.