### PR TITLE
Safely open in a new tab for a subpath scenario

### DIFF
--- a/frontend/src/metabase/browse/components/ModelsTable.tsx
+++ b/frontend/src/metabase/browse/components/ModelsTable.tsx
@@ -213,7 +213,7 @@ const TBodyRow = ({
         const subpathSafeUrl = Urls.getSubpathSafeUrl(url);
 
         if ((e.ctrlKey || e.metaKey) && e.button === 0) {
-          window.open(subpathSafeUrl, "_blank");
+          Urls.openInNewTab(subpathSafeUrl);
         } else {
           dispatch(push(url));
         }

--- a/frontend/src/metabase/browse/components/ModelsTable.tsx
+++ b/frontend/src/metabase/browse/components/ModelsTable.tsx
@@ -210,8 +210,10 @@ const TBodyRow = ({
           return;
         }
         const url = Urls.model({ id, name });
+        const subPathSafeUrl = Urls.getSubpathSafeUrl(url);
+
         if ((e.ctrlKey || e.metaKey) && e.button === 0) {
-          window.open(url, "_blank");
+          window.open(subPathSafeUrl, "_blank");
         } else {
           dispatch(push(url));
         }

--- a/frontend/src/metabase/browse/components/ModelsTable.tsx
+++ b/frontend/src/metabase/browse/components/ModelsTable.tsx
@@ -210,10 +210,10 @@ const TBodyRow = ({
           return;
         }
         const url = Urls.model({ id, name });
-        const subPathSafeUrl = Urls.getSubpathSafeUrl(url);
+        const subpathSafeUrl = Urls.getSubpathSafeUrl(url);
 
         if ((e.ctrlKey || e.metaKey) && e.button === 0) {
-          window.open(subPathSafeUrl, "_blank");
+          window.open(subpathSafeUrl, "_blank");
         } else {
           dispatch(push(url));
         }

--- a/frontend/src/metabase/lib/urls/utils.ts
+++ b/frontend/src/metabase/lib/urls/utils.ts
@@ -1,3 +1,5 @@
+import api from "metabase/lib/api";
+
 export function appendSlug(path: string | number, slug?: string) {
   return slug ? `${path}-${slug}` : String(path);
 }
@@ -28,3 +30,24 @@ export function getEncodedUrlSearchParams(query: Record<string, unknown>) {
     })
     .join("&");
 }
+
+export function getSubpathSafeUrl(url?: string) {
+  if (url === undefined) {
+    return;
+  }
+
+  return api.basename + url;
+}
+
+/**
+ * Metabase can be deployed on a subpath!
+ * If you're opening internal links in a new tab, make sure you're using subpath-safe URLs.
+ * @see {@link getSubpathSafeUrl}
+ */
+export const openInNewTab = (url?: string) => {
+  if (!url) {
+    return;
+  }
+
+  window.open(url, "_blank");
+};

--- a/frontend/src/metabase/lib/urls/utils.ts
+++ b/frontend/src/metabase/lib/urls/utils.ts
@@ -31,12 +31,8 @@ export function getEncodedUrlSearchParams(query: Record<string, unknown>) {
     .join("&");
 }
 
-export function getSubpathSafeUrl(url?: string) {
-  if (url === undefined) {
-    return;
-  }
-
-  return api.basename + url.trim();
+export function getSubpathSafeUrl(url: string) {
+  return api.basename + url;
 }
 
 /**
@@ -44,10 +40,6 @@ export function getSubpathSafeUrl(url?: string) {
  * If you're opening internal links in a new tab, make sure you're using subpath-safe URLs.
  * @see {@link getSubpathSafeUrl}
  */
-export const openInNewTab = (url?: string) => {
-  if (!url) {
-    return;
-  }
-
+export const openInNewTab = (url: string) => {
   window.open(url, "_blank");
 };

--- a/frontend/src/metabase/lib/urls/utils.ts
+++ b/frontend/src/metabase/lib/urls/utils.ts
@@ -36,7 +36,7 @@ export function getSubpathSafeUrl(url?: string) {
     return;
   }
 
-  return api.basename + url;
+  return api.basename + url.trim();
 }
 
 /**

--- a/frontend/src/metabase/lib/urls/utils.unit.spec.ts
+++ b/frontend/src/metabase/lib/urls/utils.unit.spec.ts
@@ -1,0 +1,52 @@
+import api from "metabase/lib/api";
+
+import { getSubpathSafeUrl, openInNewTab } from "./utils";
+
+const fakeBasename = "foobar";
+const originalBasename = api.basename;
+
+const mockWindowOpen = jest.spyOn(window, "open").mockImplementation();
+
+describe("utils", () => {
+  beforeEach(() => {
+    api.basename = fakeBasename;
+  });
+
+  afterEach(() => {
+    api.basename = originalBasename;
+    mockWindowOpen.mockClear();
+  });
+
+  describe("getSubpathSafeUrl", () => {
+    it("should return undefined if url is undefined", () => {
+      expect(getSubpathSafeUrl()).toBeUndefined();
+    });
+
+    it("should return basename if url is empty string", () => {
+      expect(getSubpathSafeUrl("")).toBe(fakeBasename);
+      expect(getSubpathSafeUrl("  ")).toBe(fakeBasename);
+    });
+
+    it("should return subpath-safe url", () => {
+      expect(getSubpathSafeUrl("/baz")).toBe(`${fakeBasename}/baz`);
+    });
+  });
+
+  describe("openInNewTab", () => {
+    it("should return undefined if url is undefined", () => {
+      expect(openInNewTab()).toBeUndefined();
+    });
+
+    it("should return undefined if url is empty string", () => {
+      expect(openInNewTab("")).toBeUndefined();
+      expect(openInNewTab("  ")).toBeUndefined();
+    });
+
+    it("should dasdas", () => {
+      openInNewTab("/baz");
+
+      expect(mockWindowOpen).toHaveBeenCalledTimes(1);
+      expect(mockWindowOpen).toHaveBeenCalledWith("/baz", "_blank");
+    });
+  });
+});

--- a/frontend/src/metabase/lib/urls/utils.unit.spec.ts
+++ b/frontend/src/metabase/lib/urls/utils.unit.spec.ts
@@ -18,36 +18,24 @@ describe("utils", () => {
   });
 
   describe("getSubpathSafeUrl", () => {
-    it("should return undefined if url is undefined", () => {
-      expect(getSubpathSafeUrl()).toBeUndefined();
-    });
-
-    it("should return basename if url is empty string", () => {
+    it("should return basename if url is an empty string", () => {
       expect(getSubpathSafeUrl("")).toBe(fakeBasename);
-      expect(getSubpathSafeUrl("  ")).toBe(fakeBasename);
     });
 
     it("should return subpath-safe url", () => {
       expect(getSubpathSafeUrl("/baz")).toBe(`${fakeBasename}/baz`);
-      expect(getSubpathSafeUrl("/baz   ")).toBe(`${fakeBasename}/baz`);
     });
   });
 
   describe("openInNewTab", () => {
-    it("should return undefined if url is undefined", () => {
-      expect(openInNewTab()).toBeUndefined();
-    });
+    it.each(["", "/", "/baz"])(
+      "should open the provided link in a new tab",
+      url => {
+        openInNewTab(url);
 
-    it("should return undefined if url is empty string", () => {
-      expect(openInNewTab("")).toBeUndefined();
-      expect(openInNewTab("  ")).toBeUndefined();
-    });
-
-    it("should open the provided link in a new tab", () => {
-      openInNewTab("/baz");
-
-      expect(mockWindowOpen).toHaveBeenCalledTimes(1);
-      expect(mockWindowOpen).toHaveBeenCalledWith("/baz", "_blank");
-    });
+        expect(mockWindowOpen).toHaveBeenCalledTimes(1);
+        expect(mockWindowOpen).toHaveBeenCalledWith(url, "_blank");
+      },
+    );
   });
 });

--- a/frontend/src/metabase/lib/urls/utils.unit.spec.ts
+++ b/frontend/src/metabase/lib/urls/utils.unit.spec.ts
@@ -43,7 +43,7 @@ describe("utils", () => {
       expect(openInNewTab("  ")).toBeUndefined();
     });
 
-    it("should dasdas", () => {
+    it("should open the provided link in a new tab", () => {
       openInNewTab("/baz");
 
       expect(mockWindowOpen).toHaveBeenCalledTimes(1);

--- a/frontend/src/metabase/lib/urls/utils.unit.spec.ts
+++ b/frontend/src/metabase/lib/urls/utils.unit.spec.ts
@@ -29,6 +29,7 @@ describe("utils", () => {
 
     it("should return subpath-safe url", () => {
       expect(getSubpathSafeUrl("/baz")).toBe(`${fakeBasename}/baz`);
+      expect(getSubpathSafeUrl("/baz   ")).toBe(`${fakeBasename}/baz`);
     });
   });
 

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookDataPicker/NotebookDataPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookDataPicker/NotebookDataPicker.tsx
@@ -9,6 +9,7 @@ import {
 import { METAKEY } from "metabase/lib/browser";
 import { useDispatch, useStore } from "metabase/lib/redux";
 import { checkNotNull } from "metabase/lib/types";
+import * as Urls from "metabase/lib/urls";
 import { loadMetadataForTable } from "metabase/questions/actions";
 import { getMetadata } from "metabase/selectors/metadata";
 import type { IconName } from "metabase/ui";
@@ -18,7 +19,7 @@ import type { DatabaseId, TableId } from "metabase-types/api";
 
 import { NotebookCell } from "../NotebookCell";
 
-import { getUrl, openInNewTab } from "./utils";
+import { getUrl } from "./utils";
 
 interface NotebookDataPickerProps {
   title: string;
@@ -76,8 +77,9 @@ export function NotebookDataPicker({
 
     if (isCtrlOrMetaClick) {
       const url = getUrl({ query, table, stageIndex });
+      const safeUrl = Urls.getSubpathSafeUrl(url);
 
-      openInNewTab(url);
+      Urls.openInNewTab(safeUrl);
     } else {
       setIsOpen(true);
     }
@@ -88,8 +90,9 @@ export function NotebookDataPicker({
 
     if (isMiddleClick) {
       const url = getUrl({ query, table, stageIndex });
+      const safeUrl = Urls.getSubpathSafeUrl(url);
 
-      openInNewTab(url);
+      Urls.openInNewTab(safeUrl);
     } else {
       setIsOpen(true);
     }

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookDataPicker/NotebookDataPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookDataPicker/NotebookDataPicker.tsx
@@ -71,31 +71,28 @@ export function NotebookDataPicker({
     onChangeRef.current?.(table, metadataProvider);
   };
 
+  const openDataSourceInNewTab = () => {
+    const url = getUrl({ query, table, stageIndex });
+
+    if (!url) {
+      return;
+    }
+
+    const subpathSafeUrl = Urls.getSubpathSafeUrl(url);
+    Urls.openInNewTab(subpathSafeUrl);
+  };
+
   const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
     const isCtrlOrMetaClick =
       (event.ctrlKey || event.metaKey) && event.button === 0;
 
-    if (isCtrlOrMetaClick) {
-      const url = getUrl({ query, table, stageIndex });
-      const subpathSafeUrl = Urls.getSubpathSafeUrl(url);
-
-      Urls.openInNewTab(subpathSafeUrl);
-    } else {
-      setIsOpen(true);
-    }
+    isCtrlOrMetaClick ? openDataSourceInNewTab() : setIsOpen(true);
   };
 
   const handleAuxClick = (event: MouseEvent<HTMLButtonElement>) => {
     const isMiddleClick = event.button === 1;
 
-    if (isMiddleClick) {
-      const url = getUrl({ query, table, stageIndex });
-      const subpathSafeUrl = Urls.getSubpathSafeUrl(url);
-
-      Urls.openInNewTab(subpathSafeUrl);
-    } else {
-      setIsOpen(true);
-    }
+    isMiddleClick ? openDataSourceInNewTab() : setIsOpen(true);
   };
 
   return (

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookDataPicker/NotebookDataPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookDataPicker/NotebookDataPicker.tsx
@@ -77,9 +77,9 @@ export function NotebookDataPicker({
 
     if (isCtrlOrMetaClick) {
       const url = getUrl({ query, table, stageIndex });
-      const safeUrl = Urls.getSubpathSafeUrl(url);
+      const subpathSafeUrl = Urls.getSubpathSafeUrl(url);
 
-      Urls.openInNewTab(safeUrl);
+      Urls.openInNewTab(subpathSafeUrl);
     } else {
       setIsOpen(true);
     }
@@ -90,9 +90,9 @@ export function NotebookDataPicker({
 
     if (isMiddleClick) {
       const url = getUrl({ query, table, stageIndex });
-      const safeUrl = Urls.getSubpathSafeUrl(url);
+      const subpathSafeUrl = Urls.getSubpathSafeUrl(url);
 
-      Urls.openInNewTab(safeUrl);
+      Urls.openInNewTab(subpathSafeUrl);
     } else {
       setIsOpen(true);
     }

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookDataPicker/utils.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookDataPicker/utils.ts
@@ -36,11 +36,3 @@ export const getUrl = ({
     return Urls.tableRowsQuery(databaseId, tableId);
   }
 };
-
-export const openInNewTab = (link?: string) => {
-  if (!link) {
-    return;
-  }
-
-  window.open(link, "_blank");
-};


### PR DESCRIPTION
### Description

This PR introduces subpath-safe url helpers and fixes two features that were breaking if Metabase was deployed on a subpath.
1. Model links from `/browse/models`
2. Opening data source from notebook (#46201)

### How to verify

**Regular scenario**
Notebook
- check out this branch
- run your dev instance (oss or ee, doesn't matter)
- open any query in notebook view and cmd/ctrl click on a data source
- it should open in a new tab

Browse Models
- open `/browse/models`
- cmd/ctrl click on any listed model
- it should open in a new tab

**Subpath scenario**
_Prepare sub-path scenario_
Follow the instructions from this repo: https://github.com/iethree/metabase-subpath-proxy

Notebook
- open `localhost:9090/metabase` and then open any table in a notebook mode
- cmd/ctrl + click on the data source
- it should open correctly on a `localhost:9090/metabase/question#ey...` path

Browse Models
- open `localhost:9090/browse/models`
- cmd/ctrl click on any listed model
- it should open in a new tab on a sub path

### Demo
Notebook
https://github.com/user-attachments/assets/9a271387-08af-47c1-9406-067c31df977b

Browse Models
https://github.com/user-attachments/assets/e8c2439e-1b97-4ea9-9fe4-3b083f6df500

### Checklist
- [x] Tests have been added/updated to cover changes in this PR
