### PR TITLE
Generate better release logs for success

### DIFF
--- a/.github/workflows/release-log.yml
+++ b/.github/workflows/release-log.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      VERSION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || 50 }} # Update this for the next major release
+      VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || 50 }} # Update this for the next major release
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -37,3 +37,8 @@ jobs:
           aws s3 cp \
           release/v$VERSION.html \
           s3://${{ vars.AWS_S3_STATIC_BUCKET }}/release-log/v$VERSION.html
+      - name: Create cloudfront invalidation
+        run: |
+          aws cloudfront create-invalidation \
+          --distribution-id ${{ vars.AWS_CLOUDFRONT_STATIC_ID }} \
+          --paths /release-log/v$VERSION.html

--- a/.github/workflows/release-log.yml
+++ b/.github/workflows/release-log.yml
@@ -9,8 +9,7 @@ on:
         type: number
         required: true
   schedule:
-    - cron: '15 * * * *' # hourly
-  pull_request: # FIXME FOR TESTING ONLY
+    - cron: '45 * * * *' # hourly
 
 jobs:
   update-release-log:

--- a/.github/workflows/release-log.yml
+++ b/.github/workflows/release-log.yml
@@ -1,0 +1,42 @@
+name: Update Release Log
+run-name: Update Release Log ${{ inputs.version }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Major Metabase version (e.g. 45, 52, 68)'
+        type: number
+        required: true
+  schedule:
+    - cron: '15 * * * *' # hourly
+  pull_request: # FIXME FOR TESTING ONLY
+
+env:
+  DEFAULT_VERSION: 50
+
+jobs:
+  update-release-log:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      VERSION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || github.env.DEFAULT_VERSION }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_S3_RELEASE_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_S3_RELEASE_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # we want all branches and tags
+      - name: Install Dependencies
+        run: yarn --cwd release --frozen-lockfile && npm i -g tsx
+      - name: generate release Log
+        run: cd release && tsx ./src/release-log.ts $VERSION > v$VERSION.html
+      - name: upload release log to the web
+        run: |
+          aws s3 cp \
+          release/v$VERSION.html \
+          s3://${{ vars.AWS_S3_STATIC_BUCKET }}/release-log/v$VERSION.html

--- a/.github/workflows/release-log.yml
+++ b/.github/workflows/release-log.yml
@@ -12,15 +12,12 @@ on:
     - cron: '15 * * * *' # hourly
   pull_request: # FIXME FOR TESTING ONLY
 
-env:
-  DEFAULT_VERSION: 50
-
 jobs:
   update-release-log:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      VERSION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || env.DEFAULT_VERSION }}
+      VERSION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || 50 }} # Update this for the next major release
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/release-log.yml
+++ b/.github/workflows/release-log.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      VERSION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || github.env.DEFAULT_VERSION }}
+      VERSION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || env.DEFAULT_VERSION }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/release/.gitignore
+++ b/release/.gitignore
@@ -5,3 +5,4 @@ cache.json
 dist/
 version.properties
 version-info.json
+v*.html

--- a/release/src/linked-issues.ts
+++ b/release/src/linked-issues.ts
@@ -13,9 +13,11 @@ export function getLinkedIssues(body: string) {
   return null;
 }
 
+export const issueNumberRegex = /\(#(\d+)\)/g
+
 export function getPRsFromCommitMessage(message: string) {
   const firstLine = message.split('\n\n')[0];
-  const result = [ ...firstLine.matchAll(/\(#(\d+)\)/g) ];
+  const result = [ ...firstLine.matchAll(issueNumberRegex) ];
   if (!result.length) {
     console.log('No pr found in commit message', message);
     return null;

--- a/release/src/release-log.ts
+++ b/release/src/release-log.ts
@@ -1,0 +1,77 @@
+import fs from 'fs';
+
+import { $ } from 'zx';
+
+import { issueNumberRegex } from './linked-issues';
+
+const NUM_COMMITS = 200;
+
+type CommitInfo = {
+  version: string,
+  message: string,
+  hash: string,
+  date: string,
+}
+
+const tablePageTemplate = fs.readFileSync('./src/tablePageTemplate.html', 'utf8');
+
+export async function gitLog(majorVersion: number) {
+  const { stdout } = await $`git log release-x.${majorVersion}.x --pretty='format:%(decorate:prefix=,suffix=)||%s||%H||%ah' -n ${NUM_COMMITS}`;
+  const processedCommits = stdout.split('\n').map(processCommit);
+
+  return buildTable(processedCommits, majorVersion);
+}
+
+function processCommit(commitLine: string): CommitInfo {
+  const [refs, message, hash, date] = commitLine.split('||');
+  const version = refs?.match(/(v[\d\.-RCrc]+)/)?.[1] ?? '';
+
+  return { version, message, hash, date};
+}
+
+const issueLink = (issueNumber: string) => `https://github.com/metabase/metabase/issues/${issueNumber}`;
+
+function linkifyIssueNumbers(message: string) {
+  return message.replace(issueNumberRegex, (_, issueNumber) => {
+    return `<a href="${issueLink(issueNumber)}" target="_blank">(#${issueNumber})</a>`;
+  });
+}
+
+function tableRow(commit: CommitInfo) {
+  return `<tr>
+    <td><strong>${commit.version}</strong></td>
+    <td>${linkifyIssueNumbers(commit.message)}</td>
+    <td>${commit.date}</td>
+  </tr>`;
+}
+
+function buildTable(commits: CommitInfo[], majorVersion: number) {
+  const rows = commits.map(tableRow).join('\n');
+  const currentTime = new Date().toLocaleString();
+  const tableHtml = `
+    <table>
+      <thead>
+        <tr>
+          <th>Version</th>
+          <th>Commit Message</th>
+          <th>Date</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${rows}
+      </tbody>
+    </table>`;
+  return tablePageTemplate
+    .replace(/{{release-table}}/, tableHtml)
+    .replace(/{{major-version}}/g, majorVersion.toString())
+    .replace(/{{current-time}}/, currentTime);
+}
+
+const version = Number(process.argv[2]);
+
+if (!version) {
+  console.error('Please provide a version number (e.g. 35, 57)');
+  process.exit(1);
+}
+
+console.log(await gitLog(version));

--- a/release/src/release-log.ts
+++ b/release/src/release-log.ts
@@ -16,7 +16,7 @@ type CommitInfo = {
 const tablePageTemplate = fs.readFileSync('./src/tablePageTemplate.html', 'utf8');
 
 export async function gitLog(majorVersion: number) {
-  const { stdout } = await $`git log release-x.${majorVersion}.x --pretty='format:%(decorate:prefix=,suffix=)||%s||%H||%ah' -n ${NUM_COMMITS}`;
+  const { stdout } = await $`git log origin/release-x.${majorVersion}.x --pretty='format:%(decorate:prefix=,suffix=)||%s||%H||%ah' -n ${NUM_COMMITS}`;
   const processedCommits = stdout.split('\n').map(processCommit);
 
   return buildTable(processedCommits, majorVersion);

--- a/release/src/tablePageTemplate.html
+++ b/release/src/tablePageTemplate.html
@@ -1,0 +1,39 @@
+<html>
+  <head>
+    <title>Metabase v{{major-version}} Release Log</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+      body {
+        font-family: Lato, sans-serif;
+        background-color: #282c34;
+        color: #ddd;
+        padding: 40px;
+      }
+      table {
+        border-collapse: collapse;
+      }
+      th, td {
+        padding: 8px;
+        text-align: left;
+      }
+      tr:nth-child(even) {
+        background-color: #2e323a;
+      }
+      tbody > tr:hover{
+        color: #8fbdf6;
+      }
+      a {
+        text-decoration: underline;
+        color:#2987f9;
+      }
+    </style>
+  </head>
+  <body class="p-5 text-gray-200 bg-gray-800">
+      <h1>Metabase v{{major-version}} Release Log</h1>
+      <p>as of {{current-time}}</p>
+      <div>
+        {{release-table}}
+      </div>
+  </body>
+</html>


### PR DESCRIPTION

### Description

Our new patch release workflow is good at getting fixes out quickly and easily, but it makes it hard for our success team to know what's in each patch. This adds a simple workflow that basically just formats a git log and uploads it to the web to make it real clear where each release happened.

see:
 - https://static.metabase.com/release-log/v49.html
 - https://static.metabase.com/release-log/v50.html
