### PR TITLE
Make sure we insert special segmented permission paths for sandboxed tables on downgrade to 49

### DIFF
--- a/resources/migrations/permissions/rollback/data_access.sql
+++ b/resources/migrations/permissions/rollback/data_access.sql
@@ -17,6 +17,7 @@ WHERE dp.perm_type = 'perms/data-access'
   AND dp.perm_value = 'block'
   AND dp.table_id IS NULL;
 
+-- Insert unrestricted permissions for tables, excluding those with sandboxed permissions
 INSERT INTO permissions (object, group_id)
 SELECT concat('/db/',
               dp.db_id,
@@ -27,6 +28,23 @@ SELECT concat('/db/',
               '/'),
        dp.group_id
 FROM data_permissions dp
+LEFT JOIN sandboxes sb ON dp.table_id = sb.table_id AND dp.group_id = sb.group_id
 WHERE dp.perm_type = 'perms/data-access'
   AND dp.perm_value = 'unrestricted'
-AND dp.table_id IS NOT NULL;
+  AND dp.table_id IS NOT NULL
+  AND sb.table_id IS NULL;
+
+-- Insert segmented permission paths for sandboxed tables
+INSERT INTO permissions (object, group_id)
+SELECT concat('/db/',
+              dp.db_id,
+              '/schema/',
+              replace(replace(dp.schema_name, '\', '\\'), '/', '\/'),
+              '/table/',
+              dp.table_id,
+              '/query/segmented/'),
+       dp.group_id
+FROM sandboxes sb
+JOIN data_permissions dp ON sb.table_id = dp.table_id AND sb.group_id = dp.group_id
+WHERE dp.perm_type = 'perms/data-access'
+  AND dp.table_id IS NOT NULL;

--- a/resources/migrations/permissions/rollback/data_access.sql
+++ b/resources/migrations/permissions/rollback/data_access.sql
@@ -1,13 +1,21 @@
 DELETE FROM permissions WHERE object LIKE '/db/%' AND object NOT LIKE '/db/%/native/';
 DELETE FROM permissions WHERE object LIKE '/block/db/%';
 
+-- Insert unrestricted permissions for databases, excluding those with sandboxed tables
 INSERT INTO permissions (object, group_id)
 SELECT concat('/db/', dp.db_id, '/schema/'),
        dp.group_id
 FROM data_permissions dp
 WHERE dp.perm_type = 'perms/data-access'
   AND dp.perm_value = 'unrestricted'
-  AND dp.table_id IS NULL;
+  AND dp.table_id IS NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM sandboxes sb
+    JOIN metabase_table mt ON sb.table_id = mt.id
+    WHERE mt.db_id = dp.db_id
+      AND sb.group_id = dp.group_id
+);
 
 INSERT INTO permissions (object, group_id)
 SELECT concat('/block/db/', dp.db_id, '/'),
@@ -34,17 +42,43 @@ WHERE dp.perm_type = 'perms/data-access'
   AND dp.table_id IS NOT NULL
   AND sb.table_id IS NULL;
 
+-- Insert unrestricted permissions for every table in a DB if the DB has unrestricted access and any table in the DB has a sandbox,
+-- excluding the sandboxed tables themselves
+INSERT INTO permissions (object, group_id)
+SELECT concat('/db/',
+              mt.db_id,
+              '/schema/',
+              replace(replace(mt.schema, '\', '\\'), '/', '\/'),
+              '/table/',
+              mt.id,
+              '/'),
+       dp.group_id
+FROM metabase_table mt
+JOIN data_permissions dp ON mt.db_id = dp.db_id
+WHERE dp.perm_type = 'perms/data-access'
+  AND dp.perm_value = 'unrestricted'
+  AND dp.table_id IS NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM sandboxes sb
+    WHERE sb.table_id = mt.id
+  )
+  AND EXISTS (
+    SELECT 1
+    FROM sandboxes sb2
+    JOIN metabase_table mt2 ON sb2.table_id = mt2.id
+    WHERE mt2.db_id = mt.db_id
+  );
+
 -- Insert segmented permission paths for sandboxed tables
 INSERT INTO permissions (object, group_id)
 SELECT concat('/db/',
-              dp.db_id,
+              mt.db_id,
               '/schema/',
-              replace(replace(dp.schema_name, '\', '\\'), '/', '\/'),
+              replace(replace(mt.schema, '\', '\\'), '/', '\/'),
               '/table/',
-              dp.table_id,
+              sb.table_id,
               '/query/segmented/'),
-       dp.group_id
+       sb.group_id
 FROM sandboxes sb
-JOIN data_permissions dp ON sb.table_id = dp.table_id AND sb.group_id = dp.group_id
-WHERE dp.perm_type = 'perms/data-access'
-  AND dp.table_id IS NOT NULL;
+JOIN metabase_table mt ON sb.table_id = mt.id;

--- a/resources/migrations/permissions/rollback/data_access.sql
+++ b/resources/migrations/permissions/rollback/data_access.sql
@@ -25,23 +25,6 @@ WHERE dp.perm_type = 'perms/data-access'
   AND dp.perm_value = 'block'
   AND dp.table_id IS NULL;
 
--- Insert unrestricted permissions for tables, excluding those with sandboxed permissions
-INSERT INTO permissions (object, group_id)
-SELECT concat('/db/',
-              dp.db_id,
-              '/schema/',
-              replace(replace(dp.schema_name, '\', '\\'), '/', '\/'),
-              '/table/',
-              dp.table_id,
-              '/'),
-       dp.group_id
-FROM data_permissions dp
-LEFT JOIN sandboxes sb ON dp.table_id = sb.table_id AND dp.group_id = sb.group_id
-WHERE dp.perm_type = 'perms/data-access'
-  AND dp.perm_value = 'unrestricted'
-  AND dp.table_id IS NOT NULL
-  AND sb.table_id IS NULL;
-
 -- Insert unrestricted permissions for every table in a DB if the DB has unrestricted access and any table in the DB has a sandbox,
 -- excluding the sandboxed tables themselves
 INSERT INTO permissions (object, group_id)
@@ -62,12 +45,14 @@ WHERE dp.perm_type = 'perms/data-access'
     SELECT 1
     FROM sandboxes sb
     WHERE sb.table_id = mt.id
+    AND sb.group_id = dp.group_id
   )
   AND EXISTS (
     SELECT 1
     FROM sandboxes sb2
     JOIN metabase_table mt2 ON sb2.table_id = mt2.id
     WHERE mt2.db_id = mt.db_id
+    AND sb2.group_id = dp.group_id
   );
 
 -- Insert segmented permission paths for sandboxed tables

--- a/resources/migrations/permissions/rollback/data_access.sql
+++ b/resources/migrations/permissions/rollback/data_access.sql
@@ -25,6 +25,23 @@ WHERE dp.perm_type = 'perms/data-access'
   AND dp.perm_value = 'block'
   AND dp.table_id IS NULL;
 
+-- Insert unrestricted permissions for tables, excluding those with sandboxed permissions
+INSERT INTO permissions (object, group_id)
+SELECT concat('/db/',
+              dp.db_id,
+              '/schema/',
+              replace(replace(dp.schema_name, '\', '\\'), '/', '\/'),
+              '/table/',
+              dp.table_id,
+              '/'),
+       dp.group_id
+FROM data_permissions dp
+LEFT JOIN sandboxes sb ON dp.table_id = sb.table_id AND dp.group_id = sb.group_id
+WHERE dp.perm_type = 'perms/data-access'
+  AND dp.perm_value = 'unrestricted'
+  AND dp.table_id IS NOT NULL
+  AND sb.table_id IS NULL;
+
 -- Insert unrestricted permissions for every table in a DB if the DB has unrestricted access and any table in the DB has a sandbox,
 -- excluding the sandboxed tables themselves
 INSERT INTO permissions (object, group_id)

--- a/resources/migrations/permissions/rollback/mysql_data_access.sql
+++ b/resources/migrations/permissions/rollback/mysql_data_access.sql
@@ -1,12 +1,21 @@
 DELETE FROM permissions WHERE object LIKE '/db/%' AND object NOT LIKE '/db/%/native/';
+DELETE FROM permissions WHERE object LIKE '/block/db/%';
 
+-- Insert unrestricted permissions for databases, excluding those with sandboxed tables
 INSERT INTO permissions (object, group_id)
 SELECT concat('/db/', dp.db_id, '/schema/'),
        dp.group_id
 FROM data_permissions dp
 WHERE dp.perm_type = 'perms/data-access'
   AND dp.perm_value = 'unrestricted'
-  AND dp.table_id IS NULL;
+  AND dp.table_id IS NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM sandboxes sb
+    JOIN metabase_table mt ON sb.table_id = mt.id
+    WHERE mt.db_id = dp.db_id
+      AND sb.group_id = dp.group_id
+);
 
 INSERT INTO permissions (object, group_id)
 SELECT concat('/block/db/', dp.db_id, '/'),
@@ -16,6 +25,7 @@ WHERE dp.perm_type = 'perms/data-access'
   AND dp.perm_value = 'block'
   AND dp.table_id IS NULL;
 
+-- Insert unrestricted permissions for tables, excluding those with sandboxed permissions
 INSERT INTO permissions (object, group_id)
 SELECT concat('/db/',
               dp.db_id,
@@ -26,6 +36,51 @@ SELECT concat('/db/',
               '/'),
        dp.group_id
 FROM data_permissions dp
+LEFT JOIN sandboxes sb ON dp.table_id = sb.table_id AND dp.group_id = sb.group_id
 WHERE dp.perm_type = 'perms/data-access'
   AND dp.perm_value = 'unrestricted'
-AND dp.table_id IS NOT NULL;
+  AND dp.table_id IS NOT NULL
+  AND sb.table_id IS NULL;
+
+-- Insert unrestricted permissions for every table in a DB if the DB has unrestricted access and any table in the DB has a sandbox,
+-- excluding the sandboxed tables themselves
+INSERT INTO permissions (object, group_id)
+SELECT concat('/db/',
+              mt.db_id,
+              '/schema/',
+              replace(replace(mt.schema, '\\', '\\\\'), '/', '\\/'),
+              '/table/',
+              mt.id,
+              '/'),
+       dp.group_id
+FROM metabase_table mt
+JOIN data_permissions dp ON mt.db_id = dp.db_id
+WHERE dp.perm_type = 'perms/data-access'
+  AND dp.perm_value = 'unrestricted'
+  AND dp.table_id IS NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM sandboxes sb
+    WHERE sb.table_id = mt.id
+    AND sb.group_id = dp.group_id
+  )
+  AND EXISTS (
+    SELECT 1
+    FROM sandboxes sb2
+    JOIN metabase_table mt2 ON sb2.table_id = mt2.id
+    WHERE mt2.db_id = mt.db_id
+    AND sb2.group_id = dp.group_id
+  );
+
+-- Insert segmented permission paths for sandboxed tables
+INSERT INTO permissions (object, group_id)
+SELECT concat('/db/',
+              mt.db_id,
+              '/schema/',
+              replace(replace(mt.schema, '\\', '\\\\'), '/', '\\/'),
+              '/table/',
+              sb.table_id,
+              '/query/segmented/'),
+       sb.group_id
+FROM sandboxes sb
+JOIN metabase_table mt ON sb.table_id = mt.id;

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -2076,6 +2076,12 @@
                                                                                 :created_at :%now
                                                                                 :updated_at :%now
                                                                                 :active     true})
+              table-id-3 (t2/insert-returning-pk! (t2/table-name :model/Table) {:db_id      db-id
+                                                                                :schema     "SchemaName"
+                                                                                :name       "Table 3"
+                                                                                :created_at :%now
+                                                                                :updated_at :%now
+                                                                                :active     true})
               group-id   (t2/insert-returning-pk! (t2/table-name :model/PermissionsGroup) {:name "Test Group"})
               perm-id-1  (t2/insert-returning-pk! (t2/table-name :model/Permissions)
                                                   {:object   (format "/db/%d/schema/SchemaName/table/%d/query/segmented/" db-id table-id-1)
@@ -2084,7 +2090,7 @@
                                                   {:object (format "/db/%d/schema/SchemaName/table/%d/query/segmented/" db-id table-id-2)
                                                    :group_id group-id})
               _          (t2/insert-returning-pk! (t2/table-name :model/Permissions)
-                                                  {:object (format "/db/%d/schema/SchemaName/table/%d/" db-id table-id-2)
+                                                  {:object (format "/db/%d/schema/SchemaName/table/%d/" db-id table-id-3)
                                                    :group_id group-id})
               _          (t2/query-one {:insert-into :sandboxes
                                         :values      [{:group_id             group-id
@@ -2104,7 +2110,8 @@
           (migrate! :down 49)
           (is (=? expected (t2/select-one :sandboxes :table_id table-id-1)))
           (is (= #{(format "/db/%d/schema/SchemaName/table/%d/query/segmented/" db-id table-id-1)
-                   (format "/db/%d/schema/SchemaName/table/%d/query/segmented/" db-id table-id-2)}
+                   (format "/db/%d/schema/SchemaName/table/%d/query/segmented/" db-id table-id-2)
+                   (format "/db/%d/schema/SchemaName/table/%d/" db-id table-id-3)}
                  (t2/select-fn-set :object (t2/table-name :model/Permissions) :group_id group-id))))))))
 
 (deftest view-count-test

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -2059,24 +2059,24 @@
     (testing "Can we rollback to 49 when sandboxing is configured"
       (impl/test-migrations ["v50.2024-01-10T03:27:29" "v50.2024-06-20T13:21:30"] [migrate!]
         (clear-permissions!)
-        (let [db-id      (first (t2/insert-returning-pks! (t2/table-name :model/Database) {:name       "DB"
-                                                                                           :engine     "h2"
-                                                                                           :created_at :%now
-                                                                                           :updated_at :%now
-                                                                                           :details    "{}"}))
-              table-id-1 (first (t2/insert-returning-pks! (t2/table-name :model/Table) {:db_id      db-id
-                                                                                        :schema     "SchemaName"
-                                                                                        :name       "Table 1"
-                                                                                        :created_at :%now
-                                                                                        :updated_at :%now
-                                                                                        :active     true}))
-              table-id-2 (first (t2/insert-returning-pks! (t2/table-name :model/Table) {:db_id      db-id
-                                                                                        :schema     "SchemaName"
-                                                                                        :name       "Table 2"
-                                                                                        :created_at :%now
-                                                                                        :updated_at :%now
-                                                                                        :active     true}))
-              group-id   (first (t2/insert-returning-pks! (t2/table-name :model/PermissionsGroup) {:name "Test Group"}))
+        (let [db-id      (t2/insert-returning-pk! (t2/table-name :model/Database) {:name       "DB"
+                                                                                   :engine     "h2"
+                                                                                   :created_at :%now
+                                                                                   :updated_at :%now
+                                                                                   :details    "{}"})
+              table-id-1 (t2/insert-returning-pk! (t2/table-name :model/Table) {:db_id      db-id
+                                                                                :schema     "SchemaName"
+                                                                                :name       "Table 1"
+                                                                                :created_at :%now
+                                                                                :updated_at :%now
+                                                                                :active     true})
+              table-id-2 (t2/insert-returning-pk! (t2/table-name :model/Table) {:db_id      db-id
+                                                                                :schema     "SchemaName"
+                                                                                :name       "Table 2"
+                                                                                :created_at :%now
+                                                                                :updated_at :%now
+                                                                                :active     true})
+              group-id   (t2/insert-returning-pk! (t2/table-name :model/PermissionsGroup) {:name "Test Group"})
               perm-id-1  (t2/insert-returning-pk! (t2/table-name :model/Permissions)
                                                   {:object   (format "/db/%d/schema/SchemaName/table/%d/query/segmented/" db-id table-id-1)
                                                    :group_id group-id})


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/47082

Adjusts permissions rollback to handle sandboxing better:
* If a table is sandboxed, we add a `/query/segmented/` permission path on the rollback so that it will be included properly in the permissions graph on 49
* If at least one table in a DB is sandboxed, and all the other tables are unrestricted, we need to add granular permission paths for the non-sandboxed tables.