### PR TITLE
fix: Remove help email from error diagnostic modal

### DIFF
--- a/e2e/test/scenarios/admin/databases.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases.cy.spec.js
@@ -532,7 +532,7 @@ describe("scenarios > admin > databases > exceptions", () => {
     cy.wait("@failedGet");
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Something's gone wrong");
+    cy.findByText(/Something.s gone wrong/);
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(
       "We've run into an error. You can try refreshing the page, or just go back.",

--- a/e2e/test/scenarios/admin/databases.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases.cy.spec.js
@@ -535,7 +535,7 @@ describe("scenarios > admin > databases > exceptions", () => {
     cy.findByText(/Something.s gone wrong/);
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(
-      "We've run into an error. You can try refreshing the page, or just go back.",
+      /We.ve run into an error\. You can try refreshing the page, or just go back\./,
     );
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage

--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -456,7 +456,9 @@ describe("scenarios > home > custom homepage", () => {
       cy.findByTestId("main-logo-link").click().click();
       navigationSidebar().findByText("Home").click().click();
 
-      main().findByText("Something's gone wrong").should("not.exist");
+      main()
+        .findByText(/Something.s gone wrong/)
+        .should("not.exist");
       cy.get("@getDashboardMetadata.all").should("have.length", 1);
       cy.get("@runDashCardQuery.all").should("have.length", 1);
       cy.location("pathname").should(

--- a/frontend/src/metabase/actions/components/ActionViz/Action.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.tsx
@@ -192,7 +192,7 @@ function getErrorTooltip({
     return t`Actions are not enabled for this database`;
   }
 
-  return t`Something's gone wrong`;
+  return t`Something’s gone wrong`;
 }
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage

--- a/frontend/src/metabase/components/EmptyState/EmptyState.tsx
+++ b/frontend/src/metabase/components/EmptyState/EmptyState.tsx
@@ -1,9 +1,7 @@
-import Text from "metabase/components/type/Text";
-import Button from "metabase/core/components/Button";
 import Link from "metabase/core/components/Link";
 import CS from "metabase/css/core/index.css";
 import type { IconName } from "metabase/ui";
-import { Icon, isValidIconName } from "metabase/ui";
+import { Button, Icon, Text, isValidIconName } from "metabase/ui";
 
 import {
   EmptyStateActions,
@@ -80,7 +78,7 @@ const EmptyState = ({
         </h2>
       )}
       {message && (
-        <Text role="status" color="medium" className="empty-state-message">
+        <Text role="status" color="medium" mt="xs">
           {message}
         </Text>
       )}

--- a/frontend/src/metabase/components/EmptyState/EmptyState.tsx
+++ b/frontend/src/metabase/components/EmptyState/EmptyState.tsx
@@ -1,7 +1,8 @@
+import Button from "metabase/core/components/Button";
 import Link from "metabase/core/components/Link";
 import CS from "metabase/css/core/index.css";
 import type { IconName } from "metabase/ui";
-import { Button, Icon, Text, isValidIconName } from "metabase/ui";
+import { Icon, Text, isValidIconName } from "metabase/ui";
 
 import {
   EmptyStateActions,

--- a/frontend/src/metabase/components/ErrorPages/ErrorDiagnosticModal.tsx
+++ b/frontend/src/metabase/components/ErrorPages/ErrorDiagnosticModal.tsx
@@ -4,7 +4,6 @@ import _ from "underscore";
 
 import ErrorBoundary from "metabase/ErrorBoundary";
 import Alert from "metabase/core/components/Alert";
-import Link from "metabase/core/components/Link";
 import {
   Form,
   FormCheckbox,
@@ -259,12 +258,7 @@ export const ErrorExplanationModal = ({
       </Text>
       <Text my="md">
         {c("indicates an email address to which to send diagnostic information")
-          .jt`If the error persists, you can download diagnostic information to send to
-        ${(
-          <Link key="email" variant="brand" to="mailto:help@metabase.com">
-            {t`help@metabase.com`}
-          </Link>
-        )}`}
+          .jt`If the error persists, you can download diagnostic information`}
       </Text>
       <Flex justify="flex-end">
         <Button variant="filled" onClick={openDiagnosticModal}>

--- a/frontend/src/metabase/components/ErrorPages/ErrorDiagnosticModal.tsx
+++ b/frontend/src/metabase/components/ErrorPages/ErrorDiagnosticModal.tsx
@@ -13,16 +13,7 @@ import {
 import { useToggle } from "metabase/hooks/use-toggle";
 import { capitalize } from "metabase/lib/formatting";
 import { getIsEmbedded } from "metabase/selectors/embed";
-import {
-  Button,
-  Box,
-  Icon,
-  Loader,
-  Text,
-  Stack,
-  Modal,
-  Flex,
-} from "metabase/ui";
+import { Button, Icon, Loader, Text, Stack, Modal, Flex } from "metabase/ui";
 
 import type { ErrorPayload } from "./types";
 import { useErrorInfo } from "./use-error-info";
@@ -164,13 +155,6 @@ export const ErrorDiagnosticModalTrigger = () => {
   return (
     <ErrorBoundary>
       <Stack justify="center" my="lg">
-        <Box>
-          <Text align="center">
-            {c(
-              "indicates an email address to which to send diagnostic information",
-            ).jt`Click the button below to download diagnostic information`}
-          </Text>
-        </Box>
         <Button
           leftIcon={<Icon name="download" />}
           onClick={() => setModalOpen(true)}

--- a/frontend/src/metabase/components/ErrorPages/ErrorDiagnosticModal.tsx
+++ b/frontend/src/metabase/components/ErrorPages/ErrorDiagnosticModal.tsx
@@ -238,7 +238,7 @@ export const ErrorExplanationModal = ({
       onClose={onClose}
     >
       <Text my="md">
-        {t`We've run into an error, try to refresh the page or go back.`}
+        {t`We’ve run into an error, try to refresh the page or go back.`}
       </Text>
       <Text my="md">
         {c("indicates an email address to which to send diagnostic information")

--- a/frontend/src/metabase/components/ErrorPages/ErrorDiagnosticModal.tsx
+++ b/frontend/src/metabase/components/ErrorPages/ErrorDiagnosticModal.tsx
@@ -169,14 +169,7 @@ export const ErrorDiagnosticModalTrigger = () => {
           <Text align="center">
             {c(
               "indicates an email address to which to send diagnostic information",
-            )
-              .jt`Click the button below to download diagnostic information to send
-            to
-            ${(
-              <Link key="email" variant="brand" to="mailto:help@metabase.com">
-                {t`help@metabase.com`}
-              </Link>
-            )}`}
+            ).jt`Click the button below to download diagnostic information`}
           </Text>
         </Box>
         <Button

--- a/frontend/src/metabase/components/ErrorPages/ErrorPages.tsx
+++ b/frontend/src/metabase/components/ErrorPages/ErrorPages.tsx
@@ -19,7 +19,7 @@ import {
 import { ErrorPageRoot } from "./ErrorPages.styled";
 
 export const GenericError = ({
-  title = t`Something’s gone wrong.`,
+  title = t`Something’s gone wrong`,
   message = t`We’ve run into an error. You can try refreshing the page, or just go back.`,
   details,
 }: {

--- a/frontend/src/metabase/components/ErrorPages/ErrorPages.tsx
+++ b/frontend/src/metabase/components/ErrorPages/ErrorPages.tsx
@@ -19,8 +19,8 @@ import {
 import { ErrorPageRoot } from "./ErrorPages.styled";
 
 export const GenericError = ({
-  title = t`Something's gone wrong`,
-  message = t`We've run into an error. You can try refreshing the page, or just go back.`,
+  title = t`Something’s gone wrong.`,
+  message = t`We’ve run into an error. You can try refreshing the page, or just go back.`,
   details,
 }: {
   title?: string;
@@ -87,7 +87,7 @@ export const Archived = ({
 );
 
 export const SmallGenericError = ({
-  message = t`Something's gone wrong.`,
+  message = t`Something’s gone wrong.`,
   bordered = true,
 }: {
   message?: string;


### PR DESCRIPTION
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/72413c82-4870-448c-972f-3e67590961b1.png)


Closes #44150