### PR TITLE
cached metadata provider: lower the log level for metadata retrieval so DEBUG is less busy

### DIFF
--- a/src/metabase/lib/metadata/cached_provider.cljc
+++ b/src/metabase/lib/metadata/cached_provider.cljc
@@ -50,12 +50,12 @@
 
 (defn- metadatas [cache uncached-provider metadata-type ids]
   (when (seq ids)
-    (log/debugf "Getting %s metadata with IDs %s" metadata-type (pr-str (sort ids)))
+    (log/tracef "Getting %s metadata with IDs %s" metadata-type (pr-str (sort ids)))
     (let [existing-ids (set (keys (get @cache metadata-type)))
           missing-ids  (set/difference (set ids) existing-ids)]
-      (log/debugf "Already fetched %s: %s" metadata-type (pr-str (sort (set/intersection (set ids) existing-ids))))
+      (log/tracef "Already fetched %s: %s" metadata-type (pr-str (sort (set/intersection (set ids) existing-ids))))
       (when (seq missing-ids)
-        (log/debugf "Need to fetch %s: %s" metadata-type (pr-str (sort missing-ids)))
+        (log/tracef "Need to fetch %s: %s" metadata-type (pr-str (sort missing-ids)))
         ;; TODO -- we should probably store `::nil` markers for things we tried to fetch that didn't exist
         (doseq [instance (lib.metadata.protocols/metadatas uncached-provider metadata-type missing-ids)]
           (store-in-cache! cache [metadata-type (:id instance)] instance))))


### PR DESCRIPTION
It just generates way too many logs for instances with enabled debug (like stats). [Context](https://metaboat.slack.com/archives/CKZEMT1MJ/p1719839379126579)