### PR TITLE
docs - correct tar command

### DIFF
--- a/docs/installation-and-operation/serialization.md
+++ b/docs/installation-and-operation/serialization.md
@@ -584,7 +584,7 @@ To keep file sizes over the network under control, both the `export` and `import
 To compress a directory (e.g., a directory named `metabase_data`).
 
 ```sh
-tar -czf  metabase_data
+tar -czf  metabase_data.tgz metabase_data
 ```
 
 #### Extract a directory


### PR DESCRIPTION
Updates `tar` command. `tar` expects a name for the file (`<archive-filename>`).