### PR TITLE
Refine the reproduction for " Entity picker surfaces recent questions that are not valid joins" (#44974)

### DIFF
--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -1615,7 +1615,6 @@ describe.skip("issue 44974", () => {
     join();
 
     entityPickerModal().within(() => {
-      entityPickerModalTab("Recents").click();
       cy.findByText("Question 44794 in Postgres DB").should("not.exist");
     });
   });

--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -1595,32 +1595,31 @@ describe.skip("issue 44974", () => {
 
   it("entity picker should not offer to join with a table or a question from a different database (metabase#44974)", () => {
     withDatabase(PG_DB_ID, ({ PEOPLE_ID }) => {
-      createQuestion(
-        {
-          name: "Question 44794 in Postgres DB",
-          query: {
-            database: PG_DB_ID,
-            "source-table": PEOPLE_ID,
-            limit: 1,
-          },
+      const questionDetails = {
+        name: "Question 44794 in Postgres DB",
+        query: {
+          database: PG_DB_ID,
+          "source-table": PEOPLE_ID,
+          limit: 1,
         },
-        {
-          // Visit question to put it in recents
-          visitQuestion: true,
-        },
-      );
-    });
+      };
 
-    openOrdersTable({ mode: "notebook" });
-    join();
+      createQuestion(questionDetails, {
+        // Visit question to put it in recents
+        visitQuestion: true,
+      });
 
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Recents").should(
-        "have.attr",
-        "aria-selected",
-        "true",
-      );
-      cy.findByText("Question 44794 in Postgres DB").should("not.exist");
+      openOrdersTable({ mode: "notebook" });
+      join();
+
+      entityPickerModal().within(() => {
+        entityPickerModalTab("Recents").should(
+          "have.attr",
+          "aria-selected",
+          "true",
+        );
+        cy.findByText(questionDetails.name).should("not.exist");
+      });
     });
   });
 });

--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -1584,7 +1584,8 @@ describe("issue 44668", () => {
   });
 });
 
-describe("issue 44974", () => {
+// TODO: unskip when metabase#44974 is fixed
+describe.skip("issue 44974", () => {
   const PG_DB_ID = 2;
 
   beforeEach(() => {
@@ -1592,8 +1593,7 @@ describe("issue 44974", () => {
     cy.signInAsAdmin();
   });
 
-  // TODO: unskip when metabase#44974 is fixed
-  it.skip("should not be possible to join with a question from recents which is not in the same database (metabase#44974)", () => {
+  it("should not be possible to join with a question from recents which is not in the same database (metabase#44974)", () => {
     withDatabase(PG_DB_ID, ({ PEOPLE_ID }) => {
       createQuestion(
         {

--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -1593,7 +1593,7 @@ describe.skip("issue 44974", () => {
     cy.signInAsAdmin();
   });
 
-  it("should not be possible to join with a question from recents which is not in the same database (metabase#44974)", () => {
+  it("entity picker should not offer to join with a table or a question from a different database (metabase#44974)", () => {
     withDatabase(PG_DB_ID, ({ PEOPLE_ID }) => {
       createQuestion(
         {

--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -1615,6 +1615,11 @@ describe.skip("issue 44974", () => {
     join();
 
     entityPickerModal().within(() => {
+      entityPickerModalTab("Recents").should(
+        "have.attr",
+        "aria-selected",
+        "true",
+      );
       cy.findByText("Question 44794 in Postgres DB").should("not.exist");
     });
   });


### PR DESCRIPTION
Simplify the reproduction for https://github.com/metabase/metabase/issues/44974

This makes the test more performant and clear.

I've updated the issue description to include the more specific circumstances the issue happens in.

It requires both databases to have recent questions for the entity picker to show the wrong questions.