### PR TITLE
Revert graph settings sync change

### DIFF
--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -30,6 +30,7 @@ import {
   echartsContainer,
   newButton,
   appBar,
+  openProductsTable,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATABASE;
@@ -773,6 +774,90 @@ describe("issue 44415", () => {
     cy.get("@questionId").then(questionId => {
       cy.url().should("not.include", `/question/${questionId}`);
       cy.url().should("include", "question#");
+    });
+  });
+});
+
+describe("issue 44532", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    openProductsTable();
+  });
+
+  it("should update chart metrics and dimensions with each added breakout (metabase #44532)", () => {
+    summarize();
+
+    rightSidebar()
+      .findByRole("listitem", { name: "Category" })
+      .button("Add dimension")
+      .click();
+    cy.wait("@dataset");
+
+    echartsContainer().within(() => {
+      cy.findByText("Count").should("exist"); // y-axis
+      cy.findByText("Category").should("exist"); // x-axis
+
+      // x-axis values
+      cy.findByText("Doohickey").should("exist");
+      cy.findByText("Gadget").should("exist");
+      cy.findByText("Gizmo").should("exist");
+      cy.findByText("Widget").should("exist");
+    });
+
+    rightSidebar()
+      .findByRole("listitem", { name: "Created At" })
+      .button("Add dimension")
+      .click();
+    cy.wait("@dataset");
+
+    cy.findByLabelText("Legend").within(() => {
+      cy.findByText("Doohickey").should("exist");
+      cy.findByText("Gadget").should("exist");
+      cy.findByText("Gizmo").should("exist");
+      cy.findByText("Widget").should("exist");
+    });
+
+    echartsContainer().within(() => {
+      cy.findByText("Count").should("exist"); // y-axis
+      cy.findByText("Created At").should("exist"); // x-axis
+
+      // x-axis values
+      cy.findByText("January 2023").should("exist");
+      cy.findByText("January 2024").should("exist");
+      cy.findByText("January 2025").should("exist");
+
+      // previous x-axis values
+      cy.findByText("Doohickey").should("not.exist");
+      cy.findByText("Gadget").should("not.exist");
+      cy.findByText("Gizmo").should("not.exist");
+      cy.findByText("Widget").should("not.exist");
+    });
+
+    rightSidebar().button("Done").click();
+    cy.wait("@dataset");
+
+    cy.findByLabelText("Legend").within(() => {
+      cy.findByText("Doohickey").should("exist");
+      cy.findByText("Gadget").should("exist");
+      cy.findByText("Gizmo").should("exist");
+      cy.findByText("Widget").should("exist");
+    });
+
+    echartsContainer().within(() => {
+      cy.findByText("Count").should("exist"); // y-axis
+      cy.findByText("Created At").should("exist"); // x-axis
+
+      // x-axis values
+      cy.findByText("January 2023").should("exist");
+      cy.findByText("January 2024").should("exist");
+      cy.findByText("January 2025").should("exist");
+
+      // previous x-axis values
+      cy.findByText("Doohickey").should("not.exist");
+      cy.findByText("Gadget").should("not.exist");
+      cy.findByText("Gizmo").should("not.exist");
+      cy.findByText("Widget").should("not.exist");
     });
   });
 });

--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -636,7 +636,7 @@ describe("issue 42957", () => {
   });
 });
 
-describe("issue 10493", () => {
+describe.skip("issue 10493", () => {
   beforeEach(() => {
     restore();
     cy.intercept("POST", "/api/dataset").as("dataset");

--- a/frontend/src/metabase/visualizations/index.ts
+++ b/frontend/src/metabase/visualizations/index.ts
@@ -128,15 +128,6 @@ export function getDefaultSize(display: string) {
   return visualization?.defaultSize;
 }
 
-export function hasGraphDataSettings(display: string) {
-  const visualization = visualizations.get(display);
-  const settingDefinitions = visualization?.settings ?? {};
-  return (
-    "graph.dimensions" in settingDefinitions &&
-    "graph.metrics" in settingDefinitions
-  );
-}
-
 // removes columns with `remapped_from` property and adds a `remapping` to the appropriate column
 export const extractRemappedColumns = (data: DatasetData) => {
   const cols: RemappingHydratedDatasetColumn[] = data.cols.map(col => ({


### PR DESCRIPTION
Fixes #44532, reverts #44053, reopens #10493

> [!NOTE]
> The PR label says "no-backport", but I already opened a manual backport here: #44536
> This PR is adding a repro test to a file that doesn't exist on the `release-x.50.x` branch, so I went ahead with a manual backport

A new graph settings sync step added in #44053 caused a bug when breakouts added to a query sequentially weren't properly picked up by the chart (the first breakout would set the `graph.dimensions` and it won't get updated with next breakouts). The PR reverts the change for now, so we can come up with a more robust fix

### To verify

1. New > Question > Tables > Sample Database > Products > Visualize
2. Click "Summarize" in the top right
3. Hover the "Category" column and click the "+" button
4. Hover the "Created At" column and click the "+" button
5. Ensure you see a correct Count by Category/CreatedAt chart