### PR TITLE
Fix cross-version tests

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -88,6 +88,8 @@ sources: &sources
   - *frontend_sources
   - *backend_sources
 
+
+
 e2e_ci: &e2e_ci
   - ".github/actions/build-e2e-matrix/**"
   - ".github/actions/prepare-frontend/**"
@@ -97,6 +99,7 @@ e2e_ci: &e2e_ci
   - ".github/actions/prepare-cypress/**"
   - ".github/actions/run-snowplow-micro/**"
   - ".github/workflows/e2e-tests.yml"
+  - ".github/workflows/e2e-cross-version.yml"
 
 e2e_specs: &e2e_specs
   - "**/*.cy.*.js"
@@ -105,11 +108,15 @@ e2e_specs: &e2e_specs
   - "e2e/support/**"
   - "e2e/snapshot*/**"
 
+e2e_cross_version: &e2e_cross_version
+  - "e2e/test/scenarios/cross-version/**"
+
 e2e_all:
   - *default
   - *e2e_ci
   - *sources
   - *e2e_specs
+  - *e2e_cross_version
 
 snowplow:
   - ".github/workflows/snowplow.yml"

--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -99,7 +99,6 @@ e2e_ci: &e2e_ci
   - ".github/actions/prepare-cypress/**"
   - ".github/actions/run-snowplow-micro/**"
   - ".github/workflows/e2e-tests.yml"
-  - ".github/workflows/e2e-cross-version.yml"
 
 e2e_specs: &e2e_specs
   - "**/*.cy.*.js"
@@ -109,6 +108,7 @@ e2e_specs: &e2e_specs
   - "e2e/snapshot*/**"
 
 e2e_cross_version: &e2e_cross_version
+  - ".github/workflows/e2e-cross-version.yml"
   - "e2e/test/scenarios/cross-version/**"
 
 e2e_all:
@@ -116,7 +116,6 @@ e2e_all:
   - *e2e_ci
   - *sources
   - *e2e_specs
-  - *e2e_cross_version
 
 snowplow:
   - ".github/workflows/snowplow.yml"

--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -88,8 +88,6 @@ sources: &sources
   - *frontend_sources
   - *backend_sources
 
-
-
 e2e_ci: &e2e_ci
   - ".github/actions/build-e2e-matrix/**"
   - ".github/actions/prepare-frontend/**"

--- a/.github/workflows/e2e-cross-version.yml
+++ b/.github/workflows/e2e-cross-version.yml
@@ -3,6 +3,8 @@ name: E2E Cross-version Tests
 on:
   schedule:
     - cron: '0 9 * * 0'
+  pull_request: # just for testing
+    types: [opened, synchronize]
 
 jobs:
   cross-version-testing:
@@ -100,17 +102,7 @@ jobs:
     if: ${{ always() && contains(needs.*.result, 'failure') }}
     name: Cross-version test failure
     runs-on: ubuntu-22.04
-    env:
-      BRANCH_NAME: ${{ github.event.workflow_run.head_branch }}
-      AUTHOR_NAME: ${{ github.event.workflow_run.head_commit.author.name }}
     steps:
-      - name: Generate job summary
-        run: |
-          echo "# ${{ github.event.workflow_run.name }} workflow failed! :x:" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "View the failed run attempt (#${{ github.event.workflow_run.run_attempt }}) using the following link:" >> $GITHUB_STEP_SUMMARY
-          echo "${{ github.event.workflow_run.html_url }}" >> $GITHUB_STEP_SUMMARY
-
       - uses: actions/setup-node@v4
         with:
           node-version: lts/Hydrogen # 18.x.x
@@ -119,9 +111,9 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: | # js
-            const FAILED_RUN_URL = "${{ github.event.workflow_run.html_url }}";
-            const FAILED_RUN_NAME = "${{ github.event.workflow_run.name }}";
-            const BREAKING_COMMIT = "${{ github.event.workflow_run.head_sha }}";
+            const FAILED_RUN_URL = "${{ github.event.schedule.html_url }}";
+            const FAILED_RUN_NAME = "${{ github.event.schedule.name }}";
+            const BREAKING_COMMIT = "${{ github.event.schedule.head_sha }}";
             const AUTHOR = process.env.AUTHOR_NAME;
             const BRANCH = process.env.BRANCH_NAME;
 

--- a/.github/workflows/e2e-cross-version.yml
+++ b/.github/workflows/e2e-cross-version.yml
@@ -2,14 +2,31 @@ name: E2E Cross-version Tests
 
 on:
   schedule:
-    - cron: '0 9 * * 0'
-  pull_request: # just for testing
-    types: [opened, synchronize]
+    - cron: '0 9 * * 1-5'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
-  cross-version-testing:
+  files-changed:
+    name: Check which files changed
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 3
+    outputs:
+      e2e_cross_version: ${{ steps.changes.outputs.e2e_cross_version }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test which files changed
+        uses: dorny/paths-filter@v3.0.0
+        id: changes
+        with:
+          token: ${{ github.token }}
+          filters: .github/file-paths.yaml
+
+  cross-version-testing:
+    needs: files-changed
+    if: ${{ needs.files-changed.outputs.e2e_cross_version == 'true' || github.event_name == 'schedule'}}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
     strategy:
       matrix:
         version: [
@@ -99,9 +116,10 @@ jobs:
         if-no-files-found: ignore
   notify-on-failure:
     needs: cross-version-testing
-    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    if: ${{ always() && contains(needs.*.result, 'failure') && github.ref_name == 'master' }}
     name: Cross-version test failure
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     steps:
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/e2e-cross-version.yml
+++ b/.github/workflows/e2e-cross-version.yml
@@ -112,10 +112,7 @@ jobs:
         with:
           script: | # js
             const FAILED_RUN_URL = "${{ github.event.schedule.html_url }}";
-            const FAILED_RUN_NAME = "${{ github.event.schedule.name }}";
-            const BREAKING_COMMIT = "${{ github.event.schedule.head_sha }}";
-            const AUTHOR = process.env.AUTHOR_NAME;
-            const BRANCH = process.env.BRANCH_NAME;
+            const COMMIT_SHA = "${{ github.sha }}";
 
             // notify slack of failure
             const { WebClient } = require('@slack/web-api');
@@ -130,7 +127,7 @@ jobs:
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": `:broken_heart:   Cross-version tests are failing on ${BRANCH}`,
+                    "text": `:broken_heart:   Cross-version tests are failing`,
                     "emoji": true,
                   }
                 },
@@ -142,7 +139,7 @@ jobs:
                     "type": "section",
                     "text": {
                       "type": "mrkdwn",
-                      "text": `Commit <https://github.com/metabase/metabase/commit/${BREAKING_COMMIT}|${BREAKING_COMMIT.slice(0,7)}> has failing <${FAILED_RUN_URL}|${FAILED_RUN_NAME}> tests on the <https://github.com/metabase/metabase/commits/${BRANCH}|\`${BRANCH}\`> branch.`
+                      "text": `See <${FAILED_RUN_URL}|failing run details>.`
                     }
                   },
                 ]

--- a/.github/workflows/e2e-cross-version.yml
+++ b/.github/workflows/e2e-cross-version.yml
@@ -121,6 +121,7 @@ jobs:
             const { WebClient } = require('@slack/web-api');
             const slack = new WebClient('${{ secrets.SLACK_BOT_TOKEN }}');
 
+            /* FIXME test code
             await slack.chat.postMessage({
               channel: 'engineering-ci',
               text: 'Cross-version Tests Have Failed',
@@ -147,3 +148,4 @@ jobs:
                 ]
               }]
             });
+            */

--- a/.github/workflows/e2e-cross-version.yml
+++ b/.github/workflows/e2e-cross-version.yml
@@ -136,7 +136,6 @@ jobs:
             const { WebClient } = require('@slack/web-api');
             const slack = new WebClient('${{ secrets.SLACK_BOT_TOKEN }}');
 
-            /* FIXME test code
             await slack.chat.postMessage({
               channel: 'engineering-ci',
               text: 'Cross-version Tests Have Failed',
@@ -163,4 +162,3 @@ jobs:
                 ]
               }]
             });
-            */

--- a/e2e/support/helpers/e2e-table-metadata-helpers.js
+++ b/e2e/support/helpers/e2e-table-metadata-helpers.js
@@ -12,3 +12,18 @@ export const createSegment = ({
     definition,
   });
 };
+
+export const createMetric = ({
+  name,
+  table_id,
+  definition,
+  description = null,
+}) => {
+  cy.log(`Create a metric: ${name}`);
+  return cy.request("POST", "/api/legacy-metric", {
+    name,
+    description,
+    table_id,
+    definition,
+  });
+};

--- a/e2e/support/helpers/e2e-table-metadata-helpers.js
+++ b/e2e/support/helpers/e2e-table-metadata-helpers.js
@@ -20,6 +20,7 @@ export const createMetric = ({
   description = null,
 }) => {
   cy.log(`Create a metric: ${name}`);
+  // This endpoint doesn't exist anymore, but we need this helper for cross-version tests
   return cy.request("POST", "/api/metric", {
     name,
     description,

--- a/e2e/support/helpers/e2e-table-metadata-helpers.js
+++ b/e2e/support/helpers/e2e-table-metadata-helpers.js
@@ -20,7 +20,7 @@ export const createMetric = ({
   description = null,
 }) => {
   cy.log(`Create a metric: ${name}`);
-  return cy.request("POST", "/api/legacy-metric", {
+  return cy.request("POST", "/api/metric", {
     name,
     description,
     table_id,

--- a/e2e/test/scenarios/cross-version/helpers/cross-version-helpers.js
+++ b/e2e/test/scenarios/cross-version/helpers/cross-version-helpers.js
@@ -1,5 +1,3 @@
-import { echartsContainer } from "e2e/support/helpers";
-
 export function parseVersionString(versionString) {
   if (typeof versionString === "undefined") {
     return []; // Return empty array if versionString is undefined
@@ -147,13 +145,13 @@ export function saveQuestion({ majorVersion }) {
 
 export function assertTimelineData({ majorVersion }) {
   if (majorVersion < sampleDataTimesChangedVersion) {
-    echartsContainer()
+    cy.get(".x.axis .tick")
       .should("contain", "Q1 - 2017")
       .and("contain", "Q1 - 2018")
       .and("contain", "Q1 - 2019")
       .and("contain", "Q1 - 2020");
   } else {
-    echartsContainer()
+    cy.get(".x.axis .tick")
       .should("contain", "Q1 2023")
       .and("contain", "Q1 2024")
       .and("contain", "Q1 2025")

--- a/e2e/test/scenarios/cross-version/source/02-datamodel.cy.spec.js
+++ b/e2e/test/scenarios/cross-version/source/02-datamodel.cy.spec.js
@@ -1,6 +1,9 @@
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { createSegment } from "e2e/support/helpers/e2e-table-metadata-helpers";
+import {
+  createSegment,
+  createMetric,
+} from "e2e/support/helpers/e2e-table-metadata-helpers";
 
 const { ORDERS, ORDERS_ID, REVIEWS, PRODUCTS, PEOPLE } = SAMPLE_DATABASE;
 
@@ -118,7 +121,7 @@ it("should configure data model settings", () => {
   const metric = {
     name: "Revenue",
     description: "Sum of orders subtotal",
-    type: "metric",
+    table_id: ORDERS_ID, // legacy api
     definition: {
       "source-table": ORDERS_ID,
       aggregation: [["sum", ["field", ORDERS.SUBTOTAL, null]]],
@@ -135,7 +138,7 @@ it("should configure data model settings", () => {
     },
   };
 
-  cy.createQuestion(metric);
+  createMetric(metric); // legacy api
   createSegment(segment);
 
   cy.visit("/admin/datamodel/segments");

--- a/e2e/test/scenarios/cross-version/source/02-datamodel.cy.spec.js
+++ b/e2e/test/scenarios/cross-version/source/02-datamodel.cy.spec.js
@@ -17,7 +17,7 @@ it("should configure data model settings", () => {
     "updateProductId",
   );
 
-  cy.findByTestId("admin-metadata-table-list").findByText("Orders").click();
+  cy.get(".AdminList").findByText("Orders").click();
 
   cy.findByDisplayValue("Product ID")
     .parent()
@@ -34,7 +34,8 @@ it("should configure data model settings", () => {
   cy.wait("@updateProductId");
 
   cy.visit(sampleDBDataModelPage);
-  cy.findByTestId("admin-metadata-table-list").findByText("Reviews").click();
+
+  cy.get(".AdminList").findByText("Reviews").click();
   cy.intercept("POST", `/api/field/${REVIEWS.RATING}/values`).as(
     "remapRatingValues",
   );
@@ -68,7 +69,7 @@ it("should configure data model settings", () => {
 
   // Hide PRODUCTS.EAN
   cy.visit(sampleDBDataModelPage);
-  cy.findByTestId("admin-metadata-table-list").findByText("Products").click();
+  cy.get(".AdminList").findByText("Products").click();
 
   cy.intercept("PUT", `/api/field/${PRODUCTS.EAN}`).as("hideEan");
 
@@ -100,7 +101,7 @@ it("should configure data model settings", () => {
   cy.wait("@updatePriceField");
 
   // Hide PEOPLE.PASSWORD
-  cy.findByTestId("admin-metadata-table-list").findByText("People").click();
+  cy.get(".AdminList").findByText("People").click();
 
   cy.intercept("PUT", `/api/field/${PEOPLE.PASSWORD}`).as("hidePassword");
 

--- a/e2e/test/scenarios/cross-version/target/smoke.cy.spec.js
+++ b/e2e/test/scenarios/cross-version/target/smoke.cy.spec.js
@@ -1,4 +1,3 @@
-import { echartsContainer } from "e2e/support/helpers";
 import {
   assertTimelineData,
   dismissOkToPlayWithQuestionsModal,
@@ -36,7 +35,7 @@ describe(`smoke test the migration to the version ${version}`, () => {
 
     assertTimelineData(version);
 
-    echartsContainer()
+    cy.get(".y.axis .tick")
       .should("contain", "20,000")
       .and("contain", "100,000")
       .and("contain", "140,000");
@@ -48,13 +47,13 @@ describe(`smoke test the migration to the version ${version}`, () => {
     cy.wait("@cardQuery");
 
     cy.get(".bar").should("have.length", 4);
-    echartsContainer()
+    cy.get(".x.axis .tick")
       .should("contain", "Gizmo")
       .and("contain", "Gadget")
       .and("contain", "Doohickey")
       .and("contain", "Widget");
 
-    echartsContainer()
+    cy.get(".value-labels")
       .should("contain", "3.27")
       .and("contain", "3.3")
       .and("contain", "3.71")


### PR DESCRIPTION
closes https://github.com/metabase/metabase/issues/44661 as a bandaid

the real fix will be https://github.com/metabase/metabase/issues/44662

## Description

These tests broke because people updated them as if they would be run on the branch they are in, like any other test. Since we run these so infrequently, it wasn't obvious when/what/why they broke. What actually broke them was people being good citizens and updating them to support new features (metrics and echarts visualizations), however, the versions we're testing against don't support those new features at all.

Until we move to a branch-based cross-version-testing model, this will run cross version tests nightly, and on any PR that changes code in the cross-version testing directory.



