### PR TITLE
Fix updating table questions in the notebook editor before running a query

### DIFF
--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -718,3 +718,61 @@ describe("issue 44071", () => {
       .should("be.visible");
   });
 });
+
+describe("issue 44415", () => {
+  beforeEach(() => {
+    restore();
+    cy.signIn("admin");
+    createQuestion(
+      {
+        query: {
+          "source-table": ORDERS_ID,
+          filter: [
+            "and",
+            [
+              "not-null",
+              ["field", ORDERS.DISCOUNT, { "base-type": "type/Float" }],
+            ],
+          ],
+        },
+        visualization_settings: {
+          "table.columns": [
+            {
+              name: "ID",
+              fieldRef: ["field", ORDERS.ID, null],
+              enabled: true,
+            },
+            {
+              name: "DISCOUNT",
+              fieldRef: ["field", ORDERS.DISCOUNT, null],
+              enabled: true,
+            },
+          ],
+        },
+      },
+      { wrapId: true },
+    );
+  });
+
+  it("should be able to edit a table question in the notebook editor before running its query (metabase#44415)", () => {
+    cy.get("@questionId").then(questionId =>
+      cy.visit(`/question/${questionId}/notebook`),
+    );
+
+    getNotebookStep("filter")
+      .findAllByTestId("notebook-cell-item")
+      .first()
+      .icon("close")
+      .click();
+
+    getNotebookStep("filter").should("not.exist");
+
+    visualize();
+
+    cy.findByTestId("qb-filters-panel").should("not.exist");
+    cy.get("@questionId").then(questionId => {
+      cy.url().should("not.include", `/question/${questionId}`);
+      cy.url().should("include", "question#");
+    });
+  });
+});

--- a/frontend/src/metabase/visualizations/lib/sync-settings.ts
+++ b/frontend/src/metabase/visualizations/lib/sync-settings.ts
@@ -27,10 +27,10 @@ export function syncVizSettingsWithSeries(
   const series = _series?.[0];
   const previousSeries = _previousSeries?.[0];
 
-  if (series && !series.error) {
+  if (series?.data && !series?.error) {
     newSettings = syncTableColumnSettings(newSettings, series);
 
-    if (previousSeries && !previousSeries.error) {
+    if (previousSeries?.data && !previousSeries?.error) {
       newSettings = syncGraphMetricSettings(
         newSettings,
         series,


### PR DESCRIPTION
Closes #44415 

> [!NOTE]
> The PR label says "no-backport", but I already opened a manual backport here: #44424
> This PR is adding a repro test to a file that doesn't exist on the `release-x.50.x` branch, so I went ahead with a manual backport

After refactoring the viz settings and query results sync function to work with series objects in #44053, we ended up with an incomplete null check for `series.data`, as `data` in the `DatasetData` type isn't optional or nullable. Usually, the series doesn't have `data` when there's an error, but we're explicitly checking for errors. `syncTableColumnSettings` ([here](https://github.com/metabase/metabase/blob/863bc82af10e2c439dbd6e34f174078981e6ddb0/frontend/src/metabase/visualizations/lib/sync-settings.ts#L116)) started failing if a table question with `table.columns` setting was opened directly in the notebook editor without running a query prior to that. We're calling `syncVizSettingsWithSeries` inside `updateQuestion`, so as a result it was rejecting any query changes

### To verify

1. New > question > orders > visualize
2. Resize/rearrange columns
3. Save, and open a link like `/question/:id/notebook`
4. Try to update the query (add/update/remove any clause)
5. Ensure it works