### PR TITLE
Gracefully handle ignored errors during sync

### DIFF
--- a/src/metabase/sync.clj
+++ b/src/metabase/sync.clj
@@ -34,6 +34,22 @@
      [:name       :string]
      [:steps      [:maybe [:sequential sync-util/StepNameWithMetadata]]]]]])
 
+(def ^:private phase->fn
+  {:metadata     sync-metadata/sync-db-metadata!
+   :analyze      analyze/analyze-db!
+   :field-values field-values/update-field-values!})
+
+(defn- scan-phases [scan]
+  (if (not= :full scan)
+    [:metadata]
+    [:metadata :analyze :field-values]))
+
+(defn- do-phase [phase database]
+  (let [f      (phase->fn phase)
+        result (f database)]
+    (when-not (instance? Throwable result)
+      (assoc result :name (name phase)))))
+
 (mu/defn sync-database! :- SyncDatabaseResults
   "Perform all the different sync operations synchronously for `database`.
 
@@ -49,10 +65,9 @@
     {:keys [scan], :or {scan :full}} :- [:maybe [:map
                                                  [:scan {:optional true} [:maybe [:enum :schema :full]]]]]]
    (sync-util/sync-operation :sync database (format "Sync %s" (sync-util/name-for-logging database))
-     (cond-> [(assoc (sync-metadata/sync-db-metadata! database) :name "metadata")]
-       (= scan :full)
-       (conj (assoc (analyze/analyze-db! database) :name "analyze")
-             (assoc (field-values/update-field-values! database) :name "field-values"))))))
+     (->> (scan-phases scan)
+          (keep #(do-phase % database))
+          vec))))
 
 (mu/defn sync-table!
   "Perform all the different sync operations synchronously for a given `table`. Since often called on a sequence of

--- a/src/metabase/sync.clj
+++ b/src/metabase/sync.clj
@@ -44,7 +44,7 @@
     [:metadata]
     [:metadata :analyze :field-values]))
 
-(defn- do-phase [phase database]
+(defn- do-phase! [phase database]
   (let [f      (phase->fn phase)
         result (f database)]
     (when-not (instance? Throwable result)
@@ -66,7 +66,7 @@
                                                  [:scan {:optional true} [:maybe [:enum :schema :full]]]]]]
    (sync-util/sync-operation :sync database (format "Sync %s" (sync-util/name-for-logging database))
      (->> (scan-phases scan)
-          (keep #(do-phase % database))
+          (keep #(do-phase! % database))
           vec))))
 
 (mu/defn sync-table!

--- a/src/metabase/sync.clj
+++ b/src/metabase/sync.clj
@@ -70,7 +70,8 @@
                                                  [:scan {:optional true} [:maybe [:enum :schema :full]]]]]]
    (sync-util/sync-operation :sync database (format "Sync %s" (sync-util/name-for-logging database))
      (->> (scan-phases scan)
-          (keep (partial do-phase! database))))))
+          (keep (partial do-phase! database))
+          (doall)))))
 
 (mu/defn sync-table!
   "Perform all the different sync operations synchronously for a given `table`. Since often called on a sequence of

--- a/src/metabase/sync.clj
+++ b/src/metabase/sync.clj
@@ -49,7 +49,7 @@
         result (f database)]
     (if (instance? Throwable result)
       ;; do nothing if we're configured to just move on.
-      (when-not (sync-util/*log-exceptions-and-continue?*)
+      (when-not sync-util/*log-exceptions-and-continue?*
         (throw result))
       (assoc result :name (name phase)))))
 
@@ -70,7 +70,7 @@
    (sync-util/sync-operation :sync database (format "Sync %s" (sync-util/name-for-logging database))
      (->> (scan-phases scan)
           (keep #(do-phase! % database))
-          vec))))
+          (take-while some?)))))
 
 (mu/defn sync-table!
   "Perform all the different sync operations synchronously for a given `table`. Since often called on a sequence of

--- a/src/metabase/sync.clj
+++ b/src/metabase/sync.clj
@@ -47,7 +47,10 @@
 (defn- do-phase! [phase database]
   (let [f      (phase->fn phase)
         result (f database)]
-    (when-not (instance? Throwable result)
+    (if (instance? Throwable result)
+      ;; do nothing if we're configured to just move on.
+      (when-not (sync-util/*log-exceptions-and-continue?*)
+        (throw result))
       (assoc result :name (name phase)))))
 
 (mu/defn sync-database! :- SyncDatabaseResults

--- a/test/metabase/sync_test.clj
+++ b/test/metabase/sync_test.clj
@@ -262,6 +262,21 @@
                 (is (= (expected-movie-table) movie))
                 (is (= (expected-studio-table) studio)))))))))
 
+(driver/register! ::sync-database-error-test)
+
+(defmethod driver/describe-database ::sync-database-error-test
+  [_driver _database]
+  (throw (Exception. "OOPS!")))
+
+(deftest sync-database!-error-test
+  (testing "Errors in sync-database! should be caught and handled correctly (#45848)"
+    (mt/with-temp [Database db {:engine ::sync-database-error-test}]
+      (binding [sync-util/*log-exceptions-and-continue?* true]
+        (let [results (sync/sync-database! db)]
+          (testing "Skips the metadata step"
+            (is (= ["analyze" "field-values"]
+                   (map :name results)))))))))
+
 ;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ;; !!                                                                                                               !!
 ;; !! HEY! Your tests probably don't belong in this namespace! Put them in one appropriate to the specific part of  !!


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/45948

### Description

When the `*log-exceptions-and-continue?*` option is set, each `sync-operation` will return any internal exceptions, rather than throwing them.

Unfortunately the `sync-database!` operation makes the assumption that each return value is a map, and so we will throw a type error in practice whenever any step has failed.

With this change, the higher level method will also swallow the errors.

I am not sure if this is the correct behavior, perhaps this will only serve to make flakes more subtle.