### PR TITLE
[BE] Rewrite `column_settings` keys to aliases on read

### DIFF
--- a/frontend/src/metabase/visualizations/lib/settings/visualization.js
+++ b/frontend/src/metabase/visualizations/lib/settings/visualization.js
@@ -63,12 +63,15 @@ function getSettingDefintionsForSeries(series) {
 function normalizeColumnSettings(columnSettings) {
   const newColumnSettings = {};
   for (const oldColumnKey of Object.keys(columnSettings)) {
-    const [refOrName, fieldRef] = JSON.parse(oldColumnKey);
-    // if the key is a reference, normalize the mbql syntax
-    const newColumnKey =
-      refOrName === "ref"
-        ? JSON.stringify(["ref", normalize(fieldRef)])
-        : oldColumnKey;
+    let newColumnKey = oldColumnKey;
+    if (oldColumnKey.startsWith("[")) {
+      const [refOrName, fieldRef] = JSON.parse(oldColumnKey);
+      // if the key is a reference, normalize the mbql syntax
+      newColumnKey =
+        refOrName === "ref"
+          ? JSON.stringify(["ref", normalize(fieldRef)])
+          : oldColumnKey;
+    }
     newColumnSettings[newColumnKey] = columnSettings[oldColumnKey];
   }
   return newColumnSettings;

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -5,6 +5,7 @@
    [cheshire.generate :as json.generate]
    [clojure.core.memoize :as memoize]
    [clojure.spec.alpha :as s]
+   [clojure.string :as str]
    [clojure.walk :as walk]
    [malli.core :as mc]
    [malli.error :as me]
@@ -282,7 +283,10 @@
    to modern MBQL clauses so things work correctly."
   [viz-settings]
   (letfn [(normalize-column-settings-key [k]
-            (some-> k u/qualified-name json/parse-string mbql.normalize/normalize json/generate-string))
+            (let [k (u/qualified-name k)]
+              (cond-> k
+                ;; Could be an embedded JSON string like "[\"ref\", [\"field\", ...]]"; parse and normalize it if so.
+                (str/includes? k "[") (some-> json/parse-string mbql.normalize/normalize json/generate-string))))
           (normalize-column-settings [column-settings]
             (into {} (for [[k v] column-settings]
                        [(normalize-column-settings-key k) (walk/keywordize-keys v)])))


### PR DESCRIPTION
Rewrite the column keys in viz settings to use `desired-column-alias`.

This is the BE portion of #43310.

It's a draft PR because it's definitely going to break the FE, which is expecting the field refs.

