### PR TITLE
[Manual backport 49] Fix sync indexes mark all fields with same name as indexed if one of them is

### DIFF
--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -262,6 +262,50 @@
        (finally
         (t2/delete! :model/Database (mt/id)))))))
 
+(deftest sync-indexes-top-level-and-nested-column-with-same-name-test
+  (mt/test-driver :mongo
+    (testing "when a table has fields at the top level and nested level with the same name
+             we shouldn't mistakenly mark both of them as indexed if one is(#46312)"
+      (mt/dataset (mt/dataset-definition "index-duplicate-name"
+                    ["top-level-indexed"
+                     [{:field-name "name" :indexed? true :base-type :type/Text}
+                      {:field-name "class" :indexed? false :base-type :type/Text}]
+                     [["Metabase" {"name" "Physics"}]]]
+                    ["nested-indexed"
+                     [{:field-name "name" :indexed? false :base-type :type/Text}
+                      {:field-name "class" :indexed? false :base-type :type/Text}]
+                     [["Metabase" {"name" "Physics"}]]])
+        (mongo.connection/with-mongo-database [db (mt/db)]
+          (mongo.util/create-index (mongo.util/collection db "nested-indexed") (array-map "class.name" 1)))
+       (sync/sync-database! (mt/db) {:scan :schema})
+       (testing "top level indexed, nested not"
+         (let [name-fields (t2/select [:model/Field :name :parent_id :database_indexed]
+                                      :table_id (mt/id :top-level-indexed) :name "name")]
+           (testing "sanity check that we have 2 `name` fields"
+             (is (= 2 (count name-fields))))
+
+           (testing "only the top level field is indexed"
+             (is (=? [{:name             "name"
+                       :parent_id        nil
+                       :database_indexed true}
+                      {:name             "name"
+                       :parent_id        (mt/malli=? int?)
+                       :database_indexed false}]
+                     (sort-by :parent_id name-fields))))))
+       (testing "nested field indexed, top level not"
+         (let [name-fields (t2/select [:model/Field :name :parent_id :database_indexed]
+                                      :table_id (mt/id :nested-indexed) :name "name")]
+           (testing "sanity check that we have 2 `name` fields"
+             (is (= 2 (count name-fields))))
+           (testing "only the nested field is indexed"
+             (is (=? [{:name             "name"
+                       :parent_id        nil
+                       :database_indexed false}
+                      {:name             "name"
+                       :parent_id        (mt/malli=? int?)
+                       :database_indexed true}]
+                     (sort-by :parent_id name-fields))))))))))
+
 (deftest describe-table-indexes-test
   (mt/test-driver :mongo
     (mt/dataset (mt/dataset-definition "indexing"

--- a/src/metabase/sync/sync_metadata/indexes.clj
+++ b/src/metabase/sync/sync_metadata/indexes.clj
@@ -19,7 +19,7 @@
     (let [normal-indexes           (->> indexes (filter #(= (:type %) :normal-column-index)) (map :value))
           nested-indexes           (->> indexes (filter #(= (:type %) :nested-column-index)) (map :value))
           normal-indexes-field-ids (when (seq normal-indexes)
-                                     (t2/select-pks-vec :model/Field :name [:in normal-indexes] :table_id table-id))
+                                     (t2/select-pks-vec :model/Field :name [:in normal-indexes] :table_id table-id :parent_id nil))
           nested-indexes-field-ids (remove nil? (map #(field/nested-field-names->field-id table-id %) nested-indexes))]
       (set (filter some? (concat normal-indexes-field-ids nested-indexes-field-ids))))))
 


### PR DESCRIPTION
#46313