### PR TITLE
fix stacked row tooltip shows null values

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/RowChart/utils/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/utils/events.ts
@@ -191,28 +191,34 @@ export const getLegendClickData = (
   };
 };
 
-const getBreakoutsTooltipRows = <TDatum>(
+export const getStackedTooltipRows = <TDatum>(
   bar: BarData<TDatum>,
   settings: VisualizationSettings,
   multipleSeries: Series<TDatum, SeriesInfo>[],
   seriesColors: Record<string, string>,
 ): TooltipRowModel[] =>
-  multipleSeries.map(series => {
-    const value = series.xAccessor(bar.datum);
-    return {
-      name: series.seriesName,
-      color: seriesColors[series.seriesKey],
-      value,
-      formatter: value =>
-        String(
-          formatValueForTooltip({
-            value,
-            settings,
-            column: series.seriesInfo?.metricColumn,
-          }),
-        ),
-    };
-  });
+  multipleSeries
+    .map(series => {
+      const value = series.xAccessor(bar.datum);
+      if (value == null) {
+        return null;
+      }
+
+      return {
+        name: series.seriesName,
+        color: seriesColors[series.seriesKey],
+        value,
+        formatter: (value: unknown) =>
+          String(
+            formatValueForTooltip({
+              value,
+              settings,
+              column: series.seriesInfo?.metricColumn,
+            }),
+          ),
+      };
+    })
+    .filter(isNotNull);
 
 export const getTooltipModel = <TDatum>(
   bar: BarData<TDatum>,
@@ -233,7 +239,7 @@ export const getTooltipModel = <TDatum>(
   );
 
   const hasBreakout = "breakout" in chartColumns;
-  const rows = getBreakoutsTooltipRows(
+  const rows = getStackedTooltipRows(
     bar,
     settings,
     multipleSeries,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/46396

### Description

Tooltip on stacked row charts should not show null values, this PR fixes this.

### How to verify

```sql
select 'foo' d, 10 m1, 20 m2, null m3, 1 m4
union all select 'bar', null, null, 1, null
```

- create the native query
- assign "d" column to y-axis, assign other columns to x-axis
- make it stacked
- ensure when you hover on any bar the tooltip does not show null values

### Demo

<img width="1272" alt="Screenshot 2024-08-27 at 9 25 07 PM" src="https://github.com/user-attachments/assets/a2db419f-fcb1-41c0-b9a6-76e4f7d445d0">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
