### PR TITLE
Improve N+1 detection for simple hydration methods

### DIFF
--- a/dev/src/dev.clj
+++ b/dev/src/dev.clj
@@ -319,8 +319,7 @@
 (methodical/defmethod t2.hydrate/hydrate-with-strategy :around ::t2.hydrate/multimethod-simple
   "Throws an error if do simple hydrations that make DB call on a sequence."
   [model strategy k instances]
-  (if (or config/is-prod?
-          (< (count instances) 2))
+  (if config/is-prod?
     (next-method model strategy k instances)
     (do
       ;; prevent things like dereferencing metabase.api.common/*current-user-permissions-set* from triggering the check

--- a/dev/src/dev.clj
+++ b/dev/src/dev.clj
@@ -309,26 +309,31 @@
                                  (qp.compile/compile built-query))]
     (into [query] params)))
 
+(defn- maybe-realize
+  "Realize a lazy sequence if it's a lazy sequence. Otherwise, return the value as is."
+  [x]
+  (if (instance? clojure.lang.LazySeq x)
+    (doall x)
+    x))
+
 (methodical/defmethod t2.hydrate/hydrate-with-strategy :around ::t2.hydrate/multimethod-simple
   "Throws an error if do simple hydrations that make DB call on a sequence."
   [model strategy k instances]
   (if (or config/is-prod?
-          (< (count instances) 2)
-          ;; we skip checking these keys because most of the times its call count
-          ;; are from deferencing metabase.api.common/*current-user-permissions-set*
-          (#{:can_write :can_read} k))
+          (< (count instances) 2))
     (next-method model strategy k instances)
-    (t2/with-call-count [call-count]
-      (let [res (next-method model strategy k instances)
-            ;; if it's a lazy-seq then we need to realize it so call-count is counted
-            res (if (instance? clojure.lang.LazySeq res)
-                  (doall res)
-                  res)]
-        ;; only throws an exception if the simple hydration makes a DB call
-        (when (pos-int? (call-count))
-          (throw (ex-info (format "N+1 hydration detected!!! Model %s, key %s]" (pr-str model) k)
-                          {:model model :strategy strategy :k k :items-count (count instances) :db-calls (call-count)})))
-        res))))
+    (do
+      ;; prevent things like dereferencing metabase.api.common/*current-user-permissions-set* from triggering the check
+      ;; by calling `next-method` *twice*. To reduce the performance impact, just call it with the first instance.
+      (maybe-realize (next-method model strategy k [(first instances)]))
+      ;; Now we can actually run the hydration with the full set of instances and make sure no more DB calls happened.
+      (t2/with-call-count [call-count]
+        (let [res (maybe-realize (next-method model strategy k instances))]
+          ;; only throws an exception if the simple hydration makes a DB call
+          (when (pos-int? (call-count))
+              (throw (ex-info (format "N+1 hydration detected!!! Model %s, key %s]" (pr-str model) k)
+                              {:model model :strategy strategy :k k :items-count (count instances) :db-calls (call-count)})))
+          res)))))
 
 (defn app-db-as-data-warehouse
   "Add the application database as a Database. Currently only works if your app DB uses broken-out details!"

--- a/dev/test/dev/n_plus_one_detection_test.clj
+++ b/dev/test/dev/n_plus_one_detection_test.clj
@@ -1,0 +1,39 @@
+(ns test.dev.n-plus-one-detection-test
+  (:require  [clojure.test :refer [deftest testing is]]
+             [dev]
+             [methodical.core :as methodical]
+             [toucan2.core :as t2]
+             [toucan2.tools.hydrate :as t2.hydrate]))
+
+(methodical/defmethod t2.hydrate/simple-hydrate
+  [:default ::some-silly-key-that-should-never-actually-be-hydrated!!!]
+  [_model k row]
+  (let [v (:one (t2/query-one {:select [[1 :one]]}))]
+    (assoc row k v)))
+
+(def ^:dynamic *cached?* nil)
+
+;; A simple hydration function that simulates caching. The first time it's called, it hits the database, but it
+;; doesn't on subsequent calls.
+(methodical/defmethod t2.hydrate/simple-hydrate
+  [:default ::just-a-fake-cached-hydration-function!!!]
+  [_model k row]
+  (if @*cached?*
+    (assoc row k :cached)
+    (do
+      (reset! *cached?* true)
+      (assoc row k (:not-cached (t2/query-one {:select [[true :not-cached]]}))))))
+
+(deftest n-plus-one-detection-test-works
+  (testing "it does actually detect N+1 queries"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"N\+1 hydration detected"
+                          (t2/hydrate [{} {} {}] ::some-silly-key-that-should-never-actually-be-hydrated!!!))))
+  (testing "it detects N+1 queries even when there's just one item"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"N\+1 hydration detected"
+                          (t2/hydrate [{}] ::some-silly-key-that-should-never-actually-be-hydrated!!!))))
+  (binding [*cached?* (atom false)]
+    (testing "Hydration doesn't throw"
+      (is (= [{::just-a-fake-cached-hydration-function!!! :cached}]
+             (t2/hydrate [{}] ::just-a-fake-cached-hydration-function!!!))))
+    (testing "The 'cache' was populated"
+      (is (= true @*cached?*)))))


### PR DESCRIPTION
We have N+1 detection for simple hydration methods that checks to see whether the hydration method made any DB queries at all. This makes sense, because a simple hydration method is called on each instance individually - if we make database calls *each time*, we're in trouble.

Where this runs into issues is with cached data, where the simple hydration method is populating the cache - e.g. `:can_read` or `:can_write` dereferencing `api/*current-user-permissions-set*`. Currently we specifically exclude those hydration methods from the check.

But after running into this again for a different simple hydration method, I think there's a more robust approach:

- first, run the hydration method without counting DB queries

- then, run it again and make sure we don't make any additional DB queries.

There is a potential downside here: if someone wrote a simple hydration method with side effects, they'd potentially be very confused (in development - this doesn't run in prod!) when those side effects happened twice for a single hydration. But I *think* that's fairly unlikely.