### PR TITLE
Repro #27521 - Query fails when selecting two fields from nested query, when fields are identical except for their join-alias

### DIFF
--- a/e2e/test/scenarios/joins/joins-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins-reproductions.cy.spec.js
@@ -5,7 +5,6 @@ import {
   assertQueryBuilderRowCount,
   popover,
   restore,
-  modal,
   selectSavedQuestionsToJoin,
   startNewQuestion,
   visualize,
@@ -27,6 +26,7 @@ import {
   echartsContainer,
   join,
   newButton,
+  saveQuestion,
 } from "e2e/support/helpers";
 
 const {
@@ -1181,10 +1181,7 @@ describe.skip("issue 27521", () => {
     assertTableHeader(0, "ID");
     assertTableHeader(1, "Orders → ID");
 
-    cy.button("Save").click();
-    cy.findByLabelText("Name").clear().type("Q1");
-    modal().button("Save").click();
-    modal().findByText("Not now").click();
+    saveQuestion("Q1");
 
     assertTableHeader(0, "ID");
     assertTableHeader(1, "Orders → ID");

--- a/e2e/test/scenarios/joins/joins-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins-reproductions.cy.spec.js
@@ -1139,6 +1139,7 @@ describe("issue 39448", () => {
   });
 });
 
+// See TODO inside this test when unskipping
 describe.skip("issue 27521", () => {
   beforeEach(() => {
     restore();
@@ -1229,6 +1230,9 @@ describe.skip("issue 27521", () => {
       cy.findByRole("button", { name: "Add or remove columns" }).click();
       cy.findAllByText("ID").should("have.length", 2);
       cy.findAllByText("Orders → ID").should("have.length", 1);
+
+      // TODO: add assertions for what happens when toggling all the columns here
+      // See https://github.com/metabase/metabase/issues/27521#issuecomment-1948658757
     });
   });
 

--- a/e2e/test/scenarios/joins/joins-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins-reproductions.cy.spec.js
@@ -1150,11 +1150,7 @@ describe.skip("issue 27521", () => {
     cy.visit("/");
 
     cy.log("Create Q1");
-    newButton("Question").click();
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Tables").click();
-      cy.findByText("Orders").click();
-    });
+    openOrdersTable({ mode: "notebook" });
 
     getNotebookStep("data").button("Pick columns").click();
     popover().findByText("Select none").click();

--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -529,9 +529,13 @@ describe.skip("issue 40635", () => {
   });
 
   function assertVisualizationColumns() {
-    cy.findAllByTestId("header-cell").should("contain", "ID");
-    cy.findAllByTestId("header-cell").should("contain", "Products → ID");
-    cy.findAllByTestId("header-cell").should("contain", "Products_2 → ID");
+    assertTableHeader(0, "ID");
+    assertTableHeader(1, "Products → ID");
+    assertTableHeader(2, "Products_2 → ID");
+  }
+
+  function assertTableHeader(index: number, name: string) {
+    cy.findAllByTestId("header-cell").eq(index).should("have.text", name);
   }
 
   function assertSettingsSidebar() {


### PR DESCRIPTION
Repro for #27521

The column names are still incorrect (multiple assertions in this test) and toggling the columns does not work.

![image](https://github.com/metabase/metabase/assets/6830683/2ebb5bc7-850b-4c71-8df0-d6269083bfd1)
