### PR TITLE
dx: get rid of most of CSP errors in dev mode

### DIFF
--- a/frontend/src/metabase/dev.js
+++ b/frontend/src/metabase/dev.js
@@ -1,1 +1,13 @@
 import "cljs/metabase.util.devtools";
+
+/**
+ * setNonce is required for react-remove-scroll which adds style and can handle
+ * nonce but the method we use to set nonce is not compatible with
+ * react-remove-scroll it expects __webpack_nonce__ to be defined, when we
+ * generate it at BE and put directly into html file. `get-nonce` is used inside
+ * react-remove-scroll to get nonce, so we put it manually here.
+ * react-remove-scroll is a dependency of mantine v6
+ */
+import { setNonce } from "get-nonce";
+
+setNonce(window.MetabaseNonce);

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -29,7 +29,13 @@ import {
 } from "metabase/query_builder/selectors";
 import { getIsEmbeddingSdk } from "metabase/selectors/embed";
 import { EmotionCacheProvider } from "metabase/styled-components/components/EmotionCacheProvider";
-import { Box, Button as UIButton, Icon, DelayGroup } from "metabase/ui";
+import {
+  ThemeProvider,
+  Box,
+  Button as UIButton,
+  Icon,
+  DelayGroup,
+} from "metabase/ui";
 import {
   getTableCellClickedObject,
   getTableHeaderClickedObject,
@@ -333,27 +339,29 @@ class TableInteractive extends Component {
 
     const content = (
       <EmotionCacheProvider>
-        <div style={{ display: "flex" }} ref={this.onMeasureHeaderRender}>
-          {cols.map((column, columnIndex) => (
-            <div className="fake-column" key={"column-" + columnIndex}>
-              {this.tableHeaderRenderer({
-                columnIndex,
-                rowIndex: 0,
-                key: "header",
-                style: {},
-                isVirtual: true,
-              })}
-              {pickRowsToMeasure(rows, columnIndex).map(rowIndex =>
-                this.cellRenderer({
-                  rowIndex,
+        <ThemeProvider>
+          <div style={{ display: "flex" }} ref={this.onMeasureHeaderRender}>
+            {cols.map((column, columnIndex) => (
+              <div className="fake-column" key={"column-" + columnIndex}>
+                {this.tableHeaderRenderer({
                   columnIndex,
-                  key: "row-" + rowIndex,
+                  rowIndex: 0,
+                  key: "header",
                   style: {},
-                }),
-              )}
-            </div>
-          ))}
-        </div>
+                  isVirtual: true,
+                })}
+                {pickRowsToMeasure(rows, columnIndex).map(rowIndex =>
+                  this.cellRenderer({
+                    rowIndex,
+                    columnIndex,
+                    key: "row-" + rowIndex,
+                    style: {},
+                  }),
+                )}
+              </div>
+            ))}
+          </div>
+        </ThemeProvider>
       </EmotionCacheProvider>
     );
 

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.styled.tsx
@@ -28,6 +28,9 @@ interface TableDraggableProps {
   enableCustomUserSelectHack?: boolean;
 }
 
+// this wrapper adds prop-types warning because of the nature of emotion component
+// TableDraggable doesn't allow className, style to be passed, but emotion does it
+// TODO: drop this style definition and maybe move styles to the global stylesheet
 export const TableDraggable = styled(Draggable)<TableDraggableProps>`
   ${props =>
     props.enableCustomUserSelectHack &&

--- a/package.json
+++ b/package.json
@@ -241,6 +241,7 @@
     "fetch-mock": "^9.11.0",
     "fetch-mock-jest": "^1.5.1",
     "fork-ts-checker-webpack-plugin": "^9.0.2",
+    "get-nonce": "^1.0.1",
     "glob": "^7.1.1",
     "html-webpack-plugin": "5.5.0",
     "http-server": "^14.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12378,7 +12378,7 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1, get-intrinsic@
     has-symbols "^1.0.3"
     hasown "^2.0.0"
 
-get-nonce@^1.0.0:
+get-nonce@^1.0.0, get-nonce@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/get-nonce/-/get-nonce-1.0.1.tgz#fdf3f0278073820d2ce9426c18f07481b1e0cdf3"
   integrity sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/45698

### Description

Get rid of CSP errors.

There are at least 3 reasons of CSP errors in dev mode:
1. `TableInteractive` component used `EmotionCacheProvider` without `ThemeProvider` to measure sizes, so `ThemeProvider` created its own cache, which didn't know about `nonce`
2. `mantine` -> `react-remove-scroll` uses `get-nonce` to get nonce from the [passed webpack variable](https://webpack.js.org/guides/csp/#examples), but we don't know `nonce` when the server starts, so we needed to set nonce manually for that lib.
3. `shadow-cljs` package, it puts a script without nonce into DOM and I didn't find a way to specify one. I hope @bshepherdson will be able to help with it. Meanwhile, I [started discussion](https://github.com/thheller/shadow-cljs/discussions/1199)


### How to verify

open app in a dev mode, go to any question with table interactive - there shouldn't be any error

### Before


https://github.com/user-attachments/assets/38a0ba29-1390-4af3-9c98-eeaf318c9cdf



### After
https://github.com/user-attachments/assets/4fc5b668-4d95-4cb1-afbe-15dae3d3197d
