### PR TITLE
Rename feature to query-reference-validation

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -798,7 +798,7 @@
    metabase-enterprise.serialization.test-util/with-world                       macros.metabase-enterprise.serialization.test-util/with-world
    metabase-enterprise.test/with-gtaps!                                         macros.metabase-enterprise.sandbox.test-util/with-gtaps!
    metabase-enterprise.advanced-permissions.api.util-test/with-impersonations!  macros.metabase-enterprise.advanced-permissions.api.util-test/with-impersonations!
-   metabase-enterprise.query-field-validation.api-test/with-test-setup          macros.metabase-enterprise.query-field-validation.api-test/with-test-setup
+   metabase-enterprise.query-reference-validation.api-test/with-test-setup      macros.metabase-enterprise.query-reference-validation.api-test/with-test-setup
    metabase.api.card-test/with-ordered-items                                    macros.metabase.api.card-test/with-ordered-items
    metabase.api.collection-test/with-collection-hierarchy                       macros.metabase.api.collection-test/with-collection-hierarchy
    metabase.api.collection-test/with-some-children-of-collection                macros.metabase.api.collection-test/with-some-children-of-collection

--- a/.clj-kondo/macros/metabase_enterprise/query_reference_validation/api_test.clj
+++ b/.clj-kondo/macros/metabase_enterprise/query_reference_validation/api_test.clj
@@ -1,4 +1,4 @@
-(ns macros.metabase-enterprise.query-field-validation.api-test
+(ns macros.metabase-enterprise.query-reference-validation.api-test
   (:require [macros.common]))
 
 (defmacro with-test-setup [& body]

--- a/enterprise/backend/src/metabase_enterprise/api/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/api/routes.clj
@@ -14,7 +14,7 @@
    [metabase-enterprise.content-verification.api.routes
     :as content-verification]
    [metabase-enterprise.llm.api :as llm.api]
-   [metabase-enterprise.query-field-validation.api :as api.query-field-validation]
+   [metabase-enterprise.query-reference-validation.api :as api.query-reference-validation]
    [metabase-enterprise.sandbox.api.routes :as sandbox]
    [metabase-enterprise.scim.routes :as scim]
    [metabase-enterprise.serialization.api :as api.serialization]
@@ -55,8 +55,8 @@
     "/serialization" []
     (ee.api.common/+require-premium-feature :serialization (deferred-tru "Serialization") api.serialization/routes))
    (context
-    "/query-field-validation" []
-     (ee.api.common/+require-premium-feature :query-field-validation (deferred-tru "Query Field Validation") api.query-field-validation/routes))
+    "/query-reference-validation" []
+     (ee.api.common/+require-premium-feature :query-reference-validation (deferred-tru "Query Reference Validation") api.query-reference-validation/routes))
    (context
      "/upload-management" []
      (ee.api.common/+require-premium-feature :upload-management (deferred-tru "Upload Management") api.uploads/routes))))

--- a/enterprise/backend/src/metabase_enterprise/query_reference_validation/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/query_reference_validation/api.clj
@@ -1,4 +1,4 @@
-(ns metabase-enterprise.query-field-validation.api
+(ns metabase-enterprise.query-reference-validation.api
   (:require
    [compojure.core :refer [GET]]
    [medley.core :as m]

--- a/enterprise/backend/test/metabase_enterprise/query_reference_validation/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/query_reference_validation/api_test.clj
@@ -175,7 +175,7 @@
                  :name "D"}]))))
   (testing "It requires the premium feature"
     (mt/with-premium-features #{}
-      (is (= (str "Query Field Validation is a paid feature not currently available to your instance. Please upgrade to"
+      (is (= (str "Query Reference Validation is a paid feature not currently available to your instance. Please upgrade to"
                   " use it. Learn more at metabase.com/upgrade/")
              (mt/user-http-request :crowberto :get 402 url))))))
 

--- a/enterprise/backend/test/metabase_enterprise/query_reference_validation/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/query_reference_validation/api_test.clj
@@ -1,4 +1,4 @@
-(ns metabase-enterprise.query-field-validation.api-test
+(ns metabase-enterprise.query-reference-validation.api-test
   (:require
    [clojure.set :as set]
    [clojure.string :as str]
@@ -49,7 +49,7 @@
                                                               :field_id field-2}
                             :model/QueryField {qf-3 :id}     {:card_id  card-3
                                                               :field_id field-3}]
-     (mt/with-premium-features #{:query-field-validation}
+     (mt/with-premium-features #{:query-reference-validation}
        (mt/call-with-map-params f [card-1 card-2 card-3 card-4 qf-1 qf-1b qf-2 qf-3])))))
 
 (defmacro ^:private with-test-setup
@@ -63,7 +63,7 @@
     (mt/with-anaphora [qf-1 qf-1b qf-2 qf-3 card-1 card-2 card-3 card-4]
       ~@body)))
 
-(def ^:private url "ee/query-field-validation/invalid-cards")
+(def ^:private url "ee/query-reference-validation/invalid-cards")
 
 (defn- get!
   ([] (get! {}))
@@ -242,6 +242,6 @@
                             "nullable enum of")))))
 
 (deftest is-admin-test
-  (mt/with-premium-features #{:query-field-validation}
+  (mt/with-premium-features #{:query-reference-validation}
     (testing "The endpoint is unavailable for normal users"
       (is (mt/user-http-request :rasta :get 403 url)))))

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -187,7 +187,7 @@
   "Conditionally add a `:common_name` key to `user` by combining their first and last names, or using their email if names are `nil`.
   The key will only be added if `user` contains the required keys to derive it correctly."
   [{:keys [first_name last_name email], :as user}]
-  ;; This logic is replicated in SQL in metabase-enterprise.query-field-validation.api. If the below logic changes,
+  ;; This logic is replicated in SQL in [[metabase-enterprise.query-reference.api]]. If the below logic changes,
   ;; please update the EE ns as well.
   (let [common-name (if (or first_name last_name)
                       (str/trim (str first_name " " last_name))

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -187,7 +187,7 @@
   "Conditionally add a `:common_name` key to `user` by combining their first and last names, or using their email if names are `nil`.
   The key will only be added if `user` contains the required keys to derive it correctly."
   [{:keys [first_name last_name email], :as user}]
-  ;; This logic is replicated in SQL in [[metabase-enterprise.query-reference.api]]. If the below logic changes,
+  ;; This logic is replicated in SQL in [[metabase-enterprise.query-reference-validation.api]]. If the below logic changes,
   ;; please update the EE ns as well.
   (let [common-name (if (or first_name last_name)
                       (str/trim (str first_name " " last_name))

--- a/src/metabase/public_settings/premium_features.clj
+++ b/src/metabase/public_settings/premium_features.clj
@@ -472,9 +472,9 @@
   "Enable automatic descriptions of questions and dashboards by LLMs?"
   :llm-autodescription)
 
-(define-premium-feature ^{:added "0.51.0"} enable-query-field-validation?
+(define-premium-feature ^{:added "0.51.0"} enable-query-reference-validation?
   "Enable the Query Validator Tool?"
-  :query-field-validation)
+  :query-reference-validation)
 
 (define-premium-feature enable-upload-management?
   "Should we allow admins to clean up tables created from uploads?"


### PR DESCRIPTION
### Description

Since query identifiers can reference more than just tables, it is prudent to rename this feature before it goes out into the world.
