### PR TITLE
Include collection path in the app bar for metrics

### DIFF
--- a/frontend/src/metabase/selectors/app.ts
+++ b/frontend/src/metabase/selectors/app.ts
@@ -37,6 +37,7 @@ const PATHS_WITHOUT_NAVBAR = [
 const PATHS_WITH_COLLECTION_BREADCRUMBS = [
   /\/question\//,
   /\/model\//,
+  /\/metric\//,
   /\/dashboard\//,
 ];
 const PATHS_WITH_QUESTION_LINEAGE = [/\/question/, /\/model/];


### PR DESCRIPTION
Related to #47006, but does not fully resolve it.
It simply adds a collection breadcrumb to the app bar for metrics.