### PR TITLE
Rename date/time empty filter options in the simple mode

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/table_drills.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/table_drills.cy.spec.js
@@ -4,9 +4,10 @@ import {
   popover,
   restore,
   tableHeaderClick,
+  openTable,
 } from "e2e/support/helpers";
 
-const { REVIEWS, REVIEWS_ID } = SAMPLE_DATABASE;
+const { REVIEWS, REVIEWS_ID, ACCOUNTS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > visualizations > drillthroughs > table_drills", () => {
   beforeEach(() => {
@@ -208,5 +209,38 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
     popover()
       .findByText("Drill-through doesn’t work on SQL questions.")
       .should("be.visible");
+  });
+});
+
+describe("scenarios > visualizations > drillthroughs > table_drills > nulls", () => {
+  beforeEach(() => {
+    // It's important to restore to the "setup" to have access to "Accounts" table
+    restore("setup");
+    cy.signInAsAdmin();
+    cy.viewport(1500, 800);
+  });
+
+  it("should display proper drills on a datetime cell click when there is no value (metabase#44101)", () => {
+    const CANCELLED_AT_INDEX = 9;
+
+    openTable({ table: ACCOUNTS_ID, limit: 1 });
+    cy.findAllByRole("gridcell")
+      .eq(CANCELLED_AT_INDEX)
+      .should("have.text", "")
+      .click({ force: true });
+
+    popover().within(() => {
+      cy.findByText("Filter by this date").should("be.visible");
+      cy.findByText("Is empty").should("be.visible");
+      cy.findByText("Not empty").should("be.visible").click();
+    });
+
+    cy.findByTestId("filter-pill").should(
+      "have.text",
+      "Canceled At is not empty",
+    );
+    cy.findAllByRole("gridcell")
+      .eq(CANCELLED_AT_INDEX)
+      .should("not.have.text", "");
   });
 });

--- a/frontend/src/metabase/querying/utils/drills/quick-filter-drill/quick-filter-drill.tsx
+++ b/frontend/src/metabase/querying/utils/drills/quick-filter-drill/quick-filter-drill.tsx
@@ -37,24 +37,37 @@ function getActionOverrides(
   operator: Lib.QuickFilterDrillThruOperator,
   value: unknown,
 ): Partial<ClickAction> {
-  if (Lib.isDate(column) && value != null) {
+  if (Lib.isDate(column)) {
     const action: Partial<ClickAction> = {
       sectionTitle: t`Filter by this date`,
       sectionDirection: "column",
       buttonType: "horizontal",
     };
 
-    switch (operator) {
-      case "=":
-        return { ...action, title: t`On` };
-      case "≠":
-        return { ...action, title: t`Not on` };
-      case ">":
-        return { ...action, title: t`After` };
-      case "<":
-        return { ...action, title: t`Before` };
-      default:
-        return action;
+    if (value !== null) {
+      switch (operator) {
+        case "=":
+          return { ...action, title: t`On` };
+        case "≠":
+          return { ...action, title: t`Not on` };
+        case ">":
+          return { ...action, title: t`After` };
+        case "<":
+          return { ...action, title: t`Before` };
+        default:
+          return action;
+      }
+    }
+
+    if (value === null) {
+      switch (operator) {
+        case "=":
+          return { ...action, title: t`Is empty` };
+        case "≠":
+          return { ...action, title: t`Not empty` };
+        default:
+          return action;
+      }
     }
   }
 


### PR DESCRIPTION
### What does this PR accomplish?
Resolves #44101

### Description

This PR simply renames the filter options, as specced in #44101.
It also covers/reproduces that issue with the E2E test that was missing before.

### How to verify
1. Open any table and click **on an empty** date/time field
2. The options should say only "Is empty" and "Not empty"

![image](https://github.com/metabase/metabase/assets/31325167/ce7432ca-6150-4017-9009-316c2bcb3977)

### Checklist
- [x] Tests have been added/updated to cover changes in this PR
