### PR TITLE
update static_embed_code_copied to use downloads

### DIFF
--- a/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
@@ -421,8 +421,7 @@ describe("#39152 sharing an unsaved question", () => {
               titled: true,
               font: "instance",
               theme: "light",
-              // TODO: change to expect the correct value of  `downloads`
-              hide_download_button: null,
+              downloads: null,
             },
           });
 
@@ -441,8 +440,7 @@ describe("#39152 sharing an unsaved question", () => {
               titled: true,
               font: "instance",
               theme: "light",
-              // TODO: change to expect the correct value of  `downloads`
-              hide_download_button: null,
+              downloads: null,
             },
           });
 
@@ -468,8 +466,7 @@ describe("#39152 sharing an unsaved question", () => {
               titled: true,
               font: "instance",
               theme: "light",
-              // TODO: change to expect the correct value of  `downloads`
-              hide_download_button: null,
+              downloads: null,
             },
           });
 
@@ -509,8 +506,7 @@ describe("#39152 sharing an unsaved question", () => {
               titled: false,
               font: "instance",
               theme: "night",
-              // TODO: change to expect the correct value of  `downloads`
-              hide_download_button: null,
+              downloads: null,
             },
           });
 
@@ -533,7 +529,7 @@ describe("#39152 sharing an unsaved question", () => {
                 titled: false,
                 font: "instance",
                 theme: "night",
-                hide_download_button: null,
+                downloads: null,
               },
             });
           }
@@ -566,8 +562,7 @@ describe("#39152 sharing an unsaved question", () => {
                 titled: true,
                 font: "instance",
                 theme: "light",
-                // TODO: change to expect the correct value of  `downloads`
-                hide_download_button: null,
+                downloads: true,
               },
             });
 
@@ -586,8 +581,7 @@ describe("#39152 sharing an unsaved question", () => {
                 titled: true,
                 font: "instance",
                 theme: "light",
-                // TODO: change to expect the correct value of  `downloads`
-                hide_download_button: null,
+                downloads: true,
               },
             });
 
@@ -613,8 +607,7 @@ describe("#39152 sharing an unsaved question", () => {
                 titled: true,
                 font: "instance",
                 theme: "light",
-                // TODO: change to expect the correct value of  `downloads`
-                hide_download_button: null,
+                downloads: true,
               },
             });
 
@@ -661,8 +654,7 @@ describe("#39152 sharing an unsaved question", () => {
                 titled: false,
                 font: "custom",
                 theme: "night",
-                // TODO: change to expect the correct value of  `downloads`
-                hide_download_button: null,
+                downloads: true,
               },
             });
           });

--- a/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
@@ -635,9 +635,10 @@ describe("#39152 sharing an unsaved question", () => {
 
             popover().findByText("Oswald").click();
 
-            if (resource === "question") {
-              modal().findByLabelText("Download data").click({ force: true });
-            }
+            cy.log(
+              "Assert that it sends `disabled: false` when downloads are disabled",
+            );
+            modal().findByLabelText("Download data").click({ force: true });
 
             cy.findByTestId("embed-backend")
               .findByTestId("copy-button")
@@ -654,7 +655,7 @@ describe("#39152 sharing an unsaved question", () => {
                 titled: false,
                 font: "custom",
                 theme: "night",
-                downloads: true,
+                downloads: false,
               },
             });
           });

--- a/frontend/src/metabase/public/lib/analytics.ts
+++ b/frontend/src/metabase/public/lib/analytics.ts
@@ -18,8 +18,7 @@ type Appearance = {
   bordered: boolean;
   theme: DisplayTheme;
   font: "instance" | "custom";
-  hide_download_button: boolean | null;
-  // TODO: implement `downloads` parameter in the analytics event
+  downloads: boolean | null;
 };
 
 export const trackStaticEmbedDiscarded = ({
@@ -116,8 +115,7 @@ function normalizeAppearance(
     bordered: displayOptions.bordered,
     theme: displayOptions.theme ?? "light",
     font: displayOptions.font ? "custom" : "instance",
-    // TODO: replace with `downloads` when it's implemented
-    hide_download_button: displayOptions.hide_download_button ?? null,
+    downloads: displayOptions.downloads,
   };
 }
 

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/embed_flow/jsonschema/1-0-2
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/embed_flow/jsonschema/1-0-2
@@ -1,0 +1,205 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "User interactions with public links, static embedding, and public embedding",
+  "self": {
+    "vendor": "com.metabase",
+    "name": "embed_flow",
+    "format": "jsonschema",
+    "version": "1-0-1"
+  },
+  "type": "object",
+  "properties": {
+    "event": {
+      "type": "string",
+      "enum": [
+        "static_embed_discarded",
+        "static_embed_published",
+        "static_embed_unpublished",
+        "static_embed_code_copied",
+        "public_link_copied",
+        "public_embed_code_copied",
+        "public_link_removed"
+      ],
+      "description": "The type of event being recorded."
+    },
+    "artifact": {
+      "type": "string",
+      "enum": [
+        "dashboard",
+        "question"
+      ],
+      "description": "The type of artifact involved in the event (either a dashboard or a question)."
+    },
+    "new_embed": {
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "description": "Indicates if the embed is new."
+    },
+    "params": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "description": "Parameters related to the artifact.",
+      "properties": {
+        "locked": {
+          "type": "integer",
+          "description": "Number of locked parameters in the artifact.",
+          "minimum": 0,
+          "maximum": 2147483647
+        },
+        "editable": {
+          "type": "integer",
+          "description": "Number of editable parameters in the artifact.",
+          "minimum": 0,
+          "maximum": 2147483647
+        },
+        "disabled": {
+          "type": "integer",
+          "description": "Number of disabled parameters in the artifact.",
+          "minimum": 0,
+          "maximum": 2147483647
+        }
+      }
+    },
+    "first_published_at": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "date-time",
+      "description": "The timestamp when the artifact was first published."
+    },
+    "language": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "The backend or view language of the artifact.",
+      "maxLength": 1024
+    },
+    "location": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "code_overview",
+        "code_params",
+        "code_appearance"
+      ],
+      "description": "The location in the code where the event is triggered."
+    },
+    "code": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "backend",
+        "view"
+      ],
+      "description": "Type of the language of the artifact where the event is triggered."
+    },
+    "appearance": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "description": "The appearance settings of the artifact.",
+      "properties": {
+        "title": {
+          "type": "boolean",
+          "description": "Indicates if the title is visible."
+        },
+        "border": {
+          "type": "boolean",
+          "description": "Indicates if the border is visible."
+        },
+        "theme": {
+          "type": [
+            "string"
+          ],
+          "enum": [
+            "light",
+            "night",
+            "transparent"
+          ],
+          "description": "The theme of the artifact's appearance."
+        },
+        "font": {
+          "type": "string",
+          "enum": [
+            "instance",
+            "custom"
+          ],
+          "description": "The font type used in the artifact."
+        },
+        "hide_download_button": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Indicates if the download button is hidden. It will be null on OSS instance since it's not supported."
+        }
+      }
+    },
+    "format": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "html",
+        "csv",
+        "xlsx",
+        "json",
+        null
+      ],
+      "description": "The format of the public link."
+    },
+    "source": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "public-embed",
+        "public-share"
+      ],
+      "description": "Location where the public link is copied from"
+    },
+    "time_since_creation": {
+      "description": "Number of seconds from the creation of the artifact until the event is triggered.",
+      "type": [
+        "number",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "time_since_initial_publication": {
+      "description": "Number of seconds from the initial publication of the artifact until the event is triggered.",
+      "type": [
+        "number",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "is_example_dashboard": {
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "description": "Indicates if the dashboard is the example dashboard linked in the embedding homepage."
+    }
+  },
+  "required": [
+    "event",
+    "artifact"
+  ],
+  "additionalProperties": false
+}

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/embed_flow/jsonschema/1-0-2
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/embed_flow/jsonschema/1-0-2
@@ -143,6 +143,13 @@
             "null"
           ],
           "description": "Indicates if the download button is hidden. It will be null on OSS instance since it's not supported."
+        },
+        "downloads": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Indicates if downloads are enabled, it will be null on OSS as they can't disable them"
         }
       }
     },


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/45932

This updates the `static_embed_code_copied` event to use `downloads` instead of the old flag, and it updates the E2E tests.