### PR TITLE
Fix editing models with metadata overrides

### DIFF
--- a/e2e/test/scenarios/admin/datamodel/editor.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/editor.cy.spec.js
@@ -658,7 +658,7 @@ const clearAndBlurInput = oldValue => {
 const searchAndSelectValue = (newValue, searchText = newValue) => {
   popover().within(() => {
     cy.findByRole("grid").scrollTo("top", { ensureScrollable: false });
-    cy.findByPlaceholderText("Find...").type(searchText);
+    cy.findByPlaceholderText("Find...").type(searchText, { delay: 50 });
     cy.findByText(newValue).click();
   });
 };

--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -1,5 +1,8 @@
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
+import {
+  ORDERS_DASHBOARD_ID,
+  ORDERS_QUESTION_ID,
+} from "e2e/support/cypress_sample_instance_data";
 import {
   type StructuredQuestionDetails,
   createNativeQuestion,
@@ -41,6 +44,7 @@ import {
   assertQueryBuilderRowCount,
   navigationSidebar,
   newButton,
+  tableInteractive,
 } from "e2e/support/helpers";
 import type { CardId, FieldReference } from "metabase-types/api";
 
@@ -768,6 +772,37 @@ describe("issue 25885", () => {
     verifyColumnName("ID1");
     verifyColumnName("ID2");
     verifyColumnName("ID3");
+  });
+});
+
+describe("issue 45924", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+    cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, { type: "model" });
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    cy.intercept("PUT", "/api/card/*").as("updateCard");
+  });
+
+  it("should preserve model metadata when re-running the query (metabase#45924)", () => {
+    visitModel(ORDERS_QUESTION_ID);
+    cy.wait("@dataset");
+    openQuestionActions();
+    popover().findByText("Edit metadata").click();
+    tableHeaderClick("ID");
+    cy.findByLabelText("Display name").clear().type("ID1");
+    cy.findByTestId("dataset-edit-bar").findByText("Query").click();
+    cy.findByTestId("action-buttons").button("Sort").click();
+    popover().findByText("ID").click();
+    cy.findByTestId("run-button").click();
+    cy.wait("@dataset");
+    cy.findByTestId("dataset-edit-bar").findByText("Metadata").click();
+    tableHeaderClick("ID1");
+    cy.findByLabelText("Display name").should("have.value", "ID1");
+    cy.findByTestId("dataset-edit-bar").button("Save changes").click();
+    cy.wait("@updateCard");
+    cy.wait("@dataset");
+    tableInteractive().findByText("ID1").should("be.visible");
   });
 });
 

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -5,7 +5,6 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { connect } from "react-redux";
 import { usePrevious } from "react-use";
 import { t } from "ttag";
-import _ from "underscore";
 
 import { useListModelIndexesQuery } from "metabase/api";
 import ActionButton from "metabase/components/ActionButton";
@@ -33,6 +32,7 @@ import {
   getVisualizationSettings,
   isResultsMetadataDirty,
 } from "metabase/query_builder/selectors";
+import { getWritableColumnProperties } from "metabase/query_builder/utils";
 import { getMetadata } from "metabase/selectors/metadata";
 import { Tooltip } from "metabase/ui";
 import * as Lib from "metabase-lib";
@@ -187,16 +187,6 @@ function getColumnTabIndex(columnIndex, focusedFieldIndex) {
     : EDITOR_TAB_INDEXES.PREVIOUS_FIELDS;
 }
 
-const FIELDS = [
-  "id",
-  "display_name",
-  "description",
-  "semantic_type",
-  "fk_target_field_id",
-  "visibility_type",
-  "settings",
-];
-
 function DatasetEditor(props) {
   const {
     question,
@@ -293,7 +283,8 @@ function DatasetEditor(props) {
   const inheritMappedFieldProperties = useCallback(
     changes => {
       const mappedField = metadata.field?.(changes.id)?.getPlainObject();
-      const inheritedProperties = _.pick(mappedField, ...FIELDS);
+      const inheritedProperties =
+        mappedField && getWritableColumnProperties(mappedField);
       return mappedField ? merge(inheritedProperties, changes) : changes;
     },
     [metadata],
@@ -368,7 +359,7 @@ function DatasetEditor(props) {
       await updateQuestion(questionWithDisplay, { rerunQuery: false });
       onOpenModal(MODAL_TYPES.SAVE);
     } else if (canBeDataset) {
-      await onSave(questionWithDisplay, { rerunQuery: false });
+      await onSave(questionWithDisplay, { rerunQuery: true });
       await setQueryBuilderMode("view");
       runQuestionQuery();
     } else {

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -468,6 +468,7 @@ export const queryResults = handleActions(
 export const metadataDiff = handleActions(
   {
     [RESET_QB]: { next: () => ({}) },
+    [API_CREATE_QUESTION]: { next: () => ({}) },
     [API_UPDATE_QUESTION]: { next: () => ({}) },
     [SET_METADATA_DIFF]: {
       next: (state, { payload }) => {

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -48,7 +48,7 @@ import { getIsPKFromTablePredicate } from "metabase-lib/v1/types/utils/isa";
 import { LOAD_COMPLETE_FAVICON } from "metabase/hoc/Favicon";
 import { isNotNull } from "metabase/lib/types";
 import { getQuestionWithDefaultVisualizationSettings } from "./actions/core/utils";
-import { createRawSeries } from "./utils";
+import { createRawSeries, getWritableColumnProperties } from "./utils";
 
 export const getUiControls = state => state.qb.uiControls;
 export const getQueryStatus = state => state.qb.queryStatus;
@@ -111,8 +111,40 @@ export const getIsBookmarked = (state, props) =>
       bookmark.type === "card" && bookmark.item_id === state.qb.card?.id,
   );
 
+export const getQueryBuilderMode = createSelector(
+  [getUiControls],
+  uiControls => uiControls.queryBuilderMode,
+);
+
+const getCardResultMetadata = createSelector(
+  [getCard],
+  card => card?.result_metadata,
+);
+
+const getModelMetadataDiff = createSelector(
+  [getCardResultMetadata, getMetadataDiff, getQueryBuilderMode],
+  (resultMetadata, metadataDiff, queryBuilderMode) => {
+    if (!resultMetadata || queryBuilderMode !== "dataset") {
+      return metadataDiff;
+    }
+
+    return {
+      ...metadataDiff,
+      ...Object.fromEntries(
+        resultMetadata.map(column => [
+          column.name,
+          {
+            ...getWritableColumnProperties(column),
+            ...metadataDiff[column.name],
+          },
+        ]),
+      ),
+    };
+  },
+);
+
 export const getQueryResults = createSelector(
-  [getRawQueryResults, getMetadataDiff],
+  [getRawQueryResults, getModelMetadataDiff],
   (queryResults, metadataDiff) => {
     if (!Array.isArray(queryResults) || !queryResults.length) {
       return null;
@@ -308,11 +340,6 @@ const getNextRunParameterValues = createSelector([getParameters], parameters =>
 export const getNextRunParameters = createSelector(
   [getParameters],
   parameters => normalizeParameters(parameters),
-);
-
-export const getQueryBuilderMode = createSelector(
-  [getUiControls],
-  uiControls => uiControls.queryBuilderMode,
 );
 
 export const getPreviousQueryBuilderMode = createSelector(

--- a/frontend/src/metabase/query_builder/utils.ts
+++ b/frontend/src/metabase/query_builder/utils.ts
@@ -1,11 +1,12 @@
 import type { Location } from "history";
 import querystring from "querystring";
+import _ from "underscore";
 
 import { serializeCardForUrl } from "metabase/lib/card";
 import * as Urls from "metabase/lib/urls";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
-import type { Card, Series } from "metabase-types/api";
+import type { Card, Field, Series } from "metabase-types/api";
 import type { DatasetEditorTab, QueryBuilderMode } from "metabase-types/store";
 
 interface GetPathNameFromQueryBuilderModeOptions {
@@ -178,3 +179,17 @@ export const createRawSeries = (options: {
     ]
   );
 };
+
+const WRITABLE_COLUMN_PROPERTIES = [
+  "id",
+  "display_name",
+  "description",
+  "semantic_type",
+  "fk_target_field_id",
+  "visibility_type",
+  "settings",
+];
+
+export function getWritableColumnProperties(column: Field) {
+  return _.pick(column, WRITABLE_COLUMN_PROPERTIES);
+}


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/45924

The fix consists of 2 parts:
- Using existing `card.result_metadata` in the model editor when computing the effective query results. So it's query results -> card result metadata -> metadata diff.
- Re-running the query when a model is updated. A model can be updated with either query or metadata change. I don't want to deal with making outdated query results correct by "fixing" them on the FE, so let's just re-run the query and make it simple and robust.

How to verify:
- Open some model
- Edit metadata -> Rename a column
- Query tab -> Change the query and re-run it
- Go back to Metadata tab -> The column name should not be lost
- Save changes -> The column name should not be lost