### PR TITLE
dx: make fe stress test faster

### DIFF
--- a/.github/workflows/frontend-unit-test-stress-test-flake-fix.yml
+++ b/.github/workflows/frontend-unit-test-stress-test-flake-fix.yml
@@ -41,10 +41,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
-      # - name: Prepare back-end environment
-      #   uses: ./.github/actions/prepare-backend
-      #   with:
-      #     m2-cache-key: "cljs"
+      - name: Prepare back-end environment
+        uses: ./.github/actions/prepare-backend
+        with:
+          m2-cache-key: "cljs"
       - name: Build cljs
         run: yarn build:cljs
       - name: Stress-test ${{ github.event.inputs.spec }} ${{ github.event.inputs.burn_in }} times

--- a/.github/workflows/frontend-unit-test-stress-test-flake-fix.yml
+++ b/.github/workflows/frontend-unit-test-stress-test-flake-fix.yml
@@ -4,15 +4,15 @@ on:
   workflow_dispatch:
     inputs:
       spec:
-        description: 'Relative path of the target spec'
+        description: "Relative path of the target spec"
         type: string
         required: true
       burn_in:
-        description: 'Number of times to run the test (e.g. 20)'
+        description: "Number of times to run the test (e.g. 20)"
         type: string
         required: true
       grep:
-        description: 'Grep and filter tests to run in isolation'
+        description: "Grep and filter tests to run in isolation"
         type: string
         required: false
 
@@ -41,14 +41,16 @@ jobs:
       - uses: actions/checkout@v4
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
-      - name: Prepare back-end environment
-        uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: "cljs"
+      # - name: Prepare back-end environment
+      #   uses: ./.github/actions/prepare-backend
+      #   with:
+      #     m2-cache-key: "cljs"
+      - name: Build cljs
+        run: yarn build:cljs
       - name: Stress-test ${{ github.event.inputs.spec }} ${{ github.event.inputs.burn_in }} times
         run: |
           for i in {1..${{ github.event.inputs.burn_in }}}; do
-            yarn test-unit \
+            yarn test-unit-keep-cljs \
               --testPathPattern '${{ github.event.inputs.spec }}' \
               --testNamePattern '${{ github.event.inputs.grep }}'
             if [[ "$?" != 0 ]]; then

--- a/.github/workflows/frontend-unit-test-stress-test-flake-fix.yml
+++ b/.github/workflows/frontend-unit-test-stress-test-flake-fix.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Stress-test ${{ github.event.inputs.spec }} ${{ github.event.inputs.burn_in }} times
         run: |
           for i in {1..${{ github.event.inputs.burn_in }}}; do
-            yarn test-unit-keep-cljs \
+            yarn jest --runInBand --ci --silent --no-cache \
               --testPathPattern '${{ github.event.inputs.spec }}' \
               --testNamePattern '${{ github.event.inputs.grep }}'
             if [[ "$?" != 0 ]]; then


### PR DESCRIPTION
### Description

Before we used to rebuild cljs files for every jest test run, now we build cljs files once, besides that in this PR we clean up a command to run jest and disable jest cache between runs

an example of the job https://github.com/metabase/metabase/actions/runs/10058675989/job/27802288485


### After

<img width="983" alt="image" src="https://github.com/user-attachments/assets/d7c6dc68-1836-4621-bfbb-c6a6fd6e0e3c">
