### PR TITLE
Remove description length check from copy question form

### DIFF
--- a/frontend/src/metabase/questions/components/CopyQuestionForm.tsx
+++ b/frontend/src/metabase/questions/components/CopyQuestionForm.tsx
@@ -21,7 +21,7 @@ const QUESTION_SCHEMA = Yup.object({
     .required(Errors.required)
     .max(100, Errors.maxLength)
     .default(""),
-  description: Yup.string().nullable().max(255, Errors.maxLength).default(null),
+  description: Yup.string().nullable().default(null),
   collection_id: Yup.number().nullable().default(null),
 });
 


### PR DESCRIPTION
Part of https://github.com/metabase/metabase/issues/43983, internal discussion [here](https://metaboat.slack.com/archives/C064QMXEV9N/p1718628995208319)

We don't have a max length check for question descriptions when creating a question, or when editing a description in chill mode's sidebar. However, there's a 255-length limit in the copy question form which is inconsistent and can lead to odd situations like [here](https://github.com/metabase/metabase/pull/44470#issuecomment-2189190995). The PR removes that limit