### PR TITLE
Debug QP improvements from today's eng demo

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -233,7 +233,7 @@
     clj-kondo/clj-kondo          {:mvn/version "2024.03.13"}                ; this is not for RUNNING kondo, but so we can hack on custom hooks code from the REPL.
     cloverage/cloverage          {:mvn/version "1.2.4"}
     com.gfredericks/test.chuck   {:mvn/version "0.2.14"}                    ; generating strings from regexes (useful with malli)
-    djblue/portal                {:mvn/version "0.52.2"}                    ; ui for inspecting values
+    djblue/portal                {:mvn/version "0.56.0"}                    ; ui for inspecting values
     hashp/hashp                  {:mvn/version "0.2.2"}                     ; debugging/spying utility
     io.github.camsaul/humane-are {:mvn/version "1.0.2"}
     io.github.metabase/hawk      {:git/url "https://github.com/metabase/hawk"

--- a/dev/src/dev/debug_qp.clj
+++ b/dev/src/dev/debug_qp.clj
@@ -406,9 +406,12 @@
 
 (defonce ^:private portal (atom nil))
 
-(defn- portal-setup []
+(defn- portal-setup
+  "Do setup after Portal has started, e.g. loading the custom viewers in [[dev.debug-qp.viewers]]. This is supposed to
+  be done automatically on start, but you can call this function to reload them if needed."
+  []
   (portal.api/eval-str
-   (slurp (io/resource "dev/debug_qp_viewers.cljs"))))
+   (slurp (io/resource "dev/debug_qp/viewers.cljs"))))
 
 (def ^:private default-portal-config
   {:port    1337
@@ -430,4 +433,4 @@
      (reset! portal (portal.api/start config))
      (add-tap #'portal.api/submit)
      #_{:clj-kondo/ignore [:discouraged-var]}
-     (printf "Started Portal on port %d." (:port config)))))
+     (printf "Started Portal on port %d.\n" (:port config)))))

--- a/dev/src/dev/debug_qp.clj
+++ b/dev/src/dev/debug_qp.clj
@@ -1,13 +1,14 @@
 (ns dev.debug-qp
   "Debug QP stuff as follows:
 
-    ;; start Portal if you have not done so already. Open http://localhost:4000 in your browser
+    ;; start Portal if you have not done so already. Open http://localhost:1337 in your browser
     (dev.debug-qp/start-portal!)
 
     ;; run a query with debugging enabled
     (binding [metabase.query-processor.debug/*debug* true]
       (metabase.query-processor/process-query query)"
   (:require
+   [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.walk :as walk]
    [lambdaisland.deep-diff2 :as ddiff]
@@ -403,10 +404,30 @@
    #_{:clj-kondo/ignore [:discouraged-var]}
    (println (driver/prettify-native-form driver sql))))
 
-(defn start-portal! []
-  (portal.api/start {:port 4000})
-  (add-tap #'portal.api/submit))
+(defonce ^:private portal (atom nil))
+
+(defn- portal-setup []
+  (portal.api/eval-str
+   (slurp (io/resource "dev/debug_qp_viewers.cljs"))))
+
+(def ^:private default-portal-config
+  {:port    1337
+   :on-load #'portal-setup})
 
 (defn stop-portal! []
-  (portal.api/stop)
-  (remove-tap #'portal.api/submit))
+  (when @portal
+    (portal.api/stop)
+    (remove-tap #'portal.api/submit)
+    (reset! portal nil)))
+
+(defn start-portal!
+  ([]
+   (start-portal! nil))
+
+  ([config]
+   (let [config (merge default-portal-config config)]
+     (stop-portal!)
+     (reset! portal (portal.api/start config))
+     (add-tap #'portal.api/submit)
+     #_{:clj-kondo/ignore [:discouraged-var]}
+     (printf "Started Portal on port %d." (:port config)))))

--- a/dev/src/dev/debug_qp/viewers.cljs
+++ b/dev/src/dev/debug_qp/viewers.cljs
@@ -1,14 +1,16 @@
-(ns dev.debug-qp-viewers
+(ns dev.debug-qp.viewers
   (:require
    [clojure.string :as str]
    [portal.ui.api]))
 
-(defn- format-sql [sql]
+(defn- format-sql
+  "Placeholder SQL formatter until I figure out how to integrate https://www.npmjs.com/package/sql-formatter."
+  [sql]
   (reduce
    (fn [sql sql-keyword]
      (str/replace sql (re-pattern sql-keyword) (str \newline sql-keyword)))
    sql
-   [#_"SELECT" "FROM" "WHERE" "ORDER BY" "LIMIT"]))
+   ["FROM" "WHERE" "ORDER BY" "LIMIT"]))
 
 (defn- view-sql [sql]
   [:pre

--- a/dev/src/dev/debug_qp_viewers.cljs
+++ b/dev/src/dev/debug_qp_viewers.cljs
@@ -1,0 +1,21 @@
+(ns dev.debug-qp-viewers
+  (:require
+   [clojure.string :as str]
+   [portal.ui.api]))
+
+(defn- format-sql [sql]
+  (reduce
+   (fn [sql sql-keyword]
+     (str/replace sql (re-pattern sql-keyword) (str \newline sql-keyword)))
+   sql
+   [#_"SELECT" "FROM" "WHERE" "ORDER BY" "LIMIT"]))
+
+(defn- view-sql [sql]
+  [:pre
+   {:style {:color :pink}}
+   (format-sql sql)])
+
+(portal.ui.api/register-viewer!
+ {:name      ::sql
+  :predicate string?
+  :component #'view-sql})

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -17,6 +17,7 @@
    [metabase.lib.query :as lib.query]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.util.match :as lib.util.match]
+   [metabase.query-processor.debug :as qp.debug]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.middleware.annotate :as annotate]
    [metabase.query-processor.middleware.wrap-value-literals :as qp.wrap-value-literals]
@@ -1720,7 +1721,8 @@
     (let [inner-query (preprocess driver inner-query)]
       (log/tracef "Compiling MBQL query\n%s" (u/pprint-to-str 'magenta inner-query))
       (u/prog1 (apply-clauses driver {} inner-query)
-        (log/debugf "\nHoneySQL Form: %s\n%s" (u/emoji "🍯") (u/pprint-to-str 'cyan <>))))))
+        (log/debugf "\nHoneySQL Form: %s\n%s" (u/emoji "🍯") (u/pprint-to-str 'cyan <>))
+        (qp.debug/debug> (list '🍯 <>))))))
 
 ;;;; MBQL -> Native
 

--- a/src/metabase/query_processor/compile.clj
+++ b/src/metabase/query_processor/compile.clj
@@ -2,10 +2,12 @@
   (:refer-clojure :exclude [compile])
   (:require
    [metabase.driver :as driver]
+   [metabase.query-processor.debug :as qp.debug]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.preprocess :as qp.preprocess]
    [metabase.query-processor.schema :as qp.schema]
    [metabase.query-processor.setup :as qp.setup]
+   [metabase.util :as u]
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]))
@@ -27,7 +29,8 @@
   [preprocessed-query :- ::qp.schema/query]
   (qp.setup/with-qp-setup [preprocessed-query preprocessed-query]
     (try
-      (compile* preprocessed-query)
+      (u/prog1 (compile* preprocessed-query)
+        (qp.debug/debug> (list `compile-preprocessed <>)))
       (catch Throwable e
         (throw (ex-info (i18n/tru "Error compiling query: {0}" (ex-message e))
                         {:query preprocessed-query, :type qp.error-type/driver}

--- a/src/metabase/query_processor/preprocess.clj
+++ b/src/metabase/query_processor/preprocess.clj
@@ -1,5 +1,6 @@
 (ns metabase.query-processor.preprocess
   (:require
+   [clojure.data :as data]
    [metabase.legacy-mbql.schema :as mbql.s]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.query :as lib.query]
@@ -135,10 +136,12 @@
               (when-not (= <> query)
                 (let [middleware-fn-name (if-let [fn-name (:name (meta middleware-fn))]
                                            (if-let [fn-ns (:ns (meta middleware-fn))]
-                                             (format "%s/%s" (ns-name fn-ns) fn-name)
+                                             (symbol (format "%s/%s" (ns-name fn-ns) fn-name))
                                              fn-name)
                                            middleware-fn)]
-                  (list middleware-fn-name '=> <>))))
+                  (list middleware-fn-name '=> <>
+                        ^{:portal.viewer/default :portal.viewer/diff}
+                        (data/diff query <>)))))
             ;; make sure the middleware returns a valid query... this should be dev-facing only so no need to i18n
             (when-not (map? <>)
               (throw (ex-info (format "Middleware did not return a valid query.")


### PR DESCRIPTION
* update to latest version of Portal
* Use port 1337 by default instead of 4000 to avoid conflict with the port used for FE tests for running the backend
* Support running on a different port
* Improvements to (re)starting and stopping Portal e.g. keep track of portal instance in an atom
* add custom debug viewers CLJS file with placeholder SQL formatter code
* add a few more `debug>` places to get HoneySQL and the compiled query in Portal