### PR TITLE
Put SDK client and version into data on-thread

### DIFF
--- a/src/metabase/analytics/sdk.clj
+++ b/src/metabase/analytics/sdk.clj
@@ -2,7 +2,7 @@
   "Middleware, vars, and a reporting helper for tracking analytics information about the Metabase embedding client.
 
   Here is how we collect analytics information about the embedding client:
-  The X-Metabase-Client and X-Metabase-Version headers are sent, and if present bound to *metabase-client* and *metabase-client-version* respectively.
+  The X-Metabase-Client and X-Metabase-Client-Version headers are sent, and if present bound to *metabase-client* and *metabase-client-version* respectively.
 
   When we execute a query, or record a view log, we include the *client* and *version* as embedding_client and embedding_version in the view_log or query_execution record.
 

--- a/src/metabase/analytics/sdk.clj
+++ b/src/metabase/analytics/sdk.clj
@@ -13,13 +13,13 @@
 (def ^:dynamic *version* "Used to track information about the metabase embedding client version." nil)
 (def ^:dynamic *client* "Used to track information about the metabase embedding client." nil)
 
-(mu/defn assoc-analytics :- :map
-  "Associates the current client and version with the given map, which is usually a row going into
-   the view_log or query_execution table."
+(mu/defn include-analytics :- :map
+  "Adds the currently bound, or existing `*client*` and `version` to the given map, which is usually a row going into
+   the `view_log` or `query_execution` table. Falls back to the original value."
   [m :- :map]
-  (assoc m
-         :embedding_client *client*
-         :embedding_version *version*))
+  (-> m
+      (update :embedding_client (fn [client] (or *client* client)))
+      (update :embedding_version (fn [version] (or *version* version)))))
 
 (defn bind-embedding-mw
   "Reads Metabase Client and Version headers and binds them to *metabase-client{-version}*."

--- a/src/metabase/models/query_execution.clj
+++ b/src/metabase/models/query_execution.clj
@@ -35,7 +35,7 @@
 
 (t2/define-before-insert :model/QueryExecution
   [{context :context, :as query-execution}]
-  (u/prog1 (sdk/assoc-analytics query-execution)
+  (u/prog1 (sdk/include-analytics query-execution)
     (validate-context context)))
 
 (t2/define-after-select :model/QueryExecution

--- a/src/metabase/models/view_log.clj
+++ b/src/metabase/models/view_log.clj
@@ -31,7 +31,7 @@
   (let [defaults {:timestamp :%now}]
     (->> log-entry
          (merge defaults)
-         sdk/assoc-analytics)))
+         sdk/include-analytics)))
 
 (t2/deftransforms :model/ViewLog
   {:metadata mi/transform-json

--- a/src/metabase/query_processor/middleware/process_userland_query.clj
+++ b/src/metabase/query_processor/middleware/process_userland_query.clj
@@ -64,21 +64,21 @@
 (defn- save-execution-metadata!
   "Save a `QueryExecution` row containing `execution-info`. Done asynchronously when a query is finished."
   [execution-info field-usages]
-  (qp.util/with-execute-async
-    ;; 1. Asynchronously save QueryExecution, update query average execution time etc. using the Agent/pooledExecutor
-    ;;    pool, which is a fixed pool of size `nthreads + 2`. This way we don't spin up a ton of threads doing unimportant
-    ;;    background query execution saving (as `future` would do, which uses an unbounded thread pool by default)
-    ;;
-    ;; 2. This is on purpose! By *not* using `bound-fn` or `future`, any dynamic variables in play when the task is
-    ;;    submitted, such as `db/*connection*`, won't be in play when the task is actually executed. That way we won't
-    ;;    attempt to use closed DB connections
-    (fn []
-      (let [execution-info (-> execution-info
-                               add-running-time
-                               sdk/assoc-analytics)]
+  (let [execution-info' (sdk/include-analytics execution-info)
+        ;; `sdk/assoc-analytics` reads values from dynamic vars, so we need to set them here, on the same thread:
+        ]
+    (qp.util/with-execute-async
+      ;; 1. Asynchronously save QueryExecution, update query average execution time etc. using the Agent/pooledExecutor
+      ;;    pool, which is a fixed pool of size `nthreads + 2`. This way we don't spin up a ton of threads doing unimportant
+      ;;    background query execution saving (as `future` would do, which uses an unbounded thread pool by default)
+      ;;
+      ;; 2. This is on purpose! By *not* using `bound-fn` or `future`, any dynamic variables in play when the task is
+      ;;    submitted, such as `db/*connection*`, won't be in play when the task is actually executed. That way we won't
+      ;;    attempt to use closed DB connections
+      (fn []
         (log/trace "Saving QueryExecution info")
         (try
-          (save-execution-metadata!* execution-info field-usages)
+          (save-execution-metadata!* (add-running-time execution-info') field-usages)
           (catch Throwable e
             (log/error e "Error saving query execution info")))))))
 

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -298,13 +298,14 @@
 
 (deftest embedding-sdk-info-saves-view-log
   (testing "GET /api/card with embedding headers set"
-    (mt/with-temp [:model/Database {database-id :id} {}
-                   :model/Card card-1 {:name "Card 1" :database_id database-id}]
-      (mt/user-http-request :crowberto :get 200 (str "card/" (u/the-id card-1))
-                            {:request-options {:headers {"x-metabase-client" "client-A"
-                                                         "x-metabase-client-version" "1"}}})
-      (is (= {:embedding_client "client-A", :embedding_version "1"}
-             (t2/select-one [:model/ViewLog :embedding_client :embedding_version] :model "card" :model_id (u/the-id card-1)))))))
+    (mt/test-helpers-set-global-values!
+     (mt/with-temp [:model/Database {database-id :id} {}
+                    :model/Card card-1 {:name "Card 1" :database_id database-id}]
+       (mt/user-http-request :crowberto :get 200 (str "card/" (u/the-id card-1))
+                             {:request-options {:headers {"x-metabase-client" "client-A"
+                                                          "x-metabase-client-version" "1"}}})
+       (is (= {:embedding_client "client-A", :embedding_version "1"}
+              (t2/select-one [:model/ViewLog :embedding_client :embedding_version] :model "card" :model_id (u/the-id card-1))))))))
 
 (defn do-poll-until [^Long timeout-ms thunk]
   (let [result-prom (promise)

--- a/test/metabase/server/middleware/sdk_test.clj
+++ b/test/metabase/server/middleware/sdk_test.clj
@@ -1,14 +1,21 @@
 (ns metabase.server.middleware.sdk-test
   (:require
-   [clojure.test :refer [are deftest]]
+   [clojure.string :as str]
+   [clojure.test :refer [are deftest is]]
    [metabase.analytics.sdk :as sdk]
+   [metabase.util :as u]
    [ring.mock.request :as ring.mock]))
+
+(defn wonk-case [s]
+  (str/join (for [char s]
+              (let [f (if (rand-nth [true false]) u/upper-case-en u/lower-case-en)]
+                (f char)))))
 
 (defn- mock-request
   [{:keys [client version]}]
   (cond-> (ring.mock/request :get "api/health")
-    client  (ring.mock/header :X-Metabase-Client client)
-    version (ring.mock/header :X-Metabase-Client-Version version)))
+    client  (ring.mock/header (keyword (wonk-case "x-metabase-client")) client)
+    version (ring.mock/header (keyword (wonk-case "x-metabase-client-version")) version)))
 
 (deftest bind-client-test
   (are [client]
@@ -31,3 +38,19 @@
                  (fn [e] (throw e))))
     nil
     "1.1.1"))
+
+(deftest include-analytics-is-idempotent
+  (let [m (atom {})]
+    (binding [sdk/*client* "client-A"
+              sdk/*version* "1"]
+      (is (= {:embedding_client "client-A"
+              :embedding_version "1"} (sdk/include-analytics @m)))
+      (swap! m sdk/include-analytics)
+      ;; unset the vars:
+      (binding [sdk/*client* nil
+                sdk/*version* nil]
+        (is (= {:embedding_client "client-A"
+                :embedding_version "1"} @m))
+        (is (= {:embedding_client "client-A"
+                :embedding_version "1"}
+               (sdk/include-analytics @m)))))))

--- a/test/metabase/server/middleware/sdk_test.clj
+++ b/test/metabase/server/middleware/sdk_test.clj
@@ -47,10 +47,10 @@
               :embedding_version "1"} (sdk/include-analytics @m)))
       (swap! m sdk/include-analytics)
       ;; unset the vars:
-      (binding [sdk/*client* nil
-                sdk/*version* nil]
+      (binding [sdk/*client* nil sdk/*version* nil]
         (is (= {:embedding_client "client-A"
-                :embedding_version "1"} @m))
+                :embedding_version "1"}
+               @m))
         (is (= {:embedding_client "client-A"
                 :embedding_version "1"}
                (sdk/include-analytics @m)))))))

--- a/test/metabase/server/middleware/sdk_test.clj
+++ b/test/metabase/server/middleware/sdk_test.clj
@@ -41,16 +41,16 @@
 
 (deftest include-analytics-is-idempotent
   (let [m (atom {})]
-    (binding [sdk/*client* "client-A"
-              sdk/*version* "1"]
-      (is (= {:embedding_client "client-A"
-              :embedding_version "1"} (sdk/include-analytics @m)))
+    (binding [sdk/*client* "client-C"
+              sdk/*version* "1.33.7"]
+      (is (= {:embedding_client "client-C"
+              :embedding_version "1.33.7"} (sdk/include-analytics @m)))
       (swap! m sdk/include-analytics)
       ;; unset the vars:
       (binding [sdk/*client* nil sdk/*version* nil]
-        (is (= {:embedding_client "client-A"
-                :embedding_version "1"}
+        (is (= {:embedding_client "client-C"
+                :embedding_version "1.33.7"}
                @m))
-        (is (= {:embedding_client "client-A"
-                :embedding_version "1"}
+        (is (= {:embedding_client "client-C"
+                :embedding_version "1.33.7"}
                (sdk/include-analytics @m)))))))


### PR DESCRIPTION
Closes: #45952

Well, we know dynamic vars don't cross thread boundaries, but what I didn't catch was that sometimes we can insert query metadata inth the query_executions table on another thread, in which case we will drop the `sdk/*client*` and `sdk/*version*` values.

This captures the data on-thread into a map that's passed between threads.