### PR TITLE
Fix default viz settings are ignored when saving a question from raw table view

### DIFF
--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -2079,6 +2079,52 @@ describe("issue 45452", () => {
   });
 });
 
+describe("issue 41612", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    cy.intercept("POST", "/api/card").as("createQuestion");
+  });
+
+  it("should not ignore chart viz settings when viewing raw results as a table (metabase#41612)", () => {
+    visitQuestionAdhoc(
+      {
+        display: "line",
+        dataset_query: {
+          type: "query",
+          database: SAMPLE_DB_ID,
+          query: {
+            aggregation: [["count"]],
+            breakout: [
+              [
+                "field",
+                ORDERS.CREATED_AT,
+                { "base-type": "type/DateTime", "temporal-unit": "month" },
+              ],
+            ],
+            "source-table": ORDERS_ID,
+          },
+        },
+      },
+      { visitQuestion: true },
+    );
+
+    queryBuilderMain().findByLabelText("Switch to data").click();
+    queryBuilderHeader().button("Save").click();
+    modal().button("Save").click();
+
+    cy.wait("@createQuestion").then(xhr => {
+      const card = xhr.request.body;
+      expect(card.visualization_settings["graph.metrics"]).to.deep.equal([
+        "count",
+      ]);
+      expect(card.visualization_settings["graph.dimensions"]).to.deep.equal([
+        "CREATED_AT",
+      ]);
+    });
+  });
+});
+
 function expectNoScrollbarContainer(element) {
   const hasScrollbarContainer =
     element.scrollHeight <= element.clientHeight &&

--- a/enterprise/frontend/src/embedding-sdk/lib/interactive-question/run-question-on-query-change.ts
+++ b/enterprise/frontend/src/embedding-sdk/lib/interactive-question/run-question-on-query-change.ts
@@ -47,7 +47,6 @@ export const runQuestionOnQueryChangeSdk =
       question: nextQuestion,
       queryResult: queryResults?.[0],
       datasetQuery: undefined,
-      showRawTable: false,
     });
 
     const questionPivotResult = computeQuestionPivotTable({

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -1129,7 +1129,10 @@ export const getSubmittableQuestion = (state, question) => {
     queryResult: getFirstQueryResult(state),
     datasetQuery: getLastRunDatasetQuery(state),
   });
-  const { series } = getVisualizationTransformed(extractRemappings(rawSeries));
+
+  const series = rawSeries
+    ? getVisualizationTransformed(extractRemappings(rawSeries)).series
+    : null;
 
   const resultsMetadata = getResultsMetadata(state);
   const isResultDirty = getIsResultDirty(state);

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -713,14 +713,35 @@ export const getShouldShowUnsavedChangesWarning = createSelector(
  * Returns the card and query results data in a format that `Visualization.jsx` expects
  */
 export const getRawSeries = createSelector(
-  [getQuestion, getQueryResults, getLastRunDatasetQuery, getIsShowingRawTable],
-  (question, results, lastRunDatasetQuery, isShowingRawTable) => {
-    return createRawSeries({
+  [
+    getQuestion,
+    getFirstQueryResult,
+    getLastRunDatasetQuery,
+    getIsShowingRawTable,
+  ],
+  (question, queryResult, lastRunDatasetQuery, isShowingRawTable) => {
+    const rawSeries = createRawSeries({
       question,
-      queryResult: results?.[0],
+      queryResult,
       datasetQuery: lastRunDatasetQuery,
-      showRawTable: isShowingRawTable,
     });
+    if (isShowingRawTable && rawSeries?.length > 0) {
+      const [{ card, data }] = rawSeries;
+      return [
+        {
+          card: {
+            ...card,
+            display: "table",
+            visualization_settings: {
+              ...card.visualization_settings,
+              "table.pivot": false,
+            },
+          },
+          data,
+        },
+      ];
+    }
+    return rawSeries;
   },
 );
 
@@ -1103,7 +1124,13 @@ export function getEmbeddedParameterVisibility(state, slug) {
 }
 
 export const getSubmittableQuestion = (state, question) => {
-  const series = getTransformedSeries(state);
+  const rawSeries = createRawSeries({
+    question: getQuestion(state),
+    queryResult: getFirstQueryResult(state),
+    datasetQuery: getLastRunDatasetQuery(state),
+  });
+  const { series } = getVisualizationTransformed(extractRemappings(rawSeries));
+
   const resultsMetadata = getResultsMetadata(state);
   const isResultDirty = getIsResultDirty(state);
 

--- a/frontend/src/metabase/query_builder/utils.ts
+++ b/frontend/src/metabase/query_builder/utils.ts
@@ -149,17 +149,8 @@ export const createRawSeries = (options: {
   question: Question;
   queryResult: any;
   datasetQuery?: any;
-  showRawTable?: boolean;
 }): Series => {
-  const { question, queryResult, datasetQuery, showRawTable = false } = options;
-
-  let display = question && question.display();
-  let settings = question && question.settings();
-
-  if (showRawTable) {
-    display = "table";
-    settings = { "table.pivot": false };
-  }
+  const { question, queryResult, datasetQuery } = options;
 
   // we want to provide the visualization with a card containing the latest
   // "display", "visualization_settings", etc, (to ensure the correct visualization is shown)
@@ -169,9 +160,6 @@ export const createRawSeries = (options: {
       {
         card: {
           ...question.card(),
-          display: display,
-          visualization_settings: settings,
-
           ...(datasetQuery && { dataset_query: datasetQuery }),
         },
         data: queryResult && queryResult.data,


### PR DESCRIPTION
Closes #41612

Fixes an issue when saving a new question while being in the "view raw data" mode won't include default visualization settings. The problem is that when entering the "raw data" view, we're patching the card in the [`getRawSeries` selector](https://github.com/metabase/metabase/blob/ae14aa31bc3038200f6109f8628690a77b0b7502/frontend/src/metabase/query_builder/selectors.js#L722), and then use that "table" series when constructing default viz settings [in `getSubmittableQuestion`](https://github.com/metabase/metabase/blob/ae14aa31bc3038200f6109f8628690a77b0b7502/frontend/src/metabase/query_builder/selectors.js#L1117). Fixed by constructing a separate series object in `getSubmittableQuestion`. I considered moving out this logic closer to the visualization itself, but it seems like other parts of the QB might expect a "table" series

### To verify

1. New > Question > Sample Database > Count of Orders by Created At
2. Set the visualization to "line"
3. Click the "table" icon at the bottom to enter the raw data view
4. Save the question while being in the raw data view
5. Ensure the card object in `POST /api/card` request body contains `graph.metrics` and `graph.dimensions` viz settings