### PR TITLE
Make the App DB transaction isolation level READ_COMMITTED for MySQL [MEGA PERFORMANCE BOOST]

### DIFF
--- a/test/metabase/db/connection_test.clj
+++ b/test/metabase/db/connection_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.db.connection-test
   (:require
    [clojure.test :refer :all]
+   [metabase.db.connection :as mdb.connection]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [toucan2.core :as t2]
@@ -131,3 +132,9 @@
           (catch Exception e
             (when-not (is-transaction-exception? e)
               (throw e))))))))
+
+(deftest ^:parallel transaction-isolation-level-test
+  (testing "We should always use READ_COMMITTED for the app DB (#44505)"
+    (with-open [conn (.getConnection mdb.connection/*application-db*)]
+      (is (= java.sql.Connection/TRANSACTION_READ_COMMITTED
+             (.getTransactionIsolation conn))))))

--- a/test/metabase/db/data_source_test.clj
+++ b/test/metabase/db/data_source_test.clj
@@ -12,7 +12,7 @@
 (defn- ->DataSource [s properties]
   (#'mdb.data-source/->DataSource s (some-> (not-empty properties) connection-pool/map->properties)))
 
-(deftest broken-out-details-test
+(deftest ^:parallel broken-out-details-test
   (testing :postgres
     (is (= (->DataSource
             "jdbc:postgresql://localhost:5432/metabase"
@@ -51,7 +51,7 @@
         (is (= [{:one 1}]
                (jdbc/query {:connection conn} "SELECT 1 AS one;")))))))
 
-(deftest connection-string-test
+(deftest ^:parallel connection-string-test
   (let [data-source (mdb.data-source/raw-connection-string->DataSource
                      (format "jdbc:h2:mem:%s" (mt/random-name)))]
     (with-open [conn (.getConnection data-source)]
@@ -72,7 +72,7 @@
     (is (= (mdb.data-source/raw-connection-string->DataSource "jdbc:postgresql://localhost:5432/metabase")
            (mdb.data-source/raw-connection-string->DataSource "postgres://localhost:5432/metabase")))))
 
-(deftest wonky-connection-string-test
+(deftest ^:parallel wonky-connection-string-test
   (testing "Should handle malformed user:password@host:port strings (#14678, #20121)"
     (doseq [subprotocol ["postgresql" "mysql"]]
       (testing "user AND password"
@@ -96,7 +96,7 @@
                   {"user" "cam"})
                  (mdb.data-source/raw-connection-string->DataSource (str subprotocol "://cam@localhost/metabase?password=1234")))))))))
 
-(deftest raw-connection-string-with-separate-username-and-password-test
+(deftest ^:parallel raw-connection-string-with-separate-username-and-password-test
   (testing "Raw connection string should support separate username and/or password (#20122)"
     (testing "username and password"
       (is (= (->DataSource
@@ -116,7 +116,7 @@
              (mdb.data-source/raw-connection-string->DataSource "postgres://metabase" nil "1234")
              (mdb.data-source/raw-connection-string->DataSource "postgres://metabase" "" "1234"))))))
 
-(deftest equality-test
+(deftest ^:parallel equality-test
   (testing "Two DataSources with the same URL should be equal"
     (is (= (mdb.data-source/raw-connection-string->DataSource "ABCD")
            (mdb.data-source/raw-connection-string->DataSource "ABCD"))))


### PR DESCRIPTION
On Postgres the default isolation level is `READ_COMMITTED` while it's a higher level (`REPEATABLE_READ`) for MySQL/MariaDB.

repeatable-read is more than we need or want and involves [a lot of locking](https://dev.mysql.com/doc/refman/8.0/en/innodb-transaction-isolation-levels.html) and we should change it so MySQL/MariaDB uses read-committed like Postgres does and that should speed up app DB access a lot.

I did this in the unpooled DataSource so we only get the overhead of `SET TRANSACTION ISOLATION ...` when we check out new connections. Pooled ones should already be set to the correct level.

THIS IS FOR THE APP DB AND NOT DATA WAREHOUSES!!!!!