### PR TITLE
fix db connection form icons

### DIFF
--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -28,6 +28,10 @@ export function modal() {
   return cy.get([MODAL_SELECTOR, LEGACY_MODAL_SELECTOR].join(","));
 }
 
+export function tooltip() {
+  return cy.get(".emotion-Tooltip-tooltip");
+}
+
 export function entityPickerModal() {
   return cy.findByTestId("entity-picker-modal");
 }

--- a/e2e/test/scenarios/admin/databases.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases.cy.spec.js
@@ -15,6 +15,7 @@ import {
   isEE,
   setTokenFeatures,
   modal,
+  tooltip,
 } from "e2e/support/helpers";
 import { createSegment } from "e2e/support/helpers/e2e-table-metadata-helpers";
 
@@ -148,6 +149,21 @@ describe("admin > database > add", () => {
           cy.findByLabelText(
             "Never, I'll do this manually if I need to",
           ).should("have.attr", "aria-selected", "true");
+
+          // make sure tooltips behave as expected
+          cy.findByLabelText("Host").parent().icon("info").realHover();
+        });
+
+        tooltip()
+          .findByText(/your databases ip address/i)
+          .should("be.visible");
+
+        cy.findByTestId("database-form").within(() => {
+          cy.findByLabelText("Port")
+            .parent()
+            .within(() => {
+              cy.icon("info").should("not.exist");
+            });
 
           // make sure fields needed to connect to the database are properly trimmed (metabase#12972)
           typeAndBlurUsingLabel("Display name", "QA Postgres12");

--- a/frontend/src/metabase/databases/components/DatabaseDetailField/DatabaseDetailField.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseDetailField/DatabaseDetailField.tsx
@@ -73,7 +73,7 @@ const getFieldProps = (field: EngineField, override?: EngineFieldOverride) => {
 
 const getInputProps = (field: EngineField) => {
   return {
-    rightIcon: field["helper-text"] ? "info" : undefined,
+    rightIcon: field["helper-text"] ? ("info" as const) : undefined,
     rightIconTooltip: field["helper-text"],
   };
 };

--- a/frontend/src/metabase/databases/components/DatabaseDetailField/DatabaseDetailField.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseDetailField/DatabaseDetailField.tsx
@@ -4,7 +4,6 @@ import FormNumericInput from "metabase/core/components/FormNumericInput";
 import FormSelect from "metabase/core/components/FormSelect";
 import FormTextArea from "metabase/core/components/FormTextArea";
 import FormToggle from "metabase/core/components/FormToggle";
-import type { IconName } from "metabase/ui";
 import type { EngineField } from "metabase-types/api";
 
 import { FIELD_OVERRIDES } from "../../constants";
@@ -74,8 +73,7 @@ const getFieldProps = (field: EngineField, override?: EngineFieldOverride) => {
 
 const getInputProps = (field: EngineField) => {
   return {
-    infoTooltip: field["helper-text"],
-    rightIcon: (field["helper-text"] as unknown as IconName) ?? "info",
+    rightIcon: field["helper-text"] ? "info" : undefined,
     rightIconTooltip: field["helper-text"],
   };
 };


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/46088

### Description

Fixes icons and tooltips in database connection forms. Also [deduplicates the double icon/tooltip situation](https://metaboat.slack.com/archives/C064EB1UE5P/p1722361463738979).

Before | After
--- | ---
![Screen Shot 2024-07-30 at 12 14 37 PM](https://github.com/user-attachments/assets/ec33a701-9a14-4437-b98f-742f351d4bb3) | ![Screen Shot 2024-07-30 at 12 13 58 PM](https://github.com/user-attachments/assets/a4daeb24-10dd-4ebd-8d69-14d1ac0b5393)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
