### PR TITLE
Allow unrestricted data perms to override block even if another table has legacy no-self-service

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/block_permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/block_permissions.clj
@@ -14,14 +14,14 @@
   [[metabase.models.collection]] for more details."
   :feature :advanced-permissions
   [{database-id :database :as query}]
-  (let [table-ids (query-perms/query->source-table-ids query)]
-    (or
-     (not= :blocked (data-perms/full-db-permission-for-user api/*current-user-id* :perms/view-data database-id))
+  (or
+   (not= :blocked (data-perms/full-db-permission-for-user api/*current-user-id* :perms/view-data database-id))
+   (let [table-ids (query-perms/query->source-table-ids query)]
      (= #{:unrestricted}
         (set
          (map (partial data-perms/table-permission-for-user api/*current-user-id* :perms/view-data database-id)
-              table-ids)))
-     (throw (ex-info (tru "Blocked: you are not allowed to run queries against Database {0}." database-id)
-                     {:type               qp.error-type/missing-required-permissions
-                      :actual-permissions @api/*current-user-permissions-set*
-                      :permissions-error? true})))))
+              table-ids))))
+   (throw (ex-info (tru "Blocked: you are not allowed to run queries against Database {0}." database-id)
+                   {:type               qp.error-type/missing-required-permissions
+                    :actual-permissions @api/*current-user-permissions-set*
+                    :permissions-error? true}))))

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/block_permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/block_permissions.clj
@@ -2,6 +2,7 @@
   (:require
    [metabase.api.common :as api]
    [metabase.models.data-permissions :as data-perms]
+   [metabase.models.query.permissions :as query-perms]
    [metabase.public-settings.premium-features :refer [defenterprise]]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.util.i18n :refer [tru]]))
@@ -12,10 +13,15 @@
   current User has unrestricted data permissions from another Group. See the namespace documentation for
   [[metabase.models.collection]] for more details."
   :feature :advanced-permissions
-  [{database-id :database}]
-  (or
-   (not= :blocked (data-perms/full-db-permission-for-user api/*current-user-id* :perms/view-data database-id))
-   (throw (ex-info (tru "Blocked: you are not allowed to run queries against Database {0}." database-id)
-                   {:type               qp.error-type/missing-required-permissions
-                    :actual-permissions @api/*current-user-permissions-set*
-                    :permissions-error? true}))))
+  [{database-id :database :as query}]
+  (let [table-ids (query-perms/query->source-table-ids query)]
+    (or
+     (not= :blocked (data-perms/full-db-permission-for-user api/*current-user-id* :perms/view-data database-id))
+     (= #{:unrestricted}
+        (set
+         (map (partial data-perms/table-permission-for-user api/*current-user-id* :perms/view-data database-id)
+              table-ids)))
+     (throw (ex-info (tru "Blocked: you are not allowed to run queries against Database {0}." database-id)
+                     {:type               qp.error-type/missing-required-permissions
+                      :actual-permissions @api/*current-user-permissions-set*
+                      :permissions-error? true})))))

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -351,7 +351,7 @@
 (mu/defn full-db-permission-for-user :- PermissionValue
   "Returns the effective *db-level* permission value for a given user, permission type, and database ID. If the user
   has multiple permissions for the given type in different groups, they are coalesced into a single value. The
-  db-level permission is the *most* restrictive table-level permission within that schema."
+  db-level permission is the *most* restrictive table-level permission within that database."
   [user-id perm-type database-id]
   (when (not= :model/Table (model-by-perm-type perm-type))
     (throw (ex-info (tru "Permission type {0} is not a table-level permission." perm-type)

--- a/src/metabase/models/query/permissions.clj
+++ b/src/metabase/models/query/permissions.clj
@@ -184,7 +184,7 @@
 
 (defn check-data-perms
   "Checks whether the current user has sufficient data permissions to run `query`. Returns `true` if the user has data
-  perms for the query, and throws an exception otherwise (exceptions cna be disabled by setting `throw-exceptions?` to
+  perms for the query, and throws an exception otherwise (exceptions can be disabled by setting `throw-exceptions?` to
   `false`).
 
   If the [:gtap ::perms] path is present in the query, these perms are implicitly granted to the current user."


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/45116

This PR fixes block permission enforcement so that `unrestricted` data permissions for a table override block permissions, but `legacy-no-self-service` does not. Previously block permissions were being enforced all-or-nothing for a database. This means that a single table with `legacy-no-self-service` effectively makes the entire DB `legacy-no-self-service`, until the permission is updated to a normal value.

My solution is to additionally check the permissions for each individual table in the query, and skip enforcing block perms if any of them have `unrestricted` data perms.

Similar to https://github.com/metabase/metabase/pull/45045 this bug is an artifact of the fact that we added `legacy-no-self-service` towards the end of the project after the permission enforcement code had been migrated to the new APIs, and so we didn't detect all of the edge cases that resulted. (It's also a more niche case in the permissions migration.)