### PR TITLE
[manual backport] Increase slack upload timeout to 20 seconds #46235

### DIFF
--- a/src/metabase/integrations/slack.clj
+++ b/src/metabase/integrations/slack.clj
@@ -359,8 +359,8 @@
                      (poll {:thunk       complete!
                             :done?       uploaded-to-channel?
                             ;; Cal 2024-04-30: this typically takes 1-2 seconds to succeed.
-                            ;; If it takes more than 10 seconds, something else is wrong and we should abort.
-                            :timeout-ms  3000
+                            ;; If it takes more than 20 seconds, something else is wrong and we should abort.
+                            :timeout-ms  20000
                             :interval-ms 500}))
             (throw (ex-info "Timed out waiting to confirm the file was uploaded to a Slack channel."
                             {:channel-id channel-id, :filename filename})))]


### PR DESCRIPTION
Manually backports https://github.com/metabase/metabase/pull/46235 to 49.

