### PR TITLE
[serdes] keep nulls in export when there are nulls in the db

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -1070,7 +1070,11 @@
                    [{:model "Database"   :id "My Database"}
                     {:model "Table"      :id "Schemaless Table"}
                     {:model "Field"      :id "A Field"}]}
-                 (set (serdes/dependencies ser)))))))))
+                 (set (serdes/dependencies ser))))))
+      (testing "Nullable transformations stay as nulls"
+        (let [ser (serdes/extract-one "Card" {} (t2/select-one Card :id card-id-2))]
+          (is (=? {:made_public_by_id nil}
+                  ser)))))))
 
 #_{:clj-kondo/ignore [:metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests]}
 (deftest selective-serialization-basic-test

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -440,7 +440,7 @@
    :skip      []
    :transform {:created_at          (serdes/date)
                ;; details should be imported if available regardless of options
-               :details             {:export #(when include-database-secrets %) :import identity}
+               :details             {:export #(if include-database-secrets % ::serdes/skip) :import identity}
                :creator_id          (serdes/fk :model/User)
                :initial_sync_status {:export identity :import (constantly "complete")}}})
 

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -579,7 +579,7 @@
                :last_used_at (serdes/date)
                :type         (serdes/kw)
                :field_id     {::serdes/fk true
-                              :export     (constantly nil)
+                              :export     (constantly ::serdes/skip)
                               :import     (fn [_]
                                             (let [field-ref (field-path->field-ref (serdes/path serdes/*current*))]
                                               (serdes/*import-field-fk* field-ref)))}}})

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -331,9 +331,8 @@
             ;; won't assoc if `generate-path` returned `nil`
             (m/assoc-some :serdes/meta (generate-path model-name instance))
             (into (for [[k transform] (:transform spec)
-                        :let [res ((:export transform) (get instance k))]
-                        ;; include only non-nil `transform` results
-                        :when res]
+                        :let  [res ((:export transform) (get instance k))]
+                        :when (not= res ::skip)]
                     [k res])))))
     (catch Exception e
       (throw (ex-info (format "Error extracting %s %s" model-name (:id instance))
@@ -738,8 +737,9 @@
             (into (for [[k transform] (:transform spec)
                         :when         (not (::nested transform))
                         :let          [res ((:import transform) (get ingested k))]
-                        ;; do not try to insert nil values if transformer returns nothing
-                        :when         res]
+                        :when         (and (not= res ::skip)
+                                           (or (some? res)
+                                               (contains? ingested k)))]
                     [k res])))))))
 
 (defn- spec-nested! [model-name ingested instance]
@@ -1614,7 +1614,7 @@
 
 (def parent-ref "Transformer for parent id for nested entities."
   (constantly
-   {::fk true :export (constantly nil) :import identity}))
+   {::fk true :export (constantly ::skip) :import identity}))
 
 (def date "Transformer to parse the dates."
   (constantly


### PR DESCRIPTION
this retains previous behavior, so that 1) diffs are smaller and 2) actual nulls will get into target database