### PR TITLE
dx: get rid of csp error from cljs devtool

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -369,7 +369,7 @@
                                         :git/sha "490c9b04fbf5861dbd47c0c5281dad2d113bd285"}
     org.clojars.mmb90/cljs-cache       {:mvn/version "0.1.4"}
     refactor-nrepl/refactor-nrepl      {:mvn/version "3.10.0"}
-    thheller/shadow-cljs               {:mvn/version "2.27.5"}}}
+    thheller/shadow-cljs               {:mvn/version "2.28.12"}}}
 
   ;; for local dev -- include the drivers locally with :dev:drivers
   :drivers

--- a/package.json
+++ b/package.json
@@ -289,7 +289,7 @@
     "react-refresh": "^0.13.0",
     "reg-cli": "^0.17.7",
     "semver": "^7.6.3",
-    "shadow-cljs": "2.27.4",
+    "shadow-cljs": "^2.28.12",
     "source-map-loader": "^4.0.1",
     "storybook-addon-pseudo-states": "^3.1.1",
     "stylelint": "^16.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21146,10 +21146,10 @@ shadow-cljs-jar@1.3.4:
   resolved "https://registry.yarnpkg.com/shadow-cljs-jar/-/shadow-cljs-jar-1.3.4.tgz#0939d91c468b4bc5eab5a958f79e7ef5696fdf62"
   integrity sha512-cZB2pzVXBnhpJ6PQdsjO+j/MksR28mv4QD/hP/2y1fsIa9Z9RutYgh3N34FZ8Ktl4puAXaIGlct+gMCJ5BmwmA==
 
-shadow-cljs@2.27.4:
-  version "2.27.4"
-  resolved "https://registry.yarnpkg.com/shadow-cljs/-/shadow-cljs-2.27.4.tgz#92aab4d6119d132dd110d743fecc4611f1989077"
-  integrity sha512-NgLkdK1hpjDCCVAwQdBebz+0DzgaVYaGOw1ojUwY627DLL+kG/pwhw+qiDEFeJl+CWCMFiWJgnwVEM8d/Cit5g==
+shadow-cljs@^2.28.12:
+  version "2.28.12"
+  resolved "https://registry.yarnpkg.com/shadow-cljs/-/shadow-cljs-2.28.12.tgz#a6e2b97c6a89d2553ddb024ab973a3c0f06c915e"
+  integrity sha512-/L/bBaJ/46bzB78bKAirvF/EiH7aTxGXLemfWptyungLoh8MwqPUR4c+cDFaPkUIbm8RfqbsyZngoAHE2mvL2Q==
   dependencies:
     node-libs-browser "^2.2.1"
     readline-sync "^1.4.7"


### PR DESCRIPTION
### Description

Followup of https://github.com/metabase/metabase/issues/45698.

Removes CSP error from cljs devtool.

[the author of shadow-cljs released a new version with a "fix"](https://github.com/thheller/shadow-cljs/discussions/1199#discussioncomment-10295057) 

### How to verify

open app in dev mode, reload the page - verify that console doesn't have CSP errors anymore

### Demo

### Before

https://github.com/user-attachments/assets/21b7dc44-ab1f-4920-a3d4-c9d3fdd2c22a


### After

https://github.com/user-attachments/assets/b3d061ae-c8b2-4848-92de-8f934cc60fd9


