### PR TITLE
Refine sandboxed user perms for query builder access

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
@@ -270,12 +270,11 @@
                                                      :unrestricted
                                                      (get table-id->db-id table-id)
                                                      table-id))
-                                      table-ids)
-          create-queries-perms (zipmap unblocked-table-ids (repeat :query-builder))]
-      {:perms/view-data (zipmap table-ids (repeat :unrestricted))
+                                      table-ids)]
+      {:perms/view-data (zipmap unblocked-table-ids (repeat :unrestricted))
        ;; grant create-queries to only unblocked table ids. Otherwise sandboxed users with a joined table that's
        ;; _blocked_ can be queried against from the query builder, but we never want that.
-       :perms/create-queries create-queries-perms})))
+       :perms/create-queries (zipmap table-ids (repeat :query-builder))})))
 
 
 

--- a/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
@@ -16,6 +16,7 @@
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.models.card :refer [Card]]
+   [metabase.models.data-permissions :as data-perms]
    [metabase.models.query.permissions :as query-perms]
    [metabase.public-settings.premium-features :refer [defenterprise]]
    [metabase.query-processor.error-type :as qp.error-type]
@@ -259,9 +260,24 @@
                      (query-perms/required-perms-for-query (:dataset-query (lib.metadata.protocols/card (qp.store/metadata-provider) card-id))
                                                  :throw-exceptions? true))
 
-    (let [table-ids (sandbox->table-ids sandbox)]
+    (let [table-ids (sandbox->table-ids sandbox)
+          table-id->db-id (if (seq table-ids)
+                            (m/index-by :id (t2/select :model/Table :id [:in table-ids]))
+                            {})
+          unblocked-table-ids (filter (fn [table-id] (data-perms/user-has-permission-for-table?
+                                                     api/*current-user-id*
+                                                     :perms/view-data
+                                                     :unrestricted
+                                                     (get table-id->db-id table-id)
+                                                     table-id))
+                                      table-ids)
+          create-queries-perms (zipmap unblocked-table-ids (repeat :query-builder))]
       {:perms/view-data (zipmap table-ids (repeat :unrestricted))
-       :perms/create-queries (zipmap table-ids (repeat :query-builder))})))
+       ;; grant create-queries to only unblocked table ids. Otherwise sandboxed users with a joined table that's
+       ;; _blocked_ can be queried against from the query builder, but we never want that.
+       :perms/create-queries create-queries-perms})))
+
+
 
 (defn- merge-perms
   "The shape of permissions maps is a little odd, and using `m/deep-merge` doesn't give us exactly what we want.

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
@@ -221,8 +221,7 @@
                                                                 :display_name  "Count"
                                                                 :source        :aggregation
                                                                 :field_ref     [:aggregation 0]}]
-                   ::query-perms/perms                        {:gtaps {:perms/view-data      {(mt/id :checkins) :unrestricted
-                                                                                              (mt/id :venues) :unrestricted}
+                   ::query-perms/perms                        {:gtaps {:perms/view-data      {(mt/id :checkins) :unrestricted}
                                                                        :perms/create-queries {(mt/id :checkins) :query-builder
                                                                                               (mt/id :venues) :query-builder}}}})
                 (apply-row-level-permissions


### PR DESCRIPTION
This is a fix for the scenario where if a user has a sandboxed adhoc query, they can use it to read from tables they are blocked on. 😱

If you use the query builder to setup a sandboxed query that joins to a table you are `can-view = blocked` on, we no longer grant you `create-queries` access to it when doing the sandboxing permissions calculations.

How:

- Limit create-queries permissions to unblocked tables only
- Check user permissions for each table before granting query builder access
- Prevent querying of blocked joined tables from query builder for sandboxed users
