### PR TITLE
Fix flaky test:  update-db-to-never-scan-values-on-demand-test 

### DIFF
--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -1745,6 +1745,8 @@
   (impl/test-migrations ["v50.2024-04-25T01:04:06"] [migrate!]
     (migrate!)
     (pulse-channel-test/with-send-pulse-setup!
+      ;; need this because the InitSendPulseTriggers job will need access to the scheduler, and since
+      ;; quartz job is running in a different thread other than this test's thread, we need to bind it globally
       (with-redefs [task/*quartz-scheduler* task/*quartz-scheduler*]
         (let [user-id  (:id (new-instance-with-default :core_user))
               pulse-id (:id (new-instance-with-default :pulse {:creator_id user-id}))

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -1746,7 +1746,7 @@
     (migrate!)
     (pulse-channel-test/with-send-pulse-setup!
       ;; the `pulse-channell-test/with-send-pulse-setup!` macro dynamically binds an in-memory scheduler to `task/*quartz-scheduler*`
-      ;; but we need to re-bind that to global here because the InitSendPulseTriggers job will need access to the scheduler, 
+      ;; but we need to re-bind that to global here because the InitSendPulseTriggers job will need access to the scheduler,
       ;; and since quartz job is running in a different thread other than this test's thread, we need to bind it globally
       (with-redefs [task/*quartz-scheduler* task/*quartz-scheduler*]
         (let [user-id  (:id (new-instance-with-default :core_user))

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -1745,8 +1745,9 @@
   (impl/test-migrations ["v50.2024-04-25T01:04:06"] [migrate!]
     (migrate!)
     (pulse-channel-test/with-send-pulse-setup!
-      ;; need this because the InitSendPulseTriggers job will need access to the scheduler, and since
-      ;; quartz job is running in a different thread other than this test's thread, we need to bind it globally
+      ;; the `pulse-channell-test/with-send-pulse-setup!` macro dynamically binds an in-memory scheduler to `task/*quartz-scheduler*`
+      ;; but we need to re-bind that to global here because the InitSendPulseTriggers job will need access to the scheduler, 
+      ;; and since quartz job is running in a different thread other than this test's thread, we need to bind it globally
       (with-redefs [task/*quartz-scheduler* task/*quartz-scheduler*]
         (let [user-id  (:id (new-instance-with-default :core_user))
               pulse-id (:id (new-instance-with-default :pulse {:creator_id user-id}))


### PR DESCRIPTION
The failure

```
  update db setting to never scan should remove scan field values trigger sanity check that it has all triggers to begin with
expected: #{"metabase.task.sync-and-analyze.trigger.157"
            "metabase.task.update-field-values.trigger.157"}
  actual: #{}  
```
this indicates that the scheduler doesn't have any triggers, and I suspect it's because the scheduler was shut down.
And the reason is that we were using `with-redefs` to bind `quartz-scheduler` during test, and there might be parallel tests that's using the scheduler to and it's shutdown the scheduler after it's done.

Closes https://github.com/metabase/metabase/issues/44148