### PR TITLE
Fix - More than 10 Series (using Add Series Dashboard Feature) cause Filter UI to be inaccessible

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
@@ -1706,6 +1706,8 @@ describe("issue 43219", () => {
         questions: [questionDetails],
         cards: [
           {
+            size_x: 4,
+            size_y: 3,
             series: Array.from({ length: cardsCount }, (_value, index) => {
               const question = this[getQuestionAlias(index)];
               return question;
@@ -1724,6 +1726,11 @@ describe("issue 43219", () => {
       .findByText("Text")
       .click();
 
+    getDashboardCard(0)
+      .findByText("Series 10")
+      .should("exist")
+      .and("not.be.visible");
+    getDashboardCard(0).realMouseWheel({ deltaX: 1400, deltaY: 400 });
     getDashboardCard(0).findByText("Series 10").should("be.visible");
   });
 });

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
@@ -1688,15 +1688,16 @@ describe("issue 43219", () => {
     restore();
     cy.signInAsAdmin();
 
-    for (let index = 0; index < cardsCount; ++index) {
-      const name = `Series ${index + 1}`;
-
-      createQuestion({ ...questionDetails, name }).then(
-        ({ body: question }) => {
-          cy.wrap(question).as(getQuestionAlias(index));
-        },
-      );
-    }
+    cypressWaitAll(
+      Array.from({ length: cardsCount }, (_value, index) => {
+        const name = `Series ${index + 1}`;
+        return createQuestion({ ...questionDetails, name }).then(
+          ({ body: question }) => {
+            cy.wrap(question).as(getQuestionAlias(index));
+          },
+        );
+      }),
+    );
 
     cy.then(function () {
       cy.createDashboardWithQuestions({

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
@@ -1732,12 +1732,10 @@ describe("issue 43219", () => {
       .findByText("Text")
       .click();
 
-    getDashboardCard(0).within(() => {
-      cy.findByText(
-        "Make sure to make a selection for each series, or the filter won't work on this card.",
-      ).should("be.visible");
-      cy.findByText("Series 10").should("exist").and("not.be.visible");
-    });
+    getDashboardCard(0)
+      .findByText("Series 10")
+      .should("exist")
+      .and("not.be.visible");
 
     // We need 2 realMouseWheel calls because we're scrolling 2 different elements:
     // one horizontally, and one vertically. The horizontally scrollable element is initially

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
@@ -1732,16 +1732,15 @@ describe("issue 43219", () => {
       .findByText("Text")
       .click();
 
-    getDashboardCard(0)
-      .findByText("Series 10")
-      .should("exist")
-      .and("not.be.visible");
+    getDashboardCard(0).within(() => {
+      cy.findByText("Series 10").should("exist").and("not.be.visible");
 
-    // We need 2 realMouseWheel calls because we're scrolling 2 different elements:
-    // one horizontally, and one vertically. The horizontally scrollable element is initially
-    // out of view and we need to scroll vertically to it.
-    getDashboardCard(0).realMouseWheel({ deltaY: 400 });
-    getDashboardCard(0).realMouseWheel({ deltaX: 1400 });
-    getDashboardCard(0).findByText("Series 10").should("be.visible");
+      cy.findByTestId("visualization-root").realMouseWheel({ deltaY: 400 });
+      cy.findByTestId("parameter-mapper-container").realMouseWheel({
+        deltaX: 1400,
+      });
+
+      cy.findByText("Series 10").should("be.visible");
+    });
   });
 });

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
@@ -1735,10 +1735,8 @@ describe("issue 43219", () => {
     getDashboardCard(0).within(() => {
       cy.findByText("Series 10").should("exist").and("not.be.visible");
 
-      cy.findByTestId("visualization-root").realMouseWheel({ deltaY: 400 });
-      cy.findByTestId("parameter-mapper-container").realMouseWheel({
-        deltaX: 1400,
-      });
+      cy.findByTestId("visualization-root").scrollTo("bottom");
+      cy.findByTestId("parameter-mapper-container").scrollTo("right");
 
       cy.findByText("Series 10").should("be.visible");
     });

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
@@ -1704,15 +1704,20 @@ describe("issue 43219", () => {
         dashboardDetails: {
           parameters: [textFilter],
         },
-        questions: [questionDetails],
+        questions: [
+          {
+            ...questionDetails,
+            name: "Base series",
+          },
+        ],
         cards: [
           {
             size_x: 4,
             size_y: 3,
-            series: Array.from({ length: cardsCount }, (_value, index) => {
-              const question = this[getQuestionAlias(index)];
-              return question;
-            }),
+            series: Array.from(
+              { length: cardsCount },
+              (_value, index) => this[getQuestionAlias(index)],
+            ),
           },
         ],
       }).then(({ dashboard }) => {
@@ -1727,11 +1732,18 @@ describe("issue 43219", () => {
       .findByText("Text")
       .click();
 
-    getDashboardCard(0)
-      .findByText("Series 10")
-      .should("exist")
-      .and("not.be.visible");
-    getDashboardCard(0).realMouseWheel({ deltaX: 1400, deltaY: 400 });
+    getDashboardCard(0).within(() => {
+      cy.findByText(
+        "Make sure to make a selection for each series, or the filter won't work on this card.",
+      ).should("be.visible");
+      cy.findByText("Series 10").should("exist").and("not.be.visible");
+    });
+
+    // We need 2 realMouseWheel calls because we're scrolling 2 different elements:
+    // one horizontally, and one vertically. The horizontally scrollable element is initially
+    // out of view and we need to scroll vertically to it.
+    getDashboardCard(0).realMouseWheel({ deltaY: 400 });
+    getDashboardCard(0).realMouseWheel({ deltaX: 1400 });
     getDashboardCard(0).findByText("Series 10").should("be.visible");
   });
 });

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardParameterMapper.jsx
@@ -29,7 +29,7 @@ export const DashCardParameterMapper = ({ dashcard, isMobile }) => (
         {t`Make sure to make a selection for each series, or the filter won't work on this card.`}
       </div>
     )}
-    <MapperSettingsContainer>
+    <MapperSettingsContainer data-testid="parameter-mapper-container">
       {[dashcard.card].concat(dashcard.series || []).map(card => (
         <DashCardCardParameterMapperConnected
           key={`${dashcard.id},${card.id}`}

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardParameterMapper.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardParameterMapper.styled.tsx
@@ -6,4 +6,5 @@ export const MapperSettingsContainer = styled.div`
   max-width: 100%;
   margin: 0 2rem;
   z-index: 1;
+  overflow: auto;
 `;

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -235,8 +235,10 @@ export function DashCardVisualization({
 
   return (
     <Visualization
-      className={cx(CS.flexFull, CS.overflowHidden, {
+      className={cx(CS.flexFull, {
         [CS.pointerEventsNone]: isEditingDashboardLayout,
+        [CS.overflowAuto]: visualizationOverlay,
+        [CS.overflowHidden]: !visualizationOverlay,
       })}
       classNameWidgets={cx({
         [cx(CS.textLight, CS.textMediumHover)]: isEmbed,


### PR DESCRIPTION
Fixes #43219

### Description

The original issue only mentions the problem with horizontal overflow, however vertical had the problem as well. This PR fixes both.

### How to verify

Stress test: https://github.com/metabase/metabase/actions/runs/9940076735

Repro:
1. Create 1+10 line bar questions
2. Create a dashboard
4. Add first question to it
5. Change dashcard size to minimum (4x3)
6. Add series to this dashcard - every other question from step 1
7. Add dashboard parameter (e.g. text filter)
8. Click on the parameter to start editing mapping
9. Try to map the parameter to the last series

Previously: card mapping is cut off (due to `overflow: hidden`)
Now: dashcard is scrollable


### Demo

Before: [image](https://github.com/user-attachments/assets/cc21630b-d5fb-4e7d-a929-3879468c954e)

After: [image](https://github.com/user-attachments/assets/a7ecdfd5-b978-4d35-b2d6-c8a317000013)


