### PR TITLE
Number formatter Reports correct Decimal places for negative Numbers

### DIFF
--- a/src/metabase/formatter.clj
+++ b/src/metabase/formatter.clj
@@ -129,7 +129,7 @@
                                integral? 0
                                currency? (get-in currency/currency [(keyword (or currency "USD")) :decimal_digits])
                                percent?  (min 2 decimals-in-value) ;; 5.5432 -> %554.32
-                               :else (if (>= scaled-value 1)
+                               :else (if (>= (abs scaled-value) 1)
                                        (min 2 decimals-in-value) ;; values greater than 1 round to 2 decimal places
                                        (let [n-figs (sig-figs-after-decimal scaled-value decimal)]
                                          (if (> n-figs 2)

--- a/src/metabase/formatter.clj
+++ b/src/metabase/formatter.clj
@@ -63,11 +63,11 @@
      0
      (let [val-string (-> (condp = (type value)
                             java.math.BigDecimal (.toPlainString ^BigDecimal value)
-                            java.lang.Double (format "%.20f" value)
-                            java.lang.Float (format "%.20f" value)
+                            java.lang.Double     (format "%.20f" value)
+                            java.lang.Float      (format "%.20f" value)
                             (str value))
                           (strip-trailing-zeroes (str decimal)))
-           [_n d] (str/split val-string #"[^\d*]")]
+           d          (last (str/split val-string #"[^\d*]"))]
        (count d)))))
 
 (defn- sig-figs-after-decimal

--- a/test/metabase/formatter_test.clj
+++ b/test/metabase/formatter_test.clj
@@ -90,6 +90,8 @@
       ;; and show as many decimals as necessary to display these 2 sig-figs
       (is (= ["2"    "0"]      [(format 2 nil)       (format 0 nil)]))
       (is (= ["2.1"  "0.1"]    [(format 2.1 nil)     (format 0.1 nil)]))
+      (is (= ["0.57" "-0.57"]  [(format 0.57 nil)    (format -0.57 nil)]))
+      (is (= ["2.57" "-2.57"]  [(format 2.57 nil)    (format -2.57 nil)]))
       (is (= ["2.01" "0.01"]   [(format 2.01 nil)    (format 0.01 nil)]))
       (is (= ["2"    "0.001"]  [(format 2.001 nil)   (format 0.001 nil)]))
       (is (= ["2.01" "0.006"]  [(format 2.006 nil)   (format 0.006 nil)]))

--- a/test/metabase/formatter_test.clj
+++ b/test/metabase/formatter_test.clj
@@ -25,38 +25,38 @@
       (is (= "2" (format 2 nil))))
     (testing "Currency"
       (testing "defaults to USD and two decimal places and symbol"
-        (is (= "$12,345.54" (fmt {::mb.viz/number-style "currency"
+        (is (= "$12,345.54" (fmt {::mb.viz/number-style       "currency"
                                   ::mb.viz/currency-in-header false}))))
       (testing "Defaults to currency when there is a currency style"
-        (is (= "$12,345.54" (fmt {::mb.viz/currency-style "symbol"
+        (is (= "$12,345.54" (fmt {::mb.viz/currency-style     "symbol"
                                   ::mb.viz/currency-in-header false}))))
       (testing "Defaults to currency when there is a currency"
-        (is (= "$12,345.54" (fmt {::mb.viz/currency "USD"
+        (is (= "$12,345.54" (fmt {::mb.viz/currency           "USD"
                                   ::mb.viz/currency-in-header false}))))
       (testing "respects the number of decimal places when specified"
-        (is (= "$12,345.54320" (fmt {::mb.viz/currency "USD"
-                                     ::mb.viz/decimals 5
+        (is (= "$12,345.54320" (fmt {::mb.viz/currency           "USD"
+                                     ::mb.viz/decimals           5
                                      ::mb.viz/currency-in-header false}))))
       (testing "Other currencies"
-        (is (= "AED12,345.54" (fmt {::mb.viz/currency "AED"
+        (is (= "AED12,345.54" (fmt {::mb.viz/currency           "AED"
                                     ::mb.viz/currency-in-header false})))
         (is (= "12,345.54 Cape Verdean escudos"
-               (fmt {::mb.viz/currency       "CVE"
-                     ::mb.viz/currency-style "name"
+               (fmt {::mb.viz/currency           "CVE"
+                     ::mb.viz/currency-style     "name"
                      ::mb.viz/currency-in-header false})))
         (testing "which have no 'cents' and thus no decimal places"
-          (is (= "Af12,346" (fmt {::mb.viz/currency "AFN"
+          (is (= "Af12,346" (fmt {::mb.viz/currency           "AFN"
                                   ::mb.viz/currency-in-header false})))
-          (is (= "₡12,346" (fmt {::mb.viz/currency "CRC"
+          (is (= "₡12,346" (fmt {::mb.viz/currency           "CRC"
                                  ::mb.viz/currency-in-header false})))
-          (is (= "ZK12,346" (fmt {::mb.viz/currency "ZMK"
+          (is (= "ZK12,346" (fmt {::mb.viz/currency           "ZMK"
                                   ::mb.viz/currency-in-header false})))))
       (testing "Understands name, code, and symbol"
         (doseq [[style expected] [["name" "12,345.54 Czech Republic korunas"]
                                   ["symbol" "Kč12,345.54"]
                                   ["code" "CZK 12,345.54"]]]
-          (is (= expected (fmt {::mb.viz/currency       "CZK"
-                                ::mb.viz/currency-style style
+          (is (= expected (fmt {::mb.viz/currency           "CZK"
+                                ::mb.viz/currency-style     style
                                 ::mb.viz/currency-in-header false}))
               style))))
     (testing "scientific notation"
@@ -82,21 +82,22 @@
                                         ::mb.viz/decimals     2})))
       ;; You need at least 5 digits (not the scale by 100 for percents) to show the low value
       (is (= "0.00001%" (format 0.0000001 {::mb.viz/number-style "percent"
-                                           ::mb.viz/decimals          5}))))
+                                           ::mb.viz/decimals     5}))))
     (testing "Match UI 'natural formatting' behavior for decimal values with no column formatting present"
       ;; basically, for numbers greater than 1, round to 2 decimal places,
       ;; and do not display decimals if they end up as zeroes
       ;; for numbers less than 1, round to 2 significant-figures,
       ;; and show as many decimals as necessary to display these 2 sig-figs
-      (is (= ["2"    "0"]      [(format 2 nil)       (format 0 nil)]))
-      (is (= ["2.1"  "0.1"]    [(format 2.1 nil)     (format 0.1 nil)]))
-      (is (= ["0.57" "-0.57"]  [(format 0.57 nil)    (format -0.57 nil)]))
-      (is (= ["2.57" "-2.57"]  [(format 2.57 nil)    (format -2.57 nil)]))
-      (is (= ["2.01" "0.01"]   [(format 2.01 nil)    (format 0.01 nil)]))
-      (is (= ["2"    "0.001"]  [(format 2.001 nil)   (format 0.001 nil)]))
-      (is (= ["2.01" "0.006"]  [(format 2.006 nil)   (format 0.006 nil)]))
-      (is (= ["2"    "0.0049"] [(format 2.0049 nil)  (format 0.0049 nil)]))
-      (is (= ["2"    "0.005"]  [(format 2.00499 nil) (format 0.00499 nil)])))
+      (is (= ["2"    "0"]       [(format 2 nil)       (format 0 nil)]))
+      (is (= ["2.1"  "0.1"]     [(format 2.1 nil)     (format 0.1 nil)]))
+      (is (= ["0.57" "-0.57"]   [(format 0.57 nil)    (format -0.57 nil)]))
+      (is (= ["2.57" "-2.57"]   [(format 2.57 nil)    (format -2.57 nil)]))
+      (is (= ["-0.22" "-1.34"]  [(format -0.2222 nil) (format -1.345 nil)]))
+      (is (= ["2.01" "0.01"]    [(format 2.01 nil)    (format 0.01 nil)]))
+      (is (= ["2"    "0.001"]   [(format 2.001 nil)   (format 0.001 nil)]))
+      (is (= ["2.01" "0.006"]   [(format 2.006 nil)   (format 0.006 nil)]))
+      (is (= ["2"    "0.0049"]  [(format 2.0049 nil)  (format 0.0049 nil)]))
+      (is (= ["2"    "0.005"]   [(format 2.00499 nil) (format 0.00499 nil)])))
     (testing "Column Settings"
       (letfn [(fmt-with-type
                 ([type value] (fmt-with-type type value nil))

--- a/test/metabase/pulse/pulse_integration_test.clj
+++ b/test/metabase/pulse/pulse_integration_test.clj
@@ -898,7 +898,7 @@
                                                 :user_id          (mt/user->id :rasta)}]
           (testing "The html output renders the table cells as geographic coordinates"
             (is (= [[["1" "9.85" "57.09"]
-                     ["2" "39.22" "-6.2"]
+                     ["2" "39.22" "-6.22"]
                      ["3" "-2.2" "57.2"]
                      ["4" "-89.68" "39.84"]
                      ["5" "54.65" "24.43"]]


### PR DESCRIPTION
Fixes #41640

Prior to this, the number formatter would get the incorrect number of decimal places for negative numbers.

The way the decimal places count is derived works as follows:

 - convert number to a string
 - split the string on the separator (decimal, comma, whatever the instance has set)
 - destructure that split into [int decimal]
 - count decimal to get the number of decimals.

That all works for positive numbers, but for negative numbers, the regex was just splitting on 'not digits', so we got an extra group due to the leading negative sign. This would incorrectly destructure  the 'int' part of the number into the count, thus we would always get 1 instead of the correct value.

This fixes it by just taking last instead of destructuring.