### PR TITLE
Fix log formatting for query analyzer

### DIFF
--- a/src/metabase/task/analyze_queries.clj
+++ b/src/metabase/task/analyze_queries.clj
@@ -44,13 +44,13 @@
             timer   (u/start-timer)
             card    (query-analysis/->analyzable card-id)]
         (if (failure-map/non-retryable? card)
-          (log/warnf "Skipping analysis of Card % as its query has caused failures in the past." card-id)
+          (log/warnf "Skipping analysis of Card %s as its query has caused failures in the past." card-id)
           (try
             (query-analysis/analyze-card! card)
             (failure-map/track-success! card)
             (Thread/sleep (wait-proportional (u/since-ms timer)))
             (catch Exception e
-              (log/errorf e "Error analysing and updating query for Card %" card-id)
+              (log/errorf e "Error analysing and updating query for Card %s" card-id)
               (failure-map/track-failure! card)
               (Thread/sleep (wait-fail (u/since-ms timer))))))
         (cond


### PR DESCRIPTION
### Description

This fixes the markup used for two exceptional cases.

We should add tests to hit both of these edge cases, but I'd like to get this out in the meantime to get analysis working in stats again - it currently gets poison pilled by the first non-analyzable card.