### PR TITLE
Memoize driver.u/supports?

### DIFF
--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -215,18 +215,19 @@
    critical metabase features that use this check."
   5000)
 
-(defn supports?
-  "A defensive wrapper around [[database-supports?]]. It adds logging and error handling to avoid crashing the app if this
-   method takes a long time to execute or throws an exception. This is useful because `supports?` is used in so many critical
-   places in the app, and we don't want a single driver to crash the app if it throws an exception, or delay the user if it
-   takes a long time to execute."
-  [driver feature database]
-  (try
-    (u/with-timeout supports?-timeout-ms
-      (driver/database-supports? driver feature database))
-    (catch Throwable e
-      (log/error e (u/format-color 'red "Failed to check feature '%s' for database '%s'" (name feature) (:name database)))
-      false)))
+(def ^{:arglists '([driver feature database])} supports?
+  "A defensive wrapper around [[database-supports?]]. It adds logging, caching, and error handling to avoid crashing the app
+   if this method takes a long time to execute or throws an exception. This is useful because `supports?` is used in so many
+   critical places in the app, and we don't want a single driver to crash the app if it throws an exception, or delay the user
+   if it takes a long time to execute."
+  (mdb/memoize-for-application-db ; memoize because this can be called in a tight loop, and will only change if the database changes versions
+   (fn [driver feature database]
+     (try
+       (u/with-timeout supports?-timeout-ms
+         (driver/database-supports? driver feature database))
+       (catch Throwable e
+         (log/error e (u/format-color 'red "Failed to check feature '%s' for database '%s'" (name feature) (:name database)))
+         false)))))
 
 (defn features
   "Return a set of all features supported by `driver` with respect to `database`."

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -1040,7 +1040,7 @@
 (deftest databases-list-include-saved-questions-tables-test-6
   (testing "GET /api/database?saved=true&include=tables"
     (testing "should work when there are no DBs that support nested queries"
-      (with-redefs [driver/database-supports? (constantly false)]
+      (with-redefs [driver.u/supports? (constantly false)]
         (is (nil? (fetch-virtual-database)))))))
 
 (deftest databases-list-include-saved-questions-tables-test-7

--- a/test/metabase/db/metadata_queries_test.clj
+++ b/test/metabase/db/metadata_queries_test.clj
@@ -2,7 +2,6 @@
   (:require
    [clojure.test :refer :all]
    [metabase.db.metadata-queries :as metadata-queries]
-   [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.test-util :as sql-jdbc.tu]
    [metabase.driver.util :as driver.u]
    [metabase.models :as models :refer [Database Field Table]]
@@ -60,17 +59,17 @@
       (let [table  (mi/instance Table {:id 1234})
             fields [(mi/instance Field {:id 4321 :base_type :type/Text})]]
         (testing "uses substrings if driver supports expressions"
-          (with-redefs [driver/database-supports? (constantly true)]
+          (with-redefs [driver.u/supports? (constantly true)]
             (let [query (#'metadata-queries/table-rows-sample-query table fields {:truncation-size 4})]
               (is (seq (get-in query [:query :expressions]))))))
         (testing "doesnt' use substrings if driver doesn't support expressions"
-          (with-redefs [driver/database-supports? (constantly false)]
+          (with-redefs [driver.u/supports? (constantly false)]
             (let [query (#'metadata-queries/table-rows-sample-query table fields {:truncation-size 4})]
               (is (empty? (get-in query [:query :expressions])))))))
       (testing "pre-existing json fields are still marked as `:type/Text`"
         (let [table (mi/instance Table {:id 1234})
               fields [(mi/instance Field {:id 4321, :base_type :type/Text, :semantic_type :type/SerializedJSON})]]
-          (with-redefs [driver/database-supports? (constantly true)]
+          (with-redefs [driver.u/supports? (constantly true)]
             (let [query (#'metadata-queries/table-rows-sample-query table fields {:truncation-size 4})]
               (is (empty? (get-in query [:query :expressions]))))))))))
 

--- a/test/metabase/driver/util_test.clj
+++ b/test/metabase/driver/util_test.clj
@@ -287,7 +287,7 @@
 (deftest supports?-failure-test
   (let [fake-test-db (mt/db)]
     (testing "supports? returns false when `driver/database-supports?` throws an exception"
-      (with-redefs [driver/database-supports? (fn [_ _ _] (throw (Exception. "test exception message")))]
+      (with-redefs [driver.u/supports? (fn [_ _ _] (throw (Exception. "test exception message")))]
         (let [db           (assoc fake-test-db :name (mt/random-name))
               log-messages (mt/with-log-messages-for-level [metabase.driver.util :error]
                              (is (false? (driver.u/supports? :test-driver :test-feature db))))]

--- a/test/metabase/driver/util_test.clj
+++ b/test/metabase/driver/util_test.clj
@@ -288,20 +288,22 @@
   (let [fake-test-db (mt/db)]
     (testing "supports? returns false when `driver/database-supports?` throws an exception"
       (with-redefs [driver/database-supports? (fn [_ _ _] (throw (Exception. "test exception message")))]
-        (let [log-messages (mt/with-log-messages-for-level [metabase.driver.util :error]
-                             (is (false? (driver.u/supports? :test-driver :test-feature fake-test-db))))]
+        (let [db           (assoc fake-test-db :name (mt/random-name))
+              log-messages (mt/with-log-messages-for-level [metabase.driver.util :error]
+                             (is (false? (driver.u/supports? :test-driver :test-feature db))))]
           (is (some (fn [[level ^Throwable exception message]]
                       (and (= level :error)
                            (= (.getMessage exception) "test exception message")
-                           (= message (u/format-color 'red "Failed to check feature 'test-feature' for database 'test-data'"))))
+                           (= message (u/format-color 'red "Failed to check feature 'test-feature' for database '%s'" (:name db)))))
                     log-messages)))))
     (testing "supports? returns false when `driver/database-supports?` takes longer than the timeout"
       (with-redefs [driver.u/supports?-timeout-ms 100
                     driver/database-supports?     (fn [_ _ _] (Thread/sleep 200) true)]
-        (let [log-messages (mt/with-log-messages-for-level [metabase.driver.util :error]
-                             (is (false? (driver.u/supports? :test-driver :test-feature fake-test-db))))]
+        (let [db           (assoc fake-test-db :name (mt/random-name))
+              log-messages (mt/with-log-messages-for-level [metabase.driver.util :error]
+                             (is (false? (driver.u/supports? :test-driver :test-feature db))))]
           (is (some (fn [[level ^Throwable exception message]]
                       (and (= level :error)
                            (= (.getMessage exception) "Timed out after 100.0 ms")
-                           (= message (u/format-color 'red "Failed to check feature 'test-feature' for database 'test-data'"))))
+                           (= message (u/format-color 'red "Failed to check feature 'test-feature' for database '%s'" (:name db)))))
                     log-messages)))))))

--- a/test/metabase/driver/util_test.clj
+++ b/test/metabase/driver/util_test.clj
@@ -297,13 +297,17 @@
                            (= message (u/format-color 'red "Failed to check feature 'test-feature' for database '%s'" (:name db)))))
                     log-messages)))))
     (testing "supports? returns false when `driver/database-supports?` takes longer than the timeout"
-      (with-redefs [driver.u/supports?-timeout-ms 100
-                    driver/database-supports?     (fn [_ _ _] (Thread/sleep 200) true)]
-        (let [db           (assoc fake-test-db :name (mt/random-name))
-              log-messages (mt/with-log-messages-for-level [metabase.driver.util :error]
-                             (is (false? (driver.u/supports? :test-driver :test-feature db))))]
-          (is (some (fn [[level ^Throwable exception message]]
-                      (and (= level :error)
-                           (= (.getMessage exception) "Timed out after 100.0 ms")
-                           (= message (u/format-color 'red "Failed to check feature 'test-feature' for database '%s'" (:name db)))))
-                    log-messages)))))))
+      (let [db (assoc fake-test-db :name (mt/random-name))]
+        (with-redefs [driver.u/supports?-timeout-ms 100
+                      driver/database-supports?     (fn [_ _ _] (Thread/sleep 200) true)]
+          (let [log-messages (mt/with-log-messages-for-level [metabase.driver.util :error]
+                               (is (false? (driver.u/supports? :test-driver :test-feature db))))]
+            (is (some (fn [[level ^Throwable exception message]]
+                        (and (= level :error)
+                             (= (.getMessage exception) "Timed out after 100.0 ms")
+                             (= message (u/format-color 'red "Failed to check feature 'test-feature' for database '%s'" (:name db)))))
+                      log-messages))))
+        (testing "we memoize the results for the same database, so we don't log the error again"
+          (let [log-messages (mt/with-log-messages-for-level [metabase.driver.util :error]
+                               (is (false? (driver.u/supports? :test-driver :test-feature db))))]
+            (is (nil? log-messages))))))))

--- a/test/metabase/driver/util_test.clj
+++ b/test/metabase/driver/util_test.clj
@@ -287,7 +287,7 @@
 (deftest supports?-failure-test
   (let [fake-test-db (mt/db)]
     (testing "supports? returns false when `driver/database-supports?` throws an exception"
-      (with-redefs [driver.u/supports? (fn [_ _ _] (throw (Exception. "test exception message")))]
+      (with-redefs [driver/database-supports? (fn [_ _ _] (throw (Exception. "test exception message")))]
         (let [db           (assoc fake-test-db :name (mt/random-name))
               log-messages (mt/with-log-messages-for-level [metabase.driver.util :error]
                              (is (false? (driver.u/supports? :test-driver :test-feature db))))]

--- a/test/metabase/models/database_test.clj
+++ b/test/metabase/models/database_test.clj
@@ -315,8 +315,8 @@
   ;; when it should return true.
   (testing "Make sure selecting a database calls `driver/database-supports?` with a database instance"
     (mt/with-temp [Database {db-id :id} {:engine (u/qualified-name ::test)}]
-      (mt/with-dynamic-redefs [driver/database-supports? (fn [_ _ db]
-                                                           (is (true? (mi/instance-of? :model/Database db))))]
+      (mt/with-dynamic-redefs [driver.u/supports? (fn [_ _ db]
+                                                    (is (true? (mi/instance-of? :model/Database db))))]
         (is (some? (t2/select-one-fn :features Database :id db-id)))))))
 
 (deftest hydrate-tables-test

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -726,11 +726,11 @@
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
     ;; There aren't any officially supported databases yet that don't support `:upload-with-auto-pk`
     ;; So we'll fake it here to test it for 3rd party drivers
-    (let [original-database-supports?-fn driver/database-supports?]
-      (with-redefs [driver/database-supports? (fn [driver feature db]
-                                                (if (= feature :upload-with-auto-pk)
-                                                  false
-                                                  (original-database-supports?-fn driver feature db)))]
+    (let [original-supports?-fn driver.u/supports?]
+      (with-redefs [driver.u/supports? (fn [driver feature db]
+                                         (if (= feature :upload-with-auto-pk)
+                                           false
+                                           (original-supports?-fn driver feature db)))]
         (with-mysql-local-infile-on-and-off
           (testing "Upload a CSV file with column names that are reserved by the DB, NOT ignoring them"
             (testing "A single column whose name normalizes to _mb_row_id"
@@ -1021,7 +1021,7 @@
               #"^The uploads database does not exist\.$"
               (upload-example-csv! :db-id Integer/MAX_VALUE, :schema-name "public", :table-prefix "uploaded_magic_"))))
       (testing "Uploads must be supported"
-        (mt/with-dynamic-redefs [driver/database-supports? (constantly false)]
+        (mt/with-dynamic-redefs [driver.u/supports? (constantly false)]
           (is (thrown-with-msg?
                 java.lang.Exception
                 #"^Uploads are not supported on \w+ databases\."
@@ -1188,7 +1188,7 @@
                       :data    {:status-code 422}}
                      (catch-ex-info (update-csv-with-defaults! action :file (csv-file-with []))))))
             (testing "Uploads must be supported"
-              (mt/with-dynamic-redefs [driver/database-supports? (constantly false)]
+              (mt/with-dynamic-redefs [driver.u/supports? (constantly false)]
                 (is (= {:message (format "Uploads are not supported on %s databases." (str/capitalize (name driver/*driver*)))
                         :data    {:status-code 422}}
                        (catch-ex-info (update-csv-with-defaults! action))))))))))))


### PR DESCRIPTION
This PR adds memoization to `driver.u/supports?` so we can avoid creating many threads if it is called frequently in a tight loop.

It's a speculative fix for some of the performance problems we've been dealing with recently.