### PR TITLE
Track metabase.nqa module dependencies

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -283,7 +283,12 @@
     metabase.metabot               :any
     metabase.models                :any
     metabase.moderation            :any
-    metabase.native-query-analyzer :any
+    metabase.native-query-analyzer #{metabase.config
+                                     metabase.driver
+                                     metabase.lib
+                                     metabase.public-settings
+                                     metabase.query-processor
+                                     metabase.util}
     metabase.permissions           :any
     metabase.plugins               :any
     metabase.public-settings       :any

--- a/src/metabase/native_query_analyzer.clj
+++ b/src/metabase/native_query_analyzer.clj
@@ -16,7 +16,7 @@
    [macaw.core :as macaw]
    [metabase.config :as config]
    [metabase.driver :as driver]
-   [metabase.driver.util :as driver.u]
+   [metabase.lib.native :as lib.native]
    [metabase.native-query-analyzer.impl :as nqa.impl]
    [metabase.native-query-analyzer.parameter-substitution :as nqa.sub]
    [metabase.native-query-analyzer.replacement :as nqa.replacement]
@@ -163,7 +163,7 @@
   query. Currently only support SQL-based dialects."
   [query]
   (when (and (active?) (:native query))
-    (let [driver (driver.u/database->driver (:database query))]
+    (let [driver (lib.native/engine query)]
       ;; TODO this approach is not extensible, we need to move to multimethods.
       ;; See https://github.com/metabase/metabase/issues/43516 for long term solution.
       (when (isa? driver/hierarchy driver :sql)

--- a/src/metabase/native_query_analyzer.clj
+++ b/src/metabase/native_query_analyzer.clj
@@ -16,7 +16,7 @@
    [macaw.core :as macaw]
    [metabase.config :as config]
    [metabase.driver :as driver]
-   [metabase.lib.native :as lib.native]
+   [metabase.driver.util :as driver.u]
    [metabase.native-query-analyzer.impl :as nqa.impl]
    [metabase.native-query-analyzer.parameter-substitution :as nqa.sub]
    [metabase.native-query-analyzer.replacement :as nqa.replacement]
@@ -163,7 +163,7 @@
   query. Currently only support SQL-based dialects."
   [query]
   (when (and (active?) (:native query))
-    (let [driver (lib.native/engine query)]
+    (let [driver (driver.u/database->driver (:database query))]
       ;; TODO this approach is not extensible, we need to move to multimethods.
       ;; See https://github.com/metabase/metabase/issues/43516 for long term solution.
       (when (isa? driver/hierarchy driver :sql)


### PR DESCRIPTION
### Description

The first stage of recovery is acceptance. 

Here we declare all the module dependencies of `metabase.native-query-analyzer`.
