### PR TITLE
Add dialect based feature flags for macaw

### DIFF
--- a/src/metabase/native_query_analyzer/impl.cljc
+++ b/src/metabase/native_query_analyzer/impl.cljc
@@ -41,6 +41,14 @@
      ;; For both MySQL and SQL Server, whether identifiers are case-sensitive depends on database configuration only,
      ;; and quoting has no effect on this, so we disable this option for consistency with `:case-insensitive`.
      :quotes-preserve-case? (not (contains? #{:mysql :sqlserver} driver))
+     :features              {:postgres-syntax        (= :postgres driver) ;; todo, handle things that inherit, like redshift
+                             :square-bracket-quotes  (= :sqlserver driver)
+                             :unsupported-statements true
+                             :backslash-escape-char  true
+                             ;; This will slow things down, but until we measure the difference, opt for correctness.
+                             :complex-parsing        true}
+     ;; 10 seconds
+     :timout                10000
      ;; There is no plan to be exhaustive yet.
      ;; Note that while an allowed list would be more conservative, at the time of writing only 2 of the bundled
      ;; drivers use FINAL as a reserved word, and mentioning them all would be prohibitive.

--- a/src/metabase/native_query_analyzer/impl.cljc
+++ b/src/metabase/native_query_analyzer/impl.cljc
@@ -1,4 +1,6 @@
-(ns metabase.native-query-analyzer.impl)
+(ns metabase.native-query-analyzer.impl
+  (:require
+   [metabase.driver :as driver]))
 
 ;; NOTE: In the future we should replace [[considered-drivers]] and [[macaw-options]] with (a) driver method(s),
 ;; but given that the interface with Macaw is still in a state of flux, and how simple the current configuration is,
@@ -41,7 +43,7 @@
      ;; For both MySQL and SQL Server, whether identifiers are case-sensitive depends on database configuration only,
      ;; and quoting has no effect on this, so we disable this option for consistency with `:case-insensitive`.
      :quotes-preserve-case? (not (contains? #{:mysql :sqlserver} driver))
-     :features              {:postgres-syntax        (= :postgres driver) ;; todo, handle things that inherit, like redshift
+     :features              {:postgres-syntax        (isa? driver/hierarchy driver :postgres)
                              :square-bracket-quotes  (= :sqlserver driver)
                              :unsupported-statements true
                              :backslash-escape-char  true


### PR DESCRIPTION
Refs https://github.com/metabase/macaw/issues/42

Macaw is [about to](https://github.com/metabase/macaw/pull/78) support the various [parser features](https://jsqlparser.github.io/JSqlParser/usage.html#define-the-parser-features) exposed by the underlying JSQLParser library. 

This PR wires them up in a vaguely plausible way for now - at least enough to close https://github.com/metabase/macaw/issues/42.

Looking forward we're either wanting to replace this big map with (a) multimethod(s), or give Macaw its own hierarchy and just pass down the driver. Or the first ancestor of the driver that Macaw knows about...