### PR TITLE
replace html2cavas with html2canvas-pro to support color css functions

### DIFF
--- a/frontend/src/metabase/visualizations/lib/save-chart-image.ts
+++ b/frontend/src/metabase/visualizations/lib/save-chart-image.ts
@@ -21,7 +21,7 @@ export const saveChartImage = async (selector: string, fileName: string) => {
 
   node.classList.add(SAVING_DOM_IMAGE_CLASS);
 
-  const { default: html2canvas } = await import("html2canvas");
+  const { default: html2canvas } = await import("html2canvas-pro");
   const canvas = await html2canvas(node, {
     useCORS: true,
   });

--- a/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
+++ b/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
@@ -12,7 +12,7 @@ export const saveDashboardPdf = async (
     return;
   }
 
-  const { default: html2canvas } = await import("html2canvas");
+  const { default: html2canvas } = await import("html2canvas-pro");
   const image = await html2canvas(node, {
     useCORS: true,
     onclone: (doc: Document, node: HTMLElement) => {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "hast-util-from-html": "^2.0.1",
     "hast-util-to-html": "^9.0.0",
     "history": "3",
-    "html2canvas": "^1.4.1",
+    "html2canvas-pro": "^1.5.0",
     "humanize-plus": "^1.8.1",
     "icepick": "2.4.0",
     "iframe-resizer": "^4.3.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -207,7 +207,7 @@ const config = (module.exports = {
     splitChunks: {
       cacheGroups: {
         vendors: {
-          test: /[\\/]node_modules[\\/](?!(sql-formatter|jspdf|html2canvas)[\\/])/,
+          test: /[\\/]node_modules[\\/](?!(sql-formatter|jspdf|html2canvas-pro)[\\/])/,
           chunks: "all",
           name: "vendor",
         },
@@ -222,7 +222,7 @@ const config = (module.exports = {
           name: "jspdf",
         },
         html2canvas: {
-          test: /[\\/]node_modules[\\/]html2canvas[\\/]/,
+          test: /[\\/]node_modules[\\/]html2canvas-pro[\\/]/,
           chunks: "all",
           name: "html2canvas",
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -13411,7 +13411,15 @@ html-webpack-plugin@^4.0.0:
     tapable "^1.1.3"
     util.promisify "1.0.0"
 
-html2canvas@^1.0.0-rc.5, html2canvas@^1.4.1:
+html2canvas-pro@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/html2canvas-pro/-/html2canvas-pro-1.5.0.tgz#18925def43505bad352a394b95fffb45d6d46a8f"
+  integrity sha512-izxSphcINRwfEVV6eamsPVdhsxSYqX8n/hxzK+niVWdB+onM+aYRoVO+xgS9iMmZoUleZTWg1tJwryikib2hXg==
+  dependencies:
+    css-line-break "^2.1.0"
+    text-segmentation "^1.0.3"
+
+html2canvas@^1.0.0-rc.5:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/html2canvas/-/html2canvas-1.4.1.tgz#7cef1888311b5011d507794a066041b14669a543"
   integrity sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==


### PR DESCRIPTION
### Description

While working on adding the pdf download functionality to public/embedded dashboard, I started running into this error after a rebase on master:
```
html2canvas.js:1726 Uncaught (in promise) Error: Attempting to parse an unsupported color function "color"
    at Object.parse (html2canvas.js:1726:1)
    at parse (html2canvas.js:3750:1)
    at new CSSParsedDeclaration (html2canvas.js:3644:1)
    at new ElementContainer (html2canvas.js:3796:1)
    at createContainer (html2canvas.js:4793:1)
    at parseNodeTree (html2canvas.js:4739:1)
    at parseTree (html2canvas.js:4798:1)
    at html2canvas.js:7783:1
    at step (html2canvas.js:86:1)
    at Object.next (html2canvas.js:67:1)
```
Trying to debug it, it seems like the library doesn't support some color functions like `srgb` `sgba` etc that we started to use.

You can reproduce it on [this branch](https://github.com/metabase/metabase/pull/44463) by going to a public dashboard and trying to export it as pdf.

The original `html2canvas` has not been updated in two years: https://www.npmjs.com/package/html2canvas

The solution on [this issues](https://github.com/niklasvh/html2canvas/issues/2700) seems to be moving to [html2canvas-pro](https://www.npmjs.com/package/html2canvas-pro) which is a more maintained fork that supports the `color` function(s?).


### How to verify

Everything should work as before.
