### PR TITLE
[serdes] ability to skip errors

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/api.clj
@@ -74,7 +74,8 @@
         dst      (io/file (str (.getPath path) ".tar.gz"))
         log-file (io/file path "export.log")
         err      (atom nil)
-        report   (with-open [_logger (logger/for-ns 'metabase-enterprise.serialization log-file
+        report   (with-open [_logger (logger/for-ns log-file ['metabase-enterprise.serialization
+                                                              'metabase.models.serialization]
                                                     {:additive *additive-logging*})]
                    (try                 ; try/catch inside logging to log errors
                      (let [report (serdes/with-cache
@@ -85,7 +86,7 @@
                        report)
                      (catch Exception e
                        (reset! err e)
-                       (log/error e "Error during serialization"))))]
+                       (log/errorf "Error during serialization: %s %s" (ex-message e) (ex-data e)))))]
     {:archive       (when (.exists dst)
                       dst)
      :log-file      (when (.exists log-file)
@@ -107,11 +108,12 @@
                  (and (.isDirectory f)
                       (some v2.ingest/legal-top-level-paths (.list f)))))))
 
-(defn- unpack&import [^File file & [size]]
+(defn- unpack&import [^File file & [{:keys [size skip_errors]}]]
   (let [dst      (io/file parent-dir (u.random/random-name))
         log-file (io/file dst "import.log")
         err      (atom nil)
-        report   (with-open [_logger (logger/for-ns 'metabase-enterprise.serialization log-file
+        report   (with-open [_logger (logger/for-ns log-file ['metabase-enterprise.serialization
+                                                              'metabase.models.serialization]
                                                     {:additive *additive-logging*})]
                    (try                 ; try/catch inside logging to log errors
                      (log/infof "Serdes import, size %s" size)
@@ -123,10 +125,10 @@
                        (log/infof "In total %s entries unpacked, detected source dir: %s" cnt (.getName path))
                        (serdes/with-cache
                          (-> (v2.ingest/ingest-yaml (.getPath path))
-                             (v2.load/load-metabase!))))
+                             (v2.load/load-metabase! {:skip-errors skip_errors}))))
                      (catch Exception e
                        (reset! err e)
-                       (log/error e "Error during serialization"))))]
+                       (log/errorf "Error during deserialization: %s %s" (ex-message e) (ex-data e)))))]
     {:log-file      log-file
      :error-message (some-> @err str)
      :report        report
@@ -140,7 +142,7 @@
 
   Outputs `.tar.gz` file with serialization results and an `export.log` file.
   On error outputs serialization logs directly."
-  [:as {{:strs [all_collections collection settings data_model field_values database_secrets dirname]
+  [:as {{:strs [all_collections collection settings data_model field_values database_secrets dirname skip_errors]
          :or   {all_collections true
                 settings        true
                 data_model      true}}
@@ -156,17 +158,20 @@
                              {:default     true
                               :description "Serialize all collections (`true` unless you specify `collection`)"})
    settings         (mu/with [:maybe ms/BooleanValue]
-                             {:default true
+                             {:default     true
                               :description "Serialize Metabase settings"})
    data_model       (mu/with [:maybe ms/BooleanValue]
-                             {:default true
+                             {:default     true
                               :description "Serialize Metabase data model"})
    field_values     (mu/with [:maybe ms/BooleanValue]
-                             {:default false
+                             {:default     false
                               :description "Serialize cached field values"})
    database_secrets (mu/with [:maybe ms/BooleanValue]
+                             {:default     false
+                              :description "Serialize details how to connect to each db"})
+   skip_errors      (mu/with [:maybe ms/BooleanValue]
                              {:default false
-                              :description "Serialize details how to connect to each db"})}
+                              :description "Do not break execution on errors"})}
   (api/check-superuser)
   (let [start              (System/nanoTime)
         opts               {:targets                  (mapv #(vector "Collection" %)
@@ -177,7 +182,8 @@
                             :no-settings              (not settings)
                             :include-field-values     field_values
                             :include-database-secrets database_secrets
-                            :dirname                  dirname}
+                            :dirname                  dirname
+                            :skip-errors              skip_errors}
         {:keys [archive
                 log-file
                 report
@@ -188,6 +194,7 @@
                             :source          "api"
                             :duration_ms     (int (/ (- (System/nanoTime) start) 1e6))
                             :count           (count (:seen report))
+                            :error_count     (count (:errors report))
                             :collection      (str/join "," (map str collection))
                             :all_collections (and (empty? collection)
                                                   (not (:no-collections opts)))
@@ -213,15 +220,22 @@
   - `file`: archive encoded as `multipart/form-data` (required).
 
   Returns logs of deserialization."
-  [:as {raw-params :params}]
+  [:as {{:strs [skip_errors]} :query-params
+        {:strs [file]}        :multipart-params}]
+  {skip_errors (mu/with [:maybe ms/BooleanValue]
+                        {:default     false
+                         :description "Do not break execution on errors"})
+   file        (mu/with ms/File
+                        {:description ".tgz with serialization data"})}
   (api/check-superuser)
   (try
     (let [start              (System/nanoTime)
           {:keys [log-file
                   error-message
                   report
-                  callback]} (unpack&import (get-in raw-params ["file" :tempfile])
-                                            (get-in raw-params ["file" :size]))
+                  callback]} (unpack&import (:tempfile file)
+                                            {:size        (:size file)
+                                             :skip_errors skip_errors})
           imported           (into (sorted-set) (map (comp :model last)) (:seen report))]
       (snowplow/track-event! ::snowplow/serialization api/*current-user-id*
                              {:direction     "import"
@@ -231,12 +245,13 @@
                               :count         (if (contains? imported "Setting")
                                                (inc (count (remove #(= "Setting" (:model (first %))) (:seen report))))
                                                (count (:seen report)))
+                              :error_count   (count (:errors report))
                               :success       (not error-message)
                               :error_message error-message})
       {:status  200
        :headers {"Content-Type" "text/plain"}
        :body    (on-response! log-file callback)})
     (finally
-      (io/delete-file (get-in raw-params ["file" :tempfile])))))
+      (io/delete-file (:tempfile file)))))
 
 (api/define-routes +auth)

--- a/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
@@ -87,7 +87,7 @@
   [path :- :string
    opts :- [:map
             [:backfill? {:optional true} [:maybe :boolean]]
-            [:skip-errors {:optional true} [:maybe :boolean]]]
+            [:continue-on-error {:optional true} [:maybe :boolean]]]
    ;; Deliberately separate from the opts so it can't be set from the CLI.
    & {:keys [token-check?
              require-initialized-db?]
@@ -113,7 +113,7 @@
   [path :- :string
    opts :- [:map
             [:backfill? {:optional true} [:maybe :boolean]]
-            [:skip-errors {:optional true} [:maybe :int]]]]
+            [:continue-on-error {:optional true} [:maybe :int]]]]
   (let [start    (System/nanoTime)
         err      (atom nil)
         report   (try

--- a/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
@@ -86,7 +86,8 @@
   `opts` are passed to [[v2.load/load-metabase]]."
   [path :- :string
    opts :- [:map
-            [:backfill? {:optional true} [:maybe :boolean]]]
+            [:backfill? {:optional true} [:maybe :boolean]]
+            [:skip-errors {:optional true} [:maybe :boolean]]]
    ;; Deliberately separate from the opts so it can't be set from the CLI.
    & {:keys [token-check?
              require-initialized-db?]
@@ -111,7 +112,8 @@
    opts are passed to load-metabase"
   [path :- :string
    opts :- [:map
-            [:backfill? {:optional true} [:maybe :boolean]]]]
+            [:backfill? {:optional true} [:maybe :boolean]]
+            [:skip-errors {:optional true} [:maybe :int]]]]
   (let [start    (System/nanoTime)
         err      (atom nil)
         report   (try
@@ -127,6 +129,7 @@
                             :count         (if (contains? imported "Setting")
                                              (inc (count (remove #(= "Setting" (:model (first %))) (:seen report))))
                                              (count (:seen report)))
+                            :error_count   (count (:errors report))
                             :success       (nil? @err)
                             :error_message (some-> @err str)})
     (when @err
@@ -238,15 +241,12 @@
       (throw (ex-info (format "Destination path is not writeable: %s" path) {:filename path}))))
   (let [start  (System/nanoTime)
         err    (atom nil)
+        opts   (cond-> opts
+                 (seq collection-ids)
+                 (assoc :targets (v2.extract/make-targets-of-type "Collection" collection-ids)))
         report (try
                  (serdes/with-cache
-                   (-> (cond-> opts
-                         (seq collection-ids)
-                         (assoc :targets
-                                (v2.extract/make-targets-of-type
-                                 "Collection"
-                                 collection-ids)))
-                       v2.extract/extract
+                   (-> (v2.extract/extract opts)
                        (v2.storage/store! path)))
                  (catch Exception e
                    (reset! err e)))]
@@ -255,6 +255,7 @@
                             :source          "cli"
                             :duration_ms     (int (/ (- (System/nanoTime) start) 1e6))
                             :count           (count (:seen report))
+                            :error_count     (count (:errors report))
                             :collection      (str/join "," collection-ids)
                             :all_collections (and (empty? collection-ids)
                                                   (not (:no-collections opts)))

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
@@ -179,7 +179,7 @@ Eg. if Dashboard B includes a Card A that is derived from a
                             (select-keys models)
                             (update-vals #(set (map second %))))
             extract-ids (fn [[model ids]]
-                          (eduction (map #(serdes/extract-one model opts %))
+                          (eduction (map #(serdes/log-and-extract-one model opts %))
                                     (t2/reducible-select (symbol model) :id [:in ids])))]
         (eduction cat
                   [(eduction (map extract-ids) cat by-model)

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
@@ -96,9 +96,9 @@
 
 (defn load-metabase!
   "Loads in a database export from an ingestion source, which is any Ingestable instance."
-  [ingestion & {:keys [backfill? skip-errors]
+  [ingestion & {:keys [backfill? continue-on-error]
                 :or   {backfill?   true
-                       skip-errors false}}]
+                       continue-on-error false}}]
   (t2/with-transaction [_tx]
     ;; We proceed in the arbitrary order of ingest-list, deserializing all the files. Their declared dependencies
     ;; guide the import, and make sure all containers are imported before contents, etc.
@@ -115,7 +115,7 @@
                 (try
                   (load-one! ctx item)
                   (catch Exception e
-                    (when-not skip-errors
+                    (when-not continue-on-error
                       (throw e))
                     ;; eschew big and scary stacktrace
                     (log/warnf "Skipping deserialization error: %s %s" (ex-message e) (ex-data e))

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
@@ -115,11 +115,10 @@
                 (try
                   (load-one! ctx item)
                   (catch Exception e
-                    (if skip-errors
-                      (do
-                        ;; eschew big and scary stacktrace
-                        (log/warnf "Skipping deserialization error: %s %s" (ex-message e) (ex-data e))
-                        (update ctx :errors conj e))
-                      (throw e)))))
+                    (when-not skip-errors
+                      (throw e))
+                    ;; eschew big and scary stacktrace
+                    (log/warnf "Skipping deserialization error: %s %s" (ex-message e) (ex-data e))
+                    (update ctx :errors conj e))))
               ctx
               contents))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
@@ -217,7 +217,7 @@
                       (let [res (mt/user-http-request :crowberto :post 200 "ee/serialization/import"
                                                       {:request-options {:headers {"content-type" "multipart/form-data"}}}
                                                       {:file ba}
-                                                      :skip_errors true)
+                                                      :continue_on_error true)
                             log (slurp (io/input-stream res))]
                         (testing "3 header lines, then card+database+coll, error, then dashboard+coll"
                           (is (= #{"Dashboard" "Card" "Database" "Collection"}
@@ -264,7 +264,7 @@
                   (testing "Skipping errors /api/ee/serialization/export"
                     (let [res (-> (mt/user-http-request :crowberto :post 200 "ee/serialization/export"
                                                         :collection (:id coll) :data_model false :settings false
-                                                        :skip_errors true)
+                                                        :continue_on_error true)
                                   ;; consume response to remove on-disk data
                                   io/input-stream)]
                       (with-open [tar (open-tar res)]

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -1180,7 +1180,7 @@
           (is (= (:id dash1)
                  (t2/select-one-fn select-target DashboardCard :entity_id (:entity_id dc3)))))))))
 
-(deftest skip-errors-test
+(deftest continue-on-error-test
   (let [change-ser    (fn [ser changes]
                         (vec (for [entity ser
                                    :let   [change (get changes (:entity_id entity))]]
@@ -1205,9 +1205,9 @@
                                                  (extract-one model-name opts instance)))]
               (is (logs-contain? #"Skipping Card \d+ because of an error extracting it"
                                  (mt/with-log-messages-for-level ['metabase.models.serialization :warn]
-                                   (let [ser            (vec (serdes.extract/extract {:no-settings   true
-                                                                                      :no-data-model true
-                                                                                      :skip-errors   true}))
+                                   (let [ser            (vec (serdes.extract/extract {:no-settings       true
+                                                                                      :no-data-model     true
+                                                                                      :continue-on-error true}))
                                          {errors true
                                           others false} (group-by #(instance? Exception %) ser)]
                                      (is (= 1 (count errors)))
@@ -1218,6 +1218,6 @@
                 changed (change-ser ser {(:entity_id c2) {:collection_id "does-not-exist"}})]
             (is (logs-contain? #"Skipping deserialization error"
                                (mt/with-log-messages-for-level ['metabase-enterprise :warn]
-                                 (let [report (serdes.load/load-metabase! (ingestion-in-memory changed) {:skip-errors true})]
+                                 (let [report (serdes.load/load-metabase! (ingestion-in-memory changed) {:continue-on-error true})]
                                    (is (= 1 (count (:errors report))))
                                    (is (= 3 (count (:seen report))))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -1203,7 +1203,7 @@
                                                (if (= (:entity_id instance) (:entity_id c1))
                                                  (throw (ex-info "Skip me" {}))
                                                  (extract-one model-name opts instance)))]
-              (is (logs-contain? #"Skipping \w+ \d+ because of an error extracting it"
+              (is (logs-contain? #"Skipping Card \d+ because of an error extracting it"
                                  (mt/with-log-messages-for-level ['metabase.models.serialization :warn]
                                    (let [ser            (vec (serdes.extract/extract {:no-settings   true
                                                                                       :no-data-model true

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -1184,11 +1184,9 @@
   (let [change-ser    (fn [ser changes] ;; kind of like left-join, but right side is indexed
                         (vec (for [entity ser]
                                (merge entity (get changes (:entity_id entity))))))
-        logs-contain? (fn [msg-re logs]
-                        (some #(re-find msg-re %)
-                              (->> logs
-                                   (map (fn [[_log-level _error message]] message))
-                                   (into #{}))))]
+        logs-extract  (fn [re logs]
+                        (keep #(rest (re-find re %))
+                              (map (fn [[_log-level _error message]] message) logs)))]
     (mt/with-empty-h2-app-db
       (mt/with-temp [Collection coll {:name "coll"}
                      Card       c1   {:name "card1" :collection_id (:id coll)}
@@ -1200,21 +1198,23 @@
                                                (if (= (:entity_id instance) (:entity_id c1))
                                                  (throw (ex-info "Skip me" {}))
                                                  (extract-one model-name opts instance)))]
-              (is (logs-contain? #"Skipping Card \d+ because of an error extracting it"
-                                 (mt/with-log-messages-for-level ['metabase.models.serialization :warn]
-                                   (let [ser            (vec (serdes.extract/extract {:no-settings       true
-                                                                                      :no-data-model     true
-                                                                                      :continue-on-error true}))
-                                         {errors true
-                                          others false} (group-by #(instance? Exception %) ser)]
-                                     (is (= 1 (count errors)))
-                                     (is (= 3 (count others))))))))))
+              (is (= [["Card" (str (:id c1))]]
+                     (logs-extract #"Skipping (\w+) (\d+)"
+                                   (mt/with-log-messages-for-level ['metabase.models.serialization :warn]
+                                     (let [ser            (vec (serdes.extract/extract {:no-settings       true
+                                                                                        :no-data-model     true
+                                                                                        :continue-on-error true}))
+                                           {errors true
+                                            others false} (group-by #(instance? Exception %) ser)]
+                                       (is (= 1 (count errors)))
+                                       (is (= 3 (count others)))))))))))
         (testing "It's possible to skip a few errors during load"
           (let [ser     (vec (serdes.extract/extract {:no-settings   true
                                                       :no-data-model true}))
                 changed (change-ser ser {(:entity_id c2) {:collection_id "does-not-exist"}})]
-            (is (logs-contain? #"Skipping deserialization error"
-                               (mt/with-log-messages-for-level ['metabase-enterprise :warn]
-                                 (let [report (serdes.load/load-metabase! (ingestion-in-memory changed) {:continue-on-error true})]
-                                   (is (= 1 (count (:errors report))))
-                                   (is (= 3 (count (:seen report))))))))))))))
+            (is (= [["Failed to read file for Collection does-not-exist"]]
+                   (logs-extract #"Skipping deserialization error: (.*) \{.*\}$"
+                                 (mt/with-log-messages-for-level ['metabase-enterprise :warn]
+                                   (let [report (serdes.load/load-metabase! (ingestion-in-memory changed) {:continue-on-error true})]
+                                     (is (= 1 (count (:errors report))))
+                                     (is (= 3 (count (:seen report)))))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -1181,12 +1181,9 @@
                  (t2/select-one-fn select-target DashboardCard :entity_id (:entity_id dc3)))))))))
 
 (deftest continue-on-error-test
-  (let [change-ser    (fn [ser changes]
-                        (vec (for [entity ser
-                                   :let   [change (get changes (:entity_id entity))]]
-                               (if change
-                                 (merge entity change)
-                                 entity))))
+  (let [change-ser    (fn [ser changes] ;; kind of like left-join, but right side is indexed
+                        (vec (for [entity ser]
+                               (merge entity (get changes (:entity_id entity))))))
         logs-contain? (fn [msg-re logs]
                         (some #(re-find msg-re %)
                               (->> logs

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/serialization/jsonschema/1-0-1
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/serialization/jsonschema/1-0-1
@@ -10,6 +10,12 @@
   "type": "object",
   "required": ["event", "source", "duration", "success"],
   "properties": {
+    "event": {
+      "description": "Event name",
+      "type": "string",
+      "enum": ["serialization"],
+      "maxLength": 1024
+    },
     "direction": {
       "description": "Is it import or export",
       "type": "string"

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/serialization/jsonschema/1-0-1
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/serialization/jsonschema/1-0-1
@@ -1,0 +1,72 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Serialization operation",
+  "self": {
+    "vendor": "com.metabase",
+    "name": "database",
+    "format": "jsonschema",
+    "version": "1-0-1"
+  },
+  "type": "object",
+  "required": ["event", "source", "duration", "success"],
+  "properties": {
+    "direction": {
+      "description": "Is it import or export",
+      "type": "string"
+      "enum": ["import", "export"],
+      "maxLength": 6
+    },
+    "source": {
+      "description": "The way serialization was triggered",
+      "type": "string",
+      "enum": ["cli", "api"]
+    },
+    "duration_ms": {
+      "description": "Time in milliseconds it took to execute",
+      "type": "integer"
+    },
+    "success": {
+      "description": "If serialization succeeded or failed",
+      "type": "boolean"
+    },
+    "error_message": {
+      "description": "Why serialization failed",
+      "type": "string",
+      "maxLength": 1024
+    },
+    "count": {
+      "description": "Total count of serialized entities",
+      "type": "integer"
+    },
+    "error_count": {
+      "description": "Number of errors occured during serialization (if they were skipped)",
+      "type": "integer"
+    },
+    "models": {
+      "description": "Which models were imported",
+      "type": "string",
+      "maxLength": 1024
+    },
+    "collection": {
+      "description": "Which collections were exported",
+      "type": ["string", "null"],
+      "maxLength": 1024
+    },
+    "all_collections": {
+      "description": "If all collections were exported",
+      "type": "boolean"
+    },
+    "settings": {
+      "description": "If settings were exported",
+      "type": "boolean"
+    },
+    "field_values": {
+      "description": "If field values were exported",
+      "type": "boolean"
+    },
+    "secrets": {
+      "description": "If database secrets were included in export",
+      "type": "boolean"
+    }
+  }
+}

--- a/src/metabase/analytics/snowplow.clj
+++ b/src/metabase/analytics/snowplow.clj
@@ -45,7 +45,7 @@
    ::action        "1-0-0"
    ::embed_share   "1-0-0"
    ::llm_usage     "1-0-0"
-   ::serialization "1-0-0"
+   ::serialization "1-0-1"
    ::cleanup       "1-0-0"})
 
 (def ^:private event->schema

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -187,7 +187,7 @@
 
 (defn ^:command ^:requires-init import
   {:doc "Load serialized Metabase instance as created by the [[export]] command from directory `path`."
-   :arg-spec [[nil  "--skip-errors" "Do not break execution on errors."]]}
+   :arg-spec [["-e" "--continue-on-error" "Do not break execution on errors."]]}
   [path & options]
   (call-enterprise 'metabase-enterprise.serialization.cmd/v2-load! path (get-parsed-options #'import options)))
 
@@ -219,7 +219,7 @@
               ["-D" "--no-data-model"            "Do not export any data model entities; useful for subsequent exports."]
               ["-f" "--include-field-values"     "Include field values along with field metadata."]
               ["-s" "--include-database-secrets" "Include database connection details (in plain text; use caution)."]
-              [nil  "--skip-errors"              "Do not break execution on errors."]]}
+              ["-e" "--continue-on-error"        "Do not break execution on errors."]]}
   [path & options]
   (call-enterprise 'metabase-enterprise.serialization.cmd/v2-dump! path (get-parsed-options #'export options)))
 

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -186,7 +186,8 @@
   (call-enterprise 'metabase-enterprise.serialization.cmd/v1-load! path (get-parsed-options #'load options)))
 
 (defn ^:command ^:requires-init import
-  {:doc "Load serialized Metabase instance as created by the [[export]] command from directory `path`."}
+  {:doc "Load serialized Metabase instance as created by the [[export]] command from directory `path`."
+   :arg-spec [[nil  "--skip-errors" "Do not break execution on errors."]]}
   [path & options]
   (call-enterprise 'metabase-enterprise.serialization.cmd/v2-load! path (get-parsed-options #'import options)))
 
@@ -217,7 +218,8 @@
               ["-S" "--no-settings"              "Do not export settings.yaml"]
               ["-D" "--no-data-model"            "Do not export any data model entities; useful for subsequent exports."]
               ["-f" "--include-field-values"     "Include field values along with field metadata."]
-              ["-s" "--include-database-secrets" "Include database connection details (in plain text; use caution)."]]}
+              ["-s" "--include-database-secrets" "Include database connection details (in plain text; use caution)."]
+              [nil  "--skip-errors"              "Do not break execution on errors."]]}
   [path & options]
   (call-enterprise 'metabase-enterprise.serialization.cmd/v2-dump! path (get-parsed-options #'export options)))
 

--- a/src/metabase/logger.clj
+++ b/src/metabase/logger.clj
@@ -96,25 +96,26 @@
         (recur (.getParent logger)))))
 
 (defprotocol MakeAppender
-  (make-appender ^AbstractAppender [out ns-name layout]))
+  (make-appender ^AbstractAppender [out layout]))
 
 (extend-protocol MakeAppender
   java.io.File
-  (make-appender [^java.io.File out ns-name layout]
+  (make-appender [^java.io.File out layout]
     (.build
      (doto (FileAppender/newBuilder)
-       (.setName (str ns-name "-file"))
+       (.setName "shared-appender-file")
        (.setLayout layout)
        (.withFileName (.getPath out)))))
 
   java.io.OutputStream
-  (make-appender [^java.io.OutputStream out ns-name layout]
+  (make-appender [^java.io.OutputStream out layout]
     (.build
      (doto (OutputStreamAppender/newBuilder)
-       (.setName (str ns-name "-os"))
+       (.setName "shared-appender-os")
        (.setLayout layout)
        (.setTarget out)))))
 
+#_
 (defn for-ns
   "Create separate logger for a given namespace to fork out some logs."
   ^AutoCloseable [ns out & [{:keys [additive level]
@@ -122,7 +123,7 @@
                                     level    Level/INFO}}]]
   (let [config        (configuration)
         parent-logger (effective-ns-logger ns)
-        appender      (make-appender out (logger-name ns) (find-logger-layout parent-logger))
+        appender      (make-appender out (find-logger-layout parent-logger))
         logger        (LoggerConfig. (logger-name ns) level additive)]
     (.start appender)
     (.addAppender config appender)
@@ -134,6 +135,41 @@
       (close [_]
         (let [^AbstractConfiguration config (configuration)]
           (.removeLogger config (.getName logger))
+          (.stop appender)
+          ;; this method is only present in AbstractConfiguration
+          (.removeAppender config (.getName appender))
+          (.updateLoggers (context)))))))
+
+(defn add-ns-logger
+  "Add a logger for a given namespace to the configuration."
+  [ns appender level additive]
+  (let [logger-name (str ns)
+        ns-logger   (LoggerConfig. logger-name level additive)]
+    (.addAppender ns-logger appender level nil)
+    (.addLogger (configuration) logger-name ns-logger)
+    ns-logger))
+
+(defn for-ns
+  "Create separate logger for a given namespace(s) to fork out some logs."
+  ^AutoCloseable [out nses & [{:keys [additive level]
+                               :or   {additive true
+                                      level    Level/INFO}}]]
+  (let [nses     (if (vector? nses) nses [nses])
+        config   (configuration)
+        parents  (mapv effective-ns-logger nses)
+        appender (make-appender out (find-logger-layout (first parents)))
+        loggers  (vec (for [ns nses]
+                        (add-ns-logger ns appender level additive)))]
+    (.start appender)
+    (.addAppender config appender)
+
+    (.updateLoggers (context))
+
+    (reify AutoCloseable
+      (close [_]
+        (let [^AbstractConfiguration config (configuration)]
+          (doseq [logger loggers]
+            (.removeLogger config (.getName ^LoggerConfig logger)))
           (.stop appender)
           ;; this method is only present in AbstractConfiguration
           (.removeAppender config (.getName appender))

--- a/src/metabase/logger.clj
+++ b/src/metabase/logger.clj
@@ -115,31 +115,6 @@
        (.setLayout layout)
        (.setTarget out)))))
 
-#_
-(defn for-ns
-  "Create separate logger for a given namespace to fork out some logs."
-  ^AutoCloseable [ns out & [{:keys [additive level]
-                             :or   {additive true
-                                    level    Level/INFO}}]]
-  (let [config        (configuration)
-        parent-logger (effective-ns-logger ns)
-        appender      (make-appender out (find-logger-layout parent-logger))
-        logger        (LoggerConfig. (logger-name ns) level additive)]
-    (.start appender)
-    (.addAppender config appender)
-    (.addAppender logger appender (.getLevel logger) nil)
-    (.addLogger config (.getName logger) logger)
-    (.updateLoggers (context))
-
-    (reify AutoCloseable
-      (close [_]
-        (let [^AbstractConfiguration config (configuration)]
-          (.removeLogger config (.getName logger))
-          (.stop appender)
-          ;; this method is only present in AbstractConfiguration
-          (.removeAppender config (.getName appender))
-          (.updateLoggers (context)))))))
-
 (defn add-ns-logger
   "Add a logger for a given namespace to the configuration."
   [ns appender level additive]

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -377,7 +377,7 @@
     (extract-one model opts instance)
     (catch Exception e
       (when-not (or (:skip (ex-data e))
-                    (:skip-errors opts))
+                    (:continue-on-error opts))
         (throw (ex-info (format "Exception extracting %s %s" model (:id instance))
                         {:model     model
                          :id        (:id instance)

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -370,7 +370,7 @@
   (fn [model-name _opts _instance] model-name))
 
 (defn log-and-extract-one
-  "Extracts a single entity; will replace `extract-one` as public interface once overrides are gone."
+  "Extracts a single entity; will replace `extract-one` as public interface once `extract-one` overrides are gone."
   [model opts instance]
   (log/infof "Extracting %s %s" model (:id instance))
   (try

--- a/src/metabase/util/malli/schema.clj
+++ b/src/metabase/util/malli/schema.clj
@@ -406,7 +406,7 @@
                   true m)))])
 
 (def File
-  "Schema for a file coming in HTTP from multipart/form-data"
+  "Schema for a file coming in HTTP request from multipart/form-data"
   [:map {:closed true}
    [:content-type string?]
    [:filename string?]

--- a/src/metabase/util/malli/schema.clj
+++ b/src/metabase/util/malli/schema.clj
@@ -404,3 +404,11 @@
                       (reduced false)
                       true))
                   true m)))])
+
+(def File
+  "Schema for a file coming in HTTP from multipart/form-data"
+  [:map {:closed true}
+   [:content-type string?]
+   [:filename string?]
+   [:size int?]
+   [:tempfile (InstanceOfClass java.io.File)]])

--- a/test/metabase/api/common/openapi_test.clj
+++ b/test/metabase/api/common/openapi_test.clj
@@ -6,6 +6,7 @@
    [metabase.api.common :as api]
    [metabase.api.common.openapi :as openapi]
    [metabase.api.routes :as routes]
+   [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]))
 
 ;;; inner helpers
@@ -37,9 +38,11 @@
 
 (api/defendpoint ^:multipart POST "/:id/upload"
   "docstring"
-  [id :as {raw-params :params}]
-  {id ms/PositiveInt}
-  {:data (get-in raw-params ["file" :tempfile])})
+  [id :as {{:strs [file]} :multipart-params}]
+  {id   ms/PositiveInt
+   file (mu/with ms/File
+                 {:description "File to upload"})}
+  {:id id :data file})
 
 (api/defendpoint POST "/export"
   "docstring"
@@ -97,14 +100,17 @@
                           :schema   {:$ref "#/components/schemas/metabase.lib.schema.common~1non-blank-string"}}]}}
           (#'openapi/defendpoint->path-item nil "/{id}" #'POST_:id)))
   (is (=? {:post
-           {:parameters [{:in          :path
-                          :name        :id
-                          :required    true
-                          :description some?
-                          :schema      {:type    "integer"
-                                        :minimum 1}}]
-            ;; TODO: no :requestBody since we did not spec anything, would be nice to be able to spec files
-            }}
+           {:parameters  [{:in          :path
+                           :name        :id
+                           :required    true
+                           :description some?
+                           :schema      {:type    "integer"
+                                         :minimum 1}}]
+            :requestBody {:content {"multipart/form-data"
+                                    {:schema
+                                     {:type       "object"
+                                      :properties {:file {}}
+                                      :required   [:file]}}}}}}
           (#'openapi/defendpoint->path-item nil "/{id}" #'POST_:id_upload)))
   (is (=? {:post
            {:parameters [{:in       :query

--- a/test/metabase/cmd_test.clj
+++ b/test/metabase/cmd_test.clj
@@ -30,7 +30,10 @@
    (fn []
      (testing "with no options"
        (is (= '(metabase-enterprise.serialization.cmd/v2-load! "/path/" {})
-              (cmd/import "/path/")))))))
+              (cmd/import "/path/"))))
+     (testing "with options"
+       (is (= '(metabase-enterprise.serialization.cmd/v2-load! "/path/" {:skip-errors true})
+              (cmd/import "/path/" "--skip-errors")))))))
 
 (deftest dump-command-test
   (do-with-captured-call-enterprise-calls!
@@ -69,4 +72,7 @@
        {:no-settings true}
 
        ["--no-data-model"]
-       {:no-data-model true}))))
+       {:no-data-model true}
+
+       ["--skip-errors"]
+       {:skip-errors true}))))

--- a/test/metabase/cmd_test.clj
+++ b/test/metabase/cmd_test.clj
@@ -32,8 +32,8 @@
        (is (= '(metabase-enterprise.serialization.cmd/v2-load! "/path/" {})
               (cmd/import "/path/"))))
      (testing "with options"
-       (is (= '(metabase-enterprise.serialization.cmd/v2-load! "/path/" {:skip-errors true})
-              (cmd/import "/path/" "--skip-errors")))))))
+       (is (= '(metabase-enterprise.serialization.cmd/v2-load! "/path/" {:continue-on-error true})
+              (cmd/import "/path/" "--continue-on-error")))))))
 
 (deftest dump-command-test
   (do-with-captured-call-enterprise-calls!
@@ -74,5 +74,8 @@
        ["--no-data-model"]
        {:no-data-model true}
 
-       ["--skip-errors"]
-       {:skip-errors true}))))
+       ["--continue-on-error"]
+       {:continue-on-error true}
+
+       ["-e"]
+       {:continue-on-error true}))))

--- a/test/metabase/logger_test.clj
+++ b/test/metabase/logger_test.clj
@@ -63,19 +63,34 @@
   (testing "logger/for-ns works properly"
     (let [f (io/file (System/getProperty "java.io.tmpdir") (mt/random-name))]
       (try
-        (with-open [_ (logger/for-ns 'metabase.logger-test f {:additive false})]
+        (with-open [_ (logger/for-ns f 'metabase.logger-test {:additive false})]
           (log/info "just a test"))
-        (is (=? #".*just a test\n"
-                (slurp f)))
+        (is (=? [#".*just a test$"]
+                (line-seq (io/reader f))))
         (finally
           (when (.exists f)
             (io/delete-file f)))))
     (let [baos (java.io.ByteArrayOutputStream.)]
-      (with-open [_ (logger/for-ns 'metabase.logger-test baos {:additive false})]
+      (with-open [_ (logger/for-ns baos 'metabase.logger-test {:additive false})]
         (log/info "just a test"))
       (log/info "this line is not going into our stream")
-      (let [s (.toString baos "UTF-8")]
-        (testing "We catched the line we needed"
-          (is (=? #".*just a test\n" s)))
-        (testing "Only wrapped logging is catched"
-          (is (= 1 (count (re-seq #"\n" s)))))))))
+      (testing "We catched the line we needed and did not catch the other one"
+        (is (=? [#".*just a test$"]
+                (line-seq (io/reader (.toByteArray baos))))))))
+
+  (testing "We can capture few separate namespaces"
+    (let [f (io/file (System/getProperty "java.io.tmpdir") (mt/random-name))]
+      (try
+        (with-open [_ (logger/for-ns f ['metabase.logger-test
+                                        'metabase.unknown]
+                                     {:additive false})]
+          (log/info "just a test")
+          (log/log 'metabase.unknown :info nil "separate test")
+          (testing "Check that `for-ns` will skip non-specified namespaces"
+            (log/log 'metabase.unknown2 :info nil "this one going into standard log")))
+        (is (=? [#".*just a test$"
+                 #".*separate test$"]
+                (line-seq (io/reader f))))
+        (finally
+          (when (.exists f)
+            (io/delete-file f)))))))


### PR DESCRIPTION
Fixes #45371

It became considerably bigger than I expected, mostly because I had to improve some things around how logs are handled (turned out that I forgot about logs from `metabase.models.serialization` when doing API), how OpenAPI definitions are generated (so now we can type files in there!).

Also "extract everything" and "extract only parts" are going through quite different code paths and we'll have to handle that - but a bit later, since this will conflict a lot with `serdes-spec` branch.