### PR TITLE
prevent moving snippet collections into descendents, remove recents tab

### DIFF
--- a/e2e/test/scenarios/native/snippets.cy.spec.js
+++ b/e2e/test/scenarios/native/snippets.cy.spec.js
@@ -9,6 +9,7 @@ import {
   setTokenFeatures,
   onlyOnOSS,
   entityPickerModal,
+  collectionOnTheGoModal,
 } from "e2e/support/helpers";
 
 const { ALL_USERS_GROUP } = USER_GROUPS;
@@ -255,7 +256,6 @@ describeEE("scenarios > question > snippets (EE)", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     modal().within(() => cy.findByText("Top folder").click());
     entityPickerModal().within(() => {
-      cy.findByText("Collections").click();
       cy.findByText("my favorite snippets").click();
       cy.findByText("Select").click();
     });
@@ -273,6 +273,31 @@ describeEE("scenarios > question > snippets (EE)", () => {
     cy.findByText("my favorite snippets").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("snippet 1");
+
+    cy.log("via collection picker (metabase#44930");
+
+    // Edit snippet folder
+    cy.findByTestId("sidebar-right").within(() => {
+      cy.findByText("snippet 1").parent().parent().click();
+      cy.button(/Edit/).click();
+    });
+
+    modal().findByTestId("collection-picker-button").click();
+    entityPickerModal()
+      .findByRole("button", { name: /Create a new collection/ })
+      .click();
+    collectionOnTheGoModal()
+      .findByLabelText("Give it a name")
+      .type("my special snippets");
+    collectionOnTheGoModal().findByRole("button", { name: "Create" }).click();
+    entityPickerModal().findByRole("button", { name: "Select" }).click();
+    modal().findByRole("button", { name: "Save" }).click();
+
+    cy.findByTestId("sidebar-right").within(() => {
+      cy.findByText("snippet 1").should("not.exist");
+      cy.findByText("my special snippets").click();
+      cy.findByText("snippet 1").should("exist");
+    });
   });
 
   ["admin", "nocollection"].map(user => {
@@ -304,7 +329,34 @@ describeEE("scenarios > question > snippets (EE)", () => {
         description: null,
         parent_id: null,
         namespace: "snippets",
+      }).then(({ body }) => {
+        cy.request("POST", "/api/collection", {
+          name: "Nested snippet Folder",
+          description: null,
+          parent_id: body.id,
+          namespace: "snippets",
+        });
       });
+    });
+
+    it("should not allow you to move a snippet collection into a itself or a child (metabase#44930)", () => {
+      openNativeEditor();
+      cy.icon("snippet").click();
+
+      // Edit snippet folder
+      cy.findByTestId("sidebar-right").within(() => {
+        cy.findByText("Snippet Folder")
+          .next()
+          .find(".Icon-ellipsis")
+          .click({ force: true });
+      });
+
+      popover().findByText("Edit folder details").click();
+      modal().findByTestId("collection-picker-button").click();
+
+      entityPickerModal()
+        .findByRole("button", { name: /Snippet Folder/ })
+        .should("be.disabled");
     });
 
     it("should not display snippet folder as part of collections (metabase#14907)", () => {

--- a/enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionForm.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionForm.tsx
@@ -115,10 +115,16 @@ function SnippetCollectionForm({
 
   const shouldDisableItem = useCallback(
     (item: CollectionPickerItem) => {
-      return passedCollection.id
-        ? item.effective_location?.includes(String(passedCollection.id)) ||
-            passedCollection.id === item.id
-        : false;
+      if (passedCollection.id === undefined) {
+        return false;
+      } else {
+        return (
+          item.effective_location
+            ?.split("/")
+            .includes(String(passedCollection.id)) ||
+          passedCollection.id === item.id
+        );
+      }
     },
     [passedCollection.id],
   );

--- a/enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionForm.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionForm.tsx
@@ -5,6 +5,7 @@ import _ from "underscore";
 import * as Yup from "yup";
 
 import FormCollectionPicker from "metabase/collections/containers/FormCollectionPicker";
+import type { CollectionPickerItem } from "metabase/common/components/CollectionPicker";
 import Button from "metabase/core/components/Button";
 import FormErrorMessage from "metabase/core/components/FormErrorMessage";
 import FormFooter from "metabase/core/components/FormFooter";
@@ -112,6 +113,16 @@ function SnippetCollectionForm({
     [collection.id, isEditing, handleCreate, handleUpdate, onSave],
   );
 
+  const shouldDisableItem = useCallback(
+    (item: CollectionPickerItem) => {
+      return passedCollection.id
+        ? item.effective_location?.includes(String(passedCollection.id)) ||
+            passedCollection.id === item.id
+        : false;
+    },
+    [passedCollection.id],
+  );
+
   return (
     <FormProvider
       initialValues={initialValues}
@@ -137,6 +148,9 @@ function SnippetCollectionForm({
             name="parent_id"
             title={t`Folder this should be in`}
             type="snippet-collections"
+            collectionPickerModalProps={{
+              shouldDisableItem: shouldDisableItem,
+            }}
           />
           <FormFooter>
             <FormErrorMessage inline />

--- a/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
+++ b/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
@@ -10,6 +10,7 @@ import {
 } from "metabase/collections/utils";
 import type {
   CollectionPickerItem,
+  CollectionPickerModalProps,
   CollectionPickerOptions,
 } from "metabase/common/components/CollectionPicker";
 import { CollectionPickerModal } from "metabase/common/components/CollectionPicker";
@@ -33,6 +34,7 @@ export interface FormCollectionPickerProps
   onOpenCollectionChange?: (collectionId: CollectionId) => void;
   filterPersonalCollections?: FilterItemsInPersonalCollection;
   zIndex?: number;
+  collectionPickerModalProps?: Partial<CollectionPickerModalProps>;
 }
 
 function ItemName({
@@ -57,6 +59,7 @@ function FormCollectionPicker({
   placeholder = t`Select a collection`,
   type = "collections",
   filterPersonalCollections,
+  collectionPickerModalProps,
 }: FormCollectionPickerProps) {
   const id = useUniqueId();
 
@@ -102,6 +105,7 @@ function FormCollectionPicker({
       hasConfirmButtons: true,
       namespace: type === "snippet-collections" ? "snippets" : undefined,
       allowCreateNew: showCreateNewCollectionOption,
+      hasRecents: type === "snippet-collections" ? false : true,
     }),
     [filterPersonalCollections, type, showCreateNewCollectionOption],
   );
@@ -151,6 +155,7 @@ function FormCollectionPicker({
           onChange={handleChange}
           onClose={() => setIsPickerOpen(false)}
           options={options}
+          {...collectionPickerModalProps}
         />
       )}
     </>

--- a/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
+++ b/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
@@ -105,7 +105,7 @@ function FormCollectionPicker({
       hasConfirmButtons: true,
       namespace: type === "snippet-collections" ? "snippets" : undefined,
       allowCreateNew: showCreateNewCollectionOption,
-      hasRecents: type === "snippet-collections" ? false : true,
+      hasRecents: type !== "snippet-collections",
     }),
     [filterPersonalCollections, type, showCreateNewCollectionOption],
   );

--- a/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
@@ -16,7 +16,7 @@ import type {
 import { CollectionPicker } from "./CollectionPicker";
 import { NewCollectionDialog } from "./NewCollectionDialog";
 
-interface CollectionPickerModalProps {
+export interface CollectionPickerModalProps {
   title?: string;
   onChange: (item: CollectionPickerValueItem) => void;
   onClose: () => void;
@@ -137,6 +137,7 @@ export const CollectionPickerModal = ({
             : "root"
         }
         onNewCollection={handleNewCollectionCreate}
+        namespace={options.namespace}
       />
     </>
   );

--- a/frontend/src/metabase/common/components/CollectionPicker/components/NewCollectionDialog.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/NewCollectionDialog.tsx
@@ -20,6 +20,7 @@ interface NewCollectionDialogProps {
   onClose: () => void;
   parentCollectionId: CollectionId | null;
   onNewCollection: (item: CollectionPickerItem) => void;
+  namespace?: "snippets";
 }
 
 export const NewCollectionDialog = ({
@@ -27,6 +28,7 @@ export const NewCollectionDialog = ({
   onClose,
   parentCollectionId,
   onNewCollection,
+  namespace,
 }: NewCollectionDialogProps) => {
   const [createCollection] = useCreateCollectionMutation();
 
@@ -34,6 +36,7 @@ export const NewCollectionDialog = ({
     const newCollection = await createCollection({
       name,
       parent_id: parentCollectionId === "root" ? null : parentCollectionId,
+      namespace,
     }).unwrap();
 
     onNewCollection({ ...newCollection, model: "collection" });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/44930

### Description
When working with snippets, there were a couple features / checks that were not quite working properly in the collection picker.
- Collection Picker as showing the resents tab, which shouldn't have any valid options for snippets
- When moving a snippet collection, collection descendants were not disabled
- Creating a new collection from the collection picker was not working (namespace wasn't included in request)

### How to verify
1. Go to New -> SQL Query
2. Open the snipets sidebar
3. check the above.


### Demo
![image](https://github.com/user-attachments/assets/2f99f929-8e8f-4b74-98f3-bd05e0206fca)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
