### PR TITLE
Fix model metadata tooltip visibility

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.tsx
@@ -3,7 +3,7 @@ import { useHoverDirty } from "react-use";
 import { t } from "ttag";
 
 import { color } from "metabase/lib/colors";
-import { Tooltip, DEFAULT_POPOVER_Z_INDEX } from "metabase/ui";
+import { Tooltip } from "metabase/ui";
 import type Question from "metabase-lib/v1/Question";
 import { getDatasetMetadataCompletenessPercentage } from "metabase-lib/v1/metadata/utils/models";
 
@@ -53,7 +53,6 @@ type Props = {
 };
 
 const TOOLTIP_DELAY = 700;
-const TOOLTIP_Z_INDEX = DEFAULT_POPOVER_Z_INDEX + 1;
 
 function DatasetMetadataStrengthIndicator({ dataset, ...props }: Props) {
   const rootRef = useRef<HTMLDivElement>(null);
@@ -73,7 +72,6 @@ function DatasetMetadataStrengthIndicator({ dataset, ...props }: Props) {
         label={getTooltipMessage(percentage)}
         openDelay={TOOLTIP_DELAY}
         position="bottom"
-        style={{ zIndex: TOOLTIP_Z_INDEX }}
       >
         <PercentageLabel
           color={indicationColor}

--- a/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.tsx
@@ -2,8 +2,8 @@ import { useRef } from "react";
 import { useHoverDirty } from "react-use";
 import { t } from "ttag";
 
-import Tooltip from "metabase/core/components/Tooltip";
 import { color } from "metabase/lib/colors";
+import { Tooltip, DEFAULT_POPOVER_Z_INDEX } from "metabase/ui";
 import type Question from "metabase-lib/v1/Question";
 import { getDatasetMetadataCompletenessPercentage } from "metabase-lib/v1/metadata/utils/models";
 
@@ -52,7 +52,8 @@ type Props = {
   dataset: Question;
 };
 
-const TOOLTIP_DELAY: [number, null] = [700, null];
+const TOOLTIP_DELAY = 700;
+const TOOLTIP_Z_INDEX = DEFAULT_POPOVER_Z_INDEX + 1;
 
 function DatasetMetadataStrengthIndicator({ dataset, ...props }: Props) {
   const rootRef = useRef<HTMLDivElement>(null);
@@ -69,9 +70,10 @@ function DatasetMetadataStrengthIndicator({ dataset, ...props }: Props) {
   return (
     <Root {...props} ref={rootRef}>
       <Tooltip
-        tooltip={getTooltipMessage(percentage)}
-        delay={TOOLTIP_DELAY}
-        placement="bottom"
+        label={getTooltipMessage(percentage)}
+        openDelay={TOOLTIP_DELAY}
+        position="bottom"
+        style={{ zIndex: TOOLTIP_Z_INDEX }}
       >
         <PercentageLabel
           color={indicationColor}


### PR DESCRIPTION
Fixes #45441 by converting the old Tooltip to the Mantine Tooltip.

> [!Important]
> I couldn't find a reliable way to test this, other than visually.

### Demo

Before
![image](https://github.com/user-attachments/assets/2b9c2465-1c84-49bc-a39a-103b38768657)


Now
![image](https://github.com/user-attachments/assets/4032ddf4-d90e-4869-b2f5-747c256fc6a9)
