### PR TITLE
Fix invalid API request fired on chart legend click

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.js
@@ -1085,3 +1085,66 @@ describe("issue 33208", () => {
     cy.findByTestId("scalar-value").should("be.visible");
   });
 });
+
+describe("issue 43077", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("should not fire an invalid API request when clicking a legend item on a cartesian chart with multiple aggregations", () => {
+    const cartesianQuestionDetails = {
+      dataset_query: {
+        type: "query",
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [
+            ["sum", ["field", ORDERS.QUANTITY, null]],
+            ["sum", ["field", ORDERS.TOTAL, null]],
+          ],
+          breakout: [
+            ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+          ],
+        },
+        database: 1,
+      },
+      display: "line",
+    };
+    const cardRequestSpy = cy.spy();
+    cy.intercept("/api/card/*", cardRequestSpy);
+
+    visitQuestionAdhoc(cartesianQuestionDetails);
+
+    cy.findAllByTestId("legend-item").first().click();
+
+    cy.wait(100).then(() => expect(cardRequestSpy).not.to.have.been.called);
+  });
+
+  it("should not fire an invalid API request when clicking a legend item on a row chart with multiple aggregations", () => {
+    const rowQuestionDetails = {
+      dataset_query: {
+        type: "query",
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [
+            ["sum", ["field", ORDERS.QUANTITY, null]],
+            ["sum", ["field", ORDERS.TOTAL, null]],
+          ],
+          breakout: [
+            ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+          ],
+        },
+        database: 1,
+      },
+      display: "row",
+    };
+    const cardRequestSpy = cy.spy();
+    cy.intercept("/api/card/*", cardRequestSpy);
+
+    visitQuestionAdhoc(rowQuestionDetails);
+
+    cy.findAllByTestId("legend-item").first().click();
+
+    cy.wait(100).then(() => expect(cardRequestSpy).not.to.have.been.called);
+  });
+});

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
@@ -51,6 +51,7 @@ export const useChartEvents = (
     onDeselectTimelineEvents,
     hovered,
     metadata,
+    isDashboard,
   }: VisualizationProps,
 ) => {
   const isBrushing = useRef<boolean>();
@@ -327,6 +328,8 @@ export const useChartEvents = (
           ...clickData,
           element: event.currentTarget,
         });
+      } else if (isDashboard) {
+        onOpenQuestion(seriesModel.cardId);
       }
     },
     [
@@ -336,6 +339,7 @@ export const useChartEvents = (
       visualizationIsClickable,
       onVisualizationClick,
       onOpenQuestion,
+      isDashboard,
     ],
   );
 

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
@@ -322,17 +322,11 @@ export const useChartEvents = (
         settings,
       };
 
-      if (
-        !areMultipleCards &&
-        hasBreakout &&
-        visualizationIsClickable(clickData)
-      ) {
+      if (hasBreakout && visualizationIsClickable(clickData)) {
         onVisualizationClick({
           ...clickData,
           element: event.currentTarget,
         });
-      } else {
-        onOpenQuestion(seriesModel.cardId);
       }
     },
     [

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
@@ -102,6 +102,7 @@ const RowChartVisualization = ({
   actionButtons,
   isFullscreen,
   isQueryBuilder,
+  isDashboard,
   onRender,
   onHoverChange,
   showTitle,
@@ -227,6 +228,8 @@ const RowChartVisualization = ({
         ...clickData,
         element: event.currentTarget,
       });
+    } else if (isDashboard) {
+      openQuestion();
     }
   };
 

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
@@ -216,13 +216,17 @@ const RowChartVisualization = ({
       chartColumns,
     );
 
+    const areMultipleCards = rawMultipleSeries.length > 1;
+    if (areMultipleCards) {
+      openQuestion();
+      return;
+    }
+
     if ("breakout" in chartColumns && visualizationIsClickable(clickData)) {
       onVisualizationClick({
         ...clickData,
         element: event.currentTarget,
       });
-    } else {
-      openQuestion();
     }
   };
 


### PR DESCRIPTION
- Closes: https://github.com/metabase/metabase/issues/43077

---
**Demo**

https://github.com/metabase/metabase/assets/22608765/e7f7f1e8-7462-4880-9934-0c18dfdedb43

---
**Acceptance Criteria**
- [ ] Chart legends exhibit the same user-visible behaviors as before
- [ ] Chart legends with multiple aggregations no longer fire invalid API requests when clicked
- [ ] E2E test added to validate and enforce the desired behavior