### PR TITLE
Allow ad-hoc release-notes generation

### DIFF
--- a/.github/workflows/release-notes-preview.yml
+++ b/.github/workflows/release-notes-preview.yml
@@ -37,7 +37,7 @@ jobs:
           const { getChangelog } = require('${{ github.workspace }}/release/dist/index.cjs');
           const fs = require('fs');
 
-          const version = '${{ inputs.version }}' || 'v0.50.9';
+          const version = '${{ inputs.version }}';
 
           const notes = await getChangelog({
             version,
@@ -53,6 +53,3 @@ jobs:
         name: release-notes-preview-${{inputs.version}}.md
         path: |
           ${{ github.workspace }}/release-notes-preview-*.md
-
-
-

--- a/.github/workflows/release-notes-preview.yml
+++ b/.github/workflows/release-notes-preview.yml
@@ -1,0 +1,61 @@
+name: Release Notes Preview
+run-name: Preview ${{ inputs.version }} release notes
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Metabase version (e.g. v0.46.3)'
+        type: string
+        required: true
+  pull_request: # for testing
+
+jobs:
+  preview-release-notes:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+    # - name: Fail early on the incorrect version format
+    #   if: ${{ !(startsWith(inputs.version,'v0.') || startsWith(inputs.version,'v1.')) }}
+    #   run: |
+    #     echo "The version format is invalid!"
+    #     echo "It must start with either 'v0.' or 'v1.'."
+    #     echo "Please, try again."
+    #     exit 1
+    - uses: actions/checkout@v4
+      with:
+        sparse-checkout: release
+    - name: Prepare build scripts
+      run: cd ${{ github.workspace }}/release && yarn && yarn build
+    - name: Get Release Version
+      uses: actions/github-script@v7
+      env:
+        DOCKERHUB_OWNER: test_owner
+        DOCKERHUB_REPO: test_repo
+        AWS_S3_DOWNLOADS_BUCKET: test_bucket
+      with:
+        script: | # js
+          const { getChangelog } = require('${{ github.workspace }}/release/dist/index.cjs');
+          const fs = require('fs');
+
+          const version = '${{ inputs.version }}' || 'v0.50.9';
+
+          const notes = await getChangelog({
+            version,
+            github,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+          });
+
+          console.log(notes);
+
+          fs.writeFileSync(`release-notes-preview-${version}.md`, notes);
+    - name: Upload Release Notes
+      uses: actions/upload-artifact@v4
+      with:
+        name: release-notes-preview-${{inputs.version}}.md
+        path: |
+          ${{ github.workspace }}/release-notes-preview-*.md
+
+
+

--- a/.github/workflows/release-notes-preview.yml
+++ b/.github/workflows/release-notes-preview.yml
@@ -8,20 +8,19 @@ on:
         description: 'Metabase version (e.g. v0.46.3)'
         type: string
         required: true
-  pull_request: # for testing
 
 jobs:
   preview-release-notes:
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:
-    # - name: Fail early on the incorrect version format
-    #   if: ${{ !(startsWith(inputs.version,'v0.') || startsWith(inputs.version,'v1.')) }}
-    #   run: |
-    #     echo "The version format is invalid!"
-    #     echo "It must start with either 'v0.' or 'v1.'."
-    #     echo "Please, try again."
-    #     exit 1
+    - name: Fail early on the incorrect version format
+      if: ${{ !(startsWith(inputs.version,'v0.') || startsWith(inputs.version,'v1.')) }}
+      run: |
+        echo "The version format is invalid!"
+        echo "It must start with either 'v0.' or 'v1.'."
+        echo "Please, try again."
+        exit 1
     - uses: actions/checkout@v4
       with:
         sparse-checkout: release
@@ -46,8 +45,6 @@ jobs:
             owner: context.repo.owner,
             repo: context.repo.repo,
           });
-
-          console.log(notes);
 
           fs.writeFileSync(`release-notes-preview-${version}.md`, notes);
     - name: Upload Release Notes

--- a/release/README.md
+++ b/release/README.md
@@ -55,10 +55,10 @@ The order of the arguments matters, the script will yell at you if you put the f
 
 ## Utilities
 
-In case you want to preview release notes generation, or re-generate them after a release has been built, you can use this command. (the hash doesn't matter, it's just a placeholder)
+In case you want to preview release notes generation, or re-generate them after a release has been built, you can use this command.
 
 ```sh
-yarn release-offline v0.77.0 1234567890abcdef1234567890abcdef12345678  --changelog > changelog.log
+yarn generate-changelog v0.77.0 > changelog.log
 ```
 
 ## Required checks copy

--- a/release/generate-changelog.ts
+++ b/release/generate-changelog.ts
@@ -1,0 +1,39 @@
+// changelog preview only, doesn't publish anything
+import "dotenv/config";
+import { Octokit } from "@octokit/rest";
+import "zx/globals";
+
+import {
+  isValidVersionString,
+  hasBeenReleased,
+  getChangelog,
+} from "./src";
+
+const {
+  GITHUB_TOKEN,
+  GITHUB_OWNER,
+  GITHUB_REPO,
+} = process.env as any;
+
+if (!GITHUB_TOKEN || !GITHUB_OWNER || !GITHUB_REPO) {
+  console.error("You must provide GITHUB_* environment variables in .env-template");
+}
+
+const github = new Octokit({ auth: GITHUB_TOKEN });
+
+const version = process.argv?.[2]?.trim();
+
+if (!isValidVersionString(version)) {
+  console.error(
+    "You must provide a valid version string as the first argument (e.g v0.45.6)",
+  );
+}
+
+const notes = await getChangelog({
+  version, github,
+  owner: GITHUB_OWNER,
+  repo: GITHUB_REPO,
+});
+
+console.log(notes);
+

--- a/release/generate-changelog.ts
+++ b/release/generate-changelog.ts
@@ -5,7 +5,6 @@ import "zx/globals";
 
 import {
   isValidVersionString,
-  hasBeenReleased,
   getChangelog,
 } from "./src";
 
@@ -30,7 +29,8 @@ if (!isValidVersionString(version)) {
 }
 
 const notes = await getChangelog({
-  version, github,
+  version,
+  github,
   owner: GITHUB_OWNER,
   repo: GITHUB_REPO,
 });

--- a/release/package.json
+++ b/release/package.json
@@ -11,6 +11,7 @@
     "build": "esbuild src/index.ts --bundle --outfile=dist/index.cjs --platform=node --target=node16",
     "prettier": "prettier --write",
     "release-offline": "tsx release-offline.ts",
+    "generate-changelog": "tsx generate-changelog.ts",
     "copy-required-checks": "tsx ./src/required-checks.ts",
     "test:unit": "jest --testPathPattern unit",
     "test:integration": "jest --testPathPattern integration"

--- a/release/release-offline.ts
+++ b/release/release-offline.ts
@@ -23,7 +23,6 @@ import {
   closeMilestone,
   openNextMilestones,
   versionRequirements,
-  getChangelog,
 } from "./src";
 
 const {
@@ -468,19 +467,6 @@ async function updateMilestones() {
 
   if (step === "release-notes") {
     await releaseNotes();
-  }
-
-  if (step === "changelog") {
-    // changelog preview only, doesn't publish anything
-    const { GITHUB_OWNER, GITHUB_REPO } = getGithubCredentials();
-    const notes = await getChangelog({
-      version, github,
-      owner: GITHUB_OWNER,
-      repo: GITHUB_REPO
-    });
-    // eslint-disable-next-line no-console -- allows piping to a file
-    console.log(notes);
-    return;
   }
 
   if (step === "update-milestones") {

--- a/release/src/github.ts
+++ b/release/src/github.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import type { Issue, ReleaseProps } from "./types";
+import type { GithubProps, Issue, ReleaseProps } from "./types";
 import {
   getMilestoneName,
   getNextVersions,
@@ -11,14 +11,15 @@ export const getMilestones = async ({
   github,
   owner,
   repo,
-}: Omit<ReleaseProps, "version">) => {
-  const milestones = await github.rest.issues.listMilestones({
+  state = "open",
+}: GithubProps & { state?: 'open' | 'closed' }) => {
+  const milestones = await github.paginate(github.rest.issues.listMilestones, {
     owner,
     repo,
-    state: "open",
+    state,
   });
 
-  return milestones.data;
+  return milestones;
 };
 
 export const findMilestone = async ({
@@ -26,8 +27,9 @@ export const findMilestone = async ({
   github,
   owner,
   repo,
-}: ReleaseProps) => {
-  const milestones = await getMilestones({ github, owner, repo });
+  state,
+}: ReleaseProps & { state?: 'open' | 'closed'}) => {
+  const milestones = await getMilestones({ github, owner, repo, state });
   const expectedMilestoneName = getMilestoneName(version);
 
   return milestones.find(
@@ -84,8 +86,9 @@ export const getMilestoneIssues = async ({
   owner,
   repo,
   state = "closed",
-}: ReleaseProps & { state?: "closed" | "open" }): Promise<Issue[]> => {
-  const milestone = await findMilestone({ version, github, owner, repo });
+  milestoneStatus = "closed"
+}: ReleaseProps & { state?: "closed" | "open"; milestoneStatus?: 'open' | 'closed' }): Promise<Issue[]> => {
+  const milestone = await findMilestone({ version, github, owner, repo, state: milestoneStatus });
 
   if (!milestone) {
     return [];


### PR DESCRIPTION
Adds local scripting and a github action to generate release notes from any milestone

locally, if you have environment variables set up you can just go to the release directory and:

```sh
yarn generate-changelog v0.50.9 > changelog.log
```

or, in CI, you can just trigger a workflow dispatch and get a snapshot of "if we released this version right now, what would the release notes generate?"

[successful test run on this branch](https://github.com/metabase/metabase/actions/runs/9745811686)