### PR TITLE
Fix string filters with multiple values in dashboards

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-text-category.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-text-category.cy.spec.js
@@ -47,7 +47,7 @@ describe("scenarios > dashboard > filters > text/category", () => {
     });
   });
 
-  it.skip("should drill to a question with multi-value 'contains' filter applied (metabase#42999)", () => {
+  it("should drill to a question with multi-value 'contains' filter applied (metabase#42999)", () => {
     setFilter("Text or Category", "Contains");
     cy.findAllByRole("radio", { name: "Multiple values" }).should("be.checked");
     cy.findByTestId("visualization-root").findByText("Select…").click();

--- a/frontend/src/metabase-lib/v1/parameters/utils/mbql.js
+++ b/frontend/src/metabase-lib/v1/parameters/utils/mbql.js
@@ -147,14 +147,20 @@ export function dateParameterValueToMBQL(parameterValue, fieldRef) {
 }
 
 export function stringParameterValueToMBQL(parameter, fieldRef) {
-  const parameterValue = parameter.value;
+  const parameterValue = Array.isArray(parameter.value)
+    ? parameter.value
+    : [parameter.value];
   const operator = deriveFieldOperatorFromParameter(parameter);
   const subtype = getParameterSubType(parameter);
   const operatorName = getParameterOperatorName(subtype);
+  const operatorOptions = operator?.optionsDefaults;
+  const hasMultipleValues = parameterValue.length > 1;
 
-  return [operatorName, fieldRef]
+  return [operatorName]
+    .concat(hasMultipleValues && operatorOptions ? operatorOptions : [])
+    .concat([fieldRef])
     .concat(parameterValue)
-    .concat(operator?.optionsDefaults ?? []);
+    .concat(!hasMultipleValues && operatorOptions ? operatorOptions : []);
 }
 
 export function numberParameterValueToMBQL(parameter, fieldRef) {

--- a/frontend/src/metabase-lib/v1/parameters/utils/mbql.unit.spec.js
+++ b/frontend/src/metabase-lib/v1/parameters/utils/mbql.unit.spec.js
@@ -289,27 +289,41 @@ describe("parameters/utils/mbql", () => {
       });
     });
 
-    it("should add a filter for a string parameter", () => {
-      const containsFilterQuery = applyFilterParameter(query, stageIndex, {
-        target: ["dimension", ["field", PRODUCTS.CATEGORY, null]],
-        type: "string/contains",
-        value: "foo",
-      });
-      const [containsFilter] = Lib.filters(containsFilterQuery, -1);
-      expect(Lib.displayInfo(query, stageIndex, containsFilter)).toMatchObject({
-        displayName: "Category contains foo",
-      });
-
-      const startsFilterQuery = applyFilterParameter(query, stageIndex, {
-        target: ["dimension", ["field", PRODUCTS.CATEGORY, null]],
-        type: "string/starts-with",
-        value: ["foo"],
-      });
-      const [startsFilter] = Lib.filters(startsFilterQuery, -1);
-      expect(Lib.displayInfo(query, stageIndex, startsFilter)).toMatchObject({
-        displayName: "Category starts with foo",
-      });
-    });
+    it.each([
+      {
+        parameter: {
+          target: ["dimension", ["field", PRODUCTS.CATEGORY, null]],
+          type: "string/contains",
+          value: "foo",
+        },
+        expectedDisplayName: "Category contains foo",
+      },
+      {
+        parameter: {
+          target: ["dimension", ["field", PRODUCTS.CATEGORY, null]],
+          type: "string/contains",
+          value: ["a", "b"],
+        },
+        expectedDisplayName: "Category contains 2 selections",
+      },
+      {
+        parameter: {
+          target: ["dimension", ["field", PRODUCTS.CATEGORY, null]],
+          type: "string/starts-with",
+          value: ["foo"],
+        },
+        expectedDisplayName: "Category starts with foo",
+      },
+    ])(
+      "should add a filter for a string parameter",
+      ({ parameter, expectedDisplayName }) => {
+        const newQuery = applyFilterParameter(query, stageIndex, parameter);
+        const [filter] = Lib.filters(newQuery, -1);
+        expect(Lib.displayInfo(query, stageIndex, filter)).toMatchObject({
+          displayName: expectedDisplayName,
+        });
+      },
+    );
 
     it("should adda filter for a category parameter", () => {
       const newQuery = applyFilterParameter(query, stageIndex, {


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/43990

As mentioned in the issue, in legacy MBQL there is a different syntax when there are multiple values AND operator options. That's why the issue exists only with `contains`, `does-not-contain`, `starts-with`, `ends-with` operators and multiple values.

How to verify:
- New -> Question -> Products
- Add this question to a dashboard
- Add a filter Text -> **Contains**
- Connect this filter to Vendor
- Add a filter with multiple values
- Make sure that title drill (i.e. click on the card title) works

Before:
<img width="1401" alt="Screenshot 2024-07-15 at 15 24 34" src="https://github.com/user-attachments/assets/9c1161bf-151f-4b85-87d8-e8e49f07e8a5">

Now:
- CI is green