### PR TITLE
Fix #45594: Segment name is missing from the segment revision history title

### DIFF
--- a/frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx
@@ -15,7 +15,6 @@ export default class Revision extends Component {
     objectName: PropTypes.string.isRequired,
     revision: PropTypes.object.isRequired,
     currentUser: PropTypes.object.isRequired,
-    tableMetadata: PropTypes.object.isRequired,
   };
 
   getAction() {
@@ -53,7 +52,7 @@ export default class Revision extends Component {
   }
 
   render() {
-    const { revision, tableMetadata, userColor } = this.props;
+    const { revision, userColor } = this.props;
 
     let message = revision.message;
     let diffKeys = Object.keys(revision.diff || {});
@@ -86,12 +85,7 @@ export default class Revision extends Component {
           </div>
           {message && <p>&quot;{message}&quot;</p>}
           {diffKeys.map(key => (
-            <RevisionDiff
-              key={key}
-              property={key}
-              diff={revision.diff[key]}
-              tableMetadata={tableMetadata}
-            />
+            <RevisionDiff key={key} property={key} diff={revision.diff[key]} />
           ))}
         </div>
       </li>

--- a/frontend/src/metabase/admin/datamodel/components/revisions/RevisionDiff.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/revisions/RevisionDiff.jsx
@@ -12,13 +12,11 @@ export default class RevisionDiff extends Component {
   static propTypes = {
     property: PropTypes.string.isRequired,
     diff: PropTypes.object.isRequired,
-    tableMetadata: PropTypes.object.isRequired,
   };
 
   render() {
     const {
       diff: { before, after },
-      tableMetadata,
     } = this.props;
 
     let icon;
@@ -42,7 +40,7 @@ export default class RevisionDiff extends Component {
           </div>
           <div>
             {this.props.property === "definition" ? (
-              <QueryDiff diff={this.props.diff} tableMetadata={tableMetadata} />
+              <QueryDiff diff={this.props.diff} />
             ) : (
               <TextDiff diff={this.props.diff} />
             )}

--- a/frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx
@@ -14,13 +14,13 @@ import Revision from "./Revision";
 
 class RevisionHistory extends Component {
   static propTypes = {
-    object: PropTypes.object,
+    segment: PropTypes.object,
     revisions: PropTypes.array,
     table: PropTypes.object,
   };
 
   render() {
-    const { object, revisions, table, user } = this.props;
+    const { segment, revisions, table, user } = this.props;
 
     let userColorAssignments = {};
     if (revisions) {
@@ -31,13 +31,16 @@ class RevisionHistory extends Component {
     }
 
     return (
-      <LoadingAndErrorWrapper loading={!object || !revisions}>
+      <LoadingAndErrorWrapper loading={!segment || !revisions}>
         {() => (
           <div className={CS.wrapper}>
             <Breadcrumbs
               className={CS.py4}
               crumbs={[
-                [t`Segments`, `/admin/datamodel/segments?table=${table.id}`],
+                [
+                  t`Segments`,
+                  `/admin/datamodel/segments?table=${segment.table_id}`,
+                ],
                 [t`Segment` + t` History`],
               ]}
             />
@@ -47,14 +50,14 @@ class RevisionHistory extends Component {
               data-testid="segment-revisions"
             >
               <h2 className={CS.mb4}>
-                {t`Revision History for`} &quot;{object.name}&quot;
+                {t`Revision History for`} &quot;{segment.name}&quot;
               </h2>
               <ol>
                 {revisions.map(revision => (
                   <Revision
                     key={revision.id}
                     revision={revision}
-                    objectName={object.name}
+                    objectName={segment.name}
                     currentUser={user}
                     tableMetadata={table}
                     userColor={userColorAssignments[revision.user.id]}

--- a/frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx
@@ -7,20 +7,18 @@ import { t } from "ttag";
 import Breadcrumbs from "metabase/components/Breadcrumbs";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import CS from "metabase/css/core/index.css";
-import Tables from "metabase/entities/tables";
 import { assignUserColors } from "metabase/lib/formatting";
 
 import Revision from "./Revision";
 
-class RevisionHistory extends Component {
+export default class RevisionHistory extends Component {
   static propTypes = {
     segment: PropTypes.object,
     revisions: PropTypes.array,
-    table: PropTypes.object,
   };
 
   render() {
-    const { segment, revisions, table, user } = this.props;
+    const { segment, revisions, user } = this.props;
 
     let userColorAssignments = {};
     if (revisions) {
@@ -59,7 +57,6 @@ class RevisionHistory extends Component {
                     revision={revision}
                     objectName={segment.name}
                     currentUser={user}
-                    tableMetadata={table}
                     userColor={userColorAssignments[revision.user.id]}
                   />
                 ))}
@@ -71,7 +68,3 @@ class RevisionHistory extends Component {
     );
   }
 }
-
-export default Tables.load({
-  id: (state, { object: { table_id } }) => table_id,
-})(RevisionHistory);

--- a/frontend/src/metabase/admin/datamodel/containers/RevisionHistoryApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/RevisionHistoryApp.jsx
@@ -32,7 +32,7 @@ export default connect(mapStateToProps, mapDispatchToProps)(RevisionHistoryApp);
 class SegmentRevisionHistoryInner extends Component {
   render() {
     const { segment, ...props } = this.props;
-    return <RevisionHistory object={segment} {...props} />;
+    return <RevisionHistory segment={segment} {...props} />;
   }
 }
 


### PR DESCRIPTION
### What does this PR accomplish?
- Fixes #45594 
- Reproduces that issue to prevent future regressions
- Removes redundant `table` prop

### Stress-test
50x https://github.com/metabase/metabase/actions/runs/9948179365