### PR TITLE
ci: re-enable node cache to speedup initial yarn install

### DIFF
--- a/.github/actions/prepare-frontend/action.yml
+++ b/.github/actions/prepare-frontend/action.yml
@@ -11,6 +11,7 @@ runs:
       with:
         node-version: ${{ inputs.node-version }} # this overrides, if present
         node-version-file: ".nvmrc"
+
     - name: Check to see if dependencies should be cached
       if: ${{ contains(github.event.head_commit.message, '[ci nocache]') }}
       run: |
@@ -23,11 +24,30 @@ runs:
       with:
         path: ~/.m2
         key: ${{ runner.os }}-cljs-${{ hashFiles('**/shadow-cljs.edn') }}
+
     - name: Get node_modules cache
       uses: actions/cache@v4
+      id: node-modules-cache
       if: ${{ !contains(github.event.head_commit.message, '[ci nocache]') }}
       with:
         path: node_modules
         key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock', '**/patches/*.patch') }}
+
+    - name: Get yarn cache directory path
+      id: yarn-cache-dir-path
+      if: steps.node-modules-cache.outputs.cache-hit != 'true'
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - uses: actions/cache@v4
+      if: steps.node-modules-cache.outputs.cache-hit != 'true'
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        # if global cache is used, we don't care if it's the latest or not
+        # current github actions settings will invalidate saved cache after
+        # a week or so, new cache will be fresh we'll not need to spend time
+        # on it's saving for a specific hash of yarn.lock
+        key: ${{ runner.os }}-yarn-
+
     - run: yarn install --frozen-lockfile --prefer-offline
       shell: bash


### PR DESCRIPTION
### Description

We have 3 different cases of using cache of node_modules at CI:

1. `node_modules` were already cached, so we can just restore it, yarn verifies if all packages are installed -> **fastest**
<details><summary>~2s for `yarn install`</summary>
<p>
<img width="887" alt="Screenshot 2024-08-01 at 17 14 03" src="https://github.com/user-attachments/assets/23d38938-f7d9-4781-8613-6a5fcb9beebd">






</p>
</details> 

2. `yarn.lock` is updated -> there is no cache for `node_modules` - yarn fetches all packages from registry, saves them to global cache and copies them to node_modules -> **slowest**

<details><summary>~90s for `yarn install` after latest cleanup</summary>
<p>

<img width="865" alt="Screenshot 2024-08-01 at 17 11 04" src="https://github.com/user-attachments/assets/0899fea7-8c1f-4176-bc34-534f04a6b968">




</p>
</details> 

3. `yarn.lock` is updated -> there is no cache for `node_modules`, **but** there is cache for most of the packages in global yarn cache, which we can restore from previous builds. In this case yarn fetches only packages which are not presented in global yarn cache and copies them to `node_modules` - **fast enough**

There is overhead to save and restore global yarn cache in this case, but we do it conditionally and only when `node_modules` cache is missing. 
`Post prepare frontend` adds ~15-20s to save yarn cache as it's big, but it's a win anyway

<details><summary>~45s for `yarn install`</summary>
<p>

<img width="839" alt="Screenshot 2024-08-01 at 16 37 12" src="https://github.com/user-attachments/assets/658c48b0-4aa2-4726-9b20-f8c081200697">

</p>
</details> 

With current change, if we miss `node_modules`, we do not go with case 2, but we go with case 3, shaving half of the time required for installing node_modules in the worst case