### PR TITLE
test(jest): get rid of warnings about duplicate manual mock

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -35,7 +35,7 @@ frontend_specs: &frontend_specs
   - "frontend/test/**"
   - "frontend/**/tests/**"
   - "frontend/**/*.unit.*"
-  - "jest.config.json"
+  - "jest.config.js"
   - "jest.tz.unit.conf.json"
 
 release_source: &release_sources

--- a/jest.config.js
+++ b/jest.config.js
@@ -37,6 +37,7 @@ const config = {
   modulePathIgnorePatterns: [
     "<rootDir>/target/cljs_release/.*",
     "<rootDir>/resources/frontend_client",
+    "<rootDir>/.*/__mocks__",
   ],
   setupFiles: [
     "<rootDir>/frontend/test/jest-setup.js",


### PR DESCRIPTION
### Description

Get rid of the warning 

```
jest-haste-map: duplicate manual mock found: index
  The following files share their name; please delete one of them:
    * <rootDir>/frontend/src/metabase/components/ExplicitSize/__mocks__/index.ts
    * <rootDir>/frontend/src/metabase/query_builder/components/NativeQueryEditor/__mocks__/index.ts
```

[context](https://metaboat.slack.com/archives/C0669P4AF9N/p1721827674299859)

### How to verify

`yarn jest` shouldn't print this warning

### Demo

<img width="1230" alt="image" src="https://github.com/user-attachments/assets/39eebb03-6783-483d-a850-4888accf6c9f">

