### PR TITLE
Add database type adjustments to server side generated temporal values

### DIFF
--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -224,7 +224,7 @@
     :TIMESTAMP                  :type/DateTime
     ;; This is a weird one. A timestamp with local time zone, stored without time zone but treated as being in the
     ;; Session time zone for filtering purposes etc.
-    :TIMESTAMPLTZ               :type/DateTime
+    :TIMESTAMPLTZ               :type/DateTimeWithTZ
     ;; timestamp with no time zone
     :TIMESTAMPNTZ               :type/DateTime
     ;; timestamp with time zone normalized to UTC, similar to Postgres

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -674,7 +674,7 @@
    (fn [^java.sql.Connection conn]
      (with-open [stmt (.prepareStatement conn (str "show parameters like 'TIMEZONE' in user"
                                                    (when-let [user (get-in database [:details :user])]
-                                                     (str " \"" user "\""))
+                                                     (str " \"" (str/replace user #"\s" "") "\""))
                                                    ";"))
                  rset (.executeQuery stmt)]
        (when (.next rset)

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -672,7 +672,10 @@
   (sql-jdbc.execute/do-with-connection-with-options
    driver database nil
    (fn [^java.sql.Connection conn]
-     (with-open [stmt (.prepareStatement conn "show parameters like 'TIMEZONE' in user;")
+     (with-open [stmt (.prepareStatement conn (str "show parameters like 'TIMEZONE' in user"
+                                                   (when-let [user (get-in database [:details :user])]
+                                                     (str " \"" user "\""))
+                                                   ";"))
                  rset (.executeQuery stmt)]
        (when (.next rset)
          (.getString rset "value"))))))

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -672,10 +672,7 @@
   (sql-jdbc.execute/do-with-connection-with-options
    driver database nil
    (fn [^java.sql.Connection conn]
-     (with-open [stmt (.prepareStatement conn (str "show parameters like 'TIMEZONE' in user"
-                                                   (when-let [user (get-in database [:details :user])]
-                                                     (str " \"" (str/replace user #"\s" "") "\""))
-                                                   ";"))
+     (with-open [stmt (.prepareStatement conn "show parameters like 'TIMEZONE' in user;")
                  rset (.executeQuery stmt)]
        (when (.next rset)
          (.getString rset "value"))))))

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -476,7 +476,9 @@
 
 (defmethod sql.qp/->honeysql [:snowflake :relative-datetime]
   [driver [_ amount unit]]
-  (qp.relative-datetime/maybe-cacheable-relative-datetime-honeysql driver unit amount))
+  (qp.relative-datetime/maybe-cacheable-relative-datetime-honeysql
+   driver unit amount
+   sql.qp/*parent-honeysql-col-type-info*))
 
 (defmethod sql.qp/->honeysql [:snowflake LocalDate]
   [_driver t]

--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -854,6 +854,8 @@
                        :base-type {:native "timestampltz"}}]
     (rows-for-good-datetimes-in-belize)]])
 
+;; The test needs user with no report timezone set and database timezone other than UTC. That's the reason for redefs
+;; prior to dataset generation.
 (deftest ^:synchronized correct-timestamp-type-querying-test
   (mt/test-driver
    :snowflake
@@ -867,32 +869,32 @@
                      (-> (original-dbdef->connection-details driver connection-type database-definition)
                          (assoc :user "BELIZE_PERSON")))]
        (mt/dataset
-        good-datetimes-in-belize
-        (testing "Expected data is returned using yesterday filter"
-          (let [belize-offset       (t/zone-offset "-06:00")
-                yesterday-first     (t/- (t/truncate-to (t/offset-date-time belize-offset) :days) (t/days 1))
-                yesterday-last      (t/+ yesterday-first (t/hours 18))
-                yesterday-first-str (t/format :iso-offset-date-time yesterday-first)
-                yesterday-last-str  (t/format :iso-offset-date-time yesterday-last)]
-            (doseq [[tested-field-kw base-type database-type]
-                    [[:IN_Z_OFFSET        :type/DateTimeWithLocalTZ "timestamptz"]
-                     [:IN_VARIOUS_OFFSETS :type/DateTimeWithLocalTZ "timestamptz"]
-                     [:JUST_NTZ           :type/DateTime            "timestampntz"]
-                     [:JUST_LTZ           :type/DateTimeWithTZ      "timestampltz"]]
-                    :let [tested-field [:field (mt/id :GOOD_DATETIMES tested-field-kw) {:base-type base-type}]]]
-             (testing (str "on column type " database-type)
-               (let [rows (mt/rows (qp/process-query
-                                    {:database (mt/id)
-                                     :type     :query
-                                     :query {:source-table (mt/id :GOOD_DATETIMES)
-                                             :fields [tested-field]
-                                             :filter [:time-interval tested-field -1 :day]
-                                             :order-by [[tested-field :asc]]}}))]
-                 (testing "Correct rows count returned"
-                   (is (= 4 (count rows))))
-                 (testing "First row has expected values"
-                   (is (= yesterday-first-str
-                          (ffirst rows))))
-                 (testing "Last row has expected values"
-                   (is (= yesterday-last-str
-                          (ffirst (reverse rows)))))))))))))))
+         good-datetimes-in-belize
+         (testing "Expected data is returned using yesterday filter"
+           (let [belize-offset       (t/zone-offset "-06:00")
+                 yesterday-first     (t/- (t/truncate-to (t/offset-date-time belize-offset) :days) (t/days 1))
+                 yesterday-last      (t/+ yesterday-first (t/hours 18))
+                 yesterday-first-str (t/format :iso-offset-date-time yesterday-first)
+                 yesterday-last-str  (t/format :iso-offset-date-time yesterday-last)]
+             (doseq [[tested-field-kw base-type database-type]
+                     [[:IN_Z_OFFSET        :type/DateTimeWithLocalTZ "timestamptz"]
+                      [:IN_VARIOUS_OFFSETS :type/DateTimeWithLocalTZ "timestamptz"]
+                      [:JUST_NTZ           :type/DateTime            "timestampntz"]
+                      [:JUST_LTZ           :type/DateTimeWithTZ      "timestampltz"]]
+                     :let [tested-field [:field (mt/id :GOOD_DATETIMES tested-field-kw) {:base-type base-type}]]]
+               (testing (str "on column type " database-type)
+                 (let [rows (mt/rows (qp/process-query
+                                      {:database (mt/id)
+                                       :type     :query
+                                       :query {:source-table (mt/id :GOOD_DATETIMES)
+                                               :fields [tested-field]
+                                               :filter [:time-interval tested-field -1 :day]
+                                               :order-by [[tested-field :asc]]}}))]
+                   (testing "Correct rows count returned"
+                     (is (= 4 (count rows))))
+                   (testing "First row has expected values"
+                     (is (= yesterday-first-str
+                            (ffirst rows))))
+                   (testing "Last row has expected values"
+                     (is (= yesterday-last-str
+                            (ffirst (reverse rows)))))))))))))))

--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -858,43 +858,43 @@
 ;; prior to dataset generation.
 (deftest ^:synchronized correct-timestamp-type-querying-test
   (mt/test-driver
-   :snowflake
-   (let [original-set-current-user-timezone! @#'test.data.snowflake/set-user-timezone!
-         original-dbdef->connection-details (get-method tx/dbdef->connection-details :snowflake)]
-     (with-redefs [test.data.snowflake/set-user-timezone!
-                   (fn [user _timezone]
-                     (original-set-current-user-timezone! user "America/Belize"))
-                   tx/dbdef->connection-details
-                   (fn [driver connection-type database-definition]
-                     (-> (original-dbdef->connection-details driver connection-type database-definition)
-                         (assoc :user "BELIZE_PERSON")))]
-       (mt/dataset
-         good-datetimes-in-belize
-         (testing "Expected data is returned using yesterday filter"
-           (let [belize-offset       (t/zone-offset "-06:00")
-                 yesterday-first     (t/- (t/truncate-to (t/offset-date-time belize-offset) :days) (t/days 1))
-                 yesterday-last      (t/+ yesterday-first (t/hours 18))
-                 yesterday-first-str (t/format :iso-offset-date-time yesterday-first)
-                 yesterday-last-str  (t/format :iso-offset-date-time yesterday-last)]
-             (doseq [[tested-field-kw base-type database-type]
-                     [[:IN_Z_OFFSET        :type/DateTimeWithLocalTZ "timestamptz"]
-                      [:IN_VARIOUS_OFFSETS :type/DateTimeWithLocalTZ "timestamptz"]
-                      [:JUST_NTZ           :type/DateTime            "timestampntz"]
-                      [:JUST_LTZ           :type/DateTimeWithTZ      "timestampltz"]]
-                     :let [tested-field [:field (mt/id :GOOD_DATETIMES tested-field-kw) {:base-type base-type}]]]
-               (testing (str "on column type " database-type)
-                 (let [rows (mt/rows (qp/process-query
-                                      {:database (mt/id)
-                                       :type     :query
-                                       :query {:source-table (mt/id :GOOD_DATETIMES)
-                                               :fields [tested-field]
-                                               :filter [:time-interval tested-field -1 :day]
-                                               :order-by [[tested-field :asc]]}}))]
-                   (testing "Correct rows count returned"
-                     (is (= 4 (count rows))))
-                   (testing "First row has expected values"
-                     (is (= yesterday-first-str
-                            (ffirst rows))))
-                   (testing "Last row has expected values"
-                     (is (= yesterday-last-str
-                            (ffirst (reverse rows)))))))))))))))
+    :snowflake
+    (let [original-set-current-user-timezone! @#'test.data.snowflake/set-user-timezone!
+          original-dbdef->connection-details (get-method tx/dbdef->connection-details :snowflake)]
+      (with-redefs [test.data.snowflake/set-user-timezone!
+                    (fn [user _timezone]
+                      (original-set-current-user-timezone! user "America/Belize"))
+                    tx/dbdef->connection-details
+                    (fn [driver connection-type database-definition]
+                      (-> (original-dbdef->connection-details driver connection-type database-definition)
+                          (assoc :user "BELIZE_PERSON")))]
+        (mt/dataset
+          good-datetimes-in-belize
+          (testing "Expected data is returned using yesterday filter"
+            (let [belize-offset       (t/zone-offset "-06:00")
+                  yesterday-first     (t/- (t/truncate-to (t/offset-date-time belize-offset) :days) (t/days 1))
+                  yesterday-last      (t/+ yesterday-first (t/hours 18))
+                  yesterday-first-str (t/format :iso-offset-date-time yesterday-first)
+                  yesterday-last-str  (t/format :iso-offset-date-time yesterday-last)]
+              (doseq [[tested-field-kw base-type database-type]
+                      [[:IN_Z_OFFSET        :type/DateTimeWithLocalTZ "timestamptz"]
+                       [:IN_VARIOUS_OFFSETS :type/DateTimeWithLocalTZ "timestamptz"]
+                       [:JUST_NTZ           :type/DateTime            "timestampntz"]
+                       [:JUST_LTZ           :type/DateTimeWithTZ      "timestampltz"]]
+                      :let [tested-field [:field (mt/id :GOOD_DATETIMES tested-field-kw) {:base-type base-type}]]]
+                (testing (str "on column type " database-type)
+                  (let [rows (mt/rows (qp/process-query
+                                       {:database (mt/id)
+                                        :type     :query
+                                        :query {:source-table (mt/id :GOOD_DATETIMES)
+                                                :fields [tested-field]
+                                                :filter [:time-interval tested-field -1 :day]
+                                                :order-by [[tested-field :asc]]}}))]
+                    (testing "Correct rows count returned"
+                      (is (= 4 (count rows))))
+                    (testing "First row has expected values"
+                      (is (= yesterday-first-str
+                             (ffirst rows))))
+                    (testing "Last row has expected values"
+                      (is (= yesterday-last-str
+                             (ffirst (reverse rows)))))))))))))))

--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -5,6 +5,7 @@
    [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [java-time.api :as t]
    [metabase.driver :as driver]
    [metabase.driver.common.parameters :as params]
    [metabase.driver.snowflake :as driver.snowflake]
@@ -811,3 +812,87 @@
           (mt/with-native-query-testing-context query
             (is (= [[1 "Red Medicine" 4 10.0646 -165.374 3 "Red"]]
                    (mt/rows (qp/process-query query))))))))))
+
+;;;;
+;;;; GOOD DATETIMES IN BELIZE
+;;;; Testing Snowflake timestamp types in relative date time filter.
+;;;; (In Belize they know no DST anymore.)
+;;;;
+
+(defn- rows-for-good-datetimes-in-belize
+  []
+  (let [belize-offset (t/zone-offset "-06:00")
+        number-of-points (* 4 3)
+        today-dt (t/truncate-to (t/offset-date-time belize-offset) :days)
+        first-dt-point (t/- today-dt (t/days 2))
+        dt-points (for [i (range number-of-points)]
+                    (t/+ first-dt-point (t/hours (* 6 i))))
+        various-offset-strs ["-10:00" "-04:00" "+02:00" "+09:00"]]
+    (mapv (fn [today-dt offset-str]
+            (vector (t/with-offset-same-instant today-dt (t/zone-offset "Z"))
+                    (t/with-offset-same-instant today-dt (t/zone-offset offset-str))
+                    (t/local-date-time today-dt)
+                    ;;;; Shift local date time for belize offset so timestamp_ltz has same instant as rest!
+                    ;;   Even though later in the test the user with America/Belize timezone does the data loading,
+                    ;;   the timestamps have to be adjusted.
+                    ;;   I believe that it is because of either (1) us hardcoding the :timestamp connection property
+                    ;;   to UTC (see the `connection-details->spec :snowflake`) or (2) the fact that the JVM timezone
+                    ;;   is set to UTC.
+                    (t/+ (t/local-date-time today-dt) (t/hours 6))))
+          dt-points
+          (cycle various-offset-strs))))
+
+;; BEWARE: No cleanup is done atm. It is expected that every CI run creates its own instance of this database.
+(mt/defdataset good-datetimes-in-belize
+  [["GOOD_DATETIMES" [{:field-name "IN_Z_OFFSET"
+                       :base-type {:native "timestamptz"}}
+                      {:field-name "IN_VARIOUS_OFFSETS"
+                       :base-type {:native "timestamptz"}}
+                      {:field-name "JUST_NTZ"
+                       :base-type {:native "timestampntz"}}
+                      {:field-name "JUST_LTZ"
+                       :base-type {:native "timestampltz"}}]
+    (rows-for-good-datetimes-in-belize)]])
+
+(deftest ^:synchronized correct-timestamp-type-querying-test
+  (mt/test-driver
+   :snowflake
+   (let [original-set-current-user-timezone! @#'test.data.snowflake/set-user-timezone!
+         original-dbdef->connection-details (get-method tx/dbdef->connection-details :snowflake)]
+     (with-redefs [test.data.snowflake/set-user-timezone!
+                   (fn [user _timezone]
+                     (original-set-current-user-timezone! user "America/Belize"))
+                   tx/dbdef->connection-details
+                   (fn [driver connection-type database-definition]
+                     (-> (original-dbdef->connection-details driver connection-type database-definition)
+                         (assoc :user "BELIZE_PERSON")))]
+       (mt/dataset
+        good-datetimes-in-belize
+        (testing "Expected data is returned using yesterday filter"
+          (let [belize-offset       (t/zone-offset "-06:00")
+                yesterday-first     (t/- (t/truncate-to (t/offset-date-time belize-offset) :days) (t/days 1))
+                yesterday-last      (t/+ yesterday-first (t/hours 18))
+                yesterday-first-str (t/format :iso-offset-date-time yesterday-first)
+                yesterday-last-str  (t/format :iso-offset-date-time yesterday-last)]
+            (doseq [[tested-field-kw base-type database-type]
+                    [[:IN_Z_OFFSET        :type/DateTimeWithLocalTZ "timestamptz"]
+                     [:IN_VARIOUS_OFFSETS :type/DateTimeWithLocalTZ "timestamptz"]
+                     [:JUST_NTZ           :type/DateTime            "timestampntz"]
+                     [:JUST_LTZ           :type/DateTimeWithTZ      "timestampltz"]]
+                    :let [tested-field [:field (mt/id :GOOD_DATETIMES tested-field-kw) {:base-type base-type}]]]
+             (testing (str "on column type " database-type)
+               (let [rows (mt/rows (qp/process-query
+                                    {:database (mt/id)
+                                     :type     :query
+                                     :query {:source-table (mt/id :GOOD_DATETIMES)
+                                             :fields [tested-field]
+                                             :filter [:time-interval tested-field -1 :day]
+                                             :order-by [[tested-field :asc]]}}))]
+                 (testing "Correct rows count returned"
+                   (is (= 4 (count rows))))
+                 (testing "First row has expected values"
+                   (is (= yesterday-first-str
+                          (ffirst rows))))
+                 (testing "Last row has expected values"
+                   (is (= yesterday-last-str
+                          (ffirst (reverse rows)))))))))))))))

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -160,8 +160,6 @@
    {:write? true}
    (fn [^java.sql.Connection conn]
      (with-open [stmt (.createStatement conn)]
-       ;; this screws the whole thing!!! atm i dont give because im only person on the server
-       ;; this will have to be resolved later
        (.execute stmt (format "ALTER USER \"%s\" SET TIMEZONE = '%s';" user timezone))))))
 
 (defmethod tx/create-db! :snowflake
@@ -173,7 +171,7 @@
     ;; Snowflake by default uses America/Los_Angeles timezone. See https://docs.snowflake.com/en/sql-reference/parameters#timezone.
     ;; We expect UTC in tests. Hence fixing [[metabase.query-processor.timezone/database-timezone-id]] (PR #36413)
     ;; produced lot of failures. Following expression addresses that, setting timezone for the test user.
-    (set-user-timezone! (:user (tx/dbdef->connection-details :snowlfake :server db-def)) "UTC")
+    (set-user-timezone! (:user (tx/dbdef->connection-details :snowflake :server db-def)) "UTC")
     ;; now call the default impl for SQL JDBC drivers
     (apply (get-method tx/create-db! :sql-jdbc/test-extensions) driver db-def options)))
 

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -160,7 +160,7 @@
    {:write? true}
    (fn [^java.sql.Connection conn]
      (with-open [stmt (.createStatement conn)]
-       (.execute stmt (format "ALTER USER \"%s\" SET TIMEZONE = '%s';" user timezone))))))
+       (.execute stmt (format "ALTER USER \"%s\" SET TIMEZONE = '%s';" (str/replace user #" " "") timezone))))))
 
 (defmethod tx/create-db! :snowflake
   [driver db-def & options]

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -1364,7 +1364,7 @@
 
 (def ^:dynamic *parent-honeysql-col-type-info*
   "To be bound in `->honeysql <driver> <op>` where op is on of {:>, :>=, :<, :<=, :=, :between}`. Its value should be
-  `{:base-type keyword? :database-type string?}`. The value is used in `->honeysql <driver> :relative-datetime,
+  `{:base-type keyword? :database-type string?}`. The value is used in `->honeysql <driver> :relative-datetime`,
   the :snowflake implementation at the time of writing, and later in the [[metabase.query-processor.util.relative-datetime/maybe-cacheable-relative-datetime-honeysql]]
   to determine (1) format of server-side generated sql temporal string and (2) the database type it should be cast to."
   nil)

--- a/src/metabase/query_processor/util/relative_datetime.clj
+++ b/src/metabase/query_processor/util/relative_datetime.clj
@@ -38,7 +38,7 @@
   `base-type`. When values are not present, use sane defaults."
   [driver unit amount
    & {:keys [base-type database-type]
-      :or {base-type     :type/DateTime
+      :or {base-type     :type/DateTimeWithTZ
            database-type "timestamp"}}]
   (if (use-server-side-relative-datetime? unit)
     (h2x/cast database-type (relative-datetime-sql-str unit amount base-type))

--- a/src/metabase/query_processor/util/relative_datetime.clj
+++ b/src/metabase/query_processor/util/relative_datetime.clj
@@ -1,9 +1,11 @@
 (ns metabase.query-processor.util.relative-datetime
   "Utility function for server side relative datetime computation."
   (:require
+   [java-time.api :as t]
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.query-processor.timezone :as qp.timezone]
-   [metabase.util.date-2 :as u.date]))
+   [metabase.util.date-2 :as u.date]
+   [metabase.util.honey-sql-2 :as h2x]))
 
 (defn- use-server-side-relative-datetime?
   "Check whether :relative-datetime clause could be computed server side. True for [[u.date/add-units]] greater than
@@ -11,24 +13,33 @@
   [unit]
   (contains? #{:day :week :month :quarter :year} unit))
 
+(defn- maybe-truncate-dt-value
+  [dt col-base-type]
+  (condp #(isa? %2 %1) col-base-type
+    :type/DateTimeWithTZ dt
+    :type/DateTime       (t/local-date-time dt)
+    :type/Date           (t/local-date dt)))
+
 (defn- relative-datetime-sql-str
   "Compute relative datetime from [[qp.timezone/now]] shifted by `unit` and `amount`. Format the resulting value
    to literal string compatible with most sql databases, to avoid possible jdbc driver timezone conversions."
-  [unit amount]
+  [unit amount base-type]
   (-> (qp.timezone/now)
       (u.date/truncate unit)
       (u.date/add unit amount)
+      (maybe-truncate-dt-value base-type)
       (u.date/format-sql)))
 
-;; NOTE: At the time of writing, we are supporting Snowflake and Redshift which could share the logic.
 (defn maybe-cacheable-relative-datetime-honeysql
   "Return honeysql form for relative datetime clasue, that is cacheable -- values of `getdate` or `current_timestamp`
-   are computed server side."
-  [driver unit amount]
+   are computed server side.
+
+  Adjust the values to type of the column that is used in comparison to relative-datetime using `database-type` and
+  `base-type`. When values are not present, use sane defaults."
+  [driver unit amount
+   & {:keys [base-type database-type]
+      :or {base-type     :type/DateTime
+           database-type "timestamp"}}]
   (if (use-server-side-relative-datetime? unit)
-    ;; In Snowflake, timestamp is user-specified alias to timestamp_ntz (default), timestamp_ltz or timestamp_tz.
-    ;; For more info see the docs: https://docs.snowflake.com/en/sql-reference/data-types-datetime#timestamp
-    ;; We do not have to care which timestamp is currently aliased, because [[relative-datetime-sql-str]]
-    ;; generates the now timestamp in the same timezone as `current_timestamp` or `getdate` function would.
-    [:cast (relative-datetime-sql-str unit amount) :timestamp]
+    (h2x/cast database-type (relative-datetime-sql-str unit amount base-type))
     ((get-method sql.qp/->honeysql [:sql :relative-datetime]) driver [:relative-datetime amount unit])))


### PR DESCRIPTION
Closes #46924

This PR fixes casting of timestamps to server side relative datetime logic on Snowflake. Datetime are casted to type of corresponding field.