### PR TITLE
e2e: Fix dashboard ID filter flakes

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-id.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-id.cy.spec.js
@@ -24,7 +24,20 @@ describe("scenarios > dashboard > filters > ID", () => {
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select…").click();
+
+    /**
+     * Even though we're already intercepting this route in the visitDashboard helper,
+     * it is important to alias it differently here, and to then wait for it in tests.
+     *
+     * The place where the intercept is first set matters.
+     * If we set it before the visitDashboard, we'd have to wait for it after the visit,
+     * otherwise we'd always be one wait behind in tests.
+     */
+    cy.intercept("POST", "api/dashboard/*/dashcard/*/card/*/query").as(
+      "dashboardData",
+    );
   });
+
   describe("should work for the primary key", () => {
     beforeEach(() => {
       popover().contains("ID").first().click();
@@ -32,14 +45,14 @@ describe("scenarios > dashboard > filters > ID", () => {
 
     it("when set through the filter widget", () => {
       saveDashboard();
+      cy.wait("@dashboardData");
 
       filterWidget().click();
       addWidgetStringFilter("15");
+      cy.wait("@dashboardData");
       cy.findByTestId("loading-indicator").should("not.exist");
 
-      cy.findByTestId("dashcard").within(() => {
-        cy.findByText("114.42");
-      });
+      cy.findByTestId("dashcard").should("contain", "114.42");
     });
 
     it("when set as the default filter", () => {
@@ -48,11 +61,10 @@ describe("scenarios > dashboard > filters > ID", () => {
       addWidgetStringFilter("15");
 
       saveDashboard();
+      cy.wait("@dashboardData");
       cy.findByTestId("loading-indicator").should("not.exist");
 
-      cy.findByTestId("dashcard").within(() => {
-        cy.findByText("114.42");
-      });
+      cy.findByTestId("dashcard").should("contain", "114.42");
     });
   });
 
@@ -63,15 +75,14 @@ describe("scenarios > dashboard > filters > ID", () => {
 
     it("when set through the filter widget", () => {
       saveDashboard();
+      cy.wait("@dashboardData");
 
       filterWidget().click();
       addWidgetStringFilter("4");
+      cy.wait("@dashboardData");
       cy.findByTestId("loading-indicator").should("not.exist");
 
-      cy.findByTestId("dashcard").within(() => {
-        cy.findByText("47.68");
-      });
-
+      cy.findByTestId("dashcard").should("contain", "47.68");
       checkFilterLabelAndValue("ID", "Arnold Adams - 4");
     });
 
@@ -81,12 +92,10 @@ describe("scenarios > dashboard > filters > ID", () => {
       addWidgetStringFilter("4");
 
       saveDashboard();
+      cy.wait("@dashboardData");
       cy.findByTestId("loading-indicator").should("not.exist");
 
-      cy.findByTestId("dashcard").within(() => {
-        cy.findByText("47.68");
-      });
-
+      cy.findByTestId("dashcard").should("contain", "47.68");
       checkFilterLabelAndValue("ID", "Arnold Adams - 4");
     });
   });
@@ -103,14 +112,14 @@ describe("scenarios > dashboard > filters > ID", () => {
 
     it("when set through the filter widget", () => {
       saveDashboard();
+      cy.wait("@dashboardData");
 
       filterWidget().click();
       addWidgetStringFilter("10");
+      cy.wait("@dashboardData");
       cy.findByTestId("loading-indicator").should("not.exist");
 
-      cy.findByTestId("dashcard").within(() => {
-        cy.findByText("6.75");
-      });
+      cy.findByTestId("dashcard").should("contain", "6.75");
     });
 
     it("when set as the default filter", () => {
@@ -119,11 +128,10 @@ describe("scenarios > dashboard > filters > ID", () => {
       addWidgetStringFilter("10");
 
       saveDashboard();
+      cy.wait("@dashboardData");
       cy.findByTestId("loading-indicator").should("not.exist");
 
-      cy.findByTestId("dashcard").within(() => {
-        cy.findByText("6.75");
-      });
+      cy.findByTestId("dashcard").should("contain", "6.75");
     });
   });
 });


### PR DESCRIPTION
For some reason these tests have been flaking almost constantly in the last couple of days.
After observing what's going on, I realized that we need to wait for the dashboard data responses.

Once I set those in place, the test started passing consistently.
<img width="707" alt="image" src="https://github.com/user-attachments/assets/92c56b6c-8960-4c46-993c-2deb0bd3890f">

> [!Important]
> I will force-merge this PR as soon as the stress-test confirms that the test is fixed. We need to unblock `master` ASAP.

### Stress-test
30/30 in progress https://github.com/metabase/metabase/actions/runs/10374864892