### PR TITLE
fix(webapp/browse): Use user locale if available in Browse models

### DIFF
--- a/frontend/src/metabase/browse/components/ModelsTable.tsx
+++ b/frontend/src/metabase/browse/components/ModelsTable.tsx
@@ -7,6 +7,7 @@ import {
 import { push } from "react-router-redux";
 import { t } from "ttag";
 
+import { useLocale } from "metabase/common/hooks/use-locale/use-locale";
 import EntityItem from "metabase/components/EntityItem";
 import { SortableColumnHeader } from "metabase/components/ItemsTable/BaseItemsTable";
 import {
@@ -20,9 +21,8 @@ import { Columns } from "metabase/components/ItemsTable/Columns";
 import type { ResponsiveProps } from "metabase/components/ItemsTable/utils";
 import { Ellipsified } from "metabase/core/components/Ellipsified";
 import { color } from "metabase/lib/colors";
-import { useDispatch, useSelector } from "metabase/lib/redux";
+import { useDispatch } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
-import { getLocale } from "metabase/setup/selectors";
 import {
   Flex,
   Icon,
@@ -79,9 +79,6 @@ export const ModelsTable = ({
   models = [],
   skeleton = false,
 }: ModelsTableProps) => {
-  const locale = useSelector(getLocale);
-  const localeCode: string | undefined = locale?.code;
-
   // for large datasets, we need to simplify the display to avoid performance issues
   const isLargeDataset = models.length > LARGE_DATASET_THRESHOLD;
 
@@ -92,7 +89,8 @@ export const ModelsTable = ({
     DEFAULT_SORTING_OPTIONS,
   );
 
-  const sortedModels = sortModels(models, sortingOptions, localeCode);
+  const locale = useLocale();
+  const sortedModels = sortModels(models, sortingOptions, locale);
 
   /** The name column has an explicitly set width. The remaining columns divide the remaining width. This is the percentage allocated to the collection column */
   const collectionWidth = 38.5;

--- a/frontend/src/metabase/browse/components/utils.unit.spec.tsx
+++ b/frontend/src/metabase/browse/components/utils.unit.spec.tsx
@@ -152,23 +152,80 @@ describe("sortModels", () => {
         modelMap["model named B, with collection path D / E / F"],
       ]);
     });
+
+    it("can sort by collection path, ascending, and then does a secondary sort by name - with a localized sort order", () => {
+      const sortingOptions = {
+        sort_column: "collection",
+        sort_direction: SortDirection.Asc,
+      } as const;
+
+      const addUmlauts = (model: ModelResult): ModelResult => ({
+        ...model,
+        name: model.name.replace(/^B$/g, "Bä"),
+        collection: {
+          ...model.collection,
+          effective_ancestors: model.collection?.effective_ancestors?.map(
+            ancestor => ({
+              ...ancestor,
+              name: ancestor.name.replace("X", "Ä"),
+            }),
+          ),
+        },
+      });
+
+      const swedishModelMap = {
+        "model named A, with collection path Ä / Y / Z": addUmlauts(
+          modelMap["model named A, with collection path X / Y / Z"],
+        ),
+        "model named Bä, with collection path D / E / F": addUmlauts(
+          modelMap["model named B, with collection path D / E / F"],
+        ),
+        "model named Bz, with collection path D / E / F": addUmlauts(
+          modelMap["model named Bz, with collection path D / E / F"],
+        ),
+        "model named C, with collection path Y": addUmlauts(
+          modelMap["model named C, with collection path Y"],
+        ),
+        "model named C, with collection path Z": addUmlauts(
+          modelMap["model named C, with collection path Z"],
+        ),
+      };
+
+      const swedishResults = Object.values(swedishModelMap);
+
+      // When sorting in Swedish, z comes before ä
+      const swedishLocaleCode = "sv";
+      const sorted = sortModels(
+        swedishResults,
+        sortingOptions,
+        swedishLocaleCode,
+      );
+      expect("ä".localeCompare("z", "sv", { sensitivity: "base" })).toEqual(1);
+      expect(sorted).toEqual([
+        swedishModelMap["model named Bz, with collection path D / E / F"], // Model Bz sorts before Bä
+        swedishModelMap["model named Bä, with collection path D / E / F"],
+        swedishModelMap["model named C, with collection path Y"],
+        swedishModelMap["model named C, with collection path Z"], // Collection Z sorts before Ä
+        swedishModelMap["model named A, with collection path Ä / Y / Z"],
+      ]);
+    });
+  });
+});
+
+describe("getMaxRecentModelCount", () => {
+  it("returns 8 for modelCount greater than 20", () => {
+    expect(getMaxRecentModelCount(21)).toBe(8);
+    expect(getMaxRecentModelCount(100)).toBe(8);
   });
 
-  describe("getMaxRecentModelCount", () => {
-    it("returns 8 for modelCount greater than 20", () => {
-      expect(getMaxRecentModelCount(21)).toBe(8);
-      expect(getMaxRecentModelCount(100)).toBe(8);
-    });
+  it("returns 4 for modelCount greater than 9 and less than or equal to 20", () => {
+    expect(getMaxRecentModelCount(10)).toBe(4);
+    expect(getMaxRecentModelCount(20)).toBe(4);
+  });
 
-    it("returns 4 for modelCount greater than 9 and less than or equal to 20", () => {
-      expect(getMaxRecentModelCount(10)).toBe(4);
-      expect(getMaxRecentModelCount(20)).toBe(4);
-    });
-
-    it("returns 0 for modelCount of 9 or less", () => {
-      expect(getMaxRecentModelCount(0)).toBe(0);
-      expect(getMaxRecentModelCount(5)).toBe(0);
-      expect(getMaxRecentModelCount(9)).toBe(0);
-    });
+  it("returns 0 for modelCount of 9 or less", () => {
+    expect(getMaxRecentModelCount(0)).toBe(0);
+    expect(getMaxRecentModelCount(5)).toBe(0);
+    expect(getMaxRecentModelCount(9)).toBe(0);
   });
 });

--- a/frontend/src/metabase/common/hooks/use-locale/use-locale.ts
+++ b/frontend/src/metabase/common/hooks/use-locale/use-locale.ts
@@ -1,0 +1,11 @@
+import { getCurrentUser } from "metabase/admin/datamodel/selectors";
+import { useSelector } from "metabase/lib/redux";
+import { getSetting } from "metabase/selectors/settings";
+
+/** Get the user's locale or, if that has not been set, the instance locale */
+export const useLocale = () => {
+  const instanceLocale = useSelector(state => getSetting(state, "site-locale"));
+  const userLocale: string | undefined =
+    useSelector(getCurrentUser)?.locale || undefined;
+  return userLocale || instanceLocale;
+};

--- a/frontend/src/metabase/common/hooks/use-locale/use-locale.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-locale/use-locale.unit.spec.tsx
@@ -1,0 +1,65 @@
+import { renderWithProviders, screen } from "__support__/ui";
+import { createMockUser } from "metabase-types/api/mocks";
+import {
+  createMockSettingsState,
+  createMockState,
+} from "metabase-types/store/mocks";
+
+import { useLocale } from "./use-locale";
+
+const TestComponent = () => {
+  const locale = useLocale();
+  return <div data-testid="locale">{`${locale}`}</div>;
+};
+
+describe("useLocale", () => {
+  it("returns undefined if no locale is set", async () => {
+    renderWithProviders(<TestComponent />, {
+      storeInitialState: createMockState({
+        settings: createMockSettingsState({ "site-locale": undefined }),
+        currentUser: createMockUser({ locale: null }),
+      }),
+    });
+    expect(await screen.findByTestId("locale")).toHaveTextContent("undefined");
+  });
+
+  it("returns the user's locale if the site locale is undefined", async () => {
+    renderWithProviders(<TestComponent />, {
+      storeInitialState: createMockState({
+        settings: createMockSettingsState({ "site-locale": undefined }),
+        currentUser: createMockUser({ locale: "zh" }),
+      }),
+    });
+    expect(await screen.findByTestId("locale")).toHaveTextContent("zh");
+  });
+
+  it("returns the site locale if user locale is null", async () => {
+    renderWithProviders(<TestComponent />, {
+      storeInitialState: createMockState({
+        settings: createMockSettingsState({ "site-locale": "zh" }),
+        currentUser: createMockUser({ locale: null }),
+      }),
+    });
+    expect(await screen.findByTestId("locale")).toHaveTextContent("zh");
+  });
+
+  it("returns the site locale if user locale is undefined", async () => {
+    renderWithProviders(<TestComponent />, {
+      storeInitialState: createMockState({
+        settings: createMockSettingsState({ "site-locale": "zh" }),
+        currentUser: createMockUser({ locale: undefined }),
+      }),
+    });
+    expect(await screen.findByTestId("locale")).toHaveTextContent("zh");
+  });
+
+  it("returns the user locale if both locales are set", async () => {
+    renderWithProviders(<TestComponent />, {
+      storeInitialState: createMockState({
+        settings: createMockSettingsState({ "site-locale": "zh" }),
+        currentUser: createMockUser({ locale: "ar" }),
+      }),
+    });
+    expect(await screen.findByTestId("locale")).toHaveTextContent("ar");
+  });
+});


### PR DESCRIPTION
Previously the Browse models feature looked up the locale (so that sorting is locale-dependent) - but it only looked up the _instance-wide_ locale (aka the "site locale"). This PR adds a general hook for looking up the currently used locale. It first checks the user's locale, and if this is not set, it uses the instance-wide locale.

This PR also tests that the `sortModels` utility function respects the locale provided.