### PR TITLE
Fix timeline events filtering in the query builder

### DIFF
--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -837,9 +837,14 @@ function getXDomainForTimelines(xDomain, dataInterval) {
   // If we filter timeline events up until Jan 1, 2024, we won't see any events from 2024,
   // so we need to extend xDomain by dataInterval.count * dataInterval.unit to include them
   if (xDomain && isAbsoluteDateTimeUnit(dataInterval?.unit)) {
-    const maxValue = xDomain[1]
+    let maxValue = xDomain[1]
       .clone()
       .add(dataInterval.count, dataInterval.unit);
+
+    if (dataInterval.unit !== "hour" && dataInterval.unit !== "minute") {
+      maxValue = maxValue.subtract(1, "day");
+    }
+
     return [xDomain[0], maxValue];
   }
 


### PR DESCRIPTION
Fixes #23336 

When viewing timeline events in QB chill mode, we're filtering out events outside the x-axis range. For instance, if we're viewing some data between 2022 and 2023, we don't want to see events from 2021 and 2024. The PR fixes a bug in this logic that was filtering out events in the last interval. For example, when viewing data between 2022 and 2023, the `xDomain` is `[ "01-01-2022", "01-01-2023" ]. We used to keep events in between these dates, but since we're using the first date of an interval, we're losing all the events past Jan 1, 2023, i.e., all of 2023. That happened for each absolute unit of time in the QB

### To verify

1. New > Question > Orders > Count by "Created At: Month" > Visualize
2. Click the calendar icon at the bottom right to open the events sidebar
3. The last month record is April 2026, so add an event on e.g. 10 April 2026, and ensure it's visible in the sidebar
4. Add an event past April 2026 and ensure it doesn't get displayed
5. Repeat similar steps for weeks, years, etc.