### PR TITLE
Cache liquibase migration parsing

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -634,6 +634,12 @@ jobs:
         test-args: >-
           :partition/total 4
           :partition/index ${{ matrix.partition-index }}
+    - name: Upload Test Results as artifact
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: "junit-mysql-latest-${{ matrix.partition-index }}"
+        path: ./target/junit/
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()

--- a/src/metabase/db/liquibase.clj
+++ b/src/metabase/db/liquibase.clj
@@ -117,6 +117,35 @@
     (liquibase.h2/h2-database liquibase-conn)
     (.findCorrectDatabaseImplementation (DatabaseFactory/getInstance) liquibase-conn)))
 
+(when config/is-test?
+  ;; A lot of time during migration testing is spent parsing Liquibase migration YAMLs. The code below adds cache
+  ;; for the parsed files by implementing a custom caching parser.
+  (def ^:private ^java.util.concurrent.ConcurrentHashMap -test-only-migration-file-cache
+    (java.util.concurrent.ConcurrentHashMap.))
+  (def ^:private ^:dynamic -test-only-*return-caching-parser* true)
+
+  (def ^:private -test-only-caching-parser
+    (reify liquibase.parser.ChangeLogParser
+      (getPriority [_] 1024) ;; So that it has the highest priority in the parser factory.
+      (parse [_ physicalChangeLogLocation changeLogParameters resourceAccessor]
+        (let [key [physicalChangeLogLocation (.getDatabase changeLogParameters)]]
+          (.computeIfAbsent
+           -test-only-migration-file-cache key
+           (reify java.util.function.Function
+             (apply [_ _]
+               ;; Need to rebind the dynvar so that the ParserFactory doesn't return the caching parser again.
+               (let [real-parser (binding [-test-only-*return-caching-parser* false]
+                                   (.getParser (liquibase.parser.ChangeLogParserFactory/getInstance)
+                                               physicalChangeLogLocation resourceAccessor))]
+                 (.parse real-parser physicalChangeLogLocation changeLogParameters resourceAccessor)))))))
+      (supports [_ changeLogFile resourceAccessor]
+        -test-only-*return-caching-parser*)))
+
+  (.register (liquibase.parser.ChangeLogParserFactory/getInstance) -test-only-caching-parser)
+  ;; To reset:
+  #_(liquibase.parser.ChangeLogParserFactory/setInstance nil)
+  )
+
 (defn- liquibase ^Liquibase [^Connection conn ^Database database]
   (Liquibase.
    ^String (decide-liquibase-file conn database)

--- a/src/metabase/db/liquibase.clj
+++ b/src/metabase/db/liquibase.clj
@@ -129,16 +129,16 @@
       (getPriority [_] 1024) ;; So that it has the highest priority in the parser factory.
       (parse [_ physicalChangeLogLocation changeLogParameters resourceAccessor]
         (let [key [physicalChangeLogLocation (.getDatabase changeLogParameters)]]
-          (.computeIfAbsent
-           -test-only-migration-file-cache key
-           (reify java.util.function.Function
-             (apply [_ _]
-               ;; Need to rebind the dynvar so that the ParserFactory doesn't return the caching parser again.
-               (let [real-parser (binding [-test-only-*return-caching-parser* false]
-                                   (.getParser (liquibase.parser.ChangeLogParserFactory/getInstance)
-                                               physicalChangeLogLocation resourceAccessor))]
-                 (.parse real-parser physicalChangeLogLocation changeLogParameters resourceAccessor)))))))
-      (supports [_ changeLogFile resourceAccessor]
+          (or (.get -test-only-migration-file-cache key)
+              ;; Need to rebind the dynvar so that the ParserFactory doesn't return the caching parser again.
+              (let [real-parser (binding [-test-only-*return-caching-parser* false]
+                                  (.getParser (liquibase.parser.ChangeLogParserFactory/getInstance)
+                                              physicalChangeLogLocation resourceAccessor))
+                    parsed (.parse ^liquibase.parser.ChangeLogParser real-parser
+                                   physicalChangeLogLocation changeLogParameters resourceAccessor)]
+                (.put -test-only-migration-file-cache key parsed)
+                parsed))))
+      (supports [_ _changeLogFile _resourceAccessor]
         -test-only-*return-caching-parser*)))
 
   (.register (liquibase.parser.ChangeLogParserFactory/getInstance) -test-only-caching-parser)

--- a/test/metabase/db/schema_migrations_test/impl.clj
+++ b/test/metabase/db/schema_migrations_test/impl.clj
@@ -109,6 +109,8 @@
             (parse-double (format "%d.%d" (* (parse-long major-version) 100) unix-timestamp))))
         (throw (ex-info (format "Invalid migration ID: %s" id) {:id id})))))
 
+(alter-var-root #'migration->number memoize)
+
 (deftest migration->number-test
   (is (= 356
          (migration->number 356)

--- a/test/metabase/db/setup_test.clj
+++ b/test/metabase/db/setup_test.clj
@@ -55,14 +55,15 @@
                                              "SELECT name FROM report_dashboard ORDER BY name ASC;")))))))))))
 
 (deftest setup-fresh-db-test
-  (mt/test-drivers #{:h2 :mysql :postgres}
-    (testing "can setup a fresh db"
-      (mt/with-temp-empty-app-db [conn driver/*driver*]
-        (is (= :done
-               (mdb.setup/setup-db! driver/*driver* (mdb.connection/data-source) true true)))
-        (testing "migrations are executed in the order they are defined"
-          (is (= (liquibase-test/liquibase-file->included-ids "migrations/001_update_migrations.yaml" driver/*driver*)
-                 (t2/select-pks-vec (liquibase/changelog-table-name conn) {:order-by [[:orderexecuted :asc]]}))))))))
+  (with-bindings {#'liquibase/-test-only-*return-caching-parser* true}
+    (mt/test-drivers #{:h2 :mysql :postgres}
+      (testing "can setup a fresh db"
+        (mt/with-temp-empty-app-db [conn driver/*driver*]
+          (is (= :done
+                 (mdb.setup/setup-db! driver/*driver* (mdb.connection/data-source) true true)))
+          (testing "migrations are executed in the order they are defined"
+            (is (= (liquibase-test/liquibase-file->included-ids "migrations/001_update_migrations.yaml" driver/*driver*)
+                   (t2/select-pks-vec (liquibase/changelog-table-name conn) {:order-by [[:orderexecuted :asc]]})))))))))
 
 (deftest setup-db-no-auto-migrate-test
   (mt/test-drivers #{:h2 :mysql :postgres}


### PR DESCRIPTION
### Description

A large chunk of testing time (both "real" and "user") is spent running tests that perform Liquibase migrations. Profiling those tests showed that a significant contributor is Liquibase re-parsing YAML migration files and constructing its in-memory representations of them.

This PR injects a test-only custom caching parser to Liquibase's default parser factory.

The new code can be added anywhere where it is guaranteed to be loaded early. I don't quite like where I've put it so far, so I'll be glad to move it somewhere else if you point me to a suitable location.
