### PR TITLE
test(sdk) Don't show notebook toggle button for brand new questions

### DIFF
--- a/e2e/support/helpers/e2e-notebook-helpers.ts
+++ b/e2e/support/helpers/e2e-notebook-helpers.ts
@@ -7,11 +7,15 @@ import {
 } from "e2e/support/helpers/e2e-ui-elements-helpers";
 import type { NotebookStepType } from "metabase/query_builder/components/notebook/types";
 
+export function notebookButton() {
+  return cy.findByTestId("qb-header-action-panel").icon("notebook");
+}
+
 /**
  * Switch to a notebook editor from a simple query view (aka "chill mode").
  */
 export function openNotebook() {
-  return cy.findByTestId("qb-header-action-panel").icon("notebook").click();
+  return notebookButton().click();
 }
 
 /**

--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -28,6 +28,8 @@ import {
   tableHeaderClick,
   onlyOnOSS,
   createQuestion,
+  openNotebook,
+  notebookButton,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -96,11 +98,17 @@ describe("scenarios > question > new", () => {
         cy.findByText("Orders, Count").click();
       });
 
+      cy.log("toggle notebook button should be hidden for brand new questions");
+      notebookButton().should("not.exist");
+
       visualize();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("18,760");
       // should reopen saved question picker after returning back to editor mode
-      cy.icon("notebook").click();
+      openNotebook();
+
+      notebookButton().should("be.visible");
+
       cy.findByTestId("data-step-cell").contains("Orders, Count").click();
       entityPickerModal().within(() => {
         // It is now possible to choose another saved question

--- a/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
@@ -106,8 +106,8 @@ describe("scenarios > question > notebook > native query preview sidebar", () =>
     cy.signIn("nosql");
     openReviewsTable({ mode: "notebook" });
     cy.findByTestId("qb-header-action-panel")
-      .find(".Icon")
-      .should("have.length", 1);
+      .findByLabelText(/view the sql/i)
+      .should("not.exist");
     cy.findByLabelText("View the SQL").should("not.exist");
     cy.findByTestId("native-query-preview-sidebar").should("not.exist");
     cy.get("code").should("not.exist");

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.NotebookButton.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.NotebookButton.unit.spec.tsx
@@ -11,6 +11,7 @@ import {
 import { renderWithProviders, screen } from "__support__/ui";
 import { createMockJwtConfig } from "embedding-sdk/test/mocks/config";
 import { setupSdkState } from "embedding-sdk/test/server-mocks/sdk-init";
+import { QuestionNotebookButton } from "metabase/query_builder/components/view/ViewHeader/components";
 import {
   createMockCard,
   createMockCardQueryMetadata,
@@ -62,7 +63,7 @@ const setup = ({
     TEST_CARD,
     createMockCardQueryMetadata({
       databases: [TEST_DB],
-      tables: [TEST_TABLE], // to be editable, card must have table and databse metadata
+      tables: [TEST_TABLE], // to be editable, card must have table and database metadata
     }),
   );
 
@@ -95,16 +96,25 @@ const setup = ({
 };
 
 describe("InteractiveQuestion.NotebookButton", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("should render the notebook button", async () => {
+    const shouldRenderSpy = jest.spyOn(QuestionNotebookButton, "shouldRender");
+
     setup({ isOpen: true });
 
     expect(await screen.findByLabelText("notebook icon")).toBeInTheDocument();
+    expect(shouldRenderSpy).toHaveBeenCalledTimes(1);
   });
 
   it("should fire click handler when clicking the notebook button", async () => {
+    const shouldRenderSpy = jest.spyOn(QuestionNotebookButton, "shouldRender");
     const { clickSpy } = setup({ isOpen: true });
 
     await userEvent.click(await screen.findByLabelText("notebook icon"));
+    expect(shouldRenderSpy).toHaveBeenCalledTimes(1);
     expect(clickSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.NotebookButton.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.NotebookButton.unit.spec.tsx
@@ -1,0 +1,110 @@
+import userEvent from "@testing-library/user-event";
+
+import {
+  setupAlertsEndpoints,
+  setupCardEndpoints,
+  setupCardQueryMetadataEndpoint,
+  setupCardQueryEndpoints,
+  setupDatabaseEndpoints,
+  setupTableEndpoints,
+} from "__support__/server-mocks";
+import { renderWithProviders, screen } from "__support__/ui";
+import { createMockJwtConfig } from "embedding-sdk/test/mocks/config";
+import { setupSdkState } from "embedding-sdk/test/server-mocks/sdk-init";
+import {
+  createMockCard,
+  createMockCardQueryMetadata,
+  createMockColumn,
+  createMockDatabase,
+  createMockDataset,
+  createMockDatasetData,
+  createMockTable,
+  createMockUser,
+} from "metabase-types/api/mocks";
+
+import { InteractiveQuestion } from "./InteractiveQuestion";
+
+const TEST_USER = createMockUser();
+const TEST_DB_ID = 1;
+const TEST_DB = createMockDatabase({ id: TEST_DB_ID });
+
+const TEST_TABLE_ID = 1;
+const TEST_TABLE = createMockTable({ id: TEST_TABLE_ID, db_id: TEST_DB_ID });
+
+const TEST_COLUMN = createMockColumn({
+  display_name: "Test Column",
+  name: "Test Column",
+});
+
+const TEST_DATASET = createMockDataset({
+  data: createMockDatasetData({
+    cols: [TEST_COLUMN],
+    rows: [["Test Row"]],
+  }),
+});
+
+const setup = ({
+  isOpen = true,
+}: {
+  isOpen?: boolean;
+} = {}) => {
+  const { state } = setupSdkState({
+    currentUser: TEST_USER,
+  });
+
+  const TEST_CARD = createMockCard({
+    can_delete: true,
+    enable_embedding: true,
+  });
+
+  setupCardEndpoints(TEST_CARD);
+  setupCardQueryMetadataEndpoint(
+    TEST_CARD,
+    createMockCardQueryMetadata({
+      databases: [TEST_DB],
+      tables: [TEST_TABLE], // to be editable, card must have table and databse metadata
+    }),
+  );
+
+  setupAlertsEndpoints(TEST_CARD, []);
+  setupDatabaseEndpoints(TEST_DB);
+
+  setupTableEndpoints(TEST_TABLE);
+
+  setupCardQueryEndpoints(TEST_CARD, TEST_DATASET);
+
+  const clickSpy = jest.fn();
+
+  renderWithProviders(
+    <InteractiveQuestion questionId={TEST_CARD.id}>
+      <div>Look! A Button! 👇</div>
+      <InteractiveQuestion.NotebookButton onClick={clickSpy} isOpen={isOpen} />
+    </InteractiveQuestion>,
+    {
+      mode: "sdk",
+      sdkProviderProps: {
+        config: createMockJwtConfig({
+          jwtProviderUri: "http://TEST_URI/sso/metabase",
+        }),
+      },
+      storeInitialState: state,
+    },
+  );
+
+  return { clickSpy };
+};
+
+describe("InteractiveQuestion.NotebookButton", () => {
+  it("should render the notebook button", async () => {
+    setup({ isOpen: true });
+
+    expect(await screen.findByLabelText("notebook icon")).toBeInTheDocument();
+  });
+
+  it("should fire click handler when clicking the notebook button", async () => {
+    const { clickSpy } = setup({ isOpen: true });
+
+    await userEvent.click(await screen.findByLabelText("notebook icon"));
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewTitleHeader.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewTitleHeader.unit.spec.js
@@ -326,6 +326,7 @@ describe("ViewTitleHeader", () => {
           const { setQueryBuilderMode } = setup({
             card,
             queryBuilderMode: "notebook",
+            result: { data: [] },
           });
           fireEvent.click(screen.getByLabelText("notebook icon"));
           expect(setQueryBuilderMode).toHaveBeenCalledWith("view");
@@ -464,6 +465,14 @@ describe("ViewHeader | Ad-hoc GUI question", () => {
         screen.queryByText("Total is less than 50"),
       ).not.toBeInTheDocument();
       expect(screen.queryByText("Tax is not empty")).not.toBeInTheDocument();
+    });
+
+    it("hides the close notebook editor for brand new questions", () => {
+      setup({
+        card,
+        queryBuilderMode: "notebook",
+      });
+      expect(screen.queryByLabelText("notebook icon")).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionNotebookButton/QuestionNotebookButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionNotebookButton/QuestionNotebookButton.tsx
@@ -43,12 +43,18 @@ export function QuestionNotebookButton({
 QuestionNotebookButton.shouldRender = ({
   question,
   isActionListVisible,
+  isBrandNew = false,
 }: {
   question: Question;
   isActionListVisible: boolean;
+  isBrandNew?: boolean;
 }) => {
   const { isEditable, isNative } = Lib.queryDisplayInfo(question.query());
   return (
-    !isNative && isEditable && isActionListVisible && !question.isArchived()
+    !isNative &&
+    isEditable &&
+    isActionListVisible &&
+    !question.isArchived() &&
+    !isBrandNew
   );
 };

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/ViewTitleHeaderRightSide/ViewTitleHeaderRightSide.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/ViewTitleHeaderRightSide/ViewTitleHeaderRightSide.tsx
@@ -180,16 +180,16 @@ export function ViewTitleHeaderRightSide({
           onCloseSummary={onCloseSummary}
         />
       )}
-      {!isBrandNew &&
-        QuestionNotebookButton.shouldRender({
-          question,
-          isActionListVisible,
-        }) && (
-          <QuestionNotebookButton
-            isShowingNotebook={isShowingNotebook}
-            setQueryBuilderMode={setQueryBuilderMode}
-          />
-        )}
+      {QuestionNotebookButton.shouldRender({
+        question,
+        isActionListVisible,
+        isBrandNew,
+      }) && (
+        <QuestionNotebookButton
+          isShowingNotebook={isShowingNotebook}
+          setQueryBuilderMode={setQueryBuilderMode}
+        />
+      )}
       {ToggleNativeQueryPreview.shouldRender({
         question,
         queryBuilderMode,

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/ViewTitleHeaderRightSide/ViewTitleHeaderRightSide.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/ViewTitleHeaderRightSide/ViewTitleHeaderRightSide.tsx
@@ -137,6 +137,8 @@ export function ViewTitleHeaderRightSide({
 
   const canSave = Lib.canSave(question.query(), question.type());
   const isSaveDisabled = !canSave;
+  const isBrandNew =
+    !question.isSaved() && !result && queryBuilderMode === "notebook";
   const disabledSaveTooltip = getDisabledSaveTooltip(isEditable);
 
   return (
@@ -178,15 +180,16 @@ export function ViewTitleHeaderRightSide({
           onCloseSummary={onCloseSummary}
         />
       )}
-      {QuestionNotebookButton.shouldRender({
-        question,
-        isActionListVisible,
-      }) && (
-        <QuestionNotebookButton
-          isShowingNotebook={isShowingNotebook}
-          setQueryBuilderMode={setQueryBuilderMode}
-        />
-      )}
+      {!isBrandNew &&
+        QuestionNotebookButton.shouldRender({
+          question,
+          isActionListVisible,
+        }) && (
+          <QuestionNotebookButton
+            isShowingNotebook={isShowingNotebook}
+            setQueryBuilderMode={setQueryBuilderMode}
+          />
+        )}
       {ToggleNativeQueryPreview.shouldRender({
         question,
         queryBuilderMode,


### PR DESCRIPTION

Closes https://github.com/metabase/metabase/issues/46252

### Description

Hides the notebook toggle button for brand new questions. Will be more visible once we make this button bigger in https://github.com/metabase/metabase/pull/46097.

![hideNotebookToggleButton](https://github.com/user-attachments/assets/8ecd2718-6d37-45c6-b2ec-10d40346c1ff)

![Screen Shot 2024-07-31 at 3 29 00 PM](https://github.com/user-attachments/assets/a7dda17a-75c8-4682-bf49-f3113c184c7c)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
