### PR TITLE
Add more feature flags for query analysis

### DIFF
--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -927,7 +927,7 @@ See [fonts](../configuring-metabase/fonts.md).")
 
 (defsetting sql-parsing-enabled
   (deferred-tru "SQL Parsing is enabled. Please use [[query-analysis-native-disabled]] instead.")
-  :deprecated "0.50.14"
+  :deprecated "0.51.0"
   :visibility :internal
   :export?    false
   :default    true

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -926,7 +926,8 @@ See [fonts](../configuring-metabase/fonts.md).")
   :doc        false)
 
 (defsetting sql-parsing-enabled
-  (deferred-tru "SQL Parsing is disabled")
+  (deferred-tru "SQL Parsing is enabled. Please use [[query-analysis-native-disabled]] instead.")
+  :deprecated "0.50.14"
   :visibility :internal
   :export?    false
   :default    true
@@ -937,4 +938,18 @@ See [fonts](../configuring-metabase/fonts.md).")
   :visibility :internal
   :export?    false
   :default    true
+  :type       :boolean)
+
+(defsetting query-analysis-mbql-disabled
+  (deferred-tru "Whether we should disable analysis of all ML-based queries")
+  :visibility :internal
+  :export?    false
+  :default    false
+  :type       :boolean)
+
+(defsetting query-analysis-native-disabled
+  (deferred-tru "Whether we should disable analysis of all native queries")
+  :visibility :internal
+  :export?    false
+  :init       (comp not sql-parsing-enabled)
   :type       :boolean)

--- a/src/metabase/query_analysis.clj
+++ b/src/metabase/query_analysis.clj
@@ -75,9 +75,9 @@
   [query-type]
   (and (public-settings/query-analysis-enabled)
        (case query-type
-         :native     (public-settings/query-analysis-native-disabled)
-         :query      (public-settings/query-analysis-mbql-disabled)
-         :mbql/query (public-settings/query-analysis-mbql-disabled)
+         :native     (not (public-settings/query-analysis-native-disabled))
+         :query      (not (public-settings/query-analysis-mbql-disabled))
+         :mbql/query (not (public-settings/query-analysis-mbql-disabled))
          false)))
 
 (defn- query-field-ids

--- a/src/metabase/query_analysis.clj
+++ b/src/metabase/query_analysis.clj
@@ -75,9 +75,9 @@
   [query-type]
   (and (public-settings/query-analysis-enabled)
        (case query-type
-         :native (public-settings/sql-parsing-enabled)
-         :query true
-         :mbql/query true
+         :native     (public-settings/query-analysis-native-disabled)
+         :query      (public-settings/query-analysis-mbql-disabled)
+         :mbql/query (public-settings/query-analysis-mbql-disabled)
          false)))
 
 (defn- query-field-ids
@@ -89,11 +89,11 @@
    (query-field-ids query (lib/normalized-query-type query)))
   ([query query-type]
    (case query-type
-     :native (try
-               (nqa/field-ids-for-native query)
-               (catch Exception e
-                 (log/error e "Error parsing SQL" query)))
-     :query {:explicit (mbql.u/referenced-field-ids query)}
+     :native     (try
+                   (nqa/field-ids-for-native query)
+                   (catch Exception e
+                     (log/error e "Error parsing SQL" query)))
+     :query      {:explicit (mbql.u/referenced-field-ids query)}
      :mbql/query {:explicit (lib.util/referenced-field-ids query)})))
 
 (defn update-query-analysis-for-card!

--- a/test/metabase/query_analysis_test.clj
+++ b/test/metabase/query_analysis_test.clj
@@ -16,8 +16,9 @@
       (public-settings/sql-parsing-enabled! true)
       ;; I'm not sure why this is `nil`, but it is fine for our purposes.
       (is (nil? (public-settings/query-analysis-native-disabled)))
-      (public-settings/query-analysis-native-disabled! true)
-      (is (true? (public-settings/query-analysis-native-disabled)))))
+      (testing "we can override the legacy setting"
+        (public-settings/query-analysis-native-disabled! true)
+        (is (true? (public-settings/query-analysis-native-disabled))))))
   (mt/discard-setting-changes [query-analysis-native-disabled sql-parsing-enabled]
     (testing "legacy setting disabled"
       (public-settings/sql-parsing-enabled! false)

--- a/test/metabase/query_analysis_test.clj
+++ b/test/metabase/query_analysis_test.clj
@@ -14,7 +14,7 @@
   (mt/discard-setting-changes [query-analysis-native-disabled sql-parsing-enabled]
     (testing "legacy setting enabled"
       (public-settings/sql-parsing-enabled! true)
-      ;; I'm not sure why this is nil, but it is fine for our purposes.
+      ;; I'm not sure why this is `nil`, but it is fine for our purposes.
       (is (nil? (public-settings/query-analysis-native-disabled)))
       (public-settings/query-analysis-native-disabled! true)
       (is (true? (public-settings/query-analysis-native-disabled)))))
@@ -30,10 +30,10 @@
                                query-analysis-native-disabled]
     (public-settings/query-analysis-enabled! true)
     (testing "sql parsing enabled"
-      (public-settings/query-analysis-native-disabled! true)
+      (public-settings/query-analysis-native-disabled! false)
       (is (true? (query-analysis/enabled-type? :native))))
     (testing "sql parsing disabled"
-      (public-settings/query-analysis-native-disabled! false)
+      (public-settings/query-analysis-native-disabled! true)
       (is (false? (query-analysis/enabled-type? :native))))))
 
 (deftest non-native-query-enabled-test
@@ -58,17 +58,14 @@
 (deftest no-query-analysis-enabled-test
   (mt/discard-setting-changes [query-analysis-enabled
                                query-analysis-mbql-disabled
-                               query-analysis-native-disabled
-                               sql-parsing-enabled]
+                               query-analysis-native-disabled]
     (public-settings/query-analysis-enabled! false)
     (testing "All query analysis is disabled"
-      (public-settings/sql-parsing-enabled! true)
-      (binding [query-analysis/*parse-queries-in-test?* true]
-        (is (false? (query-analysis/enabled? :native))))
-
+      (public-settings/query-analysis-native-disabled! false)
       (public-settings/query-analysis-mbql-disabled! false)
-      (is (false? (query-analysis/enabled? :query)))
-      (is (false? (query-analysis/enabled? :mbql/query))))))
+      (is (false? (query-analysis/enabled-type? :native)))
+      (is (false? (query-analysis/enabled-type? :query)))
+      (is (false? (query-analysis/enabled-type? :mbql/query))))))
 
 (deftest parse-mbql-test
   (testing "Parsing MBQL query returns correct used fields"

--- a/test/metabase/query_analysis_test.clj
+++ b/test/metabase/query_analysis_test.clj
@@ -10,16 +10,26 @@
    [metabase.test :as mt]
    [toucan2.tools.with-temp :as t2.with-temp]))
 
-(deftest native-query-enabled-test
-  (mt/discard-setting-changes [query-analysis-enabled
-                               query-analysis-native-disabled
-                               sql-parsing-enabled]
-    (public-settings/query-analysis-enabled! true)
+(deftest legacy-sql-parsing-enabled-test
+  (mt/discard-setting-changes [query-analysis-native-disabled sql-parsing-enabled]
     (testing "sql parsing enabled"
       (public-settings/sql-parsing-enabled! true)
-      (is (true? (query-analysis/enabled-type? :native))))
+      ;; I'm not sure why this is nil, but it is fine for our purposes.
+      (is (nil? (public-settings/query-analysis-native-disabled)))))
+  (mt/discard-setting-changes [query-analysis-native-disabled sql-parsing-enabled]
     (testing "sql parsing disabled"
       (public-settings/sql-parsing-enabled! false)
+      (is (true? (public-settings/query-analysis-native-disabled))))))
+
+(deftest native-query-enabled-test
+  (mt/discard-setting-changes [query-analysis-enabled
+                               query-analysis-native-disabled]
+    (public-settings/query-analysis-enabled! true)
+    (testing "sql parsing enabled"
+      (public-settings/query-analysis-native-disabled! true)
+      (is (true? (query-analysis/enabled-type? :native))))
+    (testing "sql parsing disabled"
+      (public-settings/query-analysis-native-disabled! false)
       (is (false? (query-analysis/enabled-type? :native))))))
 
 (deftest non-native-query-enabled-test

--- a/test/metabase/query_analysis_test.clj
+++ b/test/metabase/query_analysis_test.clj
@@ -12,14 +12,18 @@
 
 (deftest legacy-sql-parsing-enabled-test
   (mt/discard-setting-changes [query-analysis-native-disabled sql-parsing-enabled]
-    (testing "sql parsing enabled"
+    (testing "legacy setting enabled"
       (public-settings/sql-parsing-enabled! true)
       ;; I'm not sure why this is nil, but it is fine for our purposes.
-      (is (nil? (public-settings/query-analysis-native-disabled)))))
+      (is (nil? (public-settings/query-analysis-native-disabled)))
+      (public-settings/query-analysis-native-disabled! true)
+      (is (true? (public-settings/query-analysis-native-disabled)))))
   (mt/discard-setting-changes [query-analysis-native-disabled sql-parsing-enabled]
-    (testing "sql parsing disabled"
+    (testing "legacy setting disabled"
       (public-settings/sql-parsing-enabled! false)
-      (is (true? (public-settings/query-analysis-native-disabled))))))
+      (is (true? (public-settings/query-analysis-native-disabled)))
+      (public-settings/query-analysis-native-disabled! false)
+      (is (false? (public-settings/query-analysis-native-disabled))))))
 
 (deftest native-query-enabled-test
   (mt/discard-setting-changes [query-analysis-enabled

--- a/test/metabase/query_analysis_test.clj
+++ b/test/metabase/query_analysis_test.clj
@@ -43,7 +43,8 @@
 
 (deftest no-query-analysis-enabled-test
   (mt/discard-setting-changes [query-analysis-enabled
-                               query-analysis-mbql-enabled
+                               query-analysis-mbql-disabled
+                               query-analysis-native-disabled
                                sql-parsing-enabled]
     (public-settings/query-analysis-enabled! false)
     (testing "All query analysis is disabled"


### PR DESCRIPTION
### Description

This complements the flag used to opt out of SQL analysis in existing v50 versions, with one for MBQL. It also adds a kill switch for all analysis.

Given the overarching setting, it makes more sense to name the settings in the negative, as they are not the final authority on whether the relevant queries are analyzed, but they can disable them definitively.

In order for more consistently structured and grouped naming, and flipping to the negative, we deprecate the existing flag.