### PR TITLE
Loosen N+1 query detection again

### DIFF
--- a/dev/src/dev.clj
+++ b/dev/src/dev.clj
@@ -317,9 +317,10 @@
     x))
 
 (methodical/defmethod t2.hydrate/hydrate-with-strategy :around ::t2.hydrate/multimethod-simple
-  "Throws an error if do simple hydrations that make DB call on a sequence."
+  "Throws an error if simple hydrations make DB calls (which is an easy way to accidentally introduce an N+1 bug)."
   [model strategy k instances]
-  (if config/is-prod?
+  (if (or config/is-prod?
+          (< (count instances) 2))
     (next-method model strategy k instances)
     (do
       ;; prevent things like dereferencing metabase.api.common/*current-user-permissions-set* from triggering the check


### PR DESCRIPTION
I tightened this up by removing the condition here, thinking that CI would catch it if it was necessary - but I'm getting failures in development. Oops - didn't realize that this defmethod wasn't actually applied during CI runs.

Let's add this condition in for now, to prevent frustration in dev. We should probably also consider moving this to a different namespace where it will be "on" during CI or it might lead to further issues like this.