### PR TITLE
add e2e test for public dashboard title

### DIFF
--- a/e2e/test/scenarios/sharing/public-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-dashboard.cy.spec.js
@@ -11,6 +11,8 @@ import {
   goToTab,
   assertDashboardFixedWidth,
   assertDashboardFullWidth,
+  describeEE,
+  setTokenFeatures,
 } from "e2e/support/helpers";
 
 const { PRODUCTS } = SAMPLE_DATABASE;
@@ -260,5 +262,28 @@ describe("scenarios > public > dashboard", () => {
     cy.url().should("include", "text=002");
 
     filterWidget().findByText("002").should("be.visible");
+  });
+});
+
+describeEE("scenarios [EE] > public > dashboard", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    prepareDashboard();
+
+    setTokenFeatures("all");
+  });
+
+  it("should set the window title to `{dashboard name} · {application name}`", () => {
+    cy.request("PUT", "/api/setting/application-name", {
+      value: "Custom Application Name",
+    });
+
+    cy.get("@dashboardId").then(id => {
+      visitPublicDashboard(id);
+
+      cy.title().should("eq", "Test Dashboard · Custom Application Name");
+    });
   });
 });

--- a/e2e/test/scenarios/sharing/public-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-dashboard.cy.spec.js
@@ -77,48 +77,52 @@ const USERS = {
   "anonymous user": () => cy.signOut(),
 };
 
+const prepareDashboard = () => {
+  cy.request("PUT", "/api/setting/enable-public-sharing", { value: true });
+
+  cy.intercept("/api/dashboard/*/public_link").as("publicLink");
+
+  cy.createNativeQuestionAndDashboard({
+    questionDetails,
+    dashboardDetails,
+  }).then(
+    ({
+      body: { id, card_id, dashboard_id, dashboard_tab_id },
+      dashboardTabs,
+    }) => {
+      cy.wrap(dashboard_id).as("dashboardId");
+      // Connect filter to the card
+      cy.request("PUT", `/api/dashboard/${dashboard_id}`, {
+        tabs: dashboardTabs,
+        dashcards: [
+          {
+            id,
+            dashboard_tab_id,
+            card_id,
+            row: 0,
+            col: 0,
+            size_x: 8,
+            size_y: 6,
+            parameter_mappings: [
+              {
+                parameter_id: textFilter.id,
+                card_id,
+                target: ["dimension", ["template-tag", "c"]],
+              },
+            ],
+          },
+        ],
+      });
+    },
+  );
+};
+
 describe("scenarios > public > dashboard", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
 
-    cy.request("PUT", "/api/setting/enable-public-sharing", { value: true });
-
-    cy.intercept("/api/dashboard/*/public_link").as("publicLink");
-
-    cy.createNativeQuestionAndDashboard({
-      questionDetails,
-      dashboardDetails,
-    }).then(
-      ({
-        body: { id, card_id, dashboard_id, dashboard_tab_id },
-        dashboardTabs,
-      }) => {
-        cy.wrap(dashboard_id).as("dashboardId");
-        // Connect filter to the card
-        cy.request("PUT", `/api/dashboard/${dashboard_id}`, {
-          tabs: dashboardTabs,
-          dashcards: [
-            {
-              id,
-              dashboard_tab_id,
-              card_id,
-              row: 0,
-              col: 0,
-              size_x: 8,
-              size_y: 6,
-              parameter_mappings: [
-                {
-                  parameter_id: textFilter.id,
-                  card_id,
-                  target: ["dimension", ["template-tag", "c"]],
-                },
-              ],
-            },
-          ],
-        });
-      },
-    );
+    prepareDashboard();
   });
 
   it("should allow users to create public dashboards", () => {


### PR DESCRIPTION

### Description

We recently broke this by mistake and it was not caught by any test

I tried to test this in unit test, but the full title should be `{dashboard name} · {application name}`, and the application name is added by the route in `public-routes` which is not loaded in our jest tests, I tried to look into rendering all of that component but it would have been a bit tricky so I just added this quick e2e test.
