### PR TITLE
Archive stale content

### DIFF
--- a/src/metabase/events/audit_log.clj
+++ b/src/metabase/events/audit_log.clj
@@ -224,3 +224,14 @@
 (methodical/defmethod events/publish-event! ::cache-config-changed-event
   [topic event]
   (audit-log/record-event! topic event))
+
+(derive ::stale-items-archived ::event)
+(derive :event/stale-items-archived ::stale-items-archived)
+
+(methodical/defmethod events/publish-event! ::stale-items-archived
+  [topic {:keys [object user-id cutoff-date total]}]
+  (audit-log/record-event! topic {:details  {:total-stale-items-found total
+                                             :cutoff-date cutoff-date}
+                                  :user-id  user-id
+                                  :model    :model/Collection
+                                  :model-id (u/id object)}))

--- a/src/metabase/events/snowplow.clj
+++ b/src/metabase/events/snowplow.clj
@@ -1,0 +1,36 @@
+(ns metabase.events.snowplow
+  "This namespace is responsible for publishing events to snowplow."
+  (:require
+   [metabase.analytics.snowplow :as snowplow]
+   [metabase.events :as events]
+   [metabase.models.collection.root :as collection.root]
+   [methodical.core :as methodical]))
+
+(defn- date->datetime-str [date]
+  (format "%sT00:00:00Z" (str date)))
+
+(derive ::event :metabase/event)
+
+(derive ::stale-items-read ::event)
+(derive :event/stale-items-read ::stale-items-read)
+
+(methodical/defmethod events/publish-event! ::stale-items-read
+  [_topic {:keys [object user-id cutoff-date total]}]
+  (snowplow/track-event! ::snowplow/stale-items-read
+                         user-id
+                         {:collection_id (when-not (collection.root/is-root-collection? object)
+                                           (:id object))
+                          :total_stale_items_found total
+                          :cutoff_date (date->datetime-str cutoff-date)}))
+
+(derive ::stale-items-archived ::event)
+(derive :event/stale-items-archived ::stale-items-archived)
+
+(methodical/defmethod events/publish-event! ::stale-items-archived
+  [_topic {:keys [object user-id cutoff-date total]}]
+  (snowplow/track-event! ::snowplow/stale-items-archived
+                         user-id
+                         {:collection_id (when-not (collection.root/is-root-collection? object)
+                                           (:id object))
+                          :total_stale_items_found total
+                          :cutoff_date (date->datetime-str cutoff-date)}))


### PR DESCRIPTION
Very similar to the previous endpoint, just accepts fewer query parameters (since we don't need to limit, offset, or sort results) and archives the stale items found.

Should probably wait for review until https://github.com/metabase/metabase/pull/44711 is merged

Fixes #46292