### PR TITLE
Unskip repro for #14957: Saving a question before query has been executed can be slow with UI "hanging"

### DIFF
--- a/e2e/test/scenarios/question-reproductions/reproductions-1.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-1.cy.spec.js
@@ -312,9 +312,9 @@ describe("postgres > user > query", { tags: "@external" }, () => {
   });
 });
 
-const PG_DB_NAME = "QA Postgres12";
+describe("issue 14957", { tags: "@external" }, () => {
+  const PG_DB_NAME = "QA Postgres12";
 
-describe.skip("issue 14957", { tags: "@external" }, () => {
   beforeEach(() => {
     restore("postgres-12");
     cy.signInAsAdmin();
@@ -323,12 +323,7 @@ describe.skip("issue 14957", { tags: "@external" }, () => {
   it("should save a question before query has been executed (metabase#14957)", () => {
     openNativeEditor({ databaseName: PG_DB_NAME }).type("select pg_sleep(60)");
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Save").click();
-
-    cy.findByLabelText("Name").type("14957");
-    cy.button("Save").click();
-
+    saveQuestion("14957");
     modal().should("not.exist");
   });
 });


### PR DESCRIPTION
This PR unskips the repro for the #14957.
The issue has been fixed, but the repro remained skipped for some reason.