### PR TITLE
Add FE repro for the visual glitch when working with models that have an expression with the same name as the column

### DIFF
--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -916,7 +916,7 @@ describe("issue 35840", () => {
     });
   }
 
-  it("should not confuse model fields with expressions in dashboard parameter sources (metabase#35840)", () => {
+  it("should not confuse a model field with an expression that has the same name in dashboard parameter sources (metabase#35840)", () => {
     cy.log("Setup dashboard");
     createQuestion(modelDetails).then(({ body: model }) =>
       createQuestion(getQuestionDetails(model.id)),

--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -1,4 +1,5 @@
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 import {
   type StructuredQuestionDetails,
   createNativeQuestion,
@@ -27,8 +28,13 @@ import {
   visitModel,
   visualize,
   questionInfoButton,
+  visitDashboard,
+  editDashboard,
+  setFilter,
+  setDropdownFilterType,
+  sidebar,
 } from "e2e/support/helpers";
-import type { FieldReference } from "metabase-types/api";
+import type { CardId, FieldReference } from "metabase-types/api";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
 
@@ -867,4 +873,69 @@ describe("issue 34574", () => {
     cy.findByRole("heading", { level: 2, name: "World" }).should("be.visible");
     cy.get("strong").should("be.visible").and("have.text", "important");
   }
+});
+
+describe("issue 35840", () => {
+  const modelName = "M1";
+  const questionName = "Q1";
+
+  const modelDetails: StructuredQuestionDetails = {
+    type: "model",
+    name: modelName,
+    query: {
+      "source-table": PRODUCTS_ID,
+      expressions: {
+        Category: ["field", PRODUCTS.CATEGORY, { "base-type": "type/Text" }],
+      },
+    },
+  };
+
+  const getQuestionDetails = (modelId: CardId): StructuredQuestionDetails => ({
+    type: "question",
+    name: questionName,
+    query: {
+      "source-table": `card__${modelId}`,
+    },
+  });
+
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+  });
+
+  function checkColumnMapping(entityTab: string, entityName: string) {
+    entityPickerModal().within(() => {
+      entityPickerModalTab(entityTab).click();
+      cy.findByText(entityName).click();
+    });
+    modal().findByText("Pick a column…").click();
+    popover().findAllByText("Category").eq(0).click();
+    modal().within(() => {
+      cy.findByText("Category").should("be.visible");
+      cy.findByText("Category, Category").should("not.exist");
+    });
+  }
+
+  it("should not confuse model fields with expressions in dashboard parameter sources (metabase#35840)", () => {
+    cy.log("Setup dashboard");
+    createQuestion(modelDetails).then(({ body: model }) =>
+      createQuestion(getQuestionDetails(model.id)),
+    );
+    visitDashboard(ORDERS_DASHBOARD_ID);
+    editDashboard();
+    setFilter("Text or Category", "Is");
+    setDropdownFilterType();
+    sidebar().findByText("Edit").click();
+
+    cy.log("Use model for dropdown source");
+    modal().within(() => {
+      cy.findByText("From another model or question").click();
+      cy.findByText("Pick a model or question…").click();
+    });
+    checkColumnMapping("Models", modelName);
+
+    cy.log("Use model-based question for dropdown source");
+    modal().findByText(modelName).click();
+    checkColumnMapping("Questions", questionName);
+  });
 });


### PR DESCRIPTION
Related https://github.com/metabase/metabase/issues/35840

Just a repro that the FE now works correctly. The issue itself is not fixed.

Before:
<img width="1157" alt="Screenshot 2024-07-12 at 13 21 36" src="https://github.com/user-attachments/assets/c86ffde1-9ab7-4a5b-9c4b-b5b0cd35215f">

Now:
<img width="791" alt="Screenshot 2024-07-12 at 14 49 28" src="https://github.com/user-attachments/assets/a826e7ab-9092-489e-b1b1-b05efc08806d">
