### PR TITLE
[Permissions] Update ordering of create query permissions options

### DIFF
--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/group-sidebar.unit.spec.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/group-sidebar.unit.spec.ts
@@ -105,12 +105,6 @@ describe("getGroupsDataPermissionEditor", () => {
         iconColor: "success",
       },
       {
-        label: `Granular`,
-        value: DataPermissionValue.CONTROLLED,
-        icon: "permissions_limited",
-        iconColor: "warning",
-      },
-      {
         label: `Query builder only`,
         value: DataPermissionValue.QUERY_BUILDER,
         icon: "permissions_limited",
@@ -121,6 +115,12 @@ describe("getGroupsDataPermissionEditor", () => {
         value: DataPermissionValue.NO,
         icon: "close",
         iconColor: "danger",
+      },
+      {
+        label: `Granular`,
+        value: DataPermissionValue.CONTROLLED,
+        icon: "permissions_limited",
+        iconColor: "warning",
       },
     ]);
 

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/group-sidebar.unit.spec.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/group-sidebar.unit.spec.ts
@@ -111,16 +111,16 @@ describe("getGroupsDataPermissionEditor", () => {
         iconColor: "warning",
       },
       {
-        label: `No`,
-        value: DataPermissionValue.NO,
-        icon: "close",
-        iconColor: "danger",
-      },
-      {
         label: `Granular`,
         value: DataPermissionValue.CONTROLLED,
         icon: "permissions_limited",
         iconColor: "warning",
+      },
+      {
+        label: `No`,
+        value: DataPermissionValue.NO,
+        icon: "close",
+        iconColor: "danger",
       },
     ]);
 

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/schemas.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/schemas.ts
@@ -172,9 +172,9 @@ const buildNativePermission = (
     confirmations: nativePermissionConfirmations,
     options: [
       DATA_PERMISSION_OPTIONS.queryBuilderAndNative,
-      DATA_PERMISSION_OPTIONS.controlled,
       DATA_PERMISSION_OPTIONS.queryBuilder,
       DATA_PERMISSION_OPTIONS.no,
+      DATA_PERMISSION_OPTIONS.controlled,
     ],
     postActions: {
       controlled: () => navigateToGranularPermissions(groupId, entityId),

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/schemas.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/schemas.ts
@@ -173,8 +173,8 @@ const buildNativePermission = (
     options: [
       DATA_PERMISSION_OPTIONS.queryBuilderAndNative,
       DATA_PERMISSION_OPTIONS.queryBuilder,
-      DATA_PERMISSION_OPTIONS.no,
       DATA_PERMISSION_OPTIONS.controlled,
+      DATA_PERMISSION_OPTIONS.no,
     ],
     postActions: {
       controlled: () => navigateToGranularPermissions(groupId, entityId),

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
@@ -143,8 +143,8 @@ const buildNativePermission = (
       dbValue === DataPermissionValue.QUERY_BUILDER_AND_NATIVE &&
         DATA_PERMISSION_OPTIONS.queryBuilderAndNative,
       DATA_PERMISSION_OPTIONS.queryBuilder,
-      DATA_PERMISSION_OPTIONS.no,
       DATA_PERMISSION_OPTIONS.controlled,
+      DATA_PERMISSION_OPTIONS.no,
     ]),
     postActions: {
       controlled: () => navigateToGranularPermissions(groupId, entityId),

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
@@ -142,9 +142,9 @@ const buildNativePermission = (
     options: _.compact([
       dbValue === DataPermissionValue.QUERY_BUILDER_AND_NATIVE &&
         DATA_PERMISSION_OPTIONS.queryBuilderAndNative,
-      DATA_PERMISSION_OPTIONS.controlled,
       DATA_PERMISSION_OPTIONS.queryBuilder,
       DATA_PERMISSION_OPTIONS.no,
+      DATA_PERMISSION_OPTIONS.controlled,
     ]),
     postActions: {
       controlled: () => navigateToGranularPermissions(groupId, entityId),


### PR DESCRIPTION
### Description

Based on discussion in [this internal slack thread](https://metaboat.slack.com/archives/C01LQQ2UW03/p1721947677425419), we want to move the "Granular" permission option for create queries to be the last option for the "Create Queries" column for data permissions.

### How to verify

- Go to admin -> permissions
- Select a group (all user's group is fine)
- Click a dropdown in the create queries column for a database
- Test again by drilling down into a db with multiple schemas

### Demo

![CleanShot 2024-08-01 at 14 26 00@2x](https://github.com/user-attachments/assets/b2fd2f6a-369c-4a50-9452-ecb3c4678bb9)
![CleanShot 2024-08-01 at 14 25 18@2x](https://github.com/user-attachments/assets/de1933d6-0f02-4b97-a288-2b6d88dec3c9)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR