### PR TITLE
remove migration linter to prevent us from using deleteCascade in addColumn

### DIFF
--- a/bin/lint-migrations-file/src/change_set/strict.clj
+++ b/bin/lint-migrations-file/src/change_set/strict.clj
@@ -146,18 +146,9 @@
    (not-any? change-types-requiring-preconditions (mapcat keys changes))
    (contains? change-set :preConditions)))
 
-(defn- disallow-delete-cascade-with-add-column
-  "Returns false if addColumn changeSet uses deleteCascade. See Metabase issue #14321"
-  [{:keys [changes]}]
-  (let [[change-type {:keys [columns]}] (ffirst changes)]
-    (if (= :addColumn change-type)
-      (not-any? #(-> % :column :constraints :deleteCascade) columns)
-      true)))
-
 (s/def ::change-set
   (s/and
    rollback-present-when-required?
    precondition-present-when-required?
-   disallow-delete-cascade-with-add-column
    (s/keys :req-un [::id ::author ::changes ::comment]
            :opt-un [::preConditions])))


### PR DESCRIPTION
This linter was added in https://github.com/metabase/metabase/pull/27234 to force us to use 2 migrations to add a FK because liquibase didn't respect the `onDeleteCascade: true` setting. Now the bug is fixed upstream and we can stop adding a FK like this


```yaml
- changeSet:
      id: v50.2024-07-02T16:49:29
      author: adam-james
      comment: Add dashboard_id column to user_parameter_value to keep values unique per dashboard
      changes:
        - addColumn:
            columns:
              - column:
                  name: dashboard_id
                  type: int
                  remarks: The ID of the dashboard
            tableName: user_parameter_value

  - changeSet:
      id: v50.2024-07-02T16:55:42
      author: adam-james
      comment: Add fk constraint to user_parameter_value.dashboard_id
      changes:
        - addForeignKeyConstraint:
            baseTableName: user_parameter_value
            baseColumnNames: dashboard_id
            referencedTableName: report_dashboard
            referencedColumnNames: id
            constraintName: fk_user_parameter_value_dashboard_id
            nullable: false
            deleteCascade: true
```

and just use one migration like this

```yaml
  - changeSet:
      id: v51.2024-07-08T10:00:01
      author: qnkhuat
      comment: Create pulse_channel.channel_id
      preConditions:
        - onFail: MARK_RAN
        - not:
            - columnExists:
                tableName: pulse_channel
                columnName: channel_id
      changes:
        - addColumn:
            tableName: pulse_channel
            columns:
              - column:
                  name: channel_id
                  type: integer
                  remarks: The channel ID
                  constraints:
                    nullable: true
                    referencedTableName: channel
                    referencedColumnNames: id
                    foreignKeyName: fk_pulse_channel_channel_id
                    deleteCascade: true
```

This is the SQL generated for such migration
```clojure
metabase.pulse=> (println (:forward (dev.migrate/migration-sql-by-id "v51.2024-07-08T10:00:01" :postgres)))
ALTER TABLE pulse_channel ADD channel_id INTEGER;
ALTER TABLE pulse_channel ADD CONSTRAINT fk_pulse_channel_channel_id FOREIGN KEY (channel_id) REFERENCES channel (id) ON DELETE CASCADE;
COMMENT ON COLUMN pulse_channel.channel_id IS 'The channel ID';
nil
metabase.pulse=> (println (:forward (dev.migrate/migration-sql-by-id "v51.2024-07-08T10:00:01" :mysql)))
ALTER TABLE pulse_channel ADD channel_id INT NULL COMMENT 'The channel ID';
ALTER TABLE pulse_channel ADD CONSTRAINT fk_pulse_channel_channel_id FOREIGN KEY (channel_id) REFERENCES channel (id) ON DELETE CASCADE;
nil
metabase.pulse=> (println (:forward (dev.migrate/migration-sql-by-id "v51.2024-07-08T10:00:01" :h2)))
ALTER TABLE pulse_channel ADD channel_id INT;
ALTER TABLE pulse_channel ADD CONSTRAINT fk_pulse_channel_channel_id FOREIGN KEY (channel_id) REFERENCES channel (id) ON DELETE CASCADE;
COMMENT ON COLUMN pulse_channel.channel_id IS 'The channel ID';
nil
```