### PR TITLE
Do not insert newlines when typing text in the native editor.

### DIFF
--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.js
@@ -586,6 +586,7 @@ describe("issue 34330", () => {
 
     // can't use cy.type because it does not simulate the bug
     // Delay needed for React 18. TODO: fix shame
+    cy.wait(50);
     editor.type("USER").type("_", { delay: 1000 });
 
     cy.wait("@autocomplete").then(({ request }) => {

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.js
@@ -586,7 +586,6 @@ describe("issue 34330", () => {
 
     // can't use cy.type because it does not simulate the bug
     // Delay needed for React 18. TODO: fix shame
-    cy.wait(50);
     editor.type("USER").type("_", { delay: 1000 });
 
     cy.wait("@autocomplete").then(({ request }) => {

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -232,6 +232,9 @@ export class NativeQueryEditor extends Component<
     this.loadAceEditor();
     document.addEventListener("keydown", this.handleKeyDown);
     document.addEventListener("contextmenu", this.handleRightClick);
+
+    // hmmm, this could be dangerous
+    this.focus();
   }
 
   handleRightClick = (event: MouseEvent) => {
@@ -433,9 +436,6 @@ export class NativeQueryEditor extends Component<
 
     // reset undo manager to prevent undoing to empty editor
     editor.getSession().getUndoManager().reset();
-
-    // hmmm, this could be dangerous
-    this.focus();
 
     const aceLanguageTools = ace.require("ace/ext/language_tools");
     editor.setOptions({

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -186,6 +186,7 @@ export class NativeQueryEditor extends Component<
 
   _editor: Ace.Editor | null = null;
   _localUpdate = false;
+  _focusTimeout: number | NodeJS.Timeout = -1;
 
   constructor(props: Props) {
     super(props);
@@ -319,6 +320,7 @@ export class NativeQueryEditor extends Component<
     if (this.props.cancelQueryOnLeave) {
       this.props.cancelQuery?.();
     }
+    clearTimeout(this._focusTimeout);
     this._editor?.destroy?.();
     document.removeEventListener("keydown", this.handleKeyDown);
     document.removeEventListener("contextmenu", this.handleRightClick);
@@ -398,9 +400,11 @@ export class NativeQueryEditor extends Component<
       return;
     }
 
+    clearTimeout(this._focusTimeout);
+
     // HACK: the cursor doesn't blink without this intended small delay
     // HACK: the editor injects newlines into the query without this small delay
-    setTimeout(() => this._editor?.focus(), 50);
+    this._focusTimeout = setTimeout(() => this._editor?.focus(), 50);
   }
 
   loadAceEditor() {

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -396,6 +396,7 @@ export class NativeQueryEditor extends Component<
     }
 
     // HACK: the cursor doesn't blink without this intended small delay
+    // HACK: the editor injects newlines into the query without this small delay
     setTimeout(() => this._editor?.focus(), 50);
   }
 
@@ -434,9 +435,7 @@ export class NativeQueryEditor extends Component<
     editor.getSession().getUndoManager().reset();
 
     // hmmm, this could be dangerous
-    if (!this.props.readOnly) {
-      editor.focus();
-    }
+    this.focus();
 
     const aceLanguageTools = ace.require("ace/ext/language_tools");
     editor.setOptions({

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -736,7 +736,7 @@ export class NativeQueryEditor extends Component<
 
   handleQueryGenerated = (queryText: string) => {
     this.handleQueryUpdate(queryText);
-    this._editor?.focus();
+    this.focus();
   };
 
   isPromptInputVisible = () => {
@@ -760,7 +760,7 @@ export class NativeQueryEditor extends Component<
     const queryText = Lib.rawNativeQuery(query);
 
     this.handleQueryUpdate(await formatQuery(queryText, engine));
-    this._editor?.focus();
+    this.focus();
   };
 
   render() {

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -390,6 +390,15 @@ export class NativeQueryEditor extends Component<
     }
   };
 
+  focus() {
+    if (this.props.readOnly) {
+      return;
+    }
+
+    // HACK: the cursor doesn't blink without this intended small delay
+    setTimeout(() => this._editor?.focus(), 50);
+  }
+
   loadAceEditor() {
     const { query } = this.props;
 
@@ -692,10 +701,7 @@ export class NativeQueryEditor extends Component<
       setDatasetQuery(query.setDatabaseId(databaseId).setDefaultCollection());
 
       onSetDatabaseId?.(databaseId);
-      if (!this.props.readOnly) {
-        // HACK: the cursor doesn't blink without this intended small delay
-        setTimeout(() => this._editor?.focus(), 50);
-      }
+      this.focus();
     }
   };
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/40538

### Description

Works around a weird quirk in the ACE editor that causes newlines to be inserted when focus is called to quickly.

We were already using a timeout elsewhere, this approach just consolidates that.

The original issue was introduced when [upgrading to React 18](https://github.com/metabase/metabase/pull/41975).

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> SQL Query
2. Start typing `SELECT`
3. Make sure the editor does not add spurious newlines

### Demo

https://github.com/metabase/metabase/assets/1250185/780ac0ba-101d-436b-8c4b-f0c2331409f6



### Checklist

I found no way to reproduce this issue in Cypress. I think the bug is innocent enough for it not to have e2e tests.