### PR TITLE
Only drop idx_uniq_field_table_id_parent_id_name if it exists

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -6607,9 +6607,26 @@ databaseChangeLog:
       comment: Remove idx_uniq_field_table_id_parent_id_name because it is redundant with idx_unique_field
       preConditions:
         - onFail: MARK_RAN
-        - uniqueConstraintExists:
-            constraintName: idx_uniq_field_table_id_parent_id_name
-            tableName: metabase_field
+        - or:
+            - and:
+                - dbms:
+                    type: h2,postgresql
+                    uniqueConstraintExists:
+                      tableName: metabase_field
+                      constraintName: idx_uniq_field_table_id_parent_id_name
+            - and:
+                - dbms:
+                    type: mysql,mariadb
+                - sqlCheck:
+                    expectedResult: 1
+                    sql: >-
+                      SELECT EXISTS (
+                        SELECT *
+                        FROM information_schema.statistics
+                        WHERE table_schema = DATABASE()
+                          AND table_name = 'metabase_field'
+                          AND index_name = 'idx_uniq_field_table_id_parent_id_name'
+                      )
       changes:
         - dropUniqueConstraint:
             tableName: metabase_field

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -6605,6 +6605,11 @@ databaseChangeLog:
       id: v49.2024-06-27T00:00:05
       author: calherries
       comment: Remove idx_uniq_field_table_id_parent_id_name because it is redundant with idx_unique_field
+      preConditions:
+        - onFail: MARK_RAN
+        - uniqueConstraintExists:
+            constraintName: idx_uniq_field_table_id_parent_id_name
+            tableName: metabase_field
       changes:
         - dropUniqueConstraint:
             tableName: metabase_field


### PR DESCRIPTION
Follows up https://github.com/metabase/metabase/pull/44866

As part of https://github.com/metabase/metabase/pull/44866, we drop the unique constraint `idx_uniq_field_table_id_parent_id_name`. The problem is, there could be Metabase instances where this constraint has been dropped manually for whatever reason. We don't want to block upgrades just because someone has dropped the constraint from their app DB.

This PR adds a pre-condition to the changeset that drops the constraint where we will skip it if the constraint has already been dropped.

Bugs producing false negatives in the precondition (i.e. thinking the constraint doesn't exist when it actually does) would have been caught by all existing automated tests that downgrade. There's no automated test coverage for false positives (thinking the constraint does exist when it actually doesn't). I have tested it this manually on MySQL, H2, and Postgres. I'm not sure writing a test for that is worth it given it's much harder to write a bug producing false positives that is not super obvious.

This needs to be backported to 49.