### PR TITLE
Make import work on a fresh install

### DIFF
--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -188,9 +188,9 @@
       (log/error e "Metabase Initialization FAILED")
       (System/exit 1))))
 
-(defn- run-cmd [cmd args]
+(defn- run-cmd [cmd init-fn args]
   (classloader/require 'metabase.cmd)
-  ((resolve 'metabase.cmd/run-cmd) cmd args))
+  ((resolve 'metabase.cmd/run-cmd) cmd init-fn args))
 
 ;;; -------------------------------------------------- Tracing -------------------------------------------------------
 
@@ -212,5 +212,5 @@
   [& [cmd & args]]
   (maybe-enable-tracing)
   (if cmd
-    (run-cmd cmd args) ; run a command like `java -jar metabase.jar migrate release-locks` or `clojure -M:run migrate release-locks`
+    (run-cmd cmd init! args) ; run a command like `java -jar metabase.jar migrate release-locks` or `clojure -M:run migrate release-locks`
     (start-normally))) ; with no command line args just start Metabase normally


### PR DESCRIPTION
This introduces a new metadata on commands, `:requires-init`. If set, we'll run `metabase.core/init!` before running the command. `init!` will initialize the database and run our normal startup, though it won't actually start the Metabase server.

This allows you to use

```
env MB_CONFIG_FILE_PATH=... java -jar metabase.jar import /my/metabase/export
```

We'll run the normal init process (creating the internal user, loading from the config file, etc), then run the command.

On my machine this adds about 2-3 seconds to the time it takes to run an `import`.