### PR TITLE
fix(sdk): runtime error when font family is not provided

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabaseProvider.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabaseProvider.tsx
@@ -4,6 +4,7 @@ import { Provider } from "react-redux";
 
 import { AppInitializeController } from "embedding-sdk/components/private/AppInitializeController";
 import { SdkThemeProvider } from "embedding-sdk/components/private/SdkThemeProvider";
+import { DEFAULT_FONT } from "embedding-sdk/config";
 import type { SdkPluginsConfig } from "embedding-sdk/lib/plugins";
 import { store } from "embedding-sdk/store";
 import {
@@ -33,15 +34,13 @@ const MetabaseProviderInternal = ({
   pluginsConfig,
   theme,
 }: MetabaseProviderProps): JSX.Element => {
+  const { fontFamily = DEFAULT_FONT } = theme ?? {};
+
   useEffect(() => {
-    if (theme?.fontFamily) {
-      store.dispatch(
-        setOptions({
-          font: theme.fontFamily,
-        }),
-      );
+    if (fontFamily) {
+      store.dispatch(setOptions({ font: fontFamily }));
     }
-  }, [theme?.fontFamily]);
+  }, [fontFamily]);
 
   useEffect(() => {
     store.dispatch(setPlugins(pluginsConfig || null));

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -15,8 +15,7 @@ import { Router, useRouterHistory } from "react-router";
 import { routerReducer, routerMiddleware } from "react-router-redux";
 import _ from "underscore";
 
-import { AppInitializeController } from "embedding-sdk/components/private/AppInitializeController";
-import { SdkThemeProvider } from "embedding-sdk/components/private/SdkThemeProvider";
+import { MetabaseProviderInternal } from "embedding-sdk/components/public/MetabaseProvider";
 import { sdkReducers } from "embedding-sdk/store";
 import type { SdkStoreState } from "embedding-sdk/store/types";
 import { createMockSdkState } from "embedding-sdk/test/mocks/state";
@@ -26,7 +25,6 @@ import { UndoListing } from "metabase/containers/UndoListing";
 import { baseStyle } from "metabase/css/core/base.styled";
 import { mainReducers } from "metabase/reducers-main";
 import { publicReducers } from "metabase/reducers-public";
-import { EmotionCacheProvider } from "metabase/styled-components/components/EmotionCacheProvider";
 import { ThemeProvider } from "metabase/ui";
 import type { State } from "metabase-types/store";
 import { createMockState } from "metabase-types/store/mocks";
@@ -130,7 +128,7 @@ export function renderWithProviders(
   const wrapper = (props: any) => {
     if (mode === "sdk") {
       return (
-        <SdkWrapper {...props} config={sdkConfig} store={store} theme={theme} />
+        <MetabaseProviderInternal {...props} config={sdkConfig} store={store} />
       );
     }
 
@@ -199,31 +197,6 @@ export function TestWrapper({
           {withUndos && <UndoListing />}
         </ThemeProvider>
       </MaybeDNDProvider>
-    </Provider>
-  );
-}
-
-function SdkWrapper({
-  config,
-  children,
-  store,
-}: {
-  config: SDKConfig;
-  children: React.ReactElement;
-  store: any;
-  history?: History;
-  withRouter: boolean;
-  withDND: boolean;
-}) {
-  return (
-    <Provider store={store}>
-      <EmotionCacheProvider>
-        <SdkThemeProvider>
-          <AppInitializeController config={config}>
-            {children}
-          </AppInitializeController>
-        </SdkThemeProvider>
-      </EmotionCacheProvider>
     </Provider>
   );
 }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/44897

### Description

Fixes the SDK throwing runtime errors on `getFont` selector when the `theme` prop or the font family is not provided. In addition, it modifies the unit test to use `MetabaseProvider`

### How to verify

- Go to the Shoppy demo app.
- Remove the `theme` prop from MetabaseProvider.
- It should not crash the demo app when using this PR. It should crash with the current version of the SDK

### Checklist

- [x] Tests have been added/updated to cover changes in this PR - used MetabaseProvider for unit tests, so they take the behaviour of MetabaseProvider into consideration (i.e. setting `fontFamily`)
