### PR TITLE
Add explicit timeouts to queue implementation

### DIFF
--- a/src/metabase/task/analyze_queries.clj
+++ b/src/metabase/task/analyze_queries.clj
@@ -54,7 +54,9 @@
   ([stop-after]
    (analyzer-loop* stop-after query-analysis/next-card-id!))
   ([stop-after queue]
-   (analyzer-loop* stop-after (partial query-analysis/next-card-id! queue))))
+   (analyzer-loop! stop-after queue Long/MAX_VALUE))
+  ([stop-after queue timeout]
+   (analyzer-loop* stop-after (partial query-analysis/next-card-id! queue timeout))))
 
 (jobs/defjob ^{DisallowConcurrentExecution true
                :doc                        "Analyze "}

--- a/src/metabase/util/queue.clj
+++ b/src/metabase/util/queue.clj
@@ -9,9 +9,9 @@
   (maybe-put! [queue msg]
     "Put a message on the queue if there is space for it, otherwise drop it.
      Returns whether the item was enqueued.")
-  (blocking-put! [queue msg]
+  (blocking-put! [queue timeout msg]
     "Put a message on the queue. If necessary, block until there is space for it.")
-  (blocking-take! [queue]
+  (blocking-take! [queue timeout]
     "Take a message off the queue, blocking if necessary.")
   (clear! [queue]
     "Discard all messages on the given queue."))
@@ -25,14 +25,17 @@
   BoundedTransferQueue
   (maybe-put! [_ msg]
     (.offer async-queue msg))
-  (blocking-put! [_ msg]
-    (.offer sync-queue msg Long/MAX_VALUE TimeUnit/DAYS))
-  (blocking-take! [_]
-    ;; Async messages are given higher priority, as sync messages will never be dropped.
-    (or (.poll async-queue)
-        (.poll sync-queue block-ms TimeUnit/MILLISECONDS)
-        (do (Thread/sleep ^long sleep-ms)
-            (recur))))
+  (blocking-put! [_ timeout msg]
+    (.offer sync-queue msg timeout TimeUnit/MILLISECONDS))
+  (blocking-take! [_ timeout]
+    (loop [time-remaining timeout]
+      (when (pos? time-remaining)
+        ;; Async messages are given higher priority, as sync messages will never be dropped.
+        (or (.poll async-queue)
+            (.poll sync-queue block-ms TimeUnit/MILLISECONDS)
+            (do (Thread/sleep ^long sleep-ms)
+                ;; This is an underestimate, as the thread may have taken a while to wake up. That's OK.
+                (recur (- time-remaining block-ms sleep-ms)))))))
   (clear! [_]
     (.clear sync-queue)
     (.clear async-queue)))
@@ -56,19 +59,20 @@
             (when-not accepted?
               (.remove queued-set payload))
             accepted?)))))
-  (blocking-put! [_ msg]
+  (blocking-put! [_ timeout msg]
    ;; we cannot hold the lock while we push, so there is some chance of a duplicate
     (when (locking queued-set (.add queued-set (:payload msg msg)))
-      (.offer sync-queue msg Long/MAX_VALUE TimeUnit/DAYS)))
-  (blocking-take! [_]
-   ;; we lock here to avoid leaving a blocking entry behind that can never be cleared
-    (or (locking queued-set
-          (when-let [msg (or (.poll ^Queue async-queue)
-                             (.poll sync-queue block-ms TimeUnit/MILLISECONDS))]
-            (.remove queued-set (:payload msg msg))
-            msg))
-        (do (Thread/sleep ^long sleep-ms)
-            (recur))))
+      (.offer sync-queue msg timeout TimeUnit/MILLISECONDS)))
+  (blocking-take! [_ timeout]
+    (loop [time-remaining timeout]
+      ;; we lock here to avoid leaving a blocking entry behind that can never be cleared
+      (or (locking queued-set
+            (when-let [msg (or (.poll ^Queue async-queue)
+                               (.poll sync-queue block-ms TimeUnit/MILLISECONDS))]
+              (.remove queued-set (:payload msg msg))
+              msg))
+          (do (Thread/sleep ^long sleep-ms)
+              (recur (- time-remaining block-ms sleep-ms))))))
   (clear! [_]
     (locking queued-set
       (.clear sync-queue)

--- a/test/metabase/task/analyze_queries_test.clj
+++ b/test/metabase/task/analyze_queries_test.clj
@@ -4,7 +4,6 @@
    [metabase.query-analysis :as query-analysis]
    [metabase.task.analyze-queries :as task.analyze-queries]
    [metabase.task.setup.query-analysis-setup :as setup]
-   [metabase.util :as u]
    [metabase.util.queue :as queue]
    [toucan2.core :as t2]))
 
@@ -27,9 +26,8 @@
           (run! (partial query-analysis/analyze-async! queue)
                 card-ids))
 
-        ;; process the queue
-        (u/with-timeout 10000
-          (#'task.analyze-queries/analyzer-loop! (count card-ids) queue))
+        ;; process the queue - spending at most 100ms blocking for a message
+        (#'task.analyze-queries/analyzer-loop! (count card-ids) queue 100)
 
         (testing "QueryField is filled now"
           (testing "for a native query"

--- a/test/metabase/util/queue_test.clj
+++ b/test/metabase/util/queue_test.clj
@@ -25,7 +25,7 @@
                               nil   (swap! skipped inc)))))
         background-fn (fn []
                         (doseq [e backfill-events]
-                          (queue/blocking-put! queue {:thread "back", :payload e})))
+                          (queue/blocking-put! queue 1000 {:thread "back", :payload e})))
         run!          (fn [f]
                         (future (f)))]
 
@@ -39,7 +39,7 @@
         (while true
           ;; Stop the consumer once we are sure that there are no more events coming.
           (u/with-timeout 100
-            (vswap! processed conj (:payload (queue/blocking-take! queue)))
+            (vswap! processed conj (:payload (queue/blocking-take! queue 1000)))
             ;; Sleep to provide some backpressure
             (Thread/sleep 1)))
         (assert false "this is never reached")


### PR DESCRIPTION
### Description

It turns out that blocking indefinitely is very inconvenient for testing. This avoids needing to run things on background threads, which might be starved in CI.

Unfortunately it decreases how close we get to the heat death of the universe before requiring a process restart. I think most people will upgrade to version 52 by the year 294,295 - [If Man is still alive](https://www.youtube.com/watch?v=izQB2-Kmiic)