### PR TITLE
Fix #45877: Duplicated boolean options in a filter dropdown menu

### DIFF
--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -30,6 +30,8 @@ import {
   resetTestTable,
   resyncDatabase,
   openPeopleTable,
+  createNativeQuestion,
+  POPOVER_ELEMENT,
 } from "e2e/support/helpers";
 
 const {
@@ -41,6 +43,7 @@ const {
   REVIEWS_ID,
   PEOPLE,
   PEOPLE_ID,
+  INVOICES,
 } = SAMPLE_DATABASE;
 
 describe("issue 9339", () => {
@@ -1339,6 +1342,62 @@ describe.skip("issue 44435", () => {
     cy.findByTestId("filter-pill").then($pill => {
       const pillWidth = $pill[0].getBoundingClientRect().width;
       cy.window().its("innerWidth").should("be.gt", pillWidth);
+    });
+  });
+});
+
+// This reproduction can possibly be replaced with the unit test for the `ListField` component in the future
+describe("issue 45877", () => {
+  beforeEach(() => {
+    restore("setup");
+    cy.signInAsAdmin();
+  });
+
+  it("should not render selected boolean option twice in a filter dropdown (metabase#45877)", () => {
+    const questionDetails = {
+      name: "45877",
+      native: {
+        query: "SELECT * FROM INVOICES [[ where {{ expected_invoice }} ]]",
+        "template-tags": {
+          expected_invoice: {
+            id: "3cfb3686-0d13-48db-ab5b-100481a3a830",
+            dimension: ["field", INVOICES.EXPECTED_INVOICE, null],
+            name: "expected_invoice",
+            "display-name": "Expected Invoice",
+            type: "dimension",
+            "widget-type": "string/=",
+          },
+        },
+      },
+    };
+
+    createNativeQuestion(questionDetails, { visitQuestion: true });
+    cy.get("fieldset").should("contain", "Expected Invoice").click();
+    popover().within(() => {
+      cy.findByPlaceholderText("Search the list").should("exist");
+
+      cy.get("input[type='checkbox']")
+        .should("have.length", 2)
+        .each($checkbox => {
+          cy.wrap($checkbox).should("not.be.checked");
+        });
+
+      cy.findAllByTestId("true-filter-value").should("have.length", 1);
+      cy.findAllByTestId("false-filter-value").should("have.length", 1).click();
+
+      cy.button("Add filter").click();
+    });
+
+    // We don't even have to run the query to reproduce this issue
+    // so let's not waste time and resources doing so.
+    cy.get(POPOVER_ELEMENT).should("not.exist");
+    cy.get("fieldset").should("contain", "false").click();
+    popover().within(() => {
+      cy.findAllByTestId("true-filter-value").should("have.length", 1);
+      cy.findAllByTestId("false-filter-value")
+        .should("have.length", 1)
+        .find('input[type="checkbox"]')
+        .should("be.checked");
     });
   });
 });

--- a/frontend/src/metabase/components/ListField/ListField.tsx
+++ b/frontend/src/metabase/components/ListField/ListField.tsx
@@ -25,10 +25,8 @@ function createOptionsFromValuesWithoutOptions(
   values: RowValue[],
   options: Option[],
 ): Option {
-  const optionsMap = _.indexBy(options, "0");
-  return values
-    .filter(value => typeof value !== "string" || !optionsMap[value])
-    .map(value => [value]);
+  const optionsMap = new Map(options.map(option => [option[0], option]));
+  return values.filter(value => !optionsMap.has(value)).map(value => [value]);
 }
 
 export const ListField = ({


### PR DESCRIPTION
Closes #45877

### Description
[This line](https://github.com/metabase/metabase/pull/43293/files#diff-42c21bc38d698c32274a41b96dd510d6a86589a30dad488d037089084e4d7025R30) didn't take into account boolean filter values. So we'd add an additional `true|false` to the existing options [here](https://github.com/metabase/metabase/blob/4e7ae5cb1ed9a842fbb140ac52cfef8974ceb994/frontend/src/metabase/components/ListField/ListField.tsx#L47)

The fix was to simply remove the condition `type of value !== "string"`, but that resulted in a type error (which is why it was most likely added in the first place):

![image](https://github.com/user-attachments/assets/ee9e17d3-78ff-4ec7-8238-563839ae81bf)

The solution to this was to [use an actual JavaScript `Map`](https://github.com/metabase/metabase/pull/45880/files#diff-42c21bc38d698c32274a41b96dd510d6a86589a30dad488d037089084e4d7025R28). Kudos to @ranquild for the idea.

### How to verify
Follow the repro steps or simply run E2E reproduction.

### Demo
Before
![image](https://github.com/user-attachments/assets/436d3520-14e8-4994-8f86-edc3dc801fc6)

Now
![image](https://github.com/user-attachments/assets/55296267-cfff-4c2f-b58f-cbfb334faa94)


### Checklist
- [x] Tests have been added/updated to cover changes in this PR
