### PR TITLE
Exclude javax.annotation/javax.annotation-api

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/deps.edn
+++ b/modules/drivers/bigquery-cloud-sdk/deps.edn
@@ -3,7 +3,10 @@
 
  :deps
  ;; TODO: figure out how to be able to leave off this version string and use the version from the BOM
- {com.google.cloud/google-cloud-bigquery      {:mvn/version "2.38.1"}
+ {com.google.cloud/google-cloud-bigquery      {:mvn/version "2.38.1"
+                                               ;; this appears to be dual licensed EPL, GPL2.0 but it's not super
+                                               ;; clear so we're excluding it
+                                               :exclusions [javax.annotation/javax.annotation-api]}
   com.google.guava/guava                      {:mvn/version "33.1.0-jre"} ; specified separately so that Snyk is happy
   com.google.code.gson/gson                   {:mvn/version "2.10.1"}
   com.google.oauth-client/google-oauth-client {:mvn/version "1.35.0"}}}


### PR DESCRIPTION
dep is brought in by google cloud

From `clj -X:deps tree :aliases '[:ee :drivers]'`

```
  . metabase/bigquery-cloud-sdk metabase/modules/drivers/bigquery-cloud-sdk
    . com.google.cloud/google-cloud-bigquery 2.38.1
      . com.google.cloud/google-cloud-core 2.35.0
      [...]
      . javax.annotation/javax.annotation-api 1.3.2
```

Before this change:

```
❯ clj -X:deps tree :aliases '[:ee :drivers]' | grep 'javax.annotation/javax.annotation-api'
      . javax.annotation/javax.annotation-api 1.3.2
```

After:

```
❯ clj -X:deps tree :aliases '[:ee :drivers]' > deps-master

❯ echo $?
0
```

### Why remove this?

The project includes both the EPL and GPL 2.0 licenses: https://github.com/jakartaee/common-annotations-api/blob/master/LICENSE.md but we aren't sure if it's dual licensed or has pieces each of which are under one or the other. But it's not load bearing (just for compilation of java, not use of the bytecode) so we can exclude it.

(subject to checking bigquery use in the jar)