### PR TITLE
Track column references whether they resolve to Fields or not

### DIFF
--- a/src/metabase/models/query_field.clj
+++ b/src/metabase/models/query_field.clj
@@ -44,7 +44,8 @@
                      :where  [:and
                               [:= :qf.explicit_reference true]
                               [:= :f.active false]
-                              [:in :card_id (map :id cards)]]})
+                              [:in :card_id (map :id cards)]]
+                     :order-by [:qf.card_id :t.name :f.name]})
          (map (fn [{:keys [card_id table field table_active]}]
                 [card_id {:type  (if table_active
                                    :inactive-field

--- a/src/metabase/query_analysis.clj
+++ b/src/metabase/query_analysis.clj
@@ -81,7 +81,13 @@
          false)))
 
 (defn- explicit-references [field-ids]
-  (map #(hash-map :field-id % :explicit-reference true) field-ids))
+  (when (seq field-ids)
+    (t2/select :model/QueryField {:select [[:t.id :table-id] [:t.name :table]
+                                           [:f.id :field-id] [:f.name :column]
+                                           [true :explicit-reference]]
+                                  :from   [[(t2/table-name :model/Field) :f]]
+                                  :join   [[(t2/table-name :model/Table) :t] [:= :t.id :f.table_id]]
+                                  :where  [:in :f.id field-ids]})))
 
 (defn- query-references
   "Find out ids of all fields used in a query. Conforms to the same protocol as [[query-analyzer/field-ids-for-sql]],

--- a/src/metabase/query_analysis.clj
+++ b/src/metabase/query_analysis.clj
@@ -82,12 +82,13 @@
 
 (defn- explicit-references [field-ids]
   (when (seq field-ids)
-    (t2/select :model/QueryField {:select [[:t.id :table-id] [:t.name :table]
-                                           [:f.id :field-id] [:f.name :column]
-                                           [true :explicit-reference]]
-                                  :from   [[(t2/table-name :model/Field) :f]]
-                                  :join   [[(t2/table-name :model/Table) :t] [:= :t.id :f.table_id]]
-                                  :where  [:in :f.id field-ids]})))
+    ;; We add this on in code as `true` in MySQL-based drivers would be returned as 1.
+    (map #(assoc % :explicit-reference true)
+         (t2/select :model/QueryField {:select [[:t.id :table-id] [:t.name :table]
+                                                [:f.id :field-id] [:f.name :column]]
+                                       :from   [[(t2/table-name :model/Field) :f]]
+                                       :join   [[(t2/table-name :model/Table) :t] [:= :t.id :f.table_id]]
+                                       :where  [:in :f.id field-ids]}))))
 
 (defn- query-references
   "Find out ids of all fields used in a query. Conforms to the same protocol as [[query-analyzer/field-ids-for-sql]],

--- a/src/metabase/query_analysis.clj
+++ b/src/metabase/query_analysis.clj
@@ -110,14 +110,14 @@
   [{card-id :id, query :dataset_query}]
   (let [query-type (lib/normalized-query-type query)]
     (when (enabled-type? query-type)
-      (let [{:keys [explicit implicit]} (query-references query query-type)
-            id->row          (fn [explicit? field-id]
-                               {:card_id            card-id
-                                :field_id           field-id
-                                :explicit_reference explicit?})
-            query-field-rows (concat
-                              (map (partial id->row true) explicit)
-                              (map (partial id->row false) implicit))]
+      (let [references       (query-references query query-type)
+            reference->row   (fn [{:keys [field-id explicit-reference]}]
+                               ;; For now we only persist references which resolve to known fields
+                               (when field-id
+                                 {:card_id            card-id
+                                  :field_id           field-id
+                                  :explicit_reference explicit-reference}))
+            query-field-rows (map reference->row references)]
         (query-field/update-query-fields-for-card! card-id query-field-rows)))))
 
 (defn- replaced-inner-query-for-native-card

--- a/src/metabase/query_analysis.clj
+++ b/src/metabase/query_analysis.clj
@@ -104,7 +104,7 @@
   [{card-id :id, query :dataset_query}]
   (let [query-type (lib/normalized-query-type query)]
     (when (enabled-type? query-type)
-      (let [{:keys [explicit implicit]} (query-field-ids query)
+      (let [{:keys [explicit implicit]} (query-field-ids query query-type)
             id->row          (fn [explicit? field-id]
                                {:card_id            card-id
                                 :field_id           field-id

--- a/src/metabase/query_analysis/native_query_analyzer.clj
+++ b/src/metabase/query_analysis/native_query_analyzer.clj
@@ -182,7 +182,7 @@
         sql-string    (:query (nqa.sub/replace-tags query))
         parsed-query  (macaw/query->components (macaw/parsed-query sql-string macaw-opts) macaw-opts)
         explicit-refs (explicit-references-for-query parsed-query db-id)
-        implicit-refs (set/difference (implicit-references-for-query parsed-query db-id)
+        implicit-refs (set/difference (set (implicit-references-for-query parsed-query db-id))
                                       (set explicit-refs))]
     ;; TODO: add table refs
     (concat (mark-reference explicit-refs true)

--- a/src/metabase/query_analysis/native_query_analyzer.clj
+++ b/src/metabase/query_analysis/native_query_analyzer.clj
@@ -30,8 +30,8 @@
 
 (def ^:private field-and-table-fragment
   "HoneySQL fragment to get the Field and Table"
-  {:select [[:f.id :field_id] [[:lower :f.name] :column]
-            [:t.id :table_id] [[:lower :t.name] :table]]
+  {:select [[:f.id :field-id] [[:lower :f.name] :column]
+            [:t.id :table-id] [[:lower :t.name] :table]]
    :from   [[:metabase_field :f]]
    ;; (t2/table-name :model/Table) doesn't work on CI since models/table.clj hasn't been loaded
    :join   [[:metabase_table :t] [:= :table_id :t.id]]})

--- a/src/metabase/query_analysis/native_query_analyzer.clj
+++ b/src/metabase/query_analysis/native_query_analyzer.clj
@@ -124,11 +124,11 @@
 (defn field-reference
   "Used by tests"
   [db-id table column]
-  (t2/select-one :model/Field (assoc field-and-table-fragment
-                                     :where [:and
-                                             [:= :t.db_id db-id]
-                                             (column-query nil {:table  (name table)
-                                                                :column (name column)})])))
+  (t2/select-one :model/QueryField (assoc field-and-table-fragment
+                                          :where [:and
+                                                  [:= :t.db_id db-id]
+                                                  (column-query nil {:table  (name table)
+                                                                     :column (name column)})])))
 
 (defn- explicit-references-for-query
   "Selects IDs of Fields that could be used in the query"
@@ -137,10 +137,10 @@
         tables  (map :component table-maps)]
     (consolidate-columns
      columns
-     (t2/select :model/Field (assoc field-and-table-fragment
-                                    :where [:and
-                                            [:= :t.db_id db-id]
-                                            (into [:or] (map (partial column-query tables) columns))])))))
+     (t2/select :model/QueryField (assoc field-and-table-fragment
+                                         :where [:and
+                                                 [:= :t.db_id db-id]
+                                                 (into [:or] (map (partial column-query tables) columns))])))))
 
 (defn- wildcard-tables
   "Given a parsed query, return the list of tables we are selecting from using a wildcard."
@@ -160,11 +160,11 @@
   "Similar to explicit-field-ids-for-query, but for wildcard selects"
   [parsed-query db-id]
   (when-let [tables (wildcard-tables parsed-query)]
-    (t2/select :model/Field (merge field-and-table-fragment
-                                   {:where [:and
-                                            [:= :t.db_id db-id]
-                                            [:= :f.active true]
-                                            (into [:or] (map table-query tables))]}))))
+    (t2/select :model/QueryField (merge field-and-table-fragment
+                                        {:where [:and
+                                                 [:= :t.db_id db-id]
+                                                 [:= :f.active true]
+                                                 (into [:or] (map table-query tables))]}))))
 
 (defn- mark-reference [refs explicit?]
   (map #(assoc % :explicit-reference explicit?) refs))

--- a/test/metabase/query_analysis/native_query_analyzer_test.clj
+++ b/test/metabase/query_analysis/native_query_analyzer_test.clj
@@ -50,10 +50,10 @@
 
 (defn- field-reference [table column]
   (let [reference (nqa/field-reference (mt/id) table column)]
-    ;; check that we found a valid reference
-    (assert (= #{:table-id :table :field-id :column} (set (keys reference))))
-    (assert (every? some? (vals reference)))
-    ;; the case depends on the driver, and we use what's in the database
+    ;; sanity-check that this is the right reference
+    (assert (= (mt/id table) (:table-id reference)))
+    (assert (= (mt/id table column) (:field-id reference)))
+    ;; sanity-check the names, whose case depends on the driver
     (assert (= (name table) (u/lower-case-en (:table reference))))
     (assert (= (name column) (u/lower-case-en (:column reference))))
     ;; tag it

--- a/test/metabase/query_analysis/native_query_analyzer_test.clj
+++ b/test/metabase/query_analysis/native_query_analyzer_test.clj
@@ -18,10 +18,6 @@
            ;; this is "Perv""e""rse"
            (#'nqa/field-query :f.name "\"Perv\"\"e\"\"rse\"")))))
 
-(defn- references->id-sets [refs]
-  {:explicit (not-empty (into #{} (comp (filter :explicit-reference) (keep :field_id)) refs))
-   :implicit (not-empty (into #{} (comp (remove :explicit-reference) (keep :field_id)) refs))})
-
 (deftest ^:parallel consolidate-columns-test
   (testing "We match references with known fields where possible, and remove redundancies"
     (is (= [{:field-id 1, :table "t1", :column "c1"}
@@ -42,7 +38,7 @@
                       {:field-id 3 :table "t3" :column "c3"}]))))))
 
 (defn- refs [sql]
-  (#'nqa/references-for-native (mt/native-query {:query sql})))
+  (sort-by (juxt :table :column) (#'nqa/references-for-native (mt/native-query {:query sql}))))
 
 (defn- explicit-reference [table column found?]
   (merge
@@ -50,40 +46,39 @@
     :column             (name column)
     :explicit-reference true}
    (when found?
-     {:table_id (mt/id table)
-      :field_id (mt/id table column)})))
+     {:table-id (mt/id table)
+      :field-id (mt/id table column)})))
 
 (deftest ^:parallel field-matching-test
-  (let [q (comp references->id-sets refs)]
-    (testing "simple query matches"
-      (is (= [(explicit-reference :venues :id true)]
-             (refs "select id from venues"))))
-    (testing "quotes stop case matching"
-      (is (= [(explicit-reference :venues :id false) ]
-             (refs "select \"id\" from venues")))
-      (is (= [(explicit-reference :venues :id true)]
-             (refs "select \"ID\" from venues"))))
-    (testing "you can mix quoted and unquoted names"
-      (is (= [(explicit-reference :venues :name true)
-              (explicit-reference :venues :id true)]
-             (refs "select v.\"ID\", v.name from venues v")))
-      (is (= [(explicit-reference :venues :name true)
-              (explicit-reference :venues :id true)]
-             (refs "select v.`ID`, v.name from venues v"))))
-    (testing "It will find all relevant columns if query is not specific"
-      (is (= [(explicit-reference :checkins :id true)
-              (explicit-reference :venues :id true)]
-             (refs "select id from venues join checkins"))))
-    (testing "But if you are specific - then it's a concrete field"
-      (is (= {:explicit #{(mt/id :venues :id)} :implicit nil}
-             (q "select v.id from venues v join checkins"))))
-    (testing "And wildcards are matching everything"
-      (is (= {false 10}
-             (frequencies (map :explicit-reference (refs "select * from venues v join checkins")))))
-      (is (= {false 6}
-             (frequencies (map :explicit-reference (refs "select v.* from venues v join checkins"))))))
+  (testing "simple query matches"
+    (is (= [(explicit-reference :venues :id true)]
+           (refs "select id from venues"))))
+  (testing "quotes stop case matching"
+    (is (= [(explicit-reference :venues :id false)]
+           (refs "select \"id\" from venues")))
+    (is (= [(explicit-reference :venues :id true)]
+           (refs "select \"ID\" from venues"))))
+  (testing "you can mix quoted and unquoted names"
+    (is (= [(explicit-reference :venues :id true)
+            (explicit-reference :venues :name true)]
+           (refs "select v.\"ID\", v.name from venues v")))
+    (is (= [(explicit-reference :venues :id true)
+            (explicit-reference :venues :name true)]
+           (refs "select v.`ID`, v.name from venues v"))))
+  (testing "It will find all relevant columns if query is not specific"
+    (is (= [(explicit-reference :checkins :id true)
+            (explicit-reference :venues :id true)]
+           (refs "select id from venues join checkins"))))
+  (testing "But if you are specific - then it's a concrete field"
+    (is (= [(explicit-reference :venues :id true)]
+           (refs "select v.id from venues v join checkins"))))
+  (testing "And wildcards are matching everything"
+    (is (= {false 10}
+           (frequencies (map :explicit-reference (refs "select * from venues v join checkins")))))
+    (is (= {false 6}
+           (frequencies (map :explicit-reference (refs "select v.* from venues v join checkins"))))))
 
-    (when (not (contains? #{:snowflake :oracle} driver/*driver*))
-      (testing "Analysis does not fail due to keywords that are only reserved in other databases"
-        (is (= [(explicit-reference :venues :id true)]
-               (refs "select id as final from venues")))))))
+  (when (not (contains? #{:snowflake :oracle} driver/*driver*))
+    (testing "Analysis does not fail due to keywords that are only reserved in other databases"
+      (is (= [(explicit-reference :venues :id true)]
+             (refs "select id as final from venues"))))))

--- a/test/metabase/query_analysis_test.clj
+++ b/test/metabase/query_analysis_test.clj
@@ -27,10 +27,9 @@
     (is (false? (query-analysis/enabled-type? :unexpected)))))
 
 (defn- field-id-references [card-or-query]
-  (into #{}
-        (map :field-id)
-        (#'query-analysis/query-references
-         (:dataset_query card-or-query card-or-query))))
+  (->> (:dataset_query card-or-query card-or-query)
+       #'query-analysis/query-references
+       (into #{} (map :field-id))))
 
 (deftest parse-mbql-test
   (testing "Parsing MBQL query returns correct used fields"
@@ -55,8 +54,7 @@
           venues-name       (lib.metadata/field metadata-provider (mt/id :venues :name))
           mlv2-query        (-> (lib/query metadata-provider venues)
                                 (lib/aggregate (lib/distinct venues-name)))]
-      (is (= #{(mt/id :venues :name)}
-             (field-id-references mlv2-query))))))
+      (is (= #{(mt/id :venues :name)} (field-id-references mlv2-query))))))
 
 (deftest replace-fields-and-tables!-test
   (testing "fields and tables in a native card can be replaced"


### PR DESCRIPTION
Refers https://github.com/metabase/metabase/issues/45027

### Description

This refactor updates the plumbing between Metabase and Macaw such that column references which do not resolve to Fields are not implicitly dropped.

This prepares us to persist these records, once the underlying database model is updated.