### PR TITLE
fix mutating frozen settings when display changes

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/AreaChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/AreaChart.jsx
@@ -49,7 +49,10 @@ export default class AreaChart extends LineAreaBarChart {
 
   static onDisplayUpdate = settings => {
     if (settings["stackable.stack_display"]) {
-      settings["stackable.stack_display"] = "area";
+      return {
+        ...settings,
+        "stackable.stack_display": "area",
+      };
     }
     return settings;
   };

--- a/frontend/src/metabase/visualizations/visualizations/AreaChart.unit.spec.js
+++ b/frontend/src/metabase/visualizations/visualizations/AreaChart.unit.spec.js
@@ -1,0 +1,19 @@
+import AreaChart from "./AreaChart";
+
+describe("AreaChart", () => {
+  describe("onDisplayUpdate", () => {
+    it("should set to area if the setting exists", () => {
+      const settings = { "stackable.stack_display": "bar" };
+      const frozenSettings = Object.freeze(settings);
+
+      const expectedSettings = { "stackable.stack_display": "area" };
+
+      expect(AreaChart.onDisplayUpdate(settings)).toStrictEqual(
+        expectedSettings,
+      );
+      expect(AreaChart.onDisplayUpdate(frozenSettings)).toStrictEqual(
+        expectedSettings,
+      );
+    });
+  });
+});

--- a/frontend/src/metabase/visualizations/visualizations/BarChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/BarChart.jsx
@@ -47,7 +47,10 @@ export default class BarChart extends LineAreaBarChart {
 
   static onDisplayUpdate = settings => {
     if (settings["stackable.stack_display"]) {
-      settings["stackable.stack_display"] = "bar";
+      return {
+        ...settings,
+        "stackable.stack_display": "bar",
+      };
     }
     return settings;
   };

--- a/frontend/src/metabase/visualizations/visualizations/BarChart.unit.spec.js
+++ b/frontend/src/metabase/visualizations/visualizations/BarChart.unit.spec.js
@@ -1,0 +1,19 @@
+import BarChart from "./BarChart";
+
+describe("BarChart", () => {
+  describe("onDisplayUpdate", () => {
+    it("should set to area if the setting exists", () => {
+      const settings = { "stackable.stack_display": "area" };
+      const frozenSettings = Object.freeze(settings);
+
+      const expectedSettings = { "stackable.stack_display": "bar" };
+
+      expect(BarChart.onDisplayUpdate(settings)).toStrictEqual(
+        expectedSettings,
+      );
+      expect(BarChart.onDisplayUpdate(frozenSettings)).toStrictEqual(
+        expectedSettings,
+      );
+    });
+  });
+});


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/44121

### Description

The original issue appears to be involving a question with a certain combination of viz settings that cause the error. I could not reproduce it locally but the logs are clearly pointing out to the inability to assign `'stackable.stack_display'` to a frozen object in `onDisplayUpdate` function which is invoked when question display type changes.

This code does not exist in v50 anymore so this PR targets v49 branch.

```
Uncaught TypeError: Cannot assign to read only property 'stackable.stack_display' of object '#<Object>'
    at lK.onDisplayUpdate (BarChart.jsx:50:42)
    at ChartTypeSidebar.tsx:105:49
```

### How to verify

Ensure unit tests are passing

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
