### PR TITLE
Fix right section overflow in MultiSelect

### DIFF
--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -29,6 +29,7 @@ import {
   openNotebook,
   resetTestTable,
   resyncDatabase,
+  openPeopleTable,
 } from "e2e/support/helpers";
 
 const {
@@ -528,6 +529,33 @@ describe("issue 24994", () => {
 function assertFilterValueIsSelected(value) {
   cy.findByRole("checkbox", { name: value }).should("be.checked");
 }
+
+describe("issue 45410", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("should not overflow the last filter value with a chevron icon (metabase#45410)", () => {
+    openPeopleTable({ mode: "notebook" });
+    filter({ mode: "notebook" });
+    popover().within(() => {
+      cy.findByText("Email").click();
+      cy.findByPlaceholderText("Enter some text")
+        .type("abc@example.com,abc2@example.com")
+        .blur();
+      cy.findByText("abc2@example.com")
+        .next("button")
+        .then(([removeButton]) => {
+          cy.get("[data-chevron]").then(([chevronIcon]) => {
+            const removeButtonRect = removeButton.getBoundingClientRect();
+            const chevronIconRect = chevronIcon.getBoundingClientRect();
+            expect(removeButtonRect.right).to.be.lte(chevronIconRect.left);
+          });
+        });
+    });
+  });
+});
 
 describe("issue 25378", () => {
   const questionDetails = {

--- a/frontend/src/metabase/ui/components/inputs/MultiSelect/MultiSelect.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiSelect/MultiSelect.styled.tsx
@@ -42,7 +42,7 @@ export const getMultiSelectOverrides =
       styles: (
         theme,
         { invalid }: MultiSelectStylesParams,
-        { size = "md" },
+        { size = "md", variant = "default" },
       ) => ({
         ...getSelectInputOverrides(theme),
         ...getSelectItemsOverrides(theme, size),
@@ -54,6 +54,10 @@ export const getMultiSelectOverrides =
           paddingTop: theme.spacing.xs,
           paddingLeft: theme.spacing.xs,
           paddingBottom: theme.spacing.xs,
+          paddingRight:
+            variant === "unstyled"
+              ? RIGHT_SECTION_SIZES.unstyled
+              : RIGHT_SECTION_SIZES.default,
           alignItems: "center",
           "[data-with-icon=true] &": {
             paddingLeft: 0,
@@ -119,17 +123,11 @@ export const getMultiSelectOverrides =
             paddingTop: rem(7),
             paddingBottom: rem(7),
           },
-          values: {
-            paddingRight: RIGHT_SECTION_SIZES.default,
-          },
         }),
         unstyled: () => ({
           input: {
             paddingTop: rem(8),
             paddingBottom: rem(8),
-          },
-          values: {
-            paddingRight: RIGHT_SECTION_SIZES.unstyled,
           },
         }),
       },

--- a/frontend/src/metabase/ui/components/inputs/MultiSelect/MultiSelect.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiSelect/MultiSelect.styled.tsx
@@ -21,8 +21,10 @@ const VALUE_SIZES = {
   md: rem(28),
 };
 
-const DEFAULT_ICON_WIDTH = rem(40);
-const UNSTYLED_ICON_WIDTH = 28;
+const RIGHT_SECTION_SIZES = {
+  default: rem(40),
+  unstyled: rem(28),
+};
 
 export const getMultiSelectOverrides =
   (): MantineThemeOverride["components"] => ({
@@ -117,7 +119,7 @@ export const getMultiSelectOverrides =
             paddingBottom: rem(7),
           },
           values: {
-            paddingRight: DEFAULT_ICON_WIDTH,
+            paddingRight: RIGHT_SECTION_SIZES.default,
           },
         }),
         unstyled: () => ({
@@ -126,7 +128,7 @@ export const getMultiSelectOverrides =
             paddingBottom: rem(8),
           },
           values: {
-            paddingRight: UNSTYLED_ICON_WIDTH,
+            paddingRight: RIGHT_SECTION_SIZES.unstyled,
           },
         }),
       },

--- a/frontend/src/metabase/ui/components/inputs/MultiSelect/MultiSelect.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiSelect/MultiSelect.styled.tsx
@@ -51,8 +51,9 @@ export const getMultiSelectOverrides =
           minHeight: getSize({ size, sizes: SIZES }),
           marginLeft: 0,
           gap: theme.spacing.xs,
-          padding: theme.spacing.xs,
-          paddingRight: theme.spacing.xl,
+          paddingTop: theme.spacing.xs,
+          paddingLeft: theme.spacing.xs,
+          paddingBottom: theme.spacing.xs,
           alignItems: "center",
           "[data-with-icon=true] &": {
             paddingLeft: 0,

--- a/frontend/src/metabase/ui/components/inputs/MultiSelect/MultiSelect.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiSelect/MultiSelect.styled.tsx
@@ -52,7 +52,6 @@ export const getMultiSelectOverrides =
           marginLeft: 0,
           gap: theme.spacing.xs,
           padding: theme.spacing.xs,
-          paddingRight: theme.spacing.xl,
           alignItems: "center",
           "[data-with-icon=true] &": {
             paddingLeft: 0,

--- a/frontend/src/metabase/ui/components/inputs/MultiSelect/MultiSelect.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiSelect/MultiSelect.styled.tsx
@@ -21,6 +21,9 @@ const VALUE_SIZES = {
   md: rem(28),
 };
 
+const DEFAULT_ICON_WIDTH = rem(40);
+const UNSTYLED_ICON_WIDTH = 28;
+
 export const getMultiSelectOverrides =
   (): MantineThemeOverride["components"] => ({
     MultiSelect: {
@@ -47,6 +50,7 @@ export const getMultiSelectOverrides =
           marginLeft: 0,
           gap: theme.spacing.xs,
           padding: theme.spacing.xs,
+          paddingRight: theme.spacing.xl,
           alignItems: "center",
           "[data-with-icon=true] &": {
             paddingLeft: 0,
@@ -112,11 +116,17 @@ export const getMultiSelectOverrides =
             paddingTop: rem(7),
             paddingBottom: rem(7),
           },
+          values: {
+            paddingRight: DEFAULT_ICON_WIDTH,
+          },
         }),
         unstyled: () => ({
           input: {
             paddingTop: rem(8),
             paddingBottom: rem(8),
+          },
+          values: {
+            paddingRight: UNSTYLED_ICON_WIDTH,
           },
         }),
       },


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/45410

Similar to `Input` style overrides, we need to add padding to accommodate the right section.

How to verify:
- New -> Question -> Orders
- Filter -> User -> Name
- Try adding user names. They should not overflow the icon / button on the right

<img width="503" alt="Screenshot 2024-07-18 at 21 34 40" src="https://github.com/user-attachments/assets/6fd7e512-bac3-4607-9f4f-456938272352">
<img width="537" alt="Screenshot 2024-07-18 at 21 34 45" src="https://github.com/user-attachments/assets/b81ade9a-98d5-444c-9b40-e0c5ca7b1e8d">
