### PR TITLE
Fix search field values with has_more_values: true

### DIFF
--- a/frontend/src/metabase/querying/components/FilterValuePicker/FilterValuePicker.tsx
+++ b/frontend/src/metabase/querying/components/FilterValuePicker/FilterValuePicker.tsx
@@ -89,6 +89,7 @@ function FilterValuePicker({
       <SearchValuePicker
         fieldId={checkNotNull(fieldInfo.fieldId)}
         searchFieldId={checkNotNull(fieldInfo.searchFieldId)}
+        fieldValues={fieldData?.values ?? []}
         selectedValues={selectedValues}
         columnDisplayName={columnInfo.displayName}
         shouldCreate={shouldCreate}

--- a/frontend/src/metabase/querying/components/FilterValuePicker/FilterValuePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterValuePicker/FilterValuePicker.unit.spec.tsx
@@ -521,6 +521,10 @@ describe("StringFilterValuePicker", () => {
         screen.queryByPlaceholderText("Search the list"),
       ).not.toBeInTheDocument();
 
+      await userEvent.click(input);
+      expect(screen.getByText("Gadget")).toBeInTheDocument();
+      expect(screen.getByText("Widget")).toBeInTheDocument();
+
       await userEvent.type(input, "g");
       await userEvent.click(await screen.findByText("Gizmo"));
       expect(onChange).toHaveBeenLastCalledWith(["Gizmo"]);

--- a/frontend/src/metabase/querying/components/FilterValuePicker/SearchValuePicker/SearchValuePicker.tsx
+++ b/frontend/src/metabase/querying/components/FilterValuePicker/SearchValuePicker/SearchValuePicker.tsx
@@ -45,7 +45,7 @@ export function SearchValuePicker({
   const canSearch = searchQuery.length > 0;
 
   const {
-    data: fieldValues = [],
+    data: searchFieldValues = [],
     error: searchError,
     isFetching: isSearching,
   } = useSearchFieldValuesQuery(
@@ -61,7 +61,7 @@ export function SearchValuePicker({
   );
 
   const searchOptions = canSearch
-    ? getFieldOptions(fieldValues)
+    ? getFieldOptions(searchFieldValues)
     : getFieldOptions(initialFieldValues);
   const visibleOptions = getFilteredOptions(
     searchOptions,
@@ -83,7 +83,7 @@ export function SearchValuePicker({
   };
 
   const handleSearchTimeout = () => {
-    if (shouldSearch(searchValue, searchQuery, fieldValues)) {
+    if (shouldSearch(searchValue, searchQuery, searchFieldValues)) {
       setSearchQuery(searchValue);
     }
   };

--- a/frontend/src/metabase/querying/components/FilterValuePicker/SearchValuePicker/SearchValuePicker.tsx
+++ b/frontend/src/metabase/querying/components/FilterValuePicker/SearchValuePicker/SearchValuePicker.tsx
@@ -45,7 +45,7 @@ export function SearchValuePicker({
   const canSearch = searchQuery.length > 0;
 
   const {
-    data: fieldValues = initialFieldValues,
+    data: fieldValues = [],
     error: searchError,
     isFetching: isSearching,
   } = useSearchFieldValuesQuery(

--- a/frontend/src/metabase/querying/components/FilterValuePicker/SearchValuePicker/SearchValuePicker.tsx
+++ b/frontend/src/metabase/querying/components/FilterValuePicker/SearchValuePicker/SearchValuePicker.tsx
@@ -4,7 +4,7 @@ import { t } from "ttag";
 
 import { useSearchFieldValuesQuery } from "metabase/api";
 import { Loader, MultiAutocomplete } from "metabase/ui";
-import type { FieldId } from "metabase-types/api";
+import type { FieldId, FieldValue } from "metabase-types/api";
 
 import { getFieldOptions } from "../utils";
 
@@ -18,6 +18,7 @@ import {
 interface SearchValuePickerProps {
   fieldId: FieldId;
   searchFieldId: FieldId;
+  fieldValues: FieldValue[];
   selectedValues: string[];
   columnDisplayName: string;
   shouldCreate?: (query: string, values: string[]) => boolean;
@@ -30,6 +31,7 @@ interface SearchValuePickerProps {
 export function SearchValuePicker({
   fieldId,
   searchFieldId,
+  fieldValues: initialFieldValues,
   selectedValues,
   columnDisplayName,
   shouldCreate,
@@ -43,7 +45,7 @@ export function SearchValuePicker({
   const canSearch = searchQuery.length > 0;
 
   const {
-    data: fieldValues = [],
+    data: fieldValues = initialFieldValues,
     error: searchError,
     isFetching: isSearching,
   } = useSearchFieldValuesQuery(
@@ -58,7 +60,9 @@ export function SearchValuePicker({
     },
   );
 
-  const searchOptions = canSearch ? getFieldOptions(fieldValues) : [];
+  const searchOptions = canSearch
+    ? getFieldOptions(fieldValues)
+    : getFieldOptions(initialFieldValues);
   const visibleOptions = getFilteredOptions(
     searchOptions,
     searchValue,


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/45904

How to verify:
1. Go to Admin => Table Metadata => Sample Dataset => Reviews => Body
2. Change "Filtering on this field" to "A list of values"
3. New => Question => Reviews
4. Try filter with the "Is" operator on "Body" column, the UI shows a search box
5. Make sure the initial list is not empty

<img width="459" alt="Screenshot 2024-07-22 at 09 30 54" src="https://github.com/user-attachments/assets/30761cb1-f8f4-4f70-8a43-e38268aff0b0">
