### PR TITLE
Enable "Add to dashboard" for metrics v2

### DIFF
--- a/e2e/test/scenarios/metrics/metrics-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-dashboard.cy.spec.js
@@ -118,7 +118,7 @@ describe("scenarios > metrics > dashboard", () => {
       cy.log("Assert it's been added before the save");
       cy.location("pathname").should(
         "eq",
-        "/dashboard/1-orders-in-a-dashboard",
+        `/dashboard/${ORDERS_DASHBOARD_ID}-orders-in-a-dashboard`,
       );
       cy.location("hash").should("eq", `#add=${metricId}&edit`);
       cy.findByTestId("scalar-value").should("have.text", "18,760");

--- a/e2e/test/scenarios/metrics/metrics-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-dashboard.cy.spec.js
@@ -20,6 +20,8 @@ import {
   sidebar,
   undoToastList,
   visitDashboard,
+  openQuestionActions,
+  getDashboardCards,
 } from "e2e/support/helpers";
 
 const { ORDERS_ID, ORDERS, PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;
@@ -93,6 +95,39 @@ describe("scenarios > metrics > dashboard", () => {
     restore();
     cy.signInAsNormalUser();
     cy.intercept("POST", "/api/dataset").as("dataset");
+  });
+
+  it("should be possible to add metric to a dashboard via context menu (metabase#44220)", () => {
+    createQuestion(ORDERS_SCALAR_METRIC).then(({ body: { id: metricId } }) => {
+      cy.intercept("POST", "/api/dataset").as("dataset");
+      cy.visit(`/metric/${metricId}`);
+      cy.wait("@dataset");
+      cy.findByTestId("scalar-value").should("have.text", "18,760");
+
+      cy.log("Add metric to a dashboard via context menu");
+      openQuestionActions();
+      popover().findByTextEnsureVisible("Add to dashboard").click();
+      modal().within(() => {
+        cy.findByRole("heading", {
+          name: "Add this metric to a dashboard",
+        }).should("be.visible");
+        cy.findByText("Orders in a dashboard").click();
+        cy.button("Select").click();
+      });
+
+      cy.log("Assert it's been added before the save");
+      cy.location("pathname").should(
+        "eq",
+        "/dashboard/1-orders-in-a-dashboard",
+      );
+      cy.location("hash").should("eq", `#add=${metricId}&edit`);
+      cy.findByTestId("scalar-value").should("have.text", "18,760");
+
+      cy.log("Assert we can save the dashboard with the metric");
+      saveDashboard();
+      getDashboardCards().should("have.length", 2);
+      cy.findByTestId("scalar-value").should("have.text", "18,760");
+    });
   });
 
   it("should be possible to add metrics to a dashboard", () => {

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionActions.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionActions.tsx
@@ -186,7 +186,7 @@ export const QuestionActions = ({
     });
   }
 
-  if (isQuestion) {
+  if (isQuestion || isMetric) {
     extraButtons.push({
       title: t`Add to dashboard`,
       icon: "add_to_dash",


### PR DESCRIPTION
### What does this PR accomplish?
Fixes #44220 by enabling the "Add to dashboard" action in a card context menu.
![image](https://github.com/metabase/metabase/assets/31325167/a750a63e-4f06-40db-b944-3dba321fc38f)

It also reproduces that issue.
![image](https://github.com/metabase/metabase/assets/31325167/7ecad218-152a-466e-96ba-c5cd4cab88e0)

### Stress-test
50 x https://github.com/metabase/metabase/actions/runs/9853758208