### PR TITLE
Re-add `creator` to query validation API

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/query_reference_validation/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/query_reference_validation/api.clj
@@ -24,7 +24,8 @@
 (defn- present [card]
   (-> card
       (select-keys [:id :description :collection_id :name :entity_id :archived :collection_position
-                    :display :collection_preview :dataset_query :last_used_at :errors :collection])
+                    :display :collection_preview :dataset_query :last_used_at :errors :collection
+                    :creator])
       (update :collection (fn present-collection [collection]
                             {:id (:id collection)
                              :name (:name collection)

--- a/enterprise/backend/test/metabase_enterprise/query_reference_validation/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/query_reference_validation/api_test.clj
@@ -304,3 +304,25 @@
   (mt/with-premium-features #{:query-reference-validation}
     (testing "The endpoint is unavailable for normal users"
       (is (mt/user-http-request :rasta :get 403 url)))))
+
+(deftest all-expected-keys-are-present
+  (testing "All the expected keys are present"
+    (with-test-setup!
+      (is (= (repeat 4 #{:archived
+                         :collection
+                         :collection_id
+                         :collection_position
+                         :collection_preview
+                         :creator
+                         :dataset_query
+                         :description
+                         :display
+                         :entity_id
+                         :errors
+                         :id
+                         :last_used_at
+                         :name})
+             (->> (get! {})
+                  :data
+                  (map keys)
+                  (map set)))))))


### PR DESCRIPTION
I accidentally removed this in a previous commit 😅 