### PR TITLE
console.log as warning

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -62,7 +62,7 @@ module.exports = {
         warnOnUnassignedImports: false,
       },
     ],
-    "no-console": [2, { allow: ["warn", "error", "errorBuffer"] }],
+    "no-console": [1, { allow: ["warn", "error", "errorBuffer"] }],
     "react/no-is-mounted": 2,
     "react/prefer-es6-class": 2,
     "react/display-name": 1,


### PR DESCRIPTION
### Description

We currently have console.log flagged as error by eslint.
Vscode colors the filename of files with eslint errors in red, which is annoying because I want to differentiate between files I just added a console log for debug reasons and a file which has an actual typescript error

With this change console.logs are warning so we can tell at first glance between a file with an actual error and one with a warning.
<img width="590" alt="image" src="https://github.com/metabase/metabase/assets/1914270/69ed5237-52d8-47bb-baf5-83813535fd02">


