### PR TITLE
Permissions modal dismiss patch

### DIFF
--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -634,6 +634,39 @@ describe("scenarios > admin > permissions", () => {
     );
     cy.findByRole("alert").should("not.exist");
   });
+
+  it("split permermisson change modal should dismiss even if network request fails", () => {
+    // We need a way to pass true values for these settings in CI. Generally in CI, these values will always be false
+    // because we always start with a fresh instance. However, to test the flow of someone who has upgraded from 49 -> current
+    // we set them to false and ensure a modal is shown explaining the new permissions structure
+    const tempState = {
+      "show-updated-permission-modal": true,
+    };
+
+    // When the app calls for session properties, give them a modified API response
+    cy.intercept("/api/session/properties", req => {
+      req.continue(res => {
+        res.body = { ...res.body, ...tempState };
+      });
+    }).as("sessionProps");
+
+    // These calls are setting the permission to false, so update the local state. When the settings are refreshed
+    // from the browser, they will get the new values from local state
+    cy.intercept("api/setting/show-updated-permission-modal", {
+      statusCode: 500,
+    });
+
+    cy.visit("/admin/permissions/");
+    //Both the command palette and the admin app call refresh settings
+    cy.wait(["@sessionProps", "@sessionProps"]);
+
+    cy.findByRole("dialog", { name: /permissions may look different/ })
+      .findByRole("button", { name: "Got it" })
+      .click();
+    cy.wait("@sessionProps");
+
+    cy.findByRole("menuitem", { name: "All Users" }).click();
+  });
 });
 
 describe("scenarios > admin > permissions", () => {

--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -582,7 +582,7 @@ describe("scenarios > admin > permissions", () => {
     });
   });
 
-  it("should show a dismissable modal and banner showing split permermisson changes (#metabase#45073", () => {
+  it("should show a dismissable modal and banner showing split permisson changes (#metabase#45073", () => {
     // We need a way to pass true values for these settings in CI. Generally in CI, these values will always be false
     // because we always start with a fresh instance. However, to test the flow of someone who has upgraded from 49 -> current
     // we set them to false and ensure a modal is shown explaining the new permissions structure
@@ -635,7 +635,7 @@ describe("scenarios > admin > permissions", () => {
     cy.findByRole("alert").should("not.exist");
   });
 
-  it("split permermisson change modal should dismiss even if network request fails", () => {
+  it("split permisson change modal should dismiss even if network request fails", () => {
     // We need a way to pass true values for these settings in CI. Generally in CI, these values will always be false
     // because we always start with a fresh instance. However, to test the flow of someone who has upgraded from 49 -> current
     // we set them to false and ensure a modal is shown explaining the new permissions structure

--- a/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsPageLayout.tsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsPageLayout.tsx
@@ -21,6 +21,7 @@ import ModalContent from "metabase/components/ModalContent";
 import Button from "metabase/core/components/Button";
 import CS from "metabase/css/core/index.css";
 import fitViewport from "metabase/hoc/FitViewPort";
+import { useToggle } from "metabase/hooks/use-toggle";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { updateUserSetting } from "metabase/redux/settings";
 import type { IconName } from "metabase/ui";
@@ -80,8 +81,11 @@ function PermissionsPageLayout({
   route,
   toolbarRightContent,
   helpContent,
-  showSplitPermsModal = false,
+  showSplitPermsModal: _showSplitPermsModal = false,
 }: PermissionsPageLayoutProps) {
+  const [showSplitPermsModal, { turnOff: disableSplitPermsModal }] =
+    useToggle(_showSplitPermsModal);
+
   const saveError = useSelector(state => state.admin.permissions.saveError);
   const showRefreshModal = useSelector(showRevisionChangedModal);
 
@@ -97,6 +101,7 @@ function PermissionsPageLayout({
   }, [dispatch]);
 
   const handleDimissSplitPermsModal = () => {
+    disableSplitPermsModal();
     dispatch(
       updateUserSetting({ key: "show-updated-permission-modal", value: false }),
     );


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/46380

### Description
Previously, the modal was shown purely based on the settings in the redux store. This meant that if the request to update the value (and then refresh the settings) failed, the value would never change and the modal would not technically be dismissable

This changes moves that value that determines if we're showing the modal or not to component level state. This means that the modal can be dismissed regardless of whether or not the network request succeeds. It's worth noting that if the request does fail, the modal will appear again if you navigate away and then back to the permissions page.

### How to verify
1. Have an instance that was set up before version 50, and migrated up to 50
2. Go to the permissions page. A modal should appear explaining how permissions have changed
3. Find a way to make requests to `/api/setting/show-updated-permission-modal` to error
4. Dismiss the modal. You should see an error in your network tab, but the modal should still dismiss.

### Demo
![chrome_XJNQVgWbX7](https://github.com/user-attachments/assets/d7cc7ec7-feb1-416e-8129-48c76ccb7e92)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
