### PR TITLE
[WIP] Migrate viz settings key to name-based format

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/table-column-settings.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table-column-settings.cy.spec.js
@@ -653,7 +653,6 @@ describe("scenarios > visualizations > table column settings", () => {
         column: "ID",
         columnName: "User → ID",
         table: "user",
-        scrollTimes: 3,
       };
 
       _addColumn(newColumn);

--- a/frontend/src/metabase-lib/v1/queries/utils/dataset.ts
+++ b/frontend/src/metabase-lib/v1/queries/utils/dataset.ts
@@ -1,5 +1,3 @@
-import { getColumnKey } from "metabase-lib/v1/queries/utils/get-column-key";
-import { normalize } from "metabase-lib/v1/queries/utils/normalize";
 import type {
   DatasetColumn,
   DatasetData,
@@ -9,27 +7,15 @@ import type {
 export const datasetContainsNoResults = (data: DatasetData) =>
   data.rows == null || data.rows.length === 0;
 
-export function getColumnSettingKey(
-  { key, name, fieldRef }: TableColumnOrderSetting,
-  ignoreBaseType = false,
-) {
-  if (ignoreBaseType) {
-    return getColumnKey({ name, field_ref: normalize(fieldRef) }, true);
-  }
-
-  return key ?? getColumnKey({ name, field_ref: normalize(fieldRef) });
-}
-
 export function findColumnIndexesForColumnSettings(
   columns: DatasetColumn[],
   columnSettings: TableColumnOrderSetting[],
 ) {
   const columnIndexByKey = new Map(
-    columns.map((column, index) => [getColumnKey(column, true), index]),
+    columns.map((column, index) => [column.name, index]),
   );
   return columnSettings.map(
-    columnSetting =>
-      columnIndexByKey.get(getColumnSettingKey(columnSetting, true)) ?? -1,
+    columnSetting => columnIndexByKey.get(columnSetting.name) ?? -1,
   );
 }
 
@@ -38,12 +24,7 @@ export function findColumnSettingIndexesForColumns(
   columnSettings: TableColumnOrderSetting[],
 ) {
   const columnSettingIndexByKey = new Map(
-    columnSettings.map((columnSetting, index) => [
-      getColumnSettingKey(columnSetting, true),
-      index,
-    ]),
+    columnSettings.map((columnSetting, index) => [columnSetting.name, index]),
   );
-  return columns.map(
-    column => columnSettingIndexByKey.get(getColumnKey(column, true)) ?? -1,
-  );
+  return columns.map(column => columnSettingIndexByKey.get(column.name) ?? -1);
 }

--- a/frontend/src/metabase-lib/v1/queries/utils/dataset.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/queries/utils/dataset.unit.spec.ts
@@ -26,7 +26,6 @@ describe("dataset utils", () => {
       });
       const columnSetting = createMockTableColumnOrderSetting({
         name: "TOTAL",
-        key: `["ref",["field",${ORDERS.TOTAL},null]]`,
         fieldRef: ["field", ORDERS.TOTAL, null],
         enabled: true,
       });
@@ -51,7 +50,6 @@ describe("dataset utils", () => {
       });
       const columnSetting = createMockTableColumnOrderSetting({
         name: "TOTAL",
-        key: `["ref",["field",${ORDERS.TOTAL},{"base-type":"type/Number"}]]`,
         fieldRef: ["field", ORDERS.TOTAL, { "base-type": "type/Number" }],
         enabled: true,
       });
@@ -76,7 +74,6 @@ describe("dataset utils", () => {
       });
       const columnSetting = createMockTableColumnOrderSetting({
         name: "TOTAL",
-        key: `["ref",["field",${ORDERS.TOTAL},{"base-type":"type/Number"}]]`,
         fieldRef: ["field", ORDERS.TOTAL, { "base-type": "type/Number" }],
         enabled: true,
       });
@@ -97,7 +94,6 @@ describe("dataset utils", () => {
       });
       const columnSetting = createMockTableColumnOrderSetting({
         name: "TOTAL",
-        key: `["ref",["field",${ORDERS.TOTAL},{"base-type":"type/Number"}]]`,
         fieldRef: ["field", ORDERS.TOTAL, { "base-type": "type/Number" }],
         enabled: true,
       });
@@ -122,7 +118,6 @@ describe("dataset utils", () => {
       });
       const columnSetting = createMockTableColumnOrderSetting({
         name: "TOTAL",
-        key: `["ref",["field",${ORDERS.TOTAL},{"base-type":"type/Number"}]]`,
         fieldRef: ["field", ORDERS.TOTAL, { "base-type": "type/Number" }],
         enabled: true,
       });
@@ -147,7 +142,6 @@ describe("dataset utils", () => {
       });
       const columnSetting = createMockTableColumnOrderSetting({
         name: "TOTAL",
-        key: `["ref",["field",${ORDERS.TOTAL},{"base-type":"type/Number"}]]`,
         fieldRef: ["field", ORDERS.TOTAL, { "base-type": "type/Number" }],
         enabled: true,
       });

--- a/frontend/src/metabase-lib/v1/queries/utils/get-column-key.ts
+++ b/frontend/src/metabase-lib/v1/queries/utils/get-column-key.ts
@@ -12,7 +12,6 @@ import type { DatasetColumn } from "metabase-types/api";
 
 export const getColumnKey = (
   column: Pick<DatasetColumn, "name" | "field_ref">,
-  ignoreBaseType = false,
 ) => {
   let fieldRef = column.field_ref;
 
@@ -32,7 +31,7 @@ export const getColumnKey = (
     isExpressionReference(fieldRef) ||
     isAggregationReference(fieldRef)
   ) {
-    fieldRef = getBaseDimensionReference(fieldRef, ignoreBaseType);
+    fieldRef = getBaseDimensionReference(fieldRef);
   }
 
   const isLegacyRef =

--- a/frontend/src/metabase-lib/v1/queries/utils/get-column-key.ts
+++ b/frontend/src/metabase-lib/v1/queries/utils/get-column-key.ts
@@ -10,7 +10,11 @@ import {
 } from "metabase-lib/v1/references";
 import type { DatasetColumn } from "metabase-types/api";
 
-export const getColumnKey = (
+export const getColumnKey = (column: Pick<DatasetColumn, "name">) => {
+  return JSON.stringify(["name", column.name]);
+};
+
+export const getColumnKeyLegacy = (
   column: Pick<DatasetColumn, "name" | "field_ref">,
 ) => {
   let fieldRef = column.field_ref;

--- a/frontend/src/metabase-lib/v1/queries/utils/get-column-key.ts
+++ b/frontend/src/metabase-lib/v1/queries/utils/get-column-key.ts
@@ -46,5 +46,5 @@ export const getLegacyColumnKey = (
 };
 
 export function isLegacyColumnKey(key: string) {
-  return key.startsWith("[");
+  return key.startsWith('["ref"');
 }

--- a/frontend/src/metabase-lib/v1/queries/utils/get-column-key.ts
+++ b/frontend/src/metabase-lib/v1/queries/utils/get-column-key.ts
@@ -14,7 +14,7 @@ export const getColumnKey = (column: Pick<DatasetColumn, "name">) => {
   return JSON.stringify(["name", column.name]);
 };
 
-export const getColumnKeyLegacy = (
+export const getLegacyColumnKey = (
   column: Pick<DatasetColumn, "name" | "field_ref">,
 ) => {
   let fieldRef = column.field_ref;
@@ -38,11 +38,9 @@ export const getColumnKeyLegacy = (
     fieldRef = getBaseDimensionReference(fieldRef);
   }
 
-  const isLegacyRef =
+  const isNameKey =
     (isFieldReference(fieldRef) && hasStringFieldName(fieldRef)) ||
     isAggregationReference(fieldRef);
 
-  return JSON.stringify(
-    isLegacyRef ? ["name", column.name] : ["ref", fieldRef],
-  );
+  return JSON.stringify(isNameKey ? ["name", column.name] : ["ref", fieldRef]);
 };

--- a/frontend/src/metabase-lib/v1/queries/utils/get-column-key.ts
+++ b/frontend/src/metabase-lib/v1/queries/utils/get-column-key.ts
@@ -44,3 +44,7 @@ export const getLegacyColumnKey = (
 
   return JSON.stringify(isNameKey ? ["name", column.name] : ["ref", fieldRef]);
 };
+
+export function isLegacyColumnKey(key: string) {
+  return key.startsWith("[");
+}

--- a/frontend/src/metabase-lib/v1/queries/utils/get-column-key.unit.spec.js
+++ b/frontend/src/metabase-lib/v1/queries/utils/get-column-key.unit.spec.js
@@ -1,13 +1,13 @@
-import { getColumnKey } from "metabase-lib/v1/queries/utils/get-column-key";
+import { getColumnKeyLegacy } from "metabase-lib/v1/queries/utils/get-column-key";
 
-describe("getColumnKey", () => {
+describe("getColumnKeyLegacy", () => {
   // NOTE: run legacy tests with and without a field_ref. without is disabled in latest since it now always uses
   // field_ref, leaving test code in place to compare against older versions
   for (const fieldRefEnabled of [/*false,*/ true]) {
     describe(fieldRefEnabled ? "with field_ref" : "without field_ref", () => {
       it("should return [ref [field ...]] for field", () => {
         expect(
-          getColumnKey({
+          getColumnKeyLegacy({
             name: "foo",
             id: 1,
             field_ref: fieldRefEnabled ? ["field", 1, null] : undefined,
@@ -16,7 +16,7 @@ describe("getColumnKey", () => {
       });
       it("should return [ref [field ...]] for foreign field", () => {
         expect(
-          getColumnKey({
+          getColumnKeyLegacy({
             name: "foo",
             id: 1,
             fk_field_id: 2,
@@ -28,7 +28,7 @@ describe("getColumnKey", () => {
       });
       it("should return [ref [expression ...]] for expression", () => {
         expect(
-          getColumnKey({
+          getColumnKeyLegacy({
             name: "foo",
             expression_name: "foo",
             field_ref: fieldRefEnabled ? ["expression", "foo"] : undefined,
@@ -41,7 +41,7 @@ describe("getColumnKey", () => {
           source: "aggregation",
           field_ref: fieldRefEnabled ? ["aggregation", 0] : undefined,
         };
-        expect(getColumnKey(col, [col])).toEqual(
+        expect(getColumnKeyLegacy(col, [col])).toEqual(
           // NOTE: not ideal, matches existing behavior, but should be ["aggregation", 0]
           JSON.stringify(["name", "foo"]),
         );
@@ -54,14 +54,14 @@ describe("getColumnKey", () => {
             ? ["field", "foo", { "base-type": "type/Integer" }]
             : undefined,
         };
-        expect(getColumnKey(col, [col])).toEqual(
+        expect(getColumnKeyLegacy(col, [col])).toEqual(
           // NOTE: not ideal, matches existing behavior, but should be ["field", "foo", {"base-type": "type/Integer"}]
           JSON.stringify(["name", "foo"]),
         );
       });
       it("should return [field ...] for native query column", () => {
         expect(
-          getColumnKey({
+          getColumnKeyLegacy({
             name: "foo",
             field_ref: fieldRefEnabled
               ? ["field", "foo", { "base-type": "type/Integer" }]
@@ -82,7 +82,7 @@ describe("getColumnKey", () => {
         id: 1,
         field_ref: ["field", 1, { "join-alias": "x" }],
       };
-      expect(getColumnKey(col)).toEqual(
+      expect(getColumnKeyLegacy(col)).toEqual(
         JSON.stringify(["ref", ["field", 1, { "join-alias": "x" }]]),
       );
     });

--- a/frontend/src/metabase-lib/v1/queries/utils/get-column-key.unit.spec.js
+++ b/frontend/src/metabase-lib/v1/queries/utils/get-column-key.unit.spec.js
@@ -1,4 +1,4 @@
-import { getColumnKeyLegacy } from "metabase-lib/v1/queries/utils/get-column-key";
+import { getLegacyColumnKey } from "metabase-lib/v1/queries/utils/get-column-key";
 
 describe("getColumnKeyLegacy", () => {
   // NOTE: run legacy tests with and without a field_ref. without is disabled in latest since it now always uses
@@ -7,7 +7,7 @@ describe("getColumnKeyLegacy", () => {
     describe(fieldRefEnabled ? "with field_ref" : "without field_ref", () => {
       it("should return [ref [field ...]] for field", () => {
         expect(
-          getColumnKeyLegacy({
+          getLegacyColumnKey({
             name: "foo",
             id: 1,
             field_ref: fieldRefEnabled ? ["field", 1, null] : undefined,
@@ -16,7 +16,7 @@ describe("getColumnKeyLegacy", () => {
       });
       it("should return [ref [field ...]] for foreign field", () => {
         expect(
-          getColumnKeyLegacy({
+          getLegacyColumnKey({
             name: "foo",
             id: 1,
             fk_field_id: 2,
@@ -28,7 +28,7 @@ describe("getColumnKeyLegacy", () => {
       });
       it("should return [ref [expression ...]] for expression", () => {
         expect(
-          getColumnKeyLegacy({
+          getLegacyColumnKey({
             name: "foo",
             expression_name: "foo",
             field_ref: fieldRefEnabled ? ["expression", "foo"] : undefined,
@@ -41,7 +41,7 @@ describe("getColumnKeyLegacy", () => {
           source: "aggregation",
           field_ref: fieldRefEnabled ? ["aggregation", 0] : undefined,
         };
-        expect(getColumnKeyLegacy(col, [col])).toEqual(
+        expect(getLegacyColumnKey(col, [col])).toEqual(
           // NOTE: not ideal, matches existing behavior, but should be ["aggregation", 0]
           JSON.stringify(["name", "foo"]),
         );
@@ -54,14 +54,14 @@ describe("getColumnKeyLegacy", () => {
             ? ["field", "foo", { "base-type": "type/Integer" }]
             : undefined,
         };
-        expect(getColumnKeyLegacy(col, [col])).toEqual(
+        expect(getLegacyColumnKey(col, [col])).toEqual(
           // NOTE: not ideal, matches existing behavior, but should be ["field", "foo", {"base-type": "type/Integer"}]
           JSON.stringify(["name", "foo"]),
         );
       });
       it("should return [field ...] for native query column", () => {
         expect(
-          getColumnKeyLegacy({
+          getLegacyColumnKey({
             name: "foo",
             field_ref: fieldRefEnabled
               ? ["field", "foo", { "base-type": "type/Integer" }]
@@ -82,7 +82,7 @@ describe("getColumnKeyLegacy", () => {
         id: 1,
         field_ref: ["field", 1, { "join-alias": "x" }],
       };
-      expect(getColumnKeyLegacy(col)).toEqual(
+      expect(getLegacyColumnKey(col)).toEqual(
         JSON.stringify(["ref", ["field", 1, { "join-alias": "x" }]]),
       );
     });

--- a/frontend/src/metabase-lib/v1/references.ts
+++ b/frontend/src/metabase-lib/v1/references.ts
@@ -111,12 +111,11 @@ export const BASE_DIMENSION_REFERENCE_OMIT_OPTIONS = [
 
 export const getBaseDimensionReference = (
   mbql: DimensionReferenceWithOptions,
-  ignoreBaseType: boolean,
 ) =>
-  getDimensionReferenceWithoutOptions(mbql, [
-    ...BASE_DIMENSION_REFERENCE_OMIT_OPTIONS,
-    ...(ignoreBaseType ? ["base-type"] : []),
-  ]);
+  getDimensionReferenceWithoutOptions(
+    mbql,
+    BASE_DIMENSION_REFERENCE_OMIT_OPTIONS,
+  );
 
 /**
  * Whether this Field clause has a string Field name (as opposed to an integer Field ID). This generally means the

--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -119,7 +119,6 @@ export type PivotTableCollapsedRowsSetting = {
 
 export type TableColumnOrderSetting = {
   name: string;
-  key: string;
   enabled: boolean;
 
   // We have some corrupted visualization settings where both names are mixed

--- a/frontend/src/metabase-types/api/dataset.ts
+++ b/frontend/src/metabase-types/api/dataset.ts
@@ -24,6 +24,7 @@ export interface DatasetColumn {
   display_name: string;
   description?: string | null;
   source: string;
+  source_alias?: string;
   aggregation_index?: number;
   coercion_strategy?: string | null;
   visibility_type?: FieldVisibilityType;

--- a/frontend/src/metabase-types/api/dataset.ts
+++ b/frontend/src/metabase-types/api/dataset.ts
@@ -24,7 +24,6 @@ export interface DatasetColumn {
   display_name: string;
   description?: string | null;
   source: string;
-  source_alias?: string;
   aggregation_index?: number;
   coercion_strategy?: string | null;
   visibility_type?: FieldVisibilityType;

--- a/frontend/src/metabase-types/api/mocks/card.ts
+++ b/frontend/src/metabase-types/api/mocks/card.ts
@@ -122,7 +122,6 @@ export const createMockTableColumnOrderSetting = (
   opts?: Partial<TableColumnOrderSetting>,
 ): TableColumnOrderSetting => ({
   name: "Column",
-  key: '["ref",["field",1,null]]',
   enabled: true,
   ...opts,
 });

--- a/frontend/src/metabase/schema.js
+++ b/frontend/src/metabase/schema.js
@@ -3,18 +3,36 @@
 import { schema } from "normalizr";
 
 import { entityTypeForObject } from "metabase/lib/schema";
+import {
+  migrateCardVizSettings,
+  migrateDashboardVizSettings,
+} from "metabase/visualizations/lib/migrate-settings";
 import { getUniqueFieldId } from "metabase-lib/v1/metadata/utils/fields";
 import { SAVED_QUESTIONS_VIRTUAL_DB_ID } from "metabase-lib/v1/metadata/utils/saved-questions";
 import { generateSchemaId } from "metabase-lib/v1/metadata/utils/schema";
 
 export const ActionSchema = new schema.Entity("actions");
 export const UserSchema = new schema.Entity("users");
-export const QuestionSchema = new schema.Entity("questions");
+
+export const QuestionSchema = new schema.Entity(
+  "questions",
+  {},
+  {
+    processStrategy: card => migrateCardVizSettings(card),
+  },
+);
+
 export const ModelIndexSchema = new schema.Entity("modelIndexes");
 export const CacheConfigSchema = new schema.Entity("cacheConfigs");
 export const IndexedEntitySchema = new schema.Entity("indexedEntities");
 export const BookmarkSchema = new schema.Entity("bookmarks");
-export const DashboardSchema = new schema.Entity("dashboards");
+export const DashboardSchema = new schema.Entity(
+  "dashboards",
+  {},
+  {
+    processStrategy: dashboard => migrateDashboardVizSettings(dashboard),
+  },
+);
 export const PulseSchema = new schema.Entity("pulses");
 export const CollectionSchema = new schema.Entity("collections");
 

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/TableColumnPanel/TableColumnPanel.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/TableColumnPanel/TableColumnPanel.tsx
@@ -60,7 +60,7 @@ export const TableColumnPanel = ({
   const handleDragColumn = useCallback(
     ({ id, newIndex }: DragEndEvent) => {
       const oldIndex = columnItems.findIndex(
-        columnItem => columnItem.columnSetting.key === id,
+        columnItem => getId(columnItem) === id,
       );
 
       onChange(moveColumnInSettings(columnItems, oldIndex, newIndex));
@@ -74,10 +74,6 @@ export const TableColumnPanel = ({
     },
     [onShowWidget],
   );
-
-  const getId = useCallback((columnItem: ColumnItem) => {
-    return columnItem.columnSetting.key;
-  }, []);
 
   return (
     <div role="list" data-testid="chart-settings-table-columns">
@@ -97,3 +93,7 @@ export const TableColumnPanel = ({
     </div>
   );
 };
+
+function getId(columnItem: ColumnItem) {
+  return columnItem.column.name;
+}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/TableColumnPanel/TableColumnPanel.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/TableColumnPanel/TableColumnPanel.unit.spec.tsx
@@ -43,25 +43,21 @@ const COLUMNS = [
 const COLUMN_SETTINGS = [
   createMockTableColumnOrderSetting({
     name: "TOTAL",
-    key: `["ref",["field",${ORDERS.TOTAL},null]]`,
     fieldRef: ["field", ORDERS.TOTAL, null],
     enabled: true,
   }),
   createMockTableColumnOrderSetting({
     name: "ID",
-    key: `["ref",["field",${ORDERS.ID},null]]`,
     fieldRef: ["field", ORDERS.ID, null],
     enabled: true,
   }),
   createMockTableColumnOrderSetting({
     name: "TAX",
-    key: `["ref",["field",${ORDERS.TAX},null]]`,
     fieldRef: ["field", ORDERS.TAX, null],
     enabled: false,
   }),
   createMockTableColumnOrderSetting({
     name: "SUBTOTAL",
-    key: `["ref",["field",${ORDERS.SUBTOTAL},null]]`,
     fieldRef: ["field", ORDERS.SUBTOTAL, null],
     enabled: false,
   }),

--- a/frontend/src/metabase/visualizations/lib/migrate-settings.ts
+++ b/frontend/src/metabase/visualizations/lib/migrate-settings.ts
@@ -2,6 +2,7 @@ import { isQuestionDashCard } from "metabase/dashboard/utils";
 import {
   getColumnKey,
   getLegacyColumnKey,
+  isLegacyColumnKey,
 } from "metabase-lib/v1/queries/utils/get-column-key";
 import type {
   Card,
@@ -14,6 +15,10 @@ export function migrateColumnSettings(
   columnSettings: VisualizationSettings["column_settings"],
   resultMetadata: Field[],
 ): VisualizationSettings {
+  if (!Object.keys(columnSettings).some(isLegacyColumnKey)) {
+    return columnSettings;
+  }
+
   const columnByKey = Object.fromEntries(
     resultMetadata.map(column => [getLegacyColumnKey(column), column]),
   );
@@ -21,7 +26,9 @@ export function migrateColumnSettings(
   return Object.fromEntries(
     Object.entries(columnSettings).map(([key, setting]) => {
       const column = columnByKey[key];
-      return column ? [getColumnKey(column), setting] : [key, setting];
+      return column && isLegacyColumnKey(key)
+        ? [getColumnKey(column), setting]
+        : [key, setting];
     }),
   );
 }

--- a/frontend/src/metabase/visualizations/lib/migrate-settings.ts
+++ b/frontend/src/metabase/visualizations/lib/migrate-settings.ts
@@ -1,0 +1,82 @@
+import { isQuestionDashCard } from "metabase/dashboard/utils";
+import {
+  getColumnKey,
+  getLegacyColumnKey,
+} from "metabase-lib/v1/queries/utils/get-column-key";
+import type {
+  Card,
+  Dashboard,
+  Field,
+  VisualizationSettings,
+} from "metabase-types/api";
+
+export function migrateColumnSettings(
+  columnSettings: VisualizationSettings["column_settings"],
+  resultMetadata: Field[],
+): VisualizationSettings {
+  const columnByKey = Object.fromEntries(
+    resultMetadata.map(column => [getLegacyColumnKey(column), column]),
+  );
+
+  return Object.fromEntries(
+    Object.entries(columnSettings).map(([key, setting]) => {
+      const column = columnByKey[key];
+      return column ? [getColumnKey(column), setting] : [key, setting];
+    }),
+  );
+}
+
+export function migrateCardVizSettings(card: Card): Card {
+  const { visualization_settings, result_metadata } = card;
+  if (!visualization_settings || !result_metadata) {
+    return card;
+  }
+  const { column_settings } = visualization_settings;
+  if (!column_settings) {
+    return card;
+  }
+  return {
+    ...card,
+    visualization_settings: {
+      ...visualization_settings,
+      column_settings: migrateColumnSettings(column_settings, result_metadata),
+    },
+  };
+}
+
+export function migrateDashboardVizSettings(dashboard: Dashboard): Dashboard {
+  return {
+    ...dashboard,
+    dashcards: dashboard.dashcards?.map(dashcard => {
+      if (!isQuestionDashCard(dashcard)) {
+        return dashcard;
+      }
+      const { card, visualization_settings } = dashcard;
+      if (!card || !visualization_settings) {
+        return dashcard;
+      }
+      const { result_metadata } = card;
+      if (!result_metadata) {
+        return dashcard;
+      }
+      const { column_settings } = visualization_settings;
+      if (!column_settings) {
+        return {
+          ...dashcard,
+          card: migrateCardVizSettings(dashcard.card),
+        };
+      }
+      return {
+        ...dashcard,
+        card: migrateCardVizSettings(dashcard.card),
+        visualization_settings: {
+          ...visualization_settings,
+          column_settings: migrateColumnSettings(
+            column_settings,
+            result_metadata,
+          ),
+        },
+      };
+    }),
+  };
+}

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -28,7 +28,6 @@ import { getColumnKey } from "metabase-lib/v1/queries/utils/get-column-key";
 import {
   findColumnIndexesForColumnSettings,
   findColumnSettingIndexesForColumns,
-  getColumnSettingKey,
 } from "metabase-lib/v1/queries/utils/dataset";
 import { nestedSettings } from "./nested";
 
@@ -549,15 +548,11 @@ export const buildTableColumnSettings = ({
         );
 
         return [
-          ...columnSettings.map(setting => ({
-            ...setting,
-            key: getColumnSettingKey(setting),
-          })),
+          ...columnSettings,
           ...cols
             .filter((_, columnIndex) => settingIndexes[columnIndex] < 0)
             .map(column => ({
               name: column.name,
-              key: getColumnKey(column),
               enabled: getIsColumnVisible(column),
               fieldRef: column.field_ref,
             })),

--- a/frontend/src/metabase/visualizations/lib/settings/visualization.js
+++ b/frontend/src/metabase/visualizations/lib/settings/visualization.js
@@ -1,10 +1,8 @@
-import { assocIn } from "icepick";
 import { t } from "ttag";
 
 import { isVirtualDashCard } from "metabase/dashboard/utils";
 import { getVisualizationRaw } from "metabase/visualizations";
 import { trackCardSetToHideWhenNoResults } from "metabase/visualizations/lib/settings/analytics";
-import { normalize } from "metabase-lib/v1/queries/utils/normalize";
 
 import {
   getComputedSettings,
@@ -60,31 +58,9 @@ function getSettingDefintionsForSeries(series) {
   return definitions;
 }
 
-function normalizeColumnSettings(columnSettings) {
-  const newColumnSettings = {};
-  for (const oldColumnKey of Object.keys(columnSettings)) {
-    const [refOrName, fieldRef] = JSON.parse(oldColumnKey);
-    // if the key is a reference, normalize the mbql syntax
-    const newColumnKey =
-      refOrName === "ref"
-        ? JSON.stringify(["ref", normalize(fieldRef)])
-        : oldColumnKey;
-    newColumnSettings[newColumnKey] = columnSettings[oldColumnKey];
-  }
-  return newColumnSettings;
-}
-
 export function getStoredSettingsForSeries(series) {
-  let storedSettings =
+  const storedSettings =
     (series && series[0] && series[0].card.visualization_settings) || {};
-  if (storedSettings.column_settings) {
-    // normalize any settings stored under old style keys: [ref, [fk->, 1, 2]]
-    storedSettings = assocIn(
-      storedSettings,
-      ["column_settings"],
-      normalizeColumnSettings(storedSettings.column_settings),
-    );
-  }
   return storedSettings;
 }
 

--- a/frontend/src/metabase/visualizations/lib/sync-settings.ts
+++ b/frontend/src/metabase/visualizations/lib/sync-settings.ts
@@ -19,6 +19,8 @@ export function syncVizSettingsWithSeries(
   const previousSeries = _previousSeries?.[0];
 
   if (series?.data && !series?.error) {
+    newSettings = syncTableColumnSettings(newSettings, series);
+
     if (previousSeries?.data && !previousSeries?.error) {
       newSettings = syncGraphMetricSettings(
         newSettings,
@@ -26,14 +28,12 @@ export function syncVizSettingsWithSeries(
         previousSeries,
       );
     }
-
-    newSettings = syncNewTableColumnSettings(newSettings, series);
   }
 
   return newSettings;
 }
 
-function syncNewTableColumnSettings(
+function syncTableColumnSettings(
   settings: VisualizationSettings,
   { data }: SingleSeries,
 ): VisualizationSettings {

--- a/frontend/src/metabase/visualizations/lib/sync-settings.ts
+++ b/frontend/src/metabase/visualizations/lib/sync-settings.ts
@@ -2,7 +2,6 @@ import {
   findColumnIndexesForColumnSettings,
   findColumnSettingIndexesForColumns,
 } from "metabase-lib/v1/queries/utils/dataset";
-import { getColumnKey } from "metabase-lib/v1/queries/utils/get-column-key";
 import type {
   Series,
   SingleSeries,
@@ -71,7 +70,6 @@ function syncTableColumnSettings(
 
   const addedColumnSettings = addedColumns.map(col => ({
     name: col.name,
-    key: getColumnKey(col),
     fieldRef: col.field_ref,
     enabled: true,
   }));

--- a/frontend/src/metabase/visualizations/lib/sync-settings.ts
+++ b/frontend/src/metabase/visualizations/lib/sync-settings.ts
@@ -19,8 +19,6 @@ export function syncVizSettingsWithSeries(
   const previousSeries = _previousSeries?.[0];
 
   if (series?.data && !series?.error) {
-    newSettings = syncTableColumnSettings(newSettings, series);
-
     if (previousSeries?.data && !previousSeries?.error) {
       newSettings = syncGraphMetricSettings(
         newSettings,
@@ -28,12 +26,14 @@ export function syncVizSettingsWithSeries(
         previousSeries,
       );
     }
+
+    newSettings = syncNewTableColumnSettings(newSettings, series);
   }
 
   return newSettings;
 }
 
-function syncTableColumnSettings(
+function syncNewTableColumnSettings(
   settings: VisualizationSettings,
   { data }: SingleSeries,
 ): VisualizationSettings {

--- a/frontend/src/metabase/visualizations/lib/sync-settings.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/lib/sync-settings.unit.spec.ts
@@ -1,4 +1,3 @@
-import { getColumnKey } from "metabase-lib/v1/queries/utils/get-column-key";
 import type {
   DatasetColumn,
   TableColumnOrderSetting,
@@ -38,7 +37,6 @@ const columns: DatasetColumn[] = [
 ];
 
 const vizSettingColumns: TableColumnOrderSetting[] = columns.map(column => ({
-  key: getColumnKey(column),
   name: column.name,
   fieldRef: column.field_ref,
   enabled: true,
@@ -112,7 +110,6 @@ describe("syncVizSettingsWithSeries", () => {
         "table.columns": [
           ...vizSettingColumns.slice(1),
           {
-            key: getColumnKey(addedColumn),
             name: addedColumn.name,
             fieldRef: addedColumn.field_ref,
             enabled: true,
@@ -145,7 +142,6 @@ describe("syncVizSettingsWithSeries", () => {
         "table.columns": [
           ...vizSettingColumns.slice(1),
           {
-            key: getColumnKey(updatedColumn),
             name: updatedColumn.name,
             fieldRef: updatedColumn.field_ref,
             enabled: true,
@@ -178,7 +174,6 @@ describe("syncVizSettingsWithSeries", () => {
         "table.columns": [
           ...vizSettingColumns.slice(1),
           {
-            key: getColumnKey(updatedColumn),
             name: updatedColumn.name,
             fieldRef: updatedColumn.field_ref,
             enabled: true,

--- a/src/metabase/formatter/datetime.clj
+++ b/src/metabase/formatter/datetime.clj
@@ -62,7 +62,8 @@
                               ;; match a key with metadata, even if we do have the correct name or id
                               (update-keys #(select-keys % [::mb.viz/field-id ::mb.viz/column-name])))]
     (or (all-cols-settings {::mb.viz/field-id field-id-or-name})
-        (all-cols-settings {::mb.viz/column-name (or field-id-or-name column-name)}))))
+        (all-cols-settings {::mb.viz/column-name field-id-or-name})
+        (all-cols-settings {::mb.viz/column-name column-name}))))
 
 (defn- determine-time-format
   "Given viz-settings with a time-style and possible time-enabled (precision) entry, create the format string.

--- a/src/metabase/query_processor/streaming/common.clj
+++ b/src/metabase/query_processor/streaming/common.clj
@@ -101,7 +101,8 @@
                               (:name col))
           col-settings'   (update-keys col-settings #(select-keys % [::mb.viz/field-id ::mb.viz/column-name]))
           format-settings (or (get col-settings' {::mb.viz/field-id id-or-name})
-                              (get col-settings' {::mb.viz/column-name id-or-name}))
+                              (get col-settings' {::mb.viz/column-name id-or-name})
+                              (get col-settings' {::mb.viz/column-name (:name col)}))
           is-currency?    (or (isa? (:semantic_type col) :type/Currency)
                               (= (::mb.viz/number-style format-settings) "currency"))
           merged-settings (if is-currency?
@@ -188,7 +189,8 @@
                               ;; match a key with metadata, even if we do have the correct name or id
                               (update-keys #(select-keys % [::mb.viz/field-id ::mb.viz/column-name])))
         column-settings (or (all-cols-settings {::mb.viz/field-id field-id-or-name})
-                            (all-cols-settings {::mb.viz/column-name (or field-id-or-name column-name)}))]
+                            (all-cols-settings {::mb.viz/column-name field-id-or-name})
+                            (all-cols-settings {::mb.viz/column-name column-name}))]
     (merge
       ;; The default global settings based on the type of the column
       (global-type-settings col viz-settings)

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -412,7 +412,8 @@
     (doseq [[value col styles index] (map vector values cols cell-styles (range (count values)))]
       (let [id-or-name   (or (:id col) (:name col))
             settings     (or (get col-settings {::mb.viz/field-id id-or-name})
-                             (get col-settings {::mb.viz/column-name id-or-name}))
+                             (get col-settings {::mb.viz/column-name id-or-name})
+                             (get col-settings {::mb.viz/column-name (:name col)}))
             scaled-val   (if (and value (::mb.viz/scale settings))
                            (* value (::mb.viz/scale settings))
                            value)
@@ -434,7 +435,8 @@
     (doseq [[value col styles index] (map vector values cols cell-styles (range (count values)))]
       (let [id-or-name   (or (:id col) (:name col))
             settings     (or (get col-settings {::mb.viz/field-id id-or-name})
-                             (get col-settings {::mb.viz/column-name id-or-name}))
+                             (get col-settings {::mb.viz/column-name id-or-name})
+                             (get col-settings {::mb.viz/column-name (:name col)}))
             scaled-val   (if (and value (::mb.viz/scale settings))
                            (* value (::mb.viz/scale settings))
                            value)


### PR DESCRIPTION
Currently we have 2 formats for viz setting keys:
1. field ref-based: `["ref", ["field", 1, null]]`
2. name-based `["name", "ID"]`

In simple cases (i.e. fields coming from raw tables) we use field refs, in other cases - column names. 

The problem is that field refs can change unpredictably from id-based (`["field", 1, null]`) to name-based  (`["field", "ID", null]`), causing loss of all viz settings. One example where this can happen is when a new query stage is added. 

Another problem is that current field ref-based references prevent us from having multiple identical columns with different `temporal-unit`. `temporal-unit` is omitted from field ref-based keys and that's why such columns would be identical. Names, however, are always unique.

Starting from this PR, the FE will always send name-based keys. For backward compatibility we migrate column keys when processing data from the BE. The migration is done on the FE to reuse the existing `getColumnKey` function to be 100% accurate.

This PR also updates the BE to make sure it always tries to find a setting by a column name. The change should be backward compatible. 