### PR TITLE
Track query analysis failures

### DIFF
--- a/.clj-kondo/macros/metabase/task/setup/query_analysis_setup.clj
+++ b/.clj-kondo/macros/metabase/task/setup/query_analysis_setup.clj
@@ -8,5 +8,6 @@
          ~(macros.common/ignore-unused 'c2) 2
          ~(macros.common/ignore-unused 'c3) 3
          ~(macros.common/ignore-unused 'c4) 4
-         ~(macros.common/ignore-unused 'arch) 5]
+         ~(macros.common/ignore-unused 'archived) 5
+         ~(macros.common/ignore-unused 'invalid) 6]
      ~@body))

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -8969,10 +8969,6 @@ databaseChangeLog:
             - columnExists:
                 tableName: permissions
                 columnName: perm_value
-  - changeSet:
-      id: v51.2024-08-26T08:53:46
-      author: crisptrutski
-      comment: Add a status column to track the progress and outcome of query analysis
       changes:
         - addColumn:
             columns:

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -9120,14 +9120,19 @@ databaseChangeLog:
       id: v51.2024-08-26T08:53:46
       author: crisptrutski
       comment: Add a status column to track the progress and outcome of query analysis
+      preConditions:
+        - not:
+          - columnExists:
+              tableName: query_analysis
+              columnName: status
       changes:
         - addColumn:
+            tableName: query_analysis
             columns:
               - column:
                   name: status
                   type: ${text.type}
                   remarks: running, failed, or completed
-            tableName: query_analysis
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -8969,6 +8969,10 @@ databaseChangeLog:
             - columnExists:
                 tableName: permissions
                 columnName: perm_value
+  - changeSet:
+      id: v51.2024-08-26T08:53:46
+      author: crisptrutski
+      comment: Add a status column to track the progress and outcome of query analysis
       changes:
         - addColumn:
             columns:
@@ -9110,6 +9114,20 @@ databaseChangeLog:
               - column:
                   name: perm_value
             indexName: idx_permissions_perm_value
+
+
+- changeSet:
+      id: v51.2024-08-26T08:53:46
+      author: crisptrutski
+      comment: Add a status column to track the progress and outcome of query analysis
+      changes:
+        - addColumn:
+            columns:
+              - column:
+                  name: status
+                  type: ${text.type}
+                  remarks: running, failed, or completed
+            tableName: query_analysis
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -9115,8 +9115,7 @@ databaseChangeLog:
                   name: perm_value
             indexName: idx_permissions_perm_value
 
-
-- changeSet:
+  - changeSet:
       id: v51.2024-08-26T08:53:46
       author: crisptrutski
       comment: Add a status column to track the progress and outcome of query analysis

--- a/src/metabase/query_analysis.clj
+++ b/src/metabase/query_analysis.clj
@@ -103,15 +103,15 @@
    (query-references query (lib/normalized-query-type query)))
   ([query query-type]
    (case query-type
-       :native     (try
-                     (nqa/references-for-native query)
-                     (catch Exception e
-                       (log/debug e "Failed to analyze native query" query)))
+     :native     (try
+                   (nqa/references-for-native query)
+                   (catch Exception e
+                     (log/debug e "Failed to analyze native query" query)))
        ;; For now, all model references are resolved transitively to the ultimate field ids.
        ;; We may want to change to record model references directly rather than resolving them.
        ;; This would remove the need to invalidate consuming cards when a given model changes.
-       :query      (explicit-references (mbql.u/referenced-field-ids query))
-       :mbql/query (explicit-references (lib.util/referenced-field-ids query)))))
+     :query      (explicit-references (mbql.u/referenced-field-ids query))
+     :mbql/query (explicit-references (lib.util/referenced-field-ids query)))))
 
 (defn- update-query-analysis-for-card!
   "Clears QueryFields associated with this card and creates fresh, up-to-date-ones.

--- a/src/metabase/query_analysis.clj
+++ b/src/metabase/query_analysis.clj
@@ -107,9 +107,9 @@
                    (nqa/references-for-native query)
                    (catch Exception e
                      (log/debug e "Failed to analyze native query" query)))
-       ;; For now, all model references are resolved transitively to the ultimate field ids.
-       ;; We may want to change to record model references directly rather than resolving them.
-       ;; This would remove the need to invalidate consuming cards when a given model changes.
+     ;; For now, all model references are resolved transitively to the ultimate field ids.
+     ;; We may want to change to record model references directly rather than resolving them.
+     ;; This would remove the need to invalidate consuming cards when a given model changes.
      :query      (explicit-references (mbql.u/referenced-field-ids query))
      :mbql/query (explicit-references (lib.util/referenced-field-ids query)))))
 

--- a/src/metabase/query_analysis.clj
+++ b/src/metabase/query_analysis.clj
@@ -143,7 +143,7 @@
 
           (if-not success?
             (do
-              (log/errorf "Failed to analysis query for card %s" card-id)
+              (log/errorf "Failed to analyze query for card %s" card-id)
               (t2/update! :model/QueryAnalysis analysis-id {:status "failed"}))
             (do
               (t2/insert! :model/QueryField (map field->row (:fields references)))

--- a/src/metabase/task/sweep_query_analysis.clj
+++ b/src/metabase/task/sweep_query_analysis.clj
@@ -22,20 +22,23 @@
 ;; This number has not been chosen scientifically.
 (def ^:private max-delete-batch-size 1000)
 
-(defn- analyze-cards-without-query-fields!
+(defn- analyze-cards-without-complete-analysis!
   ([]
-   (analyze-cards-without-query-fields! query-analysis/analyze-sync!))
+   (analyze-cards-without-complete-analysis! query-analysis/analyze-sync!))
   ([analyze-fn]
    (let [cards (t2/reducible-select [:model/Card :id]
-                                    {:left-join [[:query_field :qf] [:= :qf.card_id :report_card.id]]
+                                    {:left-join [[:query_analysis :qa]
+                                                 [:= :qa.card_id :report_card.id]]
                                      :where     [:and
                                                  [:not :report_card.archived]
-                                                 [:= :qf.id nil]]})]
+                                                 [:or
+                                                  [:= :qa.id nil]
+                                                  [:not= [:coalesce :qa.status "missing"] "complete"]]]})]
      (run! analyze-fn cards))))
 
 (defn- analyze-stale-cards!
   ([]
-   (analyze-cards-without-query-fields! query-analysis/analyze-sync!))
+   (analyze-cards-without-complete-analysis! query-analysis/analyze-sync!))
   ([analyze-fn]
    ;; TODO once we are storing the hash of the query used for analysis, we'll be able to filter this properly.
    (let [cards (t2/reducible-select [:model/Card :id])]
@@ -67,7 +70,7 @@
   ([first-time? analyze-fn]
    ;; prioritize cards that are missing analysis
    (log/info "Calculating analysis for cards without any")
-   (analyze-cards-without-query-fields! analyze-fn)
+   (analyze-cards-without-complete-analysis! analyze-fn)
 
    ;; we run through all the existing analysis on our first run, as it may be stale due to an old macaw version, etc.
    (when first-time?

--- a/src/metabase/task/sweep_query_analysis.clj
+++ b/src/metabase/task/sweep_query_analysis.clj
@@ -28,12 +28,12 @@
   ([analyze-fn]
    (let [cards (t2/reducible-select [:model/Card :id]
                                     {:left-join [[:query_analysis :qa]
-                                                 [:= :qa.card_id :report_card.id]]
+                                                 [:and
+                                                  [:= :qa.card_id :report_card.id]
+                                                  [:= :qa.status "complete"]]]
                                      :where     [:and
                                                  [:not :report_card.archived]
-                                                 [:or
-                                                  [:= :qa.id nil]
-                                                  [:not= [:coalesce :qa.status "missing"] "complete"]]]})]
+                                                 [:= :qa.id nil]]})]
      (run! analyze-fn cards))))
 
 (defn- analyze-stale-cards!

--- a/test/metabase/task/analyze_queries_test.clj
+++ b/test/metabase/task/analyze_queries_test.clj
@@ -10,8 +10,8 @@
 ;; This cannot be run in parallel due to its use of the global queue.
 ;; Perhaps we should fix that...
 (deftest ^:synchronized analyzer-loop-test
-  (setup/with-test-setup! [c1 c2 c3 c4 arch]
-    (let [card-ids (map :id [c1 c2 c3 c4 arch])
+  (setup/with-test-setup! [c1 c2 c3 c4 archived invalid]
+    (let [card-ids (map :id [c1 c2 c3 c4 archived invalid])
           queue    (queue/bounded-transfer-queue 100)]
 
       ;; Make sure there is *no* pre-existing analysis.
@@ -39,4 +39,6 @@
           (testing "for an MLv2"
             (is (pos? (get-count (:id c4)))))
           (testing "but not for an archived card"
-            (is (zero? (get-count (:id arch))))))))))
+            (is (zero? (get-count (:id archived)))))
+          (testing "or the invalid card"
+            (is (zero? (get-count (:d invalid))))))))))

--- a/test/metabase/task/setup/query_analysis_setup.clj
+++ b/test/metabase/task/setup/query_analysis_setup.clj
@@ -36,7 +36,7 @@
                                   :dataset_query (mt/native-query {:query "SELECT boom, FROM"})}]
 
       ;; Make sure there is no existing analysis for the relevant cards
-      (t2/delete! :model/QueryField :card_id [:in (map :id [c1 c2 c3 c4 archived invalid])])
+      (t2/delete! :model/QueryAnalysis :card_id [:in (map :id [c1 c2 c3 c4 archived invalid])])
 
       ;; Make sure some other card has analysis
       (query-analysis/analyze-card! c3)

--- a/test/metabase/task/setup/query_analysis_setup.clj
+++ b/test/metabase/task/setup/query_analysis_setup.clj
@@ -44,7 +44,6 @@
       ;; And attempt to analyze an invalid query
       (query-analysis/analyze-card! invalid)
 
-
       (mt/call-with-map-params f [c1 c2 c3 c4 archived invalid]))))
 
 (defmacro with-test-setup!

--- a/test/metabase/task/setup/query_analysis_setup.clj
+++ b/test/metabase/task/setup/query_analysis_setup.clj
@@ -17,33 +17,39 @@
         mlv2-query        (-> (lib/query metadata-provider venues)
                               (lib/aggregate (lib/distinct venues-name)))]
 
-    (mt/with-temp [Card c1   {:query_type    "native"
-                              :dataset_query (mt/native-query {:query "SELECT id FROM venues"})}
-                   Card c2   {:query_type    "native"
-                              :dataset_query (mt/native-query {:query         "SELECT id FROM venues WHERE name = {{ name }}"
-                                                               :template-tags {"name" {:id           "_name_"
-                                                                                       :type         :text
-                                                                                       :display-name "name"
-                                                                                       :default      "qwe"}}})}
-                   Card c3   {:query_type    "query"
-                              :dataset_query (mt/mbql-query venues {:aggregation [[:distinct $name]]})}
-                   Card c4   {:query_type    "query"
-                              :dataset_query mlv2-query}
-                   Card arch {:archived      true
-                              :query_type    "native"
-                              :dataset_query (mt/native-query {:query "SELECT id FROM venues"})}]
+    (mt/with-temp [Card c1       {:query_type    "native"
+                                  :dataset_query (mt/native-query {:query "SELECT id FROM venues"})}
+                   Card c2       {:query_type    "native"
+                                  :dataset_query (mt/native-query {:query         "SELECT id FROM venues WHERE name = {{ name }}"
+                                                                   :template-tags {"name" {:id           "_name_"
+                                                                                           :type         :text
+                                                                                           :display-name "name"
+                                                                                           :default      "qwe"}}})}
+                   Card c3       {:query_type    "query"
+                                  :dataset_query (mt/mbql-query venues {:aggregation [[:distinct $name]]})}
+                   Card c4       {:query_type    "query"
+                                  :dataset_query mlv2-query}
+                   Card archived {:archived      true
+                                  :query_type    "native"
+                                  :dataset_query (mt/native-query {:query "SELECT id FROM venues"})}
+                   Card invalid  {:query_type "native"
+                                  :dataset_query (mt/native-query {:query "SELECT boom, FROM"})}]
 
-                  ;; Make sure there is no existing analysis for the relevant cards
-      (t2/delete! :model/QueryField :card_id [:in (map :id [c1 c2 c3 c4 arch])])
+      ;; Make sure there is no existing analysis for the relevant cards
+      (t2/delete! :model/QueryField :card_id [:in (map :id [c1 c2 c3 c4 archived invalid])])
 
-                  ;; Make sure some other card has analysis
+      ;; Make sure some other card has analysis
       (query-analysis/analyze-card! c3)
 
-      (mt/call-with-map-params f [c1 c2 c3 c4 arch]))))
+      ;; And attempt to analyze an invalid query
+      (query-analysis/analyze-card! invalid)
+
+
+      (mt/call-with-map-params f [c1 c2 c3 c4 archived invalid]))))
 
 (defmacro with-test-setup!
   "Set up the data required to test the Query Analysis related tasks"
   [& body]
   `(do-with-test-setup!
-    (mt/with-anaphora [c1 c2 c3 c4 arch]
+    (mt/with-anaphora [c1 c2 c3 c4 archived invalid]
       ~@body)))


### PR DESCRIPTION
This improves how we track queries that cannot be analyzed, by adding a status column to the parent record.

This also fixes a small bug in the sweeper, where it would repeat analysis of cards without any query fields.