### PR TITLE
fix pie chart total graphic not being removed

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
@@ -6,6 +6,7 @@ import {
   popover,
   tableHeaderClick,
   pieSlices,
+  leftSidebar,
 } from "e2e/support/helpers";
 
 const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -57,6 +58,32 @@ describe("scenarios > visualizations > pie chart", () => {
       ["Gizmo", "false"],
       ["Widget", "false"],
     ].map(args => checkLegendItemAriaCurrent(args[0], args[1]));
+  });
+
+  it("should instantly toggle the total after changing the setting", () => {
+    visitQuestionAdhoc({
+      dataset_query: testQuery,
+      display: "pie",
+    });
+
+    cy.findByTestId("viz-settings-button").click();
+
+    leftSidebar().within(() => {
+      cy.findByText("Display").click();
+      cy.findByText("Show total").click();
+    });
+
+    cy.findByTestId("query-visualization-root").within(() => {
+      cy.findByText("TOTAL").should("not.exist");
+    });
+
+    leftSidebar().within(() => {
+      cy.findByText("Show total").click();
+    });
+
+    cy.findByTestId("query-visualization-root").within(() => {
+      cy.findByText("TOTAL").should("be.visible");
+    });
   });
 });
 

--- a/frontend/src/metabase/visualizations/echarts/pie/option.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/option.ts
@@ -25,27 +25,33 @@ function getSliceByKey(key: PieSliceData["key"], slices: PieSlice[]) {
 }
 
 function getTotalGraphicOption(
+  settings: ComputedVisualizationSettings,
   chartModel: PieChartModel,
   formatters: PieChartFormatters,
   renderingContext: RenderingContext,
   hoveredIndex: number | undefined,
   outerRadius: number,
 ) {
+  let valueText = "";
+  let labelText = "";
+
   // Don't display any text if there isn't enough width
-  if (outerRadius * 2 < DIMENSIONS.totalDiameterThreshold) {
-    return undefined;
+  const hasSufficientWidth =
+    outerRadius * 2 >= DIMENSIONS.totalDiameterThreshold;
+
+  if (hasSufficientWidth && settings["pie.show_total"]) {
+    valueText = formatters.formatMetric(
+      hoveredIndex != null
+        ? chartModel.slices[hoveredIndex].data.displayValue
+        : chartModel.total,
+    );
+    labelText =
+      hoveredIndex != null
+        ? formatters
+            .formatDimension(chartModel.slices[hoveredIndex].data.key)
+            .toUpperCase()
+        : TOTAL_TEXT;
   }
-  const valueText = formatters.formatMetric(
-    hoveredIndex != null
-      ? chartModel.slices[hoveredIndex].data.displayValue
-      : chartModel.total,
-  );
-  const labelText =
-    hoveredIndex != null
-      ? formatters
-          .formatDimension(chartModel.slices[hoveredIndex].data.key)
-          .toUpperCase()
-      : TOTAL_TEXT;
 
   return {
     type: "group",
@@ -150,15 +156,14 @@ export function getPieChartOption(
   );
 
   // "Show total" setting
-  const graphicOption = settings["pie.show_total"]
-    ? getTotalGraphicOption(
-        chartModel,
-        formatters,
-        renderingContext,
-        hoveredIndex,
-        outerRadius,
-      )
-    : undefined;
+  const graphicOption = getTotalGraphicOption(
+    settings,
+    chartModel,
+    formatters,
+    renderingContext,
+    hoveredIndex,
+    outerRadius,
+  );
 
   // "Show percentages: On the chart" setting
   const formatSlicePercent = (key: PieSliceData["key"]) => {


### PR DESCRIPTION
https://metaboat.slack.com/archives/C064QMXEV9N/p1722459053536019

### Description

When we refactored the pie chart to not use a constant graphic option object (https://github.com/metabase/metabase/pull/43555/commits/8ab97a92589827cb3fb900175da06ff73b7ff6b0), this bug was created. Returning `undefined` for an object value in echarts does not remove the previous value. Instead, what we do in this PR is still return the graphic object, but with empty strings for text values. I confirmed that echarts does not render anything (there's no DOM elements) when the strings are empty.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create any pie chart
2. Toggle the "show total" setting from the viz settings sidebar on and off
3. It should instantly update
4. Last selected value should be saved in viz settings, and respected after refresh

### Demo

https://github.com/user-attachments/assets/b7109677-1dcc-454d-9af2-fe5ed327635d

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
