### PR TITLE
[MBQL lib] Map dashboard filters to last stage w/aggregations

### DIFF
--- a/frontend/src/metabase-lib/filter.ts
+++ b/frontend/src/metabase-lib/filter.ts
@@ -72,6 +72,10 @@ export function filterableColumns(
   return ML.filterable_columns(query, stageIndex);
 }
 
+export function dashboardFilterStageIndex(query: Query): number {
+  return ML.dashboard_filter_stage_index(query);
+}
+
 export function filterableColumnOperators(
   column: ColumnMetadata,
 ): FilterOperator[] {

--- a/frontend/src/metabase-lib/v1/parameters/utils/targets.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/targets.ts
@@ -121,6 +121,9 @@ export function buildColumnTarget(
   column: Lib.ColumnMetadata,
 ): StructuredParameterDimensionTarget {
   const fieldRef = Lib.legacyRef(query, stageIndex, column);
+  if (stageIndex !== -1) {
+    fieldRef[2] = { ...fieldRef[2], "stage-number": stageIndex };
+  }
 
   if (!isConcreteFieldReference(fieldRef)) {
     throw new Error(`Cannot build column target field reference: ${fieldRef}`);
@@ -146,7 +149,7 @@ export function getParameterColumns(question: Question, parameter?: Parameter) {
     question.type() !== "question"
       ? question.composeQuestionAdhoc().query()
       : question.query();
-  const stageIndex = -1;
+  const stageIndex = Lib.dashboardFilterStageIndex(query);
   const availableColumns =
     parameter && isTemporalUnitParameter(parameter)
       ? Lib.breakouts(query, stageIndex).map(breakout =>

--- a/frontend/src/metabase-types/api/query.ts
+++ b/frontend/src/metabase-types/api/query.ts
@@ -85,6 +85,7 @@ export interface ReferenceOptions {
   "temporal-unit"?: DatetimeUnit;
   "join-alias"?: string;
   "base-type"?: string;
+  "stage-number"?: number;
 }
 
 type BinningOptions =

--- a/src/metabase/query_processor/middleware/parameters/mbql.clj
+++ b/src/metabase/query_processor/middleware/parameters/mbql.clj
@@ -117,5 +117,6 @@
 
       :else
       (let [filter-clause (build-filter-clause query (assoc param :value param-value))
-            query         (mbql.u/add-filter-clause query filter-clause)]
+            [_ _ opts]    target
+            query         (mbql.u/add-filter-clause query (:stage-number opts) filter-clause)]
         (recur query rest)))))

--- a/test/metabase/legacy_mbql/util_test.cljc
+++ b/test/metabase/legacy_mbql/util_test.cljc
@@ -179,7 +179,7 @@
              [:= [:field 4 nil] 300]]))
         "Should be able to combine multiple compound clauses"))
 
-(t/deftest ^:parallel add-filter-clause-test
+(t/deftest ^:parallel add-filter-clause-test-1-single-stage
   (t/is (= {:database 1
             :type     :query
             :query    {:source-table 1
@@ -189,8 +189,46 @@
              :type     :query
              :query    {:source-table 1
                         :filter       [:= [:field 1 nil] 100]}}
+            0
             [:= [:field 2 nil] 200]))
         "Should be able to add a filter clause to a query"))
+
+(t/deftest ^:parallel add-filter-clause-test-2-earlier-stage
+  (t/is (= {:database 1
+            :type     :query
+            :query    {:source-query {:source-table 1
+                                      :filter       [:and [:= [:field 1 nil] 100] [:= [:field 2 nil] 200]]
+                                      :aggregation  [[:count]]}
+                       :expressions  {"negated" [:* [:field 1 nil] -1]}}}
+           (mbql.u/add-filter-clause
+             {:database 1
+              :type     :query
+              :query    {:source-query {:source-table 1
+                                        :filter       [:= [:field 1 nil] 100]
+                                        :aggregation  [[:count]]}
+                         :expressions  {"negated" [:* [:field 1 nil] -1]}}}
+             0
+             [:= [:field 2 nil] 200]))
+        "Should be able to add a filter clause to an earlier stage of a query"))
+
+(t/deftest ^:parallel add-filter-clause-test-3-later-stage
+  (doseq [stage-number [-1 1]]
+    (t/is (= {:database 1
+              :type     :query
+              :query    {:source-query {:source-table 1
+                                        :filter       [:= [:field 1 nil] 100]
+                                        :aggregation  [[:count]]}
+                         :expressions  {"negated" [:* [:field 1 nil] -1]}
+                         :filter       [:= [:field 2 nil] 200]}}
+             (mbql.u/add-filter-clause
+               {:database 1
+                :type     :query
+                :query    {:source-query {:source-table 1
+                                          :filter       [:= [:field 1 nil] 100]
+                                          :aggregation  [[:count]]}
+                           :expressions  {"negated" [:* [:field 1 nil] -1]}}}
+               stage-number
+               [:= [:field 2 nil] 200])))))
 
 (t/deftest ^:parallel desugar-time-interval-test
   (t/is (= [:between


### PR DESCRIPTION
Originally we used the last stage's columns for dashboard filters, but
then if you eg. use a custom expression to clean up the results of the
aggregation, then you can't filter at the most useful spot - before the
aggregations.

Fixes #19744. Related to #26244, #33958.

