### PR TITLE
fix viz settings not persisted during question edit

### DIFF
--- a/frontend/src/metabase/static-viz/components/ComboChart/settings.ts
+++ b/frontend/src/metabase/static-viz/components/ComboChart/settings.ts
@@ -134,7 +134,7 @@ export const computeStaticComboChartSettings = (
   fillWithDefaultValue(
     settings,
     "graph.metrics",
-    getDefaultMetrics(rawSeries),
+    getDefaultMetrics(rawSeries, settings),
     areDimensionsAndMetricsValid,
   );
 

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -144,7 +144,7 @@ export const GRAPH_DATA_SETTINGS = {
     widget: "fields",
     isValid: (series, vizSettings) =>
       getAreDimensionsAndMetricsValid(series, vizSettings),
-    getDefault: series => getDefaultMetrics(series),
+    getDefault: (series, vizSettings) => getDefaultMetrics(series, vizSettings),
     persistDefault: true,
     getProps: ([{ card, data }], vizSettings, _onChange, extra) => {
       const options = data.cols

--- a/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
@@ -54,14 +54,34 @@ export function getDefaultDimensions(
   rawSeries: RawSeries,
   settings: ComputedVisualizationSettings,
 ) {
-  return preserveExistingColumnsOrder(
-    settings["graph.dimensions"] ?? [],
-    getDefaultColumns(rawSeries).dimensions,
-  );
+  const prevDimensions = settings["graph.dimensions"] ?? [];
+  const defaultDimensions = getDefaultColumns(rawSeries).dimensions;
+  if (
+    prevDimensions.length > 0 &&
+    defaultDimensions.length > 0 &&
+    defaultDimensions[0] == null
+  ) {
+    return prevDimensions;
+  }
+
+  return preserveExistingColumnsOrder(prevDimensions, defaultDimensions);
 }
 
-export function getDefaultMetrics(rawSeries: RawSeries) {
-  return getDefaultColumns(rawSeries).metrics;
+export function getDefaultMetrics(
+  rawSeries: RawSeries,
+  settings: ComputedVisualizationSettings,
+) {
+  const prevMetrics = settings["graph.metrics"] ?? [];
+  const defaultMetrics = getDefaultColumns(rawSeries).metrics;
+  if (
+    prevMetrics.length > 0 &&
+    defaultMetrics.length > 0 &&
+    defaultMetrics[0] == null
+  ) {
+    return prevMetrics;
+  }
+
+  return defaultMetrics;
 }
 
 export const STACKABLE_SERIES_DISPLAY_TYPES = new Set(["area", "bar"]);


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/41276

### Description

We used `getDefaultColumns` to compute the default `graph.dimensions` and `graph.metrics` settings. The problem this was that `getDefaultColumns` returns `null` for both metrics and dimensions with the dataset has 0 rows. The dataset will have 0 rows when a required filter value is missing, so saving the question in that state will cause `graph.dimensions` and `graph.metrics` to both be overwritten with `[null]`.

The solution is to first check if `getDefaultColumns` returns `null` for the dimension/metric columns. If it does return `null`, and there is an existing value for `graph.dimensions` or `graph.metrics`, use the existing value instead in order to preserve the setting.

### How to verify

1. Create a native question with a filter needed in the query.
2. Save the question as a line chart with selected dimension and metric columns.
3. Remove the filter value, run the query (should error), edit the question by changing a filter name, then save again.
4. Re-add the filter value, the line chart should appear again with the same dimension and metric columns.

### Demo

**Before**

https://github.com/user-attachments/assets/f9843228-4113-4a75-81f7-c035549e7157

**After**

https://github.com/user-attachments/assets/56e251d2-b978-48d6-85fd-f88325636896

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
