### PR TITLE
Delete database using config file

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file/databases.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file/databases.clj
@@ -37,18 +37,27 @@
 
 (defn- init-from-config-file!
   [database]
-  ;; assert that we are able to connect to this Database. Otherwise, throw an Exception.
-  (driver.u/can-connect-with-details? (keyword (:engine database)) (:details database) :throw-exceptions)
-  (if-let [existing-database-id (t2/select-one-pk Database :engine (:engine database), :name (:name database))]
+  (if (contains? database :delete)
+    (let [magic-request (format "DELETE_WITH_DEPENDENTS:%s" (:name database))]
+      (when (not= magic-request (:delete database))
+        (throw (ex-info (format "To delete database %s set `delete` to %s" (pr-str (:name database)) (pr-str magic-request))
+                        {:database-name (:name database)})))
+      (when-let [existing-database-id (t2/select-one-pk Database :engine (:engine database), :name (:name database))]
+        (log/info (u/format-color :blue "Deleting Database %s %s" (:engine database) (pr-str (:name database))))
+        (t2/delete! Database :id existing-database-id)))
     (do
-      (log/info (u/format-color :blue "Updating Database %s %s" (:engine database) (pr-str (:name database))))
-      (t2/update! Database existing-database-id database))
-    (do
-      (log/info (u/format-color :green "Creating new %s Database %s" (:engine database) (pr-str (:name database))))
-      (let [db (first (t2/insert-returning-instances! Database database))]
-        (if (config-from-file-sync-databases)
-          ((requiring-resolve 'metabase.sync/sync-database!) db)
-          (log/info "Sync on database creation when initializing from file is disabled. Skipping sync."))))))
+      ;; assert that we are able to connect to this Database. Otherwise, throw an Exception.
+      (driver.u/can-connect-with-details? (keyword (:engine database)) (:details database) :throw-exceptions)
+      (if-let [existing-database-id (t2/select-one-pk Database :engine (:engine database), :name (:name database))]
+        (do
+          (log/info (u/format-color :blue "Updating Database %s %s" (:engine database) (pr-str (:name database))))
+          (t2/update! Database existing-database-id database))
+        (do
+          (log/info (u/format-color :green "Creating new %s Database %s" (:engine database) (pr-str (:name database))))
+          (let [db (first (t2/insert-returning-instances! Database database))]
+            (if (config-from-file-sync-databases)
+              ((requiring-resolve 'metabase.sync/sync-database!) db)
+              (log/info "Sync on database creation when initializing from file is disabled. Skipping sync."))))))))
 
 (defmethod advanced-config.file.i/initialize-section! :databases
   [_section-name databases]

--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file/databases.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file/databases.clj
@@ -44,7 +44,7 @@
                         {:database-name (:name database)})))
       (when-let [existing-database-id (t2/select-one-pk Database :engine (:engine database), :name (:name database))]
         (log/info (u/format-color :blue "Deleting Database %s %s" (:engine database) (pr-str (:name database))))
-        (t2/delete! Database :id existing-database-id)))
+        (t2/delete! Database existing-database-id)))
     (do
       ;; assert that we are able to connect to this Database. Otherwise, throw an Exception.
       (driver.u/can-connect-with-details? (keyword (:engine database)) (:details database) :throw-exceptions)

--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file/databases.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file/databases.clj
@@ -38,6 +38,9 @@
 (defn- init-from-config-file!
   [database]
   (if (contains? database :delete)
+    ;; Databases can be managed as a service by us.  When the service is canceled, we need to delete any information
+    ;; Metabase has about them, including any stored credentials.  This is a config file flag instead of a CLI command,
+    ;; so we can ensure the database stays deleted even after restoring backups.
     (let [magic-request (format "DELETE_WITH_DEPENDENTS:%s" (:name database))]
       (when (not= magic-request (:delete database))
         (throw (ex-info (format "To delete database %s set `delete` to %s" (pr-str (:name database)) (pr-str magic-request))

--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file/databases.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file/databases.clj
@@ -42,6 +42,7 @@
     ;; Metabase has about them, including any stored credentials.  This is a config file flag instead of a CLI command,
     ;; so we can ensure the database stays deleted even after restoring backups.
     (let [magic-request (format "DELETE_WITH_DEPENDENTS:%s" (:name database))]
+      (log/info (u/format-color :blue "Deleting databases via the config file is an internal feature subject to breaking changes."))
       (when (not= magic-request (:delete database))
         (throw (ex-info (format "To delete database %s set `delete` to %s" (pr-str (:name database)) (pr-str magic-request))
                         {:database-name (:name database)})))


### PR DESCRIPTION
== Goal ==

Currently the config file (`MB_CONFIG_FILE_PATH`) only allows adding or
changing databases, but not removing them.  Since connected databases
can be managed as a service by us, it becomes necessary to delete any
information Metabase has about them, including any stored credentials.

Since this is a destructive operation with no way to revert (without
restoring from a backup), we raise the bar for accidental deletion and
require not just a (boolean) flag, but a magic string to be set.

== How to test ==

1. Configure a database as described in https://www.metabase.com/docs/latest/configuring-metabase/config-file#databases.
2. Start your Metabase instance.
3. Verify the database shows up in the "admin" section and it works.
   Create a dashboard and questions using the database.
4. Add a `delete: "DELETE_WITH_DEPENDENTS:${name}"` line to your
   database configuration section.
5. Restart your Metabase instance.
6. Verify the database no longer shows up in the "admin" section.
   Notice that questions using it are gone, too.

Closes: https://github.com/metabase/harbormaster/issues/5173
