### PR TITLE
perf: pass uuid to BE to enable metadata caching during fetching dashboard

### DIFF
--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -215,7 +215,9 @@ function visitDashboardById(dashboard_id, config) {
   }).then(({ status, body: { dashcards, tabs } }) => {
     const dashboardAlias = "getDashboard" + dashboard_id;
 
-    cy.intercept("GET", `/api/dashboard/${dashboard_id}`).as(dashboardAlias);
+    cy.intercept("GET", new RegExp(`/api/dashboard/${dashboard_id}`)).as(
+      dashboardAlias,
+    );
 
     const canViewDashboard = hasAccess(status);
 

--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -215,9 +215,7 @@ function visitDashboardById(dashboard_id, config) {
   }).then(({ status, body: { dashcards, tabs } }) => {
     const dashboardAlias = "getDashboard" + dashboard_id;
 
-    cy.intercept("GET", new RegExp(`/api/dashboard/${dashboard_id}`)).as(
-      dashboardAlias,
-    );
+    cy.intercept("GET", `/api/dashboard/${dashboard_id}*`).as(dashboardAlias);
 
     const canViewDashboard = hasAccess(status);
 

--- a/e2e/test/scenarios/collections/trash.cy.spec.js
+++ b/e2e/test/scenarios/collections/trash.cy.spec.js
@@ -669,7 +669,7 @@ describe("scenarios > collections > trash", () => {
 
     cy.log("Make sure trash is selected for a trashed dashboard");
     cy.get("@dashboard").then(dashboard => {
-      cy.intercept("GET", `/api/dashboard/${dashboard.id}`).as("getDashboard");
+      cy.intercept("GET", `/api/dashboard/${dashboard.id}*`).as("getDashboard");
       visitDashboard(dashboard.id);
       cy.wait("@getDashboard");
       openNavigationSidebar();

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-fetching.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-fetching.cy.spec.js
@@ -1,0 +1,60 @@
+import {
+  ORDERS_COUNT_QUESTION_ID,
+  ORDERS_BY_YEAR_QUESTION_ID,
+} from "e2e/support/cypress_sample_instance_data";
+import { visitDashboard, updateDashboardCards } from "e2e/support/helpers";
+
+const cards = [
+  {
+    card_id: ORDERS_COUNT_QUESTION_ID,
+    row: 0,
+    col: 0,
+    size_x: 5,
+    size_y: 4,
+  },
+  {
+    card_id: ORDERS_BY_YEAR_QUESTION_ID,
+    row: 0,
+    col: 5,
+    size_x: 5,
+    size_y: 5,
+  },
+];
+
+describe("dashboard card fetching", () => {
+  beforeEach(() => {
+    cy.signInAsNormalUser();
+    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
+      "dashcardQuery",
+    );
+  });
+
+  it("should pass same dashboard_load_id to every query to enable metadata cache sharing", () => {
+    createDashboardWithCards({ cards }).then(visitDashboard);
+
+    cy.wait(["@dashcardQuery", "@dashcardQuery"]).then(interceptions => {
+      const query1 = interceptions[0].request.body;
+      const query2 = interceptions[1].request.body;
+
+      expect(query1.dashboard_load_id).to.have.length(36);
+      expect(query2.dashboard_load_id).to.have.length(36);
+      expect(query1.dashboard_load_id).to.equal(query2.dashboard_load_id);
+    });
+  });
+});
+
+function createDashboardWithCards({
+  dashboardName = "test dashboard",
+  cards = [],
+} = {}) {
+  return cy
+    .createDashboard({ name: dashboardName })
+    .then(({ body: { id } }) => {
+      updateDashboardCards({
+        dashboard_id: id,
+        cards,
+      });
+
+      cy.wrap(id).as("dashboardId");
+    });
+}

--- a/e2e/test/scenarios/dashboard/dashboard-management.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-management.cy.spec.js
@@ -50,7 +50,7 @@ describe("managing dashboard from the dashboard's edit menu", () => {
                 dashboardDetails: { name: dashboardName },
               }).then(({ body: { dashboard_id } }) => {
                 cy.wrap(dashboard_id).as("originalDashboardId");
-                cy.intercept("GET", `/api/dashboard/${dashboard_id}`).as(
+                cy.intercept("GET", `/api/dashboard/${dashboard_id}*`).as(
                   "getDashboard",
                 );
                 cy.intercept("PUT", `/api/dashboard/${dashboard_id}`).as(

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -884,7 +884,7 @@ describe("scenarios > dashboard", () => {
 
           cy.intercept(
             "GET",
-            `/api/dashboard/${ORDERS_DASHBOARD_ID}/query_metadata`,
+            `/api/dashboard/${ORDERS_DASHBOARD_ID}/query_metadata*`,
           ).as("queryMetadata");
         });
       },

--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -146,7 +146,7 @@ describe("issue 8030 + 32444", () => {
   };
 
   const interceptRequests = ({ dashboard_id, card1_id, card2_id }) => {
-    cy.intercept("GET", `/api/dashboard/${dashboard_id}`).as("getDashboard");
+    cy.intercept("GET", `/api/dashboard/${dashboard_id}*`).as("getDashboard");
     cy.intercept(
       "POST",
       `/api/dashboard/${dashboard_id}/dashcard/*/card/${card1_id}/query`,

--- a/e2e/test/scenarios/models/reproductions.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.js
@@ -1189,7 +1189,7 @@ describe("issue 29517 - nested question based on native model with remapped valu
 
     visitDashboard("@dashboardId");
 
-    cy.intercept("GET", `/api/dashboard/${ORDERS_DASHBOARD_ID}`).as(
+    cy.intercept("GET", `/api/dashboard/${ORDERS_DASHBOARD_ID}*`).as(
       "loadTargetDashboard",
     );
     cartesianChartCircle().eq(25).click({ force: true });

--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -441,7 +441,7 @@ describe("scenarios > home > custom homepage", () => {
     it("should not redirect when already on the dashboard homepage (metabase#43800)", () => {
       cy.intercept(
         "GET",
-        `/api/dashboard/${ORDERS_DASHBOARD_ID}/query_metadata`,
+        `/api/dashboard/${ORDERS_DASHBOARD_ID}/query_metadata*`,
       ).as("getDashboardMetadata");
       cy.intercept(
         "POST",

--- a/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.js
@@ -629,7 +629,7 @@ describe("issue 21665", () => {
     }).then(({ dashboardId, questionId }) => {
       cy.intercept(
         "GET",
-        `/api/dashboard/${dashboardId}`,
+        `/api/dashboard/${dashboardId}*`,
         cy.spy().as("dashboardLoaded"),
       ).as("getDashboard");
 

--- a/frontend/src/metabase-types/api/automagic-dashboards.ts
+++ b/frontend/src/metabase-types/api/automagic-dashboards.ts
@@ -13,6 +13,7 @@ export type XrayEntityType =
 export interface GetXrayDashboardQueryMetadataRequest {
   entity: XrayEntityType;
   entityId: number | string;
+  dashboard_load_id?: string;
 }
 
 export interface DatabaseXray {

--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -274,6 +274,11 @@ export type UpdateDashboardRequest = {
   position?: number | null;
 };
 
+export type GetDashboardQueryMetadataRequest = {
+  id: DashboardId;
+  dashboard_load_id?: string;
+};
+
 export type SaveDashboardRequest = Omit<UpdateDashboardRequest, "id">;
 
 export type CopyDashboardRequest = {

--- a/frontend/src/metabase/api/automagic-dashboards.ts
+++ b/frontend/src/metabase/api/automagic-dashboards.ts
@@ -17,8 +17,11 @@ export const automagicDashboardsApi = Api.injectEndpoints({
       DashboardQueryMetadata,
       GetXrayDashboardQueryMetadataRequest
     >({
-      query: ({ entity, entityId }) =>
-        `/api/automagic-dashboards/${entity}/${entityId}/query_metadata`,
+      query: ({ entity, entityId, ...params }) => ({
+        method: "GET",
+        url: `/api/automagic-dashboards/${entity}/${entityId}/query_metadata`,
+        params,
+      }),
       providesTags: metadata =>
         metadata ? provideDashboardQueryMetadataTags(metadata) : [],
     }),

--- a/frontend/src/metabase/api/dashboard.ts
+++ b/frontend/src/metabase/api/dashboard.ts
@@ -4,6 +4,7 @@ import type {
   Dashboard,
   DashboardId,
   DashboardQueryMetadata,
+  GetDashboardQueryMetadataRequest,
   GetDashboardRequest,
   ListDashboardsRequest,
   ListDashboardsResponse,
@@ -46,11 +47,12 @@ export const dashboardApi = Api.injectEndpoints({
     }),
     getDashboardQueryMetadata: builder.query<
       DashboardQueryMetadata,
-      DashboardId
+      GetDashboardQueryMetadataRequest
     >({
-      query: id => ({
+      query: ({ id, ...params }) => ({
         method: "GET",
         url: `/api/dashboard/${id}/query_metadata`,
+        params,
       }),
       providesTags: metadata =>
         metadata ? provideDashboardQueryMetadataTags(metadata) : [],

--- a/frontend/src/metabase/dashboard/actions/data-fetching-typed.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching-typed.ts
@@ -13,6 +13,7 @@ import Dashboards from "metabase/entities/dashboards";
 import type { Deferred } from "metabase/lib/promise";
 import { defer } from "metabase/lib/promise";
 import { createAsyncThunk } from "metabase/lib/redux";
+import { uuid } from "metabase/lib/uuid";
 import { addFields, addParamValues } from "metabase/redux/metadata";
 import { AutoApi, DashboardApi, EmbedApi, PublicApi } from "metabase/services";
 import { getParameterValuesByIdFromQueryParams } from "metabase-lib/v1/parameters/utils/parameter-parsing";
@@ -48,6 +49,7 @@ export const fetchDashboard = createAsyncThunk(
     try {
       let entities;
       let result;
+      const dashboardLoadId = uuid();
 
       const dashboardType = getDashboardType(dashId);
       const loadedDashboard = getDashboardById(getState(), dashId);
@@ -65,7 +67,7 @@ export const fetchDashboard = createAsyncThunk(
         result = denormalize(dashId, dashboard, entities);
       } else if (dashboardType === "public") {
         result = await PublicApi.dashboard(
-          { uuid: dashId },
+          { uuid: dashId, dashboard_load_id: dashboardLoadId },
           { cancelled: fetchDashboardCancellation.promise },
         );
         result = {
@@ -78,7 +80,7 @@ export const fetchDashboard = createAsyncThunk(
         };
       } else if (dashboardType === "embed") {
         result = await EmbedApi.dashboard(
-          { token: dashId },
+          { token: dashId, dashboard_load_id: dashboardLoadId },
           { cancelled: fetchDashboardCancellation.promise },
         );
         result = {
@@ -94,10 +96,16 @@ export const fetchDashboard = createAsyncThunk(
         const [entity, entityId] = subPath.split(/[/?]/);
         const [response] = await Promise.all([
           AutoApi.dashboard(
-            { subPath },
+            { subPath, dashboard_load_id: dashboardLoadId },
             { cancelled: fetchDashboardCancellation.promise },
           ),
-          dispatch(Dashboards.actions.fetchXrayMetadata({ entity, entityId })),
+          dispatch(
+            Dashboards.actions.fetchXrayMetadata({
+              entity,
+              entityId,
+              dashboard_load_id: dashboardLoadId,
+            }),
+          ),
         ]);
         result = {
           ...response,
@@ -119,10 +127,15 @@ export const fetchDashboard = createAsyncThunk(
       } else {
         const [response] = await Promise.all([
           DashboardApi.get(
-            { dashId: dashId },
+            { dashId: dashId, dashboard_load_id: dashboardLoadId },
             { cancelled: fetchDashboardCancellation.promise },
           ),
-          dispatch(Dashboards.actions.fetchMetadata({ id: dashId })),
+          dispatch(
+            Dashboards.actions.fetchMetadata({
+              id: dashId,
+              dashboard_load_id: dashboardLoadId,
+            }),
+          ),
         ]);
         result = response;
       }

--- a/frontend/src/metabase/dashboard/actions/data-fetching.js
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.js
@@ -5,6 +5,7 @@ import { showAutoApplyFiltersToast } from "metabase/dashboard/actions/parameters
 import { defer } from "metabase/lib/promise";
 import { createAction, createThunkAction } from "metabase/lib/redux";
 import { equals } from "metabase/lib/utils";
+import { uuid } from "metabase/lib/uuid";
 import {
   DashboardApi,
   CardApi,
@@ -113,7 +114,11 @@ const loadingComplete = createThunkAction(
 
 export const fetchCardData = createThunkAction(
   FETCH_CARD_DATA,
-  function (card, dashcard, { reload, clearCache, ignoreCache } = {}) {
+  function (
+    card,
+    dashcard,
+    { reload, clearCache, ignoreCache, dashboardLoadId } = {},
+  ) {
     return async function (dispatch, getState) {
       dispatch({
         type: FETCH_CARD_DATA_PENDING,
@@ -280,6 +285,7 @@ export const fetchCardData = createThunkAction(
               parameters: datasetQuery.parameters,
               ignore_cache: ignoreCache,
               dashboard_id: dashcard.dashboard_id,
+              dashboard_load_id: dashboardLoadId,
             };
 
         result = await fetchDataOrError(
@@ -305,6 +311,7 @@ export const fetchDashboardCardData =
   (dispatch, getState) => {
     const dashboard = getDashboardComplete(getState());
     const selectedTabId = getSelectedTabId(getState());
+    const dashboardLoadId = uuid();
 
     const loadingIds = getLoadingDashCards(getState()).loadingIds;
     const nonVirtualDashcards = getCurrentTabDashboardCards(
@@ -352,7 +359,7 @@ export const fetchDashboardCardData =
 
     const promises = nonVirtualDashcardsToFetch.map(({ card, dashcard }) => {
       return dispatch(
-        fetchCardData(card, dashcard, { reload, clearCache }),
+        fetchCardData(card, dashcard, { reload, clearCache, dashboardLoadId }),
       ).then(() => {
         return dispatch(updateLoadingTitle(nonVirtualDashcardsToFetch.length));
       });

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.unit.spec.tsx
@@ -238,4 +238,33 @@ describe("DashboardApp", () => {
       ).toBeInTheDocument();
     });
   });
+
+  /**
+   * passing the same uuid in the URL is required to enable metadata cache
+   * sharing on BE
+   */
+  it("should pass dashboard_load_id to dashboard and query_metadata endpoints", async () => {
+    const { dashboardId } = await setup();
+
+    const dashboardURL = fetchMock.lastUrl(
+      `path:/api/dashboard/${dashboardId}`,
+    );
+    const queryMetadataURL = fetchMock.lastUrl(
+      `path:/api/dashboard/${dashboardId}/query_metadata`,
+    );
+
+    const dashboardSearchParams = new URLSearchParams(
+      dashboardURL?.split("?")[1],
+    );
+    const queryMetadataSearchParams = new URLSearchParams(
+      queryMetadataURL?.split("?")[1],
+    );
+
+    expect(dashboardSearchParams.get("dashboard_load_id")).toHaveLength(36); // uuid length
+    expect(queryMetadataSearchParams.get("dashboard_load_id")).toHaveLength(36); // uuid length
+
+    expect(queryMetadataSearchParams.get("dashboard_load_id")).toEqual(
+      dashboardSearchParams.get("dashboard_load_id"),
+    );
+  });
 });

--- a/frontend/src/metabase/entities/dashboards.js
+++ b/frontend/src/metabase/entities/dashboards.js
@@ -177,10 +177,10 @@ const Dashboards = createEntity({
         dashboards: [DashboardSchema],
       }),
     )(
-      ({ id }) =>
+      ({ id, ...params }) =>
         dispatch =>
           entityCompatibleQuery(
-            id,
+            { id, ...params },
             dispatch,
             dashboardApi.endpoints.getDashboardQueryMetadata,
             { forceRefetch: false },
@@ -197,10 +197,10 @@ const Dashboards = createEntity({
         dashboards: [DashboardSchema],
       }),
     )(
-      ({ entity, entityId }) =>
+      ({ entity, entityId, dashboard_load_id }) =>
         dispatch =>
           entityCompatibleQuery(
-            { entity, entityId },
+            { entity, entityId, dashboard_load_id },
             dispatch,
             automagicDashboardsApi.endpoints.getXrayDashboardQueryMetadata,
           ),


### PR DESCRIPTION
### Description

FE part of https://github.com/metabase/metabase/pull/45050

we need to pass a UUID to the BE, so it will enable caching and share this cache between calls to `/dahsboard/:dashId` and `/query_metadata`.

Additionally we pass another UUID (I don't see a way to share it atm), to share cache between different http calls on `/query`

### How to verify

- open a dashboard with cards
- check network tab - make sure that parameter `dashboard_load_id` is attached to the http query 

### Demo

<img width="378" alt="image" src="https://github.com/metabase/metabase/assets/125459446/1d1945e7-9707-4cdb-a604-02c9e8241c84">

<img width="1032" alt="Screenshot 2024-07-08 at 14 45 40" src="https://github.com/metabase/metabase/assets/125459446/5f7d8a19-8293-4f48-835b-57c179637e9d">
<img width="936" alt="Screenshot 2024-07-08 at 14 45 36" src="https://github.com/metabase/metabase/assets/125459446/9b7fd517-231a-4228-b3c2-908d52731395">


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
