### PR TITLE
fix object detail view is not scrollable on mobile

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.ts
@@ -1,6 +1,7 @@
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   createQuestion,
+  modal,
   popover,
   restore,
   type StructuredQuestionDetails,
@@ -34,6 +35,29 @@ describe("issue 43075", () => {
       expect(win.document.documentElement.scrollHeight).to.be.lte(
         win.document.documentElement.offsetHeight,
       );
+    });
+  });
+});
+
+describe("issue 41133", () => {
+  const questionDetails: StructuredQuestionDetails = {
+    query: {
+      "source-table": PRODUCTS_ID,
+    },
+  };
+  beforeEach(() => {
+    cy.viewport(600, 400);
+    restore();
+    cy.signInAsAdmin();
+    createQuestion(questionDetails, { visitQuestion: true });
+  });
+
+  it("object detail view should be scrollable on narrow screens (metabase#41133)", () => {
+    cy.findByTestId("detail-shortcut").eq(0).click();
+
+    modal().within(() => {
+      cy.findByText("Created At").scrollIntoView().should("be.visible");
+      cy.findByText("is connected to:").scrollIntoView().should("be.visible");
     });
   });
 });

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailWrapper.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailWrapper.styled.tsx
@@ -30,7 +30,7 @@ export const RootModal = styled(Modal)`
       height: calc(80vh - 4rem);
     }
 
-    height: calc(100vh - 8rem);
+    max-height: calc(100vh - 8rem);
   }
 
   ${ObjectDetailsTable} {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/41133

### Description

Fixes the object detail is not scrollable on mobile devices

### How to verify

- Open any table with a big number of columns
- Open an object detail for a row of this table
- Make your browser window narrow and ensure the scrolling inside the object details works

### Demo

https://github.com/metabase/metabase/assets/14301985/186e22f5-05b0-4a12-9d2f-d3ffbef3c05c

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
