### PR TITLE
dx: clean output folder before building jar

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -97,7 +97,7 @@ const config = (module.exports = {
     filename: "[name].[contenthash].js",
     publicPath: "app/dist/",
     hashFunction: "sha256",
-    clean: true,
+    clean: !devMode,
   },
 
   module: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -97,6 +97,7 @@ const config = (module.exports = {
     filename: "[name].[contenthash].js",
     publicPath: "app/dist/",
     hashFunction: "sha256",
+    clean: true,
   },
 
   module: {


### PR DESCRIPTION
### Description

We use `writeToDisk` option, so all our "hot" files are saved into `resources/frontend_client/app/dist`, seems all the `.js`, '.js.map` and other static files were copied into jar file during building jar locally, so the size of jar could become 1.3Gb instead of 370Mb

[thread](https://metaboat.slack.com/archives/C010L1Z4F9S/p1721649291730969)

### How to verify

- CI is green
- `rm -rf ./target && ./bin/build.sh`, the resulted jar file will be under 400Mb