### PR TITLE
Reproduce #27643: Field filter linked to Boolean column causes an error when used in Embedding

### DIFF
--- a/e2e/support/helpers/e2e-setup-helpers.js
+++ b/e2e/support/helpers/e2e-setup-helpers.js
@@ -2,6 +2,22 @@ export function snapshot(name) {
   cy.request("POST", `/api/testing/snapshot/${name}`);
 }
 
+/**
+ *
+ * @param { |
+ * "blank" |
+ * "setup" |
+ * "without-models" |
+ * "default" |
+ * "default-ee" |
+ * "withSqlite" |
+ * "mongo-5" |
+ * "postgres-12" |
+ * "postgres-writable" |
+ * "mysql-8" |
+ * "mysql-writable"
+ * } name
+ */
 export function restore(name = "default") {
   cy.skipOn(name.includes("mongo") && Cypress.env("QA_DB_MONGO") !== true);
 

--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -592,6 +592,9 @@ describe.skip("27643", { tags: "@external" }, () => {
     /**
      * If we set the filter value now, this request won't be cancelled.
      * And it will override the result from the next request with filter value.
+     *
+     * This seems to only happen in Cypress since it click elements on the screen
+     * a lot faster than human. I tested this manually, and the requests were cancelled properly.
      */
     getDashboardCard()
       .findByText("Rows 1-6 of first 2000")


### PR DESCRIPTION
This is a repro test for #27643

#### Instruction for testing
- run the test with `yarn test-cypress-open-qa` since it requires Postgres DB.

![Screenshot 2024-07-02 at 8 33 34 PM](https://github.com/metabase/metabase/assets/1937582/e8b5c891-d370-4e25-a074-6a4f185a5eec)

To ensure this repo works, you can remove this line
https://github.com/metabase/metabase/blob/7d9da80164df41bf7fe99aeb159f5ec503d4e7ce/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js#L600

Which causes the card query in embedding to fail. And the test should pass.