### PR TITLE
Fix broken link to "No self-service" deprecation docs

### DIFF
--- a/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorLegacyWarning.tsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorLegacyWarning.tsx
@@ -28,7 +28,7 @@ export const PermissionsEditorLegacyNoSelfServiceWarning = () => {
             <Anchor
               fw="bold"
               target="_blank"
-              href="https://www.metabase.com/docs/v0.50/permissions/no-self-service-deprecated"
+              href="https://www.metabase.com/docs/v0.50/permissions/no-self-service-deprecation"
               style={{ color: colors.accent7 }}
             >{t`Need help? See our docs.`}</Anchor>
           </Text>


### PR DESCRIPTION
Old link (doesn't work): https://www.metabase.com/docs/v0.50/permissions/no-self-service-deprecated
Correct link: https://www.metabase.com/docs/v0.50/permissions/no-self-service-deprecation

Previous PR: #43038