### PR TITLE
Put the backport disclaimer on one line so that it wraps properly when rendered

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,5 @@
 > [!IMPORTANT]
-> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label
-> to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this
-> PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71)
-> in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not
-> apply to you, and the label will be taken care of by your reviewer.
+> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.
 
 > **Warning**
 >


### PR DESCRIPTION
This is pretty nitpicky but I noticed that the following PR paragraph has line breaks in the markdown which cause it to render like this on github:
<img width="824" alt="image" src="https://github.com/metabase/metabase/assets/32746338/69b3cfc4-7c9f-4f63-b573-fb9a050ac01e">

I've changed it so that it's a single line in the Markdown source, which allows it to wrap naturally when rendered:
<img width="793" alt="image" src="https://github.com/metabase/metabase/assets/32746338/dd83a24e-5e98-439e-bd76-712079d56e91">