### PR TITLE
fix: In delayed error/loading wrapper, on error, display the error

### DIFF
--- a/frontend/src/metabase/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper.tsx
+++ b/frontend/src/metabase/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper.tsx
@@ -1,8 +1,6 @@
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
 
-import { Transition } from "metabase/ui";
-
 import LoadingAndErrorWrapper from "./LoadingAndErrorWrapper";
 
 export type LoadingAndErrorWrapperProps = {
@@ -49,29 +47,22 @@ export const DelayedLoadingAndErrorWrapper = ({
     return () => clearTimeout(timeout);
   }, [delay]);
 
-  if (!loading && !error) {
+  if (error) {
+    return <LoadingAndErrorWrapper error={error} {...props} />;
+  }
+  if (!loading) {
     return <>{children}</>;
   }
   if (!showWrapper) {
-    // make tests aware that things are loading
+    // Don't show the wrapper yet, but make tests aware that things are loading
     return <span data-testid="loading-indicator" />;
   }
+  if (loader) {
+    return loader;
+  }
   return (
-    <Transition
-      mounted={!!(error || loading)}
-      transition="fade"
-      duration={200}
-      timingFunction="ease"
-    >
-      {styles => (
-        <div style={styles}>
-          {loader ?? (
-            <LoadingAndErrorWrapper error={error} loading={loading} {...props}>
-              {children}
-            </LoadingAndErrorWrapper>
-          )}
-        </div>
-      )}
-    </Transition>
+    <LoadingAndErrorWrapper error={error} loading={loading} {...props}>
+      {children}
+    </LoadingAndErrorWrapper>
   );
 };

--- a/frontend/src/metabase/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper.tsx
+++ b/frontend/src/metabase/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper.tsx
@@ -47,22 +47,27 @@ export const DelayedLoadingAndErrorWrapper = ({
     return () => clearTimeout(timeout);
   }, [delay]);
 
+  // Handle error condition
   if (error) {
     return <LoadingAndErrorWrapper error={error} {...props} />;
   }
-  if (!loading) {
-    return <>{children}</>;
+
+  // Handle loading condition
+  if (loading) {
+    if (!showWrapper) {
+      // Don't show the wrapper yet, but make tests aware that things are loading
+      return <span data-testid="loading-indicator" />;
+    }
+    if (loader) {
+      return loader;
+    }
+    return (
+      <LoadingAndErrorWrapper error={error} loading={loading} {...props}>
+        {children}
+      </LoadingAndErrorWrapper>
+    );
   }
-  if (!showWrapper) {
-    // Don't show the wrapper yet, but make tests aware that things are loading
-    return <span data-testid="loading-indicator" />;
-  }
-  if (loader) {
-    return loader;
-  }
-  return (
-    <LoadingAndErrorWrapper error={error} loading={loading} {...props}>
-      {children}
-    </LoadingAndErrorWrapper>
-  );
+
+  // Happy path
+  return <>{children}</>;
 };

--- a/frontend/src/metabase/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper.unit.spec.tsx
+++ b/frontend/src/metabase/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper.unit.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "__support__/ui";
+import { render, screen } from "__support__/ui";
 
 import { DelayedLoadingAndErrorWrapper } from "./DelayedLoadingAndErrorWrapper";
 
@@ -20,12 +20,7 @@ describe("DelayedLoadingAndErrorWrapper", () => {
       );
 
       expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
-      await waitFor(
-        () => expect(screen.getByTestId("loader")).toBeInTheDocument(),
-        {
-          timeout: 150,
-        },
-      );
+      await screen.findByTestId("loader", undefined, { timeout: 150 });
     });
 
     it("should display a given child if loading is false", () => {

--- a/frontend/src/metabase/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper.unit.spec.tsx
+++ b/frontend/src/metabase/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper.unit.spec.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from "__support__/ui";
+
 import { DelayedLoadingAndErrorWrapper } from "./DelayedLoadingAndErrorWrapper";
 
 describe("DelayedLoadingAndErrorWrapper", () => {

--- a/frontend/src/metabase/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper.unit.spec.tsx
+++ b/frontend/src/metabase/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper.unit.spec.tsx
@@ -1,0 +1,63 @@
+import { render, screen, waitFor } from "__support__/ui";
+import { DelayedLoadingAndErrorWrapper } from "./DelayedLoadingAndErrorWrapper";
+
+describe("DelayedLoadingAndErrorWrapper", () => {
+  describe("Loading", () => {
+    it("should display a loading message if given a true loading prop", () => {
+      render(<DelayedLoadingAndErrorWrapper error={false} loading={true} />);
+
+      expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
+    });
+    it("should display a delayed loader if given a true loading prop", async () => {
+      render(
+        <DelayedLoadingAndErrorWrapper
+          loader={<div data-testid="loader"></div>}
+          delay={100}
+          error={false}
+          loading={true}
+        />,
+      );
+
+      expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
+      await waitFor(
+        () => expect(screen.getByTestId("loader")).toBeInTheDocument(),
+        {
+          timeout: 150,
+        },
+      );
+    });
+
+    it("should display a given child if loading is false", () => {
+      render(
+        <DelayedLoadingAndErrorWrapper loading={false} error={null}>
+          <div>Hey</div>
+        </DelayedLoadingAndErrorWrapper>,
+      );
+      expect(screen.getByText("Hey")).toBeInTheDocument();
+    });
+
+    it("shouldn't fail if loaded with null children and no wrapper", () => {
+      expect(() =>
+        render(
+          <DelayedLoadingAndErrorWrapper
+            error={false}
+            loading={false}
+            noWrapper
+          />,
+        ),
+      ).not.toThrow();
+    });
+  });
+
+  describe("Errors", () => {
+    it("should display an error message if given an error object and loading is true", () => {
+      const error = {
+        type: 500,
+        message: "Big error here folks",
+      };
+
+      render(<DelayedLoadingAndErrorWrapper loading={true} error={error} />);
+      expect(screen.getByText(error.message)).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
### Description

The `DelayedAndLoadingWrapper` had a bug where if both the `loading` and `error` props were truthy, and the `loader` prop was provided, the loader would be shown, not the error.

### How to verify

In `frontend/src/metabase/browse/components/BrowseModels.tsx:131`, change the `error` prop on `DelayedLoadingAndErrorWrapper` to `true`. On master, you won't see an error message, but in this branch you will.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR