### PR TITLE
Put a band-aid around flake with spec generator

### DIFF
--- a/test/metabase/test/generate.clj
+++ b/test/metabase/test/generate.clj
@@ -1,6 +1,7 @@
 (ns metabase.test.generate
   (:require
    [clojure.spec.alpha :as s]
+   [clojure.string :as str]
    [clojure.test.check.generators :as gen]
    [java-time.api :as t]
    [metabase.legacy-mbql.util :as mbql.u]
@@ -368,6 +369,17 @@
 (defn- remove-ids [_ {:keys [visit-val] :as _visit-opts}]
   (dissoc visit-val :id))
 
+(defn- spec-gen-with-retries [query num-retries]
+  (try
+    (spec-gen query)
+       (catch clojure.lang.ExceptionInfo e
+         (if (and (pos? num-retries)
+                  (str/includes? (ex-message e) "Couldn't satisfy such-that predicate"))
+           ;; We can't recur from here, and I don't think it's worth using a more complex trampoline.
+           ;; We are not going to overflow the stack, so this should be fine.
+           (spec-gen-with-retries query (dec num-retries))
+           (throw e)))))
+
 (defn insert!
   "Insert pseudorandom entities to the current database according to `query` specmonstah spec. The process follows
   several steps while building the entities:
@@ -377,13 +389,14 @@
   - Adjust entites, in case some fields need extra tunning like incremental position, or collections.location
   - Insert entity into the db using `toucan.core/insert!` "
   [query]
-  (-> (spec-gen query)
+  (-> (spec-gen-with-retries query 5)
       (rs/visit-ents :spec-gen remove-ids)
       (rs/visit-ents :spec-gen adjust)
       (rs/visit-ents-once
        :insert! (fn [sm-db {:keys [schema-opts attrs] :as visit-opts}]
                   (try
                     (first (t2/insert-returning-instances! (:model schema-opts)
+                                                           #_{:clj-kondo/ignore [:deprecated-var]}
                                                            (rsg/spec-gen-assoc-relations
                                                              sm-db
                                                              (assoc visit-opts :visit-val (:spec-gen attrs)))))


### PR DESCRIPTION
References https://github.com/metabase/metabase/issues/45747

### Description

This increases the number of attempts we make at generating the specs from 100 to 500.

Unfortunately given hard far down the stack the actual generation occurs, I wasn't able to find a way to adjust the parameter directly. For this reason I have simply added a an extra layer of retries at the top-level.