### PR TITLE
Optimize autocomplete filters in FilterModal

### DIFF
--- a/frontend/src/metabase/querying/components/FilterContent/StringFilterEditor/StringFilterEditor.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterContent/StringFilterEditor/StringFilterEditor.unit.spec.tsx
@@ -4,13 +4,14 @@ import {
   setupFieldSearchValuesEndpoint,
   setupFieldValuesEndpoints,
 } from "__support__/server-mocks";
-import { act, renderWithProviders, screen } from "__support__/ui";
+import { renderWithProviders, screen } from "__support__/ui";
 import * as Lib from "metabase-lib";
 import { columnFinder, createQuery } from "metabase-lib/test-helpers";
 import type { GetFieldValuesResponse } from "metabase-types/api";
 import { createMockFieldValues } from "metabase-types/api/mocks";
 import {
   PEOPLE,
+  PEOPLE_STATE_VALUES,
   PRODUCT_CATEGORY_VALUES,
 } from "metabase-types/api/mocks/presets";
 
@@ -77,34 +78,44 @@ describe("StringFilterEditor", () => {
   const findColumn = columnFinder(query, availableColumns);
   const column = findColumn("PRODUCTS", "CATEGORY");
 
-  beforeAll(() => {
-    jest.useFakeTimers({ advanceTimers: true });
-  });
-
-  afterAll(() => {
-    jest.useRealTimers();
-  });
-
   describe("new filter", () => {
-    it("should handle list values", async () => {
-      const { getNextFilterName } = setup({
+    it("should handle list values when they are rendered as a list of checkboxes", async () => {
+      const { getNextFilterName, onChange } = setup({
         query,
         stageIndex,
         column,
       });
 
       await userEvent.click(await screen.findByText("Gadget"));
-
       expect(getNextFilterName()).toBe("Category is Gadget");
+      expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
+    it("should handle list values when they are rendered as an autocomplete input", async () => {
+      const { getNextFilterName, onChange, onInput } = setup({
+        query,
+        stageIndex,
+        column: findColumn("PEOPLE", "STATE"),
+        fieldValues: PEOPLE_STATE_VALUES,
+      });
+
+      const input = await screen.findByPlaceholderText("Search the list");
+      await userEvent.type(input, "T");
+      await userEvent.click(await screen.findByText("TX"));
+      expect(onInput).toHaveBeenCalled();
+
+      await userEvent.tab();
+      expect(getNextFilterName()).toBe("State is TX");
+      expect(onChange).toHaveBeenCalledTimes(1);
     });
 
     it("should handle searchable values", async () => {
-      const { getNextFilterName } = setup({
+      const { getNextFilterName, onChange, onInput } = setup({
         query,
         stageIndex,
         column: findColumn("PEOPLE", "EMAIL"),
         searchValues: {
-          a: createMockFieldValues({
+          "a@metabase": createMockFieldValues({
             field_id: PEOPLE.EMAIL,
             values: [["a@metabase.test"]],
           }),
@@ -113,15 +124,23 @@ describe("StringFilterEditor", () => {
 
       await userEvent.click(screen.getByText("contains"));
       await userEvent.click(screen.getByText("Is"));
-      await userEvent.type(screen.getByPlaceholderText("Search by Email"), "a");
-      act(() => jest.advanceTimersByTime(1000));
-      await userEvent.click(await screen.findByText("a@metabase.test"));
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(getNextFilterName()).toBeNull();
 
+      await userEvent.type(
+        screen.getByPlaceholderText("Search by Email"),
+        "a@metabase",
+      );
+      await userEvent.click(await screen.findByText("a@metabase.test"));
+      expect(onInput).toHaveBeenCalled();
+
+      await userEvent.tab();
       expect(getNextFilterName()).toBe("Email is a@metabase.test");
+      expect(onChange).toHaveBeenCalledTimes(2);
     });
 
     it("should handle non-searchable values", async () => {
-      const { getNextFilterName, onInput } = setup({
+      const { getNextFilterName, onChange, onInput } = setup({
         query,
         stageIndex,
         column: findColumn("PEOPLE", "PASSWORD"),
@@ -129,14 +148,18 @@ describe("StringFilterEditor", () => {
 
       await userEvent.click(screen.getByText("contains"));
       await userEvent.click(screen.getByText("Is"));
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(getNextFilterName()).toBeNull();
+
       await userEvent.type(
         screen.getByPlaceholderText("Enter some text"),
         "Test",
       );
-      await userEvent.tab();
-
-      expect(getNextFilterName()).toBe("Password is Test");
       expect(onInput).toHaveBeenCalled();
+
+      await userEvent.tab();
+      expect(getNextFilterName()).toBe("Password is Test");
+      expect(onChange).toHaveBeenCalledTimes(2);
     });
 
     it("should add a filter with one value", async () => {
@@ -152,10 +175,10 @@ describe("StringFilterEditor", () => {
         screen.getByPlaceholderText("Enter some text"),
         "Ga",
       );
-      await userEvent.tab();
-
-      expect(getNextFilterName()).toBe("Category starts with Ga");
       expect(onInput).toHaveBeenCalled();
+
+      await userEvent.tab();
+      expect(getNextFilterName()).toBe("Category starts with Ga");
     });
 
     it("should add a filter with no value", async () => {
@@ -223,7 +246,7 @@ describe("StringFilterEditor", () => {
         operator: "=",
         values: ["a@metabase.test"],
       });
-      const { getNextFilterName } = setup({
+      const { getNextFilterName, onInput } = setup({
         query,
         stageIndex,
         column,
@@ -238,8 +261,10 @@ describe("StringFilterEditor", () => {
       expect(screen.getByText("a@metabase.test")).toBeInTheDocument();
 
       await userEvent.type(screen.getByLabelText("Filter value"), "b");
-      act(() => jest.advanceTimersByTime(1000));
       await userEvent.click(await screen.findByText("b@metabase.test"));
+      expect(onInput).toHaveBeenCalled();
+
+      await userEvent.tab();
       expect(getNextFilterName()).toBe("Email is 2 selections");
       expect(screen.getByText("a@metabase.test")).toBeInTheDocument();
       expect(screen.getByText("b@metabase.test")).toBeInTheDocument();
@@ -252,7 +277,7 @@ describe("StringFilterEditor", () => {
         operator: "=",
         values: ["abc"],
       });
-      const { getNextFilterName } = setup({
+      const { getNextFilterName, onInput } = setup({
         query,
         stageIndex,
         column,
@@ -261,8 +286,9 @@ describe("StringFilterEditor", () => {
       expect(screen.getByText("abc")).toBeInTheDocument();
 
       await userEvent.type(screen.getByLabelText("Filter value"), "bcd");
-      await userEvent.tab();
+      expect(onInput).toHaveBeenCalled();
 
+      await userEvent.tab();
       expect(getNextFilterName()).toBe("Password is 2 selections");
       expect(screen.getByText("abc")).toBeInTheDocument();
       expect(screen.getByText("bcd")).toBeInTheDocument();
@@ -275,7 +301,7 @@ describe("StringFilterEditor", () => {
         operator: "starts-with",
         values: ["Ga"],
       });
-      const { getNextFilterName } = setup({
+      const { getNextFilterName, onInput } = setup({
         query,
         stageIndex,
         column,
@@ -284,8 +310,9 @@ describe("StringFilterEditor", () => {
 
       const input = screen.getByLabelText("Filter value");
       await userEvent.type(input, "{backspace}Wi");
-      await userEvent.tab();
+      expect(onInput).toHaveBeenCalled();
 
+      await userEvent.tab();
       expect(getNextFilterName()).toBe("Category starts with Wi");
     });
 

--- a/frontend/src/metabase/querying/components/FilterPicker/StringFilterPicker/StringFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/StringFilterPicker/StringFilterPicker.unit.spec.tsx
@@ -94,14 +94,6 @@ async function setOperator(operator: string) {
 }
 
 describe("StringFilterPicker", () => {
-  beforeAll(() => {
-    jest.useFakeTimers({ advanceTimers: true });
-  });
-
-  afterAll(() => {
-    jest.useRealTimers();
-  });
-
   describe("new filter", () => {
     it("should render a blank editor", () => {
       setup();
@@ -170,7 +162,6 @@ describe("StringFilterPicker", () => {
       await userEvent.click(screen.getByDisplayValue("Contains"));
       await userEvent.click(screen.getByText("Is"));
       await userEvent.type(screen.getByPlaceholderText("Search by Email"), "t");
-      jest.advanceTimersByTime(500);
       await userEvent.click(await screen.findByText("test@metabase.test"));
 
       await userEvent.click(screen.getByText("Add filter"));

--- a/frontend/src/metabase/querying/components/FilterValuePicker/FilterValuePicker.tsx
+++ b/frontend/src/metabase/querying/components/FilterValuePicker/FilterValuePicker.tsx
@@ -76,6 +76,8 @@ function FilterValuePicker({
         autoFocus={autoFocus}
         compact={compact}
         onChange={onChange}
+        onFocus={onFocus}
+        onBlur={onBlur}
       />
     );
   }
@@ -92,6 +94,8 @@ function FilterValuePicker({
         shouldCreate={shouldCreate}
         autoFocus={autoFocus}
         onChange={onChange}
+        onFocus={onFocus}
+        onBlur={onBlur}
       />
     );
   }

--- a/frontend/src/metabase/querying/components/FilterValuePicker/ListValuePicker/ListValuePicker.tsx
+++ b/frontend/src/metabase/querying/components/FilterValuePicker/ListValuePicker/ListValuePicker.tsx
@@ -1,4 +1,4 @@
-import type { ChangeEvent } from "react";
+import type { ChangeEvent, FocusEvent } from "react";
 import { useMemo, useState } from "react";
 import { t } from "ttag";
 
@@ -26,6 +26,8 @@ interface ListValuePickerProps {
   autoFocus?: boolean;
   compact?: boolean;
   onChange: (newValues: string[]) => void;
+  onFocus?: (event: FocusEvent<HTMLInputElement>) => void;
+  onBlur?: (event: FocusEvent<HTMLInputElement>) => void;
 }
 
 export function ListValuePicker(props: ListValuePickerProps) {
@@ -124,6 +126,8 @@ export function AutocompletePicker({
   shouldCreate,
   autoFocus,
   onChange,
+  onFocus,
+  onBlur,
 }: ListValuePickerProps) {
   const options = useMemo(() => getFieldOptions(fieldValues), [fieldValues]);
 
@@ -137,6 +141,8 @@ export function AutocompletePicker({
       searchable
       aria-label={t`Filter value`}
       onChange={onChange}
+      onFocus={onFocus}
+      onBlur={onBlur}
     />
   );
 }

--- a/frontend/src/metabase/querying/components/FilterValuePicker/SearchValuePicker/SearchValuePicker.tsx
+++ b/frontend/src/metabase/querying/components/FilterValuePicker/SearchValuePicker/SearchValuePicker.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { type FocusEvent, useState } from "react";
 import { useDebounce } from "react-use";
 import { t } from "ttag";
 
@@ -23,6 +23,8 @@ interface SearchValuePickerProps {
   shouldCreate?: (query: string, values: string[]) => boolean;
   autoFocus?: boolean;
   onChange: (newValues: string[]) => void;
+  onFocus?: (event: FocusEvent<HTMLInputElement>) => void;
+  onBlur?: (event: FocusEvent<HTMLInputElement>) => void;
 }
 
 export function SearchValuePicker({
@@ -33,6 +35,8 @@ export function SearchValuePicker({
   shouldCreate,
   autoFocus,
   onChange,
+  onFocus,
+  onBlur,
 }: SearchValuePickerProps) {
   const [searchValue, setSearchValue] = useState("");
   const [searchQuery, setSearchQuery] = useState(searchValue);
@@ -96,6 +100,8 @@ export function SearchValuePicker({
       nothingFound={notFoundMessage}
       onChange={onChange}
       onSearchChange={handleSearchChange}
+      onFocus={onFocus}
+      onBlur={onBlur}
     />
   );
 }


### PR DESCRIPTION
Related to https://github.com/metabase/metabase/issues/43426

Fixes some of the symptoms of the issue. Now, for "search box" and "list of all values" inputs, we do not update the MBQL lib query on each character. The optimization was already in place, but just wasn't used for these components.

How to verify:
- New -> Question -> Orders
- Join -> Orders (self join) on ID = ID
- Visualize
- Filter
- Select the second "User" group (implicit join for the self joined table)
- `User.Email` -> change operator to IS, enter something and select the value
- Apply filters
- Only 1 filter should be added

Please note that this PR only fixes the issue when during editing the input doesn't loose the focus. It doesn't fix the issue with MBQL lib not finding the correct filter for this column, forcing us to create a new filter each time. So the issue above won't be closed by this PR.

<img width="1175" alt="Screenshot 2024-07-14 at 20 28 32" src="https://github.com/user-attachments/assets/1ad6acea-abfd-4103-99cd-ace7d6231b97">
<img width="758" alt="Screenshot 2024-07-14 at 20 28 57" src="https://github.com/user-attachments/assets/006397d8-27df-48d2-a162-daf9eed8743c">



