### PR TITLE
Bump athena dependencies

### DIFF
--- a/modules/drivers/athena/deps.edn
+++ b/modules/drivers/athena/deps.edn
@@ -5,5 +5,5 @@
  {"athena" {:url "https://s3.amazonaws.com/maven-athena"}}
 
  :deps
- {com.amazonaws/aws-java-sdk-core {:mvn/version "1.12.683"}
-  com.metabase/athena-jdbc {:mvn/version "2.0.35"}}}
+ {com.amazonaws/aws-java-sdk-core {:mvn/version "1.12.765"}
+  com.metabase/athena-jdbc {:mvn/version "3.2.0"}}}


### PR DESCRIPTION
### Description

* Bump aws-java-sdk-core to 1.12.765
* Bump athena-jdbc to 3.2.0

Needed as there is an indirect dependency to a version of jackson core that has [a denial of service problem](https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-7569538) that our CI has picked up.

### How to verify

Running Snyk as part of our CI, we flagged the below up
![image](https://github.com/user-attachments/assets/80ff5397-a5de-4251-8fef-cf7753fc9802)

I've checked the dependencies for the AWS SDK on Maven and it's using 2.12 of Jackson so I imagine the 2.14 comes from the athena-jdbc driver.

**I don't know how destructive this dependency change is as I don't have exposure to the changes made in the AWS driver**, but I think if this is a minor enough change it would be good to prevent the issue and allow our CI to be accurate 😄 

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
