### PR TITLE
do not allow to render empty SaveQuestionModal content

### DIFF
--- a/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.tsx
@@ -82,7 +82,7 @@ interface SaveQuestionModalProps {
 }
 
 interface FormValues {
-  saveType: string;
+  saveType: "overwrite" | "create";
   collection_id: CollectionId | null | undefined;
   name: string;
   description: string;
@@ -217,7 +217,12 @@ export const SaveQuestionModal = ({
     [originalQuestion, handleOverwrite, handleCreate],
   );
 
-  const isSavedQuestionChanged = useSelector(getIsSavedQuestionChanged);
+  // we care only about the very first result as question can be changed before
+  // the modal is closed
+  const isSavedQuestionChanged = useSelector(
+    getIsSavedQuestionChanged,
+    () => true,
+  );
   const showSaveType =
     isSavedQuestionChanged &&
     originalQuestion != null &&

--- a/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.tsx
@@ -217,14 +217,13 @@ export const SaveQuestionModal = ({
     [originalQuestion, handleOverwrite, handleCreate],
   );
 
+  const isSavedQuestionChanged = useSelector(getIsSavedQuestionChanged);
   // we care only about the very first result as question can be changed before
   // the modal is closed
-  const isSavedQuestionChanged = useSelector(
-    getIsSavedQuestionChanged,
-    () => true,
-  );
+  const [isSavedQuestionInitiallyChanged] = useState(isSavedQuestionChanged);
+
   const showSaveType =
-    isSavedQuestionChanged &&
+    isSavedQuestionInitiallyChanged &&
     originalQuestion != null &&
     originalQuestion.canWrite();
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/45416

### Description

Describe the overall approach and the problem being solved.

### How to verify

- open existing question
- change it in the editor
- try to save to see a modal which suggests replacing the question
- click save and notice that modal's content doesn't disappear before modal is closed

### Demo


https://github.com/user-attachments/assets/dd94a3c4-8583-4999-b049-1fc0c110b99e



### Checklist

- [x] Tests have been added/updated to cover changes in this PR

test was failing initially
<img width="518" alt="Screenshot 2024-07-12 at 16 34 07" src="https://github.com/user-attachments/assets/8368fd8b-7f51-47d7-821c-519be5920d29">
