### PR TITLE
prevent collections with special types / non-null namespaces from appearing in recents

### DIFF
--- a/e2e/test/scenarios/native/snippets.cy.spec.js
+++ b/e2e/test/scenarios/native/snippets.cy.spec.js
@@ -255,6 +255,7 @@ describeEE("scenarios > question > snippets (EE)", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     modal().within(() => cy.findByText("Top folder").click());
     entityPickerModal().within(() => {
+      cy.findByText("Collections").click();
       cy.findByText("my favorite snippets").click();
       cy.findByText("Select").click();
     });

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -1180,7 +1180,7 @@
           :read  (perms/collection-read-path collection-or-id)
           :write (perms/collection-readwrite-path collection-or-id))})))
 
-(def ^:private instance-analytics-collection-type
+(def instance-analytics-collection-type
   "The value of the `:type` field for the `instance-analytics` Collection created in [[metabase-enterprise.audit-app.audit]]"
   "instance-analytics")
 

--- a/src/metabase/models/recent_views.clj
+++ b/src/metabase/models/recent_views.clj
@@ -35,6 +35,7 @@
    [malli.error :as me]
    [medley.core :as m]
    [metabase.config :as config]
+   [metabase.models.collection :as collection]
    [metabase.models.collection.root :as root]
    [metabase.models.interface :as mi]
    [metabase.util :as u]
@@ -429,14 +430,31 @@
     (throw (ex-info "context must be non-empty" {:context context})))
   (t2/select :model/RecentViews {:select    [:rv.* [:rc.type :card_type]]
                                  :from      [[:recent_views :rv]]
-                                 :where     (into [:and
-                                                   [:= :rv.user_id user-id]
-                                                   [:in :rv.context (map query-context->recent-context context)]])
+                                 :where     [:and
+                                             [:= :rv.user_id user-id]
+                                             [:in :rv.context (map query-context->recent-context context)]
+                                             ;; include non-collections, or collections without a namespace/type.
+                                             [:or
+                                              [:= :coll.id nil]
+                                              [:and
+                                               ;; trash collection is never returned
+                                               [:or [:= nil :coll.type] [:not= :coll.type collection/trash-collection-type]]
+                                               ;; collections in a different namespace can't interact with collections
+                                               ;; in the normal NULL namespace.
+                                               [:= nil :coll.namespace]
+                                               ;; exclude instance analytics for selects
+                                               (when (contains? (set context) :selections)
+                                                 [:or [:= nil :coll.type] [:not= :coll.type collection/instance-analytics-collection-type]])]]]
                                  :left-join [[:report_card :rc]
                                              [:and
                                               ;; only want to join on card_type if it's a card
                                               [:= :rv.model "card"]
-                                              [:= :rc.id :rv.model_id]]]
+                                              [:= :rc.id :rv.model_id]]
+
+                                             [:collection :coll]
+                                             [:and
+                                              [:= :rv.model "collection"]
+                                              [:= :coll.id :rv.model_id]]]
                                  :order-by  [[:rv.timestamp :desc]]}))
 
 (mu/defn ^:private model->return-model [model :- :keyword]


### PR DESCRIPTION
collections with types or namespaces set are "special" (e.g. the trash collection, instance analytics, or snippet collections) and shouldn't appear in recent views.

Fixes https://github.com/metabase/metabase/issues/44708