### PR TITLE
Fix Menu button in admin app on mobile view

### DIFF
--- a/e2e/test/scenarios/admin/admin-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/admin/admin-reproductions.cy.spec.js
@@ -134,3 +134,37 @@ describe("issue 41765", { tags: ["@external"] }, () => {
     popover().findByText(COLUMN_DISPLAY_NAME).should("be.visible");
   });
 });
+
+describe("(metabase#45042)", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("Should display tabs in normal view, and a nav menu in mobile view", () => {
+    cy.visit("/admin");
+
+    //Ensure tabs are present in normal view
+    cy.findByRole("navigation").within(() => {
+      cy.findByRole("link", { name: "Settings" }).should("exist");
+      cy.findByRole("link", { name: "Exit admin" }).should("exist");
+    });
+
+    //Shrink viewport
+    cy.viewport(500, 750);
+
+    //ensure that hamburger is visible and functional
+    cy.findByRole("navigation").within(() => {
+      cy.findByRole("button", { name: /burger/ })
+        .should("exist")
+        .click();
+      cy.findByRole("list", { name: "nav-list" }).should("exist");
+      cy.findByRole("link", { name: "Settings" }).should("exist");
+      cy.findByRole("link", { name: "Exit admin" }).should("exist");
+    });
+
+    //Click something to dismiss nav list
+    cy.findByRole("link", { name: "General" }).click();
+    cy.findByRole("list", { name: "nav-list" }).should("not.exist");
+  });
+});

--- a/e2e/test/scenarios/admin/admin-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/admin/admin-reproductions.cy.spec.js
@@ -158,13 +158,13 @@ describe("(metabase#45042)", () => {
       cy.findByRole("button", { name: /burger/ })
         .should("exist")
         .click();
-      cy.findByRole("list", { name: "nav-list" }).should("exist");
+      cy.findByRole("list", { name: "Navigation links" }).should("exist");
       cy.findByRole("link", { name: "Settings" }).should("exist");
       cy.findByRole("link", { name: "Exit admin" }).should("exist");
     });
 
     //Click something to dismiss nav list
     cy.findByRole("link", { name: "General" }).click();
-    cy.findByRole("list", { name: "nav-list" }).should("not.exist");
+    cy.findByRole("list", { name: "Navigation links" }).should("not.exist");
   });
 });

--- a/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.module.css
+++ b/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.module.css
@@ -1,0 +1,3 @@
+.MobileHamburgerIcon {
+  color: var(--mb-color-text-white);
+}

--- a/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.tsx
+++ b/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.tsx
@@ -1,5 +1,6 @@
+import { useClickOutside } from "@mantine/hooks";
 import cx from "classnames";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { t } from "ttag";
 
 import LogoIcon from "metabase/components/LogoIcon";
@@ -13,6 +14,7 @@ import type { AdminPath } from "metabase-types/store";
 import StoreLink from "../StoreLink";
 
 import { AdminNavItem } from "./AdminNavItem";
+import AdminNavCS from "./AdminNavbar.module.css";
 import {
   AdminExitLink,
   AdminLogoContainer,
@@ -82,25 +84,23 @@ interface AdminMobileNavbarProps {
 const MobileNavbar = ({ adminPaths, currentPath }: AdminMobileNavbarProps) => {
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
 
-  useEffect(() => {
-    if (mobileNavOpen) {
-      const listener = () => setMobileNavOpen(false);
-      document.addEventListener("click", listener, { once: true });
-      return () => document.removeEventListener("click", listener);
-    }
-  }, [mobileNavOpen]);
+  const ref = useClickOutside(() => setMobileNavOpen(false));
 
   return (
-    <AdminMobileNavbar>
+    <AdminMobileNavbar ref={ref}>
       <Button
         onClick={() => setMobileNavOpen(prev => !prev)}
         variant="subtle"
         p="0.25rem"
       >
-        <Icon name="burger" size={32} color="text-white" />
+        <Icon
+          name="burger"
+          size={32}
+          className={AdminNavCS.MobileHamburgerIcon}
+        />
       </Button>
       {mobileNavOpen && (
-        <AdminMobileNavBarItems>
+        <AdminMobileNavBarItems aria-label="nav-list">
           {adminPaths.map(({ name, key, path }) => (
             <AdminNavItem
               name={name}

--- a/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.tsx
+++ b/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.tsx
@@ -100,7 +100,7 @@ const MobileNavbar = ({ adminPaths, currentPath }: AdminMobileNavbarProps) => {
         />
       </Button>
       {mobileNavOpen && (
-        <AdminMobileNavBarItems aria-label="nav-list">
+        <AdminMobileNavBarItems aria-label={t`Navigation links`}>
           {adminPaths.map(({ name, key, path }) => (
             <AdminNavItem
               name={name}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/45042

### Description
The menu button in the mobile view of the admin app had 2 issues: It was the incorrect color, and clicking it didn't appear to do anything. Color was fixed by applying the a CSS module. The issue with the popover not displaying was due to how the `useEffect` added a listener to dismiss the list if something was clicked outside the component. Basically, the event was being fired during the same render, causing the value to be set then unset very quickly. This useEffect was replaced with the Mantine `useClickOutside` hook.

### How to verify

1. Go to the admin app with a mobile view
2. The menu button should be white, and the menu should appear when clicking on it.

### Demo
![chrome_5hWu5wAbNM](https://github.com/metabase/metabase/assets/1328979/946662be-aa47-401b-a3a8-c54e9a8670a4)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
