### PR TITLE
Avoid sorting by missing aggregation reference

### DIFF
--- a/src/metabase/models/params/custom_values.clj
+++ b/src/metabase/models/params/custom_values.clj
@@ -72,8 +72,7 @@
                                         (-> card :dataset_query :query))]
                  ;; MBQL query - hijack the final stage, drop its aggregation and breakout (if any).
                  (-> inner-mbql
-                     (dissoc :aggregation)
-                     (dissoc :order-by)
+                     (dissoc :aggregation :order-by)
                      (assoc :breakout [value-field-ref])
                      (update :limit (fnil min *max-rows*) *max-rows*)
                      (update :filter (fn [old]

--- a/src/metabase/models/params/custom_values.clj
+++ b/src/metabase/models/params/custom_values.clj
@@ -73,6 +73,7 @@
                  ;; MBQL query - hijack the final stage, drop its aggregation and breakout (if any).
                  (-> inner-mbql
                      (dissoc :aggregation)
+                     (dissoc :order-by)
                      (assoc :breakout [value-field-ref])
                      (update :limit (fnil min *max-rows*) *max-rows*)
                      (update :filter (fn [old]

--- a/test/metabase/models/params/custom_values_test.clj
+++ b/test/metabase/models/params/custom_values_test.clj
@@ -248,3 +248,23 @@
                                             :value_field [:field 0 nil]}}
                     nil
                     (constantly mock-default-result))))))))))
+
+(deftest ^:parallel order-by-aggregation-fields-test
+  (testing "Values could be retrieved for queries containing ordering by aggregation"
+    (doseq [model? [true false]]
+      (testing (format "source card is a %s" (if model? "model" "question"))
+        (mt/with-temp
+          [Card {card-id :id} (merge (-> (mt/mbql-query
+                                          products
+                                          {:aggregation [[:count]]
+                                           :breakout    [$category !month.created_at]
+                                           :order-by    [[:asc [:aggregation 0]]]})
+                                         mt/card-with-source-metadata-for-query)
+                                     {:database_id     (mt/id)
+                                      :type            (if model? :model :question)
+                                      :table_id        (mt/id :products)})]
+          (is (= {:has_more_values false
+                  :values          [["Doohickey"] ["Gadget"] ["Gizmo"] ["Widget"]]}
+                 (custom-values/values-from-card
+                  (t2/select-one Card :id card-id)
+                  (mt/$ids $products.category)))))))))

--- a/test/metabase/models/params/custom_values_test.clj
+++ b/test/metabase/models/params/custom_values_test.clj
@@ -250,7 +250,7 @@
                     (constantly mock-default-result))))))))))
 
 (deftest ^:parallel order-by-aggregation-fields-test
-  (testing "Values could be retrieved for queries containing ordering by aggregation"
+  (testing "Values could be retrieved for queries containing ordering by aggregation (#46369)"
     (doseq [model? [true false]]
       (testing (format "source card is a %s" (if model? "model" "question"))
         (mt/with-temp


### PR DESCRIPTION
Closes #46369

In `values-from-card-query` aggregation was originally removed from the last stage of a query, but not the order by clause. Queries could then end up referencing removed aggregation in order by. This PR addresses that.