### PR TITLE
Add missing day in :minute timestamp formatter

### DIFF
--- a/src/metabase/formatter/datetime.clj
+++ b/src/metabase/formatter/datetime.clj
@@ -127,7 +127,7 @@ If neither a unit nor a temporal type is provided, just bottom out by assuming a
 
 (defmethod format-timestring :minute [timezone-id temporal-str _col {:keys [date-style time-style] :as viz-settings}]
   (reformat-temporal-str timezone-id temporal-str
-                         (-> (or date-style "MMMM, yyyy")
+                         (-> (or date-style "MMMM d, yyyy")
                              (str ", " (fix-time-style time-style constants/default-time-style))
                              (post-process-date-style viz-settings))))
 

--- a/test/metabase/formatter/datetime_test.clj
+++ b/test/metabase/formatter/datetime_test.clj
@@ -32,7 +32,7 @@
              (datetime/format-temporal-str "UTC" nil :now))))
     (testing "Temporal Units are formatted"
       (testing :minute
-        (is (= "July, 2020, 6:04 PM"
+        (is (= "July 16, 2020, 6:04 PM"
                (datetime/format-temporal-str "UTC" now {:unit :minute}))))
       (testing :hour
         (is (= "July 16, 2020, 6 PM"


### PR DESCRIPTION
Fixes #47090

For some reason, the default date time formatting string for `:minute` temporal units did not include the day.
This PR adds that into the default, just like we have for `:hour` and `:week`