### PR TITLE
Support duplicate prefixes in long column names for CSV uploads

### DIFF
--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -2035,7 +2035,7 @@
   (testing "Upload a CSV file with unique column names that get sanitized to the same string"
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
       (with-mysql-local-infile-on-and-off
-       (let [long-string (str (str/join (repeat 1000 "яeαllУ_")) "long")
+       (let [long-string (str (str/join (repeat 1000 "really_")) "long")
              header      (str (str "a_" long-string ",")
                               (str "b_" long-string ",")
                               (str "b_" long-string "_with_a"))]
@@ -2049,15 +2049,12 @@
                  (testing "We preserve names where possible"
                    (let [header-names (->> (str/split header #",")
                                            (map (partial #'upload/normalize-column-name driver/*driver*)))]
-                     ;; there's some non-determinism about whether the multibyte escape codes are upper or lowercase
-                     ;; hex characters. their meaning does not matter.
-                     (is (every? (set (map u/upper-case-en column-names))
-                                 (map u/upper-case-en header-names)))))
+                     (is (every? (set column-names) header-names))))
                  (testing "We preserve prefixes where_possible"
-                   (is (= {"_m" 1
-                           "a_" 1
-                           "b_" 2}
-                          (frequencies (map #(subs % 0 2) column-names))))))))))))))
+                   (is (= {"_mb_row_" 1
+                           "a_really" 1
+                           "b_really" 2}
+                          (frequencies (map #(subs % 0 8) column-names))))))))))))))
 
 (deftest append-with-really-long-names-test
   (testing "Upload a CSV file with unique column names that get sanitized to the same string"

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -2031,7 +2031,7 @@
             (testing "We do not clean up any of the child resources synchronously (yet?)"
               (is (seq (t2/select :model/Field :table_id (:id table)))))))))))
 
-(deftest create-csv-from-really-long-names
+(deftest create-csv-from-really-long-names-test
   (testing "Upload a CSV file with unique column names that get sanitized to the same string"
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
       (with-mysql-local-infile-on-and-off
@@ -2056,7 +2056,7 @@
                            "b_really" 2}
                           (frequencies (map #(subs % 0 8) column-names))))))))))))))
 
-(deftest append-with-really-long-names
+(deftest append-with-really-long-names-test
   (testing "Upload a CSV file with unique column names that get sanitized to the same string"
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
       (with-mysql-local-infile-on-and-off
@@ -2079,7 +2079,7 @@
                       (map rest (rows-for-table table)))))
              (io/delete-file file))))))))
 
-(deftest append-with-really-long-names-that-duplicate
+(deftest append-with-really-long-names-that-duplicate-test
   (testing "Upload a CSV file with unique column names that get sanitized to the same string"
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
       (with-mysql-local-infile-on-and-off

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -2035,7 +2035,7 @@
   (testing "Upload a CSV file with unique column names that get sanitized to the same string"
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
       (with-mysql-local-infile-on-and-off
-       (let [long-string (str (str/join (repeat 1000 "really_")) "long")
+       (let [long-string (str (str/join (repeat 1000 "яeαllУ_")) "long")
              header      (str (str "a_" long-string ",")
                               (str "b_" long-string ",")
                               (str "b_" long-string "_with_a"))]
@@ -2049,12 +2049,15 @@
                  (testing "We preserve names where possible"
                    (let [header-names (->> (str/split header #",")
                                            (map (partial #'upload/normalize-column-name driver/*driver*)))]
-                     (is (every? (set column-names) header-names))))
+                     ;; there's some non-determinism about whether the multibyte escape codes are upper or lowercase
+                     ;; hex characters. their meaning does not matter.
+                     (is (every? (set (map u/upper-case-en column-names))
+                                 (map u/upper-case-en header-names)))))
                  (testing "We preserve prefixes where_possible"
-                   (is (= {"_mb_row_" 1
-                           "a_really" 1
-                           "b_really" 2}
-                          (frequencies (map #(subs % 0 8) column-names))))))))))))))
+                   (is (= {"_m" 1
+                           "a_" 1
+                           "b_" 2}
+                          (frequencies (map #(subs % 0 2) column-names))))))))))))))
 
 (deftest append-with-really-long-names-test
   (testing "Upload a CSV file with unique column names that get sanitized to the same string"

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -2107,6 +2107,6 @@
 (defmethod driver/column-name-length-limit ::short-column-test-driver [_] 10)
 
 (deftest unique-long-column-names-test
-  (let [original ["abcdefghijk" "abcdefghijklm" "abcdefgh_2_etc" "abcdefgh_3_xyz"]
-        expected [:abcdefghij   :a_c1819420     :abcdefgh_2      :abcdefgh_3]]
+  (let [original ["αbcdεf"     "αbcdεfg"   "αbc_2_etc" "αbc_3_xyz"]
+        expected [:%CE%B1bcd%  :%_852c229f :%CE%B1bc_2 :%CE%B1bc_3]]
     (is (= expected (#'upload/derive-column-names ::short-column-test-driver original)))))


### PR DESCRIPTION
### Description

Work backwards from https://github.com/metabase/metabase/pull/44809 to see the discussion that led here. This restores support for initial uploads with duplicate long columns, after it was broken [here](https://github.com/metabase/metabase/pull/44873), and opens the door to supporting appends as well.