### PR TITLE
Fix the markdown preview in model details

### DIFF
--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -816,11 +816,10 @@ describe("issue 34574", () => {
     cy.findByTestId("sidebar-right").within(() => {
       cy.log("Set the model description to a markdown text");
       cy.intercept("PUT", `/api/card/${ORDERS_MODEL_ID}`).as("updateModel");
-      cy.findByPlaceholderText("Add description")
-        .type(
-          "# Hello{enter}## World{enter}This is an **important** description!",
-        )
-        .blur();
+      cy.findByPlaceholderText("Add description").type(
+        "# Hello{enter}## World{enter}This is an **important** description!",
+      );
+      cy.realPress("Tab");
       cy.wait("@updateModel");
 
       cy.log("Make sure we immediately render the proper markdown");

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelInfoSidePanel/ModelInfoSidePanel.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelInfoSidePanel/ModelInfoSidePanel.tsx
@@ -40,6 +40,7 @@ function ModelInfoSidePanel({ model, mainTable, onChangeDescription }: Props) {
           }
           isOptional
           isMultiline
+          isMarkdown
           isDisabled={!canWrite}
           aria-label={t`Description`}
           onChange={onChangeDescription}


### PR DESCRIPTION
### What does this PR accomplish?
Fixes #34574.
Adds an E2E reproduction for this issue to prevent future regressions.

### Demo
Screenshots from different phases of the test

**Model info sidebar**
![image](https://github.com/metabase/metabase/assets/31325167/0e30339d-7514-4828-bcd2-c1ccc51cc912)

**Model details page**
![image](https://github.com/metabase/metabase/assets/31325167/c7c89b8f-9247-4204-8f0f-2467d9e7c06d)

** The final assertion - collections overview page**
![image](https://github.com/metabase/metabase/assets/31325167/9697380d-b24a-43dc-8bdc-1f1e6adb6073)

### Stress-test
50 x ✅ https://github.com/metabase/metabase/actions/runs/9894209160
