### PR TITLE
xray should not fail on models with filters

### DIFF
--- a/src/metabase/xrays/automagic_dashboards/combination.clj
+++ b/src/metabase/xrays/automagic_dashboards/combination.clj
@@ -21,6 +21,7 @@
    [clojure.walk :as walk]
    [medley.core :as m]
    [metabase.driver.util :as driver.u]
+   [metabase.models.card :as card]
    [metabase.models.interface :as mi]
    [metabase.query-processor.util :as qp.util]
    [metabase.util :as u]
@@ -78,13 +79,16 @@
    {{:keys [database]} :root :keys [source query-filter]}]
   (let [source-table (if (->> source (mi/instance-of? :model/Table))
                        (-> source u/the-id)
-                       (->> source u/the-id (str "card__")))]
+                       (->> source u/the-id (str "card__")))
+        model?       (and (mi/instance-of? :model/Card source)
+                          (card/model? source))]
     (assoc ground-metric-with-dimensions
            :dataset_query {:database database
                            :type     :query
                            :query    (cond-> (assoc metric-definition
                                                     :source-table source-table)
-                                       query-filter (assoc :filter query-filter))})))
+                                       (and (not model?)
+                                            query-filter) (assoc :filter query-filter))})))
 
 (defn- instantiate-visualization
   [[k v] dimensions metrics]


### PR DESCRIPTION
The issue: when we have a Model that has a filter *and* an aggregation, model does not contain filtered field in the end results. Our logic re-applies filters (I guess for the sake of filter tables) on x-ray cards, and this fails since you cannot filter by `created_at` if the data you have is just `id` and `count` columns.

This change skips filters for models, data is already filtered in there.

Fixes #44379 