### PR TITLE
Derive MySQLEnum from Text instead of TextLike

### DIFF
--- a/src/metabase/lib/schema/expression.cljc
+++ b/src/metabase/lib/schema/expression.cljc
@@ -166,11 +166,10 @@
   ;; This typing of each input should be replaced with an alternative scheme that checks that it's plausible to compare
   ;; all the args to an `:=` clause. Eg. comparing `:type/*` and `:type/String` is cool. Comparing `:type/IPAddress` to
   ;; `:type/Boolean` should fail; we can prove it's the wrong thing to do.
-  #{:type/Boolean :type/Text :type/Number :type/Temporal :type/IPAddress :type/MySQLEnum :type/MongoBSONID :type/Array :type/*})
+  #{:type/Boolean :type/Text :type/Number :type/Temporal :type/IPAddress :type/MongoBSONID :type/Array :type/*})
 
 (derive :type/Text        ::emptyable)
 (derive :type/MongoBSONID ::emptyable)
-(derive :type/MySQLEnum   ::emptyable)
 
 (mr/def ::emptyable
   (expression-schema ::emptyable "expression returning something emptyable (e.g. a string or BSON ID)"))

--- a/src/metabase/types.cljc
+++ b/src/metabase/types.cljc
@@ -258,7 +258,7 @@
 
 (derive :type/TextLike :type/*)
 (derive :type/MongoBSONID :type/TextLike)
-(derive :type/MySQLEnum :type/TextLike)
+(derive :type/MySQLEnum :type/Text)
 ;; IP address can be either a data type e.g. Postgres `inet` or a semantic type e.g. a `text` column that has IP
 ;; addresses
 (derive :type/IPAddress :type/TextLike)

--- a/test/metabase/lib/types/isa_test.cljc
+++ b/test/metabase/lib/types/isa_test.cljc
@@ -101,7 +101,8 @@
       (are [typ] (= ::lib.types.constants/number (lib.types.isa/field-type {base-or-effective-type-key typ}))
         :type/BigInteger :type/Integer :type/Float :type/Decimal))
     (testing "string"
-      (is (= ::lib.types.constants/string (lib.types.isa/field-type {base-or-effective-type-key :type/Text}))))
+      (are [typ] (= ::lib.types.constants/string (lib.types.isa/field-type {base-or-effective-type-key typ}))
+        :type/Text :type/MySQLEnum))
     (testing "types of string"
       (are [typ] (= ::lib.types.constants/string (lib.types.isa/field-type {base-or-effective-type-key :type/Text
                                                                             :semantic-type typ}))


### PR DESCRIPTION
Fixes #44807.

This change is in accordance with https://dev.mysql.com/doc/refman/8.0/en/enum.html describing the ENUM types as a kind of string.  All our string operations seem to work with MySQL ENUM fields.