### PR TITLE
fix(ui-library): Don't animate Buttons (micro-PR)

### DIFF
--- a/frontend/src/metabase/ui/components/buttons/Button/Button.styled.tsx
+++ b/frontend/src/metabase/ui/components/buttons/Button/Button.styled.tsx
@@ -23,6 +23,7 @@ export const getButtonOverrides = (): MantineThemeOverride["components"] => ({
           fontSize: theme.fontSizes.md,
           lineHeight: theme.lineHeight,
           overflow: "hidden",
+          transition: "none",
           [`&:has(.${getStylesRef("label")}:empty)`]: {
             padding: compact ? `${rem(3)} ${rem(3)}` : `${rem(11)} ${rem(11)}`,
             [`.${getStylesRef("leftIcon")}`]: {

--- a/frontend/src/metabase/ui/components/buttons/Button/Button.styled.tsx
+++ b/frontend/src/metabase/ui/components/buttons/Button/Button.styled.tsx
@@ -23,7 +23,7 @@ export const getButtonOverrides = (): MantineThemeOverride["components"] => ({
           fontSize: theme.fontSizes.md,
           lineHeight: theme.lineHeight,
           overflow: "hidden",
-          transition: "none",
+          ":active": { transform: "none" }, // Remove Mantine's default pressed effect
           [`&:has(.${getStylesRef("label")}:empty)`]: {
             padding: compact ? `${rem(3)} ${rem(3)}` : `${rem(11)} ${rem(11)}`,
             [`.${getStylesRef("leftIcon")}`]: {


### PR DESCRIPTION
Mantine has a default animation for Buttons: when you click the button, it pushes down a little bit. This was previously disabled by means of an `animate` prop which I removed yesterday because I thought it was dead code. This PR restores the correct behavior, which is to disable the animation.

Closes #44142