### PR TITLE
Refactor EditorTabs component

### DIFF
--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -53,7 +53,7 @@ import {
 } from "./DatasetEditor.styled";
 import DatasetFieldMetadataSidebar from "./DatasetFieldMetadataSidebar";
 import DatasetQueryEditor from "./DatasetQueryEditor";
-import EditorTabs from "./EditorTabs";
+import { EditorTabs } from "./EditorTabs";
 import { TabHintToast } from "./TabHintToast";
 import { EDITOR_TAB_INDEXES } from "./constants";
 
@@ -496,16 +496,8 @@ function DatasetEditor(props) {
           isMetric ? null : (
             <EditorTabs
               currentTab={datasetEditorTab}
+              disabledMetadata={!resultsMetadata}
               onChange={onChangeEditorTab}
-              options={[
-                { id: "query", name: t`Query`, icon: "notebook" },
-                {
-                  id: "metadata",
-                  name: t`Metadata`,
-                  icon: "label",
-                  disabled: !resultsMetadata,
-                },
-              ]}
             />
           )
         }

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/EditorTabs/EditorTabs.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/EditorTabs/EditorTabs.tsx
@@ -10,14 +10,9 @@ type Props = {
   onChange: (optionId: string) => void;
 };
 
-export function EditorTabs({
-  currentTab,
-  disabledMetadata,
-  onChange,
-  ...props
-}: Props) {
+export function EditorTabs({ currentTab, disabledMetadata, onChange }: Props) {
   return (
-    <TabBar {...props}>
+    <TabBar>
       <li>
         <Tab htmlFor="editor-tabs-query" selected={currentTab === "query"}>
           <Icon name="notebook" />

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/EditorTabs/EditorTabs.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/EditorTabs/EditorTabs.tsx
@@ -19,11 +19,7 @@ export function EditorTabs({
   return (
     <TabBar {...props}>
       <li>
-        <Tab
-          id="editor-tabs-query-label"
-          htmlFor="editor-tabs-query"
-          selected={currentTab === "query"}
-        >
+        <Tab htmlFor="editor-tabs-query" selected={currentTab === "query"}>
           <Icon name="notebook" />
           <RadioInput
             id="editor-tabs-query"
@@ -33,7 +29,6 @@ export function EditorTabs({
             onChange={() => {
               onChange("query");
             }}
-            aria-labelledby="editor-tabs-query-label"
           />
           <span>{t`Query`}</span>
         </Tab>
@@ -41,7 +36,6 @@ export function EditorTabs({
 
       <li>
         <Tab
-          id="editor-tabs-metadata-label"
           htmlFor="editor-tabs-metadata"
           selected={currentTab === "metadata"}
           disabled={disabledMetadata}
@@ -55,7 +49,6 @@ export function EditorTabs({
             onChange={() => {
               onChange("metadata");
             }}
-            aria-labelledby="editor-tabs-metadata-label"
             disabled={disabledMetadata}
             data-testid="editor-tabs-metadata"
           />

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/EditorTabs/EditorTabs.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/EditorTabs/EditorTabs.tsx
@@ -34,9 +34,8 @@ export function EditorTabs({
               onChange("query");
             }}
             aria-labelledby="editor-tabs-query-label"
-            data-testid="editor-tabs-query"
           />
-          <span data-testid="query-name">{t`Query`}</span>
+          <span>{t`Query`}</span>
         </Tab>
       </li>
 
@@ -60,7 +59,7 @@ export function EditorTabs({
             disabled={disabledMetadata}
             data-testid="editor-tabs-metadata"
           />
-          <span data-testid="metadata-name">{t`Metadata`}</span>
+          <span>{t`Metadata`}</span>
         </Tab>
       </li>
     </TabBar>

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/EditorTabs/EditorTabs.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/EditorTabs/EditorTabs.tsx
@@ -25,7 +25,7 @@ export function EditorTabs({ currentTab, disabledMetadata, onChange }: Props) {
               onChange("query");
             }}
           />
-          <span>{t`Query`}</span>
+          <span data-testid="editor-tabs-query-name">{t`Query`}</span>
         </Tab>
       </li>
 
@@ -47,7 +47,7 @@ export function EditorTabs({ currentTab, disabledMetadata, onChange }: Props) {
             disabled={disabledMetadata}
             data-testid="editor-tabs-metadata"
           />
-          <span>{t`Metadata`}</span>
+          <span data-testid="editor-tabs-metadata-name">{t`Metadata`}</span>
         </Tab>
       </li>
     </TabBar>

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/EditorTabs/EditorTabs.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/EditorTabs/EditorTabs.tsx
@@ -1,57 +1,68 @@
-import type { IconName } from "metabase/ui";
+import { t } from "ttag";
+
 import { Icon } from "metabase/ui";
 
-import { TabBar, Tab, RadioInput } from "./EditorTabs.styled";
+import { RadioInput, Tab, TabBar } from "./EditorTabs.styled";
 
 type Props = {
   currentTab: string;
-  options: {
-    id: string;
-    name: string;
-    icon: IconName;
-    disabled?: boolean;
-  }[];
+  disabledMetadata: boolean;
   onChange: (optionId: string) => void;
 };
 
-function EditorTabs({ currentTab, options, onChange, ...props }: Props) {
-  const inputId = "editor-tabs";
-
+export function EditorTabs({
+  currentTab,
+  disabledMetadata,
+  onChange,
+  ...props
+}: Props) {
   return (
     <TabBar {...props}>
-      {options.map(option => {
-        const selected = currentTab === option.id;
-        const id = `${inputId}-${option.id}`;
-        const labelId = `${id}-label`;
-        return (
-          <li key={option.id}>
-            <Tab
-              id={labelId}
-              htmlFor={id}
-              selected={selected}
-              disabled={option.disabled}
-            >
-              <Icon name={option.icon} />
-              <RadioInput
-                id={id}
-                name={inputId}
-                value={option.id}
-                checked={selected}
-                onChange={() => {
-                  onChange(option.id);
-                }}
-                aria-labelledby={labelId}
-                disabled={option.disabled}
-                data-testid={id}
-              />
-              <span data-testid={`${id}-name`}>{option.name}</span>
-            </Tab>
-          </li>
-        );
-      })}
+      <li>
+        <Tab
+          id="editor-tabs-query-label"
+          htmlFor="editor-tabs-query"
+          selected={currentTab === "query"}
+        >
+          <Icon name="notebook" />
+          <RadioInput
+            id="editor-tabs-query"
+            name="editor-tabs"
+            value="query"
+            checked={currentTab === "query"}
+            onChange={() => {
+              onChange("query");
+            }}
+            aria-labelledby="editor-tabs-query-label"
+            data-testid="editor-tabs-query"
+          />
+          <span data-testid="query-name">{t`Query`}</span>
+        </Tab>
+      </li>
+
+      <li>
+        <Tab
+          id="editor-tabs-metadata-label"
+          htmlFor="editor-tabs-metadata"
+          selected={currentTab === "metadata"}
+          disabled={disabledMetadata}
+        >
+          <Icon name="notebook" />
+          <RadioInput
+            id="editor-tabs-metadata"
+            name="editor-tabs"
+            value="metadata"
+            checked={currentTab === "metadata"}
+            onChange={() => {
+              onChange("metadata");
+            }}
+            aria-labelledby="editor-tabs-metadata-label"
+            disabled={disabledMetadata}
+            data-testid="editor-tabs-metadata"
+          />
+          <span data-testid="metadata-name">{t`Metadata`}</span>
+        </Tab>
+      </li>
     </TabBar>
   );
 }
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default EditorTabs;

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/EditorTabs/index.ts
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/EditorTabs/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./EditorTabs";
+export * from "./EditorTabs";


### PR DESCRIPTION
### Description

- Get rid of dynamic `id`/`data-testid` generation (one should be able to copy an id from HTML and just text-search the project for it)
- Get rid of dynamic children generation (`options` prop)
- Remove unused props spread
- Remove redundant `id` + `aria-labelledby` attributes (there's `htmlFor` + `id` already)
- Use named export

### How to verify

CI is green.
App works the same as before.