### PR TITLE
Fix `DateTimeRange` substitution for open ranges

### DIFF
--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -355,7 +355,7 @@ describe("issue 12720, issue 47172", () => {
     );
     cy.findByTestId("question-row-count").should(
       "have.text",
-      "Showing 1980 rows",
+      "Showing 1,980 rows",
     );
   });
 });

--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -332,7 +332,7 @@ describe("issue 12720, issue 47172", () => {
     clickThrough("Orders");
   });
 
-  it("should apply yhe specific (before|after) filter on a native question with field filter (metabase#47172)", () => {
+  it("should apply the specific (before|after) filter on a native question with field filter (metabase#47172)", () => {
     visitDashboard(ORDERS_DASHBOARD_ID);
 
     getDashboardCard(1).within(() => {
@@ -347,13 +347,15 @@ describe("issue 12720, issue 47172", () => {
     });
 
     cy.location("search").should("eq", `?filter=${dashboardFilter.default}`);
-    cy.wait("@cardQuery").then(({ response }) => {
-      expect(response.body.status).to.eq("completed");
-    });
-    tableInteractive().should("be.visible").and("not.be.empty");
+    cy.wait("@cardQuery");
+    tableInteractive().should("be.visible").and("contain", "97.44");
     cy.findByTestId("question-row-count").should(
       "not.have.text",
       "Showing 0 rows",
+    );
+    cy.findByTestId("question-row-count").should(
+      "have.text",
+      "Showing 1980 rows",
     );
   });
 });

--- a/src/metabase/driver/sql/parameters/substitution.clj
+++ b/src/metabase/driver/sql/parameters/substitution.clj
@@ -215,12 +215,19 @@
 
 (defmethod ->replacement-snippet-info [:sql DateTimeRange]
   [driver {:keys [start end]} & [field-identifier]]
-  (let [[start end] (map (fn [s]
-                           (->prepared-substitution driver (maybe-parse-temporal-literal s)))
-                         [start end])]
-    {:replacement-snippet     (format "%s >= %s AND %s < %s"
-                                      field-identifier (:sql-string start) field-identifier (:sql-string end))
-     :prepared-statement-args (concat (:param-values start) (:param-values end))}))
+  (let [[start end]       (map (fn [s]
+                                 (when s
+                                   (->prepared-substitution driver (maybe-parse-temporal-literal s))))
+                               [start end])
+        start-expr-native (when start
+                            (format "%s >= %s" field-identifier (:sql-string start)))
+        end-expr-native   (when end
+                            (format "%s < %s" field-identifier (:sql-string end)))]
+    {:replacement-snippet     (str/join " AND " (remove nil? [start-expr-native end-expr-native]))
+     :prepared-statement-args (into []
+                                    (comp (keep :param-values)
+                                              cat)
+                                     [start end])}))
 
 ;;; ------------------------------------- Field Filter replacement snippet info --------------------------------------
 

--- a/src/metabase/driver/sql/parameters/substitution.clj
+++ b/src/metabase/driver/sql/parameters/substitution.clj
@@ -226,8 +226,8 @@
     {:replacement-snippet     (str/join " AND " (remove nil? [start-expr-native end-expr-native]))
      :prepared-statement-args (into []
                                     (comp (keep :param-values)
-                                              cat)
-                                     [start end])}))
+                                          cat)
+                                    [start end])}))
 
 ;;; ------------------------------------- Field Filter replacement snippet info --------------------------------------
 

--- a/test/metabase/driver/sql/parameters/substitute_test.clj
+++ b/test/metabase/driver/sql/parameters/substitute_test.clj
@@ -552,7 +552,7 @@
          expand*
          (dissoc :template-tags)))))
 
-(deftest expand-field-filters-for-datetime-field-test
+(deftest expand-field-filters-for-date-field-test
   (mt/with-temporary-setting-values [start-of-week :sunday]
     (testing "dimension (date/single)"
       (is (= {:query  "SELECT * FROM checkins WHERE \"PUBLIC\".\"CHECKINS\".\"DATE\" = ?;"
@@ -665,8 +665,8 @@
          expand*
          (dissoc :template-tags)))))
 
-;;;; The following test is [[expand-field-filters-for-datetime-field-test]] adjusted to datetime field.
-(deftest expand-field-filters-for-date-field-test
+;;;; The following test is [[expand-field-filters-for-date-field-test]] adjusted to datetime field.
+(deftest expand-field-filters-for-datetime-field-test
   (mt/with-temporary-setting-values [start-of-week :sunday]
     (testing "dimension (date/all-options) (`on` filter with with time)"
       (is (= {:query "SELECT * FROM orders WHERE \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" >= ? AND \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" < ?;",

--- a/test/metabase/driver/sql/parameters/substitute_test.clj
+++ b/test/metabase/driver/sql/parameters/substitute_test.clj
@@ -552,7 +552,7 @@
          expand*
          (dissoc :template-tags)))))
 
-(deftest expand-field-filters-test
+(deftest expand-field-filters-for-datetime-field-test
   (mt/with-temporary-setting-values [start-of-week :sunday]
     (testing "dimension (date/single)"
       (is (= {:query  "SELECT * FROM checkins WHERE \"PUBLIC\".\"CHECKINS\".\"DATE\" = ?;"
@@ -642,6 +642,146 @@
       (is (= {:query  "SELECT * FROM ORDERS WHERE TOTAL > 100  AND CREATED_AT < now()"
               :params []}
              (expand-with-field-filter-param
+              "SELECT * FROM ORDERS WHERE TOTAL > 100 [[AND {{created}} #]] AND CREATED_AT < now()"
+              nil))))))
+
+(defn- expand-with-field-filter-param-on-datetime-field
+  ([field-filter-param]
+   (expand-with-field-filter-param-on-datetime-field "SELECT * FROM orders WHERE {{date}};" field-filter-param))
+
+  ([sql field-filter-param]
+   ;; TIMEZONE FIXME
+   (mt/with-clock (t/mock-clock #t "2016-06-07T12:00-00:00" (t/zone-id "UTC"))
+     (-> {:native     {:query
+                       sql
+                       :template-tags {"date" {:name         "date"
+                                               :display-name "Created At"
+                                               :type         :dimension
+                                               :widget-type  :date/all-options
+                                               :dimension    [:field (meta/id :orders :created-at) nil]}}}
+          :parameters (when field-filter-param
+                        [(merge {:target [:dimension [:template-tag "date"]]}
+                                field-filter-param)])}
+         expand*
+         (dissoc :template-tags)))))
+
+;;;; The following test is [[expand-field-filters-for-datetime-field-test]] adjusted to datetime field.
+(deftest expand-field-filters-for-date-field-test
+  (mt/with-temporary-setting-values [start-of-week :sunday]
+    (testing "dimension (date/all-options) (`on` filter with with time)"
+      (is (= {:query "SELECT * FROM orders WHERE \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" >= ? AND \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" < ?;",
+              :params [#t "2024-08-20T10:20Z[UTC]"
+                       #t "2024-08-20T10:21Z[UTC]"]}
+             (expand-with-field-filter-param-on-datetime-field {:type :date/all-options, :value "2024-08-20T10:20:00"}))))
+    (testing "dimension (date/all-options) (`before` filter with with time)"
+      (is (= {:query "SELECT * FROM orders WHERE \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" < ?;",
+              :params [#t "2024-08-20T10:20Z[UTC]"]}
+             (expand-with-field-filter-param-on-datetime-field {:type :date/all-options, :value "~2024-08-20T10:20:00"}))))
+    (testing "dimension (date/all-options) (`after` filter with with time)"
+      (is (= {:query "SELECT * FROM orders WHERE \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" >= ?;",
+              :params [#t "2024-08-20T10:21Z[UTC]"]}
+             (expand-with-field-filter-param-on-datetime-field {:type :date/all-options, :value "2024-08-20T10:20:00~"}))))
+    (testing "dimension (date/single)"
+      (is (= {:query
+              "SELECT * FROM orders WHERE \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" >= ? AND \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" < ?;",
+              :params [#t "2016-07-01T00:00Z[UTC]"
+                       #t "2016-07-02T00:00Z[UTC]"]}
+             (expand-with-field-filter-param-on-datetime-field {:type :date/single, :value "2016-07-01"}))))
+    (testing "dimension (date/range)"
+      (is (= {:query
+              "SELECT * FROM orders WHERE \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" >= ? AND \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" < ?;",
+              :params [#t "2016-07-01T00:00Z[UTC]"
+                       #t "2016-08-02T00:00Z[UTC]"]}
+             (expand-with-field-filter-param-on-datetime-field {:type :date/range, :value "2016-07-01~2016-08-01"}))))
+    (testing "dimension (date/month-year)"
+      (is (= {:query
+              "SELECT * FROM orders WHERE \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" >= ? AND \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" < ?;",
+              :params [#t "2016-07-01T00:00Z[UTC]"
+                       #t "2016-08-01T00:00Z[UTC]"]}
+             (expand-with-field-filter-param-on-datetime-field {:type :date/month-year, :value "2016-07"}))))
+    (testing "dimension (date/quarter-year)"
+      (is (= {:query
+              "SELECT * FROM orders WHERE \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" >= ? AND \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" < ?;",
+              :params [#t "2016-01-01T00:00Z[UTC]"
+                       #t "2016-04-01T00:00Z[UTC]"]}
+             (expand-with-field-filter-param-on-datetime-field {:type :date/quarter-year, :value "Q1-2016"}))))
+    (testing "dimension (date/all-options, before)"
+      (is (= {:query "SELECT * FROM orders WHERE \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" < ?;", :params [#t "2016-07-01T00:00Z[UTC]"]}
+             (expand-with-field-filter-param-on-datetime-field {:type :date/all-options, :value "~2016-07-01"}))))
+    (testing "dimension (date/all-options, after)"
+      (is (= {:query "SELECT * FROM orders WHERE \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" >= ?;", :params [#t "2016-07-02T00:00Z[UTC]"]}
+             (expand-with-field-filter-param-on-datetime-field {:type :date/all-options, :value "2016-07-01~"}))))
+    (testing "relative date — 'yesterday'"
+      (is (= {:query
+              "SELECT * FROM orders WHERE \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" >= ? AND \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" < ?;",
+              :params [#t "2016-06-06T00:00Z[UTC]"
+                       #t "2016-06-07T00:00Z[UTC]"]}
+             (expand-with-field-filter-param-on-datetime-field {:type :date/range, :value "yesterday"}))))
+    (testing "relative date — 'past7days'"
+      (is (= {:query
+              "SELECT * FROM orders WHERE \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" >= ? AND \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" < ?;",
+              :params [#t "2016-05-31T00:00Z[UTC]"
+                       #t "2016-06-07T00:00Z[UTC]"]}
+             (expand-with-field-filter-param-on-datetime-field {:type :date/range, :value "past7days"}))))
+    (testing "relative date — 'past30days'"
+      (is (= {:query
+              "SELECT * FROM orders WHERE \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" >= ? AND \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" < ?;",
+              :params [#t "2016-05-08T00:00Z[UTC]"
+                       #t "2016-06-07T00:00Z[UTC]"]}
+             (expand-with-field-filter-param-on-datetime-field {:type :date/range, :value "past30days"}))))
+    (testing "relative date — 'thisweek'"
+      (is (= {:query
+              "SELECT * FROM orders WHERE \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" >= ? AND \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" < ?;",
+              :params [#t "2016-06-05T00:00Z[UTC]"
+                       #t "2016-06-12T00:00Z[UTC]"]}
+             (expand-with-field-filter-param-on-datetime-field {:type :date/range, :value "thisweek"}))))
+    (testing "relative date — 'thismonth'"
+      (is (= {:query
+              "SELECT * FROM orders WHERE \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" >= ? AND \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" < ?;",
+              :params [#t "2016-06-01T00:00Z[UTC]"
+                       #t "2016-07-01T00:00Z[UTC]"]}
+             (expand-with-field-filter-param-on-datetime-field {:type :date/range, :value "thismonth"}))))
+    (testing "relative date — 'thisyear'"
+      (is (= {:query
+              "SELECT * FROM orders WHERE \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" >= ? AND \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" < ?;",
+              :params [#t "2016-01-01T00:00Z[UTC]"
+                       #t "2017-01-01T00:00Z[UTC]"]}
+             (expand-with-field-filter-param-on-datetime-field {:type :date/range, :value "thisyear"}))))
+    (testing "relative date — 'lastweek'"
+      (is (= {:query
+              "SELECT * FROM orders WHERE \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" >= ? AND \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" < ?;",
+              :params [#t "2016-05-29T00:00Z[UTC]"
+                       #t "2016-06-05T00:00Z[UTC]"]}
+             (expand-with-field-filter-param-on-datetime-field {:type :date/range, :value "lastweek"}))))
+    (testing "relative date — 'lastmonth'"
+      (is (= {:query
+              "SELECT * FROM orders WHERE \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" >= ? AND \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" < ?;",
+              :params [#t "2016-05-01T00:00Z[UTC]"
+                       #t "2016-06-01T00:00Z[UTC]"]}
+             (expand-with-field-filter-param-on-datetime-field {:type :date/range, :value "lastmonth"}))))
+    (testing "relative date — 'lastyear'"
+      (is (= {:query
+              "SELECT * FROM orders WHERE \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" >= ? AND \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" < ?;",
+              :params [#t "2015-01-01T00:00Z[UTC]"
+                       #t "2016-01-01T00:00Z[UTC]"]}
+             (expand-with-field-filter-param-on-datetime-field {:type :date/range, :value "lastyear"}))))
+    (testing "dimension with no value — just replace with an always true clause (e.g. 'WHERE 1 = 1')"
+      (is (= {:query  "SELECT * FROM orders WHERE 1 = 1;"
+              :params []}
+             (expand-with-field-filter-param-on-datetime-field nil))))
+    (testing "dimension — number — should get parsed to Number"
+      (is (= {:query  "SELECT * FROM orders WHERE \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" = 100;"
+              :params []}
+             (expand-with-field-filter-param-on-datetime-field {:type :number, :value "100"}))))
+    (testing "dimension — text"
+      (is (= {:query  "SELECT * FROM orders WHERE \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" = ?;"
+              :params ["100"]}
+             (expand-with-field-filter-param-on-datetime-field {:type :text, :value "100"}))))
+    (testing (str "*OPTIONAL* Field Filter params should not get replaced with 1 = 1 if the param is not present "
+                  "(#5541, #9489). *Optional params should be emitted entirely.")
+      (is (= {:query  "SELECT * FROM ORDERS WHERE TOTAL > 100  AND CREATED_AT < now()"
+              :params []}
+             (expand-with-field-filter-param-on-datetime-field
               "SELECT * FROM ORDERS WHERE TOTAL > 100 [[AND {{created}} #]] AND CREATED_AT < now()"
               nil))))))
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/47172

This PR fixes replacement snippet generation for open ranges.

Additionally adds E2E reproduction for this issue, which confirms it's been fixed.

The assertion when the question is in the dashboard
<img width="1993" alt="image" src="https://github.com/user-attachments/assets/e214c59f-f24e-4ca8-bd65-2f5ad8de0386">

The final assertion on the question itself
<img width="1993" alt="image" src="https://github.com/user-attachments/assets/3d4b6abe-98a9-4b49-824b-53758a756698">