### PR TITLE
perf: Reuse ZoneRegion/UTC instead of creating new object when parsing dates

### DIFF
--- a/src/metabase/util/date_2/parse.clj
+++ b/src/metabase/util/date_2/parse.clj
@@ -47,6 +47,8 @@
    {:error/message "Instance of a java.time.temporal.Temporal"}
    (partial instance? Temporal)])
 
+(def ^:private utc-zone-region (t/zone-id "UTC"))
+
 (mu/defn parse-with-formatter :- [:maybe InstanceOfTemporal]
   "Parse a String with a DateTimeFormatter, returning an appropriate instance of an `java.time` temporal class."
   [formattr
@@ -61,7 +63,7 @@
           zone-offset       (query temporal-accessor :zone-offset)
           zone-id           (or (query temporal-accessor :zone-id)
                                 (when (= zone-offset ZoneOffset/UTC)
-                                  (t/zone-id "UTC")))
+                                  utc-zone-region))
           literal-type      [(cond
                                zone-id     :zone
                                zone-offset :offset


### PR DESCRIPTION
Date parsing happens quite a bit inside `metabase.analyze.fingerprint.insights/timeseries-insight`. This small optimization if a low-hanging fruit; I'll see how it behaves after the change, maybe this should be enough. Otherwise, we may try to cache the parsed dates.
