### PR TITLE
fix padding on setup completed step when on cloud

### DIFF
--- a/frontend/src/metabase/setup/components/CompletedStep/CompletedStep.styled.tsx
+++ b/frontend/src/metabase/setup/components/CompletedStep/CompletedStep.styled.tsx
@@ -8,6 +8,7 @@ export const StepRoot = styled.section`
   border-radius: 0.5rem;
   background-color: var(--mb-color-bg-white);
   gap: 32px;
+  margin-bottom: 1.75rem;
 `;
 
 export const StepTitle = styled.div`


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/46741

# Description
Fixed a bug caused by [make the newsletter signup a checkbox instead of a button (+122 −211)](https://github.com/metabase/metabase/pull/46783/files#diff-32fa510a1d23f2fe49fd596fc072a20377e836c9d804c3f3b51776719747de2eL8)

I removed a margin bottom that it seemingly had no visual need, but it turns out it's needed to add space between the `Completed Step` and the `CloudMigrationHelp` component, which is only visible when on cloud (you can simulate it with the CYPRESS_NO_FEATURES_TOKEN, or by changing [this line](https://github.com/metabase/metabase/blob/2e770300280f88d08c948bef3deaa973381d335b/frontend/src/metabase/setup/components/CloudMigrationHelp/CloudMigrationHelp.tsx#L15-L16))

Before
<img width="946" alt="image" src="https://github.com/user-attachments/assets/015c4108-cf60-4277-8b32-5f044215bbef">


After
<img width="908" alt="image" src="https://github.com/user-attachments/assets/f82021da-a609-4060-92ac-c1d0225ae8e4">
