### PR TITLE
e2e: Fix dashboard card resizing flake

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-resizing.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-resizing.cy.spec.js
@@ -287,9 +287,6 @@ describe("scenarios > dashboard card resizing", { tags: "@flaky" }, () => {
             });
           });
 
-          saveDashboard();
-          editDashboard();
-
           dashcards.forEach(({ card }, index) => {
             resizeDashboardCard({
               card: getDashboardCard(index),

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-resizing.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-resizing.cy.spec.js
@@ -279,13 +279,9 @@ describe("scenarios > dashboard card resizing", { tags: "@flaky" }, () => {
 
         cy.request("GET", `/api/dashboard/${dashId}`).then(({ body }) => {
           const dashcards = body.dashcards;
-          dashcards.forEach(({ card }) => {
-            const dashcard = cy.contains(
-              "[data-testid=dashcard-container]",
-              card.name,
-            );
+          dashcards.forEach(({ card }, index) => {
             resizeDashboardCard({
-              card: dashcard,
+              card: getDashboardCard(index),
               x: getDefaultSize(card.display).width * 100,
               y: getDefaultSize(card.display).height * 100,
             });
@@ -294,17 +290,11 @@ describe("scenarios > dashboard card resizing", { tags: "@flaky" }, () => {
           saveDashboard();
           editDashboard();
 
-          dashcards.forEach(({ card }) => {
-            const dashcard = cy.contains(
-              "[data-testid=dashcard-container]",
-              card.name,
-            );
-            dashcard.within(() => {
-              resizeDashboardCard({
-                card: dashcard,
-                x: -getDefaultSize(card.display).width * 200,
-                y: -getDefaultSize(card.display).height * 200,
-              });
+          dashcards.forEach(({ card }, index) => {
+            resizeDashboardCard({
+              card: getDashboardCard(index),
+              x: -getDefaultSize(card.display).width * 200,
+              y: -getDefaultSize(card.display).height * 200,
             });
           });
 


### PR DESCRIPTION
### What does this PR accomplish?
It tries to reduce the flakiness of a single test in the whole spec that's been marked as flaky.

### Example of a typical failure:
- https://github.com/metabase/metabase/actions/runs/10094535264/job/27914011753#step:12:253
![image](https://github.com/user-attachments/assets/dc4d8764-c530-4155-bbc5-cc3b3d6eb50c)

### Explanation
Without the ability to really examine the full replay of a test that failed in CI, I can only assume that saving a dashboard and trying to edit it again was causing the failures. Most likely some re-rendering that prevented Cypress from clicking on "Edit dashboard". See the screenshot above.

### Solution
Remove this sequence as it doesn't make sense anyway
```js
saveDashboard();
editDashboard();
```

We are already in the edit dashboard mode. No need to save only to edit again.
The only reason why you'd save it was to assert on the card sizes. And since that doesn't happen in this test, I can only conclude that this sequence is redundant.

### Additional notes
> [!Important]
> Never **ever** store Cypress selectors in a variable! This doesn't work how you'd expect it.
> Please read [this section](https://docs.cypress.io/guides/references/best-practices#Assigning-Return-Values) from Cypress' best practices.

### Stress-test
- 5/5 ✅ https://github.com/metabase/metabase/actions/runs/10100465772
- 10/10 ✅ https://github.com/metabase/metabase/actions/runs/10100549777
- 20/20 ✅  (in progress) https://github.com/metabase/metabase/actions/runs/10100668786