### PR TITLE
Fix x-ray generate invalid query for table with Date column

### DIFF
--- a/src/metabase/xrays/automagic_dashboards/interesting.clj
+++ b/src/metabase/xrays/automagic_dashboards/interesting.clj
@@ -111,14 +111,14 @@
                                    (map u.date/parse))
         can-use?  #(mbql.s/valid-temporal-unit-for-base-type? (:base_type field) %)]
     (if (and earliest latest)
-      (let [duration      (u.date/period-duration earliest latest)
-            greater-than? #(u.date/greater-than-period-duration? % duration)]
+      (let [duration   (u.date/period-duration earliest latest)
+            less-than? #(u.date/greater-than-period-duration? % duration)]
         (cond
          ;; e.g. if [duration between earliest and latest] < 3 hours then use `:minute` resolution
-         (and (greater-than? (t/hours 3))  (can-use? :minute)) :minute
-         (and (greater-than? (t/days 7))   (can-use? :hour))   :hour
-         (and (greater-than? (t/months 6)) (can-use? :day))    :day
-         (and (greater-than? (t/years 10)) (can-use? :month))  :month
+         (and (less-than? (t/hours 3))  (can-use? :minute)) :minute
+         (and (less-than? (t/days 7))   (can-use? :hour))   :hour
+         (and (less-than? (t/months 6)) (can-use? :day))    :day
+         (and (less-than? (t/years 10)) (can-use? :month))  :month
          (can-use? :year) :year
          (can-use? :hour) :hour))
       (if (can-use? :day) :day :hour))))

--- a/test/metabase/xrays/automagic_dashboards/core_test.clj
+++ b/test/metabase/xrays/automagic_dashboards/core_test.clj
@@ -1119,30 +1119,6 @@
                first
                key)))))
 
-
-;;; ------------------- Datetime resolution inference -------------------
-
-(deftest ^:parallel optimal-datetime-resolution-test
-  (doseq [[m expected] [[{:earliest "2015"
-                          :latest   "2017"}
-                         :month]
-                        [{:earliest "2017-01-01"
-                          :latest   "2017-03-04"}
-                         :day]
-                        [{:earliest "2005"
-                          :latest   "2017"}
-                         :year]
-                        [{:earliest "2017-01-01"
-                          :latest   "2017-01-02"}
-                         :hour]
-                        [{:earliest "2017-01-01T00:00:00"
-                          :latest   "2017-01-01T00:02:00"}
-                         :minute]]
-          :let         [fingerprint {:type {:type/DateTime m}}]]
-    (testing (format "fingerprint = %s" (pr-str fingerprint))
-      (is (= expected
-             (#'interesting/optimal-datetime-resolution {:fingerprint fingerprint}))))))
-
 ;;; -------------------- Filters --------------------
 
 (defn field! [table column]

--- a/test/metabase/xrays/automagic_dashboards/interesting_test.clj
+++ b/test/metabase/xrays/automagic_dashboards/interesting_test.clj
@@ -593,3 +593,53 @@
              (interesting/normalize-seq-of-maps :froobs froobs)))
       (is (= [{:nurnies-name "Baz" :size 100}]
              (interesting/normalize-seq-of-maps :nurnies nurnies))))))
+
+
+;;; ------------------- Datetime resolution inference -------------------
+
+(deftest ^:parallel optimal-temporal-resolution-test
+  (doseq [[m base-type expected] [[{:earliest "2015"
+                                    :latest   "2017"}
+                                   :type/DateTime
+                                   :month]
+                                  [{:earliest "2017-01-01"
+                                    :latest   "2017-03-04"}
+                                   :type/DateTime
+                                   :day]
+                                  [{:earliest "2005"
+                                    :latest   "2017"}
+                                   :type/DateTime
+                                   :year]
+                                  [{:earliest "2017-01-01"
+                                    :latest   "2017-01-02"}
+                                   :type/DateTime
+                                   :hour]
+                                  [{:earliest "2017-01-01T00:00:00"
+                                    :latest   "2017-01-01T00:02:00"}
+                                   :type/DateTime
+                                   :minute]
+                                  [{:earliest "2017-01-01T00:02:00"
+                                    :latest   "2017-01-01T00:02:00"}
+                                   :type/DateTime
+                                   :minute]
+                                  [{:earliest "2017-01-01"
+                                    :latest   "2017-01-01"}
+                                   :type/Date
+                                   :day]
+                                  [{:earliest "2017-01-01"
+                                    :latest   "2018-01-01"}
+                                   :type/Date
+                                   :month]
+                                  [{:earliest "00:02:00"
+                                    :latest   "00:02:00"}
+                                   :type/Time
+                                   :minute]
+                                  [{:earliest "00:02:00"
+                                    :latest   "10:02:00"}
+                                   :type/Time
+                                   :hour]]
+          :let         [fingerprint {:type {:type/DateTime m}}]]
+    (testing (format "base_type=%s, fingerprint = %s" base-type (pr-str fingerprint))
+      (is (= expected
+             (#'interesting/optimal-temporal-resolution {:fingerprint fingerprint
+                                                         :base_type   base-type}))))))


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/46249

In the reproduction step of the issue, we're generating a breakout on the `customer.create_date` column with `:minute` breakout, this is invalid because the base type of this column is `:type/Date`.

The temporal unit is inferred by the `metabase.xrays.automagic-dashboards.interesting/optimal-temporal-resolution` function that takes a field and uses its fingerprint info of datetime `earliest and lastest` to get a temporal unit.
The fix here is to guard this function from returning an invalid unit.

### How to test:
1. Create a db with this sql
```sql
CREATE TABLE shows (
    name TEXT,
    event_date DATE,
);

INSERT INTO shows (name, event_date)
VALUES ('taylor swift concert', '2024-07-31');

```
2. sync it and x-ray on the `shows` table
3. You should be able to save the x-ray successfully