### PR TITLE
Repro #45036 and #44910: Multiple popovers can be opened simultaneously

### DIFF
--- a/e2e/test/scenarios/collections/trash.cy.spec.js
+++ b/e2e/test/scenarios/collections/trash.cy.spec.js
@@ -1,6 +1,8 @@
 import {
   READ_ONLY_PERSONAL_COLLECTION_ID,
   FIRST_COLLECTION_ID,
+  ORDERS_COUNT_QUESTION_ID,
+  ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
 import {
   popover,
@@ -687,6 +689,28 @@ describe("scenarios > collections > trash", () => {
       openNavigationSidebar();
       assertTrashSelectedInNavigationSidebar();
     });
+  });
+
+  it.skip("should open only one context menu at a time (metabase#44910)", () => {
+    cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, { archived: true });
+    cy.request("PUT", `/api/card/${ORDERS_COUNT_QUESTION_ID}`, {
+      archived: true,
+    });
+    cy.visit("/trash");
+
+    toggleEllipsisMenuFor("Orders");
+    cy.findAllByRole("dialog")
+      .should("have.length", 1)
+      .and("contain", "Move")
+      .and("contain", "Restore")
+      .and("contain", "Delete permanently");
+
+    toggleEllipsisMenuFor("Orders, Count");
+    cy.findAllByRole("dialog")
+      .should("have.length", 1)
+      .and("contain", "Move")
+      .and("contain", "Restore")
+      .and("contain", "Delete permanently");
   });
 });
 

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -917,6 +917,56 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
         });
     });
   });
+
+  it.skip("should open only one bucketing popover at a time (metabase#45036)", () => {
+    visitQuestionAdhoc(
+      {
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          type: "query",
+          query: { "source-table": PRODUCTS_ID, aggregation: [["count"]] },
+          parameters: [],
+        },
+      },
+      { mode: "notebook" },
+    );
+
+    getNotebookStep("summarize")
+      .findByText("Pick a column to group by")
+      .click();
+
+    popover()
+      .findByRole("option", { name: "Created At" })
+      .findByText("by month")
+      .click();
+
+    popover()
+      .last()
+      .within(() => {
+        cy.findByText("Year").should("be.visible");
+        cy.findByText("Hour of day").should("not.exist");
+        cy.findByText("More…").click();
+        cy.findByText("Hour of day").should("be.visible");
+      });
+
+    popover()
+      .first()
+      .findByRole("option", { name: "Price" })
+      .findByText("Auto bin")
+      .click();
+
+    popover()
+      .last()
+      .within(() => {
+        cy.findByText("Auto bin").should("be.visible");
+        cy.findByText("50 bins").should("be.visible");
+        cy.findByText("Don't bin").should("be.visible");
+
+        cy.findByText("Year").should("not.exist");
+        cy.findByText("Hour of day").should("not.exist");
+        cy.findByText("More…").should("not.exist");
+      });
+  });
 });
 
 function assertTableRowCount(expectedCount) {


### PR DESCRIPTION
This PR adds an E2E reproduction for #45036 and for #44910.

### #45036
This is the moment the test fails. It didn't close the temporal bucket menu, but it did open a binning one in the background.
![image](https://github.com/metabase/metabase/assets/31325167/08da3757-e2af-4b08-92c0-eee1da48bbda)

### #44910
The test fails because it finds two popovers open at the same time.
![image](https://github.com/metabase/metabase/assets/31325167/e5d07700-6b52-4099-80d3-434b00c0c1d0)

