### PR TITLE
Fix/logs keep pooling after unmount

### DIFF
--- a/frontend/src/metabase/admin/tasks/components/Logs/Logs.unit.spec.tsx
+++ b/frontend/src/metabase/admin/tasks/components/Logs/Logs.unit.spec.tsx
@@ -97,6 +97,18 @@ describe("Logs", () => {
         expect(screen.getByText(errMsg)).toBeInTheDocument();
       });
     });
+
+    it("should stop polling on unmount", async () => {
+      fetchMock.get("path:/api/util/logs", [log]);
+      const { unmount } = render(<Logs />);
+      await waitFor(() => [screen.getByText(new RegExp(log.process_uuid))]);
+
+      unmount();
+      act(() => {
+        jest.advanceTimersByTime(1100); // wait longer than polling period
+      });
+      expect(utilSpy).toHaveBeenCalledTimes(1); // should not have been called
+    });
   });
 
   describe("log processing", () => {

--- a/frontend/src/metabase/admin/tasks/components/Logs/Logs.unit.spec.tsx
+++ b/frontend/src/metabase/admin/tasks/components/Logs/Logs.unit.spec.tsx
@@ -101,11 +101,9 @@ describe("Logs", () => {
     it("should stop polling on unmount", async () => {
       fetchMock.get("path:/api/util/logs", [log]);
       const { unmount } = render(<Logs />);
-      await waitFor(() => {
-        expect(
-          screen.getByText(new RegExp(log.process_uuid)),
-        ).toBeInTheDocument();
-      });
+      expect(
+        await screen.findByText(new RegExp(log.process_uuid)),
+      ).toBeInTheDocument();
 
       unmount();
       act(() => {

--- a/frontend/src/metabase/admin/tasks/components/Logs/Logs.unit.spec.tsx
+++ b/frontend/src/metabase/admin/tasks/components/Logs/Logs.unit.spec.tsx
@@ -109,7 +109,7 @@ describe("Logs", () => {
       act(() => {
         jest.advanceTimersByTime(1100); // wait longer than polling period
       });
-      expect(utilSpy).toHaveBeenCalledTimes(1); // should not have been called
+      expect(utilSpy).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/frontend/src/metabase/admin/tasks/components/Logs/Logs.unit.spec.tsx
+++ b/frontend/src/metabase/admin/tasks/components/Logs/Logs.unit.spec.tsx
@@ -101,7 +101,11 @@ describe("Logs", () => {
     it("should stop polling on unmount", async () => {
       fetchMock.get("path:/api/util/logs", [log]);
       const { unmount } = render(<Logs />);
-      await waitFor(() => [screen.getByText(new RegExp(log.process_uuid))]);
+      await waitFor(() => {
+        expect(
+          screen.getByText(new RegExp(log.process_uuid)),
+        ).toBeInTheDocument();
+      });
 
       unmount();
       act(() => {

--- a/frontend/src/metabase/admin/tasks/components/Logs/hooks.ts
+++ b/frontend/src/metabase/admin/tasks/components/Logs/hooks.ts
@@ -1,6 +1,6 @@
 import { useInterval } from "@mantine/hooks";
 import { useState, useEffect, useRef, useCallback } from "react";
-import { useMount } from "react-use";
+import { useLifecycles } from "react-use";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -46,15 +46,17 @@ export function usePollingLogsQuery(pollingDurationMs: number) {
 
   // keep track of mounted state to avoid settings state after unmount
   // clear timeout that is polling for logs
-  useMount(() => {
-    isMountedRef.current = true;
-    fetchLogs();
-    pollingInterval.start();
-    return () => {
+  useLifecycles(
+    () => {
+      isMountedRef.current = true;
+      fetchLogs();
+      pollingInterval.start();
+    },
+    () => {
       isMountedRef.current = false;
       pollingInterval.stop();
-    };
-  });
+    },
+  );
 
   return { loaded, error, logs };
 }

--- a/frontend/src/metabase/admin/tasks/components/Logs/hooks.ts
+++ b/frontend/src/metabase/admin/tasks/components/Logs/hooks.ts
@@ -1,6 +1,6 @@
 import { useInterval } from "@mantine/hooks";
 import { useState, useEffect, useRef, useCallback } from "react";
-import { useLifecycles } from "react-use";
+import { useMount, useUnmount } from "react-use";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -46,17 +46,16 @@ export function usePollingLogsQuery(pollingDurationMs: number) {
 
   // keep track of mounted state to avoid settings state after unmount
   // clear timeout that is polling for logs
-  useLifecycles(
-    () => {
-      isMountedRef.current = true;
-      fetchLogs();
-      pollingInterval.start();
-    },
-    () => {
-      isMountedRef.current = false;
-      pollingInterval.stop();
-    },
-  );
+  useMount(() => {
+    isMountedRef.current = true;
+    fetchLogs();
+    pollingInterval.start();
+  });
+
+  useUnmount(() => {
+    isMountedRef.current = false;
+    pollingInterval.stop();
+  });
 
   return { loaded, error, logs };
 }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/43010

### Description

`useMount` does not offer a cleanup function the same way as `useEffect`, but `useLifecycles` does

- [useMount](https://github.com/streamich/react-use/blob/ade8d3905f544305515d010737b4ae604cc51024/docs/useMount.md)
- [useLifecycles](https://github.com/streamich/react-use/blob/ade8d3905f544305515d010737b4ae604cc51024/docs/useLifecycles.md)

### How to verify

1. Go to go `Admin -> Troubleshooting -> Logs`
2. Leave `Logs` tab - navigate anywhere
3. See in network tab, log polling stopped

### Demo

https://www.loom.com/share/35caa19c8944424a8bca3dadc78c588c?sid=e83bdb98-073e-41bb-8075-8f8bd13ede85

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
