### PR TITLE
fix(webapp/sidenav): Move Browse sidebar section in between Trash and other collections

### DIFF
--- a/e2e/test/scenarios/collections/personal-collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/personal-collections.cy.spec.js
@@ -61,7 +61,9 @@ describe("personal collections", () => {
       });
 
       cy.visit("/collection/root");
-      cy.findByRole("tree").findByText("Your personal collection");
+      cy.findAllByRole("tree")
+        .contains("Your personal collection")
+        .should("exist");
       navigationSidebar().within(() => {
         cy.icon("ellipsis").click();
       });

--- a/e2e/test/scenarios/collections/personal-collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/personal-collections.cy.spec.js
@@ -63,7 +63,7 @@ describe("personal collections", () => {
       cy.visit("/collection/root");
       cy.findAllByRole("tree")
         .contains("Your personal collection")
-        .should("exist");
+        .should("be.visible");
       navigationSidebar().within(() => {
         cy.icon("ellipsis").click();
       });

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
@@ -11,7 +11,7 @@ import {
 import { Box, type BoxProps, Icon } from "metabase/ui";
 
 import { SidebarLink } from "./SidebarItems";
-import {ExpandToggleButton} from "./SidebarItems/SidebarItems.styled";
+import { ExpandToggleButton } from "./SidebarItems/SidebarItems.styled";
 
 const openSidebarCSS = css`
   width: ${NAV_SIDEBAR_WIDTH};

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
@@ -11,6 +11,7 @@ import {
 import { Box, type BoxProps, Icon } from "metabase/ui";
 
 import { SidebarLink } from "./SidebarItems";
+import {ExpandToggleButton} from "./SidebarItems/SidebarItems.styled";
 
 const openSidebarCSS = css`
   width: ${NAV_SIDEBAR_WIDTH};
@@ -82,6 +83,12 @@ export const SidebarSection = styled(Box)<BoxProps>`
   margin-bottom: ${space(2)};
   padding-inline-start: ${space(2)};
   padding-inline-end: ${space(2)};
+`;
+
+export const TrashSidebarSection = styled(SidebarSection)`
+  ${ExpandToggleButton} {
+    width: 12px;
+  }
 `;
 
 export const SidebarHeadingWrapper = styled.div`

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
@@ -204,16 +204,17 @@ function MainNavbarView({
           )}
         </SidebarSection>
 
-        <SidebarSection>
-          <Tree
-            data={trashCollection ? [trashCollection] : []}
-            selectedId={collectionItem?.id}
-            onSelect={onItemSelect}
-            TreeNode={SidebarCollectionLink}
-            role="tree"
-            aria-label="collection tree for trash"
-          />
-        </SidebarSection>
+        {trashCollection && (
+          <SidebarSection>
+            <Tree
+              data={[trashCollection]}
+              selectedId={collectionItem?.id}
+              onSelect={onItemSelect}
+              TreeNode={SidebarCollectionLink}
+              role="tree"
+            />
+          </SidebarSection>
+        )}
       </div>
       <WhatsNewNotification />
     </SidebarContentRoot>

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
@@ -31,6 +31,7 @@ import {
   SidebarHeading,
   SidebarHeadingWrapper,
   SidebarSection,
+  TrashSidebarSection,
 } from "../MainNavbar.styled";
 import { SidebarCollectionLink, SidebarLink } from "../SidebarItems";
 import type { SelectedItem } from "../types";
@@ -171,7 +172,6 @@ function MainNavbarView({
           />
           <Tree
             data={collectionsWithoutTrash}
-            // FIXME: Ensure this works properly when the trash collection is selected
             selectedId={collectionItem?.id}
             onSelect={onItemSelect}
             TreeNode={SidebarCollectionLink}
@@ -205,7 +205,7 @@ function MainNavbarView({
         </SidebarSection>
 
         {trashCollection && (
-          <SidebarSection>
+          <TrashSidebarSection>
             <Tree
               data={[trashCollection]}
               selectedId={collectionItem?.id}
@@ -213,7 +213,7 @@ function MainNavbarView({
               TreeNode={SidebarCollectionLink}
               role="tree"
             />
-          </SidebarSection>
+          </TrashSidebarSection>
         )}
       </div>
       <WhatsNewNotification />

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
@@ -1,5 +1,5 @@
 import type { MouseEvent } from "react";
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -120,6 +120,19 @@ function MainNavbarView({
     ({ id, can_write }) => (id === null || id === "root") && can_write,
   );
 
+  const [collectionsWithoutTrash, trashCollection] = useMemo(() => {
+    let trashCollection;
+    const collectionsWithoutTrash = [];
+    for (const c of collections) {
+      if (c.type === "trash") {
+        trashCollection = c;
+      } else {
+        collectionsWithoutTrash.push(c);
+      }
+    }
+    return [collectionsWithoutTrash, trashCollection];
+  }, [collections]);
+
   return (
     <SidebarContentRoot>
       <div>
@@ -137,6 +150,36 @@ function MainNavbarView({
             <UploadCSV collection={rootCollection} />
           )}
         </SidebarSection>
+
+        {bookmarks.length > 0 && (
+          <SidebarSection>
+            <BookmarkList
+              bookmarks={bookmarks}
+              selectedItem={cardItem ?? dashboardItem ?? collectionItem}
+              onSelect={onItemSelect}
+              reorderBookmarks={reorderBookmarks}
+              onToggle={setExpandBookmarks}
+              initialState={expandBookmarks ? "expanded" : "collapsed"}
+            />
+          </SidebarSection>
+        )}
+
+        <SidebarSection>
+          <CollectionSectionHeading
+            currentUser={currentUser}
+            handleCreateNewCollection={handleCreateNewCollection}
+          />
+          <Tree
+            data={collectionsWithoutTrash}
+            // FIXME: Ensure this works properly when the trash collection is selected
+            selectedId={collectionItem?.id}
+            onSelect={onItemSelect}
+            TreeNode={SidebarCollectionLink}
+            role="tree"
+            aria-label="collection-tree"
+          />
+        </SidebarSection>
+
         <SidebarSection>
           <BrowseNavSection
             nonEntityItem={nonEntityItem}
@@ -161,31 +204,14 @@ function MainNavbarView({
           )}
         </SidebarSection>
 
-        {bookmarks.length > 0 && (
-          <SidebarSection>
-            <BookmarkList
-              bookmarks={bookmarks}
-              selectedItem={cardItem ?? dashboardItem ?? collectionItem}
-              onSelect={onItemSelect}
-              reorderBookmarks={reorderBookmarks}
-              onToggle={setExpandBookmarks}
-              initialState={expandBookmarks ? "expanded" : "collapsed"}
-            />
-          </SidebarSection>
-        )}
-
         <SidebarSection>
-          <CollectionSectionHeading
-            currentUser={currentUser}
-            handleCreateNewCollection={handleCreateNewCollection}
-          />
           <Tree
-            data={collections}
+            data={trashCollection ? [trashCollection] : []}
             selectedId={collectionItem?.id}
             onSelect={onItemSelect}
             TreeNode={SidebarCollectionLink}
             role="tree"
-            aria-label="collection-tree"
+            aria-label="collection tree for trash"
           />
         </SidebarSection>
       </div>

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
@@ -3,6 +3,7 @@ import { useCallback, useMemo } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
+import ErrorBoundary from "metabase/ErrorBoundary";
 import { useUserSetting } from "metabase/common/hooks";
 import { useHasTokenFeature } from "metabase/common/hooks/use-has-token-feature";
 import { useIsAtHomepageDashboard } from "metabase/common/hooks/use-is-at-homepage-dashboard";
@@ -121,95 +122,105 @@ function MainNavbarView({
     ({ id, can_write }) => (id === null || id === "root") && can_write,
   );
 
-  const [trashCollection, collectionsWithoutTrash] = useMemo(
+  const [[trashCollection], collectionsWithoutTrash] = useMemo(
     () => _.partition(collections, c => c.type === "trash"),
     [collections],
   );
 
   return (
-    <SidebarContentRoot>
-      <div>
-        <SidebarSection>
-          <PaddedSidebarLink
-            isSelected={nonEntityItem?.url === "/"}
-            icon="home"
-            onClick={handleHomeClick}
-            url="/"
-          >
-            {t`Home`}
-          </PaddedSidebarLink>
-
-          {hasAttachedDWHFeature && uploadDbId && rootCollection && (
-            <UploadCSV collection={rootCollection} />
-          )}
-        </SidebarSection>
-
-        {bookmarks.length > 0 && (
+    <ErrorBoundary>
+      <SidebarContentRoot>
+        <div>
           <SidebarSection>
-            <BookmarkList
-              bookmarks={bookmarks}
-              selectedItem={cardItem ?? dashboardItem ?? collectionItem}
-              onSelect={onItemSelect}
-              reorderBookmarks={reorderBookmarks}
-              onToggle={setExpandBookmarks}
-              initialState={expandBookmarks ? "expanded" : "collapsed"}
-            />
+            <PaddedSidebarLink
+              isSelected={nonEntityItem?.url === "/"}
+              icon="home"
+              onClick={handleHomeClick}
+              url="/"
+            >
+              {t`Home`}
+            </PaddedSidebarLink>
+
+            {hasAttachedDWHFeature && uploadDbId && rootCollection && (
+              <UploadCSV collection={rootCollection} />
+            )}
           </SidebarSection>
-        )}
 
-        <SidebarSection>
-          <CollectionSectionHeading
-            currentUser={currentUser}
-            handleCreateNewCollection={handleCreateNewCollection}
-          />
-          <Tree
-            data={collectionsWithoutTrash}
-            selectedId={collectionItem?.id}
-            onSelect={onItemSelect}
-            TreeNode={SidebarCollectionLink}
-            role="tree"
-            aria-label="collection-tree"
-          />
-        </SidebarSection>
-
-        <SidebarSection>
-          <BrowseNavSection
-            nonEntityItem={nonEntityItem}
-            onItemSelect={onItemSelect}
-            hasDataAccess={hasDataAccess}
-          />
-          {hasDataAccess && (
-            <>
-              {!hasOwnDatabase && isAdmin && (
-                <AddYourOwnDataLink
-                  icon="add"
-                  url={ADD_YOUR_OWN_DATA_URL}
-                  isSelected={nonEntityItem?.url?.startsWith(
-                    ADD_YOUR_OWN_DATA_URL,
-                  )}
-                  onClick={onItemSelect}
-                >
-                  {t`Add your own data`}
-                </AddYourOwnDataLink>
-              )}
-            </>
+          {bookmarks.length > 0 && (
+            <SidebarSection>
+              <ErrorBoundary>
+                <BookmarkList
+                  bookmarks={bookmarks}
+                  selectedItem={cardItem ?? dashboardItem ?? collectionItem}
+                  onSelect={onItemSelect}
+                  reorderBookmarks={reorderBookmarks}
+                  onToggle={setExpandBookmarks}
+                  initialState={expandBookmarks ? "expanded" : "collapsed"}
+                />
+              </ErrorBoundary>
+            </SidebarSection>
           )}
-        </SidebarSection>
 
-        {trashCollection && (
-          <TrashSidebarSection>
-            <Tree
-              data={[trashCollection]}
-              selectedId={collectionItem?.id}
-              onSelect={onItemSelect}
-              TreeNode={SidebarCollectionLink}
-              role="tree"
-            />
-          </TrashSidebarSection>
-        )}
-      </div>
-      <WhatsNewNotification />
-    </SidebarContentRoot>
+          <SidebarSection>
+            <ErrorBoundary>
+              <CollectionSectionHeading
+                currentUser={currentUser}
+                handleCreateNewCollection={handleCreateNewCollection}
+              />
+              <Tree
+                data={collectionsWithoutTrash.concat(1)}
+                selectedId={collectionItem?.id}
+                onSelect={onItemSelect}
+                TreeNode={SidebarCollectionLink}
+                role="tree"
+                aria-label="collection-tree"
+              />
+            </ErrorBoundary>
+          </SidebarSection>
+
+          <SidebarSection>
+            <ErrorBoundary>
+              <BrowseNavSection
+                nonEntityItem={nonEntityItem}
+                onItemSelect={onItemSelect}
+                hasDataAccess={hasDataAccess}
+              />
+              {hasDataAccess && (
+                <>
+                  {!hasOwnDatabase && isAdmin && (
+                    <AddYourOwnDataLink
+                      icon="add"
+                      url={ADD_YOUR_OWN_DATA_URL}
+                      isSelected={nonEntityItem?.url?.startsWith(
+                        ADD_YOUR_OWN_DATA_URL,
+                      )}
+                      onClick={onItemSelect}
+                    >
+                      {t`Add your own data`}
+                    </AddYourOwnDataLink>
+                  )}
+                </>
+              )}
+            </ErrorBoundary>
+          </SidebarSection>
+
+          {trashCollection && (
+            <TrashSidebarSection>
+              <ErrorBoundary>
+                <Tree
+                  data={[trashCollection]}
+                  selectedId={collectionItem?.id}
+                  onSelect={onItemSelect}
+                  TreeNode={SidebarCollectionLink}
+                  role="tree"
+                />
+              </ErrorBoundary>
+            </TrashSidebarSection>
+          )}
+        </div>
+        <WhatsNewNotification />
+      </SidebarContentRoot>
+    </ErrorBoundary>
   );
 }
 interface CollectionSectionHeadingProps {

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
@@ -168,7 +168,7 @@ function MainNavbarView({
                 handleCreateNewCollection={handleCreateNewCollection}
               />
               <Tree
-                data={collectionsWithoutTrash.concat(1)}
+                data={collectionsWithoutTrash}
                 selectedId={collectionItem?.id}
                 onSelect={onItemSelect}
                 TreeNode={SidebarCollectionLink}

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
@@ -121,18 +121,10 @@ function MainNavbarView({
     ({ id, can_write }) => (id === null || id === "root") && can_write,
   );
 
-  const [collectionsWithoutTrash, trashCollection] = useMemo(() => {
-    let trashCollection;
-    const collectionsWithoutTrash = [];
-    for (const c of collections) {
-      if (c.type === "trash") {
-        trashCollection = c;
-      } else {
-        collectionsWithoutTrash.push(c);
-      }
-    }
-    return [collectionsWithoutTrash, trashCollection];
-  }, [collections]);
+  const [trashCollection, collectionsWithoutTrash] = useMemo(
+    () => _.partition(collections, c => c.type === "trash"),
+    [collections],
+  );
 
   return (
     <SidebarContentRoot>

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarCollectionLink.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarCollectionLink.tsx
@@ -11,7 +11,6 @@ import { PLUGIN_COLLECTIONS } from "metabase/plugins";
 import type { Collection } from "metabase-types/api";
 
 import {
-  CollectionLinkRoot,
   CollectionNodeRoot,
   ExpandToggleButton,
   FullWidthLink,
@@ -122,7 +121,7 @@ const DroppableSidebarCollectionLink = forwardRef<HTMLLIElement, TreeNodeProps>(
   ) {
     const collection = item as unknown as Collection;
     return (
-      <CollectionLinkRoot data-testid="sidebar-collection-link-root">
+      <div data-testid="sidebar-collection-link-root">
         <CollectionDropTarget collection={collection}>
           {(droppableProps: DroppableProps) => (
             <SidebarCollectionLink
@@ -133,7 +132,7 @@ const DroppableSidebarCollectionLink = forwardRef<HTMLLIElement, TreeNodeProps>(
             />
           )}
         </CollectionDropTarget>
-      </CollectionLinkRoot>
+      </div>
     );
   },
 );

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarItems.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarItems.styled.tsx
@@ -75,8 +75,6 @@ export const CollectionNodeRoot = styled(NodeRoot)<{ hovered?: boolean }>`
   ${props => props.hovered && collectionDragAndDropHoverStyle}
 `;
 
-export const CollectionLinkRoot = styled.div``;
-
 const itemContentStyle = css`
   display: flex;
   align-items: center;

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarItems.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarItems.styled.tsx
@@ -2,7 +2,6 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 
 import { TreeNode } from "metabase/components/tree/TreeNode";
-import { ListRoot } from "metabase/components/tree/TreeNodeList.styled";
 import Link from "metabase/core/components/Link";
 import { alpha, color, darken } from "metabase/lib/colors";
 import { NAV_SIDEBAR_WIDTH } from "metabase/nav/constants";
@@ -76,16 +75,7 @@ export const CollectionNodeRoot = styled(NodeRoot)<{ hovered?: boolean }>`
   ${props => props.hovered && collectionDragAndDropHoverStyle}
 `;
 
-// accommodate for trash collection having margin above
-export const CollectionLinkRoot = styled.div`
-  ${ListRoot} > &:last-child {
-    margin-top: 1rem;
-  }
-
-  ${ListRoot} ${ListRoot} > &:last-child {
-    margin-top: 0;
-  }
-`;
+export const CollectionLinkRoot = styled.div``;
 
 const itemContentStyle = css`
   display: flex;


### PR DESCRIPTION
### Description

Moves the **Browse** part of the sidenav down, just above Trash.

Brief discussion here: https://metaboat.slack.com/archives/C06REDHM6BV/p1722460903919469?thread_ts=1720458369.496439&cid=C06REDHM6BV

### How to verify

Open the sidenav