### PR TITLE
fix: install frontend dependencies in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY . .
 RUN git config --global --add safe.directory /home/node
 
 # install frontend dependencies
-RUN yarn --frozen-lockfile --ignore-optional
+RUN yarn --frozen-lockfile
 
 RUN INTERACTIVE=false CI=true MB_EDITION=$MB_EDITION bin/build.sh :version ${VERSION}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ COPY . .
 # version is pulled from git, but git doesn't trust the directory due to different owners
 RUN git config --global --add safe.directory /home/node
 
+# install frontend dependencies
+RUN yarn --frozen-lockfile --ignore-optional
+
 RUN INTERACTIVE=false CI=true MB_EDITION=$MB_EDITION bin/build.sh :version ${VERSION}
 
 # ###################


### PR DESCRIPTION
### Description

Do not forget to install frontend dependencies during docker build

### How to verify

run `docker build . --build-arg MB_EDITION=ee --build-arg VERSION=v1.51.0` - it should build a jar and run it
