### PR TITLE
[notification] New method: `channel/can-connect?`

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -615,6 +615,8 @@
   metabase.api.common/defroutes                                                        clojure.core/def
   metabase.api.search-test/do-test-users                                               clojure.core/let
   metabase.async.api-response-test/with-response                                       clojure.core/let
+  metabase.channel.http-test/with-captured-http-requests                               clojure.core/fn
+  metabase.channel.http-test/with-server                                               clojure.core/let
   metabase.dashboard-subscription-test/with-dashboard-sub-for-card                     clojure.core/let
   metabase.db.custom-migrations/define-migration                                       clj-kondo.lint-as/def-catch-all
   metabase.db.custom-migrations/define-reversible-migration                            clj-kondo.lint-as/def-catch-all

--- a/.clj-kondo/src/hooks/clojure/test.clj
+++ b/.clj-kondo/src/hooks/clojure/test.clj
@@ -106,6 +106,7 @@
      clojure.core.async/take!
      clojure.core.async/to-chan!
      clojure.core.async/to-chan!!
+     metabase.channel.core/send!
      metabase.driver.sql-jdbc.execute/execute-prepared-statement!
      metabase.pulse/send-pulse!
      metabase.query-processor.store/store-database!

--- a/src/metabase/channel/core.clj
+++ b/src/metabase/channel/core.clj
@@ -26,9 +26,9 @@
 (defmulti send!
   "Send a message to a channel."
   {:added    "0.51.0"
-   :arglists '([channel-type message])}
-  (fn [channel-type _message]
-    channel-type))
+   :arglists '([channel message])}
+  (fn [channel _message]
+    (:type channel)))
 
 ;; ------------------------------------------------------------------------------------------------;;
 ;;                                             Utils                                               ;;

--- a/src/metabase/channel/core.clj
+++ b/src/metabase/channel/core.clj
@@ -13,6 +13,19 @@
 ;;                                      Channels methods                                           ;;
 ;; ------------------------------------------------------------------------------------------------;;
 
+(defmulti can-connect?
+  "Check whether we can connect to a `channel` with `detail`.
+
+  Returns `true` if we can connect to the channel.
+  Otherwise returns false or an errors map in which the key is the details key and value is the error message.
+  E.g:
+    (can-connect? :slack {:token \"invalid\"})
+    ;; => {:errors {:token \"Invalid token\"}}"
+  {:added    "0.51.0"
+   :arglists '([channel-type details])}
+  (fn [channel-type _details]
+    channel-type))
+
 (defmulti render-notification
   "Given a notification content, return a sequence of channel-specific messages.
 

--- a/src/metabase/channel/core.clj
+++ b/src/metabase/channel/core.clj
@@ -5,8 +5,8 @@
   (:require
    [metabase.plugins.classloader :as classloader]
    [metabase.util :as u]
-   [metabase.util.log :as log]
-   [metabase.util.malli.fn :as mu.fn]))
+   [metabase.util.log :as log]))
+
 
 (set! *warn-on-reflection* true)
 
@@ -14,7 +14,7 @@
 ;;                                      Channels methods                                           ;;
 ;; ------------------------------------------------------------------------------------------------;;
 
-(defmulti can-connect?*
+(defmulti can-connect?
   "Check whether we can connect to a `channel` with `detail`.
 
   Returns `true` if can connect to the channel, otherwise return faslsy or throw an appriopriate exception.
@@ -50,16 +50,6 @@
 ;; ------------------------------------------------------------------------------------------------;;
 ;;                                             Utils                                               ;;
 ;; ------------------------------------------------------------------------------------------------;;
-
-(defn can-connect?
-  [& args]
-  (try
-    (apply can-connect?* args)
-    (catch Exception e
-      (if (= ::mu.fn/invalid-input (-> e ex-data :type))
-        (throw (ex-info (ex-message e)
-                        {:errors (:humanized (ex-data e))}))
-        (throw e)))))
 
 (defn- find-and-load-metabase-channels!
   "Load namespaces that start with `metabase.channel."

--- a/src/metabase/channel/core.clj
+++ b/src/metabase/channel/core.clj
@@ -15,9 +15,9 @@
 ;; ------------------------------------------------------------------------------------------------;;
 
 (defmulti can-connect?
-  "Check whether we can connect to a `channel` with `detail`.
+  "Check whether we can connect to a `channel-type` with `detail`.
 
-  Returns `true` if can connect to the channel, otherwise return faslsy or throw an appriopriate exception.
+  Returns `true` if can connect to the channel, otherwise return falsy or throw an appropriate exception.
   In case of failure, to provide a field-specific error message on UI, return or throw an :errors map where key is the
   field name and value is the error message.
 

--- a/src/metabase/channel/email.clj
+++ b/src/metabase/channel/email.clj
@@ -47,7 +47,7 @@
     nil))
 
 (mu/defmethod channel/send! :channel/email
-  [_channel-type {:keys [subject recipients message-type message]} :- EmailMessage]
+  [_channel {:keys [subject recipients message-type message]} :- EmailMessage]
   (email/send-message-or-throw! {:subject      subject
                                  :recipients   recipients
                                  :message-type message-type
@@ -86,7 +86,7 @@
 ;; ------------------------------------------------------------------------------------------------;;
 
 (mu/defmethod channel/render-notification [:channel/email :notification/dashboard-subscription] :- [:sequential EmailMessage]
-  [_channel-details {:keys [dashboard payload pulse]} recipients]
+  [_channel-type {:keys [dashboard payload pulse]} recipients]
   (let [{:keys [user-emails
                 non-user-emails]} (recipients->emails recipients)
         timezone                  (some->> payload (some :card) channel.shared/defaulted-timezone)

--- a/src/metabase/channel/http.clj
+++ b/src/metabase/channel/http.clj
@@ -1,0 +1,31 @@
+(ns metabase.channel.http
+  (:require
+   [clj-http.client :as http]
+   [metabase.channel.core :as channel]
+   [metabase.util.malli :as mu]))
+
+(def ^:private string-or-keyword
+  [:or :string :keyword])
+
+(def ^:private HTTPPayLoad
+  [:map
+   [:url                           :string]
+   [:method                        [:enum :get :post :put :delete]]
+   [:query-params {:optional true} [:maybe [:map-of string-or-keyword string-or-keyword]]]
+   [:headers      {:optional true} [:maybe [:map-of string-or-keyword string-or-keyword]]]
+   [:body         {:optional true} :string]])
+
+(mu/defmethod channel/send! :channel/http
+  [{:keys [url method auth-method auth-info]} request]
+  (http/request (merge
+                 {:accept       :json
+                  :content-type :json
+                  :url          url
+                  :method       method}
+                 (cond-> request
+                   (= :header auth-method) (update :headers merge auth-info)
+                   (= :query-param auth-method) (update :query-params merge auth-info)))))
+
+(defmethod channel/can-connect? :channel/http
+  [_channel-type details]
+  (channel/send! (merge {:type :channel/http} details) nil))

--- a/src/metabase/channel/http.clj
+++ b/src/metabase/channel/http.clj
@@ -2,30 +2,36 @@
   (:require
    [clj-http.client :as http]
    [metabase.channel.core :as channel]
+   [metabase.channel.shared :as channel.shared]
    [metabase.util.malli :as mu]))
 
 (def ^:private string-or-keyword
   [:or :string :keyword])
 
-(def ^:private HTTPPayLoad
+(def ^:private HTTPDetails
   [:map
    [:url                           :string]
-   [:method                        [:enum :get :post :put :delete]]
-   [:query-params {:optional true} [:maybe [:map-of string-or-keyword string-or-keyword]]]
-   [:headers      {:optional true} [:maybe [:map-of string-or-keyword string-or-keyword]]]
+   [:auth-method                   [:enum :none :header :query-param :request-body]]
+   [:method       {:optional true} [:enum :get :post :put]]
+   [:query-params {:optional true} [:maybe [:map-of string-or-keyword :any]]]
+   [:headers      {:optional true} [:maybe [:map-of string-or-keyword :any]]]
    [:body         {:optional true} :string]])
 
 (mu/defmethod channel/send! :channel/http
-  [{:keys [url method auth-method auth-info]} request]
+  [{:keys [url method auth-method auth-info]} :- HTTPDetails
+   request]
   (http/request (merge
                  {:accept       :json
                   :content-type :json
-                  :url          url
-                  :method       method}
+                  :method       :post}
+                 {:url    url
+                  :method method}
                  (cond-> request
-                   (= :header auth-method) (update :headers merge auth-info)
-                   (= :query-param auth-method) (update :query-params merge auth-info)))))
+                   (= :request-body auth-method) (update :body merge auth-info)
+                   (= :header auth-method)       (update :headers merge auth-info)
+                   (= :query-param auth-method)  (update :query-params merge auth-info)))))
 
-(defmethod channel/can-connect? :channel/http
+(defmethod channel/can-connect?* :channel/http
   [_channel-type details]
-  (channel/send! (merge {:type :channel/http} details) nil))
+  (channel.shared/validate-channel-details HTTPDetails details)
+  (channel/send! (merge {:type :channel/http} details) {}))

--- a/src/metabase/channel/http.clj
+++ b/src/metabase/channel/http.clj
@@ -3,14 +3,16 @@
    [clj-http.client :as http]
    [metabase.channel.core :as channel]
    [metabase.channel.shared :as channel.shared]
-   [metabase.util.malli :as mu]))
+   [metabase.util.i18n :refer [tru]]
+   [metabase.util.malli :as mu]
+   [metabase.util.malli.schema :as ms]))
 
 (def ^:private string-or-keyword
   [:or :string :keyword])
 
 (def ^:private HTTPDetails
   [:map
-   [:url                           :string]
+   [:url                           ms/Url]
    [:auth-method                   [:enum :none :header :query-param :request-body]]
    [:method       {:optional true} [:enum :get :post :put]]
    [:query-params {:optional true} [:maybe [:map-of string-or-keyword :any]]]
@@ -31,7 +33,13 @@
                    (= :header auth-method)       (update :headers merge auth-info)
                    (= :query-param auth-method)  (update :query-params merge auth-info)))))
 
-(defmethod channel/can-connect?* :channel/http
+(defmethod channel/can-connect? :channel/http
   [_channel-type details]
   (channel.shared/validate-channel-details HTTPDetails details)
-  (channel/send! (merge {:type :channel/http} details) {}))
+  (try
+    (channel/send! (merge {:type :channel/http} details) {})
+    true
+    (catch Exception e
+      (let [data (ex-data e)]
+        (throw (ex-info (tru "Failed to connect to channel") {:request-status (:status data)
+                                                              :request-body   (:body data)}))))))

--- a/src/metabase/channel/shared.clj
+++ b/src/metabase/channel/shared.clj
@@ -1,6 +1,9 @@
 (ns metabase.channel.shared
   (:require
+   [malli.core :as mc]
+   [malli.error :as me]
    [metabase.query-processor.timezone :as qp.timezone]
+   [metabase.util.i18n :refer [tru]]
    [metabase.util.malli :as mu]
    [toucan2.core :as t2]))
 
@@ -9,3 +12,11 @@
   [card]
   (or (some->> card :database_id (t2/select-one :model/Database :id) qp.timezone/results-timezone-id)
       (qp.timezone/system-timezone-id)))
+
+(defn validate-channel-details
+  "Validate a value against a schema and throw an exception if it's invalid.
+  The :errors key are used on the UI to display field-specific error messages."
+  [schema value]
+  (when-let [errors (some-> (mc/explain schema value)
+                            me/humanize)]
+    (throw (ex-info (tru "Invalid channel details") {:errors errors}))))

--- a/src/metabase/channel/slack.clj
+++ b/src/metabase/channel/slack.clj
@@ -87,7 +87,7 @@
    [:message     {:optional true} [:maybe :string]]])
 
 (mu/defmethod channel/send! :channel/slack
-  [_channel-type message :- SlackMessage]
+  [_channel message :- SlackMessage]
   (let [{:keys [channel-id attachments]} message]
     (slack/post-chat-message! channel-id nil (create-and-upload-slack-attachments! attachments))))
 
@@ -96,7 +96,7 @@
 ;; ------------------------------------------------------------------------------------------------;;
 
 (mu/defmethod channel/render-notification [:channel/slack :notification/alert] :- [:sequential SlackMessage]
-  [_channel-details {:keys [payload card]} channel-ids]
+  [_channel-type {:keys [payload card]} channel-ids]
   (let [attachments [{:blocks [{:type "header"
                                 :text {:type "plain_text"
                                        :text (str "🔔 " (:name card))

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -303,13 +303,13 @@
         (u/prog1 (doseq [channel channels]
                    (try
                      (let [channel-type (if (= :email (keyword (:channel_type channel)))
-                                          :channel/email
-                                          :channel/slack)
+                                            :channel/email
+                                            :channel/slack)
                            messages     (channel/render-notification channel-type
                                                                      (get-notification-info pulse parts channel)
                                                                      (channels-to-channel-recipients channel))]
                        (doseq [message messages]
-                         (send-retrying! channel-type message)))
+                         (send-retrying! {:type channel-type} message)))
                      (catch Exception e
                        (log/errorf e "Error sending %s %d to channel %s" (alert-or-pulse pulse) (:id pulse) (:channel_type channel)))))
           (when (:alert_first_only pulse)

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -261,7 +261,7 @@
     (apply channel/send! args)
     (catch Exception e
       ;; Token errors have already been logged and we should not retry.
-      (when-not (and (= :channel/slack (first args))
+      (when-not (and (= :channel/slack (:type (first args)))
                      (contains? (:errors (ex-data e)) :slack-token))
         (throw e)))))
 

--- a/src/metabase/util/malli/schema.clj
+++ b/src/metabase/util/malli/schema.clj
@@ -196,6 +196,12 @@
      [:fn u/email?]]
     (deferred-tru "value must be a valid email address.")))
 
+(def Url
+  "Schema for a valid URL string."
+  (mu/with-api-error-message
+    [:fn u/url?]
+    (deferred-tru "value must be a valid URL.")))
+
 (def ValidPassword
   "Schema for a valid password of sufficient complexity which is not found on a common password list."
   (mu/with-api-error-message

--- a/test/metabase/channel/email_test.clj
+++ b/test/metabase/channel/email_test.clj
@@ -14,9 +14,9 @@
                                            email-smtp-host    " ake_smtp_host"
                                            email-smtp-port    587
                                            bcc-enabled?       false]
-          (channel/send! :channel/email {:subject      "Test"
-                                         :recipients   ["ngoc@metabase.com"]
-                                         :message-type :html
-                                         :message      "Test message"})
+          (channel/send! {:type :channel/email} {:subject      "Test"
+                                                 :recipients   ["ngoc@metabase.com"]
+                                                 :message-type :html
+                                                 :message      "Test message"})
           (is (=? {:to ["ngoc@metabase.com"]}
                   @sent-message)))))))

--- a/test/metabase/channel/http_test.clj
+++ b/test/metabase/channel/http_test.clj
@@ -1,0 +1,107 @@
+(ns metabase.channel.http-test
+  (:require
+   [clj-http.client :as http]
+   [clojure.test :refer :all]
+   [metabase.channel.core :as channel]))
+
+(def ^{:private true
+       :dynamic true}
+  *requests*
+  nil)
+
+(defn do-with-captured-http-requests
+  [f]
+  (let [*requests*' (atom [])]
+    (binding [*requests*  *requests*'
+              http/request (fn [req]
+                             (swap! *requests* conj req))]
+      (f))))
+
+(defmacro ^:private with-captured-http-requests
+  [& body]
+  `(do-with-captured-http-requests
+    (fn []
+      ~@body)))
+
+(def ^:private default-request
+  {:accept       :json
+   :content-type :json})
+
+(deftest can-connect-test
+  (testing "Can connect without auth"
+    (with-captured-http-requests
+      (channel/can-connect? :channel/http {:url         "https://www.secret_service.xyz"
+                                           :auth-method :none
+                                           :method      :post})
+      (is (= (merge default-request
+                    {:method :post
+                     :url    "https://www.secret_service.xyz"})
+             (first @*requests*)))))
+
+  (testing "Can connect with header auth"
+    (with-captured-http-requests
+      (channel/can-connect? :channel/http {:url         "https://www.secret_service.xyz"
+                                           :auth-method :header
+                                           :auth-info   {:Authorization "Bearer 123"}
+                                           :method      :post})
+      (is (= (merge default-request
+                    {:method :post
+                     :url    "https://www.secret_service.xyz"
+                     :headers {:Authorization "Bearer 123"}})
+             (first @*requests*)))))
+
+  (testing "Can connect with query-param auth"
+    (with-captured-http-requests
+      (channel/can-connect? :channel/http {:url         "https://www.secret_service.xyz"
+                                           :auth-method :query-param
+                                           :auth-info   {:token "123"}
+                                           :method      :post})
+      (is (= (merge default-request
+                    {:method       :post
+                     :url          "https://www.secret_service.xyz"
+                     :query-params {:token "123"}})
+             (first @*requests*))))))
+
+
+(deftest send!-test
+  (testing "basic send"
+    (with-captured-http-requests
+      (channel/send! {:type        :channel/http
+                      :url         "https://www.secret_service.xyz"
+                      :auth-method :none
+                      :method      :get}
+                     nil)
+      (is (= (merge default-request
+                    {:method       :get
+                     :url          "https://www.secret_service.xyz"})
+             (first @*requests*)))))
+
+  (testing "preserves req headers when use auth-method=:header"
+    (with-captured-http-requests
+      (channel/send! {:type        :channel/http
+                      :url         "https://www.secret_service.xyz"
+                      :auth-method :header
+                      :auth-info   {:Authorization "Bearer 123"}
+                      :method      :get}
+                     {:headers     {:X-Request-Id "123"}})
+      (is (= (merge default-request
+                    {:method       :get
+                     :url          "https://www.secret_service.xyz"
+                     :headers      {:Authorization "Bearer 123"
+                                    :X-Request-Id "123"}})
+             (first @*requests*)))))
+
+  (testing "preserves req query-params when use auth-method=:query-param"
+    (with-captured-http-requests
+      (channel/send! {:type        :channel/http
+                      :url         "https://www.secret_service.xyz"
+                      :auth-method :query-param
+                      :auth-info   {:token "123"}
+                      :method      :get}
+                     {:query-params {:page 1}})
+      (is (= (merge default-request
+                    {:method       :get
+                     :url          "https://www.secret_service.xyz"
+                     :query-params {:token "123"
+                                    :page 1}})
+             (first @*requests*))))))

--- a/test/metabase/channel/http_test.clj
+++ b/test/metabase/channel/http_test.clj
@@ -105,3 +105,5 @@
                      :query-params {:token "123"
                                     :page 1}})
              (first @*requests*))))))
+
+(deftest errors-test)

--- a/test/metabase/channel/http_test.clj
+++ b/test/metabase/channel/http_test.clj
@@ -1,82 +1,121 @@
 (ns metabase.channel.http-test
   (:require
+   [cheshire.core :as json]
    [clj-http.client :as http]
    [clojure.test :refer :all]
+   [compojure.core :as compojure]
+   [medley.core :as m]
    [metabase.channel.core :as channel]
    [metabase.util.i18n :refer [deferred-tru]]
    [metabase.util.urls :as urls]
-   [metabase.util.secret :as u.secret]
-   [metabase.test :as mt]))
+   [ring.adapter.jetty :as jetty]
+   [ring.middleware.params :refer [wrap-params]])
+  (:import
+   (org.eclipse.jetty.server Server)))
 
-(def ^{:private true
-       :dynamic true}
-  *requests*
-  nil)
+(set! *warn-on-reflection* true)
 
 (defn do-with-captured-http-requests
   [f]
-  (let [*requests*' (atom [])]
-    (binding [*requests*  *requests*'
-              http/request (fn [req]
-                             (swap! *requests* conj req))]
-      (f))))
+  (let [requests (atom [])]
+    (binding [http/request (fn [req]
+                             (swap! requests conj req)
+                             ::noop)]
+      (f requests))))
 
 (defmacro ^:private with-captured-http-requests
-  [& body]
+  [[requests-binding] & body]
   `(do-with-captured-http-requests
-    (fn []
+    (fn [~requests-binding]
       ~@body)))
 
 (def ^:private default-request
   {:accept       :json
    :content-type :json})
 
-(deftest can-connect-with-api-key-test
-  (mt/test-helpers-set-global-values!
-    (mt/with-temp [:model/ApiKey _ {:name          "A superuser API Key"
-                                    :user_id       (mt/user->id :crowberto)
-                                    :creator_id    (mt/user->id :lucky)
-                                    :updated_by_id (mt/user->id :lucky)
-                                    :unhashed_key  (u.secret/secret "mb_superuser")}]
-      (is (true? (channel/can-connect? :channel/http {:url         (str (urls/site-url) "/api/user/current")
-                                                      :auth-method :header
-                                                      :auth-info   {:x-api-key "mb_superuser"}
-                                                      :method      :get}))))))
+(defn apply-middleware
+  [handler middlewares]
+  (reduce
+   (fn [handler middleware-fn]
+     (middleware-fn handler))
+   handler
+   middlewares))
 
-(deftest ^:parallel can-connect-request-test
-  (testing "Can connect without auth"
-    (with-captured-http-requests
-      (is (true? (channel/can-connect? :channel/http {:url         "https://www.secret_service.xyz"
-                                                      :auth-method :none
-                                                      :method      :post})))
-      (is (= (merge default-request
-                    {:method :post
-                     :url    "https://www.secret_service.xyz"})
-             (first @*requests*)))))
+(defn- json-mw [handler]
+  (fn [req]
+    (-> req
+        (m/update-existing :body #(-> % slurp (json/parse-string true)))
+        handler
+        (m/update-existing :body json/generate-string))))
 
-  (testing "Can connect with header auth"
-    (with-captured-http-requests
-      (is (true? (channel/can-connect? :channel/http {:url         "https://www.secret_service.xyz"
-                                                      :auth-method :header
-                                                      :auth-info   {:Authorization "Bearer 123"}
-                                                      :method      :post})))
-      (is (= (merge default-request
-                    {:method :post
-                     :url    "https://www.secret_service.xyz"
-                     :headers {:Authorization "Bearer 123"}})
-             (first @*requests*)))))
+(def middlewares [json-mw wrap-params])
 
-  (testing "Can connect with query-param auth"
-    (with-captured-http-requests
-      (is (true? (channel/can-connect? :channel/http {:url         "https://www.secret_service.xyz"
-                                                      :auth-method :query-param
-                                                      :auth-info   {:token "123"}
-                                                      :method      :post})))
-      (is (= (merge default-request
-                    {:method       :post
-                     :url          "https://www.secret_service.xyz"
-                     :query-params {:token "123"}})
-             (first @*requests*))))))
+(defn do-with-server
+  [route+handlers f]
+  (let [handler        (->> route+handlers
+                            (map :route)
+                            (apply compojure/routes))
+        ^Server server (jetty/run-jetty (apply-middleware handler middlewares) {:port 0 :join? false})]
+    (try
+      (f (str "http://localhost:" (.. server getURI getPort)))
+      (finally
+        (.stop server)))))
+
+(defn- make-route
+  [method path handler]
+  {:path  path
+   :route (compojure/make-route method path handler)})
+
+(defmacro with-server
+  "Create a temporary server given a list of routes and handlers, and execute the body
+  with the server URL binding.
+
+    (with-server [url [(make-route :get (identity {:status 200}))] & handlers]
+      (http/get (str url \"/test_http_channel_200\"))"
+  [[url-binding handlers] & body]
+  `(do-with-server ~handlers
+    (fn [~url-binding]
+      ~@body)))
+
+(def get-favicon
+  (make-route :get "/favicon.ico"
+              (fn [_]
+                {:status 200
+                 :body   "Favicon"})))
+
+(def get-200
+  (make-route :get "/test_http_channel_200"
+              (fn [_]
+                {:status 200
+                 :body   "Hello, world!"})))
+
+(def get-302-redirect-200
+  (make-route :get "/test_http_channel_302_redirect_200"
+              (fn [_]
+                {:status  302
+                 :headers {"Location" (:path get-200)}})))
+
+(def get-400
+  (make-route :get "/test_http_channel_400"
+              (fn [_]
+                {:status 400
+                 :body   "Bad request"})))
+
+(def get-302-redirect-400
+  (make-route :get "/test_http_channel_302_redirect_400"
+              (fn [_]
+                {:status  302
+                 :headers {"Location" (:path get-400)}})))
+
+(def get-500
+  (make-route :get "/test_http_channel_500"
+              (fn [_]
+                {:status 500
+                 :body   "Internal server error"})))
+
+(defn can-connect?
+  [details]
+  (channel/can-connect? :channel/http details))
 
 (defmacro exception-data
   [& body]
@@ -85,25 +124,115 @@
      (catch Exception e#
        (ex-data e#))))
 
+(deftest ^:parallel can-connect-no-auth-test
+  (with-server [url [get-favicon get-200 get-302-redirect-200 get-400 get-302-redirect-400]]
+    (let [can-connect?* (fn [route]
+                          (can-connect? {:url         (str url (:path route))
+                                         :auth-method :none
+                                         :method      :get}))]
+
+      (testing "connect successfully with 200"
+        (is (true? (can-connect?* get-200))))
+      (testing "connect successfully with 302 redirect to 200"
+        (is (true? (can-connect?* get-302-redirect-200))))
+      (testing "failed to connect with a 302 that redirects to 400"
+        (is (= {:request-status 400
+                :request-body   "\"Bad request\""}
+               (exception-data (can-connect?* get-302-redirect-400)))))
+      (testing "failed to conenct to a 400"
+        (is (= {:request-status 400
+                :request-body   "\"Bad request\""}
+               (exception-data (can-connect?* get-400)))))
+      (is (=? {:request-status 500
+               ;; not sure why it's returns a response map is nil body
+               ;; looks like a jetty bug: https://stackoverflow.com/q/46299061
+               #_:request-body   #_"\"Internal server error\""}
+             (exception-data (can-connect?* get-500)))))))
+
+(deftest ^:parallel can-connect-header-auth-test
+  (with-server [url [(make-route :get "/user"
+                                 (fn [x]
+                                   (if (= "SECRET" (get-in x [:headers "x-api-key"]))
+                                     {:status 200
+                                      :body   "Hello, world!"}
+                                     {:status 401
+                                      :body   "Unauthorized"})))]]
+    (testing "connect successfully with header auth"
+      (is (true? (can-connect? {:url         (str url "/user")
+                                :method      :get
+                                :auth-method :header
+                                :auth-info   {:x-api-key "SECRET"}}))))
+
+    (testing "fail to connect with header auth"
+      (is (= {:request-status 401
+              :request-body   "\"Unauthorized\""}
+             (exception-data (can-connect? {:url         (str url "/user")
+                                            :method      :get
+                                            :auth-method :header
+                                            :auth-info   {:x-api-key "WRONG"}})))))))
+
+(deftest ^:parallel can-connect-query-param-auth-test
+  (with-server [url [(make-route :get "/user"
+                                 (fn [x]
+                                   (if (= ["qnkhuat" "secretpassword"]
+                                          [(get-in x [:query-params "username"]) (get-in x [:query-params "password"])])
+                                     {:status 200
+                                      :body   "Hello, world!"}
+                                     {:status 401
+                                      :body   "Unauthorized"})))]]
+    (testing "connect successfully with query-param auth"
+      (is (true? (can-connect? {:url         (str url "/user")
+                                :method      :get
+                                :auth-method :query-param
+                                :auth-info   {:username "qnkhuat"
+                                              :password "secretpassword"}}))))
+    (testing "fail to connect with query-param auth"
+      (is (= {:request-status 401
+              :request-body   "\"Unauthorized\""}
+             (exception-data (can-connect? {:url         (str url "/user")
+                                            :method      :get
+                                            :auth-method :query-param
+                                            :auth-info   {:username "qnkhuat"
+                                                          :password "wrongpassword"}})))))))
+
+
+(deftest ^:parallel can-connect-request-body-auth-test
+  (with-server [url [(make-route :post "/user"
+                                 (fn [x]
+                                   (if (= "SECRET_TOKEN" (get-in x [:body :token]))
+                                     {:status 200
+                                      :body   "Hello, world!"}
+                                     {:status 401
+                                      :body   "Unauthorized"})))]]
+    (testing "connect successfully with request-body auth"
+      (is (true? (can-connect? {:url         (str url "/user")
+                                :method      :post
+                                :auth-method :request-body
+                                :auth-info   {:token "SECRET_TOKEN"}}))))
+    (testing "fail to connect with request-body auth"
+      (is (= {:request-status 401
+              :request-body   "\"Unauthorized\""}
+             (exception-data (can-connect? {:url         (str url "/user")
+                                            :method      :post
+                                            :auth-method :request-body
+                                            :auth-info   {:token "WRONG_TOKEN"}})))))))
+
 (deftest ^:parallel can-connect?-errors-test
   (testing "throws an appriopriate errors if details are mismatched"
     (is (= {:errors {:url [(deferred-tru "value must be a valid URL.")]}}
-           (exception-data (channel/can-connect? :channel/http {:url         "not-an-url"
-                                                                :auth-method :none}))))
+           (exception-data (can-connect? {:url         "not-an-url"
+                                          :auth-method :none}))))
     (is (= {:errors {:auth-method ["missing required key"]}}
-           (exception-data (channel/can-connect? :channel/http {:url "https://www.secret_service.xyz"}))))
+           (exception-data (can-connect? {:url "https://www.secret_service.xyz"}))))
 
-    (is (= {:request-body "\"API endpoint does not exist.\""
+    (is (= {:request-body   "\"API endpoint does not exist.\""
             :request-status 404}
-           (exception-data (channel/can-connect? :channel/http {:url         (str (urls/site-url) "/api/not-exists")
-                                                                :method      :get
-                                                                :auth-method :none}))))))
-
-(deftest returns-300-test)
-
+           (exception-data (can-connect? {:url         (str (urls/site-url) "/api/not-exists")
+                                          :method      :get
+                                          :auth-method :none}))))))
 (deftest ^:parallel send!-test
   (testing "basic send"
-    (with-captured-http-requests
+    (with-captured-http-requests [requests]
       (channel/send! {:type        :channel/http
                       :url         "https://www.secret_service.xyz"
                       :auth-method :none
@@ -112,10 +241,10 @@
       (is (= (merge default-request
                     {:method       :get
                      :url          "https://www.secret_service.xyz"})
-             (first @*requests*)))))
+             (first @requests)))))
 
   (testing "preserves req headers when use auth-method=:header"
-    (with-captured-http-requests
+    (with-captured-http-requests [requests]
       (channel/send! {:type        :channel/http
                       :url         "https://www.secret_service.xyz"
                       :auth-method :header
@@ -127,10 +256,10 @@
                      :url          "https://www.secret_service.xyz"
                      :headers      {:Authorization "Bearer 123"
                                     :X-Request-Id "123"}})
-             (first @*requests*)))))
+             (first @requests)))))
 
   (testing "preserves req query-params when use auth-method=:query-param"
-    (with-captured-http-requests
+    (with-captured-http-requests [requests]
       (channel/send! {:type        :channel/http
                       :url         "https://www.secret_service.xyz"
                       :auth-method :query-param
@@ -142,4 +271,4 @@
                      :url          "https://www.secret_service.xyz"
                      :query-params {:token "123"
                                     :page 1}})
-             (first @*requests*))))))
+             (first @requests))))))

--- a/test/metabase/pulse/test_util.clj
+++ b/test/metabase/pulse/test_util.clj
@@ -85,8 +85,8 @@
 (defn do-with-captured-channel-send-messages!
   [thunk]
   (let [channel-messages (atom nil)]
-    (with-redefs [channel/send! (fn [channel-type message]
-                                  (swap! channel-messages update channel-type conj message))]
+    (with-redefs [channel/send! (fn [channel message]
+                                  (swap! channel-messages update (:type channel) conj message))]
       (thunk)
       @channel-messages)))
 

--- a/test/metabase/pulse_test.clj
+++ b/test/metabase/pulse_test.clj
@@ -746,7 +746,7 @@
         (mt/with-temporary-setting-values [email-smtp-host "fake_smtp_host"
                                            email-smtp-port 587]
           (mt/reset-inbox!)
-          (#'metabase.pulse/send-retrying! :channel/email fake-email-notification)
+          (#'metabase.pulse/send-retrying! {:type :channel/email} fake-email-notification)
           (is (= {:numberOfSuccessfulCallsWithoutRetryAttempt 1}
                  (get-positive-retry-metrics test-retry)))
           (is (= 1 (count @mt/inbox)))))))
@@ -757,7 +757,7 @@
         (mt/with-temporary-setting-values [email-smtp-host "fake_smtp_host"
                                            email-smtp-port 587]
           (mt/reset-inbox!)
-          (#'metabase.pulse/send-retrying! :channel/email fake-email-notification)
+          (#'metabase.pulse/send-retrying! {:type :channel/email} fake-email-notification)
           (is (= {:numberOfSuccessfulCallsWithoutRetryAttempt 1}
                  (get-positive-retry-metrics test-retry)))
           (is (= 0 (count @mt/inbox)))))))
@@ -769,7 +769,7 @@
         (mt/with-temporary-setting-values [email-smtp-host "fake_smtp_host"
                                            email-smtp-port 587]
           (mt/reset-inbox!)
-          (#'metabase.pulse/send-retrying! :channel/email fake-email-notification)
+          (#'metabase.pulse/send-retrying! {:type :channel/email} fake-email-notification)
           (is (= {:numberOfFailedCallsWithRetryAttempt 1}
                  (get-positive-retry-metrics test-retry)))
           (is (= 0 (count @mt/inbox)))))))
@@ -781,7 +781,7 @@
           (mt/with-temporary-setting-values [email-smtp-host "fake_smtp_host"
                                              email-smtp-port 587]
             (mt/reset-inbox!)
-            (#'metabase.pulse/send-retrying! :channel/email fake-email-notification)
+            (#'metabase.pulse/send-retrying! {:type :channel/email} fake-email-notification)
             (is (= {:numberOfSuccessfulCallsWithRetryAttempt 1}
                    (get-positive-retry-metrics test-retry)))
             (is (= 1 (count @mt/inbox))))))))
@@ -796,7 +796,7 @@
     (let [test-retry (retry/random-exponential-backoff-retry "test-retry" (test-retry-configuration))]
       (with-redefs [slack/post-chat-message! (constantly nil)
                     retry/decorate           (rt/test-retry-decorate-fn test-retry)]
-        (#'metabase.pulse/send-retrying! :channel/slack fake-slack-notification)
+        (#'metabase.pulse/send-retrying! {:type :channel/slack} fake-slack-notification)
         (is (= {:numberOfSuccessfulCallsWithoutRetryAttempt 1}
                (get-positive-retry-metrics test-retry))))))
   (testing "post slack message succeeds hiding token error"
@@ -805,7 +805,7 @@
                                                (throw (ex-info "Invalid token"
                                                                {:errors {:slack-token "Invalid token"}})))
                     retry/decorate           (rt/test-retry-decorate-fn test-retry)]
-        (#'metabase.pulse/send-retrying! :channel/slack fake-slack-notification)
+        (#'metabase.pulse/send-retrying! {:type :channel/slack} fake-slack-notification)
         (is (= {:numberOfSuccessfulCallsWithoutRetryAttempt 1}
                (get-positive-retry-metrics test-retry))))))
   (testing "post slack message fails b/c retry limit"
@@ -813,7 +813,7 @@
          test-retry   (retry/random-exponential-backoff-retry "test-retry" retry-config)]
      (with-redefs [slack/post-chat-message! (tu/works-after 1 (constantly nil))
                    retry/decorate           (rt/test-retry-decorate-fn test-retry)]
-       (#'metabase.pulse/send-retrying! :channel/slack fake-slack-notification)
+       (#'metabase.pulse/send-retrying! {:type :channel/slack} fake-slack-notification)
        (is (= {:numberOfFailedCallsWithRetryAttempt 1}
               (get-positive-retry-metrics test-retry))))))
   (testing "post slack message succeeds with retry"
@@ -821,7 +821,7 @@
          test-retry   (retry/random-exponential-backoff-retry "test-retry" retry-config)]
      (with-redefs [slack/post-chat-message! (tu/works-after 1 (constantly nil))
                    retry/decorate           (rt/test-retry-decorate-fn test-retry)]
-         (#'metabase.pulse/send-retrying! :channel/slack fake-slack-notification)
+         (#'metabase.pulse/send-retrying! {:type :channel/slack} fake-slack-notification)
          (is (= {:numberOfSuccessfulCallsWithRetryAttempt 1}
                 (get-positive-retry-metrics test-retry)))))))
 


### PR DESCRIPTION
Part of milestone 2.1 of https://github.com/metabase/metabase/issues/43822
This PR does 2 things:
- add a new `channel/can-connect?` multimethod and implement for http
- the `channel/send!` method now has the first arg is a map with a `:type` key.

This is needed so that we can introduce a new entity: `channel`.
