### PR TITLE
Single Log Out saml-slo-enabled defsetting

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
@@ -82,7 +82,7 @@
       ;; they will never hit "/handle_slo" so we must delete the session here:
       (t2/delete! :model/Session :id metabase-session-id)
       {:saml-logout-url
-       (when (and (sso-settings/saml-enabled)
+       (when (and (sso-settings/saml-slo-enabled)
                   (= sso_source "saml"))
          (saml/logout-redirect-location
           :idp-url (sso-settings/saml-identity-provider-uri)
@@ -96,7 +96,9 @@
   "Handles client confirmation of saml logout via slo"
   [:as req]
   (try
-    (sso.i/sso-handle-slo req)
+    (if (sso-settings/saml-slo-enabled)
+      (sso.i/sso-handle-slo req)
+      (throw (Exception. "SAML SLO is not enabled")))
     (catch Throwable e
       (log/error e "Error handling SLO")
       (sso-error-page e :out))))

--- a/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
@@ -44,7 +44,7 @@
    :body    (stencil/render-file "metabase_enterprise/sandbox/api/error_page"
                                  (let [message    (.getMessage e)
                                        data       (u/pprint-to-str (ex-data e))]
-                                   {:logDirection   log-direction
+                                   {:logDirection   (name log-direction)
                                     :errorMessage   message
                                     :exceptionClass (.getName Exception)
                                     :additionalData data}))})

--- a/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
@@ -98,7 +98,8 @@
   (try
     (if (sso-settings/saml-slo-enabled)
       (sso.i/sso-handle-slo req)
-      (throw (Exception. "SAML SLO is not enabled")))
+      (throw (ex-info "SAML Single Logout is not enabled, request forbidden."
+                      {:status-code 403})))
     (catch Throwable e
       (log/error e "Error handling SLO")
       (sso-error-page e :out))))

--- a/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
@@ -38,7 +38,7 @@
       (throw e))))
 
 (mu/defn ^:private sso-error-page
-  [^Throwable e log-direction :- [:enum "in" "out"]]
+  [^Throwable e log-direction :- [:enum :in :out]]
   {:status  (get (ex-data e) :status-code 500)
    :headers {"Content-Type" "text/html"}
    :body    (stencil/render-file "metabase_enterprise/sandbox/api/error_page"
@@ -57,7 +57,7 @@
     (sso.i/sso-post req)
     (catch Throwable e
       (log/error e "Error logging in")
-      (sso-error-page e "in"))))
+      (sso-error-page e :in))))
 
 
 ;; ------------------------------ Single Logout aka SLO ------------------------------
@@ -99,6 +99,6 @@
     (sso.i/sso-handle-slo req)
     (catch Throwable e
       (log/error e "Error handling SLO")
-      (sso-error-page e "out"))))
+      (sso-error-page e :out))))
 
 (api/define-routes)

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -251,9 +251,11 @@
 
 (defmethod sso.i/sso-handle-slo :saml
   [{:keys [cookies params]}]
-  (let [xml-str (base64-decode (:SAMLResponse params))
-        success? (slo-success? xml-str)]
-    (if-let [metabase-session-id (and success? (get-in cookies [mw.session/metabase-session-cookie :value]))]
-      (do (t2/delete! :model/Session :id metabase-session-id)
-          (mw.session/clear-session-cookie (response/redirect (urls/site-url))))
-      {:status 500 :body "SAML logout failed."})))
+  (if (sso-settings/saml-slo-enabled)
+    (let [xml-str (base64-decode (:SAMLResponse params))
+          success? (slo-success? xml-str)]
+      (if-let [metabase-session-id (and success? (get-in cookies [mw.session/metabase-session-cookie :value]))]
+        (do (t2/delete! :model/Session :id metabase-session-id)
+            (mw.session/clear-session-cookie (response/redirect (urls/site-url))))
+        {:status 500 :body "SAML logout failed."}))
+    (log/warn "SAML SLO is not enabled, not continuing Single Log Out flow.")))

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_settings.clj
@@ -167,6 +167,18 @@ on your IdP, this usually looks something like `http://www.example.com/141xkex60
                (setting/get-value-of-type :boolean :saml-enabled)
                false)))
 
+(defsetting saml-slo-enabled
+  (deferred-tru "Is SAML Single Log Out enabled?")
+  :type    :boolean
+  :default false
+  :feature :sso-saml
+  :audit   :getter
+  :export? false
+  :getter  (fn []
+             (if (saml-enabled)
+               (setting/get-value-of-type :boolean :saml-slo-enabled)
+               false)))
+
 (defsetting jwt-identity-provider-uri
   (deferred-tru "URL of JWT based login page")
   :feature :sso-jwt

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/sso_settings_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/sso_settings_test.clj
@@ -116,7 +116,11 @@
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo
            #"Setting saml-enabled is not enabled because feature :sso-saml is not available"
-           (sso-settings/saml-enabled! true))))))
+           (sso-settings/saml-enabled! true)))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Setting saml-slo-enabled is not enabled because feature :sso-saml is not available"
+           (sso-settings/saml-slo-enabled! true))))))
 
 (deftest jwt-settings-token-features-test
   (testing "Getting JWT settings should return their default values without :sso-jwt feature flag enabled"

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -1219,14 +1219,17 @@
   will happen, in [[call-on-change]] below.
 
   ###### `:feature`
+
   If non-nil, determines the Enterprise feature flag required to use this setting. If the feature is not enabled,
   the setting will behave the same as if `enabled?` returns `false` (see below).
 
   ###### `enabled?`
+
   Function which returns true if the setting should be enabled. If it returns false, the setting will throw an
   exception when it is attempted to be set, and will return its default value when read. Defaults to always enabled.
 
   ###### `audit`
+
   Keyword that determines what kind of audit log entry should be created when this setting is written. Options are
   `:never`, `:no-value`, `:raw-value`, and `:getter`. User- and database-local settings are never audited. `:getter`
   should be used for most non-sensitive settings, and will log the value returned by its getter, which may be
@@ -1235,6 +1238,7 @@
   and `:sensitive` settings.)
 
   ###### `base`
+
   A map which can provide values for any of the above options, except for :export?.
   Any top level options will override what's in this base map.
   The use case for this map is sharing strongly coupled options between similar settings, see [[uuid-nonce-base]].


### PR DESCRIPTION
resolves #44758

This adds a `defsetting` called `saml-slo-enabled` in the sso-settings namespace.

It defaults to false, and if it's false then we won't do the single logout flow, as requested in #44758.

This is going to be a breaking change, for users who rely on us doing SLO when logging out, so that needs to be in the changelog.