### PR TITLE
Backend Dependency Bump for 52

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -8,28 +8,28 @@
                                              :exclusions  [org.clojure/clojure
                                                            org.clojure/clojurescript]}
   amalloy/ring-gzip-middleware              {:mvn/version "0.1.4"}              ; Ring middleware to GZIP responses if client can handle it
-  babashka/fs                               {:mvn/version "0.5.20"}             ; Portable filesystem operations
-  bigml/histogram                           {:mvn/version "4.1.4"               ; Histogram data structure
+  babashka/fs                               {:mvn/version "0.5.22"}             ; Portable filesystem operations
+  bigml/histogram                           {:mvn/version "5.0.0"               ; Histogram data structure
                                              :exclusions  [junit/junit]}
-  buddy/buddy-core                          {:mvn/version "1.11.423"            ; various cryptographic functions
+  buddy/buddy-core                          {:mvn/version "1.12.0-430"          ; various cryptographic functions
                                              :exclusions  [commons-codec/commons-codec
                                                            org.bouncycastle/bcpkix-jdk15on
                                                            org.bouncycastle/bcprov-jdk15on
                                                            org.bouncycastle/bcpkix-jdk18on
                                                            org.bouncycastle/bcprov-jdk18on]}
-  buddy/buddy-sign                          {:mvn/version "3.5.351"}            ; JSON Web Tokens; High-Level message signing library
+  buddy/buddy-sign                          {:mvn/version "3.6.1-359"}          ; JSON Web Tokens; High-Level message signing library
   camel-snake-kebab/camel-snake-kebab       {:mvn/version "0.4.3"}              ; util functions for converting between camel, snake, and kebob case
-  cheshire/cheshire                         {:mvn/version "5.12.0"}             ; fast JSON encoding (used by Ring JSON middleware)
+  cheshire/cheshire                         {:mvn/version "5.13.0"}             ; fast JSON encoding (used by Ring JSON middleware)
   clj-bom/clj-bom                           {:mvn/version "0.1.2"}              ; handle BOMs in imported CSVs
-  clj-commons/iapetos                       {:mvn/version "0.1.13"}             ; prometheus metrics
-  clj-http/clj-http                         {:mvn/version "3.12.3"              ; HTTP client
+  clj-commons/iapetos                       {:mvn/version "0.1.14"}             ; prometheus metrics
+  clj-http/clj-http                         {:mvn/version "3.13.0"              ; HTTP client
                                              :exclusions  [commons-codec/commons-codec
                                                            commons-io/commons-io
                                                            slingshot/slingshot]}
   clojure.java-time/clojure.java-time       {:mvn/version "1.4.2"}              ; java.time utilities
   clojurewerkz/quartzite                    {:mvn/version "2.2.0"               ; scheduling library
-                                             :exclusions  [c3p0/c3p0
-                                                           org.quartz-scheduler/quartz]}
+                                             :exclusions  [com.mchange.c3p0/c3p0
+                                                           com.zaxxer/HikariCP-java7]}
   colorize/colorize                         {:mvn/version "0.1.1"               ; string output with ANSI color codes (for logging)
                                              :exclusions  [org.clojure/clojure]}
   com.clearspring.analytics/stream          {:mvn/version "2.9.8"               ; Various sketching algorithms
@@ -40,14 +40,15 @@
   com.github.albfernandez/juniversalchardet {:mvn/version "2.5.0"}
   com.github.jknack/handlebars              {:mvn/version "4.3.1"} ^{:antq/exclude "4.4.0"} ; templating engine. 4.4 requires Java 17+
   com.github.seancorfield/honeysql          {:mvn/version "2.6.1203"}           ; Honey SQL 2. SQL generation from Clojure data maps
-  com.github.seancorfield/next.jdbc         {:mvn/version "1.3.925"}            ; Talk to JDBC DBs
-  com.github.steffan-westcott/clj-otel-api  {:mvn/version "0.2.6"}              ; Telemetry library
-  com.github.vertical-blank/sql-formatter   {:mvn/version "2.0.4"}              ; Java SQL formatting library https://github.com/vertical-blank/sql-formatter
-  com.google.guava/guava                    {:mvn/version "33.1.0-jre"}         ; dep for BigQuery, Spark, and GA. Require here rather than letting different dep versions stomp on each other — see comments on #9697
+  com.github.seancorfield/next.jdbc         {:mvn/version "1.3.939"}            ; Talk to JDBC DBs
+  com.github.steffan-westcott/clj-otel-api  {:mvn/version "0.2.7"}              ; Telemetry library
+  com.github.vertical-blank/sql-formatter   {:mvn/version "2.0.5"}              ; Java SQL formatting library https://github.com/vertical-blank/sql-formatter
+  com.google.guava/guava                    {:mvn/version "33.3.1-jre"}         ; dep for BigQuery, Spark, and GA. Require here rather than letting different dep versions stomp on each other — see comments on #9697
   com.fasterxml.jackson.core/jackson-databind
-  {:mvn/version "2.17.0"}             ; JSON processor used by snowplow-java-tracker
-  com.fasterxml.woodstox/woodstox-core      {:mvn/version "6.6.1"}              ; trans dep of commons-codec
-  com.h2database/h2                         {:mvn/version "2.1.214"}            ; embedded SQL database
+  {:mvn/version "2.17.2"}             ; JSON processor used by snowplow-java-tracker
+  com.fasterxml.woodstox/woodstox-core      {:mvn/version "7.0.0"}              ; trans dep of commons-codec
+  com.h2database/h2                         ^:antq/exclude                      ; https://metaboat.slack.com/archives/CKZEMT1MJ/p1727191010259979
+                                            {:mvn/version "2.1.214"}            ; embedded SQL database
   com.gfredericks/test.chuck                {:mvn/version "0.2.14"}             ; generating strings from regex
   com.snowplowanalytics/snowplow-java-tracker
   {:mvn/version "1.0.1"               ; Snowplow analytics
@@ -56,10 +57,10 @@
   com.vladsch.flexmark/flexmark             {:mvn/version "0.64.8"}             ; Markdown parsing
   com.vladsch.flexmark/flexmark-ext-autolink
   {:mvn/version "0.64.8"}             ; Flexmark extension for auto-linking bare URLs
-  commons-codec/commons-codec               {:mvn/version "1.16.1"}             ; Apache Commons -- useful codec util fns
-  commons-io/commons-io                     {:mvn/version "2.15.1"}             ; Apache Commons -- useful IO util fns
-  commons-net/commons-net                   {:mvn/version "3.10.0"}             ; Apache Commons -- useful network utils. Transitive dep of Snowplow, pinned due to CVE-2021-37533
-  commons-validator/commons-validator       {:mvn/version "1.8.0"               ; Apache Commons -- useful validation util fns
+  commons-codec/commons-codec               {:mvn/version "1.17.1"}             ; Apache Commons -- useful codec util fns
+  commons-io/commons-io                     {:mvn/version "2.17.0"}             ; Apache Commons -- useful IO util fns
+  commons-net/commons-net                   {:mvn/version "3.11.1"}             ; Apache Commons -- useful network utils. Transitive dep of Snowplow, pinned due to CVE-2021-37533
+  commons-validator/commons-validator       {:mvn/version "1.9.0"               ; Apache Commons -- useful validation util fns
                                              :exclusions  [commons-beanutils/commons-beanutils
                                                            commons-digester/commons-digester
                                                            commons-logging/commons-logging]}
@@ -72,17 +73,17 @@
                                                            org.apache.poi/poi-ooxml]}
   environ/environ                           {:mvn/version "1.2.0"}              ; env vars/Java properties abstraction
   hiccup/hiccup                             {:mvn/version "1.0.5"}              ; HTML templating
-  inflections/inflections                   {:mvn/version "0.14.1"}             ; Clojure/Script library used for prularizing words
-  instaparse/instaparse                     {:mvn/version "1.4.12"}             ; Make your own parser
+  inflections/inflections                   {:mvn/version "0.14.2"}             ; Clojure/Script library used for prularizing words
+  instaparse/instaparse                     {:mvn/version "1.5.0"}              ; Make your own parser
   junegunn/grouper                          {:mvn/version "0.1.1"}              ; Batch processing helper
-  clj-commons/clj-yaml                      {:mvn/version "1.0.27"}             ; Clojure wrapper for YAML library SnakeYAML
+  clj-commons/clj-yaml                      {:mvn/version "1.0.28"}             ; Clojure wrapper for YAML library SnakeYAML
   io.github.camsaul/toucan2                 {:mvn/version "1.0.556"}
-  io.github.eerohele/pp                     {:git/tag "2024-01-04.60"           ; super fast pretty-printing library
-                                             :git/sha "a428751"
+  io.github.eerohele/pp                     {:git/tag "2024-09-09.69"           ; super fast pretty-printing library
+                                             :git/sha "bf0b3c1"
                                              :git/url "https://github.com/eerohele/pp"}
   io.github.metabase/macaw                  {:mvn/version "0.2.24"}             ; Parse native SQL queries
-  ;; The 2.X line of Resilience4j requires Java 17, so we cannot upgrade this dependency until that is our minimum JVM version
-  io.github.resilience4j/resilience4j-retry {:mvn/version "1.7.1" #_"must be 1.7.1"} ; Support for retrying operations
+  io.github.resilience4j/resilience4j-retry ^:antq/exclude                      ; 2.x do not support Java 8
+                                            {:mvn/version "1.7.1"}              ; Support for retrying operations
   io.prometheus/simpleclient_hotspot        {:mvn/version "0.16.0"}             ; prometheus jvm collector
   io.prometheus/simpleclient_jetty          {:mvn/version "0.16.0"}             ; prometheus jetty collector
   javax.servlet/servlet-api                 {:mvn/version "2.5"}                ; used by ring's multipart-params (file upload)
@@ -99,10 +100,10 @@
                                                           org.bouncycastle/bcprov-jdk18on]}
   metabase/throttle                         {:mvn/version "1.0.2"}              ; Tools for throttling access to API endpoints and other code pathways
   methodical/methodical                     {:mvn/version "1.0.124"}            ; drop-in replacements for Clojure multimethods and adds several advanced features
-  metosin/malli                             {:mvn/version "0.16.3"}             ; Data-driven Schemas for Clojure/Script and babashka
+  metosin/malli                             {:mvn/version "0.16.4"}             ; Data-driven Schemas for Clojure/Script and babashka
   nano-id/nano-id                           {:mvn/version "1.1.0"}              ; NanoID generator for generating entity_ids
   net.cgrand/macrovich                      {:mvn/version "0.2.2"}              ; utils for writing macros for both Clojure & ClojureScript
-  net.clojars.wkok/openai-clojure           {:mvn/version "0.16.0"
+  net.clojars.wkok/openai-clojure           {:mvn/version "0.21.0"
                                              :exclusions  [lambdaisland/uri]}   ; OpenAI
   net.i2p.crypto/eddsa                      {:mvn/version "0.3.0"}              ; ED25519 key support (optional dependency for org.apache.sshd/sshd-core)
   net.redhogs.cronparser/cron-parser-core   {:mvn/version "3.5"                 ; describe Cron schedule in human-readable language
@@ -111,29 +112,29 @@
                                              :exclusions  [org.slf4j/slf4j-api
                                                            junit/junit]}
   net.thisptr/jackson-jq                    {:mvn/version "1.0.0-preview.20240207"} ; Java implementation of the JQ json query language
-  org.apache.commons/commons-compress       {:mvn/version "1.26.1"}             ; compression utils
-  org.apache.commons/commons-lang3          {:mvn/version "3.14.0"}             ; helper methods for working with java.lang stuff
-  org.apache.logging.log4j/log4j-1.2-api    {:mvn/version "2.23.1"}             ; apache logging framework
-  org.apache.logging.log4j/log4j-api        {:mvn/version "2.23.1"}             ; add compatibility with log4j 1.2
-  org.apache.logging.log4j/log4j-core       {:mvn/version "2.23.1"}             ; apache logging framework
-  org.apache.logging.log4j/log4j-jcl        {:mvn/version "2.23.1"}             ; allows the commons-logging API to work with log4j 2
-  org.apache.logging.log4j/log4j-jul        {:mvn/version "2.23.1"}             ; java.util.logging (JUL) -> Log4j2 adapter
+  org.apache.commons/commons-compress       {:mvn/version "1.27.1"}             ; compression utils
+  org.apache.commons/commons-lang3          {:mvn/version "3.17.0"}             ; helper methods for working with java.lang stuff
+  org.apache.logging.log4j/log4j-1.2-api    {:mvn/version "2.24.0"}             ; apache logging framework
+  org.apache.logging.log4j/log4j-api        {:mvn/version "2.24.0"}             ; add compatibility with log4j 1.2
+  org.apache.logging.log4j/log4j-core       {:mvn/version "2.24.0"}             ; apache logging framework
+  org.apache.logging.log4j/log4j-jcl        {:mvn/version "2.24.0"}             ; allows the commons-logging API to work with log4j 2
+  org.apache.logging.log4j/log4j-jul        {:mvn/version "2.24.0"}             ; java.util.logging (JUL) -> Log4j2 adapter
   org.apache.logging.log4j/log4j-slf4j2-impl
-  {:mvn/version "2.23.1"}             ; allows the slf4j2 API to work with log4j 2
+  {:mvn/version "2.24.0"}             ; allows the slf4j2 API to work with log4j 2
   org.apache.logging.log4j/log4j-layout-template-json
-  {:mvn/version "2.23.1"}             ; allows the custom json logging format
-  org.apache.poi/poi                        {:mvn/version "5.2.5"}              ; Work with Office documents (e.g. Excel spreadsheets) -- newer version than one specified by Docjure
-  org.apache.poi/poi-ooxml                  {:mvn/version "5.2.5"
+  {:mvn/version "2.24.0"}             ; allows the custom json logging format
+  org.apache.poi/poi                        {:mvn/version "5.3.0"}              ; Work with Office documents (e.g. Excel spreadsheets) -- newer version than one specified by Docjure
+  org.apache.poi/poi-ooxml                  {:mvn/version "5.3.0"
                                              :exclusions  [org.bouncycastle/bcpkix-jdk15on
                                                            org.bouncycastle/bcprov-jdk15on]}
   org.apache.poi/poi-ooxml-full             {:mvn/version "5.2.5"}
-  org.apache.sshd/sshd-core                 {:mvn/version "2.12.1"              ; ssh tunneling and test server
+  org.apache.sshd/sshd-core                 {:mvn/version "2.13.2"              ; ssh tunneling and test server
                                              :exclusions  [org.slf4j/slf4j-api
                                                            org.slf4j/jcl-over-slf4j]}
   org.apache.tika/tika-core                 {:mvn/version "2.9.2"}
   org.apache.xmlgraphics/batik-all          {:mvn/version "1.17"}               ; SVG -> image
-  org.bouncycastle/bcpkix-jdk18on           {:mvn/version "1.78"}               ; Bouncy Castle crypto library -- explicit version of BC specified to resolve illegal reflective access errors
-  org.bouncycastle/bcprov-jdk18on           {:mvn/version "1.78"}
+  org.bouncycastle/bcpkix-jdk18on           {:mvn/version "1.78.1"}             ; Bouncy Castle crypto library -- explicit version of BC specified to resolve illegal reflective access errors
+  org.bouncycastle/bcprov-jdk18on           {:mvn/version "1.78.1"}
   org.clj-commons/claypoole                 {:mvn/version "1.2.2"}              ; Threadpool tools for Clojure
   org.clj-commons/hickory                   {:mvn/version "0.7.4"               ; Parse HTML into Clojure data structures
                                              :exclusions [org.jsoup/jsoup]}
@@ -145,7 +146,7 @@
   org.clojure/core.match                    {:mvn/version "1.1.0"}
   org.clojure/core.memoize                  {:mvn/version "1.1.266"}            ; useful FIFO, LRU, etc. caching mechanisms
   org.clojure/data.csv                      {:mvn/version "1.1.0"}              ; CSV parsing / generation
-  org.clojure/data.xml                      {:mvn/version "0.0.8"}              ; XML parsing / generation
+  org.clojure/data.xml                      {:mvn/version "0.2.0-alpha9"}       ; XML parsing / generation
   org.clojure/java.classpath                {:mvn/version "1.1.0"}              ; examine the Java classpath from Clojure programs
   org.clojure/java.jdbc                     {:mvn/version "0.7.12"}             ; basic JDBC access from Clojure
   org.clojure/java.jmx                      {:mvn/version "1.1.0"}              ; JMX bean library, for exporting diagnostic info
@@ -153,28 +154,27 @@
   org.clojure/math.numeric-tower            {:mvn/version "0.1.0"}              ; math functions like `ceil`
   org.clojure/tools.cli                     {:mvn/version "1.1.230"}            ; command-line argument parsing
   org.clojure/tools.logging                 {:mvn/version "1.3.0"}              ; logging framework
-  org.clojure/tools.macro                   {:mvn/version "0.2.0"}              ; local macros
+  org.clojure/tools.macro                   {:mvn/version "0.2.1"}              ; local macros
   org.clojure/tools.namespace               {:mvn/version "1.5.0"}
-  org.clojure/tools.reader                  {:mvn/version "1.4.1"}
+  org.clojure/tools.reader                  {:mvn/version "1.5.0"}
   org.clojure/tools.trace                   {:mvn/version "0.8.0"}              ; function tracing
-  ;; v. 12 of jetty-server triggers "a org/eclipse/jetty/io/EofException has been compiled by a more recent version of
-  ;; the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions
-  ;; up to 55.0"
-  org.eclipse.jetty/jetty-server            {:mvn/version "11.0.24" #_"must be 11"} ; web server
+  org.eclipse.jetty/jetty-server            ^:antq/exclude                      ; 12.x do not support Java 8
+                                            {:mvn/version "11.0.24"}            ; web server
   org.eclipse.jetty.websocket/websocket-jetty-server {:mvn/version "11.0.24"}   ; ring-jetty-adapter needs that
-  org.flatland/ordered                      {:mvn/version "1.15.11"}            ; ordered maps & sets
-  org.graalvm.js/js                         {:mvn/version "22.3.5"}             ; JavaScript engine
-  org.jsoup/jsoup                           {:mvn/version "1.17.2"}             ; required by hickory
-  org.liquibase/liquibase-core              {:mvn/version "4.26.0"              ; migration management (Java lib)
+  org.flatland/ordered                      {:mvn/version "1.15.12"}            ; ordered maps & sets
+  org.graalvm.js/js                         ^:antq/exclude                      ; newer GraalVM is not compatible with Java 8
+                                            {:mvn/version "22.3.5"}             ; JavaScript engine
+  org.jsoup/jsoup                           {:mvn/version "1.18.1"}             ; required by hickory
+  org.liquibase/liquibase-core              ^antq/exclude                       ; FIXME: no idea why
+                                            {:mvn/version "4.26.0"              ; migration management (Java lib)
                                              :exclusions  [ch.qos.logback/logback-classic]}
-  ;; The 3.X line of development for mariadb-java-client only supports the jdbc:mariadb protocol, so use 2.X for now.
-  org.mariadb.jdbc/mariadb-java-client      {:mvn/version "2.7.10"}             ; MySQL/MariaDB driver
+  org.mariadb.jdbc/mariadb-java-client      ^:antq/exclude                      ; 3.x only support jdbc:mariadb, so using 2.x for now
+                                            {:mvn/version "2.7.10"}             ; MySQL/MariaDB driver
   org.mindrot/jbcrypt                       {:mvn/version "0.4"}                ; Crypto library
-  org.postgresql/postgresql                 {:mvn/version "42.7.3"}             ; Postgres driver
-  org.quartz-scheduler/quartz               {:mvn/version "2.3.2"}              ; Quartz job scheduler, provided by quartzite but this is a newer version.
-  org.slf4j/slf4j-api                       {:mvn/version "2.0.12"}             ; abstraction for logging frameworks -- allows end user to plug in desired logging framework at deployment time
+  org.postgresql/postgresql                 {:mvn/version "42.7.4"}             ; Postgres driver
+  org.slf4j/slf4j-api                       {:mvn/version "2.0.16"}             ; abstraction for logging frameworks -- allows end user to plug in desired logging framework at deployment time
   org.tcrawley/dynapath                     {:mvn/version "1.1.0"}              ; Dynamically add Jars (e.g. Oracle or Vertica) to classpath
-  org.threeten/threeten-extra               {:mvn/version "1.7.2"}              ; extra Java 8 java.time classes like DayOfMonth and Quarter
+  org.threeten/threeten-extra               {:mvn/version "1.8.0"}              ; extra Java 8 java.time classes like DayOfMonth and Quarter
   potemkin/potemkin                         {:mvn/version "0.4.7"               ; utility macros & fns
                                              :exclusions  [riddley/riddley]}
   pretty/pretty                             {:mvn/version "1.0.5"}              ; protocol for defining how custom types should be pretty printed
@@ -233,7 +233,7 @@
   :dev
   {:extra-deps
    {com.clojure-goes-fast/clj-async-profiler
-    {:mvn/version "1.2.0"}                     ; Enables local profiling and heat map generation
+    {:mvn/version "1.3.0"}                     ; Enables local profiling and heat map generation
     com.clojure-goes-fast/clj-memory-meter
     {:mvn/version "0.3.0"}                     ; Enables easy memory measurement
     clj-http-fake/clj-http-fake  {:mvn/version "1.0.4"
@@ -241,11 +241,11 @@
     clj-kondo/clj-kondo          {:mvn/version "2024.08.01"}                ; included here mainly to facilitate working on the stuff in `.clj-kondo/src`
     cloverage/cloverage          {:mvn/version "1.2.4"}
     com.gfredericks/test.chuck   {:mvn/version "0.2.14"}                    ; generating strings from regexes (useful with malli)
-    djblue/portal                {:mvn/version "0.56.0"}                    ; ui for inspecting values
+    djblue/portal                {:mvn/version "0.57.3"}                    ; ui for inspecting values
     hashp/hashp                  {:mvn/version "0.2.2"}                     ; debugging/spying utility
     io.github.camsaul/humane-are {:mvn/version "1.0.2"}
     io.github.metabase/hawk      {:mvn/version "1.0.5"}
-    jonase/eastwood              {:mvn/version "1.4.2"                      ; inspects namespaces and reports possible problems using tools.analyzer
+    jonase/eastwood              {:mvn/version "1.4.3"                      ; inspects namespaces and reports possible problems using tools.analyzer
                                   :exclusions
                                   [org.ow2.asm/asm-all]}
     criterium/criterium          {:mvn/version "0.4.6"}                     ; benchmarking library
@@ -379,14 +379,14 @@
   {:extra-paths ["test"]
    :extra-deps
    {binaryage/devtools                 {:mvn/version "1.0.7"}
-    cider/cider-nrepl                  {:mvn/version "0.47.0"}
+    cider/cider-nrepl                  {:mvn/version "0.50.2"}
     cider/piggieback                   {:mvn/version "0.5.3"}
     cljs-bean/cljs-bean                {:mvn/version "1.9.0"}
     com.lambdaisland/glogi             {:mvn/version "1.3.169"}
     io.github.metabase/hawk            {:mvn/version "1.0.5"}
     org.clojars.mmb90/cljs-cache       {:mvn/version "0.1.4"}
     refactor-nrepl/refactor-nrepl      {:mvn/version "3.10.0"}
-    thheller/shadow-cljs               {:mvn/version "2.28.12"}}}
+    thheller/shadow-cljs               {:mvn/version "2.28.15"}}}
 
   ;; for local dev -- include the drivers locally with :dev:drivers
   :drivers
@@ -495,7 +495,7 @@
   ;; ship (such as `:dev` dependencies). See #27009 for more context.
   :check
   {:extra-deps {athos/clj-check {:git/url "https://github.com/athos/clj-check.git"
-                                 :sha     "518d5a1cbfcd7c952f548e6dbfcb9a4a5faf9062"}}
+                                 :sha     "d997df866b2a04b7ce7b17533093ee0a2e2cb729"}}
    :main-opts  ["-m" "clj-check.check"
                 "src"
                 "enterprise/backend/src"
@@ -667,7 +667,7 @@
     expound/expound                   {:mvn/version "0.9.0"}                    ; better output of spec validation errors
     io.github.borkdude/grasp          {:mvn/version "0.1.4"}
     io.github.clojure/tools.build     {:mvn/version "0.10.5"}
-    org.clojure/data.xml              {:mvn/version "0.2.0-alpha8"}
+    org.clojure/data.xml              {:mvn/version "0.2.0-alpha9"}
     org.clojure/tools.deps.alpha      {:mvn/version "0.15.1254"}
     org.fedorahosted.tennera/jgettext {:mvn/version "0.15.1"}}
 
@@ -765,7 +765,7 @@
   ;;
   ;; clojure -M:dev:nrepl (etc.)
   :nrepl
-  {:extra-deps {nrepl/nrepl {:mvn/version "1.1.1"}}
+  {:extra-deps {nrepl/nrepl {:mvn/version "1.3.0"}}
    :main-opts  ["-m" "nrepl.cmdline" "-p" "50605"]}
 
   ;; - start a Socket REPL on port 50505 that you can connect your editor to:
@@ -779,7 +779,7 @@
   ;;
   ;;    clojure -M:liquibase dbDoc target/liquibase
   :liquibase
-  {:extra-deps  {ch.qos.logback/logback-classic {:mvn/version "1.5.3"}}
+  {:extra-deps  {ch.qos.logback/logback-classic {:mvn/version "1.5.8"}}
    :extra-paths ["dev/src"]
    :main-opts   ["-m" "dev.liquibase"]}
 
@@ -850,7 +850,7 @@
   ;; watch and reload clojure namespaces
   :watch {:extra-deps
           {com.nextjournal/beholder     {:mvn/version "1.0.2"} ;; watcher
-           io.github.tonsky/clj-reload {:mvn/version "0.7.0"}} ;; reloader
+           io.github.tonsky/clj-reload {:mvn/version "0.7.1"}} ;; reloader
           :extra-paths "dev/src/watch"
           :main-opts ["-m" "watch.watcher"]}}}
 

--- a/deps.edn
+++ b/deps.edn
@@ -233,7 +233,7 @@
   :dev
   {:extra-deps
    {com.clojure-goes-fast/clj-async-profiler
-    {:mvn/version "1.3.0"}                     ; Enables local profiling and heat map generation
+    {:mvn/version "1.5.1"}                     ; Enables local profiling and heat map generation
     com.clojure-goes-fast/clj-memory-meter
     {:mvn/version "0.3.0"}                     ; Enables easy memory measurement
     clj-http-fake/clj-http-fake  {:mvn/version "1.0.4"

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -236,11 +236,11 @@
     (walk/postwalk
      (fn [x]
        (when (and (map? x)
-                  (= (:tag x) :StatusCode)
+                  (= (:tag x) :samlp:StatusCode)
                   (= (get-in x [:attrs :Value]) saml2-success-status))
          (reset! *success? true))
        x)
-     (xml/parse-str xml-str))
+     (xml/parse-str xml-str {:namespace-aware false}))
     @*success?))
 
 (defmethod sso.i/sso-handle-slo :saml

--- a/modules/drivers/athena/deps.edn
+++ b/modules/drivers/athena/deps.edn
@@ -5,5 +5,5 @@
  {"athena" {:url "https://s3.amazonaws.com/maven-athena"}}
 
  :deps
- {com.amazonaws/aws-java-sdk-core {:mvn/version "1.12.770"}
+ {com.amazonaws/aws-java-sdk-core {:mvn/version "1.12.772"}
   com.metabase/athena-jdbc {:mvn/version "2.0.35"}}}

--- a/modules/drivers/bigquery-cloud-sdk/deps.edn
+++ b/modules/drivers/bigquery-cloud-sdk/deps.edn
@@ -7,8 +7,8 @@
                                                ;; this appears to be dual licensed EPL, GPL2.0 but it's not super
                                                ;; clear so we're excluding it
                                                :exclusions [javax.annotation/javax.annotation-api]}
-  com.google.guava/guava                      {:mvn/version "33.1.0-jre"} ; specified separately so that Snyk is happy
-  com.google.code.gson/gson                   {:mvn/version "2.10.1"}
-  com.google.oauth-client/google-oauth-client {:mvn/version "1.35.0"}
+  com.google.guava/guava                      {:mvn/version "33.1.1-jre"} ; specified separately so that Snyk is happy
+  com.google.code.gson/gson                   {:mvn/version "2.11.0"}
+  com.google.oauth-client/google-oauth-client {:mvn/version "1.36.0"}
   com.google.protobuf/protobuf-java           {:mvn/version "3.25.5"} ; specified separately so that Snyk is happy
   com.google.protobuf/protobuf-java-util      {:mvn/version "3.25.5"}}}

--- a/modules/drivers/bigquery-cloud-sdk/deps.edn
+++ b/modules/drivers/bigquery-cloud-sdk/deps.edn
@@ -7,7 +7,7 @@
                                                ;; this appears to be dual licensed EPL, GPL2.0 but it's not super
                                                ;; clear so we're excluding it
                                                :exclusions [javax.annotation/javax.annotation-api]}
-  com.google.guava/guava                      {:mvn/version "33.1.1-jre"} ; specified separately so that Snyk is happy
+  com.google.guava/guava                      {:mvn/version "33.3.1-jre"} ; specified separately so that Snyk is happy
   com.google.code.gson/gson                   {:mvn/version "2.11.0"}
   com.google.oauth-client/google-oauth-client {:mvn/version "1.36.0"}
   com.google.protobuf/protobuf-java           {:mvn/version "3.25.5"} ; specified separately so that Snyk is happy

--- a/modules/drivers/druid-jdbc/deps.edn
+++ b/modules/drivers/druid-jdbc/deps.edn
@@ -4,4 +4,4 @@
  :deps
  {;; JDBC java driver used for executing queries on Druid.
   ;; Reference: https://druid.apache.org/docs/latest/api-reference/sql-jdbc
-  org.apache.calcite.avatica/avatica  {:mvn/version "1.23.0"}}}
+  org.apache.calcite.avatica/avatica  {:mvn/version "1.25.0"}}}

--- a/modules/drivers/mongo/deps.edn
+++ b/modules/drivers/mongo/deps.edn
@@ -2,5 +2,5 @@
  ["src" "resources"]
 
  :deps
- {com.google.guava/guava {:mvn/version "33.1.0-jre"}
+ {com.google.guava/guava {:mvn/version "33.3.1-jre"}
   org.mongodb/mongodb-driver-sync {:mvn/version "5.2.0"}}}

--- a/modules/drivers/presto-jdbc/deps.edn
+++ b/modules/drivers/presto-jdbc/deps.edn
@@ -2,7 +2,7 @@
  ["src" "resources"]
 
  :deps
- {com.facebook.presto/presto-jdbc {:mvn/version "0.288"}}
+ {com.facebook.presto/presto-jdbc {:mvn/version "0.289"}}
 
  :metabase.driver/parents
  #{:sql-jdbc}}

--- a/modules/drivers/sqlite/deps.edn
+++ b/modules/drivers/sqlite/deps.edn
@@ -2,4 +2,4 @@
  ["src" "resources"]
 
  :deps
- {org.xerial/sqlite-jdbc {:mvn/version "3.45.2.0"}}}
+ {org.xerial/sqlite-jdbc {:mvn/version "3.46.1.0"}}}

--- a/modules/drivers/vertica/deps.edn
+++ b/modules/drivers/vertica/deps.edn
@@ -2,7 +2,7 @@
  ["src" "resources-ee"]
 
  :deps
- {com.vertica.jdbc/vertica-jdbc {:mvn/version "23.4.0-0"}}
+ {com.vertica.jdbc/vertica-jdbc {:mvn/version "24.3.0-0"}}
 
  :aliases
  {:oss

--- a/modules/drivers/vertica/deps.edn
+++ b/modules/drivers/vertica/deps.edn
@@ -2,7 +2,7 @@
  ["src" "resources-ee"]
 
  :deps
- {com.vertica.jdbc/vertica-jdbc {:mvn/version "24.3.0-0"}}
+ {com.vertica.jdbc/vertica-jdbc {:mvn/version "23.4.0-0"}}
 
  :aliases
  {:oss

--- a/modules/drivers/vertica/deps.edn
+++ b/modules/drivers/vertica/deps.edn
@@ -2,7 +2,8 @@
  ["src" "resources-ee"]
 
  :deps
- {com.vertica.jdbc/vertica-jdbc {:mvn/version "23.4.0-0"}}
+ {com.vertica.jdbc/vertica-jdbc ^:antq/exclude ; update to 24.3 breaks the date tests
+  {:mvn/version "23.4.0-0"}}
 
  :aliases
  {:oss

--- a/src/metabase/models/notification.clj
+++ b/src/metabase/models/notification.clj
@@ -37,6 +37,7 @@
   "Set of valid notification types."
   #{:notification/system-event
     :notification/dashboard-subscription
+    :notification/alert
     ;; for testing only
     :notification/testing})
 

--- a/src/metabase/notification/payload/core.clj
+++ b/src/metabase/notification/payload/core.clj
@@ -20,7 +20,8 @@
   [:merge #_{:closed true}
    [:map
     [:payload_type                  (into [:enum] models.notification/notification-types)]
-    [:id           {:optional true} ms/PositiveInt]
+    ;; allow unsaved notification to be sent
+    [:id           {:optional true} [:maybe ms/PositiveInt]]
     [:active       {:optional true} :boolean]
     [:created_at   {:optional true} :any]
     [:updated_at   {:optional true} :any]]


### PR DESCRIPTION
Closes #44330

## Major Bumps

[bigml/histogram 4.1.4 -> 5.0.0](https://github.com/bigmlcom/histogram/commit/ada60dbdf305f1b458aa9968bfc4fb363b68a27e)
[com.fasterxml.woodstox/woodstox-core 6.6.1 -> 7.0.0](https://github.com/FasterXML/woodstox/blob/master/release-notes/VERSION)

## Minor Bumps

[buddy/buddy-core 1.11.423 -> 1.12.0-420](https://github.com/funcool/buddy-core/blob/master/CHANGES.md)
[buddy/buddy-sign 3.5.351 -> 3.6.1-359](https://github.com/funcool/buddy-sign/blob/master/CHANGES.md)
[cheshire/cheshire 5.12.0 -> 5.13.0](https://cljdoc.org/d/cheshire/cheshire/5.13.0/doc/changelog) (changelog appears to be out of date)
--- continue adding changelog links here
clj-http/clj-http                  3.12.3 -> 3.13.0
com.google.guava               33.1.0-jre -> 33.2.1-jre
commons-codec/commons-codec        1.16.1 -> 1.17.1
commons-io/commons-io              2.15.1 -> 2.16.1
commons-net/commons-net            3.10.0 -> 3.11.1
commons-validator/commons-validator 1.8.0 -> 1.9.0
instaparse/instaparse              1.4.12 -> 1.5.0
net.clojars.wkok/openai-clojure    0.16.0 -> 0.18.1
org.apache.commons/commons-lang3   3.14.0 -> 3.15.0
org.apache.poi/poi                  5.2.5 -> 5.3.0
org.apache.poi/poi-ooxml            5.2.5 -> 5.3.0
org.apache.sshd/sshd-core          2.12.1 -> 2.13.1
org.jsoup/jsoup                    1.17.2 -> 1.18.1
org.threeten/threeten-extra         1.7.2 -> 1.8.0