### PR TITLE
Manual backport of #45873

### DIFF
--- a/test/metabase/xrays/automagic_dashboards/comparison_test.clj
+++ b/test/metabase/xrays/automagic_dashboards/comparison_test.clj
@@ -1,4 +1,4 @@
-(ns metabase.xrays.automagic-dashboards.comparison-test
+(ns ^:mb/once metabase.xrays.automagic-dashboards.comparison-test
   (:require
    [clojure.test :refer :all]
    [metabase.models :refer [Card Segment Table]]


### PR DESCRIPTION
#45873 was to fix an old flake fix I broke in `master` but it should help with similar flakes we're seeing in 50.x as well.