### PR TITLE
fix: get correct values from theme to fill css variables

### DIFF
--- a/frontend/src/metabase/styled-components/theme/css-variables.ts
+++ b/frontend/src/metabase/styled-components/theme/css-variables.ts
@@ -1,5 +1,5 @@
 import { css } from "@emotion/react";
-import { get } from "underscore";
+import { getIn } from "icepick";
 
 import type { MetabaseComponentTheme } from "embedding-sdk";
 import { SDK_TO_MAIN_APP_COLORS_MAPPING } from "embedding-sdk/lib/theme/embedding-color-palette";
@@ -96,10 +96,8 @@ function getSdkDesignSystemCssVariables(theme: MantineTheme) {
  **/
 export function getThemeSpecificCssVariables(theme: MantineTheme) {
   // Get value from theme.other, which is typed as MetabaseComponentTheme
-  const getValue = (key: MetabaseComponentThemeKey) => {
-    const value = get(theme.other, key);
-
-    return value as string | undefined;
+  const getValue = (key: MetabaseComponentThemeKey): string | undefined => {
+    return getIn(theme.other, key.split("."));
   };
 
   return css`

--- a/frontend/src/metabase/styled-components/theme/css-variables.unit.spec.ts
+++ b/frontend/src/metabase/styled-components/theme/css-variables.unit.spec.ts
@@ -1,0 +1,23 @@
+import type { MantineTheme } from "metabase/ui";
+
+import { getThemeSpecificCssVariables } from "./css-variables";
+
+describe("getThemeSpecificCssVariables", () => {
+  it("returns the correct CSS variables", () => {
+    const theme = {
+      other: {
+        dashboard: {
+          backgroundColor: "red",
+          card: {
+            backgroundColor: "purple",
+          },
+        },
+      },
+    } as MantineTheme;
+
+    const styles = getThemeSpecificCssVariables(theme).styles;
+
+    expect(styles).toContain("--mb-color-bg-dashboard:red;");
+    expect(styles).toContain("--mb-color-bg-dashboard-card:purple;");
+  });
+});


### PR DESCRIPTION
### Description

Fixes background color of the dashcards after https://github.com/metabase/metabase/pull/46660

### How to verify

go to any dashboard with dashcards, make sure background of the cards is white

### Demo

### Before
<img width="1293" alt="Screenshot 2024-08-12 at 19 43 55" src="https://github.com/user-attachments/assets/992aa182-0852-4a21-bcdd-150f468030d3">

### After

<img width="1291" alt="Screenshot 2024-08-12 at 19 44 15" src="https://github.com/user-attachments/assets/93d14b0a-eac7-46f2-b17a-6f8e932027b4">




### Checklist


- [x] Tests have been added/updated to cover changes in this PR
