### PR TITLE
Lock down the Trash collection

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -549,10 +549,6 @@
         is-model-after-update? (if (nil? type)
                                  (card/model? card-before-update)
                                  (card/model? card-updates))]
-    ;; Can't move a card to the trash
-    (when (and collection_id (= collection_id (collection/trash-collection-id)))
-      (throw (ex-info (tru "Cannot move a card to the trash collection.")
-                      {:status-code 400})))
     ;; Do various permissions checks
     (doseq [f [collection/check-allowed-to-change-collection
                check-allowed-to-modify-query

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -1077,6 +1077,9 @@
   "Check that you're allowed to write Collection with `collection-id`; if `collection-id` is `nil`, check that you have
   Root Collection perms."
   [collection-id collection-namespace]
+  (when (collection/is-trash? collection-id)
+    (throw (ex-info (tru "You cannot modify the Trash Collection.")
+                    {:status-code 400})))
   (api/write-check (if collection-id
                      (t2/select-one Collection :id collection-id)
                      (cond-> collection/root-collection

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -770,10 +770,6 @@
           dash-updates                       (api/updates-with-archived-directly current-dash dash-updates)]
       (collection/check-allowed-to-change-collection current-dash dash-updates)
       (check-allowed-to-change-embedding current-dash dash-updates)
-      ;; Can't move things to the Trash.
-      (when (some-> dash-updates :collection_id (= (collection/trash-collection-id)))
-        (throw (ex-info (tru "Cannot move a card to the trash collection.")
-                        {:status-code 400})))
       (api/check-500
         (do
           (t2/with-transaction [_conn]

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -199,7 +199,7 @@
            (mt/user-http-request :crowberto :post 400 "dashboard" {:name       "Test"
                                                                    :parameters "abc"})))))
 
-(def ^:private dashboard-defaults
+(def dashboard-defaults
   {:archived                false
    :caveats                 nil
    :collection_id           nil

--- a/test/metabase/api/pulse_test.clj
+++ b/test/metabase/api/pulse_test.clj
@@ -158,7 +158,7 @@
         (dissoc :id :pulse_id :created_at :updated_at)
         (update :entity_id boolean))))
 
-(def ^:private pulse-defaults
+(def pulse-defaults
   {:collection_id       nil
    :collection_position nil
    :created_at          true

--- a/test/metabase/api/trash_test.clj
+++ b/test/metabase/api/trash_test.clj
@@ -1,0 +1,93 @@
+(ns metabase.api.trash-test
+  (:require  [clojure.test :refer [deftest testing is]]
+             [metabase.api.card-test :refer [card-with-name-and-query]]
+             [metabase.api.dashboard-test :refer [dashboard-defaults]]
+             [metabase.models.collection :as collection]
+             [metabase.test :as mt]))
+
+(deftest cannot-create-in-trash
+  (testing "Cannot create a card in the trash"
+    (is (= "You cannot modify the Trash Collection."
+           (mt/user-http-request :crowberto :post 400 "card" (assoc (card-with-name-and-query)
+                                                                    :collection_id (collection/trash-collection-id))))))
+  (testing "Cannot create a dashboard in the trash"
+    (is (= "You cannot modify the Trash Collection."
+           (mt/user-http-request :crowberto :post 400 "dashboard" (assoc dashboard-defaults
+                                                                         :name "Dashboard in trash"
+                                                                         :collection_id (collection/trash-collection-id))))))
+  (testing "Cannot create a pulse in the trash"
+    (mt/with-temp [:model/Card {card-id :id} {}]
+      (let [payload {:name          "A Pulse"
+                     :collection_id (collection/trash-collection-id)
+                     :cards         [{:id                card-id
+                                      :include_csv       false
+                                      :include_xls       false
+                                      :dashboard_card_id nil}]
+                     :channels      [{:enabled       true
+                                      :channel_type  "email"
+                                      :schedule_type "daily"
+                                      :schedule_hour 12
+                                      :schedule_day  nil
+                                      :recipients    []}]
+                     :skip_if_empty false
+                     :parameters    [{:id "abc123" :name "test" :type "date"}]}]
+        (mt/with-model-cleanup [:model/Pulse]
+          (is (= "You cannot modify the Trash Collection."
+                 (mt/user-http-request :rasta :post 400 "pulse" payload)))))))
+  (testing "Cannot create a collection in the trash"
+    (is (= "You cannot modify the Trash Collection."
+           (mt/user-http-request :crowberto :post 400 "collection" {:name      "Collection in trash"
+                                                                    :parent_id (collection/trash-collection-id)}))))
+  (testing "Cannot create a native query snippet in the trash"
+    (is (mt/user-http-request :crowberto :post 400 "native-query-snippet" {:name          "Snippet in trash"
+                                                                           :content       "SELECT 1"
+                                                                           :collection_id (collection/trash-collection-id)})))
+  (testing "Cannot create a timeline in the trash"
+    (is (= "You cannot modify the Trash Collection."
+           (mt/user-http-request :crowberto :post 400 "timeline" {:name          "Timeline in trash"
+                                                                  :default       false
+                                                                  :creator_id    (mt/user->id :crowberto)
+                                                                  :collection_id (collection/trash-collection-id)})))))
+
+(deftest cannot-move-to-trash
+  (testing "Cannot move a card to the trash"
+    (let [{id :id} (mt/user-http-request :crowberto :post 200 "card" (card-with-name-and-query))]
+      (is (= "You cannot modify the Trash Collection."
+             (mt/user-http-request :crowberto :put 400 (str "card/" id) {:collection_id (collection/trash-collection-id)})))))
+  (testing "Cannot move a dashboard to the trash"
+    (let [{id :id} (mt/user-http-request :crowberto :post 200 "dashboard" (assoc dashboard-defaults :name "Dashboard in trash"))]
+      (is (= "You cannot modify the Trash Collection."
+             (mt/user-http-request :crowberto :put 400 (str "dashboard/" id) {:collection_id (collection/trash-collection-id)})))))
+  (testing "Cannot move a pulse to the trash"
+    (mt/with-temp [:model/Card       {card-id :id}                       {}
+                   :model/Dashboard  {dashboard-id :id} {:name "Birdcage KPIs"}]
+      (let [payload {:name          "A Pulse"
+                     :cards         [{:id                card-id
+                                      :include_csv       false
+                                      :include_xls       false
+                                      :dashboard_card_id nil}]
+                     :channels      [{:enabled       true
+                                      :channel_type  "email"
+                                      :schedule_type "daily"
+                                      :schedule_hour 12
+                                      :schedule_day  nil
+                                      :recipients    []}]
+                     :dashboard_id  dashboard-id
+                     :skip_if_empty false
+                     :parameters    [{:id "abc123" :name "test" :type "date"}]}]
+        (mt/with-model-cleanup [:model/Pulse]
+          (let [{id :id} (mt/user-http-request :rasta :post 200 "pulse" payload)]
+            (is (= "You cannot modify the Trash Collection."
+                   (mt/user-http-request :rasta :put 400 (str "pulse/" id) {:collection_id (collection/trash-collection-id)}))))))))
+  (testing "Cannot move a a collection to the trash"
+    (let [{id :id} (mt/user-http-request :crowberto :post 200 "collection" {:name "Collection in trash"})]
+      (is (= "Invalid Request." (mt/user-http-request :crowberto :put 400 (str "collection/" id) {:parent_id (collection/trash-collection-id)})))))
+  (testing "Cannot move a native query snippet to the trash"
+    (let [{id :id} (mt/user-http-request :crowberto :post 200 "native-query-snippet" {:name    (str (random-uuid))
+                                                                                      :content "SELECT 1"})]
+      (is (mt/user-http-request :crowberto :put 400 (str "native-query-snippet/" id) {:collection_id (collection/trash-collection-id)}))))
+  (testing "Cannot move a timeline to the trash"
+    (let [{id :id} (mt/user-http-request :crowberto :post 200 "timeline" {:name       "Timeline in trash"
+                                                                          :default    false
+                                                                          :creator_id (mt/user->id :crowberto)})]
+      (is (= "You cannot modify the Trash Collection." (mt/user-http-request :crowberto :put 400 (str "timeline/" id) {:collection_id (collection/trash-collection-id)}))))))


### PR DESCRIPTION
Prevent anything from being moved to the trash, or created in the trash.

Fixes #44817