### PR TITLE
Tighten up queue test

### DIFF
--- a/resources/log4j2.xml
+++ b/resources/log4j2.xml
@@ -28,6 +28,8 @@
     <Logger name="metabase.plugins" level="DEBUG"/>
     <Logger name="metabase.server.middleware" level="DEBUG"/>
     <Logger name="metabase.query-processor.async" level="DEBUG"/>
+    <Logger name="metabase.task.analyze-queries" level="INFO"/>
+    <Logger name="metabase.task.sweep-query-analysis" level="INFO"/>
     <Logger name="com.mchange" level="ERROR"/>
     <Logger name="org.quartz" level="INFO"/>
     <Logger name="liquibase" level="ERROR"/>

--- a/src/metabase/task/analyze_queries.clj
+++ b/src/metabase/task/analyze_queries.clj
@@ -48,7 +48,9 @@
           (try
             (query-analysis/analyze-card! card)
             (failure-map/track-success! card)
-            (Thread/sleep (wait-proportional (u/since-ms timer)))
+            (let [sleep-ms (wait-proportional (u/since-ms timer))]
+              (log/infof "Waiting %s millis before analysing further cards" sleep-ms)
+              (Thread/sleep sleep-ms))
             (catch Exception e
               (log/errorf e "Error analysing and updating query for Card %s" card-id)
               (failure-map/track-failure! card)

--- a/src/metabase/task/sweep_query_analysis.clj
+++ b/src/metabase/task/sweep_query_analysis.clj
@@ -7,6 +7,8 @@
    [metabase.public-settings :as public-settings]
    [metabase.query-analysis :as query-analysis]
    [metabase.task :as task]
+   [metabase.util :as u]
+   [metabase.util.log :as log]
    [toucan2.core :as t2])
   (:import
    (org.quartz DisallowConcurrentExecution)))
@@ -57,7 +59,10 @@
    (sweep-query-analysis-loop! (not @has-run?))
    (reset! has-run? true))
   ([first-time?]
-   (sweep-query-analysis-loop! first-time? query-analysis/analyze-sync!))
+   (sweep-query-analysis-loop! first-time?
+                               (fn [card-or-id]
+                                 (log/infof "Queueing card %s for query analysis" (u/the-id card-or-id))
+                                 (query-analysis/analyze-sync! card-or-id))))
   ([first-time? analyze-fn]
    ;; prioritize cards that are missing analysis
    (analyze-cards-without-query-fields! analyze-fn)


### PR DESCRIPTION
### Description

Hopefully this fixes flakes like [this](https://github.com/metabase/metabase/actions/runs/10211915673/job/28254186670?pr=46410). If not it will at least reduce some test verbiage.

Update: smuggling in some extra logging on the related tasks.