### PR TITLE
Manage bookmark store updates differently

### DIFF
--- a/e2e/test/scenarios/collections/archive.cy.spec.js
+++ b/e2e/test/scenarios/collections/archive.cy.spec.js
@@ -2,8 +2,17 @@ import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   FIRST_COLLECTION_ID,
   READ_ONLY_PERSONAL_COLLECTION_ID,
+  ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import { archiveQuestion, restore } from "e2e/support/helpers";
+import {
+  archiveQuestion,
+  modal,
+  navigationSidebar,
+  openNavigationSidebar,
+  popover,
+  restore,
+  visitQuestion,
+} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PEOPLE_ID } = SAMPLE_DATABASE;
 
@@ -14,7 +23,7 @@ const getQuestionDetails = collectionId => ({
 });
 
 // being deleted in #42226
-describe.skip("scenarios > collections > archive", () => {
+describe("scenarios > collections > archive", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
@@ -218,6 +227,27 @@ describe.skip("scenarios > collections > archive", () => {
       cy.visit(`/question/${questionId}`);
       cy.findByText("This question has been archived");
     });
+  });
+
+  it("should restore bookmarked items without crashing", () => {
+    cy.request("POST", `/api/bookmark/card/${ORDERS_QUESTION_ID}`);
+    visitQuestion(ORDERS_QUESTION_ID);
+
+    cy.findByTestId("qb-header").icon("ellipsis").click();
+    popover().findByText("Archive").click();
+    modal().button("Archive").click();
+
+    openNavigationSidebar();
+    navigationSidebar().icon("ellipsis").click();
+    popover().findByText("View archive").click();
+
+    cy.findByTestId("archive-item-Orders")
+      .findByText("Orders")
+      .realHover()
+      .findByLabelText("unarchive icon")
+      .click();
+
+    navigationSidebar().button("Orders").should("exist");
   });
 });
 

--- a/frontend/src/metabase/archive/containers/ArchiveApp.styled.tsx
+++ b/frontend/src/metabase/archive/containers/ArchiveApp.styled.tsx
@@ -35,7 +35,7 @@ export const ArchiveBarContent = styled.div`
   // the same as the ProfileLinkContainer
   // in MainNavbar
   height: 48px;
-  padding: 8px 4rem 7px;
+  //padding: 8px 4rem 7px;
 `;
 
 export const ArchiveBarText = styled.div`

--- a/frontend/src/metabase/components/BulkActionBar/BulkActionBar.tsx
+++ b/frontend/src/metabase/components/BulkActionBar/BulkActionBar.tsx
@@ -42,7 +42,11 @@ export const BulkActionBar = ({
       timingFunction="ease"
     >
       {styles => (
-        <BulkActionsToast style={styles} isNavbarOpen={isNavbarOpen}>
+        <BulkActionsToast
+          style={styles}
+          isNavbarOpen={isNavbarOpen}
+          data-testid="bulk-action-bar"
+        >
           <ToastCard dark data-testid="toast-card">
             {message && <Text color="white">{message}</Text>}
             <Flex gap="sm" align="center">

--- a/frontend/src/metabase/entities/bookmarks.js
+++ b/frontend/src/metabase/entities/bookmarks.js
@@ -1,5 +1,5 @@
 import { createSelector } from "@reduxjs/toolkit";
-import { assoc, updateIn, dissoc } from "icepick";
+import { assoc, updateIn, dissoc, getIn } from "icepick";
 import _ from "underscore";
 
 import { bookmarkApi } from "metabase/api";
@@ -66,7 +66,9 @@ const Bookmarks = createEntity({
     if (type === Questions.actionTypes.UPDATE && payload?.object) {
       const { archived, type, id, name } = payload.object;
       const key = `card-${id}`;
-      if (archived) {
+      if (!getIn(state, [key])) {
+        return state;
+      } else if (archived) {
         return dissoc(state, key);
       } else {
         return updateIn(state, [key], item => ({
@@ -80,7 +82,9 @@ const Bookmarks = createEntity({
     if (type === Dashboards.actionTypes.UPDATE && payload?.object) {
       const { archived, id, name } = payload.object;
       const key = `dashboard-${id}`;
-      if (archived) {
+      if (!getIn(state, [key])) {
+        return state;
+      } else if (archived) {
         return dissoc(state, key);
       } else {
         return updateIn(state, [key], item => ({ ...item, name }));
@@ -88,10 +92,12 @@ const Bookmarks = createEntity({
     }
 
     if (type === Collections.actionTypes.UPDATE && payload?.object) {
-      const { id, authority_level, name } = payload.object;
+      const { id, authority_level, name, archived } = payload.object;
       const key = `collection-${id}`;
 
-      if (payload.object.archived) {
+      if (!getIn(state, [key])) {
+        return state;
+      } else if (archived) {
         return dissoc(state, key);
       } else {
         return updateIn(state, [key], item => ({


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/44224

### Description
This PR resolves the following:
- The crashing issue when restoring a bookmarked item
- ensures the bookmark list is updated after a restore
- adjusts the styling of the bulk actions bar in the archive app
- unskips the archive e2e test suite

### How to verify
In v50:
1. Go to a bookmarked question and archive it
2. Without refreshing the page, navigate to the archive app and restore the question
3. The question should be restored without the page crashing, as well as be present in the Nav sidebar.

### Checklist
- [x] Tests have been added/updated to cover changes in this PR
