### PR TITLE
Use `filled` button variant for the "Duplicate entity" modal

### DIFF
--- a/frontend/src/metabase/forms/components/FormSubmitButton/FormSubmitButton.tsx
+++ b/frontend/src/metabase/forms/components/FormSubmitButton/FormSubmitButton.tsx
@@ -44,6 +44,7 @@ export const FormSubmitButton = forwardRef(function FormSubmitButton(
       type="submit"
       color={submitColor}
       disabled={isDisabled}
+      variant="filled"
     >
       {submitLabel}
     </Button>


### PR DESCRIPTION
Fixes #44221 

### To reproduce
1. Open ANY saved entity (question, model, metric)
2. Open `...` menu and click "Duplicate"
3. You should see the dark blue "Duplicate" button in the modal

### Demo

**Before**
![image](https://github.com/metabase/metabase/assets/31325167/aa63a592-6f26-41fb-85e9-c645cb069736)

**Now**
![image](https://github.com/metabase/metabase/assets/31325167/0f60dd9f-be7f-4e0d-a491-cb4e8120bc2a)
