### PR TITLE
ci: Move cloverage to run nightly

### DIFF
--- a/.github/workflows/backend-cloverage.yml
+++ b/.github/workflows/backend-cloverage.yml
@@ -25,6 +25,3 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./target/coverage/codecov.json
           flags: back-end
-
-
-

--- a/.github/workflows/backend-cloverage.yml
+++ b/.github/workflows/backend-cloverage.yml
@@ -1,0 +1,30 @@
+name: Backend-Cloverage
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 10 * * 1-5' # every weekday at 5am US eastern time
+
+jobs:
+  be-linter-cloverage:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare back-end environment
+        uses: ./.github/actions/prepare-backend
+        with:
+          m2-cache-key: "cloverage"
+      - name: Build static viz frontend
+        run: yarn build-static-viz
+      - name: Collect the test coverage
+        run: clojure -X:dev:ci:ee:ee-dev:test:cloverage
+      - name: Upload coverage to codecov.io
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./target/coverage/codecov.json
+          flags: back-end
+
+
+

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -63,29 +63,6 @@ jobs:
           token: ${{ github.token }}
           filters: .github/static-viz-sources.yaml
 
-  be-linter-cloverage:
-    needs: files-changed
-    if: (github.ref_name == 'master' && needs.files-changed.outputs.backend_all == 'true')
-        || contains(github.event.pull_request.labels.*.name, 'run-cloverage')
-    runs-on: ubuntu-22.04
-    timeout-minutes: 90
-    steps:
-      - uses: actions/checkout@v4
-      - name: Prepare back-end environment
-        uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: "cloverage"
-      - name: Build static viz frontend
-        run: yarn build-static-viz
-      - name: Collect the test coverage
-        run: clojure -X:dev:ci:ee:ee-dev:test:cloverage
-      - name: Upload coverage to codecov.io
-        uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./target/coverage/codecov.json
-          flags: back-end
-
   be-linter-clj-kondo:
     needs: [files-changed, static-viz-files-changed]
     if: |

--- a/.github/workflows/rerun-workflows.yml
+++ b/.github/workflows/rerun-workflows.yml
@@ -2,7 +2,7 @@ name: Re-run Flaky Workflows
 
 on:
   workflow_run:
-    workflows: [Backend, Driver Tests, E2E Tests, Frontend]
+    workflows: [Backend, Driver Tests, E2E Tests, Frontend, Backend-Cloverage]
     types: [completed]
     branches: [master, 'release-x.**', 'backport-**']
 


### PR DESCRIPTION

Closes https://github.com/metabase/metabase/issues/44364

### Description

Removes Cloverage from the main backend CI suite and moves it to its own nightly workflow (on weekdays)
