### PR TITLE
ci(admin/performance): Test several caching strategies and methods

### DIFF
--- a/e2e/support/helpers/api/createQuestion.ts
+++ b/e2e/support/helpers/api/createQuestion.ts
@@ -1,5 +1,10 @@
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
-import type { Card, DatasetQuery, StructuredQuery } from "metabase-types/api";
+import type {
+  Card,
+  DatasetQuery,
+  NativeQuery,
+  StructuredQuery,
+} from "metabase-types/api";
 
 export type QuestionDetails = {
   dataset_query: DatasetQuery;
@@ -43,6 +48,14 @@ export type StructuredQuestionDetails = Omit<
    */
   database?: DatasetQuery["database"];
   query: StructuredQuery;
+};
+
+export type NativeQuestionDetails = Omit<QuestionDetails, "dataset_query"> & {
+  /**
+   * Defaults to SAMPLE_DB_ID.
+   */
+  database?: DatasetQuery["database"];
+  native: NativeQuery;
 };
 
 export type Options = {

--- a/e2e/support/test_tables.js
+++ b/e2e/support/test_tables.js
@@ -250,3 +250,17 @@ export const many_schemas = async dbClient => {
 
   return schemas;
 };
+
+export const cached_table = async dbClient => {
+  const tableName = "cached_table";
+
+  await dbClient.schema.dropTableIfExists(tableName);
+  await dbClient.schema.createTable(tableName, table => {
+    table.increments("id").primary();
+    table.string("my_text").notNullable();
+  });
+
+  await dbClient(tableName).insert([{ my_text: "Old Value" }]);
+
+  return null;
+};

--- a/e2e/test/scenarios/admin/performance/clock.cy.spec.ts
+++ b/e2e/test/scenarios/admin/performance/clock.cy.spec.ts
@@ -1,0 +1,70 @@
+import dayjs from "dayjs";
+import timezone from "dayjs/plugin/timezone";
+dayjs.extend(timezone);
+
+import {
+  freezeServerTime,
+  resetServerTime,
+} from "./helpers/e2e-performance-helpers";
+
+/** Some caching tests need to be able to advance the server clock manually.
+ * There's an endpoint that supports this: /api/testing/set-time.
+ * These tests guarantee that this endpoint works as expected. */
+describe("server clock", () => {
+  afterEach(() => {
+    resetServerTime();
+  });
+
+  it("can advance the server clock by one day", () => {
+    cy.signInAsAdmin();
+
+    cy.request("GET", "/api/setting/report-timezone-long").then(response => {
+      cy.wrap(response.body).as("serverTimeZone");
+    });
+
+    cy.then(function () {
+      const oneDayInMilliseconds = 86400000;
+
+      const utcFormatter = new Intl.DateTimeFormat("en-US", {
+        timeZone: "UTC",
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      });
+      const nowInUTC = utcFormatter.format(Date.now());
+
+      const tomorrowInUTC: string = dayjs(nowInUTC)
+        .add(1, "day")
+        .format("YYYY-MM-DD");
+
+      freezeServerTime({
+        addMilliseconds: oneDayInMilliseconds,
+        wrapServerTimeAs: "serverTimeInUTC",
+      });
+
+      cy.then(function () {
+        const serverDate = this.serverTimeInUTC.split("T")[0];
+        expect(serverDate).to.eq(tomorrowInUTC);
+      });
+    });
+  });
+
+  it("server clock remains stopped once manually set", () => {
+    const oneDayInMilliseconds = 86400000;
+    freezeServerTime({
+      addMilliseconds: oneDayInMilliseconds,
+      wrapServerTimeAs: "previousServerTime",
+    });
+    cy.wait(500);
+    freezeServerTime({ addMilliseconds: 0, wrapServerTimeAs: "newServerTime" });
+    cy.then(function () {
+      expect(
+        this.newServerTime,
+        "Even though 500ms of real time have elapsed, the server's clock is the same as before",
+      ).to.eq(this.previousServerTime);
+    });
+  });
+});

--- a/e2e/test/scenarios/admin/performance/dashboardsAndQuestions.cy.spec.ts
+++ b/e2e/test/scenarios/admin/performance/dashboardsAndQuestions.cy.spec.ts
@@ -19,7 +19,7 @@ import {
 import {
   advanceServerClockBy,
   getExpectedCacheDuration,
-  interceptRoutes,
+  interceptPerformanceRoutes,
   log,
   resetServerTime,
   setupDashboardTest,
@@ -124,7 +124,7 @@ describe(
     describeEE("ee", () => {
       beforeEach(() => {
         resetServerTime();
-        interceptRoutes();
+        interceptPerformanceRoutes();
         resetTestTable({ type: "postgres", table: TEST_TABLE });
         restore("postgres-writable");
         cy.signInAsAdmin();
@@ -263,7 +263,7 @@ describe(
     describe("oss", { tags: "@OSS" }, () => {
       beforeEach(() => {
         resetServerTime();
-        interceptRoutes();
+        interceptPerformanceRoutes();
         restore("postgres-12");
         cy.signInAsAdmin();
       });

--- a/e2e/test/scenarios/admin/performance/dashboardsAndQuestions.cy.spec.ts
+++ b/e2e/test/scenarios/admin/performance/dashboardsAndQuestions.cy.spec.ts
@@ -270,6 +270,7 @@ describe(
         resetTestTable({ type: "postgres", table: TEST_TABLE });
         restore("postgres-writable");
         cy.signInAsAdmin();
+        cy.visit("admin/performance");
       });
 
       (

--- a/e2e/test/scenarios/admin/performance/dashboardsAndQuestions.cy.spec.ts
+++ b/e2e/test/scenarios/admin/performance/dashboardsAndQuestions.cy.spec.ts
@@ -24,6 +24,7 @@ import {
   setupQuestionTest,
 } from "./helpers/e2e-performance-helpers";
 import {
+  cacheStrategyForm,
   disableCaching,
   selectCacheStrategy,
 } from "./helpers/e2e-strategy-form-helpers";
@@ -271,6 +272,7 @@ describe(
         restore("postgres-writable");
         cy.signInAsAdmin();
         cy.visit("/admin/performance");
+        cacheStrategyForm();
       });
 
       (

--- a/e2e/test/scenarios/admin/performance/dashboardsAndQuestions.cy.spec.ts
+++ b/e2e/test/scenarios/admin/performance/dashboardsAndQuestions.cy.spec.ts
@@ -37,6 +37,7 @@ const testCacheStrategy = ({
   inheritsStrategyFrom,
   description,
   it = itFunction,
+  oss = false,
 }: CacheTestParameters) => {
   it(description, () => {
     const { visitItem } =
@@ -50,6 +51,7 @@ const testCacheStrategy = ({
       selectCacheStrategy({
         item: itemToConfigure,
         strategy,
+        oss,
       });
     });
 
@@ -278,6 +280,7 @@ describe(
             strategy: sampleAdaptiveStrategy,
             item: sampleQuestion,
             inheritsStrategyFrom: instanceDefault,
+            oss: true,
           },
           {
             description:
@@ -285,6 +288,7 @@ describe(
             strategy: sampleAdaptiveStrategy,
             item: sampleDashboard,
             inheritsStrategyFrom: instanceDefault,
+            oss: true,
           },
         ] as CacheTestParameters[]
       ).forEach(testCacheStrategy);

--- a/e2e/test/scenarios/admin/performance/dashboardsAndQuestions.cy.spec.ts
+++ b/e2e/test/scenarios/admin/performance/dashboardsAndQuestions.cy.spec.ts
@@ -1,0 +1,292 @@
+import { describeEE, restore, setTokenFeatures } from "e2e/support/helpers";
+
+import {
+  instanceDefault,
+  questionRuntime,
+  sampleAdaptiveStrategy,
+  sampleDashboard,
+  sampleDatabase,
+  sampleDurationStrategy,
+  sampleQuestion,
+} from "./helpers/constants";
+import {
+  advanceServerClockBy,
+  getExpectedCacheDuration,
+  interceptRoutes,
+  log,
+  resetServerTime,
+  setupDashboardTest,
+  setupQuestionTest,
+  wrapResult,
+} from "./helpers/e2e-performance-helpers";
+import {
+  disableCaching,
+  selectCacheStrategy,
+} from "./helpers/e2e-strategy-form-helpers";
+import type { CacheTestParameters } from "./helpers/types";
+
+const itFunction = it;
+
+const testCacheStrategy = ({
+  strategy,
+  item,
+  inheritsStrategyFrom,
+  description,
+  it = itFunction,
+}: CacheTestParameters) => {
+  it(description, () => {
+    const { reload, visitItem } =
+      item.model === "question"
+        ? setupQuestionTest(sampleQuestion)
+        : setupDashboardTest(sampleDashboard, sampleQuestion);
+
+    const itemToConfigure = inheritsStrategyFrom ?? item;
+
+    cy.then(function () {
+      selectCacheStrategy({
+        item: itemToConfigure,
+        strategy,
+      });
+
+      visitItem();
+    });
+
+    const expectedCacheDuration = getExpectedCacheDuration(strategy);
+
+    advanceServerClockBy(expectedCacheDuration - 2000)
+      .then(() => {
+        reload();
+        wrapResult().as("firstResultBeforeCacheShouldExpire");
+      })
+      .then(() => advanceServerClockBy(1000))
+      .then(() => {
+        reload();
+        wrapResult().as("secondResultBeforeCacheShouldExpire");
+      })
+      .then(() => advanceServerClockBy(5000))
+      .then(() => {
+        reload();
+        wrapResult().as("resultAfterCacheShouldExpire");
+      });
+
+    cy.then(function () {
+      expect(this.firstResultBeforeCacheShouldExpire).to.eq(
+        this.secondResultBeforeCacheShouldExpire,
+      );
+      expect(this.resultAfterCacheShouldExpire).to.not.eq(
+        this.secondResultBeforeCacheShouldExpire,
+      );
+    });
+  });
+};
+
+const testDoNotCachePolicy = ({
+  description,
+  item,
+  inheritsStrategyFrom,
+  it = itFunction,
+}: CacheTestParameters) => {
+  it(description, () => {
+    const { reload, visitItem } =
+      item.model === "question"
+        ? setupQuestionTest(sampleQuestion)
+        : setupDashboardTest(sampleDashboard, sampleQuestion);
+    visitItem();
+
+    // Don't try to disable caching on the root since it's disabled by default
+    const shouldDisableCaching = inheritsStrategyFrom?.model !== "root";
+
+    if (shouldDisableCaching) {
+      cy.then(function () {
+        disableCaching({ item: inheritsStrategyFrom ?? item });
+        visitItem();
+        reload();
+      });
+    }
+
+    cy.then(function () {
+      log("Expect the last query to be slow");
+      expect(this.queryRuntime).to.be.approximately(questionRuntime, 250);
+    });
+  });
+};
+
+/**
+ * These tests check that dashboards and questions can use different cache invalidation strategies.
+ *
+ * Each test applies a certain cache invalidation strategy to a certain item - a question or
+ * dashboard. The strategy is either applied directly, or the item is made to inherit the
+ * strategy, either from the underlying database or from the global default policy.
+ *
+ * Since all the tests are similar, we can think of this as the same test
+ * run repeatedly with different parameters. */
+describe(
+  "Cache invalidation for dashboards and questions",
+  { tags: "@external" },
+  () => {
+    describeEE("ee", () => {
+      beforeEach(() => {
+        resetServerTime();
+        interceptRoutes();
+        restore("postgres-12");
+        cy.signInAsAdmin();
+        setTokenFeatures("all");
+      });
+
+      describe("adaptive and duration strategies", () => {
+        /** Each item in this array contains parameters for a test.
+         *
+         * You can add "it: it.only" or "it: it.skip" to any of the objects below
+         * to control which tests run
+         */
+        (
+          [
+            {
+              description: "questions can use adaptive strategy",
+              strategy: sampleAdaptiveStrategy,
+              item: sampleQuestion,
+            },
+            {
+              description:
+                "questions can inherit adaptive strategy from database",
+              strategy: sampleAdaptiveStrategy,
+              item: sampleQuestion,
+              inheritsStrategyFrom: sampleDatabase,
+            },
+            {
+              description:
+                "questions can inherit adaptive strategy from instance-wide default policy",
+              strategy: sampleAdaptiveStrategy,
+              item: sampleQuestion,
+              inheritsStrategyFrom: instanceDefault,
+            },
+            {
+              description: "questions can use duration strategy",
+              strategy: sampleDurationStrategy,
+              item: sampleQuestion,
+            },
+            {
+              description:
+                "questions can inherit duration strategy from database",
+              strategy: sampleDurationStrategy,
+              item: sampleQuestion,
+              inheritsStrategyFrom: sampleDatabase,
+            },
+            {
+              description:
+                "questions can inherit duration strategy from instance-wide default policy",
+              strategy: sampleDurationStrategy,
+              item: sampleQuestion,
+              inheritsStrategyFrom: instanceDefault,
+            },
+            {
+              description: "dashboards can use adaptive strategy",
+              strategy: sampleAdaptiveStrategy,
+              item: sampleDashboard,
+            },
+            {
+              description:
+                "dashboards can inherit adaptive strategy from database",
+              strategy: sampleAdaptiveStrategy,
+              item: sampleDashboard,
+              inheritsStrategyFrom: sampleDatabase,
+            },
+            {
+              description:
+                "dashboards can inherit adaptive strategy from instance-wide default policy",
+              strategy: sampleAdaptiveStrategy,
+              item: sampleDashboard,
+              inheritsStrategyFrom: instanceDefault,
+            },
+            {
+              description: "dashboards can use duration strategy",
+              strategy: sampleDurationStrategy,
+              item: sampleDashboard,
+            },
+            {
+              description:
+                "dashboards can inherit duration strategy from database",
+              strategy: sampleDurationStrategy,
+              item: sampleDashboard,
+              inheritsStrategyFrom: sampleDatabase,
+            },
+            {
+              description:
+                "dashboards can inherit duration strategy from instance-wide default policy",
+              strategy: sampleDurationStrategy,
+              item: sampleDashboard,
+              inheritsStrategyFrom: instanceDefault,
+            },
+          ] as CacheTestParameters[]
+        ).forEach(testCacheStrategy);
+      });
+
+      describe("no-caching policy", () => {
+        (
+          [
+            {
+              description: "questions can use no-caching policy",
+              item: sampleQuestion,
+            },
+            {
+              description:
+                "questions can inherit no-caching policy from database",
+              item: sampleQuestion,
+              inheritsStrategyFrom: sampleDatabase,
+            },
+            {
+              description:
+                "questions can inherit no-caching policy from instance-wide default policy",
+              item: sampleQuestion,
+              inheritsStrategyFrom: instanceDefault,
+            },
+            {
+              description: "dashboards can use no-caching policy",
+              item: sampleDashboard,
+            },
+            {
+              description:
+                "dashboards can inherit no-caching policy from database",
+              item: sampleDashboard,
+              inheritsStrategyFrom: sampleDatabase,
+            },
+            {
+              description:
+                "dashboards can inherit no-caching policy from instance-wide default policy",
+              item: sampleDashboard,
+              inheritsStrategyFrom: instanceDefault,
+            },
+          ] as CacheTestParameters[]
+        ).forEach(testDoNotCachePolicy);
+      });
+    });
+
+    describe("oss", { tags: "@OSS" }, () => {
+      beforeEach(() => {
+        resetServerTime();
+        interceptRoutes();
+        restore("postgres-12");
+        cy.signInAsAdmin();
+      });
+
+      (
+        [
+          {
+            description:
+              "questions can inherit adaptive strategy from instance-wide default policy",
+            strategy: sampleAdaptiveStrategy,
+            item: sampleQuestion,
+            inheritsStrategyFrom: instanceDefault,
+          },
+          {
+            description:
+              "dashboards can inherit adaptive strategy from instance-wide default policy",
+            strategy: sampleAdaptiveStrategy,
+            item: sampleDashboard,
+            inheritsStrategyFrom: instanceDefault,
+          },
+        ] as CacheTestParameters[]
+      ).forEach(testCacheStrategy);
+    });
+  },
+);

--- a/e2e/test/scenarios/admin/performance/dashboardsAndQuestions.cy.spec.ts
+++ b/e2e/test/scenarios/admin/performance/dashboardsAndQuestions.cy.spec.ts
@@ -270,7 +270,7 @@ describe(
         resetTestTable({ type: "postgres", table: TEST_TABLE });
         restore("postgres-writable");
         cy.signInAsAdmin();
-        cy.visit("admin/performance");
+        cy.visit("/admin/performance");
       });
 
       (

--- a/e2e/test/scenarios/admin/performance/dashboardsAndQuestions.cy.spec.ts
+++ b/e2e/test/scenarios/admin/performance/dashboardsAndQuestions.cy.spec.ts
@@ -130,7 +130,6 @@ describe(
         resetTestTable({ type: "postgres", table: TEST_TABLE });
         restore("postgres-writable");
         cy.signInAsAdmin();
-        // resyncDatabase({ dbId: WRITABLE_DB_ID, tableName: TEST_TABLE });
         setTokenFeatures("all");
       });
 
@@ -266,7 +265,8 @@ describe(
       beforeEach(() => {
         resetServerTime();
         interceptPerformanceRoutes();
-        restore("postgres-12");
+        resetTestTable({ type: "postgres", table: TEST_TABLE });
+        restore("postgres-writable");
         cy.signInAsAdmin();
       });
 

--- a/e2e/test/scenarios/admin/performance/helpers/constants.ts
+++ b/e2e/test/scenarios/admin/performance/helpers/constants.ts
@@ -1,0 +1,57 @@
+import type { NativeQuestionDetails } from "e2e/support/helpers/e2e-question-helpers";
+
+import {
+  type AdaptiveStrategy,
+  CacheDurationUnit,
+  type DoNotCacheStrategy,
+  type DurationStrategy,
+  type ScheduleStrategy,
+} from "metabase-types/api";
+
+import type { StrategyBearer } from "./types";
+
+export const sampleAdaptiveStrategy: AdaptiveStrategy = {
+  type: "ttl",
+  multiplier: 5,
+  min_duration_ms: 0,
+};
+export const sampleDurationStrategy: DurationStrategy = {
+  type: "duration",
+  duration: 48,
+  unit: CacheDurationUnit.Hours,
+};
+export const sampleScheduleStrategy: ScheduleStrategy = {
+  type: "schedule",
+  schedule: "0 0 * * * ?", // Invalidate hourly at the start of the hour
+};
+export const sampleDoNotCacheStrategy: DoNotCacheStrategy = { type: "nocache" };
+
+/** In milliseconds */
+export const questionRuntime = 1000;
+
+export const sampleQuestion: StrategyBearer & {
+  name: string;
+} & NativeQuestionDetails = {
+  model: "question",
+  name: "Slow question",
+  database: 2, // This is the "QA Postgres12" database
+  native: {
+    // Selecting an MD5 string makes it easy to see whether the result is cached
+    query: `select (MD5(random()::text)), pg_sleep(${questionRuntime / 1000})`,
+  },
+};
+
+export const sampleDashboard: StrategyBearer & { name: string } = {
+  model: "dashboard",
+  name: "Dashboard with a slow question",
+};
+
+export const sampleDatabase: StrategyBearer = {
+  model: "database",
+  name: "QA Postgres12",
+};
+
+export const instanceDefault: StrategyBearer = {
+  model: "root",
+  name: "Default policy",
+};

--- a/e2e/test/scenarios/admin/performance/helpers/constants.ts
+++ b/e2e/test/scenarios/admin/performance/helpers/constants.ts
@@ -38,7 +38,6 @@ export const sampleQuestion: StrategyBearer & {
   name: "Slow question",
   database: WRITABLE_DB_ID,
   native: {
-    // Selecting an MD5 string makes it easy to see whether the result is cached
     query: `SELECT * FROM ${TEST_TABLE}, pg_sleep(${questionRuntime / 1000})`,
   },
 };

--- a/e2e/test/scenarios/admin/performance/helpers/constants.ts
+++ b/e2e/test/scenarios/admin/performance/helpers/constants.ts
@@ -1,5 +1,5 @@
-import type { NativeQuestionDetails } from "e2e/support/helpers/e2e-question-helpers";
-
+import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
+import type { NativeQuestionDetails } from "e2e/support/helpers";
 import {
   type AdaptiveStrategy,
   CacheDurationUnit,
@@ -9,6 +9,8 @@ import {
 } from "metabase-types/api";
 
 import type { StrategyBearer } from "./types";
+
+export const TEST_TABLE = "cached_table";
 
 export const sampleAdaptiveStrategy: AdaptiveStrategy = {
   type: "ttl",
@@ -34,10 +36,10 @@ export const sampleQuestion: StrategyBearer & {
 } & NativeQuestionDetails = {
   model: "question",
   name: "Slow question",
-  database: 2, // This is the "QA Postgres12" database
+  database: WRITABLE_DB_ID,
   native: {
     // Selecting an MD5 string makes it easy to see whether the result is cached
-    query: `select (MD5(random()::text)), pg_sleep(${questionRuntime / 1000})`,
+    query: `SELECT * FROM ${TEST_TABLE}, pg_sleep(${questionRuntime / 1000})`,
   },
 };
 
@@ -48,7 +50,7 @@ export const sampleDashboard: StrategyBearer & { name: string } = {
 
 export const sampleDatabase: StrategyBearer = {
   model: "database",
-  name: "QA Postgres12",
+  name: "Writable Postgres12",
 };
 
 export const instanceDefault: StrategyBearer = {

--- a/e2e/test/scenarios/admin/performance/helpers/e2e-performance-helpers.ts
+++ b/e2e/test/scenarios/admin/performance/helpers/e2e-performance-helpers.ts
@@ -100,7 +100,7 @@ export const reloadItem = ({
 export const reloadQuestion = () =>
   reloadItem({ model: "question", endpointAlias: "@cardQuery" });
 export const reloadDashboard = () =>
-  reloadItem({ model: "dashboard", endpointAlias: "@dashcardQuery65" });
+  reloadItem({ model: "dashboard", endpointAlias: "@dashcardQuery" });
 
 export const resultIsCached = (previousResult: string, nextResult: string) =>
   previousResult === nextResult;

--- a/e2e/test/scenarios/admin/performance/helpers/e2e-performance-helpers.ts
+++ b/e2e/test/scenarios/admin/performance/helpers/e2e-performance-helpers.ts
@@ -1,9 +1,15 @@
-import dayjs from "dayjs";
-import duration from "dayjs/plugin/duration";
-import relativeTime from "dayjs/plugin/relativeTime";
+import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
+import type { NativeQuestionDetails } from "e2e/support/helpers";
+import {
+  createNativeQuestion,
+  modal,
+  visitDashboard,
+  visitQuestion,
+} from "e2e/support/helpers";
+import type { CacheStrategy, CacheableModel } from "metabase-types/api";
 
-dayjs.extend(duration);
-dayjs.extend(relativeTime);
+import { questionRuntime } from "./constants";
+import type { DashboardDetails } from "./types";
 
 /** Intercept routes for caching tests */
 export const interceptPerformanceRoutes = () => {
@@ -39,4 +45,192 @@ export const visitDashboardAndQuestionCachingTab = () => {
     .contains("Database caching")
     .should("be.visible");
   cy.findByRole("tab", { name: "Dashboard and question caching" }).click();
+};
+
+export const setupQuestionTest = (
+  nativeQuestionDetails: NativeQuestionDetails,
+) => {
+  log(`Create a question that takes ${questionRuntime} milliseconds to run`);
+  createNativeQuestion(nativeQuestionDetails, {
+    visitQuestion: true,
+    wrapId: true,
+  });
+  const reload = reloadQuestion;
+  const visitItem = () =>
+    cy.then(function () {
+      log("Visiting the question");
+      visitQuestion("@questionId");
+    });
+  return { reload, visitItem };
+};
+
+export const setupDashboardTest = (
+  dashboardDetails: DashboardDetails,
+  questionDetails: NativeQuestionDetails,
+) => {
+  createNativeQuestionInDashboard({
+    questionDetails,
+    dashboardDetails,
+    visitDashboard: true,
+  });
+  const reload = reloadDashboard;
+  const waitForQuery = () => cy.wait("@dashcardQuery");
+  const visitItem = () =>
+    cy.then(function () {
+      visitDashboard(this.dashboardId);
+    });
+  return { reload, visitItem, waitForQuery };
+};
+
+export const reloadItem = ({
+  /** 'Model' in the sense of 'type of thing' */
+  model,
+  endpointAlias,
+}: {
+  model: CacheableModel;
+  endpointAlias: string;
+}) => {
+  log(`Reload ${model}`);
+  cy.reload();
+  return cy.wait(endpointAlias).then(interception => {
+    cy.wrap(interception.response?.body.running_time).as("queryRuntime");
+  });
+};
+
+export const reloadQuestion = () =>
+  reloadItem({ model: "question", endpointAlias: "@cardQuery" });
+export const reloadDashboard = () =>
+  reloadItem({ model: "dashboard", endpointAlias: "@dashcardQuery65" });
+
+export const resultIsCached = (previousResult: string, nextResult: string) =>
+  previousResult === nextResult;
+export const resultIsFresh = (previousResult: string, nextResult: string) =>
+  previousResult !== nextResult;
+
+/** The caching tests load a question (sometimes inside a dashboard) which has
+ * just one result: an MD5 string. This function finds that string and wraps
+ * it. */
+export const wrapResult = () =>
+  cy.url().then(url => {
+    const timeout = 10000 + questionRuntime * 3;
+    const cell = url.includes("dashboard")
+      ? cy.findAllByTestId("cell-data", { timeout }).first()
+      : cy
+          .get("#main-data-grid", { timeout })
+          .findAllByTestId("cell-data")
+          .first();
+    cell.invoke("text").then(result => {
+      expect(
+        result.length,
+        "The result, ${result}, has the correct length",
+      ).to.eq(32);
+      return cy.wrap(result);
+    });
+  });
+
+export const saveQuestion = ({ withName }: { withName: string }) => {
+  log("Save the question");
+  cy.intercept("POST", "/api/card").as("saveQuestion");
+  cy.findByTestId("qb-header").button(/^Save/).click();
+  cy.findByLabelText("Name").type(withName);
+  modal().button("Save").click();
+  cy.findByText("Not now").click();
+  cy.wait("@saveQuestion");
+};
+
+export const getDetailsForQuestionWithFixedRuntime = ({
+  runtime,
+}: {
+  /** Runtime in milliseconds */
+  runtime: number;
+}) => ({
+  name: "Question with fixed runtime",
+  database: WRITABLE_DB_ID,
+  native: {
+    query: `select (MD5(random()::text)), pg_sleep(${runtime / 1000})`,
+  },
+});
+
+export const createNativeQuestionInDashboard = ({
+  questionDetails,
+  dashboardDetails,
+  visitDashboard: shouldVisitDashboard = true,
+}: {
+  questionDetails: NativeQuestionDetails;
+  dashboardDetails: DashboardDetails;
+  visitDashboard: boolean;
+}) =>
+  (cy as any)
+    .createNativeQuestionAndDashboard({
+      questionDetails,
+      dashboardDetails,
+    })
+    .then(({ body }: { body: { dashboard_id: number } }) => {
+      const { dashboard_id } = body;
+      cy.wrap(dashboard_id).as("dashboardId");
+      if (shouldVisitDashboard) {
+        visitDashboard(dashboard_id);
+      }
+    });
+
+/** Sets the server clock, which then stops advancing automatically */
+export const freezeServerTime = ({
+  addMilliseconds,
+  time,
+  wrapServerTimeAs,
+}: {
+  addMilliseconds?: number;
+  time?: string;
+  wrapServerTimeAs?: string;
+}) =>
+  cy
+    .request("POST", "/api/testing/set-time", {
+      "add-ms": addMilliseconds,
+      time,
+    })
+    .then(response => {
+      if (wrapServerTimeAs) {
+        cy.wrap(response.body.time).as(wrapServerTimeAs);
+      }
+    });
+
+export const resetServerTime = () => freezeServerTime({});
+
+/** Get the number of milliseconds until the moment when the cache should
+ * expire */
+export const getExpectedCacheDuration = (strategy: CacheStrategy) => {
+  if (strategy.type === "ttl") {
+    return strategy.multiplier * questionRuntime;
+  }
+
+  if (strategy.type === "duration") {
+    return strategy.duration * 60 * 60 * 1000;
+  }
+
+  if (strategy.type === "schedule") {
+    return millisecondsUntilEndOfHour();
+  }
+
+  throw new Error(`Unsupported strategy type: ${strategy.type}`);
+};
+
+export const millisecondsUntilEndOfHour = () => {
+  const now = new Date();
+  const nextHour = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+    now.getHours() + 1,
+    0,
+    0,
+    0,
+  );
+  return nextHour.getTime() - now.getTime();
+};
+
+export const advanceServerClockBy = (milliseconds: number) => {
+  log(`Advancing clock by ${milliseconds}ms`);
+  return cy.request("POST", "/api/testing/set-time", {
+    "add-ms": milliseconds,
+  });
 };

--- a/e2e/test/scenarios/admin/performance/helpers/e2e-strategy-form-helpers.ts
+++ b/e2e/test/scenarios/admin/performance/helpers/e2e-strategy-form-helpers.ts
@@ -144,7 +144,10 @@ export const selectCacheStrategy = ({
 
   // On OSS, you can only set the root policy, so there's no need to open a
   // specific strategy form
-  if (!oss) {
+  if (oss) {
+    cy.visit("/admin/performance");
+    cacheStrategyForm();
+  } else {
     openStrategyFormFor(item);
   }
 

--- a/e2e/test/scenarios/admin/performance/helpers/e2e-strategy-form-helpers.ts
+++ b/e2e/test/scenarios/admin/performance/helpers/e2e-strategy-form-helpers.ts
@@ -84,12 +84,13 @@ export const openStrategyFormForDatabaseOrDefaultPolicy = (
     ).click();
 
   if (databaseNameOrDefaultPolicy === "default policy") {
-    cy.get("body").then($body => {
-      if ($body.find('form[data-testid="strategy-form-for-root-0"]').length) {
-        // On OSS, the default policy form is open by default, so do nothing
-        return;
-      } else {
+    cy.contains("Select the cache invalidation policy").then($element => {
+      if (!$element || $element.length === 0) {
         clickLauncher();
+      } else {
+        // On OSS, the default policy form (which contains the text 'Select the
+        // cache invalidation policy') is open by default, so do nothing
+        return;
       }
     });
   } else {

--- a/e2e/test/scenarios/admin/performance/helpers/e2e-strategy-form-helpers.ts
+++ b/e2e/test/scenarios/admin/performance/helpers/e2e-strategy-form-helpers.ts
@@ -179,8 +179,14 @@ export const selectCacheStrategy = ({
 
   saveCacheStrategyForm({ strategyType: strategy.type, model: item?.model });
 
-  if (item?.model === "dashboard" || item?.model === "question") {
-    closeSidebar();
+  if (item?.model === "question") {
+    cy.findByLabelText("Close").click();
+  }
+
+  // Once dashboard sidesheets is merged, we can change this to use the same
+  // approach that we use for questions.
+  if (item?.model === "dashboard") {
+    cy.findByLabelText("More info").click();
   }
 };
 

--- a/e2e/test/scenarios/admin/performance/helpers/e2e-strategy-form-helpers.ts
+++ b/e2e/test/scenarios/admin/performance/helpers/e2e-strategy-form-helpers.ts
@@ -12,11 +12,7 @@ import type {
   InheritStrategy,
 } from "metabase-types/api";
 
-import {
-  databaseCachingPage,
-  log,
-  wrapResult,
-} from "./e2e-performance-helpers";
+import { databaseCachingPage, log } from "./e2e-performance-helpers";
 import type { SelectCacheStrategyOptions } from "./types";
 
 /** Save the cache strategy form and wait for a response from the relevant endpoint */
@@ -159,7 +155,6 @@ export const selectCacheStrategy = ({
   strategy,
 }: SelectCacheStrategyOptions) => {
   log(`Selecting ${strategy.type} strategy for ${item.model}`);
-  wrapResult().as("previousResult");
 
   match(item)
     .with({ model: "database" }, ({ name }) => {

--- a/e2e/test/scenarios/admin/performance/helpers/types.ts
+++ b/e2e/test/scenarios/admin/performance/helpers/types.ts
@@ -1,0 +1,27 @@
+import type { CacheStrategy, CacheableModel } from "metabase-types/api";
+
+export type CacheTestParameters = {
+  description: string;
+  strategy: CacheStrategy;
+  /** Item whose cache we are testing */
+  item: StrategyBearer;
+  inheritsStrategyFrom?: StrategyBearer;
+  /** Function that runs the test. Set to it, it.only, or it.skip */
+  it?: Mocha.TestFunction;
+};
+
+/** Something with a configurable cache strategy */
+export type StrategyBearer = {
+  model: CacheableModel;
+  name: string;
+};
+
+export type SelectCacheStrategyOptions<Strategy = CacheStrategy> = {
+  /** The item to be configured */
+  item: StrategyBearer;
+  strategy: Strategy;
+};
+
+export type DashboardDetails = {
+  name: string;
+};

--- a/e2e/test/scenarios/admin/performance/helpers/types.ts
+++ b/e2e/test/scenarios/admin/performance/helpers/types.ts
@@ -20,6 +20,8 @@ export type SelectCacheStrategyOptions<Strategy = CacheStrategy> = {
   /** The item to be configured */
   item: StrategyBearer;
   strategy: Strategy;
+  /** Whether the test is being run in OSS */
+  oss?: boolean;
 };
 
 export type DashboardDetails = {

--- a/e2e/test/scenarios/admin/performance/helpers/types.ts
+++ b/e2e/test/scenarios/admin/performance/helpers/types.ts
@@ -8,6 +8,8 @@ export type CacheTestParameters = {
   inheritsStrategyFrom?: StrategyBearer;
   /** Function that runs the test. Set to it, it.only, or it.skip */
   it?: Mocha.TestFunction;
+  /** Whether the test is being run in OSS */
+  oss?: boolean;
 };
 
 /** Something with a configurable cache strategy */

--- a/frontend/src/metabase/admin/performance/components/StrategyEditorForDatabases.tsx
+++ b/frontend/src/metabase/admin/performance/components/StrategyEditorForDatabases.tsx
@@ -152,7 +152,7 @@ const StrategyEditorForDatabases_Base = ({
             {targetId !== null && (
               <StrategyForm
                 targetId={targetId}
-                targetModel="database"
+                targetModel={targetId === rootId ? "root" : "database"}
                 targetName={targetDatabase?.name || t`Untitled database`}
                 setIsDirty={setIsStrategyFormDirty}
                 saveStrategy={saveStrategy}

--- a/frontend/src/metabase/admin/performance/components/StrategyForm.tsx
+++ b/frontend/src/metabase/admin/performance/components/StrategyForm.tsx
@@ -212,6 +212,7 @@ const StrategyFormBody = ({
       <StyledForm
         style={{ overflow: isInSidebar ? undefined : "auto" }}
         aria-labelledby={headingId}
+        data-testid={`strategy-form-for-${targetModel}-${targetId}`}
       >
         <FormBox isInSidebar={isInSidebar}>
           {shouldShowName && (

--- a/frontend/src/metabase/nav/components/AppBar/AppBarLarge.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLarge.tsx
@@ -1,3 +1,5 @@
+import { t } from "ttag";
+
 import type { CollectionId } from "metabase-types/api";
 
 import CollectionBreadcrumbs from "../../containers/CollectionBreadcrumbs";
@@ -75,7 +77,7 @@ const AppBarLarge = ({
           {isSearchVisible && (isEmbedded ? <SearchBar /> : <SearchButton />)}
           {isNewButtonVisible && <NewItemButton collectionId={collectionId} />}
           {isProfileLinkVisible && (
-            <AppBarProfileLinkContainer>
+            <AppBarProfileLinkContainer aria-label={t`Settings menu`}>
               <ProfileLink onLogout={onLogout} />
             </AppBarProfileLinkContainer>
           )}


### PR DESCRIPTION
This PR tests that the user can assign any of three cache invalidation strategies ("duration", "adaptive", and "don't cache") to dashboards and questions. The tests check that the following things are true:
* These strategies can be applied directly (via the sidebar)
* Dashboards and questions can inherit their caching strategy from the database that underlies them
* Dashboards and questions can inherit their caching strategy from the instance-wide default policy
* When a question inside a dashboard has been assigned a strategy, this is overridden by the strategy assigned to the dashboard.

What these tests do not examine:
* caching on OSS
* the schedule strategy
* the minimum query duration
* edge-case strategies, such as very long durations or very large values for the adaptive strategy multiplier

These may be addressed in follow-up work.

Closes #45355