### PR TITLE
Remove unnecessary api call from create collection form

### DIFF
--- a/frontend/src/metabase/api/collection.ts
+++ b/frontend/src/metabase/api/collection.ts
@@ -26,6 +26,10 @@ import {
 
 export const collectionApi = Api.injectEndpoints({
   endpoints: builder => ({
+    /**
+     * @deprecated This endpoint is extremely slow on large instances, it should not be used
+     * you probably only need a few collections, just fetch those
+     */
     listCollections: builder.query<Collection[], ListCollectionsRequest>({
       query: params => ({
         method: "GET",

--- a/frontend/src/metabase/collections/components/CreateCollectionForm/CreateCollectionForm.tsx
+++ b/frontend/src/metabase/collections/components/CreateCollectionForm/CreateCollectionForm.tsx
@@ -22,7 +22,7 @@ import * as Errors from "metabase/lib/errors";
 import type { Collection } from "metabase-types/api";
 import type { State } from "metabase-types/store";
 
-import FormAuthorityLevelFieldContainer from "../../containers/FormAuthorityLevelFieldContainer";
+import { FormAuthorityLevelField } from "../../containers/FormAuthorityLevelFieldContainer";
 
 const COLLECTION_SCHEMA = Yup.object({
   name: Yup.string()
@@ -111,7 +111,7 @@ function CreateCollectionForm({
       validationSchema={COLLECTION_SCHEMA}
       onSubmit={handleCreate}
     >
-      {({ dirty, values }) => (
+      {({ dirty }) => (
         <Form>
           <FormInput
             name="name"
@@ -131,9 +131,7 @@ function CreateCollectionForm({
             title={t`Collection it's saved in`}
             filterPersonalCollections={filterPersonalCollections}
           />
-          <FormAuthorityLevelFieldContainer
-            collectionParentId={values.parent_id}
-          />
+          <FormAuthorityLevelField />
           <FormFooter>
             <FormErrorMessage inline />
             {!!onCancel && (

--- a/frontend/src/metabase/collections/containers/FormAuthorityLevelFieldContainer.tsx
+++ b/frontend/src/metabase/collections/containers/FormAuthorityLevelFieldContainer.tsx
@@ -1,31 +1,11 @@
-import { connect } from "react-redux";
 import _ from "underscore";
 
-import Collections from "metabase/entities/collections";
+import { useSelector } from "metabase/lib/redux";
 import { PLUGIN_COLLECTION_COMPONENTS } from "metabase/plugins";
 import { getUserIsAdmin } from "metabase/selectors/user";
-import type { Collection } from "metabase-types/api";
-import type { State } from "metabase-types/store";
 
-interface OwnProps {
-  collectionParentId: Collection["id"];
-}
-
-interface StateProps {
-  isAdmin: boolean;
-}
-
-type FormAuthorityLevelFieldContainerProps = OwnProps & StateProps;
-
-function mapStateToProps(state: State): StateProps {
-  return {
-    isAdmin: getUserIsAdmin(state),
-  };
-}
-
-function FormAuthorityLevelFieldContainer({
-  isAdmin,
-}: FormAuthorityLevelFieldContainerProps) {
+export function FormAuthorityLevelField() {
+  const isAdmin = useSelector(getUserIsAdmin);
   if (!isAdmin) {
     return null;
   }
@@ -34,10 +14,3 @@ function FormAuthorityLevelFieldContainer({
     <PLUGIN_COLLECTION_COMPONENTS.FormCollectionAuthorityLevelPicker name="authority_level" />
   );
 }
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default _.compose(
-  // Ensures there's data for the `collectionsMap` prop
-  Collections.loadList({ loadingAndErrorWrapper: false }),
-  connect(mapStateToProps),
-)(FormAuthorityLevelFieldContainer);


### PR DESCRIPTION

part of https://github.com/metabase/metabase/issues/46695

### Description

Our authority level selection component was unnecessarily calling the very slow `/api/collection` endpoint any time an enterprise admin opened the "Create Collection" modal.

![Screen Shot 2024-08-12 at 9 52 33 AM](https://github.com/user-attachments/assets/83635242-d948-4b2e-a812-b2ac144a6fae)

.  | .
-- | --
Before |  ![Screen Shot 2024-08-12 at 9 50 29 AM](https://github.com/user-attachments/assets/51a195e2-0e09-47b0-b8bd-6fceacc0f514)
After | ![Screen Shot 2024-08-12 at 9 47 47 AM](https://github.com/user-attachments/assets/03db759a-ab79-410d-bfc6-d80a6cff52ab)

### How to verify

As an EE admin:

1. Click "create new collection"
2. Don't see any api calls to `/api/collection`


