### PR TITLE
Add logging catch around query analysis worker

### DIFF
--- a/src/metabase/task/analyze_queries.clj
+++ b/src/metabase/task/analyze_queries.clj
@@ -38,29 +38,32 @@
   (max fail-wait-ms (wait-proportional time-taken-ms)))
 
 (defn- analyzer-loop* [stop-after next-card-id-fn]
-  (loop [remaining stop-after]
-    (when (public-settings/query-analysis-enabled)
+  (try
+    (loop [remaining stop-after]
       (let [card-or-id (next-card-id-fn)
             card-id    (u/the-id card-or-id)
             timer      (u/start-timer)
             card       (query-analysis/->analyzable card-or-id)]
-        (if (failure-map/non-retryable? card)
-          (log/warnf "Skipping analysis of Card %s as its query has caused failures in the past." card-id)
-          (try
-            (query-analysis/analyze-card! card)
-            (failure-map/track-success! card)
-            (let [taken-ms (Math/ceil (u/since-ms timer))
-                  sleep-ms (wait-proportional taken-ms)]
-              (log/debugf "Query analysis for Card %s took %sms (incl. persisting)" card-id taken-ms)
-              (log/debugf "Waiting %sms before analysing further cards" sleep-ms)
-              (Thread/sleep sleep-ms))
-            (catch Exception e
-              (log/errorf e "Error analysing and updating query for Card %s" card-id)
-              (failure-map/track-failure! card)
-              (Thread/sleep (wait-fail (u/since-ms timer))))))
-        (cond
-          (nil? remaining) (recur nil)
-          (> remaining 1) (recur (dec remaining)))))))
+        (when (public-settings/query-analysis-enabled)
+          (if (failure-map/non-retryable? card)
+            (log/warnf "Skipping analysis of Card %s as its query has caused failures in the past." card-id)
+            (try
+              (query-analysis/analyze-card! card)
+              (failure-map/track-success! card)
+              (let [taken-ms (Math/ceil (u/since-ms timer))
+                    sleep-ms (wait-proportional taken-ms)]
+                (log/debugf "Query analysis for Card %s took %sms (incl. persisting)" card-id taken-ms)
+                (log/debugf "Waiting %sms before analysing further cards" sleep-ms)
+                (Thread/sleep sleep-ms))
+              (catch Exception e
+                (log/errorf e "Error analysing and updating query for Card %s" card-id)
+                (failure-map/track-failure! card)
+                (Thread/sleep (wait-fail (u/since-ms timer))))))
+          (cond
+            (nil? remaining) (recur nil)
+            (> remaining 1)  (recur (dec remaining))))))
+    (catch Exception e
+      (log/error e "Error attempting to analyse the next card in the queue"))))
 
 (defn- analyzer-loop!
   ([]

--- a/src/metabase/task/analyze_queries.clj
+++ b/src/metabase/task/analyze_queries.clj
@@ -63,7 +63,7 @@
             (nil? remaining) (recur nil)
             (> remaining 1)  (recur (dec remaining))))))
     (catch Exception e
-      (log/error e "Error attempting to analyse the next card in the queue"))))
+      (log/error e "Unhandled error when attempting to analyse the next card in the queue"))))
 
 (defn- analyzer-loop!
   ([]


### PR DESCRIPTION
I'm still trying to track down the queuing issue that causes certain cards to get ignored for analysis, while continuing to analyze others. I cannot reproduce it in either dev (patched to run in prod mode) or in an ephemeral environment (with [logging cranked to 11](https://github.com/metabase/metabase/pull/47128)).

The only theory I have is that somehow the card is becoming a poison pill, so adding catch-all exception logging.

1. Add a catch for unexpected errors, to log it.
2. End loop on an unexpected error - let the job get rescheduled in < 1m. This is an easy way to avoid spinning.
3. Move where we check whether the feature is enabled, so that we still clear the queue if disabled.