### PR TITLE
Add a "See this dashboard" link for dashboard sub for slack

### DIFF
--- a/src/metabase/channel/slack.clj
+++ b/src/metabase/channel/slack.clj
@@ -124,6 +124,9 @@
                          :text {:type "plain_text"
                                 :text (:name dashboard)
                                 :emoji true}}
+        link-section    {:type "section"
+                         :fields [{:type "mrkdwn"
+                                   :text (str "<" (pulse-params/dashboard-url (:id dashboard) (pulse-params/parameters pulse dashboard)) "| See this dashboard>")}]}
         creator-section {:type   "section"
                          :fields [{:type "mrkdwn"
                                    :text (str "Sent by " (-> pulse :creator :common_name))}]}
@@ -134,9 +137,7 @@
         filter-section  (when (seq filter-fields)
                           {:type   "section"
                            :fields filter-fields})]
-    (if filter-section
-      {:blocks [header-section filter-section creator-section]}
-      {:blocks [header-section creator-section]})))
+    {:blocks (filter some? [header-section link-section filter-section creator-section])}))
 
 (defn- slack-dashboard-footer
   "Returns a block element with the footer text and link which should be at the end of a Slack dashboard subscription."

--- a/src/metabase/channel/slack.clj
+++ b/src/metabase/channel/slack.clj
@@ -126,11 +126,10 @@
                                 :emoji true}}
         link-section    {:type "section"
                          :fields [{:type "mrkdwn"
-                                   :text (str "<" (pulse-params/dashboard-url (:id dashboard) (pulse-params/parameters pulse dashboard)) "|"
-                                              "Sent from " (public-settings/site-name) ">")}]}
-        creator-section {:type   "section"
-                         :fields [{:type "mrkdwn"
-                                   :text (str "Sent by " (-> pulse :creator :common_name))}]}
+                                   :text (format "<%s | *Sent from %s by %s*>"
+                                                 (pulse-params/dashboard-url (:id dashboard) (pulse-params/parameters pulse dashboard))
+                                                 (public-settings/site-name)
+                                                 (-> pulse :creator :common_name))}]}
         filters         (pulse-params/parameters pulse dashboard)
         filter-fields   (for [filter filters]
                           {:type "mrkdwn"
@@ -138,7 +137,7 @@
         filter-section  (when (seq filter-fields)
                           {:type   "section"
                            :fields filter-fields})]
-    {:blocks (filter some? [header-section link-section filter-section creator-section])}))
+    {:blocks (filter some? [header-section filter-section link-section])}))
 
 (defn- create-slack-attachment-data
   "Returns a seq of slack attachment data structures, used in `create-and-upload-slack-attachments!`"

--- a/src/metabase/channel/slack.clj
+++ b/src/metabase/channel/slack.clj
@@ -126,7 +126,8 @@
                                 :emoji true}}
         link-section    {:type "section"
                          :fields [{:type "mrkdwn"
-                                   :text (str "<" (pulse-params/dashboard-url (:id dashboard) (pulse-params/parameters pulse dashboard)) "| See this dashboard>")}]}
+                                   :text (str "<" (pulse-params/dashboard-url (:id dashboard) (pulse-params/parameters pulse dashboard)) "|"
+                                              "Sent from " (public-settings/site-name) ">")}]}
         creator-section {:type   "section"
                          :fields [{:type "mrkdwn"
                                    :text (str "Sent by " (-> pulse :creator :common_name))}]}
@@ -138,16 +139,6 @@
                           {:type   "section"
                            :fields filter-fields})]
     {:blocks (filter some? [header-section link-section filter-section creator-section])}))
-
-(defn- slack-dashboard-footer
-  "Returns a block element with the footer text and link which should be at the end of a Slack dashboard subscription."
-  [pulse dashboard]
-  {:blocks
-   [{:type "divider"}
-    {:type "context"
-     :elements [{:type "mrkdwn"
-                 :text (str "<" (pulse-params/dashboard-url (:id dashboard) (pulse-params/parameters pulse dashboard)) "|"
-                            "*Sent from " (public-settings/site-name) "*>")}]}]})
 
 (defn- create-slack-attachment-data
   "Returns a seq of slack attachment data structures, used in `create-and-upload-slack-attachments!`"
@@ -164,5 +155,4 @@
     {:channel-id  channel-id
      :attachments (remove nil?
                           (flatten [(slack-dashboard-header pulse dashboard)
-                                    (create-slack-attachment-data payload)
-                                    (slack-dashboard-footer pulse dashboard)]))}))
+                                    (create-slack-attachment-data payload)]))}))

--- a/test/metabase/dashboard_subscription_test.clj
+++ b/test/metabase/dashboard_subscription_test.clj
@@ -341,20 +341,16 @@
             (is (= {:channel-id "#general"
                     :attachments
                     [{:blocks [{:type "header", :text {:type "plain_text", :text "Aviary KPIs", :emoji true}}
-                               {:type "section", :fields [{:type "mrkdwn", :text "Sent by Rasta Toucan"}]}]}
+                               {:type "section", :fields [{:type "mrkdwn", :text (str "<https://metabase.com/testmb/dashboard/"
+                                                                                      dashboard-id
+                                                                                      " | *Sent from Metabase Test by Rasta Toucan*>")}]}]}
                      {:title           pulse.test-util/card-name
                       :rendered-info   {:attachments false
                                         :content     true}
                       :title_link      (str "https://metabase.com/testmb/question/" card-id)
                       :attachment-name "image.png"
                       :channel-id      "FOO"
-                      :fallback        pulse.test-util/card-name}
-                     {:blocks [{:type "divider"}
-                               {:type "context"
-                                :elements [{:type "mrkdwn"
-                                            :text (str "<https://metabase.com/testmb/dashboard/"
-                                                       dashboard-id
-                                                       "|*Sent from Metabase Test*>")}]}]}]}
+                      :fallback        pulse.test-util/card-name}]}
                    (pulse.test-util/thunk->boolean pulse-results))))
           (testing "attached-results-text should be invoked exactly once"
             (is (= 1
@@ -394,20 +390,16 @@
           (is (= {:channel-id "#general"
                   :attachments
                   [{:blocks [{:type "header", :text {:type "plain_text", :text "Aviary KPIs", :emoji true}}
-                             {:type "section", :fields [{:type "mrkdwn", :text "Sent by Rasta Toucan"}]}]}
+                             {:type "section", :fields [{:type "mrkdwn", :text (str "<https://metabase.com/testmb/dashboard/"
+                                                                                dashboard-id
+                                                                                " | *Sent from Metabase Test by Rasta Toucan*>")}]}]}
                    {:title           pulse.test-util/card-name
                     :rendered-info   {:attachments false, :content true, :render/text true},
                     :title_link      (str "https://metabase.com/testmb/question/" card-id)
                     :attachment-name "image.png"
                     :channel-id      "FOO"
                     :fallback        pulse.test-util/card-name}
-                   {:blocks [{:type "section" :text {:type "mrkdwn" :text "*header*"}}]}
-                   {:blocks [{:type "divider"}
-                             {:type "context"
-                              :elements [{:type "mrkdwn"
-                                          :text (str "<https://metabase.com/testmb/dashboard/"
-                                                     dashboard-id
-                                                     "|*Sent from Metabase Test*>")}]}]}]}
+                   {:blocks [{:type "section" :text {:type "mrkdwn" :text "*header*"}}]}]}
                  (pulse.test-util/thunk->boolean pulse-results)))))}}))
 
 (deftest virtual-card-heading-test
@@ -441,20 +433,18 @@
                (is (= {:channel-id "#general"
                        :attachments
                        [{:blocks [{:type "header", :text {:type "plain_text", :text "Aviary KPIs", :emoji true}}
-                                  {:type "section", :fields [{:type "mrkdwn", :text "Sent by Rasta Toucan"}]}]}
+                                  {:type "section", :fields [{:type "mrkdwn"
+                                                              :text
+                                                              (str "<https://metabase.com/testmb/dashboard/"
+                                                               dashboard-id
+                                                               " | *Sent from Metabase Test by Rasta Toucan*>")}]}]}
                         {:title           pulse.test-util/card-name
                          :rendered-info   {:attachments false, :content true, :render/text true},
                          :title_link      (str "https://metabase.com/testmb/question/" card-id)
                          :attachment-name "image.png"
                          :channel-id      "FOO"
                          :fallback        pulse.test-util/card-name}
-                        {:blocks [{:type "section" :text {:type "mrkdwn" :text "*# header, quote isn't escaped*"}}]}
-                        {:blocks [{:type "divider"}
-                                  {:type "context"
-                                   :elements [{:type "mrkdwn"
-                                               :text (str "<https://metabase.com/testmb/dashboard/"
-                                                          dashboard-id
-                                                          "|*Sent from Metabase Test*>")}]}]}]}
+                        {:blocks [{:type "section" :text {:type "mrkdwn" :text "*# header, quote isn't escaped*"}}]}]}
                       (pulse.test-util/thunk->boolean pulse-results)))))}}))
 
 (deftest dashboard-filter-test
@@ -482,26 +472,25 @@
         :slack
         (fn [{:keys [card-id dashboard-id]} [pulse-results]]
           (testing "Markdown cards are included in attachments list as :blocks sublists, and markdown is
-                  converted to mrkdwn (Slack markup language) and truncated appropriately"
+                   converted to mrkdwn (Slack markup language) and truncated appropriately"
             (is (= {:channel-id "#general"
                     :attachments
                     [{:blocks [{:type "header", :text {:type "plain_text", :text "Aviary KPIs", :emoji true}}
+
                                {:type "section",
                                 :fields [{:type "mrkdwn", :text "*State*\nCA, NY…"}  ;; "*State*\nCA, NY and NJ"
                                          {:type "mrkdwn", :text "*Quarter and Y…"}]} ;; "*Quarter and Year*\nQ1, 2021"
-                               {:type "section", :fields [{:type "mrkdwn", :text "Sent by Rasta Toucan"}]}]}
+                               {:type "section", :fields [{:type "mrkdwn", :text
+                                                           (str "<https://metabase.com/testmb/dashboard/"
+                                                                dashboard-id
+                                                                "?state=CA&state=NY&state=NJ&quarter_and_year=Q1-2021 | *Sent from Metabase Test by Rasta Toucan*>")}]}]}
+
                      {:title           pulse.test-util/card-name
                       :rendered-info   {:attachments false, :content true, :render/text true},
                       :title_link      (str "https://metabase.com/testmb/question/" card-id)
                       :attachment-name "image.png"
                       :channel-id      "FOO"
-                      :fallback        pulse.test-util/card-name}
-                     {:blocks [{:type "divider"}
-                               {:type "context"
-                                :elements [{:type "mrkdwn"
-                                            :text (str "<https://metabase.com/testmb/dashboard/"
-                                                       dashboard-id
-                                                       "?state=CA&state=NY&state=NJ&quarter_and_year=Q1-2021|*Sent from Metabase Test*>")}]}]}]}
+                      :fallback        pulse.test-util/card-name}]}
                    (pulse.test-util/thunk->boolean pulse-results)))))}})))
 
 (deftest dashboard-with-link-card-test
@@ -560,7 +549,10 @@
                     :fields
                     [{:type "mrkdwn", :text "*State*\nCA, NY, and NJ"}
                      {:type "mrkdwn", :text "*Quarter and Year*\nQ1, 2021"}]}
-                   {:type "section", :fields [{:type "mrkdwn", :text "Sent by Rasta Toucan"}]}]}
+                   {:type "section", :fields [{:type "mrkdwn",
+                                               :text
+                                               #"<https://metabase\.com/testmb/dashboard/\d+\?state=CA&state=NY&state=NJ&quarter_and_year=Q1-2021\ \| \*Sent from Metabase Test by Rasta Toucan\*>"}]}]}
+
                  {:title "Test card",
                   :rendered-info {:attachments false, :content true, :render/text true},
                   :title_link #"https://metabase.com/testmb/question/.+",
@@ -594,14 +586,7 @@
                     :text
                     {:type "mrkdwn", :text #"\*<https://metabase\.com/testmb/question/\d+\|Linked model name>\*\nLinked model desc"}}]}
                  {:blocks
-                  [{:type "section", :text {:type "mrkdwn", :text "*<https://metabase.com|https://metabase.com>*"}}]}
-                 {:blocks
-                  [{:type "divider"}
-                   {:type "context",
-                    :elements
-                    [{:type "mrkdwn",
-                      :text
-                      #"<https://metabase\.com/testmb/dashboard/\d+\?state=CA&state=NY&state=NJ&quarter_and_year=Q1-2021\|\*Sent from Metabase Test\*>"}]}]}]}
+                  [{:type "section", :text {:type "mrkdwn", :text "*<https://metabase.com|https://metabase.com>*"}}]}]}
                (pulse.test-util/thunk->boolean pulse-results))))}}))
 
 (deftest mrkdwn-length-limit-test
@@ -875,7 +860,9 @@
                     :fields
                     [{:type "mrkdwn", :text "*State*\nCA, NY, and NJ"}
                      {:type "mrkdwn", :text "*Quarter and Year*\nQ1, 2021"}]}
-                   {:type "section", :fields [{:type "mrkdwn", :text "Sent by Rasta Toucan"}]}]}
+                   {:type "section", :fields [{:type "mrkdwn"
+                                               :text #"<https://metabase\.com/testmb/dashboard/\d+\?state=CA&state=NY&state=NJ&quarter_and_year=Q1-2021 \| \*Sent from Metabase Test by Rasta Toucan\*>"}]}]}
+
                  {:blocks [{:type "section", :text {:type "mrkdwn", :text "*The first tab*"}}]}
                  {:title "Test card",
                   :rendered-info {:attachments false, :content true, :render/text true},
@@ -887,14 +874,7 @@
                  {:blocks [{:type "section", :text {:type "mrkdwn", :text "Card 2 tab-1"}}]}
                  {:blocks [{:type "section", :text {:type "mrkdwn", :text "*The second tab*"}}]}
                  {:blocks [{:type "section", :text {:type "mrkdwn", :text "Card 1 tab-2"}}]}
-                 {:blocks [{:type "section", :text {:type "mrkdwn", :text "Card 2 tab-2"}}]}
-                 {:blocks
-                  [{:type "divider"}
-                   {:type "context",
-                    :elements
-                    [{:type "mrkdwn"
-                      :text
-                      #"<https://metabase\.com/testmb/dashboard/\d+\?state=CA&state=NY&state=NJ&quarter_and_year=Q1-2021\|\*Sent from Metabase Test\*>"}]}]}]}
+                 {:blocks [{:type "section", :text {:type "mrkdwn", :text "Card 2 tab-2"}}]}]}
                (pulse.test-util/thunk->boolean pulse-results))))}}))
 
 (defn- result-attachment


### PR DESCRIPTION
<img width="549" alt="Screenshot 2024-07-30 at 10 14 55" src="https://github.com/user-attachments/assets/69ca5d98-717a-411c-8e4c-8f8ec4bc0cef">

[See it for real](https://metaboat.slack.com/archives/C04R9F5A29F/p1722309284843159)


[Context](https://metaboat.slack.com/archives/C01LQQ2UW03/p1719841214331139)