### PR TITLE
[Permissions] Fix advanced permissions edits not always saving

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/reducer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/reducer.ts
@@ -8,6 +8,7 @@ import {
   UPDATE_DATA_PERMISSION,
 } from "metabase/admin/permissions/permissions";
 import {
+  DataPermission,
   DataPermissionValue,
   type EntityId,
 } from "metabase/admin/permissions/types";
@@ -69,11 +70,13 @@ export const advancedPermissionsSlice = createSlice({
           return state;
         }
 
-        state.impersonations = state.impersonations.filter(
-          impersonation =>
-            impersonation.group_id !== payload.groupId &&
-            impersonation.db_id !== payload.entityId.databaseId,
-        );
+        if (payload?.permissionInfo?.permission === DataPermission.VIEW_DATA) {
+          state.impersonations = state.impersonations.filter(
+            impersonation =>
+              impersonation.group_id !== payload.groupId &&
+              impersonation.db_id !== payload.entityId.databaseId,
+          );
+        }
         return state;
       });
   },

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/actions.js
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/actions.js
@@ -84,7 +84,7 @@ const groupTableAccessPolicies = handleActions(
           return state;
         }
 
-        const { entityId, metadata, groupId } = payload;
+        const { entityId, metadata, groupId, value, permissionInfo } = payload;
 
         // if user is unsandboxing a specific table,
         // remove the specific table's sandbox data
@@ -95,9 +95,11 @@ const groupTableAccessPolicies = handleActions(
           });
           const isTableSandboxed = key in state;
           const isUnsandboxingTable =
-            isTableSandboxed && payload.value !== DataPermissionValue.SANDBOXED;
+            isTableSandboxed &&
+            permissionInfo.permission === DataPermission.VIEW_DATA &&
+            value !== DataPermissionValue.SANDBOXED;
 
-          if (isTableSandboxed && isUnsandboxingTable) {
+          if (isUnsandboxingTable) {
             return _.omit(state, key);
           } else {
             return state;


### PR DESCRIPTION
Closes #46450

### Description

Fixes a bug where when you make subsequent edits to other permissions for an entity after having changed it's "view data" permissions to an advanced permission in that same session of edits (i.e. you haven't saved your changes yet) the value does not get persisted to the server. For impersonated tables, this is a bug that has existed for multiple versions of metabase, but the recent permissions refactor made the same bug appear for sandboxed tables.

The failing logic is that we were removing associated associated sandboxing / impersonation data from the permissions graph if there were modifications to that entity's permissions without properly guarding if that edit was for the same column (view data permission in this case). This PR adds those guards and adds test coverage for this bug.

### How to verify

Repro steps are in the issue.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
