### PR TITLE
fix: one of migrations was removed and that causes problems on downgrade

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -7917,6 +7917,14 @@ databaseChangeLog:
                   defaultValue: null
 
   - changeSet:
+      id: v50.2024-06-28T12:35:50
+      author: piranha
+      comment: 'Clean databasechangelog table of migration that was once deleted'
+      changes:
+        - sql: "DELETE FROM ${databasechangelog.name} WHERE id = 'v50.2024-04-12T12:33:09'"
+      rollback: # nothing to do here
+
+  - changeSet:
       id: v51.2024-05-13T15:30:57
       author: metamben
       comment: Backup of dataset_query rewritten by the metrics v2 migration
@@ -8013,6 +8021,8 @@ databaseChangeLog:
 #    - If you still need to, make sure it works when Metabase is encrypted. Fields like `metabase_database.details`
 #      or `setting.value` can be encrypted, so you need to decrypt them in your migration. See #42617, #44048.
 #    - Prefer SQL migrations over custom migrations.
+#    - Still, make sure your migration is backward compatible: it might not be possible to add a constraint back
+#      if you are dropping it in a migration.
 #    - Postgres, MySQL and H2 have their differences. Make sure your migration works for all.
 #    - Custom migrations and their tests demand a high level of reliability. They should only use code from the standard library.
 #      Requiring code from the Metabase codebase is a bad idea because it can change and break your migration.

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -17,6 +17,7 @@
    [metabase.config :as config]
    [metabase.db :as mdb]
    [metabase.db.custom-migrations-test :as custom-migrations-test]
+   [metabase.db.liquibase :as liquibase]
    [metabase.db.query :as mdb.query]
    [metabase.db.schema-migrations-test.impl :as impl]
    [metabase.models
@@ -1591,6 +1592,25 @@
                             :min_duration_ms 123}}
                   (-> (t2/select-one :cache_config)
                       (update :config json/decode true)))))))))
+
+(deftest cache-config-old-id-cleanup
+  (testing "Cache config migration old id is removed from databasechangelog"
+    (impl/test-migrations ["v50.2024-06-28T12:35:50"] [migrate!]
+      (let [clog       (keyword (liquibase/changelog-table-name (mdb/data-source)))
+            last-order (:orderexecuted (t2/select-one clog {:order-by [[:orderexecuted :desc]]}))]
+        (t2/insert! clog [{:id            "v50.2024-04-12T12:33:09"
+                           :author        "piranha"
+                           :filename      "001_update_migrations.yaml"
+                           :dateexecuted  :%now
+                           :orderexecuted (inc last-order)
+                           :exectype      "EXECUTED"}])
+
+        (is (=? {:id            "v50.2024-04-12T12:33:09"
+                 :orderexecuted pos?}
+                (t2/select-one clog :id "v50.2024-04-12T12:33:09")))
+
+        (migrate!)
+        (is (nil? (t2/select-one clog :id "v50.2024-04-12T12:33:09")))))))
 
 (deftest split-data-permissions-migration-test
   (testing "View Data and Create Query permissions are created correctly based on existing data permissions"


### PR DESCRIPTION
[Context here](https://github.com/metabase/metabase/issues/44784#issuecomment-2195483705), one of issues solved was that a previously existing migration prevented older version from starting up.