### PR TITLE
fix(sdk): load custom font files when font is set to custom

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkContentWrapper.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkContentWrapper.unit.spec.tsx
@@ -1,0 +1,37 @@
+import { renderWithProviders } from "__support__/ui";
+import { SdkContentWrapper } from "embedding-sdk/components/private/SdkContentWrapper";
+import {
+  createMockSettingsState,
+  createMockState,
+} from "metabase-types/store/mocks";
+
+describe("SdkContentWrapper", () => {
+  it("injects the font-face declaration when available", () => {
+    const state = createMockState({
+      settings: createMockSettingsState({
+        "application-font-files": [
+          {
+            src: "https://example.com/foo.woff2",
+            fontFormat: "woff2",
+            fontWeight: 700,
+          },
+        ],
+      }),
+    });
+
+    renderWithProviders(<SdkContentWrapper />, { storeInitialState: state });
+
+    const rules = Array.from(document.styleSheets).flatMap(sheet =>
+      Array.from(sheet.cssRules || []),
+    );
+
+    const fontFaceRule = rules.find(
+      rule =>
+        rule.constructor.name === "CSSFontFaceRule" &&
+        rule.cssText.includes("foo.woff2"),
+    )!;
+
+    expect(fontFaceRule).toBeDefined();
+    expect(fontFaceRule.cssText).toContain("font-weight: 700");
+  });
+});

--- a/frontend/src/metabase/styled-components/selectors.ts
+++ b/frontend/src/metabase/styled-components/selectors.ts
@@ -17,15 +17,6 @@ export const getFont = createSelector(
   },
 );
 
-export const getFontFiles = createSelector(
-  [getSettings, getEmbedOptions],
-  (settings, embedOptions) => {
-    // If a font is set in the embed options, we don't need to load any font files.
-    // However, we still need to load the custom font files if the font is set to "Custom".
-    if (embedOptions.font && embedOptions.font !== "Custom") {
-      return [];
-    } else {
-      return settings["application-font-files"];
-    }
-  },
-);
+export const getFontFiles = createSelector([getSettings], settings => {
+  return settings["application-font-files"];
+});

--- a/frontend/src/metabase/styled-components/selectors.ts
+++ b/frontend/src/metabase/styled-components/selectors.ts
@@ -20,7 +20,9 @@ export const getFont = createSelector(
 export const getFontFiles = createSelector(
   [getSettings, getEmbedOptions],
   (settings, embedOptions) => {
-    if (embedOptions.font) {
+    // If a font is set in the embed options, we don't need to load any font files.
+    // However, we still need to load the custom font files if the font is set to "Custom".
+    if (embedOptions.font && embedOptions.font !== "Custom") {
       return [];
     } else {
       return settings["application-font-files"];


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/44370

### Description

Return custom font files when the embedded font is set to Custom.

### How to verify

- Go to the `fix-font-families` branch in the demo app. Run the demo app (including the API) locally.
- Fonts should now be loaded properly.

### Limitations

- We only support the 400, 700 and 900 weights in the appearance settings, and we can only set one font at a time. We will address this in https://github.com/metabase/metabase/issues/44394 next.

![CleanShot 2567-06-20 at 01 06 42@2x](https://github.com/metabase/metabase/assets/4714175/f3cb028d-bdb4-4ace-9184-40ec43f5130b)

### Demo

![CleanShot 2567-06-20 at 01 07 57@2x](https://github.com/metabase/metabase/assets/4714175/93fe9799-d263-4c9b-8e9d-087575a1338d)