### PR TITLE
Fix background-color usage in CSS-in-JS

### DIFF
--- a/frontend/src/metabase/ui/components/feedback/Skeleton/Skeleton.styled.tsx
+++ b/frontend/src/metabase/ui/components/feedback/Skeleton/Skeleton.styled.tsx
@@ -16,7 +16,7 @@ export const getSkeletonOverrides = (): MantineThemeOverride["components"] => {
         return {
           // We replace Mantine's pulsing animation with a shimmer animation
           root: {
-            "background-color": "rgba(0, 0, 0, .03)",
+            backgroundColor: "rgba(0, 0, 0, .03)",
             "&::before": {
               background:
                 "linear-gradient(100deg, transparent, rgba(0, 0, 0, .03) 50%, transparent) ! important",


### PR DESCRIPTION
Fixes this warning (introduced in #44008):

![image](https://github.com/metabase/metabase/assets/6830683/19aae566-567a-4571-8421-08d7e6cd6c48)
