### PR TITLE
Ensure the "Updated N minutes ago" message in the question footer is accurate

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/QuestionLastUpdated.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionLastUpdated.jsx
@@ -7,11 +7,11 @@ import { Icon } from "metabase/ui";
 
 import { SectionRoot } from "./QuestionLastUpdated.styled";
 
-export default function QuestionLastUpdated({ result, ...props }) {
-  return result ? (
+export default function QuestionLastUpdated({ updatedAt, ...props }) {
+  return updatedAt ? (
     <SectionRoot {...props}>
       <Icon name="clock" className={CS.mr1} />
-      {t`Updated ${moment(result.updated_at).fromNow()}`}
+      {t`Updated ${moment(updatedAt).fromNow()}`}
     </SectionRoot>
   ) : null;
 }

--- a/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
@@ -114,7 +114,7 @@ const ViewFooter = ({
             <QuestionLastUpdated
               key="last-updated"
               className={cx(CS.hide, CS.smShow)}
-              result={result}
+              updatedAt={question.card().updated_at}
             />
           ),
           QueryDownloadWidget.shouldRender({ result }) && (


### PR DESCRIPTION
**Note: probably certain BE changes should be made before this is merged**

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/9656a2a5-18cc-4d68-9a05-549192cc6a73.png)

On master, this message in the footer of a question is either hidden or says "Updated a few seconds ago". This PR fixes it so it will say "Updated N minutes ago" if the cache is N minutes old.

Probably the BE that sets the `updated_at` field of a card needs to be updated before this is merged.

Closes #42778