### PR TITLE
Remove stupid perf unit test

### DIFF
--- a/frontend/src/metabase/dashboard/actions/utils.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/actions/utils.unit.spec.ts
@@ -185,31 +185,6 @@ describe("dashboard > actions > utils", () => {
 
       expect(haveDashboardCardsChanged(newCards, oldCards)).toBe(false);
     });
-
-    it("should perform reasonably well for 1000 cards", () => {
-      const oldCards = Array(1000)
-        .fill("")
-        .map(index =>
-          createMockDashboardCard({
-            id: index,
-            visualization_settings: { foo: { bar: { baz: index * 10 } } },
-          }),
-        );
-      const newCards = Array(1000)
-        .fill("")
-        .map(index =>
-          createMockDashboardCard({
-            id: index,
-            visualization_settings: { foo: { bar: { baz: index * 10 } } },
-          }),
-        );
-
-      const startTime = performance.now();
-      expect(haveDashboardCardsChanged(newCards, oldCards)).toBe(false);
-      const endTime = performance.now();
-
-      expect(endTime - startTime).toBeLessThan(100); // 100 ms (locally this was 6 ms)
-    });
   });
 
   describe("getDashCardMoveToTabUndoMessage", () => {


### PR DESCRIPTION

### Description

This unit test was a cute attempt at getting performance testing, but it just fails randomly due to runner speed on totally unrelated changes. It is not useful, therefore we bid it a fond farewell 🫡 .

![Screen Shot 2024-07-18 at 11 03 44 AM](https://github.com/user-attachments/assets/1bcaa90a-c2de-44fc-97e5-4e43a67c59f2)

Also, since https://github.com/metabase/metabase/pull/43422 , it's big-o isn't as bad.