### PR TITLE
Fix the (object detail) flake for repro 39477

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
@@ -101,30 +101,18 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
             alias: "Products",
           },
         ],
-        limit: 5,
+        limit: 2,
       },
     };
 
     createQuestion(questionDetails, { visitQuestion: true });
+    cy.findByTestId("question-row-count").should("have.text", "Showing 2 rows");
 
-    cy.log("check click on 1st row");
-
-    cy.get("[data-testid=cell-data]").contains("37.65").realHover();
-    cy.findByTestId("detail-shortcut").findByRole("button").click();
-
+    cy.log("Check object details for the first row");
+    cy.findAllByTestId("detail-shortcut").first().click();
     cy.findByTestId("object-detail").within(() => {
-      cy.get("h2").should("contain", "Order").should("contain", 1);
-      cy.findByTestId("object-detail-close-button").click();
-    });
-
-    cy.log("check click on 3rd row");
-
-    cy.get("[data-testid=cell-data]").contains("52.72").realHover();
-    cy.findByTestId("detail-shortcut").findByRole("button").click();
-
-    cy.findByTestId("object-detail").within(() => {
-      cy.get("h2").should("contain", "Order").should("contain", 3);
-      cy.findByText("52.72");
+      cy.findByRole("heading").should("contain", "Order").and("contain", 1);
+      cy.findByText("37.65").should("be.visible");
     });
   });
 

--- a/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
@@ -109,10 +109,20 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
     cy.findByTestId("question-row-count").should("have.text", "Showing 2 rows");
 
     cy.log("Check object details for the first row");
-    cy.findAllByTestId("detail-shortcut").first().click();
+    cy.findAllByTestId("cell-data").filter(":contains(37.65)").realHover();
+    cy.get("[data-show-detail-rowindex='0']").click();
     cy.findByTestId("object-detail").within(() => {
       cy.findByRole("heading").should("contain", "Order").and("contain", 1);
       cy.findByText("37.65").should("be.visible");
+      cy.findByTestId("object-detail-close-button").click();
+    });
+
+    cy.log("Check object details for the second row");
+    cy.findAllByTestId("cell-data").filter(":contains(110.93)").realHover();
+    cy.get("[data-show-detail-rowindex='1']").click();
+    cy.findByTestId("object-detail").within(() => {
+      cy.findByRole("heading").should("contain", "Order").and("contain", 2);
+      cy.findByText("110.93").should("be.visible");
     });
   });
 


### PR DESCRIPTION
### What does this PR accomplish?
This PR fixes the E2E flake (repro for #39477).

The example of a previous failure:
https://github.com/metabase/metabase/actions/runs/10055141486/job/27792441862#step:11:471
![scenarios  question  object details -- shows correct object detail card for questions with joins after clicking on view details (metabase#39477) (failed) (attempt 2)](https://github.com/user-attachments/assets/9142621c-9ae1-43b0-83b6-c26ec1122a01)

### Explanation
It misclicked.
It was supposed to click on the third row, but it clicked on the fourth one instead.

I am not entirely sure what's the root cause, but we're using a more specific selector in this updated test version. It should make sure that we click on an object detail trigger for that specific row.

### Stress-test
50/50 ✅ https://github.com/metabase/metabase/actions/runs/10057774847