### PR TITLE
Handle non-number cases in NumberFingerprint

### DIFF
--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -191,12 +191,12 @@ export type TextFingerprintDisplayInfo = {
 };
 
 export type NumberFingerprintDisplayInfo = {
-  avg: number;
-  max: number;
-  min: number;
-  q1: number;
-  q3: number;
-  sd: number;
+  avg: unknown;
+  max: unknown;
+  min: unknown;
+  q1: unknown;
+  q3: unknown;
+  sd: unknown;
 };
 
 export type DateTimeFingerprintDisplayInfo = {

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -190,6 +190,9 @@ export type TextFingerprintDisplayInfo = {
   percentUrl: number;
 };
 
+// We're setting the values here as unknown even though
+// the API will return numbers most of the time, because
+// sometimes it doesn't!
 export type NumberFingerprintDisplayInfo = {
   avg: unknown;
   max: unknown;

--- a/frontend/src/metabase/components/MetadataInfo/ColumnFingerprintInfo/NumberFingerprint.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/ColumnFingerprintInfo/NumberFingerprint.tsx
@@ -48,10 +48,18 @@ export function NumberFingerprint({
  * @param num - a number value from the type/Number fingerprint; might not be a number
  * @returns - a tuple, [isFormattedNumber, formattedNumber]
  */
-function roundNumber(num: number | null | undefined): [boolean, string] {
-  if (num == null) {
+function roundNumber(num: unknown): [boolean, string] {
+  if (!isNumber(num)) {
     return [false, ""];
   }
 
-  return [true, Number.isInteger(num) ? num.toString() : num.toFixed(2)];
+  if (Number.isInteger(num)) {
+    return [true, num.toString()];
+  }
+
+  return [true, num.toFixed(2)];
+}
+
+function isNumber(num: unknown): num is number {
+  return typeof num === "number" && Number.isFinite(num) && !Number.isNaN(num);
 }

--- a/frontend/src/metabase/components/MetadataInfo/ColumnFingerprintInfo/NumberFingerprint.unit.spec.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/ColumnFingerprintInfo/NumberFingerprint.unit.spec.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "__support__/ui";
+import type * as Lib from "metabase-lib";
+
+import { NumberFingerprint } from "./NumberFingerprint";
+
+type SetupOpts = {
+  fingerprintTypeInfo?: {
+    avg: unknown;
+    min: unknown;
+    max: unknown;
+  };
+};
+
+function setup({ fingerprintTypeInfo }: SetupOpts) {
+  render(
+    <NumberFingerprint
+      fingerprintTypeInfo={
+        fingerprintTypeInfo as Lib.NumberFingerprintDisplayInfo
+      }
+    />,
+  );
+}
+
+describe("NumberFingerprint", () => {
+  it("should render valid numbers and round to two decimal places", () => {
+    setup({
+      fingerprintTypeInfo: {
+        avg: 123,
+        min: 456.789,
+        max: 2e4,
+      },
+    });
+    expect(screen.getByText("Average")).toBeInTheDocument();
+    expect(screen.getByText("Min")).toBeInTheDocument();
+    expect(screen.getByText("Max")).toBeInTheDocument();
+
+    expect(screen.getByText("123")).toBeInTheDocument();
+    expect(screen.getByText("456.79")).toBeInTheDocument();
+    expect(screen.getByText("20000")).toBeInTheDocument();
+  });
+  it("should ignore invalid number values in the info", () => {
+    setup({
+      fingerprintTypeInfo: {
+        avg: 123,
+        min: Infinity,
+        max: NaN,
+      },
+    });
+    expect(screen.getByText("Average")).toBeInTheDocument();
+    expect(screen.queryByText("Min")).not.toBeInTheDocument();
+    expect(screen.queryByText("Max")).not.toBeInTheDocument();
+  });
+  it("should ignore invalid non-number values in the info", () => {
+    setup({
+      fingerprintTypeInfo: {
+        avg: 123,
+        min: "456",
+        max: null,
+      },
+    });
+    expect(screen.getByText("Average")).toBeInTheDocument();
+    expect(screen.queryByText("Min")).not.toBeInTheDocument();
+    expect(screen.queryByText("Max")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/46574

### Description

Fixes a P1 bug that caused the question to crash when displaying the fingerprint info for certain tables.

The TypeScript types are incorrect which made the code pass the checker. If fixed it locally but I think we should consider fixing all the incorrect api types (like the one for [`NumberFingerprintDisplayInfo`](https://github.com/metabase/metabase/blob/master/frontend/src/metabase-lib/types.ts#L193-L200)).

### How to verify

Follow the reproduction steps in the [issue](https://github.com/metabase/metabase/issues/46574) to see if the crash still happens.


### Checklist

- [x] Tests have been added/updated to cover changes in this PR, we don't have Oracle tests for Cypress so only a unit test was added
