### PR TITLE
fix night theme png downloads

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.styled.tsx
@@ -1,6 +1,8 @@
 import { css, type Theme } from "@emotion/react";
 import styled from "@emotion/styled";
 
+import { SAVING_DOM_IMAGE_CLASS } from "metabase/visualizations/lib/save-chart-image";
+
 export interface DashCardRootProps {
   isNightMode: boolean;
   isUsuallySlow: boolean;
@@ -38,6 +40,11 @@ export const DashCardRoot = styled.div<DashCardRootProps>`
 
   ${({ shouldForceHiddenBackground }) =>
     shouldForceHiddenBackground && hiddenBackgroundStyle}
+
+  &.${SAVING_DOM_IMAGE_CLASS} {
+    border-radius: 0;
+    border: "none";
+  }
 `;
 
 export const VirtualDashCardOverlayRoot = styled.div`

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.styled.tsx
@@ -43,7 +43,7 @@ export const DashCardRoot = styled.div<DashCardRootProps>`
 
   &.${SAVING_DOM_IMAGE_CLASS} {
     border-radius: 0;
-    border: "none";
+    border: none;
   }
 `;
 

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.styled.tsx
@@ -43,7 +43,7 @@ export const DashCardRoot = styled.div<DashCardRootProps>`
 
   &.${SAVING_DOM_IMAGE_CLASS} {
     border-radius: 0;
-    border: none;
+    border: none !important;
   }
 `;
 

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
@@ -275,6 +275,7 @@ function DashCardInner({
     <ErrorBoundary>
       <DashCardRoot
         data-testid="dashcard"
+        data-dashcard-key={dashcard.id}
         className={cx(
           DashboardS.Card,
           EmbedFrameS.Card,

--- a/frontend/src/metabase/query_builder/actions/downloading.ts
+++ b/frontend/src/metabase/query_builder/actions/downloading.ts
@@ -43,9 +43,15 @@ export const downloadQueryResults =
     }
   };
 
-const downloadChart = async ({ question }: DownloadQueryResultsOpts) => {
+const downloadChart = async ({
+  question,
+  dashcardId,
+}: DownloadQueryResultsOpts) => {
   const fileName = getChartFileName(question);
-  const chartSelector = `[data-card-key='${getCardKey(question.id())}']`;
+  const chartSelector =
+    dashcardId != null
+      ? `[data-dashcard-key='${dashcardId}']`
+      : `[data-card-key='${getCardKey(question.id())}']`;
   await saveChartImage(chartSelector, fileName);
 };
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39546

### Description

When users export dashcards as PNGs on embedded dashboards with night theme the background style was missing so white text on white background looked like data was missing.

The PR is put on top of https://github.com/metabase/metabase/pull/44888 because PNG exports just failed completely when the night mode was enabled.

### How to verify

Try downloading PNGs of dashcards from static embedded dashboards with the night theme enabled:
<img width="1256" alt="Screenshot 2024-06-28 at 8 24 22 PM" src="https://github.com/metabase/metabase/assets/14301985/30bf5f32-892e-4a2c-85fb-173ff96d6bd4">
Ensure PNGs include the dark background 

### Demo

https://github.com/metabase/metabase/assets/14301985/29553363-9eef-4b68-be2c-da944f5f6cc5

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR — we have e2e tests that verify png downloads files exist
