### PR TITLE
Support ctrl + click on command palette links again

### DIFF
--- a/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-QueryActions.unit.spec.ts
+++ b/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-QueryActions.unit.spec.ts
@@ -1,6 +1,6 @@
 import userEvent from "@testing-library/user-event";
 
-import { getIcon, queryIcon, screen, within } from "__support__/ui";
+import { getIcon, queryIcon, screen, waitFor, within } from "__support__/ui";
 import {
   createMockActionParameter,
   createMockCard,
@@ -83,16 +83,20 @@ describe("ActionCreator > Query Actions", () => {
         await userEvent.click(within(view).getByRole("textbox"));
         await userEvent.paste("select * from orders where {{paramNane}}");
 
-        await userEvent.click(screen.getByRole("button", { name: "Save" }));
+        await userEvent.click(
+          await screen.findByRole("button", { name: "Save" }),
+        );
 
         // form is rendered
         expect(
-          screen.getByPlaceholderText("My new fantastic action"),
+          await screen.findByPlaceholderText("My new fantastic action"),
         ).toBeInTheDocument();
         // model is preselected
-        expect(
-          screen.getByTestId("collection-picker-button"),
-        ).toHaveTextContent(MODEL_NAME);
+        await waitFor(() =>
+          expect(
+            screen.getByTestId("collection-picker-button"),
+          ).toHaveTextContent(MODEL_NAME),
+        );
       });
     });
   });

--- a/frontend/src/metabase/palette/components/PaletteResultItem.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResultItem.tsx
@@ -1,4 +1,3 @@
-import { useCallback } from "react";
 import { Link } from "react-router";
 import { t } from "ttag";
 
@@ -17,10 +16,6 @@ export const PaletteResultItem = ({ item, active }: PaletteResultItemProps) => {
   const icon = item.icon ? getCommandPaletteIcon(item, active) : null;
 
   const subtext = item.extra?.subtext;
-
-  const handleLinkClick = useCallback((e: React.MouseEvent) => {
-    e.preventDefault();
-  }, []);
 
   const content = (
     <Flex
@@ -118,12 +113,7 @@ export const PaletteResultItem = ({ item, active }: PaletteResultItemProps) => {
 
   if (item.extra?.href) {
     return (
-      <Box
-        component={Link}
-        to={item.extra.href}
-        onClick={handleLinkClick}
-        w="100%"
-      >
+      <Box component={Link} to={item.extra.href} w="100%">
         {content}
       </Box>
     );

--- a/frontend/src/metabase/palette/components/PaletteResultsList.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResultsList.tsx
@@ -71,7 +71,15 @@ export const PaletteResultList: React.FC<PaletteResultListProps> = props => {
         // having to calculate the current action to perform based
         // on the `activeIndex`, which we would have needed to add
         // as part of the dependencies array.
-        activeRef.current?.click();
+
+        //If we have a link for a child, then click that instead
+        const childAnchor = activeRef.current?.querySelector("a");
+
+        if (childAnchor) {
+          childAnchor.click();
+        } else {
+          activeRef.current?.click();
+        }
       }
     };
     window.addEventListener("keydown", handler, { capture: true });

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -194,7 +194,6 @@ export const useCommandPalette = ({
               priority: Priority.NORMAL,
               perform: () => {
                 trackSearchClick("item", index, "command-palette");
-                dispatch(push(wrappedResult.getUrl()));
               },
               extra: {
                 isVerified: result.moderated_status === "verified",
@@ -240,13 +239,7 @@ export const useCommandPalette = ({
           name: getName(item),
           icon: icon.name,
           section: "recent",
-          perform: () => {
-            // Need to keep this logic here for when user selects via keyboard
-            const href = Urls.modelToUrl(item);
-            if (href) {
-              dispatch(push(href));
-            }
-          },
+          perform: () => {},
           extra: {
             isVerified:
               item.model !== "table" && item.moderated_status === "verified",
@@ -257,7 +250,7 @@ export const useCommandPalette = ({
         };
       }) || []
     );
-  }, [dispatch, recentItems]);
+  }, [recentItems]);
 
   useRegisterActions(hasQuery ? [] : recentItemsActions, [
     recentItemsActions,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/45205

### Description
Migrating the location changing logic from the command palette action back to the link element. Should support regular click, ctrl + click, right click -> new tab and keyboard navigation + enter.  (I only know how to write tests for 2 of those though 😢 )

### How to verify
1. Open the command palette
2. Search for something
3. hold ctrl when clicking on a result. it should open in a new tab.

### Demo
![chrome_P2aAC3J2vI](https://github.com/user-attachments/assets/2bc77c0e-0e05-4957-b59b-c72f4db2c729)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
