### PR TITLE
45749 follow up: guard against the potential `null`

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/ExecutionTime/ExecutionTime.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ExecutionTime/ExecutionTime.tsx
@@ -4,12 +4,17 @@ import { Tooltip } from "metabase/ui";
 
 import { formatDuration } from "./utils";
 
+/**
+ * `time` can most likely never be `null`
+ * but we don't have type safety in the parent of this component
+ * so we're guarding against it here preemptively!
+ */
 interface Props {
-  time?: number;
+  time?: number | null;
 }
 
 export const ExecutionTime = ({ time }: Props) => {
-  if (time === undefined) {
+  if (time == null) {
     return null;
   }
 

--- a/frontend/src/metabase/query_builder/components/view/ExecutionTime/ExecutionTime.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ExecutionTime/ExecutionTime.unit.spec.tsx
@@ -10,6 +10,12 @@ describe("ExecutionTime", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
+  it("renders nothing when time is `null`", () => {
+    const { container } = render(<ExecutionTime time={null} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
   it("renders formatted time when time is provided", () => {
     render(<ExecutionTime time={100} />);
 


### PR DESCRIPTION
A quick follow-up after #45749
We don't trust our code and we don't have the type safety in a component that calls `ExecutionTime`, so this PR adds a guard against the very unlikely but still non-zero chances of `time` being `null`.