### PR TITLE
Don't trigger onChange when create dialog is open

### DIFF
--- a/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPickerModal.tsx
+++ b/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPickerModal.tsx
@@ -133,7 +133,7 @@ export const DashboardPickerModal = ({
       <EntityPickerModal
         title={title}
         onItemSelect={handleItemSelect}
-        canSelectItem={canSelectItem(selectedItem)}
+        canSelectItem={!isCreateDialogOpen && canSelectItem(selectedItem)}
         onConfirm={handleConfirm}
         onClose={onClose}
         selectedItem={selectedItem}

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
@@ -279,13 +279,15 @@ const setup = async ({
 
   fetchMock.get(`path:/api/user/recipients`, { data: [] });
 
+  const onChangeLocation = jest.fn();
+
   renderWithProviders(
     <Route
       path="/"
       component={() => (
         <AddToDashSelectDashModal
           card={card}
-          onChangeLocation={() => undefined}
+          onChangeLocation={onChangeLocation}
           onClose={() => undefined}
         />
       )}
@@ -301,6 +303,8 @@ const setup = async ({
   if (waitForContent) {
     await waitForLoaderToBeRemoved();
   }
+
+  return { onChangeLocation };
 };
 
 describe("AddToDashSelectDashModal", () => {
@@ -586,10 +590,8 @@ describe("AddToDashSelectDashModal", () => {
   });
 
   describe('"Create a new dashboard" option', () => {
-    beforeEach(async () => {
-      await setup();
-    });
     it('should render "Create a new dashboard" option', async () => {
+      await setup();
       expect(
         await screen.findByRole("button", {
           name: /Create a new dashboard/,
@@ -598,6 +600,12 @@ describe("AddToDashSelectDashModal", () => {
     });
 
     it("should show the create dashboard dialog", async () => {
+      // Second part of test requires a value to be "selected"
+      const { onChangeLocation } = await setup({
+        dashboard: DASHBOARD_AT_ROOT,
+        mostRecentlyViewedDashboard: DASHBOARD_AT_ROOT,
+      });
+
       await userEvent.click(
         await screen.findByRole("button", {
           name: /Create a new dashboard/,
@@ -610,6 +618,11 @@ describe("AddToDashSelectDashModal", () => {
       expect(
         await screen.findByTestId("create-dashboard-on-the-go"),
       ).toBeInTheDocument();
+
+      // Pressing enter when the create dialog is open should not trigger handleConfirm (metabase#45360);
+      await userEvent.keyboard("{enter}");
+
+      expect(onChangeLocation).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/45360

### Description
When the create dashboard dialog is open on the dashboard picker and you press enter, the button bar was picking up the keypress and calling `onConfirm` with the currently selected value. This change adds another condition to `canConfirm` so that this handler won't fire when the create dialog is open (we handle this the same way already in the collection pciker)

### How to verify
1. Go to any question
2. Menu -> Add to dashboard
3. Select a dashboard, then click "Create a new dashboard"
4. press enter. Nothing should happen. If you fill out the dashboard name and press enter, it should create the dashboard and preselect it in the modal.


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
