### PR TITLE
Fix warnings/errors in memoized-supports? when SnakeHatingMap is passed as database

### DIFF
--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -19,7 +19,8 @@
    [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru trs]]
    [metabase.util.log :as log]
-   [metabase.util.malli :as mu])
+   [metabase.util.malli :as mu]
+   [metabase.util.snake-hating-map :refer [snake-hating-map?]])
   (:import
    (java.io ByteArrayInputStream)
    (java.security KeyFactory KeyStore PrivateKey)
@@ -250,8 +251,12 @@
 (def ^:private memoized-supports?*
   (memoize/memo
    (-> supports?*
-       (vary-meta assoc ::memoize/args-fn (fn [[driver feature database]]
-                                            [driver feature (mdb/unique-identifier) (:id database) (:updated_at database)])))))
+       (vary-meta assoc ::memoize/args-fn
+                  (fn [[driver feature database]]
+                    [driver feature (mdb/unique-identifier) (:id database)
+                     (if (snake-hating-map? database)
+                       (:updated-at database)
+                       (:updated_at database))])))))
 
 (defn supports?
   "A defensive wrapper around [[database-supports?]]. It adds logging, caching, and error handling to avoid crashing the app

--- a/src/metabase/util/snake_hating_map.clj
+++ b/src/metabase/util/snake_hating_map.clj
@@ -77,3 +77,8 @@
        ->SnakeHatingMap))
   ([k v & more]
    (snake-hating-map (into {k v} (partition-all 2) more))))
+
+(defn snake-hating-map?
+  "Return true if `m` is a SnakeHatingMap."
+  [m]
+  (instance? SnakeHatingMap m))


### PR DESCRIPTION
This is an aftermath of #46673. Looking up `:updated_at` in a SnakeHatingMap produces errors if memorization of `supports?` is enabled locally, and probably causes a lot of warnings in production mode.