### PR TITLE
Fix rollback when sandboxing is configured

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/gtap_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/gtap_test.clj
@@ -26,7 +26,6 @@
    :card_id              true
    :table_id             true
    :group_id             true
-   :permission_id        false
    :attribute_remappings {:foo 1}})
 
 (defmacro ^:private with-gtap-cleanup
@@ -248,8 +247,7 @@
                         :table_id             table-id-1
                         :group_id             group-id
                         :card_id              card-id-1
-                        :attribute_remappings {:foo 1}
-                        :permission_id        (mt/malli=? [:maybe :int])}]
+                        :attribute_remappings {:foo 1}}]
                       (:sandboxes result)))
               (is (t2/exists? GroupTableAccessPolicy :table_id table-id-1 :group_id group-id))))
 

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/permissions_test.clj
@@ -86,7 +86,6 @@
                                 [:group_id             [:= (u/the-id &group)]]
                                 [:table_id             [:= (u/the-id db-2-table)]]
                                 [:card_id              nil?]
-                                [:permission_id        nil?]
                                 [:attribute_remappings nil?]]]
                               (t2/select GroupTableAccessPolicy
                                          :group_id (u/the-id &group)
@@ -98,7 +97,6 @@
                                 [:group_id             [:= (u/the-id other-group)]]
                                 [:table_id             [:= (mt/id :venues)]]
                                 [:card_id              nil?]
-                                [:permission_id        nil?]
                                 [:attribute_remappings nil?]]]
                               (t2/select GroupTableAccessPolicy :group_id (u/the-id other-group)))))))))))))
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -7894,6 +7894,26 @@ databaseChangeLog:
       rollback: # no rollback necessary here too
 
   - changeSet:
+      id: v50.2024-06-20T13:21:30
+      author: noahmoss
+      comment: 'Drop permission_id column on sandboxes table to fix down migrations'
+      changes:
+        - dropColumn:
+            tableName: sandboxes
+            columnName: permission_id
+      rollback:
+        - addColumn:
+            tableName: sandboxes
+            columns:
+              - column:
+                  name: permission_id
+                  type: int
+                  remarks: 'The ID of the corresponding permissions path for this sandbox (deprecated)'
+                  constraints:
+                    nullable: true
+                  defaultValue: null
+
+  - changeSet:
       id: v51.2024-05-13T15:30:57
       author: metamben
       comment: Backup of dataset_query rewritten by the metrics v2 migration

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -2016,6 +2016,39 @@
         (is (= #{(format "/block/db/%d/" db-id)}
                (t2/select-fn-set :object (t2/table-name :model/Permissions) :group_id group-id)))))))
 
+(deftest sandboxing-rollback-test
+  (testing "Can we rollback to 49 when sandboxing is configured"
+    (impl/test-migrations ["v50.2024-01-10T03:27:29" "v50.2024-06-20T13:21:30"] [migrate!]
+      (let [db-id         (first (t2/insert-returning-pks! (t2/table-name Database) {:name       "DB"
+                                                                                     :engine     "h2"
+                                                                                     :created_at :%now
+                                                                                     :updated_at :%now
+                                                                                     :details    "{}"}))
+            table-id      (first (t2/insert-returning-pks! (t2/table-name Table) {:db_id      db-id}
+                                                                               :schema     "SchemaName"
+                                                                               :name       "Table"
+                                                                               :created_at :%now
+                                                                               :updated_at :%now
+                                                                               :active     true))
+            permission-id (t2/insert-returning-pk! (t2/table-name :model/Permissions)
+                                                   {:object "/db/fake-permission/"
+                                                    :group_id 1})
+            _             (t2/query-one {:insert-into :sandboxes
+                                         :values      [{:group_id             1
+                                                        :table_id             table-id
+                                                        :attribute_remappings "{\"foo\", 1}"
+                                                        :permission_id        permission-id}]})]
+        (migrate!)
+        (is (=? {:group_id             1
+                 :table_id             table-id
+                 :attribute_remappings "{\"foo\", 1}"}
+                (t2/select-one :sandboxes :table_id table-id)))
+        (migrate! :down 49)
+        (is (=? {:group_id             1
+                 :table_id             table-id
+                 :attribute_remappings "{\"foo\", 1}"}
+                (t2/select-one :sandboxes :table_id table-id)))))))
+
 (deftest view-count-test
   (testing "report_card.view_count and report_dashboard.view_count should be populated"
     (impl/test-migrations ["v50.2024-04-25T16:29:31" "v50.2024-04-25T16:29:36"] [migrate!]

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -2024,30 +2024,26 @@
                                                                                      :created_at :%now
                                                                                      :updated_at :%now
                                                                                      :details    "{}"}))
-            table-id      (first (t2/insert-returning-pks! (t2/table-name Table) {:db_id      db-id}
-                                                                               :schema     "SchemaName"
-                                                                               :name       "Table"
-                                                                               :created_at :%now
-                                                                               :updated_at :%now
-                                                                               :active     true))
-            permission-id (t2/insert-returning-pk! (t2/table-name :model/Permissions)
-                                                   {:object "/db/fake-permission/"
-                                                    :group_id 1})
+            table-id      (first (t2/insert-returning-pks! (t2/table-name Table) {:db_id      db-id
+                                                                                  :schema     "SchemaName"
+                                                                                  :name       "Table"
+                                                                                  :created_at :%now
+                                                                                  :updated_at :%now
+                                                                                  :active     true}))
+            permission-id (t2/insert-returning-pk! (t2/table-name :model/Permissions) {:object "/db/fake-permission/"
+                                                                                       :group_id 1})
             _             (t2/query-one {:insert-into :sandboxes
                                          :values      [{:group_id             1
                                                         :table_id             table-id
                                                         :attribute_remappings "{\"foo\", 1}"
-                                                        :permission_id        permission-id}]})]
+                                                        :permission_id        permission-id}]})
+            expected        {:group_id             1
+                             :table_id             table-id
+                             :attribute_remappings "{\"foo\", 1}"}]
         (migrate!)
-        (is (=? {:group_id             1
-                 :table_id             table-id
-                 :attribute_remappings "{\"foo\", 1}"}
-                (t2/select-one :sandboxes :table_id table-id)))
+        (is (=? expected (t2/select-one :sandboxes :table_id table-id)))
         (migrate! :down 49)
-        (is (=? {:group_id             1
-                 :table_id             table-id
-                 :attribute_remappings "{\"foo\", 1}"}
-                (t2/select-one :sandboxes :table_id table-id)))))))
+        (is (=? expected (t2/select-one :sandboxes :table_id table-id)))))))
 
 (deftest view-count-test
   (testing "report_card.view_count and report_dashboard.view_count should be populated"


### PR DESCRIPTION
In 50, I added a migration to drop the `fk_sandboxes_ref_permissions` FK constraint on the `sandboxes` table. This FK linked sandboxes to their corresponding row in the `permissions` table via the `permission_id` field. As we were moving permission definitions to a new `data_permissions` table, this FK had to be dropped first.

The intent was to eventually drop this `permission_id` column as a cleanup step as it isn't being used. I didn't realize at the time that rollback would break without this cleanup. The reason is, re-adding the FK is only possible if all of the values in the `permission_id` column exist in the `permissions` table or are `NULL`. But without further cleanup, `permission_id` would contain references to rows in `permissions` which had been deleted.

(In retrospect, the migration to drop the FK should not have needed a rollback in the first place. But I think the best way to fix this now is with a new migration that enables the rollback to work without error.)

Resolves https://github.com/metabase/metabase/issues/44455