### PR TITLE
Don't allow viewing a timeline without coll perms

### DIFF
--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -1117,6 +1117,7 @@
   [include archived]
   {include  [:maybe [:= "events"]]
    archived [:maybe :boolean]}
+  (api/read-check collection/root-collection)
   (timeline/timelines-for-collection nil {:timeline/events?   (= include "events")
                                           :timeline/archived? archived}))
 
@@ -1126,6 +1127,7 @@
   {id       ms/PositiveInt
    include  [:maybe [:= "events"]]
    archived [:maybe :boolean]}
+  (api/read-check (t2/select-one :model/Collection :id id))
   (timeline/timelines-for-collection id {:timeline/events?   (= include "events")
                                          :timeline/archived? archived}))
 


### PR DESCRIPTION
If we don't have access to the collection, we shouldn't have access to
the timelines within it.