### PR TITLE
Make Redshift sync much more robust

### DIFF
--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -5,6 +5,7 @@
    [clojure.string :as str]
    [honey.sql :as sql]
    [java-time.api :as t]
+   [metabase.config :as config]
    [metabase.driver :as driver]
    [metabase.driver.sql :as driver.sql]
    [metabase.driver.sql-jdbc.common :as sql-jdbc.common]
@@ -112,10 +113,10 @@
   ;; Redshift sync is super duper flaky and un-robust! This auto-retry is a temporary workaround until we can actually
   ;; fix #45874
   (try
-    (u/auto-retry 5
+    (u/auto-retry (if config/is-prod? 2 10)
       {:tables (into #{} (describe-database-tables database))})
     (catch Throwable e
-      (throw (ex-info (format "Error in %d describe-database: %s" driver (ex-message e))
+      (throw (ex-info (format "Error in %s describe-database: %s" driver (ex-message e))
                       {}
                       e)))))
 

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -108,7 +108,11 @@
 (defmethod driver/describe-database :redshift
   [_driver database]
   ;; TODO: change this to return a reducible so we don't have to hold 100k tables in memory in a set like this
-  {:tables (into #{} (describe-database-tables database))})
+  ;;
+  ;; Redshift sync is super duper flaky and un-robust! This auto-retry is a temporary workaround until we can actually
+  ;; fix #45874
+  (u/auto-retry 3
+    {:tables (into #{} (describe-database-tables database))}))
 
 (defmethod sql-jdbc.sync/describe-fks-sql :redshift
   [driver & {:keys [schema-names table-names]}]


### PR DESCRIPTION
Add auto-retry logic to Redshift `describe-database` as a temporary workaround for #45874 to fix CI flakes