### PR TITLE
fix: Do not pass template variables to findColumnIndexesFromLegacyRefs

### DIFF
--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -2908,3 +2908,63 @@ describe("44047", () => {
     verifyFilterWithRemapping();
   });
 });
+
+describe("44266", () => {
+  const filterDetails = {
+    name: "Equal to",
+    slug: "equal_to",
+    id: "10c0d4ba",
+    type: "number/=",
+    sectionId: "number",
+  };
+
+  const dashboardDetails = {
+    name: "44266",
+    parameters: [filterDetails],
+  };
+
+  const regularQuestion = {
+    name: "regular",
+    query: { "source-table": PRODUCTS_ID, limit: 2 },
+  };
+
+  const nativeQuestion = {
+    name: "native",
+    native: {
+      query:
+        "SELECT * from products where true [[ and price > {{price}}]] limit 5;",
+      "template-tags": {
+        price: {
+          type: "number",
+          name: "price",
+          id: "b22a5ce2-fe1d-44e3-8df4-f8951f7921bc",
+          "display-name": "Price",
+        },
+      },
+    },
+  };
+
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should allow mapping when native and regular questions can be mapped (metabase#44266)", () => {
+    cy.createDashboardWithQuestions({
+      dashboardDetails,
+      questions: [regularQuestion, nativeQuestion],
+    }).then(({ dashboard }) => {
+      visitDashboard(dashboard.id);
+      editDashboard();
+      cy.findByTestId("edit-dashboard-parameters-widget-container")
+        .findByText("Equal to")
+        .click();
+
+      getDashboardCard(1).findByText("Select…").click();
+
+      popover().findByText("Price").click();
+
+      getDashboardCard(1).findByText("Price").should("be.visible");
+    });
+  });
+});

--- a/frontend/src/metabase/dashboard/components/DashCard/utils.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/utils.ts
@@ -10,7 +10,10 @@ import {
 import type { ParameterMappingOption as ParameterMappingOption } from "metabase/parameters/utils/mapping-options";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
-import { getParameterColumns } from "metabase-lib/v1/parameters/utils/targets";
+import {
+  getParameterColumns,
+  isParameterVariableTarget,
+} from "metabase-lib/v1/parameters/utils/targets";
 import { normalize } from "metabase-lib/v1/queries/utils/normalize";
 import type {
   BaseDashboardCard,
@@ -54,10 +57,15 @@ export function getMappingOptionByTarget<T extends DashboardCard>(
     return;
   }
 
-  const isVirtual = isVirtualDashCard(dashcard);
   const isNative = isQuestionDashCard(dashcard)
     ? isNativeDashCard(dashcard)
     : false;
+
+  if (!isNative && isParameterVariableTarget(target)) {
+    return;
+  }
+
+  const isVirtual = isVirtualDashCard(dashcard);
   const normalizedTarget = normalize(target);
   const matchedMappingOptions = mappingOptions.filter(mappingOption =>
     _.isEqual(mappingOption.target, normalizedTarget),


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/44266

### Description

Having both native and regular questions on the same dashboard raised MLv2 question during mapping if the native question had a variable to map to the filter as we passed variable target to the mlv2 `findColumnIndexesFromLegacyRefs`

### How to verify

- create a dashboard with two questions: native and regular (e.g. from products), native should contain a variable with a type number
- add questions to the dashboard and try to map native question to the number filter
- make sure mapping doesn't raise an error in console

### Demo


https://github.com/metabase/metabase/assets/125459446/16735168-4a27-4ab1-adc9-4c5228d621c4

Failed e2e test
<img width="1838" alt="Screenshot 2024-06-19 at 00 23 38" src="https://github.com/metabase/metabase/assets/125459446/7080e777-c9f0-4738-920c-c9598424f8bb">


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] [stress run](https://github.com/metabase/metabase/actions/runs/9572581074/job/26392196620) ✅ 20/20
