### PR TITLE
Rework slow test group

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-resizing.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-resizing.cy.spec.js
@@ -204,7 +204,7 @@ describe("scenarios > dashboard card resizing", () => {
 
   it(
     "should display all visualization cards with their default sizes",
-    { requestTimeout: 15000, tags: "@slow" },
+    { requestTimeout: 15000 },
     () => {
       TEST_QUESTIONS.forEach(question => {
         cy.createQuestion(question);
@@ -255,7 +255,7 @@ describe("scenarios > dashboard card resizing", () => {
 
   it(
     "should not allow cards to be resized smaller than min height",
-    { requestTimeout: 15000, tags: "@slow" },
+    { requestTimeout: 15000 },
     () => {
       const cardIds = [];
       TEST_QUESTIONS.forEach(question => {

--- a/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
@@ -101,52 +101,42 @@ describe("scenarios > dashboard > dashboard back navigation", () => {
     cy.findByTestId("native-query-editor").should("not.be.visible");
   });
 
-  it(
-    "should display a back to the dashboard button in table x-ray dashboards",
-    { tags: "@slow" },
-    () => {
-      const cardTitle = "Total transactions";
-      cy.visit(`/auto/dashboard/table/${ORDERS_ID}?#show=${MAX_CARDS}`);
-      cy.wait("@dataset", { timeout: MAX_XRAY_WAIT_TIMEOUT });
+  it("should display a back to the dashboard button in table x-ray dashboards", () => {
+    const cardTitle = "Total transactions";
+    cy.visit(`/auto/dashboard/table/${ORDERS_ID}?#show=${MAX_CARDS}`);
+    cy.wait("@dataset", { timeout: MAX_XRAY_WAIT_TIMEOUT });
 
-      getDashboardCards()
-        .filter(`:contains("${cardTitle}")`)
-        .findByText(cardTitle)
-        .click();
-      cy.wait("@dataset");
+    getDashboardCards()
+      .filter(`:contains("${cardTitle}")`)
+      .findByText(cardTitle)
+      .click();
+    cy.wait("@dataset");
 
-      queryBuilderHeader()
-        .findByLabelText(/Back to .*Orders.*/)
-        .click();
+    queryBuilderHeader()
+      .findByLabelText(/Back to .*Orders.*/)
+      .click();
 
-      getDashboardCards().filter(`:contains("${cardTitle}")`).should("exist");
-    },
-  );
+    getDashboardCards().filter(`:contains("${cardTitle}")`).should("exist");
+  });
 
-  it(
-    "should display a back to the dashboard button in model x-ray dashboards",
-    { tags: "@slow" },
-    () => {
-      const cardTitle = "Orders by Subtotal";
-      cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, { type: "model" });
-      cy.visit(
-        `/auto/dashboard/model/${ORDERS_QUESTION_ID}?#show=${MAX_CARDS}`,
-      );
-      cy.wait("@dataset", { timeout: MAX_XRAY_WAIT_TIMEOUT });
+  it("should display a back to the dashboard button in model x-ray dashboards", () => {
+    const cardTitle = "Orders by Subtotal";
+    cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, { type: "model" });
+    cy.visit(`/auto/dashboard/model/${ORDERS_QUESTION_ID}?#show=${MAX_CARDS}`);
+    cy.wait("@dataset", { timeout: MAX_XRAY_WAIT_TIMEOUT });
 
-      getDashboardCards()
-        .filter(`:contains("${cardTitle}")`)
-        .findByText(cardTitle)
-        .click();
-      cy.wait("@dataset");
+    getDashboardCards()
+      .filter(`:contains("${cardTitle}")`)
+      .findByText(cardTitle)
+      .click();
+    cy.wait("@dataset");
 
-      queryBuilderHeader()
-        .findByLabelText(/Back to .*Orders.*/)
-        .click();
+    queryBuilderHeader()
+      .findByLabelText(/Back to .*Orders.*/)
+      .click();
 
-      getDashboardCards().filter(`:contains("${cardTitle}")`).should("exist");
-    },
-  );
+    getDashboardCards().filter(`:contains("${cardTitle}")`).should("exist");
+  });
 
   it("should preserve query results when navigating between the dashboard and the query builder", () => {
     createDashboardWithCards();

--- a/e2e/test/scenarios/dashboard/x-rays.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/x-rays.cy.spec.js
@@ -97,6 +97,12 @@ describe("scenarios > x-rays", { tags: "@slow" }, () => {
 
   ["X-ray", "Compare to the rest"].forEach(action => {
     it(`"${action.toUpperCase()}" should work on a nested question made from base native question (metabase#15655)`, () => {
+      if (action === "Compare to the rest") {
+        cy.log(
+          "Skipping Compare to the rest test because it takes 8 minutes in ci",
+        );
+        cy.skipOn(action === "Compare to the rest");
+      }
       cy.intercept("GET", "/api/automagic-dashboards/**").as("xray");
 
       cy.createNativeQuestion({


### PR DESCRIPTION

### Description

Took a close look at the slow test group and found:

A few of the tests were not very slow, so i sent them back to their home groups:


<img width="747" alt="Screen Shot 2024-06-17 at 1 33 33 PM" src="https://github.com/metabase/metabase/assets/30528226/7953960c-7f5b-4060-beec-20e2f15d4be9">

I looked into the very slowest group: x-rays, and discovered that ONE x-ray test is consistently taking 8 minutes (look at timestamps). I can't even get it to finish locally. IMO, that is unacceptable, and i skipped the test.

![Screen Shot 2024-06-17 at 2 04 25 PM](https://github.com/metabase/metabase/assets/30528226/20c7fed9-a120-4259-a58c-b34a0673b4d1)
![Screen Shot 2024-06-17 at 1 45 13 PM](https://github.com/metabase/metabase/assets/30528226/2f353346-23d9-4422-908c-aaf1a0cb3515)
![Screen Shot 2024-06-17 at 1 43 10 PM](https://github.com/metabase/metabase/assets/30528226/58b64dcf-ecac-4603-9c4a-7eacdc681b14)

skipping this one test brings the slow e2e job down from 31 min -> 21 min
