### PR TITLE
restrict open redirects imitating no host in them

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -54,7 +54,6 @@
    [saml20-clj.core :as saml]
    [toucan2.core :as t2])
   (:import
-   (java.net URI URISyntaxException)
    (java.util Base64)))
 
 (set! *warn-on-reflection* true)
@@ -129,11 +128,6 @@
   (api/check (sso-settings/saml-enabled)
     [400 (tru "SAML has not been enabled and/or configured")]))
 
-(defn- has-host? [uri]
-  (try
-    (-> uri URI. .getHost some?)
-    (catch URISyntaxException _ false)))
-
 (defmethod sso.i/sso-get :saml
   ;; Initial call that will result in a redirect to the IDP along with information about how the IDP can authenticate
   ;; and redirect them back to us
@@ -145,9 +139,9 @@
                        (do
                          (log/warn "Warning: expected `redirect` param, but none is present")
                          (public-settings/site-url))
-                       (if (has-host? redirect)
-                         redirect
-                         (str (public-settings/site-url) redirect)))]
+                       (if (sso-utils/relative-uri? redirect)
+                         (str (public-settings/site-url) redirect)
+                         redirect))]
     (sso-utils/check-sso-redirect redirect-url)
     (try
       (let [idp-url      (sso-settings/saml-identity-provider-uri)

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -177,7 +177,8 @@
   (testing "Check that we prevent open redirects to untrusted sites"
     (with-jwt-default-setup
       (doseq [redirect-uri ["https://badsite.com"
-                            "//badsite.com"]]
+                            "//badsite.com"
+                            "https:///badsite.com"]]
         (is (= "Invalid redirect URL"
                (-> (client/client
                     :get 400 "/auth/sso" {:request-options {:redirect-strategy :none}}

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -421,7 +421,8 @@
                          "   "
                          "/"
                          "https://badsite.com"
-                         "//badsite.com"]]
+                         "//badsite.com"
+                         "https:///badsite.com"]]
       (testing (format "\nRelayState = %s" (pr-str relay-state))
         (with-saml-default-setup
           (do-with-some-validators-disabled
@@ -436,7 +437,8 @@
 
   (testing "if the RelayState leads us to the wrong host, avoid the open redirect (boat#160)"
     (doseq [redirect-url ["https://badsite.com"
-                          "//badsite.com"]]
+                          "//badsite.com"
+                          "https:///badsite.com"]]
       (with-saml-default-setup
         (mt/with-temporary-setting-values [site-url "http://localhost:3000"]
           (do-with-some-validators-disabled
@@ -444,7 +446,8 @@
              (let [get-response (client/client :get 400 "/auth/sso"
                                   {:request-options {:redirect-strategy :none}}
                                   :redirect redirect-url)]
-               (is (= "Invalid redirect URL" (:message get-response)))))))))))
+               (testing (format "\n%s should not redirect" redirect-url)
+                 (is (= "Invalid redirect URL" (:message get-response))))))))))))
 
 (deftest login-create-account-test
   (testing "A new account will be created for a SAML user we haven't seen before"

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/sso_utils_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/sso_utils_test.clj
@@ -10,7 +10,6 @@
        "/"
        "/test"
        "localhost"
-       ;; "localhost:3000" ; URI thinks `localhost` here is scheme
        "http://localhost:3000"
        "http://localhost:3000/dashboard/1-test-dashboard?currency=British%20Pound"))
 
@@ -19,6 +18,7 @@
        "http://example.com"
        "//example.com"
        "not a url"
+       "localhost:3000" ; URI thinks `localhost` here is scheme
        "http://localhost:3000?a=not a param"))))
 
 (deftest create-new-sso-user-test

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/sso_utils_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/sso_utils_test.clj
@@ -10,7 +10,7 @@
        "/"
        "/test"
        "localhost"
-       "localhost:3000"
+       ;; "localhost:3000" ; URI thinks `localhost` here is scheme
        "http://localhost:3000"
        "http://localhost:3000/dashboard/1-test-dashboard?currency=British%20Pound"))
 


### PR DESCRIPTION
This fixes case like `redirect_to=https:///google.com`, which URI thinks has no host, but browsers have no problem just dropping one slash like it's no big deal.

There is one thing about current logic which bothers me a little bit: we're appending host if url is not relative and then check if it's conforming. Maybe it should work the other way: just append the host and that's it? This way we need to check that urls we generate for `sso-get` are always relative, but I'm pretty sure that it should be this way.

I guess I could be missing a part of logic somewhere, but it feels like checking if something is broken is way too prone for errors, it's better to just shut the door completely.