### PR TITLE
fix: uuid join conditions should not cast

### DIFF
--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -1306,27 +1306,32 @@
         expr
         [:lower expr]))))
 
+(defn- uuid-field?
+  [x]
+  (and (mbql.u/mbql-clause? x)
+       (isa? (or (:effective-type (get x 2))
+                 (:base-type (get x 2)))
+             :type/UUID)))
+
 (mu/defn- maybe-cast-uuid-for-equality
   "For := and :!=. Comparing UUID fields against non-uuid values requires casting."
   [driver field arg]
-  (if (and (isa? (or (:effective-type (get field 2))
-                     (:base-type (get field 2)))
-                 :type/UUID)
-           ;; If we could not convert the arg to a UUID then we have to cast the Field.
-           ;; This will not hit indexes, but then we're passing an arg that can only be compared textually.
-           (not (uuid? (->honeysql driver arg)))
-           ;; Check for inlined values
-           (not (= (:database-type (h2x/type-info (->honeysql driver arg))) "uuid")))
-    [::cast field "varchar"]
-    field))
+  (if (and (uuid-field? field)
+             ;; If the arg is a uuid we are happy especially for joins (#46558)
+             (not (uuid-field? arg))
+             ;; If we could not convert the arg to a UUID then we have to cast the Field.
+             ;; This will not hit indexes, but then we're passing an arg that can only be compared textually.
+             (not (uuid? (->honeysql driver arg)))
+             ;; Check for inlined values
+             (not (= (:database-type (h2x/type-info (->honeysql driver arg))) "uuid")))
+      [::cast field "varchar"]
+      field))
 
 (mu/defn- maybe-cast-uuid-for-text-compare
   "For :contains, :starts-with, and :ends-with.
    Comparing UUID fields against with these operations requires casting as the right side will have `%` for `LIKE` operations."
   [field]
-  (if (isa? (or (:effective-type (get field 2))
-                (:base-type (get field 2)))
-            :type/UUID)
+  (if (uuid-field? field)
     [::cast field "varchar"]
     field))
 

--- a/test/metabase/driver/sql_jdbc_test.clj
+++ b/test/metabase/driver/sql_jdbc_test.clj
@@ -204,6 +204,7 @@
             (= expected
                (mt/rows (qp/process-query (assoc-in model-query [:query :filter] filt))))
             [[uuid]] [:= (:field_ref col-metadata) [:value (str uuid) {:base_type :type/UUID}]]
+            [[uuid]] [:= (:field_ref col-metadata) (:field_ref col-metadata)]
             [[uuid]] [:= (:field_ref col-metadata) (str uuid)]
             [[uuid]] [:!= (:field_ref col-metadata) (str (random-uuid))]
             [[uuid]] [:starts-with (:field_ref col-metadata) (str uuid)]


### PR DESCRIPTION
Fixes: #46558

In #45575 we introduced casting uuid fields for drilldowns.

However we failed to include a check that the rhs was itself another field of uuid type and so no casting should occur. This broke joins on models when the database_type of the field may not be known.
