### PR TITLE
Sandboxing doesn't implicitly grant create-queries: add no access table level permission

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
@@ -260,8 +260,7 @@
                                                  :throw-exceptions? true))
 
     (let [table-ids (sandbox->table-ids sandbox)]
-      {:perms/view-data (zipmap table-ids (repeat :unrestricted))
-       :perms/create-queries (zipmap table-ids (repeat :query-builder))})))
+      {:perms/view-data (zipmap table-ids (repeat :unrestricted))})))
 
 (defn- merge-perms
   "The shape of permissions maps is a little odd, and using `m/deep-merge` doesn't give us exactly what we want.


### PR DESCRIPTION
We found that with sandboxing enabled, users are implicitly granted create-queries permissions for the sandboxed tables, even if they have create-queries set to `no`. [metabase-enterprise.sandbox.query-processor.middleware.row-level-restrictions/sandbox->required-perms](https://github.com/metabase/metabase/blob/master/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj#L246) is in charge of granting perms ontop of sandboxed queries. The change made here is to not add :perms/create-queries perms as well. 

But it turns out that reintroduces bug https://github.com/metabase/metabase/issues/15105, so I think we should leave it the way it is, and fix that as a follow up bit of work.

This is https://github.com/metabase/metabase/pull/15105, and the test for it [is on master here](https://github.com/metabase/metabase/blob/master/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj#L821)


[Sandboxing doesn't implicitly grant create-queries](https://github.com/metabase/metabase/commit/878a6bc38fda9b4fb2207848c992218b7e5f8e63)