### PR TITLE
Fix infinite backport PR recursion in milestone setter

### DIFF
--- a/release/src/linked-issues.ts
+++ b/release/src/linked-issues.ts
@@ -22,3 +22,9 @@ export function getPRsFromCommitMessage(message: string) {
 
   return result.map(r => Number(r[1]));
 }
+
+// backport PRs just have a pr number in the body without a keyword
+export function getBackportSourcePRNumber(body: string) {
+  const matches = body.match(/#(\d+)/);
+  return matches ? Number(matches[1]) : null;
+}

--- a/release/src/linked-issues.unit.spec.ts
+++ b/release/src/linked-issues.unit.spec.ts
@@ -1,4 +1,4 @@
-import { getLinkedIssues, getPRsFromCommitMessage } from "./linked-issues";
+import { getLinkedIssues, getPRsFromCommitMessage, getBackportSourcePRNumber } from "./linked-issues";
 
 const closingKeywords = [
   "Close",
@@ -129,5 +129,20 @@ describe("getPRsFromCommitMessage", () => {
   it("should return the PR id for a message with multiple backport PRs", () => {
     expect(getPRsFromCommitMessage("Backport (#123) (#456)")).toEqual([123, 456]);
     expect(getPRsFromCommitMessage("Backport (#1234) and (#4567)")).toEqual([1234, 4567]);
+  });
+});
+
+describe("getBackportSourcePRNumber", () => {
+  it("should return `null` when no PR is found", () => {
+    expect(getBackportSourcePRNumber("")).toBeNull();
+    expect(getBackportSourcePRNumber("Lorem ipsum dolor sit amet.")).toBeNull();
+    expect(getBackportSourcePRNumber("#yolo")).toBeNull();
+
+  });
+
+  it("should return the pr number when it is found", () => {
+    expect(getBackportSourcePRNumber("#4567")).toBe(4567);
+    expect(getBackportSourcePRNumber(" #4567 ")).toBe(4567);
+    expect(getBackportSourcePRNumber("backports #4567 and #6789")).toBe(4567);
   });
 });

--- a/release/src/milestones.ts
+++ b/release/src/milestones.ts
@@ -1,7 +1,7 @@
 import _ from "underscore";
 
 import { getMilestones } from "./github";
-import { getLinkedIssues, getPRsFromCommitMessage } from "./linked-issues";
+import { getLinkedIssues, getPRsFromCommitMessage, getBackportSourcePRNumber } from "./linked-issues";
 import type { Issue, GithubProps, Milestone } from "./types";
 import {
   getMajorVersion,
@@ -54,13 +54,17 @@ async function getOriginalPR({
     pull_number: pullRequestNumber,
   });
 
-  if (pull?.data && isBackport(pull.data)) {
-    return getOriginalPR({
-      github,
-      repo,
-      owner,
-      pullRequestNumber: pull.data.number
-    });
+  if (pull?.data && isBackport(pull.data) && pull.data.body) {
+    const sourcePRNumber = getBackportSourcePRNumber(pull.data.body);
+    if (sourcePRNumber && sourcePRNumber !== pullRequestNumber) {
+      console.log('found backport PR', pull.data.number, 'source PR', sourcePRNumber);
+      return getOriginalPR({
+        github,
+        repo,
+        owner,
+        pullRequestNumber: sourcePRNumber,
+      });
+    }
   }
 
   const linkedIssues = await getLinkedIssues(pull.data.body ?? '');

--- a/release/src/milestones.ts
+++ b/release/src/milestones.ts
@@ -186,9 +186,11 @@ export async function setMilestoneForCommits({
     })));
   }
 
-  console.log(`Tagging ${issuesToTag.length} issues with milestone ${nextMilestone.title}`)
+  const uniqueIssuesToTag = _.uniq(issuesToTag);
 
-  for (const issueNumber of issuesToTag) { // for loop to avoid rate limiting
+  console.log(`Tagging ${uniqueIssuesToTag.length} issues with milestone ${nextMilestone.title}`)
+
+  for (const issueNumber of uniqueIssuesToTag) { // for loop to avoid rate limiting
     await setMilestone({ github, owner, repo, issueNumber, milestone: nextMilestone });
   }
 }


### PR DESCRIPTION

### Description

- Fixes a bug in the auto-milestone setter that caused infinte recursion when it was parsing a backport PR 😅 
- also adds some more de-duplication of pr/issues numbers to reduce api calls

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
