### PR TITLE
Fix typo in the (segment) Revision logic

### DIFF
--- a/frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx
@@ -32,7 +32,7 @@ export default class Revision extends Component {
           return t`edited the title`;
         case "description":
           return t`edited the description`;
-        case "defintion":
+        case "definition":
           return t`edited the ` + objectName;
       }
     }


### PR DESCRIPTION
I ran into this typo that actually affects the logic of the `Revision` component. This PR fixes it.

This is only used for the segment revision history. Not sure if it's worth backporting?