### PR TITLE
Include function name in generated lambda name when using malli/defn

### DIFF
--- a/src/metabase/util/malli/defn.clj
+++ b/src/metabase/util/malli/defn.clj
@@ -86,6 +86,7 @@
   to preserve them if you specify them manually. We can fix this in the future."
   [& [fn-name :as fn-tail]]
   (let [parsed           (mu.fn/parse-fn-tail fn-tail)
+        cosmetic-name    (gensym (munge (str fn-name)))
         {attr-map :meta} parsed
         attr-map         (merge
                           {:arglists (list 'quote (deparameterized-arglists parsed))
@@ -96,13 +97,13 @@
     (if-not instrument?
       `(def ~(vary-meta fn-name merge attr-map)
          ~docstring
-         ~(mu.fn/deparameterized-fn-form parsed))
+         ~(mu.fn/deparameterized-fn-form parsed cosmetic-name))
       `(def ~(vary-meta fn-name merge attr-map)
          ~docstring
          ~(macros/case
             :clj  (let [error-context {:fn-name (list 'quote fn-name)}]
-                    (mu.fn/instrumented-fn-form error-context parsed))
-            :cljs (mu.fn/deparameterized-fn-form parsed))))))
+                    (mu.fn/instrumented-fn-form error-context parsed cosmetic-name))
+            :cljs (mu.fn/deparameterized-fn-form parsed cosmetic-name))))))
 
 (defmacro defn-
   "Same as defn, but creates a private def."

--- a/src/metabase/util/malli/fn.clj
+++ b/src/metabase/util/malli/fn.clj
@@ -139,8 +139,8 @@
     (deparameterized-fn-form (parse-fn-tail '[:- :int [x :- :int] (inc x)]))
     ;; =>
     (fn [x] (inc x))"
-  [parsed]
-  `(core/fn ~@(deparameterized-fn-tail parsed)))
+  [parsed & [fn-name]]
+  `(core/fn ~@(when fn-name [fn-name]) ~@(deparameterized-fn-tail parsed)))
 
 (def ^:dynamic *enforce*
   "Whether [[validate-input]] and [[validate-output]] should validate things or not. In Cljc code, you can
@@ -293,8 +293,8 @@
 
     (mc/-instrument {:schema [:=> [:cat :int :any] :any]}
                     (fn [x y] (+ 1 2)))"
-  [error-context parsed]
-  `(let [~'&f ~(deparameterized-fn-form parsed)]
+  [error-context parsed & [fn-name]]
+  `(let [~'&f ~(deparameterized-fn-form parsed fn-name)]
      (core/fn ~@(instrumented-fn-tail error-context (fn-schema parsed)))))
 
 ;; ------------------------------ Skipping Namespace Enforcement in prod ------------------------------


### PR DESCRIPTION
This is a QOL change that makes functions defined via `mu/defn` distinguishable in stack traces and profiles. E.g., the profile before:

<img width="874" alt="image" src="https://github.com/user-attachments/assets/a2ae0759-ba2b-48cc-b5cb-e5510816571a">

After:

<img width="862" alt="image" src="https://github.com/user-attachments/assets/2bf5a4e7-8f94-40d6-96e7-58c43d2e9b29">