### PR TITLE
Track table references, even if we don't query their columns

### DIFF
--- a/src/metabase/query_analysis.clj
+++ b/src/metabase/query_analysis.clj
@@ -80,7 +80,7 @@
          :mbql/query true
          false)))
 
-(defn- explicit-references [field-ids]
+(defn- explicit-field-references [field-ids]
   (when (seq field-ids)
     ;; We add this on in code as `true` in MySQL-based drivers would be returned as 1.
     (map #(assoc % :explicit-reference true)
@@ -89,6 +89,11 @@
                                        :from   [[(t2/table-name :model/Field) :f]]
                                        :join   [[(t2/table-name :model/Table) :t] [:= :t.id :f.table_id]]
                                        :where  [:in :f.id field-ids]}))))
+
+(defn- explicit-references [field-ids]
+  (let [field-refs (explicit-field-references field-ids)]
+    {:fields field-refs
+     :tables (distinct (map #(dissoc % :field-id :field) field-refs))}))
 
 (defn- query-references
   "Find out ids of all fields used in a query. Conforms to the same protocol as [[query-analyzer/field-ids-for-sql]],
@@ -124,7 +129,7 @@
                                  {:card_id            card-id
                                   :field_id           field-id
                                   :explicit_reference explicit-reference}))
-            query-field-rows (map reference->row references)]
+            query-field-rows (map reference->row (:fields references))]
         (query-field/update-query-fields-for-card! card-id query-field-rows)))))
 
 (defn- replaced-inner-query-for-native-card

--- a/src/metabase/query_analysis/native_query_analyzer.clj
+++ b/src/metabase/query_analysis/native_query_analyzer.clj
@@ -121,6 +121,14 @@
                    [(update-vals reference strip-quotes)]))
              analyzed-columns))))
 
+(defn table-reference
+  "Used by tests"
+  [db-id table]
+  (t2/select-one [:model/Table [:id :table-id] [:name :table]]
+                 {:where [:and
+                          [:= :t.db_id db-id]
+                          (table-query {:table (name table)})]}))
+
 (defn field-reference
   "Used by tests"
   [db-id table column]

--- a/src/metabase/query_analysis/native_query_analyzer.clj
+++ b/src/metabase/query_analysis/native_query_analyzer.clj
@@ -240,7 +240,7 @@
         implicit-refs (set/difference (set (implicit-references-for-query parsed-query db-id))
                                       (set explicit-refs))
         field-refs    (concat (mark-reference explicit-refs true)
-                             (mark-reference implicit-refs false))
+                              (mark-reference implicit-refs false))
         table-refs    (deduce-or-fetch-table-refs parsed-query db-id field-refs)]
     {:tables table-refs
      :fields field-refs}))

--- a/src/metabase/query_analysis/native_query_analyzer.clj
+++ b/src/metabase/query_analysis/native_query_analyzer.clj
@@ -97,37 +97,15 @@
      (field-query :f.name (:column column))
      (into [:or] (map table-query tables))]))
 
-(defn- strip-redundant-refs
-  "Strip out duplicate references, and unqualified references that are shadowed by found or qualified ones."
-  [references]
-  (let [qualified? (into #{} (comp (filter :table) (map :column)) references)]
-    (into #{}
-          (filter (fn [{:keys [table column]}]
-                    (or table (not (qualified? column)))))
-          references)))
-
-(defn- consolidate-columns
-  "Qualify analyzed columns with the corresponding database IDs, where we are able to resolve them."
-  [analyzed-columns database-columns]
-  (let [->tab-key             (comp u/lower-case-en :table)
-        ->col-key             (comp u/lower-case-en :column)
-        column->records       (group-by (comp ->col-key) database-columns)
-        table+column->records (group-by (juxt ->tab-key ->col-key) database-columns)]
-    (strip-redundant-refs
-     (mapcat (fn [{:keys [table column] :as reference}]
-               (or (if table
-                     (table+column->records [(normalized-key table) (normalized-key column)])
-                     (column->records (normalized-key column)))
-                   [(update-vals reference strip-quotes)]))
-             analyzed-columns))))
-
 (defn table-reference
   "Used by tests"
   [db-id table]
-  (t2/select-one [:model/Table [:id :table-id] [:name :table]]
-                 {:where [:and
-                          [:= :t.db_id db-id]
-                          (table-query {:table (name table)})]}))
+  (t2/select-one :model/QueryTable
+                 {:select [[:t.id :table-id] [:t.name :table]]
+                  :from   [[(t2/table-name :model/Table) :t]]
+                  :where  [:and
+                           [:= :t.db_id db-id]
+                           (table-query {:table (name table)})]}))
 
 (defn field-reference
   "Used by tests"
@@ -138,8 +116,69 @@
                                                   (column-query nil {:table  (name table)
                                                                      :column (name column)})])))
 
-(defn- explicit-references-for-query
-  "Selects IDs of Fields that could be used in the query"
+(defn- strip-redundant-refs
+  "Strip out duplicate references, and unqualified references that are shadowed by found or qualified ones."
+  [references]
+  ;; TODO handle schema
+  (let [qualified? (into #{} (comp (filter :table) (map :column)) references)]
+    (into #{}
+          (filter (fn [{:keys [table column]}]
+                    (or table (not (qualified? column)))))
+          references)))
+
+(defn- strip-redundant-table-refs
+  "Strip out duplicate references, and unqualified references that are shadowed by found or qualified ones."
+  [references]
+  (let [qualified? (into #{} (comp (filter :schema) (map :table)) references)]
+    (into #{}
+          (filter (fn [{:keys [schema table]}]
+                    (or schema (not (qualified? table)))))
+          references)))
+
+(defn- consolidate-columns
+  "Qualify analyzed columns with the corresponding database IDs, where we are able to resolve them."
+  [analyzed-columns database-columns]
+  ;; TODO we should handle schema as well
+  (let [->tab-key             (comp u/lower-case-en :table)
+        ->col-key             (comp u/lower-case-en :column)
+        column->records       (group-by ->col-key database-columns)
+        table+column->records (group-by (juxt ->tab-key ->col-key) database-columns)]
+    (strip-redundant-refs
+     (mapcat (fn [{:keys [table column] :as reference}]
+               (or (if table
+                     (table+column->records [(normalized-key table) (normalized-key column)])
+                     (column->records (normalized-key column)))
+                   [(update-vals reference strip-quotes)]))
+             analyzed-columns))))
+
+(defn- consolidate-tables [analyzed-tables database-tables]
+  (let [->schema-key          (comp u/lower-case-en :schema)
+        ->table-key           (comp u/lower-case-en :table)
+        table->records        (group-by ->table-key database-tables)
+        schema+table->records (group-by (juxt ->schema-key ->table-key) database-tables)]
+    (strip-redundant-table-refs
+     (mapcat (fn [{:keys [schema table] :as reference}]
+               (or (if schema
+                     (schema+table->records [(normalized-key schema) (normalized-key table)])
+                     (table->records (normalized-key table)))
+                   [(update-vals reference strip-quotes)]))
+             analyzed-tables))))
+
+(defn- table-refs-for-query
+  "Given the results of query analysis, return references to the corresponding tables and cards."
+  [{table-maps :tables} db-id]
+  (let [tables (map :component table-maps)]
+    (consolidate-tables
+     tables
+     (t2/select :model/QueryTable
+                {:select [[:t.id :table-id] [:t.name :table]]
+                 :from   [[(t2/table-name :model/Table) :t]]
+                 :where  [:and
+                         [:= :t.db_id db-id]
+                         (into [:or] (map table-query tables))]}))))
+
+(defn- explicit-field-refs-for-query
+  "Given the results of query analysis, return references to the corresponding fields and model outputs."
   [{column-maps :columns table-maps :tables} db-id]
   (let [columns (map :component column-maps)
         tables  (map :component table-maps)]
@@ -189,12 +228,13 @@
         macaw-opts    (nqa.impl/macaw-options driver)
         sql-string    (:query (nqa.sub/replace-tags query))
         parsed-query  (macaw/query->components (macaw/parsed-query sql-string macaw-opts) macaw-opts)
-        explicit-refs (explicit-references-for-query parsed-query db-id)
+        explicit-refs (explicit-field-refs-for-query parsed-query db-id)
         implicit-refs (set/difference (set (implicit-references-for-query parsed-query db-id))
                                       (set explicit-refs))]
-    ;; TODO: add table refs
-    (concat (mark-reference explicit-refs true)
-            (mark-reference implicit-refs false))))
+    ;; TODO we can optimize this to only fetch tables which have not been implicitly fetched by a field yet
+    {:tables (table-refs-for-query parsed-query db-id)
+     :fields (concat (mark-reference explicit-refs true)
+                     (mark-reference implicit-refs false))}))
 
 (defn references-for-native
   "Returns a `{:explicit #{...} :implicit #{...}}` map with field IDs that (may) be referenced in the given card's

--- a/test/metabase/query_analysis/native_query_analyzer_test.clj
+++ b/test/metabase/query_analysis/native_query_analyzer_test.clj
@@ -48,6 +48,13 @@
    :column             (name column)
    :explicit-reference true})
 
+(defn- table-reference [table]
+  (let [reference (nqa/table-reference (mt/id) table)]
+    ;; sanity-check that this is the right reference
+    (assert (= (mt/id table) (:table-id reference)))
+    ;; sanity-check the names, whose case depends on the driver
+    (assert (= (name table) (u/lower-case-en (:table reference))))))
+
 (defn- field-reference [table column]
   (let [reference (nqa/field-reference (mt/id) table column)]
     ;; sanity-check that this is the right reference


### PR DESCRIPTION
References https://github.com/metabase/metabase/issues/45028

### Description

Queries like `SELECT (*) FROM foo` do not reference any queries, yet their table references should still be tracked - for example to handle renaming.

This is a pure refactor, we do not start to persist this additional data yet.