### PR TITLE
Skip fetching collection permissions graph on update

### DIFF
--- a/e2e/test/scenarios/native/snippets.cy.spec.js
+++ b/e2e/test/scenarios/native/snippets.cy.spec.js
@@ -368,7 +368,14 @@ describeEE("scenarios > question > snippets (EE)", () => {
     });
 
     it("shouldn't update root permissions when changing permissions on a created folder (metabase#17268)", () => {
-      cy.intercept("PUT", "/api/collection/graph").as("updatePermissions");
+      cy.intercept("PUT", "/api/collection/graph", req => {
+        // make sure that we get the response graph back to make sure the edit persisted as expected
+        // in the api response check at the end of this test
+        if (req.body && typeof req.body === "object") {
+          req.body.skip_graph = false;
+        }
+        req.continue();
+      }).as("updatePermissions");
 
       openNativeEditor();
       cy.icon("snippet").click();

--- a/e2e/test/scenarios/native/snippets.cy.spec.js
+++ b/e2e/test/scenarios/native/snippets.cy.spec.js
@@ -368,14 +368,7 @@ describeEE("scenarios > question > snippets (EE)", () => {
     });
 
     it("shouldn't update root permissions when changing permissions on a created folder (metabase#17268)", () => {
-      cy.intercept("PUT", "/api/collection/graph", req => {
-        // make sure that we get the response graph back to make sure the edit persisted as expected
-        // in the api response check at the end of this test
-        if (req.body && typeof req.body === "object") {
-          req.body.skip_graph = false;
-        }
-        req.continue();
-      }).as("updatePermissions");
+      cy.intercept("PUT", "/api/collection/graph").as("updatePermissions");
 
       openNativeEditor();
       cy.icon("snippet").click();
@@ -415,12 +408,12 @@ describeEE("scenarios > question > snippets (EE)", () => {
       });
 
       // API check
-      cy.get("@updatePermissions").then(intercept => {
-        const { groups } = intercept.response.body;
-        const allUsers = groups[ALL_USERS_GROUP];
-
-        expect(allUsers.root).to.equal("write");
-      });
+      cy.request("GET", "/api/collection/graph?namespace=snippets").then(
+        ({ body }) => {
+          const allUsers = body.groups[ALL_USERS_GROUP];
+          expect(allUsers.root).to.equal("write");
+        },
+      );
     });
   });
 });

--- a/frontend/src/metabase-types/api/permissions.ts
+++ b/frontend/src/metabase-types/api/permissions.ts
@@ -102,7 +102,7 @@ export type CollectionPermissionsGraph = {
 };
 
 export type CollectionPermissions = {
-  [key: GroupId]: Partial<Record<CollectionId, CollectionPermission>>;
+  [key: GroupId | string]: Partial<Record<CollectionId, CollectionPermission>>;
 };
 
 export type CollectionPermission = "write" | "read" | "none";

--- a/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/common.unit.spec.tsx
@@ -99,12 +99,12 @@ describe("Admin > CollectionPermissionsPage", () => {
       expect(lastRequest).toEqual({
         ...defaultPermissionsGraph,
         groups: {
-          ...defaultPermissionsGraph.groups,
           3: {
             ...defaultPermissionsGraph.groups[3],
             3: "read",
           },
         },
+        skip_graph: true,
       });
     });
 
@@ -155,13 +155,13 @@ describe("Admin > CollectionPermissionsPage", () => {
       expect(lastRequest).toEqual({
         ...defaultPermissionsGraph,
         groups: {
-          ...defaultPermissionsGraph.groups,
           3: {
             ...defaultPermissionsGraph.groups[3],
             1: "write",
             3: "write",
           },
         },
+        skip_graph: true,
       });
     });
 

--- a/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/enterprise.unit.spec.tsx
@@ -110,12 +110,12 @@ describe("Admin > CollectionPermissionsPage (enterprise)", () => {
       expect(lastRequest).toEqual({
         ...iaPermissionsGraph,
         groups: {
-          ...iaPermissionsGraph.groups,
           1: {
             ...iaPermissionsGraph.groups[1],
             13371337: "none",
           },
         },
+        skip_graph: true,
       });
     });
   });

--- a/frontend/src/metabase/admin/permissions/permissions.js
+++ b/frontend/src/metabase/admin/permissions/permissions.js
@@ -33,6 +33,7 @@ import { DataPermissionType, DataPermission } from "./types";
 import { isDatabaseEntityId } from "./utils/data-entity-id";
 import {
   getModifiedGroupsPermissionsGraphParts,
+  getModifiedCollectionPermissionsGraphParts,
   mergeGroupsPermissionsUpdates,
 } from "./utils/graph/partial-updates";
 
@@ -239,14 +240,29 @@ export const saveCollectionPermissions = createThunkAction(
   SAVE_COLLECTION_PERMISSIONS,
   namespace => async (_dispatch, getState) => {
     MetabaseAnalytics.trackStructEvent("Permissions", "save");
-    const { collectionPermissions, collectionPermissionsRevision } =
-      getState().admin.permissions;
+
+    const {
+      originalCollectionPermissions,
+      collectionPermissions,
+      collectionPermissionsRevision,
+    } = getState().admin.permissions;
+
+    const modifiedPermissions = getModifiedCollectionPermissionsGraphParts(
+      originalCollectionPermissions,
+      collectionPermissions,
+    );
+
     const result = await CollectionsApi.updateGraph({
       namespace,
       revision: collectionPermissionsRevision,
-      groups: collectionPermissions,
+      groups: modifiedPermissions,
+      skip_graph: true,
     });
-    return result;
+
+    return {
+      ...result,
+      groups: collectionPermissions,
+    };
   },
 );
 

--- a/frontend/src/metabase/admin/permissions/utils/graph/partial-updates.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/partial-updates.ts
@@ -1,6 +1,9 @@
 import _ from "underscore";
 
-import type { GroupsPermissions } from "metabase-types/api";
+import type {
+  CollectionPermissions,
+  GroupsPermissions,
+} from "metabase-types/api";
 
 // utils for dealing with partial graph updates
 
@@ -48,4 +51,17 @@ export function mergeGroupsPermissionsUpdates(
   });
 
   return Object.fromEntries(latestPermissionsEntries);
+}
+
+export function getModifiedCollectionPermissionsGraphParts(
+  originalCollectionPermissions: CollectionPermissions,
+  collectionPermissions: CollectionPermissions,
+) {
+  const groupIds = Object.keys(collectionPermissions);
+  const modifiedGroupIds = groupIds.filter(groupId => {
+    const originalPerms = originalCollectionPermissions[groupId];
+    const currPerms = collectionPermissions[groupId];
+    return !_.isEqual(currPerms, originalPerms);
+  });
+  return _.pick(collectionPermissions, modifiedGroupIds);
 }

--- a/frontend/src/metabase/admin/permissions/utils/graph/partial-updates.unit.spec.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/partial-updates.unit.spec.ts
@@ -6,6 +6,7 @@ import { DataPermission, DataPermissionValue } from "../../types";
 
 import {
   getModifiedGroupsPermissionsGraphParts,
+  getModifiedCollectionPermissionsGraphParts,
   mergeGroupsPermissionsUpdates,
 } from "./partial-updates";
 
@@ -104,5 +105,27 @@ describe("mergeGroupsPermissionsUpdates", () => {
     expect(mergeGroupsPermissionsUpdates(permissions, update)).toEqual(
       expectedResult,
     );
+  });
+});
+
+describe("getModifiedCollectionPermissionsGraphParts", () => {
+  it("should only include groups that have had data permission updated", async () => {
+    const simpleUpdate = getModifiedCollectionPermissionsGraphParts(
+      {
+        "1": { "1": "write", "2": "write" },
+        "2": { "1": "write", "2": "write" },
+        "3": { "1": "write", "2": "write" },
+      },
+      {
+        "1": { "1": "write", "2": "write" },
+        "2": { "1": "read", "2": "read" },
+        "3": { "1": "write", "2": "write" },
+      },
+    );
+
+    // should not contain groups that have not been modified
+    expect(simpleUpdate).not.toHaveProperty("1");
+    expect(simpleUpdate).not.toHaveProperty("3");
+    expect(simpleUpdate).toEqual({ "2": { "1": "read", "2": "read" } });
   });
 });

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -1260,8 +1260,7 @@
   Will overwrite parts of the graph that are present in the request, and leave the rest unchanged.
 
   If the `skip_graph` query parameter is true, it will only return the current revision"
-  [:as {{:keys [namespace revision groups]} :body
-        {:strs [skip_graph]} :query-params}]
+  [:as {{:keys [namespace revision groups skip_graph]} :body}]
   {namespace [:maybe ms/NonBlankString]
    revision  ms/Int
    groups :map

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -2273,6 +2273,8 @@
   (is (malli= [:map {:closed true} [:revision :int]]
               (mt/user-http-request :crowberto
                                     :put 200
-                                    "collection/graph?skip_graph=true"
-                                    {:revision (c-perm-revision/latest-id) :groups {}}))
+                                    "collection/graph"
+                                    {:revision (c-perm-revision/latest-id)
+                                     :groups {}
+                                     :skip_graph true}))
       "PUTs with skip_graph should not return the coll permission graph."))


### PR DESCRIPTION
Closes #39997
Closes #25993

### Description

Updates the UI to integrate with the new `skip_graph` flag added to `PUT /api/collection/graph` in #45438, which skips sending the updated permissions graph in the response body.

### How to verify

There should be no functional change to the user, so please verify that the collection permissions pages continue to act as you would expect.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
