### PR TITLE
45877 follow up: Improve a11y of the `ListField` component (filter picker options dropdown)

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
@@ -235,12 +235,8 @@ describe("issue 17160", () => {
   function assertMultipleValuesFilterState() {
     cy.findByText("2 selections").click();
 
-    cy.findByTestId("Doohickey-filter-value").within(() =>
-      cy.get("input").should("be.checked"),
-    );
-    cy.findByTestId("Gadget-filter-value").within(() =>
-      cy.get("input").should("be.checked"),
-    );
+    cy.findByLabelText("Doohickey").should("be.checked");
+    cy.findByLabelText("Gadget").should("be.checked");
   }
 
   function setup() {

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-explicit-join.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-explicit-join.cy.spec.js
@@ -102,6 +102,6 @@ describe("scenarios > dashboard > filters", () => {
 
 function selectFromDropdown(values) {
   values.forEach(value => {
-    cy.findByTestId(`${value}-filter-value`).should("be.visible").click();
+    cy.findByLabelText(value).should("be.visible").click();
   });
 }

--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -779,10 +779,8 @@ describe("scenarios > dashboard > parameters", () => {
 });
 
 function isFilterSelected(filter, bool) {
-  cy.findByTestId(`${filter}-filter-value`).within(() =>
-    cy
-      .findByRole("checkbox")
-      .should(`${bool === false ? "not." : ""}be.checked`),
+  cy.findByLabelText(filter).should(
+    `${bool === false ? "not." : ""}be.checked`,
   );
 }
 

--- a/e2e/test/scenarios/dashboard/x-rays.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/x-rays.cy.spec.js
@@ -252,7 +252,7 @@ describe("scenarios > x-rays", { tags: "@slow" }, () => {
     cy.findByText("State", timeout).click();
 
     cy.findByPlaceholderText("Search the list").type("GA{enter}");
-    cy.findByTestId("GA-filter-value").should("be.visible").click();
+    cy.findByLabelText("GA").should("be.visible").click();
     cy.button("Add filter").click();
 
     // confirm results of "Total transactions" card were updated

--- a/e2e/test/scenarios/embedding/embedding-native.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-native.cy.spec.js
@@ -99,7 +99,7 @@ describe("scenarios > embedding > native questions", () => {
       filterWidget().contains("State").click();
       cy.findByPlaceholderText("Search the list").type("KS{enter}");
       cy.findAllByTestId(/-filter-value$/).should("have.length", 1);
-      cy.findByTestId("KS-filter-value").should("be.visible").click();
+      cy.findByLabelText("KS").should("be.visible").click();
       cy.button("Add filter").click();
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage

--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -1376,14 +1376,13 @@ describe("issue 45877", () => {
     popover().within(() => {
       cy.findByPlaceholderText("Search the list").should("exist");
 
-      cy.get("input[type='checkbox']")
-        .should("have.length", 2)
-        .each($checkbox => {
-          cy.wrap($checkbox).should("not.be.checked");
-        });
-
-      cy.findAllByTestId("true-filter-value").should("have.length", 1);
-      cy.findAllByTestId("false-filter-value").should("have.length", 1).click();
+      cy.findAllByLabelText("true")
+        .should("have.length", 1)
+        .and("not.be.checked");
+      cy.findAllByLabelText("false")
+        .should("have.length", 1)
+        .and("not.be.checked")
+        .click();
 
       cy.button("Add filter").click();
     });
@@ -1393,10 +1392,9 @@ describe("issue 45877", () => {
     cy.get(POPOVER_ELEMENT).should("not.exist");
     cy.get("fieldset").should("contain", "false").click();
     popover().within(() => {
-      cy.findAllByTestId("true-filter-value").should("have.length", 1);
-      cy.findAllByTestId("false-filter-value")
+      cy.findAllByLabelText("true").should("have.length", 1);
+      cy.findAllByLabelText("false")
         .should("have.length", 1)
-        .find('input[type="checkbox"]')
         .should("be.checked");
     });
   });

--- a/e2e/test/scenarios/native-filters/helpers/e2e-field-filter-helpers.js
+++ b/e2e/test/scenarios/native-filters/helpers/e2e-field-filter-helpers.js
@@ -205,7 +205,7 @@ export function pickDefaultValue(searchTerm, result) {
   // is to make sure the string is "visible" before acting on it.
   // This seems to help with the flakiness.
   //
-  cy.findByTestId(`${result}-filter-value`).should("be.visible").click();
+  cy.findByLabelText(result).should("be.visible").click();
 
   cy.button("Add filter").click();
 }

--- a/e2e/test/scenarios/permissions/permissions-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/permissions-reproductions.cy.spec.js
@@ -697,14 +697,14 @@ describeEE("issue 24966", () => {
     cy.signIn("nodata");
     visitDashboard("@dashboardId");
     filterWidget().click();
-    cy.findByTestId("Gizmo-filter-value").click();
+    cy.findByLabelText("Gizmo").click();
     cy.button("Add filter").click();
     cy.location("search").should("eq", "?text=Gizmo");
 
     cy.signInAsSandboxedUser();
     visitDashboard("@dashboardId");
     filterWidget().click();
-    cy.findByTestId("Widget-filter-value").click();
+    cy.findByLabelText("Widget").click();
     cy.button("Add filter").click();
     cy.location("search").should("eq", "?text=Widget");
   });

--- a/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.tsx
+++ b/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.tsx
@@ -594,7 +594,6 @@ export function FieldValuesWidgetInner({
             onChange={onChange}
             options={options}
             optionRenderer={optionRenderer}
-            checkedColor={checkedColor}
           />
         ) : isListMode && hasListValues && !multi ? (
           <SingleSelectListField

--- a/frontend/src/metabase/components/ListField/ListField.tsx
+++ b/frontend/src/metabase/components/ListField/ListField.tsx
@@ -4,11 +4,11 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import EmptyState from "metabase/components/EmptyState";
-import Checkbox from "metabase/core/components/CheckBox";
 import type { InputProps } from "metabase/core/components/Input";
 import Input from "metabase/core/components/Input";
 import { useDebouncedValue } from "metabase/hooks/use-debounced-value";
 import { SEARCH_DEBOUNCE_DURATION } from "metabase/lib/constants";
+import { Checkbox } from "metabase/ui";
 import type { RowValue } from "metabase-types/api";
 
 import {
@@ -137,9 +137,7 @@ export const ListField = ({
           <OptionContainer key={index}>
             <Checkbox
               data-testid={`${option[0]}-filter-value`}
-              checkedColor={
-                checkedColor ?? isDashboardFilter ? "brand" : "filter"
-              }
+              color={checkedColor ?? isDashboardFilter ? "brand" : "filter"}
               checked={selectedValues.has(option[0])}
               label={<LabelWrapper>{optionRenderer(option)}</LabelWrapper>}
               onChange={() => handleToggleOption(option[0])}

--- a/frontend/src/metabase/components/ListField/ListField.tsx
+++ b/frontend/src/metabase/components/ListField/ListField.tsx
@@ -36,7 +36,6 @@ export const ListField = ({
   optionRenderer,
   placeholder,
   isDashboardFilter,
-  checkedColor,
 }: ListFieldProps) => {
   const [selectedValues, setSelectedValues] = useState(new Set(value));
   const [addedOptions, setAddedOptions] = useState<Option>(() =>
@@ -137,7 +136,6 @@ export const ListField = ({
           <OptionContainer key={index}>
             <Checkbox
               data-testid={`${option[0]}-filter-value`}
-              color={checkedColor ?? isDashboardFilter ? "brand" : "filter"}
               checked={selectedValues.has(option[0])}
               label={<LabelWrapper>{optionRenderer(option)}</LabelWrapper>}
               onChange={() => handleToggleOption(option[0])}


### PR DESCRIPTION
This PR improves the accessibility of the filter picker, and namely `ListField` component by using the new Mantine checkbox instead of our old checkbox implementation.

It also removes unneeded `checkedColor` prop that's only used in the old Admin > Datamodel section, but doesn't have any effect on the notebook or any other part of the application.

The E2E tests have been updated to reflect these changes, and it's already much easier to target elements (due to a11y improvements).

before
```js
cy.findByTestId("Doohickey-filter-value").within(() =>
  cy.get("input").should("be.checked");
);
```

now
```js
cy.findByLabelText("Doohickey").should("be.checked");
```
