### PR TITLE
Automatic Nightly Patch Releases

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -11,6 +11,10 @@ on:
       commit:
         description: "A full-length commit SHA-1 hash"
         required: true
+      auto:
+        description: 'auto-patch release DO NOT SET MANUALLY'
+        type: boolean
+        default: false
 
 jobs:
   release-artifact:
@@ -284,6 +288,30 @@ jobs:
       - name: Wait for Metabase to start
         run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
         timeout-minutes: 3
+
+  trigger-auto-publish:
+    if: ${{ inputs.auto }}
+    needs: [run-sanity-check, check-uberjar-health, verify-docker-pull]
+    permissions:
+      actions: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: trigger auto publish
+        uses: actions/github-script@v7
+        with:
+          script: | # js
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'release.yml',
+              ref: '${{ github.ref }}',
+              inputs: {
+                commit: '${{ inputs.commit }}',
+                version: '${{ inputs.version }}',
+                auto: true,
+              }
+            });
 
   tests-complete-message:
     if: always()

--- a/.github/workflows/release-patch.yml
+++ b/.github/workflows/release-patch.yml
@@ -9,7 +9,7 @@ on:
         type: number
         required: true
   schedule:
-    - cron: '0 7 * * 1-5' # every weekday at 8am/9am Central European Time
+    - cron: '15 0 * * 1-5' # every weekday at 7/8:15 pm Eastern Time
 
 jobs:
   auto-patch-trigger:

--- a/.github/workflows/release-patch.yml
+++ b/.github/workflows/release-patch.yml
@@ -1,0 +1,91 @@
+name: Release 1b - Auto Patch
+run-name: Patch Release ${{ inputs.version }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Major Metabase version (e.g. 45, 52, 68)'
+        type: number
+        required: true
+  schedule:
+    - cron: '0 7 * * 1-5' # every weekday at 8am/9am Central European Time
+
+jobs:
+  auto-patch-trigger:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: release
+      - name: Prepare build scripts
+        run: yarn --cwd release --frozen-lockfile && yarn --cwd release build
+      - name: Trigger auto-patch
+        uses: actions/github-script@v7
+        with:
+          script: | # js
+            const {
+              getLatestGreenCommit,
+              getNextPatchVersion,
+              hasCommitBeenReleased,
+            } = require('${{ github.workspace }}/release/dist/index.cjs');
+
+            // Don't forget to update this for the next major release 🤞
+            const AUTO_RELEASE_VERSIONS = [49, 50];
+
+            async function releasePatchFor(majorVersion) {
+              const nextPatch = await getNextPatchVersion({
+                github,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                majorVersion,
+              });
+
+              const goodCommit = await getLatestGreenCommit({
+                github,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                branch: `release-x.${majorVersion}.x`,
+              });
+
+              const hasBeenReleased = await  hasCommitBeenReleased({
+                github,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: goodCommit,
+                majorVersion: Number(majorVersion),
+              });
+
+              if (nextPatch && goodCommit && !hasBeenReleased) {
+                await github.rest.actions.createWorkflowDispatch({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: 'tag-for-release.yml',
+                  ref: 'refs/heads/master',
+                  inputs: {
+                    commit: goodCommit,
+                    version: nextPatch,
+                    auto: true,
+                  }
+                });
+              } else {
+                console.log(
+                  { nextPatch, goodCommit, hasBeenReleased }
+                );
+                throw new Error(`No new patch version or no green commit found for v${majorVersion}`);
+              }
+            }
+
+            if (context.eventName === 'workflow_dispatch') {
+              const inputVersion = Number(context.payload.inputs.version);
+
+              if (typeof inputVersion !== 'number') {
+                console.log('Invalid version number', inputVersion);
+                throw new Error(`Invalid version number: ${inputVersion}`);
+              }
+
+              await releasePatchFor(inputVersion);
+            } else { // scheduled release of AUTO_RELEASE_VERSIONS
+              await Promise.all(AUTO_RELEASE_VERSIONS.map(releasePatchFor));
+            }

--- a/.github/workflows/release-patch.yml
+++ b/.github/workflows/release-patch.yml
@@ -73,7 +73,7 @@ jobs:
                 console.log(
                   { nextPatch, goodCommit, hasBeenReleased }
                 );
-                throw new Error(`No new patch version or no green commit found for v${majorVersion}`);
+                console.error(`No new patch version or no green commit found for v${majorVersion}`);
               }
             }
 

--- a/.github/workflows/release-patch.yml
+++ b/.github/workflows/release-patch.yml
@@ -49,7 +49,7 @@ jobs:
                 branch: `release-x.${majorVersion}.x`,
               });
 
-              const hasBeenReleased = await  hasCommitBeenReleased({
+              const hasBeenReleased = await hasCommitBeenReleased({
                 github,
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,10 @@ on:
         description: 'Skip publishing release notes'
         type: boolean
         default: false
+      auto:
+        description: 'auto-patch release DO NOT SET MANUALLY'
+        type: boolean
+        default: false
 
 jobs:
   check-version:
@@ -256,7 +260,7 @@ jobs:
     - name: Upload to S3
       run: aws s3 cp ./metabase.jar s3://${{ vars.AWS_S3_DOWNLOADS_BUCKET }}/${{ steps.version_path.outputs.result }}/metabase.jar
     - name: Upload to s3 latest path
-      if: ${{ steps.latest_path.outputs.result != 'false' }}
+      if: ${{ !inputs.auto && steps.latest_path.outputs.result != 'false' }}
       run: aws s3 cp ./metabase.jar s3://${{ vars.AWS_S3_DOWNLOADS_BUCKET }}/${{ steps.latest_path.outputs.result }}/metabase.jar
     - name: Create cloudfront invalidation
       run: |
@@ -402,7 +406,7 @@ jobs:
         echo "Finished!"
 
     - name: Tag the container image as latest
-      if: ${{ steps.latest_version_check.outputs.result == 'latest' }}
+      if: ${{ !inputs.auto && steps.latest_version_check.outputs.result == 'latest' }}
       run: |
         echo "Pushing ${{ env.DOCKERHUB_REPO }}:latest ..."
         docker tag localhost:5000/local-metabase:${{ steps.canonical_version.outputs.result }} ${{ env.DOCKERHUB_REPO }}:latest
@@ -510,7 +514,7 @@ jobs:
         $GITHUB_WORKSPACE/release/reorder-tags.sh ${{ needs.check-version.outputs.ee }} ${{ inputs.commit }}
 
   trigger-docs-update:
-    if: ${{ inputs.skip-release-notes != true }}
+    if: ${{ !inputs.auto && inputs.skip-release-notes != true }}
     needs:
       - push-tags
       - check-version
@@ -620,11 +624,12 @@ jobs:
               event_type: 'update-ee-extra-build',
               client_payload: {
                 version: enterpriseVersion,
+                auto: '${{ inputs.auto }}',
               }
             });
 
   draft-release-notes:
-    if: ${{ inputs.skip-release-notes != true }}
+    if: ${{ !inputs.auto && inputs.skip-release-notes != true }}
     needs: push-tags
     runs-on: ubuntu-22.04
     timeout-minutes: 15
@@ -676,7 +681,7 @@ jobs:
             });
 
   publish-version-info:
-    if: ${{ inputs.skip-version-info != true }}
+    if: ${{ !inputs.auto && inputs.skip-version-info != true }}
     runs-on: ubuntu-22.04
     needs: [push-tags, check-version]
     timeout-minutes: 15
@@ -735,6 +740,7 @@ jobs:
         --paths "/version-info.json" "/version-info-ee.json"
 
   publish-complete-message:
+    if: ${{ !inputs.auto }}
     runs-on: ubuntu-22.04
     needs: [draft-release-notes, verify-docker-pull, verify-s3-download, publish-version-info]
     timeout-minutes: 5
@@ -762,7 +768,37 @@ jobs:
               generalChannelName: 'general',
             }).catch(console.error);
 
+  auto-publish-complete-message:
+    if: ${{ inputs.auto }}
+    runs-on: ubuntu-22.04
+    needs: [push-tags, verify-docker-pull, verify-s3-download]
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: release
+      - name: Prepare build scripts
+        run: cd ${{ github.workspace }}/release && yarn && yarn build
+      - name: Send auto publish complete message
+        uses: actions/github-script@v7
+        env:
+          SLACK_RELEASE_CHANNEL: ${{ vars.SLACK_RELEASE_CHANNEL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          script: | # js
+            const { sendPublishCompleteMessage } = require('${{ github.workspace }}/release/dist/index.cjs');
+
+            await sendPublishCompleteMessage({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              version: '${{ inputs.version }}',
+              runId: '${{ github.run_id }}',
+              channelName: '${{ vars.SLACK_RELEASE_CHANNEL }}',
+              generalChannelName: '',
+            }).catch(console.error);
+
   manage-milestones:
+    if: ${{ !inputs.auto }}
     permissions: write-all
     runs-on: ubuntu-22.04
     needs: [draft-release-notes, publish-version-info] # this will ensure that the milestone stays open until the release notes are published

--- a/.github/workflows/tag-for-release.yml
+++ b/.github/workflows/tag-for-release.yml
@@ -11,6 +11,10 @@ on:
       commit:
         description: 'A full-length commit SHA-1 hash'
         required: true
+      auto:
+        description: 'auto-patch release DO NOT SET MANUALLY'
+        type: boolean
+        default: false
 
 jobs:
   start-message:
@@ -248,5 +252,6 @@ jobs:
               inputs: {
                 commit: '${{ inputs.commit }}',
                 version: '${{ inputs.version }}',
+                auto: '${{ inputs.auto }}',
               }
             });

--- a/release/src/github.ts
+++ b/release/src/github.ts
@@ -194,7 +194,9 @@ export async function getIssueWithCache ({
 }
 
 function checksPassed(checks: GithubCheck[]) {
-  const MIN_TOTAL_CHECKS = 95;
+  // we need to check total checks to make sure we didn't hit a temporary state where all checks are passing
+  // because only a few checks have triggered
+  const MIN_TOTAL_CHECKS = 95; // v49 has 96 checks, v50 has 99 checks
 
   const failedChecks = checks.filter((check) =>
     !["success", "skipped"].includes(check.conclusion ?? ''));

--- a/release/src/github.ts
+++ b/release/src/github.ts
@@ -1,6 +1,6 @@
-/* eslint-disable no-console */
-import type { GithubProps, Issue, ReleaseProps } from "./types";
+import type { GithubCheck, GithubProps, Issue, ReleaseProps } from "./types";
 import {
+  getLastReleaseTag,
   getMilestoneName,
   getNextVersions,
   isLatestVersion,
@@ -191,4 +191,95 @@ export async function getIssueWithCache ({
   }
 
   return issue?.data as Issue | null;
+}
+
+function checksPassed(checks: GithubCheck[]) {
+  const MIN_TOTAL_CHECKS = 95;
+
+  const failedChecks = checks.filter((check) =>
+    !["success", "skipped"].includes(check.conclusion ?? ''));
+
+  const pendingChecks = checks.filter((check) => check.status === "in_progress");
+  const totalChecks = checks.length;
+
+  const sha = checks[0]?.head_sha;
+
+  console.log({ sha, totalChecks, failedChecks, pendingChecks });
+
+  return failedChecks.length === 0 &&
+    pendingChecks.length === 0 &&
+    totalChecks >= MIN_TOTAL_CHECKS;
+}
+
+export async function getChecksForRef({
+  github,
+  owner,
+  repo,
+  ref,
+}: GithubProps & { ref: string }) {
+  const checks = await github.paginate(github.rest.checks.listForRef, {
+    owner,
+    repo,
+    ref,
+    per_page: 100,
+  });
+
+  return checks;
+}
+
+export async function getLatestGreenCommit({
+  github,
+  owner,
+  repo,
+  branch,
+}: GithubProps & { branch: string }) {
+  const MAX_COMMITS = 10;
+
+  const compareResponse = await github.rest.repos.compareCommitsWithBasehead({
+    owner,
+    repo,
+    basehead: `refs/heads/${branch}~${MAX_COMMITS}...refs/heads/${branch}`,
+  });
+
+  const commits = compareResponse.data.commits.reverse();
+
+  for (const commit of commits) {
+    const checks = await getChecksForRef({
+      github,
+      owner,
+      repo,
+      ref: commit.sha,
+    });
+
+    if (checksPassed(checks)) {
+      return commit.sha;
+    }
+  }
+  console.log("No green commit found");
+  return null;
+}
+
+export async function hasCommitBeenReleased({
+  github,
+  owner,
+  repo,
+  ref,
+  majorVersion,
+}: GithubProps & { ref: string, majorVersion: number }) {
+    const lastTag = await getLastReleaseTag({
+      github, owner, repo,
+      version: `v0.${majorVersion}.0`,
+    });
+
+    const tagDetail = await github.rest.git.getRef({
+      owner,
+      repo,
+      ref: `tags/${lastTag}`,
+    });
+
+    const lastTagSha = tagDetail.data.object.sha;
+
+    console.log({ lastTag, lastTagSha, ref });
+
+    return lastTagSha === ref;
 }

--- a/release/src/slack.ts
+++ b/release/src/slack.ts
@@ -22,7 +22,7 @@ export function mentionUserByGithubLogin(githubLogin?: string | null) {
   if (githubLogin && githubLogin in githubSlackMap) {
     return `<@${githubSlackMap[githubLogin]}>`;
   }
-  return `${githubLogin ?? 'unassigned'}`;
+  return `@${githubLogin ?? 'unassigned'}`;
 }
 
 export function mentionSlackTeam(teamName: string) {

--- a/release/src/slack.ts
+++ b/release/src/slack.ts
@@ -22,7 +22,7 @@ export function mentionUserByGithubLogin(githubLogin?: string | null) {
   if (githubLogin && githubLogin in githubSlackMap) {
     return `<@${githubSlackMap[githubLogin]}>`;
   }
-  return '@unassigned';
+  return `${githubLogin ?? 'unassigned'}`;
 }
 
 export function mentionSlackTeam(teamName: string) {
@@ -325,25 +325,33 @@ export async function sendPublishCompleteMessage({
   repo,
 }: {
   channelName: string,
-  generalChannelName: string,
+  generalChannelName?: string,
   version: string,
   runId: number,
   owner: string,
   repo: string,
 }) {
-  const message = `:partydeploy: *${githubRunLink(`${getGenericVersion(version)} Release is Complete`, runId.toString(), owner, repo)}* :partydeploy:\n
-   • ${slackLink("Release Notes", `https://github.com/${owner}/${repo}/releases`)} - ${mentionSlackTeam('tech-writers')}
-   • ${slackLink("EE Extra Build", `https://github.com/${owner}/metabase-ee-extra/pulls`)} - ${mentionSlackTeam('core-ems')}
-   • ${slackLink("Ops Issues", `https://github.com/${owner}/metabase-ops/issues`)} - ${mentionSlackTeam('successengineers')}
-   • ${slackLink("Docs Update", `https://github.com/${owner}/metabase.github.io/pulls`)} - ${mentionSlackTeam('tech-writers')}
-`;
+  const baseMessage = `:partydeploy: *${githubRunLink(`${getGenericVersion(version)} Release is Complete`, runId.toString(), owner, repo)}* :partydeploy:\n
+    • ${slackLink("EE Extra Build", `https://github.com/${owner}/metabase-ee-extra/pulls`)} - ${mentionSlackTeam('core-ems')}
+    • ${slackLink("Ops Issues", `https://github.com/${owner}/metabase-ops/issues`)} - ${mentionSlackTeam('successengineers')}`;
+
+  const docsMessage = `
+    • ${slackLink("Release Notes", `https://github.com/${owner}/${repo}/releases`)} - ${mentionSlackTeam('tech-writers')}
+    • ${slackLink("Docs Update", `https://github.com/${owner}/metabase.github.io/pulls`)} - ${mentionSlackTeam('tech-writers')}`;
+
+  const isPatch = version.split('.').length > 3;
+
+  const message = `${baseMessage}${isPatch ? '' : docsMessage}`;
+
   const buildThread = await getExistingSlackMessage(version, channelName);
   await sendSlackReply({ channelName, message, messageId: buildThread?.id, broadcast: true });
 
-  await sendSlackMessage({
-    message: `:partydeploy: *Metabase ${getGenericVersion(version)} has been released!* :partydeploy:\n\nSee the ${slackLink('full release notes here', `https://github.com/${owner}/${repo}/releases`)}.`,
-    channelName: generalChannelName,
-  });
+  if (!isPatch && generalChannelName) {
+    await sendSlackMessage({
+      message: `:partydeploy: *Metabase ${getGenericVersion(version)} has been released!* :partydeploy:\n\nSee the ${slackLink('full release notes here', `https://github.com/${owner}/${repo}/releases`)}.`,
+      channelName: generalChannelName,
+    });
+  }
 }
 
 export async function sendFlakeStatusReport({

--- a/release/src/types.ts
+++ b/release/src/types.ts
@@ -79,3 +79,18 @@ export type Tag = {
     url: string,
   }
 };
+
+export type GithubCheck = {
+  id: number;
+  name: string;
+  node_id: string;
+  head_sha: string;
+  external_id: string | null;
+  url: string | null;
+  html_url: string | null;
+  details_url: string | null;
+  status: "queued" | "in_progress" | "completed";
+  conclusion: "success" | "failure" | "neutral" | "cancelled" | "timed_out" | "action_required" | "skipped" | null;
+  started_at: string | null;
+  completed_at: string | null;
+};


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/46231

### Description

![Screen Shot 2024-07-29 at 4 54 09 PM](https://github.com/user-attachments/assets/59c9d71e-3073-4a8f-ae95-5ea401c6a506)


**1. New workflow: Auto Patch ([sample run](https://github.com/iethree/metabase/actions/runs/10152755714))**
- runs nightly on weekdays, or can be triggered to run manually for a single version
- scheduled runs attempt to release from 2 recent release branches
- checks git tags to find the last released version on that branch and increments by one patch
- checks the commits on the branch to find the last one with green CI
- if the last green commit hasn't been released yet, it triggers the existing build job with a new `auto` flag

**2. tag-for-release workflow update** ([sample run](https://github.com/iethree/metabase/actions/runs/10152759657))
- passes through the `auto` flag 

**3. pre-release testing workflow update** ([sample run](https://github.com/iethree/metabase/actions/runs/10152782187))
  - if the `auto` flag is present, it automatically triggers the publish job upon successful completion 

**4. Publish workflow update** ([sample run](https://github.com/iethree/metabase/actions/runs/10152995787))
  - receives the new `auto` tag, and for auto-releases:
	  - does not generate release notes
	  - does not update version-info.json
	  - does not push latest tagged docker image
	  - does not trigger docs updates
	  - does not close/open any milestones
	  - has a slightly different end-of-release slack message ([example](https://metaboat.slack.com/archives/C01BWAZJE0N/p1722293519946239?thread_ts=1722292848.599809&cid=C01BWAZJE0N))


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
