### PR TITLE
Fix - Missing schema name in data picker

### DIFF
--- a/frontend/src/metabase/common/components/EntityPicker/components/ResultItem/ResultItem.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/ResultItem/ResultItem.tsx
@@ -2,9 +2,10 @@ import { t } from "ttag";
 
 import { Ellipsified } from "metabase/core/components/Ellipsified";
 import { color } from "metabase/lib/colors";
+import { humanize, titleize } from "metabase/lib/formatting";
 import { getIcon } from "metabase/lib/icon";
 import { getName } from "metabase/lib/name";
-import { Flex, Tooltip, FixedSizeIcon } from "metabase/ui";
+import { FixedSizeIcon, Flex, Tooltip } from "metabase/ui";
 import type { SearchResult } from "metabase-types/api";
 
 import { ENTITY_PICKER_Z_INDEX } from "../EntityPickerModal";
@@ -22,6 +23,7 @@ export type ResultItemType = Pick<SearchResult, "model" | "name"> &
       | "moderated_status"
       | "display"
       | "database_name"
+      | "table_schema"
     >
   >;
 
@@ -91,9 +93,19 @@ export const ResultItem = ({
 
 function getParentInfo(item: ResultItemType) {
   if (item.model === "table") {
+    const icon = getIcon({ model: "database" }).name;
+    const databaseName = item.database_name ?? t`Database`;
+
+    if (!item.table_schema) {
+      return {
+        icon,
+        name: databaseName,
+      };
+    }
+
     return {
-      icon: getIcon({ model: "database" }).name,
-      name: item.database_name ?? t`Database`,
+      icon,
+      name: `${databaseName} (${titleize(humanize(item.table_schema))})`,
     };
   }
 

--- a/frontend/src/metabase/common/components/EntityPicker/components/ResultItem/ResultItem.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/ResultItem/ResultItem.unit.spec.tsx
@@ -119,6 +119,11 @@ const tableItem: ResultItemType = {
   database_name: "My Database",
 };
 
+const tableItemWithSchema: ResultItemType = {
+  ...tableItem,
+  table_schema: "my_schema",
+};
+
 describe("EntityPicker > ResultItem", () => {
   beforeAll(() => {
     register();
@@ -214,6 +219,19 @@ describe("EntityPicker > ResultItem", () => {
     expect(getIcon("database")).toBeInTheDocument();
     expect(
       screen.getByText(`in ${tableItem.database_name}`),
+    ).toBeInTheDocument();
+  });
+
+  it("should display table schema when available (metabase#44460)", () => {
+    setup({
+      item: tableItemWithSchema,
+    });
+    expect(screen.getByText(tableItem.name)).toBeInTheDocument();
+
+    expect(getIcon("table")).toBeInTheDocument();
+    expect(getIcon("database")).toBeInTheDocument();
+    expect(
+      screen.getByText(`in ${tableItem.database_name} (My Schema)`),
     ).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/common/components/EntityPicker/components/ResultItem/ResultItem.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/ResultItem/ResultItem.unit.spec.tsx
@@ -124,6 +124,11 @@ const tableItemWithSchema: ResultItemType = {
   table_schema: "my_schema",
 };
 
+const tableItemWithEmptySchema: ResultItemType = {
+  ...tableItem,
+  table_schema: "",
+};
+
 describe("EntityPicker > ResultItem", () => {
   beforeAll(() => {
     register();
@@ -233,5 +238,21 @@ describe("EntityPicker > ResultItem", () => {
     expect(
       screen.getByText(`in ${tableItem.database_name} (My Schema)`),
     ).toBeInTheDocument();
+  });
+
+  it("should not display empty table schema", () => {
+    setup({
+      item: tableItemWithEmptySchema,
+    });
+    expect(screen.getByText(tableItem.name)).toBeInTheDocument();
+
+    expect(getIcon("table")).toBeInTheDocument();
+    expect(getIcon("database")).toBeInTheDocument();
+    expect(
+      screen.getByText(`in ${tableItem.database_name}`),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(`in ${tableItem.database_name} ()`),
+    ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Closes #44460

### How to verify

1. Start a new question
2. Search for any table in the Data Picker (e.g. Orders)

Name of the schema the table belongs to should be displayed next to database name.

_note: some databases don't have schemas (e.g. Maria, Mongo)_

### Demo

#### Before

![image](https://github.com/metabase/metabase/assets/6830683/6e6a044e-f51c-4276-af77-65db4b817b63)

#### After

![image](https://github.com/metabase/metabase/assets/6830683/98c9fa87-425b-4d52-b6ef-c0b08084f7fc)

