### PR TITLE
docs - blocked at table level

### DIFF
--- a/docs/permissions/data.md
+++ b/docs/permissions/data.md
@@ -55,11 +55,13 @@ View data permission settings apply to different levels in your database:
 | View data permission | Database | Schema | Table |
 | -------------------- | -------- | ------ | ----- |
 | Can view             | ✅        | ✅      | ✅     |
-| Granular             | ✅        | ✅      | ❌     |
+| Granular*             | ✅        | ✅      | ❌     |
 | Sandboxed            | ❌        | ❌      | ✅     |
 | Impersonated         | ✅        | ❌      | ❌     |
 | Blocked              | ✅        | ✅      | ✅     |
 
+
+* The "Granular" setting is not itself a type of permission; it just signals that permissions are set at a level below the current level. For example, you can select "Granular" at a schema level to set permissions per table for tables in that schema.
 
 In the free, open-source version of Metabase, the **View data** setting defaults to "Can view". Since the setting's options aren't available in the OSS version, Metabase will only display this **View data** setting in the Pro/Enterprise version.
 
@@ -103,9 +105,9 @@ See [impersonated view data permissions](./impersonation.md)
 
 **Blocked** ensures people in a group can’t see the data from this database, schema, or table, regardless of their permissions at the collection level.
 
-The Blocked view data permission can be set at the database, schema, or table level.
+The Blocked view data permission can be set at the database, schema, or table level. Essentially, what Blocked does is make collections permissions _insufficient_ to view a question. For example, even if a question is in a collection that the group has access to, but that question queries a data source that is Blocked for that group, people in that group won't be able to view that question _unless_ they're in another group with the data permissions to that data source.
 
-Essentially, what Blocked does is make collections permissions insufficient to view a question. For example, even if a question is in a collection that the group has access to, but that question queries a data source that is Blocked for that group, people in that group won't be able to view that question _unless_ they're in another group with the data permissions to that data source.
+Setting blocked access for a group ALWAYS prevents the group from viewing questions built with the native query editor that query ANY tables from the same database. So even if you only block a single table in a database, the group won't be able to view the results of SQL questions that query ANY table in that database. The reason: Metabase doesn't (yet) parse SQL queries, so it can't know for sure whether the SQL queries the table you want to block.
 
 If a person in a Blocked group belongs to _another_ group that has its View data permission set to "Can view", that more permissive access will take precedence, and they'll be able to view that question.
 

--- a/docs/permissions/data.md
+++ b/docs/permissions/data.md
@@ -50,11 +50,24 @@ Permission levels include:
 - [Impersonated](#impersonated-view-data-permission)
 - [Blocked](#blocked-view-data-permission)
 
+View data permission settings apply to different levels in your database:
+
+| View data permission | Database | Schema | Table |
+| -------------------- | -------- | ------ | ----- |
+| Can view             | ✅        | ✅      | ✅     |
+| Granular             | ✅        | ✅      | ❌     |
+| Sandboxed            | ❌        | ❌      | ✅     |
+| Impersonated         | ✅        | ❌      | ❌     |
+| Blocked              | ✅        | ✅      | ✅     |
+
+
 In the free, open-source version of Metabase, the **View data** setting defaults to "Can view". Since the setting's options aren't available in the OSS version, Metabase will only display this **View data** setting in the Pro/Enterprise version.
 
 For which questions, models, and dashboards a group can view, instead see [collection permissions](collections.md).
 
 ### Can view data permission
+
+{% include plans-blockquote.html feature="Can view data permission" %}
 
 Setting to **Can view** means the group can view all the data for the data source, provided they have [collection permissions](./collections.md) to view questions, models, and dashboards.
 
@@ -72,7 +85,7 @@ For tables, you have the option to set either **Can view** or **Sandboxed**.
 
 {% include plans-blockquote.html feature="Sandboxed view data permission" %}
 
-Allows you to set row-level permissions based on user attributes.
+Allows you to set row-level permissions based on user attributes. Can only be configured at the table level.
 
 See [Data sandboxes](./data-sandboxes.md).
 
@@ -88,13 +101,13 @@ See [impersonated view data permissions](./impersonation.md)
 
 {% include plans-blockquote.html feature="Blocked view data permission" %}
 
-**Blocked** ensures people in a group can’t see the data from this database, regardless of their permissions at the collection level.
+**Blocked** ensures people in a group can’t see the data from this database, schema, or table, regardless of their permissions at the collection level.
 
-The Blocked view data permission can only be set at the database level.
+The Blocked view data permission can be set at the database, schema, or table level.
 
-Essentially, what Block does is make collections permissions insufficient to view a question. For example, even if a question is in a collection that the group has access to, but that question queries a data source that is blocked for that group, people in that group won't be able to view that question _unless_ they're in another group with the relevant data permissions.
+Essentially, what Blocked does is make collections permissions insufficient to view a question. For example, even if a question is in a collection that the group has access to, but that question queries a data source that is Blocked for that group, people in that group won't be able to view that question _unless_ they're in another group with the data permissions to that data source.
 
-If a person in a blocked group belongs to _another_ group that _does_ have View data access to the data source, that more privileged access will take precedence (overruling the block), and they'll be able to view that question.
+If a person in a Blocked group belongs to _another_ group that has its View data permission set to "Can view", that more permissive access will take precedence, and they'll be able to view that question.
 
 ## Create queries permissions
 

--- a/docs/permissions/no-self-service-deprecation.md
+++ b/docs/permissions/no-self-service-deprecation.md
@@ -85,28 +85,28 @@ We can't really make a call on what Group B's View data should be. If we switch 
 
 ### For some permission setups with groups that have "No self-service" and "Sandboxed" data access, you may need to create a new group to replicate the setup in 50 or higher
 
-Because the (more permissive) "No self-service" data access couldn't override the (less permissive) "Sandboxed" access, you could set up Metabase 49 in ways that were difficult to reason about. In this case, even though the "No self-service" setting was _more_ permissive than "Sandboxed" setting, the "Sandboxed" setting took precedence over the "No self-service" setting.
+In Metabase 49, the (more permissive) "No self-service" data access couldn't override the (less permissive) "Sandboxed" access, you could set up Metabase 49 in ways that were difficult to reason about.
 
 In the new permission system starting in Metabase 50, more permissive settings _always_ override less permissive settings. This consistent behavior makes permissions a _lot_ easier to reason about. One consequence of this improvement, however, is that in order to recreate certain permissions setups when upgrading to Metabase 50, you may need to create an _additional_ group.
 
-For example, let's say you have two groups in Metabase 49 under the old data access permission.
+For example, let's say you have two groups in Metabase 49 under the old data access permission, the All users group and the Foo group.
 
 **Permission setup in 49:**
 
 - All users group has "No self-service" data access to all of the tables in the Sample Database.
 - Foo group has "Sandboxed" access to the tables in the Sample Database.
 
-This data access setup in 49 would allow people to view questions and dashboards in collections they have access to. People in the Foo group, however, would get a sandboxed view of items. In this case, the less permissive "Sandboxed" data access in the Foo group overrode the more permissive "No self-service" in the All users group.
+This data access setup in 49 would allow people to view questions and dashboards in collections they have access to. People in the Foo group, however, would get a sandboxed view of the items. In this case, the less permissive "Sandboxed" data access in the Foo group overrode the more permissive "No self-service" in the All users group.
 
 Starting with Metabase 50, however, more permissive settings _always_ override less permissive settings. So in order to keep Foo's sandboxes in tact, we'd need to make the All users group have a View data permission setting that is _less_ permissive than the "Sandboxed" setting. So we'll need to set the View data permission for All users to "Blocked."
 
-But if you still want everyone else who isn't in the Foo group to view items in collections they have access to, you'll need to create an additional group, Bar, that contains everyone _except for_ people in the Foo group, and grant that Bar group "Can view" access to the Sample database. The Bar group's "Can view" access will override the All Users group's "Blocked" setting, and they'll be able to view the questions and dashboards. Meanwhile, Foo group still has its sandboxes. Here's a summary of the settings for 50 that you'd need:
+But if you still want everyone else who _isn't_ in the Foo group to view items in collections they have access to, you'll need to create an additional group, Bar, that contains everyone _except for_ people in the Foo group, and grant that Bar group "Can view" access to the Sample database. The Bar group's "Can view" access will override the All Users group's "Blocked" setting, and they'll be able to view the questions and dashboards. Meanwhile, Foo group still has its sandboxes. Here's a summary of the settings for 50 that you'd need:
 
 **Permission setup in 50:**
 
 - All users group is "Blocked" for all tables in the Sample database.
 - Foo group has View data permission of "Sandboxed" for all tables in the Sample database.
-- **Create New group**, Bar, that includes everyone in the All users group _except for_ people in the Foo group. Set this Bar group's View data permission set to "Can view" for the Sample database.
+- **Create a new group**, Bar, that includes everyone in the All users group _except for_ people in the Foo group. Set this Bar group's View data permission to "Can view" for the Sample database.
 
 ## Further reading
 

--- a/docs/permissions/no-self-service-deprecation.md
+++ b/docs/permissions/no-self-service-deprecation.md
@@ -23,7 +23,7 @@ Mixing two axes (querying + viewing) to a single permissions setting could yield
 
 ## What our overhaul of data permissions accomplishes
 
-- Splits [view access](./data.md#view-data-permissions) and [query access](./data.md#create-queries-permissions) into two permission dimensions.
+- Splits [view access](./data.md#view-data-permissions) and [query access](./data.md#create-queries-permissions) into two permission dimensions. This splitting allows admins to, for example, sandbox tables with or without access to the query builder (previously it wasn't possible to configure sandboxing as view only).
 - Makes permissions easier to reason about. A more restrictive permission never gives more access than a less restrictive one.
 
 ## Migration table from old permissions to new
@@ -48,16 +48,18 @@ Before, Metabase had **Data access** and **Native query editing**. Now, Metabase
 
 If you see the `No self-service (deprecated)` permission setting in **View data** for any group, you should manually change it at some point.
 
-For any group that has their **View data** access set to `No self-service (deprecated)`, you'll need to change the **View data** permission to one of the new types:
+For any group that has their **View data** access set to `No self-service (deprecated)`, you'll need to change the **View data** permission to one of the new options:
 
 - [Can view](./data.md#can-view-data-permission)
 - [Impersonated](./data.md#impersonated-view-data-permission)
 - [Sandboxed](./data.md#sandboxed-view-data-permission)
 - [Blocked](./data.md#blocked-view-data-permission)
 
-Please make the change soon, but don't stress about it: if you take no action, Metabase will change any groups with View data access set to `No self-service (deprecated)` to `Blocked` in a future release. We're defaulting to "Blocked", the least permissive View data access, to prevent any unintended access to data.
+If you take no action, Metabase will change any groups with View data access set to `No self-service (deprecated)` to `Blocked` in a future release. We're defaulting to "Blocked", the least permissive View data access, to prevent any unintended access to data. But this change to Blocked could cause people to lose access to data they previously had access to.
 
-Why we couldn't migrate this setting manually: in the old permissions system, consider people in multiple groups.
+### Why we couldn't migrate this setting manually
+
+In the old permissions system, consider people in multiple groups.
 
 - **Unrestricted** data access meant that blocks, sandboxes, or impersonations from your other groups DO NOT affect you.
 - **No Self Service** data access meant that blocks, sandboxes, or impersonations from your other groups DO affect you.
@@ -79,7 +81,32 @@ We could migrate the permissions like so:
 | **View data**      | Can view           | ?           | Blocked     | Sandboxed          | Impersonated       |
 | **Create queries** | Query Builder only | No          | No          | Query Builder only | Query Builder only |
 
-We can't really make a call on what Group B's View data should be. If we switch it to **Can view**, the person won't be affected by the blocked, sandboxed, or impersonated settings in their other group. If we set it to **Blocked**, they could lose access to that data. So we created an interim setting, `No self-service (legacy)` to manage this (temporarily) awkward transition.
+We can't really make a call on what Group B's View data should be. If we switch it to **Can view**, the person won't be affected by the Blocked, Sandboxed, or Impersonated settings in their other group. If we set it to **Blocked**, they could lose access to data that you think they should have access to. So we created an interim setting, `No self-service (legacy)` to manage this (temporarily) awkward transition.
+
+### For some permission setups with groups that have "No self-service" and "Sandboxed" data access, you may need to create a new group to replicate the setup in 50 or higher
+
+Because the (more permissive) "No self-service" data access couldn't override the (less permissive) "Sandboxed" access, you could set up Metabase 49 in ways that were difficult to reason about. In this case, even though the "No self-service" setting was _more_ permissive than "Sandboxed" setting, the "Sandboxed" setting took precedence over the "No self-service" setting.
+
+In the new permission system starting in Metabase 50, more permissive settings _always_ override less permissive settings. This consistent behavior makes permissions a _lot_ easier to reason about. One consequence of this improvement, however, is that in order to recreate certain permissions setups when upgrading to Metabase 50, you may need to create an _additional_ group.
+
+For example, let's say you have two groups in Metabase 49 under the old data access permission.
+
+**Permission setup in 49:**
+
+- All users group has "No self-service" data access to all of the tables in the Sample Database.
+- Foo group has "Sandboxed" access to the tables in the Sample Database.
+
+This data access setup in 49 would allow people to view questions and dashboards in collections they have access to. People in the Foo group, however, would get a sandboxed view of items. In this case, the less permissive "Sandboxed" data access in the Foo group overrode the more permissive "No self-service" in the All users group.
+
+Starting with Metabase 50, however, more permissive settings _always_ override less permissive settings. So in order to keep Foo's sandboxes in tact, we'd need to make the All users group have a View data permission setting that is _less_ permissive than the "Sandboxed" setting. So we'll need to set the View data permission for All users to "Blocked."
+
+But if you still want everyone else who isn't in the Foo group to view items in collections they have access to, you'll need to create an additional group, Bar, that contains everyone _except for_ people in the Foo group, and grant that Bar group "Can view" access to the Sample database. The Bar group's "Can view" access will override the All Users group's "Blocked" setting, and they'll be able to view the questions and dashboards. Meanwhile, Foo group still has its sandboxes. Here's a summary of the settings for 50 that you'd need:
+
+**Permission setup in 50:**
+
+- All users group is "Blocked" for all tables in the Sample database.
+- Foo group has View data permission of "Sandboxed" for all tables in the Sample database.
+- **Create New group**, Bar, that includes everyone in the All users group _except for_ people in the Foo group. Set this Bar group's View data permission set to "Can view" for the Sample database.
 
 ## Further reading
 


### PR DESCRIPTION
Contingent on https://github.com/metabase/metabase/pull/46542.

- Adds docs for table-level "blocked" permission setting.
- Clarifies permission setup transition from 49 to 50.