### PR TITLE
Fix CSV uploads for non-ASCII headers

### DIFF
--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -796,7 +796,7 @@
         (let [tsvs (map (partial row->tsv driver (count column-names)) values)
               sql  (sql/format {::load   [file-path (keyword table-name)]
                                 ;; We need to namespace the keyword in case the column name starts with a %
-                                :columns (map #(keyword table-name (name %)) column-names)}
+                                :columns (sql-jdbc.common/qualify-columns table-name column-names)}
                                :quoted true
                                :dialect (sql.qp/quote-style driver))]
           (with-open [^java.io.Writer writer (jio/writer file-path)]

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -793,12 +793,12 @@
     (let [temp-file (File/createTempFile table-name ".tsv")
           file-path (.getAbsolutePath temp-file)]
       (try
-        (let [tsvs (map (partial row->tsv driver (count column-names)) values)
-              sql  (sql/format {::load   [file-path (keyword table-name)]
-                                ;; We need to namespace the keyword in case the column name starts with a %
-                                :columns (sql-jdbc.common/qualify-columns table-name column-names)}
-                               :quoted true
-                               :dialect (sql.qp/quote-style driver))]
+        (let [tsvs    (map (partial row->tsv driver (count column-names)) values)
+              dialect (sql.qp/quote-style driver)
+              sql     (sql/format {::load   [file-path (keyword table-name)]
+                                   :columns (sql-jdbc.common/quote-columns dialect column-names)}
+                                  :quoted true
+                                  :dialect dialect)]
           (with-open [^java.io.Writer writer (jio/writer file-path)]
             (doseq [value (interpose \newline tsvs)]
               (.write writer (str value))))

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -790,7 +790,7 @@
   (if (not= (get-global-variable db-id "local_infile") "ON")
     ;; If it isn't turned on, fall back to the generic "INSERT INTO ..." way
     ((get-method driver/insert-into! :sql-jdbc) driver db-id table-name column-names values)
-    (let [temp-file (File/createTempFile table-name ".tjsv")
+    (let [temp-file (File/createTempFile table-name ".tsv")
           file-path (.getAbsolutePath temp-file)]
       (try
         (let [tsvs (map (partial row->tsv driver (count column-names)) values)

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -796,7 +796,7 @@
         (let [tsvs (map (partial row->tsv driver (count column-names)) values)
               sql  (sql/format {::load   [file-path (keyword table-name)]
                                 ;; We need to namespace the keyword in case the column name starts with a %
-                                :columns (map #(keyword table-name %) column-names)}
+                                :columns (map #(keyword table-name (name %)) column-names)}
                                :quoted true
                                :dialect (sql.qp/quote-style driver))]
           (with-open [^java.io.Writer writer (jio/writer file-path)]

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -909,12 +909,12 @@
   [driver db-id table-name column-names values]
   (jdbc/with-db-transaction [conn (sql-jdbc.conn/db->pooled-connection-spec db-id)]
     (let [copy-manager (CopyManager. (.unwrap ^Connection (:connection conn) PgConnection))
-          [sql & _]    (sql/format {::copy       (keyword table-name)
-                                    ;; We need to namespace the keyword in case the column name starts with a %
-                                    :columns     (sql-jdbc.common/qualify-columns table-name column-names)
-                                    ::from-stdin "''"}
-                                   :quoted true
-                                   :dialect (sql.qp/quote-style driver))
+          dialect      (sql.qp/quote-style driver)
+          [sql & _] (sql/format {::copy       (keyword table-name)
+                                 :columns     (sql-jdbc.common/quote-columns dialect column-names)
+                                 ::from-stdin "''"}
+                                :quoted true
+                                :dialect dialect)
           ;; On Postgres with a large file, 100 (3.76m) was significantly faster than 50 (4.03m) and 25 (4.27m). 1,000 was a
           ;; little faster but not by much (3.63m), and 10,000 threw an error:
           ;;     PreparedStatement can have at most 65,535 parameters

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -910,7 +910,8 @@
   (jdbc/with-db-transaction [conn (sql-jdbc.conn/db->pooled-connection-spec db-id)]
     (let [copy-manager (CopyManager. (.unwrap ^Connection (:connection conn) PgConnection))
           [sql & _]    (sql/format {::copy       (keyword table-name)
-                                    :columns     (map keyword column-names)
+                                    ;; We need to namespace the keyword in case the column name starts with a %
+                                    :columns     (map (comp #(keyword table-name %) name) column-names)
                                     ::from-stdin "''"}
                                    :quoted true
                                    :dialect (sql.qp/quote-style driver))

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -911,7 +911,7 @@
     (let [copy-manager (CopyManager. (.unwrap ^Connection (:connection conn) PgConnection))
           [sql & _]    (sql/format {::copy       (keyword table-name)
                                     ;; We need to namespace the keyword in case the column name starts with a %
-                                    :columns     (map (comp #(keyword table-name %) name) column-names)
+                                    :columns     (sql-jdbc.common/qualify-columns table-name column-names)
                                     ::from-stdin "''"}
                                    :quoted true
                                    :dialect (sql.qp/quote-style driver))

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -6,6 +6,7 @@
    [metabase.driver :as driver]
    [metabase.driver.sql :as driver.sql]
    [metabase.driver.sql-jdbc.actions :as sql-jdbc.actions]
+   [metabase.driver.sql-jdbc.common :as sql-jdbc.common]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.sql-jdbc.metadata :as sql-jdbc.metadata]
@@ -170,7 +171,7 @@
         chunks     (partition-all (or driver/*insert-chunk-rows* 100) values)
         sqls       (map #(sql/format {:insert-into (keyword table-name)
                                       ;; We need to namespace the keyword in case the column name starts with a %
-                                      :columns     (map (comp (partial keyword table-name) name) column-names)
+                                      :columns     (sql-jdbc.common/qualify-columns table-name column-names)
                                       :values      %}
                                      :quoted true
                                      :dialect (sql.qp/quote-style driver))

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -171,7 +171,8 @@
         ;; There's nothing magic about 100, but it felt good in testing. There could well be a better number.
         chunks     (partition-all (or driver/*insert-chunk-rows* 100) values)
         sqls       (map #(sql/format {:insert-into table-name
-                                      :columns     columns
+                                      ;; We need to namespace the keyword in case the column name starts with a %
+                                      :columns     (map (partial keyword table-name) columns)
                                       :values      %}
                                      :quoted true
                                      :dialect (sql.qp/quote-style driver))

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -159,9 +159,7 @@
 
 (defmethod driver/insert-into! :sql-jdbc
   [driver db-id table-name column-names values]
-  (let [table-name (keyword table-name)
-        columns    (map keyword column-names)
-        ;; We need to partition the insert into multiple statements for both performance and correctness.
+  (let [;; We need to partition the insert into multiple statements for both performance and correctness.
         ;;
         ;; On Postgres with a large file, 100 (3.76m) was significantly faster than 50 (4.03m) and 25 (4.27m). 1,000 was a
         ;; little faster but not by much (3.63m), and 10,000 threw an error:
@@ -170,9 +168,9 @@
         ;; across all drivers. With that in mind, 100 seems like a safe compromise.
         ;; There's nothing magic about 100, but it felt good in testing. There could well be a better number.
         chunks     (partition-all (or driver/*insert-chunk-rows* 100) values)
-        sqls       (map #(sql/format {:insert-into table-name
+        sqls       (map #(sql/format {:insert-into (keyword table-name)
                                       ;; We need to namespace the keyword in case the column name starts with a %
-                                      :columns     (map (partial keyword table-name) columns)
+                                      :columns     (map (partial keyword table-name) column-names)
                                       :values      %}
                                      :quoted true
                                      :dialect (sql.qp/quote-style driver))

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -169,12 +169,12 @@
         ;; across all drivers. With that in mind, 100 seems like a safe compromise.
         ;; There's nothing magic about 100, but it felt good in testing. There could well be a better number.
         chunks     (partition-all (or driver/*insert-chunk-rows* 100) values)
+        dialect    (sql.qp/quote-style driver)
         sqls       (map #(sql/format {:insert-into (keyword table-name)
-                                      ;; We need to namespace the keyword in case the column name starts with a %
-                                      :columns     (sql-jdbc.common/qualify-columns table-name column-names)
+                                      :columns     (sql-jdbc.common/quote-columns dialect column-names)
                                       :values      %}
                                      :quoted true
-                                     :dialect (sql.qp/quote-style driver))
+                                     :dialect dialect)
                         chunks)]
     (jdbc/with-db-transaction [conn (sql-jdbc.conn/db->pooled-connection-spec db-id)]
       (doseq [sql sqls]

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -170,7 +170,7 @@
         chunks     (partition-all (or driver/*insert-chunk-rows* 100) values)
         sqls       (map #(sql/format {:insert-into (keyword table-name)
                                       ;; We need to namespace the keyword in case the column name starts with a %
-                                      :columns     (map (partial keyword table-name) column-names)
+                                      :columns     (map (comp (partial keyword table-name) name) column-names)
                                       :values      %}
                                      :quoted true
                                      :dialect (sql.qp/quote-style driver))

--- a/src/metabase/driver/sql_jdbc/common.clj
+++ b/src/metabase/driver/sql_jdbc/common.clj
@@ -1,6 +1,7 @@
 (ns metabase.driver.sql-jdbc.common
   (:require
    [clojure.string :as str]
+   [honey.sql :as sql]
    [metabase.util :as u]))
 
 (def ^:private valid-separator-styles #{:url :comma :semicolon})
@@ -86,9 +87,9 @@
           kvs       (map kv-fn pairs)]
       (into {} kvs))))
 
-(defn qualify-columns
-  "Used to qualify column names when building HoneySQL queries"
-  [table-name column-names]
-  (let [qualifier (name table-name)]
-    (for [c column-names]
-      (keyword qualifier (name c)))))
+(defn quote-columns
+  "Used to quote column names when building HoneySQL queries, in case they look like function calls."
+  [dialect columns]
+  (binding [sql/*dialect* (sql/get-dialect dialect)]
+    (for [c columns]
+      [:raw (sql/format-entity c)])))

--- a/src/metabase/driver/sql_jdbc/common.clj
+++ b/src/metabase/driver/sql_jdbc/common.clj
@@ -85,3 +85,10 @@
                         [(k-fn k) v]))
           kvs       (map kv-fn pairs)]
       (into {} kvs))))
+
+(defn qualify-columns
+  "Used to qualify column names when building HoneySQL queries"
+  [table-name column-names]
+  (let [qualifier (name table-name)]
+    (for [c (column-names)]
+      (keyword qualifier (name c)))))

--- a/src/metabase/driver/sql_jdbc/common.clj
+++ b/src/metabase/driver/sql_jdbc/common.clj
@@ -90,5 +90,5 @@
   "Used to qualify column names when building HoneySQL queries"
   [table-name column-names]
   (let [qualifier (name table-name)]
-    (for [c (column-names)]
+    (for [c column-names]
       (keyword qualifier (name c)))))

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -39,7 +39,6 @@
    [toucan2.core :as t2])
   (:import
    (java.io File)
-   (java.nio.charset StandardCharsets)
    (org.apache.tika Tika)))
 
 (set! *warn-on-reflection* true)
@@ -68,29 +67,6 @@
 (defn- max-column-bytes [driver]
   (let [column-limit (some-> driver driver/column-name-length-limit)]
     (min-safe column-limit (max-bytes :model/Field :name))))
-
-(defn truncate-utf8-bytes
-  "Truncates a string to at most n bytes in UTF-8 encoding, removing whole characters."
-  [^String s ^long n]
-  (let [bytes (.getBytes s StandardCharsets/UTF_8)]
-    (if (<= (alength bytes) n)
-      s
-      (loop [byte-index 0
-             char-index 0]
-        (if (>= byte-index n)
-          (subs s 0 char-index)
-          (let [char-size  (Character/charCount (.codePointAt s char-index))
-                byte-count (count (.getBytes (subs s char-index (+ char-index char-size)) StandardCharsets/UTF_8))]
-            (if (<= (+ byte-index byte-count) n)
-              (recur (+ byte-index byte-count)
-                     (+ char-index char-size))
-              (subs s 0 char-index))))))))
-
-(defn- normalize-display-name
-  [driver raw-name]
-  (if (str/blank? raw-name)
-    "unnamed column"
-    (truncate-utf8-bytes (str/trim raw-name) (max-column-bytes driver))))
 
 (defn- normalize-column-name
   [driver raw-name]
@@ -318,20 +294,15 @@
   [driver db]
   (driver.u/supports? driver :upload-with-auto-pk db))
 
-(defn- unique-alias-fn [driver separator]
+(defn- unique-alias-fn [driver]
   (let [max-length (max-column-bytes driver)]
     (fn [base suffix]
-      (as-> (str base separator suffix) %
+      (as-> (str base "_" suffix) %
         (driver/escape-alias driver %)
         (lib.util/truncate-alias % max-length)))))
 
-(defn- derive-display-names [driver header]
-  (let [generator-fn (mbql.u/unique-name-generator :unique-alias-fn (unique-alias-fn driver " "))]
-    (mapv generator-fn
-          (for [h header] (normalize-display-name driver h)))))
-
 (defn- derive-column-names [driver header]
-  (let [generator-fn (mbql.u/unique-name-generator :unique-alias-fn (unique-alias-fn driver "_"))]
+  (let [generator-fn (mbql.u/unique-name-generator :unique-alias-fn (unique-alias-fn driver))]
     (mapv (comp keyword generator-fn)
           (for [h header] (normalize-column-name driver h)))))
 
@@ -346,7 +317,6 @@
                                 auto-pk?
                                 without-auto-pk-columns)
             settings          (upload-parsing/get-settings)
-            display-names     (derive-display-names driver header)
             column-names      (derive-column-names driver header)
             cols->upload-type (detect-schema settings column-names rows)
             col-definitions   (column-definitions driver (cond-> cols->upload-type
@@ -363,11 +333,10 @@
                                 {:primary-key [auto-pk-column-keyword]}))
         (try
           (driver/insert-into! driver (:id db) table-name csv-col-names parsed-rows)
-          {:columns (zipmap column-names display-names)
-           :stats   {:num-rows          (count rows)
-                     :num-columns       (count cols->upload-type)
-                     :generated-columns (if auto-pk? 1 0)
-                     :size-mb           (file-size-mb csv-file)}}
+          {:num-rows          (count rows)
+           :num-columns       (count cols->upload-type)
+           :generated-columns (if auto-pk? 1 0)
+           :size-mb           (file-size-mb csv-file)}
           (catch Throwable e
             (driver/drop-table! driver (:id db) table-name)
             (throw (ex-info (ex-message e) {:status-code 400} e))))))))
@@ -388,19 +357,6 @@
     :asynchronous (future (sync/sync-table! table))
     :synchronous (sync/sync-table! table)
     :never nil))
-
-(defn- set-display-names!
-  [table-id field->display-name]
-  (let [field-names    (map (comp name key) field->display-name)
-        case-statement (into [:case]
-                             (mapcat identity)
-                             (for [[n display-name] field->display-name]
-                               [[:= :name (name n)] display-name]))]
-    (t2/update! :model/Field
-                [:and
-                 [:= :table_id table-id]
-                 [:in :name field-names]]
-                {:display_name case-statement})))
 
 (defn- uploads-enabled? []
   (some? (:db_id (public-settings/uploads-settings))))
@@ -488,14 +444,13 @@
         schema            (some->> schema (ddl.i/format-name driver))
         table-name        (some->> table-name (ddl.i/format-name driver))
         schema+table-name (table-identifier {:schema schema :name table-name})
-        {:keys [columns stats]} (create-from-csv! driver db schema+table-name filename file)
+        stats             (create-from-csv! driver db schema+table-name filename file)
         ;; Sync immediately to create the Table and its Fields; the scan is settings-dependent and can be async
         table             (sync-tables/create-table! db {:name         table-name
                                                          :schema       (not-empty schema)
                                                          :display_name display-name})
         _set_is_upload    (t2/update! :model/Table (:id table) {:is_upload true})
         _sync             (scan-and-sync-table! db table)
-        _set_names        (set-display-names! (:id table) columns)
         ;; Set the display_name of the auto-generated primary key column to the same as its name, so that if users
         ;; download results from the table as a CSV and reupload, we'll recognize it as the same column
         _ (when (auto-pk-column? driver db)

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -339,7 +339,7 @@
            :size-mb           (file-size-mb csv-file)}
           (catch Throwable e
             (driver/drop-table! driver (:id db) table-name)
-            (throw (ex-info (ex-message e) {:status-code 400}))))))))
+            (throw (ex-info (ex-message e) {:status-code 400} e))))))))
 
 ;;;; +------------------+
 ;;;; |  Create upload

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -744,6 +744,24 @@
                          [Long/MAX_VALUE true]])
                        (rows-for-table table)))))))))))
 
+(deftest create-from-csv-non-ascii-test
+  (testing "Upload a CSV file with a datetime column"
+    (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
+      (with-mysql-local-infile-on-and-off
+       (with-upload-table!
+         [table (create-from-csv-and-sync-with-defaults!
+                 :file (csv-file-with ["ID,名前,年齢,職業,都市"
+                                       "1,佐藤太郎,25,エンジニア,東京"
+                                       "2,鈴木花子,30,デザイナー,大阪"
+                                       "3,田中一郎,28,マーケター,名古屋"
+                                       "4,山田次郎,35,プロジェクトマネージャー,福岡"
+                                       "5,中村美咲,32,データサイエンティスト,札幌"]))]
+         (testing "Check the data was uploaded into the table correctly"
+           (is (= (header-with-auto-pk ["unnamed_column" "ship_name" "unnamed_column_2"])
+                  #p (column-names-for-table table)))
+           (is (= nil
+                  #p (rows-for-table table)))))))))
+
 (deftest create-from-csv-empty-header-test
   (testing "Upload a CSV file with a blank column name"
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -416,45 +416,45 @@
 (deftest create-from-csv-display-name-test
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
     (with-mysql-local-infile-on-and-off
-     (let [test-names-match (fn [table expected]
-                              (is (= expected
-                                     (:display_name table)
-                                     (:name (table->card table)))))]
-       (testing "The table's display name and model's name is humanized from the CSV file name"
-         (let [csv-file-prefix "some_FILE-prefix"]
-           (do-with-uploaded-example-csv!
-            {:csv-file-prefix csv-file-prefix}
-            (fn [model]
-              (with-upload-table! [table (card->table model)]
-                (test-names-match table "Some File Prefix"))))))
-       (testing "Unicode characters are preserved in the display name, even when the table name is slugified"
-         (let [csv-file-prefix "出色的"]
-           (with-redefs [upload/strictly-monotonic-now (constantly #t "2024-06-28T00:00:00")]
-             (do-with-uploaded-example-csv!
-              {:csv-file-prefix csv-file-prefix}
-              (fn [model]
-                (with-upload-table! [table (card->table model)]
-                  (test-names-match table "出色的")
-                  (is (= (ddl.i/format-name driver/*driver* "%e5%87%ba%e8%89%b2%e7%9a%84_20240628000000")
-                         (:name table)))))))))
-       (testing "The names should be truncated to the right size"
+      (let [test-names-match (fn [table expected]
+                               (is (= expected
+                                      (:display_name table)
+                                      (:name (table->card table)))))]
+        (testing "The table's display name and model's name is humanized from the CSV file name"
+          (let [csv-file-prefix "some_FILE-prefix"]
+            (do-with-uploaded-example-csv!
+             {:csv-file-prefix csv-file-prefix}
+             (fn [model]
+               (with-upload-table! [table (card->table model)]
+                 (test-names-match table "Some File Prefix"))))))
+        (testing "Unicode characters are preserved in the display name, even when the table name is slugified"
+          (let [csv-file-prefix "出色的"]
+            (with-redefs [upload/strictly-monotonic-now (constantly #t "2024-06-28T00:00:00")]
+              (do-with-uploaded-example-csv!
+               {:csv-file-prefix csv-file-prefix}
+               (fn [model]
+                 (with-upload-table! [table (card->table model)]
+                   (test-names-match table "出色的")
+                   (is (= (ddl.i/format-name driver/*driver* "%e5%87%ba%e8%89%b2%e7%9a%84_20240628000000")
+                          (:name table)))))))))
+        (testing "The names should be truncated to the right size"
          ;; we can assume app DBs use UTF-8 encoding (metabase#11753)
-         (let [max-bytes 50]
-           (with-redefs [; redef this because the UNIX filename limit is 255 bytes, so we can't test it in CI
-                         upload/max-bytes (constantly max-bytes)]
-             (doseq [^String c ["a" "出"]]
-               (let [long-csv-file-prefix (apply str (repeat (inc max-bytes) c))
-                     char-size            (count (.getBytes ^String c "UTF-8"))]
-                 (do-with-uploaded-example-csv!
-                  {:csv-file-prefix long-csv-file-prefix}
-                  (fn [model]
-                    (with-upload-table! [table (card->table model)]
-                      (testing "The card name should be truncated to max bytes with UTF-8 encoding"
-                        (is (= (str/capitalize (apply str (repeat (quot max-bytes char-size) c)))
-                               (:name (table->card table)))))
-                      (testing "The display name should be truncated to the max bytes with UTF-8 encoding"
-                        (is (= (str/capitalize (apply str (repeat (quot max-bytes char-size) c)))
-                               (:display_name table))))))))))))))))
+          (let [max-bytes 50]
+            (with-redefs [; redef this because the UNIX filename limit is 255 bytes, so we can't test it in CI
+                          upload/max-bytes (constantly max-bytes)]
+              (doseq [^String c ["a" "出"]]
+                (let [long-csv-file-prefix (apply str (repeat (inc max-bytes) c))
+                      char-size            (count (.getBytes ^String c "UTF-8"))]
+                  (do-with-uploaded-example-csv!
+                   {:csv-file-prefix long-csv-file-prefix}
+                   (fn [model]
+                     (with-upload-table! [table (card->table model)]
+                       (testing "The card name should be truncated to max bytes with UTF-8 encoding"
+                         (is (= (str/capitalize (apply str (repeat (quot max-bytes char-size) c)))
+                                (:name (table->card table)))))
+                       (testing "The display name should be truncated to the max bytes with UTF-8 encoding"
+                         (is (= (str/capitalize (apply str (repeat (quot max-bytes char-size) c)))
+                                (:display_name table))))))))))))))))
 
 (deftest create-from-csv-table-name-test
   (testing "Can upload two files with the same name"

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -747,29 +747,29 @@
   (testing "Upload a CSV file with a datetime column"
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
       (with-mysql-local-infile-on-and-off
-       (with-upload-table!
-         [table (create-from-csv-and-sync-with-defaults!
-                 :file (csv-file-with ["ID,名前,年齢,職業,都市"
-                                       "1,佐藤太郎,25,エンジニア,東京"
-                                       "2,鈴木花子,30,デザイナー,大阪"
-                                       "3,田中一郎,28,マーケター,名古屋"
-                                       "4,山田次郎,35,プロジェクトマネージャー,福岡"
-                                       "5,中村美咲,32,データサイエンティスト,札幌"]))]
-         (testing "Check the data was uploaded into the table correctly"
-           (is (= #_(header-with-auto-pk ["ID" "名前" "年齢" "職業" "都市"])
-                  (header-with-auto-pk ["id"
-                                        "%e5%90%8d%e5%89%8d"
-                                        "%e5%b9%b4%e9%bd%a2"
-                                        "%e8%81%b7%e6%a5%ad"
-                                        "%e9%83%bd%e5%b8%82"])
-                  (column-names-for-table table)))
-           (is (= (rows-with-auto-pk
-                   [[1 "佐藤太郎" 25 "エンジニア" "東京"]
-                    [2 "鈴木花子" 30 "デザイナー" "大阪"]
-                    [3 "田中一郎" 28 "マーケター" "名古屋"]
-                    [4 "山田次郎" 35 "プロジェクトマネージャー" "福岡"]
-                    [5 "中村美咲" 32 "データサイエンティスト" "札幌"]])
-                  (rows-for-table table)))))))))
+        (with-upload-table!
+          [table (create-from-csv-and-sync-with-defaults!
+                  :file (csv-file-with ["ID,名前,年齢,職業,都市"
+                                        "1,佐藤太郎,25,エンジニア,東京"
+                                        "2,鈴木花子,30,デザイナー,大阪"
+                                        "3,田中一郎,28,マーケター,名古屋"
+                                        "4,山田次郎,35,プロジェクトマネージャー,福岡"
+                                        "5,中村美咲,32,データサイエンティスト,札幌"]))]
+          (testing "Check the data was uploaded into the table correctly"
+            (is (= #_(header-with-auto-pk ["ID" "名前" "年齢" "職業" "都市"])
+                 (header-with-auto-pk ["id"
+                                       "%e5%90%8d%e5%89%8d"
+                                       "%e5%b9%b4%e9%bd%a2"
+                                       "%e8%81%b7%e6%a5%ad"
+                                       "%e9%83%bd%e5%b8%82"])
+                   (column-names-for-table table)))
+            (is (= (rows-with-auto-pk
+                    [[1 "佐藤太郎" 25 "エンジニア" "東京"]
+                     [2 "鈴木花子" 30 "デザイナー" "大阪"]
+                     [3 "田中一郎" 28 "マーケター" "名古屋"]
+                     [4 "山田次郎" 35 "プロジェクトマネージャー" "福岡"]
+                     [5 "中村美咲" 32 "データサイエンティスト" "札幌"]])
+                   (rows-for-table table)))))))))
 
 (deftest create-from-csv-empty-header-test
   (testing "Upload a CSV file with a blank column name"

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -486,11 +486,6 @@
 (defn- query-table [table]
   (query (:db_id table) (:id table)))
 
-(defn- column-display-names-for-table [table]
-  (->> (query-table table)
-       mt/cols
-       (map :display_name)))
-
 (defn- column-names-for-table [table]
   (->> (query-table table)
        mt/cols
@@ -574,7 +569,7 @@
                                         "\"a,b,c\",\"d\""]))]
           (testing "Check the data was uploaded into the table correctly"
             (is (= (header-with-auto-pk ["c1", "c2"])
-                   (column-display-names-for-table table)))
+                   (column-names-for-table table)))
             (is (= (rows-with-auto-pk [["a,b,c" "d"]])
                    (rows-for-table table)))))))))
 
@@ -761,8 +756,13 @@
                                        "4,山田次郎,35,プロジェクトマネージャー,福岡"
                                        "5,中村美咲,32,データサイエンティスト,札幌"]))]
          (testing "Check the data was uploaded into the table correctly"
-           (is (= (header-with-auto-pk ["ID" "名前" "年齢" "職業" "都市"])
-                  (column-display-names-for-table table)))
+           (is (= #_(header-with-auto-pk ["ID" "名前" "年齢" "職業" "都市"])
+                  (header-with-auto-pk ["id"
+                                        "%e5%90%8d%e5%89%8d"
+                                        "%e5%b9%b4%e9%bd%a2"
+                                        "%e8%81%b7%e6%a5%ad"
+                                        "%e9%83%bd%e5%b8%82"])
+                  (column-names-for-table table)))
            (is (= (rows-with-auto-pk
                    [[1 "佐藤太郎" 25 "エンジニア" "東京"]
                     [2 "鈴木花子" 30 "デザイナー" "大阪"]
@@ -780,8 +780,8 @@
                                       "1,Serenity,Malcolm Reynolds"
                                       "2,Millennium Falcon, Han Solo"]))]
         (testing "Check the data was uploaded into the table correctly"
-          (is (= (header-with-auto-pk ["unnamed column" "ship name" "unnamed column 2"])
-                 (column-display-names-for-table table))))))))
+          (is (= (header-with-auto-pk ["unnamed_column" "ship_name" "unnamed_column_2"])
+                 (column-names-for-table table))))))))
 
 (deftest create-from-csv-duplicate-names-test
   (testing "Upload a CSV file with duplicate column names"
@@ -795,9 +795,7 @@
           (testing "Table and Fields exist after sync"
             (testing "Check the data was uploaded into the table correctly"
               (is (= (header-with-auto-pk ["unknown" "unknown_2" "unknown_3" "unknown_2_2"])
-                     (column-names-for-table table)))
-              (is (= (header-with-auto-pk ["unknown" "unknown 2" "unknown 3" "unknown_2"])
-                     (column-display-names-for-table table))))))))))
+                     (column-names-for-table table))))))))))
 
 (deftest create-from-csv-sanitize-to-duplicate-names-test
   (testing "Upload a CSV file with unique column names that get sanitized to the same string"
@@ -809,8 +807,6 @@
                                         "$123,12.3, 100"]))]
           (testing "Table and Fields exist after sync"
             (testing "Check the data was uploaded into the table correctly"
-              (is (= [@#'upload/auto-pk-column-name "cost $" "cost %" "cost #"]
-                     (column-display-names-for-table table)))
               (is (= [@#'upload/auto-pk-column-name "cost__" "cost___2" "cost___3"]
                      (column-names-for-table table))))))))))
 
@@ -2297,7 +2293,5 @@
 
 (deftest unique-long-column-names-test
   (let [original ["αbcdεf_αbcdεf"     "αbcdεfg_αbcdεf"   "αbc_2_etc_αbcdεf" "αbc_3_xyz_αbcdεf"]
-        expected [:%CE%B1bcd%  :%_852c229f :%CE%B1bc_2 :%CE%B1bc_3]
-        displays ["αbcdεf_" "αbcdεfg_" "αbc_2_etc" "αbc_3_xyz"]]
-    (is (= expected (#'upload/derive-column-names ::short-column-test-driver original)))
-    (is (= displays (#'upload/derive-display-names ::short-column-test-driver original)))))
+        expected [:%CE%B1bcd%  :%_852c229f :%CE%B1bc_2 :%CE%B1bc_3]]
+    (is (= expected (#'upload/derive-column-names ::short-column-test-driver original)))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/47279### 

### Description

It turns out that we had a chink in our support for non-ASCII characters - column names that start with a non-ASCII character.

This is a bit subtle, and due to the combination of our munging technique and how HoneySQL handles function calls.

- For munging, we use a shared helper that uses URL encoding internally, which prefixes escape sequences with `%`
- HoneySQL interprets keywords starting with `%` as function calls (with no argument).

~~The fix is pretty straight forward, if you namespace a field to qualify it, HoneySQL then knows it is a field.~~ For some reason this did not work for MySQL based engines, so I found another solution - manually formatting the references and putting them in `:raw` blocks.