### PR TITLE
Add default value to report_card.last_used_at

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/serialize.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/serialize.clj
@@ -101,7 +101,7 @@
   "Removes unneeded fields that can either be reconstructed from context or are meaningless
    (eg. :created_at)."
   [entity]
-  (cond-> (dissoc entity :id :creator_id :created_at :updated_at :db_id :location
+  (cond-> (dissoc entity :id :creator_id :created_at :updated_at :db_id :location :last_used_at
                   :dashboard_id :fields_hash :personal_owner_id :made_public_by_id :collection_id
                   :pulse_id :result_metadata :action_id)
     (not *include-entity-id*)   (dissoc :entity_id)
@@ -212,6 +212,7 @@
 (defmethod serialize-one Card
   [card]
   (-> card
+
       (m/update-existing :table_id (partial fully-qualified-name Table))
       (update :database_id (partial fully-qualified-name Database))
       (m/update-existing :visualization_settings convert-viz-settings)))

--- a/enterprise/backend/src/metabase_enterprise/serialization/serialize.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/serialize.clj
@@ -212,7 +212,6 @@
 (defmethod serialize-one Card
   [card]
   (-> card
-
       (m/update-existing :table_id (partial fully-qualified-name Table))
       (update :database_id (partial fully-qualified-name Database))
       (m/update-existing :visualization_settings convert-viz-settings)))

--- a/enterprise/backend/test/metabase_enterprise/serialization/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/load_test.clj
@@ -295,6 +295,7 @@
   [entity _]
   entity)
 
+;; If this test fails after adding a new column, add the column to the list of columns in `metabase-enterprise.serialization.serialize/strip-crud`
 (deftest dump-load-entities-test
   (try
     ;; in case it already exists

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/-_XgVaPuz7MY8jlG0wSEC_question_performance.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/-_XgVaPuz7MY8jlG0wSEC_question_performance.yaml
@@ -74,6 +74,5 @@ serdes/meta:
   label: question_performance
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: vUNKNOWN (13e6090)
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/-fFVxT-GLz6WO41bvw-Ar_dashboards_without_recent_views.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/-fFVxT-GLz6WO41bvw-Ar_dashboards_without_recent_views.yaml
@@ -122,6 +122,5 @@ serdes/meta:
   label: dashboards_without_recent_views
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: vUNKNOWN (901f705)
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/-lNDM3tJmuL5ltGbX0oyT_activity_log.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/-lNDM3tJmuL5ltGbX0oyT_activity_log.yaml
@@ -302,6 +302,5 @@ serdes/meta:
   label: activity_log
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: null
 type: model

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/3CtVT_JDxNvMM5aFLtEHR_is_admin_.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/3CtVT_JDxNvMM5aFLtEHR_is_admin_.yaml
@@ -35,6 +35,5 @@ serdes/meta:
   label: is_admin_
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: null
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/4DlO-I7ry2OaVQy7-RGPU_median_load_time_in_seconds_for_questions_in_this_dashboard.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/4DlO-I7ry2OaVQy7-RGPU_median_load_time_in_seconds_for_questions_in_this_dashboard.yaml
@@ -56,6 +56,5 @@ serdes/meta:
   label: median_load_time_in_seconds_for_questions_in_this_dashboard
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: vUNKNOWN (13e6090)
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/57V11my5MYVnSlaJYM8cX_most_viewed_models.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/57V11my5MYVnSlaJYM8cX_most_viewed_models.yaml
@@ -369,6 +369,5 @@ serdes/meta:
   label: most_viewed_models
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: vUNKNOWN (1308cef)
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/5EsTAgs6Uu_xz69TsrUJ4_last_viewed_models.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/5EsTAgs6Uu_xz69TsrUJ4_last_viewed_models.yaml
@@ -315,6 +315,5 @@ serdes/meta:
   label: last_viewed_models
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: vUNKNOWN (a98530f)
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/5HQS2xXAPF4hOFudut_Tg_last_viewed_dashboards.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/5HQS2xXAPF4hOFudut_Tg_last_viewed_dashboards.yaml
@@ -305,6 +305,5 @@ serdes/meta:
   label: last_viewed_dashboards
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: null
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/613VT_7b325t9FBAJZcU8_question_views_per_month.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/613VT_7b325t9FBAJZcU8_question_views_per_month.yaml
@@ -97,6 +97,5 @@ serdes/meta:
   label: question_views_per_month
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: vUNKNOWN (13e6090)
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/7FLoE9kUELG4Ess6DsSEY_last_downloads.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/7FLoE9kUELG4Ess6DsSEY_last_downloads.yaml
@@ -823,6 +823,5 @@ serdes/meta:
   label: last_downloads
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: vUNKNOWN (a98530f)
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/95Om4AllyfyB5wtl6TeGi_last_viewed_tables.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/95Om4AllyfyB5wtl6TeGi_last_viewed_tables.yaml
@@ -364,6 +364,5 @@ serdes/meta:
   label: last_viewed_tables
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: vUNKNOWN (ad99d37)
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/9shJ0y29V5o1lOSDL4ImJ_most_viewed_questions.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/9shJ0y29V5o1lOSDL4ImJ_most_viewed_questions.yaml
@@ -467,6 +467,5 @@ serdes/meta:
   label: most_viewed_questions
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: null
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/Bp2r19P5a9HjDTR4-VuZa_subscriptions_on_this_dashboard.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/Bp2r19P5a9HjDTR4-VuZa_subscriptions_on_this_dashboard.yaml
@@ -192,6 +192,5 @@ serdes/meta:
   label: subscriptions_on_this_dashboard
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: null
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/DnNyT6EtIn-Zx8bHRFHbV_questions_created_last_week.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/DnNyT6EtIn-Zx8bHRFHbV_questions_created_last_week.yaml
@@ -129,6 +129,5 @@ serdes/meta:
   label: questions_created_last_week
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: null
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/FUuJSuFo7wM6EoddmNsHf_most_active_viewers.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/FUuJSuFo7wM6EoddmNsHf_most_active_viewers.yaml
@@ -187,6 +187,5 @@ serdes/meta:
   label: most_active_viewers
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: null
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/Fnu5Kh0gYPN6P8A_fvICu_dashboard_with_this_question.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/Fnu5Kh0gYPN6P8A_fvICu_dashboard_with_this_question.yaml
@@ -112,6 +112,5 @@ serdes/meta:
   label: dashboard_with_this_question
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: null
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/G7fFejjb7cgwYlUXSvf3K_dashboards_created_last_week.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/G7fFejjb7cgwYlUXSvf3K_dashboards_created_last_week.yaml
@@ -129,6 +129,5 @@ serdes/meta:
   label: dashboards_created_last_week
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: null
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/ItdtatOMd0uUEpvx7tDAC_most_viewed_tables.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/ItdtatOMd0uUEpvx7tDAC_most_viewed_tables.yaml
@@ -334,6 +334,5 @@ serdes/meta:
   label: most_viewed_tables
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: vUNKNOWN (901f705)
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/JPERH6xYVcj3m2Zw0YVY1_active_alerts.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/JPERH6xYVcj3m2Zw0YVY1_active_alerts.yaml
@@ -76,6 +76,5 @@ serdes/meta:
   label: active_alerts
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: null
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/LXu_IZa1EDg3QOhlwunGy_sso_source.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/LXu_IZa1EDg3QOhlwunGy_sso_source.yaml
@@ -35,6 +35,5 @@ serdes/meta:
   label: sso_source
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: null
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/MOAq881VSlM2BhVUv5e_K_last_activity_on_question.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/MOAq881VSlM2BhVUv5e_K_last_activity_on_question.yaml
@@ -241,6 +241,5 @@ serdes/meta:
   label: last_activity_on_question
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: vUNKNOWN (13e6090)
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/MUXrck2HHcd2TIRuPfK0v_most_viewed_dashboards.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/MUXrck2HHcd2TIRuPfK0v_most_viewed_dashboards.yaml
@@ -232,6 +232,5 @@ serdes/meta:
   label: most_viewed_dashboards
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: null
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/P6Ityjj7igswKh4NgZZjz_view_log.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/P6Ityjj7igswKh4NgZZjz_view_log.yaml
@@ -218,6 +218,5 @@ serdes/meta:
   label: view_log
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: vUNKNOWN (7c47e04)
 type: model

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/PkIueKBME3DfRFwBsYjuE_list_of_dashboards.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/PkIueKBME3DfRFwBsYjuE_list_of_dashboards.yaml
@@ -63,6 +63,5 @@ serdes/meta:
   label: list_of_dashboards
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: vUNKNOWN (ad99d37)
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/T1vsVJUAfg30Fqiw4Dywa_most_viewed_cards.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/T1vsVJUAfg30Fqiw4Dywa_most_viewed_cards.yaml
@@ -199,6 +199,5 @@ serdes/meta:
   label: most_viewed_cards
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: null
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/UEK1JfYa3ZBp6W7F-Ui5i_questions_without_recent_views.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/UEK1JfYa3ZBp6W7F-Ui5i_questions_without_recent_views.yaml
@@ -122,6 +122,5 @@ serdes/meta:
   label: questions_without_recent_views
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: vUNKNOWN (901f705)
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/Vm-4GYORvVbGu9jHVLfg1_question_views_per_month.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/Vm-4GYORvVbGu9jHVLfg1_question_views_per_month.yaml
@@ -77,6 +77,5 @@ serdes/meta:
   label: question_views_per_month
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: null
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/W34-Nzp-T3-SPdZwGvLeB_dashboard_metadata.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/W34-Nzp-T3-SPdZwGvLeB_dashboard_metadata.yaml
@@ -209,6 +209,5 @@ serdes/meta:
   label: dashboard_metadata
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: null
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/WlQ-en2l-iRRCvO2-v5j1_recent_activity.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/WlQ-en2l-iRRCvO2-v5j1_recent_activity.yaml
@@ -420,6 +420,5 @@ serdes/meta:
   label: recent_activity
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: vUNKNOWN (ad99d37)
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/WoQnk12nwOaJ1pcb1wsr4_new_dashboards_per_month.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/WoQnk12nwOaJ1pcb1wsr4_new_dashboards_per_month.yaml
@@ -59,6 +59,5 @@ serdes/meta:
   label: new_dashboards_per_month
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: null
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/XIiIsCNMk9gg-eO2hkl8S_dashboard_views_per_month.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/XIiIsCNMk9gg-eO2hkl8S_dashboard_views_per_month.yaml
@@ -97,6 +97,5 @@ serdes/meta:
   label: dashboard_views_per_month
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: null
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/XLzhOnMmk3DkefFAMx_Vg_question_metadata.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/XLzhOnMmk3DkefFAMx_Vg_question_metadata.yaml
@@ -209,6 +209,5 @@ serdes/meta:
   label: question_metadata
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: vUNKNOWN (13e6090)
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/Y0ZykgQ64HHwAW_MYx-dW_first_login_date.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/Y0ZykgQ64HHwAW_MYx-dW_first_login_date.yaml
@@ -38,6 +38,5 @@ serdes/meta:
   label: first_login_date
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: null
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/YiHMsA2dv3iQob11DLTIz_alerts_on_this_question.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/YiHMsA2dv3iQob11DLTIz_alerts_on_this_question.yaml
@@ -139,6 +139,5 @@ serdes/meta:
   label: alerts_on_this_question
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: vUNKNOWN (13e6090)
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/YxCC6fQfHOPVvBtUkjFCN_questions_that_don_t_belong_to_a_dashboard.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/YxCC6fQfHOPVvBtUkjFCN_questions_that_don_t_belong_to_a_dashboard.yaml
@@ -150,6 +150,5 @@ serdes/meta:
   label: questions_that_don_t_belong_to_a_dashboard
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: vUNKNOWN (901f705)
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/Z18i0B5CgOe66-YScAZdx_questions_created_per_month.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/Z18i0B5CgOe66-YScAZdx_questions_created_per_month.yaml
@@ -75,6 +75,5 @@ serdes/meta:
   label: questions_created_per_month
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: null
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/ZmDKwRQBuRwfXfGipg7-k_fields.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/ZmDKwRQBuRwfXfGipg7-k_fields.yaml
@@ -327,6 +327,5 @@ serdes/meta:
   label: fields
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: vUNKNOWN (0e09ac7)
 type: model

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/_lfXwss_MckZBidbcJsgk_most_viewed_questions.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/_lfXwss_MckZBidbcJsgk_most_viewed_questions.yaml
@@ -243,6 +243,5 @@ serdes/meta:
   label: most_viewed_questions
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: null
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/_p6UGMWOQn5-yf03uGsaN_most_active_people_on_this_dashboard.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/_p6UGMWOQn5-yf03uGsaN_most_active_people_on_this_dashboard.yaml
@@ -126,6 +126,5 @@ serdes/meta:
   label: most_active_people_on_this_dashboard
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: null
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/ezcT88-OmH-5HFOFNqmX7_last_viewed_questions.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/ezcT88-OmH-5HFOFNqmX7_last_viewed_questions.yaml
@@ -314,6 +314,5 @@ serdes/meta:
   label: last_viewed_questions
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: null
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/fBr2cU-86t14YWbaS3r6-_most_viewed_dashboards.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/fBr2cU-86t14YWbaS3r6-_most_viewed_dashboards.yaml
@@ -202,6 +202,5 @@ serdes/meta:
   label: most_viewed_dashboards
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: null
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/gTeYI2eJtQUh63sZurc3z_last_queries.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/gTeYI2eJtQUh63sZurc3z_last_queries.yaml
@@ -691,6 +691,5 @@ serdes/meta:
   label: last_queries
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: vUNKNOWN (ad99d37)
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/gYt6bo9DFKz6tSeDLxYVs_active_users_last_week.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/gYt6bo9DFKz6tSeDLxYVs_active_users_last_week.yaml
@@ -86,6 +86,5 @@ serdes/meta:
   label: active_users_last_week
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: null
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/hFpp3c-7Y-CtMOrs3zeyn_last_login_date.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/hFpp3c-7Y-CtMOrs3zeyn_last_login_date.yaml
@@ -41,6 +41,5 @@ serdes/meta:
   label: last_login_date
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: null
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/kd1-A_wWOvlSuLDTFUpyb_question_views_per_week.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/kd1-A_wWOvlSuLDTFUpyb_question_views_per_week.yaml
@@ -85,6 +85,5 @@ serdes/meta:
   label: question_views_per_week
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: null
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/lh0sbjKcm9BhiiHPpPxRa_most_viewed_dashboards.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/lh0sbjKcm9BhiiHPpPxRa_most_viewed_dashboards.yaml
@@ -466,6 +466,5 @@ serdes/meta:
   label: most_viewed_dashboards
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: null
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/p-z74CSp1IOs1rXwAcwcS_most_active_creators.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/p-z74CSp1IOs1rXwAcwcS_most_active_creators.yaml
@@ -185,6 +185,5 @@ serdes/meta:
   label: most_active_creators
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: null
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/p8ZML2ebd3ItzCyWsKXLa_weekly_active_users.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/p8ZML2ebd3ItzCyWsKXLa_weekly_active_users.yaml
@@ -83,6 +83,5 @@ serdes/meta:
   label: weekly_active_users
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: null
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/t-4MnpU-Nn7Ph9GQT6zYb_question_views_last_week.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/t-4MnpU-Nn7Ph9GQT6zYb_question_views_last_week.yaml
@@ -87,6 +87,5 @@ serdes/meta:
   label: question_views_last_week
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: null
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/tKEl86EXMyTDIoO9nyFTV_last_content_viewed_at.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/tKEl86EXMyTDIoO9nyFTV_last_content_viewed_at.yaml
@@ -51,6 +51,5 @@ serdes/meta:
   label: last_content_viewed_at
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: vUNKNOWN (901f705)
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/uEf4gbDzXkj9q1uvkaTny_person_detail.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/uEf4gbDzXkj9q1uvkaTny_person_detail.yaml
@@ -89,6 +89,5 @@ serdes/meta:
   label: person_detail
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: vUNKNOWN (ad99d37)
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/vrez-ciNppijhELOxLJOY_dashboards_with_this_question.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/vrez-ciNppijhELOxLJOY_dashboards_with_this_question.yaml
@@ -224,6 +224,5 @@ serdes/meta:
   label: dashboards_with_this_question
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: vUNKNOWN (13e6090)
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/x7GwgNdjfzrpQkKTraaqo_tables.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/x7GwgNdjfzrpQkKTraaqo_tables.yaml
@@ -283,6 +283,5 @@ serdes/meta:
   label: tables
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: vUNKNOWN (0e09ac7)
 type: model

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/xrgv7nzXe_v8ORWIbq839_recent_activity_on_dashboard.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/xrgv7nzXe_v8ORWIbq839_recent_activity_on_dashboard.yaml
@@ -237,6 +237,5 @@ serdes/meta:
   label: recent_activity_on_dashboard
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: null
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/y-_5bBl0fXY9XlEbpJkrj_most_active_people_on_this_question.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/y-_5bBl0fXY9XlEbpJkrj_most_active_people_on_this_question.yaml
@@ -126,6 +126,5 @@ serdes/meta:
   label: most_active_people_on_this_question
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: vUNKNOWN (13e6090)
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/yVr4oMzxq8BPWf5HLbdwL_questions_in_this_dashboard.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/yVr4oMzxq8BPWf5HLbdwL_questions_in_this_dashboard.yaml
@@ -161,6 +161,5 @@ serdes/meta:
   label: questions_in_this_dashboard
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: null
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/ybsNZp-876qEMoA1U51dc_alerts_and_subscriptions_created_last_week.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/ybsNZp-876qEMoA1U51dc_alerts_and_subscriptions_created_last_week.yaml
@@ -109,6 +109,5 @@ serdes/meta:
   label: alerts_and_subscriptions_created_last_week
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: null
 type: question

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/zn_VtBXm5-teZmXpwGcNu_member_of.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_metabase_analytics/cards/zn_VtBXm5-teZmXpwGcNu_member_of.yaml
@@ -148,6 +148,5 @@ serdes/meta:
   label: member_of
   model: Card
 initially_published_at: null
-last_used_at: null
 metabase_version: null
 type: question

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -8216,7 +8216,6 @@ databaseChangeLog:
             tableName: report_card
             columnName: last_used_at
             columnDataType: ${timestamp_type}
-            defaultNullValue: current_timestamp
 
   - changeSet:
       id: v51.2024-05-13T15:30:57

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -8195,6 +8195,18 @@ databaseChangeLog:
   # if the card is imported with serialization, we don't want to automatically clean up
   # newly imported cards, and we don't want to have to make it nullable.
   - changeSet:
+      id: v50.2024-07-09T20:04:01
+      author: calherries
+      comment: Populate default value for report_card.last_used_at
+      changes:
+        - sql:
+            sql: >-
+              UPDATE report_card
+              SET last_used_at = current_timestamp
+              WHERE last_used_at IS NULL;
+      rollback: # nothing to do, since this is backwards compatible
+
+  - changeSet:
       id: v50.2024-07-09T20:04:02
       author: calherries
       comment: Add default value to report_card.last_used_at

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -8232,7 +8232,7 @@ databaseChangeLog:
             sql: >-
               ALTER TABLE report_card
               CHANGE last_used_at
-              created_at timestamp(6) NOT NULL DEFAULT current_timestamp(6);
+              last_used_at timestamp(6) NOT NULL DEFAULT current_timestamp(6);
       rollback: # nothing to do, since this is backwards compatible
 
   - changeSet:

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -8191,6 +8191,21 @@ databaseChangeLog:
               column:
                 name: dashboard_id
 
+  # last_used_at is used to determine if a report card is stale and should be cleaned up
+  # if the card is imported with serialization, we don't want to automatically clean up
+  # newly imported cards, and we don't want to have to make it nullable.
+  - changeSet:
+      id: v50.2024-07-09T20:04:02
+      author: calherries
+      comment: Add default value to report_card.last_used_at
+      preConditions:
+      changes:
+        - addNotNullConstraint:
+            tableName: report_card
+            columnName: last_used_at
+            columnDataType: ${timestamp_type}
+            defaultNullValue: current_timestamp
+
   - changeSet:
       id: v51.2024-05-13T15:30:57
       author: metamben

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -8209,13 +8209,31 @@ databaseChangeLog:
   - changeSet:
       id: v50.2024-07-09T20:04:02
       author: calherries
-      comment: Add default value to report_card.last_used_at
+      comment: Add not null constraint for report_card.last_used_at
       preConditions:
       changes:
         - addNotNullConstraint:
             tableName: report_card
             columnName: last_used_at
             columnDataType: ${timestamp_type}
+
+  # addDefaultValue with defaultValueComputed doesn't work for MySQL/MariaDB so we have to do this the hard way.
+  - changeSet:
+      id: v50.2024-07-09T20:04:03
+      author: calherries
+      comment: Set default for report_card.last_used_at
+      preConditions:
+      changes:
+        - sql:
+            dbms: postgresql,h2
+            sql: ALTER TABLE report_card ALTER COLUMN last_used_at SET DEFAULT CURRENT_TIMESTAMP;
+        - sql:
+            dbms: mysql,mariadb
+            sql: >-
+              ALTER TABLE report_card
+              CHANGE last_used_at
+              created_at timestamp(6) NOT NULL DEFAULT current_timestamp(6);
+      rollback: # nothing to do, since this is backwards compatible
 
   - changeSet:
       id: v51.2024-05-13T15:30:57

--- a/test/metabase/http_client.clj
+++ b/test/metabase/http_client.clj
@@ -83,7 +83,7 @@
 ;;; parse-response
 
 (def ^:private auto-deserialize-dates-keys
-  #{:created_at :updated_at :last_login :date_joined :started_at :finished_at :last_analyzed})
+  #{:created_at :updated_at :last_login :date_joined :started_at :finished_at :last_analyzed :last_used_at})
 
 (defn- auto-deserialize-dates
   "Automatically recurse over `response` and look for keys that are known to correspond to dates. Parse their values and


### PR DESCRIPTION
This PR:
1. Makes `report_card.last_used_at` non-null
2. Sets the default value to the current timestamp.

There are two motivations behind this change.

1. `report_card.last_used_at` is a nullable column that currently is not being used. In most cases the value will be non-null, but in some rare cases, such as when the card is serialized or from the app-db, it will be null. I suspect that can easily lead to bugs when we eventually do use the column. This PR prevents that bug from happening.
2. `last_used_at` will be used to identify stale questions that can be cleaned up automatically. If a card is imported from another instance, we don't want it to be immediately cleaned up. And neither do we want to never clean it up if it is never "used". It makes sense to consider it "last used" from the time it was imported for this use case.

More context [here](https://metaboat.slack.com/archives/C0641E4PB9B/p1720549646851889).

Related: https://github.com/metabase/metabase/pull/44240