### PR TITLE
fix serialization errors we get on big old databases

### DIFF
--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -856,22 +856,19 @@
   ;; :table_id and :database_id are extracted as just :table_id [database_name schema table_name].
   ;; :collection_id is extracted as its entity_id or identity-hash.
   ;; :creator_id as the user's email.
-  (try
-    (-> (serdes/extract-one-basics "Card" card)
-        (update :database_id            serdes/*export-fk-keyed* 'Database :name)
-        (update :table_id               serdes/*export-table-fk*)
-        (update :collection_id          serdes/*export-fk* 'Collection)
-        (update :creator_id             serdes/*export-user*)
-        (update :made_public_by_id      serdes/*export-user*)
-        (update :dataset_query          serdes/export-mbql)
-        (update :parameters             serdes/export-parameters)
-        (update :parameter_mappings     serdes/export-parameter-mappings)
-        (update :visualization_settings serdes/export-visualization-settings)
-        (update :result_metadata        export-result-metadata)
-        (dissoc :cache_invalidated_at :view_count :last_used_at :initially_published_at
-                :dataset_query_metrics_v2_migration_backup))
-    (catch Exception e
-      (throw (ex-info (format "Failed to export Card: %s" (ex-message e)) {:card card} e)))))
+  (-> (serdes/extract-one-basics "Card" card)
+      (update :database_id            serdes/*export-fk-keyed* 'Database :name)
+      (update :table_id               serdes/*export-table-fk*)
+      (update :collection_id          serdes/*export-fk* 'Collection)
+      (update :creator_id             serdes/*export-user*)
+      (update :made_public_by_id      serdes/*export-user*)
+      (update :dataset_query          serdes/export-mbql)
+      (update :parameters             serdes/export-parameters)
+      (update :parameter_mappings     serdes/export-parameter-mappings)
+      (update :visualization_settings serdes/export-visualization-settings)
+      (update :result_metadata        export-result-metadata)
+      (dissoc :cache_invalidated_at :view_count :last_used_at :initially_published_at
+              :dataset_query_metrics_v2_migration_backup)))
 
 (defmethod serdes/load-xform "Card"
   [card]

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -316,12 +316,16 @@
 
 (defmethod ^:private migrate-viz-settings* [1 2] [viz-settings _]
   (let [{percent? :pie.show_legend_perecent ;; [sic]
-         legend?  :pie.show_legend} viz-settings]
-    (if-let [new-value (cond
-                         legend?  "inside"
-                         percent? "legend")]
-      (assoc viz-settings :pie.percent_visibility new-value)
-      viz-settings))) ;; if nothing was explicitly set don't default to "off", let the FE deal with it
+         legend?  :pie.show_legend} viz-settings
+        new-visibility              (cond
+                                      legend?  "inside"
+                                      percent? "legend")
+        new-linktype                (when (= "page" (-> viz-settings :click_behavior :linkType))
+                                      "dashboard")]
+    (cond-> viz-settings
+      ;; if nothing was explicitly set don't default to "off", let the FE deal with it
+      new-visibility (assoc :pie.percent_visibility new-visibility)
+      new-linktype   (assoc-in [:click_behavior :linkType] new-linktype))))
 
 (defn- migrate-viz-settings
   [viz-settings]

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -926,7 +926,7 @@
        [:dimension (mbql-id->fully-qualified-name dim)]
 
        [:metric (id :guard integer?)]
-       [:metric (*export-fk* id 'LegacyMetric)]
+       [:metric (*export-fk* id 'Card)]
 
        [:segment (id :guard integer?)]
        [:segment (*export-fk* id 'Segment)])))

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -341,11 +341,15 @@
   (try
     (extract-one model opts instance)
     (catch Exception e
-      (throw (ex-info (format "Exception extracting %s %s" model (:id instance))
-                      {:model     model
-                       :id        (:id instance)
-                       :entity_id (:entity_id instance)}
-                      e)))))
+      (if (:skip (ex-data e))
+        (log/warnf "Skipping %s %s because of an error extracting it: %s %s"
+                   model (:id instance) (.getMessage e) (dissoc (ex-data e) :skip))
+        (throw (ex-info (format "Exception extracting %s %s" model (:id instance))
+                        {:model     model
+                         :id        (:id instance)
+                         :entity_id (:entity_id instance)
+                         :cause     (.getMessage e)}
+                        e))))))
 
 (defmethod extract-all :default [model opts]
   (eduction (map (partial log-and-extract-one model opts))
@@ -748,10 +752,13 @@
     (let [model-name (name model)
           model      (t2.model/resolve-model (symbol model-name))
           entity     (t2/select-one model (first (t2/primary-keys model)) id)
-          path       (mapv :id (generate-path model-name entity))]
-      (if (= (count path) 1)
-        (first path)
-        path))))
+          path       (when entity (mapv :id (generate-path model-name entity)))]
+      (cond
+        (nil? entity)      (throw (ex-info "FK target not found" {:model model
+                                                                  :id    id
+                                                                  :skip  true}))
+        (= (count path) 1) (first path)
+        :else              path))))
 
 (defn ^:dynamic ^::cache *import-fk*
   "Given an identifier, and the model it represents (symbol, name or IModel), looks up the corresponding


### PR DESCRIPTION
It fixes a few errors encountered during export of stats:

- `[:metric <id>]` targets a `Card` nowadays rather than `LegacyMetric`
- `{:linkType "page"}` seems to be targeting dashboards, just an old name for them maybe?
- Some archived questions target stuff which does not exist in the database anymore, agreed with Arakaki we're going to skip and log

Fixes #44747