### PR TITLE
build: disable licenses generation for e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -86,7 +86,7 @@ jobs:
       MB_EDITION: ${{ matrix.edition }}
       INTERACTIVE: false
       # make sure that builds on release branches get licenses, because we use them for releases
-      SKIP_LICENSES: ${{ github.event_name == "pull_request" }}
+      SKIP_LICENSES: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4
       - name: Prepare front-end environment

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -85,6 +85,7 @@ jobs:
     env:
       MB_EDITION: ${{ matrix.edition }}
       INTERACTIVE: false
+      SKIP_LICENSES: true
     steps:
       - uses: actions/checkout@v4
       - name: Prepare front-end environment

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -85,7 +85,8 @@ jobs:
     env:
       MB_EDITION: ${{ matrix.edition }}
       INTERACTIVE: false
-      SKIP_LICENSES: true
+      // make sure that builds on release branches get licenses, because we use them for releases
+      SKIP_LICENSES: ${{ github.event_name == "pull_request" }}
     steps:
       - uses: actions/checkout@v4
       - name: Prepare front-end environment

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -86,7 +86,7 @@ jobs:
       MB_EDITION: ${{ matrix.edition }}
       INTERACTIVE: false
       # make sure that builds on release branches get licenses, because we use them for releases
-      SKIP_LICENSES: github.event_name == 'pull_request'
+      SKIP_LICENSES: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
       - name: Prepare front-end environment

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -85,7 +85,7 @@ jobs:
     env:
       MB_EDITION: ${{ matrix.edition }}
       INTERACTIVE: false
-      // make sure that builds on release branches get licenses, because we use them for releases
+      # make sure that builds on release branches get licenses, because we use them for releases
       SKIP_LICENSES: ${{ github.event_name == "pull_request" }}
     steps:
       - uses: actions/checkout@v4

--- a/bin/build/src/build.clj
+++ b/bin/build/src/build.clj
@@ -49,29 +49,30 @@
 (defn- build-licenses!
   [edition]
   {:pre [(#{:oss :ee} edition)]}
-  (u/step "Generate backend license information from jar files"
-    (let [basis                     (b/create-basis {:project (u/filename u/project-root-directory "deps.edn")})
-          output-filename           (u/filename u/project-root-directory
-                                                "resources"
-                                                "license-backend-third-party.txt")
-          {:keys [without-license]} (license/generate {:basis           basis
-                                                       :backfill        (edn/read-string
-                                                                         (slurp (io/resource "overrides.edn")))
-                                                       :output-filename output-filename
-                                                       :report?         false})]
-      (when (seq without-license)
-        (run! (comp (partial u/error "Missing License: %s") first)
-              without-license))
-      (u/announce "License information generated at %s" output-filename)))
+  (when-not (env/env :skip-licenses)
+    (u/step "Generate backend license information from jar files"
+      (let [basis                     (b/create-basis {:project (u/filename u/project-root-directory "deps.edn")})
+            output-filename           (u/filename u/project-root-directory
+                                                  "resources"
+                                                  "license-backend-third-party.txt")
+            {:keys [without-license]} (license/generate {:basis           basis
+                                                         :backfill        (edn/read-string
+                                                                           (slurp (io/resource "overrides.edn")))
+                                                         :output-filename output-filename
+                                                         :report?         false})]
+        (when (seq without-license)
+          (run! (comp (partial u/error "Missing License: %s") first)
+                without-license))
+        (u/announce "License information generated at %s" output-filename)))
 
-  (u/step "Run `yarn licenses generate-disclaimer`"
-    (let [license-text (str/join \newline
-                                 (u/sh {:dir    u/project-root-directory
-                                        :quiet? true}
-                                       "yarn" "licenses" "generate-disclaimer"))]
-      (spit (u/filename u/project-root-directory
-                        "resources"
-                        "license-frontend-third-party.txt") license-text))))
+    (u/step "Run `yarn licenses generate-disclaimer`"
+      (let [license-text (str/join \newline
+                                   (u/sh {:dir    u/project-root-directory
+                                          :quiet? true}
+                                         "yarn" "licenses" "generate-disclaimer"))]
+        (spit (u/filename u/project-root-directory
+                          "resources"
+                          "license-frontend-third-party.txt") license-text)))))
 
 (defn- build-uberjar! [edition]
   {:pre [(#{:oss :ee} edition)]}


### PR DESCRIPTION
it turned out if we restore node_modules from cache at CI, it's enough for `yarn --frozen-lockfile --prefer-offline` to avoid fetching packages from yarn registry, but the step that generates licenses actually re-fetches packages from yarn registry for some reason and I didn't find a way to skip it, especially when it takes ~50s of the build.

so we can drop licenses generation at CI for e2e tests, but we'll keep them in a build that happens after a merge to master as this build is reused later for release.

[context](https://metaboat.slack.com/archives/C0669P4AF9N/p1722000023982779?thread_ts=1721925885.352739&cid=C0669P4AF9N)


### Before ~47s
<img width="419" alt="Screenshot 2024-07-29 at 14 40 44" src="https://github.com/user-attachments/assets/173da6a8-1f31-4f05-be5e-4951ff9cac15">


### After - 1ms


<img width="387" alt="Screenshot 2024-07-29 at 14 40 20" src="https://github.com/user-attachments/assets/1f22f4dd-9df5-4850-9e2d-9787bc679aeb">
