### PR TITLE
Add basic auth params to `dbms-version` call on Druid

### DIFF
--- a/modules/drivers/druid/src/metabase/driver/druid/sync.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/sync.clj
@@ -66,5 +66,10 @@
   [database]
   {:pre [(map? (:details database))]}
   (ssh/with-ssh-tunnel [details-with-tunnel (:details database)]
-    (-> (druid.client/GET (druid.client/details->url details-with-tunnel "/status"))
+    (-> (druid.client/GET (druid.client/details->url details-with-tunnel "/status")
+          :auth-enabled     (-> database :details :auth-enabled)
+          :auth-username    (-> database :details :auth-username)
+          :auth-token-value (-> (:details database)
+                                (secret/db-details-prop->secret-map "auth-token")
+                                secret/value->string))
         (select-keys [:version]))))

--- a/modules/drivers/druid/test/metabase/driver/druid/sync_test.clj
+++ b/modules/drivers/druid/test/metabase/driver/druid/sync_test.clj
@@ -4,7 +4,10 @@
    [malli.core :as mc]
    [malli.error :as me]
    [metabase.driver :as driver]
+   [metabase.driver.druid.client :as druid.client]
+   [metabase.driver.druid.sync :as druid.sync]
    [metabase.models.database :refer [Database]]
+   [metabase.models.secret :as secret]
    [metabase.sync.sync-metadata.dbms-version :as sync-dbms-ver]
    [metabase.test :as mt]
    [metabase.timeseries-query-processor-test.util :as tqpt]
@@ -60,3 +63,22 @@
             (is (nil? version-after-update)))
           (testing "Check that the value was set again after sync"
             (is (nil? (check-dbms-version (db-dbms-version db))))))))))
+
+(deftest ^:synchronized auth-dbms-version-test
+  (mt/test-driver
+   :druid
+   (testing "`dbms-version` uses auth parameters (#41579)"
+     (tqpt/with-flattened-dbdef
+       (let [get-args (volatile! nil)
+             db-with-auth-details (update (mt/db) :details assoc
+                                          :auth-enabled     true
+                                          :auth-username    "admin"
+                                          :auth-token-value "password1")]
+         ;; Following ensures that auth parameters are passed to GET during version sync if present.
+         (with-redefs [secret/value->string (constantly "password1")
+                       druid.client/GET (fn [_url & params] (vreset! get-args (apply hash-map params)) nil)]
+           ;; Just fill in the params with internally modified `dbms-version`.
+           (druid.sync/dbms-version db-with-auth-details)
+           (is (= true        (:auth-enabled     @get-args)))
+           (is (= "admin"     (:auth-username    @get-args)))
+           (is (= "password1" (:auth-token-value @get-args)))))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/41579

### Description

Basic auth params were missing in `dbms-version` call. This PR adds that.

### How to verify

New test was added. Ideally we would have e2e auth tests. That is imo overkill because driver is to be deprecated. I plan to add those tests for Druid JDBC driver while working on https://github.com/metabase/metabase/issues/45728.

Apart from newly added test, change was e2e tested manually.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
