### PR TITLE
Fix error message in Create API Key modal

### DIFF
--- a/frontend/src/metabase/admin/settings/components/ApiKeys/utils.ts
+++ b/frontend/src/metabase/admin/settings/components/ApiKeys/utils.ts
@@ -1,3 +1,4 @@
+import { t } from "ttag";
 import * as Yup from "yup";
 
 import type { ApiKey } from "metabase-types/api";
@@ -8,7 +9,9 @@ export function formatMaskedKey(maskedKey: string) {
 
 export const API_KEY_VALIDATION_SCHEMA = Yup.object({
   name: Yup.string().required(),
-  group_id: Yup.number().required(),
+  group_id: Yup.number()
+    .typeError(t`Select a group`)
+    .required(),
 });
 
 export type FlatApiKey = ApiKey & {


### PR DESCRIPTION
Removes a silly and easy-to-encounter error message from the Create API Key modal

To see the message, focus the "Select a group" dropdown and then move the focus somewhere else without selecting an option.

here's the buggy error message:
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/66d94dec-f407-4e7d-a350-1ecb0af93d64.png)

In this branch the message now reads "Select a group". (This repeats the text in the placeholder. This is just a quick/simple solution)