### PR TITLE
Exclude inactive tables from the perms cache, and block queries over inactive tables in the QP

### DIFF
--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -96,29 +96,38 @@
 ;;; ---------------------------------------- Caching ------------------------------------------------------------------
 
 (defn- relevant-permissions-for-user-and-db
-  "Returns all relevant rows for a given user and db_id, for storing in the permissions cache."
+  "Returns all relevant rows for permissions for the user, excluding permissions for deactivated tables."
   [user-id db-id]
   (t2/select :model/DataPermissions
              {:select [:p.* [:pgm.user_id :user_id]]
               :from [[:permissions_group_membership :pgm]]
               :join [[:permissions_group :pg] [:= :pg.id :pgm.group_id]
                      [:data_permissions :p] [:= :p.group_id :pg.id]]
+              :left-join [[:metabase_table :mt] [:= :mt.id :p.table_id]]
               :where [:and
                       [:= :pgm.user_id user-id]
-                      [:= :p.db_id db-id]]}))
+                      [:= :p.db_id db-id]
+                      [:or
+                       [:= :p.table_id nil]
+                       [:= :mt.active true]]]}))
 
 (defn- relevant-permissions-for-user-perm-and-db
-  "Returns all relevant rows for a given user, permission type, and db_id."
+  "Returns all relevant rows for a given user, permission type, and db_id, excluding permissions for deactivated
+  tables."
   [user-id perm-type db-id]
   (t2/select :model/DataPermissions
              {:select [:p.* [:pgm.user_id :user_id]]
               :from [[:permissions_group_membership :pgm]]
               :join [[:permissions_group :pg] [:= :pg.id :pgm.group_id]
                      [:data_permissions :p] [:= :p.group_id :pg.id]]
+              :left-join [[:metabase_table :mt] [:= :mt.id :p.table_id]]
               :where [:and
                       [:= :pgm.user_id user-id]
                       [:= :p.perm_type (u/qualified-name perm-type)]
-                      [:= :p.db_id db-id]]}))
+                      [:= :p.db_id db-id]
+                      [:or
+                       [:= :p.table_id nil]
+                       [:= :mt.active true]]]}))
 
 (def ^:dynamic *permissions-for-user*
   "A dynamically-bound atom containing a cache of data permissions that have been fetched so far for the current user.

--- a/src/metabase/models/query/permissions.clj
+++ b/src/metabase/models/query/permissions.clj
@@ -59,7 +59,7 @@
 ;;
 
 (mu/defn query->source-table-ids :- [:set [:or [:= ::native] ::lib.schema.id/table]]
-  "Return a sequence of all Table IDs referenced by `query`."
+  "Return a sequence of all Table IDs referenced by `query`, and/or the ::native keyword for native queries."
   [query :- :map]
   (set
    (flatten

--- a/src/metabase/query_processor/middleware/permissions.clj
+++ b/src/metabase/query_processor/middleware/permissions.clj
@@ -41,6 +41,20 @@
   metabase-enterprise.advanced-permissions.models.permissions.block-permissions
   [_query])
 
+(defn- check-query-does-not-access-inactive-tables
+  "Throws an exception if any of the tables referenced by this query are marked as inactive in the app DB.
+  These queries would (likely) fail anyway since an inactive table one is either deleted, or Metabase's connection
+  doesn't have access to it. But we can reject them preemptively for a more consistent experience, and to avoid
+  needing to cache permissions for inactive tables."
+  [{database-id :database, :as outer-query}]
+  (qp.store/with-metadata-provider database-id
+    (let [table-ids (filter int? (query-perms/query->source-table-ids outer-query))]
+      (doseq [table-id table-ids]
+        (let [table (lib.metadata.protocols/table (qp.store/metadata-provider) table-id)]
+          (when-not (:active table)
+            (throw (ex-info (tru "Table {0} is inactive." table-id)
+                            (select-keys table [:name :id])))))))))
+
 (mu/defn- check-card-read-perms
   "Check that the current user has permissions to read Card with `card-id`, or throw an Exception. "
   [database-id :- ::lib.schema.id/database
@@ -84,6 +98,7 @@
                 (pr-str (data-perms/permissions-for-user *current-user-id*)))
     (when (= audit/audit-db-id database-id)
       (check-audit-db-permissions outer-query))
+    (check-query-does-not-access-inactive-tables outer-query)
     (let [card-id (or *card-id* (:qp/source-card-id outer-query))
           required-perms (query-perms/required-perms-for-query outer-query :already-preprocessed? true)]
       (cond

--- a/test/metabase/query_processor/middleware/permissions_test.clj
+++ b/test/metabase/query_processor/middleware/permissions_test.clj
@@ -255,6 +255,20 @@
                             qp.perms/*card-id* model-id]
                     (check! query)))))))))))
 
+(deftest inactive-table-test
+  (testing "Make sure a query on an inactive table fails to run"
+    (mt/with-full-data-perms-for-all-users!
+      (mt/with-temp [Database db {}
+                     Table    table {:db_id (u/the-id db)
+                                     :active false}]
+        (is (thrown-with-msg?
+             ExceptionInfo
+             #"Table \d+ is inactive."
+             (check-perms-for-rasta
+              {:database (u/the-id db)
+               :type     :query
+               :query    {:source-table (u/the-id table)}})))))))
+
 (deftest e2e-nested-source-card-test
   (testing "Make sure permissions are calculated for Card -> Card -> Source Query (#12354)"
     (mt/with-non-admin-groups-no-root-collection-perms

--- a/test/metabase/query_processor/middleware/permissions_test.clj
+++ b/test/metabase/query_processor/middleware/permissions_test.clj
@@ -278,7 +278,7 @@
                                      :active false}]
         (is (thrown-with-msg?
              ExceptionInfo
-             #"Table \d+ is inactive."
+             #"Table [\d,]+ is inactive."
              (check-perms-for-rasta
               {:database (u/the-id db)
                :type     :query

--- a/test/metabase/query_processor/middleware/permissions_test.clj
+++ b/test/metabase/query_processor/middleware/permissions_test.clj
@@ -85,6 +85,21 @@
                :type     :query
                :query    {:source-table (u/the-id table)}}))))))
 
+(deftest nested-native-query-test
+  (testing "Make sure nested native query fails to run if current user doesn't have perms"
+    (t2.with-temp/with-temp [:model/Database db {}]
+      (data-perms/set-database-permission! (perms-group/all-users)
+                                           (u/the-id db)
+                                           :perms/create-queries
+                                           :query-builder)
+      (is (thrown-with-msg?
+           ExceptionInfo
+           perms-error-msg
+           (check-perms-for-rasta
+            {:database (u/the-id db)
+             :type     :query
+             :query   {:source-query {:native "SELECT * FROM VENUES"}}}))))))
+
 (deftest nested-native-query-test-2
   (testing "...but it should work if user has perms [nested native queries]"
     (t2.with-temp/with-temp [Database db]


### PR DESCRIPTION
* Excludes inactive tables from the permissions cache. This is the same optimization I initially included in https://github.com/metabase/metabase/pull/47332
* Explicitly rejects queries on inactive tables in the permissions QP middleware. This ensures consistent behavior for saved questions using tables that were subsequently deleted, and thus marked as inactive. See [here](https://metaboat.slack.com/archives/C064EB1UE5P/p1724865614315129?thread_ts=1724864863.352419&cid=C064EB1UE5P) for product justification.

Pursuant to https://github.com/metabase/metabase/issues/47276