### PR TITLE
Usage API

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -246,6 +246,7 @@
     metabase.troubleshooting       #{metabase.troubleshooting}
     metabase.types                 #{metabase.types}
     metabase.upload                #{metabase.upload}
+    metabase.usage                 #{metabase.usage}
     metabase.util                  :any                                                             ; I think util being `:any` is actually something I am ok with. But this has 32 namespaces.
     metabase.xrays                 #{metabase.xrays}}
 
@@ -309,6 +310,7 @@
     metabase.troubleshooting       :any
     metabase.types                 #{metabase.util}
     metabase.upload                :any
+    metabase.usage                 #{metabase.util}
     metabase.util                  :any
     metabase.xrays                 :any}
 

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -27,6 +27,7 @@
    [metabase.setup :as setup]
    [metabase.task :as task]
    [metabase.troubleshooting :as troubleshooting]
+   [metabase.usage :as usage]
    [metabase.util :as u]
    [metabase.util.log :as log])
   (:import
@@ -83,6 +84,7 @@
   []
   (log/info "Metabase Shutting Down ...")
   (task/stop-scheduler!)
+  (usage/stop!)
   (server/stop-web-server!)
   (prometheus/shutdown!)
   ;; This timeout was chosen based on a 30s default termination grace period in Kubernetes.
@@ -157,6 +159,7 @@
 
   (settings/migrate-encrypted-settings!)
   ;; start scheduler at end of init!
+  (usage/init!)
   (task/start-scheduler!)
   (init-status/set-complete!)
   (let [start-time (.getStartTime (ManagementFactory/getRuntimeMXBean))

--- a/src/metabase/events/view_log.clj
+++ b/src/metabase/events/view_log.clj
@@ -91,44 +91,6 @@
       (catch Throwable e
         (log/warnf e "Failed to process view event. %s" topic)))))
 
-(derive ::dashboard-queried :metabase/event)
-(derive :event/dashboard-queried ::dashboard-queried)
-
-(def ^:private update-dashboard-last-viewed-at-interval-seconds 20)
-
-(defn- update-dashboard-last-viewed-at!* [dashboard-id-timestamps]
-  (let [dashboard-id->timestamp (update-vals (group-by :id dashboard-id-timestamps)
-                                             (fn [xs] (apply t/max (map :timestamp xs))))]
-    (try
-      (t2/update! :model/Dashboard :id [:in (keys dashboard-id->timestamp)]
-                  {:last_viewed_at (into [:case]
-                                         (mapcat (fn [[id timestamp]]
-                                                   [[:= :id id] [:greatest [:coalesce :last_viewed_at (t/offset-date-time 0)] timestamp]])
-                                                 dashboard-id->timestamp))})
-      (catch Exception e
-        (log/error e "Failed to update dashboard last_viewed_at")))))
-
-(def ^:private update-dashboard-last-viewed-at-queue
-  (delay (grouper/start!
-          update-dashboard-last-viewed-at!*
-          :capacity 500
-          :interval (* update-dashboard-last-viewed-at-interval-seconds 1000))))
-
-(defn- update-dashboard-last-viewed-at!
-  "Update the `last_used_at` of a dashboard asynchronously"
-  [dashboard-id]
-  (let [now (t/offset-date-time)]
-    (grouper/submit! @update-dashboard-last-viewed-at-queue {:id dashboard-id
-                                                             :timestamp now})))
-
-(m/defmethod events/publish-event! ::dashboard-queried
-  "Handle processing for a dashboard query being run"
-  [topic {:keys [object-id] :as _event}]
-  (try
-    (update-dashboard-last-viewed-at! object-id)
-    (catch Throwable e
-      (log/warnf e "Failed to process dashboard query event. %s" topic))))
-
 (derive ::collection-read-event :metabase/event)
 (derive :event/collection-read ::collection-read-event)
 

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -4,6 +4,7 @@
    [clojure.set :as set]
    [clojure.string :as str]
    [medley.core :as m]
+   [metabase.usage :as usage]
    [metabase.api.common :as api]
    [metabase.audit :as audit]
    [metabase.config :as config]

--- a/src/metabase/query_processor/dashboard.clj
+++ b/src/metabase/query_processor/dashboard.clj
@@ -15,6 +15,7 @@
    [metabase.query-processor.card :as qp.card]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.middleware.constraints :as qp.constraints]
+   [metabase.usage :as usage]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
@@ -176,10 +177,10 @@
                     :attributes {:dashboard/id dashboard-id
                                  :dashcard/id  dashcard-id
                                  :card/id      card-id}}
-    (events/publish-event! :event/dashboard-queried {:object-id dashboard-id :user-id api/*current-user-id*})
     ;; make sure we can read this Dashboard. Card will get read-checked later on inside
     ;; [[qp.card/process-query-for-card]]
     (api/read-check Dashboard dashboard-id)
+    (usage/track! :model/Dashboard dashboard-id)
     (check-card-and-dashcard-are-in-dashboard dashboard-id card-id dashcard-id)
     (let [resolved-params (resolve-params-for-query dashboard-id card-id dashcard-id parameters)
           options         (merge

--- a/src/metabase/query_processor/middleware/update_used_cards.clj
+++ b/src/metabase/query_processor/middleware/update_used_cards.clj
@@ -1,9 +1,9 @@
 (ns metabase.query-processor.middleware.update-used-cards
   (:require
-   [java-time.api :as t]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.query-processor.schema :as qp.schema]
    [metabase.query-processor.store :as qp.store]
+   [metabase.usage :as usage]
    [metabase.util.grouper :as grouper]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
@@ -11,30 +11,6 @@
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
-
-(def ^:private update-used-card-interval-seconds 20)
-
-(defn- update-used-cards!*
-  [card-id-timestamps]
-  (let [card-id->timestamp (update-vals (group-by :id card-id-timestamps)
-                                        (fn [xs] (apply t/max (map :timestamp xs))))]
-    (log/debugf "Update last_used_at of %d cards" (count card-id->timestamp))
-    (try
-      (t2/update! :model/Card :id [:in (keys card-id->timestamp)]
-                  {:last_used_at (into [:case]
-                                       (mapcat (fn [[id timestamp]]
-                                                 [[:= :id id] [:greatest [:coalesce :last_used_at (t/offset-date-time 0)] timestamp]])
-                                               card-id->timestamp))})
-      (catch Throwable e
-        (log/error e "Error updating used cards")))))
-
-(defonce ^:private
-  update-used-cards-queue
-  (delay
-   (grouper/start!
-    update-used-cards!*
-    :capacity 500
-    :interval (* update-used-card-interval-seconds 1000))))
 
 (mu/defn update-used-cards! :- ::qp.schema/qp
   "Middleware that get all card-ids that were used during a query execution and updates their `last_used_at`.
@@ -49,10 +25,8 @@
   [qp :- ::qp.schema/qp]
   (mu/fn [query :- ::qp.schema/query
           rff   :- ::qp.schema/rff]
-    (let [now  (t/offset-date-time)
-          rff* (fn [metadata]
+    (let [rff* (fn [metadata]
                  (doseq [card-id (distinct (lib.metadata/invoked-ids (qp.store/metadata-provider) :metadata/card))]
-                   (grouper/submit! @update-used-cards-queue {:id        card-id
-                                                              :timestamp now}))
+                   (usage/track! :model/Card card-id))
                  (rff metadata))]
       (qp query rff*))))

--- a/src/metabase/usage.clj
+++ b/src/metabase/usage.clj
@@ -1,0 +1,136 @@
+(ns metabase.usage
+  (:require [com.climate.claypoole :as cp]
+            [java-time.api :as t]
+            [metabase.util.log :as log]
+            [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private ^:const batch-size
+  "How many usage records to process at once."
+  1000)
+
+(def ^:private ^:const process-queue-interval-ms
+  "How long to wait between processing the usage queue and the next run."
+  1000)
+
+(def ^:private ^:const error-interval-ms
+  "How long to wait until retrying processing the usage queue after an error."
+  1000)
+
+(def ^:dynamic *track-sync*
+  "Track usage immediately (for testing)"
+  false)
+
+(defmacro with-synchronous-tracking-enabled
+  "For testing purposes, track usage immediately."
+  [& body]
+  `(binding [*track-sync* true]
+     ~@body))
+
+(def ^:private queue
+  "A map of [model id] tuples to the last used timestamp."
+  (atom nil))
+
+(defn column
+  "The column name for the last used at field."
+  [model]
+  (case model
+    :model/Dashboard :last_viewed_at
+    :model/Card      :last_used_at))
+
+(defn- update-last-used-at! [model jobs]
+  (t2/update! (t2/table-name model)
+              :id [:in (map :id jobs)]
+              {(column model) (into [:case]
+                                    (mapcat (fn [{:keys [id timestamp]}]
+                                              [[:= :id id] [:greatest
+                                                            [:coalesce
+                                                             (column model)
+                                                             (t/offset-date-time 0)]
+                                                            timestamp]])
+                                            jobs))}))
+
+(defn track!
+  "Tracks the usage of a single instance. Inside `with-synchronous-tracking-enabled`,
+  this will happen immediately. Otherwise, it will be queued for later processing."
+  [model id]
+  (let [job {:id        id
+             :model     model
+             :timestamp (t/offset-date-time)}]
+    (if *track-sync*
+      (update-last-used-at! model [job])
+      (swap! queue (fn [queue]
+                     (let [key ((juxt :model :id) job)
+                           existing (get queue key)]
+                       (if (or (nil? existing)
+                               (t/after? (:timestamp job) (:timestamp existing)))
+                         (assoc queue key job)
+                         queue)))))))
+
+(defn- nanos-to-ms [ns] (/ ns 1e6))
+
+(defn- run-process-job! []
+  (let [start-time (System/nanoTime)
+        jobs   @queue]
+    (if-not (compare-and-set! queue jobs nil)
+      ;; Something else appended to the queue or is processing it.
+      {::result      ::failed-to-dequeue
+       ::duration-ms (nanos-to-ms (- (System/nanoTime) start-time))
+       ::queue-size  (count jobs)}
+      (let [queue-size        (count jobs)
+            model->jobs       (group-by :model (vals jobs))
+            model->split-jobs (update-vals model->jobs (fn [jobs]
+                                                         (partition-all batch-size jobs)))]
+        (when (seq jobs)
+          #_:clj-kondo/ignore
+          (cp/with-shutdown! [tp (cp/threadpool 4)]
+            (cp/pdoseq tp [[model jobs] model->split-jobs
+                           job-set jobs]
+              (update-last-used-at! model job-set))))
+        {::result      ::processed-queue
+         ::queue-size  queue-size
+         ::duration-ms (nanos-to-ms (- (System/nanoTime) start-time))}))))
+
+(defn- start-processing-worker!
+  []
+  (loop [result ::started]
+    (Thread/sleep
+     (case result
+       ;; Initial run
+       ::started           0
+       ;; The queue was modified before we could `compare-and-set!` it.
+       ::failed-to-dequeue 0
+       ;; Processing the queue was successful
+       ::processed-queue   process-queue-interval-ms
+       ;; An error occurred
+       ::error             error-interval-ms))
+    (let [{:keys [::result ::duration-ms ::queue-size]}
+          (try (run-process-job!)
+               (catch Throwable e
+                 (log/error e "Error processing usage queue.")
+                 {::result ::error}))]
+      (log/debugf "Processed usage queue in %sms [result: %s, queue-size: %s]"
+                  (Math/round ^Double duration-ms)
+                  (name result)
+                  queue-size)
+      (recur result))))
+
+(def ^:private worker
+  "An atom containing the worker future."
+  (atom nil))
+
+(defn init!
+  "Starts up the system, returning the worker future."
+  []
+  (let [w (future (start-processing-worker!))]
+    (reset! worker w)
+    w))
+
+(defn stop!
+  "Stops the worker and processes the remaining jobs."
+  ([] (stop! @worker))
+  ([worker]
+   (future-cancel worker)
+   (while (seq @queue)
+     (run-process-job!))))


### PR DESCRIPTION
Playing around with a consolidated API for tracking usage of dashboards
and cards.

The idea here is that we offer a performant API for tracking card or
dashboard usage. `(usage/track! :model/Card card-id)` is all you need.

The module has the following public functions:

- `(column model)`: the column name for the last used at field. This is
what you want to use when you're trying to get the date of last usage
in a t2/select.

- `(track! model id)`: mentioned above, a performant API for tracking
usage of a card or dashboard. Internally, it adds to an in-memory queue
of jobs, deduplicating based on the model/id (selecting the latest usage
time available)

- `(init!)` and `(stop!)` for starting and stopping processing. By
default, processing happens in separate threads.

Playing around with performance, a single call to `track!` takes about
.005ms on my machine, so we could add 200,000 calls to `track!` in a
single HTTP request and only add one second to the response time.

That example queue of 200,000 jobs would take ~1-2 seconds to fully
process. (On my machine! With a local DB! But still - seems like a lot of 
headroom available.)

`init!` starts a worker thread that will check the queue every second.
If it finds data in the queue, it will attempt to drain it in 1000-item
chunks.

`stop!` stops the workers and then drains the queue.
