### PR TITLE
Allow clicking "Remove all" for the first group in `FieldPanel` and omit removing the first field in the group

### DIFF
--- a/frontend/src/metabase/querying/components/FieldPanel/FieldPanel.tsx
+++ b/frontend/src/metabase/querying/components/FieldPanel/FieldPanel.tsx
@@ -39,8 +39,13 @@ export const FieldPanel = ({
     onChange(toggleColumnInQuery(query, stageIndex, columnItem));
   };
 
-  const handleGroupToggle = (groupItem: ColumnGroupItem) => {
-    onChange(toggleColumnGroupInQuery(query, stageIndex, groupItem));
+  const handleGroupToggle = (
+    groupItem: ColumnGroupItem,
+    groupIndex: number,
+  ) => {
+    onChange(
+      toggleColumnGroupInQuery(query, stageIndex, groupItem, groupIndex),
+    );
   };
 
   return (
@@ -75,7 +80,7 @@ export const FieldPanel = ({
                 checked={groupItem.isSelected}
                 disabled={groupItem.isDisabled}
                 aria-label={groupItem.displayName}
-                onChange={() => handleGroupToggle(groupItem)}
+                onChange={() => handleGroupToggle(groupItem, groupIndex)}
               />
             </Box>
             {groupItem.columnItems.map((columnItem, columnIndex) => (

--- a/frontend/src/metabase/querying/components/FieldPanel/FieldPanel.tsx
+++ b/frontend/src/metabase/querying/components/FieldPanel/FieldPanel.tsx
@@ -39,13 +39,8 @@ export const FieldPanel = ({
     onChange(toggleColumnInQuery(query, stageIndex, columnItem));
   };
 
-  const handleGroupToggle = (
-    groupItem: ColumnGroupItem,
-    groupIndex: number,
-  ) => {
-    onChange(
-      toggleColumnGroupInQuery(query, stageIndex, groupItem, groupIndex),
-    );
+  const handleGroupToggle = (groupItem: ColumnGroupItem) => {
+    onChange(toggleColumnGroupInQuery(query, stageIndex, groupItem));
   };
 
   return (
@@ -80,7 +75,7 @@ export const FieldPanel = ({
                 checked={groupItem.isSelected}
                 disabled={groupItem.isDisabled}
                 aria-label={groupItem.displayName}
-                onChange={() => handleGroupToggle(groupItem, groupIndex)}
+                onChange={() => handleGroupToggle(groupItem)}
               />
             </Box>
             {groupItem.columnItems.map((columnItem, columnIndex) => (

--- a/frontend/src/metabase/querying/components/FieldPanel/FieldPanel.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FieldPanel/FieldPanel.unit.spec.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 
 import { renderWithProviders, screen } from "__support__/ui";
 import * as Lib from "metabase-lib";
-import { createQuery } from "metabase-lib/test-helpers";
+import { createQuery, createQueryWithClauses } from "metabase-lib/test-helpers";
 import { PRODUCTS_ID } from "metabase-types/api/mocks/presets";
 
 import { FieldPanel } from "./FieldPanel";
@@ -138,6 +138,26 @@ describe("QueryColumnPicker", () => {
     for (const column of otherColumns) {
       expect(column).toBeChecked();
       expect(column).toBeEnabled();
+    }
+  });
+
+  it("should not allow to remove fields for aggregated queries", async () => {
+    setup({
+      query: createQueryWithClauses({
+        query: createQuery(),
+        aggregations: [
+          { operatorName: "count" },
+          { operatorName: "sum", columnName: "PRICE", tableName: "PRODUCTS" },
+        ],
+      }),
+    });
+
+    const [group, ...columns] = screen.getAllByRole("checkbox");
+    expect(group).toBeChecked();
+    expect(group).toBeDisabled();
+    for (const column of columns) {
+      expect(column).toBeChecked();
+      expect(column).toBeDisabled();
     }
   });
 

--- a/frontend/src/metabase/querying/components/FieldPanel/FieldPanel.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FieldPanel/FieldPanel.unit.spec.tsx
@@ -169,16 +169,20 @@ describe("QueryColumnPicker", () => {
       Lib.expressionClause("+", [1, 2]),
     );
     setup({ query });
-    const [orderGroup] = screen.getAllByRole("checkbox");
+    const [orderGroup, firstColumn] = screen.getAllByRole("checkbox");
     const customColumn = screen.getByRole("checkbox", { name: "Custom" });
     expect(orderGroup).toBeChecked();
     expect(orderGroup).toBeEnabled();
+    expect(firstColumn).toBeChecked();
+    expect(firstColumn).toBeEnabled();
     expect(customColumn).toBeChecked();
     expect(customColumn).toBeDisabled();
 
     await userEvent.click(orderGroup);
     expect(orderGroup).not.toBeChecked();
     expect(orderGroup).toBeEnabled();
+    expect(firstColumn).toBeChecked();
+    expect(firstColumn).toBeDisabled();
     expect(customColumn).toBeChecked();
     expect(customColumn).toBeDisabled();
   });

--- a/frontend/src/metabase/querying/components/FieldPanel/FieldPanel.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FieldPanel/FieldPanel.unit.spec.tsx
@@ -328,6 +328,33 @@ describe("QueryColumnPicker", () => {
     expect(customColumn).toBeDisabled();
   });
 
+  it("should not allow to remove columns when there are expressions and only one removable column in multi-stage queries", () => {
+    const initialQuery = Lib.appendStage(
+      createQueryWithClauses({
+        query: createQuery(),
+        breakouts: [{ tableName: "PRODUCTS", columnName: "PRICE" }],
+      }),
+    );
+    const stageIndex = 1;
+    setup({
+      query: Lib.expression(
+        initialQuery,
+        stageIndex,
+        "Custom",
+        Lib.expressionClause("+", [1, 2]),
+      ),
+    });
+
+    const [group, ...columns] = screen.getAllByRole("checkbox");
+    expect(group).toBeChecked();
+    expect(group).toBeDisabled();
+    expect(columns.length).toBe(2);
+    for (const column of columns) {
+      expect(column).toBeChecked();
+      expect(column).toBeDisabled();
+    }
+  });
+
   it("should allow to search for columns", async () => {
     setup();
     await userEvent.type(

--- a/frontend/src/metabase/querying/components/FieldPanel/FieldPanel.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FieldPanel/FieldPanel.unit.spec.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { renderWithProviders, screen } from "__support__/ui";
 import * as Lib from "metabase-lib";
 import { createQuery } from "metabase-lib/test-helpers";
+import { PRODUCTS_ID } from "metabase-types/api/mocks/presets";
 
 import { FieldPanel } from "./FieldPanel";
 
@@ -98,12 +99,12 @@ describe("QueryColumnPicker", () => {
     expect(vendorColumn).not.toBeChecked();
   });
 
-  it("should not allow to remove the last column from the data source", async () => {
+  it("should not allow to remove the last column from the data source one by one", async () => {
     setup();
     const [orderGroup, firstColumn, ...otherColumns] =
       screen.getAllByRole("checkbox");
     expect(orderGroup).toBeChecked();
-    expect(orderGroup).toBeDisabled();
+    expect(orderGroup).toBeEnabled();
 
     for (const column of otherColumns) {
       await userEvent.click(column);
@@ -112,13 +113,35 @@ describe("QueryColumnPicker", () => {
     expect(firstColumn).toBeDisabled();
     expect(orderGroup).toBeEnabled();
     expect(orderGroup).not.toBeChecked();
+  });
+
+  it("should not allow to remove the last column from the data source via group", async () => {
+    setup({ query: Lib.withDifferentTable(createQuery(), PRODUCTS_ID) });
+    const [orderGroup, firstColumn, ...otherColumns] =
+      screen.getAllByRole("checkbox");
+    expect(orderGroup).toBeChecked();
+    expect(orderGroup).toBeEnabled();
+
+    await userEvent.click(orderGroup);
+    expect(orderGroup).not.toBeChecked();
+    expect(orderGroup).toBeEnabled();
+    expect(firstColumn).toBeChecked();
+    expect(firstColumn).toBeDisabled();
+    for (const column of otherColumns) {
+      expect(column).not.toBeChecked();
+      expect(column).toBeEnabled();
+    }
 
     await userEvent.click(orderGroup);
     expect(firstColumn).toBeChecked();
     expect(firstColumn).toBeEnabled();
+    for (const column of otherColumns) {
+      expect(column).toBeChecked();
+      expect(column).toBeEnabled();
+    }
   });
 
-  it("should not allow to remove custom columns", () => {
+  it("should not allow to remove custom columns", async () => {
     const query = Lib.expression(
       createQuery(),
       -1,
@@ -129,7 +152,13 @@ describe("QueryColumnPicker", () => {
     const [orderGroup] = screen.getAllByRole("checkbox");
     const customColumn = screen.getByRole("checkbox", { name: "Custom" });
     expect(orderGroup).toBeChecked();
-    expect(orderGroup).toBeDisabled();
+    expect(orderGroup).toBeEnabled();
+    expect(customColumn).toBeChecked();
+    expect(customColumn).toBeDisabled();
+
+    await userEvent.click(orderGroup);
+    expect(orderGroup).not.toBeChecked();
+    expect(orderGroup).toBeEnabled();
     expect(customColumn).toBeChecked();
     expect(customColumn).toBeDisabled();
   });

--- a/frontend/src/metabase/querying/components/FieldPanel/types.ts
+++ b/frontend/src/metabase/querying/components/FieldPanel/types.ts
@@ -13,4 +13,5 @@ export type ColumnGroupItem = {
   displayName: string;
   isSelected: boolean;
   isDisabled: boolean;
+  isSourceGroup: boolean;
 };

--- a/frontend/src/metabase/querying/components/FieldPanel/types.ts
+++ b/frontend/src/metabase/querying/components/FieldPanel/types.ts
@@ -4,6 +4,7 @@ export type ColumnItem = {
   column: Lib.ColumnMetadata;
   displayName: string;
   isSelected: boolean;
+  isEditable: boolean;
   isDisabled: boolean;
 };
 

--- a/frontend/src/metabase/querying/components/FieldPanel/types.ts
+++ b/frontend/src/metabase/querying/components/FieldPanel/types.ts
@@ -4,7 +4,6 @@ export type ColumnItem = {
   column: Lib.ColumnMetadata;
   displayName: string;
   isSelected: boolean;
-  isEditable: boolean;
   isDisabled: boolean;
 };
 

--- a/frontend/src/metabase/querying/components/FieldPanel/utils.ts
+++ b/frontend/src/metabase/querying/components/FieldPanel/utils.ts
@@ -40,7 +40,7 @@ function getGroupsWithColumns(
   columns: Lib.ColumnMetadata[],
 ): ColumnGroupItem[] {
   const groups = Lib.groupColumns(columns);
-  return groups.map(group => {
+  return groups.map((group, groupIndex) => {
     const groupInfo = Lib.displayInfo(query, stageIndex, group);
     const columnItems = getColumnItems(query, stageIndex, group);
 
@@ -50,6 +50,7 @@ function getGroupsWithColumns(
         groupInfo.fkReferenceName || groupInfo.displayName || t`Question`,
       isSelected: columnItems.every(({ isSelected }) => isSelected),
       isDisabled: columnItems.every(({ isDisabled }) => isDisabled),
+      isSourceGroup: groupIndex === 0,
     };
   });
 }
@@ -57,8 +58,8 @@ function getGroupsWithColumns(
 function disableLastSelectedQueryColumn(
   groupItems: ColumnGroupItem[],
 ): ColumnGroupItem[] {
-  return groupItems.map((groupItem, groupIndex) => {
-    if (groupIndex !== 0) {
+  return groupItems.map(groupItem => {
+    if (!groupItem.isSourceGroup) {
       return groupItem;
     }
 
@@ -139,12 +140,11 @@ export function toggleColumnGroupInQuery(
   query: Lib.Query,
   stageIndex: number,
   groupItem: ColumnGroupItem,
-  groupIndex: number,
 ) {
   if (groupItem.isSelected) {
     return groupItem.columnItems
       .filter(columnItem => columnItem.isSelected && columnItem.isEditable)
-      .filter((_, columnIndex) => !(groupIndex === 0 && columnIndex === 0))
+      .filter((_, columnIndex) => !groupItem.isSourceGroup || columnIndex !== 0)
       .reduce(
         (query, { column }) => Lib.removeField(query, stageIndex, column),
         query,

--- a/frontend/src/metabase/querying/components/FieldPanel/utils.ts
+++ b/frontend/src/metabase/querying/components/FieldPanel/utils.ts
@@ -142,6 +142,7 @@ export function toggleColumnGroupInQuery(
   groupItem: ColumnGroupItem,
 ) {
   if (groupItem.isSelected) {
+    // always leave 1 column in the first group selected to prevent creating queries without columns
     return groupItem.columnItems
       .filter(columnItem => columnItem.isSelected && !columnItem.isDisabled)
       .filter((_, columnIndex) => !groupItem.isSourceGroup || columnIndex !== 0)

--- a/frontend/src/metabase/querying/components/FieldPanel/utils.ts
+++ b/frontend/src/metabase/querying/components/FieldPanel/utils.ts
@@ -74,7 +74,8 @@ function disableLastSelectedQueryColumn(
           columnItem.isDisabled ||
           (columnItem.isSelected && isOnlySelectedColumn),
       })),
-      isDisabled: groupItem.isSelected && isOnlySelectedColumn,
+      isDisabled:
+        groupItem.isDisabled || (groupItem.isSelected && isOnlySelectedColumn),
     };
   });
 }

--- a/frontend/src/metabase/querying/components/FieldPanel/utils.ts
+++ b/frontend/src/metabase/querying/components/FieldPanel/utils.ts
@@ -64,7 +64,9 @@ function disableLastSelectedQueryColumn(
     }
 
     const isOnlySelectedColumn =
-      groupItem.columnItems.filter(({ isSelected }) => isSelected).length === 1;
+      groupItem.columnItems.filter(
+        ({ isSelected, isEditable }) => isSelected && isEditable,
+      ).length === 1;
 
     return {
       ...groupItem,


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/39912

Previously it wasn't possible to click "Remove all" for the first group in the `FieldPanel`. Now we allow that but leave the first selected field untouched. This matches the notebook behavior.

How to verify:
- New -> Question -> Products
- Visualize
- Viz settings -> Add or remove columns
- Try `Add all` / `Remove all`
- Try adding custom expressions (which cannot be removed), aggregations, breakouts and see what happens
- Note that when there are expressions we now disallow deselecting the first field which is not the case in `master`. This is to prevent from construction of subsequently broken queries in the notebook editor which requires 1 field to be selected.

<img width="350" alt="Screenshot 2024-06-24 at 17 17 31" src="https://github.com/metabase/metabase/assets/8542534/4ec11cbf-c2ee-4598-a05f-4064c995bfd2">
<img width="342" alt="Screenshot 2024-06-24 at 17 17 37" src="https://github.com/metabase/metabase/assets/8542534/dd8993c2-f4d5-4197-9426-caa528124a83">
<img width="354" alt="Screenshot 2024-06-24 at 17 25 21" src="https://github.com/metabase/metabase/assets/8542534/d1d96572-71f5-41e3-b1a2-b23b7f1a4cee">
<img width="335" alt="Screenshot 2024-06-24 at 17 25 50" src="https://github.com/metabase/metabase/assets/8542534/a274148c-bca5-4866-87ee-ca2ef3c0c093">
<img width="336" alt="Screenshot 2024-06-24 at 17 28 38" src="https://github.com/metabase/metabase/assets/8542534/8fe21d40-6fb4-43ee-a0ba-327ec2a298c8">
