### PR TITLE
ci: move flaky specs to jail

### DIFF
--- a/e2e/test/scenarios/question/column-compare.cy.spec.ts
+++ b/e2e/test/scenarios/question/column-compare.cy.spec.ts
@@ -400,7 +400,7 @@ describeWithSnowplow("scenarios > question > column compare TODO", () => {
       ]);
     });
 
-    it("breakout on non-datetime column", () => {
+    it("breakout on non-datetime column", { tags: "@flaky" }, () => {
       createQuestion(
         { query: QUERY_SINGLE_AGGREGATION_NON_DATETIME_BREAKOUT },
         { visitQuestion: true, wrapId: true, idAlias: "questionId" },

--- a/e2e/test/scenarios/question/saved.cy.spec.js
+++ b/e2e/test/scenarios/question/saved.cy.spec.js
@@ -245,40 +245,44 @@ describe("scenarios > question > saved", () => {
     });
   });
 
-  it("'read-only' user should be able to resize column width (metabase#9772)", () => {
-    cy.signIn("readonly");
-    visitQuestion(ORDERS_QUESTION_ID);
+  it(
+    "'read-only' user should be able to resize column width (metabase#9772)",
+    { tags: "@flaky" },
+    () => {
+      cy.signIn("readonly");
+      visitQuestion(ORDERS_QUESTION_ID);
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Tax")
-      .closest(".test-TableInteractive-headerCellData")
-      .as("headerCell")
-      .then($cell => {
-        const originalWidth = $cell[0].getBoundingClientRect().width;
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText("Tax")
+        .closest(".test-TableInteractive-headerCellData")
+        .as("headerCell")
+        .then($cell => {
+          const originalWidth = $cell[0].getBoundingClientRect().width;
 
-        // Retries the assertion a few times to ensure it waits for DOM changes
-        // More context: https://github.com/metabase/metabase/pull/21823#discussion_r855302036
-        function assertColumnResized(attempt = 0) {
-          cy.get("@headerCell").then($newCell => {
-            const newWidth = $newCell[0].getBoundingClientRect().width;
-            if (newWidth === originalWidth && attempt < 3) {
-              cy.wait(100);
-              assertColumnResized(++attempt);
-            } else {
-              expect(newWidth).to.be.gt(originalWidth);
-            }
-          });
-        }
+          // Retries the assertion a few times to ensure it waits for DOM changes
+          // More context: https://github.com/metabase/metabase/pull/21823#discussion_r855302036
+          function assertColumnResized(attempt = 0) {
+            cy.get("@headerCell").then($newCell => {
+              const newWidth = $newCell[0].getBoundingClientRect().width;
+              if (newWidth === originalWidth && attempt < 3) {
+                cy.wait(100);
+                assertColumnResized(++attempt);
+              } else {
+                expect(newWidth).to.be.gt(originalWidth);
+              }
+            });
+          }
 
-        cy.wrap($cell)
-          .find(".react-draggable")
-          .trigger("mousedown", 0, 0, { force: true })
-          .trigger("mousemove", 100, 0, { force: true })
-          .trigger("mouseup", 100, 0, { force: true });
+          cy.wrap($cell)
+            .find(".react-draggable")
+            .trigger("mousedown", 0, 0, { force: true })
+            .trigger("mousemove", 100, 0, { force: true })
+            .trigger("mouseup", 100, 0, { force: true });
 
-        assertColumnResized();
-      });
-  });
+          assertColumnResized();
+        });
+    },
+  );
 
   it("should always be possible to view the full title text of the saved question", () => {
     visitQuestion(ORDERS_QUESTION_ID);


### PR DESCRIPTION
### Description

Both tests are failing in stress test. IDK is it an overhead of video recording and/or cypress-terminal-report, but to unblock other PRs let's move these two into flaky group
[stress test 1](https://github.com/metabase/metabase/actions/runs/10352409218/job/28652958428)
[stress test 2](https://github.com/metabase/metabase/actions/runs/10352413916/job/28652973624)

UPD:
- failed even before video recording has been enabled https://github.com/metabase/metabase/actions/runs/10352877105/job/28654453104