### PR TITLE
docs - locale for static and public links

### DIFF
--- a/docs/embedding/static-embedding-parameters.md
+++ b/docs/embedding/static-embedding-parameters.md
@@ -203,13 +203,14 @@ If the download button is missing when you expected it to be available, check th
 
 To display a static embed in a different language, you can set a locale for the embed. See a list of [supported locales](https://github.com/metabase/metabase/tree/master/locales).
 
-To set a locale, add `?locale=[LOCALE]` to your iframe URL, e.g., (`?locale=de-DE`).
-
-Locale isn't an appearance setting, so if you're also appending appearance settings to your URL, you'll need to separate them with a `#` symbol, like so:
+To set a locale, add `locale=[LOCALE]` to your iframe URL, e.g., `locale=de-DE`.
+Locale must come after the `?` in the URL and before the `#` (if you're including appearance settings). Like so:
 
 ```javascript
 iframeUrl = urljoin(METABASE_SITE_URL, "/embed/dashboard/" + token + "?locale=de-DE#theme=night&background=false&bordered=true&titled=true&downloads=true")
 ```
+
+Locale only affects UI elements; Metabase won't translate the text of your items (e.g., it won't translate the title of a question).
 
 ## Maximum request size
 

--- a/docs/embedding/static-embedding-parameters.md
+++ b/docs/embedding/static-embedding-parameters.md
@@ -189,7 +189,7 @@ You can preview appearance settings from your question or dashboard's [embedded 
 
 \* Available on [Pro](https://www.metabase.com/product/pro) and [Enterprise](https://www.metabase.com/product/enterprise) plans.
 
-### Allow people to download the results of an embedded question
+## Allow people to download the results of an embedded question
 
 {% include plans-blockquote.html feature="Downloading results" %}
 
@@ -198,6 +198,18 @@ By default, Metabase will include a **Download** button on embedded questions. Y
 If the download button is missing when you expected it to be available, check that the URL in the `src` attribute for your iframe has the parameter `hide_download_button=false`.
 
 > Downloading results is available only for questions, not dashboards.
+
+## Setting locale on a static embed
+
+To display a static embed in a different language, you can set a locale for the embed. See a list of [supported locales](https://github.com/metabase/metabase/tree/master/locales).
+
+To set a locale, add `?locale=[LOCALE]` to your iframe URL, e.g., (`?locale=de-DE`).
+
+Locale isn't an appearance setting, so if you're also appending appearance settings to your URL, you'll need to separate them with a `#` symbol, like so:
+
+```javascript
+iframeUrl = urljoin(METABASE_SITE_URL, "/embed/dashboard/" + token + "?locale=de-DE#theme=night&background=false&bordered=true&titled=true&downloads=true")
+```
 
 ## Maximum request size
 

--- a/docs/permissions/data.md
+++ b/docs/permissions/data.md
@@ -55,13 +55,13 @@ View data permission settings apply to different levels in your database:
 | View data permission | Database | Schema | Table |
 | -------------------- | -------- | ------ | ----- |
 | Can view             | ✅        | ✅      | ✅     |
-| Granular*             | ✅        | ✅      | ❌     |
+| Granular\*           | ✅        | ✅      | ❌     |
 | Sandboxed            | ❌        | ❌      | ✅     |
 | Impersonated         | ✅        | ❌      | ❌     |
 | Blocked              | ✅        | ✅      | ✅     |
 
 
-* The "Granular" setting is not itself a type of permission; it just signals that permissions are set at a level below the current level. For example, you can select "Granular" at a schema level to set permissions per table for tables in that schema.
+\* The "Granular" setting is not itself a type of permission; it just signals that permissions are set at a level below the current level. For example, you can select "Granular" at a schema level to set permissions per table for tables in that schema.
 
 In the free, open-source version of Metabase, the **View data** setting defaults to "Can view". Since the setting's options aren't available in the OSS version, Metabase will only display this **View data** setting in the Pro/Enterprise version.
 

--- a/docs/questions/sharing/public-links.md
+++ b/docs/questions/sharing/public-links.md
@@ -165,7 +165,21 @@ Note that the name of the filter in the URL should be specified in lower case, a
 /dashboard/42?filter_for_user_zip_code=02116
 ```
 
-## Disable public sharing in Metabase
+## Setting a locale on a public link
+
+To display a publicly linked item in a different language, you can set its locale. See a list of [supported locales](https://github.com/metabase/metabase/tree/master/locales).
+
+To set a locale, add `locale=[LOCALE]` to your URL, e.g., `locale=de-DE`.
+
+Locale must come after the `?` in the URL and before the `#` (if you're including appearance settings). Like so:
+
+```txt
+https://www.example.com/public/dashboard/tk421r2d2-c3P0-4a60-7e5a-30df125122e9?locale=de-DE#theme=night
+```
+
+Locale only affects UI elements; Metabase won't translate the text of your items (e.g., it won't translate the title of a question).
+
+## Disable public sharing
 
 Public sharing is enabled by default.
 


### PR DESCRIPTION
How to set locale for static and public links.

Also tacked on a small formatting fix.