### PR TITLE
[notification] update API to enable http channels for alert

### DIFF
--- a/src/metabase/api/pulse.clj
+++ b/src/metabase/api/pulse.clj
@@ -229,7 +229,8 @@
   (validation/check-has-application-permission :subscription false)
   (let [chan-types (-> channel-types
                        (assoc-in [:slack :configured] (slack/slack-configured?))
-                       (assoc-in [:email :configured] (email/email-configured?)))]
+                       (assoc-in [:email :configured] (email/email-configured?))
+                       (assoc-in [:http :configured] (t2/exists? :model/Channel :type :channel/http :active true)))]
     {:channels (cond
                  (premium-features/sandboxed-or-impersonated-user?)
                  (dissoc chan-types :slack)

--- a/src/metabase/models/pulse_channel.clj
+++ b/src/metabase/models/pulse_channel.clj
@@ -99,7 +99,7 @@
                                 :required    true}]}
    :http  {:type              "http"
            :name              "Webhook"
-           :alows_recipients  false
+           :allows_recipients false
            :schedules         [:hourly :daily :weekly :monthly]}})
 
 (defn channel-type?

--- a/src/metabase/models/pulse_channel.clj
+++ b/src/metabase/models/pulse_channel.clj
@@ -319,7 +319,7 @@
          (coll? recipients)
          (every? map? recipients)]}
   (let [recipients-by-type (group-by integer? (filter identity (map #(or (:id %) (:email %)) recipients)))
-        {:keys [id]}       (t2/insert-returning-pk!
+        id                 (t2/insert-returning-pk!
                             PulseChannel
                             :pulse_id       pulse_id
                             :channel_type   channel_type

--- a/src/metabase/models/pulse_channel.clj
+++ b/src/metabase/models/pulse_channel.clj
@@ -96,7 +96,11 @@
                                 :type        "select"
                                 :displayName "Post to"
                                 :options     []
-                                :required    true}]}})
+                                :required    true}]}
+   :http  {:type              "http"
+           :name              "Webhook"
+           :alows_recipients  false
+           :schedules         [:hourly :daily :weekly :monthly]}})
 
 (defn channel-type?
   "Is `channel-type` a valid value as a channel type? :tv:"
@@ -304,7 +308,7 @@
 (defn create-pulse-channel!
   "Create a new `PulseChannel` along with all related data associated with the channel such as
   `PulseChannelRecipients`."
-  [{:keys [channel_type details enabled pulse_id recipients schedule_type schedule_day schedule_hour schedule_frame]
+  [{:keys [channel_type channel_id details enabled pulse_id recipients schedule_type schedule_day schedule_hour schedule_frame]
     :or   {details          {}
            recipients       []}}]
   {:pre [(channel-type? channel_type)
@@ -315,20 +319,21 @@
          (coll? recipients)
          (every? map? recipients)]}
   (let [recipients-by-type (group-by integer? (filter identity (map #(or (:id %) (:email %)) recipients)))
-        {:keys [id]}       (first (t2/insert-returning-instances!
-                                    PulseChannel
-                                    :pulse_id       pulse_id
-                                    :channel_type   channel_type
-                                    :details        (cond-> details
-                                                      (supports-recipients? channel_type) (assoc :emails (get recipients-by-type false)))
-                                    :enabled        enabled
-                                    :schedule_type  schedule_type
-                                    :schedule_hour  (when (not= schedule_type :hourly)
-                                                      schedule_hour)
-                                    :schedule_day   (when (contains? #{:weekly :monthly} schedule_type)
-                                                      schedule_day)
-                                    :schedule_frame (when (= schedule_type :monthly)
-                                                      schedule_frame)))]
+        {:keys [id]}       (t2/insert-returning-pk!
+                            PulseChannel
+                            :pulse_id       pulse_id
+                            :channel_type   channel_type
+                            :channel_id     channel_id
+                            :details        (cond-> details
+                                              (supports-recipients? channel_type) (assoc :emails (get recipients-by-type false)))
+                            :enabled        enabled
+                            :schedule_type  schedule_type
+                            :schedule_hour  (when (not= schedule_type :hourly)
+                                              schedule_hour)
+                            :schedule_day   (when (contains? #{:weekly :monthly} schedule_type)
+                                              schedule_day)
+                            :schedule_frame (when (= schedule_type :monthly)
+                                              schedule_frame))]
     (when (and (supports-recipients? channel_type) (seq (get recipients-by-type true)))
       (update-recipients! id (get recipients-by-type true)))
     ;; return the id of our newly created channel

--- a/test/metabase/api/alert_test.clj
+++ b/test/metabase/api/alert_test.clj
@@ -3,6 +3,7 @@
   (:require
    [clojure.test :refer :all]
    [medley.core :as m]
+   [metabase.channel.http-test :as channel.http-test]
    [metabase.email-test :as et]
    [metabase.http-client :as client]
    [metabase.models
@@ -414,6 +415,34 @@
                                       #"My question")))))))
 
 
+(defn- default-http-channel
+  [id]
+  {:enabled       true
+   :channel_type  "http"
+   :channel_id    id
+   :details       {}
+   :schedule_type "daily"
+   :schedule_hour 12
+   :schedule_day  nil})
+
+(deftest create-alert-with-http-channel-test
+  (testing "Creating an alert with a HTTP channel"
+    (mt/with-model-cleanup [:model/Pulse]
+      (channel.http-test/with-server [url [channel.http-test/get-200]]
+       (mt/with-temp [:model/Channel channel {:type    :channel/http
+                                              :details {:auth-method "none"
+                                                        :url         (str url (:path channel.http-test/get-200))}}
+                      :model/Card    {card-id :id} {}]
+         (let [pulse (mt/user-http-request :crowberto :post 200 "alert"
+                                            {:alert_condition  "rows"
+                                             :alert_first_only false
+                                             :card             {:id card-id, :include_csv false, :include_xls false, :dashboard_card_id nil}
+                                             :channels         [(default-http-channel (:id channel))]})]
+           (is (=? {:pulse_id     (:id pulse)
+                    :channel_type :http
+                    :channel_id   (:id channel)}
+                  (t2/select-one :model/PulseChannel :pulse_id (:id pulse))))))))))
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                               PUT /api/alert/:id                                               |
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -629,6 +658,23 @@
           (testing "but not allowed to edit the card"
             (mt/user-http-request :rasta :put 403 (alert-url alert)
                                   (dissoc (default-alert-req card pc {} []) :channels))))))))
+
+(deftest update-alert-enable-http-channel-test
+  (mt/with-temp [:model/Pulse     alert (basic-alert)
+                 :model/Card      card  {}
+                 :model/PulseCard _     (pulse-card alert card)
+                 :model/Channel   {channel-id :id} {:type    :channel/http
+                                                    :details {:auth-method "none"
+                                                              :url         "https://metabasetest.com"}}]
+    (is (=? {:channels [{:channel_type "http"
+                         :channel_id   channel-id
+                         :enabled true}]}
+            (mt/user-http-request :crowberto :put 200 (alert-url alert)
+                                  (default-alert-req card (u/the-id alert) {:channels [(default-http-channel channel-id)]} nil))))
+    (is (=? {:pulse_id     (:id alert)
+             :channel_type :http
+             :channel_id   channel-id}
+            (t2/select-one :model/PulseChannel :pulse_id (:id alert))))))
 
 (deftest alert-event-test
   (mt/with-premium-features #{:audit-app}

--- a/test/metabase/api/alert_test.clj
+++ b/test/metabase/api/alert_test.clj
@@ -666,15 +666,18 @@
                  :model/Channel   {channel-id :id} {:type    :channel/http
                                                     :details {:auth-method "none"
                                                               :url         "https://metabasetest.com"}}]
-    (is (=? {:channels [{:channel_type "http"
-                         :channel_id   channel-id
-                         :enabled true}]}
-            (mt/user-http-request :crowberto :put 200 (alert-url alert)
-                                  (default-alert-req card (u/the-id alert) {:channels [(default-http-channel channel-id)]} nil))))
-    (is (=? {:pulse_id     (:id alert)
-             :channel_type :http
-             :channel_id   channel-id}
-            (t2/select-one :model/PulseChannel :pulse_id (:id alert))))))
+    (testing "PUT /api/channel/:id can enable a HTTP channel for an alert"
+      (is (=? {:channels [{:channel_type "http"
+                           :channel_id   channel-id
+                           :enabled true}]}
+              (mt/user-http-request :crowberto :put 200 (alert-url alert)
+                                    (default-alert-req card (u/the-id alert) {:channels [(default-http-channel channel-id)]} nil))))
+
+      (testing "make sure it's in the database"
+        (is (=? {:pulse_id     (:id alert)
+                 :channel_type :http
+                 :channel_id   channel-id}
+                (t2/select-one :model/PulseChannel :pulse_id (:id alert))))))))
 
 (deftest alert-event-test
   (mt/with-premium-features #{:audit-app}

--- a/test/metabase/api/pulse_test.clj
+++ b/test/metabase/api/pulse_test.clj
@@ -1004,6 +1004,34 @@
 
 (deftest form-input-test
   (testing "GET /api/pulse/form_input"
+    (mt/with-temporary-setting-values
+      [slack/slack-app-token "test-token"]
+      (mt/with-temp [:model/Channel _ {:type :channel/http :details {:url "https://metabasetest.com" :auth-method "none"}}]
+        (is (= {:channels {:email {:allows_recipients true
+                                   :configured        false
+                                   :name              "Email"
+                                   :recipients        ["user" "email"]
+                                   :schedules         ["hourly" "daily" "weekly" "monthly"]
+                                   :type              "email"}
+                           :http  {:alows_recipients false
+                                   :configured       true
+                                   :name             "Webhook"
+                                   :schedules        ["hourly" "daily" "weekly" "monthly"]
+                                   :type             "http"}
+                           :slack {:allows_recipients false
+                                   :configured        true
+                                   :fields            [{:displayName "Post to"
+                                                        :name        "channel"
+                                                        :options     []
+                                                        :required    true
+                                                        :type        "select"}]
+                                   :name             "Slack"
+                                   :schedules        ["hourly" "daily" "weekly" "monthly"]
+                                   :type             "slack"}}}
+               (mt/user-http-request :rasta :get 200 "pulse/form_input")))))))
+
+(deftest form-input-slack-test
+  (testing "GET /api/pulse/form_input"
     (testing "Check that Slack channels come back when configured"
       (mt/with-temporary-setting-values [slack/slack-channels-and-usernames-last-updated
                                          (t/zoned-date-time)

--- a/test/metabase/api/pulse_test.clj
+++ b/test/metabase/api/pulse_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.api.pulse-test
   "Tests for /api/pulse endpoints."
   (:require
+   [clojure.string :as str]
    [clojure.test :refer :all]
    [java-time.api :as t]
    [metabase.api.card-test :as api.card-test]
@@ -920,27 +921,37 @@
 (deftest send-test-alert-with-http-channel-test
   ;; see [[metabase-enterprise.advanced-config.api.pulse-test/test-pulse-endpoint-should-respect-email-domain-allow-list-test]]
   ;; for additional EE-specific tests
-  (testing "POST /api/pulse/test send test alert"
+  (testing "POST /api/pulse/test send test alert to a http channel"
     (mt/with-temp
-      [:model/Card card {:dataset_query (mt/mbql-query orders {:aggregation [[:count]]})}
+      [:model/Card    card    {:dataset_query (mt/mbql-query orders {:aggregation [[:count]]})}
        :model/Channel channel {:type    :channel/http
                                :details {:url         "http://example.com"
                                          :auth-method :none}}]
-      (pulse.test-util/with-captured-channel-send-messages!
-        (mt/user-http-request :rasta :post 200 "pulse/test"
-                              {:name            (mt/random-name)
-                               :cards           [{:id                (:id card)
-                                                  :include_csv       false
-                                                  :include_xls       false
-                                                  :dashboard_card_id nil}]
-                               :channels        [{:enabled       true
-                                                  :channel_type  "http"
-                                                  :channel_id    (:id channel)
-                                                  :schedule_type "daily"
-                                                  :schedule_hour 12
-                                                  :schedule_day  nil
-                                                  :recipients    []}]
-                               :alert_condition "rows"})))))
+      (is (=? {:channel/http [{:body {:alert_creator_id   (mt/user->id :rasta)
+                                      :alert_creator_name "Rasta Toucan"
+                                      :alert_id           nil
+                                      :data               {:question_id   (:id card)
+                                                           :question_name (mt/malli=? string?)
+                                                           :question_url  (mt/malli=? string?)
+                                                           :raw_data      {:cols ["count"], :rows [[18760]]},
+                                                           :type          "question"
+                                                           :visualization (mt/malli=? [:fn #(str/starts-with? % "data:image/png;base64,")])}
+                                      :type               "alert"}}]}
+              (pulse.test-util/with-captured-channel-send-messages!
+                (mt/user-http-request :rasta :post 200 "pulse/test"
+                                      {:name            (mt/random-name)
+                                       :cards           [{:id                (:id card)
+                                                          :include_csv       false
+                                                          :include_xls       false
+                                                          :dashboard_card_id nil}]
+                                       :channels        [{:enabled       true
+                                                          :channel_type  "http"
+                                                          :channel_id    (:id channel)
+                                                          :schedule_type "daily"
+                                                          :schedule_hour 12
+                                                          :schedule_day  nil
+                                                          :recipients    []}]
+                                       :alert_condition "rows"})))))))
 
 (deftest send-test-pulse-validate-emails-test
   (testing (str "POST /api/pulse/test should call " `pulse-channel/validate-email-domains)


### PR DESCRIPTION
Milestone 2.3 of https://github.com/metabase/metabase/issues/43822.

This PR updates so that `POST /api/alert` and `PUT /api/alert` accept HTTP channels as destination.

Also:
- add a test for `POST /api/pulse/test` so we can use this to send tests when setting up the HTTP channel for alerts.
- add a test for `GET /api/pulse/form_input` to check that HTTP channels are returned correctly


I didnt' create a new `POST /api/alert/test` for this because we'll soon rework these apis as part of the new architecture.