### PR TITLE
Don't show Invalid questions for Joins in Query Builder

### DIFF
--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -1586,8 +1586,7 @@ describe("issue 44668", () => {
   });
 });
 
-// TODO: unskip when metabase#44974 is fixed
-describe.skip("issue 44974", () => {
+describe("issue 44974", () => {
   const PG_DB_ID = 2;
 
   beforeEach(() => {
@@ -1598,7 +1597,7 @@ describe.skip("issue 44974", () => {
   it("entity picker should not offer to join with a table or a question from a different database (metabase#44974)", () => {
     withDatabase(PG_DB_ID, ({ PEOPLE_ID }) => {
       const questionDetails = {
-        name: "Question 44794 in Postgres DB",
+        name: "Question 44974 in Postgres DB",
         query: {
           database: PG_DB_ID,
           "source-table": PEOPLE_ID,

--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -1598,8 +1598,8 @@ describe("issue 44974", () => {
     withDatabase(PG_DB_ID, ({ PEOPLE_ID }) => {
       const questionDetails = {
         name: "Question 44974 in Postgres DB",
+        database: PG_DB_ID,
         query: {
-          database: PG_DB_ID,
           "source-table": PEOPLE_ID,
           limit: 1,
         },
@@ -1614,11 +1614,8 @@ describe("issue 44974", () => {
       join();
 
       entityPickerModal().within(() => {
-        entityPickerModalTab("Recents").should(
-          "have.attr",
-          "aria-selected",
-          "true",
-        );
+        entityPickerModalTab("Recents").should("not.exist");
+        entityPickerModalTab("Saved questions").click();
         cy.findByText(questionDetails.name).should("not.exist");
       });
     });

--- a/frontend/src/metabase-types/api/activity.ts
+++ b/frontend/src/metabase-types/api/activity.ts
@@ -43,7 +43,7 @@ export interface RecentTableItem extends BaseRecentItem {
 export interface RecentCollectionItem extends BaseRecentItem {
   model: "collection" | "dashboard" | "card" | "dataset" | "metric";
   can_write: boolean;
-  database_id?: number | null; // for models and questions
+  database_id?: number; // for models and questions
   parent_collection: {
     id: number | null;
     name: string;

--- a/frontend/src/metabase-types/api/activity.ts
+++ b/frontend/src/metabase-types/api/activity.ts
@@ -43,6 +43,7 @@ export interface RecentTableItem extends BaseRecentItem {
 export interface RecentCollectionItem extends BaseRecentItem {
   model: "collection" | "dashboard" | "card" | "dataset" | "metric";
   can_write: boolean;
+  database_id?: number | null; // for models and questions
   parent_collection: {
     id: number | null;
     name: string;

--- a/frontend/src/metabase-types/api/activity.ts
+++ b/frontend/src/metabase-types/api/activity.ts
@@ -1,5 +1,5 @@
 import type { CardDisplayType } from "./card";
-import type { InitialSyncStatus } from "./database";
+import type { DatabaseId, InitialSyncStatus } from "./database";
 
 export const ACTIVITY_MODELS = [
   "table",
@@ -43,7 +43,7 @@ export interface RecentTableItem extends BaseRecentItem {
 export interface RecentCollectionItem extends BaseRecentItem {
   model: "collection" | "dashboard" | "card" | "dataset" | "metric";
   can_write: boolean;
-  database_id?: number; // for models and questions
+  database_id?: DatabaseId; // for models and questions
   parent_collection: {
     id: number | null;
     name: string;

--- a/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
+++ b/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
@@ -6,6 +6,7 @@ import { getQuestionVirtualTableId } from "metabase-lib/v1/metadata/utils/saved-
 import type {
   CollectionItemModel,
   DatabaseId,
+  RecentItem,
   TableId,
 } from "metabase-types/api";
 
@@ -80,6 +81,19 @@ export const DataPickerModal = ({
   const questionsShouldShowItem = useMemo(() => {
     return createShouldShowItem(["card"], databaseId);
   }, [databaseId]);
+
+  const recentFilter = useCallback(
+    (recentItems: RecentItem[]) => {
+      if (databaseId) {
+        return recentItems.filter(
+          item => "database_id" in item && item.database_id === databaseId,
+        );
+      }
+
+      return recentItems;
+    },
+    [databaseId],
+  );
 
   const searchParams = useMemo(() => {
     return databaseId ? { table_db_id: databaseId } : undefined;
@@ -180,6 +194,7 @@ export const DataPickerModal = ({
   return (
     <EntityPickerModal
       canSelectItem
+      recentFilter={recentFilter}
       defaultToRecentTab={false}
       initialValue={value}
       options={options}

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -425,7 +425,7 @@
                        :order-by [[:id :desc]]
                        :limit    1}
                       :moderated_status]]
-                    (= :model card-type)
+                    (#{:question :model} card-type)
                     (conj :c.database_id))
        :from      [[:report_card :c]]
        :left-join [[:revision :r] [:and

--- a/src/metabase/models/recent_views.clj
+++ b/src/metabase/models/recent_views.clj
@@ -178,9 +178,11 @@
     [:multi {:dispatch :model}
      [:card [:map
              [:display :string]
+             [:database_id :int]
              [:parent_collection ::pc]
              [:moderated_status ::verified]]]
      [:dataset [:map
+                [:database_id :int]
                 [:parent_collection ::pc]
                 [:moderated_status ::verified]]]
      [:metric [:map
@@ -226,7 +228,7 @@
 ;; ================== Recent Cards ==================
 
 (defn card-recents
-  "Query to select card data"
+  "Query to select `report_card` data"
   [card-ids]
   (if-not (seq card-ids)
     []
@@ -235,6 +237,7 @@
                          :card.description
                          :card.archived
                          :card.id
+                         :card.database_id
                          :card.display
                          [:card.collection_id :entity-coll-id]
                          [:mr.status :moderated-status]
@@ -276,6 +279,7 @@
                    (ellide-archived model_object))]
     {:id model_id
      :name (:name card)
+     :database_id (:database_id card)
      :description (:description card)
      :display (some-> card :display name)
      :model :card
@@ -292,6 +296,7 @@
                       (ellide-archived model_object))]
     {:id model_id
      :name (:name dataset)
+     :database_id (:database_id dataset)
      :description (:description dataset)
      :model :dataset
      :can_write (mi/can-write? dataset)

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -649,7 +649,7 @@
                   :name                (:name card)
                   :collection_position nil
                   :collection_preview  true
-                  :database_id         nil
+                  :database_id         (mt/id)
                   :display             "table"
                   :description         nil
                   :entity_id           (:entity_id card)
@@ -690,7 +690,7 @@
                                                            :collection_id (u/the-id collection)}
                                Card       {card-id-2 :id} {:collection_id (u/the-id collection)}]
         (is (= #{{:id card-id-1 :database_id (mt/id)}
-                 {:id card-id-2 :database_id nil}}
+                 {:id card-id-2 :database_id (mt/id)}}
                (->> (:data (mt/user-http-request :crowberto :get 200
                                                  (str "collection/" (u/the-id collection) "/items")))
                     (map #(select-keys % [:id :database_id]))

--- a/test/metabase/models/recent_views_test.clj
+++ b/test/metabase/models/recent_views_test.clj
@@ -34,7 +34,8 @@
 (deftest simple-get-list-card-test
   (mt/with-temp
     [:model/Collection {coll-id :id} {:name "my coll"}
-     :model/Card       {card-id         :id} {:type "question" :name "name" :display "display" :collection_id coll-id}]
+     :model/Database   {db-id :id}   {}
+     :model/Card       {card-id :id} {:type "question" :name "name" :display "display" :collection_id coll-id :database_id db-id}]
     (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Card card-id :view)
     (is (= [{:description nil,
              :can_write true,
@@ -44,7 +45,8 @@
              :id card-id,
              :display "display",
              :timestamp String
-             :model :card}]
+             :model :card
+             :database_id db-id}]
            (mt/with-test-user :rasta
              (mapv fixup
                    (recent-views (mt/user->id :rasta))))))))
@@ -52,7 +54,8 @@
 (deftest simple-get-list-dataset-test
   (mt/with-temp
     [:model/Collection {coll-id :id} {:name "my coll"}
-     :model/Card       {card-id         :id} {:type "model" :name "name" :display "display" :collection_id coll-id}]
+     :model/Database   {db-id :id}   {}
+     :model/Card       {card-id         :id} {:type "model" :name "name" :display "display" :collection_id coll-id :database_id db-id}]
     (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Card card-id :view)
     (is (= [{:description nil,
              :can_write true,
@@ -61,7 +64,8 @@
              :moderated_status nil,
              :id card-id,
              :timestamp String
-             :model :dataset}]
+             :model :dataset
+             :database_id db-id}]
            (mt/with-test-user :rasta
              (mapv fixup
                    (recent-views (mt/user->id :rasta))))))))
@@ -174,14 +178,12 @@
       (mt/with-full-data-perms-for-all-users!
         (mt/with-temp
           [:model/Collection {parent-coll-id :id} {:name "parent"}
-           :model/Card       {card-id :id} {:type "question" :name "my card" :description "this is my card" :collection_id parent-coll-id}
-           :model/Card       {model-id :id} {:type "model" :name "my model" :description "this is my model" :collection_id parent-coll-id}
+           :model/Database   {db-id :id} {:name "My DB"} ;; just needed for temp tables and card's db:
 
+           :model/Card       {card-id :id} {:type "question" :name "my card" :description "this is my card" :collection_id parent-coll-id :database_id db-id}
+           :model/Card       {model-id :id} {:type "model" :name "my model" :description "this is my model" :collection_id parent-coll-id :database_id db-id}
            :model/Dashboard  {dashboard-id :id} {:name "my dash" :description "this is my dash" :collection_id parent-coll-id}
-
            :model/Collection {collection-id :id} {:name "my collection" :description "this is my collection" :location (->location parent-coll-id)}
-
-           :model/Database   {db-id :id} {:name "My DB"} ;; just needed for these temp tables
            :model/Table      {table-id :id} {:name "tablet" :display_name "I am the table" :db_id db-id, :is_upload true}]
           (doseq [[model model-id] [[:model/Card card-id]
                                     [:model/Card model-id]
@@ -216,7 +218,8 @@
                    :model :dataset,
                    :can_write true,
                    :moderated_status nil,
-                   :parent_collection {:id "ID", :name "parent", :authority_level nil}}
+                   :parent_collection {:id "ID", :name "parent", :authority_level nil}
+                   :database_id db-id}
                   {:description "this is my card",
                    :can_write true,
                    :name "my card",
@@ -224,7 +227,8 @@
                    :moderated_status nil,
                    :id "ID",
                    :display "table",
-                   :model :card}]
+                   :model :card
+                   :database_id db-id}]
                  (mt/with-test-user :rasta
                    (with-redefs [mi/can-read? (constantly true)
                                  mi/can-write? (fn ([id] (not= id table-id))


### PR DESCRIPTION
fixes https://github.com/metabase/metabase/issues/44974

- adds database_id to recents, and question collection items
- adds db id filtering to recents

![sameDBJoins](https://github.com/user-attachments/assets/2e3f8d7f-47a5-4f93-90a2-c242807a3a9c)

