### PR TITLE
fix stacking settings on line charts

### DIFF
--- a/frontend/src/metabase/static-viz/components/ComboChart/settings.ts
+++ b/frontend/src/metabase/static-viz/components/ComboChart/settings.ts
@@ -193,7 +193,7 @@ export const computeStaticComboChartSettings = (
     settings,
     "stackable.stack_type",
     getDefaultStackingValue(settings, mainCard),
-    isStackingValueValid(mainCard.display, settings, seriesDisplays),
+    isStackingValueValid(settings, seriesDisplays),
   );
 
   fillWithDefaultValue(

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -41,7 +41,7 @@ import {
   getAreDimensionsAndMetricsValid,
   getDefaultDimensions,
   getDefaultShowStackValues,
-  STACKABLE_DISPLAY_TYPES,
+  STACKABLE_SERIES_DISPLAY_TYPES,
   getDefaultMetrics,
   isShowStackValuesValid,
 } from "metabase/visualizations/shared/settings/cartesian-chart";
@@ -248,11 +248,7 @@ export const STACKABLE_SETTINGS = {
     isValid: (series, settings) => {
       const seriesDisplays = getSeriesDisplays(series, settings);
 
-      return isStackingValueValid(
-        series[0].card.display,
-        settings,
-        seriesDisplays,
-      );
+      return isStackingValueValid(settings, seriesDisplays);
     },
     getDefault: ([{ card, data }], settings) => {
       return getDefaultStackingValue(settings, card);
@@ -260,7 +256,7 @@ export const STACKABLE_SETTINGS = {
     getHidden: (series, settings) => {
       const displays = series.map(single => settings.series(single).display);
       const stackableDisplays = displays.filter(display =>
-        STACKABLE_DISPLAY_TYPES.has(display),
+        STACKABLE_SERIES_DISPLAY_TYPES.has(display),
       );
 
       return stackableDisplays.length <= 1;

--- a/frontend/src/metabase/visualizations/lib/settings/graph.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.unit.spec.js
@@ -55,6 +55,48 @@ describe("STACKABLE_SETTINGS", () => {
         expect(value).toBe("normalized");
       });
     });
+
+    describe("isValid", () => {
+      const isValid = STACKABLE_SETTINGS["stackable.stack_type"].isValid;
+
+      it("should be valid even on cards with display=line when there are stackable series (metabase#45182)", () => {
+        const result = isValid(
+          [
+            { card: { display: "line" }, id: 1 },
+            { card: { display: "line" }, id: 2 },
+            { card: { display: "line" }, id: 3 },
+          ],
+          {
+            series: series => ({
+              display: series.card.id === 1 ? "line" : "bar",
+            }),
+            "stackable.stack_type": "stacked",
+            "graph.show_values": false,
+          },
+        );
+
+        expect(result).toBe(true);
+      });
+
+      it("should not be valid when there is less than two stackable series", () => {
+        const result = isValid(
+          [
+            { card: { display: "bar" }, id: 1 },
+            { card: { display: "bar" }, id: 2 },
+            { card: { display: "bar" }, id: 3 },
+          ],
+          {
+            series: series => ({
+              display: series.card.id === 1 ? "bar" : "line",
+            }),
+            "stackable.stack_type": "stacked",
+            "graph.show_values": false,
+          },
+        );
+
+        expect(result).toBe(false);
+      });
+    });
   });
 });
 

--- a/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
@@ -20,7 +20,6 @@ import {
 } from "metabase-lib/v1/types/utils/isa";
 import type {
   Card,
-  CardDisplayType,
   DatasetColumn,
   DatasetData,
   RawSeries,
@@ -68,22 +67,18 @@ export function getDefaultMetrics(rawSeries: RawSeries) {
   return getDefaultColumns(rawSeries).metrics;
 }
 
-export const STACKABLE_DISPLAY_TYPES = new Set(["area", "bar", "combo"]);
+export const STACKABLE_SERIES_DISPLAY_TYPES = new Set(["area", "bar"]);
 
 export const isStackingValueValid = (
-  cardDisplay: CardDisplayType,
   settings: ComputedVisualizationSettings,
   seriesDisplays: string[],
 ) => {
   if (settings["stackable.stack_type"] == null) {
     return true;
   }
-  if (!STACKABLE_DISPLAY_TYPES.has(cardDisplay)) {
-    return false;
-  }
 
   const stackableDisplays = seriesDisplays.filter(display =>
-    STACKABLE_DISPLAY_TYPES.has(display),
+    STACKABLE_SERIES_DISPLAY_TYPES.has(display),
   );
   return stackableDisplays.length > 1;
 };


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/45182

### Description

Line/bar/area/combo charts are the same given the ability to change individual series display types. However, the stacking settings worked incorrectly when the viz type was `line` by not allowing to change it to something else even when there are stackable series.

### How to verify

- Create multiseries line chart
- Change invidivual series display types to `bar` for at least two series
- Ensure you can change stacking settings

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
