### PR TITLE
[serdes] a bit more descriptive exceptions

### DIFF
--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -338,7 +338,14 @@
 (defn- log-and-extract-one
   [model opts instance]
   (log/infof "Extracting %s %s" model (:id instance))
-  (extract-one model opts instance))
+  (try
+    (extract-one model opts instance)
+    (catch Exception e
+      (throw (ex-info (format "Exception extracting %s %s" model (:id instance))
+                      {:model     model
+                       :id        (:id instance)
+                       :entity_id (:entity_id instance)}
+                      e)))))
 
 (defmethod extract-all :default [model opts]
   (eduction (map (partial log-and-extract-one model opts))


### PR DESCRIPTION
While I'm trying to catch and fix all the errors that happen during serialization of stats I thought to see how they happen on the stats themselves. Right now it is just `ExceptionInfo: null`, which is not very telling - maybe this change will help.

References #44747