### PR TITLE
docs - add note about parameters for datetime functions

### DIFF
--- a/docs/questions/query-builder/expressions-list.md
+++ b/docs/questions/query-builder/expressions-list.md
@@ -569,6 +569,8 @@ Syntax: `datetimeAdd(column, amount, unit)`.
 
 Example: `datetimeAdd("2021-03-25", 1, "month")` would return the value `2021-04-25`, displayed as `April 25, 2021`.
 
+`amount` must be an integer, not a fractional number.
+
 Related: [between](#between), [datetimeSubtract](#datetimesubtract).
 
 ### [datetimeDiff](./expressions/datetimediff.md)
@@ -586,6 +588,8 @@ Subtracts some unit of time from a date or timestamp value.
 Syntax: `datetimeSubtract(column, amount, unit)`.
 
 Example: `datetimeSubtract("2021-03-25", 1, "month")` would return the value `2021-02-25`, displayed as `February 25, 2021`.
+
+`amount` must be an integer, not a fractional number.
 
 Related: [between](#between), [datetimeAdd](#datetimeadd).
 

--- a/docs/questions/query-builder/expressions-list.md
+++ b/docs/questions/query-builder/expressions-list.md
@@ -569,7 +569,7 @@ Syntax: `datetimeAdd(column, amount, unit)`.
 
 Example: `datetimeAdd("2021-03-25", 1, "month")` would return the value `2021-04-25`, displayed as `April 25, 2021`.
 
-`amount` must be an integer, not a fractional number.
+`amount` must be an integer, not a fractional number. For example, you cannot add "half a year" (0.5).
 
 Related: [between](#between), [datetimeSubtract](#datetimesubtract).
 
@@ -589,7 +589,7 @@ Syntax: `datetimeSubtract(column, amount, unit)`.
 
 Example: `datetimeSubtract("2021-03-25", 1, "month")` would return the value `2021-02-25`, displayed as `February 25, 2021`.
 
-`amount` must be an integer, not a fractional number.
+`amount` must be an integer, not a fractional number. For example, you cannot subtract "half a year" (0.5).
 
 Related: [between](#between), [datetimeAdd](#datetimeadd).
 
@@ -616,6 +616,8 @@ Checks a date column's values to see if they're within the relative range.
 Syntax: `interval(column, number, text)`.
 
 Example: `interval([Created At], -1, "month")`.
+
+The `number` must be an integer. You cannot use a fractional value.
 
 Related: [between](#between).
 
@@ -655,7 +657,7 @@ Gets a timestamp relative to the current time.
 
 Syntax: `relativeDateTime(number, text)`
 
-`number`: Period of interval, where negative values are back in time.
+`number`: Period of interval, where negative values are back in time. The `number` must be an integer. You cannot use a fractional value.
 
 `text`: Type of interval like `"day"`, `"month"`, `"year"`
 
@@ -679,7 +681,7 @@ Gets a time interval of specified length.
 
 Syntax: `timeSpan(number, text)`.
 
-`number`: Period of interval, where negative values are back in time.
+`number`: Period of interval, where negative values are back in time. The `number` must be an integer. You cannot use a fractional value.
 
 `text`: Type of interval like `"day"`, `"month"`, `"year"`
 

--- a/docs/questions/query-builder/expressions/datetimeadd.md
+++ b/docs/questions/query-builder/expressions/datetimeadd.md
@@ -32,7 +32,7 @@ title: DatetimeAdd
 
 `amount`:
 
-- A whole number or a decimal number.
+- An integer. That is, whole numbers only; no fractional numbers.
 - May be a negative number: `datetimeAdd("2021-03-25", -1, "month")` will return `2021-04-25`.
 
 ## Calculating an end date

--- a/docs/questions/query-builder/expressions/datetimeadd.md
+++ b/docs/questions/query-builder/expressions/datetimeadd.md
@@ -32,7 +32,7 @@ title: DatetimeAdd
 
 `amount`:
 
-- An integer. That is, whole numbers only; no fractional numbers.
+- An integer. You cannot use fractional values. For example, you cannot add "half a year" (0.5).
 - May be a negative number: `datetimeAdd("2021-03-25", -1, "month")` will return `2021-04-25`.
 
 ## Calculating an end date

--- a/docs/questions/query-builder/expressions/datetimesubtract.md
+++ b/docs/questions/query-builder/expressions/datetimesubtract.md
@@ -29,7 +29,7 @@ title: DatetimeSubtract
 - "millisecond"
 
 `amount`:
-- An integer. That is, whole numbers only; no fractional numbers.
+- An integer. You cannot use fractional values. For example, you cannot add "half a year" (0.5).
 - May be a negative number: `datetimeSubtract("2021-03-25", -1, "month")` will return `2021-04-25`.
 
 ## Calculating a start date

--- a/docs/questions/query-builder/expressions/datetimesubtract.md
+++ b/docs/questions/query-builder/expressions/datetimesubtract.md
@@ -29,7 +29,7 @@ title: DatetimeSubtract
 - "millisecond"
 
 `amount`:
-- A whole number or a decimal number.
+- An integer. That is, whole numbers only; no fractional numbers.
 - May be a negative number: `datetimeSubtract("2021-03-25", -1, "month")` will return `2021-04-25`.
 
 ## Calculating a start date
@@ -55,7 +55,7 @@ Say you want to check if the current datetime falls between a [start date](#calc
 | Event   | Arrive By                  | Depart At                   | On My Way     |
 |---------|----------------------------|-----------------------------|---------------|
 | Drinks  | November 12, 2022 6:30 PM  | November 12, 2022 6:00 PM   | No            |
-| Dinner  | November 12, 2022 8:00 PM  | November 12, 2022 7:30 PM   | Yes           | 
+| Dinner  | November 12, 2022 8:00 PM  | November 12, 2022 7:30 PM   | Yes           |
 | Dancing | November 13, 2022 12:00 AM | November 12, 2022 11:30 PM  | No            |
 
 **Depart At** is a custom column with the expression:
@@ -133,7 +133,7 @@ is equivalent to the Metabase `datetimeSubtract` expression:
 datetimeSubtract([Arrive By], 30, "minute")
 ```
 
-### Spreadsheets 
+### Spreadsheets
 
 Assuming the [events sample data](#calculating-a-start-date) is in a spreadsheet where "Arrive By" is in column A with a datetime format, the spreadsheet function
 

--- a/docs/questions/query-builder/expressions/datetimesubtract.md
+++ b/docs/questions/query-builder/expressions/datetimesubtract.md
@@ -29,7 +29,7 @@ title: DatetimeSubtract
 - "millisecond"
 
 `amount`:
-- An integer. You cannot use fractional values. For example, you cannot add "half a year" (0.5).
+- An integer. You cannot use fractional values. For example, you cannot subtract "half a year" (0.5).
 - May be a negative number: `datetimeSubtract("2021-03-25", -1, "month")` will return `2021-04-25`.
 
 ## Calculating a start date


### PR DESCRIPTION
Correct docs for `datetimeAdd` and `datetimeSubtract` expressions. Both functions only accept integers, not fractional values.

See https://github.com/metabase/metabase/issues/38653.

