### PR TITLE
Track query analysis failures in an in-memory map

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -204,7 +204,8 @@
                                      metabase.pulse.render.js-svg
                                      metabase.pulse.render.style}                                   ; TODO -- consolidate these into a real API namespace.
     metabase.query-processor       :any                                                             ; TODO omg scream, 29 namespaces used outside of the module. WHAT THE HECC
-    metabase.query-analysis        #{metabase.query-analysis}
+    metabase.query-analysis        #{metabase.query-analysis
+                                     metabase.query-analysis.failure-map}
     metabase.related               #{metabase.related}
     metabase.sample-data           #{metabase.sample-data}
     metabase.search                #{metabase.search}

--- a/src/metabase/query_analysis/failure_map.clj
+++ b/src/metabase/query_analysis/failure_map.clj
@@ -1,0 +1,46 @@
+(ns metabase.query-analysis.failure-map
+  (:import
+   (java.util.concurrent ConcurrentHashMap)
+   (java.util.function BiFunction)))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private ^ConcurrentHashMap cached-failures (ConcurrentHashMap.))
+
+(def ^:private max-size 10)
+
+(def ^:private max-retries 2)
+
+(defn- ->query-hash [card]
+  (hash (:dataset_query card)))
+
+(defn reset-map!
+  "Used by tests"
+  []
+  (.clear cached-failures))
+
+(defn track-failure!
+  "Record when we have failed to analyze a given version of a card, to prevent endless retrying."
+  [card]
+  ;; This size operation is close to constant time at the moment - watch out if you change the data structure.
+  (.compute cached-failures (:id card)
+            (reify BiFunction
+              (apply [_this _k existing]
+                (let [hsh (->query-hash card)]
+                  (if (= hsh (:query-hash existing))
+                    (update existing :retries-remaining #(max 0 (dec %)))
+                    (when (< (.size cached-failures) max-size)
+                      {:query-hash hsh :retries-remaining (dec max-retries)})))))))
+
+(defn track-success!
+  "Once we manage to analyze a card, we can forget about previous failures."
+  [card]
+  (.remove cached-failures (:id card)))
+
+(defn non-retryable?
+  "Should we skip retrying the given card because it has failed too many times?"
+  [card]
+  (boolean
+   (when-let [{:keys [retries-remaining query-hash]} (.get cached-failures (:id card))]
+     (and (zero? retries-remaining)
+          (= query-hash (->query-hash card))))))

--- a/src/metabase/task/analyze_queries.clj
+++ b/src/metabase/task/analyze_queries.clj
@@ -5,6 +5,7 @@
    [clojurewerkz.quartzite.triggers :as triggers]
    [metabase.public-settings :as public-settings]
    [metabase.query-analysis :as query-analysis]
+   [metabase.query-analysis.failure-map :as failure-map]
    [metabase.task :as task]
    [metabase.util :as u]
    [metabase.util.log :as log])
@@ -37,13 +38,18 @@
   (loop [remaining stop-after]
     (when (public-settings/query-analysis-enabled)
       (let [card-id (next-card-id-fn)
-            timer   (u/start-timer)]
-        (try
-          (query-analysis/analyze-card! card-id)
-          (Thread/sleep (wait-proportional (u/since-ms timer)))
-          (catch Exception e
-            (log/errorf e "Error analysing and updating query for Card %" card-id)
-            (Thread/sleep (wait-fail (u/since-ms timer)))))
+            timer   (u/start-timer)
+            card    (query-analysis/->analyzable card-id)]
+        (if (failure-map/non-retryable? card)
+          (log/warnf "Skipping analysis of Card % as its query has caused failures in the past." card-id)
+          (try
+            (query-analysis/analyze-card! card)
+            (failure-map/track-success! card)
+            (Thread/sleep (wait-proportional (u/since-ms timer)))
+            (catch Exception e
+              (log/errorf e "Error analysing and updating query for Card %" card-id)
+              (failure-map/track-failure! card)
+              (Thread/sleep (wait-fail (u/since-ms timer))))))
         (cond
           (nil? remaining) (recur nil)
           (> remaining 1) (recur (dec remaining)))))))

--- a/test/metabase/query_analysis/failure_map_test.clj
+++ b/test/metabase/query_analysis/failure_map_test.clj
@@ -1,0 +1,55 @@
+(ns metabase.query-analysis.failure-map-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.query-analysis.failure-map :as failure-map]))
+
+(def id-generator (atom 0))
+
+(defn- random-card []
+  {:id (swap! id-generator inc) :dataset_query (rand)})
+
+(def ^:private max-retries @#'failure-map/max-retries)
+(def ^:private max-size @#'failure-map/max-size)
+
+(deftest failure-map-non-retryable-test
+  (failure-map/reset-map!)
+  (let [card-1 (random-card)
+        card-2 (random-card)]
+    (testing "Initially, it is not marked as non-retryable"
+      (is (false? (failure-map/non-retryable? card-1))))
+    (when (> max-retries 1)
+      (testing "It may fail a few times"
+        (dotimes [_ (dec max-retries)]
+          (failure-map/track-failure! card-1)
+          (is (false? (failure-map/non-retryable? card-1))))))
+    (testing "Once it has been retried a certain number of times, it is no longer retryable"
+      (failure-map/track-failure! card-1)
+      (is (true? (failure-map/non-retryable? card-1))))
+    (testing "Other cards are not affected"
+      (is (false? (failure-map/non-retryable? card-2))))
+
+    ;; Technically speaking, this would have to happen before we exhausted our retries :-)
+    (testing "If the card is analyzed, it is removed from the map"
+      (failure-map/track-success! card-1)
+      (is (false? (failure-map/non-retryable? card-1))))))
+
+(deftest failure-map-bounded-test
+  (failure-map/reset-map!)
+  (let [random-cards (repeatedly max-size random-card)]
+    (testing "We can record a large number of failures"
+      (dotimes [_ max-retries]
+        (run! failure-map/track-failure! random-cards)))
+    (testing "And they are remembered"
+      (is (every? failure-map/non-retryable? random-cards)))
+    (testing "But the number that we recall is bounded\n"
+      (let [extra-card (random-card)]
+        (failure-map/track-failure! extra-card)
+        (is (false? (failure-map/non-retryable? extra-card)))
+        (testing "... with replacement"
+          (failure-map/track-success! (first random-cards))
+          (dotimes [_ max-retries]
+            (failure-map/track-failure! extra-card))
+          (is (true? (failure-map/non-retryable? extra-card))))
+        ;; clean-up
+        (failure-map/track-success! extra-card)
+        (run! failure-map/track-success! random-cards)))))

--- a/test/metabase/task/setup/query_analysis_setup.clj
+++ b/test/metabase/task/setup/query_analysis_setup.clj
@@ -37,7 +37,7 @@
                   (t2/delete! :model/QueryField :card_id [:in (map :id [c1 c2 c3 c4 arch])])
 
                   ;; Make sure some other card has analysis
-                  (query-analysis/analyze-card! (:id c3))
+                  (query-analysis/analyze-card! c3)
 
                   (mt/call-with-map-params f [c1 c2 c3 c4 arch]))))
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/45471

### Description

In the future, we will track a record summarizing the result of the last analysis attempt, which can include a running count of failures encountered.

Until then, we want some protection against runaway retries.

This does so with the aid of a bounded in-memory map.