### PR TITLE
Parse not a number passed to id filter

### DIFF
--- a/frontend/src/metabase-lib/v1/parameters/utils/mbql.js
+++ b/frontend/src/metabase-lib/v1/parameters/utils/mbql.js
@@ -163,7 +163,10 @@ export function numberParameterValueToMBQL(parameter, fieldRef) {
   const operatorName = getParameterOperatorName(subtype);
 
   return [operatorName, fieldRef].concat(
-    [].concat(parameterValue).map(v => parseFloat(v)),
+    [].concat(parameterValue).map(value => {
+      const number = parseFloat(value);
+      return isNaN(number) ? null : number;
+    }),
   );
 }
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/44790

### Description

If a string passed as a value to query param, it is treated as a valid value, but parsing it as a number causes convertion to NaN and passing it to mbql, which hangs

### How to verify

you need to have a dashboard with id filter and the value passed to it like `{{param}}` via URL parameter

### Demo


https://github.com/metabase/metabase/assets/125459446/b312604d-db18-435b-99f7-8531c69adfff



### Checklist

- tests will be added in a separate PR
