### PR TITLE
Fix the distance between "Field to map to" and "required"

### DIFF
--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/FieldMappingSelect.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/FieldMappingSelect.tsx
@@ -2,16 +2,13 @@ import { t } from "ttag";
 
 import Schemas from "metabase/entities/schemas";
 import { SchemaTableAndFieldDataSelector } from "metabase/query_builder/components/DataSelector";
+import { Text } from "metabase/ui";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type Field from "metabase-lib/v1/metadata/Field";
 import type Table from "metabase-lib/v1/metadata/Table";
 import type { FieldId, TemplateTag } from "metabase-types/api";
 
-import {
-  ContainerLabel,
-  ErrorSpan,
-  InputContainer,
-} from "./TagEditorParam.styled";
+import { ContainerLabel, InputContainer } from "./TagEditorParam.styled";
 
 export function FieldMappingSelect({
   tag,
@@ -36,7 +33,11 @@ export function FieldMappingSelect({
     <InputContainer>
       <ContainerLabel>
         {t`Field to map to`}
-        {tag.dimension == null && <ErrorSpan>{t`(required)`}</ErrorSpan>}
+        {tag.dimension == null && (
+          <Text c="error" span={true} ml="sm">
+            {t`(required)`}
+          </Text>
+        )}
       </ContainerLabel>
 
       {(!hasSelectedDimensionField ||


### PR DESCRIPTION
Closes #46724

### Description

This PR fixes the CSS regression described in #46724. I checked the version 49.14 where the space between these two words was 0.5rem.

I used this opportunity to replace the styled component with Mantine's `Text`.

### How to verify

1. New sql query
2. `select * from orders where {{ foo }}`
3. Set foo as the field filter but do not map it to any table
4. There should be a distance between "Field to map to" and "(required)"

### Demo

**Before**
<img width="975" alt="image" src="https://github.com/user-attachments/assets/4b4aca58-5b3a-4831-b400-52f275889543">

**After**
<img width="977" alt="image" src="https://github.com/user-attachments/assets/6c11bf74-9469-485b-bbe9-9ddf57760333">

### Checklist
- [ ] Tests have been added/updated to cover changes in this PR
