### PR TITLE
ci: Fix request timeout in E2E dashboard filters flake

### DIFF
--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -1462,17 +1462,11 @@ describe("issues 15279 and 24500", () => {
         });
 
         visitDashboard(dashboard_id);
-
-        cy.intercept(
-          "GET",
-          `/api/dashboard/${dashboard_id}/params/${listFilter.id}/values`,
-        ).as("listFilterValues");
       },
     );
 
     cy.log("Make sure the list filter works");
     filterWidget().contains("List").click();
-    cy.wait("@listFilterValues");
 
     popover().within(() => {
       cy.findByText("Organic").click();
@@ -1518,7 +1512,6 @@ describe("issues 15279 and 24500", () => {
 
     cy.log("Make sure the list filter still works");
     filterWidget().contains("Organic").click();
-    cy.wait("@listFilterValues");
 
     cy.log("Make sure the search filter still works");
     // reset filter value

--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -1469,7 +1469,8 @@ describe("issues 15279 and 24500", () => {
     filterWidget().contains("List").click();
 
     popover().within(() => {
-      cy.findByText("Organic").click();
+      cy.findByTextEnsureVisible("Organic").click();
+      cy.findByTestId("Organic-filter-value").should("be.checked");
       cy.button("Add filter").click();
     });
 
@@ -1512,6 +1513,7 @@ describe("issues 15279 and 24500", () => {
 
     cy.log("Make sure the list filter still works");
     filterWidget().contains("Organic").click();
+    popover().findByTestId("Organic-filter-value").should("be.checked");
 
     cy.log("Make sure the search filter still works");
     // reset filter value

--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -1404,13 +1404,16 @@ describe("issues 15279 and 24500", () => {
     sectionId: "string",
   };
 
-  // This filter is corrupted because it's missing `name` and `slug`
+  // Back when this issue was originally reported (around v47),
+  // it was enough to have a filter without `name` and `slug` in order to corrupt it.
+  // It seems that the backend validation is missing today or it's more relaxed.
+  // We're adding invalid `type` and `sectionId` to make sure the filter is still considered corrupted.
   const corruptedFilter = {
     name: "",
     slug: "",
     id: "af72ce9c",
-    type: "string/=",
-    sectionId: "string",
+    type: "foo",
+    sectionId: "bar",
   };
 
   const parameters = [listFilter, searchFilter, corruptedFilter];

--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -1420,10 +1420,11 @@ describe("issues 15279 and 24500", () => {
 
   const questionDetails = {
     name: "15279",
-    query: { "source-table": PEOPLE_ID },
+    query: { "source-table": PEOPLE_ID, limit: 2 },
   };
 
   const dashboardDetails = { parameters };
+
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();


### PR DESCRIPTION
### What does this PR accomplish?
It fixes an E2E flake in dashboard filters reproductions that had one intercepted request timing out from time to time.

### Example of a failure
https://github.com/metabase/metabase/actions/runs/10076690074/job/27857992893?pr=46048#step:13:313

![issues 15279 and 24500 -- corrupted dashboard filter should still appear in the UI without breaking other filters (metabase#15279, metabase#24500) (failed) (attempt 2)](https://github.com/user-attachments/assets/4b7373cf-a11d-4153-9cfd-403fb181c5a9)

### Explanation
I am not entirely sure why was this happening. It could be a potato CI runner, or it could be some weirdness in the UI.

### Solution
1. Limit the number of rows to speed things up
2. Make the interception url much more specific

Even after this, the test was still failing in [6/50 stress-test scenarios](https://github.com/metabase/metabase/actions/runs/10083660257).

So as the final solution, **I've removed the intercepts altogether.** 

> [Note]
> As an added bonus, this PR also improves the assertions which improves the correctness of this repro.

### Stress-test (in progress)
50/50 ✅ https://github.com/metabase/metabase/actions/runs/10083873537