### PR TITLE
Fix the operator list for `type/TextLike` PKs

### DIFF
--- a/src/metabase/lib/filter/operator.cljc
+++ b/src/metabase/lib/filter/operator.cljc
@@ -113,8 +113,9 @@
    (operator-def :!=)])
 
 (defn- key-operators-for [column]
-  (if (lib.types.isa/string-or-string-like? column)
-    text-operators
+  (condp lib.types.isa/field-type? column
+    :metabase.lib.types.constants/string      text-operators
+    :metabase.lib.types.constants/string_like text-like-operators
     numeric-key-operators))
 
 (mu/defn filter-operators :- [:sequential ::lib.schema.filter/operator]

--- a/src/metabase/lib/filter/operator.cljc
+++ b/src/metabase/lib/filter/operator.cljc
@@ -113,7 +113,7 @@
    (operator-def :!=)])
 
 (defn- key-operators-for [column]
-  (if (lib.types.isa/field-type? :metabase.lib.types.constants/string column)
+  (if (lib.types.isa/string-or-string-like? column)
     text-operators
     numeric-key-operators))
 

--- a/src/metabase/lib/filter/operator.cljc
+++ b/src/metabase/lib/filter/operator.cljc
@@ -116,6 +116,7 @@
   (condp lib.types.isa/field-type? column
     :metabase.lib.types.constants/string      text-operators
     :metabase.lib.types.constants/string_like text-like-operators
+    ;; default
     numeric-key-operators))
 
 (mu/defn filter-operators :- [:sequential ::lib.schema.filter/operator]

--- a/test/metabase/lib/filter_test.cljc
+++ b/test/metabase/lib/filter_test.cljc
@@ -402,9 +402,7 @@
                          :lib/desired-column-alias "ID",
                          :display-name "ID",
                          :position 10}]
-             (into []
-                   (map :short)
-                   (lib.filter.operator/filter-operators column)))))))
+             (mapv :short (lib.filter.operator/filter-operators column)))))))
 
 (deftest ^:parallel replace-filter-clause-test
   (testing "Make sure we are able to replace a filter clause using the lib functions for manipulating filters."

--- a/test/metabase/lib/filter_test.cljc
+++ b/test/metabase/lib/filter_test.cljc
@@ -379,8 +379,8 @@
               :display-name "Trial Converted",
               :position 10,
               :fingerprint {:global {:distinct-count 2, :nil% 0.0}}}))))
-  (testing "should return text operators for text-like PKs"
-    (is (= [:= :!= :contains :does-not-contain :is-null :not-null :is-empty :not-empty :starts-with :ends-with]
+  (testing "should return text-like operators for text-like PKs"
+    (is (= [:= :!= :is-null :not-null :is-empty :not-empty :starts-with :ends-with]
            (let [column {:description nil,
                          :lib/type :metadata/column,
                          :base-type :type/MongoBSONID,

--- a/test/metabase/lib/filter_test.cljc
+++ b/test/metabase/lib/filter_test.cljc
@@ -380,28 +380,28 @@
               :position 10,
               :fingerprint {:global {:distinct-count 2, :nil% 0.0}}}))))
   (testing "should return text-like operators for text-like PKs and FKs"
-    (for [semantic-type [:type/PK :type/FK]
-          :let [column {:description nil,
-                        :lib/type :metadata/column,
-                        :base-type :type/MongoBSONID,
-                        :semantic-type semantic-type
-                        :table-id 7,
-                        :name "ID",
-                        :coercion-strategy nil,
-                        :lib/source :source/table-defaults,
-                        :lib/source-column-alias "ID",
-                        :settings nil,
-                        :lib/source-uuid "ad9a276f-3af8-4e5a-b17e-d8170273ec0a",
-                        :nfc-path nil,
-                        :database-type "STRING",
-                        :effective-type :type/MongoBSONID,
-                        :fk-target-field-id nil,
-                        :id 14,
-                        :parent-id nil,
-                        :visibility-type :normal,
-                        :lib/desired-column-alias "ID",
-                        :display-name "ID",
-                        :position 10}]]
+    (doseq [semantic-type [:type/PK :type/FK]
+            :let [column {:description nil,
+                          :lib/type :metadata/column,
+                          :base-type :type/MongoBSONID,
+                          :semantic-type semantic-type
+                          :table-id 7,
+                          :name "ID",
+                          :coercion-strategy nil,
+                          :lib/source :source/table-defaults,
+                          :lib/source-column-alias "ID",
+                          :settings nil,
+                          :lib/source-uuid "ad9a276f-3af8-4e5a-b17e-d8170273ec0a",
+                          :nfc-path nil,
+                          :database-type "STRING",
+                          :effective-type :type/MongoBSONID,
+                          :fk-target-field-id nil,
+                          :id 14,
+                          :parent-id nil,
+                          :visibility-type :normal,
+                          :lib/desired-column-alias "ID",
+                          :display-name "ID",
+                          :position 10}]]
         (is (= [:= :!= :is-null :not-null :is-empty :not-empty]
                (mapv :short (lib.filter.operator/filter-operators column)))))))
 

--- a/test/metabase/lib/filter_test.cljc
+++ b/test/metabase/lib/filter_test.cljc
@@ -372,16 +372,39 @@
               :database-type "BOOLEAN",
               :effective-type :type/Boolean,
               :fk-target-field-id nil,
-              :operators [{:lib/type :operator/filter, :short :=, :display-name-variant :default}
-                          {:lib/type :operator/filter, :short :is-null, :display-name-variant :is-empty}
-                          {:lib/type :operator/filter, :short :not-null, :display-name-variant :not-empty}],
               :id 14,
               :parent-id nil,
               :visibility-type :normal,
               :lib/desired-column-alias "TRIAL_CONVERTED",
               :display-name "Trial Converted",
               :position 10,
-              :fingerprint {:global {:distinct-count 2, :nil% 0.0}}})))))
+              :fingerprint {:global {:distinct-count 2, :nil% 0.0}}}))))
+  (testing "should return text operators for text-like PKs"
+    (is (= [:= :!= :contains :does-not-contain :is-null :not-null :is-empty :not-empty :starts-with :ends-with]
+           (let [column {:description nil,
+                         :lib/type :metadata/column,
+                         :base-type :type/MongoBSONID,
+                         :semantic-type :type/PK,
+                         :table-id 7,
+                         :name "ID",
+                         :coercion-strategy nil,
+                         :lib/source :source/table-defaults,
+                         :lib/source-column-alias "ID",
+                         :settings nil,
+                         :lib/source-uuid "ad9a276f-3af8-4e5a-b17e-d8170273ec0a",
+                         :nfc-path nil,
+                         :database-type "STRING",
+                         :effective-type :type/MongoBSONID,
+                         :fk-target-field-id nil,
+                         :id 14,
+                         :parent-id nil,
+                         :visibility-type :normal,
+                         :lib/desired-column-alias "ID",
+                         :display-name "ID",
+                         :position 10}]
+             (into []
+                   (map :short)
+                   (lib.filter.operator/filter-operators column)))))))
 
 (deftest ^:parallel replace-filter-clause-test
   (testing "Make sure we are able to replace a filter clause using the lib functions for manipulating filters."

--- a/test/metabase/lib/filter_test.cljc
+++ b/test/metabase/lib/filter_test.cljc
@@ -379,30 +379,31 @@
               :display-name "Trial Converted",
               :position 10,
               :fingerprint {:global {:distinct-count 2, :nil% 0.0}}}))))
-  (testing "should return text-like operators for text-like PKs"
-    (is (= [:= :!= :is-null :not-null :is-empty :not-empty]
-           (let [column {:description nil,
-                         :lib/type :metadata/column,
-                         :base-type :type/MongoBSONID,
-                         :semantic-type :type/PK,
-                         :table-id 7,
-                         :name "ID",
-                         :coercion-strategy nil,
-                         :lib/source :source/table-defaults,
-                         :lib/source-column-alias "ID",
-                         :settings nil,
-                         :lib/source-uuid "ad9a276f-3af8-4e5a-b17e-d8170273ec0a",
-                         :nfc-path nil,
-                         :database-type "STRING",
-                         :effective-type :type/MongoBSONID,
-                         :fk-target-field-id nil,
-                         :id 14,
-                         :parent-id nil,
-                         :visibility-type :normal,
-                         :lib/desired-column-alias "ID",
-                         :display-name "ID",
-                         :position 10}]
-             (mapv :short (lib.filter.operator/filter-operators column)))))))
+  (testing "should return text-like operators for text-like PKs and FKs"
+    (for [semantic-type [:type/PK :type/FK]
+          :let [column {:description nil,
+                        :lib/type :metadata/column,
+                        :base-type :type/MongoBSONID,
+                        :semantic-type semantic-type
+                        :table-id 7,
+                        :name "ID",
+                        :coercion-strategy nil,
+                        :lib/source :source/table-defaults,
+                        :lib/source-column-alias "ID",
+                        :settings nil,
+                        :lib/source-uuid "ad9a276f-3af8-4e5a-b17e-d8170273ec0a",
+                        :nfc-path nil,
+                        :database-type "STRING",
+                        :effective-type :type/MongoBSONID,
+                        :fk-target-field-id nil,
+                        :id 14,
+                        :parent-id nil,
+                        :visibility-type :normal,
+                        :lib/desired-column-alias "ID",
+                        :display-name "ID",
+                        :position 10}]]
+        (is (= [:= :!= :is-null :not-null :is-empty :not-empty]
+               (mapv :short (lib.filter.operator/filter-operators column)))))))
 
 (deftest ^:parallel replace-filter-clause-test
   (testing "Make sure we are able to replace a filter clause using the lib functions for manipulating filters."

--- a/test/metabase/lib/filter_test.cljc
+++ b/test/metabase/lib/filter_test.cljc
@@ -380,7 +380,7 @@
               :position 10,
               :fingerprint {:global {:distinct-count 2, :nil% 0.0}}}))))
   (testing "should return text-like operators for text-like PKs"
-    (is (= [:= :!= :is-null :not-null :is-empty :not-empty :starts-with :ends-with]
+    (is (= [:= :!= :is-null :not-null :is-empty :not-empty]
            (let [column {:description nil,
                          :lib/type :metadata/column,
                          :base-type :type/MongoBSONID,


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/41824

Previously the lib returned numeric operators for `MongoBSONID`, now it correctly returns text-like-operators.

How to verify:
- Setup mongo https://metaboat.slack.com/archives/C0645JP1W81/p1718995386583909?thread_ts=1718994904.451859&cid=C0645JP1W81
- Make sure you can filter by PKs and "Empty" and "Not empty" operators are available

Before:
<img width="443" alt="Screenshot 2024-06-21 at 15 18 23" src="https://github.com/metabase/metabase/assets/8542534/fac16e58-6fce-494b-8e3f-1e12e8cde0e3">

After:
<img width="467" alt="Screenshot 2024-06-21 at 15 31 13" src="https://github.com/metabase/metabase/assets/8542534/2c4e7f49-141b-4e5e-b5a6-f6d41059ec75">

