### PR TITLE
Much better collection permission performance

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -8959,6 +8959,93 @@ databaseChangeLog:
         - customChange:
             class: "metabase.db.custom_migrations.MigrateLegacyColumnKeysInDashboardCardVizSettings"
 
+  - changeSet:
+      id: v51.2024-08-12T10:02:49
+      author: johnswanson
+      comment: Permissions columns
+      changes:
+        - addColumn:
+            columns:
+              - column:
+                  name: perm_value
+                  type: varchar(64)
+                  remarks: The value of the permission
+                  constraints:
+                    nullable: true
+              - column:
+                  name: perm_type
+                  type: varchar(64)
+                  remarks: The type of the permission
+                  constraints:
+                    nullable: true
+              - column:
+                  name: collection_id
+                  type: int
+                  remarks: The linked collection, if applicable
+                  constraints:
+                    nullable: true
+                    referencedTableName: collection
+                    referencedColumnNames: id
+                    foreignKeyName: fk_permissions_ref_collection_id
+            tableName: permissions
+
+
+  - changeSet:
+      id: v51.2024-08-20T11:02:24
+      author: johnswanson
+      comment: Populate `perm_value`, `perm_type`, and `collection_id` on permissions
+      rollback: # not needed.
+      changes:
+        - sqlFile:
+            dbms: postgresql
+            path: permissions/collection-access.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: mysql,mariadb
+            path: permissions/collection-access-mariadb.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: h2
+            path: permissions/collection-access-h2.sql
+            relativeToChangelogFile: true
+
+  - changeSet:
+      id: v51.2024-08-20T11:12:19
+      author: johnswanson
+      comment: Create index on `permissions.collection_id`
+      changes:
+        - createIndex:
+            tableName: permissions
+            columns:
+              - column:
+                  name: collection_id
+            indexName: idx_permissions_collection_id
+
+
+  - changeSet:
+      id: v51.2024-08-20T11:12:54
+      author: johnswanson
+      comment: Index on `permissions.perm_type`
+      changes:
+        - createIndex:
+            tableName: permissions
+            columns:
+              - column:
+                  name: perm_type
+            indexName: idx_permissions_perm_type
+
+  - changeSet:
+      id: v51.2024-08-20T11:12:55
+      author: johnswanson
+      comment: Index on `permissions.perm_value`
+      changes:
+        - createIndex:
+            tableName: permissions
+            columns:
+              - column:
+                  name: perm_value
+            indexName: idx_permissions_perm_value
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -8960,9 +8960,14 @@ databaseChangeLog:
             class: "metabase.db.custom_migrations.MigrateLegacyColumnKeysInDashboardCardVizSettings"
 
   - changeSet:
-      id: v51.2024-08-12T10:02:49
+      id: v51.2024-08-21T08:33:07
       author: johnswanson
       comment: Permissions columns
+      preConditions:
+         - not:
+              - columnExists:
+                  tableName: permissions
+                  columnName: perm_value
       changes:
         - addColumn:
             columns:
@@ -8972,12 +8977,41 @@ databaseChangeLog:
                   remarks: The value of the permission
                   constraints:
                     nullable: true
+            tableName: permissions
+
+  - changeSet:
+      id: v51.2024-08-21T08:33:08
+      author: johnswanson
+      comment: Add permissions.perm_type
+      preConditions:
+          - not:
+              - columnExists:
+                  tableName: permissions
+                  columnName: perm_type
+      changes:
+        - addColumn:
+            columns:
               - column:
                   name: perm_type
                   type: varchar(64)
                   remarks: The type of the permission
                   constraints:
                     nullable: true
+            tableName: permissions
+
+  - changeSet:
+      id: v51.2024-08-21T08:33:09
+      author: johnswanson
+      comment: Add permissions.collection_id
+      preConditions:
+          - not:
+              - columnExists:
+                  tableName: permissions
+                  columnName: collection_id
+      changes:
+        - addColumn:
+            tableName: permissions
+            columns:
               - column:
                   name: collection_id
                   type: int
@@ -8987,11 +9021,10 @@ databaseChangeLog:
                     referencedTableName: collection
                     referencedColumnNames: id
                     foreignKeyName: fk_permissions_ref_collection_id
-            tableName: permissions
 
 
   - changeSet:
-      id: v51.2024-08-20T11:02:24
+      id: v51.2024-08-21T08:33:10
       author: johnswanson
       comment: Populate `perm_value`, `perm_type`, and `collection_id` on permissions
       rollback: # not needed.
@@ -9010,9 +9043,14 @@ databaseChangeLog:
             relativeToChangelogFile: true
 
   - changeSet:
-      id: v51.2024-08-20T11:12:19
+      id: v51.2024-08-21T08:33:11
       author: johnswanson
       comment: Create index on `permissions.collection_id`
+      preConditions:
+        - not:
+            - indexExists:
+                tableName: permissions
+                indexName: idx_permissions_collection_id
       changes:
         - createIndex:
             tableName: permissions
@@ -9023,9 +9061,14 @@ databaseChangeLog:
 
 
   - changeSet:
-      id: v51.2024-08-20T11:12:54
+      id: v51.2024-08-21T08:33:12
       author: johnswanson
       comment: Index on `permissions.perm_type`
+      preConditions:
+        - not:
+            - indexExists:
+                tableName: permissions
+                indexName: idx_permissions_perm_type
       changes:
         - createIndex:
             tableName: permissions
@@ -9035,9 +9078,14 @@ databaseChangeLog:
             indexName: idx_permissions_perm_type
 
   - changeSet:
-      id: v51.2024-08-20T11:12:55
+      id: v51.2024-08-21T08:33:13
       author: johnswanson
       comment: Index on `permissions.perm_value`
+      preConditions:
+        - not:
+            - indexExists:
+                tableName: permissions
+                indexName: idx_permissions_perm_value
       changes:
         - createIndex:
             tableName: permissions

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -9060,6 +9060,7 @@ databaseChangeLog:
       id: v51.2024-08-21T08:33:11
       author: johnswanson
       comment: Create index on `permissions.collection_id`
+      rollback: # deleted with the column
       preConditions:
         - not:
             - indexExists:
@@ -9078,6 +9079,7 @@ databaseChangeLog:
       id: v51.2024-08-21T08:33:12
       author: johnswanson
       comment: Index on `permissions.perm_type`
+      rollback: # deleted with the column
       preConditions:
         - not:
             - indexExists:
@@ -9095,6 +9097,7 @@ databaseChangeLog:
       id: v51.2024-08-21T08:33:13
       author: johnswanson
       comment: Index on `permissions.perm_value`
+      rollback: # deleted with the column
       preConditions:
         - not:
             - indexExists:

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -8960,14 +8960,15 @@ databaseChangeLog:
             class: "metabase.db.custom_migrations.MigrateLegacyColumnKeysInDashboardCardVizSettings"
 
   - changeSet:
-      id: v51.2024-08-21T08:33:07
+      id: v51.2024-08-21T08:33:06
       author: johnswanson
-      comment: Permissions columns
+      comment: Add permissions.perm_value
       preConditions:
-         - not:
-              - columnExists:
-                  tableName: permissions
-                  columnName: perm_value
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: permissions
+                columnName: perm_value
       changes:
         - addColumn:
             columns:
@@ -8980,14 +8981,15 @@ databaseChangeLog:
             tableName: permissions
 
   - changeSet:
-      id: v51.2024-08-21T08:33:08
+      id: v51.2024-08-21T08:33:07
       author: johnswanson
       comment: Add permissions.perm_type
       preConditions:
-          - not:
-              - columnExists:
-                  tableName: permissions
-                  columnName: perm_type
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: permissions
+                columnName: perm_type
       changes:
         - addColumn:
             columns:
@@ -9000,14 +9002,15 @@ databaseChangeLog:
             tableName: permissions
 
   - changeSet:
-      id: v51.2024-08-21T08:33:09
+      id: v51.2024-08-21T08:33:08
       author: johnswanson
       comment: Add permissions.collection_id
       preConditions:
-          - not:
-              - columnExists:
-                  tableName: permissions
-                  columnName: collection_id
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: permissions
+                columnName: collection_id
       changes:
         - addColumn:
             tableName: permissions
@@ -9018,10 +9021,21 @@ databaseChangeLog:
                   remarks: The linked collection, if applicable
                   constraints:
                     nullable: true
-                    referencedTableName: collection
-                    referencedColumnNames: id
-                    foreignKeyName: fk_permissions_ref_collection_id
 
+  # FK constraint is added separately because deleteCascade doesn't work in addColumn -- see #14321
+  - changeSet:
+      id: v51.2024-08-21T08:33:09
+      author: johnswanson
+      comment: Add `permissions.collection_id` foreign key constraint
+      preConditions:
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: permissions
+            baseColumnNames: collection_id
+            referencedTableName: collection
+            referencedColumnNames: id
+            constraintName: fk_permissions_ref_collection_id
+            onDelete: CASCADE
 
   - changeSet:
       id: v51.2024-08-21T08:33:10

--- a/resources/migrations/permissions/collection-access-h2.sql
+++ b/resources/migrations/permissions/collection-access-h2.sql
@@ -1,3 +1,12 @@
+DELETE FROM permissions
+WHERE id IN (
+  SELECT p.id
+  FROM permissions p
+  LEFT OUTER JOIN collection c
+  ON p.object = '/collection/' || c.id || '/' OR p.object = '/collection/' || c.id || '/read/'
+  WHERE c.id IS NULL AND REGEXP_LIKE(p.object, '^/collection/\d+/(read/)?$')
+);
+
 UPDATE permissions p SET collection_id = (
   SELECT id
   FROM collection c

--- a/resources/migrations/permissions/collection-access-h2.sql
+++ b/resources/migrations/permissions/collection-access-h2.sql
@@ -1,0 +1,12 @@
+UPDATE permissions p SET collection_id = (
+  SELECT id
+  FROM collection c
+  WHERE p.object = '/collection/' || c.id || '/'
+  OR p.object = '/collection/' || c.id || '/read/'
+),
+perm_value = CASE
+  WHEN object like '/collection/%/read/' THEN 'read'
+  ELSE 'read-and-write'
+END,
+perm_type = 'perms/collection-access'
+WHERE object LIKE '/collection/%';

--- a/resources/migrations/permissions/collection-access-mariadb.sql
+++ b/resources/migrations/permissions/collection-access-mariadb.sql
@@ -1,0 +1,18 @@
+UPDATE permissions
+SET
+  -- extract the collection_id from the object path
+  collection_id = cast(substring_index(substring_index(object, '/', 3), '/', -1) as unsigned integer),
+
+
+  -- set the perm_type for matching permissions
+  perm_type = 'perms/collection-access',
+
+  -- set perm_value based on the presence of 'read/' in the object
+  perm_value = CASE
+    WHEN object LIKE '/collection/%/read/' THEN 'read'
+    WHEN object LIKE '/collection/%/' THEN 'read-and-write'
+    ELSE null
+  END
+WHERE
+  -- only update rows that match the collection pattern
+  object regexp '^/collection/[0-9]+/(read/)?$';

--- a/resources/migrations/permissions/collection-access-mariadb.sql
+++ b/resources/migrations/permissions/collection-access-mariadb.sql
@@ -1,3 +1,8 @@
+DELETE p FROM permissions p
+LEFT OUTER JOIN collection c
+ON p.object = CONCAT('/collection/', c.id, '/') OR p.object = CONCAT('/collection/', c.id, '/read/')
+WHERE c.id IS NULL AND p.object REGEXP '^/collection/\\d+/(read/)?$';
+
 UPDATE permissions
 SET
   -- extract the collection_id from the object path

--- a/resources/migrations/permissions/collection-access.sql
+++ b/resources/migrations/permissions/collection-access.sql
@@ -1,3 +1,12 @@
+DELETE FROM permissions
+WHERE id IN (
+  SELECT p.id
+  FROM permissions p
+  LEFT OUTER JOIN collection c
+  ON p.object = '/collection/' || c.id || '/' OR p.object = '/collection/' || c.id || '/read/'
+  WHERE c.id IS NULL AND p.object ~ '^/collection/\d+/(read/)?$'
+);
+
 UPDATE permissions
 SET
   -- extract the collection_id from the object path

--- a/resources/migrations/permissions/collection-access.sql
+++ b/resources/migrations/permissions/collection-access.sql
@@ -1,0 +1,17 @@
+UPDATE permissions
+SET
+  -- extract the collection_id from the object path
+  collection_id = cast(substring(object from '/collection/(\d+)/') as integer),
+
+  -- set the perm_type for matching permissions
+  perm_type = 'perms/collection-access',
+
+  -- set perm_value based on the presence of 'read/' in the object
+  perm_value = CASE
+    WHEN object LIKE '/collection/%/read/' THEN 'read'
+    WHEN object LIKE '/collection/%/' THEN 'read-and-write'
+    ELSE null
+  END
+WHERE
+  -- only update rows that match the collection pattern
+  object ~ '^/collection/\d+/(read/)?$';

--- a/src/metabase/api/action.clj
+++ b/src/metabase/api/action.clj
@@ -68,7 +68,7 @@
                                      [:= :type "model"]
                                      [:= :archived false]
                                      ;; action permission keyed off of model permission
-                                     (collection/honeysql-filter-clause @api/*current-user-permissions-set*)]}))]
+                                     (collection/honeysql-filter-clause)]}))]
       (actions-for models))))
 
 (api/defendpoint GET "/public"

--- a/src/metabase/api/action.clj
+++ b/src/metabase/api/action.clj
@@ -68,10 +68,7 @@
                                      [:= :type "model"]
                                      [:= :archived false]
                                      ;; action permission keyed off of model permission
-                                     (collection/visible-collection-ids->honeysql-filter-clause
-                                      :collection_id
-                                      (collection/permissions-set->visible-collection-ids
-                                       @api/*current-user-permissions-set*))]}))]
+                                     (collection/honeysql-filter-clause @api/*current-user-permissions-set*)]}))]
       (actions-for models))))
 
 (api/defendpoint GET "/public"

--- a/src/metabase/api/action.clj
+++ b/src/metabase/api/action.clj
@@ -68,7 +68,7 @@
                                      [:= :type "model"]
                                      [:= :archived false]
                                      ;; action permission keyed off of model permission
-                                     (collection/honeysql-filter-clause)]}))]
+                                     (collection/visible-collection-filter-clause)]}))]
       (actions-for models))))
 
 (api/defendpoint GET "/public"

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -633,9 +633,7 @@
 
 (defn- annotate-collections
   [parent-coll colls]
-  (let [visible-collection-ids (collection/permissions-set->visible-collection-ids
-                                @api/*current-user-permissions-set*
-                                {:include-archived-items :all})
+  (let [visible-collection-ids (collection/visible-collection-ids {:include-archived-items :all})
         descendant-collections (collection/descendants-flat parent-coll (collection/honeysql-filter-clause
                                                                          :id
                                                                          {:include-archived-items :all}))
@@ -949,10 +947,8 @@
 
 (defn- effective-children-ids
   "Returns effective children ids for collection."
-  [collection permissions-set]
-  (let [visible-collection-ids (set (collection/permissions-set->visible-collection-ids
-                                     permissions-set
-                                     {:permission-level :write}))
+  [collection _permissions-set]
+  (let [visible-collection-ids (set (collection/visible-collection-ids {:permission-level :write}))
         all-descendants (map :id (collection/descendants-flat collection))]
     (filterv visible-collection-ids all-descendants)))
 

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -633,7 +633,9 @@
 
 (defn- annotate-collections
   [parent-coll colls]
-  (let [visible-collection-ids (collection/permissions-set->visible-collection-ids {:include-archived-items :all})
+  (let [visible-collection-ids (collection/permissions-set->visible-collection-ids
+                                @api/*current-user-permissions-set*
+                                {:include-archived-items :all})
         descendant-collections (collection/descendants-flat parent-coll (collection/honeysql-filter-clause
                                                                          :id
                                                                          {:include-archived-items :all}))

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -434,10 +434,10 @@
        :where     [:and
                    (collection/honeysql-filter-clause :collection_id
                                                       {:include-archived-items :all
-                                                                         :permission-level (if archived?
-                                                                                             :write
-                                                                                             :read)
-                                                                         :archive-operation-id nil})
+                                                       :permission-level (if archived?
+                                                                           :write
+                                                                           :read)
+                                                       :archive-operation-id nil})
                    (if (collection/is-trash? collection)
                      [:= :c.archived_directly true]
                      [:and

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -104,7 +104,7 @@
                        (when exclude-other-user-collections
                          [:or [:= :personal_owner_id nil] [:= :personal_owner_id api/*current-user-id*]])
                        (perms/audit-namespace-clause :namespace namespace)
-                       (collection/honeysql-filter-clause
+                       (collection/visible-collection-filter-clause
                         :id
                         {:include-archived-items (if archived
                                                    :only
@@ -432,12 +432,12 @@
                                    [:= :r.model (h2x/literal "Card")]]
                    [:core_user :u] [:= :u.id :r.user_id]]
        :where     [:and
-                   (collection/honeysql-filter-clause :collection_id
-                                                      {:include-archived-items :all
-                                                       :permission-level (if archived?
-                                                                           :write
-                                                                           :read)
-                                                       :archive-operation-id nil})
+                   (collection/visible-collection-filter-clause :collection_id
+                                                                {:include-archived-items :all
+                                                                 :permission-level (if archived?
+                                                                                     :write
+                                                                                     :read)
+                                                                 :archive-operation-id nil})
                    (if (collection/is-trash? collection)
                      [:= :c.archived_directly true]
                      [:and
@@ -559,12 +559,12 @@
                                    [:= :r.model (h2x/literal "Dashboard")]]
                    [:core_user :u] [:= :u.id :r.user_id]]
        :where     [:and
-                   (collection/honeysql-filter-clause :collection_id
-                                                      {:include-archived-items :all
-                                                       :archive-operation-id nil
-                                                       :permission-level (if archived?
-                                                                           :write
-                                                                           :read)})
+                   (collection/visible-collection-filter-clause :collection_id
+                                                                {:include-archived-items :all
+                                                                 :archive-operation-id nil
+                                                                 :permission-level (if archived?
+                                                                                     :write
+                                                                                     :read)})
                    (if (collection/is-trash? collection)
                      [:= :d.archived_directly true]
                      [:and
@@ -634,7 +634,7 @@
 (defn- annotate-collections
   [parent-coll colls]
   (let [visible-collection-ids (collection/visible-collection-ids {:include-archived-items :all})
-        descendant-collections (collection/descendants-flat parent-coll (collection/honeysql-filter-clause
+        descendant-collections (collection/descendants-flat parent-coll (collection/visible-collection-filter-clause
                                                                          :id
                                                                          {:include-archived-items :all}))
 

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -177,7 +177,7 @@
                                            ;; always return metrics for now
                                            [:in :type [(u/qualified-name card-type) "metric"]]
                                            [:in :database_id ids-of-dbs-that-support-source-queries]
-                                           (collection/honeysql-filter-clause @api/*current-user-permissions-set*)]
+                                           (collection/honeysql-filter-clause)]
                                           additional-constraints)
                           :order-by [[:%lower.name :asc]]}))))
 

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -177,7 +177,7 @@
                                            ;; always return metrics for now
                                            [:in :type [(u/qualified-name card-type) "metric"]]
                                            [:in :database_id ids-of-dbs-that-support-source-queries]
-                                           (collection/honeysql-filter-clause)]
+                                           (collection/visible-collection-filter-clause)]
                                           additional-constraints)
                           :order-by [[:%lower.name :asc]]}))))
 

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -177,9 +177,7 @@
                                            ;; always return metrics for now
                                            [:in :type [(u/qualified-name card-type) "metric"]]
                                            [:in :database_id ids-of-dbs-that-support-source-queries]
-                                           (collection/visible-collection-ids->honeysql-filter-clause
-                                            (collection/permissions-set->visible-collection-ids
-                                             @api/*current-user-permissions-set*))]
+                                           (collection/honeysql-filter-clause @api/*current-user-permissions-set*)]
                                           additional-constraints)
                           :order-by [[:%lower.name :asc]]}))))
 

--- a/src/metabase/api/timeline.clj
+++ b/src/metabase/api/timeline.clj
@@ -46,7 +46,7 @@
         timelines (->> (t2/select Timeline
                                   {:where    [:and
                                               [:= :archived archived?]
-                                              (collection/honeysql-filter-clause @api/*current-user-permissions-set*)]
+                                              (collection/honeysql-filter-clause)]
                                    :order-by [[:%lower.name :asc]]})
                        (map collection.root/hydrate-root-collection))]
     (cond->> (t2/hydrate timelines :creator [:collection :can_write])

--- a/src/metabase/api/timeline.clj
+++ b/src/metabase/api/timeline.clj
@@ -46,7 +46,7 @@
         timelines (->> (t2/select Timeline
                                   {:where    [:and
                                               [:= :archived archived?]
-                                              (collection/honeysql-filter-clause)]
+                                              (collection/visible-collection-filter-clause)]
                                    :order-by [[:%lower.name :asc]]})
                        (map collection.root/hydrate-root-collection))]
     (cond->> (t2/hydrate timelines :creator [:collection :can_write])

--- a/src/metabase/api/timeline.clj
+++ b/src/metabase/api/timeline.clj
@@ -46,8 +46,7 @@
         timelines (->> (t2/select Timeline
                                   {:where    [:and
                                               [:= :archived archived?]
-                                              (collection/visible-collection-ids->honeysql-filter-clause
-                                               (collection/permissions-set->visible-collection-ids @api/*current-user-permissions-set*))]
+                                              (collection/honeysql-filter-clause @api/*current-user-permissions-set*)]
                                    :order-by [[:%lower.name :asc]]})
                        (map collection.root/hydrate-root-collection))]
     (cond->> (t2/hydrate timelines :creator [:collection :can_write])

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -299,9 +299,7 @@
   "True when the user has permissions for at least one un-archived question and one un-archived dashboard, excluding
   internal/automatically-loaded content."
   [user]
-  (let [coll-ids-filter (collection/visible-collection-ids->honeysql-filter-clause
-                         :collection_id
-                         (collection/permissions-set->visible-collection-ids @api/*current-user-permissions-set*))
+  (let [coll-ids-filter (collection/honeysql-filter-clause @api/*current-user-permissions-set* :collection_id)
         entity-exists? (fn [model] (t2/exists? model
                                                {:where [:and
                                                         [:= :archived false]

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -299,13 +299,18 @@
   "True when the user has permissions for at least one un-archived question and one un-archived dashboard, excluding
   internal/automatically-loaded content."
   [user]
-  (-> user
-      (assoc :has_question_and_dashboard
-             (and (t2/exists? :model/Card {:where (collection/honeysql-filter-clause)})
-                  (t2/exists? :model/Dashboard {:where (collection/honeysql-filter-clause)})))
-      (assoc :has_model (t2/exists? :model/Card {:where [:and
-                                                         (collection/honeysql-filter-clause)
-                                                         [:= :type "model"]]}))))
+  (let [collection-filter (collection/visible-collection-filter-clause)
+        entity-exists? (fn [model & additional-clauses] (t2/exists? model
+                                                                    {:where (into [:and
+                                                                                   [:= :archived false]
+                                                                                   collection-filter
+                                                                                   (mi/exclude-internal-content-hsql model)]
+                                                                                  additional-clauses)}))]
+    (-> user
+        (assoc :has_question_and_dashboard
+               (and (entity-exists? :model/Card)
+                    (entity-exists? :model/Dashboard)))
+        (assoc :has_model (entity-exists? :model/Card [:= :type "model"])))))
 
 (defn- add-first-login
   "Adds `first_login` key to the `User` with the oldest timestamp from that user's login history. Otherwise give the current time, as it's the user's first login."

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -1529,13 +1529,17 @@
                                 :from [[:collection :c]]}]
                               [{:select [:c.*]
                                 :from [[:collection :c]]
-                                :join [[:permissions :p] [:or
-                                                          (when (= :read (:permission-level visibility-config))
-                                                            [:= :p.object [:concat "/collection/" :c.id "/read/"]])
-                                                          [:= :p.object [:concat "/collection/" :c.id "/"]]]
+                                :join [[:permissions :p]
+                                       [:= :c.id :p.collection_id]
                                        [:permissions_group :pg] [:= :pg.id :p.group_id]
                                        [:permissions_group_membership :pgm] [:= :pgm.group_id :pg.id]]
-                                :where [:= :pgm.user_id api/*current-user-id*]}
+                                :where [:and
+                                        [:= :pgm.user_id api/*current-user-id*]
+                                        [:= :p.perm_type "perms/collection-access"]
+                                        [:or
+                                         [:= :p.perm_value "read-and-write"]
+                                         (when (= :read (:permission-level visibility-config))
+                                           [:= :p.perm_value "read"])]]}
                                {:select [:c.*]
                                 :from [[:collection :c]]
                                 :where [:in :id (user->personal-collection-and-descendant-ids api/*current-user-id*)]}])}

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -312,7 +312,6 @@
   [collection :- CollectionWithLocationAndIDOrRoot]
   (t2/select-pks-set Collection :location [:like (str (children-location collection) \%)]))
 
-
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                              Personal Collections                                              |
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -340,7 +339,7 @@
   (let [{first-name :first_name
          last-name  :last_name
          email      :email} (t2/select-one ['User :first_name :last_name :email]
-                              :id (u/the-id user-or-id))]
+                                           :id (u/the-id user-or-id))]
     (format-personal-collection-name first-name last-name email user-or-site)))
 
 (defn personal-collection-with-ui-details
@@ -424,7 +423,6 @@
           ;; in Root, so we can pass it what it needs without actually having to fetch an entire CollectionInstance
           (descendant-ids {:location "/", :id personal-collection-id}))))
 
-
 (mi/define-batched-hydration-method include-personal-collection-ids
   :personal_collection_id
   "Efficiently hydrate the `:personal_collection_id` property of a sequence of Users. (This is, predictably, the ID of
@@ -433,7 +431,7 @@
   (when (seq users)
     ;; efficiently create a map of user ID -> personal collection ID
     (let [user-id->collection-id (t2/select-fn->pk :personal_owner_id Collection
-                                   :personal_owner_id [:in (set (map u/the-id users))])]
+                                                   :personal_owner_id [:in (set (map u/the-id users))])]
       (assert (map? user-id->collection-id))
       ;; now for each User, try to find the corresponding ID out of that map. If it's not present (the personal
       ;; Collection hasn't been created yet), then instead call `user->personal-collection-id`, which will create it
@@ -481,7 +479,6 @@
   collection."
   [:set
    [:or [:= "root"] ms/PositiveInt]])
-
 
 (def ^:private CollectionVisibilityConfig
   [:map

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -407,7 +407,7 @@
           (map key)
           (into #{})))))
 
-(mu/defn visible-collection-ids->honeysql-filter-clause
+(mu/defn ^:private visible-collection-ids->honeysql-filter-clause
   "Generate an appropriate HoneySQL `:where` clause to filter something by visible Collection IDs, such as the ones
   returned by `permissions-set->visible-collection-ids`. Correctly handles all possible values returned by that
   function, including `root` Collection IDs (for the Root Collection).
@@ -437,6 +437,19 @@
 
        :else
        false))))
+
+(mu/defn honeysql-filter-clause
+  "Given a permissions-set and a `CollectionVisibilityConfig`, return a honeysql filter clause ready for use in queries."
+  ([permissions-set :- [:set :string]]
+   (honeysql-filter-clause permissions-set :collection_id))
+  ([permissions-set :- [:set :string]
+    collection-id-field :- [:or [:tuple [:= :coalesce] :keyword :keyword] :keyword]]
+   (honeysql-filter-clause permissions-set collection-id-field {}))
+  ([permissions-set :- [:set :string]
+    collection-id-field :- [:or [:tuple [:= :coalesce] :keyword :keyword]]
+    visibility-config :- CollectionVisibilityConfig]
+   (visible-collection-ids->honeysql-filter-clause collection-id-field
+                                                   (permissions-set->visible-collection-ids permissions-set visibility-config))))
 
 (mu/defn visible-collection-ids->direct-visible-descendant-clause
   "Generates an appropriate HoneySQL `:where` clause to filter out descendants of a collection A with a specific property.

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -580,10 +580,16 @@
                   [:= :archived false])
 
                 (when (= :only (:include-archived-items visibility-config))
-                  [:= :archived true])
+                  [:or
+                   [:= :archived true]
+                   ;; the trash collection is included when viewing archived-only
+                   [:= :id (trash-collection-id)]])
 
                 (when-let [op-id (:archive-operation-id visibility-config)]
-                  [:= :archive_operation_id op-id])
+                  [:or
+                   [:= :archive_operation_id op-id]
+                   ;; the trash collection is part of every `archive_operation`
+                   [:= :id (trash-collection-id)]])
 
                 (when-let [parent-coll (:effective-child-of visibility-config)]
                   (if (is-trash? parent-coll)

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -294,6 +294,177 @@
     (t2/select-one Collection :id new-parent-id)
     root-collection))
 
+(mu/defn children-location :- LocationPath
+  "Given a `collection` return a location path that should match the `:location` value of all the children of the
+  Collection.
+
+     (children-location collection) ; -> \"/10/20/30/\";
+
+     ;; To get children of this collection:
+     (t2/select Collection :location \"/10/20/30/\")"
+  [{:keys [location], :as collection} :- CollectionWithLocationAndIDOrRoot]
+  (if (collection.root/is-root-collection? collection)
+    "/"
+    (str location (u/the-id collection) "/")))
+
+(mu/defn descendant-ids :- [:maybe [:set ms/PositiveInt]]
+  "Return a set of IDs of all descendant Collections of a `collection`."
+  [collection :- CollectionWithLocationAndIDOrRoot]
+  (t2/select-pks-set Collection :location [:like (str (children-location collection) \%)]))
+
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                              Personal Collections                                              |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(mu/defn format-personal-collection-name :- ms/NonBlankString
+  "Constructs the personal collection name from user name.
+  When displaying to users we'll tranlsate it to user's locale,
+  but to keeps things consistent in the database, we'll store the name in site's locale.
+
+  Practically, use `user-or-site` = `:site` when insert or update the name in database,
+  and `:user` when we need the name for displaying purposes"
+  [first-name last-name email user-or-site]
+  {:pre [(#{:user :site} user-or-site)]}
+  (if (= :user user-or-site)
+    (cond
+      (and first-name last-name) (tru "{0} {1}''s Personal Collection" first-name last-name)
+      :else                      (tru "{0}''s Personal Collection" (or first-name last-name email)))
+    (cond
+      (and first-name last-name) (trs "{0} {1}''s Personal Collection" first-name last-name)
+      :else                      (trs "{0}''s Personal Collection" (or first-name last-name email)))))
+
+(mu/defn user->personal-collection-name :- ms/NonBlankString
+  "Come up with a nice name for the Personal Collection for `user-or-id`."
+  [user-or-id user-or-site]
+  (let [{first-name :first_name
+         last-name  :last_name
+         email      :email} (t2/select-one ['User :first_name :last_name :email]
+                              :id (u/the-id user-or-id))]
+    (format-personal-collection-name first-name last-name email user-or-site)))
+
+(defn personal-collection-with-ui-details
+  "For Personal collection, we make sure the collection's name and slug is translated to user's locale
+  This is only used for displaying purposes, For insertion or updating  the name, use site's locale instead"
+  [{:keys [personal_owner_id] :as collection}]
+  (if-not personal_owner_id
+    collection
+    (let [collection-name (user->personal-collection-name personal_owner_id :user)]
+      (assoc collection
+             :name collection-name
+             :slug (u/slugify collection-name)))))
+
+(def ^:private CollectionWithLocationAndPersonalOwnerID
+  "Schema for a Collection instance that has a valid `:location`, and a `:personal_owner_id` key *present* (but not
+  neccesarily non-nil)."
+  [:map
+   [:location          LocationPath]
+   [:personal_owner_id [:maybe ms/PositiveInt]]])
+
+(mu/defn is-personal-collection-or-descendant-of-one? :- :boolean
+  "Is `collection` a Personal Collection, or a descendant of one?"
+  [collection :- CollectionWithLocationAndPersonalOwnerID]
+  (boolean
+   (or
+    ;; If collection has an owner ID we're already done here, we know it's a Personal Collection
+    (:personal_owner_id collection)
+
+    ;; Try to get the ID of its highest-level ancestor, e.g. if `location` is `/1/2/3/` we would get `1`. Then see if
+    ;; the root-level ancestor is a Personal Collection (Personal Collections can only exist in the Root Collection.)
+    (t2/exists? Collection
+                :id                (first (location-path->ids
+                                           (:location collection)))
+                :personal_owner_id [:not= nil]))))
+
+(mu/defn user->existing-personal-collection :- [:maybe (ms/InstanceOf Collection)]
+  "For a `user-or-id`, return their personal Collection, if it already exists.
+  Use [[metabase.models.collection/user->personal-collection]] to fetch their personal Collection *and* create it if
+  needed."
+  [user-or-id]
+  (t2/select-one Collection :personal_owner_id (u/the-id user-or-id)))
+
+(mu/defn user->personal-collection :- (ms/InstanceOf Collection)
+  "Return the Personal Collection for `user-or-id`, if it already exists; if not, create it and return it."
+  [user-or-id]
+  (or (user->existing-personal-collection user-or-id)
+      (try
+        (first (t2/insert-returning-instances! Collection
+                                               {:name              (user->personal-collection-name user-or-id :site)
+                                                :personal_owner_id (u/the-id user-or-id)}))
+        ;; if an Exception was thrown why trying to create the Personal Collection, we can assume it was a race
+        ;; condition where some other thread created it in the meantime; try one last time to fetch it
+        (catch Throwable e
+          (or (user->existing-personal-collection user-or-id)
+              (throw e))))))
+
+(def ^:private ^{:arglists '([user-id])} user->personal-collection-id
+  "Cached function to fetch the ID of the Personal Collection belonging to User with `user-id`. Since a Personal
+  Collection cannot be deleted, the ID will not change; thus it is safe to cache, saving a DB call. It is also
+  required to caclulate the Current User's permissions set, which is done for every API call; thus it is cached to
+  save a DB call for *every* API call."
+  (memoize/ttl
+   ^{::memoize/args-fn (fn [[user-id]]
+                         [(mdb/unique-identifier) user-id])}
+   (fn user->personal-collection-id*
+     [user-id]
+     (u/the-id (user->personal-collection user-id)))
+   ;; cache the results for 60 minutes; TTL is here only to eventually clear out old entries/keep it from growing too
+   ;; large
+   :ttl/threshold (* 60 60 1000)))
+
+(mu/defn user->personal-collection-and-descendant-ids :- [:sequential {:min 1} ms/PositiveInt]
+  "Somewhat-optimized function that fetches the ID of a User's Personal Collection as well as the IDs of all descendants
+  of that Collection. Exists because this needs to be known to calculate the Current User's permissions set, which is
+  done for every API call; this function is an attempt to make fetching this information as efficient as reasonably
+  possible."
+  [user-or-id]
+  (let [personal-collection-id (user->personal-collection-id (u/the-id user-or-id))]
+    (cons personal-collection-id
+          ;; `descendant-ids` wants a CollectionWithLocationAndID, and luckily we know Personal Collections always go
+          ;; in Root, so we can pass it what it needs without actually having to fetch an entire CollectionInstance
+          (descendant-ids {:location "/", :id personal-collection-id}))))
+
+
+(mi/define-batched-hydration-method include-personal-collection-ids
+  :personal_collection_id
+  "Efficiently hydrate the `:personal_collection_id` property of a sequence of Users. (This is, predictably, the ID of
+  their Personal Collection.)"
+  [users]
+  (when (seq users)
+    ;; efficiently create a map of user ID -> personal collection ID
+    (let [user-id->collection-id (t2/select-fn->pk :personal_owner_id Collection
+                                   :personal_owner_id [:in (set (map u/the-id users))])]
+      (assert (map? user-id->collection-id))
+      ;; now for each User, try to find the corresponding ID out of that map. If it's not present (the personal
+      ;; Collection hasn't been created yet), then instead call `user->personal-collection-id`, which will create it
+      ;; as a side-effect. This will ensure this property never comes back as `nil`
+      (for [user users]
+        (assoc user :personal_collection_id (or (user-id->collection-id (u/the-id user))
+                                                (user->personal-collection-id (u/the-id user))))))))
+
+(mi/define-batched-hydration-method collection-is-personal
+  :is_personal
+  "Efficiently hydrate the `:is_personal` property of a sequence of Collections.
+  `true` means the collection is or nested in a personal collection."
+  [collections]
+  (if (= 1 (count collections))
+    (let [collection (first collections)]
+      (if (some? collection)
+        [(assoc collection :is_personal (is-personal-collection-or-descendant-of-one? collection))]
+        ;; root collection is nil
+        [collection]))
+    (let [personal-collection-ids (t2/select-pks-set :model/Collection :personal_owner_id [:not= nil])
+          location-is-personal    (fn [location]
+                                    (boolean
+                                     (and (string? location)
+                                          (some #(str/starts-with? location (format "/%d/" %)) personal-collection-ids))))]
+      (map (fn [{:keys [location personal_owner_id] :as coll}]
+             (if (some? coll)
+               (assoc coll :is_personal (or (some? personal_owner_id)
+                                            (location-is-personal location)))
+               nil))
+           collections))))
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                 Nested Collections: "Effective" Location Paths                                 |
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -311,56 +482,6 @@
   [:set
    [:or [:= "root"] ms/PositiveInt]])
 
-(def ^:private ^{:arglists '([])} collection-id->collection
-  "Cached function to fetch *all* collections, as a map of, well, `collection-id->collection`."
-  (memoize/ttl
-   ^{::memoize/args-fn (fn [& _]
-                         ;; If this is running in the context of a request, cache it for the duration of that request.
-                         ;; Otherwise, don't cache the results at all.)
-                         (if-let [req-id *request-id*]
-                           [req-id]
-                           [(random-uuid)]))}
-   (fn collection-id->collection*
-     []
-     (t2/select-pk->fn identity :model/Collection))
-   ;; cache the results for 10 seconds. This is a bit arbitrary but should be long enough to cover ~all requests.
-   :ttl/threshold (* 10 1000)))
-
-(defn- permissions-set->collection-id->collection
-  [permissions-set {:keys [permission-level effective-child-of]}]
-  (let [collection-id->collection (if-let [parent effective-child-of]
-                                    (t2/select-pk->fn identity :model/Collection {:where [:like :location (str (or (:location parent) "/")
-                                                                                                               "%")]})
-                                    (collection-id->collection))
-        ids-with-perm (set
-                       (for [path  permissions-set
-                             :let  [[_ id-str] (case permission-level
-                                                 :read
-                                                 (re-matches #"/collection/((?:\d+)|root)/(read/)?" path)
-
-                                                 :write
-                                                 (re-matches #"/collection/((?:\d+)|root)/" path))]
-                             :when id-str]
-                         (cond-> id-str
-                           (not= id-str "root") Integer/parseInt)))
-        has-root-permission? (or (contains? permissions-set "/") (contains? ids-with-perm "root"))
-        root-map (when has-root-permission?
-                   {"root" collection.root/root-collection})
-        ;; block an audit collection IF:
-        ;; - audit isn't enabled, OR
-        ;; - we're looking for writable collections
-        ;; Otherwise, normal read/write permissions apply
-        block-for-audit? #(and (audit/is-collection-id-audit? %)
-                               (or (not (premium-features/enable-audit-app?))
-                                   (= permission-level :write)))
-        has-permission? (fn [[id _]]
-                          (and
-                           (not (block-for-audit? id))
-                           (or (contains? permissions-set "/")
-                               (contains? ids-with-perm id))))]
-    (->> collection-id->collection
-         (filter has-permission?)
-         (merge root-map))))
 
 (def ^:private CollectionVisibilityConfig
   [:map
@@ -370,41 +491,6 @@
    [:permission-level {:optional true} [:enum :read :write]]
    [:effective-child-of {:optional true} [:maybe CollectionWithLocationAndIDOrRoot]]])
 
-(defn- should-remove-for-archived? [include-archived-items collection]
-  (case include-archived-items
-    :all false
-    :exclude (:archived collection)
-    :only (not (or (:archived collection)
-                   (is-trash? collection)))))
-
-(defn- should-remove-for-trash? [include-trash-collection? collection]
-  (if include-trash-collection?
-    false
-    (is-trash? collection)))
-
-(defn- should-remove-for-archive-operation-id [archive-operation-id collection]
-  (and (some? archive-operation-id)
-       (not= archive-operation-id (:archive_operation_id collection))))
-
-(defn- remove-non-effective-children [coll-or-root collection-id->collection]
-  (cond
-    (not coll-or-root)
-    collection-id->collection
-
-    (is-trash? coll-or-root)
-    (into {} (for [[collection-id collection] collection-id->collection
-                   :when (:archived_directly collection)]
-               [collection-id collection]))
-
-    :else (let [visible-id? (set (keys collection-id->collection))]
-            (into {} (for [[collection-id collection] collection-id->collection
-                           :when (not (collection.root/is-root-collection? collection))
-                           :let [location (:location collection)
-                                 ids (location-path->ids location)
-                                 effective-ids (filter visible-id? ids)]
-                           :when (= (last effective-ids) (:id coll-or-root))]
-                       [collection-id collection])))))
-
 (def ^:private default-visibility-config
   {:include-archived-items :exclude
    :include-trash-collection? false
@@ -412,89 +498,118 @@
    :archive-operation-id nil
    :permission-level :read})
 
-(mu/defn permissions-set->visible-collection-ids :- VisibleCollections
-  "There are four knobs we need to take into account when turning the permissions set into visible collection IDs.
-  - permission-level: generally collections with `read` permission are visible. Sometimes we want to change this and only
-    view collections with `write` permissions.
-  - include-archived-items: are archived collections currently visible, or not?
-  - archive-operation-id: when looking at a archived collection, we want to restrict visible collections to those that share
-  that operation ID.
-  - include-trash-collection?: is the Trash Collection itself visible, or not? Sometimes we want to show the Trash but
-    not the archived items inside it."
-  ([permissions-set :- [:set :string]]
-   (permissions-set->visible-collection-ids permissions-set {}))
-  ([permissions-set :- [:set :string]
+(def ^:private ^{:arglists '([read-or-write])} can-access-root-collection?
+  "Cached function to determine whether the current user can access the root collection"
+  (memoize/ttl
+   ^{::memoize/args-fn (fn [[read-or-write]]
+                         ;; If this is running in the context of a request, cache it for the duration of that request.
+                         ;; Otherwise, don't cache the results at all.)
+                         (if-let [req-id *request-id*]
+                           [req-id api/*current-user-id* read-or-write]
+                           [(random-uuid) api/*current-user-id* read-or-write]))}
+   (fn can-access-root-collection?*
+     [read-or-write]
+     (or api/*is-superuser?*
+         (t2/exists? :model/Permissions {:select [:p.*]
+                                         :from [[:permissions :p]]
+                                         :join [[:permissions_group :pg] [:= :pg.id :p.group_id]
+                                                [:permissions_group_membership :pgm] [:= :pgm.group_id :pg.id]]
+                                         :where [:and
+                                                 [:= :pgm.user_id api/*current-user-id*]
+                                                 [:or
+                                                  [:= :p.object "/collection/root/"]
+                                                  (when (= :read read-or-write)
+                                                    [:= :p.object "/collection/root/read/"])]]})))
+   ;; cache the results for 10 seconds. This is a bit arbitrary but should be long enough to cover ~all requests.
+   :ttl/threshold (* 10 1000)))
+
+(mu/defn honeysql-filter-clause
+  "Given a permissions-set and a `CollectionVisibilityConfig`, return a honeysql filter clause ready for use in queries."
+  ([]
+   (honeysql-filter-clause :collection_id))
+  ([collection-id-field :- [:or [:tuple [:= :coalesce] :keyword :keyword] :keyword]]
+   (honeysql-filter-clause collection-id-field {}))
+  ([collection-id-field :- [:or [:tuple [:= :coalesce] :keyword :keyword] :keyword]
     visibility-config :- CollectionVisibilityConfig]
    (let [visibility-config (merge default-visibility-config visibility-config)]
-     (->> (permissions-set->collection-id->collection permissions-set visibility-config)
-          (remove-non-effective-children (:effective-child-of visibility-config))
-          (remove #(should-remove-for-archived? (:include-archived-items visibility-config) (val %)))
-          (remove #(should-remove-for-archive-operation-id (:archive-operation-id visibility-config) (val %)))
-          (remove #(should-remove-for-trash? (:include-trash-collection? visibility-config) (val %)))
-          (map key)
-          (into #{})))))
+     [:or
+      ;; the root collection is included when:
+      (when (and
+             ;; we have permission for it.
+             (can-access-root-collection? (:permission-level visibility-config))
 
-(mu/defn ^:private visible-collection-ids->honeysql-filter-clause
-  "Generate an appropriate HoneySQL `:where` clause to filter something by visible Collection IDs, such as the ones
-  returned by `permissions-set->visible-collection-ids`. Correctly handles all possible values returned by that
-  function, including `root` Collection IDs (for the Root Collection).
+             ;; we're not *only* looking for archived items
+             (not= :only (:include-archived-items visibility-config))
 
-  Guaranteed to always generate a valid HoneySQL form, so this can be used directly in a query without further checks.
+             ;; we're not looking for a particular `archive_operation_id`
+             (not (:archive-operation-id visibility-config))
 
-    (t2/select Card
-      {:where (collection/visible-collection-ids->honeysql-filter-clause
-               (collection/permissions-set->visible-collection-ids
-                @*current-user-permissions-set*))})"
-  ([collection-ids :- VisibleCollections]
-   (visible-collection-ids->honeysql-filter-clause :collection_id collection-ids))
+             ;; we're not looking for the children of a collection (root definitely isn't a child!)
+             (not (:effective-child-of visibility-config)))
+        (when-not (= :only (:include-archived-items visibility-config))
+          [:= collection-id-field nil]))
+      ;; the non-root collections
+      [:in collection-id-field
+       {:select :id
+        :from [[{:union-all (if api/*is-superuser?*
+                              [{:select [:c.*]
+                                :from [[:collection :c]]}]
+                              ;; for non-admins, we can access two groups of collections:
+                              ;; first, the collections the user has explicit permissions on
+                              [{:select [:c.*]
+                                :from [[:collection :c]]
+                                :join [[:permissions :p]
+                                       [:= :c.id :p.collection_id]
+                                       [:permissions_group :pg] [:= :pg.id :p.group_id]
+                                       [:permissions_group_membership :pgm] [:= :pgm.group_id :pg.id]]
+                                :where [:and
+                                        [:= :pgm.user_id api/*current-user-id*]
+                                        [:= :p.perm_type "perms/collection-access"]
+                                        [:or
+                                         [:= :p.perm_value "read-and-write"]
+                                         (when (= :read (:permission-level visibility-config))
+                                           [:= :p.perm_value "read"])]]}
+                               ;; second, the user's personal collection and all its descendants
+                               (when-let [personal-collection-and-descendant-ids (user->personal-collection-and-descendant-ids api/*current-user-id*)]
+                                 {:select [:c.*]
+                                  :from [[:collection :c]]
+                                  :where [:in :id personal-collection-and-descendant-ids]})])}
+                :c]]
+        :where [:and
+                (when-not (:include-trash-collection? visibility-config)
+                  [:not= (trash-collection-id) :id])
 
-  ([collection-id-field    :- [:or [:tuple [:= :coalesce] :keyword :keyword] :keyword] ;; `[:vector :keyword]` allows `[:coalesce :option-1 :option-2]`
-    visible-collection-ids :- VisibleCollections]
-   (let [invisible-ids (set/difference (set (keys (collection-id->collection)))
-                                       visible-collection-ids)
+                (when (= :exclude (:include-archived-items visibility-config))
+                  [:= :archived false])
 
-         root-visible? (contains? visible-collection-ids "root")
-         non-root-visible? (seq (disj visible-collection-ids "root"))
+                (when (= :only (:include-archived-items visibility-config))
+                  [:= :archived true])
 
-         visible-ids (disj visible-collection-ids "root")
-         invisible-ids (disj invisible-ids "root")
-         non-root-clause [:and
-                          [:not= collection-id-field nil]
-                          (if (< (count invisible-ids) (count visible-ids))
-                            (when (seq invisible-ids)
-                              [:not [:in collection-id-field invisible-ids]])
-                            (when (seq visible-ids)
-                              [:in collection-id-field visible-ids]))]
-         root-clause (when root-visible?
-                       [:= collection-id-field nil])]
-     (cond
-       (and root-visible? non-root-visible?)
-       [:or root-clause non-root-clause]
+                (when-let [op-id (:archive-operation-id visibility-config)]
+                  [:= :archive_operation_id op-id])
 
-       (or root-visible? non-root-visible?)
-       (or (when root-visible? root-clause) (when non-root-visible? non-root-clause))
+                (when-let [parent-coll (:effective-child-of visibility-config)]
+                  (if (is-trash? parent-coll)
+                    [:= :archived_directly true]
+                    [:and
+                     ;; an effective child is a descendant of the parent collection
+                     [:like :location (str (children-location parent-coll) "%")]
+                     ;; but NOT a child of any OTHER visible collection
+                     [:not [:exists {:select 1
+                                     :from [[:collection :c2]]
+                                     :where [:and
+                                             (honeysql-filter-clause :c2.id (dissoc visibility-config :effective-child-of))
+                                             [:= :c.location [:concat :c2.location :c2.id (h2x/literal "/")]]
+                                             (when-not (collection.root/is-root-collection? parent-coll)
+                                               [:not= :c2.id (u/the-id parent-coll)])]}]]]))]}]])))
 
-       :else false))))
-
-(mu/defn visible-collection-ids->direct-visible-descendant-clause
-  "Generates an appropriate HoneySQL `:where` clause to filter out descendants of a collection A with a specific property.
-  This property is being a descendant of a visible collection other than A. Used for effective children calculations"
-  [parent-collection :- CollectionWithLocationAndIDOrRoot, collection-ids :- VisibleCollections]
-  (if (is-trash? parent-collection)
-    ;; the only direct descendants of the Trash are those that were trashed directly. TODO: theoretically if someone
-    ;; Trashes collection A, which I don't have permissions on, and then trashes collection B, which I do - I should
-    ;; see collection B in the Trash. But this is not something we can figure out here, because we need to look at
-    ;; whether a visible ancestor was `archived_directly`.
-    [:= :archived_directly true]
-    (let [parent-id (or (:id parent-collection) "")]
-      (into
-       ;; if the collection-ids are empty, the whole into turns into nil and we have a dangling [:and] clause in query.
-       ;; the (1 = 1) is to prevent this
-       [:and [:= [:inline 1] [:inline 1]]]
-       (let [to-disj-ids         (location-path->ids (or (:effective_location parent-collection) "/"))
-             disj-collection-ids (apply disj collection-ids (conj to-disj-ids parent-id))]
-         (for [visible-collection-id disj-collection-ids]
-           [:not-like :location (h2x/literal (format "%%/%s/%%" (str visible-collection-id)))]))))))
+(mu/defn visible-collection-ids :- VisibleCollections
+  "Returns all collection IDs that are visible given the `visibility-config` passed in. (Config provides knobs for
+  toggling permission level, trash/archive visibility, etc.)"
+  [visibility-config]
+  (cond-> (t2/select-pks-set :model/Collection {:where (honeysql-filter-clause :id visibility-config)})
+    (can-access-root-collection? (:permission-level visibility-config))
+    (conj "root")))
 
 (mu/defn- effective-location-path* :- [:maybe LocationPath]
   ([collection :- CollectionWithLocationOrRoot]
@@ -502,8 +617,7 @@
      (effective-location-path* (if (:archived_directly collection)
                                  (trash-path)
                                  (:location collection))
-                               (permissions-set->visible-collection-ids
-                                @*current-user-permissions-set*
+                               (visible-collection-ids
                                 {:include-archived-items    (if (:archived collection)
                                                               :only
                                                               :exclude)
@@ -519,7 +633,7 @@
 (mi/define-simple-hydration-method effective-location-path
   :effective_location
   "Given a `location-path` and a set of Collection IDs one is allowed to view (obtained from
-  `permissions-set->visible-collection-ids` above), calculate the 'effective' location path (excluding IDs of
+  `visible-collection-ids` above), calculate the 'effective' location path (excluding IDs of
   Collections for which we do not have read perms) we should show to the User.
 
   When called with a single argument, `collection`, this is used as a hydration function to hydrate
@@ -583,13 +697,14 @@
   Note that the map `(collection-id->collection)` is cached for the lifetime
   of the request, so this will make at most one DB query per request regardless
   of how many times it is called."
-  [collection :- [:maybe CollectionWithLocationOrRoot]]
+  [collection :- [:maybe CollectionWithLocationOrRoot]
+   collection-id->collection :- :map]
   (if (or (nil? collection)
           (collection.root/is-root-collection? collection))
     []
     (some->> (effective-location-path collection)
              location-path->ids
-             (map (collection-id->collection))
+             (map collection-id->collection)
              (map #(select-keys % [:name :id :personal_owner_id :type]))
              (map #(t2/instance :model/Collection %))
              (cons (root-collection-with-ui-details (:namespace collection)))
@@ -614,11 +729,15 @@
   Thus the existence of C will be kept hidden from the current User, and for all intents and purposes the current User
   can effectively treat A as the parent of C."
   [collections]
-  (map (fn [collection]
-         (assoc collection
-                :effective_ancestors
-                (effective-ancestors* collection)))
-       collections))
+  (let [all-ids (mapcat #(some-> % effective-location-path location-path->ids) collections)
+        collection-id->collection (if (seq all-ids)
+                                    (t2/select-pk->fn identity :model/Collection :id [:in all-ids])
+                                    {})]
+    (map (fn [collection]
+           (assoc collection
+                  :effective_ancestors
+                  (effective-ancestors* collection collection-id->collection)))
+         collections)))
 
 (mu/defn- parent-id* :- [:maybe ms/PositiveInt]
   [{:keys [location]} :- CollectionWithLocationOrRoot]
@@ -628,19 +747,6 @@
   "Get the immediate parent `collection` id, if set."
   [_model k collection]
   (assoc collection k (parent-id* collection)))
-
-(mu/defn children-location :- LocationPath
-  "Given a `collection` return a location path that should match the `:location` value of all the children of the
-  Collection.
-
-     (children-location collection) ; -> \"/10/20/30/\";
-
-     ;; To get children of this collection:
-     (t2/select Collection :location \"/10/20/30/\")"
-  [{:keys [location], :as collection} :- CollectionWithLocationAndIDOrRoot]
-  (if (collection.root/is-root-collection? collection)
-    "/"
-    (str location (u/the-id collection) "/")))
 
 (def ^:private Children
   [:schema
@@ -698,43 +804,36 @@
         ;; key
         :children)))
 
-(mu/defn descendant-ids :- [:maybe [:set ms/PositiveInt]]
-  "Return a set of IDs of all descendant Collections of a `collection`."
-  [collection :- CollectionWithLocationAndIDOrRoot]
-  (t2/select-pks-set Collection :location [:like (str (children-location collection) \%)]))
-
 (mu/defn- effective-children-where-clause
   [collection & additional-honeysql-where-clauses]
-  (let [visible-collection-ids (permissions-set->visible-collection-ids
-                                @*current-user-permissions-set*
-                                {:include-archived-items    (if (or (:archived collection)
-                                                                    (is-trash? collection))
-                                                              :only
-                                                              :exclude)
-                                 :include-trash-collection? true
-                                 :effective-child-of        collection
-                                 :archive-operation-id      (:archive_operation_id collection)
-                                 :permission-level          (if (or (:archived collection)
-                                                                    (is-trash? collection))
-                                                              :write
-                                                              :read)})]
-    ;; Collection B is an effective child of Collection A if...
-    (into
-     [:and
-       ;; it is a descendant of Collection A. For the Trash, this just means the collection is archived. Otherwise
-       ;; we check that Collection B's location contains A's location as a prefix
-      (if (is-trash? collection)
-        [:= :archived true]
-        [:like :location (h2x/literal (str (children-location collection) "%"))])
-       ;; when we're looking at a particular archived collection, we only see the subtree that was archived together.
-      (when (:archive_operation_id collection)
-        [:= :archive_operation_id (:archive_operation_id collection)])
-       ;; it is visible.
-      (visible-collection-ids->honeysql-filter-clause :id visible-collection-ids)
-       ;; don't want personal collections in collection items. Only on the sidebar
-      [:= :personal_owner_id nil]]
-      ;; (any additional conditions)
-     additional-honeysql-where-clauses)))
+  ;; Collection B is an effective child of Collection A if...
+  (into
+   [:and
+    ;; it is a descendant of Collection A. For the Trash, this just means the collection is archived. Otherwise
+    ;; we check that Collection B's location contains A's location as a prefix
+    (if (is-trash? collection)
+      [:= :archived true]
+      [:like :location (h2x/literal (str (children-location collection) "%"))])
+    ;; when we're looking at a particular archived collection, we only see the subtree that was archived together.
+    (when (:archive_operation_id collection)
+      [:= :archive_operation_id (:archive_operation_id collection)])
+    ;; it is visible.
+    (honeysql-filter-clause :id
+                            {:include-archived-items    (if (or (:archived collection)
+                                                                (is-trash? collection))
+                                                          :only
+                                                          :exclude)
+                             :include-trash-collection? true
+                             :effective-child-of        collection
+                             :archive-operation-id      (:archive_operation_id collection)
+                             :permission-level          (if (or (:archived collection)
+                                                                (is-trash? collection))
+                                                          :write
+                                                          :read)})
+    ;; don't want personal collections in collection items. Only on the sidebar
+    [:= :personal_owner_id nil]]
+   ;; (any additional conditions)
+   additional-honeysql-where-clauses))
 
 (mu/defn effective-children-query :- [:map
                                       [:select :any]
@@ -975,28 +1074,6 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                       Toucan IModel & Perms Method Impls                                       |
 ;;; +----------------------------------------------------------------------------------------------------------------+
-
-(def ^:private CollectionWithLocationAndPersonalOwnerID
-  "Schema for a Collection instance that has a valid `:location`, and a `:personal_owner_id` key *present* (but not
-  neccesarily non-nil)."
-  [:map
-   [:location          LocationPath]
-   [:personal_owner_id [:maybe ms/PositiveInt]]])
-
-(mu/defn is-personal-collection-or-descendant-of-one? :- :boolean
-  "Is `collection` a Personal Collection, or a descendant of one?"
-  [collection :- CollectionWithLocationAndPersonalOwnerID]
-  (boolean
-   (or
-    ;; If collection has an owner ID we're already done here, we know it's a Personal Collection
-    (:personal_owner_id collection)
-
-    ;; Try to get the ID of its highest-level ancestor, e.g. if `location` is `/1/2/3/` we would get `1`. Then see if
-    ;; the root-level ancestor is a Personal Collection (Personal Collections can only exist in the Root Collection.)
-    (t2/exists? Collection
-                :id                (first (location-path->ids
-                                           (:location collection)))
-                :personal_owner_id [:not= nil]))))
 
 ;;; ----------------------------------------------------- INSERT -----------------------------------------------------
 
@@ -1381,227 +1458,6 @@
     ;; check that the new location is not archived. the root can't be archived.
     (when-let [collection-id (:collection_id object-updates)]
       (api/check-400 (t2/exists? :model/Collection :id collection-id :archived false)))))
-
-;;; +----------------------------------------------------------------------------------------------------------------+
-;;; |                                              Personal Collections                                              |
-;;; +----------------------------------------------------------------------------------------------------------------+
-
-(mu/defn format-personal-collection-name :- ms/NonBlankString
-  "Constructs the personal collection name from user name.
-  When displaying to users we'll tranlsate it to user's locale,
-  but to keeps things consistent in the database, we'll store the name in site's locale.
-
-  Practically, use `user-or-site` = `:site` when insert or update the name in database,
-  and `:user` when we need the name for displaying purposes"
-  [first-name last-name email user-or-site]
-  {:pre [(#{:user :site} user-or-site)]}
-  (if (= :user user-or-site)
-    (cond
-      (and first-name last-name) (tru "{0} {1}''s Personal Collection" first-name last-name)
-      :else                      (tru "{0}''s Personal Collection" (or first-name last-name email)))
-    (cond
-      (and first-name last-name) (trs "{0} {1}''s Personal Collection" first-name last-name)
-      :else                      (trs "{0}''s Personal Collection" (or first-name last-name email)))))
-
-(mu/defn user->personal-collection-name :- ms/NonBlankString
-  "Come up with a nice name for the Personal Collection for `user-or-id`."
-  [user-or-id user-or-site]
-  (let [{first-name :first_name
-         last-name  :last_name
-         email      :email} (t2/select-one ['User :first_name :last_name :email]
-                                           :id (u/the-id user-or-id))]
-    (format-personal-collection-name first-name last-name email user-or-site)))
-
-(defn personal-collection-with-ui-details
-  "For Personal collection, we make sure the collection's name and slug is translated to user's locale
-  This is only used for displaying purposes, For insertion or updating  the name, use site's locale instead"
-  [{:keys [personal_owner_id] :as collection}]
-  (if-not personal_owner_id
-    collection
-    (let [collection-name (user->personal-collection-name personal_owner_id :user)]
-      (assoc collection
-             :name collection-name
-             :slug (u/slugify collection-name)))))
-
-(mu/defn user->existing-personal-collection :- [:maybe (ms/InstanceOf Collection)]
-  "For a `user-or-id`, return their personal Collection, if it already exists.
-  Use [[metabase.models.collection/user->personal-collection]] to fetch their personal Collection *and* create it if
-  needed."
-  [user-or-id]
-  (t2/select-one Collection :personal_owner_id (u/the-id user-or-id)))
-
-(mu/defn user->personal-collection :- (ms/InstanceOf Collection)
-  "Return the Personal Collection for `user-or-id`, if it already exists; if not, create it and return it."
-  [user-or-id]
-  (or (user->existing-personal-collection user-or-id)
-      (try
-        (first (t2/insert-returning-instances! Collection
-                                               {:name              (user->personal-collection-name user-or-id :site)
-                                                :personal_owner_id (u/the-id user-or-id)}))
-        ;; if an Exception was thrown why trying to create the Personal Collection, we can assume it was a race
-        ;; condition where some other thread created it in the meantime; try one last time to fetch it
-        (catch Throwable e
-          (or (user->existing-personal-collection user-or-id)
-              (throw e))))))
-
-(def ^:private ^{:arglists '([user-id])} user->personal-collection-id
-  "Cached function to fetch the ID of the Personal Collection belonging to User with `user-id`. Since a Personal
-  Collection cannot be deleted, the ID will not change; thus it is safe to cache, saving a DB call. It is also
-  required to caclulate the Current User's permissions set, which is done for every API call; thus it is cached to
-  save a DB call for *every* API call."
-  (memoize/ttl
-   ^{::memoize/args-fn (fn [[user-id]]
-                         [(mdb/unique-identifier) user-id])}
-   (fn user->personal-collection-id*
-     [user-id]
-     (u/the-id (user->personal-collection user-id)))
-   ;; cache the results for 60 minutes; TTL is here only to eventually clear out old entries/keep it from growing too
-   ;; large
-   :ttl/threshold (* 60 60 1000)))
-
-(mu/defn user->personal-collection-and-descendant-ids :- [:sequential {:min 1} ms/PositiveInt]
-  "Somewhat-optimized function that fetches the ID of a User's Personal Collection as well as the IDs of all descendants
-  of that Collection. Exists because this needs to be known to calculate the Current User's permissions set, which is
-  done for every API call; this function is an attempt to make fetching this information as efficient as reasonably
-  possible."
-  [user-or-id]
-  (let [personal-collection-id (user->personal-collection-id (u/the-id user-or-id))]
-    (cons personal-collection-id
-          ;; `descendant-ids` wants a CollectionWithLocationAndID, and luckily we know Personal Collections always go
-          ;; in Root, so we can pass it what it needs without actually having to fetch an entire CollectionInstance
-          (descendant-ids {:location "/", :id personal-collection-id}))))
-
-(def ^:private ^{:arglists '([read-or-write])} can-access-root-collection?
-  "Cached function to determine whether the current user can access the root collection"
-  (memoize/ttl
-   ^{::memoize/args-fn (fn [[read-or-write]]
-                         ;; If this is running in the context of a request, cache it for the duration of that request.
-                         ;; Otherwise, don't cache the results at all.)
-                         (if-let [req-id *request-id*]
-                           [req-id api/*current-user-id* read-or-write]
-                           [(random-uuid) api/*current-user-id* read-or-write]))}
-   (fn can-access-root-collection?*
-     [read-or-write]
-     (or api/*is-superuser?*
-         (t2/exists? :model/Permissions {:select [:p.*]
-                                         :from [[:permissions :p]]
-                                         :join [[:permissions_group :pg] [:= :pg.id :p.group_id]
-                                                [:permissions_group_membership :pgm] [:= :pgm.group_id :pg.id]]
-                                         :where [:and
-                                                 [:= :pgm.user_id api/*current-user-id*]
-                                                 [:or
-                                                  [:= :p.object "/collection/root/"]
-                                                  (when (= :read read-or-write)
-                                                    [:= :p.object "/collection/root/read/"])]]})))
-   ;; cache the results for 10 seconds. This is a bit arbitrary but should be long enough to cover ~all requests.
-   :ttl/threshold (* 10 1000)))
-
-(mu/defn honeysql-filter-clause
-  "Given a permissions-set and a `CollectionVisibilityConfig`, return a honeysql filter clause ready for use in queries."
-  ([]
-   (honeysql-filter-clause :collection_id))
-  ([collection-id-field :- [:or [:tuple [:= :coalesce] :keyword :keyword] :keyword]]
-   (honeysql-filter-clause collection-id-field {}))
-  ([collection-id-field :- [:or [:tuple [:= :coalesce] :keyword :keyword] :keyword]
-    visibility-config :- CollectionVisibilityConfig]
-   (let [visibility-config (merge default-visibility-config visibility-config)]
-     [:or
-      ;; the root collection is included when:
-      (when (and
-             ;; we have permission for it.
-             (can-access-root-collection? (:permission-level visibility-config))
-
-             ;; we're not *only* looking for archived items
-             (not= :only (:include-archived-items visibility-config))
-
-             ;; we're not looking for a particular `archive_operation_id`
-             (not (:archive-operation-id visibility-config))
-
-             ;; we're not looking for the children of a collection (root definitely isn't a child!)
-             (not (:effective-child-of visibility-config)))
-        (when-not (= :only (:include-archived-items visibility-config))
-          [:= collection-id-field nil]))
-      ;; the non-root collections
-      [:in collection-id-field
-       {:select :id
-        :from [[{:union-all (if api/*is-superuser?*
-                              [{:select [:c.*]
-                                :from [[:collection :c]]}]
-                              [{:select [:c.*]
-                                :from [[:collection :c]]
-                                :join [[:permissions :p]
-                                       [:= :c.id :p.collection_id]
-                                       [:permissions_group :pg] [:= :pg.id :p.group_id]
-                                       [:permissions_group_membership :pgm] [:= :pgm.group_id :pg.id]]
-                                :where [:and
-                                        [:= :pgm.user_id api/*current-user-id*]
-                                        [:= :p.perm_type "perms/collection-access"]
-                                        [:or
-                                         [:= :p.perm_value "read-and-write"]
-                                         (when (= :read (:permission-level visibility-config))
-                                           [:= :p.perm_value "read"])]]}
-                               {:select [:c.*]
-                                :from [[:collection :c]]
-                                :where [:in :id (user->personal-collection-and-descendant-ids api/*current-user-id*)]}])}
-                :dummy_alias]]
-        :where [:and
-                (when-not (:include-trash-collection? visibility-config)
-                  [:not= (trash-collection-id) :id])
-
-                (when (= :exclude (:include-archived-items visibility-config))
-                  [:= :archived false])
-
-                (when (= :only (:include-archived-items visibility-config))
-                  [:= :archived true])
-
-                (when-let [op-id (:archive-operation-id visibility-config)]
-                  [:= :archive_operation_id op-id])
-
-                (when-let [parent-coll (:effective-child-of visibility-config)]
-                  (if (is-trash? parent-coll)
-                    [:= :archived_directly true]
-                    [:like :location (str (children-location parent-coll) "%")]))]}]])))
-
-
-(mi/define-batched-hydration-method include-personal-collection-ids
-  :personal_collection_id
-  "Efficiently hydrate the `:personal_collection_id` property of a sequence of Users. (This is, predictably, the ID of
-  their Personal Collection.)"
-  [users]
-  (when (seq users)
-    ;; efficiently create a map of user ID -> personal collection ID
-    (let [user-id->collection-id (t2/select-fn->pk :personal_owner_id Collection
-                                                   :personal_owner_id [:in (set (map u/the-id users))])]
-      (assert (map? user-id->collection-id))
-      ;; now for each User, try to find the corresponding ID out of that map. If it's not present (the personal
-      ;; Collection hasn't been created yet), then instead call `user->personal-collection-id`, which will create it
-      ;; as a side-effect. This will ensure this property never comes back as `nil`
-      (for [user users]
-        (assoc user :personal_collection_id (or (user-id->collection-id (u/the-id user))
-                                                (user->personal-collection-id (u/the-id user))))))))
-
-(mi/define-batched-hydration-method collection-is-personal
-  :is_personal
-  "Efficiently hydrate the `:is_personal` property of a sequence of Collections.
-  `true` means the collection is or nested in a personal collection."
-  [collections]
-  (if (= 1 (count collections))
-    (let [collection (first collections)]
-      (if (some? collection)
-        [(assoc collection :is_personal (is-personal-collection-or-descendant-of-one? collection))]
-        ;; root collection is nil
-        [collection]))
-    (let [personal-collection-ids (t2/select-pks-set :model/Collection :personal_owner_id [:not= nil])
-          location-is-personal    (fn [location]
-                                    (boolean
-                                     (and (string? location)
-                                          (some #(str/starts-with? location (format "/%d/" %)) personal-collection-ids))))]
-      (map (fn [{:keys [location personal_owner_id] :as coll}]
-             (if (some? coll)
-               (assoc coll :is_personal (or (some? personal_owner_id)
-                                            (location-is-personal location)))
-               nil))
-           collections))))
 
 (defmulti allowed-namespaces
   "Set of Collection namespaces (as keywords) that instances of this model are allowed to go in. By default, only the

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -345,7 +345,9 @@
 
 (derive :model/Permissions :metabase/model)
 
-(defn- maybe-add-collection-id [permissions]
+(defn- maybe-break-out-permission-data
+  "Given a `Permissions` model, add `:collection_id`, `:perm_type`, and `:perm_value` iff we know how to break that out."
+  [permissions]
   (let [[match? coll-id-str read?] (re-matches #"^/collection/(\d+)/(read/)?" (:object permissions))]
     (cond-> permissions
       match? (assoc :collection_id (parse-long coll-id-str)
@@ -356,7 +358,7 @@
 
 (t2/define-before-insert :model/Permissions
   [permissions]
-  (u/prog1 (maybe-add-collection-id permissions)
+  (u/prog1 (maybe-break-out-permission-data permissions)
     (assert-valid permissions)
     (log/debug (u/format-color :green "Granting permissions for group %s: %s" (:group_id permissions) (:object permissions)))))
 

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -351,16 +351,20 @@
   (let [[match? coll-id-str read?] (re-matches #"^/collection/(\d+)/(read/)?" (:object permissions))]
     (cond-> permissions
       match? (assoc :collection_id (parse-long coll-id-str)
-                    :perm_type "perms/collection-access"
+                    :perm_type :perms/collection-access
                     :perm_value (if read?
-                                  "read"
-                                  "read-and-write")))))
+                                  :read
+                                  :read-and-write)))))
 
 (t2/define-before-insert :model/Permissions
   [permissions]
   (u/prog1 (maybe-break-out-permission-data permissions)
     (assert-valid permissions)
     (log/debug (u/format-color :green "Granting permissions for group %s: %s" (:group_id permissions) (:object permissions)))))
+
+(t2/deftransforms :model/Permissions
+  {:perm_type mi/transform-keyword
+   :perm_value mi/transform-keyword})
 
 (t2/define-before-update :model/Permissions
   [_]

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -110,14 +110,12 @@
   so we can return its `:name`."
   [honeysql-query                                :- ms/Map
    model                                         :- :string
-   {:keys [current-user-perms
-           filter-items-in-personal-collection
+   {:keys [filter-items-in-personal-collection
            archived]} :- SearchContext]
   (let [collection-id-col        (if (= model "collection")
                                    :collection.id
                                    :collection_id)
         collection-filter-clause (collection/honeysql-filter-clause
-                                  current-user-perms
                                   collection-id-col
                                   {:include-archived-items :all
                                    :include-trash-collection? true

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -113,19 +113,17 @@
    {:keys [current-user-perms
            filter-items-in-personal-collection
            archived]} :- SearchContext]
-  (let [visible-collections      (collection/permissions-set->visible-collection-ids
+  (let [collection-id-col        (if (= model "collection")
+                                   :collection.id
+                                   :collection_id)
+        collection-filter-clause (collection/honeysql-filter-clause
                                   current-user-perms
+                                  collection-id-col
                                   {:include-archived-items :all
                                    :include-trash-collection? true
                                    :permission-level (if archived
                                                        :write
-                                                       :read)})
-        collection-id-col        (if (= model "collection")
-                                   :collection.id
-                                   :collection_id)
-        collection-filter-clause (collection/visible-collection-ids->honeysql-filter-clause
-                                  collection-id-col
-                                  visible-collections)]
+                                                       :read)})]
     (cond-> honeysql-query
       true
       (sql.helpers/where collection-filter-clause (perms/audit-namespace-clause :collection.namespace nil))

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -115,7 +115,7 @@
   (let [collection-id-col        (if (= model "collection")
                                    :collection.id
                                    :collection_id)
-        collection-filter-clause (collection/honeysql-filter-clause
+        collection-filter-clause (collection/visible-collection-filter-clause
                                   collection-id-col
                                   {:include-archived-items :all
                                    :include-trash-collection? true
@@ -284,7 +284,7 @@
   [query _current-user-perms]
   (sql.helpers/where
    query
-   (collection/honeysql-filter-clause)))
+   (collection/visible-collection-filter-clause)))
 
 (defmethod search-query-for-model "indexed-entity"
   [model {:keys [current-user-perms] :as search-ctx}]

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -419,10 +419,11 @@
                    (dissoc :is_qbnewb :last_login))
                (-> (mt/user-http-request :rasta :get 200 "user/current")
                    mt/boolean-ids-and-timestamps
-                   (dissoc :is_qbnewb :has_question_and_dashboard :last_login))))))
+                   (dissoc :is_qbnewb :has_question_and_dashboard :last_login :has_model))))))
     (testing "check that `has_question_and_dashboard` is `true`."
       (mt/with-temp [Dashboard _ {:name "dash1" :creator_id (mt/user->id :rasta)}
-                     Card      _ {:name "card1" :display "table" :creator_id (mt/user->id :rasta)}]
+                     Card      _ {:name "card1" :display "table" :creator_id (mt/user->id :rasta)}
+                     Card      _ {:name "model" :creator_id (mt/user->id :rasta) :type "model"}]
         (is (= (-> (merge
                     @user-defaults
                     {:email                      "rasta@metabase.com"
@@ -432,6 +433,7 @@
                      :group_ids                  [(u/the-id (perms-group/all-users))]
                      :personal_collection_id     true
                      :has_question_and_dashboard true
+                     :has_model                  true
                      :custom_homepage            nil
                      :is_installer               (= 1 (mt/user->id :rasta))
                      :has_invited_second_user    (= 1 (mt/user->id :rasta))})
@@ -443,6 +445,10 @@
       (mt/with-empty-h2-app-db
         (is (false? (-> (mt/user-http-request :rasta :get 200 "user/current")
                         :has_question_and_dashboard)))))
+    (testing "on a fresh instance, `has_model` is `false`"
+      (mt/with-empty-h2-app-db
+        (is (false? (-> (mt/user-http-request :rasta :get 200 "user/current")
+                        :has_model)))))
     (testing "Custom homepage"
       (testing "If id is set but not enabled it is not included"
         (mt/with-temporary-setting-values [custom-homepage false

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -38,9 +38,12 @@
             Table
             User]]
    [metabase.models.collection :as collection]
+   [metabase.models.permissions :as perms]
+   [metabase.models.permissions-group :as perms-group]
    [metabase.test :as mt]
    [metabase.test.data.env :as tx.env]
    [metabase.test.fixtures :as fixtures]
+   [metabase.util :as u]
    [metabase.util.encryption :as encryption]
    [metabase.util.encryption-test :as encryption-test]
    [toucan2.core :as t2]))
@@ -2558,3 +2561,58 @@
         (testing "After the migration, fields are deactivated correctly"
           (doseq [[active? field] active+field]
             (is (= active? (t2/select-one-fn :active :metabase_field (:id field))))))))))
+
+(deftest populate-new-permission-fields-works
+  (testing "Migration v51.2024-08-21T08:33:10"
+    (impl/test-migrations ["v51.2024-08-21T08:33:06" "v51.2024-08-21T08:33:10"] [migrate!]
+      (let [read-coll-id (t2/insert-returning-pk! :collection (merge (mt/with-temp-defaults :model/Collection)
+                                                                     {:slug "foo"}))
+            read-coll-path (perms/collection-read-path read-coll-id)
+            write-coll-id (t2/insert-returning-pk! :collection (merge (mt/with-temp-defaults :model/Collection)
+                                                                      {:slug "foo"}))
+            write-coll-path (perms/collection-readwrite-path write-coll-id)
+
+            ;; a nonexistent collection permission - should get deleted!
+            nonexistent-path "/collection/99123457/"
+            nonexistent-read-path "/collection/99123456/read/"
+
+            both-perms-id (t2/insert-returning-pk! :collection (merge (mt/with-temp-defaults :model/Collection)
+                                                                      {:slug "foo"}))]
+        (t2/insert! :permissions {:object nonexistent-path
+                                  :group_id (u/the-id (perms-group/all-users))})
+        (t2/insert! :permissions {:object nonexistent-read-path
+                                  :group_id (u/the-id (perms-group/all-users))})
+        (t2/insert! :permissions {:object read-coll-path :group_id (u/the-id (perms-group/all-users))})
+        (t2/insert! :permissions {:object write-coll-path :group_id (u/the-id (perms-group/all-users))})
+
+        (t2/insert! :permissions {:object (perms/collection-readwrite-path both-perms-id)
+                                  :group_id (u/the-id (perms-group/all-users))})
+        (t2/insert! :permissions {:object (perms/collection-read-path both-perms-id)
+                                  :group_id (u/the-id (perms-group/all-users))})
+
+        (migrate!)
+        (testing "the valid permissions objects got updated correctly"
+          (is (= [{:collection_id read-coll-id
+                   :perm_type :perms/collection-access
+                   :perm_value :read
+                   :object (str "/collection/" read-coll-id "/read/")}
+                  {:collection_id write-coll-id
+                   :perm_type :perms/collection-access
+                   :perm_value :read-and-write
+                   :object (str "/collection/" write-coll-id "/")}
+                  ;; NOTE: We have two `:perms/collection-access` values for `both-perms-id`, because there were two
+                  ;; permissions rows to start with. The migration doesn't do any kind of coalescing or deduplication
+                  ;; - we may want do do that down the road.
+                  {:collection_id both-perms-id
+                   :perm_type :perms/collection-access
+                   :perm_value :read-and-write
+                   :object (str "/collection/" both-perms-id "/")}
+                  {:collection_id both-perms-id
+                   :perm_type :perms/collection-access
+                   :perm_value :read
+                   :object (str "/collection/" both-perms-id "/read/")}]
+                 (->> [read-coll-id write-coll-id both-perms-id]
+                      (mapcat #(t2/select :model/Permissions :collection_id %))
+                      (map #(select-keys % [:collection_id :perm_type :perm_value :object]))))))
+        (testing "the invalid permissions (for a nonexistent table) were deleted"
+          (is (empty? (t2/select :model/Permissions :object [:in [nonexistent-path nonexistent-read-path]]))))))))

--- a/test/metabase/models/collection_test.clj
+++ b/test/metabase/models/collection_test.clj
@@ -2,6 +2,7 @@
   (:refer-clojure :exclude [ancestors descendants])
   (:require
    [clojure.math.combinatorics :as math.combo]
+   [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [clojure.walk :as walk]
@@ -297,115 +298,76 @@
              Exception
              (collection/children-location collection)))))))
 
-;; TODO: Figure out a better way to test this!
-(deftest permissions-set->visible-collection-ids-test
-  ;; let's just say all of the collections we're dealing with are:
-  ;; - NOT the trash
-  ;; - NOT archived
-  ;; - don't have a `archive_operation_id`
-  #_(with-redefs [collection/is-trash? (constantly false)
-                collection/collection-id->collection
-                (constantly
-                 (zipmap (next (range 10))
-                         (next (map (fn [id]
-                                      {:id id
-                                       :archived false
-                                       :archive_operation_id nil})
-                                    (range 10)))))]
-    (testing "Make sure we can look at the current user's permissions set and figure out which Collections they're allowed to see"
-      (is (= #{8 9}
-             (collection/permissions-set->visible-collection-ids
-              #{"/db/1/"
-                "/db/2/native/"
-                "/db/4/schema/"
-                "/db/5/schema/PUBLIC/"
-                "/db/6/schema/PUBLIC/table/7/"
-                "/collection/8/"
-                "/collection/9/read/"}))))
+(deftest visible-collection-ids-test
+  (with-collection-hierarchy! [{:keys [a b c d e f g]}]
+    (let [->names (fn [id-set]
+                    (let [root (when (contains? id-set "root") #{"root"})
+                          others (when-let [non-root-ids (seq (disj id-set "root"))]
+                                   (t2/select-fn-set :name :model/Collection :id [:in non-root-ids]))]
+                      (set/union root others)))
+          visible-collection-ids (fn []
+                                   (->names
+                                    (set/intersection (collection/visible-collection-ids {})
+                                                      (set (conj (map :id [a b c d e f g]) "root")))))]
+      (testing "All permissions => all the collections!"
+        (with-current-user-perms-for-collections! [a b c d e f g]
+          (is (= #{"A" "B" "C" "D" "E" "F" "G"} (visible-collection-ids)))))
+      (testing "Some permissions => some of the collections!"
+        (with-current-user-perms-for-collections! [a b c]
+          (is (= #{"A" "B" "C"}
+                 (visible-collection-ids)))))
+      (testing "Some other permissions => some other collections"
+        (with-current-user-perms-for-collections! [d e f]
+          (is (= #{"D" "E" "F"}
+                 (visible-collection-ids)))))
+      (testing "If the current user is an admin, it should return *all* collections"
+        (mt/with-test-user :crowberto
+          (is (= #{"A" "B" "C" "D" "E" "F" "G" "root"}
+                 (visible-collection-ids))))))))
 
-    (testing "If the current user has root permissions then make sure the function returns `:all`, which signifies that they are able to see all Collections"
-      (is (= (into #{"root"} (range 1 10))
-             (collection/permissions-set->visible-collection-ids
-              #{"/"
-                "/db/2/native/"
-                "/collection/9/read/"}))))
-
-    (testing "for the Root Collection we should return `root`"
-      (is (= #{8 9 "root"}
-             (collection/permissions-set->visible-collection-ids
-              #{"/collection/8/"
-                "/collection/9/read/"
-                "/collection/root/"})))
-
-      (is (= #{"root"}
-             (collection/permissions-set->visible-collection-ids
-              #{"/collection/root/read/"}))))))
-
-;; testing the 2-arity form of `permissions-set->visible-collection-ids`
 (deftest permissions-set->visible-collection-ids-test-with-config
-  #_(with-redefs [collection/is-trash? #(= (:id %) 1)
-                collection/collection-id->collection
-                ;; These are the collections we get to play with
-                (constantly
-                 {1 {:id 1
-                     :archived false
-                     :archive_operation_id nil}
-                  2 {:id 2
-                     :archived true
-                     :archive_operation_id "1234"}
-                  3 {:id 3
-                     :archived true
-                     :archive_operation_id "1234"}
-                  4 {:id 4
-                     :archived true
-                     :archive_operation_id "5678"}
-                  5 {:id 5
-                     :archived false
-                     :archive_operation_id nil}})]
-    (let [permissions #{"/collection/1/" "/collection/2/"
-                        "/collection/3/" "/collection/4/"
-                        "/collection/5/"}]
-      (testing "Archived"
-        (testing "Default"
-          (is (= #{5}
-                 (collection/permissions-set->visible-collection-ids permissions {}))))
-        (testing "Only"
-          (is (= #{2 3 4}
-                 (collection/permissions-set->visible-collection-ids permissions {:include-archived-items :only}))))
-        (testing "Exclude"
-          (is (= #{5}
-                 (collection/permissions-set->visible-collection-ids permissions {:include-archived-items :exclude}))))
-        (testing "All"
-          (is (= #{2 3 4 5}
-                 (collection/permissions-set->visible-collection-ids permissions {:include-archived-items :all})))))
-      (testing "Include trash?"
-        (testing "true"
-          (is (= #{1 5}
-                 (collection/permissions-set->visible-collection-ids permissions {:include-trash-collection? true}))))
-        (testing "false"
-          (is (= #{5}
-                 (collection/permissions-set->visible-collection-ids permissions {:include-trash-collection? false}))))
-        (testing "default"
-          (is (= #{5}
-                 (collection/permissions-set->visible-collection-ids permissions {})))))
-      (testing "archive operation id"
-        (testing "can filter down to a particular archive operation id"
-          (is (= #{2 3}
-                 (collection/permissions-set->visible-collection-ids permissions {:archive-operation-id "1234"
-                                                                                  :include-archived-items :all})))
-          (is (= #{4}
-                 (collection/permissions-set->visible-collection-ids permissions {:archive-operation-id "5678"
-                                                                                  :include-archived-items :all}))))))))
+  (mt/with-temp [:model/Collection {c1 :id} {:archived false :archive_operation_id nil}
+                 :model/Collection {c2 :id} {:archived true :archive_operation_id "1234"}
+                 :model/Collection {c3 :id} {:archived true :archive_operation_id "1234"}
+                 :model/Collection {c4 :id} {:archived true :archive_operation_id "5678"}]
+    (let [visible-collection-ids (fn [c] (set/intersection (collection/visible-collection-ids c)
+                                                           #{c1 c2 c3 c4 (collection/trash-collection-id) "root"}))]
+      (with-current-user-perms-for-collections! [c1 c2 c3 c4]
+        (testing "Archived"
+          (testing "Default"
+            (is (= #{"root" c1} (visible-collection-ids {}))))
+          (testing "Only"
+            (is (= #{c2 c3 c4} (visible-collection-ids {:include-archived-items :only}))))
+          (testing "Exclude"
+            (is (= #{"root" c1} (visible-collection-ids {:include-archived-items :exclude}))))
+          (testing "All"
+            (is (= #{c1 c2 c3 c4 "root"}
+                   (visible-collection-ids {:include-archived-items :all})))))
+        (testing "Include trash?"
+          (testing "true"
+            (is (= #{c1 "root" (collection/trash-collection-id)}
+                   (visible-collection-ids {:include-trash-collection? true}))))
+          (testing "false"
+            (is (= #{c1 "root"}
+                   (visible-collection-ids {:include-trash-collection? false})
+                   ;; default
+                   (visible-collection-ids {})))))
+        (testing "archive operation id"
+          (testing "can filter down to a particular archive operation id"
+            (is (= #{c2 c3}
+                   (visible-collection-ids {:archive-operation-id "1234"
+                                            :include-archived-items :all})))
+            (is (= #{c4}
+                   (visible-collection-ids {:archive-operation-id "5678"
+                                            :include-archived-items :all}))))
+          (testing "can get the trash in the same call"
+            (is (= #{c2 c3 (collection/trash-collection-id)}
+                   (visible-collection-ids {:archive-operation-id "1234"
+                                            :include-archived-items :all
+                                            :include-trash-collection? true})))))))))
 
 (deftest effective-location-path-test
-  #_(with-redefs [audit/is-collection-id-audit? (constantly false)
-                collection/collection-id->collection (constantly
-                                                      (zipmap (map * (next (range 10)) (repeat 10))
-                                                              (next (map (fn [id]
-                                                                           {:id id
-                                                                            :archived false
-                                                                            :archive_operation_id nil})
-                                                                         (map * (range 10) (repeat 10))))))]
+  (with-redefs [audit/is-collection-id-audit? (constantly false)]
     (testing "valid input"
       (doseq [[args expected] {["/10/20/30/" #{10 20}]    "/10/20/"
                                ["/10/20/30/" #{10 30}]    "/10/30/"
@@ -423,33 +385,7 @@
         (testing (pr-str (cons 'effective-location-path args))
           (is (thrown?
                Exception
-               (apply collection/effective-location-path args))))))
-
-    (testing "Does the function also work if we call the single-arity version that powers hydration?"
-      (testing "mix of full and read perms"
-        (binding [*current-user-permissions-set* (atom #{"/collection/10/" "/collection/20/read/"})]
-          (is (= "/10/20/"
-                 (collection/effective-location-path {:location "/10/20/30/"})))))
-
-      (testing "missing some perms"
-        (binding [*current-user-permissions-set* (atom #{"/collection/10/read/" "/collection/30/read/"})]
-          (is (= "/10/30/"
-                 (collection/effective-location-path {:location "/10/20/30/"})))))
-
-      (testing "no perms"
-        (binding [*current-user-permissions-set* (atom #{})]
-          (is (= "/"
-                 (collection/effective-location-path {:location "/10/20/30/"})))))
-
-      (testing "read perms for all"
-        (binding [*current-user-permissions-set* (atom #{"/collection/10/" "/collection/20/read/" "/collection/30/read/"})]
-          (is (= "/10/20/30/"
-                 (collection/effective-location-path {:location "/10/20/30/"})))))
-
-      (testing "root perms"
-        (binding [*current-user-permissions-set* (atom #{"/"})]
-          (is (= "/10/20/30/"
-                 (collection/effective-location-path {:location "/10/20/30/"}))))))))
+               (apply collection/effective-location-path args))))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                Nested Collections: CRUD Constraints & Behavior                                 |

--- a/test/metabase/models/collection_test.clj
+++ b/test/metabase/models/collection_test.clj
@@ -624,8 +624,6 @@
                                     (map :name)
                                     set))]
 
-
-
       (testing "If we *have* perms for everything we should just see B and C."
         (with-current-user-perms-for-collections! [a b c d e f g]
           (is (= #{"B" "C"}
@@ -657,7 +655,6 @@
         (with-current-user-perms-for-collections! [a b e f g]
           (is (= #{"B" "E" "F"}
                  (effective-children a)))))
-
 
       (testing "If we remove C and both its children, both grandchildren should get get moved up"
         ;;

--- a/test/metabase/models/permissions_test.clj
+++ b/test/metabase/models/permissions_test.clj
@@ -310,3 +310,21 @@
         (testing (format "Able to revoke `%s` permission" (name perm-type))
           (perms/revoke-application-permissions! group-id perm-type)
           (is (not (= (perms) #{perm-path}))))))))
+
+(deftest maybe-break-out-permission-data-test
+  (testing "We can break out a collection permission"
+    (are [object m] (= m (select-keys (#'perms/maybe-break-out-permission-data {:object object})
+                                      [:collection_id :perm_type :perm_value]))
+      "/collection/123/" {:collection_id 123
+                          :perm_type "perms/collection-access"
+                          :perm_value "read-and-write"}
+      "/collection/123/read/" {:collection_id 123
+                               :perm_type "perms/collection-access"
+                               :perm_value "read"}
+
+      ;; We only do this for collection permissions right now.
+      "/foo/1234/" {}
+
+      ;; Note that WE DON'T break out the root collection bits at this point. Maybe we will down the road, but we need
+      ;; to think about how this works since the collection ID will be `NULL`.
+      "/collection/root/" {})))

--- a/test/metabase/models/permissions_test.clj
+++ b/test/metabase/models/permissions_test.clj
@@ -316,11 +316,11 @@
     (are [object m] (= m (select-keys (#'perms/maybe-break-out-permission-data {:object object})
                                       [:collection_id :perm_type :perm_value]))
       "/collection/123/" {:collection_id 123
-                          :perm_type "perms/collection-access"
-                          :perm_value "read-and-write"}
+                          :perm_type :perms/collection-access
+                          :perm_value :read-and-write}
       "/collection/123/read/" {:collection_id 123
-                               :perm_type "perms/collection-access"
-                               :perm_value "read"}
+                               :perm_type :perms/collection-access
+                               :perm_value :read}
 
       ;; We only do this for collection permissions right now.
       "/foo/1234/" {}


### PR DESCRIPTION
## Migrations: add and populate indexed columns `perm_value`, `perm_type`, and `collection_id` to `permissions`

These fields allows us to efficiently run queries based on collection permissions in the DB without string manipulation. Keeping the table as `permissions` allows us to do this migration in-place. **Note that in some cases collections may have been deleted from the database without deleting the associated permissions row (since there was no foreign key before).** We need to be defensive here: if we have a permissions row without a corresponding collection, delete the row before running the rest of the migration.

## Write `perm_value`, `perm_type`, and `collection_id` for new collection permissions

A very simple `before-insert` method sets these fields before a collection permission is written to the DB.

## Replace `collection/permissions-set->visible-collection-ids` and `collection/visible-collection-ids->honeysql-filter-clause` with `collection/honeysql-filter-clause`

Previously, just about everywhere we used `permissions-set->visible-collection-ids`, what we were essentially doing was an in-app join: select all the collection IDs you have permission on, then convert it to a SQL clause like `WHERE collection_id IN ( all of those collection IDs)`.

Replace both of these with `honeysql-filter-clause`, which uses the new fields we added to `permissions` above to construct a honeysql filter representing "all the collections I have permissions on", without needing to round-trip them to the application and back to the DB.

Of course, we can then write a function `visible-collection-ids`, which uses `honeysql-filter-clause`, for those cases where we *do* actually need the whole bunch in the application (we use this, for example, when constructing the `effective-location` for a collection).

I also added one more toggle to the `VisibilityConfig` that's passed into the `honeysql-filter-clause` (and used to be passed to `permissions-set->visible-collection-ids`), allowing you to select only the effective children of some collection.

The following graph shows the old vs new code doing a search for a non-admin:

```
(search/search
                                          (search/search-context
                                           {:archived                            false
                                            :created-at                          nil
                                            :created-by                          nil
                                            :current-user-id                     api/*current-user-id*
                                            :current-user-perms                  @api/*current-user-permissions-set*
                                            :filter-items-in-personal-collection nil
                                            :last-edited-at                      nil
                                            :last-edited-by                      nil
                                            :limit                               1
                                            :model-ancestors?                    false
                                            :models                              #{"dashboard" "dataset" "card"}
                                            :offset                              nil
                                            :search-native-query                 nil
                                            :search-string                       nil
                                            :table-db-id                         nil
                                            :verified                            nil
                                            :ids                                 nil}))
```

X-axis is number of collections, Y-axis is ms to complete. Also note that the timing jump for the old code coincided with it beginning to fail with an error about too many SQL parameters.

<img width="909" alt="Screenshot 2024-08-21 at 12 52 17" src="https://github.com/user-attachments/assets/442ded6f-bcee-42c1-b0bd-a1c65be0a2b4">

This is the fix for https://github.com/metabase/metabase/issues/46510 (but needs to be backported, as that issue is for v49)