### PR TITLE
Add `relative-time-interval` mbql function 2

### DIFF
--- a/.clj-kondo/src/hooks/metabase/test/data.clj
+++ b/.clj-kondo/src/hooks/metabase/test/data.clj
@@ -11,6 +11,10 @@
   []
   (not-empty (set (keys (:clj (hooks/ns-analysis 'metabase.test.data.dataset-definitions))))))
 
+(defn- local-def?
+  [ns* sexpr]
+  (= ns* (:ns (hooks/resolve {:name sexpr}))))
+
 (defn- dataset-type
   "`dataset` can be one of:
 
@@ -21,7 +25,7 @@
 
   We can only determine if an unqualified symbol refers to something in the dataset definitions namespace if there are
   cached results available from [[global-dataset-symbols]]."
-  [dataset]
+  [this-ns dataset]
   (let [sexpr       (hooks/sexpr dataset)
         global-defs (global-dataset-symbols)]
     (cond
@@ -31,20 +35,19 @@
       (namespace sexpr)
       :qualified
 
-      (empty? global-defs)
-      :unqualified/unknown
-
       (contains? global-defs sexpr)
       :unqualified/from-dataset-defs-namespace
 
-      ;; either something defined in the current namespace or let-bound in the current scope.
+      (local-def? this-ns sexpr)
+      :unqualified/local-def
+
       :else
-      :unqualified/local-def)))
+      :unqualified/unknown)))
 
 (defn dataset
-  [{{[_ dataset & body] :children} :node}]
+  [{{[_ dataset & body] :children} :node this-ns :ns}]
   (let [noop (constantly nil)
-        body (case (dataset-type dataset)
+        body (case (dataset-type this-ns dataset)
                ;; non-symbol, qualified symbols, and unqualified symbols from the current namespace/let-bound can all
                ;; get converted from something like
                ;;

--- a/bin/kondo.sh
+++ b/bin/kondo.sh
@@ -11,6 +11,9 @@ clj-kondo --copy-configs --dependencies --lint "$(clojure -A:dev -Spath)" --skip
 rm -rf .clj-kondo/metosin/malli-types-clj/
 rm -rf .clj-kondo/.cache
 
+# Initialize cache required for `hooks.metabase.test.data/dataset` hook.
+clj-kondo --dependencies --lint "test/metabase/test/data/dataset_definitions.clj"
+
 # Run Kondo against all of our Clojure files in the various directories they might live.
 find modules/drivers enterprise/backend \
      -maxdepth 2 \

--- a/frontend/src/metabase-lib/filter.ts
+++ b/frontend/src/metabase-lib/filter.ts
@@ -347,19 +347,12 @@ export function relativeDateFilterClause({
     );
   }
 
-  return expressionClause("between", [
-    expressionClause("+", [
-      columnWithoutBucket,
-      expressionClause("interval", [-offsetValue, offsetBucket]),
-    ]),
-    expressionClause("relative-datetime", [
-      value !== "current" && value < 0 ? value : 0,
-      bucket,
-    ]),
-    expressionClause("relative-datetime", [
-      value !== "current" && value > 0 ? value : 0,
-      bucket,
-    ]),
+  return expressionClause("relative-time-interval", [
+    columnWithoutBucket,
+    value,
+    bucket,
+    offsetValue,
+    offsetBucket,
   ]);
 }
 

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -275,6 +275,7 @@ export type ExpressionOperatorName =
   | "concat"
   | "interval"
   | "time-interval"
+  | "relative-time-interval"
   | "relative-datetime"
   | "inside"
   | "segment"

--- a/src/metabase/legacy_mbql/normalize.cljc
+++ b/src/metabase/legacy_mbql/normalize.cljc
@@ -159,6 +159,12 @@
        (maybe-normalize-token amount))
      (maybe-normalize-token unit)]))
 
+(defmethod normalize-mbql-clause-tokens :relative-time-interval
+  [[_ col & [_value _bucket _offset-value _offset-bucket :as args]]]
+  (into [:relative-time-interval (normalize-tokens col :ignore-path)]
+        (map maybe-normalize-token)
+        args))
+
 (defmethod normalize-mbql-clause-tokens :relative-datetime
   ;; Normalize a `relative-datetime` clause. `relative-datetime` comes in two flavors:
   ;;

--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -858,6 +858,13 @@
   unit    [:ref ::RelativeDatetimeUnit]
   options (optional TimeIntervalOptions))
 
+(defclause ^:sugar relative-time-interval
+  col           Field
+  value         :int
+  bucket        [:ref ::RelativeDatetimeUnit]
+  offset-value  :int
+  offset-bucket [:ref ::RelativeDatetimeUnit])
+
 ;; A segment is a special `macro` that saves some pre-definied filter clause, e.g. [:segment 1]
 ;; this gets replaced by a normal Filter clause in MBQL macroexpansion
 ;;
@@ -890,7 +897,7 @@
               ;; filters drivers must implement
               and or not = != < > <= >= between starts-with ends-with contains
               ;; SUGAR filters drivers do not need to implement
-              does-not-contain inside is-empty not-empty is-null not-null time-interval segment)]])
+              does-not-contain inside is-empty not-empty is-null not-null relative-time-interval time-interval segment)]])
 
 (def ^:private CaseClause
   [:tuple {:error/message ":case subclause"} Filter ExpressionArg])

--- a/src/metabase/legacy_mbql/util.cljc
+++ b/src/metabase/legacy_mbql/util.cljc
@@ -242,13 +242,13 @@
    [:relative-time-interval col value bucket offset-value offset-bucket]
    (let [col-default-bucket (cond-> col (and (vector? col) (= 3 (count col)))
                               (update 2 assoc :temporal-unit :default))
-         offset      [:interval offset-value offset-bucket]
+         offset [:interval offset-value offset-bucket]
          lower-bound (if (neg? value)
                        [:relative-datetime value bucket]
-                       [:relative-datetime 0 bucket])
+                       [:relative-datetime 1 bucket])
          upper-bound (if (neg? value)
                        [:relative-datetime 0 bucket]
-                       [:relative-datetime value bucket])
+                       [:relative-datetime (inc value) bucket])
          lower-with-offset [:+ lower-bound offset]
          upper-with-offset [:+ upper-bound offset]]
      [:and

--- a/src/metabase/lib/convert.cljc
+++ b/src/metabase/lib/convert.cljc
@@ -290,6 +290,10 @@
   [[_tag field n unit options]]
   (lib.options/ensure-uuid [:time-interval (or options {}) (->pMBQL field) n unit]))
 
+(defmethod ->pMBQL :relative-time-interval
+  [[_tag & [_column _value _bucket _offset-value _offset-bucket :as args]]]
+  (lib.options/ensure-uuid (into [:relative-time-interval {}] (map ->pMBQL) args)))
+
 ;; `:offset` is the same in legacy and pMBQL, but we need to update the expr it wraps.
 (defmethod ->pMBQL :offset
   [[tag opts expr n, :as clause]]

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -216,6 +216,7 @@
   is-empty not-empty
   starts-with ends-with
   contains does-not-contain
+  relative-time-interval
   time-interval
   segment]
  [lib.filter.update

--- a/src/metabase/lib/filter.cljc
+++ b/src/metabase/lib/filter.cljc
@@ -314,6 +314,7 @@
 (lib.common/defop ends-with [whole part])
 (lib.common/defop contains [whole part])
 (lib.common/defop does-not-contain [whole part])
+(lib.common/defop relative-time-interval [x value bucket offset-value offset-bucket])
 (lib.common/defop time-interval [x amount unit])
 (lib.common/defop segment [segment-id])
 

--- a/src/metabase/lib/filter.cljc
+++ b/src/metabase/lib/filter.cljc
@@ -278,11 +278,11 @@
 (defmethod lib.metadata.calculation/display-name-method :relative-time-interval
   [query stage-number [_tag _opts column value bucket offset-value offset-bucket] style]
   (if (neg? offset-value)
-    (i18n/tru "{0} is in {1}, starting {2} ago"
+    (i18n/tru "{0} is in the {1}, starting {2} ago"
               (lib.metadata.calculation/display-name query stage-number column style)
               (u/lower-case-en (lib.temporal-bucket/describe-temporal-interval value bucket))
               (inflections/pluralize (abs offset-value) (name offset-bucket)))
-    (i18n/tru "{0} is in {1}, starting {2} from now"
+    (i18n/tru "{0} is in the {1}, starting {2} from now"
               (lib.metadata.calculation/display-name query stage-number column style)
               (u/lower-case-en (lib.temporal-bucket/describe-temporal-interval value bucket))
               (inflections/pluralize (abs offset-value) (name offset-bucket)))))

--- a/src/metabase/lib/filter.cljc
+++ b/src/metabase/lib/filter.cljc
@@ -276,8 +276,16 @@
               (u/lower-case-en (lib.temporal-bucket/describe-temporal-interval n unit)))))
 
 (defmethod lib.metadata.calculation/display-name-method :relative-time-interval
-  [_query _stage-number _clause _style]
-  "Relative time interval")
+  [query stage-number [_tag _opts column value bucket offset-value offset-bucket] style]
+  (if (neg? offset-value)
+    (i18n/tru "{0} is in {1}, starting {2} ago"
+              (lib.metadata.calculation/display-name query stage-number column style)
+              (u/lower-case-en (lib.temporal-bucket/describe-temporal-interval value bucket))
+              (inflections/pluralize (abs offset-value) (name offset-bucket)))
+    (i18n/tru "{0} is in {1}, starting {2} from now"
+              (lib.metadata.calculation/display-name query stage-number column style)
+              (u/lower-case-en (lib.temporal-bucket/describe-temporal-interval value bucket))
+              (inflections/pluralize (abs offset-value) (name offset-bucket)))))
 
 (defmethod lib.metadata.calculation/display-name-method :relative-datetime
   [_query _stage-number [_tag _opts n unit] _style]

--- a/src/metabase/lib/filter.cljc
+++ b/src/metabase/lib/filter.cljc
@@ -275,6 +275,10 @@
               (lib.metadata.calculation/display-name query stage-number expr style)
               (u/lower-case-en (lib.temporal-bucket/describe-temporal-interval n unit)))))
 
+(defmethod lib.metadata.calculation/display-name-method :relative-time-interval
+  [_query _stage-number _clause _style]
+  "Relative time interval")
+
 (defmethod lib.metadata.calculation/display-name-method :relative-datetime
   [_query _stage-number [_tag _opts n unit] _style]
   (i18n/tru "{0}" (lib.temporal-bucket/describe-temporal-interval n unit)))

--- a/src/metabase/lib/schema/filter.cljc
+++ b/src/metabase/lib/schema/filter.cljc
@@ -112,6 +112,18 @@
            [false [:ref ::expression/integer]]]
    #_unit [:ref ::temporal-bucketing/unit.date-time.interval]])
 
+(mbql-clause/define-mbql-clause :relative-time-interval :- :type/Boolean
+  [:tuple
+   [:= {:decode/normalize common/normalize-keyword} :relative-time-interval]
+   ;; `relative-time-interval` does not support options to eg. include/exclude start or end point. Only int values
+   ;; are allowed for intervals.
+   ::common/options
+   #_col           [:ref ::expression/temporal]
+   #_value         :int
+   #_bucket        [:ref ::temporal-bucketing/unit.date-time.interval]
+   #_offset-value  :int
+   #_offset-bucket [:ref ::temporal-bucketing/unit.date-time.interval]])
+
 ;; segments are guaranteed to return valid filter clauses and thus booleans, right?
 (mbql-clause/define-mbql-clause :segment :- :type/Boolean
   [:tuple

--- a/test/metabase/legacy_mbql/normalize_test.cljc
+++ b/test/metabase/legacy_mbql/normalize_test.cljc
@@ -196,6 +196,10 @@
     {{:query {"FILTER" ["time-interval" 10 -10 "day"]}}
      {:query {:filter [:time-interval 10 -10 :day]}}}
 
+    "relative-time-interval is correctly normalized"
+    {{:query {"FILTER" ["relative-time-interval" 10 "week" -10 "week"]}}
+     {:query {:filter [:relative-time-interval 10 :week -10 :week]}}}
+
     "make sure we support time-interval options"
     {["TIME_INTERVAL" 10 -30 "DAY" {"include_current" true}]
      [:time-interval 10 -30 :day {:include-current true}]}

--- a/test/metabase/legacy_mbql/util_test.cljc
+++ b/test/metabase/legacy_mbql/util_test.cljc
@@ -309,16 +309,16 @@
       (t/testing "expression reference is transformed correctly"
         (let [expr-ref [:expression "cc"]]
           (t/is (= [:and
-                    [:>= expr-ref [:+ [:relative-datetime 0     bucket] exp-offset]]
-                    [:<  expr-ref [:+ [:relative-datetime value bucket] exp-offset]]]
+                    [:>= expr-ref [:+ [:relative-datetime 1           bucket] exp-offset]]
+                    [:<  expr-ref [:+ [:relative-datetime (inc value) bucket] exp-offset]]]
                    (mbql.u/desugar-filter-clause
                     [:relative-time-interval expr-ref value bucket offset-value offset-bucket])))))
       (t/testing "field reference is transformed correctly"
         (let [field-ref [:field 100 nil]
               exp-field-ref (update field-ref 2 assoc :temporal-unit :default)]
           (t/is (= [:and
-                    [:>= exp-field-ref [:+ [:relative-datetime 0     bucket] exp-offset]]
-                    [:<  exp-field-ref [:+ [:relative-datetime value bucket] exp-offset]]]
+                    [:>= exp-field-ref [:+ [:relative-datetime 1           bucket] exp-offset]]
+                    [:<  exp-field-ref [:+ [:relative-datetime (inc value) bucket] exp-offset]]]
                    (mbql.u/desugar-filter-clause
                     [:relative-time-interval exp-field-ref value bucket offset-value offset-bucket]))))))))
 

--- a/test/metabase/legacy_mbql/util_test.cljc
+++ b/test/metabase/legacy_mbql/util_test.cljc
@@ -276,6 +276,52 @@
            (mbql.u/desugar-filter-clause [:time-interval [:expression "CC"] :current :week]))
         "keywords like `:current` should work correctly"))
 
+(t/deftest ^:parallel desugar-relative-time-interval-negative-test
+  (t/testing "Desugaring relative-date-time produces expected [:and [:>=..] [:<..]] expression"
+    (let [value           -10
+          bucket          :day
+          offset-value    -8
+          offset-bucket   :week
+          exp-offset [:interval offset-value offset-bucket]]
+      (t/testing "expression reference is transformed correctly"
+        (let [expr-ref [:expression "cc"]]
+          (t/is (= [:and
+                    [:>= expr-ref [:+ [:relative-datetime value bucket] exp-offset]]
+                    [:<  expr-ref [:+ [:relative-datetime 0     bucket] exp-offset]]]
+                   (mbql.u/desugar-filter-clause
+                    [:relative-time-interval expr-ref value bucket offset-value offset-bucket])))))
+      (t/testing "field reference is transformed correctly"
+        (let [field-ref [:field 100 nil]
+              exp-field-ref (update field-ref 2 assoc :temporal-unit :default)]
+          (t/is (= [:and
+                    [:>= exp-field-ref [:+ [:relative-datetime value bucket] exp-offset]]
+                    [:<  exp-field-ref [:+ [:relative-datetime 0     bucket] exp-offset]]]
+                   (mbql.u/desugar-filter-clause
+                    [:relative-time-interval exp-field-ref value bucket offset-value offset-bucket]))))))))
+
+(t/deftest ^:parallel desugar-relative-time-interval-positive-test
+  (t/testing "Desugaring relative-date-time produces expected [:and [:>=..] [:<..]] expression"
+    (let [value           10
+          bucket          :day
+          offset-value    8
+          offset-bucket   :week
+          exp-offset [:interval offset-value offset-bucket]]
+      (t/testing "expression reference is transformed correctly"
+        (let [expr-ref [:expression "cc"]]
+          (t/is (= [:and
+                    [:>= expr-ref [:+ [:relative-datetime 0     bucket] exp-offset]]
+                    [:<  expr-ref [:+ [:relative-datetime value bucket] exp-offset]]]
+                   (mbql.u/desugar-filter-clause
+                    [:relative-time-interval expr-ref value bucket offset-value offset-bucket])))))
+      (t/testing "field reference is transformed correctly"
+        (let [field-ref [:field 100 nil]
+              exp-field-ref (update field-ref 2 assoc :temporal-unit :default)]
+          (t/is (= [:and
+                    [:>= exp-field-ref [:+ [:relative-datetime 0     bucket] exp-offset]]
+                    [:<  exp-field-ref [:+ [:relative-datetime value bucket] exp-offset]]]
+                   (mbql.u/desugar-filter-clause
+                    [:relative-time-interval exp-field-ref value bucket offset-value offset-bucket]))))))))
+
 (t/deftest ^:parallel desugar-relative-datetime-with-current-test
   (t/testing "when comparing `:relative-datetime`to `:field`, it should take the temporal unit of the `:field`"
     (t/is (= [:=

--- a/test/metabase/lib/filter_test.cljc
+++ b/test/metabase/lib/filter_test.cljc
@@ -703,9 +703,9 @@
                   (lib/expression-clause :relative-datetime [1 :month] nil)],
         :name "Created At is in the next month, starting 1 month from now"}
        {:clause [:relative-time-interval created-at 10 :week 10 :week]
-        :name "Created At is in next 10 weeks, starting 10 weeks from now"}
+        :name "Created At is in the next 10 weeks, starting 10 weeks from now"}
        {:clause [:relative-time-interval created-at -10 :week -10 :week]
-        :name "Created At is in previous 10 weeks, starting 10 weeks ago"}])))
+        :name "Created At is in the previous 10 weeks, starting 10 weeks ago"}])))
 
 (deftest ^:parallel specific-date-frontend-filter-display-names-test
   (let [created-at (meta/field-metadata :products :created-at)]

--- a/test/metabase/lib/filter_test.cljc
+++ b/test/metabase/lib/filter_test.cljc
@@ -701,7 +701,11 @@
                                           (lib/expression-clause :interval [-1 :month] nil)] nil)
                   (lib/expression-clause :relative-datetime [0 :month] nil)
                   (lib/expression-clause :relative-datetime [1 :month] nil)],
-        :name "Created At is in the next month, starting 1 month from now"}])))
+        :name "Created At is in the next month, starting 1 month from now"}
+       {:clause [:relative-time-interval created-at 10 :week 10 :week]
+        :name "Created At is in next 10 weeks, starting 10 weeks from now"}
+       {:clause [:relative-time-interval created-at -10 :week -10 :week]
+        :name "Created At is in previous 10 weeks, starting 10 weeks ago"}])))
 
 (deftest ^:parallel specific-date-frontend-filter-display-names-test
   (let [created-at (meta/field-metadata :products :created-at)]

--- a/test/metabase/lib/js_test.cljs
+++ b/test/metabase/lib/js_test.cljs
@@ -395,6 +395,9 @@
     [:time-interval {} [:field {} int?] 10 :day]
     (lib.js/expression-clause "time-interval" [(meta/field-metadata :products :created-at) 10 "day"] nil)
 
+    [:relative-time-interval {} [:field {} int?] 10 :day 10 :month]
+    (lib.js/expression-clause "time-interval" [(meta/field-metadata :products :created-at) 10 "day" 10 "month"] nil)
+
     [:relative-datetime {} :current :day]
     (lib.js/expression-clause "relative-datetime" ["current" "day"] nil)
 

--- a/test/metabase/lib/schema/filter_test.cljc
+++ b/test/metabase/lib/schema/filter_test.cljc
@@ -71,6 +71,7 @@
            [:time-interval field :last :hour]
            [:time-interval field 4 :hour]
            [:time-interval {:include-current true} field :next :day]
+           [:relative-time-interval field 10 :day 10 :day]
            [:segment 1]]]
       (doseq [op (filter-ops filter-expr)]
           (is (not (identical? (get-method expression/type-of-method op)

--- a/test/metabase/query_processor/middleware/desugar_test.clj
+++ b/test/metabase/query_processor/middleware/desugar_test.clj
@@ -16,6 +16,12 @@
                                      [:field 2 {:temporal-unit :day}]
                                      [:relative-datetime -30 :day]
                                      [:relative-datetime -1 :day]]
+                                    [:>=
+                                     [:field 2 {:temporal-unit :default}]
+                                     [:+ [:relative-datetime -30 :day] [:interval -30 :day]]]
+                                    [:<
+                                     [:field 2 {:temporal-unit :default}]
+                                     [:+ [:relative-datetime 0 :day] [:interval -30 :day]]]
                                     [:!= [:field 3 nil] "(not set)"]
                                     [:!= [:field 3 nil] "url"]
                                     [:> [:temporal-extract [:field 4 nil] :year-of-era] [:/ [:/ 1 2] 3]]]
@@ -38,6 +44,7 @@
                         :filter       [:and
                                        [:= [:field 1 nil] "Run Query"]
                                        [:time-interval [:field 2 nil] -30 :day]
+                                       [:relative-time-interval [:field 2 nil] -30 :day -30 :day]
                                        [:!= [:field 3 nil] "(not set)" "url"]
                                        [:> [:get-year [:field 4 nil]] [:/ 1 2 3]]]
                         :expressions  {"year" [:+

--- a/test/metabase/query_processor_test/date_bucketing_test.clj
+++ b/test/metabase/query_processor_test/date_bucketing_test.clj
@@ -950,7 +950,7 @@
   "Dynamically generated dataset with 30 checkins spaced 24 hours apart, from 15 days ago to 14 days in the future."
   (dataset-def-with-timestamps (* 24 (u/minutes->seconds 60))))
 
-(def ^:private checkins:1-per-day:60
+(def ^:private checkins:1-per-day-60
   "Dynamically generated dataset with 60 checkins spaced 24 hours apart, from 30 days ago to 29 days in the future."
   (dataset-def-with-timestamps (* 24 (u/minutes->seconds 60)) 60))
 
@@ -1069,7 +1069,7 @@
    ;; Following verifies #45942 is solved. Changing the offset ensures that intervals do not overlap.
    (testing "Syntactic sugar (`:relative-time-interval` clause) (#45942)"
      (mt/dataset
-      checkins:1-per-day:60
+      checkins:1-per-day-60
       (is (= 7
              (ffirst
               (mt/formatted-rows
@@ -1446,7 +1446,7 @@
     (mt/test-drivers
      (disj (mt/normal-drivers-with-feature :date-arithmetics) :athena)
      (mt/dataset
-      checkins:1-per-day:60
+      checkins:1-per-day-60
       (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))
             query (as-> (lib/query mp (lib.metadata/table mp (mt/id :checkins))) $q
                     (lib/expression $q "customdate" (m/find-first (comp #{(mt/id :checkins :timestamp)} :id)

--- a/test/metabase/query_processor_test/date_bucketing_test.clj
+++ b/test/metabase/query_processor_test/date_bucketing_test.clj
@@ -950,7 +950,7 @@
   "Dynamically generated dataset with 30 checkins spaced 24 hours apart, from 15 days ago to 14 days in the future."
   (dataset-def-with-timestamps (* 24 (u/minutes->seconds 60))))
 
-(def ^:private checkins-60-1-per-day
+(def ^:private checkins:1-per-day:60
   "Dynamically generated dataset with 60 checkins spaced 24 hours apart, from 30 days ago to 29 days in the future."
   (dataset-def-with-timestamps (* 24 (u/minutes->seconds 60)) 60))
 
@@ -1068,8 +1068,7 @@
    (disj (mt/normal-drivers-with-feature :date-arithmetics) :athena)
    ;; Following verifies #45942 is solved. Changing the offset ensures that intervals do not overlap.
    (testing "Syntactic sugar (`:relative-time-interval` clause) (#45942)"
-     (mt/dataset
-      checkins-60-1-per-day
+     (mt/dataset checkins:1-per-day:60
       (is (= 7
              (ffirst
               (mt/formatted-rows
@@ -1445,8 +1444,7 @@
   (testing "Datetime expressions can filter to a date range"
     (mt/test-drivers
      (disj (mt/normal-drivers-with-feature :date-arithmetics) :athena)
-     (mt/dataset
-      checkins-60-1-per-day
+     (mt/dataset checkins:1-per-day:60
       (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))
             query (as-> (lib/query mp (lib.metadata/table mp (mt/id :checkins))) $q
                     (lib/expression $q "customdate" (m/find-first (comp #{(mt/id :checkins :timestamp)} :id)

--- a/test/metabase/query_processor_test/date_bucketing_test.clj
+++ b/test/metabase/query_processor_test/date_bucketing_test.clj
@@ -1054,7 +1054,7 @@
 
 (deftest ^:parallel relative-time-interval-test
   (mt/test-drivers
-   (mt/normal-drivers-except #{:athena})
+   (disj (mt/normal-drivers-with-feature :date-arithmetics) :athena)
    ;; Following verifies #45942 is solved. Changing the offset ensures that intervals do not overlap.
    (testing "Syntactic sugar (`:relative-time-interval` clause) (#45942)"
      (mt/dataset
@@ -1433,7 +1433,7 @@
 (deftest filter-by-expression-relative-time-interval-test
   (testing "Datetime expressions can filter to a date range"
     (mt/test-drivers
-     (mt/normal-drivers-except #{:athena})
+     (disj (mt/normal-drivers-with-feature :date-arithmetics) :athena)
      (mt/dataset
       checkins:1-per-day
       (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))

--- a/test/metabase/query_processor_test/date_bucketing_test.clj
+++ b/test/metabase/query_processor_test/date_bucketing_test.clj
@@ -950,7 +950,7 @@
   "Dynamically generated dataset with 30 checkins spaced 24 hours apart, from 15 days ago to 14 days in the future."
   (dataset-def-with-timestamps (* 24 (u/minutes->seconds 60))))
 
-(def ^:private checkins:1-per-day-60
+(def ^:private checkins-60-1-per-day
   "Dynamically generated dataset with 60 checkins spaced 24 hours apart, from 30 days ago to 29 days in the future."
   (dataset-def-with-timestamps (* 24 (u/minutes->seconds 60)) 60))
 
@@ -1069,7 +1069,7 @@
    ;; Following verifies #45942 is solved. Changing the offset ensures that intervals do not overlap.
    (testing "Syntactic sugar (`:relative-time-interval` clause) (#45942)"
      (mt/dataset
-      checkins:1-per-day-60
+      checkins-60-1-per-day
       (is (= 7
              (ffirst
               (mt/formatted-rows
@@ -1446,7 +1446,7 @@
     (mt/test-drivers
      (disj (mt/normal-drivers-with-feature :date-arithmetics) :athena)
      (mt/dataset
-      checkins:1-per-day-60
+      checkins-60-1-per-day
       (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))
             query (as-> (lib/query mp (lib.metadata/table mp (mt/id :checkins))) $q
                     (lib/expression $q "customdate" (m/find-first (comp #{(mt/id :checkins :timestamp)} :id)


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/45942

The original PR https://github.com/metabase/metabase/pull/46211 was reverted because of following CI failure in master. This PR is verbatim original plus (1) update to the failing tests and (2) resolution of error logs (not harmful but ugly) from `optimize-temporal-filters` ns and (3) fix for linter error. Those are the only differences from original PR (described in the code comments).

---

(1) Problem with tests was as follows. The `filter-by-expression-relative-time-interval-test` was using `[:relative-time-interval [:expression "customdate" {:base-type :type/DateTime}] -1 :week -1 :week]]` filter and `checkins:1-per-day` dataset.

The dataset contains rows for _current day and 15 days ago_ (and also 14 future days, that's irrelevant now). I've ignored this fact _writing that test on Monday_.

Test expected that 7 days for the _relative-time-interval -1 week -1 week_ would be returned from query. That would unfortunately hold only _if test is run on Monday or Sunday_.

I've got the PR through the CI on Monday and approvals later, hence the failures.

To fix that I've added `checkins:1-per-day:60` on which it could be shown that _relative-time-interval -1 week -1 week_ offset works properly.

---

(2) While working on the former I've realized there are error logs from the filter optimization middleware which are also addressed. There is a code comment that describes it.

---

(3) With addition of new dataset for testing `[:relative-time-interval <col> -1 :week -1 :week`] new kondo error surfaced.

Specifically, of unused private var `checkins:1-per-day:60`. Closer examination showed, that (a) other private dataset vars are used also in other different places as args to `dataset` and (b) that `hooks.metabase.test.data/dataset` depends on kondo cache generated for `metabase.test.data.dataset-definitions` namespace.

To fix erroneous behavior, I've decided to modifiy hook's logic in a way, that check for locally defined var does not depend on cache anymore.

I've also added generation of cache that's required for hook's correct operation to `./bin/kondo.sh` script. (This alone, would resolve the error, but I believe it is good practice to remove that dependency from the hook's (even if just) one code path).
