### PR TITLE
Fix padding for `QueryDownloadPopover`

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.tsx
@@ -113,6 +113,8 @@ export const DashCardMenu = ({
             close();
             handleDownload(opts);
           }}
+          px="sm"
+          py="md"
         />
       );
     }

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.tsx
@@ -113,8 +113,6 @@ export const DashCardMenu = ({
             close();
             handleDownload(opts);
           }}
-          px="sm"
-          py="md"
         />
       );
     }

--- a/frontend/src/metabase/query_builder/components/QueryDownloadPopover/QueryDownloadPopover.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryDownloadPopover/QueryDownloadPopover.tsx
@@ -5,7 +5,15 @@ import { t } from "ttag";
 import { isMac } from "metabase/lib/browser";
 import { exportFormatPng, exportFormats } from "metabase/lib/urls";
 import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
-import { Group, Icon, Stack, Text, Title, Tooltip } from "metabase/ui";
+import {
+  Group,
+  Icon,
+  Stack,
+  type StackProps,
+  Text,
+  Title,
+  Tooltip,
+} from "metabase/ui";
 import { canSavePng } from "metabase/visualizations";
 import type Question from "metabase-lib/v1/Question";
 import type { Dataset } from "metabase-types/api";
@@ -17,7 +25,7 @@ type QueryDownloadPopoverProps = {
   question: Question;
   result: Dataset;
   onDownload: (opts: { type: string; enableFormatting: boolean }) => void;
-};
+} & StackProps;
 
 const getFormattingInfoTooltipLabel = () => {
   return isMac()
@@ -29,6 +37,7 @@ export const QueryDownloadPopover = ({
   question,
   result,
   onDownload,
+  ...stackProps
 }: QueryDownloadPopoverProps) => {
   const canDownloadPng = canSavePng(question.display());
   const hasTruncatedResults =
@@ -53,7 +62,7 @@ export const QueryDownloadPopover = ({
   );
 
   return (
-    <Stack w={hasTruncatedResults ? "18.75rem" : "16.25rem"} py="sm">
+    <Stack w={hasTruncatedResults ? "18.75rem" : "16.25rem"} {...stackProps}>
       <Group align="center" position="apart" px="sm">
         <Title order={4}>{t`Download full results`}</Title>
         <Tooltip label={getFormattingInfoTooltipLabel()}>

--- a/frontend/src/metabase/query_builder/components/QueryDownloadPopover/QueryDownloadPopover.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryDownloadPopover/QueryDownloadPopover.tsx
@@ -29,7 +29,6 @@ export const QueryDownloadPopover = ({
   question,
   result,
   onDownload,
-  ...stackProps
 }: QueryDownloadPopoverProps) => {
   const canDownloadPng = canSavePng(question.display());
   const hasTruncatedResults =
@@ -54,7 +53,7 @@ export const QueryDownloadPopover = ({
   );
 
   return (
-    <Stack w={hasTruncatedResults ? "18.75rem" : "16.25rem"} {...stackProps}>
+    <Stack w={hasTruncatedResults ? "18.75rem" : "16.25rem"}>
       <Group align="center" position="apart" px="sm">
         <Title order={4}>{t`Download full results`}</Title>
         <Tooltip label={getFormattingInfoTooltipLabel()}>

--- a/frontend/src/metabase/query_builder/components/QueryDownloadPopover/QueryDownloadPopover.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryDownloadPopover/QueryDownloadPopover.tsx
@@ -5,15 +5,7 @@ import { t } from "ttag";
 import { isMac } from "metabase/lib/browser";
 import { exportFormatPng, exportFormats } from "metabase/lib/urls";
 import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
-import {
-  Group,
-  Icon,
-  Stack,
-  type StackProps,
-  Text,
-  Title,
-  Tooltip,
-} from "metabase/ui";
+import { Group, Icon, Stack, Text, Title, Tooltip } from "metabase/ui";
 import { canSavePng } from "metabase/visualizations";
 import type Question from "metabase-lib/v1/Question";
 import type { Dataset } from "metabase-types/api";
@@ -25,7 +17,7 @@ type QueryDownloadPopoverProps = {
   question: Question;
   result: Dataset;
   onDownload: (opts: { type: string; enableFormatting: boolean }) => void;
-} & StackProps;
+};
 
 const getFormattingInfoTooltipLabel = () => {
   return isMac()

--- a/frontend/src/metabase/query_builder/components/QueryDownloadWidget/QueryDownloadWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryDownloadWidget/QueryDownloadWidget.tsx
@@ -70,7 +70,7 @@ const QueryDownloadWidget = ({
           )}
         </Flex>
       </Popover.Target>
-      <Popover.Dropdown>
+      <Popover.Dropdown p="0.75rem">
         <QueryDownloadPopover
           question={question}
           result={result}
@@ -78,8 +78,6 @@ const QueryDownloadWidget = ({
             setIsPopoverOpen(false);
             handleDownload(opts);
           }}
-          px="md"
-          py="lg"
         />
       </Popover.Dropdown>
     </Popover>

--- a/frontend/src/metabase/query_builder/components/QueryDownloadWidget/QueryDownloadWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryDownloadWidget/QueryDownloadWidget.tsx
@@ -78,6 +78,8 @@ const QueryDownloadWidget = ({
             setIsPopoverOpen(false);
             handleDownload(opts);
           }}
+          px="md"
+          py="lg"
         />
       </Popover.Dropdown>
     </Popover>


### PR DESCRIPTION
Fixes the padding for the `QueryDownloadPopover` component. 

In `DashCardMenu`:

Before:
![image](https://github.com/user-attachments/assets/8edf17fb-cd7e-4ab9-bafe-21f4a9ca5759)

After:
<img width="410" alt="image" src="https://github.com/user-attachments/assets/cf823f48-d715-4019-8c8c-d0e3aeaef34a">


--- 
In `ViewFooter`:
Before:
![image](https://github.com/user-attachments/assets/2a647f70-a99d-4d46-9834-d3e7422f8cd6)

After:
<img width="426" alt="image" src="https://github.com/user-attachments/assets/e3ec3c30-0ae3-40d3-9162-cfdbd1b8e499">

