### PR TITLE
Ensure that CI checks fail if cljs tests fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -394,7 +394,7 @@
     "storybook": "yarn build:cljs && start-storybook -p 6006",
     "storybook-embedding-sdk": "yarn build:cljs && IS_EMBEDDING_SDK=true start-storybook -p 6006",
     "test": "yarn test-unit && yarn test-timezones && yarn test-cypress",
-    "test-cljs": "yarn && shadow-cljs compile test",
+    "test-cljs": "yarn && shadow-cljs compile test && node target/node-tests.js",
     "test-cypress": "yarn build && ./bin/build-for-test && yarn test-cypress-run",
     "test-cypress-open": "./bin/build-for-test && CYPRESS_FE_HEALTHCHECK=false yarn test-cypress-run --e2e --open",
     "test-cypress-open-no-backend": "E2E_HOST='http://localhost:3000' yarn test-cypress-run --e2e --open",

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -37,5 +37,4 @@
   :test
   {:target    :node-test
    :output-to "target/node-tests.js"
-   :ns-regexp "-test$"
-   :autorun   true}}}
+   :ns-regexp "-test$"}}}

--- a/test/metabase/lib/js_test.cljs
+++ b/test/metabase/lib/js_test.cljs
@@ -317,6 +317,7 @@
           :cards [{:id            metric-id
                    :name          "Sum of Cans"
                    :database-id   (meta/id)
+                   :table-id      (meta/id :venues)
                    :dataset-query metric-definition
                    :description   "Number of toucans plus number of pelicans"
                    :type          :metric}]})

--- a/test/metabase/lib/js_test.cljs
+++ b/test/metabase/lib/js_test.cljs
@@ -396,7 +396,7 @@
     (lib.js/expression-clause "time-interval" [(meta/field-metadata :products :created-at) 10 "day"] nil)
 
     [:relative-time-interval {} [:field {} int?] 10 :day 10 :month]
-    (lib.js/expression-clause "time-interval" [(meta/field-metadata :products :created-at) 10 "day" 10 "month"] nil)
+    (lib.js/expression-clause "relative-time-interval" [(meta/field-metadata :products :created-at) 10 "day" 10 "month"] nil)
 
     [:relative-datetime {} :current :day]
     (lib.js/expression-clause "relative-datetime" ["current" "day"] nil)


### PR DESCRIPTION
### Description

Ensure that if `yarn test-cljs` fails it fails the CI checks

When configured to autorun, the command `shadow-cljs compile test` will exit with success even if test failures occur in the node test. See https://github.com/thheller/shadow-cljs/issues/425

In order to ensure our CI checks fail when cljs tests fail, we need to invoke node directly. To prevent running the tests twice, remove `:autorun true` from the `:test` target in shadow-cljs.edn.

Prior to this change, the command exits successfully, even though some tests are failing. After this change, test failures cause the yarn command to fail (and any currently failing tests have been fixed or disabled).

### How to verify

Describe the steps to verify that the changes are working as expected.

`yarn test-cljs`

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
