### PR TITLE
fix(browse/models): Correct the number of recently viewed models shown

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/browse/components/BrowseModels.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/browse/components/BrowseModels.unit.spec.tsx
@@ -5,22 +5,35 @@ import {
   setupSettingsEndpoints,
 } from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
-import { renderWithProviders, screen } from "__support__/ui";
+import { renderWithProviders, screen, within } from "__support__/ui";
 import { BrowseModels } from "metabase/browse/components/BrowseModels";
-import { createMockModelResult } from "metabase/browse/test-utils";
-import type { SearchResult } from "metabase-types/api";
+import {
+  createMockModelResult,
+  createMockRecentModel,
+} from "metabase/browse/test-utils";
+import type { RecentCollectionItem } from "metabase-types/api";
 import {
   createMockCollection,
   createMockTokenFeatures,
 } from "metabase-types/api/mocks";
 import { createMockSetupState } from "metabase-types/store/mocks";
 
-const setup = (modelCount: number) => {
+const setup = (modelCount: number, recentModelCount = 5) => {
   const models = mockModels.slice(0, modelCount);
+
+  // Add some instance analytics models to ensure they don't affect the page
+  models.push(...mockInstanceAnalyticsModels);
+
+  const mockRecentModels = mockModels
+    .slice(0, recentModelCount)
+    .map(model =>
+      createMockRecentModel(model as unknown as RecentCollectionItem),
+    );
+  setupRecentViewsEndpoints(mockRecentModels);
+
   setupSearchEndpoints(models);
   setupSettingsEndpoints([]);
   setupEnterprisePlugins();
-  setupRecentViewsEndpoints([]);
   return renderWithProviders(<BrowseModels />, {
     storeInitialState: {
       setup: createMockSetupState({
@@ -29,6 +42,7 @@ const setup = (modelCount: number) => {
       settings: mockSettings({
         "token-features": createMockTokenFeatures({
           official_collections: true,
+          audit_app: true,
         }),
       }),
     },
@@ -61,7 +75,7 @@ const grandchildOfInstanceAnalyticsCollection = createMockCollection({
   ],
 });
 
-const mockModels: SearchResult[] = [
+const mockModels = [
   createMockModelResult({
     id: 0,
     name: "A normal model",
@@ -92,10 +106,102 @@ const mockModels: SearchResult[] = [
   }),
 ];
 
+const mockInstanceAnalyticsModels = [
+  createMockModelResult({
+    id: 1000,
+    name: "Instance analytics model 1",
+    collection: createMockCollection({
+      type: "instance-analytics",
+    }),
+  }),
+  createMockModelResult({
+    id: 1001,
+    name: "Instance analytics model 2",
+    collection: createMockCollection({
+      type: "instance-analytics",
+    }),
+  }),
+  createMockModelResult({
+    id: 1002,
+    name: "Instance analytics model 3",
+    collection: createMockCollection({
+      type: "instance-analytics",
+    }),
+  }),
+  createMockModelResult({
+    id: 1003,
+    name: "Instance analytics model 4",
+    collection: createMockCollection({
+      type: "instance-analytics",
+    }),
+  }),
+  createMockModelResult({
+    id: 1004,
+    name: "Instance analytics model 5",
+    collection: createMockCollection({
+      type: "instance-analytics",
+    }),
+  }),
+  createMockModelResult({
+    id: 1005,
+    name: "Instance analytics model 6",
+    collection: createMockCollection({
+      type: "instance-analytics",
+    }),
+  }),
+  createMockModelResult({
+    id: 1006,
+    name: "Instance analytics model 7",
+    collection: createMockCollection({
+      type: "instance-analytics",
+    }),
+  }),
+  createMockModelResult({
+    id: 1007,
+    name: "Instance analytics model 8",
+    collection: createMockCollection({
+      type: "instance-analytics",
+    }),
+  }),
+  createMockModelResult({
+    id: 1008,
+    name: "Instance analytics model 9",
+    collection: createMockCollection({
+      type: "instance-analytics",
+    }),
+  }),
+  createMockModelResult({
+    id: 1009,
+    name: "Instance analytics model 10",
+    collection: createMockCollection({
+      type: "instance-analytics",
+    }),
+  }),
+];
+
 describe("BrowseModels", () => {
   it("does not display instance analytics collections", async () => {
     setup(4);
-    expect(await screen.findByText("A normal model")).toBeInTheDocument();
+    const modelsTable = await screen.findByRole("table", {
+      name: /Table of models/,
+    });
+    expect(
+      await within(modelsTable).findByText("A normal model"),
+    ).toBeInTheDocument();
     expect(screen.queryByText("instance analytics")).not.toBeInTheDocument();
+  });
+  it("displays recently viewed models when there are enough models", async () => {
+    setup(9);
+    const recentModelsGrid = await screen.findByRole("grid", {
+      name: /Recents/,
+    });
+    expect(recentModelsGrid).toBeInTheDocument();
+  });
+  it("displays no recently viewed models when there are fewer than 9 models", async () => {
+    setup(8);
+    const recentModelsGrid = screen.queryByRole("grid", {
+      name: /Recents/,
+    });
+    expect(recentModelsGrid).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/browse/components/BrowseModels.tsx
+++ b/frontend/src/metabase/browse/components/BrowseModels.tsx
@@ -37,19 +37,16 @@ export const BrowseModels = () => {
 
   const modelsResult = useFetchModels({ model_ancestors: true });
 
-  const { allModels, doVerifiedModelsExist } = useMemo(() => {
-    const allModels =
+  const { models, doVerifiedModelsExist } = useMemo(() => {
+    const unfilteredModels =
       (modelsResult.data?.data as ModelResult[] | undefined) ?? [];
-    const doVerifiedModelsExist = allModels.some(
+    const doVerifiedModelsExist = unfilteredModels.some(
       model => model.moderated_status === "verified",
     );
-    return { allModels, doVerifiedModelsExist };
+    const models =
+      PLUGIN_COLLECTIONS.filterOutItemsFromInstanceAnalytics(unfilteredModels);
+    return { models, doVerifiedModelsExist };
   }, [modelsResult]);
-
-  const models = useMemo(
-    () => PLUGIN_COLLECTIONS.filterOutItemsFromInstanceAnalytics(allModels),
-    [allModels],
-  );
 
   const { filteredModels } = useMemo(() => {
     // If no models are verified, don't filter them
@@ -74,9 +71,9 @@ export const BrowseModels = () => {
   );
 
   const recentModels = useMemo(() => {
-    const cap = getMaxRecentModelCount(allModels.length);
+    const cap = getMaxRecentModelCount(models.length);
     return filteredRecentModels.slice(0, cap);
-  }, [filteredRecentModels, allModels.length]);
+  }, [filteredRecentModels, models.length]);
 
   const isEmpty =
     !recentModelsResult.isLoading &&

--- a/frontend/src/metabase/browse/components/BrowseModels.unit.spec.tsx
+++ b/frontend/src/metabase/browse/components/BrowseModels.unit.spec.tsx
@@ -332,4 +332,12 @@ describe("BrowseModels", () => {
       within(recentModelsGrid).queryByText("Model 5"),
     ).not.toBeInTheDocument();
   });
+
+  it("displays no recently viewed models when there are fewer than 9 models - but instance analytics models do not count", async () => {
+    setup(8);
+    const recentModelsGrid = screen.queryByRole("grid", {
+      name: /Recents/,
+    });
+    expect(recentModelsGrid).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
### Description

The number of recently viewed models shown in Browse models depends on the number of models the user has permission to see. However, when counting these models, I mistakenly included the instance analytics models. These are never shown in Browse models, are not relevant to it, and should not be counted in this context.

### How to verify

Reduce the number of models in your instance down to 8 or fewer. (You can convert models temporarily to saved questions.) You should no longer see any recently viewed models. This should be the case even if you have instance analytics models.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
