### PR TITLE
Adding schema name to recents, search results in CP

### DIFF
--- a/frontend/src/metabase-types/api/activity.ts
+++ b/frontend/src/metabase-types/api/activity.ts
@@ -33,6 +33,7 @@ export interface BaseRecentItem {
 export interface RecentTableItem extends BaseRecentItem {
   model: "table";
   display_name: string;
+  table_schema: string;
   database: {
     id: number;
     name: string;
@@ -55,6 +56,9 @@ export interface RecentCollectionItem extends BaseRecentItem {
 }
 
 export type RecentItem = RecentTableItem | RecentCollectionItem;
+
+export const isRecentTableItem = (item: RecentItem): item is RecentTableItem =>
+  item.model === "table";
 
 export interface RecentItemsResponse {
   recent_views: RecentItem[];

--- a/frontend/src/metabase-types/api/mocks/activity.ts
+++ b/frontend/src/metabase-types/api/mocks/activity.ts
@@ -13,9 +13,10 @@ export const createMockRecentTableItem = (
   name: "my_cool_table",
   display_name: "My Cool Table",
   timestamp: "2021-03-01T00:00:00.000Z",
+  table_schema: "PUBLIC",
   database: {
     id: 1,
-    name: "My Cool Collection",
+    name: "My Cool Database",
     initial_sync_status: "complete",
   },
   ...opts,

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -316,16 +316,21 @@ export const getSearchResultSubtext = (wrappedSearchResult: any) => {
       />
     )} ${wrappedSearchResult.model_name}`;
   } else {
-    return (
-      wrappedSearchResult.getCollection().name ||
-      `${wrappedSearchResult.database_name} (${wrappedSearchResult.table_schema})`
-    );
+    if (wrappedSearchResult.model === "table") {
+      return wrappedSearchResult.table_schema
+        ? `${wrappedSearchResult.database_name} (${wrappedSearchResult.table_schema})`
+        : wrappedSearchResult.database_name;
+    } else {
+      return wrappedSearchResult.getCollection().name;
+    }
   }
 };
 
 export const getRecentItemSubtext = (item: RecentItem) => {
   if (isRecentTableItem(item)) {
-    return `${item.database.name} (${item.table_schema})`;
+    return item.table_schema
+      ? `${item.database.name} (${item.table_schema})`
+      : item.database.name;
   } else if (item.parent_collection.id === null) {
     return ROOT_COLLECTION.name;
   } else {

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -26,7 +26,7 @@ import {
 } from "metabase/selectors/settings";
 import { getShowMetabaseLinks } from "metabase/selectors/whitelabel";
 import { Icon, type IconName } from "metabase/ui";
-import type { RecentItem } from "metabase-types/api";
+import { type RecentItem, isRecentTableItem } from "metabase-types/api";
 
 import type { PaletteAction } from "../types";
 import { filterRecentItems } from "../utils";
@@ -318,14 +318,14 @@ export const getSearchResultSubtext = (wrappedSearchResult: any) => {
   } else {
     return (
       wrappedSearchResult.getCollection().name ||
-      wrappedSearchResult.database_name
+      `${wrappedSearchResult.database_name} (${wrappedSearchResult.table_schema})`
     );
   }
 };
 
 export const getRecentItemSubtext = (item: RecentItem) => {
-  if (item.model === "table") {
-    return item.database.name;
+  if (isRecentTableItem(item)) {
+    return `${item.database.name} (${item.table_schema})`;
   } else if (item.parent_collection.id === null) {
     return ROOT_COLLECTION.name;
   } else {

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.unit.spec.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.unit.spec.tsx
@@ -5,10 +5,15 @@ import Search from "metabase/entities/search";
 import { Text } from "metabase/ui";
 import {
   createMockCollection,
+  createMockRecentCollectionItem,
+  createMockRecentTableItem,
   createMockSearchResult,
 } from "metabase-types/api/mocks";
 
-import { getSearchResultSubtext } from "./useCommandPalette";
+import {
+  getRecentItemSubtext,
+  getSearchResultSubtext,
+} from "./useCommandPalette";
 
 const setup = (child: React.ReactNode) => {
   render(<Text>{child}</Text>);
@@ -58,6 +63,34 @@ describe("useCommandPalette", () => {
       setup(getSearchResultSubtext(mockSearchResult));
 
       expect(await screen.findByText("Bar Database")).toBeInTheDocument();
+    });
+
+    it("should should include the schema name in table search results when provided", async () => {
+      const mockSearchResult = Search.wrapEntity(
+        createMockSearchResult({
+          model: "table",
+          collection: createMockCollection({ id: undefined, name: undefined }),
+          database_name: "Bar Database",
+          table_schema: "My Schema",
+        }),
+      );
+      setup(getSearchResultSubtext(mockSearchResult));
+
+      expect(
+        await screen.findByText("Bar Database (My Schema)"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("getRecentItemSubtext", () => {
+    it("should work for cards", async () => {
+      const mockRecentItem = createMockRecentCollectionItem();
+      const mockRecentTableItem = createMockRecentTableItem();
+
+      expect(getRecentItemSubtext(mockRecentItem)).toBe("My Cool Collection");
+      expect(getRecentItemSubtext(mockRecentTableItem)).toBe(
+        "My Cool Database (PUBLIC)",
+      );
     });
   });
 });

--- a/src/metabase/models/recent_views.clj
+++ b/src/metabase/models/recent_views.clj
@@ -193,7 +193,7 @@
      [:dashboard [:map [:parent_collection ::pc]]]
      [:table [:map
               [:display_name :string]
-              [:table_schema :string]
+              [:table_schema [:maybe :string]]
               [:database [:map
                           [:id [:int {:min 1}]]
                           [:name :string]]]]]

--- a/src/metabase/models/recent_views.clj
+++ b/src/metabase/models/recent_views.clj
@@ -193,6 +193,7 @@
      [:dashboard [:map [:parent_collection ::pc]]]
      [:table [:map
               [:display_name :string]
+              [:table_schema :string]
               [:database [:map
                           [:id [:int {:min 1}]]
                           [:name :string]]]]]
@@ -395,7 +396,7 @@
   [table-ids]
   (t2/select :model/Table
              {:select [:t.id :t.name :t.description
-                       :t.display_name :t.active :t.visibility_type
+                       :t.display_name :t.active :t.visibility_type :t.schema
                        [:db.name :database-name]
                        [:db.id :database-id]
                        [:db.initial_sync_status :initial-sync-status]]
@@ -422,6 +423,7 @@
        :display_name (:display_name table)
        :can_write (mi/can-write? table)
        :timestamp (str timestamp)
+       :table_schema (:schema table)
        :database {:id (:database-id table)
                   :name (:database-name table)
                   :initial_sync_status (:initial-sync-status table)}})))

--- a/test/metabase/models/recent_views_test.clj
+++ b/test/metabase/models/recent_views_test.clj
@@ -163,6 +163,7 @@
                                                    :database {:id db-id, :name "test-data", :initial_sync_status "incomplete"},
                                                    :timestamp String,
                                                    :display_name "Name",
+                                                   :table_schema nil
                                                    :model :table}]]
                                      [true true [{:description nil,
                                                   :can_write true,
@@ -171,6 +172,7 @@
                                                   :id table-id,
                                                   :database {:id db-id, :name "test-data", :initial_sync_status "incomplete"},
                                                   :timestamp String,
+                                                  :table_schema nil
                                                   :display_name "Name",
                                                   :model :table}]]]]
       (with-redefs [mi/can-read? (constantly read?)
@@ -215,6 +217,7 @@
                    :name "tablet",
                    :description nil,
                    :model :table,
+                   :table_schema nil
                    :display_name "I am the table",
                    :can_write true,
                    :database {:id db-id, :name "My DB", :initial_sync_status "incomplete"}}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/44460

### Description
Adds the schema name as contextual info when displaying recent items that are tables in the command palette and data picker, as well as search results in the command palette

### How to verify
1. New question -> table -> select a table
2. Re-open the data picker and go to the recents tab. You should see the table you selected with the database and schema name as parent info
3. Open the command palette, search for a table and select it
4. re-open the command palette. The recents section should show you the table you just selected with database and schema info in the subtext

### Demo
![image](https://github.com/user-attachments/assets/3f59c5bc-fdf7-4580-abcf-ef487afb7099)
![image](https://github.com/user-attachments/assets/f13c98ce-5b6d-4b81-bf5b-dd0f2bcd5c72)

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
