### PR TITLE
Strip model cache tables from query analysis

### DIFF
--- a/src/metabase/query_analysis/native_query_analyzer.clj
+++ b/src/metabase/query_analysis/native_query_analyzer.clj
@@ -259,6 +259,11 @@
 (defn- mark-reference [refs explicit?]
   (map #(assoc % :explicit-reference explicit?) refs))
 
+(defn- strip-model-refs [refs]
+  (remove (fn [{s :schema}]
+            (and s (str/starts-with? s "metabase_cache_")))
+          refs))
+
 (defn- references-for-sql
   "Returns a `{:explicit #{...} :implicit #{...}}` map with field IDs that (may) be referenced in the given card's
   query. Errs on the side of optimism: i.e., it may return fields that are *not* in the query, and is unlikely to fail
@@ -277,8 +282,8 @@
                           (set/difference explicit-refs))
         field-refs    (concat (mark-reference explicit-refs true)
                               (mark-reference implicit-refs false))]
-    {:tables table-refs
-     :fields field-refs}))
+    {:tables (strip-model-refs table-refs)
+     :fields (strip-model-refs field-refs)}))
 
 (defn references-for-native
   "Returns a `{:explicit #{...} :implicit #{...}}` map with field IDs that (may) be referenced in the given card's


### PR DESCRIPTION
### Description

This adds a quick hack to make sure we don't report false positives for unknown tables, due to references to cached cards.

