### PR TITLE
ci(release):Tag tech writers in release message

### DIFF
--- a/release/src/slack.ts
+++ b/release/src/slack.ts
@@ -328,7 +328,7 @@ export async function sendPublishCompleteMessage({
   repo: string,
 }) {
   const message = `:partydeploy: *${githubRunLink(`${getGenericVersion(version)} Release is Complete`, runId.toString(), owner, repo)}* :partydeploy:\n
-   • ${slackLink("Release Notes", `https://github.com/${owner}/${repo}/releases`)} - ${mentionSlackTeam('growth')}
+   • ${slackLink("Release Notes", `https://github.com/${owner}/${repo}/releases`)} - ${mentionSlackTeam('tech-writers')}
    • ${slackLink("EE Extra Build", `https://github.com/${owner}/metabase-ee-extra/pulls`)} - ${mentionSlackTeam('core-ems')}
    • ${slackLink("Ops Issues", `https://github.com/${owner}/metabase-ops/issues`)} - ${mentionSlackTeam('successengineers')}
    • ${slackLink("Docs Update", `https://github.com/${owner}/metabase.github.io/pulls`)} - ${mentionSlackTeam('tech-writers')}


### PR DESCRIPTION
see [discussion](https://metaboat.slack.com/archives/C864UT5CZ/p1718366743663999?thread_ts=1718035009.872769&cid=C864UT5CZ)

### Description

Writers, rather than product marketing, is now going to be responsible for release notes, so let's tag the correct group in slack.


