### PR TITLE
Manual Backport - #46453 - [Permissions] Fix advanced permissions edits not always saving

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/reducer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/reducer.ts
@@ -8,6 +8,7 @@ import {
   UPDATE_DATA_PERMISSION,
 } from "metabase/admin/permissions/permissions";
 import {
+  DataPermission,
   DataPermissionValue,
   type EntityId,
 } from "metabase/admin/permissions/types";
@@ -69,11 +70,13 @@ export const advancedPermissionsSlice = createSlice({
           return state;
         }
 
-        state.impersonations = state.impersonations.filter(
-          impersonation =>
-            impersonation.group_id !== payload.groupId &&
-            impersonation.db_id !== payload.entityId.databaseId,
-        );
+        if (payload?.permissionInfo?.permission === DataPermission.VIEW_DATA) {
+          state.impersonations = state.impersonations.filter(
+            impersonation =>
+              impersonation.group_id !== payload.groupId &&
+              impersonation.db_id !== payload.entityId.databaseId,
+          );
+        }
         return state;
       });
   },

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/actions.js
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/actions.js
@@ -84,7 +84,7 @@ const groupTableAccessPolicies = handleActions(
           return state;
         }
 
-        const { entityId, metadata, groupId } = payload;
+        const { entityId, metadata, groupId, value, permissionInfo } = payload;
 
         // if user is unsandboxing a specific table,
         // remove the specific table's sandbox data
@@ -95,9 +95,11 @@ const groupTableAccessPolicies = handleActions(
           });
           const isTableSandboxed = key in state;
           const isUnsandboxingTable =
-            isTableSandboxed && payload.value !== DataPermissionValue.SANDBOXED;
+            isTableSandboxed &&
+            permissionInfo.permission === DataPermission.VIEW_DATA &&
+            value !== DataPermissionValue.SANDBOXED;
 
-          if (isTableSandboxed && isUnsandboxingTable) {
+          if (isUnsandboxingTable) {
             return _.omit(state, key);
           } else {
             return state;


### PR DESCRIPTION
#46453

Manual backport due to CI failure: https://github.com/metabase/metabase/actions/runs/10222612065/job/28356953509