### PR TITLE
[serdes] convert database, card and dashboard with friends to using spec

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/load_test.clj
@@ -424,15 +424,3 @@
   (let [parameters [{:values_source_config {:card_id "foo"}}]]
     (with-redefs [load/fully-qualified-name->card-id {"foo" 1}]
       (is (= [1] (mapv (comp :card_id :values_source_config) (#'load/resolve-dashboard-parameters parameters)))))))
-
-(deftest with-dbs-works-as-expected-test
-  (ts/with-dbs [source-db dest-db]
-    (ts/with-db source-db
-      (mt/with-temp
-        [:model/Card _ {:name "MY CARD"}]
-        (testing "card is available in the source db"
-          (is (some? (t2/select-one :model/Card :name "MY CARD"))))
-        (ts/with-db dest-db
-          (testing "card should not be available in the dest db"
-           ;; FAIL, select is returning a Card
-           (is (nil? (t2/select-one :model/Card :name "MY CARD")))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -861,7 +861,7 @@
             (let [logs (mt/with-log-messages-for-level ['metabase-enterprise :error]
                          (let [files (->> (#'ingest/ingest-all (io/file dump-dir))
                                           (map (comp second second))
-                                          (map #(.getName %))
+                                          (map #(.getName ^File %))
                                           set)]
                            (testing "Hidden YAML wasn't read even though it's not throwing errors"
                              (is (not (contains? files ".hidden.yaml"))))))]

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -193,30 +193,7 @@
                                                                 :collection_id [:coll 10 100]})
                :timeline                (many-random-fks 10 {} {:creator_id    [:u 10]
                                                                 :collection_id [:coll 100]})
-               :timeline-event          (many-random-fks 90 {} {:timeline_id   [:timeline 10]})
-               :pulse                   (vec (concat
-                                               ;; 10 classic pulses, from collections
-                                              (many-random-fks 10 {} {:collection_id [:coll 100]})
-                                               ;; 10 classic pulses, no collection
-                                              (many-random-fks 10 {:refs {:collection_id ::rs/omit}} {})
-                                               ;; 10 dashboard subs
-                                              (many-random-fks 10 {:refs {:collection_id ::rs/omit}}
-                                                               {:dashboard_id  [:d 100]})))
-               :pulse-card              (vec (concat
-                                               ;; 60 pulse cards for the classic pulses
-                                              (many-random-fks 60 {} {:card_id       [:c 100]
-                                                                      :pulse_id      [:pulse 10]})
-                                               ;; 60 pulse cards connected to dashcards for the dashboard subs
-                                              (many-random-fks 60 {} {:card_id           [:c 100]
-                                                                      :pulse_id          [:pulse 10 20]
-                                                                      :dashboard_card_id [:dc 300]})))
-               :pulse-channel           (vec (concat
-                                               ;; 15 channels for the classic pulses
-                                              (many-random-fks 15 {} {:pulse_id  [:pulse 10]})
-                                               ;; 15 channels for the dashboard subs
-                                              (many-random-fks 15 {} {:pulse_id  [:pulse 10 20]})))
-               :pulse-channel-recipient (many-random-fks 40 {} {:pulse_channel_id [:pulse-channel 30]
-                                                                :user_id          [:u 100]})}))
+               :timeline-event          (many-random-fks 90 {} {:timeline_id   [:timeline 10]})}))
 
           (is (= 101 (count (t2/select-fn-set :email 'User)))) ; +1 for the internal user
 

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -112,20 +112,6 @@
           (is (= #{coll-eid child-eid}
                  (by-model "Collection" (extract/extract {:user-id 218921})))))))))
 
-(deftest database-test
-  (mt/with-empty-h2-app-db
-    (ts/with-temp-dpc [Database   _ {:name "My Database"}]
-      (testing "without :include-database-secrets"
-        (let [extracted (extract/extract {})
-              dbs       (filter #(= "Database" (:model (last (serdes/path %)))) extracted)]
-          (is (= 1 (count dbs)))
-          (is (not-any? :details dbs))))
-      (testing "with :include-database-secrets"
-        (let [extracted (extract/extract {:include-database-secrets true})
-              dbs       (filter #(= "Database" (:model (last (serdes/path %)))) extracted)]
-          (is (= 1 (count dbs)))
-          (is (every? :details dbs)))))))
-
 #_{:clj-kondo/ignore [:metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests]}
 (deftest dashboard-and-cards-test
   (mt/with-empty-h2-app-db

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -591,7 +591,11 @@
        :model/DashboardCardSeries _ {:card_id c3-id, :dashboardcard_id dc1-id, :position 1}
        :model/DashboardCardSeries _ {:card_id c2-id, :dashboardcard_id dc1-id, :position 0}]
       (testing "Inlined dashcards include their series' card entity IDs"
-        (let [ser (serdes/extract-one "Dashboard" {} (t2/select-one Dashboard :id dash-id))]
+        (let [ser (serdes/extract-all "Dashboard" {:where [:= :id dash-id]})
+              #_(serdes/extract-one "Dashboard" {} (t2/select-one Dashboard :id dash-id))
+              #_ (dev.toucan2-monitor/with-queries [q]
+                    (metabase.util/prog1 (serdes/extract-one "Dashboard" {} (t2/select-one Dashboard :id dash-id))
+                      #p (q)))]
           (is (=? {:entity_id dash-eid
                    :dashcards [{:entity_id dc1-eid
                                 :series (mt/exactly=? [{:card_id c2-eid} {:card_id c3-eid}])}

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -593,7 +593,8 @@
       (testing "Inlined dashcards include their series' card entity IDs"
         (let [ser (serdes/extract-one "Dashboard" {} (t2/select-one Dashboard :id dash-id))]
           (is (=? {:entity_id dash-eid
-                   :dashcards [{:entity_id dc1-eid, :series (mt/exactly=? [{:card_id c2-eid} {:card_id c3-eid}])}
+                   :dashcards [{:entity_id dc1-eid
+                                :series (mt/exactly=? [{:position 0 :card_id c2-eid} {:position 1 :card_id c3-eid}])}
                                {:entity_id dc2-eid, :series []}]}
                   ser))
 

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -594,7 +594,7 @@
         (let [ser (serdes/extract-one "Dashboard" {} (t2/select-one Dashboard :id dash-id))]
           (is (=? {:entity_id dash-eid
                    :dashcards [{:entity_id dc1-eid
-                                :series (mt/exactly=? [{:position 0 :card_id c2-eid} {:position 1 :card_id c3-eid}])}
+                                :series (mt/exactly=? [{:card_id c2-eid} {:card_id c3-eid}])}
                                {:entity_id dc2-eid, :series []}]}
                   ser))
 

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -583,7 +583,8 @@
                         (is (< (q) 13))))]
             (is (=? {:entity_id dash-eid
                      :dashcards [{:entity_id dc1-eid
-                                  :series (mt/exactly=? [{:card_id c2-eid} {:card_id c3-eid}])}
+                                  :series (mt/exactly=? [{:card_id c2-eid :position 0}
+                                                         {:card_id c3-eid :position 1}])}
                                  {:entity_id dc2-eid, :series []}]}
                     ser))
 

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -1166,12 +1166,11 @@
                             :visualization_settings {:click_behavior {:type     "link"
                                                                       :linkType "dashboard"
                                                                       :targetId (:id dash1)}})
-          ser   (atom nil)]
-      (reset! ser (into [] (serdes.extract/extract {:no-settings   true
-                                                    :no-data-model true})))
+          ser   (into [] (serdes.extract/extract {:no-settings   true
+                                                  :no-data-model true}))]
       (t2/delete! DashboardCard :id [:in (map :id [dc1 dc2 dc3])])
       (testing "Circular dependencies are loaded correctly"
-        (is (serdes.load/load-metabase! (ingestion-in-memory @ser)))
+        (is (serdes.load/load-metabase! (ingestion-in-memory ser)))
         (let [select-target #(-> % :visualization_settings :click_behavior :targetId)]
           (is (= (:id dash2)
                  (t2/select-one-fn select-target DashboardCard :entity_id (:entity_id dc1))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -1100,7 +1100,6 @@
           (let [extract (into [] (serdes.extract/extract {:no-settings true}))]
             (ts/with-db dest-db
               (serdes.load/load-metabase! (ingestion-in-memory extract))
-              ;; this really tests `serdes/load-find-local "DashboardCardSeries"`
               (testing "Both series get imported even though they point at the same card"
                 (is (= 2
                        (t2/count :model/DashboardCardSeries)))))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -1217,3 +1217,40 @@
                                    (let [report (serdes.load/load-metabase! (ingestion-in-memory changed) {:continue-on-error true})]
                                      (is (= 1 (count (:errors report))))
                                      (is (= 3 (count (:seen report)))))))))))))))
+
+(deftest database-test
+  (mt/with-empty-h2-app-db
+    (ts/with-temp-dpc [Database   _ {:name    "My Database"
+                                     :details {:some "secret"}}]
+      (testing "without :include-database-secrets"
+        (let [extracted (vec (serdes.extract/extract {:no-settings true}))
+              dbs       (filterv #(= "Database" (:model (last (serdes/path %)))) extracted)]
+          (is (= 1 (count dbs)))
+          (is (not-any? :details dbs))
+          (testing "loading still works even if there are no details"
+            (t2/delete! Database)
+            (is (= nil
+                   (t2/select-one-fn :details Database)))
+            (serdes.load/load-metabase! (ingestion-in-memory extracted))
+            (is (= {}
+                   (t2/select-one-fn :details Database)))
+            (testing "If we did not export details - it won't override existing data"
+              (t2/update! Database {:details {:other "secret"}})
+              (serdes.load/load-metabase! (ingestion-in-memory extracted))
+              (is (= {:other "secret"}
+                     (t2/select-one-fn :details Database))))))))
+
+    ;; deleting to really check what's going on: `t2/with-dbs` is not giving correct results
+    (t2/delete! Database)
+    (ts/with-temp-dpc [Database   _ {:name    "My Database"
+                                     :details {:some "secret"}}]
+      (testing "with :include-database-secrets"
+        (let [extracted (vec (serdes.extract/extract {:no-settings true :include-database-secrets true}))
+              dbs       (filterv #(= "Database" (:model (last (serdes/path %)))) extracted)]
+          (is (= 1 (count dbs)))
+          (is (every? :details dbs))
+          (testing "Details are imported if provided"
+            (t2/delete! Database)
+            (serdes.load/load-metabase! (ingestion-in-memory extracted))
+            (is (= (:details (first dbs))
+                   (t2/select-one-fn :details Database)))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -1218,39 +1218,47 @@
                                      (is (= 1 (count (:errors report))))
                                      (is (= 3 (count (:seen report)))))))))))))))
 
-(deftest database-test
-  (mt/with-empty-h2-app-db
-    (ts/with-temp-dpc [Database   _ {:name    "My Database"
-                                     :details {:some "secret"}}]
-      (testing "without :include-database-secrets"
-        (let [extracted (vec (serdes.extract/extract {:no-settings true}))
-              dbs       (filterv #(= "Database" (:model (last (serdes/path %)))) extracted)]
-          (is (= 1 (count dbs)))
-          (is (not-any? :details dbs))
-          (testing "loading still works even if there are no details"
-            (t2/delete! Database)
-            (is (= nil
-                   (t2/select-one-fn :details Database)))
-            (serdes.load/load-metabase! (ingestion-in-memory extracted))
-            (is (= {}
-                   (t2/select-one-fn :details Database)))
-            (testing "If we did not export details - it won't override existing data"
-              (t2/update! Database {:details {:other "secret"}})
-              (serdes.load/load-metabase! (ingestion-in-memory extracted))
-              (is (= {:other "secret"}
-                     (t2/select-one-fn :details Database))))))))
+(deftest with-dbs-works-as-expected-test
+  (ts/with-dbs [source-db dest-db]
+    (ts/with-db source-db
+      (mt/with-temp
+        [:model/Card _ {:name "MY CARD"}]
+        (testing "card is available in the source db"
+          (is (some? (t2/select-one :model/Card :name "MY CARD"))))
+        (ts/with-db dest-db
+          (testing "card should not be available in the dest db"
+           (is (nil? (t2/select-one :model/Card :name "MY CARD")))))))))
 
-    ;; deleting to really check what's going on: `t2/with-dbs` is not giving correct results
-    (t2/delete! Database)
-    (ts/with-temp-dpc [Database   _ {:name    "My Database"
-                                     :details {:some "secret"}}]
-      (testing "with :include-database-secrets"
-        (let [extracted (vec (serdes.extract/extract {:no-settings true :include-database-secrets true}))
-              dbs       (filterv #(= "Database" (:model (last (serdes/path %)))) extracted)]
-          (is (= 1 (count dbs)))
-          (is (every? :details dbs))
-          (testing "Details are imported if provided"
-            (t2/delete! Database)
-            (serdes.load/load-metabase! (ingestion-in-memory extracted))
-            (is (= (:details (first dbs))
-                   (t2/select-one-fn :details Database)))))))))
+(deftest database-test
+  (ts/with-dbs [source-db dest-db]
+    (ts/with-db source-db
+      (mt/with-temp [Database   _ {:name    "My Database"
+                                   :details {:some "secret"}}]
+        (testing "without :include-database-secrets"
+          (let [extracted (vec (serdes.extract/extract {:no-settings true}))
+                dbs       (filterv #(= "Database" (:model (last (serdes/path %)))) extracted)]
+            (is (= 1 (count dbs)))
+            (is (not-any? :details dbs))
+            (ts/with-db dest-db
+              (testing "loading still works even if there are no details"
+                (serdes.load/load-metabase! (ingestion-in-memory extracted))
+                (is (= {}
+                       (t2/select-one-fn :details Database)))
+                (testing "If we did not export details - it won't override existing data"
+                  (t2/update! Database {:details {:other "secret"}})
+                  (serdes.load/load-metabase! (ingestion-in-memory extracted))
+                  (is (= {:other "secret"}
+                         (t2/select-one-fn :details Database)))))))))
+
+      (mt/with-temp [Database   _ {:name    "My Database"
+                                   :details {:some "secret"}}]
+        (testing "with :include-database-secrets"
+          (let [extracted (vec (serdes.extract/extract {:no-settings true :include-database-secrets true}))
+                dbs       (filterv #(= "Database" (:model (last (serdes/path %)))) extracted)]
+            (is (= 1 (count dbs)))
+            (is (every? :details dbs))
+            (ts/with-db dest-db
+              (testing "Details are imported if provided"
+                (serdes.load/load-metabase! (ingestion-in-memory extracted))
+                (is (= (:details (first dbs))
+                       (t2/select-one-fn :details Database)))))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/models_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/models_test.clj
@@ -49,11 +49,11 @@
 (deftest serialization-complete-spec-test
   (mt/with-empty-h2-app-db
     ;; When serialization spec is defined, it describes every column
-    (doseq [m               (-> (methods serdes/make-spec)
+    (doseq [m     (-> (methods serdes/make-spec)
                       (dissoc :default)
                       keys) #_ serdes.models/exported-models
-            :let            [spec (serdes/make-spec m nil)]
-            :when           spec]
+            :let  [spec (serdes/make-spec m nil)]
+            :when spec]
       (let [t      (t2/table-name (keyword "model" m))
             pk     (first (t2/primary-keys (keyword "model" m)))
             fields (u.conn/app-db-column-types (mdb/app-db) t)
@@ -78,10 +78,9 @@
                     set))))
         (testing "Foreign keys should be declared as such\n"
           (doseq [[fk _] (filter #(:fk (second %)) fields)
-                  :let   [fk (u/lower-case-en fk)
-                          transform (get spec' (keyword fk))]]
+                  :let   [fk        (u/lower-case-en fk)
+                          transform (get spec' (keyword fk))]
+                  :when  (not= transform :skip)]
             (testing (format "%s.%s is foreign key which is handled correctly" m fk)
-              (is (or (= transform :skip)
-                      (= serdes/*export-user* (first transform))
-                      ;; use `(serdes/fk ...)` function
-                      (::serdes/fk (meta transform)))))))))))
+              ;; uses `(serdes/fk ...)` function
+              (is (::serdes/fk (meta transform))))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/models_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/models_test.clj
@@ -49,7 +49,9 @@
 (deftest serialization-complete-spec-test
   (mt/with-empty-h2-app-db
     ;; When serialization spec is defined, it describes every column
-    (doseq [m     serdes.models/exported-models
+    (doseq [m     (-> (methods serdes/make-spec)
+                      (dissoc :default)
+                      keys) #_ serdes.models/exported-models
             :let  [spec (serdes/make-spec m nil)]
             :when spec]
       (let [t      (t2/table-name (keyword "model" m))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/models_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/models_test.clj
@@ -49,11 +49,11 @@
 (deftest serialization-complete-spec-test
   (mt/with-empty-h2-app-db
     ;; When serialization spec is defined, it describes every column
-    (doseq [m     (-> (methods serdes/make-spec)
+    (doseq [m               (-> (methods serdes/make-spec)
                       (dissoc :default)
                       keys) #_ serdes.models/exported-models
-            :let  [spec (serdes/make-spec m nil)]
-            :when spec]
+            :let            [spec (serdes/make-spec m nil)]
+            :when           spec]
       (let [t      (t2/table-name (keyword "model" m))
             pk     (first (t2/primary-keys (keyword "model" m)))
             fields (u.conn/app-db-column-types (mdb/app-db) t)
@@ -79,9 +79,9 @@
         (testing "Foreign keys should be declared as such\n"
           (doseq [[fk _] (filter #(:fk (second %)) fields)
                   :let   [fk (u/lower-case-en fk)
-                          action (get spec' (keyword fk))]]
+                          transform (get spec' (keyword fk))]]
             (testing (format "%s.%s is foreign key which is handled correctly" m fk)
-              (is (or (= action :skip)
-                      (= serdes/*export-user* (first action))
+              (is (or (= transform :skip)
+                      (= serdes/*export-user* (first transform))
                       ;; use `(serdes/fk ...)` function
-                      (::serdes/fk (meta action)))))))))))
+                      (::serdes/fk (meta transform)))))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/models_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/models_test.clj
@@ -49,17 +49,15 @@
 (deftest serialization-complete-spec-test
   (mt/with-empty-h2-app-db
     ;; When serialization spec is defined, it describes every column
-    (doseq [m     (-> (methods serdes/make-spec)
-                      (dissoc :default)
-                      keys) #_ serdes.models/exported-models
-            :let  [spec (serdes/make-spec m nil)]
-            :when spec]
+    (doseq [m    (-> (methods serdes/make-spec)
+                     (dissoc :default)
+                     keys)
+            :let [spec (serdes/make-spec m nil)]]
       (let [t      (t2/table-name (keyword "model" m))
-            pk     (first (t2/primary-keys (keyword "model" m)))
             fields (u.conn/app-db-column-types (mdb/app-db) t)
             spec'  (-> (merge (zipmap (:copy spec) (repeat :copy))
                               (zipmap (:skip spec) (repeat :skip))
-                              (zipmap [pk :updated_at] (repeat :skip)) ; always skipped
+                              (zipmap [:id :updated_at] (repeat :skip)) ; always skipped
                               (:transform spec))
                        ;; `nil`s are mostly fields which differ on `opts`
                        (dissoc nil))]
@@ -83,4 +81,4 @@
                   :when  (not= transform :skip)]
             (testing (format "%s.%s is foreign key which is handled correctly" m fk)
               ;; uses `(serdes/fk ...)` function
-              (is (::serdes/fk (meta transform))))))))))
+              (is (::serdes/fk transform)))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/models_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/models_test.clj
@@ -68,14 +68,7 @@
                   :let   [fk (u/lower-case-en fk)
                           action (get spec' (keyword fk))]]
             (testing (format "%s.%s is foreign key which is handled correctly" m fk)
-              ;; FIXME: serialization can guess where FK points by itself, but `collection_id`,
-              ;; `database_id`, and `source_card_id` are specifying that themselves right now
-              (when-not (#{"collection_id" "database_id" "source_card_id"} fk)
-                (is (#{:skip
-                       serdes/*export-fk*
-                       serdes/*export-fk-keyed*
-                       serdes/*export-table-fk*
-                       serdes/*export-user*}
-                     (if (vector? action)
-                       (first action) ;; tuple of [ser des]
-                       action)))))))))))
+              (is (or (= action :skip)
+                      (= serdes/*export-user* (first action))
+                      ;; use `(serdes/fk ...)` function
+                      (::serdes/fk (meta action)))))))))))

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -856,20 +856,13 @@
     :table_id               (serdes/fk :model/Table)
     :source_card_id         (serdes/fk :model/Card)
     :collection_id          (serdes/fk :model/Collection)
-    :creator_id             [serdes/*export-user*
-                             serdes/*import-user*]
-    :made_public_by_id      [serdes/*export-user*
-                             serdes/*import-user*]
-    :dataset_query          [serdes/export-mbql
-                             serdes/import-mbql]
-    :parameters             [serdes/export-parameters
-                             serdes/import-parameters]
-    :parameter_mappings     [serdes/export-parameter-mappings
-                             serdes/import-parameter-mappings]
-    :visualization_settings [serdes/export-visualization-settings
-                             serdes/import-visualization-settings]
-    :result_metadata        [export-result-metadata
-                             import-result-metadata]}})
+    :creator_id             [serdes/*export-user* serdes/*import-user*]
+    :made_public_by_id      [serdes/*export-user* serdes/*import-user*]
+    :dataset_query          [serdes/export-mbql serdes/import-mbql]
+    :parameters             [serdes/export-parameters serdes/import-parameters]
+    :parameter_mappings     [serdes/export-parameter-mappings serdes/import-parameter-mappings]
+    :visualization_settings [serdes/export-visualization-settings serdes/import-visualization-settings]
+    :result_metadata        [export-result-metadata import-result-metadata]}})
 
 (defmethod serdes/dependencies "Card"
   [{:keys [collection_id database_id dataset_query parameters parameter_mappings

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -840,12 +840,10 @@
                                      (when (:id m)       #{(serdes/field->path (:id m))})])))))
 
 (defmethod serdes/make-spec "Card"
-  [_model-name]
+  [_model-name _opts]
   {:copy [:archived :archived_directly :collection_position :collection_preview :created_at :description :display
           :embedding_params :enable_embedding :entity_id :metabase_version :public_uuid :query_type :type :name]
-   :skip [;; always instance-specific
-          :id :updated_at
-          ;; cache invalidation is instance-specific
+   :skip [;; cache invalidation is instance-specific
           :cache_invalidated_at
           ;; those are instance-specific analytic columns
           :view_count :last_used_at :initially_published_at

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -854,14 +854,10 @@
           ;; this column is not used anymore
           :cache_ttl]
    :transform
-   {:database_id            [#(serdes/*export-fk-keyed* % 'Database :name)
-                             #(serdes/*import-fk-keyed* % 'Database :name)]
-    :table_id               [serdes/*export-table-fk*
-                             serdes/*import-table-fk*]
-    :source_card_id         [#(serdes/*export-fk* % :model/Card)
-                             #(serdes/*import-fk* % :model/Card)]
-    :collection_id          [#(serdes/*export-fk* % 'Collection)
-                             #(serdes/*import-fk* % 'Collection)]
+   {:database_id            (serdes/fk :model/Database :name)
+    :table_id               (serdes/fk :model/Table)
+    :source_card_id         (serdes/fk :model/Card)
+    :collection_id          (serdes/fk :model/Collection)
     :creator_id             [serdes/*export-user*
                              serdes/*import-user*]
     :made_public_by_id      [serdes/*export-user*

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -856,8 +856,8 @@
     :table_id               (serdes/fk :model/Table)
     :source_card_id         (serdes/fk :model/Card)
     :collection_id          (serdes/fk :model/Collection)
-    :creator_id             [serdes/*export-user* serdes/*import-user*]
-    :made_public_by_id      [serdes/*export-user* serdes/*import-user*]
+    :creator_id             (serdes/fk :model/User)
+    :made_public_by_id      (serdes/fk :model/User)
     :dataset_query          [serdes/export-mbql serdes/import-mbql]
     :parameters             [serdes/export-parameters serdes/import-parameters]
     :parameter_mappings     [serdes/export-parameter-mappings serdes/import-parameter-mappings]

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -858,11 +858,11 @@
     :collection_id          (serdes/fk :model/Collection)
     :creator_id             (serdes/fk :model/User)
     :made_public_by_id      (serdes/fk :model/User)
-    :dataset_query          [serdes/export-mbql serdes/import-mbql]
-    :parameters             [serdes/export-parameters serdes/import-parameters]
-    :parameter_mappings     [serdes/export-parameter-mappings serdes/import-parameter-mappings]
-    :visualization_settings [serdes/export-visualization-settings serdes/import-visualization-settings]
-    :result_metadata        [export-result-metadata import-result-metadata]}})
+    :dataset_query          {:export serdes/export-mbql :import serdes/import-mbql}
+    :parameters             {:export serdes/export-parameters :import serdes/import-parameters}
+    :parameter_mappings     {:export serdes/export-parameter-mappings :import serdes/import-parameter-mappings}
+    :visualization_settings {:export serdes/export-visualization-settings :import serdes/import-visualization-settings}
+    :result_metadata        {:export export-result-metadata :import import-result-metadata}}})
 
 (defmethod serdes/dependencies "Card"
   [{:keys [collection_id database_id dataset_query parameters parameter_mappings

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -579,8 +579,11 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                               SERIALIZATION                                                    |
 ;;; +----------------------------------------------------------------------------------------------------------------+
+
 (defmethod serdes/extract-query "Dashboard" [_ opts]
-  (eduction (map #(t2/hydrate % [:dashcards :series]))
+  (eduction (map #(-> %
+                      (t2/hydrate [:dashcards :series])
+                      (t2/hydrate :tabs)))
             (serdes/extract-query-collections Dashboard opts)))
 
 (defmethod serdes/make-spec "Dashboard" [_model-name opts]

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -592,7 +592,7 @@
    :transform {:collection_id     (serdes/fk :model/Collection)
                :creator_id        (serdes/fk :model/User)
                :made_public_by_id (serdes/fk :model/User)
-               :parameters        [serdes/export-parameters serdes/import-parameters]
+               :parameters        {:export serdes/export-parameters :import serdes/import-parameters}
                :tabs              (serdes/nested :model/DashboardTab :dashboard_id opts)
                :dashcards         (serdes/nested :model/DashboardCard :dashboard_id opts)}})
 

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -587,12 +587,13 @@
             (serdes/extract-query-collections Dashboard opts)))
 
 (defmethod serdes/make-spec "Dashboard" [_model-name opts]
-  {:copy      [:archived :archived_directly :auto_apply_filters :cache_ttl :caveats :collection_position :created_at
+  {:copy      [:archived :archived_directly :auto_apply_filters :cache_ttl :caveats :collection_position
                :description :embedding_params :enable_embedding :entity_id :initially_published_at :name
                :points_of_interest :position :public_uuid :show_in_getting_started :width]
    :skip      [;; those stats are inherently local state
                :view_count :last_viewed_at]
-   :transform {:collection_id     (serdes/fk :model/Collection)
+   :transform {:created_at        (serdes/date)
+               :collection_id     (serdes/fk :model/Collection)
                :creator_id        (serdes/fk :model/User)
                :made_public_by_id (serdes/fk :model/User)
                :parameters        {:export serdes/export-parameters :import serdes/import-parameters}

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -585,13 +585,13 @@
 
 (defmethod serdes/make-spec "Dashboard" [_model-name opts]
   {:copy      [:archived :archived_directly :auto_apply_filters :cache_ttl :caveats :collection_position :created_at
-                :description :embedding_params :enable_embedding :entity_id :initially_published_at :name
-                :points_of_interest :position :public_uuid :show_in_getting_started :width]
+               :description :embedding_params :enable_embedding :entity_id :initially_published_at :name
+               :points_of_interest :position :public_uuid :show_in_getting_started :width]
    :skip      [;; those stats are inherently local state
                :view_count :last_viewed_at]
    :transform {:collection_id     (serdes/fk :model/Collection)
-               :creator_id        [serdes/*export-user* serdes/*import-user*]
-               :made_public_by_id [serdes/*export-user* serdes/*import-user*]
+               :creator_id        (serdes/fk :model/User)
+               :made_public_by_id (serdes/fk :model/User)
                :parameters        [serdes/export-parameters serdes/import-parameters]
                :tabs              (serdes/nested :model/DashboardTab :dashboard_id opts)
                :dashcards         (serdes/nested :model/DashboardCard :dashboard_id opts)}})

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -581,9 +581,7 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (defmethod serdes/extract-query "Dashboard" [_ opts]
-  (eduction (map #(-> %
-                      (t2/hydrate [:dashcards :series])
-                      (t2/hydrate :tabs)))
+  (eduction (map #(t2/hydrate % :tabs [:dashcards :series]))
             (serdes/extract-query-collections Dashboard opts)))
 
 (defmethod serdes/make-spec "Dashboard" [_model-name opts]

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -363,9 +363,10 @@
            (serdes/infer-self-path "DashboardCard" dashcard)]))
 
 (defmethod serdes/make-spec "DashboardCard" [_model-name opts]
-  {:copy      [:col :created_at :entity_id :row :size_x :size_y]
+  {:copy      [:col :entity_id :row :size_x :size_y]
    :skip      []
-   :transform {:dashboard_id           (serdes/parent-ref)
+   :transform {:created_at             (serdes/date)
+               :dashboard_id           (serdes/parent-ref)
                :card_id                (serdes/fk :model/Card)
                :action_id              (serdes/fk :model/Action)
                :dashboard_tab_id       (serdes/fk :model/DashboardTab)

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -373,7 +373,13 @@
                                         :import serdes/import-parameter-mappings}
                :visualization_settings {:export serdes/export-visualization-settings
                                         :import serdes/import-visualization-settings}
-               :series                 (serdes/nested :model/DashboardCardSeries :dashboardcard_id
-                                                      (assoc opts
-                                                             :sort-by :position
-                                                             :key-field :card_id))}})
+               :series
+               (-> (serdes/nested :model/DashboardCardSeries :dashboardcard_id
+                                  (assoc opts
+                                         :sort-by :position
+                                         :key-field :card_id))
+                   ;; FIXME: this waits to be removed when `extract-nested` (instead of using hydration) is
+                   ;; implemented
+                   (assoc :export (fn [data]
+                                    (->> (sort-by :position data)
+                                         (mapv (fn [x] {:card_id (serdes/*export-fk* (:id x) :model/Card)}))))))}})

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -369,10 +369,10 @@
                :card_id                (serdes/fk :model/Card)
                :action_id              (serdes/fk :model/Action)
                :dashboard_tab_id       (serdes/fk :model/DashboardTab)
-               :parameter_mappings     [serdes/export-parameter-mappings
-                                        serdes/import-parameter-mappings]
-               :visualization_settings [serdes/export-visualization-settings
-                                        serdes/import-visualization-settings]
+               :parameter_mappings     {:export serdes/export-parameter-mappings
+                                        :import serdes/import-parameter-mappings}
+               :visualization_settings {:export serdes/export-visualization-settings
+                                        :import serdes/import-visualization-settings}
                :series                 (serdes/nested :model/DashboardCardSeries :dashboardcard_id
                                                       (assoc opts
                                                              :sort-by :position

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -353,6 +353,13 @@
 
 ;;; ----------------------------------------------- SERIALIZATION ----------------------------------------------------
 
+(defmethod serdes/generate-path "DashboardCard" [_ dashcard]
+  (remove nil?
+          [(serdes/infer-self-path "Dashboard" (t2/select-one 'Dashboard :id (:dashboard_id dashcard)))
+           (when (:dashboard_tab_id dashcard)
+             (serdes/infer-self-path "DashboardTab" (t2/select-one :model/DashboardTab :id (:dashboard_tab_id dashcard))))
+           (serdes/infer-self-path "DashboardCard" dashcard)]))
+
 (defmethod serdes/make-spec "DashboardCard" [_model-name opts]
   {:copy      [:col :entity_id :row :size_x :size_y]
    :skip      []

--- a/src/metabase/models/dashboard_card_series.clj
+++ b/src/metabase/models/dashboard_card_series.clj
@@ -1,5 +1,6 @@
 (ns metabase.models.dashboard-card-series
   (:require
+   [metabase.models.serialization :as serdes]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
@@ -12,3 +13,23 @@
 
 (doto :model/DashboardCardSeries
   (derive :metabase/model))
+
+;; Serialization
+
+(defmethod serdes/entity-id "DashboardCardSeries" [_ instance] (:card_id instance))
+
+(defmethod serdes/generate-path "DashboardCardSeries" [_ _] nil)
+
+(defmethod serdes/load-find-local "DashboardCardSeries" [path]
+  (let [{:keys [id]} (last path)]
+    (t2/select-one :model/DashboardCardSeries :card_id {:from   [:report_card]
+                                                        :select [:id]
+                                                        :where  [:= :entity_id id]})))
+
+(defmethod serdes/make-spec "DashboardCardSeries" [_model-name _opts]
+  ;; We did not have position in serialization before, it was inferred from the sequence, but current helper
+  ;; (`serdes/nested`) is too generic and does not support that.
+  {:copy      [:position]
+   :skip      []
+   :transform {:dashboardcard_id (serdes/parent-ref)
+               :card_id          (serdes/fk :model/Card)}})

--- a/src/metabase/models/dashboard_card_series.clj
+++ b/src/metabase/models/dashboard_card_series.clj
@@ -16,7 +16,7 @@
 
 ;; Serialization
 
-(defmethod serdes/entity-id "DashboardCardSeries" [_ instance] (:card_id instance))
+;;(defmethod serdes/entity-id "DashboardCardSeries" [_ instance] (:card_id instance))
 
 (defmethod serdes/generate-path "DashboardCardSeries" [_ _] nil)
 
@@ -29,7 +29,8 @@
 (defmethod serdes/make-spec "DashboardCardSeries" [_model-name _opts]
   ;; We did not have position in serialization before, it was inferred from the sequence, but current helper
   ;; (`serdes/nested`) is too generic and does not support that.
-  {:copy      [:position]
+  {:copy      []
    :skip      []
-   :transform {:dashboardcard_id (serdes/parent-ref)
+   :transform {:position         {:export (constantly nil) :import identity}
+               :dashboardcard_id (serdes/parent-ref)
                :card_id          (serdes/fk :model/Card)}})

--- a/src/metabase/models/dashboard_card_series.clj
+++ b/src/metabase/models/dashboard_card_series.clj
@@ -18,10 +18,6 @@
 
 (defmethod serdes/generate-path "DashboardCardSeries" [_ _] nil)
 
-(defmethod serdes/load-find-local "DashboardCardSeries" [_path]
-  ;; nested will remove all previous entries because they have no entity_id anyway
-  nil)
-
 ;; TODO: this is not used atm as `DashboardCard` has custom :export/:import defined; see comment there
 ;; to be implemented.
 (defmethod serdes/make-spec "DashboardCardSeries" [_model-name _opts]

--- a/src/metabase/models/dashboard_card_series.clj
+++ b/src/metabase/models/dashboard_card_series.clj
@@ -18,16 +18,9 @@
 
 (defmethod serdes/generate-path "DashboardCardSeries" [_ _] nil)
 
-(defmethod serdes/load-find-local "DashboardCardSeries" [path]
-  ;; they are coming in as [dashcard series] pair from `serdes/nested`
-  (let [[{dashcard-eid :id} {card-eid :id}] path]
-    (t2/select-one :model/DashboardCardSeries
-                   :dashboardcard_id {:from   [:report_dashboardcard]
-                                      :select [:id]
-                                      :where  [:= :entity_id dashcard-eid]}
-                   :card_id          {:from   [:report_card]
-                                      :select [:id]
-                                      :where  [:= :entity_id card-eid]})))
+(defmethod serdes/load-find-local "DashboardCardSeries" [_path]
+  ;; nested will remove all previous entries because they have no entity_id anyway
+  nil)
 
 ;; TODO: this is not used atm as `DashboardCard` has custom :export/:import defined; see comment there
 ;; to be implemented.

--- a/src/metabase/models/dashboard_tab.clj
+++ b/src/metabase/models/dashboard_tab.clj
@@ -64,9 +64,10 @@
    (serdes/infer-self-path "DashboardTab" dashcard)])
 
 (defmethod serdes/make-spec "DashboardTab" [_model-name _opts]
-  {:copy      [:created_at :entity_id :name :position]
+  {:copy      [:entity_id :name :position]
    :skip      []
-   :transform {:dashboard_id (serdes/parent-ref)}})
+   :transform {:created_at   (serdes/date)
+               :dashboard_id (serdes/parent-ref)}})
 
 ;;; -------------------------------------------------- CRUD fns ------------------------------------------------------
 

--- a/src/metabase/models/dashboard_tab.clj
+++ b/src/metabase/models/dashboard_tab.clj
@@ -5,7 +5,6 @@
    [metabase.models.interface :as mi]
    [metabase.models.serialization :as serdes]
    [metabase.util :as u]
-   [metabase.util.date-2 :as u.date]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
    [methodical.core :as methodical]
@@ -64,12 +63,10 @@
   [(serdes/infer-self-path "Dashboard" (t2/select-one :model/Dashboard :id (:dashboard_id dashcard)))
    (serdes/infer-self-path "DashboardTab" dashcard)])
 
-(defmethod serdes/load-xform "DashboardTab"
-  [dashtab]
-  (-> dashtab
-      (dissoc :serdes/meta)
-      (update :dashboard_id serdes/*import-fk* :model/Dashboard)
-      (update :created_at   #(if (string? %) (u.date/parse %) %))))
+(defmethod serdes/make-spec "DashboardTab" [_model-name _opts]
+  {:copy      [:created_at :entity_id :name :position]
+   :skip      []
+   :transform {:dashboard_id (serdes/parent-ref)}})
 
 ;;; -------------------------------------------------- CRUD fns ------------------------------------------------------
 

--- a/src/metabase/models/dashboard_tab.clj
+++ b/src/metabase/models/dashboard_tab.clj
@@ -58,11 +58,6 @@
    :position
    :created_at])
 
-;; DashboardTabs are not serialized as their own, separate entities. They are inlined onto their parent Dashboards.
-(defmethod serdes/generate-path "DashboardTab" [_ dashcard]
-  [(serdes/infer-self-path "Dashboard" (t2/select-one :model/Dashboard :id (:dashboard_id dashcard)))
-   (serdes/infer-self-path "DashboardTab" dashcard)])
-
 (defmethod serdes/make-spec "DashboardTab" [_model-name _opts]
   {:copy      [:entity_id :name :position]
    :skip      []

--- a/src/metabase/models/dashboard_tab.clj
+++ b/src/metabase/models/dashboard_tab.clj
@@ -58,6 +58,10 @@
    :position
    :created_at])
 
+(defmethod serdes/generate-path "DashboardTab" [_ dashcard]
+  [(serdes/infer-self-path "Dashboard" (t2/select-one :model/Dashboard :id (:dashboard_id dashcard)))
+   (serdes/infer-self-path "DashboardTab" dashcard)])
+
 (defmethod serdes/make-spec "DashboardTab" [_model-name _opts]
   {:copy      [:entity_id :name :position]
    :skip      []

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -441,7 +441,7 @@
                :uploads_table_prefix
                (when include-database-secrets :details)]
    :skip      [(when-not include-database-secrets :details)]
-   :transform {:creator_id [serdes/*export-user* serdes/*import-user*]
+   :transform {:creator_id          (serdes/fk :model/User)
                :initial_sync_status [identity (constantly "complete")]}})
 
 (defmethod serdes/entity-id "Database"

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -442,7 +442,7 @@
                (when include-database-secrets :details)]
    :skip      [(when-not include-database-secrets :details)]
    :transform {:creator_id          (serdes/fk :model/User)
-               :initial_sync_status [identity (constantly "complete")]}})
+               :initial_sync_status {:export identity :import (constantly "complete")}}})
 
 (defmethod serdes/entity-id "Database"
   [_ {:keys [name]}]

--- a/src/metabase/models/dimension.clj
+++ b/src/metabase/models/dimension.clj
@@ -40,4 +40,4 @@
   {:copy      [:name :type :created_at :entity_id]
    :skip      []
    :transform {:human_readable_field_id (serdes/fk :model/Field)
-               :field_id (serdes/parent-ref)}})
+               :field_id                (serdes/parent-ref)}})

--- a/src/metabase/models/dimension.clj
+++ b/src/metabase/models/dimension.clj
@@ -5,7 +5,6 @@
   (:require
    [metabase.models.interface :as mi]
    [metabase.models.serialization :as serdes]
-   [metabase.util.date-2 :as u.date]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
@@ -36,12 +35,9 @@
    :created_at])
 
 ;;; ------------------------------------------------- Serialization --------------------------------------------------
-;; Dimensions are inlined onto their parent Fields.
-;; We can reuse the [[serdes/load-one!]] logic by implementing [[serdes/load-xform]] though.
-(defmethod serdes/load-xform "Dimension"
-  [dim]
-  (-> dim
-      serdes/load-xform-basics
-      ;; No need to handle :field_id, it was just added as the raw ID by the caller; see Field's load-one!
-      (update            :human_readable_field_id serdes/*import-field-fk*)
-      (update            :created_at              u.date/parse)))
+
+(defmethod serdes/make-spec "Dimension" [_model-name _opts]
+  {:copy      [:name :type :created_at :entity_id]
+   :skip      [; Dimensions are inlined in their Fields, no need to refer the Field itself
+               :field_id]
+   :transform {:human_readable_field_id (serdes/fk :model/Field)}})

--- a/src/metabase/models/dimension.clj
+++ b/src/metabase/models/dimension.clj
@@ -38,6 +38,6 @@
 
 (defmethod serdes/make-spec "Dimension" [_model-name _opts]
   {:copy      [:name :type :created_at :entity_id]
-   :skip      [; Dimensions are inlined in their Fields, no need to refer the Field itself
-               :field_id]
-   :transform {:human_readable_field_id (serdes/fk :model/Field)}})
+   :skip      []
+   :transform {:human_readable_field_id (serdes/fk :model/Field)
+               :field_id (serdes/parent-ref)}})

--- a/src/metabase/models/dimension.clj
+++ b/src/metabase/models/dimension.clj
@@ -37,7 +37,8 @@
 ;;; ------------------------------------------------- Serialization --------------------------------------------------
 
 (defmethod serdes/make-spec "Dimension" [_model-name _opts]
-  {:copy      [:name :type :created_at :entity_id]
+  {:copy      [:name :type :entity_id]
    :skip      []
-   :transform {:human_readable_field_id (serdes/fk :model/Field)
+   :transform {:created_at              (serdes/date)
+               :human_readable_field_id (serdes/fk :model/Field)
                :field_id                (serdes/parent-ref)}})

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -377,12 +377,12 @@
   (let [table (serdes/load-find-local (pop path))]
     (t2/select-one Field :name (-> path last :id) :table_id (:id table))))
 
-(defmethod serdes/extract-query "Field" [_model-name _opts]
-  (let [d (t2/select Dimension)
+(defmethod serdes/extract-query "Field" [_model-name opts]
+  (let [d          (t2/select Dimension)
         dimensions (->> d
                         (group-by :field_id))]
     (eduction (map #(assoc % :dimensions (get dimensions (:id %))))
-              (t2/reducible-select Field))))
+              (t2/reducible-select Field {:where (:where opts true)}))))
 
 (defmethod serdes/dependencies "Field" [field]
   ;; Fields depend on their parent Table, plus any foreign Fields referenced by their Dimensions.

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -372,6 +372,11 @@
 (defmethod serdes/entity-id "Field" [_ {:keys [name]}]
   name)
 
+(defmethod serdes/load-find-local "Field"
+  [path]
+  (let [table (serdes/load-find-local (pop path))]
+    (t2/select-one Field :name (-> path last :id) :table_id (:id table))))
+
 (defmethod serdes/extract-query "Field" [_model-name _opts]
   (let [d (t2/select Dimension)
         dimensions (->> d
@@ -400,42 +405,27 @@
              (update :human_readable_field_id serdes/*export-field-fk*)))
        (sort-by :created_at)))
 
-(defmethod serdes/extract-one "Field"
-  [_model-name _opts field]
-  (let [field (if (contains? field :dimensions)
-                field
-                (assoc field :dimensions (t2/select Dimension :field_id (:id field))))]
-    (-> (serdes/extract-one-basics "Field" field)
-        (update :dimensions         extract-dimensions)
-        (update :table_id           serdes/*export-table-fk*)
-        (update :fk_target_field_id serdes/*export-field-fk*)
-        (update :parent_id          serdes/*export-field-fk*)
-        (dissoc :fingerprint :last_analyzed :fingerprint_version))))
-
-(defmethod serdes/load-xform "Field"
-  [field]
-  (-> (serdes/load-xform-basics field)
-      (update :table_id           serdes/*import-table-fk*)
-      (update :fk_target_field_id serdes/*import-field-fk*)
-      (update :parent_id          serdes/*import-field-fk*)))
-
-(defmethod serdes/load-find-local "Field"
-  [path]
-  (let [table (serdes/load-find-local (pop path))]
-    (t2/select-one Field :name (-> path last :id) :table_id (:id table))))
-
-(defmethod serdes/load-one! "Field" [ingested maybe-local]
-  (let [field ((get-method serdes/load-one! :default) (dissoc ingested :dimensions) maybe-local)]
-    (doseq [dim (:dimensions ingested)]
-      (let [local (t2/select-one Dimension :entity_id (:entity_id dim))
-            dim   (assoc dim
-                         :field_id    (:id field)
-                         :serdes/meta [{:model "Dimension" :id (:entity_id dim)}])]
-        (serdes/load-one! dim local)))))
+(defmethod serdes/make-spec "Field" [_model-name _opts]
+  {:copy      [:active :base_type :caveats :coercion_strategy :created_at :custom_position :database_indexed
+               :database_is_auto_increment :database_partitioned :database_position :database_required :database_type
+               :description :display_name :effective_type :has_field_values :is_defective_duplicate :json_unfolding
+               :name :nfc_path :points_of_interest :position :preview_display :semantic_type :settings
+               :unique_field_helper :visibility_type]
+   :skip      [:fingerprint :fingerprint_version :last_analyzed]
+   :transform {:table_id           (serdes/fk :model/Table)
+               :fk_target_field_id (serdes/fk :model/Field)
+               :parent_id          (serdes/fk :model/Field)
+               :dimensions         [#(let [dims (or % (t2/select Dimension :field_id (:id serdes/*current*)))]
+                                       (extract-dimensions dims))
+                                    #(doseq [dim %]
+                                       (let [local (t2/select-one Dimension :entity_id (:entity_id dim))
+                                             dim   (assoc dim
+                                                          :field_id    (:id serdes/*current*)
+                                                          :serdes/meta [{:model "Dimension" :id (:entity_id dim)}])]
+                                         (serdes/load-one! dim local)))]}})
 
 (defmethod serdes/storage-path "Field" [field _]
-  (-> field
-      serdes/path
+  (-> (serdes/path field)
       drop-last
       serdes/storage-table-path-prefix
       (concat ["fields" (:name field)])))

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -399,13 +399,14 @@
       true  (disj this))))
 
 (defmethod serdes/make-spec "Field" [_model-name opts]
-  {:copy      [:active :base_type :caveats :coercion_strategy :created_at :custom_position :database_indexed
+  {:copy      [:active :base_type :caveats :coercion_strategy :custom_position :database_indexed
                :database_is_auto_increment :database_partitioned :database_position :database_required :database_type
                :description :display_name :effective_type :has_field_values :is_defective_duplicate :json_unfolding
                :name :nfc_path :points_of_interest :position :preview_display :semantic_type :settings
                :unique_field_helper :visibility_type]
    :skip      [:fingerprint :fingerprint_version :last_analyzed]
-   :transform {:table_id           (serdes/fk :model/Table)
+   :transform {:created_at        (serdes/date)
+               :table_id           (serdes/fk :model/Table)
                :fk_target_field_id (serdes/fk :model/Field)
                :parent_id          (serdes/fk :model/Field)
                :dimensions         (serdes/nested :model/Dimension :field_id opts)}})

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -405,7 +405,7 @@
                :name :nfc_path :points_of_interest :position :preview_display :semantic_type :settings
                :unique_field_helper :visibility_type]
    :skip      [:fingerprint :fingerprint_version :last_analyzed]
-   :transform {:created_at        (serdes/date)
+   :transform {:created_at         (serdes/date)
                :table_id           (serdes/fk :model/Table)
                :fk_target_field_id (serdes/fk :model/Field)
                :parent_id          (serdes/fk :model/Field)

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -549,6 +549,9 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                              Serialization                                                     |
 ;;; +----------------------------------------------------------------------------------------------------------------+
+
+(defmethod serdes/entity-id "FieldValues" [_ _] nil)
+
 (defmethod serdes/generate-path "FieldValues" [_ {:keys [field_id]}]
   (let [field (t2/select-one 'Field :id field_id)]
     (conj (serdes/generate-path "Field" field)

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -24,6 +24,7 @@
    [metabase.shared.models.visualization-settings :as mb.viz]
    [metabase.util :as u]
    [metabase.util.connection :as u.conn]
+   [metabase.util.date-2 :as u.date]
    [metabase.util.log :as log]
    [toucan2.core :as t2]
    [toucan2.model :as t2.model]))
@@ -1551,10 +1552,15 @@
                                                             :serdes/meta [{:model model-name :id entity-id}])
                                             local    (load-find-local (:serdes/meta ingested))]
                                         (load-one! ingested local)))]
-                      (t2/delete! model backward-fk parent-id :id [:not-in (map :id loaded)])))}))
+                      (if-not (seq loaded)
+                        (t2/delete! model backward-fk parent-id)
+                        (t2/delete! model backward-fk parent-id :id [:not-in (map :id loaded)]))))}))
 
 (defn parent-ref "Transformer for parent id for nested entities" []
   {::fk true :export (constantly nil) :import identity})
+
+(defn date "Transformer to parse the dates" []
+  {:export identity :import #(if (string? %) (u.date/parse %) %)})
 
 ;;; ## Memoizing appdb lookups
 

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -700,7 +700,7 @@
         (-> (select-keys ingested (:copy spec))
             (into (for [[k transform] (:transform spec)
                         :when (not (::nested transform))
-                        :let [res ((:import transform) (get ingested k))]
+                        :let  [res ((:import transform) (get ingested k))]
                         ;; do not try to insert nil values if transformer returns nothing
                         :when res]
                     [k res])))))))
@@ -708,9 +708,9 @@
 (defn- spec-post-process! [model-name ingested instance]
   (binding [*current* instance]
     (let [spec (make-spec model-name nil)]
-      (doseq [[k [_ser des :as transform]] (:transform spec)
-              :when (::nested (meta transform))]
-        (des (get ingested k))))))
+      (doseq [[k transform] (:transform spec)
+              :when         (::nested transform)]
+        ((:import transform) (get ingested k))))))
 
 (defn default-load-one!
   "Default implementation of `load-one!`"
@@ -826,7 +826,7 @@
   [id model]
   (when id
     (let [model-name (name model)
-          model      (t2.model/resolve-model (symbol model-name))
+          ;;model      (t2.model/resolve-model (symbol model-name))
           entity     (t2/select-one model (first (t2/primary-keys model)) id)
           path       (when entity
                        (mapv :id (generate-path model-name entity)))]
@@ -850,8 +850,8 @@
   Unusual parameter order means this can be used as `(update x :some_id import-fk 'SomeModel)`."
   [eid model]
   (when eid
-    (let [model-name (name model)
-          model      (t2.model/resolve-model (symbol model-name))
+    (let [;;model-name (name model)
+          ;;model      (t2.model/resolve-model (symbol model-name))
           eid        (if (vector? eid)
                        (last eid)
                        eid)

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1515,6 +1515,7 @@
 (defn fk "Export Foreign Key" [model & [field-name]]
   (cond
     ;; this `::fk` is used in tests to determine that foreign keys are handled
+    (= model :model/User)  ^::fk [*export-user* *import-user*]
     (= model :model/Table) ^::fk [*export-table-fk* *import-table-fk*]
     (= model :model/Field) ^::fk [*export-field-fk* *import-field-fk*]
     field-name             ^::fk [#(*export-fk-keyed* % model field-name) #(*import-fk-keyed* % model field-name)]

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1486,6 +1486,15 @@
   (set/union (viz-click-behavior-descendants  viz)
              (viz-column-settings-descendants viz)))
 
+;;; Common transformers
+
+(defn fk "Export Foreign Key" [model & [field-name]]
+  (cond
+    (= model :model/Table) ^::fk [*export-table-fk* *import-table-fk*]
+    field-name             ^::fk [#(*export-fk-keyed* % model field-name) #(*import-fk-keyed* % model field-name)]
+    :else                  ^::fk [#(*export-fk* % model) #(*import-fk* % model)]))
+
+
 ;;; ## Memoizing appdb lookups
 
 (defmacro with-cache

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -1041,3 +1041,8 @@
   (reduce (fn [acc v] (assoc acc (kf v) v)) {} coll))
  ([kf vf coll]
   (reduce (fn [acc v] (assoc acc (kf v) (vf v))) {} coll)))
+
+(defn rfirst
+  "Return first item from Reducible"
+  [reducible]
+  (reduce (fn [_ fst] (reduced fst)) nil reducible))

--- a/test/metabase/test/generate.clj
+++ b/test/metabase/test/generate.clj
@@ -170,7 +170,8 @@
 (s/def ::pulse-card (s/keys :req-un [::id ::position]))
 
 (s/def ::channel_type ::not-empty-string)
-(s/def ::schedule_type ::not-empty-string)
+(s/def ::schedule_type (s/with-gen (s/and string? #(contains? #{"hourly" "weekly" "monthly"} %))
+                         #(gen/elements ["hourly" "weekly" "monthly"])))
 
 (s/def ::pulse-channel (s/keys :req-un [::id ::channel_type ::details ::schedule_type]))
 (s/def ::pulse-channel-recipient (s/keys :req-un [::id]))


### PR DESCRIPTION
This converts a few models to using new spec - with Dashboard being arguably the most complex (with double nesting) in our codebase.

I think the new `nested` helper turned out to be nice, much nicer than track-nested-stuff-manually approach we had before. It handles three different cases - when there are no entity ids, when entity ids are actually identity hashes, and when there are normal entity ids. But IMO a bit of complexity is worth the result, in usage locations it's succinct and clear. It's not handling `:position` though - we decided to store that explicitly.

I did not go to making FKs determine what to do from db schema — mostly because it'll require changing calling convention and I don't want to do that until everything is done by specification rather than raw code.

References #43068 

