### PR TITLE
Fix setting the temporal bucket of columns in a join condition to "Don't bin"

### DIFF
--- a/frontend/src/metabase-lib/join.ts
+++ b/frontend/src/metabase-lib/join.ts
@@ -117,7 +117,7 @@ export function joinConditionUpdateTemporalBucketing(
   query: Query,
   stageIndex: number,
   condition: JoinCondition,
-  bucket: Bucket,
+  bucket: Bucket | null,
 ): JoinCondition {
   return ML.join_condition_update_temporal_bucketing(
     query,

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinCondition/JoinCondition.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinCondition/JoinCondition.tsx
@@ -6,7 +6,7 @@ import * as Lib from "metabase-lib";
 import { JoinConditionColumnPicker } from "../JoinConditionColumnPicker";
 import { JoinConditionOperatorPicker } from "../JoinConditionOperatorPicker";
 import { JoinConditionRemoveButton } from "../JoinConditionRemoveButton";
-import { maybeSyncTemporalBucket } from "../utils";
+import { updateTemporalBucketing } from "../utils";
 
 import { JoinConditionRoot } from "./JoinCondition.styled";
 
@@ -53,9 +53,7 @@ export function JoinCondition({
   const syncTemporalBucket = (
     condition: Lib.JoinCondition,
     newColumn: Lib.ColumnMetadata,
-    oldColumn: Lib.ColumnMetadata,
-  ) =>
-    maybeSyncTemporalBucket(query, stageIndex, condition, newColumn, oldColumn);
+  ) => updateTemporalBucketing(query, stageIndex, condition, [newColumn]);
 
   const handleOperatorChange = (newOperator: Lib.JoinConditionOperator) => {
     const newCondition = createCondition(newOperator, lhsColumn, rhsColumn);
@@ -64,12 +62,12 @@ export function JoinCondition({
 
   const handleLhsColumnChange = (newLhsColumn: Lib.ColumnMetadata) => {
     const newCondition = createCondition(operator, newLhsColumn, rhsColumn);
-    onChange(syncTemporalBucket(newCondition, newLhsColumn, rhsColumn));
+    onChange(syncTemporalBucket(newCondition, newLhsColumn));
   };
 
   const handleRhsColumnChange = (newRhsColumn: Lib.ColumnMetadata) => {
     const newCondition = createCondition(operator, lhsColumn, newRhsColumn);
-    onChange(syncTemporalBucket(newCondition, newRhsColumn, lhsColumn));
+    onChange(syncTemporalBucket(newCondition, newRhsColumn));
   };
 
   return (

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionDraft/JoinConditionDraft.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionDraft/JoinConditionDraft.tsx
@@ -6,7 +6,7 @@ import * as Lib from "metabase-lib";
 import { JoinConditionColumnPicker } from "../JoinConditionColumnPicker";
 import { JoinConditionOperatorPicker } from "../JoinConditionOperatorPicker";
 import { JoinConditionRemoveButton } from "../JoinConditionRemoveButton";
-import { maybeSyncTemporalBucket } from "../utils";
+import { updateTemporalBucketing } from "../utils";
 
 import { JoinConditionRoot } from "./JoinConditionDraft.styled";
 import { getDefaultJoinConditionOperator } from "./utils";
@@ -49,7 +49,7 @@ export function JoinConditionDraft({
     rhsColumn: Lib.ColumnMetadata | undefined,
   ) => {
     if (lhsColumn != null && rhsColumn != null) {
-      const newCondition = maybeSyncTemporalBucket(
+      const newCondition = updateTemporalBucketing(
         query,
         stageIndex,
         Lib.joinConditionClause(
@@ -59,8 +59,7 @@ export function JoinConditionDraft({
           lhsColumn,
           rhsColumn,
         ),
-        lhsColumn,
-        rhsColumn,
+        [lhsColumn, rhsColumn],
       );
       onChange(newCondition);
     }

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
@@ -824,6 +824,33 @@ describe("Notebook Editor > Join Step", () => {
   });
 
   describe("temporal bucket sync", () => {
+    it("should allow removing temporal bucketing from a new join condition", async () => {
+      const { getRecentJoin } = setup(createMockNotebookStep());
+
+      const lhsTableModal = await screen.findByTestId("entity-picker-modal");
+      await userEvent.click(await within(lhsTableModal).findByText("Reviews"));
+
+      const lhsColumnPicker = await screen.findByTestId("lhs-column-picker");
+      await userEvent.click(within(lhsColumnPicker).getByText("by month"));
+      const lhsBucketPicker = await screen.findByTestId("select-list");
+      await userEvent.click(screen.getByText("More…"));
+      await userEvent.click(within(lhsBucketPicker).getByText("Don't bin"));
+
+      const rhsColumnPicker = await screen.findByTestId("rhs-column-picker");
+      await userEvent.click(within(rhsColumnPicker).getByText("by month"));
+      const rhsBucketPicker = await screen.findByTestId("select-list");
+      await userEvent.click(screen.getByText("More…"));
+      await userEvent.click(within(rhsBucketPicker).getByText("Don't bin"));
+
+      const { conditions } = getRecentJoin();
+      const [condition] = conditions;
+
+      expect(condition.lhsColumn.longDisplayName).toBe("Created At");
+      expect(condition.rhsColumn.longDisplayName).toBe(
+        "Reviews - Created At → Created At",
+      );
+    });
+
     it("should allow removing temporal bucketing from an existing join condition", async () => {
       const { getRecentJoin } = setup(
         createMockNotebookStep({ query: getJoinedQuery() }),

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
@@ -823,6 +823,35 @@ describe("Notebook Editor > Join Step", () => {
     });
   });
 
+  describe("temporal bucket sync", () => {
+    it("should allow removing temporal bucketing from an existing join condition", async () => {
+      const { getRecentJoin } = setup(
+        createMockNotebookStep({ query: getJoinedQuery() }),
+      );
+
+      await userEvent.click(screen.getByLabelText("Left column"));
+
+      const lhsColumnPicker = await screen.findByTestId("lhs-column-picker");
+      await userEvent.click(within(lhsColumnPicker).getByText("by month"));
+      const lhsBucketPicker = await screen.findByTestId("select-list");
+      await userEvent.click(screen.getByText("More…"));
+      await userEvent.click(within(lhsBucketPicker).getByText("Don't bin"));
+
+      await userEvent.click(screen.getByLabelText("Right column"));
+      const rhsColumnPicker = await screen.findByTestId("rhs-column-picker");
+      await userEvent.click(within(rhsColumnPicker).getByText("by month"));
+      const rhsBucketPicker = await screen.findByTestId("select-list");
+      await userEvent.click(screen.getByText("More…"));
+      await userEvent.click(within(rhsBucketPicker).getByText("Don't bin"));
+
+      const { conditions } = getRecentJoin();
+      const [condition] = conditions;
+
+      expect(condition.lhsColumn.longDisplayName).toBe("Created At");
+      expect(condition.rhsColumn.longDisplayName).toBe("Products → Created At");
+    });
+  });
+
   describe("read-only", () => {
     it("shouldn't allow changing the join type", () => {
       setup(createMockNotebookStep({ query: getJoinedQuery() }), {

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/utils.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/utils.ts
@@ -1,21 +1,20 @@
 import * as Lib from "metabase-lib";
 
-export function maybeSyncTemporalBucket(
+export function updateTemporalBucketing(
   query: Lib.Query,
   stageIndex: number,
   condition: Lib.JoinCondition,
-  column1: Lib.ColumnMetadata,
-  column2: Lib.ColumnMetadata,
+  columns: Lib.ColumnMetadata[],
 ) {
-  const bucket = Lib.temporalBucket(column1) ?? Lib.temporalBucket(column2);
-  if (bucket) {
-    return Lib.joinConditionUpdateTemporalBucketing(
-      query,
-      stageIndex,
-      condition,
-      bucket,
-    );
-  }
+  const bucket =
+    columns
+      .map(column => Lib.temporalBucket(column))
+      .find(bucket => bucket != null) ?? null;
 
-  return condition;
+  return Lib.joinConditionUpdateTemporalBucketing(
+    query,
+    stageIndex,
+    condition,
+    bucket,
+  );
 }


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/42681
Demo https://www.loom.com/share/b458f7404c6b43dda475f7688103c3bb

Previously, it wasn't impossible to remove bucketing unless you created a join condition without bucketing in the first place. Now we tweak existing logic to make it possible. There are 2 interesting cases:
1. Creating new join condition. Currently the first non-empty temporal bucket wins over others, and we preserve this behavior without changes.
2. Modifying an existing join condition. Currently the temporal bucket of the changed column takes priority, but we fall back to the temporal bucket of the second column if it's empty. We stop doing this now and simply overwrite the bucket for both columns with the last selected temporal bucket in all cases.

How to verify:
- New -> Question -> Orders
- Join Reviews
- LHS column -> Created At by month
- RHS column -> Created At by month
- Select either LHS or RHS column and change the bucketing to "Don't bin"
- Make sure it's respected.

