### PR TITLE
perf: Use database-id instead of database object in memoizing calls to driver/supports?

### DIFF
--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -248,7 +248,10 @@
         false))))
 
 (def ^:private memoized-supports?*
-  (mdb/memoize-for-application-db supports?*))
+  (memoize/memo
+   (-> supports?*
+       (vary-meta assoc ::memoize/args-fn (fn [[driver feature database]]
+                                            [driver feature (mdb/unique-identifier) (:id database) (:updated_at database)])))))
 
 (defn supports?
   "A defensive wrapper around [[database-supports?]]. It adds logging, caching, and error handling to avoid crashing the app


### PR DESCRIPTION
When testing locally, I've noticed that the memorized calls to `metabase.driver.util/supports?*` are very often recomputed even if invoked against the same database. This can be explained by the fact that the whole `database` object is used for memorization, and that object seems to change often in some unrelated fields. The diff between two database objects returns something like this:

```clj
--- Contents:
  0. {:lib/methods {:escape-alias #function[clojure.core/partial/fn--5908]}}
  1. {:lib/methods {:escape-alias #function[clojure.core/partial/fn--5908]}}
```

The proposed change caches the calls to `supports?*` based on the unique database identifier rather than the whole object. This:
1. Drastically improves cache hit rate.
2. Significantly improves the performance of cache hits since hashing and equality of full `database` maps was costly.