### PR TITLE
fix(dashboard): In dashboard value source modal, after closing question picker modal, don't also close the first modal

### DIFF
--- a/frontend/src/metabase/core/components/SelectButton/SelectButton.tsx
+++ b/frontend/src/metabase/core/components/SelectButton/SelectButton.tsx
@@ -82,6 +82,7 @@ const SelectButton = forwardRef(function SelectButton(
         hasValue={hasValue}
         highlighted={highlighted}
         onClick={rightIcon === "close" ? handleClear : undefined}
+        style={{ flexShrink: 0 }}
       />
     </SelectButtonRoot>
   );

--- a/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceModal.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceModal.tsx
@@ -63,7 +63,7 @@ const ValuesSourceModal = ({
       sourceConfig={sourceConfig}
       onChangeSourceConfig={setSourceConfig}
       onSubmit={handlePickerClose}
-      onClose={onClose}
+      onClose={handlePickerClose}
     />
   );
 };


### PR DESCRIPTION
Fixes #46149

To test, follow the reproduction instructions in #46149 and see that only the top modal is closed, not the modal behind it:

1. Create a dashboard
2. Add a text filter
3. Under "How should people filter on this column?", click Edit
4. Click "Pick a modal or question"
5. Close that modal
6. On this branch (unlike master): The "Selectable values" modal remains open