### PR TITLE
Fix Analytics DB Appearing in Permissions

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/audit_app/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/index.js
@@ -3,6 +3,7 @@ import { t } from "ttag";
 import {
   PLUGIN_ADMIN_USER_MENU_ITEMS,
   PLUGIN_ADMIN_USER_MENU_ROUTES,
+  PLUGIN_AUDIT,
   PLUGIN_DASHBOARD_HEADER,
   PLUGIN_QUERY_BUILDER_HEADER,
 } from "metabase/plugins";
@@ -10,6 +11,7 @@ import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import { InstanceAnalyticsButton } from "./components/InstanceAnalyticsButton/InstanceAnalyticsButton";
 import { getUserMenuRotes } from "./routes";
+import { isAuditDb } from "./utils";
 
 if (hasPremiumFeature("audit_app")) {
   PLUGIN_ADMIN_USER_MENU_ITEMS.push(user => [
@@ -48,4 +50,6 @@ if (hasPremiumFeature("audit_app")) {
       },
     ];
   };
+
+  PLUGIN_AUDIT.isAuditDb = isAuditDb;
 }

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/utils.ts
@@ -1,0 +1,3 @@
+import type { Database } from "metabase-types/api";
+
+export const isAuditDb = (db: Database) => !!db.is_audit;

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/utils.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/utils.unit.spec.ts
@@ -1,0 +1,22 @@
+import { createMockDatabase } from "metabase-types/api/mocks";
+
+import { isAuditDb } from "./utils";
+
+describe("enterprise audit utils", () => {
+  describe("isAuditDb", () => {
+    it("should return true if the database is an audit database", () => {
+      const db = createMockDatabase({ is_audit: true });
+      expect(isAuditDb(db)).toBe(true);
+    });
+
+    it("should return false if the database is not an audit database", () => {
+      const db = createMockDatabase({ is_audit: false });
+      expect(isAuditDb(db)).toBe(false);
+    });
+
+    it("should return false if the database does not have an is_audit property", () => {
+      const db = createMockDatabase({ is_audit: undefined });
+      expect(isAuditDb(db)).toBe(false);
+    });
+  });
+});

--- a/frontend/src/metabase-types/api/database.ts
+++ b/frontend/src/metabase-types/api/database.ts
@@ -53,6 +53,7 @@ export interface Database extends DatabaseData {
   uploads_enabled: boolean;
   uploads_schema_name: string | null;
   uploads_table_prefix: string | null;
+  is_audit?: boolean;
 
   // Only appears in  GET /api/database/:id
   "can-manage"?: boolean;

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/data-sidebar.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/data-sidebar.ts
@@ -4,9 +4,11 @@ import { t } from "ttag";
 
 import type { ITreeNodeItem } from "metabase/components/tree/types";
 import { isNotNull } from "metabase/lib/types";
+import { PLUGIN_AUDIT } from "metabase/plugins";
 import { getMetadataWithHiddenTables } from "metabase/selectors/metadata";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type Metadata from "metabase-lib/v1/metadata/Metadata";
+import type { Database as DatabaseType } from "metabase-types/api";
 import type { State } from "metabase-types/store";
 
 import type { EntityId, RawDataRouteParams } from "../../types";
@@ -51,6 +53,7 @@ const getTableId = (id: string | number) => `table:${id}`;
 const getDatabasesSidebar = (metadata: Metadata): DataSidebarProps => {
   const entities = metadata
     .databasesList({ savedQuestions: false })
+    .filter(db => !PLUGIN_AUDIT.isAuditDb(db as DatabaseType))
     .map(database => ({
       id: database.id,
       name: database.name,

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.ts
@@ -6,10 +6,14 @@ import _ from "underscore";
 import Groups from "metabase/entities/groups";
 import Tables from "metabase/entities/tables";
 import { isAdminGroup, isDefaultGroup } from "metabase/lib/groups";
-import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
+import {
+  PLUGIN_AUDIT,
+  PLUGIN_FEATURE_LEVEL_PERMISSIONS,
+} from "metabase/plugins";
 import { getMetadataWithHiddenTables } from "metabase/selectors/metadata";
 import type Schema from "metabase-lib/v1/metadata/Schema";
 import type {
+  Database,
   DatabaseId,
   Group,
   GroupsPermissions,
@@ -249,6 +253,7 @@ export const getDatabasesPermissionEditor = createSelector(
       permissionSubject = "schemas";
       entities = metadata
         .databasesList({ savedQuestions: false })
+        .filter(db => !PLUGIN_AUDIT.isAuditDb(db as Database))
         .map(database => {
           const entityId = getDatabaseEntityId(database);
           return {

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -32,6 +32,7 @@ import type { GroupProps, IconName, IconProps } from "metabase/ui";
 import type Question from "metabase-lib/v1/Question";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type {
+  Database as DatabaseType,
   Bookmark,
   CacheableDashboard,
   CacheableModel,
@@ -466,6 +467,10 @@ export const PLUGIN_DASHBOARD_HEADER = {
 
 export const PLUGIN_QUERY_BUILDER_HEADER = {
   extraButtons: (_question: Question) => [],
+};
+
+export const PLUGIN_AUDIT = {
+  isAuditDb: (_db: DatabaseType) => false,
 };
 
 export const PLUGIN_UPLOAD_MANAGEMENT = {

--- a/frontend/src/metabase/selectors/metadata.ts
+++ b/frontend/src/metabase/selectors/metadata.ts
@@ -38,15 +38,7 @@ type FieldSelectorOpts = {
 
 export type MetadataSelectorOpts = TableSelectorOpts & FieldSelectorOpts;
 
-const INTERNAL_DB_ID = 13371337;
-
-const getNormalizedDatabases = (state: State) => {
-  return Object.fromEntries(
-    Object.entries(state.entities.databases).filter(
-      ([_, database]) => database.id !== INTERNAL_DB_ID,
-    ),
-  );
-};
+const getNormalizedDatabases = (state: State) => state.entities.databases;
 const getNormalizedSchemas = (state: State) => state.entities.schemas;
 
 const getNormalizedTablesUnfiltered = (state: State) => state.entities.tables;

--- a/frontend/src/metabase/selectors/metadata.ts
+++ b/frontend/src/metabase/selectors/metadata.ts
@@ -38,7 +38,15 @@ type FieldSelectorOpts = {
 
 export type MetadataSelectorOpts = TableSelectorOpts & FieldSelectorOpts;
 
-const getNormalizedDatabases = (state: State) => state.entities.databases;
+const INTERNAL_DB_ID = 13371337;
+
+const getNormalizedDatabases = (state: State) => {
+  return Object.fromEntries(
+    Object.entries(state.entities.databases).filter(
+      ([_, database]) => database.id !== INTERNAL_DB_ID,
+    ),
+  );
+};
 const getNormalizedSchemas = (state: State) => state.entities.schemas;
 
 const getNormalizedTablesUnfiltered = (state: State) => state.entities.tables;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/44856

### Description

Filters out analytics database(s) in permissions which uses legacy database fetching logic.

The easiest way to reproduce this is:
1. Navigate to any instance-analytics question
2. refresh the page
3. open admin/permissions settings, and you will see the audit db in the database list

Before | After
---|---
![Screen Shot 2024-07-22 at 4 19 28 PM](https://github.com/user-attachments/assets/88f2be47-380a-495b-a2ae-d13704b8f2ac) | ![Screen Shot 2024-07-22 at 4 20 26 PM](https://github.com/user-attachments/assets/2ad23203-9809-4b0a-96cd-461aec7ac2aa)
![Screen Shot 2024-07-22 at 4 19 36 PM](https://github.com/user-attachments/assets/bd50a253-9cf0-4ebd-b2be-154ba91386ef) | ![Screen Shot 2024-07-22 at 4 20 21 PM](https://github.com/user-attachments/assets/1802f4da-29f8-49a8-a4ee-55768effeb0c)



This has a pretty different fix in v49, where MLv2 isn't implemented as much yet. https://github.com/metabase/metabase/pull/45957


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
