### PR TITLE
MS2: Expose "Include this {period}" in time-series chrome

### DIFF
--- a/e2e/test/scenarios/filters/time-series-chrome.cy.spec.ts
+++ b/e2e/test/scenarios/filters/time-series-chrome.cy.spec.ts
@@ -1,0 +1,140 @@
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { restore, visitQuestionAdhoc } from "e2e/support/helpers";
+
+const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
+
+describe("time-series chrome filter widget", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+  });
+
+  describe("smoke tests", () => {
+    beforeEach(() => {
+      visitQuestionAdhoc({
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          query: {
+            "source-table": PRODUCTS_ID,
+            aggregation: [["count"]],
+            breakout: [
+              ["field", PRODUCTS.CREATED_AT, { "temporal-unit": "month" }],
+            ],
+          },
+          type: "query",
+        },
+      });
+    });
+
+    it("should properly display the component and all its operators", () => {
+      const operators = [
+        "Previous",
+        "Next",
+        "Current",
+        "Before",
+        "After",
+        "On",
+        "Between",
+      ];
+
+      cy.log(
+        "should display 'All time' as the initialy selected operator (metabase#22247)",
+      );
+      cy.findByTestId("timeseries-filter-button")
+        .should("have.text", "All time")
+        .click();
+
+      cy.findByTestId("datetime-filter-picker")
+        .findByDisplayValue("All time")
+        .click();
+
+      cy.findByRole("listbox").within(() => {
+        cy.findByRole("option", { name: "All time" }).should(
+          "have.attr",
+          "aria-selected",
+          "true",
+        );
+
+        cy.log("Make sure we display all the operators");
+        operators.forEach(operator => {
+          cy.findByRole("option", { name: operator }).should("be.visible");
+        });
+      });
+
+      cy.findByTestId("datetime-filter-picker").within(() => {
+        cy.log("Include 'current' interval switch should not be displayed");
+        cy.findByLabelText(/^Include/).should("not.exist");
+        cy.button("Apply").should("not.be.disabled");
+      });
+    });
+
+    it("should stay in sync with the relative date filter", () => {
+      cy.findByTestId("timeseries-filter-button").click();
+      cy.findByTestId("datetime-filter-picker")
+        .findByDisplayValue("All time")
+        .click();
+
+      cy.log(
+        "Choose the 'Previous' operator and check the state of the time-series chrome",
+      );
+      cy.findByRole("listbox")
+        .findByRole("option", { name: "Previous" })
+        .click();
+      cy.findByTestId("datetime-filter-picker").within(() => {
+        // Top row
+        cy.findByDisplayValue("Previous").should("be.visible");
+        cy.findByDisplayValue("30").should("be.visible");
+        cy.findByDisplayValue("days").should("be.visible");
+
+        cy.log("Toggle should be always off initially");
+        // This is targeting the input checkbox that is hidden
+        cy.findByLabelText("Include today").should(
+          "have.attr",
+          "aria-checked",
+          "false",
+        );
+
+        // This is clicking on an actual label in the UI
+        cy.findByText("Include today").click();
+
+        cy.findByLabelText("Include today").should(
+          "have.attr",
+          "aria-checked",
+          "true",
+        );
+        cy.button("Apply").click();
+        cy.wait("@dataset");
+      });
+
+      cy.findByTestId("filter-pill")
+        .should("have.text", "Created At is in the previous 30 days")
+        .click();
+
+      cy.log(
+        "Make sure the relative date picker reflects the state of the time-series chrome",
+      );
+      cy.findByTestId("datetime-filter-picker").within(() => {
+        cy.findByRole("tab", { name: "Previous" }).should(
+          "have.attr",
+          "aria-selected",
+          "true",
+        );
+
+        cy.findByLabelText("Include today").should(
+          "have.attr",
+          "aria-checked",
+          "true",
+        );
+
+        cy.log("Swith should preserve its state after we switch the direction");
+        cy.findByRole("tab", { name: "Next" }).click();
+        cy.findByLabelText("Include today").should(
+          "have.attr",
+          "aria-checked",
+          "true",
+        );
+      });
+    });
+  });
+});

--- a/e2e/test/scenarios/filters/time-series-chrome.cy.spec.ts
+++ b/e2e/test/scenarios/filters/time-series-chrome.cy.spec.ts
@@ -71,16 +71,9 @@ describe("time-series chrome filter widget", () => {
 
     it("should stay in sync with the relative date filter", () => {
       cy.findByTestId("timeseries-filter-button").click();
-      cy.findByTestId("datetime-filter-picker")
-        .findByDisplayValue("All time")
-        .click();
+      updateOperator("All time", "Previous");
 
-      cy.log(
-        "Choose the 'Previous' operator and check the state of the time-series chrome",
-      );
-      cy.findByRole("listbox")
-        .findByRole("option", { name: "Previous" })
-        .click();
+      cy.log("Check the state of the time-series chrome");
       cy.findByTestId("datetime-filter-picker").within(() => {
         // Top row
         cy.findByDisplayValue("Previous").should("be.visible");
@@ -127,7 +120,9 @@ describe("time-series chrome filter widget", () => {
           "true",
         );
 
-        cy.log("Swith should preserve its state after we switch the direction");
+        cy.log(
+          "Switch should preserve its state after we change the direction",
+        );
         cy.findByRole("tab", { name: "Next" }).click();
         cy.findByLabelText("Include today").should(
           "have.attr",
@@ -208,13 +203,7 @@ describe("time-series chrome filter widget", () => {
       });
 
       cy.log("Change the direction");
-      cy.findByTestId("datetime-filter-picker")
-        .findByDisplayValue("Next")
-        .click();
-      cy.findByRole("listbox")
-        .findByRole("option", { name: "Previous" })
-        .click();
-
+      updateOperator("Next", "Previous");
       cy.findByTestId("datetime-filter-picker").within(() => {
         cy.findByDisplayValue("Previous").should("be.visible");
         cy.findByLabelText("Include this quarter").should(
@@ -225,31 +214,21 @@ describe("time-series chrome filter widget", () => {
       });
     });
 
-    it("should reset the 'Include current' switch state when navigating away from the relative date filter", () => {
+    it("should reset the 'Include current' switch state when navigating away from the relative interval date filter", () => {
       cy.findByTestId("datetime-filter-picker").within(() => {
         cy.findByLabelText("Include this year").should(
           "have.attr",
           "aria-checked",
           "true",
         );
-        cy.findByDisplayValue("Next").click();
       });
 
-      cy.findByRole("listbox")
-        .findByRole("option", { name: "Current" })
-        .click();
-
+      updateOperator("Next", "Current");
       cy.findByTestId("datetime-filter-picker")
         .findByLabelText("Include today")
         .should("not.exist");
 
-      cy.findByTestId("datetime-filter-picker")
-        .findByDisplayValue("Current")
-        .click();
-      cy.findByRole("listbox")
-        .findByRole("option", { name: "Previous" })
-        .click();
-
+      updateOperator("Current", "Previous");
       cy.findByTestId("datetime-filter-picker").within(() => {
         cy.findByDisplayValue("Previous").should("be.visible");
         cy.findByLabelText("Include this year").should(
@@ -261,3 +240,8 @@ describe("time-series chrome filter widget", () => {
     });
   });
 });
+
+function updateOperator(from: string, to: string) {
+  cy.findByTestId("datetime-filter-picker").findByDisplayValue(from).click();
+  cy.findByRole("listbox").findByRole("option", { name: to }).click();
+}

--- a/e2e/test/scenarios/question-reproductions/reproductions-2.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-2.cy.spec.js
@@ -7,15 +7,12 @@ import {
   openOrdersTable,
   popover,
   modal,
-  summarize,
   openNativeEditor,
   startNewQuestion,
   entityPickerModal,
   entityPickerModalTab,
   visitQuestion,
-  openProductsTable,
   visitQuestionAdhoc,
-  sidebar,
   openNotebook,
   selectFilterOperator,
   chartPathWithFillColor,
@@ -29,105 +26,6 @@ import {
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID, PEOPLE } = SAMPLE_DATABASE;
-
-describe("time-series filter widget", () => {
-  beforeEach(() => {
-    restore();
-    cy.signInAsAdmin();
-
-    openProductsTable();
-  });
-
-  it("should properly display All time as the initial filtering (metabase#22247)", () => {
-    summarize();
-
-    sidebar().contains("Created At").click();
-    cy.wait("@dataset");
-
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("All time").click();
-
-    popover().within(() => {
-      // Implicit assertion: there is only one select button
-      cy.findByDisplayValue("All time").should("be.visible");
-
-      cy.button("Apply").should("not.be.disabled");
-    });
-  });
-
-  it("should allow switching from All time filter", () => {
-    cy.findAllByText("Summarize").first().click();
-    cy.findAllByText("Created At").last().click();
-    cy.wait("@dataset");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Done").click();
-
-    // switch to previous 30 quarters
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("All time").click();
-    popover().within(() => {
-      cy.findByDisplayValue("All time").click();
-    });
-    cy.findByTextEnsureVisible("Previous").click();
-    cy.findByDisplayValue("days").click();
-    cy.findByTextEnsureVisible("quarters").click();
-    cy.button("Apply").click();
-    cy.wait("@dataset");
-
-    cy.findByTestId("qb-filters-panel")
-      .findByText("Created At is in the previous 30 quarters")
-      .should("be.visible");
-  });
-
-  it("should stay in-sync with the actual filter", () => {
-    cy.findAllByText("Filter").first().click();
-    cy.findByTestId("filter-column-Created At").within(() => {
-      cy.findByLabelText("More options").click();
-    });
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Last 3 months").click();
-    cy.button("Apply filters").click();
-    cy.wait("@dataset");
-
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Created At is in the previous 3 months").click();
-    cy.findByDisplayValue("months").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("years").click();
-    cy.button("Update filter").click();
-    cy.wait("@dataset");
-
-    cy.findAllByText("Summarize").first().click();
-    cy.findAllByText("Created At").last().click();
-    cy.wait("@dataset");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Done").click();
-
-    cy.findByTestId("qb-filters-panel")
-      .findByText("Created At is in the previous 3 years")
-      .should("be.visible");
-
-    cy.findByTestId("timeseries-filter-button").click();
-    popover().within(() => {
-      cy.findByDisplayValue("Previous").should("be.visible");
-      cy.findByDisplayValue("All time").should("not.exist");
-      cy.findByDisplayValue("Next").should("not.exist");
-    });
-
-    // switch to All time filter
-    popover().within(() => {
-      cy.findByDisplayValue("Previous").click();
-    });
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("All time").click();
-    cy.button("Apply").click();
-    cy.wait("@dataset");
-
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Created At is in the previous 3 years").should("not.exist");
-    cy.findByTextEnsureVisible("All time");
-  });
-});
 
 describe("issue 23023", () => {
   const questionDetails = {

--- a/frontend/src/metabase/querying/components/DatePicker/DateOperatorPicker/DateOperatorPicker.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/DateOperatorPicker/DateOperatorPicker.tsx
@@ -1,8 +1,14 @@
 import { useMemo } from "react";
+import { t } from "ttag";
 
-import { Group, Stack } from "metabase/ui";
+import { Group, Stack, Flex, Switch } from "metabase/ui";
 
 import { SimpleRelativeDatePicker } from "../RelativeDatePicker";
+import {
+  getIncludeCurrentLabel,
+  getIncludeCurrent,
+  setIncludeCurrent,
+} from "../RelativeDatePicker/DateIntervalPicker/utils";
 import { SimpleSpecificDatePicker } from "../SpecificDatePicker";
 import type { DatePickerOperator, DatePickerValue } from "../types";
 
@@ -35,6 +41,16 @@ export function DateOperatorPicker({
     }
   };
 
+  const includeCurrent = value && getIncludeCurrent(value);
+
+  const handleIncludeCurrentSwitch = () => {
+    if (!value) {
+      return;
+    }
+
+    onChange(setIncludeCurrent(value, !includeCurrent));
+  };
+
   return (
     <Stack>
       <Group>
@@ -43,6 +59,19 @@ export function DateOperatorPicker({
           <SimpleRelativeDatePicker value={value} onChange={onChange} />
         )}
       </Group>
+      {value?.type === "relative" && value?.value !== "current" && (
+        <Flex>
+          <Switch
+            aria-checked={includeCurrent}
+            checked={includeCurrent}
+            data-testid="include-current-interval-option"
+            label={t`Include ${getIncludeCurrentLabel(value.unit)}`}
+            labelPosition="right"
+            onChange={handleIncludeCurrentSwitch}
+            size="sm"
+          />
+        </Flex>
+      )}
       {value?.type === "specific" && (
         <SimpleSpecificDatePicker value={value} onChange={onChange} />
       )}

--- a/frontend/src/metabase/querying/components/DatePicker/DateOperatorPicker/DateOperatorPicker.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/DateOperatorPicker/DateOperatorPicker.tsx
@@ -9,6 +9,8 @@ import {
   getIncludeCurrent,
   setIncludeCurrent,
 } from "../RelativeDatePicker/DateIntervalPicker/utils";
+import type { DateIntervalValue } from "../RelativeDatePicker/types";
+import { isIntervalValue, isRelativeValue } from "../RelativeDatePicker/utils";
 import { SimpleSpecificDatePicker } from "../SpecificDatePicker";
 import type { DatePickerOperator, DatePickerValue } from "../types";
 
@@ -41,36 +43,38 @@ export function DateOperatorPicker({
     }
   };
 
-  const includeCurrent = value && getIncludeCurrent(value);
+  const IncludeCurrentSwitch = ({ value }: { value: DateIntervalValue }) => {
+    const includeCurrent = getIncludeCurrent(value);
 
-  const handleIncludeCurrentSwitch = () => {
-    if (!value) {
-      return;
-    }
+    const handleIncludeCurrentSwitch = () => {
+      onChange(setIncludeCurrent(value, !includeCurrent));
+    };
 
-    onChange(setIncludeCurrent(value, !includeCurrent));
+    return (
+      <Flex>
+        <Switch
+          aria-checked={includeCurrent}
+          checked={includeCurrent}
+          data-testid="include-current-interval-option"
+          label={t`Include ${getIncludeCurrentLabel(value.unit)}`}
+          labelPosition="right"
+          onChange={handleIncludeCurrentSwitch}
+          size="sm"
+        />
+      </Flex>
+    );
   };
 
   return (
     <Stack>
       <Group>
         <FlexSelect data={options} value={optionType} onChange={handleChange} />
-        {value?.type === "relative" && (
+        {value && isRelativeValue(value) && (
           <SimpleRelativeDatePicker value={value} onChange={onChange} />
         )}
       </Group>
-      {value?.type === "relative" && value?.value !== "current" && (
-        <Flex>
-          <Switch
-            aria-checked={includeCurrent}
-            checked={includeCurrent}
-            data-testid="include-current-interval-option"
-            label={t`Include ${getIncludeCurrentLabel(value.unit)}`}
-            labelPosition="right"
-            onChange={handleIncludeCurrentSwitch}
-            size="sm"
-          />
-        </Flex>
+      {value && isRelativeValue(value) && isIntervalValue(value) && (
+        <IncludeCurrentSwitch value={value} />
       )}
       {value?.type === "specific" && (
         <SimpleSpecificDatePicker value={value} onChange={onChange} />

--- a/frontend/src/metabase/querying/components/DatePicker/DateOperatorPicker/DateOperatorPicker.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/DateOperatorPicker/DateOperatorPicker.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { t } from "ttag";
 
-import { Group, Stack, Flex, Switch } from "metabase/ui";
+import { Group, Stack, Switch } from "metabase/ui";
 
 import { SimpleRelativeDatePicker } from "../RelativeDatePicker";
 import {
@@ -51,17 +51,15 @@ export function DateOperatorPicker({
     };
 
     return (
-      <Flex>
-        <Switch
-          aria-checked={includeCurrent}
-          checked={includeCurrent}
-          data-testid="include-current-interval-option"
-          label={t`Include ${getIncludeCurrentLabel(value.unit)}`}
-          labelPosition="right"
-          onChange={handleIncludeCurrentSwitch}
-          size="sm"
-        />
-      </Flex>
+      <Switch
+        aria-checked={includeCurrent}
+        checked={includeCurrent}
+        data-testid="include-current-interval-option"
+        label={t`Include ${getIncludeCurrentLabel(value.unit)}`}
+        labelPosition="right"
+        onChange={handleIncludeCurrentSwitch}
+        size="sm"
+      />
     );
   };
 

--- a/frontend/src/metabase/querying/components/DatePicker/DateOperatorPicker/DateOperatorPicker.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/DateOperatorPicker/DateOperatorPicker.tsx
@@ -1,15 +1,9 @@
 import { useMemo } from "react";
-import { t } from "ttag";
 
-import { Group, Stack, Switch } from "metabase/ui";
+import { Group, Stack } from "metabase/ui";
 
 import { SimpleRelativeDatePicker } from "../RelativeDatePicker";
-import {
-  getIncludeCurrentLabel,
-  getIncludeCurrent,
-  setIncludeCurrent,
-} from "../RelativeDatePicker/DateIntervalPicker/utils";
-import type { DateIntervalValue } from "../RelativeDatePicker/types";
+import { IncludeCurrentSwitch } from "../RelativeDatePicker/IncludeCurrentSwitch";
 import { isIntervalValue, isRelativeValue } from "../RelativeDatePicker/utils";
 import { SimpleSpecificDatePicker } from "../SpecificDatePicker";
 import type { DatePickerOperator, DatePickerValue } from "../types";
@@ -43,26 +37,6 @@ export function DateOperatorPicker({
     }
   };
 
-  const IncludeCurrentSwitch = ({ value }: { value: DateIntervalValue }) => {
-    const includeCurrent = getIncludeCurrent(value);
-
-    const handleIncludeCurrentSwitch = () => {
-      onChange(setIncludeCurrent(value, !includeCurrent));
-    };
-
-    return (
-      <Switch
-        aria-checked={includeCurrent}
-        checked={includeCurrent}
-        data-testid="include-current-interval-option"
-        label={t`Include ${getIncludeCurrentLabel(value.unit)}`}
-        labelPosition="right"
-        onChange={handleIncludeCurrentSwitch}
-        size="sm"
-      />
-    );
-  };
-
   return (
     <Stack>
       <Group>
@@ -72,7 +46,7 @@ export function DateOperatorPicker({
         )}
       </Group>
       {isRelativeValue(value) && isIntervalValue(value) && (
-        <IncludeCurrentSwitch value={value} />
+        <IncludeCurrentSwitch value={value} onChange={onChange} />
       )}
       {value?.type === "specific" && (
         <SimpleSpecificDatePicker value={value} onChange={onChange} />

--- a/frontend/src/metabase/querying/components/DatePicker/DateOperatorPicker/DateOperatorPicker.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/DateOperatorPicker/DateOperatorPicker.tsx
@@ -69,11 +69,11 @@ export function DateOperatorPicker({
     <Stack>
       <Group>
         <FlexSelect data={options} value={optionType} onChange={handleChange} />
-        {value && isRelativeValue(value) && (
+        {isRelativeValue(value) && (
           <SimpleRelativeDatePicker value={value} onChange={onChange} />
         )}
       </Group>
-      {value && isRelativeValue(value) && isIntervalValue(value) && (
+      {isRelativeValue(value) && isIntervalValue(value) && (
         <IncludeCurrentSwitch value={value} />
       )}
       {value?.type === "specific" && (

--- a/frontend/src/metabase/querying/components/DatePicker/DateOperatorPicker/DateOperatorPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/DateOperatorPicker/DateOperatorPicker.unit.spec.tsx
@@ -78,4 +78,87 @@ describe("DateOperatorPicker", () => {
       unit: "month",
     });
   });
+
+  describe("Include current switch", () => {
+    it("should not show 'Include current' switch by default", async () => {
+      setup();
+
+      await userEvent.click(screen.getByDisplayValue("All time"));
+      expect(screen.queryByLabelText(/^Include/)).not.toBeInTheDocument();
+    });
+
+    it("should not show 'Include current' switch by for the specific date value", async () => {
+      setup();
+
+      await userEvent.click(screen.getByDisplayValue("All time"));
+      await userEvent.click(screen.getByText("Between"));
+      expect(screen.queryByLabelText(/^Include/)).not.toBeInTheDocument();
+    });
+
+    it("should not show 'Include current' switch by for the `Current` relative date", async () => {
+      setup();
+
+      await userEvent.click(screen.getByDisplayValue("All time"));
+      await userEvent.click(screen.getByText("Current"));
+      expect(screen.queryByLabelText(/^Include/)).not.toBeInTheDocument();
+    });
+
+    it("should show 'Include current' switch and work for the relative `Previous` or `Next`", async () => {
+      setup({
+        value: {
+          type: "relative",
+          value: 1,
+          unit: "month",
+        },
+      });
+
+      expect(screen.getByDisplayValue("Next")).toBeInTheDocument();
+      expect(screen.getByLabelText("Include this month")).toBeInTheDocument();
+    });
+
+    it("should turn the 'Include current' switch on and register that change", async () => {
+      const { onChange } = setup({
+        value: {
+          type: "relative",
+          value: 1,
+          unit: "month",
+        },
+      });
+
+      await userEvent.click(screen.getByLabelText("Include this month"));
+
+      expect(onChange).toHaveBeenCalledWith({
+        options: {
+          "include-current": true,
+        },
+        type: "relative",
+        value: 1,
+        unit: "month",
+      });
+    });
+
+    it("should turn the 'Include current' switch off and register that change", async () => {
+      const { onChange } = setup({
+        value: {
+          options: {
+            "include-current": true,
+          },
+          type: "relative",
+          value: 1,
+          unit: "month",
+        },
+      });
+
+      await userEvent.click(screen.getByLabelText("Include this month"));
+
+      expect(onChange).toHaveBeenCalledWith({
+        options: {
+          "include-current": false,
+        },
+        type: "relative",
+        value: 1,
+        unit: "month",
+      });
+    });
+  });
 });

--- a/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.tsx
@@ -10,10 +10,10 @@ import {
   NumberInput,
   Select,
   Text,
-  Switch,
   Tooltip,
 } from "metabase/ui";
 
+import { IncludeCurrentSwitch } from "../IncludeCurrentSwitch";
 import type { DateIntervalValue } from "../types";
 import {
   formatDateRange,
@@ -22,13 +22,7 @@ import {
   getUnitOptions,
 } from "../utils";
 
-import {
-  getIncludeCurrentLabel,
-  getIncludeCurrent,
-  setIncludeCurrent,
-  setUnit,
-  setDefaultOffset,
-} from "./utils";
+import { setUnit, setDefaultOffset } from "./utils";
 
 interface DateIntervalPickerProps {
   value: DateIntervalValue;
@@ -47,7 +41,6 @@ export function DateIntervalPicker({
 }: DateIntervalPickerProps) {
   const interval = getInterval(value);
   const unitOptions = getUnitOptions(value);
-  const includeCurrent = getIncludeCurrent(value);
   const dateRangeText = formatDateRange(value);
 
   const handleIntervalChange = (inputValue: number | "") => {
@@ -65,10 +58,6 @@ export function DateIntervalPicker({
 
   const handleStartingFromClick = () => {
     onChange(setDefaultOffset(value));
-  };
-
-  const handleIncludeCurrentSwitch = () => {
-    onChange(setIncludeCurrent(value, !includeCurrent));
   };
 
   const handleSubmit = (event: FormEvent) => {
@@ -105,15 +94,7 @@ export function DateIntervalPicker({
         )}
       </Flex>
       <Flex p="md" pt={0}>
-        <Switch
-          aria-checked={includeCurrent}
-          checked={includeCurrent}
-          data-testid="include-current-interval-option"
-          label={t`Include ${getIncludeCurrentLabel(value.unit)}`}
-          labelPosition="right"
-          onChange={handleIncludeCurrentSwitch}
-          size="sm"
-        />
+        <IncludeCurrentSwitch value={value} onChange={onChange} />
       </Flex>
       <Divider />
       <Group px="md" py="sm" position="apart">

--- a/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/IncludeCurrentSwitch/IncludeCurrentSwitch.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/IncludeCurrentSwitch/IncludeCurrentSwitch.tsx
@@ -1,0 +1,38 @@
+import { t } from "ttag";
+
+import { Switch } from "metabase/ui";
+
+import {
+  getIncludeCurrentLabel,
+  getIncludeCurrent,
+  setIncludeCurrent,
+} from "../DateIntervalPicker/utils";
+import type { DateIntervalValue } from "../types";
+
+interface IncludeCurrentSwitchProps {
+  value: DateIntervalValue;
+  onChange: (value: DateIntervalValue) => void;
+}
+
+export const IncludeCurrentSwitch = ({
+  value,
+  onChange,
+}: IncludeCurrentSwitchProps) => {
+  const includeCurrent = getIncludeCurrent(value);
+
+  const handleIncludeCurrentSwitch = () => {
+    onChange(setIncludeCurrent(value, !includeCurrent));
+  };
+
+  return (
+    <Switch
+      aria-checked={includeCurrent}
+      checked={includeCurrent}
+      data-testid="include-current-interval-option"
+      label={t`Include ${getIncludeCurrentLabel(value.unit)}`}
+      labelPosition="right"
+      onChange={handleIncludeCurrentSwitch}
+      size="sm"
+    />
+  );
+};

--- a/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/IncludeCurrentSwitch/index.ts
+++ b/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/IncludeCurrentSwitch/index.ts
@@ -1,0 +1,1 @@
+export * from "./IncludeCurrentSwitch";

--- a/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/utils.ts
+++ b/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/utils.ts
@@ -12,9 +12,9 @@ import { DEFAULT_VALUE } from "./constants";
 import type { DateIntervalValue, DateOffsetIntervalValue } from "./types";
 
 export function isRelativeValue(
-  value: DatePickerValue,
+  value?: DatePickerValue,
 ): value is RelativeDatePickerValue {
-  return value.type === "relative";
+  return value?.type === "relative";
 }
 
 export function isIntervalValue(

--- a/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/utils.ts
+++ b/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/utils.ts
@@ -5,10 +5,17 @@ import type {
   RelativeIntervalDirection,
   RelativeDatePickerValue,
   DatePickerTruncationUnit,
+  DatePickerValue,
 } from "../types";
 
 import { DEFAULT_VALUE } from "./constants";
 import type { DateIntervalValue, DateOffsetIntervalValue } from "./types";
+
+export function isRelativeValue(
+  value: DatePickerValue,
+): value is RelativeDatePickerValue {
+  return value.type === "relative";
+}
 
 export function isIntervalValue(
   value: RelativeDatePickerValue,


### PR DESCRIPTION
### Description

This PR concludes the Milestone 2 of #44096 by implementing the "Include this" toggle in the time-series chrome component, and covering it with both the unit and E2E tests.

Implements #42220
Resolves #44323

### How to verify
- Follow the actions from the [testing plan](https://github.com/metabase/metabase/issues/44323)
- All tests should pass in CI.

### Checklist
- [x] Tests have been added/updated to cover changes in this PR

### Additional notes
The design tweaks are not in the scope of this PR. They belong to the Milestone 3.
