### PR TITLE
Fix - `useIsTruncated` gives incorrect results

### DIFF
--- a/frontend/src/metabase/browse/components/CollectionBreadcrumbsWithTooltip.tsx
+++ b/frontend/src/metabase/browse/components/CollectionBreadcrumbsWithTooltip.tsx
@@ -39,9 +39,7 @@ export const CollectionBreadcrumbsWithTooltip = ({
     : collections;
   const justOneShown = shownCollections.length === 1;
 
-  const { areAnyTruncated, ref } = useAreAnyTruncated<HTMLDivElement>({
-    tolerance: 1,
-  });
+  const { areAnyTruncated, ref } = useAreAnyTruncated<HTMLDivElement>();
 
   const initialEllipsisRef = useRef<HTMLDivElement | null>(null);
   const [

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.unit.spec.tsx
@@ -149,27 +149,24 @@ describe("PinnedItemCard", () => {
   });
 
   describe("description", () => {
-    const originalScrollWidth = Object.getOwnPropertyDescriptor(
-      HTMLElement.prototype,
-      "scrollWidth",
-    );
+    const getBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
+    const rangeGetBoundingClientRect = Range.prototype.getBoundingClientRect;
 
     beforeAll(() => {
-      // emulate ellipsis
-      Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
-        configurable: true,
-        value: 100,
-      });
+      // Mock return values so that getIsTruncated can kick in
+      HTMLElement.prototype.getBoundingClientRect = jest
+        .fn()
+        .mockReturnValue({ height: 1, width: 1 });
+      Range.prototype.getBoundingClientRect = jest
+        .fn()
+        .mockReturnValue({ height: 1, width: 2 });
     });
 
     afterAll(() => {
-      if (originalScrollWidth) {
-        Object.defineProperty(
-          HTMLElement.prototype,
-          "scrollWidth",
-          originalScrollWidth,
-        );
-      }
+      HTMLElement.prototype.getBoundingClientRect = getBoundingClientRect;
+      Range.prototype.getBoundingClientRect = rangeGetBoundingClientRect;
+
+      jest.resetAllMocks();
     });
 
     it("should render description markdown as plain text", () => {

--- a/frontend/src/metabase/core/components/MarkdownPreview/MarkdownPreview.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/MarkdownPreview/MarkdownPreview.unit.spec.tsx
@@ -43,27 +43,24 @@ describe("MarkdownPreview", () => {
   });
 
   describe("Tooltip on ellipsis", () => {
-    const originalScrollWidth = Object.getOwnPropertyDescriptor(
-      HTMLElement.prototype,
-      "scrollWidth",
-    );
+    const getBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
+    const rangeGetBoundingClientRect = Range.prototype.getBoundingClientRect;
 
     beforeAll(() => {
-      // emulate ellipsis
-      Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
-        configurable: true,
-        value: 100,
-      });
+      // Mock return values so that getIsTruncated can kick in
+      HTMLElement.prototype.getBoundingClientRect = jest
+        .fn()
+        .mockReturnValue({ height: 1, width: 1 });
+      Range.prototype.getBoundingClientRect = jest
+        .fn()
+        .mockReturnValue({ height: 1, width: 2 });
     });
 
     afterAll(() => {
-      if (originalScrollWidth) {
-        Object.defineProperty(
-          HTMLElement.prototype,
-          "scrollWidth",
-          originalScrollWidth,
-        );
-      }
+      HTMLElement.prototype.getBoundingClientRect = getBoundingClientRect;
+      Range.prototype.getBoundingClientRect = rangeGetBoundingClientRect;
+
+      jest.resetAllMocks();
     });
 
     it("should show tooltip with markdown formatting on hover when text is truncated", async () => {

--- a/frontend/src/metabase/hooks/use-is-truncated.ts
+++ b/frontend/src/metabase/hooks/use-is-truncated.ts
@@ -5,13 +5,10 @@ import resizeObserver from "metabase/lib/resize-observer";
 
 type UseIsTruncatedProps = {
   disabled?: boolean;
-  /** To avoid rounding errors, we can require that the truncation is at least a certain number of pixels */
-  tolerance?: number;
 };
 
 export const useIsTruncated = <E extends Element>({
   disabled = false,
-  tolerance = 0,
 }: UseIsTruncatedProps = {}) => {
   const ref = useRef<E | null>(null);
   const [isTruncated, setIsTruncated] = useState(false);
@@ -24,7 +21,7 @@ export const useIsTruncated = <E extends Element>({
     }
 
     const handleResize = () => {
-      setIsTruncated(getIsTruncated(element, tolerance));
+      setIsTruncated(getIsTruncated(element));
     };
 
     handleResize();
@@ -33,21 +30,20 @@ export const useIsTruncated = <E extends Element>({
     return () => {
       resizeObserver.unsubscribe(element, handleResize);
     };
-  }, [disabled, tolerance]);
+  }, [disabled]);
 
   return { isTruncated, ref };
 };
 
-const getIsTruncated = (element: Element, tolerance: number): boolean => {
+const getIsTruncated = (element: Element): boolean => {
   return (
-    element.scrollHeight > element.clientHeight + tolerance ||
-    element.scrollWidth > element.clientWidth + tolerance
+    element.scrollHeight > element.clientHeight ||
+    element.scrollWidth > element.clientWidth
   );
 };
 
 export const useAreAnyTruncated = <E extends Element>({
   disabled = false,
-  tolerance = 0,
 }: UseIsTruncatedProps = {}) => {
   const ref = useRef(new Map<string, E>());
   const [truncationStatusByKey, setTruncationStatusByKey] = useState<
@@ -64,7 +60,7 @@ export const useAreAnyTruncated = <E extends Element>({
 
     [...elementsMap.entries()].forEach(([elementKey, element]) => {
       const handleResize = () => {
-        const isTruncated = getIsTruncated(element, tolerance);
+        const isTruncated = getIsTruncated(element);
         setTruncationStatusByKey(statuses => {
           const newStatuses = new Map(statuses);
           newStatuses.set(elementKey, isTruncated);
@@ -81,7 +77,7 @@ export const useAreAnyTruncated = <E extends Element>({
     return () => {
       unsubscribeFns.forEach(fn => fn());
     };
-  }, [disabled, tolerance]);
+  }, [disabled]);
 
   const areAnyTruncated = [...truncationStatusByKey.values()].some(Boolean);
   return { areAnyTruncated, ref };

--- a/frontend/src/metabase/hooks/use-is-truncated.ts
+++ b/frontend/src/metabase/hooks/use-is-truncated.ts
@@ -36,9 +36,13 @@ export const useIsTruncated = <E extends Element>({
 };
 
 const getIsTruncated = (element: Element): boolean => {
+  const range = document.createRange();
+  range.selectNodeContents(element);
+  const elementRect = element.getBoundingClientRect();
+  const rangeRect = range.getBoundingClientRect();
+
   return (
-    element.scrollHeight > element.clientHeight ||
-    element.scrollWidth > element.clientWidth
+    rangeRect.height > elementRect.height || rangeRect.width > elementRect.width
   );
 };
 

--- a/frontend/src/metabase/visualizations/components/skeletons/StaticSkeleton/StaticSkeleton.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/skeletons/StaticSkeleton/StaticSkeleton.unit.spec.tsx
@@ -27,27 +27,24 @@ function setup({ description }: { description?: string } = {}) {
 
 describe("StaticSkeleton", () => {
   describe("description", () => {
-    const originalScrollWidth = Object.getOwnPropertyDescriptor(
-      HTMLElement.prototype,
-      "scrollWidth",
-    );
+    const getBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
+    const rangeGetBoundingClientRect = Range.prototype.getBoundingClientRect;
 
     beforeAll(() => {
-      // emulate ellipsis
-      Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
-        configurable: true,
-        value: 100,
-      });
+      // Mock return values so that getIsTruncated can kick in
+      HTMLElement.prototype.getBoundingClientRect = jest
+        .fn()
+        .mockReturnValue({ height: 1, width: 1 });
+      Range.prototype.getBoundingClientRect = jest
+        .fn()
+        .mockReturnValue({ height: 1, width: 2 });
     });
 
     afterAll(() => {
-      if (originalScrollWidth) {
-        Object.defineProperty(
-          HTMLElement.prototype,
-          "scrollWidth",
-          originalScrollWidth,
-        );
-      }
+      HTMLElement.prototype.getBoundingClientRect = getBoundingClientRect;
+      Range.prototype.getBoundingClientRect = rangeGetBoundingClientRect;
+
+      jest.resetAllMocks();
     });
 
     it("should render description markdown as plain text", () => {

--- a/frontend/test/jest-setup.js
+++ b/frontend/test/jest-setup.js
@@ -31,3 +31,13 @@ if (process.env["DISABLE_LOGGING"] || process.env["DISABLE_LOGGING_FRONTEND"]) {
 // (hacky fix)
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder;
+
+// https://github.com/jsdom/jsdom/issues/3002
+Range.prototype.getBoundingClientRect = () => ({
+  bottom: 0,
+  height: 0,
+  left: 0,
+  right: 0,
+  top: 0,
+  width: 0,
+});


### PR DESCRIPTION
Fixes #45358

Previous attempt: #45347

### Description

The current [`getIsTruncated`](https://github.com/metabase/metabase/blob/54c1e07/frontend/src/metabase/hooks/use-is-truncated.ts#L41-L46) implementation uses `clientHeight`/`clientWidth`/`scrollHeight`/`scrollWidth`:
- these properties are integers and so they lose precision - it means they don't account for cases where 0px < difference < 1px (where "difference" means the difference between ellipsis being applied and not)
- setting `width` on an element may prevent it from resizing when ellipsis is applied, so comparing the aforementioned properties won't give any useful information

Credits to @ranquild for [the idea](https://metaboat.slack.com/archives/C0645JP1W81/p1721052584800439?thread_ts=1721031248.290819&cid=C0645JP1W81) :1st_place_medal: 

### How to verify

CI is green.

1. New question > Orders
2. Add breakout "Created At" - "Month of year"
3. Click to edit breakout
4. Hover over truncated "by month of year"

There should be a tooltip.



