### PR TITLE
Fixes the formatting

### DIFF
--- a/src/metabase/db/liquibase.clj
+++ b/src/metabase/db/liquibase.clj
@@ -258,7 +258,7 @@
   (let [done? #(empty? (locked-instances))]
     (if (done?)
       :none
-      (do (log/infof "Waiting for migration lock(s) to be released (max %.1f secs)" (/ timeout-ms 1000))
+      (do (log/infof "Waiting for migration lock(s) to be released (max %.1f secs)" (double (/ timeout-ms 1000)))
           (wait-until done? sleep-ms timeout-ms)))))
 
 (defn- liquibase->url [^Liquibase liquibase]


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/45298

Before
====

```
2024-07-04 15:54:39,084 INFO metabase.server :: Shutting Down Embedded Jetty Webserver
Exception in thread "Thread-9" java.util.IllegalFormatConversionException: f != java.lang.Long
2024-07-04 15:54:39,122 WARN db.liquibase :: (#object[liquibase.Liquibase 0x2b7e6614 liquibase.Liquibase@2b7e6614])
	at java.base/java.util.Formatter$FormatSpecifier.failConversion(Unknown Source)
	at java.base/java.util.Formatter$FormatSpecifier.printFloat(Unknown Source)
	at java.base/java.util.Formatter$FormatSpecifier.print(Unknown Source)
	at java.base/java.util.Formatter.format(Unknown Source)
	at java.base/java.util.Formatter.format(Unknown Source)
	at java.base/java.lang.String.format(Unknown Source)
	at clojure.core$format.invokeStatic(core.clj:5770)
	at clojure.core$format.doInvoke(core.clj:5764)
	at clojure.lang.RestFn.invoke(RestFn.java:423)
	at metabase.db.liquibase$wait_for_all_locks.invokeStatic(liquibase.clj:258)
	at metabase.db.liquibase$wait_for_all_locks.invoke(liquibase.clj:251)
	at metabase.db.setup$release_migration_locks_BANG_.invokeStatic(setup.clj:175)
	at metabase.db.setup$release_migration_locks_BANG_.invoke(setup.clj:170)
	at metabase.db$release_migration_locks_BANG_.invokeStatic(db.clj:91)
	at metabase.db$release_migration_locks_BANG_.invoke(db.clj:86)
	at metabase.core$destroy_BANG_.invokeStatic(core.clj:90)
	at metabase.core$destroy_BANG_.invoke(core.clj:81)
	at clojure.lang.AFn.run(AFn.java:22)
	at java.base/java.lang.Thread.run(Unknown Source)
```

And now it will correctly log

```
2024-07-09 16:04:28,345 INFO db.liquibase :: Waiting for migration lock(s) to be released (max 0.4 secs)
```

Why no tests?
====

There _is_ a test that would have caught this. And in fact running at the repl will catch it:

```clojure
liquibase=> (do (require 'clojure.test 'metabase.db.liquibase-test)
                (clojure.test/run-test metabase.db.liquibase-test/wait-for-all-locks-test))

Testing metabase.db.liquibase-test

ERROR in (wait-for-all-locks-test) (Formatter.java:4515)

:h2
 Will timeout if a lock is not released
expected: (= :timed-out (liquibase/wait-for-all-locks sleep-ms timeout-ms))
  actual: java.util.IllegalFormatConversionException: f != clojure.lang.Ratio
```

(note that ratios are exact so sometimes they become longs which is what you see in the original error message. Eg: `[(type (/ 3 2)) (type (/ 4 2))]` is `[clojure.lang.Ratio java.lang.Long]`) 

But this _passes_ in CI:

```
❯ clj -X:dev:test :only metabase.db.liquibase-test/wait-for-all-locks-test
Finding tests took 23.5 s.
Running 1 tests
Running before-run hooks...

Ran 1 tests in 1.461 seconds
3 assertions, 0 failures, 0 errors.
{:test 1, :pass 3, :fail 0, :error 0, :type :summary, :duration 1461.175042, :single-threaded 1}
Ran 0 tests in parallel, 1 single-threaded.
Finding and running tests took 25.0 s.
All tests passed.
Running after-run hooks...
```

And that's because the log level in testing is FATAL and this is an INFO level log.

Discussed ways to improve this like adding a null logger during CI but we aren't ready to increase CI times for that just yet.

