### PR TITLE
[perf] Properly buffer while streaming JSON to API responses

### DIFF
--- a/src/metabase/query_processor/streaming/json.clj
+++ b/src/metabase/query_processor/streaming/json.clj
@@ -3,6 +3,8 @@
   response with all the metadata for `:api`."
   (:require
    [cheshire.core :as json]
+   [cheshire.factory :as json.factory]
+   [cheshire.generate :as json.generate]
    [java-time.api :as t]
    [metabase.formatter :as formatter]
    [metabase.query-processor.streaming.common :as common]
@@ -10,6 +12,7 @@
    [metabase.shared.models.visualization-settings :as mb.viz]
    [metabase.util.date-2 :as u.date])
   (:import
+   (com.fasterxml.jackson.core JsonGenerator)
    (java.io BufferedWriter OutputStream OutputStreamWriter)
    (java.nio.charset StandardCharsets)))
 
@@ -75,43 +78,62 @@
   ([_]   (qp.si/stream-options :api nil))
   ([_ _] {:content-type "application/json; charset=utf-8"}))
 
-(defn- map->serialized-json-kvs
-  "{:a 100, :b 200} ; -> \"a\":100,\"b\":200"
-  ^String [m]
-  (when (seq m)
-    (let [s (json/generate-string m)]
-      (.substring s 1 (dec (count s))))))
+(defn- generate-map-contents [^JsonGenerator jgen maplike]
+  (reduce (fn [^JsonGenerator jg kv]
+            (let [k (key kv)
+                  v (val kv)]
+              (.writeFieldName jg (if (keyword? k)
+                                    (subs (str k) 1)
+                                    (str k)))
+              (json.generate/generate jg v json.factory/default-date-format nil nil)
+              jg))
+          jgen maplike))
+
+(defn- make-generator ^JsonGenerator [^OutputStream os]
+  (-> os
+      (OutputStreamWriter. StandardCharsets/UTF_8)
+      (BufferedWriter.)
+      json/create-generator))
 
 (defmethod qp.si/streaming-results-writer :api
   [_ ^OutputStream os]
-  (let [writer (BufferedWriter. (OutputStreamWriter. os StandardCharsets/UTF_8))]
+  ;; Cheshire supports a custom encoding API that we would like to use for streaming, say by generating JSON on
+  ;; `{:data {:rows (a/chan), ...}}` and having a custom encoder for the channel.
+  ;; But there's a problem: the `metadata that arrives in `finish!` adds new keys to both the `:data` and outer maps,
+  ;; and there's no way to handle that mutation with a custom encoder.
+
+  ;; So instead we would like to use Cheshire's streaming generator API. But it is very eager to `(.flush writer)`.
+  ;; That results in sending 3 + N packets over the wire, where N is the number of rows in the response! That's a lot
+  ;; of TCP overhead, which causes download time slowdowns, especially with complex load balancing etc. See #34795.
+
+  ;; And so that leads to this low-level code that mixes calls to the underlying Jackson Java library with calls to
+  ;; Cheshire's streaming API for handling Clojure data. It duplicates some Cheshire logic for generating maps, since
+  ;; Cheshire doesn't have an API which generate in key-value pairs of a map without including the `{}`s.
+  (let [jgen (make-generator os)]
     (reify qp.si/StreamingResultsWriter
       (begin! [_ _ _]
-        (.write writer "{\"data\":{\"rows\":[\n"))
+        (doto jgen
+          (.writeStartObject)
+          (.writeFieldName "data")
+          (.writeStartObject)
+          (.writeFieldName "rows")
+          (.writeStartArray)))
 
-      (write-row! [_ row row-num _ _]
-        (when-not (zero? row-num)
-          (.write writer ",\n"))
-        (json/generate-stream row writer)
-        (.flush writer))
+      (write-row! [_ row _ _ _]
+        (json.generate/generate jgen row json.factory/default-date-format nil nil))
 
       (finish! [_ {:keys [data], :as metadata}]
-        (let [data-kvs-str           (map->serialized-json-kvs data)
-              other-metadata-kvs-str (map->serialized-json-kvs (dissoc metadata :data))]
-          ;; close data.rows
-          (.write writer "\n]")
-          ;; write any remaining keys in data
-          (when (seq data-kvs-str)
-            (.write writer ",\n")
-            (.write writer data-kvs-str))
-          ;; close data
-          (.write writer "}")
-          ;; write any remaining top-level keys
-          (when (seq other-metadata-kvs-str)
-            (.write writer ",\n")
-            (.write writer other-metadata-kvs-str))
-          ;; close top-level map
-          (.write writer "}"))
-        (.flush writer)
-        (.flush os)
-        (.close writer)))))
+        (.writeEndArray jgen)
+        ;; write any remaining keys in data
+        (when-not (empty? data)
+          (generate-map-contents jgen data))
+        ;; close data
+        (.writeEndObject jgen)
+        ;; write any remaining top-level keys
+        (when-let [other-metadata (not-empty (dissoc metadata :data))]
+          (generate-map-contents jgen other-metadata))
+        ;; close top-level map
+        (doto jgen
+          (.writeEndObject)
+          (.flush)
+          (.close))))))


### PR DESCRIPTION
Fixes #34795. 

### Description

Previously, due to over-eager `.flush()` calls in Cheshire, we were
flushing the output stream for every `data.rows` entry. Typically this
resulted in 3 + N TCP packets sent, where N is the number of rows being
returned.

This PR rebuilds how we stream the JSON responses to avoid extra
`.flush()` calls. For the unit test in this PR, that reduced the number
of packets sent over the wire from 37524 to 4.

### How to verify

If you're comfortable using Wireshark or similar tools, send a query for a lot of
rows and find the `/query` call, then follow its TCP stream. You'll see 1 client packet and thousands of
server packets before this PR, and a handful of server packets with it.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
