### PR TITLE
make search results filterable by concrete ids

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/cache/cache_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cache/cache_test.clj
@@ -76,6 +76,9 @@
             (is (=? {:data [{:model "database" :model_id (:id db)}]}
                     (mt/user-http-request :crowberto :get 200 "cache/" {}
                                           :model :database)))
+            (is (=? {:data [{:model "question" :model_id (:id card1)}]}
+                    (mt/user-http-request :crowberto :get 200 "cache/" {}
+                                          :model :question)))
             (is (=? {:data [{:model "dashboard" :model_id (:id dash1)}
                             {:model "question" :model_id (:id card1)}]}
                     (mt/user-http-request :crowberto :get 200 "cache/" {}

--- a/src/metabase/api/cache.clj
+++ b/src/metabase/api/cache.clj
@@ -7,6 +7,7 @@
    [metabase.models.cache-config :as cache-config]
    [metabase.public-settings.premium-features :as premium-features :refer [defenterprise]]
    [metabase.util.i18n :refer [tru trun]]
+   [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
 
@@ -80,10 +81,12 @@
   [:as {{:strs [model collection id]
          :or   {model "root"}}
         :query-params}]
-  {model      (ms/QueryVectorOf cache-config/CachingModel)
-   ;; note that `nil` in `collection` means all configurations not scoped to any particular collection
-   collection [:maybe ms/PositiveInt]
-   id         [:maybe ms/PositiveInt]}
+  {model      (mu/with (ms/QueryVectorOf cache-config/CachingModel)
+                       {:description "Type of model"})
+   collection (mu/with [:maybe ms/PositiveInt]
+                       {:description "Collection id to filter results. Returns everything if not supplied."})
+   id         (mu/with [:maybe ms/PositiveInt]
+                       {:description "Model id to get configuration for."})}
   (when (and (not (premium-features/enable-cache-granular-controls?))
              (not= model ["root"]))
     (throw (premium-features/ee-feature-error (tru "Granular Caching"))))

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -53,6 +53,7 @@
   - `last_edited_by`: search for items last edited by a specific user
   - `search_native_query`: set to true to search the content of native queries
   - `verified`: set to true to search for verified items only (requires Content Management or Official Collections premium feature)
+  - `ids`: search for items with those ids, works iff single value passed to `models`
 
   Note that not all item types support all filters, and the results will include only models that support the provided filters. For example:
   - The `created-by` filter supports dashboards, models, actions, and cards.
@@ -60,7 +61,7 @@
 
   A search query that has both filters applied will only return models and cards."
   [q archived created_at created_by table_db_id models last_edited_at last_edited_by
-   filter_items_in_personal_collection model_ancestors search_native_query verified]
+   filter_items_in_personal_collection model_ancestors search_native_query verified ids]
   {q                                   [:maybe ms/NonBlankString]
    archived                            [:maybe :boolean]
    table_db_id                         [:maybe ms/PositiveInt]
@@ -72,7 +73,8 @@
    last_edited_by                      [:maybe (ms/QueryVectorOf ms/PositiveInt)]
    model_ancestors                     [:maybe :boolean]
    search_native_query                 [:maybe true?]
-   verified                            [:maybe true?]}
+   verified                            [:maybe true?]
+   ids                                 [:maybe (ms/QueryVectorOf ms/PositiveInt)]}
   (api/check-valid-page-params mw.offset-paging/*limit* mw.offset-paging/*offset*)
   (let  [models-set           (if (seq models)
                                 (set models)
@@ -94,7 +96,8 @@
          :search-native-query                 search_native_query
          :search-string                       q
          :table-db-id                         table_db_id
-         :verified                            verified}))))
+         :verified                            verified
+         :ids                                 (set ids)}))))
 
 
 (api/define-routes)

--- a/src/metabase/models/cache_config.clj
+++ b/src/metabase/models/cache_config.clj
@@ -79,11 +79,13 @@
       {:left-join [:report_card      [:and
                                       [:= :model [:inline "question"]]
                                       [:= :model_id :report_card.id]
-                                      [:= :report_card.collection_id collection]]
+                                      (when collection
+                                        [:= :report_card.collection_id collection])]
                    :report_dashboard [:and
                                       [:= :model [:inline "dashboard"]]
                                       [:= :model_id :report_dashboard.id]
-                                      [:= :report_dashboard.collection_id collection]]]
+                                      (when collection
+                                        [:= :report_dashboard.collection_id collection])]]
        :where     [:case
                    [:= :model [:inline "question"]]  [:!= :report_card.id nil]
                    [:= :model [:inline "dashboard"]] [:!= :report_dashboard.id nil]

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -118,7 +118,8 @@
    [:search-native-query                 {:optional true} true?]
    [:table-db-id                         {:optional true} ms/PositiveInt]
    ;; true to search for verified items only, nil will return all items
-   [:verified                            {:optional true} true?]])
+   [:verified                            {:optional true} true?]
+   [:ids                                 {:optional true} [:set {:min 1} ms/PositiveInt]]])
 
 (def all-search-columns
   "All columns that will appear in the search results, and the types of those columns. The generated search query is a

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -22,7 +22,7 @@
    [metabase.search.util :as search.util]
    [metabase.util :as u]
    [metabase.util.honey-sql-2 :as h2x]
-   [metabase.util.i18n :refer [deferred-tru]]
+   [metabase.util.i18n :refer [tru deferred-tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
@@ -710,6 +710,7 @@
                  (some? search-native-query)                 (assoc :search-native-query search-native-query)
                  (some? verified)                            (assoc :verified verified)
                  (seq ids)                                   (assoc :ids ids))]
-    (when (seq ids)
-      (assert (= (count models) 1) "We can only retrieve by ids when you ask for a single model"))
+    (when (and (seq ids)
+               (not= (count models) 1))
+      (throw (ex-info (tru "Filtering by ids work only when you ask for a single model") {:status-code 400})))
     (assoc ctx :models (search.filter/search-context->applicable-models ctx))))


### PR DESCRIPTION
Cache admin needs an API where it can retrieve instances identified by ids. Our collection endpoint is not suitable since those items can be from different collections. Adding more data to cache API feels like too much code is necessary. So search seems like the best API for this.

I've also thought about adding kind of like nested-query-string API (so `ids=urlencoded(card=9&dashboard=10)`), but maybe that's adding too much complexity given that one page will generate only two queries max (one for cards and one for dashboards).

Also fixes a bug with cache listing where not supplying collection id would filter only for root collection.