### PR TITLE
ci: enable video recordings for failing cypress tests

### DIFF
--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 
 import {
@@ -95,6 +96,21 @@ const defaultConfig = {
       removeDirectory,
     });
 
+    // this is an official workaround to keep recordings of the failed specs only
+    // https://docs.cypress.io/guides/guides/screenshots-and-videos#Delete-videos-for-specs-without-failing-or-retried-tests
+    on("after:spec", (spec, results) => {
+      if (results && results.video) {
+        // Do we have failures for any retry attempts?
+        const failures = results.tests.some(test =>
+          test.attempts.some(attempt => attempt.state === "failed"),
+        );
+        if (!failures) {
+          // delete the video if the spec passed and no tests retried
+          fs.unlinkSync(results.video);
+        }
+      }
+    });
+
     /********************************************************************
      **                          CONFIG                                **
      ********************************************************************/
@@ -134,6 +150,9 @@ const defaultConfig = {
   specPattern: "e2e/test/**/*.cy.spec.{js,ts}",
   viewportHeight: 800,
   viewportWidth: 1280,
+  // enable video recording in run mode
+  video: true,
+  videoCompression: true,
 };
 
 const mainConfig = {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/46492

### Description

Enable cypress video recordings for failing tests only. Cypress doesn't allow to record video only for the failing test, os their official solution is to record everything and then remove everything you don't need 🤯 

video recording works only in "run" mode, `cypress open` records nothing

### How to verify

- change any spec to fail (e.g. `node ./e2e/runner/run_cypress_tests.js --spec e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js` and change something, so test fails - add `.only` to the test you've changed)
- run it locally in "run" mode (e.g. `node ./e2e/runner/run_cypress_tests.js --spec e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js`), make sure spec failed
- open mocha report (e.g. `open cypress/reports/mochareports/fail-dashboard-back-navigation.html`) and check if the video for your failed spec is available in the bottom of the page and it's playable
- verify that `cypress/videos` contains video of the failed spec only
<img width="680" alt="image" src="https://github.com/user-attachments/assets/0a4977db-0960-4b84-84a4-d455f20d5f7f">



### Demo

<img width="1254" alt="image" src="https://github.com/user-attachments/assets/d643e83b-15e7-4626-b1c6-17947322c927">