### PR TITLE
ci: Fix E2E flake for the reproduction #21559

### DIFF
--- a/e2e/test/scenarios/sharing/sharing-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/sharing-reproductions.cy.spec.js
@@ -350,45 +350,39 @@ describe("issue 21559", { tags: "@external" }, () => {
     });
   });
 
-  it(
-    "should respect dashboard card visualization (metabase#21559)",
-    { tags: "@flaky" },
-    () => {
-      cy.findByTestId("add-series-button").click({ force: true });
+  it("should respect dashboard card visualization (metabase#21559)", () => {
+    cy.findByTestId("add-series-button").click({ force: true });
 
-      cy.findByTestId("add-series-modal").within(() => {
-        cy.findByText(q2Details.name).click();
+    cy.findByTestId("add-series-modal").within(() => {
+      cy.findByText(q2Details.name).click();
 
-        // wait for elements to appear inside modal
-        chartPathWithFillColor("#A989C5").should("have.length", 1);
-        chartPathWithFillColor("#88BF4D").should("have.length", 1);
+      // wait for elements to appear inside modal
+      chartPathWithFillColor("#A989C5").should("have.length", 1);
+      chartPathWithFillColor("#88BF4D").should("have.length", 1);
 
-        cy.button("Done").click();
-      });
+      cy.button("Done").click();
+    });
 
-      cy.findByTestId("add-series-modal").should("not.exist");
+    cy.findByTestId("add-series-modal").should("not.exist");
 
-      // Make sure visualization changed to bars
-      getDashboardCard(0).within(() => {
-        chartPathWithFillColor("#A989C5").should("have.length", 1);
-        chartPathWithFillColor("#88BF4D").should("have.length", 1);
-      });
+    // Make sure visualization changed to bars
+    getDashboardCard(0).within(() => {
+      chartPathWithFillColor("#A989C5").should("have.length", 1);
+      chartPathWithFillColor("#88BF4D").should("have.length", 1);
+    });
 
-      saveDashboard();
-      // Wait for "Edited a few seconds ago" to disappear because the whole
-      // dashboard re-renders after that!
-      cy.findByTestId("revision-history-button").should("not.be.visible");
+    saveDashboard();
+    // Wait for "Edited a few seconds ago" to disappear because the whole
+    // dashboard re-renders after that!
+    cy.findByTestId("revision-history-button").should("not.be.visible");
 
-      openAndAddEmailsToSubscriptions([
-        `${admin.first_name} ${admin.last_name}`,
-      ]);
+    openAndAddEmailsToSubscriptions([`${admin.first_name} ${admin.last_name}`]);
 
-      sendEmailAndAssert(email => {
-        expect(email.html).to.include("img"); // Bar chart is sent as img (inline attachment)
-        expect(email.html).not.to.include("80.52"); // Scalar displays its value in HTML
-      });
-    },
-  );
+    sendEmailAndAssert(email => {
+      expect(email.html).to.include("img"); // Bar chart is sent as img (inline attachment)
+      expect(email.html).not.to.include("80.52"); // Scalar displays its value in HTML
+    });
+  });
 });
 
 describe("issue 22524", () => {

--- a/e2e/test/scenarios/sharing/sharing-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/sharing-reproductions.cy.spec.js
@@ -366,6 +366,9 @@ describe("issue 21559", { tags: "@external" }, () => {
       chartPathWithFillColor("#88BF4D").should("have.length", 1);
 
       saveDashboard();
+      // Wait for "Edited a few seconds ago" to disappear because the whole
+      // dashboard re-renders after that!
+      cy.findByTestId("revision-history-button").should("not.be.visible");
 
       openAndAddEmailsToSubscriptions([
         `${admin.first_name} ${admin.last_name}`,


### PR DESCRIPTION
### What does this PR accomplish?
It fixes a flaky reproduction for #21559 by waiting for the dashboard to re-render.
It removes the flaky tag from this test.

### Example of a failure
https://github.com/metabase/metabase/actions/runs/10154937318/job/28081553208#step:12:399
![issue 21559 -- should respect dashboard card visualization (metabase#21559) (failed) (attempt 2)](https://github.com/user-attachments/assets/9982601b-3d96-4127-b67f-8673a18d3e42)

### Explanation
We can see from this screenshot that Cypress already clicked on the "subscriptions" icon, but the sidebar never opened. I am pretty convinced that this is due to the dashboard re-rendering after we hide "Edited a few seconds ago..." text below the dashboard title. In fact, this is the culprit behind many dashboard flakes.

### Solution
Wait until that "history text" disappears and only then try to click on elements. This might make this test one second slower, but it improves its resiliency.

### Additional Notes
This PR also improves some assertions by scoping them to the correct selectors.
And it also replaces deprecated Cypress custom commands with equivalent functional helpers.

### Stress-test
| burn ins| status | run |
|-|-|-|
| 10/10 | ✅ | https://github.com/metabase/metabase/actions/runs/10163092286 |
|100/100 | ✅ | https://github.com/metabase/metabase/actions/runs/10163186508|