### PR TITLE
fix tab actions not working in firefox

### DIFF
--- a/e2e/support/helpers/e2e-dashboard-helpers.js
+++ b/e2e/support/helpers/e2e-dashboard-helpers.js
@@ -114,9 +114,18 @@ export function saveDashboard({
   buttonLabel = "Save",
   editBarText = "You're editing this dashboard.",
   waitMs = 1,
+  awaitRequest = true,
 } = {}) {
+  cy.intercept("PUT", "/api/dashboard/*").as("saveDashboardCards");
   cy.button(buttonLabel).click();
-  cy.findByText(editBarText).should("not.exist");
+
+  if (awaitRequest) {
+    cy.wait("@saveDashboardCards").then(() => {
+      cy.findByText(editBarText).should("not.exist");
+    });
+  } else {
+    cy.findByText(editBarText).should("not.exist");
+  }
   cy.wait(waitMs); // this is stupid but necessary to due to the dashboard resizing and detaching elements
 }
 

--- a/e2e/test/scenarios/collections/revision-history.cy.spec.js
+++ b/e2e/test/scenarios/collections/revision-history.cy.spec.js
@@ -41,9 +41,9 @@ describe("revision history", () => {
       });
 
       // Save the dashboard without any changes made to it (TODO: we should probably disable "Save" button in the first place)
-      saveDashboard();
+      saveDashboard({ awaitRequest: false });
       editDashboard();
-      saveDashboard();
+      saveDashboard({ awaitRequest: false });
 
       openRevisionHistory();
 

--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -674,7 +674,7 @@ describe("scenarios > dashboard > parameters", () => {
 
     it("should not fetch dashcard data when nothing changed on save", () => {
       editDashboard();
-      saveDashboard();
+      saveDashboard({ awaitRequest: false });
 
       cy.get("@dashcardRequestSpy").should("have.callCount", 0);
     });

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -207,7 +207,7 @@ describe("scenarios > dashboard", () => {
           cy.button("Create").click();
         });
 
-        saveDashboard();
+        saveDashboard({ awaitRequest: false });
         cy.findByTestId("app-bar").findByText(NEW_COLLECTION);
       },
     );

--- a/e2e/test/scenarios/dashboard/tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/tabs.cy.spec.js
@@ -48,6 +48,7 @@ import {
   openStaticEmbeddingModal,
   publishChanges,
   visitIframe,
+  duplicateTab,
 } from "e2e/support/helpers";
 import { createMockDashboardCard } from "metabase-types/api/mocks";
 
@@ -772,6 +773,34 @@ describe("scenarios > dashboard > tabs", () => {
     cy.findAllByTestId("tab-button-input-wrapper").eq(0).findByText(longName);
     cy.findAllByTestId("tab-button-input-wrapper").eq(1).findByText("Tab 1");
     cy.findAllByTestId("tab-button-input-wrapper").eq(2).findByText("Tab 2");
+  });
+
+  it("should allow users to duplicate and delete tabs more than once (#45364)", () => {
+    visitDashboard(ORDERS_DASHBOARD_ID);
+    editDashboard();
+
+    duplicateTab("Tab 1");
+
+    cy.findAllByRole("tab").eq(0).should("have.text", "Tab 1");
+    cy.findAllByRole("tab").eq(1).should("have.text", "Copy of Tab 1");
+
+    duplicateTab("Tab 1");
+
+    cy.findAllByRole("tab").eq(0).should("have.text", "Tab 1");
+    cy.findAllByRole("tab").eq(1).should("have.text", "Copy of Tab 1");
+    cy.findAllByRole("tab").eq(2).should("have.text", "Copy of Tab 1");
+
+    deleteTab("Tab 1");
+
+    cy.findAllByRole("tab").eq(0).should("have.text", "Copy of Tab 1");
+    cy.findAllByRole("tab").eq(1).should("have.text", "Copy of Tab 1");
+
+    cy.findAllByRole("tab").eq(0).findByRole("button").click();
+    popover().within(() => {
+      cy.findByText("Delete").click();
+    });
+
+    cy.findByRole("tab").should("have.text", "Copy of Tab 1");
   });
 });
 

--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -2823,7 +2823,7 @@ describe("issue 44288", () => {
     visitDashboard("@dashboardId");
     editDashboard();
     verifyMapping();
-    saveDashboard();
+    saveDashboard({ awaitRequest: false });
     verifyFilter();
     cy.signOut();
 

--- a/frontend/src/metabase/core/components/TabButton/TabButton.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.tsx
@@ -1,5 +1,4 @@
 import type { UniqueIdentifier } from "@dnd-kit/core";
-import { useSortable } from "@dnd-kit/sortable";
 import { css, type Theme } from "@emotion/react";
 import styled from "@emotion/styled";
 import type {
@@ -259,19 +258,9 @@ export function RenameableTabButton({
     ];
   }
 
-  const dragLabel = (s: string) => {
-    if (s.length < 20) {
-      return s;
-    } else {
-      return `${s.slice(0, 17)}...`;
-    }
-  };
-
-  const { isDragging } = useSortable({ id: props.value });
-
   return (
     <RenameableTabButtonStyled
-      label={isDragging ? dragLabel(label) : label}
+      label={label}
       isSelected={isSelected}
       isRenaming={canRename && isRenaming}
       canRename={canRename}

--- a/frontend/src/metabase/core/components/TabRow/TabRow.tsx
+++ b/frontend/src/metabase/core/components/TabRow/TabRow.tsx
@@ -22,6 +22,7 @@ import { Icon } from "metabase/ui";
 import type { TabListProps } from "../TabList/TabList";
 
 import { ScrollButton, TabList } from "./TabRow.styled";
+import { tabsCollisionDetection } from "./collision-detection";
 
 interface TabRowProps<T> extends TabListProps<T> {
   width?: number | null;
@@ -103,6 +104,7 @@ function TabRowInner<T>({
         onDragEnd={onDragEnd}
         modifiers={[restrictToHorizontalAxis, restrictToParentElement]}
         sensors={[pointerSensor, mouseSensor]}
+        collisionDetection={tabsCollisionDetection}
       >
         <SortableContext
           items={itemIds ?? []}

--- a/frontend/src/metabase/core/components/TabRow/collision-detection.ts
+++ b/frontend/src/metabase/core/components/TabRow/collision-detection.ts
@@ -1,0 +1,65 @@
+import type { CollisionDetection } from "@dnd-kit/core";
+
+export const tabsCollisionDetection: CollisionDetection = ({
+  active,
+  collisionRect,
+  droppableRects,
+  droppableContainers,
+}) => {
+  // This is the same as item as `collisionRect`, but unlike `collectionRect`,
+  // which updates in realtime, `activeRect` retains the original properties of
+  // the list before dragging. E.g. `collectionRect.right` is the right value of
+  // where the user has dragged the tab to, but `activeRect.right` is the right
+  // value from where it orginally was.
+  const activeRect = droppableRects.get(active.id);
+  if (!activeRect) {
+    return [];
+  }
+  const isDraggingRight = collisionRect.right > activeRect.right;
+
+  const sortedContainers = droppableContainers.sort((a, b) => {
+    const rectA = droppableRects.get(a.id);
+    const rectB = droppableRects.get(b.id);
+
+    // This should never happen, there should be a rect for each container
+    if (!rectA || !rectB) {
+      return 0;
+    }
+
+    if (isDraggingRight) {
+      return rectA.right - rectB.right;
+    }
+    return rectB.left - rectA.left;
+  });
+
+  const filteredContainers = sortedContainers.filter(container => {
+    if (container.id === active.id) {
+      return false;
+    }
+
+    const rect = droppableRects.get(container.id);
+    // This should never happen, there should be a rect for each container
+    if (!rect) {
+      return false;
+    }
+
+    if (isDraggingRight) {
+      return rect.right >= collisionRect.right;
+    }
+    return rect.left <= collisionRect.left;
+  });
+
+  // When dragging a tab to the very right, `filteredContainers` will be empty,
+  // so we'll return the rightmost tab from `sortedContainers`.
+  const overContainer =
+    filteredContainers.length === 0
+      ? sortedContainers[sortedContainers.length - 1]
+      : filteredContainers[0];
+
+  return [
+    {
+      id: overContainer.id,
+      data: { droppableContainer: overContainer, value: 0 },
+    },
+  ];
+};


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/45364

### Description

The root cause of the issue is a bug in React 18: https://github.com/facebook/react/issues/25282. Our issue only surfaced after v50 release since we just upgraded to React 18. What happened was `TabButton` would re-render excessively when clicking on tabs or tab menu items, due to it's use of the `isDragging` value from the `useSortable` hook. These re-renders caused the `onClick` handler in `TabButtonMenu` to be lost, which is why nothing was happening when the user tried to duplicate or delete a tab. For some unknown reason, this bug would only appear in Firefox, not Chrome or Safari.

To resolve the issue, we eliminate the excessive re-renders by no longer using the `useSortable` hook and its `isDragging` value in `TabButton`. This boolean was originally used to truncate the name of a tab to allow it to be dragged to the end of the tab list. Now, instead of truncating the name to make the tab smaller and draggable to the end of the tab list, we instead implement a custom collision detection algorithm to provide to dnd-kit, that will use the edge of the tab to determine collision, and thus allow the user to drag a tab with a long name to either end, without needing to truncate the name using the `isDragging` value. 


### How to verify

Follow repro steps from the issue using Firefox, confirm it no longer happens. Also confirm you can drag a tab with a long name to either end, and dragging tabs to re-order generally still works.

### Demo

https://github.com/user-attachments/assets/8ae41b56-42e2-40d0-96b5-e3df3d525731

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
