### PR TITLE
Bump macaw to 0.2.6

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -77,7 +77,7 @@
   io.github.eerohele/pp                     {:git/tag "2024-01-04.60"           ; super fast pretty-printing library
                                              :git/sha "a428751"
                                              :git/url "https://github.com/eerohele/pp"}
-  io.github.metabase/macaw                  {:mvn/version "0.2.3"}              ; Parse native SQL queries
+  io.github.metabase/macaw                  {:mvn/version "0.2.6"}              ; Parse native SQL queries
   ;; The 2.X line of Resilience4j requires Java 17, so we cannot upgrade this dependency until that is our minimum JVM version
   io.github.resilience4j/resilience4j-retry {:mvn/version "1.7.1" #_ "must be 1.7.1"} ; Support for retrying operations
   io.prometheus/simpleclient_hotspot        {:mvn/version "0.16.0"}             ; prometheus jvm collector


### PR DESCRIPTION
There are no behavior changes in this bump, just optimizations.

The updates account for a 50% time and 80% memory decrease in sample queries in the library call itself.

Metabase adds a bunch more overhead on top, so net improvement won't be as drastic.