### PR TITLE
Update default `map.type` display for breakouts with un-binned coordinates

### DIFF
--- a/frontend/src/metabase-lib/viz/display.ts
+++ b/frontend/src/metabase-lib/viz/display.ts
@@ -99,10 +99,25 @@ export const defaultDisplay = (query: Lib.Query): DefaultDisplay => {
       return Lib.isCoordinate(column);
     });
     if (areBreakoutsCoordinates) {
+      const [{ breakout: breakoutOne }, { breakout: breakoutTwo }] =
+        getBreakoutsWithColumns(query, stageIndex, breakouts);
+      const binningOne = Lib.binning(breakoutOne);
+      const binningTwo = Lib.binning(breakoutTwo);
+      const areBothBinned = binningOne !== null && binningTwo !== null;
+
+      if (areBothBinned) {
+        return {
+          display: "map",
+          settings: {
+            "map.type": "grid",
+          },
+        };
+      }
+
       return {
         display: "map",
         settings: {
-          "map.type": "grid",
+          "map.type": "pin",
         },
       };
     }

--- a/frontend/src/metabase-lib/viz/display.ts
+++ b/frontend/src/metabase-lib/viz/display.ts
@@ -99,10 +99,8 @@ export const defaultDisplay = (query: Lib.Query): DefaultDisplay => {
       return Lib.isCoordinate(column);
     });
     if (areBreakoutsCoordinates) {
-      const [{ breakout: breakoutOne }, { breakout: breakoutTwo }] =
-        getBreakoutsWithColumns(query, stageIndex, breakouts);
-      const binningOne = Lib.binning(breakoutOne);
-      const binningTwo = Lib.binning(breakoutTwo);
+      const binningOne = Lib.binning(breakouts[0]);
+      const binningTwo = Lib.binning(breakouts[1]);
       const areBothBinned = binningOne !== null && binningTwo !== null;
 
       if (areBothBinned) {

--- a/frontend/src/metabase-lib/viz/display.unit.spec.ts
+++ b/frontend/src/metabase-lib/viz/display.unit.spec.ts
@@ -182,7 +182,32 @@ describe("defaultDisplay", () => {
     expect(defaultDisplay(query)).toEqual({ display: "line" });
   });
 
-  it("returns 'map' display for queries with 1 aggregation and 2 breakouts by coordinates", () => {
+  it("returns 'map' display with 'grid' type for queries with 1 aggregation and 2 binned breakouts by coordinates", () => {
+    const query = createQueryWithClauses({
+      aggregations: [{ operatorName: "count" }],
+      breakouts: [
+        {
+          columnName: "LATITUDE",
+          tableName: "PEOPLE",
+          binningStrategyName: "Auto bin",
+        },
+        {
+          columnName: "LONGITUDE",
+          tableName: "PEOPLE",
+          binningStrategyName: "Auto bin",
+        },
+      ],
+    });
+
+    expect(defaultDisplay(query)).toEqual({
+      display: "map",
+      settings: {
+        "map.type": "grid",
+      },
+    });
+  });
+
+  it("returns 'map' display with 'pin' type for queries with 1 aggregation and 2 un-binned breakouts by coordinates", () => {
     const query = createQueryWithClauses({
       aggregations: [{ operatorName: "count" }],
       breakouts: [
@@ -194,7 +219,28 @@ describe("defaultDisplay", () => {
     expect(defaultDisplay(query)).toEqual({
       display: "map",
       settings: {
-        "map.type": "grid",
+        "map.type": "pin",
+      },
+    });
+  });
+
+  it("returns 'map' display with 'pin' type for queries with 1 aggregation and 2 breakouts by coordinates - 1 binned, 1 unbinned", () => {
+    const query = createQueryWithClauses({
+      aggregations: [{ operatorName: "count" }],
+      breakouts: [
+        {
+          columnName: "LATITUDE",
+          tableName: "PEOPLE",
+          binningStrategyName: "Auto bin",
+        },
+        { columnName: "LONGITUDE", tableName: "PEOPLE" },
+      ],
+    });
+
+    expect(defaultDisplay(query)).toEqual({
+      display: "map",
+      settings: {
+        "map.type": "pin",
       },
     });
   });


### PR DESCRIPTION
- Closes: https://github.com/metabase/metabase/issues/10734
---
**Demo**

https://github.com/metabase/metabase/assets/22608765/b11efbe4-e6ab-4f40-b277-330539c71c98



---
**How to Manually Verify**
1. Open up the query builder
2. Create a query with one aggregation and two unbinned coordinate breakout columns
3. Click visualize and see that the default display is `"map"` with type `"pin"`
4. Create a query with one aggregation and two binned coordinate breakout columns
5. Click visualize and see that the default display is `"map"` with type `"grid"`

---
**Acceptance Criteria**
- [ ] If a query has two coordinate breakout columns that are not both binned, then use the "pin" map type as the default
- [ ] If a query has two coordinate breakout columns that are both binned, then use the "grid" map type as the default
- [ ] Updated `display.unit.spec.ts` to validate and enforce the default display desired behaviors
- [ ] All other tests continue to pass