### PR TITLE
[Auto Clean-up] Use EE API Endpoints

### DIFF
--- a/e2e/test/scenarios/collections/cleanup.cy.spec.js
+++ b/e2e/test/scenarios/collections/cleanup.cy.spec.js
@@ -203,7 +203,7 @@ describe("scenarios > collections > clean up", () => {
 
     it("show empty and error states correctly", () => {
       cy.log("should handle empty state");
-      cy.intercept("GET", "/api/collection/**/stale?**").as("stale-items");
+      cy.intercept("GET", "/api/ee/stale/**?**").as("stale-items");
 
       // visit collection w/ items but no stale items
       createCollection({ name: "Not empty w/ not stale items" })
@@ -231,7 +231,7 @@ describe("scenarios > collections > clean up", () => {
       });
 
       cy.log("should handle error state");
-      cy.intercept("GET", "/api/collection/**/stale?**", {
+      cy.intercept("GET", "/api/ee/stale/**?**", {
         statusCode: 500,
       }).as("stale-items");
 

--- a/enterprise/frontend/src/metabase-enterprise/api/collection.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/collection.ts
@@ -12,9 +12,9 @@ export const collectionApi = EnterpriseApi.injectEndpoints({
       ListStaleCollectionItemsResponse,
       ListStaleCollectionItemsRequest
     >({
-      query: ({ id, ...params }) => ({
+      query: ({ id: collectionId, ...params }) => ({
         method: "GET",
-        url: `/api/ee/collection/${id}/stale`,
+        url: `/api/ee/stale/${collectionId}`,
         params,
       }),
       providesTags: response =>

--- a/enterprise/frontend/src/metabase-enterprise/api/collection.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/collection.ts
@@ -1,0 +1,29 @@
+import { provideCollectionItemListTags } from "metabase/api/tags";
+import type {
+  ListStaleCollectionItemsRequest,
+  ListStaleCollectionItemsResponse,
+} from "metabase-enterprise/clean_up/types";
+
+import { EnterpriseApi } from "./api";
+
+export const collectionApi = EnterpriseApi.injectEndpoints({
+  endpoints: builder => ({
+    listStaleCollectionItems: builder.query<
+      ListStaleCollectionItemsResponse,
+      ListStaleCollectionItemsRequest
+    >({
+      query: ({ id, ...params }) => ({
+        method: "GET",
+        url: `/api/ee/collection/${id}/stale`,
+        params,
+      }),
+      providesTags: response =>
+        provideCollectionItemListTags(response?.data ?? [], [
+          "card",
+          "dashboard",
+        ]),
+    }),
+  }),
+});
+
+export const { useListStaleCollectionItemsQuery } = collectionApi;

--- a/enterprise/frontend/src/metabase-enterprise/clean_up/CleanupCollectionModal/CleanupCollectionModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/clean_up/CleanupCollectionModal/CleanupCollectionModal.tsx
@@ -3,7 +3,7 @@ import { withRouter } from "react-router";
 import { t } from "ttag";
 import _ from "underscore";
 
-import { skipToken, useListStaleCollectionItemsQuery } from "metabase/api";
+import { skipToken } from "metabase/api";
 import { DelayedLoadingAndErrorWrapper } from "metabase/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
 import { PaginationControls } from "metabase/components/PaginationControls";
 import Search from "metabase/entities/search";
@@ -11,8 +11,10 @@ import { useListSelect } from "metabase/hooks/use-list-select";
 import { useDispatch } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { Flex, Modal } from "metabase/ui";
-import type { StaleCollectionItem } from "metabase-types/api";
+import { useListStaleCollectionItemsQuery } from "metabase-enterprise/api/collection";
 import { SortDirection, type SortingOptions } from "metabase-types/api/sorting";
+
+import type { StaleCollectionItem } from "../types";
 
 import { CleanupCollectionBulkActions } from "./CleanupCollectionBulkActions";
 import CS from "./CleanupCollectionModal.module.css";

--- a/enterprise/frontend/src/metabase-enterprise/clean_up/CleanupCollectionModal/CleanupCollectionTable.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/clean_up/CleanupCollectionModal/CleanupCollectionTable.tsx
@@ -13,8 +13,9 @@ import {
 import { Columns } from "metabase/components/ItemsTable/Columns";
 import { Ellipsified } from "metabase/core/components/Ellipsified";
 import { FixedSizeIcon, Flex, Tooltip } from "metabase/ui";
-import type { StaleCollectionItem } from "metabase-types/api";
 import type { SortingOptions } from "metabase-types/api/sorting";
+
+import type { StaleCollectionItem } from "../types";
 
 import CS from "./CleanupCollectionTable.module.css";
 import { itemKeyFn } from "./utils";

--- a/enterprise/frontend/src/metabase-enterprise/clean_up/CleanupCollectionModal/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/clean_up/CleanupCollectionModal/utils.ts
@@ -2,7 +2,7 @@ import dayjs from "dayjs";
 import { c, t } from "ttag";
 import _ from "underscore";
 
-import type { StaleCollectionItem } from "metabase-types/api";
+import type { StaleCollectionItem } from "../types";
 
 // constant portion of this string is how mantine calculates the height of the modal
 export const getModalHeightCalc = (additionalOffset?: string) => {

--- a/enterprise/frontend/src/metabase-enterprise/clean_up/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/clean_up/types.ts
@@ -1,0 +1,20 @@
+import type {
+  CollectionId,
+  CollectionItem,
+  PaginationRequest,
+  PaginationResponse,
+} from "metabase-types/api";
+import type { SortingOptions } from "metabase-types/api/sorting";
+
+export type StaleCollectionItem = CollectionItem & { last_used_at: string };
+
+export type ListStaleCollectionItemsRequest = {
+  id: CollectionId;
+  before_date?: string;
+  is_recursive?: boolean;
+} & PaginationRequest &
+  Partial<SortingOptions>;
+
+export type ListStaleCollectionItemsResponse = {
+  data: StaleCollectionItem[];
+} & PaginationResponse;

--- a/frontend/src/metabase-types/api/collection.ts
+++ b/frontend/src/metabase-types/api/collection.ts
@@ -128,8 +128,6 @@ export interface CollectionItem {
   setCollectionPreview?: (isEnabled: boolean) => void;
 }
 
-export type StaleCollectionItem = CollectionItem & { last_used_at: string };
-
 export interface CollectionListQuery {
   archived?: boolean;
   "exclude-other-user-collections"?: boolean;
@@ -156,17 +154,6 @@ export type ListCollectionItemsRequest = {
 export type ListCollectionItemsResponse = {
   data: CollectionItem[];
   models: CollectionItemModel[] | null;
-} & PaginationResponse;
-
-export type ListStaleCollectionItemsRequest = {
-  id: CollectionId;
-  before_date?: string;
-  is_recursive?: boolean;
-} & PaginationRequest &
-  Partial<SortingOptions>;
-
-export type ListStaleCollectionItemsResponse = {
-  data: StaleCollectionItem[];
 } & PaginationResponse;
 
 export interface UpdateCollectionRequest {

--- a/frontend/src/metabase/api/collection.ts
+++ b/frontend/src/metabase/api/collection.ts
@@ -6,8 +6,6 @@ import type {
   ListCollectionItemsResponse,
   ListCollectionsRequest,
   ListCollectionsTreeRequest,
-  ListStaleCollectionItemsRequest,
-  ListStaleCollectionItemsResponse,
   UpdateCollectionRequest,
   getCollectionRequest,
 } from "metabase-types/api";
@@ -61,21 +59,6 @@ export const collectionApi = Api.injectEndpoints({
       providesTags: (response, error, { models }) =>
         provideCollectionItemListTags(response?.data ?? [], models),
     }),
-    listStaleCollectionItems: builder.query<
-      ListStaleCollectionItemsResponse,
-      ListStaleCollectionItemsRequest
-    >({
-      query: ({ id, ...params }) => ({
-        method: "GET",
-        url: `/api/collection/${id}/stale`,
-        params,
-      }),
-      providesTags: response =>
-        provideCollectionItemListTags(response?.data ?? [], [
-          "card",
-          "dashboard",
-        ]),
-    }),
     getCollection: builder.query<Collection, getCollectionRequest>({
       query: ({ id, ...body }) => {
         return {
@@ -128,7 +111,6 @@ export const {
   useListCollectionsQuery,
   useListCollectionsTreeQuery,
   useListCollectionItemsQuery,
-  useListStaleCollectionItemsQuery,
   useGetCollectionQuery,
   useCreateCollectionMutation,
   useUpdateCollectionMutation,


### PR DESCRIPTION
### Description

The BE moved the stale items endpoint from `/api` to `/api/ee`, this PR updates the UI to accommodate this change.

### How to verify

Verify that clean up modal continues to work as it did before

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
