### PR TITLE
Repro #42385 - Cover additional draft join scenario

### DIFF
--- a/e2e/test/scenarios/joins/joins-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins-reproductions.cy.spec.js
@@ -1262,4 +1262,28 @@ describe("issue 42385", { tags: "@external" }, () => {
       cy.findByLabelText("Right column").should("not.exist");
     });
   });
+
+  it("should remove invalid join clause in incomplete draft state when query database changes (metabase#42385)", () => {
+    openOrdersTable({ mode: "notebook" });
+    join();
+    entityPickerModal().within(() => {
+      entityPickerModalTab("Tables").click();
+      cy.findByText("Products").click();
+    });
+
+    getNotebookStep("join")
+      .findByLabelText("Right table")
+      .findByText("Products")
+      .click();
+
+    entityPickerModal().findByText("Reviews").click();
+
+    getNotebookStep("data").findByTestId("data-step-cell").click();
+    entityPickerModal().within(() => {
+      cy.findByText("QA Postgres12").click();
+      cy.findByText("Reviews").click();
+    });
+
+    getNotebookStep("join").should("not.exist");
+  });
 });


### PR DESCRIPTION
Follow-up on #45025 which was a fix for #42385.

### Description

Adds a test for [one more case](https://github.com/metabase/metabase/pull/45025#issuecomment-2203358162) with draft joins.
`JoinDraft` component is used in 2 places, the first PR covered only one of those places with tests.