### PR TITLE
Do not reset `table.columns` when some column is deleted

### DIFF
--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -537,7 +537,7 @@ export const buildTableColumnSettings = ({
       const settingIndexes = findColumnSettingIndexesForColumns(cols, settings);
 
       return [
-        // remove settings that have no matching columns
+        // retain settings with matching columns only
         ...settings.filter(
           (_, settingIndex) => columnIndexes[settingIndex] >= 0,
         ),

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -537,9 +537,9 @@ export const buildTableColumnSettings = ({
       const settingIndexes = findColumnSettingIndexesForColumns(cols, settings);
 
       return [
-        // remove enabled settings that have no matching columns
-        ...settings.filter((setting, settingIndex) =>
-          setting.enabled ? columnIndexes[settingIndex] >= 0 : true,
+        // remove settings that have no matching columns
+        ...settings.filter(
+          (_, settingIndex) => columnIndexes[settingIndex] >= 0,
         ),
         // add columns that do not have matching settings to the end
         ...cols

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -532,38 +532,23 @@ export const buildTableColumnSettings = ({
     getHidden: (series, vizSettings) => vizSettings["table.pivot"],
     getValue: ([{ data }], vizSettings) => {
       const { cols } = data;
+      const settings = vizSettings["table.columns"] ?? [];
+      const columnIndexes = findColumnIndexesForColumnSettings(cols, settings);
+      const settingIndexes = findColumnSettingIndexesForColumns(cols, settings);
 
-      function isValid(columnSettings) {
-        const columnIndexes = findColumnIndexesForColumnSettings(
-          cols,
-          columnSettings.filter(({ enabled }) => enabled),
-        );
-        return columnIndexes.every(columnIndex => columnIndex >= 0);
-      }
-
-      function getValue(columnSettings) {
-        const settingIndexes = findColumnSettingIndexesForColumns(
-          cols,
-          columnSettings,
-        );
-
-        return [
-          ...columnSettings,
-          ...cols
-            .filter((_, columnIndex) => settingIndexes[columnIndex] < 0)
-            .map(column => ({
-              name: column.name,
-              enabled: getIsColumnVisible(column),
-            })),
-        ];
-      }
-
-      const columnSettings = vizSettings["table.columns"];
-      if (!columnSettings || !isValid(columnSettings)) {
-        return getValue([]);
-      } else {
-        return getValue(columnSettings);
-      }
+      return [
+        // remove enabled settings that have no matching columns
+        ...settings.filter((setting, settingIndex) =>
+          setting.enabled ? columnIndexes[settingIndex] >= 0 : true,
+        ),
+        // add columns that do not have matching settings to the end
+        ...cols
+          .filter((_, columnIndex) => settingIndexes[columnIndex] < 0)
+          .map(column => ({
+            name: column.name,
+            enabled: getIsColumnVisible(column),
+          })),
+      ];
     },
     getProps: (series, settings) => {
       const [


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/7884

How to verify:
- New -> SQL query -> SELECT 1 AS C1, 2 AS C2, 3 AS C3 -> Run and save
- New -> Question -> Questions -> Select the sql query
- Change the table column order to C3, C1, C2 -> Save the question
- Go to the sql query and remove `2 as C2,`, run and save
- Go back to the question -> the column order should be preserved

Before:
<img width="1061" alt="Screenshot 2024-07-12 at 16 19 47" src="https://github.com/user-attachments/assets/272c0640-adb2-48d0-9acc-43544d5489a0">

After:
<img width="862" alt="Screenshot 2024-07-12 at 16 20 05" src="https://github.com/user-attachments/assets/19fd4707-11e2-422f-8be3-45245fe081db">
