### PR TITLE
Fix new column shortcuts overwriting viz settings

### DIFF
--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -171,6 +171,10 @@ export const queryBuilderHeader = () => {
   return cy.findByTestId("qb-header");
 };
 
+export const queryBuilderFooter = () => {
+  return cy.findByTestId("view-footer");
+};
+
 export const closeQuestionActions = () => {
   queryBuilderHeader().click();
 };

--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -31,6 +31,7 @@ import {
   newButton,
   appBar,
   openProductsTable,
+  queryBuilderFooter,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATABASE;
@@ -858,6 +859,56 @@ describe("issue 44532", () => {
       cy.findByText("Gadget").should("not.exist");
       cy.findByText("Gizmo").should("not.exist");
       cy.findByText("Widget").should("not.exist");
+    });
+  });
+});
+
+describe("issue 43294", () => {
+  const questionDetails = {
+    display: "line",
+    query: {
+      "source-table": ORDERS_ID,
+      aggregation: [["count"]],
+      breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }]],
+    },
+    visualization_settings: {
+      "graph.metrics": ["count"],
+      "graph.dimensions": ["CREATED_AT"],
+    },
+  };
+
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("should not overwrite viz settings with click actions in raw data mode (metabase#43294)", () => {
+    createQuestion(questionDetails, { visitQuestion: true });
+    queryBuilderFooter().findByLabelText("Switch to data").click();
+
+    cy.log("compare action");
+    cy.button("Add column").click();
+    popover().findByText("Compare “Count” to previous months").click();
+    popover().button("Done").click();
+
+    cy.log("extract action");
+    cy.button("Add column").click();
+    popover().findByText("Extract part of column").click();
+    popover().within(() => {
+      cy.findByText("Created At: Month").click();
+      cy.findByText("Year").click();
+    });
+
+    cy.log("combine action");
+    cy.button("Add column").click();
+    popover().findByText("Combine columns").click();
+    popover().button("Done").click();
+
+    cy.log("check visualization");
+    queryBuilderFooter().findByLabelText("Switch to visualization").click();
+    echartsContainer().within(() => {
+      cy.findByText("Count").should("be.visible");
+      cy.findByText("Created At").should("be.visible");
     });
   });
 });

--- a/frontend/src/metabase/visualizations/click-actions/actions/CombineColumnsAction/CombineColumnsAction.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/CombineColumnsAction/CombineColumnsAction.tsx
@@ -1,12 +1,14 @@
 import { t } from "ttag";
 
-import { useDispatch } from "metabase/lib/redux";
+import { useDispatch, useSelector } from "metabase/lib/redux";
+import { checkNotNull } from "metabase/lib/types";
 import { setUIControls } from "metabase/query_builder/actions";
 import { trackColumnCombineViaPlusModal } from "metabase/query_builder/analytics";
 import {
   CombineColumns,
   hasCombinations,
 } from "metabase/query_builder/components/expressions/CombineColumns";
+import { getQuestion } from "metabase/query_builder/selectors";
 import type { LegacyDrill } from "metabase/visualizations/types";
 import type { ClickActionPopoverProps } from "metabase/visualizations/types/click-actions";
 import * as Lib from "metabase-lib";
@@ -29,11 +31,12 @@ export const CombineColumnsAction: LegacyDrill = ({ question, clicked }) => {
     onChangeCardAndRun,
     onClose,
   }: ClickActionPopoverProps) => {
+    const currentQuestion = useSelector(getQuestion);
     const dispatch = useDispatch();
 
     function handleSubmit(name: string, clause: Lib.ExpressionClause) {
       const newQuery = Lib.expression(query, stageIndex, name, clause);
-      const nextQuestion = question.setQuery(newQuery);
+      const nextQuestion = checkNotNull(currentQuestion).setQuery(newQuery);
       const nextCard = nextQuestion.card();
 
       trackColumnCombineViaPlusModal(newQuery, nextQuestion);

--- a/frontend/src/metabase/visualizations/click-actions/actions/CompareAggregationsAction/CompareAggregationsAction.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/CompareAggregationsAction/CompareAggregationsAction.tsx
@@ -1,11 +1,13 @@
 import { t } from "ttag";
 
-import { useDispatch } from "metabase/lib/redux";
+import { useDispatch, useSelector } from "metabase/lib/redux";
+import { checkNotNull } from "metabase/lib/types";
 import { setUIControls } from "metabase/query_builder/actions";
 import {
   CompareAggregations,
   getOffsetPeriod,
 } from "metabase/query_builder/components/CompareAggregations";
+import { getQuestion } from "metabase/query_builder/selectors";
 import { trackColumnCompareViaPlusModal } from "metabase/querying/analytics";
 import type { LegacyDrill } from "metabase/visualizations/types";
 import type { ClickActionPopoverProps } from "metabase/visualizations/types/click-actions";
@@ -39,6 +41,7 @@ export const CompareAggregationsAction: LegacyDrill = ({
     onChangeCardAndRun,
     onClose,
   }: ClickActionPopoverProps) => {
+    const currentQuestion = useSelector(getQuestion);
     const dispatch = useDispatch();
 
     function handleSubmit(aggregations: Lib.ExpressionClause[]) {
@@ -47,7 +50,7 @@ export const CompareAggregationsAction: LegacyDrill = ({
         query,
       );
 
-      const nextQuestion = question.setQuery(nextQuery);
+      const nextQuestion = checkNotNull(currentQuestion).setQuery(nextQuery);
       const nextCard = nextQuestion.card();
 
       trackColumnCompareViaPlusModal(

--- a/frontend/src/metabase/visualizations/click-actions/actions/ExtractColumnAction/ExtractColumnAction.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/ExtractColumnAction/ExtractColumnAction.tsx
@@ -1,12 +1,14 @@
 import { t } from "ttag";
 
-import { useDispatch } from "metabase/lib/redux";
+import { useDispatch, useSelector } from "metabase/lib/redux";
+import { checkNotNull } from "metabase/lib/types";
 import { setUIControls } from "metabase/query_builder/actions";
 import { trackColumnExtractViaPlusModal } from "metabase/query_builder/analytics";
 import {
   ExtractColumn,
   hasExtractions,
 } from "metabase/query_builder/components/expressions/ExtractColumn";
+import { getQuestion } from "metabase/query_builder/selectors";
 import { rem, Box } from "metabase/ui";
 import type { LegacyDrill } from "metabase/visualizations/types";
 import type { ClickActionPopoverProps } from "metabase/visualizations/types/click-actions";
@@ -31,6 +33,7 @@ export const ExtractColumnAction: LegacyDrill = ({ question, clicked }) => {
     onChangeCardAndRun,
     onClose,
   }: ClickActionPopoverProps) => {
+    const currentQuestion = useSelector(getQuestion);
     const dispatch = useDispatch();
 
     function handleSubmit(
@@ -39,8 +42,7 @@ export const ExtractColumnAction: LegacyDrill = ({ question, clicked }) => {
       extraction: Lib.ColumnExtraction,
     ) {
       const newQuery = Lib.extract(query, stageIndex, extraction);
-
-      const nextQuestion = question.setQuery(newQuery);
+      const nextQuestion = checkNotNull(currentQuestion).setQuery(newQuery);
       const nextCard = nextQuestion.card();
 
       trackColumnExtractViaPlusModal(


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/43294
Root cause - in "raw data" mode the display type and viz settings are overwritten https://github.com/metabase/metabase/blob/1b78f5a361e807dea892ed985add6a5d05d85ccb/frontend/src/metabase/query_builder/selectors.js#L693 so we need to use `useQuestion` selector to get the correct question instance.

How to verify:
- New -> Question -> Orders
- Aggregation -> Count, Breakout -> Created At
- Visualize as a line chart
- Go to raw data -> Click on "+" -> add expressions using new shortcuts
- Go back to viz mode -> your settings shouldn't be overwritten