### PR TITLE
fix clearing parameter value closes tab

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -81,6 +81,7 @@ module.exports = {
       { additionalHooks: "(useSyncedQueryString|useSafeAsyncFunction)" },
     ],
     "prefer-const": [1, { destructuring: "all" }],
+    "no-restricted-globals": ["error", "close"],
     "no-useless-escape": 0,
     "no-only-tests/no-only-tests": [
       "error",

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -155,7 +155,6 @@ class ParameterValueWidget extends Component {
           status="clear"
           onClick={() => {
             setValue(null);
-            close();
           }}
         />
       );
@@ -198,7 +197,6 @@ class ParameterValueWidget extends Component {
           status="clear"
           onClick={() => {
             setValue(null);
-            close();
           }}
         />
       );


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/46570

### Description

The issue exists only in the `release-x.50.x` branch which is caused by https://github.com/metabase/metabase/pull/46473
When backporting the release branch version in the component did not have the `close` function definition so the backported code that used `close` called the global one. 

### How to verify & demo

Reproduction steps:
https://www.loom.com/share/47b97d3e78b64278ae4c3e8b0f2e15f0?sid=ba9cd4c7-a39f-4aed-baa1-55050df5f49e

After the fix:
https://www.loom.com/share/e280d4eadc234fe2a0853dcb0d3aba98?sid=3b420e35-8839-49aa-9fdb-803361be2e1f

### Checklist

- [x] Tests have been added/updated to cover changes in this PR — Added an ESLint rule as Cypress does not support cross-tab testing
