### PR TITLE
Disable SQL analysis by default + turn off all QueryField backfills

### DIFF
--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -923,5 +923,5 @@ See [fonts](../configuring-metabase/fonts.md).")
   (deferred-tru "SQL Parsing is disabled")
   :visibility :internal
   :export?    false
-  :default    true
+  :default    false
   :type       :boolean)

--- a/src/metabase/task/backfill_query_fields.clj
+++ b/src/metabase/task/backfill_query_fields.clj
@@ -1,13 +1,15 @@
 (ns metabase.task.backfill-query-fields
   (:require
-   [clojurewerkz.quartzite.jobs :as jobs]
-   [clojurewerkz.quartzite.triggers :as triggers]
+   #_[clojurewerkz.quartzite.jobs :as jobs]
+   #_[clojurewerkz.quartzite.triggers :as triggers]
    [metabase.models.query-field :as query-field]
-   [metabase.task :as task]
+   #_[metabase.task :as task]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
+;; Still used by tests
+#_{:clj-kondo/ignore [:unused-private-var]}
 (defn- backfill-query-fields! []
   (let [cards (t2/reducible-select :model/Card :id [:in {:from      [[:report_card :c]]
                                                          :left-join [[:query_field :f] [:= :f.card_id :c.id]]
@@ -17,12 +19,13 @@
                                                                      [:= :f.id nil]]}])]
     (run! query-field/update-query-fields-for-card! cards)))
 
-(jobs/defjob ^{org.quartz.DisallowConcurrentExecution true
+#_(jobs/defjob ^{org.quartz.DisallowConcurrentExecution true
                :doc "Backfill QueryField for cards created earlier. Runs once per instance."}
   BackfillQueryField [_ctx]
   (backfill-query-fields!))
 
-(defmethod task/init! ::BackfillQueryField [_]
+;; Disabling for v50 due to concerns about robustness and correctness of SQL analysis.
+#_(defmethod task/init! ::BackfillQueryField [_]
   (let [job     (jobs/build
                   (jobs/of-type BackfillQueryField)
                   (jobs/with-identity (jobs/key "metabase.task.backfill-query-fields.job"))

--- a/test/metabase/native_query_analyzer_test.clj
+++ b/test/metabase/native_query_analyzer_test.clj
@@ -30,8 +30,13 @@
            ;; this is "Perv""e""rse"
            (#'query-analyzer/field-query :f.name "\"Perv\"\"e\"\"rse\"")))))
 
+(defmacro with-parsing-enabled [& body]
+  `(mt/with-temporary-setting-values [sql-parsing-enabled true]
+     (binding [query-analyzer/*parse-queries-in-test?* true]
+       ~@body)))
+
 (deftest ^:parallel field-matching-test
-  (binding [query-analyzer/*parse-queries-in-test?* true]
+  (with-parsing-enabled
     (let [q (fn [sql]
               (#'query-analyzer/field-ids-for-sql (mt/native-query {:query sql})))]
       (testing "simple query matches"

--- a/test/metabase/native_query_analyzer_test.clj
+++ b/test/metabase/native_query_analyzer_test.clj
@@ -30,13 +30,8 @@
            ;; this is "Perv""e""rse"
            (#'query-analyzer/field-query :f.name "\"Perv\"\"e\"\"rse\"")))))
 
-(defmacro with-parsing-enabled [& body]
-  `(mt/with-temporary-setting-values [sql-parsing-enabled true]
-     (binding [query-analyzer/*parse-queries-in-test?* true]
-       ~@body)))
-
 (deftest ^:parallel field-matching-test
-  (with-parsing-enabled
+  (mt/with-dynamic-redefs [query-analyzer/active? (constantly true)]
     (let [q (fn [sql]
               (#'query-analyzer/field-ids-for-sql (mt/native-query {:query sql})))]
       (testing "simple query matches"

--- a/test/metabase/task/backfill_query_fields_test.clj
+++ b/test/metabase/task/backfill_query_fields_test.clj
@@ -43,8 +43,9 @@
           (is (zero? (get-count (:id c3))))
           (is (zero? (get-count (:id c4))))
           (is (zero? (get-count (:id arch)))))
-        (binding [query-analyzer/*parse-queries-in-test?* true]
-          (#'backfill/backfill-query-fields!))
+        (mt/with-temporary-setting-values [sql-parsing-enabled true]
+          (binding [query-analyzer/*parse-queries-in-test?* true]
+            (#'backfill/backfill-query-fields!)))
         (testing "QueryField is filled now"
           (testing "for a native query"
             (is (pos? (get-count (:id c1)))))


### PR DESCRIPTION
SQL analysis is not yes as robust as we would like, and does not yet power any customer facing features in v50. Some customers are seeing [huge amounts of related warnings](https://github.com/metabase/metabase/issues/44006), which also come at the cost of lots of exception catching, so we should disable it by default. There is still an option to opt-into it.