### PR TITLE
fix: Remove console warnings in cache-related code

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyFormLauncher.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyFormLauncher.styled.tsx
@@ -2,6 +2,7 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import type { HTMLAttributes, MutableRefObject } from "react";
 
+import { doNotForwardProps } from "metabase/common/utils/doNotForwardProps";
 import { color } from "metabase/lib/colors";
 import { breakpointMaxSmall } from "metabase/styled-components/theme";
 import type { ButtonProps as BaseButtonProps } from "metabase/ui";
@@ -33,7 +34,10 @@ export const PolicyToken = styled(Button)<
 `;
 PolicyToken.defaultProps = { radius: "sm" };
 
-export const StyledLauncher = styled(Flex)<
+export const StyledLauncher = styled(
+  Flex,
+  doNotForwardProps("forRoot", "inheritsRootStrategy"),
+)<
   {
     forRoot?: boolean;
     inheritsRootStrategy?: boolean;

--- a/frontend/src/metabase/common/utils/doNotForwardProps.ts
+++ b/frontend/src/metabase/common/utils/doNotForwardProps.ts
@@ -1,0 +1,3 @@
+export const doNotForwardProps = (...propNamesToBlock: string[]) => ({
+  shouldForwardProp: (propName: string) => !propNamesToBlock.includes(propName),
+});

--- a/frontend/src/metabase/components/ResponsiveContainer/ResponsiveContainer.tsx
+++ b/frontend/src/metabase/components/ResponsiveContainer/ResponsiveContainer.tsx
@@ -1,11 +1,8 @@
 import styled from "@emotion/styled";
 
 import type { RefProp } from "metabase/browse/types";
+import { doNotForwardProps } from "metabase/common/utils/doNotForwardProps";
 import { Box, type BoxProps } from "metabase/ui";
-
-const doNotForwardProps = (...propNamesToBlock: string[]) => ({
-  shouldForwardProp: (propName: string) => !propNamesToBlock.includes(propName),
-});
 
 /** Helps with @container queries in CSS */
 export const ResponsiveContainer = styled(

--- a/frontend/src/metabase/components/Schedule/utils.tsx
+++ b/frontend/src/metabase/components/Schedule/utils.tsx
@@ -20,7 +20,8 @@ export const addScheduleComponents = (
 
 const addBlanks = (arr: ReactNode[]) => {
   const result: ReactNode[] = [];
-  const addBlank = () => result.push(<Box key={result.length}></Box>);
+  const addBlank = () =>
+    result.push(<Box key={`blank-${result.length}`}></Box>);
   for (let c = 0; c < arr.length; c++) {
     const curr = arr[c];
     const next = arr[c + 1];
@@ -28,7 +29,7 @@ const addBlanks = (arr: ReactNode[]) => {
     if (isLastItemString) {
       addBlank();
       result.push(
-        <Box key={result.length} mt="-.5rem">
+        <Box key={curr} mt="-.5rem">
           {curr}
         </Box>,
       );
@@ -39,7 +40,7 @@ const addBlanks = (arr: ReactNode[]) => {
       }
       if (typeof curr === "string") {
         const wrappedCurr = (
-          <Box key={result.length} style={{ textAlign: "end" }}>
+          <Box key={`wrapped-${curr}`} style={{ textAlign: "end" }}>
             {curr}
           </Box>
         );
@@ -54,7 +55,7 @@ const addBlanks = (arr: ReactNode[]) => {
         curr.props.longestLabel.length + next.props.longestLabel.length < 24;
       if (canSelectsProbablyFitOnOneLine) {
         result[result.length - 1] = (
-          <Group spacing="xs" key={result.length}>
+          <Group spacing="xs" key={`selects-on-one-line`}>
             {result[result.length - 1]}
             {next}
           </Group>

--- a/frontend/src/metabase/components/Schedule/utils.tsx
+++ b/frontend/src/metabase/components/Schedule/utils.tsx
@@ -20,21 +20,29 @@ export const addScheduleComponents = (
 
 const addBlanks = (arr: ReactNode[]) => {
   const result: ReactNode[] = [];
-  const addBlank = () => result.push(<Box></Box>);
+  const addBlank = () => result.push(<Box key={result.length}></Box>);
   for (let c = 0; c < arr.length; c++) {
     const curr = arr[c];
     const next = arr[c + 1];
     const isLastItemString = c === arr.length - 1 && typeof curr === "string";
     if (isLastItemString) {
       addBlank();
-      result.push(<Box mt="-.5rem">{curr}</Box>);
+      result.push(
+        <Box key={result.length} mt="-.5rem">
+          {curr}
+        </Box>,
+      );
     } else {
       const isFirstItemString = c === 0 && typeof curr !== "string";
       if (isFirstItemString) {
         addBlank();
       }
       if (typeof curr === "string") {
-        const wrappedCurr = <Box style={{ textAlign: "end" }}>{curr}</Box>;
+        const wrappedCurr = (
+          <Box key={result.length} style={{ textAlign: "end" }}>
+            {curr}
+          </Box>
+        );
         result.push(wrappedCurr);
       } else {
         result.push(curr);
@@ -46,7 +54,7 @@ const addBlanks = (arr: ReactNode[]) => {
         curr.props.longestLabel.length + next.props.longestLabel.length < 24;
       if (canSelectsProbablyFitOnOneLine) {
         result[result.length - 1] = (
-          <Group spacing="xs">
+          <Group spacing="xs" key={result.length}>
             {result[result.length - 1]}
             {next}
           </Group>


### PR DESCRIPTION
This PR removes:
- a warning about missing React keys in the `Schedule` component
- a warning about invalid props in the `StrategyFormLauncher` component
