### PR TITLE
Fix pie e2e flake

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
@@ -112,6 +112,9 @@ describe("scenarios > visualizations > pie chart", () => {
       .findByText("TOTAL")
       .should("be.visible");
 
+    // In CI the command below triggers earlier than the attempt to find "TOTAL" text above which leads to fail
+    cy.wait(100);
+
     cy.findAllByTestId("legend-item").eq(0).realHover();
 
     cy.findByTestId("query-visualization-root")

--- a/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
@@ -7,6 +7,7 @@ import {
   tableHeaderClick,
   pieSlices,
   leftSidebar,
+  chartPathWithFillColor,
 } from "e2e/support/helpers";
 
 const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -112,10 +113,7 @@ describe("scenarios > visualizations > pie chart", () => {
       .findByText("TOTAL")
       .should("be.visible");
 
-    // In CI the command below triggers earlier than the attempt to find "TOTAL" text above which leads to fail
-    cy.wait(100);
-
-    cy.findAllByTestId("legend-item").eq(0).realHover();
+    chartPathWithFillColor("#F9D45C").trigger("mousemove");
 
     cy.findByTestId("query-visualization-root")
       .findByText("DOOHICKEY THE QUICK BROWN FOX J…")

--- a/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
@@ -82,6 +82,7 @@ describe("scenarios > visualizations > pie chart", () => {
       cy.findByText("Show total").click();
     });
 
+    ensureEchartsContainerHasSvg();
     cy.findByTestId("query-visualization-root").within(() => {
       cy.findByText("TOTAL").should("be.visible");
     });
@@ -111,7 +112,7 @@ describe("scenarios > visualizations > pie chart", () => {
     // Ensure chart renders before hovering the legend item
     ensureEchartsContainerHasSvg();
     cy.findByTestId("query-visualization-root").within(() => {
-      cy.findByText("TOTAL");
+      cy.findByText("TOTAL").should("be.visible");
     });
 
     cy.findAllByTestId("legend-item").eq(0).realHover();
@@ -123,6 +124,7 @@ describe("scenarios > visualizations > pie chart", () => {
 });
 
 function ensurePieChartRendered(rows, totalValue) {
+  ensureEchartsContainerHasSvg();
   cy.findByTestId("query-visualization-root").within(() => {
     // detail
     cy.findByText("TOTAL").should("be.visible");

--- a/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
@@ -7,7 +7,6 @@ import {
   tableHeaderClick,
   pieSlices,
   leftSidebar,
-  ensureEchartsContainerHasSvg,
 } from "e2e/support/helpers";
 
 const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -82,7 +81,6 @@ describe("scenarios > visualizations > pie chart", () => {
       cy.findByText("Show total").click();
     });
 
-    ensureEchartsContainerHasSvg();
     cy.findByTestId("query-visualization-root").within(() => {
       cy.findByText("TOTAL").should("be.visible");
     });
@@ -110,21 +108,19 @@ describe("scenarios > visualizations > pie chart", () => {
     });
 
     // Ensure chart renders before hovering the legend item
-    ensureEchartsContainerHasSvg();
-    cy.findByTestId("query-visualization-root").within(() => {
-      cy.findByText("TOTAL").should("be.visible");
-    });
+    cy.findByTestId("query-visualization-root")
+      .findByText("TOTAL")
+      .should("be.visible");
 
     cy.findAllByTestId("legend-item").eq(0).realHover();
 
-    cy.findByTestId("query-visualization-root").within(() => {
-      cy.findByText("DOOHICKEY THE QUICK BROWN FOX J…");
-    });
+    cy.findByTestId("query-visualization-root")
+      .findByText("DOOHICKEY THE QUICK BROWN FOX J…")
+      .should("be.visible");
   });
 });
 
 function ensurePieChartRendered(rows, totalValue) {
-  ensureEchartsContainerHasSvg();
   cy.findByTestId("query-visualization-root").within(() => {
     // detail
     cy.findByText("TOTAL").should("be.visible");

--- a/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
@@ -7,6 +7,7 @@ import {
   tableHeaderClick,
   pieSlices,
   leftSidebar,
+  ensureEchartsContainerHasSvg,
 } from "e2e/support/helpers";
 
 const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -108,6 +109,7 @@ describe("scenarios > visualizations > pie chart", () => {
     });
 
     // Ensure chart renders before hovering the legend item
+    ensureEchartsContainerHasSvg();
     cy.findByTestId("query-visualization-root").within(() => {
       cy.findByText("TOTAL");
     });


### PR DESCRIPTION
Stress test:
https://github.com/metabase/metabase/actions/runs/10294814547

The flake is caused by unexpected behavior when the second command executes before the first one. The hover action repalces "TOTAL" text with the value of a slice. Even 100ms cy.wait did not help there.

```
    // 1
    cy.findByTestId("query-visualization-root").within(() => {
      cy.findByText("TOTAL");
    });
    
    // 2
    cy.findAllByTestId("legend-item").eq(0).realHover();
```