### PR TITLE
unit tests for downloads flag

### DIFF
--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
@@ -158,7 +158,7 @@ export const EmbedFrame = ({
     : [];
   const hasVisibleParameters = visibleParameters.length > 0;
 
-  const hasHeader = Boolean(finalName || dashboardTabs || downloadsEnabled);
+  const hasHeader = Boolean(finalName || dashboardTabs) || downloadsEnabled;
   const isParameterPanelSticky =
     !!dashboard &&
     theme !== "transparent" && // https://github.com/metabase/metabase/pull/38766#discussion_r1491549200

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
@@ -158,7 +158,7 @@ export const EmbedFrame = ({
     : [];
   const hasVisibleParameters = visibleParameters.length > 0;
 
-  const hasHeader = Boolean(finalName || dashboardTabs);
+  const hasHeader = Boolean(finalName || dashboardTabs || downloadsEnabled);
   const isParameterPanelSticky =
     !!dashboard &&
     theme !== "transparent" && // https://github.com/metabase/metabase/pull/38766#discussion_r1491549200

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardPage.unit.spec.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardPage.unit.spec.tsx
@@ -1,3 +1,4 @@
+import userEvent from "@testing-library/user-event";
 import { Route } from "react-router";
 import _ from "underscore";
 
@@ -5,6 +6,8 @@ import { setupEnterprisePlugins } from "__support__/enterprise";
 import { setupEmbedDashboardEndpoints } from "__support__/server-mocks/embed";
 import { mockSettings } from "__support__/settings";
 import {
+  getIcon,
+  queryIcon,
   renderWithProviders,
   screen,
   waitForLoaderToBeRemoved,
@@ -110,10 +113,33 @@ describe("PublicOrEmbeddedDashboardPage", () => {
     expect(screen.getByText("There's nothing here, yet.")).toBeInTheDocument();
   });
 
-  it("should show the 'Export as PDF' button even when titled=false", async () => {
-    await setup({ hash: "titled=false", numberOfTabs: 1 });
+  describe("downloads flag", () => {
+    it("should show the 'Export as PDF' button even when titled=false and there's one tab", async () => {
+      await setup({ hash: "titled=false", numberOfTabs: 1 });
 
-    expect(screen.getByText("Export as PDF")).toBeInTheDocument();
+      expect(screen.getByText("Export as PDF")).toBeInTheDocument();
+    });
+
+    it('should not show the "Export as PDF" button when downloads are disabled', async () => {
+      await setup({ hash: "downloads=false", numberOfTabs: 1 });
+
+      expect(screen.queryByText("Export as PDF")).not.toBeInTheDocument();
+    });
+
+    it("should allow downloading the dashcards results when downloads are enabled", async () => {
+      await setup({ numberOfTabs: 1, hash: "downloads=true" });
+
+      await userEvent.click(getIcon("ellipsis"));
+
+      expect(screen.getByText("Download results")).toBeInTheDocument();
+    });
+
+    it("should not allow downloading the dashcards results when downloads are disabled", async () => {
+      await setup({ numberOfTabs: 1, hash: "downloads=false" });
+
+      // in this case the dashcard menu would be empty so it's not rendered at all
+      expect(queryIcon("ellipsis")).not.toBeInTheDocument();
+    });
   });
 });
 
@@ -133,7 +159,12 @@ async function setup({
       createMockDashboardCard({
         id: i + 1,
         card_id: i + 1,
-        card: createMockCard({ id: i + 1 }),
+        card: createMockCard({
+          id: i + 1,
+          //`can_write` is false in public or embedded contexts
+          // without this we'd have the "Edit" button in the dashcard menu
+          can_write: false,
+        }),
         dashboard_tab_id: tabId,
       }),
     );

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardPage.unit.spec.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardPage.unit.spec.tsx
@@ -12,6 +12,7 @@ import {
   screen,
   waitForLoaderToBeRemoved,
 } from "__support__/ui";
+import { DASHBOARD_PDF_EXPORT_ROOT_ID } from "metabase/dashboard/constants";
 import type { DashboardCard, DashboardTab } from "metabase-types/api";
 import {
   createMockCard,
@@ -140,6 +141,15 @@ describe("PublicOrEmbeddedDashboardPage", () => {
       // in this case the dashcard menu would be empty so it's not rendered at all
       expect(queryIcon("ellipsis")).not.toBeInTheDocument();
     });
+
+    it("should use the container used for pdf exports", async () => {
+      const { container } = await setup({ numberOfTabs: 1 });
+
+      expect(
+        // eslint-disable-next-line testing-library/no-node-access -- this test is testing a specific implementation detail as testing the actual functionality is not easy on jest
+        container.querySelector(`#${DASHBOARD_PDF_EXPORT_ROOT_ID}`),
+      ).toBeInTheDocument();
+    });
   });
 });
 
@@ -180,7 +190,7 @@ async function setup({
 
   setupEmbedDashboardEndpoints(MOCK_TOKEN, dashboard, dashcards);
 
-  renderWithProviders(
+  const view = renderWithProviders(
     <Route
       path="embed/dashboard/:token"
       component={PublicOrEmbeddedDashboardPage}
@@ -197,4 +207,6 @@ async function setup({
   if (numberOfTabs > 0) {
     expect(await screen.findByTestId("dashboard-grid")).toBeInTheDocument();
   }
+
+  return view;
 }

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardPage.unit.spec.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardPage.unit.spec.tsx
@@ -32,6 +32,7 @@ const DASHBOARD_TITLE = '"My test dash"';
 describe("PublicOrEmbeddedDashboardPage", () => {
   beforeAll(() => {
     mockSettings({
+      // the `whitelabel` feature is needed to test #downloads=false
       "token-features": createMockTokenFeatures({ whitelabel: true }),
     });
 

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardPage.unit.spec.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardPage.unit.spec.tsx
@@ -1,7 +1,9 @@
 import { Route } from "react-router";
 import _ from "underscore";
 
+import { setupEnterprisePlugins } from "__support__/enterprise";
 import { setupEmbedDashboardEndpoints } from "__support__/server-mocks/embed";
+import { mockSettings } from "__support__/settings";
 import {
   renderWithProviders,
   screen,
@@ -13,6 +15,7 @@ import {
   createMockDashboard,
   createMockDashboardCard,
   createMockDashboardTab,
+  createMockTokenFeatures,
 } from "metabase-types/api/mocks";
 import { createMockState } from "metabase-types/store/mocks";
 
@@ -23,6 +26,14 @@ const MOCK_TOKEN =
 const DASHBOARD_TITLE = '"My test dash"';
 
 describe("PublicOrEmbeddedDashboardPage", () => {
+  beforeAll(() => {
+    mockSettings({
+      "token-features": createMockTokenFeatures({ whitelabel: true }),
+    });
+
+    setupEnterprisePlugins();
+  });
+
   it("should display dashboard tabs", async () => {
     await setup({ numberOfTabs: 2 });
 
@@ -37,8 +48,8 @@ describe("PublicOrEmbeddedDashboardPage", () => {
     expect(screen.getByText("Tab 2")).toBeInTheDocument();
   });
 
-  it("should not display the header if title is disabled and there is only one tab (metabase#41393)", async () => {
-    await setup({ hash: "titled=false", numberOfTabs: 1 });
+  it("should not display the header if title is disabled and there is only one tab (metabase#41393) and downloads are disabled", async () => {
+    await setup({ hash: "titled=false&downloads=false", numberOfTabs: 1 });
 
     expect(screen.queryByText("Tab 1")).not.toBeInTheDocument();
     expect(screen.queryByTestId("embed-frame-header")).not.toBeInTheDocument();
@@ -97,6 +108,12 @@ describe("PublicOrEmbeddedDashboardPage", () => {
     await waitForLoaderToBeRemoved();
 
     expect(screen.getByText("There's nothing here, yet.")).toBeInTheDocument();
+  });
+
+  it("should show the 'Export as PDF' button even when titled=false", async () => {
+    await setup({ hash: "titled=false", numberOfTabs: 1 });
+
+    expect(screen.getByText("Export as PDF")).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion.unit.spec.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion.unit.spec.tsx
@@ -99,6 +99,7 @@ async function setup({
 describe("PublicOrEmbeddedQuestion", () => {
   beforeAll(() => {
     mockSettings({
+      // the `whitelabel` feature is needed to test #downloads=false
       "token-features": createMockTokenFeatures({ whitelabel: true }),
     });
 

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion.unit.spec.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion.unit.spec.tsx
@@ -1,20 +1,26 @@
 import userEvent from "@testing-library/user-event";
 import { Route } from "react-router";
 
+import { setupEnterprisePlugins } from "__support__/enterprise";
 import {
   setupPublicCardQueryEndpoints,
   setupPublicQuestionEndpoints,
 } from "__support__/server-mocks";
+import { mockSettings } from "__support__/settings";
 import {
+  getIcon,
+  queryIcon,
   renderWithProviders,
   screen,
   waitForLoaderToBeRemoved,
+  within,
 } from "__support__/ui";
 import registerVisualizations from "metabase/visualizations/register";
 import type { VisualizationProps } from "metabase/visualizations/types";
 import {
   createMockEmbedDataset,
   createMockPublicCard,
+  createMockTokenFeatures,
 } from "metabase-types/api/mocks";
 import { createMockState } from "metabase-types/store/mocks";
 
@@ -59,7 +65,13 @@ jest.mock(
   () => VisualizationMock,
 );
 
-async function setup() {
+async function setup({
+  hash,
+  queryString,
+}: {
+  hash?: string;
+  queryString?: string;
+} = {}) {
   setupPublicQuestionEndpoints(
     FAKE_UUID,
     createMockPublicCard({ name: QUESTION_NAME }),
@@ -76,13 +88,23 @@ async function setup() {
     {
       storeInitialState: createMockState(),
       withRouter: true,
-      initialRoute: `public/question/${FAKE_UUID}`,
+      initialRoute: `public/question/${FAKE_UUID}${
+        queryString ? `?` + queryString : ""
+      }${hash ? "#" + hash : ""}`,
     },
   );
   expect(await screen.findByText(QUESTION_NAME)).toBeInTheDocument();
 }
 
 describe("PublicOrEmbeddedQuestion", () => {
+  beforeAll(() => {
+    mockSettings({
+      "token-features": createMockTokenFeatures({ whitelabel: true }),
+    });
+
+    setupEnterprisePlugins();
+  });
+
   it("should render data", async () => {
     await setup();
     expect(await screen.findByText("John W.")).toBeInTheDocument();
@@ -104,5 +126,26 @@ describe("PublicOrEmbeddedQuestion", () => {
     expect(screen.getByTestId("settings")).toHaveTextContent(
       JSON.stringify({ foo: "bar" }),
     );
+  });
+
+  describe("downloads flag", () => {
+    it("should allow downloading the results when downloads are enabled", async () => {
+      await setup({ hash: "downloads=true" });
+      await waitForLoaderToBeRemoved();
+
+      await userEvent.click(getIcon("download"));
+
+      expect(
+        within(screen.getByRole("dialog")).getByText("Download full results"),
+      ).toBeInTheDocument();
+    });
+
+    it("should not allow downloading results when downloads are enabled", async () => {
+      await setup({ hash: "downloads=false" });
+
+      await waitForLoaderToBeRemoved();
+
+      expect(queryIcon("download")).not.toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION

### Description

This adds unit tests for the `#downloads` flag.
The tests on the public dashboard/question are specific for one of the dimensions between {public/static}, I used the one already used by the test setup that I found. I'll add some (more simplified) tests covering both those dimensions in the e2e as I want to keep the setup of jest tests.

While adding them I also found a bug, where the `Export tab as PDF` button was not rendered when the was only a tab in a dashboard.