### PR TITLE
convert hasPremiumFeature to TypeScript and add missing token features keys

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/settings/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/settings/index.ts
@@ -1,8 +1,9 @@
 import { hasAnySsoFeature } from "metabase/common/utils/plan";
 import MetabaseSettings from "metabase/lib/settings";
+import type { TokenFeature } from "metabase-types/api";
 
-export function hasPremiumFeature(feature) {
-  const hasFeature = MetabaseSettings.get("token-features", {})?.[feature];
+export function hasPremiumFeature(feature: TokenFeature) {
+  const hasFeature = MetabaseSettings.get("token-features")?.[feature];
   if (hasFeature == null) {
     console.warn("Unknown premium feature", feature);
   }

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -121,6 +121,8 @@ export const createMockTokenFeatures = (
   snippet_collections: false,
   email_allow_list: false,
   email_restrict_recipients: false,
+  collection_cleanup: false,
+  upload_management: false,
   ...opts,
 });
 

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -165,6 +165,8 @@ export const tokenFeatures = [
   "snippet_collections",
   "email_allow_list",
   "email_restrict_recipients",
+  "upload_management",
+  "collection_cleanup",
 ] as const;
 
 export type TokenFeature = typeof tokenFeatures[number];


### PR DESCRIPTION


### Description
While working on https://github.com/metabase/metabase/pull/46834 I noticed some token features were not typed/mocked properly.

This converts `hasPremiumFeature` to typescript and adds two missing keys to the `TokenFeature` type.

This should force us to have to keep `TokenFeature` and `createMockTokenFeatures` updated with new token features.
