### PR TITLE
docs(sdk): Update SDK README.md

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/README.md
+++ b/enterprise/frontend/src/embedding-sdk/README.md
@@ -22,15 +22,13 @@ Features planned:
 
 - You have an application using React 17 or higher
 - You have a Pro or Enterprise [subscription or free trial](https://www.metabase.com/pricing/) of Metabase
-- You have a running Metabase instance using a compatible version of the enterprise binary. v1.50.x are the only supported versions at this time. We do not recommend running this in production.
+- You have a running Metabase instance using a compatible version of the enterprise binary. v1.50.x are the only supported versions at this time.
 
 # Getting started
 
 ## Start Metabase
 
-Currently, the SDK only works with specific versions of Metabase.
-
-> Note these are not considered stable. Do not use these in production.
+Currently, the SDK only works with Metabase version 50.
 
 You have the following options:
 


### PR DESCRIPTION
Remove warnings about not using MB versions in production. This is a left over from the time we were pointing to builds off master and RCs.