### PR TITLE
[Notification] Disallow undefined key for http channel details

### DIFF
--- a/src/metabase/channel/http.clj
+++ b/src/metabase/channel/http.clj
@@ -20,10 +20,13 @@
   [:or :string :keyword])
 
 (def ^:private HTTPDetails
-  [:map
+  [:map {:closed true}
    [:url                           ms/Url]
    [:auth-method                   [:enum "none" "header" "query-param" "request-body"]]
    [:auth-info    {:optional true} [:map-of string-or-keyword :any]]
+   ;; used by the frontend to display the auth info properly
+   [:fe-form-type {:optional true} [:enum "api-key" "bearer" "basic"]]
+   ;; request method
    [:method       {:optional true} [:enum "get" "post" "put"]]])
 
 (def ^:private HTTPChannel

--- a/src/metabase/channel/http.clj
+++ b/src/metabase/channel/http.clj
@@ -25,7 +25,7 @@
    [:auth-method                   [:enum "none" "header" "query-param" "request-body"]]
    [:auth-info    {:optional true} [:map-of string-or-keyword :any]]
    ;; used by the frontend to display the auth info properly
-   [:fe-form-type {:optional true} [:enum "api-key" "bearer" "basic"]]
+   [:fe-form-type {:optional true} [:enum "api-key" "bearer" "basic" "none"]]
    ;; request method
    [:method       {:optional true} [:enum "get" "post" "put"]]])
 

--- a/test/metabase/channel/http_test.clj
+++ b/test/metabase/channel/http_test.clj
@@ -221,12 +221,19 @@
                                             :auth-info   {:token "WRONG_TOKEN"}})))))))
 
 (deftest ^:parallel can-connect?-errors-test
-  (testing "throws an appriopriate errors if details are mismatched"
-    (is (= {:errors {:url [(deferred-tru "value must be a valid URL.")]}}
-           (exception-data (can-connect? {:url         "not-an-url"
-                                          :auth-method "none"}))))
-    (is (= {:errors {:auth-method ["missing required key"]}}
-           (exception-data (can-connect? {:url "https://www.secret_service.xyz"}))))
+  (testing "throws an appriopriate errors if details are invalid"
+    (testing "invalid url"
+     (is (= {:errors {:url [(deferred-tru "value must be a valid URL.")]}}
+            (exception-data (can-connect? {:url         "not-an-url"
+                                           :auth-method "none"})))))
+
+    (testing "testing missing auth-method"
+      (is (= {:errors {:auth-method ["missing required key"]}}
+             (exception-data (can-connect? {:url "https://www.secret_service.xyz"})))))
+
+    (testing "include undefined key"
+      (is (=? {:errors {:xyz ["disallowed key"]}}
+             (exception-data (can-connect? {:xyz "hello world"})))))
 
     (with-server [url [get-400]]
       (is (= {:request-body   "\"Bad request\""
@@ -234,6 +241,10 @@
              (exception-data (can-connect? {:url         (str url (:path get-400))
                                             :method      "get"
                                             :auth-method "none"})))))))
+
+(deftest ^:parallel can-connect-details-with-undefined-key-test
+  (testing "throws an error if the details include an undefined key"))
+
 (deftest ^:parallel send!-test
   (testing "basic send"
     (with-captured-http-requests [requests]

--- a/test/metabase/channel/http_test.clj
+++ b/test/metabase/channel/http_test.clj
@@ -242,9 +242,6 @@
                                             :method      "get"
                                             :auth-method "none"})))))))
 
-(deftest ^:parallel can-connect-details-with-undefined-key-test
-  (testing "throws an error if the details include an undefined key"))
-
 (deftest ^:parallel send!-test
   (testing "basic send"
     (with-captured-http-requests [requests]


### PR DESCRIPTION
- Make the schema for http details a closed schema
- Add a new key `fe-form-type` with 3 possible values: `basic, bearer, api-key`. This is used on FE to display the form properly