### PR TITLE
Fix conventional commit reminder

### DIFF
--- a/.github/workflows/conventional-commit-pr-title-reminder.yml
+++ b/.github/workflows/conventional-commit-pr-title-reminder.yml
@@ -34,6 +34,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Remind PR authors to use conventional commit in the title
+        if: ${{ steps.is-conventional-commit.outputs.result != 'true' }}
         uses: actions/github-script@v7
         with:
           script: |

--- a/enterprise/frontend/src/embedding-sdk/README.md
+++ b/enterprise/frontend/src/embedding-sdk/README.md
@@ -1074,7 +1074,6 @@ application is located in the same directory as Metabase directory:
 }
 ```
 
-
 And then you can install the package using npm or yarn:
 
 ```bash
@@ -1088,4 +1087,3 @@ yarn
 Embedding SDK package build happens with Github actions if `embedding-sdk-build` label has been set on the PR.
 
 Published package will use a version from `package.template.json` + current date and commit short hash.
-

--- a/enterprise/frontend/src/embedding-sdk/README.md
+++ b/enterprise/frontend/src/embedding-sdk/README.md
@@ -1074,6 +1074,7 @@ application is located in the same directory as Metabase directory:
 }
 ```
 
+
 And then you can install the package using npm or yarn:
 
 ```bash

--- a/enterprise/frontend/src/embedding-sdk/README.md
+++ b/enterprise/frontend/src/embedding-sdk/README.md
@@ -1087,3 +1087,4 @@ yarn
 Embedding SDK package build happens with Github actions if `embedding-sdk-build` label has been set on the PR.
 
 Published package will use a version from `package.template.json` + current date and commit short hash.
+


### PR DESCRIPTION
This fixes the bug created by #46625. The problem was that the condition to check PR titles was removed unintentionally.

#### How to verify

Look at the following results. I added commits that would trigger the workflow.

This is now [skipped correctly](https://github.com/metabase/metabase/actions/runs/10365461023/job/28692631545?pr=46760).

And it will also still remind you if the title doesn't follow the convention
![image](https://github.com/user-attachments/assets/1eaa6096-5246-4156-913e-4f9ac5bd1689)
