### PR TITLE
Add support for pipe separator in CSVs

### DIFF
--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -217,7 +217,7 @@
 (defn- file-size-mb [csv-file]
   (/ (.length ^File csv-file) 1048576.0))
 
-(def ^:private separators ",;\t")
+(def ^:private separators ",;\t|")
 
 ;; This number was chosen arbitrarily. There is robustness / performance trade-off.
 (def ^:private max-inferred-lines 10)

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -254,6 +254,9 @@
 (defn- file-mime-type [^File file]
   (.detect tika file))
 
+(defn- assert-separator-chosen [s]
+  (or s (throw (IllegalArgumentException. "Unable to determine separator"))))
+
 (defn- infer-separator
   "Guess at what symbol is being used as a separator in the given CSV-like file.
   Our heuristic is to use the separator that gives us the most number of columns.
@@ -266,10 +269,12 @@
                                      (comp (take max-inferred-lines)
                                            (map count))
                                      (csv/read-csv reader :separator s))
-                               (catch Exception _e nil))))]
+                               (catch Exception _e :invalid))))]
     (->> (map (juxt identity count-columns) separators)
+         (remove (comp #{:invalid} second))
          (sort-by (comp separator-priority second) u/reverse-compare)
-         ffirst)))
+         ffirst
+         assert-separator-chosen)))
 
 (defn- infer-parser
   "Currently this only infers the separator, but in future it may also handle different quoting options."

--- a/src/metabase/upload/types.cljc
+++ b/src/metabase/upload/types.cljc
@@ -39,27 +39,27 @@
 ;;
 ;; We have a number of special "abstract" nodes in this graph:
 ;;
-;; - `*boolean-int*` is an ambiguous node, that could either be parsed as a boolean or as an integer.
+;; - `*boolean-int*` is an ambiguous node that could either be parsed as a boolean or as an integer.
 ;; - `*float-or-int*` is any integer, whether it has an explicit decimal point or not.
 ;;
 ;; While a `*boolean-int*` is a genuinely ambiguous value, `*float-or-int*` exist to power our desired value-type
-;; coercion and column-type promotion behaviour.
+;; coercion and column-type promotion behavior.
 ;;
 ;; - If we encounter a `*float-or-int*` inside an `int` column, then we can safely coerce it down to an integer.
-;; - If we encounter a `float` (i.e. a non-zero fraction component), then we need to promote the column to a `float.`
+;; - If we encounter a `float` (i.e., a non-zero fraction component), then we need to promote the column to a `float.`
 ;;
-;; Columns can not have an abstract type, which has no meaning outside of inference and reconciliation.
+;; Columns cannot have an abstract type, which has no meaning outside inference and reconciliation.
 ;; If we are left with an abstract type after having processed all the values, we first check whether we can coerce
-;; the type to the existing column type, and otherwise traverse further up the graph until we reach a concrete type.
+;; the type to the existing column type; if not, we traverse further up the graph until we reach a concrete type.
 ;;
-;; For ease of reference and explicitness these corresponding values are given in the `abstract->concrete` map.
+;; For ease of reference and explicitness, these corresponding values are given in the `abstract->concrete` map.
 ;; One can figure out these mappings by simply looking up through the ancestors. For now, we require that it is always
 ;; a direct ancestor, and lay out or graph so that it is the left-most one.
 
 (def h
   "This hierarchy defines a relationship between value types and their specializations.
   We use an [[metabase.util.ordered-hierarchy]] for its topological sorting, which simplify writing efficient and
-  consistent implementations for of our type inference, parsing, and relaxation."
+  consistent implementations for our type inference, parsing, and relaxation."
   (make-hierarchy
    [::text
     [::varchar-255
@@ -84,7 +84,7 @@
 ;; types e.g. redshift does not allow coercions except between text types
 (def ^:private allowed-promotions
   "A mapping of which types a column can be implicitly relaxed to, based on the content of appended values.
-  If we require a relaxation which is not allow-listed here, we will reject the corresponding file."
+  If we require a relaxation which is not allowlisted here, we will reject the corresponding file."
   {::int #{::float}})
 
 (def ^:private column-type->coercible-value-types
@@ -154,7 +154,7 @@
       ".’" #"\d[\d’]*"))))
 
 (defn- float-or-int-regex
-  "Matches integral numbers, even if they have a decimal separator - e.g. 2 or 2.0"
+  "Matches integral numbers, even if they have a decimal separator - e.g., 2 or 2.0"
   [number-separators]
   (with-parens
    (with-currency
@@ -165,7 +165,7 @@
       ".’" #"\d[\d’]*(\.[0.]+)?"))))
 
 (defn- float-regex
-  "Matches numbers, regardless of whether they have a decimal separator - e.g. 2, 2.0, or 2.2"
+  "Matches numbers, regardless of whether they have a decimal separator - e.g., 2, 2.0, or 2.2"
   [number-separators]
   (with-parens
    (with-currency

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -509,7 +509,10 @@
                 "\" 3\";;           b;false;\"$ 1,000.1\";2022-02-01;2022-02-01T00:00:00"]
    :tab        ["id    \tnulls\tstring \tbool \tnumber       \tdate      \tdatetime"
                 "2   \t\t          a \ttrue \t1.1        \t2022-01-01\t2022-01-01T00:00:00"
-                "\" 3\"\t\t           b\tfalse\t\"$ 1,000.1\"\t2022-02-01\t2022-02-01T00:00:00"]})
+                "\" 3\"\t\t           b\tfalse\t\"$ 1,000.1\"\t2022-02-01\t2022-02-01T00:00:00"]
+   :pipe       ["id    |nulls|string |bool |number       |date      |datetime"
+                "2\t   ||          a |true |1.1\t        |2022-01-01|2022-01-01T00:00:00"
+                "\" 3\"||           b|false|\"$ 1,000.1\"|2022-02-01|2022-02-01T00:00:00"]})
 
 (defn- columns-with-auto-pk [columns]
   (cond-> columns
@@ -592,7 +595,7 @@
       (is (= \, (infer-separator rows)))))
   (doseq [[separator lines] example-files]
     (testing (str "inferring " separator)
-      (let [s ({:tab \tab :semi-colon \; :comma \,} separator)]
+      (let [s ({:tab \tab :semi-colon \; :comma \, :pipe \|} separator)]
         (is (= s (infer-separator lines))))))
   ;; it's actually decently hard to make it not stumble on comma or semicolon. The strategy here is that the data
   ;; column count is greater than the header column count regardless of the separators we choose


### PR DESCRIPTION
### Description

This adds support for a `|` (pipe) separator in CSVs. I saw from DuckDB that this is another popular option. It also improves the error message if we can't determine the separator. Action some grammar linting while I'm here too.