### PR TITLE
Reduce parameter churn when loading a synced parameter list

### DIFF
--- a/frontend/src/metabase/hooks/use-synced-query-string.ts
+++ b/frontend/src/metabase/hooks/use-synced-query-string.ts
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { useUnmount } from "react-use";
 
 import { IS_EMBED_PREVIEW } from "metabase/lib/embed";
 import { buildSearchString } from "metabase/lib/urls";
@@ -26,23 +27,23 @@ export function useSyncedQueryString(object: Record<string, any>) {
         window.location.pathname + searchString + window.location.hash,
       );
     }
-
-    return () => {
-      // Remove every previously-synced keys from the query string when the component is unmounted.
-      // This is a workaround to clear the parameter list state when [SyncedParametersList] unmounts.
-      const searchString = buildSearchString({
-        filterFn: key => !(key in object),
-      });
-
-      if (searchString !== window.location.search) {
-        history.replaceState(
-          null,
-          document.title,
-          window.location.pathname + searchString + window.location.hash,
-        );
-      }
-    };
   }, [object]);
+
+  useUnmount(() => {
+    // Remove every previously-synced keys from the query string when the component is unmounted.
+    // This is a workaround to clear the parameter list state when [SyncedParametersList] unmounts.
+    const searchString = buildSearchString({
+      filterFn: key => !(key in object),
+    });
+
+    if (searchString !== window.location.search) {
+      history.replaceState(
+        null,
+        document.title,
+        window.location.pathname + searchString + window.location.hash,
+      );
+    }
+  });
 }
 
 const QUERY_PARAMS_ALLOW_LIST = ["objectId", "tab"];

--- a/frontend/src/metabase/hooks/use-synced-query-string.ts
+++ b/frontend/src/metabase/hooks/use-synced-query-string.ts
@@ -1,11 +1,10 @@
-import { useEffect } from "react";
-import { useUnmount } from "react-use";
+import { useDeepCompareEffect } from "react-use";
 
 import { IS_EMBED_PREVIEW } from "metabase/lib/embed";
 import { buildSearchString } from "metabase/lib/urls";
 
 export function useSyncedQueryString(object: Record<string, any>) {
-  useEffect(() => {
+  useDeepCompareEffect(() => {
     /**
      * We don't want to sync the query string to the URL because when previewing,
      * this changes the URL of the iframe by appending the query string to the src.
@@ -27,23 +26,23 @@ export function useSyncedQueryString(object: Record<string, any>) {
         window.location.pathname + searchString + window.location.hash,
       );
     }
+
+    return () => {
+      // Remove every previously-synced keys from the query string when the component is unmounted.
+      // This is a workaround to clear the parameter list state when [SyncedParametersList] unmounts.
+      const searchString = buildSearchString({
+        filterFn: key => !(key in object),
+      });
+
+      if (searchString !== window.location.search) {
+        history.replaceState(
+          null,
+          document.title,
+          window.location.pathname + searchString + window.location.hash,
+        );
+      }
+    };
   }, [object]);
-
-  useUnmount(() => {
-    // Remove every previously-synced keys from the query string when the component is unmounted.
-    // This is a workaround to clear the parameter list state when [SyncedParametersList] unmounts.
-    const searchString = buildSearchString({
-      filterFn: key => !(key in object),
-    });
-
-    if (searchString !== window.location.search) {
-      history.replaceState(
-        null,
-        document.title,
-        window.location.pathname + searchString + window.location.hash,
-      );
-    }
-  });
 }
 
 const QUERY_PARAMS_ALLOW_LIST = ["objectId", "tab"];

--- a/frontend/src/metabase/hooks/use-synced-query-string.unit.spec.ts
+++ b/frontend/src/metabase/hooks/use-synced-query-string.unit.spec.ts
@@ -1,0 +1,62 @@
+import { renderHook } from "@testing-library/react-hooks";
+
+import { useSyncedQueryString } from "./use-synced-query-string";
+
+describe("useSyncedQueryString", () => {
+  it("should update the query string when the object changes", () => {
+    const spy = jest.spyOn(history, "replaceState");
+    let object: object = { foo: 42 };
+    const { rerender, unmount } = renderHook(() =>
+      useSyncedQueryString(object),
+    );
+
+    expect(spy).not.toHaveBeenCalledWith("/");
+    expect(spy).toHaveBeenLastCalledWith(null, "", "/?foo=42");
+
+    object = { foo: 42, bar: "baz" };
+    rerender();
+    expect(spy).not.toHaveBeenCalledWith("/");
+    expect(spy).toHaveBeenLastCalledWith(null, "", "/?foo=42&bar=baz");
+
+    unmount();
+    expect(spy).toHaveBeenLastCalledWith(null, "", "/");
+  });
+
+  it("should override previous values with the same key", () => {
+    const spy = jest.spyOn(history, "replaceState");
+    let object: object = { foo: 42 };
+    const { rerender, unmount } = renderHook(() =>
+      useSyncedQueryString(object),
+    );
+
+    expect(spy).not.toHaveBeenCalledWith("/");
+    expect(spy).toHaveBeenLastCalledWith(null, "", "/?foo=42");
+    object = { foo: 43 };
+
+    rerender();
+    expect(spy).not.toHaveBeenCalledWith("/");
+    expect(spy).toHaveBeenLastCalledWith(null, "", "/?foo=43");
+
+    unmount();
+    expect(spy).toHaveBeenLastCalledWith(null, "", "/");
+  });
+
+  it("should respect original query parameters when the object changes or when unmounting", () => {
+    history.replaceState(null, "", "http://localhost/?objectId=123");
+
+    const spy = jest.spyOn(history, "replaceState");
+    let object: object = { foo: 42 };
+    const { rerender, unmount } = renderHook(() =>
+      useSyncedQueryString(object),
+    );
+
+    expect(spy).toHaveBeenLastCalledWith(null, "", "/?objectId=123&foo=42");
+    object = { foo: 43 };
+
+    rerender();
+    expect(spy).toHaveBeenLastCalledWith(null, "", "/?objectId=123&foo=43");
+
+    unmount();
+    expect(spy).toHaveBeenLastCalledWith(null, "", "/?objectId=123");
+  });
+});


### PR DESCRIPTION
When loading a saved question that has parameters with default values, the initial page load causes search parameters to be added to the url. Subsequent edits to the parameters also update the search parameters.

The way this was set up using `useEffect` was causing a lot of back and forth between adding an removing the parameters. On every render of the component the search parameters were first removed and then added again. This causes the url bar to flicker.

This change decouples the updating of the search parameters from the removing of search parameters on unmount, causing significantly less calls to the `history.replaceState`.

All functionality should remain the same and tests are already in place.

### Before
<img width="868" alt="Screenshot 2024-07-09 at 17 08 17" src="https://github.com/metabase/metabase/assets/1250185/448e4b79-e258-493b-9755-75a18d1e7760">

### After 
<img width="824" alt="Screenshot 2024-07-09 at 17 08 52" src="https://github.com/metabase/metabase/assets/1250185/589ccf1d-38cb-4f49-adb7-a9d3584808b3">

## To test this
1. Create a native query with a parameter
2. Add a default value to the parameter
3. Navigate to the question and keep an eye on the url, it should no longer flicker
