### PR TITLE
Show loading state while fetching data in a new model page

### DIFF
--- a/frontend/src/metabase/models/containers/NewModelOptions/NewModelOptions.tsx
+++ b/frontend/src/metabase/models/containers/NewModelOptions/NewModelOptions.tsx
@@ -4,6 +4,7 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import { useListDatabasesQuery } from "metabase/api";
+import { DelayedLoadingSpinner } from "metabase/common/components/EntityPicker/components/LoadingSpinner";
 import { Grid } from "metabase/components/Grid";
 import CS from "metabase/css/core/index.css";
 import Databases from "metabase/entities/databases";
@@ -15,7 +16,6 @@ import { NoDatabasesEmptyState } from "metabase/reference/databases/NoDatabasesE
 import { getHasDataAccess, getHasNativeWrite } from "metabase/selectors/data";
 import { getSetting } from "metabase/selectors/settings";
 import { getShowMetabaseLinks } from "metabase/selectors/whitelabel";
-import { Center, Loader } from "metabase/ui";
 
 import {
   EducationalButton,
@@ -46,11 +46,7 @@ const NewModelOptions = ({ location }: NewModelOptionsProps) => {
   const showMetabaseLinks = useSelector(getShowMetabaseLinks);
 
   if (isFetching) {
-    return (
-      <Center style={{ flexGrow: 1, height: "100vh" }}>
-        <Loader size="lg" data-testid="loading-indicator" />
-      </Center>
-    );
+    return <DelayedLoadingSpinner />;
   }
 
   if (!hasDataAccess && !hasNativeWrite) {

--- a/frontend/src/metabase/models/containers/NewModelOptions/NewModelOptions.tsx
+++ b/frontend/src/metabase/models/containers/NewModelOptions/NewModelOptions.tsx
@@ -15,6 +15,7 @@ import { NoDatabasesEmptyState } from "metabase/reference/databases/NoDatabasesE
 import { getHasDataAccess, getHasNativeWrite } from "metabase/selectors/data";
 import { getSetting } from "metabase/selectors/settings";
 import { getShowMetabaseLinks } from "metabase/selectors/whitelabel";
+import { Center, Loader } from "metabase/ui";
 
 import {
   EducationalButton,
@@ -29,7 +30,7 @@ interface NewModelOptionsProps {
 }
 
 const NewModelOptions = ({ location }: NewModelOptionsProps) => {
-  const { data } = useListDatabasesQuery();
+  const { data, isFetching } = useListDatabasesQuery();
   const databases = data?.data ?? [];
   const hasDataAccess = getHasDataAccess(databases);
   const hasNativeWrite = getHasNativeWrite(databases);
@@ -43,6 +44,14 @@ const NewModelOptions = ({ location }: NewModelOptionsProps) => {
   );
 
   const showMetabaseLinks = useSelector(getShowMetabaseLinks);
+
+  if (isFetching) {
+    return (
+      <Center style={{ flexGrow: 1, height: "100vh" }}>
+        <Loader size="lg" />
+      </Center>
+    );
+  }
 
   if (!hasDataAccess && !hasNativeWrite) {
     return (

--- a/frontend/src/metabase/models/containers/NewModelOptions/NewModelOptions.tsx
+++ b/frontend/src/metabase/models/containers/NewModelOptions/NewModelOptions.tsx
@@ -48,7 +48,7 @@ const NewModelOptions = ({ location }: NewModelOptionsProps) => {
   if (isFetching) {
     return (
       <Center style={{ flexGrow: 1, height: "100vh" }}>
-        <Loader size="lg" />
+        <Loader size="lg" data-testid="loading-indicator" />
       </Center>
     );
   }

--- a/frontend/src/metabase/models/containers/NewModelOptions/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/NewModelOptions/tests/common.unit.spec.tsx
@@ -1,4 +1,7 @@
+import fetchMock from "fetch-mock";
+
 import { screen } from "__support__/ui";
+import { delay } from "metabase/lib/promise";
 import { createMockDatabase } from "metabase-types/api/mocks";
 
 import { setup } from "./setup";
@@ -13,6 +16,22 @@ describe("NewModelOptions (OSS)", () => {
   });
 
   describe("has data access", () => {
+    it("should render loading indicator when fetching databases (metabase#44813)", async () => {
+      fetchMock.get(
+        "path:/api/database",
+        delay(2000).then(() => {
+          return [createMockDatabase()];
+        }),
+      );
+
+      setup({ databases: [createMockDatabase()] });
+
+      expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
+      expect(
+        screen.queryByText("Metabase is no fun without any data"),
+      ).not.toBeInTheDocument();
+    });
+
     it("should render options for creating a model", async () => {
       setup({ databases: [createMockDatabase()] });
 

--- a/frontend/src/metabase/models/containers/NewModelOptions/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/NewModelOptions/tests/common.unit.spec.tsx
@@ -17,14 +17,15 @@ describe("NewModelOptions (OSS)", () => {
 
   describe("has data access", () => {
     it("should render loading indicator when fetching databases (metabase#44813)", async () => {
+      setup({ databases: [createMockDatabase()] });
+      
       fetchMock.get(
         "path:/api/database",
         delay(2000).then(() => {
           return [createMockDatabase()];
         }),
+        { overwriteRoutes: true },
       );
-
-      setup({ databases: [createMockDatabase()] });
 
       expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
       expect(

--- a/frontend/src/metabase/models/containers/NewModelOptions/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/NewModelOptions/tests/common.unit.spec.tsx
@@ -18,7 +18,7 @@ describe("NewModelOptions (OSS)", () => {
   describe("has data access", () => {
     it("should render loading indicator when fetching databases (metabase#44813)", async () => {
       setup({ databases: [createMockDatabase()] });
-      
+
       fetchMock.get(
         "path:/api/database",
         delay(2000).then(() => {


### PR DESCRIPTION
Closes #44813

### Description

This PR introduces a Loader while the data `isFetching`

### How to verify

1. Throttle your network
2. Go to `http://localhost:3000/model/new`
3. You should briefly see a loading spinner before the notebook vs native model UI shows up

### Demo
https://github.com/user-attachments/assets/677404e3-a290-4179-8524-181b6658d2c4

### Checklist
- [x] Tests have been added/updated to cover changes in this PR
