### PR TITLE
fix(browse): Make Browse models table full width

### DIFF
--- a/frontend/src/metabase/browse/components/BrowseContainer.styled.tsx
+++ b/frontend/src/metabase/browse/components/BrowseContainer.styled.tsx
@@ -17,7 +17,6 @@ export const BrowseContainer = styled.div`
 `;
 
 export const BrowseSection = styled(Flex)`
-  max-width: 64rem;
   margin: 0 auto;
   width: 100%;
 `;

--- a/frontend/src/metabase/browse/components/CollectionBreadcrumbsWithTooltip.tsx
+++ b/frontend/src/metabase/browse/components/CollectionBreadcrumbsWithTooltip.tsx
@@ -69,70 +69,73 @@ export const CollectionBreadcrumbsWithTooltip = ({
   const maxWidths = getBreadcrumbMaxWidths(shownCollections, 96, ellipsifyPath);
 
   return (
-    <Tooltip
-      label={pathString}
-      disabled={!isTooltipEnabled}
-      multiline
-      maw="20rem"
+    <ResponsiveContainer
+      aria-label={pathString}
+      data-testid={`breadcrumbs-for-collection: ${collection.name}`}
+      name={containerName}
+      w="auto"
     >
-      <ResponsiveContainer
-        aria-label={pathString}
-        data-testid={`breadcrumbs-for-collection: ${collection.name}`}
-        name={containerName}
-        w="auto"
-      >
-        <CollectionLink to={Urls.collection(collection)}>
-          <Flex
-            align="center"
-            w="100%"
-            lh="1"
-            style={{ flexFlow: "row nowrap" }}
+      <CollectionLink to={Urls.collection(collection)}>
+        <Flex
+          align="center"
+          w="100%"
+          lh="1"
+          style={{ flexFlow: "row nowrap" }}
+          data-testid="collection-breadcrumb-flex"
+        >
+          <CollectionsIcon
+            name="folder"
+            // Stopping propagation so that the parent <tr>'s onclick won't fire
+            onClick={(e: React.MouseEvent) => e.stopPropagation()}
+          />
+          <Tooltip
+            label={pathString}
+            disabled={!isTooltipEnabled}
+            multiline
+            maw="20rem"
           >
-            <CollectionsIcon
-              name="folder"
-              // Stopping propagation so that the parent <tr>'s onclick won't fire
-              onClick={(e: React.MouseEvent) => e.stopPropagation()}
-            />
-            {shownCollections.map((collection, index) => {
-              const key = `collection${collection.id}`;
-              return (
-                <BreadcrumbGroup
-                  spacing={0}
-                  key={key}
-                  // Stopping propagation so that the parent <tr>'s onclick won't fire
-                  onClick={(e: React.MouseEvent) => e.stopPropagation()}
-                >
-                  {index > 0 && <PathSeparator />}
-                  <CollectionBreadcrumbsWrapper
-                    containerName={containerName}
-                    style={{ alignItems: "center" }}
-                    w="auto"
-                    display="flex"
+            <Flex wrap="nowrap">
+              {shownCollections.map((collection, index) => {
+                const key = `collection${collection.id}`;
+                return (
+                  <BreadcrumbGroup
+                    spacing={0}
+                    key={key}
+                    // Stopping propagation so that the parent <tr>'s onclick won't fire
+                    onClick={(e: React.MouseEvent) => e.stopPropagation()}
                   >
-                    {index === 0 && !justOneShown && (
-                      <InitialEllipsis ref={initialEllipsisRef} />
-                    )}
-                    {index > 0 && ellipsifyPath && <Ellipsis />}
-                    <Breadcrumb
-                      maxWidth={maxWidths[index]}
-                      index={index}
-                      isSoleBreadcrumb={collections.length === 1}
+                    {index > 0 && <PathSeparator />}
+                    <CollectionBreadcrumbsWrapper
                       containerName={containerName}
-                      ref={(el: HTMLDivElement | null) =>
-                        el && ref.current.set(key, el)
-                      }
-                      key={collection.id}
+                      style={{ alignItems: "center" }}
+                      w="auto"
+                      display="flex"
                     >
-                      {getCollectionName(collection)}
-                    </Breadcrumb>
-                  </CollectionBreadcrumbsWrapper>
-                </BreadcrumbGroup>
-              );
-            })}
-          </Flex>
-        </CollectionLink>
-      </ResponsiveContainer>
-    </Tooltip>
+                      {index === 0 && !justOneShown && (
+                        <InitialEllipsis ref={initialEllipsisRef} />
+                      )}
+                      {index > 0 && ellipsifyPath && <Ellipsis />}
+                      <Breadcrumb
+                        maxWidth={maxWidths[index]}
+                        index={index}
+                        isSoleBreadcrumb={collections.length === 1}
+                        containerName={containerName}
+                        ref={(el: HTMLDivElement | null) =>
+                          el && ref.current.set(key, el)
+                        }
+                        key={collection.id}
+                      >
+                        {getCollectionName(collection)}
+                      </Breadcrumb>
+                    </CollectionBreadcrumbsWrapper>
+                  </BreadcrumbGroup>
+                );
+              })}
+            </Flex>
+          </Tooltip>
+        </Flex>
+      </CollectionLink>
+    </ResponsiveContainer>
   );
 };
 

--- a/frontend/src/metabase/browse/components/RecentModels.styled.tsx
+++ b/frontend/src/metabase/browse/components/RecentModels.styled.tsx
@@ -2,7 +2,12 @@ import styled from "@emotion/styled";
 
 export const RecentModelsGrid = styled.div`
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(13rem, 1fr));
+  grid-template-columns: repeat(4, calc(25% - 0.375rem));
+
+  @container ItemsTableContainer (max-width: 824px) {
+    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  }
+
   gap: 0.5rem;
   margin: 0;
   width: 100%;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8d619ef0-9a85-4c3b-a886-5b10d5e41c85)

- [x] Change the browsing models page to full width from previously centered and fixed width
- [x] Change the recent cards from previous fixed width to 4 cards per row up to 8 cards totally. Make them responsive when screen is smaller to 3, 2 and 1 cards accordingly

Postponed for now:
- [ ] Change the models table to 3 evenly-distributed columns with a responsive priority from left to right. When screen is large, show 3 columns. Then hide descriptions, and finally collections. Always show names.