### PR TITLE
Async coll perm graph revision

### DIFF
--- a/src/metabase/models/collection/graph.clj
+++ b/src/metabase/models/collection/graph.clj
@@ -191,7 +191,7 @@
          (doseq [[group-id changes] changes]
            (update-audit-collection-permissions! group-id changes)
            (update-group-permissions! collection-namespace group-id changes)))
-       (let [revision-id (create-perms-revision! (:revision old-graph))]
+       (let [revision-id (:id (create-perms-revision! (:revision old-graph)))]
          ;; The graph is updated infrequently, but `diff-old` and `old-graph` can get huge on larger instances.
          (data-perms.graph/log-permissions-changes diff-old changes)
          (future (update-perms-revision! revision-id (assoc old-graph :namespace collection-namespace) changes)))))))

--- a/src/metabase/models/collection/graph.clj
+++ b/src/metabase/models/collection/graph.clj
@@ -172,7 +172,11 @@
 (mu/defn update-graph!
   "Update the Collections permissions graph for Collections of `collection-namespace` (default `nil`, the 'default'
   namespace). This works just like [[metabase.models.permission/update-data-perms-graph!]], but for Collections;
-  refer to that function's extensive documentation to get a sense for how this works."
+  refer to that function's extensive documentation to get a sense for how this works.
+
+  If there are no changes, returns nil.
+  If there are changes, returns the future that is used to call `fill-revision-details!`.
+  To run this syncronously deref the non-nil return value."
   ([new-graph]
    (update-graph! nil new-graph))
 

--- a/src/metabase/models/collection_permission_graph_revision.clj
+++ b/src/metabase/models/collection_permission_graph_revision.clj
@@ -1,7 +1,6 @@
 (ns metabase.models.collection-permission-graph-revision
   (:require
    [metabase.models.interface :as mi]
-   [metabase.util.i18n :refer [tru]]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
@@ -20,13 +19,9 @@
   {:before mi/transform-json
    :after  mi/transform-json})
 
-(t2/define-before-update :model/CollectionPermissionGraphRevision
-  [_]
-  (throw (Exception. (tru "You cannot update a CollectionPermissionGraphRevision!"))))
-
 (defn latest-id
   "Return the ID of the newest `CollectionPermissionGraphRevision`, or zero if none have been made yet.
    (This is used by the collection graph update logic that checks for changes since the original graph was fetched)."
   []
-  (or (:id (t2/select-one [CollectionPermissionGraphRevision [:%max.id :id]]))
+  (or (:id (t2/select-one [:model/CollectionPermissionGraphRevision [:%max.id :id]]))
       0))

--- a/test/metabase/models/collection/graph_test.clj
+++ b/test/metabase/models/collection/graph_test.clj
@@ -301,6 +301,25 @@
                                              (u/the-id collection)]
                                             :read))))))))
 
+(set! *warn-on-reflection* true)
+
+(defn wait-until [timeout-ms thunk]
+  (let [start (System/currentTimeMillis)]
+    (loop []
+      (if (thunk)
+        true
+        (if (> (- (System/currentTimeMillis) start) timeout-ms)
+          (throw (ex-info "wait-until timed out." {}))
+          (do (Thread/sleep ^Long (/ timeout-ms 1000))
+              (recur)))))))
+
+(defn- update-graph-and-wait!
+  "`graph/update-graph!` updates the before and after values in the graph asyncronously, so we need to wait for them to be written"
+  ([new-graph] (update-graph-and-wait! nil new-graph))
+  ([namespaze new-graph]
+   (graph/update-graph! namespaze new-graph)
+   (wait-until 1000 (fn [] (some? (:before (t2/select-one :model/CollectionPermissionGraphRevision (inc (:revision new-graph)))))))))
+
 (deftest collection-namespace-test
   (testing "The permissions graph should be namespace-aware.\n"
     (mt/with-non-admin-groups-no-root-collection-perms
@@ -339,7 +358,7 @@
           (mt/with-test-user :crowberto
             (testing "Should be able to update the graph for the default namespace.\n"
               (let [before (graph/graph)]
-                (graph/update-graph! (assoc (graph/graph) :groups {group-id {default-ab :write, currency-ab :write}}))
+                (update-graph-and-wait! (assoc before :groups {group-id {default-ab :write, currency-ab :write}}))
                 (is (= {"Default A" :read, "Default A -> B" :write, :root :none}
                        (nice-graph (graph/graph))))
 
@@ -359,6 +378,8 @@
             (testing "Should be able to update the graph for a non-default namespace.\n"
               (let [before (graph/graph :currency)]
                 (graph/update-graph! :currency (assoc (graph/graph) :groups {group-id {default-a :write, currency-a :write}}))
+                (wait-until 1000
+                            (fn [] (some? (:before (t2/select-one :model/CollectionPermissionGraphRevision (:revision (graph/graph)))))))
                 (is (= {"Currency A" :write, "Currency A -> B" :read, :root :none}
                        (nice-graph (graph/graph :currency))))
 
@@ -376,7 +397,7 @@
                               (t2/select-one CollectionPermissionGraphRevision {:order-by [[:id :desc]]}))))))
 
             (testing "should be able to update permissions for the Root Collection in the default namespace via the graph"
-              (graph/update-graph! (assoc (graph/graph) :groups {group-id {:root :read}}))
+              (update-graph-and-wait! (assoc (graph/graph) :groups {group-id {:root :read}}))
               (is (= {:root :read, "Default A" :read, "Default A -> B" :write}
                      (nice-graph (graph/graph))))
 
@@ -391,7 +412,7 @@
                         (t2/select-one CollectionPermissionGraphRevision {:order-by [[:id :desc]]})))))
 
             (testing "should be able to update permissions for Root Collection in non-default namespace"
-              (graph/update-graph! :currency (assoc (graph/graph :currency) :groups {group-id {:root :write}}))
+              (update-graph-and-wait! :currency (assoc (graph/graph :currency) :groups {group-id {:root :write}}))
               (is (= {:root :write, "Currency A" :write, "Currency A -> B" :read}
                      (nice-graph (graph/graph :currency))))
 
@@ -435,3 +456,28 @@
     (with-n-temp-users-with-personal-collections 2000
       (is (>= (t2/count Collection :personal_owner_id [:not= nil]) 2000))
       (is (map? (graph/graph))))))
+
+(deftest async-perm-graph-revisions
+  (testing "A CollectionPermissionGraphRevision should be saved when the graph is updated, even if it takes a while."
+    (clear-graph-revisions!)
+    (let [original-revision-filler graph/fill-revision-details!]
+      (with-redefs [graph/fill-revision-details! (fn [revision-id before changes]
+                                                   (future
+                                                     (Thread/sleep 1000)
+                                                     (original-revision-filler revision-id before changes)))]
+        (binding [*current-user-id* (mt/user->id :crowberto)]
+          (mt/with-temp [:model/Collection {collection-id :id} {:location "/"}]
+            (let [all-users-group-id (u/the-id (perms-group/all-users))
+                  ;; Make it so the groupp has :write to the :root collection
+                  _ (perms/revoke-collection-permissions! all-users-group-id collection-id)
+                  before (graph/graph)
+                  new-graph (assoc before :groups {(u/the-id (perms-group/all-users)) {collection-id :read}})]
+              (graph/update-graph! new-graph)
+              (is (malli= [:map [:id :some] [:user_id :some] [:before :nil] [:after :nil]]
+                          (t2/select-one :model/CollectionPermissionGraphRevision (inc (:revision before))))
+                  "Values for before and after should not be present right after the revision.")
+              (wait-until 2000
+                          (fn [] (some? (:before (t2/select-one :model/CollectionPermissionGraphRevision (inc (:revision new-graph)))))))
+              (is (malli= [:map [:before :some] [:after  :some]]
+                          (t2/select-one :model/CollectionPermissionGraphRevision (inc (:revision before))))
+                  "Values for before and after should be present in the revision."))))))))


### PR DESCRIPTION
Pursuant to https://github.com/metabase/metabase/issues/39997

Improves collection graph update performance, especially on problematic instances that have 1000+ collections and perm groups, by making the costly process of writing the potentially gigantic revision json blob to the db into an async process.

An alternative solution is to remove the collection perm graph revision capturing entirely. We still might do that since metabase/metabase does not use the perm graph revision for anything. But it may be nice to have for users and/or support. If it's needed, we could consider a diff-based approach instead.