### PR TITLE
Improve impersonation.clj to handle role collections as well

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/driver/impersonation.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/driver/impersonation.clj
@@ -69,12 +69,15 @@
           (let [conn-impersonation (first conn-impersonations)
                 role-attribute     (:attribute conn-impersonation)
                 user-attributes    (:login_attributes @api/*current-user*)
-                role               (get user-attributes role-attribute)]
-            (if (str/blank? role)
+                role               (get user-attributes role-attribute)
+                role_str (if (coll? role)
+                    (str/join "," role)
+                    role)]
+            (if (str/blank? role_str)
               (throw (ex-info (tru "User does not have attribute required for connection impersonation.")
                               {:user-id api/*current-user-id*
                                :conn-impersonations conn-impersonations}))
-              role)))))))
+              role_str)))))))
 
 (defenterprise hash-key-for-impersonation
   "Returns a hash-key for FieldValues if the current user uses impersonation for the database."


### PR DESCRIPTION
> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform) (unless it's a tiny documentation change). Also, if you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.

Closes https://github.com/metabase/metabase/issues/[issue_number]

### Description

When using impersonation, some SSO systems tend to provide collection data instead of string data; such that the following error occurs:

```
class clojure.lang.PersistentVector cannot be cast to class java.lang.CharSequence (clojure.lang.PersistentVector is in unnamed module of loader 'app'; java.lang.CharSequence is in module java.base of loader 'bootstrap')
...
metabase_enterprise.advanced_permissions.driver.impersonation$connection_impersonation_role.invokeStatic(impersonation.clj:73)
```
This merge request provides a solution. I ensured that the changed method **connection-impersonation-role** serves as the single source of truth for the role string.

It would be great if you could merge this.

### How to verify

Set up SSO which returns json/collection data in the configured impersonation database field as described [here](https://www.metabase.com/learn/metabase-basics/administration/permissions/impersonation#:~:text=Impersonation%20is%20a%20permissions%20setting,your%20database%20executes%20the%20query.)
