### PR TITLE
Disable parameter mapping with native models

### DIFF
--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -2,39 +2,39 @@ import moment from "moment-timezone"; // eslint-disable-line no-restricted-impor
 
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
+  ADMIN_PERSONAL_COLLECTION_ID,
   ORDERS_DASHBOARD_DASHCARD_ID,
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
-  ADMIN_PERSONAL_COLLECTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
 import {
-  restore,
-  popover,
-  updateDashboardCards,
-  visitDashboard,
-  filterWidget,
+  addOrUpdateDashboardCard,
+  appBar,
+  assertQueryBuilderRowCount,
+  commandPalette,
+  commandPaletteSearch,
+  createNativeQuestion,
+  createQuestion,
+  dashboardParametersContainer,
   editDashboard,
-  setFilter,
+  filterWidget,
+  getDashboardCard,
+  goToTab,
+  multiAutocompleteInput,
+  navigationSidebar,
+  openNavigationSidebar,
+  openQuestionsSidebar,
+  popover,
+  restore,
   saveDashboard,
   selectDashboardFilter,
+  setFilter,
   sidebar,
-  commandPaletteSearch,
-  commandPalette,
-  addOrUpdateDashboardCard,
   undoToast,
-  getDashboardCard,
-  openNavigationSidebar,
-  appBar,
-  dashboardParametersContainer,
-  navigationSidebar,
-  visitPublicDashboard,
-  goToTab,
-  openQuestionsSidebar,
+  updateDashboardCards,
+  visitDashboard,
   visitEmbeddedPage,
-  createQuestion,
-  multiAutocompleteInput,
-  assertQueryBuilderRowCount,
-  createNativeQuestion,
+  visitPublicDashboard,
 } from "e2e/support/helpers";
 import {
   createMockDashboardCard,
@@ -42,8 +42,8 @@ import {
 } from "metabase-types/api/mocks";
 
 import {
-  setQuarterAndYear,
   setAdHocFilter,
+  setQuarterAndYear,
 } from "../native-filters/helpers/e2e-date-filter-helpers";
 
 const {
@@ -2806,23 +2806,6 @@ describe("44288", () => {
     parameters: [parameterDetails],
   };
 
-  function getModelDashcardDetails(dashboard, card) {
-    return {
-      dashboard_id: dashboard.id,
-      card_id: card.id,
-      parameter_mappings: [
-        {
-          card_id: card.id,
-          parameter_id: parameterDetails.id,
-          target: [
-            "dimension",
-            ["field", "TOTAL", { "base-type": "type/Integer" }],
-          ],
-        },
-      ],
-    };
-  }
-
   beforeEach(() => {
     restore();
     cy.signInAsNormalUser();
@@ -2833,7 +2816,12 @@ describe("44288", () => {
       cy.createDashboard(dashboardDetails).then(({ body: dashboard }) => {
         updateDashboardCards({
           dashboard_id: dashboard.id,
-          cards: [getModelDashcardDetails(dashboard, card)],
+          cards: [
+            {
+              dashboard_id: dashboard.id,
+              card_id: card.id,
+            },
+          ],
         });
         visitDashboard(dashboard.id);
       });

--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -2828,7 +2828,7 @@ describe("44288", () => {
     cy.signInAsNormalUser();
   });
 
-  it("should be able to remove a broken mapping to a native model on a dashboard (metabase#44288)", () => {
+  it("should not be able to map a parameter to a native model on a dashboard (metabase#44288)", () => {
     createNativeQuestion(modelDetails).then(({ body: card }) => {
       cy.createDashboard(dashboardDetails).then(({ body: dashboard }) => {
         updateDashboardCards({
@@ -2844,23 +2844,8 @@ describe("44288", () => {
       .findByText(parameterDetails.name)
       .click();
     getDashboardCard().within(() => {
-      cy.button(/Unknown Field/)
-        .icon("close")
-        .click();
       cy.findByText(/Models are data sources/).should("be.visible");
       cy.findByText("Select…").should("not.exist");
-      cy.button(/Unknown Field/).should("not.exist");
-    });
-    saveDashboard();
-
-    editDashboard();
-    cy.findByTestId("edit-dashboard-parameters-widget-container")
-      .findByText(parameterDetails.name)
-      .click();
-    getDashboardCard().within(() => {
-      cy.findByText(/Models are data sources/).should("be.visible");
-      cy.findByText("Select…").should("not.exist");
-      cy.button(/Unknown Field/).should("not.exist");
     });
   });
 });

--- a/e2e/test/scenarios/models/reproductions.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.js
@@ -692,17 +692,15 @@ describe("issue 23024", () => {
     addModelToDashboardAndVisit();
   });
 
-  it("should be possible to apply the dashboard filter to the native model (metabase#23024)", () => {
+  it("should not be possible to apply the dashboard filter to the native model (metabase#23024)", () => {
     editDashboard();
 
     setFilter("Text or Category", "Is");
 
     getDashboardCard().within(() => {
-      cy.findByText("Column to filter on");
-      cy.findByText("Select…").click();
+      cy.findByText(/Models are data sources/).should("be.visible");
+      cy.findByText("Select…").should("not.exist");
     });
-
-    popover().contains("Category");
   });
 });
 

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.tsx
@@ -307,8 +307,11 @@ export function DashCardCardParameterMapper({
             />
           </TextCardDefault>
         )
-      ) : isNative && isDisabled && editingParameter ? (
-        <DisabledNativeCardHelpText parameter={editingParameter} />
+      ) : isNative && isDisabled && question && editingParameter ? (
+        <DisabledNativeCardHelpText
+          question={question}
+          parameter={editingParameter}
+        />
       ) : (
         <>
           {headerContent && (

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.tsx
@@ -206,6 +206,13 @@ export function DashCardCardParameterMapper({
           buttonText: null,
           buttonIcon: <KeyIcon name="key" />,
         };
+      } else if (isDisabled && !isVirtual) {
+        return {
+          buttonVariant: "disabled",
+          buttonTooltip: t`This card doesn't have any fields or parameters that can be mapped to this parameter type.`,
+          buttonText: t`No valid fields`,
+          buttonIcon: null,
+        };
       } else if (selectedMappingOption) {
         return {
           buttonVariant: "mapped",
@@ -234,13 +241,6 @@ export function DashCardCardParameterMapper({
               }}
             />
           ),
-        };
-      } else if (isDisabled && !isVirtual) {
-        return {
-          buttonVariant: "disabled",
-          buttonTooltip: t`This card doesn't have any fields or parameters that can be mapped to this parameter type.`,
-          buttonText: t`No valid fields`,
-          buttonIcon: null,
         };
       } else {
         return {
@@ -307,11 +307,7 @@ export function DashCardCardParameterMapper({
             />
           </TextCardDefault>
         )
-      ) : isNative &&
-        isDisabled &&
-        question &&
-        target == null &&
-        editingParameter ? (
+      ) : isNative && isDisabled && question && editingParameter ? (
         <DisabledNativeCardHelpText
           question={question}
           parameter={editingParameter}

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.tsx
@@ -206,13 +206,6 @@ export function DashCardCardParameterMapper({
           buttonText: null,
           buttonIcon: <KeyIcon name="key" />,
         };
-      } else if (isDisabled && !isVirtual) {
-        return {
-          buttonVariant: "disabled",
-          buttonTooltip: t`This card doesn't have any fields or parameters that can be mapped to this parameter type.`,
-          buttonText: t`No valid fields`,
-          buttonIcon: null,
-        };
       } else if (selectedMappingOption) {
         return {
           buttonVariant: "mapped",
@@ -241,6 +234,13 @@ export function DashCardCardParameterMapper({
               }}
             />
           ),
+        };
+      } else if (isDisabled && !isVirtual) {
+        return {
+          buttonVariant: "disabled",
+          buttonTooltip: t`This card doesn't have any fields or parameters that can be mapped to this parameter type.`,
+          buttonText: t`No valid fields`,
+          buttonIcon: null,
         };
       } else {
         return {
@@ -307,7 +307,11 @@ export function DashCardCardParameterMapper({
             />
           </TextCardDefault>
         )
-      ) : isNative && isDisabled && question && editingParameter ? (
+      ) : isNative &&
+        isDisabled &&
+        question &&
+        target == null &&
+        editingParameter ? (
         <DisabledNativeCardHelpText
           question={question}
           parameter={editingParameter}

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.unit.spec.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.unit.spec.jsx
@@ -182,6 +182,27 @@ describe("DashCardParameterMapper", () => {
     expect(screen.getByText(/unknown field/i)).toBeInTheDocument();
   });
 
+  it("should render an error state when there is a target but the list of options is empty", () => {
+    const card = createMockCard({
+      type: "model",
+      dataset_query: createMockNativeDatasetQuery({
+        native: {
+          query: "SELECT * FROM ORDERS",
+        },
+      }),
+      display: "table",
+    });
+    setup({
+      card,
+      dashcard: createMockDashboardCard({
+        card,
+      }),
+      mappingOptions: [],
+      target: ["dimension", ["field", 2, null]],
+    });
+    expect(screen.getByText(/unknown field/i)).toBeInTheDocument();
+  });
+
   it("should show header content when card is more than 2 units high", () => {
     const numberCard = createMockCard({
       dataset_query: createMockStructuredDatasetQuery({}),

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.unit.spec.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.unit.spec.jsx
@@ -182,7 +182,7 @@ describe("DashCardParameterMapper", () => {
     expect(screen.getByText(/unknown field/i)).toBeInTheDocument();
   });
 
-  it("should render an error state when mapping to a native model and there is no target", () => {
+  it("should render an error state when mapping to a native model", () => {
     const card = createMockCard({
       type: "model",
       dataset_query: createMockNativeDatasetQuery({
@@ -199,28 +199,7 @@ describe("DashCardParameterMapper", () => {
       }),
       mappingOptions: [],
     });
-    expect(screen.queryByText(/unknown field/i)).not.toBeInTheDocument();
-  });
-
-  it("should render an error state when there is a target for a native model and allow to remove the target", () => {
-    const card = createMockCard({
-      type: "model",
-      dataset_query: createMockNativeDatasetQuery({
-        native: {
-          query: "SELECT * FROM ORDERS",
-        },
-      }),
-      display: "table",
-    });
-    setup({
-      card,
-      dashcard: createMockDashboardCard({
-        card,
-      }),
-      mappingOptions: [],
-      target: ["dimension", ["field", 2, null]],
-    });
-    expect(screen.getByText(/unknown field/i)).toBeInTheDocument();
+    expect(screen.getByText(/Models are data sources/)).toBeInTheDocument();
   });
 
   it("should show header content when card is more than 2 units high", () => {

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.unit.spec.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.unit.spec.jsx
@@ -182,7 +182,27 @@ describe("DashCardParameterMapper", () => {
     expect(screen.getByText(/unknown field/i)).toBeInTheDocument();
   });
 
-  it("should render an error state when there is a target but the list of options is empty", () => {
+  it("should render an error state when mapping to a native model and there is no target", () => {
+    const card = createMockCard({
+      type: "model",
+      dataset_query: createMockNativeDatasetQuery({
+        native: {
+          query: "SELECT * FROM ORDERS",
+        },
+      }),
+      display: "table",
+    });
+    setup({
+      card,
+      dashcard: createMockDashboardCard({
+        card,
+      }),
+      mappingOptions: [],
+    });
+    expect(screen.queryByText(/unknown field/i)).not.toBeInTheDocument();
+  });
+
+  it("should render an error state when there is a target for a native model and allow to remove the target", () => {
     const card = createMockCard({
       type: "model",
       dataset_query: createMockNativeDatasetQuery({

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DisabledNativeCardHelpText/DisabledNativeCardHelpText.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DisabledNativeCardHelpText/DisabledNativeCardHelpText.tsx
@@ -2,8 +2,9 @@ import { t } from "ttag";
 
 import { getNativeDashCardEmptyMappingText } from "metabase/dashboard/utils";
 import { useSelector } from "metabase/lib/redux";
-import MetabaseSettings from "metabase/lib/settings";
+import { getDocsUrl, getLearnUrl } from "metabase/selectors/settings";
 import { getShowMetabaseLinks } from "metabase/selectors/whitelabel";
+import type Question from "metabase-lib/v1/Question";
 import type { Parameter } from "metabase-types/api";
 
 import {
@@ -14,13 +15,47 @@ import {
 } from "./DisabledNativeCardHelpText.styled";
 
 interface DisabledNativeCardHelpTextProps {
+  question: Question;
   parameter: Parameter;
 }
 
 export function DisabledNativeCardHelpText({
+  question,
   parameter,
 }: DisabledNativeCardHelpTextProps) {
+  if (question.type() === "model") {
+    return <ModelHelpText />;
+  } else {
+    return <ParameterHelpText parameter={parameter} />;
+  }
+}
+
+function ModelHelpText() {
   const showMetabaseLinks = useSelector(getShowMetabaseLinks);
+  const learnUrl = getLearnUrl("data-modeling/models#skip-the-sql-variables");
+
+  return (
+    <NativeCardDefault>
+      <NativeCardIcon name="info" />
+      <NativeCardText>
+        {t`Models are data sources and thus can’t have parameters mapped.`}
+      </NativeCardText>
+      {showMetabaseLinks && (
+        <NativeCardLink href={learnUrl}>{t`Learn more`}</NativeCardLink>
+      )}
+    </NativeCardDefault>
+  );
+}
+
+interface ParameterHelpTextProps {
+  parameter: Parameter;
+}
+
+function ParameterHelpText({ parameter }: ParameterHelpTextProps) {
+  const showMetabaseLinks = useSelector(getShowMetabaseLinks);
+  const docsUrl = useSelector(state =>
+    getDocsUrl(state, { page: "questions/native-editor/sql-parameters" }),
+  );
 
   return (
     <NativeCardDefault>
@@ -29,11 +64,7 @@ export function DisabledNativeCardHelpText({
         {getNativeDashCardEmptyMappingText(parameter)}
       </NativeCardText>
       {showMetabaseLinks && (
-        <NativeCardLink
-          href={MetabaseSettings.docsUrl(
-            "questions/native-editor/sql-parameters",
-          )}
-        >{t`Learn how`}</NativeCardLink>
+        <NativeCardLink href={docsUrl}>{t`Learn how`}</NativeCardLink>
       )}
     </NativeCardDefault>
   );

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DisabledNativeCardHelpText/DisabledNativeCardHelpText.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DisabledNativeCardHelpText/DisabledNativeCardHelpText.tsx
@@ -1,10 +1,14 @@
 import { t } from "ttag";
 
-import { getNativeDashCardEmptyMappingText } from "metabase/dashboard/utils";
 import { useSelector } from "metabase/lib/redux";
 import { getDocsUrl, getLearnUrl } from "metabase/selectors/settings";
 import { getShowMetabaseLinks } from "metabase/selectors/whitelabel";
 import type Question from "metabase-lib/v1/Question";
+import {
+  isDateParameter,
+  isNumberParameter,
+  isStringParameter,
+} from "metabase-lib/v1/parameters/utils/parameter-type";
 import type { Parameter } from "metabase-types/api";
 
 import {
@@ -60,12 +64,26 @@ function ParameterHelpText({ parameter }: ParameterHelpTextProps) {
   return (
     <NativeCardDefault>
       <NativeCardIcon name="info" />
-      <NativeCardText>
-        {getNativeDashCardEmptyMappingText(parameter)}
-      </NativeCardText>
+      <NativeCardText>{getParameterHelpText(parameter)}</NativeCardText>
       {showMetabaseLinks && (
         <NativeCardLink href={docsUrl}>{t`Learn how`}</NativeCardLink>
       )}
     </NativeCardDefault>
   );
+}
+
+export function getParameterHelpText(parameter: Parameter) {
+  if (isDateParameter(parameter)) {
+    return t`A date variable in this card can only be connected to a time type with the single date option.`;
+  }
+
+  if (isNumberParameter(parameter)) {
+    return t`A number variable in this card can only be connected to a number filter with Equal to operator.`;
+  }
+
+  if (isStringParameter(parameter)) {
+    return t`A text variable in this card can only be connected to a text filter with Is operator.`;
+  }
+
+  return t`Add a variable to this question to connect it to a dashboard filter.`;
 }

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DisabledNativeCardHelpText/tests/common.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DisabledNativeCardHelpText/tests/common.unit.spec.ts
@@ -1,27 +1,65 @@
 import { screen } from "__support__/ui";
+import { createMockParameter } from "metabase-types/api/mocks";
 
 import { setup } from "./setup";
 
 describe("DashCardParameterMapper > DisabledNativeCardHelpText (OSS)", () => {
-  it("should show a help link when `show-metabase-links: true`", () => {
-    setup({ showMetabaseLinks: true });
+  it("should show a help message for native models", () => {
+    setup({
+      cardType: "model",
+    });
 
+    expect(screen.getByText(/Models are data sources/)).toBeInTheDocument();
     expect(
-      screen.getByText(
-        "A text variable in this card can only be connected to a text filter with Is operator.",
-      ),
+      screen.getByRole("link", { name: "Learn more" }),
     ).toBeInTheDocument();
-    expect(screen.getByText("Learn how")).toBeInTheDocument();
   });
 
-  it("should show a help link when `show-metabase-links: false`", () => {
-    setup({ showMetabaseLinks: false });
+  it.each([
+    {
+      parameter: createMockParameter({ type: "id" }),
+      message: /variable/,
+    },
+    {
+      parameter: createMockParameter({ type: "string/=" }),
+      message: /text variable/,
+    },
+    {
+      parameter: createMockParameter({ type: "number/!=" }),
+      message: /number variable/,
+    },
+    {
+      parameter: createMockParameter({ type: "date/all-options" }),
+      message: /date variable/,
+    },
+  ])(
+    "should show a help message for $parameter.type",
+    ({ parameter, message }) => {
+      setup({ parameter });
+      expect(screen.getByText(message)).toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: "Learn how" }),
+      ).toBeInTheDocument();
+    },
+  );
 
-    expect(
-      screen.getByText(
-        "A text variable in this card can only be connected to a text filter with Is operator.",
-      ),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Learn how")).toBeInTheDocument();
-  });
+  it.each([{ showMetabaseLinks: false }, { showMetabaseLinks: true }])(
+    "should show a parameter help link when `show-metabase-links`: %s",
+    ({ showMetabaseLinks }) => {
+      setup({ showMetabaseLinks });
+      expect(
+        screen.getByRole("link", { name: "Learn how" }),
+      ).toBeInTheDocument();
+    },
+  );
+
+  it.each([{ showMetabaseLinks: false }, { showMetabaseLinks: true }])(
+    "should show a model help link when `show-metabase-links`: %s",
+    ({ showMetabaseLinks }) => {
+      setup({ cardType: "model", showMetabaseLinks });
+      expect(
+        screen.getByRole("link", { name: "Learn more" }),
+      ).toBeInTheDocument();
+    },
+  );
 });

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DisabledNativeCardHelpText/tests/common.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DisabledNativeCardHelpText/tests/common.unit.spec.ts
@@ -44,7 +44,7 @@ describe("DashCardParameterMapper > DisabledNativeCardHelpText (OSS)", () => {
   );
 
   it.each([{ showMetabaseLinks: false }, { showMetabaseLinks: true }])(
-    "should show a parameter help link when `show-metabase-links`: %s",
+    "should show a parameter help link and ignore the setting `show-metabase-links`: %s",
     ({ showMetabaseLinks }) => {
       setup({ showMetabaseLinks });
       expect(
@@ -54,7 +54,7 @@ describe("DashCardParameterMapper > DisabledNativeCardHelpText (OSS)", () => {
   );
 
   it.each([{ showMetabaseLinks: false }, { showMetabaseLinks: true }])(
-    "should show a model help link when `show-metabase-links`: %s",
+    "should show a model help link and ignore the setting `show-metabase-links`: %s",
     ({ showMetabaseLinks }) => {
       setup({ cardType: "model", showMetabaseLinks });
       expect(

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DisabledNativeCardHelpText/tests/enterprise.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DisabledNativeCardHelpText/tests/enterprise.unit.spec.ts
@@ -8,25 +8,23 @@ function setup(opts: SetupOpts) {
 }
 
 describe("DashCardParameterMapper > DisabledNativeCardHelpText (EE without token)", () => {
-  it("should show a help link when `show-metabase-links: true`", () => {
-    setup({ showMetabaseLinks: true });
+  it.each([{ showMetabaseLinks: false }, { showMetabaseLinks: true }])(
+    "should show a parameter help link when showMetabaseLinks = %s",
+    ({ showMetabaseLinks }) => {
+      setup({ showMetabaseLinks });
+      expect(
+        screen.getByRole("link", { name: "Learn how" }),
+      ).toBeInTheDocument();
+    },
+  );
 
-    expect(
-      screen.getByText(
-        "A text variable in this card can only be connected to a text filter with Is operator.",
-      ),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Learn how")).toBeInTheDocument();
-  });
-
-  it("should show a help link when `show-metabase-links: false`", () => {
-    setup({ showMetabaseLinks: false });
-
-    expect(
-      screen.getByText(
-        "A text variable in this card can only be connected to a text filter with Is operator.",
-      ),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Learn how")).toBeInTheDocument();
-  });
+  it.each([{ showMetabaseLinks: false }, { showMetabaseLinks: true }])(
+    "should show a model help link when `show-metabase-links`: %s",
+    ({ showMetabaseLinks }) => {
+      setup({ cardType: "model", showMetabaseLinks });
+      expect(
+        screen.getByRole("link", { name: "Learn more" }),
+      ).toBeInTheDocument();
+    },
+  );
 });

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DisabledNativeCardHelpText/tests/enterprise.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DisabledNativeCardHelpText/tests/enterprise.unit.spec.ts
@@ -9,7 +9,7 @@ function setup(opts: SetupOpts) {
 
 describe("DashCardParameterMapper > DisabledNativeCardHelpText (EE without token)", () => {
   it.each([{ showMetabaseLinks: false }, { showMetabaseLinks: true }])(
-    "should show a parameter help link when showMetabaseLinks = %s",
+    "should show a parameter help link and ignore the setting showMetabaseLinks = %s",
     ({ showMetabaseLinks }) => {
       setup({ showMetabaseLinks });
       expect(
@@ -19,7 +19,7 @@ describe("DashCardParameterMapper > DisabledNativeCardHelpText (EE without token
   );
 
   it.each([{ showMetabaseLinks: false }, { showMetabaseLinks: true }])(
-    "should show a model help link when `show-metabase-links`: %s",
+    "should show a model help link and ignore the setting `show-metabase-links`: %s",
     ({ showMetabaseLinks }) => {
       setup({ cardType: "model", showMetabaseLinks });
       expect(

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DisabledNativeCardHelpText/tests/premium.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DisabledNativeCardHelpText/tests/premium.unit.spec.ts
@@ -12,7 +12,7 @@ function setup(opts: SetupOpts) {
 }
 
 describe("DashCardParameterMapper > DisabledNativeCardHelpText (EE with token)", () => {
-  it("should show a help link when `show-metabase-links: true`", () => {
+  it("should show a parameter help link when `show-metabase-links: true`", () => {
     setup({ showMetabaseLinks: true });
 
     expect(
@@ -23,7 +23,7 @@ describe("DashCardParameterMapper > DisabledNativeCardHelpText (EE with token)",
     expect(screen.getByText("Learn how")).toBeInTheDocument();
   });
 
-  it("should not show a help link when `show-metabase-links: false`", () => {
+  it("should not show a parameter help link when `show-metabase-links: false`", () => {
     setup({ showMetabaseLinks: false });
 
     expect(
@@ -32,5 +32,19 @@ describe("DashCardParameterMapper > DisabledNativeCardHelpText (EE with token)",
       ),
     ).toBeInTheDocument();
     expect(screen.queryByText("Learn how")).not.toBeInTheDocument();
+  });
+
+  it("should show a model help link when `show-metabase-links: true`", () => {
+    setup({ cardType: "model", showMetabaseLinks: true });
+
+    expect(screen.getByText(/Models are data sources/)).toBeInTheDocument();
+    expect(screen.getByText("Learn more")).toBeInTheDocument();
+  });
+
+  it("should not show a model help link when `show-metabase-links: false`", () => {
+    setup({ cardType: "model", showMetabaseLinks: false });
+
+    expect(screen.getByText(/Models are data sources/)).toBeInTheDocument();
+    expect(screen.queryByText("Learn more")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DisabledNativeCardHelpText/tests/setup.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DisabledNativeCardHelpText/tests/setup.tsx
@@ -1,8 +1,11 @@
 import { setupEnterprisePlugins } from "__support__/enterprise";
 import { mockSettings } from "__support__/settings";
 import { renderWithProviders } from "__support__/ui";
-import type { TokenFeatures } from "metabase-types/api";
+import { SAMPLE_METADATA } from "metabase-lib/test-helpers";
+import Question from "metabase-lib/v1/Question";
+import type { Parameter, TokenFeatures } from "metabase-types/api";
 import {
+  createMockCard,
   createMockParameter,
   createMockTokenFeatures,
 } from "metabase-types/api/mocks";
@@ -11,12 +14,16 @@ import { createMockState } from "metabase-types/store/mocks";
 import { DisabledNativeCardHelpText } from "../DisabledNativeCardHelpText";
 
 export interface SetupOpts {
+  question?: Question;
+  parameter?: Parameter;
   showMetabaseLinks?: boolean;
   hasEnterprisePlugins?: boolean;
   tokenFeatures?: Partial<TokenFeatures>;
 }
 
 export const setup = ({
+  question = new Question(createMockCard(), SAMPLE_METADATA),
+  parameter = createMockParameter(),
   showMetabaseLinks = true,
   hasEnterprisePlugins,
   tokenFeatures = {},
@@ -33,7 +40,7 @@ export const setup = ({
   }
 
   renderWithProviders(
-    <DisabledNativeCardHelpText parameter={createMockParameter()} />,
+    <DisabledNativeCardHelpText question={question} parameter={parameter} />,
     { storeInitialState: state },
   );
 };

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DisabledNativeCardHelpText/tests/setup.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DisabledNativeCardHelpText/tests/setup.tsx
@@ -3,7 +3,7 @@ import { mockSettings } from "__support__/settings";
 import { renderWithProviders } from "__support__/ui";
 import { SAMPLE_METADATA } from "metabase-lib/test-helpers";
 import Question from "metabase-lib/v1/Question";
-import type { Parameter, TokenFeatures } from "metabase-types/api";
+import type { CardType, Parameter, TokenFeatures } from "metabase-types/api";
 import {
   createMockCard,
   createMockParameter,
@@ -14,16 +14,17 @@ import { createMockState } from "metabase-types/store/mocks";
 import { DisabledNativeCardHelpText } from "../DisabledNativeCardHelpText";
 
 export interface SetupOpts {
-  question?: Question;
   parameter?: Parameter;
+  cardType?: CardType;
+  isModel?: boolean;
   showMetabaseLinks?: boolean;
   hasEnterprisePlugins?: boolean;
   tokenFeatures?: Partial<TokenFeatures>;
 }
 
 export const setup = ({
-  question = new Question(createMockCard(), SAMPLE_METADATA),
   parameter = createMockParameter(),
+  cardType = "question",
   showMetabaseLinks = true,
   hasEnterprisePlugins,
   tokenFeatures = {},
@@ -34,6 +35,10 @@ export const setup = ({
       "token-features": createMockTokenFeatures(tokenFeatures),
     }),
   });
+  const question = new Question(
+    createMockCard({ type: cardType }),
+    SAMPLE_METADATA,
+  );
 
   if (hasEnterprisePlugins) {
     setupEnterprisePlugins();

--- a/frontend/src/metabase/dashboard/utils.ts
+++ b/frontend/src/metabase/dashboard/utils.ts
@@ -1,4 +1,3 @@
-import { t } from "ttag";
 import _ from "underscore";
 
 import { IS_EMBED_PREVIEW } from "metabase/lib/embed";
@@ -9,11 +8,6 @@ import {
   getGenericErrorMessage,
   getPermissionErrorMessage,
 } from "metabase/visualizations/lib/errors";
-import {
-  isDateParameter,
-  isNumberParameter,
-  isStringParameter,
-} from "metabase-lib/v1/parameters/utils/parameter-type";
 import type {
   ActionDashboardCard,
   BaseDashboardCard,
@@ -27,7 +21,6 @@ import type {
   Database,
   Dataset,
   EmbedDataset,
-  Parameter,
   QuestionDashboardCard,
   VirtualCard,
   VirtualCardDisplay,
@@ -136,22 +129,6 @@ export function showVirtualDashCardInfoText(
   } else {
     return true;
   }
-}
-
-export function getNativeDashCardEmptyMappingText(parameter: Parameter) {
-  if (isDateParameter(parameter)) {
-    return t`A date variable in this card can only be connected to a time type with the single date option.`;
-  }
-
-  if (isNumberParameter(parameter)) {
-    return t`A number variable in this card can only be connected to a number filter with Equal to operator.`;
-  }
-
-  if (isStringParameter(parameter)) {
-    return t`A text variable in this card can only be connected to a text filter with Is operator.`;
-  }
-
-  return t`Add a variable to this question to connect it to a dashboard filter.`;
 }
 
 export function getAllDashboardCards(dashboard: Dashboard) {

--- a/frontend/src/metabase/parameters/utils/mapping-options.ts
+++ b/frontend/src/metabase/parameters/utils/mapping-options.ts
@@ -153,8 +153,7 @@ export function getParameterMappingOptions(
   }
 
   const { isNative } = Lib.queryDisplayInfo(question.query());
-  const isQuestion = question.type() === "question";
-  if (!isNative || !isQuestion) {
+  if (!isNative) {
     const { query, stageIndex, columns } = getParameterColumns(
       question,
       parameter ?? undefined,


### PR DESCRIPTION
closes https://github.com/metabase/metabase/issues/44288
Demo https://www.loom.com/share/2718b1e2389046858343fa88a12a3b7c

Changes:
- Disallows parameter mapping to native models

How to verify:
- add a SQL (`SELECT * FROM ORDERS`) model to a dashboard and try to map it to a numeric parameter
- you should see a new error message

<img width="342" alt="Screenshot 2024-06-18 at 15 06 41" src="https://github.com/metabase/metabase/assets/8542534/9caa2171-6e54-4717-aaa8-f87e19bfd37a">
