### PR TITLE
fix(sdk): remove the --force flag from npm installation guide

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/README.md
+++ b/enterprise/frontend/src/embedding-sdk/README.md
@@ -162,7 +162,7 @@ app.listen(PORT, () => {
 You can install Metabase Embedding SDK for React via npm:
 
 ```bash
-npm install @metabase/embedding-sdk-react --force
+npm install @metabase/embedding-sdk-react
 ```
 
 or using yarn:


### PR DESCRIPTION
Removes the `--force` flag from `npm install`.