### PR TITLE
docs(sdk): Update readme pointing to the most recent v50 version

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/README.md
+++ b/enterprise/frontend/src/embedding-sdk/README.md
@@ -22,7 +22,7 @@ Features planned:
 
 - You have an application using React 17 or higher
 - You have a Pro or Enterprise [subscription or free trial](https://www.metabase.com/pricing/) of Metabase
-- You have a running Metabase instance using a compatible version of the enterprise binary. The v1.50.x are the only supported versions at this time. We do not recommend running this in production.
+- You have a running Metabase instance using a compatible version of the enterprise binary. v1.50.x are the only supported versions at this time. We do not recommend running this in production.
 
 # Getting started
 

--- a/enterprise/frontend/src/embedding-sdk/README.md
+++ b/enterprise/frontend/src/embedding-sdk/README.md
@@ -22,7 +22,7 @@ Features planned:
 
 - You have an application using React 17 or higher
 - You have a Pro or Enterprise [subscription or free trial](https://www.metabase.com/pricing/) of Metabase
-- You have a running Metabase instance using a compatible version of the enterprise binary. The v1.50.0 release candidate is the only supported version at this time. We do not recommend running this in production.
+- You have a running Metabase instance using a compatible version of the enterprise binary. The v1.50.x are the only supported versions at this time. We do not recommend running this in production.
 
 # Getting started
 
@@ -39,12 +39,12 @@ You have the following options:
 Start the Metabase container:
 
 ```bash
-docker run -d -p 3000:3000 --name metabase metabase/metabase-enterprise:v1.50.0-RC2
+docker run -d -p 3000:3000 --name metabase metabase/metabase-enterprise:v1.50.6
 ```
 
 ### 2. Running the Jar file
 
-1. Download the Jar file from https://downloads.metabase.com/enterprise/v1.50.0-RC2/metabase.jar
+1. Download the Jar file from https://downloads.metabase.com/enterprise/v1.50.6/metabase.jar
 2. Create a new directory and move the Metabase JAR into it.
 3. Change into your new Metabase directory and run the JAR.
 
@@ -453,7 +453,7 @@ const theme = {
         backgroundColor: "#95A5A6",
       },
     },
-    
+
     collectionBrowser: {
        breadcrumbs: {
          expandButton: {


### PR DESCRIPTION
We want to update the readme and deploy this to NPM so users can use the latest version of Metabase instead of v50 RC2.
