### PR TITLE
Revert: Fix appends for long column names

### DIFF
--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -963,16 +963,6 @@
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)
 
-(defmulti column-name-length-limit
-  "Return the maximum number of characters allowed in a column name, or `nil` if there is no limit."
-  {:changelog-test/ignore true, :added "0.49.19", :arglists '([driver])}
-  dispatch-on-initialized-driver
-  :hierarchy #'hierarchy)
-
-(defmethod column-name-length-limit :default [driver]
-  ;; For most databases, the same limit is used for all identifier types.
-  (table-name-length-limit driver))
-
 (defmulti create-table!
   "Create a table named `table-name`. If the table already exists it will throw an error.
   `args` is an optional map with an optional entry `primary-key`. The `primary-key` value is a vector of column names

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -133,9 +133,8 @@
   "Calls detect-schema on rows from a CSV file. `rows` is a vector of strings"
   [rows]
   (with-open [reader (io/reader (csv-file-with rows))]
-    (let [[header & rows] (csv/read-csv reader)
-          column-names (#'upload/derive-column-names nil header)]
-      (#'upload/detect-schema (upload-parsing/get-settings) column-names rows))))
+    (let [[header & rows] (csv/read-csv reader)]
+      (#'upload/detect-schema (upload-parsing/get-settings) header rows))))
 
 (deftest ^:parallel detect-schema-test
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
@@ -1993,69 +1992,3 @@
             (is (= [false] (mapv :active (t2/select :model/Table :id (:id table)))))
             (testing "We do not clean up any of the child resources synchronously (yet?)"
               (is (seq (t2/select :model/Field :table_id (:id table)))))))))))
-
-(deftest create-csv-from-really-long-names
-  (testing "Upload a CSV file with unique column names that get sanitized to the same string"
-    (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
-      (with-mysql-local-infile-on-and-off
-       (let [long-string (str (str/join (repeat 1000 "really_")) "long")]
-         (with-upload-table!
-           [table (create-from-csv-and-sync-with-defaults!
-                   :file (csv-file-with [(str (str "a_" long-string ",")
-                                              (str "b_" long-string ",")
-                                              (str "b_" long-string "_with_a"))
-                                         "a,b1,b2"]))]
-           (testing "Table and Fields exist after sync"
-             (testing "Check the data was uploaded into the table correctly"
-               (let [column-names (column-names-for-table table)]
-                 (is (=  @#'upload/auto-pk-column-name (first column-names)))
-                 (is (= 4 (count (distinct column-names))))
-                 (is (= 1 (count (filter #(str/starts-with? % "a_") column-names))))
-                 (is (= 2 (count (filter #(str/starts-with? % "b_") column-names)))))))))))))
-
-(deftest append-with-really-long-names
-  (testing "Upload a CSV file with unique column names that get sanitized to the same string"
-    (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
-      (with-mysql-local-infile-on-and-off
-       (let [long-string  (str (str/join (repeat 1000 "really_")) "long")
-             header       (str (str "a_" long-string ",")
-                               (str "b_" long-string))
-             original-row "a,b"
-             appended-row "A,B"]
-         (with-upload-table!
-           [table (create-from-csv-and-sync-with-defaults!
-                   :file (csv-file-with [header original-row]))]
-           (let [csv-rows [header appended-row]
-                 file     (csv-file-with csv-rows (mt/random-name))]
-             (is (= {:row-count 1}
-                    (update-csv! ::upload/append {:file file, :table-id (:id table)})))
-             (testing "Check the data was appended into the table"
-               (is (= (map second (rows-with-auto-pk
-                                   [(csv/read-csv original-row)
-                                    (csv/read-csv appended-row)]))
-                      (map rest (rows-for-table table)))))
-             (io/delete-file file))))))))
-
-(deftest append-with-really-long-names-that-duplicate
-  (testing "Upload a CSV file with unique column names that get sanitized to the same string"
-    (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
-      (with-mysql-local-infile-on-and-off
-       (let [long-string  (str (str/join (repeat 1000 "really_")) "long")
-             header       (str (str "a_" long-string ",")
-                               (str "b_" long-string ",")
-                               (str "b_" long-string "_with_a"))
-             original-row "a,b1,b2"
-             appended-row "A,B1,B2"]
-         (with-upload-table!
-           [table (create-from-csv-and-sync-with-defaults!
-                   :file (csv-file-with [header original-row]))]
-           (let [csv-rows [header appended-row]
-                 file     (csv-file-with csv-rows (mt/random-name))]
-             ;; TODO: we should be able to make this work with smarter truncation
-             (is (= {:message "The CSV file contains duplicate column names."
-                     :data    {:status-code 422}}
-                    (catch-ex-info (update-csv! ::upload/append {:file file, :table-id (:id table)}))))
-             (testing "Check the data was not uploaded into the table"
-               (is (= (map second (rows-with-auto-pk [(csv/read-csv original-row)]))
-                      (map rest (rows-for-table table)))))
-             (io/delete-file file))))))))


### PR DESCRIPTION
This reverts https://github.com/metabase/metabase/pull/44727.

Introducing the buffer was a breaking change, meaning that tables created before this change would *never* support appending to in the future. 

It's better to defer fixing appends for new uploads one more release, rather than making it so that we will never be able to append to these older tables.