### PR TITLE
Remove unused dimension options from query_metadata

### DIFF
--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -354,13 +354,10 @@
           tables (t2/hydrate tables
                              [:fields [:target :has_field_values] :has_field_values :dimensions :name_field]
                              :segments
-                             :metrics)
-          dbs    (when (seq tables)
-                   (t2/select-pk->fn identity Database :id [:in (into #{} (map :db_id) tables)]))]
+                             :metrics)]
       (for [table tables]
         (-> table
             (m/dissoc-in [:db :details])
-            (assoc-dimension-options (-> table :db_id dbs))
             format-fields-for-response
             fix-schema
             (update :fields #(remove (comp #{:hidden :sensitive} :visibility_type) %)))))))

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -4605,8 +4605,7 @@
                                  {:id (mt/id :checkins)}
                                  {:id (mt/id :reviews)}
                                  {:id (mt/id :products)
-                                  :fields sequential?
-                                  :dimension_options map?}
+                                  :fields sequential?}
                                  {:id (mt/id :venues)}])
            :cards [{:id link-card}]
            :databases [{:id (mt/id) :engine string?}]


### PR DESCRIPTION
Cuts the API response by 50%; -1 DB call.