### PR TITLE
Fix pulse being sent multiple times

### DIFF
--- a/src/metabase/task/send_pulses.clj
+++ b/src/metabase/task/send_pulses.clj
@@ -113,36 +113,16 @@
     (t2/delete! :model/PulseChannel :id [:in ids-to-delete])
     (set ids-to-delete)))
 
-(defn- ms-duration->priority
-  "Converts a duration in milliseconds to a priority value for a trigger.
-
-  Pulses are time sensitive, so we need it to have higher priority than other tasks, in which has a default priority of 5."
-  [ms-duration]
-  (-> ms-duration
-      (/ 1000)
-      ;; assuming 1 hour is the max duration a pulse can take
-      (#(- (* 60 60) %))
-      ;; make sure it's higher than 5 (the default priority)
-      (max 6)
-      int))
-
 (defn- send-pulse!*
   "Do several things:
   - Clear PulseChannels that have no recipients and no channel set for a pulse
-  - Send a pulse to a list of channels
-  - Update the priority of the trigger if the pulse is sent successfully"
-  [schedule-map pulse-id channel-ids]
+  - Send a pulse to a list of channels"
+  [pulse-id channel-ids]
   (let [cleared-channel-ids         (clear-pulse-channels-no-recipients! pulse-id)
         to-send-channel-ids         (set/difference channel-ids cleared-channel-ids)
         to-send-enabled-channel-ids (t2/select-pks-set :model/PulseChannel :id [:in to-send-channel-ids] :enabled true)]
     (if (seq to-send-enabled-channel-ids)
-      (let [start    (System/currentTimeMillis)
-            result   (send-pulse! pulse-id to-send-enabled-channel-ids)
-            end      (System/currentTimeMillis)
-            priority (ms-duration->priority (- end start))]
-        (when (= :done result)
-          (log/infof "Updating priority of trigger %s to %d" (.getName ^TriggerKey (send-pulse-trigger-key pulse-id schedule-map)) priority)
-          (task/reschedule-trigger! (send-pulse-trigger pulse-id schedule-map channel-ids (send-trigger-timezone) priority))))
+      (send-pulse! pulse-id to-send-enabled-channel-ids)
       (log/infof "Skip sending pulse %d because all channels have no recipients" pulse-id))))
 
 ;; called in [driver/report-timezone] setter
@@ -163,9 +143,8 @@
 (jobs/defjob ^{:doc "Triggers that send a pulse to a list of channels at a specific time"}
   SendPulse
   [context]
-  (let [{:strs [pulse-id channel-ids]} (qc/from-job-data context)
-        trigger-key                    (.. context getTrigger getKey getName)]
-    (send-pulse!* (:schedule-map (send-pulse-trigger-key->info trigger-key)) pulse-id channel-ids)))
+  (let [{:strs [pulse-id channel-ids]} (qc/from-job-data context)]
+    (send-pulse!* pulse-id channel-ids)))
 
 ;;; ------------------------------------------------ Job: InitSendPulseTriggers ----------------------------------------------------
 

--- a/test/metabase/task/send_pulses_test.clj
+++ b/test/metabase/task/send_pulses_test.clj
@@ -93,7 +93,7 @@
                                                         :channel_type :slack
                                                         :details      {}}
                                                        daily-at-1am)]
-          (#'task.send-pulses/send-pulse!* daily-at-1am pulse #{pc pc-disabled pc-no-recipient})
+          (#'task.send-pulses/send-pulse!* pulse #{pc pc-disabled pc-no-recipient})
           (testing "only send to enabled channels that has recipients"
             (is (= #{pc} @sent-channel-ids)))
 

--- a/test/metabase/task/send_pulses_test.clj
+++ b/test/metabase/task/send_pulses_test.clj
@@ -100,26 +100,6 @@
           (testing "channels that has no recipients are deleted"
             (is (false? (t2/exists? :model/PulseChannel pc-no-recipient)))))))))
 
-(deftest send-pulse!*-update-trigger-priority-test
-  (testing "send-pulse!* should update the priority of the trigger based on the duration of the pulse"
-    (pulse-channel-test/with-send-pulse-setup!
-     (with-redefs [task.send-pulses/ms-duration->priority (constantly 7)
-                   metabase.pulse/send-pulse!             (constantly nil)]
-       (mt/with-temp
-         [:model/Pulse        {pulse :id} {}
-          :model/PulseChannel {pc :id}    (merge
-                                           {:pulse_id     pulse
-                                            :channel_type :slack
-                                            :details      {:channel "#random"}}
-                                           daily-at-1am)]
-         (testing "priority is 6 to start with"
-           (is (= 6 (-> (pulse-channel-test/send-pulse-triggers pulse) first :priority))))
-         (#'task.send-pulses/send-pulse!* daily-at-1am pulse #{pc})
-         (testing "send pulse should update its priority"
-           ;; 5 is the default priority of a trigger, we need it to be higher than that because
-           ;; pulse is time sensitive compared to other tasks like sync
-           (is (= 7 (-> (pulse-channel-test/send-pulse-triggers pulse) first :priority)))))))))
-
 (deftest init-send-pulse-triggers!-group-runs-test
   (testing "a SendJob trigger will send pulse to channels that have the same schedueld time"
     (pulse-channel-test/with-send-pulse-setup!


### PR DESCRIPTION
In https://github.com/metabase/metabase/pull/42331 we updated so that every send-pulse trigger will reschedule its trigger with a new priority based on its processing time.
This was meant to prioritize fast pulses to be executed first. 

However, it introduced a bug in that the `reschedule` step will re-trigger itself if `now == the new schedule time`.

So imagine you have a trigger that runs at `06:00:00.000`, and the `reschedule` happens at `06:00:00.03`, then it'll re-trigger itself to run another time. 

Although prioritizing fast pulse is nice, it doesn't make a big difference, so I'll revert that change.

If we still want this, we can create a separate job instead of doing it inline with the send-pulse job itself.

How to reproduce:
1. Setup email
2. Create a question that limit to 1 result (basically create a question that process very fast)
3. Create an alert that is schedule earliest to your time
4. Modify the function `metabase.task.send-pulses/send-pulse!*` to 
```clojure
(defn- send-pulse!*
  [schedule-map pulse-id channel-ids]
  (let [cleared-channel-ids         (clear-pulse-channels-no-recipients! pulse-id)
        to-send-channel-ids         (set/difference channel-ids cleared-channel-ids)
        to-send-enabled-channel-ids (t2/select-pks-set :model/PulseChannel :id [:in to-send-channel-ids] :enabled true)]
   (task/reschedule-trigger! (send-pulse-trigger pulse-id schedule-map channel-ids (send-trigger-timezone) 6))
   (if (seq to-send-enabled-channel-ids)
     (send-pulse! pulse-id to-send-enabled-channel-ids)
     (log/infof "Skip sending pulse %d because all channels have no recipients" pulse-id))))
```
We basically move the `reschedule` step to the top here, this will increase the likelihood of having multiple triggers within a second.
5. wait until the trigger time of the pulse ( sorry :( )

Fixes https://github.com/metabase/metabase/issues/45622