### PR TITLE
WIP: Update url when editing question in notebook editor

### DIFF
--- a/frontend/src/metabase/query_builder/components/notebook/Notebook.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/Notebook.tsx
@@ -1,7 +1,10 @@
 import { t } from "ttag";
 
 import { useDispatch } from "metabase/lib/redux";
-import { setUIControls } from "metabase/query_builder/actions";
+import {
+  type UpdateQuestionOpts,
+  setUIControls,
+} from "metabase/query_builder/actions";
 import { Box, Button } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
@@ -15,7 +18,10 @@ export type NotebookProps = {
   isResultDirty: boolean;
   reportTimezone: string;
   hasVisualizeButton?: boolean;
-  updateQuestion: (question: Question) => Promise<void>;
+  updateQuestion: (
+    question: Question,
+    options?: UpdateQuestionOpts,
+  ) => Promise<void>;
   runQuestionQuery: () => void;
   setQueryBuilderMode: (mode: string) => void;
   readOnly?: boolean;
@@ -64,7 +70,7 @@ const Notebook = ({
 
   const handleUpdateQuestion = (question: Question): Promise<void> => {
     dispatch(setUIControls({ isModifiedFromNotebook: true }));
-    return updateQuestion(question);
+    return updateQuestion(question, { shouldUpdateUrl: true });
   };
 
   return (


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/38148

### Description

This PR enables the `shouldUpdateUrl` flag in the notebook editor, causing the base64 string in the url to update as a user makes changes to a question in the notebook.

This enables a couple of things:
- refreshing the notebook editor does not lose state, you can keep editing from where you left of 
- you can now share links to unfinished/unsaved questions



### How to verify

Describe the steps to verify that the changes are working as expected.

1. create a new question in the notebook editor
2. make some changes (ie. add filters, aggregations, custom columns, ...)
3. refresh the page at every step, the notebook editor should not lose state

### Extra considerations

As it stands, this also works for saved questions. This might be a bit unintuitive:
1. Open a saved question (let's say it's named "Question Foo") in the notebook editor
2. make some changes
4. copy the link in the url bar and share it with a coworker
5. open the shared link in a new browser window/tab
6. the question should be in the same state as at the end of step 2.
7. save the question, you will get asked to override "Question Foo"

Some product input would be nice here.

### Demo

https://github.com/metabase/metabase/assets/1250185/d2d0fccc-9687-408c-90a4-4c5c6e7425a6



