### PR TITLE
Remove excess deprecation logs in production build

### DIFF
--- a/frontend/src/metabase/redux/metadata.js
+++ b/frontend/src/metabase/redux/metadata.js
@@ -5,13 +5,18 @@ import Databases from "metabase/entities/databases";
 import Fields from "metabase/entities/fields";
 import Segments from "metabase/entities/segments";
 import Tables from "metabase/entities/tables";
+import { isProduction } from "metabase/env";
 import { createThunkAction, fetchData } from "metabase/lib/redux";
 import { getMetadata } from "metabase/selectors/metadata";
 import { MetabaseApi, RevisionsApi } from "metabase/services";
 
 // NOTE: All of these actions are deprecated. Use metadata entities directly.
 
-const deprecated = message => console.warn("DEPRECATED: " + message);
+const deprecated = message => {
+  if (!isProduction) {
+    console.warn("DEPRECATED: " + message);
+  }
+};
 
 export const FETCH_SEGMENTS = Segments.actions.fetchList.toString();
 export const fetchSegments = (reload = false) => {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/45053

### Description

This removes deprecation logs mentioned in the task.

**Note:**

> instrument.js:111 [DEPRECATED] Default export is deprecated. Instead use `import { create } from 'zustand'`.

relates to sentry package, this should be fixed in the demo app itself

### How to verify

1. Check app in the dev mode (`yarn dev`), open any dashboard, deprecation logs should exist
2. Switch `isProduction` clause, deprecation logs should not be visible.

