### PR TITLE
Add `report_dashboard.last_viewed_at`

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/load.clj
@@ -441,6 +441,11 @@
     ;; for a deprecated feature
     (m/update-existing-in p [:values_source_config :card_id] fully-qualified-name->card-id)))
 
+(defn- parse-timestamp [ts]
+  (if (string? ts)
+    (u.date/parse ts)
+    ts))
+
 (defn load-dashboards!
   "Loads `dashboards` (which is a sequence of maps parsed from a YAML dump of dashboards) in a given `context`."
   {:added "0.40.0"}
@@ -449,6 +454,7 @@
                                             (for [dashboard dashboards]
                                               (-> dashboard
                                                   (update :parameters resolve-dashboard-parameters)
+                                                  (update :last_viewed_at parse-timestamp)
                                                   (dissoc :dashboard_cards)
                                                   (assoc :collection_id (:collection context)
                                                          :creator_id    (default-user-id)))))

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -8372,10 +8372,6 @@ databaseChangeLog:
                   defaultValueComputed: current_timestamp
                   constraints:
                     nullable: false
-      rollback:
-        - dropColumn:
-            tableName: report_dashboard
-            columnName: last_viewed_at
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -8351,6 +8351,32 @@ databaseChangeLog:
             columnName: explicit_reference
             defaultValueBoolean: true
 
+  - changeSet:
+      id: v51.2024-07-10T12:28:10
+      author: johnswanson
+      comment: Add `last_viewed_at` to dashboards
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+          - columnExists:
+              tableName: report_dashboard
+              columnName: last_viewed_at
+      changes:
+        - addColumn:
+            tableName: report_dashboard
+            columns:
+              - column:
+                  name: last_viewed_at
+                  type: ${timestamp_type}
+                  remarks: Timestamp of when this dashboard was last viewed
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+      rollback:
+        - dropColumn:
+            tableName: report_dashboard
+            columnName: last_viewed_at
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/events/view_log.clj
+++ b/src/metabase/events/view_log.clj
@@ -96,7 +96,8 @@
 (def ^:private update-dashboard-last-viewed-at-interval-seconds 20)
 
 (defn- update-dashboard-last-viewed-at!* [dashboard-ids]
-  (t2/update! :model/Dashboard {:id [:in (into #{} dashboard-ids)]} {:last_viewed_at :%now}))
+  (t2/update! :model/Dashboard :id [:in dashboard-ids]
+              {:last_viewed_at :%now}))
 
 (def ^:private update-dashboard-last-viewed-at-queue
   (delay (grouper/start!

--- a/src/metabase/events/view_log.clj
+++ b/src/metabase/events/view_log.clj
@@ -90,6 +90,17 @@
       (catch Throwable e
         (log/warnf e "Failed to process view event. %s" topic)))))
 
+(derive ::dashboard-queried :metabase/event)
+(derive :event/dashboard-queried ::dashboard-queried)
+
+(m/defmethod events/publish-event! ::dashboard-queried
+  "Handle processing for a dashboard query being run"
+  [topic {:keys [object-id] :as _event}]
+  (try
+    (t2/update! :model/Dashboard {:id object-id} {:last_viewed_at :%now})
+    (catch Throwable e
+      (log/warnf e "Failed to process dashboard query event. %s" topic))))
+
 (derive ::collection-read-event :metabase/event)
 (derive :event/collection-read ::collection-read-event)
 

--- a/src/metabase/events/view_log.clj
+++ b/src/metabase/events/view_log.clj
@@ -106,7 +106,7 @@
                                                    [[:= :id id] [:greatest [:coalesce :last_viewed_at (t/offset-date-time 0)] timestamp]])
                                                  dashboard-id->timestamp))})
       (catch Exception e
-        (log/error e "Failed to increment view counts")))))
+        (log/error e "Failed to update dashboard last_viewed_at")))))
 
 (def ^:private update-dashboard-last-viewed-at-queue
   (delay (grouper/start!

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -242,7 +242,8 @@
    ;;   lower-numbered positions appearing before higher numbered ones.
    ;; TODO: querying on stats we don't have any dashboard that has a position, maybe we could just drop it?
    :public_uuid :made_public_by_id
-   :position :initially_published_at :view_count])
+   :position :initially_published_at :view_count
+   :last_viewed_at])
 
 (def ^:private excluded-columns-for-dashcard-revision
   [:entity_id :created_at :updated_at :collection_authority_level])
@@ -623,7 +624,8 @@
         (update :collection_id     serdes/*export-fk* Collection)
         (update :creator_id        serdes/*export-user*)
         (update :made_public_by_id serdes/*export-user*)
-        (dissoc :view_count))))
+        (dissoc :view_count
+                :last_viewed_at))))
 
 (defmethod serdes/load-xform "Dashboard"
   [dash]

--- a/src/metabase/query_processor/dashboard.clj
+++ b/src/metabase/query_processor/dashboard.clj
@@ -5,6 +5,7 @@
    [medley.core :as m]
    [metabase.api.common :as api]
    [metabase.driver.common.parameters.operators :as params.ops]
+   [metabase.events :as events]
    [metabase.legacy-mbql.normalize :as mbql.normalize]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.models.dashboard :as dashboard :refer [Dashboard]]
@@ -175,6 +176,7 @@
                     :attributes {:dashboard/id dashboard-id
                                  :dashcard/id  dashcard-id
                                  :card/id      card-id}}
+    (events/publish-event! :event/dashboard-queried {:object-id dashboard-id :user-id api/*current-user-id*})
     ;; make sure we can read this Dashboard. Card will get read-checked later on inside
     ;; [[qp.card/process-query-for-card]]
     (api/read-check Dashboard dashboard-id)

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -107,6 +107,7 @@
                  (dissoc :id)
                  (assoc :created_at (boolean created_at)
                         :updated_at (boolean updated_at))
+                 (update :last_viewed_at boolean)
                  (update :entity_id boolean)
                  (update :collection_id boolean)
                  (update :collection boolean)
@@ -206,6 +207,7 @@
    :collection_position     nil
    :collection              true
    :created_at              true ; assuming you call dashboard-response on the results
+   :last_viewed_at          true
    :description             nil
    :embedding_params        nil
    :enable_embedding        false

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -107,7 +107,6 @@
                  (dissoc :id)
                  (assoc :created_at (boolean created_at)
                         :updated_at (boolean updated_at))
-                 (update :last_viewed_at boolean)
                  (update :entity_id boolean)
                  (update :collection_id boolean)
                  (update :collection boolean)
@@ -200,32 +199,6 @@
            (mt/user-http-request :crowberto :post 400 "dashboard" {:name       "Test"
                                                                    :parameters "abc"})))))
 
-(def dashboard-defaults
-  {:archived                false
-   :caveats                 nil
-   :collection_id           nil
-   :collection_position     nil
-   :collection              true
-   :created_at              true ; assuming you call dashboard-response on the results
-   :last_viewed_at          true
-   :description             nil
-   :embedding_params        nil
-   :enable_embedding        false
-   :initially_published_at  nil
-   :entity_id               true
-   :made_public_by_id       nil
-   :parameters              []
-   :points_of_interest      nil
-   :cache_ttl               nil
-   :position                nil
-   :width                   "fixed"
-   :public_uuid             nil
-   :auto_apply_filters      true
-   :show_in_getting_started false
-   :updated_at              true
-   :view_count              0
-   :archived_directly        false})
-
 (deftest create-dashboard-test
   (testing "POST /api/dashboard"
     (mt/with-non-admin-groups-no-root-collection-perms
@@ -239,19 +212,14 @@
                                                                 :parameters    [{:id "abc123", :name "test", :type "date"}]
                                                                 :cache_ttl     1234
                                                                 :collection_id (u/the-id collection)})]
-              (is (=? (merge
-                        dashboard-defaults
-                        {:name           test-dashboard-name
-                         :creator_id     (mt/user->id :rasta)
-                         :parameters     [{:id "abc123", :name "test", :type "date"}]
-                         :updated_at     true
-                         :created_at     true
-                         :collection_id  true
-                         :collection     true
-                         :cache_ttl      1234
-                         :last-edit-info {:timestamp true :id true :first_name "Rasta"
-                                          :last_name "Toucan" :email "rasta@metabase.com"}})
-                      (dashboard-response created)))
+              (is (=? {:name           test-dashboard-name
+                       :creator_id     (mt/user->id :rasta)
+                       :parameters     [{:id "abc123", :name "test", :type "date"}]
+                       :cache_ttl      1234
+                       :last-edit-info {:first_name "Rasta"
+                                        :last_name "Toucan"
+                                        :email "rasta@metabase.com"}}
+                      created))
               (testing "A POST /api/dashboard should return the same essential data as a GET of that same dashboard after creation (#34828)"
                 (let [retrieved (mt/user-http-request :rasta :get 200 (format "dashboard/%d" dashboard-id))]
                   (is (= (update created :last-edit-info dissoc :timestamp)
@@ -488,39 +456,37 @@
                                                                                                     dashboard)}]
         (with-dashboards-in-readable-collection [dashboard-id]
           (api.card-test/with-cards-in-readable-collection [card-id]
-            (is (=? (merge
-                     dashboard-defaults
-                     {:name                       "Test Dashboard"
-                      :creator_id                 (mt/user->id :rasta)
-                      :collection                 true
-                      :collection_id              true
-                      :collection_authority_level nil
-                      :can_write                  false
-                      :param_fields               nil
-                      :param_values               nil
-                      :last-edit-info             {:timestamp true :id true :first_name "Test" :last_name "User" :email "test@example.com"}
-                      :tabs                       [{:name "Test Dashboard Tab" :position 0 :id dashtab-id :dashboard_id dashboard-id}]
-                      :dashcards                  [{:size_x                     4
-                                                    :size_y                     4
-                                                    :col                        0
-                                                    :row                        0
-                                                    :collection_authority_level nil
-                                                    :updated_at                 true
-                                                    :created_at                 true
-                                                    :entity_id                  (:entity_id dashcard)
-                                                    :parameter_mappings         []
-                                                    :visualization_settings     {}
-                                                    :dashboard_tab_id           dashtab-id
-                                                    :card                       (merge api.card-test/card-defaults-no-hydrate
-                                                                                       {:name                   "Dashboard Test Card"
-                                                                                        :creator_id             (mt/user->id :rasta)
-                                                                                        :can_write              false ;; hydrate :can_write for issue #35077
-                                                                                        :collection_id          true
-                                                                                        :display                "table"
-                                                                                        :entity_id              (:entity_id card)
-                                                                                        :visualization_settings {}
-                                                                                        :result_metadata        nil})
-                                                    :series                     []}]})
+            (is (=? {:name                       "Test Dashboard"
+                     :creator_id                 (mt/user->id :rasta)
+                     :collection                 true
+                     :collection_id              true
+                     :collection_authority_level nil
+                     :can_write                  false
+                     :param_fields               nil
+                     :param_values               nil
+                     :last-edit-info             {:timestamp true :id true :first_name "Test" :last_name "User" :email "test@example.com"}
+                     :tabs                       [{:name "Test Dashboard Tab" :position 0 :id dashtab-id :dashboard_id dashboard-id}]
+                     :dashcards                  [{:size_x                     4
+                                                   :size_y                     4
+                                                   :col                        0
+                                                   :row                        0
+                                                   :collection_authority_level nil
+                                                   :updated_at                 true
+                                                   :created_at                 true
+                                                   :entity_id                  (:entity_id dashcard)
+                                                   :parameter_mappings         []
+                                                   :visualization_settings     {}
+                                                   :dashboard_tab_id           dashtab-id
+                                                   :card                       (merge api.card-test/card-defaults-no-hydrate
+                                                                                      {:name                   "Dashboard Test Card"
+                                                                                       :creator_id             (mt/user->id :rasta)
+                                                                                       :can_write              false ;; hydrate :can_write for issue #35077
+                                                                                       :collection_id          true
+                                                                                       :display                "table"
+                                                                                       :entity_id              (:entity_id card)
+                                                                                       :visualization_settings {}
+                                                                                       :result_metadata        nil})
+                                                   :series                     []}]}
                     (dashboard-response (mt/user-http-request :rasta :get 200 (format "dashboard/%d" dashboard-id)))))))))))
 
 (deftest fetch-dashboard-test-2
@@ -579,47 +545,45 @@
                                                                              :target       [:dimension [:field field-id nil]]}]}]
         (with-dashboards-in-readable-collection [dashboard-id]
           (api.card-test/with-cards-in-readable-collection [card-id]
-            (is (=?
-                 (merge dashboard-defaults
-                        {:name                       "Test Dashboard"
-                         :creator_id                 (mt/user->id :rasta)
-                         :collection_id              true
-                         :collection_authority_level nil
-                         :can_write                  false
-                         :param_values               nil
-                         :param_fields               {field-id {:id               field-id
-                                                                :table_id         table-id
-                                                                :display_name     display-name
-                                                                :base_type        "type/Text"
-                                                                :semantic_type    nil
-                                                                :has_field_values "search"
-                                                                :name_field       nil
-                                                                :dimensions       []}}
-                         :tabs                       []
-                         :dashcards                  [{:size_x                     4
-                                                       :size_y                     4
-                                                       :col                        0
-                                                       :row                        0
-                                                       :updated_at                 true
-                                                       :created_at                 true
-                                                       :entity_id                  (:entity_id dashcard)
-                                                       :collection_authority_level nil
-                                                       :parameter_mappings         [{:card_id      1
-                                                                                     :parameter_id "foo"
-                                                                                     :target       ["dimension" ["field" field-id nil]]}]
-                                                       :visualization_settings     {}
-                                                       :dashboard_tab_id           nil
-                                                       :card                       (merge api.card-test/card-defaults-no-hydrate
-                                                                                          {:name                   "Dashboard Test Card"
-                                                                                           :creator_id             (mt/user->id :rasta)
-                                                                                           :collection_id          true
-                                                                                           :collection             false
-                                                                                           :entity_id              (:entity_id card)
-                                                                                           :display                "table"
-                                                                                           :query_type             nil
-                                                                                           :visualization_settings {}
-                                                                                           :result_metadata        nil})
-                                                       :series                     []}]})
+            (is (=? {:name                       "Test Dashboard"
+                     :creator_id                 (mt/user->id :rasta)
+                     :collection_id              true
+                     :collection_authority_level nil
+                     :can_write                  false
+                     :param_values               nil
+                     :param_fields               {field-id {:id               field-id
+                                                            :table_id         table-id
+                                                            :display_name     display-name
+                                                            :base_type        "type/Text"
+                                                            :semantic_type    nil
+                                                            :has_field_values "search"
+                                                            :name_field       nil
+                                                            :dimensions       []}}
+                     :tabs                       []
+                     :dashcards                  [{:size_x                     4
+                                                   :size_y                     4
+                                                   :col                        0
+                                                   :row                        0
+                                                   :updated_at                 true
+                                                   :created_at                 true
+                                                   :entity_id                  (:entity_id dashcard)
+                                                   :collection_authority_level nil
+                                                   :parameter_mappings         [{:card_id      1
+                                                                                 :parameter_id "foo"
+                                                                                 :target       ["dimension" ["field" field-id nil]]}]
+                                                   :visualization_settings     {}
+                                                   :dashboard_tab_id           nil
+                                                   :card                       (merge api.card-test/card-defaults-no-hydrate
+                                                                                      {:name                   "Dashboard Test Card"
+                                                                                       :creator_id             (mt/user->id :rasta)
+                                                                                       :collection_id          true
+                                                                                       :collection             false
+                                                                                       :entity_id              (:entity_id card)
+                                                                                       :display                "table"
+                                                                                       :query_type             nil
+                                                                                       :visualization_settings {}
+                                                                                       :result_metadata        nil})
+                                                   :series                     []}]}
                  (dashboard-response (mt/user-http-request :rasta :get 200 (format "dashboard/%d" dashboard-id)))))))))))
 
 (deftest fetch-dashboard-test-4
@@ -752,10 +716,10 @@
         (t2.with-temp/with-temp [Dashboard {dashboard-id :id} {:name "Test Dashboard"}]
           (with-dashboards-in-writeable-collection [dashboard-id]
             (testing "GET before update"
-              (is (= (merge dashboard-defaults {:name          "Test Dashboard"
-                                                :creator_id    (mt/user->id :rasta)
-                                                :collection    false
-                                                :collection_id true})
+              (is (=? {:name          "Test Dashboard"
+                       :creator_id    (mt/user->id :rasta)
+                       :collection    false
+                       :collection_id true}
                      (dashboard-response (t2/select-one Dashboard :id dashboard-id)))))
 
             (testing "PUT response"
@@ -766,29 +730,29 @@
                                                         ;; these things should fail to update
                                                         :creator_id  (mt/user->id :trashbird)})
                     get-response (mt/user-http-request :rasta :get 200 (format "dashboard/%d" dashboard-id))]
-                (is (=? (merge dashboard-defaults {:name           "My Cool Dashboard"
-                                                   :dashcards      []
-                                                   :tabs           []
-                                                   :description    "Some awesome description"
-                                                   :creator_id     (mt/user->id :rasta)
-                                                   :cache_ttl      1234
-                                                   :last-edit-info {:timestamp true :id true :first_name "Rasta"
-                                                                    :last_name "Toucan" :email "rasta@metabase.com"}
-                                                   :collection     true
-                                                   :collection_id  true})
+                (is (=? {:name           "My Cool Dashboard"
+                         :dashcards      []
+                         :tabs           []
+                         :description    "Some awesome description"
+                         :creator_id     (mt/user->id :rasta)
+                         :cache_ttl      1234
+                         :last-edit-info {:timestamp true :id true :first_name "Rasta"
+                                          :last_name "Toucan" :email "rasta@metabase.com"}
+                         :collection     true
+                         :collection_id  true}
                         (dashboard-response put-response)))
                 (testing "A PUT should return the updated value so a follow-on GET is not needed (#34828)"
                   (is (= (update put-response :last-edit-info dissoc :timestamp)
                          (update get-response :last-edit-info dissoc :timestamp))))))
 
             (testing "GET after update"
-              (is (= (merge dashboard-defaults {:name          "My Cool Dashboard"
-                                                :description   "Some awesome description"
-                                                :cache_ttl     1234
-                                                :creator_id    (mt/user->id :rasta)
-                                                :collection    false
-                                                :collection_id true
-                                                :view_count    1})
+              (is (=? {:name          "My Cool Dashboard"
+                       :description   "Some awesome description"
+                       :cache_ttl     1234
+                       :creator_id    (mt/user->id :rasta)
+                       :collection    false
+                       :collection_id true
+                       :view_count    1}
                      (dashboard-response (t2/select-one Dashboard :id dashboard-id)))))
 
             (testing "No-op PUT: Do not return 500"
@@ -824,19 +788,19 @@
     (testing "allow `:caveats` and `:points_of_interest` to be empty strings, and `:show_in_getting_started` should be a boolean"
       (t2.with-temp/with-temp [Dashboard {dashboard-id :id} {:name "Test Dashboard"}]
         (with-dashboards-in-writeable-collection [dashboard-id]
-          (is (=? (merge dashboard-defaults {:name                    "Test Dashboard"
-                                             :creator_id              (mt/user->id :rasta)
-                                             :collection              true
-                                             :collection_id           true
-                                             :dashcards               []
-                                             :tabs                    []
-                                             :caveats                 ""
-                                             :points_of_interest      ""
-                                             :cache_ttl               1337
-                                             :last-edit-info
-                                             {:timestamp true, :id true, :first_name "Rasta"
-                                              :last_name "Toucan", :email "rasta@metabase.com"}
-                                             :show_in_getting_started true})
+          (is (=? {:name                    "Test Dashboard"
+                   :creator_id              (mt/user->id :rasta)
+                   :collection              true
+                   :collection_id           true
+                   :dashcards               []
+                   :tabs                    []
+                   :caveats                 ""
+                   :points_of_interest      ""
+                   :cache_ttl               1337
+                   :last-edit-info
+                   {:timestamp true, :id true, :first_name "Rasta"
+                    :last_name "Toucan", :email "rasta@metabase.com"}
+                   :show_in_getting_started true}
                   (dashboard-response (mt/user-http-request :rasta :put 200 (str "dashboard/" dashboard-id)
                                                             {:caveats                 ""
                                                              :points_of_interest      ""
@@ -1167,14 +1131,12 @@
                                                       :description "A description"
                                                       :creator_id  (mt/user->id :rasta)}]
           (let [response (mt/user-http-request :rasta :post 200 (format "dashboard/%d/copy" (:id dashboard)))]
-            (is (= (merge
-                    dashboard-defaults
-                    {:name          "Test Dashboard"
+            (is (=? {:name          "Test Dashboard"
                      :description   "A description"
                      :creator_id    (mt/user->id :rasta)
                      :collection    false
-                     :collection_id false})
-                   (dashboard-response response)))
+                     :collection_id false}
+                    (dashboard-response response)))
             (is (some? (:entity_id response)))
             (is (not=  (:entity_id dashboard) (:entity_id response))
                 "The copy should have a new entity ID generated")))))))
@@ -1189,14 +1151,12 @@
           (let [response (mt/user-http-request :crowberto :post 200 (format "dashboard/%d/copy" (:id dashboard))
                                                {:name        "Test Dashboard - Duplicate"
                                                 :description "A new description"})]
-            (is (= (merge
-                    dashboard-defaults
-                    {:name          "Test Dashboard - Duplicate"
+            (is (=? {:name          "Test Dashboard - Duplicate"
                      :description   "A new description"
                      :creator_id    (mt/user->id :crowberto)
                      :collection_id false
-                     :collection    false})
-                   (dashboard-response response)))
+                     :collection    false}
+                    (dashboard-response response)))
             (is (some? (:entity_id response)))
             (is (not= (:entity_id dashboard) (:entity_id response))
                 "The copy should have a new entity ID generated")))))))

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -55,7 +55,6 @@
    [metabase.server.request.util :as req.util]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
-   [metabase.test.util.thread-local :as tu.thread-local]
    [metabase.util :as u]
    [ring.util.codec :as codec]
    [toucan2.core :as t2]
@@ -4746,7 +4745,7 @@
         (is (= @cached-calls-count 1))))))
 
 (deftest querying-a-dashboard-dashcard-updates-last-viewed-at
-  (binding [tu.thread-local/*thread-local* false]
+  (mt/test-helpers-set-global-values!
     (mt/dataset test-data
       (mt/with-temp [:model/Dashboard {dashboard-id :id} {:last_viewed_at #t "2000-01-01"}
                      :model/Card {card-id :id} {:dataset_query (mt/native-query

--- a/test/metabase/api/embed_test.clj
+++ b/test/metabase/api/embed_test.clj
@@ -25,7 +25,6 @@
    [metabase.query-processor.middleware.process-userland-query-test :as process-userland-query-test]
    [metabase.query-processor.test-util :as qp.test-util]
    [metabase.test :as mt]
-   [metabase.test.util.thread-local :as tu.thread-local]
    [metabase.util :as u]
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp])
@@ -1668,13 +1667,13 @@
                           ((get output-helper export-format))))))))))))
 
 (deftest querying-a-dashboard-dashcard-updates-last-viewed-at
-  (binding [tu.thread-local/*thread-local* false]
+  (mt/test-helpers-set-global-values!
     (mt/dataset test-data
-    (with-embedding-enabled-and-new-secret-key
-      (with-temp-dashcard [dashcard {:dash {:enable_embedding true
-                                            :last_viewed_at #t "2000-01-01"}}]
-        (let [dashboard-id (t2/select-one-fn :id :model/Dashboard :id (:dashboard_id dashcard))
-              original-last-viewed-at (t2/select-one-fn :last_viewed_at :model/Dashboard dashboard-id)]
-          (mt/with-temporary-setting-values [synchronous-batch-updates true]
-            (client/client :get 202 (dashcard-url dashcard))
-            (is (not= original-last-viewed-at (t2/select-one-fn :last_viewed_at :model/Dashboard :id dashboard-id))))))))))
+      (with-embedding-enabled-and-new-secret-key
+        (with-temp-dashcard [dashcard {:dash {:enable_embedding true
+                                              :last_viewed_at #t "2000-01-01"}}]
+          (let [dashboard-id (t2/select-one-fn :id :model/Dashboard :id (:dashboard_id dashcard))
+                original-last-viewed-at (t2/select-one-fn :last_viewed_at :model/Dashboard dashboard-id)]
+            (mt/with-temporary-setting-values [synchronous-batch-updates true]
+              (client/client :get 202 (dashcard-url dashcard))
+              (is (not= original-last-viewed-at (t2/select-one-fn :last_viewed_at :model/Dashboard :id dashboard-id))))))))))

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -22,7 +22,6 @@
    [metabase.models.permissions :as perms]
    [metabase.models.permissions-group :as perms-group]
    [metabase.test :as mt]
-   [metabase.test.util.thread-local :as tu.thread-local]
    [metabase.util :as u]
    [throttle.core :as throttle]
    [toucan2.core :as t2]
@@ -718,7 +717,7 @@
   (testing "GET /api/public/dashboard/:uuid/card/:card-id"
     (testing "Dashboard's last_viewed_at should be updated when a public DashCard is viewed"
       (mt/with-temporary-setting-values [enable-public-sharing true]
-        (binding [tu.thread-local/*thread-local* false]
+        (mt/test-helpers-set-global-values!
           (t2.with-temp/with-temp [Collection {collection-id :id}]
             (perms/revoke-collection-permissions! (perms-group/all-users) collection-id)
             (with-temp-public-dashboard-and-card [dash {card-id :id, :as card} dashcard]

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -22,6 +22,7 @@
    [metabase.models.permissions :as perms]
    [metabase.models.permissions-group :as perms-group]
    [metabase.test :as mt]
+   [metabase.test.util.thread-local :as tu.thread-local]
    [metabase.util :as u]
    [throttle.core :as throttle]
    [toucan2.core :as t2]
@@ -712,6 +713,20 @@
             (is (= [[100]]
                    (mt/rows
                     (mt/user-http-request :rasta :get 202 (dashcard-url dash card dashcard)))))))))))
+
+(deftest execute-public-dashcard-updates-last-viewed-at
+  (testing "GET /api/public/dashboard/:uuid/card/:card-id"
+    (testing "Dashboard's last_viewed_at should be updated when a public DashCard is viewed"
+      (mt/with-temporary-setting-values [enable-public-sharing true]
+        (binding [tu.thread-local/*thread-local* false]
+          (t2.with-temp/with-temp [Collection {collection-id :id}]
+            (perms/revoke-collection-permissions! (perms-group/all-users) collection-id)
+            (with-temp-public-dashboard-and-card [dash {card-id :id, :as card} dashcard]
+              (let [original-last-viewed-at (t2/select-one-fn :last_viewed_at :model/Dashboard (:id dash))]
+                (t2/update! Card card-id {:collection_id collection-id})
+                (mt/with-temporary-setting-values [synchronous-batch-updates true]
+                  (mt/user-http-request :rasta :get 202 (dashcard-url dash card dashcard)))
+                (is (not= original-last-viewed-at (t2/select-one-fn :last_viewed_at :model/Dashboard :id (:id dash))))))))))))
 
 (deftest execute-public-dashcard-params-validation-test
   (testing "GET /api/public/dashboard/:uuid/card/:card-id"

--- a/test/metabase/api/trash_test.clj
+++ b/test/metabase/api/trash_test.clj
@@ -1,9 +1,13 @@
 (ns metabase.api.trash-test
   (:require  [clojure.test :refer [deftest testing is]]
              [metabase.api.card-test :refer [card-with-name-and-query]]
-             [metabase.api.dashboard-test :refer [dashboard-defaults]]
              [metabase.models.collection :as collection]
              [metabase.test :as mt]))
+
+(def dashboard-defaults {:name          "Dashboard"
+                         :parameters    [{:id "abc123", :name "test", :type "date"}]
+                         :cache_ttl     1234
+                         :collection_id nil})
 
 (deftest cannot-create-in-trash
   (testing "Cannot create a card in the trash"

--- a/test/metabase/http_client.clj
+++ b/test/metabase/http_client.clj
@@ -83,7 +83,7 @@
 ;;; parse-response
 
 (def ^:private auto-deserialize-dates-keys
-  #{:created_at :updated_at :last_login :date_joined :started_at :finished_at :last_analyzed :last_used_at})
+  #{:created_at :updated_at :last_login :date_joined :started_at :finished_at :last_analyzed :last_used_at :last_viewed_at})
 
 (defn- auto-deserialize-dates
   "Automatically recurse over `response` and look for keys that are known to correspond to dates. Parse their values and

--- a/test/metabase/query_processor/dashboard_test.clj
+++ b/test/metabase/query_processor/dashboard_test.clj
@@ -9,7 +9,9 @@
    [metabase.query-processor :as qp]
    [metabase.query-processor.card-test :as qp.card-test]
    [metabase.query-processor.dashboard :as qp.dashboard]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.test.util.thread-local :as tu.thread-local]
+   [toucan2.core :as t2]))
 
 ;; there are more tests in [[metabase.api.dashboard-test]]
 
@@ -403,3 +405,17 @@
                                                         :type    "category"
                                                         :value   nil
                                                         :default ["Gizmo"]}])))))))))
+
+(deftest running-a-query-for-dashcard-sets-last-viewed-at
+  (binding [tu.thread-local/*thread-local* false]
+    (mt/dataset test-data
+      (mt/with-temp [:model/Dashboard {dashboard-id :id} {:last_viewed_at #t "2000-01-01"}
+                     :model/Card {card-id :id} {:dataset_query (mt/native-query
+                                                                 {:query "SELECT COUNT(*) FROM \"ORDERS\""
+                                                                  :template-tags {}})}
+                     :model/DashboardCard {dashcard-id :id} {:card_id card-id
+                                                             :dashboard_id dashboard-id}]
+        (let [original-last-viewed-at (t2/select-one-fn :last_viewed_at :model/Dashboard dashboard-id)]
+          (mt/with-temporary-setting-values [synchronous-batch-updates true]
+            (run-query-for-dashcard dashboard-id card-id dashcard-id)
+            (is (not= original-last-viewed-at (t2/select-one-fn :last_viewed_at :model/Dashboard :id dashboard-id)))))))))

--- a/test/metabase/query_processor/dashboard_test.clj
+++ b/test/metabase/query_processor/dashboard_test.clj
@@ -10,7 +10,6 @@
    [metabase.query-processor.card-test :as qp.card-test]
    [metabase.query-processor.dashboard :as qp.dashboard]
    [metabase.test :as mt]
-   [metabase.test.util.thread-local :as tu.thread-local]
    [toucan2.core :as t2]))
 
 ;; there are more tests in [[metabase.api.dashboard-test]]
@@ -407,7 +406,7 @@
                                                         :default ["Gizmo"]}])))))))))
 
 (deftest running-a-query-for-dashcard-sets-last-viewed-at
-  (binding [tu.thread-local/*thread-local* false]
+  (mt/test-helpers-set-global-values!
     (mt/dataset test-data
       (mt/with-temp [:model/Dashboard {dashboard-id :id} {:last_viewed_at #t "2000-01-01"}
                      :model/Card {card-id :id} {:dataset_query (mt/native-query


### PR DESCRIPTION
Defaults to `NOW()`. Also, reset all values of `report_card.last_used_at` to `NOW()` and make it non-nullable with a default of `NOW()`. See comments in the migrations file for details.

Fixes #44251 