### PR TITLE
fix(webapp/sidenav): Fix bookmark reordering

### DIFF
--- a/e2e/test/scenarios/organization/bookmarks-question.cy.spec.js
+++ b/e2e/test/scenarios/organization/bookmarks-question.cy.spec.js
@@ -8,6 +8,8 @@ import {
   visitQuestion,
 } from "e2e/support/helpers";
 
+import { toggleQuestionBookmarkStatus } from "./helpers/bookmark-helpers";
+
 describe("scenarios > question > bookmarks", () => {
   beforeEach(() => {
     restore();
@@ -17,7 +19,7 @@ describe("scenarios > question > bookmarks", () => {
 
   it("should add, update bookmark name when question name is updated, then remove bookmark from question page", () => {
     visitQuestion(ORDERS_QUESTION_ID);
-    toggleBookmark();
+    toggleQuestionBookmarkStatus();
 
     openNavigationSidebar();
     navigationSidebar().within(() => {
@@ -64,7 +66,7 @@ describe("scenarios > question > bookmarks", () => {
     });
 
     // Remove bookmark
-    toggleBookmark({ wasSelected: true });
+    toggleQuestionBookmarkStatus({ wasSelected: true });
 
     navigationSidebar().within(() => {
       getSidebarSectionTitle(/Bookmarks/).should("not.exist");
@@ -72,11 +74,3 @@ describe("scenarios > question > bookmarks", () => {
     });
   });
 });
-
-function toggleBookmark({ wasSelected = false } = {}) {
-  const iconName = wasSelected ? "bookmark_filled" : "bookmark";
-  cy.findByTestId("qb-header-action-panel").within(() => {
-    cy.icon(iconName).click();
-  });
-  cy.wait("@toggleBookmark");
-}

--- a/e2e/test/scenarios/organization/bookmarks-reordering.cy.spec.ts
+++ b/e2e/test/scenarios/organization/bookmarks-reordering.cy.spec.ts
@@ -1,0 +1,57 @@
+import {
+  ORDERS_COUNT_QUESTION_ID,
+  ORDERS_QUESTION_ID,
+} from "e2e/support/cypress_sample_instance_data";
+import {
+  openNavigationSidebar,
+  restore,
+  visitQuestion,
+} from "e2e/support/helpers";
+
+import {
+  createAndBookmarkQuestion,
+  moveBookmark,
+  toggleQuestionBookmarkStatus,
+  verifyBookmarksOrder,
+} from "./helpers/bookmark-helpers";
+
+describe("scenarios > nav > bookmarks", () => {
+  beforeEach(() => {
+    restore();
+    cy.intercept("/api/bookmark/card/*").as("toggleBookmark");
+    cy.intercept("/api/bookmark/ordering").as("reorderBookmarks");
+    cy.signInAsAdmin();
+  });
+
+  it("should allow bookmarks to be reordered", () => {
+    cy.log("Create three bookmarks");
+    ["Question 1", "Question 2", "Question 3"].forEach(
+      createAndBookmarkQuestion,
+    );
+    openNavigationSidebar();
+    verifyBookmarksOrder(["Question 3", "Question 2", "Question 1"]);
+    moveBookmark("Question 1", -100);
+    verifyBookmarksOrder(["Question 1", "Question 3", "Question 2"]);
+    moveBookmark("Question 3", 100);
+    verifyBookmarksOrder(["Question 1", "Question 2", "Question 3"]);
+  });
+
+  it("should restore bookmarks order if PUT fails", () => {
+    cy.intercept(
+      { method: "PUT", url: "/api/bookmark/ordering" },
+      { statusCode: 500 },
+    ).as("failedToReorderBookmarks");
+    cy.log("Create two bookmarks");
+    visitQuestion(ORDERS_QUESTION_ID);
+    toggleQuestionBookmarkStatus();
+    visitQuestion(ORDERS_COUNT_QUESTION_ID);
+    toggleQuestionBookmarkStatus();
+    openNavigationSidebar();
+    const initialOrder = ["Orders, Count", "Orders"];
+    verifyBookmarksOrder(initialOrder);
+    moveBookmark("Orders, Count", 100, {
+      putAlias: "failedToReorderBookmarks",
+    });
+    verifyBookmarksOrder(initialOrder);
+  });
+});

--- a/e2e/test/scenarios/organization/helpers/bookmark-helpers.ts
+++ b/e2e/test/scenarios/organization/helpers/bookmark-helpers.ts
@@ -1,0 +1,57 @@
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { moveDnDKitElement, navigationSidebar } from "e2e/support/helpers";
+
+export const toggleQuestionBookmarkStatus = ({ wasSelected = false } = {}) => {
+  const iconName = wasSelected ? "bookmark_filled" : "bookmark";
+  cy.findByTestId("qb-header-action-panel").within(() => {
+    cy.icon(iconName).click();
+  });
+  cy.wait("@toggleBookmark");
+};
+
+export const createAndBookmarkQuestion = (questionName: string) => {
+  createSimpleQuestion(questionName);
+  toggleQuestionBookmarkStatus();
+};
+
+export const createSimpleQuestion = (name: string) =>
+  cy.createQuestion(
+    {
+      name,
+      display: "table",
+      database: SAMPLE_DB_ID,
+      query: { "source-table": SAMPLE_DATABASE.ORDERS_ID },
+      visualization_settings: {},
+    },
+    { visitQuestion: true },
+  );
+
+export const verifyBookmarksOrder = (expectedOrder: string[]) => {
+  navigationSidebar()
+    .findByLabelText(/Bookmarks/)
+    .within(() => {
+      cy.get("li")
+        .should("have.length", expectedOrder.length)
+        .each((bookmark, index) => {
+          cy.wrap(bookmark).contains(expectedOrder[index]);
+        });
+    });
+};
+
+export const moveBookmark = (
+  name: string,
+  verticalDistance: number,
+  {
+    /** Alias for PUT request endpoint */
+    putAlias = "reorderBookmarks",
+  } = {},
+) => {
+  moveDnDKitElement(
+    navigationSidebar()
+      .findByLabelText(/Bookmarks/)
+      .findByText(name),
+    { vertical: verticalDistance },
+  );
+  cy.wait(`@${putAlias}`);
+};

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BookmarkList/BookmarkList.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BookmarkList/BookmarkList.tsx
@@ -44,7 +44,7 @@ interface CollectionSidebarBookmarksProps {
   }: {
     newIndex: number;
     oldIndex: number;
-  }) => void;
+  }) => Promise<any>;
   onToggle: (isExpanded: boolean) => void;
   initialState: "expanded" | "collapsed";
 }
@@ -135,12 +135,12 @@ const BookmarkList = ({
   }, []);
 
   const handleSortEnd = useCallback(
-    (input: DragEndEvent) => {
+    async (input: DragEndEvent) => {
       document.body.classList.remove(GrabberS.grabbing);
       setIsSorting(false);
       const newIndex = bookmarks.findIndex(b => b.id === input.over?.id);
       const oldIndex = bookmarks.findIndex(b => b.id === input.active.id);
-      reorderBookmarks({ newIndex, oldIndex });
+      await reorderBookmarks({ newIndex, oldIndex });
     },
     [reorderBookmarks, bookmarks],
   );

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarContainer.tsx
@@ -61,7 +61,7 @@ interface Props extends MainNavbarProps {
   allError: boolean;
   allFetched: boolean;
   logout: () => void;
-  onReorderBookmarks: (bookmarks: Bookmark[]) => void;
+  onReorderBookmarks: (bookmarks: Bookmark[]) => Promise<any>;
   onChangeLocation: (location: LocationDescriptor) => void;
 }
 
@@ -133,14 +133,14 @@ function MainNavbarContainer({
   }, [rootCollection, trashCollection, collections, currentUser]);
 
   const reorderBookmarks = useCallback(
-    ({ newIndex, oldIndex }: { newIndex: number; oldIndex: number }) => {
+    async ({ newIndex, oldIndex }: { newIndex: number; oldIndex: number }) => {
       const newBookmarks = [...bookmarks];
       const movedBookmark = newBookmarks[oldIndex];
 
       newBookmarks.splice(oldIndex, 1);
       newBookmarks.splice(newIndex, 0, movedBookmark);
 
-      onReorderBookmarks(newBookmarks);
+      await onReorderBookmarks(newBookmarks);
     },
     [bookmarks, onReorderBookmarks],
   );

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
@@ -60,7 +60,7 @@ type Props = {
   }: {
     newIndex: number;
     oldIndex: number;
-  }) => void;
+  }) => Promise<any>;
 };
 const OTHER_USERS_COLLECTIONS_URL = Urls.otherUsersPersonalCollections();
 const ADD_YOUR_OWN_DATA_URL = "/admin/databases/create";


### PR DESCRIPTION
On master, when you drag bookmarks to reorder them, the correct order is not saved, and bookmarks appear to be shuffled almost randomly if you reorder them more than once.

On this branch, bookmarks are reordered correctly and optimistically.

![Kapture 2024-07-19 at 19 59 39](https://github.com/user-attachments/assets/ce6c74d3-8ed9-482c-bc32-90a66d3945c4)

Closes #45635

Known problem: There is some flickering, as the GIF above shows

[x] e2e tests added