### PR TITLE
E2E test for custom date expression error

### DIFF
--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -928,6 +928,26 @@ describe("issue 44532", () => {
   });
 });
 
+describe("issue 33441", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("should show an error message for an incorrect date expression (metabase#33441)", () => {
+    openOrdersTable({ mode: "notebook" });
+    addCustomColumn();
+    enterCustomColumnDetails({
+      formula: 'datetimeDiff([Created At] , now, "days")',
+      name: "Date",
+    });
+    popover().within(() => {
+      cy.findByText("Invalid expression").should("be.visible");
+      cy.button("Done").should("be.disabled");
+    });
+  });
+});
+
 describe("issue 43294", () => {
   const questionDetails = {
     display: "line",


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/33441
100x stress test https://github.com/metabase/metabase/actions/runs/9666117532

The issue was fixed recently by adding a `Lib.diagnoseExpression` and a try-catch for malli errors.

How to verify:
- New -> Question -> Orders
- Custom expression -> `datetimeDiff([Date Received] , now, "days")` -> blur
- Make sure there is an error message now

<img width="545" alt="Screenshot 2024-06-25 at 12 22 42" src="https://github.com/metabase/metabase/assets/8542534/1dbca496-462b-41b6-b132-53bc1a344937">
