### PR TITLE
Throw reasonable error when incompatible temporal unit is used in time unit parameter

### DIFF
--- a/src/metabase/query_processor/middleware/catch_exceptions.clj
+++ b/src/metabase/query_processor/middleware/catch_exceptions.clj
@@ -34,11 +34,15 @@
 
 (defmethod format-exception ExceptionInfo
   [e]
-  (let [{error-type :type, :as data} (ex-data e)]
+  ;; `:curated` or `:curated_error` is a flag that signals whether the error message in `e` was approved by product
+  ;; to be shown to the user. It is used by FE.
+  (let [{error-type :type, curated :curated, :as data} (ex-data e)]
     (merge
      ((get-method format-exception Throwable) e)
      (when (qp.error-type/known-error-type? error-type)
        {:error_type error-type})
+     (when curated
+       {:error_curated curated})
      ;; TODO - we should probably change this key to `:data` so we're not mixing lisp-case and snake_case keys
      {:ex-data data})))
 

--- a/src/metabase/query_processor/middleware/catch_exceptions.clj
+++ b/src/metabase/query_processor/middleware/catch_exceptions.clj
@@ -34,15 +34,15 @@
 
 (defmethod format-exception ExceptionInfo
   [e]
-  ;; `:curated` or `:curated_error` is a flag that signals whether the error message in `e` was approved by product
+  ;; `:is-curated` is a flag that signals whether the error message in `e` was approved by product
   ;; to be shown to the user. It is used by FE.
-  (let [{error-type :type, curated :curated, :as data} (ex-data e)]
+  (let [{error-type :type, is-curated :is-curated, :as data} (ex-data e)]
     (merge
      ((get-method format-exception Throwable) e)
      (when (qp.error-type/known-error-type? error-type)
        {:error_type error-type})
-     (when curated
-       {:error_curated curated})
+     (when is-curated
+       {:error_is_curated is-curated})
      ;; TODO - we should probably change this key to `:data` so we're not mixing lisp-case and snake_case keys
      {:ex-data data})))
 

--- a/src/metabase/query_processor/middleware/parameters/mbql.clj
+++ b/src/metabase/query_processor/middleware/parameters/mbql.clj
@@ -103,10 +103,10 @@
     (assert (some? base-type) "`base-type` is not set.")
     (when-not (qp.u.temporal-bucket/compatible-temporal-unit? base-type new-unit)
       (throw (ex-info (tru "This chart can not be broken out by the selected unit of time: {0}." value)
-                      {:type      qp.error-type/invalid-query
-                       :curated   true
-                       :base-type base-type
-                       :unit      new-unit})))
+                      {:type       qp.error-type/invalid-query
+                       :is-curated true
+                       :base-type  base-type
+                       :unit       new-unit})))
     (lib.util.match/replace-in
       query [:query :breakout]
       [:field (_ :guard #(= target-field-id %)) (opts :guard #(= temporal-unit (:temporal-unit %)))]

--- a/src/metabase/query_processor/middleware/parameters/mbql.clj
+++ b/src/metabase/query_processor/middleware/parameters/mbql.clj
@@ -9,7 +9,11 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.lib.util.match :as lib.util.match]
+   [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.store :as qp.store]
+   [metabase.query-processor.util :as qp.util]
+   [metabase.query-processor.util.temporal-bucket :as qp.u.temporal-bucket]
+   [metabase.util.i18n :refer [tru]]
    [metabase.util.malli :as mu]))
 
 (set! *warn-on-reflection* true)
@@ -90,9 +94,15 @@
 
 (defn- update-breakout-unit
   [query
-   {[_dimension [_field target-field-id {:keys [temporal-unit]}]] :target
+   {[_dimension [_tag target-field-id {:keys [temporal-unit]}  :as field]] :target
     :keys [value] :as _param}]
-  (let [new-unit (keyword value)]
+  (let [new-unit (keyword value)
+        base-type (qp.util/field->base-type query field)]
+    (when-not (qp.u.temporal-bucket/compatible-temporal-unit? base-type new-unit)
+      (throw (ex-info (tru "This chart can not be broken out by the selected unit of time: {0}." value)
+                      {:type        qp.error-type/invalid-query
+                       :base-type   base-type
+                       :unit        new-unit})))
     (lib.util.match/replace-in
       query [:query :breakout]
       [:field (_ :guard #(= target-field-id %)) (opts :guard #(= temporal-unit (:temporal-unit %)))]

--- a/src/metabase/query_processor/middleware/parameters/mbql.clj
+++ b/src/metabase/query_processor/middleware/parameters/mbql.clj
@@ -103,9 +103,10 @@
     (assert (some? base-type) "`base-type` is not set.")
     (when-not (qp.u.temporal-bucket/compatible-temporal-unit? base-type new-unit)
       (throw (ex-info (tru "This chart can not be broken out by the selected unit of time: {0}." value)
-                      {:type        qp.error-type/invalid-query
-                       :base-type   base-type
-                       :unit        new-unit})))
+                      {:type      qp.error-type/invalid-query
+                       :curated   true
+                       :base-type base-type
+                       :unit      new-unit})))
     (lib.util.match/replace-in
       query [:query :breakout]
       [:field (_ :guard #(= target-field-id %)) (opts :guard #(= temporal-unit (:temporal-unit %)))]

--- a/src/metabase/query_processor/util.clj
+++ b/src/metabase/query_processor/util.clj
@@ -10,10 +10,8 @@
    [metabase.driver :as driver]
    [metabase.legacy-mbql.normalize :as mbql.normalize]
    [metabase.lib.convert :as lib.convert]
-   [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema.expression :as lib.schema.expression]
    [metabase.query-processor.schema :as qp.schema]
-   [metabase.query-processor.store :as qp.store]
    [metabase.util :as u]
    [metabase.util.malli :as mu]))
 
@@ -229,16 +227,3 @@
   "Returns `true` if query is an internal query."
   [{query-type :type} :- ::qp.schema/qp]
   (= :internal (keyword query-type)))
-
-(defn field->base-type
-  "Return base-type for a `field` clause. Field is expected to appear in the top level of the `_legacy-query`,
-  ie. not in its source query or source queries of its joins."
-  [{source-metadatas :source-metadata :as _legacy-query} [_tag id-or-name opts :as _field]]
-  (or (:base-type opts)
-      (when (integer? id-or-name)
-        (:base-type (lib.metadata/field (qp.store/metadata-provider) id-or-name)))
-      (when (string? id-or-name)
-        (some (fn [{:keys [name base_type] :as _source-metadata}]
-                (when (= name id-or-name)
-                  base_type))
-              source-metadatas))))

--- a/src/metabase/query_processor/util/temporal_bucket.clj
+++ b/src/metabase/query_processor/util/temporal_bucket.clj
@@ -1,0 +1,36 @@
+(ns metabase.query-processor.util.temporal-bucket
+  (:require
+   [clojure.set :as set]))
+
+(def valid-date-units
+  "Valid temporal units for date."
+  #{:default :day :day-of-week :day-of-month :day-of-year
+    :week :week-of-year :month :month-of-year :quarter :quarter-of-year :year})
+
+(def valid-time-units
+  "Valid temporal units for time."
+  #{:default :millisecond :second :minute :minute-of-hour :hour :hour-of-day})
+
+(def valid-datetime-units
+  "Valid temporal units for date time."
+  (set/union valid-date-units valid-time-units))
+
+;; TODO -- this should be changed to `:effective-type` once we finish the metadata changes.
+(defmulti valid-units-for-base-type
+  "Returns valid temrpoal units for the `base-type`."
+  {:arglists '([base-type])}
+  keyword)
+
+;; for stuff like UNIX timestamps -- skip validation for now. (UNIX timestamp should be bucketable with any unit
+;; anyway). Once `:effective-type` is in place, we can actually check those Fields here.
+(defmethod valid-units-for-base-type :type/*        [_] valid-datetime-units)
+(defmethod valid-units-for-base-type :type/Date     [_] valid-date-units)
+(defmethod valid-units-for-base-type :type/Time     [_] valid-time-units)
+(defmethod valid-units-for-base-type :type/DateTime [_] valid-datetime-units)
+
+(defn compatible-temporal-unit?
+  "Check whether some column of `a-type` can be bucketted by the`temporal-unit`. Any column can be bucketed by `nil`
+  temporal unit. "
+  [a-type temporal-unit]
+  (or (nil? temporal-unit)
+      (contains? (valid-units-for-base-type a-type) temporal-unit)))

--- a/src/metabase/query_processor/util/temporal_bucket.clj
+++ b/src/metabase/query_processor/util/temporal_bucket.clj
@@ -1,19 +1,18 @@
 (ns metabase.query-processor.util.temporal-bucket
   (:require
-   [clojure.set :as set]))
+   [metabase.lib.schema.temporal-bucketing :as lib.schema.temporal-bucketing]))
 
 (def valid-date-units
   "Valid temporal units for date."
-  #{:default :day :day-of-week :day-of-month :day-of-year
-    :week :week-of-year :month :month-of-year :quarter :quarter-of-year :year})
+  (into #{:default} lib.schema.temporal-bucketing/date-bucketing-units))
 
 (def valid-time-units
   "Valid temporal units for time."
-  #{:default :millisecond :second :minute :minute-of-hour :hour :hour-of-day})
+  (into #{:default} lib.schema.temporal-bucketing/time-bucketing-units))
 
 (def valid-datetime-units
   "Valid temporal units for date time."
-  (set/union valid-date-units valid-time-units))
+  lib.schema.temporal-bucketing/temporal-bucketing-units)
 
 ;; TODO -- this should be changed to `:effective-type` once we finish the metadata changes.
 (defmulti valid-units-for-base-type
@@ -30,7 +29,7 @@
 
 (defn compatible-temporal-unit?
   "Check whether some column of `a-type` can be bucketted by the`temporal-unit`. Any column can be bucketed by `nil`
-  temporal unit. "
+  temporal unit."
   [a-type temporal-unit]
   (or (nil? temporal-unit)
       (contains? (valid-units-for-base-type a-type) temporal-unit)))

--- a/src/metabase/query_processor/util/temporal_bucket.clj
+++ b/src/metabase/query_processor/util/temporal_bucket.clj
@@ -2,17 +2,9 @@
   (:require
    [metabase.lib.schema.temporal-bucketing :as lib.schema.temporal-bucketing]))
 
-(def valid-date-units
-  "Valid temporal units for date."
-  (into #{:default} lib.schema.temporal-bucketing/date-bucketing-units))
-
-(def valid-time-units
-  "Valid temporal units for time."
-  (into #{:default} lib.schema.temporal-bucketing/time-bucketing-units))
-
-(def valid-datetime-units
-  "Valid temporal units for date time."
-  lib.schema.temporal-bucketing/temporal-bucketing-units)
+(def ^:private valid-date-units (into #{:default} lib.schema.temporal-bucketing/date-bucketing-units))
+(def ^:private valid-time-units (into #{:default} lib.schema.temporal-bucketing/time-bucketing-units))
+(def ^:private valid-datetime-units lib.schema.temporal-bucketing/temporal-bucketing-units)
 
 ;; TODO -- this should be changed to `:effective-type` once we finish the metadata changes.
 (defmulti valid-units-for-base-type

--- a/test/metabase/query_processor/middleware/catch_exceptions_test.clj
+++ b/test/metabase/query_processor/middleware/catch_exceptions_test.clj
@@ -28,7 +28,7 @@
   (testing "Should nicely format a chain of exceptions, with the top-level Exception appearing first"
     (testing "lowest-level error `:type` should be pulled up to the top-level"
       (let [e1 (ex-info "1" {:level 1})
-            e2 (ex-info "2" {:level 2, :type qp.error-type/qp :curated true} e1)
+            e2 (ex-info "2" {:level 2, :type qp.error-type/qp :is-curated true} e1)
             e3 (ex-info "3" {:level 3} e2)]
         (is (= {:status     :failed
                 :class      clojure.lang.ExceptionInfo
@@ -40,9 +40,9 @@
                               :class         clojure.lang.ExceptionInfo
                               :error         "2"
                               :stacktrace    true
-                              :ex-data       {:level 2, :type :qp, :curated true}
+                              :ex-data       {:level 2, :type :qp, :is-curated true}
                               :error_type    :qp
-                              :error_curated true}
+                              :error_is_curated true}
                              {:status     :failed
                               :class      clojure.lang.ExceptionInfo
                               :error      "3"

--- a/test/metabase/query_processor/middleware/catch_exceptions_test.clj
+++ b/test/metabase/query_processor/middleware/catch_exceptions_test.clj
@@ -28,7 +28,7 @@
   (testing "Should nicely format a chain of exceptions, with the top-level Exception appearing first"
     (testing "lowest-level error `:type` should be pulled up to the top-level"
       (let [e1 (ex-info "1" {:level 1})
-            e2 (ex-info "2" {:level 2, :type qp.error-type/qp} e1)
+            e2 (ex-info "2" {:level 2, :type qp.error-type/qp :curated true} e1)
             e3 (ex-info "3" {:level 3} e2)]
         (is (= {:status     :failed
                 :class      clojure.lang.ExceptionInfo
@@ -36,12 +36,13 @@
                 :stacktrace true
                 :error_type :qp
                 :ex-data    {:level 1}
-                :via        [{:status     :failed
-                              :class      clojure.lang.ExceptionInfo
-                              :error      "2"
-                              :stacktrace true
-                              :ex-data    {:level 2, :type :qp}
-                              :error_type :qp}
+                :via        [{:status        :failed
+                              :class         clojure.lang.ExceptionInfo
+                              :error         "2"
+                              :stacktrace    true
+                              :ex-data       {:level 2, :type :qp, :curated true}
+                              :error_type    :qp
+                              :error_curated true}
                              {:status     :failed
                               :class      clojure.lang.ExceptionInfo
                               :error      "3"

--- a/test/metabase/query_processor_test/date_bucketing_test.clj
+++ b/test/metabase/query_processor_test/date_bucketing_test.clj
@@ -33,6 +33,7 @@
    [metabase.query-processor :as qp]
    [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.middleware.format-rows :as format-rows]
+   [metabase.query-processor.preprocess :as qp.preprocess]
    [metabase.query-processor.test-util :as qp.test-util]
    [metabase.test :as mt]
    [metabase.util :as u]
@@ -1365,6 +1366,20 @@
 
       (testing "annual"
         (is (= [488444.41] (unit-totals "year")))))))
+
+(deftest incompatible-temporal-unit-parameter-test
+  (testing "Incompatible time unit parameter yields expected error"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"This chart can not be broken out by the selected unit of time: minute\."
+         (qp.preprocess/preprocess
+          (mt/mbql-query
+           checkins
+           {:type       :query
+            :query      {:aggregation  [[:count]]
+                         :breakout     [!day.date]}
+            :parameters [{:type   :temporal-unit
+                          :target [:dimension !day.date]
+                          :value  "minute"}]}))))))
 
 (deftest day-of-week-custom-start-of-week-test
   (mt/test-drivers (mt/normal-drivers)

--- a/test/metabase/query_processor_test/date_bucketing_test.clj
+++ b/test/metabase/query_processor_test/date_bucketing_test.clj
@@ -1367,7 +1367,7 @@
       (testing "annual"
         (is (= [488444.41] (unit-totals "year")))))))
 
-(deftest incompatible-temporal-unit-parameter-test
+(deftest ^:parallel incompatible-temporal-unit-parameter-test
   (testing "Incompatible time unit parameter yields expected error"
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo #"This chart can not be broken out by the selected unit of time: minute\."


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/46068

Context [on slack](https://metaboat.slack.com/archives/C0645JP1W81/p1722596802747439).