### PR TITLE
Add a reproduction for "Cannot find the new column in pick columns after alter schema and synced"

### DIFF
--- a/e2e/test/scenarios/admin/admin-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/admin/admin-reproductions.cy.spec.js
@@ -87,6 +87,11 @@ describe("issue 41765", { tags: ["@external"] }, () => {
     });
   });
 
+  function enterAdmin() {
+    appBar().icon("gear").click();
+    popover().findByText("Admin settings").click();
+  }
+
   function exitAdmin() {
     appBar().findByText("Exit admin").click();
   }
@@ -116,9 +121,10 @@ describe("issue 41765", { tags: ["@external"] }, () => {
     getNotebookStep("data").button("Pick columns").click();
     popover().findByText(COLUMN_DISPLAY_NAME).should("not.exist");
 
-    // It's ok to navigate here since we are not testing the cache at this point
-    cy.visit(`/admin/databases/${WRITABLE_DB_ID}`);
+    enterAdmin();
 
+    appBar().findByText("Databases").click();
+    cy.findAllByRole("link").contains(WRITABLE_DB_DISPLAY_NAME).click();
     cy.button("Sync database schema now").click();
 
     exitAdmin();

--- a/e2e/test/scenarios/admin/admin-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/admin/admin-reproductions.cy.spec.js
@@ -1,5 +1,14 @@
 import { WRITABLE_DB_ID, SAMPLE_DB_ID } from "e2e/support/cypress_data";
-import { restore } from "e2e/support/helpers";
+import {
+  appBar,
+  entityPickerModal,
+  getNotebookStep,
+  popover,
+  queryWritableDB,
+  resetTestTable,
+  restore,
+  resyncDatabase,
+} from "e2e/support/helpers";
 
 describe("issue 26470", { tags: "@external" }, () => {
   beforeEach(() => {
@@ -52,5 +61,70 @@ describe("issue 21532", () => {
     cy.location().should(location => {
       expect(location.pathname).to.eq("/");
     });
+  });
+});
+
+describe("issue 41765", { tags: ["@external"] }, () => {
+  // In this test we are testing the in-browser cache that metabase uses,
+  // so we need to navigate by clicking trough the UI without reloading the page.
+
+  const WRITABLE_DB_DISPLAY_NAME = "Writable Postgres12";
+
+  const TEST_TABLE = "scoreboard_actions";
+  const TEST_TABLE_DISPLAY_NAME = "Scoreboard Actions";
+
+  const COLUMN_NAME = "another_column";
+  const COLUMN_DISPLAY_NAME = "Another Column";
+
+  beforeEach(() => {
+    resetTestTable({ type: "postgres", table: TEST_TABLE });
+    restore("postgres-writable");
+    cy.signInAsAdmin();
+
+    resyncDatabase({
+      dbId: WRITABLE_DB_ID,
+      tableName: TEST_TABLE,
+    });
+  });
+
+  function exitAdmin() {
+    appBar().findByText("Exit admin").click();
+  }
+
+  function openWritableDatabaseQuestion() {
+    // start new question without navigating
+    appBar().findByText("New").click();
+    popover().findByText("Question").click();
+
+    entityPickerModal().within(() => {
+      cy.findByText("Tables").click();
+      cy.findByText(WRITABLE_DB_DISPLAY_NAME).click();
+      cy.findByText(TEST_TABLE_DISPLAY_NAME).click();
+    });
+  }
+
+  it("re-syncing a database should invalidate the table cache (metabase#41765)", () => {
+    cy.visit("/");
+
+    queryWritableDB(
+      `ALTER TABLE ${TEST_TABLE} ADD ${COLUMN_NAME} text;`,
+      "postgres",
+    );
+
+    openWritableDatabaseQuestion();
+
+    getNotebookStep("data").button("Pick columns").click();
+    popover().findByText(COLUMN_DISPLAY_NAME).should("not.exist");
+
+    // It's ok to navigate here since we are not testing the cache at this point
+    cy.visit(`/admin/databases/${WRITABLE_DB_ID}`);
+
+    cy.button("Sync database schema now").click();
+
+    exitAdmin();
+    openWritableDatabaseQuestion();
+
+    getNotebookStep("data").button("Pick columns").click();
+    popover().findByText(COLUMN_DISPLAY_NAME).should("be.visible");
   });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/41765


Adds a reproduction for https://github.com/metabase/metabase/issues/41765 which was fixed in v50.

It also is another signal that https://github.com/metabase/metabase/issues/10330 might be fixed.

The issue depends on navigating without reloading the page, so this test does that as well as opposed to using the more standard `startNewQuestion`, etc. helpers.