### PR TITLE
Update look and feel copy

### DIFF
--- a/e2e/support/helpers/e2e-embedding-helpers.js
+++ b/e2e/support/helpers/e2e-embedding-helpers.js
@@ -153,7 +153,7 @@ export function openEmbedModalFromMenu() {
 /**
  * Open Static Embedding setup modal
  * @param {object} params
- * @param {("overview"|"parameters"|"appearance")} [params.activeTab] - modal tab to open
+ * @param {("overview"|"parameters"|"lookAndFeel")} [params.activeTab] - modal tab to open
  * @param {("code"|"preview")} [params.previewMode] - preview mode type to activate
  * @param {boolean} [params.acceptTerms] - whether we need to go through the legalese step
  */
@@ -180,7 +180,7 @@ export function openStaticEmbeddingModal({
       const tabKeyToNameMap = {
         overview: "Overview",
         parameters: "Parameters",
-        appearance: "Appearance",
+        lookAndFeel: "Look and Feel",
       };
 
       cy.findByRole("tab", { name: tabKeyToNameMap[activeTab] }).click();

--- a/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
@@ -628,7 +628,7 @@ describeEE("scenarios > embedding > dashboard appearance", () => {
     cy.wait("@previewEmbed");
 
     modal().within(() => {
-      cy.findByRole("tab", { name: "Appearance" }).click();
+      cy.findByRole("tab", { name: "Look and Feel" }).click();
       cy.get("@previewEmbedSpy").should("have.callCount", 1);
 
       cy.log("Assert dashboard theme");
@@ -663,7 +663,7 @@ describeEE("scenarios > embedding > dashboard appearance", () => {
         .findByTestId("embed-frame")
         .should("have.css", "border-top-width", "1px");
       // We're getting an input element which is 0x0 in size
-      cy.findByLabelText("Border").click({ force: true });
+      cy.findByLabelText("Dashboard border").click({ force: true });
       getIframeBody()
         .findByTestId("embed-frame")
         .should("have.css", "border-top-width", "0px");

--- a/e2e/test/scenarios/embedding/embedding-questions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-questions.cy.spec.js
@@ -263,12 +263,12 @@ describeEE("scenarios > embedding > questions > downloads", () => {
       cy.get("@questionId").then(questionId => {
         visitQuestion(questionId);
 
-        openStaticEmbeddingModal({ activeTab: "appearance" });
+        openStaticEmbeddingModal({ activeTab: "lookAndFeel" });
 
         cy.log(
           "Embedding settings page should not show option to disable downloads",
         );
-        cy.findByLabelText("Playing with appearance options")
+        cy.findByLabelText("Customizing look and feel")
           .should("not.contain", "Download data")
           .and("not.contain", "Enable users to download data from this embed");
 
@@ -323,7 +323,7 @@ describeEE("scenarios > embedding > questions > downloads", () => {
         visitQuestion(questionId);
 
         openStaticEmbeddingModal({
-          activeTab: "appearance",
+          activeTab: "lookAndFeel",
           acceptTerms: false,
         });
 

--- a/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
@@ -152,13 +152,15 @@ describe("scenarios > embedding > smoke tests", { tags: "@OSS" }, () => {
         visitAndEnableSharing(object);
 
         modal().within(() => {
-          cy.findByRole("tab", { name: "Appearance" }).click();
+          cy.findByRole("tab", { name: "Look and Feel" }).click();
 
           cy.findByText("Background");
           cy.findByText(
             object === "dashboard" ? "Dashboard title" : "Question title",
           );
-          cy.findByText("Border");
+          cy.findByText(
+            object === "dashboard" ? "Dashboard border" : "Question border",
+          );
           cy.findByText(
             (_, element) =>
               element.textContent ===

--- a/e2e/test/scenarios/embedding/embedding-snippets.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-snippets.cy.spec.js
@@ -70,7 +70,7 @@ features.forEach(feature => {
         .and("contain", "JSX");
 
       modal().within(() => {
-        cy.findByRole("tab", { name: "Appearance" }).click();
+        cy.findByRole("tab", { name: "Look and Feel" }).click();
 
         // No download button for dashboards even for pro/enterprise users metabase#23477
         cy.findByLabelText(
@@ -113,7 +113,7 @@ features.forEach(feature => {
             getEmbeddingJsCode({ type: "question", id: ORDERS_QUESTION_ID }),
           );
 
-        cy.findByRole("tab", { name: "Appearance" }).click();
+        cy.findByRole("tab", { name: "Look and Feel" }).click();
 
         // set transparent background metabase#23477
         cy.findByText("Transparent").click();

--- a/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
@@ -469,7 +469,7 @@ describe("#39152 sharing an unsaved question", () => {
 
           cy.log("Assert copying code in Appearance tab");
           modal().within(() => {
-            cy.findByRole("tab", { name: "Appearance" }).click();
+            cy.findByRole("tab", { name: "Look and Feel" }).click();
 
             cy.findByText("Ruby").click();
           });
@@ -480,11 +480,12 @@ describe("#39152 sharing an unsaved question", () => {
             cy.findByLabelText("Dark").click({ force: true });
             if (resource === "dashboard") {
               cy.findByLabelText("Dashboard title").click({ force: true });
+              cy.findByLabelText("Dashboard border").click({ force: true });
             }
             if (resource === "question") {
               cy.findByLabelText("Question title").click({ force: true });
+              cy.findByLabelText("Question border").click({ force: true });
             }
-            cy.findByLabelText("Border").click({ force: true });
           });
 
           cy.findByTestId("embed-backend")
@@ -581,7 +582,7 @@ describe("#39152 sharing an unsaved question", () => {
 
             cy.log("Assert copying code in Appearance tab");
             modal().within(() => {
-              cy.findByRole("tab", { name: "Appearance" }).click();
+              cy.findByRole("tab", { name: "Look and Feel" }).click();
 
               cy.findByText("Ruby").click();
             });
@@ -592,11 +593,12 @@ describe("#39152 sharing an unsaved question", () => {
               cy.findByLabelText("Dark").click({ force: true });
               if (resource === "dashboard") {
                 cy.findByLabelText("Dashboard title").click({ force: true });
+                cy.findByLabelText("Dashboard border").click({ force: true });
               }
               if (resource === "question") {
                 cy.findByLabelText("Question title").click({ force: true });
+                cy.findByLabelText("Question border").click({ force: true });
               }
-              cy.findByLabelText("Border").click({ force: true });
               cy.findByLabelText("Font").click();
             });
 

--- a/e2e/test/scenarios/sharing/sharing-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/sharing-reproductions.cy.spec.js
@@ -638,7 +638,7 @@ describeEE("issue 26988", () => {
     cy.wait("@previewDashboard");
     getIframeBody().should("have.css", "font-family", "Lato, sans-serif");
 
-    cy.findByRole("tabpanel", { name: "Look and Feel" })
+    cy.findByTestId("look-and-feel-settings")
       .findByLabelText("Font")
       .as("font-control")
       .click();

--- a/e2e/test/scenarios/sharing/sharing-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/sharing-reproductions.cy.spec.js
@@ -638,7 +638,7 @@ describeEE("issue 26988", () => {
     cy.wait("@previewDashboard");
     getIframeBody().should("have.css", "font-family", "Lato, sans-serif");
 
-    cy.findByTestId("look-and-feel-settings")
+    cy.findByLabelText("Customizing look and feel")
       .findByLabelText("Font")
       .as("font-control")
       .click();

--- a/e2e/test/scenarios/sharing/sharing-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/sharing-reproductions.cy.spec.js
@@ -630,7 +630,7 @@ describeEE("issue 26988", () => {
     });
 
     openStaticEmbeddingModal({
-      activeTab: "appearance",
+      activeTab: "lookAndFeel",
       previewMode: "preview",
       acceptTerms: false,
     });
@@ -638,7 +638,7 @@ describeEE("issue 26988", () => {
     cy.wait("@previewDashboard");
     getIframeBody().should("have.css", "font-family", "Lato, sans-serif");
 
-    cy.findByLabelText("Playing with appearance options")
+    cy.findByRole("tabpanel", { name: "Look and Feel" })
       .findByLabelText("Font")
       .as("font-control")
       .click();

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/LookAndFeelSettings.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/LookAndFeelSettings.tsx
@@ -72,18 +72,14 @@ export const LookAndFeelSettings = ({
       <StaticEmbedSetupPaneSettingsContentSection
         title={t`Customizing look and feel`}
       >
-        <Text>{jt`These options require changing the server code. You can play around with and preview the options here. Check out the ${(
-          <ExternalLink
-            key="doc"
-            href={`${docsUrl}${utmTags}#customizing-the-appearance-of-static-embeds`}
-          >{t`documentation`}</ExternalLink>
-        )} for more.`}</Text>
-      </StaticEmbedSetupPaneSettingsContentSection>
-      <StaticEmbedSetupPaneSettingsContentSection
-        mt="2rem"
-        data-testid="look-and-feel-settings"
-      >
         <Stack spacing="1rem">
+          <Text>{jt`These options require changing the server code. You can play around with and preview the options here. Check out the ${(
+            <ExternalLink
+              key="doc"
+              href={`${docsUrl}${utmTags}#customizing-the-appearance-of-static-embeds`}
+            >{t`documentation`}</ExternalLink>
+          )} for more.`}</Text>
+
           {canWhitelabel ? (
             <Select
               label={
@@ -188,6 +184,7 @@ export const LookAndFeelSettings = ({
           )}
         </Stack>
       </StaticEmbedSetupPaneSettingsContentSection>
+
       {!canWhitelabel && (
         <>
           <Divider my="2rem" />

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/LookAndFeelSettings.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/LookAndFeelSettings.tsx
@@ -91,13 +91,12 @@ export const LookAndFeelSettings = ({
                   Font
                 </Text>
               }
-              value={
-                displayOptions.font === null ? "null" : displayOptions.font
-              }
+              value={displayOptions.font}
               data={[
                 {
                   label: t`Use instance font`,
-                  value: "null",
+                  // @ts-expect-error Mantine v6 and v7 both expect value to be a string
+                  value: null,
                 },
                 ...availableFonts?.map(font => ({
                   label: font,
@@ -107,7 +106,7 @@ export const LookAndFeelSettings = ({
               onChange={value => {
                 onChangeDisplayOptions({
                   ...displayOptions,
-                  font: value === "null" ? null : value,
+                  font: value,
                 });
               }}
             />

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/LookAndFeelSettings.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/LookAndFeelSettings.tsx
@@ -1,10 +1,8 @@
-import type { ChangeEvent } from "react";
 import { match } from "ts-pattern";
 import { jt, t } from "ttag";
 
 import { getPlan } from "metabase/common/utils/plan";
 import ExternalLink from "metabase/core/components/ExternalLink";
-import Select from "metabase/core/components/Select";
 import { useUniqueId } from "metabase/hooks/use-unique-id";
 import { color } from "metabase/lib/colors";
 import { useSelector } from "metabase/lib/redux";
@@ -18,7 +16,14 @@ import {
   getUpgradeUrl,
 } from "metabase/selectors/settings";
 import { getCanWhitelabel } from "metabase/selectors/whitelabel";
-import { Divider, SegmentedControl, Stack, Switch, Text } from "metabase/ui";
+import {
+  Divider,
+  SegmentedControl,
+  Select,
+  Stack,
+  Switch,
+  Text,
+} from "metabase/ui";
 
 import { DisplayOptionSection } from "./StaticEmbedSetupPane.styled";
 import { StaticEmbedSetupPaneSettingsContentSection } from "./StaticEmbedSetupPaneSettingsContentSection";
@@ -60,7 +65,6 @@ export const LookAndFeelSettings = ({
   );
   const utmTags = `?utm_source=${plan}&utm_media=static-embed-settings-appearance`;
 
-  const fontControlLabelId = useUniqueId("display-option");
   const downloadDataId = useUniqueId("download-data");
 
   return (
@@ -77,39 +81,41 @@ export const LookAndFeelSettings = ({
       </StaticEmbedSetupPaneSettingsContentSection>
       <StaticEmbedSetupPaneSettingsContentSection mt="2rem">
         <Stack spacing="1rem">
-          <DisplayOptionSection title={t`Font`} titleId={fontControlLabelId}>
-            {canWhitelabel ? (
-              <Select
-                value={displayOptions.font}
-                options={[
-                  {
-                    name: t`Use instance font`,
-                    value: null,
-                  },
-                  ...availableFonts?.map(font => ({
-                    name: font,
-                    value: font,
-                  })),
-                ]}
-                buttonProps={{
-                  "aria-labelledby": fontControlLabelId,
-                }}
-                onChange={(e: ChangeEvent<HTMLSelectElement>) => {
-                  onChangeDisplayOptions({
-                    ...displayOptions,
-                    font: e.target.value,
-                  });
-                }}
-              />
-            ) : (
-              <Text>{jt`You can change the font with ${(
-                <ExternalLink
-                  key="fontPlan"
-                  href={upgradePageUrl}
-                >{t`a paid plan`}</ExternalLink>
-              )}.`}</Text>
-            )}
-          </DisplayOptionSection>
+          {canWhitelabel ? (
+            <Select
+              label={
+                <Text fw="bold" mb="0.25rem" lh="1rem">
+                  Font
+                </Text>
+              }
+              value={
+                displayOptions.font === null ? "null" : displayOptions.font
+              }
+              data={[
+                {
+                  label: t`Use instance font`,
+                  value: "null",
+                },
+                ...availableFonts?.map(font => ({
+                  label: font,
+                  value: font,
+                })),
+              ]}
+              onChange={value => {
+                onChangeDisplayOptions({
+                  ...displayOptions,
+                  font: value === "null" ? null : value,
+                });
+              }}
+            />
+          ) : (
+            <Text>{jt`You can change the font with ${(
+              <ExternalLink
+                key="fontPlan"
+                href={upgradePageUrl}
+              >{t`a paid plan`}</ExternalLink>
+            )}.`}</Text>
+          )}
 
           <DisplayOptionSection title={t`Background`}>
             <SegmentedControl

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/LookAndFeelSettings.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/LookAndFeelSettings.tsx
@@ -79,7 +79,10 @@ export const LookAndFeelSettings = ({
           >{t`documentation`}</ExternalLink>
         )} for more.`}</Text>
       </StaticEmbedSetupPaneSettingsContentSection>
-      <StaticEmbedSetupPaneSettingsContentSection mt="2rem">
+      <StaticEmbedSetupPaneSettingsContentSection
+        mt="2rem"
+        data-testid="look-and-feel-settings"
+      >
         <Stack spacing="1rem">
           {canWhitelabel ? (
             <Select

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/LookAndFeelSettings.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/LookAndFeelSettings.tsx
@@ -36,7 +36,7 @@ export interface AppearanceSettingsProps {
   onChangeDisplayOptions: (displayOptions: EmbeddingDisplayOptions) => void;
 }
 
-export const AppearanceSettings = ({
+export const LookAndFeelSettings = ({
   resourceType,
   displayOptions,
   onChangeDisplayOptions,

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/LookAndFeelSettings.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/LookAndFeelSettings.tsx
@@ -1,4 +1,5 @@
 import type { ChangeEvent } from "react";
+import { match } from "ts-pattern";
 import { jt, t } from "ttag";
 
 import { getPlan } from "metabase/common/utils/plan";
@@ -65,64 +66,17 @@ export const LookAndFeelSettings = ({
   return (
     <>
       <StaticEmbedSetupPaneSettingsContentSection
-        title={t`Customizing your embed’s appearance`}
+        title={t`Customizing look and feel`}
       >
-        <Text>{jt`These cosmetic options requiring changing the server code. You can play around with and preview the options here, and check out the ${(
+        <Text>{jt`These options require changing the server code. You can play around with and preview the options here. Check out the ${(
           <ExternalLink
             key="doc"
             href={`${docsUrl}${utmTags}#customizing-the-appearance-of-static-embeds`}
           >{t`documentation`}</ExternalLink>
         )} for more.`}</Text>
       </StaticEmbedSetupPaneSettingsContentSection>
-      <StaticEmbedSetupPaneSettingsContentSection
-        title={t`Playing with appearance options`}
-        mt="2rem"
-      >
+      <StaticEmbedSetupPaneSettingsContentSection mt="2rem">
         <Stack spacing="1rem">
-          <DisplayOptionSection title={t`Background`}>
-            <SegmentedControl
-              value={displayOptions.theme ?? undefined}
-              // `data` type is required to be mutable, but THEME_OPTIONS is const.
-              data={[...THEME_OPTIONS]}
-              fullWidth
-              bg={color("bg-light")}
-              onChange={(value: ThemeOptions) => {
-                onChangeDisplayOptions({
-                  ...displayOptions,
-                  theme: value,
-                });
-              }}
-            />
-          </DisplayOptionSection>
-
-          <Switch
-            label={getTitleLabel(resourceType)}
-            labelPosition="left"
-            size="sm"
-            variant="stretch"
-            checked={displayOptions.titled}
-            onChange={e =>
-              onChangeDisplayOptions({
-                ...displayOptions,
-                titled: e.target.checked,
-              })
-            }
-          />
-
-          <Switch
-            label={t`Border`}
-            labelPosition="left"
-            size="sm"
-            variant="stretch"
-            checked={displayOptions.bordered}
-            onChange={e =>
-              onChangeDisplayOptions({
-                ...displayOptions,
-                bordered: e.target.checked,
-              })
-            }
-          />
-
           <DisplayOptionSection title={t`Font`} titleId={fontControlLabelId}>
             {canWhitelabel ? (
               <Select
@@ -156,6 +110,50 @@ export const LookAndFeelSettings = ({
               )}.`}</Text>
             )}
           </DisplayOptionSection>
+
+          <DisplayOptionSection title={t`Background`}>
+            <SegmentedControl
+              value={displayOptions.theme ?? undefined}
+              // `data` type is required to be mutable, but THEME_OPTIONS is const.
+              data={[...THEME_OPTIONS]}
+              fullWidth
+              bg={color("bg-light")}
+              onChange={(value: ThemeOptions) => {
+                onChangeDisplayOptions({
+                  ...displayOptions,
+                  theme: value,
+                });
+              }}
+            />
+          </DisplayOptionSection>
+
+          <Switch
+            label={getBorderTitle(resourceType)}
+            labelPosition="left"
+            size="sm"
+            variant="stretch"
+            checked={displayOptions.bordered}
+            onChange={e =>
+              onChangeDisplayOptions({
+                ...displayOptions,
+                bordered: e.target.checked,
+              })
+            }
+          />
+
+          <Switch
+            label={getTitleLabel(resourceType)}
+            labelPosition="left"
+            size="sm"
+            variant="stretch"
+            checked={displayOptions.titled}
+            onChange={e =>
+              onChangeDisplayOptions({
+                ...displayOptions,
+                titled: e.target.checked,
+              })
+            }
+          />
 
           {canWhitelabel && resourceType === "question" && (
             // We only show the "Download Data" toggle if the users are pro/enterprise
@@ -213,4 +211,12 @@ function getTitleLabel(resourceType: EmbedResourceType) {
   }
 
   return null;
+}
+
+function getBorderTitle(resourceType: EmbedResourceType) {
+  return match(resourceType)
+    .returnType<string>()
+    .with("dashboard", () => t`Dashboard border`)
+    .with("question", () => t`Question border`)
+    .exhaustive();
 }

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/ServerEmbedCodePane.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/ServerEmbedCodePane.tsx
@@ -177,7 +177,7 @@ function getTitle({
       : undefined;
   }
 
-  if (variant === "appearance") {
+  if (variant === "lookAndFeel") {
     return hasAppearanceCodeDiff
       ? t`Here’s the code you’ll need to alter:`
       : undefined;

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/StaticEmbedSetupPane.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/StaticEmbedSetupPane.tsx
@@ -31,8 +31,8 @@ import { getCanWhitelabel } from "metabase/selectors/whitelabel";
 import { Stack, Tabs } from "metabase/ui";
 import { getParameterValue } from "metabase-lib/v1/parameters/utils/parameter-values";
 
-import { AppearanceSettings } from "./AppearanceSettings";
 import { EmbedModalContentStatusBar } from "./EmbedModalContentStatusBar";
+import { LookAndFeelSettings } from "./LookAndFeelSettings";
 import { OverviewSettings } from "./OverviewSettings";
 import { ParametersSettings } from "./ParametersSettings";
 import { PreviewModeSelector } from "./PreviewModeSelector";
@@ -226,7 +226,7 @@ export const StaticEmbedSetupPane = ({
     const locationMap = {
       overview: "code_overview",
       parameters: "code_params",
-      appearance: "code_appearance",
+      lookAndFeel: "code_appearance",
     } as const;
     trackStaticEmbedCodeCopied({
       artifact: resourceType,
@@ -265,9 +265,9 @@ export const StaticEmbedSetupPane = ({
             onClick={() => setActiveTab(EMBED_MODAL_TABS.Parameters)}
           >{t`Parameters`}</Tabs.Tab>
           <Tabs.Tab
-            value={EMBED_MODAL_TABS.Appearance}
-            onClick={() => setActiveTab(EMBED_MODAL_TABS.Appearance)}
-          >{t`Appearance`}</Tabs.Tab>
+            value={EMBED_MODAL_TABS.LookAndFeel}
+            onClick={() => setActiveTab(EMBED_MODAL_TABS.LookAndFeel)}
+          >{t`Look and Feel`}</Tabs.Tab>
         </Tabs.List>
         {/**
          * Please do not add more than one `Tabs.Panel` here.
@@ -330,10 +330,10 @@ export const StaticEmbedSetupPane = ({
                 </>
               }
             />
-          ) : activeTab === EMBED_MODAL_TABS.Appearance ? (
+          ) : activeTab === EMBED_MODAL_TABS.LookAndFeel ? (
             <SettingsTabLayout
               settingsSlot={
-                <AppearanceSettings
+                <LookAndFeelSettings
                   resourceType={resourceType}
                   displayOptions={displayOptions}
                   onChangeDisplayOptions={setDisplayOptions}
@@ -352,7 +352,7 @@ export const StaticEmbedSetupPane = ({
                     isTransparent={displayOptions.theme === "transparent"}
                   />
                   {activePane === "code"
-                    ? getServerEmbedCodePane(EMBED_MODAL_TABS.Appearance)
+                    ? getServerEmbedCodePane(EMBED_MODAL_TABS.LookAndFeel)
                     : null}
                 </>
               }

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tabs.ts
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tabs.ts
@@ -1,5 +1,5 @@
 export const EMBED_MODAL_TABS = {
   Overview: "overview" as const,
   Parameters: "parameters" as const,
-  Appearance: "appearance" as const,
+  LookAndFeel: "lookAndFeel" as const,
 };

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tests/common.unit.spec.tsx
@@ -475,7 +475,7 @@ describe("Static Embed Setup phase", () => {
         ).toBeVisible();
 
         const link = within(
-          screen.getByTestId("look-and-feel-settings"),
+          screen.getByLabelText("Customizing look and feel"),
         ).getByRole("link", {
           name: "a paid plan",
         });

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tests/common.unit.spec.tsx
@@ -380,18 +380,16 @@ describe("Static Embed Setup phase", () => {
       }
     });
 
-    describe("Appearance tab", () => {
+    describe("Look and Feel tab", () => {
       it("should render link to documentation", async () => {
         await setup({
           props: {
             resourceType,
           },
-          activeTab: "Appearance",
+          activeTab: "Look and Feel",
         });
 
-        expect(
-          screen.getByText("Customizing your embed’s appearance"),
-        ).toBeVisible();
+        expect(screen.getByText("Customizing look and feel")).toBeVisible();
 
         const link = screen.getByRole("link", {
           name: "documentation",
@@ -410,7 +408,7 @@ describe("Static Embed Setup phase", () => {
             resourceType,
             resource,
           },
-          activeTab: "Appearance",
+          activeTab: "Look and Feel",
         });
 
         expect(screen.getByLabelText("Code")).toBeChecked();
@@ -425,7 +423,7 @@ describe("Static Embed Setup phase", () => {
           props: {
             resourceType,
           },
-          activeTab: "Appearance",
+          activeTab: "Look and Feel",
         });
 
         await userEvent.click(screen.getByText("Preview"));
@@ -438,7 +436,7 @@ describe("Static Embed Setup phase", () => {
           props: {
             resourceType,
           },
-          activeTab: "Appearance",
+          activeTab: "Look and Feel",
         });
 
         await userEvent.click(screen.getByText("Transparent"));
@@ -467,7 +465,7 @@ describe("Static Embed Setup phase", () => {
           props: {
             resourceType,
           },
-          activeTab: "Appearance",
+          activeTab: "Look and Feel",
         });
 
         expect(
@@ -477,7 +475,7 @@ describe("Static Embed Setup phase", () => {
         ).toBeVisible();
 
         const link = within(
-          screen.getByLabelText("Playing with appearance options"),
+          screen.getByTestId("look-and-feel-settings"),
         ).getByRole("link", {
           name: "a paid plan",
         });
@@ -491,7 +489,7 @@ describe("Static Embed Setup phase", () => {
       it('should render "Powered by Metabase" banner caption', async () => {
         await setup({
           props: {},
-          activeTab: "Appearance",
+          activeTab: "Look and Feel",
         });
 
         expect(
@@ -530,13 +528,11 @@ describe("Static Embed Setup phase", () => {
 
     await userEvent.click(
       screen.getByRole("tab", {
-        name: "Appearance",
+        name: "Look and Feel",
       }),
     );
 
-    expect(
-      screen.getByText("Customizing your embed’s appearance"),
-    ).toBeVisible();
+    expect(screen.getByText("Customizing look and feel")).toBeVisible();
 
     expect(screen.getByLabelText("Preview")).toBeChecked();
 
@@ -577,7 +573,7 @@ describe("Static Embed Setup phase", () => {
 
     await userEvent.click(
       screen.getByRole("tab", {
-        name: "Appearance",
+        name: "Look and Feel",
       }),
     );
 
@@ -607,7 +603,7 @@ describe("Static Embed Setup phase", () => {
 
     await userEvent.click(
       screen.getByRole("tab", {
-        name: "Appearance",
+        name: "Look and Feel",
       }),
     );
 

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tests/enterprise.unit.spec.tsx
@@ -13,13 +13,13 @@ describe("Static Embed Setup phase - EE, no token", () => {
       resourceType: "question" as const,
     },
   ])("$resourceType", ({ resourceType }) => {
-    describe("Appearance tab", () => {
+    describe("Look and Feel tab", () => {
       it("should not render Font selector", async () => {
         await setup({
           props: {
             resourceType,
           },
-          activeTab: "Appearance",
+          activeTab: "Look and Feel",
           hasEnterprisePlugins: true,
         });
 
@@ -33,7 +33,7 @@ describe("Static Embed Setup phase - EE, no token", () => {
       it('should render "Powered by Metabase" banner caption', async () => {
         await setup({
           props: {},
-          activeTab: "Appearance",
+          activeTab: "Look and Feel",
           hasEnterprisePlugins: true,
         });
 

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tests/premium.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tests/premium.unit.spec.tsx
@@ -38,13 +38,13 @@ describe("Static Embed Setup phase - EE, with token", () => {
       });
     });
 
-    describe("Appearance tab", () => {
+    describe("Look and Feel tab", () => {
       it("should render Font selector", async () => {
         await setup({
           props: {
             resourceType,
           },
-          activeTab: "Appearance",
+          activeTab: "Look and Feel",
           hasEnterprisePlugins: true,
           tokenFeatures: createMockTokenFeatures({ whitelabel: true }),
         });
@@ -54,7 +54,7 @@ describe("Static Embed Setup phase - EE, with token", () => {
 
         await userEvent.click(fontSelect);
 
-        const popover = await screen.findByRole("grid");
+        const popover = await screen.findByRole("listbox", { name: "Font" });
 
         FONTS_MOCK_VALUES.forEach(fontName => {
           expect(within(popover).getByText(fontName)).toBeVisible();
@@ -72,7 +72,7 @@ describe("Static Embed Setup phase - EE, with token", () => {
           props: {
             resourceType,
           },
-          activeTab: "Appearance",
+          activeTab: "Look and Feel",
           hasEnterprisePlugins: true,
           tokenFeatures: createMockTokenFeatures({ whitelabel: true }),
         });
@@ -87,14 +87,12 @@ describe("Static Embed Setup phase - EE, with token", () => {
           props: {
             resourceType,
           },
-          activeTab: "Appearance",
+          activeTab: "Look and Feel",
           hasEnterprisePlugins: true,
           tokenFeatures: createMockTokenFeatures({ whitelabel: true }),
         });
 
-        expect(
-          screen.getByText("Customizing your embed’s appearance"),
-        ).toBeVisible();
+        expect(screen.getByText("Customizing look and feel")).toBeVisible();
 
         const link = screen.getByRole("link", {
           name: "documentation",
@@ -113,7 +111,7 @@ describe("Static Embed Setup phase - EE, with token", () => {
               resourceType,
               resource: getMockResource(resourceType, true),
             },
-            activeTab: "Appearance",
+            activeTab: "Look and Feel",
             hasEnterprisePlugins: true,
             tokenFeatures: createMockTokenFeatures({ whitelabel: true }),
           });

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tests/setup.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tests/setup.tsx
@@ -63,7 +63,7 @@ export async function setup(
     tokenFeatures = createMockTokenFeatures(),
   }: {
     props: Partial<StaticEmbedSetupPaneProps>;
-    activeTab?: "Overview" | "Parameters" | "Appearance";
+    activeTab?: "Overview" | "Parameters" | "Look and Feel";
     hasEnterprisePlugins?: boolean;
     tokenFeatures?: TokenFeatures;
   } = {

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/types.ts
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/types.ts
@@ -6,4 +6,4 @@ export type EmbedResourceParameterWithValue = EmbedResourceParameter & {
   value: string;
 };
 
-export type EmbedCodePaneVariant = "overview" | "parameters" | "appearance";
+export type EmbedCodePaneVariant = "overview" | "parameters" | "lookAndFeel";


### PR DESCRIPTION
Part of #44273

I initially intended for this PR to implement the toggle for #44273, but after the initial copy change, it seemed it involved a lot of line changes, so I'll just leave it here.

This PR updates the copy on the "Look and Feel" tab (was "Appearance") and reorders the location of each setting + renames some labels to [match the design](https://www.figma.com/design/1YcsFf5yYdFZTguwoKVdkj/Re-design-the-transparent-background-setting-in-interactive-embedds?node-id=917-6518&t=NKXLRBgBaxzBbFQe-0). 

No new tests has been added, since this is only changing copies, only failed existing tests are fixed.