### PR TITLE
Fix exported png got different backgrounds based on screen density

### DIFF
--- a/frontend/src/metabase/visualizations/lib/save-chart-image.ts
+++ b/frontend/src/metabase/visualizations/lib/save-chart-image.ts
@@ -28,6 +28,7 @@ export const saveChartImage = async (selector: string, fileName: string) => {
 
   const { default: html2canvas } = await import("html2canvas-pro");
   const canvas = await html2canvas(node, {
+    scale: 2,
     useCORS: true,
     onclone: (doc: Document, node: HTMLElement) => {
       node.classList.add(SAVING_DOM_IMAGE_CLASS);


### PR DESCRIPTION
Reported in https://metaboat.slack.com/archives/C01LQQ2UW03/p1723219945676859

This is very hard to debug, but thanks to @npretto for finding the GitHub issue that contains [this work around](https://github.com/niklasvh/html2canvas/issues/2302#issuecomment-672846820).

### Description

It seems different screen with different density produce exports with different background colors.

### How to verify

Well, just use normal screen, mine was 1080p desktop monitor. You can't use a Macbook or an iPad for this as it doesn't show the bug.

Then export a dashboard card. You should see a beautiful white background export without weird grey/brown tint color.

### Demo
on an external screen

#### After
- ![line chart-8_13_2024, 7_46_05 PM](https://github.com/user-attachments/assets/733a93ff-c3e6-46ef-8910-23f9fed29efa)

Static embed
- [New dash (6).pdf](https://github.com/user-attachments/files/16600008/New.dash.6.pdf)
- [New dash (7).pdf](https://github.com/user-attachments/files/16600014/New.dash.7.pdf)
- ![line chart-8_13_2024, 8_02_54 PM](https://github.com/user-attachments/assets/dde4b427-4d32-48e7-932b-1dbcaf128279)
- ![line chart-8_13_2024, 8_03_00 PM](https://github.com/user-attachments/assets/b2d17f36-65a9-4a2f-827c-f701e8f814fb)


#### Before
- ![line chart-8_13_2024, 7_46_21 PM](https://github.com/user-attachments/assets/8c412dbf-05f1-4c13-8073-c0278c132a09)

Static embed

- [New dash (4).pdf](https://github.com/user-attachments/files/16599937/New.dash.4.pdf)
- [New dash (5).pdf](https://github.com/user-attachments/files/16599938/New.dash.5.pdf)
- ![line chart-8_13_2024, 7_59_01 PM](https://github.com/user-attachments/assets/88936d06-33ef-41ce-ad2a-4b83cd4fd405)
- ![line chart-8_13_2024, 7_59_05 PM](https://github.com/user-attachments/assets/a4718035-2fa0-4222-8abb-72e4f991c8ab)


### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~ Absolutely no idea how to automate this.
