### PR TITLE
Pass missing size to info icon

### DIFF
--- a/frontend/src/metabase/components/MetadataInfo/ColumnInfoIcon/ColumnInfoIcon.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/ColumnInfoIcon/ColumnInfoIcon.tsx
@@ -90,6 +90,7 @@ export function TableColumnInfoIcon({
           className={className}
           name="info_filled"
           hasDescription={Boolean(field.description)}
+          size={size}
         />
       </span>
     </TableColumnInfoPopover>


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/44869

### Description

Passes the missing size prop to the info icon which was causing a single pixel shift.

### How to verify


1. New sql question
2. Type `select * from orders where tax = {{t}}`
3. Change variable type to the field filter
4. Move mouse over the list of available fields


https://github.com/metabase/metabase/assets/1250185/f461701c-cf75-4be2-b15f-d49e41bd7f7a


