### PR TITLE
Adds plan-alias info to premium-embedding-token and exposes it in troubleshooting

### DIFF
--- a/src/metabase/public_settings/premium_features.clj
+++ b/src/metabase/public_settings/premium_features.clj
@@ -104,6 +104,7 @@
    [:status                         [:string {:min 1}]]
    [:error-details {:optional true} [:maybe [:string {:min 1}]]]
    [:features      {:optional true} [:sequential [:string {:min 1}]]]
+   [:plan-alias    {:optional true} :string]
    [:trial         {:optional true} :boolean]
    [:valid-thru    {:optional true} [:string {:min 1}]]
    [:max-users     {:optional true} pos-int?]

--- a/src/metabase/troubleshooting.clj
+++ b/src/metabase/troubleshooting.clj
@@ -40,6 +40,7 @@
                                        :jdbc-driver {:name    (.getDriverName metadata)
                                                      :version (.getDriverVersion metadata)}}))
     :run-mode                     (config/config-kw :mb-run-mode)
+    :plan-alias (or (some-> (premium-features/premium-embedding-token) premium-features/fetch-token-status :plan-alias) "")
     :version                      config/mb-version-info
     :settings                     {:report-timezone (driver/report-timezone)}}
    (when (premium-features/is-airgapped?)


### PR DESCRIPTION
resolves: #42828

We want to expose this in upselling at some point, according to the issue.

I've added it in the troubleshooting payload to help us verify.