### PR TITLE
Refactor perms middleware to enforce view-data at the table-level

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
@@ -256,10 +256,12 @@
   [{card-id :card_id :as sandbox}]
   (if card-id
     (qp.store/cached card-id
-                     (query-perms/required-perms (:dataset-query (lib.metadata.protocols/card (qp.store/metadata-provider) card-id))
+                     (query-perms/required-perms-for-query (:dataset-query (lib.metadata.protocols/card (qp.store/metadata-provider) card-id))
                                                  :throw-exceptions? true))
-    {:perms/view-data :unrestricted
-     :perms/create-queries (zipmap (sandbox->table-ids sandbox) (repeat :query-builder))}))
+
+    (let [table-ids (sandbox->table-ids sandbox)]
+      {:perms/view-data (zipmap table-ids (repeat :unrestricted))
+       :perms/create-queries (zipmap table-ids (repeat :query-builder))})))
 
 (defn- merge-perms
   "The shape of permissions maps is a little odd, and using `m/deep-merge` doesn't give us exactly what we want.

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/card_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/card_test.clj
@@ -10,8 +10,8 @@
    [metabase.util :as u]
    [toucan2.tools.with-temp :as t2.with-temp]))
 
-(deftest users-with-segmented-perms-test
-  (testing "Users with segmented permissions should be able to save cards"
+(deftest users-with-sandboxed-perms-test
+  (testing "Users with sandboxed permissions should be able to save cards"
     (let [card-name (mt/random-name)]
       (mt/with-model-cleanup [:model/Card]
         (mt/with-temp [:model/Database                   db {}
@@ -32,7 +32,7 @@
                                                (assoc (api.card-test/card-with-name-and-query card-name (api.card-test/mbql-count-query db table))
                                                       :collection_id (u/the-id collection))))))))))
 
-    (testing "Users with segmented permissions should be able to update the query associated to a card"
+    (testing "Users with sandboxed permissions should be able to update the query associated to a card"
       (mt/with-model-cleanup [:model/Card]
         (mt/with-temp [:model/Database                   db {}
                        :model/Collection                 collection {}
@@ -101,6 +101,40 @@
                                       (assoc (api.card-test/card-with-name-and-query "foobar"
                                                                                      (api.card-test/mbql-count-query db table))
                                              :collection_id (u/the-id collection)))))))))))
+
+(deftest sandbox-join-permissions-test
+  (testing "Sandboxed query can't be saved when sandboxed table is joined to a table that the current user doesn't have access to"
+    (mt/with-temp [:model/Collection collection {}]
+      (mt/with-model-cleanup [:model/Card]
+        (met/with-gtaps! (mt/$ids orders
+                                  {:gtaps      {:orders {:remappings {"user_id" [:dimension $user_id->people.id]}}}
+                                   :attributes {"user_id" 1}})
+          (perms/grant-collection-readwrite-permissions! &group collection)
+          (data-perms/set-table-permission! &group (mt/id :products) :perms/view-data :legacy-no-self-service)
+          (data-perms/set-table-permission! &group (mt/id :products) :perms/create-queries :no)
+          (let [query (mt/mbql-query orders
+                                     {:limit 5
+                                      :aggregation [:count]
+                                      :joins [{:source-table $$products
+                                               :fields       :all
+                                               :alias        "Products"
+                                               :condition    [:= $product_id &Products.products.id]}]})]
+            (mt/user-http-request :rasta :post 403 "card"
+                                  (assoc (api.card-test/card-with-name-and-query (mt/random-name) query)
+                                         :collection_id (u/the-id collection))))
+
+          (mt/with-temp [:model/Card card {:dataset_query (mt/mbql-query products)}]
+            (let [query (mt/mbql-query orders
+                                       {:limit 5
+                                        :aggregation [:count]
+                                        :joins [{:source-table (str "card__" (:id card))
+                                                 :fields       :all
+                                                 :strategy     :left-join
+                                                 :alias        "Products"
+                                                 :condition    [:= $product_id &Products.products.id]}]})]
+             (mt/user-http-request :rasta :post 403 "card"
+                                   (assoc (api.card-test/card-with-name-and-query (mt/random-name) query)
+                                          :collection_id (u/the-id collection))))))))))
 
 (deftest parameters-with-source-is-card-test
   (testing "a card with a parameter whose source is a card should respect sandboxing"

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
@@ -222,7 +222,8 @@
                                                                 :display_name  "Count"
                                                                 :source        :aggregation
                                                                 :field_ref     [:aggregation 0]}]
-                   ::query-perms/perms                        {:gtaps {:perms/view-data :unrestricted
+                   ::query-perms/perms                        {:gtaps {:perms/view-data      {(mt/id :checkins) :unrestricted
+                                                                                              (mt/id :venues) :unrestricted}
                                                                        :perms/create-queries {(mt/id :checkins) :query-builder
                                                                                               (mt/id :venues) :query-builder}}}})
                 (apply-row-level-permissions

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
@@ -1137,3 +1137,36 @@
             (qp/process-query (qp/userland-query query))
             (is (=? {:is_sandboxed true}
                     (qe)))))))))
+
+(deftest sandbox-join-permissions-test
+  (testing "Sandboxed query fails when sandboxed table is joined to a table that the current user doesn't have access to"
+    (met/with-gtaps! (mt/$ids orders
+                              {:gtaps      {:orders {:remappings {"user_id" [:dimension $user_id->people.id]}}}
+                               :attributes {"user_id" 1}})
+      (data-perms/set-table-permission! &group (mt/id :products) :perms/view-data :legacy-no-self-service)
+      (data-perms/set-table-permission! &group (mt/id :products) :perms/create-queries :no)
+      (let [query (mt/mbql-query orders
+                                 {:limit 5
+                                  :aggregation [:count]
+                                  :joins [{:source-table $$products
+                                           :fields       :all
+                                           :alias        "Products"
+                                           :condition    [:= $product_id &Products.products.id]}]})]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"You do not have permissions to run this query"
+             (qp/process-query query))))
+
+      (mt/with-temp [:model/Card card {:dataset_query (mt/mbql-query products)}]
+        (let [query (mt/mbql-query orders
+                                   {:limit 5
+                                    :aggregation [:count]
+                                    :joins [{:source-table (str "card__" (:id card))
+                                             :fields       :all
+                                             :strategy     :left-join
+                                             :alias        "Products"
+                                             :condition    [:= $product_id &Products.products.id]}]})]
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo
+               #"You do not have permissions to run this query"
+               (qp/process-query query))))))))

--- a/src/metabase/api/automagic_dashboards.clj
+++ b/src/metabase/api/automagic_dashboards.clj
@@ -69,7 +69,7 @@
   [query]
   (api/check-403
    (query-perms/check-data-perms (:dataset_query query)
-                                 (query-perms/required-perms (:dataset_query query))
+                                 (query-perms/required-perms-for-query (:dataset_query query))
                                  :throw-exceptions? false))
   query)
 

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -437,7 +437,7 @@
   {:pre [(map? query)]}
   (when-not (query-perms/can-run-query? query)
     (let [required-perms (try
-                           (query-perms/required-perms query :throw-exceptions? true)
+                           (query-perms/required-perms-for-query query :throw-exceptions? true)
                            (catch Throwable e
                              e))]
       (throw (ex-info (tru "You cannot save this Question because you do not have permissions to run its query.")

--- a/src/metabase/models/query/permissions.clj
+++ b/src/metabase/models/query/permissions.clj
@@ -185,10 +185,12 @@
 (defn check-db-level-perms
   "Checks that the current user has at least `required-perm` for the entire DB specified by `db-id`."
   [perm-type required-perm gtap-perms db-id]
-  (or (data-perms/at-least-as-permissive? perm-type (perm-type gtap-perms) required-perm)
+  (or
       (data-perms/at-least-as-permissive? perm-type
                                           (data-perms/full-db-permission-for-user api/*current-user-id* perm-type db-id)
                                           required-perm)
+      (when gtap-perms
+       (data-perms/at-least-as-permissive? perm-type gtap-perms required-perm))
       (throw (perms-exception {db-id {perm-type required-perm}}))))
 
 (defn check-table-level-perms

--- a/src/metabase/models/query/permissions.clj
+++ b/src/metabase/models/query/permissions.clj
@@ -218,9 +218,9 @@
     true))
 
 (defn check-data-perms
-  "Checks whether the current user has sufficient data permissions to run `query`. Returns `true` if the user has data
-  perms for the query, and throws an exception otherwise (exceptions can be disabled by setting `throw-exceptions?` to
-  `false`).
+  "Checks whether the current user has sufficient view data and query permissions to run `query`. Returns `true` if the
+  user has perms for the query, and throws an exception otherwise (exceptions can be disabled by setting
+  `throw-exceptions?` to `false`).
 
   If the [:gtap ::perms] path is present in the query, these perms are implicitly granted to the current user."
   [{{gtap-perms :gtaps} ::perms, db-id :database} required-perms & {:keys [throw-exceptions?]
@@ -235,6 +235,9 @@
     ;; Check view-data and create-queries permissions, for individual tables or the entire DB
     (doseq [perm-type [:perms/view-data :perms/create-queries]]
       (when-let [db-or-table-perms (perm-type required-perms)]
+        ;; In practice, `view-data` will be defined at the table-level, and `create-queries` will either be table-level
+        ;; or :query-builder-and-native for the entire DB. But we should enforce whatever `required-perms` are provided,
+        ;; in case that ever changes.
         (cond
           (keyword? db-or-table-perms)
           (check-db-level-perms perm-type db-or-table-perms (perm-type gtap-perms) db-id)

--- a/src/metabase/models/query/permissions.clj
+++ b/src/metabase/models/query/permissions.clj
@@ -241,7 +241,7 @@
 
           (map? db-or-table-perms)
           (check-table-level-perms perm-type
-                                   :asdf
+                                   db-or-table-perms
                                    (perm-type gtap-perms)
                                    db-id)
 

--- a/src/metabase/models/query/permissions.clj
+++ b/src/metabase/models/query/permissions.clj
@@ -144,7 +144,7 @@
           (merge
            (when (seq table-ids)
              {:perms/create-queries (zipmap table-ids (repeat :query-builder))
-              :perms/data-access    (zipmap table-ids (repeat :unrestricted))})
+              :perms/view-data      (zipmap table-ids (repeat :unrestricted))})
            (when native?
              (native-query-perms query))))))
     ;; if for some reason we can't expand the Card (i.e. it's an invalid legacy card) just return a set of permissions

--- a/src/metabase/query_processor/middleware/permissions.clj
+++ b/src/metabase/query_processor/middleware/permissions.clj
@@ -85,7 +85,7 @@
     (when (= audit/audit-db-id database-id)
       (check-audit-db-permissions outer-query))
     (let [card-id (or *card-id* (:qp/source-card-id outer-query))
-          required-perms (query-perms/required-perms outer-query :already-preprocessed? true)]
+          required-perms (query-perms/required-perms-for-query outer-query :already-preprocessed? true)]
       (cond
         card-id
         (do
@@ -131,7 +131,7 @@
     (check-card-read-perms database-id *card-id*))
   (when-not (query-perms/check-data-perms
              outer-query
-             (query-perms/required-perms outer-query :already-preprocessed? true)
+             (query-perms/required-perms-for-query outer-query :already-preprocessed? true)
              :throw-exceptions? false)
     (check-block-permissions outer-query)))
 

--- a/test/metabase/models/query/permissions_test.clj
+++ b/test/metabase/models/query/permissions_test.clj
@@ -104,16 +104,16 @@
 (deftest ^:parallel native-query-perms-test
   (is (= {:perms/create-queries :query-builder-and-native
           :perms/view-data :unrestricted}
-         (query-perms/required-perms
+         (query-perms/required-perms-for-query
           (native "SELECT count(*) FROM toucan_sightings;")))))
 
 (deftest ^:parallel mbql-query-test
   (is (= {:perms/view-data :unrestricted
           :perms/create-queries {(mt/id :venues) :query-builder}}
-         (query-perms/required-perms (mt/mbql-query venues))))
+         (query-perms/required-perms-for-query (mt/mbql-query venues))))
   (is (= {:perms/view-data :unrestricted
           :perms/create-queries {(mt/id :venues) :query-builder}}
-         (query-perms/required-perms
+         (query-perms/required-perms-for-query
           {:query    {:source-table (mt/id :venues)
                       :filter       [:> [:field (mt/id :venues :id) nil] 10]}
            :type     :query
@@ -127,9 +127,9 @@
       (mt/with-no-data-perms-for-all-users!
         (binding [*current-user-permissions-set* (atom nil)
                   *current-user-id*              (mt/user->id :rasta)]
-          (is (= {:perms/view-data :unrestricted
+          (is (= {:perms/view-data      {(u/the-id table) :unrestricted}
                   :perms/create-queries {(u/the-id table) :query-builder}}
-                 (query-perms/required-perms
+                 (query-perms/required-perms-for-query
                   {:database (u/the-id db)
                    :type     :query
                    :query    {:source-table (u/the-id table)}}))))))))
@@ -138,7 +138,7 @@
   (testing "should be able to calculate permissions of a query before normalization"
     (is (= {:perms/view-data :unrestricted
             :perms/create-queries {(mt/id :venues) :query-builder}}
-           (query-perms/required-perms
+           (query-perms/required-perms-for-query
             {:query    {"SOURCE_TABLE" (mt/id :venues)
                         "FILTER"       [">" (mt/id :venues :id) 10]}
              :type     :query
@@ -149,7 +149,7 @@
     (is (= {:perms/view-data :unrestricted
             :perms/create-queries {(mt/id :venues) :query-builder
                                    (mt/id :checkins) :query-builder}}
-           (query-perms/required-perms
+           (query-perms/required-perms-for-query
             (mt/mbql-query checkins
               {:order-by [[:asc $checkins.venue_id->venues.name]]}))))))
 
@@ -162,7 +162,7 @@
                                                         :type     :query
                                                         :query    {:source-table (mt/id :venues)}}}]
       (is (= {:paths #{"/collection/root/read/"}}
-             (query-perms/required-perms
+             (query-perms/required-perms-for-query
               (query-with-source-card card)))))))
 
 (deftest ^:parallel nested-query-test-2
@@ -173,7 +173,7 @@
                                               :type     :query
                                               :query    {:source-table (mt/id :venues)}}}]
       (is (= {:paths #{(perms/collection-read-path collection)}}
-             (query-perms/required-perms
+             (query-perms/required-perms-for-query
               (query-with-source-card card)))))))
 
 (deftest ^:parallel nested-query-with-join-test
@@ -185,7 +185,7 @@
                                          :query    {:source-table (mt/id :checkins)
                                                     :order-by     [[:asc [:field (mt/id :users :id) {:source-field (mt/id :checkins :user_id)}]]]}}}]
       (is (= {:paths #{"/collection/root/read/"}}
-             (query-perms/required-perms
+             (query-perms/required-perms-for-query
               (query-with-source-card card)))))))
 
 (deftest ^:parallel nested-native-query-test
@@ -195,7 +195,7 @@
                                                         :type     :native
                                                         :native   {:query "SELECT * FROM CHECKINS"}}}]
       (is (= {:paths #{"/collection/root/read/"}}
-             (query-perms/required-perms
+             (query-perms/required-perms-for-query
               (query-with-source-card card)))))))
 
 (deftest ^:parallel nested-native-query-test-2
@@ -203,7 +203,7 @@
                 "READWRITE permissions to save the query since we can't verify that it belongs to a Card that you can view.")
     (is (= {:perms/view-data :unrestricted
             :perms/create-queries :query-builder-and-native}
-           (query-perms/required-perms
+           (query-perms/required-perms-for-query
             {:database (mt/id)
              :type     :query
              :query    {:source-query {:native "SELECT * FROM CHECKINS"}}}
@@ -212,7 +212,7 @@
 (deftest ^:parallel invalid-queries-test
   (testing "invalid/legacy queries should return perms for something that doesn't exist so no one gets to see it"
     (is (= {:perms/create-queries {0 :query-builder}}
-           (query-perms/required-perms
+           (query-perms/required-perms-for-query
             (mt/mbql-query venues
               {:filter [:WOW 100 200]}))))))
 
@@ -225,7 +225,7 @@
       (is (= {:perms/view-data :unrestricted
               :perms/create-queries {(mt/id :users) :query-builder
                                      (mt/id :checkins) :query-builder}}
-             (query-perms/required-perms
+             (query-perms/required-perms-for-query
               (mt/mbql-query users
                 {:joins [{:fields       :all
                           :alias        "__alias__"
@@ -239,7 +239,7 @@
       (is (= {:perms/view-data :unrestricted
               :perms/create-queries {(mt/id :users) :query-builder
                                      (mt/id :checkins) :query-builder}}
-           (query-perms/required-perms
+           (query-perms/required-perms-for-query
             (mt/mbql-query users
               {:joins [{:alias        "c"
                         :source-table $$checkins
@@ -253,7 +253,7 @@
           query             (lib/query metadata-provider venues)]
       (is (= {:perms/view-data :unrestricted
               :perms/create-queries {(mt/id :venues) :query-builder}}
-             (query-perms/required-perms query))))))
+             (query-perms/required-perms-for-query query))))))
 
 (deftest ^:parallel pmbql-native-query-test
   (testing "Should be able to calculate permissions for a pMBQL native query (#39024)"
@@ -262,7 +262,7 @@
                                                           :native   "SELECT *;"})]
       (is (= {:perms/view-data :unrestricted
               :perms/create-queries :query-builder-and-native}
-             (query-perms/required-perms query))))))
+             (query-perms/required-perms-for-query query))))))
 
 (deftest ^:parallel native-query-referenced-card-permissions-test
   (testing "Check permissions for native query card reference parameters (the `:metabase.models.query.permissions/referenced-card-ids` key(s))"
@@ -275,7 +275,7 @@
                 :perms/view-data      :unrestricted
                 :paths                #{(format "/collection/%d/read/" collection-1-id)
                                         (format "/collection/%d/read/" collection-2-id)}}
-               (query-perms/required-perms
+               (query-perms/required-perms-for-query
                 {:database                         (mt/id)
                  :type                             :native
                  :native                           "SELECT * FROM (SELECT * FROM whatever);"
@@ -293,12 +293,12 @@
                   :perms/view-data      :unrestricted
                   :paths                #{(format "/collection/%d/read/" collection-1-id)
                                           (format "/collection/%d/read/" collection-2-id)}}
-                 (query-perms/required-perms native-query)))
+                 (query-perms/required-perms-for-query native-query)))
           (testing "pMBQL query"
             (is (= {:perms/create-queries :query-builder-and-native
                     :perms/view-data      :unrestricted
                     :paths                #{(format "/collection/%d/read/" collection-1-id)
                                             (format "/collection/%d/read/" collection-2-id)}}
-                   (query-perms/required-perms
+                   (query-perms/required-perms-for-query
                     (lib/query (lib.metadata.jvm/application-database-metadata-provider (mt/id))
                                (lib/->pMBQL native-query)))))))))))

--- a/test/metabase/models/query/permissions_test.clj
+++ b/test/metabase/models/query/permissions_test.clj
@@ -108,10 +108,10 @@
           (native "SELECT count(*) FROM toucan_sightings;")))))
 
 (deftest ^:parallel mbql-query-test
-  (is (= {:perms/view-data :unrestricted
+  (is (= {:perms/view-data      {(mt/id :venues) :unrestricted}
           :perms/create-queries {(mt/id :venues) :query-builder}}
          (query-perms/required-perms-for-query (mt/mbql-query venues))))
-  (is (= {:perms/view-data :unrestricted
+  (is (= {:perms/view-data      {(mt/id :venues) :unrestricted}
           :perms/create-queries {(mt/id :venues) :query-builder}}
          (query-perms/required-perms-for-query
           {:query    {:source-table (mt/id :venues)
@@ -136,7 +136,7 @@
 
 (deftest ^:parallel mbql-query-test-3
   (testing "should be able to calculate permissions of a query before normalization"
-    (is (= {:perms/view-data :unrestricted
+    (is (= {:perms/view-data      {(mt/id :venues) :unrestricted}
             :perms/create-queries {(mt/id :venues) :query-builder}}
            (query-perms/required-perms-for-query
             {:query    {"SOURCE_TABLE" (mt/id :venues)
@@ -146,7 +146,8 @@
 
 (deftest ^:parallel mbql-query-with-join-test
   (testing "you should need perms for both tables if you include a JOIN"
-    (is (= {:perms/view-data :unrestricted
+    (is (= {:perms/view-data      {(mt/id :venues) :unrestricted
+                                   (mt/id :checkins) :unrestricted}
             :perms/create-queries {(mt/id :venues) :query-builder
                                    (mt/id :checkins) :query-builder}}
            (query-perms/required-perms-for-query
@@ -222,7 +223,8 @@
                                                  (mt/mbql-query checkins
                                                    {:aggregation [[:sum $id]]
                                                     :breakout    [$user_id]}))]
-      (is (= {:perms/view-data :unrestricted
+      (is (= {:perms/view-data      {(mt/id :users) :unrestricted
+                                     (mt/id :checkins) :unrestricted}
               :perms/create-queries {(mt/id :users) :query-builder
                                      (mt/id :checkins) :query-builder}}
              (query-perms/required-perms-for-query
@@ -235,8 +237,8 @@
                                          [:field "USER_ID" {:base-type :type/Integer, :join-alias "__alias__"}]]}]
                  :limit 10})
               :throw-exceptions? true)))
-
-      (is (= {:perms/view-data :unrestricted
+      (is (= {:perms/view-data      {(mt/id :users) :unrestricted
+                                     (mt/id :checkins) :unrestricted}
               :perms/create-queries {(mt/id :users) :query-builder
                                      (mt/id :checkins) :query-builder}}
            (query-perms/required-perms-for-query
@@ -251,7 +253,7 @@
     (let [metadata-provider (lib.metadata.jvm/application-database-metadata-provider (mt/id))
           venues            (lib.metadata/table metadata-provider (mt/id :venues))
           query             (lib/query metadata-provider venues)]
-      (is (= {:perms/view-data :unrestricted
+      (is (= {:perms/view-data      {(mt/id :venues) :unrestricted}
               :perms/create-queries {(mt/id :venues) :query-builder}}
              (query-perms/required-perms-for-query query))))))
 

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -649,7 +649,7 @@
                                            (lib.tu/metadata-provider-with-cards-for-queries [{}])
                                            (lib.tu/merged-mock-metadata-provider {:cards [{:id 1, :collection-id 1000}]}))
         (is (= {:paths #{(perms/collection-read-path (t2/instance :model/Collection {:id 1000}))}}
-               (query-perms/required-perms (query-with-source-card 1 :aggregation [:count]))))))))
+               (query-perms/required-perms-for-query (query-with-source-card 1 :aggregation [:count]))))))))
 
 (deftest ^:parallel card-perms-test-2
   (testing "perms for a Card with a SQL source query\n"
@@ -658,7 +658,7 @@
       (qp.store/with-metadata-provider (qp.test-util/metadata-provider-with-cards-for-queries
                                         [(mt/native-query {:query "SELECT * FROM VENUES"})])
         (is (= {:paths #{(perms/collection-read-path collection/root-collection)}}
-               (query-perms/required-perms (query-with-source-card 1 :aggregation [:count]))))))))
+               (query-perms/required-perms-for-query (query-with-source-card 1 :aggregation [:count]))))))))
 
 (deftest card-perms-test-3
   (testing "perms for Card -> Card -> MBQL Source query\n"


### PR DESCRIPTION
Pasting my summary from Slack:
> QP permissions middleware looks for View data perms for the full DB by default. This is satisfied when all tables are Sandboxed or Can view. But when any tables are No self-service (deprecated), this condition isn't satisfied.
>
> When running the query, there's an additional mechanism in the sandboxing middleware to add extra perms that are required by the sandboxes via a special key. That's why there isn't an error when running the query. But when saving the card, we run the permission-checking middleware but don't do the full query pre-processing so this mechanism doesn't take effect, and it leads to an error.

TL;DR: This PR refactors the permission-checking middleware so that we enforce `view-data` perms at the table-level to run a query, rather than always enforcing `view-data` perms for the entire DB. This avoids `No self-service (deprecated)` in _other_ tables from impacting the permissions of a query that doesn't touch those tables. 

Fixes https://github.com/metabase/metabase/issues/45595