### PR TITLE
Sync Snowflake `VARIANT` type as new `:type/SnowflakeVariant`

### DIFF
--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -194,7 +194,7 @@
         (maybe-add-role-to-spec-url details))))
 
 (defmethod sql-jdbc.sync/database-type->base-type :snowflake
-  [_ base-type]
+  [_driver base-type]
   ({:NUMBER                     :type/Number
     :DECIMAL                    :type/Decimal
     :NUMERIC                    :type/Number
@@ -230,7 +230,8 @@
     :TIMESTAMPNTZ               :type/DateTime
     ;; timestamp with time zone normalized to UTC, similar to Postgres
     :TIMESTAMPTZ                :type/DateTimeWithLocalTZ
-    :VARIANT                    :type/*
+    ;; `VARIANT` is allowed to be any type. See https://docs.snowflake.com/en/sql-reference/data-types-semistructured
+    :VARIANT                    :type/SnowflakeVariant
     ;; Maybe also type *
     :OBJECT                     :type/Dictionary
     :ARRAY                      :type/*} base-type))

--- a/src/metabase/lib/convert.cljc
+++ b/src/metabase/lib/convert.cljc
@@ -413,7 +413,7 @@
              :get-week :get-year :get-month :get-day :get-hour
              :get-minute :get-second :get-quarter
              :datetime-add :datetime-subtract
-             :concat :substring :replace :regexextract :regex-match-first
+             :concat :substring :replace :regex-match-first
              :length :trim :ltrim :rtrim :upper :lower]]
   (lib.hierarchy/derive tag ::expression))
 

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -169,7 +169,7 @@
   concat
   substring
   replace
-  regexextract
+  regex-match-first
   length
   trim
   ltrim

--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -276,7 +276,6 @@
 (lib.common/defop concat [s1 s2 & more])
 (lib.common/defop substring [s start end])
 (lib.common/defop replace [s search replacement])
-(lib.common/defop regexextract [s regex])
 (lib.common/defop regex-match-first [s regex])
 (lib.common/defop length [s])
 (lib.common/defop trim [s])

--- a/src/metabase/lib/schema/expression/string.cljc
+++ b/src/metabase/lib/schema/expression/string.cljc
@@ -18,11 +18,12 @@
 (mbql-clause/define-tuple-mbql-clause :length :- :type/Integer
   [:schema [:ref ::expression/string]])
 
-(doseq [op [:regexextract :regex-match-first]]
-  (mbql-clause/define-tuple-mbql-clause op :- :type/Text
-    #_str [:schema [:ref ::expression/string]]
-    ;; TODO regex type?
-    #_regex [:schema [:ref ::expression/string]]))
+;;; `regex-match-first` is called `regexextract` in the FE QB expression editor. See
+;;; https://metaboat.slack.com/archives/C04DN5VRQM6/p1721158713517859
+(mbql-clause/define-tuple-mbql-clause :regex-match-first :- :type/Text
+  #_str [:schema [:ref ::expression/string]]
+  ;; TODO regex type?
+  #_regex [:schema [:ref ::expression/string]])
 
 (mbql-clause/define-tuple-mbql-clause :replace :- :type/Text
   #_str [:schema [:ref ::expression/string]]

--- a/src/metabase/types.cljc
+++ b/src/metabase/types.cljc
@@ -253,6 +253,17 @@
 (derive :type/DruidHyperUnique :type/field-values-unsupported)
 (derive :type/DruidJSON :type/field-values-unsupported)
 
+;;; The Snowflake `VARIANT` type is allowed to be anything, so just mark it as deriving from the core root types so
+;;; we're allowed to use any sort of filter with it (whether it makes sense or not). See
+;;; https://docs.snowflake.com/en/sql-reference/data-types-semistructured
+(doseq [t [:type/Number
+           :type/Text
+           :type/Temporal
+           :type/Boolean
+           :type/Collection
+           :type/field-values-unsupported]]
+  (derive :type/SnowflakeVariant t))
+
 ;;; Text-Like Types: Things that should be displayed as text for most purposes but that *shouldn't* support advanced
 ;;; filter options like starts with / contains
 

--- a/test/metabase/lib/expression_test.cljc
+++ b/test/metabase/lib/expression_test.cljc
@@ -72,7 +72,7 @@
                           #_#_(lib/concat string-field "abc") :type/Text
                           (lib/substring string-field 0 10) :type/Text
                           (lib/replace string-field "abc" "def") :type/Text
-                          (lib/regexextract string-field "abc") :type/Text
+                          (lib/regex-match-first string-field "abc") :type/Text
                           (lib/length string-field) :type/Integer
                           (lib/trim string-field) :type/Text
                           (lib/rtrim string-field) :type/Text

--- a/test/metabase/sync/analyze/fingerprint_test.clj
+++ b/test/metabase/sync/analyze/fingerprint_test.clj
@@ -27,15 +27,19 @@
          (#'sync.fingerprint/base-types->descendants #{:type/ImageURL :type/AvatarURL}))))
 
 (def ^:private skip-fingerprint-base-types
-  #{"type/*"
-    "type/Structured"
-    "type/SerializedJSON"
-    "type/JSON"
-    "type/Dictionary"
-    "type/Array"
-    "type/Collection"
-    "type/XML"
-    "type/DruidJSON"})
+  (into #{"type/*"
+          "type/Structured"
+          "type/SerializedJSON"
+          "type/JSON"
+          "type/Dictionary"
+          "type/Array"
+          "type/Collection"
+          "type/XML"}
+        ;; collection and structured subtypes never get fingerprinted
+        (comp (mapcat descendants)
+              (map u/qualified-name))
+        [:type/Collection
+         :type/Structured]))
 
 (deftest ^:parallel honeysql-for-fields-that-need-fingerprint-updating-test
   (testing (str "Make sure we generate the correct HoneySQL WHERE clause based on whatever is in "


### PR DESCRIPTION
Snowflake has a `VARIANT` type that is untyped but can be any type of value.

Probably by accident in < 49 we allowed you to use custom expressions that take `type/Text` arguments like `regexextract` (called `regex-match-first` under the hood) against `VARIANT` columns. In 49+ we have better type checking and only let you use `regex-match-first` against `type/Text` columns, so these queries stopped working.

The fix here was to sync `VARIANT` as a new base type called `:type/SnowflakeVariant` that derives from `:type/Text` as well as the other major core base types like `:type/Number` and `:type/Temporal` so you should theoretically be allowed to use with anything in the custom expression editor (whether or not this makes sense is not something we can currently check unfortunately since the column is untyped). 

Fixes #45206

This fix will not take effect until the database is re-synced.

Also I noticed that we have an MLv2 function and schema for a `:regexextract` clause, even tho it doesn't actually exist, so I fixed that while I was at it. 

Fixes #45672