### PR TITLE
Include missing opts arg for transform->nested

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -1717,12 +1717,12 @@
                    :model/DashboardCardSeries s   {:dashboardcard_id (:id dc1) :card_id (:id c2)}]
       (let [spec (serdes/make-spec "DashboardCard" nil)]
         (is (= {(:id dc1) [s]}
-               (#'serdes/transform->nested (-> spec :transform :series) [dc1])))
+               (#'serdes/transform->nested (-> spec :transform :series) {} [dc1])))
         (is (=? (assoc dc1 :series [s])
                 (u/rfirst (serdes/extract-query "DashboardCard" {:where [:= :id (:id dc1)]})))))
       (let [spec (serdes/make-spec "Dashboard" nil)]
         (is (= {(:id d) [(assoc dc1 :series [s])]}
-               (#'serdes/transform->nested (-> spec :transform :dashcards) [d])))
+               (#'serdes/transform->nested (-> spec :transform :dashcards) {} [d])))
         (is (=? (assoc d
                        :dashcards [(assoc dc1 :series [s])]
                        :tabs nil)


### PR DESCRIPTION
was missing from the call.

Also had to disable hooks to commit:

```
✖ clj-kondo --config ./.clj-kondo/config.edn --config-dir ./.clj-kondo --parallel --lint:
metabase/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj:458:20: warning: Unresolved var: ts/extract-one
metabase/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj:1691:8: warning: Unresolved var: mbc/ensure-audit-db-installed!
metabase/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj:1757:18: warning: Unresolved var: ts/create!
linting took 247ms, errors: 0, warnings: 3
error Command failed with exit code 1.
```
