### PR TITLE
improve cartesian charts performance

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.ts
@@ -1,5 +1,4 @@
 import { t } from "ttag";
-import _ from "underscore";
 
 import { getObjectKeys } from "metabase/lib/objects";
 import { parseTimestamp } from "metabase/lib/time-dayjs";


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/44778

### Description

Improves slow cartesian charts rendering on larger datasets by reducing number of expensive operations that include:
- call cljs metabase-lib code
- format text
- measure text width

**1) Optimize `scaleDataset`**
It [used to call](https://github.com/metabase/metabase/pull/44861/files#diff-ad0928481b30ef8299f367e9bb5f751f4e4750709c3006d7809c979105240a6eL639) `getColumnScaling` per series per datum but this function inside calls `getColumnKey` which calls cljs metabase-lib code that turned out to be not so fast.

**2) Optimize `aggregateColumnValuesForDatum`**
It [used to call](https://github.com/metabase/metabase/pull/44861/files#diff-ad0928481b30ef8299f367e9bb5f751f4e4750709c3006d7809c979105240a6eL126) `isMetric` metabase-lib function per datum per series which also turned out to be expensive.

**3) Optimize `getTicksDimensions`**
Previously, we [computed the width of every x-axis tick](https://github.com/metabase/metabase/pull/44861/files#diff-da82c365b720de7b1763897dad5f4317e53823954e8f7cdabfd01166e59a32d3L315) which involves formatting and measuring text width. Both operations are expensive and it does not make much sense to call it for every tick on 10k length datasets. Now for continuous values such as numbers or dates we measure 50 values from the dataset including start and end. On category values we select top 50 values by string length and measure them.

### How to verify

CI is green: nothing should change in terms of charts behavior.
Compare how charts with many data points behave compared in terms of performance with `master`.

### Demo

20k data points

**Before**
First `useModelAndOption` took 1.86s
Subsequent call ~760 ms

<img width="1728" alt="Screenshot 2024-06-27 at 7 54 33 PM" src="https://github.com/metabase/metabase/assets/14301985/61a1245a-15de-44a3-9e5b-53d59fa542fb">

**After**
First `useModelAndOption` took 574ms
Subsequent call ~16 ms

<img width="1728" alt="Screenshot 2024-06-27 at 7 53 03 PM" src="https://github.com/metabase/metabase/assets/14301985/21b80872-32b4-4f5b-b39c-9b74dc08eb5d">

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR
