### PR TITLE
test: add a test for the edge case in mapping on parameter change

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.tsx
@@ -87,7 +87,6 @@ export function DashCardCardParameterMapper({
   useResetParameterMapping({
     editingParameter,
     isNative,
-    isDisabled,
     dashcardId: dashcard.id,
   });
 

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.unit.spec.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.unit.spec.jsx
@@ -455,9 +455,7 @@ describe("DashCardCardParameterMapper", () => {
 
     expect(parameterActions.resetParameterMapping).not.toHaveBeenCalled();
 
-    const { rerender } = setup({
-      ...props,
-    });
+    const { rerender } = setup(props);
 
     rerender(
       <DashCardCardParameterMapper

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/hooks.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/hooks.ts
@@ -9,12 +9,10 @@ import type { DashCardId, Parameter } from "metabase-types/api";
 export function useResetParameterMapping({
   editingParameter,
   isNative,
-  isDisabled,
   dashcardId,
 }: {
   editingParameter: Parameter | null | undefined;
   isNative: boolean;
-  isDisabled: boolean;
   dashcardId: DashCardId;
 }) {
   const prevParameter = usePrevious(editingParameter);
@@ -25,11 +23,7 @@ export function useResetParameterMapping({
       return;
     }
 
-    if (
-      isNative &&
-      isDisabled &&
-      prevParameter.type !== editingParameter.type
-    ) {
+    if (isNative && prevParameter.type !== editingParameter.type) {
       const subType = getParameterSubType(editingParameter);
       const prevSubType = getParameterSubType(prevParameter);
 
@@ -37,12 +31,5 @@ export function useResetParameterMapping({
         dispatch(resetParameterMapping(editingParameter.id, dashcardId));
       }
     }
-  }, [
-    isNative,
-    isDisabled,
-    prevParameter,
-    editingParameter,
-    dispatch,
-    dashcardId,
-  ]);
+  }, [isNative, prevParameter, editingParameter, dispatch, dashcardId]);
 }


### PR DESCRIPTION
Followup of https://github.com/metabase/metabase/pull/44526

### Description

Add a unit test for the edge case: we should reset mapping for native question when parameter type is changed from equal to something different

### How to verify

- add a dashboard, number filter `equal to`, sql question with a number variable
- set mapping to the question
- change parameter type to something different, then change to `equal to`
- verify that mapping is not specified

### Demo



https://github.com/metabase/metabase/assets/125459446/5c0b98aa-5925-40ca-9213-44a81d8a7aa2





### Checklist

- [x] Tests have been added/updated to cover changes in this PR
