### PR TITLE
Trigger ee extra build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -546,6 +546,24 @@ jobs:
               }
             });
 
+  trigger-ee-extra-pr:
+    needs: verify-s3-download
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          github_token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+          script: | # js
+            github.rest.repos.createDispatchEvent({
+              owner: '${{ github.repository_owner }}',
+              repo: 'metabase-ee-extra',
+              event_type: 'update-ee-extra-build',
+              client_payload: {
+                version: '${{ inputs.version }}'
+              }
+            });
+
   draft-release-notes:
     if: ${{ inputs.skip-release-notes != true }}
     needs: push-tags


### PR DESCRIPTION
Depends on: https://github.com/metabase/metabase-ee-extra/pull/153

### Description

As part of the release publishing workflow, automatically create a new build PR in the ee-extra repo.
