### PR TITLE
Fix #35954: SQL-converted question with field filter breaks filtered dashboard if reverted back to its editor version

### DIFF
--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -1,5 +1,6 @@
 import moment from "moment-timezone"; // eslint-disable-line no-restricted-imports -- deprecated usage
 
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ADMIN_PERSONAL_COLLECTION_ID,
@@ -3441,7 +3442,7 @@ describe.skip("issue 35954", () => {
     cache_ttl: null,
     type: "question",
     dataset_query: {
-      database: 1,
+      database: SAMPLE_DB_ID,
       type: "native",
       native: {
         "template-tags": {

--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -3580,6 +3580,39 @@ describe("issue 35954", () => {
 
     cy.findByTestId("fixed-width-filters").icon("gear").click();
     getDashboardCard().should("contain", "Unknown Field");
+
+    cy.get("@dashboardId").then(id => {
+      cy.log("Make sure this works for the public sharing setting");
+      cy.request("POST", `/api/dashboard/${id}/public_link`).then(
+        ({ body: { uuid } }) => {
+          // Set the filter through the URL
+          cy.visit(`/public/dashboard/${uuid}?equal_to=3`);
+        },
+      );
+      cy.findAllByTestId("cell-data")
+        .should("contain", "christ")
+        .and("contain", "xavier")
+        .and("not.contain", "kale");
+
+      cy.log("Make sure this works for the embedding setting");
+      cy.request("PUT", `/api/dashboard/${id}`, {
+        embedding_params: {
+          equal_to: "locked",
+        },
+        enable_embedding: true,
+      });
+
+      const payload = {
+        resource: { dashboard: id },
+        params: { equal_to: [3] },
+      };
+
+      visitEmbeddedPage(payload);
+      cy.findAllByTestId("cell-data")
+        .should("contain", "christ")
+        .and("contain", "xavier")
+        .and("not.contain", "kale");
+    });
   });
 });
 

--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -3306,6 +3306,17 @@ describe("issue 34955", () => {
         .should("have.length", 2);
     });
   });
+
+  function connectFilterToColumn(column) {
+    getDashboardCard().within(() => {
+      cy.findByText("Column to filter on");
+      cy.findByText("Select…").click();
+    });
+
+    popover().within(() => {
+      cy.findByText(column).click();
+    });
+  }
 });
 
 describe("issue 35852", () => {
@@ -3421,14 +3432,3 @@ describe("issue 35852", () => {
     });
   }
 });
-
-function connectFilterToColumn(column) {
-  getDashboardCard().within(() => {
-    cy.findByText("Column to filter on");
-    cy.findByText("Select…").click();
-  });
-
-  popover().within(() => {
-    cy.findByText(column).click();
-  });
-}

--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -1,6 +1,5 @@
 import moment from "moment-timezone"; // eslint-disable-line no-restricted-imports -- deprecated usage
 
-import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ADMIN_PERSONAL_COLLECTION_ID,
@@ -39,7 +38,6 @@ import {
   visitPublicDashboard,
   setModelMetadata,
   tableHeaderClick,
-  questionInfoButton,
 } from "e2e/support/helpers";
 import {
   createMockDashboardCard,
@@ -3422,181 +3420,6 @@ describe("issue 35852", () => {
       });
     });
   }
-});
-
-describe("issue 35954", () => {
-  const questionDetails = {
-    name: "35954",
-    query: {
-      "source-table": REVIEWS_ID,
-      limit: 2,
-    },
-  };
-
-  const dashboardDetails = {
-    name: "35954D",
-  };
-
-  const updatedQuestionDetails = {
-    dataset_query: {
-      database: SAMPLE_DB_ID,
-      type: "native",
-      native: {
-        "template-tags": {
-          RATING: {
-            type: "dimension",
-            name: "RATING",
-            id: "017b9185-c7cc-41ec-ba17-b8b21af879cc",
-            "display-name": "SQL Filter",
-            default: null,
-            dimension: ["field", REVIEWS.RATING, null],
-            "widget-type": "number/=",
-            options: null,
-          },
-        },
-        collection: "REVIEWS",
-        query: "SELECT * FROM REVIEWS WHERE {{RATING}} LIMIT 2",
-      },
-    },
-    parameters: [
-      {
-        id: "017b9185-c7cc-41ec-ba17-b8b21af879cc",
-        type: "number/=",
-        target: ["dimension", ["template-tag", "RATING"]],
-        slug: "RATING",
-      },
-    ],
-    parameter_mappings: [],
-  };
-
-  beforeEach(() => {
-    restore();
-    cy.signInAsAdmin();
-
-    cy.createQuestionAndDashboard({
-      questionDetails,
-      cardDetails: {
-        size_x: 16,
-        size_y: 8,
-      },
-      dashboardDetails,
-    }).then(({ body: { dashboard_id, card_id } }) => {
-      cy.wrap(card_id).as("questionId");
-      cy.wrap(dashboard_id).as("dashboardId");
-
-      cy.request("PUT", `/api/card/${card_id}`, updatedQuestionDetails);
-
-      visitDashboard(dashboard_id);
-    });
-  });
-
-  it("should not break the UI when the dashboard filter loses connection (metabase#35954)", () => {
-    editDashboard();
-    cy.log("Add the number filter");
-    setFilter("Number");
-    connectFilterToColumn("SQL Filter");
-    saveDashboard();
-
-    cy.log("Give it a value and make sure that the filer applies");
-    filterWidget().click();
-    popover().within(() => {
-      cy.findByPlaceholderText("Enter a number").type(3).blur();
-      cy.button("Add filter").click();
-    });
-    cy.findAllByTestId("cell-data")
-      .should("contain", "kale")
-      .and("contain", "pete")
-      .and("not.contain", "xavier");
-
-    cy.log("Drill down to the question from the dashboard");
-    cy.findByTestId("legend-caption-title").click();
-    cy.get("@questionId").then(id => {
-      cy.location("pathname").should(
-        "eq",
-        `/question/${id}-${questionDetails.name}`,
-      );
-      cy.location("search").should("eq", "?RATING=3");
-    });
-
-    cy.log("Revert the question to its original (GUI) version");
-    cy.intercept("POST", "/api/revision/revert").as("revertQuestion");
-    questionInfoButton().click();
-    cy.findByTestId("saved-question-history-list")
-      .find("li")
-      .filter(":contains(You created this)")
-      .findByTestId("question-revert-button")
-      .click();
-    cy.wait("@revertQuestion");
-    // Mid-test assertions to root out the flakiness
-    cy.findByTestId("saved-question-history-list").should(
-      "contain",
-      "You edited this",
-    );
-    cy.findByTestId("saved-question-history-list")
-      .findAllByTestId("question-revert-button")
-      .should("have.length", 2);
-
-    cy.findByLabelText(`Back to ${dashboardDetails.name}`).click();
-
-    cy.get("@dashboardId").then(id => {
-      cy.location("pathname").should(
-        "eq",
-        `/dashboard/${id}-${dashboardDetails.name.toLowerCase()}`,
-      );
-    });
-
-    cy.log("Make sure the disconnected filter doesn't break UI");
-    // The filter widget will still have the number 3 applied as the filter,
-    // but that shouldn't affect our results since the filter is disconnected.
-    cy.findAllByTestId("cell-data")
-      .should("contain", "christ")
-      .and("contain", "xavier")
-      .and("not.contain", "kale");
-
-    // Reloading the dashboard breaks the filter in the original issue
-    cy.reload();
-
-    cy.log(
-      "Make sure the UI shows the filter is not connected to the GUI card",
-    );
-    editDashboard();
-
-    cy.findByTestId("fixed-width-filters").icon("gear").click();
-    getDashboardCard().should("contain", "Unknown Field");
-
-    cy.get("@dashboardId").then(id => {
-      cy.log("Make sure this works for the public sharing setting");
-      cy.request("POST", `/api/dashboard/${id}/public_link`).then(
-        ({ body: { uuid } }) => {
-          // Set the filter through the URL
-          cy.visit(`/public/dashboard/${uuid}?equal_to=3`);
-        },
-      );
-      cy.findAllByTestId("cell-data")
-        .should("contain", "christ")
-        .and("contain", "xavier")
-        .and("not.contain", "kale");
-
-      cy.log("Make sure this works for the embedding setting");
-      cy.request("PUT", `/api/dashboard/${id}`, {
-        embedding_params: {
-          equal_to: "locked",
-        },
-        enable_embedding: true,
-      });
-
-      const payload = {
-        resource: { dashboard: id },
-        params: { equal_to: [3] },
-      };
-
-      visitEmbeddedPage(payload);
-      cy.findAllByTestId("cell-data")
-        .should("contain", "christ")
-        .and("contain", "xavier")
-        .and("not.contain", "kale");
-    });
-  });
 });
 
 function connectFilterToColumn(column) {

--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -3438,9 +3438,6 @@ describe("issue 35954", () => {
   };
 
   const updatedQuestionDetails = {
-    name: "35954",
-    cache_ttl: null,
-    type: "question",
     dataset_query: {
       database: SAMPLE_DB_ID,
       type: "native",
@@ -3461,29 +3458,15 @@ describe("issue 35954", () => {
         query: "SELECT * FROM REVIEWS WHERE {{RATING}} LIMIT 2",
       },
     },
-    display: "table",
-    description: null,
-    visualization_settings: {
-      "table.pivot_column": "PRODUCT_ID",
-      "table.cell_column": "RATING",
-    },
     parameters: [
       {
         id: "017b9185-c7cc-41ec-ba17-b8b21af879cc",
         type: "number/=",
         target: ["dimension", ["template-tag", "RATING"]],
-        name: "Dashboard Parameter",
         slug: "RATING",
       },
     ],
     parameter_mappings: [],
-    archived: false,
-    enable_embedding: false,
-    embedding_params: null,
-    collection_id: null,
-    collection_position: null,
-    collection_preview: true,
-    result_metadata: null,
   };
 
   beforeEach(() => {

--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -3424,7 +3424,7 @@ describe("issue 35852", () => {
   }
 });
 
-describe.skip("issue 35954", () => {
+describe("issue 35954", () => {
   const questionDetails = {
     name: "35954",
     query: {
@@ -3566,7 +3566,7 @@ describe.skip("issue 35954", () => {
     // The filter widget will still have the number 3 applied as the filter,
     // but that shouldn't affect our results since the filter is disconnected.
     cy.findAllByTestId("cell-data")
-      .should("contain", "jesus")
+      .should("contain", "christ")
       .and("contain", "xavier")
       .and("not.contain", "kale");
 
@@ -3577,8 +3577,8 @@ describe.skip("issue 35954", () => {
       "Make sure the UI shows the filter is not connected to the GUI card",
     );
     editDashboard();
-    // I couldn't find a better way to select this :(
-    cy.findByTestId("fixed-width-filters").icon("gear");
+
+    cy.findByTestId("fixed-width-filters").icon("gear").click();
     getDashboardCard().should("contain", "Unknown Field");
   });
 });

--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-with-question-revert.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-with-question-revert.cy.spec.js
@@ -1,0 +1,323 @@
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import {
+  snapshot,
+  editDashboard,
+  filterWidget,
+  getDashboardCard,
+  popover,
+  restore,
+  saveDashboard,
+  setFilter,
+  visitDashboard,
+  visitEmbeddedPage,
+  questionInfoButton,
+  modal,
+  getIframeBody,
+  visitQuestion,
+} from "e2e/support/helpers";
+
+const { REVIEWS, REVIEWS_ID } = SAMPLE_DATABASE;
+
+describe("issue 35954", () => {
+  const questionDetails = {
+    name: "35954",
+    query: {
+      "source-table": REVIEWS_ID,
+      limit: 2,
+    },
+  };
+
+  const dashboardDetails = {
+    name: "35954D",
+  };
+
+  const updatedQuestionDetails = {
+    dataset_query: {
+      database: SAMPLE_DB_ID,
+      type: "native",
+      native: {
+        "template-tags": {
+          RATING: {
+            type: "dimension",
+            name: "RATING",
+            id: "017b9185-c7cc-41ec-ba17-b8b21af879cc",
+            "display-name": "Field-mapped Rating",
+            default: null,
+            dimension: ["field", REVIEWS.RATING, null],
+            "widget-type": "number/=",
+            options: null,
+          },
+        },
+        query: "SELECT * FROM REVIEWS WHERE {{RATING}} LIMIT 2",
+      },
+    },
+    parameters: [
+      {
+        id: "017b9185-c7cc-41ec-ba17-b8b21af879cc",
+        type: "number/=",
+        target: ["dimension", ["template-tag", "RATING"]],
+        slug: "RATING",
+      },
+    ],
+    parameter_mappings: [],
+  };
+
+  // This potentially reproduces metabase#45022 as well
+  context(
+    "dashboard filter that loses connection should not crash the UI (metabase#35954)",
+    () => {
+      before(() => {
+        restore();
+        cy.signInAsAdmin();
+
+        cy.createQuestionAndDashboard({
+          questionDetails,
+          cardDetails: {
+            size_x: 16,
+            size_y: 8,
+          },
+          dashboardDetails,
+        }).then(({ body: { dashboard_id, card_id } }) => {
+          cy.wrap(card_id).as("questionId");
+          cy.wrap(dashboard_id).as("dashboardId");
+
+          cy.request("PUT", `/api/card/${card_id}`, updatedQuestionDetails);
+
+          visitDashboard(dashboard_id);
+          editDashboard();
+          cy.log("Add the number filter");
+          setFilter("Number");
+          connectFilterToColumn("Field-mapped Rating");
+          saveDashboard();
+
+          cy.log("Give it a value and make sure that the filer applies");
+          filterWidget().click();
+          popover().within(() => {
+            cy.findByPlaceholderText("Enter a number").type(3).blur();
+            cy.button("Add filter").click();
+          });
+          assertFilterIsApplied();
+
+          cy.log("Drill down to the question from the dashboard");
+          cy.findByTestId("legend-caption-title").click();
+          cy.get("@questionId").then(id => {
+            cy.location("pathname").should(
+              "eq",
+              `/question/${id}-${questionDetails.name}`,
+            );
+            cy.location("search").should("eq", "?RATING=3");
+          });
+
+          cy.log("Revert the question to its original (GUI) version");
+          cy.intercept("POST", "/api/revision/revert").as("revertQuestion");
+          questionInfoButton().click();
+          cy.findByTestId("saved-question-history-list")
+            .find("li")
+            .filter(":contains(You created this)")
+            .findByTestId("question-revert-button")
+            .click();
+          cy.wait("@revertQuestion");
+          // Mid-test assertions to root out the flakiness
+          cy.findByTestId("saved-question-history-list").should(
+            "contain",
+            "You edited this",
+          );
+          cy.findByTestId("saved-question-history-list")
+            .findAllByTestId("question-revert-button")
+            .should("have.length", 2);
+
+          cy.findByLabelText(`Back to ${dashboardDetails.name}`).click();
+
+          cy.get("@dashboardId").then(id => {
+            cy.location("pathname").should(
+              "eq",
+              `/dashboard/${id}-${dashboardDetails.name.toLowerCase()}`,
+            );
+            cy.location("search").should("eq", "?equal_to=3");
+          });
+
+          cy.log("Make sure the disconnected filter doesn't break UI");
+          // The filter widget will still have the number 3 applied as the filter,
+          // but that shouldn't affect our results since the filter is disconnected.
+          assertFilterIsDisconnected();
+
+          // Reloading the dashboard breaks the filter in the original issue
+          cy.reload();
+
+          cy.log(
+            "Make sure the UI shows the filter is not connected to the GUI card",
+          );
+          editDashboard();
+
+          cy.findByTestId("fixed-width-filters").icon("gear").click();
+          getDashboardCard().should("contain", "Unknown Field");
+
+          snapshot("35954");
+        });
+      });
+
+      beforeEach(() => {
+        restore("35954");
+        cy.signInAsAdmin();
+      });
+
+      it("should be able to remove the broken connection and connect the filter to the GUI question", function () {
+        visitDashboard(this.dashboardId);
+        editDashboard();
+        openFilterSettings();
+        getDashboardCard().findByLabelText("Disconnect").click();
+        connectFilterToColumn("Rating");
+        saveDashboard();
+
+        cy.location("search").should("eq", "?equal_to=3");
+        assertFilterIsApplied();
+      });
+
+      it("filter should automatically be re-connected when the question is reverted back to the SQL version", function () {
+        visitQuestion(this.questionId);
+
+        questionInfoButton().click();
+        cy.findByTestId("saved-question-history-list")
+          .find("li")
+          .filter(":contains(You edited this)")
+          .findByTestId("question-revert-button")
+          .click();
+
+        cy.location("search").should("eq", "?RATING=");
+        assertFilterIsDisconnected();
+
+        visitDashboard(this.dashboardId);
+        cy.location("search").should("eq", "?equal_to=3");
+        assertFilterIsApplied();
+      });
+
+      it("should work for public dashboards", function () {
+        cy.request(
+          "POST",
+          `/api/dashboard/${this.dashboardId}/public_link`,
+        ).then(({ body: { uuid } }) => {
+          // Set the filter through the URL
+          cy.visit(`/public/dashboard/${uuid}?equal_to=3`);
+        });
+        assertFilterIsDisconnected();
+      });
+
+      it("should work for embedding preview", function () {
+        const id = this.dashboardId;
+
+        cy.request("PUT", `/api/dashboard/${id}`, {
+          embedding_params: {
+            equal_to: "enabled",
+          },
+          enable_embedding: true,
+        });
+
+        // Discard the legalese modal so we don't need to do an extra click in the UI
+        cy.request("PUT", "/api/setting/show-static-embed-terms", {
+          value: false,
+        });
+
+        visitDashboard(id);
+        cy.findByTestId("resource-embed-button").click();
+        cy.findByTestId("embed-menu-embed-modal-item").click();
+        modal().findByText("Static embed").click();
+
+        cy.findByTestId("embedding-preview").within(() => {
+          cy.intercept("GET", "api/preview_embed/dashboard/**").as(
+            "previewEmbed",
+          );
+          cy.findByRole("tab", { name: "Parameters" }).click();
+          cy.findByText("Preview").click();
+          // One is for the dashboard, and the other one is for the dashboard card
+          cy.wait(["@previewEmbed", "@previewEmbed"]);
+        });
+
+        getIframeBody().within(() => {
+          cy.findByRole("heading", { name: dashboardDetails.name });
+
+          assertFilterIsDisconnected();
+
+          filterWidget().click();
+          cy.findByPlaceholderText("Enter a number").type("3{enter}");
+          cy.button("Add filter").click();
+
+          assertFilterIsDisconnected();
+        });
+      });
+
+      it("should work for embedding with the editable parameter", function () {
+        const id = this.dashboardId;
+
+        cy.request("PUT", `/api/dashboard/${id}`, {
+          embedding_params: {
+            equal_to: "enabled",
+          },
+          enable_embedding: true,
+        });
+
+        const payload = {
+          resource: { dashboard: id },
+          params: {},
+        };
+
+        visitEmbeddedPage(payload);
+        assertFilterIsDisconnected();
+
+        filterWidget().click();
+        cy.findByPlaceholderText("Enter a number").type("3{enter}");
+        cy.button("Add filter").click();
+
+        assertFilterIsDisconnected();
+      });
+
+      it("should work for embedding with the locked parameter", function () {
+        const id = this.dashboardId;
+
+        cy.request("PUT", `/api/dashboard/${id}`, {
+          embedding_params: {
+            equal_to: "locked",
+          },
+          enable_embedding: true,
+        });
+
+        const payload = {
+          resource: { dashboard: id },
+          params: { equal_to: [3] },
+        };
+
+        visitEmbeddedPage(payload);
+        assertFilterIsDisconnected();
+      });
+    },
+  );
+});
+
+function connectFilterToColumn(column, index = 0) {
+  getDashboardCard().within(() => {
+    cy.findByText("Column to filter on");
+    cy.findByText("Select…").click();
+  });
+
+  popover().within(() => {
+    cy.findAllByText(column).eq(index).click();
+  });
+}
+
+function openFilterSettings() {
+  cy.findByTestId("fixed-width-filters").icon("gear").click();
+}
+
+function assertFilterIsDisconnected() {
+  cy.findAllByTestId("cell-data")
+    .should("contain", "christ")
+    .and("contain", "xavier")
+    .and("not.contain", "kale");
+}
+
+function assertFilterIsApplied() {
+  cy.findAllByTestId("cell-data")
+    .should("contain", "kale")
+    .and("contain", "pete")
+    .and("not.contain", "xavier");
+}

--- a/frontend/src/metabase-lib/v1/parameters/utils/targets.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/targets.ts
@@ -57,6 +57,10 @@ export function getParameterTargetField(
 
   // native queries
   if (isTemplateTagReference(fieldRef)) {
+    if (!Lib.queryDisplayInfo(question.query()).isNative) {
+      return null;
+    }
+
     const dimension = TemplateTagDimension.parseMBQL(
       fieldRef,
       metadata,

--- a/frontend/src/metabase-lib/v1/parameters/utils/targets.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/targets.ts
@@ -41,8 +41,10 @@ export function getTemplateTagFromTarget(target: ParameterTarget) {
   return type === "template-tag" ? tag : null;
 }
 
-// returns only real DB fields and not all mapped columns
-// for columns, use getMappingOptionByTarget
+/**
+ * Returns only real DB fields and not all mapped columns.
+ * Use getMappingOptionByTarget for columns.
+ */
 export function getParameterTargetField(
   question: Question,
   parameter: Parameter,

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapperButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapperButton.tsx
@@ -103,6 +103,7 @@ export const DashCardCardParameterMapperButton = ({
           buttonText: t`Unknown Field`,
           buttonIcon: (
             <CloseIconButton
+              aria-label={t`Disconnect`}
               onClick={e => {
                 handleChangeTarget(null);
                 e.stopPropagation();

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -7,6 +7,7 @@ import _ from "underscore";
 import Actions from "metabase/entities/actions";
 import Dashboards from "metabase/entities/dashboards";
 import Questions from "metabase/entities/questions";
+import Revisions from "metabase/entities/revisions";
 import { handleActions, combineReducers } from "metabase/lib/redux";
 import { NAVIGATE_BACK_TO_DASHBOARD } from "metabase/query_builder/actions";
 
@@ -328,6 +329,10 @@ const dashcardData = handleActions(
     },
     [Questions.actionTypes.UPDATE]: (state, { payload: { object: card } }) =>
       _.mapObject(state, dashboardData => dissoc(dashboardData, card.id)),
+    [Revisions.actionTypes.REVERT]: (state, { payload: revision }) =>
+      _.mapObject(state, dashboardData =>
+        dissoc(dashboardData, revision.model_id),
+      ),
   },
   INITIAL_DASHBOARD_STATE.dashcardData,
 );

--- a/frontend/src/metabase/entities/revisions.js
+++ b/frontend/src/metabase/entities/revisions.js
@@ -4,6 +4,8 @@ import { createEntity, entityCompatibleQuery } from "metabase/lib/entities";
 import Dashboards from "./dashboards";
 import Questions from "./questions";
 
+const REVERT = "metabase/entities/revisions/REVERT_REVISION";
+
 /**
  * @deprecated use "metabase/api" instead
  */
@@ -26,6 +28,10 @@ const Revision = createEntity({
         ),
   },
 
+  actionTypes: {
+    REVERT,
+  },
+
   objectActions: {
     // use thunk since we don't actually want to dispatch an action
     revert: revision => async dispatch => {
@@ -39,7 +45,8 @@ const Revision = createEntity({
         revisionApi.endpoints.revertRevision,
       );
 
-      return dispatch(Revision.actions.invalidateLists());
+      dispatch(Revision.actions.invalidateLists());
+      dispatch({ type: REVERT, payload: revision });
     },
   },
 


### PR DESCRIPTION
This PR originally only reproduced #35954, but then @ranquild did his magic and actually fixed the root cause, so now the PR resolves #35954.

We've added quite involved E2E reproduction that also checks for the public sharing and the embedding scenarios.
It tests for a lot of permutations and tries to cover some edge cases.
![image](https://github.com/metabase/metabase/assets/31325167/199ee7a0-f01e-4b7a-8868-54bbb81f01fc)

### Stress-test
10x ✅  https://github.com/metabase/metabase/actions/runs/9767290080
20x ✅ https://github.com/metabase/metabase/actions/runs/9767622124