### PR TITLE
Fix auto release schedule off by one

### DIFF
--- a/.github/workflows/release-patch.yml
+++ b/.github/workflows/release-patch.yml
@@ -9,7 +9,7 @@ on:
         type: number
         required: true
   schedule:
-    - cron: '15 0 * * 1-5' # every weekday at 7/8:15 pm Eastern Time
+    - cron: '15 0 * * 2-6' # every weekday at 7/8:15 pm Eastern Time
 
 jobs:
   auto-patch-trigger:


### PR DESCRIPTION
00:15 is the _next_ day, so a mon-fri release at 8pm eastern time is actually a tues-sat release UTC. 🤦 
