### PR TITLE
Detect queries referencing unknown fields

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/query_reference_validation/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/query_reference_validation/api.clj
@@ -44,7 +44,7 @@
         card-query          (query-field/cards-with-reference-errors
                              (m/assoc-some
                               ;; TODO this table has a lot of fields... we should whittle down to what we need.
-                              {:select    (into [:c.id :c.name] sorting-selects)
+                              {:select    (into [:c.*] sorting-selects)
                                :from      [[(t2/table-name :model/Card) :c]]
                                :left-join sorting-joins
                                :where     [:= :c.archived false]

--- a/enterprise/backend/src/metabase_enterprise/query_reference_validation/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/query_reference_validation/api.clj
@@ -43,7 +43,8 @@
                               [(into sorting-selects [sort-dir-kw])])
         card-query          (query-field/cards-with-reference-errors
                              (m/assoc-some
-                              {:select    (into [:c.*] sorting-selects)
+                              ;; TODO this table has a lot of fields... we should whittle down to what we need.
+                              {:select    (into [:c.id :c.name] sorting-selects)
                                :from      [[(t2/table-name :model/Card) :c]]
                                :left-join sorting-joins
                                :where     [:= :c.archived false]

--- a/enterprise/backend/test/metabase_enterprise/query_reference_validation/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/query_reference_validation/api_test.clj
@@ -32,24 +32,30 @@
                             ;; QFs not to include:
                             ;; - Field is still active
                             :model/QueryField {}             {:card_id  card-1
+                                                              :table    "ORDERS"
                                                               :column   "tax"
                                                               :field_id (mt/id :orders :tax)}
                             ;; - Implicit reference
                             :model/QueryField {}             {:card_id            card-2
+                                                              :table              "T1"
                                                               :column             "FA"
                                                               :field_id           field-1
                                                               :explicit_reference false}
                             ;; QFs to include:
                             :model/QueryField {qf-1 :id}     {:card_id  card-1
+                                                              :table    "T1"
                                                               :column   "FA"
                                                               :field_id field-1}
                             :model/QueryField {qf-1b :id}    {:card_id  card-1
+                                                              :table    "T1"
                                                               :column   "FAB"
                                                               :field_id nil}
                             :model/QueryField {qf-2 :id}     {:card_id  card-2
+                                                              :table    "T1"
                                                               :column   "FB"
                                                               :field_id field-2}
                             :model/QueryField {qf-3 :id}     {:card_id  card-3
+                                                              :table    "T2"
                                                               :column   "FC"
                                                               :field_id field-3}]
      (mt/with-premium-features #{:query-reference-validation}
@@ -180,8 +186,7 @@
                 [{:id     card-1
                   :name   "A"
                   :errors [{:type "inactive-field", :table "T1", :field "FA"}
-                           ;; TODO fix the table name here once we track it in QueryField
-                           {:type "unknown-field", :table "unknown", :field "FAB"}]}
+                           {:type "unknown-field",  :table "T1", :field "FAB"}]}
                  {:id     card-2
                   :name   "B"
                   :errors [{:type "inactive-field", :table "T1", :field "FB"}]}
@@ -202,8 +207,7 @@
                 [{:id     card-1
                   :name   "A"
                   :errors [{:type "inactive-field", :table "T1", :field "FA"}
-                           ;; TODO fix the table name here once we track it in QueryField
-                           {:type "unknown-field", :table "unknown", :field "FAB"}]}
+                           {:type "unknown-field",  :table "T1", :field "FAB"}]}
                  {:id     card-2
                   :name   "B"
                   :errors [{:type "inactive-field", :table "T1", :field "FB"}]}]}

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -8508,29 +8508,42 @@ databaseChangeLog:
   - changeSet:
       id: v51.2024-07-25T11:56:27
       author: crisptrutski
-      comment: Add `column` and `table` columns to query fields
+      comment: Wipe stale query fields, so we can add new non-nullable columns
+      changes:
+        - delete:
+            tableName: query_field
+            remarks: remove stale analysis, so the new fields can be non-nullable
+
+  - changeSet:
+      id: v51.2024-07-25T11:57:27
+      author: crisptrutski
+      comment: Add `column` column to query fields
       preConditions:
         - not:
           - columnExists:
               tableName: query_field
               columnName: column
-        - not:
-          - columnExists:
-              tableName: query_field
-              columnName: table
       changes:
-        - delete:
-            tableName: query_field
-            remarks: remove stale analysis, so the new fields can be non-nullable
         - addColumn:
             tableName: query_field
             columns:
               - column:
                   name: column
                   type: varchar(254) # matching metabase_field.name
-                  remarks: name of the table column or model output being referenced
+                  remarks: name of the table or card being referenced
                   constraints:
                     nullable: false
+
+  - changeSet:
+      id: v51.2024-07-25T11:58:27
+      author: crisptrutski
+      comment: Add `table` column to query fields
+      preConditions:
+        - not:
+          - columnExists:
+              tableName: query_field
+              columnName: table
+      changes:
         - addColumn:
             tableName: query_field
             columns:

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -8505,6 +8505,40 @@ databaseChangeLog:
                   constraints:
                     nullable: true
 
+  - changeSet:
+      id: v51.2024-07-25T11:56:27
+      author: crisptrutski
+      comment: Add `column` to query fields
+      preConditions:
+        - not:
+          - columnExists:
+              tableName: query_field
+              columnName: column
+      changes:
+        - delete:
+            tableName: query_field
+            remarks: remove stale analysis, so the new field can be non-nullable
+        - addColumn:
+            tableName: query_field
+            columns:
+              - column:
+                  name: column
+                  type: varchar(254) # matching metabase_field.name
+                  remarks: name of the table field or model output being referenced
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: v51.2024-07-25T12:02:21
+      author: crisptrutski
+      comment: Make `field_id` nullable on query fields
+      changes:
+        - dropNotNullConstraint:
+            tableName: query_field
+            columnDataType: int
+            columnName: field_id
+            remarks: This value is null if the field does not exist, or is created within a model
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -8509,6 +8509,7 @@ databaseChangeLog:
       id: v51.2024-07-25T11:56:27
       author: crisptrutski
       comment: Wipe stale query fields, so we can add new non-nullable columns
+      rollback: # none, entries will be recreated by sweeper
       changes:
         - delete:
             tableName: query_field

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -8508,23 +8508,36 @@ databaseChangeLog:
   - changeSet:
       id: v51.2024-07-25T11:56:27
       author: crisptrutski
-      comment: Add `column` to query fields
+      comment: Add `column` and `table` columns to query fields
       preConditions:
         - not:
           - columnExists:
               tableName: query_field
               columnName: column
+        - not:
+          - columnExists:
+              tableName: query_field
+              columnName: table
       changes:
         - delete:
             tableName: query_field
-            remarks: remove stale analysis, so the new field can be non-nullable
+            remarks: remove stale analysis, so the new fields can be non-nullable
         - addColumn:
             tableName: query_field
             columns:
               - column:
                   name: column
                   type: varchar(254) # matching metabase_field.name
-                  remarks: name of the table field or model output being referenced
+                  remarks: name of the table column or model output being referenced
+                  constraints:
+                    nullable: false
+        - addColumn:
+            tableName: query_field
+            columns:
+              - column:
+                  name: table
+                  type: varchar(254) # matching metabase_table.name
+                  remarks: name of the table or card being referenced
                   constraints:
                     nullable: false
 

--- a/src/metabase/models/query_field.clj
+++ b/src/metabase/models/query_field.clj
@@ -1,6 +1,7 @@
 (ns metabase.models.query-field
   (:require
    [metabase.util :as u]
+   [metabase.util.log :as log]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
@@ -8,9 +9,6 @@
 
 (doto :model/QueryField
   (derive :metabase/model))
-
-(defn- db-true? [x]
-  (or (true? x) (= "1" x)))
 
 (defn cards-with-reference-errors
   "Given some HoneySQL query map with :model/Card bound as :c, restrict this query to only return cards
@@ -53,10 +51,11 @@
                                   [:= :f.active false]]
                                  [:in :card_id (map :id cards)]]
                      :order-by  [:qf.card_id :field :table]})
-         (map (fn [{:keys [card_id table field field_unknown table_active]}]
+         (map (fn [{:keys [card_id table field field_unknown table_active] :as result}]
+                (log/warn result)
                 [card_id {:type  (cond
-                                   (db-true? field_unknown) :unknown-field
-                                   (db-true? table_active)  :inactive-field
+                                   field_unknown :unknown-field
+                                   table_active  :inactive-field
                                    :else         :inactive-table)
                           :table table
                           :field field}]))

--- a/src/metabase/models/query_field.clj
+++ b/src/metabase/models/query_field.clj
@@ -49,7 +49,7 @@
                                   [:= :f.id nil]
                                   [:= :f.active false]]
                                  [:in :card_id (map :id cards)]]
-                     :order-by  [:qf.card_id :t.name :f.name]})
+                     :order-by  [:qf.card_id :qf.field :qf.table]})
          (map (fn [{:keys [card_id table field field_unknown table_active]}]
                 [card_id {:type  (cond
                                    field_unknown :unknown-field

--- a/src/metabase/models/query_field.clj
+++ b/src/metabase/models/query_field.clj
@@ -13,7 +13,7 @@
   (if (= 0 x) false x))
 
 (defn- coerce-booleans [m]
-  (update-vals coerce-boolean m))
+  (update-vals m coerce-boolean))
 
 (defn cards-with-reference-errors
   "Given some HoneySQL query map with :model/Card bound as :c, restrict this query to only return cards

--- a/src/metabase/models/query_field.clj
+++ b/src/metabase/models/query_field.clj
@@ -49,7 +49,7 @@
                                   [:= :f.id nil]
                                   [:= :f.active false]]
                                  [:in :card_id (map :id cards)]]
-                     :order-by  [:qf.card_id :qf.field :qf.table]})
+                     :order-by  [:qf.card_id :field :table]})
          (map (fn [{:keys [card_id table field field_unknown table_active]}]
                 [card_id {:type  (cond
                                    field_unknown :unknown-field

--- a/src/metabase/models/query_field.clj
+++ b/src/metabase/models/query_field.clj
@@ -9,6 +9,9 @@
 (doto :model/QueryField
   (derive :metabase/model))
 
+(defn- db-true? [x]
+  (or (true? x) (= "1" x)))
+
 (defn cards-with-reference-errors
   "Given some HoneySQL query map with :model/Card bound as :c, restrict this query to only return cards
   with invalid references."
@@ -52,8 +55,8 @@
                      :order-by  [:qf.card_id :field :table]})
          (map (fn [{:keys [card_id table field field_unknown table_active]}]
                 [card_id {:type  (cond
-                                   field_unknown :unknown-field
-                                   table_active  :inactive-field
+                                   (db-true? field_unknown) :unknown-field
+                                   (db-true? table_active)  :inactive-field
                                    :else         :inactive-table)
                           :table table
                           :field field}]))

--- a/src/metabase/models/query_field.clj
+++ b/src/metabase/models/query_field.clj
@@ -10,7 +10,10 @@
   (derive :metabase/model))
 
 (defn- coerce-boolean [x]
-  (if (= 0 x) false x))
+  (cond
+    (= 0 x) false
+    (= 0M x) false
+    :else x))
 
 (defn- coerce-booleans [m]
   (update-vals m coerce-boolean))

--- a/src/metabase/models/query_field.clj
+++ b/src/metabase/models/query_field.clj
@@ -9,47 +9,55 @@
 (doto :model/QueryField
   (derive :metabase/model))
 
-(def ^:private reference-error-joins
-  [[(t2/table-name :model/QueryField) :qf]
-   [:and
-    [:= :qf.card_id :c.id]
-    [:= :qf.explicit_reference true]]
-
-   [(t2/table-name :model/Field) :f]
-   [:and
-    [:= :qf.field_id :f.id]
-    [:= :f.active false]]])
-
 (defn cards-with-reference-errors
   "Given some HoneySQL query map with :model/Card bound as :c, restrict this query to only return cards
-  with invalid references.
-  For now this only handles inactive references, but in future it will also handle unknown references too."
+  with invalid references."
   [card-query-map]
   ;; NOTE: We anticipate a schema change to support missing references that will result in left-joins and
   ;; where clauses being appended as well.
-  (update card-query-map :join concat reference-error-joins))
+  (-> card-query-map
+      (update :join concat
+              [[(t2/table-name :model/QueryField) :qf]
+               [:and
+                [:= :qf.card_id :c.id]
+                [:= :qf.explicit_reference true]]])
+      (update :left-join concat
+              [[(t2/table-name :model/Field) :f]
+               [:= :qf.field_id :f.id]])
+      (update :where
+              (fn [existing-where]
+                [:and
+                 existing-where
+                 [:or
+                  [:= :f.id nil]
+                  [:= :f.active false]]]))))
 
 (defn reference-errors
   "Given a seq of cards, return a map of card-id => reference errors"
   [cards]
   (when (seq cards)
     (->> (t2/select :model/QueryField
-                    {:select [:qf.card_id
-                              [:f.name :field]
-                              [:t.name :table]
-                              [:t.active :table_active]]
-                     :from   [[(t2/table-name :model/QueryField) :qf]]
-                     :join   [[(t2/table-name :model/Field) :f] [:= :f.id :qf.field_id]
-                              [(t2/table-name :model/Table) :t] [:= :t.id :f.table_id]]
-                     :where  [:and
-                              [:= :qf.explicit_reference true]
-                              [:= :f.active false]
-                              [:in :card_id (map :id cards)]]
-                     :order-by [:qf.card_id :t.name :f.name]})
-         (map (fn [{:keys [card_id table field table_active]}]
-                [card_id {:type  (if table_active
-                                   :inactive-field
-                                   :inactive-table)
+                    {:select    [:qf.card_id
+                                 [:qf.column :field]
+                                 ;; TODO once we store a table name on query_field we can use that instead
+                                 [[:coalesce :t.name "unknown"] :table]
+                                 [[:= :f.id nil] :field_unknown]
+                                 [[:coalesce :t.active false] :table_active]]
+                     :from      [[(t2/table-name :model/QueryField) :qf]]
+                     :left-join [[(t2/table-name :model/Field) :f] [:= :f.id :qf.field_id]
+                                 [(t2/table-name :model/Table) :t] [:= :t.id :f.table_id]]
+                     :where     [:and
+                                 [:= :qf.explicit_reference true]
+                                 [:or
+                                  [:= :f.id nil]
+                                  [:= :f.active false]]
+                                 [:in :card_id (map :id cards)]]
+                     :order-by  [:qf.card_id :t.name :f.name]})
+         (map (fn [{:keys [card_id table field field_unknown table_active]}]
+                [card_id {:type  (cond
+                                   field_unknown :unknown-field
+                                   table_active  :inactive-field
+                                   :else         :inactive-table)
                           :table table
                           :field field}]))
          (reduce (fn [acc [id error]]

--- a/src/metabase/models/query_field.clj
+++ b/src/metabase/models/query_field.clj
@@ -13,8 +13,6 @@
   "Given some HoneySQL query map with :model/Card bound as :c, restrict this query to only return cards
   with invalid references."
   [card-query-map]
-  ;; NOTE: We anticipate a schema change to support missing references that will result in left-joins and
-  ;; where clauses being appended as well.
   (-> card-query-map
       (update :join concat
               [[(t2/table-name :model/QueryField) :qf]

--- a/src/metabase/models/query_field.clj
+++ b/src/metabase/models/query_field.clj
@@ -10,9 +10,10 @@
   (derive :metabase/model))
 
 (defn- coerce-boolean [x]
-  (if (zero? x)
-    false
-    x))
+  (if (= 0 x) false x))
+
+(defn- coerce-booleans [m]
+  (update-vals coerce-boolean m))
 
 (defn cards-with-reference-errors
   "Given some HoneySQL query map with :model/Card bound as :c, restrict this query to only return cards
@@ -55,10 +56,11 @@
                                   [:= :f.active false]]
                                  [:in :card_id (map :id cards)]]
                      :order-by  [:qf.card_id :field :table]})
+         (map coerce-booleans)
          (map (fn [{:keys [card_id table field field_unknown table_active]}]
                 [card_id {:type  (cond
-                                   (coerce-boolean field_unknown) :unknown-field
-                                   (coerce-boolean table_active)  :inactive-field
+                                   field_unknown :unknown-field
+                                   table_active  :inactive-field
                                    :else         :inactive-table)
                           :table table
                           :field field}]))

--- a/src/metabase/models/query_field.clj
+++ b/src/metabase/models/query_field.clj
@@ -69,7 +69,13 @@
   Returns `nil` (and logs the error) if there was a parse error."
   [card-id query-field-rows]
   (t2/with-transaction [_conn]
-    (let [existing            (t2/select :model/QueryField :card_id card-id)
+    (t2/delete! :model/QueryField :card_id card-id)
+    (t2/insert! :model/QueryField query-field-rows)
+
+    ;; let's wait and see if we get flakes again.
+    ;; the following diff algorithm broke once we could no longer depend on :field_id being non-null
+
+    #_(let [existing            (t2/select :model/QueryField :card_id card-id)
           {:keys [to-update
                   to-create
                   to-delete]} (u/row-diff existing query-field-rows

--- a/src/metabase/models/query_field.clj
+++ b/src/metabase/models/query_field.clj
@@ -39,8 +39,7 @@
     (->> (t2/select :model/QueryField
                     {:select    [:qf.card_id
                                  [:qf.column :field]
-                                 ;; TODO once we store a table name on query_field we can use that instead
-                                 [[:coalesce :t.name "unknown"] :table]
+                                 [:qf.table :table]
                                  [[:= :f.id nil] :field_unknown]
                                  [[:coalesce :t.active false] :table_active]]
                      :from      [[(t2/table-name :model/QueryField) :qf]]

--- a/src/metabase/query_analysis.clj
+++ b/src/metabase/query_analysis.clj
@@ -123,12 +123,11 @@
   (let [query-type (lib/normalized-query-type query)]
     (when (enabled-type? query-type)
       (let [references       (query-references query query-type)
-            reference->row   (fn [{:keys [field-id explicit-reference]}]
-                               ;; For now we only persist references which resolve to known fields
-                               (when field-id
-                                 {:card_id            card-id
-                                  :field_id           field-id
-                                  :explicit_reference explicit-reference}))
+            reference->row   (fn [{:keys [column field-id explicit-reference]}]
+                               {:card_id            card-id
+                                :column             column
+                                :field_id           field-id
+                                :explicit_reference explicit-reference})
             query-field-rows (map reference->row (:fields references))]
         (query-field/update-query-fields-for-card! card-id query-field-rows)))))
 

--- a/src/metabase/query_analysis.clj
+++ b/src/metabase/query_analysis.clj
@@ -123,8 +123,9 @@
   (let [query-type (lib/normalized-query-type query)]
     (when (enabled-type? query-type)
       (let [references       (query-references query query-type)
-            reference->row   (fn [{:keys [column field-id explicit-reference]}]
+            reference->row   (fn [{:keys [table column field-id explicit-reference]}]
                                {:card_id            card-id
+                                :table              table
                                 :column             column
                                 :field_id           field-id
                                 :explicit_reference explicit-reference})

--- a/test/metabase/models/query_field_test.clj
+++ b/test/metabase/models/query_field_test.clj
@@ -8,10 +8,12 @@
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp]))
 
-(def ^:private query-field-keys [:card_id :column :field_id :explicit_reference])
+(def ^:private query-field-keys [:card_id :table :column :field_id :explicit_reference])
 
 (defn- qf->map [query-field]
-  (update (select-keys query-field query-field-keys) :column u/lower-case-en))
+  (-> (select-keys query-field query-field-keys)
+      (update :table u/lower-case-en)
+      (update :column u/lower-case-en)))
 
 (defn- query-fields-for-card
   [card-id]
@@ -53,17 +55,29 @@
 
 (deftest query-fields-created-by-queries-test
   (with-test-setup
-    (let [total-qf {:card_id            card-id
-                    :column             "total"
-                    :field_id           total-id
-                    :explicit_reference true}
-          tax-qf   {:card_id            card-id
-                    :column             "tax"
-                    :field_id           tax-id
-                    :explicit_reference true}]
+    (let [total-qf     {:card_id            card-id
+                        :table              "orders"
+                        :column             "total"
+                        :field_id           total-id
+                        :explicit_reference true}
+          tax-qf       {:card_id            card-id
+                        :table              "orders"
+                        :column             "tax"
+                        :field_id           tax-id
+                        :explicit_reference true}
+          not-total-qf {:card_id            card-id
+                        :table              "orders"
+                        :column             "not_total"
+                        :field_id           nil
+                        :explicit_reference true}
+          not-tax      {:card_id            card-id
+                        :table              "orders"
+                        :column             "not_tax"
+                        :field_id           nil
+                        :explicit_reference true}]
 
       (testing "A freshly created card has relevant corresponding QueryFields"
-        (is (= #{total-qf}
+        (is (= #{total-qf not-tax}
                (query-fields-for-card card-id))))
 
       (testing "Adding new columns to the query also adds the QueryFields"
@@ -73,7 +87,7 @@
 
       (testing "Removing columns from the query removes the QueryFields"
         (trigger-parse! card-id "SELECT tax, not_total FROM orders")
-        (is (= #{tax-qf}
+        (is (= #{tax-qf not-total-qf}
                (query-fields-for-card card-id))))
 
       (testing "Columns referenced via field filters are still found"
@@ -89,17 +103,11 @@
         (is (= #{tax-qf total-qf}
                (query-fields-for-card card-id)))))))
 
-(deftest bogus-queries-test
-  (with-test-setup
-    (testing "Updating a query with bogus columns does not create QueryFields"
-      (trigger-parse! card-id "SELECT DOES, NOT_EXIST FROM orders")
-      (is (empty? (t2/select :model/QueryField :card_id card-id))))))
-
-
 (deftest unknown-test
   (with-test-setup
     (let [qux-qf {:card_id            card-id
-                  :column             "total"
+                  :table              "orders"
+                  :column             "qux"
                   :field_id           nil
                   :explicit_reference true}]
       (testing "selecting an unknown column"
@@ -110,10 +118,12 @@
 (deftest wildcard-test
   (with-test-setup
     (let [total-qf {:card_id          card-id
+                    :table            "orders"
                     :column           "total"
                     :field_id         total-id
                     :explicit_reference false}
           tax-qf   {:card_id          card-id
+                    :table            "orders"
                     :column           "tax"
                     :field_id         tax-id
                     :explicit_reference false}]
@@ -127,10 +137,12 @@
 (deftest table-wildcard-test
   (with-test-setup
     (let [total-qf {:card_id          card-id
+                    :table            "orders"
                     :column           "total"
                     :field_id         total-id
                     :explicit_reference true}
           tax-qf   {:card_id          card-id
+                    :table            "orders"
                     :column           "tax"
                     :field_id         tax-id
                     :explicit_reference true}]


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/45027

### Description

This change modifies the Query Analysis persistence to also record columns which could not be resolved to fields we've previously found during a sync. It then exposes these new rows as a new kind of error in the Query Reference Validation API.