### PR TITLE
Extend dev/migration-sql-by-id with `db-type` argument

### DIFF
--- a/dev/src/dev/migrate.clj
+++ b/dev/src/dev/migrate.clj
@@ -10,8 +10,10 @@
    (liquibase Contexts Liquibase RuntimeEnvironment)
    (liquibase.changelog ChangeLogIterator)
    (liquibase.changelog.filter ChangeSetFilter)
-   (liquibase.sqlgenerator SqlGeneratorFactory)
-   (liquibase.changelog.visitor ListVisitor)))
+   (liquibase.changelog.visitor ListVisitor)
+   (liquibase.database.core H2Database MySQLDatabase PostgresDatabase MariaDBDatabase)
+   (liquibase.exception RollbackImpossibleException)
+   (liquibase.sqlgenerator SqlGeneratorFactory)))
 
 (set! *warn-on-reflection* true)
 
@@ -116,27 +118,39 @@
 (defn- change->sql
   [change sql-generator-factory database]
   {:forward  (stmts-to-sql (.generateStatements change database) sql-generator-factory database)
-   :rollback (stmts-to-sql (.generateRollbackStatements change database) sql-generator-factory database)})
+   :rollback (try (stmts-to-sql (.generateRollbackStatements change database) sql-generator-factory database)
+                  (catch RollbackImpossibleException e
+                    (str "Rollback impossible " e)))})
 
-(defn migration-sql-by-id
-  "Get the sql statements for a specific migration ID.
-    (migration-sql-by-id \"v51.2024-06-12T18:53:02\")
+(defn- get-database-instance [db-type]
+  (case db-type
+    :postgres (PostgresDatabase.)
+    :mysql    (MySQLDatabase.)
+    :mariadb  (MariaDBDatabase.)
+    :h2       (H2Database.)))
+
+(mu/defn migration-sql-by-id
+  "Get the sql statements for a specific migration ID and DB type. If no DB type is provided, it will use the current
+   application DB type.
+    (migration-sql-by-id \"v51.2024-06-12T18:53:02\" :postgres)
     ;; =>
       {:forward \"DROP INDEX public.idx_user_id_device_id;\",
        :rollback \"CREATE INDEX idx_user_id_device_id ON public.login_history(session_id, device_id);\"}"
-  [id]
-  (t2/with-connection [conn]
-    (liquibase/with-liquibase [^Liquibase liquibase conn]
-      (let [database            (.getDatabase liquibase)
-            change-log-iterator (ChangeLogIterator. (.getDatabaseChangeLog liquibase) (into-array ChangeSetFilter []))
-            list-visistor       (ListVisitor.)
-            runtime-env         (RuntimeEnvironment. database (Contexts.) nil)
-            _                   (.run change-log-iterator list-visistor runtime-env)
-            change-set          (first (filter #(= id (.getId %))(.getSeenChangeSets list-visistor)))
-            sql-generator-factory (SqlGeneratorFactory/getInstance)]
-        (reduce (fn [acc data]
+  ([id]
+   (migration-sql-by-id id (mdb/db-type)))
+  ([id db-type :- [:enum :postgres :mysql :mariadb :h2]]
+   (t2/with-connection [conn]
+     (liquibase/with-liquibase [^Liquibase liquibase conn]
+       (let [database            (get-database-instance db-type)
+             change-log-iterator (ChangeLogIterator. (.getDatabaseChangeLog liquibase) (into-array ChangeSetFilter []))
+             list-visistor       (ListVisitor.)
+             runtime-env         (RuntimeEnvironment. database (Contexts.) nil)
+             _                   (.run change-log-iterator list-visistor runtime-env)
+             change-set          (first (filter #(= id (.getId %)) (.getSeenChangeSets list-visistor)))
+             sql-generator-factory (SqlGeneratorFactory/getInstance)]
+         (reduce (fn [acc data]
                   ;; merge all changes in one change set into one single :forward and :rollback
-                  (merge-with (fn [x y]
-                                (str x "\n" y)) acc data))
-                {}
-                (map #(change->sql % sql-generator-factory database) (.getChanges change-set)))))))
+                   (merge-with (fn [x y]
+                                 (str x "\n" y)) acc data))
+                 {}
+                 (map #(change->sql % sql-generator-factory database) (.getChanges change-set))))))))

--- a/dev/src/dev/migrate.clj
+++ b/dev/src/dev/migrate.clj
@@ -122,7 +122,7 @@
                   (catch RollbackImpossibleException e
                     (str "Rollback impossible " e)))})
 
-(defn- get-database-instance [db-type]
+(defn- liquibase-database [db-type]
   (case db-type
     :postgres (PostgresDatabase.)
     :mysql    (MySQLDatabase.)
@@ -141,7 +141,7 @@
   ([id db-type :- [:enum :postgres :mysql :mariadb :h2]]
    (t2/with-connection [conn]
      (liquibase/with-liquibase [^Liquibase liquibase conn]
-       (let [database            (get-database-instance db-type)
+       (let [database            (liquibase-database db-type)
              change-log-iterator (ChangeLogIterator. (.getDatabaseChangeLog liquibase) (into-array ChangeSetFilter []))
              list-visistor       (ListVisitor.)
              runtime-env         (RuntimeEnvironment. database (Contexts.) nil)

--- a/dev/test/dev/migrate_test.clj
+++ b/dev/test/dev/migrate_test.clj
@@ -4,8 +4,25 @@
    [metabase.dev.migrate :as dev.migrate]))
 
 (deftest migration-sql-by-id-test
-  (is (= {:forward
-          "ALTER TABLE public.query_field RENAME COLUMN direct_reference TO explicit_reference;",
-          :rollback
-          "ALTER TABLE public.query_field RENAME COLUMN explicit_reference TO direct_reference;"}
-         (dev.migrate/migration-sql-by-id "v51.2024-06-07T12:37:36"))))
+  (doseq [[id test] {"v50.2024-05-08T09:00:01"
+                     {:postgres {:forward  "ALTER TABLE task_history ALTER COLUMN status DROP DEFAULT;"
+                                 :rollback "Rollback impossible liquibase.exception.RollbackImpossibleException: No inverse to liquibase.change.core.DropDefaultValueChange created"}
+                      :h2       {:forward  "ALTER TABLE task_history ALTER COLUMN  status SET DEFAULT NULL;"
+                                 :rollback "Rollback impossible liquibase.exception.RollbackImpossibleException: No inverse to liquibase.change.core.DropDefaultValueChange created"}
+                      :mysql    {:forward  "ALTER TABLE task_history ALTER status DROP DEFAULT;"
+                                 :rollback "Rollback impossible liquibase.exception.RollbackImpossibleException: No inverse to liquibase.change.core.DropDefaultValueChange created"}
+                      :mariadb  {:forward  "ALTER TABLE task_history ALTER status DROP DEFAULT;"
+                                 :rollback "Rollback impossible liquibase.exception.RollbackImpossibleException: No inverse to liquibase.change.core.DropDefaultValueChange created"}}
+                     "v50.2024-05-29T14:05:01"
+                     {:postgres {:forward  "ALTER TABLE collection ADD archived_directly BOOLEAN;\nCOMMENT ON COLUMN collection.archived_directly IS 'Whether the item was trashed independently or as a subcollection';"
+                                 :rollback "ALTER TABLE collection DROP COLUMN archived_directly;"}
+                      :h2       {:forward  "ALTER TABLE collection ADD archived_directly BOOLEAN;\nCOMMENT ON COLUMN collection.archived_directly IS 'Whether the item was trashed independently or as a subcollection';"
+                                 :rollback "ALTER TABLE collection DROP COLUMN archived_directly;"}
+                      :mysql    {:forward  "ALTER TABLE collection ADD archived_directly TINYINT NULL COMMENT 'Whether the item was trashed independently or as a subcollection';"
+                                 :rollback "ALTER TABLE collection DROP COLUMN archived_directly;"}
+                      :mariadb  {:forward  "ALTER TABLE collection ADD archived_directly TINYINT(1) NULL COMMENT 'Whether the item was trashed independently or as a subcollection';"
+                                 :rollback "ALTER TABLE collection DROP COLUMN archived_directly;"}}}
+          [db-type expected] test]
+    (testing (str "migration SQL for " (name db-type))
+      (is (= expected
+             (dev.migrate/migration-sql-by-id id db-type))))))


### PR DESCRIPTION
This PR includes two enhancements to the new `dev/migration-sql-by-id` function added by https://github.com/metabase/metabase/pull/44872.

See the comments in the code for their description