### PR TITLE
45003 entity picker recents context

### DIFF
--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -549,6 +549,24 @@ describe("scenarios > collection defaults", () => {
           children: ["Third collection"],
         });
       });
+
+      cy.log(
+        "the collection picker should show an error if we are unable to move a collection (metabase#40700)",
+      );
+      cy.intercept("PUT", `/api/collection/${THIRD_COLLECTION_ID}`, {
+        statusCode: 500,
+        body: { message: "Ryan said no" },
+      });
+      openCollectionMenu();
+      popover().findByText("Move").click();
+
+      entityPickerModal().within(() => {
+        entityPickerModalTab("Collections").click();
+        entityPickerModalItem(0, "Our analytics").click();
+        cy.button("Move").click();
+        cy.log("Entity picker should show an error message");
+        cy.findByText("Ryan said no").should("exist");
+      });
     });
 
     describe("bulk actions", () => {

--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -30,6 +30,7 @@ import {
   createQuestion,
   openNotebook,
   notebookButton,
+  shouldDisplayTabs,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -272,6 +273,20 @@ describe("scenarios > question > new", () => {
       entityPickerModalTab("Tables").click();
       cy.findByText("Orders").click();
     });
+
+    cy.log(
+      "The selected table should be saved and show in recents (metabase#45003)",
+    );
+
+    cy.findByRole("button", { name: /Orders/ }).click();
+    shouldDisplayTabs(["Recents", "Models", "Tables", "Saved questions"]);
+    entityPickerModalTab("Recents").click();
+    cy.findByRole("dialog", { name: "Pick your starting data" })
+      .findByRole("button", { name: /Orders/ })
+      .should("exist");
+    cy.findByRole("dialog", { name: "Pick your starting data" })
+      .findByRole("button", { name: /Close/ })
+      .click();
 
     cy.findByTestId("qb-header").within(() => {
       cy.findByText("Save").click();

--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -523,12 +523,30 @@ describe(
         type: "model",
       });
 
-      cy.visit("/question/new");
+      cy.intercept("POST", "/api/activity/recents").as("recents");
+
+      cy.visit("/question/notebook");
 
       entityPickerModal().within(() => {
         entityPickerModalTab("Saved questions").should("be.visible");
         entityPickerModalTab("Models").should("be.visible");
         entityPickerModalTab("Tables").should("be.visible");
+        entityPickerModalItem(1, "Orders Model").click();
+      });
+
+      cy.wait("@recents");
+
+      cy.button(/Orders Model/).click();
+
+      entityPickerModal().within(() => {
+        tabsShouldBe("Models", [
+          "Recents",
+          "Models",
+          "Tables",
+          "Saved questions",
+        ]);
+        entityPickerModalTab("Recents").click();
+        cy.findByTestId("result-item").should("contain.text", "Orders Model");
       });
     });
   },

--- a/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
@@ -123,12 +123,7 @@ describe("scenarios > notebook > data source", () => {
       openNotebook();
       cy.findByTestId("data-step-cell").should("have.text", "Reviews").click();
       entityPickerModal().within(() => {
-        tabsShouldBe("Tables", [
-          "Recents",
-          "Models",
-          "Tables",
-          "Saved questions",
-        ]);
+        tabsShouldBe("Tables", ["Models", "Tables", "Saved questions"]);
         // should not show databases step if there's only 1 database
         entityPickerModalLevel(0).should("not.exist");
         // should not show schema step if there's only 1 schema
@@ -142,12 +137,7 @@ describe("scenarios > notebook > data source", () => {
       openNotebook();
       cy.findByTestId("data-step-cell").should("have.text", "Orders").click();
       entityPickerModal().within(() => {
-        tabsShouldBe("Tables", [
-          "Recents",
-          "Models",
-          "Tables",
-          "Saved questions",
-        ]);
+        tabsShouldBe("Tables", ["Models", "Tables", "Saved questions"]);
         // should not show databases step if there's only 1 database
         entityPickerModalLevel(0).should("not.exist");
         // should not show schema step if there's only 1 schema

--- a/e2e/test/scenarios/question/saved.cy.spec.js
+++ b/e2e/test/scenarios/question/saved.cy.spec.js
@@ -20,8 +20,6 @@ import {
   entityPickerModal,
   collectionOnTheGoModal,
   tableHeaderClick,
-  entityPickerModalItem,
-  entityPickerModalTab,
 } from "e2e/support/helpers";
 
 describe("scenarios > question > saved", () => {
@@ -296,34 +294,6 @@ describe("scenarios > question > saved", () => {
       // scrollHeight: height of the text content, including content not visible on the screen
       const heightDifference = $el[0].clientHeight - $el[0].scrollHeight;
       expect(heightDifference).to.eq(0);
-    });
-  });
-
-  it("should allow you to move a question, and show you an error if the api request fails", () => {
-    visitQuestion(ORDERS_QUESTION_ID);
-    openQuestionActions();
-    popover().findByText("Move").click();
-    entityPickerModal().within(() => {
-      entityPickerModalItem(1, "First collection").click();
-      cy.button("Move").click();
-    });
-
-    cy.findByTestId("app-bar")
-      .findByRole("link", { name: /First collection/ })
-      .should("exist");
-
-    cy.intercept("PUT", `/api/card/${ORDERS_QUESTION_ID}`, {
-      statusCode: 500,
-      body: { message: "Ryan said no" },
-    });
-
-    openQuestionActions();
-    popover().findByText("Move").click();
-
-    entityPickerModal().within(() => {
-      entityPickerModalTab("Collections").click();
-      entityPickerModalItem(0, "Our analytics").click();
-      cy.button("Move").click();
     });
   });
 });

--- a/e2e/test/scenarios/question/saved.cy.spec.js
+++ b/e2e/test/scenarios/question/saved.cy.spec.js
@@ -20,6 +20,8 @@ import {
   entityPickerModal,
   collectionOnTheGoModal,
   tableHeaderClick,
+  entityPickerModalItem,
+  entityPickerModalTab,
 } from "e2e/support/helpers";
 
 describe("scenarios > question > saved", () => {
@@ -294,6 +296,34 @@ describe("scenarios > question > saved", () => {
       // scrollHeight: height of the text content, including content not visible on the screen
       const heightDifference = $el[0].clientHeight - $el[0].scrollHeight;
       expect(heightDifference).to.eq(0);
+    });
+  });
+
+  it("should allow you to move a question, and show you an error if the api request fails", () => {
+    visitQuestion(ORDERS_QUESTION_ID);
+    openQuestionActions();
+    popover().findByText("Move").click();
+    entityPickerModal().within(() => {
+      entityPickerModalItem(1, "First collection").click();
+      cy.button("Move").click();
+    });
+
+    cy.findByTestId("app-bar")
+      .findByRole("link", { name: /First collection/ })
+      .should("exist");
+
+    cy.intercept("PUT", `/api/card/${ORDERS_QUESTION_ID}`, {
+      statusCode: 500,
+      body: { message: "Ryan said no" },
+    });
+
+    openQuestionActions();
+    popover().findByText("Move").click();
+
+    entityPickerModal().within(() => {
+      entityPickerModalTab("Collections").click();
+      entityPickerModalItem(0, "Our analytics").click();
+      cy.button("Move").click();
     });
   });
 });

--- a/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
@@ -7,6 +7,7 @@ import type { RecentItem, SearchModel, SearchResult } from "metabase-types/api";
 
 import type { EntityTab } from "../../EntityPicker";
 import { EntityPickerModal, defaultOptions } from "../../EntityPicker";
+import { useLogRecentItem } from "../../EntityPicker/hooks/use-log-recent-item";
 import type {
   CollectionPickerItem,
   CollectionPickerOptions,
@@ -54,6 +55,16 @@ export const CollectionPickerModal = ({
     null,
   );
 
+  const { handleLogRecentItem } = useLogRecentItem();
+
+  const handleChange = useCallback(
+    (item: CollectionPickerValueItem) => {
+      onChange(item);
+      handleLogRecentItem(item);
+    },
+    [onChange, handleLogRecentItem],
+  );
+
   const [
     isCreateDialogOpen,
     { turnOn: openCreateDialog, turnOff: closeCreateDialog },
@@ -68,15 +79,15 @@ export const CollectionPickerModal = ({
       if (options.hasConfirmButtons) {
         setSelectedItem(item);
       } else if (canSelectItem(item)) {
-        await onChange(item);
+        await handleChange(item);
       }
     },
-    [onChange, options],
+    [handleChange, options],
   );
 
   const handleConfirm = async () => {
     if (selectedItem && canSelectItem(selectedItem)) {
-      await onChange(selectedItem);
+      await handleChange(selectedItem);
     }
   };
 

--- a/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
@@ -55,14 +55,14 @@ export const CollectionPickerModal = ({
     null,
   );
 
-  const { handleLogRecentItem } = useLogRecentItem();
+  const { tryLogRecentItem } = useLogRecentItem();
 
   const handleChange = useCallback(
     (item: CollectionPickerValueItem) => {
       onChange(item);
-      handleLogRecentItem(item);
+      tryLogRecentItem(item);
     },
-    [onChange, handleLogRecentItem],
+    [onChange, tryLogRecentItem],
   );
 
   const [
@@ -75,19 +75,19 @@ export const CollectionPickerModal = ({
   }>();
 
   const handleItemSelect = useCallback(
-    async (item: CollectionPickerItem) => {
+    (item: CollectionPickerItem) => {
       if (options.hasConfirmButtons) {
         setSelectedItem(item);
       } else if (canSelectItem(item)) {
-        await handleChange(item);
+        handleChange(item);
       }
     },
     [handleChange, options],
   );
 
-  const handleConfirm = async () => {
+  const handleConfirm = () => {
     if (selectedItem && canSelectItem(selectedItem)) {
-      await handleChange(selectedItem);
+      handleChange(selectedItem);
     }
   };
 

--- a/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
@@ -58,8 +58,8 @@ export const CollectionPickerModal = ({
   const { tryLogRecentItem } = useLogRecentItem();
 
   const handleChange = useCallback(
-    (item: CollectionPickerValueItem) => {
-      onChange(item);
+    async (item: CollectionPickerValueItem) => {
+      await onChange(item);
       tryLogRecentItem(item);
     },
     [onChange, tryLogRecentItem],
@@ -75,19 +75,19 @@ export const CollectionPickerModal = ({
   }>();
 
   const handleItemSelect = useCallback(
-    (item: CollectionPickerItem) => {
+    async (item: CollectionPickerItem) => {
       if (options.hasConfirmButtons) {
         setSelectedItem(item);
       } else if (canSelectItem(item)) {
-        handleChange(item);
+        await handleChange(item);
       }
     },
     [handleChange, options],
   );
 
-  const handleConfirm = () => {
+  const handleConfirm = async () => {
     if (selectedItem && canSelectItem(selectedItem)) {
-      handleChange(selectedItem);
+      await handleChange(selectedItem);
     }
   };
 

--- a/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPickerModal.tsx
+++ b/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPickerModal.tsx
@@ -11,6 +11,7 @@ import {
   EntityPickerModal,
   defaultOptions as defaultEntityPickerOptions,
 } from "../../EntityPicker";
+import { useLogRecentItem } from "../../EntityPicker/hooks/use-log-recent-item";
 import type {
   DashboardPickerItem,
   DashboardPickerOptions,
@@ -66,6 +67,16 @@ export const DashboardPickerModal = ({
     canSelectItem(value) ? value : null,
   );
 
+  const { handleLogRecentItem } = useLogRecentItem();
+
+  const handleOnChange = useCallback(
+    (item: DashboardPickerValueItem) => {
+      onChange(item);
+      handleLogRecentItem(item);
+    },
+    [onChange, handleLogRecentItem],
+  );
+
   const [
     isCreateDialogOpen,
     { turnOn: openCreateDialog, turnOff: closeCreateDialog },
@@ -80,15 +91,15 @@ export const DashboardPickerModal = ({
       if (options.hasConfirmButtons) {
         setSelectedItem(item);
       } else if (canSelectItem(item)) {
-        onChange(item);
+        handleOnChange(item);
       }
     },
-    [onChange, options],
+    [handleOnChange, options],
   );
 
   const handleConfirm = () => {
     if (selectedItem && canSelectItem(selectedItem)) {
-      onChange(selectedItem);
+      handleOnChange(selectedItem);
     }
   };
 

--- a/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPickerModal.tsx
+++ b/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPickerModal.tsx
@@ -67,14 +67,14 @@ export const DashboardPickerModal = ({
     canSelectItem(value) ? value : null,
   );
 
-  const { handleLogRecentItem } = useLogRecentItem();
+  const { tryLogRecentItem } = useLogRecentItem();
 
   const handleOnChange = useCallback(
     (item: DashboardPickerValueItem) => {
       onChange(item);
-      handleLogRecentItem(item);
+      tryLogRecentItem(item);
     },
-    [onChange, handleLogRecentItem],
+    [onChange, tryLogRecentItem],
   );
 
   const [

--- a/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
+++ b/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
@@ -71,7 +71,7 @@ export const DataPickerModal = ({
     databaseId,
   });
 
-  const { handleLogRecentItem } = useLogRecentItem();
+  const { tryLogRecentItem } = useLogRecentItem();
 
   const modelsShouldShowItem = useMemo(() => {
     return createShouldShowItem(["dataset"], databaseId);
@@ -111,10 +111,10 @@ export const DataPickerModal = ({
       const id =
         item.model === "table" ? item.id : getQuestionVirtualTableId(item.id);
       onChange(id);
-      handleLogRecentItem(item);
+      tryLogRecentItem(item);
       onClose();
     },
-    [onChange, onClose, handleLogRecentItem],
+    [onChange, onClose, tryLogRecentItem],
   );
 
   const handleCardChange = useCallback(

--- a/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
+++ b/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
@@ -124,9 +124,10 @@ export const DataPickerModal = ({
       }
 
       onChange(getQuestionVirtualTableId(item.id));
+      tryLogRecentItem(item);
       onClose();
     },
-    [onChange, onClose],
+    [onChange, onClose, tryLogRecentItem],
   );
 
   const tabs: EntityTab<NotebookDataPickerValueItem["model"]>[] = [

--- a/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
+++ b/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
@@ -12,6 +12,7 @@ import type {
 
 import type { EntityTab } from "../../EntityPicker";
 import { EntityPickerModal, defaultOptions } from "../../EntityPicker";
+import { useLogRecentItem } from "../../EntityPicker/hooks/use-log-recent-item";
 import type { QuestionPickerItem } from "../../QuestionPicker";
 import { QuestionPicker } from "../../QuestionPicker";
 import { useAvailableData } from "../hooks";
@@ -70,6 +71,8 @@ export const DataPickerModal = ({
     databaseId,
   });
 
+  const { handleLogRecentItem } = useLogRecentItem();
+
   const modelsShouldShowItem = useMemo(() => {
     return createShouldShowItem(["dataset"], databaseId);
   }, [databaseId]);
@@ -108,9 +111,10 @@ export const DataPickerModal = ({
       const id =
         item.model === "table" ? item.id : getQuestionVirtualTableId(item.id);
       onChange(id);
+      handleLogRecentItem(item);
       onClose();
     },
-    [onChange, onClose],
+    [onChange, onClose, handleLogRecentItem],
   );
 
   const handleCardChange = useCallback(
@@ -204,6 +208,7 @@ export const DataPickerModal = ({
       title={title}
       onClose={onClose}
       onItemSelect={handleChange}
+      recentsContext={["selections"]}
     />
   );
 };

--- a/frontend/src/metabase/common/components/EntityPicker/hooks/use-log-recent-item.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/hooks/use-log-recent-item.tsx
@@ -1,0 +1,27 @@
+import { useCallback } from "react";
+
+import { useLogRecentItemMutation } from "metabase/api";
+import { isLoggableActivityModel } from "metabase-types/api";
+
+import type { CollectionPickerItem } from "../../CollectionPicker";
+import type { NotebookDataPickerValueItem } from "../../DataPicker";
+
+export const useLogRecentItem = () => {
+  const [logRecentItem] = useLogRecentItemMutation();
+
+  const handleLogRecentItem = useCallback(
+    (item: CollectionPickerItem | NotebookDataPickerValueItem) => {
+      if (item && isLoggableActivityModel(item)) {
+        logRecentItem({
+          model_id: item.id,
+          model: item.model,
+        });
+      }
+    },
+    [logRecentItem],
+  );
+
+  return {
+    handleLogRecentItem,
+  };
+};

--- a/frontend/src/metabase/common/components/EntityPicker/hooks/use-log-recent-item.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/hooks/use-log-recent-item.tsx
@@ -9,9 +9,9 @@ import type { NotebookDataPickerValueItem } from "../../DataPicker";
 export const useLogRecentItem = () => {
   const [logRecentItem] = useLogRecentItemMutation();
 
-  const handleLogRecentItem = useCallback(
+  const tryLogRecentItem = useCallback(
     (item: CollectionPickerItem | NotebookDataPickerValueItem) => {
-      if (item && isLoggableActivityModel(item)) {
+      if (isLoggableActivityModel(item)) {
         logRecentItem({
           model_id: item.id,
           model: item.model,
@@ -22,6 +22,6 @@ export const useLogRecentItem = () => {
   );
 
   return {
-    handleLogRecentItem,
+    tryLogRecentItem,
   };
 };

--- a/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPickerModal.tsx
+++ b/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPickerModal.tsx
@@ -7,6 +7,7 @@ import {
   EntityPickerModal,
   defaultOptions as defaultEntityPickerOptions,
 } from "../../EntityPicker";
+import { useLogRecentItem } from "../../EntityPicker/hooks/use-log-recent-item";
 import type {
   QuestionPickerItem,
   QuestionPickerOptions,
@@ -58,21 +59,30 @@ export const QuestionPickerModal = ({
   const [selectedItem, setSelectedItem] = useState<QuestionPickerItem | null>(
     null,
   );
+  const { handleLogRecentItem } = useLogRecentItem();
+
+  const handleOnChange = useCallback(
+    (item: QuestionPickerValueItem) => {
+      onChange(item);
+      handleLogRecentItem(item);
+    },
+    [onChange, handleLogRecentItem],
+  );
 
   const handleItemSelect = useCallback(
     (item: QuestionPickerItem) => {
       if (options.hasConfirmButtons) {
         setSelectedItem(item);
       } else if (canSelectItem(item)) {
-        onChange(item);
+        handleOnChange(item);
       }
     },
-    [onChange, options],
+    [handleOnChange, options],
   );
 
   const handleConfirm = () => {
     if (selectedItem && canSelectItem(selectedItem)) {
-      onChange(selectedItem);
+      handleOnChange(selectedItem);
     }
   };
 

--- a/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPickerModal.tsx
+++ b/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPickerModal.tsx
@@ -59,14 +59,14 @@ export const QuestionPickerModal = ({
   const [selectedItem, setSelectedItem] = useState<QuestionPickerItem | null>(
     null,
   );
-  const { handleLogRecentItem } = useLogRecentItem();
+  const { tryLogRecentItem } = useLogRecentItem();
 
   const handleOnChange = useCallback(
     (item: QuestionPickerValueItem) => {
       onChange(item);
-      handleLogRecentItem(item);
+      tryLogRecentItem(item);
     },
-    [onChange, handleLogRecentItem],
+    [onChange, tryLogRecentItem],
   );
 
   const handleItemSelect = useCallback(

--- a/frontend/src/metabase/containers/MoveModal.tsx
+++ b/frontend/src/metabase/containers/MoveModal.tsx
@@ -68,7 +68,7 @@ export const MoveModal = ({
         id: initialCollectionId,
         model: "collection",
       }}
-      onChange={async newCollection => await onMove({ id: newCollection.id })}
+      onChange={newCollection => onMove({ id: newCollection.id })}
       options={{
         showSearch: true,
         allowCreateNew: true,

--- a/frontend/src/metabase/containers/MoveModal.tsx
+++ b/frontend/src/metabase/containers/MoveModal.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -5,6 +6,7 @@ import type { OnMoveWithOneItem } from "metabase/collections/types";
 import { isItemCollection } from "metabase/collections/utils";
 import {
   CollectionPickerModal,
+  type CollectionPickerValueItem,
   type CollectionPickerItem,
 } from "metabase/common/components/CollectionPicker";
 import type {
@@ -61,6 +63,12 @@ export const MoveModal = ({
   const searchResultFilter = makeSearchResultFilter(shouldDisableItem);
   const recentFilter = makeRecentFilter(shouldDisableItem);
 
+  const handleMove = useCallback(
+    async (newCollection: CollectionPickerValueItem) =>
+      await onMove({ id: newCollection.id }),
+    [onMove],
+  );
+
   return (
     <CollectionPickerModal
       title={title}
@@ -68,7 +76,7 @@ export const MoveModal = ({
         id: initialCollectionId,
         model: "collection",
       }}
-      onChange={newCollection => onMove({ id: newCollection.id })}
+      onChange={handleMove}
       options={{
         showSearch: true,
         allowCreateNew: true,

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.unit.spec.tsx
@@ -25,7 +25,7 @@ function setup({ step = createMockNotebookStep() }: SetupOpts = {}) {
 
   setupDatabasesEndpoints([createSampleDatabase()]);
   setupSearchEndpoints([]);
-  setupRecentViewsAndSelectionsEndpoints([]);
+  setupRecentViewsAndSelectionsEndpoints([], "context=selections");
 
   renderWithProviders(
     <NotebookStep

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.unit.spec.tsx
@@ -25,7 +25,7 @@ function setup({ step = createMockNotebookStep() }: SetupOpts = {}) {
 
   setupDatabasesEndpoints([createSampleDatabase()]);
   setupSearchEndpoints([]);
-  setupRecentViewsAndSelectionsEndpoints([], "context=selections");
+  setupRecentViewsAndSelectionsEndpoints([], ["selections"]);
 
   renderWithProviders(
     <NotebookStep

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.unit.spec.tsx
@@ -58,7 +58,7 @@ const setup = (
   const updateQuery = jest.fn();
   setupDatabasesEndpoints([createSampleDatabase()]);
   setupSearchEndpoints([]);
-  setupRecentViewsAndSelectionsEndpoints([], "context=selections");
+  setupRecentViewsAndSelectionsEndpoints([], ["selections"]);
 
   renderWithProviders(
     <DataStep

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.unit.spec.tsx
@@ -58,7 +58,7 @@ const setup = (
   const updateQuery = jest.fn();
   setupDatabasesEndpoints([createSampleDatabase()]);
   setupSearchEndpoints([]);
-  setupRecentViewsAndSelectionsEndpoints([]);
+  setupRecentViewsAndSelectionsEndpoints([], "context=selections");
 
   renderWithProviders(
     <DataStep

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
@@ -173,7 +173,7 @@ function setup({
 
   setupDatabasesEndpoints(DATABASES);
   setupSearchEndpoints(searchItems);
-  setupRecentViewsAndSelectionsEndpoints(recentItems, "context=selections");
+  setupRecentViewsAndSelectionsEndpoints(recentItems, ["selections"]);
 
   function Wrapper() {
     const [query, setQuery] = useState(step.query);

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
@@ -173,7 +173,7 @@ function setup({
 
   setupDatabasesEndpoints(DATABASES);
   setupSearchEndpoints(searchItems);
-  setupRecentViewsAndSelectionsEndpoints(recentItems);
+  setupRecentViewsAndSelectionsEndpoints(recentItems, "context=selections");
 
   function Wrapper() {
     const [query, setQuery] = useState(step.query);

--- a/frontend/src/metabase/timelines/common/components/MoveTimelineModal/MoveTimelineModal.tsx
+++ b/frontend/src/metabase/timelines/common/components/MoveTimelineModal/MoveTimelineModal.tsx
@@ -33,8 +33,8 @@ const MoveTimelineModal = ({
       value={{ id: timeline.collection_id ?? "root", model: "collection" }}
       title={t`Move ${getTimelineName(timeline)}`}
       onClose={onClose}
-      onChange={async newCollection => {
-        await handleSubmit(newCollection.id);
+      onChange={newCollection => {
+        handleSubmit(newCollection.id);
       }}
       options={{
         confirmButtonText: t`Move`,

--- a/frontend/src/metabase/timelines/common/components/MoveTimelineModal/MoveTimelineModal.tsx
+++ b/frontend/src/metabase/timelines/common/components/MoveTimelineModal/MoveTimelineModal.tsx
@@ -1,7 +1,10 @@
 import { useCallback } from "react";
 import { t } from "ttag";
 
-import { CollectionPickerModal } from "metabase/common/components/CollectionPicker";
+import {
+  CollectionPickerModal,
+  type CollectionPickerValueItem,
+} from "metabase/common/components/CollectionPicker";
 import { getTimelineName } from "metabase/lib/timelines";
 import type { CollectionId, Timeline } from "metabase-types/api";
 
@@ -20,7 +23,7 @@ const MoveTimelineModal = ({
   onClose,
 }: MoveTimelineModalProps): JSX.Element => {
   const handleSubmit = useCallback(
-    async (collectionId: CollectionId) => {
+    async ({ id: collectionId }: CollectionPickerValueItem) => {
       await onSubmit(timeline, collectionId);
       onSubmitSuccess?.();
       onClose?.();
@@ -33,9 +36,7 @@ const MoveTimelineModal = ({
       value={{ id: timeline.collection_id ?? "root", model: "collection" }}
       title={t`Move ${getTimelineName(timeline)}`}
       onClose={onClose}
-      onChange={newCollection => {
-        handleSubmit(newCollection.id);
-      }}
+      onChange={handleSubmit}
       options={{
         confirmButtonText: t`Move`,
         showPersonalCollections: true,

--- a/frontend/test/__support__/server-mocks/activity.ts
+++ b/frontend/test/__support__/server-mocks/activity.ts
@@ -15,6 +15,8 @@ export function setupRecentViewsAndSelectionsEndpoints(
   fetchMock.get(url => url.endsWith(`/api/activity/recents?${context}`), {
     recents: recentItems,
   });
+
+  fetchMock.post("path:/api/activity/recents", 200);
 }
 
 export function setupPopularItemsEndpoints(popularItems: PopularItem[]) {

--- a/frontend/test/__support__/server-mocks/activity.ts
+++ b/frontend/test/__support__/server-mocks/activity.ts
@@ -10,14 +10,11 @@ export function setupRecentViewsEndpoints(recentItems: RecentItem[]) {
 
 export function setupRecentViewsAndSelectionsEndpoints(
   recentItems: RecentItem[],
+  context: string = "context=selections&context=views",
 ) {
-  fetchMock.get(
-    url =>
-      url.endsWith("/api/activity/recents?context=selections&context=views"),
-    {
-      recents: recentItems,
-    },
-  );
+  fetchMock.get(url => url.endsWith(`/api/activity/recents?${context}`), {
+    recents: recentItems,
+  });
 }
 
 export function setupPopularItemsEndpoints(popularItems: PopularItem[]) {

--- a/frontend/test/__support__/server-mocks/activity.ts
+++ b/frontend/test/__support__/server-mocks/activity.ts
@@ -1,6 +1,12 @@
 import fetchMock from "fetch-mock";
+import querystring from "querystring";
 
-import type { PopularItem, RecentItem, Dashboard } from "metabase-types/api";
+import type {
+  PopularItem,
+  RecentItem,
+  Dashboard,
+  RecentContexts,
+} from "metabase-types/api";
 
 export function setupRecentViewsEndpoints(recentItems: RecentItem[]) {
   fetchMock.get(/\/api\/activity\/recents\?*/, {
@@ -10,11 +16,17 @@ export function setupRecentViewsEndpoints(recentItems: RecentItem[]) {
 
 export function setupRecentViewsAndSelectionsEndpoints(
   recentItems: RecentItem[],
-  context: string = "context=selections&context=views",
+  context: RecentContexts[] = ["selections", "views"],
 ) {
-  fetchMock.get(url => url.endsWith(`/api/activity/recents?${context}`), {
-    recents: recentItems,
-  });
+  fetchMock.get(
+    url =>
+      url.endsWith(
+        `/api/activity/recents?${querystring.stringify({ context })}`,
+      ),
+    {
+      recents: recentItems,
+    },
+  );
 
   fetchMock.post("path:/api/activity/recents", 200);
 }

--- a/src/metabase/models/recent_views.clj
+++ b/src/metabase/models/recent_views.clj
@@ -80,14 +80,14 @@
 
 (def rv-models
   "These are models for which we will retrieve recency."
-  [:card :model ;; n.b.: `:card` and `:model` are stored in recent_views as "card", and a join with report_card is
-                ;; needed to distinguish between them.
+  [:card :dataset ;; n.b.: `:card` and `:model` are stored in recent_views as "card", and a join with report_card is
+                  ;; needed to distinguish between them.
    :dashboard :table :collection])
 
 (mu/defn rv-model->model
   "Given a rv-model, returns the toucan model identifier for it."
   [rvm :- (into [:enum] rv-models)]
-  (get {:model      :model/Card
+  (get {:dataset    :model/Card
         :card       :model/Card
         :dashboard  :model/Dashboard
         :table      :model/Table
@@ -100,13 +100,13 @@
                     {:select [:rv.id]
                      :from [[:recent_views :rv]]
                      :where [:and
-                             [:= :rv.model (get {:model "card"} model (name model))]
+                             [:= :rv.model (get {:dataset "card"} model (name model))]
                              [:= :rv.user_id user-id]
                              [:= :rv.context (h2x/literal (name context))]
-                             (when (#{:card :model} model) ;; TODO add metric
+                             (when (#{:card :dataset} model) ;; TODO add metric
                                [:= :rc.type (cond (= model :card) (h2x/literal "question")
                                                   ;; TODO add metric
-                                                  (= model :model) (h2x/literal "model"))])]
+                                                  (= model :dataset) (h2x/literal "model"))])]
                      :left-join [[:report_card :rc]
                                  [:and
                                   [:= :rc.id :rv.model_id]


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/45003

### Description
PR changes the request that the data picker makes to fetch recents, but also moves the selection logging to the individual pickers so that it works for both picker modals with and without confirmation buttons.

### How to verify
1. New question -> Sample Dataset -> Pick a table
2. Re-open the data picker, and you should see the table you just picked in the recents tab of the data picker

### Demo
![chrome_LfFKEElMXW](https://github.com/user-attachments/assets/08224b42-0426-483c-ac6c-c306e0331595)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
