### PR TITLE
Elevate "starting from" option in the relative date picker

### DIFF
--- a/e2e/support/helpers/e2e-relative-date-picker-helpers.js
+++ b/e2e/support/helpers/e2e-relative-date-picker-helpers.js
@@ -41,8 +41,7 @@ function setStartingFrom({ value, unit }) {
  * @param {string} params.unit - interval unit in singular form (e.g. "day", not "days")
  */
 function addStartingFrom({ value, unit }) {
-  popover().findByLabelText("Options").click();
-  popover().last().findByText("Starting from…").click();
+  popover().findByLabelText("Starting from…").click();
   setStartingFrom({ value, unit });
 }
 

--- a/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
@@ -637,9 +637,10 @@ describe("scenarios > question > custom column", () => {
     });
     cy.findByRole("listbox").findByText("years").click();
 
-    popover().findByLabelText("Options").click();
-    popover().last().findByText("Include this year").click();
-    popover().button("Add filter").click();
+    popover().within(() => {
+      cy.findByText("Include this year").click();
+      cy.button("Add filter").click();
+    });
 
     visualize(({ body }) => {
       expect(body.error).to.not.exist;

--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -537,10 +537,11 @@ describe("issue 25378", () => {
       cy.findByDisplayValue("days").click();
     });
     cy.findByRole("listbox").findByText("months").click();
-    popover().findByLabelText("Options").click();
-    popover().last().findByText("Starting from…").click();
 
-    popover().button("Add filter").click();
+    popover().within(() => {
+      cy.findByLabelText("Starting from…").click();
+      cy.button("Add filter").click();
+    });
 
     visualize(response => {
       expect(response.body.error).to.not.exist;

--- a/e2e/test/scenarios/filters/relative-datetime.cy.spec.js
+++ b/e2e/test/scenarios/filters/relative-datetime.cy.spec.js
@@ -267,10 +267,8 @@ const openCreatedAt = tab => {
 };
 
 const addStartingFrom = () => {
-  popover().findByLabelText("Options").click();
   popover()
-    .last()
-    .findByText(/Starting from/)
+    .findByLabelText(/Starting from/)
     .click();
 };
 

--- a/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.tsx
@@ -95,6 +95,7 @@ export function DateIntervalPicker({
         {canUseRelativeOffsets && (
           <Tooltip label={t`Starting from…`} position="bottom">
             <Button
+              aria-label={t`Starting from…`}
               c="text-medium"
               variant="subtle"
               leftIcon={<Icon name="arrow_left_to_line" />}

--- a/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.tsx
@@ -7,11 +7,11 @@ import {
   Divider,
   Flex,
   Group,
-  Menu,
   NumberInput,
   Select,
   Text,
   Switch,
+  Tooltip,
 } from "metabase/ui";
 
 import type { DateIntervalValue } from "../types";
@@ -92,26 +92,16 @@ export function DateIntervalPicker({
           ml="md"
           onChange={handleUnitChange}
         />
-        <Menu>
-          <Menu.Target>
+        {canUseRelativeOffsets && (
+          <Tooltip label={t`Starting from…`} position="bottom">
             <Button
-              c="text-dark"
+              c="text-medium"
               variant="subtle"
-              leftIcon={<Icon name="ellipsis" />}
-              aria-label={t`Options`}
+              leftIcon={<Icon name="arrow_left_to_line" />}
+              onClick={handleStartingFromClick}
             />
-          </Menu.Target>
-          <Menu.Dropdown>
-            {canUseRelativeOffsets && (
-              <Menu.Item
-                icon={<Icon name="arrow_left_to_line" />}
-                onClick={handleStartingFromClick}
-              >
-                {t`Starting from…`}
-              </Menu.Item>
-            )}
-          </Menu.Dropdown>
-        </Menu>
+          </Tooltip>
+        )}
       </Flex>
       <Flex p="md" pt={0}>
         <Switch

--- a/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.unit.spec.tsx
@@ -156,7 +156,6 @@ describe("DateIntervalPicker", () => {
           value: defaultValue,
         });
 
-        await userEvent.click(screen.getByLabelText("Options"));
         await userEvent.click(await screen.findByText("Include today"));
 
         expect(onChange).toHaveBeenCalledWith({
@@ -168,24 +167,13 @@ describe("DateIntervalPicker", () => {
         expect(onSubmit).not.toHaveBeenCalled();
       });
 
-      it("should not allow to add relative offsets by default", async () => {
-        setup({
-          value: defaultValue,
-        });
-
-        await userEvent.click(screen.getByLabelText("Options"));
-        expect(await screen.findByText("Include today")).toBeInTheDocument();
-        expect(screen.queryByText("Starting from…")).not.toBeInTheDocument();
-      });
-
-      it("should allow to a relative offset if enabled", async () => {
+      it("should allow to a relative offset", async () => {
         const { onChange, onSubmit } = setup({
           value: defaultValue,
           canUseRelativeOffsets: true,
         });
 
-        await userEvent.click(screen.getByLabelText("Options"));
-        await userEvent.click(await screen.findByText("Starting from…"));
+        await userEvent.click(await screen.findByLabelText("Starting from…"));
 
         expect(onChange).toHaveBeenLastCalledWith({
           ...defaultValue,

--- a/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.tsx
@@ -116,6 +116,7 @@ export function DateOffsetIntervalPicker({
           onChange={handleOffsetUnitChange}
         />
         <Button
+          c="text-medium"
           variant="subtle"
           leftIcon={<Icon name="close" />}
           aria-label={t`Remove offset`}

--- a/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/RelativeDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/RelativeDatePicker.unit.spec.tsx
@@ -69,8 +69,7 @@ describe("RelativeDatePicker", () => {
       canUseRelativeOffsets: true,
     });
 
-    await userEvent.click(screen.getByLabelText("Options"));
-    await userEvent.click(await screen.findByText("Starting from…"));
+    await userEvent.click(await screen.findByLabelText("Starting from…"));
     await userEvent.clear(screen.getByLabelText("Starting from interval"));
     await userEvent.type(screen.getByLabelText("Starting from interval"), "20");
     await userEvent.click(screen.getByLabelText("Next"));
@@ -113,8 +112,7 @@ describe("RelativeDatePicker", () => {
       canUseRelativeOffsets: true,
     });
 
-    await userEvent.click(screen.getByLabelText("Options"));
-    await userEvent.click(await screen.findByText("Starting from…"));
+    await userEvent.click(await screen.findByLabelText("Starting from…"));
     await userEvent.click(screen.getByText("Update filter"));
 
     expect(onChange).toHaveBeenCalledWith({
@@ -149,8 +147,7 @@ describe("RelativeDatePicker", () => {
     });
 
     await userEvent.click(screen.getByText("Next"));
-    await userEvent.click(screen.getByLabelText("Options"));
-    await userEvent.click(await screen.findByText("Starting from…"));
+    await userEvent.click(await screen.findByLabelText("Starting from…"));
     await userEvent.click(screen.getByText("Update filter"));
 
     expect(onChange).toHaveBeenCalledWith({


### PR DESCRIPTION
### Description

This micro-pr elevates the "Starting from" icon/action in the relative date picker, as per design in Figma. It is a part of the Milestone 1 of #44096

### How to verify

Describe the steps to verify that the changes are working as expected.

**Notebook**
1. Open Orders table in a notebook view
2. Click on a filter > Created At
3. Choose "Relative dates"
4. Popover should show an "arrow left" icon, in the same row as the number input and the time period input
5. Hovering the icon should show a tooltip "Starting from..."
![image](https://github.com/metabase/metabase/assets/31325167/52d6b9c0-2407-455e-b838-3731f26cc201)
6. Clicking the icon should make it possible to set the date offset in the row below ("include this" should NOT be visible)
![image](https://github.com/metabase/metabase/assets/31325167/0094a0ca-fa77-47e1-907f-fc9a95ee6f4e)
7. Clicking on "X" next to the offset should remove this row, and the arrow left icon should be visible again.
8. Include this should be visible again, but reset to unchecked

**Filter modal**
1. Open Orders table
2. Click on a "Filter" (pill)
3. Choose `...` next to "Created At" and choose "Relative dates"
4. Popover should show a toggle with "Include this..." period
5. Hovering the icon should show a tooltip "Starting from..."
![image](https://github.com/metabase/metabase/assets/31325167/b6a674af-6764-4496-8f19-8cb86a1c65f6)
6. Clicking the icon should make it possible to set the date offset in the row below ("include this" should NOT be visible)
![image](https://github.com/metabase/metabase/assets/31325167/dc08a2fc-df36-4804-9924-559e3123917d)
7. Clicking on "X" next to the offset should remove this row, and the arrow left icon should be visible again.
8. Include this should be visible again, but reset to unchecked

**Drill-through context**
1. Open Orders table
2. Click on a table header cell "Created At"
3. Filter by this column
4. Relative dates
5. Hovering the icon should show a tooltip "Starting from..."
![image](https://github.com/metabase/metabase/assets/31325167/2605205b-6a5d-4232-8f58-2ac97cb18923)
6. Clicking the icon should make it possible to set the date offset in the row below ("include this" should NOT be visible)
![image](https://github.com/metabase/metabase/assets/31325167/69218925-13ab-4868-94d1-3a4c284da98c)
7. Clicking on "X" next to the offset should remove this row, and the arrow left icon should be visible again.
8. Include this should be visible again, but reset to unchecked

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
