### PR TITLE
Use original display name for fields in uploaded tables

### DIFF
--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -396,9 +396,9 @@
   [table-id field->display-name]
   (let [field->display-name (update-keys field->display-name (comp u/lower-case-en name))
         case-statement      (into [:case]
-                             (mapcat identity)
-                             (for [[n display-name] field->display-name]
-                               [[:= [:lower :name] n] display-name]))]
+                                  (mapcat identity)
+                                  (for [[n display-name] field->display-name]
+                                    [[:= [:lower :name] n] display-name]))]
     ;; Using t2/update! results in an invalid query for certain versions of PostgreSQL
     ;; SELECT * FROM \"metabase_field\" WHERE \"id\" AND (\"table_id\" = ?) AND ...
     ;;                                        ^^^^^

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -394,15 +394,15 @@
 
 (defn- set-display-names!
   [table-id field->display-name]
-  (let [field-names    (map (comp name key) field->display-name)
+  (let [field-names    (map (comp u/lower-case-en name key) field->display-name)
         case-statement (into [:case]
                              (mapcat identity)
                              (for [[n display-name] field->display-name]
-                               [[:= :name (name n)] display-name]))]
+                               [[:= [:lower :name] [:lower (name n)]] display-name]))]
     (t2/update! :model/Field
                 [:and
                  [:= :table_id table-id]
-                 [:in :name field-names]
+                 [:in [:lower :name] field-names]
                  ;; We don't want to replace display names that have been set manually.
                  [:= [:lower :name] [:lower :display_name]]]
                 {:display_name case-statement})))

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -781,7 +781,7 @@
                                       "1,Serenity,Malcolm Reynolds"
                                       "2,Millennium Falcon, Han Solo"]))]
         (testing "Check the data was uploaded into the table correctly"
-          (is (= (header-with-auto-pk ["Unnamed column" "Ship Name" "Unnamed Column 2"])
+          (is (= (header-with-auto-pk ["Unnamed Column" "Ship Name" "Unnamed Column 2"])
                  (column-display-names-for-table table))))))))
 
 (deftest create-from-csv-duplicate-names-test

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -487,6 +487,11 @@
 (defn- query-table [table]
   (query (:db_id table) (:id table)))
 
+(defn- column-display-names-for-table [table]
+  (->> (query-table table)
+       mt/cols
+       (map :display_name)))
+
 (defn- column-names-for-table [table]
   (->> (query-table table)
        mt/cols
@@ -570,7 +575,7 @@
                                         "\"a,b,c\",\"d\""]))]
           (testing "Check the data was uploaded into the table correctly"
             (is (= (header-with-auto-pk ["c1", "c2"])
-                   (column-names-for-table table)))
+                   (column-display-names-for-table table)))
             (is (= (rows-with-auto-pk [["a,b,c" "d"]])
                    (rows-for-table table)))))))))
 
@@ -748,29 +753,24 @@
   (testing "Upload a CSV file with a datetime column"
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
       (with-mysql-local-infile-on-and-off
-        (with-upload-table!
-          [table (create-from-csv-and-sync-with-defaults!
-                  :file (csv-file-with ["ID,名前,年齢,職業,都市"
-                                        "1,佐藤太郎,25,エンジニア,東京"
-                                        "2,鈴木花子,30,デザイナー,大阪"
-                                        "3,田中一郎,28,マーケター,名古屋"
-                                        "4,山田次郎,35,プロジェクトマネージャー,福岡"
-                                        "5,中村美咲,32,データサイエンティスト,札幌"]))]
-          (testing "Check the data was uploaded into the table correctly"
-            (is (= #_(header-with-auto-pk ["ID" "名前" "年齢" "職業" "都市"])
-                 (header-with-auto-pk ["id"
-                                       "%e5%90%8d%e5%89%8d"
-                                       "%e5%b9%b4%e9%bd%a2"
-                                       "%e8%81%b7%e6%a5%ad"
-                                       "%e9%83%bd%e5%b8%82"])
-                   (column-names-for-table table)))
-            (is (= (rows-with-auto-pk
-                    [[1 "佐藤太郎" 25 "エンジニア" "東京"]
-                     [2 "鈴木花子" 30 "デザイナー" "大阪"]
-                     [3 "田中一郎" 28 "マーケター" "名古屋"]
-                     [4 "山田次郎" 35 "プロジェクトマネージャー" "福岡"]
-                     [5 "中村美咲" 32 "データサイエンティスト" "札幌"]])
-                   (rows-for-table table)))))))))
+       (with-upload-table!
+         [table (create-from-csv-and-sync-with-defaults!
+                 :file (csv-file-with ["ID,名前,年齢,職業,都市"
+                                       "1,佐藤太郎,25,エンジニア,東京"
+                                       "2,鈴木花子,30,デザイナー,大阪"
+                                       "3,田中一郎,28,マーケター,名古屋"
+                                       "4,山田次郎,35,プロジェクトマネージャー,福岡"
+                                       "5,中村美咲,32,データサイエンティスト,札幌"]))]
+         (testing "Check the data was uploaded into the table correctly"
+           (is (= (header-with-auto-pk ["ID" "名前" "年齢" "職業" "都市"])
+                  (column-display-names-for-table table)))
+           (is (= (rows-with-auto-pk
+                   [[1 "佐藤太郎" 25 "エンジニア" "東京"]
+                    [2 "鈴木花子" 30 "デザイナー" "大阪"]
+                    [3 "田中一郎" 28 "マーケター" "名古屋"]
+                    [4 "山田次郎" 35 "プロジェクトマネージャー" "福岡"]
+                    [5 "中村美咲" 32 "データサイエンティスト" "札幌"]])
+                  (rows-for-table table)))))))))
 
 (deftest create-from-csv-empty-header-test
   (testing "Upload a CSV file with a blank column name"
@@ -781,8 +781,8 @@
                                       "1,Serenity,Malcolm Reynolds"
                                       "2,Millennium Falcon, Han Solo"]))]
         (testing "Check the data was uploaded into the table correctly"
-          (is (= (header-with-auto-pk ["unnamed_column" "ship_name" "unnamed_column_2"])
-                 (column-names-for-table table))))))))
+          (is (= (header-with-auto-pk ["unnamed column" "ship name" "unnamed column 2"])
+                 (column-display-names-for-table table))))))))
 
 (deftest create-from-csv-duplicate-names-test
   (testing "Upload a CSV file with duplicate column names"
@@ -796,7 +796,9 @@
           (testing "Table and Fields exist after sync"
             (testing "Check the data was uploaded into the table correctly"
               (is (= (header-with-auto-pk ["unknown" "unknown_2" "unknown_3" "unknown_2_2"])
-                     (column-names-for-table table))))))))))
+                     (column-names-for-table table)))
+              (is (= (header-with-auto-pk ["unknown" "unknown 2" "unknown 3" "unknown_2"])
+                     (column-display-names-for-table table))))))))))
 
 (deftest create-from-csv-sanitize-to-duplicate-names-test
   (testing "Upload a CSV file with unique column names that get sanitized to the same string"
@@ -808,6 +810,8 @@
                                         "$123,12.3, 100"]))]
           (testing "Table and Fields exist after sync"
             (testing "Check the data was uploaded into the table correctly"
+              (is (= [@#'upload/auto-pk-column-name "cost $" "cost %" "cost #"]
+                     (column-display-names-for-table table)))
               (is (= [@#'upload/auto-pk-column-name "cost__" "cost___2" "cost___3"]
                      (column-names-for-table table))))))))))
 
@@ -2294,5 +2298,7 @@
 
 (deftest unique-long-column-names-test
   (let [original ["αbcdεf_αbcdεf"     "αbcdεfg_αbcdεf"   "αbc_2_etc_αbcdεf" "αbc_3_xyz_αbcdεf"]
-        expected [:%CE%B1bcd%  :%_852c229f :%CE%B1bc_2 :%CE%B1bc_3]]
-    (is (= expected (#'upload/derive-column-names ::short-column-test-driver original)))))
+        expected [:%CE%B1bcd%  :%_852c229f :%CE%B1bc_2 :%CE%B1bc_3]
+        displays ["αbcdεf_" "αbcdεfg_" "αbc_2_etc" "αbc_3_xyz"]]
+    (is (= expected (#'upload/derive-column-names ::short-column-test-driver original)))
+    (is (= displays (#'upload/derive-display-names ::short-column-test-driver original)))))

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -753,24 +753,24 @@
   (testing "Upload a CSV file with a datetime column"
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
       (with-mysql-local-infile-on-and-off
-       (with-upload-table!
-         [table (create-from-csv-and-sync-with-defaults!
-                 :file (csv-file-with ["ID,名前,年齢,職業,都市"
-                                       "1,佐藤太郎,25,エンジニア,東京"
-                                       "2,鈴木花子,30,デザイナー,大阪"
-                                       "3,田中一郎,28,マーケター,名古屋"
-                                       "4,山田次郎,35,プロジェクトマネージャー,福岡"
-                                       "5,中村美咲,32,データサイエンティスト,札幌"]))]
-         (testing "Check the data was uploaded into the table correctly"
-           (is (= (header-with-auto-pk ["ID" "名前" "年齢" "職業" "都市"])
-                  (column-display-names-for-table table)))
-           (is (= (rows-with-auto-pk
-                   [[1 "佐藤太郎" 25 "エンジニア" "東京"]
-                    [2 "鈴木花子" 30 "デザイナー" "大阪"]
-                    [3 "田中一郎" 28 "マーケター" "名古屋"]
-                    [4 "山田次郎" 35 "プロジェクトマネージャー" "福岡"]
-                    [5 "中村美咲" 32 "データサイエンティスト" "札幌"]])
-                  (rows-for-table table)))))))))
+        (with-upload-table!
+          [table (create-from-csv-and-sync-with-defaults!
+                  :file (csv-file-with ["ID,名前,年齢,職業,都市"
+                                        "1,佐藤太郎,25,エンジニア,東京"
+                                        "2,鈴木花子,30,デザイナー,大阪"
+                                        "3,田中一郎,28,マーケター,名古屋"
+                                        "4,山田次郎,35,プロジェクトマネージャー,福岡"
+                                        "5,中村美咲,32,データサイエンティスト,札幌"]))]
+          (testing "Check the data was uploaded into the table correctly"
+            (is (= (header-with-auto-pk ["ID" "名前" "年齢" "職業" "都市"])
+                   (column-display-names-for-table table)))
+            (is (= (rows-with-auto-pk
+                    [[1 "佐藤太郎" 25 "エンジニア" "東京"]
+                     [2 "鈴木花子" 30 "デザイナー" "大阪"]
+                     [3 "田中一郎" 28 "マーケター" "名古屋"]
+                     [4 "山田次郎" 35 "プロジェクトマネージャー" "福岡"]
+                     [5 "中村美咲" 32 "データサイエンティスト" "札幌"]])
+                   (rows-for-table table)))))))))
 
 (deftest create-from-csv-empty-header-test
   (testing "Upload a CSV file with a blank column name"
@@ -813,7 +813,7 @@
               (is (= #_[@#'upload/auto-pk-column-name "Cost $" "Cost %" "Cost #"]
                    ;; Blame it on humanization/name->human-readable-name
                    (header-with-auto-pk ["Cost" "Cost 2" "Cost 3"])
-                   (column-display-names-for-table table)))
+                     (column-display-names-for-table table)))
               (is (= [@#'upload/auto-pk-column-name "cost__" "cost___2" "cost___3"]
                      (column-names-for-table table))))))))))
 
@@ -1937,22 +1937,22 @@
     (doseq [action (actions-to-test driver/*driver*)]
       (testing (action-testing-str action)
         (with-uploads-enabled!
-         (testing "Append should handle new non-ascii columns being added in the latest CSV"
-           (with-upload-table! [table (create-upload-table!)]
-             (column-display-names-for-table table)
+          (testing "Append should handle new non-ascii columns being added in the latest CSV"
+            (with-upload-table! [table (create-upload-table!)]
+              (column-display-names-for-table table)
              ;; Reorder as well for good measure
-             (let [csv-rows ["α,name"
-                             "omega,Everything"]
-                   file     (csv-file-with csv-rows)]
-               (testing "The new row is inserted with the values correctly reordered"
-                 (is (= {:row-count 1} (update-csv! action {:file file, :table-id (:id table)})))
-                 (is (= ["name" "α"]
-                        (rest (column-display-names-for-table table))))
-                 (is (= (set (updated-contents action
-                                               [["Obi-Wan Kenobi" nil]]
-                                               [["Everything" "omega"]]))
-                        (set (rows-for-table table)))))
-               (io/delete-file file)))))))))
+              (let [csv-rows ["α,name"
+                              "omega,Everything"]
+                    file     (csv-file-with csv-rows)]
+                (testing "The new row is inserted with the values correctly reordered"
+                  (is (= {:row-count 1} (update-csv! action {:file file, :table-id (:id table)})))
+                  (is (= ["name" "α"]
+                         (rest (column-display-names-for-table table))))
+                  (is (= (set (updated-contents action
+                                                [["Obi-Wan Kenobi" nil]]
+                                                [["Everything" "omega"]]))
+                         (set (rows-for-table table)))))
+                (io/delete-file file)))))))))
 
 (deftest update-type-mismatch-test
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads)


### PR DESCRIPTION
### Description

It's not a great experience when using foreign languages to have obfuscated field names for CSV uploads.

This change makes sure we preserve the pre-munged name in the display name.