### PR TITLE
fix: pivot table disappear

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -40,7 +40,6 @@ import {
   QueryBuilderMain,
   QueryBuilderViewHeaderContainer,
   QueryBuilderViewRoot,
-  StyledDebouncedFrame,
   StyledSyncedParametersList,
 } from "./View.styled";
 import ViewFooter from "./ViewFooter";
@@ -310,14 +309,8 @@ class View extends Component {
   };
 
   renderMain = ({ leftSidebar, rightSidebar }) => {
-    const {
-      question,
-      mode,
-      parameters,
-      isLiveResizable,
-      setParameterValue,
-      queryBuilderMode,
-    } = this.props;
+    const { question, mode, parameters, setParameterValue, queryBuilderMode } =
+      this.props;
 
     if (queryBuilderMode === "notebook") {
       // we need to render main only in view mode
@@ -343,14 +336,7 @@ class View extends Component {
           />
         )}
 
-        <StyledDebouncedFrame enabled={!isLiveResizable}>
-          <QueryVisualization
-            {...this.props}
-            noHeader
-            className={CS.spread}
-            mode={queryMode}
-          />
-        </StyledDebouncedFrame>
+        <QueryVisualization {...this.props} noHeader mode={queryMode} />
         <TimeseriesChrome
           question={this.props.question}
           updateQuestion={this.props.updateQuestion}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/43129

### Description

**Problem:**
`react-virtualized` [AutoSizer](https://github.com/bvaughn/react-virtualized/blob/e78651c3d844c6f639347d1fb796072783c175d2/source/AutoSizer/AutoSizer.js#L170) depends on `parentNode`'s size after mounted in order to calculate the correct `width` and `height` but [ExplicitSize](https://github.com/metabase/metabase/blob/bdf67dbe3f50af70e8aa64dd5b6bec4685dae573/frontend/src/metabase/components/ExplicitSize.tsx#L213) that wraps `DebouncedFrame` initially pass `null` and them real values. In the end when `AutoSizer` is mounted, its parent (DebouncedFrame) does not have a `height` set resulting in table rows being hidden in a tiny container.

I didn't investigate further why it works when you just arrived at the page because I have the following questions about `DebouncedFrame` and `ExplicitSize`

**Why DebouncedFrame and ExplicitSize?**
From the component comments:
> This component prevents children elements from being rerendered while it's being resized...

I understand the idea here, especially when using together with `ExplicitSize` that it modifies its state whenever you resize the browser window that results in re-render.

I didn't understand the reason why we need to keep track of the component size in a React state and not let the DOM do its job, because doing this, we end up triggering re-render every time the window is resized and also re-rendering the same component twice on mount (first render, set state with actual size, render again).

**Solution**
Remove `DebouncedFrame`
By removing it we also lose the greyed out table while resizing, maybe it's important to keep it 🤔 

I'm opening this a draft pull requests because I'd like to hear feedbacks about this approach.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create a new question
2. Choose pivot table visualization
3. Open notebook
4. Go back to visualization

### Demo

https://www.loom.com/share/2ef979d755e744da826c25d12b36d992?sid=a91217bc-bf42-4ee1-a12d-c9993b6d0292

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
