### PR TITLE
Fix parameter mapping in auto-wiring a new card

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-wiring.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-wiring.cy.spec.js
@@ -27,9 +27,11 @@ import {
   findDashCardAction,
   removeDashboardCard,
   sidebar,
+  dashboardHeader,
 } from "e2e/support/helpers";
 
-const { ORDERS_ID, PRODUCTS_ID, REVIEWS_ID } = SAMPLE_DATABASE;
+const { ORDERS_ID, PRODUCTS_ID, REVIEWS_ID, ORDERS, PEOPLE, PRODUCTS } =
+  SAMPLE_DATABASE;
 
 const cards = [
   {
@@ -692,6 +694,84 @@ describe("dashboard filters auto-wiring", () => {
       cy.tick(8000);
       undoToast().should("not.exist");
     });
+  });
+
+  it("should auto-wire a new card to correct parameter targets (metabase#44720)", () => {
+    cy.log("create a dashboard with 2 parameters mapped to the same card");
+    const questionDetails = {
+      name: "Test",
+      query: {
+        "source-table": ORDERS_ID,
+      },
+    };
+    const sourceParameter = {
+      name: "Source",
+      slug: "source",
+      id: "27454068",
+      type: "string/=",
+      sectionId: "string",
+    };
+    const categoryParameter = {
+      name: "Category",
+      slug: "category",
+      id: "27454069",
+      type: "string/=",
+      sectionId: "string",
+    };
+    const dashboardDetails = {
+      parameters: [sourceParameter, categoryParameter],
+    };
+    const getParameterMappings = card => [
+      {
+        card_id: card.id,
+        parameter_id: sourceParameter.id,
+        target: [
+          "dimension",
+          ["field", PEOPLE.SOURCE, { "source-field": ORDERS.USER_ID }],
+        ],
+      },
+      {
+        card_id: card.id,
+        parameter_id: categoryParameter.id,
+        target: [
+          "dimension",
+          ["field", PRODUCTS.CATEGORY, { "source-field": ORDERS.PRODUCT_ID }],
+        ],
+      },
+    ];
+    cy.createDashboardWithQuestions({
+      dashboardDetails,
+      questions: [questionDetails],
+    }).then(({ dashboard, questions: [card] }) => {
+      updateDashboardCards({
+        dashboard_id: dashboard.id,
+        cards: [
+          {
+            card_id: card.id,
+            parameter_mappings: getParameterMappings(card),
+          },
+        ],
+      });
+      visitDashboard(dashboard.id);
+    });
+
+    cy.log("add a card to the dashboard and auto-wire");
+    editDashboard();
+    dashboardHeader().icon("add").click();
+    cy.findByTestId("add-card-sidebar")
+      .findByText(questionDetails.name)
+      .click();
+    undoToast().button("Auto-connect").click();
+
+    cy.log("check auto-wired parameter mapping");
+    cy.findByTestId("fixed-width-filters")
+      .findByText(sourceParameter.name)
+      .click();
+    getDashboardCard(1).findByText("User.Source").should("be.visible");
+    cy.findByTestId("fixed-width-filters")
+      .findByText(categoryParameter.name)
+      .click();
+    getDashboardCard(1).findByText("Product.Category").should("be.visible");
   });
 });
 

--- a/frontend/src/metabase/dashboard/actions/auto-wire-parameters/actions.ts
+++ b/frontend/src/metabase/dashboard/actions/auto-wire-parameters/actions.ts
@@ -157,7 +157,11 @@ export function showAutoWireToastNewCard({
       );
 
       for (const dashcard of dashcards) {
-        for (const mapping of dashcard.parameter_mappings ?? []) {
+        const mappings = (dashcard.parameter_mappings ?? []).filter(
+          mapping => mapping.parameter_id === parameter.id,
+        );
+
+        for (const mapping of mappings) {
           const option = getMappingOptionByTarget(
             dashcardMappingOptions,
             targetDashcard,


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/44720

There was a bug where we incorrectly computed the parameter target when iterating over cards in auto-wiring.

How to verify:
- New -> Question -> Orders -> Save
- New -> Dashboard
- Add 2 Text filters -> Connect 1 to User.Source and another Product.Category
- Add the same question again and Auto-connect
- Each parameter should be mapped to correctly, i.e. to User.Source, Product.Category

Before
<img width="1304" alt="Screenshot 2024-07-18 at 11 26 34" src="https://github.com/user-attachments/assets/d21bc03a-a70e-444d-8b6a-9fece2d6b467">

After
<img width="1329" alt="Screenshot 2024-07-18 at 11 26 56" src="https://github.com/user-attachments/assets/074eb2d6-c13e-4479-b663-1c9f7adfc03a">
<img width="1284" alt="Screenshot 2024-07-18 at 11 26 49" src="https://github.com/user-attachments/assets/ee5c5205-3a25-4553-8bb5-f3613594060c">
