### PR TITLE
Restore foreign key support for Mongo

### DIFF
--- a/modules/drivers/mongo/src/metabase/driver/mongo.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo.clj
@@ -304,6 +304,14 @@
   [_driver _feature _db]
   true)
 
+;; We say Mongo supports foreign keys so that the front end can use implicit
+;; joins. In reality, Mongo doesn't support foreign keys.
+;; Only define an implementation for `:foreign-keys` if none exists already.
+;; In test extensions we define an alternate implementation, and we don't want
+;; to stomp over that if it was loaded already.
+(when-not (get (methods driver/database-supports?) [:mongo :foreign-keys])
+  (defmethod driver/database-supports? [:mongo :foreign-keys] [_driver _feature _db] true))
+
 (defmethod driver/mbql->native :mongo
   [_ query]
   (mongo.qp/mbql->native query))

--- a/modules/drivers/mongo/test/metabase/test/data/mongo.clj
+++ b/modules/drivers/mongo/test/metabase/test/data/mongo.clj
@@ -6,6 +6,8 @@
    [clojure.test :refer :all]
    [flatland.ordered.map :as ordered-map]
    [medley.core :as m]
+   [metabase.config :as config]
+   [metabase.driver :as driver]
    [metabase.driver.ddl.interface :as ddl.i]
    [metabase.driver.mongo.connection :as mongo.connection]
    [metabase.driver.mongo.util :as mongo.util]
@@ -20,6 +22,9 @@
 
 (defmethod tx/supports-time-type? :mongo [_driver] false)
 (defmethod tx/supports-timestamptz-type? :mongo [_driver] false)
+
+;; During tests don't treat Mongo as having FK support
+(defmethod driver/database-supports? [:mongo :foreign-keys] [_driver _feature _db] (not config/is-test?))
 
 (defn ssl-required?
   "Returns if the mongo server requires an SSL connection."


### PR DESCRIPTION
Closes #44511

### Description

Probably as part of `driver/supports?` refactor, Mongo foreign key support was removed, instead of transformation to `driver/database-supports?`. Back then support for foreign keys was disabled during testing, hence no tests for eg. implicit joins ran.

This PR restores previous state, apart from conversion to `database-supports?`. Implicit joins were tested manually. Aim of this PR is to return driver to pre-regression state. Automated testing should be carried out as follow up, as required change is non-trivial.

Specifically, my belief is that implicit joins should be decoupled from `:foreign-keys` database feature, because foreign key relationships can be defined in Metabase independently from underlying database support (reproduction from the issue as an example).

If implicit joins are enabled should rather depend on `:joins` database feature. Application should not care if `fk_target_field_id` of `metabase_field` was obtained by sync or was defined by user.

Then, for implicit joins tests to pass, for databases that do not support foreign keys relationships, hence auto detection during sync is not available, `get-or-create-database` post sync hook can be created and relationships could be added to application database based on clojure side examination of test data table definitions.

Stub of described approach can be found in [`tx-post-sync-hook`](https://github.com/metabase/metabase/tree/tx-post-sync-hook) branch. Reason, this PR does not contained proposed change is that some tests fail due to ordering differences. My suspicion is that there is another issue with ordering, that is out of scope of pre-regression state restoration.

Finally, the issue https://github.com/metabase/metabase/issues/44573 was opened to track automated testing for Mongo implicit joins.

### How to verify

Manually, until the issue is not addressed.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
