### PR TITLE
Patch storybook to fix failed loki tests with runtime error

### DIFF
--- a/patches/@storybook+core-common+6.5.16.patch
+++ b/patches/@storybook+core-common+6.5.16.patch
@@ -1,0 +1,29 @@
+diff --git a/node_modules/@storybook/core-common/templates/base-preview-head.html b/node_modules/@storybook/core-common/templates/base-preview-head.html
+index 45c0c30..b61173d 100644
+--- a/node_modules/@storybook/core-common/templates/base-preview-head.html
++++ b/node_modules/@storybook/core-common/templates/base-preview-head.html
+@@ -326,24 +326,4 @@
+     // eslint-disable-next-line no-console
+     console.warn('unable to connect to top frame for connecting dev tools');
+   }
+-
+-  window.onerror = function onerror(message, source, line, column, err) {
+-    if (window.CONFIG_TYPE !== 'DEVELOPMENT') return;
+-    // eslint-disable-next-line no-var, vars-on-top
+-    var xhr = new window.XMLHttpRequest();
+-    xhr.open('POST', '/runtime-error');
+-    xhr.setRequestHeader('Content-Type', 'application/json;charset=UTF-8');
+-    xhr.send(
+-      JSON.stringify({
+-        /* eslint-disable object-shorthand */
+-        message: message,
+-        source: source,
+-        line: line,
+-        column: column,
+-        error: err && { message: err.message, name: err.name, stack: err.stack },
+-        origin: 'preview',
+-        /* eslint-enable object-shorthand */
+-      })
+-    );
+-  };
+ </script>


### PR DESCRIPTION
We [encountered failed Loki tests](https://metaboat.slack.com/archives/C064QMXEV9N/p1719420501728319) when a story throw runtime errors.

This problem [is fixed in Storybook v7](https://github.com/storybookjs/storybook/commit/5d86bcfc9ad26595663ebdea7f6cc21b7943377e) but it [isn't easy to upgrade](https://metaboat.slack.com/archives/C064QMXEV9N/p1719428500883389?thread_ts=1719420501.728319&cid=C064QMXEV9N). So we resort to patching this instead for the time-being.

#### How to test
1. Before: Try to create a story with a runtime error. I think throwing some errors should do and run `yarn test-visual:loki` You should see loki failing when our story was trying to call `/runtime-error` endpoint.
2. After: run `yarn` to apply the patch and try running the test again.