### PR TITLE
Repro #42773: "-modified" suffix briefly shown in a model's name input during creation

### DIFF
--- a/e2e/test/scenarios/question/saved.cy.spec.js
+++ b/e2e/test/scenarios/question/saved.cy.spec.js
@@ -7,6 +7,7 @@ import {
   appBar,
   collectionOnTheGoModal,
   entityPickerModal,
+  entityPickerModalTab,
   modal,
   openNotebook,
   openOrdersTable,
@@ -298,6 +299,30 @@ describe("scenarios > question > saved", () => {
       // scrollHeight: height of the text content, including content not visible on the screen
       const heightDifference = $el[0].clientHeight - $el[0].scrollHeight;
       expect(heightDifference).to.eq(0);
+    });
+  });
+
+  it("should not show '- Modified' suffix after we click 'Save' on a new model (metabase#42773)", () => {
+    cy.log("Use UI to create a model based on the Products table");
+    cy.visit("/model/new");
+    cy.findByTestId("new-model-options")
+      .findByText("Use the notebook editor")
+      .click();
+
+    entityPickerModal().within(() => {
+      entityPickerModalTab("Tables").click();
+      cy.findByText("Products").click();
+    });
+
+    cy.findByTestId("dataset-edit-bar").button("Save").click();
+
+    cy.findByTestId("save-question-modal").within(() => {
+      cy.button("Save").click();
+      cy.wait("@cardCreate");
+      // It is important to have extremely short timeout in order to catch the issue
+      cy.findByDisplayValue("Products - Modified", { timeout: 10 }).should(
+        "not.exist",
+      );
     });
   });
 });


### PR DESCRIPTION
### What does this PR accomplish?
It adds E2E reproduction for #42773, which confirms that the issue has been fixed on `master`.

### Before
The test utilizes extremely short timeout of 10ms in order to catch this string while it's still in the DOM. I've removed the fix from `master` to verify that we can consistently test this, and the test failed every single time.
![image](https://github.com/user-attachments/assets/1193721d-94eb-4323-9262-7ab5aaa25044)

In order to verify that the test catches the issue, please apply this patch on `master`:
```
diff --git a/frontend/src/metabase/components/SaveQuestionForm/context.tsx b/frontend/src/metabase/components/SaveQuestionForm/context.tsx
index 0528b065d0..86f9892255 100644
--- a/frontend/src/metabase/components/SaveQuestionForm/context.tsx
+++ b/frontend/src/metabase/components/SaveQuestionForm/context.tsx
@@ -32,14 +32,12 @@ export const SaveQuestionContext =
 
 export const SaveQuestionProvider = ({
   question,
-  originalQuestion: latestOriginalQuestion,
+  originalQuestion,
   onCreate,
   onSave,
   multiStep = false,
   children,
 }: PropsWithChildren<SaveQuestionProps>) => {
-  const [originalQuestion] = useState(latestOriginalQuestion); // originalQuestion from props changes during saving
-
   const defaultCollectionId = useGetDefaultCollectionId(
     originalQuestion?.collectionId(),
   );
```

### After
The test is reliably passing
![image](https://github.com/user-attachments/assets/bd8a3ba4-78c0-49ed-996b-10748df206d4)

### Stress-test
50/50 ✅ https://github.com/metabase/metabase/actions/runs/10497508100

### Additional notes
I'll cherry pick this repro to #47086 to finally fix it in the release-x.50.x branch as well.