### PR TITLE
Fix FE crash for line/area/bar charts with no data

### DIFF
--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -1162,7 +1162,7 @@ describe("issue 19894", () => {
 describe("issue 44637", () => {
   beforeEach(() => {
     restore();
-    cy.signInAsAdmin();
+    cy.signInAsNormalUser();
   });
 
   it("should not crash when rendering a line/bar chart with empty results (metabase#44637)", () => {

--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -35,6 +35,10 @@ import {
   enterCustomColumnDetails,
   addCustomColumn,
   tableInteractive,
+  createNativeQuestion,
+  queryBuilderMain,
+  leftSidebar,
+  assertQueryBuilderRowCount,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -1152,5 +1156,35 @@ describe("issue 19894", () => {
 
     popover().findByText("Category").should("be.visible");
     popover().findByText("Count").should("be.visible");
+  });
+});
+
+describe("issue 44637", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should not crash when rendering a line/bar chart with empty results (metabase#44637)", () => {
+    createNativeQuestion(
+      {
+        native: {
+          query: "SELECT '2023-01-01'::date, 2 FROM people WHERE false",
+        },
+      },
+      { visitQuestion: true },
+    );
+
+    assertQueryBuilderRowCount(0);
+    queryBuilderMain().findByText("No results!").should("exist");
+    queryBuilderFooter().button("Visualization").click();
+    leftSidebar().icon("bar").click();
+    queryBuilderMain().within(() => {
+      cy.findByText("No results!").should("exist");
+      cy.findByText("Something's gone wrong").should("not.exist");
+    });
+
+    queryBuilderFooter().icon("calendar").click();
+    rightSidebar().findByText("Add an event");
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModalView.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModalView.tsx
@@ -71,7 +71,7 @@ export const ImpersonationModalView = ({
 
   // Does the "role" field need to first be filled out on the DB details page?
   const roleRequired =
-    database.features.includes("connection-impersonation-requires-role") &&
+    database.features?.includes("connection-impersonation-requires-role") &&
     database.details["role"] == null;
 
   // for redshift, we impersonate using users, not roles

--- a/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
+++ b/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
@@ -13,7 +13,7 @@ const getDescriptionForNow: HelpTextConfig["description"] = (
   database,
   reportTimezone,
 ) => {
-  const hasTimezoneFeatureFlag = database.features.includes("set-timezone");
+  const hasTimezoneFeatureFlag = database.features?.includes("set-timezone");
   const timezone = hasTimezoneFeatureFlag ? reportTimezone : "UTC";
   const nowAtTimezone = getNowAtTimezone(timezone, reportTimezone);
 

--- a/frontend/src/metabase-types/api/database.ts
+++ b/frontend/src/metabase-types/api/database.ts
@@ -41,7 +41,7 @@ export type DatabaseFeature =
 export interface Database extends DatabaseData {
   id: DatabaseId;
   is_saved_questions: boolean;
-  features: DatabaseFeature[];
+  features?: DatabaseFeature[];
   creator_id?: number;
   timezone?: string;
   native_permissions: "write" | "none";

--- a/frontend/src/metabase/admin/settings/components/UploadSettings/utils.ts
+++ b/frontend/src/metabase/admin/settings/components/UploadSettings/utils.ts
@@ -10,4 +10,4 @@ export const getSchemaOptions = (schema: Schema[]) =>
 export const dbHasSchema = (databases: Database[], dbId: number): boolean =>
   !!databases
     .find((db: Database) => db.id === dbId)
-    ?.features.includes("schemas");
+    ?.features?.includes("schemas");

--- a/frontend/src/metabase/metabot/utils.ts
+++ b/frontend/src/metabase/metabot/utils.ts
@@ -3,7 +3,7 @@ import type Database from "metabase-lib/v1/metadata/Database";
 
 export const canUseMetabotOnDatabase = (database: Database) => {
   return (
-    database.features.includes("nested-queries") &&
+    database.features?.includes("nested-queries") &&
     canGenerateQueriesForDatabase(database)
   );
 };

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
@@ -124,7 +124,7 @@ const TEST_DATABASE = createMockDatabase({
 
 const TEST_DATABASE_WITHOUT_NESTED_QUERIES = createMockDatabase({
   ...TEST_DATABASE,
-  features: TEST_DATABASE.features.filter(
+  features: TEST_DATABASE.features?.filter(
     feature => feature !== "nested-queries",
   ),
 });

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -804,7 +804,14 @@ const getTimeseriesDataInterval = createSelector(
 
 export const getTimeseriesXDomain = createSelector(
   [getIsTimeseries, getTimeseriesXValues],
-  (isTimeseries, xValues) => xValues && isTimeseries && d3.extent(xValues),
+  (isTimeseries, xValues) => {
+    return (
+      isTimeseries &&
+      Array.isArray(xValues) &&
+      xValues.length > 0 &&
+      d3.extent(xValues)
+    );
+  },
 );
 
 export const getFetchedTimelines = createSelector([getEntities], entities => {


### PR DESCRIPTION
Fixes #44637

This fixes an issue where rendering a time-series chart with no data would either crash the FE or make it stuck in a loading state. I believe there are two underlying problems (the original issue mentions either an FE error about array `includes` or another error about `clone`):

1. QB has a `getTimeseriesXDomain` selector that returns the min/max date for a time-series. We use that info to filter out suitable timeline events. Apparently, if there's no data, xDomain is `[ undefined, undefined ]`. We've recently added code working with the `xDomain` to fix an issue with timeline events (#44355), and that code started to fail. It made the issue more prominent though, because of the same problem we also had a FE crash when opening the timeline events sidebar in similar scenario
2. As @dpsutton mentioned [here](https://metaboat.slack.com/archives/C0641E4PB9B/p1719323759632479?thread_ts=1719323278.429529&cid=C0641E4PB9B), there are rare circumstances when a database object coming from the API could lack the `features` property. However, the FE code assumes it's always present, and it failed in a similar situation. It's pretty hard to reproduce and cover with a test, so hopefully, TypeScript should provide enough safety

### To verify

1. New > SQL Query
2. Fill in `SELECT '2023-01-01'::date, 2 FROM PEOPLE WHERE false` and run the query
3. Change the visualization to line/area/bar
4. Make sure it doesn't crash and doesn't get stuck in a loading state, but shows "No results"