### PR TITLE
[serdes] use spec instead of a pipeline for Card

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/models_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/models_test.clj
@@ -62,11 +62,14 @@
                 :let   [fk (u/lower-case-en fk)
                         action (get spec' (keyword fk))]]
           (testing (format "%s.%s is foreign key which is handled correctly" m fk)
-            ;; FIXME: maybe serialization can guess where FK points by itself?
+            ;; FIXME: serialization can guess where FK points by itself, but `collection_id` and `database_id` are
+            ;; specifying that themselves right now
             (when-not (#{"collection_id" "database_id"} fk)
               (is (#{:skip
                      serdes/*export-fk*
                      serdes/*export-fk-keyed*
                      serdes/*export-table-fk*
                      serdes/*export-user*}
-                   (or (:ser action) action))))))))))
+                   (if (vector? action)
+                     (first action) ;; tuple of [ser des]
+                     action))))))))))

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -891,26 +891,26 @@
           ;; this column is not used anymore
           :cache_ttl]
    :transform
-   {:database_id            {:ser #(serdes/*export-fk-keyed* % 'Database :name)
-                             :des #(serdes/*import-fk-keyed* % 'Database :name)}
-    :table_id               {:ser serdes/*export-table-fk*
-                             :des serdes/*import-table-fk*}
-    :collection_id          {:ser #(serdes/*export-fk* % 'Collection)
-                             :des #(serdes/*import-fk* % 'Collection)}
-    :creator_id             {:ser serdes/*export-user*
-                             :des serdes/*import-user*}
-    :made_public_by_id      {:ser serdes/*export-user*
-                             :des serdes/*import-user*}
-    :dataset_query          {:ser serdes/export-mbql
-                             :des serdes/import-mbql}
-    :parameters             {:ser serdes/export-parameters
-                             :des serdes/import-parameters}
-    :parameter_mappings     {:ser serdes/export-parameter-mappings
-                             :des serdes/import-parameter-mappings}
-    :visualization_settings {:ser serdes/export-visualization-settings
-                             :des serdes/import-visualization-settings}
-    :result_metadata        {:ser export-result-metadata
-                             :des import-result-metadata}}})
+   {:database_id            [#(serdes/*export-fk-keyed* % 'Database :name)
+                             #(serdes/*import-fk-keyed* % 'Database :name)]
+    :table_id               [serdes/*export-table-fk*
+                             serdes/*import-table-fk*]
+    :collection_id          [#(serdes/*export-fk* % 'Collection)
+                             #(serdes/*import-fk* % 'Collection)]
+    :creator_id             [serdes/*export-user*
+                             serdes/*import-user*]
+    :made_public_by_id      [serdes/*export-user*
+                             serdes/*import-user*]
+    :dataset_query          [serdes/export-mbql
+                             serdes/import-mbql]
+    :parameters             [serdes/export-parameters
+                             serdes/import-parameters]
+    :parameter_mappings     [serdes/export-parameter-mappings
+                             serdes/import-parameter-mappings]
+    :visualization_settings [serdes/export-visualization-settings
+                             serdes/import-visualization-settings]
+    :result_metadata        [export-result-metadata
+                             import-result-metadata]}})
 
 (defmethod serdes/dependencies "Card"
   [{:keys [collection_id database_id dataset_query parameters parameter_mappings

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -878,11 +878,18 @@
 
 (defmethod serdes/make-spec "Card"
   [_model-name]
-  {:copy [:name :description :archived :collection_position :enable_embedding :type :query_type
-          :display :archived_directly :entity_id :collection_preview :metabase_version :public_uuid
-          :created_at :embedding_params]
-   :skip [:id :updated_at :cache_invalidated_at :view_count :last_used_at :initially_published_at
-          :dataset_query_metrics_v2_migration_backup :cache_ttl]
+  {:copy [:archived :archived_directly :collection_position :collection_preview :created_at :description :display
+          :embedding_params :enable_embedding :entity_id :metabase_version :public_uuid :query_type :type :name]
+   :skip [ ;; always instance-specific
+          :id :updated_at
+          ;; cache invalidation is instance-specific
+          :cache_invalidated_at
+          ;; those are instance-specific analytic columns
+          :view_count :last_used_at :initially_published_at
+          ;; this is data migration column
+          :dataset_query_metrics_v2_migration_backup
+          ;; this column is not used anymore
+          :cache_ttl]
    :transform
    {:database_id            {:ser #(serdes/*export-fk-keyed* % 'Database :name)
                              :des #(serdes/*import-fk-keyed* % 'Database :name)}

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -876,55 +876,48 @@
                                     [(when (:table_id m) #{(serdes/table->path (:table_id m))})
                                      (when (:id m)       #{(serdes/field->path (:id m))})])))))
 
-(defmethod serdes/extract-one "Card"
-  [_model-name _opts card]
-  ;; Cards have :table_id, :database_id, :collection_id, :creator_id that need conversion.
-  ;; :table_id and :database_id are extracted as just :table_id [database_name schema table_name].
-  ;; :collection_id is extracted as its entity_id or identity-hash.
-  ;; :creator_id as the user's email.
-  (-> (serdes/extract-one-basics "Card" card)
-      (update :database_id            serdes/*export-fk-keyed* 'Database :name)
-      (update :table_id               serdes/*export-table-fk*)
-      (update :collection_id          serdes/*export-fk* 'Collection)
-      (update :creator_id             serdes/*export-user*)
-      (update :made_public_by_id      serdes/*export-user*)
-      (update :dataset_query          serdes/export-mbql)
-      (update :parameters             serdes/export-parameters)
-      (update :parameter_mappings     serdes/export-parameter-mappings)
-      (update :visualization_settings serdes/export-visualization-settings)
-      (update :result_metadata        export-result-metadata)
-      (dissoc :cache_invalidated_at :view_count :last_used_at :initially_published_at
-              :dataset_query_metrics_v2_migration_backup)))
-
-(defmethod serdes/load-xform "Card"
-  [card]
-  (-> card
-      serdes/load-xform-basics
-      (update :database_id            serdes/*import-fk-keyed* 'Database :name)
-      (update :table_id               serdes/*import-table-fk*)
-      (update :creator_id             serdes/*import-user*)
-      (update :made_public_by_id      serdes/*import-user*)
-      (update :collection_id          serdes/*import-fk* 'Collection)
-      (update :dataset_query          serdes/import-mbql)
-      (update :parameters             serdes/import-parameters)
-      (update :parameter_mappings     serdes/import-parameter-mappings)
-      (update :visualization_settings serdes/import-visualization-settings)
-      (update :result_metadata        import-result-metadata)))
+(defmethod serdes/make-spec "Card"
+  [_model-name]
+  {:copy [:name :description :archived :collection_position :enable_embedding :type :query_type
+          :display :archived_directly :entity_id :collection_preview :metabase_version :public_uuid
+          :created_at :embedding_params]
+   :skip [:id :updated_at :cache_invalidated_at :view_count :last_used_at :initially_published_at
+          :dataset_query_metrics_v2_migration_backup :cache_ttl]
+   :transform
+   {:database_id            {:ser #(serdes/*export-fk-keyed* % 'Database :name)
+                             :des #(serdes/*import-fk-keyed* % 'Database :name)}
+    :table_id               {:ser serdes/*export-table-fk*
+                             :des serdes/*import-table-fk*}
+    :collection_id          {:ser #(serdes/*export-fk* % 'Collection)
+                             :des #(serdes/*import-fk* % 'Collection)}
+    :creator_id             {:ser serdes/*export-user*
+                             :des serdes/*import-user*}
+    :made_public_by_id      {:ser serdes/*export-user*
+                             :des serdes/*import-user*}
+    :dataset_query          {:ser serdes/export-mbql
+                             :des serdes/import-mbql}
+    :parameters             {:ser serdes/export-parameters
+                             :des serdes/import-parameters}
+    :parameter_mappings     {:ser serdes/export-parameter-mappings
+                             :des serdes/import-parameter-mappings}
+    :visualization_settings {:ser serdes/export-visualization-settings
+                             :des serdes/import-visualization-settings}
+    :result_metadata        {:ser export-result-metadata
+                             :des import-result-metadata}}})
 
 (defmethod serdes/dependencies "Card"
   [{:keys [collection_id database_id dataset_query parameters parameter_mappings
            result_metadata table_id visualization_settings]}]
-  (->> (map serdes/mbql-deps parameter_mappings)
-       (reduce set/union #{})
-       (set/union (serdes/parameters-deps parameters))
-       (set/union #{[{:model "Database" :id database_id}]})
-       ; table_id and collection_id are nullable.
-       (set/union (when table_id #{(serdes/table->path table_id)}))
-       (set/union (when collection_id #{[{:model "Collection" :id collection_id}]}))
-       (set/union (result-metadata-deps result_metadata))
-       (set/union (serdes/mbql-deps dataset_query))
-       (set/union (serdes/visualization-settings-deps visualization_settings))
-       vec))
+  (set
+   (concat
+    (mapcat serdes/mbql-deps parameter_mappings)
+    (serdes/parameters-deps parameters)
+    [[{:model "Database" :id database_id}]]
+    (when table_id #{(serdes/table->path table_id)})
+    (when collection_id #{[{:model "Collection" :id collection_id}]})
+    (result-metadata-deps result_metadata)
+    (serdes/mbql-deps dataset_query)
+    (serdes/visualization-settings-deps visualization_settings))))
 
 (defmethod serdes/descendants "Card" [_model-name id]
   (let [card               (t2/select-one Card :id id)
@@ -932,19 +925,17 @@
         template-tags      (some->> card :dataset_query :native :template-tags vals (keep :card-id))
         parameters-card-id (some->> card :parameters (keep (comp :card_id :values_source_config)))
         snippets           (some->> card :dataset_query :native :template-tags vals (keep :snippet-id))]
-    (set/union
+    (set
+     (concat
       (when (and (string? source-table)
                  (str/starts-with? source-table "card__"))
-        #{["Card" (Integer/parseInt (.substring ^String source-table 6))]})
-      (when (seq template-tags)
-        (set (for [card-id template-tags]
-               ["Card" card-id])))
-      (when (seq parameters-card-id)
-        (set (for [card-id parameters-card-id]
-               ["Card" card-id])))
-      (when (seq snippets)
-        (set (for [snippet-id snippets]
-               ["NativeQuerySnippet" snippet-id]))))))
+        [["Card" (parse-long (subs source-table 6))]])
+      (for [card-id template-tags]
+        ["Card" card-id])
+      (for [card-id parameters-card-id]
+        ["Card" card-id])
+      (for [snippet-id snippets]
+        ["NativeQuerySnippet" snippet-id])))))
 
 
 ;;; ------------------------------------------------ Audit Log --------------------------------------------------------

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -563,7 +563,7 @@
 (defn- ->table-name
   "Returns the table name that a particular ingested entity should finally be inserted into."
   [ingested]
-  (->> ingested ingested-model (keyword "model") t2/table-name name))
+  (->> ingested ingested-model (keyword "model") t2/table-name))
 
 (defmulti ingested-model-columns
   "Called by `drop-excess-keys` (which is in turn called by `load-xform-basics`) to determine the full set of keys that

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -305,8 +305,8 @@
 (defn- extract-by-spec [model-name _opts instance]
   (when-let [spec (make-spec model-name)]
     (into (select-keys instance (:copy spec))
-          (for [[k v] (:transform spec)]
-            [k ((:ser v) (get instance k))]))))
+          (for [[k [ser _des]] (:transform spec)]
+            [k (ser (get instance k))]))))
 
 (defmulti extract-all
   "Entry point for extracting all entities of a particular model:
@@ -667,8 +667,8 @@
         spec       (make-spec model-name)]
     (when spec
       (into (select-keys ingested (:copy spec))
-            (for [[k v] (:transform spec)]
-              [k ((:des v) (get ingested k))])))))
+            (for [[k [_ser des]] (:transform spec)]
+              [k (des (get ingested k))])))))
 
 (defn default-load-one!
   "Default implementation of `load-one!`"

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -288,6 +288,26 @@
 ;;;
 ;;; *Note:* "descendants" and "dependencies" are quite different things!
 
+(defmulti make-spec
+  "Return specification for serialization. This should be a map of three keys: `:copy`, `:skip`, `:transform`.
+
+  `:copy` and `:skip` are vectors of field names. `:skip` is only used in tests to check that all fields were
+  mentioned.
+
+  `:transform` is a map from field name to a `{:ser (fn [v] ...) :des (fn [v] ...)}` map with functions to
+  serialize/deserialize data.
+
+  For behavior, see `extract-by-spec` and `load-by-spec`."
+  (fn [model-name] model-name))
+
+(defmethod make-spec :default [_] nil)
+
+(defn- extract-by-spec [model-name _opts instance]
+  (when-let [spec (make-spec model-name)]
+    (into (select-keys instance (:copy spec))
+          (for [[k v] (:transform spec)]
+            [k ((:ser v) (get instance k))]))))
+
 (defmulti extract-all
   "Entry point for extracting all entities of a particular model:
   `(extract-all \"ModelName\" {opts...})`
@@ -387,8 +407,11 @@
         (assoc :serdes/meta (generate-path model-name entity))
         (dissoc pk :updated_at))))
 
-(defmethod extract-one :default [model-name _opts entity]
-  (extract-one-basics model-name entity))
+(defmethod extract-one :default [model-name opts entity]
+  ;; `extract-by-spec` is called here since most of tests use `extract-one` right now
+  (or (some-> (extract-by-spec model-name opts entity)
+              (assoc :serdes/meta (generate-path model-name entity)))
+      (extract-one-basics model-name entity)))
 
 (defmulti descendants
   "Returns set of `[model-name database-id]` pairs for all entities contained or used by this entity. e.g. the Dashboard
@@ -639,11 +662,20 @@
   (fn [ingested _]
     (ingested-model ingested)))
 
+(defn- load-by-spec [ingested]
+  (let [model-name (ingested-model ingested)
+        spec       (make-spec model-name)]
+    (when spec
+      (into (select-keys ingested (:copy spec))
+            (for [[k v] (:transform spec)]
+              [k ((:des v) (get ingested k))])))))
+
 (defn default-load-one!
   "Default implementation of `load-one!`"
   [ingested maybe-local]
   (let [model    (ingested-model ingested)
-        adjusted (load-xform ingested)]
+        adjusted (or (load-by-spec ingested)
+                     (load-xform ingested))]
     (binding [mi/*deserializing?* true]
       (if (nil? maybe-local)
         (load-insert! model adjusted)
@@ -752,7 +784,8 @@
     (let [model-name (name model)
           model      (t2.model/resolve-model (symbol model-name))
           entity     (t2/select-one model (first (t2/primary-keys model)) id)
-          path       (when entity (mapv :id (generate-path model-name entity)))]
+          path       (when entity
+                       (mapv :id (generate-path model-name entity)))]
       (cond
         (nil? entity)      (throw (ex-info "FK target not found" {:model model
                                                                   :id    id

--- a/src/metabase/util/connection.clj
+++ b/src/metabase/util/connection.clj
@@ -2,20 +2,38 @@
   (:require [metabase.util :as u]
             [toucan2.core :as t2])
   (:import
-   (java.sql Connection)))
+   (java.sql Connection ResultSet ResultSetMetaData)))
 
 (set! *warn-on-reflection* true)
+
+(defn- consume-rset [^ResultSet rset cb]
+  (into {} (iteration
+            (fn [_]
+              (when (.next rset)
+                (cb rset))))))
 
 (defn app-db-column-types
   "Returns a map of all column names to their respective type names for the given `table-name` in the provided
   application-db."
   [app-db table-name']
-  (let [table-name (cond-> table-name'
+  (let [table-name (cond-> (name table-name')
                      (= (:db-type app-db) :h2) u/upper-case-en)]
     (t2/with-connection [^Connection conn]
-      (with-open [rset (.getColumns (.getMetaData conn) nil nil table-name nil)]
-        (into {}
-              (iteration
-               (fn [_]
-                 (when (.next rset)
-                   [(.getString rset "COLUMN_NAME") (.getString rset "TYPE_NAME")]))))))))
+      (let [md (.getMetaData conn)]
+        (with-open [cols (.getColumns md nil nil table-name nil)
+                    pks  (.getPrimaryKeys md nil nil table-name)
+                    fks  (.getImportedKeys md nil nil table-name)]
+          (let [pks (consume-rset pks (fn [^ResultSet pks]
+                                        [(.getString pks "COLUMN_NAME") true]))
+                fks (consume-rset fks (fn [^ResultSet fks]
+                                        [(.getString fks "FKCOLUMN_NAME")
+                                         (str (.getString fks "PKTABLE_NAME")
+                                              "."
+                                              (.getString fks "PKCOLUMN_NAME"))]))]
+            (consume-rset cols (fn [^ResultSet cols]
+                                 (let [col (.getString cols "COLUMN_NAME")]
+                                   [col {:type    (.getString cols "TYPE_NAME")
+                                         :notnull (= (.getInt cols "NULLABLE")
+                                                     ResultSetMetaData/columnNoNulls)
+                                         :pk      (get pks col)
+                                         :fk      (get fks col)}])))))))))


### PR DESCRIPTION
Idea is to add serialization spec to every serializable model, making it more declarative. This will allow us to work with given data and even check various constraints (foreign keys?).

This is a first naïve version, but I'm sure it won't be too hard to support all weird corner cases, i.e. inlined models (like tabs and dashcards in Dashboard). I'd rather keep first commit small and understandable to gather some opinions on general approach.

Why three top-level keys instead of just specifying every field as a top-level key: for brevity. It's hard to see what's going on when a model is big as Card.