### PR TITLE
fix(sdk): Remove default Count aggregation without triggering a query update

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/components/Summarize.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/components/Summarize.tsx
@@ -50,6 +50,8 @@ const SummarizeInner = ({
   };
 
   const {
+    query,
+    stageIndex,
     aggregations,
     handleAddAggregations,
     handleAddBreakout,
@@ -59,13 +61,16 @@ const SummarizeInner = ({
     handleUpdateAggregation,
     handleUpdateBreakout,
     hasAggregations,
-    query,
-  } = useSummarizeQuery(currentQuery, setCurrentQuery);
+  } = useSummarizeQuery({
+    query: currentQuery,
+    onQueryChange: setCurrentQuery,
+  });
 
   return (
     <Stack w="100%" h="100%">
       <SummarizeAggregationItemList
         query={query}
+        stageIndex={stageIndex}
         aggregations={aggregations}
         onAddAggregations={handleAddAggregations}
         onUpdateAggregation={handleUpdateAggregation}
@@ -75,6 +80,7 @@ const SummarizeInner = ({
       {hasAggregations && (
         <SummarizeBreakoutColumnList
           query={query}
+          stageIndex={stageIndex}
           onAddBreakout={handleAddBreakout}
           onUpdateBreakout={handleUpdateBreakout}
           onRemoveBreakout={handleRemoveBreakout}

--- a/frontend/src/metabase-lib/aggregation.ts
+++ b/frontend/src/metabase-lib/aggregation.ts
@@ -37,8 +37,7 @@ export function aggregate(
   return ML.aggregate(query, stageIndex, clause);
 }
 
-export function aggregateByCount(query: Query): Query {
-  const stageIndex = -1;
+export function aggregateByCount(query: Query, stageIndex: number): Query {
   const operators = availableAggregationOperators(query, stageIndex);
   const countOperator = operators.find(operator => {
     const info = displayInfo(query, stageIndex, operator);

--- a/frontend/src/metabase/query_builder/actions/object-detail.js
+++ b/frontend/src/metabase/query_builder/actions/object-detail.js
@@ -118,7 +118,7 @@ export const loadObjectDetailFKReferences = createThunkAction(
           metadataProvider,
           table,
         );
-        const aggregatedQuery = Lib.aggregateByCount(baseQuery);
+        const aggregatedQuery = Lib.aggregateByCount(baseQuery, -1);
         const query = filterByFk(aggregatedQuery, fk.origin, objectId);
         const finalCard = Question.create({ databaseId, metadata })
           .setQuery(query)

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionActions.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionActions.unit.spec.tsx
@@ -1,3 +1,4 @@
+import { waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { createMockEntitiesState } from "__support__/store";
@@ -103,13 +104,17 @@ describe("QuestionActions", () => {
       expect(await screen.findByRole("dialog")).toBeInTheDocument();
 
       await userEvent.click(screen.getByText("Edit query definition"));
-      expect(onSetQueryBuilderMode).toHaveBeenCalledWith("dataset", {
-        datasetEditorTab: "query",
+      await waitFor(() => {
+        expect(onSetQueryBuilderMode).toHaveBeenCalledWith("dataset", {
+          datasetEditorTab: "query",
+        });
       });
 
       await userEvent.click(screen.getByText("Edit metadata"));
-      expect(onSetQueryBuilderMode).toHaveBeenCalledWith("dataset", {
-        datasetEditorTab: "metadata",
+      await waitFor(() => {
+        expect(onSetQueryBuilderMode).toHaveBeenCalledWith("dataset", {
+          datasetEditorTab: "metadata",
+        });
       });
     });
 

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/AddAggregationButton/AddAggregationButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/AddAggregationButton/AddAggregationButton.tsx
@@ -9,20 +9,20 @@ import { AggregationPicker } from "../SummarizeSidebar.styled";
 
 import { AddAggregationButtonRoot } from "./AddAggregationButton.styled";
 
-const STAGE_INDEX = -1;
-
 interface AddAggregationButtonProps {
   query: Lib.Query;
+  stageIndex: number;
   onAddAggregations: (aggregation: Lib.Aggregable[]) => void;
 }
 
 export function AddAggregationButton({
   query,
+  stageIndex,
   onAddAggregations,
 }: AddAggregationButtonProps) {
   const [isOpened, setIsOpened] = useState(false);
-  const hasAggregations = Lib.aggregations(query, STAGE_INDEX).length > 0;
-  const operators = Lib.availableAggregationOperators(query, STAGE_INDEX);
+  const hasAggregations = Lib.aggregations(query, stageIndex).length > 0;
+  const operators = Lib.availableAggregationOperators(query, stageIndex);
 
   const renderTooltip = (children: ReactNode) =>
     hasAggregations ? (
@@ -50,7 +50,7 @@ export function AddAggregationButton({
       <Popover.Dropdown>
         <AggregationPicker
           query={query}
-          stageIndex={STAGE_INDEX}
+          stageIndex={stageIndex}
           operators={operators}
           hasExpressionInput={false}
           onAdd={aggregations => {

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/AggregationItem/AggregationItem.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/AggregationItem/AggregationItem.tsx
@@ -7,10 +7,9 @@ import { AggregationPicker } from "../SummarizeSidebar.styled";
 
 import { AggregationName, RemoveIcon, Root } from "./AggregationItem.styled";
 
-const STAGE_INDEX = -1;
-
 interface AggregationItemProps {
   query: Lib.Query;
+  stageIndex: number;
   aggregation: Lib.AggregationClause;
   aggregationIndex: number;
   onAdd: (aggregations: Lib.Aggregable[]) => void;
@@ -20,6 +19,7 @@ interface AggregationItemProps {
 
 export function AggregationItem({
   query,
+  stageIndex,
   aggregation,
   aggregationIndex,
   onAdd,
@@ -27,10 +27,10 @@ export function AggregationItem({
   onRemove,
 }: AggregationItemProps) {
   const [isOpened, setIsOpened] = useState(false);
-  const { displayName } = Lib.displayInfo(query, STAGE_INDEX, aggregation);
+  const { displayName } = Lib.displayInfo(query, stageIndex, aggregation);
 
   const operators = Lib.selectedAggregationOperators(
-    Lib.availableAggregationOperators(query, STAGE_INDEX),
+    Lib.availableAggregationOperators(query, stageIndex),
     aggregation,
   );
 
@@ -49,7 +49,7 @@ export function AggregationItem({
       <Popover.Dropdown>
         <AggregationPicker
           query={query}
-          stageIndex={STAGE_INDEX}
+          stageIndex={stageIndex}
           clause={aggregation}
           clauseIndex={aggregationIndex}
           operators={operators}

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/BreakoutColumnList/BreakoutColumnList.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/BreakoutColumnList/BreakoutColumnList.tsx
@@ -12,10 +12,9 @@ import * as Lib from "metabase-lib";
 import { ColumnGroupName, SearchContainer } from "./BreakoutColumnList.styled";
 import { BreakoutColumnListItem } from "./BreakoutColumnListItem";
 
-const STAGE_INDEX = -1;
-
 export interface BreakoutColumnListProps {
   query: Lib.Query;
+  stageIndex: number;
   onAddBreakout: (column: Lib.ColumnMetadata) => void;
   onUpdateBreakout: (
     breakout: Lib.BreakoutClause,
@@ -27,6 +26,7 @@ export interface BreakoutColumnListProps {
 
 export function BreakoutColumnList({
   query,
+  stageIndex,
   onAddBreakout,
   onUpdateBreakout,
   onRemoveBreakout,
@@ -39,41 +39,51 @@ export function BreakoutColumnList({
   );
   const isSearching = searchQuery.trim().length > 0;
 
-  const breakouts = Lib.breakouts(query, STAGE_INDEX);
+  const breakouts = Lib.breakouts(query, stageIndex);
   const [pinnedBreakouts, setPinnedBreakouts] = useState(breakouts);
 
   const allColumns = useMemo(
-    () => Lib.breakoutableColumns(query, STAGE_INDEX),
-    [query],
+    () => Lib.breakoutableColumns(query, stageIndex),
+    [query, stageIndex],
   );
 
   const [pinnedColumns, unpinnedColumns] = useMemo(
     () =>
       _.partition(allColumns, column =>
-        isPinnedColumn(query, pinnedBreakouts, column),
+        isPinnedColumn(query, stageIndex, pinnedBreakouts, column),
       ),
-    [query, pinnedBreakouts, allColumns],
+    [query, stageIndex, pinnedBreakouts, allColumns],
   );
 
   const pinnedItems = useMemo(
     () =>
-      pinnedColumns.map(column => getColumnListItem(query, breakouts, column)),
-    [query, breakouts, pinnedColumns],
+      pinnedColumns.map(column =>
+        getColumnListItem(query, stageIndex, breakouts, column),
+      ),
+    [query, stageIndex, breakouts, pinnedColumns],
   );
 
   const sections = useMemo(
     () =>
       getColumnSections(
         query,
+        stageIndex,
         isSearching ? allColumns : unpinnedColumns,
         debouncedSearchQuery,
       ),
-    [query, allColumns, unpinnedColumns, isSearching, debouncedSearchQuery],
+    [
+      query,
+      stageIndex,
+      allColumns,
+      unpinnedColumns,
+      isSearching,
+      debouncedSearchQuery,
+    ],
   );
 
   const handleRemovePinnedBreakout = useCallback(
     (column: Lib.ColumnMetadata) => {
-      const { breakoutPosition } = Lib.displayInfo(query, STAGE_INDEX, column);
+      const { breakoutPosition } = Lib.displayInfo(query, stageIndex, column);
       const isPinned =
         breakoutPosition != null && breakoutPosition < pinnedBreakouts.length;
 
@@ -84,7 +94,7 @@ export function BreakoutColumnList({
 
       onRemoveBreakout(column);
     },
-    [query, pinnedBreakouts, onRemoveBreakout],
+    [query, stageIndex, pinnedBreakouts, onRemoveBreakout],
   );
 
   const handleReplaceBreakout = useCallback(
@@ -119,10 +129,11 @@ export function BreakoutColumnList({
       {!isSearching && (
         <DelayGroup>
           <ul data-testid="pinned-dimensions">
-            {pinnedItems.map(item => (
+            {pinnedItems.map((item, itemIndex) => (
               <BreakoutColumnListItem
-                key={item.longDisplayName}
+                key={itemIndex}
                 query={query}
+                stageIndex={stageIndex}
                 item={item}
                 breakout={item.breakout}
                 isPinned
@@ -146,10 +157,11 @@ export function BreakoutColumnList({
             <li key={section.name}>
               <ColumnGroupName>{section.name}</ColumnGroupName>
               <ul>
-                {section.items.map(item => (
+                {section.items.map((item, itemIndex) => (
                   <BreakoutColumnListItem
-                    key={item.longDisplayName}
+                    key={itemIndex}
                     query={query}
+                    stageIndex={stageIndex}
                     item={item}
                     breakout={item.breakout}
                     onAddColumn={onAddBreakout}
@@ -175,10 +187,11 @@ export function BreakoutColumnList({
 
 function getColumnListItem(
   query: Lib.Query,
+  stageIndex: number,
   breakouts: Lib.BreakoutClause[],
   column: Lib.ColumnMetadata,
 ) {
-  const displayInfo = Lib.displayInfo(query, STAGE_INDEX, column);
+  const displayInfo = Lib.displayInfo(query, stageIndex, column);
   const breakout =
     displayInfo.breakoutPosition != null
       ? breakouts[displayInfo.breakoutPosition]
@@ -192,25 +205,26 @@ function getColumnListItem(
 
 function getColumnSections(
   query: Lib.Query,
+  stageIndex: number,
   columns: Lib.ColumnMetadata[],
   searchQuery: string,
 ) {
-  const breakouts = Lib.breakouts(query, STAGE_INDEX);
+  const breakouts = Lib.breakouts(query, stageIndex);
   const formattedSearchQuery = searchQuery.trim().toLowerCase();
 
   const filteredColumns =
     formattedSearchQuery.length > 0
       ? columns.filter(column => {
-          const { displayName } = Lib.displayInfo(query, STAGE_INDEX, column);
+          const { displayName } = Lib.displayInfo(query, stageIndex, column);
           return displayName.toLowerCase().includes(formattedSearchQuery);
         })
       : columns;
 
   return Lib.groupColumns(filteredColumns).map(group => {
-    const groupInfo = Lib.displayInfo(query, STAGE_INDEX, group);
+    const groupInfo = Lib.displayInfo(query, stageIndex, group);
 
     const items = Lib.getColumnsFromColumnGroup(group).map(column =>
-      getColumnListItem(query, breakouts, column),
+      getColumnListItem(query, stageIndex, breakouts, column),
     );
 
     return {
@@ -222,10 +236,11 @@ function getColumnSections(
 
 function isPinnedColumn(
   query: Lib.Query,
+  stageIndex: number,
   pinnedBreakouts: Lib.BreakoutClause[],
   column: Lib.ColumnMetadata,
 ) {
-  const { breakoutPosition } = Lib.displayInfo(query, STAGE_INDEX, column);
+  const { breakoutPosition } = Lib.displayInfo(query, stageIndex, column);
   const maxPinnedBreakoutIndex = pinnedBreakouts.length - 1;
   return breakoutPosition != null && breakoutPosition <= maxPinnedBreakoutIndex;
 }

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/BreakoutColumnList/BreakoutColumnListItem/BreakoutColumnListItem.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/BreakoutColumnList/BreakoutColumnListItem/BreakoutColumnListItem.tsx
@@ -17,10 +17,9 @@ import {
   Root,
 } from "./BreakoutColumnListItem.styled";
 
-const STAGE_INDEX = -1;
-
 interface BreakoutColumnListItemProps {
   query: Lib.Query;
+  stageIndex: number;
   item: Lib.ColumnDisplayInfo & { column: Lib.ColumnMetadata };
   breakout?: Lib.BreakoutClause;
   isPinned?: boolean;
@@ -32,6 +31,7 @@ interface BreakoutColumnListItemProps {
 
 export function BreakoutColumnListItem({
   query,
+  stageIndex,
   item,
   breakout,
   isPinned = false,
@@ -43,12 +43,12 @@ export function BreakoutColumnListItem({
   const isSelected = typeof item.breakoutPosition === "number";
 
   const handleAddClick = useCallback(() => {
-    onAddColumn(Lib.withDefaultBucket(query, STAGE_INDEX, item.column));
-  }, [query, item.column, onAddColumn]);
+    onAddColumn(Lib.withDefaultBucket(query, stageIndex, item.column));
+  }, [query, stageIndex, item.column, onAddColumn]);
 
   const handleListItemClick = useCallback(() => {
-    onReplaceColumns?.(Lib.withDefaultBucket(query, STAGE_INDEX, item.column));
-  }, [query, item.column, onReplaceColumns]);
+    onReplaceColumns?.(Lib.withDefaultBucket(query, stageIndex, item.column));
+  }, [query, stageIndex, item.column, onReplaceColumns]);
 
   const handleRemoveColumn = useCallback(
     (event: MouseEvent) => {
@@ -72,7 +72,7 @@ export function BreakoutColumnListItem({
         <TitleContainer>
           <ColumnTypeIcon
             query={query}
-            stageIndex={STAGE_INDEX}
+            stageIndex={stageIndex}
             column={item.column}
             position="left"
             size={18}
@@ -81,7 +81,7 @@ export function BreakoutColumnListItem({
         </TitleContainer>
         <BucketPickerPopover
           query={query}
-          stageIndex={STAGE_INDEX}
+          stageIndex={stageIndex}
           column={item.column}
           color="summarize"
           isEditing={isSelected}

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeContent/SummarizeAggregationItemList.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeContent/SummarizeAggregationItemList.tsx
@@ -2,15 +2,14 @@ import cx from "classnames";
 
 import CS from "metabase/css/core/index.css";
 import { Group, type GroupProps } from "metabase/ui";
-import * as Lib from "metabase-lib";
+import type * as Lib from "metabase-lib";
 
 import { AddAggregationButton } from "../AddAggregationButton";
 import { AggregationItem } from "../AggregationItem";
 
-import { STAGE_INDEX } from "./use-summarize-query";
-
 type SummarizeAggregationItemListProps = {
   query: Lib.Query;
+  stageIndex: number;
   aggregations: Lib.AggregationClause[];
   onAddAggregations: (aggregations: Lib.Aggregable[]) => void;
   onUpdateAggregation: (
@@ -22,6 +21,7 @@ type SummarizeAggregationItemListProps = {
 
 export const SummarizeAggregationItemList = ({
   query,
+  stageIndex,
   aggregations,
   onAddAggregations,
   onUpdateAggregation,
@@ -36,8 +36,9 @@ export const SummarizeAggregationItemList = ({
   >
     {aggregations.map((aggregation, aggregationIndex) => (
       <AggregationItem
-        key={Lib.displayInfo(query, STAGE_INDEX, aggregation).longDisplayName}
+        key={aggregationIndex}
         query={query}
+        stageIndex={stageIndex}
         aggregation={aggregation}
         aggregationIndex={aggregationIndex}
         onAdd={onAddAggregations}
@@ -47,6 +48,10 @@ export const SummarizeAggregationItemList = ({
         onRemove={() => onRemoveAggregation(aggregation)}
       />
     ))}
-    <AddAggregationButton query={query} onAddAggregations={onAddAggregations} />
+    <AddAggregationButton
+      query={query}
+      stageIndex={stageIndex}
+      onAddAggregations={onAddAggregations}
+    />
   </Group>
 );

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeContent/SummarizeBreakoutColumnList.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeContent/SummarizeBreakoutColumnList.tsx
@@ -10,6 +10,7 @@ import { SectionTitle } from "../SummarizeSidebar.styled";
 
 type SummarizeBreakoutColumnListProps = {
   query: Lib.Query;
+  stageIndex: number;
   onAddBreakout: (column: Lib.ColumnMetadata) => void;
   onUpdateBreakout: (
     clause: Lib.BreakoutClause,
@@ -21,6 +22,7 @@ type SummarizeBreakoutColumnListProps = {
 
 export const SummarizeBreakoutColumnList = ({
   query,
+  stageIndex,
   onAddBreakout,
   onUpdateBreakout,
   onRemoveBreakout,
@@ -36,6 +38,7 @@ export const SummarizeBreakoutColumnList = ({
     <SectionTitle>{t`Group by`}</SectionTitle>
     <BreakoutColumnList
       query={query}
+      stageIndex={stageIndex}
       onAddBreakout={onAddBreakout}
       onUpdateBreakout={onUpdateBreakout}
       onRemoveBreakout={onRemoveBreakout}

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeContent/use-summarize-query.ts
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeContent/use-summarize-query.ts
@@ -2,21 +2,39 @@ import { useCallback, useMemo, useState } from "react";
 
 import * as Lib from "metabase-lib";
 
-export const STAGE_INDEX = -1;
-export const useSummarizeQuery = (
-  initialQuery: Lib.Query,
-  onQueryChange: (query: Lib.Query) => void,
-) => {
-  const [isDefaultAggregationRemoved, setDefaultAggregationRemoved] =
-    useState(false);
+const STAGE_INDEX = -1;
+
+interface UseSummarizeQueryProps {
+  query: Lib.Query;
+  onQueryChange: (nextQuery: Lib.Query) => void;
+}
+
+export const useSummarizeQuery = ({
+  query: initialQuery,
+  onQueryChange,
+}: UseSummarizeQueryProps) => {
+  const [hasDefaultAggregation, setHasDefaultAggregation] = useState(() =>
+    shouldAddDefaultAggregation(initialQuery),
+  );
 
   const query = useMemo(
-    () => getQuery(initialQuery, isDefaultAggregationRemoved),
-    [initialQuery, isDefaultAggregationRemoved],
+    () =>
+      hasDefaultAggregation
+        ? Lib.aggregateByCount(initialQuery, STAGE_INDEX)
+        : initialQuery,
+    [initialQuery, hasDefaultAggregation],
   );
 
   const aggregations = Lib.aggregations(query, STAGE_INDEX);
   const hasAggregations = aggregations.length > 0;
+
+  const handleChange = useCallback(
+    (nextQuery: Lib.Query) => {
+      setHasDefaultAggregation(false);
+      onQueryChange(nextQuery);
+    },
+    [onQueryChange],
+  );
 
   const handleAddAggregations = useCallback(
     (aggregations: Lib.Aggregable[]) => {
@@ -24,9 +42,9 @@ export const useSummarizeQuery = (
         (query, aggregation) => Lib.aggregate(query, STAGE_INDEX, aggregation),
         query,
       );
-      onQueryChange(nextQuery);
+      handleChange(nextQuery);
     },
-    [query, onQueryChange],
+    [query, handleChange],
   );
 
   const handleUpdateAggregation = useCallback(
@@ -37,61 +55,61 @@ export const useSummarizeQuery = (
         aggregation,
         nextAggregation,
       );
-      onQueryChange(nextQuery);
+      handleChange(nextQuery);
     },
-    [query, onQueryChange],
+    [query, handleChange],
   );
 
   const handleRemoveAggregation = useCallback(
     (aggregation: Lib.AggregationClause) => {
-      const nextQuery = Lib.removeClause(query, STAGE_INDEX, aggregation);
-      const nextAggregations = Lib.aggregations(nextQuery, STAGE_INDEX);
-      if (nextAggregations.length === 0) {
-        setDefaultAggregationRemoved(true);
+      if (hasDefaultAggregation) {
+        setHasDefaultAggregation(false);
+      } else {
+        handleChange(Lib.removeClause(query, STAGE_INDEX, aggregation));
       }
-      onQueryChange(nextQuery);
     },
-    [query, onQueryChange],
+    [query, hasDefaultAggregation, handleChange],
   );
 
   const handleAddBreakout = useCallback(
     (column: Lib.ColumnMetadata) => {
       const nextQuery = Lib.breakout(query, STAGE_INDEX, column);
-      onQueryChange(nextQuery);
+      handleChange(nextQuery);
     },
-    [query, onQueryChange],
+    [query, handleChange],
   );
 
   const handleUpdateBreakout = useCallback(
     (clause: Lib.BreakoutClause, column: Lib.ColumnMetadata) => {
       const nextQuery = Lib.replaceClause(query, STAGE_INDEX, clause, column);
-      onQueryChange(nextQuery);
+      handleChange(nextQuery);
     },
-    [query, onQueryChange],
+    [query, handleChange],
   );
 
   const handleRemoveBreakout = useCallback(
     (column: Lib.ColumnMetadata) => {
       const { breakoutPosition } = Lib.displayInfo(query, STAGE_INDEX, column);
-      if (typeof breakoutPosition === "number") {
+      if (breakoutPosition != null) {
         const breakouts = Lib.breakouts(query, STAGE_INDEX);
         const clause = breakouts[breakoutPosition];
         const nextQuery = Lib.removeClause(query, STAGE_INDEX, clause);
-        onQueryChange(nextQuery);
+        handleChange(nextQuery);
       }
     },
-    [query, onQueryChange],
+    [query, handleChange],
   );
 
   const handleReplaceBreakouts = useCallback(
     (column: Lib.ColumnMetadata) => {
       const nextQuery = Lib.replaceBreakouts(query, STAGE_INDEX, column);
-      onQueryChange(nextQuery);
+      handleChange(nextQuery);
     },
-    [query, onQueryChange],
+    [query, handleChange],
   );
   return {
     query,
+    stageIndex: STAGE_INDEX,
     aggregations,
     hasAggregations,
     handleAddAggregations,
@@ -104,17 +122,7 @@ export const useSummarizeQuery = (
   };
 };
 
-function getQuery(query: Lib.Query, isDefaultAggregationRemoved: boolean) {
-  const hasAggregations = Lib.aggregations(query, STAGE_INDEX).length > 0;
-
-  const shouldAddDefaultAggregation =
-    !hasAggregations &&
-    !Lib.isMetricBased(query, STAGE_INDEX) &&
-    !isDefaultAggregationRemoved;
-
-  if (!shouldAddDefaultAggregation) {
-    return query;
-  }
-
-  return Lib.aggregateByCount(query);
+function shouldAddDefaultAggregation(query: Lib.Query): boolean {
+  const aggregations = Lib.aggregations(query, STAGE_INDEX);
+  return aggregations.length === 0 && !Lib.isMetricBased(query, STAGE_INDEX);
 }

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.tsx
@@ -27,6 +27,7 @@ export function SummarizeSidebar({
 }: SummarizeSidebarProps) {
   const {
     query,
+    stageIndex,
     aggregations,
     hasAggregations,
     handleAddAggregations,
@@ -36,7 +37,10 @@ export function SummarizeSidebar({
     handleUpdateBreakout,
     handleRemoveBreakout,
     handleReplaceBreakouts,
-  } = useSummarizeQuery(initialQuery, onQueryChange);
+  } = useSummarizeQuery({
+    query: initialQuery,
+    onQueryChange,
+  });
 
   const handleDoneClick = useCallback(() => {
     onQueryChange(query);
@@ -53,6 +57,7 @@ export function SummarizeSidebar({
       <SummarizeAggregationItemList
         px="lg"
         query={query}
+        stageIndex={stageIndex}
         aggregations={aggregations}
         onAddAggregations={handleAddAggregations}
         onUpdateAggregation={handleUpdateAggregation}
@@ -63,6 +68,7 @@ export function SummarizeSidebar({
         <SummarizeBreakoutColumnList
           px="lg"
           query={query}
+          stageIndex={stageIndex}
           onAddBreakout={handleAddBreakout}
           onUpdateBreakout={handleUpdateBreakout}
           onRemoveBreakout={handleRemoveBreakout}

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.unit.spec.tsx
@@ -135,14 +135,28 @@ describe("SummarizeSidebar", () => {
       expect(onQueryChange).toHaveBeenCalledTimes(1);
     });
 
-    it("should allow to remove a default aggregation", async () => {
-      const { getNextAggregations, onQueryChange } = await setup();
+    it("should allow to remove the default aggregation without triggering a query update", async () => {
+      const { onQueryChange } = await setup();
 
       const countButton = screen.getByLabelText("Count");
       await userEvent.click(within(countButton).getByLabelText("close icon"));
 
+      expect(screen.queryByLabelText("Count")).not.toBeInTheDocument();
+      expect(onQueryChange).not.toHaveBeenCalled();
+    });
+
+    it("should allow to add the default aggregation manually after it was removed", async () => {
+      const { getNextAggregations, onQueryChange } = await setup();
+
+      const countButton = screen.getByLabelText("Count");
+      await userEvent.click(within(countButton).getByLabelText("close icon"));
+      await userEvent.click(screen.getByText("Add a metric"));
+      await userEvent.click(await screen.findByText("Count of rows"));
+
       const aggregations = getNextAggregations();
-      expect(aggregations).toHaveLength(0);
+      const [aggregation] = aggregations;
+      expect(aggregations).toHaveLength(1);
+      expect(aggregation.displayName).toBe("Count");
       expect(onQueryChange).toHaveBeenCalledTimes(1);
     });
 

--- a/frontend/src/metabase/reference/utils.js
+++ b/frontend/src/metabase/reference/utils.js
@@ -66,7 +66,7 @@ export const getQuestion = ({
     let query = Lib.queryFromTableOrCardMetadata(metadataProvider, table);
 
     if (getCount) {
-      query = Lib.aggregateByCount(query);
+      query = Lib.aggregateByCount(query, -1);
     }
 
     if (fieldId) {


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/44298
Demo https://www.loom.com/share/ea943eaf9548456da9c8606eb1a5083d

Previously removing the default aggregation in the summarize sidebar was a destructive action. Now we handle it with a simple state update.

I did some small cleanup and passed `stageIndex: -1` from a single place in summarize components.

How to verify:
- New -> Question -> Orders
- Join -> Products. Select some specific fields in the join, like ID, Category.
- Visualize
- Summarize -> Remove the default aggregation 
- Nothing should happen apart from changes in the sidebar itself
- Open the notebook editor
- Open join field picker
- See that your fields are still there