### PR TITLE
Preserve display-name and long-display-name in aggregation expressions

### DIFF
--- a/frontend/src/metabase-lib/v1/expressions/index.ts
+++ b/frontend/src/metabase-lib/v1/expressions/index.ts
@@ -331,7 +331,7 @@ export function isMetric(expr: unknown): boolean {
   return (
     Array.isArray(expr) &&
     expr[0] === "metric" &&
-    expr.length === 2 &&
+    (expr.length === 2 || expr.length === 3) &&
     typeof expr[1] === "number"
   );
 }

--- a/src/metabase/lib/metric.cljc
+++ b/src/metabase/lib/metric.cljc
@@ -78,12 +78,18 @@
    (select-keys metric-metadata [:description :aggregation-position])))
 
 (defmethod lib.metadata.calculation/display-info-method :metric
-  [query stage-number [_tag _opts metric-id-or-name]]
-  (if-let [metric-metadata (resolve-metric query metric-id-or-name)]
-    (lib.metadata.calculation/display-info query stage-number metric-metadata)
-    {:effective-type    :type/*
-     :display-name      (fallback-display-name)
-     :long-display-name (fallback-display-name)}))
+  [query stage-number [_tag opts metric-id-or-name]]
+  (let [display-name (:display-name opts)
+        opts (cond-> opts
+               (and display-name (not (:long-display-name opts)))
+               (assoc :long-display-name display-name))]
+    (merge
+     (if-let [metric-metadata (resolve-metric query metric-id-or-name)]
+       (lib.metadata.calculation/display-info query stage-number metric-metadata)
+       {:effective-type    :type/*
+        :display-name      (fallback-display-name)
+        :long-display-name (fallback-display-name)})
+     (select-keys opts [:name :display-name :long-display-name]))))
 
 (defmethod lib.metadata.calculation/column-name-method :metric
   [query stage-number [_tag _opts metric-id-or-name]]

--- a/test/metabase/lib/metric_test.cljc
+++ b/test/metabase/lib/metric_test.cljc
@@ -87,6 +87,15 @@
     metric-clause
     metric-metadata))
 
+(deftest ^:parallel metric-expression-display-info-test
+  (are [metric] (=? {:display-name      "CC"
+                     :long-display-name "CC"
+                     :effective-type    :type/Integer
+                     :description       "Number of toucans plus number of pelicans"}
+                    (lib/display-info query-with-metric metric))
+    (update metric-clause 1 assoc :display-name "CC")
+    (assoc metric-metadata :display-name "CC")))
+
 (deftest ^:parallel unknown-display-info-test
   (is (=? {:effective-type    :type/*
            :display-name      "[Unknown Metric]"


### PR DESCRIPTION
Fixes #13437.
