### PR TITLE
Redshift CI flake fix: enable robust sync behavior in tests

### DIFF
--- a/test/metabase/test/data/impl/get_or_create.clj
+++ b/test/metabase/test/data/impl/get_or_create.clj
@@ -130,9 +130,9 @@
           ;; only do "quick sync" for non `test-data` datasets, because it can take literally MINUTES on CI.
           ;;
           ;; MEGA SUPER HACK !!! I'm experimenting with this so Redshift tests stop being so flaky on CI! It seems like
-          ;; if we ever delete a table sometimes Redshift still thinks it's there for a bit and sync can fail because
-          ;; that it tries to sync a Table that is gone! So enable normal resilient sync behavior for Redshift tests to
-          ;; fix the flakes. If this fixes things I'll try to come up with a more robust solution. -- Cam 2024-07-19
+          ;; if we ever delete a table sometimes Redshift still thinks it's there for a bit and sync can fail because it
+          ;; tries to sync a Table that is gone! So enable normal resilient sync behavior for Redshift tests to fix the
+          ;; flakes. If this fixes things I'll try to come up with a more robust solution. -- Cam 2024-07-19. See #45874
           (binding [sync-util/*log-exceptions-and-continue?* (= driver :redshift)]
             (sync/sync-database! db {:scan (if full-sync? :full :schema)}))
           ;; add extra metadata for fields

--- a/test/metabase/test/data/impl/get_or_create.clj
+++ b/test/metabase/test/data/impl/get_or_create.clj
@@ -128,7 +128,12 @@
         (u/profile (format "%s %s Database %s (reference H2 duration: %s)"
                            (if full-sync? "Sync" "QUICK sync") driver database-name reference-duration)
           ;; only do "quick sync" for non `test-data` datasets, because it can take literally MINUTES on CI.
-          (binding [sync-util/*log-exceptions-and-continue?* false]
+          ;;
+          ;; MEGA SUPER HACK !!! I'm experimenting with this so Redshift tests stop being so flaky on CI! It seems like
+          ;; if we ever delete a table sometimes Redshift still thinks it's there for a bit and sync can fail because
+          ;; that it tries to sync a Table that is gone! So enable normal resilient sync behavior for Redshift tests to
+          ;; fix the flakes. If this fixes things I'll try to come up with a more robust solution. -- Cam 2024-07-19
+          (binding [sync-util/*log-exceptions-and-continue?* (not= driver :redshift)]
             (sync/sync-database! db {:scan (if full-sync? :full :schema)}))
           ;; add extra metadata for fields
           (try

--- a/test/metabase/test/data/impl/get_or_create.clj
+++ b/test/metabase/test/data/impl/get_or_create.clj
@@ -133,7 +133,7 @@
           ;; if we ever delete a table sometimes Redshift still thinks it's there for a bit and sync can fail because
           ;; that it tries to sync a Table that is gone! So enable normal resilient sync behavior for Redshift tests to
           ;; fix the flakes. If this fixes things I'll try to come up with a more robust solution. -- Cam 2024-07-19
-          (binding [sync-util/*log-exceptions-and-continue?* (not= driver :redshift)]
+          (binding [sync-util/*log-exceptions-and-continue?* (= driver :redshift)]
             (sync/sync-database! db {:scan (if full-sync? :full :schema)}))
           ;; add extra metadata for fields
           (try

--- a/test/metabase/xrays/automagic_dashboards/comparison_test.clj
+++ b/test/metabase/xrays/automagic_dashboards/comparison_test.clj
@@ -1,4 +1,4 @@
-(ns metabase.xrays.automagic-dashboards.comparison-test
+(ns ^:mb/once metabase.xrays.automagic-dashboards.comparison-test
   (:require
    [clojure.test :refer :all]
    [metabase.models :refer [Card Segment Table]]


### PR DESCRIPTION
In normal prod usage sync failures get caught and logged and sync carries on, for example if sync fails for one Table we catch it but continue syncing the other tables.

Normally when loading test data we disable this catch-and-continue behavior so we can find bugs or problems with the sync code or test data loading code more easily. Redshift sync tends to get flaky however in tests because we're creating and deleting a lot of tables and sometimes tables deleted a few seconds ago get reported as still being present when we try to sync that DB again, but then sync on the table itself fails because it's gone. 

Prior to #45268 we disabled deleting tables during test runs for Redshift due to flakiness, but I reenabled deletion because it was causing problems in lots of tests since we no longer destroyed and reloaded the test data so many times...

This is my new fix for the issue, enable robust sync behavior for Redshift. I want to see if this fixes the problem or not and unblocks CI. I will try to come up with a more robust long-term solution as a follow on at some point -- I want to get to the bottom of why Redshift is reporting deleted tables as still being present (is this info getting cached somewhere?)
