### PR TITLE
MS1: Elevate "include this {period}" and "starting from" in the relative date picker

### DIFF
--- a/e2e/support/helpers/e2e-relative-date-picker-helpers.js
+++ b/e2e/support/helpers/e2e-relative-date-picker-helpers.js
@@ -47,8 +47,9 @@ function addStartingFrom({ value, unit }) {
 }
 
 function toggleCurrentInterval() {
-  popover().findByLabelText("Options").click();
-  popover().last().findByTestId("include-current-interval-option").click();
+  popover()
+    .findByTestId("include-current-interval-option")
+    .click({ force: true });
 }
 
 export const relativeDatePicker = {

--- a/e2e/support/helpers/e2e-relative-date-picker-helpers.js
+++ b/e2e/support/helpers/e2e-relative-date-picker-helpers.js
@@ -41,8 +41,7 @@ function setStartingFrom({ value, unit }) {
  * @param {string} params.unit - interval unit in singular form (e.g. "day", not "days")
  */
 function addStartingFrom({ value, unit }) {
-  popover().findByLabelText("Options").click();
-  popover().last().findByText("Starting from…").click();
+  popover().findByLabelText("Starting from…").click();
   setStartingFrom({ value, unit });
 }
 

--- a/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
@@ -637,9 +637,10 @@ describe("scenarios > question > custom column", () => {
     });
     cy.findByRole("listbox").findByText("years").click();
 
-    popover().findByLabelText("Options").click();
-    popover().last().findByText("Include this year").click();
-    popover().button("Add filter").click();
+    popover().within(() => {
+      cy.findByText("Include this year").click();
+      cy.button("Add filter").click();
+    });
 
     visualize(({ body }) => {
       expect(body.error).to.not.exist;

--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -537,10 +537,11 @@ describe("issue 25378", () => {
       cy.findByDisplayValue("days").click();
     });
     cy.findByRole("listbox").findByText("months").click();
-    popover().findByLabelText("Options").click();
-    popover().last().findByText("Starting from…").click();
 
-    popover().button("Add filter").click();
+    popover().within(() => {
+      cy.findByLabelText("Starting from…").click();
+      cy.button("Add filter").click();
+    });
 
     visualize(response => {
       expect(response.body.error).to.not.exist;

--- a/e2e/test/scenarios/filters/filter.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter.cy.spec.js
@@ -522,13 +522,9 @@ describe("scenarios > question > filter", () => {
       cy.findByText("Created At").click();
       cy.findByText("Relative dates…").click();
       cy.findByText("Past").click();
-      cy.findByLabelText("Options").click();
+      cy.findByText(/^Include/).click();
+      cy.button("Add filter").click();
     });
-    popover()
-      .last()
-      .findByText(/^Include/)
-      .click();
-    popover().button("Add filter").click();
 
     getNotebookStep("filter")
       .findByText("Created At is in the previous 30 days")
@@ -545,11 +541,10 @@ describe("scenarios > question > filter", () => {
     getNotebookStep("filter")
       .findByText("Created At is in the previous 30 days")
       .click();
-    popover().findByLabelText("Options").click();
+
     popover()
-      .last()
       .findByTestId("include-current-interval-option")
-      .should("have.attr", "aria-selected", "true");
+      .should("have.attr", "aria-checked", "true");
   });
 
   it("should be able to convert case-insensitive filter to custom expression (metabase#14959)", () => {

--- a/e2e/test/scenarios/filters/relative-datetime.cy.spec.js
+++ b/e2e/test/scenarios/filters/relative-datetime.cy.spec.js
@@ -267,10 +267,8 @@ const openCreatedAt = tab => {
 };
 
 const addStartingFrom = () => {
-  popover().findByLabelText("Options").click();
   popover()
-    .last()
-    .findByText(/Starting from/)
+    .findByLabelText(/Starting from/)
     .click();
 };
 

--- a/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.tsx
@@ -7,11 +7,11 @@ import {
   Divider,
   Flex,
   Group,
-  Menu,
   NumberInput,
   Select,
   Text,
   Switch,
+  Tooltip,
 } from "metabase/ui";
 
 import type { DateIntervalValue } from "../types";
@@ -92,26 +92,17 @@ export function DateIntervalPicker({
           ml="md"
           onChange={handleUnitChange}
         />
-        <Menu>
-          <Menu.Target>
+        {canUseRelativeOffsets && (
+          <Tooltip label={t`Starting from…`} position="bottom">
             <Button
-              c="text-dark"
+              aria-label={t`Starting from…`}
+              c="text-medium"
               variant="subtle"
-              leftIcon={<Icon name="ellipsis" />}
-              aria-label={t`Options`}
+              leftIcon={<Icon name="arrow_left_to_line" />}
+              onClick={handleStartingFromClick}
             />
-          </Menu.Target>
-          <Menu.Dropdown>
-            {canUseRelativeOffsets && (
-              <Menu.Item
-                icon={<Icon name="arrow_left_to_line" />}
-                onClick={handleStartingFromClick}
-              >
-                {t`Starting from…`}
-              </Menu.Item>
-            )}
-          </Menu.Dropdown>
-        </Menu>
+          </Tooltip>
+        )}
       </Flex>
       <Flex p="md" pt={0}>
         <Switch

--- a/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.tsx
@@ -11,6 +11,7 @@ import {
   NumberInput,
   Select,
   Text,
+  Switch,
 } from "metabase/ui";
 
 import type { DateIntervalValue } from "../types";
@@ -66,7 +67,7 @@ export function DateIntervalPicker({
     onChange(setDefaultOffset(value));
   };
 
-  const handleIncludeCurrentClick = () => {
+  const handleIncludeCurrentSwitch = () => {
     onChange(setIncludeCurrent(value, !includeCurrent));
   };
 
@@ -109,16 +110,19 @@ export function DateIntervalPicker({
                 {t`Starting from…`}
               </Menu.Item>
             )}
-            <Menu.Item
-              icon={<Icon name={includeCurrent ? "check" : "calendar"} />}
-              onClick={handleIncludeCurrentClick}
-              aria-selected={includeCurrent}
-              data-testid="include-current-interval-option"
-            >
-              {t`Include ${getIncludeCurrentLabel(value.unit)}`}
-            </Menu.Item>
           </Menu.Dropdown>
         </Menu>
+      </Flex>
+      <Flex p="md" pt={0}>
+        <Switch
+          aria-checked={includeCurrent}
+          checked={includeCurrent}
+          data-testid="include-current-interval-option"
+          label={t`Include ${getIncludeCurrentLabel(value.unit)}`}
+          labelPosition="right"
+          onChange={handleIncludeCurrentSwitch}
+          size="sm"
+        />
       </Flex>
       <Divider />
       <Group px="md" py="sm" position="apart">

--- a/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.unit.spec.tsx
@@ -156,7 +156,6 @@ describe("DateIntervalPicker", () => {
           value: defaultValue,
         });
 
-        await userEvent.click(screen.getByLabelText("Options"));
         await userEvent.click(await screen.findByText("Include today"));
 
         expect(onChange).toHaveBeenCalledWith({
@@ -168,24 +167,13 @@ describe("DateIntervalPicker", () => {
         expect(onSubmit).not.toHaveBeenCalled();
       });
 
-      it("should not allow to add relative offsets by default", async () => {
-        setup({
-          value: defaultValue,
-        });
-
-        await userEvent.click(screen.getByLabelText("Options"));
-        expect(await screen.findByText("Include today")).toBeInTheDocument();
-        expect(screen.queryByText("Starting from…")).not.toBeInTheDocument();
-      });
-
-      it("should allow to a relative offset if enabled", async () => {
+      it("should allow to a relative offset", async () => {
         const { onChange, onSubmit } = setup({
           value: defaultValue,
           canUseRelativeOffsets: true,
         });
 
-        await userEvent.click(screen.getByLabelText("Options"));
-        await userEvent.click(await screen.findByText("Starting from…"));
+        await userEvent.click(await screen.findByLabelText("Starting from…"));
 
         expect(onChange).toHaveBeenLastCalledWith({
           ...defaultValue,

--- a/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.tsx
@@ -116,6 +116,7 @@ export function DateOffsetIntervalPicker({
           onChange={handleOffsetUnitChange}
         />
         <Button
+          c="text-medium"
           variant="subtle"
           leftIcon={<Icon name="close" />}
           aria-label={t`Remove offset`}

--- a/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/RelativeDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/RelativeDatePicker.unit.spec.tsx
@@ -69,8 +69,7 @@ describe("RelativeDatePicker", () => {
       canUseRelativeOffsets: true,
     });
 
-    await userEvent.click(screen.getByLabelText("Options"));
-    await userEvent.click(await screen.findByText("Starting from…"));
+    await userEvent.click(await screen.findByLabelText("Starting from…"));
     await userEvent.clear(screen.getByLabelText("Starting from interval"));
     await userEvent.type(screen.getByLabelText("Starting from interval"), "20");
     await userEvent.click(screen.getByLabelText("Next"));
@@ -113,8 +112,7 @@ describe("RelativeDatePicker", () => {
       canUseRelativeOffsets: true,
     });
 
-    await userEvent.click(screen.getByLabelText("Options"));
-    await userEvent.click(await screen.findByText("Starting from…"));
+    await userEvent.click(await screen.findByLabelText("Starting from…"));
     await userEvent.click(screen.getByText("Update filter"));
 
     expect(onChange).toHaveBeenCalledWith({
@@ -149,8 +147,7 @@ describe("RelativeDatePicker", () => {
     });
 
     await userEvent.click(screen.getByText("Next"));
-    await userEvent.click(screen.getByLabelText("Options"));
-    await userEvent.click(await screen.findByText("Starting from…"));
+    await userEvent.click(await screen.findByLabelText("Starting from…"));
     await userEvent.click(screen.getByText("Update filter"));
 
     expect(onChange).toHaveBeenCalledWith({


### PR DESCRIPTION
Closes Milestone 1 of https://github.com/metabase/metabase/issues/44096

### Description

This PR is really just a combination of the two previously reviewed PRs:
- https://github.com/metabase/metabase/pull/44179
- https://github.com/metabase/metabase/pull/44242

No further changes have been made

### Additional info
The goal of the Milestone 1 was to update the relative date picker by exposing "Include this" and "starting from". Please keep in mind that this PR still doesn't address copy changes or the design tweaks. That is the scope of the milestone 2.