### PR TITLE
[perf] Improve DB syncing times

### DIFF
--- a/src/metabase/lib/metadata/cached_provider.cljc
+++ b/src/metabase/lib/metadata/cached_provider.cljc
@@ -51,18 +51,19 @@
 (defn- metadatas [cache uncached-provider metadata-type ids]
   (when (seq ids)
     (log/tracef "Getting %s metadata with IDs %s" metadata-type (pr-str (sort ids)))
-    (let [existing-ids (set (keys (get @cache metadata-type)))
-          missing-ids  (set/difference (set ids) existing-ids)]
-      (log/tracef "Already fetched %s: %s" metadata-type (pr-str (sort (set/intersection (set ids) existing-ids))))
-      (when (seq missing-ids)
-        (log/tracef "Need to fetch %s: %s" metadata-type (pr-str (sort missing-ids)))
-        ;; TODO -- we should probably store `::nil` markers for things we tried to fetch that didn't exist
-        (doseq [instance (lib.metadata.protocols/metadatas uncached-provider metadata-type missing-ids)]
-          (store-in-cache! cache [metadata-type (:id instance)] instance))))
+    (let [metadata-cache (get @cache metadata-type)]
+      (when-not (every? #(contains? metadata-cache %) ids)
+        (let [existing-ids (set (keys metadata-cache))
+              missing-ids  (set/difference (set ids) existing-ids)]
+          (log/tracef "Already fetched %s: %s" metadata-type (pr-str (sort (set/intersection (set ids) existing-ids))))
+          (when (seq missing-ids)
+            (log/tracef "Need to fetch %s: %s" metadata-type (pr-str (sort missing-ids)))
+            ;; TODO -- we should probably store `::nil` markers for things we tried to fetch that didn't exist
+            (doseq [instance (lib.metadata.protocols/metadatas uncached-provider metadata-type missing-ids)]
+              (store-in-cache! cache [metadata-type (:id instance)] instance))))))
     (into []
-          (comp (map (fn [id]
-                       (get-in-cache cache [metadata-type id])))
-                (filter some?))
+          (keep (fn [id]
+                  (get-in-cache cache [metadata-type id])))
           ids)))
 
 (defn- cached-metadatas [cache metadata-type metadata-ids]

--- a/src/metabase/lib/util/match/impl.cljc
+++ b/src/metabase/lib/util/match/impl.cljc
@@ -41,8 +41,9 @@
   [replace-fn clause-parents form]
   (cond
     (map? form)
-    (into form (for [[k v] form]
-                 [k (replace-fn (conj clause-parents k) v)]))
+    (reduce-kv (fn [form k v]
+                 (assoc form k (replace-fn (conj clause-parents k) v)))
+               form form)
 
     (sequential? form)
     (mapv (partial replace-fn (if (keyword? (first form))

--- a/src/metabase/sync/sync_metadata/fields/common.clj
+++ b/src/metabase/sync/sync_metadata/fields/common.clj
@@ -63,9 +63,10 @@
   corresponding Metabase Field for field metadata from the DB, or vice versa. Will prefer exact matches."
   [field-metadata :- TableMetadataFieldWithOptionalID
    other-metadata :- [:set TableMetadataFieldWithOptionalID]]
-  (let [matches (keep
+  (let [field-meta-canonical (canonical-name field-metadata)
+        matches (keep
                   (fn [other-field-metadata]
-                    (when (= (canonical-name field-metadata)
+                    (when (= field-meta-canonical
                              (canonical-name other-field-metadata))
                       other-field-metadata))
                   other-metadata)]

--- a/src/metabase/util/snake_hating_map.clj
+++ b/src/metabase/util/snake_hating_map.clj
@@ -12,6 +12,8 @@
    [potemkin :as p]
    [pretty.core :as pretty]))
 
+(set! *warn-on-reflection* true)
+
 (defn- snake-cased-key? [k]
   (some-> k (str/includes? "_")))
 
@@ -50,6 +52,9 @@
     (keys m))
   (meta [_this]
     (meta m))
+  (entryAt [this k]
+    (when (contains? m k)
+      (potemkin.PersistentMapProxy$MapEntry. this k)))
   (with-meta [this metta]
     (let [m' (with-meta m metta)]
       (if (identical? m m')


### PR DESCRIPTION
The benchmark I used is the reduced version of this dataset: https://drive.google.com/file/d/1VhY_Kr7bSWAmnpj3AK2e8ayVTPyOniOj/view?usp=sharing, but I only use 3 tables from it (3tables x 800colums x 1row). On `master` on my machine, the full sync time (add db + fingerprinting + updating field values) is 1.5 minutes. With the suggested commits, I brought it down to 1 minute (~33% reduction).

Nothing controversial here besides caching the attempt to load EE namespaces. This should be fine unless you support a case where EE namespaces suddenly appear on classpath during server operation and Metabase picks it up?