### PR TITLE
Remove unnecessary explicit size from charts legend layout

### DIFF
--- a/frontend/src/metabase/visualizations/components/legend/LegendLayout.jsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendLayout.jsx
@@ -1,8 +1,6 @@
 import PropTypes from "prop-types";
 import _ from "underscore";
 
-import ExplicitSize from "metabase/components/ExplicitSize";
-
 import Legend from "./Legend";
 import LegendActions from "./LegendActions";
 import {
@@ -35,7 +33,7 @@ const propTypes = {
   canRemoveSeries: PropTypes.func,
 };
 
-const LegendLayout = ({
+export const LegendLayout = ({
   className,
   items,
   hovered,
@@ -98,5 +96,3 @@ const LegendLayout = ({
 };
 
 LegendLayout.propTypes = propTypes;
-
-export default _.compose(ExplicitSize())(LegendLayout);

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.styled.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 
 import { ResponsiveEChartsRenderer } from "metabase/visualizations/components/EChartsRenderer";
-import LegendLayout from "metabase/visualizations/components/legend/LegendLayout";
+import { LegendLayout } from "metabase/visualizations/components/legend/LegendLayout";
 
 import { getChartPadding } from "./padding";
 

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
@@ -28,7 +28,8 @@ function _CartesianChart(props: VisualizationProps) {
     card,
     getHref,
     gridSize,
-    width,
+    width: outerWidth,
+    height: outerHeight,
     showTitle,
     headerIcon,
     actionButtons,
@@ -98,7 +99,7 @@ function _CartesianChart(props: VisualizationProps) {
           actionButtons={actionButtons}
           getHref={canSelectTitle ? getHref : undefined}
           onSelectTitle={canSelectTitle ? onOpenQuestion : undefined}
-          width={width}
+          width={outerWidth}
         />
       )}
       <CartesianChartLegendLayout
@@ -113,6 +114,8 @@ function _CartesianChart(props: VisualizationProps) {
         canRemoveSeries={canRemoveSeries}
         onRemoveSeries={onRemoveSeries}
         onHoverChange={onHoverChange}
+        width={outerWidth}
+        height={outerHeight}
       >
         {/**@ts-expect-error emotion does not properly provide prop types due */}
         <CartesianChartRenderer

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.styled.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 
 import LegendCaption from "metabase/visualizations/components/legend/LegendCaption";
-import LegendLayout from "metabase/visualizations/components/legend/LegendLayout";
+import { LegendLayout } from "metabase/visualizations/components/legend/LegendLayout";
 import { getChartPadding } from "metabase/visualizations/visualizations/CartesianChart/padding";
 
 interface RowVisualizationRootProps {

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
@@ -110,7 +110,8 @@ const RowChartVisualization = ({
   rawSeries: rawMultipleSeries,
   series: multipleSeries,
   fontFamily,
-  width,
+  width: outerWidth,
+  height: outerHeight,
   getHref,
 }: VisualizationProps) => {
   const formatColumnValue = useMemo(() => {
@@ -286,11 +287,13 @@ const RowChartVisualization = ({
           icon={headerIcon}
           actionButtons={actionButtons}
           onSelectTitle={canSelectTitle ? openQuestion : undefined}
-          width={width}
+          width={outerWidth}
           getHref={getHref}
         />
       )}
       <RowChartLegendLayout
+        width={outerWidth}
+        height={outerHeight}
         hasLegend={hasLegend}
         items={legendItems}
         actionButtons={!hasTitle ? actionButtons : undefined}


### PR DESCRIPTION
https://github.com/metabase/metabase/issues/45454

### Description

An attempt to fix https://github.com/metabase/metabase/issues/45454
I did not manage to reproduce the original problem in any browser, however, it looks like the problem is related to `ExplicitSize` hoc which is triggered in a loop. This PR removes unnecessary `ExplicitSize` usage from `LegendLayout` which wraps two viz implementations: cartesian charts built with echarts and the Row chart built with visx.

### How to verify

First of all, try to reproduce the original issue.
Then ensure cartesian charts built with echarts (line/area/bar/combo/waterfall/scatter) and the Row chart work correctly. This includes the way they resize when they have horizontal or vertical legends.

### Demo

https://github.com/user-attachments/assets/22453799-c0d8-4041-af7c-7afa765e8154

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR
