### PR TITLE
ci(manual backport): improve logic for searching commit that wasn't merged correctly

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -107,8 +107,23 @@ jobs:
             echo "PR has been merged, searching for a squashed commit in the base branch"
             echo "searching for a commit in a ${ORIGINAL_BASE_REF} that contains pull request number ${ORIGINAL_PULL_REQUEST_NUMBER}"
             SQUASHED_COMMIT=$(env -i git log ${ORIGINAL_BASE_REF} --grep="(#${ORIGINAL_PULL_REQUEST_NUMBER})" --format="%H")
-            echo "found commit ${SQUASHED_COMMIT}"
-            git cherry-pick ${SQUASHED_COMMIT}
+
+            if [ -n "${SQUASHED_COMMIT}" ]; then
+              echo "found commit ${SQUASHED_COMMIT}"
+              git cherry-pick ${SQUASHED_COMMIT}
+            else
+              echo "probably a PR wasn't merged with Squash And Merge button, searching again"
+              SQUASHED_COMMIT=$(env -i git log ${ORIGINAL_BASE_REF} --grep="#${ORIGINAL_PULL_REQUEST_NUMBER}" --format="%H")
+
+              if [ -n "${SQUASHED_COMMIT}" ]; then
+                echo "found commit ${SQUASHED_COMMIT}"
+                git cherry-pick ${SQUASHED_COMMIT}
+              fi
+
+              echo "No squashed commit found for PR #${ORIGINAL_PULL_REQUEST_NUMBER}"
+              exit 1
+            fi
+
           else
             echo "PR has not been merged, copying all commits"
             git cherry-pick ${ORIGINAL_BASE_SHA}..${ORIGINAL_HEAD_SHA}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -118,10 +118,10 @@ jobs:
               if [ -n "${SQUASHED_COMMIT}" ]; then
                 echo "found commit ${SQUASHED_COMMIT}"
                 git cherry-pick ${SQUASHED_COMMIT}
+              else
+                echo "No squashed commit found for PR #${ORIGINAL_PULL_REQUEST_NUMBER}"
+                exit 1
               fi
-
-              echo "No squashed commit found for PR #${ORIGINAL_PULL_REQUEST_NUMBER}"
-              exit 1
             fi
 
           else


### PR DESCRIPTION
### Description
[context](https://metaboat.slack.com/archives/C0669P4AF9N/p1722869078935519)

Covers a case when PR is not merged correctly (by squash & merge button, which adds (#PR_NUMBER) to the end of the string)

e.g. [this commit](https://github.com/metabase/metabase/commit/fab23e52bebe0ec0344edcf4ae1aa1bf3ec5411e)
doesn't have `(#46453)` in the end, but has a variant without `()`

### How to verify

probably only fork allows to test it, but permissions will not allow to go through the steps