### PR TITLE
Improve Query Analysis sweeper scheduling

### DIFF
--- a/src/metabase/task.clj
+++ b/src/metabase/task.clj
@@ -224,8 +224,17 @@
         (log/debug "Job already exists:" (-> ^JobDetail job .getKey .getName))
         (reschedule-task! job trigger)))))
 
+(mu/defn trigger-now!
+  "Immediatley trigger exeuction of task"
+  [job-key :- (ms/InstanceOfClass JobKey)]
+  (try
+    (when-let [scheduler (scheduler)]
+        (.triggerJob scheduler job-key))
+      (catch Throwable e
+        (log/errorf e "Failed to trigger immediate execution of task %s" job-key))))
+
 (mu/defn delete-task!
-  "delete a task from the scheduler"
+  "Delete a task from the scheduler"
   [job-key :- (ms/InstanceOfClass JobKey) trigger-key :- (ms/InstanceOfClass TriggerKey)]
   (when-let [scheduler (scheduler)]
     (qs/delete-trigger scheduler trigger-key)

--- a/src/metabase/task/sweep_query_analysis.clj
+++ b/src/metabase/task/sweep_query_analysis.clj
@@ -87,17 +87,22 @@
     (sweep-query-analysis-loop!)))
 
 (defmethod task/init! ::SweepQueryAnalysis [_]
-  (let [job     (jobs/build
+  (let [job-key (jobs/key "metabase.task.backfill-query-fields.job")
+        job     (jobs/build
                   (jobs/of-type SweepQueryAnalysis)
-                  (jobs/with-identity (jobs/key "metabase.task.backfill-query-fields.job"))
-                  (jobs/store-durably))
+                  (jobs/with-identity job-key)
+                  (jobs/store-durably)
+                  (jobs/request-recovery))
         trigger (triggers/build
                   (triggers/with-identity (triggers/key "metabase.task.backfill-query-fields.trigger"))
                   (triggers/start-now)
                   (triggers/with-schedule
-                   (cron/schedule
-                    (cron/cron-schedule
-                     ;; run every 4 hours at a random minute:
-                     (format "0 %d 0/4 1/1 * ? *" (rand-int 60)))
-                    (cron/with-misfire-handling-instruction-do-nothing))))]
-    (task/schedule-task! job trigger)))
+                    (cron/schedule
+                      (cron/cron-schedule
+                       ;; run every 4 hours at a random minute:
+                       (format "0 %d 0/4 1/1 * ? *" (rand-int 60)))
+                      (cron/with-misfire-handling-instruction-ignore-misfires))))]
+    ;; Schedule the repeats
+    (task/schedule-task! job trigger)
+    ;; Don't wait, try to kick it off immediately
+    (task/trigger-now! job-key)))


### PR DESCRIPTION
### Description

This tweaks the way that we schedule background query analysis.

1. Always run immediately on start-up, unless its already running on another instance.
2. If we're still running when a trigger fires, start immediately again once it finishes.

This should help with staleness and gaps on new deployments.