### PR TITLE
Use regular mantine buttons for filter and summarize buttons in query builder

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewTitleHeader.module.css
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewTitleHeader.module.css
@@ -1,7 +1,7 @@
 .FilterButton {
   transition: background 300ms linear, border 300ms linear;
 
-  &:hover:not([data-hack="🤣"]) {
+  &:hover:not([data-css-specifity-hack="🤣"]) {
     color: var(--mb-color-filter);
     border-color: color-mix(in srgb, var(--mb-color-filter) 30%, white);
     background-color: color-mix(in srgb, var(--mb-color-filter) 10%, white);

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewTitleHeader.module.css
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewTitleHeader.module.css
@@ -1,7 +1,7 @@
 .FilterButton {
   transition: background 300ms linear, border 300ms linear;
 
-  &:hover {
+  &:hover:not([data-hack="🤣"]) {
     color: var(--mb-color-filter);
     border-color: color-mix(in srgb, var(--mb-color-filter) 30%, white);
     background-color: color-mix(in srgb, var(--mb-color-filter) 10%, white);

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewTitleHeader.module.css
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewTitleHeader.module.css
@@ -1,0 +1,19 @@
+.FilterButton {
+  transition: background 300ms linear, border 300ms linear;
+
+  &:hover {
+    color: var(--mb-color-filter);
+    border-color: color-mix(in srgb, var(--mb-color-filter) 30%, white);
+    background-color: color-mix(in srgb, var(--mb-color-filter) 10%, white);
+  }
+}
+
+.SummarizeButton {
+  transition: background 300ms linear, border 300ms linear;
+
+  &:hover:not([data-active="true"]) {
+    color: var(--mb-color-summarize);
+    border-color: color-mix(in srgb, var(--mb-color-summarize) 40%, white);
+    background-color: color-mix(in srgb, var(--mb-color-summarize) 15%, white);
+  }
+}

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewTitleHeader.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewTitleHeader.styled.tsx
@@ -78,6 +78,26 @@ export const SavedQuestionHeaderButtonContainer = styled.div<{
   right: ${props => (props.isModelOrMetric ? "0px" : "0.38rem")};
 `;
 
+export const FilterButton = styled(MantineButton)`
+  transition: background 300ms linear, border 300ms linear;
+
+  &:hover {
+    color: var(--mb-color-filter);
+    border-color: color-mix(in srgb, var(--mb-color-filter) 30%, white);
+    background-color: color-mix(in srgb, var(--mb-color-filter) 10%, white);
+  }
+` as unknown as typeof MantineButton;
+
+export const SummarizeButton = styled(MantineButton)`
+  transition: background 300ms linear, border 300ms linear;
+
+  &:hover:not([data-active="true"]) {
+    color: var(--mb-color-summarize);
+    border-color: color-mix(in srgb, var(--mb-color-summarize) 40%, white);
+    background-color: color-mix(in srgb, var(--mb-color-summarize) 15%, white);
+  }
+` as unknown as typeof MantineButton;
+
 export const HeaderButton = styled(Button)<{
   active: boolean;
 }>`

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewTitleHeader.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewTitleHeader.styled.tsx
@@ -78,26 +78,6 @@ export const SavedQuestionHeaderButtonContainer = styled.div<{
   right: ${props => (props.isModelOrMetric ? "0px" : "0.38rem")};
 `;
 
-export const FilterButton = styled(MantineButton)`
-  transition: background 300ms linear, border 300ms linear;
-
-  &:hover {
-    color: var(--mb-color-filter);
-    border-color: color-mix(in srgb, var(--mb-color-filter) 30%, white);
-    background-color: color-mix(in srgb, var(--mb-color-filter) 10%, white);
-  }
-` as unknown as typeof MantineButton;
-
-export const SummarizeButton = styled(MantineButton)`
-  transition: background 300ms linear, border 300ms linear;
-
-  &:hover:not([data-active="true"]) {
-    color: var(--mb-color-summarize);
-    border-color: color-mix(in srgb, var(--mb-color-summarize) 40%, white);
-    background-color: color-mix(in srgb, var(--mb-color-summarize) 15%, white);
-  }
-` as unknown as typeof MantineButton;
-
 export const HeaderButton = styled(Button)<{
   active: boolean;
 }>`

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/FilterHeaderButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/FilterHeaderButton.tsx
@@ -1,13 +1,11 @@
 import { t } from "ttag";
 
-import { color } from "metabase/lib/colors";
 import type { QueryModalType } from "metabase/query_builder/constants";
 import { MODAL_TYPES } from "metabase/query_builder/constants";
+import { Button } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
 import type { QueryBuilderMode } from "metabase-types/store";
-
-import { HeaderButton } from "../ViewTitleHeader.styled";
 
 interface FilterHeaderButtonProps {
   className?: string;
@@ -19,17 +17,14 @@ export function FilterHeaderButton({
   onOpenModal,
 }: FilterHeaderButtonProps) {
   return (
-    <HeaderButton
+    <Button
+      color="filter"
       className={className}
-      active={false}
-      large
-      labelBreakpoint="sm"
-      color={color("filter")}
       onClick={() => onOpenModal(MODAL_TYPES.FILTERS)}
       data-testid="question-filter-header"
     >
       {t`Filter`}
-    </HeaderButton>
+    </Button>
   );
 }
 

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/FilterHeaderButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/FilterHeaderButton.tsx
@@ -2,10 +2,11 @@ import { t } from "ttag";
 
 import type { QueryModalType } from "metabase/query_builder/constants";
 import { MODAL_TYPES } from "metabase/query_builder/constants";
-import { Button } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
 import type { QueryBuilderMode } from "metabase-types/store";
+
+import { FilterButton } from "../ViewTitleHeader.styled";
 
 interface FilterHeaderButtonProps {
   className?: string;
@@ -17,14 +18,14 @@ export function FilterHeaderButton({
   onOpenModal,
 }: FilterHeaderButtonProps) {
   return (
-    <Button
+    <FilterButton
       color="filter"
       className={className}
       onClick={() => onOpenModal(MODAL_TYPES.FILTERS)}
       data-testid="question-filter-header"
     >
       {t`Filter`}
-    </Button>
+    </FilterButton>
   );
 }
 

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/FilterHeaderButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/FilterHeaderButton.tsx
@@ -1,12 +1,14 @@
+import cx from "classnames";
 import { t } from "ttag";
 
 import type { QueryModalType } from "metabase/query_builder/constants";
 import { MODAL_TYPES } from "metabase/query_builder/constants";
+import { Button } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
 import type { QueryBuilderMode } from "metabase-types/store";
 
-import { FilterButton } from "../ViewTitleHeader.styled";
+import ViewTitleHeaderS from "../ViewTitleHeader.module.css";
 
 interface FilterHeaderButtonProps {
   className?: string;
@@ -18,14 +20,14 @@ export function FilterHeaderButton({
   onOpenModal,
 }: FilterHeaderButtonProps) {
   return (
-    <FilterButton
+    <Button
       color="filter"
-      className={className}
+      className={cx(className, ViewTitleHeaderS.FilterButton)}
       onClick={() => onOpenModal(MODAL_TYPES.FILTERS)}
       data-testid="question-filter-header"
     >
       {t`Filter`}
-    </FilterButton>
+    </Button>
   );
 }
 

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionSummarizeWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionSummarizeWidget.jsx
@@ -1,22 +1,19 @@
 /* eslint-disable react/prop-types */
 import { t } from "ttag";
 
-import { color } from "metabase/lib/colors";
+import { Button } from "metabase/ui";
 import * as Lib from "metabase-lib";
-
-import { HeaderButton } from "../ViewTitleHeader.styled";
 
 export function QuestionSummarizeWidget({
   isShowingSummarySidebar,
   onEditSummary,
   onCloseSummary,
-  ...props
+  className,
 }) {
   return (
-    <HeaderButton
-      large
-      color={color("summarize")}
-      labelBreakpoint="sm"
+    <Button
+      color="summarize"
+      variant={isShowingSummarySidebar ? "filled" : "default"}
       onClick={async () => {
         if (isShowingSummarySidebar) {
           onCloseSummary();
@@ -25,10 +22,10 @@ export function QuestionSummarizeWidget({
         }
       }}
       active={isShowingSummarySidebar}
-      {...props}
+      className={className}
     >
       {t`Summarize`}
-    </HeaderButton>
+    </Button>
   );
 }
 

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionSummarizeWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionSummarizeWidget.jsx
@@ -1,8 +1,9 @@
 /* eslint-disable react/prop-types */
 import { t } from "ttag";
 
-import { Button } from "metabase/ui";
 import * as Lib from "metabase-lib";
+
+import { SummarizeButton } from "../ViewTitleHeader.styled";
 
 export function QuestionSummarizeWidget({
   isShowingSummarySidebar,
@@ -11,7 +12,7 @@ export function QuestionSummarizeWidget({
   className,
 }) {
   return (
-    <Button
+    <SummarizeButton
       color="summarize"
       variant={isShowingSummarySidebar ? "filled" : "default"}
       onClick={async () => {
@@ -21,11 +22,11 @@ export function QuestionSummarizeWidget({
           onEditSummary();
         }
       }}
-      active={isShowingSummarySidebar}
+      data-active={isShowingSummarySidebar}
       className={className}
     >
       {t`Summarize`}
-    </Button>
+    </SummarizeButton>
   );
 }
 

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionSummarizeWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionSummarizeWidget.jsx
@@ -1,9 +1,11 @@
 /* eslint-disable react/prop-types */
+import cx from "classnames";
 import { t } from "ttag";
 
+import { Button } from "metabase/ui";
 import * as Lib from "metabase-lib";
 
-import { SummarizeButton } from "../ViewTitleHeader.styled";
+import ViewTitleHeaderS from "../ViewTitleHeader.module.css";
 
 export function QuestionSummarizeWidget({
   isShowingSummarySidebar,
@@ -12,7 +14,7 @@ export function QuestionSummarizeWidget({
   className,
 }) {
   return (
-    <SummarizeButton
+    <Button
       color="summarize"
       variant={isShowingSummarySidebar ? "filled" : "default"}
       onClick={async () => {
@@ -23,10 +25,10 @@ export function QuestionSummarizeWidget({
         }
       }}
       data-active={isShowingSummarySidebar}
-      className={className}
+      className={cx(className, ViewTitleHeaderS.SummarizeButton)}
     >
       {t`Summarize`}
-    </SummarizeButton>
+    </Button>
   );
 }
 


### PR DESCRIPTION
No functional, and very small visual changes here, but makes things more uniform, and will make things look not-stupid in https://github.com/metabase/metabase/pull/46097 because all the border sizes and buttons will match.

. | .
--- | ---
Before | ![Screen Shot 2024-07-24 at 4 53 36 PM](https://github.com/user-attachments/assets/a4cc7abd-1f63-431b-bdca-59520cb92b12)
After | ![Screen Shot 2024-07-24 at 4 54 02 PM](https://github.com/user-attachments/assets/091845a1-4858-4d69-8efe-9176958c22d6)

![buttons](https://github.com/user-attachments/assets/01723570-f2b9-4875-adcd-af134f0e42ac)


Existing coverage should handle these button clicks thoroughly.