### PR TITLE
Move the compare to the past aggregation to the bottom of the dropdown and hide it when no temporal breakouts are available

### DIFF
--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -1249,7 +1249,7 @@ describe("issue 43294", () => {
 
     cy.log("compare action");
     cy.button("Add column").click();
-    popover().findByText("Compare “Count” to previous months").click();
+    popover().findByText("Compare to the past").click();
     popover().button("Done").click();
 
     cy.log("extract action");

--- a/e2e/test/scenarios/question/column-compare.cy.spec.ts
+++ b/e2e/test/scenarios/question/column-compare.cy.spec.ts
@@ -154,7 +154,7 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
       );
 
       verifySummarizeText({
-        itemName: "Compare “Count” to previous period ...",
+        itemName: "Compare to the past",
         step2Title: "Compare “Count” to previous period",
         offsetHelp: "periods ago based on grouping",
       });
@@ -172,7 +172,7 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
       });
 
       verifyNotebookText({
-        itemName: "Compare “Count” to previous period ...",
+        itemName: "Compare to the past",
         step2Title: "Compare “Count” to previous period",
         offsetHelp: "periods ago based on grouping",
       });
@@ -213,7 +213,7 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
       );
 
       verifySummarizeText({
-        itemName: "Compare “Count” to previous months ...",
+        itemName: "Compare to the past",
         step2Title: "Compare “Count” to previous months",
         offsetHelp: "months ago based on “Created At”",
       });
@@ -234,7 +234,7 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
       });
 
       verifyNotebookText({
-        itemName: "Compare “Count” to previous months ...",
+        itemName: "Compare to the past",
         step2Title: "Compare “Count” to previous months",
         offsetHelp: "months ago based on “Created At”",
       });
@@ -265,6 +265,8 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
           expression: "Count / Offset(Count, -1) - 1",
         },
       ]);
+
+      visualize();
       verifyColumns([
         "Count (previous month)",
         "Count (vs previous month)",
@@ -279,7 +281,7 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
       );
 
       verifySummarizeText({
-        itemName: "Compare “Count” to previous period ...",
+        itemName: "Compare to the past",
         step2Title: "Compare “Count” to previous period",
         offsetHelp: "periods ago based on “Created At”",
       });
@@ -300,7 +302,7 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
       });
 
       verifyNotebookText({
-        itemName: "Compare “Count” to previous period ...",
+        itemName: "Compare to the past",
         step2Title: "Compare “Count” to previous period",
         offsetHelp: "periods ago based on “Created At”",
       });
@@ -331,6 +333,8 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
           expression: "Count / Offset(Count, -1) - 1",
         },
       ]);
+
+      visualize();
       verifyColumns([
         "Count (previous period)",
         "Count (vs previous period)",
@@ -344,14 +348,11 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
         { visitQuestion: true, wrapId: true, idAlias: "questionId" },
       );
 
-      verifySummarizeText({
-        itemName: "Compare “Count” to previous rows ...",
-        step2Title: "Compare “Count” to previous rows",
-        offsetHelp: "rows above based on “Category”",
-      });
+      cy.button("Summarize").click();
+      rightSidebar().button("Add aggregation").click();
+      verifyNoColumnCompareShortcut();
 
       tableHeaderClick("Category");
-      verifyNoColumnCompareShortcut();
 
       verifyColumnDrillText({
         itemName: "Compare “Count” to previous rows",
@@ -359,14 +360,14 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
         offsetHelp: "rows above based on “Category”",
       });
 
+      openNotebook();
+      cy.button("Summarize").click();
+      verifyNoColumnCompareShortcut();
+      cy.realPress("Escape");
+
+      openVisualization();
       verifyPlusButtonText({
         itemName: "Compare “Count” to previous rows",
-        step2Title: "Compare “Count” to previous rows",
-        offsetHelp: "rows above based on “Category”",
-      });
-
-      verifyNotebookText({
-        itemName: "Compare “Count” to previous rows ...",
         step2Title: "Compare “Count” to previous rows",
         offsetHelp: "rows above based on “Category”",
       });
@@ -376,13 +377,20 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
 
       cy.get("@questionId").then(questionId => {
         expectGoodSnowplowEvent({
-          event: "column_compare_via_shortcut",
+          event: "column_compare_via_plus_modal",
           custom_expressions_used: CUSTOM_EXPRESSIONS_USED,
           database_id: SAMPLE_DB_ID,
           question_id: questionId,
         });
       });
 
+      verifyColumns([
+        "Count (previous value)",
+        "Count (vs previous value)",
+        "Count (% vs previous value)",
+      ]);
+
+      openEditor();
       verifyAggregations([
         {
           name: "Count (previous value)",
@@ -397,11 +405,6 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
           expression: "Count / Offset(Count, -1) - 1",
         },
       ]);
-      verifyColumns([
-        "Count (previous value)",
-        "Count (vs previous value)",
-        "Count (% vs previous value)",
-      ]);
     });
   });
 
@@ -413,7 +416,7 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
       );
 
       verifySummarizeText({
-        itemName: "Compare to previous period ...",
+        itemName: "Compare to the past",
         step1Title: "Compare one of these to the previous period",
         step2Title: "Compare “Count” to previous period",
         offsetHelp: "periods ago based on grouping",
@@ -433,7 +436,7 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
       });
 
       verifyNotebookText({
-        itemName: "Compare to previous period ...",
+        itemName: "Compare to the past",
         step1Title: "Compare one of these to the previous period",
         step2Title: "Compare “Count” to previous period",
         offsetHelp: "periods ago based on grouping",
@@ -475,7 +478,7 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
       );
 
       verifySummarizeText({
-        itemName: "Compare to previous months ...",
+        itemName: "Compare to the past",
         step1Title: "Compare one of these to the previous months",
         step2Title: "Compare “Count” to previous months",
         offsetHelp: "months ago based on “Created At”",
@@ -498,7 +501,7 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
       });
 
       verifyNotebookText({
-        itemName: "Compare to previous months ...",
+        itemName: "Compare to the past",
         step1Title: "Compare one of these to the previous months",
         step2Title: "Compare “Count” to previous months",
         offsetHelp: "months ago based on “Created At”",
@@ -530,6 +533,8 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
           expression: "Count / Offset(Count, -1) - 1",
         },
       ]);
+
+      visualize();
       verifyColumns([
         "Count (previous month)",
         "Count (vs previous month)",
@@ -544,7 +549,7 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
       );
 
       verifySummarizeText({
-        itemName: "Compare to previous period ...",
+        itemName: "Compare to the past",
         step1Title: "Compare one of these to the previous period",
         step2Title: "Compare “Count” to previous period",
         offsetHelp: "periods ago based on “Created At”",
@@ -567,7 +572,7 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
       });
 
       verifyNotebookText({
-        itemName: "Compare to previous period ...",
+        itemName: "Compare to the past",
         step1Title: "Compare one of these to the previous period",
         step2Title: "Compare “Count” to previous period",
         offsetHelp: "periods ago based on “Created At”",
@@ -599,6 +604,8 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
           expression: "Count / Offset(Count, -1) - 1",
         },
       ]);
+
+      visualize();
       verifyColumns([
         "Count (previous period)",
         "Count (vs previous period)",
@@ -612,12 +619,9 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
         { visitQuestion: true, wrapId: true, idAlias: "questionId" },
       );
 
-      verifySummarizeText({
-        itemName: "Compare to previous rows ...",
-        step2Title: "Compare “Count” to previous rows",
-        step1Title: "Compare one of these to the previous rows",
-        offsetHelp: "rows above based on “Category”",
-      });
+      cy.button("Summarize").click();
+      rightSidebar().button("Add aggregation").click();
+      verifyNoColumnCompareShortcut();
 
       tableHeaderClick("Category");
       verifyNoColumnCompareShortcut();
@@ -628,15 +632,14 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
         offsetHelp: "rows above based on “Category”",
       });
 
+      openNotebook();
+      cy.button("Summarize").click();
+      verifyNoColumnCompareShortcut();
+      cy.realPress("Escape");
+
+      openVisualization();
       verifyPlusButtonText({
         itemName: "Compare to previous rows",
-        step2Title: "Compare “Count” to previous rows",
-        step1Title: "Compare one of these to the previous rows",
-        offsetHelp: "rows above based on “Category”",
-      });
-
-      verifyNotebookText({
-        itemName: "Compare to previous rows ...",
         step2Title: "Compare “Count” to previous rows",
         step1Title: "Compare one of these to the previous rows",
         offsetHelp: "rows above based on “Category”",
@@ -647,13 +650,20 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
 
       cy.get("@questionId").then(questionId => {
         expectGoodSnowplowEvent({
-          event: "column_compare_via_shortcut",
+          event: "column_compare_via_plus_modal",
           custom_expressions_used: CUSTOM_EXPRESSIONS_USED,
           database_id: SAMPLE_DB_ID,
           question_id: questionId,
         });
       });
 
+      verifyColumns([
+        "Count (previous value)",
+        "Count (vs previous value)",
+        "Count (% vs previous value)",
+      ]);
+
+      openEditor();
       verifyAggregations([
         {
           name: "Count (previous value)",
@@ -667,11 +677,6 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
           name: "Count (% vs previous value)",
           expression: "Count / Offset(Count, -1) - 1",
         },
-      ]);
-      verifyColumns([
-        "Count (previous value)",
-        "Count (vs previous value)",
-        "Count (% vs previous value)",
       ]);
     });
   });
@@ -785,8 +790,6 @@ function verifyAggregations(results: AggregationResult[]) {
 }
 
 function verifyColumns(names: string[]) {
-  visualize();
-
   for (const name of names) {
     cy.findAllByTestId("header-cell").contains(name).should("be.visible");
   }
@@ -804,4 +807,12 @@ function verifyBreakoutRequiredError() {
       "Window function requires either breakouts or order by in the query",
     )
     .should("be.visible");
+}
+
+function openEditor() {
+  cy.button("Show Editor").click();
+}
+
+function openVisualization() {
+  cy.button("Show Visualization").click();
 }

--- a/e2e/test/scenarios/question/column-compare.cy.spec.ts
+++ b/e2e/test/scenarios/question/column-compare.cy.spec.ts
@@ -215,25 +215,25 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
 
       verifySummarizeText({
         itemName: "Compare to the past",
-        step2Title: "Compare “Count” to previous period",
+        step2Title: "Compare “Count” to the past",
         offsetHelp: "periods ago based on grouping",
       });
 
       verifyColumnDrillText({
-        itemName: "Compare “Count” to previous period",
-        step2Title: "Compare “Count” to previous period",
+        itemName: "Compare to the past",
+        step2Title: "Compare “Count” to the past",
         offsetHelp: "periods ago based on grouping",
       });
 
       verifyPlusButtonText({
-        itemName: "Compare “Count” to previous period",
-        step2Title: "Compare “Count” to previous period",
+        itemName: "Compare to the past",
+        step2Title: "Compare “Count” to the past",
         offsetHelp: "periods ago based on grouping",
       });
 
       verifyNotebookText({
         itemName: "Compare to the past",
-        step2Title: "Compare “Count” to previous period",
+        step2Title: "Compare “Count” to the past",
         offsetHelp: "periods ago based on grouping",
       });
 
@@ -274,7 +274,7 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
 
       verifySummarizeText({
         itemName: "Compare to the past",
-        step2Title: "Compare “Count” to previous months",
+        step2Title: "Compare “Count” to the past",
         offsetHelp: "months ago based on “Created At”",
       });
 
@@ -282,20 +282,20 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
       verifyNoColumnCompareShortcut();
 
       verifyColumnDrillText({
-        itemName: "Compare “Count” to previous months",
-        step2Title: "Compare “Count” to previous months",
+        itemName: "Compare to the past",
+        step2Title: "Compare “Count” to the past",
         offsetHelp: "months ago based on “Created At”",
       });
 
       verifyPlusButtonText({
-        itemName: "Compare “Count” to previous months",
-        step2Title: "Compare “Count” to previous months",
+        itemName: "Compare to the past",
+        step2Title: "Compare “Count” to the past",
         offsetHelp: "months ago based on “Created At”",
       });
 
       verifyNotebookText({
         itemName: "Compare to the past",
-        step2Title: "Compare “Count” to previous months",
+        step2Title: "Compare “Count” to the past",
         offsetHelp: "months ago based on “Created At”",
       });
 
@@ -341,7 +341,7 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
 
       verifySummarizeText({
         itemName: "Compare to the past",
-        step2Title: "Compare “Count” to previous period",
+        step2Title: "Compare “Count” to the past",
         offsetHelp: "periods ago based on “Created At”",
       });
 
@@ -349,20 +349,20 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
       verifyNoColumnCompareShortcut();
 
       verifyColumnDrillText({
-        itemName: "Compare “Count” to previous period",
-        step2Title: "Compare “Count” to previous period",
+        itemName: "Compare to the past",
+        step2Title: "Compare “Count” to the past",
         offsetHelp: "periods ago based on “Created At”",
       });
 
       verifyPlusButtonText({
-        itemName: "Compare “Count” to previous period",
-        step2Title: "Compare “Count” to previous period",
+        itemName: "Compare to the past",
+        step2Title: "Compare “Count” to the past",
         offsetHelp: "periods ago based on “Created At”",
       });
 
       verifyNotebookText({
         itemName: "Compare to the past",
-        step2Title: "Compare “Count” to previous period",
+        step2Title: "Compare “Count” to the past",
         offsetHelp: "periods ago based on “Created At”",
       });
 
@@ -408,7 +408,7 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
 
       verifySummarizeText({
         itemName: "Compare to the past",
-        step2Title: "Compare “Count” to previous rows",
+        step2Title: "Compare “Count” to the past",
         offsetHelp: "rows above based on “Category”",
       });
 
@@ -416,14 +416,14 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
       verifyNoColumnCompareShortcut();
 
       verifyColumnDrillText({
-        itemName: "Compare “Count” to previous rows",
-        step2Title: "Compare “Count” to previous rows",
+        itemName: "Compare to the past",
+        step2Title: "Compare “Count” to the past",
         offsetHelp: "rows above based on “Category”",
       });
 
       verifyPlusButtonText({
-        itemName: "Compare “Count” to previous rows",
-        step2Title: "Compare “Count” to previous rows",
+        itemName: "Compare to the past",
+        step2Title: "Compare “Count” to the past",
         offsetHelp: "rows above based on “Category”",
       });
 
@@ -437,7 +437,7 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
 
       verifyNotebookText({
         itemName: "Compare to the past",
-        step2Title: "Compare “Count” to previous rows",
+        step2Title: "Compare “Count” to the past",
         offsetHelp: "rows above based on “Category”",
       });
 
@@ -484,28 +484,28 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
 
       verifySummarizeText({
         itemName: "Compare to the past",
-        step1Title: "Compare one of these to the previous period",
-        step2Title: "Compare “Count” to previous period",
+        step1Title: "Compare one of these to the past",
+        step2Title: "Compare “Count” to the past",
         offsetHelp: "periods ago based on grouping",
       });
 
       verifyColumnDrillText({
-        itemName: "Compare “Count” to previous period",
-        step2Title: "Compare “Count” to previous period",
+        itemName: "Compare to the past",
+        step2Title: "Compare “Count” to the past",
         offsetHelp: "periods ago based on grouping",
       });
 
       verifyPlusButtonText({
-        itemName: "Compare to previous period",
-        step1Title: "Compare one of these to the previous period",
-        step2Title: "Compare “Count” to previous period",
+        itemName: "Compare to the past",
+        step1Title: "Compare one of these to the past",
+        step2Title: "Compare “Count” to the past",
         offsetHelp: "periods ago based on grouping",
       });
 
       verifyNotebookText({
         itemName: "Compare to the past",
-        step1Title: "Compare one of these to the previous period",
-        step2Title: "Compare “Count” to previous period",
+        step1Title: "Compare one of these to the past",
+        step2Title: "Compare “Count” to the past",
         offsetHelp: "periods ago based on grouping",
       });
 
@@ -546,8 +546,8 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
 
       verifySummarizeText({
         itemName: "Compare to the past",
-        step1Title: "Compare one of these to the previous months",
-        step2Title: "Compare “Count” to previous months",
+        step1Title: "Compare one of these to the past",
+        step2Title: "Compare “Count” to the past",
         offsetHelp: "months ago based on “Created At”",
       });
 
@@ -555,22 +555,22 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
       verifyNoColumnCompareShortcut();
 
       verifyColumnDrillText({
-        itemName: "Compare “Count” to previous months",
-        step2Title: "Compare “Count” to previous months",
+        itemName: "Compare to the past",
+        step2Title: "Compare “Count” to the past",
         offsetHelp: "months ago based on “Created At”",
       });
 
       verifyPlusButtonText({
-        itemName: "Compare to previous months",
-        step1Title: "Compare one of these to the previous months",
-        step2Title: "Compare “Count” to previous months",
+        itemName: "Compare to the past",
+        step1Title: "Compare one of these to the past",
+        step2Title: "Compare “Count” to the past",
         offsetHelp: "months ago based on “Created At”",
       });
 
       verifyNotebookText({
         itemName: "Compare to the past",
-        step1Title: "Compare one of these to the previous months",
-        step2Title: "Compare “Count” to previous months",
+        step1Title: "Compare one of these to the past",
+        step2Title: "Compare “Count” to the past",
         offsetHelp: "months ago based on “Created At”",
       });
 
@@ -616,8 +616,8 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
 
       verifySummarizeText({
         itemName: "Compare to the past",
-        step1Title: "Compare one of these to the previous period",
-        step2Title: "Compare “Count” to previous period",
+        step1Title: "Compare one of these to the past",
+        step2Title: "Compare “Count” to the past",
         offsetHelp: "periods ago based on “Created At”",
       });
 
@@ -625,22 +625,22 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
       verifyNoColumnCompareShortcut();
 
       verifyColumnDrillText({
-        itemName: "Compare “Count” to previous period",
-        step2Title: "Compare “Count” to previous period",
+        itemName: "Compare to the past",
+        step2Title: "Compare “Count” to the past",
         offsetHelp: "periods ago based on “Created At”",
       });
 
       verifyPlusButtonText({
-        itemName: "Compare to previous period",
-        step1Title: "Compare one of these to the previous period",
-        step2Title: "Compare “Count” to previous period",
+        itemName: "Compare to the past",
+        step1Title: "Compare one of these to the past",
+        step2Title: "Compare “Count” to the past",
         offsetHelp: "periods ago based on “Created At”",
       });
 
       verifyNotebookText({
         itemName: "Compare to the past",
-        step1Title: "Compare one of these to the previous period",
-        step2Title: "Compare “Count” to previous period",
+        step1Title: "Compare one of these to the past",
+        step2Title: "Compare “Count” to the past",
         offsetHelp: "periods ago based on “Created At”",
       });
 
@@ -686,8 +686,8 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
 
       verifySummarizeText({
         itemName: "Compare to the past",
-        step2Title: "Compare “Count” to previous rows",
-        step1Title: "Compare one of these to the previous rows",
+        step2Title: "Compare “Count” to the past",
+        step1Title: "Compare one of these to the past",
         offsetHelp: "rows above based on “Category”",
       });
 
@@ -695,22 +695,22 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
       verifyNoColumnCompareShortcut();
 
       verifyColumnDrillText({
-        itemName: "Compare “Count” to previous rows",
-        step2Title: "Compare “Count” to previous rows",
+        itemName: "Compare to the past",
+        step2Title: "Compare “Count” to the past",
         offsetHelp: "rows above based on “Category”",
       });
 
       verifyPlusButtonText({
-        itemName: "Compare to previous rows",
-        step2Title: "Compare “Count” to previous rows",
-        step1Title: "Compare one of these to the previous rows",
+        itemName: "Compare to the past",
+        step2Title: "Compare “Count” to the past",
+        step1Title: "Compare one of these to the past",
         offsetHelp: "rows above based on “Category”",
       });
 
       verifyNotebookText({
         itemName: "Compare to the past",
-        step2Title: "Compare “Count” to previous rows",
-        step1Title: "Compare one of these to the previous rows",
+        step2Title: "Compare “Count” to the past",
+        step1Title: "Compare one of these to the past",
         offsetHelp: "rows above based on “Category”",
       });
 

--- a/e2e/test/scenarios/question/column-compare.cy.spec.ts
+++ b/e2e/test/scenarios/question/column-compare.cy.spec.ts
@@ -146,6 +146,66 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
     });
   });
 
+  describe("no temporal columns", () => {
+    beforeEach(() => {
+      cy.request("PUT", `/api/field/${PRODUCTS.CREATED_AT}`, {
+        base_type: "type/Text",
+      });
+    });
+
+    it("no breakout", () => {
+      createQuestion(
+        { query: QUERY_NO_AGGREGATION },
+        { visitQuestion: true, wrapId: true, idAlias: "questionId" },
+      );
+
+      cy.log("chill mode - summarize sidebar");
+      cy.button("Summarize").click();
+      rightSidebar().button("Count").icon("close").click();
+      rightSidebar().button("Add aggregation").click();
+      verifyNoColumnCompareShortcut();
+
+      cy.log("chill mode - column drill");
+      tableHeaderClick("Title");
+      verifyNoColumnCompareShortcut();
+
+      cy.log("chill mode - plus button");
+      cy.button("Add column").click();
+      verifyNoColumnCompareShortcut();
+
+      cy.log("notebook editor");
+      openNotebook();
+      cy.button("Summarize").click();
+      verifyNoColumnCompareShortcut();
+    });
+
+    it("one breakout", () => {
+      createQuestion(
+        { query: QUERY_SINGLE_AGGREGATION_NON_DATETIME_BREAKOUT },
+        { visitQuestion: true, wrapId: true, idAlias: "questionId" },
+      );
+
+      cy.log("chill mode - summarize sidebar");
+      cy.button("Summarize").click();
+      rightSidebar().button("Count").icon("close").click();
+      rightSidebar().button("Add aggregation").click();
+      verifyNoColumnCompareShortcut();
+
+      cy.log("chill mode - column drill");
+      tableHeaderClick("Category");
+      verifyNoColumnCompareShortcut();
+
+      cy.log("chill mode - plus button");
+      cy.button("Add column").click();
+      verifyNoColumnCompareShortcut();
+
+      cy.log("notebook editor");
+      openNotebook();
+      cy.button("Summarize").click();
+      verifyNoColumnCompareShortcut();
+    });
+  });
+
   describe("single aggregation", () => {
     it("no breakout", () => {
       createQuestion(

--- a/e2e/test/scenarios/question/column-compare.cy.spec.ts
+++ b/e2e/test/scenarios/question/column-compare.cy.spec.ts
@@ -326,7 +326,6 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
         },
       ]);
 
-      visualize();
       verifyColumns([
         "Count (previous month)",
         "Count (vs previous month)",
@@ -394,7 +393,6 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
         },
       ]);
 
-      visualize();
       verifyColumns([
         "Count (previous period)",
         "Count (vs previous period)",
@@ -408,11 +406,14 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
         { visitQuestion: true, wrapId: true, idAlias: "questionId" },
       );
 
-      cy.button("Summarize").click();
-      rightSidebar().button("Add aggregation").click();
-      verifyNoColumnCompareShortcut();
+      verifySummarizeText({
+        itemName: "Compare to the past",
+        step2Title: "Compare “Count” to previous rows",
+        offsetHelp: "rows above based on “Category”",
+      });
 
       tableHeaderClick("Category");
+      verifyNoColumnCompareShortcut();
 
       verifyColumnDrillText({
         itemName: "Compare “Count” to previous rows",
@@ -420,14 +421,22 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
         offsetHelp: "rows above based on “Category”",
       });
 
+      verifyPlusButtonText({
+        itemName: "Compare “Count” to previous rows",
+        step2Title: "Compare “Count” to previous rows",
+        offsetHelp: "rows above based on “Category”",
+      });
+
       openNotebook();
+
       cy.button("Summarize").click();
       verifyNoColumnCompareShortcut();
       cy.realPress("Escape");
 
       openVisualization();
-      verifyPlusButtonText({
-        itemName: "Compare “Count” to previous rows",
+
+      verifyNotebookText({
+        itemName: "Compare to the past",
         step2Title: "Compare “Count” to previous rows",
         offsetHelp: "rows above based on “Category”",
       });
@@ -437,20 +446,13 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
 
       cy.get("@questionId").then(questionId => {
         expectGoodSnowplowEvent({
-          event: "column_compare_via_plus_modal",
+          event: "column_compare_via_shortcut",
           custom_expressions_used: CUSTOM_EXPRESSIONS_USED,
           database_id: SAMPLE_DB_ID,
           question_id: questionId,
         });
       });
 
-      verifyColumns([
-        "Count (previous value)",
-        "Count (vs previous value)",
-        "Count (% vs previous value)",
-      ]);
-
-      openEditor();
       verifyAggregations([
         {
           name: "Count (previous value)",
@@ -464,6 +466,11 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
           name: "Count (% vs previous value)",
           expression: "Count / Offset(Count, -1) - 1",
         },
+      ]);
+      verifyColumns([
+        "Count (previous value)",
+        "Count (vs previous value)",
+        "Count (% vs previous value)",
       ]);
     });
   });
@@ -594,7 +601,6 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
         },
       ]);
 
-      visualize();
       verifyColumns([
         "Count (previous month)",
         "Count (vs previous month)",
@@ -665,7 +671,6 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
         },
       ]);
 
-      visualize();
       verifyColumns([
         "Count (previous period)",
         "Count (vs previous period)",
@@ -679,9 +684,12 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
         { visitQuestion: true, wrapId: true, idAlias: "questionId" },
       );
 
-      cy.button("Summarize").click();
-      rightSidebar().button("Add aggregation").click();
-      verifyNoColumnCompareShortcut();
+      verifySummarizeText({
+        itemName: "Compare to the past",
+        step2Title: "Compare “Count” to previous rows",
+        step1Title: "Compare one of these to the previous rows",
+        offsetHelp: "rows above based on “Category”",
+      });
 
       tableHeaderClick("Category");
       verifyNoColumnCompareShortcut();
@@ -692,14 +700,15 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
         offsetHelp: "rows above based on “Category”",
       });
 
-      openNotebook();
-      cy.button("Summarize").click();
-      verifyNoColumnCompareShortcut();
-      cy.realPress("Escape");
-
-      openVisualization();
       verifyPlusButtonText({
         itemName: "Compare to previous rows",
+        step2Title: "Compare “Count” to previous rows",
+        step1Title: "Compare one of these to the previous rows",
+        offsetHelp: "rows above based on “Category”",
+      });
+
+      verifyNotebookText({
+        itemName: "Compare to the past",
         step2Title: "Compare “Count” to previous rows",
         step1Title: "Compare one of these to the previous rows",
         offsetHelp: "rows above based on “Category”",
@@ -710,20 +719,13 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
 
       cy.get("@questionId").then(questionId => {
         expectGoodSnowplowEvent({
-          event: "column_compare_via_plus_modal",
+          event: "column_compare_via_shortcut",
           custom_expressions_used: CUSTOM_EXPRESSIONS_USED,
           database_id: SAMPLE_DB_ID,
           question_id: questionId,
         });
       });
 
-      verifyColumns([
-        "Count (previous value)",
-        "Count (vs previous value)",
-        "Count (% vs previous value)",
-      ]);
-
-      openEditor();
       verifyAggregations([
         {
           name: "Count (previous value)",
@@ -737,6 +739,12 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
           name: "Count (% vs previous value)",
           expression: "Count / Offset(Count, -1) - 1",
         },
+      ]);
+
+      verifyColumns([
+        "Count (previous value)",
+        "Count (vs previous value)",
+        "Count (% vs previous value)",
       ]);
     });
   });
@@ -850,6 +858,8 @@ function verifyAggregations(results: AggregationResult[]) {
 }
 
 function verifyColumns(names: string[]) {
+  visualize();
+
   for (const name of names) {
     cy.findAllByTestId("header-cell").contains(name).should("be.visible");
   }
@@ -867,10 +877,6 @@ function verifyBreakoutRequiredError() {
       "Window function requires either breakouts or order by in the query",
     )
     .should("be.visible");
-}
-
-function openEditor() {
-  cy.button("Show Editor").click();
 }
 
 function openVisualization() {

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -346,7 +346,7 @@ function ColumnPickerHeader({
 }
 
 function renderItemName(item: ListItem) {
-  return "displayName" in item ? item.displayName : undefined;
+  return item.displayName;
 }
 
 function omitItemDescription() {

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -51,6 +51,7 @@ type CompareListItem = {
   type: "action";
   name: string;
   selected?: boolean;
+  icon: string;
   items: [];
 };
 

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -134,7 +134,7 @@ export function AggregationPicker({
       });
     }
 
-    if (canAddTemporalCompareAggregation(query, stageIndex, aggregations)) {
+    if (canAddTemporalCompareAggregation(query, stageIndex)) {
       sections.push({
         type: "action",
         key: "compare",
@@ -155,15 +155,7 @@ export function AggregationPicker({
     }
 
     return sections;
-  }, [
-    metadata,
-    query,
-    stageIndex,
-    clauseIndex,
-    operators,
-    hasExpressionInput,
-    aggregations,
-  ]);
+  }, [metadata, query, stageIndex, clauseIndex, operators, hasExpressionInput]);
 
   const checkIsItemSelected = useCallback(
     (item: ListItem) => item.selected,

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -4,7 +4,10 @@ import { t } from "ttag";
 import AccordionList from "metabase/core/components/AccordionList";
 import { useToggle } from "metabase/hooks/use-toggle";
 import { useSelector } from "metabase/lib/redux";
-import { CompareAggregations } from "metabase/query_builder/components/CompareAggregations";
+import {
+  canAddTemporalCompareAggregation,
+  CompareAggregations,
+} from "metabase/query_builder/components/CompareAggregations";
 import { ExpressionWidget } from "metabase/query_builder/components/expressions/ExpressionWidget";
 import { ExpressionWidgetHeader } from "metabase/query_builder/components/expressions/ExpressionWidgetHeader";
 import { getQuestion } from "metabase/query_builder/selectors";
@@ -419,30 +422,6 @@ function getMetricListItem(
     selected:
       clauseIndex != null && metricInfo.aggregationPosition === clauseIndex,
   };
-}
-
-function canAddTemporalCompareAggregation(
-  query: Lib.Query,
-  stageIndex: number,
-  aggregations: Lib.AggregationClause[],
-): boolean {
-  if (aggregations.length === 0) {
-    // Hide the "Compare to the past" option if there are no aggregations
-    return false;
-  }
-
-  const breakoutableColumns = Lib.breakoutableColumns(query, stageIndex);
-  const hasAtLeastOneTemporalBreakoutColumn = breakoutableColumns.some(column =>
-    Lib.isTemporal(column),
-  );
-
-  if (!hasAtLeastOneTemporalBreakoutColumn) {
-    // Hide the "Compare to the past" option if there are no
-    // temporal columns to break out on
-    return false;
-  }
-
-  return true;
 }
 
 function checkIsColumnSelected(columnInfo: Lib.ColumnDisplayInfo) {

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
@@ -384,26 +384,18 @@ describe("AggregationPicker", () => {
 
     it("displays the shortcut with correct label if there is 1 aggregation", () => {
       setup({ query: createQueryWithCountAggregation() });
-
-      expect(
-        screen.getByText("Compare “Count” to previous period ..."),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Compare to the past")).toBeInTheDocument();
     });
 
     it("displays the shortcut with correct label if there are multiple aggregation", () => {
       setup({ query: createQueryWithCountAndSumAggregations() });
-
-      expect(
-        screen.getByText("Compare to previous period ..."),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Compare to the past")).toBeInTheDocument();
     });
 
     it("calls 'onAdd' on submit", async () => {
       const { onAdd } = setup({ query: createQueryWithCountAggregation() });
 
-      await userEvent.click(
-        screen.getByText("Compare “Count” to previous period ..."),
-      );
+      await userEvent.click(screen.getByText("Compare to the past"));
       await userEvent.click(screen.getByText("Done"));
 
       expect(onAdd).toHaveBeenCalled();
@@ -412,9 +404,7 @@ describe("AggregationPicker", () => {
     it("does not call 'onSelect' on submit", async () => {
       const { onSelect } = setup({ query: createQueryWithCountAggregation() });
 
-      await userEvent.click(
-        screen.getByText("Compare “Count” to previous period ..."),
-      );
+      await userEvent.click(screen.getByText("Compare to the past"));
       await userEvent.click(screen.getByText("Done"));
 
       expect(onSelect).not.toHaveBeenCalled();

--- a/frontend/src/metabase/query_builder/components/CompareAggregations/CompareAggregations.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/CompareAggregations/CompareAggregations.unit.spec.tsx
@@ -46,10 +46,10 @@ describe("CompareAggregations", () => {
       setup({ query: queryWithCountAggregation });
 
       expect(
-        screen.getByText("Compare “Count” to previous period"),
+        screen.getByText("Compare “Count” to the past"),
       ).toBeInTheDocument();
       expect(
-        screen.queryByText("Compare one of these to the previous period"),
+        screen.queryByText("Compare one of these to the past"),
       ).not.toBeInTheDocument();
     });
 
@@ -57,15 +57,13 @@ describe("CompareAggregations", () => {
       const { onClose } = setup({ query: queryWithCountAggregation });
 
       expect(
-        screen.getByText("Compare “Count” to previous period"),
+        screen.getByText("Compare “Count” to the past"),
       ).toBeInTheDocument();
       expect(
-        screen.queryByText("Compare one of these to the previous period"),
+        screen.queryByText("Compare one of these to the past"),
       ).not.toBeInTheDocument();
 
-      await userEvent.click(
-        screen.getByText("Compare “Count” to previous period"),
-      );
+      await userEvent.click(screen.getByText("Compare “Count” to the past"));
 
       expect(onClose).toHaveBeenCalled();
     });
@@ -76,10 +74,10 @@ describe("CompareAggregations", () => {
       setup({ query: queryWithCountAndSumAggregations });
 
       expect(
-        screen.getByText("Compare one of these to the previous period"),
+        screen.getByText("Compare one of these to the past"),
       ).toBeInTheDocument();
       expect(
-        screen.queryByText("Compare “Count” to previous period"),
+        screen.queryByText("Compare “Count” to the past"),
       ).not.toBeInTheDocument();
       expect(screen.getByText("Count")).toBeInTheDocument();
       expect(screen.getByText("Sum of Price")).toBeInTheDocument();
@@ -93,27 +91,25 @@ describe("CompareAggregations", () => {
       await userEvent.click(screen.getByText("Count"));
 
       expect(
-        screen.getByText("Compare “Count” to previous period"),
+        screen.getByText("Compare “Count” to the past"),
       ).toBeInTheDocument();
 
-      await userEvent.click(
-        screen.getByText("Compare “Count” to previous period"),
-      );
+      await userEvent.click(screen.getByText("Compare “Count” to the past"));
 
       await userEvent.click(screen.getByText("Sum of Price"));
 
       expect(
-        screen.getByText("Compare “Sum of Price” to previous period"),
+        screen.getByText("Compare “Sum of Price” to the past"),
       ).toBeInTheDocument();
 
       await userEvent.click(
-        screen.getByText("Compare “Sum of Price” to previous period"),
+        screen.getByText("Compare “Sum of Price” to the past"),
       );
 
       expect(onClose).not.toHaveBeenCalled();
 
       await userEvent.click(
-        screen.getByText("Compare one of these to the previous period"),
+        screen.getByText("Compare one of these to the past"),
       );
 
       expect(onClose).toHaveBeenCalled();

--- a/frontend/src/metabase/query_builder/components/CompareAggregations/utils.ts
+++ b/frontend/src/metabase/query_builder/components/CompareAggregations/utils.ts
@@ -90,3 +90,29 @@ export const canSubmit = (
   const areColumnsValid = columns.length > 0;
   return isPeriodValid && areColumnsValid;
 };
+
+export function canAddTemporalCompareAggregation(
+  query: Lib.Query,
+  stageIndex: number,
+  aggregations?: Lib.AggregationClause[],
+): boolean {
+  const aggregationsToUse = aggregations ?? Lib.aggregations(query, stageIndex);
+
+  if (aggregationsToUse.length === 0) {
+    // Hide the "Compare to the past" option if there are no aggregations
+    return false;
+  }
+
+  const breakoutableColumns = Lib.breakoutableColumns(query, stageIndex);
+  const hasAtLeastOneTemporalBreakoutColumn = breakoutableColumns.some(column =>
+    Lib.isTemporal(column),
+  );
+
+  if (!hasAtLeastOneTemporalBreakoutColumn) {
+    // Hide the "Compare to the past" option if there are no
+    // temporal columns to break out on
+    return false;
+  }
+
+  return true;
+}

--- a/frontend/src/metabase/query_builder/components/CompareAggregations/utils.ts
+++ b/frontend/src/metabase/query_builder/components/CompareAggregations/utils.ts
@@ -94,11 +94,9 @@ export const canSubmit = (
 export function canAddTemporalCompareAggregation(
   query: Lib.Query,
   stageIndex: number,
-  aggregations?: Lib.AggregationClause[],
 ): boolean {
-  const aggregationsToUse = aggregations ?? Lib.aggregations(query, stageIndex);
-
-  if (aggregationsToUse.length === 0) {
+  const aggregations = Lib.aggregations(query, stageIndex);
+  if (aggregations.length === 0) {
     // Hide the "Compare to the past" option if there are no aggregations
     return false;
   }

--- a/frontend/src/metabase/query_builder/components/CompareAggregations/utils.ts
+++ b/frontend/src/metabase/query_builder/components/CompareAggregations/utils.ts
@@ -44,15 +44,12 @@ export const getTitle = (
   stageIndex: number,
   aggregation?: Lib.AggregationClause | Lib.ExpressionClause,
 ): string => {
-  const period = getOffsetPeriod(query, stageIndex);
-
   if (!aggregation) {
-    return t`Compare one of these to the previous ${period}`;
+    return t`Compare one of these to the past`;
   }
 
   const info = Lib.displayInfo(query, stageIndex, aggregation);
-
-  return t`Compare “${info.displayName}” to previous ${period}`;
+  return t`Compare “${info.displayName}” to the past`;
 };
 
 export const getAggregations = (

--- a/frontend/src/metabase/querying/utils/drills/compare-aggregations-drill/compare-aggregations-drill.tsx
+++ b/frontend/src/metabase/querying/utils/drills/compare-aggregations-drill/compare-aggregations-drill.tsx
@@ -2,7 +2,10 @@ import { t } from "ttag";
 
 import { useDispatch } from "metabase/lib/redux";
 import { setUIControls } from "metabase/query_builder/actions";
-import { CompareAggregations } from "metabase/query_builder/components/CompareAggregations";
+import {
+  canAddTemporalCompareAggregation,
+  CompareAggregations,
+} from "metabase/query_builder/components/CompareAggregations";
 import { trackColumnCompareViaColumnHeader } from "metabase/querying/analytics";
 import type {
   ClickActionPopoverProps,
@@ -13,11 +16,7 @@ import * as Lib from "metabase-lib";
 export const compareAggregationsDrill: Drill<
   Lib.CompareAggregationsDrillThruInfo
 > = ({ drill, question, query, stageIndex, clicked }) => {
-  const aggregations = Lib.aggregations(query, stageIndex);
-  if (
-    !clicked.column ||
-    !canAddTemporalCompareAggregation(query, stageIndex, aggregations)
-  ) {
+  if (!clicked.column || !canAddTemporalCompareAggregation(query, stageIndex)) {
     return [];
   }
 
@@ -71,27 +70,3 @@ export const compareAggregationsDrill: Drill<
     },
   ];
 };
-
-function canAddTemporalCompareAggregation(
-  query: Lib.Query,
-  stageIndex: number,
-  aggregations: Lib.AggregationClause[],
-): boolean {
-  if (aggregations.length === 0) {
-    // Hide the "Compare to the past" option if there are no aggregations
-    return false;
-  }
-
-  const breakoutableColumns = Lib.breakoutableColumns(query, stageIndex);
-  const hasAtLeastOneTemporalBreakoutColumn = breakoutableColumns.some(column =>
-    Lib.isTemporal(column),
-  );
-
-  if (!hasAtLeastOneTemporalBreakoutColumn) {
-    // Hide the "Compare to the past" option if there are no
-    // temporal columns to break out on
-    return false;
-  }
-
-  return true;
-}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/46499 as part of https://github.com/metabase/metabase/issues/46493

### Description

- Make the "Compare to the past" dropdown item an action and move it to the bottom
- Simplify the label to just be "Compare to the past"
- Only show the "Compare to the past" button when, there either is a) a temporal breakout already in use, or b) there are temporal columns that _can be added_ as breakouts later (we will auto-select one in a follow up PR).

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> Orders
2. Create an aggregation: Sum of Subtotal
3. Click the "+" button in the aggregation section the dropdown should look like the screenshots below

Verify that
- when there are no temporal columns is not on a temporal column, the "Compare to the past" button does not show
- when there are no temporal columns, the "Compare to the past" button does not show

Notes: 

### Demo
<img width="245" alt="Screenshot 2024-08-05 at 17 48 53" src="https://github.com/user-attachments/assets/cf225306-d50f-4657-a343-58c4d91a0a9d">


