### PR TITLE
(tiny PR) Make collections tabbable

### DIFF
--- a/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
+++ b/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
@@ -169,7 +169,10 @@ function ActionMenu({
   return (
     // this component is used within a `<Link>` component,
     // so we must prevent events from triggering the activation of the link
-    <EventSandbox preventDefault>
+    <EventSandbox
+      preventDefault
+      unsandboxEvents={["onKeyDown", "onKeyPress", "onKeyUp"]}
+    >
       <>
         <EntityItemMenu
           className={className}


### PR DESCRIPTION
On master, you cannot use Tab and Shift-Tab to navigate through a collection page. The reason: when the focus reaches an action menu, the Tab key does nothing. Here's an animated screenshot. I'm using a keystroke visualizer (Keycastr) to show what keys I'm pressing: Tab (⇥) and Shift-Tab (⇤).

![Kapture 2024-07-15 at 22.06.55.gif](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/9273f729-9385-428a-a6d3-89388925a24b.gif)

On this branch, you can use Tab and Shift-Tab to navigate through a collection page, as expected:

![Kapture 2024-07-16 at 07 39 49](https://github.com/user-attachments/assets/784b3413-d9a7-4260-832b-97dc3cb16916)


Closes #45141
