### PR TITLE
e2e: Rewrite dashboard card resizing spec

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-resizing.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-resizing.cy.spec.js
@@ -198,16 +198,16 @@ const viewports = [
   [1440, 800],
 ];
 
-describe("scenarios > dashboard card resizing", () => {
-  beforeEach(() => {
-    restore();
-    cy.signInAsAdmin();
-  });
+describe(
+  "scenarios > dashboard card resizing",
+  { requestTimeout: 15000 },
+  () => {
+    beforeEach(() => {
+      restore();
+      cy.signInAsAdmin();
+    });
 
-  it(
-    "should display all visualization cards with their default sizes",
-    { requestTimeout: 15000 },
-    () => {
+    it("should display all visualization cards with their default sizes", () => {
       TEST_QUESTIONS.forEach(question => {
         createQuestion(question);
       });
@@ -252,13 +252,9 @@ describe("scenarios > dashboard card resizing", () => {
           });
         });
       });
-    },
-  );
+    });
 
-  it(
-    "should not allow cards to be resized smaller than min height",
-    { requestTimeout: 15000 },
-    () => {
+    it("should not allow cards to be resized smaller than min height", () => {
       const cardIds = [];
       TEST_QUESTIONS.forEach(question => {
         createQuestion(question).then(({ body: { id } }) => {
@@ -299,9 +295,9 @@ describe("scenarios > dashboard card resizing", () => {
           });
         });
       });
-    },
-  );
-});
+    });
+  },
+);
 
 describe("issue 31701", () => {
   const entityCard = () => getDashboardCard(0);

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-resizing.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-resizing.cy.spec.js
@@ -270,26 +270,17 @@ describe("scenarios > dashboard card resizing", { tags: "@flaky" }, () => {
           dashcards: cardIds.map((cardId, index) => ({
             id: index,
             card_id: cardId,
-            row: index * 2,
+            row: index * 10,
             col: 0,
-            size_x: 2,
-            size_y: 2,
+            size_x: 18,
+            size_y: 10,
           })),
         });
         visitDashboard(dashId);
         editDashboard();
 
         cy.request("GET", `/api/dashboard/${dashId}`).then(({ body }) => {
-          const dashcards = body.dashcards;
-          dashcards.forEach(({ card }, index) => {
-            resizeDashboardCard({
-              card: getDashboardCard(index),
-              x: getDefaultSize(card.display).width * 100,
-              y: getDefaultSize(card.display).height * 100,
-            });
-          });
-
-          dashcards.forEach(({ card }, index) => {
+          body.dashcards.forEach(({ card }, index) => {
             resizeDashboardCard({
               card: getDashboardCard(index),
               x: -getDefaultSize(card.display).width * 200,

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-resizing.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-resizing.cy.spec.js
@@ -301,77 +301,77 @@ describe("scenarios > dashboard card resizing", () => {
       });
     },
   );
+});
 
-  describe("issue 31701", () => {
-    const entityCard = () => getDashboardCard(0);
-    const customCard = () => getDashboardCard(1);
+describe("issue 31701", () => {
+  const entityCard = () => getDashboardCard(0);
+  const customCard = () => getDashboardCard(1);
 
-    const editEntityLinkContainer = () =>
-      cy.findByTestId("entity-edit-display-link");
-    const editCustomLinkContainer = () =>
-      cy.findByTestId("custom-edit-text-link");
+  const editEntityLinkContainer = () =>
+    cy.findByTestId("entity-edit-display-link");
+  const editCustomLinkContainer = () =>
+    cy.findByTestId("custom-edit-text-link");
 
-    const viewEntityLinkContainer = () =>
-      cy.findByTestId("entity-view-display-link");
-    const viewCustomLinkContainer = () =>
-      cy.findByTestId("custom-view-text-link");
+  const viewEntityLinkContainer = () =>
+    cy.findByTestId("entity-view-display-link");
+  const viewCustomLinkContainer = () =>
+    cy.findByTestId("custom-view-text-link");
 
-    beforeEach(() => {
-      restore();
-      cy.signInAsAdmin();
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
 
-      createQuestion({
-        name: TEST_QUESTION_NAME,
-        query: {
-          "source-table": ORDERS_ID,
-        },
-      });
-
-      createDashboard({
-        name: TEST_DASHBOARD_NAME,
-      }).then(({ body: { id: dashId } }) => {
-        visitDashboard(dashId);
-      });
-
-      editDashboard();
-
-      cy.log("Add first link card (connected to an entity");
-      cy.findByLabelText("Add link card").click();
-      getDashboardCard(0).as("entityCard").click().type(TEST_QUESTION_NAME);
-      popover()
-        .findAllByTestId("search-result-item-name")
-        .first()
-        .trigger("click");
-
-      cy.log("Add second link card (text only)");
-      cy.findByLabelText("Add link card").click();
-      getDashboardCard(1)
-        .as("customCard")
-        .click()
-        .type(TEST_QUESTION_NAME)
-        .realPress("Tab");
+    createQuestion({
+      name: TEST_QUESTION_NAME,
+      query: {
+        "source-table": ORDERS_ID,
+      },
     });
 
-    it("should prevent link dashboard card overflows (metabase#31701)", () => {
-      cy.log("when editing dashboard");
-      viewports.forEach(([width, height]) => {
-        cy.log(`Testing on resolution ${width} x ${height}`);
-        cy.viewport(width, height);
+    createDashboard({
+      name: TEST_DASHBOARD_NAME,
+    }).then(({ body: { id: dashId } }) => {
+      visitDashboard(dashId);
+    });
 
-        assertLinkCardOverflow(editEntityLinkContainer(), entityCard());
-        assertLinkCardOverflow(editCustomLinkContainer(), customCard());
-      });
+    editDashboard();
 
-      saveDashboard();
+    cy.log("Add first link card (connected to an entity");
+    cy.findByLabelText("Add link card").click();
+    getDashboardCard(0).as("entityCard").click().type(TEST_QUESTION_NAME);
+    popover()
+      .findAllByTestId("search-result-item-name")
+      .first()
+      .trigger("click");
 
-      cy.log("when viewing a saved dashboard");
-      viewports.forEach(([width, height]) => {
-        cy.log(`Testing on resolution ${width} x ${height}`);
-        cy.viewport(width, height);
+    cy.log("Add second link card (text only)");
+    cy.findByLabelText("Add link card").click();
+    getDashboardCard(1)
+      .as("customCard")
+      .click()
+      .type(TEST_QUESTION_NAME)
+      .realPress("Tab");
+  });
 
-        assertLinkCardOverflow(viewEntityLinkContainer(), entityCard());
-        assertLinkCardOverflow(viewCustomLinkContainer(), customCard());
-      });
+  it("should prevent link dashboard card overflows (metabase#31701)", () => {
+    cy.log("when editing dashboard");
+    viewports.forEach(([width, height]) => {
+      cy.log(`Testing on resolution ${width} x ${height}`);
+      cy.viewport(width, height);
+
+      assertLinkCardOverflow(editEntityLinkContainer(), entityCard());
+      assertLinkCardOverflow(editCustomLinkContainer(), customCard());
+    });
+
+    saveDashboard();
+
+    cy.log("when viewing a saved dashboard");
+    viewports.forEach(([width, height]) => {
+      cy.log(`Testing on resolution ${width} x ${height}`);
+      cy.viewport(width, height);
+
+      assertLinkCardOverflow(viewEntityLinkContainer(), entityCard());
+      assertLinkCardOverflow(viewCustomLinkContainer(), customCard());
     });
   });
 });

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-resizing.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-resizing.cy.spec.js
@@ -10,6 +10,8 @@ import {
   restore,
   saveDashboard,
   visitDashboard,
+  createQuestion,
+  createDashboard,
 } from "e2e/support/helpers";
 import { GRID_WIDTH } from "metabase/lib/dashboard_grid";
 
@@ -207,9 +209,9 @@ describe("scenarios > dashboard card resizing", { tags: "@flaky" }, () => {
     { requestTimeout: 15000 },
     () => {
       TEST_QUESTIONS.forEach(question => {
-        cy.createQuestion(question);
+        createQuestion(question);
       });
-      cy.createDashboard().then(({ body: { id: dashId } }) => {
+      createDashboard().then(({ body: { id: dashId } }) => {
         visitDashboard(dashId);
 
         cy.findByTestId("dashboard-header").within(() => {
@@ -259,11 +261,11 @@ describe("scenarios > dashboard card resizing", { tags: "@flaky" }, () => {
     () => {
       const cardIds = [];
       TEST_QUESTIONS.forEach(question => {
-        cy.createQuestion(question).then(({ body: { id } }) => {
+        createQuestion(question).then(({ body: { id } }) => {
           cardIds.push(id);
         });
       });
-      cy.createDashboard().then(({ body: { id: dashId } }) => {
+      createDashboard().then(({ body: { id: dashId } }) => {
         cy.request("PUT", `/api/dashboard/${dashId}`, {
           dashcards: cardIds.map((cardId, index) => ({
             id: index,
@@ -349,14 +351,14 @@ describe("scenarios > dashboard card resizing", { tags: "@flaky" }, () => {
 });
 
 const createLinkDashboard = () => {
-  cy.createQuestion({
+  createQuestion({
     name: TEST_QUESTION_NAME,
     query: {
       "source-table": ORDERS_ID,
     },
   });
 
-  cy.createDashboard({
+  createDashboard({
     name: TEST_DASHBOARD_NAME,
   }).then(({ body: { id: dashId } }) => {
     visitDashboard(dashId);

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-resizing.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-resizing.cy.spec.js
@@ -198,7 +198,7 @@ const viewports = [
   [1440, 800],
 ];
 
-describe("scenarios > dashboard card resizing", { tags: "@flaky" }, () => {
+describe("scenarios > dashboard card resizing", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();


### PR DESCRIPTION
### What does this PR accomplish?
- Speeds up dashboard-card-resizing spec by 100% in CI
- Removes the flakiness (confirmed by stress-testing)
- Simplifies test cases without losing the confidence that the feature works
- Improves assertions
- Improves the quality of the code by following Cypress' best practices (no more selectors stored as variable that you access later)

> [!Note]
> This whole spec now runs in about 45s while it previously took 1:35-1:45.

### Notable changes
1. "should not allow cards to be resized smaller than min height"
    - Removed the part where we first manually resize cards UP (in consultation with @oisincoveney )
    - We're now starting by creating each card from some large size (18x10) using the API
    - We then resize those cards manually and assert that they cannot be shrunk smaller than their min size
2. "should prevent link dashboard card overflows (metabase#31701)"
    - Improved readability of a helper function
    - Improved the test speed by simply rearranging how and when we loop through each viewport size
    - Reduced the number of setup, visits, etc. by merging two tests into one

### Stress-test
- [dashboard card resizing - min size](https://github.com/metabase/metabase/actions/runs/10116710768) (previous notorious flake) - 50/50 :white_check_mark: in half the time it took previously
- [dashboard card resizing - repro 31701](https://github.com/metabase/metabase/actions/runs/10117264648) - 100/100 :white_check_mark: (now runs in 7 seconds, from 25-30s before)
- the whole spec 5/5 ✅ (https://github.com/metabase/metabase/actions/runs/10117379736)
- the whole spec 50/50 ✅ (https://github.com/metabase/metabase/actions/runs/10117580416)