### PR TITLE
Adjust distinct aggregation expansion on Mongo

### DIFF
--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -1136,14 +1136,14 @@
                                   ;; \$ is added to identifiers so eg. `q~count1` becomes `$q~count1`. Those values
                                   ;; are used match against `aggr-expr` where identifiers have the prefix.
                                   (map #(str \$ %)))
-                            distinct-keys)
-        aggr-expr' (walk/postwalk (fn [x]
-                                    (if (and (string? x)
-                                             (distinct-vals x))
-                                      {$size x}
-                                      x))
-                                  aggr-expr)]
-    [aggr-expr' mappings]))
+                            distinct-keys)]
+    [(walk/postwalk (fn [x]
+                      (if (and (string? x)
+                               (distinct-vals x))
+                        {$size x}
+                        x))
+                    aggr-expr)
+     mappings]))
 
 (defn- expand-aggregations
   "Expands the aggregations in `aggr-expr` into groupings and post processing

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -1160,10 +1160,11 @@
   usually does) refer to the fields introduced by the preceding maps."
   [aggr-expr]
   (let [aggr-name (annotate/aggregation-name (:query *query*) aggr-expr)
-        [aggr-expr' aggregations-seen] (simplify-extracted-aggregations
-                                        aggr-name
-                                        (-> (extract-aggregations aggr-expr aggr-name)
-                                            adjust-distinct-aggregations))
+        [aggr-expr' aggregations-seen] (-> (simplify-extracted-aggregations
+                                            aggr-name
+                                            (extract-aggregations aggr-expr aggr-name))
+                                           adjust-distinct-aggregations)
+
         raggr-expr (->rvalue aggr-expr')
         expandeds (map (fn [[aggr name]]
                          (expand-aggregation [:aggregation-options aggr {:name name}]))

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -1128,10 +1128,7 @@
 
   `aggr-expr` is expected to be a clause that is a result of [[extract-aggregations]]. For details see its docstring.
 
-  Distinct values are computed using the `$addToSet` in a `$group` stage. `$size` transforms them to actual count.
-
-  If there is a need for more _pre-post_ transformations (as per results of [[expand-aggregations]]), this function
-  should be generalized."
+  Distinct values are computed using the `$addToSet` in a `$group` stage. `$size` transforms them to actual count."
   [[aggr-expr mappings]]
   (let [distinct-keys (filter (fn [[clause]] (= :distinct clause)) (keys mappings))
         distinct-vals (into #{}

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -9,7 +9,7 @@
    [java-time.api :as t]
    [metabase.driver :as driver]
    [metabase.driver.common :as driver.common]
-   [metabase.driver.mongo.operators :refer [$add $addToSet $and $avg $concat $cond
+   [metabase.driver.mongo.operators :refer [$add $addFields $addToSet $and $avg $concat $cond
                                             $dayOfMonth $dayOfWeek $dayOfYear $divide $eq $expr
                                             $group $gt $gte $hour $limit $literal $lookup $lt $lte $match $max $min
                                             $minute $mod $month $multiply $ne $not $or $project $regexMatch $second
@@ -45,9 +45,6 @@
 
 ;; this is just a very limited schema to make sure we're generating valid queries. We should expand it more in the
 ;; future
-
-(def ^:private $addFields
-  :$addFields)
 
 (def ^:private $ProjectStage   [:map-of [:= $project]   [:map-of ::lib.schema.common/non-blank-string :any]])
 (def ^:private $SortStage      [:map-of [:= $sort]      [:map-of ::lib.schema.common/non-blank-string [:enum -1 1]]])

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -1157,10 +1157,9 @@
   usually does) refer to the fields introduced by the preceding maps."
   [aggr-expr]
   (let [aggr-name (annotate/aggregation-name (:query *query*) aggr-expr)
-        [aggr-expr' aggregations-seen] (-> (simplify-extracted-aggregations
-                                            aggr-name
-                                            (extract-aggregations aggr-expr aggr-name))
-                                           adjust-distinct-aggregations)
+        [aggr-expr' aggregations-seen] (->> (extract-aggregations aggr-expr aggr-name)
+                                            (simplify-extracted-aggregations aggr-name)
+                                            adjust-distinct-aggregations)
 
         raggr-expr (->rvalue aggr-expr')
         expandeds (map (fn [[aggr name]]

--- a/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
@@ -273,8 +273,9 @@
       (is (= {:projections ["count" "count_2"]
               :query
               [{"$group" {"_id" nil, "count" {"$addToSet" "$name"}, "count_2" {"$addToSet" "$price"}}}
+               {"$addFields" {"count" {"$size" "$count"} "count_2" {"$size" "$count_2"}}}
                {"$sort" {"_id" 1}}
-               {"$project" {"_id" false, "count" {"$size" "$count"}, "count_2" {"$size" "$count_2"}}}
+               {"$project" {"_id" false, "count" true, "count_2" true}}
                {"$limit" 5}],
               :collection  "venues"
               :mbql?       true}

--- a/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
@@ -288,7 +288,7 @@
 (deftest ^:parallel multiple-aggregations-with-distinct-count-expression-test
   (mt/test-driver
    :mongo
-   (testing "Should generate correct queries for `:distinct` in expressions ()"
+   (testing "Should generate correct queries for `:distinct` in expressions (#35425)"
      (is (= {:projections ["expression" "expression_2"],
              :query
              [{"$group"

--- a/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
@@ -285,6 +285,32 @@
                                [:distinct $price]]
                  :limit       5})))))))
 
+(deftest ^:parallel multiple-aggregations-with-distinct-count-expression-test
+  (mt/test-driver
+   :mongo
+   (testing "Should generate correct queries for `:distinct` in expressions ()"
+     (is (= {:projections ["expression" "expression_2"],
+             :query
+             [{"$group"
+               {"_id"                 nil,
+                "expression~count"    {"$addToSet" "$name"},
+                "expression~count1"   {"$addToSet" "$price"},
+                "expression_2~count"  {"$addToSet" "$name"},
+                "expression_2~count1" {"$addToSet" "$price"}}}
+              {"$addFields"
+               {"expression"   {"$add" [{"$size" "$expression~count"} {"$size" "$expression~count1"}]},
+                "expression_2" {"$subtract" [{"$size" "$expression_2~count"} {"$size" "$expression_2~count1"}]}}}
+              {"$sort" {"_id" 1}}
+              {"$project" {"_id" false, "expression" true, "expression_2" true}}
+              {"$limit" 5}],
+             :collection "venues",
+             :mbql? true}
+            (qp.compile/compile
+             (mt/mbql-query venues
+                            {:aggregation [[:+ [:distinct $name] [:distinct $price]]
+                                           [:- [:distinct $name] [:distinct $price]]]
+                             :limit       5})))))))
+
 (defn- extract-projections [projections q]
   (select-keys (get-in q [:query 0 "$project"]) projections))
 


### PR DESCRIPTION
Closes  #35425

### Description

This PR modifies expressions that are used in `$addFields` stage in aggregation transformation. Specifically, names that are result of `:distinct` aggregation are wrapped in `$size` to produce actual counts.

### How to verify

- Existing test was modified to check for the new behavior.
- New test was added to check compilation of more complex case.
- New test was added to ensure querying works as expected even more complex case.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
