### PR TITLE
Fix unable to rollback due to dropped not null constraint on 50

### DIFF
--- a/dev/src/dev/migrate.clj
+++ b/dev/src/dev/migrate.clj
@@ -42,7 +42,7 @@
                       :where  [:> :orderexecuted {:select   [:orderexecuted]
                                                   :from     [:databasechangelog]
                                                   :where    [:like :id (format "%s%%" id)]
-                                                  :order-by [:orderexecuted :desc]
+                                                  :order-by [[:orderexecuted :desc]]
                                                   :limit    1}]
                       :limit 1})
        :count

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -7564,6 +7564,7 @@ databaseChangeLog:
             tableName: task_history
             columnDataType: ${timestamp_type}
             columnName: ended_at
+      rollback: # we can't reliably add back the constraint while downgrading
 
   - changeSet:
       id: v50.2024-05-08T09:00:04
@@ -7574,6 +7575,7 @@ databaseChangeLog:
             tableName: task_history
             columnDataType: int
             columnName: duration
+      rollback: # we can't reliably add back the constraint while downgrading
 
   - changeSet:
       id: v50.2024-05-08T09:00:05


### PR DESCRIPTION
Partially fixes https://github.com/metabase/metabase/issues/44784#issuecomment-2194903570

The case where you migrate to 50 and use it for a while. You'll start having `task_history.eneded_at = null ` in your db.

Now you want to rollback; you can't because rollback is trying to add a not null constraint on `task_history.ended_at, task_history.duration`, in which you have null values.

It's ok to not add these back because these values are not really used for anything other than showing it in the Admin/Troubleshooting/Tasks page.

Other checks:
- adding a rollback does not change the checksum
- drop not null is idempotence, so it won't fail when users try to upgrade again.