### PR TITLE
Remove incorrect default parameter from release note generation code

### DIFF
--- a/release/src/github.ts
+++ b/release/src/github.ts
@@ -86,7 +86,7 @@ export const getMilestoneIssues = async ({
   owner,
   repo,
   state = "closed",
-  milestoneStatus = "closed"
+  milestoneStatus,
 }: ReleaseProps & { state?: "closed" | "open"; milestoneStatus?: 'open' | 'closed' }): Promise<Issue[]> => {
   const milestone = await findMilestone({ version, github, owner, repo, state: milestoneStatus });
 


### PR DESCRIPTION
By enabling release notes generation from either open or closed issues, I mis-set a defualt parameter in `getMilestonIssues()` - this removes that default and lets the (correct) default in `findMilestone()` prevail.

This did not affect the release-notes-preview job because it explicitly set its milestone status based on whether or not the version had been rleased already.