### PR TITLE
refactor: Simplify question data source

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/QuestionDataSource.jsx
@@ -1,25 +1,20 @@
 import PropTypes from "prop-types";
-import { isValidElement } from "react";
 import { t } from "ttag";
 
 import { skipToken, useGetCollectionQuery } from "metabase/api";
-import { TableInfoIcon } from "metabase/components/MetadataInfo/TableInfoIcon/TableInfoIcon";
 import Tooltip from "metabase/core/components/Tooltip";
 import Questions from "metabase/entities/questions";
 import { color } from "metabase/lib/colors";
-import { isNotNull } from "metabase/lib/types";
 import * as Urls from "metabase/lib/urls";
 import * as Lib from "metabase-lib";
 import {
   getQuestionIdFromVirtualTableId,
-  getQuestionVirtualTableId,
   isVirtualCardId,
 } from "metabase-lib/v1/metadata/utils/saved-questions";
-import * as ML_Urls from "metabase-lib/v1/urls";
 
 import { HeadBreadcrumbs } from "../HeaderBreadcrumbs";
 
-import { IconWrapper, TablesDivider } from "./QuestionDataSource.styled";
+import { getDataSourceParts } from "./utils";
 
 QuestionDataSource.propTypes = {
   question: PropTypes.object,
@@ -166,130 +161,3 @@ function SourceDatasetBreadcrumbs({ question, ...props }) {
 
 QuestionDataSource.shouldRender = ({ question, isObjectDetail = false }) =>
   getDataSourceParts({ question, isObjectDetail }).length > 0;
-
-function getDataSourceParts({ question, subHead, isObjectDetail }) {
-  if (!question) {
-    return [];
-  }
-
-  const { isEditable } = Lib.queryDisplayInfo(question.query());
-  const hasDataPermission = isEditable;
-  if (!hasDataPermission) {
-    return [];
-  }
-
-  const parts = [];
-  const query = question.query();
-  const metadata = question.metadata();
-  const { isNative } = Lib.queryDisplayInfo(query);
-
-  const database = metadata.database(Lib.databaseID(query));
-  if (database) {
-    parts.push({
-      icon: !subHead ? "database" : undefined,
-      name: database.displayName(),
-      href: database.id >= 0 && Urls.browseDatabase(database),
-    });
-  }
-
-  const table = !isNative
-    ? metadata.table(Lib.sourceTableOrCardId(query))
-    : question.legacyQuery().table();
-  if (table && table.hasSchema()) {
-    const isBasedOnSavedQuestion = isVirtualCardId(table.id);
-    if (!isBasedOnSavedQuestion) {
-      parts.push({
-        name: table.schema_name,
-        href: database.id >= 0 && Urls.browseSchema(table),
-      });
-    }
-  }
-
-  if (table) {
-    const hasTableLink = subHead || isObjectDetail;
-    if (isNative) {
-      return {
-        name: table.displayName(),
-        link: hasTableLink ? getTableURL() : "",
-      };
-    }
-
-    const allTables = [
-      table,
-      ...Lib.joins(query, -1)
-        .map(join => Lib.pickerInfo(query, Lib.joinedThing(query, join)))
-        .map(pickerInfo => {
-          if (pickerInfo?.tableId != null) {
-            return metadata.table(pickerInfo.tableId);
-          }
-
-          if (pickerInfo?.cardId != null) {
-            return metadata.table(getQuestionVirtualTableId(pickerInfo.cardId));
-          }
-
-          return undefined;
-        }),
-    ].filter(isNotNull);
-
-    parts.push(
-      <QuestionTableBadges
-        tables={allTables}
-        subHead={subHead}
-        hasLink={hasTableLink}
-        isLast={!isObjectDetail}
-      />,
-    );
-  }
-
-  return parts.filter(part => isValidElement(part) || part.name || part.icon);
-}
-
-QuestionTableBadges.propTypes = {
-  tables: PropTypes.arrayOf(PropTypes.object).isRequired,
-  hasLink: PropTypes.bool,
-  subHead: PropTypes.bool,
-  isLast: PropTypes.bool,
-};
-
-function QuestionTableBadges({ tables, subHead, hasLink, isLast }) {
-  const badgeInactiveColor = isLast && !subHead ? "text-dark" : "text-light";
-
-  const parts = tables.map(table => (
-    <HeadBreadcrumbs.Badge
-      key={table.id}
-      to={hasLink ? getTableURL(table) : ""}
-      inactiveColor={badgeInactiveColor}
-    >
-      <span>
-        {table.displayName()}
-        {!subHead && (
-          <IconWrapper>
-            <TableInfoIcon
-              table={table}
-              icon="info_filled"
-              size={12}
-              position="bottom"
-            />
-          </IconWrapper>
-        )}
-      </span>
-    </HeadBreadcrumbs.Badge>
-  ));
-
-  return (
-    <HeadBreadcrumbs
-      parts={parts}
-      variant={subHead ? "subhead" : "head"}
-      divider={<TablesDivider>+</TablesDivider>}
-      data-testid="question-table-badges"
-    />
-  );
-}
-
-function getTableURL(table) {
-  if (isVirtualCardId(table.id)) {
-    const cardId = getQuestionIdFromVirtualTableId(table.id);
-    return Urls.question({ id: cardId, name: table.displayName() });
-  }
-  return ML_Urls.getUrl(table.newQuestion());
-}

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/QuestionDataSource.jsx
@@ -23,12 +23,6 @@ QuestionDataSource.propTypes = {
   isObjectDetail: PropTypes.bool,
 };
 
-function isMaybeBasedOnDataset(question) {
-  const query = question.query();
-  const sourceTableId = Lib.sourceTableOrCardId(query);
-  return isVirtualCardId(sourceTableId);
-}
-
 export function QuestionDataSource({
   question,
   originalQuestion,
@@ -39,19 +33,19 @@ export function QuestionDataSource({
     return null;
   }
 
+  const query = question.query();
+  const sourceTableId = Lib.sourceTableOrCardId(query);
+
+  const { isNative } = Lib.queryDisplayInfo(query);
+  const sourceQuestionId = getQuestionIdFromVirtualTableId(sourceTableId);
+
   const variant = subHead ? "subhead" : "head";
 
-  const { isNative } = Lib.queryDisplayInfo(question.query());
-
-  if (isNative || !isMaybeBasedOnDataset(question)) {
+  if (isNative || !isVirtualCardId(sourceTableId)) {
     return (
       <DataSourceCrumbs question={question} variant={variant} {...props} />
     );
   }
-
-  const query = question.query();
-  const sourceTableId = Lib.sourceTableOrCardId(query);
-  const sourceQuestionId = getQuestionIdFromVirtualTableId(sourceTableId);
 
   if (originalQuestion?.id() === sourceQuestionId) {
     return (

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/utils.js
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/utils.js
@@ -6,15 +6,15 @@ import { isNotNull } from "metabase/lib/types";
 import * as Urls from "metabase/lib/urls";
 import * as Lib from "metabase-lib";
 import {
-  isVirtualCardId,
   getQuestionIdFromVirtualTableId,
   getQuestionVirtualTableId,
+  isVirtualCardId,
 } from "metabase-lib/v1/metadata/utils/saved-questions";
 import * as ML_Urls from "metabase-lib/v1/urls";
 
 import { HeadBreadcrumbs } from "../HeaderBreadcrumbs";
 
-import { TablesDivider, IconWrapper } from "./QuestionDataSource.styled";
+import { IconWrapper, TablesDivider } from "./QuestionDataSource.styled";
 
 export function getDataSourceParts({ question, subHead, isObjectDetail }) {
   if (!question) {

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/utils.js
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/utils.js
@@ -21,18 +21,19 @@ export function getDataSourceParts({ question, subHead, isObjectDetail }) {
     return [];
   }
 
-  const { isEditable } = Lib.queryDisplayInfo(question.query());
+  const query = question.query();
+  const { isEditable, isNative } = Lib.queryDisplayInfo(query);
+
   const hasDataPermission = isEditable;
   if (!hasDataPermission) {
     return [];
   }
 
   const parts = [];
-  const query = question.query();
-  const metadata = question.metadata();
-  const { isNative } = Lib.queryDisplayInfo(query);
 
+  const metadata = question.metadata();
   const database = metadata.database(Lib.databaseID(query));
+
   if (database) {
     parts.push({
       icon: !subHead ? "database" : undefined,

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/utils.js
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/utils.js
@@ -1,0 +1,144 @@
+import PropTypes from "prop-types";
+import { isValidElement } from "react";
+
+import { TableInfoIcon } from "metabase/components/MetadataInfo/TableInfoIcon/TableInfoIcon";
+import { isNotNull } from "metabase/lib/types";
+import * as Urls from "metabase/lib/urls";
+import * as Lib from "metabase-lib";
+import {
+  isVirtualCardId,
+  getQuestionIdFromVirtualTableId,
+  getQuestionVirtualTableId,
+} from "metabase-lib/v1/metadata/utils/saved-questions";
+import * as ML_Urls from "metabase-lib/v1/urls";
+
+import { HeadBreadcrumbs } from "../HeaderBreadcrumbs";
+
+import { TablesDivider, IconWrapper } from "./QuestionDataSource.styled";
+
+export function getDataSourceParts({ question, subHead, isObjectDetail }) {
+  if (!question) {
+    return [];
+  }
+
+  const { isEditable } = Lib.queryDisplayInfo(question.query());
+  const hasDataPermission = isEditable;
+  if (!hasDataPermission) {
+    return [];
+  }
+
+  const parts = [];
+  const query = question.query();
+  const metadata = question.metadata();
+  const { isNative } = Lib.queryDisplayInfo(query);
+
+  const database = metadata.database(Lib.databaseID(query));
+  if (database) {
+    parts.push({
+      icon: !subHead ? "database" : undefined,
+      name: database.displayName(),
+      href: database.id >= 0 && Urls.browseDatabase(database),
+    });
+  }
+
+  const table = !isNative
+    ? metadata.table(Lib.sourceTableOrCardId(query))
+    : question.legacyQuery().table();
+  if (table && table.hasSchema()) {
+    const isBasedOnSavedQuestion = isVirtualCardId(table.id);
+    if (!isBasedOnSavedQuestion) {
+      parts.push({
+        name: table.schema_name,
+        href: database.id >= 0 && Urls.browseSchema(table),
+      });
+    }
+  }
+
+  if (table) {
+    const hasTableLink = subHead || isObjectDetail;
+    if (isNative) {
+      return {
+        name: table.displayName(),
+        link: hasTableLink ? getTableURL() : "",
+      };
+    }
+
+    const allTables = [
+      table,
+      ...Lib.joins(query, -1)
+        .map(join => Lib.pickerInfo(query, Lib.joinedThing(query, join)))
+        .map(pickerInfo => {
+          if (pickerInfo?.tableId != null) {
+            return metadata.table(pickerInfo.tableId);
+          }
+
+          if (pickerInfo?.cardId != null) {
+            return metadata.table(getQuestionVirtualTableId(pickerInfo.cardId));
+          }
+
+          return undefined;
+        }),
+    ].filter(isNotNull);
+
+    parts.push(
+      <QuestionTableBadges
+        tables={allTables}
+        subHead={subHead}
+        hasLink={hasTableLink}
+        isLast={!isObjectDetail}
+      />,
+    );
+  }
+
+  return parts.filter(part => isValidElement(part) || part.name || part.icon);
+}
+
+QuestionTableBadges.propTypes = {
+  tables: PropTypes.arrayOf(PropTypes.object).isRequired,
+  hasLink: PropTypes.bool,
+  subHead: PropTypes.bool,
+  isLast: PropTypes.bool,
+};
+
+function QuestionTableBadges({ tables, subHead, hasLink, isLast }) {
+  const badgeInactiveColor = isLast && !subHead ? "text-dark" : "text-light";
+
+  const parts = tables.map(table => (
+    <HeadBreadcrumbs.Badge
+      key={table.id}
+      to={hasLink ? getTableURL(table) : ""}
+      inactiveColor={badgeInactiveColor}
+    >
+      <span>
+        {table.displayName()}
+        {!subHead && (
+          <IconWrapper>
+            <TableInfoIcon
+              table={table}
+              icon="info_filled"
+              size={12}
+              position="bottom"
+            />
+          </IconWrapper>
+        )}
+      </span>
+    </HeadBreadcrumbs.Badge>
+  ));
+
+  return (
+    <HeadBreadcrumbs
+      parts={parts}
+      variant={subHead ? "subhead" : "head"}
+      divider={<TablesDivider>+</TablesDivider>}
+      data-testid="question-table-badges"
+    />
+  );
+}
+
+function getTableURL(table) {
+  if (isVirtualCardId(table.id)) {
+    const cardId = getQuestionIdFromVirtualTableId(table.id);
+    return Urls.question({ id: cardId, name: table.displayName() });
+  }
+  return ML_Urls.getUrl(table.newQuestion());
+}


### PR DESCRIPTION
### Description

1. This PR makes `QuestionDataSource` component easier to reason about by [splitting utils into a separate file](https://github.com/metabase/metabase/pull/46989/commits/2c7971833131ec16c4358a79cf31b99dbbe7d9e4).
2. It also slightly improves its performance since it optimizes how many times we're calling an expensive `question.query()`.
    - [call it once instead of three times](https://github.com/metabase/metabase/pull/46989/commits/51ba1a6664fff4f80cf79d774d88583d282cd603)
    - [call it once instead of twice](https://github.com/metabase/metabase/pull/46989/commits/e876d21f986be95ea7276c28b218d1bb587bbfa9)


### How to verify
Everything should still behave and work like before. No changes in functionality. Therefore, all tests should pass in CI.
