### PR TITLE
Add support for disabled command palette items. Make search states disabled

### DIFF
--- a/frontend/src/metabase/palette/components/PaletteResultItem.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResultItem.tsx
@@ -32,7 +32,7 @@ export const PaletteResultItem = ({ item, active }: PaletteResultItemProps) => {
       gap="0.5rem"
       fw={700}
       style={{
-        cursor: "pointer",
+        cursor: item.disabled ? "default" : "cursor",
         borderRadius: "0.5rem",
         flexGrow: 1,
         flexBasis: 0,
@@ -40,6 +40,7 @@ export const PaletteResultItem = ({ item, active }: PaletteResultItemProps) => {
       bg={active ? color("brand") : "none"}
       c={active ? color("text-white") : color("text-dark")}
       aria-label={item.name}
+      aria-disabled={item.disabled ? true : false}
     >
       {/** Icon Container */}
       {icon && (

--- a/frontend/src/metabase/palette/components/PaletteResults.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResults.tsx
@@ -9,7 +9,7 @@ import { Flex, Box } from "metabase/ui";
 
 import { useCommandPalette } from "../hooks/useCommandPalette";
 import type { PaletteActionImpl } from "../types";
-import { processResults, findClosestActionIndex } from "../utils";
+import { processResults, navigateActionIndex } from "../utils";
 
 import { PaletteResultItem } from "./PaletteResultItem";
 import { PaletteResultList } from "./PaletteResultsList";
@@ -37,23 +37,24 @@ export const PaletteResults = withRouter(
     }, [processedResults, query]);
 
     useKeyPressEvent("End", () => {
-      const lastIndex = processedResults.length - 1;
-      query.setActiveIndex(lastIndex);
+      query.setActiveIndex(
+        navigateActionIndex(processedResults, processedResults.length, -1),
+      );
     });
 
     useKeyPressEvent("Home", () => {
-      query.setActiveIndex(1);
+      query.setActiveIndex(navigateActionIndex(processedResults, -1, 1));
     });
 
     useKeyPressEvent("PageDown", () => {
       query.setActiveIndex(i =>
-        findClosestActionIndex(processedResults, i, PAGE_SIZE),
+        navigateActionIndex(processedResults, i, PAGE_SIZE),
       );
     });
 
     useKeyPressEvent("PageUp", () => {
       query.setActiveIndex(i =>
-        findClosestActionIndex(processedResults, i, -PAGE_SIZE),
+        navigateActionIndex(processedResults, i, -PAGE_SIZE),
       );
     });
 

--- a/frontend/src/metabase/palette/components/PaletteResults.unit.spec.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResults.unit.spec.tsx
@@ -271,4 +271,15 @@ describe("PaletteResults", () => {
     // One call is always made to determine if the instance has models inside useCommandPaletteBasicActions
     expect(fetchMock.calls("path:/api/search").length).toBe(2);
   });
+
+  it("should not allow you to select or click disabled items", async () => {
+    setup({ query: "modelsssss" });
+    expect(await screen.findByLabelText(/No results/)).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+    expect(
+      await screen.findByLabelText(/Search documentation/),
+    ).toHaveAttribute("aria-disabled", "false");
+  });
 });

--- a/frontend/src/metabase/palette/components/PaletteResultsList.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResultsList.tsx
@@ -11,6 +11,7 @@ import { useKBar, KBAR_LISTBOX, getListboxItemId } from "kbar";
 import * as React from "react";
 
 import type { PaletteActionImpl } from "../types";
+import { navigateActionIndex } from "../utils";
 
 const START_INDEX = 0;
 
@@ -52,15 +53,7 @@ export const PaletteResultList: React.FC<PaletteResultListProps> = props => {
         event.preventDefault();
         event.stopPropagation();
         query.setActiveIndex(index => {
-          let nextIndex = index > START_INDEX ? index - 1 : index;
-          // avoid setting active index on a group
-          if (typeof itemsRef.current[nextIndex] === "string") {
-            if (nextIndex === 0) {
-              return index;
-            }
-            nextIndex -= 1;
-          }
-          return nextIndex;
+          return navigateActionIndex(itemsRef.current, index, -1);
         });
       } else if (
         event.key === "ArrowDown" ||
@@ -69,16 +62,7 @@ export const PaletteResultList: React.FC<PaletteResultListProps> = props => {
         event.preventDefault();
         event.stopPropagation();
         query.setActiveIndex(index => {
-          let nextIndex =
-            index < itemsRef.current.length - 1 ? index + 1 : index;
-          // avoid setting active index on a group
-          if (typeof itemsRef.current[nextIndex] === "string") {
-            if (nextIndex === itemsRef.current.length - 1) {
-              return index;
-            }
-            nextIndex += 1;
-          }
-          return nextIndex;
+          return navigateActionIndex(itemsRef.current, index, 1);
         });
       } else if (event.key === "Enter") {
         event.preventDefault();
@@ -154,12 +138,13 @@ export const PaletteResultList: React.FC<PaletteResultListProps> = props => {
         }}
       >
         {props.items.map((item, index) => {
-          const handlers = typeof item !== "string" && {
-            onPointerMove: () =>
-              activeIndex !== index && query.setActiveIndex(index),
-            onPointerDown: () => query.setActiveIndex(index),
-            onClick: () => execute(item),
-          };
+          const handlers = typeof item !== "string" &&
+            item.disabled !== true && {
+              onPointerMove: () =>
+                activeIndex !== index && query.setActiveIndex(index),
+              onPointerDown: () => query.setActiveIndex(index),
+              onClick: () => execute(item),
+            };
           const active = index === activeIndex;
 
           return (

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -148,6 +148,7 @@ export const useCommandPalette = ({
           name: t`Loading...`,
           keywords: searchQuery,
           section: "search",
+          disabled: true,
         },
       ];
     } else if (searchError) {
@@ -156,6 +157,7 @@ export const useCommandPalette = ({
           id: "search-error",
           name: t`Could not load search results`,
           section: "search",
+          disabled: true,
         },
       ];
     } else if (debouncedSearchText) {
@@ -208,6 +210,7 @@ export const useCommandPalette = ({
             name: t`No results for “${debouncedSearchText}”`,
             keywords: debouncedSearchText,
             section: "search",
+            disabled: true,
           },
         ];
       }

--- a/frontend/src/metabase/palette/types.ts
+++ b/frontend/src/metabase/palette/types.ts
@@ -17,6 +17,7 @@ interface PaletteActionExtras {
     /** subtext: text to come after the item name */
     subtext?: string;
   };
+  disabled?: boolean;
 }
 
 export type PaletteAction = Action &

--- a/frontend/src/metabase/palette/utils.ts
+++ b/frontend/src/metabase/palette/utils.ts
@@ -35,6 +35,21 @@ export const processSection = (
   }
 };
 
+const actionIsStringOrDisabled = (action: string | PaletteActionImpl) =>
+  typeof action === "string" || action.disabled;
+
+export const navigateActionIndex = (
+  actions: (string | PaletteActionImpl)[],
+  index: number,
+  diff: number,
+): number => {
+  if (actions.every(action => typeof action === "string" || action.disabled)) {
+    return index;
+  } else {
+    return findClosestActionIndex(actions, index, diff);
+  }
+};
+
 export const findClosestActionIndex = (
   actions: (string | PaletteActionImpl)[],
   index: number,
@@ -44,7 +59,7 @@ export const findClosestActionIndex = (
     return findClosestActionIndex(actions, -1, 1);
   } else if (index + diff > actions.length - 1) {
     return findClosestActionIndex(actions, actions.length, -1);
-  } else if (typeof actions[index + diff] === "string") {
+  } else if (actionIsStringOrDisabled(actions[index + diff])) {
     if (diff < 0) {
       return findClosestActionIndex(actions, index, diff - 1);
     } else {

--- a/frontend/src/metabase/palette/utils.unit.spec.ts
+++ b/frontend/src/metabase/palette/utils.unit.spec.ts
@@ -1,15 +1,18 @@
 import type { PaletteActionImpl } from "./types";
-import { processResults, processSection } from "./utils";
+import { navigateActionIndex, processResults, processSection } from "./utils";
 
 interface mockAction {
   name: string;
   section?: string;
+  disabled?: boolean;
 }
 
 const createMockAction = ({
   name,
   section = "basic",
-}: mockAction): PaletteActionImpl => ({ name, section } as PaletteActionImpl);
+  disabled,
+}: mockAction): PaletteActionImpl =>
+  ({ name, section, disabled } as PaletteActionImpl);
 
 describe("command palette utils", () => {
   describe("processSection", () => {
@@ -102,6 +105,105 @@ describe("command palette utils", () => {
           expect(val).toBeLessThan(next);
         },
       );
+    });
+  });
+
+  describe("navigateActionIndex", () => {
+    const DISABLED = createMockAction({ name: "disabled", disabled: true });
+    const NORMAL = createMockAction({ name: "normal" });
+
+    it("should navigate to the next index", () => {
+      const items = [NORMAL, NORMAL, NORMAL];
+      const index = 0;
+      expect(navigateActionIndex(items, index, 1)).toBe(1);
+    });
+    it("should navigate to the previous index", () => {
+      const items = [NORMAL, NORMAL, NORMAL];
+      const index = 1;
+      expect(navigateActionIndex(items, index, -1)).toBe(0);
+    });
+    it("should navigate not navigate off the list", () => {
+      const items = [NORMAL, NORMAL, NORMAL];
+      expect(navigateActionIndex(items, 0, -1)).toBe(0);
+      expect(navigateActionIndex(items, 0, -4)).toBe(0);
+      expect(navigateActionIndex(items, 2, 1)).toBe(2);
+      expect(navigateActionIndex(items, 2, 10)).toBe(2);
+    });
+    it("should handle indexes being out of normal bounds", () => {
+      const items = [NORMAL, NORMAL, NORMAL];
+      expect(navigateActionIndex(items, -3, -1)).toBe(0);
+      expect(navigateActionIndex(items, -3, 1)).toBe(0);
+
+      expect(navigateActionIndex(items, 20, 1)).toBe(2);
+      expect(navigateActionIndex(items, 20, -1)).toBe(2);
+    });
+    it("should navigate past strings", () => {
+      const items = [NORMAL, "foo", NORMAL, NORMAL];
+      expect(navigateActionIndex(items, 0, 1)).toBe(2);
+      expect(navigateActionIndex(items, 2, -1)).toBe(0);
+    });
+    it("should navigate past disabled items", () => {
+      const items = [NORMAL, DISABLED, NORMAL, NORMAL];
+      expect(navigateActionIndex(items, 0, 1)).toBe(2);
+      expect(navigateActionIndex(items, 2, -1)).toBe(0);
+    });
+    it("should handle disabled items and strings near boundries", () => {
+      const short = [DISABLED, NORMAL, NORMAL, NORMAL, "foo"];
+      expect(navigateActionIndex(short, 3, 1)).toBe(3);
+      expect(navigateActionIndex(short, 1, -1)).toBe(1);
+
+      const long = [DISABLED, DISABLED, NORMAL, NORMAL, NORMAL, "foo", "foo"];
+      expect(navigateActionIndex(long, 4, 1)).toBe(4);
+      expect(navigateActionIndex(long, 4, 2)).toBe(4);
+      expect(navigateActionIndex(long, 4, 3)).toBe(4);
+      expect(navigateActionIndex(long, 3, 2)).toBe(4);
+      expect(navigateActionIndex(long, 3, 3)).toBe(4);
+
+      expect(navigateActionIndex(long, 2, -1)).toBe(2);
+      expect(navigateActionIndex(long, 2, -2)).toBe(2);
+      expect(navigateActionIndex(long, 2, -3)).toBe(2);
+      expect(navigateActionIndex(long, 3, -2)).toBe(2);
+      expect(navigateActionIndex(long, 3, -4)).toBe(2);
+    });
+
+    it("should handle when current index is a string or disabled", () => {
+      const items = [DISABLED, DISABLED, NORMAL, NORMAL, NORMAL, "foo", "foo"];
+      expect(navigateActionIndex(items, 1, 1)).toBe(2);
+      expect(navigateActionIndex(items, 1, -1)).toBe(2);
+      expect(navigateActionIndex(items, 5, 1)).toBe(4);
+      expect(navigateActionIndex(items, 6, -1)).toBe(4);
+    });
+
+    it("should always find a valid index if one is available", () => {
+      const items = [DISABLED, DISABLED, "foo", NORMAL, DISABLED, "foo", "foo"];
+
+      expect(navigateActionIndex(items, 4, 1)).toBe(3);
+      expect(navigateActionIndex(items, 4, 2)).toBe(3);
+      expect(navigateActionIndex(items, 4, 3)).toBe(3);
+      expect(navigateActionIndex(items, 3, 2)).toBe(3);
+      expect(navigateActionIndex(items, 3, 3)).toBe(3);
+
+      expect(navigateActionIndex(items, 2, -1)).toBe(3);
+      expect(navigateActionIndex(items, 2, -2)).toBe(3);
+      expect(navigateActionIndex(items, 2, -3)).toBe(3);
+      expect(navigateActionIndex(items, 3, -2)).toBe(3);
+      expect(navigateActionIndex(items, 3, -4)).toBe(3);
+    });
+
+    it("should return the current index if no valid options are available", () => {
+      const items = [DISABLED, DISABLED, "foo", DISABLED, "foo", "foo"];
+
+      expect(navigateActionIndex(items, 4, 1)).toBe(4);
+      expect(navigateActionIndex(items, 4, 2)).toBe(4);
+      expect(navigateActionIndex(items, 4, 3)).toBe(4);
+      expect(navigateActionIndex(items, 3, 2)).toBe(3);
+      expect(navigateActionIndex(items, 3, 3)).toBe(3);
+
+      expect(navigateActionIndex(items, 2, -1)).toBe(2);
+      expect(navigateActionIndex(items, 2, -2)).toBe(2);
+      expect(navigateActionIndex(items, 2, -3)).toBe(2);
+      expect(navigateActionIndex(items, 3, -2)).toBe(3);
+      expect(navigateActionIndex(items, 3, -4)).toBe(3);
     });
   });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/44928

### Description
Adds the ability to have a disabled item in the command palette (something kbar doesn't support out of the box). Disabled items will not be accessible by mouse or keyboard, but still be visible like a normal item

### How to verify

1. Open the command palette and perform a search for something that does not exist
2. Try clicking the "No Results Found" item. It should not highlight, or be clickable
3. try to select it via the keyboard, it should be inaccessible.

### Demo
![chrome_HtigAPp24h](https://github.com/metabase/metabase/assets/1328979/b71bdc33-6f0c-495a-9dbb-0132633ede18)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
