### PR TITLE
Prevent opening data source in a new tab for embedding SDK

### DIFF
--- a/frontend/src/metabase/query_builder/components/notebook/NotebookDataPicker/NotebookDataPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookDataPicker/NotebookDataPicker.tsx
@@ -7,10 +7,11 @@ import {
   getDataPickerValue,
 } from "metabase/common/components/DataPicker";
 import { METAKEY } from "metabase/lib/browser";
-import { useDispatch, useStore } from "metabase/lib/redux";
+import { useDispatch, useSelector, useStore } from "metabase/lib/redux";
 import { checkNotNull } from "metabase/lib/types";
 import * as Urls from "metabase/lib/urls";
 import { loadMetadataForTable } from "metabase/questions/actions";
+import { getIsEmbeddingSdk } from "metabase/selectors/embed";
 import { getMetadata } from "metabase/selectors/metadata";
 import type { IconName } from "metabase/ui";
 import { Group, Icon, UnstyledButton, Tooltip } from "metabase/ui";
@@ -52,6 +53,8 @@ export function NotebookDataPicker({
   const dispatch = useDispatch();
   const onChangeRef = useLatest(onChange);
 
+  const isEmbeddingSdk = useSelector(getIsEmbeddingSdk);
+
   const tableInfo = useMemo(
     () => table && Lib.displayInfo(query, stageIndex, table),
     [query, stageIndex, table],
@@ -86,20 +89,24 @@ export function NotebookDataPicker({
     const isCtrlOrMetaClick =
       (event.ctrlKey || event.metaKey) && event.button === 0;
 
-    isCtrlOrMetaClick ? openDataSourceInNewTab() : setIsOpen(true);
+    isCtrlOrMetaClick && !isEmbeddingSdk
+      ? openDataSourceInNewTab()
+      : setIsOpen(true);
   };
 
   const handleAuxClick = (event: MouseEvent<HTMLButtonElement>) => {
     const isMiddleClick = event.button === 1;
 
-    isMiddleClick ? openDataSourceInNewTab() : setIsOpen(true);
+    isMiddleClick && !isEmbeddingSdk
+      ? openDataSourceInNewTab()
+      : setIsOpen(true);
   };
 
   return (
     <>
       <Tooltip
         label={t`${METAKEY}+click to open in new tab`}
-        hidden={!table}
+        hidden={!table || isEmbeddingSdk}
         events={{
           hover: true,
           focus: false,


### PR DESCRIPTION
### Description
This PR prevents opening data source links from a notebook in an embedding SDK scenario. It is a part of the Milestone 4 of https://github.com/metabase/metabase/issues/46201.

### How to verify
- Run embedding SDK instance.
- Open notebook editor
- Make sure meta/ctrl or middle click do not open the data source in a new tab

Run provided unit tests.

### Checklist
- [x] Tests have been added/updated to cover changes in this PR
