### PR TITLE
Fix oom during sync field values

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/sandbox/models/params/field_values_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/models/params/field_values_test.clj
@@ -26,8 +26,8 @@
   (doseq [fv-type [:sandbox :linked-filter]]
     (testing "create a new field values and fix up the human readable values"
       (met/with-gtaps! {:gtaps {:categories {:query (mt/mbql-query categories {:filter [:and
-                                                                                       [:> $id 3]
-                                                                                       [:< $id 6]]})}}}
+                                                                                        [:> $id 3]
+                                                                                        [:< $id 6]]})}}}
         ;; the categories-id doesn't have a field values, we fake it with a full fieldvalues to make it easier to test
         (t2/insert! FieldValues {:type                  :full
                                  :field_id              (mt/id :categories :id)
@@ -68,8 +68,8 @@
 
     (testing "make sure the Fieldvalues respect [field-values/*total-max-length*]"
       (met/with-gtaps! {:gtaps {:categories {:query (mt/mbql-query categories {:filter [:and
-                                                                                       [:> $id 3]
-                                                                                       [:< $id 6]]})}}}
+                                                                                        [:> $id 3]
+                                                                                        [:< $id 6]]})}}}
         (binding [field-values/*total-max-length* 5]
           (is (= ["Asian"]
                  (:values (params.field-values/get-or-create-advanced-field-values!

--- a/src/metabase/db/metadata_queries.clj
+++ b/src/metabase/db/metadata_queries.clj
@@ -72,8 +72,6 @@
        :middleware {:disable-remaps? true}}
       rff))))
 
-;; I'm not sure whether this field-distinct-values and field-distinct-values belong to this namespace
-;; maybe it's better to keep this in metabase.models.field or metabase.models.field-values
 (defn search-values-query
  "Generate the MBQL query used to power FieldValues search in [[metabase.api.field/search-values]]. The actual query generated
   differs slightly based on whether the two Fields are the same Field.

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -367,10 +367,9 @@
             (assoc-in [:data :rows] (persistent! @rows))))
 
        ([result row]
-        (assert (and (= 1 (count row))
-                     (string? (first row))))
+        (assert (= 1 (count row)))
         (vswap! total-char + (count (first row)))
-        (if (>= @total-char max-char-len)
+        (if (> @total-char max-char-len)
           (reduced (assoc result ::reached-char-len-limit true))
           (do
            (offer-row row)

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -384,7 +384,7 @@
       {:values          distinct-values
        ;; has_more_values=true means the list of values we return is a subset of all possible values.
        :has_more_values (or (true? (::reached-char-len-limit result))
-                            ;; `distinct-values` is from a query 
+                            ;; `distinct-values` is from a query
                             ;; with limit = [[*absolute-max-distinct-values-limit*]].
                             ;; So, if the returned `distinct-values` has length equal to that exact limit,
                             ;; we assume the returned values is just a subset of what we have in DB.

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -384,7 +384,7 @@
       {:values          distinct-values
        ;; has_more_values=true means the list of values we return is a subset of all possible values.
        :has_more_values (or (true? (::reached-char-len-limit result))
-                            ;; [[field-distinct-values]] runs a query
+                            ;; `distinct-values` is from a query 
                             ;; with limit = [[*absolute-max-distinct-values-limit*]].
                             ;; So, if the returned `distinct-values` has length equal to that exact limit,
                             ;; we assume the returned values is just a subset of what we have in DB.

--- a/src/metabase/models/params/chain_filter.clj
+++ b/src/metabase/models/params/chain_filter.clj
@@ -439,6 +439,8 @@
     (log/debugf "Chain filter MBQL query:\n%s" (u/pprint-to-str 'magenta mbql-query))
     (try
       (let [query-limit (get-in mbql-query [:query :limit])
+            ;; FIXME: this can OOM for text column if each value are too large. See #46411
+            ;; Consider using the [[field-values/distinct-text-field-rff] rff]
             values      (qp/process-query mbql-query (constantly conj))]
         {:values          values
          ;; It's unlikely that we don't have a query-limit, but better safe than sorry and default it true

--- a/src/metabase/models/params/field_values.clj
+++ b/src/metabase/models/params/field_values.clj
@@ -80,7 +80,6 @@
             ;; we have a hard limit for how many values we want to store in FieldValues,
             ;; let's make sure we respect that limit here.
             ;; For a more detailed docs on this limt check out [[field-values/distinct-values]]
-            ;; FIX ME: this can OOM for text column if each value are too large. See #46411
             limited-values                   (field-values/take-by-length field-values/*total-max-length* values)]
         {:values          limited-values
          :has_more_values (or (> (count values)

--- a/src/metabase/models/params/field_values.clj
+++ b/src/metabase/models/params/field_values.clj
@@ -80,7 +80,7 @@
             ;; we have a hard limit for how many values we want to store in FieldValues,
             ;; let's make sure we respect that limit here.
             ;; For a more detailed docs on this limt check out [[field-values/distinct-values]]
-            ;; TODO: can OOM here too
+            ;; FIX ME: this can OOM for text column if each value are too large. See #46411
             limited-values                   (field-values/take-by-length field-values/*total-max-length* values)]
         {:values          limited-values
          :has_more_values (or (> (count values)

--- a/src/metabase/models/params/field_values.clj
+++ b/src/metabase/models/params/field_values.clj
@@ -80,6 +80,7 @@
             ;; we have a hard limit for how many values we want to store in FieldValues,
             ;; let's make sure we respect that limit here.
             ;; For a more detailed docs on this limt check out [[field-values/distinct-values]]
+            ;; TODO: can OOM here too
             limited-values                   (field-values/take-by-length field-values/*total-max-length* values)]
         {:values          limited-values
          :has_more_values (or (> (count values)

--- a/test/metabase/db/metadata_queries_test.clj
+++ b/test/metabase/db/metadata_queries_test.clj
@@ -7,6 +7,7 @@
    [metabase.models :as models :refer [Database Field Table]]
    [metabase.models.interface :as mi]
    [metabase.models.table :as table]
+   [metabase.query-processor :as qp]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 
@@ -78,10 +79,14 @@
       ;; currently only applied for bigquery tables in which a table can have a required partition filter
       (is (=? [:> [:field (:id field2) {:base-type :type/Integer}] (mt/malli=? int?)]
               (get-in (#'metadata-queries/table-rows-sample-query table [field1] {}) [:query :filter]))))
-    (testing "the field mbql on a table that requires a filter will include a filter"
+    (testing "the mbql on a table that requires a filter will include a filter"
       ;; currently only applied for bigquery tables in which a table can have a required partition filter
-      (is (=? [:> [:field (:id field2) {:base-type :type/Integer}] (mt/malli=? int?)]
-              (get (#'metadata-queries/field-mbql-query table {}) :filter))))))
+      (let [query (atom nil)]
+        (with-redefs [qp/process-query (fn [& args]
+                                         (reset! query (-> args first :query)))]
+          (metadata-queries/table-query (:id table) {})
+          (is (=? [:> [:field (:id field2) {:base-type :type/Integer}] (mt/malli=? int?)]
+                  (:filter @query))))))))
 
 (deftest ^:parallel text-field?-test
   (testing "recognizes fields suitable for fingerprinting"

--- a/test/metabase/db/metadata_queries_test.clj
+++ b/test/metabase/db/metadata_queries_test.clj
@@ -26,11 +26,6 @@
     (is (= 1000
            (metadata-queries/field-count (t2/select-one Field :id (mt/id :checkins :venue_id)))))))
 
-(deftest field-distinct-values-test
-  (mt/test-drivers (metadata-queries-test-drivers)
-    (is (= [1 2 3 4 5 6 7 8 9 10 11 12 13 14 15]
-           (map (comp int first) (metadata-queries/field-distinct-values (t2/select-one Field :id (mt/id :checkins :user_id))))))))
-
 (deftest table-rows-sample-test
   (mt/test-drivers (sql-jdbc.tu/normal-sql-jdbc-drivers)
     (let [expected [["20th Century Cafe"]

--- a/test/metabase/models/field_values_test.clj
+++ b/test/metabase/models/field_values_test.clj
@@ -3,10 +3,8 @@
   (:require
    [cheshire.core :as json]
    [clojure.java.jdbc :as jdbc]
-   [clojure.string :as str]
    [clojure.test :refer :all]
    [java-time.api :as t]
-   [metabase.db.metadata-queries :as metadata-queries]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.models.database :refer [Database]]
    [metabase.models.dimension :refer [Dimension]]
@@ -151,18 +149,24 @@
         (is (= expected
                (#'field-values/field-should-have-field-values? input)))))))
 
-(deftest distinct-values-test
-  (with-redefs [metadata-queries/field-distinct-values (constantly [[1] [2] [3] [4]])]
-    (is (= {:values          [[1] [2] [3] [4]]
-            :has_more_values false}
-           (#'field-values/distinct-values {}))))
+(defn distinct-field-values
+  [id]
+  (field-values/distinct-values (t2/select-one :model/Field id)))
 
-  (testing "(#2332) check that if field values are long we only store a subset of it"
-    (with-redefs [metadata-queries/field-distinct-values (constantly [["AAAA"] [(str/join (repeat (+ 100 field-values/*total-max-length*) "A"))]])]
-      (testing "The total length of stored values must less than our max-length-limit"
-        (is (= {:values          [["AAAA"]]
-                :has_more_values true}
-              (#'field-values/distinct-values {})))))))
+(deftest distinct-values-test
+  (testing "Correctly get distinct field values for text fields"
+    (is (= {:values [["Doohickey"] ["Gadget"] ["Gizmo"] ["Widget"]]
+            :has_more_values false}
+           (distinct-field-values (mt/id :products :category)))))
+  (testing "Correctly get distinct field values for non-text fields"
+    (is (= {:values [[1] [2] [3] [4] [5]]
+            :has_more_values false}
+           (distinct-field-values (mt/id :reviews :rating)))))
+  (testing "if the values of text field exceeds max-char-len, return a subset of it (#2332)"
+    (binding [field-values/*total-max-length* 16]
+      (is (= {:values          [["Doohickey"] ["Gadget"]]
+              :has_more_values true}
+             (distinct-field-values (mt/id :products :category)))))))
 
 (deftest clear-field-values-for-field!-test
   (mt/with-temp [Database    {database-id :id} {}

--- a/test/metabase/models/field_values_test.clj
+++ b/test/metabase/models/field_values_test.clj
@@ -162,11 +162,15 @@
     (is (= {:values [[1] [2] [3] [4] [5]]
             :has_more_values false}
            (distinct-field-values (mt/id :reviews :rating)))))
-  (testing "if the values of text field exceeds max-char-len, return a subset of it (#2332)"
+  (testing "if the values of field exceeds max-char-len, return a subset of it (#2332)"
     (binding [field-values/*total-max-length* 16]
       (is (= {:values          [["Doohickey"] ["Gadget"]]
               :has_more_values true}
-             (distinct-field-values (mt/id :products :category)))))))
+             (distinct-field-values (mt/id :products :category)))))
+    (binding [field-values/*total-max-length* 3]
+      (is (= {:values          [[1] [2] [3]]
+              :has_more_values true}
+             (distinct-field-values (mt/id :reviews :rating)))))))
 
 (deftest clear-field-values-for-field!-test
   (mt/with-temp [Database    {database-id :id} {}

--- a/test/metabase/sync/field_values_test.clj
+++ b/test/metabase/sync/field_values_test.clj
@@ -5,7 +5,6 @@
    [clojure.test :refer :all]
    [java-time.api :as t]
    [metabase.analyze :as analyze]
-   [metabase.db.metadata-queries :as metadata-queries]
    [metabase.models :refer [Field FieldValues Table]]
    [metabase.models.field-values :as field-values]
    [metabase.sync :as sync]
@@ -213,14 +212,14 @@
                                :type :sandbox
                                :hash_key "random-key"})
       (testing "adding more values even if it's exceed our cardinality limit, "
-        (one-off-dbs/insert-rows-and-sync! (one-off-dbs/range-str 50 (+ 100 metadata-queries/absolute-max-distinct-values-limit)))
+        (one-off-dbs/insert-rows-and-sync! (one-off-dbs/range-str 50 (+ 100 field-values/*absolute-max-distinct-values-limit*)))
         (testing "has_field_values shouldn't change and has_more_values should be true"
           (is (= :list
                  (t2/select-one-fn :has_field_values Field
                                       :id (mt/id :blueberries_consumed :str)))))
         (testing "it should still have FieldValues, but the stored list has at most [metadata-queries/absolute-max-distinct-values-limit] elements"
-          (is (= {:values                (take metadata-queries/absolute-max-distinct-values-limit
-                                               (one-off-dbs/range-str (+ 100 metadata-queries/absolute-max-distinct-values-limit)))
+          (is (= {:values                (take field-values/*absolute-max-distinct-values-limit*
+                                               (one-off-dbs/range-str (+ 100 field-values/*absolute-max-distinct-values-limit*)))
                   :human_readable_values []
                   :has_more_values       true}
                  (into {} (t2/select-one [FieldValues :values :human_readable_values :has_more_values]


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/46411 by reworking the `field-distinct-values` function so that it stops getting rows from jdbc if the total char of all rows exceeds the char limit.


### How to test:
1. Create a db with this script

```sql
CREATE TABLE example_table (id SERIAL PRIMARY KEY,
                            content TEXT);

INSERT INTO example_table (content)
SELECT
    substr(
        -- Generate a long random string
        repeat(
            md5(random()::text) ||
            md5(random()::text) ||
            md5(random()::text) ||
            md5(random()::text) ||
            md5(random()::text) ||
            md5(random()::text) ||
            md5(random()::text) ||
            md5(random()::text) ||
            md5(random()::text) ||
            md5(random()::text) ||
            md5(random()::text),
            90909  -- Number of repetitions to exceed 1,000,000 characters
        ),
        1,
        200000
    )
FROM generate_series(1, 999);
```
2. Start MB with a max heap size of 512mb
3. Sync the DB should succeed