### PR TITLE
fix pie slice border missing in backend static viz

### DIFF
--- a/frontend/src/metabase/visualizations/hooks/use-browser-rendering-context.ts
+++ b/frontend/src/metabase/visualizations/hooks/use-browser-rendering-context.ts
@@ -26,11 +26,11 @@ export const useBrowserRenderingContext = (
   const isNightMode = useSelector(getIsNightMode);
 
   return useMemo(() => {
-    const style = getVisualizationTheme(
-      theme.other,
+    const style = getVisualizationTheme({
+      theme: theme.other,
       isDashboard,
-      isNightMode && isFullscreen,
-    );
+      isNightmode: isNightMode && isFullscreen,
+    });
 
     return {
       getColor: name => color(name, palette),

--- a/frontend/src/metabase/visualizations/hooks/use-browser-rendering-context.ts
+++ b/frontend/src/metabase/visualizations/hooks/use-browser-rendering-context.ts
@@ -29,7 +29,7 @@ export const useBrowserRenderingContext = (
     const style = getVisualizationTheme({
       theme: theme.other,
       isDashboard,
-      isNightmode: isNightMode && isFullscreen,
+      isNightMode: isNightMode && isFullscreen,
     });
 
     return {

--- a/frontend/src/metabase/visualizations/shared/components/RowChart/RowChart.stories.tsx
+++ b/frontend/src/metabase/visualizations/shared/components/RowChart/RowChart.stories.tsx
@@ -85,7 +85,7 @@ export const Default = Template.bind({});
 Default.args = DEFAULT_ROW_CHART_ARGS;
 
 const ThemedRowChart = () => {
-  const theme = useRowChartTheme("Lato");
+  const theme = useRowChartTheme("Lato", false, false);
 
   return (
     <Box h={600} bg="white" p="8px">

--- a/frontend/src/metabase/visualizations/shared/utils/theme.ts
+++ b/frontend/src/metabase/visualizations/shared/utils/theme.ts
@@ -24,17 +24,22 @@ function getPieBorderColor(
 /**
  * Computes the visualization style from the Mantine theme.
  */
-export function getVisualizationTheme(
-  options: MantineThemeOther,
-  isDashboard?: boolean,
-  isNightMode?: boolean,
-  isStaticViz?: boolean,
-): VisualizationTheme {
-  const { cartesian } = options;
+export function getVisualizationTheme({
+  theme,
+  isDashboard,
+  isNightMode,
+  isStaticViz,
+}: {
+  theme: MantineThemeOther;
+  isDashboard?: boolean;
+  isNightMode?: boolean;
+  isStaticViz?: boolean;
+}): VisualizationTheme {
+  const { cartesian } = theme;
 
   // This allows sdk users to set the base font size,
   // which scales the visualization's font sizes.
-  const baseFontSize = getSizeInPx(options.fontSize);
+  const baseFontSize = getSizeInPx(theme.fontSize);
 
   // ECharts requires font sizes in px for offset calculations.
   const px = (value: string) =>
@@ -50,14 +55,12 @@ export function getVisualizationTheme(
     pie: {
       borderColor: isStaticViz
         ? color("text-white")
-        : getPieBorderColor(options, isDashboard, isNightMode),
+        : getPieBorderColor(theme, isDashboard, isNightMode),
     },
   };
 }
 
-export const DEFAULT_VISUALIZATION_THEME = getVisualizationTheme(
-  DEFAULT_METABASE_COMPONENT_THEME,
-  false,
-  false,
-  true,
-);
+export const DEFAULT_VISUALIZATION_THEME = getVisualizationTheme({
+  theme: DEFAULT_METABASE_COMPONENT_THEME,
+  isStaticViz: true,
+});

--- a/frontend/src/metabase/visualizations/shared/utils/theme.ts
+++ b/frontend/src/metabase/visualizations/shared/utils/theme.ts
@@ -5,7 +5,8 @@ import { getSizeInPx } from "metabase/visualizations/shared/utils/size-in-px";
 import type { VisualizationTheme } from "metabase/visualizations/types";
 
 function getPieBorderColor(
-  options: MantineThemeOther,
+  dashboardCardBg: string,
+  questionBg: string,
   isDashboard: boolean | undefined,
   isNightMode: boolean | undefined,
 ) {
@@ -13,12 +14,12 @@ function getPieBorderColor(
     return "var(--mb-color-bg-night)";
   }
   if (isDashboard) {
-    return options.dashboard.card.backgroundColor;
+    return dashboardCardBg;
   }
-  if (options.question.backgroundColor === "transparent") {
+  if (questionBg === "transparent") {
     return "var(--mb-color-bg-white)";
   }
-  return options.question.backgroundColor;
+  return questionBg;
 }
 
 /**
@@ -30,12 +31,15 @@ export function getVisualizationTheme({
   isNightMode,
   isStaticViz,
 }: {
-  theme: MantineThemeOther;
+  theme: Partial<MantineThemeOther>;
   isDashboard?: boolean;
   isNightMode?: boolean;
   isStaticViz?: boolean;
 }): VisualizationTheme {
-  const { cartesian } = theme;
+  const { cartesian, dashboard, question } = theme;
+  if (cartesian == null || dashboard == null || question == null) {
+    throw Error("Missing required theme values");
+  }
 
   // This allows sdk users to set the base font size,
   // which scales the visualization's font sizes.
@@ -55,7 +59,12 @@ export function getVisualizationTheme({
     pie: {
       borderColor: isStaticViz
         ? color("text-white")
-        : getPieBorderColor(theme, isDashboard, isNightMode),
+        : getPieBorderColor(
+            dashboard.card.backgroundColor,
+            question.backgroundColor,
+            isDashboard,
+            isNightMode,
+          ),
     },
   };
 }

--- a/frontend/src/metabase/visualizations/shared/utils/theme.ts
+++ b/frontend/src/metabase/visualizations/shared/utils/theme.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_METABASE_COMPONENT_THEME } from "embedding-sdk/lib/theme";
+import { color } from "metabase/lib/colors";
 import type { MantineThemeOther } from "metabase/ui";
 import { getSizeInPx } from "metabase/visualizations/shared/utils/size-in-px";
 import type { VisualizationTheme } from "metabase/visualizations/types";
@@ -27,6 +28,7 @@ export function getVisualizationTheme(
   options: MantineThemeOther,
   isDashboard?: boolean,
   isNightMode?: boolean,
+  isStaticViz?: boolean,
 ): VisualizationTheme {
   const { cartesian } = options;
 
@@ -46,11 +48,16 @@ export function getVisualizationTheme(
       },
     },
     pie: {
-      borderColor: getPieBorderColor(options, isDashboard, isNightMode),
+      borderColor: isStaticViz
+        ? color("text-white")
+        : getPieBorderColor(options, isDashboard, isNightMode),
     },
   };
 }
 
 export const DEFAULT_VISUALIZATION_THEME = getVisualizationTheme(
   DEFAULT_METABASE_COMPONENT_THEME,
+  false,
+  false,
+  true,
 );

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
@@ -139,7 +139,7 @@ const RowChartVisualization = ({
   );
   const goal = useMemo(() => getChartGoal(settings), [settings]);
   const stackOffset = getStackOffset(settings);
-  const theme = useRowChartTheme(fontFamily);
+  const theme = useRowChartTheme(fontFamily, isDashboard, isFullscreen);
 
   const chartWarnings = useMemo(
     () => getChartWarnings(chartColumns, data.rows),

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/utils/theme.ts
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/utils/theme.ts
@@ -1,17 +1,26 @@
 import { useMemo } from "react";
 
+import { getIsNightMode } from "metabase/dashboard/selectors";
 import { color } from "metabase/lib/colors";
+import { useSelector } from "metabase/lib/redux";
 import { useMantineTheme } from "metabase/ui";
 import type { RowChartTheme } from "metabase/visualizations/shared/components/RowChart/types";
 import { getVisualizationTheme } from "metabase/visualizations/shared/utils/theme";
 
 export const useRowChartTheme = (
   fontFamily: string = "Lato",
+  isDashboard: boolean,
+  isFullscreen: boolean,
 ): RowChartTheme => {
+  const isNightMode = useSelector(getIsNightMode);
   const theme = useMantineTheme();
 
   return useMemo(() => {
-    const { cartesian } = getVisualizationTheme(theme.other);
+    const { cartesian } = getVisualizationTheme({
+      theme: theme.other,
+      isNightMode: isNightMode && isFullscreen,
+      isDashboard,
+    });
 
     return {
       axis: {

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/utils/theme.ts
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/utils/theme.ts
@@ -57,5 +57,5 @@ export const useRowChartTheme = (
         color: color("border"),
       },
     };
-  }, [theme, fontFamily]);
+  }, [theme, fontFamily, isDashboard, isFullscreen, isNightMode]);
 };


### PR DESCRIPTION
### Description

In https://github.com/metabase/metabase/pull/43555/commits/1fab1f8d18e1d227cb865db97abe07349455661b, we accidentally removed the pie slice border from the subscription output, since the backend could not read the css variable we were using.

This PR fixes that by not using the css var for static viz, and instead using the default white color. This is fine because we don't have customizable subscriptions (e.g. background will always be white).

### How to verify

1. Create a pie chart
2. Add to a dashboard
3. Send a subscription
4. Confirm it has the white border around slices

### Demo


![Screenshot 2024-08-01 at 10.06.45 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/f485030a-1508-4566-b249-86390d79caa2.png)

Static viz is fixed

![Screenshot 2024-08-01 at 10.07.21 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/72d2b811-b201-4c16-82fe-edf584066967.png)

Storybook is still correct

![Screenshot 2024-08-01 at 10.06.57 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/59ed95f5-d6e2-489f-8a26-dc8619589d26.png)

In-app viz is still correct

![Screenshot 2024-08-01 at 10.27.45 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/36830138-5d5b-48c2-8b05-9e3c1dad52f5.png)

Night mode is still correct

![Screenshot 2024-08-01 at 10.06.54 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/b771759a-d247-4580-b906-a0022bcd79fe.png)

Embedded storybook example is still correct

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR

_Hard to test since the bug didn't occur in storybook, only after rendering the png with batik._