### PR TITLE
Add model icon to model section of a collection

### DIFF
--- a/frontend/src/metabase/collections/components/PinnedItemOverview/PinnedItemOverview.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemOverview/PinnedItemOverview.tsx
@@ -188,6 +188,7 @@ function PinnedItemOverview({
           <div>
             <SectionTitle
               title={t`Models`}
+              icon="model"
               description={
                 isRootCollection(collection)
                   ? t`Start new explorations here`


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/43659
Pursuant of #44783

### Description

Adds a model icon to model section of a collection.

### How to verify

- Visit a collection with a models section, see that the icon is there

### Demo

Before (see no icon before "Models" title)
<img width="1492" alt="Screenshot 2024-07-16 at 9 52 51 PM" src="https://github.com/user-attachments/assets/79af872a-fd8c-40d9-a791-a8e46127818a">

After (see icon before "Models" title)
<img width="1490" alt="Screenshot 2024-07-16 at 9 53 08 PM" src="https://github.com/user-attachments/assets/0a26075f-b0da-447a-b5b8-a61c991e6efc">

### Checklist

~- [ ] Tests have been added/updated to cover changes in this PR~
Skipping since it's a really simple change.
