### PR TITLE
Update later stage stale references on clause removal

### DIFF
--- a/src/metabase/lib/remove_replace.cljc
+++ b/src/metabase/lib/remove_replace.cljc
@@ -76,6 +76,56 @@
       stage-number)
     query))
 
+;; TODO: Examine whether also 0th stage does not need updating refs. Eg. those in order by.
+(defn- update-stale-references-in-stage
+  "Fix stale references in `stage-number` stage of `query-modfied`. `stage-number` should not be 0."
+  [query-modified stage-number query-original]
+  (let [old-previous-stage-columns (lib.metadata.calculation/returned-columns query-original (dec stage-number))
+        new-previous-stage-columns (lib.metadata.calculation/returned-columns query-modified (dec stage-number))
+        source-uuid->new-column (m/index-by :lib/source-uuid new-previous-stage-columns)]
+    (lib.util/update-query-stage
+     query-modified stage-number
+     #(lib.util.match/replace
+       %
+       #{:field}
+       (let [old-matching-column (lib.equality/find-matching-column &match old-previous-stage-columns)
+             source-uuid (:lib/source-uuid old-matching-column)
+             new-column  (source-uuid->new-column source-uuid)
+             new-name    (:lib/desired-column-alias new-column)]
+         (assoc &match 2 new-name))))))
+
+(defn- update-stale-references
+  "Update stale refs in query after clause removal.
+
+  ## Gist
+  For stages that follow `previous-stage-number` match existing on-stage refs to new visible columns, generated for
+  the modified query. Swap these refs with fresh refs created using new visible columns, but use the original column
+  options.
+
+  ## Problem
+
+  Let's have a query with 2 `:sum` aggregations in stage 0, and custom expressions based on these aggregations
+  in stage 1.
+
+  These aggregation columns have same `:name`. Field refs, intended for use in stage 1, generated out of those
+  columns, are then identified by `:lib/desired-column-alias`. Stage 1 will be using ref
+  `[:field <opts> \"sum_2\"]` for the second aggregation.
+
+  Removing the first from the stage 0, will remove clauses refeencing it in further stages. So far so good.
+
+  But removal only is not sufficient -- _with the first aggregation `[:field <opts> \"sum\"]` removed
+  the `[:field <opts> \"sum_2\"]` reference became stale_, because stage 0 has now no _returned column_ with
+  desired alias \"sum_2\"."
+  [query-with-modified-refs previous-stage-number unmodified-query-for-stage]
+  (if-let [this-stage-number (lib.util/next-stage-number query-with-modified-refs
+                                                         previous-stage-number)]
+    (recur (update-stale-references-in-stage query-with-modified-refs
+                                             this-stage-number
+                                             unmodified-query-for-stage)
+           this-stage-number
+           unmodified-query-for-stage)
+    query-with-modified-refs))
+
 (defn- remove-replace-location
   [query stage-number unmodified-query-for-stage location target-clause remove-replace-fn]
   (let [result (lib.util/update-query-stage query stage-number
@@ -86,29 +136,32 @@
         [:expressions]
         (-> result
             (remove-local-references
-              stage-number
-              unmodified-query-for-stage
-              :expression
-              {}
-              (lib.util/expression-name target-clause))
-            (remove-stage-references stage-number unmodified-query-for-stage target-uuid))
+             stage-number
+             unmodified-query-for-stage
+             :expression
+             {}
+             (lib.util/expression-name target-clause))
+            (remove-stage-references stage-number unmodified-query-for-stage target-uuid)
+            (update-stale-references stage-number unmodified-query-for-stage))
 
         [:aggregation]
         (-> result
             (remove-local-references
-              stage-number
-              unmodified-query-for-stage
-              :aggregation
-              {}
-              target-uuid)
-            (remove-stage-references stage-number unmodified-query-for-stage target-uuid))
+             stage-number
+             unmodified-query-for-stage
+             :aggregation
+             {}
+             target-uuid)
+            (remove-stage-references stage-number unmodified-query-for-stage target-uuid)
+            (update-stale-references stage-number unmodified-query-for-stage))
 
         #_{:clj-kondo/ignore [:invalid-arity]}
         (:or
           [:breakout]
           [:fields]
           [:joins _ :fields])
-        (remove-stage-references result stage-number unmodified-query-for-stage target-uuid)
+        (-> (remove-stage-references result stage-number unmodified-query-for-stage target-uuid)
+            (update-stale-references stage-number unmodified-query-for-stage))
 
         _
         result)

--- a/src/metabase/lib/remove_replace.cljc
+++ b/src/metabase/lib/remove_replace.cljc
@@ -76,7 +76,6 @@
       stage-number)
     query))
 
-;; TODO: Examine whether also 0th stage does not need updating refs. Eg. those in order by.
 (defn- update-stale-references-in-stage
   "Fix stale references in `stage-number` stage of `query-modfied`. `stage-number` should not be 0."
   [query-modified stage-number query-original]
@@ -91,7 +90,7 @@
        (let [old-matching-column (lib.equality/find-matching-column &match old-previous-stage-columns)
              source-uuid (:lib/source-uuid old-matching-column)
              new-column  (source-uuid->new-column source-uuid)
-             new-name    (:lib/desired-column-alias new-column)]
+             new-name    ((some-fn :lib/desired-column-alias :name) new-column)]
          (assoc &match 2 new-name))))))
 
 (defn- update-stale-references

--- a/test/metabase/lib/remove_replace_test.cljc
+++ b/test/metabase/lib/remove_replace_test.cljc
@@ -276,29 +276,49 @@
                 (lib/remove-clause query 0 (last aggregations))))))))
 
 (deftest ^:parallel remove-clause-adjust-ref-names-test
-   (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
-                   (lib/aggregate (lib/sum (meta/field-metadata :orders :total)))
-                   (lib/aggregate (lib/sum (meta/field-metadata :orders :subtotal)))
-                   (lib/breakout (meta/field-metadata :orders :user-id))
-                   lib/append-stage)
-         [a0-column a1-column] (-> query
-                                   lib/visible-columns
-                                   (->> (filter #(= "sum" (:name %)))))
-         query (-> query
-                   (lib/expression "xix" (lib/ref a0-column))
-                   (lib/expression "yiy" (lib/ref a1-column)))
-         a0-ref (first (lib/aggregations query 0))]
-     (testing "Next stage field ref indetifier is adjusted from sum_2 to sum."
-       (is (=? {:stages [some?
-                         {:lib/type :mbql.stage/mbql,
-                          :expressions
-                          [[:field
-                            {:lib/uuid string?
-                             :base-type :type/Float
-                             :effective-type :type/Float
-                             :lib/expression-name "yiy"}
-                            "sum"]]}]}
-               (lib/remove-clause query 0 a0-ref))))))
+  (testing "Field identifiers of same name field refs are adjusted on field removal"
+    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                    (lib/aggregate (lib/sum (meta/field-metadata :orders :total)))
+                    (lib/aggregate (lib/sum (meta/field-metadata :orders :subtotal)))
+                    (lib/breakout (meta/field-metadata :orders :user-id))
+                    lib/append-stage)
+          [a0-column a1-column] (-> query
+                                    lib/visible-columns
+                                    (->> (filter #(= "sum" (:name %)))))
+          query (-> query
+                    (lib/expression "xix" (lib/ref a0-column))
+                    (lib/expression "yiy" (lib/ref a1-column)))
+          a0-ref (first (lib/aggregations query 0))]
+      (testing "Base: Second stage field refs are identified as sum and sum_2"
+        (is (=? {:stages [{:lib/type :mbql.stage/mbql,
+                           :aggregation [[:sum {} [:field {} (meta/id :orders :total)]]
+                                         [:sum {} [:field {} (meta/id :orders :subtotal)]]]
+                           :breakout [[:field {} (meta/id :orders :user-id)]]}
+                          {:lib/type :mbql.stage/mbql,
+                           :expressions
+                           [[:field
+                             {:base-type :type/Float
+                              :effective-type :type/Float
+                              :lib/expression-name "xix"}
+                             "sum"]
+                            [:field
+                             {:base-type :type/Float
+                              :effective-type :type/Float
+                              :lib/expression-name "yiy"}
+                             "sum_2"]]}]}
+                query)))
+      (testing "Second stage field ref indetifier is adjusted from sum_2 to sum."
+        (is (=? {:stages [{:lib/type :mbql.stage/mbql,
+                           :aggregation [[:sum {} [:field {} (meta/id :orders :subtotal)]]]
+                           :breakout [[:field {} (meta/id :orders :user-id)]]}
+                          {:lib/type :mbql.stage/mbql,
+                           :expressions
+                           [[:field
+                             {:base-type :type/Float
+                              :effective-type :type/Float
+                              :lib/expression-name "yiy"}
+                             "sum"]]}]}
+                (lib/remove-clause query 0 a0-ref)))))))
 
 (deftest ^:parallel remove-clause-expression-test
   (let [query (-> lib.tu/venues-query


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/40046

This PR adds functionality that updates field ref identifiers in later stages after clause removal. If stage contains multiple clauses of a same name, next stage references to those clauses are identified by the name deduplicated (eg. sum becoming sum, sum_2, sum_3 etc.).

When the clause producing next stage sum is removed, also the next stage sum field ref is removed. Remaining sum_2 and sum_3 references are than stale. With this PR in, those name identifiers are correctly adjusted.