### PR TITLE
Tag core-release group in pre-release messages

### DIFF
--- a/.github/workflows/release-status.yml
+++ b/.github/workflows/release-status.yml
@@ -3,7 +3,7 @@ name: Release and Backport Status Check
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 11 * * 1-5' # every weekday at 6am US eastern time
+    - cron: '0 7 * * 1-5' # every weekday at 8am/9am Central European Time
 
 jobs:
   check-release-status:

--- a/release/github-slack-map.json
+++ b/release/github-slack-map.json
@@ -86,5 +86,6 @@
   "core-ems": "S053QF4U49G",
   "tech-writers": "S078147J78S",
   "successengineers": "S05AAL8PUA1",
-  "growth": "S056LQCRQG5"
+  "growth": "S056LQCRQG5",
+  "core-release": "S02UJK9DN59"
 }

--- a/release/src/slack.ts
+++ b/release/src/slack.ts
@@ -116,7 +116,7 @@ export async function sendPreReleaseStatus({
 			"type": "section",
 			"text": {
 				"type": "mrkdwn",
-				"text": `_<https://github.com/metabase/metabase/milestone/${milestoneId}|:direction-sign: Milestone> targeted for release on ${date}_`,
+				"text": `_<https://github.com/metabase/metabase/milestone/${milestoneId}|:direction-sign: Milestone> targeted for release on ${date}_ ${mentionSlackTeam('core-release')}`,
 			}
 		},
   ];


### PR DESCRIPTION

### Description

Update the pre-release status slack messages to
- be earlier in the day, European time
- tag the @core-release slack team


<img width="643" alt="Screen Shot 2024-06-25 at 9 19 28 AM" src="https://github.com/metabase/metabase/assets/30528226/3ca07fcc-52ad-4e1c-94af-a0a793f5a4eb">
