### PR TITLE
bump onboarding version to 1.3.0

### DIFF
--- a/frontend/src/metabase/setup/analytics.ts
+++ b/frontend/src/metabase/setup/analytics.ts
@@ -3,7 +3,7 @@ import type { UsageReason } from "metabase-types/api";
 
 import type { SetupStep } from "./types";
 
-const ONBOARDING_VERSION = "1.2.0";
+const ONBOARDING_VERSION = "1.3.0";
 const SETUP_SCHEMA_VERSION = "1-0-3";
 const SETTINGS_SCHEMA_VERSION = "1-0-2";
 


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/46741

[notion thread](https://www.notion.so/Reduce-the-number-of-choices-in-onboarding-flow-f74849658dce4cceb9a9fd33b243f820?d=a3f0972fcf7a42939106f0e09f4aa6f6&pvs=4#a62f60c6438f4f55a3831c812e5c21b3)

This updates the onboarding version to 1.3.0.

The new onboarding version includes the changes from [Reduce the number of choices in onboarding flow](https://www.notion.so/metabase/Reduce-the-number-of-choices-in-onboarding-flow-f74849658dce4cceb9a9fd33b243f820):
- [make the newsletter signup a checkbox instead of a button (+122 −211)](https://github.com/metabase/metabase/pull/46783) 
- [skip analytics opt out step for people on cloud (+191 −25)](https://github.com/metabase/metabase/pull/46965)