### PR TITLE
fix(webapp/collections): Tweak the height of action menu items so they align well with icons

### DIFF
--- a/frontend/src/metabase/components/EntityMenuItem/EntityMenuItem.styled.tsx
+++ b/frontend/src/metabase/components/EntityMenuItem/EntityMenuItem.styled.tsx
@@ -48,6 +48,7 @@ export const MenuItemIcon = styled(Icon)`
 
 export const MenuItemTitle = styled.span`
   font-weight: bold;
+  line-height: 1rem;
 `;
 
 export const MenuLink = styled(Link)`


### PR DESCRIPTION
On master, "Restore" is a bit low relative to the icon:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/067be5b3-e0ed-4d3e-9a00-4c4022b46925.png)


In this branch, "Restore" aligns with the icon:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/6096e374-0311-4048-9dcd-310ea252f1b9.png)