### PR TITLE
fix(sdk): missing semantic text colors mapping

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkGlobalStylesWrapper.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkGlobalStylesWrapper.unit.spec.tsx
@@ -1,5 +1,7 @@
-import { renderWithProviders } from "__support__/ui";
+import { renderWithProviders, screen } from "__support__/ui";
 import { SdkGlobalStylesWrapper } from "embedding-sdk/components/private/SdkGlobalStylesWrapper";
+import { SdkThemeProvider } from "embedding-sdk/components/private/SdkThemeProvider";
+import { Text } from "metabase/ui";
 import {
   createMockSettingsState,
   createMockState,
@@ -35,5 +37,23 @@ describe("SdkGlobalStylesWrapper", () => {
 
     expect(fontFaceRule).toBeDefined();
     expect(fontFaceRule.cssText).toContain("font-weight: 700");
+  });
+
+  it("should use foreground color from the theme", () => {
+    const theme = {
+      colors: { "text-primary": "rgb(255, 0, 255)" },
+    };
+
+    renderWithProviders(
+      <SdkThemeProvider theme={theme}>
+        <SdkGlobalStylesWrapper>
+          <Text>Hello world</Text>
+        </SdkGlobalStylesWrapper>
+      </SdkThemeProvider>,
+    );
+
+    expect(window.getComputedStyle(screen.getByText("Hello world")).color).toBe(
+      "rgb(255, 0, 255)",
+    );
   });
 });

--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkThemeProvider.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkThemeProvider.unit.spec.tsx
@@ -48,4 +48,20 @@ describe("SdkThemeProvider", () => {
     // SDK colors should override user interface colors
     expect(filter.color).toBe("rgb(44, 44, 44)");
   });
+
+  it("should use foreground color from the theme", () => {
+    const theme = {
+      colors: { "text-primary": "rgb(255, 0, 255)" },
+    };
+
+    renderWithProviders(
+      <SdkThemeProvider theme={theme}>
+        <Text>Hello world</Text>
+      </SdkThemeProvider>,
+    );
+
+    expect(window.getComputedStyle(screen.getByText("Hello world")).color).toBe(
+      "rgb(255, 0, 255)",
+    );
+  });
 });

--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkThemeProvider.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkThemeProvider.unit.spec.tsx
@@ -48,20 +48,4 @@ describe("SdkThemeProvider", () => {
     // SDK colors should override user interface colors
     expect(filter.color).toBe("rgb(44, 44, 44)");
   });
-
-  it("should use foreground color from the theme", () => {
-    const theme = {
-      colors: { "text-primary": "rgb(255, 0, 255)" },
-    };
-
-    renderWithProviders(
-      <SdkThemeProvider theme={theme}>
-        <Text>Hello world</Text>
-      </SdkThemeProvider>,
-    );
-
-    expect(window.getComputedStyle(screen.getByText("Hello world")).color).toBe(
-      "rgb(255, 0, 255)",
-    );
-  });
 });

--- a/frontend/src/metabase/styled-components/theme/css-variables.ts
+++ b/frontend/src/metabase/styled-components/theme/css-variables.ts
@@ -63,6 +63,7 @@ function getDesignSystemCssVariables(theme: MantineTheme) {
       transparent
     );
 
+    /* Semantic colors */
     --mb-color-focus: ${theme.fn.themeColor("focus")};
     --mb-color-bg-white: ${theme.fn.themeColor("bg-white")};
     --mb-color-bg-black: ${theme.fn.themeColor("bg-black")};
@@ -81,6 +82,9 @@ function getDesignSystemCssVariables(theme: MantineTheme) {
     --mb-color-success: ${theme.fn.themeColor("success")};
     --mb-color-summarize: ${theme.fn.themeColor("summarize")};
     --mb-color-warning: ${theme.fn.themeColor("warning")};
+    --mb-color-text-primary: var(--mb-color-text-dark);
+    --mb-color-text-secondary: var(--mb-color-text-medium);
+    --mb-color-text-tertiary: var(--mb-color-text-light);
   `;
 }
 


### PR DESCRIPTION
### Description

Shoppy has the wrong foreground text color right now, because `--mb-color-text-primary` did not get mapped to `var(--mb-color-text-dark)` in the sdk's code path, which means the theme options did not take effect. This PR adds the same mapping as we have in `colors.module.css` and `EmbedFrame.module.css`

![CleanShot 2567-07-19 at 22 23 29@2x](https://github.com/user-attachments/assets/6d427a6c-5f8e-42e0-989d-8a3f13a33187)

### How to verify

- Run Shoppy
- Foreground color should be #E3E7E4 for theStitch theme.