### PR TITLE
Reduce memory usage when sending anon stat

### DIFF
--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -375,7 +375,8 @@
   ([summary execution]
    (-> summary
        (update :executions u/safe-inc)
-       (update-in [:by_status (if (:has_error execution)
+       ;; MYSQL is returning true as 1, false as 0! what!
+       (update-in [:by_status (if (#{1 true} (:has_error execution))
                                 "failed"
                                 "completed")] u/safe-inc)
        (update-in [:num_per_user (:executor_id execution)] u/safe-inc)

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -362,16 +362,20 @@
 
 ;;; Execution Metrics
 
-(defn summarize-executions
+(defn- summarize-executions
   "Summarize `executions`, by incrementing approriate counts in a summary map."
   ([]
-   (summarize-executions (t2/reducible-select [:model/QueryExecution :executor_id :running_time :error])))
+   (summarize-executions (t2/reducible-query {:select [:executor_id :running_time [[:case
+                                                                                    [:= :error nil ] false
+                                                                                    [:= :error "" ] false
+                                                                                    :else true] :has_error]]
+                                              :from   [:query_execution]})))
   ([executions]
    (reduce summarize-executions {:executions 0, :by_status {}, :num_per_user {}, :num_by_latency {}} executions))
   ([summary execution]
    (-> summary
        (update :executions u/safe-inc)
-       (update-in [:by_status (if (:error execution)
+       (update-in [:by_status (if (:has_error execution)
                                 "failed"
                                 "completed")] u/safe-inc)
        (update-in [:num_per_user (:executor_id execution)] u/safe-inc)

--- a/test/metabase/analytics/stats_test.clj
+++ b/test/metabase/analytics/stats_test.clj
@@ -222,6 +222,8 @@
 (deftest new-impl-test
   (mt/with-temp [QueryExecution _ (merge query-execution-defaults
                                          {:error "some error"})
+                 QueryExecution _ (merge query-execution-defaults
+                                         {:error "some error"})
                  QueryExecution _ query-execution-defaults]
     (is (= (old-execution-metrics)
            (#'stats/execution-metrics))


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/46403

How test
1. Start MB with a small heapsize (512MB)
2. insert 200k of query Execution
```clojure
;; insert 200k of query Execution
(let [rand-char (fn [] (char (+ (int \A) (rand-int 26))))
        big-error (clojure.string/join (repeatedly 1e5 rand-char))]
    (doseq [_ (range 200)]
      (t2/insert! :model/QueryExecution (for [_ (range 1e3)]
                                          {:hash (byte-array 32),
                                           :result_rows 1,
                                           :started_at :%now,
                                           :executor_id nil,
                                           :native false,
                                           :card_id nil,
                                           :context :ad-hoc,
                                           :running_time 1
                                           :error big-error})))
    (t2/count :model/QueryExecution))

```
3. Try calling summarize-executions
```clojure
(summarize-executions)
```