### PR TITLE
[QP] Return datetimes in SQL Server, even with date-sized truncation

### DIFF
--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -186,6 +186,18 @@
             [year month day hour minute second fraction precision])
       (h2x/with-database-type-info "datetime2")))
 
+(defn- from-date-expression
+  "When truncating to date-sized chunks (year, quarter, month, week, day) we use the `:DateFromParts` function, which
+  returns a `:date` (Metabase `:type/Date`). But truncation is not supposed to change the type of the column!
+
+  This returns the `:DateFromParts` expression if the original field is `:type/Date`; otherwise (eg. `:type/DateTime`)
+  it casts to `:datetime2`."
+  [base-expr day-expr]
+  (if (or (= (:base-type *field-options*) :type/Date)
+          (lib.util.match/match-one base-expr [::h2x/typed _ {:database-type (_ :guard #{:date "date"})}]))
+    day-expr
+    (h2x/cast :datetime2 day-expr)))
+
 (defmethod sql.qp/date [:sqlserver :hour]
   [_driver _unit expr]
   (if (= (h2x/database-type expr) "time")
@@ -202,7 +214,7 @@
   ;; SQL functions like `day()` that don't return a full DATE. See `optimized-temporal-buckets` below for more info.
   (if (::optimized-bucketing? *field-options*)
     (h2x/day expr)
-    [:DateFromParts (h2x/year expr) (h2x/month expr) (h2x/day expr)]))
+    (from-date-expression expr [:DateFromParts (h2x/year expr) (h2x/month expr) (h2x/day expr)])))
 
 (defmethod sql.qp/date [:sqlserver :day-of-week]
   [_driver _unit expr]
@@ -239,7 +251,7 @@
   [_ _ expr]
   (if (::optimized-bucketing? *field-options*)
     (h2x/month expr)
-    [:DateFromParts (h2x/year expr) (h2x/month expr) [:inline 1]]))
+    (from-date-expression expr [:DateFromParts (h2x/year expr) (h2x/month expr) [:inline 1]])))
 
 (defmethod sql.qp/date [:sqlserver :month-of-year]
   [_driver _unit expr]
@@ -250,9 +262,9 @@
 ;;     DATEADD(quarter, DATEPART(quarter, %s) - 1, FORMAT(%s, 'yyyy-01-01'))
 (defmethod sql.qp/date [:sqlserver :quarter]
   [_driver _unit expr]
-  (date-add :quarter
-            (h2x/dec (date-part :quarter expr))
-            [:DateFromParts (h2x/year expr) [:inline 1] [:inline 1]]))
+  (->> [:DateFromParts (h2x/year expr) [:inline 1] [:inline 1]]
+       (date-add :quarter (h2x/dec (date-part :quarter expr)))
+       (from-date-expression expr)))
 
 (defmethod sql.qp/date [:sqlserver :quarter-of-year]
   [_driver _unit expr]
@@ -262,7 +274,7 @@
   [_driver _unit expr]
   (if (::optimized-bucketing? *field-options*)
     (h2x/year expr)
-    [:DateFromParts (h2x/year expr) [:inline 1] [:inline 1]]))
+    (from-date-expression expr [:DateFromParts (h2x/year expr) [:inline 1] [:inline 1]])))
 
 (defmethod sql.qp/date [:sqlserver :year-of-era]
   [_driver _unit expr]


### PR DESCRIPTION
Previously, truncating a `:type/DateTime` column by `:month` or `:day`
would return a `:type/Date`, which subtly broke the query.

In particular, if you try to order-by the breakout column `Created At (month)`
then it would not get de-duplicated, causing a SQL error about conflicting
ORDER BY clauses.

Fixes #46992.

The existing and new tests together check that:
1. Actual `:type/Date` columns are left alone
2. Bucketed `:type/DateTime` columns are `CAST` back to `datetime2`
3. The `:result_metadata` types are accurate in both cases.

### How to verify

1. Connect a MS SQL Server database
2. Breakout on a `:type/DateTime` column like `Orders.CREATED_AT`
3. Switch to table view
4. Click the `Created At` header and sort on it
5. Observe the query still works

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
