### PR TITLE
fix(sdk): always pull the latest image in the cli

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/cli/steps/start-local-metabase-container.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/steps/start-local-metabase-container.ts
@@ -106,7 +106,7 @@ export const startLocalMetabaseContainer: CliStepMethod = async state => {
       .join(" ");
 
     const { stderr, stdout } = await exec(
-      `docker run --detach -p ${port}:3000 ${envFlags} --name ${CONTAINER_NAME} ${IMAGE_NAME}`,
+      `docker run --pull always --detach -p ${port}:3000 ${envFlags} --name ${CONTAINER_NAME} ${IMAGE_NAME}`,
     );
 
     if (stdout) {


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/46738

Check https://docs.docker.com/reference/cli/docker/container/run/#pull