### PR TITLE
Check for cardId being undefined in downloads

### DIFF
--- a/frontend/src/metabase/query_builder/actions/downloading.ts
+++ b/frontend/src/metabase/query_builder/actions/downloading.ts
@@ -76,7 +76,8 @@ const getDatasetParams = ({
   visualizationSettings,
 }: DownloadQueryResultsOpts): DownloadQueryResultsParams => {
   const cardId = question.id();
-  const isQuestionInStaticEmbedDashboard = dashcardId != null && token != null;
+  const isQuestionInStaticEmbedDashboard =
+    dashcardId != null && cardId != null && token != null;
 
   // Formatting is always enabled for Excel
   const format_rows = enableFormatting && type !== "xlsx" ? "true" : "false";
@@ -89,7 +90,8 @@ const getDatasetParams = ({
     };
   }
 
-  const isQuestionInPublicDashboard = dashboardId != null && uuid != null;
+  const isQuestionInPublicDashboard =
+    dashboardId != null && cardId != null && uuid != null;
   if (isQuestionInPublicDashboard) {
     return {
       method: "POST",
@@ -101,7 +103,8 @@ const getDatasetParams = ({
     };
   }
 
-  const isDashboard = dashboardId != null && dashcardId != null;
+  const isDashboard =
+    dashboardId != null && dashcardId != null && cardId != null;
   if (isDashboard) {
     return {
       method: "POST",


### PR DESCRIPTION
There was a fairly complex case where we had `cardId` undefined by mistake made in another area of the app. Let's add a simple check and guard against similar errors in the future. 