### PR TITLE
Performance: partial data-permissions graph refactor

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/connection_impersonation.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/connection_impersonation.clj
@@ -28,7 +28,7 @@
                                    {:where [:and
                                             (when db-id [:= :db_id db-id])
                                             (when group-id [:= :group_id group-id])
-                                            (when group-id [:in :group_id group-ids])
+                                            (when group-ids [:in :group_id group-ids])
                                             (when-not audit-db? [:not [:= :db_id audit/audit-db-id]])]})]
      (reduce (fn [acc {:keys [db_id group_id]}]
                 (assoc-in acc [group_id db_id :view-data] :impersonated))

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/connection_impersonation.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/connection_impersonation.clj
@@ -21,13 +21,14 @@
 (defenterprise add-impersonations-to-permissions-graph
   "Augment a provided permissions graph with active connection impersonation policies."
   :feature :advanced-permissions
-  [graph & {:keys [group-id db-id audit-db?]}]
+  [graph & {:keys [group-ids group-id db-id audit-db?]}]
   (m/deep-merge
    graph
    (let [impersonations (t2/select :model/ConnectionImpersonation
                                    {:where [:and
                                             (when db-id [:= :db_id db-id])
                                             (when group-id [:= :group_id group-id])
+                                            (when group-id [:in :group_id group-ids])
                                             (when-not audit-db? [:not [:= :db_id audit/audit-db-id]])]})]
      (reduce (fn [acc {:keys [db_id group_id]}]
                 (assoc-in acc [group_id db_id :view-data] :impersonated))

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
@@ -120,13 +120,14 @@
 (defenterprise add-sandboxes-to-permissions-graph
   "Augments a provided permissions graph with active sandboxing policies."
   :feature :sandboxes
-  [graph & {:keys [group-id db-id audit?]}]
+  [graph & {:keys [group-ids group-id db-id audit?]}]
   (let [sandboxes (t2/select :model/GroupTableAccessPolicy
                              {:select [:s.group_id :s.table_id :t.db_id :t.schema]
                               :from [[:sandboxes :s]]
                               :join [[:metabase_table :t] [:= :s.table_id :t.id]]
                               :where [:and
                                       (when group-id [:= :s.group_id group-id])
+                                      (when group-ids [:in :s.group_id group-ids])
                                       (when db-id [:= :t.db_id db-id])
                                       (when-not audit? [:not [:= :t.db_id audit/audit-db-id]])]})]
     ;; Incorporate each sandbox policy into the permissions graph.

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
@@ -122,14 +122,14 @@ if (hasPremiumFeature("advanced_permissions")) {
   PLUGIN_REDUCERS.advancedPermissionsPlugin = advancedPermissionsSlice.reducer;
 
   PLUGIN_DATA_PERMISSIONS.permissionsPayloadExtraSelectors.push(
-    (state, modifiedGroupIds) => {
+    (state, data) => {
       const impersonations = getImpersonations(state);
-      const modifiedGroupImpersonations = impersonations.filter(impersonation =>
-        modifiedGroupIds.has(`${impersonation.group_id}`),
-      );
+      const impersonationGroupIds = impersonations.map(i => `${i.group_id}`);
 
       return {
-        impersonations: modifiedGroupImpersonations,
+        ...data,
+        modifiedGroupIds: [...data.modifiedGroupIds, ...impersonationGroupIds],
+        impersonations,
       };
     },
   );

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
@@ -121,9 +121,18 @@ if (hasPremiumFeature("advanced_permissions")) {
 
   PLUGIN_REDUCERS.advancedPermissionsPlugin = advancedPermissionsSlice.reducer;
 
-  PLUGIN_DATA_PERMISSIONS.permissionsPayloadExtraSelectors.push(state => ({
-    impersonations: getImpersonations(state),
-  }));
+  PLUGIN_DATA_PERMISSIONS.permissionsPayloadExtraSelectors.push(
+    (state, modifiedGroupIds) => {
+      const impersonations = getImpersonations(state);
+      const modifiedGroupImpersonations = impersonations.filter(impersonation =>
+        modifiedGroupIds.has(`${impersonation.group_id}`),
+      );
+
+      return {
+        impersonations: modifiedGroupImpersonations,
+      };
+    },
+  );
 
   PLUGIN_DATA_PERMISSIONS.hasChanges.push(
     state => getImpersonations(state).length > 0,

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
@@ -125,12 +125,7 @@ if (hasPremiumFeature("advanced_permissions")) {
     (state, data) => {
       const impersonations = getImpersonations(state);
       const impersonationGroupIds = impersonations.map(i => `${i.group_id}`);
-
-      return {
-        ...data,
-        modifiedGroupIds: [...data.modifiedGroupIds, ...impersonationGroupIds],
-        impersonations,
-      };
+      return [{ impersonations }, impersonationGroupIds];
     },
   );
 

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/index.js
@@ -1,5 +1,6 @@
 import { push } from "react-router-redux";
 import { t } from "ttag";
+import _ from "underscore";
 
 import { DataPermissionValue } from "metabase/admin/permissions/types";
 import {
@@ -24,11 +25,7 @@ import sandboxingReducer from "./actions";
 import { LoginAttributesWidget } from "./components/LoginAttributesWidget";
 import { getSandboxedTableWarningModal } from "./confirmations";
 import EditSandboxingModal from "./containers/EditSandboxingModal";
-import {
-  getGroupIdsOfModifiedPolices,
-  getDraftPolicies,
-  hasPolicyChanges,
-} from "./selectors";
+import { getDraftPolicies, hasPolicyChanges } from "./selectors";
 
 const OPTION_SEGMENTED = {
   label: t`Sandboxed`,
@@ -90,13 +87,11 @@ if (hasPremiumFeature("sandboxes")) {
   PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_POST_ACTION[OPTION_SEGMENTED.value] =
     getEditSegmentedAccessPostAction;
 
-  PLUGIN_DATA_PERMISSIONS.permissionsPayloadExtraSelectors.push(
-    (state, data) => {
-      const sandboxes = getDraftPolicies(state);
-      const modifiedGroupIds = getGroupIdsOfModifiedPolices(state);
-      return [{ sandboxes }, modifiedGroupIds];
-    },
-  );
+  PLUGIN_DATA_PERMISSIONS.permissionsPayloadExtraSelectors.push(state => {
+    const sandboxes = getDraftPolicies(state);
+    const modifiedGroupIds = _.uniq(sandboxes.map(sb => sb.group_id));
+    return [{ sandboxes }, modifiedGroupIds];
+  });
 
   PLUGIN_DATA_PERMISSIONS.hasChanges.push(hasPolicyChanges);
   PLUGIN_REDUCERS.sandboxingPlugin = sandboxingReducer;

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/index.js
@@ -24,7 +24,11 @@ import sandboxingReducer from "./actions";
 import { LoginAttributesWidget } from "./components/LoginAttributesWidget";
 import { getSandboxedTableWarningModal } from "./confirmations";
 import EditSandboxingModal from "./containers/EditSandboxingModal";
-import { getDraftPolicies, hasPolicyChanges } from "./selectors";
+import {
+  getGroupIdsOfModifiedPolices,
+  getDraftPolicies,
+  hasPolicyChanges,
+} from "./selectors";
 
 const OPTION_SEGMENTED = {
   label: t`Sandboxed`,
@@ -87,14 +91,14 @@ if (hasPremiumFeature("sandboxes")) {
     getEditSegmentedAccessPostAction;
 
   PLUGIN_DATA_PERMISSIONS.permissionsPayloadExtraSelectors.push(
-    (state, modifiedGroupIds) => {
+    (state, data) => {
       const sandboxes = getDraftPolicies(state);
-      const modifiedGroupSandboxes = sandboxes.filter(sandbox =>
-        modifiedGroupIds.has(`${sandbox.group_id}`),
-      );
+      const modifiedGroupIds = getGroupIdsOfModifiedPolices(state);
 
       return {
-        sandboxes: modifiedGroupSandboxes,
+        ...data,
+        modifiedGroupIds: [...data.modifiedGroupIds, ...modifiedGroupIds],
+        sandboxes,
       };
     },
   );

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/index.js
@@ -86,12 +86,18 @@ if (hasPremiumFeature("sandboxes")) {
   PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_POST_ACTION[OPTION_SEGMENTED.value] =
     getEditSegmentedAccessPostAction;
 
-  PLUGIN_DATA_PERMISSIONS.permissionsPayloadExtraSelectors.push(state => {
-    const sandboxes = getDraftPolicies(state);
-    return {
-      sandboxes,
-    };
-  });
+  PLUGIN_DATA_PERMISSIONS.permissionsPayloadExtraSelectors.push(
+    (state, modifiedGroupIds) => {
+      const sandboxes = getDraftPolicies(state);
+      const modifiedGroupSandboxes = sandboxes.filter(sandbox =>
+        modifiedGroupIds.has(`${sandbox.group_id}`),
+      );
+
+      return {
+        sandboxes: modifiedGroupSandboxes,
+      };
+    },
+  );
 
   PLUGIN_DATA_PERMISSIONS.hasChanges.push(hasPolicyChanges);
   PLUGIN_REDUCERS.sandboxingPlugin = sandboxingReducer;

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/index.js
@@ -94,12 +94,7 @@ if (hasPremiumFeature("sandboxes")) {
     (state, data) => {
       const sandboxes = getDraftPolicies(state);
       const modifiedGroupIds = getGroupIdsOfModifiedPolices(state);
-
-      return {
-        ...data,
-        modifiedGroupIds: [...data.modifiedGroupIds, ...modifiedGroupIds],
-        sandboxes,
-      };
+      return [{ sandboxes }, modifiedGroupIds];
     },
   );
 

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/selectors.ts
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/selectors.ts
@@ -1,4 +1,5 @@
 import { createSelector } from "@reduxjs/toolkit";
+import _ from "underscore";
 
 import type { GroupTableAccessPolicyParams, SandboxesState } from "./types";
 import { getPolicyKeyFromParams } from "./utils";
@@ -22,6 +23,33 @@ export const getGroupTableAccessPolicy = (
     state.plugins.sandboxingPlugin.groupTableAccessPolicies[key] ??
     state.plugins.sandboxingPlugin.originalGroupTableAccessPolicies[key]
   );
+};
+
+// return new and altered policies
+export const getGroupIdsOfModifiedPolices = (state: SandboxesState) => {
+  const originalPolicies =
+    state.plugins.sandboxingPlugin.originalGroupTableAccessPolicies;
+  const policies = state.plugins.sandboxingPlugin.groupTableAccessPolicies;
+
+  const allPolicyKeys = _.uniq(
+    Object.keys(originalPolicies).concat(Object.keys(policies)),
+  );
+
+  const modifiedGroupIds = allPolicyKeys
+    .map(key => {
+      const before = originalPolicies[key];
+      const after = policies[key];
+      const groupId = before?.group_id ?? after?.group_id;
+
+      // empty key can be present in original, so we may have an empty group id
+      if (!groupId || _.isEqual(before, after)) {
+        return null;
+      }
+      return `${groupId}`;
+    })
+    .filter(x => x !== null);
+
+  return modifiedGroupIds;
 };
 
 export const getDraftPolicies = (state: SandboxesState) => {

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/selectors.ts
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/selectors.ts
@@ -1,5 +1,4 @@
 import { createSelector } from "@reduxjs/toolkit";
-import _ from "underscore";
 
 import type { GroupTableAccessPolicyParams, SandboxesState } from "./types";
 import { getPolicyKeyFromParams } from "./utils";

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/selectors.ts
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/selectors.ts
@@ -25,33 +25,6 @@ export const getGroupTableAccessPolicy = (
   );
 };
 
-// return new and altered policies
-export const getGroupIdsOfModifiedPolices = (state: SandboxesState) => {
-  const originalPolicies =
-    state.plugins.sandboxingPlugin.originalGroupTableAccessPolicies;
-  const policies = state.plugins.sandboxingPlugin.groupTableAccessPolicies;
-
-  const allPolicyKeys = _.uniq(
-    Object.keys(originalPolicies).concat(Object.keys(policies)),
-  );
-
-  const modifiedGroupIds = allPolicyKeys
-    .map(key => {
-      const before = originalPolicies[key];
-      const after = policies[key];
-      const groupId = before?.group_id ?? after?.group_id;
-
-      // empty key can be present in original, so we may have an empty group id
-      if (!groupId || _.isEqual(before, after)) {
-        return null;
-      }
-      return `${groupId}`;
-    })
-    .filter(x => x !== null);
-
-  return modifiedGroupIds;
-};
-
 export const getDraftPolicies = (state: SandboxesState) => {
   return Object.values(state.plugins.sandboxingPlugin.groupTableAccessPolicies);
 };

--- a/frontend/src/metabase-types/api/permissions.ts
+++ b/frontend/src/metabase-types/api/permissions.ts
@@ -18,7 +18,7 @@ export type PermissionsGraph = {
 };
 
 export type GroupsPermissions = {
-  [key: GroupId]: GroupPermissions;
+  [key: GroupId | string]: GroupPermissions;
 };
 
 export type GroupPermissions = {

--- a/frontend/src/metabase/admin/permissions/permissions.js
+++ b/frontend/src/metabase/admin/permissions/permissions.js
@@ -32,7 +32,7 @@ import { trackPermissionChange } from "./analytics";
 import { DataPermissionType, DataPermission } from "./types";
 import { isDatabaseEntityId } from "./utils/data-entity-id";
 import {
-  getModifiedPermissionsGraphParts,
+  getModifiedGroupsPermissionsGraphParts,
   mergeGroupsPermissionsUpdates,
 } from "./utils/graph/partial-updates";
 
@@ -212,15 +212,18 @@ export const saveDataPermissions = createThunkAction(
         { modifiedGroupIds: [], permissions: {} },
       );
 
-    const partialPermissionsGraph = getModifiedPermissionsGraphParts(
-      allGroupIds,
+    const modifiedGroups = getModifiedGroupsPermissionsGraphParts(
       dataPermissions,
       originalDataPermissions,
-      advancedPermissions,
-      dataPermissionsRevision,
+      allGroupIds,
+      advancedPermissions.modifiedGroupIds,
     );
 
-    return await PermissionsApi.updateGraph(partialPermissionsGraph);
+    return await PermissionsApi.updateGraph({
+      groups: modifiedGroups,
+      revision: dataPermissionsRevision,
+      ...advancedPermissions.permissions,
+    });
   },
 );
 

--- a/frontend/src/metabase/admin/permissions/utils/graph/partial-updates.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/partial-updates.ts
@@ -2,75 +2,30 @@ import _ from "underscore";
 
 import type { GroupsPermissions } from "metabase-types/api";
 
-type AdvancedPermissions = Record<
-  string,
-  { group_id: number; [key: string]: unknown }[] | undefined
->;
-
-interface AdvancedPermissionsData {
-  modifiedGroupIds: string[];
-  permissions: AdvancedPermissions;
-}
-
 // utils for dealing with partial graph updates
-
-function getModifiedGroupIdsInGraph(
-  groupIds: string[],
-  originalDataPermissions: GroupsPermissions,
-  newDataPermissions: GroupsPermissions,
-) {
-  // find only the groupIds that have had some kind of modification made in their permissions graph
-  return groupIds.filter(groupId => {
-    return !_.isEqual(
-      newDataPermissions[groupId as unknown as number],
-      originalDataPermissions[groupId as unknown as number],
-    );
-  });
-}
-
-function getModifiedAdvancedPermissions(
-  advancedPermissions: AdvancedPermissions,
-  modifiedGroupIds: string[],
-) {
-  const groupIds = new Set(modifiedGroupIds);
-
-  return Object.fromEntries(
-    Object.entries(advancedPermissions).map(([key, items]) => {
-      const modified = (items || []).filter(item =>
-        groupIds.has(`${item.group_id}`),
-      );
-      return [key, modified];
-    }),
-  );
-}
 
 // select only the parts of the permission graph that contain some kind of edit
 // currently only selects values based on some kind of modification happening anywhere
 // in the graph for a particular group
-export function getModifiedPermissionsGraphParts(
-  allGroupIds: string[],
+export function getModifiedGroupsPermissionsGraphParts(
   dataPermissions: GroupsPermissions,
   originalDataPermissions: GroupsPermissions,
-  advancedPermissionsData: AdvancedPermissionsData,
-  dataPermissionsRevision: number,
+  allGroupIds: string[],
+  externallyModifiedGroupIds: string[],
 ) {
-  const modifiedGroupIds = _.uniq([
-    ...getModifiedGroupIdsInGraph(
-      allGroupIds,
-      originalDataPermissions,
-      dataPermissions,
-    ),
-    ...advancedPermissionsData.modifiedGroupIds,
+  const dataPermissionsModifiedGroupIds = allGroupIds.filter(groupId => {
+    return !_.isEqual(
+      dataPermissions[groupId],
+      originalDataPermissions[groupId],
+    );
+  });
+
+  const allModifiedGroupIds = _.uniq([
+    ...dataPermissionsModifiedGroupIds,
+    ...externallyModifiedGroupIds,
   ]);
 
-  return {
-    groups: _.pick(dataPermissions, modifiedGroupIds),
-    revision: dataPermissionsRevision,
-    ...getModifiedAdvancedPermissions(
-      advancedPermissionsData.permissions,
-      modifiedGroupIds,
-    ),
-  };
+  return _.pick(dataPermissions, allModifiedGroupIds);
 }
 
 export function mergeGroupsPermissionsUpdates(

--- a/frontend/src/metabase/admin/permissions/utils/graph/partial-updates.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/partial-updates.ts
@@ -43,8 +43,7 @@ export function mergeGroupsPermissionsUpdates(
 
   const latestPermissionsEntries = allGroupIds.map(groupId => {
     const permissions =
-      newDataPermissions[groupId as unknown as number] ??
-      originalDataPermissions[groupId as unknown as number];
+      newDataPermissions[groupId] ?? originalDataPermissions[groupId];
     return [groupId, permissions];
   });
 

--- a/frontend/src/metabase/admin/permissions/utils/graph/partial-updates.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/partial-updates.ts
@@ -1,0 +1,72 @@
+import _ from "underscore";
+
+import type { GroupPermissions } from "metabase-types/api";
+
+// utils for dealing with partial graph updates
+
+// access
+
+export function getModifiedGroupIds(
+  groupIds: string[],
+  originalDataPermissions: GroupPermissions,
+  newDataPermissions: GroupPermissions,
+) {
+  // find only the groupIds that have had some kind of modification made in their permissions graph
+  return groupIds.filter(groupId => {
+    return !_.isEqual(
+      newDataPermissions[groupId as unknown as number],
+      originalDataPermissions[groupId as unknown as number],
+    );
+  });
+}
+
+function getModifiedGroupItems(
+  items: { group_id: number }[],
+  groupIds: Set<string>,
+) {
+  return items.filter(item => groupIds.has(`${item.group_id}`));
+}
+
+export function getPermissionsUpdatesForGroupIds(
+  dataPermissions: GroupPermissions,
+  dataPermissionsRevision: number,
+  advancedPermissionsData: Record<string, { group_id: number }[]>,
+  groupIds: string[],
+) {
+  const groupIdsSet = new Set(groupIds);
+
+  const filterAdvancedPermissionsData = Object.fromEntries(
+    Object.entries(advancedPermissionsData).map(([key, value]) => {
+      return [key, getModifiedGroupItems(value, groupIdsSet)];
+    }),
+  );
+
+  return {
+    groups: _.pick(dataPermissions, groupIds),
+    revision: dataPermissionsRevision,
+    ...filterAdvancedPermissionsData,
+  };
+}
+
+export function mergeGroupPermissionsUpdates(
+  originalDataPermissions: GroupPermissions | null | undefined,
+  newDataPermissions: GroupPermissions,
+) {
+  if (!originalDataPermissions) {
+    return newDataPermissions;
+  }
+
+  const allGroupIds = _.uniq([
+    ...Object.keys(originalDataPermissions),
+    ...Object.keys(newDataPermissions),
+  ]);
+
+  const latestPermissionsEntries = allGroupIds.map(groupId => {
+    const permissions =
+      newDataPermissions[groupId as unknown as number] ??
+      originalDataPermissions[groupId as unknown as number];
+    return [groupId, permissions];
+  });
+
+  return Object.fromEntries(latestPermissionsEntries);
+}

--- a/frontend/src/metabase/admin/permissions/utils/graph/partial-updates.unit.spec.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/partial-updates.unit.spec.ts
@@ -1,0 +1,175 @@
+import _ from "underscore";
+
+import type { GroupsPermissions } from "metabase-types/api";
+
+import { DataPermission, DataPermissionValue } from "../../types";
+
+import {
+  getModifiedPermissionsGraphParts,
+  mergeGroupsPermissionsUpdates,
+} from "./partial-updates";
+
+describe("getModifiedPermissionsGraphParts", () => {
+  const simpleUpdate = getModifiedPermissionsGraphParts(
+    ["1", "2"],
+    {
+      "1": {
+        "1": { [DataPermission.VIEW_DATA]: DataPermissionValue.UNRESTRICTED },
+      },
+      "2": { "1": { [DataPermission.VIEW_DATA]: DataPermissionValue.NO } },
+    },
+    {
+      "1": {
+        "1": { [DataPermission.VIEW_DATA]: DataPermissionValue.UNRESTRICTED },
+      },
+      "2": {
+        "1": { [DataPermission.VIEW_DATA]: DataPermissionValue.UNRESTRICTED },
+      },
+    },
+    { modifiedGroupIds: [], permissions: {} },
+    2,
+  );
+
+  it("should include groups that have had data permission updated", async () => {
+    expect(simpleUpdate).toEqual({
+      groups: {
+        "2": { "1": { [DataPermission.VIEW_DATA]: DataPermissionValue.NO } },
+      },
+      revision: 2,
+    });
+  });
+
+  it("should not include groups that have not been altered", async () => {
+    expect(simpleUpdate.groups).not.toHaveProperty("1");
+  });
+
+  // partially apply arguments for terser testing below
+  const advancedGetModifiedPermissionsGraphParts = _.partial(
+    getModifiedPermissionsGraphParts,
+    ["1", "2"],
+    {
+      "1": {
+        "1": { [DataPermission.VIEW_DATA]: DataPermissionValue.UNRESTRICTED },
+      },
+      "2": {
+        "1": { [DataPermission.VIEW_DATA]: DataPermissionValue.UNRESTRICTED },
+      },
+    },
+    {
+      "1": {
+        "1": { [DataPermission.VIEW_DATA]: DataPermissionValue.UNRESTRICTED },
+      },
+      "2": {
+        "1": { [DataPermission.VIEW_DATA]: DataPermissionValue.UNRESTRICTED },
+      },
+    },
+  );
+
+  it("should include groups that have had an advanced permission added", async () => {
+    expect(
+      advancedGetModifiedPermissionsGraphParts(
+        {
+          modifiedGroupIds: ["1"],
+          permissions: {
+            testAdvancedPermission: [{ group_id: 1 }],
+          },
+        },
+        2,
+      ),
+    ).toEqual({
+      groups: {
+        "1": {
+          "1": { [DataPermission.VIEW_DATA]: DataPermissionValue.UNRESTRICTED },
+        },
+      },
+      revision: 2,
+      testAdvancedPermission: [{ group_id: 1 }],
+    });
+  });
+
+  it("should include groups that have had an advanced permission updated", async () => {
+    expect(
+      advancedGetModifiedPermissionsGraphParts(
+        {
+          modifiedGroupIds: ["1"],
+          permissions: {
+            testAdvancedPermission: [{ group_id: 1, some_attribute: 1 }],
+          },
+        },
+        2,
+      ),
+    ).toEqual({
+      groups: {
+        "1": {
+          "1": { [DataPermission.VIEW_DATA]: DataPermissionValue.UNRESTRICTED },
+        },
+      },
+      revision: 2,
+      testAdvancedPermission: [{ group_id: 1, some_attribute: 1 }],
+    });
+  });
+
+  it("should include groups that have had an advanced permission removed", async () => {
+    expect(
+      advancedGetModifiedPermissionsGraphParts(
+        {
+          modifiedGroupIds: ["1"],
+          permissions: {
+            testAdvancedPermission: [],
+          },
+        },
+        2,
+      ),
+    ).toEqual({
+      groups: {
+        "1": {
+          "1": {
+            [DataPermission.VIEW_DATA]: DataPermissionValue.UNRESTRICTED,
+          },
+        },
+      },
+      revision: 2,
+      testAdvancedPermission: [],
+    });
+  });
+});
+
+describe("mergeGroupsPermissionsUpdates", () => {
+  // test is a product of bad typings... ideally our state should never be null
+  // but our reducers are typed such that it could be null
+  it("should take only new permissions if there's not previous state", async () => {
+    const update: GroupsPermissions = {
+      "1": {
+        "1": { [DataPermission.VIEW_DATA]: DataPermissionValue.UNRESTRICTED },
+      },
+    };
+
+    expect(mergeGroupsPermissionsUpdates(undefined, update)).toBe(update);
+  });
+
+  it("should only apply updates to groups that have been modified", async () => {
+    const permissions: GroupsPermissions = {
+      "1": {
+        "1": { [DataPermission.VIEW_DATA]: DataPermissionValue.UNRESTRICTED },
+      },
+      "2": {
+        "1": { [DataPermission.VIEW_DATA]: DataPermissionValue.UNRESTRICTED },
+      },
+    };
+
+    const update: GroupsPermissions = {
+      "2": { "1": { [DataPermission.VIEW_DATA]: DataPermissionValue.NO } },
+    };
+
+    const expectedResult = {
+      "1": {
+        "1": { [DataPermission.VIEW_DATA]: DataPermissionValue.UNRESTRICTED },
+      },
+      "2": { "1": { [DataPermission.VIEW_DATA]: DataPermissionValue.NO } },
+    };
+
+    expect(mergeGroupsPermissionsUpdates(permissions, update)).toEqual(
+      expectedResult,
+    );
+  });
+});

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -118,7 +118,7 @@ export const PLUGIN_DATA_PERMISSIONS: {
   permissionsPayloadExtraSelectors: ((
     state: State,
     modifiedGroupIds: Set<string>,
-  ) => Record<string, unknown>)[];
+  ) => Record<string, { group_id: string }>)[];
   hasChanges: ((state: State) => boolean)[];
   shouldRestrictNativeQueryPermissions: (
     permissions: GroupsPermissions,

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -117,6 +117,7 @@ export const PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_POST_ACTION = {
 export const PLUGIN_DATA_PERMISSIONS: {
   permissionsPayloadExtraSelectors: ((
     state: State,
+    modifiedGroupIds: Set<string>,
   ) => Record<string, unknown>)[];
   hasChanges: ((state: State) => boolean)[];
   shouldRestrictNativeQueryPermissions: (

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -117,8 +117,7 @@ export const PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_POST_ACTION = {
 export const PLUGIN_DATA_PERMISSIONS: {
   permissionsPayloadExtraSelectors: ((
     state: State,
-    modifiedGroupIds: Set<string>,
-  ) => Record<string, { group_id: string }>)[];
+  ) => [Record<string, undefined | { group_id: string }[]>, string[]])[];
   hasChanges: ((state: State) => boolean)[];
   shouldRestrictNativeQueryPermissions: (
     permissions: GroupsPermissions,

--- a/src/metabase/api/permissions.clj
+++ b/src/metabase/api/permissions.clj
@@ -101,9 +101,10 @@
                                      (upsert-sandboxes! sandbox-updates))
             impersonation-updates  (:impersonations graph)
             impersonations         (when impersonation-updates
-                                     (insert-impersonations! impersonation-updates))]
+                                     (insert-impersonations! impersonation-updates))
+            group-ids (-> graph :groups keys)]
         (merge {:revision (perms-revision/latest-id)}
-               (when-not skip-graph {:groups (:groups (data-perms.graph/api-graph {}))})
+               (when-not skip-graph {:groups (:groups (data-perms.graph/api-graph {:group-ids group-ids}))})
                (when sandboxes {:sandboxes sandboxes})
                (when impersonations {:impersonations impersonations}))))))
 

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -541,7 +541,7 @@
   "Returns a tree representation of all data permissions. Can be optionally filtered by group ID, database ID,
   and/or permission type. This is intended to power the permissions editor in the admin panel, and should not be used
   for permission enforcement, as it will read much more data than necessary."
-  [& {:keys [group-id db-id perm-type audit?]}]
+  [& {:keys [group-id group-ids db-id perm-type audit?]}]
   (let [data-perms (t2/select [:model/DataPermissions
                                [:perm_type :type]
                                [:group_id :group-id]
@@ -553,6 +553,7 @@
                                        (when perm-type [:= :perm_type (u/qualified-name perm-type)])
                                        (when db-id [:= :db_id db-id])
                                        (when group-id [:= :group_id group-id])
+                                       (when group-ids [:in :group_id group-ids])
                                        (when-not audit? [:not= :db_id audit/audit-db-id])]})]
     (reduce
      (fn [graph {group-id  :group-id

--- a/src/metabase/models/data_permissions/graph.clj
+++ b/src/metabase/models/data_permissions/graph.clj
@@ -141,13 +141,16 @@
                                                             {:where [:and
                                                                      (when-not audit? [:not= :id audit/audit-db-id])]}))]
     ;; Don't add admin perms when we're fetching the perms for a specific non-admin group or set of groups
-    (if (not (or (= group-id admin-group-id)
-                 (contains? (set group-ids) admin-group-id)))
-      api-graph
+    (if (or (= group-id admin-group-id)
+            (contains? (set group-ids) admin-group-id)
+            ;; If we're not filtering on specific group IDs, always include the admin group
+            (and (nil? group-id)
+                 (nil? (seq group-ids))))
       (reduce (fn [api-graph db-id]
                 (assoc-in api-graph [admin-group-id db-id] admin-perms))
               api-graph
-              db-ids))))
+              db-ids)
+      api-graph)))
 
 (defn remove-empty-vals
   "Recursively walks a nested map from bottom-up, removing keys with nil or empty map values."

--- a/src/metabase/models/data_permissions/graph.clj
+++ b/src/metabase/models/data_permissions/graph.clj
@@ -171,6 +171,7 @@
   ([& {:as opts}
     :- [:map
         [:group-id {:optional true} [:maybe pos-int?]]
+        [:group-ids {:optional true} [:maybe [:sequential pos-int?]]]
         [:db-id {:optional true} [:maybe pos-int?]]
         [:audit? {:optional true} [:maybe :boolean]]
         [:perm-type {:optional true} [:maybe data-perms/PermissionType]]]]
@@ -425,7 +426,8 @@
   "Takes an API-style perms graph and sets the permissions in the database accordingly. Additionally validates the revision number,
    logs the changes, and ensures impersonations and sandboxes are consistent."
   ([new-graph :- api.permission-graph/StrictData]
-   (let [old-graph (api-graph)
+   (let [group-ids (-> new-graph :groups keys)
+         old-graph (api-graph {:group-ids group-ids})
          [old new] (data/diff (:groups old-graph) (:groups new-graph))
          old       (or old {})
          new       (or new {})]


### PR DESCRIPTION
Closes #44768

### Description

Updates to the BE (code already approved) and FE changes to allow for partial editing of permissions graphs in the admin settings. This change detects which groups have had some kind of modification within the graph and only sends that part of the graph / omits unmodified groups in the update request body. The backend now only sends a response with just the modified groups, which the FE will now merge back into the client's graph.

### How to verify

The changes _should_ not change the user experience in any way than increasing performance. Please verify that modifying permissions continue to do what you'd expect.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
