### PR TITLE
update trend chart copy

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.jsx
@@ -450,7 +450,7 @@ Object.assign(SmartScalar, {
   ) {
     if (!insights || insights.length === 0) {
       throw new NoBreakoutError(
-        t`Group by a time field to see how this has changed over time`,
+        t`Group only by a time field to see how this has changed over time`,
       );
     }
   },


### PR DESCRIPTION
### Description

[Slack convo](https://metaboat.slack.com/archives/C064QMXEV9N/p1721305455682859?thread_ts=1720463978.888189&cid=C064QMXEV9N)

We want to make it more explicit that for trend chart to work datasets should be grouped by a single time field only.

### How to verify

1) New -> Orders -> Group by Created At and Product -> Category
2) Change viz type to Trend
3) Ensure it shows the updated copy

### Demo

<img width="962" alt="Screenshot 2024-07-18 at 1 35 42 PM" src="https://github.com/user-attachments/assets/7bbafd64-9e71-47fe-9662-6ce9b709038a">

### Checklist

- [-] Tests have been added/updated to cover changes in this PR
