### PR TITLE
expose MB_DB_QUERY_TIMEOUT_MINUTES setting

### DIFF
--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -348,6 +348,15 @@ Default: `null`
 
 The port for [MB_DB_HOST](#mb_db_host).
 
+
+### `MB_DB_QUERY_TIMEOUT_MINUTES`
+
+Type: integer<br>
+Default: `180`
+
+Timeout in minutes for query execution, both Metabase application database and data connections. In case you're execute a query and run into a timeout, you might consider increasing this value.
+
+
 ### `MB_DB_TYPE`
 
 Type: string (`"h2"`, `"postgres"`, `"mysql"`)<br>

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -129,6 +129,23 @@
         In case you're connecting via an SSH tunnel and run into a timeout, you might consider increasing this value
         as the connections via tunnels have more overhead than connections without.")
 
+;; This is normally set via the env var `MB_DB_QUERY_TIMEOUT_MINUTES`
+(defsetting db-query-timeout-minutes
+  "By default, this is 20 minutes."
+  :visibility :internal
+  :export?    false
+  :type       :integer
+  ;; I don't know if these numbers make sense, but my thinking is we want to enable (somewhat) long-running queries on
+  ;; prod but for test and dev purposes we want to fail faster because it usually means I broke something in the QP
+  ;; code
+  :default    (if config/is-prod?
+                20
+                3)
+  :doc "Timeout in minutes for databases query execution, both Metabase application database and data connections.
+  If you have long-running queries, you might consider increasing this value.
+  Adjusting the timeout does not impact Metabase’s frontend.
+  Please be aware that other services (like Nginx) may still drop long-running queries.")
+
 (defn- connection-error? [^Throwable throwable]
   (and (some? throwable)
        (or (instance? java.net.ConnectException throwable)

--- a/src/metabase/query_processor/pipeline.clj
+++ b/src/metabase/query_processor/pipeline.clj
@@ -1,8 +1,8 @@
 (ns metabase.query-processor.pipeline
   (:require
    [clojure.core.async :as a]
-   [metabase.config :as config]
    [metabase.driver :as driver]
+   [metabase.driver.util :as driver.u]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.util :as u]
    [metabase.util.i18n :as i18n]
@@ -99,10 +99,4 @@
 
 (def ^:dynamic ^Long *query-timeout-ms*
   "Maximum amount of time query is allowed to run, in ms."
-  ;; I don't know if these numbers make sense, but my thinking is we want to enable (somewhat) long-running queries on
-  ;; prod but for test and dev purposes we want to fail faster because it usually means I broke something in the QP
-  ;; code
-  (u/minutes->ms
-   (if config/is-prod?
-     20
-     3)))
+  (u/minutes->ms (driver.u/db-query-timeout-minutes)))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/41685

### Description

I created the MB_DB_QUERY_TIMEOUT_MINUTES setting and used it in the *query-timeout-ms* function.


### How to verify
I used oracle db for tests.
Test query:
```
WITH FUNCTION my_sleep(i NUMBER)
RETURN NUMBER IS
BEGIN
    DBMS_SESSION.sleep(i);
    RETURN i;
END;
SELECT my_sleep(X) FROM dual
```

Custom MB_DB_QUERY_TIMEOUT_MINUTES
1. Set the environment variable MB_DB_QUERY_TIMEOUT_MINUTES=1
2. Run the test query for X=30 in native query mode. The query should return a result.
3. Run the test query for X=130 in native query mode. Metabase should throw an exception.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
