### PR TITLE
e2e: Remove flaky tag from timeseries question with a goal test in alert-types spec

### DIFF
--- a/e2e/test/scenarios/sharing/alert/alert-types.cy.spec.js
+++ b/e2e/test/scenarios/sharing/alert/alert-types.cy.spec.js
@@ -67,38 +67,34 @@ describe("scenarios > alert > types", { tags: "@external" }, () => {
   });
 
   describe("goal based alerts", () => {
-    it(
-      "should work for timeseries questions with a set goal",
-      { tags: "@flaky" },
-      () => {
-        cy.request("PUT", `/api/card/${timeSeriesQuestionId}`, {
-          visualization_settings: {
-            "graph.show_goal": true,
-            "graph.goal_value": 7000,
-            "graph.dimensions": ["CREATED_AT"],
-            "graph.metrics": ["count"],
-          },
-        });
+    it("should work for timeseries questions with a set goal", () => {
+      cy.request("PUT", `/api/card/${timeSeriesQuestionId}`, {
+        visualization_settings: {
+          "graph.show_goal": true,
+          "graph.goal_value": 7000,
+          "graph.dimensions": ["CREATED_AT"],
+          "graph.metrics": ["count"],
+        },
+      });
 
-        cy.log("Set the goal on timeseries question");
-        visitQuestion(timeSeriesQuestionId);
-        cy.findByTestId("chart-container").should("contain", "Goal");
+      cy.log("Set the goal on timeseries question");
+      visitQuestion(timeSeriesQuestionId);
+      cy.findByTestId("chart-container").should("contain", "Goal");
 
-        openAlertModal();
-        cy.findByTestId("alert-create").within(() => {
-          cy.findByText("Reaches the goal line").click();
-          cy.findByText("The first time").click();
-          cy.button("Done").click();
-        });
+      openAlertModal();
+      cy.findByTestId("alert-create").within(() => {
+        cy.findByText("Reaches the goal line").click();
+        cy.findByText("The first time").click();
+        cy.button("Done").click();
+      });
 
-        cy.log("Check the API response");
-        cy.wait("@savedAlert").then(({ response: { body } }) => {
-          expect(body.alert_condition).to.equal("goal");
-          expect(body.alert_above_goal).to.equal(true);
-          expect(body.alert_first_only).to.equal(true);
-        });
-      },
-    );
+      cy.log("Check the API response");
+      cy.wait("@savedAlert").then(({ response: { body } }) => {
+        expect(body.alert_condition).to.equal("goal");
+        expect(body.alert_above_goal).to.equal(true);
+        expect(body.alert_first_only).to.equal(true);
+      });
+    });
 
     it("should not be possible to create goal based alert for a multi-series question", () => {
       cy.createQuestion(multiSeriesQuestionWithGoal, { visitQuestion: true });


### PR DESCRIPTION
### Stress-test on `master`
50/50 ✅ https://github.com/metabase/metabase/actions/runs/10196749153