### PR TITLE
More date formats

### DIFF
--- a/frontend/src/metabase/lib/formatting/date.tsx
+++ b/frontend/src/metabase/lib/formatting/date.tsx
@@ -59,7 +59,7 @@ const DATE_STYLE_TO_FORMAT: DATE_STYLE_TO_FORMAT_TYPE = {
   "MMMM D, YYYY": {
     month: "MMMM YYYY",
   },
-  "D MMMM, YYYY": {
+  "D MMMM YYYY": {
     month: "MMMM YYYY",
   },
   "dddd, MMMM D, YYYY": {

--- a/frontend/src/metabase/lib/formatting/date.tsx
+++ b/frontend/src/metabase/lib/formatting/date.tsx
@@ -39,11 +39,21 @@ const DATE_STYLE_TO_FORMAT: DATE_STYLE_TO_FORMAT_TYPE = {
   "M/D/YYYY": {
     month: "M/YYYY",
   },
+  "MM/DD/YYYY": {
+    month: "MM/YYYY",
+  },
   "D/M/YYYY": {
     month: "M/YYYY",
   },
+  "DD/MM/YYYY": {
+    month: "MM/YYYY",
+  },
   "YYYY/M/D": {
     month: "YYYY/M",
+    quarter: "YYYY - [Q]Q",
+  },
+  "YYYY/MM/DD": {
+    month: "YYYY/MM",
     quarter: "YYYY - [Q]Q",
   },
   "MMMM D, YYYY": {

--- a/frontend/src/metabase/lib/formatting/date.tsx
+++ b/frontend/src/metabase/lib/formatting/date.tsx
@@ -66,6 +66,10 @@ const DATE_STYLE_TO_FORMAT: DATE_STYLE_TO_FORMAT_TYPE = {
     week: "MMMM D, YYYY",
     month: "MMMM YYYY",
   },
+  "dddd, D MMMM YYYY": {
+    week: "D MMMM YYYY",
+    month: "MMMM YYYY",
+  },
 };
 
 const DATE_RANGE_MONTH_PLACEHOLDER = "<MONTH>";


### PR DESCRIPTION
### Description

- Adds 2-digit date formats (`YYYY-MM-DD` as opposed to `YYYY-M-D`), because some of us prefer a 'fixed width' label regardless of the exact date.
- Removes comma after `MMMM` in `D MMMM, YYYY` format ( reference https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style/Dates_and_numbers#Dates,_months,_and_years )
-  Add `dddd, D MMMM YYYY` date format

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
