### PR TITLE
perf: Allocation improvements on sync-db/fingerprinting path

### DIFF
--- a/src/metabase/sync/sync_metadata/fields/common.clj
+++ b/src/metabase/sync/sync_metadata/fields/common.clj
@@ -64,12 +64,12 @@
   [field-metadata :- TableMetadataFieldWithOptionalID
    other-metadata :- [:set TableMetadataFieldWithOptionalID]]
   (let [field-meta-canonical (canonical-name field-metadata)
-        matches (keep
-                  (fn [other-field-metadata]
-                    (when (= field-meta-canonical
-                             (canonical-name other-field-metadata))
-                      other-field-metadata))
-                  other-metadata)]
+        matches (into [] (keep
+                          (fn [other-field-metadata]
+                            (when (= field-meta-canonical
+                                     (canonical-name other-field-metadata))
+                              other-field-metadata)))
+                      other-metadata)]
     (case (count matches)
       0
       nil

--- a/test/metabase/lib/schema/util_test.cljc
+++ b/test/metabase/lib/schema/util_test.cljc
@@ -34,21 +34,20 @@
 
 (deftest ^:parallel collect-uuids-test
   (are [query expected-uuids] (= expected-uuids
-                                 (sort (lib.schema.util/collect-uuids query)))
+                                 (lib.schema.util/collect-uuids query))
     query-with-no-duplicate-uuids
-    ["00000000-0000-0000-0000-000000000001"
-     "00000000-0000-0000-0000-000000000002"
-     "00000000-0000-0000-0000-000000000010"
-     "00000000-0000-0000-0000-000000000020"]
+    #{"00000000-0000-0000-0000-000000000001"
+      "00000000-0000-0000-0000-000000000002"
+      "00000000-0000-0000-0000-000000000010"
+      "00000000-0000-0000-0000-000000000020"}
 
     query-with-duplicate-uuids
-    ["00000000-0000-0000-0000-000000000001"
-     "00000000-0000-0000-0000-000000000001"
-     "00000000-0000-0000-0000-000000000010"
-     "00000000-0000-0000-0000-000000000020"]))
+    #{"00000000-0000-0000-0000-000000000001"
+      "00000000-0000-0000-0000-000000000010"
+      "00000000-0000-0000-0000-000000000020"}))
 
 (deftest ^:parallel collect-uuids-from-lib-options
-  (is (= ["f590f35f-9224-45f1-8334-422f15fc4abd"]
+  (is (= #{"f590f35f-9224-45f1-8334-422f15fc4abd"}
          (lib.schema.util/collect-uuids
           {:lib/type :mbql/query
            :database 1
@@ -63,7 +62,7 @@
 (deftest ^:parallel unique-uuids-schema-test
   (is (not (mc/explain ::lib.schema.util/unique-uuids query-with-no-duplicate-uuids)))
   (is (mc/explain ::lib.schema.util/unique-uuids query-with-duplicate-uuids))
-  (is (= ["Duplicate :lib/uuid \"00000000-0000-0000-0000-000000000001\""]
+  (is (= ["Duplicate :lib/uuid #{\"00000000-0000-0000-0000-000000000001\"}"]
          (me/humanize (mc/explain ::lib.schema.util/unique-uuids query-with-duplicate-uuids)))))
 
 (deftest ^:parallel distinct-refs-test

--- a/test/metabase/lib/schema_test.cljc
+++ b/test/metabase/lib/schema_test.cljc
@@ -12,7 +12,7 @@
     (is (not (mc/explain ::lib.schema/query lib.schema.util-test/query-with-no-duplicate-uuids))))
   (testing "should not validate if UUIDs are duplicated"
     (is (mc/explain ::lib.schema/query lib.schema.util-test/query-with-duplicate-uuids))
-    (is (= ["Duplicate :lib/uuid \"00000000-0000-0000-0000-000000000001\""]
+    (is (= ["Duplicate :lib/uuid #{\"00000000-0000-0000-0000-000000000001\"}"]
            (me/humanize (mc/explain ::lib.schema/query lib.schema.util-test/query-with-duplicate-uuids))))))
 
 (def ^:private valid-ag-1


### PR DESCRIPTION
A follow-up to https://github.com/metabase/metabase/pull/46103.

I focused on optimizing allocation overhead and brought the total allocation size in the same 3tbl x 800col x 1 row benchmark from 24.45GB to 20.45GB (16% reduction). The absolute run time doesn't seem to change much from it, but relieving some memory and GC pressure is worth doing.