### PR TITLE
🍒 Backport pivot tables reproductions

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
@@ -1276,6 +1276,60 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
       cy.button("Save").should("have.attr", "disabled");
     });
   });
+
+  describe("issue 38265", () => {
+    beforeEach(() => {
+      createQuestion(
+        {
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [
+              ["count"],
+              [
+                "sum",
+                ["field", ORDERS.SUBTOTAL, { "base-type": "type/Float" }],
+              ],
+            ],
+            breakout: [
+              [
+                "field",
+                ORDERS.CREATED_AT,
+                { "base-type": "type/DateTime", "temporal-unit": "month" },
+              ],
+              [
+                "field",
+                PEOPLE.STATE,
+                { "base-type": "type/Text", "source-field": ORDERS.USER_ID },
+              ],
+              [
+                "field",
+                PRODUCTS.CATEGORY,
+                { "base-type": "type/Text", "source-field": ORDERS.PRODUCT_ID },
+              ],
+            ],
+          },
+          display: "pivot",
+        },
+        {
+          visitQuestion: true,
+        },
+      );
+    });
+
+    it("correctly filters the query when zooming in on a **row** header (metabase#38265)", () => {
+      cy.findByTestId("pivot-table").findByText("KS").click();
+      popover().findByText("Zoom in").click();
+
+      cy.log("Filter pills");
+      cy.findByTestId("filter-pill").should("have.text", "User → State is KS");
+
+      cy.log("Pivot table column headings");
+      cy.findByTestId("pivot-table")
+        .should("contain", "Created At: Month")
+        .and("contain", "User → Latitude")
+        .and("contain", "User → Longitude");
+    });
+  });
 });
 
 const testQuery = {

--- a/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
@@ -1,4 +1,4 @@
-import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   restore,
@@ -17,6 +17,7 @@ import {
   modal,
   dashboardCards,
   queryBuilderMain,
+  createQuestion,
 } from "e2e/support/helpers";
 import { PIVOT_TABLE_BODY_LABEL } from "metabase/visualizations/visualizations/PivotTable/constants";
 
@@ -1207,6 +1208,74 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
       );
     },
   );
+
+  describe("issue 37380", () => {
+    beforeEach(() => {
+      const categoryField = [
+        "field",
+        PRODUCTS.CATEGORY,
+        { "base-type": "type/Text" },
+      ];
+
+      const createdAtField = [
+        "field",
+        PRODUCTS.CREATED_AT,
+        {
+          "base-type": "type/DateTime",
+          "temporal-unit": "month",
+        },
+      ];
+
+      // to reproduce metabase#37380 it's important that user has access to the database, but not to the table
+      cy.updatePermissionsGraph({
+        [USER_GROUPS.DATA_GROUP]: {
+          [SAMPLE_DB_ID]: {
+            "create-queries": {
+              PUBLIC: {
+                [PRODUCTS_ID]: "no",
+              },
+            },
+          },
+        },
+      });
+
+      createQuestion(
+        {
+          query: {
+            "source-table": PRODUCTS_ID,
+            aggregation: ["count"],
+            breakout: [categoryField, createdAtField],
+          },
+          display: "pivot",
+          visualization_settings: {
+            "pivot_table.column_split": {
+              rows: [createdAtField],
+              columns: [categoryField],
+              values: [["aggregation", 0]],
+            },
+            "pivot_table.column_widths": {
+              leftHeaderWidths: [141],
+              totalLeftHeaderWidths: 141,
+              valueHeaderWidths: {},
+            },
+          },
+        },
+        {
+          wrapId: true,
+          idAlias: "questionId",
+        },
+      );
+    });
+
+    it("does not allow users with no table access to update pivot questions (metabase#37380)", () => {
+      cy.signInAsNormalUser();
+      visitQuestion("@questionId");
+      cy.findByTestId("viz-settings-button").click();
+      cy.findByLabelText("Show row totals").click();
+
+      cy.button("Save").should("have.attr", "disabled");
+    });
+  });
 });
 
 const testQuery = {

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
@@ -195,12 +195,14 @@ export const settings = {
         return hasOnlyFormattableColumns && !columnFormat.highlight_row;
       });
     },
-    getProps: (series: Series) => ({
-      canHighlightRow: false,
-      cols: (series[0].data.cols as DatasetColumn[]).filter(
-        isFormattablePivotColumn,
-      ),
-    }),
+    getProps: (series: Series) => {
+      const cols = series[0].data?.cols ?? [];
+
+      return {
+        canHighlightRow: false,
+        cols: cols.filter(isFormattablePivotColumn),
+      };
+    },
     getHidden: ([{ data }]: [{ data: DatasetData }]) =>
       !data?.cols.some(col => isFormattablePivotColumn(col)),
   },


### PR DESCRIPTION
### What does this PR accomplish?
This is a manual backport of three PRs (#45143, #45066, #43437) that all add E2E reproductions for the pivot table. I've had to resolve some minor merge conflicts around imports, but otherwise these are clean cherry-picks.

@kamilmielnik 's #43437 also has a small fix.
Not sure why it wasn't backported since it reproduces a P1 escalation? It's important we know that this works in the current release, and not just in `master`.

Merging this PR will close #39504 as already fixed.