### PR TITLE
ci: do not save same m2 cache multiple times

### DIFF
--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -2,7 +2,7 @@ name: Test database driver
 inputs:
   junit-name:
     required: true
-    default: 'driver'
+    default: "driver"
   test-args:
     required: false
 
@@ -14,7 +14,7 @@ runs:
     - name: Prepare back-end environment
       uses: ./.github/actions/prepare-backend
       with:
-        m2-cache-key: driver-${{ inputs.junit-name }}
+        m2-cache-key: driver
     - name: Build static viz frontend
       run: yarn build-static-viz
       shell: bash
@@ -25,7 +25,7 @@ runs:
       uses: dorny/test-reporter@v1
       if: failure()
       with:
-        path: 'target/junit/**/*_test.xml'
+        path: "target/junit/**/*_test.xml"
         name: JUnit Test Report ${{ inputs.junit-name }}
         reporter: java-junit
         list-suites: failed


### PR DESCRIPTION
### Description

We save multiple caches of the same m2 cache with different keys and break the quota of available space at GitHub actions cache. Let's deduplicate this cache

### How to verify

CI is green, there is no cache per driver job, but one m2 cache is reused

https://github.com/metabase/metabase/actions/caches


