### PR TITLE
test: wait for element to be rendered in flaky test

### DIFF
--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.unit.spec.tsx
@@ -6,7 +6,7 @@ import {
   setupSearchEndpoints,
 } from "__support__/server-mocks";
 import { createMockEntitiesState } from "__support__/store";
-import { renderWithProviders, screen } from "__support__/ui";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
 import { checkNotNull } from "metabase/lib/types";
 import { getMetadata } from "metabase/selectors/metadata";
 import type { TemplateTag } from "metabase-types/api";
@@ -130,7 +130,9 @@ describe("TagEditorParam", () => {
       });
       const { setTemplateTag } = setup({ tag });
 
-      await userEvent.click(await screen.findByText("People"));
+      await waitForElementsToLoad("People");
+
+      await userEvent.click(screen.getByText("People"));
       await userEvent.click(await screen.findByText("Source"));
 
       expect(setTemplateTag).toHaveBeenCalledWith({
@@ -149,7 +151,9 @@ describe("TagEditorParam", () => {
       });
       const { setTemplateTag } = setup({ tag });
 
-      await userEvent.click(await screen.findByText("People"));
+      await waitForElementsToLoad("People");
+
+      await userEvent.click(screen.getByText("People"));
       await userEvent.click(await screen.findByText("Name"));
 
       expect(setTemplateTag).toHaveBeenCalledWith({
@@ -168,7 +172,9 @@ describe("TagEditorParam", () => {
       });
       const { setTemplateTag } = setup({ tag });
 
-      await userEvent.click(await screen.findByText("Orders"));
+      await waitForElementsToLoad("Orders");
+
+      await userEvent.click(screen.getByText("Orders"));
       await userEvent.click(await screen.findByText("Quantity"));
 
       expect(setTemplateTag).toHaveBeenCalledWith({
@@ -187,7 +193,9 @@ describe("TagEditorParam", () => {
       });
       const { setTemplateTag } = setup({ tag });
 
-      await userEvent.click(await screen.findByText("Reviews"));
+      await waitForElementsToLoad("Reviews");
+
+      await userEvent.click(screen.getByText("Reviews"));
       await userEvent.click(await screen.findByText("Rating"));
 
       expect(setTemplateTag).toHaveBeenCalledWith({
@@ -206,7 +214,9 @@ describe("TagEditorParam", () => {
       });
       const { setTemplateTag } = setup({ tag });
 
-      await userEvent.click(await screen.findByText("Name"));
+      await waitForElementsToLoad("Name");
+
+      await userEvent.click(screen.getByText("Name"));
       await userEvent.click(await screen.findByText("Address"));
 
       expect(setTemplateTag).toHaveBeenCalledWith({
@@ -312,3 +322,12 @@ describe("TagEditorParam", () => {
     });
   });
 });
+
+async function waitForElementsToLoad(text: string) {
+  await waitFor(
+    () => {
+      expect(screen.getByText(text)).toBeInTheDocument();
+    },
+    { timeout: 10000 },
+  );
+}


### PR DESCRIPTION
### Description

[test is flaky](https://metaboat.slack.com/archives/C5XHN8GLW/p1721728505717639)

the root cause of flakiness seems in the number of re-renderings after "setup" function is called in test - I managed to get at least 3 renders, so we have to wait for elements to appear in the DOM longer. 

<img width="1515" alt="image" src="https://github.com/user-attachments/assets/06e3c7f6-aa75-4080-b5a0-0f97250997b1">

all 4 cases were updated to wait up to 10s (plus a bonus test which didn't fail _yet_)


The simplest solution I found is to wait longer, stress test passes on master, so it's not that easy to catch this flake https://github.com/metabase/metabase/actions/runs/10058675989/job/27802288485

### How to verify

CI is green

- stress ✅ https://github.com/metabase/metabase/actions/runs/10076378830/job/27856627057