### PR TITLE
hide echarts tooltip on scroll

### DIFF
--- a/frontend/src/metabase/components/ExplicitSize/ExplicitSize.tsx
+++ b/frontend/src/metabase/components/ExplicitSize/ExplicitSize.tsx
@@ -3,8 +3,8 @@ import debounce from "lodash.debounce";
 import type {
   CSSProperties,
   ComponentType,
-  PropsWithoutRef,
   ForwardedRef,
+  PropsWithoutRef,
 } from "react";
 import React, { Component } from "react";
 import ReactDOM from "react-dom";

--- a/frontend/src/metabase/visualizations/components/EChartsRenderer/EChartsRenderer.tsx
+++ b/frontend/src/metabase/visualizations/components/EChartsRenderer/EChartsRenderer.tsx
@@ -1,7 +1,7 @@
 import type { EChartsCoreOption, EChartsType } from "echarts/core";
 import { init } from "echarts/core";
 import mergeRefs from "merge-refs";
-import { useEffect, useRef, forwardRef } from "react";
+import { forwardRef, useEffect, useRef } from "react";
 import { useMount, useUnmount, useUpdateEffect } from "react-use";
 
 import { registerEChartsModules } from "metabase/visualizations/echarts";

--- a/frontend/src/metabase/visualizations/echarts/tooltip/index.tsx
+++ b/frontend/src/metabase/visualizations/echarts/tooltip/index.tsx
@@ -1,6 +1,7 @@
 import type { EChartsType } from "echarts/core";
 import type React from "react";
 import { useEffect, useMemo } from "react";
+import _ from "underscore";
 
 import { isNotNull } from "metabase/lib/types";
 import TooltipStyles from "metabase/visualizations/components/ChartTooltip/EChartsTooltip/EChartsTooltip.module.css";
@@ -147,4 +148,19 @@ export const usePieChartValuesColorsClasses = (chartModel: PieChartModel) => {
   }, [chartModel.slices]);
 
   return useInjectSeriesColorsClasses(hexColors);
+};
+
+export const useCloseTooltipOnScroll = (
+  chartRef: React.MutableRefObject<EChartsType | undefined>,
+) => {
+  useEffect(() => {
+    const handleScroll = _.throttle(() => {
+      chartRef.current?.dispatchAction({
+        type: "hideTip",
+      });
+    }, 50);
+
+    window.addEventListener("scroll", handleScroll, true);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, [chartRef]);
 };

--- a/frontend/src/metabase/visualizations/echarts/tooltip/index.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/tooltip/index.unit.spec.ts
@@ -1,0 +1,48 @@
+import { renderHook } from "@testing-library/react-hooks";
+import type { EChartsType } from "echarts/core";
+import type { MutableRefObject } from "react";
+import _ from "underscore";
+
+import { useCloseTooltipOnScroll } from ".";
+
+describe("useCloseTooltipOnScroll", () => {
+  let chartRefMock: MutableRefObject<EChartsType | undefined>;
+
+  beforeEach(() => {
+    chartRefMock = {
+      current: {
+        dispatchAction: jest.fn(),
+      } as unknown as EChartsType,
+    };
+    jest.clearAllMocks();
+  });
+
+  it("should attach and remove scroll event listener", () => {
+    const addEventListenerSpy = jest.spyOn(window, "addEventListener");
+    const removeEventListenerSpy = jest.spyOn(window, "removeEventListener");
+
+    const { unmount } = renderHook(() => useCloseTooltipOnScroll(chartRefMock));
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith(
+      "scroll",
+      expect.any(Function),
+      true,
+    );
+    unmount();
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      "scroll",
+      expect.any(Function),
+    );
+  });
+
+  it("should hide tooltip on scroll", () => {
+    renderHook(() => useCloseTooltipOnScroll(chartRefMock));
+
+    const scrollEvent = new Event("scroll");
+    window.dispatchEvent(scrollEvent);
+
+    expect(chartRefMock.current?.dispatchAction).toHaveBeenCalledWith({
+      type: "hideTip",
+    });
+  });
+});

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
@@ -4,7 +4,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChartRenderingErrorBoundary } from "metabase/visualizations/components/ChartRenderingErrorBoundary";
 import LegendCaption from "metabase/visualizations/components/legend/LegendCaption";
 import { getLegendItems } from "metabase/visualizations/echarts/cartesian/model/legend";
-import { useCartesianChartSeriesColorsClasses } from "metabase/visualizations/echarts/tooltip";
+import {
+  useCartesianChartSeriesColorsClasses,
+  useCloseTooltipOnScroll,
+} from "metabase/visualizations/echarts/tooltip";
 import type { VisualizationProps } from "metabase/visualizations/types";
 import {
   CartesianChartLegendLayout,
@@ -94,6 +97,8 @@ function _CartesianChart(props: VisualizationProps) {
 
   const canSelectTitle = !!onChangeCardAndRun;
   const seriesColorsCss = useCartesianChartSeriesColorsClasses(chartModel);
+
+  useCloseTooltipOnScroll(chartRef);
 
   return (
     <CartesianChartRoot isQueryBuilder={isQueryBuilder}>

--- a/frontend/src/metabase/visualizations/visualizations/PieChart/PieChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/PieChart.tsx
@@ -6,7 +6,10 @@ import { getPieChartFormatters } from "metabase/visualizations/echarts/pie/forma
 import { getPieChartModel } from "metabase/visualizations/echarts/pie/model";
 import { getPieChartOption } from "metabase/visualizations/echarts/pie/option";
 import { getTooltipOption } from "metabase/visualizations/echarts/pie/tooltip";
-import { usePieChartValuesColorsClasses } from "metabase/visualizations/echarts/tooltip";
+import {
+  useCloseTooltipOnScroll,
+  usePieChartValuesColorsClasses,
+} from "metabase/visualizations/echarts/tooltip";
 import { useBrowserRenderingContext } from "metabase/visualizations/hooks/use-browser-rendering-context";
 import type { VisualizationProps } from "metabase/visualizations/types";
 
@@ -112,6 +115,8 @@ export function PieChart(props: VisualizationProps) {
         ...hoverData,
       },
     );
+
+  useCloseTooltipOnScroll(chartRef);
 
   return (
     <ChartWithLegend


### PR DESCRIPTION
### Description

Hides ECharts tooltip on scroll so it does not look stuck on dashboards.

### How to verify

- Add a cartesian and a pie chart on a dashboard
- Hover chart elements to see the tooltip
- Scroll and ensure the tooltip hides

### Demo

https://github.com/user-attachments/assets/2d00d50c-cd4b-40c7-a6fe-3b1c2588e528

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
