### PR TITLE
fix: dont always optimize between expressions

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -451,7 +451,9 @@
                                  ;; too many false positives for now
                                  :unused-ret-vals
                                  ;; Kondo lints this for us anyway, and this isn't as easy to configure.
-                                 :wrong-arity]
+                                 :wrong-arity
+                                 ;; Kondo lints this for us anyway, and this isn't as easy to configure.
+                                 :suspicious-expression]
                ;; Snowplow has a dynamic dependency on okhttp3.CookieJar that we
                ;; don't use but eastwood detects. This is discussed in Slack here
                ;; https://clojurians.slack.com/archives/C03S1KBA2/p1667925853699669

--- a/src/metabase/query_processor/middleware/auto_bucket_datetimes.clj
+++ b/src/metabase/query_processor/middleware/auto_bucket_datetimes.clj
@@ -112,6 +112,11 @@
         (not (every? auto-bucketable-value? values)))
       :do-not-bucket-reason/not-all-values-are-auto-bucketable)
 
+    ;; *  do not autobucket fields that are updating the time interval
+    (lib.util.match/match-one x
+      [(_tag :guard #{:+ :-}) _ [:field _ _] [:interval _ _n (unit :guard #{:minute :hour :second})]])
+    :do-not-bucket-reason/bucket-between-relative-starting-from
+
     ;; do not auto-bucket fields inside a `:time-interval` filter: it already supplies its own unit
     ;; do not auto-bucket fields inside a `:datetime-diff` clause: the precise timestamp is needed for the difference
     (mbql.u/is-clause? #{:time-interval :datetime-diff} x)

--- a/test/metabase/query_processor/middleware/auto_bucket_datetimes_test.clj
+++ b/test/metabase/query_processor/middleware/auto_bucket_datetimes_test.clj
@@ -228,6 +228,19 @@
             {:source-table 1
              :breakout     [[:field Integer/MAX_VALUE nil]]})))))
 
+(deftest ^:parallel do-not-auto-bucket-time-interval-test
+  (testing "does a :type/DateTime breakout Field that is already bucketed pass thru unchanged?"
+    (qp.store/with-metadata-provider meta/metadata-provider
+      (is (= {:source-table (meta/id :orders)
+              :filter       [:between [:+ [:field (meta/id :orders :created-at) nil] [:interval 1 :minute]]
+                               [:relative-datetime -10 :minute]
+                               [:relative-datetime 0 :minute]]}
+             (auto-bucket-mbql
+               {:source-table (meta/id :orders)
+                :filter       [:between [:+ [:field (meta/id :orders :created-at) nil] [:interval 1 :minute]]
+                               [:relative-datetime -10 :minute]
+                               [:relative-datetime 0 :minute]]}))))))
+
 (deftest ^:parallel auto-bucket-unix-timestamp-fields-test
   (testing "do UNIX TIMESTAMP fields get auto-bucketed?"
     (qp.store/with-metadata-provider unix-timestamp-metadata-provider

--- a/test/metabase/query_processor/middleware/optimize_temporal_filters_test.clj
+++ b/test/metabase/query_processor/middleware/optimize_temporal_filters_test.clj
@@ -175,14 +175,27 @@
     (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
                     (lib/with-fields [(meta/field-metadata :orders :id)])
                     (lib/filter (lib/between
-                                 (-> (meta/field-metadata :orders :created-at)
-                                     (lib/with-temporal-bucket :default))
-                                 (lib/relative-datetime -17 :week)
-                                 (lib/relative-datetime -16 :week))))]
+                                  (-> (meta/field-metadata :orders :created-at)
+                                      (lib/with-temporal-bucket :default))
+                                  (lib/relative-datetime -17 :week)
+                                  (lib/relative-datetime -16 :week))))]
       (is (=? {:query {:filter [:between
                                 [:field (meta/id :orders :created-at) {:base-type :type/DateTimeWithLocalTZ, :temporal-unit :default}]
                                 [:relative-datetime -17 :week]
                                 [:relative-datetime -16 :week]]}}
+              (optimize-temporal-filters (lib.convert/->legacy-MBQL query))))))
+  (testing "Don't optimize different buckets"
+    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                    (lib/with-fields [(meta/field-metadata :orders :id)])
+                    (lib/filter (lib/between
+                                  (-> (meta/field-metadata :orders :created-at)
+                                        (lib/with-temporal-bucket :day))
+                                  (lib/relative-datetime -1 :week)
+                                  (lib/relative-datetime 0 :week))))]
+      (is (=? {:query {:filter [:between
+                                [:field (meta/id :orders :created-at) {}]
+                                [:relative-datetime -1 :week]
+                                [:relative-datetime 0 :week]]}}
               (optimize-temporal-filters (lib.convert/->legacy-MBQL query)))))))
 
 (defn- optimize-filter-clauses [t]
@@ -444,7 +457,23 @@
                           [:relative-datetime 0 :month]]
                  :source-query {:source-table $$users
                                 :aggregation [[:count]]
-                                :breakout [[:field %last-login {:temporal-unit :month}]]}})))))))
+                                :breakout [[:field %last-login {:temporal-unit :month}]]}}))))))
+  (testing "Don't optimize when temporal units are different. (#42291)"
+    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                    (lib/with-fields [(meta/field-metadata :orders :id)])
+                    (lib/filter (lib/between
+                                  (lib/+
+                                    (-> (meta/field-metadata :orders :created-at)
+                                        (lib/with-temporal-bucket :day))
+                                    (lib/interval 2 :day))
+                                  (lib/relative-datetime -1 :week)
+                                  (lib/relative-datetime 0 :week))))]
+      (is (=? {:query {:filter [:between
+                                [:+ [:field (meta/id :orders :created-at) {}]
+                                 [:interval 2 :day]]
+                                [:relative-datetime -1 :week]
+                                [:relative-datetime 0 :week]]}}
+              (optimize-temporal-filters (lib.convert/->legacy-MBQL query)))))))
 
 (deftest ^:parallel optimize-date-equals-date-filters-test
   (qp.store/with-metadata-provider meta/metadata-provider


### PR DESCRIPTION
Fixes #42291

The frontend produces expressions like

```
[:between
 [+ [:field ... {:temporal-bucket :day] [:interval 2 :day]]
 [:relative-datetime -1 :week]
 [:relative-datetime 0 :week]]
```

This should not be optimized because of the mixed `:day` and `:week` units. However, it was being optimized since the compatible units weren't being properly picked up by the match.
