### PR TITLE
hide terminal-report logs from console

### DIFF
--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -52,7 +52,9 @@ const defaultConfig = {
 
     // cypress-terminal-report
     if (isCI) {
-      installLogsPrinter(on);
+      installLogsPrinter(on, {
+        printLogsToConsole: "never",
+      });
     }
 
     /********************************************************************

--- a/e2e/support/cypress.js
+++ b/e2e/support/cypress.js
@@ -3,11 +3,28 @@ registerCypressGrep();
 
 import "@cypress/skip-test/support";
 import "@testing-library/cypress/add-commands";
+import { configure } from "@testing-library/cypress";
 import "cypress-real-events/support";
 import addContext from "mochawesome/addContext";
 import "./commands";
 
 const isCI = Cypress.env("CI");
+
+// remove default html output on test failure
+configure({
+  getElementError: (message, container) => {
+    // to re-enable the default stack trace, uncomment
+    // import { prettyDOM } from "@testing-library/dom";
+    // const error = new Error(
+    //  [message, prettyDOM(container)].filter(Boolean).join('\n\n'),
+    // )
+    const error = new Error(message);
+    error.name = "TestingLibraryElementError";
+    error.stack = null;
+
+    return error;
+  },
+});
 
 Cypress.on("uncaught:exception", (err, runnable) => false);
 

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -84,6 +84,8 @@ describe("scenarios > dashboard", () => {
       const existingQuestionName = "Orders, Count";
 
       cy.visit("/");
+      // TODO: remove, it should fail to verify cypress-terminal-report logs
+      cy.findByTestId("234");
       appBar().findByText("New").click();
       popover().findByText("Dashboard").should("be.visible").click();
 

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -84,8 +84,6 @@ describe("scenarios > dashboard", () => {
       const existingQuestionName = "Orders, Count";
 
       cy.visit("/");
-      // TODO: remove, it should fail to verify cypress-terminal-report logs
-      cy.findByTestId("234");
       appBar().findByText("New").click();
       popover().findByText("Dashboard").should("be.visible").click();
 


### PR DESCRIPTION
closes https://github.com/metabase/metabase/issues/46954

### Description

This PR hides cypress-terminal-reports logs from github actions, as users said it's hard to find a failing test name because of the noise from terminal-report.

From now, cypress-terminal-report logs will be inside mocha report only

### How to verify

Currently we have a single explicitly failing test, check logs of dashboard-ee job and verify that there is no log from cypress-terminal-report

download mocha report from the artifacts section of the job, unzip and verify that mocha report contains logs from cypress-terminal-report (above the screenshot)

<img width="1563" alt="image" src="https://github.com/user-attachments/assets/35cb7f0e-e205-4b73-ab17-70ec22d223f8">


### Demo

check the [failing job](https://github.com/metabase/metabase/actions/runs/10410178544/job/28831691309?pr=46891), it's much cleaner than before, you can easily navigate to the error if needed

mocha report has logs from cypress-terminal-report 
<img width="1614" alt="image" src="https://github.com/user-attachments/assets/82ac7d6f-dd33-4cea-9ec5-b4feffff450c">

