### PR TITLE
Fix #37893: Do not offer alerts for models

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
@@ -36,7 +36,7 @@ describe("scenarios > embedding > smoke tests", { tags: "@OSS" }, () => {
 
     cy.findByTestId("view-footer").within(() => {
       cy.icon("download").should("exist");
-      cy.icon("bell").should("exist");
+      cy.icon("bell").should("not.exist");
       cy.icon("share").should("not.exist");
     });
   });

--- a/e2e/test/scenarios/sharing/alert/alert.cy.spec.js
+++ b/e2e/test/scenarios/sharing/alert/alert.cy.spec.js
@@ -1,12 +1,14 @@
 import {
   ORDERS_QUESTION_ID,
   ORDERS_COUNT_QUESTION_ID,
+  ORDERS_MODEL_ID,
 } from "e2e/support/cypress_sample_instance_data";
 import {
   restore,
   setupSMTP,
   mockSlackConfigured,
   visitQuestion,
+  visitModel,
 } from "e2e/support/helpers";
 
 const channels = { slack: mockSlackConfigured, email: setupSMTP };
@@ -85,6 +87,17 @@ describe("scenarios > alert", () => {
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("The wide world of alerts").should("not.exist");
       });
+    });
+  });
+
+  it("should not be offered for models (metabase#37893)", () => {
+    visitModel(ORDERS_MODEL_ID);
+    cy.findByTestId("view-footer").within(() => {
+      cy.findByTestId("question-row-count")
+        .should("have.text", "Showing first 2,000 rows")
+        .and("be.visible");
+      cy.icon("download").should("exist");
+      cy.icon("bell").should("not.exist");
     });
   });
 });

--- a/frontend/src/metabase/query_builder/components/view/QuestionAlertWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionAlertWidget.jsx
@@ -82,4 +82,6 @@ export default class QuestionAlertWidget extends Component {
 }
 
 QuestionAlertWidget.shouldRender = ({ question, visualizationSettings }) =>
-  question.alertType(visualizationSettings) !== null && !question.isArchived();
+  question.alertType(visualizationSettings) !== null &&
+  !question.isArchived() &&
+  question.type() !== "model";

--- a/frontend/src/metabase/query_builder/components/view/QuestionAlertWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionAlertWidget.jsx
@@ -82,6 +82,4 @@ export default class QuestionAlertWidget extends Component {
 }
 
 QuestionAlertWidget.shouldRender = ({ question, visualizationSettings }) =>
-  question.alertType(visualizationSettings) !== null &&
-  !question.isArchived() &&
-  question.type() !== "model";
+  question.alertType(visualizationSettings) !== null && !question.isArchived();

--- a/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
@@ -128,23 +128,24 @@ const ViewFooter = ({
               dashboardId={question.card().dashboardId}
             />
           ),
-          QuestionAlertWidget.shouldRender({
-            question,
-            visualizationSettings,
-          }) && (
-            <QuestionAlertWidget
-              key="alerts"
-              className={cx(CS.hide, CS.smShow)}
-              canManageSubscriptions={canManageSubscriptions}
-              question={question}
-              questionAlerts={questionAlerts}
-              onCreateAlert={() =>
-                question.isSaved()
-                  ? onOpenModal("create-alert")
-                  : onOpenModal("save-question-before-alert")
-              }
-            />
-          ),
+          type !== "model" &&
+            QuestionAlertWidget.shouldRender({
+              question,
+              visualizationSettings,
+            }) && (
+              <QuestionAlertWidget
+                key="alerts"
+                className={cx(CS.hide, CS.smShow)}
+                canManageSubscriptions={canManageSubscriptions}
+                question={question}
+                questionAlerts={questionAlerts}
+                onCreateAlert={() =>
+                  question.isSaved()
+                    ? onOpenModal("create-alert")
+                    : onOpenModal("save-question-before-alert")
+                }
+              />
+            ),
           type === "question" &&
             !question.isArchived() &&
             (question.isSaved() ? (

--- a/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
@@ -128,24 +128,24 @@ const ViewFooter = ({
               dashboardId={question.card().dashboardId}
             />
           ),
-          type !== "model" &&
-            QuestionAlertWidget.shouldRender({
-              question,
-              visualizationSettings,
-            }) && (
-              <QuestionAlertWidget
-                key="alerts"
-                className={cx(CS.hide, CS.smShow)}
-                canManageSubscriptions={canManageSubscriptions}
-                question={question}
-                questionAlerts={questionAlerts}
-                onCreateAlert={() =>
-                  question.isSaved()
-                    ? onOpenModal("create-alert")
-                    : onOpenModal("save-question-before-alert")
-                }
-              />
-            ),
+
+          QuestionAlertWidget.shouldRender({
+            question,
+            visualizationSettings,
+          }) && (
+            <QuestionAlertWidget
+              key="alerts"
+              className={cx(CS.hide, CS.smShow)}
+              canManageSubscriptions={canManageSubscriptions}
+              question={question}
+              questionAlerts={questionAlerts}
+              onCreateAlert={() =>
+                question.isSaved()
+                  ? onOpenModal("create-alert")
+                  : onOpenModal("save-question-before-alert")
+              }
+            />
+          ),
           type === "question" &&
             !question.isArchived() &&
             (question.isSaved() ? (

--- a/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
@@ -128,7 +128,6 @@ const ViewFooter = ({
               dashboardId={question.card().dashboardId}
             />
           ),
-
           QuestionAlertWidget.shouldRender({
             question,
             visualizationSettings,


### PR DESCRIPTION
Deals with the frontend portion of #37893. The backend will be implemented separately.

### Description

This PR removes the option to set alerts on models, at least on the FE.

> [!Important]
> It doesn't handle the scenarios in which some instances might already have alerts set on models, as I believe that wasn't the scope of this issue.
>
> It also doesn't prevent users from using API to set alerts on models. That should be handled separately on the backend.

### How to verify
1. Open any saved model or create one
2. You shouldn't be able to see the bell icon in the footer, i.e. you shouldn't be able to set up an alert for this model in the UI

### Demo
![Screenshot 2024-07-15 at 23 52 15](https://github.com/user-attachments/assets/af9a11a6-a8e5-4334-b27c-5a78eb3b9e13)

### Checklist
- [x] Tests have been added/updated to cover changes in this PR

### Stress-test
50x ✅ https://github.com/metabase/metabase/actions/runs/9948042881
