### PR TITLE
Add mu/defn- as private counterpart to mu/defn

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -664,9 +664,11 @@
   metabase.upload-test/with-upload-table!                                              clojure.core/let
   metabase.util.files/with-open-path-to-resource                                       clojure.core/let
   metabase.util.malli.defn/defn                                                        schema.core/defn
+  metabase.util.malli.defn/defn-                                                       schema.core/defn
   metabase.util.malli.fn/fn                                                            schema.core/fn
   metabase.util.malli/defmethod                                                        schema.core/defmethod
   metabase.util.malli/defn                                                             schema.core/defn
+  metabase.util.malli/defn-                                                            schema.core/defn
   metabase.util.malli/fn                                                               schema.core/fn
   metabase.util.ssh/with-ssh-tunnel                                                    clojure.core/let
   metabase.xrays.domain-entities.malli/defn                                            schema.core/defn

--- a/src/metabase/util/malli.cljc
+++ b/src/metabase/util/malli.cljc
@@ -1,5 +1,5 @@
 (ns metabase.util.malli
-  (:refer-clojure :exclude [fn defn defmethod])
+  (:refer-clojure :exclude [fn defn defn- defmethod])
   (:require
    #?@(:clj
        ([metabase.util.i18n]
@@ -18,7 +18,7 @@
 #?(:clj
    (p/import-vars
     [mu.fn fn]
-    [mu.defn defn]))
+    [mu.defn defn defn-]))
 
 (core/defn humanize-include-value
   "Pass into mu/humanize to include the value received in the error message."

--- a/src/metabase/util/malli/defn.clj
+++ b/src/metabase/util/malli/defn.clj
@@ -1,6 +1,7 @@
 (ns metabase.util.malli.defn
-  (:refer-clojure :exclude [defn])
+  (:refer-clojure :exclude [defn defn-])
   (:require
+   [clojure.core :as core]
    [clojure.string :as str]
    [malli.destructure]
    [metabase.util :as u]
@@ -10,7 +11,7 @@
 (set! *warn-on-reflection* true)
 
 ;;; TODO -- this should generate type hints from the schemas and from the return type as well.
-(defn- deparameterized-arglist [{:keys [args]}]
+(core/defn- deparameterized-arglist [{:keys [args]}]
   (-> (malli.destructure/parse args)
       :arglist
       (with-meta (macros/case
@@ -29,13 +30,13 @@
                      (cond-> args-meta
                        resolved-tag (assoc :tag resolved-tag)))))))
 
-(defn- deparameterized-arglists [{:keys [arities], :as _parsed}]
+(core/defn- deparameterized-arglists [{:keys [arities], :as _parsed}]
   (let [[arities-type arities-value] arities]
     (case arities-type
       :single   (list (deparameterized-arglist arities-value))
       :multiple (map deparameterized-arglist (:arities arities-value)))))
 
-(defn- annotated-docstring
+(core/defn- annotated-docstring
   "Generate a docstring with additional information about inputs and return type using a parsed fn tail (as parsed
   by [[mx/SchematizedParams]])."
   [{original-docstring           :doc
@@ -102,3 +103,10 @@
             :clj  (let [error-context {:fn-name (list 'quote fn-name)}]
                     (mu.fn/instrumented-fn-form error-context parsed))
             :cljs (mu.fn/deparameterized-fn-form parsed))))))
+
+(defmacro defn-
+  "Same as defn, but creates a private def."
+  [& [fn-name fn-tail]]
+  `(defn
+     ~(with-meta fn-name (assoc (meta fn-name) :private true))
+     ~@(rest fn-tail)))

--- a/src/metabase/util/malli/defn.clj
+++ b/src/metabase/util/malli/defn.clj
@@ -106,7 +106,7 @@
 
 (defmacro defn-
   "Same as defn, but creates a private def."
-  [& [fn-name fn-tail]]
+  [fn-name & fn-tail]
   `(defn
      ~(with-meta fn-name (assoc (meta fn-name) :private true))
-     ~@(rest fn-tail)))
+     ~@fn-tail))

--- a/test/metabase/util/malli/defn_test.clj
+++ b/test/metabase/util/malli/defn_test.clj
@@ -184,7 +184,10 @@
                            (catch java.lang.Exception error (throw (metabase.util.malli.fn/fixup-stacktrace error))))))))
                  expansion)))))))
 
-(mu/defn- private-foo :- :int [x] x)
+
+(mu/defn- private-foo :- :int
+  [x :- :int]
+  x)
 
 (deftest ^:parallel private-defn-test
   (testing "The defn- macro creates a private function"

--- a/test/metabase/util/malli/defn_test.clj
+++ b/test/metabase/util/malli/defn_test.clj
@@ -183,3 +183,9 @@
                            (clojure.core/->> (&f) (metabase.util.malli.fn/validate-output {:fn-name 'f} :int))
                            (catch java.lang.Exception error (throw (metabase.util.malli.fn/fixup-stacktrace error))))))))
                  expansion)))))))
+
+(mu/defn- private-foo :- :int [x] x)
+
+(deftest ^:parallel private-defn-test
+  (testing "The defn- macro creates a private function"
+    (is (true? (:private (meta #'private-foo))))))


### PR DESCRIPTION
Found myself reaching for this but it didn't exist so I figured I would try to add it. Just adds a private version of `mu/defn` called `mu/defn-`, implemented pretty much the same way as `clojure.core/defn-`