### PR TITLE
[49 Backport] Catch exceptions from driver/database-supports? outside driver code and Memoize driver.u/supports? (#44719) (#44804)

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -100,6 +100,7 @@
    malli.core/explainer                               {:message "Use metabase.util.malli.registry/explainer instead of malli.core/explainer"}
    me.flowthing.pp/pprint                             {:message "Use metabase.util.log instead of me.flowthing.pp/pprint"}
    medley.core/random-uuid                            {:message "Use clojure.core/random-uuid instead of medley.core/random-uuid"}
+   metabase.driver/database-supports?                 {:message "Use metabase.driver.util/supports? instead of metabase.driver/database-supports?"}
    metabase.lib.equality/find-column-indexes-for-refs {:message "Use lib.equality/closest-matches-in-metadata or lib.equality/find-closest-matches-for-refs instead of lib.equality/find-column-indexes-for-refs"}
    metabase.test/with-temp*                           {:message "Use mt/with-temp instead of mt/with-temp*"}
    toucan2.tools.with-temp                            {:message "Use mt/with-temp instead of t2.with-temp/with-temp"}}
@@ -635,7 +636,11 @@
   ;; `metabase.driver.*`, excluding `-test` namespaces.
   ;;
   {:pattern "metabase(?:(?:(?:-enterprise\\.sandbox)?\\.query-processor\\.)|(?:\\.driver\\.)).*(?<!-test)$"
-   :name    qp-and-driver-source-namespaces}]
+   :name    qp-and-driver-source-namespaces}
+
+  ;; driver namespaces
+  {:pattern "metabase\\.driver.*$"
+   :name    driver-namespaces}]
 
  :config-in-ns
  {test-namespaces
@@ -645,7 +650,8 @@
     :private-call                                        {:level :off}
     :metabase/defsetting-must-specify-export             {:level :off}
     :hooks.metabase.test.data/mbql-query-first-arg       {:level :error}
-    :metabase/test-helpers-use-non-thread-safe-functions {:level :warning}}
+    :metabase/test-helpers-use-non-thread-safe-functions {:level :warning}
+    :discouraged-var                                     {metabase.driver/database-supports? {:level :off}}}
    :hooks
    {:analyze-call
     {clojure.core/defmacro hooks.clojure.core/non-thread-safe-form-should-end-with-exclamation
@@ -690,6 +696,11 @@
      toucan.models    {:message "Don't use application database inside MLv2 code"}
      toucan.util.test {:message "Don't use application database inside MLv2 code"}
      toucan2.core     {:message "Don't use application database inside MLv2 code"}}}}
+
+  driver-namespaces
+  {:linters
+   {:discouraged-var
+    {metabase.driver/database-supports? {:level :off}}}}
 
   qp-and-driver-source-namespaces
   {:linters

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/driver/impersonation.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/driver/impersonation.clj
@@ -5,6 +5,7 @@
    [metabase.api.common :as api]
    [metabase.driver :as driver]
    [metabase.driver.sql :as driver.sql]
+   [metabase.driver.util :as driver.u]
    [metabase.models.field :as field]
    [metabase.models.permissions :as perms :refer [Permissions]]
    [metabase.models.permissions-group-membership
@@ -92,7 +93,7 @@
   support connection impersonation, or for non-EE instances."
   :feature :advanced-permissions
   [driver ^Connection conn database]
-  (when (driver/database-supports? driver :connection-impersonation database)
+  (when (driver.u/supports? driver :connection-impersonation database)
     (try
       (let [enabled?           (impersonation-enabled-for-db? database)
             default-role       (driver.sql/default-database-role driver database)

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
@@ -12,6 +12,7 @@
    [metabase.api.common :as api]
    [metabase.driver :as driver]
    [metabase.driver.sql.query-processor :as sql.qp]
+   [metabase.driver.util :as driver.u]
    [metabase.mbql.normalize :as mbql.normalize]
    [metabase.mbql.util :as mbql.u]
    [metabase.models :refer [Card Collection Field Table]]
@@ -81,7 +82,7 @@
 
 (defn- venues-category-native-gtap-def []
   (driver/with-driver (or driver/*driver* :h2)
-    (assert (driver/database-supports? driver/*driver* :native-parameters (mt/db)))
+    (assert (driver.u/supports? driver/*driver* :native-parameters (mt/db)))
     {:query (mt/native-query
               {:query
                (format-honeysql
@@ -98,7 +99,7 @@
 
 (defn- parameterized-sql-with-join-gtap-def []
   (driver/with-driver (or driver/*driver* :h2)
-    (assert (driver/database-supports? driver/*driver* :native-parameters (mt/db)))
+    (assert (driver.u/supports? driver/*driver* :native-parameters (mt/db)))
     {:query (mt/native-query
               {:query
                (format-honeysql

--- a/src/metabase/actions.clj
+++ b/src/metabase/actions.clj
@@ -6,6 +6,7 @@
    [malli.error :as me]
    [metabase.api.common :as api]
    [metabase.driver :as driver]
+   [metabase.driver.util :as driver.u]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.mbql.normalize :as mbql.normalize]
    [metabase.mbql.schema :as mbql.s]
@@ -121,7 +122,7 @@
 (defn check-actions-enabled-for-database!
   "Throws an appropriate error if actions are unsupported or disabled for a database, otherwise returns nil."
   [{db-settings :settings db-id :id driver :engine db-name :name :as db}]
-  (when-not (driver/database-supports? driver :actions db)
+  (when-not (driver.u/supports? driver :actions db)
     (throw (ex-info (i18n/tru "{0} Database {1} does not support actions."
                               (u/qualified-name driver)
                               (format "%d %s" db-id (pr-str db-name)))

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -10,7 +10,7 @@
    [metabase.api.common.validation :as validation]
    [metabase.api.dataset :as api.dataset]
    [metabase.api.field :as api.field]
-   [metabase.driver :as driver]
+   [metabase.driver.util :as driver.u]
    [metabase.events :as events]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
@@ -743,13 +743,11 @@
   (api/let-404 [{:keys [database_id] :as card} (t2/select-one Card :id card-id)]
     (let [database (t2/select-one Database :id database_id)]
       (api/write-check database)
-      (when-not (driver/database-supports? (:engine database)
-                                           :persist-models database)
+      (when-not (driver.u/supports? (:engine database) :persist-models database)
         (throw (ex-info (tru "Database does not support persisting")
                         {:status-code 400
                          :database    (:name database)})))
-      (when-not (driver/database-supports? (:engine database)
-                                           :persist-models-enabled database)
+      (when-not (driver.u/supports? (:engine database) :persist-models-enabled database)
         (throw (ex-info (tru "Persisting models not enabled for database")
                         {:status-code 400
                          :database    (:name database)})))

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -96,7 +96,7 @@
 (defn- card-database-supports-nested-queries? [{{database-id :database, :as database} :dataset_query, :as _card}]
   (when database-id
     (when-let [driver (driver.u/database->driver database-id)]
-      (driver/database-supports? driver :nested-queries database))))
+      (driver.u/supports? driver :nested-queries database))))
 
 (defn- card-has-ambiguous-columns?
   "We know a card has ambiguous columns if any of the columns that come back end in `_2` (etc.) because that's what
@@ -136,7 +136,7 @@
   (set (filter (fn [db-id]
                  (try
                    (when-let [db (t2/select-one Database :id db-id)]
-                     (driver/database-supports? (:engine db) :nested-queries db))
+                     (driver.u/supports? (:engine db) :nested-queries db))
                    (catch Throwable e
                      (log/error e (tru "Error determining whether Database supports nested queries")))))
                (t2/select-pks-set Database))))
@@ -231,7 +231,7 @@
 (defn- uploadable-db?
   "Are uploads supported for this database?"
   [db]
-  (driver/database-supports? (driver.u/database->driver db) :uploads db))
+  (driver.u/supports? (driver.u/database->driver db) :uploads db))
 
 (defn- add-can-upload-to-dbs
   "Add an entry to each DB about whether the user can upload to it."

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -6,7 +6,6 @@
    [medley.core :as m]
    [metabase.api.common :as api]
    [metabase.db.query :as mdb.query]
-   [metabase.driver :as driver]
    [metabase.driver.h2 :as h2]
    [metabase.driver.util :as driver.u]
    [metabase.events :as events]
@@ -272,7 +271,7 @@
   (dimension-index-for-type :type/Coordinate #(.contains ^String (str (:name %)) (str auto-bin-str))))
 
 (defn- supports-numeric-binning? [db]
-  (and db (driver/database-supports? (:engine db) :binning db)))
+  (and db (driver.u/supports? (:engine db) :binning db)))
 
 ;; TODO: Remove all this when the FE is fully ported to [[metabase.lib.binning/available-binning-strategies]].
 (defn- assoc-field-dimension-options [{:keys [base_type semantic_type fingerprint] :as field} db]

--- a/src/metabase/automagic_dashboards/combination.clj
+++ b/src/metabase/automagic_dashboards/combination.clj
@@ -25,7 +25,7 @@
     [metabase.automagic-dashboards.schema :as ads]
     [metabase.automagic-dashboards.util :as magic.util]
     [metabase.automagic-dashboards.visualization-macros :as visualization]
-    [metabase.driver :as driver]
+    [metabase.driver.util :as driver.u]
     [metabase.models.interface :as mi]
     [metabase.query-processor.util :as qp.util]
     [metabase.util :as u]
@@ -164,7 +164,7 @@
   [{:keys [base_type db fingerprint aggregation]}]
   (or (nil? aggregation)
       (not (isa? base_type :type/Number))
-      (and (driver/database-supports? (:engine db) :binning db)
+      (and (driver.u/supports? (:engine db) :binning db)
            (-> fingerprint :type :type/Number :min))))
 
 (defn- valid-bindings? [{:keys [root]} satisfied-dimensions bindings]

--- a/src/metabase/db/metadata_queries.clj
+++ b/src/metabase/db/metadata_queries.clj
@@ -175,7 +175,7 @@
   (let [database           (table/database table)
         driver             (driver.u/database->driver database)
         text-fields        (filter text-field? fields)
-        field->expressions (when (and truncation-size (driver/database-supports? driver :expressions database))
+        field->expressions (when (and truncation-size (driver.u/supports? driver :expressions database))
                              (into {} (for [field text-fields]
                                         [field [(str (gensym "substring"))
                                                 [:substring [:field (u/the-id field) nil]

--- a/src/metabase/driver/sql_jdbc/sync/describe_database.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_database.clj
@@ -133,7 +133,7 @@
   [driver conn]
   ;; `sql-jdbc.sync.interface/have-select-privilege?` is slow because we're doing a SELECT query on each table
   ;; It's basically a N+1 operation where N is the number of tables in the database
-  (if (driver/database-supports? driver :table-privileges nil)
+  (if (driver.u/supports? driver :table-privileges nil)
     (let [schema+table-with-select-privileges (schema+table-with-select-privileges driver conn)]
       (fn [{schema :schema table :name ttype :type}]
         ;; driver/current-user-table-privileges does not return privileges for external table on redshift, and foreign

--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -13,6 +13,7 @@
    [metabase.driver.sql-jdbc.sync.common :as sql-jdbc.sync.common]
    [metabase.driver.sql-jdbc.sync.interface :as sql-jdbc.sync.interface]
    [metabase.driver.sql.query-processor :as sql.qp]
+   [metabase.driver.util :as driver.u]
    [metabase.lib.schema.literal :as lib.schema.literal]
    [metabase.models :refer [Field]]
    [metabase.models.table :as table]
@@ -188,7 +189,7 @@
              :json-unfolding    json?}
             (when semantic-type
               {:semantic-type semantic-type})
-            (when (and json? (driver/database-supports? driver :nested-field-columns db))
+            (when (and json? (driver.u/supports? driver :nested-field-columns db))
               {:visibility-type :details-only}))))))
 
 (defn describe-table-fields-xf

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -214,18 +214,19 @@
    critical metabase features that use this check."
   5000)
 
-(defn supports?
-  "A defensive wrapper around [[database-supports?]]. It adds logging and error handling to avoid crashing the app if this
-   method takes a long time to execute or throws an exception. This is useful because `supports?` is used in so many critical
-   places in the app, and we don't want a single driver to crash the app if it throws an exception, or delay the user if it
-   takes a long time to execute."
-  [driver feature database]
-  (try
-    (u/with-timeout supports?-timeout-ms
-      (driver/database-supports? driver feature database))
-    (catch Throwable e
-      (log/error e (u/format-color 'red "Failed to check feature '%s' for database '%s'" (name feature) (:name database)))
-      false)))
+(def ^{:arglists '([driver feature database])} supports?
+  "A defensive wrapper around [[database-supports?]]. It adds logging, caching, and error handling to avoid crashing the app
+   if this method takes a long time to execute or throws an exception. This is useful because `supports?` is used in so many
+   critical places in the app, and we don't want a single driver to crash the app if it throws an exception, or delay the user
+   if it takes a long time to execute."
+  (mdb.connection/memoize-for-application-db ; memoize because this can be called in a tight loop, and will only change if the database changes versions
+   (fn [driver feature database]
+     (try
+       (u/with-timeout supports?-timeout-ms
+         (driver/database-supports? driver feature database))
+       (catch Throwable e
+         (log/error e (u/format-color 'red "Failed to check feature '%s' for database '%s'" (name feature) (:name database)))
+         false)))))
 
 (defn features
   "Return a set of all features supported by `driver` with respect to `database`."

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -208,11 +208,30 @@
 ;;; |                                             Available Drivers Info                                             |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
+(def supports?-timeout-ms
+  "The maximum time in milliseconds that [[supports?]] should take to execute. This should be enough for a driver to
+   query the database and check if it supports a feature under normal circumstances, but not so high that it delays
+   critical metabase features that use this check."
+  5000)
+
+(defn supports?
+  "A defensive wrapper around [[database-supports?]]. It adds logging and error handling to avoid crashing the app if this
+   method takes a long time to execute or throws an exception. This is useful because `supports?` is used in so many critical
+   places in the app, and we don't want a single driver to crash the app if it throws an exception, or delay the user if it
+   takes a long time to execute."
+  [driver feature database]
+  (try
+    (u/with-timeout supports?-timeout-ms
+      (driver/database-supports? driver feature database))
+    (catch Throwable e
+      (log/error e (u/format-color 'red "Failed to check feature '%s' for database '%s'" (name feature) (:name database)))
+      false)))
+
 (defn features
   "Return a set of all features supported by `driver` with respect to `database`."
   [driver database]
   (set (for [feature driver/driver-features
-             :when (driver/database-supports? driver feature database)]
+             :when (supports? driver feature database)]
          feature)))
 
 (defn available-drivers

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -214,19 +214,31 @@
    critical metabase features that use this check."
   5000)
 
-(def ^{:arglists '([driver feature database])} supports?
+(def ^:dynamic *memoize-supports?*
+  "If true, [[supports?]] is memoized for the application DB. Memoization is disabled in dev and test mode by default to avoid
+   accidental coupling between tests."
+  (not (or config/is-test? config/is-dev?)))
+
+(def ^:private supports?*
+  (fn [driver feature database]
+    (try
+      (u/with-timeout supports?-timeout-ms
+        (driver/database-supports? driver feature database))
+      (catch Throwable e
+        (log/error e (u/format-color 'red "Failed to check feature '%s' for database '%s'" (name feature) (:name database)))
+        false))))
+
+(def ^:private memoized-supports?*
+  (mdb.connection/memoize-for-application-db supports?*))
+
+(defn supports?
   "A defensive wrapper around [[database-supports?]]. It adds logging, caching, and error handling to avoid crashing the app
    if this method takes a long time to execute or throws an exception. This is useful because `supports?` is used in so many
    critical places in the app, and we don't want a single driver to crash the app if it throws an exception, or delay the user
    if it takes a long time to execute."
-  (mdb.connection/memoize-for-application-db ; memoize because this can be called in a tight loop, and will only change if the database changes versions
-   (fn [driver feature database]
-     (try
-       (u/with-timeout supports?-timeout-ms
-         (driver/database-supports? driver feature database))
-       (catch Throwable e
-         (log/error e (u/format-color 'red "Failed to check feature '%s' for database '%s'" (name feature) (:name database)))
-         false)))))
+  [driver feature database]
+  (let [f (if *memoize-supports?* memoized-supports?* supports?*)]
+    (f driver feature database)))
 
 (defn features
   "Return a set of all features supported by `driver` with respect to `database`."

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -242,7 +242,7 @@
       (u/prog1 (cond-> database
                  ;; If the engine doesn't support nested field columns, `json_unfolding` must be nil
                  (and (some? (:details changes))
-                      (not (driver/database-supports? (or new-engine existing-engine) :nested-field-columns database)))
+                      (not (driver.u/supports? (or new-engine existing-engine) :nested-field-columns database)))
                  (update :details dissoc :json_unfolding)
 
                  (or
@@ -259,7 +259,7 @@
         ;; This maintains a constraint that if a driver doesn't support actions, it can never be enabled
         ;; If we drop support for actions for a driver, we'd need to add a migration to disable actions for all databases
         (when (and (:database-enable-actions (or new-settings existing-settings))
-                   (not (driver/database-supports? (or new-engine existing-engine) :actions database)))
+                   (not (driver.u/supports? (or new-engine existing-engine) :actions database)))
           (throw (ex-info (trs "The database does not support actions.")
                           {:status-code     400
                            :existing-engine existing-engine

--- a/src/metabase/query_processor/middleware/add_implicit_joins.clj
+++ b/src/metabase/query_processor/middleware/add_implicit_joins.clj
@@ -7,6 +7,7 @@
    [clojure.walk :as walk]
    [medley.core :as m]
    [metabase.driver :as driver]
+   [metabase.driver.util :as driver.u]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.lib.schema.common :as lib.schema.common]
@@ -290,7 +291,7 @@
   [query]
   (if (mbql.u/match-one (:query query) [:field _ (_ :guard (every-pred :source-field (complement :join-alias)))])
     (do
-      (when-not (driver/database-supports? driver/*driver* :foreign-keys (lib.metadata/database (qp.store/metadata-provider)))
+      (when-not (driver.u/supports? driver/*driver* :foreign-keys (lib.metadata/database (qp.store/metadata-provider)))
         (throw (ex-info (tru "{0} driver does not support foreign keys." driver/*driver*)
                         {:driver driver/*driver*
                          :type   qp.error-type/unsupported-feature})))

--- a/src/metabase/query_processor/middleware/check_features.clj
+++ b/src/metabase/query_processor/middleware/check_features.clj
@@ -1,6 +1,7 @@
 (ns metabase.query-processor.middleware.check-features
   (:require
    [metabase.driver :as driver]
+   [metabase.driver.util :as driver.u]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.mbql.schema :as mbql.s]
    [metabase.mbql.util :as mbql.u]
@@ -12,7 +13,7 @@
 (defn assert-driver-supports
   "Assert that the driver/database supports keyword `feature`."
   [feature]
-  (when-not (driver/database-supports? driver/*driver* feature (lib.metadata/database (qp.store/metadata-provider)))
+  (when-not (driver.u/supports? driver/*driver* feature (lib.metadata/database (qp.store/metadata-provider)))
     (throw (ex-info (tru "{0} is not supported by this driver." (name feature))
                     {:type    qp.error-type/unsupported-feature
                      :feature feature}))))

--- a/src/metabase/query_processor/middleware/parameters/native.clj
+++ b/src/metabase/query_processor/middleware/parameters/native.clj
@@ -27,6 +27,7 @@
   (:require
    [clojure.set :as set]
    [metabase.driver :as driver]
+   [metabase.driver.util :as driver.u]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.query-processor.store :as qp.store]))
 
@@ -34,7 +35,7 @@
   "Expand parameters inside an *inner* native `query`. Not recursive -- recursive transformations are handled in
   the `middleware.parameters` functions that invoke this function."
   [inner-query]
-  (if-not (driver/database-supports? driver/*driver* :native-parameters (lib.metadata/database (qp.store/metadata-provider)))
+  (if-not (driver.u/supports? driver/*driver* :native-parameters (lib.metadata/database (qp.store/metadata-provider)))
     inner-query
     ;; Totally ridiculous, but top-level native queries use the key `:query` for SQL or equivalent, while native
     ;; source queries use `:native`. So we need to handle either case.

--- a/src/metabase/query_processor/middleware/results_metadata.clj
+++ b/src/metabase/query_processor/middleware/results_metadata.clj
@@ -4,6 +4,7 @@
    as a checksum in the API response."
   (:require
    [metabase.driver :as driver]
+   [metabase.driver.util :as driver.u]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.query-processor.reducible :as qp.reducible]
    [metabase.query-processor.store :as qp.store]
@@ -30,7 +31,7 @@
     ;; if its DB doesn't support nested queries in the first place
     (when (and metadata
                driver/*driver*
-               (driver/database-supports? driver/*driver* :nested-queries (lib.metadata/database (qp.store/metadata-provider)))
+               (driver.u/supports? driver/*driver* :nested-queries (lib.metadata/database (qp.store/metadata-provider)))
                card-id
                (not source-card-id))
       (t2/update! :model/Card card-id {:result_metadata metadata}))

--- a/src/metabase/query_processor/timezone.clj
+++ b/src/metabase/query_processor/timezone.clj
@@ -4,6 +4,7 @@
    [java-time.api :as t]
    [metabase.config :as config]
    [metabase.driver :as driver]
+   [metabase.driver.util :as driver.u]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.query-processor.store :as qp.store]
    [metabase.util.i18n :refer [tru]]
@@ -46,7 +47,7 @@
    (report-timezone-id-if-supported driver/*driver* (lib.metadata/database (qp.store/metadata-provider))))
 
   (^String [driver database]
-   (when (driver/database-supports? driver :set-timezone database)
+   (when (driver.u/supports? driver :set-timezone database)
      (valid-timezone-id (report-timezone-id*)))))
 
 (defn database-timezone-id

--- a/src/metabase/sync/fetch_metadata.clj
+++ b/src/metabase/sync/fetch_metadata.clj
@@ -27,7 +27,7 @@
   "Get more detailed information about a `table` belonging to `database`. Includes information about the Fields."
   [database :- i/DatabaseInstance
    table    :- i/TableInstance]
-  (if (driver/database-supports? (driver.u/database->driver database) :describe-fields database)
+  (if (driver.u/supports? (driver.u/database->driver database) :describe-fields database)
     (set (fields-metadata database :table-names [(:name table)] :schema-names [(:schema table)]))
     (:fields (driver/describe-table (driver.u/database->driver database) database table))))
 
@@ -44,8 +44,8 @@
   [database :- i/DatabaseInstance
    table    :- i/TableInstance]
   (let [driver (driver.u/database->driver database)]
-    (when (driver/database-supports? driver :foreign-keys database)
-      (if (driver/database-supports? driver :describe-fks database)
+    (when (driver.u/supports? driver :foreign-keys database)
+      (if (driver.u/supports? driver :describe-fks database)
         (vec (driver/describe-fks driver database :table-names [(:name table)] :schema-names [(:schema table)]))
         #_{:clj-kondo/ignore [:deprecated-var]}
         (vec (for [x (driver/describe-table-fks driver database table)]
@@ -61,7 +61,7 @@
   [database :- i/DatabaseInstance
    table    :- i/TableInstance]
   (let [driver (driver.u/database->driver database)]
-    (when (driver/database-supports? driver :nested-field-columns database)
+    (when (driver.u/supports? driver :nested-field-columns database)
       (sql-jdbc.sync/describe-nested-field-columns driver database table))))
 
 (mu/defn index-metadata :- [:maybe i/TableIndexMetadata]

--- a/src/metabase/sync/sync_metadata/fields.clj
+++ b/src/metabase/sync/sync_metadata/fields.clj
@@ -39,7 +39,6 @@
   * In general the methods in these namespaces return the number of rows updated; these numbers are summed and used
     for logging purposes by higher-level sync logic."
   (:require
-   [metabase.driver :as driver]
    [metabase.driver.util :as driver.u]
    [metabase.models.table :as table]
    [metabase.sync.fetch-metadata :as fetch-metadata]
@@ -114,7 +113,7 @@
                            [:total-fields   ms/IntGreaterThanOrEqualToZero]]]
   "Sync the Fields in the Metabase application database for all the Tables in a `database`."
   [database :- i/DatabaseInstance]
-  (if (driver/database-supports? (driver.u/database->driver database) :describe-fields database)
+  (if (driver.u/supports? (driver.u/database->driver database) :describe-fields database)
     (sync-fields-for-db! database)
     (->> (sync-util/db->sync-tables database)
          (map (partial sync-fields-for-table! database))

--- a/src/metabase/sync/sync_metadata/fields/our_metadata.clj
+++ b/src/metabase/sync/sync_metadata/fields/our_metadata.clj
@@ -6,7 +6,7 @@
   (:require
    [clojure.set :as set]
    [medley.core :as m]
-   [metabase.driver :as driver]
+   [metabase.driver.util :as driver.u]
    [metabase.models.table :as table]
    [metabase.sync.fetch-metadata :as fetch-metadata]
    [metabase.sync.interface :as i]
@@ -93,5 +93,5 @@
   [database :- i/DatabaseInstance
    table    :- i/TableInstance]
     (cond-> (fetch-metadata/table-fields-metadata database table)
-      (driver/database-supports? (:engine database) :nested-field-columns database)
+      (driver.u/supports? (:engine database) :nested-field-columns database)
       (set/union (fetch-metadata/nfc-metadata database table))))

--- a/src/metabase/sync/sync_metadata/fks.clj
+++ b/src/metabase/sync/sync_metadata/fks.clj
@@ -3,7 +3,6 @@
   (:require
    [honey.sql :as sql]
    [metabase.db.connection :as mdb.connection]
-   [metabase.driver :as driver]
    [metabase.driver.util :as driver.u]
    [metabase.models.table :as table]
    [metabase.sync.fetch-metadata :as fetch-metadata]
@@ -134,7 +133,7 @@
 
   This function also sets all the tables that should be synced to have `initial-sync-status=complete` once the sync is done."
   [database :- i/DatabaseInstance]
-  (u/prog1 (if (driver/database-supports? (driver.u/database->driver database) :describe-fks database)
+  (u/prog1 (if (driver.u/supports? (driver.u/database->driver database) :describe-fks database)
              (sync-fks-for-db! database)
              (reduce (fn [update-info table]
                        (let [table         (t2.realize/realize table)

--- a/src/metabase/sync/sync_metadata/indexes.clj
+++ b/src/metabase/sync/sync_metadata/indexes.clj
@@ -1,7 +1,6 @@
 (ns metabase.sync.sync-metadata.indexes
   (:require
    [clojure.data :as data]
-   [metabase.driver :as driver]
    [metabase.driver.util :as driver.u]
    [metabase.models.field :as field]
    [metabase.sync.fetch-metadata :as fetch-metadata]
@@ -27,7 +26,7 @@
 (defn maybe-sync-indexes-for-table!
   "Sync the indexes for `table` if the driver supports storing index info."
   [database table]
-  (if (driver/database-supports? (driver.u/database->driver database) :index-info database)
+  (if (driver.u/supports? (driver.u/database->driver database) :index-info database)
     (sync-util/with-error-handling (format "Error syncing Indexes for %s" (sync-util/name-for-logging table))
       (let [indexes                    (fetch-metadata/index-metadata database table)
             indexed-field-ids          (indexes->field-ids (:id table) indexes)
@@ -51,7 +50,7 @@
 (defn maybe-sync-indexes!
   "Sync the indexes for all tables in `database` if the driver supports storing index info."
   [database]
-  (if (driver/database-supports? (driver.u/database->driver database) :index-info database)
+  (if (driver.u/supports? (driver.u/database->driver database) :index-info database)
     (apply merge-with + empty-stats
            (map #(maybe-sync-indexes-for-table! database %) (sync-util/db->sync-tables database)))
     empty-stats))

--- a/src/metabase/sync/sync_metadata/sync_table_privileges.clj
+++ b/src/metabase/sync/sync_metadata/sync_table_privileges.clj
@@ -17,7 +17,7 @@
     (when (and (not= :redshift driver)
                ;; redshift does support table-privileges, but we don't want to sync it now because table privileges are
                ;; meant to enhance action features, but redshift does not support actions for now, so we skip it here.
-               (driver/database-supports? driver :table-privileges database))
+               (driver.u/supports? driver :table-privileges database))
       (let [rows               (driver/current-user-table-privileges driver database)
             schema+table->id   (t2/select-fn->pk (fn [t] {:schema (:schema t), :table (:name t)}) :model/Table :db_id (:id database))
             rows-with-table-id (keep (fn [row]

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -410,7 +410,7 @@
   (merge (ordered-map/ordered-map auto-pk-column-keyword ::auto-incrementing-int-pk) columns))
 
 (defn- create-auto-pk-column? [driver db]
-  (driver/database-supports? driver :upload-with-auto-pk db))
+  (driver.u/supports? driver :upload-with-auto-pk db))
 
 (defn- load-from-csv!
   "Loads a table from a CSV file. If the table already exists, it will throw an error.
@@ -476,7 +476,7 @@
       (ex-info (tru "Uploads are not permitted for sandboxed users.")
                {:status-code 403})
 
-      (not (driver/database-supports? driver :uploads db))
+      (not (driver.u/supports? driver :uploads db))
       (ex-info (tru "Uploads are not supported on {0} databases." (str/capitalize (name driver)))
                {:status-code 422}))))
 
@@ -486,7 +486,7 @@
   (or (can-use-uploads-error db)
       (cond
         (and (str/blank? schema-name)
-             (driver/database-supports? (driver.u/database->driver db) :schemas db))
+             (driver.u/supports? (driver.u/database->driver db) :schemas db))
         (ex-info (tru "A schema has not been set.")
                  {:status-code 422})
         (not (perms/set-has-full-permissions? @api/*current-user-permissions-set*

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -1026,7 +1026,7 @@
 (deftest databases-list-include-saved-questions-tables-test-6
   (testing "GET /api/database?saved=true&include=tables"
     (testing "should work when there are no DBs that support nested queries"
-      (with-redefs [driver/database-supports? (constantly false)]
+      (with-redefs [driver.u/supports? (constantly false)]
         (is (nil? (fetch-virtual-database)))))))
 
 (deftest databases-list-include-saved-questions-tables-test-7

--- a/test/metabase/db/metadata_queries_test.clj
+++ b/test/metabase/db/metadata_queries_test.clj
@@ -2,7 +2,6 @@
   (:require
    [clojure.test :refer :all]
    [metabase.db.metadata-queries :as metadata-queries]
-   [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.test-util :as sql-jdbc.tu]
    [metabase.driver.util :as driver.u]
    [metabase.models :as models :refer [Database Field Table]]
@@ -60,17 +59,17 @@
       (let [table  (mi/instance Table {:id 1234})
             fields [(mi/instance Field {:id 4321 :base_type :type/Text})]]
         (testing "uses substrings if driver supports expressions"
-          (with-redefs [driver/database-supports? (constantly true)]
+          (with-redefs [driver.u/supports? (constantly true)]
             (let [query (#'metadata-queries/table-rows-sample-query table fields {:truncation-size 4})]
               (is (seq (get-in query [:query :expressions]))))))
         (testing "doesnt' use substrings if driver doesn't support expressions"
-          (with-redefs [driver/database-supports? (constantly false)]
+          (with-redefs [driver.u/supports? (constantly false)]
             (let [query (#'metadata-queries/table-rows-sample-query table fields {:truncation-size 4})]
               (is (empty? (get-in query [:query :expressions])))))))
       (testing "pre-existing json fields are still marked as `:type/Text`"
         (let [table (mi/instance Table {:id 1234})
               fields [(mi/instance Field {:id 4321, :base_type :type/Text, :semantic_type :type/SerializedJSON})]]
-          (with-redefs [driver/database-supports? (constantly true)]
+          (with-redefs [driver.u/supports? (constantly true)]
             (let [query (#'metadata-queries/table-rows-sample-query table fields {:truncation-size 4})]
               (is (empty? (get-in query [:query :expressions]))))))))))
 

--- a/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
+++ b/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
@@ -32,9 +32,9 @@
    (filter
     (fn [driver]
       (let [uses-default-describe-table? (and (identical? (get-method driver/describe-table :sql-jdbc) (get-method driver/describe-table driver))
-                                              (not (driver/database-supports? driver :describe-fields nil)))
+                                              (not (driver.u/supports? driver :describe-fields nil)))
             uses-default-describe-fields? (and (identical? (get-method driver/describe-fields :sql-jdbc) (get-method driver/describe-fields driver))
-                                               (driver/database-supports? driver :describe-fields nil))]
+                                               (driver.u/supports? driver :describe-fields nil))]
         (or uses-default-describe-table?
             uses-default-describe-fields?)))
     (descendants driver/hierarchy :sql-jdbc))))
@@ -42,7 +42,7 @@
 (deftest ^:parallel describe-fields-nested-field-columns-test
   (testing (str "Drivers that support describe-fields should not support the nested field columns feature."
                 "It is possible to support both in the future but this has not been implemented yet.")
-    (is (empty? (filter #(driver/database-supports? % :describe-fields nil)
+    (is (empty? (filter #(driver.u/supports? % :describe-fields nil)
                         (mt/normal-drivers-with-feature :nested-field-columns))))))
 
 (deftest ^:parallel describe-table-test
@@ -95,7 +95,7 @@
 (defn- describe-fields-for-table [db table]
   (let [driver (driver.u/database->driver db)]
     (sort-by :database-position
-             (if (driver/database-supports? driver :describe-fields db)
+             (if (driver.u/supports? driver :describe-fields db)
                (vec (sql-jdbc.describe-table/describe-fields driver db
                                                              :schema-names [(:schema table)]
                                                              :table-names [(:name table)]))

--- a/test/metabase/driver/util_test.clj
+++ b/test/metabase/driver/util_test.clj
@@ -3,6 +3,7 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [metabase.driver :as driver]
    [metabase.driver.h2 :as h2]
    [metabase.driver.util :as driver.u]
    [metabase.lib.test-metadata :as meta]
@@ -10,7 +11,8 @@
    [metabase.public-settings.premium-features :as premium-features]
    [metabase.query-processor.store :as qp.store]
    [metabase.test :as mt]
-   [metabase.test.fixtures :as fixtures])
+   [metabase.test.fixtures :as fixtures]
+   [metabase.util :as u])
   (:import
    (java.nio.charset StandardCharsets)
    (java.util Base64)
@@ -278,8 +280,30 @@
    (is (=? {:driver-name "H2", :superseded-by :deprecated}
            (:h2 (driver.u/available-drivers-info))))))
 
-(deftest ^:paralell database-id->driver-use-qp-store-test
+(deftest ^:parallel database-id->driver-use-qp-store-test
   (qp.store/with-metadata-provider (lib.tu/mock-metadata-provider
                                     {:database (assoc meta/database :id Integer/MAX_VALUE, :engine :wow)})
     (is (= :wow
            (driver.u/database->driver Integer/MAX_VALUE)))))
+
+(deftest supports?-failure-test
+  (let [fake-test-db (mt/db)]
+    (testing "supports? returns false when `driver/database-supports?` throws an exception"
+      (with-redefs [driver/database-supports? (fn [_ _ _] (throw (Exception. "test exception message")))]
+        (let [log-messages (mt/with-log-messages-for-level [metabase.driver.util :error]
+                             (is (false? (driver.u/supports? :test-driver :test-feature fake-test-db))))]
+          (is (some (fn [[level ^Throwable exception message]]
+                      (and (= level :error)
+                           (= (.getMessage exception) "test exception message")
+                           (= message (u/format-color 'red "Failed to check feature 'test-feature' for database 'test-data'"))))
+                    log-messages)))))
+    (testing "supports? returns false when `driver/database-supports?` takes longer than the timeout"
+      (with-redefs [driver.u/supports?-timeout-ms 100
+                    driver/database-supports?     (fn [_ _ _] (Thread/sleep 200) true)]
+        (let [log-messages (mt/with-log-messages-for-level [metabase.driver.util :error]
+                             (is (false? (driver.u/supports? :test-driver :test-feature fake-test-db))))]
+          (is (some (fn [[level ^Throwable exception message]]
+                      (and (= level :error)
+                           (= (.getMessage exception) "Timed out after 100.0 ms")
+                           (= message (u/format-color 'red "Failed to check feature 'test-feature' for database 'test-data'"))))
+                    log-messages)))))))

--- a/test/metabase/driver/util_test.clj
+++ b/test/metabase/driver/util_test.clj
@@ -290,20 +290,26 @@
   (let [fake-test-db (mt/db)]
     (testing "supports? returns false when `driver/database-supports?` throws an exception"
       (with-redefs [driver/database-supports? (fn [_ _ _] (throw (Exception. "test exception message")))]
-        (let [log-messages (mt/with-log-messages-for-level [metabase.driver.util :error]
-                             (is (false? (driver.u/supports? :test-driver :test-feature fake-test-db))))]
+        (let [db           (assoc fake-test-db :name (mt/random-name))
+              log-messages (mt/with-log-messages-for-level [metabase.driver.util :error]
+                             (is (false? (driver.u/supports? :test-driver :test-feature db))))]
           (is (some (fn [[level ^Throwable exception message]]
                       (and (= level :error)
                            (= (.getMessage exception) "test exception message")
-                           (= message (u/format-color 'red "Failed to check feature 'test-feature' for database 'test-data'"))))
+                           (= message (u/format-color 'red "Failed to check feature 'test-feature' for database '%s'" (:name db)))))
                     log-messages)))))
     (testing "supports? returns false when `driver/database-supports?` takes longer than the timeout"
-      (with-redefs [driver.u/supports?-timeout-ms 100
-                    driver/database-supports?     (fn [_ _ _] (Thread/sleep 200) true)]
-        (let [log-messages (mt/with-log-messages-for-level [metabase.driver.util :error]
-                             (is (false? (driver.u/supports? :test-driver :test-feature fake-test-db))))]
-          (is (some (fn [[level ^Throwable exception message]]
-                      (and (= level :error)
-                           (= (.getMessage exception) "Timed out after 100.0 ms")
-                           (= message (u/format-color 'red "Failed to check feature 'test-feature' for database 'test-data'"))))
-                    log-messages)))))))
+      (let [db (assoc fake-test-db :name (mt/random-name))]
+        (with-redefs [driver.u/supports?-timeout-ms 100
+                      driver/database-supports?     (fn [_ _ _] (Thread/sleep 200) true)]
+          (let [log-messages (mt/with-log-messages-for-level [metabase.driver.util :error]
+                               (is (false? (driver.u/supports? :test-driver :test-feature db))))]
+            (is (some (fn [[level ^Throwable exception message]]
+                        (and (= level :error)
+                             (= (.getMessage exception) "Timed out after 100.0 ms")
+                             (= message (u/format-color 'red "Failed to check feature 'test-feature' for database '%s'" (:name db)))))
+                      log-messages))))
+        (testing "we memoize the results for the same database, so we don't log the error again"
+          (let [log-messages (mt/with-log-messages-for-level [metabase.driver.util :error]
+                               (is (false? (driver.u/supports? :test-driver :test-feature db))))]
+            (is (nil? log-messages))))))))

--- a/test/metabase/driver/util_test.clj
+++ b/test/metabase/driver/util_test.clj
@@ -292,24 +292,25 @@
       (with-redefs [driver/database-supports? (fn [_ _ _] (throw (Exception. "test exception message")))]
         (let [db           (assoc fake-test-db :name (mt/random-name))
               log-messages (mt/with-log-messages-for-level [metabase.driver.util :error]
-                             (is (false? (driver.u/supports? :test-driver :test-feature db))))]
+                             (is (false? (driver.u/supports? :test-driver :expressions db))))]
           (is (some (fn [[level ^Throwable exception message]]
                       (and (= level :error)
                            (= (.getMessage exception) "test exception message")
-                           (= message (u/format-color 'red "Failed to check feature 'test-feature' for database '%s'" (:name db)))))
+                           (= message (u/format-color 'red "Failed to check feature 'expressions' for database '%s'" (:name db)))))
                     log-messages)))))
-    (testing "supports? returns false when `driver/database-supports?` takes longer than the timeout"
-      (let [db (assoc fake-test-db :name (mt/random-name))]
-        (with-redefs [driver.u/supports?-timeout-ms 100
-                      driver/database-supports?     (fn [_ _ _] (Thread/sleep 200) true)]
-          (let [log-messages (mt/with-log-messages-for-level [metabase.driver.util :error]
-                               (is (false? (driver.u/supports? :test-driver :test-feature db))))]
-            (is (some (fn [[level ^Throwable exception message]]
-                        (and (= level :error)
-                             (= (.getMessage exception) "Timed out after 100.0 ms")
-                             (= message (u/format-color 'red "Failed to check feature 'test-feature' for database '%s'" (:name db)))))
-                      log-messages))))
-        (testing "we memoize the results for the same database, so we don't log the error again"
-          (let [log-messages (mt/with-log-messages-for-level [metabase.driver.util :error]
-                               (is (false? (driver.u/supports? :test-driver :test-feature db))))]
-            (is (nil? log-messages))))))))
+    (binding [driver.u/*memoize-supports?* true]
+      (testing "supports? returns false when `driver/database-supports?` takes longer than the timeout"
+        (let [db (assoc fake-test-db :name (mt/random-name))]
+          (with-redefs [driver.u/supports?-timeout-ms 100
+                        driver/database-supports? (fn [_ _ _] (Thread/sleep 200) true)]
+            (let [log-messages (mt/with-log-messages-for-level [metabase.driver.util :error]
+                                 (is (false? (driver.u/supports? :test-driver :expressions db))))]
+              (is (some (fn [[level ^Throwable exception message]]
+                          (and (= level :error)
+                               (= (.getMessage exception) "Timed out after 100.0 ms")
+                               (= message (u/format-color 'red "Failed to check feature 'expressions' for database '%s'" (:name db)))))
+                        log-messages))))
+          (testing "we memoize the results for the same database, so we don't log the error again"
+            (let [log-messages (mt/with-log-messages-for-level [metabase.driver.util :error]
+                                 (is (false? (driver.u/supports? :test-driver :expressions db))))]
+              (is (nil? log-messages)))))))))

--- a/test/metabase/models/database_test.clj
+++ b/test/metabase/models/database_test.clj
@@ -325,6 +325,6 @@
   ;; when it should return true.
   (testing "Make sure selecting a database calls `driver/database-supports?` with a database instance"
     (mt/with-temp [Database {db-id :id} {:engine (u/qualified-name ::test)}]
-      (mt/with-dynamic-redefs [driver/database-supports? (fn [_ _ db]
-                                                           (is (true? (mi/instance-of? :model/Database db))))]
+      (mt/with-dynamic-redefs [driver.u/supports? (fn [_ _ db]
+                                                    (is (true? (mi/instance-of? :model/Database db))))]
         (is (some? (t2/select-one-fn :features Database :id db-id)))))))

--- a/test/metabase/models/database_test.clj
+++ b/test/metabase/models/database_test.clj
@@ -99,7 +99,7 @@
   (mt/test-drivers #{:sqlite}
     (testing "Updating database-enable-actions to true should fail if the engine doesn't support actions"
       (t2.with-temp/with-temp [Database database {:engine :sqlite}]
-        (is (= false (driver/database-supports? :sqlite :actions database)))
+        (is (= false (driver.u/supports? :sqlite :actions database)))
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
              #"The database does not support actions."

--- a/test/metabase/models/model_index_test.clj
+++ b/test/metabase/models/model_index_test.clj
@@ -6,7 +6,7 @@
    [clojurewerkz.quartzite.scheduler :as qs]
    [malli.core :as mc]
    [malli.error :as me]
-   [metabase.driver :as driver]
+   [metabase.driver.util :as driver.u]
    [metabase.models.card :refer [Card]]
    [metabase.models.model-index :as model-index :refer [ModelIndex
                                                         ModelIndexValue]]
@@ -185,7 +185,7 @@
                        [:native (mt/native-query
                                  (qp/compile
                                   (mt/mbql-query products {:fields [$id $title]})))]
-                       (when (driver/database-supports? (:engine (mt/db)) :left-join (mt/db))
+                       (when (driver.u/supports? (:engine (mt/db)) :left-join (mt/db))
                          [:join (mt/$ids
                                  {:type     :query,
                                   :query    {:source-table $$people,

--- a/test/metabase/query_processor/middleware/parameters/mbql_test.clj
+++ b/test/metabase/query_processor/middleware/parameters/mbql_test.clj
@@ -4,6 +4,7 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.driver :as driver]
+   [metabase.driver.util :as driver.u]
    [metabase.mbql.normalize :as mbql.normalize]
    [metabase.query-processor :as qp]
    [metabase.query-processor.middleware.parameters.mbql :as qp.mbql]
@@ -300,7 +301,7 @@
 (deftest ^:parallel handle-fk-forms-test
   (mt/test-drivers (params-test-drivers)
     (qp.store/with-metadata-provider (mt/id)
-      (when (driver/database-supports? driver/*driver* :foreign-keys (mt/db))
+      (when (driver.u/supports? driver/*driver* :foreign-keys (mt/db))
         (testing "Make sure we properly handle paramters that have `fk->` forms in `:dimension` targets (#9017)"
           (is (= [[31 "Bludso's BBQ" 5 33.8894 -118.207 2]
                   [32 "Boneyard Bistro" 5 34.1477 -118.428 3]

--- a/test/metabase/query_processor/test_util.clj
+++ b/test/metabase/query_processor/test_util.clj
@@ -14,6 +14,7 @@
    [metabase.db.connection :as mdb.connection]
    [metabase.driver :as driver]
    [metabase.driver.test-util :as driver.tu]
+   [metabase.driver.util :as driver.u]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.jvm :as lib.metadata.jvm]
    [metabase.lib.test-util :as lib.tu]
@@ -58,7 +59,7 @@
                :let   [driver (tx/the-driver-with-test-extensions driver)]
                :when  (driver/with-driver driver
                         (let [db (data/db)]
-                          (every? #(driver/database-supports? driver % db) features)))]
+                          (every? #(driver.u/supports? driver % db) features)))]
            driver))))
 
 (alter-meta! #'normal-drivers-with-feature assoc :arglists (list (into ['&] (sort driver/driver-features))))
@@ -353,7 +354,7 @@
 (defn supports-report-timezone?
   "Returns truthy if `driver` supports setting a timezone"
   [driver]
-  (driver/database-supports? driver :set-timezone (data/db)))
+  (driver.u/supports? driver :set-timezone (data/db)))
 
 (defn cols
   "Return the result `:cols` from query `results`, or throw an Exception if they're missing."

--- a/test/metabase/query_processor_test/advanced_math_test.clj
+++ b/test/metabase/query_processor_test/advanced_math_test.clj
@@ -81,7 +81,7 @@
                (ffirst
                 (mt/formatted-rows [1.0]
                   (mt/process-query query))))))))
-  (when (driver/database-supports? driver/*driver* :expression-aggregations (mt/db))
+  (when (driver.u/supports? driver/*driver* :expression-aggregations (mt/db))
     (testing "Inside an expression aggregation"
       (let [query (mt/mbql-query venues
                     {:aggregation [[:+ agg 1]]})]

--- a/test/metabase/query_processor_test/date_bucketing_test.clj
+++ b/test/metabase/query_processor_test/date_bucketing_test.clj
@@ -23,6 +23,7 @@
    [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.driver.sql.query-processor-test-util :as sql.qp-test-util]
+   [metabase.driver.util :as driver.u]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
@@ -80,7 +81,7 @@
                                       [id (u.date/format-sql (t/local-date-time (u.date/parse s))) cnt])
 
                                     (or (= timezone :utc)
-                                        (not (driver/database-supports? driver/*driver* :set-timezone (mt/db))))
+                                        (not (driver.u/supports? driver/*driver* :set-timezone (mt/db))))
                                     utc-results
 
                                     :else

--- a/test/metabase/query_processor_test/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor_test/date_time_zone_functions_test.clj
@@ -4,6 +4,7 @@
    [clojure.test :refer :all]
    [java-time.api :as t]
    [metabase.driver :as driver]
+   [metabase.driver.util :as driver.u]
    [metabase.models :refer [Card]]
    [metabase.query-processor :as qp]
    [metabase.query-processor.test-util :as qp.test-util]
@@ -181,7 +182,7 @@
                                           :limit       1})]
           (mt/with-native-query-testing-context query
             (is (= (if (or (= driver/*driver* :sqlserver)
-                           (driver/database-supports? driver/*driver* :set-timezone (mt/db)))
+                           (driver.u/supports? driver/*driver* :set-timezone (mt/db)))
                      {:get-year        2004
                       :get-quarter     1
                       :get-month       1
@@ -551,7 +552,7 @@
                                 $times.dt
                                 [:convert-timezone [:field (mt/id :times :dt) nil] "Asia/Seoul"]))))))
 
-          (when (driver/database-supports? driver/*driver* :set-timezone (mt/db))
+          (when (driver.u/supports? driver/*driver* :set-timezone (mt/db))
             (mt/with-report-timezone-id "Europe/Rome"
               (testing "results should be displayed in the converted timezone, not report-tz"
                 (is (= ["2004-03-19T09:19:09+01:00" "2004-03-19T17:19:09+09:00"]
@@ -577,7 +578,7 @@
                                  "Asia/Seoul"
                                  "UTC"]))))))
 
-          (when (driver/database-supports? driver/*driver* :set-timezone (mt/db))
+          (when (driver.u/supports? driver/*driver* :set-timezone (mt/db))
             (mt/with-report-timezone-id "Europe/Rome"
               (testing "the base timezone should be the timezone of column (Asia/Ho_Chi_Minh)"
                 (is (= ["2004-03-19T03:19:09+01:00" "2004-03-19T11:19:09+09:00"]
@@ -926,7 +927,7 @@
                            "2022-10-03T00:00:00Z"))))) ; 2022-10-03T00:00:00Z
   (testing "hour under a day"
     (mt/with-temporary-setting-values [driver/report-timezone "Atlantic/Cape_Verde"]
-      (is (partial= (if (driver/database-supports? driver/*driver* :set-timezone (mt/db))
+      (is (partial= (if (driver.u/supports? driver/*driver* :set-timezone (mt/db))
                       {:second 82800 :minute 1380 :hour 23 :day 1}
                       {:second 82800 :minute 1380 :hour 23 :day 0})
                     (diffs "2022-10-02T00:00:00Z"          ; 2022-10-01T23:00:00-01:00
@@ -937,7 +938,7 @@
                            "2022-10-03T00:00:00+01:00"))))) ; 2022-10-02T23:00:00Z
   (testing "hour under a week"
     (mt/with-temporary-setting-values [driver/report-timezone "Atlantic/Cape_Verde"]
-      (is (partial= (if (driver/database-supports? driver/*driver* :set-timezone (mt/db))
+      (is (partial= (if (driver.u/supports? driver/*driver* :set-timezone (mt/db))
                       {:hour 167 :day 7 :week 1}
                       {:hour 167 :day 6 :week 0})
                     (diffs "2022-10-02T00:00:00Z"          ; 2022-10-01T23:00:00-01:00
@@ -957,7 +958,7 @@
                            "2022-10-09T00:00:00Z"))))) ; 2022-10-09T00:00:00Z
   (testing "hour under a month"
     (mt/with-temporary-setting-values [driver/report-timezone "Atlantic/Cape_Verde"]
-      (is (partial= (if (driver/database-supports? driver/*driver* :set-timezone (mt/db))
+      (is (partial= (if (driver.u/supports? driver/*driver* :set-timezone (mt/db))
                       {:hour 743 :day 31 :week 4 :month 1}
                       {:hour 743 :day 30 :week 4 :month 0})
                     (diffs "2022-10-02T00:00:00Z"          ; 2022-10-01T23:00:00-01:00
@@ -977,7 +978,7 @@
                            "2022-11-02T00:00:00Z"))))) ; 2022-11-02T00:00:00Z
   (testing "hour under a quarter"
     (mt/with-temporary-setting-values [driver/report-timezone "Atlantic/Cape_Verde"]
-      (is (partial= (if (driver/database-supports? driver/*driver* :set-timezone (mt/db))
+      (is (partial= (if (driver.u/supports? driver/*driver* :set-timezone (mt/db))
                       {:month 3 :quarter 1}
                       {:month 2 :quarter 0})
                     (diffs "2022-10-02T00:00:00Z"          ; 2022-10-01T23:00:00-01:00
@@ -1006,7 +1007,7 @@
                            "2023-10-02T00:00:00Z"))))) ; 2023-10-02T00:00:00Z
   (testing "hour under a year"
     (mt/with-temporary-setting-values [driver/report-timezone "Atlantic/Cape_Verde"]
-      (is (partial= (if (driver/database-supports? driver/*driver* :set-timezone (mt/db))
+      (is (partial= (if (driver.u/supports? driver/*driver* :set-timezone (mt/db))
                       {:day 365 :month 12 :year 1}
                       {:day 364 :month 11 :year 0})
                     (diffs "2022-10-02T00:00:00Z"          ; 2022-10-01T23:00:00-01:00

--- a/test/metabase/query_processor_test/timezones_test.clj
+++ b/test/metabase/query_processor_test/timezones_test.clj
@@ -6,6 +6,7 @@
    [java-time.api :as t]
    [metabase.driver :as driver]
    [metabase.driver.sql.query-processor :as sql.qp]
+   [metabase.driver.util :as driver.u]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.query-processor :as qp]
    [metabase.query-processor.store :as qp.store]
@@ -260,7 +261,7 @@
   (mt/dataset all-dates-leap-year
     (mt/test-drivers (set-timezone-drivers)
       (let [extract-units (cond-> (disj u.date/extract-units :day-of-year)
-                            (not (driver/database-supports? driver/*driver* ::extract-week-of-year-us (mt/db)))
+                            (not (driver.u/supports? driver/*driver* ::extract-week-of-year-us (mt/db)))
                             (disj :week-of-year))
             ;; :week-of-year-instance is the behavior of u.date/extract (based on public-settings start-of-week)
             extract-translate {:year :year-of-era :week-of-year :week-of-year-us}

--- a/test/metabase/test/data/dataset_definition_test.clj
+++ b/test/metabase/test/data/dataset_definition_test.clj
@@ -3,6 +3,7 @@
    [clojure.test :refer :all]
    [metabase.driver :as driver]
    [metabase.driver.ddl.interface :as ddl.i]
+   [metabase.driver.util :as driver.u]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 
@@ -30,7 +31,7 @@
                    :fk_target_field_id nil
                    :semantic_type      :type/PK}]
                  user-fields)))
-        (when (driver/database-supports? driver/*driver* :foreign-keys (mt/db))
+        (when (driver.u/supports? driver/*driver* :foreign-keys (mt/db))
           (testing "user_custom_id is a FK non user.custom_id"
             (is (= #{{:name               (format-name "user_custom_id")
                       :fk_target_field_id (mt/id :user :custom_id)

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -822,11 +822,11 @@
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
     ;; There aren't any officially supported databases yet that don't support `:upload-with-auto-pk`
     ;; So we'll fake it here to test it for 3rd party drivers
-    (let [original-database-supports?-fn driver.u/supports?]
+    (let [original-supports?-fn driver.u/supports?]
       (with-redefs [driver.u/supports? (fn [driver feature db]
                                          (if (= feature :upload-with-auto-pk)
                                            false
-                                           (original-database-supports?-fn driver feature db)))]
+                                           (original-supports?-fn driver feature db)))]
         (with-mysql-local-infile-on-and-off
           (testing "Upload a CSV file with column names that are reserved by the DB, NOT ignoring them"
             (testing "A single column whose name normalizes to _mb_row_id"

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -1037,7 +1037,8 @@
           _                    (t2/update! :model/Database db-id {:is_on_demand false
                                                                   :is_full_sync false})]
       (try
-        (with-redefs [;; do away with the `future` invocation since we don't want race conditions in a test
+        (with-redefs [driver.u/supports? (constantly true)
+                      ;; do away with the `future` invocation since we don't want race conditions in a test
                       future-call (fn [thunk]
                                     (swap! in-future? (constantly true))
                                     (thunk))]


### PR DESCRIPTION
This PR backports changes from two PRs to 49. 
1. https://github.com/metabase/metabase/pull/43429
2. https://github.com/metabase/metabase/pull/44719

I'm unsure how I missed backporting the first PR, because I definitely intended to and I even changed the milestone. It landed in master around the time of the 50 RC so I probably just forgot to backport it twice.