### PR TITLE
ci: Fix the native snippet flake

### DIFF
--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -35,7 +35,10 @@ export function openNativeEditor({
 
   databaseName && cy.findByText(databaseName).click();
 
+  // We are first loading databases to see if we should show the
+  // database selector or simply display the previously selected database
   cy.findAllByTestId("loading-indicator").should("not.exist");
+
   return focusNativeEditor().as(alias);
 }
 

--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -43,11 +43,13 @@ export function openNativeEditor({
 }
 
 export function focusNativeEditor() {
-  return cy
-    .findByTestId("native-query-editor")
+  cy.findByTestId("native-query-editor")
     .should("be.visible")
     .should("have.class", "ace_editor")
-    .click()
+    .click();
+
+  return cy
+    .findByTestId("native-query-editor")
     .should("have.class", "ace_focus");
 }
 

--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -35,6 +35,7 @@ export function openNativeEditor({
 
   databaseName && cy.findByText(databaseName).click();
 
+  cy.findAllByTestId("loading-indicator").should("not.exist");
   return focusNativeEditor().as(alias);
 }
 

--- a/e2e/test/scenarios/native/snippets.cy.spec.js
+++ b/e2e/test/scenarios/native/snippets.cy.spec.js
@@ -31,26 +31,26 @@ describe("scenarios > question > snippets", () => {
   });
 
   it("should let you create and use a snippet", () => {
+    cy.log("Type a query and highlight some of the text");
     openNativeEditor().type(
-      // Type a query and highlight some of the text
       "select 'stuff'" + "{shift}{leftarrow}".repeat("'stuff'".length),
     );
 
-    // Add a snippet of that text
-    cy.icon("snippet").click();
+    cy.log("Add a snippet of that text");
+    cy.findByTestId("native-query-editor-sidebar").icon("snippet").click();
     cy.findByTestId("sidebar-content").findByText("Create a snippet").click();
 
     modal().within(() => {
       cy.findByLabelText("Give your snippet a name").type("stuff-snippet");
-      cy.findByText("Save").click();
+      cy.button("Save").click();
     });
 
-    // SQL editor should get updated automatically
-    cy.get("@editor").contains("select {{snippet: stuff-snippet}}");
+    cy.log("SQL editor should get updated automatically");
+    cy.get("@editor").should("contain", "select {{snippet: stuff-snippet}}");
 
-    // Run the query and check the value
+    cy.log("Run the query and check the value");
     cy.findByTestId("native-query-editor-container").icon("play").click();
-    cy.findByTestId("scalar-value").contains("stuff");
+    cy.findByTestId("scalar-value").should("have.text", "stuff");
   });
 
   it("should let you edit snippet", () => {


### PR DESCRIPTION
### What does this PR accomplish?
It fixes the native snippet E2E flake by waiting for the ace editor to fully render.

The example of a failure.
Cypress starts typing, then the UI re-renders and it loses the first "s", so the editor only sees "elect {{snippet: stuff-snippet}}".
![scenarios  question  snippets -- should let you create and use a snippet burning 35 of 50 (failed)](https://github.com/user-attachments/assets/c6578c1b-3334-42c3-860d-e003e1d65d41)

### Explanation
We briefly display the loading state for databases to determine whether or not to display the database dropdown selector. Furthermore, if there's only one database or if we remembered the last selected database in metabase settings, the UI will still flicker ever so slightly between the data selector and the "chosen/selected" database being directly shown in the native editor.

This all causes ace editor to re-render.
It's possible that the cause should be fixed at the source but for the sake of the expediency, this PR puts some guards in place for the related native editor helpers. These guards will not get in the way even if we fix the FE source code in the future.

### Stress-test
- 50/50 ✅ https://github.com/metabase/metabase/actions/runs/10057185526
- 100/100 ✅ https://github.com/metabase/metabase/actions/runs/10057283973