### PR TITLE
Update the `Past` to `Previous` in date filters

### DIFF
--- a/docs/questions/query-builder/introduction.md
+++ b/docs/questions/query-builder/introduction.md
@@ -89,7 +89,7 @@ Here you can add multiple filters to your question in one go. Filter options wil
 One important thing to understand when filtering on a date column is the difference between specific and relative dates:
 
 - **Specific dates** are things like November 1, 2010, or June 3 – July 12, 2017; they always refer to the same date(s).
-- **Relative dates** are things like "the past 30 days," or "the current week;" as time passes, the dates these options refer to _change_. Relative dates are a useful way to set up a filter on a question so that it stays up-to-date by showing you, for example, how many people visited your website in the last 7 days. You can also click on the **...** to specify a **Starting from** option, which lets you offset the relative date range. For example, you could set the range as the "Previous 7 days, starting from 2 days ago".
+- **Relative dates** are things like "the previous 30 days," or "the current week;" as time passes, the dates these options refer to _change_. Relative dates are a useful way to set up a filter on a question so that it stays up-to-date by showing you, for example, how many people visited your website in the last 7 days. You can also click on the **...** to specify a **Starting from** option, which lets you offset the relative date range. For example, you could set the range as the "Previous 7 days, starting from 2 days ago".
 
 ### Filtering by a segment
 

--- a/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
@@ -632,7 +632,7 @@ describe("scenarios > question > custom column", () => {
     popover().within(() => {
       cy.findByText("MiscDate").click();
       cy.findByText("Relative dates…").click();
-      cy.findByText("Past").click();
+      cy.findByText("Previous").click();
       cy.findByDisplayValue("days").click();
     });
     cy.findByRole("listbox").findByText("years").click();
@@ -824,7 +824,7 @@ describe("scenarios > question > custom column > data type", () => {
       cy.findByText("DoB").click();
       cy.findByPlaceholderText("Enter a number").should("not.exist");
       cy.findByText("Relative dates…").click();
-      cy.findByText("Past").click();
+      cy.findByText("Previous").click();
       cy.findByDisplayValue("days").should("be.visible");
     });
   });
@@ -844,7 +844,7 @@ describe("scenarios > question > custom column > data type", () => {
       cy.findByPlaceholderText("Enter a number").should("not.exist");
 
       cy.findByText("Relative dates…").click();
-      cy.findByText("Past").click();
+      cy.findByText("Previous").click();
       cy.findByDisplayValue("days").should("be.visible");
     });
   });
@@ -863,7 +863,7 @@ describe("scenarios > question > custom column > data type", () => {
       cy.findByText("MiscDate").click();
       cy.findByPlaceholderText("Enter a number").should("not.exist");
       cy.findByText("Relative dates…").click();
-      cy.findByText("Past").click();
+      cy.findByText("Previous").click();
       cy.findByDisplayValue("days").should("be.visible");
     });
   });

--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -613,7 +613,7 @@ describe("scenarios > dashboard > parameters", () => {
       setFilter("Time", "Relative Date");
 
       sidebar().findByText("Default value").next().click();
-      popover().contains("Past 7 days").click({ force: true });
+      popover().contains("Previous 7 days").click({ force: true });
       saveDashboard();
 
       const { interceptor } = spyRequestFinished("dashcardRequestSpy");

--- a/e2e/test/scenarios/dashboard/tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/tabs.cy.spec.js
@@ -682,7 +682,7 @@ describe("scenarios > dashboard > tabs", () => {
     ).as("saveCard");
 
     filterWidget().click();
-    popover().findByText("Past 7 days").click();
+    popover().findByText("Previous 7 days").click();
 
     // Loader in the 2nd tab
     getDashboardCard(0).within(() => {

--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -269,7 +269,7 @@ describe("issue 20683", { tags: "@external" }, () => {
     popover().within(() => {
       cy.findByText("Created At").click();
       cy.findByText("Relative dates…").click();
-      cy.findByText("Past").click();
+      cy.findByText("Previous").click();
       cy.findByText("Current").click();
       cy.findByText("Quarter").click();
     });

--- a/e2e/test/scenarios/filters/filter-types.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter-types.cy.spec.js
@@ -378,7 +378,7 @@ const RELATIVE_DATE_CASES = [
   // Past
   {
     title: "yesterday",
-    offset: "Past",
+    offset: "Previous",
     unit: "day",
     value: 1,
     expectedDisplayName: "Created At is yesterday",
@@ -386,14 +386,14 @@ const RELATIVE_DATE_CASES = [
   },
   {
     title: "previous 7 days",
-    offset: "Past",
+    offset: "Previous",
     unit: "days",
     value: 7,
     expectedDisplayName: "Created At is in the previous 7 days",
   },
   {
     title: "previous 3 weeks starting a quarter ago",
-    offset: "Past",
+    offset: "Previous",
     unit: "weeks",
     value: 3,
     offsetUnit: "quarter",
@@ -403,7 +403,7 @@ const RELATIVE_DATE_CASES = [
   },
   {
     title: "previous month",
-    offset: "Past",
+    offset: "Previous",
     unit: "month",
     value: 1,
     expectedDisplayName: "Created At is in the previous month",
@@ -411,14 +411,14 @@ const RELATIVE_DATE_CASES = [
   },
   {
     title: "previous 3 months",
-    offset: "Past",
+    offset: "Previous",
     unit: "months",
     value: 3,
     expectedDisplayName: "Created At is in the previous 3 months",
   },
   {
     title: "previous two quarters",
-    offset: "Past",
+    offset: "Previous",
     unit: "quarters",
     value: 2,
     expectedDisplayName: "Created At is in the previous 2 quarters",

--- a/e2e/test/scenarios/filters/filter.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter.cy.spec.js
@@ -521,7 +521,7 @@ describe("scenarios > question > filter", () => {
     popover().within(() => {
       cy.findByText("Created At").click();
       cy.findByText("Relative dates…").click();
-      cy.findByText("Past").click();
+      cy.findByText("Previous").click();
       cy.findByText(/^Include/).click();
       cy.button("Add filter").click();
     });

--- a/e2e/test/scenarios/filters/operators.cy.spec.js
+++ b/e2e/test/scenarios/filters/operators.cy.spec.js
@@ -38,7 +38,7 @@ describe("operators in questions", () => {
       unexpected: ["Is null", "Not null"],
     },
     relativeDates: {
-      expected: ["Past", "Next", "Current"],
+      expected: ["Previous", "Next", "Current"],
       unexpected: ["Is null", "Not null"],
     },
     specificDates: {
@@ -101,7 +101,7 @@ describe("operators in questions", () => {
       popover().within(() => {
         cy.findByText("Created At").click();
         cy.findByText("Relative dates…").click();
-        cy.findByText("Past").click();
+        cy.findByText("Previous").click();
       });
 
       popover().within(() => {

--- a/e2e/test/scenarios/filters/relative-datetime.cy.spec.js
+++ b/e2e/test/scenarios/filters/relative-datetime.cy.spec.js
@@ -39,7 +39,7 @@ describe("scenarios > question > relative-datetime", () => {
           date([[-15, unit]]),
           date([[-30, unit]]),
         ]);
-        withStartingFrom("Past", [10, unit], [10, unit]);
+        withStartingFrom("Previous", [10, unit], [10, unit]);
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Showing 2 rows").should("exist");
       }),
@@ -172,7 +172,7 @@ describe("scenarios > question > relative-datetime", () => {
     it("should change the starting from units to match (metabase#22222)", () => {
       openOrdersTable();
 
-      openCreatedAt("Past");
+      openCreatedAt("Previous");
       addStartingFrom();
       setRelativeDatetimeUnit("months");
       popover().within(() => {
@@ -184,7 +184,7 @@ describe("scenarios > question > relative-datetime", () => {
     it("should allow changing values with starting from (metabase#22227)", () => {
       openOrdersTable();
 
-      openCreatedAt("Past");
+      openCreatedAt("Previous");
       addStartingFrom();
       setRelativeDatetimeUnit("months");
       setRelativeDatetimeValue(1);
@@ -307,7 +307,7 @@ const withStartingFrom = (dir, [num, unit], [startNum, startUnit]) => {
   setRelativeDatetimeUnit(unit);
 
   setStartingFromValue(startNum);
-  setStartingFromUnit(startUnit + (dir === "Past" ? " ago" : " from now"));
+  setStartingFromUnit(startUnit + (dir === "Previous" ? " ago" : " from now"));
 
   cy.intercept("POST", "/api/dataset").as("dataset");
   popover().within(() => cy.findByText("Add filter").click());

--- a/e2e/test/scenarios/native-filters/helpers/e2e-date-filter-helpers.js
+++ b/e2e/test/scenarios/native-filters/helpers/e2e-date-filter-helpers.js
@@ -51,7 +51,7 @@ export function setAdHocFilter({
   if (condition) {
     cy.findByText(condition).click({ force: true });
   } else {
-    cy.findByText("Past").click({ force: true });
+    cy.findByText("Previous").click({ force: true });
   }
 
   if (quantity) {

--- a/frontend/src/metabase-lib/v1/parameters/constants.ts
+++ b/frontend/src/metabase-lib/v1/parameters/constants.ts
@@ -178,11 +178,11 @@ export const DATE_MBQL_FILTER_MAPPING: FilterMap = {
     mapping: ["=", null, ["relative-datetime", -1, "day"]],
   },
   past7days: {
-    name: t`Past 7 Days`,
+    name: t`Previous 7 Days`,
     mapping: ["time-interval", null, -7, "day"],
   },
   past30days: {
-    name: t`Past 30 Days`,
+    name: t`Previous 30 Days`,
     mapping: ["time-interval", null, -30, "day"],
   },
   past1weeks: {

--- a/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/DatePicker.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/DatePicker.tsx
@@ -51,7 +51,7 @@ export type DateOperator = {
 export const DATE_OPERATORS: DateOperator[] = [
   {
     name: "previous",
-    displayName: t`Past`,
+    displayName: t`Previous`,
     init: filter => getPreviousDateFilter(filter),
     test: filter => isPreviousDateFilter(filter),
     group: "relative",

--- a/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/DatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/DatePicker.unit.spec.tsx
@@ -311,7 +311,7 @@ describe("DatePicker", () => {
         "quarters",
         "years",
       ];
-      const relativeTimeDirection = ["past", "next"];
+      const relativeTimeDirection = ["previous", "next"];
       const relativeTimeValue = 4;
 
       relativeTimeDirection.forEach(direction => {
@@ -341,7 +341,7 @@ describe("DatePicker", () => {
             expect(changeSpy).toHaveBeenLastCalledWith([
               "time-interval",
               ["field", ORDERS.CREATED_AT, null],
-              (direction === "past" ? -1 : 1) * relativeTimeValue,
+              (direction === "previous" ? -1 : 1) * relativeTimeValue,
               unit.slice(0, -1), // without the 's'
             ]);
           });

--- a/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/DatePickerHeader.unit.spec.js
+++ b/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/DatePickerHeader.unit.spec.js
@@ -13,7 +13,7 @@ describe("DatePickerHeader", () => {
       />,
     );
 
-    expect(screen.getByText("Past")).toBeInTheDocument();
+    expect(screen.getByText("Previous")).toBeInTheDocument();
     expect(screen.getByText("Current")).toBeInTheDocument();
     expect(screen.getByText("Next")).toBeInTheDocument();
   });

--- a/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
@@ -194,7 +194,7 @@ const RelativeDatePicker = (props: RelativeDatePickerProps) => {
       data-testid="relative-date-picker"
     >
       {startingFrom ? (
-        <GridText>{intervals < 0 ? t`Past` : t`Next`}</GridText>
+        <GridText>{intervals < 0 ? t`Previous` : t`Next`}</GridText>
       ) : null}
       <NumericInput
         className={CS.textRight}

--- a/frontend/src/metabase/components/DateRelativeWidget/DateRelativeWidget.tsx
+++ b/frontend/src/metabase/components/DateRelativeWidget/DateRelativeWidget.tsx
@@ -28,8 +28,12 @@ const SHORTCUTS: Shortcut[] = [
     operator: ["=", "<", ">"],
     values: [["relative-datetime", -1, "day"]],
   },
-  { name: t`Past 7 days`, operator: "time-interval", values: [-7, "day"] },
-  { name: t`Past 30 days`, operator: "time-interval", values: [-30, "day"] },
+  { name: t`Previous 7 days`, operator: "time-interval", values: [-7, "day"] },
+  {
+    name: t`Previous 30 days`,
+    operator: "time-interval",
+    values: [-30, "day"],
+  },
 ];
 
 const RELATIVE_SHORTCUTS: ShortcutMap = {

--- a/frontend/src/metabase/components/DateRelativeWidget/DateRelativeWidget.unit.spec.tsx
+++ b/frontend/src/metabase/components/DateRelativeWidget/DateRelativeWidget.unit.spec.tsx
@@ -18,7 +18,7 @@ describe("DateRelativeWidget", () => {
     );
     expect(screen.getByText("Today")).toBeVisible();
     expect(screen.getByText("Today")).toHaveAttribute("aria-selected", "false");
-    expect(screen.getByText("Past 7 days")).toBeVisible();
-    expect(screen.getByText("Past 30 days")).toBeVisible();
+    expect(screen.getByText("Previous 7 days")).toBeVisible();
+    expect(screen.getByText("Previous 30 days")).toBeVisible();
   });
 });

--- a/frontend/src/metabase/parameters/utils/formatting.unit.spec.ts
+++ b/frontend/src/metabase/parameters/utils/formatting.unit.spec.ts
@@ -59,7 +59,7 @@ describe("metabase/parameters/utils/formatting", () => {
       {
         type: "date/relative",
         value: "past30days",
-        expected: "Past 30 Days",
+        expected: "Previous 30 Days",
       },
       {
         type: "date/month-year",

--- a/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/utils.ts
+++ b/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/utils.ts
@@ -12,7 +12,7 @@ import { getDirection } from "../utils";
 
 export function getDirectionText(value: DateOffsetIntervalValue): string {
   const direction = getDirection(value);
-  return direction === "last" ? t`Past` : t`Next`;
+  return direction === "last" ? t`Previous` : t`Next`;
 }
 
 export function setUnit(

--- a/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/RelativeDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/RelativeDatePicker.unit.spec.tsx
@@ -6,7 +6,7 @@ import type { RelativeDatePickerValue } from "../types";
 
 import { RelativeDatePicker } from "./RelativeDatePicker";
 
-const TABS = ["Past", "Current", "Next"];
+const TABS = ["Previous", "Current", "Next"];
 const TAB_CASES = TABS.flatMap(fromTab => TABS.map(toTab => [fromTab, toTab]));
 
 interface SetupOpts {
@@ -60,7 +60,7 @@ describe("RelativeDatePicker", () => {
     await userEvent.click(screen.getByLabelText("Next"));
     expect(screen.getByLabelText("Interval")).toHaveValue("20");
 
-    await userEvent.click(screen.getByLabelText("Past"));
+    await userEvent.click(screen.getByLabelText("Previous"));
     expect(screen.getByLabelText("Interval")).toHaveValue("20");
   });
 
@@ -75,7 +75,7 @@ describe("RelativeDatePicker", () => {
     await userEvent.click(screen.getByLabelText("Next"));
     expect(screen.getByLabelText("Starting from interval")).toHaveValue("20");
 
-    await userEvent.click(screen.getByLabelText("Past"));
+    await userEvent.click(screen.getByLabelText("Previous"));
     expect(screen.getByLabelText("Starting from interval")).toHaveValue("20");
   });
 

--- a/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/constants.ts
+++ b/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/constants.ts
@@ -3,7 +3,7 @@ import { t } from "ttag";
 import type { Tab } from "./types";
 
 export const TABS: Tab[] = [
-  { label: t`Past`, direction: "last" },
+  { label: t`Previous`, direction: "last" },
   { label: t`Current`, direction: "current" },
   { label: t`Next`, direction: "next" },
 ];


### PR DESCRIPTION
Closes #44340

### Description

This PR updates the copy in date filter pickers by replacing the word "Past" with the "Previous". It then proceeds to update and fix the related tests.

### How to verify

**Relative date picker**
1. Open Orders table
2. Click on the "Created At" header cell > Filter on this Column > Relative dates
3. It should say "Previous" instead of "Past"
![image](https://github.com/metabase/metabase/assets/31325167/1b0c3b58-c6c1-41c8-b4da-6f33d6abb953)
4. Add the filter and the filter pill should say "Created At is in the previous 30 days"
![image](https://github.com/metabase/metabase/assets/31325167/1c582525-6b1b-4aaa-8bb1-5e14a5c4a070)

This same component is used in the Notebook filter picker and in the chill mode filter modal.

**Timeseries chrome**
1. Orders > "Count" broken down by "Created at"
2. Visualize
3. Click on "All options" in the timeseries chrome
4. The list should contain "Previous" instead of "Past"
![image](https://github.com/metabase/metabase/assets/31325167/4d7a4db6-89ff-47a2-b240-81f1ca36e2e3)

**Dashboard relative filters**
1. Add Orders to the dashboard
2. Add a dashboard filter
3. Choose Time > Relative filter (optionally connect it to the dashboard card)
4. Save the dashboard
5. Click on the filter and you should see "Previous 7 days" and "Previous 30 days"
![image](https://github.com/metabase/metabase/assets/31325167/f18cd8b1-8e71-4c8a-95af-3e61aeb56e2a)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
