### PR TITLE
Ignore unknown columns when reverting cards and dashboards

### DIFF
--- a/src/metabase/api/revision.clj
+++ b/src/metabase/api/revision.clj
@@ -3,8 +3,6 @@
    [compojure.core :refer [GET POST]]
    [metabase.api.card :as api.card]
    [metabase.api.common :as api]
-   [metabase.models.card :refer [Card]]
-   [metabase.models.dashboard :refer [Dashboard]]
    [metabase.models.revision :as revision :refer [Revision]]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
@@ -15,8 +13,8 @@
 
 (defn- model-and-instance [entity-name id]
   (case entity-name
-    "card"      [Card (t2/select-one Card :id id)]
-    "dashboard" [Dashboard (t2/select-one Dashboard :id id)]))
+    "card"      [:model/Card (t2/select-one :model/Card :id id)]
+    "dashboard" [:model/Dashboard (t2/select-one :model/Dashboard :id id)]))
 
 (api/defendpoint GET "/"
   "Get revisions of an object."
@@ -37,7 +35,7 @@
         _                (api/write-check instance)
         revision         (api/check-404 (t2/select-one Revision :model (name model), :model_id id, :id revision_id))]
     ;; if reverting a Card, make sure we have *data* permissions to run the query we're reverting to
-    (when (= model Card)
+    (when (= model :model/Card)
       (api.card/check-data-permissions-for-query (get-in revision [:object :dataset_query])))
     ;; ok, we're g2g
     (revision/revert!

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -291,9 +291,9 @@
    (remove #(contains? inactive-card-ids (:card_id %)) dashcards)))
 
 (defmethod revision/revert-to-revision! :model/Dashboard
-  [_model dashboard-id _user-id serialized-dashboard]
+  [model dashboard-id user-id serialized-dashboard]
   ;; Update the dashboard description / name / permissions
-  (t2/update! :model/Dashboard dashboard-id (dissoc serialized-dashboard :cards :tabs))
+  ((get-method revision/revert-to-revision! :default) model dashboard-id user-id (dissoc serialized-dashboard :cards :tabs))
   ;; Now update the tabs and cards as needed
   (let [serialized-dashcards      (:cards serialized-dashboard)
         current-tabs              (t2/select-fn-vec #(dissoc (t2.realize/realize %) :created_at :updated_at :entity_id :dashboard_id)

--- a/test/metabase/api/revision_test.clj
+++ b/test/metabase/api/revision_test.clj
@@ -2,13 +2,8 @@
   (:require
    [clojure.test :refer :all]
    [metabase.config :as config]
-   [metabase.models.card :refer [Card]]
-   [metabase.models.collection :refer [Collection]]
-   [metabase.models.dashboard :refer [Dashboard]]
-   [metabase.models.dashboard-card :refer [DashboardCard]]
-   [metabase.models.revision :as revision :refer [Revision]]
+   [metabase.models.revision :as revision]
    [metabase.test :as mt]
-   [metabase.test.data.users :as test.users]
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
    [toucan2.core :as t2]
@@ -18,7 +13,7 @@
 
 (def ^:private rasta-revision-info
   (delay
-    {:id (test.users/user->id :rasta), :common_name "Rasta Toucan", :first_name "Rasta", :last_name "Toucan"}))
+    {:id (mt/user->id :rasta), :common_name "Rasta Toucan", :first_name "Rasta", :last_name "Toucan"}))
 
 (defn- get-revisions [entity object-id]
   (for [revision (mt/user-http-request :rasta :get "revision" :entity entity, :id object-id)]
@@ -26,20 +21,20 @@
 
 (defn- create-card-revision! [card-id is-creation? user]
   (revision/push-revision!
-   {:object       (t2/select-one Card :id card-id)
-    :entity       Card
+   {:object       (t2/select-one :model/Card :id card-id)
+    :entity       :model/Card
     :id           card-id
-    :user-id      (test.users/user->id user)
+    :user-id      (mt/user->id user)
     :is-creation? is-creation?}))
 
 (defn- create-dashboard-revision!
   "Fetch the latest version of a Dashboard and save a revision entry for it. Returns the fetched Dashboard."
   [dash-id is-creation? user]
   (revision/push-revision!
-   {:object       (t2/select-one Dashboard :id dash-id)
-    :entity       Dashboard
+   {:object       (t2/select-one :model/Dashboard :id dash-id)
+    :entity       :model/Dashboard
     :id           dash-id
-    :user-id      (test.users/user->id user)
+    :user-id      (mt/user->id user)
     :is-creation? is-creation?}))
 
 ;;; # GET /revision
@@ -52,14 +47,14 @@
 ;; case with no revisions (maintains backwards compatibility with old installs before revisions)
 (deftest no-revisions-test
   (testing "Loading revisions, where there are no revisions, should work"
-    (t2.with-temp/with-temp [Card {:keys [id]}]
+    (t2.with-temp/with-temp [:model/Card {:keys [id]}]
       (is (= [{:user {}, :diff nil, :description "modified this.", :has_multiple_changes false}]
              (get-revisions :card id))))))
 
 ;; case with single creation revision
 (deftest single-revision-test
   (testing "Loading a single revision works"
-    (t2.with-temp/with-temp [Card {:keys [id] :as card}]
+    (t2.with-temp/with-temp [:model/Card {:keys [id] :as card}]
       (create-card-revision! (:id card) true :rasta)
       (is (=? [{:is_reversion         false
                 :is_creation          true
@@ -72,7 +67,7 @@
               (get-revisions :card id))))))
 
 (deftest get-revision-for-entity-with-revision-exceeds-max-revision-test
-  (t2.with-temp/with-temp [Card {:keys [id] :as card} {:name "A card"}]
+  (t2.with-temp/with-temp [:model/Card {:keys [id] :as card} {:name "A card"}]
     (create-card-revision! (:id card) true :rasta)
     (doseq [i (range (inc revision/max-revisions))]
       (t2/update! :model/Card (:id card) {:name (format "New name %d" i)})
@@ -98,15 +93,15 @@
 ;; case with multiple revisions, including reversion
 (deftest multiple-revisions-with-reversion-test
   (testing "Creating multiple revisions, with a reversion, works"
-    (t2.with-temp/with-temp [Card {:keys [id name], :as card}]
+    (t2.with-temp/with-temp [:model/Card {:keys [id name], :as card}]
       (create-card-revision! (:id card) true :rasta)
-      (t2/update! Card {:name "something else"})
+      (t2/update! :model/Card {:name "something else"})
       (create-card-revision! (:id card) false :rasta)
-      (t2/insert! Revision
+      (t2/insert! :model/Revision
                   :model        "Card"
                   :model_id     id
-                  :user_id      (test.users/user->id :rasta)
-                  :object       (revision/serialize-instance Card (:id card) card)
+                  :user_id      (mt/user->id :rasta)
+                  :object       (revision/serialize-instance :model/Card (:id card) card)
                   :message      "because i wanted to"
                   :is_creation  false
                   :is_reversion true)
@@ -158,11 +153,11 @@
 
 (deftest revert-test
   (testing "Reverting through API works"
-    (t2.with-temp/with-temp [Dashboard {:keys [id] :as dash}   {}
-                             Card      {card-id :id, :as card} {}]
+    (t2.with-temp/with-temp [:model/Dashboard {:keys [id] :as dash}   {}
+                             :model/Card      {card-id :id, :as card} {}]
       (is (=? {:id id}
               (create-dashboard-revision! (:id dash) true :rasta)))
-      (let [dashcard (first (t2/insert-returning-instances! DashboardCard
+      (let [dashcard (first (t2/insert-returning-instances! :model/DashboardCard
                                                             :dashboard_id id
                                                             :card_id (:id card)
                                                             :size_x 4
@@ -171,11 +166,11 @@
                                                             :col    0))]
         (is (=? {:id id}
                 (create-dashboard-revision! (:id dash) false :rasta)))
-        (is (pos? (t2/delete! (t2/table-name DashboardCard) :id (:id dashcard)))))
+        (is (pos? (t2/delete! (t2/table-name :model/DashboardCard) :id (:id dashcard)))))
       (is (=? {:id id}
               (create-dashboard-revision! (:id dash) false :rasta)))
       (testing "Revert to the previous revision, allowed because rasta has permissions on parent collection"
-        (let [[_ {previous-revision-id :id}] (revision/revisions Dashboard id)]
+        (let [[_ {previous-revision-id :id}] (revision/revisions :model/Dashboard id)]
           (is (=? {:id          int?
                    :description "reverted to an earlier version."}
                   (mt/user-http-request :rasta :post 200 "revision/revert" {:entity      :dashboard
@@ -226,14 +221,14 @@
 (deftest permission-check-on-revert-test
   (testing "Are permissions enforced by the revert action in the revision api?"
     (mt/with-non-admin-groups-no-root-collection-perms
-      (mt/with-temp [Collection collection {:name "Personal collection"}
-                     Dashboard  dashboard {:collection_id (u/the-id collection) :name "Personal dashboard"}]
+      (mt/with-temp [:model/Collection collection {:name "Personal collection"}
+                     :model/Dashboard  dashboard {:collection_id (u/the-id collection) :name "Personal dashboard"}]
         (create-dashboard-revision! (:id dashboard) true :crowberto)
         ;; update so that the revision is accepted
-        (t2/update! Dashboard :id (:id dashboard) {:name "Personal dashboard edited"})
+        (t2/update! :model/Dashboard :id (:id dashboard) {:name "Personal dashboard edited"})
         (create-dashboard-revision! (:id dashboard) false :crowberto)
         (let [dashboard-id          (u/the-id dashboard)
-              [_ {prev-rev-id :id}] (revision/revisions Dashboard dashboard-id)
+              [_ {prev-rev-id :id}] (revision/revisions :model/Dashboard dashboard-id)
               update-req            {:entity :dashboard, :id dashboard-id, :revision_id prev-rev-id}]
           ;; rasta should not have permissions to update the dashboard (i.e. revert), because they are not admin and do
           ;; not have any particular permission on the collection where it lives (because of the
@@ -244,52 +239,52 @@
 (deftest dashboard-revision-description-test
   (testing "revision description for dashboard are generated correctly"
     (t2.with-temp/with-temp
-      [Collection {coll-id :id}      {:name "New Collection"}
-       Card       {card-id-1 :id}    {:name "Card 1"}
-       Card       {card-id-2 :id}    {:name "Card 2"}
-       Dashboard  {dashboard-id :id} {:name "A dashboard"}]
+      [:model/Collection {coll-id :id}      {:name "New Collection"}
+       :model/Card       {card-id-1 :id}    {:name "Card 1"}
+       :model/Card       {card-id-2 :id}    {:name "Card 2"}
+       :model/Dashboard  {dashboard-id :id} {:name "A dashboard"}]
       ;; 0. create the dashboard
       (create-dashboard-revision! dashboard-id true :crowberto)
 
       ;; 1. rename
-      (t2/update! Dashboard :id dashboard-id {:name "New name"})
+      (t2/update! :model/Dashboard :id dashboard-id {:name "New name"})
       (create-dashboard-revision! dashboard-id false :crowberto)
 
       ;; 2. add description
-      (t2/update! Dashboard :id dashboard-id {:description "A beautiful dashboard"})
+      (t2/update! :model/Dashboard :id dashboard-id {:description "A beautiful dashboard"})
       (create-dashboard-revision! dashboard-id false :crowberto)
 
       ;; 3. add 2 cards
-      (let [dashcard-ids (t2/insert-returning-pks! DashboardCard [{:dashboard_id dashboard-id
-                                                                   :card_id      card-id-1
-                                                                   :size_x       4
-                                                                   :size_y       4
-                                                                   :col          1
-                                                                   :row          1}
-                                                                  {:dashboard_id dashboard-id
-                                                                   :card_id      card-id-2
-                                                                   :size_x       4
-                                                                   :size_y       4
-                                                                   :col          1
-                                                                   :row          1}])]
+      (let [dashcard-ids (t2/insert-returning-pks! :model/DashboardCard [{:dashboard_id dashboard-id
+                                                                          :card_id      card-id-1
+                                                                          :size_x       4
+                                                                          :size_y       4
+                                                                          :col          1
+                                                                          :row          1}
+                                                                         {:dashboard_id dashboard-id
+                                                                          :card_id      card-id-2
+                                                                          :size_x       4
+                                                                          :size_y       4
+                                                                          :col          1
+                                                                          :row          1}])]
         (create-dashboard-revision! dashboard-id false :crowberto)
 
         ;; 4. remove 1 card
-        (t2/delete! DashboardCard :id (first dashcard-ids))
+        (t2/delete! :model/DashboardCard :id (first dashcard-ids))
         (create-dashboard-revision! dashboard-id false :crowberto)
 
         ;; 5. arrange cards
-        (t2/update! DashboardCard :id (second dashcard-ids) {:col 2
-                                                             :row 2})
+        (t2/update! :model/DashboardCard :id (second dashcard-ids) {:col 2
+                                                                    :row 2})
         (create-dashboard-revision! dashboard-id false :crowberto))
 
       ;; 6. Move to a new collection
-      (t2/update! Dashboard :id dashboard-id {:collection_id coll-id})
+      (t2/update! :model/Dashboard :id dashboard-id {:collection_id coll-id})
       (create-dashboard-revision! dashboard-id false :crowberto)
 
       ;; 7. revert to an earlier revision
-      (let [earlier-revision-id (t2/select-one-pk Revision :model "Dashboard" :model_id dashboard-id {:order-by [[:timestamp :desc]]})]
-        (revision/revert! {:entity Dashboard :id dashboard-id :user-id (mt/user->id :crowberto) :revision-id earlier-revision-id}))
+      (let [earlier-revision-id (t2/select-one-pk :model/Revision :model "Dashboard" :model_id dashboard-id {:order-by [[:timestamp :desc]]})]
+        (revision/revert! {:entity :model/Dashboard :id dashboard-id :user-id (mt/user->id :crowberto) :revision-id earlier-revision-id}))
 
       (is (= [{:description          "reverted to an earlier version."
                :has_multiple_changes false}
@@ -313,19 +308,19 @@
 (deftest dashboard-width-revision-diff-test
   (testing "The Dashboard's revision history correctly reports dashboard width changes (#38910)"
     (t2.with-temp/with-temp
-        [Dashboard  {dashboard-id :id :as dash} {:name "A dashboard"}
-         Revision   _ {:model    "Dashboard"
-                       :model_id dashboard-id
-                       :user_id  (mt/user->id :crowberto)
-                       :object   (assoc dash :width nil)}
-         Revision   _ {:model    "Dashboard"
-                       :model_id dashboard-id
-                       :user_id  (mt/user->id :crowberto)
-                       :object   (assoc dash :width "full")}
-         Revision   _ {:model    "Dashboard"
-                       :model_id dashboard-id
-                       :user_id  (mt/user->id :crowberto)
-                       :object   (assoc dash :width "fixed")}]
+        [:model/Dashboard  {dashboard-id :id :as dash} {:name "A dashboard"}
+         :model/Revision   _ {:model    "Dashboard"
+                              :model_id dashboard-id
+                              :user_id  (mt/user->id :crowberto)
+                              :object   (assoc dash :width nil)}
+         :model/Revision   _ {:model    "Dashboard"
+                              :model_id dashboard-id
+                              :user_id  (mt/user->id :crowberto)
+                              :object   (assoc dash :width "full")}
+         :model/Revision   _ {:model    "Dashboard"
+                              :model_id dashboard-id
+                              :user_id  (mt/user->id :crowberto)
+                              :object   (assoc dash :width "fixed")}]
         (is (= ["changed the width setting from full to fixed."
                 "changed the width setting."
                 "modified this."]
@@ -335,39 +330,39 @@
 (deftest card-revision-description-test
   (testing "revision description for card are generated correctly"
     (t2.with-temp/with-temp
-      [Collection {coll-id :id} {:name "New Collection"}
-       Card       {card-id :id} {:name                   "A card"
-                                 :display                "table"
-                                 :dataset_query          (mt/mbql-query venues)
-                                 :visualization_settings {}}]
+      [:model/Collection {coll-id :id} {:name "New Collection"}
+       :model/Card       {card-id :id} {:name                   "A card"
+                                        :display                "table"
+                                        :dataset_query          (mt/mbql-query venues)
+                                        :visualization_settings {}}]
       ;; 0. create the card
       (create-card-revision! card-id true :crowberto)
 
       ;; 1. rename
-      (t2/update! Card :id card-id {:name "New name"})
+      (t2/update! :model/Card :id card-id {:name "New name"})
       (create-card-revision! card-id false :crowberto)
 
       ;; 2. turn to a model
-      (t2/update! Card :id card-id {:type :model})
+      (t2/update! :model/Card :id card-id {:type :model})
       (create-card-revision! card-id false :crowberto)
 
       ;; 3. edit query and metadata
-      (t2/update! Card :id card-id {:dataset_query (mt/mbql-query venues {:aggregation [[:count]]})
-                                    :display       "scalar"})
+      (t2/update! :model/Card :id card-id {:dataset_query (mt/mbql-query venues {:aggregation [[:count]]})
+                                           :display       "scalar"})
       (create-card-revision! card-id false :crowberto)
 
       ;; 4. add description
-      (t2/update! Card :id card-id {:description "meaningful number"})
+      (t2/update! :model/Card :id card-id {:description "meaningful number"})
       (create-card-revision! card-id false :crowberto)
 
 
       ;; 5. change collection
-      (t2/update! Card :id card-id {:collection_id coll-id})
+      (t2/update! :model/Card :id card-id {:collection_id coll-id})
       (create-card-revision! card-id false :crowberto)
 
       ;; 6. revert to an earlier revision
-      (let [earlier-revision-id (t2/select-one-pk Revision :model "Card" :model_id card-id {:order-by [[:timestamp :desc]]})]
-        (revision/revert! {:entity Card :id card-id :user-id (mt/user->id :crowberto) :revision-id earlier-revision-id}))
+      (let [earlier-revision-id (t2/select-one-pk :model/Revision :model "Card" :model_id card-id {:order-by [[:timestamp :desc]]})]
+        (revision/revert! {:entity :model/Card :id card-id :user-id (mt/user->id :crowberto) :revision-id earlier-revision-id}))
 
       (is (= [{:description          "reverted to an earlier version.",
                :has_multiple_changes false}
@@ -389,36 +384,36 @@
 (deftest card-metric-revision-description-test
   (testing "revision description for card are generated correctly"
     (t2.with-temp/with-temp
-      [Collection {coll-id :id} {:name "New Collection"}
-       Card       {card-id :id} {:name                   "A metric"
-                                 :display                "table"
-                                 :dataset_query          (mt/mbql-query venues)
-                                 :type :metric
-                                 :visualization_settings {}}]
+      [:model/Collection {coll-id :id} {:name "New Collection"}
+       :model/Card       {card-id :id} {:name                   "A metric"
+                                        :display                "table"
+                                        :dataset_query          (mt/mbql-query venues)
+                                        :type :metric
+                                        :visualization_settings {}}]
       ;; 0. create the card
       (create-card-revision! card-id true :crowberto)
 
       ;; 1. rename
-      (t2/update! Card :id card-id {:name "New name"})
+      (t2/update! :model/Card :id card-id {:name "New name"})
       (create-card-revision! card-id false :crowberto)
 
       ;; 2. edit query and metadata
-      (t2/update! Card :id card-id {:dataset_query (mt/mbql-query venues {:aggregation [[:count]]})
-                                    :display       "scalar"})
+      (t2/update! :model/Card :id card-id {:dataset_query (mt/mbql-query venues {:aggregation [[:count]]})
+                                           :display       "scalar"})
       (create-card-revision! card-id false :crowberto)
 
       ;; 3. add description
-      (t2/update! Card :id card-id {:description "meaningful number"})
+      (t2/update! :model/Card :id card-id {:description "meaningful number"})
       (create-card-revision! card-id false :crowberto)
 
 
       ;; 4. change collection
-      (t2/update! Card :id card-id {:collection_id coll-id})
+      (t2/update! :model/Card :id card-id {:collection_id coll-id})
       (create-card-revision! card-id false :crowberto)
 
       ;; 5. revert to an earlier revision
-      (let [earlier-revision-id (t2/select-one-pk Revision :model "Card" :model_id card-id {:order-by [[:timestamp :desc]]})]
-        (revision/revert! {:entity Card :id card-id :user-id (mt/user->id :crowberto) :revision-id earlier-revision-id}))
+      (let [earlier-revision-id (t2/select-one-pk :model/Revision :model "Card" :model_id card-id {:order-by [[:timestamp :desc]]})]
+        (revision/revert! {:entity :model/Card :id card-id :user-id (mt/user->id :crowberto) :revision-id earlier-revision-id}))
 
       (is (= [{:description          "reverted to an earlier version.",
                :has_multiple_changes false}
@@ -447,22 +442,22 @@
     (mt/with-temporary-setting-values [site-locale "fr"]
       (testing "revisions description are translated"
         (t2.with-temp/with-temp
-          [Card       {card-id :id} {:name                   "A card"
-                                     :display                "table"
-                                     :dataset_query          (mt/mbql-query venues)
-                                     :visualization_settings {}}]
+          [:model/Card       {card-id :id} {:name                   "A card"
+                                            :display                "table"
+                                            :dataset_query          (mt/mbql-query venues)
+                                            :visualization_settings {}}]
           ;; 0. create the card
           (create-card-revision! card-id true :crowberto)
 
           ;; 1. rename
-          (t2/update! Card :id card-id {:description "meaningful number"
-                                        :name        "New name"})
+          (t2/update! :model/Card :id card-id {:description "meaningful number"
+                                               :name        "New name"})
           (create-card-revision! card-id false :crowberto)
 
 
           ;; 2. revert to an earlier revision
-          (let [earlier-revision-id (t2/select-one-pk Revision :model "Card" :model_id card-id {:order-by [[:timestamp :desc]]})]
-            (revision/revert! {:entity Card :id card-id :user-id (mt/user->id :crowberto) :revision-id earlier-revision-id}))
+          (let [earlier-revision-id (t2/select-one-pk :model/Revision :model "Card" :model_id card-id {:order-by [[:timestamp :desc]]})]
+            (revision/revert! {:entity :model/Card :id card-id :user-id (mt/user->id :crowberto) :revision-id earlier-revision-id}))
 
           (is (= [{:description          "est revenu à une version antérieure."
                    :has_multiple_changes false}
@@ -477,25 +472,25 @@
 (deftest revert-does-not-create-new-revision
   (testing "revert a dashboard that previously added cards should not recreate duplicate revisions(#30869)"
     (t2.with-temp/with-temp
-      [Dashboard  {dashboard-id :id} {:name "A dashboard"}]
+      [:model/Dashboard  {dashboard-id :id} {:name "A dashboard"}]
       ;; 0. create the dashboard
       (create-dashboard-revision! dashboard-id true :crowberto)
 
       ;; 1. add 2 cards
-      (t2/insert-returning-pks! DashboardCard [{:dashboard_id dashboard-id
-                                                :size_x       4
-                                                :size_y       4
-                                                :col          1
-                                                :row          1}
-                                               {:dashboard_id dashboard-id
-                                                :size_x       4
-                                                :size_y       4
-                                                :col          1
-                                                :row          1}])
+      (t2/insert-returning-pks! :model/DashboardCard [{:dashboard_id dashboard-id
+                                                       :size_x       4
+                                                       :size_y       4
+                                                       :col          1
+                                                       :row          1}
+                                                      {:dashboard_id dashboard-id
+                                                       :size_x       4
+                                                       :size_y       4
+                                                       :col          1
+                                                       :row          1}])
       (create-dashboard-revision! dashboard-id false :crowberto)
 
-      (let [earlier-revision-id (t2/select-one-pk Revision :model "Dashboard" :model_id dashboard-id {:order-by [[:timestamp :desc]]})]
-        (revision/revert! {:entity Dashboard :id dashboard-id :user-id (mt/user->id :crowberto) :revision-id earlier-revision-id}))
+      (let [earlier-revision-id (t2/select-one-pk :model/Revision :model "Dashboard" :model_id dashboard-id {:order-by [[:timestamp :desc]]})]
+        (revision/revert! {:entity :model/Dashboard :id dashboard-id :user-id (mt/user->id :crowberto) :revision-id earlier-revision-id}))
 
       (is (= [{:description          "reverted to an earlier version."
                :has_multiple_changes false}
@@ -505,3 +500,37 @@
                :has_multiple_changes false}]
              (map #(select-keys % [:description :has_multiple_changes])
                   (mt/user-http-request :crowberto :get 200 "revision" :entity "dashboard" :id dashboard-id)))))))
+
+(deftest revert-ignores-extra-fields
+  (testing "Reverting should not error if nonexistent fields are present in the revert: "
+    (t2.with-temp/with-temp [:model/Card {card-id :id} {:name "A card"}
+                             :model/Dashboard {dashboard-id :id} {:name "A dashboard"}]
+      (testing "Reverting a card..."
+        ;; Create the revision with an extra, unknown field on the card
+        (revision/push-revision!
+         {:object       (assoc (t2/select-one :model/Card :id card-id) :unknown_field true)
+          :entity       :model/Card
+          :id           card-id
+          :user-id      (mt/user->id :crowberto)
+          :is-creation? false})
+        ;; Update the card to a new version
+        (t2/update! :model/Card {:name "A card with a new name"})
+        ;; Revert to the saved revision and check that the revert succeeded despite the extra field
+        (let [earlier-revision-id (t2/select-one-pk :model/Revision :model "Card" :model_id card-id {:order-by [[:timestamp :desc]]})]
+          (revision/revert! {:entity :model/Card :id card-id :user-id (mt/user->id :crowberto) :revision-id earlier-revision-id}))
+        (is (= "A card" (t2/select-one-fn :name :model/Card :id card-id))))
+
+      (testing "Reverting a dashboard..."
+        ;; Create the revision with an extra, unknown field on the dashboard
+        (revision/push-revision!
+         {:object       (assoc (t2/select-one :model/Dashboard :id dashboard-id) :unknown_field true)
+          :entity       :model/Dashboard
+          :id           dashboard-id
+          :user-id      (mt/user->id :crowberto)
+          :is-creation? false})
+        ;; Update the dashboard to a new version
+        (t2/update! :model/Dashboard {:name "A dashboard with a new name"})
+        ;; Revert to the saved revision and check that the revert succeeded despite the extra field
+        (let [earlier-revision-id (t2/select-one-pk :model/Revision :model "Dashboard" :model_id dashboard-id {:order-by [[:timestamp :desc]]})]
+          (revision/revert! {:entity :model/Dashboard :id dashboard-id :user-id (mt/user->id :crowberto) :revision-id earlier-revision-id}))
+        (is (= "A dashboard" (t2/select-one-fn :name :model/Dashboard :id dashboard-id)))))))

--- a/test/metabase/models/revision_test.clj
+++ b/test/metabase/models/revision_test.clj
@@ -355,8 +355,8 @@
   (mt/with-model-cleanup [:model/Revision]
     (testing "Check that reverting to a previous revision adds an appropriate revision"
       (t2.with-temp/with-temp [Card {card-id :id}]
-        (push-fake-revision! card-id, :name "Tips Created by Day")
-        (push-fake-revision! card-id, :name "Spots Created by Day")
+        (push-fake-revision! card-id :name "Tips Created by Day")
+        (push-fake-revision! card-id :name "Spots Created by Day")
         (let [[_ {old-revision-id :id}] (revision/revisions ::FakedCard card-id)]
           (revision/revert! {:entity ::FakedCard, :id card-id, :user-id (mt/user->id :rasta), :revision-id old-revision-id})
           (is (partial=


### PR DESCRIPTION
When reverting cards and dashboards, ignores columns that are present in the revision but don't exist on the actual model. This should solve cases where a field is dropped between versions and makes a revision incompatible.

I've done this by first selecting the existing instance that we're reverting (via table name rather than toucan model) and getting the set of keys that are present. Then we simply ignore any fields that aren't part of that set.

I've also added a test case for this, and did some clean up of old toucan model references (i.e. `Card` -> `:model/Card`).

Note: this is _not_ a comprehensive fix for cross-version revisions. There only handles cases where columns are dropped, but other types of schema changes could also break revisions. So we still need to add better error handling for cases that aren't covered. 

Resolves https://github.com/metabase/metabase/issues/31901

I've filed https://github.com/metabase/metabasea/issues/45070 as a lower-priority follow-up to surface error messages better in revisions.