### PR TITLE
[notification] Fix test pulse endpoint does not work properly for http channels

### DIFF
--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -306,7 +306,7 @@
 
   Only supports HTTP channels for now, returns a map with type key for slack and email"
   [{channel-type :channel_type :as pulse-channel}]
-  (if (= "http" channel-type)
+  (if (= :http (keyword channel-type))
     (t2/select-one :model/Channel :id (:channel_id pulse-channel))
     {:type (keyword "channel" (name channel-type))}))
 
@@ -331,7 +331,6 @@
                            messages (channel/render-notification (:type channel)
                                                                  (get-notification-info pulse parts pulse-channel)
                                                                  (channel-recipients pulse-channel))]
-                       (println channel pulse-channel)
                        (log/debugf "Rendered %d messages for %s %d to channel %s"
                                    (count messages)
                                    (alert-or-pulse pulse)

--- a/test/metabase/api/pulse_test.clj
+++ b/test/metabase/api/pulse_test.clj
@@ -6,6 +6,7 @@
    [java-time.api :as t]
    [metabase.api.card-test :as api.card-test]
    [metabase.api.pulse :as api.pulse]
+   [metabase.channel.http-test :as channel.http-test]
    [metabase.http-client :as client]
    [metabase.integrations.slack :as slack]
    [metabase.models
@@ -922,36 +923,42 @@
   ;; see [[metabase-enterprise.advanced-config.api.pulse-test/test-pulse-endpoint-should-respect-email-domain-allow-list-test]]
   ;; for additional EE-specific tests
   (testing "POST /api/pulse/test send test alert to a http channel"
-    (mt/with-temp
-      [:model/Card    card    {:dataset_query (mt/mbql-query orders {:aggregation [[:count]]})}
-       :model/Channel channel {:type    :channel/http
-                               :details {:url         "http://example.com"
-                                         :auth-method :none}}]
-      (is (=? {:channel/http [{:body {:alert_creator_id   (mt/user->id :rasta)
-                                      :alert_creator_name "Rasta Toucan"
-                                      :alert_id           nil
-                                      :data               {:question_id   (:id card)
-                                                           :question_name (mt/malli=? string?)
-                                                           :question_url  (mt/malli=? string?)
-                                                           :raw_data      {:cols ["count"], :rows [[18760]]},
-                                                           :type          "question"
-                                                           :visualization (mt/malli=? [:fn #(str/starts-with? % "data:image/png;base64,")])}
-                                      :type               "alert"}}]}
-              (pulse.test-util/with-captured-channel-send-messages!
-                (mt/user-http-request :rasta :post 200 "pulse/test"
-                                      {:name            (mt/random-name)
-                                       :cards           [{:id                (:id card)
-                                                          :include_csv       false
-                                                          :include_xls       false
-                                                          :dashboard_card_id nil}]
-                                       :channels        [{:enabled       true
-                                                          :channel_type  "http"
-                                                          :channel_id    (:id channel)
-                                                          :schedule_type "daily"
-                                                          :schedule_hour 12
-                                                          :schedule_day  nil
-                                                          :recipients    []}]
-                                       :alert_condition "rows"})))))))
+    (let [requests (atom [])
+          endpoint (channel.http-test/make-route
+                    :post "/test"
+                    (fn [req]
+                      (swap! requests conj req)))]
+      (channel.http-test/with-server [url [endpoint]]
+        (mt/with-temp
+          [:model/Card    card    {:dataset_query (mt/mbql-query orders {:aggregation [[:count]]})}
+           :model/Channel channel {:type    :channel/http
+                                   :details {:url         (str url "/test")
+                                             :auth-method :none}}]
+          (mt/user-http-request :rasta :post 200 "pulse/test"
+                                {:name            (mt/random-name)
+                                 :cards           [{:id                (:id card)
+                                                    :include_csv       false
+                                                    :include_xls       false
+                                                    :dashboard_card_id nil}]
+                                 :channels        [{:enabled       true
+                                                    :channel_type  "http"
+                                                    :channel_id    (:id channel)
+                                                    :schedule_type "daily"
+                                                    :schedule_hour 12
+                                                    :schedule_day  nil
+                                                    :recipients    []}]
+                                 :alert_condition "rows"})
+          (is (=? {:body {:alert_creator_id   (mt/user->id :rasta)
+                          :alert_creator_name "Rasta Toucan"
+                          :alert_id           nil
+                          :data               {:question_id   (:id card)
+                                               :question_name (mt/malli=? string?)
+                                               :question_url  (mt/malli=? string?)
+                                               :raw_data      {:cols ["count"], :rows [[18760]]},
+                                               :type          "question"
+                                               :visualization (mt/malli=? [:fn #(str/starts-with? % "data:image/png;base64,")])}
+                          :type               "alert"}}
+                  (first @requests))))))))
 
 (deftest send-test-pulse-validate-emails-test
   (testing (str "POST /api/pulse/test should call " `pulse-channel/validate-email-domains)

--- a/test/metabase/channel/http_test.clj
+++ b/test/metabase/channel/http_test.clj
@@ -48,8 +48,7 @@
   (fn [req]
     (-> req
         (m/update-existing :body #(-> % slurp (json/parse-string true)))
-        handler
-        (m/update-existing :body json/generate-string))))
+        handler)))
 
 (def middlewares [json-mw wrap-params])
 
@@ -64,7 +63,10 @@
       (finally
         (.stop server)))))
 
-(defn- make-route
+(defn make-route
+  "Create a route to be used with [[with-server]].
+
+  (make-route :get \"/test\" (fn [req] {:status 200 :body \"Hello, world!\"}))"
   [method path handler]
   {:path  path
    :route (compojure/make-route method path handler)})

--- a/test/metabase/channel/http_test.clj
+++ b/test/metabase/channel/http_test.clj
@@ -142,16 +142,16 @@
         (is (true? (can-connect?* get-302-redirect-200))))
       (testing "failed to connect with a 302 that redirects to 400"
         (is (= {:request-status 400
-                :request-body   "\"Bad request\""}
+                :request-body   "Bad request"}
                (exception-data (can-connect?* get-302-redirect-400)))))
       (testing "failed to conenct to a 400"
         (is (= {:request-status 400
-                :request-body   "\"Bad request\""}
+                :request-body   "Bad request"}
                (exception-data (can-connect?* get-400)))))
       (is (=? {:request-status 500
                ;; not sure why it's returns a response map is nil body
                ;; looks like a jetty bug: https://stackoverflow.com/q/46299061
-               #_:request-body   #_"\"Internal server error\""}
+               #_:request-body   #_"Internal server error"}
              (exception-data (can-connect?* get-500)))))))
 
 (deftest ^:parallel can-connect-header-auth-test
@@ -170,7 +170,7 @@
 
     (testing "fail to connect with header auth"
       (is (= {:request-status 401
-              :request-body   "\"Unauthorized\""}
+              :request-body   "Unauthorized"}
              (exception-data (can-connect? {:url         (str url "/user")
                                             :method      "get"
                                             :auth-method "header"
@@ -193,7 +193,7 @@
                                               :password "secretpassword"}}))))
     (testing "fail to connect with query-param auth"
       (is (= {:request-status 401
-              :request-body   "\"Unauthorized\""}
+              :request-body   "Unauthorized"}
              (exception-data (can-connect? {:url         (str url "/user")
                                             :method      "get"
                                             :auth-method "query-param"
@@ -216,7 +216,7 @@
                                 :auth-info   {:token "SECRET_TOKEN"}}))))
     (testing "fail to connect with request-body auth"
       (is (= {:request-status 401
-              :request-body   "\"Unauthorized\""}
+              :request-body   "Unauthorized"}
              (exception-data (can-connect? {:url         (str url "/user")
                                             :method      "post"
                                             :auth-method "request-body"
@@ -231,7 +231,7 @@
            (exception-data (can-connect? {:url "https://www.secret_service.xyz"}))))
 
     (with-server [url [get-400]]
-      (is (= {:request-body   "\"Bad request\""
+      (is (= {:request-body   "Bad request"
               :request-status 400}
              (exception-data (can-connect? {:url         (str url (:path get-400))
                                             :method      "get"


### PR DESCRIPTION
Fix POST /api/pulse/test does not send pulse for HTTP channels.

Nick found this bug when trying to integrate FE with BE in https://metaboat.slack.com/archives/C07318NQ5M2/p1722544629672509

The question is, why didn't our test catch this? and it was because our test helper `pulse.test-util/with-captured-channel-send-messages!` was capturing all call to `channel/send!`, so in a way this is not an e2e tests because the failure happens inside the `channel/send!` implementation for HTTP channel.

We fixed this bug and also add 2 e2e tests for 2 flows:
- send alert to HTTP channel using `pulse/send-pulse!`, this is the function that our quartz scheduler will call to send pulses
- POST /api/pulse/test for HTTP channels