### PR TITLE
Fix #43873 flaky E2E segments test

### DIFF
--- a/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.js
@@ -23,7 +23,7 @@ import {
   summarize,
   modal,
   filter,
-  filterField,
+  saveQuestion,
   visitQuestion,
 } from "e2e/support/helpers";
 import { createSegment } from "e2e/support/helpers/e2e-table-metadata-helpers";
@@ -749,50 +749,36 @@ describe("scenarios > admin > datamodel > segments", () => {
       cy.findByText("Preview");
     });
 
-    it("should show no questions based on a new segment", () => {
+    it("should see a newly asked question in its questions list", () => {
+      cy.intercept("GET", "/api/table/*/query_metadata*").as("metadata");
+      // Ask question
       cy.visit("/reference/segments/1/questions");
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText(`Questions about ${SEGMENT_NAME}`);
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText(
-        "Questions about this segment will appear here as they're added",
-      );
-    });
+      cy.wait(["@metadata", "@metadata", "@metadata"]);
 
-    it(
-      "should see a newly asked question in its questions list",
-      { tags: "@flaky" },
-      () => {
-        // Ask question
-        cy.visit("/reference/segments/1/questions");
-
-        cy.button("Ask a question").click();
-        cy.findAllByText("37.65");
-
-        filter();
-        filterField("Product ID", {
-          value: "14",
-        });
-        cy.findByTestId("apply-filters").click();
-
-        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-        cy.findByText("Product ID is 14");
-        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-        cy.findByText("Save").click();
-        cy.findAllByText("Save").last().click();
-
-        // Check list
-        cy.visit("/reference/segments/1/questions");
-        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-        cy.findByText(
+      cy.get("main").should("contain", `Questions about ${SEGMENT_NAME}`);
+      cy.findByRole("status")
+        .as("emptyStateMessage")
+        .should(
+          "have.text",
           "Questions about this segment will appear here as they're added",
-        ).should("not.exist");
-        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-        cy.findByText(
-          `Orders, Filtered by ${SEGMENT_NAME} and Product ID is 14`,
         );
-      },
-    );
+
+      cy.button("Ask a question").click();
+      cy.findByTestId("filter-pill").should("have.text", "Orders < 100");
+      cy.findAllByTestId("cell-data").should("contain", "37.65");
+
+      summarize();
+      cy.findAllByTestId("sidebar-right").button("Done").click();
+      cy.findByTestId("scalar-value").should("have.text", "13,005");
+      saveQuestion("Foo");
+
+      // Check list
+      cy.visit("/reference/segments/1/questions");
+      cy.wait(["@metadata", "@metadata", "@metadata"]);
+
+      cy.get("@emptyStateMessage").should("not.exist");
+      cy.findByRole("heading", { name: "Foo" }).should("be.visible");
+    });
 
     it("should update that segment", () => {
       cy.visit("/admin");


### PR DESCRIPTION
### What does this PR accomplish?
It fixes E2E flake in data model > segments.
Resolves #43873

### Explanation
When we load a segment based on an Orders table, we have to wait for the metadata for three tables (Orders, and two FK relationships: Products and Users). In the flaky scenario, UI already loads while the metadata itself didn't load. So when we start a new question, it doesn't open an Orders table. It starts from an empty new question picker
![image](https://github.com/metabase/metabase/assets/31325167/776fd95d-a814-45b4-8c95-2d8a888b9b06)

### Solution
Explicitly wait for the metadata to load.

### Stress-test
20/20 ✅ https://github.com/metabase/metabase/actions/runs/9599000245
