### PR TITLE
docs: bring back code highlighting

### DIFF
--- a/docs/actions/custom.md
+++ b/docs/actions/custom.md
@@ -79,7 +79,7 @@ If something goes wrong, Metabase will display the error message it received fro
 
 You could write an action that would update the `plan` column for a record in the `invoices` table in the Sample Database:
 
-```
+```sql
 {% raw %}
 UPDATE invoices
 SET plan = {{ plan }}
@@ -99,7 +99,7 @@ The code in brackets `[[ ]]` makes the statement optional: the bracket-enclosed 
 
 Insert statements are pretty straightforward:
 
-```
+```sql
 {% raw %}
 INSERT INTO invoices (
   account_id
@@ -122,7 +122,7 @@ VALUES (
 
 If you get a type error when you submit a form, you may need to `CAST` the data type in the query so it matches the data type of the target field in the database. Here we're casting a value to a `boolean`:
 
-```
+```sql
 {% raw %}
 UPDATE invoices
 SET expected_invoice = CAST({{expected_invoice}} AS boolean)
@@ -134,7 +134,7 @@ WHERE id = {{id}};
 
 You can also reference saved questions in actions. Here we're taking the results of a `SELECT` statement on a saved question ("Potential customers") and inserting the results into a `people_to_write` table.
 
-```
+```sql
 {% raw %}
 WITH prospects AS {{#6-potential-customers}}
 

--- a/docs/configuring-metabase/config-file.md
+++ b/docs/configuring-metabase/config-file.md
@@ -25,7 +25,7 @@ The config file is split up into sections: `version` and `config.` Under `config
 
 Like so:
 
-```
+```yml
 version: 1
 config:
   settings:
@@ -44,7 +44,7 @@ The first user created in a Metabase instance is an Admin. The first user listed
 
 In the following example, assuming that the Metabase hasn't already been set up (which creates the first user) both users `first@example.com` and `admin@example.com` will be admins: `first@example.com` because it's the first user account on the list, and `admin@example.com` because that user has the `is_superuser` flag set to true.
 
-```
+```yml
 version: 1
 config:
   users:
@@ -69,7 +69,7 @@ If the Metabase has already been set up, then `first @example.com` will be loade
 
 On a new Metabase, the example below sets up an admin user account and one database connection.
 
-```
+```yml
 {% raw %}
 version: 1
 config:
@@ -102,7 +102,7 @@ You can also configure [uploads](../databases/uploads.md) in the config file wit
 
 Here's an example:
 
-```
+```yml
 {% raw %}
 version: 1
 config:
@@ -140,7 +140,7 @@ When loading a data model from a serialized export, you want to disable the sche
 
 To disable the initial database sync, you can add `config-from-file-sync-database` to the `settings` list and set the value to `false`. The setting `config-from-file-sync-database` must come _before_ the databases list, like so:
 
-```
+```yml
 version: 1
 config:
   settings:
@@ -157,19 +157,19 @@ In this config file, you can specify _any_ Admin setting.
 
 In general, the settings you can set in the `settings` section of this config file map to the [environment variables](./environment-variables.md), so check them out to see which settings you can use in your config file. The actual key that you include in the config file differs slightly from the format used for environment variables. For environment variables, the form is in screaming snake case, prefixed by an `MB`:
 
-```
+```txt
 MB_NAME_OF_VARIABLE
 ```
 
 Whereas in the config file, you'd translate that to:
 
-```
+```txt
 name-of-variable
 ```
 
 So for example, if you wanted to specify the `MB_EMAIL_FROM_NAME` in the `config.yml` file:
 
-```
+```yml
 version: 1
 config:
   settings:
@@ -183,7 +183,7 @@ config:
 
 Just to give you an idea for some settings, here's an incomplete list of settings you can set via the config file:
 
-```
+```txt
 application-colors
 config-from-file-sync-databases
 check-for-updates
@@ -223,6 +223,6 @@ But you can set any of the Admin settings with the config file. Check out the li
 
 Since loading from a config file is a Pro/Enterprise feature: for new installations, you'll need to supply Metabase with a token using the `MB_PREMIUM_EMBEDDING_TOKEN` environment variable.
 
-```
+```sh
 MB_PREMIUM_EMBEDDING_TOKEN="[your token]" java -jar metabase.jar
 ```

--- a/docs/configuring-metabase/fonts.md
+++ b/docs/configuring-metabase/fonts.md
@@ -66,7 +66,7 @@ To get a URL for a [Google Font](https://fonts.google.com/), visit the Google Fo
 
 We'd paste the URL [https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;700&display=swap](https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;700&display=swap) into our browser's address bar. This URL will return a response like:
 
-```
+```css
 * cyrillic-ext */
 @font-face {
   font-family: 'Roboto Mono';
@@ -109,7 +109,7 @@ Then the link you'll need is:
 
 Which follows the pattern:
 
-```
+```txt
 raw.githubusercontent.com/${user}/${repo}/${branch}/${path}
 ```
 

--- a/docs/configuring-metabase/slack.md
+++ b/docs/configuring-metabase/slack.md
@@ -32,7 +32,7 @@ You may get a warning that says:
 
 This warning is expected (Metabase is the third party here). You can click on **Configure** to see the app manifest Metabase sent along in the URL. Here is the manifest in YAML format:
 
-```
+```yml
 _metadata:
   major_version: 1
   minor_version: 1

--- a/docs/data-modeling/models.md
+++ b/docs/data-modeling/models.md
@@ -140,7 +140,7 @@ See [asking questions][question].
 
 You can refer to a model in a SQL query just like you can refer to a saved question:
 
-```
+```sql
 {% raw %}
 SELECT * FROM {{#1-customer-model}}
 {% endraw %}
@@ -148,7 +148,7 @@ SELECT * FROM {{#1-customer-model}}
 
 Or as a [common table expression (CTE)][cte]:
 
-```
+```sql
 {% raw %}
 WITH model AS {{#3807-invoice-model}}
 SELECT *

--- a/docs/databases/connections/mysql.md
+++ b/docs/databases/connections/mysql.md
@@ -113,13 +113,13 @@ You'll see the same error message when attempting to connect to the MySQL server
 
 **How to fix this:** Recreate the MySQL user with the correct host name:
 
-```
+```sql
 CREATE USER 'metabase'@'172.17.0.1' IDENTIFIED BY 'thepassword';
 ```
 
 Otherwise, if necessary, a wildcard may be used for the host name:
 
-```
+```sql
 CREATE USER 'metabase'@'%' IDENTIFIED BY 'thepassword';
 ```
 
@@ -132,7 +132,7 @@ FLUSH PRIVILEGES;
 
 Remember to drop the old user:
 
-```
+```sql
 DROP USER 'metabase'@'localhost';
 ```
 
@@ -155,21 +155,21 @@ Use the `['--default-authentication-plugin=mysql_native_password']` modifiers wh
 
 - or in docker-compose:
 
-```
+```yml
 mysql:
-    image: mysql:8.xx.xx
-    container_name: mysql
-    hostname: mysql
-    ports:
-      - 3306:3306
-    environment:
-      - "MYSQL_ROOT_PASSWORD=xxxxxx"
-      - "MYSQL_USER=metabase"
-      - "MYSQL_PASSWORD=xxxxxx"
-      - "MYSQL_DATABASE=metabase"
-    volumes:
-      - $PWD/mysql:/var/lib/mysql
-    command: ['--default-authentication-plugin=mysql_native_password']
+  image: mysql:8.xx.xx
+  container_name: mysql
+  hostname: mysql
+  ports:
+    - 3306:3306
+  environment:
+    - "MYSQL_ROOT_PASSWORD=xxxxxx"
+    - "MYSQL_USER=metabase"
+    - "MYSQL_PASSWORD=xxxxxx"
+    - "MYSQL_DATABASE=metabase"
+  volumes:
+    - $PWD/mysql:/var/lib/mysql
+  command: ["--default-authentication-plugin=mysql_native_password"]
 ```
 
 ## Further reading

--- a/docs/databases/connections/oracle.md
+++ b/docs/databases/connections/oracle.md
@@ -94,7 +94,7 @@ By default, the plugins directory is called `plugins`, and lives in the same dir
 
 For example, if you're running Metabase from a directory called `/app/`, you should move the Oracle JDBC driver JAR to `/app/plugins/`:
 
-```bash
+```txt
 # example directory structure for running Metabase with Oracle support
 /app/metabase.jar
 /app/plugins/ojdbc8.jar

--- a/docs/databases/connections/vertica.md
+++ b/docs/databases/connections/vertica.md
@@ -31,7 +31,7 @@ By default, the plugins directory is called `plugins`, and lives in the same dir
 
 For example, if you're running Metabase from a directory called `/app/`, you should move the Vertica JDBC driver JAR to `/app/plugins/`:
 
-```bash
+```txt
 # example directory structure for running Metabase with Vertica support
 /app/metabase.jar
 /app/plugins/vertica-jdbc-8.0.0-0.jar

--- a/docs/developers-guide/drivers/plugins.md
+++ b/docs/developers-guide/drivers/plugins.md
@@ -75,7 +75,7 @@ Place the JAR you built in your Metabase's `/plugins` directory, and you're off 
 
 Here's an example plugin manifest with comments to get you started on writing your own.
 
-```
+```txt
 # Basic user-facing information about the driver goes under the info: key
 info:
 

--- a/docs/embedding/static-embedding.md
+++ b/docs/embedding/static-embedding.md
@@ -166,9 +166,12 @@ This key is shared across all static embeds. Whoever has access to this key coul
 
 Dashboards are a fixed aspect ratio, so if you'd like to ensure they're automatically sized vertically to fit their contents you can use the [iFrame Resizer](https://github.com/davidjbradshaw/iframe-resizer) script. Metabase serves a copy for convenience:
 
-```
+```html
 <script src="http://metabase.example.com/app/iframeResizer.js"></script>
-<iframe src="http://metabase.example.com/embed/dashboard/TOKEN" onload="iFrameResize({}, this)"></iframe>
+<iframe
+  src="http://metabase.example.com/embed/dashboard/TOKEN"
+  onload="iFrameResize({}, this)"
+></iframe>
 ```
 
 ## Custom destinations on dashboards in static embeds

--- a/docs/installation-and-operation/running-metabase-on-docker.md
+++ b/docs/installation-and-operation/running-metabase-on-docker.md
@@ -271,10 +271,10 @@ Here is an example `docker-compose.yml` file to start a Metabase Docker containe
 
 In addition to this example yml file, you'll need to create two files:
 
-- db_user.txt
-- db_password.txt
+- `db_user.txt`
+- `db_password.txt`
 
-These files should be in the same directory as the `docker-compose.yml`. Put the db_user in the db_user.txt file, and db_password in the db_password.txt file.
+These files should be in the same directory as the `docker-compose.yml`. Put the `db_user` in the `db_user.txt` file, and db_password in the `db_password.txt` file.
 
 Notice the "\_FILE" on the environment variables that have a secret:
 
@@ -331,13 +331,13 @@ secrets:
 
 We currently support the following [environment variables](../configuring-metabase/environment-variables.md) to be used as secrets:
 
-- MB_DB_USER
-- MB_DB_PASS
-- MB_DB_CONNECTION_URI
-- MB_EMAIL_SMTP_PASSWORD
-- MB_EMAIL_SMTP_USERNAME
-- MB_LDAP_PASSWORD
-- MB_LDAP_BIND_DN
+- `MB_DB_USER`
+- `MB_DB_PASS`
+- `MB_DB_CONNECTION_URI`
+- `MB_EMAIL_SMTP_PASSWORD`
+- `MB_EMAIL_SMTP_USERNAME`
+- `MB_LDAP_PASSWORD`
+- `MB_LDAP_BIND_DN`
 
 In order for the Metabase container to read the files and use the contents as a secret, the environment variable name needs to be appended with a "\_FILE" as explained above.
 

--- a/docs/permissions/data-sandboxes.md
+++ b/docs/permissions/data-sandboxes.md
@@ -33,11 +33,11 @@ Data sandboxes show specific data to each person based on their [user attributes
 - Restrict **columns** (as well as rows) for specific people with a [custom sandbox](#custom-data-sandboxes-use-a-saved-question-to-create-a-custom-view-of-a-table) (also known as an advanced sandbox).
 
 |                                                | Basic sandbox (filter by a column in the table) | Custom sandbox (use a saved SQL question) |
-|------------------------------------------------|-------------------------------------------------|-------------------------------------------|
-| Restrict rows by filtering on a single column  | ✅                                               | ✅                                         |
-| Restrict rows by filtering on multiple columns | ❌                                               | ✅                                         |
-| Restrict columns                               | ❌                                               | ✅                                         |
-| Edit columns                                   | ❌                                               | ✅                                         |
+| ---------------------------------------------- | ----------------------------------------------- | ----------------------------------------- |
+| Restrict rows by filtering on a single column  | ✅                                              | ✅                                        |
+| Restrict rows by filtering on multiple columns | ❌                                              | ✅                                        |
+| Restrict columns                               | ❌                                              | ✅                                        |
+| Edit columns                                   | ❌                                              | ✅                                        |
 
 ### Basic data sandboxes: filter by a column in the table
 
@@ -188,25 +188,25 @@ How user attributes, SQL parameters, and custom sandboxes work together to displ
 
 A standard `WHERE` clause filters a table by setting a column to a fixed value:
 
-```
+```sql
 WHERE column_name = column_value
 ```
 
 In step 2 of the [row restriction setup](#restricting-rows-in-an-custom-sandbox-with-user-attributes) above, you'll add a SQL variable so that the `WHERE` clause will accept a dynamic value. The [SQL variable type](../questions/native-editor/sql-parameters.md#sql-variable-types) must be text, number, or date:
 
-```
+```sql
 WHERE plan = {%raw%}{{ plan_variable }}{%endraw%}
 ```
 
 In steps 9-10 of the [row restriction setup](#restricting-rows-in-an-custom-sandbox-with-user-attributes) above, you're telling Metabase to map the SQL variable `plan_variable` to a **user attribute key** (such as "User's Plan"). Metabase will use the key to look up the specific **user attribute value** (such as "Basic") associated with a person's Metabase account. When that person logs into Metabase and uses the sandboxed table, they'll see the query result that is filtered on:
 
-```
+```sql
 WHERE plan = "Basic"
 ```
 
 Note that the parameters must be required for SQL questions used to create a custom sandbox. E.g., you cannot use an optional parameter; the following won't work:
 
-```
+```sql
 [[WHERE plan = {%raw%}{{ plan_variable }}{%endraw%}]]
 ```
 

--- a/docs/questions/native-editor/referencing-saved-questions-in-queries.md
+++ b/docs/questions/native-editor/referencing-saved-questions-in-queries.md
@@ -28,7 +28,7 @@ Only the `#` and `ID` is required. Metabase just displays the model or question 
 
 The same syntax can be used in [Common Table Expressions (CTEs)](https://www.metabase.com/learn/sql-questions/sql-cte) (with SQL databases that support CTEs):
 
-```
+```sql
 WITH gizmo_orders AS {% raw %}{{#5-gizmo-orders-in-2019}}{% endraw %}
 SELECT count(*)
 FROM gizmo_orders
@@ -36,7 +36,7 @@ FROM gizmo_orders
 
 When this query is run, the `{% raw %}{{#5-gizmo-orders-in-2019}}{% endraw %}` tag will be substituted with the SQL query of the referenced question, surrounded by parentheses. So it'll look like this under the hood:
 
-```
+```sql
 WITH
   gizmo_orders AS (
     SELECT

--- a/docs/questions/native-editor/sql-parameters.md
+++ b/docs/questions/native-editor/sql-parameters.md
@@ -18,7 +18,7 @@ Field Filters, a special type of filter, have a [slightly different syntax](#fie
 
 This example defines a **Text** variable called `category`:
 
-```
+```sql
 {% raw %}
 SELECT
   count(*)
@@ -31,7 +31,7 @@ WHERE
 
 Metabase will read the variable and attach a filter widget to the query, which people can use to change the value inserted into the `cat` variable with quotes. So if someone entered "Gizmo" into the filter widget, the query Metabase would run would be:
 
-```
+```sql
 SELECT
   count(*)
 FROM
@@ -118,7 +118,7 @@ Let's say you want to create a Field Filter that filters the `People` table by s
 
 The syntax for Field Filters differs from a Text, Number, or Date variable.
 
-```
+```sql
 {% raw %}
 SELECT
   *
@@ -145,10 +145,10 @@ For a more in-depth guide, check out [Field Filters: create smart filter widgets
 
 Make sure your SQL dialect matches the database you've selected. Common issues involving how tables are quoted in the query:
 
-| Database | Dialect quirk              | Example               |
-| -------- | -------------------------- | -------------------- |
-| BigQuery | Schemas and tables must be quoted with backticks. | `` FROM `dataset.table` `` |
-| Oracle   | Schemas and tables must be quoted in double quotes.   | `FROM schema.table`  |
+| Database | Dialect quirk                                       | Example                    |
+| -------- | --------------------------------------------------- | -------------------------- |
+| BigQuery | Schemas and tables must be quoted with backticks.   | `` FROM `dataset.table` `` |
+| Oracle   | Schemas and tables must be quoted in double quotes. | `FROM schema.table`        |
 
 For more help, see [Troubleshooting SQL error messages](../../troubleshooting-guide/error-message.md#sql-editor).
 
@@ -207,7 +207,7 @@ The reason is that field filters generate SQL based on the mapped field; Metabas
 
 Your main query should be aware of all the tables that your Field Filter variable is pointing to, otherwise you'll get a SQL syntax error. For example, let's say that your main query includes a field filter like this:
 
-```
+```sql
 {% raw %}
 SELECT
   *
@@ -220,7 +220,7 @@ WHERE
 
 Let's say the `{% raw %}{{ product_category }}{% endraw %}` variable refers to another question that uses the `Products` table. For the field filter to work, you'll need to include a join to `Products` in your main query.
 
-```
+```sql
 {% raw %}
 SELECT
   *
@@ -259,7 +259,7 @@ In the variables sidebar, you can set a default value for your variable. This va
 
 You can also define default values directly in your query by enclosing comment syntax inside the end brackets of an optional parameter.
 
-```
+```sql
 WHERE column = [[ {% raw %}{{ your_parameter }}{% endraw %} --]] your_default_value
 ```
 
@@ -267,7 +267,7 @@ The comment will "activate" whenever you pass a value to `your_parameter`.
 
 This is useful when defining complex default values (for example, if your default value is a function like `CURRENT_DATE`). Here's a PostgreSQL example that sets the default value of a Date filter to the current date using `CURRENT_DATE`:
 
-```
+```sql
 {% raw %}
 SELECT
   *
@@ -297,7 +297,7 @@ To make a variable optional in your native query, put `[[ .. ]]` brackets around
 
 In this example, if no value is given to `cat`, then the query will just select all the rows from the `products` table. But if `cat` does have a value, like "Widget", then the query will only grab the products with a category type of Widget:
 
-```
+```sql
 {% raw %}
 SELECT
   count(*)
@@ -313,7 +313,7 @@ You need to make sure that your SQL is still valid when no value is passed to th
 
 For example, excluding the `WHERE` keyword from the bracketed clause will cause an error if there's no value given for `cat`:
 
-```
+```sql
 -- this will cause an error:
 {% raw %}
 SELECT
@@ -327,7 +327,7 @@ WHERE
 
 That's because when no value is given for `cat`, Metabase will try to execute SQL as if the clause in `[[ ]]` didn't exist:
 
-```
+```sql
 SELECT
   count(*)
 FROM
@@ -339,7 +339,7 @@ which is not a valid SQL query.
 
 Instead, put the entire `WHERE` clause in `[[ ]]`:
 
-```
+```sql
 {% raw %}
 SELECT
   count(*)
@@ -352,7 +352,7 @@ FROM
 
 When there's no value given for `cat`, Metabase will just execute:
 
-```
+```sql
 {% raw %}
 SELECT
   count(*)
@@ -367,7 +367,7 @@ which is still a valid query.
 
 To use multiple optional clauses, you must include at least one regular `WHERE` clause followed by optional clauses, each starting with `AND`:
 
-```
+```sql
 {% raw %}
 SELECT
   count(*)

--- a/docs/questions/native-editor/sql-snippets.md
+++ b/docs/questions/native-editor/sql-snippets.md
@@ -16,7 +16,7 @@ For example, if you frequently perform queries that involve multiple tables, you
 
 Here's a simple query with a join using the **Sample Database** included with Metabase.
 
-```
+```sql
 SELECT *
 FROM orders AS o
 LEFT JOIN products AS p
@@ -29,11 +29,11 @@ In the **SQL editor**:
 
 1. **Highlight a section of SQL** that you want to save. In this case, we'll select the following SQL code:
 
-    ```
-    orders AS o
-    LEFT JOIN products AS p
-    ON o.product_id = p.id
-    ```
+   ```sql
+   orders AS o
+   LEFT JOIN products AS p
+   ON o.product_id = p.id
+   ```
 
 2. **Right-click on the highlighted section.**
 3. **Select Save as snippet** to create a snippet. A modal will pop up with the SQL statement you highlighted.
@@ -41,7 +41,7 @@ In the **SQL editor**:
 
 In this case, we named the snippet "Orders and Products". The snippet will now be available for anyone to use. Here's what the snippet looks like in the SQL editor:
 
-```
+```sql
 SELECT *
 FROM {% raw %}{{snippet: Orders and Products}}{% endraw %}
 ```

--- a/docs/questions/native-editor/writing-sql.md
+++ b/docs/questions/native-editor/writing-sql.md
@@ -24,7 +24,7 @@ After clicking **SQL query**, you'll see an editor where you can write and run q
 
 To try it out, make sure you've selected the [Sample Database][sample-database-gloss], then paste in this short SQL query:
 
-```
+```sql
 SELECT
     sum(subtotal),
     created_at

--- a/docs/questions/sharing/visualizations/table.md
+++ b/docs/questions/sharing/visualizations/table.md
@@ -22,7 +22,7 @@ Click on a column heading and Metabase will present quick options for filtering 
 
 ### Filter by this column
 
-You can enter a value and filter the column  value:
+You can enter a value and filter the column value:
 
 Text filters:
 
@@ -99,14 +99,12 @@ You can display the text as is, or you can display the text as a link. If you se
 For example, you could create a dynamic URL using a parameter from another column in the results:
 
 ```html
-{% raw %}
-https://www.example.com/{{category}}
-{% endraw %}
+{% raw %} https://www.example.com/{{category}} {% endraw %}
 ```
 
-In the above example, Metabase would take the value for the `category` column for that row  (in this case `widget`), and insert it into the URL:
+In the above example, Metabase would take the value for the `category` column for that row (in this case `widget`), and insert it into the URL:
 
-```
+```html
 https://www.example.com/widget
 ```
 
@@ -195,11 +193,11 @@ Lets you change the unit of currency from whatever the system default is.
 
 ### Currency label style
 
- Allows you to switch between displaying the currency label as:
+Allows you to switch between displaying the currency label as:
 
- - a symbol (like $)
- - a code (like USD)
- - the full name of the currency (like "US dollars")
+- a symbol (like $)
+- a code (like USD)
+- the full name of the currency (like "US dollars")
 
 ### Where to display the unit of currency
 

--- a/docs/troubleshooting-guide/cant-see-tables.md
+++ b/docs/troubleshooting-guide/cant-see-tables.md
@@ -27,7 +27,7 @@ Sometimes your browser will show an old cached list of tables. Browser extension
 
 1. Go to the Metabase [SQL editor](../questions/native-editor/writing-sql.md).
 2. Test the connection to your database by running:
-   ```
+   ```sql
    SELECT 1
    ```
 
@@ -43,7 +43,7 @@ To make sure that your table is actually queryable by Metabase:
 
 1. Go to the Metabase [SQL editor](../questions/native-editor/writing-sql.md).
 2. Look for your table:
-   ```
+   ```sql
    SELECT *
    FROM your_table
    ```

--- a/docs/troubleshooting-guide/db-connection.md
+++ b/docs/troubleshooting-guide/db-connection.md
@@ -102,7 +102,7 @@ psql -h HOSTNAME -p PORT -d DATABASENAME -U DATABASEUSER
 
 1. Go to the Metabase [SQL editor](../questions/native-editor/writing-sql.md).
 2. Test the connection to your database by running:
-   ```
+   ```sql
    SELECT 1
    ```
 

--- a/docs/troubleshooting-guide/ldap.md
+++ b/docs/troubleshooting-guide/ldap.md
@@ -10,15 +10,15 @@ Metabase can use LDAP for authentication. [This article][ldap-learn] explains ho
 
 You can test Metabase with LDAP by using this `docker-compose` definition:
 
-```
-version: '3.7'
+```yml
+version: "3.7"
 services:
   metabase-ldap:
     image: metabase/metabase:latest
     container_name: metabase-ldap
     hostname: metabase-ldap
     volumes:
-    - /dev/urandom:/dev/random:ro
+      - /dev/urandom:/dev/random:ro
     ports:
       - 3000:3000
     networks:


### PR DESCRIPTION
A while ago i removed code highlighting from some SQL articles because wrong highlights made the code very difficult to read. With https://github.com/metabase/metabase.github.io/pull/3786, highlighting is fixed, so we can bring it back.