### PR TITLE
[serdes] query action depends on stuff in its dataset_query

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -871,7 +871,7 @@
               (let [ser (ts/extract-one "Action" action-id)]
                 (is (=? {:serdes/meta [{:model "Action" :id (:entity_id action) :label "my_action"}]
                          :creator_id  "ann@heart.band"
-                         :type        :implicit
+                         :type        "implicit"
                          :created_at  string?
                          :model_id    card-eid-1
                          :implicit    [{:kind "row/update"}]}
@@ -909,7 +909,7 @@
               (let [ser (ts/extract-one "Action" action-id)]
                 (is (=? {:serdes/meta [{:model "Action" :id (:entity_id action) :label "my_action"}]
                          :creator_id  "ann@heart.band"
-                         :type        :http
+                         :type        "http"
                          :created_at  string?
                          :model_id    card-eid-1
                          :http        [{:template {}}]}
@@ -949,7 +949,7 @@
                 (is (=? {:serdes/meta [{:model "Action"
                                         :id    (:entity_id action)
                                         :label "my_action"}]
-                         :type        :query
+                         :type        "query"
                          :creator_id  "ann@heart.band"
                          :created_at  string?
                          :query       [{:dataset_query {:database "My Database"

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -973,7 +973,7 @@
                                                    @serialized))]
               (is (some? action-serialized))
               (testing ":type should be a string"
-                (is (keyword? (:type action-serialized))))))))
+                (is (string? (:type action-serialized))))))))
       (testing "loading succeeds"
         (ts/with-db dest-db
           (serdes.load/load-metabase! (ingestion-in-memory @serialized))

--- a/src/metabase/models/action.clj
+++ b/src/metabase/models/action.clj
@@ -365,9 +365,10 @@
    :transform {:action_id (serdes/parent-ref)}})
 
 (defmethod serdes/make-spec "Action" [_model-name opts]
-  {:copy      [:archived :description :entity_id :name :public_uuid :type]
+  {:copy      [:archived :description :entity_id :name :public_uuid]
    :skip      []
    :transform {:created_at             (serdes/date)
+               :type                   (serdes/kw)
                :creator_id             (serdes/fk :model/User)
                :made_public_by_id      (serdes/fk :model/User)
                :model_id               (serdes/fk :model/Card)
@@ -385,7 +386,8 @@
    (concat
     ;; other stuff is implicitly referenced through a Card
     [[{:model "Card" :id (:model_id action)}]]
-    (when (= (:type action) :query)
+    ;; this method is called on ingested data before transformation and so here it always will be a string
+    (when (= (:type action) "query")
       (concat
        [[{:model "Database" :id (-> action :query first :database_id)}]]
        (serdes/mbql-deps (:dataset_query action)))))))


### PR DESCRIPTION
no backport since it's the issue I discovered working on #47049 and it's fixed in there, so it's kind of a forward-port :)