### PR TITLE
backported "Error on import into an empty appdb (#44840)"

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_db.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_db.clj
@@ -262,7 +262,8 @@
         (let [report (log/with-no-logs
                        (serialization.cmd/v2-load-internal! (str (instance-analytics-plugin-dir (plugins/plugins-dir)))
                                                             {:backfill? false}
-                                                            :token-check? false))]
+                                                            :token-check? false
+                                                            :require-initialized-db? false))]
           (if (not-empty (:errors report))
             (log/info (str "Error Loading Analytics Content: " (pr-str report)))
             (do

--- a/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
@@ -27,6 +27,7 @@
    [metabase.models.user :refer [User]]
    [metabase.plugins :as plugins]
    [metabase.public-settings.premium-features :as premium-features]
+   [metabase.setup :as setup]
    [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-trs trs]]
    [metabase.util.log :as log]
@@ -88,10 +89,14 @@
    opts :- [:map
             [:backfill? {:optional true} [:maybe :boolean]]]
    ;; Deliberately separate from the opts so it can't be set from the CLI.
-   & {:keys [token-check?]
-      :or   {token-check? true}}]
+   & {:keys [token-check?
+             require-initialized-db?]
+      :or   {token-check? true
+             require-initialized-db? true}}]
   (plugins/load-plugins!)
   (mdb/setup-db!)
+  (when (and require-initialized-db? (not (setup/has-user-setup)))
+    (throw (ex-info "You cannot `import` into an empty database. Please set up Metabase normally, then retry." {})))
   (when token-check?
     (check-premium-token!))
   ; TODO This should be restored, but there's no manifest or other meta file written by v2 dumps.


### PR DESCRIPTION
Backports #44840 

I was thinking about the potential options here.

On one hand, we could initialize the app db ourselves. This is a little problematic, because:

- our `init!` function is in `metabase.core` and calling it yields a painful cyclical dependency. It's also pretty tied to outputting things to the user that they might not expect during an import, e.g. "Looks like this is a new installation ... preparing setup wizard", and starts up jobs, etc.

- if we choose to *only* initialize the database ourselves (only the bits that we actually *need* initialized), I'm a little nervous about maybe missing something. Right now we need to create the internal user and create users from the config file before running the import. If we added a third thing, would we remember to update this?

- we could refactor to put all of the above in one spot, but this is a P1 and it feels important to close this out as quickly as possible. We also don't claim to support initializing the app DB from an import in the first place.

So: just throw an exception if the app db hasn't been set up yet. Our heuristic here is whether a single non-internal user has been created. So if you want to use your config, you can run:

```
MB_CONFIG_FILE_PATH=dev/config.yml java -jar metabase.jar
java -jar metabase.jar import /my/exported/dump
```

If you try to run `java -jar metabase.jar import ...` on a fresh DB, it'll now fail with the error message:

```
You cannot `import` into an empty database. Please set up Metabase
normally, then retry.
```