### PR TITLE
Elevate include this period in the relative date picker

### DIFF
--- a/e2e/support/helpers/e2e-relative-date-picker-helpers.js
+++ b/e2e/support/helpers/e2e-relative-date-picker-helpers.js
@@ -47,8 +47,9 @@ function addStartingFrom({ value, unit }) {
 }
 
 function toggleCurrentInterval() {
-  popover().findByLabelText("Options").click();
-  popover().last().findByTestId("include-current-interval-option").click();
+  popover()
+    .findByTestId("include-current-interval-option")
+    .click({ force: true });
 }
 
 export const relativeDatePicker = {

--- a/e2e/test/scenarios/filters/filter.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter.cy.spec.js
@@ -522,13 +522,9 @@ describe("scenarios > question > filter", () => {
       cy.findByText("Created At").click();
       cy.findByText("Relative dates…").click();
       cy.findByText("Past").click();
-      cy.findByLabelText("Options").click();
+      cy.findByText(/^Include/).click();
+      cy.button("Add filter").click();
     });
-    popover()
-      .last()
-      .findByText(/^Include/)
-      .click();
-    popover().button("Add filter").click();
 
     getNotebookStep("filter")
       .findByText("Created At is in the previous 30 days")
@@ -545,11 +541,10 @@ describe("scenarios > question > filter", () => {
     getNotebookStep("filter")
       .findByText("Created At is in the previous 30 days")
       .click();
-    popover().findByLabelText("Options").click();
+
     popover()
-      .last()
       .findByTestId("include-current-interval-option")
-      .should("have.attr", "aria-selected", "true");
+      .should("have.attr", "aria-checked", "true");
   });
 
   it("should be able to convert case-insensitive filter to custom expression (metabase#14959)", () => {

--- a/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.tsx
@@ -11,6 +11,7 @@ import {
   NumberInput,
   Select,
   Text,
+  Switch,
 } from "metabase/ui";
 
 import type { DateIntervalValue } from "../types";
@@ -66,7 +67,7 @@ export function DateIntervalPicker({
     onChange(setDefaultOffset(value));
   };
 
-  const handleIncludeCurrentClick = () => {
+  const handleIncludeCurrentSwitch = () => {
     onChange(setIncludeCurrent(value, !includeCurrent));
   };
 
@@ -109,18 +110,20 @@ export function DateIntervalPicker({
                 {t`Starting from…`}
               </Menu.Item>
             )}
-            <Menu.Item
-              icon={<Icon name={includeCurrent ? "check" : "calendar"} />}
-              onClick={handleIncludeCurrentClick}
-              aria-selected={includeCurrent}
-              data-testid="include-current-interval-option"
-            >
-              {t`Include ${getIncludeCurrentLabel(value.unit)}`}
-            </Menu.Item>
           </Menu.Dropdown>
         </Menu>
       </Flex>
-      <Flex p="md">{t`Include ${getIncludeCurrentLabel(value.unit)}`}</Flex>
+      <Flex p="md" pt={0}>
+        <Switch
+          aria-checked={includeCurrent}
+          checked={includeCurrent}
+          data-testid="include-current-interval-option"
+          label={t`Include ${getIncludeCurrentLabel(value.unit)}`}
+          labelPosition="right"
+          onChange={handleIncludeCurrentSwitch}
+          size="sm"
+        />
+      </Flex>
       <Divider />
       <Group px="md" py="sm" position="apart">
         <Group c="text-medium" spacing="sm">

--- a/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.tsx
@@ -120,6 +120,7 @@ export function DateIntervalPicker({
           </Menu.Dropdown>
         </Menu>
       </Flex>
+      <Flex p="md">{t`Include ${getIncludeCurrentLabel(value.unit)}`}</Flex>
       <Divider />
       <Group px="md" py="sm" position="apart">
         <Group c="text-medium" spacing="sm">


### PR DESCRIPTION
### Description

This PR elevates "Include this..." option in the UI for:
- Notebook filters
- Filter modal (simple mode)
- Drill-through filters

They are all using the same component, so fixing it in one place updated all of the above.

This resolves the majority of the tasks in the Milestone 1 of #44096

### How to verify

Describe the steps to verify that the changes are working as expected.

**Notebook**
1. Open Orders table in a notebook view
2. Click on a filter > Created At
3. Choose "Relative dates"
4. Popover should show a toggle with "Include this..." period
<img width="406" alt="image" src="https://github.com/metabase/metabase/assets/31325167/4ccc67be-b705-4bf2-9236-601bee11f65a">

**Filter modal**
1. Open Orders table
2. Click on a "Filter" (pill)
3. Choose `...` next to "Created At" and choose "Relative dates"
4. Popover should show a toggle with "Include this..." period
<img width="1189" alt="image" src="https://github.com/metabase/metabase/assets/31325167/ec5d34aa-34c9-4020-aca5-30d22afeaeeb">

**Drill-through context**
1. Open Orders table
2. Click on a table header cell "Created At"
3. Filter by this column
4. Relative dates
5. Popover should show a toggle with "Include this..." period
<img width="398" alt="image" src="https://github.com/metabase/metabase/assets/31325167/375358d0-4bbb-4338-ba6e-b593cb7c1e72">

> [!Note]
> For all of the options above, this should work the same for both `Past` and `Next`

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

### Out of scope
- Updating the design any further (will be a theme in a separate PR)