### PR TITLE
e2e: allow cypress to start with --browser=firefox passed

### DIFF
--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -106,7 +106,9 @@ const defaultConfig = {
         );
         if (!failures) {
           // delete the video if the spec passed and no tests retried
-          fs.unlinkSync(results.video);
+          if (fs.existsSync(results.video)) {
+            fs.unlinkSync(results.video);
+          }
         }
       }
     });


### PR DESCRIPTION
### Description

verify that file exists before trying to remove it, for some reason it's firefox specific


### How to verify

`yarn test-cypress-open --browser=firefox` starts cypress locally

### Demo

https://github.com/user-attachments/assets/6cc32b2a-5425-4182-bb2c-b4905010b209

