### PR TITLE
Revert "Add :legacy/merge-indents? to .cljfmt.edn (#47345)"

### DIFF
--- a/.cljfmt.edn
+++ b/.cljfmt.edn
@@ -1,9 +1,5 @@
 ;; Cljfmt config. See https://github.com/weavejester/cljfmt#formatting-options
-{;; Following option is required for cljfmt to run correctly in vscode/calva.
- ;; Source: https://calva.io/formatting/#indentation-rules
- :legacy/merge-indents? true
- 
- :sort-ns-references?
+{:sort-ns-references?
  true
 
  :function-arguments-indentation


### PR DESCRIPTION
Reverts attempt to make cljfmt work with vscode as it seems to cause problems as in https://github.com/metabase/metabase/actions/runs/10598919594/job/29372665653?pr=47332