### PR TITLE
Populate newly created metrics in recents

### DIFF
--- a/e2e/test/scenarios/metrics/metrics-editing.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-editing.cy.spec.js
@@ -1,6 +1,8 @@
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_MODEL_ID } from "e2e/support/cypress_sample_instance_data";
 import {
+  appBar,
+  commandPalette,
   createQuestion,
   echartsContainer,
   enterCustomColumnDetails,
@@ -97,8 +99,16 @@ describe("scenarios > metrics > editing", () => {
         cy.findByText("Orders").click();
       });
       addAggregation({ operatorName: "Count of rows" });
-      saveMetric();
+      saveMetric({ name: "my new metric" });
       verifyScalarValue("18,760");
+
+      cy.log(
+        "newly created metric should be visible in recents (metabase#442223)",
+      );
+      appBar()
+        .findByText(/search/i)
+        .click();
+      commandPalette().findByText("my new metric").should("be.visible");
     });
 
     it("should be able to rename a metric", () => {

--- a/e2e/test/scenarios/metrics/metrics-editing.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-editing.cy.spec.js
@@ -103,7 +103,7 @@ describe("scenarios > metrics > editing", () => {
       verifyScalarValue("18,760");
 
       cy.log(
-        "newly created metric should be visible in recents (metabase#442223)",
+        "newly created metric should be visible in recents (metabase#44223)",
       );
       appBar()
         .findByText(/search/i)

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.tsx
@@ -19,6 +19,7 @@ import getSelectedItems, {
   isCollectionPath,
   isModelPath,
   isQuestionPath,
+  isMetricPath,
 } from "./getSelectedItems";
 import type {
   MainNavbarOwnProps,
@@ -140,7 +141,8 @@ function maybeGetQuestionId(
   { location, params }: MainNavbarOwnProps,
 ) {
   const { pathname } = location;
-  const canFetchQuestion = isQuestionPath(pathname) || isModelPath(pathname);
+  const canFetchQuestion =
+    isQuestionPath(pathname) || isModelPath(pathname) || isMetricPath(pathname);
   return canFetchQuestion ? Urls.extractEntityId(params.slug) : null;
 }
 

--- a/frontend/src/metabase/nav/containers/MainNavbar/getSelectedItems.ts
+++ b/frontend/src/metabase/nav/containers/MainNavbar/getSelectedItems.ts
@@ -51,6 +51,10 @@ export function isModelPath(pathname: string): boolean {
   return pathname.startsWith("/model");
 }
 
+export function isMetricPath(pathname: string): boolean {
+  return pathname.startsWith("/metric");
+}
+
 function isDashboardPath(pathname: string): boolean {
   return pathname.startsWith("/dashboard");
 }


### PR DESCRIPTION

Closes https://github.com/metabase/metabase/issues/44223

### Description

Newly-created metrics were not being added to recents upon creation because we were not re-fetching their card via GET after we sent the creation POST.  This updates the logic (thanks @kamilmielnik!) that detects what urls should trigger a card fetch so that that api endpoint gets called when a metric is newly created.

![Screen Shot 2024-07-25 at 3 36 42 PM](https://github.com/user-attachments/assets/50baca02-84ae-41f6-b179-4f0ec89f5ed9)

### How to verify

- create any new metric
- click the search bar
- see your new metric in recents!

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
