### PR TITLE
Milestone tracing logic update

### DIFF
--- a/release/src/linked-issues.ts
+++ b/release/src/linked-issues.ts
@@ -14,7 +14,8 @@ export function getLinkedIssues(body: string) {
 }
 
 export function getPRsFromCommitMessage(message: string) {
-  const result = [ ...message.matchAll(/\(#(\d+)\)/g) ];
+  const firstLine = message.split('\n\n')[0];
+  const result = [ ...firstLine.matchAll(/\(#(\d+)\)/g) ];
   if (!result.length) {
     console.log('no pr found in commit message', message);
     return null;

--- a/release/src/linked-issues.unit.spec.ts
+++ b/release/src/linked-issues.unit.spec.ts
@@ -129,6 +129,14 @@ describe("getPRsFromCommitMessage", () => {
   it("should return the PR id for a message with multiple backport PRs", () => {
     expect(getPRsFromCommitMessage("Backport (#123) (#456)")).toEqual([123, 456]);
     expect(getPRsFromCommitMessage("Backport (#1234) and (#4567)")).toEqual([1234, 4567]);
+    expect(getPRsFromCommitMessage("Backport (#1234) and (#4567) (#8989)")).toEqual([1234, 4567, 8989]);
+  });
+
+  it("should ignore pr numbers outside the title", () => {
+    expect(getPRsFromCommitMessage("Backport (#123) (#456)\n\n(#888) (#999)")).toEqual([123, 456]);
+    expect(getPRsFromCommitMessage("Backport (#1234) and (#4567)\n\n(#888)")).toEqual([1234, 4567]);
+    expect(getPRsFromCommitMessage("Backport (#1234)\n\n and (#4567) (#8989)")).toEqual([1234]);
+    expect(getPRsFromCommitMessage("Backport\n\n (#1234)\n\n and (#4567) (#8989)")).toEqual(null);
   });
 });
 


### PR DESCRIPTION
### Description

Our milestone-tracing logic was a little over-eager in detecting PR numbers from commit messages.

For example, a PR that [backported a bunch of changes mentioning a bunch of PRs](https://github.com/metabase/metabase/actions/runs/9694690637/job/26752868314#step:4:30) created some unintended messages.

The basic logic for tracing a release-branch commit back to an issue is:

- get all pr numbers from commit message in release branch, and fetch those PRs
- if its a backport pr, find the source PR from the pr body
- if its a source PR, find any issues closed in the PR body

I think the safer assumption is that we should only trace PRs mentioned in the first line of a commit message - other pr mentions should be informational

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
