### PR TITLE
Use automation token for checkout in docs update action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -537,6 +537,8 @@ jobs:
               }
             });
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
       - name: update releases.md
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
The automation for updating the version list failed on the CLA check. This uses the automation token for checkout as well, which should resolve the issue. see pr: https://github.com/metabase/metabase/pull/45658



see failure: https://github.com/metabase/metabase/pull/45658/checks?check_run_id=27522572368