### PR TITLE
Speed up permission migrations by 95% under specific conditions

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -7021,6 +7021,52 @@ databaseChangeLog:
               DROP VIEW IF EXISTS v_content;
 
   - changeSet:
+      id: v50.2024-02-26T22:15:52
+      author: noahmoss
+      comment: Add index on data_permissions(group_id, db_id, perm_value)
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - indexExists:
+                tableName: data_permissions
+                indexName: idx_data_permissions_group_id_db_id_perm_value
+      changes:
+        - createIndex:
+            tableName: data_permissions
+            indexName: idx_data_permissions_group_id_db_id_perm_value
+            columns:
+              - column:
+                  name: group_id
+              - column:
+                  name: db_id
+              - column:
+                  name: perm_value
+
+  - changeSet:
+      id: v50.2024-02-26T22:15:53
+      author: noahmoss
+      comment: Add index on data_permissions(group_id, db_id, table_id, perm_value)
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - indexExists:
+                tableName: data_permissions
+                indexName: idx_data_permissions_group_id_db_id_table_id_perm_value
+      changes:
+        - createIndex:
+            tableName: data_permissions
+            indexName: idx_data_permissions_group_id_db_id_table_id_perm_value
+            columns:
+              - column:
+                  name: group_id
+              - column:
+                  name: db_id
+              - column:
+                  name: table_id
+              - column:
+                  name: perm_value
+
+  - changeSet:
       id: v50.2024-02-26T22:15:54
       author: noahmoss
       comment: New `view-data` permission

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -7042,6 +7042,7 @@ databaseChangeLog:
       id: v50.2024-02-26T22:15:55
       author: noahmoss
       comment: New `create_queries` permission
+      validCheckSum: 9:7c2bc517b6def4e3278394b0399c3d4b
       changes:
         - sqlFile:
             path: permissions/create_queries.sql

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -7070,6 +7070,7 @@ databaseChangeLog:
       id: v50.2024-02-26T22:15:54
       author: noahmoss
       comment: New `view-data` permission
+      validCheckSum: 9:68d8f2fdf00395a9e614b0db8a2ec7bb
       changes:
         - sqlFile:
             dbms: postgresql,h2

--- a/resources/migrations/permissions/create_queries.sql
+++ b/resources/migrations/permissions/create_queries.sql
@@ -41,37 +41,26 @@ WHERE pg.name != 'Administrators'
        AND dp.table_id IS NULL
        AND dp.perm_type = 'perms/create-queries' );
 
-
+-- Insert table-level rows for all tables that have table-level data access permissions,
+-- and don't already have any create-queries permissions stored at the DB- or table-level.
 INSERT INTO data_permissions (group_id, perm_type, db_id, schema_name, table_id, perm_value)
-SELECT pg.id AS group_id,
-       'perms/create-queries' AS perm_type,
-       mt.db_id AS db_id,
-       mt.schema AS schema_name,
-       mt.id AS table_id,
-       CASE
-           WHEN EXISTS
-                  (SELECT 1
-                   FROM data_permissions dp
-                   WHERE dp.group_id = pg.id
-                     AND dp.table_id = mt.id
-                     AND dp.perm_type = 'perms/data-access'
-                     AND dp.perm_value = 'unrestricted' ) THEN 'query-builder'
-           ELSE 'no'
-       END AS perm_value
-FROM permissions_group pg
-CROSS JOIN metabase_table mt
-WHERE pg.name != 'Administrators'
-  -- Insert table-level rows for all tables that have table-level data access permissions,
-  -- and don't already have any create-queries permissions stored at the DB- or table-level.
-  AND EXISTS
-    (SELECT 1
-     FROM data_permissions dp
-     WHERE dp.group_id = pg.id
-       AND dp.table_id = mt.id
-       AND dp.perm_type = 'perms/data-access' )
+SELECT
+  dp.group_id,
+  'perms/create-queries' AS perm_type,
+  dp.db_id,
+  dp.schema_name,
+  dp.table_id,
+  CASE
+    WHEN dp.perm_value = 'unrestricted' THEN 'query-builder'
+    ELSE 'no'
+  END AS perm_value
+FROM data_permissions dp
+  WHERE
+    dp.perm_type = 'perms/data-access'
+    AND dp.table_id IS NOT NULL
   AND NOT EXISTS
     (SELECT 1
-     FROM data_permissions dp
-     WHERE dp.group_id = pg.id
-       AND dp.db_id = mt.db_id
-       AND dp.perm_type = 'perms/create-queries' );
+     FROM data_permissions dp2
+     WHERE dp2.group_id = dp.group_id
+       AND dp2.db_id = dp.db_id
+       AND dp2.perm_type = 'perms/create-queries' );

--- a/resources/migrations/permissions/create_queries.sql
+++ b/resources/migrations/permissions/create_queries.sql
@@ -55,12 +55,12 @@ SELECT
     ELSE 'no'
   END AS perm_value
 FROM data_permissions dp
-  WHERE
-    dp.perm_type = 'perms/data-access'
-    AND dp.table_id IS NOT NULL
-  AND NOT EXISTS
-    (SELECT 1
-     FROM data_permissions dp2
-     WHERE dp2.group_id = dp.group_id
-       AND dp2.db_id = dp.db_id
-       AND dp2.perm_type = 'perms/create-queries' );
+WHERE
+  dp.perm_type = 'perms/data-access'
+  AND dp.table_id IS NOT NULL
+AND NOT EXISTS
+  (SELECT 1
+   FROM data_permissions dp2
+   WHERE dp2.group_id = dp.group_id
+     AND dp2.db_id = dp.db_id
+     AND dp2.perm_type = 'perms/create-queries' );

--- a/resources/migrations/permissions/rollback/view_data.sql
+++ b/resources/migrations/permissions/rollback/view_data.sql
@@ -118,3 +118,11 @@ WHERE pg.name != 'Administrators'
      WHERE dp.group_id = pg.id
        AND dp.table_id = mt.id
        AND dp.perm_type = 'perms/create-queries');
+
+DELETE
+FROM data_permissions
+WHERE perm_type = 'perms/view-data';
+
+DELETE
+FROM data_permissions
+WHERE perm_type = 'perms/create-queries';

--- a/resources/migrations/permissions/view_data.sql
+++ b/resources/migrations/permissions/view_data.sql
@@ -17,57 +17,86 @@ SELECT
   dp.db_id,
   dp.schema_name,
   dp.table_id,
-  CASE
-    WHEN dp.perm_value = 'no-self-service'
-    AND EXISTS (
-      SELECT
-        1
-      FROM
-        permissions_group_membership pgm
-        JOIN (
-          SELECT
-            group_id,
-            db_id,
-            CAST(NULL AS INTEGER) AS table_id
-          FROM
-            connection_impersonations
-          UNION
-          SELECT
-            group_id,
-            db_id,
-            CAST(NULL AS INTEGER) AS table_id
-          FROM
-            data_permissions
-          WHERE
-            perm_value = 'block'
-            AND table_id IS NULL
-          UNION
-          SELECT
-            group_id,
-            CAST(NULL AS INTEGER) as db_id,
-            table_id
-          FROM
-            sandboxes
-        ) AS sp ON pgm.group_id = sp.group_id
-      WHERE
-        pgm.group_id <> dp.group_id
-        AND (
-          sp.db_id IS NULL
-          OR sp.db_id = dp.db_id
-        )
-        AND (
-          sp.table_id IS NULL
-          OR sp.table_id = dp.table_id
-        )
-    ) THEN 'legacy-no-self-service'
-    ELSE 'unrestricted'
-  END AS perm_value
+  'legacy-no-self-service' AS perm_value
 FROM
   data_permissions dp
 WHERE
-  dp.table_id IS NOT NULL;
-  dp.perm_type = 'perms/data-access'
+  dp.table_id IS NOT NULL
+  AND dp.perm_type = 'perms/data-access'
+  AND dp.perm_value = 'no-self-service'
+  AND EXISTS (
+    SELECT
+      1
+    FROM
+      permissions_group_membership pgm
+      JOIN (
+        SELECT
+          group_id,
+          db_id,
+          CAST(NULL AS INTEGER) AS table_id
+        FROM
+          connection_impersonations
+        UNION
+        SELECT
+          group_id,
+          db_id,
+          CAST(NULL AS INTEGER) AS table_id
+        FROM
+          data_permissions
+        WHERE
+          perm_value = 'block'
+          AND table_id IS NULL
+        UNION
+        SELECT
+          group_id,
+          CAST(NULL AS INTEGER) as db_id,
+          table_id
+        FROM
+          sandboxes
+      ) AS sp ON pgm.group_id = sp.group_id
+    WHERE
+      pgm.group_id <> dp.group_id
+      AND (
+        sp.db_id IS NULL
+        OR sp.db_id = dp.db_id
+      )
+      AND (
+        sp.table_id IS NULL
+        OR sp.table_id = dp.table_id
+      )
+  );
 
+INSERT INTO
+  data_permissions (
+    group_id,
+    perm_type,
+    db_id,
+    schema_name,
+    table_id,
+    perm_value
+  )
+SELECT
+  dp.group_id,
+  'perms/view-data' AS perm_type,
+  dp.db_id,
+  dp.schema_name,
+  dp.table_id,
+  'unrestricted' AS perm_value
+FROM
+  data_permissions dp
+WHERE
+  dp.table_id IS NOT NULL
+  AND dp.perm_type = 'perms/data-access'
+  AND NOT EXISTS (
+    SELECT
+      1
+    FROM
+    data_permissions dp1
+    WHERE
+     dp1.group_id = dp.group_id
+     AND dp1.table_id = dp.table_id
+     AND dp1.perm_value = 'legacy-no-self-service'
+  );
 
 -- If all tables in a DB have the same view-data permission, insert a DB-level view-data permission instead
 INSERT INTO

--- a/resources/migrations/permissions/view_data.sql
+++ b/resources/migrations/permissions/view_data.sql
@@ -65,8 +65,8 @@ SELECT
 FROM
   data_permissions dp
 WHERE
+  dp.table_id IS NOT NULL;
   dp.perm_type = 'perms/data-access'
-  AND dp.table_id IS NOT NULL;
 
 
 -- If all tables in a DB have the same view-data permission, insert a DB-level view-data permission instead
@@ -88,8 +88,8 @@ WITH
     FROM
       data_permissions
     WHERE
-      perm_type = 'perms/view-data'
-      AND table_id IS NOT NULL
+      table_id IS NOT NULL
+      AND perm_type = 'perms/view-data'
     GROUP BY
       group_id,
       db_id


### PR DESCRIPTION
(Hopefully) resolves https://github.com/metabase/metabase/issues/45701

This PR does two things to optimize the permission migrations in 50 when an instance has a large number of tables, and permissions are set granularly on the tables:
1. It rewrites the `create-queries` migration to avoid a `CROSS JOIN` between groups and tables. This was my first instinct, and it resulted in a decent performance improvement under my test conditions and is incidentally easier to understand IMO, so it's a benefit all around. But the failing migration in #45701 is actually the `view-data` migration, which runs first, so I don't think this resolves the root issue. Leading to...
2. Two new multi-column indexes on the `data_permissions` table: one on `(group_id, db_id, perm_value)` and one on `(group_id, db_id, table_id, perm_value)`. These are both common access patterns both in the migrations and in fetching permissions in the application so I think these are worth keeping around. We also have single-column indexes on all the foreign key columns, but it seems like these multi-column indexes impact performance much more.

3. Edit: I did more load testing with even more total tables and analyzed the query plan and found another place to optimize in the view_data migration. I've split one query into two: one to add `legacy-no-self-service` rows for tables that need it, and another to add `unrestricted` rows for the remaining tables.

**Testing**
Migrations should behave the same as before, so correctness testing is covered by existing tests.

For load testing, I created 100 users randomly distributed into 20 groups, with each user in between 1-10 groups. I also attached 30 copies of the sample H2 database, as well as one 1000 row Postgres database. 

Without these changes: migrating up takes ~**30-35 seconds**
With these changes: migrating up takes ~**2-6 seconds**

(There's a decent amount of variability between attempts—I could only reproduce consistently by randomizing permissions between attempts. But these are the rough numbers I observed.)