### PR TITLE
Fix false negatives for query reference validation

### DIFF
--- a/.clj-kondo/macros/metabase_enterprise/query_reference_validation/api_test.clj
+++ b/.clj-kondo/macros/metabase_enterprise/query_reference_validation/api_test.clj
@@ -6,6 +6,7 @@
          ~(macros.common/ignore-unused 'card-2) 2
          ~(macros.common/ignore-unused 'card-3) 3
          ~(macros.common/ignore-unused 'card-4) 4
+         ~(macros.common/ignore-unused 'card-5) 5
          ~(macros.common/ignore-unused 'coll-2) 100
          ~(macros.common/ignore-unused 'coll-3) 200]
      ~@body))

--- a/enterprise/backend/test/metabase_enterprise/query_reference_validation/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/query_reference_validation/api_test.clj
@@ -155,7 +155,12 @@
                             :effective_ancestors [{:id "root" :name "Our analytics" :authority_level nil}
                                                   {:id coll-2
                                                    :name (t2/select-one-fn :name :model/Collection :id coll-2)
-                                                   :type nil}]}}]
+                                                   :type nil}]}}
+              {:collection {:id nil
+                            :name nil
+                            :authority_level nil
+                            :type nil
+                            :effective_ancestors []}}]
              (map #(select-keys % [:collection]) (:data (get!))))))))
 
 (deftest premium-feature-test
@@ -220,7 +225,10 @@
               :data
               [{:id     card-3
                 :name   "C"
-                :errors [{:type "unknown-table", :table "T3"}]}]}
+                :errors [{:type "unknown-table", :table "T3"}]}
+               {:id    card-5
+                :name "E"
+                :errors [{:type "unknown-table", :table "T5"}]}]}
              (-> (get! {:limit 3 :offset 2})
                  (select-keys [:total :limit :offset :data])
                  (with-data-keys [:id :name :errors])))))))
@@ -228,16 +236,16 @@
 (deftest sorting-test
   (testing "Lets you specify the sort key"
     (with-test-setup
-      (is (= {:total 3
+      (is (= {:total 4
               :data
-              [{:id card-5}
-               {:id card-3}
+              [{:id card-3}
                {:id card-2}
-               {:id card-1}]}
+               {:id card-1}
+               {:id card-5}]}
              (-> (get! {:sort_column "collection" :sort_direction "desc"})
                  (select-keys [:total :data])
                  (with-data-keys [:id]))))
-      (is (= {:total 3
+      (is (= {:total 4
               :data
               [{:id card-1}
                {:id card-2}
@@ -246,7 +254,7 @@
              (-> (get! {:sort_column "last_edited_at" :sort_direction "asc"})
                  (select-keys [:total :data])
                  (with-data-keys [:id]))))
-      (is (= {:total 3
+      (is (= {:total 4
               :data
               [{:id card-5}
                {:id card-3}
@@ -255,6 +263,7 @@
              (-> (get! {:sort_column "last_edited_at" :sort_direction "desc"})
                  (select-keys [:total :data])
                  (with-data-keys [:id]))))))
+
   (testing "Rejects bad keys"
     (with-test-setup
       (is (str/starts-with? (:sort_column
@@ -281,7 +290,7 @@
                    (select-keys [:total :data])
                    (with-data-keys [:id])))))
       (testing "we can look in the root coll (which recursively contains coll-2 and coll-3)"
-        (is (= {:total 3
+        (is (= {:total 4
                 :data
                 [{:id card-1}
                  {:id card-2}

--- a/enterprise/backend/test/metabase_enterprise/query_reference_validation/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/query_reference_validation/api_test.clj
@@ -19,6 +19,7 @@
                             :model/Card       {card-2 :id}   {:name "B" :collection_id coll-2}
                             :model/Card       {card-3 :id}   {:name "C" :collection_id coll-3}
                             :model/Card       {card-4 :id}   {:name "D"}
+                            :model/Card       {card-5 :id}   {:name "E"}
                             :model/Field      {field-1 :id}  {:active   false
                                                               :name     "FA"
                                                               :table_id table-1}
@@ -29,6 +30,7 @@
                             :model/QueryAnalysis {qa-1 :id}  {:card_id card-1}
                             :model/QueryAnalysis {qa-2 :id}  {:card_id card-2}
                             :model/QueryAnalysis {qa-3 :id}  {:card_id card-3}
+                            :model/QueryAnalysis {qa-5 :id}  {:card_id card-5}
 
                             ;; QTs not to include:
                             ;; - Table is still active
@@ -49,6 +51,10 @@
                                                                :analysis_id qa-3
                                                                :table       "T3"
                                                                :table_id    nil}
+                            :model/QueryTable {}              {:card_id     card-5
+                                                               :analysis_id qa-5
+                                                               :table       "T5"
+                                                               :table_id    nil}
 
                             ;; QFs not to include:
                             ;; - Field is still active
@@ -66,6 +72,7 @@
                                                               :table_id           table-1
                                                               :field_id           field-1
                                                               :explicit_reference false}
+
                             ;; - No resolved table, probably an imaginary column due to Macaw bugs
                             :model/QueryField {}             {:card_id            card-3
                                                               :analysis_id        qa-3
@@ -108,7 +115,7 @@
                                                               :field_id    nil}]
      (mt/with-premium-features #{:query-reference-validation}
        (mt/with-temporary-setting-values [query-analysis-enabled true]
-         (mt/call-with-map-params f [card-1 card-2 card-3 card-4 coll-2 coll-3]))))))
+         (mt/call-with-map-params f [card-1 card-2 card-3 card-4 card-5 coll-2 coll-3]))))))
 
 (defmacro ^:private with-test-setup
   "Creates some non-stale QueryFields and anaphorically provides stale QueryField IDs called `qf-{1-3}` and `qf-1b` and
@@ -118,7 +125,7 @@
   `card-4` is guaranteed not to have problems"
   [& body]
   `(do-with-test-setup
-    (mt/with-anaphora [card-1 card-2 card-3 card-4 coll-2 coll-3]
+    (mt/with-anaphora [card-1 card-2 card-3 card-4 card-5 coll-2 coll-3]
       ~@body)))
 
 (def ^:private url "ee/query-reference-validation/invalid-cards")
@@ -171,7 +178,7 @@
 (deftest list-invalid-cards-basic-test
   (testing "Only returns cards with problematic field refs"
     (with-test-setup
-      (is (= {:total 3
+      (is (= {:total 4
               :data
               [{:id     card-1
                 :name   "A"
@@ -182,7 +189,10 @@
                 :errors [{:type "inactive-table", :table "T2"}]}
                {:id     card-3
                 :name   "C"
-                :errors [{:type "unknown-table", :table "T3"}]}]}
+                :errors [{:type "unknown-table", :table "T3"}]}
+               {:id     card-5
+                :name   "E"
+                :errors [{:type "unknown-table", :table "T5"}]}]}
                (-> (get!)
                    (select-keys [:data :total])
                    (update :data (fn [data] (map #(select-keys % [:id :name :errors]) data)))))))))
@@ -190,7 +200,7 @@
 (deftest pagination-test
   (testing "Lets you page results"
     (with-test-setup
-      (is (= {:total  3
+      (is (= {:total  4
               :limit  2
               :offset 0
               :data
@@ -204,14 +214,14 @@
                (-> (get! {:limit 2})
                    (select-keys [:total :limit :offset :data])
                    (with-data-keys [:id :name :errors]))))
-      (is (= {:total  3
-              :limit  1
+      (is (= {:total  4
+              :limit  3
               :offset 2
               :data
               [{:id     card-3
                 :name   "C"
                 :errors [{:type "unknown-table", :table "T3"}]}]}
-             (-> (get! {:limit 1 :offset 2})
+             (-> (get! {:limit 3 :offset 2})
                  (select-keys [:total :limit :offset :data])
                  (with-data-keys [:id :name :errors])))))))
 
@@ -220,7 +230,8 @@
     (with-test-setup
       (is (= {:total 3
               :data
-              [{:id card-3}
+              [{:id card-5}
+               {:id card-3}
                {:id card-2}
                {:id card-1}]}
              (-> (get! {:sort_column "collection" :sort_direction "desc"})
@@ -230,13 +241,15 @@
               :data
               [{:id card-1}
                {:id card-2}
-               {:id card-3}]}
+               {:id card-3}
+               {:id card-5}]}
              (-> (get! {:sort_column "last_edited_at" :sort_direction "asc"})
                  (select-keys [:total :data])
                  (with-data-keys [:id]))))
       (is (= {:total 3
               :data
-              [{:id card-3}
+              [{:id card-5}
+               {:id card-3}
                {:id card-2}
                {:id card-1}]}
              (-> (get! {:sort_column "last_edited_at" :sort_direction "desc"})
@@ -272,7 +285,8 @@
                 :data
                 [{:id card-1}
                  {:id card-2}
-                 {:id card-3}]}
+                 {:id card-3}
+                 {:id card-5}]}
                (-> (get! {})
                    (select-keys [:total :data])
                    (with-data-keys [:id]))))))))

--- a/src/metabase/models/query_analysis.clj
+++ b/src/metabase/models/query_analysis.clj
@@ -21,22 +21,39 @@
 
 (defn cards-with-reference-errors
   "Given some HoneySQL query map with :model/Card bound as :c, restrict this query to only return cards
-  with invalid references."
+  with invalid references (problematic query fields or query tables)."
   [card-query-map]
   (-> card-query-map
-      (sql.helpers/join
-       [(t2/table-name :model/QueryField) :qf]
-       [:and
-        [:= :qf.card_id :c.id]
-        [:= :qf.explicit_reference true]
-        [:not= :qf.table nil]])
-      (sql.helpers/left-join
-       [(t2/table-name :model/Field) :f]
-       [:= :qf.field_id :f.id])
+      (sql.helpers/with
+       [:problematic_query_fields
+        {:select [:qf.card_id]
+         :from [[(t2/table-name :model/QueryField) :qf]]
+         :left-join [[(t2/table-name :model/Field) :f]
+                     [:= :qf.field_id :f.id]]
+         :where [:and
+                 [:= :qf.explicit_reference true]
+                 [:not= :qf.table nil]
+                 [:or
+                  [:= :f.id nil]
+                  [:= :f.active false]]]}]
+
+       [:problematic_query_tables
+        {:select [:qt.card_id]
+         :from [[(t2/table-name :model/QueryTable) :qt]]
+         :left-join [[(t2/table-name :model/Table) :t]
+                     [:= :qt.table_id :t.id]]
+         :where [:or
+                 [:= :qt.table_id nil]
+                 [:= :t.active false]]}])
+
       (sql.helpers/where
        [:or
-        [:= :f.id nil]
-        [:= :f.active false]])))
+        [:exists {:select [1]
+                  :from [[:problematic_query_fields :pqf]]
+                  :where [:= :c.id :pqf.card_id]}]
+        [:exists {:select [1]
+                  :from [[:problematic_query_tables :pqt]]
+                  :where [:= :c.id :pqt.card_id]}]])))
 
 (defn- group-errors [errors]
   (reduce (fn [acc [id error]]

--- a/src/metabase/query_analysis.clj
+++ b/src/metabase/query_analysis.clj
@@ -91,8 +91,8 @@
 
 (defn- explicit-references [field-ids]
   (let [field-refs (explicit-field-references field-ids)]
-    {:fields field-refs
-     :tables (distinct (map #(dissoc % :field-id :field) field-refs))}))
+    {:fields (distinct field-refs)
+     :tables (distinct (map #(dissoc % :field-id :column :explicit-reference) field-refs))}))
 
 (defn- query-references
   "Find out ids of all fields used in a query. Conforms to the same protocol as [[query-analyzer/field-ids-for-sql]],


### PR DESCRIPTION
### Description

This PR should fix two issues that could lead to cards with issues not showing up in the query validation tool:

1. We were not picking up issues with table-only references (e.g. `SELECT COUNT(*) FROM unknown_table`)
2. Healthy field references could "mask" issues with other fields on a given query.

While this update should fix the issue, it comes at the cost of far less scalable query. Perhaps there's a smart way to optimize this query still, otherwise we might want to consider denormalizing whether a table or field is active on the corresponding analysis rows.

Update: this now fixes a 3rd issue where we didn't de-duplicate table references properly for MBQL cards.