### PR TITLE
Fix underlying records drill from pivot tables

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
@@ -961,8 +961,7 @@ describe("issue 45481", () => {
   });
 
   it("should not crash when the table viz gets automatically pivoted (metabase#45481)", () => {
-    openOrdersTable();
-    openNotebook();
+    openOrdersTable({ mode: "notebook" });
     summarize({ mode: "notebook" });
     popover().findByText("Count of rows").click();
     getNotebookStep("summarize")
@@ -979,5 +978,53 @@ describe("issue 45481", () => {
     });
     visualize();
     tableInteractive().should("be.visible");
+  });
+});
+
+describe("issue 12368", () => {
+  const questionDetails = {
+    type: "question",
+    query: {
+      "source-table": PRODUCTS_ID,
+      aggregation: [["count"]],
+      breakout: [
+        ["field", PRODUCTS.VENDOR, { "base-type": "type/Text" }],
+        ["field", PRODUCTS.CATEGORY, { "base-type": "type/Text" }],
+      ],
+    },
+    visualization_settings: {
+      "table.pivot": true,
+      "table.pivot_column": "CATEGORY",
+      "table.cell_column": "count",
+      column_settings: {
+        [`["ref",["field",${PRODUCTS.VENDOR},null]]`]: {
+          column_title: "Vendor2",
+        },
+      },
+    },
+  };
+
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("should clear pivot settings when doing underlying records drill from a pivot table (metabase#12368)", () => {
+    cy.log("drill thru from a pivot table");
+    createQuestion(questionDetails, { visitQuestion: true });
+    cy.findAllByTestId("cell-data").contains("1").first().click();
+    popover().findByText("See this Product").click();
+
+    cy.log("pivot flag should be cleared but other viz settings are preserved");
+    tableInteractive().within(() => {
+      cy.findByText("Ean").should("be.visible");
+      cy.findByText("Vendor2").should("be.visible");
+    });
+    cy.findByTestId("viz-settings-button").click();
+    cy.findByTestId("chartsettings-sidebar").within(() => {
+      cy.button("Add or remove columns").should("be.visible");
+      cy.findByText("Pivot column").should("not.exist");
+      cy.findByText("Cell column").should("not.exist");
+    });
   });
 });

--- a/frontend/src/metabase/querying/utils/drills/underlying-records-drill/underlying-records-drill.ts
+++ b/frontend/src/metabase/querying/utils/drills/underlying-records-drill/underlying-records-drill.ts
@@ -33,7 +33,10 @@ export const underlyingRecordsDrill: Drill<
       section: "records",
       icon: "table_spaced",
       buttonType: "horizontal",
-      question: () => applyDrill(drill).setDisplay("table"),
+      question: () =>
+        applyDrill(drill)
+          .setDisplay("table")
+          .updateSettings({ "table.pivot": false }),
     },
   ];
 };


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/12368

Simplified repro steps:
- New -> Question -> Products
- Aggregation -> Count
- Breakout -> Vendor, Category
- Visualize
- It should be visualized as a table (with a pivot flag, not the actual pivot table!). If not, change the viz type manually
- Open viz settings -> Toggle the pivot toggle off and on
- Save the question
- Click on any cell with data -> See this Product
- Open the viz settings
- You should see regular table options and not pivot table options

Before:
<img width="1114" alt="Screenshot 2024-07-12 at 15 49 16" src="https://github.com/user-attachments/assets/69f51911-9aef-4d22-bfa2-20d08ba7f4a5">

After:
<img width="687" alt="Screenshot 2024-07-12 at 15 49 32" src="https://github.com/user-attachments/assets/cb551f96-03fd-4b40-a02b-c6d62c4a300d">
