### PR TITLE
[serdes] spec check requires up-to-date db

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/models_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/models_test.clj
@@ -6,6 +6,7 @@
    [metabase-enterprise.serialization.v2.models :as serdes.models]
    [metabase.db :as mdb]
    [metabase.models.serialization :as serdes]
+   [metabase.test :as mt]
    [metabase.util :as u]
    [metabase.util.connection :as u.conn]
    [toucan2.core :as t2]))
@@ -40,36 +41,37 @@
               (when-not (#{"Pulse" "PulseChannel" "PulseCard" "User" "PermissionsGroup"} (name model))
                 (is (not random-entity-id?))))))))))
 
-(deftest ^:parallel serialization-complete-spec-test
-  ;; When serialization spec is defined, it describes every column
-  (doseq [m     serdes.models/exported-models
-          :let  [spec (serdes/make-spec m)]
-          :when spec]
-    (let [t      (t2/table-name (keyword "model" m))
-          fields (u.conn/app-db-column-types (mdb/app-db) t)
-          spec'  (merge (zipmap (:copy spec) (repeat :copy))
-                        (zipmap (:skip spec) (repeat :skip))
-                        (:transform spec))]
-      (testing (format "%s should declare every column in serialization spec" m)
-        (is (= (->> (keys fields)
-                    (map u/lower-case-en)
-                    set)
-               (->> (keys spec')
-                    (map name)
-                    set))))
-      (testing "Foreign keys should be declared as such\n"
-        (doseq [[fk _] (filter #(:fk (second %)) fields)
-                :let   [fk (u/lower-case-en fk)
-                        action (get spec' (keyword fk))]]
-          (testing (format "%s.%s is foreign key which is handled correctly" m fk)
-            ;; FIXME: serialization can guess where FK points by itself, but `collection_id` and `database_id` are
-            ;; specifying that themselves right now
-            (when-not (#{"collection_id" "database_id"} fk)
-              (is (#{:skip
-                     serdes/*export-fk*
-                     serdes/*export-fk-keyed*
-                     serdes/*export-table-fk*
-                     serdes/*export-user*}
-                   (if (vector? action)
-                     (first action) ;; tuple of [ser des]
-                     action))))))))))
+(deftest serialization-complete-spec-test
+  (mt/with-empty-h2-app-db
+    ;; When serialization spec is defined, it describes every column
+    (doseq [m     serdes.models/exported-models
+            :let  [spec (serdes/make-spec m)]
+            :when spec]
+      (let [t      (t2/table-name (keyword "model" m))
+            fields (u.conn/app-db-column-types (mdb/app-db) t)
+            spec'  (merge (zipmap (:copy spec) (repeat :copy))
+                          (zipmap (:skip spec) (repeat :skip))
+                          (:transform spec))]
+        (testing (format "%s should declare every column in serialization spec" m)
+          (is (= (->> (keys fields)
+                      (map u/lower-case-en)
+                      set)
+                 (->> (keys spec')
+                      (map name)
+                      set))))
+        (testing "Foreign keys should be declared as such\n"
+          (doseq [[fk _] (filter #(:fk (second %)) fields)
+                  :let   [fk (u/lower-case-en fk)
+                          action (get spec' (keyword fk))]]
+            (testing (format "%s.%s is foreign key which is handled correctly" m fk)
+              ;; FIXME: serialization can guess where FK points by itself, but `collection_id` and `database_id` are
+              ;; specifying that themselves right now
+              (when-not (#{"collection_id" "database_id"} fk)
+                (is (#{:skip
+                       serdes/*export-fk*
+                       serdes/*export-fk-keyed*
+                       serdes/*export-table-fk*
+                       serdes/*export-user*}
+                     (if (vector? action)
+                       (first action) ;; tuple of [ser des]
+                       action)))))))))))


### PR DESCRIPTION
It needs that h2 app db, because it will fail if you switch branches and db schema is too different.