### PR TITLE
fix: use correct schema version for embed flow analytics

### DIFF
--- a/frontend/src/metabase/public/lib/analytics.ts
+++ b/frontend/src/metabase/public/lib/analytics.ts
@@ -9,7 +9,7 @@ import type {
 } from "./types";
 
 const SCHEMA_NAME = "embed_flow";
-const SCHEMA_VERSION = "1-0-1";
+const SCHEMA_VERSION = "1-0-2";
 
 // We changed the UI to `Look and Feel` now
 type Appearance = {


### PR DESCRIPTION
Fix after [update static_embed_code_copied to use downloads (+227 −24)](https://github.com/metabase/metabase/pull/45944)

It wasn't caught by expectNoBadSnowplowEvents,It seems like snowplow-micro doesn't detect errors in nested objects?