### PR TITLE
fix background on dashcard png export when in embed night theme

### DIFF
--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.module.css
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.module.css
@@ -12,7 +12,12 @@ body {
   background-color: var(--mb-color-bg-dashboard);
 }
 
-.ThemeNight.EmbedFrame {
+.ThemeNight.EmbedFrame,
+/* This is to make it work when exporting to pdfs, where the EmbedFrame is not
+part of the exported dom We don't export the whole EmbedFrame because it
+contains the header with the title and the tabs, or sometimes we just want to
+export a dashcard */
+.ThemeNight.EmbedFrame .WithThemeBackground {
   background-color: var(--mb-color-bg-black);
   border-color: var(--mb-color-bg-dark);
 }

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
@@ -14,6 +14,7 @@ import DashboardS from "metabase/css/dashboard.module.css";
 import * as MetabaseAnalytics from "metabase/lib/analytics";
 import { formatNumber } from "metabase/lib/formatting";
 import { equals } from "metabase/lib/utils";
+import EmbedFrameS from "metabase/public/components/EmbedFrame/EmbedFrame.module.css";
 import { getIsShowingRawTable } from "metabase/query_builder/selectors";
 import { getIsEmbeddingSdk } from "metabase/selectors/embed";
 import { getFont } from "metabase/styled-components/selectors";
@@ -518,7 +519,12 @@ class Visualization extends PureComponent {
           ) : (
             <div
               data-card-key={getCardKey(series[0].card?.id)}
-              className={cx(CS.flex, CS.flexColumn, CS.flexFull)}
+              className={cx(
+                CS.flex,
+                CS.flexColumn,
+                CS.flexFull,
+                EmbedFrameS.WithThemeBackground,
+              )}
             >
               <CardVisualization
                 {...this.props}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39546

### Description

This was in part extracted from [DRAFT- Embed pdf export - MS2 (+221 −55)](https://github.com/metabase/metabase/pull/44463) where I fixed the background issues for the newly added dashboard export in embedding (therefore with night theme)

### How to verify

For dashcard:
- from embed preview of a dashboard
- set theme to night
- use dashcard actions to download results -> png
- it should have dark background


For single card:
- from embed preview of card
- set theme to night
- download results -> png
- it should have dark background