### PR TITLE
zoom-in-timeseries-drill: do not include :hour and :minute for DATE columns

### DIFF
--- a/src/metabase/lib/drill_thru/zoom_in_timeseries.cljc
+++ b/src/metabase/lib/drill_thru/zoom_in_timeseries.cljc
@@ -57,17 +57,6 @@
                               (filter #(contains? lib.schema.temporal-bucketing/datetime-truncation-units %))
                               (lib.temporal-bucket/available-temporal-buckets query stage field)))))
 
-(mu/defn- unit->next-unit
-  :- [:map-of
-      ::lib.schema.temporal-bucketing/unit.date-time.truncate
-      ::lib.schema.drill-thru/drill-thru.zoom-in.timeseries.next-unit]
-  [query :- ::lib.schema/query
-   stage :- :int
-   field :- :mbql.clause/field]
-  (let [units (valid-current-units query stage field)]
-    (zipmap (drop-last units)
-            (drop 1 units))))
-
 (mu/defn- matching-breakout-dimension :- [:maybe ::lib.schema.drill-thru/context.row.value]
   [query        :- ::lib.schema/query
    stage-number :- :int
@@ -86,7 +75,8 @@
    stage :- :int
    field :- :mbql.clause/field]
   (when-let [current-unit (lib.temporal-bucket/raw-temporal-bucket field)]
-    ((unit->next-unit query stage field) current-unit)))
+    (second (drop-while #(not= % current-unit)
+                        (valid-current-units query stage field)))))
 
 (mu/defn- describe-next-unit :- ::lib.schema.common/non-blank-string
   [unit :- ::lib.schema.drill-thru/drill-thru.zoom-in.timeseries.next-unit]

--- a/src/metabase/lib/drill_thru/zoom_in_timeseries.cljc
+++ b/src/metabase/lib/drill_thru/zoom_in_timeseries.cljc
@@ -49,13 +49,14 @@
    [metabase.shared.util.i18n :as i18n]
    [metabase.util.malli :as mu]))
 
-(mu/defn- valid-current-units :- [:vector ::lib.schema.temporal-bucketing/unit.date-time.truncate]
+(mu/defn- valid-current-units :- [:sequential ::lib.schema.temporal-bucketing/unit.date-time.truncate]
   [query :- ::lib.schema/query
    stage :- :int
    field :- :mbql.clause/field]
-  (into [] (reverse (eduction (map lib.temporal-bucket/raw-temporal-bucket)
-                              (filter #(contains? lib.schema.temporal-bucketing/datetime-truncation-units %))
-                              (lib.temporal-bucket/available-temporal-buckets query stage field)))))
+  (->> (lib.temporal-bucket/available-temporal-buckets query stage field)
+       (map lib.temporal-bucket/raw-temporal-bucket)
+       (filter lib.schema.temporal-bucketing/datetime-truncation-units)
+       reverse))
 
 (mu/defn- matching-breakout-dimension :- [:maybe ::lib.schema.drill-thru/context.row.value]
   [query        :- ::lib.schema/query

--- a/src/metabase/lib/drill_thru/zoom_in_timeseries.cljc
+++ b/src/metabase/lib/drill_thru/zoom_in_timeseries.cljc
@@ -75,8 +75,9 @@
    stage :- :int
    field :- :mbql.clause/field]
   (when-let [current-unit (lib.temporal-bucket/raw-temporal-bucket field)]
-    (second (drop-while #(not= % current-unit)
-                        (valid-current-units query stage field)))))
+    (->> (valid-current-units query stage field)
+         (drop-while #(not= % current-unit))
+         second)))
 
 (mu/defn- describe-next-unit :- ::lib.schema.common/non-blank-string
   [unit :- ::lib.schema.drill-thru/drill-thru.zoom-in.timeseries.next-unit]


### PR DESCRIPTION

Closes https://github.com/metabase/metabase/issues/39366

### Description

When the user attempts to drill through a DATE column, we should not return `:hour` or `:minute` drill throughs from `available-drill-thrus`. Previously we did, which resulted in an error being displayed when the user attempted to select them.

Modify `next-breakout-unit` in zoom_in_timeseries.cljc to not return :hour or :minute units for :type/Date columns, which prevents these from being returned by `available-drill-thrus`, which prevents them appearing in UI context menus.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Databases -> Sample Database -> People
2. Summarize -> Count -> Done
3. Breakout by -> Time -> BIRTH_DATE
4. Select "All Time" by "Day" at the bottom
5. Click on a datapoint in the graph
6. Verify that "See this day by hour" does *not* appear in the context menu

You can also do a similar process for a pivot table visualization, and probably 10 other ways I'm not aware of 😬.

### Demo

#### before

<img width="1323" alt="zoom-in-timeseries-before" src="https://github.com/user-attachments/assets/8f7db905-1d57-4079-9cee-33f6ee9d1086">

<img width="1322" alt="before-error" src="https://github.com/user-attachments/assets/4010cf58-5afc-4c0c-92cd-31cd7c822d30">


#### after

<img width="1325" alt="zoom-in-timeseries-after" src="https://github.com/user-attachments/assets/d1eec540-2e77-4a7f-82b6-dfb670fbbbbb">


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
