### PR TITLE
Fix #44754: qbnewq modal can't be dismissed with keyboard

### DIFF
--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -2,6 +2,7 @@ import { USERS } from "e2e/support/cypress_data";
 import {
   ADMIN_PERSONAL_COLLECTION_ID,
   ORDERS_DASHBOARD_ID,
+  ORDERS_BY_YEAR_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
 import {
   describeEE,
@@ -23,6 +24,7 @@ import {
   entityPickerModal,
   dashboardGrid,
   entityPickerModalTab,
+  visitQuestion,
 } from "e2e/support/helpers";
 
 const { admin } = USERS;
@@ -127,6 +129,20 @@ describe("scenarios > home > homepage", () => {
       cy.wait("@getDashboard");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders");
+    });
+
+    it("should be able to dismiss qbnewq modal using keyboard (metabase#44754)", () => {
+      cy.intercept("PUT", "/api/user/*/modal/qbnewb").as("modalDismiss");
+
+      cy.signInAsNormalUser();
+      visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
+      modal()
+        .should("be.visible")
+        .and("contain", "It's okay to play around with saved questions");
+
+      cy.realPress("Escape");
+      cy.wait("@modalDismiss");
+      modal().should("not.exist");
     });
 
     // TODO: popular items endpoint is currently broken in OSS. Re-enable test once endpoint has been fixed.

--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -132,9 +132,22 @@ describe("scenarios > home > homepage", () => {
     });
 
     it("should be able to dismiss qbnewq modal using keyboard (metabase#44754)", () => {
-      cy.intercept("PUT", "/api/user/*/modal/qbnewb").as("modalDismiss");
+      const randomUser = {
+        email: "random@metabase.test",
+        password: "12341234",
+      };
 
-      cy.signInAsNormalUser();
+      // We've already dismissed qbnewq modal for all existing users.
+      cy.log("Create a new admin user and log in as that user");
+      cy.request("POST", "/api/user", randomUser).then(({ body: { id } }) => {
+        cy.request("PUT", `/api/user/${id}`, { is_superuser: true });
+        cy.request("POST", "/api/session", {
+          username: randomUser.email,
+          password: randomUser.password,
+        });
+      });
+
+      cy.intercept("PUT", "/api/user/*/modal/qbnewb").as("modalDismiss");
       visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
       modal()
         .should("be.visible")

--- a/frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.tsx
+++ b/frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.tsx
@@ -46,12 +46,12 @@ export const SavedQuestionIntroModal = ({
   return (
     <Modal.Root opened={isShowingNewbModal} onClose={onClose} size={500}>
       <Modal.Overlay />
-      <Modal.Content p="1rem">
-        <Modal.Header mb="1rem">
+      <Modal.Content p="md">
+        <Modal.Header mb="md">
           <Modal.Title>{title}</Modal.Title>
         </Modal.Header>
         <Modal.Body ta="center">
-          <Box mb="1rem" ta="left">
+          <Box mb="md" ta="left">
             {message}
           </Box>
           <Button variant="filled" onClick={onClose}>{t`Okay`}</Button>

--- a/frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.tsx
+++ b/frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.tsx
@@ -1,6 +1,6 @@
 import { t } from "ttag";
 
-import { Modal, Button, Box } from "metabase/ui";
+import { Modal, Button, Text } from "metabase/ui";
 import type Question from "metabase-lib/v1/Question";
 
 interface Props {
@@ -51,9 +51,9 @@ export const SavedQuestionIntroModal = ({
           <Modal.Title>{title}</Modal.Title>
         </Modal.Header>
         <Modal.Body ta="center">
-          <Box mb="md" ta="left">
+          <Text mb="lg" align="left">
             {message}
-          </Box>
+          </Text>
           <Button variant="filled" onClick={onClose}>{t`Okay`}</Button>
         </Modal.Body>
       </Modal.Content>

--- a/frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.tsx
+++ b/frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.tsx
@@ -1,10 +1,6 @@
-import cx from "classnames";
 import { t } from "ttag";
 
-import Modal from "metabase/components/Modal";
-import ModalContent from "metabase/components/ModalContent";
-import ButtonsS from "metabase/css/components/buttons.module.css";
-import CS from "metabase/css/core/index.css";
+import { Modal, Button, Box } from "metabase/ui";
 import type Question from "metabase-lib/v1/Question";
 
 interface Props {
@@ -48,18 +44,19 @@ export const SavedQuestionIntroModal = ({
   const { title, message } = getLabels(question);
 
   return (
-    <Modal isOpen={isShowingNewbModal}>
-      <ModalContent title={title} className={cx(CS.textCentered, CS.py2)}>
-        <div className={cx(CS.px2, CS.pb2, CS.textParagraph)}>{message}</div>
-        <div className={cx("Form-actions", CS.flex, CS.justifyCenter, CS.py1)}>
-          <button
-            className={cx(ButtonsS.Button, ButtonsS.ButtonPrimary)}
-            onClick={onClose}
-          >
-            {t`Okay`}
-          </button>
-        </div>
-      </ModalContent>
-    </Modal>
+    <Modal.Root opened={isShowingNewbModal} onClose={onClose} size={500}>
+      <Modal.Overlay />
+      <Modal.Content p="1rem">
+        <Modal.Header mb="1rem">
+          <Modal.Title>{title}</Modal.Title>
+        </Modal.Header>
+        <Modal.Body ta="center">
+          <Box mb="1rem" ta="left">
+            {message}
+          </Box>
+          <Button variant="filled" onClick={onClose}>{t`Okay`}</Button>
+        </Modal.Body>
+      </Modal.Content>
+    </Modal.Root>
   );
 };


### PR DESCRIPTION
### What does this PR accomplish?
Fixes #44754.
Adds an E2E reproduction for this issue as well.

Note that @mazameli [said in Slack](https://metaboat.slack.com/archives/C02H619CJ8K/p1717517825579359) he would redesign this modal because it currently looks weird. This PR also moves the modal more toward that new design, but it is faaar from pixel perfect (since this wasn't the intention of this PR)

We can either wait for Maz to bless this change, or we can adjust the design later as needed.

**Before**
![image](https://github.com/metabase/metabase/assets/31325167/1bd9cc58-6609-4388-b37b-9bd1440dcb93)

**Maz**
![image](https://github.com/metabase/metabase/assets/31325167/2fc3a731-9fbf-4413-aa72-cb4a1010428d)

**This PR**
![image](https://github.com/metabase/metabase/assets/31325167/6bd9f67a-9d2f-47a6-acde-b8b5dcf96298)

![image](https://github.com/metabase/metabase/assets/31325167/51aee826-41a8-4325-a333-1b9e6c511b8d)

![image](https://github.com/metabase/metabase/assets/31325167/86c1c556-9ebe-47e7-ae42-850d3cfcc017)

### Stress-test
100 x ✅ https://github.com/metabase/metabase/actions/runs/9842301728