### PR TITLE
Repro parameter field matching issues for questions based on sql models

### DIFF
--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -2589,6 +2589,7 @@ describe("issue 42829", () => {
     drillAndVerifyResults();
   });
 
+  // param_fields is null for public dashboards, should be fixed on the BE
   it.skip("should be able to get field values coming from a sql model-based question in a public dashboard (metabase#42829)", () => {
     cy.get("@dashboardId").then(dashboardId =>
       visitPublicDashboard(dashboardId),
@@ -2596,6 +2597,7 @@ describe("issue 42829", () => {
     filterAndVerifyResults();
   });
 
+  // param_fields is null for embedded dashboards, should be fixed on the BE
   it.skip("should be able to get field values coming from a sql model-based question in a embedded dashboard (metabase#42829)", () => {
     cy.get("@dashboardId").then(dashboardId =>
       visitEmbeddedPage({

--- a/frontend/src/metabase-lib/v1/parameters/utils/targets.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/targets.ts
@@ -103,7 +103,9 @@ export function getParameterTargetField(
       return null;
     }
 
-    return metadata.field(fieldValuesInfo.fieldId);
+    // do not use `metadata.field(id)` because it only works for fields loaded
+    // with the original table, not coming from model metadata
+    return fields.find(field => field.id === fieldValuesInfo.fieldId);
   }
 
   return null;


### PR DESCRIPTION
Fixes the FE part of https://github.com/metabase/metabase/issues/42829
Fix walkthrough https://www.loom.com/share/e731f5b38bea48809dc65d6551853cfc

The fix doesn't work for embedded or public dashboards because of `param_fields` not populated on the BE.

How to verify:
- New -> Model -> SQL -> `SELECT * FROM PRODUCTS` -> Run -> Save
- Edit metadata -> Select `CATEGORY` -> Set to `Products.Category` -> Save
- New -> Question -> Models -> Select this model, Summarize -> Number of distinct values -> `State`
- Add this question to a dashboard
- Filter -> Location -> Map this filter to `State` -> Save dashboard
- Click on the filter widget. You should see the field values (state short names)
- Make this dashboard public and open the filter widget
- See that there is a plain text input because there is a bug on the BE.