### PR TITLE
[manual backport] Skip long values in JSON unfolding query (#46089)

### DIFF
--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -4,6 +4,13 @@ title: Driver interface changelog
 
 # Driver Interface Changelog
 
+## Metabase 0.49.22
+
+- A new optional method `metabase.driver.sql/json-field-length` has been added. It should be implemented for all
+  drivers that derive from `:sql` and support the `:nested-field-columns` feature. If implemented, Metabase will skip
+  querying large JSON values during the "sync-fields" step that could otherwise slow down the inference of nested
+  field columns and cause Metabase to run out of heap space.
+
 ## Metabase 0.49.9
 
 - Another driver feature has been added: `upload-with-auto-pk`. It only affects drivers that support `uploads`, and

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -15,6 +15,7 @@
    [metabase.driver.common :as driver.common]
    [metabase.driver.mysql.actions :as mysql.actions]
    [metabase.driver.mysql.ddl :as mysql.ddl]
+   [metabase.driver.sql :as driver.sql]
    [metabase.driver.sql-jdbc.common :as sql-jdbc.common]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
@@ -254,6 +255,10 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                           metabase.driver.sql impls                                            |
 ;;; +----------------------------------------------------------------------------------------------------------------+
+
+(defmethod driver.sql/json-field-length :mysql
+  [_ json-field-identifier]
+  [:length [:cast json-field-identifier :char]])
 
 (defmethod sql.qp/unix-timestamp->honeysql [:mysql :seconds] [_ _ expr]
   [:from_unixtime expr])

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -221,6 +221,10 @@
 ;;; |                                           metabase.driver.sql impls                                            |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
+(defmethod driver.sql/json-field-length :postgres
+  [_ json-field-identifier]
+  [:length [:cast json-field-identifier :text]])
+
 (defn- ->timestamp [honeysql-form]
   (h2x/cast-unless-type-in "timestamp" #{"timestamp" "timestamptz" "timestamp with time zone" "date"} honeysql-form))
 

--- a/src/metabase/driver/sql.clj
+++ b/src/metabase/driver/sql.clj
@@ -70,6 +70,17 @@
     (merge {:params nil
             :query  (unprepare/unprepare driver (cons sql params))})))
 
+(defmulti json-field-length
+  "Return a HoneySQL expression that calculates the number of characters in a JSON field for a given driver.
+  `json-field-identifier` is the Identifier ([[metabase.util.honey-sql-2/Identifier]]) for a JSON field."
+  {:added "0.49.22", :arglists '([driver json-field-identifier])}
+  driver/dispatch-on-initialized-driver
+  :hierarchy #'driver/hierarchy)
+
+(defmethod json-field-length :default
+  [_driver _native-form]
+  ;; we rely on this to tell if the method is implemented for this driver or not
+  ::nyi)
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                              Connection Impersonation                                          |

--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -8,6 +8,7 @@
    [medley.core :as m]
    [metabase.db.metadata-queries :as metadata-queries]
    [metabase.driver :as driver]
+   [metabase.driver.sql :as driver.sql]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.sql-jdbc.sync.common :as sql-jdbc.sync.common]
@@ -16,10 +17,12 @@
    [metabase.driver.util :as driver.u]
    [metabase.lib.schema.literal :as lib.schema.literal]
    [metabase.models :refer [Field]]
+   [metabase.models.setting :as setting]
    [metabase.models.table :as table]
    [metabase.sync.util :as sync-util]
    [metabase.util :as u]
    [metabase.util.honey-sql-2 :as h2x]
+   [metabase.util.i18n :refer [deferred-tru]]
    [metabase.util.log :as log]
    [metabase.util.malli.registry :as mr]
    #_{:clj-kondo/ignore [:discouraged-namespace]}
@@ -395,7 +398,7 @@
   "Parses given json (a string or a reader) into a map of paths to types, i.e. `{[\"bob\"} String}`.
 
   Uses Jackson Streaming API to skip allocating data structures, eschews allocating values when possible.
-  Respects *nested-field-column-max-row-length*."
+  Respects [[nested-field-columns-max-row-length]]."
   [v path]
   (if-not (json-object? v)
     {}
@@ -548,40 +551,58 @@
                                         (false? (:json_unfolding existing-field))))]
         (remove should-not-unfold? json-fields)))))
 
+(setting/defsetting nested-field-columns-value-length-limit
+  (deferred-tru (str "Maximum length of a JSON string before skipping it during sync for JSON unfolding. If this is set "
+                     "too high it could lead to slow syncs or out of memory errors."))
+  :visibility :internal
+  :export?    true
+  :type       :integer
+  :default    50000)
+
 (defn- sample-json-row-honey-sql
   "Return a honeysql query used to get row sample to describe json columns.
 
   If the table has PKs, try to fetch both first and last rows (see #25744).
   Else fetch the first n rows only."
-  [table-identifier json-field-identifiers pk-identifiers]
+  [driver table-identifier json-field-identifiers pk-identifiers]
   (let [pks-expr         (mapv vector pk-identifiers)
         table-expr       [table-identifier]
-        json-field-exprs (mapv vector json-field-identifiers)]
+        json-field-exprs (mapv (fn [field]
+                                 (if (= (driver.sql/json-field-length driver field) ::driver.sql/nyi)
+                                   [field]
+                                   [[:case
+                                     [:<
+                                      [:inline (nested-field-columns-value-length-limit)]
+                                      (driver.sql/json-field-length driver field)]
+                                     nil
+                                     :else
+                                     field]
+                                    (last (h2x/identifier->components field))]))
+                               json-field-identifiers)]
     (if (seq pk-identifiers)
       {:select json-field-exprs
        :from   [table-expr]
        ;; mysql doesn't support limit in subquery, so we're using inner join here
-       :join  [[{:union [{:nest {:select   pks-expr
-                                 :from     [table-expr]
-                                 :order-by (mapv #(vector % :asc) pk-identifiers)
-                                 :limit    (/ metadata-queries/nested-field-sample-limit 2)}}
-                         {:nest {:select   pks-expr
-                                 :from     [table-expr]
-                                 :order-by (mapv #(vector % :desc) pk-identifiers)
-                                 :limit    (/ metadata-queries/nested-field-sample-limit 2)}}]}
-                :result]
-               (into [:and]
-                     (for [pk-identifier pk-identifiers]
-                       [:=
-                        (h2x/identifier :field :result (last (h2x/identifier->components pk-identifier)))
-                        pk-identifier]))]}
+       :join   [[{:union-all [{:nest {:select   pks-expr
+                                      :from     [table-expr]
+                                      :order-by (mapv #(vector % :asc) pk-identifiers)
+                                      :limit    (/ metadata-queries/nested-field-sample-limit 2)}}
+                              {:nest {:select   pks-expr
+                                      :from     [table-expr]
+                                      :order-by (mapv #(vector % :desc) pk-identifiers)
+                                      :limit    (/ metadata-queries/nested-field-sample-limit 2)}}]}
+                 :result]
+                (into [:and]
+                      (for [pk-identifier pk-identifiers]
+                        [:=
+                         (h2x/identifier :field :result (last (h2x/identifier->components pk-identifier)))
+                         pk-identifier]))]}
       {:select json-field-exprs
        :from   [table-expr]
        :limit  metadata-queries/nested-field-sample-limit})))
 
-(defn- describe-json-fields
+(defn- sample-json-reducible-query
   [driver jdbc-spec table json-fields pks]
-  (log/infof "Inferring schema for %d JSON fields in %s" (count json-fields) (sync-util/name-for-logging table))
   (let [table-identifier-info [(:schema table) (:name table)]
         json-field-identifiers (mapv #(apply h2x/identifier :field (into table-identifier-info [(:name %)])) json-fields)
         table-identifier (apply h2x/identifier :table table-identifier-info)
@@ -589,10 +610,15 @@
                            (mapv #(apply h2x/identifier :field (into table-identifier-info [%])) pks))
         sql-args         (sql.qp/format-honeysql
                           driver
-                          (sample-json-row-honey-sql table-identifier json-field-identifiers pk-identifiers))
-        query            (jdbc/reducible-query jdbc-spec sql-args {:identifiers identity})
-        field-types      (transduce (map json-map->types) describe-json-rf query)
-        fields           (field-types->fields field-types)]
+                          (sample-json-row-honey-sql driver table-identifier json-field-identifiers pk-identifiers))]
+    (jdbc/reducible-query jdbc-spec sql-args {:identifiers identity})))
+
+(defn- describe-json-fields
+  [driver jdbc-spec table json-fields pks]
+  (log/infof "Inferring schema for %d JSON fields in %s" (count json-fields) (sync-util/name-for-logging table))
+  (let [query       (sample-json-reducible-query driver jdbc-spec table json-fields pks)
+        field-types (transduce (map json-map->types) describe-json-rf query)
+        fields      (field-types->fields field-types)]
     (if (> (count fields) max-nested-field-columns)
       (do
         (log/warn

--- a/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
+++ b/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
@@ -10,6 +10,7 @@
    [metabase.driver.ddl.interface :as ddl.i]
    [metabase.driver.mysql :as mysql]
    [metabase.driver.mysql-test :as mysql-test]
+   [metabase.driver.sql :as driver.sql]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
@@ -429,6 +430,57 @@
                           driver/*driver*
                           (mt/db)
                           {:name "big_json" :id (mt/id "big_json")})))))))))
+
+(mt/defdataset long-json
+  [["long_json_table"
+     ;; `short_json` and `long_json` have the same schema,
+     ;; in the first row, both have an "a" key.
+     ;; in the second row, both have a "b" key, except `long_json` has a longer value.
+    [{:field-name "short_json", :base-type :type/JSON}
+     {:field-name "long_json",  :base-type :type/JSON}]
+    [[(json/generate-string {:a "x"}) (json/generate-string {:a "x"})]
+     [(json/generate-string {:b "y"}) (json/generate-string {:b (apply str (repeat 10 "y"))})]]]])
+
+(deftest long-json-sample-json-query-test
+  (testing "Long JSON values should be omitted from the sample for describe-table (#45163)"
+    (mt/test-drivers (mt/normal-drivers-with-feature :nested-field-columns)
+      (when-not (mysql/mariadb? (mt/db))
+        (mt/with-temporary-setting-values [sql-jdbc.describe-table/nested-field-columns-value-length-limit
+                                           (dec (count (json/generate-string {:b (apply str (repeat 10 "y"))})))]
+          (mt/dataset long-json
+            (sync/sync-database! (mt/db) {:scan :schema})
+            (let [jdbc-spec   (sql-jdbc.conn/db->pooled-connection-spec (mt/db))
+                  table       (t2/select-one :model/Table :db_id (mt/id) :name "long_json_table")
+                  json-fields (t2/select :model/Field :table_id (:id table) :name [:in ["short_json" "long_json"]])
+                  pks         ["id"]
+                  sample      (fn []
+                                (let [rows (#'sql-jdbc.describe-table/sample-json-reducible-query driver/*driver* jdbc-spec table json-fields pks)]
+                                  (into #{} (map #(update-vals % json/parse-string)) rows)))]
+              (is (= #{{:short_json {"a" "x"}, :long_json {"a" "x"}}
+                       {:short_json {"b" "y"}, :long_json nil}}
+                     (sample)))
+              (testing "If driver.sql/json-field-length is not implemented for the driver don't omit the long value"
+                (letfn [(do-with-removed-method [thunk]
+                          (let [original-method (get-method driver.sql/json-field-length driver/*driver*)]
+                            (if (= original-method (get-method driver.sql/json-field-length :default))
+                              (thunk)
+                              (do (remove-method driver.sql/json-field-length driver/*driver*)
+                                  (thunk)
+                                  (defmethod driver.sql/json-field-length driver/*driver* [driver field]
+                                    (original-method driver field))))))]
+                  (do-with-removed-method
+                   (fn []
+                     (is (= #{{:short_json {"a" "x"}, :long_json {"a" "x"}}
+                              {:short_json {"b" "y"}, :long_json {"b" "yyyyyyyyyy"}}}
+                            (sample)))))))
+              (testing "The resulting synced fields exclude the field that corresponds to the long value"
+                (is (= #{"id"
+                         "short_json"
+                         "long_json"
+                         "short_json → a"
+                         "short_json → b"
+                         "long_json → a"} ; note there is no "long_json → b" because it was excluded from the sample
+                       (t2/select-fn-set :name :model/Field :table_id (:id table), :active true)))))))))))
 
 (mt/defdataset json-unwrap-bigint-and-boolean
   "Used for testing mysql json value unwrapping"


### PR DESCRIPTION
Manual backport of https://github.com/metabase/metabase/pull/46089

The only conflict was in the driver changelog.