### PR TITLE
fix(sdk): sync fetch request token function with store

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/README.md
+++ b/enterprise/frontend/src/embedding-sdk/README.md
@@ -900,6 +900,7 @@ async function fetchRefreshToken(url) {
 }
 
 // Pass this configuration to MetabaseProvider.
+// Wrap the fetchRequestToken function in useCallback if it has dependencies to prevent re-renders.
 const config = { fetchRefreshToken };
 ```
 

--- a/enterprise/frontend/src/embedding-sdk/hooks/private/use-init-data.ts
+++ b/enterprise/frontend/src/embedding-sdk/hooks/private/use-init-data.ts
@@ -45,10 +45,12 @@ export const useInitData = ({ config }: InitDataLoaderParameters) => {
   }, [dispatch]);
 
   useEffect(() => {
+    dispatch(setFetchRefreshTokenFn(config.fetchRequestToken ?? null));
+  }, [dispatch, config.fetchRequestToken]);
+
+  useEffect(() => {
     if (loginStatus.status === "uninitialized") {
       api.basename = config.metabaseInstanceUrl;
-
-      dispatch(setFetchRefreshTokenFn(config.fetchRequestToken ?? null));
 
       if (isValidJwtAuth(config)) {
         setupJwtAuth(config, dispatch);


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/45583

### Description

The `config.fetchRequestToken` function in the embedding sdk did not synchronize to the Redux context, therefore it always used the function captured from the first render. This PR ensures that the function gets updated.

### How to verify

- Check out the `test-sync-fetch-refresh-token` branch in Shoppy
- Click on the red button a couple of times to increment the counter
- Change the site via the site switcher
- The network request should include a "X-Integer" header with the latest count.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
