### PR TITLE
[serdes] extract result_metadata.fk_target_field_id

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -27,6 +27,7 @@
             User]]
    [metabase.models.action :as action]
    [metabase.models.serialization :as serdes]
+   [metabase.query-processor :as qp]
    [metabase.test :as mt]
    [metabase.util :as u]
    [toucan2.core :as t2]))
@@ -1539,3 +1540,19 @@
           ;; - 1 for dashcards, there are 7
           ;; - 2 for series (7 dashcards / 5 -> 2 batches)
           (is (= 5 (qc))))))))
+
+(deftest result-metadata-test
+  (mt/with-temp [:model/Card c {:dataset_query (mt/query venues)}]
+    (let [res (qp/process-query
+               (qp/userland-query
+                (:dataset_query c)
+                {:card-id (:id c)}))]
+      (when-not (= (:status res) :completed)
+        (throw (ex-info "Query failed" res)))
+      (let [ser (serdes/extract-one "Card" nil (t2/select-one :model/Card (:id c)))]
+        (is (=? {:base_type          :type/Integer
+                 :id                 [string? "PUBLIC" "VENUES" "CATEGORY_ID"]
+                 :fk_target_field_id [string? "PUBLIC" "CATEGORIES" "ID"]
+                 :field_ref          [:field [string? "PUBLIC" "VENUES" "CATEGORY_ID"] nil]}
+                (->> (:result_metadata ser)
+                     (u/seek #(= (:display_name %) "Category ID")))))))))

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -819,7 +819,8 @@
       (-> (dissoc m :fingerprint)
           (m/update-existing :table_id  serdes/*export-table-fk*)
           (m/update-existing :id        serdes/*export-field-fk*)
-          (m/update-existing :field_ref serdes/export-mbql)))))
+          (m/update-existing :field_ref serdes/export-mbql)
+          (m/update-existing :fk_target_field_id serdes/*export-field-fk*)))))
 
 (defn- import-result-metadata [metadata]
   (when metadata
@@ -827,7 +828,9 @@
       (-> m
           (m/update-existing :table_id  serdes/*import-table-fk*)
           (m/update-existing :id        serdes/*import-field-fk*)
-          (m/update-existing :field_ref serdes/import-mbql)))))
+          (m/update-existing :field_ref serdes/import-mbql)
+          ;; NOTE: temporary until `instance_analytics` is updated
+          (m/update-existing :fk_target_field_id #(if (number? %) % (serdes/*import-field-fk* %)))))))
 
 (defn- result-metadata-deps [metadata]
   (when (seq metadata)


### PR DESCRIPTION
Fixes an issue with `result_metadata.fk_target_field_id` being extracted as a simple integer id (which is incorrect after importing).

Note the `NOTE` - it's there because `instance_analytics` needs to be updated first. So I need this merged, then a new export of instance analytics, and then it can be dropped.