### PR TITLE
Don't encrypt boolean settings (by default)

### DIFF
--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -212,7 +212,6 @@
                 (application-name-for-setting-descriptions))
   :type       :boolean
   :default    true
-  :encryption :never
   :visibility :public
   :audit      :getter)
 

--- a/src/metabase/util/encryption.clj
+++ b/src/metabase/util/encryption.clj
@@ -37,6 +37,11 @@
 (defonce ^:private ^{:tag 'bytes} default-secret-key
   (validate-and-hash-secret-key (env/env :mb-encryption-secret-key)))
 
+(defn default-encryption-enabled?
+  "Is the `MB_ENCRYPTION_SECRET_KEY` set, enabling encryption?"
+  []
+  (boolean default-secret-key))
+
 ;; log a nice message letting people know whether DB details encryption is enabled
 (when-not *compile-files*
   (log/info

--- a/test/metabase/models/setting_test.clj
+++ b/test/metabase/models/setting_test.clj
@@ -105,6 +105,13 @@
   :encryption :never
   :feature    :test-feature)
 
+(defsetting test-boolean-encrypted-setting
+  "Setting to test that a boolean setting can be encrypted, even though the default is not to. This only shows up in dev."
+  :visibility :internal
+  :type       :boolean
+  :encryption :maybe
+  :feature    :test-feature)
+
 ;; ## HELPER FUNCTIONS
 
 (defn db-fetch-setting
@@ -1556,3 +1563,9 @@
       (is (not= "foobar" (actual-value-in-db :test-never-encrypted-setting)))
       (setting/migrate-encrypted-settings!)
       (is (not= "foobar" (actual-value-in-db :test-never-encrypted-setting))))))
+
+(deftest boolean-settings-default-to-never-encrypted
+  (testing "Boolean settings default to never encrypted"
+    (is (= :never (:encryption (setting/resolve-setting :test-boolean-setting)))))
+  (testing "Boolean settings can be encrypted"
+    (is (= :maybe (:encryption (setting/resolve-setting :test-boolean-encrypted-setting))))))


### PR DESCRIPTION
We have tooling to disable encryption on settings even when the `MB_ENCRYPTION_SECRET_KEY` is set. Turn it on by default for all boolean settings, which don't need to be encrypted.

I also optimized the code that decrypts settings on startup because I didn't want to delay startup if someone had set a bunch of boolean settings. With 20 set, the old version added about 200+ ms to startup, about 10ms per boolean setting, whether or not it was encrypted or in the DB already. The optimized version selects all the never-encrypt values from the database at once (a bit silly, but we also just exclude raw `true` and `false` values so we don't bother checking them) and updates them if they're encrypted - this adds ~40ms to startup with 20 encrypted boolean settings (about 2ms per boolean setting) and ~5ms to startup on subsequent runs, when no encrypted values are in the DB.

Fixes #47101 