### PR TITLE
Add repro for "Join UI picks the first schema even if a different one is selected"

### DIFF
--- a/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
@@ -5,8 +5,9 @@ import {
   ORDERS_MODEL_ID,
   SECOND_COLLECTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import type { StructuredQuestionDetails } from "e2e/support/helpers";
 import {
+  join,
+  type StructuredQuestionDetails,
   createQuestion,
   entityPickerModal,
   entityPickerModalItem,
@@ -151,7 +152,7 @@ describe("scenarios > notebook > data source", () => {
     });
 
     it(
-      "should correctly display a table from a multi-schema database (metabase#39807)",
+      "should correctly display a table from a multi-schema database (metabase#39807,metabase#11958)",
       { tags: "@external" },
       () => {
         const dialect = "postgres";
@@ -188,12 +189,36 @@ describe("scenarios > notebook > data source", () => {
           assertDataPickerEntitySelected(2, tableName);
 
           entityPickerModalTab("Recents").click();
-
           cy.contains("button", "Animals")
             .should("exist")
             .and("contain.text", tableName)
             .and("have.attr", "aria-selected", "true");
+
+          entityPickerModalTab("Tables").click();
+          cy.findByText(dbName).click();
+          cy.findByText(schemaName).click();
+          cy.findByText(tableName).click();
         });
+
+        cy.log("select a table from the second schema");
+        join();
+        entityPickerModal().within(() => {
+          entityPickerModalTab("Tables").click();
+          cy.findByText("Public").click();
+          cy.findByText("Many Data Types").click();
+        });
+        popover().findByText("Name").click();
+        popover().findByText("Text").click();
+
+        cy.log("select a table from the third schema");
+        join();
+        entityPickerModal().within(() => {
+          entityPickerModalTab("Tables").click();
+          cy.findByText("Domestic").click();
+          cy.findByText("Animals").click();
+        });
+        popover().findByText("Name").click();
+        popover().findByText("Name").click();
       },
     );
 

--- a/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
@@ -156,13 +156,15 @@ describe("scenarios > notebook > data source", () => {
       { tags: "@external" },
       () => {
         const dialect = "postgres";
-        const TEST_TABLE = "multi_schema";
+        const testTable1 = "multi_schema";
+        const testTable2 = "many_data_types";
 
         const dbName = "Writable Postgres12";
         const schemaName = "Wild";
         const tableName = "Animals";
 
-        resetTestTable({ type: dialect, table: TEST_TABLE });
+        resetTestTable({ type: dialect, table: testTable1 });
+        resetTestTable({ type: dialect, table: testTable2 });
         restore(`${dialect}-writable`);
 
         cy.signInAsAdmin();


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/11958

Fixed with the new data picker. You can now select arbitrary tables with different schemas without your previous choice affecting another.