### PR TITLE
/api/testing/set-time: ability to set JVM time during development

### DIFF
--- a/test/metabase/api/testing_test.clj
+++ b/test/metabase/api/testing_test.clj
@@ -4,6 +4,7 @@
    [clojure.java.jdbc :as jdbc]
    [clojure.test :refer :all]
    [java-time.api :as t]
+   [java-time.clock]
    [metabase.api.testing :as testing]
    [metabase.db :as mdb]
    [metabase.test :as mt]
@@ -58,19 +59,22 @@
       (is (= [{:a 1}] (jdbc/query {:datasource (mdb/app-db)} ["select a from test_view"]))))))
 
 (deftest set-time-test
-  (let [t (t/zoned-date-time 2024 7 8 15 00 00)]
-    (testing "You can set exact date and reset it back"
-      (is (= {:result "set" :time "2024-07-08T15:00:00Z"}
-             (mt/user-http-request :rasta :post 200 "testing/set-time"
-                                   {:time (u.date/format t)})))
-      (is (=? {:result "reset" :time string?}
-              (mt/user-http-request :rasta :post 200 "testing/set-time"))))
-    (testing "You can move date with `add-ms`"
-      (is (= {:result "set" :time "2024-07-08T15:00:00Z"}
-             (mt/user-http-request :rasta :post 200 "testing/set-time"
-                                   {:time (u.date/format t)})))
-      (is (= {:result "set" :time "2024-07-08T15:00:10Z"}
-             (mt/user-http-request :rasta :post 200 "testing/set-time"
-                                   {:add-ms 10000})))
-      (is (=? {:result "reset" :time string?}
-              (mt/user-http-request :rasta :post 200 "testing/set-time"))))))
+  (try
+    (let [t (t/zoned-date-time 2024 7 8 15 00 00)]
+      (testing "You can set exact date and reset it back"
+        (is (= {:result "set" :time "2024-07-08T15:00:00Z"}
+               (mt/user-http-request :rasta :post 200 "testing/set-time"
+                                     {:time (u.date/format t)})))
+        (is (=? {:result "reset" :time string?}
+                (mt/user-http-request :rasta :post 200 "testing/set-time"))))
+      (testing "You can move date with `add-ms`"
+        (is (= {:result "set" :time "2024-07-08T15:00:00Z"}
+               (mt/user-http-request :rasta :post 200 "testing/set-time"
+                                     {:time (u.date/format t)})))
+        (is (= {:result "set" :time "2024-07-08T15:00:10Z"}
+               (mt/user-http-request :rasta :post 200 "testing/set-time"
+                                     {:add-ms 10000})))
+        (is (=? {:result "reset" :time string?}
+                (mt/user-http-request :rasta :post 200 "testing/set-time")))))
+    (finally
+      (alter-var-root #'java-time.clock/*clock* (constantly nil)))))

--- a/test/metabase/api/testing_test.clj
+++ b/test/metabase/api/testing_test.clj
@@ -3,10 +3,12 @@
    [clojure.java.io :as io]
    [clojure.java.jdbc :as jdbc]
    [clojure.test :refer :all]
+   [java-time.api :as t]
    [metabase.api.testing :as testing]
    [metabase.db :as mdb]
    [metabase.test :as mt]
-   [metabase.util :as u]))
+   [metabase.util :as u]
+   [metabase.util.date-2 :as u.date]))
 
 (set! *warn-on-reflection* true)
 
@@ -54,3 +56,21 @@
     (mt/with-temp-empty-app-db [_conn :h2]
       (#'testing/restore-snapshot! snapshot-name)
       (is (= [{:a 1}] (jdbc/query {:datasource (mdb/app-db)} ["select a from test_view"]))))))
+
+(deftest set-time-test
+  (let [t (t/zoned-date-time 2024 7 8 15 00 00)]
+    (testing "You can set exact date and reset it back"
+      (is (= {:result "set" :time "2024-07-08T15:00:00Z"}
+             (mt/user-http-request :rasta :post 200 "testing/set-time"
+                                   {:time (u.date/format t)})))
+      (is (=? {:result "reset" :time string?}
+              (mt/user-http-request :rasta :post 200 "testing/set-time"))))
+    (testing "You can move date with `add-ms`"
+      (is (= {:result "set" :time "2024-07-08T15:00:00Z"}
+             (mt/user-http-request :rasta :post 200 "testing/set-time"
+                                   {:time (u.date/format t)})))
+      (is (= {:result "set" :time "2024-07-08T15:00:10Z"}
+             (mt/user-http-request :rasta :post 200 "testing/set-time"
+                                   {:add-ms 10000})))
+      (is (=? {:result "reset" :time string?}
+              (mt/user-http-request :rasta :post 200 "testing/set-time"))))))


### PR DESCRIPTION
This is needed so we can write e2e tests for caching. [Context](https://metaboat.slack.com/archives/C06KX7QECN4/p1720436017539679)

/cc @rafpaf 