### PR TITLE
Alert on asset download error

### DIFF
--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -203,7 +203,7 @@ describe("scenarios > home > homepage", () => {
       cy.findByText("Orders, Count").should("not.exist");
     });
 
-    it("should show an alert if applications assets are not served", done => {
+    it("should show an alert if applications assets are not served", () => {
       // intercepting and modifying index.html to cause a network error. originally
       // attempted to intercept the request for the JS file, but the browser
       // generally loaded it from a cache, making it difficult to force an error.
@@ -222,12 +222,19 @@ describe("scenarios > home > homepage", () => {
         },
       );
 
-      cy.visit("/");
-
-      cy.on("window:alert", text => {
-        expect(text).to.contain("Failed to load an asset");
-        done();
+      cy.on("window:before:load", win => {
+        cy.spy(win.console, "error").as("errorConsole");
       });
+
+      cy.visit("/");
+      cy.get("@errorConsole").should(
+        "have.been.calledWithMatch",
+        /Could not download asset/,
+      );
+      cy.get("@errorConsole").should(
+        "have.been.calledWithMatch",
+        /bad-link\.js/,
+      );
     });
   });
 });

--- a/resources/frontend_client/index_template.html
+++ b/resources/frontend_client/index_template.html
@@ -41,6 +41,7 @@
 
     <!-- If you modify this script, make sure you update the whitelisted Content-Security-Policy hash in metabase.server.middleware.security -->
     <script type="text/javascript">{{{bootstrapJS}}}</script>
+    <script type="text/javascript">{{{assetOnErrorJS}}}</script>
   </head>
 
   <body>

--- a/resources/frontend_client/inline_js/asset_loading_error.js
+++ b/resources/frontend_client/inline_js/asset_loading_error.js
@@ -1,11 +1,12 @@
 (function () {
-  window.metabase.AssetErrorLoad = function (tag) {
+  window.Metabase = window.Metabase || {};
+  window.Metabase.AssetErrorLoad = function (tag) {
     console.error(
-      `Could not download asset ${tag.src} from your metabase instance. 
-This shouldn't happen normally, but can happen in certain 
-instances where your browser has cached the index.html page, or 
-there are different versions of metabase behind the same load balancer. 
-If clearing your cache doesn't resolve the issue, please ensure 
+      `Could not download asset ${tag.src} from your metabase instance. \
+This shouldn't happen normally, but can happen in certain \
+instances where your browser has cached the index.html page, or \
+there are different versions of metabase behind the same load balancer. \
+If clearing your cache doesn't resolve the issue, please ensure \
 all of your deployed instances of metabase are on the same version.`,
     );
   };

--- a/resources/frontend_client/inline_js/asset_loading_error.js
+++ b/resources/frontend_client/inline_js/asset_loading_error.js
@@ -1,20 +1,12 @@
 (function () {
-  window.mbErrorAlert = false;
-  window.AssetErrorLoad = function (tag) {
+  window.metabase.AssetErrorLoad = function (tag) {
     console.error(
       `Could not download asset ${tag.src} from your metabase instance. 
 This shouldn't happen normally, but can happen in certain 
 instances where your browser has cached the index.html page, or 
 there are different versions of metabase behind the same load balancer. 
-If clearing your cache doesn't resolve the issue, please ensure your
-all your deployed instances of metabase are on the same version.`,
+If clearing your cache doesn't resolve the issue, please ensure 
+all of your deployed instances of metabase are on the same version.`,
     );
-
-    if (!window.mbErrorAlert) {
-      alert(
-        "Failed to load an asset. Please clear your cache and refresh the page.",
-      );
-      window.mbErrorAlert = true;
-    }
   };
 })();

--- a/resources/frontend_client/inline_js/asset_loading_error.js
+++ b/resources/frontend_client/inline_js/asset_loading_error.js
@@ -1,0 +1,20 @@
+(function () {
+  window.mbErrorAlert = false;
+  window.AssetErrorLoad = function (tag) {
+    console.error(
+      `Could not download asset ${tag.src} from your metabase instance. 
+This shouldn't happen normally, but can happen in certain 
+instances where your browser has cached the index.html page, or 
+there are different versions of metabase behind the same load balancer. 
+If clearing your cache doesn't resolve the issue, please ensure your
+all your deployed instances of metabase are on the same version.`,
+    );
+
+    if (!window.mbErrorAlert) {
+      alert(
+        "Failed to load an asset. Please clear your cache and refresh the page.",
+      );
+      window.mbErrorAlert = true;
+    }
+  };
+})();

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -34,7 +34,9 @@
     (mapv file-hash [ ;; inline script in index.html that sets `MetabaseBootstrap` and the like
                      "frontend_client/inline_js/index_bootstrap.js"
                      ;; inline script in init.html
-                     "frontend_client/inline_js/init.js"])))
+                     "frontend_client/inline_js/init.js"
+                     ;; inline script in init.html to handle errors when grabbing app scripts
+                     "frontend_client/inline_js/asset_loading_error.js"])))
 
 (defn- cache-prevention-headers
   "Headers that tell browsers not to cache a response."

--- a/src/metabase/server/routes/index.clj
+++ b/src/metabase/server/routes/index.clj
@@ -81,6 +81,7 @@
    (let [{:keys [anon-tracking-enabled google-auth-client-id], :as public-settings} (setting/user-readable-values-map #{:public})]
      {:bootstrapJS          (load-inline-js "index_bootstrap")
       :bootstrapJSON        (escape-script (json/generate-string public-settings))
+      :assetOnErrorJS       (load-inline-js "asset_loading_error")
       :userLocalizationJSON (escape-script (load-localization (:locale params)))
       :siteLocalizationJSON (escape-script (load-localization (public-settings/site-locale)))
       :nonceJSON            (escape-script (json/generate-string nonce))

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,7 +61,7 @@ class OnScriptError {
         (data, cb) => {
           // Manipulate the content
           data.assetTags.scripts.forEach(script => {
-            script.attributes.onerror = `metabase.AssetErrorLoad(this)`;
+            script.attributes.onerror = `Metabase.AssetErrorLoad(this)`;
           });
           // Tell webpack to move on
           cb(null, data);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,7 +61,7 @@ class OnScriptError {
         (data, cb) => {
           // Manipulate the content
           data.assetTags.scripts.forEach(script => {
-            script.attributes.onerror = `AssetErrorLoad(this)`;
+            script.attributes.onerror = `metabase.AssetErrorLoad(this)`;
           });
           // Tell webpack to move on
           cb(null, data);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,6 +53,24 @@ const CSS_CONFIG = {
   importLoaders: 1,
 };
 
+class OnScriptError {
+  apply(compiler) {
+    compiler.hooks.compilation.tap("OnScriptError", compilation => {
+      HtmlWebpackPlugin.getHooks(compilation).alterAssetTags.tapAsync(
+        "OnScriptError",
+        (data, cb) => {
+          // Manipulate the content
+          data.assetTags.scripts.forEach(script => {
+            script.attributes.onerror = `AssetErrorLoad(this)`;
+          });
+          // Tell webpack to move on
+          cb(null, data);
+        },
+      );
+    });
+  }
+}
+
 const config = (module.exports = {
   mode: devMode ? "development" : "production",
   context: SRC_PATH,
@@ -243,6 +261,7 @@ const config = (module.exports = {
       filename: devMode ? "[name].css" : "[name].[contenthash].css",
       chunkFilename: devMode ? "[id].css" : "[id].[contenthash].css",
     }),
+    new OnScriptError(),
     new HtmlWebpackPlugin({
       filename: "../../index.html",
       chunksSortMode: "manual",


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39449

### Description
Adds an `onerror` handler to bundled scripts from webpack. If triggered, will display an alert to the user asking that they clear their cache and refresh the browser. Also logs a console error with some more developer related information. If there are multiple errors, we should only show 1 alert, but as many console errors as needed.

### How to verify

1. Clear your `release/frontend_client/app/dist folder`
2. Build a release version of mb with `yarn build-release`
3. Start the backend, then rename some of your built JS assets
4. open `localhost:3000`. You should see an alert pop up, and error messages in the JS console. Only 1 alert should display

### Demo
![image](https://github.com/metabase/metabase/assets/1328979/7add3896-7616-4160-b468-5e20c30e979e)
![image](https://github.com/metabase/metabase/assets/1328979/76d97352-2772-4182-8eb9-5f2ea53c01bd)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
