### PR TITLE
Change the error message for offset in custom columns

### DIFF
--- a/e2e/test/scenarios/question/offset.cy.spec.ts
+++ b/e2e/test/scenarios/question/offset.cy.spec.ts
@@ -94,7 +94,7 @@ describe("scenarios > question > offset", () => {
 
       popover().within(() => {
         cy.button("Done").should("be.disabled");
-        cy.findByText("OFFSET is not supported in custom expressions").should(
+        cy.findByText("OFFSET is not supported in custom columns").should(
           "exist",
         );
       });

--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -486,7 +486,7 @@
            :friendly true})
         (when (and (= expression-mode :expression)
                    (lib.util.match/match-one expr :offset))
-          {:message  (i18n/tru "OFFSET is not supported in custom expressions")
+          {:message  (i18n/tru "OFFSET is not supported in custom columns")
            :friendly true})
         (when (and (= expression-mode :expression)
                    (lib.util.match/match-one expr :offset)

--- a/test/metabase/lib/expression_test.cljc
+++ b/test/metabase/lib/expression_test.cljc
@@ -518,7 +518,7 @@
 (deftest ^:parallel diagnose-expression-test-4-offset-not-allowed-in-expressions
   (testing "adding/editing an expression using offset is not allowed"
     (let [query (lib/query meta/metadata-provider (meta/table-metadata :orders))]
-      (is (=? {:message "OFFSET is not supported in custom expressions"}
+      (is (=? {:message "OFFSET is not supported in custom columns"}
               (lib.expression/diagnose-expression query 0 :expression
                                                   (lib/offset (meta/field-metadata :orders :subtotal) -1)
                                                   nil))))))


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/45327

From `OFFSET is not supported in custom expressions` to `OFFSET is not supported in custom columns`