### PR TITLE
Fix several problems with the localization of the Performance feature

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/caching/components/ResetButtonContainer.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/ResetButtonContainer.styled.tsx
@@ -3,16 +3,19 @@ import styled from "@emotion/styled";
 
 import type { FormSubmitButtonProps } from "metabase/forms";
 import { FormSubmitButton } from "metabase/forms";
-import { alpha } from "metabase/lib/colors";
 
 export const ResetAllFormSubmitButton = styled(FormSubmitButton, {
   shouldForwardProp: prop => prop !== "highlightOnHover",
 })<FormSubmitButtonProps & { highlightOnHover?: boolean }>`
-  ${({ highlightOnHover, theme }) =>
+  ${({ highlightOnHover }) =>
     highlightOnHover
       ? css`
           :hover {
-            background-color: ${alpha(theme.fn.themeColor("error"), 0.15)};
+            background-color: color-mix(
+              in srgb,
+              var(--mb-color-error),
+              transparent 85%
+            );
           }
         `
       : ""}

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/ResetButtonContainer.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/ResetButtonContainer.tsx
@@ -49,6 +49,8 @@ const ResetAllToDefaultButtonFormBody = () => {
             }}
             label={
               <Text
+                // Prevents the label from getting cut off vertically
+                h="1rem"
                 lh="1"
                 fw="normal"
                 color="error"

--- a/enterprise/frontend/src/metabase-enterprise/caching/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/caching/constants.ts
@@ -1,7 +1,7 @@
 import { t } from "ttag";
 import * as Yup from "yup";
 
-import { positiveInteger } from "metabase/admin/performance/constants/complex";
+import { getPositiveIntegerSchema } from "metabase/admin/performance/constants/complex";
 import type { StrategyData } from "metabase/admin/performance/types";
 import { defaultCron } from "metabase/admin/performance/utils";
 import { CacheDurationUnit } from "metabase-types/api";
@@ -19,7 +19,7 @@ const scheduleStrategyValidationSchema = Yup.object({
 
 const durationStrategyValidationSchema = Yup.object({
   type: Yup.string().equals(["duration"]),
-  duration: positiveInteger.default(24),
+  duration: getPositiveIntegerSchema().default(24),
   unit: Yup.string().test(
     "is-duration-unit",
     "${path} is not a valid duration",
@@ -27,15 +27,16 @@ const durationStrategyValidationSchema = Yup.object({
   ),
 });
 
+/** Caching strategies available on EE only */
 export const enterpriseOnlyCachingStrategies: Record<string, StrategyData> = {
   schedule: {
     label: t`Schedule: pick when to regularly invalidate the cache`,
     shortLabel: t`Scheduled`,
-    validateWith: scheduleStrategyValidationSchema,
+    validationSchema: scheduleStrategyValidationSchema,
   },
   duration: {
     label: t`Duration: keep the cache for a number of hours`,
-    validateWith: durationStrategyValidationSchema,
+    validationSchema: durationStrategyValidationSchema,
     shortLabel: t`Duration`,
   },
 };

--- a/frontend/src/metabase/admin/performance/components/StrategyForm.tsx
+++ b/frontend/src/metabase/admin/performance/components/StrategyForm.tsx
@@ -1,7 +1,7 @@
 import { useFormikContext } from "formik";
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { t } from "ttag";
+import { c, t } from "ttag";
 import _ from "underscore";
 
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
@@ -45,6 +45,7 @@ import {
   getLabelString,
   cronToScheduleSettings,
   scheduleSettingsToCron,
+  getStrategyValidationSchema,
 } from "../utils";
 
 import {
@@ -341,7 +342,7 @@ const ScheduleStrategyFormFields = () => {
       schedule={schedule}
       scheduleOptions={["hourly", "daily", "weekly", "monthly"]}
       onScheduleChange={onScheduleChange}
-      verb={t`Invalidate`}
+      verb={c("A verb in the imperative mood").t`Invalidate`}
       timezone={timezone}
     />
   );
@@ -415,13 +416,19 @@ const StrategySelector = ({
       >
         <Stack mt="md" spacing="md">
           {_.map(availableStrategies, (option, name) => {
-            const optionLabelParts = getLabelString(option.label, model).split(
-              ":",
-            );
+            const labelString = getLabelString(option.label, model);
+            /** Special colon sometimes used in Asian languages */
+            const wideColon = "：";
+            const colon = labelString.includes(wideColon) ? wideColon : ":";
+            const optionLabelParts = labelString.split(colon);
             const optionLabelFormatted = (
               <>
                 <strong>{optionLabelParts[0]}</strong>
-                {optionLabelParts[1] ? <>: {optionLabelParts[1]}</> : null}
+                {optionLabelParts[1] ? (
+                  <>
+                    {colon} {optionLabelParts[1]}
+                  </>
+                ) : null}
               </>
             );
             return (
@@ -431,6 +438,12 @@ const StrategySelector = ({
                 label={optionLabelFormatted}
                 autoFocus={values.type === name}
                 role="radio"
+                styles={{
+                  label: {
+                    paddingLeft: undefined,
+                    paddingInlineStart: ".5rem",
+                  },
+                }}
               />
             );
           })}
@@ -491,9 +504,10 @@ const getDefaultValueForField = (
   strategyType: CacheStrategyType,
   fieldName?: string,
 ) => {
-  return fieldName
-    ? PLUGIN_CACHING.strategies[strategyType].validateWith.cast({})[fieldName]
-    : "";
+  const schema = getStrategyValidationSchema(
+    PLUGIN_CACHING.strategies[strategyType],
+  );
+  return fieldName ? schema.cast({})[fieldName] : "";
 };
 
 const MultiplierFieldSubtitle = () => (

--- a/frontend/src/metabase/admin/performance/hooks/useSaveStrategy.tsx
+++ b/frontend/src/metabase/admin/performance/hooks/useSaveStrategy.tsx
@@ -13,6 +13,7 @@ import type {
 import { rootId } from "../constants/simple";
 import {
   getFieldsForStrategyType,
+  getStrategyValidationSchema,
   populateMinDurationSeconds,
   translateConfigToAPI,
 } from "../utils";
@@ -53,8 +54,9 @@ export const useSaveStrategy = (
         const validFields = getFieldsForStrategyType(values.type);
         const newStrategy = _.pick(values, validFields) as CacheStrategy;
 
-        const validatedStrategy =
-          strategies[values.type].validateWith.validateSync(newStrategy);
+        const strategyData = strategies[values.type];
+        const strategySchema = getStrategyValidationSchema(strategyData);
+        const validatedStrategy = strategySchema.validateSync(newStrategy);
 
         const newConfig: CacheConfig = {
           ...baseConfig,

--- a/frontend/src/metabase/admin/performance/types.ts
+++ b/frontend/src/metabase/admin/performance/types.ts
@@ -14,7 +14,8 @@ export type StrategyData = {
    * The human-readable label for the strategy, which can be a string or a function that takes a model and returns a string */
   label: StrategyLabel;
   shortLabel?: StrategyLabel;
-  validateWith: AnySchema;
+  /** Schema used to validate the value. This field can optionally be set to a function that returns a schema. This helps ensure that calls to ttag functions do not run until after the locale is set */
+  validationSchema: AnySchema | (() => AnySchema);
 };
 
 export enum PerformanceTabId {

--- a/frontend/src/metabase/admin/performance/utils.tsx
+++ b/frontend/src/metabase/admin/performance/utils.tsx
@@ -1,12 +1,10 @@
-import dayjs from "dayjs";
 import { t } from "ttag";
 import { memoize } from "underscore";
 import type { SchemaObjectDescription } from "yup/lib/schema";
 
 import {
   Cron,
-  optionNameTranslations,
-  weekdays,
+  getScheduleStrings,
 } from "metabase/components/Schedule/constants";
 import { isNullOrUndefined } from "metabase/lib/types";
 import { PLUGIN_CACHING } from "metabase/plugins";
@@ -23,12 +21,13 @@ import type {
 } from "metabase-types/api";
 
 import { defaultMinDurationMs, rootId } from "./constants/simple";
-import type { StrategyLabel } from "./types";
+import type { StrategyData, StrategyLabel } from "./types";
 
 const AM = 0;
 const PM = 1;
 
 const dayToCron = (day: ScheduleSettings["schedule_day"]) => {
+  const { weekdays } = getScheduleStrings();
   const index = weekdays.findIndex(o => o.value === day);
   if (index === -1) {
     throw new Error(`Invalid day: ${day}`);
@@ -93,6 +92,8 @@ export const cronToScheduleSettings_unmemoized = (
   if (!cron) {
     return defaultSchedule;
   }
+
+  const { weekdays } = getScheduleStrings();
 
   // The Quartz cron library used in the backend distinguishes between 'no specific value' and 'all values',
   // but for simplicity we can treat them as the same here
@@ -174,13 +175,13 @@ export const defaultCron = scheduleSettingsToCron(defaultSchedule);
 const isValidAmPm = (amPm: number) => amPm === AM || amPm === PM;
 
 export const hourToTwelveHourFormat = (hour: number) => hour % 12 || 12;
+
 export const hourTo24HourFormat = (hour: number, amPm: number): number => {
   if (!isValidAmPm(amPm)) {
     amPm = AM;
   }
-  const amPmString = amPm === AM ? "AM" : "PM";
-  const convertedString = dayjs(`${hour} ${amPmString}`, "h A").format("HH");
-  return parseInt(convertedString);
+  const hour24 = amPm === PM ? (hour % 12) + 12 : hour % 12;
+  return hour24 === 24 ? 0 : hour24;
 };
 
 type ErrorWithMessage = { data: { message: string } };
@@ -207,9 +208,10 @@ export const resolveSmoothly = async (
 
 export const getFrequencyFromCron = (cron: string) => {
   const scheduleType = cronToScheduleSettings(cron)?.schedule_type;
+  const { scheduleOptionNames } = getScheduleStrings();
   return isNullOrUndefined(scheduleType)
     ? ""
-    : optionNameTranslations[scheduleType];
+    : scheduleOptionNames[scheduleType];
 };
 
 export const isValidStrategyName = (
@@ -241,11 +243,20 @@ export const getShortStrategyLabel = (
   }
 };
 
+export const getStrategyValidationSchema = (strategyData: StrategyData) => {
+  if (typeof strategyData.validationSchema === "function") {
+    return strategyData.validationSchema();
+  } else {
+    return strategyData.validationSchema;
+  }
+};
+
 export const getFieldsForStrategyType = (strategyType: CacheStrategyType) => {
   const { strategies } = PLUGIN_CACHING;
-  const strategy = strategies[strategyType];
-  const validationSchemaDescription =
-    strategy.validateWith.describe() as SchemaObjectDescription;
+  const strategyData = strategies[strategyType];
+  const validationSchemaDescription = getStrategyValidationSchema(
+    strategyData,
+  ).describe() as SchemaObjectDescription;
   const fieldRecord = validationSchemaDescription.fields;
   const fields = Object.keys(fieldRecord);
   return fields;

--- a/frontend/src/metabase/components/Schedule/Schedule.tsx
+++ b/frontend/src/metabase/components/Schedule/Schedule.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { type ReactNode, useCallback } from "react";
 import { c } from "ttag";
 
 import { capitalize } from "metabase/lib/formatting/strings";
@@ -14,20 +14,11 @@ import {
   SelectWeekday,
   SelectWeekdayOfMonth,
 } from "./components";
-import {
-  defaultDay,
-  defaultHour,
-  frames,
-  optionNameTranslations,
-  weekdayOfMonthOptions,
-} from "./constants";
+import { defaultDay, defaultHour, getScheduleStrings } from "./constants";
 import type { ScheduleChangeProp, UpdateSchedule } from "./types";
-import { addScheduleComponents, getLongestSelectLabel } from "./utils";
+import { fillScheduleTemplate, getLongestSelectLabel } from "./utils";
 
 type ScheduleProperty = keyof ScheduleSettings;
-
-const getOptionName = (option: ScheduleType) =>
-  optionNameTranslations[option] || capitalize(option);
 
 export interface ScheduleProps {
   schedule: ScheduleSettings;
@@ -124,9 +115,11 @@ export const Schedule = ({
       style={{
         gridTemplateColumns: "fit-content(100%) auto",
         gap: ".5rem",
+        rowGap: ".35rem",
       }}
     >
       {renderSchedule({
+        fillScheduleTemplate,
         schedule,
         updateSchedule,
         scheduleOptions,
@@ -139,6 +132,7 @@ export const Schedule = ({
 };
 
 const renderSchedule = ({
+  fillScheduleTemplate,
   schedule,
   updateSchedule,
   scheduleOptions,
@@ -147,7 +141,13 @@ const renderSchedule = ({
   minutesOnHourPicker,
 }: Omit<ScheduleProps, "onScheduleChange"> & {
   updateSchedule: UpdateSchedule;
+  fillScheduleTemplate: (
+    template: string,
+    components: ReactNode[],
+  ) => ReactNode;
 }) => {
+  const { frames, weekdayOfMonthOptions } = getScheduleStrings();
+
   const itemProps = {
     schedule,
     updateSchedule,
@@ -176,10 +176,14 @@ const renderSchedule = ({
   if (scheduleType === "hourly") {
     if (minutesOnHourPicker) {
       // e.g. "Send hourly at 15 minutes past the hour"
-      return addScheduleComponents(
+      return fillScheduleTemplate(
         c(
           "{0} is a verb like 'Send', {1} is an adverb like 'hourly', {2} is a number of minutes",
-        ).t`{0} {1} at {2} minutes past the hour`,
+        ).t`${"{0}"} ${"{1}"} at ${"{2}"} minutes past the hour`,
+        // NOTE: Expressions like ${"{0}"} do two things: they put a placeholder
+        // into the string shown to translators (a.k.a. the "msgid" string), and
+        // they put a placeholder in the translated string (a.k.a. the "msgstr" string),
+        // so that we can insert components into the translated string in the right places
         [
           verb,
           <SelectFrequency key="frequency" {...frequencyProps} />,
@@ -188,11 +192,11 @@ const renderSchedule = ({
       );
     } else {
       // e.g. "Send hourly"
-      return addScheduleComponents(
-        // We cannot use "{0} {1}" as an argument to the t function, since only has placeholders.
+      return fillScheduleTemplate(
+        // We cannot use "{0} {1}" as an argument to the t function, since it only has placeholders.
         // So, as a workaround, we include square brackets in the string, and then remove them.
         c("{0} is a verb like 'Send', {1} is an adverb like 'hourly'.")
-          .t`[{0} {1}]`
+          .t`[${"{0}"} ${"{1}"}]`
           .replace(/^\[/, "")
           .replace(/\]$/, ""),
         [verb, <SelectFrequency key="frequency" {...frequencyProps} />],
@@ -200,10 +204,10 @@ const renderSchedule = ({
     }
   } else if (scheduleType === "daily") {
     // e.g. "Send daily at 12:00pm"
-    return addScheduleComponents(
+    return fillScheduleTemplate(
       c(
         "{0} is a verb like 'Send', {1} is an adverb like 'hourly', {2} is a time like '12:00pm'",
-      ).t`{0} {1} at {2}`,
+      ).t`${"{0}"} ${"{1}"} at ${"{2}"}`,
       [
         verb,
         <SelectFrequency key="frequency" {...frequencyProps} />,
@@ -212,10 +216,10 @@ const renderSchedule = ({
     );
   } else if (scheduleType === "weekly") {
     // e.g. "Send weekly on Tuesday at 12:00pm"
-    return addScheduleComponents(
+    return fillScheduleTemplate(
       c(
         "{0} is a verb like 'Send', {1} is an adverb like 'hourly', {2} is a day like 'Tuesday', {3} is a time like '12:00pm'",
-      ).t`{0} {1} on {2} at {3}`,
+      ).t`${"{0}"} ${"{1}"} on ${"{2}"} at ${"{3}"}`,
       [
         verb,
         <SelectFrequency key="frequency" {...frequencyProps} />,
@@ -226,10 +230,10 @@ const renderSchedule = ({
   } else if (scheduleType === "monthly") {
     // e.g. "Send monthly on the 15th at 12:00pm"
     if (schedule.schedule_frame === "mid") {
-      return addScheduleComponents(
+      return fillScheduleTemplate(
         c(
           "{0} is a verb like 'Send', {1} is an adverb like 'hourly', {2} is the noun '15th' (as in 'the 15th of the month'), {3} is a time like '12:00pm'",
-        ).t`{0} {1} on the {2} at {3}`,
+        ).t`${"{0}"} ${"{1}"} on the ${"{2}"} at ${"{3}"}`,
         [
           verb,
           <SelectFrequency key="frequency" {...frequencyProps} />,
@@ -239,10 +243,10 @@ const renderSchedule = ({
       );
     } else {
       // e.g. "Send monthly on the first Tuesday at 12:00pm"
-      return addScheduleComponents(
+      return fillScheduleTemplate(
         c(
           "{0} is a verb like 'Send', {1} is an adverb like 'hourly', {2} is an adjective like 'first', {3} is a day like 'Tuesday', {4} is a time like '12:00pm'",
-        ).t`{0} {1} on the {2} {3} at {4}`,
+        ).t`${"{0}"} ${"{1}"} on the ${"{2}"} ${"{3}"} at ${"{4}"}`,
         [
           verb,
           <SelectFrequency key="frequency" {...frequencyProps} />,
@@ -271,8 +275,10 @@ const SelectFrequency = ({
   updateSchedule: UpdateSchedule;
   scheduleOptions: ScheduleType[];
 }) => {
+  const { scheduleOptionNames } = getScheduleStrings();
+
   const scheduleTypeOptions = scheduleOptions.map(option => ({
-    label: getOptionName(option),
+    label: scheduleOptionNames[option] || capitalize(option),
     value: option,
   }));
 

--- a/frontend/src/metabase/components/Schedule/components.tsx
+++ b/frontend/src/metabase/components/Schedule/components.tsx
@@ -1,10 +1,12 @@
 import { useMemo } from "react";
 import { t } from "ttag";
+import _ from "underscore";
 
 import {
   hourTo24HourFormat,
   hourToTwelveHourFormat,
 } from "metabase/admin/performance/utils";
+import { measureTextWidth } from "metabase/lib/measure-text";
 import { useSelector } from "metabase/lib/redux";
 import { has24HourModeSetting } from "metabase/lib/time";
 import { getApplicationName } from "metabase/selectors/whitelabel";
@@ -17,24 +19,26 @@ import type {
 } from "metabase-types/api";
 
 import {
-  amAndPM,
+  type Weekday,
   defaultHour,
-  frames,
   getHours,
+  getScheduleStrings,
   minutes,
-  weekdayOfMonthOptions,
-  weekdays,
 } from "./constants";
 import type { UpdateSchedule } from "./types";
 import { getLongestSelectLabel } from "./utils";
 
+export type SelectFrameProps = {
+  schedule: ScheduleSettings;
+  updateSchedule: UpdateSchedule;
+  frames?: { label: string; value: ScheduleFrameType }[];
+};
+
 export const SelectFrame = ({
   schedule,
   updateSchedule,
-}: {
-  schedule: ScheduleSettings;
-  updateSchedule: UpdateSchedule;
-}) => {
+  frames = getScheduleStrings().frames,
+}: SelectFrameProps) => {
   return (
     <AutoWidthSelect
       value={schedule.schedule_frame}
@@ -55,6 +59,7 @@ export const SelectTime = ({
   updateSchedule: UpdateSchedule;
   timezone?: string | null;
 }) => {
+  const { amAndPM } = getScheduleStrings();
   const applicationName = useSelector(getApplicationName);
   const isClock12Hour = !has24HourModeSetting();
   const hourIn24HourFormat =
@@ -68,11 +73,12 @@ export const SelectTime = ({
     : hourIn24HourFormat;
   const amPm = hourIn24HourFormat >= 12 ? 1 : 0;
   const hourIndex = isClock12Hour && hour === 12 ? 0 : hour;
+  const value = hourIndex === 0 && isClock12Hour ? "12" : hourIndex.toString();
   return (
     <Group spacing={isClock12Hour ? "xs" : "sm"} style={{ rowGap: ".5rem" }}>
       {/* Select the hour */}
       <AutoWidthSelect
-        value={hourIndex.toString()}
+        value={value}
         data={getHours()}
         onChange={(value: string) => {
           const num = Number(value);
@@ -107,13 +113,16 @@ export const SelectTime = ({
   );
 };
 
+export type SelectWeekdayProps = {
+  schedule: ScheduleSettings;
+  updateSchedule: UpdateSchedule;
+};
+
 export const SelectWeekday = ({
   schedule,
   updateSchedule,
-}: {
-  schedule: ScheduleSettings;
-  updateSchedule: UpdateSchedule;
-}) => {
+}: SelectWeekdayProps) => {
+  const { weekdays } = getScheduleStrings();
   return (
     <AutoWidthSelect
       value={schedule.schedule_day}
@@ -125,23 +134,32 @@ export const SelectWeekday = ({
   );
 };
 
+export type SelectWeekdayOfMonthProps = {
+  schedule: ScheduleSettings;
+  updateSchedule: UpdateSchedule;
+  weekdayOfMonthOptions?: (
+    | Weekday
+    | { label: string; value: "calendar-day" }
+  )[];
+};
+
 /** Selects the weekday of the month, e.g. the first Monday of the month
   "First" is selected via SelectFrame. This component provides the weekday */
 export const SelectWeekdayOfMonth = ({
   schedule,
   updateSchedule,
-}: {
-  schedule: ScheduleSettings;
-  updateSchedule: UpdateSchedule;
-}) => (
-  <AutoWidthSelect
-    value={schedule.schedule_day || "calendar-day"}
-    onChange={(value: ScheduleDayType | "calendar-day") =>
-      updateSchedule("schedule_day", value === "calendar-day" ? null : value)
-    }
-    data={weekdayOfMonthOptions}
-  />
-);
+  weekdayOfMonthOptions = getScheduleStrings().weekdayOfMonthOptions,
+}: SelectWeekdayOfMonthProps) => {
+  return (
+    <AutoWidthSelect
+      value={schedule.schedule_day || "calendar-day"}
+      onChange={(value: ScheduleDayType | "calendar-day") =>
+        updateSchedule("schedule_day", value === "calendar-day" ? null : value)
+      }
+      data={weekdayOfMonthOptions}
+    />
+  );
+};
 
 export const SelectMinute = ({
   schedule,
@@ -165,25 +183,24 @@ export const SelectMinute = ({
 };
 
 export const AutoWidthSelect = (props: SelectProps) => {
-  const longestLabel = useMemo(
-    () => getLongestSelectLabel(props.data),
-    [props.data],
-  );
-  const maxWidth =
-    longestLabel.length > 15 ? "unset" : `${longestLabel.length + 0.85}rem`;
+  const maxWidth = useMemo(() => {
+    const longestLabel = getLongestSelectLabel(props.data);
+    const maxWidth = `${measureTextWidth(longestLabel) + 60}px`;
+    return maxWidth;
+  }, [props.data]);
   return (
     <Select
       miw="5rem"
-      maw={maxWidth}
+      w={maxWidth}
       styles={{
         wrapper: {
-          paddingRight: 0,
+          paddingInlineEnd: 0,
           marginTop: 0,
         },
         label: {
           marginBottom: 0,
         },
-        input: { paddingRight: 0 },
+        input: { paddingInlineEnd: 0, lineHeight: "2.5rem" },
       }}
       {...props}
     />

--- a/frontend/src/metabase/components/Schedule/components.tsx
+++ b/frontend/src/metabase/components/Schedule/components.tsx
@@ -12,6 +12,7 @@ import { has24HourModeSetting } from "metabase/lib/time";
 import { getApplicationName } from "metabase/selectors/whitelabel";
 import type { SelectProps } from "metabase/ui";
 import { Box, Group, SegmentedControl, Select, Tooltip } from "metabase/ui";
+import type { FontStyle } from "metabase/visualizations/shared/types/measure-text";
 import type {
   ScheduleDayType,
   ScheduleFrameType,
@@ -182,12 +183,15 @@ export const SelectMinute = ({
   );
 };
 
-export const AutoWidthSelect = (props: SelectProps) => {
+export const AutoWidthSelect = ({
+  style,
+  ...props
+}: { style?: FontStyle } & SelectProps) => {
   const maxWidth = useMemo(() => {
     const longestLabel = getLongestSelectLabel(props.data);
-    const maxWidth = `${measureTextWidth(longestLabel) + 60}px`;
+    const maxWidth = `${measureTextWidth(longestLabel, style) + 60}px`;
     return maxWidth;
-  }, [props.data]);
+  }, [props.data, style]);
   return (
     <Select
       miw="5rem"

--- a/frontend/src/metabase/components/Schedule/components.tsx
+++ b/frontend/src/metabase/components/Schedule/components.tsx
@@ -1,14 +1,13 @@
 import { useMemo } from "react";
 import { t } from "ttag";
-import _ from "underscore";
 
 import {
   hourTo24HourFormat,
   hourToTwelveHourFormat,
 } from "metabase/admin/performance/utils";
-import { measureTextWidth } from "metabase/lib/measure-text";
 import { useSelector } from "metabase/lib/redux";
 import { has24HourModeSetting } from "metabase/lib/time";
+import { getSetting } from "metabase/selectors/settings";
 import { getApplicationName } from "metabase/selectors/whitelabel";
 import type { SelectProps } from "metabase/ui";
 import { Box, Group, SegmentedControl, Select, Tooltip } from "metabase/ui";
@@ -27,7 +26,7 @@ import {
   minutes,
 } from "./constants";
 import type { UpdateSchedule } from "./types";
-import { getLongestSelectLabel } from "./utils";
+import { getLongestSelectLabel, measureTextWidthSafely } from "./utils";
 
 export type SelectFrameProps = {
   schedule: ScheduleSettings;
@@ -186,12 +185,20 @@ export const SelectMinute = ({
 export const AutoWidthSelect = ({
   style,
   ...props
-}: { style?: FontStyle } & SelectProps) => {
+}: { style?: Partial<FontStyle> } & SelectProps) => {
+  const fontFamily = useSelector(state =>
+    getSetting(state, "application-font"),
+  );
   const maxWidth = useMemo(() => {
     const longestLabel = getLongestSelectLabel(props.data);
-    const maxWidth = `${measureTextWidth(longestLabel, style) + 60}px`;
+    const maxWidth = `${
+      measureTextWidthSafely(longestLabel, 50, {
+        family: fontFamily,
+        ...style,
+      }) + 60
+    }px`;
     return maxWidth;
-  }, [props.data, style]);
+  }, [props.data, style, fontFamily]);
   return (
     <Select
       miw="5rem"

--- a/frontend/src/metabase/components/Schedule/constants.ts
+++ b/frontend/src/metabase/components/Schedule/constants.ts
@@ -1,39 +1,49 @@
 import { c, t } from "ttag";
-import { times } from "underscore";
+import _ from "underscore";
 
 import { has24HourModeSetting } from "metabase/lib/time";
-import type { ScheduleDayType } from "metabase-types/api";
+import type { ScheduleDayType, ScheduleFrameType } from "metabase-types/api";
 
-export const minutes = times(60, n => ({
+export const minutes = _.times(60, n => ({
   label: n.toString(),
   value: n.toString(),
 }));
 
-const addZeroesToHour = (
-  hour: number,
-  { useZero = false }: { useZero: boolean },
-) => {
-  if (!useZero && hour === 0) {
-    hour = 12;
-  }
-  return c("This is a time like 12:00pm. {0} is the hour part of the time")
-    .t`${hour}:00`;
-};
-
 export const getHours = () => {
+  const localizedHours = [
+    c("A time on a 24-hour clock").t`0:00`,
+    c("A time").t`1:00`,
+    c("A time").t`2:00`,
+    c("A time").t`3:00`,
+    c("A time").t`4:00`,
+    c("A time").t`5:00`,
+    c("A time").t`6:00`,
+    c("A time").t`7:00`,
+    c("A time").t`8:00`,
+    c("A time").t`9:00`,
+    c("A time").t`10:00`,
+    c("A time").t`11:00`,
+    c("A time").t`12:00`,
+    c("A time on a 24-hour clock").t`13:00`,
+    c("A time on a 24-hour clock").t`14:00`,
+    c("A time on a 24-hour clock").t`15:00`,
+    c("A time on a 24-hour clock").t`16:00`,
+    c("A time on a 24-hour clock").t`17:00`,
+    c("A time on a 24-hour clock").t`18:00`,
+    c("A time on a 24-hour clock").t`19:00`,
+    c("A time on a 24-hour clock").t`20:00`,
+    c("A time on a 24-hour clock").t`21:00`,
+    c("A time on a 24-hour clock").t`22:00`,
+    c("A time on a 24-hour clock").t`23:00`,
+  ];
   const isClock24Hour = has24HourModeSetting();
-  return times(isClock24Hour ? 24 : 12, n => ({
-    label: addZeroesToHour(n, { useZero: isClock24Hour }),
-    value: `${n}`,
+  const hourCount = isClock24Hour ? 24 : 12;
+  const firstHourIndex = isClock24Hour ? 0 : 12;
+  const firstHourValue = isClock24Hour ? 0 : 12;
+  return _.times(hourCount, n => ({
+    label: localizedHours[n === 0 ? firstHourIndex : n],
+    value: `${n === 0 ? firstHourValue : n}`,
   }));
-};
-
-export const optionNameTranslations = {
-  // The context is needed because 'hourly' can be an adjective ('hourly rate') or adverb ('update hourly'). Same with 'daily', 'weekly', and 'monthly'.
-  hourly: c("adverb").t`hourly`,
-  daily: c("adverb").t`daily`,
-  weekly: c("adverb").t`weekly`,
-  monthly: c("adverb").t`monthly`,
 };
 
 export type Weekday = {
@@ -41,42 +51,99 @@ export type Weekday = {
   value: ScheduleDayType;
 };
 
-export const weekdays: Weekday[] = [
-  { label: t`Sunday`, value: "sun" },
-  { label: t`Monday`, value: "mon" },
-  { label: t`Tuesday`, value: "tue" },
-  { label: t`Wednesday`, value: "wed" },
-  { label: t`Thursday`, value: "thu" },
-  { label: t`Friday`, value: "fri" },
-  { label: t`Saturday`, value: "sat" },
-];
+/** These strings are created in a function, rather than in module scope, so that ttag is not called until the locale is set */
+export const getScheduleStrings = () => {
+  const scheduleOptionNames = {
+    // The context is needed because 'hourly' can be an adjective ('hourly rate') or adverb ('update hourly'). Same with 'daily', 'weekly', and 'monthly'.
+    hourly: c("adverb").t`hourly`,
+    daily: c("adverb").t`daily`,
+    weekly: c("adverb").t`weekly`,
+    monthly: c("adverb").t`monthly`,
+  };
 
-export const weekdayOfMonthOptions = [
-  { label: t`calendar day`, value: "calendar-day" },
-  ...weekdays,
-];
+  const weekdays: Weekday[] = [
+    {
+      label: c(
+        "Occurs in phrases like 'Send weekly on Sunday'. Only capitalize if necessary",
+      ).t`Sunday`,
+      value: "sun",
+    },
+    {
+      label: c(
+        "Occurs in phrases like 'Send weekly on Monday'. Only capitalize if necessary",
+      ).t`Monday`,
+      value: "mon",
+    },
+    {
+      label: c(
+        "Occurs in phrases like 'Send weekly on Tuesday'. Only capitalize if necessary",
+      ).t`Tuesday`,
+      value: "tue",
+    },
+    {
+      label: c(
+        "Occurs in phrases like 'Send weekly on Wednesday'. Only capitalize if necessary",
+      ).t`Wednesday`,
+      value: "wed",
+    },
+    {
+      label: c(
+        "Occurs in phrases like 'Send weekly on Thursday'. Only capitalize if necessary",
+      ).t`Thursday`,
+      value: "thu",
+    },
+    {
+      label: c(
+        "Occurs in phrases like 'Send weekly on Friday'. Only capitalize if necessary",
+      ).t`Friday`,
+      value: "fri",
+    },
+    {
+      label: c(
+        "Occurs in phrases like 'Send weekly on Saturday'. Only capitalize if necessary",
+      ).t`Saturday`,
+      value: "sat",
+    },
+  ];
 
-export const amAndPM = [
-  { label: c("As in 9:00 AM").t`AM`, value: "0" },
-  { label: c("As in 9:00 PM").t`PM`, value: "1" },
-];
+  const weekdayOfMonthOptions: (
+    | Weekday
+    | { label: string; value: "calendar-day" }
+  )[] = [{ label: t`calendar day`, value: "calendar-day" }, ...weekdays];
 
-export const frames = [
-  {
-    label: c("Appears in contexts like 'Monthly on the first Monday'").t`first`,
-    value: "first",
-  },
-  {
-    label: c("Appears in contexts like 'Monthly on the last Monday'").t`last`,
-    value: "last",
-  },
-  {
-    label: c(
-      "This is a noun meaning 'the fifteenth of the month', not an adjective. It appears in the phrase 'Monthly on the 15th'",
-    ).t`15th`,
-    value: "mid",
-  },
-];
+  const amAndPM = [
+    // We use a fallback string in case the translator translated
+    // 'AM' or 'PM' as an empty string, which might happen since
+    // certain cultures do not use AM/PM.
+    { label: c("As in 9:00 AM").t`AM`.trim() || "AM", value: "0" },
+    { label: c("As in 9:00 PM").t`PM`.trim() || "PM", value: "1" },
+  ];
+
+  const frames: { label: string; value: ScheduleFrameType }[] = [
+    {
+      label: c("Appears in contexts like 'Monthly on the first Monday'")
+        .t`first`,
+      value: "first",
+    },
+    {
+      label: c("Appears in contexts like 'Monthly on the last Monday'").t`last`,
+      value: "last",
+    },
+    {
+      label: c(
+        "This is a noun meaning 'the fifteenth of the month', not an adjective. It appears in the phrase 'Monthly on the 15th'",
+      ).t`15th`,
+      value: "mid",
+    },
+  ];
+  return {
+    scheduleOptionNames,
+    weekdays,
+    weekdayOfMonthOptions,
+    amAndPM,
+    frames,
+  };
+};
 
 export const defaultDay = "mon";
 export const defaultHour = 8;

--- a/frontend/src/metabase/components/Schedule/constants.unit.spec.ts
+++ b/frontend/src/metabase/components/Schedule/constants.unit.spec.ts
@@ -1,0 +1,46 @@
+import _ from "underscore";
+
+import { has24HourModeSetting } from "metabase/lib/time";
+
+import { getHours } from "./constants";
+
+jest.mock("metabase/lib/time", () => ({
+  has24HourModeSetting: jest.fn(),
+}));
+
+describe("getHours", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  const setup = ({ isClock24Hour }: { isClock24Hour: boolean }) => {
+    (has24HourModeSetting as jest.Mock).mockReturnValue(isClock24Hour);
+  };
+  it("should return hours for a 24-hour clock when has24HourModeSetting returns true", () => {
+    setup({ isClock24Hour: true });
+    const result = getHours();
+    expect(result).toHaveLength(24);
+
+    const labels = result.map(hour => hour.label);
+    const values = result.map(hour => hour.value);
+
+    // prettier-ignore
+    expect(labels).toEqual(["0:00", "1:00", "2:00", "3:00", "4:00", "5:00", "6:00", "7:00", "8:00", "9:00", "10:00", "11:00", "12:00", "13:00", "14:00", "15:00", "16:00", "17:00", "18:00", "19:00", "20:00", "21:00", "22:00", "23:00"])
+    // prettier-ignore
+    expect(values).toEqual(["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23"]);
+  });
+
+  it("should return hours for a 12-hour clock when has24HourModeSetting returns false", () => {
+    setup({ isClock24Hour: false });
+
+    const result = getHours();
+    expect(result).toHaveLength(12);
+
+    const labels = result.map(hour => hour.label);
+    const values = result.map(hour => hour.value);
+
+    // prettier-ignore
+    expect(labels).toEqual(["12:00", "1:00", "2:00", "3:00", "4:00", "5:00", "6:00", "7:00", "8:00", "9:00", "10:00", "11:00"])
+    // prettier-ignore
+    expect(values).toEqual(["12", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"]);
+  });
+});

--- a/frontend/src/metabase/components/Schedule/utils.tsx
+++ b/frontend/src/metabase/components/Schedule/utils.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 import { isValidElement } from "react";
+import _ from "underscore";
 
+import { measureTextWidth } from "metabase/lib/measure-text";
 import type { SelectProps } from "metabase/ui";
 import { Box, Group } from "metabase/ui";
 
@@ -11,44 +13,62 @@ const placeholderRegex = /^\{(\d)+\}$/;
 const regexForSplittingOnPlaceholders = /(\{\d+\})/;
 
 /** Takes a translated string containing placeholders and returns a JSX expression containing components substituted in for the placeholders */
-export const addScheduleComponents = (
+export const fillScheduleTemplate = (
   /** A translated string containing placeholders, such as:
    * - "{0} {1} on {2} at {3}"
    * - "{0} {1} {2} à {3}" (a French example)
    * - "{1} {2} um {3} {0}" (a German example)
    */
-  str: string,
-  components: ReactNode[],
+  template: string,
+  nodes: ReactNode[],
 ): ReactNode => {
-  const segments = str
+  const segments = template
     .split(regexForSplittingOnPlaceholders)
     .filter(part => part.trim());
   const arr = segments.map(segment => {
     const match = segment.match(placeholderRegex);
-    return match ? components[parseInt(match[1])] : segment;
+    return match ? nodes[parseInt(match[1])] : segment.trim();
   });
-  const withBlanks = addBlanks(arr);
-  return withBlanks;
+  const simplifiedArray = combineConsecutiveStrings(arr);
+  const laidOut = layoutSchedule(simplifiedArray);
+  return laidOut;
 };
 
-const addBlanks = (arr: ReactNode[]) => {
+const layoutSchedule = (nodes: ReactNode[]) => {
   const result: ReactNode[] = [];
   const addBlank = () =>
     result.push(<Box key={`blank-${result.length}`}></Box>);
-  for (let c = 0; c < arr.length; c++) {
-    const curr = arr[c];
-    const next = arr[c + 1];
-    const isLastItemString = c === arr.length - 1 && typeof curr === "string";
-    if (isLastItemString) {
-      addBlank();
-      result.push(
-        <Box key={curr} mt="-.5rem">
-          {curr}
-        </Box>,
-      );
+  for (let c = 0; c < nodes.length; c++) {
+    const curr = nodes[c];
+    const next = nodes[c + 1];
+    const nodeAfterNext = nodes[c + 2];
+    const isLastNodeString = c === nodes.length - 1 && typeof curr === "string";
+    const isCurrentNodeASelect = isValidElement(curr);
+    const isNextNodeASelect = isValidElement(next);
+    const isNodeAfterNextASelect = isValidElement(nodeAfterNext);
+    if (isLastNodeString) {
+      if (nodes.length === 2) {
+        result[result.length - 1] = (
+          <Group
+            spacing="md"
+            style={{ rowGap: ".35rem" }}
+            key={`items-on-one-line`}
+          >
+            {result[result.length - 1]}
+            {curr}
+          </Group>
+        );
+      } else {
+        addBlank();
+        result.push(
+          <Box key={curr} mt="-.5rem">
+            {curr}
+          </Box>,
+        );
+      }
     } else {
-      const isFirstItemString = c === 0 && typeof curr !== "string";
-      if (isFirstItemString) {
+      const isFirstNodeString = c === 0 && typeof curr !== "string";
+      if (isFirstNodeString) {
         addBlank();
       }
       if (typeof curr === "string") {
@@ -63,18 +83,21 @@ const addBlanks = (arr: ReactNode[]) => {
       }
     }
     // Insert blank nodes between adjacent Selects unless they can fit on one line
-    if (isValidElement(curr) && isValidElement(next)) {
+    if (isCurrentNodeASelect && isNextNodeASelect) {
       const canSelectsProbablyFitOnOneLine =
-        (curr.props.longestLabel?.length || 5) +
-          (next.props.longestLabel?.length || 5) <
-        24;
+        measureTextWidthSafely(curr.props.longestLabel, 200) +
+          measureTextWidthSafely(next.props.longestLabel, 200) <
+        300;
       if (canSelectsProbablyFitOnOneLine) {
         result[result.length - 1] = (
-          <Group spacing="xs" key={`selects-on-one-line`}>
+          <Group style={{ gap: ".35rem" }} key={`selects-on-one-line`}>
             {result[result.length - 1]}
             {next}
           </Group>
         );
+        if (isNodeAfterNextASelect) {
+          addBlank();
+        }
         c++;
       } else {
         addBlank();
@@ -84,8 +107,28 @@ const addBlanks = (arr: ReactNode[]) => {
   return <>{result}</>;
 };
 
+export const combineConsecutiveStrings = (arr: ReactNode[]) => {
+  return arr.reduce<ReactNode[]>((acc, node) => {
+    const prevNode = _.last(acc);
+    if (typeof node === "string" && typeof prevNode === "string") {
+      acc[acc.length - 1] += ` ${node}`;
+    } else {
+      acc.push(node);
+    }
+    return acc;
+  }, []);
+};
+
 export const getLongestSelectLabel = (data: SelectProps["data"]) =>
-  data.reduce((acc, option) => {
+  data.reduce<string>((acc, option) => {
     const label = typeof option === "string" ? option : option.label || "";
     return label.length > acc.length ? label : acc;
   }, "");
+
+const measureTextWidthSafely = (text: string, defaultWidth: number) => {
+  try {
+    return measureTextWidth(text);
+  } catch {
+    return defaultWidth;
+  }
+};

--- a/frontend/src/metabase/components/Schedule/utils.tsx
+++ b/frontend/src/metabase/components/Schedule/utils.tsx
@@ -5,6 +5,7 @@ import _ from "underscore";
 import { measureTextWidth } from "metabase/lib/measure-text";
 import type { SelectProps } from "metabase/ui";
 import { Box, Group } from "metabase/ui";
+import type { FontStyle } from "metabase/visualizations/shared/types/measure-text";
 
 const placeholderRegex = /^\{(\d)+\}$/;
 
@@ -125,9 +126,14 @@ export const getLongestSelectLabel = (data: SelectProps["data"]) =>
     return label.length > acc.length ? label : acc;
   }, "");
 
-const measureTextWidthSafely = (text: string, defaultWidth: number) => {
+/** Since measureTextWidth can throw an error, this function catches the error and returns a default width */
+export const measureTextWidthSafely = (
+  text: string,
+  defaultWidth: number,
+  style?: Partial<FontStyle>,
+) => {
   try {
-    return measureTextWidth(text);
+    return measureTextWidth(text, style);
   } catch {
     return defaultWidth;
   }

--- a/frontend/src/metabase/components/Schedule/utils.tsx
+++ b/frontend/src/metabase/components/Schedule/utils.tsx
@@ -126,7 +126,14 @@ export const getLongestSelectLabel = (data: SelectProps["data"]) =>
     return label.length > acc.length ? label : acc;
   }, "");
 
-/** Since measureTextWidth can throw an error, this function catches the error and returns a default width */
+/** Since measureTextWidth can throw an error, this function catches the error and returns a default width
+ *
+ * Note that you may want to set the style prop to reflect the currently chosen font family, like this:
+ * ```
+ *    const fontFamily = useSelector(state => getSetting(state, "application-font"));
+ *    measureTextWidthSafely("string", 50, {family: fontFamily});
+ * ```
+ * */
 export const measureTextWidthSafely = (
   text: string,
   defaultWidth: number,

--- a/frontend/src/metabase/components/Schedule/utils.unit.spec.tsx
+++ b/frontend/src/metabase/components/Schedule/utils.unit.spec.tsx
@@ -2,10 +2,14 @@ import { render, screen } from "@testing-library/react";
 
 import type { SelectProps } from "metabase/ui";
 
-import { addScheduleComponents, getLongestSelectLabel } from "./utils";
+import {
+  fillScheduleTemplate,
+  getLongestSelectLabel,
+  combineConsecutiveStrings,
+} from "./utils";
 
 describe("utils", () => {
-  describe("addScheduleComponents", () => {
+  describe("fillScheduleTemplate", () => {
     // Mock translation dictionary
     const translations = {
       // English strings
@@ -42,7 +46,7 @@ describe("utils", () => {
       const { invalidate, monthly, first, tuesday, twelvePm } = translations.en;
       const scheduleDescription =
         translations.en["{0} {1} on the {2} {3} at {4}"];
-      const scheduleReactNode = addScheduleComponents(scheduleDescription, [
+      const scheduleReactNode = fillScheduleTemplate(scheduleDescription, [
         <div key="verb">{invalidate} </div>,
         <div key="frequency">{monthly} </div>,
         <div key="frame">{first} </div>,
@@ -60,7 +64,7 @@ describe("utils", () => {
       const { invalidate, monthly, first, tuesday, twelvePm } = translations.de;
       const scheduleDescription =
         translations.de["{0} {1} on the {2} {3} at {4}"];
-      const scheduleReactNode = addScheduleComponents(scheduleDescription, [
+      const scheduleReactNode = fillScheduleTemplate(scheduleDescription, [
         <div key="verb">{invalidate} </div>,
         <div key="frequency">{monthly} </div>,
         <div key="frame">{first} </div>,
@@ -129,5 +133,43 @@ describe("utils", () => {
       const result = getLongestSelectLabel(data);
       expect(result).toBe("valid label");
     });
+  });
+});
+
+describe("combineConsecutiveStrings", () => {
+  it("should combine consecutive strings into one", () => {
+    const input = ["hello", "world", 42, "foo", "bar", null, "baz"];
+    const expectedOutput = ["hello world", 42, "foo bar", null, "baz"];
+    expect(combineConsecutiveStrings(input)).toEqual(expectedOutput);
+  });
+
+  it("should handle arrays without consecutive strings correctly", () => {
+    const input = [42, "hello", null, undefined, "world"];
+    const expectedOutput = [42, "hello", null, undefined, "world"];
+    expect(combineConsecutiveStrings(input)).toEqual(expectedOutput);
+  });
+
+  it("should handle an empty array correctly", () => {
+    const input: any[] = [];
+    const expectedOutput: any[] = [];
+    expect(combineConsecutiveStrings(input)).toEqual(expectedOutput);
+  });
+
+  it("should handle an array with only one type of element correctly", () => {
+    const input = ["hello", "world", "foo", "bar"];
+    const expectedOutput = ["hello world foo bar"];
+    expect(combineConsecutiveStrings(input)).toEqual(expectedOutput);
+  });
+
+  it("should handle an array with no strings correctly", () => {
+    const input = [42, null, undefined, true, false];
+    const expectedOutput = [42, null, undefined, true, false];
+    expect(combineConsecutiveStrings(input)).toEqual(expectedOutput);
+  });
+
+  it("should handle array with consecutive and non-consecutive strings correctly", () => {
+    const input = ["one", "two", 3, "four", "five", 6, "seven"];
+    const expectedOutput = ["one two", 3, "four five", 6, "seven"];
+    expect(combineConsecutiveStrings(input)).toEqual(expectedOutput);
   });
 });

--- a/frontend/src/metabase/components/Schedule/utils.unit.spec.tsx
+++ b/frontend/src/metabase/components/Schedule/utils.unit.spec.tsx
@@ -8,7 +8,10 @@ import {
   combineConsecutiveStrings,
 } from "./utils";
 
-describe("utils", () => {
+const allowAnyAmountOfWhitespace = (str: string) =>
+  new RegExp(str.replace(/ /g, "\\s*"));
+
+describe("Schedule utility functions", () => {
   describe("fillScheduleTemplate", () => {
     // Mock translation dictionary
     const translations = {
@@ -56,7 +59,9 @@ describe("utils", () => {
       render(<div data-testid="schedule">{scheduleReactNode}</div>);
       const scheduleElement = screen.getByTestId("schedule");
       expect(scheduleElement).toHaveTextContent(
-        "Invalidate monthly on the first Tuesday at 12:00pm",
+        allowAnyAmountOfWhitespace(
+          "Invalidate monthly on the first Tuesday at 12:00pm",
+        ),
       );
     });
 
@@ -74,7 +79,9 @@ describe("utils", () => {
       render(<div data-testid="schedule">{scheduleReactNode}</div>);
       const scheduleElement = screen.getByTestId("schedule");
       expect(scheduleElement).toHaveTextContent(
-        "monatlich am erste Dienstag um 12:00 Uhr ungültig machen",
+        allowAnyAmountOfWhitespace(
+          "monatlich am erste Dienstag um 12:00 Uhr ungültig machen",
+        ),
       );
     });
   });

--- a/frontend/src/metabase/lib/measure-text.ts
+++ b/frontend/src/metabase/lib/measure-text.ts
@@ -1,3 +1,5 @@
+import _ from "underscore";
+
 import type {
   FontStyle,
   TextMeasurer,
@@ -27,5 +29,11 @@ export const measureText: TextMeasurer = (text: string, style: FontStyle) => {
   };
 };
 
-export const measureTextWidth = (text: string, style: FontStyle) =>
-  measureText(text, style).width;
+const styleDefaults = {
+  size: "14px",
+  family: "sans-serif",
+  weight: "normal",
+};
+
+export const measureTextWidth = (text: string, style?: FontStyle) =>
+  measureText(text, _.defaults(style, styleDefaults)).width;

--- a/frontend/src/metabase/lib/measure-text.ts
+++ b/frontend/src/metabase/lib/measure-text.ts
@@ -35,5 +35,5 @@ const styleDefaults = {
   weight: "normal",
 };
 
-export const measureTextWidth = (text: string, style?: FontStyle) =>
+export const measureTextWidth = (text: string, style?: Partial<FontStyle>) =>
   measureText(text, _.defaults(style, styleDefaults)).width;

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -364,6 +364,7 @@ export const PLUGIN_CACHING = {
     PluginPlaceholder as ComponentType<InvalidateNowButtonProps>,
   hasQuestionCacheSection: (_question: Question) => false,
   canOverrideRootStrategy: false,
+  /** Metadata describing the different kinds of strategies */
   strategies: strategies,
 };
 


### PR DESCRIPTION
Fixes several problems with localization of the Performance feature:
* There were untranslated strings in the strategy form
* Incorrect usage of placeholders was preventing the Schedule picker from using the correct word ordering
* The colon punctuation mark in Asian languages was making the styling of radio buttons incorrect in Japanese and Korean
* The dropdowns were too narrow in Japanese and Korean. The reason is that I assumed that the average character width in all languages is the same as English, but characters are relatively wide in those languages

As part of this work I also looked through some of our most popular languages and corrected a lot of translations of performance-related strings.

Closes #45779
