### PR TITLE
Fix relative date options popover placement

### DIFF
--- a/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
@@ -6,6 +6,7 @@ import { t } from "ttag";
 import TippyPopover from "metabase/components/Popover/TippyPopover";
 import CS from "metabase/css/core/index.css";
 import { isValidTimeInterval } from "metabase/lib/time";
+import { DEFAULT_POPOVER_Z_INDEX } from "metabase/ui";
 import type Filter from "metabase-lib/v1/queries/structured/Filter";
 import {
   formatStartingFrom,
@@ -225,6 +226,7 @@ const RelativeDatePicker = (props: RelativeDatePickerProps) => {
           placement="bottom-start"
           content={optionsContent}
           onClose={() => setOptionsVisible(false)}
+          zIndex={DEFAULT_POPOVER_Z_INDEX}
         >
           <MoreButton
             icon="ellipsis"

--- a/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
@@ -3,9 +3,9 @@ import type { DurationInputArg2 } from "moment-timezone"; // eslint-disable-line
 import { useState } from "react";
 import { t } from "ttag";
 
-import TippyPopover from "metabase/components/Popover/TippyPopover";
 import CS from "metabase/css/core/index.css";
 import { isValidTimeInterval } from "metabase/lib/time";
+import { Popover } from "metabase/ui";
 import type Filter from "metabase-lib/v1/queries/structured/Filter";
 import {
   formatStartingFrom,
@@ -220,19 +220,22 @@ const RelativeDatePicker = (props: RelativeDatePickerProps) => {
         periods={ALL_PERIODS}
       />
       {showOptions ? (
-        <TippyPopover
-          visible={optionsVisible}
-          placement="bottom-start"
-          content={optionsContent}
+        <Popover
+          opened={optionsVisible}
           onClose={() => setOptionsVisible(false)}
+          position="bottom-start"
         >
-          <MoreButton
-            icon="ellipsis"
-            aria-label={t`Options`}
-            primaryColor={primaryColor}
-            onClick={() => setOptionsVisible(!optionsVisible)}
-          />
-        </TippyPopover>
+          <Popover.Target>
+            <MoreButton
+              icon="ellipsis"
+              aria-label={t`Options`}
+              primaryColor={primaryColor}
+              onClick={() => setOptionsVisible(!optionsVisible)}
+            />
+          </Popover.Target>
+
+          <Popover.Dropdown>{optionsContent}</Popover.Dropdown>
+        </Popover>
       ) : (
         <div />
       )}

--- a/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/RelativeDatePicker.tsx
@@ -3,9 +3,9 @@ import type { DurationInputArg2 } from "moment-timezone"; // eslint-disable-line
 import { useState } from "react";
 import { t } from "ttag";
 
+import TippyPopover from "metabase/components/Popover/TippyPopover";
 import CS from "metabase/css/core/index.css";
 import { isValidTimeInterval } from "metabase/lib/time";
-import { Popover } from "metabase/ui";
 import type Filter from "metabase-lib/v1/queries/structured/Filter";
 import {
   formatStartingFrom,
@@ -220,22 +220,19 @@ const RelativeDatePicker = (props: RelativeDatePickerProps) => {
         periods={ALL_PERIODS}
       />
       {showOptions ? (
-        <Popover
-          opened={optionsVisible}
+        <TippyPopover
+          visible={optionsVisible}
+          placement="bottom-start"
+          content={optionsContent}
           onClose={() => setOptionsVisible(false)}
-          position="bottom-start"
         >
-          <Popover.Target>
-            <MoreButton
-              icon="ellipsis"
-              aria-label={t`Options`}
-              primaryColor={primaryColor}
-              onClick={() => setOptionsVisible(!optionsVisible)}
-            />
-          </Popover.Target>
-
-          <Popover.Dropdown>{optionsContent}</Popover.Dropdown>
-        </Popover>
+          <MoreButton
+            icon="ellipsis"
+            aria-label={t`Options`}
+            primaryColor={primaryColor}
+            onClick={() => setOptionsVisible(!optionsVisible)}
+          />
+        </TippyPopover>
       ) : (
         <div />
       )}


### PR DESCRIPTION
Fixes #46342

### Description

The issue was present in the release branch, but not in `master`.
I realized that we've switched to using Mantine popover in `master`, while still using the old and deprecated `TippyPopover` in the release branch.

My original solution was to start using Mantine Popover in the release branch, too. But that led to failures in the dashboard parameters relative date filter. Applying that solution would've had a cascading effect and would require a lot of other, unrelated changes.

In the end, the solution was way simpler.
The problem is that the offset popover is still based on the old `TippyPopover` whose z-index is set to 4, while the relative date picker lives in a Mantine Popover whose z-index is 300.

I've just applied the Mantine z-index to the TippyPopover, and the stacking context took care of the rest.

### Demo
https://github.com/user-attachments/assets/6596124e-b0f6-4090-91e2-2685037c5d2c

### How to verify
Follow the repro steps from the issue or run the E2E repro from this PR.

- [x] Tests have been added

### Stress-test
50/50 ✅ https://github.com/metabase/metabase/actions/runs/10347967307