### PR TITLE
[Notification] Handle channel name conflicts

### DIFF
--- a/src/metabase/api/channel.clj
+++ b/src/metabase/api/channel.clj
@@ -55,6 +55,9 @@
    details     :map
    active      [:maybe {:default true} :boolean]}
   (validation/check-has-application-permission :setting)
+  (when (t2/exists? :model/Channel :name name)
+    (throw (ex-info "Channel with that name already exists" {:status-code 400
+                                                             :errors      {:name "Channel with that name already exists"}})))
   (test-channel-connection! type details)
   (u/prog1 (t2/insert-returning-instance! :model/Channel body)
     (events/publish-event! :event/channel-create {:object <> :user-id api/*current-user-id*})))

--- a/src/metabase/api/channel.clj
+++ b/src/metabase/api/channel.clj
@@ -56,7 +56,7 @@
    active      [:maybe {:default true} :boolean]}
   (validation/check-has-application-permission :setting)
   (when (t2/exists? :model/Channel :name name)
-    (throw (ex-info "Channel with that name already exists" {:status-code 400
+    (throw (ex-info "Channel with that name already exists" {:status-code 409
                                                              :errors      {:name "Channel with that name already exists"}})))
   (test-channel-connection! type details)
   (u/prog1 (t2/insert-returning-instance! :model/Channel body)

--- a/src/metabase/models/channel.clj
+++ b/src/metabase/models/channel.clj
@@ -53,7 +53,7 @@
       deactivated?
       ;; Channel.name has an unique constraint and it's an useful property for serialization
       ;; So we rename deactivated channels so new channel can reuse the name
-      (assoc :name (format "%s DEACTIVATED_%d" (:name instance) (quot (System/currentTimeMillis) 1000))))))
+      (assoc :name (format "%s DEACTIVATED_%s" (:name instance) (random-uuid))))))
 
 (defmethod audit-log/model-details :model/Channel
   [channel _event-type]

--- a/src/metabase/models/channel.clj
+++ b/src/metabase/models/channel.clj
@@ -53,7 +53,8 @@
       deactivated?
       ;; Channel.name has an unique constraint and it's an useful property for serialization
       ;; So we rename deactivated channels so new channel can reuse the name
-      (assoc :name (format "%s DEACTIVATED_%s" (:name instance) (random-uuid))))))
+      ;; Limit to 254 characters to avoid hitting character limit
+      (assoc :name (subs (format "DEACTIVATED_%d %s" (:id instance) (:name instance)) 0 254)))))
 
 (defmethod audit-log/model-details :model/Channel
   [channel _event-type]

--- a/src/metabase/models/channel.clj
+++ b/src/metabase/models/channel.clj
@@ -52,7 +52,7 @@
     (cond-> instance
       deactivated?
       ;; Channel.name has an unique constraint and it's an useful property for serialization
-      ;; So we rename deactivated channels so new channel can reuse the name
+      ;; We rename deactivated channels so that new channels can reuse the name
       ;; Limit to 254 characters to avoid hitting character limit
       (assoc :name (subs (format "DEACTIVATED_%d %s" (:id instance) (:name instance)) 0 254)))))
 

--- a/src/metabase/models/channel.clj
+++ b/src/metabase/models/channel.clj
@@ -53,7 +53,7 @@
       deactivated?
       ;; Channel.name has an unique constraint and it's an useful property for serialization
       ;; So we rename deactivated channels so new channel can reuse the name
-      (assoc :name (format "DEACTIVATED %s %d" (:name instance) (quot (System/currentTimeMillis) 1000))))))
+      (assoc :name (format "%s DEACTIVATED_%d" (:name instance) (quot (System/currentTimeMillis) 1000))))))
 
 (defmethod audit-log/model-details :model/Channel
   [channel _event-type]

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -184,6 +184,11 @@
       (str (upper-case-en (subs s 0 1))
            (lower-case-en (subs s 1))))))
 
+(defn truncate
+  "Truncate a string to `n` characters."
+  [s n]
+  (subs s 0 (min (count s) n)))
+
 (defn regex->str
   "Returns the contents of a regex as a string.
 

--- a/test/metabase/api/channel_test.clj
+++ b/test/metabase/api/channel_test.clj
@@ -72,6 +72,12 @@
                               {:active false})
         (is (= false (t2/select-one-fn :active :model/Channel (:id channel))))))))
 
+(deftest create-channel-with-existing-name-error-test
+  (let [channel-details default-test-channel]
+    (mt/with-temp [:model/Channel _chn channel-details]
+      (is (= {:errors {:name "Channel with that name already exists"}}
+             (mt/user-http-request :crowberto :post 400 "channel" default-test-channel))))))
+
 (def ns-keyword->str #(str (.-sym %)))
 
 (deftest list-channels-test

--- a/test/metabase/api/channel_test.clj
+++ b/test/metabase/api/channel_test.clj
@@ -76,7 +76,7 @@
   (let [channel-details default-test-channel]
     (mt/with-temp [:model/Channel _chn channel-details]
       (is (= {:errors {:name "Channel with that name already exists"}}
-             (mt/user-http-request :crowberto :post 400 "channel" default-test-channel))))))
+             (mt/user-http-request :crowberto :post 409 "channel" default-test-channel))))))
 
 (def ns-keyword->str #(str (.-sym %)))
 

--- a/test/metabase/models/channel_test.clj
+++ b/test/metabase/models/channel_test.clj
@@ -43,4 +43,4 @@
       (testing "will delete pulse channels"
         (is (not (t2/exists? :model/PulseChannel pc-id))))
       (testing "will change the name"
-        (is (some? (re-find #"DEACTIVATED New name \d+" (t2/select-one-fn :name :model/Channel id))))))))
+        (is (some? (re-find #"New name DEACTIVATED_\d+" (t2/select-one-fn :name :model/Channel id))))))))

--- a/test/metabase/models/channel_test.clj
+++ b/test/metabase/models/channel_test.clj
@@ -21,8 +21,7 @@
                                                                    :active  true})]
         (is (encryption/possibly-encrypted-string? (t2/select-one-fn :details :channel (:id channel))))))))
 
-
-(deftest toggle-channel-active-will-update-pulse-channel-test
+(deftest deactivate-channel-test
   (mt/with-temp
     [:model/Channel      {id :id}       {:name    "Test channel"
                                          :type    "channel/metabase-test"
@@ -39,6 +38,9 @@
       (is (pos? (t2/update! :model/Channel id {:active true})))
       (is (t2/exists? :model/PulseChannel pc-id)))
 
-   (testing "deactivate channel will delete pulse channels"
-     (t2/update! :model/Channel id {:active false})
-     (is (not (t2/exists? :model/PulseChannel pc-id))))))
+    (testing "deactivate channel"
+      (t2/update! :model/Channel id {:active false})
+      (testing "will delete pulse channels"
+        (is (not (t2/exists? :model/PulseChannel pc-id))))
+      (testing "will change the name"
+        (is (some? (re-find #"DEACTIVATED New name \d+" (t2/select-one-fn :name :model/Channel id))))))))

--- a/test/metabase/models/channel_test.clj
+++ b/test/metabase/models/channel_test.clj
@@ -43,4 +43,4 @@
       (testing "will delete pulse channels"
         (is (not (t2/exists? :model/PulseChannel pc-id))))
       (testing "will change the name"
-        (is (some? (re-find #"New name DEACTIVATED_\d+" (t2/select-one-fn :name :model/Channel id))))))))
+        (is (some? (re-find #"New name DEACTIVATED_\w+" (t2/select-one-fn :name :model/Channel id))))))))

--- a/test/metabase/models/channel_test.clj
+++ b/test/metabase/models/channel_test.clj
@@ -43,4 +43,4 @@
       (testing "will delete pulse channels"
         (is (not (t2/exists? :model/PulseChannel pc-id))))
       (testing "will change the name"
-        (is (some? (re-find #"New name DEACTIVATED_\w+" (t2/select-one-fn :name :model/Channel id))))))))
+        (is (= (format "DEACTIVATED_%d New name" id) (t2/select-one-fn :name :model/Channel id)))))))

--- a/test/metabase/util_test.cljc
+++ b/test/metabase/util_test.cljc
@@ -271,6 +271,13 @@
     "IBIS" "Ibis"
     "Ibis" "Ibis"))
 
+(deftest ^:parallel truncate-test
+  (are [s n expected] (= expected
+                         (u/truncate s n))
+    "string" 10 "string"
+    "string" 3  "str"
+    "string" 0  ""))
+
 #?(:clj
    (deftest capitalize-en-turkish-test
      (mt/with-locale "tr"


### PR DESCRIPTION
Currently if you deactivate a channel, you won't be able to create a new channel with the same name. This is due because we have a unique constraint on channel.name.

Changes:
- On channel deactivate: updates its name to free the name for reuse. E.g: Channel Name => DEACTIVATED_1 Channel Name(1 is the id)
- Creating a channel with a duplicated name will return a sensible error

Context: https://metaboat.slack.com/archives/C07318NQ5M2/p1723576176223559?thread_ts=1723573553.946069&cid=C07318NQ5M2