### PR TITLE
Use team instead of group for auto request review

### DIFF
--- a/.github/auto_request_review.yml
+++ b/.github/auto_request_review.yml
@@ -12,9 +12,9 @@ reviewers:
 files:
   # migrations related files
   'resources/migrations/**':
-    - migration-owners
+    - team:core-backend-components
   'src/metabase/db/custom_migrations.clj':
-    - migration-owners
+    - team:core-backend-components
 
 options:
   ignore_draft: true

--- a/.github/auto_request_review.yml
+++ b/.github/auto_request_review.yml
@@ -2,13 +2,6 @@
 # See https://github.com/necojackarc/auto-request-review/tree/master?tab=readme-ov-file#reviewers-configuration
 # for the spec
 
-reviewers:
-  groups:
-    migration-owners:
-      - qnkhuat
-      - calherries
-      #- team:core-backend-components # can use team, but it needs a PAT, will figure it out later
-
 files:
   # migrations related files
   'resources/migrations/**':

--- a/.github/workflows/auto-request-review.yml
+++ b/.github/workflows/auto-request-review.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Request review based on files changes and/or groups the author belongs to
         uses: necojackarc/auto-request-review@v0.13.0
         with:
-          token: '${{ secrets.GITHUB_TOKEN }}'
+          token: '${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}'

--- a/.github/workflows/auto-request-review.yml
+++ b/.github/workflows/auto-request-review.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Request review based on files changes and/or groups the author belongs to
         uses: necojackarc/auto-request-review@v0.13.0
         with:
-          token: '${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}'
+          token: '${{ secrets.GITHUB_TOKEN }}'

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -8249,9 +8249,10 @@ databaseChangeLog:
               - column:
                   name: device_id
       rollback:
-        - dropIndex:
+        - dropIndex
             tableName: login_history
             indexName: idx_user_id_device_id
+
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -8249,10 +8249,9 @@ databaseChangeLog:
               - column:
                   name: device_id
       rollback:
-        - dropIndex
+        - dropIndex:
             tableName: login_history
             indexName: idx_user_id_device_id
-
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -8253,6 +8253,7 @@ databaseChangeLog:
             tableName: login_history
             indexName: idx_user_id_device_id
 
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -8253,7 +8253,6 @@ databaseChangeLog:
             tableName: login_history
             indexName: idx_user_id_device_id
 
-
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################


### PR DESCRIPTION
Change so that any changes to migrations file will now request a review for BEC team instead of just me and Cal like before.