### PR TITLE
Fix n+1 query in sandboxing enforcement

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/table.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/table.clj
@@ -31,10 +31,7 @@
   "Returns true if the user has sandboxed permissions. If a sandbox policy exists, it overrides existing permission on
   the table."
   [table :- (ms/InstanceOf Table)]
-  (contains? (->> (sandbox.api.util/enforced-sandboxes-for api/*current-user-id*)
-                  (map :table_id)
-                  set)
-             (u/the-id table)))
+  (boolean (seq (sandbox.api.util/enforced-sandboxes-for api/*current-user-id* #{(:id table)}))))
 
 (mu/defn ^:private query->fields-ids :- [:maybe [:sequential :int]]
   [{{{:keys [fields]} :query} :dataset_query} :- [:maybe :map]]

--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/util.clj
@@ -5,6 +5,7 @@
    [medley.core :as m]
    [metabase.api.common :refer [*current-user-id* *is-superuser?*]]
    [metabase.models.data-permissions :as data-perms]
+   [metabase.models.user :as user]
    [metabase.public-settings.premium-features :refer [defenterprise]]
    [metabase.util.i18n :refer [tru]]
    [toucan2.core :as t2]))
@@ -13,25 +14,31 @@
   "Takes all the group-ids a user belongs to and a sandbox, and determines whether the sandbox should be enforced for the user.
   This is done by checking whether any *other* group provides `:unrestricted` access to the sandboxed table (without
   its own sandbox). If so, we don't enforce the sandbox."
-  [group-id->sandboxes {:as _sandbox :keys [group_id table_id] {:keys [db_id]} :table}]
-  (let [group-id->sandboxes (dissoc group-id->sandboxes group_id)]
-    (not-any? (fn [[other-group-id other-group-sandboxes]]
-                (and
-                 ;; If the user is in another group with data access to the table, and no sandbox defined for it, then
-                 ;; we assume this sandbox should not be enforced.
-                 (data-perms/group-has-permission-for-table? other-group-id
-                                                             :perms/view-data
-                                                             :unrestricted
-                                                             db_id
-                                                             table_id)
-                 (not-any? (fn [sandbox] (= (:table_id sandbox) table_id)) other-group-sandboxes)))
-              group-id->sandboxes)))
+  [user-group-ids group-id->sandboxes {:as _sandbox :keys [table_id] {:keys [db_id]} :table}]
+  ;; If any *other* non-sandboxed groups the user is in provide unrestricted view-data access to the table, we don't
+  ;; enforce the sandbox.
+  (let [groups-to-exclude
+        ;; Don't check permissions of other groups which also define sandboxes on the relevant table. The fact that
+        ;; there is a conflict between sandboxes will cause a QP error later on when trying to run queries, so this
+        ;; isn't a valid sandboxing state anyway.
+        (reduce-kv (fn [excluded-group-ids group-id sandboxes]
+                     (if (some #(= (:table_id %) table_id) sandboxes)
+                       (conj excluded-group-ids group-id)
+                       excluded-group-ids))
+                   #{}
+                   group-id->sandboxes)]
+    (not (data-perms/groups-have-permission-for-table? (set/difference user-group-ids groups-to-exclude)
+                                                       :perms/view-data
+                                                       :unrestricted
+                                                       db_id
+                                                       table_id))))
 
 (defn enforced-sandboxes-for
   "Given a user-id, return the sandboxes that should be enforced for the current user. A sandbox is not enforced if the
   user is in a different permissions group that grants full access to the table."
   [user-id]
-  (let [sandboxes-with-group-ids (t2/hydrate
+  (let [user-group-ids           (user/group-ids user-id)
+        sandboxes-with-group-ids (t2/hydrate
                                   (t2/select :model/GroupTableAccessPolicy
                                              {:select [[:pgm.group_id :group_id]
                                                        [:s.*]]
@@ -45,7 +52,8 @@
                                                (->> sandboxes
                                                     (filter :table_id)
                                                     (into #{})))))]
-    (filter #(enforce-sandbox? group-id->sandboxes %) (reduce set/union #{} (vals group-id->sandboxes)))))
+    (filter #(enforce-sandbox? user-group-ids group-id->sandboxes %)
+            (reduce set/union #{} (vals group-id->sandboxes)))))
 
 (defenterprise sandboxed-user?
   "Returns true if the currently logged in user has segmented permissions. Throws an exception if no current user

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
@@ -197,7 +197,7 @@
   [{:keys [table_id group_id], :as gtap}]
   (let [db-id (database/table-id->database-id table_id)]
     ;; Remove native query access to the DB when saving a sandbox
-    (when (= (data-perms/table-permission-for-group group_id :perms/create-queries db-id table_id) :query-builder-and-native)
+    (when (= (data-perms/table-permission-for-groups #{group_id} :perms/create-queries db-id table_id) :query-builder-and-native)
       (data-perms/set-database-permission! group_id db-id :perms/create-queries :query-builder)))
   (u/prog1 gtap
     (check-columns-match-table gtap)))

--- a/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
@@ -62,7 +62,7 @@
 
 (defn- tables->sandboxes [table-ids]
   (qp.store/cached [*current-user-id* table-ids]
-    (let [enforced-sandboxes (mt.api.u/enforced-sandboxes-for *current-user-id*)]
+    (let [enforced-sandboxes (mt.api.u/enforced-sandboxes-for *current-user-id* table-ids)]
        (when (seq enforced-sandboxes)
          (assert-one-gtap-per-table enforced-sandboxes)
          enforced-sandboxes))))

--- a/enterprise/backend/test/metabase_enterprise/audit_app/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/permissions_test.clj
@@ -107,12 +107,12 @@
                     audit/default-audit-collection (constantly collection)]
         (testing "Updating permissions for the audit collection also updates audit DB permissions"
           ;; Audit DB starts with full data access but no query builder access
-          (is (= :unrestricted (data-perms/table-permission-for-groups group-id :perms/view-data database-id (:id view-table))))
-          (is (= :no (data-perms/table-permission-for-groups group-id :perms/create-queries database-id (:id view-table))))
+          (is (= :unrestricted (data-perms/table-permission-for-groups #{group-id} :perms/view-data database-id (:id view-table))))
+          (is (= :no (data-perms/table-permission-for-groups #{group-id} :perms/create-queries database-id (:id view-table))))
           ;; Granting access to the audit collection also grants query builder access to the DB
           (update-graph! (assoc-in (graph :clear-revisions? true) [:groups group-id (:id collection)] :read))
-          (is (= :unrestricted (data-perms/table-permission-for-groups group-id :perms/view-data database-id (:id view-table))))
-          (is (= :query-builder (data-perms/table-permission-for-groups group-id :perms/create-queries database-id (:id view-table)))))
+          (is (= :unrestricted (data-perms/table-permission-for-groups #{group-id} :perms/view-data database-id (:id view-table))))
+          (is (= :query-builder (data-perms/table-permission-for-groups #{group-id} :perms/create-queries database-id (:id view-table)))))
         (testing "Unable to update instance analytics to writable"
           (is (thrown-with-msg?
                Exception

--- a/enterprise/backend/test/metabase_enterprise/audit_app/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/permissions_test.clj
@@ -107,12 +107,12 @@
                     audit/default-audit-collection (constantly collection)]
         (testing "Updating permissions for the audit collection also updates audit DB permissions"
           ;; Audit DB starts with full data access but no query builder access
-          (is (= :unrestricted (data-perms/table-permission-for-group group-id :perms/view-data database-id (:id view-table))))
-          (is (= :no (data-perms/table-permission-for-group group-id :perms/create-queries database-id (:id view-table))))
+          (is (= :unrestricted (data-perms/table-permission-for-groups group-id :perms/view-data database-id (:id view-table))))
+          (is (= :no (data-perms/table-permission-for-groups group-id :perms/create-queries database-id (:id view-table))))
           ;; Granting access to the audit collection also grants query builder access to the DB
           (update-graph! (assoc-in (graph :clear-revisions? true) [:groups group-id (:id collection)] :read))
-          (is (= :unrestricted (data-perms/table-permission-for-group group-id :perms/view-data database-id (:id view-table))))
-          (is (= :query-builder (data-perms/table-permission-for-group group-id :perms/create-queries database-id (:id view-table)))))
+          (is (= :unrestricted (data-perms/table-permission-for-groups group-id :perms/view-data database-id (:id view-table))))
+          (is (= :query-builder (data-perms/table-permission-for-groups group-id :perms/create-queries database-id (:id view-table)))))
         (testing "Unable to update instance analytics to writable"
           (is (thrown-with-msg?
                Exception

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/table_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/table_test.clj
@@ -21,9 +21,9 @@
 (deftest query-metadata-test
   (testing "GET /api/table/:id/query_metadata"
     (met/with-gtaps! {:gtaps      {:venues
-                                  {:remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}
-                                   :query      (mt.tu/restricted-column-query (mt/id))}}
-                     :attributes {:cat 50}}
+                                   {:remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}
+                                    :query      (mt.tu/restricted-column-query (mt/id))}}
+                      :attributes {:cat 50}}
       (testing "Users with restricted access to the columns of a table should only see columns included in the GTAP question"
         (is (= #{"CATEGORY_ID" "ID" "NAME"}
                (field-names :rasta))))
@@ -37,8 +37,8 @@
     (testing (str "If a GTAP has a question, but that question doesn't include a clause to restrict the columns that "
                   "are returned, all fields should be returned")
       (met/with-gtaps! {:gtaps      {:venues {:query      (mt/mbql-query venues)
-                                             :remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}}}
-                       :attributes {:cat 50}}
+                                              :remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}}}
+                        :attributes {:cat 50}}
         (is (= all-columns
                (field-names :rasta)))))))
 

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
@@ -178,8 +178,8 @@
 (deftest middleware-test
   (testing "Make sure the middleware does the correct transformation given the GTAPs we have"
     (met/with-gtaps! {:gtaps      {:checkins (checkins-user-mbql-gtap-def)
-                                  :venues   (dissoc (venues-price-mbql-gtap-def) :query)}
-                     :attributes {"user" 5, "price" 1}}
+                                   :venues   (dissoc (venues-price-mbql-gtap-def) :query)}
+                      :attributes {"user" 5, "price" 1}}
       (testing "Should add a filter for attributes-only GTAP"
         (is (=? (mt/query checkins
                   {:type  :query
@@ -237,7 +237,7 @@
   (testing "Make sure the middleware does the correct transformation given the GTAPs we have"
     (testing "Should substitute appropriate value in native query"
       (met/with-gtaps! {:gtaps      {:venues (venues-category-native-gtap-def)}
-                       :attributes {"cat" 50}}
+                        :attributes {"cat" 50}}
         (is (=? (mt/query nil
                   {:database (mt/id)
                    :type     :query
@@ -314,8 +314,8 @@
   (mt/test-drivers (e2e-test-drivers)
     (testing "Another basic test, this one uses a stringified float for the login attribute"
       (met/with-gtaps! {:gtaps      {:venues {:query      (mt/mbql-query venues)
-                                             :remappings {:cat ["variable" [:field (mt/id :venues :latitude) nil]]}}}
-                       :attributes {"cat" "34.1018"}}
+                                              :remappings {:cat ["variable" [:field (mt/id :venues :latitude) nil]]}}}
+                        :attributes {"cat" "34.1018"}}
         (is (= [[3]]
                (run-venues-count-query)))))))
 
@@ -323,8 +323,8 @@
   (mt/test-drivers (e2e-test-drivers)
     (testing "Tests that users can have a different parameter name in their query than they have in their user attributes"
       (met/with-gtaps! {:gtaps      {:venues {:query      (:query (venues-category-native-gtap-def))
-                                             :remappings {:something.different ["variable" ["template-tag" "cat"]]}}}
-                       :attributes {"something.different" 50}}
+                                              :remappings {:something.different ["variable" ["template-tag" "cat"]]}}}
+                        :attributes {"something.different" 50}}
         (is (= [[10]]
                (run-venues-count-query)))))))
 
@@ -341,7 +341,7 @@
   (mt/test-drivers (e2e-test-drivers)
     (testing "When no card_id is included in the GTAP, should default to a query against the table, with the GTAP criteria applied"
       (met/with-gtaps! {:gtaps      {:venues (dissoc (venues-category-mbql-gtap-def) :query)}
-                       :attributes {"cat" 50}}
+                        :attributes {"cat" 50}}
         (is (= [[10]]
                (run-venues-count-query)))))))
 
@@ -349,7 +349,7 @@
   (mt/test-drivers (e2e-test-drivers)
     (testing "Same test as above but make sure we coerce a numeric string correctly"
       (met/with-gtaps! {:gtaps      {:venues (dissoc (venues-category-mbql-gtap-def) :query)}
-                       :attributes {"cat" "50"}}
+                        :attributes {"cat" "50"}}
         (is (= [[10]]
                (run-venues-count-query)))))))
 
@@ -357,7 +357,7 @@
   (mt/test-drivers (e2e-test-drivers)
     (testing "Admins always bypass sandboxes, even if they are in a sandboxed group"
       (met/with-gtaps-for-user! :crowberto {:gtaps      {:venues (venues-category-mbql-gtap-def)}
-                                           :attributes {"cat" 50}}
+                                            :attributes {"cat" 50}}
         (is (= [[100]]
                (run-venues-count-query)))))))
 
@@ -365,7 +365,7 @@
   (mt/test-drivers (e2e-test-drivers)
     (testing "A non-admin impersonating an admin (i.e. when running a public or embedded question) should always bypass sandboxes (#30535)"
       (met/with-gtaps-for-user! :rasta {:gtaps      {:venues (venues-category-mbql-gtap-def)}
-                                       :attributes {"cat" 50}}
+                                        :attributes {"cat" 50}}
         (mt/with-test-user :rasta
           (mw.session/as-admin
             (is (= [[100]]
@@ -428,8 +428,8 @@
                   "3 - Checkins are related to Venues, query for checkins, grouping by the Venue's price\n"
                   "4 - Order by the Venue's price to ensure a predictably ordered response")
       (met/with-gtaps! {:gtaps      {:checkins (checkins-user-mbql-gtap-def)
-                                    :venues   nil}
-                       :attributes {"user" 5}}
+                                     :venues   nil}
+                        :attributes {"user" 5}}
         (mt/with-mock-fks-for-drivers-without-fk-constraints
           (is (= [[1 10] [2 36] [3 4] [4 5]]
                  (run-checkins-count-broken-out-by-price-query))))))))
@@ -440,8 +440,8 @@
                   "permissions on checkins and venues, so we need to apply a GTAP to the original table (checkins) in "
                   "addition to the related table (venues). This test uses a GTAP question for both tables")
       (met/with-gtaps! {:gtaps      {:checkins (checkins-user-mbql-gtap-def)
-                                    :venues   (venues-price-mbql-gtap-def)}
-                       :attributes {"user" 5, "price" 1}}
+                                     :venues   (venues-price-mbql-gtap-def)}
+                        :attributes {"user" 5, "price" 1}}
         (mt/with-mock-fks-for-drivers-without-fk-constraints
           (is (= #{[nil 45] [1 10]}
                  (set (run-checkins-count-broken-out-by-price-query)))))))))
@@ -450,8 +450,8 @@
   (mt/test-drivers (row-level-restrictions-fk-drivers)
     (testing "Test that the FK related table can be a \"default\" GTAP, i.e. a GTAP where the `card_id` is nil"
       (met/with-gtaps! {:gtaps      {:checkins (checkins-user-mbql-gtap-def)
-                                    :venues   (dissoc (venues-price-mbql-gtap-def) :query)}
-                       :attributes {"user" 5, "price" 1}}
+                                     :venues   (dissoc (venues-price-mbql-gtap-def) :query)}
+                        :attributes {"user" 5, "price" 1}}
         (mt/with-mock-fks-for-drivers-without-fk-constraints
           (is (= #{[nil 45] [1 10]}
                  (set (run-checkins-count-broken-out-by-price-query)))))))))
@@ -461,9 +461,9 @@
     (testing (str "Test that we have multiple FK related, segmented tables. This test has checkins with a GTAP "
                   "question with venues and users having the default GTAP and segmented permissions")
       (met/with-gtaps! {:gtaps      {:checkins (checkins-user-mbql-gtap-def)
-                                    :venues   (dissoc (venues-price-mbql-gtap-def) :query)
-                                    :users    {:remappings {:user ["variable" [:field (mt/id :users :id) nil]]}}}
-                       :attributes {"user" 5, "price" 1}}
+                                     :venues   (dissoc (venues-price-mbql-gtap-def) :query)
+                                     :users    {:remappings {:user ["variable" [:field (mt/id :users :id) nil]]}}}
+                        :attributes {"user" 5, "price" 1}}
         (mt/with-mock-fks-for-drivers-without-fk-constraints
           (is (= #{[nil "Quentin Sören" 45] [1 "Quentin Sören" 10]}
                  (set
@@ -488,7 +488,7 @@
 (deftest remark-test
   (testing "make sure GTAP queries still include ID of user who ran them in the remark"
     (met/with-gtaps! {:gtaps      {:venues (venues-category-mbql-gtap-def)}
-                     :attributes {"cat" 50}}
+                      :attributes {"cat" 50}}
       (is (= (format "Metabase:: userID: %d queryType: MBQL queryHash: <hash>" (mt/user->id :rasta))
              (run-query-returning-remark
               (fn []
@@ -498,7 +498,7 @@
   (mt/test-drivers (row-level-restrictions-fk-drivers)
     (testing "Make sure that if a GTAP is in effect we can still do stuff like breakouts (#229)"
       (met/with-gtaps! {:gtaps      {:venues (venues-category-native-gtap-def)}
-                       :attributes {"cat" 50}}
+                        :attributes {"cat" 50}}
         (is (= [[1 6] [2 4]]
                (mt/format-rows-by [int int]
                  (mt/rows
@@ -516,7 +516,7 @@
              (mt/format-rows-by [int int identity int]
                (mt/rows
                 (met/with-gtaps! {:gtaps      {:checkins (parameterized-sql-with-join-gtap-def)}
-                                 :attributes {"user" 1}}
+                                  :attributes {"user" 1}}
                   (mt/run-mbql-query checkins
                     {:limit 2})))))))))
 
@@ -530,7 +530,7 @@
              (mt/format-rows-by [int int identity int]
                (mt/rows
                 (met/with-gtaps! {:gtaps      {:checkins (parameterized-sql-with-join-gtap-def)}
-                                 :attributes {"user" 1}}
+                                  :attributes {"user" 1}}
                   (mt/run-mbql-query checkins
                     {:limit 2})))))))))
 
@@ -555,13 +555,13 @@
                                 (dissoc :fk_target_field_id))))]
       (testing "A query with a simple attributes-based sandbox should have the same metadata"
         (met/with-gtaps! {:gtaps      {:venues (dissoc (venues-category-mbql-gtap-def) :query)}
-                         :attributes {"cat" 50}}
+                          :attributes {"cat" 50}}
           (is (=? (expected-cols)
                   (cols)))))
 
       (testing "A query with an equivalent MBQL query sandbox should have the same metadata"
         (met/with-gtaps! {:gtaps      {:venues (venues-category-mbql-gtap-def)}
-                         :attributes {"cat" 50}}
+                          :attributes {"cat" 50}}
           (is (=? (expected-cols)
                   (cols)))))
 
@@ -574,8 +574,8 @@
 
                                                     :template_tags
                                                     {:cat {:name "cat" :display_name "cat" :type "number" :required true}}})
-                                          :remappings {:cat ["variable" ["template-tag" "cat"]]}}}
-                         :attributes {"cat" 50}}
+                                           :remappings {:cat ["variable" ["template-tag" "cat"]]}}}
+                          :attributes {"cat" 50}}
           (is (=? (expected-cols)
                   (cols)))))
 
@@ -589,8 +589,8 @@
 
                                                     :template_tags
                                                     {:cat {:name "cat" :display_name "cat" :type "number" :required true}}})
-                                          :remappings {:cat ["variable" ["template-tag" "cat"]]}}}
-                         :attributes {"cat" 50}}
+                                           :remappings {:cat ["variable" ["template-tag" "cat"]]}}}
+                          :attributes {"cat" 50}}
           (let [[id-col name-col _ _ longitude-col price-col] (expected-cols)]
             (is (=? [name-col id-col longitude-col price-col]
                     (cols)))))))))
@@ -735,7 +735,7 @@
 (deftest dont-cache-sandboxes-test
   (cache-test/with-mock-cache [save-chan]
     (met/with-gtaps! {:gtaps      {:venues (venues-category-mbql-gtap-def)}
-                     :attributes {"cat" 50}}
+                      :attributes {"cat" 50}}
       (letfn [(run-query []
                 (qp/process-query (assoc (mt/mbql-query venues {:aggregation [[:count]]})
                                          :cache-strategy {:type             :ttl
@@ -965,7 +965,7 @@
       (let [mbql-sandbox-results (met/with-gtaps! {:gtaps      (mt/$ids
                                                                 {:orders   {:remappings {"user_id" [:dimension $orders.user_id]}}
                                                                  :products {:remappings {"user_cat" [:dimension $products.category]}}})
-                                                  :attributes {"user_id" 1, "user_cat" "Widget"}}
+                                                   :attributes {"user_id" 1, "user_cat" "Widget"}}
                                    (mt/with-column-remappings [orders.product_id products.title]
                                      (mt/run-mbql-query orders)))]
         (doseq [orders-gtap-card-has-metadata?   [true false]
@@ -979,15 +979,15 @@
                                                                                            :id           "1"
                                                                                            :name         "uid"
                                                                                            :type         :number}}})
-                                                     :remappings {"user_id" [:variable [:template-tag "uid"]]}}
-                                          :products {:query      (mt/native-query
-                                                                   {:query         "SELECT * FROM PRODUCTS WHERE CATEGORY={{cat}} AND PRICE > 10"
-                                                                    :template-tags {"cat" {:display-name "Category"
-                                                                                           :id           "2"
-                                                                                           :name         "cat"
-                                                                                           :type         :text}}})
-                                                     :remappings {"user_cat" [:variable [:template-tag "cat"]]}}}
-                             :attributes {"user_id" "1", "user_cat" "Widget"}}
+                                                      :remappings {"user_id" [:variable [:template-tag "uid"]]}}
+                                           :products {:query      (mt/native-query
+                                                                    {:query         "SELECT * FROM PRODUCTS WHERE CATEGORY={{cat}} AND PRICE > 10"
+                                                                     :template-tags {"cat" {:display-name "Category"
+                                                                                            :id           "2"
+                                                                                            :name         "cat"
+                                                                                            :type         :text}}})
+                                                      :remappings {"user_cat" [:variable [:template-tag "cat"]]}}}
+                              :attributes {"user_id" "1", "user_cat" "Widget"}}
               (when orders-gtap-card-has-metadata?
                 (set-query-metadata-for-gtap-card! &group :orders "uid" 1))
               (when products-gtap-card-has-metadata?
@@ -1019,7 +1019,7 @@
         (met/with-gtaps! {:gtaps      (mt/$ids
                                        {:orders   {:remappings {:user_id [:dimension $orders.user_id]}}
                                         :products {:remappings {:user_cat [:dimension $products.category]}}})
-                         :attributes {:user_id 1, :user_cat "Widget"}}
+                          :attributes {:user_id 1, :user_cat "Widget"}}
           (data-perms/set-table-permission! &group (mt/id :people) :perms/create-queries :query-builder)
           (data-perms/set-database-permission! &group (mt/id) :perms/view-data :unrestricted)
           (is (= (->> [["Twitter" nil      0 401.51]
@@ -1081,10 +1081,10 @@
       ;; with-gtaps! creates a new copy of the database. So make sure to do that before anything else. Gets really
       ;; confusing when `(mt/id)` and friends change value halfway through the test
       (met/with-gtaps! {:gtaps {:products
-                               {:remappings {:category
-                                             ["dimension"
-                                              [:field (mt/id :products :category)
-                                               nil]]}}}}
+                                {:remappings {:category
+                                              ["dimension"
+                                               [:field (mt/id :products :category)
+                                                nil]]}}}}
         (mt/with-persistence-enabled [persist-models!]
           (mt/with-temp [Card model {:type          :model
                                      :dataset_query (mt/mbql-query

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -258,7 +258,8 @@
                            perm-value))
 
 (mu/defn table-permission-for-groups :- PermissionValue
-  "Returns the effective permission value for a given *group*, permission type, and database ID, and table ID."
+  "Returns the effective permission value provided by a set of *group-ids*, for a provided permission type, database
+  ID, and table ID."
   [group-ids perm-type database-id table-id]
   (when (not= :model/Table (model-by-perm-type perm-type))
     (throw (ex-info (tru "Permission type {0} is not a table-level permission." perm-type)
@@ -279,8 +280,8 @@
         (least-permissive-value perm-type))))
 
 (mu/defn groups-have-permission-for-table? :- :boolean
-  "Returns a Boolean indicating whether the group has the specified permission value for the given table ID, or a more
-  permissive value."
+  "Returns a Boolean indicating whether the provided groups grant the specified permission level or higher for the given
+  table ID, or a more permissive value. (i.e. if a user is in all of these groups, would they have this permission?)"
   [group-ids perm-type perm-value database-id table-id]
   (at-least-as-permissive? perm-type
                            (table-permission-for-groups group-ids perm-type database-id table-id)

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -257,9 +257,9 @@
                            (database-permission-for-group group-id perm-type database-id)
                            perm-value))
 
-(mu/defn table-permission-for-group :- PermissionValue
+(mu/defn table-permission-for-groups :- PermissionValue
   "Returns the effective permission value for a given *group*, permission type, and database ID, and table ID."
-  [group-id perm-type database-id table-id]
+  [group-ids perm-type database-id table-id]
   (when (not= :model/Table (model-by-perm-type perm-type))
     (throw (ex-info (tru "Permission type {0} is not a table-level permission." perm-type)
                     {perm-type (Permissions perm-type)})))
@@ -268,7 +268,7 @@
                                       {:select [[:p.perm_value :value]]
                                        :from [[:data_permissions :p]]
                                        :where [:and
-                                               [:= :p.group_id group-id]
+                                               [:in :p.group_id group-ids]
                                                [:= :p.perm_type (u/qualified-name perm-type)]
                                                [:= :p.db_id database-id]
                                                [:or
@@ -278,14 +278,13 @@
                                                                                 perm-type)))
         (least-permissive-value perm-type))))
 
-(mu/defn group-has-permission-for-table? :- :boolean
+(mu/defn groups-have-permission-for-table? :- :boolean
   "Returns a Boolean indicating whether the group has the specified permission value for the given table ID, or a more
   permissive value."
-  [group-id perm-type perm-value database-id table-id]
+  [group-ids perm-type perm-value database-id table-id]
   (at-least-as-permissive? perm-type
-                           (table-permission-for-group group-id perm-type database-id table-id)
+                           (table-permission-for-groups group-ids perm-type database-id table-id)
                            perm-value))
-
 
 (mu/defn table-permission-for-user :- PermissionValue
   "Returns the effective permission value for a given user, permission type, and database ID, and table ID. If the user


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/44786

In order to check whether a sandbox should be enforced for a user we need to check that no _other_ group the user is in provides access. This previously ended up as an n+1 query: for each sandbox we were hitting the DB individually for each other sandbox.

I've changed this to be a single query per sandbox, which takes a set of the groups to check and fetches all their permissions at once. I've had to restructure the logic a little, but the behavior should be the same.