### PR TITLE
do not run licenses step only when the value is true

### DIFF
--- a/bin/build/src/build.clj
+++ b/bin/build/src/build.clj
@@ -49,7 +49,7 @@
 (defn- build-licenses!
   [edition]
   {:pre [(#{:oss :ee} edition)]}
-  (when-not (env/env :skip-licenses)
+  (when-not (= (env/env :skip-licenses) "true")
     (u/step "Generate backend license information from jar files"
       (let [basis                     (b/create-basis {:project (u/filename u/project-root-directory "deps.edn")})
             output-filename           (u/filename u/project-root-directory


### PR DESCRIPTION
we need to explicitly compare env variable with `true` as false it treated as positive value