### PR TITLE
perf: Optimize validation with Malli

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -95,7 +95,7 @@
                                                           org.bouncycastle/bcpkix-jdk18on
                                                           org.bouncycastle/bcprov-jdk18on]}
   metabase/throttle                         {:mvn/version "1.0.2"}              ; Tools for throttling access to API endpoints and other code pathways
-  metosin/malli                             {:mvn/version "0.14.0"}             ; Data-driven Schemas for Clojure/Script and babashka
+  metosin/malli                             {:mvn/version "0.16.3"}             ; Data-driven Schemas for Clojure/Script and babashka
   nano-id/nano-id                           {:mvn/version "1.1.0"}              ; NanoID generator for generating entity_ids
   net.cgrand/macrovich                      {:mvn/version "0.2.2"}              ; utils for writing macros for both Clojure & ClojureScript
   net.clojars.wkok/openai-clojure           {:mvn/version "0.16.0"

--- a/src/metabase/analyze/schema.clj
+++ b/src/metabase/analyze/schema.clj
@@ -1,17 +1,10 @@
 (ns metabase.analyze.schema
   "Schemas used by the analyze code."
   (:require
-   [clojure.string :as str]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]))
 
-(mr/def ::no-kebab-case-keys
-  [:fn
-   {:error/message "Map should not contain any kebab-case keys"}
-   (fn [m]
-     (every? (fn [k]
-               (not (str/includes? k "-")))
-             (keys m)))])
+(mr/def ::no-kebab-case-keys (ms/MapWithNoKebabKeys))
 
 (mr/def ::Table
   [:and

--- a/src/metabase/lib/metadata/protocols.cljc
+++ b/src/metabase/lib/metadata/protocols.cljc
@@ -61,7 +61,8 @@
 (defn metadata-provider?
   "Whether `x` is a valid [[MetadataProvider]]."
   [x]
-  (satisfies? MetadataProvider x))
+  #?(:clj (extends? MetadataProvider (class x))
+     :cljs (satisfies? MetadataProvider x)))
 
 (mr/def ::metadata-provider
   "Schema for something that satisfies the [[metabase.lib.metadata.protocols/MetadataProvider]] protocol."
@@ -158,7 +159,8 @@
 (defn cached-metadata-provider?
   "Whether `x` is a valid [[CachedMetadataProvider]]."
   [x]
-  (satisfies? CachedMetadataProvider x))
+   #?(:clj (extends? CachedMetadataProvider (class x))
+      :cljs (satisfies? CachedMetadataProvider x)))
 
 (mr/def ::cached-metadata-provider
   [:fn

--- a/src/metabase/lib/schema.cljc
+++ b/src/metabase/lib/schema.cljc
@@ -106,10 +106,12 @@
   "For ref validation purposes we should ignore `:joins` and any namespaced keys that might be used to record additional
   info e.g. `:lib/metadata`."
   [stage]
-  (select-keys stage (into []
-                           (comp (filter simple-keyword?)
-                                 (remove (partial = :joins)))
-                           (keys stage))))
+  (reduce-kv (fn [acc k _]
+               (if (or (qualified-keyword? k)
+                       (= k :joins))
+                 (dissoc acc k)
+                 acc))
+             stage stage))
 
 (defn- expression-ref-errors-for-stage [stage]
   (let [expression-names (into #{} (map (comp :lib/expression-name second)) (:expressions stage))]

--- a/src/metabase/sync/interface.clj
+++ b/src/metabase/sync/interface.clj
@@ -1,7 +1,6 @@
 (ns metabase.sync.interface
   "Schemas and constants used by the sync code."
   (:require
-   [clojure.string :as str]
    [malli.util :as mut]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.util.malli.registry :as mr]
@@ -114,13 +113,7 @@
 ;; out from the ns declaration when running `cljr-clean-ns`. Plus as a bonus in the future we could add additional
 ;; validations to these, e.g. requiring that a Field have a base_type
 
-(mr/def ::no-kebab-case-keys
-  [:fn
-   {:error/message "Map should not contain any kebab-case keys"}
-   (fn [m]
-     (every? (fn [k]
-               (not (str/includes? k "-")))
-             (keys m)))])
+(mr/def ::no-kebab-case-keys (ms/MapWithNoKebabKeys))
 
 (mr/def ::DatabaseInstance
   [:and

--- a/src/metabase/util/malli/registry.cljc
+++ b/src/metabase/util/malli/registry.cljc
@@ -17,7 +17,7 @@
   You generally shouldn't use this outside of this namespace unless you have a really good reason to do so! Make sure
   you used namespaced keys if you are using it elsewhere."
   [k schema value-thunk]
-  (or (get-in @cache [k schema])
+  (or (get (get @cache k) schema) ; get-in is terribly inefficient
       (let [v (value-thunk)]
         (swap! cache assoc-in [k schema] v)
         v)))

--- a/test/metabase/api/alert_test.clj
+++ b/test/metabase/api/alert_test.clj
@@ -210,7 +210,7 @@
 
 (deftest post-alert-test
   (is (= {:errors          {:alert_condition "enum of rows, goal"}
-          :specific-errors {:alert_condition ["should be either rows or goal, received: \"not rows\""]}}
+          :specific-errors {:alert_condition ["should be either \"rows\" or \"goal\", received: \"not rows\""]}}
          (mt/user-http-request
           :rasta :post 400 "alert" {:alert_condition "not rows"
                                     :card            "foobar"})))
@@ -419,7 +419,7 @@
 
 (deftest put-alert-test-2
   (is (= {:errors {:alert_condition "nullable enum of rows, goal"},
-          :specific-errors {:alert_condition ["should be either rows or goal, received: \"not rows\""]}}
+          :specific-errors {:alert_condition ["should be either \"rows\" or \"goal\", received: \"not rows\""]}}
          (mt/user-http-request
           :rasta :put 400 "alert/1" {:alert_condition "not rows"})))
 

--- a/test/metabase/api/api_key_test.clj
+++ b/test/metabase/api/api_key_test.clj
@@ -85,7 +85,7 @@
                      [:group :name]))))
     (testing "A non-empty name is required"
       (is (= {:errors          {:name "value must be a non-blank string."}
-              :specific-errors {:name ["should be at least 1 characters, received: \"\"" "non-blank string, received: \"\""]}}
+              :specific-errors {:name ["should be at least 1 character, received: \"\"" "non-blank string, received: \"\""]}}
              (mt/user-http-request :crowberto :post 400 "api-key"
                                    {:group_id group-id
                                     :name     ""}))))

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -873,7 +873,7 @@
                    (t2/select-one-fn :width Dashboard :id (u/the-id dashboard)))))
 
           (testing "values that are not 'fixed' or 'full' error."
-            (is (= "should be either fixed or full, received: 1200"
+            (is (= "should be either \"fixed\" or \"full\", received: 1200"
                    (-> (mt/user-http-request :rasta :put 400 (str "dashboard/" (u/the-id dashboard)) {:width 1200})
                        :specific-errors
                        :dash-updates

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -192,7 +192,7 @@
   (testing "GET /api/database/:id"
     (testing "Invalid `?include` should return an error"
       (is (= {:errors          {:include "nullable enum of tables, tables.fields"},
-              :specific-errors {:include ["should be either tables or tables.fields, received: \"schemas\""]}}
+              :specific-errors {:include ["should be either \"tables\" or \"tables.fields\", received: \"schemas\""]}}
              (mt/user-http-request :lucky :get 400 (format "database/%d?include=schemas" (mt/id))))))))
 
 (deftest get-database-legacy-no-self-service-test

--- a/test/metabase/lib/schema/expression/temporal_test.cljc
+++ b/test/metabase/lib/schema/expression/temporal_test.cljc
@@ -75,7 +75,7 @@
                         (me/humanize (mc/explain ::temporal/timezone-id input)))
     "US/Pacific"  nil
     "US/Specific" ["invalid timezone ID: \"US/Specific\"" "timezone offset string literal"]
-    ""            ["should be at least 1 characters" "non-blank string" "invalid timezone ID: \"\"" "timezone offset string literal"]
+    ""            ["should be at least 1 character" "non-blank string" "invalid timezone ID: \"\"" "timezone offset string literal"]
     "  "          ["non-blank string" "invalid timezone ID: \"  \"" "timezone offset string literal"]
     nil           ["should be a string" "non-blank string" "invalid timezone ID: nil" "timezone offset string literal"]))
 


### PR DESCRIPTION
This PR contains various bits and pieces that make value validation with Malli more allocation-efficient (and somewhat faster). E.g., since #46167, this PR further reduces the allocations in the DB add/sync benchmark from 20 GB to ~15 GB.

Malli is updated to the latest version to include this: https://github.com/metosin/malli/pull/1079.

`satisfies?` is bad on hot paths because of https://clojure-goes-fast.com/blog/performance-tidbit-instanceof/, https://clojure.atlassian.net/browse/CLJ-1814.