### PR TITLE
Implement transfer queues for performing async backfills

### DIFF
--- a/src/metabase/util/queue.clj
+++ b/src/metabase/util/queue.clj
@@ -1,0 +1,83 @@
+(ns metabase.util.queue
+  (:import
+   (java.util HashSet Queue Set)
+   (java.util.concurrent ArrayBlockingQueue BlockingQueue SynchronousQueue TimeUnit)))
+
+(set! *warn-on-reflection* true)
+
+(defprotocol BoundedTransferQueue
+  (maybePut! [queue msg]
+    "Put a message on the queue if there is space for it, otherwise drop it.
+     Returns whether the item was enqueued.")
+  (blockingPut! [queue msg]
+    "Put a message on the queue. If necessary, block until there is space for it.")
+  (blockingTake! [queue]
+    "Take a message off the queue, blocking if necessary."))
+
+;; Similar to java.util.concurrent.LinkedTransferQueue, but bounded.
+(deftype ^:private ArrayTransferQueue
+         [^ArrayBlockingQueue async-queue
+          ^SynchronousQueue sync-queue
+          ^long block-ms
+          ^long sleep-ms]
+  BoundedTransferQueue
+  (maybePut! [_ msg]
+    (.offer async-queue msg))
+  (blockingPut! [_ msg]
+    (.offer sync-queue msg Long/MAX_VALUE TimeUnit/DAYS))
+  (blockingTake! [_]
+    ;; Async messages are given higher priority, as sync messages will never be dropped.
+    (or (.poll async-queue)
+        (.poll sync-queue block-ms TimeUnit/MILLISECONDS)
+        (do (Thread/sleep ^long sleep-ms)
+            (recur)))))
+
+;; Similar to ArrayTransferQueue, but drops events that are already in the queue.
+(deftype ^:private DeduplicatingArrayTransferQueue
+  [^Queue async-queue
+   ^BlockingQueue sync-queue
+   ^Set queued-set
+   ^long block-ms
+   ^long sleep-ms]
+  BoundedTransferQueue
+  (maybePut!
+    [_ msg]
+    (let [payload (:payload msg msg)]
+      ;; we hold the lock while we push to avoid races
+      (locking queued-set
+        ;; returns null if we have already enqueued the message
+        (when (.add queued-set payload)
+          ;; returns false if we dropped the message
+          (when-not (.offer ^Queue async-queue msg)
+            (.remove queued-set payload))))))
+  (blockingPut! [_ msg]
+   ;; we cannot hold the lock while we push, so there is some chance of a duplicate
+    (when (locking queued-set (.add queued-set (:payload msg msg)))
+      (.offer sync-queue msg Long/MAX_VALUE TimeUnit/DAYS)))
+  (blockingTake! [_]
+   ;; we lock here to avoid leaving a blocking entry behind that can never be cleared
+    (or (locking queued-set
+          (when-let [msg (or (.poll ^Queue async-queue)
+                             (.poll sync-queue block-ms TimeUnit/MILLISECONDS))]
+            (.remove queued-set (:payload msg msg))
+            msg))
+        (do (Thread/sleep ^long sleep-ms)
+            (recur)))))
+
+(defn bounded-transaction-queue
+  "Create a bounded transfer queue, specialized based on the high-level options."
+  [capacity & {:keys [block-ms sleep-ms dedupe?]
+               :or   {block-ms 100
+                      sleep-ms 100
+                      dedupe?  false}}]
+  (if dedupe?
+    (->DeduplicatingArrayTransferQueue (ArrayBlockingQueue. capacity)
+                                       (SynchronousQueue.)
+                                       (HashSet.)
+                                       block-ms
+                                       sleep-ms)
+
+    (->ArrayTransferQueue (ArrayBlockingQueue. capacity)
+                          (SynchronousQueue.)
+                          block-ms
+                          sleep-ms)))

--- a/src/metabase/util/queue.clj
+++ b/src/metabase/util/queue.clj
@@ -49,7 +49,7 @@
         (when (.add queued-set payload)
           (let [accepted? (.offer ^Queue async-queue msg)]
             (when-not accepted?
-             (.remove queued-set payload))
+              (.remove queued-set payload))
             accepted?)))))
   (blockingPut! [_ msg]
    ;; we cannot hold the lock while we push, so there is some chance of a duplicate

--- a/src/metabase/util/queue.clj
+++ b/src/metabase/util/queue.clj
@@ -16,10 +16,10 @@
 
 ;; Similar to java.util.concurrent.LinkedTransferQueue, but bounded.
 (deftype ^:private ArrayTransferQueue
-         [^ArrayBlockingQueue async-queue
-          ^SynchronousQueue sync-queue
-          ^long block-ms
-          ^long sleep-ms]
+  [^ArrayBlockingQueue async-queue
+   ^SynchronousQueue sync-queue
+   ^long block-ms
+   ^long sleep-ms]
   BoundedTransferQueue
   (maybePut! [_ msg]
     (.offer async-queue msg))

--- a/src/metabase/util/queue.clj
+++ b/src/metabase/util/queue.clj
@@ -64,7 +64,7 @@
         (do (Thread/sleep ^long sleep-ms)
             (recur)))))
 
-(defn bounded-transaction-queue
+(defn bounded-transfer-queue
   "Create a bounded transfer queue, specialized based on the high-level options."
   [capacity & {:keys [block-ms sleep-ms dedupe?]
                :or   {block-ms 100

--- a/src/metabase/util/queue.clj
+++ b/src/metabase/util/queue.clj
@@ -47,9 +47,10 @@
       (locking queued-set
         ;; returns null if we have already enqueued the message
         (when (.add queued-set payload)
-          ;; returns false if we dropped the message
-          (when-not (.offer ^Queue async-queue msg)
-            (.remove queued-set payload))))))
+          (let [accepted? (.offer ^Queue async-queue msg)]
+            (when-not accepted?
+             (.remove queued-set payload))
+            accepted?)))))
   (blockingPut! [_ msg]
    ;; we cannot hold the lock while we push, so there is some chance of a duplicate
     (when (locking queued-set (.add queued-set (:payload msg msg)))

--- a/test/metabase/util/queue_test.clj
+++ b/test/metabase/util/queue_test.clj
@@ -1,0 +1,59 @@
+(ns metabase.util.queue-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [metabase.util :as u]
+   [metabase.util.queue :as queue])
+  (:import
+   (java.util Set)
+   (metabase.util.queue DeduplicatingArrayTransactionQueue)))
+
+(set! *warn-on-reflection* true)
+
+(deftest deduplicateing-bounded-blocking-queue-test
+  (let [capacity         10
+        q                (queue/bounded-transaction-queue capacity :sleep-ms 10 :block-ms 10 :dedupe? true)
+        realtime-threads 5
+        n-real           300
+        n-back           10000
+        dropped          (volatile! 0)
+        realtime-fn      (fn []
+                           (let [id (rand-int 1000)]
+                             (dotimes [i n-real]
+                            ;; Enqueue realtime events from newest to oldest
+                               (let [payload (- (dec n-back) i)]
+                                 (when-not (queue/maybePut! q {:thread (str "real-" id) :payload payload})
+                                   (vswap! dropped inc)))
+                               (Thread/sleep 1))))
+        background-fn    (fn []
+                           (dotimes [i n-back]
+                          ;; Enqueue background events from oldest to newest
+                             (queue/blockingPut! q {:thread "back", :payload i})))
+        run!             (fn [f]
+                           (future (f)))]
+
+    (run! background-fn)
+    (future
+      (dotimes [i realtime-threads]
+        ;; Stagger out when the realtime threads start
+        (Thread/sleep ^long (* 100 i))
+        (run! realtime-fn)))
+
+    (let [processed (volatile! [])]
+      (try
+        (while true
+          ;; Stop the consumer once we are sure that there are no more events coming.
+          (u/with-timeout 100
+            (vswap! processed conj (:payload (queue/blockingTake! q)))))
+        (testing "This is never reached"
+          (is false))
+        (catch Exception _
+          (testing "We processed at least as many events as guaranteed"
+            (is (>= (count @processed) (+ n-back capacity))))
+          (testing "Some items are dropped"
+            (is (pos? @dropped)))
+          (testing "Some items are deduplicated"
+            (is (< (count @processed) (+ n-back (* realtime-threads n-real)))))
+          (testing "Every item is processed"
+            (is (= (set (range n-back)) (set @processed))))
+          (testing "No phantom items are left in the set"
+            (is (zero? (.size ^Set (.-queued-set ^DeduplicatingArrayTransactionQueue q))))))))))

--- a/test/metabase/util/queue_test.clj
+++ b/test/metabase/util/queue_test.clj
@@ -20,14 +20,14 @@
         realtime-fn      (fn []
                            (let [id (rand-int 1000)]
                              (dotimes [i n-real]
-                            ;; Enqueue realtime events from newest to oldest
+                               ;; Enqueue realtime events from newest to oldest
                                (let [payload (- (dec n-back) i)]
                                  (when-not (queue/maybePut! q {:thread (str "real-" id) :payload payload})
                                    (vswap! dropped inc)))
                                (Thread/sleep 1))))
         background-fn    (fn []
                            (dotimes [i n-back]
-                          ;; Enqueue background events from oldest to newest
+                             ;; Enqueue background events from oldest to newest
                              (queue/blockingPut! q {:thread "back", :payload i})))
         run!             (fn [f]
                            (future (f)))]

--- a/test/metabase/util/queue_test.clj
+++ b/test/metabase/util/queue_test.clj
@@ -11,7 +11,7 @@
 
 (deftest deduplicateing-bounded-blocking-queue-test
   (let [capacity         10
-        q                (queue/bounded-transaction-queue capacity :sleep-ms 10 :block-ms 10 :dedupe? true)
+        q                (queue/bounded-transfer-queue capacity :sleep-ms 10 :block-ms 10 :dedupe? true)
         realtime-threads 5
         n-real           300
         n-back           10000

--- a/test/metabase/util/queue_test.clj
+++ b/test/metabase/util/queue_test.clj
@@ -1,11 +1,12 @@
 (ns metabase.util.queue-test
   (:require
    [clojure.test :refer [deftest is testing]]
+   [metabase.test :as mt]
    [metabase.util :as u]
    [metabase.util.queue :as queue])
   (:import
    (java.util Set)
-   (metabase.util.queue DeduplicatingArrayTransactionQueue)))
+   (metabase.util.queue DeduplicatingArrayTransferQueue)))
 
 (set! *warn-on-reflection* true)
 
@@ -55,5 +56,7 @@
             (is (< (count @processed) (+ n-back (* realtime-threads n-real)))))
           (testing "Every item is processed"
             (is (= (set (range n-back)) (set @processed))))
+          (testing "The realtime events are processed in order"
+            (mt/ordered-subset? (take n-real (range (dec n-back) 0 -1)) @processed))
           (testing "No phantom items are left in the set"
-            (is (zero? (.size ^Set (.-queued-set ^DeduplicatingArrayTransactionQueue q))))))))))
+            (is (zero? (.size ^Set (.-queued-set ^DeduplicatingArrayTransferQueue q))))))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/45461

### Description

This is a fairly generic queue that's come out of discussion around using bounded resources for backfills. It essentially implements a bounded version of Java's built-in `TransactionQueue`, which allows publishers to optionally block until their message has been processed. For non-blocking publishers it behaves like a regular `ArrayBlockingQueue`. 

We may want to rework or abandon this based on the outcome of the related [tech doc](https://www.notion.so/metabase/Minimal-SQL-Analysis-Scheduling-ab8b5a63c1dc4fa3b820173b0cd9fe75) for the SQL analysis backfill.