### PR TITLE
Add storybook docs for embedding e2e tests

### DIFF
--- a/docs/developers-guide/e2e-tests.md
+++ b/docs/developers-guide/e2e-tests.md
@@ -173,6 +173,14 @@ Cypress._.times(N, ()=> {
 });
 ```
 
+### Embedding SDK tests
+
+Tests located in `e2e/test/scenarios/embedding-sdk` are used to run automated checks for the Embedding SDK.
+
+Embedding SDK is a library, and not an application. We use Storybook to host public components, and we run tests against it.
+
+In order to run stories used for tests locally, please check [storybook setup docs](https://github.com/metabase/metabase/blob/master/enterprise/frontend/src/embedding-sdk/README.md#storybook)
+
 ## DB Snapshots
 
 At the beginning of each test suite we wipe the backend's db and settings cache. This ensures that the test suite starts in a predictable state.

--- a/enterprise/frontend/src/embedding-sdk/README.md
+++ b/enterprise/frontend/src/embedding-sdk/README.md
@@ -86,7 +86,7 @@ java -jar metabase.jar
 You can then use the API key to authenticate with Metabase in your application. Here's an example of how you can
 authenticate with the API key:
 
-``` 
+```
 const metabaseConfig = {
     ...
     apiKey: "YOUR_API_KEY"
@@ -1010,6 +1010,22 @@ For security issues, please follow the instructions for responsible
 disclosure [here](https://github.com/metabase/metabase/blob/master/SECURITY.md#reporting-a-vulnerability).
 
 # Development
+
+## Storybook
+
+You can use storybook to run SDK components during local development.
+
+When you have Metabase instance running:
+```bash
+yarn storybook-embedding-sdk
+```
+
+
+### Initial configuration
+1. Set JWT secret to be "`0000000000000000000000000000000000000000000000000000000000000000`" in Admin > Authentication > JWT > String used by the JWT signing key
+1. Make sure "User Provisioning" setting is set to "`on`".
+1. Set Authorized Origins to "`*`" in Admin > Embedding > Interactive embedding
+
 
 ## Building locally
 


### PR DESCRIPTION
Relates to https://github.com/metabase/metabase/pull/45512

### Description

We want to add docs describing initial setup to run Embedding SDK Storybook, which is used for e2e tests.
This is needed for people who would experience issues with our e2e tests and would like to run our Storybook.

### How to verify

Check if docs make sense
