### PR TITLE
Avoid adding temporal-unit to lhs cols

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
@@ -627,21 +627,38 @@
       :bigquery-cloud-sdk
       (mt/dataset
         attempted-murders
-        (doseq [:let [expectations {["Europe/Oslo" :date "2020-01-09"] #t"2020-01-09",
-                                    ["Europe/Oslo" :datetime "2020-01-09"] #t"2020-01-09T00:00",
-                                    ["Europe/Oslo" :datetime "2020-01-09T01:03"] #t"2020-01-09T01:03",
-                                    ["Europe/Oslo" :datetime_tz "2020-01-09"] #t"2020-01-09T01:00+01:00[Europe/Oslo]",
-                                    ["Europe/Oslo" :datetime_tz "2020-01-09T01:03"] #t"2020-01-09T02:03+01:00[Europe/Oslo]",
-                                    ["UTC" :date "2020-01-09"] #t"2020-01-09",
-                                    ["UTC" :datetime "2020-01-09"] #t"2020-01-09T00:00",
-                                    ["UTC" :datetime "2020-01-09T01:03"] #t"2020-01-09T01:03",
-                                    ["UTC" :datetime_tz "2020-01-09"] #t"2020-01-09T00:00Z[UTC]",
-                                    ["UTC" :datetime_tz "2020-01-09T01:03"] #t"2020-01-09T01:03Z[UTC]",
-                                    [nil :date "2020-01-09"] #t"2020-01-09"
-                                    [nil :datetime "2020-01-09"] #t"2020-01-09T00:00",
-                                    [nil :datetime "2020-01-09T01:03"] #t"2020-01-09T01:03",
-                                    [nil :datetime_tz "2020-01-09"] (t/offset-date-time (u.date/parse "2020-01-09T00:00Z"))
-                                    [nil :datetime_tz "2020-01-09T01:03"] #t"2020-01-09T01:03Z[UTC]"}]
+        (doseq [:let [expectations {["Europe/Oslo" :date "2020-01-09"]
+                                    [#t"2020-01-09"],
+                                    ["Europe/Oslo" :datetime "2020-01-09"]
+                                    [#t "2020-01-09T00:00" #t "2020-01-10T00:00"],
+                                    ["Europe/Oslo" :datetime "2020-01-09T01:03"]
+                                    [#t "2020-01-09T01:03" #t "2020-01-09T01:04"],
+                                    ["Europe/Oslo" :datetime_tz "2020-01-09"]
+                                    [#t "2020-01-09T00:00+01:00[Europe/Oslo]" #t "2020-01-10T00:00+01:00[Europe/Oslo]"],
+                                    ["Europe/Oslo" :datetime_tz "2020-01-09T01:03"]
+                                    [#t "2020-01-09T01:03+01:00[Europe/Oslo]" #t "2020-01-09T01:04+01:00[Europe/Oslo]"],
+
+                                    ["UTC" :date "2020-01-09"]
+                                    [#t"2020-01-09"],
+                                    ["UTC" :datetime "2020-01-09"]
+                                    [#t "2020-01-09T00:00" #t "2020-01-10T00:00"],
+                                    ["UTC" :datetime "2020-01-09T01:03"]
+                                    [#t "2020-01-09T01:03" #t "2020-01-09T01:04"],
+                                    ["UTC" :datetime_tz "2020-01-09"]
+                                    [#t "2020-01-09T00:00Z[UTC]" #t "2020-01-10T00:00Z[UTC]"],
+                                    ["UTC" :datetime_tz "2020-01-09T01:03"]
+                                    [#t "2020-01-09T01:03Z[UTC]" #t "2020-01-09T01:04Z[UTC]"],
+
+                                    [nil :date "2020-01-09"]
+                                    [#t"2020-01-09"]
+                                    [nil :datetime "2020-01-09"]
+                                    [#t "2020-01-09T00:00" #t "2020-01-10T00:00"],
+                                    [nil :datetime "2020-01-09T01:03"]
+                                    [#t "2020-01-09T01:03" #t "2020-01-09T01:04"],
+                                    [nil :datetime_tz "2020-01-09"]
+                                    [#t "2020-01-09T00:00Z[UTC]" #t "2020-01-10T00:00Z[UTC]"]
+                                    [nil :datetime_tz "2020-01-09T01:03"]
+                                    [#t "2020-01-09T01:03Z[UTC]" #t "2020-01-09T01:04Z[UTC]"]}]
                 tz [nil "Europe/Oslo" "UTC"]
                 field [:date :datetime :datetime_tz]
                 value (cond-> ["2020-01-09"]
@@ -667,7 +684,7 @@
                                          :name "d"
                                          :target [:dimension [:template-tag "d"]]
                                          :value value}]}]
-                (is (= [expected] (:params (qp.compile/compile query))))))))))))
+                (is (= expected (:params (qp.compile/compile query))))))))))))
 
 (deftest current-datetime-honeysql-form-test
   (mt/test-driver :bigquery-cloud-sdk

--- a/src/metabase/driver/common/parameters.clj
+++ b/src/metabase/driver/common/parameters.clj
@@ -73,6 +73,11 @@
   (pretty [_]
     (list (pretty/qualify-symbol-for-*ns* `->DateRange) start end)))
 
+(p.types/defrecord+ DateTimeRange [start end]
+  pretty/PrettyPrintable
+  (pretty [_]
+          (list (pretty/qualify-symbol-for-*ns* `->DateRange) start end)))
+
 (def no-value
   "Convenience for representing an *optional* parameter present in a query but whose value is unspecified in the param
   values."

--- a/src/metabase/driver/common/parameters/dates.clj
+++ b/src/metabase/driver/common/parameters/dates.clj
@@ -511,7 +511,7 @@
   of datetimes. By adding 0 temporal padding the end interval has to be adjusted."
   [end-dt unit-fn]
   (when (and end-dt unit-fn)
-    (t/- (t/+ end-dt (unit-fn 1)) (t/seconds 1))))
+    (t/+ end-dt (unit-fn 1))))
 
 (mu/defn date-str->datetime-range :- DateStringRange
   "Generate range from `date-range-str`.
@@ -519,10 +519,12 @@
   First [[date-string->range]] generates range for dates (inclusive by default). Operating on that range,
   this function:
   1. converts dates to OffsetDateTime, respecting qp timezone, adding zero temporal padding,
-  2. updates range correct _inclusive datetime_
+  2. updates range to correct _end-exclusive datetime_*
   3. formats the range.
 
-  This function is meant to be used for generating inclusive intervals for `:type/DateTime` field filters."
+  This function is meant to be used for generating inclusive intervals for `:type/DateTime` field filters.
+
+  * End-exclusive gte lt filters are generated for `:type/DateTime` fields."
   [raw-date-str]
   (let [range-raw (date-string->range raw-date-str)]
     (-> (update-vals range-raw date-str->qp-aware-offset-dt)

--- a/src/metabase/driver/common/parameters/dates.clj
+++ b/src/metabase/driver/common/parameters/dates.clj
@@ -480,7 +480,7 @@
              (t/offset-date-time y M d h m s 0 (t/zone-offset (qp.timezone/results-timezone-id))))))))
 
 (defn- date-str->unit-fn
-  "Return appropriate function for interval end adjustments in [[inclusive-datetime-range-end]]."
+  "Return appropriate function for interval end adjustments in [[exclusive-datetime-range-end]]."
   [date-str]
   (when date-str
     (if (re-matches shared.ut/local-date-regex date-str)

--- a/src/metabase/driver/common/parameters/dates.clj
+++ b/src/metabase/driver/common/parameters/dates.clj
@@ -482,15 +482,12 @@
   "Generate offset datetime from `date-str` with respect to `results-timezone`."
   [date-str]
   (when date-str
-    (let [[y M d h m s] (parse-date-str date-str)
-        ;; I'm unable to tell whether we timzone-id will be offset or actuall id. Potentially zoned datetime may be
-        ;; created. For that reason last expression of this function ensures OffsetDateTime is always returned.
-          dt (try (t/zoned-date-time y M d h m s 0 (t/zone-id (qp.timezone/results-timezone-id)))
+    (let [[y M d h m s] (parse-date-str date-str)]
+      (try (.toOffsetDateTime (t/zoned-date-time y M d h m s 0 (t/zone-id (qp.timezone/results-timezone-id))))
+           (catch Throwable _
+             (try (t/offset-date-time y M d h m s 0 (t/zone-offset (qp.timezone/results-timezone-id)))
                   (catch Throwable _
-                    (try (t/offset-date-time y M d h m s 0 (t/zone-offset (qp.timezone/results-timezone-id)))
-                         (catch Throwable _
-                           (t/offset-date-time y M d h m s 0 (t/zone-id "Z"))))))]
-      (t/offset-date-time dt))))
+                    (t/offset-date-time y M d h m s 0 (t/zone-id "Z")))))))))
 
 (defn- date-str->unit-fn
   "Return appropriate function for interval end adjustments in [[inclusive-datetime-range-end]]."

--- a/src/metabase/driver/sql/parameters/substitution.clj
+++ b/src/metabase/driver/sql/parameters/substitution.clj
@@ -253,10 +253,10 @@
      :prepared-statement-args args}))
 
 (mu/defn- field->clause :- mbql.s/field
-  [driver     :- :keyword
+  [_driver     :- :keyword
    field      :- ::lib.schema.metadata/column
-   param-type :- ::lib.schema.parameter/type
-   value]
+   _param-type :- ::lib.schema.parameter/type
+   _value]
   ;; The [[metabase.query-processor.middleware.parameters/substitute-parameters]] QP middleware actually happens before
   ;; the [[metabase.query-processor.middleware.resolve-fields/resolve-fields]] middleware that would normally fetch all
   ;; the Fields we need in a single pass, so this is actually necessary here. I don't think switching the order of the
@@ -266,7 +266,9 @@
   [:field
    (u/the-id field)
    {:base-type                (:base-type field)
-    :temporal-unit            (align-temporal-unit-with-param-type-and-value driver field param-type value)
+    ;; Set default :temporal-unit for temporal parameters so we avoid LHS cast that make indexes unusable.
+    ;; :temporal-unit was set to nil for non temporal fields and this change does not modify that.
+    :temporal-unit            (when (isa? (:base-type field) :type/Temporal) :default)
     ::add/source-table        (:table-id field)
     ;; in case anyone needs to know we're compiling a Field filter.
     ::compiling-field-filter? true}])

--- a/src/metabase/driver/sql/parameters/substitution.clj
+++ b/src/metabase/driver/sql/parameters/substitution.clj
@@ -268,8 +268,6 @@
   [:field
    (u/the-id field)
    {:base-type                (:base-type field)
-    ;; Set default :temporal-unit for temporal parameters so we avoid LHS cast that make indexes unusable.
-    ;; :temporal-unit was set to nil for non temporal fields and this change does not modify that.
     :temporal-unit            (align-temporal-unit-with-param-type-and-value driver field param-type value)
     ::add/source-table        (:table-id field)
     ;; in case anyone needs to know we're compiling a Field filter.
@@ -286,7 +284,8 @@
        :replacement-snippet))
 
 (defn- field-filter->replacement-snippet-for-datetime-field
-  "TODO: convert to gte lt from between last step"
+  "Generate replacement snippet for field filter on datetime field. For details on how range is generated see
+  the docstring of [[params.dates/date-str->datetime-range]]."
   [driver {:keys [field] {:keys [value type]} :value :as _field-filter}]
   (letfn [(->datetime-replacement-snippet-info
             [range]

--- a/src/metabase/shared/util/time.cljc
+++ b/src/metabase/shared/util/time.cljc
@@ -3,6 +3,7 @@
   In Java these return [[OffsetDateTime]], in JavaScript they return Moments.
   Most of the implementations are in the split CLJ/CLJS files [[metabase.shared.util.internal.time]]."
   (:require
+   [clojure.string :as str]
    [metabase.shared.util.internal.time :as internal]
    [metabase.shared.util.internal.time-common :as common]
    [metabase.shared.util.namespaces :as shared.ns]
@@ -102,3 +103,12 @@
    (internal/format-relative-date-range n unit offset-n offset-unit options))
   ([t n unit offset-n offset-unit options]
    (internal/format-relative-date-range (coerce-to-timestamp t) n unit offset-n offset-unit options)))
+
+(defn yyyyMMddhhmmss->parts
+  "Generate parts vector for `yyyy-MM-ddThh:mm:ss` format `date-str`. Trailing parts, if not present in the string,
+  are added. Not compatile with strings containing milliseconds or timezone."
+  [date-str]
+  (let [parts (mapv #?(:clj #(Integer/parseInt %)
+                       :cljs js/parseInt)
+                    (str/split date-str #"-|:|T"))]
+    (into parts (repeat (- 6 (count parts)) 0))))

--- a/test/metabase/driver/sql/parameters/substitute_test.clj
+++ b/test/metabase/driver/sql/parameters/substitute_test.clj
@@ -91,9 +91,9 @@
     (testing "non-optional"
       (let [query ["select * from orders where " (param "created_at")]]
         (testing "param is present"
-          (is (= ["select * from orders where \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" BETWEEN ? AND ?"
+          (is (= ["select * from orders where \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" >= ? AND \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" < ?"
                   [(t/zoned-date-time "2019-09-20T19:52:00" (t/zone-id "UTC"))
-                   (t/zoned-date-time "2019-09-20T19:52:59" (t/zone-id "UTC"))]]
+                   (t/zoned-date-time "2019-09-20T19:53:00" (t/zone-id "UTC"))]]
                  (substitute query {"created_at" (date-field-filter-value)}))))
         (testing "param is missing"
           (is (= ["select * from orders where 1 = 1" []]
@@ -102,9 +102,9 @@
     (testing "optional"
       (let [query ["select * from orders " (optional "where " (param "created_at"))]]
         (testing "param is present"
-          (is (= ["select * from orders where \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" BETWEEN ? AND ?"
+          (is (= ["select * from orders where \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" >= ? AND \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" < ?"
                   [(t/zoned-date-time "2019-09-20T19:52:00" (t/zone-id "UTC"))
-                   (t/zoned-date-time "2019-09-20T19:52:59" (t/zone-id "UTC"))]]
+                   (t/zoned-date-time "2019-09-20T19:53:00" (t/zone-id "UTC"))]]
                  (substitute query {"created_at" (date-field-filter-value)}))))
         (testing "param is missing — should be omitted entirely"
           (is (= ["select * from orders" nil]

--- a/test/metabase/driver/sql/parameters/substitute_test.clj
+++ b/test/metabase/driver/sql/parameters/substitute_test.clj
@@ -84,7 +84,7 @@
   (params/map->FieldFilter
    {:field (meta/field-metadata :orders :created-at)
     :value {:type  :date/single
-            :value "2019-09-20T19:52"}}))
+            :value (str (t/offset-date-time "2019-09-20T19:52:00.000-07:00"))}}))
 
 (deftest ^:parallel substitute-field-filter-test
   (testing "field-filters"

--- a/test/metabase/driver/sql/parameters/substitute_test.clj
+++ b/test/metabase/driver/sql/parameters/substitute_test.clj
@@ -84,15 +84,16 @@
   (params/map->FieldFilter
    {:field (meta/field-metadata :orders :created-at)
     :value {:type  :date/single
-            :value (str (t/offset-date-time "2019-09-20T19:52:00.000-07:00"))}}))
+            :value "2019-09-20T19:52"}}))
 
 (deftest ^:parallel substitute-field-filter-test
   (testing "field-filters"
     (testing "non-optional"
       (let [query ["select * from orders where " (param "created_at")]]
         (testing "param is present"
-          (is (= ["select * from orders where DATE_TRUNC('minute', \"PUBLIC\".\"ORDERS\".\"CREATED_AT\") = ?"
-                  [(t/offset-date-time "2019-09-20T19:52:00.000-07:00")]]
+          (is (= ["select * from orders where \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" BETWEEN ? AND ?"
+                  [(t/zoned-date-time "2019-09-20T19:52:00" (t/zone-id "UTC"))
+                   (t/zoned-date-time "2019-09-20T19:52:59" (t/zone-id "UTC"))]]
                  (substitute query {"created_at" (date-field-filter-value)}))))
         (testing "param is missing"
           (is (= ["select * from orders where 1 = 1" []]
@@ -101,8 +102,9 @@
     (testing "optional"
       (let [query ["select * from orders " (optional "where " (param "created_at"))]]
         (testing "param is present"
-          (is (= ["select * from orders where DATE_TRUNC('minute', \"PUBLIC\".\"ORDERS\".\"CREATED_AT\") = ?"
-                  [#t "2019-09-20T19:52:00.000-07:00"]]
+          (is (= ["select * from orders where \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" BETWEEN ? AND ?"
+                  [(t/zoned-date-time "2019-09-20T19:52:00" (t/zone-id "UTC"))
+                   (t/zoned-date-time "2019-09-20T19:52:59" (t/zone-id "UTC"))]]
                  (substitute query {"created_at" (date-field-filter-value)}))))
         (testing "param is missing — should be omitted entirely"
           (is (= ["select * from orders" nil]

--- a/test/metabase/driver/sql/parameters/substitution_test.clj
+++ b/test/metabase/driver/sql/parameters/substitution_test.clj
@@ -3,6 +3,7 @@
   [[metabase.driver.sql.parameters.substitute-test]]."
   (:require
    [clojure.test :refer :all]
+   [java-time.api :as t]
    [metabase.driver :as driver]
    [metabase.driver.common.parameters :as params]
    [metabase.driver.sql.parameters.substitution
@@ -12,9 +13,7 @@
    [metabase.lib.test-metadata :as meta]
    [metabase.query-processor.store :as qp.store]
    [metabase.test :as mt]
-   [metabase.util.honey-sql-2 :as h2x])
-  (:import
-   (java.time LocalDate LocalDateTime)))
+   [metabase.util.honey-sql-2 :as h2x]))
 
 (set! *warn-on-reflection* true)
 
@@ -100,13 +99,13 @@
         (let [field-filter (params/map->FieldFilter
                              {:field (lib.metadata/field (qp.store/metadata-provider) (meta/id :orders :created-at))
                               :value {:type :date/all-options, :value "next3days"}})
-              expected-args [(LocalDate/of 2018 7 2)
-                             (LocalDate/of 2018 7 4)]]
+              expected-args [(t/zoned-date-time 2018 7 2 0 0 0 0 (t/zone-id "UTC"))
+                             (t/zoned-date-time 2018 7 4 23 59 59 0 (t/zone-id "UTC"))]]
           (testing "default implementation"
             (driver/with-driver ::temporal-unit-alignment-original
               (is (= {:prepared-statement-args expected-args
                       ;; `sql.qp/date [driver :day]` was called due to `:day` returned from the multimethod by default
-                      :replacement-snippet "DAY(\"PUBLIC\".\"ORDERS\".\"CREATED_AT\") BETWEEN ? AND ?"}
+                      :replacement-snippet "\"PUBLIC\".\"ORDERS\".\"CREATED_AT\" BETWEEN ? AND ?"}
                      (sql.params.substitution/->replacement-snippet-info ::temporal-unit-alignment-original field-filter)))))
           (testing "override"
             (driver/with-driver ::temporal-unit-alignment-override
@@ -118,13 +117,13 @@
         (let [field-filter (params/map->FieldFilter
                              {:field (lib.metadata/field (qp.store/metadata-provider) (meta/id :orders :created-at))
                               :value {:type :date/all-options, :value "past30minutes"}})
-              expected-args [(LocalDateTime/of 2018 7 1 12 00 00)
-                             (LocalDateTime/of 2018 7 1 12 29 00)]]
+              expected-args [(t/zoned-date-time 2018 7 1 12 0 0 0 (t/zone-id "UTC"))
+                             (t/zoned-date-time 2018 7 1 12 29 59 0 (t/zone-id "UTC"))]]
           (testing "default implementation"
             (driver/with-driver ::temporal-unit-alignment-original
               (is (= {:prepared-statement-args expected-args
                       ;; `sql.qp/date [driver :day]` was called due to `:day` returned from the multimethod by default
-                      :replacement-snippet "MINUTE(\"PUBLIC\".\"ORDERS\".\"CREATED_AT\") BETWEEN ? AND ?"}
+                      :replacement-snippet "\"PUBLIC\".\"ORDERS\".\"CREATED_AT\" BETWEEN ? AND ?"}
                      (sql.params.substitution/->replacement-snippet-info ::temporal-unit-alignment-original field-filter)))))
           (testing "override"
             (driver/with-driver ::temporal-unit-alignment-override

--- a/test/metabase/driver/sql/parameters/substitution_test.clj
+++ b/test/metabase/driver/sql/parameters/substitution_test.clj
@@ -100,34 +100,34 @@
                              {:field (lib.metadata/field (qp.store/metadata-provider) (meta/id :orders :created-at))
                               :value {:type :date/all-options, :value "next3days"}})
               expected-args [(t/zoned-date-time 2018 7 2 0 0 0 0 (t/zone-id "UTC"))
-                             (t/zoned-date-time 2018 7 4 23 59 59 0 (t/zone-id "UTC"))]]
+                             (t/zoned-date-time 2018 7 5 0 0 0 0 (t/zone-id "UTC"))]]
           (testing "default implementation"
             (driver/with-driver ::temporal-unit-alignment-original
               (is (= {:prepared-statement-args expected-args
                       ;; `sql.qp/date [driver :day]` was called due to `:day` returned from the multimethod by default
-                      :replacement-snippet "\"PUBLIC\".\"ORDERS\".\"CREATED_AT\" BETWEEN ? AND ?"}
+                      :replacement-snippet "\"PUBLIC\".\"ORDERS\".\"CREATED_AT\" >= ? AND \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" < ?"}
                      (sql.params.substitution/->replacement-snippet-info ::temporal-unit-alignment-original field-filter)))))
           (testing "override"
             (driver/with-driver ::temporal-unit-alignment-override
               (is (= {:prepared-statement-args expected-args
                       ;; no extra `sql.qp/date` calls due to `nil` returned from the override
-                      :replacement-snippet "\"PUBLIC\".\"ORDERS\".\"CREATED_AT\" BETWEEN ? AND ?"}
+                      :replacement-snippet "\"PUBLIC\".\"ORDERS\".\"CREATED_AT\" >= ? AND \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" < ?"}
                      (sql.params.substitution/->replacement-snippet-info ::temporal-unit-alignment-override field-filter)))))))
       (testing "datetime"
         (let [field-filter (params/map->FieldFilter
                              {:field (lib.metadata/field (qp.store/metadata-provider) (meta/id :orders :created-at))
                               :value {:type :date/all-options, :value "past30minutes"}})
               expected-args [(t/zoned-date-time 2018 7 1 12 0 0 0 (t/zone-id "UTC"))
-                             (t/zoned-date-time 2018 7 1 12 29 59 0 (t/zone-id "UTC"))]]
+                             (t/zoned-date-time 2018 7 1 12 30 0 0 (t/zone-id "UTC"))]]
           (testing "default implementation"
             (driver/with-driver ::temporal-unit-alignment-original
               (is (= {:prepared-statement-args expected-args
                       ;; `sql.qp/date [driver :day]` was called due to `:day` returned from the multimethod by default
-                      :replacement-snippet "\"PUBLIC\".\"ORDERS\".\"CREATED_AT\" BETWEEN ? AND ?"}
+                      :replacement-snippet "\"PUBLIC\".\"ORDERS\".\"CREATED_AT\" >= ? AND \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" < ?"}
                      (sql.params.substitution/->replacement-snippet-info ::temporal-unit-alignment-original field-filter)))))
           (testing "override"
             (driver/with-driver ::temporal-unit-alignment-override
               (is (= {:prepared-statement-args expected-args
                       ;; no extra `sql.qp/date` calls due to `nil` returned from the override
-                      :replacement-snippet "\"PUBLIC\".\"ORDERS\".\"CREATED_AT\" BETWEEN ? AND ?"}
+                      :replacement-snippet "\"PUBLIC\".\"ORDERS\".\"CREATED_AT\" >= ? AND \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" < ?"}
                      (sql.params.substitution/->replacement-snippet-info ::temporal-unit-alignment-override field-filter))))))))))

--- a/test/metabase/query_analysis/native_query_analyzer/parameter_substitution_test.clj
+++ b/test/metabase/query_analysis/native_query_analyzer/parameter_substitution_test.clj
@@ -144,7 +144,7 @@
 
 (deftest field-filter-date-test
   (doseq [date-filter ["created_range" "created_my" "created_qy" "created_rel" "date_ao"]]
-    (is (= "SELECT * FROM people WHERE \"PUBLIC\".\"PEOPLE\".\"CREATED_AT\" BETWEEN ? AND ?"
+    (is (= "SELECT * FROM people WHERE \"PUBLIC\".\"PEOPLE\".\"CREATED_AT\" >= ? AND \"PUBLIC\".\"PEOPLE\".\"CREATED_AT\" < ?"
            (->sql (mt/native-query {:template-tags (tags date-filter)
                                     :query         (format "SELECT * FROM people WHERE {{%s}}" date-filter)}))))))
 

--- a/test/metabase/query_analysis/native_query_analyzer/parameter_substitution_test.clj
+++ b/test/metabase/query_analysis/native_query_analyzer/parameter_substitution_test.clj
@@ -144,7 +144,7 @@
 
 (deftest field-filter-date-test
   (doseq [date-filter ["created_range" "created_my" "created_qy" "created_rel" "date_ao"]]
-    (is (= "SELECT * FROM people WHERE CAST(\"PUBLIC\".\"PEOPLE\".\"CREATED_AT\" AS date) BETWEEN ? AND ?"
+    (is (= "SELECT * FROM people WHERE \"PUBLIC\".\"PEOPLE\".\"CREATED_AT\" BETWEEN ? AND ?"
            (->sql (mt/native-query {:template-tags (tags date-filter)
                                     :query         (format "SELECT * FROM people WHERE {{%s}}" date-filter)}))))))
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/21133

### Description

This PR enables use of indexes in native query's `FieldFilter` expansions. That is achieved by removing LHS casts from temporal types.

For `:type/Date` columns nothing special is required -- original logic generates dates and uses sql's _between_ for matching.

For `:type/DateTime` columns ranges are generated that are used in _gte lt_ matching expression.

It might make sense to unify the _between_ vs _gte lt_ in the future to rather make things simpler. (If there is any reason against it please let me know in the review.)
