### PR TITLE
[E2E] Rewrite and expand repro #27643

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -20,6 +20,7 @@ import {
   queryBuilderMain,
   queryBuilderFooter,
   withDatabase,
+  visitPublicQuestion,
 } from "e2e/support/helpers";
 
 const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -628,24 +629,13 @@ describe("issue 27643", () => {
         createNativeQuestion(getQuestionDetails(fieldId), {
           wrapId: true,
           idAlias: "questionId",
+          visitQuestion: true,
         });
-      });
-
-      cy.get("@questionId").then(questionId => {
-        cy.request("POST", `/api/card/${questionId}/public_link`).then(
-          ({ body: { uuid } }) => {
-            cy.wrap(uuid).as("questionPublicUuid");
-          },
-        );
       });
     });
 
     it("should allow a native question filter to map to a boolean field filter parameter in static embedding (metabase#27643)", () => {
       cy.log("Test the question");
-      cy.get("@questionId").then(questionId => {
-        visitQuestion(questionId);
-      });
-
       toggleFilterWidgetValues(["false"]);
       queryBuilderMain().button("Get Answer").click();
       queryBuilderFooter().findByText("Showing 455 rows").should("be.visible");
@@ -664,10 +654,10 @@ describe("issue 27643", () => {
         .should("be.visible");
 
       cy.log("Test the public question");
-      cy.signOut();
-      cy.get("@questionPublicUuid").then(uuid => {
-        cy.visit(`/public/question/${uuid}`);
+      cy.get("@questionId").then(questionId => {
+        visitPublicQuestion(questionId);
       });
+
       toggleFilterWidgetValues(["false"]);
       cy.findByTestId("visualization-root")
         .findByText("Rows 1-13 of 455")

--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -537,6 +537,7 @@ describe("issue 27643", () => {
     cy.signInAsAdmin();
     resyncDatabase({
       dbId: PG_DB_ID,
+      tableName: "invoices",
     });
     withDatabase(PG_DB_ID, ({ INVOICES }) => {
       cy.wrap(INVOICES.EXPECTED_INVOICE).as(

--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -504,7 +504,7 @@ describe("issues 20845, 25031", () => {
 // - Add tests for public sharing (question)
 // - Add tests for public sharing (dashboard)
 // BONUS: Ideally add tests for email subscriptions with the filter applied
-describe("27643", () => {
+describe("issue 27643", () => {
   beforeEach(() => {
     restore("setup");
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -587,14 +587,15 @@ describe("issue 27643", () => {
           };
 
           cy.editDashboardCard(dashboardCard, mapFilterToCard);
-          visitDashboard(dashboard_id);
         });
     });
 
     it("in static embedding and in public dashboard scenarios (metabase#27643-1)", () => {
       cy.log("Test the dashboard");
+      visitDashboard("@dashboardId");
+      getDashboardCard().should("contain", "true");
       toggleFilterWidgetValues(["false"]);
-      getDashboardCard().findByText("Rows 1-4 of 455").should("be.visible");
+      getDashboardCard().should("contain", "false");
 
       cy.log("Test the embedded dashboard");
       cy.get("@dashboardId").then(dashboard => {
@@ -602,20 +603,22 @@ describe("issue 27643", () => {
           resource: { dashboard },
           params: {},
         });
-      });
 
-      toggleFilterWidgetValues(["false"]);
-      getDashboardCard().findByText("Rows 1-4 of 455").should("be.visible");
+        getDashboardCard().should("contain", "true");
+        toggleFilterWidgetValues(["false"]);
+        getDashboardCard().should("contain", "false");
+      });
 
       cy.log("Test the public dashboard");
       cy.get("@dashboardId").then(dashboardId => {
         // We were signed out due to the previous visitEmbeddedPage
         cy.signInAsAdmin();
         visitPublicDashboard(dashboardId);
-      });
 
-      toggleFilterWidgetValues(["false"]);
-      getDashboardCard().findByText("Rows 1-4 of 455").should("be.visible");
+        getDashboardCard().should("contain", "true");
+        toggleFilterWidgetValues(["false"]);
+        getDashboardCard().should("contain", "false");
+      });
     });
   });
 

--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -19,7 +19,6 @@ import {
   createNativeQuestion,
   queryBuilderMain,
   queryBuilderFooter,
-  resyncDatabase,
   withDatabase,
 } from "e2e/support/helpers";
 
@@ -535,10 +534,6 @@ describe("issue 27643", () => {
   beforeEach(() => {
     restore("postgres-12");
     cy.signInAsAdmin();
-    resyncDatabase({
-      dbId: PG_DB_ID,
-      tableName: "invoices",
-    });
     withDatabase(PG_DB_ID, ({ INVOICES }) => {
       cy.wrap(INVOICES.EXPECTED_INVOICE).as(
         "postgresInvoicesExpectedInvoiceId",

--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -534,6 +534,7 @@ describe("issue 27643", () => {
   };
 
   beforeEach(() => {
+    // This issue was only reproducible against the Postgres database.
     restore("postgres-12");
     cy.signInAsAdmin();
     withDatabase(PG_DB_ID, ({ INVOICES }) => {

--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -496,6 +496,14 @@ describe("issues 20845, 25031", () => {
   });
 });
 
+// TODO:
+// - Add tests for question embedding
+// - Add tests for dashboard embedding
+// - Add tests for embedding previews in both cases
+// - Add tests for disabled, editable and locked parameters in both cases
+// - Add tests for public sharing (question)
+// - Add tests for public sharing (dashboard)
+// BONUS: Ideally add tests for email subscriptions with the filter applied
 describe("27643", () => {
   beforeEach(() => {
     restore("setup");

--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -543,7 +543,7 @@ describe("issue 27643", () => {
     });
   });
 
-  describe("dashboards", () => {
+  describe("should allow a dashboard filter to map to a boolean field filter parameter (metabase#27643)", () => {
     beforeEach(() => {
       const dashboardParameter = {
         id: "2850aeab",
@@ -589,7 +589,7 @@ describe("issue 27643", () => {
         });
     });
 
-    it("should allow a dashboard filter to map to a boolean field filter parameter in static embedding (metabase#27643)", () => {
+    it("in static embedding and in public dashboard scenarios (metabase#27643-1)", () => {
       cy.log("Test the dashboard");
       toggleFilterWidgetValues(["false"]);
       getDashboardCard().findByText("Rows 1-4 of 455").should("be.visible");
@@ -617,7 +617,7 @@ describe("issue 27643", () => {
     });
   });
 
-  describe("questions", () => {
+  describe("should allow a native question filter to map to a boolean field filter parameter (metabase#27643)", () => {
     beforeEach(() => {
       cy.get("@postgresInvoicesExpectedInvoiceId").then(fieldId => {
         createNativeQuestion(getQuestionDetails(fieldId), {
@@ -628,7 +628,7 @@ describe("issue 27643", () => {
       });
     });
 
-    it("should allow a native question filter to map to a boolean field filter parameter in static embedding (metabase#27643)", () => {
+    it("in static embedding and in public question scenarios (metabase#27643-2)", () => {
       cy.log("Test the question");
       toggleFilterWidgetValues(["false"]);
       queryBuilderMain().button("Get Answer").click();

--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -18,7 +18,6 @@ import {
   getDashboardCard,
   createNativeQuestion,
   queryBuilderMain,
-  queryBuilderFooter,
   withDatabase,
   visitPublicQuestion,
   visitPublicDashboard,
@@ -628,16 +627,17 @@ describe("issue 27643", () => {
         createNativeQuestion(getQuestionDetails(fieldId), {
           wrapId: true,
           idAlias: "questionId",
-          visitQuestion: true,
         });
       });
     });
 
     it("in static embedding and in public question scenarios (metabase#27643-2)", () => {
       cy.log("Test the question");
+      visitQuestion("@questionId");
+      cy.findAllByTestId("cell-data").should("contain", "true");
       toggleFilterWidgetValues(["false"]);
       queryBuilderMain().button("Get Answer").click();
-      queryBuilderFooter().findByText("Showing 455 rows").should("be.visible");
+      cy.findAllByTestId("cell-data").should("contain", "false");
 
       cy.log("Test the embedded question");
       cy.get("@questionId").then(question => {
@@ -645,24 +645,22 @@ describe("issue 27643", () => {
           resource: { question },
           params: {},
         });
-      });
 
-      toggleFilterWidgetValues(["false"]);
-      cy.findByTestId("visualization-root")
-        .findByText("Rows 1-13 of 455")
-        .should("be.visible");
+        cy.findAllByTestId("cell-data").should("contain", "true");
+        toggleFilterWidgetValues(["false"]);
+        cy.findAllByTestId("cell-data").should("contain", "false");
+      });
 
       cy.log("Test the public question");
       cy.get("@questionId").then(questionId => {
         // We were signed out due to the previous visitEmbeddedPage
         cy.signInAsAdmin();
         visitPublicQuestion(questionId);
-      });
 
-      toggleFilterWidgetValues(["false"]);
-      cy.findByTestId("visualization-root")
-        .findByText("Rows 1-13 of 455")
-        .should("be.visible");
+        cy.findAllByTestId("cell-data").should("contain", "true");
+        toggleFilterWidgetValues(["false"]);
+        cy.findAllByTestId("cell-data").should("contain", "false");
+      });
     });
   });
 });

--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -14,19 +14,11 @@ import {
   getIframeBody,
   addOrUpdateDashboardCard,
   describeEE,
-  createNativeQuestion,
-  createDashboardWithTabs,
-  withDatabase,
-  resyncDatabase,
   toggleFilterWidgetValues,
   getDashboardCard,
 } from "e2e/support/helpers";
-import {
-  createMockDashboardCard,
-  createMockParameter,
-} from "metabase-types/api/mocks";
 
-const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
+const { PRODUCTS, PRODUCTS_ID, INVOICES } = SAMPLE_DATABASE;
 
 describe.skip("issue 15860", () => {
   const q1IdFilter = {
@@ -504,71 +496,66 @@ describe("issues 20845, 25031", () => {
   });
 });
 
-describe.skip("27643", { tags: "@external" }, () => {
-  const PG_DB_ID = 2;
-
+describe("27643", () => {
   beforeEach(() => {
-    restore("postgres-12");
+    restore("setup");
     cy.signInAsAdmin();
-    resyncDatabase({
-      dbId: PG_DB_ID,
-    });
-    const TEMPLATE_TAG_NAME = "boolean_param";
-    withDatabase(PG_DB_ID, ({ INVOICES }) => {
-      /** @type {import("e2e/support/helpers").NativeQuestionDetails} */
-      const questionDetails = {
-        name: "Postgres SQL with boolean parameter",
-        database: PG_DB_ID,
-        native: {
-          query: "SELECT * FROM INVOICES [[ where {{ boolean_param }} ]]",
-          "template-tags": {
-            boolean_param: {
-              id: "3cfb3686-0d13-48db-ab5b-100481a3a830",
-              dimension: ["field", INVOICES.EXPECTED_INVOICE, null],
-              name: TEMPLATE_TAG_NAME,
-              "display-name": "Boolean Param",
-              type: "dimension",
-              "widget-type": "string/=",
-            },
+
+    const TEMPLATE_TAG_NAME = "expected_invoice";
+
+    const questionDetails = {
+      name: "27643",
+      native: {
+        query: "SELECT * FROM INVOICES [[ where {{ expected_invoice }} ]]",
+        "template-tags": {
+          [TEMPLATE_TAG_NAME]: {
+            id: "3cfb3686-0d13-48db-ab5b-100481a3a830",
+            dimension: ["field", INVOICES.EXPECTED_INVOICE, null],
+            name: TEMPLATE_TAG_NAME,
+            "display-name": "Expected Invoice",
+            type: "dimension",
+            "widget-type": "string/=",
           },
         },
+      },
+    };
+
+    const dashboardParameter = {
+      id: "2850aeab",
+      name: "Text filter for boolean field",
+      slug: "text_filter_for_boolean_field",
+      type: "string/=",
+    };
+
+    const dashboardDetails = {
+      name: "Dashboard with card with boolean field filter",
+      enable_embedding: true,
+      embedding_params: {
+        [dashboardParameter.slug]: "enabled",
+      },
+      parameters: [dashboardParameter],
+    };
+
+    cy.createNativeQuestionAndDashboard({
+      questionDetails,
+      dashboardDetails,
+    }).then(({ body: dashboardCard }) => {
+      const { card_id, dashboard_id } = dashboardCard;
+
+      cy.wrap(dashboard_id).as("dashboardId");
+      cy.wrap(card_id).as("questionId");
+
+      const mapFilterToCard = {
+        parameter_mappings: [
+          {
+            parameter_id: dashboardParameter.id,
+            card_id,
+            target: ["dimension", ["template-tag", TEMPLATE_TAG_NAME]],
+          },
+        ],
       };
-      createNativeQuestion(questionDetails)
-        .then(({ body: question }) => {
-          const DASHBOARD_FILTER_ID = "2850aeab";
-          const DASHBOARD_PARAMETER = createMockParameter({
-            id: DASHBOARD_FILTER_ID,
-            name: "Text filter for boolean field",
-            slug: "text_filter_for_boolean_field",
-          });
-          const dashboardDetails = {
-            name: "dashboard with card with boolean field filter",
-            enable_embedding: true,
-            embedding_params: {
-              [DASHBOARD_PARAMETER.slug]: "enabled",
-            },
-            dashcards: [
-              createMockDashboardCard({
-                id: -1,
-                size_x: 12,
-                size_y: 8,
-                card_id: question.id,
-                parameter_mappings: [
-                  {
-                    parameter_id: DASHBOARD_FILTER_ID,
-                    card_id: question.id,
-                    target: ["dimension", ["template-tag", TEMPLATE_TAG_NAME]],
-                  },
-                ],
-              }),
-            ],
-            parameters: [DASHBOARD_PARAMETER],
-          };
-          return createDashboardWithTabs(dashboardDetails);
-        })
-        .then(dashboard => {
-          cy.wrap(dashboard.id).as("dashboardId");
-        });
+
+      cy.editDashboardCard(dashboardCard, mapFilterToCard);
     });
   });
 
@@ -579,12 +566,12 @@ describe.skip("27643", { tags: "@external" }, () => {
     });
 
     toggleFilterWidgetValues(["false"]);
-    getDashboardCard().findByText("Rows 1-6 of 455").should("be.visible");
+    getDashboardCard().findByText("Rows 1-4 of 455").should("be.visible");
 
     cy.log("Test embedded dashboard");
-    cy.get("@dashboardId").then(dashboardId => {
+    cy.get("@dashboardId").then(dashboard => {
       visitEmbeddedPage({
-        resource: { dashboard: dashboardId },
+        resource: { dashboard },
         params: {},
       });
     });
@@ -597,7 +584,7 @@ describe.skip("27643", { tags: "@external" }, () => {
      * a lot faster than human. I tested this manually, and the requests were cancelled properly.
      */
     getDashboardCard()
-      .findByText("Rows 1-6 of first 2000")
+      .findByText("Rows 1-4 of first 2000")
       .should("be.visible");
 
     toggleFilterWidgetValues(["false"]);

--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -514,7 +514,8 @@ describe("issue 27643", () => {
       name: "27643",
       database: PG_DB_ID,
       native: {
-        query: "SELECT * FROM INVOICES [[ where {{ expected_invoice }} ]]",
+        query:
+          "SELECT * FROM INVOICES [[ where {{ expected_invoice }} ]] limit 1",
         "template-tags": {
           [TEMPLATE_TAG_NAME]: {
             id: "3cfb3686-0d13-48db-ab5b-100481a3a830",

--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -21,6 +21,7 @@ import {
   queryBuilderFooter,
   withDatabase,
   visitPublicQuestion,
+  visitPublicDashboard,
 } from "e2e/support/helpers";
 
 const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -584,21 +585,12 @@ describe("issue 27643", () => {
           };
 
           cy.editDashboardCard(dashboardCard, mapFilterToCard);
-
-          cy.request("POST", `/api/dashboard/${dashboard_id}/public_link`).then(
-            ({ body: { uuid } }) => {
-              cy.wrap(uuid).as("dashboardPublicUuid");
-            },
-          );
+          visitDashboard(dashboard_id);
         });
     });
 
     it("should allow a dashboard filter to map to a boolean field filter parameter in static embedding (metabase#27643)", () => {
       cy.log("Test the dashboard");
-      cy.get("@dashboardId").then(dashboardId => {
-        visitDashboard(dashboardId);
-      });
-
       toggleFilterWidgetValues(["false"]);
       getDashboardCard().findByText("Rows 1-4 of 455").should("be.visible");
 
@@ -614,10 +606,10 @@ describe("issue 27643", () => {
       getDashboardCard().findByText("Rows 1-4 of 455").should("be.visible");
 
       cy.log("Test the public dashboard");
-      cy.signOut();
-      cy.get("@dashboardPublicUuid").then(uuid => {
-        cy.visit(`/public/dashboard/${uuid}`);
+      cy.get("@dashboardId").then(dashboardId => {
+        visitPublicDashboard(dashboardId);
       });
+
       toggleFilterWidgetValues(["false"]);
       getDashboardCard().findByText("Rows 1-4 of 455").should("be.visible");
     });

--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -607,6 +607,8 @@ describe("issue 27643", () => {
 
       cy.log("Test the public dashboard");
       cy.get("@dashboardId").then(dashboardId => {
+        // We were signed out due to the previous visitEmbeddedPage
+        cy.signInAsAdmin();
         visitPublicDashboard(dashboardId);
       });
 
@@ -647,6 +649,8 @@ describe("issue 27643", () => {
 
       cy.log("Test the public question");
       cy.get("@questionId").then(questionId => {
+        // We were signed out due to the previous visitEmbeddedPage
+        cy.signInAsAdmin();
         visitPublicQuestion(questionId);
       });
 

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -630,6 +630,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
 
       visualize();
 
+      cy.findByLabelText("Switch to data").click();
       cy.findAllByTestId("header-cell").should("contain", "Median of Price");
     });
 
@@ -660,6 +661,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
 
       visualize();
 
+      cy.findByLabelText("Switch to data").click();
       cy.findAllByTestId("header-cell")
         .should("contain", "Median of Median of Mega price")
         .should("contain", "Median of Count");


### PR DESCRIPTION
### What does this PR accomplish?
It expands the original reproduction for #27643 to include regular, embedding and public scenarios. 

Once fully implemented, this PR will close #27643 again.
Example [failed Replay.io test](https://app.replay.io/recording/e2etestscenariosembeddingembedding-reproductionscyspecjs--8e8a17c7-5281-43e5-b4cc-a98d49a92379?commentId=&focusWindow=eyJiZWdpbiI6eyJwb2ludCI6IjEzODg5Mzk0MTE5NDQwNzcwMTcwNjE1ODA0Mjk0MTI1MzM3MSIsInRpbWUiOjY4OTE5fSwiZW5kIjp7InBvaW50IjoiMTYwOTYxMjAyODU2MzYxMzQ4OTYwNzIwODQ5OTMwODQ2NDgzIiwidGltZSI6Nzc2NTR9fQ%253D%253D&point=147980460707474566311840456456039828&primaryPanel=cypress&secondaryPanel=network&time=73443&viewMode=dev).

### Stress tests
1. dashboards (50/50 ✅  https://github.com/metabase/metabase/actions/runs/10095093139)
2. questions (50/50 ✅  https://github.com/metabase/metabase/actions/runs/10095095932)

### Follow-up
Extract the problem around preview to [Dashboard parameter preview doesn't work in static embed modal when publishing a parameter as "locked" and change to "editable"](https://github.com/metabase/metabase/issues/45997#top) following an embedding team discussion.