### PR TITLE
Better Release Slack Notifications

### DIFF
--- a/.github/workflows/build-for-release.yml
+++ b/.github/workflows/build-for-release.yml
@@ -29,16 +29,17 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
           script: | # js
-            const { sendReleaseMessage } = require('${{ github.workspace }}/release/dist/index.cjs');
+            const { sendPreReleaseMessage } = require('${{ github.workspace }}/release/dist/index.cjs');
 
-            await sendReleaseMessage({
-              stage: 'build-start',
+            await sendPreReleaseMessage({
               github,
               owner: context.repo.owner,
               repo: context.repo.repo,
               version: '${{ inputs.version }}',
               runId: '${{ github.run_id }}',
               releaseSha: '${{ inputs.commit }}',
+              userName: '${{ github.actor }}',
+              channelName: '${{ vars.SLACK_RELEASE_CHANNEL }}',
             }).catch(console.error);
 
   check-version:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -284,3 +284,37 @@ jobs:
       - name: Wait for Metabase to start
         run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
         timeout-minutes: 3
+
+  tests-complete-message:
+    if: always()
+    runs-on: ubuntu-22.04
+    needs: [run-sanity-check, check-uberjar-health, verify-docker-pull]
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: release
+      - name: Prepare build scripts
+        run: cd ${{ github.workspace }}/release && yarn && yarn build
+      - name: Send tests complete message
+        uses: actions/github-script@v7
+        env:
+          SLACK_RELEASE_CHANNEL: ${{ vars.SLACK_RELEASE_CHANNEL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          script: | # js
+            const { sendTestsCompleteMessage } = require('${{ github.workspace }}/release/dist/index.cjs');
+
+            const allJobsSuccessful =
+              '${{ needs.run-sanity-check.result }}' === 'success' &&
+              '${{ needs.check-uberjar-health.result }}' === 'success' &&
+              '${{ needs.verify-docker-pull.result }}' === 'success';
+
+            await sendTestsCompleteMessage({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              version: '${{ inputs.version }}',
+              runId: '${{ github.run_id }}',
+              channelName: '${{ vars.SLACK_RELEASE_CHANNEL }}',
+              testsStatus: allJobsSuccessful ? 'success' : 'failure',
+            }).catch(console.error);

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -316,5 +316,5 @@ jobs:
               version: '${{ inputs.version }}',
               runId: '${{ github.run_id }}',
               channelName: '${{ vars.SLACK_RELEASE_CHANNEL }}',
-              testsStatus: allJobsSuccessful ? 'success' : 'failure',
+              testStatus: allJobsSuccessful ? 'success' : 'failure',
             }).catch(console.error);

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -649,7 +649,7 @@ jobs:
           sparse-checkout: release
       - name: Prepare build scripts
         run: cd ${{ github.workspace }}/release && yarn && yarn build
-      - name: Send publish start message
+      - name: Send publish complete message
         uses: actions/github-script@v7
         env:
           SLACK_RELEASE_CHANNEL: ${{ vars.SLACK_RELEASE_CHANNEL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,34 @@ jobs:
 
           return versions;
 
+  publish-start-message:
+    runs-on: ubuntu-22.04
+    needs: [check-version]
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: release
+      - name: Prepare build scripts
+        run: cd ${{ github.workspace }}/release && yarn && yarn build
+      - name: Send publish start message
+        uses: actions/github-script@v7
+        env:
+          SLACK_RELEASE_CHANNEL: ${{ vars.SLACK_RELEASE_CHANNEL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          script: | # js
+            const { sendPublishStartMessage } = require('${{ github.workspace }}/release/dist/index.cjs');
+
+            await sendPublishStartMessage({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              version: '${{ inputs.version }}',
+              runId: '${{ github.run_id }}',
+              channelName: '${{ vars.SLACK_RELEASE_CHANNEL }}',
+            }).catch(console.error);
+
+
   download-uberjar:
     needs: check-version
     runs-on: ubuntu-22.04
@@ -610,6 +638,34 @@ jobs:
         aws cloudfront create-invalidation \
         --distribution-id ${{ vars.AWS_CLOUDFRONT_STATIC_ID }} \
         --paths "/version-info.json" "/version-info-ee.json"
+
+  publish-complete-message:
+    runs-on: ubuntu-22.04
+    needs: [draft-release-notes, verify-docker-pull, verify-s3-download, publish-version-info]
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: release
+      - name: Prepare build scripts
+        run: cd ${{ github.workspace }}/release && yarn && yarn build
+      - name: Send publish start message
+        uses: actions/github-script@v7
+        env:
+          SLACK_RELEASE_CHANNEL: ${{ vars.SLACK_RELEASE_CHANNEL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          script: | # js
+            const { sendPublishCompleteMessage } = require('${{ github.workspace }}/release/dist/index.cjs');
+
+            await sendPublishCompleteMessage({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              version: '${{ inputs.version }}',
+              runId: '${{ github.run_id }}',
+              channelName: '${{ vars.SLACK_RELEASE_CHANNEL }}',
+              generalChannelName: 'general',
+            }).catch(console.error);
 
   manage-milestones:
     permissions: write-all

--- a/.github/workflows/tag-for-release.yml
+++ b/.github/workflows/tag-for-release.yml
@@ -23,22 +23,23 @@ jobs:
       - name: Prepare build scripts
         run: cd ${{ github.workspace }}/release && yarn && yarn build
       - name: Send build start message
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         env:
           SLACK_RELEASE_CHANNEL: ${{ vars.SLACK_RELEASE_CHANNEL }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
           script: | # js
-            const { sendReleaseMessage } = require('${{ github.workspace }}/release/dist/index.cjs');
+            const { sendPreReleaseMessage } = require('${{ github.workspace }}/release/dist/index.cjs');
 
-            await sendReleaseMessage({
-              stage: 'build-start',
+            await sendPreReleaseMessage({
               github,
               owner: context.repo.owner,
               repo: context.repo.repo,
               version: '${{ inputs.version }}',
               runId: '${{ github.run_id }}',
               releaseSha: '${{ inputs.commit }}',
+              userName: '${{ github.actor }}',
+              channelName: '${{ vars.SLACK_RELEASE_CHANNEL }}',
             }).catch(console.error);
 
   check-version:

--- a/release/github-slack-map.json
+++ b/release/github-slack-map.json
@@ -82,5 +82,9 @@
   "vbenedetti": "U04MRS3JTLH",
   "victoriaspek": "U02KD3E703E",
   "WiNloSt": "U02MYNXD605",
-  "zbodi74": "U05EV72TPN2"
+  "zbodi74": "U05EV72TPN2",
+  "core-ems": "S053QF4U49G",
+  "tech-writers": "S078147J78S",
+  "successengineers": "S05AAL8PUA1",
+  "growth": "S056LQCRQG5"
 }

--- a/release/src/slack.ts
+++ b/release/src/slack.ts
@@ -241,7 +241,6 @@ export async function sendPreReleaseMessage({
   userName: string,
 }) {
   const title = getReleaseTitle(version);
-  const space = "\n";
 
   const milestone = await findMilestone({ version, github, owner, repo });
   console.log("Milestone", milestone);
@@ -266,10 +265,7 @@ export async function sendPreReleaseMessage({
     userName ? `started by ${mentionUserByGithubLogin(userName)}` : null
   ].filter(Boolean).join(" - ");
 
-  const message = [
-    title,
-    preReleaseMessage,
-  ].join(space);
+  const message = `${title}\n${preReleaseMessage}`;
 
   await sendSlackMessage({ message, channelName });
 }

--- a/release/src/slack.ts
+++ b/release/src/slack.ts
@@ -21,6 +21,10 @@ export function mentionUserByGithubLogin(githubLogin?: string | null) {
   return '@unassigned';
 }
 
+export function mentionSlackTeam(teamName: string) {
+  return `<!subteam^${githubSlackMap[teamName]}|${teamName}>`;
+}
+
 export function getChannelTopic(channelName: string) {
   return slack.conversations.list({
     types: 'public_channel',
@@ -148,18 +152,56 @@ export async function sendPreReleaseStatus({
   });
 }
 
-type BuildStage =
-  | "build-start"
-  | "build-done"
-  | "test-start"
-  | "test-done"
-  | "publish-start"
-  | "publish-done";
-
 function sendSlackMessage({ channelName = SLACK_CHANNEL_NAME, message }: { channelName?: string, message: string }) {
   return slack.chat.postMessage({
     channel: channelName,
     text: message,
+  });
+}
+
+async function getSlackChannelId(channelName: string) {
+  const response = await slack.conversations.list({
+    limit: 9999,
+    exclude_archived: true,
+  });
+  return response.channels?.find((channel) => channel.name === channelName)?.id;
+}
+
+async function getExistingSlackMessage(version: string, channelName: string) {
+  const channelId = await getSlackChannelId(channelName);
+  if (!channelId) {
+    throw new Error(`Could not find channel ${channelName}`);
+  }
+
+  const response = await slack.conversations.history({
+    channel: channelId,
+  });
+
+  const existingMessage = response.messages?.find(
+    message => message.text?.includes(getReleaseTitle(version)),
+  );
+
+  if (!existingMessage) {
+    return null;
+  }
+
+  return {
+    id: existingMessage.ts ?? '',
+    body: existingMessage.text ?? '',
+  };
+}
+
+async function sendSlackReply({ channelName, message, messageId, broadcast }: {channelName: string, message: string, messageId?: string, broadcast?: boolean}) {
+  const channelId = await getSlackChannelId(channelName);
+  if (!channelId) {
+    throw new Error(`Could not find channel ${channelName}`);
+  }
+
+  return slack.chat.postMessage({
+    channel: channelId,
+    text: message,
+    thread_ts: messageId, // if this is empty it should post in the channel
+    reply_broadcast: !!broadcast,
   });
 }
 
@@ -182,58 +224,124 @@ function githubRunLink(
   );
 }
 
-export async function sendReleaseMessage({
+export async function sendPreReleaseMessage({
   github,
   owner,
   repo,
-  stage,
   version,
   runId,
   releaseSha,
+  channelName,
+  userName,
 }: ReleaseProps & {
-  stage: BuildStage;
   version: string;
   runId: string;
   releaseSha: string;
+  channelName: string,
+  userName: string,
 }) {
-
   const title = getReleaseTitle(version);
   const space = "\n";
-  let message = "";
 
-  if (stage === "build-start") {
-    const milestone = await findMilestone({ version, github, owner, repo });
-    console.log("Milestone", milestone);
-    const milestoneLink = milestone?.number
-      ? slackLink(
-          `_:direction-sign: Milestone_`,
-          `https://github.com/${owner}/${repo}/milestone/${milestone.number}?closed=1`,
-        )
-      : "";
+  const milestone = await findMilestone({ version, github, owner, repo });
+  console.log("Milestone", milestone);
+  const milestoneLink = milestone?.number
+    ? slackLink(
+        `_:direction-sign: Milestone_`,
+        `https://github.com/${owner}/${repo}/milestone/${milestone.number}?closed=1`,
+      )
+    : "";
 
-    const releaseCommitLink = slackLink(
-      `_:merged: Release Commit_`,
-      `https://github.com/${owner}/${repo}/commit/${releaseSha}`,
-    );
+  const releaseCommitLink = slackLink(
+    `_:merged: Release Commit_`,
+    `https://github.com/${owner}/${repo}/commit/${releaseSha}`,
+  );
 
-    const githubBuildLink = githubRunLink("_🏗️ CI Build_", runId, owner, repo);
+  const githubBuildLink = githubRunLink("_🏗️ CI Build_", runId, owner, repo);
 
-    const preReleaseMessage = [
-      releaseCommitLink,
-      milestoneLink,
-      githubBuildLink,
-    ].filter(Boolean).join(" - ");
+  const preReleaseMessage = [
+    releaseCommitLink,
+    milestoneLink,
+    githubBuildLink,
+    userName ? `started by ${mentionUserByGithubLogin(userName)}` : null
+  ].filter(Boolean).join(" - ");
 
-    message = [
-      title,
-      preReleaseMessage,
-    ].join(space);
-  }
+  const message = [
+    title,
+    preReleaseMessage,
+  ].join(space);
 
-  if (message) {
-    await sendSlackMessage({ message });
-    return;
-  }
+  await sendSlackMessage({ message, channelName });
+}
 
-  console.error(`No message to send for ${stage}`);
+export async function sendTestsCompleteMessage({
+  channelName,
+  version,
+  runId,
+  testStatus,
+  owner,
+  repo,
+}: {
+  channelName: string,
+  version: string,
+  runId: number,
+  testStatus: 'success' | 'failure',
+  owner: string,
+  repo: string,
+}) {
+  const message = testStatus === 'success'
+    ? `:very-green-check: ${getGenericVersion(version)} ${githubRunLink("Pre-release Tests Passed", runId.toString(), owner, repo)}`
+    : `:x: ${getGenericVersion(version)} ${githubRunLink("Pre-release Tests Failed", runId.toString(), owner, repo)}`;
+
+  const buildThread = await getExistingSlackMessage(version, channelName);
+
+  await sendSlackReply({ channelName, message, messageId: buildThread?.id });
+}
+
+export async function sendPublishStartMessage({
+  channelName,
+  version,
+  runId,
+  owner,
+  repo,
+}: {
+  channelName: string,
+  version: string,
+  runId: number,
+  owner: string,
+  repo: string,
+}) {
+  const message = `:loading: ${githubRunLink(`Publishing ${getGenericVersion(version)}`, runId.toString(), owner, repo)}`;
+  const buildThread = await getExistingSlackMessage(version, channelName);
+  await sendSlackReply({ channelName, message, messageId: buildThread?.id });
+}
+
+export async function sendPublishCompleteMessage({
+  channelName,
+  generalChannelName,
+  version,
+  runId,
+  owner,
+  repo,
+}: {
+  channelName: string,
+  generalChannelName: string,
+  version: string,
+  runId: number,
+  owner: string,
+  repo: string,
+}) {
+  const message = `:partydeploy: *${githubRunLink(`${getGenericVersion(version)} Release is Complete`, runId.toString(), owner, repo)}* :partydeploy:\n
+   • ${slackLink("Release Notes", `https://github.com/${owner}/${repo}/releases`)} - ${mentionSlackTeam('growth')}
+   • ${slackLink("EE Extra Build", `https://github.com/${owner}/metabase-ee-extra/pulls`)} - ${mentionSlackTeam('core-ems')}
+   • ${slackLink("Ops Issues", `https://github.com/${owner}/metabase-ops/issues`)} - ${mentionSlackTeam('successengineers')}
+   • ${slackLink("Docs Update", `https://github.com/${owner}/metabase.github.io/pulls`)} - ${mentionSlackTeam('tech-writers')}
+`;
+  const buildThread = await getExistingSlackMessage(version, channelName);
+  await sendSlackReply({ channelName, message, messageId: buildThread?.id, broadcast: true });
+
+  await sendSlackMessage({
+    message: `:partydeploy: *Metabase ${getGenericVersion(version)} has been released!* :partydeploy:\n\nSee the ${slackLink('full release notes here', `https://github.com/${owner}/${repo}/releases`)}.`,
+    channelName: generalChannelName,
+  });
 }


### PR DESCRIPTION
closes https://github.com/metabase/metabase/issues/44154

### Description

Adds additional automated slack messages to the release process, and updates an existing message
- Build start message now tags the person who triggered the build
- Adds a message to notify of the result of pre-release testing
- Adds a message to notify that the publish job has started
- Automates (the previously manual) step of notifying that the publish is complete.
- Automates (the previously manual) step of notifying the #general channel that the release is complete

![Screen Shot 2024-06-14 at 10 59 45 AM](https://github.com/metabase/metabase/assets/30528226/9c14c8e7-da98-4146-959f-55f657dee3b7)


✅ Test run:
- [tag workflow](https://github.com/iethree/metabase/actions/runs/9513241398)
- [test workflow](https://github.com/iethree/metabase/actions/runs/9513263640)
- [publish workflow](https://github.com/iethree/metabase/actions/runs/9513357424)
- [slack thread](https://metaboat.slack.com/archives/C01BWAZJE0N/p1718354425203489)
