### PR TITLE
fix import order in the files with disabled rules

### DIFF
--- a/e2e/support/cypress_data.js
+++ b/e2e/support/cypress_data.js
@@ -7,7 +7,7 @@ import { ORDERS_PRODUCTS_ACCESS } from "./test_roles";
  * For that reason, we have some sanity checks in the `default.cy.snap.js` spec.
  *
  * SAMPLE_DB_TABLES contains only the references to the four main tables ids in sample database.
- * We need these references to avoid circular dependecy issue in custom commands and e2e helpers.
+ * We need these references to avoid circular dependency issue in custom commands and e2e helpers.
  * That is the only place they should be used. NEVER use them in tests!
  *
  * USER_GROUPS

--- a/frontend/src/metabase-lib/v1/Question.ts
+++ b/frontend/src/metabase-lib/v1/Question.ts
@@ -4,7 +4,6 @@ import { assoc, assocIn, chain, dissoc, getIn } from "icepick";
 import slugg from "slugg";
 import _ from "underscore";
 
-// NOTE: the order of these matters due to circular dependency issues
 import { utf8_to_b64url } from "metabase/lib/encoding";
 import * as Lib from "metabase-lib";
 import {

--- a/frontend/src/metabase-lib/v1/Question.ts
+++ b/frontend/src/metabase-lib/v1/Question.ts
@@ -1,25 +1,42 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { assoc, assocIn, chain, dissoc, getIn } from "icepick";
-import _ from "underscore";
-/* eslint-disable import/order */
-// NOTE: the order of these matters due to circular dependency issues
 import slugg from "slugg";
+import _ from "underscore";
+
+// NOTE: the order of these matters due to circular dependency issues
+import { utf8_to_b64url } from "metabase/lib/encoding";
 import * as Lib from "metabase-lib";
-import StructuredQuery, {
-  STRUCTURED_QUERY_TEMPLATE,
-} from "metabase-lib/v1/queries/StructuredQuery";
+import {
+  ALERT_TYPE_PROGRESS_BAR_GOAL,
+  ALERT_TYPE_ROWS,
+  ALERT_TYPE_TIMESERIES_GOAL,
+} from "metabase-lib/v1/Alert";
+import type Database from "metabase-lib/v1/metadata/Database";
+import Metadata from "metabase-lib/v1/metadata/Metadata";
+import type Table from "metabase-lib/v1/metadata/Table";
+import { getQuestionVirtualTableId } from "metabase-lib/v1/metadata/utils/saved-questions";
+import { getCardUiParameters } from "metabase-lib/v1/parameters/utils/cards";
+import {
+  applyFilterParameter,
+  applyTemporalUnitParameter,
+} from "metabase-lib/v1/parameters/utils/mbql";
+import {
+  isFilterParameter,
+  isTemporalUnitParameter,
+} from "metabase-lib/v1/parameters/utils/parameter-type";
+import { getTemplateTagParametersFromCard } from "metabase-lib/v1/parameters/utils/template-tags";
+import type AtomicQuery from "metabase-lib/v1/queries/AtomicQuery";
+import InternalQuery from "metabase-lib/v1/queries/InternalQuery";
 import NativeQuery, {
   NATIVE_QUERY_TEMPLATE,
 } from "metabase-lib/v1/queries/NativeQuery";
-import type AtomicQuery from "metabase-lib/v1/queries/AtomicQuery";
-import InternalQuery from "metabase-lib/v1/queries/InternalQuery";
 import type BaseQuery from "metabase-lib/v1/queries/Query";
-import Metadata from "metabase-lib/v1/metadata/Metadata";
-import type Database from "metabase-lib/v1/metadata/Database";
-import type Table from "metabase-lib/v1/metadata/Table";
+import StructuredQuery, {
+  STRUCTURED_QUERY_TEMPLATE,
+} from "metabase-lib/v1/queries/StructuredQuery";
+import { isTransientId } from "metabase-lib/v1/queries/utils/card";
 import { sortObject } from "metabase-lib/v1/utils";
-
 import type {
   CardDisplayType,
   Card as CardObject,
@@ -38,28 +55,7 @@ import type {
   VisualizationSettings,
 } from "metabase-types/api";
 
-// TODO: remove these dependencies
-import { getCardUiParameters } from "metabase-lib/v1/parameters/utils/cards";
-import { utf8_to_b64url } from "metabase/lib/encoding";
-
-import { getTemplateTagParametersFromCard } from "metabase-lib/v1/parameters/utils/template-tags";
-import {
-  applyFilterParameter,
-  applyTemporalUnitParameter,
-} from "metabase-lib/v1/parameters/utils/mbql";
-import { getQuestionVirtualTableId } from "metabase-lib/v1/metadata/utils/saved-questions";
-import { isTransientId } from "metabase-lib/v1/queries/utils/card";
-import {
-  ALERT_TYPE_PROGRESS_BAR_GOAL,
-  ALERT_TYPE_ROWS,
-  ALERT_TYPE_TIMESERIES_GOAL,
-} from "metabase-lib/v1/Alert";
-
 import type { Query } from "../types";
-import {
-  isFilterParameter,
-  isTemporalUnitParameter,
-} from "metabase-lib/v1/parameters/utils/parameter-type";
 
 export type QuestionCreatorOpts = {
   databaseId?: DatabaseId;

--- a/frontend/src/metabase-lib/v1/metadata/Table.ts
+++ b/frontend/src/metabase-lib/v1/metadata/Table.ts
@@ -1,14 +1,13 @@
-/* eslint-disable import/order */
 import _ from "underscore";
 
 // NOTE: this needs to be imported first due to some cyclical dependency nonsense
-import Question from "../Question";
-
+import { singularize } from "metabase/lib/formatting";
 import { isVirtualCardId } from "metabase-lib/v1/metadata/utils/saved-questions";
 import { getAggregationOperators } from "metabase-lib/v1/operators/utils";
 import type StructuredQuery from "metabase-lib/v1/queries/StructuredQuery";
 import type { NormalizedTable } from "metabase-types/api";
-import { singularize } from "metabase/lib/formatting";
+
+import Question from "../Question";
 
 import type Database from "./Database";
 import type Field from "./Field";

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -1,32 +1,26 @@
-/* eslint-disable import/order */
 /*eslint no-use-before-define: "error"*/
-
 import { createSelector } from "@reduxjs/toolkit";
 import * as d3 from "d3";
 import { getIn, merge, updateIn } from "icepick";
 import _ from "underscore";
 
-import * as Lib from "metabase-lib";
-
-// Needed due to wrong dependency resolution order
+import { getAlerts } from "metabase/alert/selectors";
+import { getDashboardById } from "metabase/dashboard/selectors";
+import Databases from "metabase/entities/databases";
+import { cleanIndexFlags } from "metabase/entities/model-indexes/actions";
+import Timelines from "metabase/entities/timelines";
+import { LOAD_COMPLETE_FAVICON } from "metabase/hoc/Favicon";
+import { parseTimestamp } from "metabase/lib/time";
+import { getSortedTimelines } from "metabase/lib/timelines";
+import { isNotNull } from "metabase/lib/types";
+import { getEmbedOptions, getIsEmbedded } from "metabase/selectors/embed";
+import { getMetadata } from "metabase/selectors/metadata";
+import { getSetting } from "metabase/selectors/settings";
 import { MetabaseApi } from "metabase/services";
 import {
   extractRemappings,
   getVisualizationTransformed,
 } from "metabase/visualizations";
-import { getComputedSettingsForSeries } from "metabase/visualizations/lib/settings/visualization";
-
-import Databases from "metabase/entities/databases";
-import { cleanIndexFlags } from "metabase/entities/model-indexes/actions";
-import Timelines from "metabase/entities/timelines";
-
-import { getAlerts } from "metabase/alert/selectors";
-import { getDashboardById } from "metabase/dashboard/selectors";
-import { parseTimestamp } from "metabase/lib/time";
-import { getSortedTimelines } from "metabase/lib/timelines";
-import { getEmbedOptions, getIsEmbedded } from "metabase/selectors/embed";
-import { getMetadata } from "metabase/selectors/metadata";
-import { getSetting } from "metabase/selectors/settings";
 import { getMode as getQuestionMode } from "metabase/visualizations/click-actions/lib/modes";
 import {
   computeTimeseriesDataInverval,
@@ -36,16 +30,17 @@ import {
   getXValues,
   isTimeseries,
 } from "metabase/visualizations/lib/renderer_utils";
-import { isAbsoluteDateTimeUnit } from "metabase-types/guards/date-time";
+import { getComputedSettingsForSeries } from "metabase/visualizations/lib/settings/visualization";
+import * as Lib from "metabase-lib";
+import Question from "metabase-lib/v1/Question";
 import { getCardUiParameters } from "metabase-lib/v1/parameters/utils/cards";
 import {
   normalizeParameterValue,
   normalizeParameters,
 } from "metabase-lib/v1/parameters/utils/parameter-values";
-import Question from "metabase-lib/v1/Question";
 import { getIsPKFromTablePredicate } from "metabase-lib/v1/types/utils/isa";
-import { LOAD_COMPLETE_FAVICON } from "metabase/hoc/Favicon";
-import { isNotNull } from "metabase/lib/types";
+import { isAbsoluteDateTimeUnit } from "metabase-types/guards/date-time";
+
 import { getQuestionWithDefaultVisualizationSettings } from "./actions/core/utils";
 import { createRawSeries, getWritableColumnProperties } from "./utils";
 import {

--- a/frontend/src/metabase/visualizations/components/LeafletMap.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletMap.jsx
@@ -1,16 +1,15 @@
-/* eslint-disable import/order, react/prop-types */
-import { Component, createRef } from "react";
-import _ from "underscore";
-
+/* eslint-disable react/prop-types */
+import "leaflet-draw";
 import "leaflet/dist/leaflet.css";
 import "./LeafletMap.module.css";
 
 import L from "leaflet";
-import "leaflet-draw";
+import { Component, createRef } from "react";
+import _ from "underscore";
 
+import MetabaseSettings from "metabase/lib/settings";
 import * as Lib from "metabase-lib";
 import Question from "metabase-lib/v1/Question";
-import MetabaseSettings from "metabase/lib/settings";
 
 export default class LeafletMap extends Component {
   constructor(props) {

--- a/frontend/src/metabase/visualizations/lib/settings.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/settings.unit.spec.js
@@ -1,16 +1,13 @@
-/* eslint-disable import/order */
-import { createMockTableColumnOrderSetting } from "metabase-types/api/mocks";
-import { ORDERS } from "metabase-types/api/mocks/presets";
-
 // NOTE: need to load visualizations first for getSettings to work
-import "metabase/visualizations/index";
-
+import "metabase/visualizations";
 import {
   getClickBehaviorSettings,
   getComputedSettings,
   getSettingsWidgets,
   mergeSettings,
 } from "metabase/visualizations/lib/settings";
+import { createMockTableColumnOrderSetting } from "metabase-types/api/mocks";
+import { ORDERS } from "metabase-types/api/mocks/presets";
 
 describe("settings framework", () => {
   const mockObject = "[mockObject]";

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -1,28 +1,25 @@
-/* eslint-disable import/order */
-import { t } from "ttag";
 import moment from "moment-timezone"; // eslint-disable-line no-restricted-imports -- deprecated usage
+import { t } from "ttag";
 import _ from "underscore";
 
-import ChartNestedSettingColumns from "metabase/visualizations/components/settings/ChartNestedSettingColumns";
-import { ChartSettingTableColumns } from "metabase/visualizations/components/settings/ChartSettingTableColumns";
+import { currency } from "cljs/metabase.shared.util.currency";
 import {
   formatColumn,
   getCurrencySymbol,
   getDateFormatFromStyle,
   numberFormatterForOptions,
 } from "metabase/lib/formatting";
-
 import { hasHour } from "metabase/lib/formatting/datetime-utils";
-
-import { currency } from "cljs/metabase.shared.util.currency";
 import MetabaseSettings from "metabase/lib/settings";
+import ChartNestedSettingColumns from "metabase/visualizations/components/settings/ChartNestedSettingColumns";
+import { ChartSettingTableColumns } from "metabase/visualizations/components/settings/ChartSettingTableColumns";
 import {
-  isCoordinate,
-  isCurrency,
-  isDate,
-  isDateWithoutTime,
-  isNumber,
-} from "metabase-lib/v1/types/utils/isa";
+  getDefaultCurrency,
+  getDefaultCurrencyInHeader,
+  getDefaultCurrencyStyle,
+  getDefaultNumberSeparators,
+  getDefaultNumberStyle,
+} from "metabase/visualizations/shared/settings/column";
 import {
   getColumnKey,
   getObjectColumnSettings,
@@ -31,14 +28,15 @@ import {
   findColumnIndexesForColumnSettings,
   findColumnSettingIndexesForColumns,
 } from "metabase-lib/v1/queries/utils/dataset";
-import { nestedSettings } from "./nested";
 import {
-  getDefaultCurrency,
-  getDefaultCurrencyInHeader,
-  getDefaultCurrencyStyle,
-  getDefaultNumberSeparators,
-  getDefaultNumberStyle,
-} from "metabase/visualizations/shared/settings/column";
+  isCoordinate,
+  isCurrency,
+  isDate,
+  isDateWithoutTime,
+  isNumber,
+} from "metabase-lib/v1/types/utils/isa";
+
+import { nestedSettings } from "./nested";
 
 // HACK: cyclical dependency causing errors in unit tests
 // import { getVisualizationRaw } from "metabase/visualizations";

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -11,6 +11,7 @@ import {
 } from "metabase/lib/formatting";
 import { hasHour } from "metabase/lib/formatting/datetime-utils";
 import MetabaseSettings from "metabase/lib/settings";
+import { getVisualizationRaw } from "metabase/visualizations";
 import ChartNestedSettingColumns from "metabase/visualizations/components/settings/ChartNestedSettingColumns";
 import { ChartSettingTableColumns } from "metabase/visualizations/components/settings/ChartSettingTableColumns";
 import {
@@ -37,12 +38,6 @@ import {
 } from "metabase-lib/v1/types/utils/isa";
 
 import { nestedSettings } from "./nested";
-
-// HACK: cyclical dependency causing errors in unit tests
-// import { getVisualizationRaw } from "metabase/visualizations";
-function getVisualizationRaw(...args) {
-  return require("metabase/visualizations").getVisualizationRaw(...args);
-}
 
 function getCurrency(currency, currencyStyle) {
   return (0)


### PR DESCRIPTION
### Description

There were a few `eslint-disable import/order` rules. changing the imports order previously led to the circular dependencies problem, it's not a problem anymore, so we can remove `eslint-disable import/order`

### How to verify

CI is green