### PR TITLE
🤖 Manual backport: "Single Log Out saml-slo-enabled defsetting" to 49

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
@@ -39,13 +39,13 @@
       (throw e))))
 
 (mu/defn ^:private sso-error-page
-  [^Throwable e log-direction :- [:enum "in" "out"]]
+  [^Throwable e log-direction :- [:enum :in :out]]
   {:status  (get (ex-data e) :status-code 500)
    :headers {"Content-Type" "text/html"}
    :body    (stencil/render-file "metabase_enterprise/sandbox/api/error_page"
                                  (let [message    (.getMessage e)
                                        data       (u/pprint-to-str (ex-data e))]
-                                   {:logDirection   log-direction
+                                   {:logDirection   (name log-direction)
                                     :errorMessage   message
                                     :exceptionClass (.getName Exception)
                                     :additionalData data}))})
@@ -57,8 +57,8 @@
   (try
     (sso.i/sso-post req)
     (catch Throwable e
-      (log/error e (trs "Error logging in"))
-      (sso-error-page e "in"))))
+      (log/error e "Error logging in")
+      (sso-error-page e :in))))
 
 
 ;; ------------------------------ Single Logout aka SLO ------------------------------
@@ -83,7 +83,7 @@
       ;; they will never hit "/handle_slo" so we must delete the session here:
       (t2/delete! :model/Session :id metabase-session-id)
       {:saml-logout-url
-       (when (and (sso-settings/saml-enabled)
+       (when (and (sso-settings/saml-slo-enabled)
                   (= sso_source "saml"))
          (saml/logout-redirect-location
           :idp-url (sso-settings/saml-identity-provider-uri)
@@ -97,9 +97,12 @@
   "Handles client confirmation of saml logout via slo"
   [:as req]
   (try
-    (sso.i/sso-handle-slo req)
+    (if (sso-settings/saml-slo-enabled)
+      (sso.i/sso-handle-slo req)
+      (throw (ex-info "SAML Single Logout is not enabled, request forbidden."
+                      {:status-code 403})))
     (catch Throwable e
-      (log/error e (trs "Error handling SLO"))
-      (sso-error-page e "out"))))
+      (log/error e "Error handling SLO")
+      (sso-error-page e :out))))
 
 (api/define-routes)

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -246,9 +246,11 @@
 
 (defmethod sso.i/sso-handle-slo :saml
   [{:keys [cookies params]}]
-  (let [xml-str (base64-decode (:SAMLResponse params))
-        success? (slo-success? xml-str)]
-    (if-let [metabase-session-id (and success? (get-in cookies [mw.session/metabase-session-cookie :value]))]
-      (do (t2/delete! :model/Session :id metabase-session-id)
-          (mw.session/clear-session-cookie (response/redirect (urls/site-url))))
-      {:status 500 :body "SAML logout failed."})))
+  (if (sso-settings/saml-slo-enabled)
+    (let [xml-str (base64-decode (:SAMLResponse params))
+          success? (slo-success? xml-str)]
+      (if-let [metabase-session-id (and success? (get-in cookies [mw.session/metabase-session-cookie :value]))]
+        (do (t2/delete! :model/Session :id metabase-session-id)
+            (mw.session/clear-session-cookie (response/redirect (urls/site-url))))
+        {:status 500 :body "SAML logout failed."}))
+    (log/warn "SAML SLO is not enabled, not continuing Single Log Out flow.")))

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_settings.clj
@@ -168,6 +168,18 @@ on your IdP, this usually looks something like `http://www.example.com/141xkex60
                (setting/get-value-of-type :boolean :saml-enabled)
                false)))
 
+(defsetting saml-slo-enabled
+  (deferred-tru "Is SAML Single Log Out enabled?")
+  :type    :boolean
+  :default false
+  :feature :sso-saml
+  :audit   :getter
+  :export? false
+  :getter  (fn []
+             (if (saml-enabled)
+               (setting/get-value-of-type :boolean :saml-slo-enabled)
+               false)))
+
 (defsetting jwt-identity-provider-uri
   (deferred-tru "URL of JWT based login page")
   :feature :sso-jwt

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -672,23 +672,43 @@
                                             :last-name  "user"
                                             :email      "test1234@metabsae.com"})))))))
 
-(deftest logout-should-delete-session-test
-  (testing "Successful SAML SLO logouts should delete the user's session."
-    (let [session-id (str (random-uuid))]
-      (mt/with-temp [:model/User user {:email "saml_test@metabase.com" :sso_source "saml"}
-                     :model/Session _ {:user_id (:id user) :id session-id}]
-        (with-saml-default-setup
-          (is (t2/exists? :model/Session :id session-id))
-          (let [req-options (-> (saml-post-request-options
-                                 (saml-slo-test-response)
-                                 (saml/str->base64 default-redirect-uri))
-                                ;; Client sends their session cookie during the SLO request redirect from the IDP.
-                                (assoc-in [:request-options :cookies mw.session/metabase-session-cookie :value] session-id))
-                response    (client-full-response :post 302 "/auth/sso/handle_slo" req-options)]
-            (is (str/blank? (get-in response [:cookies mw.session/metabase-session-cookie :value]))
-                "After a successful log-out, you don't have a session")
-            (is (not (t2/exists? :model/Session :id session-id))
-                "After a successful log-out, the session is deleted")))))))
+(deftest logout-should-delete-session-test-slo-enabled
+  (testing "Successful SAML SLO logouts should delete the user's session, when saml-slo-enabled."
+    (mt/with-temporary-setting-values [saml-slo-enabled true]
+      (let [session-id (str (random-uuid))]
+        (mt/with-temp [:model/User user {:email "saml_test@metabase.com" :sso_source "saml"}
+                       :model/Session _ {:user_id (:id user) :id session-id}]
+          (with-saml-default-setup
+            (is (t2/exists? :model/Session :id session-id))
+            (let [req-options (-> (saml-post-request-options
+                                   (saml-slo-test-response)
+                                   (saml/str->base64 default-redirect-uri))
+                                  ;; Client sends their session cookie during the SLO request redirect from the IDP.
+                                  (assoc-in [:request-options :cookies mw.session/metabase-session-cookie :value] session-id))
+                  response    (client-full-response :post 302 "/auth/sso/handle_slo" req-options)]
+              (is (str/blank? (get-in response [:cookies mw.session/metabase-session-cookie :value]))
+                  "After a successful log-out, you don't have a session")
+              (is (not (t2/exists? :model/Session :id session-id))
+                  "After a successful log-out, the session is deleted"))))))))
+
+(deftest logout-should-not-delete-session-test-slo-disabled
+  (testing "Successful SAML SLO logouts should not delete the user's session, when not saml-slo-enabled."
+    (mt/with-temporary-setting-values [saml-slo-enabled false]
+      (let [session-id (str (random-uuid))]
+        (mt/with-temp [:model/User user {:email "saml_test@metabase.com" :sso_source "saml"}
+                       :model/Session _ {:user_id (:id user) :id session-id}]
+          (with-saml-default-setup
+            (is (t2/exists? :model/Session :id session-id))
+            (let [req-options (-> (saml-post-request-options
+                                   (saml-slo-test-response)
+                                   (saml/str->base64 default-redirect-uri))
+                                  ;; Client sends their session cookie during the SLO request redirect from the IDP.
+                                  (assoc-in [:request-options :cookies mw.session/metabase-session-cookie :value] session-id))
+                  response    (client-full-response :post 403 "/auth/sso/handle_slo" req-options)]
+              (is (str/blank? (get-in response [:cookies mw.session/metabase-session-cookie :value]))
+                  "After a successful log-out, you don't have a session")
+              (is (t2/exists? :model/Session :id session-id)
+                  "After a successful log-out, the session is deleted"))))))))
 
 (deftest logout-should-delete-session-when-idp-slo-conf-missing-test
   (testing "Missing SAML SLO config logouts should still delete the user's session."

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/sso_settings_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/sso_settings_test.clj
@@ -116,7 +116,11 @@
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo
            #"Setting saml-enabled is not enabled because feature :sso-saml is not available"
-           (sso-settings/saml-enabled! true))))))
+           (sso-settings/saml-enabled! true)))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Setting saml-slo-enabled is not enabled because feature :sso-saml is not available"
+           (sso-settings/saml-slo-enabled! true))))))
 
 (deftest jwt-settings-token-features-test
   (testing "Getting JWT settings should return their default values without :sso-jwt feature flag enabled"

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -1187,14 +1187,17 @@
   will happen, in [[call-on-change]] below.
 
   ###### `:feature`
+
   If non-nil, determines the Enterprise feature flag required to use this setting. If the feature is not enabled,
   the setting will behave the same as if `enabled?` returns `false` (see below).
 
   ###### `enabled?`
+
   Function which returns true if the setting should be enabled. If it returns false, the setting will throw an
   exception when it is attempted to be set, and will return its default value when read. Defaults to always enabled.
 
   ###### `audit`
+
   Keyword that determines what kind of audit log entry should be created when this setting is written. Options are
   `:never`, `:no-value`, `:raw-value`, and `:getter`. User- and database-local settings are never audited. `:getter`
   should be used for most non-sensitive settings, and will log the value returned by its getter, which may be
@@ -1203,6 +1206,7 @@
   and `:sensitive` settings.)
 
   ###### `base`
+
   A map which can provide values for any of the above options, except for :export?.
   Any top level options will override what's in this base map.
   The use case for this map is sharing strongly coupled options between similar settings, see [[uuid-nonce-base]].


### PR DESCRIPTION
This is a manual backport of https://github.com/metabase/metabase/pull/44794

----

🤖 Manual backport: "Single Log Out saml-slo-enabled defsetting" to 49

----


- backport:
  - use `client/client-real-response`, instead of `client-full-response`
* stop using strings for enum values (prefer kw)
* only do SLO when saml-slo-enabled is true
* make defsetting docstring formatting consistent
* log-direction is a string
* add test for enabling / disabling saml slo
* also return a 403 when the client tries, but it's disabled
* use client-full-response, which won't add '/api'.
* fix typo in deftest name