### PR TITLE
Replace CSS variables in static viz

### DIFF
--- a/frontend/src/metabase/static-viz/components/ProgressBar/ProgressBar.tsx
+++ b/frontend/src/metabase/static-viz/components/ProgressBar/ProgressBar.tsx
@@ -105,18 +105,18 @@ const ProgressBar = ({
           <>
             <CheckMarkIcon
               size={layout.iconSize}
-              color="var(--mb-color-text-white)"
+              color="#ffffff"
               x={10}
               y={(layout.barHeight - layout.iconSize) / 2}
             />
             <Text
               fontSize={layout.fontSize}
               textAnchor="start"
-              color="var(--mb-color-text-white)"
+              color="#ffffff"
               x={layout.iconSize + 16}
               y={layout.barHeight / 2}
               verticalAnchor="middle"
-              fill="var(--mb-color-text-white)"
+              fill="#ffffff"
             >
               {barText}
             </Text>


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/44115

Removes CSS variables in `static-viz` directory as CSS variables cannot be used in the Batik CSS engine.
