### PR TITLE
ci: pin replayio version

### DIFF
--- a/.github/actions/prepare-cypress/action.yml
+++ b/.github/actions/prepare-cypress/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Install Replay.io browser
-      run: npx replayio install
+      run: npx replayio@1.5.1 install
       shell: bash
 
     - name: Check to see if dependencies should be cached


### PR DESCRIPTION
### Description

[context](https://metaboat.slack.com/archives/C052LBPDAF3/p1720041261983819)
pin replayio to avoid installing the latest version of the package to prevent CI from being affected by the broken package.

npx and not a dependency in package.json was used as a package brings a lot of dependencies with it

### How to verify

CI is green
