### PR TITLE
docs(sdk): indicate react 18 requirement for embedding sdk

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/README.md
+++ b/enterprise/frontend/src/embedding-sdk/README.md
@@ -32,7 +32,7 @@ Features planned:
 
 # Prerequisites
 
-- You have an application using React 17 or higher
+- You have an application using React 18
 - You have a Pro or Enterprise [subscription or free trial](https://www.metabase.com/pricing/) of Metabase
 - You have a running Metabase instance using a compatible version of the enterprise binary. v1.50.x are the only supported versions at this time.
 


### PR DESCRIPTION
### Description

The embedding SDK currently has an issue with the `MetabaseProvider` crashing when used in React 17. We update the docs to indicate React 18 requirement for the time being, until we've resolved the compatibility issue.