### PR TITLE
 logic to handle downloads url parameter

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-questions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-questions.cy.spec.js
@@ -306,7 +306,7 @@ describeEE("scenarios > embedding > questions > downloads", () => {
           "Trying to prevent downloads via query params doesn't have any effect",
         );
         cy.url().then(url => {
-          cy.visit(url + "&hide_download_button=true");
+          cy.visit(url + "&downloads=false");
         });
 
         cy.get("[data-testid=cell-data]").should("have.text", "Foo");
@@ -349,7 +349,7 @@ describeEE("scenarios > embedding > questions > downloads", () => {
         cy.get("[data-testid=cell-data]").should("have.text", "Foo");
 
         cy.location("search").should("eq", "?text=Foo");
-        cy.location("hash").should("match", /&hide_download_button=true$/);
+        cy.location("hash").should("match", /&downloads=false$/);
 
         cy.log("We don't even show the footer if it's empty");
         cy.findByRole("contentinfo").should("not.exist");

--- a/e2e/test/scenarios/embedding/embedding-snippets.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-snippets.cy.spec.js
@@ -17,7 +17,7 @@ import { getEmbeddingJsCode, IFRAME_CODE } from "./shared/embedding-snippets";
 const features = ["none", "all"];
 
 features.forEach(feature => {
-  describe("scenarios > embedding > code snippets", () => {
+  describe(`[features=${feature}] scenarios > embedding > code snippets`, () => {
     beforeEach(() => {
       restore();
       cy.signInAsAdmin();
@@ -25,6 +25,7 @@ features.forEach(feature => {
     });
 
     it("dashboard should have the correct embed snippet", () => {
+      const defaultDownloadsValue = feature === "all" ? true : undefined;
       visitDashboard(ORDERS_DASHBOARD_ID);
       openStaticEmbeddingModal({ acceptTerms: false });
 
@@ -42,7 +43,11 @@ features.forEach(feature => {
           .invoke("text")
           .should(
             "match",
-            getEmbeddingJsCode({ type: "dashboard", id: ORDERS_DASHBOARD_ID }),
+            getEmbeddingJsCode({
+              type: "dashboard",
+              id: ORDERS_DASHBOARD_ID,
+              downloads: defaultDownloadsValue,
+            }),
           );
 
         cy.findAllByTestId("embed-backend-select-button")
@@ -72,11 +77,6 @@ features.forEach(feature => {
       modal().within(() => {
         cy.findByRole("tab", { name: "Appearance" }).click();
 
-        // No download button for dashboards even for pro/enterprise users metabase#23477
-        cy.findByLabelText(
-          "Enable users to download data from this embed",
-        ).should("not.exist");
-
         // set transparent background metabase#23477
         cy.findByText("Transparent").click();
         cy.get(".ace_content")
@@ -88,12 +88,33 @@ features.forEach(feature => {
               type: "dashboard",
               id: ORDERS_DASHBOARD_ID,
               theme: "transparent",
+              downloads: defaultDownloadsValue,
             }),
           );
+
+        if (feature === "all") {
+          cy.findByText(
+            "Enable users to download data from this embed",
+          ).click();
+
+          cy.get(".ace_content")
+            .first()
+            .invoke("text")
+            .should(
+              "match",
+              getEmbeddingJsCode({
+                type: "dashboard",
+                id: ORDERS_DASHBOARD_ID,
+                theme: "transparent",
+                downloads: false,
+              }),
+            );
+        }
       });
     });
 
     it("question should have the correct embed snippet", () => {
+      const defaultDownloadsValue = feature === "all" ? true : undefined;
       visitQuestion(ORDERS_QUESTION_ID);
       openStaticEmbeddingModal({ acceptTerms: false });
 
@@ -110,7 +131,11 @@ features.forEach(feature => {
           .invoke("text")
           .should(
             "match",
-            getEmbeddingJsCode({ type: "question", id: ORDERS_QUESTION_ID }),
+            getEmbeddingJsCode({
+              type: "question",
+              id: ORDERS_QUESTION_ID,
+              downloads: defaultDownloadsValue,
+            }),
           );
 
         cy.findByRole("tab", { name: "Appearance" }).click();
@@ -126,6 +151,7 @@ features.forEach(feature => {
               type: "question",
               id: ORDERS_QUESTION_ID,
               theme: "transparent",
+              downloads: defaultDownloadsValue,
             }),
           );
 
@@ -144,7 +170,7 @@ features.forEach(feature => {
                 type: "question",
                 id: ORDERS_QUESTION_ID,
                 theme: "transparent",
-                hideDownloadButton: true,
+                downloads: false,
               }),
             );
         }

--- a/e2e/test/scenarios/embedding/shared/embedding-snippets.js
+++ b/e2e/test/scenarios/embedding/shared/embedding-snippets.js
@@ -1,4 +1,4 @@
-export const getEmbeddingJsCode = ({ type, id, hideDownloadButton, theme }) => {
+export const getEmbeddingJsCode = ({ type, id, downloads, theme }) => {
   return new RegExp(
     `// you will need to install via 'npm install jsonwebtoken' or in your package.json
 
@@ -15,7 +15,7 @@ var token = jwt.sign(payload, METABASE_SECRET_KEY);
 
 var iframeUrl = METABASE_SITE_URL + "/embed/${type}/" + token +
   "#${getThemeParameter(theme)}bordered=true&titled=true${getParameter({
-      hideDownloadButton,
+      downloads,
     })}";`
       .split("\n")
       .join("")
@@ -35,11 +35,11 @@ export const IFRAME_CODE = `iframe(
   .split("\n")
   .join("");
 
-function getParameter({ hideDownloadButton }) {
+function getParameter({ downloads }) {
   let parameter = "";
 
-  if (hideDownloadButton) {
-    parameter += "&hide_download_button=true";
+  if (downloads !== undefined) {
+    parameter += `&downloads=${downloads}`;
   }
 
   return parameter;

--- a/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
@@ -532,7 +532,7 @@ describe("#39152 sharing an unsaved question", () => {
                 titled: true,
                 font: "instance",
                 theme: "light",
-                hide_download_button: resource === "question" ? false : null,
+                hide_download_button: null,
               },
             });
 
@@ -550,7 +550,7 @@ describe("#39152 sharing an unsaved question", () => {
                 titled: true,
                 font: "instance",
                 theme: "light",
-                hide_download_button: resource === "question" ? false : null,
+                hide_download_button: null,
               },
             });
 
@@ -575,7 +575,7 @@ describe("#39152 sharing an unsaved question", () => {
                 titled: true,
                 font: "instance",
                 theme: "light",
-                hide_download_button: resource === "question" ? false : null,
+                hide_download_button: null,
               },
             });
 
@@ -620,7 +620,7 @@ describe("#39152 sharing an unsaved question", () => {
                 titled: false,
                 font: "custom",
                 theme: "night",
-                hide_download_button: resource === "question" ? true : null,
+                hide_download_button: null,
               },
             });
           });

--- a/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
@@ -420,6 +420,7 @@ describe("#39152 sharing an unsaved question", () => {
               titled: true,
               font: "instance",
               theme: "light",
+              // TODO: change to expect the correct value of  `downloads`
               hide_download_button: null,
             },
           });
@@ -438,6 +439,7 @@ describe("#39152 sharing an unsaved question", () => {
               titled: true,
               font: "instance",
               theme: "light",
+              // TODO: change to expect the correct value of  `downloads`
               hide_download_button: null,
             },
           });
@@ -463,6 +465,7 @@ describe("#39152 sharing an unsaved question", () => {
               titled: true,
               font: "instance",
               theme: "light",
+              // TODO: change to expect the correct value of  `downloads`
               hide_download_button: null,
             },
           });
@@ -501,6 +504,7 @@ describe("#39152 sharing an unsaved question", () => {
               titled: false,
               font: "instance",
               theme: "night",
+              // TODO: change to expect the correct value of  `downloads`
               hide_download_button: null,
             },
           });
@@ -532,6 +536,7 @@ describe("#39152 sharing an unsaved question", () => {
                 titled: true,
                 font: "instance",
                 theme: "light",
+                // TODO: change to expect the correct value of  `downloads`
                 hide_download_button: null,
               },
             });
@@ -550,6 +555,7 @@ describe("#39152 sharing an unsaved question", () => {
                 titled: true,
                 font: "instance",
                 theme: "light",
+                // TODO: change to expect the correct value of  `downloads`
                 hide_download_button: null,
               },
             });
@@ -575,6 +581,7 @@ describe("#39152 sharing an unsaved question", () => {
                 titled: true,
                 font: "instance",
                 theme: "light",
+                // TODO: change to expect the correct value of  `downloads`
                 hide_download_button: null,
               },
             });
@@ -620,6 +627,7 @@ describe("#39152 sharing an unsaved question", () => {
                 titled: false,
                 font: "custom",
                 theme: "night",
+                // TODO: change to expect the correct value of  `downloads`
                 hide_download_button: null,
               },
             });

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/InteractiveDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/InteractiveDashboard.tsx
@@ -124,7 +124,6 @@ const InteractiveDashboardInner = ({
         <PublicOrEmbeddedDashboard
           dashboardId={dashboardId}
           parameterQueryParams={initialParameterValues}
-          hideDownloadButton={displayOptions.hideDownloadButton}
           hideParameters={displayOptions.hideParameters}
           titled={displayOptions.titled}
           cardTitled={withCardTitle}
@@ -137,6 +136,7 @@ const InteractiveDashboardInner = ({
           font={font}
           bordered={displayOptions.bordered}
           navigateToNewCardFromDashboard={handleNavigateToNewCardFromDashboard}
+          downloads={false}
         />
       )}
     </Box>

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/InteractiveDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveDashboard/InteractiveDashboard.tsx
@@ -136,7 +136,7 @@ const InteractiveDashboardInner = ({
           font={font}
           bordered={displayOptions.bordered}
           navigateToNewCardFromDashboard={handleNavigateToNewCardFromDashboard}
-          downloads={false}
+          downloadsEnabled={false}
         />
       )}
     </Box>

--- a/enterprise/frontend/src/embedding-sdk/components/public/StaticDashboard/StaticDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/StaticDashboard/StaticDashboard.tsx
@@ -45,7 +45,6 @@ export const StaticDashboardInner = ({
       <PublicOrEmbeddedDashboard
         dashboardId={dashboardId}
         parameterQueryParams={initialParameterValues}
-        hideDownloadButton={displayOptions.hideDownloadButton}
         hideParameters={displayOptions.hideParameters}
         titled={displayOptions.titled}
         cardTitled={withCardTitle}
@@ -57,6 +56,7 @@ export const StaticDashboardInner = ({
         setRefreshElapsedHook={setRefreshElapsedHook}
         font={font}
         bordered={displayOptions.bordered}
+        downloads={withDownloads}
       />
     </Box>
   );

--- a/enterprise/frontend/src/embedding-sdk/components/public/StaticDashboard/StaticDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/StaticDashboard/StaticDashboard.tsx
@@ -56,7 +56,7 @@ export const StaticDashboardInner = ({
         setRefreshElapsedHook={setRefreshElapsedHook}
         font={font}
         bordered={displayOptions.bordered}
-        downloads={withDownloads}
+        downloadsEnabled={withDownloads}
       />
     </Box>
   );

--- a/enterprise/frontend/src/metabase-enterprise/resource_downloads/resource_downloads_plugin.ts
+++ b/enterprise/frontend/src/metabase-enterprise/resource_downloads/resource_downloads_plugin.ts
@@ -1,7 +1,25 @@
+import { match } from "ts-pattern";
+
 import { PLUGIN_RESOURCE_DOWNLOADS } from "metabase/plugins";
 
-// TODO: implement real logic
 /**
  * Returns if 'download results' on cards and pdf exports are enabled in public and embedded contexts.
  */
-PLUGIN_RESOURCE_DOWNLOADS.areDownloadsEnabled = () => true;
+PLUGIN_RESOURCE_DOWNLOADS.areDownloadsEnabled = ({
+  hide_download_button,
+  downloads,
+}: {
+  hide_download_button?: boolean | null;
+  downloads?: boolean | null;
+}) => {
+  return (
+    match({ hide_download_button, downloads })
+      // `downloads` has priority over `hide_download_button`
+      .with({ downloads: true }, () => true)
+      .with({ downloads: false }, () => false)
+      // but we still support the old `hide_download_button` option
+      .with({ hide_download_button: true }, () => false)
+      // by default downloads are enabled
+      .otherwise(() => true)
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/resource_downloads/resource_downloads_plugin.ts
+++ b/enterprise/frontend/src/metabase-enterprise/resource_downloads/resource_downloads_plugin.ts
@@ -1,25 +1,28 @@
 import { match } from "ts-pattern";
 
 import { PLUGIN_RESOURCE_DOWNLOADS } from "metabase/plugins";
+import { hasPremiumFeature } from "metabase-enterprise/settings";
 
-/**
- * Returns if 'download results' on cards and pdf exports are enabled in public and embedded contexts.
- */
-PLUGIN_RESOURCE_DOWNLOADS.areDownloadsEnabled = ({
-  hide_download_button,
-  downloads,
-}: {
-  hide_download_button?: boolean | null;
-  downloads?: boolean | null;
-}) => {
-  return (
-    match({ hide_download_button, downloads })
-      // `downloads` has priority over `hide_download_button`
-      .with({ downloads: true }, () => true)
-      .with({ downloads: false }, () => false)
-      // but we still support the old `hide_download_button` option
-      .with({ hide_download_button: true }, () => false)
-      // by default downloads are enabled
-      .otherwise(() => true)
-  );
-};
+if (hasPremiumFeature("whitelabel")) {
+  /**
+   * Returns if 'download results' on cards and pdf exports are enabled in public and embedded contexts.
+   */
+  PLUGIN_RESOURCE_DOWNLOADS.areDownloadsEnabled = ({
+    hide_download_button,
+    downloads,
+  }: {
+    hide_download_button?: boolean | null;
+    downloads?: boolean | null;
+  }) => {
+    return (
+      match({ hide_download_button, downloads })
+        // `downloads` has priority over `hide_download_button`
+        .with({ downloads: true }, () => true)
+        .with({ downloads: false }, () => false)
+        // but we still support the old `hide_download_button` option
+        .with({ hide_download_button: true }, () => false)
+        // by default downloads are enabled
+        .otherwise(() => true)
+    );
+  };
+}

--- a/enterprise/frontend/src/metabase-enterprise/resource_downloads/tests/common.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/resource_downloads/tests/common.unit.spec.ts
@@ -1,0 +1,23 @@
+import { PLUGIN_RESOURCE_DOWNLOADS } from "metabase/plugins";
+
+import { downloadsEnabledTestData, setup } from "./setup";
+
+describe("[OSS] resource downloads plugin", () => {
+  beforeAll(() => {
+    setup({ hasEnterprisePlugins: false });
+  });
+
+  describe("areDownloadsEnabled - should always return true on OSS", () => {
+    it.each(downloadsEnabledTestData)(
+      `with { downloads:$downloads, hide_download_button:$hide_download_button } it should return true`,
+      ({ hide_download_button, downloads }) => {
+        expect(
+          PLUGIN_RESOURCE_DOWNLOADS.areDownloadsEnabled({
+            hide_download_button,
+            downloads,
+          }),
+        ).toBe(true);
+      },
+    );
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/resource_downloads/tests/enterprise.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/resource_downloads/tests/enterprise.unit.spec.ts
@@ -1,0 +1,23 @@
+import { PLUGIN_RESOURCE_DOWNLOADS } from "metabase/plugins";
+
+import { downloadsEnabledTestData, setup } from "./setup";
+
+describe("[EE - no features] resource downloads plugin", () => {
+  beforeAll(() => {
+    setup({ hasEnterprisePlugins: false });
+  });
+
+  describe("areDownloadsEnabled - should always return true if we don't have the whitelabel feature", () => {
+    it.each(downloadsEnabledTestData)(
+      `with { downloads:$downloads, hide_download_button:$hide_download_button } it should return true`,
+      ({ hide_download_button, downloads }) => {
+        expect(
+          PLUGIN_RESOURCE_DOWNLOADS.areDownloadsEnabled({
+            hide_download_button,
+            downloads,
+          }),
+        ).toBe(true);
+      },
+    );
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/resource_downloads/tests/premium.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/resource_downloads/tests/premium.unit.spec.ts
@@ -1,0 +1,27 @@
+import { PLUGIN_RESOURCE_DOWNLOADS } from "metabase/plugins";
+import { createMockTokenFeatures } from "metabase-types/api/mocks";
+
+import { downloadsEnabledTestData, setup } from "./setup";
+
+describe("[EE - with token features] resource downloads plugin", () => {
+  describe("areDownloadsEnabled", () => {
+    beforeEach(() => {
+      setup({
+        hasEnterprisePlugins: true,
+        tokenFeatures: createMockTokenFeatures({ whitelabel: true }),
+      });
+    });
+
+    it.each(downloadsEnabledTestData)(
+      `with { downloads:$downloads, hide_download_button:$hide_download_button } it should return $downloadsEnabled`,
+      ({ hide_download_button, downloads, downloadsEnabled }) => {
+        expect(
+          PLUGIN_RESOURCE_DOWNLOADS.areDownloadsEnabled({
+            hide_download_button,
+            downloads,
+          }),
+        ).toBe(downloadsEnabled);
+      },
+    );
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/resource_downloads/tests/setup.ts
+++ b/enterprise/frontend/src/metabase-enterprise/resource_downloads/tests/setup.ts
@@ -1,0 +1,40 @@
+import { setupEnterprisePlugins } from "__support__/enterprise";
+import { mockSettings } from "__support__/settings";
+import type { TokenFeatures } from "metabase-types/api";
+import { createMockTokenFeatures } from "metabase-types/api/mocks";
+
+export interface SetupOpts {
+  tokenFeatures?: TokenFeatures;
+  hasEnterprisePlugins?: boolean;
+}
+
+export const setup = ({
+  tokenFeatures = createMockTokenFeatures(),
+  hasEnterprisePlugins = false,
+}: SetupOpts = {}) => {
+  mockSettings({ "token-features": tokenFeatures });
+
+  if (hasEnterprisePlugins) {
+    setupEnterprisePlugins();
+  }
+};
+
+export const downloadsEnabledTestData = [
+  { hide_download_button: true, downloads: true, downloadsEnabled: true },
+  { hide_download_button: true, downloads: false, downloadsEnabled: false },
+  { hide_download_button: true, downloads: undefined, downloadsEnabled: false },
+  { hide_download_button: false, downloads: true, downloadsEnabled: true },
+  { hide_download_button: false, downloads: false, downloadsEnabled: false },
+  { hide_download_button: false, downloads: undefined, downloadsEnabled: true },
+  { hide_download_button: undefined, downloads: true, downloadsEnabled: true },
+  {
+    hide_download_button: undefined,
+    downloads: false,
+    downloadsEnabled: false,
+  },
+  {
+    hide_download_button: undefined,
+    downloads: undefined,
+    downloadsEnabled: true,
+  },
+];

--- a/frontend/src/metabase/dashboard/constants.ts
+++ b/frontend/src/metabase/dashboard/constants.ts
@@ -8,14 +8,14 @@ import type { EmbedDisplayParams } from "./types";
 export const DASHBOARD_DESCRIPTION_MAX_LENGTH = 1500;
 
 export const SIDEBAR_NAME: Record<DashboardSidebarName, DashboardSidebarName> =
-{
-  addQuestion: "addQuestion",
-  action: "action",
-  clickBehavior: "clickBehavior",
-  editParameter: "editParameter",
-  sharing: "sharing",
-  info: "info",
-};
+  {
+    addQuestion: "addQuestion",
+    action: "action",
+    clickBehavior: "clickBehavior",
+    editParameter: "editParameter",
+    sharing: "sharing",
+    info: "info",
+  };
 
 export const INITIAL_DASHBOARD_STATE: DashboardState = {
   dashboardId: null,

--- a/frontend/src/metabase/dashboard/constants.ts
+++ b/frontend/src/metabase/dashboard/constants.ts
@@ -58,5 +58,5 @@ export const DEFAULT_DASHBOARD_DISPLAY_OPTIONS: EmbedDisplayParams = {
   hideParameters: null,
   font: null,
   theme: "light",
-  downloads: true,
+  downloadsEnabled: true,
 };

--- a/frontend/src/metabase/dashboard/constants.ts
+++ b/frontend/src/metabase/dashboard/constants.ts
@@ -8,14 +8,14 @@ import type { EmbedDisplayParams } from "./types";
 export const DASHBOARD_DESCRIPTION_MAX_LENGTH = 1500;
 
 export const SIDEBAR_NAME: Record<DashboardSidebarName, DashboardSidebarName> =
-  {
-    addQuestion: "addQuestion",
-    action: "action",
-    clickBehavior: "clickBehavior",
-    editParameter: "editParameter",
-    sharing: "sharing",
-    info: "info",
-  };
+{
+  addQuestion: "addQuestion",
+  action: "action",
+  clickBehavior: "clickBehavior",
+  editParameter: "editParameter",
+  sharing: "sharing",
+  info: "info",
+};
 
 export const INITIAL_DASHBOARD_STATE: DashboardState = {
   dashboardId: null,
@@ -55,8 +55,8 @@ export const DEFAULT_DASHBOARD_DISPLAY_OPTIONS: EmbedDisplayParams = {
   bordered: false,
   titled: true,
   cardTitled: true,
-  hideDownloadButton: null,
   hideParameters: null,
   font: null,
   theme: "light",
+  downloads: true,
 };

--- a/frontend/src/metabase/dashboard/hooks/use-dashboard-url-params.ts
+++ b/frontend/src/metabase/dashboard/hooks/use-dashboard-url-params.ts
@@ -10,7 +10,6 @@ import { useLocationSync } from "metabase/dashboard/hooks/use-location-sync";
 import type { RefreshPeriod } from "metabase/dashboard/types";
 import type { DashboardUrlHashOptions } from "metabase/dashboard/types/hash-options";
 import { parseHashOptions } from "metabase/lib/browser";
-import { PLUGIN_RESOURCE_DOWNLOADS } from "metabase/plugins";
 import { useEmbedFrameOptions } from "metabase/public/hooks";
 import type { DisplayTheme } from "metabase/public/lib/types";
 
@@ -25,7 +24,7 @@ export const useDashboardUrlParams = ({
 }) => {
   const { font, setFont } = useEmbedFont();
 
-  const { bordered, titled, hide_parameters, hide_download_button, downloads } =
+  const { bordered, titled, hide_parameters, downloadsEnabled } =
     useEmbedFrameOptions({ location });
 
   const {
@@ -35,11 +34,6 @@ export const useDashboardUrlParams = ({
     setTheme,
     theme,
   } = useEmbedTheme();
-
-  const downloadsEnabled = PLUGIN_RESOURCE_DOWNLOADS.areDownloadsEnabled({
-    hide_download_button,
-    downloads,
-  });
 
   const { isFullscreen, onFullscreenChange } = useDashboardFullscreen();
   const { onRefreshPeriodChange, refreshPeriod, setRefreshElapsedHook } =

--- a/frontend/src/metabase/dashboard/hooks/use-dashboard-url-params.ts
+++ b/frontend/src/metabase/dashboard/hooks/use-dashboard-url-params.ts
@@ -10,6 +10,7 @@ import { useLocationSync } from "metabase/dashboard/hooks/use-location-sync";
 import type { RefreshPeriod } from "metabase/dashboard/types";
 import type { DashboardUrlHashOptions } from "metabase/dashboard/types/hash-options";
 import { parseHashOptions } from "metabase/lib/browser";
+import { PLUGIN_RESOURCE_DOWNLOADS } from "metabase/plugins";
 import { useEmbedFrameOptions } from "metabase/public/hooks";
 import type { DisplayTheme } from "metabase/public/lib/types";
 
@@ -24,7 +25,7 @@ export const useDashboardUrlParams = ({
 }) => {
   const { font, setFont } = useEmbedFont();
 
-  const { bordered, titled, hide_parameters, hide_download_button } =
+  const { bordered, titled, hide_parameters, hide_download_button, downloads } =
     useEmbedFrameOptions({ location });
 
   const {
@@ -34,6 +35,11 @@ export const useDashboardUrlParams = ({
     setTheme,
     theme,
   } = useEmbedTheme();
+
+  const downloadsEnabled = PLUGIN_RESOURCE_DOWNLOADS.areDownloadsEnabled({
+    hide_download_button,
+    downloads,
+  });
 
   const { isFullscreen, onFullscreenChange } = useDashboardFullscreen();
   const { onRefreshPeriodChange, refreshPeriod, setRefreshElapsedHook } =
@@ -81,8 +87,8 @@ export const useDashboardUrlParams = ({
     onRefreshPeriodChange,
     bordered,
     titled,
-    hideDownloadButton: hide_download_button,
     font,
     setFont,
+    downloadsEnabled,
   };
 };

--- a/frontend/src/metabase/dashboard/types/display-options.ts
+++ b/frontend/src/metabase/dashboard/types/display-options.ts
@@ -20,4 +20,6 @@ export type DashboardRefreshPeriodControls = {
 
 export type DashboardDisplayOptionControls = EmbedDisplayControls &
   DashboardFullscreenControls &
-  DashboardRefreshPeriodControls;
+  DashboardRefreshPeriodControls & {
+    downloadsEnabled: boolean | null;
+  };

--- a/frontend/src/metabase/dashboard/types/embed-display-options.ts
+++ b/frontend/src/metabase/dashboard/types/embed-display-options.ts
@@ -36,7 +36,7 @@ export type EmbedDisplayParams = {
   hideParameters: EmbedHideParameters;
   font: EmbedFont;
   theme: DisplayTheme;
-  downloads: boolean;
+  downloadsEnabled: boolean;
 };
 
 export type EmbedDisplayControls = EmbedThemeControls &

--- a/frontend/src/metabase/dashboard/types/embed-display-options.ts
+++ b/frontend/src/metabase/dashboard/types/embed-display-options.ts
@@ -36,7 +36,7 @@ export type EmbedDisplayParams = {
   hideParameters: EmbedHideParameters;
   font: EmbedFont;
   theme: DisplayTheme;
-  downloads: boolean
+  downloads: boolean;
 };
 
 export type EmbedDisplayControls = EmbedThemeControls &

--- a/frontend/src/metabase/dashboard/types/embed-display-options.ts
+++ b/frontend/src/metabase/dashboard/types/embed-display-options.ts
@@ -33,10 +33,10 @@ export type EmbedDisplayParams = {
   bordered: boolean;
   titled: EmbedTitle;
   cardTitled: EmbedTitle;
-  hideDownloadButton: EmbedHideDownloadButton;
   hideParameters: EmbedHideParameters;
   font: EmbedFont;
   theme: DisplayTheme;
+  downloads: boolean
 };
 
 export type EmbedDisplayControls = EmbedThemeControls &

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -484,5 +484,8 @@ export const PLUGIN_RESOURCE_DOWNLOADS = {
   /**
    * Returns if 'download results' on cards and pdf exports are enabled in public and embedded contexts.
    */
-  areDownloadsEnabled: () => true,
+  areDownloadsEnabled: (_args: {
+    hide_download_button?: boolean | null;
+    downloads?: boolean | null;
+  }) => true,
 };

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
@@ -113,7 +113,7 @@ export const EmbedFrame = ({
   titled,
   theme,
   hide_parameters,
-  downloads = true,
+  downloadsEnabled = true,
 }: EmbedFrameProps) => {
   const isEmbeddingSdk = useSelector(getIsEmbeddingSdk);
   const hasEmbedBranding = useSelector(
@@ -148,7 +148,7 @@ export const EmbedFrame = ({
     .filter(Boolean)
     .join(",");
 
-  const showFooter = hasEmbedBranding || (downloads && actionButtons);
+  const showFooter = hasEmbedBranding || (downloadsEnabled && actionButtons);
 
   const finalName = titled ? name : null;
 
@@ -200,7 +200,7 @@ export const EmbedFrame = ({
             )}
             data-testid="embed-frame-header"
           >
-            {(finalName || downloads) && (
+            {(finalName || downloadsEnabled) && (
               <TitleAndDescriptionContainer>
                 <TitleAndButtonsContainer
                   data-testid="fixed-width-dashboard-header"
@@ -215,7 +215,7 @@ export const EmbedFrame = ({
                   )}
                   <Box style={{ flex: 1 }} />
                   {/* TODO: move this to a prop passed by PublicDashboard ? */}
-                  {dashboard && downloads && (
+                  {dashboard && downloadsEnabled && (
                     <Button
                       variant="subtle"
                       leftIcon={<Icon name="document" />}

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
@@ -74,6 +74,7 @@ export type EmbedFrameBaseProps = Partial<{
   setParameterValueToDefault: (id: ParameterId) => void;
   children: ReactNode;
   dashboardTabs: ReactNode;
+  downloadsEnabled: boolean;
 }>;
 
 export type EmbedFrameProps = EmbedFrameBaseProps & DashboardUrlHashOptions;
@@ -112,8 +113,6 @@ export const EmbedFrame = ({
   titled,
   theme,
   hide_parameters,
-  hide_download_button,
-  // TODO: merge `downloads` with `hide_download_button` on the higher level component?
   downloads = true,
 }: EmbedFrameProps) => {
   const isEmbeddingSdk = useSelector(getIsEmbeddingSdk);
@@ -149,8 +148,7 @@ export const EmbedFrame = ({
     .filter(Boolean)
     .join(",");
 
-  const showFooter =
-    hasEmbedBranding || (!hide_download_button && actionButtons);
+  const showFooter = hasEmbedBranding || (downloads && actionButtons);
 
   const finalName = titled ? name : null;
 

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/AppearanceSettings.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/AppearanceSettings.tsx
@@ -157,9 +157,8 @@ export const AppearanceSettings = ({
             )}
           </DisplayOptionSection>
 
-          {canWhitelabel && resourceType === "question" && (
+          {canWhitelabel && (
             // We only show the "Download Data" toggle if the users are pro/enterprise
-            // and they're sharing a question metabase#23477
             <DisplayOptionSection
               title={t`Download data`}
               titleId={downloadDataId}
@@ -170,11 +169,11 @@ export const AppearanceSettings = ({
                 labelPosition="left"
                 size="sm"
                 variant="stretch"
-                checked={!displayOptions.hide_download_button}
+                checked={displayOptions.downloads ?? true}
                 onChange={e =>
                   onChangeDisplayOptions({
                     ...displayOptions,
-                    hide_download_button: !e.target.checked,
+                    downloads: e.target.checked,
                   })
                 }
               />

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/ServerEmbedCodePane.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/ServerEmbedCodePane.tsx
@@ -59,7 +59,7 @@ export const ServerEmbedCodePane = ({
   );
 
   const canWhitelabel = useSelector(getCanWhitelabel);
-  const shouldShowDownloadData = canWhitelabel && resourceType === "question";
+  const shouldShowDownloadData = canWhitelabel;
 
   if (!selectedServerCodeOption) {
     return null;

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/StaticEmbedSetupPane.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/StaticEmbedSetupPane.tsx
@@ -89,7 +89,7 @@ export const StaticEmbedSetupPane = ({
     useState<EmbeddingParametersValues>({});
 
   const canWhitelabel = useSelector(getCanWhitelabel);
-  const shouldShowDownloadData = canWhitelabel && resourceType === "question";
+  const shouldShowDownloadData = canWhitelabel;
   const [displayOptions, setDisplayOptions] = useState<EmbeddingDisplayOptions>(
     getDefaultDisplayOptions(shouldShowDownloadData),
   );

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/config.ts
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/config.ts
@@ -8,7 +8,6 @@ export function getDefaultDisplayOptions(
     theme: "light",
     bordered: true,
     titled: true,
-    hide_download_button: shouldShownDownloadData ? false : null,
-    downloads: null,
+    downloads: shouldShownDownloadData ? true : null,
   };
 }

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tests/premium.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tests/premium.unit.spec.tsx
@@ -124,7 +124,7 @@ describe("Static Embed Setup phase - EE, with token", () => {
           await userEvent.click(screen.getByLabelText("Download data"));
 
           expect(screen.getByTestId("text-editor-mock")).toHaveTextContent(
-            `hide_download_button=true`,
+            `downloads=false`,
           );
         });
       }

--- a/frontend/src/metabase/public/constants.ts
+++ b/frontend/src/metabase/public/constants.ts
@@ -4,5 +4,5 @@ export const DEFAULT_EMBED_DISPLAY_PARAMS = {
   titled: DEFAULT_DASHBOARD_DISPLAY_OPTIONS.titled,
   theme: undefined,
   hideParameters: DEFAULT_DASHBOARD_DISPLAY_OPTIONS.hideParameters,
-  hideDownloadButton: DEFAULT_DASHBOARD_DISPLAY_OPTIONS.hideDownloadButton,
+  downloads: DEFAULT_DASHBOARD_DISPLAY_OPTIONS.downloads,
 } as const;

--- a/frontend/src/metabase/public/constants.ts
+++ b/frontend/src/metabase/public/constants.ts
@@ -4,5 +4,5 @@ export const DEFAULT_EMBED_DISPLAY_PARAMS = {
   titled: DEFAULT_DASHBOARD_DISPLAY_OPTIONS.titled,
   theme: undefined,
   hideParameters: DEFAULT_DASHBOARD_DISPLAY_OPTIONS.hideParameters,
-  downloads: DEFAULT_DASHBOARD_DISPLAY_OPTIONS.downloads,
+  downloadsEnabled: DEFAULT_DASHBOARD_DISPLAY_OPTIONS.downloadsEnabled,
 } as const;

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboard.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboard.tsx
@@ -29,6 +29,11 @@ import type {
   SuccessfulFetchDashboardResult,
 } from "metabase/dashboard/types";
 import { PLUGIN_RESOURCE_DOWNLOADS } from "metabase/plugins";
+import { isActionDashCard } from "metabase/dashboard/utils";
+import title from "metabase/hoc/Title";
+import { isWithinIframe } from "metabase/lib/dom";
+import ParametersS from "metabase/parameters/components/ParameterValueWidget.module.css";
+import { WithPublicDashboardEndpoints } from "metabase/public/containers/PublicOrEmbeddedDashboard/WithPublicDashboardEndpoints";
 import { setErrorPage } from "metabase/redux/app";
 import type { DashboardId } from "metabase-types/api";
 import type { State } from "metabase-types/store";
@@ -64,7 +69,7 @@ type ReduxProps = ConnectedProps<typeof connector>;
 type OwnProps = {
   dashboardId: DashboardId;
   parameterQueryParams: Query;
-
+  downloadsEnabled?: boolean;
   navigateToNewCardFromDashboard?: (
     opts: NavigateToNewCardFromDashboardOpts,
   ) => void;
@@ -168,7 +173,7 @@ class PublicOrEmbeddedDashboardInner extends Component<PublicOrEmbeddedDashboard
       bordered,
       titled,
       theme,
-      hideDownloadButton,
+      downloadsEnabled = true,
       hideParameters,
       navigateToNewCardFromDashboard,
       selectedTabId,
@@ -177,8 +182,6 @@ class PublicOrEmbeddedDashboardInner extends Component<PublicOrEmbeddedDashboard
       dashboardId,
       cardTitled,
     } = this.props;
-
-    const downloadsEnabled = PLUGIN_RESOURCE_DOWNLOADS.areDownloadsEnabled();
 
     return (
       <PublicOrEmbeddedDashboardView
@@ -202,11 +205,10 @@ class PublicOrEmbeddedDashboardInner extends Component<PublicOrEmbeddedDashboard
         titled={titled}
         theme={theme}
         hideParameters={hideParameters}
-        hideDownloadButton={hideDownloadButton}
         navigateToNewCardFromDashboard={navigateToNewCardFromDashboard}
         slowCards={slowCards}
         cardTitled={cardTitled}
-        downloadsEnabled={downloadsEnabled}
+        downloads={downloadsEnabled}
       />
     );
   }

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboard.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboard.tsx
@@ -28,12 +28,6 @@ import type {
   FetchDashboardResult,
   SuccessfulFetchDashboardResult,
 } from "metabase/dashboard/types";
-import { PLUGIN_RESOURCE_DOWNLOADS } from "metabase/plugins";
-import { isActionDashCard } from "metabase/dashboard/utils";
-import title from "metabase/hoc/Title";
-import { isWithinIframe } from "metabase/lib/dom";
-import ParametersS from "metabase/parameters/components/ParameterValueWidget.module.css";
-import { WithPublicDashboardEndpoints } from "metabase/public/containers/PublicOrEmbeddedDashboard/WithPublicDashboardEndpoints";
 import { setErrorPage } from "metabase/redux/app";
 import type { DashboardId } from "metabase-types/api";
 import type { State } from "metabase-types/store";

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboard.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboard.tsx
@@ -202,7 +202,7 @@ class PublicOrEmbeddedDashboardInner extends Component<PublicOrEmbeddedDashboard
         navigateToNewCardFromDashboard={navigateToNewCardFromDashboard}
         slowCards={slowCards}
         cardTitled={cardTitled}
-        downloads={downloadsEnabled}
+        downloadsEnabled={downloadsEnabled}
       />
     );
   }

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardPage.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardPage.tsx
@@ -26,7 +26,7 @@ export const PublicOrEmbeddedDashboardPage = (props: WithRouterProps) => {
   const {
     bordered,
     hasNightModeToggle,
-    hideDownloadButton,
+    downloadsEnabled,
     hideParameters,
     isFullscreen,
     isNightMode,
@@ -59,7 +59,7 @@ export const PublicOrEmbeddedDashboardPage = (props: WithRouterProps) => {
         onFullscreenChange={onFullscreenChange}
         onRefreshPeriodChange={onRefreshPeriodChange}
         bordered={bordered}
-        hideDownloadButton={hideDownloadButton}
+        downloads={downloadsEnabled}
         theme={theme}
         titled={titled}
         font={font}

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardPage.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardPage.tsx
@@ -59,7 +59,7 @@ export const PublicOrEmbeddedDashboardPage = (props: WithRouterProps) => {
         onFullscreenChange={onFullscreenChange}
         onRefreshPeriodChange={onRefreshPeriodChange}
         bordered={bordered}
-        downloads={downloadsEnabled}
+        downloadsEnabled={downloadsEnabled}
         theme={theme}
         titled={titled}
         font={font}

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardView.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardView.tsx
@@ -65,7 +65,7 @@ export function PublicOrEmbeddedDashboardView({
   navigateToNewCardFromDashboard,
   slowCards,
   cardTitled,
-  downloads,
+  downloadsEnabled,
 }: {
   dashboard: Dashboard | null;
   hasNightModeToggle?: boolean;
@@ -96,7 +96,7 @@ export function PublicOrEmbeddedDashboardView({
   ) => void;
   slowCards: Record<number, boolean>;
   cardTitled: boolean;
-  downloads: boolean;
+  downloadsEnabled: boolean;
 }) {
   const buttons = !isWithinIframe()
     ? getDashboardActions({
@@ -153,7 +153,7 @@ export function PublicOrEmbeddedDashboardView({
       titled={titled}
       theme={theme}
       hide_parameters={hideParameters}
-      downloadsEnabled={downloads}
+      downloadsEnabled={downloadsEnabled}
     >
       <LoadingAndErrorWrapper
         className={cx({
@@ -193,7 +193,7 @@ export function PublicOrEmbeddedDashboardView({
                 withCardTitle={cardTitled}
                 clickBehaviorSidebarDashcard={null}
                 navigateToNewCardFromDashboard={navigateToNewCardFromDashboard}
-                downloadsEnabled={downloads}
+                downloadsEnabled={downloadsEnabled}
               />
             </DashboardContainer>
           );

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardView.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardView.tsx
@@ -18,7 +18,6 @@ import { DashboardTabs } from "metabase/dashboard/components/DashboardTabs";
 import type {
   DashboardFullscreenControls,
   DashboardRefreshPeriodControls,
-  EmbedHideDownloadButton,
   EmbedHideParameters,
   EmbedThemeControls,
   RefreshPeriod,
@@ -63,11 +62,10 @@ export function PublicOrEmbeddedDashboardView({
   titled,
   theme,
   hideParameters,
-  hideDownloadButton,
   navigateToNewCardFromDashboard,
   slowCards,
   cardTitled,
-  downloadsEnabled,
+  downloads,
 }: {
   dashboard: Dashboard | null;
   hasNightModeToggle?: boolean;
@@ -93,13 +91,12 @@ export function PublicOrEmbeddedDashboardView({
   titled: boolean;
   theme: DisplayTheme;
   hideParameters: EmbedHideParameters;
-  hideDownloadButton: EmbedHideDownloadButton;
   navigateToNewCardFromDashboard?: (
     opts: NavigateToNewCardFromDashboardOpts,
   ) => void;
   slowCards: Record<number, boolean>;
   cardTitled: boolean;
-  downloadsEnabled: boolean;
+  downloads: boolean;
 }) {
   const buttons = !isWithinIframe()
     ? getDashboardActions({
@@ -156,7 +153,7 @@ export function PublicOrEmbeddedDashboardView({
       titled={titled}
       theme={theme}
       hide_parameters={hideParameters}
-      hide_download_button={hideDownloadButton}
+      downloadsEnabled={downloads}
     >
       <LoadingAndErrorWrapper
         className={cx({
@@ -196,7 +193,7 @@ export function PublicOrEmbeddedDashboardView({
                 withCardTitle={cardTitled}
                 clickBehaviorSidebarDashcard={null}
                 navigateToNewCardFromDashboard={navigateToNewCardFromDashboard}
-                downloadsEnabled={downloadsEnabled}
+                downloadsEnabled={downloads}
               />
             </DashboardContainer>
           );

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion.tsx
@@ -3,7 +3,6 @@ import { useCallback, useEffect, useState } from "react";
 import { useMount } from "react-use";
 
 import { useDispatch, useSelector } from "metabase/lib/redux";
-import { PLUGIN_RESOURCE_DOWNLOADS } from "metabase/plugins";
 import { useEmbedFrameOptions } from "metabase/public/hooks";
 import { setErrorPage } from "metabase/redux/app";
 import { addFields, addParamValues } from "metabase/redux/metadata";
@@ -47,19 +46,8 @@ export const PublicOrEmbeddedQuestion = ({
   const [parameterValues, setParameterValues] = useState<ParameterValuesMap>(
     {},
   );
-  const {
-    bordered,
-    hide_download_button,
-    hide_parameters,
-    theme,
-    titled,
-    downloads,
-  } = useEmbedFrameOptions({ location });
-
-  const downloadsEnabled = PLUGIN_RESOURCE_DOWNLOADS.areDownloadsEnabled({
-    hide_download_button,
-    downloads,
-  });
+  const { bordered, hide_parameters, theme, titled, downloadsEnabled } =
+    useEmbedFrameOptions({ location });
 
   useMount(async () => {
     if (uuid) {

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion.tsx
@@ -47,8 +47,19 @@ export const PublicOrEmbeddedQuestion = ({
   const [parameterValues, setParameterValues] = useState<ParameterValuesMap>(
     {},
   );
+  const {
+    bordered,
+    hide_download_button,
+    hide_parameters,
+    theme,
+    titled,
+    downloads,
+  } = useEmbedFrameOptions({ location });
 
-  const downloadsEnabled = PLUGIN_RESOURCE_DOWNLOADS.areDownloadsEnabled();
+  const downloadsEnabled = PLUGIN_RESOURCE_DOWNLOADS.areDownloadsEnabled({
+    hide_download_button,
+    downloads,
+  });
 
   useMount(async () => {
     if (uuid) {
@@ -167,9 +178,6 @@ export const PublicOrEmbeddedQuestion = ({
     );
   };
 
-  const { bordered, hide_download_button, hide_parameters, theme, titled } =
-    useEmbedFrameOptions({ location });
-
   return (
     <PublicOrEmbeddedQuestionView
       initialized={initialized}
@@ -183,7 +191,6 @@ export const PublicOrEmbeddedQuestion = ({
       setParameterValue={setParameterValue}
       setParameterValueToDefault={setParameterValueToDefault}
       bordered={bordered}
-      hide_download_button={hide_download_button}
       hide_parameters={hide_parameters}
       theme={theme}
       titled={titled}

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestionView.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestionView.tsx
@@ -32,7 +32,6 @@ export function PublicOrEmbeddedQuestionView({
   setParameterValue,
   setParameterValueToDefault,
   bordered,
-  hide_download_button,
   hide_parameters,
   theme,
   titled,
@@ -50,7 +49,6 @@ export function PublicOrEmbeddedQuestionView({
   setParameterValue: (parameterId: ParameterId, value: any) => Promise<void>;
   setParameterValueToDefault: (parameterId: ParameterId) => void;
   bordered: boolean;
-  hide_download_button: boolean | null;
   hide_parameters: string | null;
   theme: DisplayTheme | undefined;
   titled: boolean;
@@ -80,7 +78,6 @@ export function PublicOrEmbeddedQuestionView({
       enableParameterRequiredBehavior
       setParameterValueToDefault={setParameterValueToDefault}
       bordered={bordered}
-      hide_download_button={hide_download_button}
       hide_parameters={hide_parameters}
       theme={theme}
       titled={titled}

--- a/frontend/src/metabase/public/hooks/use-embed-frame-options.ts
+++ b/frontend/src/metabase/public/hooks/use-embed-frame-options.ts
@@ -12,7 +12,8 @@ export const useEmbedFrameOptions = ({ location }: { location: Location }) => {
     titled = DEFAULT_EMBED_DISPLAY_PARAMS.titled,
     theme = DEFAULT_EMBED_DISPLAY_PARAMS.theme,
     hide_parameters = DEFAULT_EMBED_DISPLAY_PARAMS.hideParameters,
-    hide_download_button = DEFAULT_EMBED_DISPLAY_PARAMS.hideDownloadButton,
+    hide_download_button = null,
+    downloads = DEFAULT_EMBED_DISPLAY_PARAMS.downloads,
   } = parseHashOptions(location.hash) as DashboardUrlHashOptions;
 
   return {
@@ -21,5 +22,6 @@ export const useEmbedFrameOptions = ({ location }: { location: Location }) => {
     theme,
     hide_parameters,
     hide_download_button,
+    downloads,
   };
 };

--- a/frontend/src/metabase/public/hooks/use-embed-frame-options.ts
+++ b/frontend/src/metabase/public/hooks/use-embed-frame-options.ts
@@ -3,6 +3,7 @@ import type { Location } from "history";
 import type { DashboardUrlHashOptions } from "metabase/dashboard/types";
 import { parseHashOptions } from "metabase/lib/browser";
 import { isWithinIframe } from "metabase/lib/dom";
+import { PLUGIN_RESOURCE_DOWNLOADS } from "metabase/plugins";
 
 import { DEFAULT_EMBED_DISPLAY_PARAMS } from "../constants";
 
@@ -13,8 +14,13 @@ export const useEmbedFrameOptions = ({ location }: { location: Location }) => {
     theme = DEFAULT_EMBED_DISPLAY_PARAMS.theme,
     hide_parameters = DEFAULT_EMBED_DISPLAY_PARAMS.hideParameters,
     hide_download_button = null,
-    downloads = DEFAULT_EMBED_DISPLAY_PARAMS.downloads,
+    downloads = DEFAULT_EMBED_DISPLAY_PARAMS.downloadsEnabled,
   } = parseHashOptions(location.hash) as DashboardUrlHashOptions;
+
+  const downloadsEnabled = PLUGIN_RESOURCE_DOWNLOADS.areDownloadsEnabled({
+    hide_download_button,
+    downloads,
+  });
 
   return {
     bordered,
@@ -22,6 +28,6 @@ export const useEmbedFrameOptions = ({ location }: { location: Location }) => {
     theme,
     hide_parameters,
     hide_download_button,
-    downloads,
+    downloadsEnabled,
   };
 };

--- a/frontend/src/metabase/public/lib/analytics.ts
+++ b/frontend/src/metabase/public/lib/analytics.ts
@@ -17,6 +17,8 @@ type Appearance = {
   theme: DisplayTheme;
   font: "instance" | "custom";
   hide_download_button: boolean | null;
+  // TODO:
+  // downloads: boolean | null;
 };
 
 export const trackStaticEmbedDiscarded = ({
@@ -112,7 +114,7 @@ function normalizeAppearance(
     bordered: displayOptions.bordered,
     theme: displayOptions.theme ?? "light",
     font: displayOptions.font ? "custom" : "instance",
-    hide_download_button: displayOptions.hide_download_button,
+    hide_download_button: displayOptions.hide_download_button ?? null,
   };
 }
 

--- a/frontend/src/metabase/public/lib/analytics.ts
+++ b/frontend/src/metabase/public/lib/analytics.ts
@@ -114,6 +114,7 @@ function normalizeAppearance(
     bordered: displayOptions.bordered,
     theme: displayOptions.theme ?? "light",
     font: displayOptions.font ? "custom" : "instance",
+    // TODO: replace with `downloads` when it's implemented
     hide_download_button: displayOptions.hide_download_button ?? null,
   };
 }

--- a/frontend/src/metabase/public/lib/types.ts
+++ b/frontend/src/metabase/public/lib/types.ts
@@ -30,7 +30,8 @@ export type EmbeddingDisplayOptions = {
   theme: DisplayTheme;
   bordered: boolean;
   titled: boolean;
-  hide_download_button: boolean | null;
+  /** this is deprecated in favor of `downloads`, but it's still supported */
+  hide_download_button?: boolean | null;
   downloads: boolean | null;
 };
 


### PR DESCRIPTION
closes https://github.com/metabase/metabase/issues/44285, part of https://github.com/metabase/metabase/issues/42628

This adds support for the URL parameter downloads and passes it down to the components that needs it


What should work on this pr:
- export tab to pdf in both public and static embed dashboards
- download results on dashcards on both public and static embed dashboards
- downloads results on public and static embed questions
- on all the above, only in EE/PRO `#downloads=false` should remove that functionality