### PR TITLE
Make cljfmt work with vscode

### DIFF
--- a/.cljfmt.edn
+++ b/.cljfmt.edn
@@ -1,5 +1,9 @@
 ;; Cljfmt config. See https://github.com/weavejester/cljfmt#formatting-options
-{:sort-ns-references?
+{;; Following option is required for cljfmt to run correctly in vscode/calva.
+ ;; Source: https://calva.io/formatting/#indentation-rules
+ :legacy/merge-indents? true
+ 
+ :sort-ns-references?
  true
 
  :function-arguments-indentation


### PR DESCRIPTION
`cljfmt` stopped working for me after recent changes to our formatting config. Change in this PR makes it work correctly again. Reference to docs can be found in a comment.