### PR TITLE
test: Update embedding state mocks

### DIFF
--- a/frontend/src/metabase-types/store/mocks/embed.ts
+++ b/frontend/src/metabase-types/store/mocks/embed.ts
@@ -1,12 +1,13 @@
 import type { EmbedOptions, EmbedState } from "metabase-types/store";
 
-const createMockEmbedOptions = (opts?: Partial<EmbedOptions>) => ({
+export const createMockEmbedOptions = (opts?: Partial<EmbedOptions>) => ({
   ...opts,
 });
 
 export const createMockEmbedState = (
-  opts?: Partial<EmbedOptions>,
+  opts?: Partial<EmbedState>,
 ): EmbedState => ({
-  options: createMockEmbedOptions(opts),
+  options: createMockEmbedOptions(),
   isEmbeddingSdk: false,
+  ...opts,
 });

--- a/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
@@ -9,6 +9,7 @@ import { createMockCard } from "metabase-types/api/mocks";
 import type { EmbedOptions } from "metabase-types/store";
 import {
   createMockAppState,
+  createMockEmbedOptions,
   createMockEmbedState,
   createMockQueryBuilderState,
 } from "metabase-types/store/mocks";
@@ -174,8 +175,10 @@ function setup(embedOptions: Partial<EmbedOptions>) {
     storeInitialState: {
       app: createMockAppState({ isNavbarOpen: false }),
       embed: createMockEmbedState({
-        ...DEFAULT_EMBED_OPTIONS,
-        ...embedOptions,
+        options: createMockEmbedOptions({
+          ...DEFAULT_EMBED_OPTIONS,
+          ...embedOptions,
+        }),
       }),
       qb: createMockQueryBuilderState({
         card: createMockCard(),

--- a/frontend/src/metabase/nav/containers/Navbar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.unit.spec.tsx
@@ -24,6 +24,7 @@ import { createMockDatabase, createMockUser } from "metabase-types/api/mocks";
 import type { State } from "metabase-types/store";
 import {
   createMockAppState,
+  createMockEmbedOptions,
   createMockEmbedState,
   createMockState,
 } from "metabase-types/store/mocks";
@@ -54,7 +55,9 @@ async function setup({
     app: createMockAppState({
       isNavbarOpen: isOpen ?? isNavbarOpenForPathname(pathname, true),
     }),
-    embed: createMockEmbedState(embedOptions),
+    embed: createMockEmbedState({
+      options: createMockEmbedOptions(embedOptions),
+    }),
     currentUser: user,
   });
 


### PR DESCRIPTION
This PR updates the embedding state mocks (helpers).

It exports `createMockEmbedOptions` that forces a user to explicitly pass the options but it also makes it available to mock `isEmbeddingSdk`, which wasn't possible before.