### PR TITLE
Dashboard Paramter Value Now Works in Preview Embed

### DIFF
--- a/src/metabase/api/embed/common.clj
+++ b/src/metabase/api/embed/common.clj
@@ -413,7 +413,10 @@
           (throw e))))))
 
 (defn dashboard-param-values
-  "Common implementation for fetching parameter values for embedding and preview-embedding."
+  "Common implementation for fetching parameter values for embedding and preview-embedding.
+  Optionally pass a map with `:preview` containing `true` (or some non-falsy value) to disable checking
+  if the dashboard is 'published'. This is intended to power the `preview_embed` api endpoints.
+  The `:preview` key will default to `false`."
   [token searched-param-id prefix id-query-params
    & {:keys [preview] :or {preview false}}]
   (let [unsigned-token                       (embed/unsign token)

--- a/src/metabase/api/embed/common.clj
+++ b/src/metabase/api/embed/common.clj
@@ -414,7 +414,7 @@
 
 (defn dashboard-param-values
   "Common implementation for fetching parameter values for embedding and preview-embedding."
-  [token prefix id-query-params searched-param-id
+  [token searched-param-id prefix id-query-params
    & {:keys [preview] :or {preview false}}]
   (let [unsigned-token (embed/unsign token)
         dashboard-id   (embed/get-in-unsigned-token-or-throw unsigned-token [:resource :dashboard])]

--- a/src/metabase/api/embed/common.clj
+++ b/src/metabase/api/embed/common.clj
@@ -418,7 +418,7 @@
    & {:keys [preview] :or {preview false}}]
   (let [unsigned-token                       (embed/unsign token)
         dashboard-id                         (embed/get-in-unsigned-token-or-throw unsigned-token [:resource :dashboard])
-        _                                    (when-not preview (check-embedding-enabled-for-card dashboard-id))
+        _                                    (when-not preview (check-embedding-enabled-for-dashboard dashboard-id))
         slug-token-params                    (embed/get-in-unsigned-token-or-throw unsigned-token [:params])
         {parameters       :parameters
          embedding-params :embedding_params} (t2/select-one :model/Dashboard :id dashboard-id)

--- a/src/metabase/api/embed/common.clj
+++ b/src/metabase/api/embed/common.clj
@@ -414,44 +414,45 @@
 
 (defn dashboard-param-values
   "Common implementation for fetching parameter values for embedding and preview-embedding."
-  [token searched-param-id prefix id-query-params]
-  (let [unsigned-token                       (embed/unsign token)
-        dashboard-id                         (embed/get-in-unsigned-token-or-throw unsigned-token [:resource :dashboard])
-        _                                    (check-embedding-enabled-for-dashboard dashboard-id)
-        slug-token-params                    (embed/get-in-unsigned-token-or-throw unsigned-token [:params])
-        {parameters       :parameters
-         embedding-params :embedding_params} (t2/select-one :model/Dashboard :id dashboard-id)
-        id->slug                             (into {} (map (juxt :id :slug) parameters))
-        slug->id                             (into {} (map (juxt :slug :id) parameters))
-        searched-param-slug                  (get id->slug searched-param-id)]
-    (try
-      ;; you can only search for values of a parameter if it is ENABLED and NOT PRESENT in the JWT.
-      (when-not (= (get embedding-params (keyword searched-param-slug)) "enabled")
-        (throw (ex-info (tru "Cannot search for values: {0} is not an enabled parameter." (pr-str searched-param-slug))
-                        {:status-code 400})))
-      (when (get slug-token-params (keyword searched-param-slug))
-        (throw (ex-info (tru "You can''t specify a value for {0} if it's already set in the JWT." (pr-str searched-param-slug))
-                        {:status-code 400})))
-      ;; ok, at this point we can run the query
-      (let [merged-id-params (param-values-merged-params id->slug slug->id embedding-params slug-token-params id-query-params)]
-        (try
-          (binding [api/*current-user-permissions-set* (atom #{"/"})
-                    api/*is-superuser?*                 true]
-            (api.dashboard/param-values (t2/select-one :model/Dashboard :id dashboard-id) searched-param-id merged-id-params prefix))
-          (catch Throwable e
-            (throw (ex-info (.getMessage e)
-                            {:merged-id-params merged-id-params}
-                            e)))))
-      (catch Throwable e
-        (let [e (ex-info (.getMessage e)
-                         {:dashboard-id        dashboard-id
-                          :dashboard-params    parameters
-                          :allowed-param-slugs embedding-params
-                          :slug->id            slug->id
-                          :id->slug            id->slug
-                          :param-id            searched-param-id
-                          :param-slug          searched-param-slug
-                          :token-params        slug-token-params}
-                         e)]
-          (log/errorf e "Chain filter error\n%s" (u/pprint-to-str (u/all-ex-data e)))
-          (throw e))))))
+  [token prefix id-query-params searched-param-id
+   & {:keys [preview] :or {preview false}}]
+  (let [unsigned-token (embed/unsign token)
+        dashboard-id   (embed/get-in-unsigned-token-or-throw unsigned-token [:resource :dashboard])]
+    (when-not preview (check-embedding-enabled-for-card dashboard-id))
+    (let [slug-token-params                    (embed/get-in-unsigned-token-or-throw unsigned-token [:params])
+          {parameters       :parameters
+           embedding-params :embedding_params} (t2/select-one :model/Dashboard :id dashboard-id)
+          id->slug                             (into {} (map (juxt :id :slug) parameters))
+          slug->id                             (into {} (map (juxt :slug :id) parameters))
+          searched-param-slug                  (get id->slug searched-param-id)]
+      (try
+        ;; you can only search for values of a parameter if it is ENABLED and NOT PRESENT in the JWT.
+        (when-not (= (get embedding-params (keyword searched-param-slug)) "enabled")
+          (throw (ex-info (tru "Cannot search for values: {0} is not an enabled parameter." (pr-str searched-param-slug))
+                          {:status-code 400})))
+        (when (get slug-token-params (keyword searched-param-slug))
+          (throw (ex-info (tru "You can''t specify a value for {0} if it's already set in the JWT." (pr-str searched-param-slug))
+                          {:status-code 400})))
+        ;; ok, at this point we can run the query
+        (let [merged-id-params (param-values-merged-params id->slug slug->id embedding-params slug-token-params id-query-params)]
+          (try
+            (binding [api/*current-user-permissions-set* (atom #{"/"})
+                      api/*is-superuser?*                true]
+              (api.dashboard/param-values (t2/select-one :model/Dashboard :id dashboard-id) searched-param-id merged-id-params prefix))
+            (catch Throwable e
+              (throw (ex-info (.getMessage e)
+                              {:merged-id-params merged-id-params}
+                              e)))))
+        (catch Throwable e
+          (let [e (ex-info (.getMessage e)
+                           {:dashboard-id        dashboard-id
+                            :dashboard-params    parameters
+                            :allowed-param-slugs embedding-params
+                            :slug->id            slug->id
+                            :id->slug            id->slug
+                            :param-id            searched-param-id
+                            :param-slug          searched-param-slug
+                            :token-params        slug-token-params}
+                           e)]
+            (log/errorf e "Chain filter error\n%s" (u/pprint-to-str (u/all-ex-data e)))
+            (throw e)))))))

--- a/src/metabase/api/preview_embed.clj
+++ b/src/metabase/api/preview_embed.clj
@@ -59,7 +59,7 @@
 (api/defendpoint GET "/dashboard/:token/params/:param-key/values"
   "Embedded version of chain filter values endpoint."
   [token param-key :as {:keys [query-params]}]
-  (api.embed.common/dashboard-param-values token param-key nil query-params))
+  (api.embed.common/dashboard-param-values token param-key nil query-params :preview true))
 
 (api/defendpoint GET "/dashboard/:token/dashcard/:dashcard-id/card/:card-id"
   "Fetch the results of running a Card belonging to a Dashboard you're considering embedding with JWT `token`."

--- a/src/metabase/api/preview_embed.clj
+++ b/src/metabase/api/preview_embed.clj
@@ -59,7 +59,7 @@
 (api/defendpoint GET "/dashboard/:token/params/:param-key/values"
   "Embedded version of chain filter values endpoint."
   [token param-key :as {:keys [query-params]}]
-  (api.embed.common/dashboard-param-values token param-key nil query-params :preview true))
+  (api.embed.common/dashboard-param-values token param-key nil query-params {:preview true}))
 
 (api/defendpoint GET "/dashboard/:token/dashcard/:dashcard-id/card/:card-id"
   "Fetch the results of running a Card belonging to a Dashboard you're considering embedding with JWT `token`."

--- a/test/metabase/api/preview_embed_test.clj
+++ b/test/metabase/api/preview_embed_test.clj
@@ -567,7 +567,7 @@
   (testing "embedding with parameter that has source is a static list"
     (with-embedding-enabled-and-new-secret-key
       (api.dashboard-test/with-chain-filter-fixtures [{:keys [dashboard]}]
-        (t2/update! Dashboard (u/the-id dashboard) {:enable_embedding true
+        (t2/update! Dashboard (u/the-id dashboard) {:enable_embedding false ;; works without enabling embedding on the dashboard (#44962)
                                                     :embedding_params {"static_category"       "enabled"
                                                                        "static_category_label" "enabled"}})
         (let [signed-token (dash-token dashboard)


### PR DESCRIPTION
Fixes: #44962

Prior, a common util fn used both in the embed and preview_embed endpoints was causing the preview_embed to error out
when fetching dashboard parameter values because it was checking if embedding was enabled. This check is needed for
the normal embedding endpoints, but we want the preview embed endpoints to work without needing to publish the
dashboard first.