### PR TITLE
Do not render `ExecutionTime` if there is no `time` to format

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/ExecutionTime/ExecutionTime.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ExecutionTime/ExecutionTime.tsx
@@ -5,11 +5,17 @@ import { Tooltip } from "metabase/ui";
 import { formatDuration } from "./utils";
 
 interface Props {
-  time: number;
+  time?: number;
 }
 
-export const ExecutionTime = ({ time }: Props) => (
-  <Tooltip label={t`Query execution time`}>
-    <span data-testid="execution-time">{formatDuration(time)}</span>
-  </Tooltip>
-);
+export const ExecutionTime = ({ time }: Props) => {
+  if (!time) {
+    return null;
+  }
+
+  return (
+    <Tooltip label={t`Query execution time`}>
+      <span data-testid="execution-time">{formatDuration(time)}</span>
+    </Tooltip>
+  );
+};

--- a/frontend/src/metabase/query_builder/components/view/ExecutionTime/ExecutionTime.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ExecutionTime/ExecutionTime.tsx
@@ -9,7 +9,7 @@ interface Props {
 }
 
 export const ExecutionTime = ({ time }: Props) => {
-  if (!time) {
+  if (time !== 0 && !time) {
     return null;
   }
 

--- a/frontend/src/metabase/query_builder/components/view/ExecutionTime/ExecutionTime.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ExecutionTime/ExecutionTime.tsx
@@ -9,7 +9,7 @@ interface Props {
 }
 
 export const ExecutionTime = ({ time }: Props) => {
-  if (time !== 0 && !time) {
+  if (time === undefined) {
     return null;
   }
 

--- a/frontend/src/metabase/query_builder/components/view/ExecutionTime/ExecutionTime.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ExecutionTime/ExecutionTime.unit.spec.tsx
@@ -16,6 +16,12 @@ describe("ExecutionTime", () => {
     expect(screen.getByTestId("execution-time")).toHaveTextContent("100 ms");
   });
 
+  it("renders formatted time when time is provided, but the time is 0", () => {
+    render(<ExecutionTime time={0} />);
+
+    expect(screen.getByTestId("execution-time")).toHaveTextContent("0 ms");
+  });
+
   it("shows tooltip", async () => {
     render(<ExecutionTime time={100} />);
 

--- a/frontend/src/metabase/query_builder/components/view/ExecutionTime/ExecutionTime.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ExecutionTime/ExecutionTime.unit.spec.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { ExecutionTime } from "./ExecutionTime";
+
+describe("ExecutionTime", () => {
+  it("renders nothing when no time is provided (metabase#45730)", () => {
+    const { container } = render(<ExecutionTime />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders formatted time when time is provided", () => {
+    render(<ExecutionTime time={100} />);
+
+    expect(screen.getByTestId("execution-time")).toHaveTextContent("100 ms");
+  });
+
+  it("shows tooltip", async () => {
+    render(<ExecutionTime time={100} />);
+
+    await userEvent.hover(screen.getByTestId("execution-time"));
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
+      "Query execution time",
+    );
+  });
+});


### PR DESCRIPTION
### What does this PR accomplish?
Fixes #45730 by preventing the render to happen if `time` is missing for any reason.

We could run into this because of a network error (as explained in the issue). In that case, `result` does not contain the `running_time` that we're passing down to `ExecutionTime` component.

I've adjusted the props interface to reflect this new finding.

### Checklist
- [x] Tests have been added/updated to cover changes in this PR