### PR TITLE
Fix collection id on collection items endpoint

### DIFF
--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -753,8 +753,9 @@
                           (post-process-collection-children (keyword model) collection rows)))
                    cat
                    (map coalesce-edit-info)))
-       (map #(api/present-in-trash-if-archived-directly % (collection/trash-collection-id)))
        (map remove-unwanted-keys)
+       ;; the collection these are presented "in" is the ID of the collection we're getting `/items` on.
+       (map #(assoc % :collection_id (:id collection)))
        (sort-by (comp ::index meta))))
 
 (defn- select-name

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -1596,9 +1596,7 @@
                                                      (perms-for-archiving coll)))))))))
 
 (defmethod hydrate-can-restore :default [_model items]
-  (for [{collection :collection
-         :as item*} (t2/hydrate items :collection)
-        :let [item (dissoc item* :collection)]]
+  (for [[{collection :collection} item] (map vector (t2/hydrate items :collection) items)]
     (assoc item :can_restore (boolean
                               (and
                                ;; the item is archived

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -670,6 +670,16 @@
                         (= (:id item) (:id card))))
               first))))))
 
+(deftest collection-items-returns-collections-with-correct-collection-id-test
+  (testing "GET /api/collection/:id/items?model=collection"
+    (testing "check that the ID and collection_id don't match"
+      (t2.with-temp/with-temp [:model/Collection parent {}
+                               :model/Collection child {:location (collection/children-location parent)}]
+        (is (= {:id (:id child)
+                :collection_id (:id parent)}
+               (select-keys (first (:data (mt/user-http-request :crowberto :get 200 (str "collection/" (u/the-id parent) "/items?model=collection"))))
+                            [:id :collection_id])))))))
+
 (deftest collection-items-return-database-id-for-datasets-test
   (testing "GET /api/collection/:id/items"
     (testing "Database id is returned for items in which dataset is true"


### PR DESCRIPTION
When fetching collection items, we need to fetch the true
`collection_id` in order to figure out things like `can_restore` and
`can_delete`, but set it to the displayed/effective `collection_id` when
we actually send it out.

This fixes a bug where collections had their `collection_id` match their
`id` when returned by this endpoint.

Also, fix a potential bug in `hydrate-can-restore`: if the `items` you're hydrating already have a `:collection` key it would be overwritten. AFAICT this wasn't actually being hit, but seems best to fix it anyway.