### PR TITLE
Perf fix for card metadata in QP

### DIFF
--- a/src/metabase/lib/card.cljc
+++ b/src/metabase/lib/card.cljc
@@ -1,9 +1,11 @@
 (ns metabase.lib.card
   (:require
+   [medley.core :as m]
    [metabase.legacy-mbql.normalize :as mbql.normalize]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
+   [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.lib.query :as lib.query]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.id :as lib.schema.id]
@@ -72,46 +74,51 @@
   nominal refs so as to not completely destroy the FE. Once we port more stuff over maybe we can fix this."
   true)
 
-(mu/defn ->card-metadata-column :- ::lib.schema.metadata/column
-  "Massage possibly-legacy Card results metadata into MLv2 ColumnMetadata."
-  ([metadata-providerable col]
-   (->card-metadata-column metadata-providerable nil col))
-
-  ([metadata-providerable :- ::lib.schema.metadata/metadata-providerable
-    card-or-id            :- [:maybe [:or ::lib.schema.id/card ::lib.schema.metadata/card]]
-    col                   :- :map]
+(defn- ->card-metadata-column
+  [col
+   card
+   field]
    (let [col (-> col
                  (update-keys u/->kebab-case-en))]
      (cond-> (merge
               {:base-type :type/*, :lib/type :metadata/column}
-              (when-let [field-id (:id col)]
-                (when (empty? (select-keys col [:display-name]))
-                  (try
-                    (lib.metadata/field metadata-providerable field-id)
-                    (catch #?(:clj Throwable :cljs :default) _
-                      nil))))
+              field
               col
               {:lib/type                :metadata/column
                :lib/source              :source/card
                :lib/source-column-alias ((some-fn :lib/source-column-alias :name) col)})
-       card-or-id
-       (assoc :lib/card-id (u/the-id card-or-id))
+       card
+       (assoc :lib/card-id (u/the-id card))
 
        (and *force-broken-card-refs*
             ;; never force broken refs for Models, because Models can have give columns with completely
             ;; different names the Field ID of a different column, somehow. See #22715
             (or
-             ;; we can only do this check if `card-or-id` is passed in.
-             (not card-or-id)
-             (not= (:type (lib.metadata/card metadata-providerable (u/the-id card-or-id)))
-                   :model)))
+             ;; we can only do this check if `card` is passed in.
+             (not card)
+             (not= (:type card) :model)))
        (assoc ::force-broken-id-refs true)
 
        ;; If the incoming col doesn't have `:semantic-type :type/FK`, drop `:fk-target-field-id`.
        ;; This comes up with metadata on SQL cards, which might be linked to their original DB field but should not be
        ;; treated as FKs unless the metadata is configured accordingly.
        (not= (:semantic-type col) :type/FK)
-       (assoc :fk-target-field-id nil)))))
+       (assoc :fk-target-field-id nil))))
+
+(mu/defn ->card-metadata-columns :- [:sequential ::lib.schema.metadata/column]
+  "Massage possibly-legacy Card results metadata into MLv2 ColumnMetadata."
+  ([metadata-providerable cols]
+   (->card-metadata-columns metadata-providerable nil cols))
+
+  ([metadata-providerable :- ::lib.schema.metadata/metadata-providerable
+    card-or-id            :- [:maybe [:or ::lib.schema.id/card ::lib.schema.metadata/card]]
+    cols                  :- [:sequential :map]]
+   (let [card              (lib.metadata/card metadata-providerable (u/the-id card-or-id))
+         metadata-provider (lib.metadata/->metadata-provider metadata-providerable)
+         field-ids         (keep :id cols)
+         fields            (lib.metadata.protocols/metadatas metadata-provider :metadata/column field-ids)
+         field-id->field   (m/index-by :id fields)]
+     (mapv #(->card-metadata-column % card (get field-id->field (:id %))) cols))))
 
 (def ^:private CardColumnMetadata
   [:merge
@@ -141,8 +148,7 @@
         (when-let [cols (not-empty (cond
                                      (map? result-metadata)        (:columns result-metadata)
                                      (sequential? result-metadata) result-metadata))]
-          (mapv (partial ->card-metadata-column metadata-providerable card)
-                cols))))))
+          (->card-metadata-columns metadata-providerable card cols))))))
 
 (mu/defn saved-question-metadata :- CardColumns
   "Metadata associated with a Saved Question with `card-id`."

--- a/src/metabase/lib/card.cljc
+++ b/src/metabase/lib/card.cljc
@@ -117,8 +117,8 @@
     card-or-id            :- [:maybe [:or ::lib.schema.id/card ::lib.schema.metadata/card]]
     cols                  :- [:sequential :map]]
    (let [metadata-provider (lib.metadata/->metadata-provider metadata-providerable)
-         card-id           (u/the-id card-or-id)
-         card              (lib.metadata/card metadata-providerable card-id)
+         card-id           (when card-or-id (u/the-id card-or-id))
+         card              (when card-id (lib.metadata/card metadata-providerable card-id))
          field-ids         (keep :id cols)
          fields            (lib.metadata.protocols/metadatas metadata-provider :metadata/column field-ids)
          field-id->field   (m/index-by :id fields)]

--- a/src/metabase/lib/card.cljc
+++ b/src/metabase/lib/card.cljc
@@ -85,10 +85,11 @@
      (cond-> (merge
               {:base-type :type/*, :lib/type :metadata/column}
               (when-let [field-id (:id col)]
-                (try
-                  (lib.metadata/field metadata-providerable field-id)
-                  (catch #?(:clj Throwable :cljs :default) _
-                    nil)))
+                (when (empty? (select-keys col [:display-name]))
+                  (try
+                    (lib.metadata/field metadata-providerable field-id)
+                    (catch #?(:clj Throwable :cljs :default) _
+                      nil))))
               col
               {:lib/type                :metadata/column
                :lib/source              :source/card

--- a/src/metabase/lib/card.cljc
+++ b/src/metabase/lib/card.cljc
@@ -75,6 +75,8 @@
   true)
 
 (defn- ->card-metadata-column
+  "Massage possibly-legacy Card results metadata into MLv2 ColumnMetadata. Note that `card` might be unavailable so we
+  accept both `card-id` and `card`."
   [col
    card-id
    card

--- a/src/metabase/query_processor/middleware/binning.clj
+++ b/src/metabase/query_processor/middleware/binning.clj
@@ -72,8 +72,7 @@
       (throw (ex-info (tru "Cannot update binned field: query is missing source-metadata")
                       {:field field-name})))
     ;; try to find field in source-metadata with matching name
-    (let [mlv2-metadatas (for [col source-metadata]
-                           (lib.card/->card-metadata-column (qp.store/metadata-provider) col))]
+    (let [mlv2-metadatas (lib.card/->card-metadata-columns (qp.store/metadata-provider) source-metadata)]
       (or
        (lib.equality/find-matching-column
         [:field {:lib/uuid (str (random-uuid)), :base-type :type/*} field-name]


### PR DESCRIPTION
The perf regression was introduced in https://github.com/metabase/metabase/pull/31706 to handle an edge case. This PR batches field requests.

For history - the biggest reason why we fetch fields for columns is that `table-id` is missing in `result-metadata` and that's a very common case. 

Before
```
POST /api/dashboard/save 200 2.4 s (900 DB calls) App DB connections: 0/15 Jetty threads: 5/50 (2 idle, 0 queued) (94 total active threads) Queries in flight: 0 (0 queued) {:metabase-user-id 1}
```

Now

```
POST /api/dashboard/save 200 2.2 s (539 DB calls) App DB connections: 0/7 Jetty threads: 5/50 (2 idle, 0 queued) (93 total active threads) Queries in flight: 0 (0 queued) {:metabase-user-id 1}
```