### PR TITLE
update `dashboard_pdf_exported` and use it in embedding context

### DIFF
--- a/e2e/test/scenarios/embedding/embed-resource-downloads.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embed-resource-downloads.cy.spec.ts
@@ -3,10 +3,13 @@ import {
   ORDERS_DASHBOARD_ID,
 } from "e2e/support/cypress_sample_instance_data";
 import {
-  describeEE,
+  describeWithSnowplowEE,
+  expectGoodSnowplowEvent,
+  expectNoBadSnowplowEvents,
   getDashboardCardMenu,
   main,
   popover,
+  resetSnowplow,
   restore,
   setTokenFeatures,
   showDashboardCardActions,
@@ -17,10 +20,11 @@ import {
  *  Unless the product changes, these should test the same things as `public-resource-downloads.cy.spec.ts`
  */
 
-describeEE(
+describeWithSnowplowEE(
   "Static embed dashboards/questions downloads (results and export as pdf)",
   () => {
     beforeEach(() => {
+      resetSnowplow();
       cy.deleteDownloadsFolder();
     });
 
@@ -36,6 +40,10 @@ describeEE(
         setTokenFeatures("all");
 
         cy.signOut();
+      });
+
+      afterEach(() => {
+        expectNoBadSnowplowEvents();
       });
 
       it("#downloads=false should disable both PDF downloads and dashcard results downloads", () => {
@@ -76,6 +84,12 @@ describeEE(
         cy.get("header").findByText("Export as PDF").click();
 
         cy.verifyDownload("Orders in a dashboard.pdf");
+
+        expectGoodSnowplowEvent({
+          event: "dashboard_pdf_exported",
+          dashboard_id: 0,
+          dashboard_accessed_via: "static-embed",
+        });
       });
 
       it("should be able to download a static embedded dashcard as CSV", () => {

--- a/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
+++ b/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
@@ -351,6 +351,7 @@ describeWithSnowplow("scenarios > dashboard > download pdf", () => {
       expectGoodSnowplowEvent({
         event: "dashboard_pdf_exported",
         dashboard_id: dashboard.id,
+        dashboard_accessed_via: "internal",
       });
     });
   });

--- a/e2e/test/scenarios/sharing/public-resource-downloads.cy.spec.ts
+++ b/e2e/test/scenarios/sharing/public-resource-downloads.cy.spec.ts
@@ -5,11 +5,14 @@ import {
 } from "e2e/support/cypress_sample_instance_data";
 import {
   assertNotEmptyObject,
-  describeEE,
+  describeWithSnowplowEE,
   downloadAndAssert,
+  expectGoodSnowplowEvent,
+  expectNoBadSnowplowEvents,
   getDashboardCardMenu,
   main,
   popover,
+  resetSnowplow,
   restore,
   setTokenFeatures,
   showDashboardCardActions,
@@ -19,10 +22,11 @@ import {
  *  Unless the product changes, these should test the same things as `embed-resource-downloads.cy.spec.ts`
  */
 
-describeEE(
+describeWithSnowplowEE(
   "Public dashboards/questions downloads (results and export as pdf)",
   () => {
     beforeEach(() => {
+      resetSnowplow();
       cy.deleteDownloadsFolder();
     });
 
@@ -50,6 +54,10 @@ describeEE(
         cy.signOut();
       });
 
+      afterEach(() => {
+        expectNoBadSnowplowEvents();
+      });
+
       it("#downloads=false should disable both PDF downloads and dashcard results downloads", () => {
         cy.visit(`${publicLink}#downloads=false`);
         waitLoading();
@@ -68,6 +76,12 @@ describeEE(
         cy.get("header").findByText("Export as PDF").click();
 
         cy.verifyDownload("Orders in a dashboard.pdf");
+
+        expectGoodSnowplowEvent({
+          event: "dashboard_pdf_exported",
+          dashboard_id: 0,
+          dashboard_accessed_via: "public-link",
+        });
       });
 
       it("should be able to download a public dashcard as CSV", () => {

--- a/frontend/src/metabase/dashboard/analytics.ts
+++ b/frontend/src/metabase/dashboard/analytics.ts
@@ -3,7 +3,7 @@ import type { DashboardId, DashboardWidth } from "metabase-types/api";
 
 import type { SectionId } from "./sections";
 
-const DASHBOARD_SCHEMA_VERSION = "1-1-4";
+const DASHBOARD_SCHEMA_VERSION = "1-1-5";
 
 export const trackAutoApplyFiltersDisabled = (dashboardId: DashboardId) => {
   trackSchemaEvent("dashboard", DASHBOARD_SCHEMA_VERSION, {
@@ -12,10 +12,25 @@ export const trackAutoApplyFiltersDisabled = (dashboardId: DashboardId) => {
   });
 };
 
-export const trackExportDashboardToPDF = (dashboardId: DashboardId) => {
+type DashboardAccessedVia =
+  | "internal"
+  | "public-link"
+  | "static-embed"
+  | "interactive-iframe-embed"
+  | "sdk-embed";
+
+export const trackExportDashboardToPDF = ({
+  dashboardId,
+  dashboardAccessedVia,
+}: {
+  dashboardId?: DashboardId;
+  dashboardAccessedVia: DashboardAccessedVia;
+}) => {
   trackSchemaEvent("dashboard", DASHBOARD_SCHEMA_VERSION, {
     event: "dashboard_pdf_exported",
-    dashboard_id: dashboardId,
+    // we send 0 because the snowplow table requires a value
+    dashboard_id: dashboardId ?? 0,
+    dashboard_accessed_via: dashboardAccessedVia,
   });
 };
 

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/DashboardActionMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/DashboardActionMenu.tsx
@@ -5,6 +5,7 @@ import EntityMenu from "metabase/components/EntityMenu";
 import { trackExportDashboardToPDF } from "metabase/dashboard/analytics";
 import { DASHBOARD_PDF_EXPORT_ROOT_ID } from "metabase/dashboard/constants";
 import type { DashboardFullscreenControls } from "metabase/dashboard/types";
+import { isWithinIframe } from "metabase/lib/dom";
 import { PLUGIN_DASHBOARD_HEADER } from "metabase/plugins";
 import {
   getExportTabAsPdfButtonText,
@@ -51,7 +52,12 @@ export const getExtraButtons = ({
     action: async () => {
       const cardNodeSelector = `#${DASHBOARD_PDF_EXPORT_ROOT_ID}`;
       await saveDashboardPdf(cardNodeSelector, dashboard.name).then(() => {
-        trackExportDashboardToPDF(dashboard.id);
+        trackExportDashboardToPDF({
+          dashboardId: dashboard.id,
+          dashboardAccessedVia: isWithinIframe()
+            ? "interactive-iframe-embed"
+            : "internal",
+        });
       });
     },
   });

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/dashboard/jsonschema/1-1-5
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/dashboard/jsonschema/1-1-5
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Dashboard events",
+  "self": {
+    "vendor": "com.metabase",
+    "name": "dashboard",
+    "format": "jsonschema",
+    "version": "1-1-4"
+  },
+  "type": "object",
+  "properties": {
+    "event": {
+      "description": "Event name",
+      "type": "string",
+      "enum": [
+        "dashboard_created",
+        "dashboard_saved",
+        "question_added_to_dashboard",
+        "auto_apply_filters_disabled",
+        "dashboard_tab_created",
+        "dashboard_tab_deleted",
+        "dashboard_tab_duplicated",
+        "new_text_card_created",
+        "new_heading_card_created",
+        "new_link_card_created",
+        "new_action_card_created",
+        "card_set_to_hide_when_no_results",
+        "dashboard_pdf_exported",
+        "card_moved_to_tab",
+        "dashboard_card_duplicated",
+        "dashboard_card_replaced",
+        "dashboard_section_added",
+        "dashboard_width_toggled",
+        "dashboard_filter_required"
+      ],
+      "maxLength": 1024
+    },
+    "dashboard_id": {
+      "description": "Unique identifier for a dashboard within the Metabase instance",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "question_id": {
+      "description": "Unique identifier for a question added to a dashboard",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "num_tabs": {
+      "description": "Number of tabs affected after the event",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "total_num_tabs": {
+      "description": "Total number of active tabs after the events",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "duration_milliseconds": {
+      "description": "Duration the action took to complete in milliseconds",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "section_layout": {
+      "description": "String describing the layout that was selected from the pre-built options",
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1024
+    },
+    "full_width": {
+      "description": "Boolean set to True if the dashboard was toggled to full width and False if full width was disabled.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "event",
+    "dashboard_id"
+  ],
+  "additionalProperties": true
+}

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/dashboard/jsonschema/1-1-5
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/dashboard/jsonschema/1-1-5
@@ -91,6 +91,13 @@
         "boolean",
         "null"
       ]
+    },
+    "dashboard_accessed_via": {
+      "description": "Indicate if the dashboard was accessed via metabase ('internal'), public link, static embed etc",
+      "type": [
+        "string",
+        "null"
+      ]
     }
   },
   "required": [


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/46007

### Description

Since we added pdf export to public/embedded dashboards, this pr changes `dashboard_pdf_exported` to accept a new field `dashboard_accessed_via` that tells us how the dashboard was accesses (internal, public link, static embed, sdk, interactive embedding).

For public/static scenarios we decided to not pass the dashboard id (as it would be either a signed jwt, or a uuid) and after [this slack thread](https://metaboat.slack.com/archives/C010L1Z4F9S/p1721746019685229?thread_ts=1721745811.912789&cid=C010L1Z4F9S) we opted to send 0 instead of making the field not required, so that we don't have to create a new table for the event.

Asking review also to @metabase/core-frontend-dashviz as this changes the event sent from the FE