### PR TITLE
reduce logs during setup tests

### DIFF
--- a/frontend/src/metabase/setup/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/setup/tests/common.unit.spec.tsx
@@ -139,7 +139,7 @@ describe("setup (OSS)", () => {
       await selectUsageReason("embedding");
       await clickNextStep();
 
-      await screen.getByText("Finish").click();
+      await userEvent.click(screen.getByText("Finish"));
 
       expect(await getLastSettingsPutPayload()).toEqual({
         "embedding-homepage": "visible",
@@ -158,9 +158,9 @@ describe("setup (OSS)", () => {
       await selectUsageReason("self-service-analytics");
       await clickNextStep();
 
-      await screen.getByText("I'll add my data later").click();
+      await userEvent.click(screen.getByText("I'll add my data later"));
 
-      await screen.getByText("Finish").click();
+      await userEvent.click(screen.getByText("Finish"));
 
       const flags = await getLastSettingsPutPayload();
 
@@ -186,7 +186,7 @@ describe("setup (OSS)", () => {
       await selectUsageReason("embedding");
       await clickNextStep();
 
-      await screen.getByText("Finish").click();
+      await userEvent.click(screen.getByText("Finish"));
 
       const flags = await getLastSettingsPutPayload();
 

--- a/frontend/src/metabase/setup/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/setup/tests/enterprise.unit.spec.tsx
@@ -180,7 +180,7 @@ const errMsg = () => screen.findByText(/This token doesn’t seem to be valid/);
 const submitBtn = () => screen.findByRole("button", { name: "Activate" });
 
 const submit = async () => {
-  (await submitBtn()).click();
+  await userEvent.click(await submitBtn());
 
   const settingEndpoint = "path:/api/setting/premium-embedding-token";
   await waitFor(() => expect(fetchMock.done(settingEndpoint)).toBe(true));

--- a/frontend/src/metabase/setup/tests/premium.unit.spec.tsx
+++ b/frontend/src/metabase/setup/tests/premium.unit.spec.tsx
@@ -1,6 +1,7 @@
 /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectSectionToHaveLabel", "expectSectionsToHaveLabelsInOrder"] }] */
 
 import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import { createMockTokenFeatures } from "metabase-types/api/mocks";
 
@@ -55,7 +56,7 @@ describe("setup (EE, hosting and embedding feature)", () => {
     await selectUsageReason("embedding");
     await clickNextStep();
 
-    screen.getByText("Finish").click();
+    await userEvent.click(screen.getByText("Finish"));
 
     expect(await getLastSettingsPutPayload()).toEqual({
       "embedding-homepage": "visible",

--- a/frontend/src/metabase/setup/tests/setup.tsx
+++ b/frontend/src/metabase/setup/tests/setup.tsx
@@ -7,6 +7,7 @@ import {
   setupPropertiesEndpoints,
   setupSettingsEndpoints,
 } from "__support__/server-mocks";
+import { mockSettings } from "__support__/settings";
 import { renderWithProviders, screen } from "__support__/ui";
 import type {
   SettingDefinition,
@@ -18,7 +19,6 @@ import {
   createMockTokenFeatures,
 } from "metabase-types/api/mocks";
 import {
-  createMockSettingsState,
   createMockSetupState,
   createMockState,
 } from "metabase-types/store/mocks";
@@ -45,10 +45,12 @@ export async function setup({
     setup: createMockSetupState({
       step: "welcome",
     }),
-    settings: createMockSettingsState({
-      "token-features": tokenFeatures,
-      "available-locales": [["en", "English"]],
-    }),
+    settings: mockSettings(
+      createMockSettings({
+        "token-features": tokenFeatures,
+        "available-locales": [["en", "English"]],
+      }),
+    ),
   });
 
   if (hasEnterprisePlugins) {


### PR DESCRIPTION
### Description

While working on https://github.com/metabase/metabase/pull/46783 I was running into issues because the terminal of jest tests was full of warnings:
- things not wrapped in act (caused by `getByText().click()` instead of using userEvent, I thought also .click was automatically wrapped in act by testing library, TIL), fixed by d78dfdc7de9da614d62a0d83b6705505cb956522
- unknown features, fixed by e59c6b175b98c275df9534b8dc5568d86d3d1313
- getSteps selector not being memoized, fixed by a6a5fc313296869ed865426fd2c3e933888a0465

There are still a few logs about some missing token-features but I'll address them in a separate PR as they're not mocked at all by our helpers

I extracted this refactor in a separate PR from the featuer so that we can backport this