### PR TITLE
Fix deselecting the last join column

### DIFF
--- a/frontend/src/metabase/common/components/FieldPicker/FieldPicker.tsx
+++ b/frontend/src/metabase/common/components/FieldPicker/FieldPicker.tsx
@@ -43,7 +43,7 @@ export const FieldPicker = ({
   onSelectAll,
   onSelectNone,
   isColumnSelected,
-  isColumnDisabled = () => false,
+  isColumnDisabled,
   ...props
 }: FieldPickerProps) => {
   const items = useMemo(() => {
@@ -54,7 +54,7 @@ export const FieldPicker = ({
     return items.map(item => ({
       ...item,
       isSelected: isColumnSelected(item, items),
-      isDisabled: isColumnDisabled(item, items),
+      isDisabled: isColumnDisabled?.(item, items),
     }));
   }, [query, stageIndex, columns, isColumnSelected, isColumnDisabled]);
 

--- a/frontend/src/metabase/common/components/FieldPicker/FieldPicker.tsx
+++ b/frontend/src/metabase/common/components/FieldPicker/FieldPicker.tsx
@@ -12,14 +12,23 @@ import {
   ItemIcon,
 } from "./FieldPicker.styled";
 
+export interface FieldPickerItem {
+  column: Lib.ColumnMetadata;
+  columnInfo: Lib.ColumnDisplayInfo;
+}
+
 interface FieldPickerProps {
   query: Lib.Query;
   stageIndex: number;
   columns: Lib.ColumnMetadata[];
   "data-testid"?: string;
   isColumnSelected: (
-    column: Lib.ColumnMetadata,
-    columnInfo: Lib.ColumnDisplayInfo,
+    item: FieldPickerItem,
+    items: FieldPickerItem[],
+  ) => boolean;
+  isColumnDisabled?: (
+    item: FieldPickerItem,
+    items: FieldPickerItem[],
   ) => boolean;
   onToggle: (column: Lib.ColumnMetadata, isSelected: boolean) => void;
   onSelectAll: () => void;
@@ -34,25 +43,23 @@ export const FieldPicker = ({
   onSelectAll,
   onSelectNone,
   isColumnSelected,
+  isColumnDisabled = () => false,
   ...props
 }: FieldPickerProps) => {
-  const items = useMemo(
-    () =>
-      columns.map(column => {
-        const columnInfo = Lib.displayInfo(query, stageIndex, column);
-        return {
-          column,
-          columnInfo,
-          isSelected: isColumnSelected(column, columnInfo),
-        };
-      }),
-    [query, stageIndex, columns, isColumnSelected],
-  );
+  const items = useMemo(() => {
+    const items = columns.map(column => ({
+      column,
+      columnInfo: Lib.displayInfo(query, stageIndex, column),
+    }));
+    return items.map(item => ({
+      ...item,
+      isSelected: isColumnSelected(item, items),
+      isDisabled: isColumnDisabled(item, items),
+    }));
+  }, [query, stageIndex, columns, isColumnSelected, isColumnDisabled]);
 
   const isAll = items.every(item => item.isSelected);
   const isNone = items.every(item => !item.isSelected);
-  const isDisabledDeselection =
-    items.filter(item => item.isSelected).length <= 1;
 
   const handleLabelToggle = () => {
     if (isAll) {
@@ -80,11 +87,8 @@ export const FieldPicker = ({
           <li key={item.columnInfo.longDisplayName}>
             <Label as="label">
               <Checkbox
-                checked={isColumnSelected(item.column, item.columnInfo)}
-                disabled={
-                  isColumnSelected(item.column, item.columnInfo) &&
-                  isDisabledDeselection
-                }
+                checked={item.isSelected}
+                disabled={item.isDisabled}
                 onChange={event => onToggle(item.column, event.target.checked)}
               />
               <ItemIcon

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.tsx
@@ -1,7 +1,10 @@
 import { useMemo } from "react";
 import { t } from "ttag";
 
-import { FieldPicker } from "metabase/common/components/FieldPicker";
+import {
+  FieldPicker,
+  type FieldPickerItem,
+} from "metabase/common/components/FieldPicker";
 import { NotebookDataPicker } from "metabase/query_builder/components/notebook/NotebookDataPicker";
 import { Icon, Popover, Tooltip } from "metabase/ui";
 import * as Lib from "metabase-lib";
@@ -127,11 +130,6 @@ function DataFieldPicker({
     updateQuery(nextQuery);
   };
 
-  const isColumnSelected = (column: Lib.ColumnMetadata) => {
-    const columnInfo = Lib.displayInfo(query, stageIndex, column);
-    return Boolean(columnInfo.selected);
-  };
-
   const handleSelectAll = () => {
     const nextQuery = Lib.withFields(query, stageIndex, []);
     updateQuery(nextQuery);
@@ -148,9 +146,20 @@ function DataFieldPicker({
       stageIndex={stageIndex}
       columns={columns}
       isColumnSelected={isColumnSelected}
+      isColumnDisabled={isColumnDisabled}
       onToggle={handleToggle}
       onSelectAll={handleSelectAll}
       onSelectNone={handleSelectNone}
     />
   );
+}
+
+function isColumnSelected({ columnInfo }: FieldPickerItem) {
+  return Boolean(columnInfo.selected);
+}
+
+function isColumnDisabled(item: FieldPickerItem, items: FieldPickerItem[]) {
+  const isSelected = isColumnSelected(item);
+  const isOnlySelected = items.filter(isColumnSelected).length === 1;
+  return isSelected && isOnlySelected;
 }

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
@@ -656,6 +656,8 @@ describe("Notebook Editor > Join Step", () => {
         "join-columns-picker",
       );
       await userEvent.click(within(joinColumnsPicker).getByText("Select none"));
+      expect(within(joinColumnsPicker).getByLabelText("ID")).not.toBeChecked();
+      expect(within(joinColumnsPicker).getByLabelText("ID")).toBeEnabled();
       await userEvent.click(within(joinColumnsPicker).getByLabelText("ID"));
       expect(within(joinColumnsPicker).getByLabelText("ID")).toBeChecked();
       expect(within(joinColumnsPicker).getByLabelText("ID")).toBeEnabled();

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
@@ -646,6 +646,25 @@ describe("Notebook Editor > Join Step", () => {
       expect(price).toBeUndefined();
     });
 
+    it("should allow deselecting the last join column", async () => {
+      setup();
+
+      const modal = await screen.findByTestId("entity-picker-modal");
+      await userEvent.click(await within(modal).findByText("Reviews"));
+      await userEvent.click(await screen.findByLabelText("Pick columns"));
+      const joinColumnsPicker = await screen.findByTestId(
+        "join-columns-picker",
+      );
+      await userEvent.click(within(joinColumnsPicker).getByText("Select none"));
+      await userEvent.click(within(joinColumnsPicker).getByLabelText("ID"));
+      expect(within(joinColumnsPicker).getByLabelText("ID")).toBeChecked();
+      expect(within(joinColumnsPicker).getByLabelText("ID")).toBeEnabled();
+
+      await userEvent.click(within(joinColumnsPicker).getByLabelText("ID"));
+      expect(within(joinColumnsPicker).getByLabelText("ID")).not.toBeChecked();
+      expect(within(joinColumnsPicker).getByLabelText("ID")).toBeEnabled();
+    });
+
     it("should be able to select no columns when adding a new join", async () => {
       const { getRecentJoin } = setup();
 

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTableColumnDraftPicker/JoinTableColumnDraftPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTableColumnDraftPicker/JoinTableColumnDraftPicker.tsx
@@ -1,4 +1,7 @@
-import { FieldPicker } from "metabase/common/components/FieldPicker";
+import {
+  FieldPicker,
+  type FieldPickerItem,
+} from "metabase/common/components/FieldPicker";
 import type * as Lib from "metabase-lib";
 
 interface JoinTableColumnPickerDraftProps {
@@ -16,7 +19,7 @@ export function JoinTableColumnDraftPicker({
   selectedColumns,
   onChange,
 }: JoinTableColumnPickerDraftProps) {
-  const isColumnSelected = (column: Lib.ColumnMetadata) => {
+  const isColumnSelected = ({ column }: FieldPickerItem) => {
     return selectedColumns.includes(column);
   };
 

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTableColumnPicker/JoinTableColumnPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTableColumnPicker/JoinTableColumnPicker.tsx
@@ -1,6 +1,9 @@
 import { useMemo } from "react";
 
-import { FieldPicker } from "metabase/common/components/FieldPicker";
+import {
+  FieldPicker,
+  type FieldPickerItem,
+} from "metabase/common/components/FieldPicker";
 import * as Lib from "metabase-lib";
 
 interface JoinTableColumnPickerProps {
@@ -54,9 +57,6 @@ export function JoinTableColumnPicker({
   );
 }
 
-function isColumnSelected(
-  column: Lib.ColumnMetadata,
-  columnInfo: Lib.ColumnDisplayInfo,
-) {
+function isColumnSelected({ columnInfo }: FieldPickerItem) {
   return Boolean(columnInfo.selected);
 }


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/45451

Makes the last join column enabled.

How to verify:
- New -> Question -> Orders
- Join -> Products
- Open the column picker for the join -> Select none
- Check ID column
- Make sure it is not disabled and can be unchecked

<img width="502" alt="Screenshot 2024-07-12 at 09 33 16" src="https://github.com/user-attachments/assets/f0067e27-01d7-4a42-9501-9f774a41c961">
