### PR TITLE
Repro #44550: Missing display name for the filter with an offset

### DIFF
--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -984,3 +984,68 @@ describe("metabase#32985", () => {
     });
   });
 });
+
+describe.skip("metabase#44550", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should display the filter with an offset appropriately in the time-series chrome and in the filter modal (metabase#44550)", () => {
+    const questionDetails = {
+      database: SAMPLE_DB_ID,
+      query: {
+        "source-table": ORDERS_ID,
+        aggregation: [["count"]],
+        breakout: [
+          [
+            "field",
+            ORDERS.CREATED_AT,
+            {
+              "base-type": "type/DateTime",
+              "temporal-unit": "month",
+            },
+          ],
+        ],
+        filter: [
+          "between",
+          [
+            "+",
+            [
+              "field",
+              ORDERS.CREATED_AT,
+              {
+                "base-type": "type/DateTime",
+              },
+            ],
+            ["interval", 7, "day"],
+          ],
+          ["relative-datetime", -30, "day"],
+          ["relative-datetime", 0, "day"],
+        ],
+      },
+      type: "query",
+    };
+
+    createQuestion(questionDetails, { visitQuestion: true });
+    cy.findByTestId("filters-visibility-control").click();
+    cy.findByTestId("filter-pill").should(
+      "have.text",
+      "Created At is in the previous 30 days, starting 7 days ago",
+    );
+
+    cy.log("Repro for the time-series chrome");
+    cy.findByTestId("timeseries-filter-button")
+      .should("not.have.text", "All time")
+      .and("contain", /previous 30 days/i)
+      .and("contain", /7 days ago/i);
+
+    cy.log("Repro for the filter modal");
+    filter();
+    // Not entirely sure how the DOM looks like in this scenario.
+    // TODO: Update the test if needed.
+    cy.findByTestId("filter-column-Created At")
+      .should("contain", /previous 30 days/i)
+      .and("contain", /7 days ago/i);
+  });
+});


### PR DESCRIPTION
This PR reproduces #44550

It will first fail for the time-series chrome component
![image](https://github.com/metabase/metabase/assets/31325167/2573785e-5234-4f21-b201-a6370d482d54)

But even if I skip that part, it will still fail for the filter modal.
![image](https://github.com/metabase/metabase/assets/31325167/3d42194d-84ce-4fd6-a303-b50fd22df3cc)

Which is to say that it correctly reproduces both scenarios that this issue is about.