### PR TITLE
Various hardenings for SQL analysis

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -821,7 +821,7 @@
    metabase.lib.common/defop                                                    macros.metabase.lib.common/defop
    metabase.models.params.chain-filter-test/chain-filter                        macros.metabase.models.params.chain-filter-test/chain-filter
    metabase.models.params.chain-filter-test/chain-filter-search                 macros.metabase.models.params.chain-filter-test/chain-filter
-   metabase.models.query-field-test/with-test-setup                             macros.metabase.models.query-field-test/with-test-setup
+   metabase.models.query-analysis-test/with-test-setup                          macros.metabase.models.query-analysis-test/with-test-setup
    metabase.models.user-test/with-groups                                        macros.metabase.models.user-test/with-groups
    metabase.query-processor.streaming/streaming-response                        macros.metabase.query-processor.streaming/streaming-response
    metabase.related-test/with-world                                             macros.metabase.related-test/with-world

--- a/.clj-kondo/macros/metabase/models/query_analysis_test.clj
+++ b/.clj-kondo/macros/metabase/models/query_analysis_test.clj
@@ -1,4 +1,4 @@
-(ns macros.metabase.models.query-field-test
+(ns macros.metabase.models.query-analysis-test
   (:require [macros.common]))
 
 (defmacro with-test-setup [& body]

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -8810,6 +8810,37 @@ databaseChangeLog:
               column:
                 name: analysis_id
 
+  - changeSet:
+      id: v51.2024-08-02T11:56:27
+      author: crisptrutski
+      comment: Add `schema` column to query fields
+      preConditions:
+        - not:
+            - columnExists:
+                tableName: query_field
+                columnName: schema
+      changes:
+        - addColumn:
+            tableName: query_field
+            columns:
+              - column:
+                  name: schema
+                  type: varchar(254) # matching metabase_table.schema
+                  remarks: name of the schema of the table being referenced
+                  constraints:
+                    nullable: true
+
+  - changeSet:
+      id: v51.2024-08-02T12:02:21
+      author: crisptrutski
+      comment: Make `table` nullable on query fields
+      changes:
+        - dropNotNullConstraint:
+            tableName: query_field
+            columnDataType: varchar(254) # matching metabase_table.name
+            columnName: table
+            remarks: This value is null if the field does not exist, and macaw could not determine the table
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/models/query_analysis.clj
+++ b/src/metabase/models/query_analysis.clj
@@ -43,7 +43,7 @@
           {}
           errors))
 
-(defn field-reference-errors
+(defn- field-reference-errors
   "Given a seq of cards, return a map of card-id => field reference errors"
   [cards]
   (when (seq cards)

--- a/src/metabase/query_analysis.clj
+++ b/src/metabase/query_analysis.clj
@@ -113,7 +113,7 @@
      :query      (explicit-references (mbql.u/referenced-field-ids query))
      :mbql/query (explicit-references (lib.util/referenced-field-ids query)))))
 
-(defn update-query-analysis-for-card!
+(defn- update-query-analysis-for-card!
   "Clears QueryFields associated with this card and creates fresh, up-to-date-ones.
 
   Returns `nil` (and logs the error) if there was a parse error.
@@ -130,9 +130,10 @@
                                   :schema      schema
                                   :table       table
                                   :table_id    table-id})
-              field->row       (fn [{:keys [table column table-id field-id explicit-reference]}]
+              field->row       (fn [{:keys [schema table column table-id field-id explicit-reference]}]
                                  {:card_id            card-id
                                   :analysis_id        analysis-id
+                                  :schema             schema
                                   :table              table
                                   :column             column
                                   :table_id           table-id

--- a/src/metabase/task/analyze_queries.clj
+++ b/src/metabase/task/analyze_queries.clj
@@ -49,7 +49,7 @@
             (query-analysis/analyze-card! card)
             (failure-map/track-success! card)
             (let [sleep-ms (wait-proportional (u/since-ms timer))]
-              (log/infof "Waiting %s millis before analysing further cards" sleep-ms)
+              (log/infof "Waiting %s millis before analysing further cards after finishing Card %s" sleep-ms card-id)
               (Thread/sleep sleep-ms))
             (catch Exception e
               (log/errorf e "Error analysing and updating query for Card %s" card-id)

--- a/test/metabase/models/query_analysis_test.clj
+++ b/test/metabase/models/query_analysis_test.clj
@@ -1,4 +1,4 @@
-(ns metabase.models.query-field-test
+(ns metabase.models.query-analysis-test
   (:require
    [clojure.set :as set]
    [clojure.test :refer :all]
@@ -190,11 +190,10 @@
 (deftest no-column-test
   (with-test-setup
     (let [qt {:card_id  card-id
-              :schema   nil
+              :schema   "public"
               :table    "orders"
               :table_id table-id}]
       (testing "simple select count(*)"
         (trigger-parse! card-id "select count(*) from orders")
         (is (empty? (query-fields-for-card card-id)))
-        (is (= #{qt}
-               (query-tables-for-card card-id)))))))
+        (is (= #{qt} (query-tables-for-card card-id)))))))

--- a/test/metabase/query_analysis/native_query_analyzer_test.clj
+++ b/test/metabase/query_analysis/native_query_analyzer_test.clj
@@ -91,7 +91,7 @@
   (testing "real existent schema"
     (let [sql "select id from public.venues"]
       (is (= [(field-reference :venues :id)] (field-refs sql)))
-      (is (= [(table-reference :venues)] #p (table-refs sql)))))
+      (is (= [(table-reference :venues)] (table-refs sql)))))
   (testing "non-existent schema"
     (let [sql "select id from blah.venues"]
       (is (= [(missing-field-reference :blah :venues :id)] (field-refs sql)))

--- a/test/metabase/query_analysis/native_query_analyzer_test.clj
+++ b/test/metabase/query_analysis/native_query_analyzer_test.clj
@@ -42,10 +42,13 @@
   (-> (mt/native-query {:query sql})
       (#'nqa/references-for-native)
       (update-vals
-       (partial sort-by (juxt :table :column)))))
+       (partial sort-by (juxt :schema :table :column)))))
 
 (defn- field-refs [sql]
   (:fields (refs sql)))
+
+(defn- table-refs [sql]
+  (:tables (refs sql)))
 
 (defn- table-reference [table]
   (let [reference (nqa/table-reference (mt/id) table)]
@@ -66,33 +69,54 @@
     ;; tag it
     (assoc reference :explicit-reference true)))
 
-(defn- missing-reference [table column]
-  (merge
-   {:table              (name table)
-    :column             (name column)
-    :explicit-reference true}
-   ;; the table might be be resolved...
-   (nqa/table-reference (mt/id) table)))
+(defn- missing-field-reference
+  ([table column]
+   (missing-field-reference nil table column))
+  ([schema table column]
+   (merge
+    {:schema             (some-> schema name)
+     :table              (some-> table name)
+     :column             (name column)
+     :explicit-reference true}
+    ;; the table might be resolved...
+    (nqa/table-reference (mt/id) schema table))))
 
 (deftest ^:parallel field-matching-simple-test
   (testing "simple query matches"
-    (is (= [(field-reference :venues :id)]
-           (field-refs "select id from venues")))))
+    (let [sql "select id from venues"]
+      (is (= [(field-reference :venues :id)] (field-refs sql)))
+      (is (= [(table-reference :venues)] (table-refs sql))))))
+
+(deftest ^:parallel field-matching-schema-test
+  (testing "real existent schema"
+    (let [sql "select id from public.venues"]
+      (is (= [(field-reference :venues :id)] (field-refs sql)))
+      (is (= [(table-reference :venues)] #p (table-refs sql)))))
+  (testing "non-existent schema"
+    (let [sql "select id from blah.venues"]
+      (is (= [(missing-field-reference :blah :venues :id)] (field-refs sql)))
+      (is (= [{:schema "blah", :table "venues"}] (table-refs sql))))))
 
 (deftest ^:parallel field-matching-case-test
   (testing "quotes stop case matching"
-    (is (= [(missing-reference :venues :id)]
-           (field-refs "select \"id\" from venues")))
-    (is (= [(field-reference :venues :id)]
-           (field-refs "select \"ID\" from venues"))))
+    (is (= [(missing-field-reference :venues :id)] (field-refs "select \"id\" from venues")))
+    (is (= [(field-reference :venues :id)] (field-refs "select \"ID\" from venues"))))
+
   (testing "unresolved references use case verbatim"
-    (is (= [{:column "id", :table "unKnown", :explicit-reference true}]
-           (field-refs "select \"id\" from unKnown")))
-    (is (= [{:column "ID", :table "unknowN", :explicit-reference true}]
-           (field-refs "select ID from unknowN"))))
+    (let [sql "select \"id\" from unKnown"]
+      (is (= [{:table "unKnown", :column "id", :explicit-reference true}] (field-refs sql)))
+      (is (= [{:table "unKnown"}] (table-refs sql))))
+    (let [sql "select ID from unknowN"]
+      (is (= [{:table "unknowN", :column "ID", :explicit-reference true}] (field-refs sql)))
+      (is (= [{:table "unknowN"}] (table-refs sql)))))
+
   (testing "resolved references normalize the case"
-    (is (not= "veNUES" (:table (first (field-refs "select id from veNUES")))))
-    (is (= "venues" (u/lower-case-en (:table (first (field-refs "select id from veNUES")))))))
+    (let [sql        "select id from veNUES"]
+      (doseq [ref (concat (field-refs sql) (table-refs sql))
+              :let [table-name (:table ref)]]
+        (is (not= "veNUES" table-name))
+        (is (= "venues" (u/lower-case-en table-name))))))
+
   (testing "you can mix quoted and unquoted names"
     (is (= [(field-reference :venues :id)
             (field-reference :venues :name)]
@@ -115,12 +139,27 @@
     (is (= {false 6}
            (frequencies (map :explicit-reference (field-refs "select v.* from venues v join checkins")))))))
 
+(deftest ^:parallel pseudo-table-fields-tests
+  (testing "When macaw returns an unknown field without a table, we keep it even if it could be phantom."
+    ;; At the time of writing this test, Macaw would (incorrectly) return "week" as an ambiguous source column.
+    (is (= [{                      :column "week",       :explicit-reference true}
+            {:table "source_table" :column "flobbed_at", :explicit-reference true}]
+           (field-refs "WITH date_series AS (
+                       SELECT generate_series('2016-01-01'::date, '2024-09-14'::date, '1 week') AS week
+                     )
+                     SELECT week, COUNT(*) as count
+                     FROM date_series
+                     JOIN source_table
+                       ON flobbed_at < week
+                     GROUP BY week
+                     ORDER BY week")))))
+
 (deftest ^:parallel field-matching-keywords-test
   (when (not (contains? #{:snowflake :oracle} driver/*driver*))
     (testing "Analysis does not fail due to keywords that are only reserved in other databases"
       (is (= [(field-reference :venues :id)]
              (field-refs "select id as final from venues")))
-      (is (= [(missing-reference :venues :final)]
+      (is (= [(missing-field-reference :venues :final)]
              (field-refs "select final from venues"))))))
 
 (deftest ^:parallel table-without-field-reference-test


### PR DESCRIPTION
### Description

This change should fix some explosions in stats due to phantom fields, while also making things a bit more rigorous.

- Record the table schema in query_field - especially useful for unknown tables
- Allow null table names in query_field - they might be phantoms, or they might not
  - We still have the option to filter them out in tools we build on top
- Tighten up matching logic to consider schema