### PR TITLE
Fix parsing of MB_JETTY_SKIP_SNI

### DIFF
--- a/src/metabase/server.clj
+++ b/src/metabase/server.clj
@@ -28,7 +28,7 @@
     :trust-password  (config/config-str :mb-jetty-ssl-truststore-password)
     :client-auth     (when (config/config-bool :mb-jetty-ssl-client-auth)
                        :need)
-    :sni-host-check? (when (config/config-str :mb-jetty-skip-sni)
+    :sni-host-check? (when (config/config-bool :mb-jetty-skip-sni)
                        false)}))
 
 (defn- jetty-config []

--- a/test/metabase/server_test.clj
+++ b/test/metabase/server_test.clj
@@ -6,16 +6,18 @@
 
 (deftest config-test
   (testing "Make sure our Jetty config functions work as expected/we don't accidentally break things (#9333)"
-    (with-redefs [config/config-str (constantly "10")]
+    (with-redefs [config/config-str (constantly "10")
+                  config/config-bool (constantly true)]
       (is (= {:keystore            "10"
               :max-queued          10
               :request-header-size 10
               :port                10
               :min-threads         10
               :host                "10"
-              :daemon?             false
+              :daemon?             true
               :ssl?                true
               :sni-host-check?     false
+              :client-auth         :need
               :trust-password      "10"
               :key-password        "10"
               :truststore          "10"


### PR DESCRIPTION
Env var should be parsed as a bool, not a string.

Fixes https://github.com/metabase/metabase/issues/42435.