### PR TITLE
Fix 46221: Wrong collection shown in ad-hoc model-based questions

### DIFF
--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -1,5 +1,6 @@
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
+  FIRST_COLLECTION_ID,
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
@@ -44,6 +45,7 @@ import {
   navigationSidebar,
   newButton,
   tableInteractive,
+  type NativeQuestionDetails,
 } from "e2e/support/helpers";
 import type { CardId, FieldReference } from "metabase-types/api";
 
@@ -1259,4 +1261,40 @@ describe.skip("issues 28270, 33708", () => {
         .and("contain.text", "Reviews");
     });
   }
+});
+
+describe("issue 46221", () => {
+  const modelDetails: NativeQuestionDetails = {
+    name: "46221",
+    native: { query: "select 42" },
+    type: "model",
+    collection_id: FIRST_COLLECTION_ID as number,
+  };
+
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    createNativeQuestion(modelDetails, { visitQuestion: true });
+  });
+
+  it("should retain the same collection name between ad-hoc question based on a model and a model itself (metabase#46221)", () => {
+    cy.location("pathname").should("match", /^\/model\/\d+/);
+    cy.findByTestId("head-crumbs-container")
+      .should("contain", "First collection")
+      .and("contain", modelDetails.name);
+
+    cy.log("Change the viz type");
+    cy.findByTestId("viz-type-button").click();
+    cy.findByTestId("sidebar-left").within(() => {
+      cy.findByTestId("Table-button").click();
+    });
+
+    cy.log("Make sure we're now in an ad-hoc question mode");
+    cy.location("pathname").should("eq", "/question");
+
+    cy.findByTestId("head-crumbs-container")
+      .should("contain", "First collection")
+      .and("contain", modelDetails.name);
+  });
 });

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/QuestionDataSource.jsx
@@ -4,7 +4,6 @@ import { t } from "ttag";
 
 import { TableInfoIcon } from "metabase/components/MetadataInfo/TableInfoIcon/TableInfoIcon";
 import Tooltip from "metabase/core/components/Tooltip";
-import Collections from "metabase/entities/collections";
 import Questions from "metabase/entities/questions";
 import { color } from "metabase/lib/colors";
 import { isNotNull } from "metabase/lib/types";
@@ -70,38 +69,27 @@ export function QuestionDataSource({
 
   return (
     <Questions.Loader id={sourceQuestionId} loadingAndErrorWrapper={false}>
-      {({ question: sourceQuestion }) => (
-        <Collections.Loader
-          id={sourceQuestion?.collectionId()}
-          loadingAndErrorWrapper={false}
-        >
-          {({ collection, loading }) => {
-            if (!sourceQuestion || loading) {
-              return null;
-            }
-            if (
-              sourceQuestion.type() === "model" ||
-              sourceQuestion.type() === "metric"
-            ) {
-              return (
-                <SourceDatasetBreadcrumbs
-                  question={sourceQuestion}
-                  collection={collection}
-                  variant={variant}
-                  {...props}
-                />
-              );
-            }
-            return (
-              <DataSourceCrumbs
-                question={question}
-                variant={variant}
-                {...props}
-              />
-            );
-          }}
-        </Collections.Loader>
-      )}
+      {({ question: sourceQuestion }) => {
+        if (!sourceQuestion) {
+          return null;
+        }
+
+        if (
+          sourceQuestion.type() === "model" ||
+          sourceQuestion.type() === "metric"
+        ) {
+          return (
+            <SourceDatasetBreadcrumbs
+              question={sourceQuestion}
+              variant={variant}
+              {...props}
+            />
+          );
+        }
+        return (
+          <DataSourceCrumbs question={question} variant={variant} {...props} />
+        );
+      }}
     </Questions.Loader>
   );
 }

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/QuestionDataSource.jsx
@@ -2,6 +2,7 @@ import PropTypes from "prop-types";
 import { isValidElement } from "react";
 import { t } from "ttag";
 
+import { skipToken, useGetCollectionQuery } from "metabase/api";
 import { TableInfoIcon } from "metabase/components/MetadataInfo/TableInfoIcon/TableInfoIcon";
 import Tooltip from "metabase/core/components/Tooltip";
 import Questions from "metabase/entities/questions";
@@ -111,10 +112,19 @@ function DataSourceCrumbs({ question, variant, isObjectDetail, ...props }) {
 
 SourceDatasetBreadcrumbs.propTypes = {
   question: PropTypes.object.isRequired,
-  collection: PropTypes.object.isRequired,
 };
 
-function SourceDatasetBreadcrumbs({ question, collection, ...props }) {
+function SourceDatasetBreadcrumbs({ question, ...props }) {
+  const collectionId = question?.collectionId();
+
+  const { data: collection, isFetching } = useGetCollectionQuery(
+    collectionId ? { id: collectionId } : skipToken,
+  );
+
+  if (isFetching) {
+    return null;
+  }
+
   return (
     <HeadBreadcrumbs
       {...props}


### PR DESCRIPTION
Reproduces and closes #46221 

### Description
The PR fixes the wrong collection shown in the header breadcrumb for ad-hoc questions started from models.

Even though a collection was marked as a prop in `SourceDatasetBreadcrumbs`, it was missing in an ["ad-hoc question based on a model" scenario](https://github.com/metabase/metabase/pull/47008/files#diff-07451a7d6dee0bda8f57111c88091ed316b21f909d8779318401e69795c36613R61-R69).
![image](https://github.com/user-attachments/assets/258e99f2-8fbe-47ad-83b9-698c492a1ca9)


This PR moves the collection fetching logic inside that component. This also contains the logic to where it's absolutely needed.

### How to verify
- Follow the steps from the original issue.
- Run accompanied E2E test

### Demo
https://github.com/user-attachments/assets/38e00cf2-904f-439c-afef-be41baad6ec9

### Checklist
- [x] Tests have been added/updated to cover changes in this PR

### Stress-test
50/50 ✅ https://github.com/metabase/metabase/actions/runs/10471232741

### Additional notes
- This PR does not address #47006
