### PR TITLE
feat(sdk): add useMetabaseAuthStatus hook to get current authentication status

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/README.md
+++ b/enterprise/frontend/src/embedding-sdk/README.md
@@ -843,6 +843,23 @@ return (
 );
 ```
 
+### Getting Metabase authentication status
+
+You can query the Metabase authentication status using the `useMetabaseAuthStatus` hook.
+This is useful if you want to completely hide Metabase components when the user is not authenticated.
+
+```jsx
+const auth = useMetabaseAuthStatus()
+
+if (auth.status === "error") {
+  return <div>Failed to authenticate: {auth.error.message}</div>
+}
+
+if (auth.status === "success") {
+  return <InteractiveQuestion questionId={110} />;
+}
+```
+
 ### Reloading Metabase components
 
 In case you need to reload a Metabase component, for example, your users modify your application data and that data is used to render a question in Metabase. If you embed this question and want to force Metabase to reload the question to show the latest data, you can do so by using the `key` prop to force a component to reload.

--- a/enterprise/frontend/src/embedding-sdk/README.md
+++ b/enterprise/frontend/src/embedding-sdk/README.md
@@ -848,6 +848,8 @@ return (
 You can query the Metabase authentication status using the `useMetabaseAuthStatus` hook.
 This is useful if you want to completely hide Metabase components when the user is not authenticated.
 
+This hook can only be used within components wrapped by `MetabaseProvider`.
+
 ```jsx
 const auth = useMetabaseAuthStatus()
 

--- a/enterprise/frontend/src/embedding-sdk/hooks/public/index.ts
+++ b/enterprise/frontend/src/embedding-sdk/hooks/public/index.ts
@@ -2,3 +2,4 @@ export * from "./use-current-user";
 export * from "./use-application-name";
 export * from "./use-question-search";
 export * from "./use-available-fonts";
+export * from "./use-metabase-auth-status";

--- a/enterprise/frontend/src/embedding-sdk/hooks/public/use-metabase-auth-status.ts
+++ b/enterprise/frontend/src/embedding-sdk/hooks/public/use-metabase-auth-status.ts
@@ -1,0 +1,4 @@
+import { useSdkSelector } from "embedding-sdk/store";
+import { getLoginStatus } from "embedding-sdk/store/selectors";
+
+export const useMetabaseAuthStatus = () => useSdkSelector(getLoginStatus);


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/45585

### Description

Exposes a React hook to check if we've successfully authenticated via the MetabaseProvider, so we can support rendering the component conditionally. When the user is not logged in, we see the default error messages added with withPublicComponentWrapper. We want to provide the ability to skip rendering the component when the `MetabaseProvider` authentication fails for any reason.

### How to verify

- Go to the demo app
- Calls the `useMetabaseAuthStatus` hook
- The authentication status (`auth.status`) should change accordingly.