### PR TITLE
fix(sdk): apply the default viz height only in visualization view

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/Visualization.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/Visualization.tsx
@@ -23,7 +23,8 @@ export const QuestionVisualization = () => {
     onNavigateBack,
   } = useInteractiveQuestionContext();
 
-  const { height, ref, width } = useSdkElementSize();
+  const display = question?.card()?.display;
+  const { height, ref, width } = useSdkElementSize(display);
 
   if (isQuestionLoading) {
     return <SdkLoader />;

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionResult.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionResult.tsx
@@ -126,7 +126,7 @@ export const InteractiveQuestionResult = ({
   return (
     <Box
       className={cx(CS.flexFull, CS.fullWidth)}
-      h={height}
+      h={height ?? "100%"}
       bg="var(--mb-color-bg-question)"
     >
       {content}

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionResult.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionResult.tsx
@@ -1,12 +1,11 @@
 import cx from "classnames";
-import { type ReactElement, type ReactNode, useMemo, useState } from "react";
+import { type ReactElement, type ReactNode, useState } from "react";
 import { t } from "ttag";
 
 import {
   SdkError,
   SdkLoader,
 } from "embedding-sdk/components/private/PublicComponentWrapper";
-import { getDefaultVizHeight } from "embedding-sdk/lib/default-height";
 import CS from "metabase/css/core/index.css";
 import { Box, Flex, Group, Stack } from "metabase/ui";
 
@@ -72,14 +71,6 @@ export const InteractiveQuestionResult = ({
   const { question, queryResults, isQuestionLoading } =
     useInteractiveQuestionContext();
 
-  const card = question?.card();
-
-  const defaultHeight = useMemo(() => {
-    if (questionView === "visualization" && card) {
-      return getDefaultVizHeight(card.display);
-    }
-  }, [questionView, card]);
-
   let content;
 
   if (isQuestionLoading) {
@@ -135,7 +126,7 @@ export const InteractiveQuestionResult = ({
   return (
     <Box
       className={cx(CS.flexFull, CS.fullWidth)}
-      h={height ?? defaultHeight}
+      h={height}
       bg="var(--mb-color-bg-question)"
     >
       {content}

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionResult.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionResult.tsx
@@ -1,6 +1,5 @@
 import cx from "classnames";
-import type { ReactElement, ReactNode } from "react";
-import { useState } from "react";
+import { type ReactElement, type ReactNode, useMemo, useState } from "react";
 import { t } from "ttag";
 
 import {
@@ -74,7 +73,12 @@ export const InteractiveQuestionResult = ({
     useInteractiveQuestionContext();
 
   const card = question?.card();
-  const defaultHeight = card ? getDefaultVizHeight(card.display) : undefined;
+
+  const defaultHeight = useMemo(() => {
+    if (questionView === "visualization" && card) {
+      return getDefaultVizHeight(card.display);
+    }
+  }, [questionView, card]);
 
   let content;
 

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
@@ -1,4 +1,5 @@
 import { within } from "@testing-library/react";
+import type { FC, ReactNode } from "react";
 
 import {
   setupAlertsEndpoints,
@@ -66,8 +67,10 @@ function InteractiveQuestionTestResult() {
 
 const setup = ({
   isValidCard = true,
+  wrapper: Wrapper = props => props.children,
 }: {
   isValidCard?: boolean;
+  wrapper?: FC<{ children: ReactNode }>;
 } = {}) => {
   const { state } = setupSdkState({
     currentUser: TEST_USER,
@@ -93,9 +96,11 @@ const setup = ({
   setupCardQueryEndpoints(TEST_CARD, TEST_DATASET);
 
   return renderWithProviders(
-    <InteractiveQuestion questionId={TEST_CARD.id}>
-      <InteractiveQuestionTestResult />
-    </InteractiveQuestion>,
+    <Wrapper>
+      <InteractiveQuestion questionId={TEST_CARD.id}>
+        <InteractiveQuestionTestResult />
+      </InteractiveQuestion>
+    </Wrapper>,
     {
       mode: "sdk",
       sdkProviderProps: {

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
@@ -1,5 +1,4 @@
 import { within } from "@testing-library/react";
-import type { FC, ReactNode } from "react";
 
 import {
   setupAlertsEndpoints,
@@ -67,10 +66,8 @@ function InteractiveQuestionTestResult() {
 
 const setup = ({
   isValidCard = true,
-  wrapper: Wrapper = props => props.children,
 }: {
   isValidCard?: boolean;
-  wrapper?: FC<{ children: ReactNode }>;
 } = {}) => {
   const { state } = setupSdkState({
     currentUser: TEST_USER,
@@ -96,11 +93,9 @@ const setup = ({
   setupCardQueryEndpoints(TEST_CARD, TEST_DATASET);
 
   return renderWithProviders(
-    <Wrapper>
-      <InteractiveQuestion questionId={TEST_CARD.id}>
-        <InteractiveQuestionTestResult />
-      </InteractiveQuestion>
-    </Wrapper>,
+    <InteractiveQuestion questionId={TEST_CARD.id}>
+      <InteractiveQuestionTestResult />
+    </InteractiveQuestion>,
     {
       mode: "sdk",
       sdkProviderProps: {

--- a/enterprise/frontend/src/embedding-sdk/hooks/private/use-sdk-element-size.ts
+++ b/enterprise/frontend/src/embedding-sdk/hooks/private/use-sdk-element-size.ts
@@ -1,11 +1,13 @@
 import { useElementSize } from "@mantine/hooks";
 
-export const useSdkElementSize = () => {
+import { getDefaultVizHeight } from "embedding-sdk/lib/default-height";
+
+export const useSdkElementSize = (display?: string) => {
   const { height, ref, width } = useElementSize();
 
   // Some of our components by default don't have a specified height (i.e. the Visualization component)
   // and are rendering with a height of 0. This is a workaround to set a default height for those components.
-  const elementHeight = height || (width ? width / 9 : 500);
+  const elementHeight = height || (display && getDefaultVizHeight(display));
 
   return { height: elementHeight, ref, width };
 };


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/46825

### Description

Fixes the interactive question's filters panel being cut-off due to the default visualization height. We only apply the default viz height when in the visualization view, and there is no parent height available. We fallback to full-height if the parent height is already available.

```jsx
<div className="App" style={{ width: 1200, height: 800 }}>
  <InteractiveQuestion questionId={158} />
</div>
```

Note: we can't test this without E2E, as react-testing-library doesn't actually have layout engine that defines the height, so `useElementSize` doesn't take effect

### How to verify

- Use the above code sample
- The default visualization height should only take effect when in the Visualization tab, and there is no parent height available.

### Demo

Without parent height defined:

https://github.com/user-attachments/assets/f90e85fc-d790-4470-b8c1-47e0bedce839