### PR TITLE
Make the sandbox cleanup logic more robust, and reorganize some perms code for better testing

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/application_permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/application_permissions.clj
@@ -5,8 +5,8 @@
    [clojure.data :as data]
    [metabase.models :refer [ApplicationPermissionsRevision Permissions]]
    [metabase.models.application-permissions-revision :as a-perm-revision]
-   [metabase.models.data-permissions.graph :as data-perms.graph]
    [metabase.models.permissions :as perms]
+   [metabase.permissions.util :as perms.u]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
@@ -81,10 +81,10 @@
         old-perms          (:groups old-graph)
         new-perms          (:groups new-graph)
         [diff-old changes] (data/diff old-perms new-perms)]
-    (data-perms.graph/log-permissions-changes diff-old changes)
-    (data-perms.graph/check-revision-numbers old-graph new-graph)
+    (perms.u/log-permissions-changes diff-old changes)
+    (perms.u/check-revision-numbers old-graph new-graph)
     (when (seq changes)
       (t2/with-transaction [_conn]
        (doseq [[group-id changes] changes]
          (update-application-permissions! group-id changes))
-       (data-perms.graph/save-perms-revision! ApplicationPermissionsRevision (:revision old-graph) (:groups old-graph) changes)))))
+       (perms.u/save-perms-revision! ApplicationPermissionsRevision (:revision old-graph) (:groups old-graph) changes)))))

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/permissions/delete_sandboxes.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/permissions/delete_sandboxes.clj
@@ -35,44 +35,33 @@
 (defn- delete-gtaps-for-group-table! [{:keys [group-id table-id] :as _context} changes]
   (log/debugf "Deleting unneeded GTAPs for Group %d for Table %d. Graph changes: %s"
              group-id table-id (pr-str changes))
-  (cond
-    (= changes :unrestricted)
+  (if (not= changes :sandboxed)
     (do
       (log/debugf "Group %d now has full data perms for Table %d, deleting GTAP for this Table if one exists"
                  group-id table-id)
       (delete-gtaps-with-condition! group-id [:= :table.id table-id]))
-
-    (= changes :sandboxed)
     (log/debugf "Group %d now has full sandboxed query perms for Table %d. Do not need to delete GTAPs."
                group-id table-id)))
 
 (defn- delete-gtaps-for-group-schema! [{:keys [group-id database-id schema-name], :as context} changes]
   (log/debugf "Deleting unneeded GTAPs for Group %d for Database %d, schema %s. Graph changes: %s"
              group-id database-id (pr-str schema-name) (pr-str changes))
-  (cond
-    (= changes :unrestricted)
+  (if (keyword? changes)
     (do
-      (log/debugf "Group %d changes has full data perms for Database %d schema %s, deleting all GTAPs for this schema"
-                  group-id database-id (pr-str schema-name))
+      (log/debugf "Group %d changes has %s perms for Database %d schema %s, deleting all sandboxes for this schema"
+                  group-id changes database-id (pr-str schema-name))
       (delete-gtaps-with-condition! group-id [:and [:= :table.db_id database-id] [:= :table.schema schema-name]]))
-
-    :else
     (doseq [table-id (set (keys changes))]
       (delete-gtaps-for-group-table! (assoc context :table-id table-id) (get changes table-id)))))
 
 (defn- delete-gtaps-for-group-database! [{:keys [group-id database-id], :as context} changes]
   (log/debugf "Deleting unneeded GTAPs for Group %d for Database %d. Graph changes: %s"
               group-id database-id (pr-str changes))
-  (if (#{:unrestricted :legacy-no-self-service :blocked :impersonated} changes)
+  (if (keyword? changes)
+    ;; If we're setting a single permission type for the entire DB, clear all sandboxes in the DB
     (do
-      (log/debugf "Group %d %s for Database %d, deleting all GTAPs for this DB"
-                  group-id
-                  (case changes
-                    :unrestricted "now has full data perms"
-                    :legacy-no-self-service "now has full data perms"
-                    :blocked      "is now BLOCKED from all non-data-perms access"
-                    :impersonated "is now using connection impersonation")
-                  database-id)
+      (log/debugf "Group %d now has %s perms for Database %d, deleting all sandboxes for this schema"
+                  group-id changes database-id)
       (delete-gtaps-with-condition! group-id [:= :table.db_id database-id]))
     (doseq [schema-name (set (keys changes))]
       (delete-gtaps-for-group-schema!

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
@@ -48,7 +48,10 @@
         (is (nil? (perms group-id)))))))
 
 (defn- grant-block-perms! [group-id]
-  (data-perms.graph/update-data-perms-graph! [group-id (mt/id) :view-data] :blocked))
+  (data-perms.graph/update-data-perms-graph!
+   (-> (data-perms.graph/api-graph)
+       (assoc-in [:groups group-id (mt/id) :view-data] :blocked)
+       (assoc-in [:groups group-id (mt/id) :create-queries] :no))))
 
 (defn- api-grant-block-perms! [group-id]
   (let [current-graph (data-perms.graph/api-graph)
@@ -84,13 +87,13 @@
         (t2.with-temp/with-temp [PermissionsGroup {group-id :id}]
           (testing "Group should have unrestricted view-data perms upon creation"
             (is (= :unrestricted
-                   (test-db-perms group-id))))
-          ;; Revoke native perms so that we can set block perms
-          (data-perms/set-database-permission! group-id (mt/id) :perms/create-queries :query-builder)
-          (testing "group has no existing permissions"
-            (mt/with-restored-data-perms-for-group! group-id
-              (grant! group-id)
-              (is (nil? (test-db-perms group-id)))))
+                   (test-db-perms group-id)))
+            ; Revoke native perms so that we can set block perms
+            (data-perms/set-database-permission! group-id (mt/id) :perms/create-queries :query-builder)
+            (testing "group has no existing permissions"
+              (mt/with-restored-data-perms-for-group! group-id
+                (grant! group-id)
+                (is (nil? (test-db-perms group-id))))))
           (testing "group has existing data permissions... :block should remove them"
             (mt/with-restored-data-perms-for-group! group-id
               (data-perms/set-database-permission! group-id (mt/id) :perms/view-data :unrestricted)

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
@@ -138,9 +138,9 @@
               new-graph     (assoc-in current-graph
                                       [:groups group-id (mt/id)]
                                       {:view-data :blocked :create-queries :query-builder-and-native})]
-          (is (=? {:message #".*Invalid DB permissions: If you have write access for native queries, you must have data access to all schemas.*"}
+          (is (=? #"Cannot parse permissions graph because it is invalid.*"
                   (mt/with-premium-features #{:advanced-permissions}
-                    (mt/user-http-request :crowberto :put 500 "permissions/graph" new-graph)))))))))
+                    (mt/user-http-request :crowberto :put 400 "permissions/graph" new-graph)))))))))
 
 (deftest delete-database-delete-block-perms-test
   (testing "If a Database gets DELETED, any block permissions for it should get deleted too."

--- a/src/metabase/api/permission_graph.clj
+++ b/src/metabase/api/permission_graph.clj
@@ -103,20 +103,6 @@
     (fn [{:keys [native schemas]}]
       (not (and (= native :write) schemas (not (#{:all :impersonated} schemas)))))]])
 
-(def ^:private DbGraph
-  [:schema {:registry {"DataPerms" DataPerms}}
-   [:map-of
-    Id
-    [:map
-     [:view-data {:optional true} Schemas]
-     [:create-queries {:optional true} Schemas]
-     [:data {:optional true} "DataPerms"]
-     [:download {:optional true} "DataPerms"]
-     [:data-model {:optional true} "DataPerms"]
-     ;; We use :yes and :no instead of booleans for consistency with the application perms graph, and
-     ;; consistency with the language used on the frontend.
-     [:details {:optional true} [:enum :yes :no]]]]])
-
 (def StrictDbGraph
   "like db-graph, but with added validations:
    - Ensures 'view-data' is not 'blocked' if 'create-queries' is 'query-builder-and-native'."
@@ -138,10 +124,11 @@
 
 (def DataPermissionsGraph
   "Used to transform, and verify data permissions graph"
-  [:map [:groups [:map-of GroupId [:maybe DbGraph]]]])
+  [:map
+   [:groups [:map-of GroupId [:maybe StrictDbGraph]]]])
 
-(def StrictData
-  "Top level strict data graph schema"
+(def StrictApiPermissionsGraph
+  "Top level strict data graph schema expected over the API. Includes revision ID for avoiding concurrent updates."
   [:map
    [:groups [:map-of GroupId [:maybe StrictDbGraph]]]
    [:revision int?]])

--- a/src/metabase/api/permissions.clj
+++ b/src/metabase/api/permissions.clj
@@ -149,7 +149,7 @@
             new       (or new {})]
         (perms.u/log-permissions-changes old new)
         (perms.u/check-revision-numbers old-graph new-graph)
-        (data-perms.graph/update-data-perms-graph! new)
+        (data-perms.graph/update-data-perms-graph! {:groups new})
         (perms.u/save-perms-revision! :model/PermissionsRevision (:revision old-graph) old new)
         (let [sandbox-updates        (:sandboxes new-graph)
               sandboxes              (when sandbox-updates

--- a/src/metabase/api/permissions.clj
+++ b/src/metabase/api/permissions.clj
@@ -1,6 +1,7 @@
 (ns metabase.api.permissions
   "/api/permissions endpoints."
   (:require
+   [clojure.data :as data]
    [compojure.core :refer [DELETE GET POST PUT]]
    [honey.sql.helpers :as sql.helpers]
    [java-time.api :as t]
@@ -19,6 +20,7 @@
     :refer [PermissionsGroup]]
    [metabase.models.permissions-revision :as perms-revision]
    [metabase.models.setting :as setting :refer [defsetting]]
+   [metabase.permissions.util :as perms.u]
    [metabase.public-settings.premium-features
     :as premium-features
     :refer [defenterprise]]
@@ -129,28 +131,37 @@
   {body :map
    skip-graph [:maybe :boolean]}
   (api/check-superuser)
-  (let [graph (mc/decode api.permission-graph/DataPermissionsGraph
-                         body
-                         (mtx/transformer
-                          mtx/string-transformer
-                          (mtx/transformer {:name :perm-graph})))]
-    (when-not (mc/validate api.permission-graph/DataPermissionsGraph graph)
-      (let [explained (mu/explain api.permission-graph/DataPermissionsGraph graph)]
+  (let [new-graph (mc/decode api.permission-graph/StrictApiPermissionsGraph
+                             body
+                             (mtx/transformer
+                              mtx/string-transformer
+                              (mtx/transformer {:name :perm-graph})))]
+    (when-not (mc/validate api.permission-graph/DataPermissionsGraph new-graph)
+      (let [explained (mu/explain api.permission-graph/DataPermissionsGraph new-graph)]
         (throw (ex-info (tru "Cannot parse permissions graph because it is invalid: {0}" (pr-str explained))
                         {:status-code 400}))))
     (t2/with-transaction [_conn]
-      (data-perms.graph/update-data-perms-graph! (dissoc graph :sandboxes :impersonations))
-      (let [sandbox-updates        (:sandboxes graph)
-            sandboxes              (when sandbox-updates
-                                     (upsert-sandboxes! sandbox-updates))
-            impersonation-updates  (:impersonations graph)
-            impersonations         (when impersonation-updates
-                                     (insert-impersonations! impersonation-updates))
-            group-ids (-> graph :groups keys)]
-        (merge {:revision (perms-revision/latest-id)}
-               (when-not skip-graph {:groups (:groups (data-perms.graph/api-graph {:group-ids group-ids}))})
-               (when sandboxes {:sandboxes sandboxes})
-               (when impersonations {:impersonations impersonations}))))))
+      (let [group-ids (-> new-graph :groups keys)
+            old-graph (data-perms.graph/api-graph {:group-ids group-ids})
+            [old new] (data/diff (:groups old-graph)
+                                 (:groups new-graph))
+            old       (or old {})
+            new       (or new {})]
+        (perms.u/log-permissions-changes old new)
+        (perms.u/check-revision-numbers old-graph new-graph)
+        (data-perms.graph/update-data-perms-graph! new)
+        (perms.u/save-perms-revision! :model/PermissionsRevision (:revision old-graph) old new)
+        (let [sandbox-updates        (:sandboxes new-graph)
+              sandboxes              (when sandbox-updates
+                                       (upsert-sandboxes! sandbox-updates))
+              impersonation-updates  (:impersonations new-graph)
+              impersonations         (when impersonation-updates
+                                       (insert-impersonations! impersonation-updates))
+              group-ids (-> new-graph :groups keys)]
+          (merge {:revision (perms-revision/latest-id)}
+                 (when-not skip-graph {:groups (:groups (data-perms.graph/api-graph {:group-ids group-ids}))})
+                 (when sandboxes {:sandboxes sandboxes})
+                 (when impersonations {:impersonations impersonations})))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                          PERMISSIONS GROUP ENDPOINTS                                           |

--- a/src/metabase/models/collection/graph.clj
+++ b/src/metabase/models/collection/graph.clj
@@ -9,11 +9,11 @@
    [metabase.db.query :as mdb.query]
    [metabase.models.collection :as collection :refer [Collection]]
    [metabase.models.collection-permission-graph-revision :as c-perm-revision]
-   [metabase.models.data-permissions.graph :as data-perms.graph]
    [metabase.models.permissions :as perms :refer [Permissions]]
    [metabase.models.permissions-group
     :as perms-group
     :refer [PermissionsGroup]]
+   [metabase.permissions.util :as perms.u]
    [metabase.public-settings.premium-features :refer [defenterprise]]
    [metabase.util :as u]
    [metabase.util.honey-sql-2 :as h2x]
@@ -198,7 +198,7 @@
          new-perms          (into {} (for [[group-id collection-id->perms] new-perms]
                                        [group-id (select-keys collection-id->perms (keys (get old-perms group-id)))]))
          [diff-old changes] (data/diff old-perms new-perms)]
-     (data-perms.graph/check-revision-numbers old-graph new-graph)
+     (perms.u/check-revision-numbers old-graph new-graph)
      (when (seq changes)
        (let [revision-id (t2/with-transaction [_conn]
                            (doseq [[group-id changes] changes]
@@ -206,5 +206,5 @@
                              (update-group-permissions! collection-namespace group-id changes))
                            (:id (create-perms-revision! (:revision old-graph))))]
          ;; The graph is updated infrequently, but `diff-old` and `old-graph` can get huge on larger instances.
-         (data-perms.graph/log-permissions-changes diff-old changes)
+         (perms.u/log-permissions-changes diff-old changes)
          (fill-revision-details! revision-id (assoc old-graph :namespace collection-namespace) changes))))))

--- a/src/metabase/models/data_permissions/graph.clj
+++ b/src/metabase/models/data_permissions/graph.clj
@@ -389,8 +389,8 @@
    (update-data-perms-graph!* (assoc-in (-> api-graph :groups) ks new-value))))
 
 (mu/defn update-data-perms-graph!
-  "Takes an API-style perms graph and sets the permissions in the database accordingly. Additionally validates the revision number,
-   logs the changes, and ensures impersonations and sandboxes are consistent."
+  "Takes an API-style perms graph and sets the permissions in the database accordingly. Additionally ensures
+  impersonations and sandboxes are consistent if necessary."
   ([graph-updates :- api.permission-graph/DataPermissionsGraph]
    (when (seq graph-updates)
      (let [group-updates (:groups graph-updates)]

--- a/src/metabase/models/data_permissions/graph.clj
+++ b/src/metabase/models/data_permissions/graph.clj
@@ -7,10 +7,8 @@
   Essentially, this is a translation layer between the graph used by the v1 permissions schema and the v2 permissions
   schema."
   (:require
-   [clojure.data :as data]
    [clojure.string :as str]
    [medley.core :as m]
-   [metabase.api.common :as api]
    [metabase.api.permission-graph :as api.permission-graph]
    [metabase.audit :as audit]
    [metabase.models.data-permissions :as data-perms]
@@ -21,7 +19,6 @@
     :refer [defenterprise]]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
-   [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [toucan2.core :as t2]))
 
@@ -162,7 +159,7 @@
          (into {}))
     m))
 
-(mu/defn api-graph :- api.permission-graph/StrictData
+(mu/defn api-graph :- api.permission-graph/DataPermissionsGraph
   "Converts the backend representation of the data permissions graph to the representation we send over the API. Mainly
   renames permission types and values from the names stored in the database to the ones expected by the frontend.
   - Converts DB key names to API key names
@@ -364,8 +361,8 @@
 (defn check-audit-db-permissions
   "Check that the changes coming in does not attempt to change audit database permission. Admins should
   change these permissions implicitly via collection permissions."
-  [changes]
-  (let [changes-ids (->> changes
+  [group-updates]
+  (let [changes-ids (->> group-updates
                          vals
                          (map keys)
                          (apply concat))]
@@ -373,41 +370,6 @@
       (throw (ex-info (tru
                        (str "Audit database permissions can only be changed by updating audit collection permissions."))
                       {:status-code 400})))))
-
-(defn log-permissions-changes
-  "Log changes to the permissions graph."
-  [old new]
-  (log/debug "Changing permissions"
-             "\n FROM:" (u/pprint-to-str :magenta old)
-             "\n TO:"   (u/pprint-to-str :blue new)))
-
-(defn check-revision-numbers
-  "Check that the revision number coming in as part of `new-graph` matches the one from `old-graph`. This way we can
-  make sure people don't submit a new graph based on something out of date, which would otherwise stomp over changes
-  made in the interim. Return a 409 (Conflict) if the numbers don't match up."
-  [old-graph new-graph]
-  (when (not= (:revision old-graph) (:revision new-graph))
-    (throw (ex-info (tru
-                      (str "Looks like someone else edited the permissions and your data is out of date. "
-                           "Please fetch new data and try again."))
-                    {:status-code 409}))))
-
-(defn save-perms-revision!
-  "Save changes made to permission graph for logging/auditing purposes.
-  This doesn't do anything if `*current-user-id*` is unset (e.g. for testing or REPL usage).
-  *  `model`   -- revision model, should be one of
-                  [PermissionsRevision, CollectionPermissionGraphRevision, ApplicationPermissionsRevision]
-  *  `before`  -- the graph before the changes
-  *  `changes` -- set of changes applied in this revision."
-  [model current-revision before changes]
-  (when api/*current-user-id*
-    (first (t2/insert-returning-instances! model
-                                           ;; manually specify ID here so if one was somehow inserted in the meantime in the fraction of a second since we
-                                           ;; called `check-revision-numbers` the PK constraint will fail and the transaction will abort
-                                           :id      (inc current-revision)
-                                           :before  before
-                                           :after   changes
-                                           :user_id api/*current-user-id*))))
 
 (mu/defn update-data-perms-graph!*
   "Takes an API-style perms graph and sets the permissions in the database accordingly."
@@ -429,21 +391,14 @@
 (mu/defn update-data-perms-graph!
   "Takes an API-style perms graph and sets the permissions in the database accordingly. Additionally validates the revision number,
    logs the changes, and ensures impersonations and sandboxes are consistent."
-  ([new-graph :- api.permission-graph/StrictData]
-   (let [group-ids (-> new-graph :groups keys)
-         old-graph (api-graph {:group-ids group-ids})
-         [old new] (data/diff (:groups old-graph) (:groups new-graph))
-         old       (or old {})
-         new       (or new {})]
-     (when (or (seq old) (seq new))
-       (log-permissions-changes old new)
-       (check-revision-numbers old-graph new-graph)
-       (check-audit-db-permissions new)
+  ([graph-updates :- api.permission-graph/DataPermissionsGraph]
+   (when (seq graph-updates)
+     (let [group-updates (:groups graph-updates)]
+       (check-audit-db-permissions group-updates)
        (t2/with-transaction [_conn]
-         (update-data-perms-graph!* new)
-         (save-perms-revision! :model/PermissionsRevision (:revision old-graph) old new)
-         (delete-impersonations-if-needed-after-permissions-change! new)
-         (delete-gtaps-if-needed-after-permissions-change! new)))))
+         (update-data-perms-graph!* group-updates)
+         (delete-impersonations-if-needed-after-permissions-change! group-updates)
+         (delete-gtaps-if-needed-after-permissions-change! group-updates)))))
 
   ;; The following arity is provided soley for convenience for tests/REPL usage
   ([ks :- [:vector :any] new-value]

--- a/src/metabase/models/data_permissions/graph.clj
+++ b/src/metabase/models/data_permissions/graph.clj
@@ -106,7 +106,7 @@
 
 (defn- rename-perm
   "Transforms a 'leaf' value with db-level or table-level perms in the data permissions graph into an API-style data permissions value.
-  There's some tricks in here that ellide table-level and table-level permissions values that are the most-permissive setting."
+  There's some tricks in here that ellide schema-level and table-level permissions values that are the most-permissive setting."
   [perm-map]
   (let [granular-keys [:perms/download-results :perms/manage-table-metadata
                        :perms/view-data :perms/create-queries]]

--- a/src/metabase/permissions/util.clj
+++ b/src/metabase/permissions/util.clj
@@ -4,8 +4,53 @@
   (:require
    [clojure.string :as str]
    [malli.core :as mc]
+   [metabase.api.common :as api]
+   [metabase.util :as u]
+   [metabase.util.i18n :refer [tru]]
+   [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.regex :as u.regex]))
+   [metabase.util.regex :as u.regex]
+   [toucan2.core :as t2]))
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                         API-level helpers                                                      |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(defn log-permissions-changes
+  "Log changes to the permissions graph."
+  [old new]
+  (log/debug "Changing permissions"
+             "\n FROM:" (u/pprint-to-str :magenta old)
+             "\n TO:"   (u/pprint-to-str :blue new)))
+
+(defn check-revision-numbers
+  "Check that the revision number coming in as part of `new-graph` matches the one from `old-graph`. This way we can
+  make sure people don't submit a new graph based on something out of date, which would otherwise stomp over changes
+  made in the interim. Return a 409 (Conflict) if the numbers don't match up."
+  [old-graph new-graph]
+  (when (not= (:revision old-graph) (:revision new-graph))
+    (throw (ex-info (tru
+                      (str "Looks like someone else edited the permissions and your data is out of date. "
+                           "Please fetch new data and try again."))
+                    {:status-code 409}))))
+
+(defn save-perms-revision!
+  "Save changes made to permission graph for logging/auditing purposes.
+  This doesn't do anything if `*current-user-id*` is unset (e.g. for testing or REPL usage).
+  *  `model`   -- revision model, should be one of
+                  [PermissionsRevision, CollectionPermissionGraphRevision, ApplicationPermissionsRevision]
+  *  `before`  -- the graph before the changes
+  *  `changes` -- set of changes applied in this revision."
+  [model current-revision before changes]
+  (when api/*current-user-id*
+    (first (t2/insert-returning-instances! model
+                                           ;; manually specify ID here so if one was somehow inserted in the meantime in the fraction of a second since we
+                                           ;; called `check-revision-numbers` the PK constraint will fail and the transaction will abort
+                                           :id      (inc current-revision)
+                                           :before  before
+                                           :after   changes
+                                           :user_id api/*current-user-id*))))
+
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                    PATH CLASSIFICATION + VALIDATION                                            |

--- a/test/metabase/api/permissions_test_util.clj
+++ b/test/metabase/api/permissions_test_util.clj
@@ -4,7 +4,7 @@
             [metabase.api.permission-graph :as api.permission-graph]))
 
 (def ^:private graph-output-schema
-  [:map-of @#'api.permission-graph/GroupId @#'api.permission-graph/DbGraph])
+  [:map-of @#'api.permission-graph/GroupId @#'api.permission-graph/StrictDbGraph])
 
 (defn- decode-and-validate [schema value]
   (mc/validate schema (mc/decode schema value (mtx/string-transformer))))

--- a/test/metabase/models/data_permissions/graph_test.clj
+++ b/test/metabase/models/data_permissions/graph_test.clj
@@ -10,7 +10,7 @@
    [toucan2.core :as db]))
 
 (deftest update-db-level-view-data-permissions!-test
-  (mt/with-premium-features #{:advanced-permissions}
+  (mt/with-premium-features #{:advanced-permissions :sandboxes}
     (mt/with-temp [:model/PermissionsGroup {group-id-1 :id}      {}
                    :model/Database         {database-id-1 :id}   {}
                    :model/Table            {table-id-1 :id}      {:db_id database-id-1
@@ -54,7 +54,7 @@
              :perms/download-results :no}}})))))
 
 (deftest update-db-level-create-queries-permissions!-test
-  (mt/with-premium-features #{:advanced-permissions}
+  (mt/with-premium-features #{:advanced-permissions :sandboxes}
     (mt/with-temp [:model/PermissionsGroup {group-id-1 :id}      {}
                    :model/Database         {database-id-1 :id}   {}
                    :model/Table            {table-id-1 :id}      {:db_id database-id-1
@@ -120,7 +120,7 @@
             {:perms/create-queries {"PUBLIC" {table-id-1 :no}}}}})))))
 
 (deftest update-db-level-data-access-permissions!-test
-  (mt/with-premium-features #{:advanced-permissions}
+  (mt/with-premium-features #{:advanced-permissions :sandboxes}
     (mt/with-temp [:model/PermissionsGroup {group-id-1 :id}      {}
                    :model/Database         {database-id-1 :id}   {}
                    :model/Table            {table-id-1 :id}      {:db_id database-id-1
@@ -437,7 +437,7 @@
 
 (deftest update-graph-validate-db-perms-test
   (testing "Check that validation of native query perms doesn't fail if only one of them changes"
-    (mt/with-additional-premium-features #{:advanced-permissions}
+    (mt/with-additional-premium-features #{:advanced-permissions :sandboxes}
       (mt/with-temp [:model/Database {db-id :id}]
         (mt/with-no-data-perms-for-all-users!
           (let [ks [:groups (u/the-id (perms-group/all-users)) db-id]]
@@ -476,7 +476,7 @@
 
 (deftest no-op-partial-graph-updates
   (testing "Partial permission graphs with no changes to the existing graph do not error when run repeatedly (#25221)"
-    (mt/with-additional-premium-features #{:advanced-permissions}
+    (mt/with-additional-premium-features #{:advanced-permissions :sandboxes}
       (mt/with-temp [:model/PermissionsGroup group]
         ;; Bind *current-user* so that permission revisions are written, which was the source of the original error
         (mt/with-current-user (mt/user->id :rasta)


### PR DESCRIPTION
1. Makes sandbox deletion more robust. When permissions for a db/schema/table change, we go through and ensure that any sandboxes that are no longer relevant are properly deleted. The existing logic had hard-coded permission values (i.e. `:unrestricted`, `:blocked`) but this isn't robust for when new permission values are added (like `:legacy-no-self-service`)
2. Reorganizes some permissions code to improve test coverage. The reason this wasn't caught before is that all the tests in `metabase.models.data-permissions.graph` were testing `update-data-perms-graph!*` instead of the actual entrypoint, `update-data-perms-graph!`. This was mainly because the latter also checks revision numbers, which are annoying to get correct in tests that don't care about concurrent updates.
	* To fix this I've moved some pieces of `update-data-perms-graph!` into the `PUT /api/permissions/graph` API handler, specifically logging permission changes, checking revision numbers, and saving the revision to the `permissions_revision` table. The helper functions for these I've moved to `metabase.permissions.util` since they're used from other namespaces as well.
	* Then, I've updated the permissions graph tests to call `update-data-perms-graph!` directly so that they _also_ exercise `delete-impersonations-if-needed-after-permissions-change!` and `delete-gtaps-if-needed-after-permissions-change!`