### PR TITLE
Load system-wide user.clj when REPL starts

### DIFF
--- a/dev/src/user.clj
+++ b/dev/src/user.clj
@@ -5,6 +5,14 @@
    [metabase.plugins.classloader :as classloader]
    [metabase.util :as u]))
 
+;; Load all user.clj files (including the system-wide one).
+(when *file* ; Ensure we don't load ourselves recursively, just in case.
+  (->> (.getResources (.getContextClassLoader (Thread/currentThread)) "user.clj")
+       enumeration-seq
+       rest ; First file in the enumeration will be this file, so skip it.
+       (run! #(do (println "Loading" (str %))
+                  (clojure.lang.Compiler/load (clojure.java.io/reader %))))))
+
 ;; Wrap these with ignore-exceptions to reduce the "required" deps of this namespace
 ;; We sometimes need to run cmd stuffs like `clojure -M:migrate rollback n 3` and these
 ;; libraries might not be available in the classpath


### PR DESCRIPTION
This is a minor QOL feature that loads system-wide `user.clj` file from the project-local `user.clj`. The setup is described here: https://clojure-goes-fast.com/blog/system-wide-user-clj/. Don't know if anybody else uses something similar but it shouldn't disrupt anyone who doesn't. This is also dev-time only, so production builds will not be impacted.
