### PR TITLE
Track queries with inactive tables

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/query_field_validation/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/query_field_validation/api.clj
@@ -41,12 +41,13 @@
                          [:in :card_id (map :id cards)]]})))
 
 (defn- inactive-errors [inactive-fields]
-  (reduce
-   (fn [acc {:keys [field table table_active]}]
-     (update acc (if table_active :inactive-fields :inactive-tables) conj
-             {:table table, :field field}))
-   {:inactive-fields []
-    :inactive-tables []}
+  (mapv
+   (fn [{:keys [field table table_active]}]
+     {:type  (if table_active
+               :inactive-field
+               :inactive-table)
+      :table table
+      :field field})
    inactive-fields))
 
 (defn- cards-with-inactive-fields

--- a/enterprise/backend/src/metabase_enterprise/query_field_validation/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/query_field_validation/api.clj
@@ -46,7 +46,7 @@
      (update acc (if table_active :inactive-fields :inactive-tables) conj
              {:table table, :field field}))
    {:inactive-fields []
-    :inactive_tables []}
+    :inactive-tables []}
    inactive-fields))
 
 (defn- cards-with-inactive-fields

--- a/enterprise/backend/src/metabase_enterprise/query_field_validation/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/query_field_validation/api.clj
@@ -25,6 +25,30 @@
                                       [:= :qf.field_id :f.id]
                                       [:= :f.active false]]])
 
+(defn- inactive-fields [cards]
+  (when (seq cards)
+    (t2/select :model/QueryField
+               {:select [:qf.card_id
+                         [:f.name :field]
+                         [:t.name :table]
+                         [:t.active :table_active]]
+                :from   [[(t2/table-name :model/QueryField) :qf]]
+                :join   [[(t2/table-name :model/Field) :f] [:= :f.id :qf.field_id]
+                         [(t2/table-name :model/Table) :t] [:= :t.id :f.table_id]]
+                :where  [:and
+                         [:= :qf.explicit_reference true]
+                         [:= :f.active false]
+                         [:in :card_id (map :id cards)]]})))
+
+(defn- inactive-errors [inactive-fields]
+  (reduce
+   (fn [acc {:keys [field table table_active]}]
+     (update acc (if table_active :inactive-fields :inactive-tables) conj
+             {:table table, :field field}))
+   {:inactive-fields []
+    :inactive_tables []}
+   inactive-fields))
+
 (defn- cards-with-inactive-fields
   [sort-column sort-direction offset limit]
   (let [sort-dir-kw           (keyword sort-direction)
@@ -59,22 +83,9 @@
                                :limit  limit
                                :offset offset)
         cards                 (t2/select :model/Card card-query)
-        card-id->query-fields (when (seq cards)
-                                (group-by :card_id (t2/select :model/QueryField
-                                                              {:select [:qf.* [:f.name :column_name] [:t.name :table_name]]
-                                                               :from   [[(t2/table-name :model/QueryField) :qf]]
-                                                               :join   [[(t2/table-name :model/Field) :f] [:= :f.id :qf.field_id]
-                                                                        [(t2/table-name :model/Table) :t] [:= :t.id :f.table_id]]
-                                                               :where  [:and
-                                                                        [:= :qf.explicit_reference true]
-                                                                        [:= :f.active false]
-                                                                        [:in :card_id (map :id cards)]]})))
-
+        id->inactive-fields   (group-by :card_id (inactive-fields cards))
         add-errors            (fn [{:keys [id] :as card}]
-                                (assoc-in card
-                                          [:errors :inactive-fields]
-                                          (for [{:keys [table_name column_name]} (card-id->query-fields id)]
-                                            {:table table_name :field column_name})))]
+                                (assoc card :errors (inactive-errors (id->inactive-fields id))))]
     (map add-errors (t2/hydrate cards :collection :creator))))
 
 (defn- invalid-card-count

--- a/enterprise/backend/test/metabase_enterprise/query_field_validation/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/query_field_validation/api_test.clj
@@ -162,18 +162,14 @@
                 :data
                 [{:id     card-1
                   :name   "A"
-                  :errors {:inactive-fields [{:field "FA"
-                                              :table "T1"}
-                                             {:field "FAB"
-                                              :table "T1"}]}}
+                  :errors [{:type "inactive-field", :table "T1", :field "FA"}
+                           {:type "inactive-field", :table "T1", :field "FAB"}]}
                  {:id     card-2
                   :name   "B"
-                  :errors {:inactive-fields [{:field "FB"
-                                              :table "T1"}]}}
+                  :errors [{:type "inactive-field", :table "T1", :field "FB"}]}
                  {:id     card-3
                   :name   "C"
-                  :errors {:inactive-tables [{:field "FC"
-                                              :table "T2"}]}}]}
+                  :errors [{:type "inactive-table", :table "T2", :field "FC"}]}]}
                (get!)
                [{:id   card-4
                  :name "D"}]))))
@@ -192,14 +188,11 @@
                 :data
                 [{:id     card-1
                   :name   "A"
-                  :errors {:inactive-fields [{:field "FA"
-                                              :table "T1"}
-                                             {:field "FAB"
-                                              :table "T1"}]}}
+                  :errors [{:type "inactive-field", :table "T1", :field "FA"}
+                           {:type "inactive-field", :table "T1", :field "FAB"}]}
                  {:id     card-2
                   :name   "B"
-                  :errors {:inactive-fields [{:field "FB"
-                                              :table "T1"}]}}]}
+                  :errors [{:type "inactive-field", :table "T1", :field "FB"}]}]}
                (get! {:limit 2})
                [{:id   card-3
                  :name "C"}
@@ -211,8 +204,7 @@
                 :data
                 [{:id     card-3
                   :name   "C"
-                  :errors {:inactive-tables [{:field "FC"
-                                              :table "T2"}]}}]}
+                  :errors [{:type "inactive-table", :table "T2", :field "FC"}]}]}
                (get! {:limit 1 :offset 2})
                [{:id   card-1
                  :name "A"}

--- a/enterprise/backend/test/metabase_enterprise/query_field_validation/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/query_field_validation/api_test.clj
@@ -11,7 +11,8 @@
 
 (defn- do-with-test-setup [f]
   (query-analysis/without-analysis
-   (t2.with-temp/with-temp [:model/Table      {table  :id}   {:name "T"}
+   (t2.with-temp/with-temp [:model/Table      {table-1 :id}  {:name "T1"}
+                            :model/Table      {table-2 :id}  {:name "T2" :active false}
                             ;; no coll-1; its card is in the root collection
                             :model/Collection {coll-2 :id}   {:name "ZZY"}
                             :model/Collection {coll-3 :id}   {:name "ZZZ"}
@@ -21,16 +22,16 @@
                             :model/Card       {card-4 :id}   {:name "D"}
                             :model/Field      {field-1 :id}  {:active   false
                                                               :name     "FA"
-                                                              :table_id table}
+                                                              :table_id table-1}
                             :model/Field      {field-1b :id} {:active   false
                                                               :name     "FAB"
-                                                              :table_id table}
+                                                              :table_id table-1}
                             :model/Field      {field-2 :id}  {:active   false
                                                               :name     "FB"
-                                                              :table_id table}
+                                                              :table_id table-1}
                             :model/Field      {field-3 :id}  {:active   false
                                                               :name     "FC"
-                                                              :table_id table}
+                                                              :table_id table-2}
                             ;; QFs not to include:
                             ;; - Field is still active
                             :model/QueryField {}             {:card_id  card-1
@@ -162,17 +163,17 @@
                 [{:id     card-1
                   :name   "A"
                   :errors {:inactive-fields [{:field "FA"
-                                              :table "T"}
+                                              :table "T1"}
                                              {:field "FAB"
-                                              :table "T"}]}}
+                                              :table "T1"}]}}
                  {:id     card-2
                   :name   "B"
                   :errors {:inactive-fields [{:field "FB"
-                                              :table "T"}]}}
+                                              :table "T1"}]}}
                  {:id     card-3
                   :name   "C"
-                  :errors {:inactive-fields [{:field "FC"
-                                              :table "T"}]}}]}
+                  :errors {:inactive-tables [{:field "FC"
+                                              :table "T2"}]}}]}
                (get!)
                [{:id   card-4
                  :name "D"}]))))
@@ -192,13 +193,13 @@
                 [{:id     card-1
                   :name   "A"
                   :errors {:inactive-fields [{:field "FA"
-                                              :table "T"}
+                                              :table "T1"}
                                              {:field "FAB"
-                                              :table "T"}]}}
+                                              :table "T1"}]}}
                  {:id     card-2
                   :name   "B"
                   :errors {:inactive-fields [{:field "FB"
-                                              :table "T"}]}}]}
+                                              :table "T1"}]}}]}
                (get! {:limit 2})
                [{:id   card-3
                  :name "C"}
@@ -210,8 +211,8 @@
                 :data
                 [{:id     card-3
                   :name   "C"
-                  :errors {:inactive-fields [{:field "FC"
-                                              :table "T"}]}}]}
+                  :errors {:inactive-tables [{:field "FC"
+                                              :table "T2"}]}}]}
                (get! {:limit 1 :offset 2})
                [{:id   card-1
                  :name "A"}


### PR DESCRIPTION
### Description

This change distinguishes between references to columns that are inactive within active tables, and those that reference tables that are themselves inactive.

This also flattens the errors so that it's a bit less of faff to group them.