### PR TITLE
ci(sdk): clarify SDK release workflow input description

### DIFF
--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -9,7 +9,7 @@ on:
         type: string
         required: true
       git_ref:
-        description: 'Valid git reference e.g. branches, tags, hashes'
+        description: 'A git commit hash that will be used to build the SDK'
         type: string
         required: true
 


### PR DESCRIPTION
This workflow was copied over from `uberjar.yml` workflow, and the description was tweaked for flexibility. However, at some point, we decided the best way to deploy is to use the exact commit to avoid any accidental release. If you use a branch name like `master` we could accidentally release a different commit since there's no guarantee that at the time you start the workflow, the `master` branch would stay on the same commit you've acknowlegdged before.

See this [Slack thread](https://metaboat.slack.com/archives/C063Q3F1HPF/p1718365926367029?thread_ts=1718356472.143249&cid=C063Q3F1HPF) for more details.
