### PR TITLE
Lock down the trash collection more

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
@@ -2,7 +2,6 @@
   (:refer-clojure :exclude [load])
   (:require
    [clojure.java.io :as io]
-   [clojure.set :as set]
    [clojure.string :as str]
    [metabase-enterprise.serialization.dump :as dump]
    [metabase-enterprise.serialization.load :as load]
@@ -237,25 +236,20 @@
     (.mkdirs f)
     (when-not (.canWrite f)
       (throw (ex-info (format "Destination path is not writeable: %s" path) {:filename path}))))
-  (let [start                (System/nanoTime)
-        ;; we _ALWAYS_ export the Trash. Its descendants are empty, so we won't export anything extra as a result, but
-        ;; we will export items that are currently in the Trash, assuming they were trashed *from* a place we're
-        ;; exporting.
-        collection-ids+trash (set/union collection-ids
-                                        #{(collection/trash-collection-id)})
-        err                  (atom nil)
-        report               (try
-                               (serdes/with-cache
-                                 (-> (cond-> opts
-                                       (seq collection-ids)
-                                       (assoc :targets
-                                              (v2.extract/make-targets-of-type
-                                               "Collection"
-                                               collection-ids+trash)))
-                                     v2.extract/extract
-                                     (v2.storage/store! path)))
-                               (catch Exception e
-                                 (reset! err e)))]
+  (let [start  (System/nanoTime)
+        err    (atom nil)
+        report (try
+                 (serdes/with-cache
+                   (-> (cond-> opts
+                         (seq collection-ids)
+                         (assoc :targets
+                                (v2.extract/make-targets-of-type
+                                 "Collection"
+                                 collection-ids)))
+                       v2.extract/extract
+                       (v2.storage/store! path)))
+                 (catch Exception e
+                   (reset! err e)))]
     (snowplow/track-event! ::snowplow/serialization nil
                            {:direction       "export"
                             :source          "cli"

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/entity_ids.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/entity_ids.clj
@@ -4,6 +4,7 @@
    [clojure.string :as str]
    [metabase.db :as mdb]
    [metabase.models]
+   [metabase.models.collection :as collection]
    [metabase.models.serialization :as serdes]
    [metabase.util :as u]
    [metabase.util.i18n :refer [trs]]
@@ -122,10 +123,15 @@
                                (entity-id-models))]
     (zero? error-count)))
 
+(defn- drop-entity-id-conditions-for-model [model]
+  (case model
+    :model/Collection {:id [:not= (collection/trash-collection-id)]}
+    {}))
+
 (defn- drop-entity-ids-for-model! [model]
   (log/infof "Dropping Entity IDs for model %s" (name model))
   (try
-    (let [update-count (t2/update! model {:entity_id nil})]
+    (let [update-count (t2/update! model (drop-entity-id-conditions-for-model model) {:entity_id nil})]
       (when (pos? update-count)
         (log/infof "Updated %d %s instance(s) successfully." update-count (name model)))
       {:update-count update-count})

--- a/enterprise/backend/test/metabase_enterprise/serialization/cmd_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/cmd_test.clj
@@ -191,7 +191,7 @@
                          "settings"        true
                          "field_values"    false
                          "duration_ms"     pos?
-                         "count"           4
+                         "count"           3
                          "source"          "cli"
                          "secrets"         false
                          "success"         true
@@ -207,7 +207,7 @@
                          "duration_ms"   pos?
                          "source"        "cli"
                          "models"        "Card,Collection,Setting"
-                         "count"         4
+                         "count"         3
                          "success"       true
                          "error_message" nil}
                         (-> (snowplow-test/pop-event-data-and-user-id!) first :data))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -227,7 +227,7 @@
                                                  (fnil conj []) entity))
                                        {} @extraction))
             ;; +1 for the Trash collection
-            (is (= 111 (-> @entities (get "Collection") count))))
+            (is (= 110 (-> @entities (get "Collection") count))))
 
           (testing "storage"
             (storage/store! (seq @extraction) dump-dir)
@@ -237,7 +237,7 @@
 
             (testing "for Collections"
               ;; +1 for the Trash collection
-              (is (= 111 (count (for [f (file-set (io/file dump-dir))
+              (is (= 110 (count (for [f (file-set (io/file dump-dir))
                                       :when (and (= (first f) "collections")
                                                  (let [[a b] (take-last 2 f)]
                                                    (= b (str a ".yaml"))))]

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -28,7 +28,6 @@
             TimelineEvent
             User]]
    [metabase.models.action :as action]
-   [metabase.models.collection :as collection]
    [metabase.models.serialization :as serdes]
    [metabase.test :as mt]
    [metabase.util.malli.schema :as ms]
@@ -43,8 +42,6 @@
        (filter #(= model-name (:model %)))
        (map :id)
        set))
-
-(def ^:private trash-eid (delay (:entity_id (collection/trash-collection))))
 
 (deftest fundamentals-test
   (mt/with-empty-h2-app-db
@@ -103,15 +100,15 @@
 
       (testing "overall extraction returns the expected set"
         (testing "no user specified"
-          (is (= #{coll-eid child-eid @trash-eid}
+          (is (= #{coll-eid child-eid}
                  (by-model "Collection" (extract/extract nil)))))
 
         (testing "valid user specified"
-          (is (= #{coll-eid child-eid pc-eid @trash-eid}
+          (is (= #{coll-eid child-eid pc-eid}
                  (by-model "Collection" (extract/extract {:user-id mark-id})))))
 
         (testing "invalid user specified"
-          (is (= #{coll-eid child-eid @trash-eid}
+          (is (= #{coll-eid child-eid}
                  (by-model "Collection" (extract/extract {:user-id 218921})))))))))
 
 (deftest database-test
@@ -556,12 +553,11 @@
                       (into [])
                       (map :name)))))
         (testing "unowned collections and the personal one with a user"
-          ;; the trash is always included
-          (is (= #{coll-eid mark-coll-eid @trash-eid}
+          (is (= #{coll-eid mark-coll-eid}
                  (->> {:collection-set (#'extract/collection-set-for-user mark-id)}
                       (serdes/extract-all "Collection")
                       (by-model "Collection"))))
-          (is (= #{coll-eid dave-coll-eid @trash-eid}
+          (is (= #{coll-eid dave-coll-eid}
                  (->> {:collection-set (#'extract/collection-set-for-user dave-id)}
                       (serdes/extract-all "Collection")
                       (by-model "Collection"))))))
@@ -1706,7 +1702,7 @@
         (is (some? (audit/default-custom-reports-collection))))
       (let [ser (extract/extract {:no-settings   true
                                   :no-data-model true})]
-        (is (= #{@trash-eid} (by-model "Collection" ser)))))))
+        (is (= #{} (by-model "Collection" ser)))))))
 
 (deftest entity-id-in-targets-test
   (mt/with-temp [Collection c {:name "Top-Level Collection"}]

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/storage_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/storage_test.clj
@@ -10,7 +10,6 @@
    [metabase-enterprise.serialization.v2.storage :as storage]
    [metabase.models :refer [Card Collection Dashboard DashboardCard Database Field FieldValues NativeQuerySnippet
                             Table]]
-   [metabase.models.collection :as collection]
    [metabase.models.serialization :as serdes]
    [metabase.test :as mt]
    [metabase.util.date-2 :as u.date]
@@ -26,8 +25,6 @@
                :let               [rel (.relativize base (.toPath file))]]
            (mapv str rel)))))
 
-(def ^:private trash-dir (delay (str (:entity_id (collection/trash-collection)) "_trash")))
-
 (deftest basic-dump-test
   (ts/with-random-dump-dir [dump-dir "serdesv2-"]
     (mt/with-empty-h2-app-db
@@ -39,8 +36,7 @@
           (storage/store! export dump-dir)
           (testing "the right files in the right places"
             (is (= #{[parent-filename (str parent-filename ".yaml")]
-                     [parent-filename child-filename (str child-filename ".yaml")]
-                     [@trash-dir (str @trash-dir ".yaml")]}
+                     [parent-filename child-filename (str child-filename ".yaml")]}
                    (file-set (io/file dump-dir "collections")))
                 "collections form a tree, with same-named files")
             (is (contains? (file-set (io/file dump-dir))
@@ -85,8 +81,7 @@
             (let [gp-dir (str (:entity_id grandparent) "_grandparent_collection")
                   p-dir  (str (:entity_id parent)      "_parent_collection")
                   c-dir  (str (:entity_id child)       "_child_collection")]
-              (is (= #{[@trash-dir (str @trash-dir ".yaml")]                                  ; Trash collection, always included
-                       [gp-dir (str gp-dir ".yaml")]                                          ; Grandparent collection
+              (is (= #{[gp-dir (str gp-dir ".yaml")]                                          ; Grandparent collection
                        [gp-dir p-dir (str p-dir ".yaml")]                                     ; Parent collection
                        [gp-dir p-dir c-dir (str c-dir ".yaml")]                               ; Child collection
                        ["cards" (str (:entity_id c1) "_root_card.yaml")]                      ; Root card
@@ -121,12 +116,10 @@
             (testing "collections under collections/"
               (is (= #{[gp-dir (str gp-dir ".yaml")]                                          ; Grandparent collection
                        [gp-dir p-dir (str p-dir ".yaml")]                                     ; Parent collection
-                       [gp-dir p-dir c-dir (str c-dir ".yaml")]                               ; Child collection
-                       [@trash-dir (str @trash-dir ".yaml")]}
+                       [gp-dir p-dir c-dir (str c-dir ".yaml")]}                              ; Child collection
                      (file-set (io/file dump-dir "collections")))))
             (testing "snippets under snippets/"
-              (is (= #{
-                       [(str (:entity_id c1) "_root_snippet.yaml")]                      ; Root snippet
+              (is (= #{[(str (:entity_id c1) "_root_snippet.yaml")]                      ; Root snippet
                        [gp-dir (str (:entity_id c2) "_grandparent_snippet.yaml")]        ; Grandparent snippet
                        [gp-dir p-dir (str (:entity_id c3) "_parent_snippet.yaml")]       ; Parent snippet
                        [gp-dir p-dir c-dir (str (:entity_id c4) "_child_snippet.yaml")]} ; Child snippet

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -1147,8 +1147,9 @@
            (collection/perms-for-moving collection-before-update new-parent)))
 
         ;; We can't move a collection to the Trash
-        (api/check-400
-         (not (collection/is-trash? new-parent)))
+        (api/check
+         (not (collection/is-trash? new-parent))
+         [400 "You cannot modify the Trash Collection."])
         ;; ok, we're good to move!
         (collection/move-collection! collection-before-update new-location)))))
 
@@ -1192,6 +1193,8 @@
                (not= (keyword authority_level) (:authority_level collection-before-update)))
       (premium-features/assert-has-feature :official-collections (tru "Official Collections"))
       (api/check-403 api/*is-superuser?*))
+    (api/check (not (collection/is-trash? collection-before-update))
+               400 "You cannot modify the Trash Collection.")
     ;; ok, go ahead and update it! Only update keys that were specified in the `body`. But not `parent_id` since
     ;; that's not actually a property of Collection, and since we handle moving a Collection separately below.
     (let [updates (u/select-keys-when collection-updates :present [:name :description :authority_level])]

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -1150,6 +1150,7 @@
         (api/check
          (not (collection/is-trash? new-parent))
          [400 "You cannot modify the Trash Collection."])
+
         ;; ok, we're good to move!
         (collection/move-collection! collection-before-update new-location)))))
 
@@ -1193,8 +1194,6 @@
                (not= (keyword authority_level) (:authority_level collection-before-update)))
       (premium-features/assert-has-feature :official-collections (tru "Official Collections"))
       (api/check-403 api/*is-superuser?*))
-    (api/check (not (collection/is-trash? collection-before-update))
-               400 "You cannot modify the Trash Collection.")
     ;; ok, go ahead and update it! Only update keys that were specified in the `body`. But not `parent_id` since
     ;; that's not actually a property of Collection, and since we handle moving a Collection separately below.
     (let [updates (u/select-keys-when collection-updates :present [:name :description :authority_level])]

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -1106,6 +1106,9 @@
   (let [collection-before-updates (t2/instance :model/Collection (t2/original collection))
         {collection-name :name
          :as collection-updates}  (or (t2/changes collection) {})]
+    (api/check
+     (not (is-trash? collection-before-updates))
+     [400 "You cannot modify the Trash Collection."])
     ;; VARIOUS CHECKS BEFORE DOING ANYTHING:
     ;; (1) if this is a personal Collection, check that the 'propsed' changes are allowed
     (when (:personal_owner_id collection-before-updates)

--- a/test/metabase/api/trash_test.clj
+++ b/test/metabase/api/trash_test.clj
@@ -85,7 +85,8 @@
                    (mt/user-http-request :rasta :put 400 (str "pulse/" id) {:collection_id (collection/trash-collection-id)}))))))))
   (testing "Cannot move a a collection to the trash"
     (let [{id :id} (mt/user-http-request :crowberto :post 200 "collection" {:name "Collection in trash"})]
-      (is (= "Invalid Request." (mt/user-http-request :crowberto :put 400 (str "collection/" id) {:parent_id (collection/trash-collection-id)})))))
+      (is (= "You cannot modify the Trash Collection."
+             (mt/user-http-request :crowberto :put 400 (str "collection/" id) {:parent_id (collection/trash-collection-id)})))))
   (testing "Cannot move a native query snippet to the trash"
     (let [{id :id} (mt/user-http-request :crowberto :post 200 "native-query-snippet" {:name    (str (random-uuid))
                                                                                       :content "SELECT 1"})]
@@ -95,3 +96,13 @@
                                                                           :default    false
                                                                           :creator_id (mt/user->id :crowberto)})]
       (is (= "You cannot modify the Trash Collection." (mt/user-http-request :crowberto :put 400 (str "timeline/" id) {:collection_id (collection/trash-collection-id)}))))))
+
+(deftest cannot-edit-the-trash
+  (testing "cannot archive the trash"
+    (is (= "You cannot modify the Trash Collection."
+           (mt/user-http-request :crowberto :put 400 (str "collection/" (collection/trash-collection-id))
+                                 {:archived true}))))
+  (testing "cannot change the trash name"
+    (is (= "You cannot modify the Trash Collection."
+           (mt/user-http-request :crowberto :put 400 (str "collection/" (collection/trash-collection-id))
+                                 {:name "New Name"})))))


### PR DESCRIPTION
Oops. I was very thorough in checking that you couldn't modify the trash collection in the sense of moving things to or from it. I missed the most obvious thing: actually modifying the trash collection itself. So if someone wanted, they could change the name of the Trash to "Definitely Not the Trash".

Fixes #44817 