### PR TITLE
fix db switching in ts/with-dbs

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/load_test.clj
@@ -424,3 +424,15 @@
   (let [parameters [{:values_source_config {:card_id "foo"}}]]
     (with-redefs [load/fully-qualified-name->card-id {"foo" 1}]
       (is (= [1] (mapv (comp :card_id :values_source_config) (#'load/resolve-dashboard-parameters parameters)))))))
+
+(deftest with-dbs-works-as-expected-test
+  (ts/with-dbs [source-db dest-db]
+    (ts/with-db source-db
+      (mt/with-temp
+        [:model/Card _ {:name "MY CARD"}]
+        (testing "card is available in the source db"
+          (is (some? (t2/select-one :model/Card :name "MY CARD"))))
+        (ts/with-db dest-db
+          (testing "card should not be available in the dest db"
+           ;; FAIL, select is returning a Card
+           (is (nil? (t2/select-one :model/Card :name "MY CARD")))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -744,7 +744,7 @@
         (ts/with-dbs [source-db dest-db]
           (ts/with-db source-db
             ;; preparation
-            (t2.with-temp/with-temp [Dashboard _ {:name "some dashboard"}]
+            (mt/with-temp [Dashboard _ {:name "some dashboard"}]
               (testing "export (v2-dump) command"
                 (is (cmd/v2-dump! dump-dir {})
                     "works"))
@@ -752,8 +752,9 @@
               (testing "import (v2-load) command"
                 (ts/with-db dest-db
                   (testing "doing ingestion"
-                    (is (cmd/v2-load! dump-dir {})
-                        "works"))))))))))
+                    (mt/with-temp [:model/User _ {}]
+                      (is (cmd/v2-load! dump-dir {})
+                          "works")))))))))))
 
   (testing "without :serialization feature enabled"
     (ts/with-random-dump-dir [dump-dir "serdesv2-"]
@@ -770,9 +771,10 @@
               (testing "import (v2-load) command"
                 (ts/with-db dest-db
                   (testing "doing ingestion"
-                    (is (thrown-with-msg? Exception #"Please upgrade"
-                                          (cmd/v2-load! dump-dir {}))
-                        "throws")))))))))))
+                    (mt/with-temp [:model/User _ {}]
+                      (is (thrown-with-msg? Exception #"Please upgrade"
+                                            (cmd/v2-load! dump-dir {}))
+                          "throws"))))))))))))
 
 (deftest pivot-export-test
   (testing "Pivot table export and load correctly"


### PR DESCRIPTION
mt/with-temp opens transaction which is used by toucan to make requests, so `mt/with-db` had no impact on database used inside of mt/with-temp

Fixes #46032 
