### PR TITLE
Pass enterprise version to cloud issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -536,13 +536,16 @@ jobs:
       - uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
-          script: |
+          script: | # js
+            const version = '${{ inputs.version }}';
+            const enterpriseVersion = version.replace(/^v0\./, "v1.");
+
             github.rest.repos.createDispatchEvent({
               owner: '${{ github.repository_owner }}',
               repo: '${{ vars.OPS_REPO }}',
               event_type: 'create-release-issues',
               client_payload: {
-                version: '${{ inputs.version }}'
+                version: enterpriseVersion,
               }
             });
 


### PR DESCRIPTION
The current automation is opening issues like https://github.com/metabase/metabase-ops/issues/1174 with the OSS version in the title, while we only use the enterprise in cloud. 