### PR TITLE
Update e2e test for field values remapping to catch a more advanced case

### DIFF
--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -2673,14 +2673,16 @@ describe.skip("issue 44288", () => {
   });
 });
 
-describe("issue 44231", () => {
-  const productQuestionDetails = {
+describe.skip("issue 44231", () => {
+  const pkModelDetails = {
     name: "Products",
+    type: "model",
     query: { "source-table": PRODUCTS_ID },
   };
 
-  const orderQuestionDetails = {
+  const fkQuestionDetails = {
     name: "Orders",
+    type: "question",
     query: { "source-table": ORDERS_ID },
   };
 
@@ -2731,26 +2733,29 @@ describe("issue 44231", () => {
 
     cy.createDashboardWithQuestions({
       dashboardDetails,
-      questions: [productQuestionDetails, orderQuestionDetails],
-    }).then(({ dashboard, questions: [card1, card2] }) => {
+      questions: [pkModelDetails, fkQuestionDetails],
+    }).then(({ dashboard, questions: [pkCard, fkCard] }) => {
       updateDashboardCards({
         dashboard_id: dashboard.id,
         cards: [
           {
-            card_id: card1.id,
+            card_id: pkCard.id,
             parameter_mappings: [
               {
-                card_id: card1.id,
+                card_id: pkCard.id,
                 parameter_id: parameterDetails.id,
-                target: ["dimension", ["field", PRODUCTS.ID, null]],
+                target: [
+                  "dimension",
+                  ["field", "ID", { "base-type": "type/BigInteger" }],
+                ],
               },
             ],
           },
           {
-            card_id: card2.id,
+            card_id: fkCard.id,
             parameter_mappings: [
               {
-                card_id: card2.id,
+                card_id: fkCard.id,
                 parameter_id: parameterDetails.id,
                 target: ["dimension", ["field", ORDERS.PRODUCT_ID, null]],
               },


### PR DESCRIPTION
Issue https://github.com/metabase/metabase/issues/44231
Comment https://github.com/metabase/metabase/issues/44231#issuecomment-2178682975

Use a models for both PK + FK columns. This breaks the BE:
1. The BE no longer hydrates `param_fields` and `param_values` as it fails to find the corresponding DB field
2. The BE fails to find the find when doing a call for parameter values