### PR TITLE
fix(sdk): increase setup timeout to 15s to avoid 'user already created' issue on retry

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/cli/steps/setup-metabase-instance.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/steps/setup-metabase-instance.ts
@@ -87,9 +87,9 @@ export const setupMetabaseInstance: CliStepMethod = async state => {
             },
           }),
           headers: { "content-type": "application/json" },
-          signal: AbortSignal.timeout(2500),
+          signal: AbortSignal.timeout(15_000),
         }),
-      { retries: 20, delay: 1000 },
+      { retries: 5, delay: 1000 },
     );
 
     if (!res.ok) {


### PR DESCRIPTION
I had the cli run into this error a few times: (console logs added by me to debug, they're not present on master)
<img width="1165" alt="image" src="https://github.com/user-attachments/assets/debd1641-8b35-4fad-97f8-da5a4ff36d1b">

I think it happened because the first request got killed by the timeout, but it still reached the BE so it created the user, the next retry will therefore fail because the endpoint cannot be used if a user already exists.

I also reduced the retries, I think we only needed the high number because of the issue solved with [fix(sdk): fix health endpoint in pollMetabaseInstance (+1 −1)](https://github.com/metabase/metabase/pull/46730) (ie: the cli started this tasks too early when the BE was unresponsive, so this step failed many times before succeeding).