### PR TITLE
Increase the Codecov frontend target

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,7 +6,7 @@ coverage:
   status:
     project:
       back-end:
-        # Project must always have at least 78% coverage (by line)
+        # Project must always have at least the target amount coverage (by line)
         target: 85%
         # Whole-project test coverage is allowed to drop up to 5%. (For situtations where we delete code with full coverage)
         threshold: 5%

--- a/codecov.yml
+++ b/codecov.yml
@@ -14,7 +14,7 @@ coverage:
           - back-end
 
       front-end:
-        target: 50%
+        target: 60%
         threshold: 5%
         flags:
           - front-end


### PR DESCRIPTION
### Description

Our codecov actions needed some love and attention.
This PR makes the comment that explains the back-end target more flexible.
It also updates the front-end target to 60%, since we've done a decent job at adding more tests.

![image](https://github.com/metabase/metabase/assets/31325167/0a269c73-f891-470b-a87e-5afca289f18f)

