### PR TITLE
copy change in csv modal

### DIFF
--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionUploadInfoModal.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionUploadInfoModal.tsx
@@ -32,7 +32,10 @@ export const UploadInfoModal = ({
             <>
               <InfoModalBody>
                 <p>
-                  {t`Allow people to upload CSV files to your database so that they can query the CSV data just like any other table.`}
+                  {t`Team members will be able to upload CSV files and work with them just like any other data source.`}
+                </p>
+                <p>
+                  {t`You'll be able to pick the default database where the data should be stored when enabling the feature.`}
                 </p>
               </InfoModalBody>
               <Button

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionUploadInfoModal.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionUploadInfoModal.tsx
@@ -41,7 +41,7 @@ export const UploadInfoModal = ({
                 primary
                 role="link"
               >
-                {t`Go to setup.`}
+                {t`Go to setup`}
               </Button>
             </>
           ) : (

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionUploadInfoModal.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionUploadInfoModal.tsx
@@ -27,15 +27,12 @@ export const UploadInfoModal = ({
       <ModalContent title=" " onClose={onClose}>
         <InfoModalContainer>
           <NewBadge>{t`New`}</NewBadge>
-          <InfoModalTitle>{t`Uploads CSVs to ${applicationName}`}</InfoModalTitle>
+          <InfoModalTitle>{t`Upload CSVs to ${applicationName}`}</InfoModalTitle>
           {isAdmin ? (
             <>
               <InfoModalBody>
                 <p>
-                  {t`Team members will be able to upload CSV files and work with them just like any other data source`}
-                </p>
-                <p>
-                  {t`You'll be able to pick the default database where the data should be stored when enabling the feature.`}
+                  {t`Allow people to upload CSV files to your database so that they can query the CSV data just like any other table.`}
                 </p>
               </InfoModalBody>
               <Button
@@ -44,7 +41,7 @@ export const UploadInfoModal = ({
                 primary
                 role="link"
               >
-                {t`Enable in settings`}
+                {t`Go to setup.`}
               </Button>
             </>
           ) : (

--- a/frontend/src/metabase/collections/components/CollectionHeader/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/tests/common.unit.spec.tsx
@@ -232,7 +232,7 @@ describe("CollectionHeader", () => {
       await userEvent.click(screen.getByLabelText("Upload data"));
 
       expect(await screen.findByRole("dialog")).toBeInTheDocument();
-      expect(screen.getByText("Uploads CSVs to Metabase")).toBeInTheDocument();
+      expect(screen.getByText("Upload CSVs to Metabase")).toBeInTheDocument();
     });
 
     it("should show an informational modal with a link to settings for admins", async () => {
@@ -245,7 +245,7 @@ describe("CollectionHeader", () => {
       await userEvent.click(screen.getByLabelText("Upload data"));
 
       expect(await screen.findByRole("dialog")).toBeInTheDocument();
-      expect(screen.getByText("Enable in settings")).toBeInTheDocument();
+      expect(screen.getByText("Go to setup")).toBeInTheDocument();
       expect(screen.getByRole("link")).toBeInTheDocument();
     });
 


### PR DESCRIPTION
- Fixes typo in modal, and cleans up some copy.
- Changes button text so it's clear that we're sending them to the setup page, not turning on uploads on click.