### PR TITLE
[small] [opening for discussion] Add `keepalive` to frontend requests

### DIFF
--- a/frontend/src/metabase/lib/api.js
+++ b/frontend/src/metabase/lib/api.js
@@ -283,6 +283,7 @@ export class Api extends EventEmitter {
       headers,
       body: requestBody,
       signal,
+      keepalive: true,
     });
 
     return fetch(request)


### PR DESCRIPTION
> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform) (unless it's a tiny documentation change). Also, if you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.

✅ License Agreement Signed

### Description

A lot of load-balancers will have separate timeouts for connection with keepalives sent and connections without. AWS ELBs default to 1 minute for no keep-alives and 1 hour with keep-alives. Setting up a question that takes more than 1 minute isn't that rare! And failures will look as if the question timed out rather than something at the network level timing out.

This won't fix it for [all browsers[(https://caniuse.com/?search=keepalive). (https://caniuse.com/\?search\=keepalive), but I think it'd solve it for some users, and it would avoid people needing to change their load-balancer settings to get metabase questions working properly.

<img width="837" alt="Screenshot 2024-08-13 at 5 43 19 PM" src="https://github.com/user-attachments/assets/00aa3801-3e7e-4ce9-8c8a-cdb0a65305c7">

### How to verify

**Note: I haven't actually checked this one yet!** I wanted to open up this PR to check whether there was any context I was missing & whether the intention behind this change made sense. If it does, I'll test it out and make sure I'm actually editing the right `fetch` call.

I _have_ needed to tweak load-balancer settings to get slow metabase queries working properly.

- [Request docs for keepalive](https://developer.mozilla.org/en-US/docs/Web/API/Request)


If you want to test out against another load-balancer, I'd recommend setting up a sleep UDF if the database that you're testing with doesn't support `select sleep(300)`. Here's some code that works with Redshift:

```
CREATE OR REPLACE FUNCTION public.f_sleep(seconds INTEGER)
    RETURNS INTEGER
    IMMUTABLE AS
$$
    import time
    time.sleep(seconds)
    return seconds

$$ LANGUAGE plpythonu;
```

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
