### PR TITLE
fix(sdk): List breakouts in SummarizeSidebar even if there are no aggregations

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/components/Summarize.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/components/Summarize.tsx
@@ -31,7 +31,8 @@ const SummarizeInner = ({
   onClose: () => void;
 }) => {
   const {
-    aggregations,
+    query,
+    stageIndex,
     handleAddAggregations,
     handleAddBreakout,
     handleRemoveAggregation,
@@ -39,8 +40,6 @@ const SummarizeInner = ({
     handleReplaceBreakouts,
     handleUpdateAggregation,
     handleUpdateBreakout,
-    hasAggregations,
-    query,
   } = useSummarizeQuery(question.query(), onQueryChange);
 
   return (
@@ -48,8 +47,7 @@ const SummarizeInner = ({
       <Button onClick={onClose}>Close</Button>
       <SummarizeContent
         query={query}
-        aggregations={aggregations}
-        hasAggregations={hasAggregations}
+        stageIndex={stageIndex}
         onAddAggregations={handleAddAggregations}
         onUpdateAggregation={handleUpdateAggregation}
         onRemoveAggregation={handleRemoveAggregation}

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/AggregationItem/AggregationItem.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/AggregationItem/AggregationItem.tsx
@@ -7,10 +7,9 @@ import { AggregationPicker } from "../SummarizeSidebar.styled";
 
 import { AggregationName, RemoveIcon, Root } from "./AggregationItem.styled";
 
-const STAGE_INDEX = -1;
-
 interface AggregationItemProps {
   query: Lib.Query;
+  stageIndex: number;
   aggregation: Lib.AggregationClause;
   aggregationIndex: number;
   onAdd: (aggregations: Lib.Aggregable[]) => void;
@@ -20,6 +19,7 @@ interface AggregationItemProps {
 
 export function AggregationItem({
   query,
+  stageIndex,
   aggregation,
   aggregationIndex,
   onAdd,
@@ -27,10 +27,10 @@ export function AggregationItem({
   onRemove,
 }: AggregationItemProps) {
   const [isOpened, setIsOpened] = useState(false);
-  const { displayName } = Lib.displayInfo(query, STAGE_INDEX, aggregation);
+  const { displayName } = Lib.displayInfo(query, stageIndex, aggregation);
 
   const operators = Lib.selectedAggregationOperators(
-    Lib.availableAggregationOperators(query, STAGE_INDEX),
+    Lib.availableAggregationOperators(query, stageIndex),
     aggregation,
   );
 
@@ -49,7 +49,7 @@ export function AggregationItem({
       <Popover.Dropdown>
         <AggregationPicker
           query={query}
-          stageIndex={STAGE_INDEX}
+          stageIndex={stageIndex}
           clause={aggregation}
           clauseIndex={aggregationIndex}
           operators={operators}

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeContent/SummarizeContent.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeContent/SummarizeContent.tsx
@@ -15,8 +15,7 @@ import { STAGE_INDEX } from "./use-summarize-query";
 
 export type SummarizeContentProps = {
   query: Lib.Query;
-  aggregations: Lib.AggregationClause[];
-  hasAggregations: boolean;
+  stageIndex: number;
   onAddAggregations: (aggregations: Lib.Aggregable[]) => void;
   onUpdateAggregation: (
     aggregation: Lib.AggregationClause,
@@ -34,8 +33,7 @@ export type SummarizeContentProps = {
 
 export const SummarizeContent = ({
   query,
-  aggregations,
-  hasAggregations,
+  stageIndex,
   onAddAggregations,
   onUpdateAggregation,
   onRemoveAggregation,
@@ -44,6 +42,11 @@ export const SummarizeContent = ({
   onRemoveBreakout,
   onReplaceBreakouts,
 }: SummarizeContentProps) => {
+  const aggregations = Lib.aggregations(query, stageIndex);
+  const breakouts = Lib.breakouts(query, stageIndex);
+  const hasAggregations = aggregations.length > 0;
+  const hasBreakouts = breakouts.length > 0;
+
   return (
     <>
       <AggregationsContainer>
@@ -53,6 +56,7 @@ export const SummarizeContent = ({
               Lib.displayInfo(query, STAGE_INDEX, aggregation).longDisplayName
             }
             query={query}
+            stageIndex={stageIndex}
             aggregation={aggregation}
             aggregationIndex={aggregationIndex}
             onAdd={onAddAggregations}
@@ -67,11 +71,13 @@ export const SummarizeContent = ({
           onAddAggregations={onAddAggregations}
         />
       </AggregationsContainer>
-      {hasAggregations && (
+      {(hasAggregations || hasBreakouts) && (
         <ColumnListContainer>
           <SectionTitle>{t`Group by`}</SectionTitle>
           <BreakoutColumnList
             query={query}
+            stageIndex={stageIndex}
+            breakouts={breakouts}
             onAddBreakout={onAddBreakout}
             onUpdateBreakout={onUpdateBreakout}
             onRemoveBreakout={onRemoveBreakout}

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeContent/use-summarize-query.ts
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeContent/use-summarize-query.ts
@@ -3,6 +3,7 @@ import { useCallback, useMemo, useState } from "react";
 import * as Lib from "metabase-lib";
 
 export const STAGE_INDEX = -1;
+
 export const useSummarizeQuery = (
   initialQuery: Lib.Query,
   onQueryChange: (query: Lib.Query) => void,
@@ -14,9 +15,6 @@ export const useSummarizeQuery = (
     () => getQuery(initialQuery, isDefaultAggregationRemoved),
     [initialQuery, isDefaultAggregationRemoved],
   );
-
-  const aggregations = Lib.aggregations(query, STAGE_INDEX);
-  const hasAggregations = aggregations.length > 0;
 
   const handleAddAggregations = useCallback(
     (aggregations: Lib.Aggregable[]) => {
@@ -92,8 +90,7 @@ export const useSummarizeQuery = (
   );
   return {
     query,
-    aggregations,
-    hasAggregations,
+    stageIndex: STAGE_INDEX,
     handleAddAggregations,
     handleUpdateAggregation,
     handleRemoveAggregation,

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.tsx
@@ -23,8 +23,7 @@ export function SummarizeSidebar({
 }: SummarizeSidebarProps) {
   const {
     query,
-    aggregations,
-    hasAggregations,
+    stageIndex,
     handleAddAggregations,
     handleUpdateAggregation,
     handleRemoveAggregation,
@@ -48,8 +47,7 @@ export function SummarizeSidebar({
     >
       <SummarizeContent
         query={query}
-        aggregations={aggregations}
-        hasAggregations={hasAggregations}
+        stageIndex={stageIndex}
         onAddAggregations={handleAddAggregations}
         onUpdateAggregation={handleUpdateAggregation}
         onRemoveAggregation={handleRemoveAggregation}

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.unit.spec.tsx
@@ -179,13 +179,6 @@ describe("SummarizeSidebar", () => {
     );
   });
 
-  it("shouldn't list breakout columns without an aggregation", async () => {
-    await setup({ withDefaultAggregation: false });
-
-    expect(screen.queryByText("Group by")).not.toBeInTheDocument();
-    expect(screen.queryAllByTestId("dimension-list-item").length).toBe(0);
-  });
-
   it("should allow searching breakout columns", async () => {
     await setup();
 
@@ -315,7 +308,22 @@ describe("SummarizeSidebar", () => {
     expect(breakout2.displayName).toBe("Quantity: Auto binned");
   });
 
-  it("should list breakouts if there are available but all aggregations are removed", async () => {
+  it("should list breakouts if there are initially available and a custom aggregation is removed", async () => {
+    await setup({ card: createSummarizedCard() });
+
+    await userEvent.click(
+      within(screen.getByLabelText("Max of Quantity")).getByLabelText(/close/),
+    );
+    expect(screen.queryByLabelText(/Max of Quantity/)).not.toBeInTheDocument();
+    expect(screen.getByText("Group by")).toBeInTheDocument();
+    expect(screen.getByLabelText("Product → Category")).toBeInTheDocument();
+    expect(screen.getByLabelText("Product → Category")).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("should list breakouts if there are added after the sidebar is opened and the default aggregation is removed", async () => {
     await setup();
 
     await userEvent.click(screen.getByText("Category"));

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.unit.spec.tsx
@@ -9,14 +9,14 @@ import Question from "metabase-lib/v1/Question";
 import type { Card, UnsavedCard } from "metabase-types/api";
 import { createMockCard } from "metabase-types/api/mocks";
 import {
+  createAdHocCard,
+  createSampleDatabase,
   ORDERS,
   ORDERS_ID,
   PEOPLE_ID,
   PRODUCTS,
   PRODUCTS_ID,
   SAMPLE_DB_ID,
-  createAdHocCard,
-  createSampleDatabase,
 } from "metabase-types/api/mocks/presets";
 import {
   createMockQueryBuilderState,
@@ -313,6 +313,33 @@ describe("SummarizeSidebar", () => {
     const [breakout1, breakout2] = getNextBreakouts();
     expect(breakout1.displayName).toBe("Category");
     expect(breakout2.displayName).toBe("Quantity: Auto binned");
+  });
+
+  it("should list breakouts if there are available but all aggregations are removed", async () => {
+    await setup();
+
+    await userEvent.click(screen.getByText("Category"));
+    expect(screen.getByLabelText("Category")).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+
+    await userEvent.click(
+      within(screen.getByLabelText("Count")).getByLabelText(/close/),
+    );
+    expect(screen.queryByLabelText(/Count/)).not.toBeInTheDocument();
+    expect(screen.getByText("Group by")).toBeInTheDocument();
+    expect(screen.getByLabelText("Category")).toBeInTheDocument();
+    expect(screen.getByLabelText("Category")).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+
+    await userEvent.click(
+      within(screen.getByLabelText("Category")).getByLabelText(/close/),
+    );
+    expect(screen.queryByText("Group by")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Category")).not.toBeInTheDocument();
   });
 
   it("should allow picking a temporal bucket for breakout columns", async () => {


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/29172
Demo https://www.loom.com/share/9ffb9c8c58eb48acaa7ed2c41525cd61

Changes:
- In the summarize sidebar, when there are breakouts but no aggregations, display the breakouts and not an empty sidebar.
- When the sidebar is opened, do not add "Count" by default if there breakouts

<img width="385" alt="Screenshot 2024-06-28 at 11 25 58" src="https://github.com/metabase/metabase/assets/8542534/d82f7130-d2b5-4ff4-a995-141612c8a873">
