### PR TITLE
[Mongo] Convert bson Decimal128 negative zero to BigInteger zero

### DIFF
--- a/modules/drivers/mongo/src/metabase/driver/mongo/conversion.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/conversion.clj
@@ -17,7 +17,6 @@
 
    TODOs should be addressed during follow-up of monger removal."
   (:require
-   [clojure.string :as str]
    [flatland.ordered.map :as ordered-map]
    [java-time.api :as t]
    [metabase.query-processor.timezone :as qp.timezone]))
@@ -38,12 +37,11 @@
 
   org.bson.types.Decimal128
   (from-document [^org.bson.types.Decimal128 input _opts]
-    (try (.bigDecimalValue input)
-         ;; Convert negative and positive zero to 0M
-         (catch ArithmeticException e
-           (if (str/includes? (ex-message e) "zero can not be converted to a BigDecimal")
-             0M
-             (throw e)))))
+    ;; As per https://mongodb.github.io/mongo-java-driver/5.1/apidocs/bson/org/bson/types/Decimal128.html#bigDecimalValue()
+    ;; org.bson.types.Decimal128/POSITIVE_ZERO is convertible to big decimal.
+    (if (.equals input org.bson.types.Decimal128/NEGATIVE_ZERO)
+      0M
+      (.bigDecimalValue input)))
 
   java.util.List
   (from-document [^java.util.List input opts]

--- a/modules/drivers/mongo/src/metabase/driver/mongo/conversion.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/conversion.clj
@@ -17,6 +17,7 @@
 
    TODOs should be addressed during follow-up of monger removal."
   (:require
+   [clojure.string :as str]
    [flatland.ordered.map :as ordered-map]
    [java-time.api :as t]
    [metabase.query-processor.timezone :as qp.timezone]))
@@ -37,7 +38,11 @@
 
   org.bson.types.Decimal128
   (from-document [^org.bson.types.Decimal128 input _opts]
-    (.bigDecimalValue input))
+    (try (.bigDecimalValue input)
+         (catch ArithmeticException e
+           (if (str/includes? (ex-message e) "Negative zero can not be converted to a BigDecimal")
+             0M
+             (throw e)))))
 
   java.util.List
   (from-document [^java.util.List input opts]

--- a/modules/drivers/mongo/src/metabase/driver/mongo/conversion.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/conversion.clj
@@ -39,8 +39,9 @@
   org.bson.types.Decimal128
   (from-document [^org.bson.types.Decimal128 input _opts]
     (try (.bigDecimalValue input)
+         ;; Convert negative and positive zero to 0M
          (catch ArithmeticException e
-           (if (str/includes? (ex-message e) "Negative zero can not be converted to a BigDecimal")
+           (if (str/includes? (ex-message e) "zero can not be converted to a BigDecimal")
              0M
              (throw e)))))
 

--- a/modules/drivers/mongo/test/metabase/driver/mongo/conversion_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/conversion_test.clj
@@ -31,9 +31,9 @@
   (testing "Bson Decimal128 zero is converted to BigDecimal zero"
     (is (= {"negativeZero" 0M}
            (mongo.conversion/from-document
-            (org.bson.Document. "negativeZero" (org.bson.types.Decimal128/parse "-0"))
+            (org.bson.Document. "negativeZero" org.bson.types.Decimal128/NEGATIVE_ZERO)
             nil)))
     (is (= {"positiveZero" 0M}
            (mongo.conversion/from-document
-            (org.bson.Document. "positiveZero" (org.bson.types.Decimal128/parse "+0"))
+            (org.bson.Document. "positiveZero" org.bson.types.Decimal128/POSITIVE_ZERO)
             nil)))))

--- a/modules/drivers/mongo/test/metabase/driver/mongo/conversion_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/conversion_test.clj
@@ -26,3 +26,10 @@
                (-> mseqk mongo.conversion/to-document (mongo.conversion/from-document {:keywordize true}))))
         (is (= mseqs
                (-> mseqs mongo.conversion/to-document (mongo.conversion/from-document nil))))))))
+
+(deftest bson-negative-zero->big-decimal-test
+  (testing "Bson Decimal128 negative zero is converted to BigDecimal zero"
+    (is (= {"negativeZero" 0M}
+           (mongo.conversion/from-document
+            (org.bson.Document. "negativeZero" (org.bson.types.Decimal128/parse "-0"))
+            nil)))))

--- a/modules/drivers/mongo/test/metabase/driver/mongo/conversion_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/conversion_test.clj
@@ -28,8 +28,12 @@
                (-> mseqs mongo.conversion/to-document (mongo.conversion/from-document nil))))))))
 
 (deftest bson-negative-zero->big-decimal-test
-  (testing "Bson Decimal128 negative zero is converted to BigDecimal zero"
+  (testing "Bson Decimal128 zero is converted to BigDecimal zero"
     (is (= {"negativeZero" 0M}
            (mongo.conversion/from-document
             (org.bson.Document. "negativeZero" (org.bson.types.Decimal128/parse "-0"))
+            nil)))
+    (is (= {"positiveZero" 0M}
+           (mongo.conversion/from-document
+            (org.bson.Document. "positiveZero" (org.bson.types.Decimal128/parse "+0"))
             nil)))))


### PR DESCRIPTION
Closes #44506

### Description

~~This PR _has a potential_ to fix the issue. It is not clear from the issue, if results returned from Mongo contain negative zero. Though it seems very likely as the exception mentioned in the issue is almost certainly thrown during the `.bigDecimalValue` conversion of `from-document`.~~

~~I've considered also possibility of digits getting lost _somewhere_ on the application side. I find that unlikely as all `from-document` calls occur right on the results returned from dbms.~~

This PR adds negative zero handling to `from-document` conversion function.

### How to verify

Run the newly added test.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
