### PR TITLE
Fix - Flaky #34514 test

### DIFF
--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -992,6 +992,9 @@ describe("issue 34514", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    cy.intercept("GET", "/api/database/*/schema/*").as("fetchTables");
+    cy.intercept("GET", "/api/database/*").as("fetchDatabase");
 
     cy.visit("/");
     // It's important to navigate via UI so that there are
@@ -1005,10 +1008,12 @@ describe("issue 34514", () => {
   it("should not make network request with invalid query (metabase#34514)", () => {
     entityPickerModal().within(() => {
       entityPickerModalTab("Tables").click();
+      cy.wait("@fetchTables");
       cy.findByText("Orders").click();
     });
 
     cy.findByTestId("run-button").click();
+    cy.wait("@dataset");
     assertQueryTabState();
 
     cy.go("back");
@@ -1018,16 +1023,23 @@ describe("issue 34514", () => {
   it("should allow browser history navigation between tabs (metabase#34514)", () => {
     entityPickerModal().within(() => {
       entityPickerModalTab("Tables").click();
+      cy.wait("@fetchTables");
       cy.findByText("Orders").click();
     });
 
     cy.findByTestId("run-button").click();
+    cy.wait("@dataset");
     assertQueryTabState();
 
     cy.findByTestId("editor-tabs-metadata-name").click();
     assertMetadataTabState();
 
+    // Close the TabHinToast component.
+    // This isn't a part of the test scenario but it helps with flakiness.
+    cy.icon("close").click();
+
     cy.go("back");
+    cy.wait(["@dataset", "@fetchDatabase"]); // This should be removed when (metabase#45787) is fixed
     assertQueryTabState();
 
     cy.go("back");


### PR DESCRIPTION
Follow-up on #45709

### Description

New tests always failed in the backport PR (#45782).
Interestingly stress test passed for the `master` branch.
One of the reasons is #45787.

This PR has "no-backport" label because these changes already are present in the backport PR (#45782). It's a reverse-backport if you will.

Stress test: https://github.com/metabase/metabase/actions/runs/9990647041