### PR TITLE
fix(admin/performance): Ensure that the tab's title (e.g. Database caching) and 'Performance' are visible in document title

### DIFF
--- a/frontend/src/metabase/admin/routes.jsx
+++ b/frontend/src/metabase/admin/routes.jsx
@@ -162,12 +162,21 @@ const getRoutes = (store, CanAccessSettings, IsAdmin) => (
         path="performance"
         component={createAdminRouteGuard("performance")}
       >
-        <IndexRoute title={t`Performance`} path="" component={PerformanceApp} />
-        <Route
-          title={t`Model persistence`}
-          path={PerformanceTabId.Models}
-          component={() => <PerformanceApp tabId={PerformanceTabId.Models} />}
-        />
+        <Route title={t`Performance`}>
+          <IndexRedirect to={PerformanceTabId.Databases} />
+          <Route
+            title={t`Database caching`}
+            path={PerformanceTabId.Databases}
+            component={() => (
+              <PerformanceApp tabId={PerformanceTabId.Databases} />
+            )}
+          />
+          <Route
+            title={t`Model persistence`}
+            path={PerformanceTabId.Models}
+            component={() => <PerformanceApp tabId={PerformanceTabId.Models} />}
+          />
+        </Route>
       </Route>
       <Route
         path="tools"


### PR DESCRIPTION
Closes #46603

### Description

Adds the correct document title

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/54b00dca-016c-460b-9e49-9c19d98edf88.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/ead3ef8b-072e-4c86-a160-1c9d40ce7a63.png)

### How to verify

Visit Admin / Performance and look at the title in your browser tab