### PR TITLE
Fix dev `migrate!` command

### DIFF
--- a/dev/src/dev/migrate.clj
+++ b/dev/src/dev/migrate.clj
@@ -14,7 +14,7 @@
   []
   ((juxt :id :comments)
    (t2/query-one {:select [:id :comments]
-                  :from   [:databasechangelog]
+                  :from   [(keyword (liquibase/changelog-table-name (mdb/data-source)))]
                   :order-by [[:orderexecuted :desc]]
                   :limit 1})))
 (defn migrate!
@@ -24,8 +24,7 @@
    (migrate! :up))
   ;; do we really use this in dev?
   ([direction & [version]]
-   (mdb/migrate! (mdb/db-type) (mdb/data-source)
-                 direction version)
+   (mdb/migrate! (mdb/data-source) direction version)
    #_{:clj-kondo/ignore [:discouraged-var]}
    (println "Migrated up. Latest migration:" (latest-migration))))
 


### PR DESCRIPTION
There were two problems here:

- wrong args to `mdb/migrate!` (passing the db-type as well as the data source), and

- in MySQL, the changelog table name is not `:databasechangelog`. Use `metabase.db.liquibase/changelog-table-name` to get the actual table name.