### PR TITLE
Repro #33327: Visualization does not recover from an error in native query editor

### DIFF
--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
@@ -7,6 +7,8 @@ import {
   createNativeQuestion,
 } from "e2e/support/helpers";
 
+import { getRunQueryButton } from "../native-filters/helpers/e2e-sql-filter-helpers";
+
 describe("issue 11727", { tags: "@external" }, () => {
   const PG_DB_ID = 2;
 
@@ -107,5 +109,48 @@ describe("issue 38083", () => {
       .within(() => {
         cy.icon("time_history").should("not.exist");
       });
+  });
+});
+
+describe("issue 33327", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should recover from a visualization error (metabase#33327)", () => {
+    const query = "SELECT 1";
+    createNativeQuestion(
+      { native: { query }, display: "scalar" },
+      {
+        visitQuestion: true,
+      },
+    );
+
+    cy.findByTestId("scalar-value").should("have.text", "1");
+
+    cy.findByTestId("visibility-toggler").click();
+    cy.findByTestId("native-query-editor")
+      .should("contain", query)
+      .type("{leftarrow}--");
+
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    cy.findByTestId("native-query-editor").should("contain", "SELECT --1");
+    getRunQueryButton().click();
+    cy.wait("@dataset");
+
+    cy.findByTestId("visualization-root").icon("warning").should("be.visible");
+    cy.findByTestId("scalar-value").should("not.exist");
+
+    cy.findByTestId("native-query-editor")
+      .should("contain", "SELECT --1")
+      .type("{leftarrow}{backspace}{backspace}");
+    cy.findByTestId("native-query-editor").should("contain", query);
+
+    getRunQueryButton().click();
+    cy.wait("@dataset");
+
+    cy.findByTestId("scalar-value").should("have.text", "1");
+    cy.findByTestId("visualization-root").icon("warning").should("not.exist");
   });
 });


### PR DESCRIPTION
### What does this PR do?
This PR reproduces #33327 and confirms that the issue has been fixed.
Closes #33327 

### Demo
The error state
![image](https://github.com/user-attachments/assets/9fe8b22c-98c4-4268-abf6-9a0ac71063fd)

Recovered from error
![image](https://github.com/user-attachments/assets/96652f9f-a1df-450b-92a4-aff74ae3d14d)

### Stress-test
50 x ✅ https://github.com/metabase/metabase/actions/runs/9974150641
