### PR TITLE
fix(admin/performance): Don't show tooltip on default policy

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyFormLauncher.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyFormLauncher.tsx
@@ -9,6 +9,15 @@ import type { CacheConfig } from "metabase-types/api";
 
 import { PolicyToken, StyledLauncher } from "./StrategyFormLauncher.styled";
 
+export type StrategyFormLauncherProps = {
+  forId: number;
+  targetId: number | null;
+  title: string;
+  updateTargetId: UpdateTargetId;
+  configs: CacheConfig[];
+  isFormDirty: boolean;
+};
+
 export const StrategyFormLauncher = ({
   forId,
   targetId,
@@ -16,14 +25,7 @@ export const StrategyFormLauncher = ({
   updateTargetId,
   configs,
   isFormDirty,
-}: {
-  forId: number;
-  targetId: number | null;
-  title: string;
-  updateTargetId: UpdateTargetId;
-  configs: CacheConfig[];
-  isFormDirty: boolean;
-}) => {
+}: StrategyFormLauncherProps) => {
   const forRoot = forId === rootId;
 
   const config = findWhere(configs, { model_id: forId });
@@ -32,7 +34,7 @@ export const StrategyFormLauncher = ({
   const rootStrategy = rootConfig?.strategy ?? { type: "nocache" };
   const savedStrategy = config?.strategy;
 
-  const inheritsRootStrategy = savedStrategy === undefined;
+  const inheritsRootStrategy = !forRoot && savedStrategy === undefined;
   const strategy = savedStrategy ?? rootStrategy;
   const isBeingEdited = targetId === forId;
 
@@ -61,6 +63,7 @@ export const StrategyFormLauncher = ({
       updateTargetId(forId, isFormDirty);
     }
   };
+  const shouldDisableTooltip = !inheritsRootStrategy;
 
   return (
     <StyledLauncher
@@ -71,6 +74,9 @@ export const StrategyFormLauncher = ({
       inheritsRootStrategy={inheritsRootStrategy}
       justify="space-between"
       gap="md"
+      data-testid={`strategy-form-launcher${
+        shouldDisableTooltip ? "" : "-with-tooltip"
+      }`}
     >
       <Flex gap="0.5rem" color="text-medium" align="center">
         <FixedSizeIcon name={forRoot ? "star" : "database"} color="inherit" />
@@ -81,7 +87,7 @@ export const StrategyFormLauncher = ({
       <Flex wrap="nowrap" lh="1.5rem" gap=".5rem">
         <Tooltip
           position="bottom"
-          disabled={!inheritsRootStrategy}
+          disabled={shouldDisableTooltip}
           label={t`Using default policy`}
         >
           <PolicyToken

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyFormLauncher.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyFormLauncher.unit.spec.tsx
@@ -1,0 +1,100 @@
+import { setupEnterprisePlugins } from "__support__/enterprise";
+import { mockSettings } from "__support__/settings";
+import { createMockEntitiesState } from "__support__/store";
+import { renderWithProviders, screen } from "__support__/ui";
+import { rootId } from "metabase/admin/performance/constants/simple";
+import { CacheDurationUnit } from "metabase-types/api";
+import {
+  createMockSettings,
+  createMockTokenFeatures,
+} from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
+
+import {
+  StrategyFormLauncher,
+  type StrategyFormLauncherProps,
+} from "./StrategyFormLauncher";
+
+const defaultProps: Pick<
+  StrategyFormLauncherProps,
+  "configs" | "isFormDirty" | "updateTargetId"
+> = {
+  configs: [
+    {
+      model: "root",
+      model_id: 0,
+      strategy: {
+        type: "duration",
+        duration: 96,
+        unit: CacheDurationUnit.Hours,
+      },
+    },
+    { model: "database", model_id: 1, strategy: { type: "nocache" } },
+  ],
+  isFormDirty: false,
+  updateTargetId: (_: number | null, __: boolean) => {},
+};
+
+const renderStrategyFormLauncher = (props: StrategyFormLauncherProps) => {
+  const storeInitialState = createMockState({
+    entities: createMockEntitiesState({}),
+    settings: mockSettings(
+      createMockSettings({
+        "token-features": createMockTokenFeatures({
+          cache_granular_controls: true,
+        }),
+      }),
+    ),
+  });
+
+  setupEnterprisePlugins();
+
+  return renderWithProviders(<StrategyFormLauncher {...props} />, {
+    storeInitialState,
+  });
+};
+
+describe("StrategyFormLauncher", () => {
+  it("can render a button representing the default policy", async () => {
+    renderStrategyFormLauncher({
+      forId: rootId,
+      targetId: null,
+      title: "Default policy",
+      ...defaultProps,
+    });
+    const launcher = await screen.findByLabelText(
+      "Edit default policy (currently: Duration: 96h)",
+    );
+    expect(launcher).toHaveTextContent("Default policy");
+    expect(launcher).toHaveAttribute("data-testid", "strategy-form-launcher");
+  });
+  it("can render a button representing a database with a Don't cache policy", async () => {
+    renderStrategyFormLauncher({
+      forId: 1,
+      targetId: null,
+      title: "Database 1",
+      ...defaultProps,
+    });
+    const launcher = await screen.findByLabelText(
+      "Edit policy for database 'Database 1' (currently: No caching)",
+    );
+    expect(launcher).toHaveTextContent("Database 1");
+    expect(launcher).toHaveAttribute("data-testid", "strategy-form-launcher");
+  });
+  it("can render a button representing a database that inherits root policy", async () => {
+    renderStrategyFormLauncher({
+      forId: 2,
+      targetId: null,
+      title: "Database 2",
+      ...defaultProps,
+    });
+    const launcher = await screen.findByLabelText(
+      "Edit policy for database 'Database 2' (currently inheriting the default policy, Duration: 96h)",
+    );
+    expect(launcher).toHaveTextContent("Database 2");
+    expect(launcher).toHaveAttribute(
+      "data-testid",
+      "strategy-form-launcher-with-tooltip",
+    );
+  });
+});


### PR DESCRIPTION
This branch removes the tooltip shown here in Admin / Performance when you hover your mouse over the default policy:
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/0d0dec42-a75c-4f5b-8e13-ae40f68c9428.png)

That tooltip is misplaced, since that button represents the default caching policy. The tooltip is used elsewhere to mean "this item is following the default policy, rather than a special policy assigned to the item".

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
