### PR TITLE
fix png export when on dark theme (public/embed) not having the dark …

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.styled.tsx
@@ -1,8 +1,6 @@
 import { css, type Theme } from "@emotion/react";
 import styled from "@emotion/styled";
 
-import { SAVING_DOM_IMAGE_CLASS } from "metabase/visualizations/lib/save-chart-image";
-
 export interface DashCardRootProps {
   isNightMode: boolean;
   isUsuallySlow: boolean;
@@ -40,11 +38,6 @@ export const DashCardRoot = styled.div<DashCardRootProps>`
 
   ${({ shouldForceHiddenBackground }) =>
     shouldForceHiddenBackground && hiddenBackgroundStyle}
-
-  &.${SAVING_DOM_IMAGE_CLASS} {
-    border-radius: 0;
-    border: none !important;
-  }
 `;
 
 export const VirtualDashCardOverlayRoot = styled.div`

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.module.css
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.module.css
@@ -15,7 +15,7 @@ body {
 .ThemeNight.EmbedFrame,
 /* this is to make it work when exporting to pdfs,
 where the EmbedFrame is not part of the exported dom */
-.ThemeNight.EmbedFrame > .WithThemeBackground {
+.ThemeNight.EmbedFrame .WithThemeBackground {
   background-color: var(--mb-color-bg-black);
   border-color: var(--mb-color-bg-dark);
 }

--- a/frontend/src/metabase/visualizations/lib/save-chart-image.ts
+++ b/frontend/src/metabase/visualizations/lib/save-chart-image.ts
@@ -32,6 +32,9 @@ export const saveChartImage = async (selector: string, fileName: string) => {
     onclone: (doc: Document, node: HTMLElement) => {
       node.classList.add(SAVING_DOM_IMAGE_CLASS);
       node.classList.add(EmbedFrameS.WithThemeBackground);
+
+      node.style.borderRadius = "0px";
+      node.style.border = "none";
     },
   });
 

--- a/frontend/src/metabase/visualizations/lib/save-chart-image.ts
+++ b/frontend/src/metabase/visualizations/lib/save-chart-image.ts
@@ -5,6 +5,8 @@ export const SAVING_DOM_IMAGE_HIDDEN_CLASS = "saving-dom-image-hidden";
 export const SAVING_DOM_IMAGE_DISPLAY_NONE_CLASS =
   "saving-dom-image-display-none";
 
+import EmbedFrameS from "metabase/public/components/EmbedFrame/EmbedFrame.module.css";
+
 export const saveDomImageStyles = css`
   .${SAVING_DOM_IMAGE_CLASS} {
     .${SAVING_DOM_IMAGE_HIDDEN_CLASS} {
@@ -24,14 +26,14 @@ export const saveChartImage = async (selector: string, fileName: string) => {
     return;
   }
 
-  node.classList.add(SAVING_DOM_IMAGE_CLASS);
-
   const { default: html2canvas } = await import("html2canvas-pro");
   const canvas = await html2canvas(node, {
     useCORS: true,
+    onclone: (doc: Document, node: HTMLElement) => {
+      node.classList.add(SAVING_DOM_IMAGE_CLASS);
+      node.classList.add(EmbedFrameS.WithThemeBackground);
+    },
   });
-
-  node.classList.remove(SAVING_DOM_IMAGE_CLASS);
 
   canvas.toBlob(blob => {
     if (blob) {


### PR DESCRIPTION
This fixes the background color on a public/embedded questions not being dark when exporting to png

Before:
![Revenue per quarter-7_12_2024, 6_49_34 PM](https://github.com/user-attachments/assets/e7b6ebe0-4ef6-4fe8-881a-6660d1890f61)

After:
![Revenue per quarter-7_12_2024, 6_50_00 PM](https://github.com/user-attachments/assets/b3f4056a-9b8d-4758-9dfe-cddffa6cdc43)


The actual fix is in the first commit, the second commit moves part of the changes from https://github.com/metabase/metabase/pull/44941 in the same place, so that we only have one place to look when we encounter png export issues. @alxnddr let me know if you're ok with this or if you want me to revert that commit