### PR TITLE
Fix deserialization of mongo native query string

### DIFF
--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -1391,15 +1391,10 @@
   "Parse a serialized native query. Like a normal JSON parse, but handles BSON/MongoDB extended JSON forms."
   [^String s]
   (try
-    ;; TODO: Fixme! In following expression we were previously creating BasicDBObject's. As part of Monger removal
-    ;;       in favor of plain mongo-java-driver we now create Documents. I believe following conversion was and is
-    ;;       responsible for https://github.com/metabase/metabase/issues/38181. When pipeline is deserialized,
-    ;;       we end up with vector of `Document`s into which are appended new query stages, which are clojure
-    ;;       structures. When we render the query in "view native query" in query builder, clojure structures
-    ;;       are transformed to json correctly. But documents are rendered to their string representation (screenshot
-    ;;       in the issue). Possible fix could be to represent native queries in ejson v2, which conforms to json rfc,
-    ;;       hence there would be no need for special bson values handling. That is to be further investigated.
-    (mapv (fn [^org.bson.BsonValue v] (-> v .asDocument org.bson.Document.))
+    ;; Only way to parse _ejson array_ using bson library is through `BsonArray/parse`. That results in sequence
+    ;; of `org.bson.BsonDocument`s. Currently `org.bson.Document` fits our needs better as it (1) implements `Map`
+    ;; and (2) converts `BsonValue`s to java types.
+    (mapv (fn [^org.bson.BsonValue v] (-> v .asDocument .toJson org.bson.Document/parse))
           (org.bson.BsonArray/parse s))
     (catch Throwable e
       (throw (ex-info (tru "Unable to parse query: {0}" (.getMessage e))

--- a/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
@@ -602,3 +602,9 @@
                            #{}
                            (filter #(contains? % "$lookup") (:query compiled)))]
        (is (= #{1 2 3 4} indices))))))
+
+(deftest ^:parallel parse-query-string-test
+  (testing "`parse-query-string` returns no `Bson...` typed values  (#38181)"
+    ;; ie. parse result does not look as follows: `#object[org.bson.BsonString 0x5f26b3a1 "BsonString{value='1000'}"]`
+    (let [parsed (mongo.qp/parse-query-string "[{\"limit\": \"1000\"}]")]
+      (is (not (instance? org.bson.BsonValue (get-in parsed [0 "limit"])))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/43901
Closes https://github.com/metabase/metabase/issues/38181

### Description

This PR ensures that `Document`s generated during deserialization of Mongo query string contain serializable types, ie. not `Bson...` types as eg. `BsonInt32`.

### How to verify

Run modified tests.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
