### PR TITLE
add a test to check that openapi definitions can be generated

### DIFF
--- a/src/metabase/api/common/openapi.clj
+++ b/src/metabase/api/common/openapi.clj
@@ -126,10 +126,11 @@
 (defn- compojure-renames
   "Find out everything that's renamed in Compojure routes"
   [args]
-  (let [idx (inc (.indexOf ^PersistentVector args :as))]
-    (when (pos? idx)
-      (let [req-bindings (get args idx)
-            renames      (->> (keys req-bindings) ; {{c :count} :query-params} ; => [{c :count}]
+  (let [idx          (inc (.indexOf ^PersistentVector args :as))
+        req-bindings (get args idx)]
+    (when (and (pos? idx)
+               (map? req-bindings))
+      (let [renames (->> (keys req-bindings) ; {{c :count} :query-params} ; => [{c :count}]
                               (filter map?)       ; no stuff like {:keys [a]}
                               (apply merge))]
         (update-keys renames keyword)))))

--- a/test/metabase/api/common/openapi_test.clj
+++ b/test/metabase/api/common/openapi_test.clj
@@ -5,6 +5,7 @@
    [malli.json-schema :as mjs]
    [metabase.api.common :as api]
    [metabase.api.common.openapi :as openapi]
+   [metabase.api.routes :as routes]
    [metabase.util.malli.schema :as ms]))
 
 ;;; inner helpers
@@ -136,3 +137,6 @@
                                   {:allOf [{:type "string", :minLength 1}
                                            {}]}}}}
          (openapi/openapi-object #'routes))))
+
+(deftest ^:parallel openapi-all-routes
+  (is (openapi/openapi-object #'routes/routes)))


### PR DESCRIPTION
This time it was `/api-key/count`, because it's arguments are defined as `[:as body]` and the code did not expect that :)