### PR TITLE
[E2E] Remove the `default-ee` spec

### DIFF
--- a/e2e/snapshot-creators/default.cy.snap.js
+++ b/e2e/snapshot-creators/default.cy.snap.js
@@ -7,14 +7,7 @@ import {
   USERS,
   USER_GROUPS,
 } from "e2e/support/cypress_data";
-import {
-  deleteToken,
-  describeEE,
-  restore,
-  setTokenFeatures,
-  snapshot,
-  withSampleDatabase,
-} from "e2e/support/helpers";
+import { restore, snapshot, withSampleDatabase } from "e2e/support/helpers";
 
 const {
   STATIC_ORDERS_ID,
@@ -70,29 +63,6 @@ describe("snapshots", () => {
     });
   });
 
-  describeEE("default-ee", () => {
-    it("default-ee", () => {
-      restore("blank");
-      setup();
-      updateSettings();
-      setTokenFeatures("all");
-      addUsersAndGroups(true);
-      createCollections();
-      withSampleDatabase(SAMPLE_DATABASE => {
-        ensureTableIdsAreCorrect(SAMPLE_DATABASE);
-        hideNewSampleTables(SAMPLE_DATABASE);
-        createQuestionsAndDashboards(SAMPLE_DATABASE);
-        createModels(SAMPLE_DATABASE);
-        cy.writeFile(
-          "e2e/support/cypress_sample_database.json",
-          SAMPLE_DATABASE,
-        );
-      });
-      deleteToken();
-      snapshot("default-ee");
-    });
-  });
-
   function setup() {
     cy.request("GET", "/api/session/properties").then(
       ({ body: properties }) => {
@@ -132,9 +102,7 @@ describe("snapshots", () => {
     });
   }
 
-  function addUsersAndGroups(isEE = false) {
-    const lowest_read_data_permission = isEE ? "blocked" : "unrestricted";
-
+  function addUsersAndGroups() {
     // groups
     cy.request("POST", "/api/permissions/group", { name: "collection" }).then(
       ({ body }) => {
@@ -169,7 +137,7 @@ describe("snapshots", () => {
       [ALL_USERS_GROUP]: {
         [SAMPLE_DB_ID]: {
           // set the data permission so the UI doesn't warn us that "all users has higher permissions than X"
-          "view-data": lowest_read_data_permission,
+          "view-data": "unrestricted",
           "create-queries": "no",
         },
       },
@@ -187,13 +155,13 @@ describe("snapshots", () => {
       },
       [COLLECTION_GROUP]: {
         [SAMPLE_DB_ID]: {
-          "view-data": lowest_read_data_permission,
+          "view-data": "unrestricted",
           "create-queries": "no",
         },
       },
       [READONLY_GROUP]: {
         [SAMPLE_DB_ID]: {
-          "view-data": lowest_read_data_permission,
+          "view-data": "unrestricted",
           "create-queries": "no",
         },
       },

--- a/e2e/support/helpers/e2e-permissions-helpers.js
+++ b/e2e/support/helpers/e2e-permissions-helpers.js
@@ -1,5 +1,6 @@
 import _ from "underscore";
 
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { popover } from "e2e/support/helpers";
 
 export function selectSidebarItem(item) {
@@ -146,5 +147,19 @@ export function assertDatasetReqIsSandboxed(options = {}) {
       const errMsg = `Expected every result in column to be equal to: ${columnAssertion}`;
       expect(values.every(assertionFn)).to.equal(true, errMsg);
     }
+  });
+}
+
+export function blockUserGroupPermissions(
+  groupName,
+  databaseId = SAMPLE_DB_ID,
+) {
+  cy.updatePermissionsGraph({
+    [groupName]: {
+      [SAMPLE_DB_ID]: {
+        "view-data": "blocked",
+        "create-queries": "no",
+      },
+    },
   });
 }

--- a/e2e/support/helpers/e2e-permissions-helpers.js
+++ b/e2e/support/helpers/e2e-permissions-helpers.js
@@ -150,12 +150,9 @@ export function assertDatasetReqIsSandboxed(options = {}) {
   });
 }
 
-export function blockUserGroupPermissions(
-  groupName,
-  databaseId = SAMPLE_DB_ID,
-) {
+export function blockUserGroupPermissions(groupId, databaseId = SAMPLE_DB_ID) {
   cy.updatePermissionsGraph({
-    [groupName]: {
+    [groupId]: {
       [databaseId]: {
         "view-data": "blocked",
         "create-queries": "no",

--- a/e2e/support/helpers/e2e-permissions-helpers.js
+++ b/e2e/support/helpers/e2e-permissions-helpers.js
@@ -156,7 +156,7 @@ export function blockUserGroupPermissions(
 ) {
   cy.updatePermissionsGraph({
     [groupName]: {
-      [SAMPLE_DB_ID]: {
+      [databaseId]: {
         "view-data": "blocked",
         "create-queries": "no",
       },

--- a/e2e/support/helpers/e2e-setup-helpers.js
+++ b/e2e/support/helpers/e2e-setup-helpers.js
@@ -9,7 +9,6 @@ export function snapshot(name) {
  * "setup" |
  * "without-models" |
  * "default" |
- * "default-ee" |
  * "withSqlite" |
  * "mongo-5" |
  * "postgres-12" |

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-source.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-source.cy.spec.js
@@ -1,7 +1,8 @@
-import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
+import { USER_GROUPS, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   assertDatasetReqIsSandboxed,
+  blockUserGroupPermissions,
   describeEE,
   editDashboard,
   filterWidget,
@@ -393,9 +394,10 @@ describe(
 
 describeEE("scenarios > dashboard > filters", () => {
   beforeEach(() => {
-    restore("default-ee");
+    restore("default");
     cy.signInAsAdmin();
     setTokenFeatures("all");
+    blockUserGroupPermissions(USER_GROUPS.ALL_USERS_GROUP);
   });
 
   it("should sandbox parameter values in dashboards", () => {

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-source.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-source.cy.spec.js
@@ -394,7 +394,7 @@ describe(
 
 describeEE("scenarios > dashboard > filters", () => {
   beforeEach(() => {
-    restore("default");
+    restore();
     cy.signInAsAdmin();
     setTokenFeatures("all");
     blockUserGroupPermissions(USER_GROUPS.ALL_USERS_GROUP);

--- a/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
@@ -669,7 +669,7 @@ describe("issue 28756", () => {
 
 describeEE("issue 29076", () => {
   beforeEach(() => {
-    restore("default");
+    restore();
 
     cy.intercept("/api/dashboard/*/dashcard/*/card/*/query").as("cardQuery");
 

--- a/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
@@ -669,12 +669,13 @@ describe("issue 28756", () => {
 
 describeEE("issue 29076", () => {
   beforeEach(() => {
-    restore("default-ee");
+    restore("default");
 
     cy.intercept("/api/dashboard/*/dashcard/*/card/*/query").as("cardQuery");
 
     cy.signInAsAdmin();
     setTokenFeatures("all");
+
     cy.updatePermissionsGraph({
       [ALL_USERS_GROUP]: {
         [SAMPLE_DB_ID]: {

--- a/e2e/test/scenarios/native-filters/sql-filters-source.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-filters-source.cy.spec.js
@@ -564,7 +564,7 @@ describe("scenarios > filters > sql filters > values source", () => {
 
 describeEE("scenarios > filters > sql filters > values source", () => {
   beforeEach(() => {
-    restore("default");
+    restore();
     cy.signInAsAdmin();
     setTokenFeatures("all");
     blockUserGroupPermissions(USER_GROUPS.ALL_USERS_GROUP);

--- a/e2e/test/scenarios/native-filters/sql-filters-source.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-filters-source.cy.spec.js
@@ -1,6 +1,7 @@
 import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
+  blockUserGroupPermissions,
   checkFilterListSourceHasValue,
   describeEE,
   multiAutocompleteInput,
@@ -563,9 +564,10 @@ describe("scenarios > filters > sql filters > values source", () => {
 
 describeEE("scenarios > filters > sql filters > values source", () => {
   beforeEach(() => {
-    restore("default-ee");
+    restore("default");
     cy.signInAsAdmin();
     setTokenFeatures("all");
+    blockUserGroupPermissions(USER_GROUPS.ALL_USERS_GROUP);
     cy.intercept("POST", "/api/dataset/parameter/values").as("parameterValues");
     cy.intercept("GET", "/api/card/*/params/*/values").as(
       "cardParameterValues",

--- a/e2e/test/scenarios/permissions/permissions-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/permissions-reproductions.cy.spec.js
@@ -8,6 +8,7 @@ import {
 import {
   assertDatasetReqIsSandboxed,
   assertQueryBuilderRowCount,
+  blockUserGroupPermissions,
   commandPaletteSearch,
   describeEE,
   entityPickerModal,
@@ -605,9 +606,10 @@ describeEE("issue 24966", () => {
   const dashboardDetails = { parameters: [dashboardFilter] };
 
   beforeEach(() => {
-    restore("default-ee");
+    restore("default");
     cy.signInAsAdmin();
     setTokenFeatures("all");
+    blockUserGroupPermissions(USER_GROUPS.ALL_USERS_GROUP);
 
     // Add user attribute to existing user
     cy.request("PUT", `/api/user/${NODATA_USER_ID}`, {

--- a/e2e/test/scenarios/permissions/permissions-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/permissions-reproductions.cy.spec.js
@@ -606,7 +606,7 @@ describeEE("issue 24966", () => {
   const dashboardDetails = { parameters: [dashboardFilter] };
 
   beforeEach(() => {
-    restore("default");
+    restore();
     cy.signInAsAdmin();
     setTokenFeatures("all");
     blockUserGroupPermissions(USER_GROUPS.ALL_USERS_GROUP);

--- a/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
+++ b/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
@@ -52,7 +52,7 @@ const { DATA_GROUP, COLLECTION_GROUP } = USER_GROUPS;
 describeEE("formatting > sandboxes", () => {
   describe("admin", () => {
     beforeEach(() => {
-      restore("default-ee");
+      restore();
       cy.signInAsAdmin();
       setTokenFeatures("all");
       blockUserGroupPermissions(USER_GROUPS.ALL_USERS_GROUP);
@@ -96,7 +96,7 @@ describeEE("formatting > sandboxes", () => {
     const QUESTION_NAME = "Joined test";
 
     beforeEach(() => {
-      restore("default-ee");
+      restore();
       cy.signInAsAdmin();
       setTokenFeatures("all");
       blockUserGroupPermissions(USER_GROUPS.ALL_USERS_GROUP);
@@ -214,7 +214,7 @@ describeEE("formatting > sandboxes", () => {
 
   describe("Sandboxing reproductions", () => {
     beforeEach(() => {
-      restore("default-ee");
+      restore();
       cy.signInAsAdmin();
       setTokenFeatures("all");
       blockUserGroupPermissions(USER_GROUPS.ALL_USERS_GROUP);

--- a/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
+++ b/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
@@ -8,6 +8,7 @@ import {
 import {
   assertDatasetReqIsSandboxed,
   assertQueryBuilderRowCount,
+  blockUserGroupPermissions,
   chartPathWithFillColor,
   describeEE,
   entityPickerModal,
@@ -54,6 +55,7 @@ describeEE("formatting > sandboxes", () => {
       restore("default-ee");
       cy.signInAsAdmin();
       setTokenFeatures("all");
+      blockUserGroupPermissions(USER_GROUPS.ALL_USERS_GROUP);
       cy.visit("/admin/people");
     });
 
@@ -97,6 +99,7 @@ describeEE("formatting > sandboxes", () => {
       restore("default-ee");
       cy.signInAsAdmin();
       setTokenFeatures("all");
+      blockUserGroupPermissions(USER_GROUPS.ALL_USERS_GROUP);
 
       // Add user attribute to existing ("normal" / id:2) user
       cy.request("PUT", `/api/user/${NORMAL_USER_ID}`, {
@@ -214,6 +217,7 @@ describeEE("formatting > sandboxes", () => {
       restore("default-ee");
       cy.signInAsAdmin();
       setTokenFeatures("all");
+      blockUserGroupPermissions(USER_GROUPS.ALL_USERS_GROUP);
     });
 
     it("should allow joins to the sandboxed table (metabase-enterprise#154)", () => {

--- a/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
+++ b/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
@@ -55,7 +55,7 @@ describeEE("formatting > sandboxes", () => {
       restore();
       cy.signInAsAdmin();
       setTokenFeatures("all");
-      blockUserGroupPermissions(USER_GROUPS.ALL_USERS_GROUP);
+      preparePermissions();
       cy.visit("/admin/people");
     });
 
@@ -99,7 +99,7 @@ describeEE("formatting > sandboxes", () => {
       restore();
       cy.signInAsAdmin();
       setTokenFeatures("all");
-      blockUserGroupPermissions(USER_GROUPS.ALL_USERS_GROUP);
+      preparePermissions();
 
       // Add user attribute to existing ("normal" / id:2) user
       cy.request("PUT", `/api/user/${NORMAL_USER_ID}`, {
@@ -217,7 +217,7 @@ describeEE("formatting > sandboxes", () => {
       restore();
       cy.signInAsAdmin();
       setTokenFeatures("all");
-      blockUserGroupPermissions(USER_GROUPS.ALL_USERS_GROUP);
+      preparePermissions();
     });
 
     it("should allow joins to the sandboxed table (metabase-enterprise#154)", () => {
@@ -1189,4 +1189,10 @@ function createJoinedQuestion(name, { visitQuestion = false } = {}) {
     },
     { wrapId: true, visitQuestion },
   );
+}
+
+function preparePermissions() {
+  blockUserGroupPermissions(USER_GROUPS.ALL_USERS_GROUP);
+  blockUserGroupPermissions(USER_GROUPS.COLLECTION_GROUP);
+  blockUserGroupPermissions(USER_GROUPS.READONLY_GROUP);
 }


### PR DESCRIPTION
Closes #47095

### Description

Improvements based on these internal slack threads: https://metaboat.slack.com/archives/C505ZNNH4/p1722611219985539
https://metaboat.slack.com/archives/C505ZNNH4/p1724187422396359

Removes the `default-ee` snapshot in favor of a util that restricts all of a groups permissions. Full reason in threads. The hope is for folks to make better assertions using the helpers utilized in  #46465 to assert that permissions have been set up correctly and that the data under test is in fact sandboxed.

### How to verify

- Remove calls to `blockUserGroupPermissions` and see that the tests fail 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
