### PR TITLE
Fix handling explicit joins in metrics

### DIFF
--- a/dev/src/dev/debug_qp.clj
+++ b/dev/src/dev/debug_qp.clj
@@ -6,7 +6,7 @@
 
     ;; run a query with debugging enabled
     (binding [metabase.query-processor.debug/*debug* true]
-      (metabase.query-processor/process-query query)"
+      (metabase.query-processor/process-query query))"
   (:require
    [clojure.java.io :as io]
    [clojure.string :as str]

--- a/src/metabase/query_processor/middleware/metrics.clj
+++ b/src/metabase/query_processor/middleware/metrics.clj
@@ -108,7 +108,7 @@
                              (map (juxt :fk-field-id :alias))
                              (lib/joins query agg-stage-index))
         new-joins (remove (comp existing-joins (juxt :fk-field-id :alias)) metric-joins)
-        source-field->join-alias (into {} (map (juxt :fk-field-id :alias)) new-joins)
+        source-field->join-alias (dissoc (into {} (map (juxt :fk-field-id :alias)) new-joins) nil)
         query-with-joins (reduce #(lib/join %1 agg-stage-index %2)
                                  query
                                  new-joins)]


### PR DESCRIPTION
Fixes the problem mentioned in [Slack](https://metaboat.slack.com/archives/C051AG38B2S/p1723578692370739?thread_ts=1723561234.651549&cid=C051AG38B2S).