### PR TITLE
Don't disable triggers before data perms migration

### DIFF
--- a/resources/migrations/permissions/data_access.sql
+++ b/resources/migrations/permissions/data_access.sql
@@ -1,4 +1,3 @@
-ALTER TABLE data_permissions DISABLE TRIGGER ALL;
 -- Insert DB-level permissions for cases where no table-level perms are set
 
 INSERT INTO data_permissions (group_id, perm_type, db_id, schema_name, table_id, perm_value)
@@ -114,5 +113,3 @@ WHERE NOT EXISTS (
       AND dp.perm_type = 'perms/data-access'
 )
 AND pg.name != 'Administrators';
-
-ALTER TABLE data_permissions ENABLE TRIGGER ALL;

--- a/resources/migrations/permissions/download_results.sql
+++ b/resources/migrations/permissions/download_results.sql
@@ -1,6 +1,4 @@
 -- Insert DB-level permissions with a check for table-level permissions
-ALTER TABLE data_permissions DISABLE TRIGGER ALL;
-
 INSERT INTO data_permissions (group_id, perm_type, db_id, schema_name, table_id, perm_value)
 SELECT pg.id AS group_id,
        'perms/download-results' AS perm_type,
@@ -120,5 +118,3 @@ WHERE NOT EXISTS (
       AND dp.perm_type = 'perms/download-results'
 )
 AND pg.name != 'Administrators';
-
-ALTER TABLE data_permissions ENABLE TRIGGER ALL;

--- a/resources/migrations/permissions/manage_table_metadata.sql
+++ b/resources/migrations/permissions/manage_table_metadata.sql
@@ -1,6 +1,4 @@
 -- Insert DB-level permissions with a check for table-level permissions
-ALTER TABLE data_permissions DISABLE TRIGGER ALL;
-
 INSERT INTO data_permissions (group_id, perm_type, db_id, schema_name, table_id, perm_value)
 SELECT pg.id AS group_id,
        'perms/manage-table-metadata' AS perm_type,
@@ -98,5 +96,3 @@ WHERE NOT EXISTS (
       AND dp.perm_type = 'perms/manage-table-metadata'
 )
 AND pg.name != 'Administrators';
-
-ALTER TABLE data_permissions ENABLE TRIGGER ALL;


### PR DESCRIPTION
I didn't consider that we might not have permissions necessary to disable triggers.
