### PR TITLE
Fix n+1 when getting field values for dashboard

### DIFF
--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -394,28 +394,44 @@
       nil)))
 
 (defn- delete-duplicates-and-return-latest!
-  "This is a workaround for the issue of stale FieldValues rows (metabase#668)
-  In order to mitigate the impact of duplicates, we return the most recently updated row, and delete the older rows."
-  [rows]
-  (if (<= (count rows) 1)
-    (first rows)
-    (let [[latest & duplicates] (sort-by :updated_at u/reverse-compare rows)]
-      (t2/delete! FieldValues :id [:in (map :id duplicates)])
-      latest)))
+  "Takes a list of field values, return a map of field-id -> latest FieldValues.
 
-(defn get-latest-field-values
+  If a field has more than one Field Values, delete the old ones. This is a workaround for the issue of stale FieldValues rows (metabase#668)
+  In order to mitigate the impact of duplicates, we return the most recently updated row, and delete the older rows.
+
+  It assumes that all rows are of the same type. Rows could be from multiple field-ids."
+  [fvs]
+  (let [fvs-grouped-by-field-id (update-vals (group-by :field_id fvs)
+                                             #(sort-by :updated_at u/reverse-compare %))
+        to-delete-fv-ids        (->> (vals fvs-grouped-by-field-id)
+                                     (mapcat rest)
+                                     (map :id))]
+    (when (seq to-delete-fv-ids)
+      (t2/delete! :model/FieldValues :id [:in to-delete-fv-ids]))
+    (update-vals fvs-grouped-by-field-id first)))
+
+(defn- get-latest-field-values
   "This returns the FieldValues with the given :type and :hash_key for the given Field.
-   This may implicitly delete shadowed entries in the database, see [[delete-duplicates-and-return-latest!]]"
+  This may implicitly delete shadowed entries in the database, see [[delete-duplicates-and-return-latest!]]"
   [field-id type hash]
   (assert (= (nil? hash) (= type :full)) ":hash_key must be nil iff :type is :full")
-  (delete-duplicates-and-return-latest!
-   (t2/select FieldValues :field_id field-id :type type :hash_key hash)))
+  (-> (t2/select :model/FieldValues :field_id field-id :type type :hash_key hash)
+      delete-duplicates-and-return-latest!
+      (get field-id)))
 
 (defn get-latest-full-field-values
   "This returns the full FieldValues for the given Field.
    This may implicitly delete shadowed entries in the database, see [[delete-duplicates-and-return-latest!]]"
   [field-id]
   (get-latest-field-values field-id :full nil))
+
+(defn batched-get-latest-full-field-values
+  "Batched version of [[get-latest-full-field-values]] .
+  Takes a list of field-ids and returns a map of field-id -> full FieldValues.
+  This may implicitly delete shadowed entries in the database, see [[delete-duplicates-and-return-latest!]]"
+  [field-ids]
+  (delete-duplicates-and-return-latest!
+   (t2/select :model/FieldValues :field_id [:in field-ids] :type :full :hash_key nil)))
 
 (defn create-or-update-full-field-values!
   "Create or update the full FieldValues object for `field`. If the FieldValues object already exists, then update values for

--- a/src/metabase/models/params/field_values.clj
+++ b/src/metabase/models/params/field_values.clj
@@ -48,8 +48,9 @@
     (let [field-ids (->> (t2/select :model/Field :id [:in (set field-ids)])
                          field/readable-fields-only
                          (map :id))]
-      (update-vals (field-values/batched-get-latest-full-field-values field-ids)
-                   #(select-keys % [:field_id :human_readable_values :values])))))
+      (when (seq field-ids)
+        (update-vals (field-values/batched-get-latest-full-field-values field-ids)
+                     #(select-keys % [:field_id :human_readable_values :values]))))))
 
 (defenterprise field-id->field-values-for-current-user
   "Fetch *existing* FieldValues for a sequence of `field-ids` for the current User. Values are returned as a map of

--- a/src/metabase/models/params/field_values.clj
+++ b/src/metabase/models/params/field_values.clj
@@ -2,7 +2,6 @@
   "Code related to fetching FieldValues for Fields to populate parameter widgets. Always used by the field
   values (`GET /api/field/:id/values`) endpoint; used by the chain filter endpoints under certain circumstances."
   (:require
-   [medley.core :as m]
    [metabase.db.query :as mdb.query]
    [metabase.models.field :as field]
    [metabase.models.field-values :as field-values :refer [FieldValues]]
@@ -46,15 +45,11 @@
   "OSS implementation; used as a fallback for the EE implementation for any fields that aren't subject to sandboxing."
   [field-ids]
   (when (seq field-ids)
-    (not-empty
-     (let [fields       (-> (t2/select :model/Field :id [:in (set field-ids)])
-                            (field/readable-fields-only)
-                            (t2/hydrate :values))
-           field-values (->> (map #(select-keys (field-values/get-latest-full-field-values (:id %))
-                                                [:field_id :human_readable_values :values])
-                                  fields)
-                             (keep not-empty))]
-       (m/index-by :field_id field-values)))))
+    (let [field-ids (->> (t2/select :model/Field :id [:in (set field-ids)])
+                         field/readable-fields-only
+                         (map :id))]
+      (update-vals (field-values/batched-get-latest-full-field-values field-ids)
+                   #(select-keys % [:field_id :human_readable_values :values])))))
 
 (defenterprise field-id->field-values-for-current-user
   "Fetch *existing* FieldValues for a sequence of `field-ids` for the current User. Values are returned as a map of


### PR DESCRIPTION
1b of https://github.com/metabase/metabase/issues/45780

Results: Calling `GET /api/dashboard/:id` on the "E-commerce insights" that has 4 filters
**Before**
33 calls
[before.csv](https://github.com/user-attachments/files/16707109/queries12175938864117816972.csv)

**After**
29 calls
[after.csv](https://github.com/user-attachments/files/16707130/queries5625071427222021509.csv)
