### PR TITLE
[Notification] audit log for channel create and update

### DIFF
--- a/src/metabase/api/channel.clj
+++ b/src/metabase/api/channel.clj
@@ -7,7 +7,9 @@
    [metabase.api.common :as api]
    [metabase.api.common.validation :as validation]
    [metabase.channel.core :as channel]
+   [metabase.events :as events]
    [metabase.models.interface :as mi]
+   [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru]]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
@@ -25,8 +27,8 @@
   [:as {{:keys [include_inactive]} :body}]
   {include_inactive [:maybe {:default false} :boolean]}
   (map remove-details-if-needed (if include_inactive
-                                          (t2/select :model/Channel)
-                                          (t2/select :model/Channel :active true))))
+                                  (t2/select :model/Channel)
+                                  (t2/select :model/Channel :active true))))
 
 (defn- test-channel-connection!
   "Test if a channel can be connected, throw an exception if it fails."
@@ -54,7 +56,8 @@
    active      [:maybe {:default true} :boolean]}
   (validation/check-has-application-permission :setting)
   (test-channel-connection! type details)
-  (t2/insert-returning-instance! :model/Channel body))
+  (u/prog1 (t2/insert-returning-instance! :model/Channel body)
+    (events/publish-event! :event/channel-create {:object <> :user-id api/*current-user-id*})))
 
 (api/defendpoint GET "/:id"
   "Get a channel"
@@ -79,7 +82,11 @@
     (when (or details-changed? type-changed?)
       (test-channel-connection! (or type (:type channel-before-update))
                                 (or details (:details channel-before-update))))
-   (t2/update! :model/Channel id body)))
+    (t2/update! :model/Channel id body)
+    (u/prog1 (t2/select-one :model/Channel id)
+      (events/publish-event! :event/channel-update {:object          <>
+                                                    :user-id         api/*current-user-id*
+                                                    :previous-object channel-before-update}))))
 
 (api/defendpoint POST "/test"
   "Test a channel connection"

--- a/src/metabase/events/audit_log.clj
+++ b/src/metabase/events/audit_log.clj
@@ -224,3 +224,11 @@
 (methodical/defmethod events/publish-event! ::cache-config-changed-event
   [topic event]
   (audit-log/record-event! topic event))
+
+(derive ::channel-event ::event)
+(derive :event/channel-create ::channel-event)
+(derive :event/channel-update ::channel-event)
+
+(methodical/defmethod events/publish-event! ::channel-event
+  [topic event]
+  (audit-log/record-event! topic event))

--- a/src/metabase/models/channel.clj
+++ b/src/metabase/models/channel.clj
@@ -48,4 +48,4 @@
 
 (defmethod audit-log/model-details :model/Channel
   [channel _event-type]
-  (select-keys channel [:id :name :description :type]))
+  (select-keys channel [:id :name :description :type :active]))

--- a/src/metabase/models/channel.clj
+++ b/src/metabase/models/channel.clj
@@ -1,5 +1,6 @@
 (ns ^{:added "0.51.0"} metabase.models.channel
   (:require
+   [metabase.models.audit-log :as audit-log]
    [metabase.models.interface :as mi]
    [metabase.models.permissions :as perms]
    [metabase.models.serialization :as serdes]
@@ -44,3 +45,7 @@
   [instance]
   (assert-channel-type instance)
   instance)
+
+(defmethod audit-log/model-details :model/Channel
+  [channel _event-type]
+  (select-keys channel [:id :name :description :type]))

--- a/test/metabase/api/channel_test.clj
+++ b/test/metabase/api/channel_test.clj
@@ -155,7 +155,8 @@
               (is (= {:details  {:description "Test channel description"
                                  :id          id
                                  :name        "Test channel"
-                                 :type        "channel/metabase-test"}
+                                 :type        "channel/metabase-test"
+                                 :active      true}
                       :model    "Channel"
                       :model_id id
                       :topic    :channel-create

--- a/test/metabase/api/channel_test.clj
+++ b/test/metabase/api/channel_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase.channel.core :as channel]
+   [metabase.public-settings.premium-features :as premium-features]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 
@@ -143,3 +144,29 @@
            (mt/user-http-request :crowberto :post 400 "channel/test"
                                  (assoc default-test-channel :details {:return-type  "throw"
                                                                        :return-value {:errors {:email "Invalid email"}}}))))))
+
+(deftest channel-audit-log-test
+  (testing "audit log for channel apis"
+    (mt/with-premium-features #{:audit-app}
+      (mt/with-model-cleanup [:model/Channel]
+        (with-redefs [premium-features/enable-cache-granular-controls? (constantly true)]
+          (let [id (:id (mt/user-http-request :crowberto :post 200 "channel" default-test-channel))]
+            (testing "POST /api/channel"
+              (is (= {:details  {:description "Test channel description"
+                                 :id          id
+                                 :name        "Test channel"
+                                 :type        "channel/metabase-test"}
+                      :model    "Channel"
+                      :model_id id
+                      :topic    :channel-create
+                      :user_id  (mt/user->id :crowberto)}
+                     (mt/latest-audit-log-entry :channel-create))))
+
+            (testing "PUT /api/channel/:id"
+              (mt/user-http-request :crowberto :put 200 (str "channel/" id) (assoc default-test-channel :name "Updated Name"))
+              (is (= {:details  {:new {:name "Updated Name"} :previous {:name "Test channel"}}
+                      :model    "Channel"
+                      :model_id id
+                      :topic    :channel-update
+                      :user_id  (mt/user->id :crowberto)}
+                     (mt/latest-audit-log-entry :channel-update))))))))))

--- a/test/metabase/events/audit_log_test.clj
+++ b/test/metabase/events/audit_log_test.clj
@@ -527,3 +527,36 @@
                 :topic    :password-reset-successful
                 :model    "User"}
                (mt/latest-audit-log-entry :password-reset-successful (mt/user->id :rasta))))))))
+
+(deftest create-channel-event-test
+  (mt/with-current-user (mt/user->id :rasta)
+    (mt/with-temp [:model/Channel channel {:name    "Test channel"
+                                           :type    "channel/metabase-test"
+                                           :details {:return-type  "return-value"
+                                                     :return-value true}}]
+      (testing :event/channel-create
+        (is (= {:object channel}
+               (events/publish-event! :event/channel-create {:object channel})))
+        (is (= {:model_id (:id channel)
+                :user_id  (mt/user->id :rasta)
+                :details  {:id          (:id channel)
+                           :name        "Test channel"
+                           :description nil
+                           :type        "channel/metabase-test"}
+                :topic    :channel-create
+                :model    "Channel"}
+               (mt/latest-audit-log-entry :channel-create (:id channel)))))
+
+      (testing :event/channel-update
+        (events/publish-event! :event/channel-update {:object          (assoc channel
+                                                                              :details {:new-detail true}
+                                                                              :name "New Name")
+                                                      :previous-object channel})
+
+        (is (= {:model_id (:id channel)
+                :user_id  (mt/user->id :rasta)
+                :details  {:previous {:name "Test channel"}
+                           :new      {:name "New Name"}}
+                :topic    :channel-update
+                :model    "Channel"}
+               (mt/latest-audit-log-entry :channel-update (:id channel))))))))

--- a/test/metabase/events/audit_log_test.clj
+++ b/test/metabase/events/audit_log_test.clj
@@ -542,7 +542,8 @@
                 :details  {:id          (:id channel)
                            :name        "Test channel"
                            :description nil
-                           :type        "channel/metabase-test"}
+                           :type        "channel/metabase-test"
+                           :active      true}
                 :topic    :channel-create
                 :model    "Channel"}
                (mt/latest-audit-log-entry :channel-create (:id channel)))))


### PR DESCRIPTION
Part of milestone 3 of https://github.com/metabase/metabase/issues/43822

Record audit log event :channel-create for POST /api/channel
Record audit log event :channel-update for PUT /api/channel/:id

Audit details only include [:id, :name, :description, :type, :enabled]