### PR TITLE
Add `:relative-time-interval` mbql function

### DIFF
--- a/frontend/src/metabase-lib/filter.ts
+++ b/frontend/src/metabase-lib/filter.ts
@@ -347,19 +347,12 @@ export function relativeDateFilterClause({
     );
   }
 
-  return expressionClause("between", [
-    expressionClause("+", [
-      columnWithoutBucket,
-      expressionClause("interval", [-offsetValue, offsetBucket]),
-    ]),
-    expressionClause("relative-datetime", [
-      value !== "current" && value < 0 ? value : 0,
-      bucket,
-    ]),
-    expressionClause("relative-datetime", [
-      value !== "current" && value > 0 ? value : 0,
-      bucket,
-    ]),
+  return expressionClause("relative-time-interval", [
+    columnWithoutBucket,
+    value,
+    bucket,
+    offsetValue,
+    offsetBucket,
   ]);
 }
 

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -275,6 +275,7 @@ export type ExpressionOperatorName =
   | "concat"
   | "interval"
   | "time-interval"
+  | "relative-time-interval"
   | "relative-datetime"
   | "inside"
   | "segment"

--- a/src/metabase/legacy_mbql/normalize.cljc
+++ b/src/metabase/legacy_mbql/normalize.cljc
@@ -159,6 +159,12 @@
        (maybe-normalize-token amount))
      (maybe-normalize-token unit)]))
 
+(defmethod normalize-mbql-clause-tokens :relative-time-interval
+  [[_ col & [_value _bucket _offset-value _offset-bucket :as args]]]
+  (into [:relative-time-interval (normalize-tokens col :ignore-path)]
+        (map maybe-normalize-token)
+        args))
+
 (defmethod normalize-mbql-clause-tokens :relative-datetime
   ;; Normalize a `relative-datetime` clause. `relative-datetime` comes in two flavors:
   ;;

--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -858,6 +858,13 @@
   unit    [:ref ::RelativeDatetimeUnit]
   options (optional TimeIntervalOptions))
 
+(defclause ^:sugar relative-time-interval
+  col           Field
+  value         :int
+  bucket        [:ref ::RelativeDatetimeUnit]
+  offset-value  :int
+  offset-bucket [:ref ::RelativeDatetimeUnit])
+
 ;; A segment is a special `macro` that saves some pre-definied filter clause, e.g. [:segment 1]
 ;; this gets replaced by a normal Filter clause in MBQL macroexpansion
 ;;
@@ -890,7 +897,7 @@
               ;; filters drivers must implement
               and or not = != < > <= >= between starts-with ends-with contains
               ;; SUGAR filters drivers do not need to implement
-              does-not-contain inside is-empty not-empty is-null not-null time-interval segment)]])
+              does-not-contain inside is-empty not-empty is-null not-null relative-time-interval time-interval segment)]])
 
 (def ^:private CaseClause
   [:tuple {:error/message ":case subclause"} Filter ExpressionArg])

--- a/src/metabase/legacy_mbql/util.cljc
+++ b/src/metabase/legacy_mbql/util.cljc
@@ -242,13 +242,13 @@
    [:relative-time-interval col value bucket offset-value offset-bucket]
    (let [col-default-bucket (cond-> col (and (vector? col) (= 3 (count col)))
                               (update 2 assoc :temporal-unit :default))
-         offset      [:interval offset-value offset-bucket]
+         offset [:interval offset-value offset-bucket]
          lower-bound (if (neg? value)
                        [:relative-datetime value bucket]
-                       [:relative-datetime 0 bucket])
+                       [:relative-datetime 1 bucket])
          upper-bound (if (neg? value)
                        [:relative-datetime 0 bucket]
-                       [:relative-datetime value bucket])
+                       [:relative-datetime (inc value) bucket])
          lower-with-offset [:+ lower-bound offset]
          upper-with-offset [:+ upper-bound offset]]
      [:and

--- a/src/metabase/lib/convert.cljc
+++ b/src/metabase/lib/convert.cljc
@@ -290,6 +290,10 @@
   [[_tag field n unit options]]
   (lib.options/ensure-uuid [:time-interval (or options {}) (->pMBQL field) n unit]))
 
+(defmethod ->pMBQL :relative-time-interval
+  [[_tag & [_column _value _bucket _offset-value _offset-bucket :as args]]]
+  (lib.options/ensure-uuid (into [:relative-time-interval {}] (map ->pMBQL) args)))
+
 ;; `:offset` is the same in legacy and pMBQL, but we need to update the expr it wraps.
 (defmethod ->pMBQL :offset
   [[tag opts expr n, :as clause]]

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -216,6 +216,7 @@
   is-empty not-empty
   starts-with ends-with
   contains does-not-contain
+  relative-time-interval
   time-interval
   segment]
  [lib.filter.update

--- a/src/metabase/lib/filter.cljc
+++ b/src/metabase/lib/filter.cljc
@@ -314,6 +314,7 @@
 (lib.common/defop ends-with [whole part])
 (lib.common/defop contains [whole part])
 (lib.common/defop does-not-contain [whole part])
+(lib.common/defop relative-time-interval [x value bucket offset-value offset-bucket])
 (lib.common/defop time-interval [x amount unit])
 (lib.common/defop segment [segment-id])
 

--- a/src/metabase/lib/filter.cljc
+++ b/src/metabase/lib/filter.cljc
@@ -278,11 +278,11 @@
 (defmethod lib.metadata.calculation/display-name-method :relative-time-interval
   [query stage-number [_tag _opts column value bucket offset-value offset-bucket] style]
   (if (neg? offset-value)
-    (i18n/tru "{0} is in {1}, starting {2} ago"
+    (i18n/tru "{0} is in the {1}, starting {2} ago"
               (lib.metadata.calculation/display-name query stage-number column style)
               (u/lower-case-en (lib.temporal-bucket/describe-temporal-interval value bucket))
               (inflections/pluralize (abs offset-value) (name offset-bucket)))
-    (i18n/tru "{0} is in {1}, starting {2} from now"
+    (i18n/tru "{0} is in the {1}, starting {2} from now"
               (lib.metadata.calculation/display-name query stage-number column style)
               (u/lower-case-en (lib.temporal-bucket/describe-temporal-interval value bucket))
               (inflections/pluralize (abs offset-value) (name offset-bucket)))))

--- a/src/metabase/lib/filter.cljc
+++ b/src/metabase/lib/filter.cljc
@@ -276,8 +276,16 @@
               (u/lower-case-en (lib.temporal-bucket/describe-temporal-interval n unit)))))
 
 (defmethod lib.metadata.calculation/display-name-method :relative-time-interval
-  [_query _stage-number _clause _style]
-  "Relative time interval")
+  [query stage-number [_tag _opts column value bucket offset-value offset-bucket] style]
+  (if (neg? offset-value)
+    (i18n/tru "{0} is in {1}, starting {2} ago"
+              (lib.metadata.calculation/display-name query stage-number column style)
+              (u/lower-case-en (lib.temporal-bucket/describe-temporal-interval value bucket))
+              (inflections/pluralize (abs offset-value) (name offset-bucket)))
+    (i18n/tru "{0} is in {1}, starting {2} from now"
+              (lib.metadata.calculation/display-name query stage-number column style)
+              (u/lower-case-en (lib.temporal-bucket/describe-temporal-interval value bucket))
+              (inflections/pluralize (abs offset-value) (name offset-bucket)))))
 
 (defmethod lib.metadata.calculation/display-name-method :relative-datetime
   [_query _stage-number [_tag _opts n unit] _style]

--- a/src/metabase/lib/filter.cljc
+++ b/src/metabase/lib/filter.cljc
@@ -275,6 +275,10 @@
               (lib.metadata.calculation/display-name query stage-number expr style)
               (u/lower-case-en (lib.temporal-bucket/describe-temporal-interval n unit)))))
 
+(defmethod lib.metadata.calculation/display-name-method :relative-time-interval
+  [_query _stage-number _clause _style]
+  "Relative time interval")
+
 (defmethod lib.metadata.calculation/display-name-method :relative-datetime
   [_query _stage-number [_tag _opts n unit] _style]
   (i18n/tru "{0}" (lib.temporal-bucket/describe-temporal-interval n unit)))

--- a/src/metabase/lib/schema/filter.cljc
+++ b/src/metabase/lib/schema/filter.cljc
@@ -112,6 +112,18 @@
            [false [:ref ::expression/integer]]]
    #_unit [:ref ::temporal-bucketing/unit.date-time.interval]])
 
+(mbql-clause/define-mbql-clause :relative-time-interval :- :type/Boolean
+  [:tuple
+   [:= {:decode/normalize common/normalize-keyword} :relative-time-interval]
+   ;; `relative-time-interval` does not support options to eg. include/exclude start or end point. Only int values
+   ;; are allowed for intervals.
+   ::common/options
+   #_col           [:ref ::expression/temporal]
+   #_value         :int
+   #_bucket        [:ref ::temporal-bucketing/unit.date-time.interval]
+   #_offset-value  :int
+   #_offset-bucket [:ref ::temporal-bucketing/unit.date-time.interval]])
+
 ;; segments are guaranteed to return valid filter clauses and thus booleans, right?
 (mbql-clause/define-mbql-clause :segment :- :type/Boolean
   [:tuple

--- a/test/metabase/legacy_mbql/normalize_test.cljc
+++ b/test/metabase/legacy_mbql/normalize_test.cljc
@@ -196,6 +196,10 @@
     {{:query {"FILTER" ["time-interval" 10 -10 "day"]}}
      {:query {:filter [:time-interval 10 -10 :day]}}}
 
+    "relative-time-interval is correctly normalized"
+    {{:query {"FILTER" ["relative-time-interval" 10 "week" -10 "week"]}}
+     {:query {:filter [:relative-time-interval 10 :week -10 :week]}}}
+
     "make sure we support time-interval options"
     {["TIME_INTERVAL" 10 -30 "DAY" {"include_current" true}]
      [:time-interval 10 -30 :day {:include-current true}]}

--- a/test/metabase/legacy_mbql/util_test.cljc
+++ b/test/metabase/legacy_mbql/util_test.cljc
@@ -309,16 +309,16 @@
       (t/testing "expression reference is transformed correctly"
         (let [expr-ref [:expression "cc"]]
           (t/is (= [:and
-                    [:>= expr-ref [:+ [:relative-datetime 0     bucket] exp-offset]]
-                    [:<  expr-ref [:+ [:relative-datetime value bucket] exp-offset]]]
+                    [:>= expr-ref [:+ [:relative-datetime 1           bucket] exp-offset]]
+                    [:<  expr-ref [:+ [:relative-datetime (inc value) bucket] exp-offset]]]
                    (mbql.u/desugar-filter-clause
                     [:relative-time-interval expr-ref value bucket offset-value offset-bucket])))))
       (t/testing "field reference is transformed correctly"
         (let [field-ref [:field 100 nil]
               exp-field-ref (update field-ref 2 assoc :temporal-unit :default)]
           (t/is (= [:and
-                    [:>= exp-field-ref [:+ [:relative-datetime 0     bucket] exp-offset]]
-                    [:<  exp-field-ref [:+ [:relative-datetime value bucket] exp-offset]]]
+                    [:>= exp-field-ref [:+ [:relative-datetime 1           bucket] exp-offset]]
+                    [:<  exp-field-ref [:+ [:relative-datetime (inc value) bucket] exp-offset]]]
                    (mbql.u/desugar-filter-clause
                     [:relative-time-interval exp-field-ref value bucket offset-value offset-bucket]))))))))
 

--- a/test/metabase/legacy_mbql/util_test.cljc
+++ b/test/metabase/legacy_mbql/util_test.cljc
@@ -276,6 +276,52 @@
            (mbql.u/desugar-filter-clause [:time-interval [:expression "CC"] :current :week]))
         "keywords like `:current` should work correctly"))
 
+(t/deftest ^:parallel desugar-relative-time-interval-negative-test
+  (t/testing "Desugaring relative-date-time produces expected [:and [:>=..] [:<..]] expression"
+    (let [value           -10
+          bucket          :day
+          offset-value    -8
+          offset-bucket   :week
+          exp-offset [:interval offset-value offset-bucket]]
+      (t/testing "expression reference is transformed correctly"
+        (let [expr-ref [:expression "cc"]]
+          (t/is (= [:and
+                    [:>= expr-ref [:+ [:relative-datetime value bucket] exp-offset]]
+                    [:<  expr-ref [:+ [:relative-datetime 0     bucket] exp-offset]]]
+                   (mbql.u/desugar-filter-clause
+                    [:relative-time-interval expr-ref value bucket offset-value offset-bucket])))))
+      (t/testing "field reference is transformed correctly"
+        (let [field-ref [:field 100 nil]
+              exp-field-ref (update field-ref 2 assoc :temporal-unit :default)]
+          (t/is (= [:and
+                    [:>= exp-field-ref [:+ [:relative-datetime value bucket] exp-offset]]
+                    [:<  exp-field-ref [:+ [:relative-datetime 0     bucket] exp-offset]]]
+                   (mbql.u/desugar-filter-clause
+                    [:relative-time-interval exp-field-ref value bucket offset-value offset-bucket]))))))))
+
+(t/deftest ^:parallel desugar-relative-time-interval-positive-test
+  (t/testing "Desugaring relative-date-time produces expected [:and [:>=..] [:<..]] expression"
+    (let [value           10
+          bucket          :day
+          offset-value    8
+          offset-bucket   :week
+          exp-offset [:interval offset-value offset-bucket]]
+      (t/testing "expression reference is transformed correctly"
+        (let [expr-ref [:expression "cc"]]
+          (t/is (= [:and
+                    [:>= expr-ref [:+ [:relative-datetime 0     bucket] exp-offset]]
+                    [:<  expr-ref [:+ [:relative-datetime value bucket] exp-offset]]]
+                   (mbql.u/desugar-filter-clause
+                    [:relative-time-interval expr-ref value bucket offset-value offset-bucket])))))
+      (t/testing "field reference is transformed correctly"
+        (let [field-ref [:field 100 nil]
+              exp-field-ref (update field-ref 2 assoc :temporal-unit :default)]
+          (t/is (= [:and
+                    [:>= exp-field-ref [:+ [:relative-datetime 0     bucket] exp-offset]]
+                    [:<  exp-field-ref [:+ [:relative-datetime value bucket] exp-offset]]]
+                   (mbql.u/desugar-filter-clause
+                    [:relative-time-interval exp-field-ref value bucket offset-value offset-bucket]))))))))
+
 (t/deftest ^:parallel desugar-relative-datetime-with-current-test
   (t/testing "when comparing `:relative-datetime`to `:field`, it should take the temporal unit of the `:field`"
     (t/is (= [:=

--- a/test/metabase/lib/filter_test.cljc
+++ b/test/metabase/lib/filter_test.cljc
@@ -703,9 +703,9 @@
                   (lib/expression-clause :relative-datetime [1 :month] nil)],
         :name "Created At is in the next month, starting 1 month from now"}
        {:clause [:relative-time-interval created-at 10 :week 10 :week]
-        :name "Created At is in next 10 weeks, starting 10 weeks from now"}
+        :name "Created At is in the next 10 weeks, starting 10 weeks from now"}
        {:clause [:relative-time-interval created-at -10 :week -10 :week]
-        :name "Created At is in previous 10 weeks, starting 10 weeks ago"}])))
+        :name "Created At is in the previous 10 weeks, starting 10 weeks ago"}])))
 
 (deftest ^:parallel specific-date-frontend-filter-display-names-test
   (let [created-at (meta/field-metadata :products :created-at)]

--- a/test/metabase/lib/filter_test.cljc
+++ b/test/metabase/lib/filter_test.cljc
@@ -701,7 +701,11 @@
                                           (lib/expression-clause :interval [-1 :month] nil)] nil)
                   (lib/expression-clause :relative-datetime [0 :month] nil)
                   (lib/expression-clause :relative-datetime [1 :month] nil)],
-        :name "Created At is in the next month, starting 1 month from now"}])))
+        :name "Created At is in the next month, starting 1 month from now"}
+       {:clause [:relative-time-interval created-at 10 :week 10 :week]
+        :name "Created At is in next 10 weeks, starting 10 weeks from now"}
+       {:clause [:relative-time-interval created-at -10 :week -10 :week]
+        :name "Created At is in previous 10 weeks, starting 10 weeks ago"}])))
 
 (deftest ^:parallel specific-date-frontend-filter-display-names-test
   (let [created-at (meta/field-metadata :products :created-at)]

--- a/test/metabase/lib/js_test.cljs
+++ b/test/metabase/lib/js_test.cljs
@@ -395,6 +395,9 @@
     [:time-interval {} [:field {} int?] 10 :day]
     (lib.js/expression-clause "time-interval" [(meta/field-metadata :products :created-at) 10 "day"] nil)
 
+    [:relative-time-interval {} [:field {} int?] 10 :day 10 :month]
+    (lib.js/expression-clause "time-interval" [(meta/field-metadata :products :created-at) 10 "day" 10 "month"] nil)
+
     [:relative-datetime {} :current :day]
     (lib.js/expression-clause "relative-datetime" ["current" "day"] nil)
 

--- a/test/metabase/lib/schema/filter_test.cljc
+++ b/test/metabase/lib/schema/filter_test.cljc
@@ -71,6 +71,7 @@
            [:time-interval field :last :hour]
            [:time-interval field 4 :hour]
            [:time-interval {:include-current true} field :next :day]
+           [:relative-time-interval field 10 :day 10 :day]
            [:segment 1]]]
       (doseq [op (filter-ops filter-expr)]
           (is (not (identical? (get-method expression/type-of-method op)

--- a/test/metabase/query_processor/middleware/desugar_test.clj
+++ b/test/metabase/query_processor/middleware/desugar_test.clj
@@ -16,6 +16,12 @@
                                      [:field 2 {:temporal-unit :day}]
                                      [:relative-datetime -30 :day]
                                      [:relative-datetime -1 :day]]
+                                    [:>=
+                                     [:field 2 {:temporal-unit :default}]
+                                     [:+ [:relative-datetime -30 :day] [:interval -30 :day]]]
+                                    [:<
+                                     [:field 2 {:temporal-unit :default}]
+                                     [:+ [:relative-datetime 0 :day] [:interval -30 :day]]]
                                     [:!= [:field 3 nil] "(not set)"]
                                     [:!= [:field 3 nil] "url"]
                                     [:> [:temporal-extract [:field 4 nil] :year-of-era] [:/ [:/ 1 2] 3]]]
@@ -38,6 +44,7 @@
                         :filter       [:and
                                        [:= [:field 1 nil] "Run Query"]
                                        [:time-interval [:field 2 nil] -30 :day]
+                                       [:relative-time-interval [:field 2 nil] -30 :day -30 :day]
                                        [:!= [:field 3 nil] "(not set)" "url"]
                                        [:> [:get-year [:field 4 nil]] [:/ 1 2 3]]]
                         :expressions  {"year" [:+

--- a/test/metabase/query_processor_test/date_bucketing_test.clj
+++ b/test/metabase/query_processor_test/date_bucketing_test.clj
@@ -1054,7 +1054,7 @@
 
 (deftest ^:parallel relative-time-interval-test
   (mt/test-drivers
-   (mt/normal-drivers-except #{:athena})
+   (disj (mt/normal-drivers-with-feature :date-arithmetics) :athena)
    ;; Following verifies #45942 is solved. Changing the offset ensures that intervals do not overlap.
    (testing "Syntactic sugar (`:relative-time-interval` clause) (#45942)"
      (mt/dataset
@@ -1433,7 +1433,7 @@
 (deftest filter-by-expression-relative-time-interval-test
   (testing "Datetime expressions can filter to a date range"
     (mt/test-drivers
-     (mt/normal-drivers-except #{:athena})
+     (disj (mt/normal-drivers-with-feature :date-arithmetics) :athena)
      (mt/dataset
       checkins:1-per-day
       (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/45942
Closes https://github.com/metabase/metabase/issues/34573

### Description

This PR adds `:relative-time-interval` mbql function and modifies FE to generate relative datetime filters using it.

Function has a following signature `column, value, bucket, offsetValue, offsetBucket`. `options` are not used as I found them redundant at this point. `value` and `offsetValue` are allowed to be integer only at this point.

Function is desugared into form as follows `[:and [:>=..] [:<..]]` in desugar qp middleware.

More context [on slack](https://metaboat.slack.com/archives/C04DN5VRQM6/p1721849734133429).

### How to verify

Run modified and new tests, or verify manually following reproductions in the linked issues.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
