### PR TITLE
Enable type info computation for string id fields

### DIFF
--- a/test/metabase/query_processor/middleware/wrap_value_literals_test.clj
+++ b/test/metabase/query_processor/middleware/wrap_value_literals_test.clj
@@ -10,9 +10,11 @@
    [metabase.lib.test-util :as lib.tu]
    [metabase.lib.test-util.macros :as lib.tu.macros]
    [metabase.query-processor.middleware.wrap-value-literals :as qp.wrap-value-literals]
+   [metabase.query-processor.preprocess :as qp.preprocess]
    [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.timezone :as qp.timezone]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [toucan2.tools.with-temp :as toucan2.with-temp]))
 
 (driver/register! ::tz-driver, :abstract? true)
 
@@ -301,3 +303,17 @@
                      lib.convert/->legacy-MBQL
                      wrap-value-literals
                      (lib/query query))))))))
+
+(deftest ^:parallel model-with-enum-field-expression-test
+  (testing "type info is added to fields coming from model source query (#46059)"
+    ;; Basically, this checks whether the [[metabase.query-processor.middleware.wrap-value-literals/type-info]] :field
+    ;; adds options to values in expressions, where other arg if field clause with name instead of int id.
+    (toucan2.with-temp/with-temp [:model/Card {id :id} {:dataset_query (mt/mbql-query venues)
+                                                        :type          :model}]
+      (let [query (mt/mbql-query
+                   venues
+                   {:source-table (str "card__" id)
+                    :filter [:= [:field "ID" {:base-type :type/Integer}] 1]})
+            preprocessed (qp.preprocess/preprocess query)]
+        ;; [:query :filter 2 2 :database_type] points to wrapped value's options
+        (is (= "BIGINT" (get-in preprocessed [:query :filter 2 2 :database_type])))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/46059

### Description

In `sql.qp/->honeysql [:postgres :value]` it is expected that wrapped values have `:database_type`. Types are added to integer id fields using metadata provider. That's 

Field clauses coming from models are identified by string name. This PR modifies `wrap-value-literals` middleware, so types are added also to values in expression with fields having name instead of id.

### How to verify

Run new test or follow the reproduction steps from the description.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
