### PR TITLE
fix(sdk): Fix CLI not showing Postgres password field

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/cli/utils/ask-for-db-connection-info.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/utils/ask-for-db-connection-info.ts
@@ -33,19 +33,6 @@ export async function askForDatabaseConnectionInfo(options: Options) {
       continue;
     }
 
-    const visibleIf = field["visible-if"];
-
-    const shouldShowField =
-      !visibleIf ||
-      Object.entries(visibleIf).every(
-        ([key, expected]) => connection[key] === expected,
-      );
-
-    // Skip fields that should be hidden
-    if (!shouldShowField) {
-      continue;
-    }
-
     const name = field["display-name"];
     const helperText = field["helper-text"];
 


### PR DESCRIPTION
### Description

When running the CLI, and adding Postgres, there wouldn't be a prompt for the password field, and the CLI will fail to connect to the DB.

### How to verify

1. run
    ```
    yarn build-embedding-sdk-cli:watch
    ```
1. In another terminal, possibly a different directory with a React application (I haven't tested if testing in Metabase folder works), run
    ```
    node ../metabase/resources/embedding-sdk/dist/cli.js start
    ```
    This assumes your project is at the same level as the Metabase folder.
1. Follows the steps and add Postgres DB. You should now see the password field

### Demo
#### After
<img width="1179" alt="image" src="https://github.com/user-attachments/assets/a29e6eab-fc69-44ff-88c5-5eb6f1e15ea7">

#### Before
<img width="1178" alt="image" src="https://github.com/user-attachments/assets/823edfaf-aac6-449d-94a8-2a8b8f402283">



### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
