### PR TITLE
Log alllllll the query analysis queueing things 

### DIFF
--- a/resources/log4j2.xml
+++ b/resources/log4j2.xml
@@ -33,6 +33,7 @@
     <Logger name="metabase.server.middleware" level="DEBUG"/>
     <Logger name="metabase.task.analyze-queries" level="DEBUG"/>
     <Logger name="metabase.task.sweep-query-analysis" level="DEBUG"/>
+    <Logger name="metabase.util.queue" level="DEBUG"/>
     <Logger name="org.quartz" level="INFO"/>
     <Logger name="net.snowflake.client.jdbc.SnowflakeConnectString" level="ERROR"/>
 

--- a/resources/log4j2.xml
+++ b/resources/log4j2.xml
@@ -29,11 +29,11 @@
     <Logger name="metabase.metabot" level="DEBUG"/>
     <Logger name="metabase.plugins" level="DEBUG"/>
     <Logger name="metabase.query-processor.async" level="DEBUG"/>
-    <Logger name="metabase.query-analysis" level="DEBUG"/>
+    <Logger name="metabase.query-analysis" level="TRACE"/>
     <Logger name="metabase.server.middleware" level="DEBUG"/>
-    <Logger name="metabase.task.analyze-queries" level="DEBUG"/>
-    <Logger name="metabase.task.sweep-query-analysis" level="DEBUG"/>
-    <Logger name="metabase.util.queue" level="DEBUG"/>
+    <Logger name="metabase.task.analyze-queries" level="TRACE"/>
+    <Logger name="metabase.task.sweep-query-analysis" level="TRACE"/>
+    <Logger name="metabase.util.queue" level="TRACE"/>
     <Logger name="org.quartz" level="INFO"/>
     <Logger name="net.snowflake.client.jdbc.SnowflakeConnectString" level="ERROR"/>
 

--- a/src/metabase/query_analysis.clj
+++ b/src/metabase/query_analysis.clj
@@ -31,7 +31,8 @@
 (def ^:dynamic *analyze-execution-in-dev?*
   "Managing a background thread in the REPL is likely to confuse and infuriate, especially when running tests.
   For this reason, we run analysis on the main thread by default."
-  ::immediate)
+  ::queued
+  #_::immediate)
 
 (def ^:dynamic *analyze-execution-in-test?*
   "A card's query is normally analyzed on every create/update.

--- a/src/metabase/query_analysis.clj
+++ b/src/metabase/query_analysis.clj
@@ -215,8 +215,8 @@
         card-id (:id card)]
     (cond
       (not card)       (log/warnf "Card not found: %s" card-id)
-      (:archived card) (log/warnf "Skipping archived card: %s" card-id)
-      :else            (log/debugf "Performing query analysis for card %s" card-id))
+      (:archived card) (log/warnf "[query-analysis] Skipping archived card: %s" card-id)
+      :else            (log/debugf "[query-analysis] Performing query analysis for card %s" card-id))
     (when (and card (not (:archived card)))
       (update-query-analysis-for-card! card))))
 
@@ -242,12 +242,12 @@
   (let [id        (u/the-id card-or-id)
         enqueued? (queue/maybe-put! queue card-or-id)]
     (if enqueued?
-      (log/debugf "Queued Card %s for async analysis" id)
-      (log/warnf "Deferred analysis of Card %s, as the queue is full" id))))
+      (log/debugf "[query-analysis] Queued Card %s for async analysis" id)
+      (log/warnf "[query-analysis] Deferred analysis of Card %s, as the queue is full" id))))
 
 (defn- blocking-put! [queue timeout card-or-id]
   (let [id (u/the-id card-or-id)]
-    (log/debugf "Synchronously analyzing Card %s" id)
+    (log/debugf "[query-analysis] Synchronously analyzing Card %s" id)
     (queue/blocking-put! queue timeout card-or-id)))
 
 (defn analyze-async!

--- a/src/metabase/query_analysis.clj
+++ b/src/metabase/query_analysis.clj
@@ -248,7 +248,7 @@
 
 (defn- blocking-put! [queue timeout card-or-id]
   (let [id (u/the-id card-or-id)]
-    (log/debugf "[query-analysis] Synchronously analyzing Card %s" id)
+    (log/tracef "[query-analysis] Synchronously analyzing Card %s" id)
     (queue/blocking-put! queue timeout card-or-id)))
 
 (defn analyze-async!

--- a/src/metabase/task/analyze_queries.clj
+++ b/src/metabase/task/analyze_queries.clj
@@ -37,11 +37,12 @@
 (defn- wait-fail ^long [time-taken-ms]
   (max fail-wait-ms (wait-proportional time-taken-ms)))
 
+
 (defn- analyzer-loop* [stop-after next-card-id-fn]
   (loop [remaining stop-after]
     (when (public-settings/query-analysis-enabled)
       (let [card-or-id (next-card-id-fn)
-            _ (log/debugf "[query-analysis] next message: %s" card-or-id)
+            _ (log/debugf "[query-analysis] next message: %s" (u/the-id card-or-id))
             card-id    (u/the-id card-or-id)
             timer      (u/start-timer)
             card       (query-analysis/->analyzable card-or-id)]

--- a/src/metabase/task/analyze_queries.clj
+++ b/src/metabase/task/analyze_queries.clj
@@ -37,7 +37,6 @@
 (defn- wait-fail ^long [time-taken-ms]
   (max fail-wait-ms (wait-proportional time-taken-ms)))
 
-
 (defn- analyzer-loop* [stop-after next-card-id-fn]
   (loop [remaining stop-after]
     (when (public-settings/query-analysis-enabled)

--- a/src/metabase/task/analyze_queries.clj
+++ b/src/metabase/task/analyze_queries.clj
@@ -42,8 +42,8 @@
   (loop [remaining stop-after]
     (when (public-settings/query-analysis-enabled)
       (let [card-or-id (next-card-id-fn)
-            _ (log/debugf "[query-analysis] next message: %s" (u/the-id card-or-id))
             card-id    (u/the-id card-or-id)
+            _ (log/debugf "[query-analysis] next message: %s" card-id)
             timer      (u/start-timer)
             card       (query-analysis/->analyzable card-or-id)]
         (if (failure-map/non-retryable? card)

--- a/src/metabase/task/analyze_queries.clj
+++ b/src/metabase/task/analyze_queries.clj
@@ -43,7 +43,7 @@
     (when (public-settings/query-analysis-enabled)
       (let [card-or-id (next-card-id-fn)
             card-id    (u/the-id card-or-id)
-            _ (log/debugf "[query-analysis] next message: %s" card-id)
+            _ (log/tracef "[query-analysis] next message: %s" card-id)
             timer      (u/start-timer)
             card       (query-analysis/->analyzable card-or-id)]
         (if (failure-map/non-retryable? card)

--- a/src/metabase/task/sweep_query_analysis.clj
+++ b/src/metabase/task/sweep_query_analysis.clj
@@ -70,7 +70,7 @@
    (analyze-cards-without-query-fields! analyze-fn)
 
    ;; we run through all the existing analysis on our first run, as it may be stale due to an old macaw version, etc.
-   (when first-time?
+   #_(when first-time?
      (log/info "Recalculating potentially stale analysis")
      ;; this will repeat the cards we've just back-filled, but in the steady state there should be none of those.
      ;; in the future, we will track versions, hashes, and timestamps to reduce the cost of this operation.

--- a/src/metabase/task/sweep_query_analysis.clj
+++ b/src/metabase/task/sweep_query_analysis.clj
@@ -33,7 +33,7 @@
                                                  [:= :qf.id nil]]})]
      (run! analyze-fn cards))))
 
-(defn- analyze-stale-cards!
+#_(defn- analyze-stale-cards!
   ([]
    (analyze-cards-without-query-fields! query-analysis/analyze-sync!))
   ([analyze-fn]
@@ -64,17 +64,17 @@
                                (fn [card-or-id]
                                  (log/debugf "Queueing card %s for query analysis" (u/the-id card-or-id))
                                  (query-analysis/analyze-sync! card-or-id))))
-  ([first-time? analyze-fn]
+  ([_first-time? analyze-fn]
    ;; prioritize cards that are missing analysis
    (log/info "Calculating analysis for cards without any")
    (analyze-cards-without-query-fields! analyze-fn)
 
    ;; we run through all the existing analysis on our first run, as it may be stale due to an old macaw version, etc.
    #_(when first-time?
-     (log/info "Recalculating potentially stale analysis")
+       (log/info "Recalculating potentially stale analysis")
      ;; this will repeat the cards we've just back-filled, but in the steady state there should be none of those.
      ;; in the future, we will track versions, hashes, and timestamps to reduce the cost of this operation.
-     (analyze-stale-cards! analyze-fn))
+       (analyze-stale-cards! analyze-fn))
 
    ;; empty out useless records
    (log/info "Deleting analysis for archived cards")

--- a/src/metabase/util/queue.clj
+++ b/src/metabase/util/queue.clj
@@ -1,4 +1,7 @@
 (ns metabase.util.queue
+  (:require
+   [metabase.util :as u]
+   [metabase.util.log :as log])
   (:import
    (java.util.concurrent ArrayBlockingQueue SynchronousQueue TimeUnit)))
 
@@ -22,15 +25,25 @@
                                        ^long sleep-ms]
   BoundedTransferQueue
   (maybe-put! [_ msg]
-    (.offer async-queue msg))
+    (log/debugf "[query-analysis] put: async queue length: %s" (.size async-queue))
+    (log/debugf "[query-analysis] maybe-put! %s %s"
+                msg
+                (.offer async-queue msg)))
   (blocking-put! [_ timeout msg]
-    (.offer sync-queue msg timeout TimeUnit/MILLISECONDS))
+    (log/debugf "[query-analysis] synchronously putting %s" msg)
+    (.offer sync-queue msg timeout TimeUnit/MILLISECONDS)
+    (log/debugf "[query-analysis] done with sync put %s" msg))
   (blocking-take! [_ timeout]
     (loop [time-remaining timeout]
       (when (pos? time-remaining)
+        (log/debugf "[query-analysis] take: async queue length: %s" (.size async-queue))
         ;; Async messages are given higher priority, as sync messages will never be dropped.
-        (or (.poll async-queue)
-            (.poll sync-queue block-ms TimeUnit/MILLISECONDS)
+        (or (u/prog1 (.poll async-queue)
+              (when <>
+                (log/debugf "[query-analysis] took %s off the async queue" <>)))
+            (u/prog1 (.poll sync-queue block-ms TimeUnit/MILLISECONDS)
+              (when <>
+                (log/debugf "[query-analysis] took %s off the sync queue" <>)))
             (do (Thread/sleep ^long sleep-ms)
                 ;; This is an underestimate, as the thread may have taken a while to wake up. That's OK.
                 (recur (- time-remaining block-ms sleep-ms)))))))

--- a/src/metabase/util/queue.clj
+++ b/src/metabase/util/queue.clj
@@ -25,28 +25,28 @@
                                        ^long sleep-ms]
   BoundedTransferQueue
   (maybe-put! [_ msg]
-    (log/debugf "[query-analysis] put: async queue length: %s" (.size async-queue))
+    (log/tracef "[query-analysis] put: async queue length: %s" (.size async-queue))
     (u/prog1 (.offer async-queue msg)
-      (log/debugf "[query-analysis] maybe-put! %s %s"
+      (log/tracef "[query-analysis] maybe-put! %s %s"
                   (u/the-id msg)
                   <>)))
   (blocking-put! [_ timeout msg]
-    (log/debugf "[query-analysis] synchronously putting %s" (u/the-id msg))
+    (log/tracef "[query-analysis] synchronously putting %s" (u/the-id msg))
     (.offer sync-queue msg timeout TimeUnit/MILLISECONDS)
-    (log/debugf "[query-analysis] done with sync put %s" (u/the-id msg)))
+    (log/tracef "[query-analysis] done with sync put %s" (u/the-id msg)))
   (blocking-take! [_ timeout]
     (loop [time-remaining timeout]
       (when (pos? time-remaining)
         (let [s (.size async-queue)]
           (when (pos? s)
-            (log/debugf "[query-analysis] take: async queue length: %s" s)))
+            (log/tracef "[query-analysis] take: async queue length: %s" s)))
         ;; Async messages are given higher priority, as sync messages will never be dropped.
         (or (u/prog1 (.poll async-queue)
               (when <>
-                (log/debugf "[query-analysis] took %s off the async queue" <>)))
+                (log/tracef "[query-analysis] took %s off the async queue" <>)))
             (u/prog1 (.poll sync-queue block-ms TimeUnit/MILLISECONDS)
               (when <>
-                (log/debugf "[query-analysis] took %s off the sync queue" <>)))
+                (log/tracef "[query-analysis] took %s off the sync queue" <>)))
             (do (Thread/sleep ^long sleep-ms)
                 ;; This is an underestimate, as the thread may have taken a while to wake up. That's OK.
                 (recur (- time-remaining block-ms sleep-ms)))))))

--- a/src/metabase/util/queue.clj
+++ b/src/metabase/util/queue.clj
@@ -43,10 +43,10 @@
         ;; Async messages are given higher priority, as sync messages will never be dropped.
         (or (u/prog1 (.poll async-queue)
               (when <>
-                (log/debugf "[query-analysis] took %s off the async queue" <>)))
+                (log/debugf "[query-analysis] took %s off the async queue" (u/the-id <>))))
             (u/prog1 (.poll sync-queue block-ms TimeUnit/MILLISECONDS)
               (when <>
-                (log/debugf "[query-analysis] took %s off the sync queue" <>)))
+                (log/debugf "[query-analysis] took %s off the sync queue" (u/the-id <>))))
             (do (Thread/sleep ^long sleep-ms)
                 ;; This is an underestimate, as the thread may have taken a while to wake up. That's OK.
                 (recur (- time-remaining block-ms sleep-ms)))))))

--- a/src/metabase/util/queue.clj
+++ b/src/metabase/util/queue.clj
@@ -43,10 +43,10 @@
         ;; Async messages are given higher priority, as sync messages will never be dropped.
         (or (u/prog1 (.poll async-queue)
               (when <>
-                (log/debugf "[query-analysis] took %s off the async queue" (u/the-id <>))))
+                (log/debugf "[query-analysis] took %s off the async queue" <>)))
             (u/prog1 (.poll sync-queue block-ms TimeUnit/MILLISECONDS)
               (when <>
-                (log/debugf "[query-analysis] took %s off the sync queue" (u/the-id <>))))
+                (log/debugf "[query-analysis] took %s off the sync queue" <>)))
             (do (Thread/sleep ^long sleep-ms)
                 ;; This is an underestimate, as the thread may have taken a while to wake up. That's OK.
                 (recur (- time-remaining block-ms sleep-ms)))))))


### PR DESCRIPTION
Every now and then it seems like cards aren't getting analyzed on stats. I can't reproduce this locally. I've read all the relevant code through ten times over, and have no ideas.

The idea here is to println debug the way to stability.

Ideally this doesn't get merged, and is just used to spin up a cloud environment.