### PR TITLE
Disable Pivot Export Post Processing Step

### DIFF
--- a/src/metabase/query_processor/streaming/csv.clj
+++ b/src/metabase/query_processor/streaming/csv.clj
@@ -25,6 +25,16 @@
                                                               (u.date/format (t/zoned-date-time)))}
     :write-keepalive-newlines? false}))
 
+;; As a first step towards hollistically solving this issue: https://github.com/metabase/metabase/issues/44556
+;; (which is basically that very large pivot tables can crash the export process),
+;; The post processing is disabled completely.
+;; This should remain `false` until it's fixed
+;; TODO: rework this post-processing once there's a clear way in app to enable/disable it, or to select alternate download options
+(def ^:dynamic *pivot-export-post-processing-enabled*
+  "Flag to enable/disable export post-processing of pivot tables.
+  Disabled by default and should remain disabled until Issue #44556 is resolved and a clear plan is made."
+  false)
+
 (defmethod qp.si/streaming-results-writer :csv
   [_ ^OutputStream os]
   (let [writer             (BufferedWriter. (OutputStreamWriter. os StandardCharsets/UTF_8))
@@ -34,7 +44,7 @@
     (reify qp.si/StreamingResultsWriter
       (begin! [_ {{:keys [ordered-cols results_timezone format-rows? pivot-export-options]
                    :or   {format-rows? true}} :data} viz-settings]
-        (let [opts      (when pivot-export-options
+        (let [opts      (when (and *pivot-export-post-processing-enabled* pivot-export-options)
                           (assoc pivot-export-options :column-titles (mapv :display_name ordered-cols)))
               ;; col-names are created later when exporting a pivot table, so only create them if there are no pivot options
               col-names (when-not opts (common/column-titles ordered-cols (::mb.viz/column-settings viz-settings) format-rows?))]

--- a/test/metabase/api/downloads_exports_test.clj
+++ b/test/metabase/api/downloads_exports_test.clj
@@ -15,6 +15,8 @@
    [clojure.set :as set]
    [clojure.test :refer :all]
    [dk.ative.docjure.spreadsheet :as spreadsheet]
+   [metabase.query-processor.streaming.csv :as qp.csv]
+   [metabase.query-processor.streaming.xlsx :as qp.xlsx]
    [metabase.test :as mt])
   (:import
    (org.apache.poi.xssf.usermodel XSSFSheet)))
@@ -72,76 +74,77 @@
                                                [:field "C" {:base-type :type/Text}]
                                                [:field "D" {:base-type :type/Text}]]
                                               :source-table (format "card__%s" pivot-data-card-id)}}}]
-      (let [result (->> (mt/user-http-request :crowberto :post 200 (format "card/%d/query/csv?format_rows=false" pivot-card-id))
-                        csv/read-csv)]
-        (testing "Pivot CSV Exports look like a Pivoted Table"
-          (testing "The Headers Properly indicate the pivot rows names."
-            ;; Pivot Rows Header are Simply the Column names from the rows specified in
-            ;; [:visualization_settings :pivot_table.column_split :rows]
-            (is (= [["C" "D"]
-                    ["C" "D"]]
-                   [(take 2 (first result))
-                    (take 2 (second result))])))
-          (testing "The Headers Properly indicate the pivot column names."
-            (let [[header1 header2]  (map set (take 2 result))
-                  possible-vals-of-a #{"AA" "AB" "AC" "AD"}
-                  possible-vals-of-b #{"BA" "BB" "BC" "BD"}]
-              ;; In a Pivot Table, the Column headers are derived from the Possible Values in each Pivot Column
-              ;; Since the test data used here has defined 2 Pivot Columns, there must be 2 Header rows
-              ;; to fully capture all of the combinations of possible values for each pivot-col specified in
-              ;; [:visualization_settings :pivot_table.column_split :columns]
-              ;; To hopefully illustrate a bit, Let's consider that:
-              ;; Cat A can have "AA" "AB" "AC" "AD"
-              ;; Cat B can have "BA" "BB" "BC" "BD"
-              ;; The first 4 Entries in Header 1 (excluding the Pivot Rows Display Names) will all be "AA"
-              ;; And the first 4 Entries in Header 2 will be "BA" "BB" "BC" "BD"
-              (is (= [["AA" "AA" "AA" "AA"]
-                      ["BA" "BB" "BC" "BD"]]
-                     [(take 4 (drop 2 (first result)))
-                      (take 4 (drop 2 (second result)))]))
-              ;; This combination logic would continue for each specified Pivot Column, but we'll just stick with testing 2
-              ;; To keep things relatively easy to read and understand.
-              (testing "The first Header only contains possible values from the first specified pivot column"
-                (is (set/subset? possible-vals-of-a header1))
-                (is (not (set/subset? possible-vals-of-b header1))))
-              (testing "The second Header only contains possible values from the second specified pivot column"
-                (is (set/subset? possible-vals-of-b header2))
-                (is (not (set/subset? possible-vals-of-a header2))))
-              (testing "The Headers also show the Row Totals header"
-                (is (= ["Row totals"
-                        "Row totals"]
-                       (map last (take 2 result))))))))
+      (binding [qp.csv/*pivot-export-post-processing-enabled* true]
+        (let [result (->> (mt/user-http-request :crowberto :post 200 (format "card/%d/query/csv?format_rows=false" pivot-card-id))
+                          csv/read-csv)]
+          (testing "Pivot CSV Exports look like a Pivoted Table"
+            (testing "The Headers Properly indicate the pivot rows names."
+              ;; Pivot Rows Header are Simply the Column names from the rows specified in
+              ;; [:visualization_settings :pivot_table.column_split :rows]
+              (is (= [["C" "D"]
+                      ["C" "D"]]
+                     [(take 2 (first result))
+                      (take 2 (second result))])))
+            (testing "The Headers Properly indicate the pivot column names."
+              (let [[header1 header2]  (map set (take 2 result))
+                    possible-vals-of-a #{"AA" "AB" "AC" "AD"}
+                    possible-vals-of-b #{"BA" "BB" "BC" "BD"}]
+                ;; In a Pivot Table, the Column headers are derived from the Possible Values in each Pivot Column
+                ;; Since the test data used here has defined 2 Pivot Columns, there must be 2 Header rows
+                ;; to fully capture all of the combinations of possible values for each pivot-col specified in
+                ;; [:visualization_settings :pivot_table.column_split :columns]
+                ;; To hopefully illustrate a bit, Let's consider that:
+                ;; Cat A can have "AA" "AB" "AC" "AD"
+                ;; Cat B can have "BA" "BB" "BC" "BD"
+                ;; The first 4 Entries in Header 1 (excluding the Pivot Rows Display Names) will all be "AA"
+                ;; And the first 4 Entries in Header 2 will be "BA" "BB" "BC" "BD"
+                (is (= [["AA" "AA" "AA" "AA"]
+                        ["BA" "BB" "BC" "BD"]]
+                       [(take 4 (drop 2 (first result)))
+                        (take 4 (drop 2 (second result)))]))
+                ;; This combination logic would continue for each specified Pivot Column, but we'll just stick with testing 2
+                ;; To keep things relatively easy to read and understand.
+                (testing "The first Header only contains possible values from the first specified pivot column"
+                  (is (set/subset? possible-vals-of-a header1))
+                  (is (not (set/subset? possible-vals-of-b header1))))
+                (testing "The second Header only contains possible values from the second specified pivot column"
+                  (is (set/subset? possible-vals-of-b header2))
+                  (is (not (set/subset? possible-vals-of-a header2))))
+                (testing "The Headers also show the Row Totals header"
+                  (is (= ["Row totals"
+                          "Row totals"]
+                         (map last (take 2 result))))))))
 
-        (testing "The Columns Properly indicate the pivot row names."
-          (let [col1               (map first result)
-                col2               (map second result)
-                possible-vals-of-c #{"CA" "CB" "CC" "CD"}
-                possible-vals-of-d #{"DA" "DB" "DC" "DD"}]
-            ;; In a Pivot Table, the Row headers (the first columns in the result)
-            ;; are derived from the Possible Values in each Pivot Row
-            ;; Since the test data used here has defined 2 Pivot Rows, there are 2 Row Header columns
-            ;; to fully capture all of the combinations of possible values for each pivot-row specified in
-            ;; [:visualization_settings :pivot_table.column_split :rows]
-            ;; To hopefully illustrate a bit, Let's consider that:
-            ;; Cat C can have "CA" "CB" "CC" "CD"
-            ;; Cat D can have "DA" "DB" "DC" "DD"
-            ;; The first 4 Entries in col1 (excluding the Pivot Rows Display Names) will all be "CA"
-            ;; And the first 4 Entries in col2 will be "DA" "DB" "DC" "DD"
-            (is (= [["CA" "CA" "CA" "CA"]
-                    ["DA" "DB" "DC" "DD"]]
-                   [(take 4 (drop 2 col1))
-                    (take 4 (drop 2 col2))]))
-            ;; This combination logic would continue for each specified Pivot Row, but we'll just stick with testing 2
-            ;; To keep things relatively easy to read and understand.
-            (testing "The first Column only contains possible values from the first specified pivot row"
-              (is (set/subset? possible-vals-of-c (set col1)))
-              (is (not (set/subset? possible-vals-of-d (set col1)))))
-            (testing "The second Column only contains possible values from the second specified pivot row"
-              (is (set/subset? possible-vals-of-d (set col2)))
-              (is (not (set/subset? possible-vals-of-c (set col2)))))
-            (testing "The 1st Column also shows the Grand Total"
-              (is (= "Grand Totals"
-                     (first (last result)))))))))))
+          (testing "The Columns Properly indicate the pivot row names."
+            (let [col1               (map first result)
+                  col2               (map second result)
+                  possible-vals-of-c #{"CA" "CB" "CC" "CD"}
+                  possible-vals-of-d #{"DA" "DB" "DC" "DD"}]
+              ;; In a Pivot Table, the Row headers (the first columns in the result)
+              ;; are derived from the Possible Values in each Pivot Row
+              ;; Since the test data used here has defined 2 Pivot Rows, there are 2 Row Header columns
+              ;; to fully capture all of the combinations of possible values for each pivot-row specified in
+              ;; [:visualization_settings :pivot_table.column_split :rows]
+              ;; To hopefully illustrate a bit, Let's consider that:
+              ;; Cat C can have "CA" "CB" "CC" "CD"
+              ;; Cat D can have "DA" "DB" "DC" "DD"
+              ;; The first 4 Entries in col1 (excluding the Pivot Rows Display Names) will all be "CA"
+              ;; And the first 4 Entries in col2 will be "DA" "DB" "DC" "DD"
+              (is (= [["CA" "CA" "CA" "CA"]
+                      ["DA" "DB" "DC" "DD"]]
+                     [(take 4 (drop 2 col1))
+                      (take 4 (drop 2 col2))]))
+              ;; This combination logic would continue for each specified Pivot Row, but we'll just stick with testing 2
+              ;; To keep things relatively easy to read and understand.
+              (testing "The first Column only contains possible values from the first specified pivot row"
+                (is (set/subset? possible-vals-of-c (set col1)))
+                (is (not (set/subset? possible-vals-of-d (set col1)))))
+              (testing "The second Column only contains possible values from the second specified pivot row"
+                (is (set/subset? possible-vals-of-d (set col2)))
+                (is (not (set/subset? possible-vals-of-c (set col2)))))
+              (testing "The 1st Column also shows the Grand Total"
+                (is (= "Grand Totals"
+                       (first (last result))))))))))))
 
 (deftest multi-measure-pivot-tables-headers-test
   (testing "Pivot tables with multiple measures correctly include the measure titles in the final header row."
@@ -161,22 +164,22 @@
                                                                [:avg [:field (mt/id :products :rating) {:base-type :type/Float}]]],
                                                 :breakout     [[:field (mt/id :products :category) {:base-type :type/Text}]
                                                                [:field (mt/id :products :created_at) {:base-type :type/DateTime, :temporal-unit :month}]]}}}]
-        (let [result (->> (mt/user-http-request :crowberto :post 200 (format "card/%d/query/csv?format_rows=false" pivot-card-id))
-                          csv/read-csv)]
-          (is (= [["Created At" "Doohickey" "Doohickey" "Gadget" "Gadget" "Gizmo" "Gizmo" "Widget" "Widget" "Row totals" "Row totals"]
-                  ["Created At"
-                   "Sum of Price"
-                   "Average of Rating"
-                   "Sum of Price"
-                   "Average of Rating"
-                   "Sum of Price"
-                   "Average of Rating"
-                   "Sum of Price"
-                   "Average of Rating"
-                   "Sum of Price"
-                   "Average of Rating"]]
-               (take 2 result))))))))
-
+        (binding [qp.csv/*pivot-export-post-processing-enabled* true]
+          (let [result (->> (mt/user-http-request :crowberto :post 200 (format "card/%d/query/csv?format_rows=false" pivot-card-id))
+                            csv/read-csv)]
+            (is (= [["Created At" "Doohickey" "Doohickey" "Gadget" "Gadget" "Gizmo" "Gizmo" "Widget" "Widget" "Row totals" "Row totals"]
+                    ["Created At"
+                     "Sum of Price"
+                     "Average of Rating"
+                     "Sum of Price"
+                     "Average of Rating"
+                     "Sum of Price"
+                     "Average of Rating"
+                     "Sum of Price"
+                     "Average of Rating"
+                     "Sum of Price"
+                     "Average of Rating"]]
+                   (take 2 result)))))))))
 
 (deftest ^:parallel zero-column-pivot-tables-test
   (testing "Pivot tables with zero columns download correctly."
@@ -195,15 +198,16 @@
                                                 :aggregation  [[:sum [:field (mt/id :products :price) {:base-type :type/Float}]]]
                                                 :breakout     [[:field (mt/id :products :category) {:base-type :type/Text}]
                                                                [:field (mt/id :products :created_at) {:base-type :type/DateTime :temporal-unit :month}]]}}}]
-        (let [result (->> (mt/user-http-request :crowberto :post 200 (format "card/%d/query/csv?format_rows=false" pivot-card-id))
-                          csv/read-csv)]
-          (is (= [["Created At" "Category" "Sum of Price"]
-                  ["2016-05-01T00:00:00Z" "Doohickey" "144.12"]
-                  ["2016-05-01T00:00:00Z" "Gadget" "81.58"]
-                  ["2016-05-01T00:00:00Z" "Gizmo" "75.09"]
-                  ["2016-05-01T00:00:00Z" "Widget" "90.21"]
-                  ["Totals for 2016-05-01T00:00:00Z" "" "391"]]
-                 (take 6 result))))))))
+        (binding [qp.csv/*pivot-export-post-processing-enabled* true]
+          (let [result (->> (mt/user-http-request :crowberto :post 200 (format "card/%d/query/csv?format_rows=false" pivot-card-id))
+                            csv/read-csv)]
+            (is (= [["Created At" "Category" "Sum of Price"]
+                    ["2016-05-01T00:00:00Z" "Doohickey" "144.12"]
+                    ["2016-05-01T00:00:00Z" "Gadget" "81.58"]
+                    ["2016-05-01T00:00:00Z" "Gizmo" "75.09"]
+                    ["2016-05-01T00:00:00Z" "Widget" "90.21"]
+                    ["Totals for 2016-05-01T00:00:00Z" "" "391"]]
+                   (take 6 result)))))))))
 
 (deftest ^:parallel zero-row-pivot-tables-test
   (testing "Pivot tables with zero rows download correctly."
@@ -220,11 +224,12 @@
                                                {:source-table (mt/id :products)
                                                 :aggregation  [[:sum [:field (mt/id :products :price) {:base-type :type/Float}]]]
                                                 :breakout     [[:field (mt/id :products :category) {:base-type :type/Text}]]}}}]
-        (let [result (->> (mt/user-http-request :crowberto :post 200 (format "card/%d/query/csv?format_rows=false" pivot-card-id))
-                          csv/read-csv)]
-          (is (= [["Category" "Doohickey" "Gadget" "Gizmo" "Widget" "Row totals"]
-                  ["Grand Totals" "2185.89" "3019.2" "2834.88" "3109.31" "11149.28"]]
-                 result)))))))
+        (binding [qp.csv/*pivot-export-post-processing-enabled* true]
+          (let [result (->> (mt/user-http-request :crowberto :post 200 (format "card/%d/query/csv?format_rows=false" pivot-card-id))
+                            csv/read-csv)]
+            (is (= [["Category" "Doohickey" "Gadget" "Gizmo" "Widget" "Row totals"]
+                    ["Grand Totals" "2185.89" "3019.2" "2834.88" "3109.31" "11149.28"]]
+                   result))))))))
 
 (deftest ^:parallel zero-column-multiple-meausres-pivot-tables-test
   (testing "Pivot tables with zero columns and multiple measures download correctly."
@@ -244,31 +249,32 @@
                                                                [:sum [:field (mt/id :products :price) {:base-type :type/Float}]]]
                                                 :breakout     [[:field (mt/id :products :category) {:base-type :type/Text}]
                                                                [:field (mt/id :products :created_at) {:base-type :type/DateTime :temporal-unit :year}]]}}}]
-        (let [result (->> (mt/user-http-request :crowberto :post 200 (format "card/%d/query/csv?format_rows=false" pivot-card-id))
-                          csv/read-csv)]
-          (is (= [["Created At" "Category" "Sum of Price" "Sum of Price"]
-                  ["2016-01-01T00:00:00Z" "Doohickey" "632.14" "632.14"]
-                  ["2016-01-01T00:00:00Z" "Gadget" "679.83" "679.83"]
-                  ["2016-01-01T00:00:00Z" "Gizmo" "529.7" "529.7"]
-                  ["2016-01-01T00:00:00Z" "Widget" "987.39" "987.39"]
-                  ["Totals for 2016-01-01T00:00:00Z" "" "2829.06" "2829.06"]
-                  ["2017-01-01T00:00:00Z" "Doohickey" "854.19" "854.19"]
-                  ["2017-01-01T00:00:00Z" "Gadget" "1059.11" "1059.11"]
-                  ["2017-01-01T00:00:00Z" "Gizmo" "1080.18" "1080.18"]
-                  ["2017-01-01T00:00:00Z" "Widget" "1014.68" "1014.68"]
-                  ["Totals for 2017-01-01T00:00:00Z" "" "4008.16" "4008.16"]
-                  ["2018-01-01T00:00:00Z" "Doohickey" "496.43" "496.43"]
-                  ["2018-01-01T00:00:00Z" "Gadget" "844.51" "844.51"]
-                  ["2018-01-01T00:00:00Z" "Gizmo" "997.94" "997.94"]
-                  ["2018-01-01T00:00:00Z" "Widget" "912.2" "912.2"]
-                  ["Totals for 2018-01-01T00:00:00Z" "" "3251.08" "3251.08"]
-                  ["2019-01-01T00:00:00Z" "Doohickey" "203.13" "203.13"]
-                  ["2019-01-01T00:00:00Z" "Gadget" "435.75" "435.75"]
-                  ["2019-01-01T00:00:00Z" "Gizmo" "227.06" "227.06"]
-                  ["2019-01-01T00:00:00Z" "Widget" "195.04" "195.04"]
-                  ["Totals for 2019-01-01T00:00:00Z" "" "1060.98" "1060.98"]
-                  ["Grand Totals" "" "11149.28" "11149.28"]]
-                 result)))))))
+        (binding [qp.csv/*pivot-export-post-processing-enabled* true]
+          (let [result (->> (mt/user-http-request :crowberto :post 200 (format "card/%d/query/csv?format_rows=false" pivot-card-id))
+                            csv/read-csv)]
+            (is (= [["Created At" "Category" "Sum of Price" "Sum of Price"]
+                    ["2016-01-01T00:00:00Z" "Doohickey" "632.14" "632.14"]
+                    ["2016-01-01T00:00:00Z" "Gadget" "679.83" "679.83"]
+                    ["2016-01-01T00:00:00Z" "Gizmo" "529.7" "529.7"]
+                    ["2016-01-01T00:00:00Z" "Widget" "987.39" "987.39"]
+                    ["Totals for 2016-01-01T00:00:00Z" "" "2829.06" "2829.06"]
+                    ["2017-01-01T00:00:00Z" "Doohickey" "854.19" "854.19"]
+                    ["2017-01-01T00:00:00Z" "Gadget" "1059.11" "1059.11"]
+                    ["2017-01-01T00:00:00Z" "Gizmo" "1080.18" "1080.18"]
+                    ["2017-01-01T00:00:00Z" "Widget" "1014.68" "1014.68"]
+                    ["Totals for 2017-01-01T00:00:00Z" "" "4008.16" "4008.16"]
+                    ["2018-01-01T00:00:00Z" "Doohickey" "496.43" "496.43"]
+                    ["2018-01-01T00:00:00Z" "Gadget" "844.51" "844.51"]
+                    ["2018-01-01T00:00:00Z" "Gizmo" "997.94" "997.94"]
+                    ["2018-01-01T00:00:00Z" "Widget" "912.2" "912.2"]
+                    ["Totals for 2018-01-01T00:00:00Z" "" "3251.08" "3251.08"]
+                    ["2019-01-01T00:00:00Z" "Doohickey" "203.13" "203.13"]
+                    ["2019-01-01T00:00:00Z" "Gadget" "435.75" "435.75"]
+                    ["2019-01-01T00:00:00Z" "Gizmo" "227.06" "227.06"]
+                    ["2019-01-01T00:00:00Z" "Widget" "195.04" "195.04"]
+                    ["Totals for 2019-01-01T00:00:00Z" "" "1060.98" "1060.98"]
+                    ["Grand Totals" "" "11149.28" "11149.28"]]
+                   result))))))))
 
 (deftest pivot-table-native-pivot-in-xlsx-test
   (testing "Pivot table xlsx downloads produce a 'native pivot' in the workbook."
@@ -288,12 +294,13 @@
                                                                [:avg [:field (mt/id :products :rating) {:base-type :type/Float}]]]
                                                 :breakout     [[:field (mt/id :products :category) {:base-type :type/Text}]
                                                                [:field (mt/id :products :created_at) {:base-type :type/DateTime :temporal-unit :month}]]}}}]
-        (let [result (mt/user-http-request :crowberto :post 200 (format "card/%d/query/xlsx?format_rows=false" pivot-card-id))
-              pivot  (with-open [in (io/input-stream result)]
-                       (->> (spreadsheet/load-workbook in)
-                            (spreadsheet/select-sheet "pivot")
-                            ((fn [s] (.getPivotTables ^XSSFSheet s)))))]
-          (is (not (nil? pivot))))))))
+        (binding [qp.xlsx/*pivot-export-post-processing-enabled* true]
+          (let [result (mt/user-http-request :crowberto :post 200 (format "card/%d/query/xlsx?format_rows=false" pivot-card-id))
+                pivot  (with-open [in (io/input-stream result)]
+                         (->> (spreadsheet/load-workbook in)
+                              (spreadsheet/select-sheet "pivot")
+                              ((fn [s] (.getPivotTables ^XSSFSheet s)))))]
+            (is (not (nil? pivot)))))))))
 
 (deftest ^:parallel zero-column-native-pivot-tables-test
   (testing "Pivot tables with zero columns download correctly as xlsx."
@@ -312,23 +319,24 @@
                                                 :aggregation  [[:sum [:field (mt/id :products :price) {:base-type :type/Float}]]]
                                                 :breakout     [[:field (mt/id :products :category) {:base-type :type/Text}]
                                                                [:field (mt/id :products :created_at) {:base-type :type/DateTime :temporal-unit :month}]]}}}]
-        (let [result       (mt/user-http-request :crowberto :post 200 (format "card/%d/query/xlsx?format_rows=false" pivot-card-id))
-              [pivot data] (with-open [in (io/input-stream result)]
-                             (let [wb    (spreadsheet/load-workbook in)
-                                   pivot (.getPivotTables ^XSSFSheet (spreadsheet/select-sheet "pivot" wb))
-                                   data  (->> (spreadsheet/select-sheet "data" wb)
-                                              spreadsheet/row-seq
-                                              (mapv (fn [row] (->> (spreadsheet/cell-seq row)
-                                                                   (mapv spreadsheet/read-cell)))))]
-                               [pivot data]))]
-          (is (not (nil? pivot)))
-          (is (= [["Category" "Created At" "Sum of Price"]
-                  ["Doohickey" #inst "2016-05-01T00:00:00.000-00:00" 144.12]
-                  ["Doohickey" #inst "2016-06-01T00:00:00.000-00:00" 82.92]
-                  ["Doohickey" #inst "2016-07-01T00:00:00.000-00:00" 78.22]
-                  ["Doohickey" #inst "2016-08-01T00:00:00.000-00:00" 71.09]
-                  ["Doohickey" #inst "2016-09-01T00:00:00.000-00:00" 45.65]]
-                 (take 6 data))))))))
+        (binding [qp.xlsx/*pivot-export-post-processing-enabled* true]
+          (let [result       (mt/user-http-request :crowberto :post 200 (format "card/%d/query/xlsx?format_rows=false" pivot-card-id))
+                [pivot data] (with-open [in (io/input-stream result)]
+                               (let [wb    (spreadsheet/load-workbook in)
+                                     pivot (.getPivotTables ^XSSFSheet (spreadsheet/select-sheet "pivot" wb))
+                                     data  (->> (spreadsheet/select-sheet "data" wb)
+                                                spreadsheet/row-seq
+                                                (mapv (fn [row] (->> (spreadsheet/cell-seq row)
+                                                                     (mapv spreadsheet/read-cell)))))]
+                                 [pivot data]))]
+            (is (not (nil? pivot)))
+            (is (= [["Category" "Created At" "Sum of Price"]
+                    ["Doohickey" #inst "2016-05-01T00:00:00.000-00:00" 144.12]
+                    ["Doohickey" #inst "2016-06-01T00:00:00.000-00:00" 82.92]
+                    ["Doohickey" #inst "2016-07-01T00:00:00.000-00:00" 78.22]
+                    ["Doohickey" #inst "2016-08-01T00:00:00.000-00:00" 71.09]
+                    ["Doohickey" #inst "2016-09-01T00:00:00.000-00:00" 45.65]]
+                   (take 6 data)))))))))
 
 (deftest ^:parallel zero-row-native-pivot-tables-test
   (testing "Pivot tables with zero rows download correctly as xlsx."
@@ -345,19 +353,77 @@
                                                {:source-table (mt/id :products)
                                                 :aggregation  [[:sum [:field (mt/id :products :price) {:base-type :type/Float}]]]
                                                 :breakout     [[:field (mt/id :products :category) {:base-type :type/Text}]]}}}]
-        (let [result       (mt/user-http-request :crowberto :post 200 (format "card/%d/query/xlsx?format_rows=false" pivot-card-id))
-              [pivot data] (with-open [in (io/input-stream result)]
-                             (let [wb    (spreadsheet/load-workbook in)
-                                   pivot (.getPivotTables ^XSSFSheet (spreadsheet/select-sheet "pivot" wb))
-                                   data  (->> (spreadsheet/select-sheet "data" wb)
-                                              spreadsheet/row-seq
-                                              (mapv (fn [row] (->> (spreadsheet/cell-seq row)
-                                                                   (mapv spreadsheet/read-cell)))))]
-                               [pivot data]))]
-          (is (not (nil? pivot)))
-          (is (= [["Category" "Sum of Price"]
-                  ["Doohickey" 2185.89]
-                  ["Gadget" 3019.2]
-                  ["Gizmo" 2834.88]
-                  ["Widget" 3109.31]]
-                 (take 6 data))))))))
+        (binding [qp.xlsx/*pivot-export-post-processing-enabled* true]
+          (let [result       (mt/user-http-request :crowberto :post 200 (format "card/%d/query/xlsx?format_rows=false" pivot-card-id))
+                [pivot data] (with-open [in (io/input-stream result)]
+                               (let [wb    (spreadsheet/load-workbook in)
+                                     pivot (.getPivotTables ^XSSFSheet (spreadsheet/select-sheet "pivot" wb))
+                                     data  (->> (spreadsheet/select-sheet "data" wb)
+                                                spreadsheet/row-seq
+                                                (mapv (fn [row] (->> (spreadsheet/cell-seq row)
+                                                                     (mapv spreadsheet/read-cell)))))]
+                                 [pivot data]))]
+            (is (not (nil? pivot)))
+            (is (= [["Category" "Sum of Price"]
+                    ["Doohickey" 2185.89]
+                    ["Gadget" 3019.2]
+                    ["Gizmo" 2834.88]
+                    ["Widget" 3109.31]]
+                   (take 6 data)))))))))
+
+(deftest ^:parallel pivot-table-exports-respect-dynamic-var-setting
+  (testing "Pivot tables will export the 'classic' way by default for."
+    (testing "for csv"
+      (mt/dataset test-data
+        (mt/with-temp [:model/Card {pivot-card-id :id}
+                       {:display                :pivot
+                        :visualization_settings {:pivot_table.column_split
+                                                 {:rows    [[:field (mt/id :products :created_at) {:base-type :type/DateTime :temporal-unit :month}]
+                                                            [:field (mt/id :products :category) {:base-type :type/Text}]]
+                                                  :columns []
+                                                  :values  [[:aggregation 0]]}}
+                        :dataset_query          {:database (mt/id)
+                                                 :type     :query
+                                                 :query
+                                                 {:source-table (mt/id :products)
+                                                  :aggregation  [[:sum [:field (mt/id :products :price) {:base-type :type/Float}]]]
+                                                  :breakout     [[:field (mt/id :products :category) {:base-type :type/Text}]
+                                                                 [:field (mt/id :products :created_at) {:base-type :type/DateTime :temporal-unit :month}]]}}}]
+          (let [result (->> (mt/user-http-request :crowberto :post 200 (format "card/%d/query/csv?format_rows=false" pivot-card-id))
+                            csv/read-csv)]
+            (is (= [["Category" "Created At" "pivot-grouping" "Sum of Price"]
+                    ["Doohickey" "2016-05-01T00:00:00Z" "0" "144.12"]
+                    ["Doohickey" "2016-06-01T00:00:00Z" "0" "82.92"]
+                    ["Doohickey" "2016-07-01T00:00:00Z" "0" "78.22"]
+                    ["Doohickey" "2016-08-01T00:00:00Z" "0" "71.09"]
+                    ["Doohickey" "2016-09-01T00:00:00Z" "0" "45.65"]]
+                   (take 6 result)))))))
+    (testing "for xlsx"
+      (mt/dataset test-data
+        (mt/with-temp [:model/Card {pivot-card-id :id}
+                       {:display                :pivot
+                        :visualization_settings {:pivot_table.column_split
+                                                 {:rows    []
+                                                  :columns [[:field (mt/id :products :category) {:base-type :type/Text}]]
+                                                  :values  [[:aggregation 0]]}}
+                        :dataset_query          {:database (mt/id)
+                                                 :type     :query
+                                                 :query
+                                                 {:source-table (mt/id :products)
+                                                  :aggregation  [[:sum [:field (mt/id :products :price) {:base-type :type/Float}]]]
+                                                  :breakout     [[:field (mt/id :products :category) {:base-type :type/Text}]]}}}]
+          (let [result (mt/user-http-request :crowberto :post 200 (format "card/%d/query/xlsx?format_rows=false" pivot-card-id))
+                data   (with-open [in (io/input-stream result)]
+                         (let [wb   (spreadsheet/load-workbook in)
+                               data (->> (spreadsheet/select-sheet "Query result" wb)
+                                         spreadsheet/row-seq
+                                         (mapv (fn [row] (->> (spreadsheet/cell-seq row)
+                                                              (mapv spreadsheet/read-cell)))))]
+                           data))]
+            (is (= [["Category" "pivot-grouping" "Sum of Price"]
+                    ["Doohickey" 0.0 2185.89]
+                    ["Gadget" 0.0 3019.2]
+                    ["Gizmo" 0.0 2834.88]
+                    ["Widget" 0.0 3109.31]
+                    [nil 1.0 11149.28]]
+                 (take 6 data)))))))))


### PR DESCRIPTION
This PR disables the 'make exports look pivoted' post processing step for csv and xlsx exports.

This is in response to a reported issue that Large Pivot Table downloads are failing entirely: #44556

A more hollistic fix and improvement to the post processing feature will be worked on, so the post processing code is left untouched in this PR.

The dynamic vars in the csv and xlsx namespaces each default `false` and disable the export from running any post processing. The var should remain `false` until we've got a plan for these types of exports, and there is no way for users (either through ENV or UI) to change this, so the feature is effectively disabled.
