### PR TITLE
Prevent waterfall chart negative values from having column value scaling double applied

### DIFF
--- a/frontend/src/metabase/lib/formatting/numbers.tsx
+++ b/frontend/src/metabase/lib/formatting/numbers.tsx
@@ -63,16 +63,16 @@ export function formatNumber(
 ): any {
   options = { ...getDefaultNumberOptions(options), ...options };
 
-  if (typeof options.scale === "number" && !isNaN(options.scale)) {
-    number = options.scale * number;
-  }
-
   if (number < 0 && options.negativeInParentheses) {
     return (
       "(" +
       formatNumber(-number, { ...options, negativeInParentheses: false }) +
       ")"
     );
+  }
+
+  if (typeof options.scale === "number" && !isNaN(options.scale)) {
+    number = options.scale * number;
   }
 
   if (options.compact) {

--- a/frontend/src/metabase/lib/formatting/numbers.unit.spec.js
+++ b/frontend/src/metabase/lib/formatting/numbers.unit.spec.js
@@ -70,4 +70,38 @@ describe("formatNumber", () => {
     });
     expect(fullResult).toEqual("-$500,000.00");
   });
+
+  it("should only apply scaling once when negativeInParentheses option is true (metabase#40490)", () => {
+    const numberFormatter = numberFormatterForOptions({});
+
+    const formatOptions = {
+      negativeInParentheses: true,
+      scale: 0.01,
+      jsx: false,
+      field: "1234567",
+      number_style: "decimal",
+      number_separators: ".,",
+      _numberFormatter: numberFormatter,
+      _header_unit: "$",
+      column: {
+        display_name: "1234567",
+        source: "native",
+        field_ref: [
+          "field",
+          "1234567",
+          {
+            "base-type": "type/Integer",
+          },
+        ],
+        name: "1234567",
+        base_type: "type/Integer",
+        effective_type: "type/Integer",
+      },
+      _column_title_full: "1234567",
+    };
+
+    const result = formatNumber(1234567, formatOptions);
+    expect(result).not.toEqual("123.4567");
+    expect(result).toEqual("12,345.67");
+  });
 });


### PR DESCRIPTION
- Closes: https://github.com/metabase/metabase/issues/40490

**Before**

![Screenshot from 2024-06-13 16-43-14](https://github.com/metabase/metabase/assets/22608765/e5aee84f-6e38-450d-b426-ed57d29bf728)

**After**

![Screenshot from 2024-06-13 16-42-22](https://github.com/metabase/metabase/assets/22608765/9da7d1e2-cb73-4248-853a-f7fac8c8cf12)
