### PR TITLE
Better display names for CSV upload tables

### DIFF
--- a/src/metabase/sync/sync_metadata/tables.clj
+++ b/src/metabase/sync/sync_metadata/tables.clj
@@ -112,7 +112,7 @@
            :schema                  (:schema table)
            :description             (:description table)
            :database_require_filter (:database_require_filter table)
-           :display_name            (or (:display_name table) (humanization/name->human-readable-name table))
+           :display_name            (or (:display_name table) (humanization/name->human-readable-name (:name table)))
            :name                    (:name table)})))
 
 (defn create-or-reactivate-table!

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -389,14 +389,16 @@
 
 (defn- create-from-csv-and-sync!
   "This is separated from `create-csv-upload!` for testing"
-  [{:keys [db file schema table-name]}]
+  [{:keys [db file schema table-name display-name]}]
   (let [driver            (driver.u/database->driver db)
         schema            (some->> schema (ddl.i/format-name driver))
         table-name        (some->> table-name (ddl.i/format-name driver))
         schema+table-name (table-identifier {:schema schema :name table-name})
         stats             (create-from-csv! driver db schema+table-name file)
         ;; Sync immediately to create the Table and its Fields; the scan is settings-dependent and can be async
-        table             (sync-tables/create-or-reactivate-table! db {:name table-name :schema (not-empty schema)})
+        table             (sync-tables/create-table! db {:name         table-name
+                                                         :schema       (not-empty schema)
+                                                         :display_name display-name})
         _set_is_upload    (t2/update! :model/Table (:id table) {:is_upload true})
         _sync             (scan-and-sync-table! db table)
         ;; Set the display_name of the auto-generated primary key column to the same as its name, so that if users
@@ -446,12 +448,18 @@
       (let [timer             (start-timer)
             filename-prefix   (or (second (re-matches #"(.*)\.(csv|tsv)$" filename))
                                   filename)
+            display-name      (humanization/name->human-readable-name filename-prefix)
+            display-name      (u/truncate-string-to-byte-count display-name max-field-name-length)
             driver            (driver.u/database->driver database)
-            table-name        (->> (str table-prefix filename-prefix)
+            table-name        (->> (str table-prefix display-name)
                                    (unique-table-name driver)
                                    (u/lower-case-en))
             {:keys [stats
-                    table]}   (create-from-csv-and-sync! {:db database :file file :schema schema-name :table-name table-name})
+                    table]}   (create-from-csv-and-sync! {:db           database
+                                                          :file         file
+                                                          :schema       schema-name
+                                                          :table-name   table-name
+                                                          :display-name display-name})
             card              (card/create-card!
                                {:collection_id          collection-id
                                 :type                   :model
@@ -460,7 +468,7 @@
                                                          :query    {:source-table (:id table)}
                                                          :type     :query}
                                 :display                :table
-                                :name                   (humanization/name->human-readable-name filename-prefix)
+                                :name                   display-name
                                 :visualization_settings {}}
                                @api/*current-user*)
             upload-seconds    (/ (since-ms timer) 1e3)

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -42,21 +42,22 @@
 (set! *warn-on-reflection* true)
 
 ;; TODO: move these to a more appropriate namespace if they need to be reused
-(defmulti ^:private max-bytes
+(defmulti max-bytes
   "This tracks the size of various text fields in bytes."
-  (fn [model _column-name] model))
+  {:arglists '([model column])}
+  (fn [model _column] model))
 
-(defmethod max-bytes :model/Table [_ column-name]
-  (case column-name
-    :display_name 254
+(defmethod max-bytes :model/Table [_ column]
+  (case column
+    :display_name 256
+    :name 256))
+
+(defmethod max-bytes :model/Field [_ column]
+  (case column
     :name 254))
 
-(defmethod max-bytes :model/Field [_ column-name]
-  (case column-name
-    :name 254))
-
-(defmethod max-bytes :model/Card  [_ column-name]
-  (case column-name
+(defmethod max-bytes :model/Card  [_ column]
+  (case column
     :name 254))
 
 (def ^:private min-safe (fnil min Long/MAX_VALUE Long/MAX_VALUE))

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -1,6 +1,14 @@
 (ns metabase.util
   "Common utility functions useful throughout the codebase."
   (:require
+   #?@(:clj  ([clojure.math.numeric-tower :as math]
+              [me.flowthing.pp :as pp]
+              [metabase.config :as config]
+              #_{:clj-kondo/ignore [:discouraged-namespace]}
+              [metabase.util.jvm :as u.jvm]
+              [metabase.util.string :as u.str]
+              [potemkin :as p]
+              [ring.util.codec :as codec]))
    [camel-snake-kebab.internals.macros :as csk.macros]
    [clojure.data :refer [diff]]
    [clojure.pprint :as pprint]
@@ -13,17 +21,10 @@
    [metabase.shared.util.namespaces :as u.ns]
    [metabase.util.format :as u.format]
    [metabase.util.log :as log]
+   [metabase.util.malli :as mu]
    [metabase.util.memoize :as memoize]
    [net.cgrand.macrovich :as macros]
-   [weavejester.dependency :as dep]
-   #?@(:clj  ([clojure.math.numeric-tower :as math]
-              [me.flowthing.pp :as pp]
-              [metabase.config :as config]
-              #_{:clj-kondo/ignore [:discouraged-namespace]}
-              [metabase.util.jvm :as u.jvm]
-              [metabase.util.string :as u.str]
-              [potemkin :as p]
-              [ring.util.codec :as codec])))
+   [weavejester.dependency :as dep])
   #?(:clj (:import
            (clojure.lang Reflector)
            (java.text Normalizer Normalizer$Form)
@@ -989,3 +990,35 @@
                          (transient {})
                          m))]
      (with-meta ret (meta m)))))
+
+(mu/defn string-byte-count :- [:int {:min 0}]
+  "Number of bytes in a string using UTF-8 encoding."
+  [s :- :string]
+  #?(:clj (count (.getBytes (str s) "UTF-8"))
+     :cljs (.. (js/TextEncoder.) (encode s) -length)))
+
+#?(:clj
+   (mu/defn ^:private string-character-at :- [:string {:min 0, :max 1}]
+     [s :- :string
+      i :- [:int {:min 0}]]
+     (str (.charAt ^String s i))))
+
+(mu/defn truncate-string-to-byte-count :- :string
+  "Truncate string `s` to `max-length-bytes` UTF-8 bytes (as opposed to truncating to some number of *characters*)."
+  [s                :- :string
+   max-length-bytes :- [:int {:min 1}]]
+  #?(:clj
+     (loop [i 0, cumulative-byte-count 0]
+       (cond
+         (= cumulative-byte-count max-length-bytes) (subs s 0 i)
+         (> cumulative-byte-count max-length-bytes) (subs s 0 (dec i))
+         (>= i (count s))                           s
+         :else                                      (recur (inc i)
+                                                           (long (+
+                                                                  cumulative-byte-count
+                                                                  (string-byte-count (string-character-at s i)))))))
+
+     :cljs
+     (let [buf (js/Uint8Array. max-length-bytes)
+           result (.encodeInto (js/TextEncoder.) s buf)] ;; JS obj {read: chars_converted, write: bytes_written}
+       (subs s 0 (.-read result)))))

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -21,7 +21,6 @@
    [metabase.shared.util.namespaces :as u.ns]
    [metabase.util.format :as u.format]
    [metabase.util.log :as log]
-   [metabase.util.malli :as mu]
    [metabase.util.memoize :as memoize]
    [net.cgrand.macrovich :as macros]
    [weavejester.dependency :as dep])
@@ -991,22 +990,20 @@
                          m))]
      (with-meta ret (meta m)))))
 
-(mu/defn string-byte-count :- [:int {:min 0}]
+(defn string-byte-count
   "Number of bytes in a string using UTF-8 encoding."
-  [s :- :string]
+  [s]
   #?(:clj (count (.getBytes (str s) "UTF-8"))
      :cljs (.. (js/TextEncoder.) (encode s) -length)))
 
 #?(:clj
-   (mu/defn ^:private string-character-at :- [:string {:min 0, :max 1}]
-     [s :- :string
-      i :- [:int {:min 0}]]
+   (defn ^:private string-character-at
+     [s i]
      (str (.charAt ^String s i))))
 
-(mu/defn truncate-string-to-byte-count :- :string
+(defn truncate-string-to-byte-count
   "Truncate string `s` to `max-length-bytes` UTF-8 bytes (as opposed to truncating to some number of *characters*)."
-  [s                :- :string
-   max-length-bytes :- [:int {:min 1}]]
+  [s max-length-bytes]
   #?(:clj
      (loop [i 0, cumulative-byte-count 0]
        (cond

--- a/test/metabase/lib/util_test.cljc
+++ b/test/metabase/lib/util_test.cljc
@@ -1,13 +1,13 @@
 (ns metabase.lib.util-test
   (:require
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
-   [clojure.string :as str]
    [clojure.test :refer [are deftest is testing]]
    [metabase.lib.core :as lib]
    [metabase.lib.equality :as lib.equality]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
-   [metabase.lib.util :as lib.util]))
+   [metabase.lib.util :as lib.util]
+   [metabase.util :as u]))
 
 #?(:cljs
    (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
@@ -223,46 +223,10 @@
     "0601246074"           "00000001"
     "2915035893"           "00000000"))
 
-(deftest ^:parallel truncate-string-to-byte-count-test
-  (letfn [(truncate-string-to-byte-count [s byte-length]
-            (let [truncated (#'lib.util/truncate-string-to-byte-count s byte-length)]
-              (is (<= (#'lib.util/string-byte-count truncated) byte-length))
-              (is (str/starts-with? s truncated))
-              truncated))]
-    (doseq [[s max-length->expected] {"12345"
-                                      {1  "1"
-                                       2  "12"
-                                       3  "123"
-                                       4  "1234"
-                                       5  "12345"
-                                       6  "12345"
-                                       10 "12345"}
-
-                                      "가나다라"
-                                      {1  ""
-                                       2  ""
-                                       3  "가"
-                                       4  "가"
-                                       5  "가"
-                                       6  "가나"
-                                       7  "가나"
-                                       8  "가나"
-                                       9  "가나다"
-                                       10 "가나다"
-                                       11 "가나다"
-                                       12 "가나다라"
-                                       13 "가나다라"
-                                       15 "가나다라"
-                                       20 "가나다라"}}
-            [max-length expected] max-length->expected]
-      (testing (pr-str (list `lib.util/truncate-string-to-byte-count s max-length))
-        (is (= expected
-               (truncate-string-to-byte-count s max-length)))))))
-
 (deftest ^:parallel truncate-alias-test
   (letfn [(truncate-alias [s max-bytes]
             (let [truncated (lib.util/truncate-alias s max-bytes)]
-              (is (<= (#'lib.util/string-byte-count truncated) max-bytes))
+              (is (<= (u/string-byte-count truncated) max-bytes))
               truncated))]
     (doseq [[s max-bytes->expected] { ;; 20-character plain ASCII string
                                      "01234567890123456789"

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -367,31 +367,26 @@
        (do-with-upload-table! ~create-table-expr (fn [~table-binding] ~@body)))))
 
 (deftest create-from-csv-display-name-test
-  (testing "The display name is humanized from the CSV file name"
-    (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
+  (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
+    (testing "The display name is humanized from the CSV file name"
       (let [csv-file-prefix "some_FILE-prefix"]
-        (with-upload-table!
-          [table (card->table (upload-example-csv! :csv-file-prefix csv-file-prefix))]
+        (with-upload-table! [table (card->table (upload-example-csv! :csv-file-prefix csv-file-prefix))]
           (is (= "Some File Prefix"
-                 (:display_name table)))))))
-  (testing "Unicode characters are preserved in the display name, even when the table name is slugified"
-    (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
+                 (:display_name table))))))
+    (testing "Unicode characters are preserved in the display name, even when the table name is slugified"
       (let [csv-file-prefix "出色的"]
         (with-redefs [upload/strictly-monotonic-now (constantly #t "2024-06-28T00:00:00")]
-          (with-upload-table!
-            [table (card->table (upload-example-csv! :csv-file-prefix csv-file-prefix))]
+          (with-upload-table! [table (card->table (upload-example-csv! :csv-file-prefix csv-file-prefix))]
             (is (=? {:display_name "出色的"
                      :name         "%E5%87%BA%E8%89%B2%E7%9A%84_20240628000000"}
-                    table)))))))
-  (testing "The display name should be truncated to 254 bytes with UTF-8 encoding"
-    ;; we can assume app DBs use UTF-8 encoding. see #11753
-    (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
+                    table))))))
+    (testing "The display name should be truncated to 254 bytes with UTF-8 encoding"
+      ;; we can assume app DBs use UTF-8 encoding (metabase#11753)
       (let [long-csv-file-prefix     (apply str (repeat 1000 "出"))
             char-size                (count (.getBytes "出" "UTF-8"))
             expected-number-of-chars (quot 254 char-size)]
         (with-redefs [upload/strictly-monotonic-now (constantly #t "2024-06-28T00:00:00")]
-          (with-upload-table!
-            [table (card->table (upload-example-csv! :csv-file-prefix long-csv-file-prefix))]
+          (with-upload-table! [table (card->table (upload-example-csv! :csv-file-prefix long-csv-file-prefix))]
             (is (=? {:display_name (apply str (repeat expected-number-of-chars "出"))}
                     table))))))))
 

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -377,6 +377,7 @@
                      :name         "%E5%87%BA%E8%89%B2%E7%9A%84_20240628000000"}
                     table)))))))
   (testing "The display name should be truncated to 254 bytes with UTF-8 encoding"
+    ;; we can assume app DBs use UTF-8 encoding. see #11753
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
       (let [long-csv-file-prefix     (apply str (repeat 1000 "出"))
             char-size                (count (.getBytes "出" "UTF-8"))

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -381,7 +381,7 @@
           (with-redefs [upload/strictly-monotonic-now (constantly #t "2024-06-28T00:00:00")]
             (with-upload-table! [table (card->table (upload-example-csv! :csv-file-prefix csv-file-prefix))]
               (test-names-match table "出色的")
-              (is (= "%E5%87%BA%E8%89%B2%E7%9A%84_20240628000000"
+              (is (= (ddl.i/format-name driver/*driver* "%e5%87%ba%e8%89%b2%e7%9a%84_20240628000000")
                      (:name table)))))))
       (testing "The names should be truncated to the right size"
         ;; we can assume app DBs use UTF-8 encoding (metabase#11753)

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -386,7 +386,7 @@
       (testing "The names should be truncated to the right size"
         ;; we can assume app DBs use UTF-8 encoding (metabase#11753)
         (doseq [c ["a" "出"]]
-          (let [long-csv-file-prefix (apply str (repeat 1000 c))
+          (let [long-csv-file-prefix (apply str (repeat 300 c))
                 char-size            (count (.getBytes c "UTF-8"))]
             (with-upload-table! [table (card->table (upload-example-csv! :csv-file-prefix long-csv-file-prefix))]
               (testing "The card name should be truncated to 254 bytes with UTF-8 encoding"

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -387,7 +387,7 @@
         ;; we can assume app DBs use UTF-8 encoding (metabase#11753)
         (let [max-bytes 50]
           (with-redefs [; redef this because the UNIX filename limit is 255 bytes, so we can't test it in CI
-                        upload/max-bytes (constantly 50)]
+                        upload/max-bytes (constantly max-bytes)]
             (doseq [c ["a" "出"]]
               (let [long-csv-file-prefix (apply str (repeat (inc max-bytes) c))
                     char-size            (count (.getBytes c "UTF-8"))]

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -386,8 +386,8 @@
       (testing "The names should be truncated to the right size"
         ;; we can assume app DBs use UTF-8 encoding (metabase#11753)
         (doseq [c ["a" "出"]]
-          (let [long-csv-file-prefix     (apply str (repeat 1000 c))
-                char-size                (count (.getBytes c "UTF-8"))]
+          (let [long-csv-file-prefix (apply str (repeat 1000 c))
+                char-size            (count (.getBytes c "UTF-8"))]
             (with-upload-table! [table (card->table (upload-example-csv! :csv-file-prefix long-csv-file-prefix))]
               (testing "The card name should be truncated to 254 bytes with UTF-8 encoding"
                 (is (= (str/capitalize (apply str (repeat (quot 254 char-size) c)))

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -367,7 +367,14 @@
        (do-with-upload-table! ~create-table-expr (fn [~table-binding] ~@body)))))
 
 (deftest create-from-csv-display-name-test
-  (testing "The display name should be the file name prefix, but the table name is slugified"
+  (testing "The display name is humanized from the CSV file name"
+    (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
+      (let [csv-file-prefix "some_FILE-prefix"]
+        (with-upload-table!
+          [table (card->table (upload-example-csv! :csv-file-prefix csv-file-prefix))]
+          (is (= "Some File Prefix"
+                 (:display_name table)))))))
+  (testing "Unicode characters are preserved in the display name, even when the table name is slugified"
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
       (let [csv-file-prefix "出色的"]
         (with-redefs [upload/strictly-monotonic-now (constantly #t "2024-06-28T00:00:00")]

--- a/test/metabase/util_test.cljc
+++ b/test/metabase/util_test.cljc
@@ -1,14 +1,14 @@
 (ns ^:mb/once metabase.util-test
   "Tests for functions in `metabase.util`."
   (:require
-   #?@(:clj [[metabase.test :as mt]])
+   #?@(:clj [[metabase.test :as mt]
+             [malli.generator :as mg]])
    [clojure.string :as str]
    [clojure.test :refer [are deftest is testing]]
    [clojure.test.check.clojure-test :refer [defspec]]
    [clojure.test.check.generators :as gen]
    [clojure.test.check.properties :as prop]
    [flatland.ordered.map :refer [ordered-map]]
-   [malli.generator :as mg]
    [metabase.util :as u])
   #?(:clj (:import [java.time DayOfWeek Month])))
 


### PR DESCRIPTION
This PR does two things:
1. Improves the display name for CSV upload tables to be more user-friendly.
2. Truncates the table's display name and name and the model's name to the maximum size the app DB allows, which allowing files with long names to be uploaded.*

*If the filename exceeds the filesystem's limits (e.g. 255 bytes for UNIX), the upload will still fail. But that's out of scope.

### **Previously** 

The display name for a table was just the humanized version of the table name. The table name is the concatenation of the upload table name prefix, the slugified file name, and a unique timestamp.

That results in ugly table names like this:

![image](https://github.com/metabase/metabase/assets/39073188/0137cca4-3b30-465c-83cf-61b4ed6742bc)

It's worse for non-ASCII characters; for a CSV file called 𡨸漢.csv the name of the table would be `<upload-prefix>%3F%3F%E6%BC%A2_<timestamp>` and the display name would be the humanized version of that: `<upload-prefix>%3F%3F%E6%BC%A2 <timestamp>`.

### **After this PR**

We'll set the display name from newly uploaded tables to directly from the file name, rather than from the name of the table.

So the display name for a file called "𡨸漢.csv" would be "𡨸漢". We'll also humanize the file name, so the display name for a file called "some_FILE-name.csv" would be "Some File Name".

For any files with really long names that result in a display name that exceeds the size of the `display_name` field in the app DB, we'll truncate the string to the maximum size for the field. The same truncation applies to the `report_card.name` field for the upload model.