### PR TITLE
[serdes] allow entity ids in targets

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/api.clj
@@ -133,8 +133,8 @@
         :query-params}]
   {dirname          (mu/with [:maybe string?]
                              {:description "name of directory and archive file (default: `<instance-name>-<YYYY-MM-dd_HH-mm>`)"})
-   collection       (mu/with [:maybe (ms/QueryVectorOf ms/PositiveInt)]
-                             {:description "collections' db ids to serialize"})
+   collection       (mu/with [:maybe (ms/QueryVectorOf [:or ms/PositiveInt ms/NonBlankString])]
+                             {:description "collections' db ids/entity-ids to serialize"})
    all_collections  (mu/with [:maybe ms/BooleanValue]
                              {:default     true
                               :description "Serialize all collections (`true` unless you specify `collection`)"})

--- a/enterprise/backend/src/metabase_enterprise/serialization/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/api.clj
@@ -133,7 +133,10 @@
         :query-params}]
   {dirname          (mu/with [:maybe string?]
                              {:description "name of directory and archive file (default: `<instance-name>-<YYYY-MM-dd_HH-mm>`)"})
-   collection       (mu/with [:maybe (ms/QueryVectorOf [:or ms/PositiveInt ms/NonBlankString])]
+   collection       (mu/with [:maybe (ms/QueryVectorOf
+                                      [:or
+                                       ms/PositiveInt
+                                       [:re {:error/message "value must be string with `eid:<...>` prefix"} "^eid:.{21}$"]])]
                              {:description "collections' db ids/entity-ids to serialize"})
    all_collections  (mu/with [:maybe ms/BooleanValue]
                              {:default     true

--- a/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
@@ -75,7 +75,7 @@
 
               (testing "We can export that collection using entity id"
                 (let [f (mt/user-http-request :crowberto :post 200 "ee/serialization/export" {}
-                                              :collection (:entity_id coll) :data_model false :settings false)]
+                                              :collection (str "eid:" (:entity_id coll)) :data_model false :settings false)]
                   (is (= #{:log :dir :dashboard :card :collection}
                          (tar-file-types f)))))
 

--- a/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
@@ -58,7 +58,7 @@
       (mt/with-premium-features #{:serialization}
         (testing "POST /api/ee/serialization/export"
           (mt/with-empty-h2-app-db
-            (mt/with-temp [Collection    coll  {}
+            (mt/with-temp [Collection    coll  {:name "API Collection"}
                            Dashboard     _     {:collection_id (:id coll)}
                            Card          _     {:collection_id (:id coll)}]
               (testing "API respects parameters"
@@ -70,6 +70,12 @@
               (testing "We can export just a single collection"
                 (let [f (mt/user-http-request :crowberto :post 200 "ee/serialization/export" {}
                                               :collection (:id coll) :data_model false :settings false)]
+                  (is (= #{:log :dir :dashboard :card :collection}
+                         (tar-file-types f)))))
+
+              (testing "We can export that collection using entity id"
+                (let [f (mt/user-http-request :crowberto :post 200 "ee/serialization/export" {}
+                                              :collection (:entity_id coll) :data_model false :settings false)]
                   (is (= #{:log :dir :dashboard :card :collection}
                          (tar-file-types f)))))
 

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -1707,3 +1707,15 @@
       (let [ser (extract/extract {:no-settings   true
                                   :no-data-model true})]
         (is (= #{@trash-eid} (by-model "Collection" ser)))))))
+
+(deftest entity-id-in-targets-test
+  (mt/with-temp [Collection c {:name "Top-Level Collection"}]
+    (testing "Conversion from eid to id works"
+      (is (= (:id c)
+             (serdes/eid->id "Collection" (:entity_id c)))))
+    (testing "Extracting by entity id works"
+      (let [ser (extract/extract {:targets       [["Collection" (:entity_id c)]]
+                                  :no-settings   true
+                                  :no-data-model true})]
+        (is (= #{(:entity_id c)}
+               (by-model "Collection" ser)))))))

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -208,7 +208,11 @@
   {:doc "Serialize Metabase instance into directory at `path`."
    :arg-spec [["-c" "--collection ID"            "Export only specified ID(s). Use commas to separate multiple IDs."
                :id        :collection-ids
-               :parse-fn  (fn [raw-string] (map parse-long (str/split raw-string #"\s*,\s*")))]
+               :parse-fn  (fn [raw-string] (->> (str/split raw-string #"\s*,\s*")
+                                                (map (fn [v]
+                                                       (if (re-matches #"\d+" v)
+                                                         (parse-long v)
+                                                         v)))))]
               ["-C" "--no-collections"           "Do not export any content in collections."]
               ["-S" "--no-settings"              "Do not export settings.yaml"]
               ["-D" "--no-data-model"            "Do not export any data model entities; useful for subsequent exports."]

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -206,13 +206,13 @@
 
 (defn ^:command export
   {:doc "Serialize Metabase instance into directory at `path`."
-   :arg-spec [["-c" "--collection ID"            "Export only specified ID(s). Use commas to separate multiple IDs."
+   :arg-spec [["-c" "--collection ID"            "Export only specified ID(s). Use commas to separate multiple IDs. You can pass entity ids with `eid:<...>` as a prefix."
                :id        :collection-ids
                :parse-fn  (fn [raw-string] (->> (str/split raw-string #"\s*,\s*")
                                                 (map (fn [v]
-                                                       (if (re-matches #"\d+" v)
-                                                         (parse-long v)
-                                                         v)))))]
+                                                       (if (str/starts-with? v "eid:")
+                                                         v
+                                                         (parse-long v))))))]
               ["-C" "--no-collections"           "Do not export any content in collections."]
               ["-S" "--no-settings"              "Do not export settings.yaml"]
               ["-D" "--no-data-model"            "Do not export any data model entities; useful for subsequent exports."]

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -82,6 +82,18 @@
 (defmethod entity-id :default [_ {:keys [entity_id]}]
   (str/trim entity_id))
 
+(defn eid->id
+  "Given model name and its entity id, returns it database-local id.
+
+  Is kind of reverse transformation to `entity-id` function defined here.
+
+  NOTE: Not implemented for `Database`, `Table` and `Field`, since those rely more on `path` than a single id. To be
+  done if a need arises."
+  [model-name eid]
+  (let [model (keyword "model" model-name)
+        pk    (first (t2/primary-keys model))]
+    (t2/select-one-fn pk [model pk] :entity_id eid)) )
+
 ;;; ## Hashing entities
 ;;; In the worst case, an entity is already present in two instances linked by serdes, and it doesn't have `entity_id`
 ;;; set because it existed before we added the column. If we write a migration to just generate random `entity_id`s on

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -91,8 +91,10 @@
   done if a need arises."
   [model-name eid]
   (let [model (keyword "model" model-name)
-        pk    (first (t2/primary-keys model))]
-    (t2/select-one-fn pk [model pk] :entity_id eid)) )
+        pk    (first (t2/primary-keys model))
+        eid   (cond-> eid
+                (str/starts-with? eid "eid:") (subs 4))]
+    (t2/select-one-fn pk [model pk] :entity_id eid)))
 
 ;;; ## Hashing entities
 ;;; In the worst case, an entity is already present in two instances linked by serdes, and it doesn't have `entity_id`

--- a/test/metabase/cmd_test.clj
+++ b/test/metabase/cmd_test.clj
@@ -53,8 +53,8 @@
        ["--collection" "123"]
        {:collection-ids [123]}
 
-       ["-c" "123, 456, ASDF"]
-       {:collection-ids [123 456 "ASDF"]}
+       ["-c" "123, 456, eid:qj0jT7SXwEUezz1wSjTAZ, nicht"]
+       {:collection-ids [123 456 "eid:qj0jT7SXwEUezz1wSjTAZ" nil]}
 
        ["-c" "123,456,789"]
        {:collection-ids [123 456 789]}

--- a/test/metabase/cmd_test.clj
+++ b/test/metabase/cmd_test.clj
@@ -53,8 +53,8 @@
        ["--collection" "123"]
        {:collection-ids [123]}
 
-       ["-c" "123, 456"]
-       {:collection-ids [123 456]}
+       ["-c" "123, 456, ASDF"]
+       {:collection-ids [123 456 "ASDF"]}
 
        ["-c" "123,456,789"]
        {:collection-ids [123 456 789]}


### PR DESCRIPTION
Fixes #45224

We're not accepting anything than Collection from outside (both CLI and API are explicitly only asking for collection ids), but it feels too fragile not to support this a bit more universally. It's not absolutely universal (see comment for `eid->id`), but I think that's good enough for now.