### PR TITLE
Pass enterprise version to ee-extra build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -555,12 +555,15 @@ jobs:
         with:
           github-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
           script: | # js
+            const version = '${{ inputs.version }}';
+            const enterpriseVersion = version.replace(/^v0\./, "v1.");
+
             github.rest.repos.createDispatchEvent({
               owner: '${{ github.repository_owner }}',
               repo: 'metabase-ee-extra',
               event_type: 'update-ee-extra-build',
               client_payload: {
-                version: '${{ inputs.version }}'
+                version: enterpriseVersion,
               }
             });
 


### PR DESCRIPTION
Found a bug in [this run](https://github.com/metabase/metabase-ee-extra/actions/runs/9578386604/job/26408528068#step:4:6). We need to pull the EE jar, not the OSS jar for ee-extra builds. This updates the workflow to pass the enterprise version number.

