### PR TITLE
Migrate Tooltip in FormField to mantine to fix z-index issue

### DIFF
--- a/frontend/src/metabase/core/components/FormField/FormField.tsx
+++ b/frontend/src/metabase/core/components/FormField/FormField.tsx
@@ -2,7 +2,7 @@ import type { HTMLAttributes, ReactNode, Ref } from "react";
 import { forwardRef } from "react";
 import { t } from "ttag";
 
-import Tooltip from "metabase/core/components/Tooltip";
+import { Tooltip } from "metabase/ui";
 
 import {
   FieldCaption,
@@ -82,7 +82,7 @@ const FormField = forwardRef(function FormField(
               <OptionalTag>{t`(optional)`}</OptionalTag>
             )}
             {(infoLabel || infoTooltip) && (
-              <Tooltip tooltip={infoTooltip} maxWidth="100%">
+              <Tooltip multiline label={infoTooltip}>
                 {infoLabel ? (
                   <FieldInfoLabel>{infoLabel}</FieldInfoLabel>
                 ) : (


### PR DESCRIPTION
Picked up a small FE issue for a change of pace! Resolves #41953 which was introduced by #38298 and seems to be the result of the modal z-index being [hardcoded at 200](https://github.com/metabase/metabase/blob/nm-fix-collection-type-tooltip/frontend/src/metabase/ui/components/overlays/Modal/Modal.styled.tsx#L5) which is greater than the [z-index of 4](https://github.com/metabase/metabase/blob/nm-fix-collection-type-tooltip/frontend/src/metabase/components/Popover/constants.ts) which is hardcoded for the Popover component.

I saw the deprecation notice in `Tooltip.tsx` that it's deprecated in favor of the Mantine tooltip in metabase/ui, so I swapped it in in the `FormField` component, and that seems to fix the issue. I also set the `multiline` prop so that the long text doesn't overflow the viewport on small screen widths.

Please let me know if this is the wrong way to go about this. Also not sure if any testing is needed/appropriate here but I'm happy to add some. 🙏 

Before             |  After
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/654ba2d2-b5d3-47e3-91a8-87049bae471c)  |  ![](https://github.com/user-attachments/assets/8abbde61-a69d-4d21-b7fd-745b8122a4f3)