### PR TITLE
Create new release note sections

### DIFF
--- a/release/src/constants.ts
+++ b/release/src/constants.ts
@@ -1,0 +1,5 @@
+export const nonUserFacingLabels = [
+  '.CI & Tests',
+  '.Building & Releasing',
+  'Type:Documentation',
+];

--- a/release/src/release-notes.ts
+++ b/release/src/release-notes.ts
@@ -39,6 +39,8 @@ SHA-256 checksum for the {{version}} JAR:
 
 **Already Fixed**
 
+Issues that we have recently confirmed to have been fixed at some point in the past.
+
 {{already-fixed}}
 
 **Under the Hood**

--- a/release/src/release-notes.ts
+++ b/release/src/release-notes.ts
@@ -1,3 +1,6 @@
+import { match } from 'ts-pattern';
+
+import { nonUserFacingLabels } from "./constants";
 import { getMilestoneIssues, isLatestRelease } from "./github";
 import type { ReleaseProps, Issue } from "./types";
 import {
@@ -34,15 +37,35 @@ SHA-256 checksum for the {{version}} JAR:
 
 {{bug-fixes}}
 
+**Already Fixed**
+
+{{already-fixed}}
+
+**Under the Hood**
+
+{{under-the-hood}}
+
 </details>
 
 `;
 
-const isBugIssue = (issue: Issue) => {
+const hasLabel = (issue: Issue, label: string) => {
   if (typeof issue.labels === 'string') {
-    return issue.labels.includes("Type:Bug");
+    return issue.labels.includes(label);
   }
-  return issue.labels.some(tag => tag.name === "Type:Bug");
+  return issue.labels.some(tag => tag.name === label);
+}
+
+const isBugIssue = (issue: Issue) => {
+  return hasLabel(issue, "Type:Bug");
+}
+
+const isAlreadyFixedIssue = (issue: Issue) => {
+  return hasLabel(issue, ".Already Fixed");
+};
+
+const isNonUserFacingIssue = (issue: Issue) => {
+  return nonUserFacingLabels.some(label => hasLabel(issue, label));
 }
 
 const formatIssue = (issue: Issue) => `- ${issue.title} (#${issue.number})`;
@@ -69,6 +92,35 @@ export const getReleaseTitle = (version: string) => {
   return `Metabase ${version}`;
 };
 
+enum IssueType {
+  bugFixes = 'bugFixes',
+  enhancements = 'enhancements',
+  alreadyFixedIssues = 'alreadyFixedIssues',
+  underTheHoodIssues = 'underTheHoodIssues',
+}
+
+const issueMap: Record<IssueType, Issue[]> = {
+  bugFixes: [],
+  enhancements: [],
+  alreadyFixedIssues: [],
+  underTheHoodIssues: [],
+};
+
+export const categorizeIssues = (issues: Issue[]) => {
+  return issues.reduce((issueMap, issue) => {
+    const category: IssueType = match(issue)
+      .when(isNonUserFacingIssue, () => IssueType.underTheHoodIssues)
+      .when(isAlreadyFixedIssue, () => IssueType.alreadyFixedIssues)
+      .when(isBugIssue, () => IssueType.bugFixes)
+      .otherwise(() => IssueType.enhancements);
+
+    return {
+      ...issueMap,
+      [category]: [...issueMap[category], issue],
+    }
+  }, { ...issueMap });
+};
+
 export const generateReleaseNotes = ({
   version,
   checksum,
@@ -78,15 +130,16 @@ export const generateReleaseNotes = ({
   checksum: string;
   issues: Issue[];
 }) => {
-  const bugFixes = issues.filter(isBugIssue);
-  const enhancements = issues.filter(issue => !isBugIssue(issue));
+  const issuesByType = categorizeIssues(issues);
 
   return releaseTemplate
     .replace(
       "{{enhancements}}",
-      enhancements?.map(formatIssue).join("\n") ?? "",
+      issuesByType.enhancements.map(formatIssue).join("\n") ?? "",
     )
-    .replace("{{bug-fixes}}", bugFixes?.map(formatIssue).join("\n") ?? "")
+    .replace("{{bug-fixes}}", issuesByType.bugFixes.map(formatIssue).join("\n") ?? "")
+    .replace("{{already-fixed}}", issuesByType.alreadyFixedIssues.map(formatIssue).join("\n"))
+    .replace("{{under-the-hood}}", issuesByType.underTheHoodIssues.map(formatIssue).join("\n"))
     .replace("{{docker-tag}}", getDockerTag(version))
     .replace("{{download-url}}", getDownloadUrl(version))
     .replace("{{version}}", version)

--- a/release/src/release-notes.unit.spec.ts
+++ b/release/src/release-notes.unit.spec.ts
@@ -57,7 +57,7 @@ describe("Release Notes", () => {
 
       expect(notes).toContain("**Enhancements**\n\n- Feature Issue (#2)");
       expect(notes).toContain("**Bug fixes**\n\n- Bug Issue (#1)");
-      expect(notes).toContain("**Already Fixed**\n\n- Issue Already Fixed (#3)");
+      expect(notes).toContain("**Already Fixed**\n\nIssues that we have recently confirmed to have been fixed at some point in the past.\n\n- Issue Already Fixed (#3)");
       expect(notes).toContain("**Under the Hood**\n\n- Issue That Users Don't Care About (#4)");
 
       expect(notes).toContain("metabase/metabase:v0.2.3");
@@ -66,7 +66,7 @@ describe("Release Notes", () => {
       );
     });
 
-    it.only("should generate enterprise release notes", () => {
+    it("should generate enterprise release notes", () => {
       const notes = generateReleaseNotes({
         version: "v1.2.3",
         checksum: "1234567890abcdef",
@@ -78,7 +78,7 @@ describe("Release Notes", () => {
 
       expect(notes).toContain("**Enhancements**\n\n- Feature Issue (#2)");
       expect(notes).toContain("**Bug fixes**\n\n- Bug Issue (#1)");
-      expect(notes).toContain("**Already Fixed**\n\n- Issue Already Fixed (#3)");
+      expect(notes).toContain("**Already Fixed**\n\nIssues that we have recently confirmed to have been fixed at some point in the past.\n\n- Issue Already Fixed (#3)");;
       expect(notes).toContain("**Under the Hood**\n\n- Issue That Users Don't Care About (#4)");
 
       expect(notes).toContain("metabase/metabase-enterprise:v1.2.3");


### PR DESCRIPTION
### Description

Creates two new release-notes sections:
- Already Fixed
- Under the Hood

Under the hood issues take highest priority, they are any issue in a milestone with these labels:
- Type:Documentation
- .Ci & Tests
- .Building & Releasing

Already Fixed Issues will also not show up in the bug fix section even if they also have a bug fix tag.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
