### PR TITLE
Fix crash on restoring bookmarked items, update bookmarks on restore

### DIFF
--- a/e2e/support/commands/api/dashboard.js
+++ b/e2e/support/commands/api/dashboard.js
@@ -14,8 +14,9 @@ Cypress.Commands.add(
     cy.log(`Create a dashboard: ${name}`);
 
     // For all the possible keys, refer to `src/metabase/api/dashboard.clj`
-    cy.request("POST", "/api/dashboard", { name, ...dashboardDetails }).then(
-      ({ body }) => {
+    return cy
+      .request("POST", "/api/dashboard", { name, ...dashboardDetails })
+      .then(({ body }) => {
         if (wrapId) {
           cy.wrap(body.id).as(idAlias);
         }
@@ -31,8 +32,9 @@ Cypress.Commands.add(
             dashcards,
           });
         }
-      },
-    );
+
+        return new Promise(resolve => resolve({ body }));
+      });
   },
 );
 

--- a/e2e/support/commands/api/dashboard.js
+++ b/e2e/support/commands/api/dashboard.js
@@ -14,9 +14,8 @@ Cypress.Commands.add(
     cy.log(`Create a dashboard: ${name}`);
 
     // For all the possible keys, refer to `src/metabase/api/dashboard.clj`
-    return cy
-      .request("POST", "/api/dashboard", { name, ...dashboardDetails })
-      .then(({ body }) => {
+    cy.request("POST", "/api/dashboard", { name, ...dashboardDetails }).then(
+      ({ body }) => {
         if (wrapId) {
           cy.wrap(body.id).as(idAlias);
         }
@@ -32,9 +31,8 @@ Cypress.Commands.add(
             dashcards,
           });
         }
-
-        return new Promise(resolve => resolve({ body }));
-      });
+      },
+    );
   },
 );
 

--- a/e2e/test/scenarios/collections/trash.cy.spec.js
+++ b/e2e/test/scenarios/collections/trash.cy.spec.js
@@ -118,6 +118,18 @@ describe("scenarios > collections > trash", () => {
       native: { query: "select 1;" },
     });
 
+    cy.log("Bookmark the resources to test metabase#44224");
+
+    cy.get("@collectionId").then(collectionId => {
+      cy.get("@dashboardId").then(dashboardId => {
+        cy.get("@questionId").then(questionId => {
+          cy.request("POST", `/api/bookmark/card/${questionId}`);
+          cy.request("POST", `/api/bookmark/collection/${collectionId}`);
+          cy.request("POST", `/api/bookmark/dashboard/${dashboardId}`);
+        });
+      });
+    });
+
     visitRootCollection();
 
     cy.log("should be able to move to trash from collection view");
@@ -626,6 +638,8 @@ describe("scenarios > collections > trash", () => {
   });
 });
 
+describe("Restoring items", () => {});
+
 function toggleEllipsisMenuFor(item) {
   collectionTable().within(() => {
     cy.findByText(item)
@@ -638,31 +652,37 @@ function toggleEllipsisMenuFor(item) {
 function createCollection(collectionInfo, archive) {
   return cy
     .createCollection(collectionInfo)
-    .then(({ body: collection }) =>
-      Promise.all([collection, archive && cy.archiveCollection(collection.id)]),
-    )
+    .then(({ body: collection }) => {
+      cy.wrap(collection.id).as("collectionId");
+      return Promise.all([
+        collection,
+        archive && cy.archiveCollection(collection.id),
+      ]);
+    })
     .then(([collection]) => collection);
 }
 
 function createQuestion(questionInfo, archive) {
-  return _createQuestion(questionInfo).then(({ body: question }) =>
-    Promise.all([question, archive && archiveQuestion(question.id)]).then(
-      ([question]) => question,
-    ),
+  return _createQuestion(questionInfo, { wrapId: true }).then(
+    ({ body: question }) =>
+      Promise.all([question, archive && archiveQuestion(question.id)]).then(
+        ([question]) => question,
+      ),
   );
 }
 
 function createNativeQuestion(questionInfo, archive) {
-  return _createNativeQuestion(questionInfo).then(({ body: question }) =>
-    Promise.all([question, archive && archiveQuestion(question.id)]).then(
-      ([question]) => question,
-    ),
+  return _createNativeQuestion(questionInfo, { wrapId: true }).then(
+    ({ body: question }) =>
+      Promise.all([question, archive && archiveQuestion(question.id)]).then(
+        ([question]) => question,
+      ),
   );
 }
 
 function createDashboard(dashboardInfo, archive) {
   return cy
-    .createDashboard(dashboardInfo)
+    .createDashboard(dashboardInfo, { wrapId: true })
     .then(({ body: dashboard }) =>
       Promise.all([dashboard, archive && cy.archiveDashboard(dashboard.id)]),
     )

--- a/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
+++ b/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
@@ -21,6 +21,7 @@ import {
 } from "metabase/collections/utils";
 import { ConfirmDeleteModal } from "metabase/components/ConfirmDeleteModal";
 import EventSandbox from "metabase/components/EventSandbox";
+import { bookmarks as BookmarkEntity } from "metabase/entities";
 import { useDispatch } from "metabase/lib/redux";
 import { entityForObject } from "metabase/lib/schema";
 import * as Urls from "metabase/lib/urls";
@@ -140,6 +141,7 @@ function ActionMenu({
     const result = await dispatch(
       Entity.actions.update({ id: item.id, archived: false }),
     );
+    await dispatch(BookmarkEntity.actions.invalidateLists());
     const parent = HACK_getParentCollectionFromEntityUpdateAction(item, result);
     const redirect = parent ? Urls.collection(parent) : `/collection/root`;
 

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionContentView.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionContentView.tsx
@@ -21,6 +21,7 @@ import {
   isTrashedCollection,
 } from "metabase/collections/utils";
 import ItemsDragLayer from "metabase/containers/dnd/ItemsDragLayer";
+import Bookmarks from "metabase/entities/bookmarks";
 import Collections from "metabase/entities/collections";
 import Search from "metabase/entities/search";
 import { useListSelect } from "metabase/hooks/use-list-select";
@@ -220,9 +221,10 @@ export const CollectionContentView = ({
                 canWrite={collection.can_write}
                 canRestore={collection.can_restore}
                 canDelete={collection.can_delete}
-                onUnarchive={() => {
+                onUnarchive={async () => {
                   const input = { ...actionId, name: collection.name };
-                  dispatch(Collections.actions.setArchived(input, false));
+                  await dispatch(Collections.actions.setArchived(input, false));
+                  await dispatch(Bookmarks.actions.invalidateLists());
                 }}
                 onMove={({ id }) =>
                   dispatch(Collections.actions.setCollection(actionId, { id }))

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -21,6 +21,7 @@ import type {
   FetchDashboardResult,
   SuccessfulFetchDashboardResult,
 } from "metabase/dashboard/types";
+import Bookmarks from "metabase/entities/bookmarks";
 import Dashboards from "metabase/entities/dashboards";
 import { getMainElement } from "metabase/lib/dom";
 import { useDispatch } from "metabase/lib/redux";
@@ -436,7 +437,10 @@ function DashboardInner(props: DashboardProps) {
                 canWrite={canWrite}
                 canRestore={canRestore}
                 canDelete={canDelete}
-                onUnarchive={() => dispatch(setArchivedDashboard(false))}
+                onUnarchive={async () => {
+                  await dispatch(setArchivedDashboard(false));
+                  await dispatch(Bookmarks.actions.invalidateLists());
+                }}
                 onMove={({ id }) => dispatch(moveDashboardToCollection({ id }))}
                 onDeletePermanently={() => {
                   const { id } = dashboard;

--- a/frontend/src/metabase/entities/bookmarks.js
+++ b/frontend/src/metabase/entities/bookmarks.js
@@ -1,5 +1,5 @@
 import { createSelector } from "@reduxjs/toolkit";
-import { assoc, updateIn, dissoc } from "icepick";
+import { assoc, updateIn, dissoc, getIn } from "icepick";
 import _ from "underscore";
 
 import { bookmarkApi } from "metabase/api";
@@ -62,10 +62,14 @@ const Bookmarks = createEntity({
   objectSelectors: {
     getIcon,
   },
+
   reducer: (state = {}, { type, payload, error }) => {
     if (type === Questions.actionTypes.UPDATE && payload?.object) {
       const { archived, type, id, name } = payload.object;
       const key = `card-${id}`;
+      if (!getIn(state, [key])) {
+        return state;
+      }
       if (archived) {
         return dissoc(state, key);
       } else {
@@ -80,6 +84,9 @@ const Bookmarks = createEntity({
     if (type === Dashboards.actionTypes.UPDATE && payload?.object) {
       const { archived, id, name } = payload.object;
       const key = `dashboard-${id}`;
+      if (!getIn(state, [key])) {
+        return state;
+      }
       if (archived) {
         return dissoc(state, key);
       } else {
@@ -91,6 +98,9 @@ const Bookmarks = createEntity({
       const { id, authority_level, name } = payload.object;
       const key = `collection-${id}`;
 
+      if (!getIn(state, [key])) {
+        return state;
+      }
       if (payload.object.archived) {
         return dissoc(state, key);
       } else {

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -11,6 +11,7 @@ import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import Toaster from "metabase/components/Toaster";
 import CS from "metabase/css/core/index.css";
 import QueryBuilderS from "metabase/css/query_builder.module.css";
+import Bookmarks from "metabase/entities/bookmarks";
 import Questions from "metabase/entities/questions";
 import {
   rememberLastUsedDatabase,
@@ -457,7 +458,10 @@ class View extends Component {
 
 const mapDispatchToProps = dispatch => ({
   onSetDatabaseId: id => dispatch(rememberLastUsedDatabase(id)),
-  onUnarchive: question => dispatch(setArchivedQuestion(question, false)),
+  onUnarchive: async question => {
+    await dispatch(setArchivedQuestion(question, false));
+    await dispatch(Bookmarks.actions.invalidateLists());
+  },
   onMove: (question, newCollection) =>
     dispatch(
       Questions.actions.setCollection({ id: question.id() }, newCollection, {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/44224

### Description
Changes updates to bookmark store when Questions / Dashboards / Collections are updated, as well as re-fetches bookmarks when trashed items are restored.

_There is a separate PR fixing this in the release branch, since archive is a different experience in v50_

### How to verify

1. Have a bookmarked Question, Dashboard, and Collection. Move them to the trash
2. Without refreshing, Go to the trash and restore each of them. The application should not crash, and the item should appear in your bookmarks list
3. Repeat the process, but instead of restoring from the trash, restore from the entity page

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
