### PR TITLE
Add a repro for "Cannot create another filter value if it starts with the same value as an existing value"

### DIFF
--- a/frontend/src/metabase/querying/components/FilterValuePicker/FilterValuePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterValuePicker/FilterValuePicker.unit.spec.tsx
@@ -881,6 +881,22 @@ describe("StringFilterValuePicker", () => {
 
       expect(onChange).toHaveBeenLastCalledWith([]);
     });
+
+    it("should allow to add multiple values that extend each other (metabase#21915)", async () => {
+      const { onChange, onFocus, onBlur } = await setupStringPicker({
+        query,
+        stageIndex,
+        column,
+        values: ["a"],
+      });
+
+      await userEvent.type(screen.getByLabelText("Filter value"), "ab,abc");
+      await userEvent.tab();
+
+      expect(onFocus).toHaveBeenCalled();
+      expect(onChange).toHaveBeenLastCalledWith(["a", "ab", "abc"]);
+      expect(onBlur).toHaveBeenCalled();
+    });
   });
 });
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/21915

This was fixed when we switched to mantine.