### PR TITLE
Fix metabase lib returning the string "null" as the drill through value

### DIFF
--- a/src/metabase/lib/drill_thru/common.cljc
+++ b/src/metabase/lib/drill_thru/common.cljc
@@ -41,3 +41,8 @@
   "Does the source table for this `query` have more than one primary key?"
   [query]
   (> (count (lib.metadata.calculation/primary-keys query)) 1))
+
+(defn drill-value->js
+  "Convert a drill value to a JS value"
+  [value]
+  (if (= value :null) nil value))

--- a/src/metabase/lib/drill_thru/quick_filter.cljc
+++ b/src/metabase/lib/drill_thru/quick_filter.cljc
@@ -131,6 +131,7 @@
 (defmethod lib.drill-thru.common/drill-thru-info-method :drill-thru/quick-filter
   [_query _stage-number drill-thru]
   (-> (select-keys drill-thru [:type :operators :value])
+      (update :value lib.drill-thru.common/drill-value->js)
       (update :operators (fn [operators]
                            (mapv :name operators)))))
 

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -65,6 +65,7 @@
    [metabase.lib.cache :as lib.cache]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib.core]
+   [metabase.lib.drill-thru.common :as lib.drill-thru.common]
    [metabase.lib.equality :as lib.equality]
    [metabase.lib.expression :as lib.expression]
    [metabase.lib.field :as lib.field]
@@ -1968,7 +1969,7 @@
   #js {"column"     column
        "query"      a-query
        "stageIndex" stage-number
-       "value"      (if (= value :null) nil value)})
+       "value"      (lib.drill-thru.common/drill-value->js value)})
 
 (defn ^:export aggregation-drill-details
   "Returns a JS object with the details needed to render the complex UI for `compare-aggregation` drills.

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -369,6 +369,8 @@
   Recursively converts CLJS maps and sequences into JS objects and arrays."
   [x]
   (cond
+    ;; `(seqable? nil) ; => true`, so we need to check for it before
+    (nil? x)     nil
     ;; Note that map? is only true for CLJS maps, not JS objects.
     (map? x)     (display-info-map->js x)
     (string? x)  x

--- a/test/metabase/lib/drill_thru_test.cljc
+++ b/test/metabase/lib/drill_thru_test.cljc
@@ -5,6 +5,7 @@
    [malli.error :as me]
    [medley.core :as m]
    [metabase.lib.core :as lib]
+   [metabase.lib.drill-thru.common :as lib.drill-thru.common]
    [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]
    [metabase.lib.field :as-alias lib.field]
    [metabase.lib.schema :as lib.schema]
@@ -822,3 +823,15 @@
                        :initial-op {:short :=}}
                       {:type            :drill-thru/sort
                        :sort-directions [:asc :desc]}]})))
+
+(deftest ^:parallel drill-value->js-test
+  (testing "should convert :null to nil, but preserve all other values"
+    (doseq [[input expected] [[:null nil]
+                              [nil nil]
+                              [:foo :foo]
+                              ["foo" "foo"]
+                              [1 1]
+                              [[:a 1 {:b true}] [:a 1 {:b true}]]
+                              '((1 :null nil) '(1 :null nil))
+                              #{1 :null nil} #{1 :null nil}]]
+      (is (= expected (lib.drill-thru.common/drill-value->js input))))))

--- a/test/metabase/lib/drill_thru_test.cljc
+++ b/test/metabase/lib/drill_thru_test.cljc
@@ -825,13 +825,7 @@
                        :sort-directions [:asc :desc]}]})))
 
 (deftest ^:parallel drill-value->js-test
-  (testing "should convert :null to nil, but preserve all other values"
+  (testing "should convert :null to nil"
     (doseq [[input expected] [[:null nil]
-                              [nil nil]
-                              [:foo :foo]
-                              ["foo" "foo"]
-                              [1 1]
-                              [[:a 1 {:b true}] [:a 1 {:b true}]]
-                              '((1 :null nil) '(1 :null nil))
-                              #{1 :null nil} #{1 :null nil}]]
+                              [nil nil] ]]
       (is (= expected (lib.drill-thru.common/drill-value->js input))))))

--- a/test/metabase/lib/js_test.cljs
+++ b/test/metabase/lib/js_test.cljs
@@ -671,11 +671,12 @@
 
 (deftest ^:parallel display-info->js-test
   (testing "all data structures are converted correctly"
-    (is (= #js {:arr     #js ["a" #js {:inner true}]
-                :string  "passed"
-                :keyword "too"
-                :value   nil}
-           (lib.js/display-info->js {:arr     [:a {:inner true}]
-                                     :string  "passed"
-                                     :keyword :too
-                                     :value   nil})))))
+    (is (goog.object/equals
+         #js {:arr     #js ["a" #js {:inner true}]
+              :string  "passed"
+              :keyword "too"
+              :value   nil}
+         (lib.js/display-info->js {:arr     [:a {:inner true}]
+                                   :string  "passed"
+                                   :keyword :too
+                                   :value   nil})))))

--- a/test/metabase/lib/js_test.cljs
+++ b/test/metabase/lib/js_test.cljs
@@ -671,12 +671,12 @@
 
 (deftest ^:parallel display-info->js-test
   (testing "all data structures are converted correctly"
-    (is (goog.object/equals
-         #js {:arr     #js ["a" #js {:inner true}]
-              :string  "passed"
-              :keyword "too"
-              :value   nil}
-         (lib.js/display-info->js {:arr     [:a {:inner true}]
-                                   :string  "passed"
-                                   :keyword :too
-                                   :value   nil})))))
+    (let [input        {:arr [:a {:inner true}]
+                        :string  "passed"
+                        :keyword :too
+                        :value   nil}
+          expected #js {:arr #js ["a" #js {:inner true}]
+                        :string  "passed"
+                        :keyword "too"
+                        :value   nil}]
+      (is (js= expected (lib.js/display-info->js input))))))

--- a/test/metabase/lib/js_test.cljs
+++ b/test/metabase/lib/js_test.cljs
@@ -668,3 +668,14 @@
               (is (=? (lib/append-stage agg-only)
                       (.-query obj)))
               (is (=? -1 (.-stageIndex obj))))))))))
+
+(deftest ^:parallel display-info->js-test
+  (testing "all data structures are converted correctly"
+    (is (= #js {:arr     #js ["a" #js {:inner true}]
+                :string  "passed"
+                :keyword "too"
+                :value   nil}
+           (lib.js/display-info->js {:arr     [:a {:inner true}]
+                                     :string  "passed"
+                                     :keyword :too
+                                     :value   nil})))))


### PR DESCRIPTION
Fixes #44232

### Description

This PR is reusing the technique that already existed, in which we'd check if the `:value` is a keyword `:null` and return `nil` instead. That logic is now encapsulated in a new `drill-value->js` function.

So after we fixed the `:null` - > `"null", we're left with one more transformation.

In Clojure, `nil` is `sequable`, so it was hitting [this condition](https://github.com/metabase/metabase/blob/fdc0b71512835263b6cb52e22b7bf03cb1a3bb0f/src/metabase/lib/js.cljs#L376). So we ended up converting an empty list `()` into an empty array `[]` [because of this line](https://github.com/metabase/metabase/blob/fdc0b71512835263b6cb52e22b7bf03cb1a3bb0f/src/metabase/lib/js.cljs#L361).

Credits and kudos to @piranha for helping me debug this, and for fixing the latter issue.

### How to verify

Follow the repro steps from the original issue and confirm that the value is now a proper JS `null`.


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
