### PR TITLE
Abandon deduplicating queue due to a race condition

### DIFF
--- a/test/metabase/util/queue_test.clj
+++ b/test/metabase/util/queue_test.clj
@@ -46,7 +46,7 @@
            :dropped   @dropped
            :skipped   @skipped})))))
 
-(deftest deduplicating-bounded-blocking-queue-test
+(deftest bounded-blocking-queue-test
   (let [realtime-event-count 500
         backfill-event-count 1000
         capacity             (- realtime-event-count 100)

--- a/test/metabase/util/queue_test.clj
+++ b/test/metabase/util/queue_test.clj
@@ -3,10 +3,7 @@
    [clojure.test :refer [deftest is testing]]
    [metabase.test :as mt]
    [metabase.util :as u]
-   [metabase.util.queue :as queue])
-  (:import
-   (java.util Set)
-   (metabase.util.queue DeduplicatingArrayTransferQueue)))
+   [metabase.util.queue :as queue]))
 
 (set! *warn-on-reflection* true)
 
@@ -50,30 +47,26 @@
            :skipped   @skipped})))))
 
 (deftest deduplicating-bounded-blocking-queue-test
-  (doseq [dedupe? [true false]]
-    (let [realtime-event-count 500
-          backfill-event-count 1000
-          capacity             (- realtime-event-count 100)
-          ;; Enqueue background events from oldest to newest
-          backfill-events      (range backfill-event-count)
-          ;; Enqueue realtime events from newest to oldest
-          realtime-events      (take realtime-event-count (reverse backfill-events))
-          queue                (queue/bounded-transfer-queue capacity :sleep-ms 10 :block-ms 10 :dedupe? dedupe?)
+  (let [realtime-event-count 500
+        backfill-event-count 1000
+        capacity             (- realtime-event-count 100)
+        ;; Enqueue background events from oldest to newest
+        backfill-events      (range backfill-event-count)
+        ;; Enqueue realtime events from newest to oldest
+        realtime-events      (take realtime-event-count (reverse backfill-events))
+        queue                (queue/bounded-transfer-queue capacity :sleep-ms 10 :block-ms 10)
 
-          {:keys [processed sent dropped skipped] :as _result}
-          (simulate-queue! queue
-                           :backfill-events backfill-events
-                           :realtime-events realtime-events)]
+        {:keys [processed sent dropped skipped] :as _result}
+        (simulate-queue! queue
+                         :backfill-events backfill-events
+                         :realtime-events realtime-events)]
 
       (testing "We processed all the events that were enqueued"
         (is (= (+ (count backfill-events) sent)
                (count processed))))
 
-      (if dedupe?
-        (testing "Some items are deduplicated"
-          (is (pos? skipped)))
-        (testing "No items are skipped"
-          (is (zero? skipped))))
+      (testing "No items are skipped"
+          (is (zero? skipped)))
 
       (testing "Some items are dropped"
         (is (pos? dropped)))
@@ -82,8 +75,4 @@
         (is (= (set (concat backfill-events realtime-events)) (set processed))))
 
       (testing "The realtime events are processed in order"
-        (mt/ordered-subset? realtime-events processed))
-
-      (when dedupe?
-        (testing "No phantom items are left in the set"
-          (is (zero? (.size ^Set (.-queued-set ^DeduplicatingArrayTransferQueue queue)))))))))
+        (mt/ordered-subset? realtime-events processed))))

--- a/test/metabase/util/queue_test.clj
+++ b/test/metabase/util/queue_test.clj
@@ -46,7 +46,7 @@
            :dropped   @dropped
            :skipped   @skipped})))))
 
-(deftest bounded-blocking-queue-test
+(deftest bounded-transfer-queue-test
   (let [realtime-event-count 500
         backfill-event-count 1000
         capacity             (- realtime-event-count 100)


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/46010

### Description

The more advanced version of the queue appears to have a race condition, but I can't figure out how it occurs.

We probably don't need this optimization, so removing this variant for now.