### PR TITLE
Fix setting the join strategy for not yet existing join clauses

### DIFF
--- a/frontend/src/metabase-lib/join.ts
+++ b/frontend/src/metabase-lib/join.ts
@@ -40,8 +40,9 @@ export function joins(query: Query, stageIndex: number): Join[] {
 export function joinClause(
   joinable: Joinable,
   conditions: JoinCondition[],
+  strategy: JoinStrategy,
 ): Join {
-  return ML.join_clause(joinable, conditions);
+  return ML.join_clause(joinable, conditions, strategy);
 }
 
 export function joinConditionClause(

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinComplete/JoinComplete.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinComplete/JoinComplete.tsx
@@ -64,7 +64,7 @@ export function JoinComplete({
       joinPosition,
     );
     if (newConditions.length) {
-      const newJoin = Lib.joinClause(newTable, newConditions);
+      const newJoin = Lib.joinClause(newTable, newConditions, strategy);
       onJoinChange(newJoin);
     } else {
       onDraftRhsTableChange(newTable);

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinDraft/JoinDraft.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinDraft/JoinDraft.tsx
@@ -65,7 +65,7 @@ export function JoinDraft({
       newTable,
     );
     if (newConditions.length > 0) {
-      const newJoin = Lib.joinClause(newTable, newConditions);
+      const newJoin = Lib.joinClause(newTable, newConditions, strategy);
       onJoinChange(newJoin);
     } else {
       const newColumns = Lib.joinableColumns(query, stageIndex, newTable);
@@ -78,7 +78,7 @@ export function JoinDraft({
   const handleConditionChange = (newCondition: Lib.JoinCondition) => {
     if (rhsTable) {
       const newJoin = Lib.withJoinFields(
-        Lib.joinClause(rhsTable, [newCondition]),
+        Lib.joinClause(rhsTable, [newCondition], strategy),
         getJoinFields(rhsTableColumns, selectedRhsTableColumns),
       );
       onJoinChange(newJoin);

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
@@ -64,6 +64,14 @@ function getJoinQueryHelpers(query: Lib.Query) {
     Lib.joinConditionRHSColumns(query, 0, table),
   );
 
+  const defaultStrategy = Lib.availableJoinStrategies(query, 0).find(
+    strategy => Lib.displayInfo(query, 0, strategy).default,
+  );
+
+  if (!defaultStrategy) {
+    throw new Error("No default strategy found");
+  }
+
   const defaultOperator = Lib.joinConditionOperators(query, 0).find(
     operator => Lib.displayInfo(query, 0, operator).default,
   );
@@ -72,14 +80,25 @@ function getJoinQueryHelpers(query: Lib.Query) {
     throw new Error("No default operator found");
   }
 
-  return { table, defaultOperator, findLHSColumn, findRHSColumn };
+  return {
+    table,
+    defaultStrategy,
+    defaultOperator,
+    findLHSColumn,
+    findRHSColumn,
+  };
 }
 
 function getJoinedQuery() {
   const query = createQuery({ metadata });
 
-  const { table, defaultOperator, findLHSColumn, findRHSColumn } =
-    getJoinQueryHelpers(query);
+  const {
+    table,
+    defaultStrategy,
+    defaultOperator,
+    findLHSColumn,
+    findRHSColumn,
+  } = getJoinQueryHelpers(query);
 
   const ordersProductId = findLHSColumn("ORDERS", "PRODUCT_ID");
   const productsId = findRHSColumn("PRODUCTS", "ID");
@@ -93,10 +112,8 @@ function getJoinedQuery() {
     productsId,
   );
 
-  const strategy = Lib.availableJoinStrategies(query, stageIndex)[0];
-
   const join = Lib.withJoinFields(
-    Lib.joinClause(table, [condition], strategy),
+    Lib.joinClause(table, [condition], defaultStrategy),
     "all",
   );
 

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
@@ -84,17 +84,23 @@ function getJoinedQuery() {
   const ordersProductId = findLHSColumn("ORDERS", "PRODUCT_ID");
   const productsId = findRHSColumn("PRODUCTS", "ID");
 
+  const stageIndex = -1;
   const condition = Lib.joinConditionClause(
     query,
-    0,
+    stageIndex,
     defaultOperator,
     ordersProductId,
     productsId,
   );
 
-  const join = Lib.withJoinFields(Lib.joinClause(table, [condition]), "all");
+  const strategy = Lib.availableJoinStrategies(query, stageIndex)[0];
 
-  return Lib.join(query, 0, join);
+  const join = Lib.withJoinFields(
+    Lib.joinClause(table, [condition], strategy),
+    "all",
+  );
+
+  return Lib.join(query, stageIndex, join);
 }
 
 function getJoinedQueryWithMultipleConditions() {
@@ -445,36 +451,6 @@ describe("Notebook Editor > Join Step", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("should handle join strategy", async () => {
-    const { getRecentJoin } = setup(
-      createMockNotebookStep({ query: getJoinedQuery() }),
-    );
-
-    await userEvent.click(screen.getByLabelText("Change join type"));
-    let popover = await screen.findByTestId("select-list");
-    let leftJoin = within(popover).getByLabelText("Left outer join");
-    let rightJoin = within(popover).getByLabelText("Right outer join");
-
-    expect(leftJoin).toHaveAttribute("aria-selected", "true");
-    expect(rightJoin).toHaveAttribute("aria-selected", "false");
-
-    await userEvent.click(rightJoin);
-    await waitFor(() =>
-      expect(screen.queryByTestId("select-list")).not.toBeInTheDocument(),
-    );
-
-    await userEvent.click(screen.getByLabelText("Change join type"));
-    popover = await screen.findByTestId("select-list");
-    leftJoin = within(popover).getByLabelText("Left outer join");
-    rightJoin = within(popover).getByLabelText("Right outer join");
-
-    expect(leftJoin).toHaveAttribute("aria-selected", "false");
-    expect(rightJoin).toHaveAttribute("aria-selected", "true");
-
-    const { strategy } = getRecentJoin();
-    expect(strategy.shortName).toBe("right-join");
-  });
-
   it("should handle join operator", async () => {
     const { getRecentJoin } = setup(
       createMockNotebookStep({ query: getJoinedQuery() }),
@@ -503,6 +479,64 @@ describe("Notebook Editor > Join Step", () => {
 
     const [condition] = getRecentJoin().conditions;
     expect(condition.operator.shortName).toBe("!=");
+  });
+
+  describe("join strategies", () => {
+    it("should be able to change the join strategy for a new join clause", async () => {
+      const { getRecentJoin } = setup();
+
+      await userEvent.click(
+        within(screen.getByLabelText("Right table")).getByRole("button"),
+      );
+      const lhsTableModal = await screen.findByTestId("entity-picker-modal");
+      await userEvent.click(await within(lhsTableModal).findByText("Reviews"));
+
+      await userEvent.click(screen.getByLabelText("Change join type"));
+      const strategyPopover = await screen.findByTestId("select-list");
+      await userEvent.click(
+        within(strategyPopover).getByLabelText("Right outer join"),
+      );
+
+      await userEvent.click(screen.getByLabelText("Left column"));
+      const lhsColumnPopover = await screen.findByTestId("lhs-column-picker");
+      await userEvent.click(within(lhsColumnPopover).getByText("ID"));
+
+      const rhsColumnPopover = await screen.findByTestId("rhs-column-picker");
+      await userEvent.click(within(rhsColumnPopover).getByText("ID"));
+
+      const { strategy } = getRecentJoin();
+      expect(strategy.shortName).toBe("right-join");
+    });
+
+    it("should be able to change the join strategy of an existing join clause", async () => {
+      const { getRecentJoin } = setup(
+        createMockNotebookStep({ query: getJoinedQuery() }),
+      );
+
+      await userEvent.click(screen.getByLabelText("Change join type"));
+      let popover = await screen.findByTestId("select-list");
+      let leftJoin = within(popover).getByLabelText("Left outer join");
+      let rightJoin = within(popover).getByLabelText("Right outer join");
+
+      expect(leftJoin).toHaveAttribute("aria-selected", "true");
+      expect(rightJoin).toHaveAttribute("aria-selected", "false");
+
+      await userEvent.click(rightJoin);
+      await waitFor(() =>
+        expect(screen.queryByTestId("select-list")).not.toBeInTheDocument(),
+      );
+
+      await userEvent.click(screen.getByLabelText("Change join type"));
+      popover = await screen.findByTestId("select-list");
+      leftJoin = within(popover).getByLabelText("Left outer join");
+      rightJoin = within(popover).getByLabelText("Right outer join");
+
+      expect(leftJoin).toHaveAttribute("aria-selected", "false");
+      expect(rightJoin).toHaveAttribute("aria-selected", "true");
+
+      const { strategy } = getRecentJoin();
+      expect(strategy.shortName).toBe("right-join");
+    });
   });
 
   describe("join fields", () => {

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
@@ -554,6 +554,35 @@ describe("Notebook Editor > Join Step", () => {
       const { strategy } = getRecentJoin();
       expect(strategy.shortName).toBe("right-join");
     });
+
+    it("should be able to change the join strategy of an existing join clause after removing the rhs table and selecting join conditions", async () => {
+      const { getRecentJoin } = setup(
+        createMockNotebookStep({ query: getJoinedQuery() }),
+      );
+
+      await userEvent.click(screen.getByLabelText("Change join type"));
+      const strategyPopover = await screen.findByTestId("select-list");
+      await userEvent.click(
+        within(strategyPopover).getByLabelText("Right outer join"),
+      );
+
+      await userEvent.click(
+        within(screen.getByLabelText("Right table")).getByRole("button", {
+          name: /Products/,
+        }),
+      );
+      const lhsTableModal = await screen.findByTestId("entity-picker-modal");
+      await userEvent.click(await within(lhsTableModal).findByText("Reviews"));
+
+      const lhsColumnPopover = await screen.findByTestId("lhs-column-picker");
+      await userEvent.click(within(lhsColumnPopover).getByText("ID"));
+
+      const rhsColumnPopover = await screen.findByTestId("rhs-column-picker");
+      await userEvent.click(within(rhsColumnPopover).getByText("ID"));
+
+      const { strategy } = getRecentJoin();
+      expect(strategy.shortName).toBe("right-join");
+    });
   });
 
   describe("join fields", () => {

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -355,14 +355,19 @@
 
 (mu/defn join-clause :- lib.join.util/PartialJoin
   "Create an MBQL join map from something that can conceptually be joined against. A `Table`? An MBQL or native query? A
-  Saved Question? You should be able to join anything, and this should return a sensible MBQL join map."
+  Saved Question? You should be able to join anything, and this should return a sensible MBQL join map. Uses a left join
+  by default."
   ([joinable]
    (-> (join-clause-method joinable)
        (u/assoc-default :fields :all)))
 
   ([joinable conditions]
+   (join-clause joinable conditions :left-join))
+
+  ([joinable conditions strategy]
    (-> (join-clause joinable)
-       (with-join-conditions conditions))))
+       (with-join-conditions conditions)
+       (with-join-strategy strategy))))
 
 (mu/defn with-join-fields :- lib.join.util/PartialJoin
   "Update a join (or a function that will return a join) to include `:fields`, either `:all`, `:none`, or a sequence of

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -1498,12 +1498,12 @@
 
 (defn ^:export join-clause
   "Create a join clause (an `:mbql/join` map) against something `joinable` (Table metadata, a Saved Question, another
-  query, etc.) with 1 or more `conditions`, which should be an array of filter clauses. You can then adjust this join
-  clause with functions like [[with-join-fields]], or add it to a query with [[join]].
+  query, etc.) with 1 or more `conditions`, which should be an array of filter clauses, and a join strategy. You can
+  then adjust this join clause with functions like [[with-join-fields]], or add it to a query with [[join]].
 
   > **Code health:** Healthy"
-  [joinable conditions]
-  (lib.core/join-clause joinable conditions))
+  [joinable conditions strategy]
+  (lib.core/join-clause joinable conditions strategy))
 
 (defn ^:export join
   "Add `a-join`, a join clause as created by [[join-clause]], to the specified stage of `a-query`.

--- a/test/metabase/lib/join_test.cljc
+++ b/test/metabase/lib/join_test.cljc
@@ -67,6 +67,18 @@
              :lib/options {:lib/uuid string?}
              :fields      :all}
             (lib/join-clause (meta/table-metadata :orders)))))
+  (testing "Should allow specifying the join strategy when creating a join clause"
+    (is (= [:left-join :right-join :inner-join]
+           (let [query lib.tu/query-with-join
+                 product-table (meta/table-metadata :products)
+                 products-id (meta/id :products :id)
+                 orders-product-id (meta/id :orders :product-id)
+                 join-conditions [(lib/= orders-product-id products-id)]
+                 join-strategies (lib/available-join-strategies query)]
+             (into [] (comp
+                       (map #(lib/join-clause product-table join-conditions %))
+                       (map :strategy))
+                   join-strategies)))))
   (testing "source-card"
     (let [query {:lib/type :mbql/query
                  :lib/metadata lib.tu/metadata-provider-with-mock-cards


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/42858

Previously we ignored the initial join strategy set before creating a new join clause. This PR fixes the issue by:
1) allowing to pass the join strategy directly when creating a new join clause
2) making the join strategy required on the FE to make sure it's not forgotten - improving the API

How to verify:
- New -> Question -> Orders
- Join Reviews
- Without selecting columns for the join condition, change the join strategy to "Right join"
- Set the columns
- Make sure the join strategy is not ignored