### PR TITLE
Analyze queries asynchronously when cards are saved

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -794,7 +794,7 @@
    metabase-enterprise.serialization.test-util/with-world                       macros.metabase-enterprise.serialization.test-util/with-world
    metabase-enterprise.test/with-gtaps!                                         macros.metabase-enterprise.sandbox.test-util/with-gtaps!
    metabase-enterprise.advanced-permissions.api.util-test/with-impersonations!  macros.metabase-enterprise.advanced-permissions.api.util-test/with-impersonations!
-   metabase-enterprise.query-field-validation.api-test/with-test-setup          macros.metabase-enterprise.query-field-validation.api-test/with-test-setup
+   metabase-enterprise.query-field-validation.api-test/with-test-setup!         macros.metabase-enterprise.query-field-validation.api-test/with-test-setup!
    metabase.api.card-test/with-ordered-items                                    macros.metabase.api.card-test/with-ordered-items
    metabase.api.collection-test/with-collection-hierarchy                       macros.metabase.api.collection-test/with-collection-hierarchy
    metabase.api.collection-test/with-some-children-of-collection                macros.metabase.api.collection-test/with-some-children-of-collection
@@ -807,7 +807,7 @@
    metabase.lib.common/defop                                                    macros.metabase.lib.common/defop
    metabase.models.params.chain-filter-test/chain-filter                        macros.metabase.models.params.chain-filter-test/chain-filter
    metabase.models.params.chain-filter-test/chain-filter-search                 macros.metabase.models.params.chain-filter-test/chain-filter
-   metabase.models.query-field-test/with-test-setup                             macros.metabase.models.query-field-test/with-test-setup
+   metabase.models.query-field-test/with-test-setup!                            macros.metabase.models.query-field-test/with-test-setup!
    metabase.models.user-test/with-groups                                        macros.metabase.models.user-test/with-groups
    metabase.query-processor.streaming/streaming-response                        macros.metabase.query-processor.streaming/streaming-response
    metabase.related-test/with-world                                             macros.metabase.related-test/with-world

--- a/.clj-kondo/macros/metabase/models/query_field_test.clj
+++ b/.clj-kondo/macros/metabase/models/query_field_test.clj
@@ -1,7 +1,7 @@
 (ns macros.metabase.models.query-field-test
   (:require [macros.common]))
 
-(defmacro with-test-setup [& body]
+(defmacro with-test-setup! [& body]
   `(let [~(macros.common/ignore-unused 'card-id)  1
          ~(macros.common/ignore-unused 'table-id) 2
          ~(macros.common/ignore-unused 'tax-id)   3

--- a/.clj-kondo/macros/metabase_enterprise/query_field_validation/api_test.clj
+++ b/.clj-kondo/macros/metabase_enterprise/query_field_validation/api_test.clj
@@ -1,7 +1,7 @@
 (ns macros.metabase-enterprise.query-field-validation.api-test
   (:require [macros.common]))
 
-(defmacro with-test-setup [& body]
+(defmacro with-test-setup! [& body]
   `(let [~(macros.common/ignore-unused 'card-1) 1
          ~(macros.common/ignore-unused 'card-2) 2
          ~(macros.common/ignore-unused 'card-3) 3

--- a/enterprise/backend/test/metabase_enterprise/query_field_validation/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/query_field_validation/api_test.clj
@@ -3,45 +3,48 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [mb.hawk.assert-exprs.approximately-equal :as hawk.approx]
+   [metabase.query-analysis :as query-analysis]
    [metabase.test :as mt]
    [ring.util.codec :as codec]
    [toucan2.tools.with-temp :as t2.with-temp]))
 
 (defn- do-with-test-setup! [f]
-  (t2.with-temp/with-temp [:model/Table      {table  :id}  {:name "T"}
-                           :model/Collection {coll-1 :id}  {:name "ZZX"}
-                           :model/Collection {coll-2 :id}  {:name "ZZY"}
-                           :model/Collection {coll-3 :id}  {:name "ZZZ"}
-                           :model/Card       {card-1 :id}  {:name "A" :collection_id coll-1}
-                           :model/Card       {card-2 :id}  {:name "B" :collection_id coll-2}
-                           :model/Card       {card-3 :id}  {:name "C" :collection_id coll-3}
-                           :model/Card       {card-4 :id}  {:name "D"}
-                           :model/Field      {field-1 :id} {:active   false
-                                                            :name     "FA"
-                                                            :table_id table}
-                           :model/Field      {field-2 :id} {:active   false
-                                                            :name     "FB"
-                                                            :table_id table}
-                           :model/Field      {field-3 :id} {:active   false
-                                                            :name     "FC"
-                                                            :table_id table}
-                           ;; QFs not to include:
-                           ;; - Field is still active
-                           :model/QueryField {}            {:card_id  card-1
-                                                            :field_id (mt/id :orders :tax)}
-                           ;; - Implicit reference
-                           :model/QueryField {}            {:card_id            card-2
-                                                            :field_id           field-1
-                                                            :explicit_reference false}
-                           ;; QFs to include:
-                           :model/QueryField {qf-1 :id}    {:card_id  card-1
-                                                            :field_id field-1}
-                           :model/QueryField {qf-2 :id}    {:card_id  card-2
-                                                            :field_id field-2}
-                           :model/QueryField {qf-3 :id}    {:card_id  card-3
-                                                            :field_id field-3}]
-    (mt/with-premium-features #{:query-field-validation}
-      (mt/call-with-map-params f [card-1 card-2 card-3 card-4 qf-1 qf-2 qf-3]))))
+  ;; Make sure that no additional analysis is created by hooks
+  (query-analysis/without-analysis
+    (t2.with-temp/with-temp [:model/Table      {table  :id}  {:name "T"}
+                             :model/Collection {coll-1 :id}  {:name "ZZX"}
+                             :model/Collection {coll-2 :id}  {:name "ZZY"}
+                             :model/Collection {coll-3 :id}  {:name "ZZZ"}
+                             :model/Card       {card-1 :id}  {:name "A" :collection_id coll-1}
+                             :model/Card       {card-2 :id}  {:name "B" :collection_id coll-2}
+                             :model/Card       {card-3 :id}  {:name "C" :collection_id coll-3}
+                             :model/Card       {card-4 :id}  {:name "D"}
+                             :model/Field      {field-1 :id} {:active   false
+                                                              :name     "FA"
+                                                              :table_id table}
+                             :model/Field      {field-2 :id} {:active   false
+                                                              :name     "FB"
+                                                              :table_id table}
+                             :model/Field      {field-3 :id} {:active   false
+                                                              :name     "FC"
+                                                              :table_id table}
+                             ;; QFs not to include:
+                             ;; - Field is still active
+                             :model/QueryField {}            {:card_id  card-1
+                                                              :field_id (mt/id :orders :tax)}
+                             ;; - Implicit reference
+                             :model/QueryField {}            {:card_id            card-2
+                                                              :field_id           field-1
+                                                              :explicit_reference false}
+                             ;; QFs to include:
+                             :model/QueryField {qf-1 :id}    {:card_id  card-1
+                                                              :field_id field-1}
+                             :model/QueryField {qf-2 :id}    {:card_id  card-2
+                                                              :field_id field-2}
+                             :model/QueryField {qf-3 :id}    {:card_id  card-3
+                                                              :field_id field-3}]
+      (mt/with-premium-features #{:query-field-validation}
+        (mt/call-with-map-params f [card-1 card-2 card-3 card-4 qf-1 qf-2 qf-3])))))
 
 (defmacro ^:private with-test-setup!
   "Creates some non-stale QueryFields and anaphorical provides stale QueryField IDs called `qf-{1-3}` and their

--- a/enterprise/backend/test/metabase_enterprise/query_field_validation/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/query_field_validation/api_test.clj
@@ -3,7 +3,6 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [mb.hawk.assert-exprs.approximately-equal :as hawk.approx]
-   [metabase.query-analysis :as query-analysis]
    [metabase.test :as mt]
    [ring.util.codec :as codec]
    [toucan2.tools.with-temp :as t2.with-temp]))
@@ -41,7 +40,6 @@
                                                             :field_id field-2}
                            :model/QueryField {qf-3 :id}    {:card_id  card-3
                                                             :field_id field-3}]
-    (run! query-analysis/analyze-card! [card-1 card-2 card-3 card-4])
     (mt/with-premium-features #{:query-field-validation}
       (mt/call-with-map-params f [card-1 card-2 card-3 card-4 qf-1 qf-2 qf-3]))))
 

--- a/enterprise/backend/test/metabase_enterprise/query_field_validation/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/query_field_validation/api_test.clj
@@ -3,11 +3,12 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [mb.hawk.assert-exprs.approximately-equal :as hawk.approx]
+   [metabase.query-analysis :as query-analysis]
    [metabase.test :as mt]
    [ring.util.codec :as codec]
    [toucan2.tools.with-temp :as t2.with-temp]))
 
-(defn- do-with-test-setup [f]
+(defn- do-with-test-setup! [f]
   (t2.with-temp/with-temp [:model/Table      {table  :id}  {:name "T"}
                            :model/Collection {coll-1 :id}  {:name "ZZX"}
                            :model/Collection {coll-2 :id}  {:name "ZZY"}
@@ -40,17 +41,18 @@
                                                             :field_id field-2}
                            :model/QueryField {qf-3 :id}    {:card_id  card-3
                                                             :field_id field-3}]
+    (run! query-analysis/analyze-card! [card-1 card-2 card-3 card-4])
     (mt/with-premium-features #{:query-field-validation}
       (mt/call-with-map-params f [card-1 card-2 card-3 card-4 qf-1 qf-2 qf-3]))))
 
-(defmacro ^:private with-test-setup
+(defmacro ^:private with-test-setup!
   "Creates some non-stale QueryFields and anaphorical provides stale QueryField IDs called `qf-{1-3}` and their
   corresponding Card IDs (`card-{1-3}`). The cards are named A, B, and C. The Fields are called FA, FB, FB and they
   all point to a Table called T.
 
   `card-4` is guaranteed not to have problems"
   [& body]
-  `(do-with-test-setup (mt/with-anaphora [qf-1 qf-2 qf-3 card-1 card-2 card-3 card-4]
+  `(do-with-test-setup! (mt/with-anaphora [qf-1 qf-2 qf-3 card-1 card-2 card-3 card-4]
                          ~@body)))
 
 (def ^:private url "ee/query-field-validation/invalid-cards")
@@ -88,7 +90,7 @@
 
 (deftest list-invalid-cards-basic-test
   (testing "Only returns cards with problematic field refs"
-    (with-test-setup
+    (with-test-setup!
       (resp= {:total 3,
               :data
               [{:id     card-1
@@ -113,7 +115,7 @@
 
 (deftest pagination-test
   (testing "Lets you page results"
-    (with-test-setup
+    (with-test-setup!
       (resp= {:total  4
               :limit  2
               :offset 0
@@ -149,7 +151,7 @@
 
 (deftest sorting-test
   (testing "Lets you specify the sort key"
-    (with-test-setup
+    (with-test-setup!
       (resp= {:total 3
               :data
               [{:id card-3}
@@ -169,7 +171,7 @@
                {:id card-1}]}
              (get! {:sort_column "last_edited_at" :sort_direction "desc"}))))
   (testing "Rejects bad keys"
-    (with-test-setup
+    (with-test-setup!
       (is (str/starts-with? (:sort_column
                              (:errors
                               (mt/user-http-request :crowberto :get 400 (str url "?sort_column=favorite_bird"))))

--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -84,9 +84,13 @@
 (defn config-bool "Fetch a configuration key and parse it as a boolean."  ^Boolean [k] (some-> k config-str Boolean/parseBoolean))
 (defn config-kw   "Fetch a configuration key and parse it as a keyword."  ^Keyword [k] (some-> k config-str keyword))
 
-(def ^Boolean is-dev?  "Are we running in `dev` mode (i.e. in a REPL or via `clojure -M:run`)?" (= :dev  (config-kw :mb-run-mode)))
-(def ^Boolean is-prod? "Are we running in `prod` mode (i.e. from a JAR)?"                       (= :prod (config-kw :mb-run-mode)))
-(def ^Boolean is-test? "Are we running in `test` mode (i.e. via `clojure -X:test`)?"            (= :test (config-kw :mb-run-mode)))
+(def run-mode
+  "The mode in which Metabase is being run"
+  (config-kw :mb-run-mode))
+
+(def ^Boolean is-dev?  "Are we running in `dev` mode (i.e. in a REPL or via `clojure -M:run`)?" (= :dev  run-mode))
+(def ^Boolean is-prod? "Are we running in `prod` mode (i.e. from a JAR)?"                       (= :prod run-mode))
+(def ^Boolean is-test? "Are we running in `test` mode (i.e. via `clojure -X:test`)?"            (= :test run-mode))
 
 ;;; Version stuff
 

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -533,7 +533,7 @@
       (log/info "Card references Fields in params:" field-ids)
       (field-values/update-field-values-for-on-demand-dbs! field-ids))
     (parameter-card/upsert-or-delete-from-parameters! "card" (:id card) (:parameters card))
-    (query-analysis/safe-update-query-analysis-for-card! card)))
+    (query-analysis/analyze-async! card)))
 
 (t2/define-before-update :model/Card
   [{:keys [verified-result-metadata?] :as card}]
@@ -561,7 +561,7 @@
   [card]
   (u/prog1 card
     (when (contains? (t2/changes card) :dataset_query)
-      (query-analysis/safe-update-query-analysis-for-card! card))))
+      (query-analysis/analyze-async! card))))
 
 ;; Cards don't normally get deleted (they get archived instead) so this mostly affects tests
 (t2/define-before-delete :model/Card

--- a/src/metabase/query_analysis.clj
+++ b/src/metabase/query_analysis.clj
@@ -31,26 +31,27 @@
   we disable analysis by default."
   ::disabled)
 
-(defmacro with-queued-analysis
-  "Override default execution mode to always use the queue. Does nothing in prod."
-  [& body]
-  `(binding [*analyze-execution-in-dev?*  ::queued
-             *analyze-execution-in-test?* ::queued]
+(defmacro with-execution*
+  "Override the default execution mode, except in prod."
+  [execution & body]
+  `(binding [*analyze-execution-in-dev?* ~execution
+             *analyze-execution-in-test?* ~execution]
      ~@body))
+
+(defmacro with-queued-analysis
+  "Override the default execution mode to always use the queue. Does nothing in prod - only use this in tests."
+  [& body]
+  `(with-execution* ::queued ~@body))
 
 (defmacro with-immediate-analysis
-  "Override default execution mode to always use the current thread. Does nothing in prod."
+  "Override the default execution mode to always use the current thread. Does nothing in prod - only use this in tests."
   [& body]
-  `(binding [*analyze-execution-in-dev?*  ::immediate
-             *analyze-execution-in-test?* ::immediate]
-     ~@body))
+  `(with-execution* ::immediate ~@body))
 
 (defmacro without-analysis
-  "Override default execution mode to always use the current thread. Does nothing in prod."
+  "Override the default execution mode to always use the current thread. Does nothing in prod - only use this in tests."
   [& body]
-  `(binding [*analyze-execution-in-dev?*  ::immediate
-             *analyze-execution-in-test?* ::immediate]
-     ~@body))
+  `(with-execution* ::disabled ~@body))
 
 (defn- execution []
   (case config/run-mode

--- a/src/metabase/query_analysis.clj
+++ b/src/metabase/query_analysis.clj
@@ -45,6 +45,13 @@
              *analyze-execution-in-test?* ::immediate]
      ~@body))
 
+(defmacro without-analysis
+  "Override default execution mode to always use the current thread. Does nothing in prod."
+  [& body]
+  `(binding [*analyze-execution-in-dev?*  ::immediate
+             *analyze-execution-in-test?* ::immediate]
+     ~@body))
+
 (defn- execution []
   (case config/run-mode
     :prod ::queued

--- a/src/metabase/query_analysis.clj
+++ b/src/metabase/query_analysis.clj
@@ -163,8 +163,8 @@
 (defn- queue-or-analyze! [offer-fn! card-or-id]
   (case (execution)
     ::immediate (analyze-card! (u/the-id card-or-id))
-    ::queued   (offer-fn! queue (u/the-id card-or-id))
-    ::disabled           nil))
+    ::queued    (offer-fn! queue (u/the-id card-or-id))
+    ::disabled  nil))
 
 (defn analyze-async!
   "Asynchronously hand-off the given card for analysis, at a high priority."

--- a/src/metabase/query_analysis.clj
+++ b/src/metabase/query_analysis.clj
@@ -32,14 +32,14 @@
   ::disabled)
 
 (defmacro with-queued-analysis
-  "Override default execution mode to always use the queue."
+  "Override default execution mode to always use the queue. Does nothing in prod."
   [& body]
   `(binding [*analyze-execution-in-dev?*  ::queued
              *analyze-execution-in-test?* ::queued]
      ~@body))
 
 (defmacro with-immediate-analysis
-  "Override default execution mode to always use the current thread."
+  "Override default execution mode to always use the current thread. Does nothing in prod."
   [& body]
   `(binding [*analyze-execution-in-dev?*  ::immediate
              *analyze-execution-in-test?* ::immediate]

--- a/src/metabase/query_analysis.clj
+++ b/src/metabase/query_analysis.clj
@@ -148,14 +148,15 @@
   []
   (queue/blocking-take! queue))
 
-(defn analyze-async!
-  "Put the given card at the back of the high priority analysis queue, or drop it if the queue is full."
-  [card-id]
-  (when (enabled?)
-    (queue/maybe-put! queue card-id)))
 
 (defn analyze-sync!
   "Synchronously hand-off the given card for analysis, at a low priority. May block indefinitely, relies on consumer."
-  [card-id]
+  [card-or-id]
   (when (enabled?)
-    (queue/blocking-put! queue card-id)))
+    (queue/maybe-put! queue (u/the-id card-or-id))))
+
+(defn analyze-sync!
+  "Synchronously hand-off the given card for analysis, at a low priority. May block indefinitely, relies on consumer."
+  [card-or-id]
+  (when (enabled?)
+    (queue/blocking-put! queue (u/the-id card-or-id))))

--- a/src/metabase/query_analysis.clj
+++ b/src/metabase/query_analysis.clj
@@ -73,14 +73,6 @@
     (when (some? res)
       (query-field/update-query-fields-for-card! card-id query-field-rows))))
 
-(defn safe-update-query-analysis-for-card!
-  "A version of [[update-query-analysis-for-card!]] that swallows any exceptions."
-  [card]
-  (try
-    (update-query-analysis-for-card! card)
-    (catch Exception e
-      (log/error e "Error updating query fields"))))
-
 (defn- replaced-inner-query-for-native-card
   [query {:keys [fields tables] :as _replacement-ids}]
   (let [keyvals-set         #(set/union (set (keys %))

--- a/src/metabase/task/backfill_query_fields.clj
+++ b/src/metabase/task/backfill_query_fields.clj
@@ -10,13 +10,16 @@
 
 (set! *warn-on-reflection* true)
 
-(defn- backfill-missing-query-fields! []
-  (let [cards (t2/reducible-select [:model/Card :id]
-                                   {:left-join [[:query_field :f] [:= :f.card_id :report_card.id]]
-                                    :where     [:and
-                                                [:not :report_card.archived]
-                                                [:= :f.id nil]]})]
-    (run! query-analysis/analyze-sync! cards)))
+(defn- backfill-missing-query-fields!
+  ([]
+   (backfill-missing-query-fields! query-analysis/analyze-sync!))
+  ([analyze-fn]
+   (let [cards (t2/reducible-select [:model/Card :id]
+                                    {:left-join [[:query_field :f] [:= :f.card_id :report_card.id]]
+                                     :where     [:and
+                                                 [:not :report_card.archived]
+                                                 [:= :f.id nil]]})]
+     (run! analyze-fn cards))))
 
 (jobs/defjob ^{DisallowConcurrentExecution true
                :doc                        "Backfill QueryField for cards created earlier. Runs once per instance."}

--- a/src/metabase/task/backfill_query_fields.clj
+++ b/src/metabase/task/backfill_query_fields.clj
@@ -18,7 +18,7 @@
                                              :where     [:and
                                                          [:not :c.archived]
                                                          [:= :f.id nil]]}])]
-    (run! (comp query-analysis/analyze-async! :id) cards)))
+    (run! query-analysis/analyze-async! cards)))
 
 (jobs/defjob ^{DisallowConcurrentExecution true
                :doc                        "Backfill QueryField for cards created earlier. Runs once per instance."}

--- a/src/metabase/task/backfill_query_fields.clj
+++ b/src/metabase/task/backfill_query_fields.clj
@@ -18,7 +18,7 @@
                                              :where     [:and
                                                          [:not :c.archived]
                                                          [:= :f.id nil]]}])]
-    (run! query-analysis/analyze-async! cards)))
+    (run! query-analysis/analyze-sync! cards)))
 
 (jobs/defjob ^{DisallowConcurrentExecution true
                :doc                        "Backfill QueryField for cards created earlier. Runs once per instance."}

--- a/test/metabase/models/query_field_test.clj
+++ b/test/metabase/models/query_field_test.clj
@@ -18,7 +18,7 @@
                     :card_id card-id))
 
 (defn- do-with-test-setup! [f]
-  (binding [query-analysis/*analyze-queries-in-test?* true]
+  (query-analysis/with-immediate-analysis
     (let [table-id (mt/id :orders)
           tax-id   (mt/id :orders :tax)
           total-id (mt/id :orders :total)]

--- a/test/metabase/models/query_field_test.clj
+++ b/test/metabase/models/query_field_test.clj
@@ -25,8 +25,6 @@
       (t2.with-temp/with-temp [:model/Card {card-id :id}
                                {:dataset_query (mt/native-query {:query "SELECT NOT_TAX, TOTAL FROM orders"})}]
         (try
-          ;; TODO - it would be nice if we could rather just enable the actual analyzer for the duration of this test
-          (query-analysis/analyze-card! card-id)
           (f {:card-id  card-id
               :tax-id   tax-id
               :total-id total-id
@@ -46,8 +44,7 @@
   [card-id query]
   (if (string? query)
     (t2/update! :model/Card card-id {:dataset_query (mt/native-query {:query query})})
-    (t2/update! :model/Card card-id {:dataset_query query}))
-  (query-analysis/analyze-card! card-id))
+    (t2/update! :model/Card card-id {:dataset_query query})))
 
 ;;;;
 ;;;; Actual tests

--- a/test/metabase/task/analyze_queries_test.clj
+++ b/test/metabase/task/analyze_queries_test.clj
@@ -46,7 +46,7 @@
             (is (every? zero? (map get-count card-ids))))
 
           ;; queue the cards
-          (binding [query-analysis/*analyze-queries-in-test?* true]
+          (query-analysis/with-queued-analysis
             (run! query-analysis/analyze-async! card-ids))
 
           ;; run the analysis for 1s

--- a/test/metabase/task/backfill_query_fields_test.clj
+++ b/test/metabase/task/backfill_query_fields_test.clj
@@ -48,9 +48,8 @@
             expected-ids (into #{} (map :id) [c1 c2 c3 c4])]
 
         ;; Run the backfill with a mocked out publisher
-        (query-analysis/with-queued-analysis
-          (#'backfill/backfill-missing-query-fields!
-           #(swap! queued-ids conj (:id %))))
+        (#'backfill/backfill-missing-query-fields!
+         #(swap! queued-ids conj (:id %)))
 
         (testing "The expected cards were all sent to the analyzer"
           (is (= expected-ids (set/intersection expected-ids @queued-ids))))

--- a/test/metabase/task/backfill_query_fields_test.clj
+++ b/test/metabase/task/backfill_query_fields_test.clj
@@ -11,14 +11,22 @@
    [metabase.test :as mt]
    [metabase.util :as u]
    [metabase.util.queue :as queue]
-   [toucan2.core :as t2]))
+   [toucan2.core :as t2])
+  (:import
+   [java.util.concurrent TimeoutException]))
+
 
 (deftest backfill-query-field-test
+  ;; Clean up any cruft from the REPL, or other failed tests.
+  (queue/clear! @#'query-analysis/queue)
+
   (let [metadata-provider (lib.metadata.jvm/application-database-metadata-provider (mt/id))
         venues            (lib.metadata/table metadata-provider (mt/id :venues))
         venues-name       (lib.metadata/field metadata-provider (mt/id :venues :name))
         mlv2-query        (-> (lib/query metadata-provider venues)
-                              (lib/aggregate (lib/distinct venues-name)))]
+                              (lib/aggregate (lib/distinct venues-name)))
+        some-card-id      (t2/select-one-pk :model/Card :archived false)]
+
     (mt/with-temp [Card c1   {:query_type    "native"
                               :dataset_query (mt/native-query {:query "SELECT id FROM venues"})}
                    Card c2   {:query_type    "native"
@@ -35,16 +43,41 @@
                               :query_type    "native"
                               :dataset_query (mt/native-query {:query "SELECT id FROM venues"})}]
 
+      ;; Make sure there is no existing analysis for the relevant cards
       (t2/delete! :model/QueryField :card_id [:in (map :id [c1 c2 c3 c4 arch])])
-      (queue/clear! @#'query-analysis/queue)
 
-      (#'backfill/backfill-query-fields!)
+      ;; Make sure some other card has analysis
+      (testing "There is at least one card with existing analysis"
+        (query-analysis/analyze-card! some-card-id)
+        (is (pos? (count (t2/select :model/QueryField :card_id some-card-id)))))
 
       (let [queued-ids   (atom #{})
-            relevant-ids (into #{} (map :id) [c1 c2 c3 c4 arch])
-            expected-ids (into #{} (map :id [c1 c2 c3 c4]))]
-        (try
-          (u/with-timeout 10
-            (while true (swap! queued-ids conj (query-analysis/next-card-id!))))
-          (catch Exception _))
-        (is (= expected-ids (set/intersection @queued-ids relevant-ids)))))))
+            expected-ids (into #{} (map :id) [c1 c2 c3 c4])
+            analyzer     (future
+                           (try
+                             (while true
+                               (u/with-timeout 500
+                                 (swap! queued-ids conj (query-analysis/next-card-id!))))
+                             (catch TimeoutException _)))]
+
+        ;; Run the backfill - note that it is blocking.
+        (query-analysis/with-queued-analysis
+          (#'backfill/backfill-missing-query-fields!))
+
+        ;; make sure the analyzer thread has died
+        (u/with-timeout 1000
+          @analyzer)
+
+        (testing "The expected cards were all sent to the analyzer"
+          (is (= expected-ids (set/intersection expected-ids @queued-ids))))
+
+        (testing "The card with existing analysis was not sent to the analyzer again"
+          (is (not (@queued-ids some-card-id))))))))
+
+
+(comment
+  (set! *warn-on-reflection* true)
+  (queue/clear! @#'query-analysis/queue)
+  (.-queued-set @#'query-analysis/queue)
+  (.peek (.-async-queue @#'query-analysis/queue))
+  (.peek (.-sync-queue @#'query-analysis/queue)))

--- a/test/metabase/util/queue_test.clj
+++ b/test/metabase/util/queue_test.clj
@@ -66,7 +66,8 @@
                            :realtime-events realtime-events)]
 
       (testing "We processed all the events that were enqueued"
-        (is (= (count processed) (+ (count backfill-events) sent))))
+        (is (= (+ (count backfill-events) sent)
+               (count processed))))
 
       (if dedupe?
         (testing "Some items are deduplicated"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/45463

### Description

I cut this PR early to smoke out test failures in CI.

The approach here is going to be reworked - rather than triggering analysis manually, the idea is to use fixtures to run  background analyzer for given namespaces.