### PR TITLE
Revert "Preprocess queries before data perms check"

### DIFF
--- a/src/metabase/models/query/permissions.clj
+++ b/src/metabase/models/query/permissions.clj
@@ -133,9 +133,7 @@
   (try
     (let [query (mbql.normalize/normalize query)]
       ;; if we are using a Card as our source, our perms are that Card's (i.e. that Card's Collection's) read perms
-      (if-let [source-card-id (if already-preprocessed?
-                                (:qp/source-card-id query)
-                                (qp.util/query->source-card-id query))]
+      (if-let [source-card-id (qp.util/query->source-card-id query)]
         {:paths (source-card-read-perms source-card-id)}
         ;; otherwise if there's no source card then calculate perms based on the Tables referenced in the query
         (let [query               (cond-> query
@@ -265,14 +263,7 @@
 (mu/defn can-run-query?
   "Return `true` if the current user has sufficient permissions to run `query`, and `false` otherwise."
   [query]
-  (let [preprocessed-query (try ((requiring-resolve 'metabase.query-processor.preprocess/preprocess) query)
-                                (catch Exception e
-                                 (log/info e "Failed to preprocess query, falling back to unprocessed")
-                                 false))
-        query (or preprocessed-query query)
-        required-perms (required-perms-for-query query
-                                                 :already-preprocessed?
-                                                 (boolean preprocessed-query))]
+  (let [required-perms (required-perms-for-query query)]
     (check-data-perms query required-perms :throw-exceptions? false)))
 
 (defn can-query-table?


### PR DESCRIPTION
Reverts metabase/metabase#45601

This was a redundant fix. Theoretically we probably _should_ preprocess before checking permissions as it could lead to other permissions failures if we rely on preprocessing to happen before perms are checked. But the only situation where this happens right now is for sandboxing, and we've fixed that particular issue elsewhere.

https://github.com/metabase/metabase/issues/46346#issuecomment-2261648497