### PR TITLE
Support backward compatibility when passing `theme=transparent`

### DIFF
--- a/frontend/src/metabase/dashboard/hooks/use-dashboard-url-params.ts
+++ b/frontend/src/metabase/dashboard/hooks/use-dashboard-url-params.ts
@@ -40,6 +40,11 @@ export const useDashboardUrlParams = ({
     theme,
   } = useEmbedTheme();
 
+  const normalizedTheme = normalizeTheme({
+    theme,
+    background,
+  });
+
   const { isFullscreen, onFullscreenChange } = useDashboardFullscreen();
   const { onRefreshPeriodChange, refreshPeriod, setRefreshElapsedHook } =
     useDashboardRefreshPeriod({ onRefresh });
@@ -87,9 +92,27 @@ export const useDashboardUrlParams = ({
     titled,
     font,
     setFont,
-    theme,
+    theme: normalizedTheme,
     setTheme,
     hideParameters: hide_parameters,
     hideDownloadButton: hide_download_button,
   };
 };
+
+/**
+ * When both `background: false` and `theme: "transparent"` options are supplied,
+ * the new behavior takes precedence (metabase#43838)
+ */
+function normalizeTheme({
+  theme,
+  background,
+}: {
+  theme: DisplayTheme;
+  background: boolean;
+}) {
+  if (!background && theme === "transparent") {
+    return "light";
+  }
+
+  return theme;
+}

--- a/frontend/src/metabase/dashboard/hooks/use-dashboard-url-params.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/hooks/use-dashboard-url-params.unit.spec.tsx
@@ -1,0 +1,211 @@
+import type { Location } from "history";
+import { Route } from "react-router";
+
+import { renderWithProviders, screen } from "__support__/ui";
+
+import { useDashboardUrlParams } from "./use-dashboard-url-params";
+
+describe("useDashboardUrlParams", () => {
+  describe("should handle backward compatibility when `theme=transparent` and `background=false` (metabase#43838)", () => {
+    it('should return theme: "light" by default', async () => {
+      interface ComponentProps {
+        location: Location;
+      }
+      const Component = ({ location }: ComponentProps) => {
+        const { theme } = useDashboardUrlParams({
+          location,
+          onRefresh: jest.fn(),
+        });
+        return <>theme: {theme}</>;
+      };
+
+      renderWithProviders(
+        <>
+          <Route path="*" component={Component} />
+        </>,
+        {
+          withRouter: true,
+        },
+      );
+
+      expect(await screen.findByText("theme: light")).toBeInTheDocument();
+    });
+
+    it('should return theme: "light" when provided', async () => {
+      interface ComponentProps {
+        location: Location;
+      }
+      const Component = ({ location }: ComponentProps) => {
+        const { theme } = useDashboardUrlParams({
+          location,
+          onRefresh: jest.fn(),
+        });
+        return <>theme: {theme}</>;
+      };
+
+      renderWithProviders(
+        <>
+          <Route path="*" component={Component} />
+        </>,
+        {
+          withRouter: true,
+          initialRoute: "#theme=light",
+        },
+      );
+
+      expect(await screen.findByText("theme: light")).toBeInTheDocument();
+    });
+
+    it('should return theme: "night" when provided', async () => {
+      interface ComponentProps {
+        location: Location;
+      }
+      const Component = ({ location }: ComponentProps) => {
+        const { theme } = useDashboardUrlParams({
+          location,
+          onRefresh: jest.fn(),
+        });
+        return <>theme: {theme}</>;
+      };
+
+      renderWithProviders(
+        <>
+          <Route path="*" component={Component} />
+        </>,
+        {
+          withRouter: true,
+          initialRoute: "#theme=night",
+        },
+      );
+
+      expect(await screen.findByText("theme: night")).toBeInTheDocument();
+    });
+
+    it('should return theme: "transparent" when provided', async () => {
+      interface ComponentProps {
+        location: Location;
+      }
+      const Component = ({ location }: ComponentProps) => {
+        const { theme } = useDashboardUrlParams({
+          location,
+          onRefresh: jest.fn(),
+        });
+        return <>theme: {theme}</>;
+      };
+
+      renderWithProviders(
+        <>
+          <Route path="*" component={Component} />
+        </>,
+        {
+          withRouter: true,
+          initialRoute: "#theme=transparent",
+        },
+      );
+
+      expect(await screen.findByText("theme: transparent")).toBeInTheDocument();
+    });
+
+    describe('background: "false"', () => {
+      it('should return theme: "light" by default', async () => {
+        interface ComponentProps {
+          location: Location;
+        }
+        const Component = ({ location }: ComponentProps) => {
+          const { theme } = useDashboardUrlParams({
+            location,
+            onRefresh: jest.fn(),
+          });
+          return <>theme: {theme}</>;
+        };
+
+        renderWithProviders(
+          <>
+            <Route path="*" component={Component} />
+          </>,
+          {
+            withRouter: true,
+            initialRoute: "#background=false",
+          },
+        );
+
+        expect(await screen.findByText("theme: light")).toBeInTheDocument();
+      });
+
+      it('should return theme: "light" when provided', async () => {
+        interface ComponentProps {
+          location: Location;
+        }
+        const Component = ({ location }: ComponentProps) => {
+          const { theme } = useDashboardUrlParams({
+            location,
+            onRefresh: jest.fn(),
+          });
+          return <>theme: {theme}</>;
+        };
+
+        renderWithProviders(
+          <>
+            <Route path="*" component={Component} />
+          </>,
+          {
+            withRouter: true,
+            initialRoute: "#background=false&theme=light",
+          },
+        );
+
+        expect(await screen.findByText("theme: light")).toBeInTheDocument();
+      });
+
+      it('should return theme: "night" when provided', async () => {
+        interface ComponentProps {
+          location: Location;
+        }
+        const Component = ({ location }: ComponentProps) => {
+          const { theme } = useDashboardUrlParams({
+            location,
+            onRefresh: jest.fn(),
+          });
+          return <>theme: {theme}</>;
+        };
+
+        renderWithProviders(
+          <>
+            <Route path="*" component={Component} />
+          </>,
+          {
+            withRouter: true,
+            initialRoute: "#background=false&theme=night",
+          },
+        );
+
+        expect(await screen.findByText("theme: night")).toBeInTheDocument();
+      });
+
+      it('should return theme: "light" when `theme=transparent`, since the new behavior should take precedence', async () => {
+        interface ComponentProps {
+          location: Location;
+        }
+        const Component = ({ location }: ComponentProps) => {
+          const { theme } = useDashboardUrlParams({
+            location,
+            onRefresh: jest.fn(),
+          });
+          return <>theme: {theme}</>;
+        };
+
+        renderWithProviders(
+          <>
+            <Route path="*" component={Component} />
+          </>,
+          {
+            withRouter: true,
+            initialRoute: "#background=false&theme=transparent",
+          },
+        );
+
+        expect(await screen.findByText("theme: light")).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/frontend/src/metabase/dashboard/hooks/use-dashboard-url-params.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/hooks/use-dashboard-url-params.unit.spec.tsx
@@ -5,204 +5,95 @@ import { renderWithProviders, screen } from "__support__/ui";
 
 import { useDashboardUrlParams } from "./use-dashboard-url-params";
 
+interface SetupOpts {
+  hash: string;
+}
+function setup({ hash }: SetupOpts) {
+  renderWithProviders(
+    <>
+      <Route path="*" component={TestComponent} />
+    </>,
+    {
+      withRouter: true,
+      initialRoute: hash,
+    },
+  );
+}
+
+interface TestComponentProps {
+  location: Location;
+}
+const TestComponent = ({ location }: TestComponentProps) => {
+  const { theme } = useDashboardUrlParams({
+    location,
+    onRefresh: jest.fn(),
+  });
+  return <>theme: {theme}</>;
+};
+
 describe("useDashboardUrlParams", () => {
   describe("should handle backward compatibility when `theme=transparent` and `background=false` (metabase#43838)", () => {
     it('should return theme: "light" by default', async () => {
-      interface ComponentProps {
-        location: Location;
-      }
-      const Component = ({ location }: ComponentProps) => {
-        const { theme } = useDashboardUrlParams({
-          location,
-          onRefresh: jest.fn(),
-        });
-        return <>theme: {theme}</>;
-      };
-
-      renderWithProviders(
-        <>
-          <Route path="*" component={Component} />
-        </>,
-        {
-          withRouter: true,
-        },
-      );
+      setup({
+        hash: "#",
+      });
 
       expect(await screen.findByText("theme: light")).toBeInTheDocument();
     });
 
     it('should return theme: "light" when provided', async () => {
-      interface ComponentProps {
-        location: Location;
-      }
-      const Component = ({ location }: ComponentProps) => {
-        const { theme } = useDashboardUrlParams({
-          location,
-          onRefresh: jest.fn(),
-        });
-        return <>theme: {theme}</>;
-      };
-
-      renderWithProviders(
-        <>
-          <Route path="*" component={Component} />
-        </>,
-        {
-          withRouter: true,
-          initialRoute: "#theme=light",
-        },
-      );
+      setup({
+        hash: "#theme=light",
+      });
 
       expect(await screen.findByText("theme: light")).toBeInTheDocument();
     });
 
     it('should return theme: "night" when provided', async () => {
-      interface ComponentProps {
-        location: Location;
-      }
-      const Component = ({ location }: ComponentProps) => {
-        const { theme } = useDashboardUrlParams({
-          location,
-          onRefresh: jest.fn(),
-        });
-        return <>theme: {theme}</>;
-      };
-
-      renderWithProviders(
-        <>
-          <Route path="*" component={Component} />
-        </>,
-        {
-          withRouter: true,
-          initialRoute: "#theme=night",
-        },
-      );
+      setup({
+        hash: "#theme=night",
+      });
 
       expect(await screen.findByText("theme: night")).toBeInTheDocument();
     });
 
     it('should return theme: "transparent" when provided', async () => {
-      interface ComponentProps {
-        location: Location;
-      }
-      const Component = ({ location }: ComponentProps) => {
-        const { theme } = useDashboardUrlParams({
-          location,
-          onRefresh: jest.fn(),
-        });
-        return <>theme: {theme}</>;
-      };
-
-      renderWithProviders(
-        <>
-          <Route path="*" component={Component} />
-        </>,
-        {
-          withRouter: true,
-          initialRoute: "#theme=transparent",
-        },
-      );
+      setup({
+        hash: "#theme=transparent",
+      });
 
       expect(await screen.findByText("theme: transparent")).toBeInTheDocument();
     });
 
     describe('background: "false"', () => {
       it('should return theme: "light" by default', async () => {
-        interface ComponentProps {
-          location: Location;
-        }
-        const Component = ({ location }: ComponentProps) => {
-          const { theme } = useDashboardUrlParams({
-            location,
-            onRefresh: jest.fn(),
-          });
-          return <>theme: {theme}</>;
-        };
-
-        renderWithProviders(
-          <>
-            <Route path="*" component={Component} />
-          </>,
-          {
-            withRouter: true,
-            initialRoute: "#background=false",
-          },
-        );
+        setup({
+          hash: "#background=false",
+        });
 
         expect(await screen.findByText("theme: light")).toBeInTheDocument();
       });
 
       it('should return theme: "light" when provided', async () => {
-        interface ComponentProps {
-          location: Location;
-        }
-        const Component = ({ location }: ComponentProps) => {
-          const { theme } = useDashboardUrlParams({
-            location,
-            onRefresh: jest.fn(),
-          });
-          return <>theme: {theme}</>;
-        };
-
-        renderWithProviders(
-          <>
-            <Route path="*" component={Component} />
-          </>,
-          {
-            withRouter: true,
-            initialRoute: "#background=false&theme=light",
-          },
-        );
+        setup({
+          hash: "#background=false&theme=light",
+        });
 
         expect(await screen.findByText("theme: light")).toBeInTheDocument();
       });
 
       it('should return theme: "night" when provided', async () => {
-        interface ComponentProps {
-          location: Location;
-        }
-        const Component = ({ location }: ComponentProps) => {
-          const { theme } = useDashboardUrlParams({
-            location,
-            onRefresh: jest.fn(),
-          });
-          return <>theme: {theme}</>;
-        };
-
-        renderWithProviders(
-          <>
-            <Route path="*" component={Component} />
-          </>,
-          {
-            withRouter: true,
-            initialRoute: "#background=false&theme=night",
-          },
-        );
+        setup({
+          hash: "#background=false&theme=night",
+        });
 
         expect(await screen.findByText("theme: night")).toBeInTheDocument();
       });
 
       it('should return theme: "light" when `theme=transparent`, since the new behavior should take precedence', async () => {
-        interface ComponentProps {
-          location: Location;
-        }
-        const Component = ({ location }: ComponentProps) => {
-          const { theme } = useDashboardUrlParams({
-            location,
-            onRefresh: jest.fn(),
-          });
-          return <>theme: {theme}</>;
-        };
-
-        renderWithProviders(
-          <>
-            <Route path="*" component={Component} />
-          </>,
-          {
-            withRouter: true,
-            initialRoute: "#background=false&theme=transparent",
-          },
-        );
+        setup({
+          hash: "#background=false&theme=transparent",
+        });
 
         expect(await screen.findByText("theme: light")).toBeInTheDocument();
       });

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/StaticEmbedSetupPane.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/StaticEmbedSetupPane.tsx
@@ -14,10 +14,8 @@ import {
   trackStaticEmbedUnpublished,
 } from "metabase/public/lib/analytics";
 import { getEmbedServerCodeExampleOptions } from "metabase/public/lib/code";
-import {
-  getSignedPreviewUrlWithoutHash,
-  optionsToHashParams,
-} from "metabase/public/lib/embed";
+import { getIframeQueryWithoutDefaults } from "metabase/public/lib/code-templates";
+import { getSignedPreviewUrlWithoutHash } from "metabase/public/lib/embed";
 import type {
   EmbeddingDisplayOptions,
   EmbeddingParameters,
@@ -155,7 +153,8 @@ export const StaticEmbedSetupPane = ({
     ],
   );
 
-  const iframeUrl = iframeUrlWithoutHash + optionsToHashParams(displayOptions);
+  const iframeUrl =
+    iframeUrlWithoutHash + getIframeQueryWithoutDefaults(displayOptions);
 
   const handleSave = async () => {
     if (!resource.enable_embedding) {

--- a/frontend/src/metabase/public/lib/code-templates.ts
+++ b/frontend/src/metabase/public/lib/code-templates.ts
@@ -5,16 +5,19 @@ import type {
   EmbeddingParametersValues,
 } from "./types";
 
-function getIframeQuerySource(displayOptions: EmbeddingDisplayOptions) {
-  return JSON.stringify(
-    optionsToHashParams(
-      removeDefaultValueParameters(displayOptions, {
-        theme: "light",
-        hide_download_button: false,
-        background: true,
-      }),
-    ),
+export function getIframeQueryWithoutDefaults(
+  displayOptions: EmbeddingDisplayOptions,
+) {
+  return optionsToHashParams(
+    removeDefaultValueParameters(displayOptions, {
+      theme: "light",
+      hide_download_button: false,
+      background: true,
+    }),
   );
+}
+function getIframeQuerySource(displayOptions: EmbeddingDisplayOptions) {
+  return JSON.stringify(getIframeQueryWithoutDefaults(displayOptions));
 }
 
 function removeDefaultValueParameters(


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/45202

### Description

Support backward compatibility by allowing `theme=transparent`. There's no CSS change since everything is already working fine. This PR ensures we override `theme=transparent` and `background=false` to `theme: "light"` and `background: false` [(spec)](https://www.notion.so/metabase/Re-design-transparent-theme-for-static-embedding-and-public-links-a28e98a6e5c64301a48387c7b333d569?pvs=4#2e1eff4f88df49e3b6ee7e37af559ea1).

### How to verify

Try applying `theme=transparent&background=false` to static embedding dashboards ([questions don't have `background` option](https://www.notion.so/metabase/Re-design-transparent-theme-for-static-embedding-and-public-links-a28e98a6e5c64301a48387c7b333d569?pvs=4#2bb0cb2ade334707a0448de8500cc75a)), the beavhior should be like `theme=light&background=false` otherwise, the behavior should be the same as the passed parameters.

### Demo

#### `theme=transparent`
![image](https://github.com/metabase/metabase/assets/1937582/52f226e7-807b-4f1a-a716-f13a9e233602)

#### `theme=transparent&background=false`
![image](https://github.com/metabase/metabase/assets/1937582/d8bbbace-e8a3-45ce-9018-c6ac7d242f29)

#### `theme=light&background=false` should behave the same as the above condition
![image](https://github.com/metabase/metabase/assets/1937582/9c2b9680-e02d-4087-98f4-fdeb3cf57efb)

#### `theme=night&background=false`
![image](https://github.com/metabase/metabase/assets/1937582/0663e3b2-2178-478e-b705-9384e57b90bf)


#### `theme=night`
![image](https://github.com/metabase/metabase/assets/1937582/4f6147ed-9ef8-4eab-a284-42f583ef5e17)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
