### PR TITLE
[49 backport] Skip fingerprinting or scanning field values for fields with base-type=type/Collection (#45160)

### DIFF
--- a/src/metabase/db/util.clj
+++ b/src/metabase/db/util.clj
@@ -33,7 +33,7 @@
 (def ^:private NamespacedKeyword
   [:and :keyword [:fn (comp seq namespace)]])
 
-(mu/defn ^:private type-keyword->descendants :- [:set {:min 1} ms/NonBlankString]
+(mu/defn type-keyword->descendants :- [:set {:min 1} ms/NonBlankString]
   "Return a set of descendents of Metabase `type-keyword`. This includes `type-keyword` itself, so the set will always
   have at least one element.
 

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -213,7 +213,10 @@
       (boolean
        (and
         (not (contains? #{:retired :sensitive :hidden :details-only} (keyword visibility-type)))
-        (not (isa? (keyword base-type) :type/Temporal))
+        (not (some #(isa? (keyword base-type) %) [:type/field-values-unsupported
+                                                  :type/Structured
+                                                  :type/Temporal
+                                                  :type/Collection]))
         (not (= (keyword base-type) :type/*))
         (#{:list :auto-list} (keyword has-field-values)))))))
 

--- a/src/metabase/sync/analyze/fingerprint.clj
+++ b/src/metabase/sync/analyze/fingerprint.clj
@@ -160,8 +160,8 @@
     [:not (mdb.u/isa :semantic_type :type/PK)]
     [:= :semantic_type nil]]
    [:not-in :visibility_type ["retired" "sensitive"]]
-   [:not= :base_type (u/qualified-name :type/*)]
-   [:not (mdb.u/isa :base_type :type/Structured)]])
+   [:not-in :base_type (-> (set (mapcat mdb.u/type-keyword->descendants [:type/Structured :type/Collection]))
+                           (conj (u/qualified-name :type/*)))]])
 
 (def ^:dynamic *refingerprint?*
   "Whether we are refingerprinting or doing the normal fingerprinting. Refingerprinting should get fields that already

--- a/test/metabase/models/field_values_test.clj
+++ b/test/metabase/models/field_values_test.clj
@@ -95,7 +95,23 @@
                                    {{:has_field_values :list
                                      :visibility_type  :normal
                                      :base_type        :type/*}
-                                    false}}
+                                    false}
+
+                                   "type/Structured fields should be excluded"
+                                   (into {}
+                                         (for [base-type (conj (descendants :type/Structured) :type/Structured)]
+                                           [{:has_field_values :list
+                                             :visibility_type  :normal
+                                             :base_type        base-type}
+                                            false]))
+
+                                   "type/Collection fields should be excluded"
+                                   (into {}
+                                         (for [base-type (conj (descendants :type/Collection) :type/Collection)]
+                                           [{:has_field_values :list
+                                             :visibility_type  :normal
+                                             :base_type        base-type}
+                                            false]))}
           [input expected] input->expected]
     (testing (str group "\n")
       (testing (pr-str (list 'field-should-have-field-values? input))

--- a/test/metabase/sync/analyze/fingerprint_test.clj
+++ b/test/metabase/sync/analyze/fingerprint_test.clj
@@ -28,6 +28,17 @@
   (is (= #{"type/ImageURL" "type/AvatarURL"}
          (#'fingerprint/base-types->descendants #{:type/ImageURL :type/AvatarURL}))))
 
+(def ^:private skip-fingerprint-base-types
+  #{"type/*"
+    "type/Structured"
+    "type/SerializedJSON"
+    "type/JSON"
+    "type/Dictionary"
+    "type/Array"
+    "type/Collection"
+    "type/XML"
+    "type/DruidJSON"})
+
 (deftest ^:parallel honeysql-for-fields-that-need-fingerprint-updating-test
   (testing (str "Make sure we generate the correct HoneySQL WHERE clause based on whatever is in "
                 "`*fingerprint-version->types-that-should-be-re-fingerprinted*`")
@@ -38,8 +49,7 @@
               [:not (mdb.u/isa :semantic_type :type/PK)]
               [:= :semantic_type nil]]
              [:not-in :visibility_type ["retired" "sensitive"]]
-             [:not= :base_type "type/*"]
-             [:not (mdb.u/isa :base_type :type/Structured)]
+             [:not-in :base_type skip-fingerprint-base-types]
              [:or
               [:and
                [:< :fingerprint_version 1]
@@ -55,8 +65,7 @@
             [:not (mdb.u/isa :semantic_type :type/PK)]
             [:= :semantic_type nil]]
            [:not-in :visibility_type ["retired" "sensitive"]]
-           [:not= :base_type "type/*"]
-           [:not (mdb.u/isa :base_type :type/Structured)]
+           [:not-in :base_type skip-fingerprint-base-types]
            [:or
             [:and
              [:< :fingerprint_version 2]
@@ -78,8 +87,7 @@
               [:not (mdb.u/isa :semantic_type :type/PK)]
               [:= :semantic_type nil]]
              [:not-in :visibility_type ["retired" "sensitive"]]
-             [:not= :base_type "type/*"]
-             [:not (mdb.u/isa :base_type :type/Structured)]
+             [:not-in :base_type skip-fingerprint-base-types]
              [:or
               [:and
                [:< :fingerprint_version 2]
@@ -102,8 +110,7 @@
               [:not (mdb.u/isa :semantic_type :type/PK)]
               [:= :semantic_type nil]]
              [:not-in :visibility_type ["retired" "sensitive"]]
-             [:not= :base_type "type/*"]
-             [:not (mdb.u/isa :base_type :type/Structured)]
+             [:not-in :base_type skip-fingerprint-base-types]
              [:or
               [:and
                [:< :fingerprint_version 4]
@@ -131,8 +138,7 @@
                      [:not (mdb.u/isa :semantic_type :type/PK)]
                      [:= :semantic_type nil]]
                     [:not-in :visibility_type ["retired" "sensitive"]]
-                    [:not= :base_type "type/*"]
-                    [:not (mdb.u/isa :base_type :type/Structured)]]}
+                    [:not-in :base_type skip-fingerprint-base-types]]}
            (binding [fingerprint/*refingerprint?* true]
              (#'fingerprint/honeysql-for-fields-that-need-fingerprint-updating))))))
 

--- a/test/metabase/sync/analyze/fingerprint_test.clj
+++ b/test/metabase/sync/analyze/fingerprint_test.clj
@@ -36,8 +36,7 @@
     "type/Dictionary"
     "type/Array"
     "type/Collection"
-    "type/XML"
-    "type/DruidJSON"})
+    "type/XML"})
 
 (deftest ^:parallel honeysql-for-fields-that-need-fingerprint-updating-test
   (testing (str "Make sure we generate the correct HoneySQL WHERE clause based on whatever is in "


### PR DESCRIPTION
Backports https://github.com/metabase/metabase/pull/45160 to 49