### PR TITLE
fix public resource flake

### DIFF
--- a/e2e/test/scenarios/sharing/public-resource-downloads.cy.spec.ts
+++ b/e2e/test/scenarios/sharing/public-resource-downloads.cy.spec.ts
@@ -41,6 +41,7 @@ describeEE(
 
         popover()
           .findByTestId("public-link-input")
+          .should("not.have.value", "")
           .invoke("val")
           .then(url => {
             publicLink = url as string;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/45727

### Description

Apparently when the backend is slow, cypress takes the value of the empty input, this makes it wait for it to be populated


stress test: https://github.com/metabase/metabase/actions/runs/9976292987