### PR TITLE
Add INFO log for each table before JSON unfolding during field sync

### DIFF
--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -16,6 +16,7 @@
    [metabase.lib.schema.literal :as lib.schema.literal]
    [metabase.models :refer [Field]]
    [metabase.models.table :as table]
+   [metabase.sync.util :as sync-util]
    [metabase.util :as u]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.log :as log]
@@ -580,6 +581,7 @@
 
 (defn- describe-json-fields
   [driver jdbc-spec table json-fields pks]
+  (log/infof "Inferring schema for %d JSON fields in %s" (count json-fields) (sync-util/name-for-logging table))
   (let [table-identifier-info [(:schema table) (:name table)]
         json-field-identifiers (mapv #(apply h2x/identifier :field (into table-identifier-info [(:name %)])) json-fields)
         table-identifier (apply h2x/identifier :table table-identifier-info)

--- a/src/metabase/sync/sync_metadata/fields.clj
+++ b/src/metabase/sync/sync_metadata/fields.clj
@@ -62,7 +62,6 @@
   properties (e.g. base type and comment/remark) as needed. Returns number of Fields synced."
   [table       :- i/TableInstance
    db-metadata :- [:set i/TableMetadataField]]
-  (log/infof "Updating field metadata for %s" (sync-util/name-for-logging table))
   (+ (sync-instances/sync-instances! table db-metadata (fields.our-metadata/our-metadata table))
      ;; Now that tables are synced and fields created as needed make sure field properties are in sync.
      ;; Re-fetch our metadata because there might be somethings that have changed after calling

--- a/src/metabase/sync/sync_metadata/fields.clj
+++ b/src/metabase/sync/sync_metadata/fields.clj
@@ -62,6 +62,7 @@
   properties (e.g. base type and comment/remark) as needed. Returns number of Fields synced."
   [table       :- i/TableInstance
    db-metadata :- [:set i/TableMetadataField]]
+  (log/infof "Updating field metadata for %s" (sync-util/name-for-logging table))
   (+ (sync-instances/sync-instances! table db-metadata (fields.our-metadata/our-metadata table))
      ;; Now that tables are synced and fields created as needed make sure field properties are in sync.
      ;; Re-fetch our metadata because there might be somethings that have changed after calling


### PR DESCRIPTION
Pursuant towards https://github.com/metabase/metabase/issues/44983

This PR adds an info-level log message to better diagnose OOM issues during JSON unfolding.

Similar to https://github.com/metabase/metabase/pull/41365, but for JSON unfolding.

After this merges, you'll need to add the logger in the log4j file:
```
<Logger name="metabase.driver.sql-jdbc.sync.describe-table" level="INFO"/>
```