### PR TITLE
Indicate in-progress exports

### DIFF
--- a/e2e/support/helpers/e2e-downloads-helpers.ts
+++ b/e2e/support/helpers/e2e-downloads-helpers.ts
@@ -166,3 +166,14 @@ function getEndpoint({
     method: "POST",
   };
 }
+
+export function dismissDownloadStatus() {
+  cy.findByTestId("status-root-container").within(() => {
+    cy.findByRole("status").within(() => {
+      cy.findAllByText("Download completed");
+      cy.findByLabelText("Dismiss").click();
+    });
+
+    cy.findByRole("status").should("not.exist");
+  });
+}

--- a/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
@@ -27,6 +27,7 @@ import {
   setEmbeddingParameter,
   assertEmbeddingParameter,
   multiAutocompleteInput,
+  dismissDownloadStatus,
 } from "e2e/support/helpers";
 import { createMockParameter } from "metabase-types/api/mocks";
 
@@ -526,6 +527,7 @@ describe("scenarios > embedding > dashboard parameters", () => {
         assertSheetRowsCount(54)(sheet);
       },
     );
+    dismissDownloadStatus();
   });
 });
 

--- a/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
+++ b/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
@@ -30,6 +30,7 @@ import {
   showDashboardCardActions,
   getDashboardCard,
   multiAutocompleteInput,
+  dismissDownloadStatus,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -384,15 +385,4 @@ function assertOrdersExport(length) {
       assertSheetRowsCount(length)(sheet);
     },
   );
-}
-
-function dismissDownloadStatus() {
-  cy.findByTestId("status-root-container").within(() => {
-    cy.findByRole("status").within(() => {
-      cy.findAllByText("Download completed");
-      cy.findByLabelText("Dismiss").click();
-    });
-
-    cy.findByRole("status").should("not.exist");
-  });
 }

--- a/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
+++ b/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
@@ -81,6 +81,8 @@ describe("scenarios > question > download", () => {
         expect(sheet["A1"].v).to.eq("Count");
         expect(sheet["A2"].v).to.eq(18760);
       });
+
+      dismissDownloadStatus();
     });
   });
 
@@ -124,6 +126,8 @@ describe("scenarios > question > download", () => {
         },
       );
 
+      dismissDownloadStatus();
+
       downloadAndAssert(
         {
           ...opts,
@@ -148,6 +152,8 @@ describe("scenarios > question > download", () => {
 
       assertOrdersExport(18760);
 
+      dismissDownloadStatus();
+
       editDashboard();
 
       setFilter("ID");
@@ -171,6 +177,8 @@ describe("scenarios > question > download", () => {
       });
 
       assertOrdersExport(1);
+
+      dismissDownloadStatus();
     });
 
     it("should allow downloading parameterized cards opened from dashboards as a user with no self-service permission (metabase#20868)", () => {
@@ -244,6 +252,8 @@ describe("scenarios > question > download", () => {
                 assertSheetRowsCount(1)(sheet);
               },
             );
+
+            dismissDownloadStatus();
           });
         });
       });
@@ -374,4 +384,15 @@ function assertOrdersExport(length) {
       assertSheetRowsCount(length)(sheet);
     },
   );
+}
+
+function dismissDownloadStatus() {
+  cy.findByTestId("status-root-container").within(() => {
+    cy.findByRole("status").within(() => {
+      cy.findAllByText("Download completed");
+      cy.findByLabelText("Dismiss").click();
+    });
+
+    cy.findByRole("status").should("not.exist");
+  });
 }

--- a/e2e/test/scenarios/sharing/public-question.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-question.cy.spec.js
@@ -10,6 +10,7 @@ import {
   createPublicQuestionLink,
   modal,
   openNativeEditor,
+  dismissDownloadStatus,
 } from "e2e/support/helpers";
 
 const { PEOPLE } = SAMPLE_DATABASE;
@@ -91,6 +92,7 @@ describe("scenarios > public > question", () => {
           { fileType: "xlsx", questionId: id, publicUuid },
           assertSheetRowsCount(5),
         );
+        dismissDownloadStatus();
       });
     });
   });

--- a/frontend/src/metabase-types/api/database.ts
+++ b/frontend/src/metabase-types/api/database.ts
@@ -1,11 +1,11 @@
 import type { ScheduleSettings } from "./settings";
 import type { Table } from "./table";
 
-import type { ISO8601Time } from ".";
+import type { ISO8601Time, LongTaskStatus } from ".";
 
 export type DatabaseId = number;
 
-export type InitialSyncStatus = "incomplete" | "complete" | "aborted";
+export type InitialSyncStatus = LongTaskStatus;
 
 export type DatabaseSettings = {
   [key: string]: any;

--- a/frontend/src/metabase-types/api/util.ts
+++ b/frontend/src/metabase-types/api/util.ts
@@ -41,3 +41,5 @@ export interface BugReportDetails {
   "metabase-info": MetabaseInfo;
   "system-info": SystemInfo;
 }
+
+export type LongTaskStatus = "incomplete" | "complete" | "aborted";

--- a/frontend/src/metabase-types/store/downloads.ts
+++ b/frontend/src/metabase-types/store/downloads.ts
@@ -1,0 +1,8 @@
+export interface Download {
+  id: number;
+  title: string;
+  status: "complete" | "in-progress" | "error";
+  error?: string;
+}
+
+export type DownloadsState = Download[];

--- a/frontend/src/metabase-types/store/index.ts
+++ b/frontend/src/metabase-types/store/index.ts
@@ -11,3 +11,4 @@ export * from "./requests";
 export * from "./settings";
 export * from "./setup";
 export * from "./state";
+export * from "./downloads";

--- a/frontend/src/metabase-types/store/mocks/downloads.ts
+++ b/frontend/src/metabase-types/store/mocks/downloads.ts
@@ -1,0 +1,10 @@
+import type { Download } from "../downloads";
+
+export const createMockDownload = (props: Partial<Download> = {}): Download => {
+  return {
+    id: Date.now(),
+    title: "file.csv",
+    status: "in-progress",
+    ...props,
+  };
+};

--- a/frontend/src/metabase-types/store/mocks/index.ts
+++ b/frontend/src/metabase-types/store/mocks/index.ts
@@ -12,3 +12,4 @@ export * from "./settings";
 export * from "./setup";
 export * from "./state";
 export * from "./upload";
+export * from "./downloads";

--- a/frontend/src/metabase-types/store/state.ts
+++ b/frontend/src/metabase-types/store/state.ts
@@ -6,6 +6,7 @@ import type { AdminState } from "./admin";
 import type { AppState } from "./app";
 import type { AuthState } from "./auth";
 import type { DashboardState } from "./dashboard";
+import type { DownloadsState } from "./downloads";
 import type { EmbedState } from "./embed";
 import type { EntitiesState } from "./entities";
 import type { MetabotState } from "./metabot";
@@ -37,6 +38,7 @@ export interface State {
   upload: FileUploadState;
   modal: ModalName;
   undo: UndoState;
+  downloads: DownloadsState;
 }
 
 export type Dispatch<T = any> = (action: T) => unknown | Promise<unknown>;

--- a/frontend/src/metabase/lib/dom.js
+++ b/frontend/src/metabase/lib/dom.js
@@ -567,3 +567,15 @@ export function reload() {
 export function redirect(url) {
   window.location.href = url;
 }
+
+export function openSaveDialog(fileName, fileContent) {
+  const url = URL.createObjectURL(fileContent);
+  const link = document.createElement("a");
+  link.href = url;
+  link.setAttribute("download", fileName);
+  document.body.appendChild(link);
+  link.click();
+
+  URL.revokeObjectURL(url);
+  link.remove();
+}

--- a/frontend/src/metabase/public/containers/PublicApp/PublicApp.tsx
+++ b/frontend/src/metabase/public/containers/PublicApp/PublicApp.tsx
@@ -3,6 +3,7 @@ import { connect } from "react-redux";
 import { PublicError } from "metabase/public/components/PublicError";
 import { PublicNotFound } from "metabase/public/components/PublicNotFound";
 import { getErrorPage } from "metabase/selectors/app";
+import { PublicStatusListing } from "metabase/status/components/PublicStatusListing";
 import type { AppErrorDescriptor, State } from "metabase-types/store";
 
 interface OwnProps {
@@ -25,7 +26,12 @@ function PublicApp({ errorPage, children }: Props) {
   if (errorPage) {
     return errorPage.status === 404 ? <PublicNotFound /> : <PublicError />;
   }
-  return children;
+  return (
+    <>
+      {children}
+      <PublicStatusListing />
+    </>
+  );
 }
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage

--- a/frontend/src/metabase/query_builder/actions/index.ts
+++ b/frontend/src/metabase/query_builder/actions/index.ts
@@ -1,5 +1,4 @@
 export * from "./core";
-export * from "./downloading";
 export * from "./models";
 export * from "./native";
 export * from "./navigation";

--- a/frontend/src/metabase/query_builder/components/QueryDownloadPopover/use-download-data.ts
+++ b/frontend/src/metabase/query_builder/components/QueryDownloadPopover/use-download-data.ts
@@ -2,7 +2,7 @@ import { useAsyncFn } from "react-use";
 import type { AsyncFnReturn } from "react-use/lib/useAsyncFn";
 
 import { useDispatch } from "metabase/lib/redux";
-import { downloadQueryResults } from "metabase/query_builder/actions";
+import { downloadQueryResults } from "metabase/redux/downloads";
 import type Question from "metabase-lib/v1/Question";
 import type {
   DashboardId,

--- a/frontend/src/metabase/query_builder/components/QueryDownloadWidget/QueryDownloadWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryDownloadWidget/QueryDownloadWidget.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { t } from "ttag";
 
-import LoadingSpinner from "metabase/components/LoadingSpinner";
 import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
 import { Flex, Popover, Tooltip } from "metabase/ui";
 import type Question from "metabase-lib/v1/Question";
@@ -40,7 +39,7 @@ const QueryDownloadWidget = ({
 }: QueryDownloadWidgetProps) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
-  const [{ loading }, handleDownload] = useDownloadData({
+  const [, handleDownload] = useDownloadData({
     question,
     result,
     dashboardId,
@@ -54,20 +53,14 @@ const QueryDownloadWidget = ({
     <Popover opened={isPopoverOpen} onClose={() => setIsPopoverOpen(false)}>
       <Popover.Target>
         <Flex className={className}>
-          {loading ? (
-            <Tooltip label={t`Downloading…`}>
-              <LoadingSpinner size={18} />
-            </Tooltip>
-          ) : (
-            <Tooltip label={t`Download full results`}>
-              <DownloadIcon
-                onClick={() => setIsPopoverOpen(!isPopoverOpen)}
-                name="download"
-                size={20}
-                data-testid="download-button"
-              />
-            </Tooltip>
-          )}
+          <Tooltip label={t`Download full results`}>
+            <DownloadIcon
+              onClick={() => setIsPopoverOpen(!isPopoverOpen)}
+              name="download"
+              size={20}
+              data-testid="download-button"
+            />
+          </Tooltip>
         </Flex>
       </Popover.Target>
       <Popover.Dropdown p="0.75rem">

--- a/frontend/src/metabase/reducers-common.ts
+++ b/frontend/src/metabase/reducers-common.ts
@@ -7,6 +7,7 @@ import { dashboardReducers as dashboard } from "metabase/dashboard/reducers";
 import * as parameters from "metabase/parameters/reducers";
 import app from "metabase/redux/app";
 import { reducer as auth } from "metabase/redux/auth";
+import { reducer as downloads } from "metabase/redux/downloads";
 import embed from "metabase/redux/embed";
 import entities, { enhanceRequestsReducer } from "metabase/redux/entities";
 import requests from "metabase/redux/requests";
@@ -32,4 +33,5 @@ export const commonReducers = {
   modal,
   dashboard,
   parameters: combineReducers(parameters),
+  downloads,
 };

--- a/frontend/src/metabase/redux/downloads.ts
+++ b/frontend/src/metabase/redux/downloads.ts
@@ -241,6 +241,8 @@ const getChartFileName = (question: Question) => {
 };
 
 export const getDownloads = (state: State) => state.downloads;
+export const hasActiveDownloads = (state: State) =>
+  state.downloads.some(download => download.status === "in-progress");
 
 const initialState: DownloadsState = [];
 

--- a/frontend/src/metabase/redux/downloads.ts
+++ b/frontend/src/metabase/redux/downloads.ts
@@ -1,7 +1,9 @@
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 import { t } from "ttag";
 import _ from "underscore";
 
 import api, { GET, POST } from "metabase/lib/api";
+import { openSaveDialog } from "metabase/lib/dom";
 import { checkNotNull } from "metabase/lib/types";
 import * as Urls from "metabase/lib/urls";
 import { saveChartImage } from "metabase/visualizations/lib/save-chart-image";
@@ -13,6 +15,7 @@ import type {
   Dataset,
   VisualizationSettings,
 } from "metabase-types/api";
+import type { DownloadsState, State } from "metabase-types/store";
 
 export interface DownloadQueryResultsOpts {
   type: string;
@@ -34,14 +37,16 @@ interface DownloadQueryResultsParams {
   params?: URLSearchParams | string;
 }
 
-export const downloadQueryResults =
-  (opts: DownloadQueryResultsOpts) => async () => {
+export const downloadQueryResults = createAsyncThunk(
+  "metabase/downloads/downloadQueryResults",
+  async (opts: DownloadQueryResultsOpts, { dispatch }) => {
     if (opts.type === Urls.exportFormatPng) {
-      await downloadChart(opts);
+      downloadChart(opts);
     } else {
-      await downloadDataset(opts);
+      dispatch(downloadDataset({ opts, id: Date.now() }));
     }
-  };
+  },
+);
 
 const downloadChart = async ({
   question,
@@ -55,13 +60,18 @@ const downloadChart = async ({
   await saveChartImage(chartSelector, fileName);
 };
 
-const downloadDataset = async (opts: DownloadQueryResultsOpts) => {
-  const params = getDatasetParams(opts);
-  const response = await getDatasetResponse(params);
-  const fileName = getDatasetFileName(response.headers, opts.type);
-  const fileContent = await response.blob();
-  openSaveDialog(fileName, fileContent);
-};
+export const downloadDataset = createAsyncThunk(
+  "metabase/downloads/downloadDataset",
+  async ({ opts, id }: { opts: DownloadQueryResultsOpts; id: number }) => {
+    const params = getDatasetParams(opts);
+    const response = await getDatasetResponse(params);
+    const name = getDatasetFileName(response.headers, opts.type);
+    const fileContent = await response.blob();
+    openSaveDialog(name, fileContent);
+
+    return { id, name };
+  },
+);
 
 const getDatasetParams = ({
   type,
@@ -230,14 +240,47 @@ const getChartFileName = (question: Question) => {
   return `${name}-${date}.png`;
 };
 
-const openSaveDialog = (fileName: string, fileContent: Blob) => {
-  const url = URL.createObjectURL(fileContent);
-  const link = document.createElement("a");
-  link.href = url;
-  link.setAttribute("download", fileName);
-  document.body.appendChild(link);
-  link.click();
+export const getDownloads = (state: State) => state.downloads;
 
-  URL.revokeObjectURL(url);
-  link.remove();
-};
+const initialState: DownloadsState = [];
+
+const downloads = createSlice({
+  name: "metabase/downloads",
+  initialState,
+  reducers: {
+    clearAll: () => initialState,
+  },
+  extraReducers: builder => {
+    builder
+      .addCase(downloadDataset.pending, (state, action) => {
+        const title = t`Results for ${
+          action.meta.arg.opts.question.card().name
+        }`;
+        state.push({
+          id: action.meta.arg.id,
+          title,
+          status: "in-progress",
+        });
+      })
+      .addCase(downloadDataset.fulfilled, (state, action) => {
+        const download = state.find(item => item.id === action.meta.arg.id);
+        if (download) {
+          download.status = "complete";
+          download.title = action.payload.name;
+        }
+      })
+      .addCase(downloadDataset.rejected, (state, action) => {
+        const download = state.find(item => item.id === action.meta.arg.id);
+        if (download) {
+          download.status = "error";
+          download.error =
+            action.error.message ?? t`Could not download the file`;
+        }
+      });
+  },
+});
+
+export const {
+  actions: { clearAll },
+} = downloads;
+export const { reducer } = downloads;

--- a/frontend/src/metabase/redux/downloads.unit.spec.ts
+++ b/frontend/src/metabase/redux/downloads.unit.spec.ts
@@ -1,6 +1,6 @@
 import api from "metabase/lib/api";
 
-import * as downloading from "./downloading";
+import * as downloads from "./downloads";
 
 describe("getDatasetResponse", () => {
   describe("normal deployment", () => {
@@ -9,7 +9,7 @@ describe("getDatasetResponse", () => {
     it("should handle absolute URLs", () => {
       const url = `${origin}/embed/question/123.xlsx`;
 
-      expect(downloading.getDatasetDownloadUrl(url)).toBe(
+      expect(downloads.getDatasetDownloadUrl(url)).toBe(
         `${origin}/embed/question/123.xlsx`,
       );
     });
@@ -17,7 +17,7 @@ describe("getDatasetResponse", () => {
     it("should handle relative URLs", () => {
       const url = "/embed/question/123.xlsx";
 
-      expect(downloading.getDatasetDownloadUrl(url)).toBe(
+      expect(downloads.getDatasetDownloadUrl(url)).toBe(
         `/embed/question/123.xlsx`,
       );
     });
@@ -44,7 +44,7 @@ describe("getDatasetResponse", () => {
     it("should handle absolute URLs", () => {
       const url = `${origin}${subpath}/embed/question/123.xlsx`;
 
-      expect(downloading.getDatasetDownloadUrl(url)).toBe(
+      expect(downloads.getDatasetDownloadUrl(url)).toBe(
         `/embed/question/123.xlsx`,
       );
     });
@@ -52,7 +52,7 @@ describe("getDatasetResponse", () => {
     it("should handle relative URLs", () => {
       const url = "/embed/question/123.xlsx";
 
-      expect(downloading.getDatasetDownloadUrl(url)).toBe(
+      expect(downloads.getDatasetDownloadUrl(url)).toBe(
         `/embed/question/123.xlsx`,
       );
     });

--- a/frontend/src/metabase/status/components/DatabaseStatusSmall/DatabaseStatusSmall.tsx
+++ b/frontend/src/metabase/status/components/DatabaseStatusSmall/DatabaseStatusSmall.tsx
@@ -1,12 +1,11 @@
 import { t } from "ttag";
 
-import { isReducedMotionPreferred } from "metabase/lib/dom";
 import { isSyncAborted, isSyncInProgress } from "metabase/lib/syncing";
-import type { IconName } from "metabase/ui";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type { InitialSyncStatus } from "metabase-types/api";
 
 import StatusSmall from "../StatusSmall";
+import { getIconName, isSpinnerVisible } from "../utils/status";
 
 export interface DatabaseStatusSmallProps {
   databases: Database[];
@@ -51,26 +50,6 @@ const getStatusLabel = (status: InitialSyncStatus): string => {
       return t`Done!`;
     case "aborted":
       return t`Error syncing`;
-  }
-};
-
-const getIconName = (status: InitialSyncStatus): IconName => {
-  switch (status) {
-    case "incomplete":
-      return "database";
-    case "complete":
-      return "check";
-    case "aborted":
-      return "warning";
-  }
-};
-
-const isSpinnerVisible = (status: InitialSyncStatus): boolean => {
-  switch (status) {
-    case "incomplete":
-      return !isReducedMotionPreferred();
-    default:
-      return false;
   }
 };
 

--- a/frontend/src/metabase/status/components/DownloadsStatus/DownloadsStatus.tsx
+++ b/frontend/src/metabase/status/components/DownloadsStatus/DownloadsStatus.tsx
@@ -1,0 +1,45 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { useSelector, useDispatch } from "metabase/lib/redux";
+import { clearAll, getDownloads } from "metabase/redux/downloads";
+import useStatusVisibility from "metabase/status/hooks/use-status-visibility";
+
+import { DownloadsStatusLarge } from "../DownloadsStatusLarge";
+import { DownloadsStatusSmall } from "../DownloadsStatusSmall";
+import { isCompleted } from "../utils/downloads";
+
+export const DownloadsStatus = (): JSX.Element | null => {
+  const [isExpanded, setIsExpanded] = useState(true);
+  const downloads = useSelector(getDownloads);
+  const dispatch = useDispatch();
+  const hasActiveDownloads =
+    downloads.length > 0 && !downloads.every(isCompleted);
+  const isVisible = useStatusVisibility(hasActiveDownloads);
+
+  const handleDismiss = useCallback(() => {
+    dispatch(clearAll());
+  }, [dispatch]);
+
+  useEffect(() => {
+    if (!isVisible && !hasActiveDownloads && downloads.length > 0) {
+      handleDismiss();
+    }
+  }, [isVisible, handleDismiss, downloads.length, hasActiveDownloads]);
+
+  if (downloads.length === 0) {
+    return null;
+  }
+
+  return isExpanded ? (
+    <DownloadsStatusLarge
+      downloads={downloads}
+      onDismiss={handleDismiss}
+      onCollapse={() => setIsExpanded(false)}
+    />
+  ) : (
+    <DownloadsStatusSmall
+      downloads={downloads}
+      onExpand={() => setIsExpanded(true)}
+    />
+  );
+};

--- a/frontend/src/metabase/status/components/DownloadsStatus/DownloadsStatus.unit.spec.tsx
+++ b/frontend/src/metabase/status/components/DownloadsStatus/DownloadsStatus.unit.spec.tsx
@@ -1,0 +1,183 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+
+import { act, renderWithProviders, screen, waitFor } from "__support__/ui";
+import { downloadDataset } from "metabase/redux/downloads";
+import { HIDE_DELAY } from "metabase/status/hooks/use-status-visibility";
+import Question from "metabase-lib/v1/Question";
+import { createMockCard, createMockDataset } from "metabase-types/api/mocks";
+import type { Dispatch, Download } from "metabase-types/store";
+import { createMockState } from "metabase-types/store/mocks";
+
+import { DownloadsStatus } from "./DownloadsStatus";
+
+jest.mock("metabase/lib/dom", () => ({
+  ...jest.requireActual("metabase/lib/dom"),
+  openSaveDialog: jest.fn(),
+}));
+
+const getDownloadDatasetAction = () =>
+  downloadDataset({
+    opts: {
+      type: "csv",
+      question: new Question(createMockCard({ id: 1, name: "test card" })),
+      result: createMockDataset(),
+    },
+    id: 1,
+  });
+
+interface SetupOpts {
+  downloads?: Download[];
+}
+
+const setup = ({ downloads = [] }: SetupOpts = {}) => {
+  const state = createMockState({
+    downloads,
+  });
+
+  return renderWithProviders(<DownloadsStatus />, {
+    storeInitialState: state,
+  });
+};
+
+describe("DownloadsStatus", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+    fetchMock.restore();
+  });
+
+  it("should show and update downloads status", async () => {
+    const { store } = setup();
+    const dispatch = store.dispatch as Dispatch;
+
+    fetchMock.post(
+      "http://localhost/api/card/1/query/csv?format_rows=false",
+      {
+        headers: { "Content-Disposition": 'filename="test.csv"' },
+      },
+      { delay: 500 },
+    );
+
+    // Initially shows nothing
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+
+    // Download starts
+    await act(async () => {
+      dispatch(getDownloadDatasetAction());
+    });
+
+    expect(screen.getByText("Downloading…")).toBeInTheDocument();
+    expect(screen.getByText("Results for test card")).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    // Download competed
+    expect(await screen.findByText("test.csv")).toBeInTheDocument();
+
+    // Wait until the status should automatically hide
+    act(() => {
+      jest.advanceTimersByTime(HIDE_DELAY);
+    });
+
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("should show and update downloads status when errored", async () => {
+    const { store } = setup();
+    const dispatch = store.dispatch as Dispatch;
+
+    fetchMock.post(
+      "http://localhost/api/card/1/query/csv?format_rows=false",
+      {
+        throws: new Error("Network error"),
+      },
+      { delay: 500 },
+    );
+
+    // Initially shows nothing
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+
+    // Download starts
+    await act(async () => {
+      dispatch(getDownloadDatasetAction());
+    });
+
+    expect(screen.getByText("Downloading…")).toBeInTheDocument();
+    expect(screen.getByText("Results for test card")).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    // Download errored
+    expect(await screen.findByText("Network error")).toBeInTheDocument();
+
+    // Errors do not hide automatically
+    act(() => {
+      jest.advanceTimersByTime(HIDE_DELAY);
+    });
+
+    expect(screen.getByRole("status")).toBeInTheDocument();
+
+    // Dismiss the error
+    userEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+
+    await waitFor(() =>
+      expect(screen.queryByRole("status")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("should collapse and expand", async () => {
+    const { store } = setup();
+    const dispatch = store.dispatch as Dispatch;
+
+    fetchMock.post(
+      "http://localhost/api/card/1/query/csv?format_rows=false",
+      {
+        headers: { "Content-Disposition": 'filename="test.csv"' },
+      },
+      { delay: 500 },
+    );
+
+    // Initially shows nothing
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+
+    // Download starts
+    await act(async () => {
+      dispatch(getDownloadDatasetAction());
+    });
+
+    expect(screen.getByText("Results for test card")).toBeInTheDocument();
+
+    userEvent.click(screen.getByRole("button", { name: "Collapse" }));
+
+    // Shows smaller status without text
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Results for test card"),
+      ).not.toBeInTheDocument();
+    });
+    expect(screen.getByRole("status")).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    // Download completed, still show smaller status
+    expect(await screen.findByLabelText("check icon")).toBeInTheDocument();
+    expect(screen.queryByText("test.csv")).not.toBeInTheDocument();
+
+    // Expand by clicking on the smaller status
+    userEvent.click(screen.getByRole("status"));
+
+    // Now status shows file names
+    expect(await screen.findByText("test.csv")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/status/components/DownloadsStatus/index.ts
+++ b/frontend/src/metabase/status/components/DownloadsStatus/index.ts
@@ -1,0 +1,1 @@
+export * from "./DownloadsStatus";

--- a/frontend/src/metabase/status/components/DownloadsStatusLarge/DownloadsStatusLarge.stories.tsx
+++ b/frontend/src/metabase/status/components/DownloadsStatusLarge/DownloadsStatusLarge.stories.tsx
@@ -1,0 +1,61 @@
+import type { ComponentStory } from "@storybook/react";
+
+import { DownloadsStatusLarge } from "./DownloadsStatusLarge";
+
+export default {
+  title: "Status/DownloadsStatusLarge",
+  component: DownloadsStatusLarge,
+};
+
+const Template: ComponentStory<typeof DownloadsStatusLarge> = args => {
+  return <DownloadsStatusLarge {...args} />;
+};
+
+export const Incomplete = Template.bind({});
+Incomplete.args = {
+  downloads: [
+    {
+      id: 1,
+      title: "is-alex?.csv",
+      status: "in-progress",
+    },
+    {
+      id: 2,
+      title: "top-secret.xlsx",
+      status: "in-progress",
+    },
+  ],
+};
+
+export const Complete = Template.bind({});
+Complete.args = {
+  downloads: [
+    {
+      id: 1,
+      title: "is-alex?.csv",
+      status: "complete",
+    },
+    {
+      id: 2,
+      title: "top-secret.xlsx",
+      status: "complete",
+    },
+  ],
+};
+
+export const Aborted = Template.bind({});
+Aborted.args = {
+  downloads: [
+    {
+      id: 1,
+      title: "is-alex?.csv",
+      status: "error",
+      error: "Out of memory: too many people named Alex",
+    },
+    {
+      id: 2,
+      title: "top-secret.xlsx",
+      status: "error",
+    },
+  ],
+};

--- a/frontend/src/metabase/status/components/DownloadsStatusLarge/DownloadsStatusLarge.tsx
+++ b/frontend/src/metabase/status/components/DownloadsStatusLarge/DownloadsStatusLarge.tsx
@@ -1,0 +1,71 @@
+import { useMemo } from "react";
+import { t } from "ttag";
+
+import type { Download } from "metabase-types/store";
+
+import StatusLarge from "../StatusLarge";
+import { isCompleted, isErrored, isInProgress } from "../utils/downloads";
+
+export interface DownloadsStatusLargeProps {
+  downloads: Download[];
+  onDismiss: () => void;
+  onCollapse: () => void;
+}
+
+export const DownloadsStatusLarge = ({
+  downloads,
+  onDismiss,
+  onCollapse,
+}: DownloadsStatusLargeProps) => {
+  const status = useMemo(() => {
+    return {
+      title: getTitle(downloads),
+      items: downloads.map(download => ({
+        id: download.id,
+        title: download.title,
+        icon: "download",
+        description: getDownloadDescription(download),
+        isInProgress: isInProgress(download),
+        isCompleted: isCompleted(download),
+        isAborted: isErrored(download),
+      })),
+    };
+  }, [downloads]);
+
+  const hasInProgress = downloads.some(isInProgress);
+
+  return (
+    <StatusLarge
+      isActive
+      status={status}
+      onCollapse={hasInProgress ? onCollapse : undefined}
+      onDismiss={hasInProgress ? undefined : onDismiss}
+    />
+  );
+};
+
+const getTitle = (downloads: Download[]): string => {
+  const isDone = downloads.every(isCompleted);
+  const isError = downloads.some(isErrored);
+
+  if (isError) {
+    return t`Download error`;
+  } else if (isDone) {
+    return t`Done!`;
+  } else {
+    return t`Downloading…`;
+  }
+};
+
+const getDownloadDescription = (download: Download): string => {
+  const isDone = isCompleted(download);
+  const isError = isErrored(download);
+
+  if (isError) {
+    return download.error ?? t`Download failed`;
+  } else if (isDone) {
+    return t`Download completed`;
+  } else {
+    return "";
+  }
+};

--- a/frontend/src/metabase/status/components/DownloadsStatusLarge/index.ts
+++ b/frontend/src/metabase/status/components/DownloadsStatusLarge/index.ts
@@ -1,0 +1,1 @@
+export * from "./DownloadsStatusLarge";

--- a/frontend/src/metabase/status/components/DownloadsStatusSmall/DownloadsStatusSmall.tsx
+++ b/frontend/src/metabase/status/components/DownloadsStatusSmall/DownloadsStatusSmall.tsx
@@ -1,0 +1,54 @@
+import { t } from "ttag";
+
+import type { LongTaskStatus } from "metabase-types/api";
+import type { Download } from "metabase-types/store";
+
+import StatusSmall from "../StatusSmall";
+import { isErrored, isInProgress } from "../utils/downloads";
+import { getIconName, isSpinnerVisible } from "../utils/status";
+
+export interface DownloadsStatusSmallProps {
+  downloads: Download[];
+  onExpand?: () => void;
+}
+
+export const DownloadsStatusSmall = ({
+  downloads,
+  onExpand,
+}: DownloadsStatusSmallProps): JSX.Element => {
+  const status = getStatus(downloads);
+  const statusLabel = getStatusLabel(status);
+  const hasSpinner = isSpinnerVisible(status);
+  const icon = getIconName(status);
+
+  return (
+    <StatusSmall
+      status={status}
+      statusLabel={statusLabel}
+      hasSpinner={hasSpinner}
+      icon={icon}
+      onExpand={onExpand}
+    />
+  );
+};
+
+const getStatus = (downloads: Download[]): LongTaskStatus => {
+  if (downloads.some(isInProgress)) {
+    return "incomplete";
+  } else if (downloads.some(isErrored)) {
+    return "aborted";
+  } else {
+    return "complete";
+  }
+};
+
+const getStatusLabel = (status: LongTaskStatus): string => {
+  switch (status) {
+    case "incomplete":
+      return t`Downloading…`;
+    case "complete":
+      return t`Done!`;
+    case "aborted":
+      return t`Download error`;
+  }
+};

--- a/frontend/src/metabase/status/components/DownloadsStatusSmall/index.ts
+++ b/frontend/src/metabase/status/components/DownloadsStatusSmall/index.ts
@@ -1,0 +1,1 @@
+export * from "./DownloadsStatusSmall";

--- a/frontend/src/metabase/status/components/PublicStatusListing/PublicStatusListing.styled.tsx
+++ b/frontend/src/metabase/status/components/PublicStatusListing/PublicStatusListing.styled.tsx
@@ -1,0 +1,8 @@
+import styled from "@emotion/styled";
+
+export const PublicStatusListingRoot = styled.div`
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  z-index: 2;
+`;

--- a/frontend/src/metabase/status/components/PublicStatusListing/PublicStatusListing.tsx
+++ b/frontend/src/metabase/status/components/PublicStatusListing/PublicStatusListing.tsx
@@ -1,8 +1,12 @@
+import { useCheckActiveDownloadsBeforeUnload } from "metabase/status/hooks/use-check-active-downloads-before-unload";
+
 import { DownloadsStatus } from "../DownloadsStatus";
 
 import { PublicStatusListingRoot } from "./PublicStatusListing.styled";
 
 export const PublicStatusListing = () => {
+  useCheckActiveDownloadsBeforeUnload();
+
   return (
     <PublicStatusListingRoot data-testid="status-root-container">
       <DownloadsStatus />

--- a/frontend/src/metabase/status/components/PublicStatusListing/PublicStatusListing.tsx
+++ b/frontend/src/metabase/status/components/PublicStatusListing/PublicStatusListing.tsx
@@ -1,0 +1,11 @@
+import { DownloadsStatus } from "../DownloadsStatus";
+
+import { PublicStatusListingRoot } from "./PublicStatusListing.styled";
+
+export const PublicStatusListing = () => {
+  return (
+    <PublicStatusListingRoot data-testid="status-root-container">
+      <DownloadsStatus />
+    </PublicStatusListingRoot>
+  );
+};

--- a/frontend/src/metabase/status/components/PublicStatusListing/index.ts
+++ b/frontend/src/metabase/status/components/PublicStatusListing/index.ts
@@ -1,0 +1,1 @@
+export * from "./PublicStatusListing";

--- a/frontend/src/metabase/status/components/StatusLarge/StatusLarge.tsx
+++ b/frontend/src/metabase/status/components/StatusLarge/StatusLarge.tsx
@@ -1,3 +1,5 @@
+import { t } from "ttag";
+
 import { Ellipsified } from "metabase/core/components/Ellipsified";
 import type { IconName } from "metabase/ui";
 import { Icon } from "metabase/ui";
@@ -54,12 +56,12 @@ const StatusLarge = ({
           <Ellipsified>{status.title}</Ellipsified>
         </StatusTitle>
         {onCollapse && (
-          <StatusToggle onClick={onCollapse}>
+          <StatusToggle onClick={onCollapse} aria-label={t`Collapse`}>
             <Icon name="chevrondown" />
           </StatusToggle>
         )}
         {onDismiss && (
-          <StatusToggle onClick={onDismiss}>
+          <StatusToggle onClick={onDismiss} aria-label={t`Dismiss`}>
             <Icon name="close" />
           </StatusToggle>
         )}

--- a/frontend/src/metabase/status/components/StatusListing/StatusListing.tsx
+++ b/frontend/src/metabase/status/components/StatusListing/StatusListing.tsx
@@ -6,6 +6,7 @@ import { hasActiveUploads } from "metabase/redux/uploads";
 import { getUserIsAdmin, getUser } from "metabase/selectors/user";
 
 import DatabaseStatus from "../../containers/DatabaseStatus";
+import { DownloadsStatus } from "../DownloadsStatus";
 import { FileUploadStatus } from "../FileUploadStatus";
 
 import { StatusListingRoot } from "./StatusListing.styled";
@@ -29,6 +30,7 @@ const StatusListing = () => {
     <StatusListingRoot data-testid="status-root-container">
       {isAdmin && <DatabaseStatus />}
       <FileUploadStatus />
+      <DownloadsStatus />
     </StatusListingRoot>
   );
 };

--- a/frontend/src/metabase/status/components/StatusListing/StatusListing.tsx
+++ b/frontend/src/metabase/status/components/StatusListing/StatusListing.tsx
@@ -3,7 +3,7 @@ import { t } from "ttag";
 
 import { useSelector } from "metabase/lib/redux";
 import { hasActiveUploads } from "metabase/redux/uploads";
-import { getUserIsAdmin, getUser } from "metabase/selectors/user";
+import { getUserIsAdmin } from "metabase/selectors/user";
 
 import DatabaseStatus from "../../containers/DatabaseStatus";
 import { DownloadsStatus } from "../DownloadsStatus";
@@ -12,7 +12,6 @@ import { FileUploadStatus } from "../FileUploadStatus";
 import { StatusListingRoot } from "./StatusListing.styled";
 
 const StatusListing = () => {
-  const isLoggedIn = !!useSelector(getUser);
   const isAdmin = useSelector(getUserIsAdmin);
 
   const uploadInProgress = useSelector(hasActiveUploads);
@@ -21,10 +20,6 @@ const StatusListing = () => {
     uploadInProgress,
     t`CSV Upload in progress. Are you sure you want to leave?`,
   );
-
-  if (!isLoggedIn) {
-    return null;
-  }
 
   return (
     <StatusListingRoot data-testid="status-root-container">

--- a/frontend/src/metabase/status/components/StatusListing/StatusListing.tsx
+++ b/frontend/src/metabase/status/components/StatusListing/StatusListing.tsx
@@ -4,6 +4,7 @@ import { t } from "ttag";
 import { useSelector } from "metabase/lib/redux";
 import { hasActiveUploads } from "metabase/redux/uploads";
 import { getUserIsAdmin } from "metabase/selectors/user";
+import { useCheckActiveDownloadsBeforeUnload } from "metabase/status/hooks/use-check-active-downloads-before-unload";
 
 import DatabaseStatus from "../../containers/DatabaseStatus";
 import { DownloadsStatus } from "../DownloadsStatus";
@@ -20,6 +21,8 @@ const StatusListing = () => {
     uploadInProgress,
     t`CSV Upload in progress. Are you sure you want to leave?`,
   );
+
+  useCheckActiveDownloadsBeforeUnload();
 
   return (
     <StatusListingRoot data-testid="status-root-container">

--- a/frontend/src/metabase/status/components/utils/downloads.ts
+++ b/frontend/src/metabase/status/components/utils/downloads.ts
@@ -1,0 +1,7 @@
+import type { Download } from "metabase-types/store";
+
+export const isCompleted = (download: Download) =>
+  download.status === "complete";
+export const isErrored = (download: Download) => download.status === "error";
+export const isInProgress = (download: Download) =>
+  download.status === "in-progress";

--- a/frontend/src/metabase/status/components/utils/status.ts
+++ b/frontend/src/metabase/status/components/utils/status.ts
@@ -1,0 +1,23 @@
+import { isReducedMotionPreferred } from "metabase/lib/dom";
+import type { IconName } from "metabase/ui";
+import type { LongTaskStatus } from "metabase-types/api";
+
+export const getIconName = (status: LongTaskStatus): IconName => {
+  switch (status) {
+    case "incomplete":
+      return "download";
+    case "complete":
+      return "check";
+    case "aborted":
+      return "warning";
+  }
+};
+
+export const isSpinnerVisible = (status: LongTaskStatus): boolean => {
+  switch (status) {
+    case "incomplete":
+      return !isReducedMotionPreferred();
+    default:
+      return false;
+  }
+};

--- a/frontend/src/metabase/status/hooks/use-check-active-downloads-before-unload.ts
+++ b/frontend/src/metabase/status/hooks/use-check-active-downloads-before-unload.ts
@@ -1,0 +1,13 @@
+import { useBeforeUnload } from "react-use";
+import { t } from "ttag";
+
+import { useSelector } from "metabase/lib/redux";
+import { hasActiveDownloads } from "metabase/redux/downloads";
+
+export const useCheckActiveDownloadsBeforeUnload = () => {
+  const downloadInProgress = useSelector(hasActiveDownloads);
+  useBeforeUnload(
+    downloadInProgress,
+    t`Export in progress. Are you sure you want to leave?`,
+  );
+};

--- a/frontend/src/metabase/status/hooks/use-status-visibility.ts
+++ b/frontend/src/metabase/status/hooks/use-status-visibility.ts
@@ -1,6 +1,6 @@
 import { useState, useLayoutEffect } from "react";
 
-const HIDE_DELAY = 6000;
+export const HIDE_DELAY = 6000;
 
 const useStatusVisibility = (isActive: boolean) => {
   const [isVisible, setIsVisible] = useState(isActive);


### PR DESCRIPTION
# Since I'm on vacation please merge the PR once it is approved

Closes https://github.com/metabase/metabase/issues/44686
Closes https://github.com/metabase/metabase/issues/41532

### Description

Adds an in-progress indicator when users are exporting questions as CSV, JSON, or XLSX from the query builder or dashboards. We don't show it for PNG exports since they are essentially client-side and there is no meaningful delay.

It should be visible in all context: authenticated, public dashboards, embedded dashboards.

**Even though this PR contains string changes we are still backporting it to v50**
[Slack thread on backporting](https://metaboat.slack.com/archives/C064QMXEV9N/p1721324616525049)

### How to verify

Verify CSV, JSON, or XLSX downloads from query builder, dashboards including public and embedded show the loader.

### Demo

<img width="868" alt="Screenshot 2024-07-17 at 1 15 36 AM" src="https://github.com/user-attachments/assets/9fa6582c-f0d3-4102-89e6-c4a012dbcc51">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
