### PR TITLE
Request-level caching for sandboxes

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -797,8 +797,10 @@
    clojurewerkz.quartzite.schedule.simple/schedule                              macros.quartz/simple-schedule
    clojurewerkz.quartzite.triggers/build                                        macros.quartz/build-trigger
    metabase-enterprise.sandbox.test-util/with-gtaps!                            macros.metabase-enterprise.sandbox.test-util/with-gtaps!
+   metabase-enterprise.sandbox.test-util/with-gtaps-for-user!                   macros.metabase-enterprise.sandbox.test-util/with-gtaps!
    metabase-enterprise.serialization.test-util/with-world                       macros.metabase-enterprise.serialization.test-util/with-world
    metabase-enterprise.test/with-gtaps!                                         macros.metabase-enterprise.sandbox.test-util/with-gtaps!
+   metabase-enterprise.test/with-gtaps-for-user!                                macros.metabase-enterprise.sandbox.test-util/with-gtaps!
    metabase-enterprise.advanced-permissions.api.util-test/with-impersonations!  macros.metabase-enterprise.advanced-permissions.api.util-test/with-impersonations!
    metabase-enterprise.query-reference-validation.api-test/with-test-setup      macros.metabase-enterprise.query-reference-validation.api-test/with-test-setup
    metabase.api.card-test/with-ordered-items                                    macros.metabase.api.card-test/with-ordered-items

--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/table.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/table.clj
@@ -28,10 +28,10 @@
                            [:= :pgm.user_id (u/the-id user-or-user-id)]]}))
 
 (mu/defn only-sandboxed-perms? :- :boolean
-  "Returns true if the user has sandboxed permissions. If a sandbox policy exists, it overrides existing permission on
+  "Returns true if the user has sandboxed permissions for the given table. If a sandbox policy exists, it overrides existing permission on
   the table."
   [table :- (ms/InstanceOf Table)]
-  (boolean (seq (sandbox.api.util/enforced-sandboxes-for api/*current-user-id* #{(:id table)}))))
+  (boolean (seq (sandbox.api.util/enforced-sandboxes-for-tables #{(:id table)}))))
 
 (mu/defn ^:private query->fields-ids :- [:maybe [:sequential :int]]
   [{{{:keys [fields]} :query} :dataset_query} :- [:maybe :map]]
@@ -48,7 +48,7 @@
 (defenterprise fetch-table-query-metadata
   "Returns the query metadata used to power the Query Builder for the given table `id`. `include-sensitive-fields?`,
   `include-hidden-fields?` and `include-editable-data-model?` can be either booleans or boolean strings."
-  :feature :none
+  :feature :sandboxes
   [id opts]
   (let [table            (api/check-404 (t2/select-one Table :id id))
         sandboxed-perms? (only-sandboxed-perms? table)
@@ -66,7 +66,7 @@
 
 (defenterprise batch-fetch-table-query-metadatas
   "Returns the query metadata used to power the Query Builder for the tables specified by`ids`."
-  :feature :none
+  :feature :sandboxes
   [ids]
   (for [table (api.table/batch-fetch-query-metadatas* ids)]
     (let [sandboxed-perms? (only-sandboxed-perms? table)]

--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/util.clj
@@ -36,11 +36,14 @@
                                                          table_id))
       true)))
 
-(defn enforced-sandboxes-for
-  "Given a user-id and optional set of table-ids, return the sandboxes that should be enforced for the current user on
-  any of the tables. A sandbox is not enforced if the user is in a different permissions group that grants full access
-  to the table."
-  [user-id & [table-ids]]
+(defenterprise enforced-sandboxes-for-user
+  "Given a user-id, returns the set of sandboxes that should be enforced for the provided user ID. This result is cached
+  for the duration of a request in [[metabase.models.data-permissions/*sandboxes-for-user*]].
+
+  WARNING: This should NOT be used directly for sandboxing enforcement. Use `*sandboxes-for-user*` or
+  `enforced-sandboxes-for-tables` below, so that the cache is used."
+  :feature :sandboxes
+  [user-id]
   (let [user-group-ids           (user/group-ids user-id)
         sandboxes-with-group-ids (t2/hydrate
                                   (t2/select :model/GroupTableAccessPolicy
@@ -49,9 +52,7 @@
                                               :from [[:permissions_group_membership :pgm]]
                                               :left-join [[:sandboxes :s] [:= :s.group_id :pgm.group_id]]
                                               :where [:and
-                                                      [:= :pgm.user_id user-id]
-                                                      (when table-ids
-                                                       [:in :s.table_id table-ids])]})
+                                                      [:= :pgm.user_id user-id]]})
                                   :table)
         group-id->sandboxes (->> sandboxes-with-group-ids
                                  (group-by :group_id)
@@ -62,6 +63,13 @@
     (filter #(enforce-sandbox? user-group-ids group-id->sandboxes %)
             (reduce set/union #{} (vals group-id->sandboxes)))))
 
+(defn enforced-sandboxes-for-tables
+  "Given set of table-ids, return the sandboxes that should be enforced for the current user on any of the tables. A
+  sandbox is not enforced if the user is in a different permissions group that grants full access to the table."
+  [table-ids]
+  (let [enforced-sandboxes-for-user @data-perms/*sandboxes-for-user*]
+    (filter #((set table-ids) (:table_id %)) enforced-sandboxes-for-user)))
+
 (defenterprise sandboxed-user?
   "Returns true if the currently logged in user has any enforced sandboxes. Throws an exception if no current user is
   bound."
@@ -70,7 +78,7 @@
   (boolean
    (when-not *is-superuser?*
      (if *current-user-id*
-       (seq (enforced-sandboxes-for *current-user-id*))
+       (seq @data-perms/*sandboxes-for-user*)
        ;; If no *current-user-id* is bound we can't check for sandboxes, so we should throw in this case to avoid
        ;; returning `false` for users who should actually be sandboxes.
        (throw (ex-info (str (tru "No current user found"))

--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/util.clj
@@ -64,7 +64,7 @@
             (reduce set/union #{} (vals group-id->sandboxes)))))
 
 (defn enforced-sandboxes-for-tables
-  "Given set of table-ids, return the sandboxes that should be enforced for the current user on any of the tables. A
+  "Given collection of table-ids, return the sandboxes that should be enforced for the current user on any of the tables. A
   sandbox is not enforced if the user is in a different permissions group that grants full access to the table."
   [table-ids]
   (let [enforced-sandboxes-for-user @data-perms/*sandboxes-for-user*]

--- a/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
@@ -62,7 +62,7 @@
 
 (defn- tables->sandboxes [table-ids]
   (qp.store/cached [*current-user-id* table-ids]
-    (let [enforced-sandboxes (mt.api.u/enforced-sandboxes-for *current-user-id* table-ids)]
+    (let [enforced-sandboxes (mt.api.u/enforced-sandboxes-for-tables table-ids)]
        (when (seq enforced-sandboxes)
          (assert-one-gtap-per-table enforced-sandboxes)
          enforced-sandboxes))))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/models/params/chain_filter_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/models/params/chain_filter_test.clj
@@ -2,8 +2,8 @@
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.test :as met]
-   [metabase.api.common :as api]
    [metabase.models :refer [FieldValues]]
+   [metabase.models.data-permissions :as data-perms]
    [metabase.models.field-values :as field-values]
    [metabase.models.params.chain-filter :as chain-filter]
    [metabase.test :as mt]
@@ -27,16 +27,14 @@
 
         (testing "When chain-filter with constraints"
           (testing "creates a linked-filter FieldValues if not sandboxed"
-            ;; HACK to run this outside of sandboxing
-            (binding [api/*current-user-id*              nil
-                      api/*current-user-permissions-set* (atom #{"/"})]
+            (binding [data-perms/*sandboxes-for-user* (delay nil)]
               (is (= {:values          [["Artisan"]]
                       :has_more_values false}
                      (mt/$ids (chain-filter/chain-filter %categories.name
                                                          [{:field-id %categories.id :op := :value 3}])))))
             (is (= 1 (t2/count FieldValues :field_id (mt/id :categories :name) :type :linked-filter))))
 
-          (testing "creates another linked-filter FieldValues if  sandboxed"
+          (testing "creates another linked-filter FieldValues if sandboxed"
             (is (= {:values          []
                     :has_more_values false}
                    (mt/$ids (chain-filter/chain-filter %categories.name

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -133,10 +133,22 @@
   sorry. The values are collections of rows of DataPermissions."
   (delay nil))
 
+(defenterprise enforced-sandboxes-for-user
+  "Given a user-id, returns the set of sandboxes that should be enforced for the provided user ID. This result is
+  cached for the duration of a request. Empty on OSS instances."
+  metabase-enterprise.sandbox.api.util
+  [_user-id]
+  #{})
+
+(def ^:dynamic *sandboxes-for-user*
+  "Filled by `enforced-sandboxes-for-user`. Empty on OSS instances, or EE instances without the `sandboxes` feature."
+  (delay nil))
+
 (defmacro with-relevant-permissions-for-user
-  "Populates the `*permissions-for-user*` dynamic var for use by the cache-aware functions in this namespace."
+  "Populates the `*permissions-for-user*` and `dynamic var for use by the cache-aware functions in this namespace."
   [user-id & body]
-  `(binding [*permissions-for-user* (delay (relevant-permissions-for-user ~user-id))]
+  `(binding [*permissions-for-user* (delay (relevant-permissions-for-user ~user-id))
+             *sandboxes-for-user*   (delay (enforced-sandboxes-for-user ~user-id))]
      ~@body))
 
 (defn- get-permissions [user-id perm-type db-id]


### PR DESCRIPTION
Adds request-level caching for sandboxes, similar to how we do caching for data permissions.