### PR TITLE
Fix admin nav overflow

### DIFF
--- a/frontend/src/metabase/nav/components/AdminNavbar/AdminNavItem.styled.tsx
+++ b/frontend/src/metabase/nav/components/AdminNavbar/AdminNavItem.styled.tsx
@@ -9,7 +9,7 @@ interface AdminNavLinkProps {
 }
 
 export const AdminNavLink = styled(Link)<AdminNavLinkProps>`
-  padding: 0.5rem 1rem;
+  display: block;
   text-decoration: none;
   color: ${props =>
     props.isSelected ? color("text-white") : alpha("text-white", 0.63)};

--- a/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.styled.tsx
+++ b/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.styled.tsx
@@ -24,14 +24,19 @@ export const AdminNavbarRoot = styled.nav`
 
 export const AdminNavbarItems = styled.ul`
   display: flex;
-  flex: 1 0 auto;
+  flex: 1 1 auto;
+  align-items: center;
+  text-align: center;
+  line-break: anywhere;
+  gap: 1rem;
+  margin-inline: 1rem;
   margin-right: auto;
   margin-left: 2rem;
 `;
 
 export const MobileHide = styled.div`
   display: flex;
-  flex: 1 0 auto;
+  flex: 1 1 auto;
   align-items: center;
   ${breakpointMaxMedium} {
     display: none;
@@ -51,7 +56,7 @@ export const AdminMobileNavBarItems = styled.ul`
   display: flex;
   flex-direction: column;
   text-align: right;
-  padding: 1rem;
+  padding: 1.5rem;
   gap: 2rem;
   border-radius: 0 0 0 0.5rem;
   top: ${ADMIN_NAVBAR_HEIGHT};


### PR DESCRIPTION
fixes #45876 

This is a css-only approach to this problem where certain languages' menu items push admin. menu items off the screen

Before | After
--- | ---
![badbuttons](https://github.com/user-attachments/assets/43b3e08d-7c92-47c7-84d1-fc13e727f66e) | ![css-only button fix](https://github.com/user-attachments/assets/1baa4013-c465-41ae-9fdc-dba53e8acd46)

