### PR TITLE
ensure the canceled chan is closed

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -376,10 +376,12 @@
         (when cancel-chan
           (a/close! cancel-chan))))
     (catch java.util.concurrent.CancellationException _e
-      (a/close! cancel-chan)
+      (when cancel-chan
+        (a/close! cancel-chan))
       (throw (ex-info (tru "Query cancelled") {:sql sql :parameters parameters ::cancelled? true})))
     (catch BigQueryException e
-      (a/close! cancel-chan)
+      (when cancel-chan
+        (a/close! cancel-chan))
       (if (.isRetryable e)
         (throw (ex-info (tru "BigQueryException executing query")
                         {:retryable? (.isRetryable e), :sql sql, :parameters parameters}

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -749,7 +749,7 @@
               future-thread-names (fn []
                                     ;; kinda hacky but we don't control this thread pool
                                     (into #{} (comp (map (fn [^Thread t] (.getName t)))
-                                                    (filter #(str/includes? % "clojure-agent-send-off-pool")))
+                                                    (filter #(str/includes? % "bigquery-cancel-watcher")))
                                           (.keySet (Thread/getAllStackTraces))))
               count-before        (count (future-thread-names))]
           (dotimes [_ 10]

--- a/src/metabase/async/streaming_response.clj
+++ b/src/metabase/async/streaming_response.clj
@@ -74,6 +74,7 @@
       nil)
     (catch Throwable e
       (log/error e "Caught unexpected Exception in streaming response body")
+      (a/>!! canceled-chan :throwable)
       (write-error! os e)
       nil)))
 


### PR DESCRIPTION
Lots of ways to verify this.

#### Verifying with Siege

`siege` is a fantastic program. I'm testing by using a card against bigquery that selects 2000 rows. Grab an api key and then:

```
siege --concurrent=15 --time=30s --header="x-api-key:$API_KEY" "http://localhost:30500/api/card/108/query POST"
```

Hit it with 15 concurrent users for 30 seconds.

We will see some threads to watch for bigquery cancel chan, but they should go away

```clojure
;; on the fixed jar
user=> (count (into #{} (comp (map (fn [^Thread t] (.getName t)))
                        (filter #(str/includes? % "bigquery-cancel-watcher")))
              (.keySet (Thread/getAllStackTraces))))
30
user=> (count (into #{} (comp (map (fn [^Thread t] (.getName t)))
                        (filter #(str/includes? % "bigquery-cancel-watcher")))
              (.keySet (Thread/getAllStackTraces))))
0

;; on an unfixed jar these are acumulating
user=> (count (into #{} (comp (map (fn [^Thread t] (.getName t)))
                        (filter #(str/includes? % "bigquery-cancel-watcher")))
              (.keySet (Thread/getAllStackTraces))))
176
```

Note that i think we only leak now when there's an error in the streaming response, like

```
:cause Deflater has been closed, :_status 500}
java.lang.NullPointerException: Deflater has been closed
	at java.base/java.util.zip.Deflater.ensureOpen(Deflater.java:902)
	at java.base/java.util.zip.Deflater.deflate(Deflater.java:564)
	at java.base/java.util.zip.Deflater.deflate(Deflater.java:464)
	at java.base/java.util.zip.GZIPOutputStream.finish(GZIPOutputStream.java:163)
	at java.base/java.util.zip.DeflaterOutputStream.close(DeflaterOutputStream.java:244)
	at metabase.async.streaming_response$delay_output_stream$fn__52184.invoke(streaming_response.clj:120)
	at metabase.async.streaming_response.proxy$java.io.OutputStream$ff19274a.close(Unknown Source)
	at java.base/sun.nio.cs.StreamEncoder.implClose(StreamEncoder.java:439)
	at java.base/sun.nio.cs.StreamEncoder.lockedClose(StreamEncoder.java:237)
	at java.base/sun.nio.cs.StreamEncoder.close(StreamEncoder.java:222)
	at java.base/java.io.OutputStreamWriter.close(OutputStreamWriter.java:266)
	at java.base/java.io.BufferedWriter.implClose(BufferedWriter.java:398)
	at java.base/java.io.BufferedWriter.close(BufferedWriter.java:380)
	at metabase.async.streaming_response$write_error_BANG_.invokeStatic(streaming_response.clj:60)
	at metabase.async.streaming_response$write_error_BANG_.invoke(streaming_response.clj:45)
	at metabase.async.streaming_response$do_f_STAR_.invokeStatic(streaming_response.clj:77)
	at metabase.async.streaming_response$do_f_STAR_.invoke(streaming_response.clj:66)
	at metabase.async.streaming_response$do_f_async$task__52169.invoke(streaming_response.clj:87)
	at clojure.lang.AFn.run(AFn.java:22)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
2024-07-03 15:02:05,348 ERROR async.streaming-response :: bound-fn caught unexpected Exception
```