### PR TITLE
E2E repro for "Dashboard filters do not work with SQL models"

### DIFF
--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -34,6 +34,7 @@ import {
   createQuestion,
   multiAutocompleteInput,
   assertQueryBuilderRowCount,
+  createNativeQuestion,
 } from "e2e/support/helpers";
 import {
   createMockDashboardCard,
@@ -2582,5 +2583,92 @@ describe("issue 43799", () => {
       .findByText("People - User → Source is Google")
       .should("be.visible");
     assertQueryBuilderRowCount(4);
+  });
+});
+
+describe.skip("issue 44288", () => {
+  const modelDetails = {
+    name: "SQL model",
+    type: "model",
+    native: { query: "SELECT * FROM PRODUCTS" },
+  };
+
+  const parameterDetails = {
+    name: "Text",
+    slug: "text",
+    id: "27454068",
+    type: "string/=",
+    sectionId: "string",
+  };
+
+  const dashboardDetails = {
+    parameters: [parameterDetails],
+    enable_embedding: true,
+    embedding_params: {
+      [parameterDetails.slug]: "enabled",
+    },
+  };
+
+  function mapFilter() {
+    cy.findByTestId("edit-dashboard-parameters-widget-container")
+      .findByText(parameterDetails.name)
+      .click();
+    selectDashboardFilter(getDashboardCard(), "CATEGORY");
+  }
+
+  function verifyFilter() {
+    filterWidget().click();
+    popover().within(() => {
+      cy.findByPlaceholderText("Enter some text").type("Gadget");
+      cy.button("Add filter").click();
+    });
+    getDashboardCard().within(() => {
+      cy.findAllByText("Gadget").should("have.length.above", 1);
+      cy.findByText("Doohickey").should("not.exit");
+      cy.findByText("Gizmo").should("not.exit");
+      cy.findByText("Widget").should("not.exit");
+    });
+  }
+
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    createNativeQuestion(modelDetails).then(({ body: card }) => {
+      cy.createDashboard(dashboardDetails).then(({ body: dashboard }) => {
+        updateDashboardCards({
+          dashboard_id: dashboard.id,
+          cards: [{ card_id: card.id }],
+        });
+        cy.wrap(dashboard.id).as("dashboardId");
+      });
+    });
+    cy.signOut();
+  });
+
+  it("should allow filtering a SQL model in a dashboard (metabase#44288)", () => {
+    cy.log("regular dashboards");
+    cy.signInAsNormalUser();
+    visitDashboard("@dashboardId");
+    editDashboard();
+    mapFilter();
+    saveDashboard();
+    verifyFilter();
+    cy.signOut();
+
+    cy.log("public dashboards");
+    cy.signInAsAdmin();
+    cy.get("@dashboardId").then(dashboardId =>
+      visitPublicDashboard(dashboardId),
+    );
+    verifyFilter();
+
+    cy.log("embedded dashboards");
+    cy.get("@dashboardId").then(dashboardId =>
+      visitEmbeddedPage({
+        resource: { dashboard: dashboardId },
+        params: {},
+      }),
+    );
+    verifyFilter();
   });
 });

--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -2624,9 +2624,9 @@ describe.skip("issue 44288", () => {
     });
     getDashboardCard().within(() => {
       cy.findAllByText("Gadget").should("have.length.above", 1);
-      cy.findByText("Doohickey").should("not.exit");
-      cy.findByText("Gizmo").should("not.exit");
-      cy.findByText("Widget").should("not.exit");
+      cy.findByText("Doohickey").should("not.exist");
+      cy.findByText("Gizmo").should("not.exist");
+      cy.findByText("Widget").should("not.exist");
     });
   }
 


### PR DESCRIPTION
Reproduces:
- https://github.com/metabase/metabase/issues/40011
- https://github.com/metabase/metabase/issues/44288

Currently if you add a SQL model to a dashboard, dashboard filters do not actually filter data. This PR adds and e2e test that reproduces this issue for all dashboard types as they use different endpoints to query data.

