### PR TITLE
fix flaky unit test by removing un-needed waitForElementToBeRemoved

### DIFF
--- a/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
@@ -204,8 +204,6 @@ describe("EmbedHomepage (OSS)", () => {
         source: "embedding-homepage-dismiss",
       });
 
-      await waitForElementToBeRemoved(() => queryFeedbackModal());
-
       expect(
         screen.getByText("Your feedback was submitted, thank you."),
       ).toBeInTheDocument();


### PR DESCRIPTION
https://metaboat.slack.com/archives/C5XHN8GLW/p1720521443315479

### Description

That waitForElementToBeRemoved is not needed as the test already waits for two http requests.

Stress test in CI: https://github.com/metabase/metabase/actions/runs/9857832684

### How to verify

This is how I reproduced the flakiness and how I reproed that's not happening with this change.

- apply the diff attached
- run `yarn jest --maxWorkers 12` on one terminal (to max CPU usage)
- run the stress test

```
diff --git a/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx b/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
index c018a68660..2e9221039d 100644
--- a/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
@@ -9,6 +9,13 @@ import {
   getLastFeedbackCall,
 } from "./setup";
 
+const stressTest = (n = 100) =>
+  test.each(
+    Array(n)
+      .fill(null)
+      .map((_, i) => i),
+  );
+
 describe("EmbedHomepage (OSS)", () => {
   it("should default to the static tab for OSS builds", () => {
     setup();
@@ -180,33 +187,39 @@ describe("EmbedHomepage (OSS)", () => {
       ).not.toBeInTheDocument();
     });
 
-    it("should send feedback when submitting the modal", async () => {
-      await setupForFeedbackModal();
+    stressTest(20)(
+      "should send feedback when submitting the modal",
+      async () => {
+        await setupForFeedbackModal();
 
-      await userEvent.type(
-        screen.getByLabelText("Feedback"),
-        "I had an issue with X",
-      );
+        await userEvent.type(
+          screen.getByLabelText("Feedback"),
+          "I had an issue with X",
+        );
 
-      await userEvent.type(screen.getByLabelText("Email"), "user@example.org");
+        await userEvent.type(
+          screen.getByLabelText("Email"),
+          "user@example.org",
+        );
 
-      await userEvent.click(screen.getByText("Send"));
+        await userEvent.click(screen.getByText("Send"));
 
-      const lastCall = getLastHomepageSettingSettingCall();
-      const body = await lastCall?.request?.json();
-      expect(body).toEqual({ value: "dismissed-run-into-issues" });
+        const lastCall = getLastHomepageSettingSettingCall();
+        const body = await lastCall?.request?.json();
+        expect(body).toEqual({ value: "dismissed-run-into-issues" });
 
-      const feedbackBody = await getLastFeedbackCall()?.request?.json();
+        const feedbackBody = await getLastFeedbackCall()?.request?.json();
 
-      expect(feedbackBody).toEqual({
-        comments: "I had an issue with X",
-        email: "user@example.org",
-        source: "embedding-homepage-dismiss",
-      });
+        expect(feedbackBody).toEqual({
+          comments: "I had an issue with X",
+          email: "user@example.org",
+          source: "embedding-homepage-dismiss",
+        });
 
-      expect(
-        screen.getByText("Your feedback was submitted, thank you."),
-      ).toBeInTheDocument();
-    });
+        expect(
+          screen.getByText("Your feedback was submitted, thank you."),
+        ).toBeInTheDocument();
+      },
+    );
   });
 });
```
