### PR TITLE
Fix bad i18n string

### DIFF
--- a/src/metabase/integrations/ldap.clj
+++ b/src/metabase/integrations/ldap.clj
@@ -56,7 +56,7 @@
   :audit :getter)
 
 (defsetting ldap-user-filter
-  (deferred-tru "User lookup filter. The placeholder '{login}' will be replaced by the user supplied login.")
+  (deferred-tru "User lookup filter. The placeholder '{login'} will be replaced by the user supplied login.")
   :default "(&(objectClass=inetOrgPerson)(|(uid={login})(mail={login})))"
   :audit   :getter)
 


### PR DESCRIPTION
Fixes #46440

couple things come together here.

Bad escaping:
The `{` characters are used for format strings and placeholders like

```clojure
impl=> (translate "fr" "After {0}" ["Bob"])
"Après Bob"
```

And if you want _literal_ {'s in your translation string, you must escape them like "'{" or "'}" using an apostrophe. But this isn't the end of our worries.

in `resources/zh-CN.edn`, we actually have _two_ translations for the original string:

```clojure
"User lookup filter. The placeholder '{login}' will be replaced by the user supplied login."
"用户找过滤器，占位符 '{login'} 将替换为用户提供的登录名。"

,,,

"User lookup filter. The placeholder '{login}' will be replaced by the user supplied login."
"用户查找筛选器。占位符“{login}”将替换为用户提供的登录名。"
```

And this later has unescaped curlies.

<img width="1164" alt="image" src="https://github.com/user-attachments/assets/31ec3be8-ee30-4bc7-8af7-04174c3f51ba">
(note: I fixed the i18n string here. But with the fix of the source string, we'll have a new key to translate)

> [!NOTE]  
> This string is broken, but in a benign way. "foo '{bar}'" is _busted_. successfully quotes the first `{`, and then has the sequence `bar}` before it hits an open escape `'` that is unterminated. It just ignores this. So it breaks in an acceptable way.

The fix for that is at
https://poeditor.com/projects/po_edit?per_page=20&id=200535&id_language=31&filter=&order=&search=User+lookup+filter but will need to wait for the new source translation string in this instance with the corrected escaping.

```clojure
;; simulate what happens at runtime
impl=> (translated-format-string "zh_CN"
                                 "User lookup filter. The placeholder '{login}' will be replaced by the user supplied login."
                                 {})
"用户查找筛选器。占位符“{login}”将替换为用户提供的登录名。"
impl=> (MessageFormat. *1 (locale "zh_CN"))
Execution error (NumberFormatException) at java.lang.NumberFormatException/forInputString (NumberFormatException.java:67).
For input string: "login"
;; the problematic zh-CN string
impl=> (MessageFormat. "用户查找筛选器。占位符“{login}”将替换为用户提供的登录名。")
Execution error (NumberFormatException) at java.lang.NumberFormatException/forInputString (NumberFormatException.java:67).
For input string: "login"
;; minimal reproduction
impl=> (MessageFormat. "“{login}”")
Execution error (NumberFormatException) at java.lang.NumberFormatException/forInputString (NumberFormatException.java:67).
For input string: "login"

impl=> (MessageFormat. "“'{login}'”") ;; <-- busted in the benign way
#object[java.text.MessageFormat
        "0x2b37e363"
        "java.text.MessageFormat@c2f4bbaa"]
impl=> (MessageFormat. "“'{login'}”") ;; <-- correctly escapes both { and }
#object[java.text.MessageFormat
        "0x4f3c8819"
        "java.text.MessageFormat@c2f4bbaa"]
```
