### PR TITLE
Optimize: compute chart title href only on mouseenter and focus

### DIFF
--- a/e2e/test/scenarios/dashboard/title-drill.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/title-drill.cy.spec.js
@@ -453,7 +453,7 @@ describe("scenarios > dashboard > title drill", () => {
       cy.signInAsAdmin();
     });
 
-    it.only("titles become actual HTML anchors on focus and on hover", () => {
+    it("titles become actual HTML anchors on focus and on hover", () => {
       cy.createDashboardWithQuestions({
         dashboardName: "Dashboard with aggregated Q2",
         questions: [
@@ -517,40 +517,46 @@ describe("scenarios > dashboard > title drill", () => {
         getDashboardCard(0)
           .findByRole("link", { name: "Line chart" })
           .as("line-chart-title");
-        cy.get("@line-chart-title").should("have.attr", "href", "#");
-        cy.get("@line-chart-title").focus();
-        cy.get("@line-chart-title")
-          .should("have.attr", "href")
-          .and("eq", `/question/${questions[0].id}-line-chart`);
-
         getDashboardCard(1)
           .findByRole("link", { name: "Row chart" })
           .as("row-chart-title");
-        cy.get("@row-chart-title").should("have.attr", "href", "#");
-        cy.get("@row-chart-title").focus();
-        cy.get("@row-chart-title")
-          .should("have.attr", "href")
-          .and("eq", `/question/${questions[1].id}-row-chart`);
-
         getDashboardCard(2)
           .findByRole("link", { name: "Map chart" })
           .as("map-chart-title");
-        cy.get("@map-chart-title").should("have.attr", "href", "#");
-        cy.get("@map-chart-title").realHover();
-        cy.get("@map-chart-title")
-          .should("have.attr", "href")
-          .and("eq", `/question/${questions[2].id}-map-chart`);
-
         getDashboardCard(3)
           .findByRole("link", { name: "Funnel chart" })
           .as("funnel-chart-title");
-        cy.get("@funnel-chart-title").should("have.attr", "href", "#");
-        cy.get("@funnel-chart-title").realHover();
-        cy.get("@funnel-chart-title")
-          .should("have.attr", "href")
-          .and("eq", `/question/${questions[3].id}-funnel-chart`);
+
+        assertTitleHrefOnFocus({
+          elementAlias: "@line-chart-title",
+          href: `/question/${questions[0].id}-line-chart`,
+        });
+        assertTitleHrefOnFocus({
+          elementAlias: "@row-chart-title",
+          href: `/question/${questions[1].id}-row-chart`,
+        });
+        assertTitleHrefOnHover({
+          elementAlias: "@map-chart-title",
+          href: `/question/${questions[2].id}-map-chart`,
+        });
+        assertTitleHrefOnHover({
+          elementAlias: "@funnel-chart-title",
+          href: `/question/${questions[3].id}-funnel-chart`,
+        });
       });
     });
+
+    function assertTitleHrefOnFocus({ elementAlias, href }) {
+      cy.get(elementAlias).should("have.attr", "href", "#");
+      cy.get(elementAlias).focus();
+      cy.get(elementAlias).should("have.attr", "href", href);
+    }
+
+    function assertTitleHrefOnHover({ elementAlias, href }) {
+      cy.get(elementAlias).should("have.attr", "href", "#");
+      cy.get(elementAlias).realHover();
+      cy.get(elementAlias).should("have.attr", "href", href);
+    }
   });
 });
 

--- a/e2e/test/scenarios/dashboard/title-drill.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/title-drill.cy.spec.js
@@ -44,15 +44,18 @@ describe("scenarios > dashboard > title drill", () => {
           cy.findByTestId("loading-indicator").should("not.exist");
 
           getDashboardCard().findByRole("link", { name: "Q1" }).as("title");
+          cy.get("@title").realHover();
           cy.get("@title")
             .should("have.attr", "href")
             .and("include", `/question/${questionId}`);
           cy.get("@title").click();
 
           queryBuilderMain().within(() => {
-            cy.findByText("This question is written in SQL.").should("exist");
-            cy.findByText("foo").should("exist");
-            cy.findByText("bar").should("exist");
+            cy.findByText("This question is written in SQL.").should(
+              "be.visible",
+            );
+            cy.findByText("foo").should("be.visible");
+            cy.findByText("bar").should("be.visible");
           });
 
           cy.location("pathname").should("eq", `/question/${questionId}-q1`);
@@ -71,15 +74,18 @@ describe("scenarios > dashboard > title drill", () => {
           cy.findByTestId("loading-indicator").should("not.exist");
 
           getDashboardCard().findByRole("link", { name: "Q1" }).as("title");
+          cy.get("@title").realHover();
           cy.get("@title")
             .should("have.attr", "href")
             .and("include", `/question/${questionId}`);
           cy.get("@title").click();
 
           queryBuilderMain().within(() => {
-            cy.findByText("This question is written in SQL.").should("exist");
-            cy.findByText("foo").should("exist");
-            cy.findByText("bar").should("exist");
+            cy.findByText("This question is written in SQL.").should(
+              "be.visible",
+            );
+            cy.findByText("foo").should("be.visible");
+            cy.findByText("bar").should("be.visible");
           });
 
           cy.location("pathname").should("eq", `/question/${questionId}-q1`);
@@ -272,6 +278,7 @@ describe("scenarios > dashboard > title drill", () => {
         getDashboardCard()
           .findByRole("link", { name: "GUI Question" })
           .as("title");
+        cy.get("@title").realHover();
         cy.get("@title")
           .should("have.attr", "href")
           .and("include", "/question#");
@@ -280,10 +287,10 @@ describe("scenarios > dashboard > title drill", () => {
         // make sure the query builder filter is present
         cy.findByTestId("qb-filters-panel")
           .findByText("Category is Doohickey")
-          .should("exist");
+          .should("be.visible");
 
         // make sure the results match
-        queryBuilderMain().findByText("42").should("exist");
+        queryBuilderMain().findByText("42").should("be.visible");
         cy.location("href").should("include", "/question#");
       });
     });
@@ -298,18 +305,19 @@ describe("scenarios > dashboard > title drill", () => {
         cy.wait("@cardQuery");
 
         // make sure query results are correct
-        getDashboardCard().findByText("42").should("exist");
+        getDashboardCard().findByText("42").should("be.visible");
 
         getDashboardCard()
           .findByRole("link", { name: "GUI Question" })
           .as("title");
+        cy.get("@title").realHover();
         cy.get("@title")
           .should("have.attr", "href")
           .and("include", "/question?category=Doohickey&id=#");
         cy.get("@title").click();
 
         // make sure the results match
-        queryBuilderMain().findByText("42").should("exist");
+        queryBuilderMain().findByText("42").should("be.visible");
         cy.get("@questionId").then(questionId => {
           cy.location("href").should(
             "include",
@@ -329,13 +337,13 @@ describe("scenarios > dashboard > title drill", () => {
         cy.wait("@cardQuery");
 
         // make sure the results reflect the new filter
-        queryBuilderMain().findByText("53").should("exist");
+        queryBuilderMain().findByText("53").should("be.visible");
 
         // make sure the set parameter filter persists after a page refresh
         cy.reload();
         cy.wait("@cardQuery");
 
-        queryBuilderMain().findByText("53").should("exist");
+        queryBuilderMain().findByText("53").should("be.visible");
 
         // make sure the unset id parameter works
         filterWidget().last().click();
@@ -348,7 +356,7 @@ describe("scenarios > dashboard > title drill", () => {
         cy.findAllByTestId("run-button").first().click();
         cy.wait("@cardQuery");
 
-        queryBuilderMain().findByText("1").should("exist");
+        queryBuilderMain().findByText("1").should("be.visible");
       });
     });
   });
@@ -423,6 +431,7 @@ describe("scenarios > dashboard > title drill", () => {
       getDashboardCard()
         .findByRole("link", { name: baseNestedQuestionDetails.name })
         .as("title");
+      cy.get("@title").realHover();
       cy.get("@title").should("have.attr", "href").and("include", "/question#");
       cy.get("@title").click();
 
@@ -444,7 +453,7 @@ describe("scenarios > dashboard > title drill", () => {
       cy.signInAsAdmin();
     });
 
-    it("titles are actual HTML anchors", () => {
+    it.only("titles become actual HTML anchors on focus and on hover", () => {
       cy.createDashboardWithQuestions({
         dashboardName: "Dashboard with aggregated Q2",
         questions: [
@@ -500,23 +509,44 @@ describe("scenarios > dashboard > title drill", () => {
       }).then(({ dashboard, questions }) => {
         visitDashboard(dashboard.id);
 
+        // make cursor start from a place where subsequent realHover() calls
+        // won't make the cursor move over the other cards during test
+        // (which would interfere with assertions)
+        cy.findByTestId("sidebar-toggle").realHover();
+
         getDashboardCard(0)
           .findByRole("link", { name: "Line chart" })
+          .as("line-chart-title");
+        cy.get("@line-chart-title").should("have.attr", "href", "#");
+        cy.get("@line-chart-title").focus();
+        cy.get("@line-chart-title")
           .should("have.attr", "href")
           .and("eq", `/question/${questions[0].id}-line-chart`);
 
         getDashboardCard(1)
           .findByRole("link", { name: "Row chart" })
+          .as("row-chart-title");
+        cy.get("@row-chart-title").should("have.attr", "href", "#");
+        cy.get("@row-chart-title").focus();
+        cy.get("@row-chart-title")
           .should("have.attr", "href")
           .and("eq", `/question/${questions[1].id}-row-chart`);
 
         getDashboardCard(2)
           .findByRole("link", { name: "Map chart" })
+          .as("map-chart-title");
+        cy.get("@map-chart-title").should("have.attr", "href", "#");
+        cy.get("@map-chart-title").realHover();
+        cy.get("@map-chart-title")
           .should("have.attr", "href")
           .and("eq", `/question/${questions[2].id}-map-chart`);
 
         getDashboardCard(3)
           .findByRole("link", { name: "Funnel chart" })
+          .as("funnel-chart-title");
+        cy.get("@funnel-chart-title").should("have.attr", "href", "#");
+        cy.get("@funnel-chart-title").realHover();
+        cy.get("@funnel-chart-title")
           .should("have.attr", "href")
           .and("eq", `/question/${questions[3].id}-funnel-chart`);
       });

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
@@ -16,7 +16,7 @@ import {
   isQuestionDashCard,
 } from "metabase/dashboard/utils";
 import { color } from "metabase/lib/colors";
-import { useSelector } from "metabase/lib/redux";
+import { useSelector, useStore } from "metabase/lib/redux";
 import { isJWT } from "metabase/lib/utils";
 import { PLUGIN_COLLECTIONS } from "metabase/plugins";
 import EmbedFrameS from "metabase/public/components/EmbedFrame/EmbedFrame.module.css";
@@ -32,7 +32,7 @@ import type {
   VirtualCard,
   VisualizationSettings,
 } from "metabase-types/api";
-import type { State, StoreDashcard } from "metabase-types/store";
+import type { StoreDashcard } from "metabase-types/store";
 
 import { DashCardRoot } from "./DashCard.styled";
 import { DashCardActionsPanel } from "./DashCardActionsPanel/DashCardActionsPanel";
@@ -115,9 +115,10 @@ function DashCardInner({
   const dashcardData = useSelector(state =>
     getDashcardData(state, dashcard.id),
   );
+  const store = useStore();
   const getHref = useCallback(
-    (state: State) => getDashcardHref(state, dashcard.id),
-    [dashcard.id],
+    () => getDashcardHref(store.getState(), dashcard.id),
+    [store, dashcard.id],
   );
   const [isPreviewingCard, setIsPreviewingCard] = useState(false);
   const cardRootRef = useRef<HTMLDivElement>(null);

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
@@ -32,7 +32,7 @@ import type {
   VirtualCard,
   VisualizationSettings,
 } from "metabase-types/api";
-import type { StoreDashcard } from "metabase-types/store";
+import type { State, StoreDashcard } from "metabase-types/store";
 
 import { DashCardRoot } from "./DashCard.styled";
 import { DashCardActionsPanel } from "./DashCardActionsPanel/DashCardActionsPanel";
@@ -115,7 +115,10 @@ function DashCardInner({
   const dashcardData = useSelector(state =>
     getDashcardData(state, dashcard.id),
   );
-  const href = useSelector(state => getDashcardHref(state, dashcard.id));
+  const getHref = useCallback(
+    (state: State) => getDashcardHref(state, dashcard.id),
+    [dashcard.id],
+  );
   const [isPreviewingCard, setIsPreviewingCard] = useState(false);
   const cardRootRef = useRef<HTMLDivElement>(null);
 
@@ -323,7 +326,7 @@ function DashCardInner({
           headerIcon={headerIcon}
           expectedDuration={expectedDuration}
           error={error}
-          href={navigateToNewCardFromDashboard ? href : undefined}
+          getHref={navigateToNewCardFromDashboard ? getHref : undefined}
           isAction={isAction}
           isEmbed={isEmbed}
           isXray={isXray}

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -27,7 +27,6 @@ import type {
   VisualizationSettings,
   DashboardCard,
 } from "metabase-types/api";
-import type { State } from "metabase-types/store";
 
 import { ClickBehaviorSidebarOverlay } from "./ClickBehaviorSidebarOverlay/ClickBehaviorSidebarOverlay";
 import {
@@ -47,7 +46,7 @@ interface DashCardVisualizationProps {
   dashcard: DashboardCard;
   series: Series;
   mode?: QueryClickActionsMode | Mode;
-  getHref?: (state: State) => string | undefined;
+  getHref?: () => string | undefined;
 
   gridSize: {
     width: number;

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -27,6 +27,7 @@ import type {
   VisualizationSettings,
   DashboardCard,
 } from "metabase-types/api";
+import type { State } from "metabase-types/store";
 
 import { ClickBehaviorSidebarOverlay } from "./ClickBehaviorSidebarOverlay/ClickBehaviorSidebarOverlay";
 import {
@@ -46,7 +47,7 @@ interface DashCardVisualizationProps {
   dashcard: DashboardCard;
   series: Series;
   mode?: QueryClickActionsMode | Mode;
-  href: string | undefined;
+  getHref?: (state: State) => string | undefined;
 
   gridSize: {
     width: number;
@@ -94,7 +95,7 @@ export function DashCardVisualization({
   dashboard,
   series,
   mode,
-  href,
+  getHref,
   gridSize,
   gridItemWidth,
   totalNumGridCols,
@@ -246,7 +247,7 @@ export function DashCardVisualization({
       rawSeries={series}
       metadata={metadata}
       mode={mode}
-      href={href}
+      getHref={getHref}
       gridSize={gridSize}
       totalNumGridCols={totalNumGridCols}
       headerIcon={headerIcon}

--- a/frontend/src/metabase/visualizations/components/ChartCaption.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartCaption.tsx
@@ -8,7 +8,6 @@ import type {
   TransformedSeries,
   VisualizationSettings,
 } from "metabase-types/api";
-import type { State } from "metabase-types/store";
 
 import { ChartCaptionRoot } from "./ChartCaption.styled";
 
@@ -18,7 +17,7 @@ interface ChartCaptionProps {
   icon?: IconProps;
   actionButtons?: ReactNode;
   width?: number;
-  getHref?: (state: State) => string | undefined;
+  getHref?: () => string | undefined;
   onChangeCardAndRun: OnChangeCardAndRun;
 }
 

--- a/frontend/src/metabase/visualizations/components/ChartCaption.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartCaption.tsx
@@ -8,6 +8,7 @@ import type {
   TransformedSeries,
   VisualizationSettings,
 } from "metabase-types/api";
+import type { State } from "metabase-types/store";
 
 import { ChartCaptionRoot } from "./ChartCaption.styled";
 
@@ -17,7 +18,7 @@ interface ChartCaptionProps {
   icon?: IconProps;
   actionButtons?: ReactNode;
   width?: number;
-  href?: string;
+  getHref?: (state: State) => string | undefined;
   onChangeCardAndRun: OnChangeCardAndRun;
 }
 
@@ -27,7 +28,7 @@ const ChartCaption = ({
   icon,
   actionButtons,
   onChangeCardAndRun,
-  href,
+  getHref,
   width,
 }: ChartCaptionProps) => {
   const title = settings["card.title"] ?? series[0].card.name;
@@ -47,7 +48,7 @@ const ChartCaption = ({
     <ChartCaptionRoot
       title={title}
       description={description}
-      href={href}
+      getHref={getHref}
       icon={icon}
       actionButtons={actionButtons}
       onSelectTitle={canSelectTitle ? handleSelectTitle : undefined}

--- a/frontend/src/metabase/visualizations/components/ChartCaption.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartCaption.unit.spec.tsx
@@ -2,7 +2,12 @@ import userEvent from "@testing-library/user-event";
 import type { ComponentPropsWithoutRef } from "react";
 import _ from "underscore";
 
-import { render, screen, getIcon, queryIcon } from "__support__/ui";
+import {
+  screen,
+  getIcon,
+  queryIcon,
+  renderWithProviders,
+} from "__support__/ui";
 import type { Card, Series } from "metabase-types/api";
 import {
   createMockCard,
@@ -51,7 +56,7 @@ const setup = (props: Partial<Props> = {}) => {
     width = 200,
   } = props;
 
-  render(
+  renderWithProviders(
     <ChartCaption
       series={series}
       onChangeCardAndRun={onChangeCardAndRun}

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
@@ -75,7 +75,7 @@ const SMALL_CARD_WIDTH_THRESHOLD = 150;
 
 class Visualization extends PureComponent {
   state = {
-    href: undefined,
+    getHref: undefined,
     hovered: null,
     clicked: null,
     error: null,
@@ -343,7 +343,7 @@ class Visualization extends PureComponent {
       actionButtons,
       className,
       dashcard,
-      href,
+      getHref,
       errorMessageOverride,
       showTitle,
       isDashboard,
@@ -491,7 +491,7 @@ class Visualization extends PureComponent {
                 icon={headerIcon}
                 actionButtons={extra}
                 width={width}
-                href={href}
+                getHref={getHref}
                 onChangeCardAndRun={
                   this.props.onChangeCardAndRun && !replacementContent
                     ? this.handleOnChangeCardAndRun
@@ -544,7 +544,7 @@ class Visualization extends PureComponent {
                 onRender={this.onRender}
                 onActionDismissal={this.hideActions}
                 gridSize={gridSize}
-                href={href}
+                getHref={getHref}
                 onChangeCardAndRun={
                   this.props.onChangeCardAndRun
                     ? this.handleOnChangeCardAndRun

--- a/frontend/src/metabase/visualizations/components/legend/LegendCaption.jsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendCaption.jsx
@@ -39,10 +39,6 @@ function shouldHideDescription(width) {
  * Using non-empty href will ensure that a focusable link is rendered.
  * We need a focusable element to handle onFocus.
  * (Using a div with tabIndex={0} breaks the sequence of focusable elements)
- *
- * All this is an optimization for computing the href, which uses getNewCardUrl
- * that makes a few MLv2 calls, which are expensive. It's a performance issue
- * on dashboards that have hundreds of dashcards - hence this lazy computation.
  */
 const HREF_PLACEHOLDER = "#";
 
@@ -57,6 +53,11 @@ const LegendCaption = ({
   width,
 }) => {
   const store = useStore();
+  /*
+   * Optimization: lazy computing the href, which uses getNewCardUrl,
+   * which makes a few MLv2 calls, which are expensive. It's a performance issue
+   * on dashboards that have hundreds of dashcards.
+   */
   const [href, setHref] = useState(getHref ? HREF_PLACEHOLDER : undefined);
 
   const handleFocus = useCallback(() => {

--- a/frontend/src/metabase/visualizations/components/legend/LegendCaption.jsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendCaption.jsx
@@ -54,9 +54,12 @@ const LegendCaption = ({
 }) => {
   const store = useStore();
   /*
-   * Optimization: lazy computing the href, which uses getNewCardUrl,
-   * which makes a few MLv2 calls, which are expensive. It's a performance issue
-   * on dashboards that have hundreds of dashcards.
+   * Optimization: lazy computing the href on title focus & mouseenter only.
+   * Href computation uses getNewCardUrl, which makes a few MLv2 calls,
+   * which are expensive.
+   * It's a performance issue on dashboards that have hundreds of dashcards
+   * (during initial render and after changing dashboard parameters which can
+   * potentially affect the href).
    */
   const [href, setHref] = useState(getHref ? HREF_PLACEHOLDER : undefined);
 

--- a/frontend/src/metabase/visualizations/components/legend/LegendCaption.jsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendCaption.jsx
@@ -7,7 +7,6 @@ import Markdown from "metabase/core/components/Markdown";
 import Tooltip from "metabase/core/components/Tooltip";
 import CS from "metabase/css/core/index.css";
 import DashboardS from "metabase/css/dashboard.module.css";
-import { useStore } from "metabase/lib/redux";
 import EmbedFrameS from "metabase/public/components/EmbedFrame/EmbedFrame.module.css";
 
 import LegendActions from "./LegendActions";
@@ -61,21 +60,18 @@ const LegendCaption = ({
    * potentially affect the href).
    */
   const [href, setHref] = useState(getHref ? HREF_PLACEHOLDER : undefined);
-  const store = useStore();
 
   const handleFocus = useCallback(() => {
     if (getHref) {
-      const state = store.getState();
-      setHref(getHref(state));
+      setHref(getHref());
     }
-  }, [store, getHref]);
+  }, [getHref]);
 
   const handleMouseEnter = useCallback(() => {
     if (getHref) {
-      const state = store.getState();
-      setHref(getHref(state));
+      setHref(getHref());
     }
-  }, [store, getHref]);
+  }, [getHref]);
 
   return (
     <LegendCaptionRoot className={className} data-testid="legend-caption">

--- a/frontend/src/metabase/visualizations/components/legend/LegendCaption.jsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendCaption.jsx
@@ -52,7 +52,6 @@ const LegendCaption = ({
   onSelectTitle,
   width,
 }) => {
-  const store = useStore();
   /*
    * Optimization: lazy computing the href on title focus & mouseenter only.
    * Href computation uses getNewCardUrl, which makes a few MLv2 calls,
@@ -62,6 +61,7 @@ const LegendCaption = ({
    * potentially affect the href).
    */
   const [href, setHref] = useState(getHref ? HREF_PLACEHOLDER : undefined);
+  const store = useStore();
 
   const handleFocus = useCallback(() => {
     if (getHref) {

--- a/frontend/src/metabase/visualizations/components/legend/LegendLabel.tsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendLabel.tsx
@@ -1,6 +1,7 @@
 import cx from "classnames";
 import {
   useCallback,
+  type FocusEventHandler,
   type MouseEvent,
   type MouseEventHandler,
   type ReactNode,
@@ -15,9 +16,18 @@ interface Props {
   className?: string;
   href?: LinkProps["to"];
   onClick: MouseEventHandler;
+  onFocus: FocusEventHandler;
+  onMouseEnter: MouseEventHandler;
 }
 
-export const LegendLabel = ({ children, className, href, onClick }: Props) => {
+export const LegendLabel = ({
+  children,
+  className,
+  href,
+  onClick,
+  onFocus,
+  onMouseEnter,
+}: Props) => {
   const handleLinkClick = useCallback(
     (event: MouseEvent) => {
       // Prefer programmatic onClick handling over native browser's href handling.
@@ -35,6 +45,8 @@ export const LegendLabel = ({ children, className, href, onClick }: Props) => {
           [S.link]: onClick,
         })}
         onClick={onClick}
+        onFocus={onFocus}
+        onMouseEnter={onMouseEnter}
       >
         {children}
       </div>
@@ -46,6 +58,8 @@ export const LegendLabel = ({ children, className, href, onClick }: Props) => {
       className={cx(S.text, S.link, className)}
       to={href}
       onClick={handleLinkClick}
+      onFocus={onFocus}
+      onMouseEnter={onMouseEnter}
     >
       {children}
     </Link>

--- a/frontend/src/metabase/visualizations/types/visualization.ts
+++ b/frontend/src/metabase/visualizations/types/visualization.ts
@@ -17,6 +17,7 @@ import type {
   TransformedSeries,
   VisualizationSettings,
 } from "metabase-types/api";
+import type { State } from "metabase-types/store";
 
 import type { RemappingHydratedDatasetColumn } from "./columns";
 import type { HoveredObject } from "./hover";
@@ -73,7 +74,7 @@ export interface StaticVisualizationProps {
 export interface VisualizationProps {
   series: Series;
   card: Card;
-  href: string | undefined;
+  getHref?: (state: State) => string | undefined;
   data: DatasetData;
   metadata: Metadata;
   rawSeries: RawSeries;

--- a/frontend/src/metabase/visualizations/types/visualization.ts
+++ b/frontend/src/metabase/visualizations/types/visualization.ts
@@ -17,7 +17,6 @@ import type {
   TransformedSeries,
   VisualizationSettings,
 } from "metabase-types/api";
-import type { State } from "metabase-types/store";
 
 import type { RemappingHydratedDatasetColumn } from "./columns";
 import type { HoveredObject } from "./hover";
@@ -74,7 +73,7 @@ export interface StaticVisualizationProps {
 export interface VisualizationProps {
   series: Series;
   card: Card;
-  getHref?: (state: State) => string | undefined;
+  getHref?: () => string | undefined;
   data: DatasetData;
   metadata: Metadata;
   rawSeries: RawSeries;

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
@@ -26,7 +26,7 @@ function _CartesianChart(props: VisualizationProps) {
     rawSeries,
     settings: originalSettings,
     card,
-    href,
+    getHref,
     gridSize,
     width,
     showTitle,
@@ -96,7 +96,7 @@ function _CartesianChart(props: VisualizationProps) {
           description={description}
           icon={headerIcon}
           actionButtons={actionButtons}
-          href={canSelectTitle ? href : undefined}
+          getHref={canSelectTitle ? getHref : undefined}
           onSelectTitle={canSelectTitle ? onOpenQuestion : undefined}
           width={width}
         />

--- a/frontend/src/metabase/visualizations/visualizations/Funnel/Funnel.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Funnel/Funnel.tsx
@@ -201,7 +201,7 @@ export function Funnel(props: VisualizationProps) {
     onChangeCardAndRun,
     rawSeries,
     fontFamily,
-    href,
+    getHref,
   } = props;
   const hasTitle = showTitle && settings["card.title"];
 
@@ -225,7 +225,7 @@ export function Funnel(props: VisualizationProps) {
           series={rawSeries}
           settings={settings}
           icon={headerIcon}
-          href={href}
+          getHref={getHref}
           actionButtons={actionButtons}
           onChangeCardAndRun={onChangeCardAndRun}
         />

--- a/frontend/src/metabase/visualizations/visualizations/Funnel/Funnel.unit.spec.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Funnel/Funnel.unit.spec.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from "__support__/ui";
+import { renderWithProviders, screen } from "__support__/ui";
 import { ThemeProvider } from "metabase/ui";
 import registerVisualizations from "metabase/visualizations/register";
 import {
@@ -45,7 +45,7 @@ const setup = (funnelProps, visualizationSettings = {}) => {
     ...visualizationSettings,
   });
 
-  render(
+  renderWithProviders(
     <ThemeProvider>
       <Funnel
         series={[series]}

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
@@ -111,7 +111,7 @@ const RowChartVisualization = ({
   series: multipleSeries,
   fontFamily,
   width,
-  href,
+  getHref,
 }: VisualizationProps) => {
   const formatColumnValue = useMemo(() => {
     return getColumnValueFormatter();
@@ -287,7 +287,7 @@ const RowChartVisualization = ({
           actionButtons={actionButtons}
           onSelectTitle={canSelectTitle ? openQuestion : undefined}
           width={width}
-          href={href}
+          getHref={getHref}
         />
       )}
       <RowChartLegendLayout


### PR DESCRIPTION
Optimization of #43816 due to #43258

### Description

Previously: `getNewCardUrl` was being called to compute `href` for every dashcard title on mount and when dashboard parameters changed
Now: `getNewCardUrl` is called only when chart title gets hovered or focused. This means 0 calls during initial render, so app does not freeze anymore (arguably; at least not because of `href` anymore)


### How to verify

Follow steps from #43258 (it requires importing 6GB SQL file)

### Demo - simple case

The 1st part of the video shows hover, and the 2nd part shows focus (with Tab key).

https://github.com/metabase/metabase/assets/6830683/6317a1d0-b7c8-47f4-b443-4740a7e578ed

### Demo - performance case from issue report

#### Before

In the recording app is frozen for approx. 8s at 0:16 - 0:24

https://github.com/metabase/metabase/assets/6830683/b205228f-6d56-4dae-86fe-f718f3a80f77

#### After

In the recording app is "frozen" for approx. 1s at 0:16 - 0:17 - that's the initial render of 300 cards.

https://github.com/metabase/metabase/assets/6830683/cd47a485-80c5-4ae2-ba9f-974d8b87b766



