### PR TITLE
Do not collide "no results" with "running the query"

### DIFF
--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -1736,3 +1736,52 @@ describe("issue 39771", () => {
     });
   });
 });
+
+describe("issue 41464", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("should not overlap 'no results' and the loading state (metabase#41464)", () => {
+    visitQuestionAdhoc({
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        type: "query",
+        query: {
+          "source-table": ORDERS_ID,
+          filter: [
+            ">",
+            ["field", ORDERS.TOTAL, { "base-type": "type/Float" }],
+            1000,
+          ],
+        },
+        parameters: [],
+      },
+    });
+
+    cy.intercept(
+      {
+        method: "POST",
+        url: "/api/dataset",
+        middleware: true,
+      },
+      req => {
+        req.on("response", res => {
+          // Throttle the response to 50kbps
+          res.setThrottle(50);
+        });
+      },
+    );
+
+    cy.findByTestId("filter-pill")
+      .should("have.text", "Total is greater than 1000")
+      .icon("close")
+      .click();
+
+    cy.findByTestId("query-builder-main").within(() => {
+      cy.findByTestId("loading-indicator").should("be.visible");
+      cy.findByText("No results!", { timeout: 500 }).should("not.exist");
+    });
+  });
+});

--- a/frontend/src/metabase/query_builder/components/VisualizationResult.jsx
+++ b/frontend/src/metabase/query_builder/components/VisualizationResult.jsx
@@ -59,11 +59,12 @@ export default class VisualizationResult extends Component {
       selectedTimelineEventIds,
       onNavigateBack,
       className,
+      isRunning,
     } = this.props;
     const { showCreateAlertModal } = this.state;
 
     const noResults = datasetContainsNoResults(result.data);
-    if (noResults) {
+    if (noResults && !isRunning) {
       const supportsRowsPresentAlert = question.alertType() === ALERT_TYPE_ROWS;
 
       // successful query but there were 0 rows returned with the result


### PR DESCRIPTION
### What does this PR accomplish?
Fixes #41464

This logic might change once we start using RTK Query, but for now checking for `isRunning` seemed like the best alternative to `isFetching`.

### Demo
![Kapture 2024-07-05 at 09 02 23](https://github.com/metabase/metabase/assets/31325167/158935a4-6585-434d-8000-aeb97b28df8c)

### Tests
This PR adds E2E reproduction for this issue. I tested it on `master` to make sure it doesn't give me false positives and it was failing there every single time. It should pass without exception on this branch.

![image](https://github.com/metabase/metabase/assets/31325167/e895f4b7-7757-4533-829a-14f398b42674)

To confirm this, here's the stress-test run:
100x ✅ https://github.com/metabase/metabase/actions/runs/9839027863

