### PR TITLE
[MBQL lib] Disable expression type checking entirely

### DIFF
--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -816,7 +816,8 @@ describe("issue 27123", () => {
   });
 });
 
-describe("issue 29094", () => {
+// TODO: Unskip this test when we bring back expression type checking. See #31877.
+describe.skip("issue 29094", () => {
   beforeEach(() => {
     restore();
     cy.signInAsNormalUser();

--- a/test/metabase/lib/expression_test.cljc
+++ b/test/metabase/lib/expression_test.cljc
@@ -468,18 +468,19 @@
 (deftest ^:parallel diagnose-expression-test-2
   (testing "correct expression are accepted silently"
     (testing "type errors are reported"
-      (are [mode expr] (=? {:message #"Type error: .*"}
-                           (lib.expression/diagnose-expression
-                            lib.tu/venues-query 0 mode
-                            (lib.convert/->pMBQL expr)
-                            #?(:clj nil :cljs js/undefined)))
-        :expression  [:/ [:field 1 {:base-type :type/Address}] 100]
-        ;; To make this test case work, the aggregation schema has to be
-        ;; tighter and not allow anything. That's a bigger piece of work,
-        ;; because it makes expressions and aggregations mutually recursive
-        ;; or requires a large amount of duplication.
-        #_#_:aggregation [:sum [:is-empty [:field 1 {:base-type :type/Boolean}]]]
-        :filter      [:sum [:field 1 {:base-type :type/Integer}]]))))
+      (binding [lib.schema.expression/*suppress-expression-type-check?* false]
+        (are [mode expr] (=? {:message #"Type error: .*"}
+                             (lib.expression/diagnose-expression
+                              lib.tu/venues-query 0 mode
+                              (lib.convert/->pMBQL expr)
+                              #?(:clj nil :cljs js/undefined)))
+          :expression  [:/ [:field 1 {:base-type :type/Address}] 100]
+             ;; To make this test case work, the aggregation schema has to be
+             ;; tighter and not allow anything. That's a bigger piece of work,
+             ;; because it makes expressions and aggregations mutually recursive
+             ;; or requires a large amount of duplication.
+          #_#_:aggregation [:sum [:is-empty [:field 1 {:base-type :type/Boolean}]]]
+          :filter      [:sum [:field 1 {:base-type :type/Integer}]])))))
 
 (deftest ^:parallel diagnose-expression-test-3
   (testing "correct expression are accepted silently"

--- a/test/metabase/lib/remove_replace_test.cljc
+++ b/test/metabase/lib/remove_replace_test.cljc
@@ -9,6 +9,7 @@
    [metabase.lib.options :as lib.options]
    [metabase.lib.query :as lib.query]
    [metabase.lib.remove-replace :as lib.remove-replace]
+   [metabase.lib.schema.expression :as lib.schema.expression]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
    [metabase.lib.test-util.macros :as lib.tu.macros]))
@@ -344,20 +345,21 @@
                   (lib/remove-clause 0 expr-a)))))))
 
 (deftest ^:parallel replace-clause-order-by-test
-  (let [query (-> lib.tu/venues-query
-                  (lib/filter (lib/= "myvenue" (meta/field-metadata :venues :name)))
-                  (lib/order-by (meta/field-metadata :venues :name))
-                  (lib/order-by (meta/field-metadata :venues :name)))
-        order-bys (lib/order-bys query)]
-    (is (= 2 (count order-bys)))
-    (let [replaced (-> query
-                       (lib/replace-clause (first order-bys) (lib/order-by-clause (meta/field-metadata :venues :id))))
-          replaced-order-bys (lib/order-bys replaced)]
-      (is (not= order-bys replaced-order-bys))
-      (is (=? [:asc {} [:field {} (meta/id :venues :id)]]
-              (first replaced-order-bys)))
-      (is (= 2 (count replaced-order-bys)))
-      (is (= (second order-bys) (second replaced-order-bys))))))
+  (binding [lib.schema.expression/*suppress-expression-type-check?* true]
+    (let [query (-> lib.tu/venues-query
+                    (lib/filter (lib/= "myvenue" (meta/field-metadata :venues :name)))
+                    (lib/order-by (meta/field-metadata :venues :name))
+                    (lib/order-by (meta/field-metadata :venues :name)))
+          order-bys (lib/order-bys query)]
+      (is (= 2 (count order-bys)))
+      (let [replaced (-> query
+                         (lib/replace-clause (first order-bys) (lib/order-by-clause (meta/field-metadata :venues :id))))
+            replaced-order-bys (lib/order-bys replaced)]
+        (is (not= order-bys replaced-order-bys))
+        (is (=? [:asc {} [:field {} (meta/id :venues :id)]]
+                (first replaced-order-bys)))
+        (is (= 2 (count replaced-order-bys)))
+        (is (= (second order-bys) (second replaced-order-bys)))))))
 
 (deftest ^:parallel replace-clause-filters-test
   (let [query (-> lib.tu/venues-query
@@ -504,22 +506,23 @@
                   (lib/filter (lib/= [:field {:lib/uuid (str (random-uuid)) :base-type :type/Integer} "sum"] 1))
                   (lib/replace-clause 0 (first aggregations) (lib/max (meta/field-metadata :venues :price)))))))
     (testing "replacing with dependent should cascade removing invalid parts"
-      (is (=? {:stages [{:aggregation [[:sum {} [:field {} (meta/id :products :id)]]
-                                       [:max {} [:field {} (meta/id :products :price)]]]}
-                        (fn [stage] (not-any? stage [:filters :expressions]))]}
-              (-> (lib/query meta/metadata-provider (meta/table-metadata :products))
-                  (lib/aggregate (lib/sum (meta/field-metadata :products :id)))
-                  (lib/aggregate (lib/max (meta/field-metadata :products :created-at)))
-                  (lib/append-stage)
-                  (as-> <>
-                        (lib/expression <> "max month" (lib/get-month (lib/ref (m/find-first (comp #{"max"} :name)
-                                                                                             (lib/orderable-columns <>)))))
-                    (lib/filter <> (lib/= (lib/ref (m/find-first (comp #{"max month"} :name)
-                                                                 (lib/filterable-columns <>)))
-                                          1))
-                    (lib/replace-clause <> 0
-                                        (second (lib/aggregations <> 0))
-                                        (lib/max (meta/field-metadata :products :price))))))))))
+      (binding [lib.schema.expression/*suppress-expression-type-check?* false]
+        (is (=? {:stages [{:aggregation [[:sum {} [:field {} (meta/id :products :id)]]
+                                         [:max {} [:field {} (meta/id :products :price)]]]}
+                          (fn [stage] (not-any? stage [:filters :expressions]))]}
+                (-> (lib/query meta/metadata-provider (meta/table-metadata :products))
+                    (lib/aggregate (lib/sum (meta/field-metadata :products :id)))
+                    (lib/aggregate (lib/max (meta/field-metadata :products :created-at)))
+                    (lib/append-stage)
+                    (as-> <>
+                          (lib/expression <> "max month" (lib/get-month (lib/ref (m/find-first (comp #{"max"} :name)
+                                                                                               (lib/orderable-columns <>)))))
+                      (lib/filter <> (lib/= (lib/ref (m/find-first (comp #{"max month"} :name)
+                                                                   (lib/filterable-columns <>)))
+                                            1))
+                      (lib/replace-clause <> 0
+                                          (second (lib/aggregations <> 0))
+                                          (lib/max (meta/field-metadata :products :price)))))))))))
 
 (deftest ^:parallel replace-metric-test
   (testing "replacing with metric should work"
@@ -1444,17 +1447,18 @@
                                     (lib/ref (meta/field-metadata :people :id))
                                     "id")))))
     (testing "removed when types conflict"
-      (let [query (lib/filter query 0 (lib/= (lib/get-week (lib/expression-ref query "created at") :iso) 3))]
-        (is (= 2 (count (lib/filters query 0))))
-        (is (=? {:stages [{:lib/type :mbql.stage/mbql
-                           :expressions [[:field {:effective-type :type/BigInteger, :lib/expression-name "id"}
-                                          (meta/id :people :id)]]
-                           :filters [[:not-null {} [:expression {:effective-type :type/BigInteger} "id"]]]}]}
-                (lib/replace-clause query 0
-                                    (first (lib/expressions query 0))
-                                    (lib/with-expression-name
-                                      (lib/ref (meta/field-metadata :people :id))
-                                      "id"))))))))
+      (binding [lib.schema.expression/*suppress-expression-type-check?* false]
+        (let [query (lib/filter query 0 (lib/= (lib/get-week (lib/expression-ref query "created at") :iso) 3))]
+          (is (= 2 (count (lib/filters query 0))))
+          (is (=? {:stages [{:lib/type :mbql.stage/mbql
+                             :expressions [[:field {:effective-type :type/BigInteger, :lib/expression-name "id"}
+                                            (meta/id :people :id)]]
+                             :filters [[:not-null {} [:expression {:effective-type :type/BigInteger} "id"]]]}]}
+                  (lib/replace-clause query 0
+                                      (first (lib/expressions query 0))
+                                      (lib/with-expression-name
+                                        (lib/ref (meta/field-metadata :people :id))
+                                        "id")))))))))
 
 (def ^:private join-query
   (let [products-query (lib/query meta/metadata-provider (meta/table-metadata :products))

--- a/test/metabase/lib/schema/aggregation_test.cljc
+++ b/test/metabase/lib/schema/aggregation_test.cljc
@@ -3,7 +3,8 @@
    [clojure.test :refer [are deftest testing]]
    [malli.core :as mc]
    [malli.error :as me]
-   [metabase.lib.schema]))
+   [metabase.lib.schema]
+   [metabase.lib.schema.expression :as lib.schema.expression]))
 
 (comment metabase.lib.schema/keep-me)
 
@@ -30,24 +31,25 @@
        [:field {:lib/uuid "00000000-0000-0000-0000-000000000000"} 1]
        0.1]))
   (testing "invalid"
-    (are [clause] (me/humanize (mc/explain :mbql.clause/percentile clause))
-      ;; p > 1
-      [:percentile
-       {:lib/uuid "00000000-0000-0000-0000-000000000000"}
-       [:field {:lib/uuid "00000000-0000-0000-0000-000000000000"} 1]
-       1.1]
+    (binding [lib.schema.expression/*suppress-expression-type-check?* false]
+      (are [clause] (me/humanize (mc/explain :mbql.clause/percentile clause))
+        ;; p > 1
+        [:percentile
+         {:lib/uuid "00000000-0000-0000-0000-000000000000"}
+         [:field {:lib/uuid "00000000-0000-0000-0000-000000000000"} 1]
+         1.1]
 
-      ;; p < 0
-      [:percentile
-       {:lib/uuid "00000000-0000-0000-0000-000000000000"}
-       [:field {:lib/uuid "00000000-0000-0000-0000-000000000000"} 1]
-       -1]
+        ;; p < 0
+        [:percentile
+         {:lib/uuid "00000000-0000-0000-0000-000000000000"}
+         [:field {:lib/uuid "00000000-0000-0000-0000-000000000000"} 1]
+         -1]
 
-      ;; not a number
-      [:percentile
-       {:lib/uuid "00000000-0000-0000-0000-000000000000"}
-       [:field {:lib/uuid "00000000-0000-0000-0000-000000000000", :base-type :type/Text} 1]
-       0.5])))
+        ;; not a number
+        [:percentile
+         {:lib/uuid "00000000-0000-0000-0000-000000000000"}
+         [:field {:lib/uuid "00000000-0000-0000-0000-000000000000", :base-type :type/Text} 1]
+         0.5]))))
 
 (deftest ^:parallel arithmetic-expression-test
   (testing "valid"

--- a/test/metabase/lib/schema/expression/arithmetic_test.cljc
+++ b/test/metabase/lib/schema/expression/arithmetic_test.cljc
@@ -27,12 +27,13 @@
         (is (mc/validate :mbql.clause/* expr))
         (is (mc/validate ::expression/integer expr))))
     (testing "Multiplication with one or more non-integer args should NOT be considered to be an integer expression."
-      (let [expr [:* {:lib/uuid (str (random-uuid))} venues-price 2.1]]
-        (is (= :type/Float
-               (expression/type-of expr)))
-        (is (mc/validate :mbql.clause/* expr))
-        (is (not (mc/validate ::expression/integer expr)))
-        (is (mc/validate ::expression/number expr))))))
+      (binding [expression/*suppress-expression-type-check?* false]
+        (let [expr [:* {:lib/uuid (str (random-uuid))} venues-price 2.1]]
+          (is (= :type/Float
+                 (expression/type-of expr)))
+          (is (mc/validate :mbql.clause/* expr))
+          (is (not (mc/validate ::expression/integer expr)))
+          (is (mc/validate ::expression/number expr)))))))
 
 (deftest ^:parallel power-type-of-test
   (testing "Make sure we can calculate type of a `:power` clause (#29944)"

--- a/test/metabase/lib/schema/expression/temporal_test.cljc
+++ b/test/metabase/lib/schema/expression/temporal_test.cljc
@@ -41,16 +41,17 @@
       :current                 :default)))
 
 (deftest ^:parallel invalid-absolute-datetime-test
-  (are [expr] (me/humanize (mc/explain ::expression/date expr))
-    ;; wrong literal string
-    [:absolute-datetime {:lib/uuid "00000000-0000-0000-0000-000000000000"} "2023-03-08T19:55:01" :day]
-    ;; wrong unit
-    [:absolute-datetime {:lib/uuid "00000000-0000-0000-0000-000000000000"} "2023-03-08" :hour]
-    ;; base-type specified, but it's non-temporal
-    [:absolute-datetime
-     {:lib/uuid "00000000-0000-0000-0000-000000000000", :base-type :type/Integer}
-     "2023-03-08T19:55:01"
-     :day]))
+  (binding [expression/*suppress-expression-type-check?* false]
+    (are [expr] (me/humanize (mc/explain ::expression/date expr))
+      ;; wrong literal string
+      [:absolute-datetime {:lib/uuid "00000000-0000-0000-0000-000000000000"} "2023-03-08T19:55:01" :day]
+      ;; wrong unit
+      [:absolute-datetime {:lib/uuid "00000000-0000-0000-0000-000000000000"} "2023-03-08" :hour]
+      ;; base-type specified, but it's non-temporal
+      [:absolute-datetime
+       {:lib/uuid "00000000-0000-0000-0000-000000000000", :base-type :type/Integer}
+       "2023-03-08T19:55:01"
+       :day])))
 
 (deftest ^:parallel temporal-extract-test
   (is (not (me/humanize

--- a/test/metabase/lib/schema/filter_test.cljc
+++ b/test/metabase/lib/schema/filter_test.cljc
@@ -87,14 +87,15 @@
       (is (mc/validate ::expression/boolean (ensure-uuids filter-expr))))))
 
 (deftest ^:parallel invalid-filter-test
-  (testing "invalid filters"
-    (are [clause] (mc/explain
-                   ::expression/boolean
-                   (ensure-uuids clause))
-      ;; xor doesn't exist
-      [:xor 13 [:field 1 {:lib/uuid (str (random-uuid))}]]
-      ;; 1 is not a valid <string> arg
-      [:contains "abc" 1])))
+  (binding [expression/*suppress-expression-type-check?* false]
+    (testing "invalid filters"
+      (are [clause] (mc/explain
+                     ::expression/boolean
+                     (ensure-uuids clause))
+        ;; xor doesn't exist
+        [:xor 13 [:field 1 {:lib/uuid (str (random-uuid))}]]
+        ;; 1 is not a valid <string> arg
+        [:contains "abc" 1]))))
 
 (deftest ^:parallel mongo-types-test
   (testing ":type/MongoBSONID"

--- a/test/metabase/lib/schema/literal_test.cljc
+++ b/test/metabase/lib/schema/literal_test.cljc
@@ -19,17 +19,18 @@
       #?@(:clj ((bigint 1)
                 (biginteger 1)))))
   (testing "invalid schemas"
-    (are [n] (are [schema] (mc/explain schema n)
-               ::expression/boolean
-               ::expression/string
-               ::expression/date
-               ::expression/time
-               ::expression/datetime
-               ::expression/temporal)
-      (int 1)
-      (long 1)
-      #?@(:clj ((bigint 1)
-                (biginteger 1))))))
+    (binding [expression/*suppress-expression-type-check?* false]
+      (are [n] (are [schema] (mc/explain schema n)
+                 ::expression/boolean
+                 ::expression/string
+                 ::expression/date
+                 ::expression/time
+                 ::expression/datetime
+                 ::expression/temporal)
+        (int 1)
+        (long 1)
+        #?@(:clj ((bigint 1)
+                  (biginteger 1)))))))
 
 (deftest ^:parallel string-literal-type-of-test
   (is (mc/validate ::literal/string.datetime "2023-03-08T03:18"))
@@ -51,14 +52,15 @@
       ::expression/equality-comparable
       ::expression/expression))
   (testing "invalid schemas"
-    (are [schema] (mc/explain schema "s")
-      ::expression/boolean
-      ::expression/integer
-      ::expression/number
-      ::expression/date
-      ::expression/time
-      ::expression/datetime
-      ::expression/temporal)))
+    (binding [expression/*suppress-expression-type-check?* false]
+      (are [schema] (mc/explain schema "s")
+        ::expression/boolean
+        ::expression/integer
+        ::expression/number
+        ::expression/date
+        ::expression/time
+        ::expression/datetime
+        ::expression/temporal))))
 
 (deftest ^:parallel value-test
   ;; we're using (not (me/humanize (mc/explain ...))) here rather than `(mc/validate ...)` because it makes test
@@ -113,14 +115,15 @@
                        [:value {:lib/uuid "00000000-0000-0000-0000-000000000000"} 1]))))))
 
 (deftest ^:parallel type-of-value-test
-  (testing "should not validate against different type"
-    (are [clause schema] (me/humanize (mc/explain schema clause))
-      [:value {:lib/uuid "00000000-0000-0000-0000-000000000000", :effective-type :type/Text} nil]
-      ::expression/number
+  (binding [expression/*suppress-expression-type-check?* false]
+    (testing "should not validate against different type"
+      (are [clause schema] (me/humanize (mc/explain schema clause))
+        [:value {:lib/uuid "00000000-0000-0000-0000-000000000000", :effective-type :type/Text} nil]
+        ::expression/number
 
-      [:value {:lib/uuid "00000000-0000-0000-0000-000000000000", :effective-type :type/Float} nil]
-      ::expression/string
+        [:value {:lib/uuid "00000000-0000-0000-0000-000000000000", :effective-type :type/Float} nil]
+        ::expression/string
 
-      ;; look at the `:effective-type` and/or `:effective-type`, not the wrapped literal type.
-      [:value {:lib/uuid "00000000-0000-0000-0000-000000000000", :effective-type :type/Number} "Not a number"]
-      ::expression/string)))
+        ;; look at the `:effective-type` and/or `:effective-type`, not the wrapped literal type.
+        [:value {:lib/uuid "00000000-0000-0000-0000-000000000000", :effective-type :type/Number} "Not a number"]
+        ::expression/string))))

--- a/test/metabase/lib/schema/mbql_clause_test.cljc
+++ b/test/metabase/lib/schema/mbql_clause_test.cljc
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer [deftest is testing]]
    [malli.core :as mc]
+   [metabase.lib.schema.expression :as expression]
    [metabase.lib.schema.filter]
    [metabase.lib.schema.literal]
    [metabase.lib.schema.mbql-clause :as mbql-clause]))
@@ -14,9 +15,10 @@
        ::mbql-clause/clause
        [:contains {:lib/uuid "1527d17e-a2f0-4e5f-a92b-65d1db90c094"} "x" "y"]))
   (testing "1 should not be allowed as a <string> arg"
-    (is (not (mc/validate
-              ::mbql-clause/clause
-              [:contains {:lib/uuid "1527d17e-a2f0-4e5f-a92b-65d1db90c094"} "x" 1])))))
+    (binding [expression/*suppress-expression-type-check?* false]
+      (is (not (mc/validate
+                ::mbql-clause/clause
+                [:contains {:lib/uuid "1527d17e-a2f0-4e5f-a92b-65d1db90c094"} "x" 1]))))))
 
 (deftest ^:parallel resolve-schema-test
   (testing "Schema should be registered"


### PR DESCRIPTION
Fixes #44431.

### Description

Our type checking is too strict to support some legitimate use cases that
have no workaround at present. We can bring back this type-checking
eventually, once it's possible to correctly express things like
automatic coercion of strings to numbers in `SUM` aggregations.

### How to verify

For example, MySQL automatic string to number coercion.

1. Have a MySQL database with a table with a `VARCHAR` column that contains numbers.
2. Use a custom expression to `SUM` this column.
3. It works!

### Demo

![2024-08-26-123025_534x505_scrot](https://github.com/user-attachments/assets/96ff6b3a-5326-484c-a160-b48982313d2e)
![2024-08-26-123050_1024x1164_scrot](https://github.com/user-attachments/assets/3132d42a-4b38-48a8-9e0f-89340ffb54dd)
![2024-08-26-123100_405x202_scrot](https://github.com/user-attachments/assets/90185258-0558-46c1-bc0b-77fcd9f8936f)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
