### PR TITLE
e2e: Fix dashboard number filter flakes

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-number.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-number.cy.spec.js
@@ -1,7 +1,4 @@
-import {
-  ORDERS_DASHBOARD_ID,
-  ORDERS_DASHBOARD_DASHCARD_ID,
-} from "e2e/support/cypress_sample_instance_data";
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 import {
   restore,
   popover,
@@ -35,6 +32,18 @@ describe("scenarios > dashboard > filters > number", () => {
     visitDashboard(ORDERS_DASHBOARD_ID);
 
     editDashboard();
+
+    /**
+     * Even though we're already intercepting this route in the visitDashboard helper,
+     * it is important to alias it differently here, and to then wait for it in tests.
+     *
+     * The place where the intercept is first set matters.
+     * If we set it before the visitDashboard, we'd have to wait for it after the visit,
+     * otherwise we'd always be one wait behind in tests.
+     */
+    cy.intercept("POST", "api/dashboard/*/dashcard/*/card/*/query").as(
+      "dashboardData",
+    );
   });
 
   it("should work when set through the filter widget", () => {
@@ -53,19 +62,19 @@ describe("scenarios > dashboard > filters > number", () => {
     });
 
     saveDashboard();
+    cy.wait("@dashboardData");
 
     DASHBOARD_NUMBER_FILTERS.forEach(
       ({ operator, value, representativeResult }, index) => {
         filterWidget().eq(index).click();
         addWidgetNumberFilter(value);
+        cy.wait("@dashboardData");
 
         cy.log(`Make sure ${operator} filter returns correct result`);
-        cy.findByTestId("dashcard").within(() => {
-          cy.findByText(representativeResult);
-        });
+        cy.findByTestId("dashcard").should("contain", representativeResult);
 
         clearFilterWidget(index);
-        cy.wait(`@dashcardQuery${ORDERS_DASHBOARD_DASHCARD_ID}`);
+        cy.wait("@dashboardData");
       },
     );
   });
@@ -79,27 +88,25 @@ describe("scenarios > dashboard > filters > number", () => {
     addWidgetNumberFilter("2.07");
 
     saveDashboard();
+    cy.wait("@dashboardData");
 
-    cy.findByTestId("dashcard").within(() => {
-      cy.findByText("37.65");
-    });
+    cy.findByTestId("dashcard")
+      .should("contain", "37.65")
+      .and("not.contain", "101.04");
 
     clearFilterWidget();
+    cy.wait("@dashboardData");
 
     filterWidget().click();
-
     addWidgetNumberFilter("5.27", { buttonLabel: "Update filter" });
+    cy.wait("@dashboardData");
 
-    cy.findByTestId("dashcard").within(() => {
-      cy.findByText("101.04");
-    });
+    cy.findByTestId("dashcard")
+      .should("contain", "101.04")
+      .and("not.contain", "37.65");
   });
 
   it("should support being required", () => {
-    cy.intercept("POST", "api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashboardData",
-    );
-
     setFilter("Number", "Equal to", "Equal to");
     selectDashboardFilter(cy.findByTestId("dashcard"), "Tax");
 

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-number.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-number.cy.spec.js
@@ -96,6 +96,8 @@ describe("scenarios > dashboard > filters > number", () => {
   });
 
   it("should support being required", () => {
+    cy.intercept("POST", "api/dashboard/*/dashcard/*/card/*/query").as("foo");
+
     setFilter("Number", "Equal to", "Equal to");
     selectDashboardFilter(cy.findByTestId("dashcard"), "Tax");
 
@@ -119,16 +121,19 @@ describe("scenarios > dashboard > filters > number", () => {
     sidebar().findByText("Default value").next().click();
     addWidgetNumberFilter("2.07", { buttonLabel: "Update filter" });
 
-    saveDashboard();
+    saveDashboard({ awaitRequest: true });
+    cy.wait("@foo");
     ensureDashboardCardHasText("37.65");
 
     // Updates the filter value
     setFilterWidgetValue("5.27", "Enter a number");
+    cy.wait("@foo");
     ensureDashboardCardHasText("95.77");
 
     // Resets the value back by clicking widget icon
     resetFilterWidgetToDefault();
     filterWidget().findByText("2.07");
+    cy.wait("@foo");
     ensureDashboardCardHasText("37.65");
 
     // Removing value resets back to default

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-number.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-number.cy.spec.js
@@ -96,7 +96,9 @@ describe("scenarios > dashboard > filters > number", () => {
   });
 
   it("should support being required", () => {
-    cy.intercept("POST", "api/dashboard/*/dashcard/*/card/*/query").as("foo");
+    cy.intercept("POST", "api/dashboard/*/dashcard/*/card/*/query").as(
+      "dashboardData",
+    );
 
     setFilter("Number", "Equal to", "Equal to");
     selectDashboardFilter(cy.findByTestId("dashcard"), "Tax");
@@ -121,19 +123,19 @@ describe("scenarios > dashboard > filters > number", () => {
     sidebar().findByText("Default value").next().click();
     addWidgetNumberFilter("2.07", { buttonLabel: "Update filter" });
 
-    saveDashboard({ awaitRequest: true });
-    cy.wait("@foo");
+    saveDashboard();
+    cy.wait("@dashboardData");
     ensureDashboardCardHasText("37.65");
 
     // Updates the filter value
     setFilterWidgetValue("5.27", "Enter a number");
-    cy.wait("@foo");
+    cy.wait("@dashboardData");
     ensureDashboardCardHasText("95.77");
 
     // Resets the value back by clicking widget icon
     resetFilterWidgetToDefault();
     filterWidget().findByText("2.07");
-    cy.wait("@foo");
+    cy.wait("@dashboardData");
     ensureDashboardCardHasText("37.65");
 
     // Removing value resets back to default


### PR DESCRIPTION
For some reason these tests have been flaking almost constantly in the last couple of days.
After observing what's going on, I realized that we need to wait for the dashboard data responses.

Once I set those in place, the test started passing consistently.

> [!Important]
> I will force-merge this PR as soon as the stress-test confirms that the test is fixed. We need to unblock `master` ASAP.

### Stress-test
30/30 ✅ https://github.com/metabase/metabase/actions/runs/10374282112