### PR TITLE
Add missing tests for temporal unit parameters parsing and fix issues

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/temporal-unit-parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/temporal-unit-parameters.cy.spec.js
@@ -503,20 +503,20 @@ describe("scenarios > dashboard > temporal unit parameters", () => {
       popover().findByText("UNIT").click();
       saveDashboard();
 
-      cy.log("verify click behavior with a valid temporal unit");
-      getDashboardCard().findByText("year").click();
-      dashboardHeader().findByText("Target dashboard").should("be.visible");
-      filterWidget().findByText("Year").should("be.visible");
-      getDashboardCard().findByText("Created At: Year").should("be.visible");
-
       cy.log("verify that invalid temporal units are ignored");
-      visitDashboard("@sourceDashboardId");
       getDashboardCard().findByText("invalid").click();
       dashboardHeader().findByText("Target dashboard").should("be.visible");
       filterWidget()
         .findByText(/invalid/i)
         .should("not.exist");
       getDashboardCard().findByText("Created At: Month").should("be.visible");
+
+      cy.log("verify click behavior with a valid temporal unit");
+      visitDashboard("@sourceDashboardId");
+      getDashboardCard().findByText("year").click();
+      dashboardHeader().findByText("Target dashboard").should("be.visible");
+      filterWidget().findByText("Year").should("be.visible");
+      getDashboardCard().findByText("Created At: Year").should("be.visible");
     });
 
     it("should pass a temporal unit with 'custom destination -> url' click behavior", () => {

--- a/frontend/src/metabase-lib/v1/parameters/utils/click-behavior.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/click-behavior.ts
@@ -37,6 +37,8 @@ import type {
 } from "metabase-types/api";
 import { isImplicitActionClickBehavior } from "metabase-types/guards";
 
+import { parseParameterValue } from "./parameter-parsing";
+
 interface Target {
   id: Parameter["id"];
   name: Parameter["name"] | null | undefined;
@@ -372,6 +374,12 @@ export function formatSourceForTarget(
   },
 ) {
   const datum = data[source.type][source.id.toLowerCase()] || {};
+  const parameter = getParameter(target, { extraData, clickBehavior });
+
+  if (parameter?.type === "temporal-unit") {
+    return parseParameterValue(datum.value, parameter);
+  }
+
   if (
     "column" in datum &&
     datum.column &&
@@ -382,7 +390,6 @@ export function formatSourceForTarget(
 
     if (target.type === "parameter") {
       // we should serialize differently based on the target parameter type
-      const parameter = getParameter(target, { extraData, clickBehavior });
       if (parameter) {
         return formatDateForParameterType(
           datum.value,

--- a/frontend/src/metabase-lib/v1/parameters/utils/parameter-parsing.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/parameter-parsing.ts
@@ -34,7 +34,7 @@ export function getParameterValueFromQueryParams(
   return normalizeParameterValueForWidget(parsedValue, parameter);
 }
 
-function parseParameterValue(value: any, parameter: Parameter) {
+export function parseParameterValue(value: any, parameter: Parameter) {
   const type = getParameterType(parameter);
   if (type === "temporal-unit") {
     const availableUnits = Lib.availableTemporalUnits();

--- a/frontend/src/metabase-lib/v1/parameters/utils/parameter-parsing.unit.spec.js
+++ b/frontend/src/metabase-lib/v1/parameters/utils/parameter-parsing.unit.spec.js
@@ -1,7 +1,7 @@
 import {
   getParameterValueFromQueryParams,
   getParameterValuesByIdFromQueryParams,
-} from "./parameter-values";
+} from "./parameter-parsing";
 
 describe("parameters/utils/parameter-values", () => {
   let field1;

--- a/frontend/src/metabase/dashboard/actions/data-fetching-typed.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching-typed.ts
@@ -13,9 +13,9 @@ import Dashboards from "metabase/entities/dashboards";
 import type { Deferred } from "metabase/lib/promise";
 import { defer } from "metabase/lib/promise";
 import { createAsyncThunk } from "metabase/lib/redux";
-import { getParameterValuesByIdFromQueryParams } from "metabase/parameters/utils/parameter-values";
 import { addFields, addParamValues } from "metabase/redux/metadata";
 import { AutoApi, DashboardApi, EmbedApi, PublicApi } from "metabase/services";
+import { getParameterValuesByIdFromQueryParams } from "metabase-lib/v1/parameters/utils/parameter-parsing";
 import type { DashboardCard, DashboardId } from "metabase-types/api";
 
 // normalizr schemas

--- a/frontend/src/metabase/dashboard/actions/parameters.ts
+++ b/frontend/src/metabase/dashboard/actions/parameters.ts
@@ -16,9 +16,9 @@ import {
   setParameterName as setParamName,
   setParameterType as setParamType,
 } from "metabase/parameters/utils/dashboards";
-import { getParameterValuesByIdFromQueryParams } from "metabase/parameters/utils/parameter-values";
 import { addUndo, dismissUndo } from "metabase/redux/undo";
 import { buildTemporalUnitOption } from "metabase-lib/v1/parameters/utils/operators";
+import { getParameterValuesByIdFromQueryParams } from "metabase-lib/v1/parameters/utils/parameter-parsing";
 import {
   isParameterValueEmpty,
   PULSE_PARAM_EMPTY,

--- a/frontend/src/metabase/parameters/utils/parameter-values.ts
+++ b/frontend/src/metabase/parameters/utils/parameter-values.ts
@@ -1,5 +1,6 @@
 import type { Query } from "history";
 
+import * as Lib from "metabase-lib";
 import type Field from "metabase-lib/v1/metadata/Field";
 import type { FieldFilterUiParameter } from "metabase-lib/v1/parameters/types";
 import { getParameterType } from "metabase-lib/v1/parameters/utils/parameter-type";
@@ -34,13 +35,18 @@ export function getParameterValueFromQueryParams(
 }
 
 function parseParameterValue(value: any, parameter: Parameter) {
+  const type = getParameterType(parameter);
+  if (type === "temporal-unit") {
+    const availableUnits = Lib.availableTemporalUnits();
+    return availableUnits.some(unit => unit === value) ? value : null;
+  }
+
   // TODO this casting should be removed as we tidy up Parameter types
   const { fields } = parameter as FieldFilterUiParameter;
   if (Array.isArray(fields) && fields.length > 0) {
     return parseParameterValueForFields(value, fields);
   }
 
-  const type = getParameterType(parameter);
   if (type === "number") {
     return parseParameterValueForNumber(value);
   }

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion.tsx
@@ -4,7 +4,6 @@ import { useMount } from "react-use";
 import _ from "underscore";
 
 import { useDispatch, useSelector } from "metabase/lib/redux";
-import { getParameterValuesByIdFromQueryParams } from "metabase/parameters/utils/parameter-values";
 import { useEmbedFrameOptions } from "metabase/public/hooks";
 import { setErrorPage } from "metabase/redux/app";
 import { addParamValues, addFields } from "metabase/redux/metadata";
@@ -17,6 +16,7 @@ import {
   maybeUsePivotEndpoint,
 } from "metabase/services";
 import { getCardUiParameters } from "metabase-lib/v1/parameters/utils/cards";
+import { getParameterValuesByIdFromQueryParams } from "metabase-lib/v1/parameters/utils/parameter-parsing";
 import { getParameterValuesBySlug } from "metabase-lib/v1/parameters/utils/parameter-values";
 import { getParametersFromCard } from "metabase-lib/v1/parameters/utils/template-tags";
 import { applyParameters } from "metabase-lib/v1/queries/utils/card";

--- a/frontend/src/metabase/query_builder/actions/core/parameterUtils.ts
+++ b/frontend/src/metabase/query_builder/actions/core/parameterUtils.ts
@@ -1,9 +1,9 @@
 import { hasMatchingParameters } from "metabase/parameters/utils/dashboards";
-import { getParameterValuesByIdFromQueryParams } from "metabase/parameters/utils/parameter-values";
 import { setErrorPage } from "metabase/redux/app";
 import { DashboardApi } from "metabase/services";
 import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import { getCardUiParameters } from "metabase-lib/v1/parameters/utils/cards";
+import { getParameterValuesByIdFromQueryParams } from "metabase-lib/v1/parameters/utils/parameter-parsing";
 import {
   cardIsEquivalent,
   cardParametersAreEquivalent,


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/42118

Previously it was possible to pass invalid temporal unit parameters
- via URL
- via click behaviors

This PR fixes these issues and adds the corresponding tests.

Also found a BE issue https://github.com/metabase/metabase/issues/44684