### PR TITLE
Quieter Patch Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -586,6 +586,7 @@ jobs:
             --assignee "jeff-bruemmer"
 
   trigger-cloud-issues:
+    if: ${{ !inputs.auto }}
     needs: push-tags
     runs-on: ubuntu-22.04
     timeout-minutes: 10
@@ -624,7 +625,7 @@ jobs:
               event_type: 'update-ee-extra-build',
               client_payload: {
                 version: enterpriseVersion,
-                auto: '${{ inputs.auto }}',
+                auto: true, // always auto-merge
               }
             });
 

--- a/release/src/slack.ts
+++ b/release/src/slack.ts
@@ -331,17 +331,17 @@ export async function sendPublishCompleteMessage({
   owner: string,
   repo: string,
 }) {
-  const baseMessage = `:partydeploy: *${githubRunLink(`${getGenericVersion(version)} Release is Complete`, runId.toString(), owner, repo)}* :partydeploy:\n
-    • ${slackLink("EE Extra Build", `https://github.com/${owner}/metabase-ee-extra/pulls`)} - ${mentionSlackTeam('core-ems')}
-    • ${slackLink("Ops Issues", `https://github.com/${owner}/metabase-ops/issues`)} - ${mentionSlackTeam('successengineers')}`;
+  const baseMessage = `:partydeploy: *${githubRunLink(`${getGenericVersion(version)} Release is Complete`, runId.toString(), owner, repo)}* :partydeploy:`;
 
-  const docsMessage = `
+  const fullMessage = `\n
+    • ${slackLink("EE Extra Build", `https://github.com/${owner}/metabase-ee-extra/pulls`)}}
+    • ${slackLink("Ops Issues", `https://github.com/${owner}/metabase-ops/issues`)} - ${mentionSlackTeam('successengineers')}
     • ${slackLink("Release Notes", `https://github.com/${owner}/${repo}/releases`)} - ${mentionSlackTeam('tech-writers')}
     • ${slackLink("Docs Update", `https://github.com/${owner}/metabase.github.io/pulls`)} - ${mentionSlackTeam('tech-writers')}`;
 
   const isPatch = version.split('.').length > 3;
 
-  const message = `${baseMessage}${isPatch ? '' : docsMessage}`;
+  const message = `${baseMessage}${isPatch ? '' : fullMessage}`;
 
   const buildThread = await getExistingSlackMessage(version, channelName);
   await sendSlackReply({ channelName, message, messageId: buildThread?.id, broadcast: true });


### PR DESCRIPTION
### Description

- Auto-merging ee-extra PRs seems to work well, and reviews were merely perfunctory, so they will now always [auto-merge](https://metaboat.slack.com/archives/C864UT5CZ/p1724857146273149?thread_ts=1724751785.038469&cid=C864UT5CZ) if tests pass for both minor and patch releases.
- [EMs will no longer be tagged on releases](https://metaboat.slack.com/archives/C864UT5CZ/p1724373962585969?thread_ts=1724372984.555279&cid=C864UT5CZ), since they don't have to review EE-extra PRs
- We will [no longer create cloud update issue for patches](https://metaboat.slack.com/archives/C864UT5CZ/p1724772027102349), since we don't want to set a patch to a default.

