### PR TITLE
Bump macaw to 0.1.65

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -76,7 +76,7 @@
   io.github.eerohele/pp                     {:git/tag "2024-01-04.60"           ; super fast pretty-printing library
                                              :git/sha "a428751"
                                              :git/url "https://github.com/eerohele/pp"}
-  io.github.metabase/macaw                  {:mvn/version "0.1.60"}             ; Parse native SQL queries
+  io.github.metabase/macaw                  {:mvn/version "0.1.65"}             ; Parse native SQL queries
   ;; The 2.X line of Resilience4j requires Java 17, so we cannot upgrade this dependency until that is our minimum JVM version
   io.github.resilience4j/resilience4j-retry {:mvn/version "1.7.1" #_ "must be 1.7.1"} ; Support for retrying operations
   io.prometheus/simpleclient_hotspot        {:mvn/version "0.16.0"}             ; prometheus jvm collector


### PR DESCRIPTION
Refs https://github.com/metabase/macaw/issues/42

A bunch of small improvements, notably a timeout and support for MSSQL square bracket quotes.
