### PR TITLE
Return info about the proper billing status on the license page

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/billing/billing.clj
+++ b/enterprise/backend/src/metabase_enterprise/billing/billing.clj
@@ -61,7 +61,7 @@
   (let [token    (premium-features/premium-embedding-token)
         email    (t2/select-one-fn :email :model/User :id api/*current-user-id*)
         language (i18n/user-locale-string)]
-    (if (str/starts-with? token "airgap_")
+    (if (and token (str/starts-with? token "airgap_"))
       (billing-status)
       (fetch-billing-status* token email language))))
 

--- a/enterprise/backend/test/metabase_enterprise/billing/billing_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/billing/billing_test.clj
@@ -5,17 +5,19 @@
 
 (deftest fetch-billing-status-test
   (testing "Passes through billing status fetched from server"
-    (binding [http/request (fn [& _]
-                             {:status 200
-                              :body   "{\"version\":\"v1\",\"content\":null}"})]
-      (is (= {:version "v1"
-              :content nil}
-             (mt/user-http-request :rasta :get 200 "/ee/billing"))))))
+    (mt/with-temporary-setting-values [premium-embedding-token nil]
+      (binding [http/request (fn [& _]
+                               {:status 200
+                                :body   "{\"version\":\"v1\",\"content\":null}"})]
+        (is (= {:version "v1"
+                :content nil}
+               (mt/user-http-request :rasta :get 200 "/ee/billing")))))))
 
 (deftest fetch-billing-status-error-test
   (testing "When receiving a non json result consume the error and return an empty content blob"
-    (binding [http/request (fn [& _]
-                             {:status 404
-                              :body   "error"})]
-      (is (= {:content nil}
-             (mt/user-http-request :crowberto :get 200 "/ee/billing"))))))
+    (mt/with-temporary-setting-values [premium-embedding-token nil]
+      (binding [http/request (fn [& _]
+                               {:status 404
+                                :body   "error"})]
+        (is (= {:content nil}
+               (mt/user-http-request :crowberto :get 200 "/ee/billing")))))))


### PR DESCRIPTION
Return relevant billing status information, solves: metabase/metabase-private/issues/215

<img width="200" alt="Screenshot 2024-06-27 at 2 44 36 PM" src="https://github.com/metabase/metabase/assets/343288/7ff82434-16e8-4401-8d84-e216b1820773">
