### PR TITLE
fix docs url

### DIFF
--- a/frontend/src/metabase/palette/components/PaletteResults.unit.spec.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResults.unit.spec.tsx
@@ -261,4 +261,14 @@ describe("PaletteResults", () => {
     // One call is always made to determine if the instance has models inside useCommandPaletteBasicActions
     expect(fetchMock.calls("path:/api/search").length).toBe(1);
   });
+
+  it("should provide a link to docs with the proper url param", async () => {
+    setup({ query: "model" });
+    expect(
+      await screen.findByRole("link", { name: /Search documentation/ }),
+    ).toHaveAttribute("href", expect.stringContaining("?query=model"));
+
+    // One call is always made to determine if the instance has models inside useCommandPaletteBasicActions
+    expect(fetchMock.calls("path:/api/search").length).toBe(2);
+  });
 });

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -85,6 +85,9 @@ export const useCommandPalette = ({
   );
 
   const docsAction = useMemo<PaletteAction[]>(() => {
+    const link = debouncedSearchText
+      ? getDocsSearchUrl({ query: debouncedSearchText })
+      : docsUrl;
     const ret: PaletteAction[] = [
       {
         id: "search_docs",
@@ -95,11 +98,10 @@ export const useCommandPalette = ({
         keywords: debouncedSearchText, // Always match the debouncedSearchText string
         icon: "document",
         perform: () => {
-          if (debouncedSearchText) {
-            window.open(getDocsSearchUrl({ debouncedSearchText }));
-          } else {
-            window.open(docsUrl);
-          }
+          window.open(link);
+        },
+        extra: {
+          href: link,
         },
       },
     ];


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/44112

### Description
Fix the query param in the docs link

### How to verify

1. Open the command palette and type a query
2. Click the docs link option. A new tab should open with the query populated

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
