### PR TITLE
Improve Clear cache button text and question refresh button tooltip

### DIFF
--- a/e2e/test/scenarios/admin/performance/helpers/e2e-performance-helpers.ts
+++ b/e2e/test/scenarios/admin/performance/helpers/e2e-performance-helpers.ts
@@ -20,6 +20,7 @@ export const interceptPerformanceRoutes = () => {
   cy.intercept("POST", "/api/cache/invalidate?include=overrides&database=*").as(
     "invalidateCacheForSampleDatabase",
   );
+  cy.intercept("POST", "/api/cache/invalidate?*").as("invalidateCache");
 };
 
 /** Cypress log messages sometimes occur out of order so it is helpful to log to the console as well. */

--- a/e2e/test/scenarios/admin/performance/performance.cy.spec.ts
+++ b/e2e/test/scenarios/admin/performance/performance.cy.spec.ts
@@ -204,7 +204,7 @@ describe("scenarios > admin > performance", () => {
       saveCacheStrategyForm({ strategyType: "duration", model: "database" });
 
       cy.log("Now there's a 'Clear cache' button. Click it");
-      cy.button(/Clear cache/).click();
+      cy.button(/Clear cache for this database/).click();
 
       cy.log('Confirm via the "Clear cache" dialog');
       cy.findByRole("dialog")

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -1286,6 +1286,24 @@ describeEE("scenarios > dashboard > caching", () => {
       cy.findByLabelText(/Caching policy/).should("contain", "Adaptive");
     });
   });
+
+  it("can click 'Clear cache' for a dashboard", () => {
+    interceptPerformanceRoutes();
+    visitDashboard(ORDERS_DASHBOARD_ID);
+
+    openSidebarCacheStrategyForm();
+
+    rightSidebar().within(() => {
+      cy.findByRole("heading", { name: /Caching settings/ }).should(
+        "be.visible",
+      );
+      cy.findByRole("button", {
+        name: /Clear cache for this dashboard/,
+      }).click();
+      cy.wait("@invalidateCache");
+      cy.findByText("Cache cleared").should("be.visible");
+    });
+  });
 });
 
 describe("scenarios > dashboard > permissions", () => {

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -1300,6 +1300,9 @@ describeEE("scenarios > dashboard > caching", () => {
       cy.findByRole("button", {
         name: /Clear cache for this dashboard/,
       }).click();
+      modal().within(() => {
+        cy.findByRole("button", { name: /Clear cache/ }).click();
+      });
       cy.wait("@invalidateCache");
       cy.findByText("Cache cleared").should("be.visible");
     });

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -1300,10 +1300,13 @@ describeEE("scenarios > dashboard > caching", () => {
       cy.findByRole("button", {
         name: /Clear cache for this dashboard/,
       }).click();
-      modal().within(() => {
-        cy.findByRole("button", { name: /Clear cache/ }).click();
-      });
-      cy.wait("@invalidateCache");
+    });
+
+    modal().within(() => {
+      cy.findByRole("button", { name: /Clear cache/ }).click();
+    });
+    cy.wait("@invalidateCache");
+    rightSidebar().within(() => {
       cy.findByText("Cache cleared").should("be.visible");
     });
   });

--- a/e2e/test/scenarios/question/caching.cy.spec.js
+++ b/e2e/test/scenarios/question/caching.cy.spec.js
@@ -54,4 +54,22 @@ describeEE("scenarios > question > caching", () => {
       cy.findByLabelText(/Caching policy/).should("contain", "Adaptive");
     });
   });
+
+  it("can click 'Clear cache' for a question", () => {
+    interceptPerformanceRoutes();
+    visitQuestion(ORDERS_QUESTION_ID);
+
+    openSidebarCacheStrategyForm();
+
+    rightSidebar().within(() => {
+      cy.findByRole("heading", { name: /Caching settings/ }).should(
+        "be.visible",
+      );
+      cy.findByRole("button", {
+        name: /Clear cache for this question/,
+      }).click();
+      cy.wait("@invalidateCache");
+      cy.findByText("Cache cleared").should("be.visible");
+    });
+  });
 });

--- a/e2e/test/scenarios/question/caching.cy.spec.js
+++ b/e2e/test/scenarios/question/caching.cy.spec.js
@@ -69,10 +69,13 @@ describeEE("scenarios > question > caching", () => {
       cy.findByRole("button", {
         name: /Clear cache for this question/,
       }).click();
-      modal().within(() => {
-        cy.findByRole("button", { name: /Clear cache/ }).click();
-      });
-      cy.wait("@invalidateCache");
+    });
+    modal().within(() => {
+      cy.findByRole("button", { name: /Clear cache/ }).click();
+    });
+    cy.wait("@invalidateCache");
+
+    rightSidebar().within(() => {
       cy.findByText("Cache cleared").should("be.visible");
     });
   });

--- a/e2e/test/scenarios/question/caching.cy.spec.js
+++ b/e2e/test/scenarios/question/caching.cy.spec.js
@@ -1,6 +1,7 @@
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 import {
   describeEE,
+  modal,
   restore,
   rightSidebar,
   setTokenFeatures,
@@ -68,6 +69,9 @@ describeEE("scenarios > question > caching", () => {
       cy.findByRole("button", {
         name: /Clear cache for this question/,
       }).click();
+      modal().within(() => {
+        cy.findByRole("button", { name: /Clear cache/ }).click();
+      });
       cy.wait("@invalidateCache");
       cy.findByText("Cache cleared").should("be.visible");
     });

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/InvalidateNowButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/InvalidateNowButton.tsx
@@ -1,5 +1,6 @@
 import { useFormikContext } from "formik";
 import { useCallback, useMemo } from "react";
+import { match } from "ts-pattern";
 import { c, t } from "ttag";
 
 import { IconInButton } from "metabase/admin/performance/components/StrategyForm.styled";
@@ -56,14 +57,15 @@ const InvalidateNowFormBody = ({
     [askConfirmation, targetName, submitForm],
   );
 
-  const buttonText = useMemo(() => {
-    const map: Record<ModelWithClearableCache, string> = {
-      dashboard: t`Clear cache for this dashboard`,
-      question: t`Clear cache for this question`,
-      database: t`Clear cache for this database`,
-    };
-    return map[targetModel];
-  }, [targetModel]);
+  const buttonText = useMemo(
+    () =>
+      match(targetModel)
+        .with("dashboard", () => t`Clear cache for this dashboard`)
+        .with("question", () => t`Clear cache for this question`)
+        .with("database", () => t`Clear cache for this database`)
+        .exhaustive(),
+    [targetModel],
+  );
 
   return (
     <>

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/InvalidateNowButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/InvalidateNowButton.tsx
@@ -5,17 +5,16 @@ import { c, t } from "ttag";
 import { IconInButton } from "metabase/admin/performance/components/StrategyForm.styled";
 import { useInvalidateTarget } from "metabase/admin/performance/hooks/useInvalidateTarget";
 import { useIsFormPending } from "metabase/admin/performance/hooks/useIsFormPending";
+import type { ModelWithClearableCache } from "metabase/admin/performance/types";
 import { Form, FormProvider } from "metabase/forms";
 import { useConfirmation } from "metabase/hooks/use-confirmation";
 import { color } from "metabase/lib/colors";
-import type {
-  InvalidatableModel,
-  InvalidateNowButtonProps,
-} from "metabase/plugins";
+import type { InvalidateNowButtonProps } from "metabase/plugins";
 import { Group, Icon, Loader, Text } from "metabase/ui";
 
 import { StyledInvalidateNowButton } from "./InvalidateNowButton.styled";
 
+/** Button that clears the cache of a particular object (the "target") */
 export const InvalidateNowButton = ({
   targetId,
   targetModel,
@@ -37,7 +36,7 @@ const InvalidateNowFormBody = ({
   targetModel,
 }: {
   targetName?: string;
-  targetModel: InvalidatableModel;
+  targetModel: ModelWithClearableCache;
 }) => {
   const { show: askConfirmation, modalContent: confirmationModal } =
     useConfirmation();
@@ -58,7 +57,7 @@ const InvalidateNowFormBody = ({
   );
 
   const buttonText = useMemo(() => {
-    const map: Record<InvalidatableModel, string> = {
+    const map: Record<ModelWithClearableCache, string> = {
       dashboard: t`Clear cache for this dashboard`,
       question: t`Clear cache for this question`,
       database: t`Clear cache for this database`,

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/InvalidateNowButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/InvalidateNowButton.tsx
@@ -1,5 +1,5 @@
 import { useFormikContext } from "formik";
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { c, t } from "ttag";
 
 import { IconInButton } from "metabase/admin/performance/components/StrategyForm.styled";
@@ -8,7 +8,10 @@ import { useIsFormPending } from "metabase/admin/performance/hooks/useIsFormPend
 import { Form, FormProvider } from "metabase/forms";
 import { useConfirmation } from "metabase/hooks/use-confirmation";
 import { color } from "metabase/lib/colors";
-import type { InvalidateNowButtonProps } from "metabase/plugins";
+import type {
+  InvalidatableModel,
+  InvalidateNowButtonProps,
+} from "metabase/plugins";
 import { Group, Icon, Loader, Text } from "metabase/ui";
 
 import { StyledInvalidateNowButton } from "./InvalidateNowButton.styled";
@@ -21,12 +24,21 @@ export const InvalidateNowButton = ({
   const invalidateTarget = useInvalidateTarget(targetId, targetModel);
   return (
     <FormProvider initialValues={{}} onSubmit={invalidateTarget}>
-      <InvalidateNowFormBody targetName={targetName} />
+      <InvalidateNowFormBody
+        targetModel={targetModel}
+        targetName={targetName}
+      />
     </FormProvider>
   );
 };
 
-const InvalidateNowFormBody = ({ targetName }: { targetName?: string }) => {
+const InvalidateNowFormBody = ({
+  targetName,
+  targetModel,
+}: {
+  targetName?: string;
+  targetModel: InvalidatableModel;
+}) => {
   const { show: askConfirmation, modalContent: confirmationModal } =
     useConfirmation();
   const { submitForm } = useFormikContext();
@@ -45,6 +57,15 @@ const InvalidateNowFormBody = ({ targetName }: { targetName?: string }) => {
     [askConfirmation, targetName, submitForm],
   );
 
+  const buttonText = useMemo(() => {
+    const map: Record<InvalidatableModel, string> = {
+      dashboard: t`Clear cache for this dashboard`,
+      question: t`Clear cache for this question`,
+      database: t`Clear cache for this database`,
+    };
+    return map[targetModel];
+  }, [targetModel]);
+
   return (
     <>
       <Form>
@@ -57,8 +78,8 @@ const InvalidateNowFormBody = ({ targetName }: { targetName?: string }) => {
           disabled={wasFormRecentlyPending}
           label={
             <Group spacing="sm">
-              <Icon color={color("danger")} name="trash" />
-              <Text>{t`Clear cache`}</Text>
+              <Icon color="var(--mb-color-danger)" name="trash" />
+              <Text>{buttonText}</Text>
             </Group>
           }
           activeLabel={

--- a/frontend/src/metabase-lib/v1/Question.ts
+++ b/frontend/src/metabase-lib/v1/Question.ts
@@ -240,14 +240,6 @@ class Question {
     return this.setCard(assoc(this.card(), "display", display));
   }
 
-  cacheTTL(): number | null {
-    return this._card?.cache_ttl;
-  }
-
-  setCacheTTL(cache) {
-    return this.setCard(assoc(this.card(), "cache_ttl", cache));
-  }
-
   type(): CardType {
     return this._card?.type ?? "question";
   }

--- a/frontend/src/metabase-types/api/dataset.ts
+++ b/frontend/src/metabase-types/api/dataset.ts
@@ -1,4 +1,4 @@
-import type { LocalFieldReference } from "metabase-types/api";
+import type { CacheStrategy, LocalFieldReference } from "metabase-types/api";
 
 import type { Card } from "./card";
 import type { DatabaseId } from "./database";
@@ -66,6 +66,12 @@ export interface DatasetData {
 
 export type JsonQuery = DatasetQuery & {
   parameters?: unknown[];
+  "cache-strategy"?: CacheStrategy & {
+    /** An ISO 8601 date */
+    "invalidated-at"?: string;
+    /** In milliseconds */
+    "avg-execution-ms"?: number;
+  };
 };
 
 export interface Dataset {
@@ -84,6 +90,12 @@ export interface Dataset {
   error_is_curated?: boolean;
   context?: string;
   status?: string;
+  /** In milliseconds */
+  average_execution_time?: number;
+  /** A date in ISO 8601 format */
+  cached?: string;
+  /** A date in ISO 8601 format */
+  started_at?: string;
 }
 
 export interface EmbedDatasetData {

--- a/frontend/src/metabase/admin/performance/components/StrategyForm.tsx
+++ b/frontend/src/metabase/admin/performance/components/StrategyForm.tsx
@@ -15,7 +15,7 @@ import {
   useFormContext,
 } from "metabase/forms";
 import { useSelector } from "metabase/lib/redux";
-import { PLUGIN_CACHING, isInvalidatableModel } from "metabase/plugins";
+import { PLUGIN_CACHING } from "metabase/plugins";
 import { getSetting } from "metabase/selectors/settings";
 import {
   Box,
@@ -41,6 +41,7 @@ import { CacheDurationUnit } from "metabase-types/api";
 import { strategyValidationSchema } from "../constants/complex";
 import { rootId } from "../constants/simple";
 import { useIsFormPending } from "../hooks/useIsFormPending";
+import { isModelWithClearableCache } from "../types";
 import {
   cronToScheduleSettings,
   getLabelString,
@@ -295,7 +296,7 @@ const FormButtons = ({
 
   if (
     shouldAllowInvalidation &&
-    isInvalidatableModel(targetModel) &&
+    isModelWithClearableCache(targetModel) &&
     targetId &&
     targetName
   ) {

--- a/frontend/src/metabase/admin/performance/components/StrategyForm.tsx
+++ b/frontend/src/metabase/admin/performance/components/StrategyForm.tsx
@@ -15,7 +15,7 @@ import {
   useFormContext,
 } from "metabase/forms";
 import { useSelector } from "metabase/lib/redux";
-import { PLUGIN_CACHING } from "metabase/plugins";
+import { PLUGIN_CACHING, isInvalidatableModel } from "metabase/plugins";
 import { getSetting } from "metabase/selectors/settings";
 import {
   Box,
@@ -276,10 +276,6 @@ const FormButtons = ({
 }: FormButtonsProps) => {
   const { dirty } = useFormikContext<CacheStrategy>();
 
-  if (targetId === rootId) {
-    shouldAllowInvalidation = false;
-  }
-
   const { isFormPending, wasFormRecentlyPending } = useIsFormPending();
 
   const isSavingPossible = dirty || isFormPending || wasFormRecentlyPending;
@@ -297,7 +293,12 @@ const FormButtons = ({
     );
   }
 
-  if (shouldAllowInvalidation && targetId && targetName) {
+  if (
+    shouldAllowInvalidation &&
+    isInvalidatableModel(targetModel) &&
+    targetId &&
+    targetName
+  ) {
     return (
       <FormButtonsGroup isInSidebar={isInSidebar}>
         <PLUGIN_CACHING.InvalidateNowButton

--- a/frontend/src/metabase/admin/performance/types.ts
+++ b/frontend/src/metabase/admin/performance/types.ts
@@ -23,3 +23,12 @@ export enum PerformanceTabId {
   Models = "models",
   DashboardsAndQuestions = "dashboards-and-questions",
 }
+
+export type ModelWithClearableCache = Exclude<CacheableModel, "root">;
+
+/** The default policy's cache cannot be cleared. But objects of other kinds,
+ * such as dashboards, databases, and questions, can have their cache cleared
+ * (if they have a cache) */
+export const isModelWithClearableCache = (
+  model: CacheableModel,
+): model is ModelWithClearableCache => model !== "root";

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -14,6 +14,7 @@ import {
   getPerformanceTabMetadata,
   strategies,
 } from "metabase/admin/performance/constants/complex";
+import type { ModelWithClearableCache } from "metabase/admin/performance/types";
 import { UNABLE_TO_CHANGE_ADMIN_PERMISSIONS } from "metabase/admin/permissions/constants/messages";
 import {
   type DataPermission,
@@ -374,14 +375,10 @@ export const PLUGIN_MODERATION = {
   ) => [],
 };
 
-export type InvalidatableModel = Exclude<CacheableModel, "root">;
-export const isInvalidatableModel = (
-  model: CacheableModel,
-): model is InvalidatableModel => model !== "root";
-
 export type InvalidateNowButtonProps = {
   targetId: number;
-  targetModel: InvalidatableModel;
+  /** The type of object that the target is */
+  targetModel: ModelWithClearableCache;
   targetName: string;
 };
 

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -374,9 +374,14 @@ export const PLUGIN_MODERATION = {
   ) => [],
 };
 
+export type InvalidatableModel = Exclude<CacheableModel, "root">;
+export const isInvalidatableModel = (
+  model: CacheableModel,
+): model is InvalidatableModel => model !== "root";
+
 export type InvalidateNowButtonProps = {
   targetId: number;
-  targetModel: CacheableModel;
+  targetModel: InvalidatableModel;
   targetName: string;
 };
 

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewTitleHeader.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewTitleHeader.unit.spec.js
@@ -266,7 +266,7 @@ describe("ViewTitleHeader", () => {
           await userEvent.hover(refreshButton);
           const tooltip = screen.getByRole("tooltip");
           expect(tooltip).toHaveAttribute("data-placement", "top");
-          expect(tooltip).toHaveTextContent("Clear cache and refresh");
+          expect(tooltip).toHaveTextContent("Refresh");
         });
       });
     });

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewTitleHeader.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewTitleHeader.unit.spec.js
@@ -266,7 +266,7 @@ describe("ViewTitleHeader", () => {
           await userEvent.hover(refreshButton);
           const tooltip = screen.getByRole("tooltip");
           expect(tooltip).toHaveAttribute("data-placement", "top");
-          expect(tooltip).toHaveTextContent("Refresh");
+          expect(tooltip).toHaveTextContent("Clear cache and refresh");
         });
       });
     });

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/ViewTitleHeaderRightSide/ViewTitleHeaderRightSide.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/ViewTitleHeaderRightSide/ViewTitleHeaderRightSide.tsx
@@ -132,10 +132,16 @@ export function ViewTitleHeaderRightSide({
     }
   }, [isShowingQuestionInfoSidebar, onOpenQuestionInfo, onCloseQuestionInfo]);
 
-  const getRunButtonLabel = useCallback(
-    () => (isRunning ? t`Cancel` : t`Refresh`),
-    [isRunning],
-  );
+  const cacheStrategyType = result?.json_query?.["cache-strategy"]?.type;
+  const getRunButtonLabel = useCallback(() => {
+    if (isRunning) {
+      return t`Cancel`;
+    }
+    if ([undefined, "nocache"].includes(cacheStrategyType)) {
+      return `Refresh`;
+    }
+    return t`Clear cache and refresh`;
+  }, [isRunning, cacheStrategyType]);
 
   const canSave = Lib.canSave(question.query(), question.type());
   const isSaveDisabled = !canSave;


### PR DESCRIPTION
### Description

This PR introduces two changes:
* To clarify that the "Clear cache" button does not clear the entire cache, but just the cached results for a particular entity, this PR makes the text on that button more specific: "Clear cache for this question", "Clear cache for this dashboard", or "Clear cache for this database", depending on the context.
* On question pages, to clarify what the Refresh button does, its tooltip says "Clear cache and refresh"

The new Clear cache button is at the bottom of each of these screenshots:

![image](https://github.com/user-attachments/assets/3dda2b9e-b841-4cd6-b94b-c44d34272c00)

![image](https://github.com/user-attachments/assets/d24359b7-b3f1-480d-8a26-8da45f591e0a)

![image](https://github.com/user-attachments/assets/153a0cb8-25c4-4aab-932f-476f71d5df68)

The new tooltip has this text:

![image](https://github.com/user-attachments/assets/211bfb68-0a9e-4fb9-a83d-397552a3847d)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
