### PR TITLE
fix downloads e2e flakes

### DIFF
--- a/e2e/support/helpers/e2e-downloads-helpers.ts
+++ b/e2e/support/helpers/e2e-downloads-helpers.ts
@@ -23,6 +23,7 @@ interface DownloadAndAssertParams {
   publicUuid?: string;
   dashboardId?: number;
   enableFormatting?: boolean;
+  dismissStatus?: boolean;
 }
 
 /**
@@ -42,6 +43,7 @@ export function downloadAndAssert(
     downloadMethod = "POST",
     isDashboard,
     enableFormatting = true,
+    dismissStatus = true,
   }: DownloadAndAssertParams,
   callback: (data: unknown) => void,
 ) {
@@ -97,6 +99,10 @@ export function downloadAndAssert(
       fileType === "xlsx" && Object.assign(req, { encoding: "binary" });
 
       cy.request(req).then(({ body }) => {
+        if (dismissStatus) {
+          dismissDownloadStatus();
+        }
+
         const { SheetNames, Sheets } = xlsx.read(body, {
           // See the full list of Parsing options: https://github.com/SheetJS/sheetjs#parsing-options
           type: "binary",

--- a/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
@@ -27,7 +27,6 @@ import {
   setEmbeddingParameter,
   assertEmbeddingParameter,
   multiAutocompleteInput,
-  dismissDownloadStatus,
   createDashboardWithTabs,
   createQuestion,
 } from "e2e/support/helpers";
@@ -538,7 +537,6 @@ describe("scenarios > embedding > dashboard parameters", () => {
         assertSheetRowsCount(54)(sheet);
       },
     );
-    dismissDownloadStatus();
   });
 
   it("should send 'X-Metabase-Client' header for api requests", () => {

--- a/e2e/test/scenarios/permissions/download-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/download-permissions.cy.spec.js
@@ -207,7 +207,7 @@ describeEE("scenarios > admin > permissions > data > downloads", () => {
         visitQuestion(id);
 
         downloadAndAssert(
-          { fileType: "xlsx", questionId: id },
+          { fileType: "xlsx", questionId: id, dismissStatus: false },
           assertSheetRowsCount(18760),
         );
       });

--- a/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
+++ b/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
@@ -155,7 +155,8 @@ describe("scenarios > question > download", () => {
         cy.findByTestId("legend-caption").realHover();
       });
 
-      assertOrdersExport(18760);
+      // In CI agents after downloads Cypress gets stuck for a while so the downloads status gets closed by timeout
+      assertOrdersExport(18760, false);
 
       editDashboard();
 
@@ -179,7 +180,8 @@ describe("scenarios > question > download", () => {
         cy.findByTestId("legend-caption").realHover();
       });
 
-      assertOrdersExport(1);
+      // In CI agents after downloads Cypress gets stuck for a while so the downloads status gets closed by timeout
+      assertOrdersExport(1, false);
     });
 
     it("should allow downloading parameterized cards opened from dashboards as a user with no self-service permission (metabase#20868)", () => {
@@ -391,7 +393,7 @@ describeWithSnowplow("[snowplow] scenarios > dashboard", () => {
   });
 });
 
-function assertOrdersExport(length) {
+function assertOrdersExport(length, dismissStatus = true) {
   downloadAndAssert(
     {
       fileType: "xlsx",
@@ -399,6 +401,7 @@ function assertOrdersExport(length) {
       dashcardId: ORDERS_DASHBOARD_DASHCARD_ID,
       dashboardId: ORDERS_DASHBOARD_ID,
       isDashboard: true,
+      dismissStatus,
     },
     sheet => {
       expect(sheet["A1"].v).to.eq("ID");

--- a/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
+++ b/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
@@ -30,7 +30,6 @@ import {
   startNewQuestion,
   visitDashboard,
   visualize,
-  dismissDownloadStatus,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -90,8 +89,6 @@ describe("scenarios > question > download", () => {
           accessed_via: "internal",
           export_type: fileType,
         });
-
-        dismissDownloadStatus();
       });
     });
   });
@@ -135,8 +132,6 @@ describe("scenarios > question > download", () => {
           expect(sheet["A2"].v).to.eq("USD 39.72");
         },
       );
-
-      dismissDownloadStatus();
 
       downloadAndAssert(
         {
@@ -258,8 +253,6 @@ describe("scenarios > question > download", () => {
                 assertSheetRowsCount(1)(sheet);
               },
             );
-
-            dismissDownloadStatus();
           });
         });
       });

--- a/e2e/test/scenarios/sharing/public-question.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-question.cy.spec.js
@@ -10,7 +10,6 @@ import {
   createPublicQuestionLink,
   modal,
   openNativeEditor,
-  dismissDownloadStatus,
 } from "e2e/support/helpers";
 
 const { PEOPLE } = SAMPLE_DATABASE;
@@ -92,7 +91,6 @@ describe("scenarios > public > question", () => {
           { fileType: "xlsx", questionId: id, publicUuid },
           assertSheetRowsCount(5),
         );
-        dismissDownloadStatus();
       });
     });
   });


### PR DESCRIPTION
Cypress may get stuck for a few seconds after downloading a file which happens frequently on dashboards. So the step that closed successfull download status failed because it gets hidden by a timeout sooner than Cypress gets unstuck.

Stress test:
https://github.com/metabase/metabase/actions/runs/10294844338