### PR TITLE
[openapi] do not die when :query-params is not a map

### DIFF
--- a/src/metabase/api/common/openapi.clj
+++ b/src/metabase/api/common/openapi.clj
@@ -117,8 +117,9 @@
           (= :as x)   (recur (nnext args)
                              (into params (when (map? y)
                                             (let [qp (:query-params (set/map-invert y))]
-                                              ;; {c :count :keys [a b}} ; => [count a b]
-                                              (flatten (vals qp))))))
+                                              (when (map? qp)
+                                                ;; {c :count :keys [a b}} ; => [count a b]
+                                                (flatten (vals qp)))))))
           (symbol? x) (recur (next args)
                              (conj params x)))))))
 


### PR DESCRIPTION
One little bug slipped through the cracks, if you use `[:as {qps :query-params}]` we don't have that much data to work with - let's just skip for now.