### PR TITLE
Only check create-queries perms when fetching DB/schema metadata

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
@@ -25,8 +25,9 @@
      db-id
      (:table_id instance))))
 
-(defenterprise current-user-can-read-schema?
-  "Enterprise version. Returns a boolean whether the current user can read the given schema"
+(defenterprise current-user-can-manage-schema-metadata?
+  "Enterprise version. Returns a boolean whether the current user has permission to edit table metadata for any tables
+  in the schema"
   :feature :advanced-permissions
   [db-id schema-name]
   (data-perms/user-has-permission-for-schema?

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -174,9 +174,9 @@
                           :from     [:report_card]
                           :where    (into [:and
                                            [:not= :result_metadata nil]
-                                           [:= :archived false]
+                                           [:= :archived false
                                            ;; always return metrics for now
-                                                  [:in :type [(u/qualified-name card-type) "metric"]]
+                                                  [:in :type [(u/qualified-name card-type) "metric"]]]
                                            [:in :database_id ids-of-dbs-that-support-source-queries]
                                            (collection/visible-collection-ids->honeysql-filter-clause
                                             (collection/permissions-set->visible-collection-ids
@@ -1096,14 +1096,11 @@
   at least some of its tables?)"
   [database-id schema-name]
   (or
-   (and (= :unrestricted (data-perms/full-db-permission-for-user api/*current-user-id*
-                                                                 :perms/view-data
-                                                                 database-id))
-        (contains? #{:query-builder :query-builder-and-native}
-                   (data-perms/schema-permission-for-user api/*current-user-id*
-                                                          :perms/create-queries
-                                                          database-id
-                                                          schema-name)))
+   (contains? #{:query-builder :query-builder-and-native}
+              (data-perms/schema-permission-for-user api/*current-user-id*
+                                                     :perms/create-queries
+                                                     database-id
+                                                     schema-name))
    (current-user-can-read-schema? database-id schema-name)))
 
 (api/defendpoint GET "/:id/syncable_schemas"

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -1085,8 +1085,9 @@
 
 ;;; ------------------------------------------ GET /api/database/:id/schemas -----------------------------------------
 
-(defenterprise current-user-can-read-schema?
-  "OSS implementation. Returns a boolean whether the current user can write the given field."
+(defenterprise current-user-can-manage-schema-metadata?
+  "Returns a boolean whether the current user has permission to edit table metadata for any tables in the schema.
+  On OSS, this is only available to admins."
   metabase-enterprise.advanced-permissions.common
   [_db-id _schema-name]
   (mi/superuser?))
@@ -1101,7 +1102,7 @@
                                                      :perms/create-queries
                                                      database-id
                                                      schema-name))
-   (current-user-can-read-schema? database-id schema-name)))
+   (current-user-can-manage-schema-metadata? database-id schema-name)))
 
 (api/defendpoint GET "/:id/syncable_schemas"
   "Returns a list of all syncable schemas found for the database `id`."

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -174,9 +174,9 @@
                           :from     [:report_card]
                           :where    (into [:and
                                            [:not= :result_metadata nil]
-                                           [:= :archived false
+                                           [:= :archived false]
                                            ;; always return metrics for now
-                                                  [:in :type [(u/qualified-name card-type) "metric"]]]
+                                           [:in :type [(u/qualified-name card-type) "metric"]]
                                            [:in :database_id ids-of-dbs-that-support-source-queries]
                                            (collection/visible-collection-ids->honeysql-filter-clause
                                             (collection/permissions-set->visible-collection-ids

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -76,15 +76,11 @@
   ([_model pk]
    (if (should-read-audit-db? pk)
      false
-     (and (= :unrestricted (data-perms/full-db-permission-for-user
-                            api/*current-user-id*
-                            :perms/view-data
-                            pk))
-          (contains? #{:query-builder :query-builder-and-native}
-                    (data-perms/most-permissive-database-permission-for-user
-                     api/*current-user-id*
-                     :perms/create-queries
-                     pk))))))
+     (contains? #{:query-builder :query-builder-and-native}
+                (data-perms/most-permissive-database-permission-for-user
+                 api/*current-user-id*
+                 :perms/create-queries
+                 pk)))))
 
 (defenterprise current-user-can-write-db?
   "OSS implementation. Returns a boolean whether the current user can write the given field."


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/45046

When checking read permissions for databases or schemas (the _metadata_, not the data itself), we previously had required `Data access` to be `Unrestricted` for at least one table.

In the new permissions system in v50, this is now dependent instead on the new `Create queries` permission. You can see a database or schema if you have _at least_ query builder access to any table.

However, we were still checking that the user also has `View data` access to the entire database (either unrestricted or sandboxed). Originally this was fine, since these were the only two options for `View data`, so this was just an extra check that caused no issues. When we added the transitional `No self-service (deprecated)` permission level, however, this resulted in unexpected behavior: if a user is in a group with `No self-service (deprecated)` set for any table, it causes the entire DB to fail the read check and be hidden from the browse data page.

I've fixed this by removing the unnecessary conditions in DB/schema permission checks, and added a couple new test cases.