### PR TITLE
Don't return an archived dashboard as the most recently viewed dashboard

### DIFF
--- a/src/metabase/models/recent_views.clj
+++ b/src/metabase/models/recent_views.clj
@@ -153,8 +153,11 @@
    {:where    [:and
                [:= :user_id user-id]
                [:= :model (h2x/literal "dashboard")]
-               [:> :timestamp (t/minus (t/zoned-date-time) (t/days 1))]]
-    :order-by [[:id :desc]]}))
+               [:> :timestamp (t/minus (t/zoned-date-time) (t/days 1))]
+               [:not= :d.archived true]]
+    :order-by [[:recent_views.id :desc]]
+    :left-join [[:report_dashboard :d]
+                [:= :recent_views.model_id :d.id]]}))
 
 (def Item
   "The shape of a recent view item, returned from `GET /recent_views`."

--- a/test/metabase/api/activity_test.clj
+++ b/test/metabase/api/activity_test.clj
@@ -45,8 +45,8 @@
                                      {:topic :event/card-query :event {:card-id (:id card-1)}}
                                      {:topic :event/table-read :event {:object table-1}}]]
         (events/publish-event! topic (assoc event :user-id (mt/user->id :crowberto))))
-      (testing "most_recently_viewed_dashboard endpoint shows the current user's most recently viewed dashboard."
-        (is (= (assoc dash-3 :collection nil :view_count 0) #_dash-2 ;; TODO: this should be dash-2, because dash-3 is archived
+      (testing "most_recently_viewed_dashboard endpoint shows the current user's most recently viewed non-archived dashboard."
+        (is (= (assoc dash-2 :collection nil :view_count 0)
                (mt/user-http-request :crowberto :get 200 "activity/most_recently_viewed_dashboard")))))
     (mt/with-test-user :rasta
       (testing "If nothing has been viewed, return a 204"

--- a/test/metabase/models/recent_views_test.clj
+++ b/test/metabase/models/recent_views_test.clj
@@ -293,7 +293,6 @@
     (t2.with-temp/with-temp [:model/Dashboard {dash-id :id} {}
                              :model/Dashboard {dash-id-2 :id} {}
                              :model/Dashboard {dash-id-3 :id} {}]
-
       (is (nil? (recent-views/most-recently-viewed-dashboard-id (mt/user->id :rasta))))
 
       (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Dashboard dash-id :view)
@@ -306,7 +305,11 @@
 
       (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Dashboard dash-id :view)
       (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Dashboard dash-id-3 :view)
-      (is (= dash-id-3 (recent-views/most-recently-viewed-dashboard-id (mt/user->id :rasta)))))))
+      (is (= dash-id-3 (recent-views/most-recently-viewed-dashboard-id (mt/user->id :rasta))))
+
+      (testing "archived dashboards are not returned (#45223)"
+        (t2/update! :model/Dashboard dash-id-3 {:archived true})
+        (is (= dash-id (recent-views/most-recently-viewed-dashboard-id (mt/user->id :rasta))))))))
 
 (deftest id-pruning-test
   (mt/with-temp [:model/Database a-db     {}


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/45223

Simply updates the `most_recently_viewed_dashboard` query to exclude archived dashboards. 