### PR TITLE
Make connection uri sensitive respecting exceptions

### DIFF
--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -64,6 +64,11 @@
      #(u/ignore-exceptions (driver/the-driver %))]]
    (deferred-tru "value must be a valid database engine.")))
 
+(defn- add-conn-uri-sensitive-exception
+  "Add radction exception for `:conn-uri` detail, which is handled in `mi/to-json :model/Database` implementation."
+  [db]
+  (update db :details vary-meta assoc :sensitive-exceptions #{:conn-uri}))
+
 
 ;;; ----------------------------------------------- GET /api/database ------------------------------------------------
 
@@ -349,11 +354,13 @@
                             (= include "tables.fields") (map #(update % :fields filter-sensitive-fields))))))))
 
 (defn get-database
-  "Get a single Database with `id`."
+  "Get a single Database with `id`. Add sensitive exception for `:conn-uri` detail, handled
+  in `mi/to-json :model/Database`."
   [id {:keys [include include-editable-data-model? exclude-uneditable-details?]}]
   (let [filter-by-data-access?       (not (or include-editable-data-model? exclude-uneditable-details?))
         database                     (api/check-404 (t2/select-one Database :id id))]
     (cond-> database
+      true                         add-conn-uri-sensitive-exception
       filter-by-data-access?       api/read-check
       exclude-uneditable-details?  api/write-check
       true                         add-expanded-schedules
@@ -802,20 +809,22 @@
     (if valid?
       ;; no error, proceed with creation. If record is inserted successfuly, publish a `:database-create` event.
       ;; Throw a 500 if nothing is inserted
-      (u/prog1 (api/check-500 (first (t2/insert-returning-instances!
-                                      Database
-                                      (merge
-                                       {:name         name
-                                        :engine       engine
-                                        :details      details-or-error
-                                        :is_full_sync is_full_sync
-                                        :is_on_demand is_on_demand
-                                        :cache_ttl    cache_ttl
-                                        :creator_id   api/*current-user-id*}
-                                       (when schedules
-                                         (sync.schedules/schedule-map->cron-strings schedules))
-                                       (when (some? auto_run_queries)
-                                         {:auto_run_queries auto_run_queries})))))
+      (u/prog1 (api/check-500 (-> (t2/insert-returning-instances!
+                                   Database
+                                   (merge
+                                    {:name         name
+                                     :engine       engine
+                                     :details      details-or-error
+                                     :is_full_sync is_full_sync
+                                     :is_on_demand is_on_demand
+                                     :cache_ttl    cache_ttl
+                                     :creator_id   api/*current-user-id*}
+                                    (when schedules
+                                      (sync.schedules/schedule-map->cron-strings schedules))
+                                    (when (some? auto_run_queries)
+                                      {:auto_run_queries auto_run_queries})))
+                                  first
+                                  add-conn-uri-sensitive-exception))
         (events/publish-event! :event/database-create {:object <> :user-id api/*current-user-id*})
         (snowplow/track-event! ::snowplow/database-connection-successful
                                api/*current-user-id*
@@ -972,7 +981,8 @@
        (when (premium-features/enable-cache-granular-controls?)
          (t2/update! Database id {:cache_ttl cache_ttl}))
 
-       (let [db (t2/select-one Database :id id)]
+       (let [db (-> (t2/select-one Database :id id)
+                    add-conn-uri-sensitive-exception)]
          (events/publish-event! :event/database-update {:object db
                                                         :user-id api/*current-user-id*
                                                         :previous-object existing-database})

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -65,7 +65,7 @@
    (deferred-tru "value must be a valid database engine.")))
 
 (defn- add-conn-uri-sensitive-exception
-  "Add radction exception for `:conn-uri` detail, which is handled in `mi/to-json :model/Database` implementation."
+  "Add redaction exception for `:conn-uri` detail, which is handled in `mi/to-json :model/Database` implementation."
   [db]
   (update db :details vary-meta assoc :sensitive-exceptions #{:conn-uri}))
 

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -648,7 +648,7 @@
 (def default-sensitive-fields
   "Set of fields that should always be obfuscated in API responses, as they contain sensitive data."
   #{:password :pass :tunnel-pass :tunnel-private-key :tunnel-private-key-passphrase :access-token :refresh-token
-    :service-account-json})
+    :service-account-json :conn-uri})
 
 (defn sensitive-fields
   "Returns all sensitive fields that should be redacted in API responses for a given database. Calls get-sensitive-fields

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -410,10 +410,10 @@
   Users with write perms can see the `details` but remove anything resembling a password. No one gets to see this in
   an API response!
 
-  Then, connection uri is a special case of sensitive field. It should be sent only in API responses of /database...
+  Then, connection uri is a special case of sensitive field. It should be sent only in API responses of /database/:id
   endpoints, to enable editing. Otherwise it should be treated as secret, as it can contain eg. password. That is
   handled in [[redact-sensitive-fields]] by processing exceptions from sensitive fields. Those are added in API's
-  [[metabase.api.database/get-database]].
+  [[metabase.api.database/add-conn-uri-sensitive-exception]] in endpoints' code.
 
   Also remove settings that the User doesn't have read perms for."
   [db json-generator]

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -391,10 +391,29 @@
             driver.u/default-sensitive-fields))
       driver.u/default-sensitive-fields))
 
+(defn- redact-sensitive-fields
+  "Redact sensitive fields from database, respecting `:sensitive-exceptions` metadata. Example of sensitive exceptions
+  usage is described in the docstring of the `mi/to-json :model/Database` implementation."
+  [{:keys [details] :as db}]
+  (let [sensitive-exceptions (-> details meta :sensitive-exceptions)
+        sensitive-fields (apply disj
+                                (sensitive-fields-for-db db)
+                                sensitive-exceptions)
+        keys-to-redact (filter sensitive-fields (keys details))]
+    (m/update-existing db :details merge
+                       (zipmap keys-to-redact
+                               (repeat (count keys-to-redact)
+                                       protected-password)))))
+
 (methodical/defmethod mi/to-json :model/Database
   "When encoding a Database as JSON remove the `details` for any User without write perms for the DB.
   Users with write perms can see the `details` but remove anything resembling a password. No one gets to see this in
   an API response!
+
+  Then, connection uri is a special case of sensitive field. It should be sent only in API responses of /database...
+  endpoints, to enable editing. Otherwise it should be treated as secret, as it can contain eg. password. That is
+  handled in [[redact-sensitive-fields]] by processing exceptions from sensitive fields. Those are added in API's
+  [[metabase.api.database/get-database]].
 
   Also remove settings that the User doesn't have read perms for."
   [db json-generator]
@@ -403,11 +422,7 @@
               (do (log/debug "Fully redacting database details during json encoding.")
                   (dissoc db :details))
               (do (log/debug "Redacting sensitive fields within database details during json encoding.")
-                  (update db :details (fn [details]
-                                        (reduce
-                                         #(m/update-existing %1 %2 (constantly protected-password))
-                                         details
-                                         (sensitive-fields-for-db db))))))]
+                  (redact-sensitive-fields db)))]
      (update db :settings
              (fn [settings]
                (when (map? settings)

--- a/test/metabase/models/database_test.clj
+++ b/test/metabase/models/database_test.clj
@@ -113,7 +113,7 @@
                         :details     {:additional-options            nil
                                       :ssl                           false
                                       :password                      "Password1234"
-                                      :conn-uri                     "can contain sensitive data"
+                                      :conn-uri                      "can contain sensitive data"
                                       :tunnel-host                   "localhost"
                                       :port                          5432
                                       :dbname                        "mydb"

--- a/test/metabase/models/database_test.clj
+++ b/test/metabase/models/database_test.clj
@@ -113,6 +113,7 @@
                         :details     {:additional-options            nil
                                       :ssl                           false
                                       :password                      "Password1234"
+                                      :conn-uri                     "can contain sensitive data"
                                       :tunnel-host                   "localhost"
                                       :port                          5432
                                       :dbname                        "mydb"
@@ -175,6 +176,7 @@
                                  "tunnel-enabled"                true
                                  "port"                          5432
                                  "password"                      "**MetabasePass**"
+                                 "conn-uri"                      "**MetabasePass**"
                                  "tunnel-host"                   "localhost"}
                   "settings"    {"database-enable-actions" true}
                   "id"          3}


### PR DESCRIPTION
Context [on slack](https://metaboat.slack.com/archives/C97M2U8M6/p1722501915213469).

#### The idea
Admins can see `conn-uri` of mongo dbs as they can edit the admin screen where this is configured:
<img width="696" alt="image" src="https://github.com/user-attachments/assets/09d7d6d5-a959-46c1-987a-cd1f28f9a58f">

But this connection string gets hydrated onto places unexpectedly: like when a db is hydrated onto field values. This PR adds `:conn-uri` to `default-sensitive-fields`. Then, by use of clojure's metadata, details returned from selected endpoints are marked to avoid redaction. Redaction happens in `to-json :model/Database` implementation, that is called after the enpoint functions complete, hence the decision to use metadata.