### PR TITLE
fix: Allow submit buttons to override the variant prop

### DIFF
--- a/frontend/src/metabase/forms/components/FormSubmitButton/FormSubmitButton.tsx
+++ b/frontend/src/metabase/forms/components/FormSubmitButton/FormSubmitButton.tsx
@@ -44,7 +44,6 @@ export const FormSubmitButton = forwardRef(function FormSubmitButton(
       type="submit"
       color={submitColor}
       disabled={isDisabled}
-      variant="filled"
     >
       {submitLabel}
     </Button>

--- a/frontend/src/metabase/questions/components/CopyQuestionForm.tsx
+++ b/frontend/src/metabase/questions/components/CopyQuestionForm.tsx
@@ -88,7 +88,7 @@ export const CopyQuestionForm = ({
           {!!onCancel && (
             <Button type="button" onClick={onCancel}>{t`Cancel`}</Button>
           )}
-          <FormSubmitButton label={t`Duplicate`} />
+          <FormSubmitButton label={t`Duplicate`} variant="filled" />
         </FormFooter>
       </Form>
     </FormProvider>


### PR DESCRIPTION
Submit buttons previously had `variant=filled` imposed on them. Let's allow that prop to be overridden.

This PR also specifies the 'filled' variant for the question duplication modal, since the previous default 'filled' variant for submit button was added to make that specific button filled.