### PR TITLE
Update Milestone Setter

### DIFF
--- a/.github/workflows/check-milestone.yml
+++ b/.github/workflows/check-milestone.yml
@@ -29,8 +29,8 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
 
-            const branchName = '${{ github.ref }}';
-            const commitMessage = '${{ github.event.head_commit.message }}';
+            const branchName = `${{ github.ref }}`;
+            const commitMessage = context?.payload?.head_commit?.message ?? '';
 
             await setMilestoneForCommits({
               github,

--- a/release/package.json
+++ b/release/package.json
@@ -27,6 +27,7 @@
     "semver": "^7.5.4",
     "tsx": "^3.12.7",
     "typescript": "^5.1.6",
+    "underscore": "^1.13.6",
     "zx": "^8.1.0"
   },
   "devDependencies": {

--- a/release/src/milestones.ts
+++ b/release/src/milestones.ts
@@ -1,3 +1,5 @@
+import _ from "underscore";
+
 import { getMilestones } from "./github";
 import { getLinkedIssues, getPRsFromCommitMessage } from "./linked-issues";
 import type { Issue, GithubProps, Milestone } from "./types";
@@ -158,8 +160,11 @@ export async function setMilestoneForCommits({
   console.log('Next milestone:', nextMilestone.title);
 
   // figure out issue or PR
-  const PRsToCheck = commitMessages.flatMap(getPRsFromCommitMessage).filter(isNotNull);
-
+  const PRsToCheck = _.uniq(
+    commitMessages
+      .flatMap(getPRsFromCommitMessage)
+      .filter(isNotNull)
+  );
   if (!PRsToCheck.length) {
     throw new Error('No PRs found in commit messages');
   }

--- a/release/yarn.lock
+++ b/release/yarn.lock
@@ -2818,6 +2818,11 @@ typescript@^5.1.6:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
   integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==
 
+underscore@^1.13.6:
+  version "1.13.6"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.6.tgz#04786a1f589dc6c09f761fc5f45b89e935136441"
+  integrity sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==
+
 undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"


### PR DESCRIPTION
- fixes the action breaking with multiline commit messages ([example](https://github.com/metabase/metabase/actions/runs/9608833262/job/26502270520#step:4:8))
- dedupes pr/issue numbers for efficiency

[test run in my fork](https://github.com/iethree/metabase/actions/runs/9610013754/job/26505603550)