### PR TITLE
Populate permission cache only for one DB at a time

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -95,6 +95,7 @@
                                                           org.bouncycastle/bcpkix-jdk18on
                                                           org.bouncycastle/bcprov-jdk18on]}
   metabase/throttle                         {:mvn/version "1.0.2"}              ; Tools for throttling access to API endpoints and other code pathways
+  methodical/methodical                     {:mvn/version "1.0.123"}            ; drop-in replacements for Clojure multimethods and adds several advanced features
   metosin/malli                             {:mvn/version "0.16.3"}             ; Data-driven Schemas for Clojure/Script and babashka
   nano-id/nano-id                           {:mvn/version "1.1.0"}              ; NanoID generator for generating entity_ids
   net.cgrand/macrovich                      {:mvn/version "0.2.2"}              ; utils for writing macros for both Clojure & ClojureScript
@@ -183,8 +184,8 @@
   slingshot/slingshot                       {:mvn/version "0.12.2"}             ; enhanced throw/catch, used by other deps
   stencil/stencil                           {:mvn/version "0.5.0"}              ; Mustache templates for Clojure
   user-agent/user-agent                     {:mvn/version "0.1.1"}              ; User-Agent string parser, for Login History page & elsewhere
-  weavejester/dependency                    {:mvn/version "0.2.1"}              ; Dependency graphs and topological sorting
-  }
+  weavejester/dependency                    {:mvn/version "0.2.1"}}             ; Dependency graphs and topological sorting
+
 
 
  ;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -247,7 +248,6 @@
                                   [org.ow2.asm/asm-all]}
     criterium/criterium          {:mvn/version "0.4.6"}                     ; benchmarking library
     lambdaisland/deep-diff2      {:mvn/version "2.11.216"}                  ; way better diffs
-    methodical/methodical        {:mvn/version "1.0.111"}                   ; drop-in replacements for Clojure multimethods and adds several advanced features
     org.clojure/algo.generic     {:mvn/version "1.0.1"}
     peridot/peridot              {:git/url "https://github.com/piranha/peridot.git"
                                   :sha "999d0a02425c906c35bace749654dc095ecf3e6a"} ; mocking Ring requests; waiting for upstream release of commit 0fc7c01 (explicit charset)

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -160,10 +160,10 @@
       (if (db-ids db-id)
         (get-in perms [user-id perm-type db-id])
         (let [fetched-perms (relevant-permissions-for-user-and-db user-id db-id)]
-         (reset! *permissions-for-user*
-                 {:db-ids (conj db-ids db-id)
-                  :perms  (merge perms fetched-perms)})
-         (get-in fetched-perms [user-id perm-type db-id]))))
+          (reset! *permissions-for-user*
+                  {:db-ids (conj db-ids db-id)
+                   :perms  (merge perms fetched-perms)})
+          (get-in fetched-perms [user-id perm-type db-id]))))
     ;; If we're checking permissions for a *different* user than ourselves, fetch it straight from the DB
     (relevant-permissions-for-user-perm-and-db user-id perm-type db-id)))
 

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -96,29 +96,36 @@
 ;;; ---------------------------------------- Caching ------------------------------------------------------------------
 
 (defn- relevant-permissions-for-user-and-db
-  "Returns all relevant rows for permissions for the user"
+  "Returns all relevant rows for permissions for the user, excluding permissions for deactivated tables."
   [user-id db-id]
   (t2/select :model/DataPermissions
              {:select [:p.* [:pgm.user_id :user_id]]
               :from [[:permissions_group_membership :pgm]]
               :join [[:permissions_group :pg] [:= :pg.id :pgm.group_id]
                      [:data_permissions :p] [:= :p.group_id :pg.id]]
+              :left-join [[:metabase_table :mt] [:= :mt.id :p.table_id]]
               :where [:and
                       [:= :pgm.user_id user-id]
-                      [:= :p.db_id db-id]]}))
+                      [:= :p.db_id db-id]
+                      [:or [:= :p.table_id nil]
+                           [:= :mt.active true]]]}))
 
 (defn- relevant-permissions-for-user-perm-and-db
-  "Returns all relevant rows for a given user, permission type, and db_id"
+  "Returns all relevant rows for a given user, permission type, and db_id, excluding permissions for deactivated
+  tables."
   [user-id perm-type db-id]
   (t2/select :model/DataPermissions
              {:select [:p.* [:pgm.user_id :user_id]]
               :from [[:permissions_group_membership :pgm]]
               :join [[:permissions_group :pg] [:= :pg.id :pgm.group_id]
                      [:data_permissions :p] [:= :p.group_id :pg.id]]
+              :left-join [[:metabase_table :mt] [:= :mt.id :p.table_id]]
               :where [:and
                       [:= :pgm.user_id user-id]
                       [:= :p.perm_type (u/qualified-name perm-type)]
-                      [:= :p.db_id db-id]]}))
+                      [:= :p.db_id db-id]
+                      [:or [:= :p.table_id nil]
+                           [:= :mt.active true]]]}))
 
 (def ^:dynamic *permissions-for-user*
   "A dynamically-bound atom containing a cache of data permissions that have been fetched so far for the current user.

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -128,7 +128,7 @@
                  accidentally use the cache of the wrong user, and `perms` are vectors of data_permissions entries.
 
   When checking permissions, if a DB has not been fetched, it will be added to the cache before the check returns."
-  nil)
+  (atom {:db-ids #{} :perms {}}))
 
 (defenterprise enforced-sandboxes-for-user
   "Given a user-id, returns the set of sandboxes that should be enforced for the provided user ID. This result is

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -107,8 +107,9 @@
               :where [:and
                       [:= :pgm.user_id user-id]
                       [:= :p.db_id db-id]
-                      [:or [:= :p.table_id nil]
-                           [:= :mt.active true]]]}))
+                      [:or
+                       [:= :p.table_id nil]
+                       [:= :mt.active true]]]}))
 
 (defn- relevant-permissions-for-user-perm-and-db
   "Returns all relevant rows for a given user, permission type, and db_id, excluding permissions for deactivated
@@ -124,8 +125,9 @@
                       [:= :pgm.user_id user-id]
                       [:= :p.perm_type (u/qualified-name perm-type)]
                       [:= :p.db_id db-id]
-                      [:or [:= :p.table_id nil]
-                           [:= :mt.active true]]]}))
+                      [:or
+                       [:= :p.table_id nil]
+                       [:= :mt.active true]]]}))
 
 (def ^:dynamic *permissions-for-user*
   "A dynamically-bound atom containing a cache of data permissions that have been fetched so far for the current user.

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -96,38 +96,29 @@
 ;;; ---------------------------------------- Caching ------------------------------------------------------------------
 
 (defn- relevant-permissions-for-user-and-db
-  "Returns all relevant rows for permissions for the user, excluding permissions for deactivated tables."
+  "Returns all relevant rows for a given user and db_id, for storing in the permissions cache."
   [user-id db-id]
   (t2/select :model/DataPermissions
              {:select [:p.* [:pgm.user_id :user_id]]
               :from [[:permissions_group_membership :pgm]]
               :join [[:permissions_group :pg] [:= :pg.id :pgm.group_id]
                      [:data_permissions :p] [:= :p.group_id :pg.id]]
-              :left-join [[:metabase_table :mt] [:= :mt.id :p.table_id]]
               :where [:and
                       [:= :pgm.user_id user-id]
-                      [:= :p.db_id db-id]
-                      [:or
-                       [:= :p.table_id nil]
-                       [:= :mt.active true]]]}))
+                      [:= :p.db_id db-id]]}))
 
 (defn- relevant-permissions-for-user-perm-and-db
-  "Returns all relevant rows for a given user, permission type, and db_id, excluding permissions for deactivated
-  tables."
+  "Returns all relevant rows for a given user, permission type, and db_id."
   [user-id perm-type db-id]
   (t2/select :model/DataPermissions
              {:select [:p.* [:pgm.user_id :user_id]]
               :from [[:permissions_group_membership :pgm]]
               :join [[:permissions_group :pg] [:= :pg.id :pgm.group_id]
                      [:data_permissions :p] [:= :p.group_id :pg.id]]
-              :left-join [[:metabase_table :mt] [:= :mt.id :p.table_id]]
               :where [:and
                       [:= :pgm.user_id user-id]
                       [:= :p.perm_type (u/qualified-name perm-type)]
-                      [:= :p.db_id db-id]
-                      [:or
-                       [:= :p.table_id nil]
-                       [:= :mt.active true]]]}))
+                      [:= :p.db_id db-id]]}))
 
 (def ^:dynamic *permissions-for-user*
   "A dynamically-bound atom containing a cache of data permissions that have been fetched so far for the current user.

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -4,7 +4,6 @@
    [clojure.set :as set]
    [clojure.test :refer :all]
    [java-time.api :as t]
-   [metabase.api.common :as api]
    [metabase.audit :as audit]
    [metabase.config :as config]
    [metabase.lib.core :as lib]
@@ -1014,7 +1013,7 @@
   (let [metadata-provider (lib.metadata.jvm/application-database-metadata-provider (mt/id))
         venues            (lib.metadata/table metadata-provider (mt/id :venues))
         query             (lib/query metadata-provider venues)]
-    (binding [api/*current-user-id* (mt/user->id :crowberto)]
+    (mt/with-current-user (mt/user->id :crowberto)
       (mt/with-temp [:model/Card card {:dataset_query query}
                      :model/Card no-query {}]
         (is (=? {:can_run_adhoc_query true}

--- a/test/metabase/models/data_permissions_test.clj
+++ b/test/metabase/models/data_permissions_test.clj
@@ -232,34 +232,6 @@
                   (is (= :query-builder (data-perms/table-permission-for-user user-id :perms/create-queries database-id table-id-1)))
                   (is (zero? (call-count))))))))))))
 
-(deftest inactive-table-permission-test
-  (testing "An inactive table appears as if it has no permissions, and is not cached"
-    (mt/with-temp [:model/PermissionsGroup           {group-id-1 :id}  {}
-                   :model/User                       {user-id   :id}   {}
-                   :model/PermissionsGroupMembership {}                {:user_id  user-id
-                                                                        :group_id group-id-1}
-                   :model/Database                   {database-id :id} {}
-                   :model/Table                      {table-id-1 :id}  {:db_id database-id}]
-      ;; Revoke All Users perms so that it doesn't override perms in the new groups
-      (mt/with-no-data-perms-for-all-users!
-        (data-perms/set-database-permission! group-id-1 database-id :perms/view-data :blocked)
-        (data-perms/set-table-permission! group-id-1 table-id-1 :perms/view-data :unrestricted)
-        (is (= :unrestricted
-               (data-perms/table-permission-for-user user-id :perms/view-data database-id table-id-1)))
-        (t2/update! :model/Table table-id-1 {:active false})
-
-        ;; Deactivated table has minimum permissions when reading straight from DB
-        (is (= :blocked (data-perms/table-permission-for-user user-id :perms/view-data database-id table-id-1)))
-
-        ;; Deactivated table has minimum permissions when reading from cache
-        (data-perms/with-relevant-permissions-for-user user-id
-          (is (= :blocked (data-perms/table-permission-for-user user-id :perms/view-data database-id table-id-1))))
-
-        ;; Reactivating the table allows the perms to be read again
-        (t2/update! :model/Table table-id-1 {:active true})
-        (is (= :unrestricted
-               (data-perms/table-permission-for-user user-id :perms/view-data database-id table-id-1)))))))
-
 (deftest permissions-for-user-test
   (mt/with-temp [:model/PermissionsGroup           {group-id-1 :id}    {}
                  :model/PermissionsGroup           {group-id-2 :id}    {}

--- a/test/metabase/query_processor/middleware/permissions_test.clj
+++ b/test/metabase/query_processor/middleware/permissions_test.clj
@@ -85,21 +85,6 @@
                :type     :query
                :query    {:source-table (u/the-id table)}}))))))
 
-(deftest nested-native-query-test
-  (testing "Make sure nested native query fails to run if current user doesn't have perms"
-    (t2.with-temp/with-temp [:model/Database db {}]
-      (data-perms/set-database-permission! (perms-group/all-users)
-                                           (u/the-id db)
-                                           :perms/create-queries
-                                           :query-builder)
-      (is (thrown-with-msg?
-           ExceptionInfo
-           perms-error-msg
-           (check-perms-for-rasta
-            {:database (u/the-id db)
-             :type     :query
-             :query   {:source-query {:native "SELECT * FROM VENUES"}}}))))))
-
 (deftest nested-native-query-test-2
   (testing "...but it should work if user has perms [nested native queries]"
     (t2.with-temp/with-temp [Database db]


### PR DESCRIPTION
Splits up the permissions cache so that we fetch it on-demand only for a single DB at a time. I've converted it from a `delay` to an atom that contains both the cached `perms`, and a set of `db-ids` which we've already fetched.

I've also excluded deactivated tables when fetching perms, both straight from the DB as well as when the cache is populated. These tables are essentially invisible to the application so this should be safe.

Also bumped methodical to include https://github.com/camsaul/methodical/pull/150. I'd normally do this as a separate PR but I want to save time getting these in.

Resolves https://github.com/metabase/metabase/issues/47276

### Timing

Here's a timing comparison on an instance with 10 DBs with 1,000 tables each, with permissions set granularly at the table-level for multiple permission types. This shows the request timing when a non-admin does a refresh of a dashboard that includes one card over the sample databases, but doesn't touch any of the large databases.

In this situation, the slow `query_metadata` and `query` API calls have been eliminated. The `database` call time has been cut in half, and this call is only done once on the initial page load, so it's less impactful.

On master             |  On PR branch
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/ef473a21-c998-46b4-bb0d-1671518bdd27)  |  ![](https://github.com/user-attachments/assets/456d1e06-4f35-4762-88e1-a26e79edd428)