### PR TITLE
Skip Crashing click-behavior e2e test

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -1246,7 +1246,8 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       })();
     });
 
-    it("should allow setting dashboard tab with parameter for a column", () => {
+    // replay browser crashing on this test consistently
+    it.skip("should allow setting dashboard tab with parameter for a column", () => {
       cy.createQuestion(TARGET_QUESTION);
 
       const dashboard = {

--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -1246,8 +1246,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       })();
     });
 
-    // replay browser crashing on this test consistently
-    it.skip("should allow setting dashboard tab with parameter for a column", () => {
+    it("should allow setting dashboard tab with parameter for a column", () => {
       cy.createQuestion(TARGET_QUESTION);
 
       const dashboard = {
@@ -1332,8 +1331,8 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
         });
       });
     });
-
-    it("should allow setting URL as custom destination and updating dashboard filters for different columns", () => {
+    // replay browser crashing on this test consistently
+    it.skip("should allow setting URL as custom destination and updating dashboard filters for different columns", () => {
       cy.createQuestion(TARGET_QUESTION);
       cy.createDashboard(
         {


### PR DESCRIPTION
This is caused by a replay.io browser bug: https://metaboat.slack.com/archives/C052LBPDAF3/p1718282540893529?thread_ts=1718272634.940839&cid=C052LBPDAF3