### PR TITLE
Manual backport — Fix broken line/area/bar charts after adding a second stage filter

### DIFF
--- a/e2e/test/scenarios/question/reproductions/10493-graph-data-settings-sync.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/10493-graph-data-settings-sync.cy.spec.js
@@ -1,0 +1,63 @@
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import {
+  restore,
+  modal,
+  visitQuestionAdhoc,
+  filter,
+  echartsContainer,
+} from "e2e/support/helpers";
+
+const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+
+describe("issue 10493", () => {
+  beforeEach(() => {
+    restore();
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    cy.signInAsAdmin();
+  });
+
+  it("should not reset chart axes after adding a new query stage (metabase#10493)", () => {
+    visitQuestionAdhoc({
+      display: "bar",
+      dataset_query: {
+        type: "query",
+        database: SAMPLE_DB_ID,
+        query: {
+          aggregation: [["count"]],
+          breakout: [
+            [
+              "field",
+              ORDERS.QUANTITY,
+              { "base-type": "type/Integer", binning: { strategy: "default" } },
+            ],
+          ],
+          "source-table": ORDERS_ID,
+        },
+      },
+    });
+
+    filter();
+    modal().within(() => {
+      cy.findByText("Summaries").click();
+      cy.findByTestId("filter-column-Count").within(() => {
+        cy.findByPlaceholderText("Min").type("0");
+        cy.findByPlaceholderText("Max").type("30000");
+      });
+      cy.button("Apply filters").click();
+    });
+    cy.wait("@dataset");
+
+    echartsContainer().within(() => {
+      // y axis
+      cy.findByText("Count").should("exist");
+      cy.findByText("21,000").should("exist");
+      cy.findByText("3,000").should("exist");
+
+      // x axis
+      cy.findByText("Quantity").should("exist");
+      cy.findByText("25").should("exist");
+      cy.findByText("75").should("exist");
+    });
+  });
+});

--- a/frontend/src/metabase/query_builder/actions/core/core.js
+++ b/frontend/src/metabase/query_builder/actions/core/core.js
@@ -34,7 +34,6 @@ import {
   isBasedOnExistingQuestion,
   getParameters,
   getSubmittableQuestion,
-  getQueryResults,
 } from "../../selectors";
 import { updateUrl } from "../navigation";
 import { zoomInRow } from "../object-detail";
@@ -112,10 +111,7 @@ export const reloadCard = createThunkAction(RELOAD_CARD, () => {
  *     - `navigateToNewCardInsideQB` is being called (see below)
  */
 export const SET_CARD_AND_RUN = "metabase/qb/SET_CARD_AND_RUN";
-export const setCardAndRun = (
-  nextCard,
-  { shouldUpdateUrl = true, prevQueryResults } = {},
-) => {
+export const setCardAndRun = (nextCard, { shouldUpdateUrl = true } = {}) => {
   return async (dispatch, getState) => {
     // clone
     const card = copy(nextCard);
@@ -131,12 +127,7 @@ export const setCardAndRun = (
 
     // Update the card and originalCard before running the actual query
     dispatch({ type: SET_CARD_AND_RUN, payload: { card, originalCard } });
-    dispatch(
-      runQuestionQuery({
-        shouldUpdateUrl,
-        prevQueryResults,
-      }),
-    );
+    dispatch(runQuestionQuery({ shouldUpdateUrl }));
 
     // Load table & database metadata for the current question
     dispatch(loadMetadataForCard(card));
@@ -175,16 +166,13 @@ export const navigateToNewCardInsideQB = createThunkAction(
           dispatch(openUrl(url));
         } else {
           dispatch(onCloseSidebars());
-          const prevQueryResults = getQueryResults(getState());
           if (!cardQueryIsEquivalent(previousCard, nextCard)) {
             // clear the query result so we don't try to display the new visualization before running the new query
             dispatch(clearQueryResult());
           }
           // When the dataset query changes, we should change the type,
           // to start building a new ad-hoc question based on a dataset
-          dispatch(
-            setCardAndRun({ ...card, type: "question" }, { prevQueryResults }),
-          );
+          dispatch(setCardAndRun({ ...card, type: "question" }));
         }
         if (objectId !== undefined) {
           dispatch(zoomInRow({ objectId }));

--- a/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
+++ b/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
@@ -2,7 +2,7 @@ import { assocIn } from "icepick";
 import _ from "underscore";
 
 import { loadMetadataForCard } from "metabase/questions/actions";
-import { syncVizSettingsWithQueryResults } from "metabase/visualizations/lib/sync-settings";
+import { syncVizSettingsWithSeries } from "metabase/visualizations/lib/sync-settings";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
 import { getTemplateTagParametersFromCard } from "metabase-lib/v1/parameters/utils/template-tags";
@@ -135,7 +135,13 @@ export const updateQuestion = (
 
     const queryResult = getFirstQueryResult(getState());
     newQuestion = newQuestion.setSettings(
-      syncVizSettingsWithQueryResults(newQuestion.settings(), queryResult),
+      syncVizSettingsWithSeries(newQuestion.settings(), [
+        {
+          card: newQuestion.card(),
+          data: queryResult?.data,
+          error: queryResult?.error,
+        },
+      ]),
     );
 
     if (!newQuestion.canAutoRun()) {

--- a/frontend/src/metabase/query_builder/actions/querying.js
+++ b/frontend/src/metabase/query_builder/actions/querying.js
@@ -8,12 +8,14 @@ import { createThunkAction } from "metabase/lib/redux";
 import { getWhiteLabeledLoadingMessageFactory } from "metabase/selectors/whitelabel";
 import { runQuestionQuery as apiRunQuestionQuery } from "metabase/services";
 import { getSensibleDisplays } from "metabase/visualizations";
-import { syncVizSettingsWithQueryResults } from "metabase/visualizations/lib/sync-settings";
+import { syncVizSettingsWithSeries } from "metabase/visualizations/lib/sync-settings";
 import * as Lib from "metabase-lib";
 import { isAdHocModelQuestion } from "metabase-lib/v1/metadata/utils/models";
 import { isSameField } from "metabase-lib/v1/queries/utils/field-ref";
 
 import {
+  getCard,
+  getFirstQueryResult,
   getIsResultDirty,
   getIsRunning,
   getOriginalQuestion,
@@ -95,7 +97,6 @@ export const runQuestionQuery = ({
   shouldUpdateUrl = true,
   ignoreCache = false,
   overrideWithQuestion = null,
-  prevQueryResults = undefined,
 } = {}) => {
   return async (dispatch, getState) => {
     dispatch(loadStartUIControls());
@@ -137,11 +138,7 @@ export const runQuestionQuery = ({
             duration,
           ),
         );
-        return dispatch(
-          queryCompleted(question, queryResults, {
-            prevQueryResults: prevQueryResults ?? getQueryResults(getState()),
-          }),
-        );
+        return dispatch(queryCompleted(question, queryResults));
       })
       .catch(error => dispatch(queryErrored(startTime, error)));
 
@@ -176,25 +173,25 @@ export const CLEAR_QUERY_RESULT = "metabase/query_builder/CLEAR_QUERY_RESULT";
 export const clearQueryResult = createAction(CLEAR_QUERY_RESULT);
 
 export const QUERY_COMPLETED = "metabase/qb/QUERY_COMPLETED";
-export const queryCompleted = (
-  question,
-  queryResults,
-  { prevQueryResults } = {},
-) => {
+export const queryCompleted = (question, queryResults) => {
   return async (dispatch, getState) => {
-    const [{ data }] = queryResults;
-    const [{ data: prevData }] = prevQueryResults ?? [{}];
+    const [{ data, error }] = queryResults;
+    const prevCard = getCard(getState());
+    const { data: prevData, error: prevError } =
+      getFirstQueryResult(getState()) ?? {};
+
     const originalQuestion = getOriginalQuestionWithParameterValues(getState());
     const { isEditable } = Lib.queryDisplayInfo(question.query());
     const isDirty = isEditable && question.isDirtyComparedTo(originalQuestion);
 
     if (isDirty) {
+      const series = [{ card: question.card(), data, error }];
+      const previousSeries =
+        prevCard && (prevData || prevError)
+          ? [{ card: prevCard, data: prevData, error: prevError }]
+          : null;
       question = question.setSettings(
-        syncVizSettingsWithQueryResults(
-          question.settings(),
-          queryResults[0],
-          prevQueryResults?.[0],
-        ),
+        syncVizSettingsWithSeries(question.settings(), series, previousSeries),
       );
 
       question = question.maybeResetDisplay(

--- a/frontend/src/metabase/visualizations/index.ts
+++ b/frontend/src/metabase/visualizations/index.ts
@@ -128,6 +128,15 @@ export function getDefaultSize(display: string) {
   return visualization?.defaultSize;
 }
 
+export function hasGraphDataSettings(display: string) {
+  const visualization = visualizations.get(display);
+  const settingDefinitions = visualization?.settings ?? {};
+  return (
+    "graph.dimensions" in settingDefinitions &&
+    "graph.metrics" in settingDefinitions
+  );
+}
+
 // removes columns with `remapped_from` property and adds a `remapping` to the appropriate column
 export const extractRemappedColumns = (data: DatasetData) => {
   const cols: RemappingHydratedDatasetColumn[] = data.cols.map(col => ({


### PR DESCRIPTION
Manual backport of #44053

The only difference is that on `master` we have question repro tests merged into a few groups. OTOH, on `release-x.50.x` each repro has its own file. So this PR adds a repro test as a separate file for 50