### PR TITLE
Hide non-qualified fields from query validator

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/query_reference_validation/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/query_reference_validation/api_test.clj
@@ -53,18 +53,28 @@
                             ;; QFs not to include:
                             ;; - Field is still active
                             :model/QueryField {}             {:card_id     card-1
-                                                              :analysis_id qa-3
+                                                              :analysis_id qa-1
                                                               :table       "ORDERS"
                                                               :column      "tax"
                                                               :table_id    (mt/id :orders)
                                                               :field_id    (mt/id :orders :tax)}
                             ;; - Implicit reference
                             :model/QueryField {}             {:card_id            card-2
-                                                              :analysis_id        qa-3
+                                                              :analysis_id        qa-2
                                                               :table              "T1"
                                                               :column             "FA"
+                                                              :table_id           table-1
                                                               :field_id           field-1
                                                               :explicit_reference false}
+                            ;; - No resolved table, probably an imaginary column due to Macaw bugs
+                            :model/QueryField {}             {:card_id            card-3
+                                                              :analysis_id        qa-3
+                                                              :table              nil
+                                                              :column             "FALSE"
+                                                              :table_id           nil
+                                                              :field_id           nil
+                                                              :explicit_reference true}
+
                             ;; QFs to include:
                             :model/QueryField {}             {:card_id     card-1
                                                               :analysis_id qa-1

--- a/src/metabase/models/query_analysis.clj
+++ b/src/metabase/models/query_analysis.clj
@@ -28,7 +28,8 @@
        [(t2/table-name :model/QueryField) :qf]
        [:and
         [:= :qf.card_id :c.id]
-        [:= :qf.explicit_reference true]])
+        [:= :qf.explicit_reference true]
+        [:not= :qf.table nil]])
       (sql.helpers/left-join
        [(t2/table-name :model/Field) :f]
        [:= :qf.field_id :f.id])


### PR DESCRIPTION
We started persisting *all* `:source-columns` in https://github.com/metabase/metabase/pull/46432, and this compensates that for that by suppressing any references that we couldn't nail down to a table.

See this question for examples of the kinds of references we'd be suppressing: https://stats.metabase.com/question/19045-phantom-query-analysis-fields