### PR TITLE
Reset report_card.last_used_at for all cards

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -8206,11 +8206,11 @@ databaseChangeLog:
               column:
                 name: dashboard_id
 
-  # last_used_at will be used to determine if a report card is stale and should be cleaned up
-  # if the card is imported with serialization. We don't want to automatically clean up
-  # newly imported cards, and we don't want to have to make it nullable.
-  # Because we weren't collecting this data before, we have to populate all existing cards
-  # with the current timestamp to provide a "lower bound" for when the card was last used.
+  # After this migration, last_used_at becomes the lowest timestamp after which we know that
+  # the card has not been used. last_used_at will be used to determine if a report
+  # card is stale and should be cleaned up if the card is imported with serialization.
+  # Because we weren't collecting last_used_at before, we have to populate all existing cards
+  # with the current timestamp to provide a "lower bound" after which the card has not been used.
   - changeSet:
       id: v50.2024-07-09T20:04:00
       author: calherries

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -8206,11 +8206,13 @@ databaseChangeLog:
               column:
                 name: dashboard_id
 
-  # last_used_at is used to determine if a report card is stale and should be cleaned up
-  # if the card is imported with serialization, we don't want to automatically clean up
+  # last_used_at will be used to determine if a report card is stale and should be cleaned up
+  # if the card is imported with serialization. We don't want to automatically clean up
   # newly imported cards, and we don't want to have to make it nullable.
+  # Because we weren't collecting this data before, we have to populate all existing cards
+  # with the current timestamp to provide a "lower bound" for when the card was last used.
   - changeSet:
-      id: v50.2024-07-09T20:04:01
+      id: v50.2024-07-09T20:04:00
       author: calherries
       comment: Populate default value for report_card.last_used_at
       changes:
@@ -8218,7 +8220,6 @@ databaseChangeLog:
             sql: >-
               UPDATE report_card
               SET last_used_at = current_timestamp
-              WHERE last_used_at IS NULL;
       rollback: # nothing to do, since this is backwards compatible
 
   - changeSet:

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -8217,9 +8217,7 @@ databaseChangeLog:
       comment: Populate default value for report_card.last_used_at
       changes:
         - sql:
-            sql: >-
-              UPDATE report_card
-              SET last_used_at = current_timestamp
+            sql: UPDATE report_card SET last_used_at = current_timestamp
       rollback: # nothing to do, since this is backwards compatible
 
   - changeSet:


### PR DESCRIPTION
Follows https://github.com/metabase/metabase/pull/45323

This fixes an issue with the last PR caught here:  https://github.com/metabase/metabase/pull/45323#discussion_r1673893401

This PR turns `last_used_at` to effectively be a safe "lower bound" to help us determine when we can automatically clean up content. If `last_used_at` is time T, we know that the card could not have been used after time T. But we can not deduce from `last_used_at` whether the card was used between time T' and T, where T' is before T. T is the lower bound in that we know definitively that the card was not used since then.

If we ever want to use `last_used_at` for things like displaying "this card was used X days ago", we can't. Because there's a chance the `last_used_at` value was set by this migration.

It might be more accurate to rename this field `unused_since` instead of `last_used_at` for this reason.

Like https://github.com/metabase/metabase/pull/45323, this should not be backported into the 50 branch before we start capturing `last_used_at` again, which we expect to do in https://github.com/metabase/metabase/pull/45007.