### PR TITLE
Style download result popover on dark theme

### DIFF
--- a/frontend/src/metabase/query_builder/components/QueryDownloadPopover/DownloadButton.module.css
+++ b/frontend/src/metabase/query_builder/components/QueryDownloadPopover/DownloadButton.module.css
@@ -4,14 +4,16 @@
 
 .DownloadButton {
   cursor: pointer;
+  border: 1px solid var(--mb-color-border);
   border-radius: 0.5rem;
-  background: var(--mb-color-bg-white);
-  color: var(--mb-color-text-dark);
+  background: var(--mb-color-background);
+  color: var(--mb-color-text-primary);
 }
 
 .DownloadButton:hover {
-  background: var(--mb-color-brand);
-  color: var(--mb-color-text-white);
+  border-color: var(--mb-color-background-hover);
+  background: var(--mb-color-background-hover);
+  color: var(--mb-color-text-hover);
 
   & .UnformattedTextInfo {
     visibility: visible;


### PR DESCRIPTION
This is a follow up to #46491. Reported [on Slack](https://metaboat.slack.com/archives/C063Q3F1HPF/p1723116490598469?thread_ts=1722869146.028559&cid=C063Q3F1HPF)

### Description

Style the download results popover in dark theme.

### How to verify

1. Go to a dashboard
1. Click sharing > Embed
1. Select Static embedding
1. Select Look and Feel tab
1. Select dark mode and click preview

### Demo

#### After
![Screenshot 2024-08-08 at 8 39 30 PM](https://github.com/user-attachments/assets/30ea1a9e-5f5a-4046-8463-1f413b7920b7)

#### Before
![Screenshot 2024-08-08 at 8 39 41 PM](https://github.com/user-attachments/assets/f2a46a4b-67a9-42bf-b382-4e0d7e3192a7)

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~ I used to try to add loki tests for this, no matter what, I couldn't get the dashboard action to show up in loki.
