### PR TITLE
convert embed.ts to ts and to use createSlice from rtk

### DIFF
--- a/frontend/src/metabase/redux/embed.ts
+++ b/frontend/src/metabase/redux/embed.ts
@@ -1,6 +1,6 @@
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 
-import { parseHashOptions, parseSearchOptions } from "metabase/lib/browser";
+import { parseSearchOptions } from "metabase/lib/browser";
 import type { EmbedOptions } from "metabase-types/store";
 
 export const DEFAULT_EMBED_OPTIONS: EmbedOptions = {
@@ -15,6 +15,19 @@ export const DEFAULT_EMBED_OPTIONS: EmbedOptions = {
   action_buttons: true,
 } as const;
 
+export const urlParameterToBoolean = (
+  urlParameter: string | string[] | boolean | undefined,
+) => {
+  if (urlParameter === undefined) {
+    return undefined;
+  }
+  if (Array.isArray(urlParameter)) {
+    return Boolean(urlParameter.at(-1));
+  } else {
+    return Boolean(urlParameter);
+  }
+};
+
 const interactiveEmbedSlice = createSlice({
   name: "interactiveEmbed",
   initialState: {
@@ -26,10 +39,35 @@ const interactiveEmbedSlice = createSlice({
       state,
       action: PayloadAction<{ search: string; hash: string }>,
     ) => {
+      const searchOptions = parseSearchOptions(action.payload.search);
       state.options = {
-        ...DEFAULT_EMBED_OPTIONS,
-        ...parseSearchOptions(action.payload.search),
-        ...parseHashOptions(action.payload.hash),
+        side_nav:
+          urlParameterToBoolean(searchOptions.side_nav) ??
+          DEFAULT_EMBED_OPTIONS["side_nav"],
+        header:
+          urlParameterToBoolean(searchOptions.header) ??
+          DEFAULT_EMBED_OPTIONS["header"],
+        top_nav:
+          urlParameterToBoolean(searchOptions.top_nav) ??
+          DEFAULT_EMBED_OPTIONS["top_nav"],
+        search:
+          urlParameterToBoolean(searchOptions.search) ??
+          DEFAULT_EMBED_OPTIONS["search"],
+        new_button:
+          urlParameterToBoolean(searchOptions.new_button) ??
+          DEFAULT_EMBED_OPTIONS["new_button"],
+        breadcrumbs:
+          urlParameterToBoolean(searchOptions.breadcrumbs) ??
+          DEFAULT_EMBED_OPTIONS["breadcrumbs"],
+        logo:
+          urlParameterToBoolean(searchOptions.logo) ??
+          DEFAULT_EMBED_OPTIONS["logo"],
+        additional_info:
+          urlParameterToBoolean(searchOptions.additional_info) ??
+          DEFAULT_EMBED_OPTIONS["additional_info"],
+        action_buttons:
+          urlParameterToBoolean(searchOptions.action_buttons) ??
+          DEFAULT_EMBED_OPTIONS["action_buttons"],
       };
     },
     setOptions: (state, action: PayloadAction<Partial<EmbedOptions>>) => {

--- a/frontend/src/metabase/redux/embed.ts
+++ b/frontend/src/metabase/redux/embed.ts
@@ -1,12 +1,9 @@
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+
 import { parseHashOptions, parseSearchOptions } from "metabase/lib/browser";
-import {
-  combineReducers,
-  createAction,
-  handleActions,
-} from "metabase/lib/redux";
 import type { EmbedOptions } from "metabase-types/store";
 
-export const DEFAULT_EMBED_OPTIONS = {
+export const DEFAULT_EMBED_OPTIONS: EmbedOptions = {
   top_nav: true,
   side_nav: "default",
   search: false,
@@ -18,42 +15,34 @@ export const DEFAULT_EMBED_OPTIONS = {
   action_buttons: true,
 } as const;
 
-export const SET_INITIAL_URL_OPTIONS = "metabase/embed/SET_INITIAL_URL_OPTIONS";
-export const setInitialUrlOptions = createAction(
-  SET_INITIAL_URL_OPTIONS,
-  ({ search, hash }: { search: string; hash: string }) => {
-    return {
-      ...parseSearchOptions(search),
-      ...parseHashOptions(hash),
-    };
+const interactiveEmbedSlice = createSlice({
+  name: "interactiveEmbed",
+  initialState: {
+    options: {} as EmbedOptions,
+    isEmbeddingSdk: false,
   },
-);
-
-export const SET_OPTIONS = "metabase/embed/SET_OPTIONS";
-export const setOptions = createAction(
-  SET_OPTIONS,
-  (options: Partial<EmbedOptions>) => options,
-);
-
-const options = handleActions(
-  {
-    [SET_INITIAL_URL_OPTIONS]: (state, { payload }) => ({
-      ...DEFAULT_EMBED_OPTIONS,
-      ...payload,
-    }),
-
-    [SET_OPTIONS]: (state, { payload }) => ({
-      ...state,
-      ...payload,
-    }),
+  reducers: {
+    setInitialUrlOptions: (
+      state,
+      action: PayloadAction<{ search: string; hash: string }>,
+    ) => {
+      state.options = {
+        ...DEFAULT_EMBED_OPTIONS,
+        ...parseSearchOptions(action.payload.search),
+        ...parseHashOptions(action.payload.hash),
+      };
+    },
+    setOptions: (state, action: PayloadAction<Partial<EmbedOptions>>) => {
+      state.options = {
+        ...state.options,
+        ...action.payload,
+      };
+    },
   },
-  {},
-);
-
-const isEmbeddingSdk = handleActions({}, false);
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default combineReducers({
-  options,
-  isEmbeddingSdk,
 });
+
+export const { setInitialUrlOptions, setOptions } =
+  interactiveEmbedSlice.actions;
+
+// eslint-disable-next-line import/no-default-export
+export default interactiveEmbedSlice.reducer;

--- a/frontend/src/metabase/redux/embed.ts
+++ b/frontend/src/metabase/redux/embed.ts
@@ -40,7 +40,7 @@ const interactiveEmbedSlice = createSlice({
   reducers: {
     setInitialUrlOptions: (
       state,
-      action: PayloadAction<{ search: string; hash: string }>,
+      action: PayloadAction<{ search: string }>,
     ) => {
       const searchOptions = parseSearchOptions(action.payload.search);
 

--- a/frontend/src/metabase/redux/embed.ts
+++ b/frontend/src/metabase/redux/embed.ts
@@ -1,4 +1,5 @@
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+import { pick } from "underscore";
 
 import { parseSearchOptions } from "metabase/lib/browser";
 import type { EmbedOptions } from "metabase-types/store";
@@ -14,6 +15,8 @@ export const DEFAULT_EMBED_OPTIONS: EmbedOptions = {
   additional_info: true,
   action_buttons: true,
 } as const;
+
+const allowedEmbedOptions = Object.keys(DEFAULT_EMBED_OPTIONS);
 
 export const urlParameterToBoolean = (
   urlParameter: string | string[] | boolean | undefined,
@@ -40,34 +43,10 @@ const interactiveEmbedSlice = createSlice({
       action: PayloadAction<{ search: string; hash: string }>,
     ) => {
       const searchOptions = parseSearchOptions(action.payload.search);
+
       state.options = {
-        side_nav:
-          urlParameterToBoolean(searchOptions.side_nav) ??
-          DEFAULT_EMBED_OPTIONS["side_nav"],
-        header:
-          urlParameterToBoolean(searchOptions.header) ??
-          DEFAULT_EMBED_OPTIONS["header"],
-        top_nav:
-          urlParameterToBoolean(searchOptions.top_nav) ??
-          DEFAULT_EMBED_OPTIONS["top_nav"],
-        search:
-          urlParameterToBoolean(searchOptions.search) ??
-          DEFAULT_EMBED_OPTIONS["search"],
-        new_button:
-          urlParameterToBoolean(searchOptions.new_button) ??
-          DEFAULT_EMBED_OPTIONS["new_button"],
-        breadcrumbs:
-          urlParameterToBoolean(searchOptions.breadcrumbs) ??
-          DEFAULT_EMBED_OPTIONS["breadcrumbs"],
-        logo:
-          urlParameterToBoolean(searchOptions.logo) ??
-          DEFAULT_EMBED_OPTIONS["logo"],
-        additional_info:
-          urlParameterToBoolean(searchOptions.additional_info) ??
-          DEFAULT_EMBED_OPTIONS["additional_info"],
-        action_buttons:
-          urlParameterToBoolean(searchOptions.action_buttons) ??
-          DEFAULT_EMBED_OPTIONS["action_buttons"],
+        ...DEFAULT_EMBED_OPTIONS,
+        ...pick(searchOptions, allowedEmbedOptions),
       };
     },
     setOptions: (state, action: PayloadAction<Partial<EmbedOptions>>) => {

--- a/frontend/src/metabase/redux/embed.unit.spec.ts
+++ b/frontend/src/metabase/redux/embed.unit.spec.ts
@@ -1,0 +1,48 @@
+import { configureStore, type Dispatch } from "@reduxjs/toolkit";
+
+import embedReduer, {
+  DEFAULT_EMBED_OPTIONS,
+  setInitialUrlOptions,
+} from "./embed";
+
+describe("embed reducer", () => {
+  describe("setInitialUrlOptions", () => {
+    it("should set default options", () => {
+      const store = createMockStore();
+
+      store.dispatch(setInitialUrlOptions({ search: "" }));
+
+      expect(store.getState().embed.options).toEqual(DEFAULT_EMBED_OPTIONS);
+    });
+
+    it("should set options from search", () => {
+      const store = createMockStore();
+
+      store.dispatch(
+        setInitialUrlOptions({ search: "top_nav=false&new_button=true" }),
+      );
+
+      expect(store.getState().embed.options.top_nav).toBe(false);
+      expect(store.getState().embed.options.new_button).toBe(true);
+    });
+
+    it("should ignore invalid options", () => {
+      const store = createMockStore();
+
+      store.dispatch(
+        setInitialUrlOptions({ search: "top_nav=false&invalid_option=123" }),
+      );
+
+      expect(store.getState().embed.options).not.toHaveProperty(
+        "invalid_option",
+      );
+    });
+  });
+});
+
+const createMockStore = () => {
+  const store = configureStore({
+    reducer: { embed: embedReduer },
+  });
+  return store as typeof store & { dispatch: Dispatch };
+};


### PR DESCRIPTION

### Description

Converts embed.ts to modern typescript with redux toolkit.

The only functional change should be this line: https://github.com/metabase/metabase/pull/44496/files#diff-7526f6e750a6f2338b0dd9132316659a2b6d188cf7ad21c08a068067fbf61a4bR49
Where I only put in the state the things that are supposed to be there instead of everything.
I also removed the parsing of hash parameters as according to the docs all the supported parameters are search ones

### How to verify

Everything should work as before

