### PR TITLE
Remove "is empty" and "not empty" from time-series chrome

### DIFF
--- a/frontend/src/metabase/querying/components/DatePicker/DateOperatorPicker/constants.ts
+++ b/frontend/src/metabase/querying/components/DatePicker/DateOperatorPicker/constants.ts
@@ -43,14 +43,4 @@ export const OPERATOR_OPTIONS: OperatorOption[] = [
     value: "between",
     operators: ["between"],
   },
-  {
-    label: t`Is empty`,
-    value: "is-null",
-    operators: ["is-null"],
-  },
-  {
-    label: t`Not empty`,
-    value: "not-null",
-    operators: ["not-null"],
-  },
 ];

--- a/frontend/src/metabase/querying/components/TimeseriesChrome/TimeseriesFilterPicker/TimeseriesFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/TimeseriesChrome/TimeseriesFilterPicker/TimeseriesFilterPicker.unit.spec.tsx
@@ -76,13 +76,11 @@ describe("TimeseriesFilterPicker", () => {
 
     await userEvent.click(screen.getByText("All time"));
     await userEvent.click(await screen.findByDisplayValue("All time"));
-    await userEvent.click(await screen.findByText("Is empty"));
+    await userEvent.click(await screen.findByText("Current"));
     await userEvent.click(screen.getByText("Apply"));
 
     expect(getNextFilterParts()).toMatchObject({
-      operator: "is-null",
-      column: expect.anything(),
-      values: [],
+      value: "current",
     });
   });
 


### PR DESCRIPTION
Closes #44098

### Description

This PR removes "Is empty" and "Not empty" filter options as per #44098.

### How to verify

1. Open "Orders" table
2. Summarize Count by Created At: Month
3. Click on "All time" in the timeseries chrome at the bottom of the visualization
4. You should not see these removed filter options anymore

Before
![image](https://github.com/metabase/metabase/assets/31325167/d85e8b32-e77b-4f62-9979-c11998defe92)

After
![image](https://github.com/metabase/metabase/assets/31325167/97caceda-6450-478f-b20d-bd8110bf8267)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
