### PR TITLE
Use the initial `originalQuestion` in the `saveModal`

### DIFF
--- a/e2e/test/scenarios/question/saved.cy.spec.js
+++ b/e2e/test/scenarios/question/saved.cy.spec.js
@@ -7,6 +7,7 @@ import {
   appBar,
   collectionOnTheGoModal,
   entityPickerModal,
+  entityPickerModalTab,
   modal,
   openNotebook,
   openOrdersTable,
@@ -294,6 +295,30 @@ describe("scenarios > question > saved", () => {
       // scrollHeight: height of the text content, including content not visible on the screen
       const heightDifference = $el[0].clientHeight - $el[0].scrollHeight;
       expect(heightDifference).to.eq(0);
+    });
+  });
+
+  it("should not show '- Modified' suffix after we click 'Save' on a new model (metabase#42773)", () => {
+    cy.log("Use UI to create a model based on the Products table");
+    cy.visit("/model/new");
+    cy.findByTestId("new-model-options")
+      .findByText("Use the notebook editor")
+      .click();
+
+    entityPickerModal().within(() => {
+      entityPickerModalTab("Tables").click();
+      cy.findByText("Products").click();
+    });
+
+    cy.findByTestId("dataset-edit-bar").button("Save").click();
+
+    cy.findByTestId("save-question-modal").within(() => {
+      cy.button("Save").click();
+      cy.wait("@cardCreate");
+      // It is important to have extremely short timeout in order to catch the issue
+      cy.findByDisplayValue("Products - Modified", { timeout: 10 }).should(
+        "not.exist",
+      );
     });
   });
 });

--- a/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.tsx
@@ -85,12 +85,13 @@ const isOverwriteMode = (
 
 export const SaveQuestionModal = ({
   question,
-  originalQuestion,
+  originalQuestion: latestOriginalQuestion,
   onCreate,
   onSave,
   onClose,
   multiStep,
 }: SaveQuestionModalProps) => {
+  const [originalQuestion] = useState(latestOriginalQuestion); // originalQuestion from props changes during saving
   const isReadonly = originalQuestion != null && !originalQuestion.canWrite();
 
   const initialCollectionId = useGetDefaultCollectionId(


### PR DESCRIPTION
### Description
This PR fixes #42773 by mimicking the solution we already have in `master` (that's proven to be working).

tl;dr
We need to remember the *initial* state of the "original" question because it changes to the ad-hoc question in Redux just before the save modal is closed.

### How to verify
Follow the repro steps and make sure you don't see `- Modified` at any stage during the question/metric/model save.

### Checklist
- [x] Tests have been added/updated to cover changes in this PR

> [!Important]
> Adds the same repro from #47103