### PR TITLE
Sort trash collection by last_edited_at desc

### DIFF
--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsTable.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionItemsTable.tsx
@@ -34,6 +34,20 @@ import {
   CollectionTable,
 } from "./CollectionContent.styled";
 
+const getDefaultSortingOptions = (
+  collection: Collection | undefined,
+): SortingOptions => {
+  return isRootTrashCollection(collection)
+    ? {
+        sort_column: "last_edited_at",
+        sort_direction: SortDirection.Desc,
+      }
+    : {
+        sort_column: "name",
+        sort_direction: SortDirection.Asc,
+      };
+};
+
 export type CollectionItemsTableProps = {
   collectionId: CollectionId;
 } & Partial<{
@@ -81,10 +95,7 @@ export const CollectionItemsTable = ({
   const isEmbeddingSdk = useSelector(getIsEmbeddingSdk);
 
   const [unpinnedItemsSorting, setUnpinnedItemsSorting] =
-    useState<SortingOptions>({
-      sort_column: "name",
-      sort_direction: SortDirection.Asc,
-    });
+    useState<SortingOptions>(() => getDefaultSortingOptions(collection));
 
   const [total, setTotal] = useState<number | null>(null);
 


### PR DESCRIPTION
### Description

Changes the default sort direction when viewing the trash collection to be last_edit_at desc

### How to verify

- view trash collection

### Demo
(view on page load - notice sorting icon next to delete at column)
<img width="1491" alt="Screenshot 2024-06-13 at 4 08 32 PM" src="https://github.com/metabase/metabase/assets/7104357/e9260a62-3bbf-4538-afc5-f18d1e663dd3">

