### PR TITLE
Properly handle frontend test dependencies

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -38,10 +38,14 @@ frontend_specs: &frontend_specs
   - "jest.config.json"
   - "jest.tz.unit.conf.json"
 
+release_source: &release_sources
+  - "release/**"
+
 frontend_all: &frontend_all
   - *frontend_ci
   - *frontend_sources
   - *frontend_specs
+  - *release_sources
 
 frontend_loki_ci: &frontend_loki_ci
   - ".github/workflows/loki.yml"

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -84,7 +84,7 @@ jobs:
         with:
           m2-cache-key: "cljs"
       - name: prepare dependencies in release directory
-        run: cd release && yarn --frozen-lockfile && cd ..
+        run: yarn --cwd release --frozen-lockfile
       - name: Run frontend unit tests and collect the code coverage information
         if: github.ref_name == 'master'
         run: yarn run test-unit --coverage --silent

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -83,6 +83,8 @@ jobs:
         uses: ./.github/actions/prepare-backend
         with:
           m2-cache-key: "cljs"
+      - name: prepare dependencies in release directory
+        run: cd release && yarn --frozen-lockfile && cd ..
       - name: Run frontend unit tests and collect the code coverage information
         if: github.ref_name == 'master'
         run: yarn run test-unit --coverage --silent


### PR DESCRIPTION
## Description

Since our release directory is also typescript, we run its tests along with our frontend tests, however some of the release directory dependencies differ from the main repo's dependencies, so we should install them separately to prevent failures like this: https://github.com/metabase/metabase/actions/runs/9893040257/job/27327225855?pr=45415

