### PR TITLE
we had unlimited xrays since 2018 and it is time to end this madness

### DIFF
--- a/src/metabase/xrays/automagic_dashboards/core.clj
+++ b/src/metabase/xrays/automagic_dashboards/core.clj
@@ -560,7 +560,7 @@
            :cards dashcards)))
 
 (def ^:private ^:const ^Long max-related 8)
-(def ^:private ^:const ^Long max-cards 15)
+(def ^:private ^:const ^Long max-cards 30)
 
 (defn ->related-entity
   "Turn `entity` into an entry in `:related.`"
@@ -876,8 +876,7 @@
                                                :dashboard-templates-prefix ["table"]})
                                             opts)]
                            (automagic-dashboard root'))
-                         (let [opts      (assoc opts :show :all)
-                               root'     (merge root
+                         (let [root'     (merge root
                                                 (when cell-query
                                                   {:url cell-url})
                                                 opts)


### PR DESCRIPTION
Fixes #43258

Back in 2018, we've [set `:show` to be `:all`](https://github.com/metabase/metabase/commit/77500ca6e9fa7df55e3a439fa5fc05411665cba3) for x-ray dashboard, and so our card limit was not respected. We've agreed to limit this to 30 cards per x-ray dashboard.

I'm having hard time to understand what to test, since this seems more like a configuration (and this option is supplied all over the tests, so it's tested well), rather than a behavior change.