### PR TITLE
Adjust undo toast timeout 12s -> 8s

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-wiring.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-wiring.cy.spec.js
@@ -660,6 +660,38 @@ describe("dashboard filters auto-wiring", () => {
         .should("have.length", 1)
         .should("contain", "Removed card");
     });
+
+    it("should dismiss toasts on timeout", () => {
+      createDashboardWithCards({ cards }).then(dashboardId => {
+        visitDashboard(dashboardId);
+      });
+
+      editDashboard();
+      setFilter("Text or Category", "Is");
+
+      cy.clock();
+      selectDashboardFilter(getDashboardCard(0), "Name");
+
+      undoToast().should("be.visible");
+
+      // AUTO_WIRE_TOAST_TIMEOUT
+      cy.tick(12000);
+
+      undoToast().should("not.exist");
+
+      removeFilterFromDashCard(0);
+
+      selectDashboardFilter(getDashboardCard(0), "Name");
+
+      cy.clock();
+      undoToast().findByRole("button", { name: "Auto-connect" }).click();
+
+      undoToast().should("be.visible");
+
+      // AUTO_WIRE_UNDO_TOAST_TIMEOUT
+      cy.tick(8000);
+      undoToast().should("not.exist");
+    });
   });
 });
 

--- a/frontend/src/metabase/containers/UndoListing.jsx
+++ b/frontend/src/metabase/containers/UndoListing.jsx
@@ -93,6 +93,8 @@ function UndoToast({ undo, onUndo, onDismiss }) {
     dispatch(resumeUndo(undo));
   };
 
+  const animationDuration = undo.initialTimeout / 1000;
+
   return (
     <Transition
       mounted={mounted}
@@ -121,7 +123,10 @@ function UndoToast({ undo, onUndo, onDismiss }) {
               pos="absolute"
               top={0}
               left={0}
-              className={CS.progress}
+              w="100%"
+              className={`${CS.progress}  ${
+                animationDuration === 8 ? CS.progress8s : CS.progress12s
+              }`}
             />
           )}
           <CardContent>

--- a/frontend/src/metabase/containers/UndoListing.jsx
+++ b/frontend/src/metabase/containers/UndoListing.jsx
@@ -93,8 +93,6 @@ function UndoToast({ undo, onUndo, onDismiss }) {
     dispatch(resumeUndo(undo));
   };
 
-  const animationDuration = undo.initialTimeout / 1000;
-
   return (
     <Transition
       mounted={mounted}
@@ -124,9 +122,11 @@ function UndoToast({ undo, onUndo, onDismiss }) {
               top={0}
               left={0}
               w="100%"
-              className={`${CS.progress}  ${
-                animationDuration === 8 ? CS.progress8s : CS.progress12s
-              }`}
+              className={CS.progress}
+              /* override animation duration based on timeout */
+              style={{
+                animationDuration: `${undo.initialTimeout}ms`,
+              }}
             />
           )}
           <CardContent>

--- a/frontend/src/metabase/containers/UndoListing.module.css
+++ b/frontend/src/metabase/containers/UndoListing.module.css
@@ -12,7 +12,14 @@
   /* it must be in sync with AUTO_WIRE_TOAST_TIMEOUT */
   animation: animated-progress 12s linear;
   transform-origin: left;
-  width: 100%;
+}
+
+.progress8s {
+  animation-duration: 8s;
+}
+
+.progress12s {
+  animation-duration: 8s;
 }
 
 .toast:hover .progress {

--- a/frontend/src/metabase/containers/UndoListing.module.css
+++ b/frontend/src/metabase/containers/UndoListing.module.css
@@ -19,7 +19,7 @@
 }
 
 .progress12s {
-  animation-duration: 8s;
+  animation-duration: 12s;
 }
 
 .toast:hover .progress {

--- a/frontend/src/metabase/containers/UndoListing.module.css
+++ b/frontend/src/metabase/containers/UndoListing.module.css
@@ -9,17 +9,8 @@
 }
 
 .progress {
-  /* it must be in sync with AUTO_WIRE_TOAST_TIMEOUT */
-  animation: animated-progress 12s linear;
+  animation: animated-progress linear;
   transform-origin: left;
-}
-
-.progress8s {
-  animation-duration: 8s;
-}
-
-.progress12s {
-  animation-duration: 12s;
 }
 
 .toast:hover .progress {

--- a/frontend/src/metabase/dashboard/actions/auto-wire-parameters/constants.ts
+++ b/frontend/src/metabase/dashboard/actions/auto-wire-parameters/constants.ts
@@ -1,1 +1,2 @@
 export const AUTO_WIRE_TOAST_TIMEOUT = 12000;
+export const AUTO_WIRE_UNDO_TOAST_TIMEOUT = 8000;

--- a/frontend/src/metabase/dashboard/actions/auto-wire-parameters/toasts.ts
+++ b/frontend/src/metabase/dashboard/actions/auto-wire-parameters/toasts.ts
@@ -16,7 +16,10 @@ import type {
 } from "metabase-types/api";
 import type { Dispatch, GetState } from "metabase-types/store";
 
-import { AUTO_WIRE_TOAST_TIMEOUT } from "./constants";
+import {
+  AUTO_WIRE_TOAST_TIMEOUT,
+  AUTO_WIRE_UNDO_TOAST_TIMEOUT,
+} from "./constants";
 
 export const AUTO_WIRE_TOAST_ID = _.uniqueId();
 
@@ -75,7 +78,7 @@ export const showAutoWireParametersToast =
           message: t`The filter was auto-connected to all questions containing “${columnName}”.`,
           actionLabel: t`Undo`,
           showProgress: true,
-          timeout: 12000,
+          timeout: AUTO_WIRE_UNDO_TOAST_TIMEOUT,
           type: "filterAutoConnectDone",
           extraInfo: {
             dashcardIds: dashcardAttributes.map(({ id }) => id),
@@ -155,7 +158,7 @@ export const showAddedCardAutoWireParametersToast =
         addUndo({
           message,
           showProgress: true,
-          timeout: AUTO_WIRE_TOAST_TIMEOUT,
+          timeout: AUTO_WIRE_UNDO_TOAST_TIMEOUT,
           type: "filterAutoConnect",
           action: revertAutoWireParametersToNewCard,
         }),

--- a/frontend/src/metabase/redux/undo.js
+++ b/frontend/src/metabase/redux/undo.js
@@ -129,6 +129,7 @@ export default function (state = [], { type, payload, error }) {
 
     const undo = {
       ...payload,
+      initialTimeout: payload.timeout,
       // normalize "action" to "actions"
       actions: payload.action ? [payload.action] : payload.actions || [],
       action: null,

--- a/frontend/src/metabase/redux/undo.unit.spec.ts
+++ b/frontend/src/metabase/redux/undo.unit.spec.ts
@@ -123,6 +123,20 @@ describe("metabase/redux/undo", () => {
     // undo is dismissed, timeout passed
     expect(store.getState().undo.length).toBe(0);
   });
+
+  it("should hide toast after timeout is passed", async () => {
+    const store = createMockStore();
+    const timeout = 1000;
+
+    store.dispatch(addUndo({ id: MOCK_ID, timeout }));
+
+    // await act is required to simulate store update on the next tick
+    await act(async () => {
+      jest.advanceTimersByTime(timeout);
+    });
+
+    expect(store.getState().undo.length).toBe(0);
+  });
 });
 
 const createMockStore = () => {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/44423

### Description

Auto-wiring toast timeout is 12s, for undo toast we decided to reduce it to 8s.

### How to verify

- Add a dashboard with 2 cards and a filter
- map one card to a filter
- when "auto-connect" toast appears, click "auto-connect"
- make sure that undo toast is shown for 8s before disappearing

### Demo


https://github.com/metabase/metabase/assets/125459446/885cdada-c0f1-41e6-baa9-3ab92257672c



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
