### PR TITLE
Batch permission updates with many tables

### DIFF
--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -700,6 +700,16 @@
   (doseq [[perm-type perm-value] (new-database-permissions group-or-id)]
     (set-database-permission! group-or-id db-or-id perm-type perm-value)))
 
+(def ^:private ^:dynamic *permission-batch-size* 1000)
+
+(defn- batch-insert-permissions!
+  "In certain cases, when updating the permissions for many tables at once, we need to batch the insertions to avoid
+  hitting database limits for the number of parameters in a prepared statement. This is only really applicable when a DB
+  has more than ~10k tables and we're transitioning from database-level permissions to table-level permissions."
+  [new-perms]
+  (doseq [batched-new-perms (partition-all *permission-batch-size* new-perms)]
+    (t2/insert! :model/DataPermissions batched-new-perms)))
+
 (mu/defn set-table-permissions!
   "Sets table permissions to specified values for a given group. If a permission value already exists for a specified
   group and table, it will be updated to the new value.
@@ -777,7 +787,7 @@
                                             :schema_name (:schema table)})
                                          other-tables)]
                 (t2/delete! :model/DataPermissions :id (:id existing-db-perm))
-                (t2/insert! :model/DataPermissions (concat other-new-perms new-perms))))
+                (batch-insert-permissions! (concat other-new-perms new-perms))))
             (let [existing-table-perms (t2/select :model/DataPermissions
                                                   :perm_type (u/qualified-name perm-type)
                                                   :group_id  group-id
@@ -794,7 +804,7 @@
                 ;; Otherwise, just replace the rows for the individual table perm
                 (do
                   (t2/delete! :model/DataPermissions :perm_type perm-type :group_id group-id {:where [:in :table_id table-ids]})
-                  (t2/insert! :model/DataPermissions new-perms))))))))))
+                  (batch-insert-permissions! new-perms))))))))))
 
 (mu/defn set-table-permission!
   "Sets permissions for a single table to the specified value for a given group."

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -700,14 +700,14 @@
   (doseq [[perm-type perm-value] (new-database-permissions group-or-id)]
     (set-database-permission! group-or-id db-or-id perm-type perm-value)))
 
-(def ^:private ^:dynamic *permission-batch-size* 1000)
+(def ^:private permission-batch-size 1000)
 
 (defn- batch-insert-permissions!
   "In certain cases, when updating the permissions for many tables at once, we need to batch the insertions to avoid
   hitting database limits for the number of parameters in a prepared statement. This is only really applicable when a DB
   has more than ~10k tables and we're transitioning from database-level permissions to table-level permissions."
   [new-perms]
-  (doseq [batched-new-perms (partition-all *permission-batch-size* new-perms)]
+  (doseq [batched-new-perms (partition-all permission-batch-size new-perms)]
     (t2/insert! :model/DataPermissions batched-new-perms)))
 
 (mu/defn set-table-permissions!


### PR DESCRIPTION
Addresses the likely root cause of a error reported by a customer: https://metaboat.slack.com/archives/C013N8XL286/p1720022143997779

Basically, for most permission updates, we just need to write a single row. However, if permissions are set at the DB-level (i.e. a single row for every table in the DB) and we change the permission of a single table, we need to delete the DB-level row and write a row for _every_ table to ensure consistency. 

Because we're writing these new table-level rows in a single `t2/insert!` call, it's generating a prepared statement with 6 parameters (one for each column in the `data_permissions` table) for every table. If the DB has more than 10,922 tables, this will hit Postgres's limit for parameters in a single prepared statement. The customer in question indicated they have fewer than this number of tables, but I can't see any other possible root cause of their error message.

Batching this into several updates gets around this limit. I've tested manually using a temp DB with many tables to ensure that the writes succeed. The permissions page itself is incredibly slow with this many tables but the DB writes don't seem to be the bottleneck. Not sure there's a great way to unit test this but open to suggestions.

If this is still an issue we can consider other more structural changes to reduce the number of permissions that needs to be written in this scenario. 