### PR TITLE
Update `query-dependents`

### DIFF
--- a/src/metabase/lib/fe_util.cljc
+++ b/src/metabase/lib/fe_util.cljc
@@ -170,7 +170,7 @@
 (defn- query-dependents
   [metadata-providerable query-or-join]
   (let [base-stage (first (:stages query-or-join))
-        database-id (:database query-or-join -1)]
+        database-id (or (:database query-or-join) -1)]
     (concat
      (when (pos? database-id)
        [{:type :database, :id database-id}


### PR DESCRIPTION
Handle `:database` set to nil. I believe that `query-or-join`
should not even have nil set for `:database` in the first place.
This commit should enable further debugging
and hopefully make failing question work.

More context on [slack](https://metaboat.slack.com/archives/C04DN5VRQM6/p1718332028360439).

After merging (1) further investigation, and based on the results of that (2) tests are needed.

No backport is set on the PR. Backporting is TDB after (1) and (2) are completed.
