### PR TITLE
bind ts4 to avoid implicit updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -308,6 +308,7 @@
     "@types/react-dom": "^17.0.11",
     "set-value": "4.0.1",
     "source-map-js": "1.2.0",
+    "typescript": "^4.7.2",
     "unset-value": "2.0.1",
     "webpack-dev-middleware": "^5.3.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -22589,15 +22589,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.7.2:
+typescript@^4.7.2, typescript@^5.3.3:
   version "4.7.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.2.tgz#1f9aa2ceb9af87cca227813b4310fff0b51593c4"
   integrity sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==
-
-typescript@^5.3.3:
-  version "5.4.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.5.tgz#42ccef2c571fdbd0f6718b1d1f5e6e5ef006f611"
-  integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==
 
 uglify-js@^3.1.4:
   version "3.14.1"


### PR DESCRIPTION
[context](https://metaboat.slack.com/archives/C505ZNNH4/p1721757334687389)

seems cypress implicitly took ts5 from postcss package, so let's bind it to 4.7.2 in release branch, master uses 5.4.5