### PR TITLE
Add a reproduction for "Can't edit joined tables after saving the question"

### DIFF
--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -33,7 +33,8 @@ import {
   openProductsTable,
 } from "e2e/support/helpers";
 
-const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATABASE;
+const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID, PEOPLE, PEOPLE_ID } =
+  SAMPLE_DATABASE;
 
 describe("issue 32625, issue 31635", () => {
   const CC_NAME = "Is Promotion";
@@ -859,5 +860,54 @@ describe("issue 44532", () => {
       cy.findByText("Gizmo").should("not.exist");
       cy.findByText("Widget").should("not.exist");
     });
+  });
+});
+
+describe("issue 43531", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should be possible to change the join tables in a saved question (metabase#43531)", () => {
+    //
+    createQuestion(
+      {
+        name: "Question 43531",
+        query: {
+          "source-table": ORDERS_ID,
+          joins: [
+            {
+              fields: "all",
+              "source-table": PRODUCTS_ID,
+              condition: [
+                "=",
+                ["field", ORDERS.PRODUCT_ID, null],
+                ["field", PRODUCTS.ID, { "join-alias": "Products" }],
+              ],
+              alias: "Products",
+            },
+            {
+              fields: "all",
+              "source-table": PEOPLE_ID,
+              condition: [
+                "=",
+                ["field", ORDERS.USER_ID, null],
+                ["field", PEOPLE.ID, { "join-alias": "People" }],
+              ],
+              alias: "People",
+            },
+          ],
+        },
+      },
+      { wrapId: true, visitQuestion: true },
+    );
+
+    openNotebook();
+
+    cy.findAllByTestId("notebook-cell-item").contains("People").click();
+    modal().findByText("Reviews").click();
+
+    saveQuestion();
   });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/43531: "Can't edit joined tables after saving the question"

Adds a reproduction for the issue that has been fixed in v50.


Here is the issue description as per the issue:


1. Create a new question
2. Add a few joins
3. Save the question
4. Try editing the question changing one of the joins you made. You'll be able to change the left and right column, but you won't be able to change the left and right tables.

