### PR TITLE
docs: special field filter syntax

### DIFF
--- a/docs/questions/native-editor/sql-parameters.md
+++ b/docs/questions/native-editor/sql-parameters.md
@@ -141,6 +141,17 @@ A MongoDB native query example might look like this:
 
 For a more in-depth guide, check out [Field Filters: create smart filter widgets for SQL questions][field-filter].
 
+### Field filters in BigQuery and Oracle
+
+Make sure your SQL dialect matches the database you've selected. Common issues:
+
+| Database | Do this                    | Avoid                |
+| -------- | -------------------------- | -------------------- |
+| BigQuery | `` FROM `dataset.table` `` | `FROM dataset.table` |
+| Oracle   | `FROM "schema"."table"`    | `FROM schema.table`  |
+
+For more help, see [Troubleshooting SQL error messages](../../troubleshooting-guide/error-message.md#sql-editor).
+
 ## How to create different types of filter widgets
 
 The kind of filter widget that Metabase displays when you create a Field Filter widget depends on a setting for that field in Metabase called **Filtering on this field**. Admins can set this field option to:

--- a/docs/questions/native-editor/sql-parameters.md
+++ b/docs/questions/native-editor/sql-parameters.md
@@ -143,12 +143,12 @@ For a more in-depth guide, check out [Field Filters: create smart filter widgets
 
 ### Field filters in BigQuery and Oracle
 
-Make sure your SQL dialect matches the database you've selected. Common issues:
+Make sure your SQL dialect matches the database you've selected. Common issues involving how tables are quoted in the query:
 
-| Database | Do this                    | Avoid                |
+| Database | Dialect quirk              | Example               |
 | -------- | -------------------------- | -------------------- |
-| BigQuery | `` FROM `dataset.table` `` | `FROM dataset.table` |
-| Oracle   | `FROM "schema"."table"`    | `FROM schema.table`  |
+| BigQuery | Schemas and tables must be quoted with backticks. | `` FROM `dataset.table` `` |
+| Oracle   | Schemas and tables must be quoted in double quotes.   | `FROM schema.table`  |
 
 For more help, see [Troubleshooting SQL error messages](../../troubleshooting-guide/error-message.md#sql-editor).
 

--- a/docs/questions/native-editor/writing-sql.md
+++ b/docs/questions/native-editor/writing-sql.md
@@ -82,17 +82,6 @@ For questions, [dashboards](../../dashboards/start.md), and [models](../../data-
 
 See [History](../../exploration-and-organization/history.md).
 
-## Your SQL syntax must match the dialect used by the database
-
-Make sure your SQL dialect matches the database you've selected. Common errors:
-
-| Database | Do this                    | Avoid                |
-| -------- | -------------------------- | -------------------- |
-| BigQuery | `` FROM `dataset.table` `` | `FROM dataset.table` |
-| Oracle   | `FROM "schema"."table"`    | `FROM schema.table`  |
-
-For more help, see [Troubleshooting SQL error messages](../../troubleshooting-guide/error-message.md#sql-editor).
-
 ## Explore SQL question results using the Query Builder
 
 On saved SQL questions without [parameters](./sql-parameters.md), you'll get the **Explore results** button. It will create a new Query Builder question that uses the SQL question results as a data source.

--- a/docs/troubleshooting-guide/filters.md
+++ b/docs/troubleshooting-guide/filters.md
@@ -76,6 +76,10 @@ Metabase needs to know the data type of a column in order to present you with a 
 
 Timestamps, in particular, are the root of all evil, so please be patient with your Metabase admin (or yourself!) when trying to get the data type right.
 
+## Field filters in BigQuery and Oracle
+
+If you are getting an error when using field filters with BigQuery or Oracle, make sure you use the correct syntax for the `FROM` clause. See [Field filters in BigQuery and Oracle](../questions/native-editor/sql-parameters.md#field-filters-in-bigquery-and-oracle).
+
 ## Missing or incorrect filter values
 
 If your filter dropdown menu displays the wrong values for a column:


### PR DESCRIPTION
[Slack thread](https://metaboat.slack.com/archives/C013N8XL286/p1724090273363419). We also have received tickets about this issue last few months, I just never got around to fixing this.

This note was moved from Field Filters article to SQL editor article [here](https://github.com/metabase/metabase/commit/41aed8c32b6fd191314605948ad19ab6d3c37327).
I think it should be placed back into the field filters article.

I'm putting it into that article because it's only an issue when using field filters, it doesn't apply not with general queries. So you can write your queries in BQ and never experience an issue, but as soon as you try a field filter, you get an error. That means that people are not likely to look in the general SQL editor docs (because until now, sql editor was working just fine) but in the field filter docs (because that's what changed when they got an error)

We even have users pointing out in docs feedback that backticks are not usually required.

I also changed the heading so that it'd be easier to find for BQ and Oracle users when skimming the article. 


