### PR TITLE
E2E repro for "Selecting Exclude Hours of the day from Date Filter"

### DIFF
--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -2845,6 +2845,30 @@ describe("issue 44288", () => {
   });
 });
 
+describe("issue 27579", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("should be able to remove the last exclude hour option (metabase#27579)", () => {
+    visitDashboard(ORDERS_DASHBOARD_ID);
+    editDashboard();
+    setFilter("Time", "All Options");
+    selectDashboardFilter(getDashboardCard(), "Created At");
+    saveDashboard();
+    filterWidget().click();
+    popover().within(() => {
+      cy.findByText("Exclude...").click();
+      cy.findByText("Hours of the day...").click();
+      cy.findByLabelText("12 AM").should("be.checked");
+
+      cy.findByText("Select none...").click();
+      cy.findByLabelText("12 AM").should("not.be.checked");
+    });
+  });
+});
+
 describe("issue 32804", () => {
   const question1Details = {
     name: "Q1",


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/27579

How to verify:
- New -> Question -> Orders -> Save
- New -> Dashboard
- Add the Orders question
- Filter -> Time -> All Options
- Connect to Created At
- Save dashboard
- Click on the filter widget -> Exclude -> Hour of the day -> Click select all/none
- All options should be unselected

Before
https://www.loom.com/share/c12d33f389174aa2b02e7392daac65f8

Now
<img width="677" alt="Screenshot 2024-07-15 at 16 46 30" src="https://github.com/user-attachments/assets/e54f2f1b-f8a9-4408-bbb6-34d5fe7cc75b">
