### PR TITLE
Reproduction for "When List style field is changed to show remapped foreign key, then cached values are not updated"

### DIFF
--- a/e2e/test/scenarios/admin/datamodel/reproductions.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/reproductions.cy.spec.js
@@ -125,7 +125,11 @@ describe("issue 15542", () => {
 
   function openOrdersTable() {
     // Navigate without reloading the page
-    navigationSidebar().findByText("Databases").click({ force: true });
+    navigationSidebar().findByText("Databases").click({
+      // force the click because the sidebar might be closed but
+      // that is not what we are testing here.
+      force: true,
+    });
 
     cy.findByText("Sample Database").click();
     cy.findByText("Orders").click();

--- a/e2e/test/scenarios/admin/datamodel/reproductions.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/reproductions.cy.spec.js
@@ -1,15 +1,20 @@
 import { SAMPLE_DB_ID, SAMPLE_DB_SCHEMA_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
+  visitAlias,
   restore,
   openReviewsTable,
   popover,
   summarize,
   commandPaletteButton,
   commandPalette,
+  tableHeaderClick,
+  navigationSidebar,
+  appBar,
 } from "e2e/support/helpers";
 
-const { PEOPLE_ID, PEOPLE, REVIEWS, REVIEWS_ID } = SAMPLE_DATABASE;
+const { PEOPLE_ID, PEOPLE, REVIEWS, REVIEWS_ID, ORDERS, ORDERS_ID } =
+  SAMPLE_DATABASE;
 
 describe("issue 17768", () => {
   beforeEach(() => {
@@ -103,6 +108,90 @@ describe("issue 21984", () => {
     commandPaletteButton().click();
     commandPalette().within(() => {
       cy.findByText("Recent items").should("not.exist");
+    });
+  });
+});
+
+describe("issue 15542", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.wrap(
+      `/admin/datamodel/database/${SAMPLE_DB_ID}/schema/${SAMPLE_DB_SCHEMA_ID}/table/${ORDERS_ID}/field/${ORDERS.PRODUCT_ID}/general`,
+    ).as("ORDERS_PRODUCT_ID_URL");
+    cy.intercept("POST", "/api/field/*/dimension").as("fieldDimensionUpdate");
+  });
+
+  function openOrdersTable() {
+    // Navigate without reloading the page
+    navigationSidebar().findByText("Databases").click({ force: true });
+
+    cy.findByText("Sample Database").click();
+    cy.findByText("Orders").click();
+  }
+
+  function exitAdmin() {
+    // Navigate without reloading the page
+    cy.findByText("Exit admin").click();
+  }
+
+  function openOrdersProductIdSettings() {
+    // Navigate without reloading the page
+    appBar().icon("gear").click();
+    popover().findByText("Admin settings").click();
+
+    appBar().findByText("Table Metadata").click();
+    cy.findByText("Orders").click();
+
+    cy.findByTestId("column-PRODUCT_ID").icon("gear").click();
+  }
+
+  function select(name) {
+    return cy.findAllByTestId("select-button").contains(name);
+  }
+
+  it("should be possible to use the foreign key field display values immediately when changing the setting", () => {
+    // This test does manual naviation instead of using openOrdersTable and similar
+    // helpers because they use cy.visit under the hood and that reloads the page,
+    // clearing the in-browser cache, which is what we are testing here.
+
+    visitAlias("@ORDERS_PRODUCT_ID_URL");
+
+    select("Plain input box").click();
+    popover().findByText("A list of all values").click();
+
+    select("Use original value").click();
+    popover().findByText("Use foreign key").click();
+    popover().findByText("Title").click();
+
+    cy.wait("@fieldDimensionUpdate");
+
+    exitAdmin();
+    openOrdersTable();
+
+    tableHeaderClick("Product ID");
+    popover().findByText("Filter by this column").click();
+
+    popover().within(() => {
+      cy.findByText("1").should("not.exist");
+      cy.findByText("Rustic Paper Wallet").should("be.visible");
+    });
+
+    openOrdersProductIdSettings();
+
+    select("Use foreign key").click();
+    popover().findByText("Use original value").click();
+
+    exitAdmin();
+    openOrdersTable();
+
+    tableHeaderClick("Product ID");
+    popover().findByText("Filter by this column").click();
+
+    popover().within(() => {
+      cy.findByText("1").should("be.visible");
+      cy.findByText("Rustic Paper Wallet").should("not.exist");
     });
   });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/15542


The issue was fixed in v50, and this PR adds a reproduction for it.

The test in this PR is a bit messy: for it to reproduce the actual issue it needs to navigate to different pages within the SPA **without doing a full page reload** to avoid clearing the cache. The test therefore cannot make use of the usual `openOrdersTable`-style helpers in clicks around the UI to do the navigation instead.

[Stress test](https://github.com/metabase/metabase/actions/runs/9694628954/job/26752669166)