### PR TITLE
fix: Reduce bcrypt work factor when running tests

### DIFF
--- a/src/metabase/util/password.clj
+++ b/src/metabase/util/password.clj
@@ -88,6 +88,12 @@
        (or (= (config/config-kw :mb-password-complexity) :weak)
            (is-uncommon? password))))
 
+(def ^:private default-bcrypt-work-factor
+  "Default work factor used for hashing passwords with BCrypt. Intentionally reduced for tests to reduce testing time."
+  (if config/is-test?
+    4
+    10))
+
 ;; copied from cemerick.friend.credentials EPL v1.0 license
 (defn hash-bcrypt
   "Hashes a given plaintext password using bcrypt and an optional
@@ -97,7 +103,7 @@
   [password & {:keys [work-factor]}]
   (BCrypt/hashpw password (if work-factor
                             (BCrypt/gensalt work-factor)
-                            (BCrypt/gensalt))))
+                            (BCrypt/gensalt default-bcrypt-work-factor))))
 
 (defn bcrypt-verify
   "Returns true if the plaintext [password] corresponds to [hash],


### PR DESCRIPTION
### Description

Preliminary analysis showed that this redundant work is responsible for ~15% of driver test runtime (and possibly other testing time as well). @camsaul has suggested this trivial approach to address this. We reduce the work factor to 4 which is the minimal that the underlying BCrypt library accepts. In terms of the time to hash a single password the difference is the following:

| Factor | Time to hash 1 password |
|---|---|
| 10 | 75 ms |
| 4 | 1.5 ms |

Thus, decreasing the factor in tests to 4 should remove its impact on test times almost completely.

Not sure if any tests are necessary here?