### PR TITLE
ci: enable cypress-terminal-report only at CI

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -50,25 +50,25 @@ jobs:
       java_version: ${{ fromJson(steps.dependencies.outputs.result).java_version }}
       node_version: ${{ fromJson(steps.dependencies.outputs.result).node_version }}
     steps:
-    - uses: actions/checkout@v4
-      with:
-        sparse-checkout: release
-    - name: Prepare build scripts
-      run: cd ${{ github.workspace }}/release && yarn && yarn build
-    - name: Get build dependencies
-      uses: actions/github-script@v7
-      id: dependencies
-      with:
-        script: | # js
-          const { getBuildRequirements, getVersionFromReleaseBranch } = require('${{ github.workspace }}/release/dist/index.cjs');
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: release
+      - name: Prepare build scripts
+        run: cd ${{ github.workspace }}/release && yarn && yarn build
+      - name: Get build dependencies
+        uses: actions/github-script@v7
+        id: dependencies
+        with:
+          script: | # js
+            const { getBuildRequirements, getVersionFromReleaseBranch } = require('${{ github.workspace }}/release/dist/index.cjs');
 
-          const version = getVersionFromReleaseBranch('${{ github.ref }}');
-          const requirements = getBuildRequirements(version);
+            const version = getVersionFromReleaseBranch('${{ github.ref }}');
+            const requirements = getBuildRequirements(version);
 
-          return {
-            java_version: requirements.java,
-            node_version: requirements.node,
-          };
+            return {
+              java_version: requirements.java,
+              node_version: requirements.node,
+            };
 
   build:
     needs: [files-changed, e2e-matrix-builder, get-build-requirements]
@@ -92,12 +92,12 @@ jobs:
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
         with:
-          node-version: '${{ needs.get-build-requirements.outputs.node_version }}'
+          node-version: "${{ needs.get-build-requirements.outputs.node_version }}"
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
         with:
           m2-cache-key: e2e-tests
-          java-version: '${{ needs.get-build-requirements.outputs.java_version || 11 }}'
+          java-version: "${{ needs.get-build-requirements.outputs.java_version || 11 }}"
 
       - name: Build uberjar with ./bin/build.sh
         run: ./bin/build.sh
@@ -127,6 +127,7 @@ jobs:
       MB_SNOWPLOW_AVAILABLE: true
       MB_SNOWPLOW_URL: "http://localhost:9090" # Snowplow micro
       TZ: US/Pacific # to make node match the instance tz
+      CYPRESS_CI: true
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.e2e-matrix-builder.outputs.matrix) }}

--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -50,7 +50,9 @@ const defaultConfig = {
     // `config` is the resolved Cypress config
 
     // cypress-terminal-report
-    installLogsPrinter(on);
+    if (process.env.CYPRESS_CI) {
+      installLogsPrinter(on);
+    }
 
     /********************************************************************
      **                        PREPROCESSOR                            **

--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -15,6 +15,7 @@ const {
 } = require("@esbuild-plugins/node-modules-polyfill");
 
 const isEnterprise = process.env["MB_EDITION"] === "ee";
+const isCI = process.env["CYPRESS_CI"] === "true";
 
 const hasSnowplowMicro = process.env["MB_SNOWPLOW_AVAILABLE"];
 const snowplowMicroUrl = process.env["MB_SNOWPLOW_URL"];
@@ -50,7 +51,7 @@ const defaultConfig = {
     // `config` is the resolved Cypress config
 
     // cypress-terminal-report
-    if (process.env.CYPRESS_CI) {
+    if (isCI) {
       installLogsPrinter(on);
     }
 

--- a/e2e/support/cypress.js
+++ b/e2e/support/cypress.js
@@ -33,9 +33,11 @@ Cypress.on("test:after:run", (test, runnable) => {
     }
     filename += `${titleToFileName(test.title)} (failed).png`;
 
-    Cypress.Mochawesome.context.forEach(ctx => {
-      addContext({ test }, ctx);
-    });
+    if (Cypress.env("CI")) {
+      Cypress.Mochawesome.context.forEach(ctx => {
+        addContext({ test }, ctx);
+      });
+    }
 
     addContext(
       { test },

--- a/e2e/support/cypress.js
+++ b/e2e/support/cypress.js
@@ -93,24 +93,30 @@ Cypress.on("window:load", window => {
 });
 
 // cypress-terminal-report
-afterEach(() => {
-  cy.wait(50, { log: false }).then(() =>
-    cy.addTestContext(Cypress.TerminalReport.getLogs("txt")),
-  );
-});
+if (Cypress.env("CI")) {
+  afterEach(() => {
+    cy.wait(50, { log: false }).then(() =>
+      cy.addTestContext(Cypress.TerminalReport.getLogs("txt")),
+    );
+  });
 
-const options = {
-  collectTypes: [
-    "cons:log",
-    "cons:info",
-    // 'cons:warn', - intentionally disabled because of noise from mbql
-    "cons:error",
-    "cy:log",
-    "cy:xhr",
-    "cy:request",
-    "cy:intercept",
-    "cy:command",
-  ],
-};
-// Ensure that after plugin installation is after the afterEach handling the integration.
-require("cypress-terminal-report/src/installLogsCollector")(options);
+  const options = {
+    collectTypes: [
+      "cons:log",
+      "cons:info",
+      // 'cons:warn', - intentionally disabled because of noise from mbql
+      "cons:error",
+      "cy:log",
+      "cy:xhr",
+      "cy:request",
+      "cy:intercept",
+      "cy:command",
+    ],
+    xhr: {
+      printBody: false,
+    },
+  };
+
+  // Ensure that after plugin installation is after the afterEach handling the integration.
+  require("cypress-terminal-report/src/installLogsCollector")(options);
+}

--- a/e2e/support/cypress.js
+++ b/e2e/support/cypress.js
@@ -7,6 +7,8 @@ import "cypress-real-events/support";
 import addContext from "mochawesome/addContext";
 import "./commands";
 
+const isCI = Cypress.env("CI");
+
 Cypress.on("uncaught:exception", (err, runnable) => false);
 
 Cypress.on("test:before:run", () => {
@@ -33,7 +35,8 @@ Cypress.on("test:after:run", (test, runnable) => {
     }
     filename += `${titleToFileName(test.title)} (failed).png`;
 
-    if (Cypress.env("CI")) {
+    if (isCI) {
+      // cypress-terminal-report
       Cypress.Mochawesome.context.forEach(ctx => {
         addContext({ test }, ctx);
       });
@@ -95,7 +98,7 @@ Cypress.on("window:load", window => {
 });
 
 // cypress-terminal-report
-if (Cypress.env("CI")) {
+if (isCI) {
   afterEach(() => {
     cy.wait(50, { log: false }).then(() =>
       cy.addTestContext(Cypress.TerminalReport.getLogs("txt")),


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/46870

### Description

We need to use cypress-terminal-report only at CI, locally we have cypress timeline.

Also I added a filter, so now xhr body will not be printed in console

### How to verify

- run cypress locally
- focus on a specific test and change it so it fails
- make sure when test failed, there is no report in terminal