### PR TITLE
Do not show revert button for default parameter

### DIFF
--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
@@ -4,6 +4,7 @@ import {
   adhocQuestionHash,
   runNativeQuery,
   openNativeEditor,
+  createNativeQuestion,
 } from "e2e/support/helpers";
 
 describe("issue 11727", { tags: "@external" }, () => {
@@ -68,5 +69,43 @@ describe("issue 16584", () => {
     cy.findByTestId("query-visualization-root")
       .findByText("NL")
       .should("exist");
+  });
+});
+
+describe("issue 38083", () => {
+  const QUESTION = {
+    name: "SQL query with a date parameter",
+    native: {
+      query: "select * from people where state = {{ state }} limit 1",
+      "template-tags": {
+        state: {
+          id: "6b8b10ef-0104-1047-1e1b-2492d5954555",
+          type: "text" as const,
+          name: "state",
+          "display-name": "State",
+          "widget-type": "string/=",
+          default: "CA",
+          required: true,
+        },
+      },
+    },
+  };
+
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should not show the revert to default icon when the default value is selected (metabase#38083)", () => {
+    createNativeQuestion(QUESTION, {
+      visitQuestion: true,
+    });
+
+    cy.get("legend")
+      .contains(QUESTION.native["template-tags"].state["display-name"])
+      .parent("fieldset")
+      .within(() => {
+        cy.icon("time_history").should("not.exist");
+      });
   });
 });

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -153,7 +153,7 @@ class ParameterValueWidget extends Component {
     if (
       required &&
       defaultValue &&
-      !areParameterValuesIdentical(value, defaultValue)
+      !areParameterValuesIdentical(wrapArray(value), wrapArray(defaultValue))
     ) {
       return (
         <WidgetStatusIcon
@@ -419,4 +419,11 @@ function isFieldWidget(parameter) {
   return parameter.hasVariableTemplateTagTarget
     ? canQuery
     : canQuery || hasFields(parameter);
+}
+
+function wrapArray(value) {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  return [value];
 }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/38083

### Description

Fixes an issue where the default value and values were being compared incorrectly (as direct values and arrays).

This PR coerces all of them to arrays so the comparisons are correct.


### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create a native question `select * from people where state = {{ state }}`,
2. Make it required and add a default value, say `CA`,
3. Save the question and reload the page with `?state=CA` in the URL,
4. Observe that the parameter widget does not have a reset icon,
5. For other values in the URL `state=OR` should still show the icon.


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
