### PR TITLE
`cursor:pointer` on `ParameterValueWidget`

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
@@ -284,7 +284,7 @@ describe("scenarios > embedding > dashboard parameters", () => {
       assertRequiredEnabledForName({ name: "Not Used Filter", enabled: false });
     });
 
-    it("should render cursor pointer on hover over a toggle", () => {
+    it("should render cursor pointer on hover over a toggle (metabase#46223)", () => {
       visitDashboard("@dashboardId");
 
       cy.findAllByTestId("parameter-value-widget-target")

--- a/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
@@ -283,6 +283,15 @@ describe("scenarios > embedding > dashboard parameters", () => {
       assertRequiredEnabledForName({ name: "User", enabled: false });
       assertRequiredEnabledForName({ name: "Not Used Filter", enabled: false });
     });
+
+    it("should render cursor pointer on hover over a toggle", () => {
+      visitDashboard("@dashboardId");
+
+      cy.findAllByTestId("parameter-value-widget-target")
+        .first()
+        .realHover()
+        .should("have.css", "cursor", "pointer");
+    });
   });
 
   context("API", () => {

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.tsx
@@ -205,7 +205,7 @@ export const ParameterValueWidget = ({
       {...popoverProps}
     >
       <Popover.Target>
-        <Box onClick={toggle}>
+        <Box onClick={toggle} className={CS.cursorPointer}>
           <Sortable
             id={parameter.id}
             draggingStyle={{ opacity: 0.5 }}

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.tsx
@@ -205,7 +205,11 @@ export const ParameterValueWidget = ({
       {...popoverProps}
     >
       <Popover.Target>
-        <Box onClick={toggle} className={CS.cursorPointer}>
+        <Box
+          data-testid="parameter-value-widget-target"
+          onClick={toggle}
+          className={CS.cursorPointer}
+        >
           <Sortable
             id={parameter.id}
             draggingStyle={{ opacity: 0.5 }}


### PR DESCRIPTION
Re-adds `cursor: pointer` to the `ParameterValueWidget`. I can't seem to take screenshots with a cursor, so if you'd like to see the change then you'll need to pull down the branch