### PR TITLE
do not reset metrics settings when dimension changes

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
@@ -766,6 +766,39 @@ describe("scenarios > visualizations > line chart", () => {
       cy.findByText(X_AXIS_VALUE);
     });
   });
+
+  it("should not reset selected metrics series when changing a dimension (metabase#42540)", () => {
+    visitQuestionAdhoc({
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [
+            ["count"],
+            ["sum", ["field", ORDERS.TOTAL, null]],
+            ["avg", ["field", ORDERS.QUANTITY, null]],
+          ],
+          breakout: [
+            ["field", PRODUCTS.CATEGORY, { "source-field": ORDERS.PRODUCT_ID }],
+          ],
+        },
+        type: "query",
+      },
+      display: "line",
+      visualization_settings: {
+        "graph.x_axis.scale": "ordinal",
+        "graph.dimensions": ["RATING"],
+        "graph.metrics": ["count", "sum"], // Only two metrics should be visible
+      },
+    });
+
+    cy.button("Summarize").click();
+    cy.findByLabelText("Tax").click();
+
+    cy.findByTestId("visualization-root")
+      .findAllByText("Average of Quantity")
+      .should("not.exist");
+  });
 });
 
 function showTooltipForFirstCircleInSeries(seriesColor) {

--- a/frontend/src/metabase/static-viz/components/ComboChart/settings.ts
+++ b/frontend/src/metabase/static-viz/components/ComboChart/settings.ts
@@ -6,7 +6,8 @@ import {
 } from "metabase/visualizations/echarts/cartesian/model/series";
 import type { LegacySeriesSettingsObjectKey } from "metabase/visualizations/echarts/cartesian/model/types";
 import {
-  getAreDimensionsAndMetricsValid,
+  getAreDimensionsValid,
+  getAreMetricsValid,
   getDefaultBubbleSizeCol,
   getDefaultDataLabelsFrequency,
   getDefaultDimensionFilter,
@@ -143,22 +144,17 @@ export const computeStaticComboChartSettings = (
     getDefaultMetricFilter(mainCard.display),
   );
 
-  const areDimensionsAndMetricsValid = getAreDimensionsAndMetricsValid(
-    rawSeries,
-    settings,
-  );
-
   fillWithDefaultValue(
     settings,
     "graph.dimensions",
     getDefaultDimensions(rawSeries, settings),
-    areDimensionsAndMetricsValid,
+    getAreDimensionsValid(rawSeries, settings),
   );
   fillWithDefaultValue(
     settings,
     "graph.metrics",
     getDefaultMetrics(rawSeries),
-    areDimensionsAndMetricsValid,
+    getAreMetricsValid(rawSeries, settings),
   );
 
   const cardsColumns = getCardsColumns(rawSeries, settings);

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -38,12 +38,13 @@ import {
   getDefaultColumns,
   getDefaultDimensionFilter,
   getDefaultMetricFilter,
-  getAreDimensionsAndMetricsValid,
   getDefaultDimensions,
   getDefaultShowStackValues,
   STACKABLE_DISPLAY_TYPES,
   getDefaultMetrics,
   isShowStackValuesValid,
+  getAreDimensionsValid,
+  getAreMetricsValid,
 } from "metabase/visualizations/shared/settings/cartesian-chart";
 import { isNumeric } from "metabase-lib/v1/types/utils/isa";
 
@@ -89,7 +90,7 @@ export const GRAPH_DATA_SETTINGS = {
         ? "0.5rem"
         : "1rem",
     isValid: (series, vizSettings) =>
-      getAreDimensionsAndMetricsValid(series, vizSettings),
+      getAreDimensionsValid(series, vizSettings),
     getDefault: (series, vizSettings) =>
       getDefaultDimensions(series, vizSettings),
     persistDefault: true,
@@ -150,8 +151,7 @@ export const GRAPH_DATA_SETTINGS = {
     section: t`Data`,
     title: t`Y-axis`,
     widget: "fields",
-    isValid: (series, vizSettings) =>
-      getAreDimensionsAndMetricsValid(series, vizSettings),
+    isValid: (series, vizSettings) => getAreMetricsValid(series, vizSettings),
     getDefault: series => getDefaultMetrics(series),
     persistDefault: true,
     getProps: ([{ card, data }], vizSettings, _onChange, extra) => {

--- a/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
@@ -35,22 +35,29 @@ export function getDefaultMetricFilter(display: string) {
   return display === "scatter" ? isNumeric : isMetric;
 }
 
-export function getAreDimensionsAndMetricsValid(
+export function getAreDimensionsValid(
   rawSeries: RawSeries,
   settings: ComputedVisualizationSettings,
 ) {
-  return rawSeries.some(
-    ({ card, data }) =>
-      columnsAreValid(
-        card.visualization_settings["graph.dimensions"],
-        data,
-        settings["graph._dimension_filter"],
-      ) &&
-      columnsAreValid(
-        card.visualization_settings["graph.metrics"],
-        data,
-        settings["graph._metric_filter"],
-      ),
+  return rawSeries.some(({ card, data }) =>
+    columnsAreValid(
+      card.visualization_settings["graph.dimensions"],
+      data,
+      settings["graph._dimension_filter"],
+    ),
+  );
+}
+
+export function getAreMetricsValid(
+  rawSeries: RawSeries,
+  settings: ComputedVisualizationSettings,
+) {
+  return rawSeries.some(({ card, data }) =>
+    columnsAreValid(
+      card.visualization_settings["graph.metrics"],
+      data,
+      settings["graph._metric_filter"],
+    ),
   );
 }
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/42540

### Description

This PR prevents metrics visualization settings from resetting when chart dimension changes so that users can swap a dimension without the need to reconfigure metrics settings.

### How to verify

1. New Orders -> Count of Rows and Sum of Total by Created at
2. Go to viz settings and remove "Sum of Total" from Y-axis
3. Open the Summarize sidebar and change the dimension to Tax by clicking on it (not on the plus button)
4. Ensure the chart shows only "Count" series and "Sum of Total" is hidden

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
