### PR TITLE
Fix the order we attempt to set DW transaction isolation in [PERFORMANCE BOOST]

### DIFF
--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -238,8 +238,8 @@
   [driver ^Connection conn]
   (let [dbmeta (.getMetaData conn)]
     (loop [[[level-name ^Integer level] & more] [[:read-uncommitted Connection/TRANSACTION_READ_UNCOMMITTED]
-                                                 [:repeatable-read  Connection/TRANSACTION_REPEATABLE_READ]
-                                                 [:read-committed   Connection/TRANSACTION_READ_COMMITTED]]]
+                                                 [:read-committed   Connection/TRANSACTION_READ_COMMITTED]
+                                                 [:repeatable-read  Connection/TRANSACTION_REPEATABLE_READ]]]
       (cond
         (.supportsTransactionIsolationLevel dbmeta level)
         (do


### PR DESCRIPTION
So we're supposed to be setting transaction isolation to the lowest level the DW supports but I'm an idiot and put the list of levels to try in the wrong order, meaning if `READ_UNCOMMITED` isn't supported then we tried `REPEATABLE_READ` next instead of `READ_COMMITED`. Oops! 

This change should speed up queries a lot for DBs that support `READ_COMMITED` but not `READ_UNCOMMITED`.