### PR TITLE
docs(sdk): add demo video to the sdk readme

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/README.md
+++ b/enterprise/frontend/src/embedding-sdk/README.md
@@ -4,6 +4,14 @@
 
 The Metabase Embedding SDK for React offers a way to integrate Metabase into your application more seamlessly and with greater flexibility than using the current interactive embedding offering based on iframes.
 
+<div>
+  <a href="https://www.loom.com/share/b6998692937c4ecaab1af097f2123c6f">
+    <img style="max-width: 300px" src="https://cdn.loom.com/sessions/thumbnails/b6998692937c4ecaab1af097f2123c6f-with-play.gif">
+  </a>
+</div>
+
+[Watch a 5-minute tour of the SDK's features.](https://www.loom.com/share/b6998692937c4ecaab1af097f2123c6f)
+
 Features currently supported:
 
 - embedding questions - static


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/44485

Add a quick 5-minute tour of the embedding sdk to README.

<img src="https://github.com/metabase/metabase/assets/4714175/a5b9c438-2ada-4b3b-9a97-5dfdd0d18fba" width="400">