### PR TITLE
Avoid loading test data that has already been loaded

### DIFF
--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -54,6 +54,11 @@ title: Driver interface changelog
   Honey SQL version) has been removed; replace all usages with the two-arity version. Honey SQL 2 has been the only
   supported version since Metabase 0.49.0.
 
+- The `:skip-drop-db?` option sometimes passed to methods for loading and destroying test data is no longer passed,
+  you can remove code that checks for it. Test data code is now better about avoiding unneeded/redundant calls to
+  `metabase.test.data.interface/create-db!`, so test data loading code should not need to call `DROP DATABASE IF
+  EXISTS` before loading test data.
+
 ## Metabase 0.50.0
 
 - The Metabase `metabase.mbql.*` namespaces have been moved to `metabase.legacy-mbql.*`. You probably didn't need to

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/models_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/models_test.clj
@@ -6,14 +6,18 @@
    [metabase-enterprise.serialization.v2.models :as serdes.models]
    [metabase.models.serialization :as serdes]))
 
-(deftest every-model-is-supported-test
+(deftest ^:parallel every-model-is-supported-test
   (testing "Serialization support\n"
     (testing "We know about every model"
-      (is (= (set (concat serdes.models/exported-models
-                          serdes.models/inlined-models
-                          serdes.models/excluded-models))
-             (set (map name (v2.entity-ids/toucan-models))))))
+      (let [known-models (set (concat serdes.models/exported-models
+                                      serdes.models/inlined-models
+                                      serdes.models/excluded-models))]
+        (doseq [model (v2.entity-ids/toucan-models)]
+          (testing model
+            (is (contains? known-models (name model)))))))))
 
+(deftest ^:parallel every-model-is-supported-test-2
+  (testing "Serialization support\n"
     (let [should-have-entity-id (set (concat serdes.models/data-model serdes.models/content))
           excluded              (set serdes.models/excluded-models)]
       (doseq [model (v2.entity-ids/toucan-models)]

--- a/modules/drivers/mongo/test/metabase/test/data/mongo.clj
+++ b/modules/drivers/mongo/test/metabase/test/data/mongo.clj
@@ -61,9 +61,7 @@
   false)
 
 (defmethod tx/create-db! :mongo
-  [driver {:keys [table-definitions], :as dbdef} & {:keys [skip-drop-db?], :or {skip-drop-db? false}}]
-  (when-not skip-drop-db?
-    (destroy-db! driver dbdef))
+  [driver {:keys [table-definitions], :as dbdef} & _options]
   (mongo.connection/with-mongo-database [^MongoDatabase db (tx/dbdef->connection-details driver :db dbdef)]
     (doseq [{:keys [field-definitions table-name rows]} table-definitions]
       (doseq [{:keys [field-name indexed?]} field-definitions]

--- a/test/metabase/driver/sql_jdbc/connection_test.clj
+++ b/test/metabase/driver/sql_jdbc/connection_test.clj
@@ -35,7 +35,7 @@
 (use-fixtures :once (fixtures/initialize :db))
 (use-fixtures :once ssh-test/do-with-mock-servers)
 
-(deftest can-connect-with-details?-test
+(deftest ^:parallel can-connect-with-details?-test
   (testing "Should not be able to connect without setting h2/*allow-testing-h2-connections*"
     (is (not (driver.u/can-connect-with-details? :h2 (:details (data/db))))))
   (binding [h2/*allow-testing-h2-connections* true]

--- a/test/metabase/query_processor/preprocess_test.clj
+++ b/test/metabase/query_processor/preprocess_test.clj
@@ -5,7 +5,8 @@
    [metabase.driver :as driver]
    [metabase.query-processor :as qp]
    [metabase.query-processor.preprocess :as qp.preprocess]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.test.data.interface :as tx]))
 
 (deftest preprocess-caching-test
   (testing "`preprocess` should work the same even if query has cached results (#18579)"
@@ -39,6 +40,16 @@
                    (qp.preprocess/preprocess query)))))))))
 
 (driver/register! ::custom-escape-spaces-to-underscores :parent :h2)
+
+(defmethod tx/create-db! ::custom-escape-spaces-to-underscores
+  [& _]
+  ;; no-op since we should be able to reuse the data from H2 tests
+  nil)
+
+(defmethod tx/destroy-db! ::custom-escape-spaces-to-underscores
+  [& _]
+  ;; no-op since we don't want to stomp on data used by H2 tests
+  nil)
 
 (defmethod driver/escape-alias ::custom-escape-spaces-to-underscores
   [driver field-alias]

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -359,8 +359,7 @@
   and load the appropriate data. (This refers to creating the actual *DBMS* database itself, *not* a Metabase
   `Database` object.)
 
-  Optional `options` as third param. Currently supported options include `skip-drop-db?`. If unspecified,
-  `skip-drop-db?` should default to `false`.
+  Optional key-value parameter `options`. Not currently used.
 
   This method should drop existing databases with the same name if applicable, unless the `skip-drop-db?` arg is
   truthy. This is to work around a scenario where the Postgres driver terminates the connection before dropping the DB
@@ -368,7 +367,7 @@
 
   This method is not expected to return anything; use `dbdef->connection-details` to get connection details for this
   database after you create it."
-  {:arglists '([driver database-definition & {:keys [skip-drop-db?]}])}
+  {:arglists '([driver database-definition & {:as _options}])}
   dispatch-on-driver-with-test-extensions
   :hierarchy #'driver/hierarchy)
 

--- a/test/metabase/test/data/sql/ddl.clj
+++ b/test/metabase/test/data/sql/ddl.clj
@@ -13,19 +13,18 @@
 (defmulti drop-db-ddl-statements
   "Return a sequence of DDL statements for dropping a DB using the multimethods in the SQL test extensons namespace, if
   applicable."
-  {:arglists '([driver dbdef & {:keys [skip-drop-db?]}])}
+  {:arglists '([driver dbdef & {:as _options}])}
   tx/dispatch-on-driver-with-test-extensions
   :hierarchy #'driver/hierarchy)
 
 (defmethod drop-db-ddl-statements :sql/test-extensions
-  [driver dbdef & {:keys [skip-drop-db?]}]
-  (when-not skip-drop-db?
-    (try
-      [(sql.tx/drop-db-if-exists-sql driver dbdef)]
-      (catch Throwable e
-        (throw (ex-info "Error generating DDL statements for dropping database"
-                        {:driver driver}
-                        e))))))
+  [driver dbdef & {:as _options}]
+  (try
+    [(sql.tx/drop-db-if-exists-sql driver dbdef)]
+    (catch Throwable e
+      (throw (ex-info "Error generating DDL statements for dropping database"
+                      {:driver driver}
+                      e)))))
 
 (defn create-db-ddl-statements
   "DDL statements to create the DB itself (does not include statements to drop the DB if it already exists).

--- a/test/metabase/test/data/sql_jdbc/load_data.clj
+++ b/test/metabase/test/data/sql_jdbc/load_data.clj
@@ -206,12 +206,10 @@
   (delay (edn/read-string (slurp "test_resources/load-durations.edn"))))
 
 (defn create-db!
-  "Default implementation of `create-db!` for SQL drivers."
-  {:arglists '([driver dbdef & {:keys [skip-drop-db?]}])}
+  "Default implementation of [[metabase.test.data.interface/create-db!]] for SQL drivers. Loads test data into a data
+  warehouse (creates tables/columns and inserts rows)."
+  {:arglists '([driver dbdef & {:as _options}])}
   [driver {:keys [table-definitions] :as dbdef} & options]
-  ;; first execute statements to drop the DB if needed (this will do nothing if `skip-drop-db?` is true)
-  (doseq [statement (apply ddl/drop-db-ddl-statements driver dbdef options)]
-    (execute/execute-sql! driver :server dbdef statement))
   ;; now execute statements to create the DB
   (doseq [statement (ddl/create-db-ddl-statements driver dbdef)]
     (execute/execute-sql! driver :server dbdef statement))

--- a/test/metabase/test_runner.clj
+++ b/test/metabase/test_runner.clj
@@ -70,7 +70,8 @@
     (hawk/find-tests directories options)))
 
 (def ^:private excluded-directories
-  ["classes"
+  [".clj-kondo/src"
+   "classes"
    "dev"
    "enterprise/backend/src"
    "local"

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -388,7 +388,7 @@
         (let [max-bytes 50]
           (with-redefs [; redef this because the UNIX filename limit is 255 bytes, so we can't test it in CI
                         upload/max-bytes (constantly max-bytes)]
-            (doseq [c ["a" "出"]]
+            (doseq [^String c ["a" "出"]]
               (let [long-csv-file-prefix (apply str (repeat (inc max-bytes) c))
                     char-size            (count (.getBytes c "UTF-8"))]
                 (with-upload-table! [table (card->table (upload-example-csv! :csv-file-prefix long-csv-file-prefix))]


### PR DESCRIPTION
Make sure we don't trash and then reload `test-data` multiple times during test runs.

CI performance improvement