### PR TITLE
Fix redshift flakes in describe-database

### DIFF
--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -104,7 +104,7 @@
 
 (defmethod driver/describe-database :redshift
   [driver database]
-  ;; Redshift sync is super duper flaky and un-robust! This auto-retry is a temporary workaround until we can actually
+  ;; Redshift sync is can flake when schemas are dropped! This auto-retry is a temporary workaround until we can actually
   ;; fix #45874
   (try
     (u/auto-retry (if config/is-prod? 2 5)

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -59,7 +59,7 @@
   ;; https://github.com/aws/amazon-redshift-jdbc-driver/blob/master/src/main/java/com/amazon/redshift/jdbc/RedshiftDatabaseMetaData.java#L1794
   ;;
   ;; Why we use `svv_redshift_tables` and `svv_external_tables`:
-  ;; We can't use `svv_tables` or `svv_all_tables` because the query would fails if there are external tables. There
+  ;; We can't use `svv_tables` or `svv_all_tables` because the query would fail if there are external tables. There
   ;; are no table-level privileges for external tables, so the use of `pg_catalog.has_table_privilege` with an external
   ;; table causes an exception.
   ;;

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -5,6 +5,7 @@
    [clojure.string :as str]
    [honey.sql :as sql]
    [java-time.api :as t]
+   [metabase.config :as config]
    [metabase.driver :as driver]
    [metabase.driver.sql :as driver.sql]
    [metabase.driver.sql-jdbc.common :as sql-jdbc.common]
@@ -102,9 +103,24 @@
      (sql-jdbc.execute/reducible-query database get-tables-sql))))
 
 (defmethod driver/describe-database :redshift
-  [_driver database]
-  ;; TODO: change this to return a reducible so we don't have to hold 100k tables in memory in a set like this
-  {:tables (into #{} (describe-database-tables database))})
+  [driver database]
+  ;; Redshift sync is super duper flaky and un-robust! This auto-retry is a temporary workaround until we can actually
+  ;; fix #45874
+  (try
+    (u/auto-retry (if config/is-prod? 2 5)
+      (try
+        ;; TODO: change this to return a reducible so we don't have to hold 100k tables in memory in a set like this
+        {:tables (into #{} (describe-database-tables database))}
+        (catch Throwable e
+          ;; during test/REPL runs, wait a second before throwing the exception, that way when we do our retry there is
+          ;; a better chance of it succeeding.
+          (when-not config/is-prod?
+            (Thread/sleep 1000))
+          (throw e))))
+    (catch Throwable e
+      (throw (ex-info (format "Error in %s describe-database: %s" driver (ex-message e))
+                      {}
+                      e)))))
 
 (defmethod sql-jdbc.sync/describe-fks-sql :redshift
   [driver & {:keys [schema-names table-names]}]

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -5,6 +5,7 @@
    [clojure.string :as str]
    [honey.sql :as sql]
    [java-time.api :as t]
+   [metabase.config :as config]
    [metabase.driver :as driver]
    [metabase.driver.sql :as driver.sql]
    [metabase.driver.sql-jdbc.common :as sql-jdbc.common]
@@ -53,7 +54,8 @@
   (apply (get-method driver/describe-table :sql-jdbc) args))
 
 (def ^:private get-tables-sql
-  ;; Cal 2024-04-09 This query does not return tables from datashares, which is a relatively new feature of redshift.
+  ;; Cal 2024-04-09 This query uses tables that the JDBC redshift driver currently uses.
+  ;; It does not return tables from datashares, which is a relatively new feature of redshift.
   ;; See https://github.com/dbt-labs/dbt-redshift/issues/742 for an implementation for DBT's integration with redshift
   ;; for inspiration, and the JDBC driver itself:
   ;; https://github.com/aws/amazon-redshift-jdbc-driver/blob/master/src/main/java/com/amazon/redshift/jdbc/RedshiftDatabaseMetaData.java#L1794
@@ -61,19 +63,37 @@
   [(str/join
     "\n"
     ["select"
-     "  table_name as name,"
-     "  table_schema as schema,"
-     "  table_type as type,"
-     "  remarks as description"
-     ;; svv_all_tables would include tables from other databases that the user has access to via redshift datashares,
-     ;; which we don't support yet.
-     "from svv_tables t"
-     "where table_schema !~ '^information_schema|catalog_history|pg_|metabase_cache_'"
-     "  and pg_catalog.has_schema_privilege(table_schema, 'USAGE')"
+     "  c.relname as name,"
+     "  n.nspname as schema,"
+     "  case c.relkind"
+     "    when 'r' then 'table'"
+     "    when 'p' then 'partitioned table'"
+     "    when 'v' then 'view'"
+     "    when 'f' then 'foreign table'"
+     "    when 'm' then 'materialized view'"
+     "    end as type,"
+     "  d.description"
+     "  from pg_catalog.pg_namespace n, pg_catalog.pg_class c"
+     "  left join pg_catalog.pg_description d on c.oid = d.objoid and d.objsubid = 0"
+     "  left join pg_catalog.pg_class dc on d.classoid=dc.oid and dc.relname='pg_class'"
+     "  left join pg_catalog.pg_namespace dn on dn.oid=dc.relnamespace and dn.nspname='pg_catalog'"
+     "  where c.relnamespace = n.oid"
+     "    and n.nspname !~ '^information_schema|catalog_history|pg_|metabase_cache_'"
+     "    and c.relkind in ('r', 'p', 'v', 'f', 'm')"
+     "    and pg_catalog.has_schema_privilege(n.nspname, 'USAGE')"
+     "    and (pg_catalog.has_table_privilege('\"'||n.nspname||'\".\"'||c.relname||'\"','SELECT')"
+     "         or pg_catalog.has_any_column_privilege('\"'||n.nspname||'\".\"'||c.relname||'\"','SELECT'))"
+     "union all"
+     "select"
+     "  tablename as name,"
+     "  schemaname as schema,"
+     "  'EXTERNAL TABLE' as type,"
+     ;; external tables don't have descriptions
+     "  null as description"
+     "from svv_external_tables t"
+     "where schemaname !~ '^information_schema|catalog_history|pg_|metabase_cache_'"
      ;; for external tables, USAGE privileges on a schema is sufficient to select
-     "   and (table_type <> 'EXTERNAL TABLE'"
-     "        and (pg_catalog.has_table_privilege('\"'||table_schema||'\".\"'||table_name||'\"','SELECT')"
-     "             or pg_catalog.has_any_column_privilege('\"'||table_schema||'\".\"'||table_name||'\"','SELECT')))"])])
+     "  and pg_catalog.has_schema_privilege(t.schemaname, 'USAGE')"])])
 
 (defn- describe-database-tables
   [database]
@@ -87,9 +107,25 @@
      (sql-jdbc.execute/reducible-query database get-tables-sql))))
 
 (defmethod driver/describe-database :redshift
-  [_driver database]
+  [driver database]
   ;; TODO: change this to return a reducible so we don't have to hold 100k tables in memory in a set like this
-  {:tables (into #{} (describe-database-tables database))})
+  ;;
+  ;; Redshift sync is super duper flaky and un-robust! This auto-retry is a temporary workaround until we can actually
+  ;; fix #45874
+  (try
+    (u/auto-retry (if config/is-prod? 2 5)
+      (try
+        {:tables (into #{} (describe-database-tables database))}
+        (catch Throwable e
+          ;; during test/REPL runs, wait a second before throwing the exception, that way when we do our retry there is
+          ;; a better chance of it succeeding.
+          (when-not config/is-prod?
+            (Thread/sleep 1000))
+          (throw e))))
+    (catch Throwable e
+      (throw (ex-info (format "Error in %s describe-database: %s" driver (ex-message e))
+                      {}
+                      e)))))
 
 (defmethod sql-jdbc.sync/describe-fks-sql :redshift
   [driver & {:keys [schema-names table-names]}]

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -71,12 +71,9 @@
      "where table_schema !~ '^information_schema|catalog_history|pg_|metabase_cache_'"
      "  and pg_catalog.has_schema_privilege(table_schema, 'USAGE')"
      ;; for external tables, USAGE privileges on a schema is sufficient to select
-     "   and ("
-     "     case when table_type = 'EXTERNAL TABLE' then true else"
-     "       (pg_catalog.has_table_privilege('\"'||table_schema||'\".\"'||table_name||'\"','SELECT')"
-     "         or pg_catalog.has_any_column_privilege('\"'||table_schema||'\".\"'||table_name||'\"','SELECT'))"
-     "       end"
-     "   )"])])
+     "   and (table_type <> 'EXTERNAL TABLE'"
+     "        and (pg_catalog.has_table_privilege('\"'||table_schema||'\".\"'||table_name||'\"','SELECT')"
+     "             or pg_catalog.has_any_column_privilege('\"'||table_schema||'\".\"'||table_name||'\"','SELECT')))"])])
 
 (defn- describe-database-tables
   [database]

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -5,7 +5,6 @@
    [clojure.string :as str]
    [honey.sql :as sql]
    [java-time.api :as t]
-   [metabase.config :as config]
    [metabase.driver :as driver]
    [metabase.driver.sql :as driver.sql]
    [metabase.driver.sql-jdbc.common :as sql-jdbc.common]
@@ -63,37 +62,20 @@
   [(str/join
     "\n"
     ["select"
-     "  c.relname as name,"
-     "  n.nspname as schema,"
-     "  case c.relkind"
-     "    when 'r' then 'table'"
-     "    when 'p' then 'partitioned table'"
-     "    when 'v' then 'view'"
-     "    when 'f' then 'foreign table'"
-     "    when 'm' then 'materialized view'"
-     "    end as type,"
-     "  d.description"
-     "  from pg_catalog.pg_namespace n, pg_catalog.pg_class c"
-     "  left join pg_catalog.pg_description d on c.oid = d.objoid and d.objsubid = 0"
-     "  left join pg_catalog.pg_class dc on d.classoid=dc.oid and dc.relname='pg_class'"
-     "  left join pg_catalog.pg_namespace dn on dn.oid=dc.relnamespace and dn.nspname='pg_catalog'"
-     "  where c.relnamespace = n.oid"
-     "    and n.nspname !~ '^information_schema|catalog_history|pg_|metabase_cache_'"
-     "    and c.relkind in ('r', 'p', 'v', 'f', 'm')"
-     "    and pg_catalog.has_schema_privilege(n.nspname, 'USAGE')"
-     "    and (pg_catalog.has_table_privilege('\"'||n.nspname||'\".\"'||c.relname||'\"','SELECT')"
-     "         or pg_catalog.has_any_column_privilege('\"'||n.nspname||'\".\"'||c.relname||'\"','SELECT'))"
-     "union all"
-     "select"
-     "  tablename as name,"
-     "  schemaname as schema,"
-     "  'EXTERNAL TABLE' as type,"
-     ;; external tables don't have descriptions
-     "  null as description"
-     "from svv_external_tables t"
-     "where schemaname !~ '^information_schema|catalog_history|pg_|metabase_cache_'"
-     ;; for external tables, USAGE privileges on a schema is sufficient to select
-     "  and pg_catalog.has_schema_privilege(t.schemaname, 'USAGE')"])])
+     "  table_name as name,"
+     "  schema_name as schema,"
+     "  table_type as type,"
+     "  remarks as description"
+     "from svv_all_tables t"
+     "where schema_name !~ '^information_schema|catalog_history|pg_|metabase_cache_'"
+       ;; for external tables, USAGE privileges on a schema is sufficient to select
+     "  and pg_catalog.has_schema_privilege(schema_name, 'USAGE')"
+     "   and ("
+     "     case when type = 'EXTERNAL TABLE' then true else"
+     "       (pg_catalog.has_table_privilege('\"'||schema_name||'\".\"'||table_name||'\"','SELECT')"
+     "         or pg_catalog.has_any_column_privilege('\"'||schema_name||'\".\"'||table_name||'\"','SELECT'))"
+     "       end"
+     "   )"])])
 
 (defn- describe-database-tables
   [database]
@@ -107,25 +89,9 @@
      (sql-jdbc.execute/reducible-query database get-tables-sql))))
 
 (defmethod driver/describe-database :redshift
-  [driver database]
+  [_driver database]
   ;; TODO: change this to return a reducible so we don't have to hold 100k tables in memory in a set like this
-  ;;
-  ;; Redshift sync is super duper flaky and un-robust! This auto-retry is a temporary workaround until we can actually
-  ;; fix #45874
-  (try
-    (u/auto-retry (if config/is-prod? 2 5)
-      (try
-        {:tables (into #{} (describe-database-tables database))}
-        (catch Throwable e
-          ;; during test/REPL runs, wait a second before throwing the exception, that way when we do our retry there is
-          ;; a better chance of it succeeding.
-          (when-not config/is-prod?
-            (Thread/sleep 1000))
-          (throw e))))
-    (catch Throwable e
-      (throw (ex-info (format "Error in %s describe-database: %s" driver (ex-message e))
-                      {}
-                      e)))))
+  {:tables (into #{} (describe-database-tables database))})
 
 (defmethod sql-jdbc.sync/describe-fks-sql :redshift
   [driver & {:keys [schema-names table-names]}]

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -23,8 +23,7 @@
    [metabase.util :as u]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.log :as log]
-   [toucan2.core :as t2]
-   [toucan2.tools.with-temp :as t2.with-temp])
+   [toucan2.core :as t2])
   (:import
    (metabase.plugins.jdbc_proxy ProxyDriver)))
 
@@ -250,7 +249,7 @@
     :redshift
     (testing "Late-binding view with with data types that cause a JDBC error can still be synced successfully (#21215)"
       (let [db-details (tx/dbdef->connection-details :redshift nil nil)]
-        (t2.with-temp/with-temp [Database database {:engine :redshift, :details db-details}]
+        (mt/with-temp [Database database {:engine :redshift, :details db-details}]
           (let [view-nm      (tx/db-qualified-table-name (:name database) "lbv")
                 qual-view-nm (format "\"%s\".\"%s\"" (redshift.test/unique-session-schema) view-nm)]
             (execute!
@@ -494,3 +493,95 @@
                               :target [:variable [:template-tag "date"]]
                               :value  "2024-07-02"}]
                 :middleware {:format-rows? false}})))))))
+
+;; Cal 2024-08-19: this test can take some seconds, maybe consider dropping it to make CI faster
+(deftest redshift-describe-database-test
+  (mt/test-driver :redshift
+    ;; make sure test data is loaded
+    (mt/db)
+    ;; create a DIFFERENT schema than our unique-session-schema to fill with trash asynchronously
+    (let [do-with-connection (fn [f]
+                               (sql-jdbc.execute/do-with-connection-with-options
+                                :redshift
+                                (sql-jdbc.conn/connection-details->spec :redshift @redshift.test/db-connection-details)
+                                {:write? true}
+                                f))
+          schema             (str (redshift.test/unique-session-schema) "_2")]
+      (log/debug "UNIQUE SESSION SCHEMA =" (redshift.test/unique-session-schema))
+      (try
+        (do-with-connection
+         (fn [^java.sql.Connection conn]
+           (with-open [stmt (.createStatement conn)]
+             (.execute stmt (format "CREATE SCHEMA IF NOT EXISTS \"%s\";" schema)))))
+        ;; now asynchronously load a bunch of trash into the schema
+        (let [fut (future
+                    (do-with-connection
+                     (fn [^java.sql.Connection conn]
+                       (with-open [stmt (.createStatement conn)]
+                         (dotimes [_ 10]
+                           (let [table (u/lower-case-en (mt/random-name))]
+                             (log/debug "CREATING AND DROPPING" schema table)
+                             (.execute stmt (format "CREATE TABLE \"%s\".\"%s\" (id INTEGER);" schema table))
+                             (.execute stmt (format "DROP TABLE \"%s\".\"%s\";" schema table))))))))]
+          (try
+            ;; now run sync a bunch of times and make sure it completes ok.
+            (dotimes [i 5]
+              (log/debug "Sync #" i)
+              (let [sync-tables (:tables (driver/describe-database :redshift (mt/db)))]
+                (doseq [{sync-table-name :name, :as synced-table} sync-tables]
+                  (testing (format "\nsynced table: %s" (u/pprint-to-str synced-table))
+                    (is (or (str/starts-with? sync-table-name "test_data_")
+                            (= sync-table-name "extsales")
+                            (#{"ioczvlzuryxmervumwrn" "umcwdqwjjaagvmrgrdhi"} sync-table-name)))))))
+            (finally
+              ;; cancel the async trash-loading future if it's still running.
+              (future-cancel fut))))
+        (finally
+          ;; clean up after ourselves and drop the test schema.
+          (do-with-connection
+           (fn [^java.sql.Connection conn]
+             (with-open [stmt (.createStatement conn)]
+               (.execute stmt (format "DROP SCHEMA \"%s\";" schema))))))))))
+
+;; Cal 2024-08-19: this test currently fails if the retries in driver/describe-database are disabled.
+#_(deftest redshift-describe-database-schema-test
+  (mt/test-driver :redshift
+    (mt/db)
+    (let [do-with-connection (fn [f]
+                               (sql-jdbc.execute/do-with-connection-with-options
+                                :redshift
+                                (sql-jdbc.conn/connection-details->spec :redshift @redshift.test/db-connection-details)
+                                {:write? true}
+                                f))
+          base-schema        (redshift.test/unique-session-schema)]
+      (try
+        ;; Asynchronously create and drop schemas
+        (let [fut (future
+                    (do-with-connection
+                     (fn [^java.sql.Connection conn]
+                       (with-open [stmt (.createStatement conn)]
+                         (dotimes [i 20]
+                           (let [schema (str base-schema "_" i)]
+                             (log/debug "CREATING AND DROPPING SCHEMA" schema)
+                             (.execute stmt (format "CREATE SCHEMA \"%s\";" schema))
+                             (.execute stmt (format "CREATE TABLE \"%s\".\"test_table\" (id INTEGER);" schema))
+                             (.execute stmt (format "DROP TABLE \"%s\".\"test_table\";" schema))
+                             (.execute stmt (format "DROP SCHEMA \"%s\";" schema))))))))]
+          (try
+            ;; Run sync multiple times while schemas are being created and dropped
+            (dotimes [i 10]
+              (log/debug "Sync #" i)
+              (let [sync-schemas (map :schema (:tables (driver/describe-database :redshift (mt/db))))]
+                (testing (format "\nsynced schemas: %s" (u/pprint-to-str sync-schemas))
+                  (is (some #{(redshift.test/unique-session-schema)}
+                            sync-schemas)))))
+            (finally
+              (future-cancel fut))))
+        (finally
+          ;; Clean up any remaining schemas
+          (do-with-connection
+           (fn [^java.sql.Connection conn]
+             (with-open [stmt (.createStatement conn)]
+               (doseq [i (range 10)]
+                 (let [schema (str base-schema "_" i)]
+                   (.execute stmt (format "DROP SCHEMA IF EXISTS \"%s\" CASCADE;" schema))))))))))))

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -494,8 +494,9 @@
                               :value  "2024-07-02"}]
                 :middleware {:format-rows? false}})))))))
 
-;; Cal 2024-08-19: this test can take some seconds, maybe consider dropping it to make CI faster
-(deftest redshift-describe-database-test
+;; Cal 2024-08-19: this test needs to pass if the retries in the [[driver/describe-database]] implementation for
+;; redshift are removed. See #45874
+#_(deftest redshift-describe-database-test
   (mt/test-driver :redshift
     ;; make sure test data is loaded
     (mt/db)
@@ -543,7 +544,8 @@
              (with-open [stmt (.createStatement conn)]
                (.execute stmt (format "DROP SCHEMA \"%s\";" schema))))))))))
 
-;; Cal 2024-08-19: this test currently fails if the retries in driver/describe-database are disabled.
+;; Cal 2024-08-19: this test needs to pass if the retries in the [[driver/describe-database]] implementation for
+;; redshift are removed. See #45874
 #_(deftest redshift-describe-database-schema-test
   (mt/test-driver :redshift
     (mt/db)

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -6,8 +6,6 @@
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
-   [metabase.driver.sql-jdbc.sync.describe-database
-    :as sql-jdbc.describe-database]
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.models.database :refer [Database]]
    [metabase.models.field :refer [Field]]
@@ -357,7 +355,7 @@
              qual-tbl-nm
              qual-mview-nm)
             (is (some #(= mview-nm (:name %))
-                      (:tables (sql-jdbc.describe-database/describe-database :redshift database))))))))))
+                      (:tables (driver/describe-database :redshift database))))))))))
 
 (mt/defdataset unix-timestamps
   [["timestamps"


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/45874

This PR fixes the redshift flakes in `metabase.driver/describe-database` and removes the previously added auto-retry logic.

I don't want to backport this yet because it feels a little risky to go out to all customers on a minor version.

The tricky part is proving that the set of tables returned by the new method is the same as the old method under all configurations. There have been holes in our test coverage before.