### PR TITLE
Fix translation imports

### DIFF
--- a/release/src/auto-translate.ts
+++ b/release/src/auto-translate.ts
@@ -1,4 +1,7 @@
 import 'dotenv/config';
+import fs from 'fs';
+
+import chalk from 'chalk';
 import fetch from 'node-fetch';
 
 const baseUrl = 'https://api.poeditor.com/v2'


### PR DESCRIPTION
I removed the "zx/globals" imports to fix CI errors, but failed to put in some of the explicit imports, which caused [this error](https://github.com/metabase/metabase/actions/runs/9946049660/job/27475688934#step:5:20) in the auto-translate script