### PR TITLE
Add e2e repro for "Join condition is not automatically selected"

### DIFF
--- a/e2e/test/scenarios/joins/joins-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins-reproductions.cy.spec.js
@@ -1111,3 +1111,27 @@ describe("issue 31769", () => {
       .should("exist");
   });
 });
+
+describe("issue 39448", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("should load joined table metadata for suggested join conditions (metabase#39448)", () => {
+    openOrdersTable({ mode: "notebook" });
+    cy.findByTestId("action-buttons").button("Join data").click();
+    entityPickerModal().within(() => {
+      entityPickerModalTab("Tables").click();
+      cy.findByText("Products").click();
+    });
+    getNotebookStep("join").within(() => {
+      cy.findByLabelText("Right table").should("have.text", "Products");
+      cy.findByLabelText("Left column")
+        .findByText("Product ID")
+        .should("be.visible");
+      cy.findByLabelText("Right column").findByText("ID").should("be.visible");
+      cy.findByLabelText("Change operator").should("have.text", "=");
+    });
+  });
+});


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39448
Reproduces https://github.com/metabase/metabase/issues/39448

Seems like a temporary regression in master, but let's add an explicit test for it anyway.

How to verify:
- Open home -> reload
- New -> Question -> Orders -> Save
- Join -> Tables -> Products
- The join condition should appear