### PR TITLE
Tweak failure map size and test

### DIFF
--- a/src/metabase/query_analysis/failure_map.clj
+++ b/src/metabase/query_analysis/failure_map.clj
@@ -7,7 +7,7 @@
 
 (def ^:private ^ConcurrentHashMap cached-failures (ConcurrentHashMap.))
 
-(def ^:private max-size 10)
+(def ^:private max-size 10000)
 
 (def ^:private max-retries 2)
 

--- a/test/metabase/query_analysis/failure_map_test.clj
+++ b/test/metabase/query_analysis/failure_map_test.clj
@@ -9,6 +9,7 @@
   {:id (swap! id-generator inc) :dataset_query (rand)})
 
 (def ^:private max-retries @#'failure-map/max-retries)
+
 (def ^:private max-size @#'failure-map/max-size)
 
 (deftest failure-map-non-retryable-test
@@ -43,7 +44,8 @@
       (is (every? failure-map/non-retryable? random-cards)))
     (testing "But the number that we recall is bounded\n"
       (let [extra-card (random-card)]
-        (failure-map/track-failure! extra-card)
+        (dotimes [_ max-retries]
+          (failure-map/track-failure! extra-card))
         (is (false? (failure-map/non-retryable? extra-card)))
         (testing "... with replacement"
           (failure-map/track-success! (first random-cards))


### PR DESCRIPTION
### Description

Increase failure map size, and improve the test.

The map size had been set ridiculously slow to help with debugging, and I forgot to increase it again.

The test had toothless assertion - we needed to record a failure more times before it would block further retries.