### PR TITLE
move subtext to command palette item generation. Support model-indexes

### DIFF
--- a/frontend/src/metabase/palette/components/PaletteResultItem.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResultItem.tsx
@@ -88,7 +88,10 @@ export const PaletteResultItem = ({ item, active }: PaletteResultItemProps) => {
               fz="0.75rem"
               lh="1rem"
               fw="normal"
-            >{`— ${subtext}`}</Text>
+            >
+              {`—`}
+              {subtext}
+            </Text>
           )}
         </Box>
         <Text

--- a/frontend/src/metabase/palette/components/PaletteResultItem.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResultItem.tsx
@@ -16,8 +16,7 @@ interface PaletteResultItemProps {
 export const PaletteResultItem = ({ item, active }: PaletteResultItemProps) => {
   const icon = item.icon ? getCommandPaletteIcon(item, active) : null;
 
-  const parentName =
-    item.extra?.parentCollection || item.extra?.database || null;
+  const subtext = item.extra?.subtext;
 
   const handleLinkClick = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -81,7 +80,7 @@ export const PaletteResultItem = ({ item, active }: PaletteResultItemProps) => {
               }}
             />
           )}
-          {parentName && (
+          {subtext && (
             <Text
               component="span"
               ml="0.25rem"
@@ -89,7 +88,7 @@ export const PaletteResultItem = ({ item, active }: PaletteResultItemProps) => {
               fz="0.75rem"
               lh="1rem"
               fw="normal"
-            >{`— ${parentName}`}</Text>
+            >{`— ${subtext}`}</Text>
           )}
         </Box>
         <Text

--- a/frontend/src/metabase/palette/components/PaletteResultItem.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResultItem.tsx
@@ -89,8 +89,7 @@ export const PaletteResultItem = ({ item, active }: PaletteResultItemProps) => {
               lh="1rem"
               fw="normal"
             >
-              {`—`}
-              {subtext}
+              — {subtext}
             </Text>
           )}
         </Box>

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -23,7 +23,7 @@ import {
   getSettings,
 } from "metabase/selectors/settings";
 import { getShowMetabaseLinks } from "metabase/selectors/whitelabel";
-import type { IconName } from "metabase/ui";
+import { type IconName, Icon } from "metabase/ui";
 import type { RecentItem } from "metabase-types/api";
 
 import type { PaletteAction } from "../types";
@@ -297,9 +297,21 @@ export const useCommandPalette = ({
   );
 };
 
-const getSearchResultSubtext = (wrappedSearchResult: any) => {
+export const getSearchResultSubtext = (wrappedSearchResult: any) => {
   if (wrappedSearchResult.model === "indexed-entity") {
-    return t`a record in ${wrappedSearchResult.model_name}`;
+    return (
+      <>
+        {t`a record in`}{" "}
+        <Icon
+          name="model"
+          style={{
+            verticalAlign: "bottom",
+            marginLeft: "0.25rem",
+          }}
+        />
+        {`${wrappedSearchResult.model_name}`}
+      </>
+    );
   } else {
     return (
       wrappedSearchResult.getCollection().name ||
@@ -308,7 +320,7 @@ const getSearchResultSubtext = (wrappedSearchResult: any) => {
   }
 };
 
-const getRecentItemSubtext = (item: RecentItem) => {
+export const getRecentItemSubtext = (item: RecentItem) => {
   if (item.model === "table") {
     return item.database.name;
   } else if (item.parent_collection.id === null) {

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -3,7 +3,7 @@ import { useRegisterActions, useKBar, Priority } from "kbar";
 import { useMemo, useState } from "react";
 import { push } from "react-router-redux";
 import { useDebounce } from "react-use";
-import { t } from "ttag";
+import { t, jt } from "ttag";
 
 import { getAdminPaths } from "metabase/admin/app/selectors";
 import { getSectionsWithPlugins } from "metabase/admin/settings/selectors";
@@ -193,9 +193,7 @@ export const useCommandPalette = ({
                 dispatch(push(wrappedResult.getUrl()));
               },
               extra: {
-                parentCollection: wrappedResult.getCollection().name,
                 isVerified: result.moderated_status === "verified",
-                database: result.database_name,
                 href: wrappedResult.getUrl(),
                 iconColor: icon.color,
                 subtext: getSearchResultSubtext(wrappedResult),
@@ -246,9 +244,7 @@ export const useCommandPalette = ({
           },
           extra: {
             isVerified:
-              item.model === "table"
-                ? false
-                : item.moderated_status === "verified",
+              item.model !== "table" && item.moderated_status === "verified",
             href: Urls.modelToUrl(item),
             iconColor: icon.color,
             subtext: getRecentItemSubtext(item),
@@ -299,19 +295,15 @@ export const useCommandPalette = ({
 
 export const getSearchResultSubtext = (wrappedSearchResult: any) => {
   if (wrappedSearchResult.model === "indexed-entity") {
-    return (
-      <>
-        {t`a record in`}{" "}
-        <Icon
-          name="model"
-          style={{
-            verticalAlign: "bottom",
-            marginLeft: "0.25rem",
-          }}
-        />
-        {`${wrappedSearchResult.model_name}`}
-      </>
-    );
+    return jt`a record in ${(
+      <Icon
+        name="model"
+        style={{
+          verticalAlign: "bottom",
+          marginInlineStart: "0.25rem",
+        }}
+      />
+    )} ${wrappedSearchResult.model_name}`;
   } else {
     return (
       wrappedSearchResult.getCollection().name ||

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.unit.spec.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.unit.spec.tsx
@@ -1,0 +1,63 @@
+import type React from "react";
+
+import { render, screen } from "__support__/ui";
+import Search from "metabase/entities/search";
+import { Text } from "metabase/ui";
+import {
+  createMockSearchResult,
+  createMockCollection,
+} from "metabase-types/api/mocks";
+
+import { getSearchResultSubtext } from "./useCommandPalette";
+
+const setup = (child: React.ReactNode) => {
+  render(<Text>{child}</Text>);
+};
+
+describe("useCommandPalette", () => {
+  describe("getSearchResultSubtext", () => {
+    it("should work for model indexes", async () => {
+      const mockSearchResult = Search.wrapEntity(
+        createMockSearchResult({
+          model: "indexed-entity",
+          model_name: "foo",
+        }),
+      );
+      setup(getSearchResultSubtext(mockSearchResult));
+
+      expect(await screen.findByText(/a record in/)).toBeInTheDocument();
+      expect(await screen.findByText(/foo/)).toBeInTheDocument();
+      expect(
+        await screen.findByRole("img", { name: /model/ }),
+      ).toBeInTheDocument();
+    });
+
+    it("should work for cards", async () => {
+      const mockSearchResult = Search.wrapEntity(
+        createMockSearchResult({
+          model: "card",
+          collection: createMockCollection({
+            name: "Foo Collection",
+            id: 2,
+          }),
+        }),
+      );
+      setup(getSearchResultSubtext(mockSearchResult));
+
+      expect(await screen.findByText("Foo Collection")).toBeInTheDocument();
+    });
+
+    it("should work for tables", async () => {
+      const mockSearchResult = Search.wrapEntity(
+        createMockSearchResult({
+          model: "table",
+          collection: createMockCollection({ id: undefined, name: undefined }),
+          database_name: "Bar Database",
+        }),
+      );
+      setup(getSearchResultSubtext(mockSearchResult));
+
+      expect(await screen.findByText("Bar Database")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/metabase/palette/types.ts
+++ b/frontend/src/metabase/palette/types.ts
@@ -5,12 +5,8 @@ import type { IconName } from "metabase/ui";
 
 interface PaletteActionExtras {
   extra?: {
-    /** parentCollection: Name of the collection to show in the palette item */
-    parentCollection?: string | null;
     /** isVerified: If true, will show a verified badge next to the item name */
     isVerified?: boolean;
-    /** database: Name of the database to show next the name in the palette item. */
-    database?: string | null;
     /**
      * href: If defined, the palette item will be wrapped in a link. This allows for
      * browser interactions to open items in new tabs/windows
@@ -18,6 +14,8 @@ interface PaletteActionExtras {
     href?: LocationDescriptor | null;
     /** iconColor: Color of the icon in the  */
     iconColor?: string;
+    /**subtext: text to come after the item name */
+    subtext?: string;
   };
 }
 

--- a/frontend/src/metabase/palette/types.ts
+++ b/frontend/src/metabase/palette/types.ts
@@ -12,9 +12,9 @@ interface PaletteActionExtras {
      * browser interactions to open items in new tabs/windows
      */
     href?: LocationDescriptor | null;
-    /** iconColor: Color of the icon in the  */
+    /** iconColor: Color of the icon in the list item*/
     iconColor?: string;
-    /**subtext: text to come after the item name */
+    /** subtext: text to come after the item name */
     subtext?: string;
   };
 }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/44136

### Description
Adds subtext to search results in the command palette that are indexed entities. Also re-arranges some logic into util files for (hopefully) easier testing

### How to verify

Describe the steps to verify that the changes are working as expected.

1.  Ensure that you have an indexed model (see issue for steps)
2. Type a search query
3. You should see subtext of `a model in ${x}`

### Demo
![image](https://github.com/metabase/metabase/assets/1328979/ec5f6717-d72b-4f47-9a34-f39ea70f5758)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
