### PR TITLE
docs - warning for mysql

### DIFF
--- a/docs/questions/query-builder/expressions-list.md
+++ b/docs/questions/query-builder/expressions-list.md
@@ -728,7 +728,7 @@ Example: `year("2021-03-25T12:52:37")` would return the year 2021 as an integer,
 
 ### Offset
 
-> The `Offset` function is currently unavailable for MySQL/MariaDB.
+> ⚠️ The `Offset` function is currently unavailable for MySQL/MariaDB.
 
 Returns the value of an expression in a different row. `Offset` can only be used in the query builder's Summarize step (you cannot use `Offset` to create a custom column).
 

--- a/docs/questions/query-builder/expressions/offset.md
+++ b/docs/questions/query-builder/expressions/offset.md
@@ -4,7 +4,7 @@ title: Offset
 
 # Offset
 
-> The `Offset` function is currently unavailable for MySQL/MariaDB.
+> ⚠️ The `Offset` function is currently unavailable for MySQL/MariaDB.
 
 The `Offset` function returns the value of an expression in a different row. `Offset` can only be used in the query builder's Summarize step (you cannot use `Offset` to create a custom column).
 


### PR DESCRIPTION
Add a warning symbol to a blockquote regarding `Offset`'s unavailability for MySQL. Stopgap until we get a more salient warning blockquote.