### PR TITLE
test: reduce flakiness by waiting longer for loader to disappear

### DIFF
--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -293,9 +293,14 @@ export function getBrokenUpTextMatcher(textToFind: string): MatcherFunction {
  * @see https://metaboat.slack.com/archives/C505ZNNH4/p1684753502335459?thread_ts=1684751522.480859&cid=C505ZNNH4
  */
 export const waitForLoaderToBeRemoved = async () => {
-  await waitFor(() => {
-    expect(screen.queryByTestId("loading-indicator")).not.toBeInTheDocument();
-  });
+  await waitFor(
+    () => {
+      expect(screen.queryByTestId("loading-indicator")).not.toBeInTheDocument();
+      // default timeout is 1s, but sometimes it's not enough and leads to flakiness,
+      // 3s should be enough
+    },
+    { timeout: 3000 },
+  );
 };
 
 /**


### PR DESCRIPTION
This PR reduces flakiness overall and particularly in the `MetadataTableSettings`

in some cases 1s not enough for loader to disappear on potato machines, so let's increase it and wait a bit more.

To test flakiness locally I ran `yarn jest` in one tab to overload CPU and in second tab.

```
hyperfine --runs 50 "node 'node_modules/.bin/jest' '/Users/uladzimirhavenchyk/p/metabase/frontend/src/metabase/admin/datamodel/metadata/components/MetadataTableSettings/MetadataTableSettings.unit.spec.tsx'" --show-output
```

[hyperfine](https://github.com/sharkdp/hyperfine) is a tool that allows to repeat command and gather results, kind of local stress-test.

it used to fail with 1s timeout and passed with 3s timeout

<img width="774" alt="image" src="https://github.com/user-attachments/assets/1efbc67d-53a4-4676-bfc4-4c02fef5466a">

[example of flaky test](https://github.com/metabase/metabase/actions/runs/10178553689/job/28152409000?pr=45902)
