### PR TITLE
make enable-query-caching setting work

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/cache/cache_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cache/cache_test.clj
@@ -2,7 +2,6 @@
   (:require
    [clojure.test :refer :all]
    [java-time.api :as t]
-   [metabase.public-settings :as public-settings]
    [metabase.query-processor.card :as qp.card]
    [metabase.test :as mt]
    [metabase.util :as u]
@@ -14,144 +13,140 @@
                  {:order-by [[:id :desc]]}))
 
 (deftest cache-config-test
-  (mt/discard-setting-changes [enable-query-caching]
-    (public-settings/enable-query-caching! true)
-    (mt/with-model-cleanup [:model/CacheConfig]
-      (testing "Caching API"
-        (mt/with-premium-features #{:cache-granular-controls :audit-app}
-          (mt/with-temp [:model/Database      db     {}
-                         :model/Collection    col1   {:name "col1"}
-                         :model/Dashboard     dash1  {:name          "dash1"
-                                                      :collection_id (:id col1)}
-                         :model/Card          card1  {:name          "card1"
-                                                      :database_id   (:id db)
-                                                      :collection_id (:id col1)}
-                         :model/Card          card2  {:name          "card2"
-                                                      :database_id   (:id db)
-                                                      :collection_id (:id col1)}
-                         :model/Card          card3  {:name "card3"}]
+  (mt/with-model-cleanup [:model/CacheConfig]
+    (testing "Caching API"
+      (mt/with-premium-features #{:cache-granular-controls :audit-app}
+        (mt/with-temp [:model/Database      db     {}
+                       :model/Collection    col1   {:name "col1"}
+                       :model/Dashboard     dash1  {:name          "dash1"
+                                                    :collection_id (:id col1)}
+                       :model/Card          card1  {:name          "card1"
+                                                    :database_id   (:id db)
+                                                    :collection_id (:id col1)}
+                       :model/Card          card2  {:name          "card2"
+                                                    :database_id   (:id db)
+                                                    :collection_id (:id col1)}
+                       :model/Card          card3  {:name "card3"}]
 
-            (testing "Access from regular users"
-              (testing "No general access"
-                (is (= "You don't have permissions to do that."
-                       (mt/user-http-request :rasta :get 403 "cache/"))))
-              (testing "But have access to a separate (accessible to them) entities"
-                (is (= {:data []}
-                       (mt/user-http-request :rasta :get 200 "cache/"
-                                             :model "question" :id (:id card1))))))
+          (testing "Access from regular users"
+            (testing "No general access"
+              (is (= "You don't have permissions to do that."
+                     (mt/user-http-request :rasta :get 403 "cache/"))))
+            (testing "But have access to a separate (accessible to them) entities"
+              (is (= {:data []}
+                     (mt/user-http-request :rasta :get 200 "cache/"
+                                           :model "question" :id (:id card1))))))
 
-            (testing "Can configure root"
-              (is (mt/user-http-request :crowberto :put 200 "cache/"
-                                        {:model    "root"
-                                         :model_id 0
-                                         :strategy {:type "nocache" :name "root"}}))
-              (is (=? {:data [{:model "root" :model_id 0}]}
-                      (mt/user-http-request :crowberto :get 200 "cache/"
-                                            :model "root")))
-              (testing "Is audited"
-                (is (=? {:topic    :cache-config-update
-                         :user_id  (:id (mt/fetch-user :crowberto))
-                         :model    "CacheConfig"
-                         :model_id int?
-                         :details  {:model     "root"
-                                    :model-id  0
-                                    ;; no check for old value in case you had something in appdb
-                                    :new-value {:strategy "nocache" :config {:name "root"}}}}
-                        (last-audit-event)))))
+          (testing "Can configure root"
+            (is (mt/user-http-request :crowberto :put 200 "cache/"
+                                      {:model    "root"
+                                       :model_id 0
+                                       :strategy {:type "nocache" :name "root"}}))
+            (is (=? {:data [{:model "root" :model_id 0}]}
+                    (mt/user-http-request :crowberto :get 200 "cache/"
+                                          :model "root")))
+            (testing "Is audited"
+              (is (=? {:topic    :cache-config-update
+                       :user_id  (:id (mt/fetch-user :crowberto))
+                       :model    "CacheConfig"
+                       :model_id int?
+                       :details  {:model     "root"
+                                  :model-id  0
+                                  ;; no check for old value in case you had something in appdb
+                                  :new-value {:strategy "nocache" :config {:name "root"}}}}
+                      (last-audit-event)))))
 
-            (testing "Can configure others"
-              (is (mt/user-http-request :crowberto :put 200 "cache/"
-                                        {:model    "database"
-                                         :model_id (:id db)
-                                         :strategy {:type "nocache" :name "db"}}))
-              (is (mt/user-http-request :crowberto :put 200 "cache/"
-                                        {:model    "dashboard"
-                                         :model_id (:id dash1)
-                                         :strategy {:type "nocache" :name "dash"}}))
-              (is (mt/user-http-request :crowberto :put 200 "cache/"
-                                        {:model    "question"
-                                         :model_id (:id card1)
-                                         :strategy {:type "nocache" :name "card1"}})))
+          (testing "Can configure others"
+            (is (mt/user-http-request :crowberto :put 200 "cache/"
+                                      {:model    "database"
+                                       :model_id (:id db)
+                                       :strategy {:type "nocache" :name "db"}}))
+            (is (mt/user-http-request :crowberto :put 200 "cache/"
+                                      {:model    "dashboard"
+                                       :model_id (:id dash1)
+                                       :strategy {:type "nocache" :name "dash"}}))
+            (is (mt/user-http-request :crowberto :put 200 "cache/"
+                                      {:model    "question"
+                                       :model_id (:id card1)
+                                       :strategy {:type "nocache" :name "card1"}})))
 
-            (testing "HTTP responds with correct listings"
-              (is (=? {:data [{:model "root" :model_id 0}]}
-                      (mt/user-http-request :crowberto :get 200 "cache/")))
-              (is (=? {:data [{:model "database" :model_id (:id db)}]}
+          (testing "HTTP responds with correct listings"
+            (is (=? {:data [{:model "root" :model_id 0}]}
+                    (mt/user-http-request :crowberto :get 200 "cache/")))
+            (is (=? {:data [{:model "database" :model_id (:id db)}]}
+                    (mt/user-http-request :crowberto :get 200 "cache/" {}
+                                          :model :database)))
+            (is (=? {:data [{:model "dashboard" :model_id (:id dash1)}
+                            {:model "question" :model_id (:id card1)}]}
+                    (mt/user-http-request :crowberto :get 200 "cache/" {}
+                                          :collection (:id col1) :model :dashboard :model :question))))
+
+          (testing "We select correct config for something from a db"
+            (testing "First card has own config"
+              (is (=? {:type :nocache :name "card1"}
+                      (:cache-strategy (#'qp.card/query-for-card card1 {} {} {} {}))))
+              (is (=? {:type :nocache :name "card1"}
+                      (:cache-strategy (#'qp.card/query-for-card card1 {} {} {} {:dashboard-id (u/the-id dash1)})))))
+            (testing "Second card should hit database or dashboard cache"
+              (is (=? {:type :nocache :name "db"}
+                      (:cache-strategy (#'qp.card/query-for-card card2 {} {} {} {}))))
+              (is (=? {:type :nocache :name "dash"}
+                      (:cache-strategy (#'qp.card/query-for-card card2 {} {} {} {:dashboard-id (u/the-id dash1)})))))
+            (testing "Third card targets other db and gets root config"
+              (is (=? {:type :nocache :name "root"}
+                      (:cache-strategy (#'qp.card/query-for-card card3 {} {} {} {}))))))
+
+          (testing "It's possible to delete a configuration"
+            (is (nil? (mt/user-http-request :crowberto :delete 204 "cache/"
+                                            {:model    "database"
+                                             :model_id (:id db)})))
+            (testing "Listing for databases becomes empty"
+              (is (=? {:data []}
                       (mt/user-http-request :crowberto :get 200 "cache/" {}
-                                            :model :database)))
-              (is (=? {:data [{:model "dashboard" :model_id (:id dash1)}
-                              {:model "question" :model_id (:id card1)}]}
-                      (mt/user-http-request :crowberto :get 200 "cache/" {}
-                                            :collection (:id col1) :model :dashboard :model :question))))
+                                            :model :database))))
+            (testing "And card2 gets root config"
+              (is (=? {:type :nocache :name "root"}
+                      (:cache-strategy (#'qp.card/query-for-card card2 {} {} {} {}))))))
 
-            (testing "We select correct config for something from a db"
-              (testing "First card has own config"
-                (is (=? {:type :nocache :name "card1"}
-                        (:cache-strategy (#'qp.card/query-for-card card1 {} {} {} {}))))
-                (is (=? {:type :nocache :name "card1"}
-                        (:cache-strategy (#'qp.card/query-for-card card1 {} {} {} {:dashboard-id (u/the-id dash1)})))))
-              (testing "Second card should hit database or dashboard cache"
-                (is (=? {:type :nocache :name "db"}
-                        (:cache-strategy (#'qp.card/query-for-card card2 {} {} {} {}))))
-                (is (=? {:type :nocache :name "dash"}
-                        (:cache-strategy (#'qp.card/query-for-card card2 {} {} {} {:dashboard-id (u/the-id dash1)})))))
-              (testing "Third card targets other db and gets root config"
-                (is (=? {:type :nocache :name "root"}
-                        (:cache-strategy (#'qp.card/query-for-card card3 {} {} {} {}))))))
-
-            (testing "It's possible to delete a configuration"
-              (is (nil? (mt/user-http-request :crowberto :delete 204 "cache/"
-                                              {:model    "database"
-                                               :model_id (:id db)})))
-              (testing "Listing for databases becomes empty"
-                (is (=? {:data []}
-                        (mt/user-http-request :crowberto :get 200 "cache/" {}
-                                              :model :database))))
-              (testing "And card2 gets root config"
-                (is (=? {:type :nocache :name "root"}
-                        (:cache-strategy (#'qp.card/query-for-card card2 {} {} {} {}))))))
-
-            (testing "It's possible to use advanced cache strategies"
-              (is (mt/user-http-request :crowberto :put 200 "cache/"
-                                        {:model    "root"
-                                         :model_id 0
-                                         :strategy {:type     "schedule"
-                                                    :schedule "0/2 * * * * ?"}})))))))))
+          (testing "It's possible to use advanced cache strategies"
+            (is (mt/user-http-request :crowberto :put 200 "cache/"
+                                      {:model    "root"
+                                       :model_id 0
+                                       :strategy {:type     "schedule"
+                                                  :schedule "0/2 * * * * ?"}}))))))))
 
 (deftest invalidation-test
-  (mt/discard-setting-changes [enable-query-caching]
-    (public-settings/enable-query-caching! true)
-    (mt/with-model-cleanup [:model/CacheConfig
-                            [:model/QueryCache :updated_at]]
-      (mt/with-premium-features #{:cache-granular-controls :audit-app}
-        (mt/with-temp [:model/Dashboard     dash           {}
-                       :model/Card          {card1-id :id} {:database_id   (mt/id)
-                                                            :dataset_query (mt/mbql-query venues {:order-by [[:asc $id]]
-                                                                                                  :limit    5})}
-                       :model/Card          {card2-id :id} {:database_id   (mt/id)
-                                                            :dataset_query (mt/mbql-query venues {:order-by [[:asc $id]]
-                                                                                                  :limit    5})}
-                       :model/DashboardCard _              {:dashboard_id (:id dash)
-                                                            :card_id      card1-id}
-                       :model/CacheConfig   _              {:model          "database"
-                                                            :model_id       (mt/id)
-                                                            :strategy       "schedule"
-                                                            :config         {:schedule "0 * * * * ?"}
-                                                            :invalidated_at (t/offset-date-time)}
-                       :model/CacheConfig   _              {:model          "dashboard"
-                                                            :model_id       (:id dash)
-                                                            :strategy       "schedule"
-                                                            :config         {:schedule "0 * * * * ?"}
-                                                            :invalidated_at (t/offset-date-time)}]
-          (let [run-query! (fn [card-id & params]
-                             (-> (apply mt/user-http-request :crowberto :post 202 (format "card/%d/query" card-id) params)
-                                 (select-keys [:cached])))
-                invalidate! (fn [status & args]
-                              (apply mt/user-http-request :crowberto :post status "cache/invalidate" args))]
+  (mt/with-model-cleanup [:model/CacheConfig
+                          [:model/QueryCache :updated_at]]
+    (mt/with-premium-features #{:cache-granular-controls :audit-app}
+      (mt/with-temp [:model/Dashboard     dash           {}
+                     :model/Card          {card1-id :id} {:database_id   (mt/id)
+                                                          :dataset_query (mt/mbql-query venues {:order-by [[:asc $id]]
+                                                                                                :limit    5})}
+                     :model/Card          {card2-id :id} {:database_id   (mt/id)
+                                                          :dataset_query (mt/mbql-query venues {:order-by [[:asc $id]]
+                                                                                                :limit    5})}
+                     :model/DashboardCard _              {:dashboard_id (:id dash)
+                                                          :card_id      card1-id}
+                     :model/CacheConfig   _              {:model          "database"
+                                                          :model_id       (mt/id)
+                                                          :strategy       "schedule"
+                                                          :config         {:schedule "0 * * * * ?"}
+                                                          :invalidated_at (t/offset-date-time)}
+                     :model/CacheConfig   _              {:model          "dashboard"
+                                                          :model_id       (:id dash)
+                                                          :strategy       "schedule"
+                                                          :config         {:schedule "0 * * * * ?"}
+                                                          :invalidated_at (t/offset-date-time)}]
+        (let [run-query!  (fn [card-id & params]
+                           (-> (apply mt/user-http-request :crowberto :post 202 (format "card/%d/query" card-id) params)
+                               (select-keys [:cached])))
+              invalidate! (fn [status & args]
+                            (apply mt/user-http-request :crowberto :post status "cache/invalidate" args))]
 
-            (is (=? {:data [{:model "database" :model_id (mt/id)}]}
-                    (mt/user-http-request :crowberto :get 200 "cache/"
-                                          :model "database")))
+          (is (=? {:data [{:model "database" :model_id (mt/id)}]}
+                  (mt/user-http-request :crowberto :get 200 "cache/"
+                                        :model "database")))
 
             (testing "making a query will cache it"
               (is (=? {:cached nil :data some?}
@@ -187,4 +182,4 @@
               (is (=? {:count pos-int?}
                       (invalidate! 200 :include :overrides :database (mt/id))))
               (is (=? {:cached nil :data some?}
-                      (run-query! card1-id {:dashboard_id (:id dash)}))))))))))
+                      (run-query! card1-id {:dashboard_id (:id dash)})))))))))

--- a/enterprise/backend/test/metabase_enterprise/cache/strategies_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cache/strategies_test.clj
@@ -5,7 +5,6 @@
    [metabase-enterprise.cache.strategies :as strategies]
    [metabase-enterprise.task.cache :as task.cache]
    [metabase.models.query :as query]
-   [metabase.public-settings :as public-settings]
    [metabase.query-processor :as qp]
    [metabase.query-processor.card :as qp.card]
    [metabase.test :as mt]
@@ -16,238 +15,234 @@
 
 (deftest caching-strategies
   (mt/with-empty-h2-app-db
-    (mt/discard-setting-changes [enable-query-caching]
-      (public-settings/enable-query-caching! true)
-      (mt/with-premium-features #{:cache-granular-controls}
+    (mt/with-premium-features #{:cache-granular-controls}
 
-        (let [query (mt/mbql-query venues {:order-by [[:asc $id]] :limit 5})
-              mkres (fn [input]
-                      {:cache/details (if input
-                                        {:cached true, :updated_at input, :hash some?}
-                                        {:stored true, :hash some?})
-                       :row_count     5
-                       :status        :completed})]
-          (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
-            (testing "strategy = ttl"
-              (let [query (assoc query :cache-strategy {:type             :ttl
-                                                        :multiplier       10
-                                                        :min-duration-ms  0
-                                                        :avg-execution-ms 500})]
-                (testing "Results are stored and available immediately"
-                  (mt/with-clock #t "2024-02-13T10:00:00Z"
-                    (is (=? (mkres nil)
-                            (-> (qp/process-query query) (dissoc :data))))
-                    (is (=? (mkres #t "2024-02-13T10:00:00Z")
-                            (-> (qp/process-query query) (dissoc :data))))))
-                (testing "4 seconds past that results are still there - 10 * 500 = 5 seconds"
-                  (mt/with-clock #t "2024-02-13T10:00:04Z"
-                    (is (=? (mkres #t "2024-02-13T10:00:00Z")
-                            (-> (qp/process-query query) (dissoc :data))))))
-                (testing "6 seconds later results are unavailable"
-                  (mt/with-clock #t "2024-02-13T10:00:06Z"
-                    (is (=? (mkres nil)
-                            (-> (qp/process-query query) (dissoc :data)))))))))
+      (let [query (mt/mbql-query venues {:order-by [[:asc $id]] :limit 5})
+            mkres (fn [input]
+                    {:cache/details (if input
+                                      {:cached true, :updated_at input, :hash some?}
+                                      {:stored true, :hash some?})
+                     :row_count     5
+                     :status        :completed})]
+        (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
+          (testing "strategy = ttl"
+            (let [query (assoc query :cache-strategy {:type             :ttl
+                                                      :multiplier       10
+                                                      :min-duration-ms  0
+                                                      :avg-execution-ms 500})]
+              (testing "Results are stored and available immediately"
+                (mt/with-clock #t "2024-02-13T10:00:00Z"
+                  (is (=? (mkres nil)
+                          (-> (qp/process-query query) (dissoc :data))))
+                  (is (=? (mkres #t "2024-02-13T10:00:00Z")
+                          (-> (qp/process-query query) (dissoc :data))))))
+              (testing "4 seconds past that results are still there - 10 * 500 = 5 seconds"
+                (mt/with-clock #t "2024-02-13T10:00:04Z"
+                  (is (=? (mkres #t "2024-02-13T10:00:00Z")
+                          (-> (qp/process-query query) (dissoc :data))))))
+              (testing "6 seconds later results are unavailable"
+                (mt/with-clock #t "2024-02-13T10:00:06Z"
+                  (is (=? (mkres nil)
+                          (-> (qp/process-query query) (dissoc :data)))))))))
 
-          (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
-            (testing "strategy = duration"
-              (let [query (assoc query :cache-strategy {:type            :duration
-                                                        :duration        1
-                                                        :unit            "minutes"
-                                                        :min-duration-ms 0})]
-                (testing "Results are stored and available immediately"
-                  (mt/with-clock #t "2024-02-13T10:00:00Z"
-                    (is (=? (mkres nil)
-                            (-> (qp/process-query query) (dissoc :data))))
-                    (is (=? (mkres #t "2024-02-13T10:00:00Z")
-                            (-> (qp/process-query query) (dissoc :data)))))
-                  (mt/with-clock #t "2024-02-13T10:00:59Z"
-                    (is (=? (mkres #t "2024-02-13T10:00:00Z")
-                            (-> (qp/process-query query) (dissoc :data)))))
-                  (mt/with-clock #t "2024-02-13T10:01:01Z"
-                    (is (=? (mkres nil)
-                            (-> (qp/process-query query) (dissoc :data)))))))))
+        (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
+          (testing "strategy = duration"
+            (let [query (assoc query :cache-strategy {:type            :duration
+                                                      :duration        1
+                                                      :unit            "minutes"
+                                                      :min-duration-ms 0})]
+              (testing "Results are stored and available immediately"
+                (mt/with-clock #t "2024-02-13T10:00:00Z"
+                  (is (=? (mkres nil)
+                          (-> (qp/process-query query) (dissoc :data))))
+                  (is (=? (mkres #t "2024-02-13T10:00:00Z")
+                          (-> (qp/process-query query) (dissoc :data)))))
+                (mt/with-clock #t "2024-02-13T10:00:59Z"
+                  (is (=? (mkres #t "2024-02-13T10:00:00Z")
+                          (-> (qp/process-query query) (dissoc :data)))))
+                (mt/with-clock #t "2024-02-13T10:01:01Z"
+                  (is (=? (mkres nil)
+                          (-> (qp/process-query query) (dissoc :data)))))))))
 
-          (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
-            (testing "strategy = schedule"
-              (let [query (assoc query :cache-strategy {:type           :schedule
-                                                        :schedule       "0/2 * * * *"
-                                                        :invalidated-at (t/offset-date-time #t "2024-02-13T10:00:00Z")})]
-                (testing "Results are stored and available immediately"
-                  (mt/with-clock #t "2024-02-13T10:01:00Z"
+        (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
+          (testing "strategy = schedule"
+            (let [query (assoc query :cache-strategy {:type           :schedule
+                                                      :schedule       "0/2 * * * *"
+                                                      :invalidated-at (t/offset-date-time #t "2024-02-13T10:00:00Z")})]
+              (testing "Results are stored and available immediately"
+                (mt/with-clock #t "2024-02-13T10:01:00Z"
+                  (is (=? (mkres nil)
+                          (-> (qp/process-query query) (dissoc :data))))
+                  (is (=? (mkres #t "2024-02-13T10:01:00Z")
+                          (-> (qp/process-query query) (dissoc :data))))))
+              (let [query (assoc-in query [:cache-strategy :invalidated-at] (t/offset-date-time #t "2024-02-13T10:02:00Z"))]
+                (testing "Cache is invalidated when schedule ran after the query"
+                  (mt/with-clock #t "2024-02-13T10:03:00Z"
                     (is (=? (mkres nil)
-                            (-> (qp/process-query query) (dissoc :data))))
-                    (is (=? (mkres #t "2024-02-13T10:01:00Z")
                             (-> (qp/process-query query) (dissoc :data))))))
-                (let [query (assoc-in query [:cache-strategy :invalidated-at] (t/offset-date-time #t "2024-02-13T10:02:00Z"))]
-                  (testing "Cache is invalidated when schedule ran after the query"
-                    (mt/with-clock #t "2024-02-13T10:03:00Z"
-                      (is (=? (mkres nil)
-                              (-> (qp/process-query query) (dissoc :data))))))
-                  (testing "schedule did not run - cache is still intact"
-                    (mt/with-clock #t "2024-02-13T10:08:00Z"
-                      (is (=? (mkres #t "2024-02-13T10:03:00Z")
-                              (-> (qp/process-query query) (dissoc :data))))))))))
+                (testing "schedule did not run - cache is still intact"
+                  (mt/with-clock #t "2024-02-13T10:08:00Z"
+                    (is (=? (mkres #t "2024-02-13T10:03:00Z")
+                            (-> (qp/process-query query) (dissoc :data))))))))))
 
-          (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
-            (testing "strategy = query"
-              (let [query (assoc query :cache-strategy {:type           :query
-                                                        :field_id       0
-                                                        :aggregation    "max"
-                                                        :schedule       "0/2 * * * *"
-                                                        :invalidated-at (t/offset-date-time #t "2024-02-13T11:00:00Z")})]
-                (testing "Results are stored and available immediately"
-                  (mt/with-clock #t "2024-02-13T11:01:00Z"
+        (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
+          (testing "strategy = query"
+            (let [query (assoc query :cache-strategy {:type           :query
+                                                      :field_id       0
+                                                      :aggregation    "max"
+                                                      :schedule       "0/2 * * * *"
+                                                      :invalidated-at (t/offset-date-time #t "2024-02-13T11:00:00Z")})]
+              (testing "Results are stored and available immediately"
+                (mt/with-clock #t "2024-02-13T11:01:00Z"
+                  (is (=? (mkres nil)
+                          (-> (qp/process-query query) (dissoc :data))))
+                  (is (=? (mkres #t "2024-02-13T11:01:00Z")
+                          (-> (qp/process-query query) (dissoc :data))))))
+              (let [query (assoc-in query [:cache-strategy :invalidated-at] (t/offset-date-time #t "2024-02-13T11:02:00Z"))]
+                (testing "Cache is invalidated when schedule ran after the query"
+                  (mt/with-clock #t "2024-02-13T11:03:00Z"
                     (is (=? (mkres nil)
-                            (-> (qp/process-query query) (dissoc :data))))
-                    (is (=? (mkres #t "2024-02-13T11:01:00Z")
                             (-> (qp/process-query query) (dissoc :data))))))
-                (let [query (assoc-in query [:cache-strategy :invalidated-at] (t/offset-date-time #t "2024-02-13T11:02:00Z"))]
-                  (testing "Cache is invalidated when schedule ran after the query"
-                    (mt/with-clock #t "2024-02-13T11:03:00Z"
-                      (is (=? (mkres nil)
-                              (-> (qp/process-query query) (dissoc :data))))))
-                  (testing "schedule did not run - cache is still intact"
-                    (mt/with-clock #t "2024-02-13T11:08:00Z"
-                      (is (=? (mkres #t "2024-02-13T11:03:00Z")
-                              (-> (qp/process-query query) (dissoc :data)))))))))))))))
+                (testing "schedule did not run - cache is still intact"
+                  (mt/with-clock #t "2024-02-13T11:08:00Z"
+                    (is (=? (mkres #t "2024-02-13T11:03:00Z")
+                            (-> (qp/process-query query) (dissoc :data))))))))))))))
 
 (deftest e2e-advanced-caching
   (mt/with-empty-h2-app-db
-    (mt/discard-setting-changes [enable-query-caching]
-      (public-settings/enable-query-caching! true)
-      (mt/with-premium-features #{:cache-granular-controls}
-        (mt/dataset (mt/dataset-definition "caching1"
-                                           ["table"
-                                            [{:field-name "value" :indexed? true :base-type :type/Text}]
-                                            [["a"] ["b"] ["c"]]])
-          (mt/with-temp [:model/Card       card1 {:dataset_query (mt/mbql-query table)}
-                         :model/Card       card2 {:dataset_query (mt/mbql-query table)}
-                         :model/Card       card3 {:dataset_query (mt/mbql-query table)}
-                         :model/Card       card4 {:dataset_query (mt/mbql-query table)}
-                         :model/Card       card5 {:dataset_query (mt/mbql-query table)}
+    (mt/with-premium-features #{:cache-granular-controls}
+      (mt/dataset (mt/dataset-definition "caching1"
+                                         ["table"
+                                          [{:field-name "value" :indexed? true :base-type :type/Text}]
+                                          [["a"] ["b"] ["c"]]])
+        (mt/with-temp [:model/Card       card1 {:dataset_query (mt/mbql-query table)}
+                       :model/Card       card2 {:dataset_query (mt/mbql-query table)}
+                       :model/Card       card3 {:dataset_query (mt/mbql-query table)}
+                       :model/Card       card4 {:dataset_query (mt/mbql-query table)}
+                       :model/Card       card5 {:dataset_query (mt/mbql-query table)}
 
-                         :model/CacheConfig _cr {:model    "root"
-                                                 :model_id 0
-                                                 :strategy :ttl
-                                                 :config   {:multiplier      200
-                                                            :min_duration_ms 10}}
-                         :model/CacheConfig _c1 {:model    "question"
-                                                 :model_id (:id card1)
-                                                 :strategy :ttl
-                                                 :config   {:multiplier      100
-                                                            :min_duration_ms 0}}
-                         :model/CacheConfig _c2 {:model    "question"
-                                                 :model_id (:id card2)
-                                                 :strategy :duration
-                                                 :config   {:duration 1
-                                                            :unit     "minutes"}}
-                         :model/CacheConfig _c3 {:model    "question"
-                                                 :model_id (:id card3)
-                                                 :strategy :schedule
-                                                 :config   {:schedule "0 0/2 * * * ? *"}}
-                         :model/CacheConfig c4  {:model    "question"
-                                                 :model_id (:id card4)
-                                                 :strategy :query
-                                                 :config   {:field_id    (mt/id :table :id)
-                                                            :aggregation "max"
-                                                            :schedule    "0 0/2 * * * ? *"}}]
-            (let [t     (fn [seconds]
-                          (t/plus #t "2024-02-13T10:00:00Z" (t/duration seconds :seconds)))
-                  mkres (fn [input]
-                          {:cache/details (if input
-                                            {:cached true, :updated_at input, :hash some?}
-                                            {:stored true, :hash some?})
-                           :row_count     3
-                           :status        :completed})]
-              (testing "strategy = ttl"
-                (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
-                  (mt/with-clock (t 0)
-                    (let [q (with-redefs [query/average-execution-time-ms (constantly 1000)]
-                              (#'qp.card/query-for-card card1 [] {} {} {}))]
-                      (is (=? {:type :ttl :multiplier 100}
-                              (:cache-strategy q)))
-                      (is (=? (mkres nil)
-                              (-> (qp/process-query q) (dissoc :data))))
-                      (testing "There is cache on second call"
-                        (is (=? (mkres (t 0))
-                                (-> (qp/process-query q) (dissoc :data)))))
-                      (testing "No cache after expiration"
-                        (mt/with-clock (t 101) ;; avg execution time 1s * multiplier 100 + 1
-                          (is (=? (mkres nil)
-                                  (-> (qp/process-query q) (dissoc :data))))))))))
-
-              (testing "strategy = duration"
-                (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
-                  (mt/with-clock (t 0)
-                    (let [q (#'qp.card/query-for-card card2 [] {} {} {})]
-                      (is (=? {:type :duration}
-                              (:cache-strategy q)))
-                      (is (=? (mkres nil)
-                              (-> (qp/process-query q) (dissoc :data))))
-                      (testing "There is cache on the next call"
-                        (is (=? (mkres (t 0))
-                                (-> (qp/process-query q) (dissoc :data)))))
-                      (testing "No cache after expiration"
-                        (mt/with-clock (t 61)
-                          (is (=? (mkres nil)
-                                  (-> (qp/process-query q) (dissoc :data))))))))))
-
-              (testing "strategy = schedule"
-                (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
-                  (mt/with-clock (t 0)
-                    (is (pos? (#'task.cache/refresh-schedule-configs!)))
-                    (let [q (#'qp.card/query-for-card card3 [] {} {} {})]
-                      (is (=? {:type :schedule}
-                              (:cache-strategy q)))
-                      (is (=? (mkres nil)
-                              (-> (qp/process-query q) (dissoc :data))))
-                      (testing "There is cache on second call"
-                        (is (=? (mkres (t 0))
-                                (-> (qp/process-query q) (dissoc :data)))))))
-                  (testing "No cache after job ran again"
-                    (mt/with-clock (t 121)
-                      (is (pos? (#'task.cache/refresh-schedule-configs!)))
-                      (let [q (#'qp.card/query-for-card card3 {} {} {} {})]
+                       :model/CacheConfig _cr {:model    "root"
+                                               :model_id 0
+                                               :strategy :ttl
+                                               :config   {:multiplier      200
+                                                          :min_duration_ms 10}}
+                       :model/CacheConfig _c1 {:model    "question"
+                                               :model_id (:id card1)
+                                               :strategy :ttl
+                                               :config   {:multiplier      100
+                                                          :min_duration_ms 0}}
+                       :model/CacheConfig _c2 {:model    "question"
+                                               :model_id (:id card2)
+                                               :strategy :duration
+                                               :config   {:duration 1
+                                                          :unit     "minutes"}}
+                       :model/CacheConfig _c3 {:model    "question"
+                                               :model_id (:id card3)
+                                               :strategy :schedule
+                                               :config   {:schedule "0 0/2 * * * ? *"}}
+                       :model/CacheConfig c4  {:model    "question"
+                                               :model_id (:id card4)
+                                               :strategy :query
+                                               :config   {:field_id    (mt/id :table :id)
+                                                          :aggregation "max"
+                                                          :schedule    "0 0/2 * * * ? *"}}]
+          (let [t     (fn [seconds]
+                        (t/plus #t "2024-02-13T10:00:00Z" (t/duration seconds :seconds)))
+                mkres (fn [input]
+                        {:cache/details (if input
+                                          {:cached true, :updated_at input, :hash some?}
+                                          {:stored true, :hash some?})
+                         :row_count     3
+                         :status        :completed})]
+            (testing "strategy = ttl"
+              (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
+                (mt/with-clock (t 0)
+                  (let [q (with-redefs [query/average-execution-time-ms (constantly 1000)]
+                            (#'qp.card/query-for-card card1 [] {} {} {}))]
+                    (is (=? {:type :ttl :multiplier 100}
+                            (:cache-strategy q)))
+                    (is (=? (mkres nil)
+                            (-> (qp/process-query q) (dissoc :data))))
+                    (testing "There is cache on second call"
+                      (is (=? (mkres (t 0))
+                              (-> (qp/process-query q) (dissoc :data)))))
+                    (testing "No cache after expiration"
+                      (mt/with-clock (t 101) ;; avg execution time 1s * multiplier 100 + 1
                         (is (=? (mkres nil)
-                                (-> (qp/process-query q) (dissoc :data)))))))))
+                                (-> (qp/process-query q) (dissoc :data))))))))))
 
-              (testing "strategy = query"
-                (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
-                  (mt/with-clock (t 0)
-                    (is (pos? (#'task.cache/refresh-query-configs!)))
-                    (let [q (#'qp.card/query-for-card card4 [] {} {} {})]
-                      (is (=? {:type :query}
-                              (:cache-strategy q)))
-                      (is (=? (mkres nil)
-                              (-> (qp/process-query q) (dissoc :data))))
-                      (testing "There is cache on second call"
-                        (is (= 1 (count (t2/select :model/QueryCache))))
-                        (is (=? (mkres (t 0))
-                                (-> (qp/process-query q) (dissoc :data)))))))
+            (testing "strategy = duration"
+              (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
+                (mt/with-clock (t 0)
+                  (let [q (#'qp.card/query-for-card card2 [] {} {} {})]
+                    (is (=? {:type :duration}
+                            (:cache-strategy q)))
+                    (is (=? (mkres nil)
+                            (-> (qp/process-query q) (dissoc :data))))
+                    (testing "There is cache on the next call"
+                      (is (=? (mkres (t 0))
+                              (-> (qp/process-query q) (dissoc :data)))))
+                    (testing "No cache after expiration"
+                      (mt/with-clock (t 61)
+                        (is (=? (mkres nil)
+                                (-> (qp/process-query q) (dissoc :data))))))))))
 
+            (testing "strategy = schedule"
+              (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
+                (mt/with-clock (t 0)
+                  (is (pos? (#'task.cache/refresh-schedule-configs!)))
+                  (let [q (#'qp.card/query-for-card card3 [] {} {} {})]
+                    (is (=? {:type :schedule}
+                            (:cache-strategy q)))
+                    (is (=? (mkres nil)
+                            (-> (qp/process-query q) (dissoc :data))))
+                    (testing "There is cache on second call"
+                      (is (=? (mkres (t 0))
+                              (-> (qp/process-query q) (dissoc :data)))))))
+                (testing "No cache after job ran again"
                   (mt/with-clock (t 121)
+                    (is (pos? (#'task.cache/refresh-schedule-configs!)))
+                    (let [q (#'qp.card/query-for-card card3 {} {} {} {})]
+                      (is (=? (mkres nil)
+                              (-> (qp/process-query q) (dissoc :data)))))))))
+
+            (testing "strategy = query"
+              (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
+                (mt/with-clock (t 0)
+                  (is (pos? (#'task.cache/refresh-query-configs!)))
+                  (let [q (#'qp.card/query-for-card card4 [] {} {} {})]
+                    (is (=? {:type :query}
+                            (:cache-strategy q)))
+                    (is (=? (mkres nil)
+                            (-> (qp/process-query q) (dissoc :data))))
+                    (testing "There is cache on second call"
+                      (is (= 1 (count (t2/select :model/QueryCache))))
+                      (is (=? (mkres (t 0))
+                              (-> (qp/process-query q) (dissoc :data)))))))
+
+                (mt/with-clock (t 121)
+                  (is (pos? (#'task.cache/refresh-query-configs!)))
+                  (testing "Nothing to run, because it's already scheduled for later"
+                    (is (nil? (#'task.cache/refresh-query-configs!))))
+                  (testing "Job ran again, but state has not changed, so there's still cache"
+                    (let [q (#'qp.card/query-for-card card4 {} {} {} {})]
+                      (is (=? (mkres (t 0))
+                              (-> (qp/process-query q) (dissoc :data)))))))
+
+                (mt/with-clock (t 242)
+                  (let [state (:state (t2/select-one :model/CacheConfig :id (:id c4)))]
+                    (t2/update! :model/CacheConfig {:id (:id c4)} {:config (assoc (:config c4)
+                                                                                  :field_id (mt/id :table :value))})
                     (is (pos? (#'task.cache/refresh-query-configs!)))
-                    (testing "Nothing to run, because it's already scheduled for later"
-                      (is (nil? (#'task.cache/refresh-query-configs!))))
-                    (testing "Job ran again, but state has not changed, so there's still cache"
-                      (let [q (#'qp.card/query-for-card card4 {} {} {} {})]
-                        (is (=? (mkres (t 0))
-                                (-> (qp/process-query q) (dissoc :data)))))))
+                    (testing "Marker has changed"
+                      (is (not= state
+                                (:state (t2/select-one :model/CacheConfig :id (:id c4)))))))
+                  (testing "No cache after the data has changed"
+                    (let [q (#'qp.card/query-for-card card4 {} {} {} {})]
+                      (is (=? (mkres nil)
+                              (-> (qp/process-query q) (dissoc :data)))))))))
 
-                  (mt/with-clock (t 242)
-                    (let [state (:state (t2/select-one :model/CacheConfig :id (:id c4)))]
-                      (t2/update! :model/CacheConfig {:id (:id c4)} {:config (assoc (:config c4)
-                                                                                    :field_id (mt/id :table :value))})
-                      (is (pos? (#'task.cache/refresh-query-configs!)))
-                      (testing "Marker has changed"
-                        (is (not= state
-                                  (:state (t2/select-one :model/CacheConfig :id (:id c4)))))))
-                    (testing "No cache after the data has changed"
-                      (let [q (#'qp.card/query-for-card card4 {} {} {} {})]
-                        (is (=? (mkres nil)
-                                (-> (qp/process-query q) (dissoc :data)))))))))
-
-              (testing "default strategy = ttl"
-                (let [q (#'qp.card/query-for-card card5 [] {} {} {})]
-                  (is (=? {:type :ttl :multiplier 200}
-                          (:cache-strategy q))))))))))))
+            (testing "default strategy = ttl"
+              (let [q (#'qp.card/query-for-card card5 [] {} {} {})]
+                (is (=? {:type :ttl :multiplier 200}
+                        (:cache-strategy q)))))))))))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
@@ -1062,19 +1062,18 @@
                                                                                         :min-duration-ms  0}))]
                             {:cached?  (boolean (:cached (:cache/details results)))
                              :num-rows (count (mt/rows results))}))]
-          (mt/with-temporary-setting-values [enable-query-caching true]
-            (testing "Make sure the underlying card for the GTAP returns cached results without sandboxing"
-              (mt/with-current-user nil
-                (testing "First run -- should not be cached"
-                  (is (= {:cached? false, :num-rows 5}
-                         (run-query))))
-                (testing "Should be cached by now"
-                  (is (= {:cached? true, :num-rows 5}
-                         (run-query))))))
-            (testing "Ok, now try to access the Table that is sandboxed by the cached Card"
-              ;; this should *NOT* be cached because we're generating a nested query with sandboxing in play.
-              (is (= {:cached? false, :num-rows 5}
-                     (run-query))))))))))
+          (testing "Make sure the underlying card for the GTAP returns cached results without sandboxing"
+            (mt/with-current-user nil
+              (testing "First run -- should not be cached"
+                (is (= {:cached? false, :num-rows 5}
+                       (run-query))))
+              (testing "Should be cached by now"
+                (is (= {:cached? true, :num-rows 5}
+                       (run-query))))))
+          (testing "Ok, now try to access the Table that is sandboxed by the cached Card"
+            ;; this should *NOT* be cached because we're generating a nested query with sandboxing in play.
+            (is (= {:cached? false, :num-rows 5}
+                   (run-query)))))))))
 
 (deftest persistence-disabled-when-sandboxed
   (mt/test-drivers (mt/normal-drivers-with-feature :persist-models)

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -262,9 +262,9 @@
   :audit      :getter)
 
 (defsetting enable-query-caching
-  (deferred-tru "Enabling caching will save the results of queries that take a long time to run.")
+  (deferred-tru "Allow caching results of queries that take a long time to run.")
   :type       :boolean
-  :default    false
+  :default    true
   :visibility :authenticated
   :audit      :getter)
 

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -1,11 +1,8 @@
 (ns metabase.query-processor.middleware.cache
   "Middleware that returns cached results for queries when applicable.
 
-  If caching is enabled (`enable-query-caching` is `true`) cached results will be returned for Cards if possible.
-  There's a global default TTL defined by the setting `query-caching-default-ttl`, but individual Cards can override
-  this value with custom TTLs with a value for `:cache_ttl`.
-
-  For all other queries, caching is skipped.
+  If query caching is enabled, cache strategy has been passed and it's not a `{:type :nocache}`, THEN cached results
+  will be returned for Cards if available or stored if applicable. For all other queries, caching is skipped.
 
   The default backend is `db`, which uses the application database; this value can be changed by setting the env var
   `MB_QP_CACHE_BACKEND`. Refer to [[metabase.query-processor.middleware.cache-backend.interface]] for more details
@@ -220,7 +217,8 @@
                 (save-results-xform start-time-ns metadata query-hash cache-strategy (rff metadata)))))))))
 
 (defn- is-cacheable? {:arglists '([query])} [{:keys [cache-strategy]}]
-  (and (some? cache-strategy)
+  (and (public-settings/enable-query-caching)
+       (some? cache-strategy)
        (not= (:type cache-strategy) :nocache)))
 
 (defn maybe-return-cached-results
@@ -229,6 +227,7 @@
 
      *  Caching (the `enable-query-caching` Setting) must be enabled
      *  The query must pass a `:cache-strategy` value
+     *  This strategy should not be of type `:nocache`
      *  The query must already be permissions-checked. Since the cache bypasses the normal
         query processor pipeline, the ad-hoc permissions-checking middleware isn't applied for cached results.
         (The various `/api/card/` endpoints that make use of caching do `can-read?` checks for the Card *before*

--- a/test/metabase/api/cache_test.clj
+++ b/test/metabase/api/cache_test.clj
@@ -1,37 +1,34 @@
 (ns metabase.api.cache-test
   (:require
    [clojure.test :refer :all]
-   [metabase.public-settings :as public-settings]
    [metabase.test :as mt]))
 
 ;; the other part is in `metabase-enterprise.cache.cache-test`
 (deftest cache-config-test
-  (mt/discard-setting-changes [enable-query-caching]
-    (public-settings/enable-query-caching! true)
-    (mt/with-model-cleanup [:model/CacheConfig]
-      (mt/with-premium-features #{}
-        (testing "Advanced caching requires premium token"
-          (is (= "Granular Caching is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/"
-                 (mt/user-http-request :crowberto :put 402 "cache/"
-                                       {:model    "question"
-                                        :model_id 123456789
-                                        :strategy {:type "nocache"}})))
-          (is (= "Granular Caching is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/"
-                 (mt/user-http-request :crowberto :get 402 "cache/"
-                                       :model "question"))))
-        (testing "Can operate on root settings though"
-          (is (mt/user-http-request :crowberto :put 200 "cache/"
-                                    {:model    "root"
-                                     :model_id 0
-                                     :strategy {:type "nocache"}}))
-          (is (=? {:data [{:model "root" :model_id 0}]}
-                  (mt/user-http-request :crowberto :get 200 "cache/"
-                                        :model "root")))
-          (is (nil? (mt/user-http-request :crowberto :delete 204 "cache/"
-                                          {:model "root" :model_id 0}))))
-        (testing "But no advanced strategies can be used"
-          (is (:errors (mt/user-http-request :crowberto :put 400 "cache/"
-                                             {:model    "root"
-                                              :model_id 0
-                                              :strategy {:type     "schedule"
-                                                         :schedule "0/2 * * * * ?"}}))))))))
+  (mt/with-model-cleanup [:model/CacheConfig]
+    (mt/with-premium-features #{}
+      (testing "Advanced caching requires premium token"
+        (is (= "Granular Caching is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/"
+               (mt/user-http-request :crowberto :put 402 "cache/"
+                                     {:model    "question"
+                                      :model_id 123456789
+                                      :strategy {:type "nocache"}})))
+        (is (= "Granular Caching is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/"
+               (mt/user-http-request :crowberto :get 402 "cache/"
+                                     :model "question"))))
+      (testing "Can operate on root settings though"
+        (is (mt/user-http-request :crowberto :put 200 "cache/"
+                                  {:model    "root"
+                                   :model_id 0
+                                   :strategy {:type "nocache"}}))
+        (is (=? {:data [{:model "root" :model_id 0}]}
+                (mt/user-http-request :crowberto :get 200 "cache/"
+                                      :model "root")))
+        (is (nil? (mt/user-http-request :crowberto :delete 204 "cache/"
+                                        {:model "root" :model_id 0}))))
+      (testing "But no advanced strategies can be used"
+        (is (:errors (mt/user-http-request :crowberto :put 400 "cache/"
+                                           {:model    "root"
+                                            :model_id 0
+                                            :strategy {:type     "schedule"
+                                                       :schedule "0/2 * * * * ?"}})))))))

--- a/test/metabase/query_processor/preprocess_test.clj
+++ b/test/metabase/query_processor/preprocess_test.clj
@@ -12,32 +12,31 @@
     ;; make a copy of the `test-data` DB so there will be no cache entries from previous test runs possibly affecting
     ;; this test.
     (mt/with-temp-copy-of-db
-      (mt/with-temporary-setting-values [enable-query-caching  true]
-        (let [query            (assoc (mt/mbql-query venues {:order-by [[:asc $id]], :limit 5})
-                                      :cache-strategy {:type             :ttl
-                                                       :multiplier       60
-                                                       :avg-execution-ms 100
-                                                       :min-duration-ms  0})
-              run-query        (fn []
-                                 (let [results (qp/process-query query)]
-                                   {:cached?  (boolean (:cached (:cache/details results)))
-                                    :num-rows (count (mt/rows results))}))
-              expected-results (qp.preprocess/preprocess query)]
-          (testing "Check preprocess before caching to make sure results make sense"
-            (is (=? {:database (mt/id)}
-                    expected-results)))
-          (testing "Run the query a few of times so we know it's cached"
-            (testing "first run"
-              (is (= {:cached?  false
-                      :num-rows 5}
-                     (run-query))))
-            (testing "should be cached now"
-              (is (= {:cached?  true
-                      :num-rows 5}
-                     (run-query))))
-            (testing "preprocess should return same results even when query was cached."
-              (is (= expected-results
-                     (qp.preprocess/preprocess query))))))))))
+      (let [query            (assoc (mt/mbql-query venues {:order-by [[:asc $id]], :limit 5})
+                                    :cache-strategy {:type             :ttl
+                                                     :multiplier       60
+                                                     :avg-execution-ms 100
+                                                     :min-duration-ms  0})
+            run-query        (fn []
+                               (let [results (qp/process-query query)]
+                                 {:cached?  (boolean (:cached (:cache/details results)))
+                                  :num-rows (count (mt/rows results))}))
+            expected-results (qp.preprocess/preprocess query)]
+        (testing "Check preprocess before caching to make sure results make sense"
+          (is (=? {:database (mt/id)}
+                  expected-results)))
+        (testing "Run the query a few of times so we know it's cached"
+          (testing "first run"
+            (is (= {:cached?  false
+                    :num-rows 5}
+                   (run-query))))
+          (testing "should be cached now"
+            (is (= {:cached?  true
+                    :num-rows 5}
+                   (run-query))))
+          (testing "preprocess should return same results even when query was cached."
+            (is (= expected-results
+                   (qp.preprocess/preprocess query)))))))))
 
 (driver/register! ::custom-escape-spaces-to-underscores :parent :h2)
 


### PR DESCRIPTION
I've removed it from tests (and added to one) since it defaults to true now, and made it actually used by code - so it can act as a kill switch for caching without thrashing your cache configuration.