### PR TITLE
make local cypress dx great again

### DIFF
--- a/frontend/src/metabase/styled-components/components/EmotionCacheProvider/EmotionCacheProvider.tsx
+++ b/frontend/src/metabase/styled-components/components/EmotionCacheProvider/EmotionCacheProvider.tsx
@@ -3,6 +3,8 @@ import { CacheProvider } from "@emotion/react";
 import type { ReactNode } from "react";
 import { useMemo } from "react";
 
+import { isCypressActive } from "metabase/env";
+
 interface EmotionCacheProviderProps {
   children?: ReactNode;
 }
@@ -11,7 +13,11 @@ export const EmotionCacheProvider = ({
   children,
 }: EmotionCacheProviderProps) => {
   const emotionCache = useMemo(() => {
-    const cache = createCache({ key: "emotion", nonce: window.MetabaseNonce });
+    const cache = createCache({
+      key: "emotion",
+      nonce: window.MetabaseNonce,
+      ...(isCypressActive && { speedy: true }),
+    });
     // This disables :first-child not working in SSR warnings
     // Source: https://github.com/emotion-js/emotion/issues/1105#issuecomment-557726922
     cache.compat = true;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/46840

### Description

when we travel between cypress rendering history, there is an internal logic which replaces all `style` tags in the head, where emotion puts styles in dev mode. 
When we edit dashboard, there can be ~1.7k of style tags attached to the head, so every click took ~3s on my dev machine (M2Max + 32Gb RAM).

Using `speedy` option in emotion allow us to keep styles in memory and not in `head`, so cypress can replace styles way faster.

kudos to @Andarist for a tip!

### How to verify

- run cypress locally
- go to dashboard.cy.spec and choose one test, put `.only`
- wait for a test to pass, then click through the left sidebar - there shouldn't be any delay between UI "states"

### Demo

### Before


https://github.com/user-attachments/assets/67841e48-17e9-4eba-bda8-ff4822e399cc


### After



https://github.com/user-attachments/assets/98d1f674-af22-4ef8-9533-328854a40963

