### PR TITLE
Pivot Tables with no Pivot Columns should still download

### DIFF
--- a/src/metabase/api/embed/common.clj
+++ b/src/metabase/api/embed/common.clj
@@ -251,27 +251,6 @@
       (assoc (select-keys param [:type :target :slug])
              :value value))))
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 ;;; ---------------------------- Card Fns used by both /api/embed and /api/preview_embed -----------------------------
 
 (defn card-for-unsigned-token

--- a/src/metabase/query_processor/pivot/postprocess.clj
+++ b/src/metabase/query_processor/pivot/postprocess.clj
@@ -65,17 +65,17 @@
         ;; will be from the columns in the same order as presented in pivot-cols.
         ;; So, if pivot-cols is [0 1], the first col-value-group will have [first-value-from-first-col first-value-from-second-col]
         col-value-groups           (apply math.combo/cartesian-product (concat
-                                                                (map (fn [col-k]
-                                                                       (all-values-for rows col-k false))
-                                                                     pivot-cols)
-                                                                (when (seq measure-titles)
-                                                                  [measure-titles])))
+                                                                        (map (fn [col-k]
+                                                                               (all-values-for rows col-k false))
+                                                                             pivot-cols)
+                                                                        (when (seq measure-titles)
+                                                                          [measure-titles])))
         header-indices             (if (or multiple-measures? (not (seq pivot-cols)))
-                             ;; when there are more than 1 pivot-measures, we need to
-                             ;; add one more header row that holds the titles of the measure columns
-                             ;; and we know it's always just one more row, so we can inc the count.
-                             (range (inc (count pivot-cols)))
-                             (range (count pivot-cols)))]
+                                     ;; when there are more than 1 pivot-measures, we need to
+                                     ;; add one more header row that holds the titles of the measure columns
+                                     ;; and we know it's always just one more row, so we can inc the count.
+                                     (range (inc (count pivot-cols)))
+                                     (range (count pivot-cols)))]
     ;; Each Header (1 header row per pivot-col) will first start with the Pivot Row Titles. There will be (count pivot-rows) entries.
     ;; Then, Get all of the nth entries in the col-value-gropus for the nth header, and then append "Row Totals" label.
     (mapv
@@ -85,6 +85,7 @@
              (map #(nth % col-idx) col-value-groups)
              (if (and
                   multiple-measures?
+                  (seq pivot-cols)
                   (= col-idx (last header-indices)))
                measure-titles
                (when include-row-totals-header?

--- a/src/metabase/query_processor/streaming/csv.clj
+++ b/src/metabase/query_processor/streaming/csv.clj
@@ -40,7 +40,8 @@
               col-names (when-not opts (common/column-titles ordered-cols (::mb.viz/column-settings viz-settings) format-rows?))]
           ;; when pivot options exist, we want to save them to access later when processing the complete set of results for export.
           (when opts
-            (reset! pivot-options opts))
+            (reset! pivot-options (merge {:pivot-rows []
+                                          :pivot-cols []} opts)))
           (vreset! ordered-formatters
                    (if format-rows?
                      (mapv #(formatter/create-formatter results_timezone % viz-settings) ordered-cols)

--- a/test/metabase/api/downloads_exports_test.clj
+++ b/test/metabase/api/downloads_exports_test.clj
@@ -197,3 +197,47 @@
                   ["2016-05-01T00:00:00Z" "Widget" "90.21"]
                   ["Totals for 2016-05-01T00:00:00Z" "" "391"]]
                  (take 6 result))))))))
+
+(deftest ^:parallel zero-column-multiple-meausres-pivot-tables-test
+  (testing "Pivot tables with zero columns and multiple measures download correctly."
+    (mt/dataset test-data
+      (mt/with-temp [:model/Card {pivot-card-id :id}
+                     {:display                :pivot
+                      :visualization_settings {:pivot_table.column_split
+                                               {:rows    [[:field (mt/id :products :created_at) {:base-type :type/DateTime :temporal-unit :month}]
+                                                          [:field (mt/id :products :category) {:base-type :type/Text}]]
+                                                :columns []
+                                                :values  [[:aggregation 0] [:aggregation 1]]}}
+                      :dataset_query          {:database (mt/id)
+                                               :type     :query
+                                               :query
+                                               {:source-table (mt/id :products)
+                                                :aggregation  [[:sum [:field (mt/id :products :price) {:base-type :type/Float}]]
+                                                               [:sum [:field (mt/id :products :price) {:base-type :type/Float}]]]
+                                                :breakout     [[:field (mt/id :products :category) {:base-type :type/Text}]
+                                                               [:field (mt/id :products :created_at) {:base-type :type/DateTime :temporal-unit :year}]]}}}]
+        (let [result (->> (mt/user-http-request :crowberto :post 200 (format "card/%d/query/csv?format_rows=false" pivot-card-id))
+                          csv/read-csv)]
+          (is (= [["Created At" "Category" "Sum of Price" "Sum of Price"]
+                  ["2016-01-01T00:00:00Z" "Doohickey" "632.14" "632.14"]
+                  ["2016-01-01T00:00:00Z" "Gadget" "679.83" "679.83"]
+                  ["2016-01-01T00:00:00Z" "Gizmo" "529.7" "529.7"]
+                  ["2016-01-01T00:00:00Z" "Widget" "987.39" "987.39"]
+                  ["Totals for 2016-01-01T00:00:00Z" "" "2829.06" "2829.06"]
+                  ["2017-01-01T00:00:00Z" "Doohickey" "854.19" "854.19"]
+                  ["2017-01-01T00:00:00Z" "Gadget" "1059.11" "1059.11"]
+                  ["2017-01-01T00:00:00Z" "Gizmo" "1080.18" "1080.18"]
+                  ["2017-01-01T00:00:00Z" "Widget" "1014.68" "1014.68"]
+                  ["Totals for 2017-01-01T00:00:00Z" "" "4008.16" "4008.16"]
+                  ["2018-01-01T00:00:00Z" "Doohickey" "496.43" "496.43"]
+                  ["2018-01-01T00:00:00Z" "Gadget" "844.51" "844.51"]
+                  ["2018-01-01T00:00:00Z" "Gizmo" "997.94" "997.94"]
+                  ["2018-01-01T00:00:00Z" "Widget" "912.2" "912.2"]
+                  ["Totals for 2018-01-01T00:00:00Z" "" "3251.08" "3251.08"]
+                  ["2019-01-01T00:00:00Z" "Doohickey" "203.13" "203.13"]
+                  ["2019-01-01T00:00:00Z" "Gadget" "435.75" "435.75"]
+                  ["2019-01-01T00:00:00Z" "Gizmo" "227.06" "227.06"]
+                  ["2019-01-01T00:00:00Z" "Widget" "195.04" "195.04"]
+                  ["Totals for 2019-01-01T00:00:00Z" "" "1060.98" "1060.98"]
+                  ["Grand Totals" "" "11149.28" "11149.28"]]
+                 result)))))))


### PR DESCRIPTION
Fixes #44159

Pivot Tables can still be valid without columns, and therefore the download should respect such a query and be successfully exported.

In this PR, the postprocessing of pivot results into 'visual pivot' exports for csv takes into account the zero-column configuration and the download no longer fails.
