### PR TITLE
Fix field values remapping with models & custom dropdown source in public dashboards

### DIFF
--- a/e2e/support/commands/api/composite/createDashboardWithQuestions.js
+++ b/e2e/support/commands/api/composite/createDashboardWithQuestions.js
@@ -2,9 +2,9 @@ import { cypressWaitAll } from "e2e/support/helpers";
 
 Cypress.Commands.add(
   "createDashboardWithQuestions",
-  ({ dashboardName, questions }) => {
+  ({ dashboardName, dashboardDetails, questions }) => {
     return cy
-      .createDashboard({ name: dashboardName })
+      .createDashboard({ name: dashboardName, ...dashboardDetails })
       .then(({ body: dashboard }) => {
         return cypressWaitAll(
           questions.map(query =>

--- a/e2e/test/scenarios/dashboard-filters/reproductions/44047-parameter-model-mapping-public.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/44047-parameter-model-mapping-public.cy.spec.js
@@ -1,0 +1,109 @@
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import {
+  createQuestion,
+  editDashboard,
+  filterWidget,
+  getDashboardCard,
+  popover,
+  restore,
+  saveDashboard,
+  selectDashboardFilter,
+  setFilter,
+  setFilterQuestionSource,
+  undoToast,
+  visitDashboard,
+  visitPublicDashboard,
+} from "e2e/support/helpers";
+const { REVIEWS, REVIEWS_ID } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  name: "Question",
+  type: "question",
+  query: {
+    "source-table": REVIEWS_ID,
+    limit: 100,
+  },
+};
+
+const sourceQuestionDetails = {
+  name: "Source question",
+  type: "question",
+  query: {
+    "source-table": REVIEWS_ID,
+    fields: [
+      ["field", REVIEWS.ID, { "base-type": "type/BigInteger" }],
+      ["field", REVIEWS.RATING, { "base-type": "type/BigInteger" }],
+    ],
+  },
+};
+
+const modelDetails = {
+  name: "Model",
+  type: "model",
+  query: {
+    "source-table": REVIEWS_ID,
+    limit: 100,
+  },
+};
+
+describe("44047", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    cy.request("PUT", `/api/field/${REVIEWS.RATING}`, {
+      semantic_type: "type/Category",
+    });
+    cy.request("POST", `/api/field/${REVIEWS.RATING}/dimension`, {
+      type: "internal",
+      name: "Rating",
+    });
+    cy.request("POST", `/api/field/${REVIEWS.RATING}/values`, {
+      values: [
+        [1, "A"],
+        [2, "B"],
+        [3, "C"],
+        [4, "D"],
+        [5, "E"],
+      ],
+    });
+  });
+
+  it("should be able to use remapped values from an integer field with an overridden semantic type used for a custom dropdown source in public dashboards (metabase#44047)", () => {
+    createQuestion(sourceQuestionDetails);
+    cy.createDashboardWithQuestions({
+      questions: [questionDetails, modelDetails],
+    }).then(({ dashboard }) => cy.wrap(dashboard.id).as("dashboardId"));
+
+    cy.log("setup dashboard");
+    visitDashboard("@dashboardId");
+    editDashboard();
+    setFilter("Text or Category", "Is");
+    selectDashboardFilter(getDashboardCard(0), "Rating");
+    undoToast().button("Undo auto-connection").click();
+    selectDashboardFilter(getDashboardCard(1), "Rating");
+    setFilterQuestionSource({
+      question: sourceQuestionDetails.name,
+      field: "Rating",
+    });
+    saveDashboard();
+
+    cy.log("verify filtering works in a regular dashboard");
+    verifyFilterWithRemapping();
+
+    cy.log("verify filtering works in a public dashboard");
+    cy.get("@dashboardId").then(visitPublicDashboard);
+    verifyFilterWithRemapping();
+  });
+});
+
+function verifyFilterWithRemapping() {
+  filterWidget().click();
+  popover().within(() => {
+    cy.findByText("A").click();
+    cy.button("Add filter").click();
+  });
+
+  const sampleReviewer = "dorcas";
+  getDashboardCard(0).findByText(sampleReviewer).should("be.visible");
+  getDashboardCard(1).findByText(sampleReviewer).should("be.visible");
+}

--- a/e2e/test/scenarios/dashboard-filters/reproductions/44047-parameter-model-mapping-public.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/44047-parameter-model-mapping-public.cy.spec.js
@@ -9,13 +9,13 @@ import {
   visitPublicDashboard,
 } from "e2e/support/helpers";
 
-const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+const { REVIEWS, REVIEWS_ID } = SAMPLE_DATABASE;
 
 const questionDetails = {
   name: "Question",
   type: "question",
   query: {
-    "source-table": ORDERS_ID,
+    "source-table": REVIEWS_ID,
     limit: 100,
   },
 };
@@ -24,7 +24,7 @@ const modelDetails = {
   name: "Model",
   type: "model",
   query: {
-    "source-table": ORDERS_ID,
+    "source-table": REVIEWS_ID,
     limit: 100,
   },
 };
@@ -33,10 +33,10 @@ const sourceQuestionDetails = {
   name: "Source question",
   type: "question",
   query: {
-    "source-table": ORDERS_ID,
+    "source-table": REVIEWS_ID,
     fields: [
-      ["field", ORDERS.ID, { "base-type": "type/BigInteger" }],
-      ["field", ORDERS.QUANTITY, { "base-type": "type/Integer" }],
+      ["field", REVIEWS.ID, { "base-type": "type/BigInteger" }],
+      ["field", REVIEWS.RATING, { "base-type": "type/Integer" }],
     ],
   },
 };
@@ -63,7 +63,7 @@ function getQuestionDashcardDetails(dashboard, card) {
         parameter_id: parameterDetails.id,
         target: [
           "dimension",
-          ["field", ORDERS.QUANTITY, { type: "type/Integer" }],
+          ["field", REVIEWS.RATING, { type: "type/Integer" }],
         ],
       },
     ],
@@ -78,7 +78,7 @@ function getModelDashcardDetails(dashboard, card) {
       {
         card_id: card.id,
         parameter_id: parameterDetails.id,
-        target: ["dimension", ["field", "QUANTITY", { type: "type/Integer" }]],
+        target: ["dimension", ["field", "RATING", { type: "type/Integer" }]],
       },
     ],
   };
@@ -88,15 +88,15 @@ describe("44047", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-    cy.request("PUT", `/api/field/${ORDERS.QUANTITY}`, {
+    cy.request("PUT", `/api/field/${REVIEWS.RATING}`, {
       semantic_type: "type/Category",
     });
-    cy.request("POST", `/api/field/${ORDERS.QUANTITY}/dimension`, {
+    cy.request("POST", `/api/field/${REVIEWS.RATING}/dimension`, {
       type: "internal",
       name: "Rating",
     });
-    cy.request("POST", `/api/field/${ORDERS.QUANTITY}/values`, {
-      values: [[0, "Remapped"]],
+    cy.request("POST", `/api/field/${REVIEWS.RATING}/values`, {
+      values: [[1, "Remapped"]],
     });
   });
 

--- a/frontend/src/metabase-lib/metadata/Field.ts
+++ b/frontend/src/metabase-lib/metadata/Field.ts
@@ -99,6 +99,7 @@ class FieldInner extends Base {
 
   // added when creating "virtual fields" that are associated with a given query
   query?: StructuredQuery | NativeQuery;
+  _comesFromEndpoint?: boolean;
 
   getPlainObject(): IField {
     return this._plainObject;

--- a/frontend/src/metabase-lib/parameters/utils/cards.ts
+++ b/frontend/src/metabase-lib/parameters/utils/cards.ts
@@ -8,6 +8,7 @@ import { getValuePopulatedParameters } from "metabase-lib/parameters/utils/param
 import { getParameterTargetField } from "metabase-lib/parameters/utils/targets";
 import { getParametersFromCard } from "metabase-lib/parameters/utils/template-tags";
 import type { Card, Parameter, ParameterTarget } from "metabase-types/api";
+import { isDimensionTarget } from "metabase-types/guards";
 
 export function getCardUiParameters(
   card: Card,
@@ -42,6 +43,9 @@ export function getCardUiParameters(
       };
     }
 
-    return { ...parameter, hasVariableTemplateTagTarget: true };
+    return {
+      ...parameter,
+      hasVariableTemplateTagTarget: !isDimensionTarget(target),
+    };
   });
 }

--- a/frontend/src/metabase-lib/parameters/utils/targets.ts
+++ b/frontend/src/metabase-lib/parameters/utils/targets.ts
@@ -48,7 +48,10 @@ export function getParameterTargetField(
     const metadata = question.metadata();
     const dimension = Dimension.parseMBQL(target[1], metadata, query);
 
-    return dimension?.field();
+    const field = dimension?.field();
+    if (typeof field?.id === "number") {
+      return field;
+    }
   }
 
   return null;

--- a/frontend/src/metabase-lib/parameters/utils/targets.ts
+++ b/frontend/src/metabase-lib/parameters/utils/targets.ts
@@ -1,9 +1,9 @@
 import * as Lib from "metabase-lib";
-import type { TemplateTagDimension } from "metabase-lib/Dimension";
-import Dimension from "metabase-lib/Dimension";
+import Dimension, { TemplateTagDimension } from "metabase-lib/Dimension";
 import type Question from "metabase-lib/Question";
 import type NativeQuery from "metabase-lib/queries/NativeQuery";
 import type StructuredQuery from "metabase-lib/queries/StructuredQuery";
+import { isTemplateTagReference } from "metabase-lib/references";
 import type TemplateTagVariable from "metabase-lib/variables/TemplateTagVariable";
 import type {
   ConcreteFieldReference,
@@ -41,17 +41,46 @@ export function getParameterTargetField(
   target: ParameterTarget,
   question: Question,
 ) {
-  if (isDimensionTarget(target)) {
-    const query = question.legacyQuery({ useStructuredQuery: true }) as
-      | NativeQuery
-      | StructuredQuery;
-    const metadata = question.metadata();
-    const dimension = Dimension.parseMBQL(target[1], metadata, query);
+  if (!isDimensionTarget(target)) {
+    return null;
+  }
 
+  const fieldRef = target[1];
+  const metadata = question.metadata();
+
+  // native queries
+  if (isTemplateTagReference(fieldRef)) {
+    const dimension = TemplateTagDimension.parseMBQL(
+      fieldRef,
+      metadata,
+      question.legacyQuery() as NativeQuery,
+    );
+    return dimension?.field();
+  }
+
+  if (isConcreteFieldReference(fieldRef)) {
+    const [_type, fieldIdOrName] = fieldRef;
+    const fields = metadata.fieldsList();
+    // we can match by id directly without finding this column via query
+    if (typeof fieldIdOrName === "number") {
+      return fields.find(field => field.id === fieldIdOrName);
+    }
+
+    const query = question.legacyQuery({
+      useStructuredQuery: true,
+    }) as StructuredQuery;
+    const dimension = Dimension.parseMBQL(target[1], metadata, query);
     const field = dimension?.field();
-    if (typeof field?.id === "number") {
+    // in embedding MLv1 fails to find the correct field because there is no `query` available
+    // in this case MLv1 syntheses a field that is not originated from a BE endpoint
+    // we need to ignore it here and try to match by name instead
+    if (field && field._comesFromEndpoint) {
       return field;
     }
+
+    return fields.find(
+      field => typeof field.id == "number" && field.name === fieldIdOrName,
+    );
   }
 
   return null;

--- a/frontend/src/metabase/dashboard/selectors.unit.spec.js
+++ b/frontend/src/metabase/dashboard/selectors.unit.spec.js
@@ -62,8 +62,8 @@ const STATE = {
     schemas: {},
     tables: {},
     fields: {
-      1: { id: 1 },
-      2: { id: 2 },
+      1: { id: 1, uniqueId: 1 },
+      2: { id: 2, uniqueId: 2 },
     },
     metrics: {},
     segments: {},


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/44047
Repro https://www.loom.com/share/bd15abd6412f46d0aa778f3388169e34

I didn't manage to repro the same issue in E2E no matter what I tried. So I made API calls with data for what I reproduced locally - see the video above. The repro is not 100% correct as the model query doesn't execute. But without the fix the repro fails, which is good.

In the issue we're hitting this https://github.com/metabase/metabase/blob/ddf5b10824ca8c7015c7b43d2457fe1a21ebdea8/frontend/src/metabase-lib/Dimension.ts#L843 which creates invalid field stubs, which breaks parameter remapping logic downstream. v49 is based on MLv1 so we're fixing a MLv1 field matching logic here. To not break everything, this fix only changes field matching for parameters . 

How to verify:
- CI is green
