### PR TITLE
[manual backport] Dowload Row Limit Env Var (#46401)

### DIFF
--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -852,3 +852,10 @@ See [fonts](../configuring-metabase/fonts.md).")
                   (if-not (pos-int? value)
                     20
                     value))))
+
+(defsetting download-row-limit
+  (deferred-tru "Exports row limit excluding the header. xlsx downloads are limited to 1048575 rows even if this limit is higher.")
+  :visibility :internal
+  :export?    true
+  :type       :integer
+  :doc false)

--- a/src/metabase/pulse/util.clj
+++ b/src/metabase/pulse/util.clj
@@ -20,18 +20,18 @@
     (try
       (when-let [{query :dataset_query
                   :keys [dataset result_metadata]
-                  :as card} (t2/select-one :model/Card :id card-id, :archived false)]
+                  :as   card} (t2/select-one :model/Card :id card-id, :archived false)]
         (let [query         (assoc query :async? false)
               process-query (fn []
                               (binding [qp.perms/*card-id* card-id]
-                                (qp/process-query-and-save-with-max-results-constraints!
+                                (qp/process-query-and-save-execution!
                                  (assoc query :middleware {:skip-results-metadata? true
                                                            :process-viz-settings?  true
                                                            :js-int-to-string?      false})
                                  (merge (cond->
-                                          {:executed-by               pulse-creator-id
-                                           :context                   :pulse
-                                           :card-id                   card-id}
+                                            {:executed-by               pulse-creator-id
+                                             :context                   :pulse
+                                             :card-id                   card-id}
                                           dataset
                                           (assoc :metadata/dataset-metadata result_metadata))
                                         options))))

--- a/src/metabase/query_processor/middleware/limit.clj
+++ b/src/metabase/query_processor/middleware/limit.clj
@@ -25,9 +25,8 @@
     (update :query assoc :limit max-rows, ::original-limit original-limit)))
 
 (defn- xlsx-export?
-  [& {info :info}]
-  (let [context (:context info)]
-    (= context :xlsx-download)))
+  [query]
+  (= (-> query :info :context) :xlsx-download))
 
 (defn determine-query-max-rows
   "Given a `query`, return the max rows that should be returned. This is either:

--- a/src/metabase/query_processor/middleware/limit.clj
+++ b/src/metabase/query_processor/middleware/limit.clj
@@ -2,6 +2,7 @@
   "Middleware that handles limiting the maximum number of rows returned by a query."
   (:require
    [metabase.mbql.util :as mbql.u]
+   [metabase.public-settings :as public-settings]
    [metabase.query-processor.interface :as qp.i]
    [metabase.query-processor.util :as qp.util]))
 
@@ -23,14 +24,25 @@
          (qp.util/query-without-aggregations-or-limits? query))
     (update :query assoc :limit max-rows, ::original-limit original-limit)))
 
+(defn- xlsx-export?
+  [& {info :info}]
+  (let [context (:context info)]
+    (= context :xlsx-download)))
+
 (defn determine-query-max-rows
   "Given a `query`, return the max rows that should be returned. This is either:
-  1. the output of [[metabase.mbql.util/query->max-rows-limit]] when called on the given query
-  2. [[metabase.query-processor.interface/absolute-max-results]] (a constant, non-nil backstop value)"
+  1. the output of [[metabase.legacy-mbql.util/query->max-rows-limit]] when called on the given query
+  2. the value of `pubic-settings/download-row-limit`
+     a. if it is less than [[metabase.query-processor.interface/absolute-max-results]] or
+     b. if it is greater and the export is NOT xlsx otherwise,
+  3. [[metabase.query-processor.interface/absolute-max-results]] (a constant, non-nil backstop value)"
   [query]
   (when-not (disable-max-results? query)
-    (or (mbql.u/query->max-rows-limit query)
-        qp.i/absolute-max-results)))
+    (cond-> (or (mbql.u/query->max-rows-limit query)
+                (public-settings/download-row-limit)
+                qp.i/absolute-max-results)
+      (xlsx-export? query)
+      (min qp.i/absolute-max-results))))
 
 (defn add-default-limit
   "Pre-processing middleware. Add default `:limit` to MBQL queries without any aggregations."

--- a/src/metabase/query_processor/middleware/limit.clj
+++ b/src/metabase/query_processor/middleware/limit.clj
@@ -30,7 +30,7 @@
 
 (defn determine-query-max-rows
   "Given a `query`, return the max rows that should be returned. This is either:
-  1. the output of [[metabase.legacy-mbql.util/query->max-rows-limit]] when called on the given query
+  1. the output of [[metabase.mbql.util/query->max-rows-limit]] when called on the given query
   2. the value of `pubic-settings/download-row-limit`
      a. if it is less than [[metabase.query-processor.interface/absolute-max-results]] or
      b. if it is greater and the export is NOT xlsx otherwise,

--- a/test/metabase/pulse_test.clj
+++ b/test/metabase/pulse_test.clj
@@ -13,12 +13,12 @@
    [metabase.models.permissions :as perms]
    [metabase.models.permissions-group :as perms-group]
    [metabase.models.pulse :as pulse]
+   [metabase.public-settings :as public-settings]
    [metabase.pulse]
    [metabase.pulse.render :as render]
    [metabase.pulse.render.body :as body]
    [metabase.pulse.test-util :as pulse.test-util]
    [metabase.pulse.util :as pu]
-   [metabase.query-processor.middleware.constraints :as qp.constraints]
    [metabase.test :as mt]
    [metabase.test.util :as tu]
    [metabase.util :as u]
@@ -342,8 +342,7 @@
 
       :fixture
       (fn [_ thunk]
-        (with-redefs [qp.constraints/default-query-constraints (constantly {:max-results           10000
-                                                                            :max-results-bare-rows 30})]
+        (mt/with-temporary-setting-values [public-settings/download-row-limit 30]
           (thunk)))
       :pulse-card {:include_csv true}
       :assert

--- a/test/metabase/query_processor/middleware/limit_test.clj
+++ b/test/metabase/query_processor/middleware/limit_test.clj
@@ -113,6 +113,6 @@
                            :query       {}
                            ;; setting a constraint here will result in `(mbql.u/query->max-rows-limit query)` returning that limit
                            ;; so we can use this to check the behaviour of `limit/add-default-limit` when download-row-limit is unset
-                           :constraints (when limit {:max-results-bare-rows limit})
+                           :constraints {:max-results-bare-rows limit}
                            :info        {:context context}})
                          [:query :limit])))))))


### PR DESCRIPTION
* Dowload Row Limit Env Var

Adds `MB_DOWNLOAD_ROW_LIMIT` to enable changing the row limit on downloads and alert/subscription attachments (not the rendered tables, but the .csv, etc.).

Based on: #44982 (Thanks, @r-kot)

Partially implements: #28144

The difference in this PR compared to #44982 is that the download limit applies to all downloads, the only exception being when the limit is above `qp.i/absolute-max-results` (1048575, based on Excel's limitation); in such a case, the user supplied limit is only used if the download is csv or json, and `qp.i/absolute-max-results` is used for xlsx.

This PR also fixes alert/subscription attachment limits; prior to this, they were set to the in-app limit of 2000 rows, but now they will follow the user supplied download-row-limit.

This PR also adds a test to the downloads-and-exports test namespace, confirming that they follow the supplied limit, or the max limit if none is supplied.

* add test confirming the default limit works

* fix test to use the download-row-limit

* address review feedback

* Update src/metabase/public_settings.clj



* add test covering case where download-row-limit is unset