### PR TITLE
Make import work on a fresh install (#45297)

### DIFF
--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -185,7 +185,7 @@
   (log/warn (u/colorize :red (trs "''load'' is deprecated and will be removed in a future release. Please migrate to ''import''.")))
   (call-enterprise 'metabase-enterprise.serialization.cmd/v1-load! path (get-parsed-options #'load options)))
 
-(defn ^:command import
+(defn ^:command ^:requires-init import
   {:doc "Load serialized Metabase instance as created by the [[export]] command from directory `path`."}
   [path & options]
   (call-enterprise 'metabase-enterprise.serialization.cmd/v2-load! path (get-parsed-options #'import options)))
@@ -281,6 +281,10 @@
       arg-spec
       (:errors (cli/parse-opts args arg-spec)))))
 
+(defn- requires-init?
+  [command-name]
+  (-> command-name cmd->var meta :requires-init))
+
 (defn- fail!
   [& messages]
   (doseq [msg messages]
@@ -290,7 +294,7 @@
 (defn run-cmd
   "Run `cmd` with `args`. This is a function above. e.g. `clojure -M:run metabase migrate force` becomes
   `(migrate \"force\")`."
-  [command-name args]
+  [command-name init-fn args]
   (if-let [errors (validate command-name args)]
     (do
       (when (cmd->var command-name)
@@ -298,6 +302,8 @@
         (help command-name))
       (apply fail! errors))
     (try
+      (when (requires-init? command-name)
+        (init-fn))
       (apply @(cmd->var command-name) args)
       (catch Throwable e
         (.printStackTrace e)

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -176,9 +176,9 @@
       (log/error e (trs "Metabase Initialization FAILED"))
       (System/exit 1))))
 
-(defn- run-cmd [cmd args]
+(defn- run-cmd [cmd init-fn args]
   (classloader/require 'metabase.cmd)
-  ((resolve 'metabase.cmd/run-cmd) cmd args))
+  ((resolve 'metabase.cmd/run-cmd) cmd init-fn args))
 
 ;;; -------------------------------------------------- Tracing -------------------------------------------------------
 
@@ -200,5 +200,5 @@
   [& [cmd & args]]
   (maybe-enable-tracing)
   (if cmd
-    (run-cmd cmd args) ; run a command like `java -jar metabase.jar migrate release-locks` or `clojure -M:run migrate release-locks`
+    (run-cmd cmd init! args) ; run a command like `java -jar metabase.jar migrate release-locks` or `clojure -M:run migrate release-locks`
     (start-normally))) ; with no command line args just start Metabase normally


### PR DESCRIPTION
This introduces a new metadata on commands, `:requires-init`. If set, we'll run `metabase.core/init!` before running the command. `init!` will initialize the database and run our normal startup, though it won't actually start the Metabase server.

This allows you to use

```
env MB_CONFIG_FILE_PATH=... java -jar metabase.jar import /my/metabase/export
```

We'll run the normal init process (creating the internal user, loading from the config file, etc), then run the command.

On my machine this adds about 2-3 seconds to the time it takes to run an `import`.