### PR TITLE
Tweak some sandboxing-related comments

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
@@ -1,5 +1,5 @@
 (ns metabase-enterprise.sandbox.models.group-table-access-policy
-  "Model definition for sandboxes, aka Group Table Access Policies (old name). A sandbox is useed to control access to a
+  "Model definition for sandboxes, aka Group Table Access Policies (old name). A sandbox is used to control access to a
   certain Table for a certain PermissionsGroup. Whenever a member of that group attempts to query the Table in question,
   a Saved Question specified by the GTAP is instead used as the source of the query.
 

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
@@ -1,7 +1,7 @@
 (ns metabase-enterprise.sandbox.models.group-table-access-policy
-  "Model definition for Group Table Access Policy, aka GTAP. A GTAP is useed to control access to a certain Table for a
-  certain PermissionsGroup. Whenever a member of that group attempts to query the Table in question, a Saved Question
-  specified by the GTAP is instead used as the source of the query.
+  "Model definition for sandboxes, aka Group Table Access Policies (old name). A sandbox is useed to control access to a
+  certain Table for a certain PermissionsGroup. Whenever a member of that group attempts to query the Table in question,
+  a Saved Question specified by the GTAP is instead used as the source of the query.
 
   See documentation in [[metabase.models.permissions]] for more information about the Metabase permissions system."
   (:require
@@ -34,7 +34,7 @@
 
 (doto :model/GroupTableAccessPolicy
   (derive :metabase/model)
-  ;;; only admins can work with GTAPs
+  ;;; only admins can work with sandboxes
   (derive ::mi/read-policy.superuser)
   (derive ::mi/write-policy.superuser))
 
@@ -137,12 +137,11 @@
             sandboxes)))
 
 (mu/defn check-columns-match-table
-  "Make sure the result metadata data columns for the Card associated with a GTAP match up with the columns in the Table
-  that's getting GTAPped. It's ok to remove columns, but you cannot add new columns. The base types of the Card
-  columns can derive from the respective base types of the columns in the Table itself, but you cannot return an
-  entirely different type."
+  "Make sure the result metadata data columns for the Card associated with a sandbox match up with the columns in the Table
+  that's getting sandboxed The base types of the Card columns can derive from the respective base types of the columns in
+  the Table itself, but you cannot return an entirely different type. Extra columns in the sandboxing Card are ignored."
   ([{card-id :card_id, table-id :table_id}]
-   ;; not all GTAPs have Cards
+   ;; not all sandboxes have Cards
    (when card-id
      ;; not all Cards have saved result metadata
      (when-let [result-metadata (t2/select-one-fn :result_metadata Card :id card-id)]
@@ -158,7 +157,7 @@
 
 (defenterprise pre-update-check-sandbox-constraints
   "If a Card is updated, and its result metadata changes, check that these changes do not violate the constraints placed
-  on GTAPs (the Card cannot add fields or change types vs. the original Table)."
+  on sandboxes (the Card cannot add fields or change types vs. the original Table)."
   :feature :sandboxes
   [{new-result-metadata :result_metadata, card-id :id}]
   (when new-result-metadata
@@ -209,7 +208,7 @@
     (let [original (t2/original updates)
           updated  (merge original updates)]
       (when-not (= (:table_id original) (:table_id updated))
-        (throw (ex-info (tru "You cannot change the Table ID of a GTAP once it has been created.")
+        (throw (ex-info (tru "You cannot change the table ID of a sandbox once it has been created.")
                         {:id          id
                          :status-code 400})))
       (when (:card_id updates)

--- a/enterprise/backend/test/metabase_enterprise/sandbox/models/group_table_access_policy_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/models/group_table_access_policy_test.clj
@@ -39,7 +39,7 @@
                                                           :group_id (u/the-id (perms-group/all-users))}]
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo
-           #"You cannot change the Table ID of a sandbox once it has been created"
+           #"You cannot change the table ID of a sandbox once it has been created"
            (t2/update! GroupTableAccessPolicy (:id gtap) {:table_id (mt/id :checkins)}))))))
 
 (deftest disallow-queries-that-add-columns-test

--- a/enterprise/backend/test/metabase_enterprise/sandbox/models/group_table_access_policy_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/models/group_table_access_policy_test.clj
@@ -34,12 +34,12 @@
                (t2/select-one-fn :attribute_remappings GroupTableAccessPolicy :id (u/the-id gtap))))))))
 
 (deftest disallow-changing-table-id-test
-  (testing "You can't change the table_id of a GTAP after it has been created."
+  (testing "You can't change the table_id of a sandbox after it has been created."
     (t2.with-temp/with-temp [GroupTableAccessPolicy gtap {:table_id (mt/id :venues)
                                                           :group_id (u/the-id (perms-group/all-users))}]
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo
-           #"You cannot change the Table ID of a GTAP once it has been created"
+           #"You cannot change the Table ID of a sandbox once it has been created"
            (t2/update! GroupTableAccessPolicy (:id gtap) {:table_id (mt/id :checkins)}))))))
 
 (deftest disallow-queries-that-add-columns-test


### PR DESCRIPTION
* Fix the claim that you can't add columns to a card used as a sandbox definition. This was changed in 2021: https://github.com/metabase/metabase/pull/14735
* Change some instances of `GTAP` to `sandbox` to move towards consistent language