### PR TITLE
(loading/error wrapper): Let RTK query results be passed directly

### DIFF
--- a/frontend/src/metabase/components/LoadingAndErrorWrapper/LoadingAndErrorWrapper.tsx
+++ b/frontend/src/metabase/components/LoadingAndErrorWrapper/LoadingAndErrorWrapper.tsx
@@ -7,7 +7,7 @@ import LoadingSpinner from "metabase/components/LoadingSpinner";
 import CS from "metabase/css/core/index.css";
 import { Box, Title } from "metabase/ui";
 
-import type { CoreLoadingProps } from "./types";
+import type { CoreLoadingPropsVariant } from "./types";
 import { getErrorAndLoading, getErrorMessage } from "./utils";
 
 type DelayProps =
@@ -37,7 +37,7 @@ export type LoadingAndErrorWrapperProps = {
   noBackground?: boolean;
   children?: ReactNode | (() => ReactNode);
 } & DelayProps &
-  CoreLoadingProps;
+  CoreLoadingPropsVariant;
 
 /** Show a loading indicator, error message, or - if both loading and error are falsy - the children */
 export const LoadingAndErrorWrapper = ({

--- a/frontend/src/metabase/components/LoadingAndErrorWrapper/LoadingAndErrorWrapper.unit.spec.tsx
+++ b/frontend/src/metabase/components/LoadingAndErrorWrapper/LoadingAndErrorWrapper.unit.spec.tsx
@@ -38,6 +38,32 @@ describe("Loading", () => {
         render(<LoadingAndErrorWrapper loading={false} />),
       ).not.toThrow();
     });
+
+    it("can receive a result object", () => {
+      const result = { isLoading: true, error: null };
+      render(
+        <LoadingAndErrorWrapper result={result}>
+          <Data />
+        </LoadingAndErrorWrapper>,
+      );
+      expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
+      expect(screen.queryByText("Data")).not.toBeInTheDocument();
+    });
+
+    it("can receive a results array", () => {
+      const results = [
+        { isLoading: true, error: null },
+        { isLoading: false, error },
+      ];
+      render(
+        <LoadingAndErrorWrapper result={results}>
+          <Data />
+        </LoadingAndErrorWrapper>,
+      );
+      expect(screen.getByText(error.message)).toBeInTheDocument();
+      expect(screen.queryByTestId("loading-indicator")).not.toBeInTheDocument();
+      expect(screen.queryByText("Data")).not.toBeInTheDocument();
+    });
   });
 
   describe("error condition", () => {

--- a/frontend/src/metabase/components/LoadingAndErrorWrapper/types.tsx
+++ b/frontend/src/metabase/components/LoadingAndErrorWrapper/types.tsx
@@ -7,3 +7,9 @@ export type LoadableResult = {
   error?: any;
   isLoading?: boolean;
 };
+
+export type CoreLoadingPropsVariant =
+  | CoreLoadingProps
+  | {
+      result?: LoadableResult | LoadableResult[];
+    };


### PR DESCRIPTION
*Draft for discussion*

This branch adds a `result` prop to the `LoadingAndErrorWrapper` component. This allows an RTK query result to be passed directly to the component without needing to destructure it into `isLoading` and `error`. For example, you can do this:

```typescript
const { data, ...result } = useQuery();
return (
   <LoadingAndErrorWrapper result={result}>
       <HappyPath data={data} />
   </Loading>
 );
```

You can also pass an array of results. If you do so, the `LoadingAndErrorWrapper` component will display a loading indicator if any one of the results is loading. If one or more results has an error, the first error message will be displayed.

- [x] Tests have been added/updated to cover changes in this PR