### PR TITLE
Fix exports E2E flakes

### DIFF
--- a/e2e/support/helpers/e2e-downloads-helpers.ts
+++ b/e2e/support/helpers/e2e-downloads-helpers.ts
@@ -176,13 +176,16 @@ function getEndpoint({
  */
 export function ensureDownloadStatusDismissed() {
   cy.get("body").then(body => {
-    const hasStausContainer =
-      body.find("[data-testid=status-root-container]").length > 0;
+    const statusContainer = body.find("[data-testid=status-root-container]");
 
-    if (!hasStausContainer) {
+    const hasDownloadStatus =
+      statusContainer.length > 0 && statusContainer.text().includes("Download");
+    if (!hasDownloadStatus) {
+      cy.log("No download status popover");
       return;
     }
 
+    cy.log("Has download status popover, closing it");
     cy.findByTestId("status-root-container").within(() => {
       cy.findByRole("status").within(() => {
         cy.findAllByText("Download completed");

--- a/e2e/support/helpers/e2e-downloads-helpers.ts
+++ b/e2e/support/helpers/e2e-downloads-helpers.ts
@@ -184,15 +184,6 @@ export function ensureDownloadStatusDismissed() {
       cy.log("No download status popover");
       return;
     }
-
-    cy.log("Has download status popover, closing it");
-    cy.findByTestId("status-root-container").within(() => {
-      cy.findByRole("status").within(() => {
-        cy.findAllByText("Download completed");
-        cy.findByLabelText("Dismiss").click();
-      });
-
-      cy.findByRole("status").should("not.exist");
-    });
+    cy.findByLabelText("Dismiss").click();
   });
 }

--- a/e2e/support/helpers/e2e-downloads-helpers.ts
+++ b/e2e/support/helpers/e2e-downloads-helpers.ts
@@ -169,21 +169,12 @@ function getEndpoint({
   };
 }
 
-/**
- * Upon successful export, we display a status popup that automatically closes after a set time.
- * However, Cypress sometimes hangs after file downloads, making it difficult to determine if
- * the status popup has already closed on its own or if we need to close it manually.
- */
 export function ensureDownloadStatusDismissed() {
-  cy.get("body").then(body => {
-    const statusContainer = body.find("[data-testid=status-root-container]");
-
-    const hasDownloadStatus =
-      statusContainer.length > 0 && statusContainer.text().includes("Download");
-    if (!hasDownloadStatus) {
-      cy.log("No download status popover");
-      return;
-    }
-    cy.findByLabelText("Dismiss").click();
-  });
+  // Upon successful export, we display a status popup that automatically closes after a set time.
+  //  However, Cypress sometimes hangs after file downloads, making it difficult to determine if
+  //  the status popup has already closed on its own or if we need to close it manually which makes
+  //  any attempts to close it flaky. As a workaround we wait until it gets removed by itself.
+  cy.findByTestId("status-root-container")
+    .contains("Download", { timeout: 10000 })
+    .should("not.exist");
 }

--- a/e2e/support/helpers/e2e-downloads-helpers.ts
+++ b/e2e/support/helpers/e2e-downloads-helpers.ts
@@ -23,7 +23,6 @@ interface DownloadAndAssertParams {
   publicUuid?: string;
   dashboardId?: number;
   enableFormatting?: boolean;
-  dismissStatus?: boolean;
 }
 
 /**
@@ -43,7 +42,6 @@ export function downloadAndAssert(
     downloadMethod = "POST",
     isDashboard,
     enableFormatting = true,
-    dismissStatus = true,
   }: DownloadAndAssertParams,
   callback: (data: unknown) => void,
 ) {
@@ -99,10 +97,7 @@ export function downloadAndAssert(
       fileType === "xlsx" && Object.assign(req, { encoding: "binary" });
 
       cy.request(req).then(({ body }) => {
-        if (dismissStatus) {
-          dismissDownloadStatus();
-        }
-
+        ensureDownloadStatusDismissed();
         const { SheetNames, Sheets } = xlsx.read(body, {
           // See the full list of Parsing options: https://github.com/SheetJS/sheetjs#parsing-options
           type: "binary",
@@ -174,14 +169,27 @@ function getEndpoint({
   };
 }
 
-export function dismissDownloadStatus() {
-  cy.findByTestId("status-root-container").within(() => {
-    cy.findByRole("status").within(() => {
-      cy.findAllByText("Download completed");
-      cy.findByLabelText("Dismiss").as("dismissButton");
-      cy.get("@dismissButton").click();
-    });
+/**
+ * Upon successful export, we display a status popup that automatically closes after a set time.
+ * However, Cypress sometimes hangs after file downloads, making it difficult to determine if
+ * the status popup has already closed on its own or if we need to close it manually.
+ */
+export function ensureDownloadStatusDismissed() {
+  cy.get("body").then(body => {
+    const hasStausContainer =
+      body.find("[data-testid=status-root-container]").length > 0;
 
-    cy.findByRole("status").should("not.exist");
+    if (!hasStausContainer) {
+      return;
+    }
+
+    cy.findByTestId("status-root-container").within(() => {
+      cy.findByRole("status").within(() => {
+        cy.findAllByText("Download completed");
+        cy.findByLabelText("Dismiss").click();
+      });
+
+      cy.findByRole("status").should("not.exist");
+    });
   });
 }

--- a/e2e/test/scenarios/permissions/download-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/download-permissions.cy.spec.js
@@ -207,7 +207,7 @@ describeEE("scenarios > admin > permissions > data > downloads", () => {
         visitQuestion(id);
 
         downloadAndAssert(
-          { fileType: "xlsx", questionId: id, dismissStatus: false },
+          { fileType: "xlsx", questionId: id },
           assertSheetRowsCount(18760),
         );
       });

--- a/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
+++ b/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
@@ -156,7 +156,7 @@ describe("scenarios > question > download", () => {
       });
 
       // In CI agents after downloads Cypress gets stuck for a while so the downloads status gets closed by timeout
-      assertOrdersExport(18760, false);
+      assertOrdersExport(18760);
 
       editDashboard();
 
@@ -181,7 +181,7 @@ describe("scenarios > question > download", () => {
       });
 
       // In CI agents after downloads Cypress gets stuck for a while so the downloads status gets closed by timeout
-      assertOrdersExport(1, false);
+      assertOrdersExport(1);
     });
 
     it("should allow downloading parameterized cards opened from dashboards as a user with no self-service permission (metabase#20868)", () => {

--- a/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
+++ b/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
@@ -393,7 +393,7 @@ describeWithSnowplow("[snowplow] scenarios > dashboard", () => {
   });
 });
 
-function assertOrdersExport(length, dismissStatus = true) {
+function assertOrdersExport(length) {
   downloadAndAssert(
     {
       fileType: "xlsx",
@@ -401,7 +401,6 @@ function assertOrdersExport(length, dismissStatus = true) {
       dashcardId: ORDERS_DASHBOARD_DASHCARD_ID,
       dashboardId: ORDERS_DASHBOARD_ID,
       isDashboard: true,
-      dismissStatus,
     },
     sheet => {
       expect(sheet["A1"].v).to.eq("ID");

--- a/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
@@ -108,7 +108,7 @@ describe("scenarios > visualizations > pie chart", () => {
       display: "pie",
     });
 
-    // Ensure chart renders before hovering the legend item
+    cy.log("Ensure chart renders before hovering the legend item");
     cy.findByTestId("query-visualization-root")
       .findByText("TOTAL")
       .should("be.visible");

--- a/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
@@ -108,11 +108,6 @@ describe("scenarios > visualizations > pie chart", () => {
       display: "pie",
     });
 
-    cy.log("Ensure chart renders before hovering the legend item");
-    cy.findByTestId("query-visualization-root")
-      .findByText("TOTAL")
-      .should("be.visible");
-
     chartPathWithFillColor("#F9D45C").trigger("mousemove");
 
     cy.findByTestId("query-visualization-root")


### PR DESCRIPTION
### Description

This PR fixes E2E flakes related to data export. We recently introduced an export status popup which hangs for a few seconds after a successful export until it gets closed automatically. In specs we need to close (or get it closed via a timeout) because it may cover elements that we want to click on further. The problem is that Cypress after downloading a file can hang an unpredictable amount of time so at the end we can't know whether the status popup is present or got closed already. Any attempts to close it are flaky so I changed it to waiting until it gets removed automatically.

Downloads specs stress tests:
- https://github.com/metabase/metabase/actions/runs/10328552618
- https://github.com/metabase/metabase/actions/runs/10328398897
- https://github.com/metabase/metabase/actions/runs/10328965922
