### PR TITLE
Set validCheckSum for permissions migration to ANY

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -7070,7 +7070,7 @@ databaseChangeLog:
       id: v50.2024-02-26T22:15:54
       author: noahmoss
       comment: New `view-data` permission
-      validCheckSum: 9:68d8f2fdf00395a9e614b0db8a2ec7bb
+      validCheckSum: ANY
       changes:
         - sqlFile:
             dbms: postgresql,h2


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/45967

The `validCheckSum` was for the Postgres version, but the MySQL version has a slightly different checkSum