### PR TITLE
Allow setting user attributes in advanced config

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file/users.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file/users.clj
@@ -21,11 +21,15 @@
 (s/def :metabase-enterprise.advanced-config.file.users.config-file-spec/email
   string?)
 
+(s/def :metabase-enterprise.advanced-config.file.users.config-file-spec/login_attributes
+  (s/map-of keyword? string?))
+
 (s/def ::config-file-spec
   (s/keys :req-un [:metabase-enterprise.advanced-config.file.users.config-file-spec/first_name
                    :metabase-enterprise.advanced-config.file.users.config-file-spec/last_name
                    :metabase-enterprise.advanced-config.file.users.config-file-spec/password
-                   :metabase-enterprise.advanced-config.file.users.config-file-spec/email]))
+                   :metabase-enterprise.advanced-config.file.users.config-file-spec/email]
+          :opt-un [:metabase-enterprise.advanced-config.file.users.config-file-spec/login_attributes]))
 
 (defmethod advanced-config.file.i/section-spec :users
   [_section]


### PR DESCRIPTION
Basically, I find this useful in local development (e.g. to test sandboxing). It might be useful for others as well.
