### PR TITLE
[serdes] http api: be more picky about files we unpack from an archive

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/api.clj
@@ -1,7 +1,6 @@
 (ns metabase-enterprise.serialization.api
   (:require
    [clojure.java.io :as io]
-   [clojure.set :as set]
    [clojure.string :as str]
    [compojure.core :refer [POST]]
    [java-time.api :as t]
@@ -106,8 +105,7 @@
   (->> (.listFiles parent)
        (u/seek (fn [^File f]
                  (and (.isDirectory f)
-                      (seq (set/intersection v2.ingest/legal-top-level-paths
-                                             (set (.list f)))))))))
+                      (some v2.ingest/legal-top-level-paths (.list f)))))))
 
 (defn- unpack&import [^File file & [size]]
   (let [dst      (io/file parent-dir (u.random/random-name))

--- a/enterprise/backend/src/metabase_enterprise/serialization/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/api.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.serialization.api
   (:require
    [clojure.java.io :as io]
+   [clojure.set :as set]
    [clojure.string :as str]
    [compojure.core :refer [POST]]
    [java-time.api :as t]
@@ -98,6 +99,16 @@
                       (when (.exists dst)
                         (io/delete-file dst)))}))
 
+(defn- find-serialization-dir
+  "Find an actual top-level dir with serialization data inside, instead of picking up various .DS_Store and similar
+  things."
+  ^File [^File parent]
+  (->> (.listFiles parent)
+       (u/seek (fn [^File f]
+                 (and (.isDirectory f)
+                      (seq (set/intersection v2.ingest/legal-top-level-paths
+                                             (set (.list f)))))))))
+
 (defn- unpack&import [^File file & [size]]
   (let [dst      (io/file parent-dir (u.random/random-name))
         log-file (io/file dst "import.log")
@@ -106,9 +117,14 @@
                                                     {:additive *additive-logging*})]
                    (try                 ; try/catch inside logging to log errors
                      (log/infof "Serdes import, size %s" size)
-                     (let [path (u.compress/untgz file dst)]
+                     (let [cnt  (u.compress/untgz file dst)
+                           path (find-serialization-dir dst)]
+                       (when-not path
+                         (throw (ex-info "No source dir detected" {:dst   (.getPath dst)
+                                                                   :count cnt})))
+                       (log/infof "In total %s entries unpacked, detected source dir: %s" cnt (.getName path))
                        (serdes/with-cache
-                         (-> (v2.ingest/ingest-yaml (.getPath (io/file dst path)))
+                         (-> (v2.ingest/ingest-yaml (.getPath path))
                              (v2.load/load-metabase!))))
                      (catch Exception e
                        (reset! err e)

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/ingest.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/ingest.clj
@@ -56,7 +56,7 @@
       (yaml/from-file {:key-fn parse-key})
       read-timestamps))
 
-(def ^:private legal-top-level-paths
+(def legal-top-level-paths "Known top-level paths for directory with serialization output"
   #{"actions" "collections" "databases" "snippets"}) ; But return the hierarchy without labels.
 
 (defn- ingest-all [^File root-dir]

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
@@ -108,4 +108,5 @@
                     :seen      #{}
                     :ingestion ingestion
                     :from-ids  (m/index-by :id contents)}]
+      (log/infof "Starting deserialization, total %s documents" (count contents))
       (reduce load-one! ctx contents))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
@@ -212,6 +212,10 @@
   (testing "We are able to find serialization dir even in presence of various hidden dirs"
     (let [dst (io/file api.serialization/parent-dir (u.random/random-name))]
       (.mkdirs (io/file dst "._hidden_dir"))
+      (.mkdirs (io/file dst "not_hidden_dir"))
+      (is (= nil
+             (#'api.serialization/find-serialization-dir dst)))
       (.mkdirs (io/file dst "real_dir" "collections"))
       (is (= "real_dir"
-             (.getName ^File (#'api.serialization/find-serialization-dir dst)))))))
+             (.getName ^File (#'api.serialization/find-serialization-dir dst))))
+      (run! io/delete-file (reverse (file-seq dst))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
@@ -8,8 +8,10 @@
    [metabase.models :refer [Card Collection Dashboard]]
    [metabase.test :as mt]
    [metabase.util.compress :as u.compress]
+   [metabase.util.random :as u.random]
    [toucan2.core :as t2])
   (:import
+   (java.io File)
    (org.apache.commons.compress.archivers.tar TarArchiveEntry TarArchiveInputStream)
    (org.apache.commons.compress.compressors.gzip GzipCompressorInputStream)))
 
@@ -90,7 +92,7 @@
                     (let [res   (mt/user-http-request :crowberto :post 500 "ee/serialization/export" {}
                                                       :collection (:id coll) :data_model false :settings false)
                           lines (str/split-lines (slurp (io/input-stream res)))]
-                      (testing "First three lines for coll+dash+card, and then error during compression"
+                      (testing "First three lines for coll+dash+card, and then an error during compression"
                         (is (= #{"Collection" "Dashboard" "Card"}
                                (log-types (take 3 lines))))
                         (is (re-find #"deliberate error message" (str/join "\n" (->> lines (drop 3) (take 3))))))))))
@@ -205,3 +207,11 @@
         ;; in `api/on-response!`, so maybe add some Thread/sleep here.
         (is (= known-files
                (set (.list (io/file api.serialization/parent-dir)))))))))
+
+(deftest find-serialization-dir-test
+  (testing "We are able to find serialization dir even in presence of various hidden dirs"
+    (let [dst (io/file api.serialization/parent-dir (u.random/random-name))]
+      (.mkdirs (io/file dst "._hidden_dir"))
+      (.mkdirs (io/file dst "real_dir" "collections"))
+      (is (= "real_dir"
+             (.getName ^File (#'api.serialization/find-serialization-dir dst)))))))

--- a/src/metabase/util/compress.clj
+++ b/src/metabase/util/compress.clj
@@ -40,7 +40,8 @@
     dst))
 
 (defn untgz
-  "Uncompress tar+gzip file `archive` to a directory `dst`."
+  "Uncompress tar+gzip file `archive` to a directory `dst`.
+  Skips hidden entries, returns number of unpacked entries (files + dirs)."
   [^File archive ^File dst]
   (with-open [tar (-> (io/input-stream archive)
                       (GzipCompressorInputStream.)

--- a/src/metabase/util/compress.clj
+++ b/src/metabase/util/compress.clj
@@ -1,6 +1,7 @@
 (ns metabase.util.compress
   (:require
-   [clojure.java.io :as io])
+   [clojure.java.io :as io]
+   [clojure.string :as str])
   (:import
    (java.io File)
    (org.apache.commons.compress.archivers.tar TarArchiveEntry TarArchiveInputStream TarArchiveOutputStream)
@@ -44,11 +45,14 @@
   (with-open [tar (-> (io/input-stream archive)
                       (GzipCompressorInputStream.)
                       (TarArchiveInputStream.))]
-    (let [[dir :as tar-entries] (entries tar)]
-      (doseq [^TarArchiveEntry e tar-entries]
-        (let [f (io/file dst (.getName e))]
-          (if (.isFile e)
-            (io/copy tar f)
-            (.mkdirs f))))
-      (when dir
-        (.getName ^TarArchiveEntry dir)))))
+    (let [tar-entries (entries tar)]
+      (count
+       (for [^TarArchiveEntry e tar-entries
+             :let [actual-name (last (.split (.getName e) "/"))]
+             ;; skip hidden files
+             :when (not (str/starts-with? actual-name "."))]
+         (let [f (io/file dst (.getName e))]
+           (if (.isFile e)
+             (io/copy tar f)
+             (.mkdirs f))
+           true))))))


### PR DESCRIPTION
Previously we unpacked everything and picked up first entry as the directory containing the data. This works well when archives are passed as is. However, if a user unpacks and then packs an archive, there is a good chance that some hidden directories will appear - and they are first in order.

So we skip those right now, and additionally check known markers of the serialization data directory.

[Context](https://metaboat.slack.com/archives/C05MPF0TM3L/p1722438171600739?thread_ts=1722425662.581279&cid=C05MPF0TM3L)