### PR TITLE
[Bug Fix] Use effective location when building initial path in entity picker

### DIFF
--- a/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPicker.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPicker.tsx
@@ -158,7 +158,7 @@ export const CollectionPickerInner = (
           idPath: getCollectionIdPath(
             {
               id: currentCollection.id,
-              location: currentCollection.location,
+              location: currentCollection.effective_location,
               is_personal: currentCollection.is_personal,
             },
             userPersonalCollectionId,

--- a/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPicker.unit.spec.tsx
@@ -11,7 +11,7 @@ import {
   within,
   waitFor,
 } from "__support__/ui";
-import type { CollectionId } from "metabase-types/api";
+import type { Collection, CollectionId } from "metabase-types/api";
 import {
   createMockCollection,
   createMockCollectionItem,
@@ -25,6 +25,7 @@ type MockCollection = {
   id: CollectionId;
   name: string;
   location: string | null;
+  effective_location: string | null;
   is_personal: boolean;
   collections: MockCollection[];
 };
@@ -34,12 +35,14 @@ const collectionTree: MockCollection[] = [
     id: "root",
     name: "Our Analytics",
     location: null,
+    effective_location: null,
     is_personal: false,
     collections: [
       {
         id: 4,
         name: "Collection 4",
         location: "/",
+        effective_location: "/",
         is_personal: false,
         collections: [
           {
@@ -47,6 +50,7 @@ const collectionTree: MockCollection[] = [
             name: "Collection 3",
             collections: [],
             location: "/4/",
+            effective_location: "/4/",
             is_personal: false,
           },
         ],
@@ -56,6 +60,7 @@ const collectionTree: MockCollection[] = [
         is_personal: false,
         name: "Collection 2",
         location: "/",
+        effective_location: "/",
         collections: [],
       },
     ],
@@ -64,11 +69,13 @@ const collectionTree: MockCollection[] = [
     name: "My personal collection",
     id: 1,
     location: "/",
+    effective_location: "/",
     is_personal: true,
     collections: [
       {
         id: 5,
         location: "/1/",
+        effective_location: "/1/",
         name: "personal sub_collection",
         is_personal: true,
         collections: [],
@@ -86,6 +93,7 @@ const flattenCollectionTree = (
       id: n.id,
       is_personal: !!n.is_personal,
       location: n.location,
+      effective_location: n.effective_location,
     })),
   ].concat(...node.map(n => flattenCollectionTree(n.collections)));
 };
@@ -98,6 +106,7 @@ const setupCollectionTreeMocks = (node: MockCollection[]) => {
         name: c.name,
         model: "collection",
         location: c.location || "/",
+        effective_location: c.effective_location || "/",
       }),
     );
 
@@ -128,8 +137,9 @@ const setup = ({
   mockGetBoundingClientRect();
   mockScrollBy();
 
-  const allCollections =
-    flattenCollectionTree(collectionTree).map(createMockCollection);
+  const allCollections = flattenCollectionTree(collectionTree).map(c =>
+    createMockCollection(c as Collection),
+  );
 
   //Setup individual collection mocks
   allCollections.forEach(collection => {

--- a/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPicker.tsx
+++ b/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPicker.tsx
@@ -169,7 +169,7 @@ const DashboardPickerInner = (
         const idPath = getCollectionIdPath(
           {
             id: currentCollection.id,
-            location: currentCollection.location,
+            location: currentCollection.effective_location,
             is_personal: currentCollection.is_personal,
           },
           userPersonalCollectionId,

--- a/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPicker.unit.spec.tsx
@@ -60,6 +60,7 @@ const collectionTree: NestedCollectionItem[] = [
         name: "Collection 4",
         model: "collection",
         location: "/",
+        effective_location: "/",
         can_write: true,
         descendants: [
           {
@@ -79,6 +80,7 @@ const collectionTree: NestedCollectionItem[] = [
               },
             ],
             location: "/4/",
+            effective_location: "/4/",
             can_write: true,
             is_personal: false,
           },
@@ -90,6 +92,7 @@ const collectionTree: NestedCollectionItem[] = [
         is_personal: false,
         name: "Collection 2",
         location: "/",
+        effective_location: "/",
         can_write: true,
         descendants: [],
       },
@@ -100,6 +103,7 @@ const collectionTree: NestedCollectionItem[] = [
     id: 1,
     model: "collection",
     location: "/",
+    effective_location: "/",
     is_personal: true,
     can_write: true,
     descendants: [
@@ -107,6 +111,7 @@ const collectionTree: NestedCollectionItem[] = [
         id: 5,
         model: "collection",
         location: "/1/",
+        effective_location: "/1/",
         name: "personal sub_collection",
         is_personal: true,
         can_write: true,

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
@@ -63,6 +63,7 @@ const COLLECTION = createMockCollection({
   can_write: true,
   is_personal: false,
   location: "/",
+  effective_location: "/",
 });
 
 const SUBCOLLECTION = createMockCollection({
@@ -71,6 +72,7 @@ const SUBCOLLECTION = createMockCollection({
   can_write: true,
   is_personal: false,
   location: `/${COLLECTION.id}/`,
+  effective_location: `/${COLLECTION.id}/`,
 });
 
 const PERSONAL_COLLECTION = createMockCollection({
@@ -80,6 +82,7 @@ const PERSONAL_COLLECTION = createMockCollection({
   can_write: true,
   is_personal: true,
   location: "/",
+  effective_location: "/",
 });
 
 const PERSONAL_SUBCOLLECTION = createMockCollection({
@@ -88,6 +91,7 @@ const PERSONAL_SUBCOLLECTION = createMockCollection({
   can_write: true,
   is_personal: true,
   location: `/${PERSONAL_COLLECTION.id}/`,
+  effective_location: `/${PERSONAL_COLLECTION.id}/`,
 });
 
 const ROOT_COLLECTION = createMockCollection({


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/44316

### Description
If the collection (or dashboard) picker is supplied with an initial value, it will try and compute a path to show panels in the entity picker. This was being computed from the `location` property, which can include collections the current user doesn't have access to. Switching this to use `effective_location` solves the issue above

### How to verify
1. log in as a user who has access to a sub collection, but doesn't have access to it's parent
2. create a question and save it in that sub collection
3. open the question that was just made, and try to move it. Everything should work as expected, and you should not see any panels that complain about permissions

### Demo
![chrome_NyR0PWKLCU](https://github.com/metabase/metabase/assets/1328979/64294c26-99de-400a-851c-67010ac19fb4)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
