### PR TITLE
fix(sdk): make sure generated password has at least one number, one u…

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/cli/utils/generate-password.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/utils/generate-password.ts
@@ -1,16 +1,29 @@
 export function generateRandomDemoPassword(): string {
   const chars = "abcdefghijklmnopqrstuvwxyz";
+  const upperCaseChars = chars.toUpperCase();
   const numbers = "0123456789";
 
-  const allChars = chars + chars.toUpperCase() + numbers;
+  const allChars = chars + upperCaseChars + numbers;
   const length = 14;
 
   let password = "";
 
-  for (let i = 0; i < length; i++) {
-    const randomIndex = Math.floor(Math.random() * allChars.length);
-    password += allChars[randomIndex];
+  //make sure we have at least 1 number, one upper case and one lower case character
+  password += pickRandom(chars);
+  password += pickRandom(upperCaseChars);
+  password += pickRandom(numbers);
+
+  for (let i = password.length; i < length; i++) {
+    password += pickRandom(allChars);
   }
 
-  return password;
+  return shuffle(password);
 }
+
+const pickRandom = (arr: string) => arr[Math.floor(Math.random() * arr.length)];
+
+const shuffle = (arr: string) =>
+  arr
+    .split("")
+    .sort(() => Math.random() - 0.5)
+    .join("");


### PR DESCRIPTION

Using the sdk CI I ran into the issue where the user creation failed because the password was too common (??) which looking at the password seemed unlikely, but it was only characters without numbers so I thought that was the reason.

It's unlikely to happen, but from what I've seen it looks like this error requires the user to start the process again from the start so I did this little change to make it less likely to happen