### PR TITLE
Allow getting non-model ancestors in search API

### DIFF
--- a/frontend/src/metabase-types/api/search.ts
+++ b/frontend/src/metabase-types/api/search.ts
@@ -136,7 +136,9 @@ export type SearchRequest = {
   last_edited_by?: UserId[];
   search_native_query?: boolean | null;
   verified?: boolean | null;
-  model_ancestors?: boolean | null;
+  /** Set to true to return data that describes the whole collection path
+   * rather than just the parent collection */
+  ancestors?: boolean;
 
   // this should be in ListCollectionItemsRequest but legacy code expects them here
   collection?: CollectionId;

--- a/frontend/src/metabase/browse/components/BrowseModels.tsx
+++ b/frontend/src/metabase/browse/components/BrowseModels.tsx
@@ -34,7 +34,7 @@ export const BrowseModels = () => {
   /** Mapping of filter names to true if the filter is active or false if it is inactive */
   const [actualModelFilters, setActualModelFilters] = useModelFilterSettings();
 
-  const modelsResult = useFetchModels({ model_ancestors: true });
+  const modelsResult = useFetchModels({ ancestors: true });
 
   const { models, doVerifiedModelsExist } = useMemo(() => {
     const unfilteredModels =

--- a/frontend/src/metabase/common/hooks/use-fetch-models.tsx
+++ b/frontend/src/metabase/common/hooks/use-fetch-models.tsx
@@ -5,7 +5,6 @@ export const useFetchModels = (req: Partial<SearchRequest> = {}) => {
   const modelsResult = useSearchQuery({
     models: ["dataset"], // 'model' in the sense of 'type of thing'
     filter_items_in_personal_collection: "exclude",
-    model_ancestors: false,
     ...req,
   });
   return modelsResult;

--- a/frontend/src/metabase/common/hooks/use-has-models.tsx
+++ b/frontend/src/metabase/common/hooks/use-has-models.tsx
@@ -6,7 +6,6 @@ import { useFetchModels } from "./use-fetch-models";
 export const useHasModels = (req: Partial<SearchRequest> = {}) => {
   const modelsResult = useFetchModels({
     limit: 1,
-    model_ancestors: false,
     ...req,
   });
   const modelsLength = modelsResult.data?.data.length;

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -61,7 +61,7 @@
 
   A search query that has both filters applied will only return models and cards."
   [q archived created_at created_by table_db_id models last_edited_at last_edited_by
-   filter_items_in_personal_collection model_ancestors search_native_query verified ids]
+   filter_items_in_personal_collection model_ancestors ancestors search_native_query verified ids]
   {q                                   [:maybe ms/NonBlankString]
    archived                            [:maybe :boolean]
    table_db_id                         [:maybe ms/PositiveInt]
@@ -72,6 +72,7 @@
    last_edited_at                      [:maybe ms/NonBlankString]
    last_edited_by                      [:maybe (ms/QueryVectorOf ms/PositiveInt)]
    model_ancestors                     [:maybe :boolean]
+   ancestors                           [:maybe :boolean]
    search_native_query                 [:maybe true?]
    verified                            [:maybe true?]
    ids                                 [:maybe (ms/QueryVectorOf ms/PositiveInt)]}
@@ -91,6 +92,7 @@
          :last-edited-by                      (set last_edited_by)
          :limit                               mw.offset-paging/*limit*
          :model-ancestors?                    model_ancestors
+         :ancestors?                          ancestors
          :models                              models-set
          :offset                              mw.offset-paging/*offset*
          :search-native-query                 search_native_query

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -102,7 +102,6 @@
    [:archived?          [:maybe :boolean]]
    [:current-user-id    pos-int?]
    [:current-user-perms [:set perms.u/PathSchema]]
-   [:model-ancestors?   :boolean]
    [:models             [:set SearchableModel]]
    [:search-string      [:maybe ms/NonBlankString]]
    ;;
@@ -117,6 +116,7 @@
    [:offset-int                          {:optional true} ms/Int]
    [:search-native-query                 {:optional true} true?]
    [:table-db-id                         {:optional true} ms/PositiveInt]
+   [:ancestor-models                     {:optional true} [:maybe [:set SearchableModel]]]
    ;; true to search for verified items only, nil will return all items
    [:verified                            {:optional true} true?]
    [:ids                                 {:optional true} [:set {:min 1} ms/PositiveInt]]])

--- a/test/metabase/search/filter_test.clj
+++ b/test/metabase/search/filter_test.clj
@@ -7,10 +7,10 @@
    [metabase.test :as mt]))
 
 (def default-search-ctx
-  {:search-string       nil
-   :archived?           false
+  {:search-string      nil
+   :archived?          false
    :models             search.config/all-models
-   :model-ancestors?   false
+   :ancestor-models    #{}
    :current-user-id    1
    :current-user-perms #{"/"}})
 

--- a/test/metabase/search/impl_test.clj
+++ b/test/metabase/search/impl_test.clj
@@ -64,7 +64,6 @@
                                                  :models             search.config/all-models
                                                  :current-user-id    (mt/user->id :crowberto)
                                                  :current-user-perms #{"/"}
-                                                 :model-ancestors?   false
                                                  :limit-int          100}))]
           ;; warm it up, in case the DB call depends on the order of test execution and it needs to
           ;; do some initialization


### PR DESCRIPTION
Previously we had a `model_ancestors` flag that allowed you to retrieve the ancestors of the collection a "thing" was in, when you discovered it in search.

This expands this a little, allowing you to get the collection ancestors for any type of model you retrieve (assuming that makes sense).