### PR TITLE
Fix document title when opening a multi-series question from dashboard

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
@@ -43,12 +43,15 @@ import {
 } from "e2e/support/helpers";
 import { createSegment } from "e2e/support/helpers/e2e-table-metadata-helpers";
 import { DASHBOARD_SLOW_TIMEOUT } from "metabase/dashboard/constants";
-import { createMockDashboardCard } from "metabase-types/api/mocks";
+import {
+  createMockDashboardCard,
+  createMockParameter,
+} from "metabase-types/api/mocks";
 
 const { SAMPLE_DATABASE } = require("e2e/support/cypress_sample_database");
 
 const { ALL_USERS_GROUP, COLLECTION_GROUP } = USER_GROUPS;
-const { ORDERS_ID, ORDERS, PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;
+const { ORDERS_ID, ORDERS, PRODUCTS_ID, PRODUCTS, PEOPLE } = SAMPLE_DATABASE;
 
 describe("issue 12578", () => {
   const ORDERS_QUESTION = {
@@ -1409,6 +1412,91 @@ describe("issue 40695", () => {
       cy.findByText("Orders").should("exist");
       cy.findByText("Orders, Count").should("not.exist");
       getDashboardCards().should("have.length", 1);
+    });
+  });
+});
+
+describe("issue 42165", () => {
+  const peopleSourceFieldRef = [
+    "field",
+    PEOPLE.SOURCE,
+    { "base-type": "type/Text", "source-field": ORDERS.USER_ID },
+  ];
+  const ordersCreatedAtFieldRef = [
+    "field",
+    ORDERS.CREATED_AT,
+    { "base-type": "type/DateTime", "temporal-unit": "month" },
+  ];
+
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
+      "dashcardQuery",
+    );
+
+    cy.createDashboardWithQuestions({
+      dashboardDetails: {
+        parameters: [
+          createMockParameter({
+            id: "param-1",
+            name: "Date",
+            slug: "date",
+            type: "date/all-options",
+          }),
+        ],
+      },
+      questions: [
+        {
+          name: "fooBarQuestion",
+          display: "bar",
+          query: {
+            aggregation: [["count"]],
+            breakout: [peopleSourceFieldRef, ordersCreatedAtFieldRef],
+            "source-table": ORDERS_ID,
+          },
+        },
+      ],
+    }).then(({ dashboard: _dashboard }) => {
+      cy.request("GET", `/api/dashboard/${_dashboard.id}`).then(
+        ({ body: dashboard }) => {
+          const [dashcard] = dashboard.dashcards;
+          const [parameter] = dashboard.parameters;
+          cy.request("PUT", `/api/dashboard/${dashboard.id}`, {
+            dashcards: [
+              {
+                ...dashcard,
+                parameter_mappings: [
+                  {
+                    card_id: dashcard.card_id,
+                    parameter_id: parameter.id,
+                    target: ["dimension", ordersCreatedAtFieldRef],
+                  },
+                ],
+              },
+            ],
+          }).then(() => {
+            cy.wrap(_dashboard.id).as("dashboardId");
+          });
+        },
+      );
+    });
+  });
+
+  it("should use card name instead of series names when navigating to QB from dashcard title", () => {
+    cy.get("@dashboardId").then(dashboardId => {
+      visitDashboard(dashboardId);
+
+      filterWidget().click();
+      popover().findByText("Last 30 Days").click();
+      cy.wait("@dashcardQuery");
+
+      getDashboardCard(0).findByText("fooBarQuestion").click();
+
+      cy.wait("@dataset");
+      cy.title().should("eq", "fooBarQuestion · Metabase");
     });
   });
 });

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
@@ -98,7 +98,9 @@ function _CartesianChart(props: VisualizationProps) {
           icon={headerIcon}
           actionButtons={actionButtons}
           getHref={canSelectTitle ? getHref : undefined}
-          onSelectTitle={canSelectTitle ? onOpenQuestion : undefined}
+          onSelectTitle={
+            canSelectTitle ? () => onOpenQuestion(card.id) : undefined
+          }
           width={outerWidth}
         />
       )}


### PR DESCRIPTION
Closes #42165

Fixes an issue when opening a multi-series question from a dashboard, the document title becomes the name of the first series instead of the question name. This happened because [`onOpenQuestion` handler](https://github.com/metabase/metabase/blob/4c1964db7ecd89e5901618d3983bbe4db133c85e/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts#L60) wasn't receiving a proper `cardId` argument and was using an unexpected card object from a transformed series.

### To verify

1. New > Question > Sample Database > Orders > Count by PEOPLE.SOURCE and ORDERS.CREATED_AT > Save
2. Create a dashboard with the question from step 1, add a date parameter and connect it to ORDERS.CREATED_AT
3. Click the dashboard card name
4. Ensure the document.title uses the question name instead of a series name (Affiliate)

### Demo

**Before**

https://github.com/user-attachments/assets/d42ced5c-d935-40e1-98a7-4339774592ea

**After**

https://github.com/user-attachments/assets/12e01f04-5818-4e53-ac1e-7d74109cdf15