### PR TITLE
Fix - Invalid join clause does not disappear after changing query source to use a different database

### DIFF
--- a/e2e/test/scenarios/joins/joins-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins-reproductions.cy.spec.js
@@ -1233,3 +1233,33 @@ describe.skip("issue 27521", () => {
     cy.findAllByTestId("header-cell").eq(index).should("have.text", name);
   }
 });
+
+describe("issue 42385", { tags: "@external" }, () => {
+  beforeEach(() => {
+    restore("postgres-12");
+    cy.signInAsNormalUser();
+  });
+
+  it("should remove invalid draft join clause when query database changes (metabase#42385)", () => {
+    openOrdersTable({ mode: "notebook" });
+    join();
+    entityPickerModal().within(() => {
+      entityPickerModalTab("Tables").click();
+      cy.findByText("Reviews").click();
+    });
+
+    getNotebookStep("data").findByTestId("data-step-cell").click();
+    entityPickerModal().within(() => {
+      cy.findByText("QA Postgres12").click();
+      cy.findByText("Reviews").click();
+    });
+
+    getNotebookStep("join").within(() => {
+      cy.findByLabelText("Right table")
+        .findByText("Pick data…")
+        .should("be.visible");
+      cy.findByLabelText("Left column").should("not.exist");
+      cy.findByLabelText("Right column").should("not.exist");
+    });
+  });
+});

--- a/e2e/test/scenarios/joins/joins-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins-reproductions.cy.spec.js
@@ -1237,7 +1237,7 @@ describe.skip("issue 27521", () => {
 describe("issue 42385", { tags: "@external" }, () => {
   beforeEach(() => {
     restore("postgres-12");
-    cy.signInAsNormalUser();
+    cy.signInAsAdmin();
   });
 
   it("should remove invalid draft join clause when query database changes (metabase#42385)", () => {

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinDraft/JoinDraft.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinDraft/JoinDraft.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useLatest } from "react-use";
 import { t } from "ttag";
 
 import { Box, Flex, Text } from "metabase/ui";
@@ -32,6 +33,7 @@ export function JoinDraft({
   isReadOnly,
   onJoinChange,
 }: JoinDraftProps) {
+  const databaseId = Lib.databaseID(query);
   const [strategy, setStrategy] = useState(
     () => initialStrategy ?? getDefaultJoinStrategy(query, stageIndex),
   );
@@ -84,6 +86,25 @@ export function JoinDraft({
       onJoinChange(newJoin);
     }
   };
+
+  const resetStateRef = useLatest(() => {
+    const rhsTableColumns = initialRhsTable
+      ? Lib.joinableColumns(query, stageIndex, initialRhsTable)
+      : [];
+
+    setStrategy(initialStrategy ?? getDefaultJoinStrategy(query, stageIndex));
+    setRhsTable(initialRhsTable);
+    setRhsTableColumns(rhsTableColumns);
+    setSelectedRhsTableColumns(rhsTableColumns);
+    setLhsColumn(undefined);
+  });
+
+  useEffect(
+    function resetStateOnDatabaseChange() {
+      resetStateRef.current();
+    },
+    [databaseId, resetStateRef],
+  );
 
   return (
     <Flex miw="100%" gap="1rem">


### PR DESCRIPTION
Closes #42385

### How to verify

1. Have another database connected
2. Start a question based on Orders table from Sample DB
3. Join Accounts table but do not specify join condition
4. Change data source to a table from a different DB

Right table should disappear from the join clause.
