### PR TITLE
Feature/28144 override download row limit for csv

### DIFF
--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -9,6 +9,7 @@
    [metabase.models.setting :as setting :refer [defsetting]]
    [metabase.plugins.classloader :as classloader]
    [metabase.public-settings.premium-features :as premium-features]
+   [metabase.query-processor.interface :as qp.i]
    [metabase.util :as u]
    [metabase.util.fonts :as u.fonts]
    [metabase.util.i18n
@@ -934,5 +935,5 @@ See [fonts](../configuring-metabase/fonts.md).")
   :visibility :internal
   :export?    false
   :type       :integer
-  :default    10000000
+  :default    qp.i/absolute-max-results
   :doc "CSV export row limit.")

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -926,3 +926,13 @@ See [fonts](../configuring-metabase/fonts.md).")
   :export?    false
   :default    true
   :type       :boolean)
+
+
+;; This is normally set via the env var `MB_ROW_LIMIT_CSV`
+(defsetting row-limit-csv
+  "CSV export row limit."
+  :visibility :internal
+  :export?    false
+  :type       :integer
+  :default    10000000
+  :doc "CSV export row limit.")

--- a/test/metabase/query_processor/middleware/limit_test.clj
+++ b/test/metabase/query_processor/middleware/limit_test.clj
@@ -2,6 +2,7 @@
   "Tests for the `:limit` clause and `:max-results` constraints."
   (:require
    [clojure.test :refer :all]
+   [metabase.public-settings :as public-settings]
    [metabase.query-processor.interface :as qp.i]
    [metabase.query-processor.middleware.limit :as limit]
    [metabase.query-processor.reducible :as qp.reducible]
@@ -33,6 +34,17 @@
                                             :query {}})]
       (is (= query
              (limit/add-default-limit query))))))
+
+(deftest ^:parallel csv-max-results-test
+         (testing "Apply `absolute-max-results` limit in the :csv-download case"
+                  (let [query {:type :query
+                               :query {}
+                               :info {:context :csv-download}}]
+                       (is (= {:type  :query
+                               :query {:limit (public-settings/row-limit-csv)
+                                       ::limit/original-limit nil}
+                               :info {:context :csv-download}}
+                              (limit/add-default-limit query))))))
 
 (deftest max-results-constraint-test
   (testing "Apply an arbitrary max-results on the query and ensure our results size is appropriately constrained"

--- a/test/metabase/query_processor/middleware/limit_test.clj
+++ b/test/metabase/query_processor/middleware/limit_test.clj
@@ -36,15 +36,27 @@
              (limit/add-default-limit query))))))
 
 (deftest ^:parallel csv-max-results-test
-         (testing "Apply `absolute-max-results` limit in the :csv-download case"
-                  (let [query {:type :query
-                               :query {}
-                               :info {:context :csv-download}}]
-                       (is (= {:type  :query
-                               :query {:limit (public-settings/row-limit-csv)
-                                       ::limit/original-limit nil}
-                               :info {:context :csv-download}}
-                              (limit/add-default-limit query))))))
+  (testing "Apply `absolute-max-results` limit in the :csv-download case"
+    (let [query {:type :query
+                 :query {}
+                 :info {:context :csv-download}}]
+      (is (= {:type  :query
+              :query {:limit (public-settings/row-limit-csv)
+                      ::limit/original-limit nil}
+              :info {:context :csv-download}}
+              (limit/add-default-limit query))))))
+
+(deftest csv-custom-limit-test
+  (testing "Apply custom csv row limit in the :csv-download case"
+    (mt/with-temp-env-var-value! [mb-row-limit-csv 1000]
+      (let [query {:type :query
+                   :query {}
+                   :info {:context :csv-download}}]
+        (is (= {:type  :query
+                :query {:limit 1000
+                ::limit/original-limit nil}
+                :info {:context :csv-download}}
+                (limit/add-default-limit query)))))))
 
 (deftest max-results-constraint-test
   (testing "Apply an arbitrary max-results on the query and ensure our results size is appropriately constrained"


### PR DESCRIPTION
Partially implements https://github.com/metabase/metabase/issues/28144

### Description

I created the MB_ROW_LIMIT_CSV setting and used it in the determine-query-max-rows function.

### How to verify

1. set environment variable: MB_ROW_LIMIT_CSV=X
2. export csv file

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
