### PR TITLE
[QP] Test `:results_metadata` column names are disambiguated, eg. `ID_2`

### DIFF
--- a/test/metabase/query_processor/middleware/results_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/results_metadata_test.clj
@@ -377,3 +377,15 @@
     (is (=? {:status :completed
              :data   {:results_metadata (symbol "nil #_\"key is not present.\"")}}
             (qp/process-query (assoc-in query [:middleware :skip-results-metadata?] true))))))
+
+(deftest ^:parallel results-metadata-disambiguated-field-names-test
+  (let [query (mt/mbql-query orders {:joins  [{:source-table $$products
+                                               :alias        "Products"
+                                               :condition    [:= $product_id &Products.products.id]
+                                               :fields       [&Products.$products.id]}]
+                                     :fields [$id]
+                                     :limit  5})]
+    (is (=? {:status :completed
+             :data   {:results_metadata {:columns [{:name "ID"}
+                                                   {:name "ID_2"}]}}}
+            (mt/process-query query)))))


### PR DESCRIPTION
This makes the names inconsistent with what's in `data.cols` on the same
API response(!) but consistent with what MBQL lib will return for this query.

The change to the prod code was incorporated into #44999; this adds a test for the logic.