### PR TITLE
Disable Validation API if Analysis is disabled

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/query_reference_validation/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/query_reference_validation/api.clj
@@ -105,7 +105,7 @@
             :offset mw.offset-paging/*offset*})))
 
 (defn +check-setting
-  "Middleware that returns a 401 response if `request` has no associated `:metabase-user-id`."
+  "Middleware that gates this API behind the associated feature flag"
   [handler]
   (with-meta
    (fn [request respond raise]

--- a/enterprise/backend/src/metabase_enterprise/query_reference_validation/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/query_reference_validation/api.clj
@@ -6,6 +6,7 @@
    [metabase.api.routes.common :refer [+auth]]
    [metabase.models.collection :as collection]
    [metabase.models.query-analysis :as query-analysis]
+   [metabase.public-settings :as public-settings]
    [metabase.server.middleware.offset-paging :as mw.offset-paging]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
@@ -103,4 +104,14 @@
            {:limit mw.offset-paging/*limit*
             :offset mw.offset-paging/*offset*})))
 
-(api/define-routes api/+check-superuser +auth)
+(defn +check-setting
+  "Middleware that returns a 401 response if `request` has no associated `:metabase-user-id`."
+  [handler]
+  (with-meta
+   (fn [request respond raise]
+     (if (public-settings/query-analysis-enabled)
+       (handler request respond raise)
+       (respond {:status 429 :body "Query Analysis must be enabled to use the Query Reference Validator"})))
+   (meta handler)))
+
+(api/define-routes api/+check-superuser +auth +check-setting)

--- a/enterprise/backend/test/metabase_enterprise/query_reference_validation/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/query_reference_validation/api_test.clj
@@ -97,7 +97,8 @@
                                                               :table_id    nil
                                                               :field_id    nil}]
      (mt/with-premium-features #{:query-reference-validation}
-       (mt/call-with-map-params f [card-1 card-2 card-3 card-4 coll-2 coll-3])))))
+       (mt/with-temporary-setting-values [query-analysis-enabled true]
+         (mt/call-with-map-params f [card-1 card-2 card-3 card-4 coll-2 coll-3]))))))
 
 (defmacro ^:private with-test-setup
   "Creates some non-stale QueryFields and anaphorically provides stale QueryField IDs called `qf-{1-3}` and `qf-1b` and
@@ -149,6 +150,13 @@
 
 (defn- with-data-keys [{:keys [data] :as resp} ks]
   (assoc resp :data (map (fn [d] (select-keys d ks)) data)))
+
+(deftest setting-test
+  (testing "It requires the query analysis setting"
+    (with-test-setup
+      (mt/with-temporary-setting-values [query-analysis-enabled false]
+        (is (= "Query Analysis must be enabled to use the Query Reference Validator"
+               (mt/user-http-request :crowberto :get 429 url)))))))
 
 (deftest list-invalid-cards-basic-test
   (testing "Only returns cards with problematic field refs"

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -938,7 +938,7 @@ See [fonts](../configuring-metabase/fonts.md).")
 
 (defsetting query-analysis-enabled
   (deferred-tru "Whether or not we analyze any queries at all")
-  :visibility :internal
+  :visibility :admin
   :export?    false
   :default    true
   :type       :boolean)


### PR DESCRIPTION
### Description

The query validation tool will not behave correctly if query analysis is disabled.

This PR gates the API behind that feature, and makes it visible to admins.

Thread here: https://metaboat.slack.com/archives/C06V3JMECH2/p1721809657496249