### PR TITLE
Fix bulk actions danger button style regression

### DIFF
--- a/frontend/src/metabase/components/BulkActionBar/BulkActionBar.styled.tsx
+++ b/frontend/src/metabase/components/BulkActionBar/BulkActionBar.styled.tsx
@@ -48,10 +48,8 @@ export const BulkActionButton = styled(Button)`
 ` as unknown as typeof Button;
 
 export const BulkActionDangerButton = styled(BulkActionButton)`
-  color: var(--mb-color-danger);
-
   :hover {
     color: var(--mb-color-text-white);
-    background-color: var(--mb-color-bg-error);
+    background-color: var(--mb-color-error);
   }
 ` as unknown as typeof Button;


### PR DESCRIPTION
### Description

Fixes a regression from css variable refactor that affected the styles of the bulk actions danger button and some mistake that left the button text red when it should have been white
.
<img width="517" alt="Screenshot 2024-06-13 at 3 47 54 PM" src="https://github.com/metabase/metabase/assets/7104357/f9782b50-1f23-441d-a77e-761d5dc758d2">
<img width="518" alt="Screenshot 2024-06-13 at 3 47 47 PM" src="https://github.com/metabase/metabase/assets/7104357/fcce221c-c7e1-4ccb-a3e2-7603ba951b35">
<img width="539" alt="Screenshot 2024-06-13 at 3 48 08 PM" src="https://github.com/metabase/metabase/assets/7104357/6e8f7245-dacc-4578-9c05-0f5684941ebc">
