### PR TITLE
Add extra geojson content type

### DIFF
--- a/src/metabase/api/geojson.clj
+++ b/src/metabase/api/geojson.clj
@@ -137,6 +137,7 @@
                     (throw (ex-info (tru "GeoJSON URL failed to load") {:status-code 400}))))
         success? (<= 200 (:status resp) 399)
         allowed-content-types #{"application/geo+json"
+                                "application/vnd.geo+json"
                                 "application/json"
                                 "text/plain"}
         ok-content-type? (some #(str/starts-with? (get-in resp [:headers :content-type]) %)


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/46307

Seems like this content type is obsolete in favor `application/geo+json`, at least according to the IANA page here: https://www.iana.org/assignments/media-types/application/vnd.geo+json

However I don't see any harm in supporting it.