### PR TITLE
Fix iframe resizer not working

### DIFF
--- a/e2e/support/helpers/e2e-embedding-helpers.js
+++ b/e2e/support/helpers/e2e-embedding-helpers.js
@@ -107,18 +107,24 @@ export function visitEmbeddedPage(
   }
 }
 
+export function getIframeUrl() {
+  modal().findByText("Preview").click();
+
+  return cy.document().then(doc => {
+    const iframe = doc.querySelector("iframe");
+
+    return iframe.src;
+  });
+}
+
 /**
  * Grab an iframe `src` via UI and open it,
  * but make sure user is signed out.
  */
 export function visitIframe() {
-  modal().findByText("Preview").click();
-
-  cy.document().then(doc => {
-    const iframe = doc.querySelector("iframe");
-
+  getIframeUrl().then(iframeUrl => {
     cy.signOut();
-    cy.visit(iframe.src);
+    cy.visit(iframeUrl);
   });
 }
 

--- a/e2e/test/scenarios/embedding/embedding-dashboard.html
+++ b/e2e/test/scenarios/embedding/embedding-dashboard.html
@@ -1,0 +1,11 @@
+<script src="http://localhost:4000/app/iframeResizer.js"></script>
+<iframe
+  id="iframe"
+  onload="iFrameResize({checkOrigin: false}, this)"
+  style="width: 100%; border: 0"
+></iframe>
+<script>
+  document.getElementById("iframe").src = new URLSearchParams(
+    location.search,
+  ).get("iframeUrl");
+</script>

--- a/frontend/src/metabase/lib/dom.js
+++ b/frontend/src/metabase/lib/dom.js
@@ -495,23 +495,10 @@ export function initializeIframeResizer(onReady = () => {}) {
       onReady,
     };
 
-    // FIXME: Crimes
-    // This is needed so the FE test framework which runs in node
-    // without the avaliability of require.ensure skips over this part
-    // which is for external purposes only.
-    //
-    // Ideally that should happen in the test config, but it doesn't
-    // seem to want to play nice when messing with require
-    if (typeof require.ensure !== "function") {
-      return false;
-    }
-
     // Make iframe-resizer avaliable to the embed
     // We only care about contentWindow so require that minified file
 
-    require.ensure([], require => {
-      require("iframe-resizer/js/iframeResizer.contentWindow.js");
-    });
+    import("iframe-resizer/js/iframeResizer.contentWindow.js");
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/47061

### Description

This fixes the issue where iframe-resizer not working on static embedded dashboards

### How to verify

Run the Cypress test `e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js`'s "should resize iframe to dashboard content size (metabase#47061)"

### Demo

#### After
![image](https://github.com/user-attachments/assets/ada85e81-34a4-47dc-b36f-a0387e723696)


#### Before
![Screenshot 2024-08-21 at 5 30 25 PM](https://github.com/user-attachments/assets/6f079997-8e84-48a6-aa14-39f271d7c608)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
