### PR TITLE
Fix flaky test update-db-to-never-scan-values-on-demand-test

### DIFF
--- a/src/metabase/util/jvm.clj
+++ b/src/metabase/util/jvm.clj
@@ -302,7 +302,12 @@
 
 (defn poll
   "Returns `(thunk)` if the result satisfies the `done?` predicate within the timeout and nil otherwise.
-  The default timeout is 1000ms and the default interval is 100ms."
+  The default timeout is 1000ms and the default interval is 100ms.
+
+    (u/poll {:thunk       (fn [] (upload!))
+             :done        (fn [response] (get-in response [:status :done]))
+             :timeout-ms  1000
+             :interval-ms 100})"
   [{:keys [thunk done? timeout-ms interval-ms]
     :or   {timeout-ms 1000 interval-ms 100}}]
   (let [start-time (System/currentTimeMillis)]

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -1275,9 +1275,6 @@
       (mt/with-temp
         [:model/Database db {}]
         (testing "update db setting to never scan should remove scan field values trigger"
-          (testing "sanity check that it has all triggers to begin with"
-            (is (= (task.sync-databases-test/all-db-sync-triggers-name db)
-                   (task.sync-databases-test/query-all-db-sync-triggers-name db))))
           (mt/user-http-request :crowberto :put 200 (format "/database/%d" (:id db))
                                 {:details     {:let-user-control-scheduling true}
                                  :schedules   {:metadata_sync      schedule-map-for-weekly

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -1279,7 +1279,7 @@
                    ;; this is flaking and I suspect it's because the triggers is created async in
                    ;; post-insert hook of Database
                    (u/poll {:thunk     #(task.sync-databases-test/query-all-db-sync-triggers-name db)
-                            :done       not-empty
+                            :done?      not-empty
                             :timeout-ms 300}))))
           (mt/user-http-request :crowberto :put 200 (format "/database/%d" (:id db))
                                 {:details     {:let-user-control-scheduling true}

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -1268,13 +1268,19 @@
                       (:metadata_sync_schedule db)))
             (is (not= (-> schedule-map-for-last-friday-at-11pm u.cron/schedule-map->cron-string)
                       (:cache_field_values_schedule db)))))))))
-
 (deftest update-db-to-never-scan-values-on-demand-test
   (with-db-scheduler-setup!
     (with-test-driver-available!
       (mt/with-temp
         [:model/Database db {}]
         (testing "update db setting to never scan should remove scan field values trigger"
+          (testing "sanity check that it has all triggers to begin with"
+            (is (= (task.sync-databases-test/all-db-sync-triggers-name db)
+                   ;; this is flaking and I suspect it's because the triggers is created async in
+                   ;; post-insert hook of Database
+                   (u/poll {:thunk     #(task.sync-databases-test/query-all-db-sync-triggers-name db)
+                            :done       not-empty
+                            :timeout-ms 300}))))
           (mt/user-http-request :crowberto :put 200 (format "/database/%d" (:id db))
                                 {:details     {:let-user-control-scheduling true}
                                  :schedules   {:metadata_sync      schedule-map-for-weekly


### PR DESCRIPTION
[Flaky run](https://github.com/metabase/metabase/actions/runs/10568352226/job/29280015374#step:7:1747)

The flaky assertion is a sanity check that after adding a database, we add the 2 default quartz triggers for sync.

This is currently done in the `post-insert` hook.

I have exhausted all options for how it could flake, and I suspect that it's because Quartz added the trigger async.

So, I added a retry with a timeout for it.