### PR TITLE
Fix testing week-of-year extraction in `general-timezone-support-test`

### DIFF
--- a/test/metabase/query_processor_test/timezones_test.clj
+++ b/test/metabase/query_processor_test/timezones_test.clj
@@ -248,7 +248,7 @@
       (for [i (range 366)]
         [(u.date/add start-date :day i)])]]))
 
-(defmethod driver/database-supports? [::driver ::extract-week-of-year-us]
+(defmethod driver/database-supports? [::driver/driver ::extract-week-of-year-us]
   [_driver _feature _database]
   true)
 

--- a/test/metabase/query_processor_test/timezones_test.clj
+++ b/test/metabase/query_processor_test/timezones_test.clj
@@ -248,7 +248,7 @@
       (for [i (range 366)]
         [(u.date/add start-date :day i)])]]))
 
-(defmethod driver/database-supports? [:driver ::extract-week-of-year-us]
+(defmethod driver/database-supports? [::driver ::extract-week-of-year-us]
   [_driver _feature _database]
   true)
 


### PR DESCRIPTION
This PR fixes an issue where we were not testing week-of-year extraction by accident.