### PR TITLE
fix(sdk): fix health endpoint in pollMetabaseInstance

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/cli/steps/poll-metabase-instance.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/steps/poll-metabase-instance.ts
@@ -18,7 +18,7 @@ export const pollMetabaseInstance: CliStepMethod = async state => {
   while (attempts < HEALTH_CHECK_MAX_ATTEMPTS) {
     // fetch will throw an error if the server is not reachable
     try {
-      const res = await fetch(`${state.instanceUrl}/health`, {
+      const res = await fetch(`${state.instanceUrl}/api/health`, {
         method: "GET",
       });
 


### PR DESCRIPTION
The endpoint was missing the `/api` prefix, the backend replies to `/health` with 200 and some html even before the initialization has finished, causing the next step to fail.