### PR TITLE
Fix the homepage dashboard being loaded everywhere

### DIFF
--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -25,6 +25,7 @@ import {
   dashboardGrid,
   entityPickerModalTab,
   visitQuestion,
+  createDashboard,
 } from "e2e/support/helpers";
 
 const { admin } = USERS;
@@ -526,6 +527,22 @@ describe("scenarios > home > custom homepage", () => {
         "equal",
         `/dashboard/${ORDERS_DASHBOARD_ID}`,
       );
+    });
+
+    it("should not load the homepage dashboard when visiting another dashboard directly (metabase#43800)", () => {
+      cy.intercept("GET", "/api/dashboard/*").as("getDashboard");
+      cy.intercept("GET", "/api/dashboard/*/query_metadata*").as(
+        "getDashboardMetadata",
+      );
+
+      const dashboardName = "Test Dashboard";
+      createDashboard({ name: dashboardName }).then(({ body: dashboard }) =>
+        visitDashboard(dashboard.id),
+      );
+
+      dashboardHeader().findByText(dashboardName).should("be.visible");
+      cy.get("@getDashboard.all").should("have.length", 1);
+      cy.get("@getDashboardMetadata.all").should("have.length", 1);
     });
   });
 });

--- a/frontend/src/metabase/common/hooks/use-homepage-dashboard.tsx
+++ b/frontend/src/metabase/common/hooks/use-homepage-dashboard.tsx
@@ -1,31 +1,18 @@
-import { useLocation } from "react-use";
-
 import { skipToken, useGetDashboardQuery } from "metabase/api";
 import { useSelector } from "metabase/lib/redux";
 import { getCustomHomePageDashboardId } from "metabase/selectors/app";
 import { getSettingsLoading } from "metabase/selectors/settings";
 
-import { useSetting } from "./use-setting";
-
 export const useHomepageDashboard = () => {
   const dashboardId = useSelector(getCustomHomePageDashboardId);
   const isLoadingSettings = useSelector(getSettingsLoading);
-  const siteUrl = useSetting("site-url");
-  const location = useLocation();
 
   const { data: dashboard, isLoading: isLoadingDashboard } =
     useGetDashboardQuery(dashboardId ? { id: dashboardId } : skipToken);
-
-  const pathname = location?.href?.replace(siteUrl, "");
-
-  const isAtHomepageDashboard = Boolean(
-    dashboardId && pathname?.startsWith(`/dashboard/${dashboardId}`),
-  );
 
   return {
     dashboardId,
     dashboard,
     isLoading: isLoadingDashboard || isLoadingSettings,
-    canNavigateHome: !isAtHomepageDashboard || dashboard?.archived,
   };
 };

--- a/frontend/src/metabase/common/hooks/use-is-at-homepage-dashboard.ts
+++ b/frontend/src/metabase/common/hooks/use-is-at-homepage-dashboard.ts
@@ -1,0 +1,19 @@
+import { useLocation } from "react-use";
+
+import { useSelector } from "metabase/lib/redux";
+import { getCustomHomePageDashboardId } from "metabase/selectors/app";
+
+import { useSetting } from "./use-setting";
+
+export const useIsAtHomepageDashboard = () => {
+  const dashboardId = useSelector(getCustomHomePageDashboardId);
+  const siteUrl = useSetting("site-url");
+  const location = useLocation();
+  const pathname = location?.href?.replace(siteUrl, "");
+
+  return (
+    dashboardId != null &&
+    pathname != null &&
+    pathname.startsWith(`/dashboard/${dashboardId}`)
+  );
+};

--- a/frontend/src/metabase/nav/components/AppBar/AppBarLogo.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLogo.tsx
@@ -1,6 +1,6 @@
 import type { MouseEvent } from "react";
 
-import { useHomepageDashboard } from "metabase/common/hooks/use-homepage-dashboard";
+import { useIsAtHomepageDashboard } from "metabase/common/hooks/use-is-at-homepage-dashboard";
 import LogoIcon from "metabase/components/LogoIcon";
 
 import { LogoLink } from "./AppBarLogo.styled";
@@ -18,7 +18,7 @@ export function AppBarLogo({
   isNavBarEnabled,
   onLogoClick,
 }: AppBarLogoProps): JSX.Element | null {
-  const { canNavigateHome } = useHomepageDashboard();
+  const isAtHomepageDashboard = useIsAtHomepageDashboard();
 
   if (!isLogoVisible) {
     return null;
@@ -27,7 +27,7 @@ export function AppBarLogo({
   const handleClick = (event: MouseEvent) => {
     // Prevent navigating to the dashboard homepage when a user is already there
     // https://github.com/metabase/metabase/issues/43800
-    if (!canNavigateHome) {
+    if (isAtHomepageDashboard) {
       event.preventDefault();
     }
     onLogoClick?.();

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
@@ -5,7 +5,7 @@ import _ from "underscore";
 
 import { useUserSetting } from "metabase/common/hooks";
 import { useHasTokenFeature } from "metabase/common/hooks/use-has-token-feature";
-import { useHomepageDashboard } from "metabase/common/hooks/use-homepage-dashboard";
+import { useIsAtHomepageDashboard } from "metabase/common/hooks/use-is-at-homepage-dashboard";
 import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
 import { Tree } from "metabase/components/tree";
 import {
@@ -81,7 +81,7 @@ function MainNavbarView({
     "expand-bookmarks-in-nav",
   );
 
-  const { canNavigateHome } = useHomepageDashboard();
+  const isAtHomepageDashboard = useIsAtHomepageDashboard();
 
   const {
     card: cardItem,
@@ -100,12 +100,12 @@ function MainNavbarView({
     (event: MouseEvent) => {
       // Prevent navigating to the dashboard homepage when a user is already there
       // https://github.com/metabase/metabase/issues/43800
-      if (!canNavigateHome) {
+      if (isAtHomepageDashboard) {
         event.preventDefault();
       }
       onItemSelect();
     },
-    [canNavigateHome, onItemSelect],
+    [isAtHomepageDashboard, onItemSelect],
   );
 
   // Can upload CSVs if

--- a/frontend/src/metabase/redux/user.ts
+++ b/frontend/src/metabase/redux/user.ts
@@ -54,7 +54,11 @@ export const currentUser = createReducer<User | null>(null, builder => {
     })
     .addCase(Dashboards.actionTypes.UPDATE, (state, { payload }) => {
       const { dashboard } = payload;
-      if (state?.custom_homepage?.dashboard_id && dashboard.archived) {
+      if (
+        state != null &&
+        state.custom_homepage?.dashboard_id === dashboard.id &&
+        dashboard.archived
+      ) {
         state.custom_homepage = null;
       }
     });

--- a/frontend/src/metabase/redux/user.ts
+++ b/frontend/src/metabase/redux/user.ts
@@ -1,5 +1,6 @@
 import { createAction, createReducer } from "@reduxjs/toolkit";
 
+import Dashboards from "metabase/entities/dashboards";
 import Users from "metabase/entities/users";
 import { createAsyncThunk } from "metabase/lib/redux";
 import { CLOSE_QB_NEWB_MODAL } from "metabase/query_builder/actions";
@@ -50,5 +51,11 @@ export const currentUser = createReducer<User | null>(null, builder => {
         };
       }
       return state;
+    })
+    .addCase(Dashboards.actionTypes.UPDATE, (state, { payload }) => {
+      const { dashboard } = payload;
+      if (state?.custom_homepage?.dashboard_id && dashboard.archived) {
+        state.custom_homepage = null;
+      }
     });
 });


### PR DESCRIPTION
Follow-up for https://github.com/metabase/metabase/pull/43836

Previously the homepage dashboard was loaded everywhere even when the homepage was not visited. This PR fixes the issue by splitting the `useHomepageDashboard` hook into 2 and fixing the case with the homepage dashboard being archived during the session with a redux state update.

How to verify:
- Set a custom homepage dashboard
- Open another dashboard
- Reload the page. There should be only 1 dashboard loaded.

Before
<img width="1321" alt="Screenshot 2024-07-26 at 13 51 19" src="https://github.com/user-attachments/assets/be75bfcc-8650-4e7f-9b1a-6f8ab808583c">

After
<img width="1322" alt="Screenshot 2024-07-26 at 13 51 48" src="https://github.com/user-attachments/assets/9199f2c8-be87-4e71-a14e-8d62cb3da58a">

