### PR TITLE
Add reproduction for "Result inconsistencies with Preview in GUI editor #40399"

### DIFF
--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -949,15 +949,15 @@ describe("issue 40399", () => {
 
     openNotebook();
 
-    cy.findByTestId("step-filter-0-0").within(() => {
-      cy.findByTestId("step-preview-button").click();
+    getNotebookStep("filter", { stage: 0 }).within(() => {
+      cy.icon("play").click();
       cy.findByTestId("preview-root")
         .findAllByText("Widget")
         .should("be.visible");
     });
 
-    cy.findByTestId("step-join-0-0").within(() => {
-      cy.findByTestId("step-preview-button").click();
+    getNotebookStep("join", { stage: 0 }).within(() => {
+      cy.icon("play").click();
       cy.findByTestId("preview-root")
         .findAllByText("Gizmo")
         .should("be.visible");
@@ -965,8 +965,8 @@ describe("issue 40399", () => {
       cy.findByTestId("preview-root").findByText("Widget").should("not.exist");
     });
 
-    cy.findByTestId("step-data-0-0").within(() => {
-      cy.findByTestId("step-preview-button").click();
+    getNotebookStep("data", { stage: 0 }).within(() => {
+      cy.icon("play").click();
       cy.findByTestId("preview-root")
         .findAllByText("Gizmo")
         .should("be.visible");

--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -923,7 +923,6 @@ describe("issue 40399", () => {
     createQuestion(
       {
         name: "40399",
-
         query: {
           "source-table": PRODUCTS_ID,
           joins: [

--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -34,7 +34,7 @@ import {
   queryBuilderFooter,
 } from "e2e/support/helpers";
 
-const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATABASE;
+const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
 
 describe("issue 32625, issue 31635", () => {
   const CC_NAME = "Is Promotion";
@@ -909,6 +909,70 @@ describe("issue 43294", () => {
     echartsContainer().within(() => {
       cy.findByText("Count").should("be.visible");
       cy.findByText("Created At").should("be.visible");
+    });
+  });
+});
+
+describe("issue 40399", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should not show results from other stages in a stages preview (metabase#40399)", () => {
+    createQuestion(
+      {
+        name: "40399",
+
+        query: {
+          "source-table": PRODUCTS_ID,
+          joins: [
+            {
+              fields: "all",
+              alias: "Orders",
+              "source-table": ORDERS_ID,
+              strategy: "left-join",
+              condition: [
+                "=",
+                ["field", PRODUCTS.ID, null],
+                ["field", ORDERS.PRODUCT_ID, { "join-alias": "Orders" }],
+              ],
+            },
+          ],
+          filter: ["=", ["field", PRODUCTS.CATEGORY, null], "Widget"],
+        },
+      },
+      {
+        visitQuestion: true,
+      },
+    );
+
+    openNotebook();
+
+    cy.findByTestId("step-filter-0-0").within(() => {
+      cy.findByTestId("step-preview-button").click();
+      cy.findByTestId("preview-root")
+        .findAllByText("Widget")
+        .should("be.visible");
+    });
+
+    cy.findByTestId("step-join-0-0").within(() => {
+      cy.findByTestId("step-preview-button").click();
+      cy.findByTestId("preview-root")
+        .findAllByText("Gizmo")
+        .should("be.visible");
+
+      cy.findByTestId("preview-root").findByText("Widget").should("not.exist");
+    });
+
+    cy.findByTestId("step-data-0-0").within(() => {
+      cy.findByTestId("step-preview-button").click();
+      cy.findByTestId("preview-root")
+        .findAllByText("Gizmo")
+        .should("be.visible");
+
+      cy.findByTestId("preview-root").findAllByText("Gizmo").should("exist");
+      cy.findByTestId("preview-root").findAllByText("Widget").should("exist");
     });
   });
 });

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.tsx
@@ -160,6 +160,7 @@ function NotebookStep({
                   transparent
                   hasPreviewButton={hasPreviewButton}
                   onClick={openPreview}
+                  data-testid="step-preview-button"
                 />
               </StepButtonContainer>
             )}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/40399

This issue was fixed with the [introduction of `previewQuery`](https://github.com/metabase/metabase/issues/42831) but this PR adds a reproduction for the broken behavior.


[Stress test run](https://github.com/metabase/metabase/actions/runs/9660564238)