### PR TITLE
Require preConditions for certain liquibase change types to encourage idempotence

### DIFF
--- a/bin/lint-migrations-file/src/change_set/strict.clj
+++ b/bin/lint-migrations-file/src/change_set/strict.clj
@@ -143,7 +143,7 @@
   (or
    (int? id)
    (< (major-version id) 51)
-   (not (some change-types-requiring-preconditions (mapcat keys changes)))
+   (not-any? change-types-requiring-preconditions (mapcat keys changes))
    (contains? change-set :preConditions)))
 
 (defn- disallow-delete-cascade-with-add-column

--- a/bin/lint-migrations-file/src/change_set/strict.clj
+++ b/bin/lint-migrations-file/src/change_set/strict.clj
@@ -140,12 +140,11 @@
   We don't currently assert on the structure of the preCondition to provide flexibility if there are cases where idempotence is not
   desired."
   [{:keys [id changes] :as change-set}]
-  (let [[change-type _] (ffirst changes)]
-    (or
-     (< (major-version id) 51)
-     (if (change-types-requiring-preconditions change-type)
-       (contains? change-set :preConditions)
-       true))))
+  (or
+   (int? id)
+   (< (major-version id) 51)
+   (some change-types-requiring-preconditions (mapcat keys changes))
+   (contains? change-set :preConditions)))
 
 (defn- disallow-delete-cascade-with-add-column
   "Returns false if addColumn changeSet uses deleteCascade. See Metabase issue #14321"

--- a/bin/lint-migrations-file/src/change_set/strict.clj
+++ b/bin/lint-migrations-file/src/change_set/strict.clj
@@ -141,7 +141,6 @@
   desired."
   [{:keys [id changes] :as change-set}]
   (or
-   (int? id)
    (< (major-version id) 51)
    (not-any? change-types-requiring-preconditions (mapcat keys changes))
    (contains? change-set :preConditions)))

--- a/bin/lint-migrations-file/src/change_set/strict.clj
+++ b/bin/lint-migrations-file/src/change_set/strict.clj
@@ -35,7 +35,7 @@
   (s/keys :opt-un [::dbms]))
 
 (s/def ::preConditions
-  (s/coll-of ::preCondition))
+  (s/nilable (s/coll-of ::preCondition)))
 
 (s/def ::dbms
   (s/keys :req-un [::type]))
@@ -122,6 +122,31 @@
    (some change-types-supporting-rollback (mapcat keys changes))
    (contains? change-set :rollback)))
 
+(def ^:private change-types-requiring-preconditions
+  #{:createTable
+    :dropTable
+    :addColumn
+    :dropColumn
+    :createIndex
+    :dropIndex
+    :addForeignKeyConstraint
+    :dropForeignKeyConstraint})
+
+(defn- precondition-present-when-required?
+  "Ensures that certain changeSet types include a preCondition. The intent is for the preCondition to ensure that the changeSet is
+  idempotent by checking whether the table/column/index/etc does not exist before trying to create it. (Or inversely, that it does
+  exist before trying to drop it.)
+
+  We don't currently assert on the structure of the preCondition to provide flexibility if there are cases where idempotence is not
+  desired."
+  [{:keys [id changes] :as change-set}]
+  (let [[change-type _] (ffirst changes)]
+    (or
+     (< (major-version id) 51)
+     (if (change-types-requiring-preconditions change-type)
+       (contains? change-set :preConditions)
+       true))))
+
 (defn- disallow-delete-cascade-with-add-column
   "Returns false if addColumn changeSet uses deleteCascade. See Metabase issue #14321"
   [{:keys [changes]}]
@@ -133,6 +158,7 @@
 (s/def ::change-set
   (s/and
    rollback-present-when-required?
+   precondition-present-when-required?
    disallow-delete-cascade-with-add-column
    (s/keys :req-un [::id ::author ::changes ::comment]
            :opt-un [::preConditions])))

--- a/bin/lint-migrations-file/src/change_set/strict.clj
+++ b/bin/lint-migrations-file/src/change_set/strict.clj
@@ -143,7 +143,7 @@
   (or
    (int? id)
    (< (major-version id) 51)
-   (some change-types-requiring-preconditions (mapcat keys changes))
+   (not (some change-types-requiring-preconditions (mapcat keys changes)))
    (contains? change-set :preConditions)))
 
 (defn- disallow-delete-cascade-with-add-column

--- a/bin/lint-migrations-file/src/change_set/strict.clj
+++ b/bin/lint-migrations-file/src/change_set/strict.clj
@@ -141,6 +141,7 @@
   desired."
   [{:keys [id changes] :as change-set}]
   (or
+   (int? id)
    (< (major-version id) 51)
    (not-any? change-types-requiring-preconditions (mapcat keys changes))
    (contains? change-set :preConditions)))

--- a/bin/lint-migrations-file/src/lint_migrations_file.clj
+++ b/bin/lint-migrations-file/src/lint_migrations_file.clj
@@ -103,8 +103,8 @@
              (format "Migration(s) [%s] uses invalid types (in %s)"
                      (str/join "," (map #(str "'" % "'") using-types?))
                      (str/join "," (map #(str "'" % "'") target-types)))
-              {:invalid-ids using-types?
-               :target-types target-types})))))
+             {:invalid-ids using-types?
+              :target-types target-types})))))
 
 (defn require-no-bare-blob-or-text-types!
   "Ensures that no \"text\" or \"blob\" type columns are added in any changesets."

--- a/bin/lint-migrations-file/test/lint_migrations_file_test.clj
+++ b/bin/lint-migrations-file/test/lint_migrations_file_test.clj
@@ -261,6 +261,13 @@
                      :id "v51.2024-01-01T10:30:00"
                      :changes [(mock-create-table-changes)])))))
 
+  (testing "other change types are exempt"
+    (is (= :ok
+           (validate!
+            (mock-change-set
+             :changes
+             [{:sql {:dbms "h2", :sql "1"}}])))))
+
   (testing "nil preConditions is allowed"
     (is (= :ok
            (validate! (mock-change-set

--- a/bin/lint-migrations-file/test/lint_migrations_file_test.clj
+++ b/bin/lint-migrations-file/test/lint_migrations_file_test.clj
@@ -252,6 +252,28 @@
   (testing "change types with automatic rollback support are allowed"
     (is (= :ok (validate! (mock-change-set :id "v49.2024-01-01T10:30:00" :changes [(mock-add-column-changes)]))))))
 
+(deftest require-precondition-test
+  (testing "certain change types require preConditions"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"Invalid change set\."
+         (validate! (mock-change-set
+                     :id "v51.2024-01-01T10:30:00"
+                     :changes [(mock-create-table-changes)])))))
+
+  (testing "nil preConditions is allowed"
+    (is (= :ok
+           (validate! (mock-change-set
+                       :id "v51.2024-01-01T10:30:00"
+                       :changes [(mock-create-table-changes)]
+                       :preConditions nil)))))
+
+  (testing "changeSets prior to v51 are exempt"
+    (is (= :ok
+           (validate! (mock-change-set
+                       :id "v50.2024-01-01T10:30:00"
+                       :changes [(mock-create-table-changes)]))))))
+
 (deftest disallow-deletecascade-in-addcolumn-test
   (testing "addColumn with deleteCascade fails"
     (is (thrown-with-msg?

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -7430,11 +7430,6 @@ databaseChangeLog:
                   remarks: The copy of dataset_query before the metrics v2 migration
                   type: ${text.type}
       preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - columnExists:
-                tableName: report_card
-                columnName: dataset_query_metrics_v2_migration_backup
 
   - changeSet:
       id: v51.2024-05-13T16:00:00

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -7429,6 +7429,12 @@ databaseChangeLog:
                   name: dataset_query_metrics_v2_migration_backup
                   remarks: The copy of dataset_query before the metrics v2 migration
                   type: ${text.type}
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: report_card
+                columnName: dataset_query_metrics_v2_migration_backup
 
   - changeSet:
       id: v51.2024-05-13T16:00:00


### PR DESCRIPTION
This updates the migration linter to require preconditions on create/drop operations (on tables, columns, indexes, and FKs). The idea is that it's usually a good idea to make a migration idempotent—i.e. check that the index actually exists before you try to drop it, and vice versa. It usually won't make a difference, but it help avoid errors where an instance gets into an inconsistent state and tries to run a migration again for some reason.

You can still skip adding a precondition by including the key (`preConditions:`) but leaving it blank, similar to with rollbacks. But it's a forcing function to consider whether it'd be necessary or useful.

Thought of this as a follow-up for https://github.com/metabase/metabase/issues/44455. Adding a precondition to the changeset in question to make it idempotent would have been a better option to support downgrades than an explict rollback migration.