### PR TITLE
Hide attached DWH database details

### DIFF
--- a/e2e/test/scenarios/admin/databases.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases.cy.spec.js
@@ -489,6 +489,23 @@ describe("scenarios > admin > databases > exceptions", () => {
     cy.button("Remove this database").should("not.be.disabled");
   });
 
+  it("should handle is_attached_dwh databases", () => {
+    cy.intercept("GET", `/api/database/${SAMPLE_DB_ID}`, req => {
+      req.reply(res => {
+        res.body.details = null;
+        res.body.is_attached_dwh = true;
+      });
+    }).as("loadDatabase");
+
+    cy.visit("/admin/databases/1");
+    cy.wait("@loadDatabase");
+
+    cy.get("nav").should("contain", "Metabase Admin");
+    cy.get("span").contains(/Sample Database/i);
+    cy.get("div").contains("This database cannot be modified.");
+    cy.button("Remove this database").should("not.exist");
+  });
+
   it("should show error upon a bad request", () => {
     cy.intercept("POST", "/api/database", req => {
       req.reply({

--- a/e2e/test/scenarios/admin/databases.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases.cy.spec.js
@@ -500,10 +500,10 @@ describe("scenarios > admin > databases > exceptions", () => {
     cy.visit("/admin/databases/1");
     cy.wait("@loadDatabase");
 
-    cy.get("nav").should("contain", "Metabase Admin");
-    cy.get("span").contains(/Sample Database/i);
-    cy.get("div").contains("This database cannot be modified.");
-    cy.button("Remove this database").should("not.exist");
+    cy.findByTestId("main-logo");
+    cy.findByTestId("breadcrumbs").findByText("Sample Database");
+    cy.findByRole("main").findByText("This database cannot be modified.");
+    cy.findByTestId("database-actions-panel").should("not.exist");
   });
 
   it("should show error upon a bad request", () => {

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModalView.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModalView.tsx
@@ -72,7 +72,7 @@ export const ImpersonationModalView = ({
   // Does the "role" field need to first be filled out on the DB details page?
   const roleRequired =
     database.features?.includes("connection-impersonation-requires-role") &&
-    database.details["role"] == null;
+    (!database.details || database.details["role"] == null);
 
   // for redshift, we impersonate using users, not roles
   const impersonationUsesUsers = database.engine === "redshift";

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationWarning/ImpersonationWarning.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationWarning/ImpersonationWarning.tsx
@@ -16,7 +16,7 @@ interface ImpersonationWarningProps {
 export const ImpersonationWarning = ({
   database,
 }: ImpersonationWarningProps) => {
-  const databaseUser = database.details.user;
+  const databaseUser = database.details && database.details.user;
   const isRedshift = database.engine === "redshift";
 
   // eslint-disable-next-line no-literal-metabase-strings -- Metabase settings

--- a/frontend/src/metabase-lib/v1/metadata/Field.ts
+++ b/frontend/src/metabase-lib/v1/metadata/Field.ts
@@ -546,7 +546,7 @@ class FieldInner extends Base {
 
   isJsonUnfolded() {
     const database = this.table?.database;
-    return this.json_unfolding ?? database?.details["json-unfolding"] ?? true;
+    return this.json_unfolding ?? database?.details?.["json-unfolding"] ?? true;
   }
 
   canUnfoldJson() {

--- a/frontend/src/metabase-types/api/database.ts
+++ b/frontend/src/metabase-types/api/database.ts
@@ -65,7 +65,10 @@ export interface DatabaseData {
   id?: DatabaseId;
   name: string;
   engine: string | undefined;
-  details: Record<string, unknown>;
+  // If current user lacks write permission to database, `details` will be
+  // missing in responses from the backend, cf. implementation of
+  // [[metabase.models.interface/to-json]] for `:model/Database`:
+  details?: Record<string, unknown>;
   schedules: DatabaseSchedules;
   auto_run_queries: boolean | null;
   refingerprint: boolean | null;

--- a/frontend/src/metabase-types/api/database.ts
+++ b/frontend/src/metabase-types/api/database.ts
@@ -54,6 +54,7 @@ export interface Database extends DatabaseData {
   uploads_schema_name: string | null;
   uploads_table_prefix: string | null;
   is_audit?: boolean;
+  is_attached_dwh?: boolean;
 
   // Only appears in  GET /api/database/:id
   "can-manage"?: boolean;

--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.tsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.tsx
@@ -170,13 +170,17 @@ function DatabaseEditApp(props: DatabaseEditAppProps) {
               >
                 <DatabaseEditContent>
                   <DatabaseEditForm>
-                    <DatabaseForm
-                      initialValues={database}
-                      isAdvanced
-                      onSubmit={handleSubmit}
-                      setIsDirty={setIsDirty}
-                      autofocusFieldName={autofocusFieldName}
-                    />
+                    {editingExistingDatabase && database.is_attached_dwh ? (
+                      <div>This database cannot be modified.</div>
+                    ) : (
+                      <DatabaseForm
+                        initialValues={database}
+                        isAdvanced
+                        onSubmit={handleSubmit}
+                        setIsDirty={setIsDirty}
+                        autofocusFieldName={autofocusFieldName}
+                      />
+                    )}
                   </DatabaseEditForm>
                   <div>{addingNewDatabase && <DatabaseEditHelp />}</div>
                 </DatabaseEditContent>
@@ -188,7 +192,7 @@ function DatabaseEditApp(props: DatabaseEditAppProps) {
         {editingExistingDatabase && (
           <Sidebar
             database={database}
-            isAdmin={isAdmin}
+            isAdmin={isAdmin && !database.is_attached_dwh}
             isModelPersistenceEnabled={isModelPersistenceEnabled}
             updateDatabase={updateDatabase}
             deleteDatabase={deleteDatabase}

--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.tsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.tsx
@@ -49,7 +49,7 @@ import {
 } from "./DatabaseEditApp.styled";
 
 interface DatabaseEditAppProps {
-  database: Database;
+  database?: Database;
   params: { databaseId: DatabaseId };
   reset: () => void;
   initializeDatabase: (databaseId: DatabaseId) => void;

--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.tsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.tsx
@@ -168,11 +168,11 @@ function DatabaseEditApp(props: DatabaseEditAppProps) {
                 loading={!database}
                 error={initializeError}
               >
-                <DatabaseEditContent>
-                  <DatabaseEditForm>
-                    {editingExistingDatabase && database.is_attached_dwh ? (
-                      <div>This database cannot be modified.</div>
-                    ) : (
+                {editingExistingDatabase && database.is_attached_dwh ? (
+                  <div>{t`This database cannot be modified.`}</div>
+                ) : (
+                  <DatabaseEditContent>
+                    <DatabaseEditForm>
                       <DatabaseForm
                         initialValues={database}
                         isAdvanced
@@ -180,10 +180,10 @@ function DatabaseEditApp(props: DatabaseEditAppProps) {
                         setIsDirty={setIsDirty}
                         autofocusFieldName={autofocusFieldName}
                       />
-                    )}
-                  </DatabaseEditForm>
-                  <div>{addingNewDatabase && <DatabaseEditHelp />}</div>
-                </DatabaseEditContent>
+                    </DatabaseEditForm>
+                    <div>{addingNewDatabase && <DatabaseEditHelp />}</div>
+                  </DatabaseEditContent>
+                )}
               </LoadingAndErrorWrapper>
             </div>
           </div>

--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.tsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.tsx
@@ -189,10 +189,10 @@ function DatabaseEditApp(props: DatabaseEditAppProps) {
           </div>
         </ErrorBoundary>
 
-        {editingExistingDatabase && (
+        {editingExistingDatabase && !database.is_attached_dwh && (
           <Sidebar
             database={database}
-            isAdmin={isAdmin && !database.is_attached_dwh}
+            isAdmin={isAdmin}
             isModelPersistenceEnabled={isModelPersistenceEnabled}
             updateDatabase={updateDatabase}
             deleteDatabase={deleteDatabase}

--- a/frontend/src/metabase/admin/databases/database.js
+++ b/frontend/src/metabase/admin/databases/database.js
@@ -74,7 +74,10 @@ export const selectEngine = createAction(SELECT_ENGINE);
 // Migration is run as a separate action because that makes it easy to track in tests
 const migrateDatabaseToNewSchedulingSettings = database => {
   return async function (dispatch, getState) {
-    if (database.details["let-user-control-scheduling"] == null) {
+    if (
+      database.details &&
+      database.details["let-user-control-scheduling"] == null
+    ) {
       dispatch({
         type: MIGRATE_TO_NEW_SCHEDULING_SETTINGS,
         payload: {
@@ -109,7 +112,10 @@ export const initializeDatabase = function (databaseId) {
         dispatch({ type: INITIALIZE_DATABASE, payload: database });
 
         // If the new scheduling toggle isn't set, run the migration
-        if (database.details["let-user-control-scheduling"] == null) {
+        if (
+          database.details &&
+          database.details["let-user-control-scheduling"] == null
+        ) {
           dispatch(migrateDatabaseToNewSchedulingSettings(database));
         }
       } catch (error) {

--- a/frontend/src/metabase/admin/databases/editParamsForUserControlledScheduling.js
+++ b/frontend/src/metabase/admin/databases/editParamsForUserControlledScheduling.js
@@ -4,7 +4,7 @@ export function editParamsForUserControlledScheduling(database) {
 }
 
 function editSyncParamsForUserControlledScheduling(database) {
-  if (database.details["let-user-control-scheduling"]) {
+  if (database.details?.["let-user-control-scheduling"]) {
     database.is_full_sync = false;
   }
 }
@@ -12,7 +12,7 @@ function editSyncParamsForUserControlledScheduling(database) {
 function editScheduleParamsForUserControlledScheduling(database) {
   const { details, schedules } = database;
 
-  if (details["let-user-control-scheduling"] && !schedules?.metadata_sync) {
+  if (details?.["let-user-control-scheduling"] && !schedules?.metadata_sync) {
     database.schedules.metadata_sync = {
       schedule_type: "daily",
     };

--- a/frontend/src/metabase/databases/components/DatabaseAuthCodeDescription/DatabaseAuthCodeDescription.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseAuthCodeDescription/DatabaseAuthCodeDescription.tsx
@@ -19,7 +19,7 @@ const DatabaseAuthCodeDescription = (): JSX.Element | null => {
     return null;
   }
 
-  const clientId = details["client-id"] ?? "";
+  const clientId = details?.["client-id"] ?? "";
   const authCodeUrl = new URL(AUTH_CODE_URLS[engine]);
   const googleDriveUrl = new URL(AUTH_CODE_URLS["bigquery_with_drive"]);
   authCodeUrl.searchParams.set("client_id", String(clientId));

--- a/frontend/src/metabase/databases/components/DatabaseClientIdDescription/DatabaseClientIdDescription.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseClientIdDescription/DatabaseClientIdDescription.tsx
@@ -18,7 +18,7 @@ const DatabaseClientIdDescription = (): JSX.Element | null => {
     return null;
   }
 
-  const projectId = details["project-id"] ?? "";
+  const projectId = details?.["project-id"] ?? "";
   const projectUrl = new URL(CREDENTIAL_URLS[engine]);
   projectUrl.searchParams.set("project", String(projectId));
 

--- a/frontend/src/metabase/databases/utils/schema.ts
+++ b/frontend/src/metabase/databases/utils/schema.ts
@@ -69,7 +69,7 @@ export const getSubmitValues = (
   const entries = fields
     .filter(field => isDetailField(field))
     .filter(field => isFieldVisible(field, values.details))
-    .map(field => [field.name, values.details[field.name]]);
+    .map(field => [field.name, values.details?.[field.name]]);
 
   return {
     ...values,

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -9129,6 +9129,27 @@ databaseChangeLog:
                   type: ${text.type}
                   remarks: running, failed, or completed
 
+  - changeSet:
+      id: v51.2024-08-27T00:00:00
+      author: devurandom
+      comment: Add is_attached_dwh to metabase_database
+      preConditions:
+        - not:
+            - columnExists:
+                tableName: metabase_database
+                columnName: is_attached_dwh
+      changes:
+        - addColumn:
+            tableName: metabase_database
+            columns:
+              - column:
+                  name: is_attached_dwh
+                  type: ${boolean.type}
+                  defaultValueBoolean: false
+                  remarks: 'This is an attached data warehouse, do not serialize it and hide its details from the UI'
+                  constraints:
+                    nullable: false
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/serialization-order.edn
+++ b/resources/serialization-order.edn
@@ -85,6 +85,7 @@
                                   :is_on_demand
                                   :is_sample
                                   :is_audit
+                                  :is_attached_dwh
                                   :metadata_sync_schedule
                                   :cache_field_values_schedule
                                   :settings

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -289,7 +289,12 @@
   * `exclude_uneditable_details` will only include DBs for which the current user can edit the DB details. Has no
     effect unless Enterprise Edition code is available and the advanced-permissions feature is enabled.
 
-  * `include_only_uploadable` will only include DBs into which Metabase can insert new data."
+  * `include_only_uploadable` will only include DBs into which Metabase can insert new data.
+
+  Independently of these flags, the implementation of [[metabase.models.interface/to-json]] for `:model/Database` in
+  [[metabase.models.database]] uses the implementation of [[metabase.models.interface/can-write?]] for `:model/Database`
+  in [[metabase.models.database]] to exclude the `details` field, if the requesting user lacks permission to change the
+  database details."
   [include saved include_editable_data_model exclude_uneditable_details include_only_uploadable include_analytics]
   {include                       (mu/with-api-error-message
                                   [:maybe [:= "tables"]]
@@ -370,7 +375,12 @@
    Passing include_editable_data_model will only return tables for which the current user has data model editing
    permissions, if Enterprise Edition code is available and a token with the advanced-permissions feature is present.
    In addition, if the user has no data access for the DB (aka block permissions), it will return only the DB name, ID
-   and tables, with no additional metadata."
+   and tables, with no additional metadata.
+
+   Independently of these flags, the implementation of [[metabase.models.interface/to-json]] for `:model/Database` in
+   [[metabase.models.database]] uses the implementation of [[metabase.models.interface/can-write?]] for `:model/Database`
+   in [[metabase.models.database]] to exclude the `details` field, if the requesting user lacks permission to change the
+   database details."
   [id include include_editable_data_model exclude_uneditable_details]
   {id      ms/PositiveInt
    include [:maybe [:enum "tables" "tables.fields"]]}

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -269,7 +269,7 @@
       include-tables?              add-tables
       true                         add-can-upload-to-dbs
       include-editable-data-model? filter-databases-by-data-model-perms
-      exclude-uneditable-details?  (#(filter mi/can-write? %))
+      exclude-uneditable-details?  (#(filter (some-fn :is_attached_dwh mi/can-write?) %))
       filter-by-data-access?       (#(filter mi/can-read? %))
       include-saved-questions-db?  (add-saved-questions-virtual-database :include-tables? include-saved-questions-tables?)
       ;; Perms checks for uploadable DBs are handled by exclude-uneditable-details? (see below)

--- a/src/metabase/lib/schema/metadata.cljc
+++ b/src/metabase/lib/schema/metadata.cljc
@@ -333,13 +333,14 @@
    [:id ::lib.schema.id/database]
    ;; TODO -- this should validate against the driver features list in [[metabase.driver/features]] if we're in
    ;; Clj mode
-   [:dbms-version {:optional true} [:maybe :map]]
-   [:details      {:optional true} :map]
-   [:engine       {:optional true} :keyword]
-   [:features     {:optional true} [:set :keyword]]
-   [:is-audit     {:optional true} :boolean]
-   [:settings     {:optional true} [:maybe :map]]
-   [:lib/methods  {:optional true} [:maybe [:ref ::database.methods]]]])
+   [:dbms-version    {:optional true} [:maybe :map]]
+   [:details         {:optional true} :map]
+   [:engine          {:optional true} :keyword]
+   [:features        {:optional true} [:set :keyword]]
+   [:is-audit        {:optional true} :boolean]
+   [:is-attached-dwh {:optional true} :boolean]
+   [:settings        {:optional true} [:maybe :map]]
+   [:lib/methods     {:optional true} [:maybe [:ref ::database.methods]]]])
 
 (mr/def ::metadata-provider
   "Schema for something that satisfies the [[metabase.lib.metadata.protocols/MetadataProvider]] protocol."

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -88,6 +88,8 @@
   (mi/superuser?))
 
 (defmethod mi/can-write? :model/Database
+  ;; Lack of permission to change database details will also exclude the `details` field from the HTTP response,
+  ;; cf. the implementation of [[metabase.models.interface/to-json]] for `:model/Database`.
   ([instance]
    (mi/can-write? :model/Database (u/the-id instance)))
   ([_model pk]

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -39,6 +39,7 @@
                          :uploads_table_prefix])
    {:engine                      "h2"
     :name                        "test-data (h2)"
+    :is_attached_dwh             false
     :is_sample                   false
     :is_full_sync                true
     :is_on_demand                false


### PR DESCRIPTION
== Goal ==

Hide attached DWH database details from anyone incl. admins:
* Do not show them in the UI
* Do not permit to change them
* Do not serialize them

The aim is that customers cannot gain access to (parts of) credentials,
and they cannot break a feature they are paying for by changing
connection details.

Database details are already generally excluded from H2 dump snapshots
(see `metabase.cmd.copy/*copy-h2-database-details*`), thus nothing
changes there.

== Implementation ==

The Metabase backend already contains provisions in the implementation
of `metabase.models.interface/to-json` for `:model/Database` to hide the
`details` of the database in HTTP responses, if the user lacks write
permission on the database.  We utilize this by adding an
`is_attached_dwh` column to the `database` table and rejecting
`metabase.models.interface/can-write?` when this flag is enabled.  In
the "admin" UI, we show a replacement text instead of the edit form when
the flag is set.  (It might be correct to show this whenever `details`
is absent.  See below for possible follow-up work.)

However, several sections of the frontend code expected the `details`
field to always be present.  In order to make `details` optional, as the
backend seems to handle it, we fix the respective code to treat this
case in the way that appears appropriate in the context.

== How to test ==

=== New behaviour ===

Setting the `is_attached_dwh` field hides the database details:

1. Configure a database as described in https://www.metabase.com/docs/latest/configuring-metabase/config-file#databases.
   - In addition to the fields you would normally set, also set
     `is_attached_dwh: true`.
   - This also works when adding this flag to a database that previously
     did not have this flag set.
2. Start your Metabase instance.
3. Verify the database shows up in the "admin" section
   (`/admin/databases`).
4. Verify that clicking the database to see its details only reveals
   "This database cannot be modified."
5. Verify that responses from the backend do not include a `details`
   field for this database.

=== Original behaviour ===

Behaviour without setting the `is_attached_dwh` field is unchanged:

1. Configure a database as described in https://www.metabase.com/docs/latest/configuring-metabase/config-file#databases.
   - Only set the fields you would normally set.  Do not set
     `is_attached_dwh` (or set it to `false`).
2. Start your Metabase instance.
3. Verify the database shows up in the "admin" section
   (`/admin/databases`).
4. Verify that clicking the database to see its details only reveal the
   regular edit form, showing connection fields like `host`, `user`,
   etc. with the values you configured.

== How this will be rolled out ==

1. Upgrade existing Metabase Cloud instances with data warehouse to a
   Metabase version that supports `is_attached_dwh`.
2. Set `is_attached_dwh` in the database section of the config file for
   Metabase Cloud instances with a data warehouse.

== Possible follow-up work ==

In https://github.com/metabase/metabase/issues/25715, absent
`database.details` was identified as a bug.  Since then, `details` was
made `NOT NULL` in the application database, so this bug can no longer
occur.  However, today backend responses can be missing the `details`
field, if the current user lacks write permission to the database
setting (see above).  Fully re-evaluating #25715 in this context is
outside the scope of this PR.

Closes: https://github.com/metabase/harbormaster/issues/5051