### PR TITLE
[Notification] Remove channel details for users without write perms

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/channel_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/channel_test.clj
@@ -16,24 +16,35 @@
         [group {:name "New Group"}
          user  [group]]
         (letfn [(update-channel [user status]
-                  (testing (format "set slack setting with %s user" (mt/user-descriptor user))
+                  (testing (format "set channel setting with %s user" (mt/user-descriptor user))
                     (mt/with-temp [:model/Channel {id :id} {:type "channel/metabase-test"
                                                             :details {:return-type  "return-value"
                                                                       :return-value true}}]
                       (mt/user-http-request user :put status (format "channel/%d" id) {:name (mt/random-name)}))))
                 (create-channel [user status]
-                  (testing (format "create slack setting with %s user" (mt/user-descriptor user))
+                  (testing (format "create channel setting with %s user" (mt/user-descriptor user))
                     (mt/user-http-request user :post status "channel" {:name (mt/random-name)
                                                                        :type "channel/metabase-test"
                                                                        :details {:return-type  "return-value"
-                                                                                 :return-value true}})))]
+                                                                                 :return-value true}})))
+                (include-details [user include-details?]
+                  (mt/with-temp [:model/Channel {id :id} {:type "channel/metabase-test"
+                                                          :details {:return-type  "return-value"
+                                                                    :return-value true}}]
+                    (testing (format "GET /api/channel/:id with %s user" (mt/user-descriptor user))
+                      (is (= include-details? (contains? (mt/user-http-request user :get 200 (str "channel/" id)) :details))))
+
+                    (testing (format "GET /api/channel with %s user" (mt/user-descriptor user))
+                      (is (every? #(= % include-details?) (map #(contains? % :details) (mt/user-http-request user :get 200 "channel/")))))))]
 
           (testing "if `advanced-permissions` is disabled, require admins"
             (mt/with-premium-features #{}
               (create-channel user 403)
               (update-channel user 403)
               (create-channel :crowberto 200)
-              (update-channel :crowberto 200)))
+              (update-channel :crowberto 200)
+              (include-details :crowberto true)
+              (include-details user false)))
 
           (testing "if `advanced-permissions` is enabled"
             (mt/with-premium-features #{:advanced-permissions}
@@ -41,11 +52,15 @@
                 (create-channel user 403)
                 (update-channel user 403)
                 (create-channel :crowberto 200)
-                (update-channel :crowberto 200))
+                (update-channel :crowberto 200)
+                (include-details :crowberto true)
+                (include-details user false))
 
               (testing "succeed if user's group has `setting` permission"
                 (perms/grant-application-permissions! group :setting)
                 (create-channel user 200)
                 (update-channel user 200)
                 (create-channel :crowberto 200)
-                (update-channel user 200)))))))))
+                (update-channel user 200)
+                (include-details :crowberto true)
+                (include-details user true)))))))))

--- a/src/metabase/models/channel.clj
+++ b/src/metabase/models/channel.clj
@@ -10,7 +10,8 @@
 
 (defmethod mi/can-write? :model/Channel
   [& _]
-  (perms/current-user-has-application-permissions? :setting))
+  (or (mi/superuser?)
+      (perms/current-user-has-application-permissions? :setting)))
 
 (defmethod serdes/entity-id "Channel"
   [_ {:keys [name]}]

--- a/test/metabase/api/pulse_test.clj
+++ b/test/metabase/api/pulse_test.clj
@@ -1049,11 +1049,11 @@
                                    :recipients        ["user" "email"]
                                    :schedules         ["hourly" "daily" "weekly" "monthly"]
                                    :type              "email"}
-                           :http  {:alows_recipients false
-                                   :configured       true
-                                   :name             "Webhook"
-                                   :schedules        ["hourly" "daily" "weekly" "monthly"]
-                                   :type             "http"}
+                           :http  {:allows_recipients false
+                                   :configured        true
+                                   :name              "Webhook"
+                                   :schedules         ["hourly" "daily" "weekly" "monthly"]
+                                   :type              "http"}
                            :slack {:allows_recipients false
                                    :configured        true
                                    :fields            [{:displayName "Post to"


### PR DESCRIPTION
Only returns channel.details for Admin or Setting managers

Epic: https://github.com/metabase/metabase/issues/43822