### PR TITLE
🍒 refactor: Tests depend on exported default polling value (#45264)

### DIFF
--- a/frontend/src/metabase/admin/tasks/components/Logs/Logs.tsx
+++ b/frontend/src/metabase/admin/tasks/components/Logs/Logs.tsx
@@ -19,7 +19,11 @@ interface LogsProps {
   pollingDurationMs?: number;
 }
 
-export const Logs = ({ pollingDurationMs = 1000 }: LogsProps) => {
+export const DEFAULT_POLLING_DURATION_MS = 1000;
+
+export const Logs = ({
+  pollingDurationMs = DEFAULT_POLLING_DURATION_MS,
+}: LogsProps) => {
   const [selectedProcessUUID, setSelectedProcessUUID] = useState("ALL");
   const { loaded, error, logs } = usePollingLogsQuery(pollingDurationMs);
   const processUUIDs = useMemo(() => getAllProcessUUIDs(logs), [logs]);

--- a/frontend/src/metabase/admin/tasks/components/Logs/Logs.unit.spec.tsx
+++ b/frontend/src/metabase/admin/tasks/components/Logs/Logs.unit.spec.tsx
@@ -3,7 +3,7 @@ import fetchMock from "fetch-mock";
 
 import { UtilApi } from "metabase/services";
 
-import { Logs } from "./Logs";
+import { Logs, DEFAULT_POLLING_DURATION_MS } from "./Logs";
 import { maybeMergeLogs } from "./utils";
 
 const log = {
@@ -49,7 +49,7 @@ describe("Logs", () => {
         expect(utilSpy).toHaveBeenCalledTimes(1),
       ]);
       act(() => {
-        jest.advanceTimersByTime(1100); // wait longer than polling period
+        jest.advanceTimersByTime(DEFAULT_POLLING_DURATION_MS + 100);
       });
       expect(utilSpy).toHaveBeenCalledTimes(1); // should not have been called
       act(() => {
@@ -61,7 +61,7 @@ describe("Logs", () => {
         ).toBeInTheDocument();
       });
       act(() => {
-        jest.advanceTimersByTime(1100);
+        jest.advanceTimersByTime(DEFAULT_POLLING_DURATION_MS + 100);
       });
       expect(utilSpy).toHaveBeenCalledTimes(2); // should have issued new request
     });
@@ -107,7 +107,7 @@ describe("Logs", () => {
 
       unmount();
       act(() => {
-        jest.advanceTimersByTime(1100); // wait longer than polling period
+        jest.advanceTimersByTime(DEFAULT_POLLING_DURATION_MS + 100);
       });
       expect(utilSpy).toHaveBeenCalledTimes(1);
     });
@@ -118,10 +118,10 @@ describe("Logs", () => {
       const originalLogs = [log];
       const shouldNotBeMerged = maybeMergeLogs(originalLogs, [log]);
       expect(shouldNotBeMerged).toBe(originalLogs);
-      const shoudlBeMerged = maybeMergeLogs(originalLogs, [
+      const shouldBeMerged = maybeMergeLogs(originalLogs, [
         { ...log, msg: "different" },
       ]);
-      expect(shoudlBeMerged).not.toBe(originalLogs);
+      expect(shouldBeMerged).not.toBe(originalLogs);
     });
   });
 });


### PR DESCRIPTION
Manual backport of [d237bb3](https://github.com/metabase/metabase/commit/d237bb315873c032b2608f4193f4abea2f289a20) (#45264)