### PR TITLE
Decouple query analysis models from validation API

### DIFF
--- a/src/metabase/models/query_field.clj
+++ b/src/metabase/models/query_field.clj
@@ -9,6 +9,52 @@
 (doto :model/QueryField
   (derive :metabase/model))
 
+(def ^:private reference-error-joins
+  [[(t2/table-name :model/QueryField) :qf]
+   [:and
+    [:= :qf.card_id :c.id]
+    [:= :qf.explicit_reference true]]
+
+   [(t2/table-name :model/Field) :f]
+   [:and
+    [:= :qf.field_id :f.id]
+    [:= :f.active false]]])
+
+(defn cards-with-reference-errors
+  "Given some HoneySQL querty map with :model/Card bound as :c, restrict this query to only return cards
+  with invalid references.
+  For now this only handles inactive references, but in future it will also handle unknown references too."
+  [card-query-map]
+  ;; NOTE: We anticipate a schema change to support missing references that will result in left-joins and
+  ;; where clauses being appended as well.
+  (update card-query-map :join concat reference-error-joins))
+
+(defn reference-errors
+  "Given a seq of cards, return a map of card-id => reference errors"
+  [cards]
+  (when (seq cards)
+    (->> (t2/select :model/QueryField
+                    {:select [:qf.card_id
+                              [:f.name :field]
+                              [:t.name :table]
+                              [:t.active :table_active]]
+                     :from   [[(t2/table-name :model/QueryField) :qf]]
+                     :join   [[(t2/table-name :model/Field) :f] [:= :f.id :qf.field_id]
+                              [(t2/table-name :model/Table) :t] [:= :t.id :f.table_id]]
+                     :where  [:and
+                              [:= :qf.explicit_reference true]
+                              [:= :f.active false]
+                              [:in :card_id (map :id cards)]]})
+         (map (fn [{:keys [card_id table field table_active]}]
+                [card_id {:type  (if table_active
+                                   :inactive-field
+                                   :inactive-table)
+                          :table table
+                          :field field}]))
+         (reduce (fn [acc [id error]]
+                   (update acc id u/conjv error))
+                 {}))))
+
 ;;; Updating QueryField from card
 
 (defn update-query-fields-for-card!

--- a/src/metabase/models/query_field.clj
+++ b/src/metabase/models/query_field.clj
@@ -21,7 +21,7 @@
     [:= :f.active false]]])
 
 (defn cards-with-reference-errors
-  "Given some HoneySQL querty map with :model/Card bound as :c, restrict this query to only return cards
+  "Given some HoneySQL query map with :model/Card bound as :c, restrict this query to only return cards
   with invalid references.
   For now this only handles inactive references, but in future it will also handle unknown references too."
   [card-query-map]


### PR DESCRIPTION
### Description

This is a small refactoring to encapsulate the way that query analysis is stored, such that the Query Reference Validation API can be independently maintained. This should help to enforce a better module boundary between the relevant teams.