### PR TITLE
Filter invalid recent and search items in move modal

### DIFF
--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -28,6 +28,9 @@ import {
   openCollectionMenu,
   createQuestion,
   entityPickerModalItem,
+  createCollection,
+  openCollectionItemMenu,
+  entityPickerModalTab,
 } from "e2e/support/helpers";
 
 import { displaySidebarChildOf } from "./helpers/e2e-collections-sidebar.js";
@@ -716,6 +719,72 @@ describe("scenarios > collection defaults", () => {
               "data-active",
               "true",
             );
+          });
+        });
+
+        it("moving collections should disable moving into any of the moving collections in recents or search (metabase#45248)", () => {
+          createCollection({ name: "Outer collection 1" }).then(
+            ({ body: { id: parentCollectionId } }) => {
+              cy.wrap(parentCollectionId).as("outerCollectionId");
+              createCollection({
+                name: "Inner collection 1",
+                parent_id: parentCollectionId,
+              }).then(({ body: { id: innerCollectionId } }) => {
+                cy.wrap(innerCollectionId).as("innerCollectionId");
+              });
+              createCollection({
+                name: "Inner collection 2",
+                parent_id: parentCollectionId,
+              });
+            },
+          );
+          createCollection({ name: "Outer collection 2" });
+
+          // modify the inner collection so that it shows up in recents
+          cy.get("@innerCollectionId").then(innerCollectionId => {
+            cy.request("PUT", `/api/collection/${innerCollectionId}`, {
+              name: "Inner collection 1 - modified",
+            });
+          });
+          cy.visit("/collection/root");
+
+          cy.log("single move");
+
+          cy.findByTestId("collection-table").within(() => {
+            openCollectionItemMenu("Outer collection 1");
+          });
+
+          popover().findByText("Move").click();
+
+          entityPickerModal().within(() => {
+            entityPickerModalTab("Recents").should(
+              "have.attr",
+              "data-active",
+              "true",
+            );
+
+            cy.findByText(/inner collection/).should("not.exist");
+
+            cy.button("Cancel").click();
+          });
+
+          cy.log("bulk move");
+
+          cy.findByTestId("collection-table").within(() => {
+            selectItemUsingCheckbox("Orders");
+            selectItemUsingCheckbox("Outer collection 1");
+          });
+
+          cy.findByTestId("toast-card").button("Move").click();
+
+          entityPickerModal().within(() => {
+            entityPickerModalTab("Recents").should(
+              "have.attr",
+              "data-active",
+              "true",
+            );
+
+            cy.findByText(/inner collection/).should("not.exist");
           });
         });
       });

--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -708,7 +708,6 @@ describe("scenarios > collection defaults", () => {
 
           entityPickerModal().within(() => {
             cy.log("should disable all moving collections");
-            cy.findByRole("tab", { name: /Collections/ }).click();
             findPickerItem("First collection").should("have.attr", "disabled");
             findPickerItem("Another collection").should(
               "have.attr",

--- a/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
@@ -3,7 +3,7 @@ import { t } from "ttag";
 
 import { useToggle } from "metabase/hooks/use-toggle";
 import { Button, Icon } from "metabase/ui";
-import type { SearchModel, SearchResult } from "metabase-types/api";
+import type { RecentItem, SearchModel, SearchResult } from "metabase-types/api";
 
 import type { EntityTab } from "../../EntityPicker";
 import { EntityPickerModal, defaultOptions } from "../../EntityPicker";
@@ -23,6 +23,8 @@ export interface CollectionPickerModalProps {
   options?: CollectionPickerOptions;
   value: Pick<CollectionPickerValueItem, "id" | "model">;
   shouldDisableItem?: (item: CollectionPickerItem) => boolean;
+  searchResultFilter?: (searchResults: SearchResult[]) => SearchResult[];
+  recentFilter?: (recentItems: RecentItem[]) => RecentItem[];
 }
 
 const canSelectItem = (
@@ -44,6 +46,8 @@ export const CollectionPickerModal = ({
   value,
   options = defaultOptions,
   shouldDisableItem,
+  searchResultFilter,
+  recentFilter,
 }: CollectionPickerModalProps) => {
   options = { ...defaultOptions, ...options };
   const [selectedItem, setSelectedItem] = useState<CollectionPickerItem | null>(
@@ -111,6 +115,16 @@ export const CollectionPickerModal = ({
     pickerRef.current?.onNewCollection(newCollection);
   };
 
+  const composedSearchResultFilter = useCallback(
+    (searchResults: SearchResult[]) => {
+      if (searchResultFilter) {
+        return searchFilter(searchResultFilter(searchResults));
+      }
+      return searchFilter(searchResults);
+    },
+    [searchResultFilter],
+  );
+
   return (
     <>
       <EntityPickerModal
@@ -122,7 +136,8 @@ export const CollectionPickerModal = ({
         selectedItem={selectedItem}
         tabs={tabs}
         options={options}
-        searchResultFilter={searchFilter}
+        searchResultFilter={composedSearchResultFilter}
+        recentFilter={recentFilter}
         actionButtons={modalActions}
         trapFocus={!isCreateDialogOpen}
       />


### PR DESCRIPTION
Closes #45248 

### Description

When moving collections, you should not be able to move a parent collection into one of its children. This is enforced in the collection picker tree, but recents and search would present invalid options. Note: the API prevented any invalid moves, but we should remove them from the UI in the first place to avoid frustrating users with invalid options.


Note: `Inner Collection` is a subcollection of `Outer Collection`, and should not be shown as a valid move target. you also can't move a collection into itself.

. | Before | After
--|--|--
recents | ![Screen Shot 2024-07-24 at 1 30 38 PM](https://github.com/user-attachments/assets/31da0b01-1ee7-4efa-9364-ace91eeabe10) | ![Screen Shot 2024-07-24 at 1 30 16 PM](https://github.com/user-attachments/assets/8668b9fb-19be-4d6b-a5a0-8c0dc16c521d)
search | ![Screen Shot 2024-07-24 at 1 30 43 PM](https://github.com/user-attachments/assets/05543926-db09-4971-bb9b-1152ab5a747a) | ![Screen Shot 2024-07-24 at 1 30 23 PM](https://github.com/user-attachments/assets/7a0aafbb-ecc8-45fc-a94d-847f11b39dc9)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
