### PR TITLE
fix: Use an indicator-agnostic testid

### DIFF
--- a/e2e/test/scenarios/admin-2/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/settings.cy.spec.js
@@ -1011,7 +1011,7 @@ describe("scenarios > admin > localization", () => {
 
     cy.wait("@dataset");
 
-    cy.findByTestId("loading-spinner").should("not.exist");
+    cy.findByTestId("loading-indicator").should("not.exist");
 
     // verify that the correct row is displayed
     cy.findByTestId("TableInteractive-root").within(() => {

--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -502,7 +502,7 @@ describe("scenarios > collection defaults", () => {
       // we need to do this manually because we need to await the correct number of api requests to keep this from flaking
 
       entityPickerModal().within(() => {
-        cy.findByTestId("loading-spinner").should("not.exist");
+        cy.findByTestId("loading-indicator").should("not.exist");
         cy.findByRole("tab", { name: /Collections/ }).click();
         cy.wait([
           "@getCollectionItems",

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-id.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-id.cy.spec.js
@@ -35,7 +35,7 @@ describe("scenarios > dashboard > filters > ID", () => {
 
       filterWidget().click();
       addWidgetStringFilter("15");
-      cy.findByTestId("loading-spinner").should("not.exist");
+      cy.findByTestId("loading-indicator").should("not.exist");
 
       cy.findByTestId("dashcard").within(() => {
         cy.findByText("114.42");
@@ -48,7 +48,7 @@ describe("scenarios > dashboard > filters > ID", () => {
       addWidgetStringFilter("15");
 
       saveDashboard();
-      cy.findByTestId("loading-spinner").should("not.exist");
+      cy.findByTestId("loading-indicator").should("not.exist");
 
       cy.findByTestId("dashcard").within(() => {
         cy.findByText("114.42");
@@ -66,7 +66,7 @@ describe("scenarios > dashboard > filters > ID", () => {
 
       filterWidget().click();
       addWidgetStringFilter("4");
-      cy.findByTestId("loading-spinner").should("not.exist");
+      cy.findByTestId("loading-indicator").should("not.exist");
 
       cy.findByTestId("dashcard").within(() => {
         cy.findByText("47.68");
@@ -81,7 +81,7 @@ describe("scenarios > dashboard > filters > ID", () => {
       addWidgetStringFilter("4");
 
       saveDashboard();
-      cy.findByTestId("loading-spinner").should("not.exist");
+      cy.findByTestId("loading-indicator").should("not.exist");
 
       cy.findByTestId("dashcard").within(() => {
         cy.findByText("47.68");
@@ -106,7 +106,7 @@ describe("scenarios > dashboard > filters > ID", () => {
 
       filterWidget().click();
       addWidgetStringFilter("10");
-      cy.findByTestId("loading-spinner").should("not.exist");
+      cy.findByTestId("loading-indicator").should("not.exist");
 
       cy.findByTestId("dashcard").within(() => {
         cy.findByText("6.75");
@@ -119,7 +119,7 @@ describe("scenarios > dashboard > filters > ID", () => {
       addWidgetStringFilter("10");
 
       saveDashboard();
-      cy.findByTestId("loading-spinner").should("not.exist");
+      cy.findByTestId("loading-indicator").should("not.exist");
 
       cy.findByTestId("dashcard").within(() => {
         cy.findByText("6.75");

--- a/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
@@ -329,7 +329,7 @@ describe(
       cy.wait("@dashboard");
 
       getDashboardCard().within(() => {
-        cy.findByTestId("loading-spinner").should("be.visible");
+        cy.findByTestId("loading-indicator").should("be.visible");
         cy.findByText("Sleep card").click();
         cy.wait("@card");
       });

--- a/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
@@ -1238,7 +1238,9 @@ describe("issue 39863", () => {
   }
 
   function assertNoLoadingSpinners() {
-    dashboardGrid().findAllByTestId("loading-spinner").should("have.length", 0);
+    dashboardGrid()
+      .findAllByTestId("loading-indicator")
+      .should("have.length", 0);
   }
 
   beforeEach(() => {

--- a/e2e/test/scenarios/dashboard/tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/tabs.cy.spec.js
@@ -686,7 +686,7 @@ describe("scenarios > dashboard > tabs", () => {
 
     // Loader in the 2nd tab
     getDashboardCard(0).within(() => {
-      cy.findByTestId("loading-spinner").should("exist");
+      cy.findByTestId("loading-indicator").should("exist");
       cy.wait("@saveCard");
       cy.findAllByTestId("table-row").should("exist");
     });
@@ -695,7 +695,7 @@ describe("scenarios > dashboard > tabs", () => {
     // should not show a loader and re-run query
     goToTab("Tab 1");
     getDashboardCard(0).within(() => {
-      cy.findByTestId("loading-spinner").should("not.exist");
+      cy.findByTestId("loading-indicator").should("not.exist");
       cy.findAllByTestId("table-row").should("exist");
     });
   });

--- a/e2e/test/scenarios/dashboard/title-drill.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/title-drill.cy.spec.js
@@ -41,7 +41,7 @@ describe("scenarios > dashboard > title drill", () => {
     describe("as a user with access to underlying data", () => {
       it("should let you click through the title to the query builder (metabase#13042)", () => {
         cy.get("@questionId").then(questionId => {
-          cy.findByTestId("loading-spinner").should("not.exist");
+          cy.findByTestId("loading-indicator").should("not.exist");
 
           getDashboardCard().findByRole("link", { name: "Q1" }).as("title");
           cy.get("@title")
@@ -68,7 +68,7 @@ describe("scenarios > dashboard > title drill", () => {
 
       it("should let you click through the title to the query builder (metabase#13042)", () => {
         cy.get("@questionId").then(questionId => {
-          cy.findByTestId("loading-spinner").should("not.exist");
+          cy.findByTestId("loading-indicator").should("not.exist");
 
           getDashboardCard().findByRole("link", { name: "Q1" }).as("title");
           cy.get("@title")

--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -1551,7 +1551,7 @@ describe("issue 25322", () => {
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(parameterDetails.name).click();
-    popover().findByTestId("loading-spinner").should("exist");
+    popover().findByTestId("loading-indicator").should("exist");
   });
 });
 

--- a/e2e/test/scenarios/filters/filter.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter.cy.spec.js
@@ -133,7 +133,7 @@ describe("scenarios > question > filter", () => {
     cy.findByTestId("apply-filters").click();
 
     cy.log("Reported failing on v0.36.4 and v0.36.5.1");
-    cy.findByTestId("loading-spinner").should("not.exist");
+    cy.findByTestId("loading-indicator").should("not.exist");
     cy.findAllByText("148.23"); // one of the subtotals for this product
     cy.findAllByText("Fantastic Wool Shirt").should("not.exist");
   });

--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -450,7 +450,7 @@ describe("scenarios > home > custom homepage", () => {
 
       cy.visit("/");
       dashboardGrid()
-        .findAllByTestId("loading-spinner")
+        .findAllByTestId("loading-indicator")
         .should("have.length", 0);
 
       cy.findByTestId("main-logo-link").click().click();

--- a/e2e/test/scenarios/question-reproductions/reproductions-1.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-1.cy.spec.js
@@ -300,7 +300,7 @@ describe("postgres > user > query", { tags: "@external" }, () => {
 
     // Wait until "doing science" spinner disappears (DOM is ready for assertions)
     // TODO: if this proves to be reliable, extract it as a helper function for waiting on DOM to render
-    cy.findByTestId("loading-spinner").should("not.exist");
+    cy.findByTestId("loading-indicator").should("not.exist");
 
     // Assertions
     cy.log("Fails in v0.36.6");
@@ -979,13 +979,13 @@ describe("issue 19341", () => {
     // Test "Saved Questions" table is hidden in QB data selector
     startNewQuestion();
     entityPickerModal().within(() => {
-      cy.findByTestId("loading-spinner").should("not.exist");
+      cy.findByTestId("loading-indicator").should("not.exist");
       cy.findByText("Orders").should("exist");
       cy.findAllByRole("tab").should("not.exist");
 
       // Ensure the search doesn't list saved questions
       cy.findByPlaceholderText("Search…").type("Ord");
-      cy.findByTestId("loading-spinner").should("not.exist");
+      cy.findByTestId("loading-indicator").should("not.exist");
 
       cy.findAllByTestId("result-item").then($result => {
         const searchResults = $result.toArray();

--- a/e2e/test/scenarios/question/nulls.cy.spec.js
+++ b/e2e/test/scenarios/question/nulls.cy.spec.js
@@ -99,7 +99,7 @@ describe("scenarios > question > null", () => {
 
       cy.log("Reported failing in v0.37.0.2");
       cy.findByTestId("dashcard-container").within(() => {
-        cy.findByTestId("loading-spinner").should("not.exist");
+        cy.findByTestId("loading-indicator").should("not.exist");
         cy.findByTestId("legend-caption-title").should("have.text", "13626");
         cy.findByTestId("pie-chart").should("be.visible");
         cy.findByTestId("detail-value")
@@ -133,7 +133,7 @@ describe("scenarios > question > null", () => {
 
           visitDashboard(DASHBOARD_ID);
           cy.log("P0 regression in v0.37.1!");
-          cy.findByTestId("loading-spinner").should("not.exist");
+          cy.findByTestId("loading-indicator").should("not.exist");
           cy.findByText("13801_Q1");
           cy.findAllByTestId("scalar-value").should("contain", "0");
           cy.findByText("13801_Q2");

--- a/e2e/test/scenarios/search/recently-viewed.cy.spec.js
+++ b/e2e/test/scenarios/search/recently-viewed.cy.spec.js
@@ -41,7 +41,7 @@ describe("search > recently viewed", () => {
 
     cy.findByPlaceholderText("Search…").click();
 
-    cy.findByTestId("loading-spinner").should("not.exist");
+    cy.findByTestId("loading-indicator").should("not.exist");
   });
 
   it("shows list of recently viewed items", () => {
@@ -62,7 +62,7 @@ describe("search > recently viewed", () => {
   it("shows up-to-date list of recently viewed items after another page is visited (metabase#36868)", () => {
     cy.findByPlaceholderText("Search…").click();
     cy.wait("@recent");
-    cy.findByTestId("loading-spinner").should("not.exist");
+    cy.findByTestId("loading-indicator").should("not.exist");
     cy.log("check output");
     cy.wait(10000);
 

--- a/e2e/test/scenarios/search/search-snowplow.cy.spec.js
+++ b/e2e/test/scenarios/search/search-snowplow.cy.spec.js
@@ -94,7 +94,7 @@ describeWithSnowplow("scenarios > search > snowplow", () => {
         qs: { top_nav: true, search: true },
       });
       cy.findByPlaceholderText("Search…").type("coun");
-      cy.findByTestId("loading-spinner").should("not.exist");
+      cy.findByTestId("loading-indicator").should("not.exist");
 
       expectGoodSnowplowEvent({
         event: NEW_SEARCH_QUERY_EVENT_NAME,

--- a/e2e/test/scenarios/search/search-typeahead.cy.spec.js
+++ b/e2e/test/scenarios/search/search-typeahead.cy.spec.js
@@ -24,7 +24,7 @@ import {
         user === "admin" ? Object.entries(USERS).length : 1;
 
       cy.findByPlaceholderText("Search…").type("pers");
-      cy.findByTestId("loading-spinner").should("not.exist");
+      cy.findByTestId("loading-indicator").should("not.exist");
       cy.findByTestId("search-results-list").within(() => {
         cy.findAllByText(/personal collection$/i).should(
           "have.length",

--- a/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
@@ -395,7 +395,7 @@ describe("#22206 adding and removing columns doesn't duplicate columns", () => {
     cy.signInAsNormalUser();
     openOrdersTable();
 
-    cy.findByTestId("loading-spinner").should("not.exist");
+    cy.findByTestId("loading-indicator").should("not.exist");
   });
 
   it("should not duplicate column in settings when removing and adding it back", () => {
@@ -411,7 +411,7 @@ describe("#22206 adding and removing columns doesn't duplicate columns", () => {
     // rerun query
     cy.findAllByTestId("run-button").first().click();
     cy.wait("@dataset");
-    cy.findByTestId("loading-spinner").should("not.exist");
+    cy.findByTestId("loading-indicator").should("not.exist");
 
     // add column back again
     cy.findByTestId("sidebar-content")

--- a/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentWrapper/PublicComponentWrapper.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentWrapper/PublicComponentWrapper.unit.spec.tsx
@@ -42,7 +42,7 @@ describe("PublicComponentWrapper", () => {
 
   it("renders loader when loginStatus is loading", () => {
     setup({ status: "loading" });
-    const loader = screen.getByTestId("loading-spinner");
+    const loader = screen.getByTestId("loading-indicator");
     expect(loader).toBeInTheDocument();
   });
 

--- a/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentWrapper/SdkLoader.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentWrapper/SdkLoader.tsx
@@ -7,5 +7,5 @@ export const SdkLoader = () => {
 
   const LoaderComponent = CustomLoader || Loader;
 
-  return <LoaderComponent data-testid="loading-spinner" />;
+  return <LoaderComponent data-testid="loading-indicator" />;
 };

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
@@ -101,7 +101,7 @@ describe("InteractiveQuestion", () => {
   it("should initially render with a loader", async () => {
     setup();
 
-    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
   });
 
   it("should render when question is valid", async () => {
@@ -133,7 +133,7 @@ describe("InteractiveQuestion", () => {
       await within(screen.getByRole("gridcell")).findByText("Test Row"),
     ).toBeInTheDocument();
 
-    expect(screen.queryByTestId("loading-spinner")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("loading-indicator")).not.toBeInTheDocument();
     // Mimicking drilling down by rerunning the query again
     const storeDispatch = store.dispatch as unknown as ThunkDispatch<
       State,
@@ -146,7 +146,7 @@ describe("InteractiveQuestion", () => {
     });
 
     expect(screen.queryByText("Question not found")).not.toBeInTheDocument();
-    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
     expect(
       within(await screen.findByRole("gridcell")).getByText("Test Row"),
     ).toBeInTheDocument();

--- a/enterprise/frontend/src/embedding-sdk/components/public/StaticQuestion/StaticQuestion.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/StaticQuestion/StaticQuestion.unit.spec.tsx
@@ -91,7 +91,7 @@ const setup = ({
 describe("StaticQuestion", () => {
   it("should render a loader on initialization", () => {
     setup();
-    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
   });
 
   it("should render question if question is valid", async () => {

--- a/frontend/src/metabase/actions/containers/ActionExecuteModal/ActionExecuteModal.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionExecuteModal/ActionExecuteModal.unit.spec.tsx
@@ -64,7 +64,7 @@ describe("Actions > ActionExecuteModal", () => {
       shouldPrefetch: true,
     });
 
-    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
 
     await waitForLoaderToBeRemoved();
 

--- a/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettings.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettings.unit.spec.tsx
@@ -514,7 +514,9 @@ describe("Admin > Settings > UploadSetting", () => {
         name: "Update settings",
       });
       await userEvent.click(updateButton);
-      expect(await screen.findByTestId("loading-spinner")).toBeInTheDocument();
+      expect(
+        await screen.findByTestId("loading-indicator"),
+      ).toBeInTheDocument();
       expect(
         screen.queryByRole("button", { name: "Update settings" }),
       ).not.toBeInTheDocument();
@@ -540,7 +542,9 @@ describe("Admin > Settings > UploadSetting", () => {
         name: "Update settings",
       });
       await userEvent.click(updateButton);
-      expect(await screen.findByTestId("loading-spinner")).toBeInTheDocument();
+      expect(
+        await screen.findByTestId("loading-indicator"),
+      ).toBeInTheDocument();
       expect(
         screen.queryByRole("button", { name: "Update settings" }),
       ).not.toBeInTheDocument();

--- a/frontend/src/metabase/admin/tasks/components/Logs/Logs.unit.spec.tsx
+++ b/frontend/src/metabase/admin/tasks/components/Logs/Logs.unit.spec.tsx
@@ -34,7 +34,7 @@ describe("Logs", () => {
       fetchMock.get("path:/api/util/logs", []);
       render(<Logs />);
       await waitFor(() => [
-        expect(screen.getByTestId("loading-spinner")).toBeInTheDocument(),
+        expect(screen.getByTestId("loading-indicator")).toBeInTheDocument(),
         expect(utilSpy).toHaveBeenCalledTimes(1),
       ]);
     });
@@ -45,7 +45,7 @@ describe("Logs", () => {
       utilSpy.mockReturnValueOnce(new Promise(res => (resolve = res)));
       render(<Logs />);
       await waitFor(() => [
-        expect(screen.getByTestId("loading-spinner")).toBeInTheDocument(),
+        expect(screen.getByTestId("loading-indicator")).toBeInTheDocument(),
         expect(utilSpy).toHaveBeenCalledTimes(1),
       ]);
       act(() => {

--- a/frontend/src/metabase/browse/components/TableBrowser/TableBrowser.unit.spec.js
+++ b/frontend/src/metabase/browse/components/TableBrowser/TableBrowser.unit.spec.js
@@ -18,7 +18,7 @@ describe("TableBrowser", () => {
 
     expect(screen.getByText("Orders")).toBeInTheDocument();
     expect(screen.getByLabelText("bolt_filled icon")).toBeInTheDocument();
-    expect(screen.queryByTestId("loading-spinner")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("loading-indicator")).not.toBeInTheDocument();
   });
 
   it.each(["incomplete", "complete"])(
@@ -43,7 +43,7 @@ describe("TableBrowser", () => {
       expect(
         screen.queryByLabelText("bolt_filled icon"),
       ).not.toBeInTheDocument();
-      expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+      expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
     },
   );
 
@@ -67,7 +67,7 @@ describe("TableBrowser", () => {
 
     expect(screen.getByText("Orders")).toBeInTheDocument();
     expect(screen.getByLabelText("bolt_filled icon")).toBeInTheDocument();
-    expect(screen.queryByTestId("loading-spinner")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("loading-indicator")).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/src/metabase/browse/containers/TableBrowser/TableBrowser.unit.spec.js
+++ b/frontend/src/metabase/browse/containers/TableBrowser/TableBrowser.unit.spec.js
@@ -28,7 +28,7 @@ describe("TableBrowser", () => {
     const calls = await fetchMock.calls(/\/api\/database\/1\/schema\/public/);
     expect(calls.length).toBe(1);
     // check the loading spinner is present
-    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
     // change the table to have initial_sync_status='complete'
     fetchMock.get(
       "path:/api/database/1/schema/public",

--- a/frontend/src/metabase/common/components/EntityPicker/components/LoadingSpinner/LoadingSpinner.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/LoadingSpinner/LoadingSpinner.tsx
@@ -36,7 +36,7 @@ export const DelayedLoadingSpinner = ({
 
   if (!show) {
     // make tests aware that things are loading
-    return <span data-testid="loading-spinner" />;
+    return <span data-testid="loading-indicator" />;
   }
 
   return <LoadingSpinner text={text} />;

--- a/frontend/src/metabase/common/components/EntityPicker/components/LoadingSpinner/LoadingSpinner.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/LoadingSpinner/LoadingSpinner.tsx
@@ -8,7 +8,7 @@ export const LoadingSpinner = ({ text }: { text?: string }) => (
     align="center"
     justify="center"
     h="100%"
-    data-testid="loading-spinner"
+    data-testid="loading-indicator"
     gap="md"
   >
     <Loader size="lg" />

--- a/frontend/src/metabase/common/hooks/entity-framework/use-action-list-query/use-action-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/entity-framework/use-action-list-query/use-action-list-query.unit.spec.tsx
@@ -35,7 +35,7 @@ const setup = () => {
 describe("useActionListQuery", () => {
   it("should be initially loading", () => {
     setup();
-    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
   });
 
   it("should show data from the response", async () => {

--- a/frontend/src/metabase/common/hooks/entity-framework/use-action-query/use-action-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/entity-framework/use-action-query/use-action-query.unit.spec.tsx
@@ -37,7 +37,7 @@ const setup = () => {
 describe("useActionQuery", () => {
   it("should be initially loading", () => {
     setup();
-    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
   });
 
   it("should show data from the response", async () => {

--- a/frontend/src/metabase/common/hooks/entity-framework/use-bookmark-list-query/use-bookmark-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/entity-framework/use-bookmark-list-query/use-bookmark-list-query.unit.spec.tsx
@@ -48,7 +48,7 @@ describe("useBookmarkListQuery", () => {
   it("should be initially loading", () => {
     setup();
 
-    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
   });
 
   it("should display error", async () => {

--- a/frontend/src/metabase/common/hooks/entity-framework/use-collection-list-query/use-collection-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/entity-framework/use-collection-list-query/use-collection-list-query.unit.spec.tsx
@@ -48,7 +48,7 @@ describe("useCollectionListQuery", () => {
   it("should be initially loading", () => {
     setup();
 
-    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
   });
 
   it("should display error", async () => {

--- a/frontend/src/metabase/common/hooks/entity-framework/use-collection-query/use-collection-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/entity-framework/use-collection-query/use-collection-query.unit.spec.tsx
@@ -42,7 +42,7 @@ const setup = ({ error }: { error?: string } = {}) => {
 describe("useCollectionQuery", () => {
   it("should be initially loading", () => {
     setup();
-    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
   });
 
   it("should display error", async () => {

--- a/frontend/src/metabase/common/hooks/entity-framework/use-dashboard-query/use-dashboard-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/entity-framework/use-dashboard-query/use-dashboard-query.unit.spec.tsx
@@ -34,7 +34,7 @@ const setup = () => {
 describe("useDashboardQuery", () => {
   it("should be initially loading", () => {
     setup();
-    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
   });
 
   it("should show data from the response", async () => {

--- a/frontend/src/metabase/common/hooks/entity-framework/use-database-list-query/use-database-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/entity-framework/use-database-list-query/use-database-list-query.unit.spec.tsx
@@ -35,7 +35,7 @@ const setup = () => {
 describe("useDatabaseListQuery", () => {
   it("should be initially loading", () => {
     setup();
-    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
   });
 
   it("should show data from the response", async () => {

--- a/frontend/src/metabase/common/hooks/entity-framework/use-database-query/use-database-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/entity-framework/use-database-query/use-database-query.unit.spec.tsx
@@ -44,7 +44,7 @@ const setup = ({ hasDataAccess = true }: SetupOpts = {}) => {
 describe("useDatabaseQuery", () => {
   it("should be initially loading", () => {
     setup();
-    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
   });
 
   it("should show data from the response", async () => {

--- a/frontend/src/metabase/common/hooks/entity-framework/use-entity-list-query/use-entity-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/entity-framework/use-entity-list-query/use-entity-list-query.unit.spec.tsx
@@ -114,7 +114,7 @@ describe("useEntityListQuery", () => {
   it("should be initially loading", () => {
     setup();
 
-    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
   });
 
   it("should initially load data only once the reload flag in a nested component tree", async () => {
@@ -204,7 +204,7 @@ describe("useEntityListQuery", () => {
     expect(fetchMock.calls("path:/api/database")).toHaveLength(1);
 
     expect(
-      within(screen.getByTestId("test2")).getByTestId("loading-spinner"),
+      within(screen.getByTestId("test2")).getByTestId("loading-indicator"),
     ).toBeInTheDocument();
 
     await delay(100); // trigger fetch request to be resolved
@@ -212,6 +212,6 @@ describe("useEntityListQuery", () => {
     await delay(0); // trigger extra event loop to make sure React state has been updated
 
     expect(fetchMock.calls("path:/api/database")).toHaveLength(1);
-    expect(screen.queryByTestId("loading-spinner")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("loading-indicator")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/common/hooks/entity-framework/use-entity-query/use-entity-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/entity-framework/use-entity-query/use-entity-query.unit.spec.tsx
@@ -86,7 +86,7 @@ describe("useEntityQuery", () => {
   it("should be initially loading", () => {
     setup();
 
-    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
   });
 
   it("should initially load data only once the reload flag", async () => {

--- a/frontend/src/metabase/common/hooks/entity-framework/use-model-indexes-list-query/use-model-indexes-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/entity-framework/use-model-indexes-list-query/use-model-indexes-list-query.unit.spec.tsx
@@ -46,7 +46,7 @@ const setup = () => {
 describe("useModelIndexesListQuery", () => {
   it("should be initially loading", () => {
     setup();
-    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
   });
 
   it("should show data from the response", async () => {

--- a/frontend/src/metabase/common/hooks/entity-framework/use-question-list-query/use-question-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/entity-framework/use-question-list-query/use-question-list-query.unit.spec.tsx
@@ -40,7 +40,7 @@ const setup = () => {
 describe("useQuestionListQuery", () => {
   it("should be initially loading", () => {
     setup();
-    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
   });
 
   it("should show data from the response", async () => {

--- a/frontend/src/metabase/common/hooks/entity-framework/use-question-query/use-question-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/entity-framework/use-question-query/use-question-query.unit.spec.tsx
@@ -31,7 +31,7 @@ const setup = () => {
 describe("useQuestionQuery", () => {
   it("should be initially loading", () => {
     setup();
-    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
   });
 
   it("should show data from the response", async () => {

--- a/frontend/src/metabase/common/hooks/entity-framework/use-revision-list-query/use-revision-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/entity-framework/use-revision-list-query/use-revision-list-query.unit.spec.tsx
@@ -40,7 +40,7 @@ function setup() {
 describe("useRevisionListQuery", () => {
   it("should be initially loading", () => {
     setup();
-    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
   });
 
   it("should show data from the response", async () => {

--- a/frontend/src/metabase/common/hooks/entity-framework/use-search-list-query/use-search-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/entity-framework/use-search-list-query/use-search-list-query.unit.spec.tsx
@@ -82,7 +82,7 @@ const setup = () => {
 describe("useSearchListQuery", () => {
   it("should be initially loading", () => {
     setup();
-    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
   });
 
   it("should show data from the response", async () => {

--- a/frontend/src/metabase/common/hooks/entity-framework/use-table-list-query/use-table-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/entity-framework/use-table-list-query/use-table-list-query.unit.spec.tsx
@@ -40,7 +40,7 @@ const setup = () => {
 describe("useTableListQuery", () => {
   it("should be initially loading", () => {
     setup();
-    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
   });
 
   it("should show data from the response", async () => {

--- a/frontend/src/metabase/common/hooks/entity-framework/use-table-query/use-table-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/entity-framework/use-table-query/use-table-query.unit.spec.tsx
@@ -31,7 +31,7 @@ const setup = () => {
 describe("useTableQuery", () => {
   it("should be initially loading", () => {
     setup();
-    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
   });
 
   it("should show data from the response", async () => {

--- a/frontend/src/metabase/common/hooks/entity-framework/use-user-list-query/use-user-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/entity-framework/use-user-list-query/use-user-list-query.unit.spec.tsx
@@ -59,7 +59,7 @@ function setup({ getRecipients = false }: TestComponentProps = {}) {
 describe("useUserListQuery", () => {
   it("should be initially loading", () => {
     setup();
-    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
   });
 
   it("should show data from the response", async () => {

--- a/frontend/src/metabase/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper.tsx
+++ b/frontend/src/metabase/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper.tsx
@@ -54,7 +54,7 @@ export const DelayedLoadingAndErrorWrapper = ({
   }
   if (!showWrapper) {
     // make tests aware that things are loading
-    return <span data-testid="loading-spinner" />;
+    return <span data-testid="loading-indicator" />;
   }
   return (
     <Transition

--- a/frontend/src/metabase/components/LoadingAndErrorWrapper/LoadingAndErrorWrapper.unit.spec.js
+++ b/frontend/src/metabase/components/LoadingAndErrorWrapper/LoadingAndErrorWrapper.unit.spec.js
@@ -6,7 +6,7 @@ describe("LoadingAndErrorWrapper", () => {
     it("should display a loading message if given a true loading prop", () => {
       render(<LoadingAndErrorWrapper loading={true} />);
 
-      expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+      expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
     });
 
     it("should display a given child if loading is false", () => {

--- a/frontend/src/metabase/components/LoadingSpinner/LoadingSpinner.tsx
+++ b/frontend/src/metabase/components/LoadingSpinner/LoadingSpinner.tsx
@@ -18,7 +18,7 @@ const BaseLoadingSpinner = ({
 }: Props) => (
   <SpinnerRoot
     className={className}
-    data-testid={dataTestId ?? "loading-spinner"}
+    data-testid={dataTestId ?? "loading-indicator"}
   >
     {isReducedMotionPreferred() ? (
       <Icon name="hourglass" size="24" />

--- a/frontend/src/metabase/nav/components/search/SearchResults/SearchResults.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchResults/SearchResults.tsx
@@ -51,7 +51,7 @@ export type SearchResultsProps = {
 
 export const SearchLoadingSpinner = () => (
   <Stack p="xl" align="center">
-    <Loader size="lg" data-testid="loading-spinner" />
+    <Loader size="lg" data-testid="loading-indicator" />
     <Text size="xl" color="text-light">
       {t`Loading…`}
     </Text>

--- a/frontend/src/metabase/nav/containers/MainNavbar/NavbarLoadingView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/NavbarLoadingView.tsx
@@ -22,7 +22,7 @@ const SectionTitleSkeleton = () => (
 
 export function NavbarLoadingView() {
   return (
-    <div aria-busy data-testid="loading-spinner">
+    <div aria-busy data-testid="loading-indicator">
       <SidebarSection>
         <NavLinkSkeleton />
       </SidebarSection>

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.unit.spec.js
@@ -187,7 +187,7 @@ describe("DataSelector", () => {
     await delay(1);
     expect(fetchDatabases).toHaveBeenCalled();
     rerender(<DataSelector {...props} loading />);
-    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
 
     // select a db
     let nextMetadata = createMockMetadata({ databases });

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.unit.spec.js
@@ -34,7 +34,7 @@ describe("DataSelectorDatabaseSchemaPicker", () => {
   it("displays loading message when it has no databases", () => {
     render(<DataSelectorDatabaseSchemaPicker databases={[]} />);
 
-    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
   });
 
   describe("displays picker when it has databases", () => {
@@ -100,8 +100,8 @@ describe("DataSelectorDatabaseSchemaPicker", () => {
       ],
     });
     setup({ database });
-    // There should only be one loading-spinner next to the database name, and not the schema names
-    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    // There should only be one loading-indicator next to the database name, and not the schema names
+    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
     expect(screen.getByText("Schema 1")).toBeInTheDocument();
     expect(screen.getByText("Schema 2")).toBeInTheDocument();
   });

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorTablePicker/DataSelectorTablePicker.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorTablePicker/DataSelectorTablePicker.unit.spec.tsx
@@ -42,7 +42,7 @@ describe("DataSelectorTablePicker", () => {
         tables: [createMockTable({ initial_sync_status })],
       });
       setup({ database });
-      expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+      expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
     },
   );
 
@@ -51,7 +51,7 @@ describe("DataSelectorTablePicker", () => {
       tables: [createMockTable({ initial_sync_status: "complete" })],
     });
     setup({ database });
-    expect(screen.queryByTestId("loading-spinner")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("loading-indicator")).not.toBeInTheDocument();
   });
 
   it("when no table is in database", () => {

--- a/frontend/src/metabase/querying/components/FilterValuePicker/FilterValuePicker.tsx
+++ b/frontend/src/metabase/querying/components/FilterValuePicker/FilterValuePicker.tsx
@@ -61,7 +61,7 @@ function FilterValuePicker({
   if (isLoading) {
     return (
       <Center h="2.5rem">
-        <Loader data-testid="loading-spinner" />
+        <Loader data-testid="loading-indicator" />
       </Center>
     );
   }

--- a/frontend/src/metabase/search/components/SearchFilterPopoverWrapper/SearchFilterPopoverWrapper.tsx
+++ b/frontend/src/metabase/search/components/SearchFilterPopoverWrapper/SearchFilterPopoverWrapper.tsx
@@ -34,7 +34,7 @@ export const SearchFilterPopoverWrapper = ({
   if (isLoading) {
     return (
       <Center p="lg">
-        <Loader data-testid="loading-spinner" />
+        <Loader data-testid="loading-indicator" />
       </Center>
     );
   }

--- a/frontend/src/metabase/search/components/SearchFilterPopoverWrapper/SearchFilterPopoverWrapper.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/SearchFilterPopoverWrapper/SearchFilterPopoverWrapper.unit.spec.tsx
@@ -26,7 +26,7 @@ describe("SearchFilterPopoverWrapper", () => {
   it("should render loading spinner when isLoading is true", () => {
     setup({ isLoading: true });
 
-    const loadingSpinner = screen.getByTestId("loading-spinner");
+    const loadingSpinner = screen.getByTestId("loading-indicator");
     expect(loadingSpinner).toBeInTheDocument();
   });
 

--- a/frontend/src/metabase/search/components/SearchUserPicker/SearchUserPicker.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/SearchUserPicker/SearchUserPicker.unit.spec.tsx
@@ -43,7 +43,7 @@ const setup = async ({
   );
 
   await waitFor(() => {
-    expect(screen.queryByTestId("loading-spinner")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("loading-indicator")).not.toBeInTheDocument();
   });
 
   return { mockOnChange };

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailView.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailView.unit.spec.tsx
@@ -306,7 +306,7 @@ describe("ObjectDetailView", () => {
     // because this row is not in the test dataset, it should trigger a fetch
     setup({ question: mockQuestion, zoomedRowID: "101", zoomedRow: undefined });
 
-    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
     expect(
       await screen.findByText(/Extremely Hungry Toucan/i),
     ).toBeInTheDocument();
@@ -318,7 +318,7 @@ describe("ObjectDetailView", () => {
     // because this row is not in the test dataset, it should trigger a fetch
     setup({ question: mockQuestion, zoomedRowID: "102", zoomedRow: undefined });
 
-    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
     expect(await screen.findByText(/we're a little lost/i)).toBeInTheDocument();
   });
 

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -315,7 +315,7 @@ export function getBrokenUpTextMatcher(textToFind: string): MatcherFunction {
  */
 export const waitForLoaderToBeRemoved = async () => {
   await waitFor(() => {
-    expect(screen.queryByTestId("loading-spinner")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("loading-indicator")).not.toBeInTheDocument();
   });
 };
 


### PR DESCRIPTION
Changes the `"loading-spinner"` testid to `"loading-indicator"`.

Closes #44271