### PR TITLE
Fix coll permissions for audit collection

### DIFF
--- a/e2e/test/scenarios/organization/timelines-question.cy.spec.js
+++ b/e2e/test/scenarios/organization/timelines-question.cy.spec.js
@@ -302,96 +302,105 @@ describe("scenarios > organization > timelines > question", () => {
     });
 
     it("should toggle individual event visibility", () => {
-      cy.createTimelineWithEvents({
-        timeline: { name: "Releases" },
-        events: [
-          { name: "RC1", timestamp: "2024-10-20T00:00:00Z", icon: "cloud" },
-        ],
-      });
-
-      cy.createTimelineWithEvents({
-        timeline: { name: "Timeline for collection", collection_id: 2 },
-        events: [
-          { name: "TC1", timestamp: "2022-05-20T00:00:00Z", icon: "warning" },
-        ],
-      });
-
-      visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
-
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Visualization").should("be.visible");
-      echartsIcon("cloud").should("be.visible");
-
-      // should hide individual events from chart if hidden in sidebar
-      cy.icon("calendar").click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Releases").click();
-      toggleEventVisibility("RC1");
-
-      echartsIcon("cloud").should("not.exist");
-
-      // should show individual events in chart again
-      toggleEventVisibility("RC1");
-
-      echartsIcon("cloud").should("be.visible");
-
-      // should show a newly created event
-      cy.button("Add an event").click();
-      cy.findByLabelText("Event name").type("RC2");
-      cy.findByLabelText("Date").type("10/20/2023");
-      cy.button("Create").click();
-      cy.wait("@createEvent");
-
-      echartsIcon("star").should("be.visible");
-
-      // should then hide the newly created event
-      toggleEventVisibility("RC2");
-
-      echartsIcon("star").should("not.exist");
-
-      // its timeline, visible but having one hidden event
-      // should display its checkbox with a "dash" icon
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Releases")
-        .closest("[aria-label=Timeline card header]")
-        .within(() => {
-          cy.icon("dash").should("be.visible");
-
-          // Hide the timeline then show it again
-          cy.findByRole("checkbox").click();
-          cy.findByRole("checkbox").click();
+      cy.request("POST", "/api/collection", {
+        name: "Parent",
+        parent_id: null,
+      }).then(({ body: { id: PARENT_COLLECTION_ID } }) => {
+        cy.createTimelineWithEvents({
+          timeline: { name: "Releases" },
+          events: [
+            { name: "RC1", timestamp: "2024-10-20T00:00:00Z", icon: "cloud" },
+          ],
         });
 
-      // once timeline is visible, all its events should be visible
-      echartsIcon("star").should("be.visible");
-      echartsIcon("cloud").should("be.visible");
-
-      // should initialize events in a hidden timelime
-      // with event checkboxes unchecked
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Timeline for collection").click();
-
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("TC1")
-        .closest("[aria-label=Timeline event card]")
-        .within(() => {
-          cy.findByRole("checkbox").should("not.be.checked");
+        cy.createTimelineWithEvents({
+          timeline: {
+            name: "Timeline for collection",
+            collection_id: PARENT_COLLECTION_ID,
+          },
+          events: [
+            { name: "TC1", timestamp: "2022-05-20T00:00:00Z", icon: "warning" },
+          ],
         });
 
-      // making a hidden timeline visible
-      // should make its events automatically visible
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Timeline for collection")
-        .closest("[aria-label=Timeline card header]")
-        .within(() => cy.findByRole("checkbox").click());
+        visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
 
-      echartsIcon("warning").should("be.visible");
+        cy.findByTestId("view-footer")
+          .findByText("Visualization")
+          .should("be.visible");
+        echartsIcon("cloud").should("be.visible");
 
-      // events whose timeline was invisible on page load
-      // should be hideable once their timelines are visible
-      toggleEventVisibility("TC1");
+        // should hide individual events from chart if hidden in sidebar
+        cy.icon("calendar").click();
+        cy.findByTestId("sidebar-content").findByText("Releases").click();
+        toggleEventVisibility("RC1");
 
-      echartsIcon("warning").should("not.exist");
+        echartsIcon("cloud").should("not.exist");
+
+        // should show individual events in chart again
+        toggleEventVisibility("RC1");
+
+        echartsIcon("cloud").should("be.visible");
+
+        // should show a newly created event
+        cy.button("Add an event").click();
+        cy.findByLabelText("Event name").type("RC2");
+        cy.findByLabelText("Date").type("10/20/2023");
+        cy.button("Create").click();
+        cy.wait("@createEvent");
+
+        echartsIcon("star").should("be.visible");
+
+        // should then hide the newly created event
+        toggleEventVisibility("RC2");
+
+        echartsIcon("star").should("not.exist");
+
+        // its timeline, visible but having one hidden event
+        // should display its checkbox with a "dash" icon
+        cy.findByTestId("sidebar-content")
+          .findByText("Releases")
+          .closest("[aria-label=Timeline card header]")
+          .within(() => {
+            cy.icon("dash").should("be.visible");
+
+            // Hide the timeline then show it again
+            cy.findByRole("checkbox").click();
+            cy.findByRole("checkbox").click();
+          });
+
+        // once timeline is visible, all its events should be visible
+        echartsIcon("star").should("be.visible");
+        echartsIcon("cloud").should("be.visible");
+
+        // should initialize events in a hidden timelime
+        // with event checkboxes unchecked
+        cy.findByTestId("sidebar-content")
+          .findByText("Timeline for collection")
+          .click();
+
+        cy.findByTestId("sidebar-content")
+          .findByText("TC1")
+          .closest("[aria-label=Timeline event card]")
+          .within(() => {
+            cy.findByRole("checkbox").should("not.be.checked");
+          });
+
+        // making a hidden timeline visible
+        // should make its events automatically visible
+        cy.findByTestId("sidebar-content")
+          .findByText("Timeline for collection")
+          .closest("[aria-label=Timeline card header]")
+          .within(() => cy.findByRole("checkbox").click());
+
+        echartsIcon("warning").should("be.visible");
+
+        // events whose timeline was invisible on page load
+        // should be hideable once their timelines are visible
+        toggleEventVisibility("TC1");
+
+        echartsIcon("warning").should("not.exist");
+      });
     });
 
     it("should color the event icon when hovering", () => {

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -961,7 +961,9 @@
 (defn- effective-children-ids
   "Returns effective children ids for collection."
   [collection permissions-set]
-  (let [visible-collection-ids (set (collection/permissions-set->visible-collection-ids permissions-set))
+  (let [visible-collection-ids (set (collection/permissions-set->visible-collection-ids
+                                     permissions-set
+                                     {:permission-level :write}))
         all-descendants (map :id (collection/descendants-flat collection))]
     (filterv visible-collection-ids all-descendants)))
 

--- a/test/metabase/models/collection_test.clj
+++ b/test/metabase/models/collection_test.clj
@@ -380,7 +380,8 @@
                                                                                   :include-archived-items :all}))))))))
 
 (deftest effective-location-path-test
-  (with-redefs [collection/collection-id->collection (constantly
+  (with-redefs [audit/is-collection-id-audit? (constantly false)
+                collection/collection-id->collection (constantly
                                                       (zipmap (map * (next (range 10)) (repeat 10))
                                                               (next (map (fn [id]
                                                                            {:id id


### PR DESCRIPTION
We've had a function in `models.collection` for a while that has taken a permissions set and returned a set of collection IDs that the user has permissions on. I refactored this recently, but didn't notice that it was actually doing the permissions checks slightly incorrectly, and kept that wrong behavior in my refactor. Specifically, because it only looks at the user's permissions and the collection IDs and doesn't use `mi/can-read?` or `mi/can-write?`, it's completely indifferent to whether a collection is an audit collection or not.

This is arguably not a *permissions* issue: the two errors that could come about here are:

- someone sees the audit collection even though the audit feature is disabled, or

- someone is presented with the audit collection in a context where only writable collections should be present - when they try to actually write to it, it fails (since then we're doing the real permissions check).

The primary motivation for this fix was to prevent audit dashboards and cards from appearing in the list of stale items.