### PR TITLE
e2e: Remove the assertion about the tooltip on returning to the notebook page

### DIFF
--- a/e2e/test/scenarios/question/notebook-link-to-data-source.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-link-to-data-source.cy.spec.ts
@@ -98,11 +98,6 @@ describe("scenarios > notebook > link to data source", () => {
     );
 
     cy.findByTestId("qb-save-button").should("be.enabled");
-    cy.go("back");
-
-    cy.log("Tooltip should not linger open when we go back");
-    getNotebookStep("data").findByText("Reviews").should("be.visible");
-    cy.findByRole("tooltip").should("not.exist");
   });
 
   context("questions", () => {


### PR DESCRIPTION
### Description
The removed assertion was causing this test to flake in CI. [Example](https://github.com/metabase/metabase/actions/runs/10377932557/job/28734223118#step:13:808).
What's worse is that I can reliably see the tooltip in the UI 100% of the time when running Cypress locally, but the assertion is passing. I think this is a Cypress-specific quirk that cannot be replicated in normal usage.

See the tooltip in UI, but notice the last assertion passing
![image](https://github.com/user-attachments/assets/a3624de2-8192-4ad0-931c-05b3b71bec3a)

After confirming that this behavior is not present in the real app usage, I decided to remove the assertion to prevent further flakes and confusion.

### Explanation
After Cypress clicks on the data source it opens a new window with that source. Since this is not a real usage, Cypress asserts a few things on the new page, and then programmatically goes back. My assumption is that it either has the previous page state in cache or (more likely) the cursor is still in the same position which triggers the hover, and thus the tooltip to show.

### Conclusion
It is impossible to reliably test this in Cypress, and to mimic the real-world usage (human behavior).

### Demo
If I do things programmatically (that is if I only use my keyboard) then sure - I can replicate this behavior
https://github.com/user-attachments/assets/1e9dfd28-0f31-42a4-9261-17d748eddff8



But if I use the app like the average human would do and I use my mouse to see the new tab, there's no way I can see the tooltip still being present (without me explicitly hovering its container again) when I go back to the tab with the notebook open.
https://github.com/user-attachments/assets/65948c69-50b1-498c-8582-6ecd6415d4a5


