### PR TITLE
fix(#46893) - Sharing popover in query builder view should be next to button

### DIFF
--- a/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
@@ -279,6 +279,54 @@ describe("#39152 sharing an unsaved question", () => {
   });
 });
 
+describe("metabase#46893 - popover should appear next to button, not at the top left of the page", () => {
+  it("should show the public link popover next to the dashboard sharing button", () => {
+    restore();
+    cy.signInAsAdmin();
+    cy.request("PUT", "/api/setting/enable-public-sharing", { value: true });
+
+    createResource("dashboard").then(({ body: { id } }) => {
+      createPublicDashboardLink(id);
+      visitDashboard(id);
+    });
+
+    cy.findByTestId("resource-embed-button").click();
+
+    cy.findByTestId("embed-header-menu").then($menu => {
+      cy.findByTestId("resource-embed-button").then($button => {
+        const menuRect = $menu[0].getBoundingClientRect();
+        const buttonRect = $button[0].getBoundingClientRect();
+
+        expect(menuRect.left).to.be.closeTo(buttonRect.left, 20);
+        expect(menuRect.top).to.be.closeTo(buttonRect.bottom, 20);
+      });
+    });
+  });
+
+  it("should show the public link popover next to the question sharing button", () => {
+    restore();
+    cy.signInAsAdmin();
+    cy.request("PUT", "/api/setting/enable-public-sharing", { value: true });
+
+    createResource("question").then(({ body: { id } }) => {
+      createPublicQuestionLink(id);
+      visitQuestion(id);
+    });
+
+    cy.findByTestId("resource-embed-button").click();
+
+    cy.findByTestId("embed-header-menu").then($menu => {
+      cy.findByTestId("resource-embed-button").then($button => {
+        const menuRect = $menu[0].getBoundingClientRect();
+        const buttonRect = $button[0].getBoundingClientRect();
+
+        expect(menuRect.right).to.be.closeTo(buttonRect.right, 20);
+        expect(menuRect.bottom).to.be.closeTo(buttonRect.top, 20);
+      });
+    });
+  });
+});
+
 ["dashboard", "question"].forEach(resource => {
   describeWithSnowplow(`public ${resource} sharing snowplow events`, () => {
     beforeEach(() => {

--- a/frontend/src/metabase/components/ViewFooterButton/ViewFooterButton.tsx
+++ b/frontend/src/metabase/components/ViewFooterButton/ViewFooterButton.tsx
@@ -17,12 +17,12 @@ export type ViewFooterButtonProps = {
 
 export const ViewFooterButton = forwardRef(function _ViewFooterButton(
   { icon, tooltipLabel, ...actionIconProps }: ViewFooterButtonProps,
-  ref: Ref<HTMLButtonElement>,
+  ref: Ref<HTMLDivElement>,
 ) {
   return (
     <Tooltip label={tooltipLabel}>
-      <Center>
-        <ActionIcon ref={ref} variant="viewFooter" {...actionIconProps}>
+      <Center ref={ref}>
+        <ActionIcon variant="viewFooter" {...actionIconProps}>
           <Icon size={18} name={icon} />
         </ActionIcon>
       </Center>

--- a/frontend/src/metabase/dashboard/components/EmbedMenu/AdminEmbedMenu.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/EmbedMenu/AdminEmbedMenu.styled.tsx
@@ -1,7 +1,0 @@
-import styled from "@emotion/styled";
-
-import { Menu } from "metabase/ui";
-
-export const AdminEmbedMenuContainer = styled(Menu.Dropdown)`
-  overflow: auto;
-`;

--- a/frontend/src/metabase/dashboard/components/EmbedMenu/AdminEmbedMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/EmbedMenu/AdminEmbedMenu.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { t } from "ttag";
 
+import CS from "metabase/css/core/index.css";
 import type {
   EmbedMenuModes,
   EmbedMenuProps,
@@ -14,8 +15,6 @@ import { ResourceEmbedButton } from "metabase/public/components/ResourceEmbedBut
 import { ViewFooterSharingButton } from "metabase/query_builder/components/view/ViewFooterSharingButton";
 import { getSetting } from "metabase/selectors/settings";
 import { Center, Icon, Menu, Stack, Text, Title } from "metabase/ui";
-
-import { AdminEmbedMenuContainer } from "./AdminEmbedMenu.styled";
 
 export const AdminEmbedMenu = ({
   resource,
@@ -59,9 +58,15 @@ export const AdminEmbedMenu = ({
 
   return (
     <Menu withinPortal position="bottom-start">
-      <Menu.Target>{target}</Menu.Target>
+      <Menu.Target>
+        <Center>{target}</Center>
+      </Menu.Target>
 
-      <AdminEmbedMenuContainer w="13.75rem" data-testid="embed-header-menu">
+      <Menu.Dropdown
+        className={CS.overflowAuto}
+        w="13.75rem"
+        data-testid="embed-header-menu"
+      >
         <Menu.Item
           data-testid="embed-menu-public-link-item"
           py={isPublicSharingEnabled ? "md" : "sm"}
@@ -105,7 +110,7 @@ export const AdminEmbedMenu = ({
             </Stack>
           )}
         </Menu.Item>
-      </AdminEmbedMenuContainer>
+      </Menu.Dropdown>
     </Menu>
   );
 };


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/46893

### Description

Ensures that there's a ref-able container in the `AdminEmbedMenu` component to ensure that the sharing popover has a `ref` it can attach to, ensuring that its position is right next to the button.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Login as an admin
2. Ensure public sharing is enabled
3. Go to a question
4. On the bottom right, click on the share button (tooltip should say Sharing or Embedding)
5. The popover should be right next to the button, not at the top left of the screen

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
