### PR TITLE
Be explicit about truncating characters versus bytes

### DIFF
--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -958,13 +958,13 @@
   nil)
 
 (defmulti table-name-length-limit
-  "Return the maximum number of characters allowed in a table name, or `nil` if there is no limit."
+  "Return the maximum number of bytes allowed in a table name, or `nil` if there is no limit."
   {:changelog-test/ignore true, :added "0.47.0", :arglists '([driver])}
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)
 
 (defmulti column-name-length-limit
-  "Return the maximum number of characters allowed in a column name, or `nil` if there is no limit."
+  "Return the maximum number of bytes allowed in a column name, or `nil` if there is no limit."
   {:changelog-test/ignore true, :added "0.49.19", :arglists '([driver])}
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)


### PR DESCRIPTION
### Description

We pun on bytes and characters when dealing with determining the table and field names for uploads, because we are always dealing with ASCII characters.

Despite things being OK for now, future code unaware of this gotcha could re-use these driver methods with strings containing multi-byte codepoints, or conversely we could change the way that we normalize table names and no longer use ASCII. The probability is not high, but there's no harm in being more precise in our comments, and declaring our assumptions

Thanks to [this call out](https://github.com/metabase/metabase/pull/44727#discussion_r1655478906) for spurring this change.