### PR TITLE
Cards in dashboards: milestone 1 (backend)

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/models_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/models_test.clj
@@ -78,13 +78,15 @@
               (:skip spec) (keys (:transform spec))))
 
           (testing "Every column should be declared in serialization spec"
-            (is (set/subset?
-                 (->> (keys fields)
-                      (map u/lower-case-en)
-                      set)
-                 (->> (keys spec')
-                      (map name)
-                      set))))
+            (let [specs (->> (keys spec')
+                             (map name)
+                             set)
+                  fields (->> (keys fields)
+                              (map u/lower-case-en)
+                              set)]
+
+              (is (set/subset? fields specs)
+                  (format "Missing specs: %s" (pr-str (set/difference fields specs))))))
 
           (testing "Foreign keys should be declared as such\n"
             (doseq [[fk _] (filter #(:fk (second %)) fields)

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -9506,7 +9506,7 @@ databaseChangeLog:
                     nullable: true
 
   - changeSet:
-      id: v51.2024-09-11T09:06:54
+      id: v52.2024-10-08T09:49:40
       author: johnswanson
       comment: Make `report_card.dashboard_id` a foreign key
       preConditions:
@@ -9524,7 +9524,7 @@ databaseChangeLog:
             onDelete: CASCADE
 
   - changeSet:
-      id: v51.2024-09-11T12:34:05
+      id: v52.2024-10-08T10:12:46
       author: johnswanson
       comment: Add an index for `report_card.dashboard_id`
       rollback: # will be removed with the column

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -9527,6 +9527,7 @@ databaseChangeLog:
       id: v51.2024-09-11T12:34:05
       author: johnswanson
       comment: Add an index for `report_card.dashboard_id`
+      rollback: # will be removed with the column
       preConditions:
         - onFail: MARK_RAN
         - not:

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -9523,6 +9523,24 @@ databaseChangeLog:
             constraintName: fk_report_card_ref_dashboard_id
             onDelete: CASCADE
 
+  - changeSet:
+      id: v51.2024-09-11T12:34:05
+      author: johnswanson
+      comment: Add an index for `report_card.dashboard_id`
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - indexExists:
+                tableName: report_card
+                indexName: idx_report_card_dashboard_id
+      changes:
+        - createIndex:
+            indexName: idx_report_card_dashboard_id
+            tableName: report_card
+            columns:
+              - column:
+                  name: dashboard_id
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -9484,6 +9484,21 @@ databaseChangeLog:
               WHERE "KEY" = 'embedding-app-origin';
       rollback: # not needed
 
+  - changeSet:
+      id: v52.2024-10-08T09:44:44
+      author: johnswanson
+      comment: Add `report_card.dashboard_id`
+      changes:
+        - addColumn:
+            tableName: report_card
+            columns:
+              - column:
+                  name: dashboard_id
+                  type: int
+                  remarks: The dashboard that owns the card, if it is a dashboard-internal card.
+                  constraints:
+                    nullable: true
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -9488,6 +9488,12 @@ databaseChangeLog:
       id: v52.2024-10-08T09:44:44
       author: johnswanson
       comment: Add `report_card.dashboard_id`
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+          - columnExists:
+              tableName: report_card
+              columnName: dashboard_id
       changes:
         - addColumn:
             tableName: report_card
@@ -9503,6 +9509,11 @@ databaseChangeLog:
       id: v51.2024-09-11T09:06:54
       author: johnswanson
       comment: Make `report_card.dashboard_id` a foreign key
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+          - foreignKeyConstraintExists:
+            - foreignKeyName: fk_report_card_ref_dashboard_id
       changes:
         - addForeignKeyConstraint:
             baseTableName: report_card

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -9500,50 +9500,7 @@ databaseChangeLog:
                     nullable: true
 
   - changeSet:
-      id: v51.2024-08-28T07:03:42
-      author: johnswanson
-      comment: Add `report_dashboardcard.is_dashboard_internal_card`
-      changes:
-        - addColumn:
-            tableName: report_dashboardcard
-            columns:
-              - column:
-                  name: is_dashboard_internal_card
-                  type: ${boolean.type}
-                  remarks: |
-                    A denormalized representation that this edge from dashboard<->card should be the *only* edge from its card.
-                    Provides an efficient way to enforce the fact that
-                  defaultValueBoolean: false
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v51.2024-08-28T07:03:43
-      author: johnswanson
-      comment: Add `report_dashboardcard.dashboard_internal_card_id`
-      changes:
-        - sql:
-            # TODO: just add the column normally and adjust `before-insert` to set.
-            sql: >-
-              ALTER TABLE report_dashboardcard
-              ADD COLUMN dashboard_internal_card_id INT GENERATED ALWAYS AS (CASE WHEN is_dashboard_internal_card THEN card_id ELSE NULL END) STORED;
-      rollback:
-        - sql:
-            sql: >-
-              ALTER TABLE report_dashboardcard DROP COLUMN dashboard_internal_card_id;
-
-  - changeSet:
-      id: v51.2024-08-28T07:03:44
-      author: johnswanson
-      comment: Add unique index on `report_dashboardcard.dashboard_internal_card_id`
-      changes:
-        - addUniqueConstraint:
-            tableName: report_dashboardcard
-            columnNames: dashboard_internal_card_id
-            constraintName: unique_dashcard_dashboard_internal_card_id
-
-  - changeSet:
-      id: v51.2024-08-28T07:03:45
+      id: v51.2024-09-11T09:06:54
       author: johnswanson
       comment: Make `report_card.dashboard_id` a foreign key
       changes:
@@ -9553,19 +9510,6 @@ databaseChangeLog:
             referencedTableName: report_dashboard
             referencedColumnNames: id
             constraintName: fk_report_card_ref_dashboard_id
-            onDelete: CASCADE
-
-  - changeSet:
-      id: v51.2024-08-28T07:03:46
-      author: johnswanson
-      comment: Make `report_dashboardcard.dashboard_internal_card_id` a foreign key
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: report_dashboardcard
-            baseColumnNames: dashboard_internal_card_id
-            referencedTableName: report_card
-            referencedColumnNames: id
-            constraintName: fk_report_dashboardcard_ref_card_id
             onDelete: CASCADE
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -9523,6 +9523,7 @@ databaseChangeLog:
       comment: Add `report_dashboardcard.dashboard_internal_card_id`
       changes:
         - sql:
+            # TODO: just add the column normally and adjust `before-insert` to set.
             sql: >-
               ALTER TABLE report_dashboardcard
               ADD COLUMN dashboard_internal_card_id INT GENERATED ALWAYS AS (CASE WHEN is_dashboard_internal_card THEN card_id ELSE NULL END) STORED;

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -9499,6 +9499,74 @@ databaseChangeLog:
                   constraints:
                     nullable: true
 
+  - changeSet:
+      id: v51.2024-08-28T07:03:42
+      author: johnswanson
+      comment: Add `report_dashboardcard.is_dashboard_internal_card`
+      changes:
+        - addColumn:
+            tableName: report_dashboardcard
+            columns:
+              - column:
+                  name: is_dashboard_internal_card
+                  type: ${boolean.type}
+                  remarks: |
+                    A denormalized representation that this edge from dashboard<->card should be the *only* edge from its card.
+                    Provides an efficient way to enforce the fact that
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: v51.2024-08-28T07:03:43
+      author: johnswanson
+      comment: Add `report_dashboardcard.dashboard_internal_card_id`
+      changes:
+        - sql:
+            sql: >-
+              ALTER TABLE report_dashboardcard
+              ADD COLUMN dashboard_internal_card_id INT GENERATED ALWAYS AS (CASE WHEN is_dashboard_internal_card THEN card_id ELSE NULL END) STORED;
+      rollback:
+        - sql:
+            sql: >-
+              ALTER TABLE report_dashboardcard DROP COLUMN dashboard_internal_card_id;
+
+  - changeSet:
+      id: v51.2024-08-28T07:03:44
+      author: johnswanson
+      comment: Add unique index on `report_dashboardcard.dashboard_internal_card_id`
+      changes:
+        - addUniqueConstraint:
+            tableName: report_dashboardcard
+            columnNames: dashboard_internal_card_id
+            constraintName: unique_dashcard_dashboard_internal_card_id
+
+  - changeSet:
+      id: v51.2024-08-28T07:03:45
+      author: johnswanson
+      comment: Make `report_card.dashboard_id` a foreign key
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: report_card
+            baseColumnNames: dashboard_id
+            referencedTableName: report_dashboard
+            referencedColumnNames: id
+            constraintName: fk_report_card_ref_dashboard_id
+            onDelete: CASCADE
+
+  - changeSet:
+      id: v51.2024-08-28T07:03:46
+      author: johnswanson
+      comment: Make `report_dashboardcard.dashboard_internal_card_id` a foreign key
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: report_dashboardcard
+            baseColumnNames: dashboard_internal_card_id
+            referencedTableName: report_card
+            referencedColumnNames: id
+            constraintName: fk_report_dashboardcard_ref_card_id
+            onDelete: CASCADE
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -524,7 +524,7 @@
   "Update a `Card`."
   [id :as {{:keys [dataset_query description display name visualization_settings archived collection_id
                    collection_position enable_embedding embedding_params result_metadata parameters
-                   cache_ttl collection_preview type]
+                   cache_ttl collection_preview type dashboard_id]
             :as   card-updates} :body}]
   {id                     ms/PositiveInt
    name                   [:maybe ms/NonBlankString]
@@ -541,7 +541,8 @@
    collection_position    [:maybe ms/PositiveInt]
    result_metadata        [:maybe analyze/ResultsMetadata]
    cache_ttl              [:maybe ms/PositiveInt]
-   collection_preview     [:maybe :boolean]}
+   collection_preview     [:maybe :boolean]
+   dashboard_id           [:maybe ms/PositiveInt]}
   (check-if-card-can-be-saved dataset_query type)
   (let [card-before-update     (t2/hydrate (api/write-check Card id)
                                            [:moderation_reviews :moderator_details])

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -465,7 +465,7 @@
 
 (api/defendpoint POST "/"
   "Create a new `Card`. Card `type` can be `question`, `metric`, or `model`."
-  [:as {{:keys [collection_id collection_position dataset_query description display name
+  [:as {{:keys [collection_id collection_position dataset_query description display name dashboard_id
                 parameters parameter_mappings result_metadata visualization_settings cache_ttl type], :as body} :body}]
   {name                   ms/NonBlankString
    type                   [:maybe ::card-type]
@@ -478,7 +478,8 @@
    collection_id          [:maybe ms/PositiveInt]
    collection_position    [:maybe ms/PositiveInt]
    result_metadata        [:maybe analyze/ResultsMetadata]
-   cache_ttl              [:maybe ms/PositiveInt]}
+   cache_ttl              [:maybe ms/PositiveInt]
+   dashboard_id           [:maybe ms/PositiveInt]}
   (check-if-card-can-be-saved dataset_query type)
   ;; check that we have permissions to run the query that we're trying to save
   (check-data-permissions-for-query dataset_query)

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -471,14 +471,14 @@
   (card-query :question collection options))
 
 (defmethod post-process-collection-children :dataset
-  [_ _options collection rows]
+  [_ options collection rows]
   (let [queries-before (map :dataset_query rows)
         queries-parsed (map (comp mbql.normalize/normalize json/parse-string) queries-before)]
     ;; We need to normalize the dataset queries for hydration, but reset the field to avoid leaking that transform.
     (->> (map #(assoc %2 :dataset_query %1) queries-parsed rows)
          upload/model-hydrate-based-on-upload
          (map #(assoc %2 :dataset_query %1) queries-before)
-         (post-process-collection-children :card collection))))
+         (post-process-collection-children options :card collection))))
 
 (defn- fully-parameterized-text?
   "Decide if `text`, usually (a part of) a query, is fully parameterized given the parameter types

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -478,7 +478,7 @@
     (->> (map #(assoc %2 :dataset_query %1) queries-parsed rows)
          upload/model-hydrate-based-on-upload
          (map #(assoc %2 :dataset_query %1) queries-before)
-         (post-process-collection-children options :card collection))))
+         (post-process-collection-children :card options collection))))
 
 (defn- fully-parameterized-text?
   "Decide if `text`, usually (a part of) a query, is fully parameterized given the parameter types

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -441,6 +441,7 @@
                      [:and
                       [:= :collection_id (:id collection)]
                       [:= :c.archived_directly false]])
+                   [:= :c.dashboard_id nil]
                    [:= :archived (boolean archived?)]
                    (case card-type
                      :model
@@ -652,6 +653,7 @@
                   (t2/reducible-query {:select-distinct [:collection_id :type]
                                        :from            [:report_card]
                                        :where           [:and
+                                                         [:= :dashboard_id nil]
                                                          [:= :archived false]
                                                          [:in :collection_id descendant-collection-ids]]})))
 

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -344,7 +344,6 @@
               (or
                (not (readable? parent-card))
                (not (readable? card)))
-
               :discard
 
               (or (:dashboard_id card)

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -626,10 +626,10 @@
 (defn- assert-no-invalid-dashboard-internal-dashcards [dashboard to-create]
   (when-let [card-ids (seq (keep :card_id to-create))]
     (api/check-400 (not (t2/exists? :model/Card
-                         {:where [:and
-                                  [:not= :dashboard_id (u/the-id dashboard)]
-                                  [:not= :dashboard_id nil]
-                                  [:in :id card-ids]]})))))
+                                    {:where [:and
+                                             [:not= :dashboard_id (u/the-id dashboard)]
+                                             [:not= :dashboard_id nil]
+                                             [:in :id card-ids]]})))))
 
 (defn- do-update-dashcards!
   [dashboard current-cards new-cards]

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -324,35 +324,42 @@
   [id]
   ((get-dashboard-fn *dashboard-load-id*) id))
 
-(defn- cards-to-copy
+(mu/defn- cards-to-copy :- [:map
+                            [:discard [:sequential :any]]
+                            [:copy [:map-of ms/PositiveInt :any]]
+                            [:reference [:map-of ms/PositiveInt :any]]]
   "Returns a map of which cards we need to copy, which cards we need to reference, and which are not to be copied. The
   `:copy` and `:reference` keys are maps from id to card. The `:discard` key is a vector of cards which were not
-  copied due to permissions."
-  [deep-copy? dashcards]
+  copied due to permissions.
+
+  If we're making a deep copy, we copy all cards that we have necessary permissions on. Otherwise, we copy Dashboard
+  Questions (questions stored 'in' the dashboard rather than a collection) and reference the rest (assuming
+  permissions)."
+  [deep-copy? :- ms/MaybeBooleanValue
+   dashcards :- [:sequential :any]]
   (letfn [(card->cards [{:keys [card series]}] (into [card] series))
           (readable? [card] (and (mi/model card) (mi/can-read? card)))
           (card->decision [parent-card card]
             (cond
-              (not (readable? parent-card))
+              (or
+               (not (readable? parent-card))
+               (not (readable? card)))
+
               :discard
 
-              (not (readable? card))
-              :discard
+              (or (:dashboard_id card)
+                  (and deep-copy? (not= :model (:type card))))
+              :copy
 
-              (and (not deep-copy?)
-                   (not (:dashboard_id card)))
-              :reference
-
-              (readable? card)
-              :retain))
+              :else :reference))
           (split-cards [{:keys [card] :as db-card}]
             (let [cards (card->cards db-card)]
               (group-by (partial card->decision card) cards)))]
     (reduce (fn [acc db-card]
-              (let [{:keys [retain discard reference]} (split-cards db-card)]
+              (let [{:keys [discard copy reference]} (split-cards db-card)]
                 (-> acc
                     (update :reference merge (m/index-by :id reference))
-                    (update :copy merge (m/index-by :id retain))
+                    (update :copy merge (m/index-by :id copy))
                     (update :discard concat discard))))
             {:reference {}
              :copy {}
@@ -360,34 +367,26 @@
             dashcards)))
 
 (defn- maybe-duplicate-cards
-  "Takes a dashboard id, and duplicates the cards both on the dashboard's cards and dashcardseries. Returns a map of
-  {:copied {old-card-id duplicated-card} :uncopied [card]} so that the new dashboard can adjust accordingly.
+  "Takes a dashboard id, and duplicates the cards both on the dashboard's cards and dashcardseries as necessary.
+
+  Returns a map of {:copied {old-card-id duplicated-card} :uncopied [card]} so that the new dashboard can adjust accordingly.
 
   If `deep-copy?` is `false`, doesn't copy any cards *except* for Dashboard Questions, which must be copied."
   [deep-copy? new-dashboard old-dashboard dest-coll-id]
   (let [same-collection? (= (:collection_id old-dashboard) dest-coll-id)
         {:keys [copy discard reference]} (cards-to-copy deep-copy? (:dashcards old-dashboard))]
-    (reduce (fn [m [[id card] copy-or-reference]]
-              (assoc-in m
-                        [(case copy-or-reference :copy :copied :reference :referenced) id]
-                        (if (or (= copy-or-reference :reference)
-                                (= (:type card) :model))
-                          card
-                          (card/create-card!
-                           (cond-> (assoc card :collection_id dest-coll-id)
-                             same-collection?
-                             (update :name #(str % " - " (tru "Duplicate")))
-
-                             (:dashboard_id card)
-                             (assoc :dashboard_id (u/the-id new-dashboard)))
-                           @api/*current-user*
-                           ;; creating cards from a transaction. wait until tx complete to signal event
-                           true))))
-            {:copied {}
-             :referenced {}
-             :uncopied discard}
-            (concat (zipmap copy (repeat :copy))
-                    (zipmap reference (repeat :reference))))))
+    {:copied (into {} (for [[id to-copy] copy]
+                        [id (card/create-card!
+                             (cond-> to-copy
+                               true (assoc :collection_id dest-coll-id)
+                               same-collection? (update :name #(str % " - " (tru "Duplicate")))
+                               (:dashboard_id to-copy)
+                               (assoc :dashboard_id (u/the-id new-dashboard)))
+                             @api/*current-user*
+                             ;; creating cards from a transaction. wait until tx complete to signal event
+                             true)]))
+     :discarded discard
+     :referenced reference}))
 
 (defn- duplicate-tabs
   [new-dashboard existing-tabs]
@@ -470,7 +469,7 @@
                          (let [dash (first (t2/insert-returning-instances! :model/Dashboard dashboard-data))
                                {id->new-card :copied
                                 id->referenced-card :referenced
-                                uncopied :uncopied}
+                                uncopied :discarded}
                                (maybe-duplicate-cards is_deep_copy dash existing-dashboard collection_id)
 
                                id->new-tab-id (when-let [existing-tabs (seq (:tabs existing-dashboard))]

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -624,13 +624,12 @@
     dashboard-cards))
 
 (defn- assert-no-invalid-dashboard-internal-dashcards [dashboard to-create]
-  (api/check-400 (not
-                  (seq
-                   (->> to-create
-                        ;; FIXME: this isn't the right check, we don't have a `:card` on the new dashcards.
-                        (map :card)
-                        (keep :dashboard_id)
-                        (remove #(= % (u/the-id dashboard))))))))
+  (when-let [card-ids (seq (keep :card_id to-create))]
+    (api/check-400 (not (t2/exists? :model/Card
+                         {:where [:and
+                                  [:not= :dashboard_id (u/the-id dashboard)]
+                                  [:not= :dashboard_id nil]
+                                  [:in :id card-ids]]})))))
 
 (defn- do-update-dashcards!
   [dashboard current-cards new-cards]

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -325,48 +325,53 @@
   ((get-dashboard-fn *dashboard-load-id*) id))
 
 (defn- cards-to-copy
-  "Returns a map of which cards we need to copy and which are not to be copied. The `:copy` key is a map from id to
-  card. The `:discard` key is a vector of cards which were not copied due to permissions."
+  "Returns a map of which cards we need to copy, which cards we need to reference, and which are not to be copied. The
+  `:copy` and `:reference` keys are maps from id to card. The `:discard` key is a vector of cards which were not
+  copied due to permissions."
   [deep-copy? dashcards]
-  (letfn [(split-cards [{:keys [card series] :as db-card}]
+  (letfn [(card->cards [{:keys [card series]}] (into [card] series))
+          (readable? [card] (and (mi/model card) (mi/can-read? card)))
+          (card->decision [parent-card card]
             (cond
+              (not (readable? parent-card))
+              :discard
+
+              (not (readable? card))
+              :discard
+
               (and (not deep-copy?)
                    (not (:dashboard_id card)))
-              {}
+              :reference
 
-              (nil? (:card_id db-card)) ; text card
-              {}
-
-              ;; cards without permissions are just a map with an :id from [[hide-unreadable-card]]
-              (not (mi/model card))
-              {:retain nil, :discard (into [card] series)}
-
-              (mi/can-read? card)
-              (let [{writable true unwritable false} (group-by (comp boolean mi/can-read?)
-                                                               series)]
-                {:retain (into [card] writable), :discard unwritable})
-              ;; if you can't write the base, we don't have anywhere to put the series
-              :else
-              {:discard (into [card] series)}))]
+              (readable? card)
+              :retain))
+          (split-cards [{:keys [card] :as db-card}]
+            (let [cards (card->cards db-card)]
+              (group-by (partial card->decision card) cards)))]
     (reduce (fn [acc db-card]
-              (let [{:keys [retain discard]} (split-cards db-card)]
+              (let [{:keys [retain discard reference]} (split-cards db-card)]
                 (-> acc
+                    (update :reference merge (m/index-by :id reference))
                     (update :copy merge (m/index-by :id retain))
                     (update :discard concat discard))))
-            {:copy {}
+            {:reference {}
+             :copy {}
              :discard []}
             dashcards)))
 
 (defn- maybe-duplicate-cards
   "Takes a dashboard id, and duplicates the cards both on the dashboard's cards and dashcardseries. Returns a map of
-  {:copied {old-card-id duplicated-card} :uncopied [card]} so that the new dashboard can adjust accordingly."
+  {:copied {old-card-id duplicated-card} :uncopied [card]} so that the new dashboard can adjust accordingly.
+
+  If `deep-copy?` is `false`, doesn't copy any cards *except* for Dashboard Questions, which must be copied."
   [deep-copy? new-dashboard old-dashboard dest-coll-id]
   (let [same-collection? (= (:collection_id old-dashboard) dest-coll-id)
-        {:keys [copy discard]} (cards-to-copy deep-copy? (:dashcards old-dashboard))]
-    (reduce (fn [m [id card]]
+        {:keys [copy discard reference]} (cards-to-copy deep-copy? (:dashcards old-dashboard))]
+    (reduce (fn [m [[id card] copy-or-reference]]
               (assoc-in m
-                        [:copied id]
-                        (if (= (:type card) :model)
+                        [(case copy-or-reference :copy :copied :reference :referenced) id]
+                        (if (or (= copy-or-reference :reference)
+                                (= (:type card) :model))
                           card
                           (card/create-card!
                            (cond-> (assoc card :collection_id dest-coll-id)
@@ -379,8 +384,10 @@
                            ;; creating cards from a transaction. wait until tx complete to signal event
                            true))))
             {:copied {}
+             :referenced {}
              :uncopied discard}
-            copy)))
+            (concat (zipmap copy (repeat :copy))
+                    (zipmap reference (repeat :reference))))))
 
 (defn- duplicate-tabs
   [new-dashboard existing-tabs]
@@ -396,12 +403,8 @@
   If the dashboard has tabs, fix up the tab ids in dashcards to point to the new tabs.
   Then if shallow copy, return the cards. If deep copy, replace ids with id from the newly-copied cards.
   If there is no new id, it means user lacked curate permissions for the cards
-  collections and it is omitted. Dashboard-id is only needed for useful errors."
-  [dashboard-id dashcards deep? id->new-card id->new-tab-id]
-  (when (and deep? (nil? id->new-card))
-    (throw (ex-info (tru "No copied card information found")
-                    {:user-id api/*current-user-id*
-                     :dashboard-id dashboard-id})))
+  collections and it is omitted."
+  [dashcards id->new-card id->referenced-card id->new-tab-id]
   (let [dashcards (if (seq id->new-tab-id)
                     (map #(assoc % :dashboard_tab_id (id->new-tab-id (:dashboard_tab_id %)))
                          dashcards)
@@ -412,8 +415,12 @@
               (nil? (:card_id dashboard-card))
               dashboard-card
 
+              ;; referenced cards need no manipulation
+              (get id->referenced-card (:card_id dashboard-card))
+              dashboard-card
+
               ;; if we didn't duplicate, it doesn't go in the dashboard
-              (not (id->new-card (:card_id dashboard-card)))
+              (not (get id->new-card (:card_id dashboard-card)))
               nil
 
               :else
@@ -461,16 +468,17 @@
                          (api/maybe-reconcile-collection-position! dashboard-data)
                         ;; Ok, now save the Dashboard
                          (let [dash (first (t2/insert-returning-instances! :model/Dashboard dashboard-data))
-                               {id->new-card :copied uncopied :uncopied}
+                               {id->new-card :copied
+                                id->referenced-card :referenced
+                                uncopied :uncopied}
                                (maybe-duplicate-cards is_deep_copy dash existing-dashboard collection_id)
 
                                id->new-tab-id (when-let [existing-tabs (seq (:tabs existing-dashboard))]
                                                 (duplicate-tabs dash existing-tabs))]
                            (reset! new-cards (vals id->new-card))
-                           (when-let [dashcards (seq (update-cards-for-copy from-dashboard-id
-                                                                            (:dashcards existing-dashboard)
-                                                                            is_deep_copy
+                           (when-let [dashcards (seq (update-cards-for-copy (:dashcards existing-dashboard)
                                                                             id->new-card
+                                                                            id->referenced-card
                                                                             id->new-tab-id))]
                              (api/check-500 (dashboard/add-dashcards! dash dashcards)))
                            (cond-> dash
@@ -617,11 +625,13 @@
     dashboard-cards))
 
 (defn- assert-no-invalid-dashboard-internal-dashcards [dashboard to-create]
-  (api/check-400 (seq
-                  (->> to-create
-                       (map :card)
-                       (keep :dashboard_id)
-                       (remove #(= % (u/the-id dashboard)))))))
+  (api/check-400 (not
+                  (seq
+                   (->> to-create
+                        ;; FIXME: this isn't the right check, we don't have a `:card` on the new dashcards.
+                        (map :card)
+                        (keep :dashboard_id)
+                        (remove #(= % (u/the-id dashboard))))))))
 
 (defn- do-update-dashcards!
   [dashboard current-cards new-cards]

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -327,9 +327,13 @@
 (defn- cards-to-copy
   "Returns a map of which cards we need to copy and which are not to be copied. The `:copy` key is a map from id to
   card. The `:discard` key is a vector of cards which were not copied due to permissions."
-  [dashcards]
+  [deep-copy? dashcards]
   (letfn [(split-cards [{:keys [card series] :as db-card}]
             (cond
+              (and (not deep-copy?)
+                   (not (:dashboard_id card)))
+              {}
+
               (nil? (:card_id db-card)) ; text card
               {}
 
@@ -353,12 +357,12 @@
              :discard []}
             dashcards)))
 
-(defn- duplicate-cards
+(defn- maybe-duplicate-cards
   "Takes a dashboard id, and duplicates the cards both on the dashboard's cards and dashcardseries. Returns a map of
   {:copied {old-card-id duplicated-card} :uncopied [card]} so that the new dashboard can adjust accordingly."
-  [dashboard dest-coll-id]
-  (let [same-collection? (= (:collection_id dashboard) dest-coll-id)
-        {:keys [copy discard]} (cards-to-copy (:dashcards dashboard))]
+  [deep-copy? new-dashboard old-dashboard dest-coll-id]
+  (let [same-collection? (= (:collection_id old-dashboard) dest-coll-id)
+        {:keys [copy discard]} (cards-to-copy deep-copy? (:dashcards old-dashboard))]
     (reduce (fn [m [id card]]
               (assoc-in m
                         [:copied id]
@@ -367,7 +371,10 @@
                           (card/create-card!
                            (cond-> (assoc card :collection_id dest-coll-id)
                              same-collection?
-                             (update :name #(str % " - " (tru "Duplicate"))))
+                             (update :name #(str % " - " (tru "Duplicate")))
+
+                             (:dashboard_id card)
+                             (assoc :dashboard_id (u/the-id new-dashboard)))
                            @api/*current-user*
                            ;; creating cards from a transaction. wait until tx complete to signal event
                            true))))
@@ -399,36 +406,34 @@
                     (map #(assoc % :dashboard_tab_id (id->new-tab-id (:dashboard_tab_id %)))
                          dashcards)
                     dashcards)]
-    (if-not deep?
-      dashcards
-      (keep (fn [dashboard-card]
-              (cond
-               ;; text cards need no manipulation
-                (nil? (:card_id dashboard-card))
-                dashboard-card
+    (keep (fn [dashboard-card]
+            (cond
+              ;; text cards need no manipulation
+              (nil? (:card_id dashboard-card))
+              dashboard-card
 
-               ;; if we didn't duplicate, it doesn't go in the dashboard
-                (not (id->new-card (:card_id dashboard-card)))
-                nil
+              ;; if we didn't duplicate, it doesn't go in the dashboard
+              (not (id->new-card (:card_id dashboard-card)))
+              nil
 
-                :else
-                (let [new-id (fn [id]
-                               (-> id id->new-card :id))]
-                  (-> dashboard-card
-                      (update :card_id new-id)
-                      (assoc :card (-> dashboard-card :card_id id->new-card))
-                      (m/update-existing :parameter_mappings
-                                         (fn [pms]
-                                           (keep (fn [pm]
-                                                   (m/update-existing pm :card_id new-id))
-                                                 pms)))
-                      (m/update-existing :series
-                                         (fn [series]
-                                           (keep (fn [card]
-                                                   (when-let [id' (new-id (:id card))]
-                                                     (assoc card :id id')))
-                                                 series)))))))
-            dashcards))))
+              :else
+              (let [new-id (fn [id]
+                             (-> id id->new-card :id))]
+                (-> dashboard-card
+                    (update :card_id new-id)
+                    (assoc :card (-> dashboard-card :card_id id->new-card))
+                    (m/update-existing :parameter_mappings
+                                       (fn [pms]
+                                         (keep (fn [pm]
+                                                 (m/update-existing pm :card_id new-id))
+                                               pms)))
+                    (m/update-existing :series
+                                       (fn [series]
+                                         (keep (fn [card]
+                                                 (when-let [id' (new-id (:id card))]
+                                                   (assoc card :id id')))
+                                               series)))))))
+          dashcards)))
 
 (api/defendpoint POST "/:from-dashboard-id/copy"
   "Copy a Dashboard."
@@ -457,8 +462,7 @@
                         ;; Ok, now save the Dashboard
                          (let [dash (first (t2/insert-returning-instances! :model/Dashboard dashboard-data))
                                {id->new-card :copied uncopied :uncopied}
-                               (when is_deep_copy
-                                 (duplicate-cards existing-dashboard collection_id))
+                               (maybe-duplicate-cards is_deep_copy dash existing-dashboard collection_id)
 
                                id->new-tab-id (when-let [existing-tabs (seq (:tabs existing-dashboard))]
                                                 (duplicate-tabs dash existing-tabs))]
@@ -612,9 +616,17 @@
     (dashboard-card/delete-dashboard-cards! dashcard-ids)
     dashboard-cards))
 
+(defn- assert-no-invalid-dashboard-internal-dashcards [dashboard to-create]
+  (api/check-400 (seq
+                  (->> to-create
+                       (map :card)
+                       (keep :dashboard_id)
+                       (remove #(= % (u/the-id dashboard)))))))
+
 (defn- do-update-dashcards!
   [dashboard current-cards new-cards]
   (let [{:keys [to-create to-update to-delete]} (u/row-diff current-cards new-cards)]
+    (assert-no-invalid-dashboard-internal-dashcards dashboard to-create)
     (when (seq to-update)
       (update-dashcards! dashboard to-update))
     {:deleted-dashcards (when (seq to-delete)
@@ -779,6 +791,7 @@
           dash-updates                       (api/updates-with-archived-directly current-dash dash-updates)]
       (collection/check-allowed-to-change-collection current-dash dash-updates)
       (check-allowed-to-change-embedding current-dash dash-updates)
+
       (api/check-500
        (do
          (t2/with-transaction [_conn]
@@ -791,6 +804,10 @@
                                 :present #{:description :position :width :collection_id :collection_position :cache_ttl :archived_directly}
                                 :non-nil #{:name :parameters :caveats :points_of_interest :show_in_getting_started :enable_embedding
                                            :embedding_params :archived :auto_apply_filters}))]
+             (doseq [k [:archived :collection_id]]
+               (when-let [[_ new-val] (find updates k)]
+                 (card/with-allowed-changes-to-dashboard-internal-card
+                   (t2/update! :model/Card :dashboard_id id {k new-val}))))
              (t2/update! Dashboard id updates)
              (when (contains? updates :collection_id)
                (events/publish-event! :event/collection-touch {:collection-id id :user-id api/*current-user-id*}))

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -532,7 +532,7 @@
    If the search string contains a number like '123' we match that as a prefix against the card IDs.
    If the search string contains a number at the start AND text like '123-foo' we match do an exact match on card ID, and a substring match on the card name.
    If the search string does not start with a number, and is text like 'foo' we match that as a substring on the card name."
-  [database-id search-card-slug]
+  [database-id search-card-slug include-dashboard-questions?]
   (let [search-id   (re-find #"\d*" search-card-slug)
         search-name (-> (re-matches #"\d*-?(.*)" search-card-slug)
                         second
@@ -542,7 +542,8 @@
                {:where    [:and
                            [:= :report_card.database_id database-id]
                            [:= :report_card.archived false]
-                           [:= :report_card.dashboard_id nil]
+                           (when-not include-dashboard-questions?
+                             [:= :report_card.dashboard_id nil])
                            (cond
                              ;; e.g. search-string = "123"
                              (and (not-empty search-id) (empty? search-name))
@@ -666,12 +667,13 @@
   "Return a list of `Card` autocomplete suggestions for a given `query` in a given `Database`.
 
   This is intended for use with the ACE Editor when the User is typing in a template tag for a `Card`, e.g. {{#...}}."
-  [id query]
-  {id    ms/PositiveInt
-   query ms/NonBlankString}
+  [id query include_dashboard_questions]
+  {id                          ms/PositiveInt
+   query                       ms/NonBlankString
+   include_dashboard_questions ms/MaybeBooleanValue}
   (api/read-check Database id)
   (try
-    (->> (autocomplete-cards id query)
+    (->> (autocomplete-cards id query include_dashboard_questions)
          (filter mi/can-read?)
          (map #(select-keys % [:id :name :type :collection_name])))
     (catch Throwable e

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -542,6 +542,7 @@
                {:where    [:and
                            [:= :report_card.database_id database-id]
                            [:= :report_card.archived false]
+                           [:= :report_card.dashboard_id nil]
                            (cond
                              ;; e.g. search-string = "123"
                              (and (not-empty search-id) (empty? search-name))

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -80,7 +80,7 @@
   A search query that has both filters applied will only return models and cards."
   [q archived created_at created_by table_db_id models last_edited_at last_edited_by
    filter_items_in_personal_collection model_ancestors search_engine search_native_query
-   verified ids calculate_available_models]
+   verified ids calculate_available_models include_dashboard_questions]
   {q                                   [:maybe ms/NonBlankString]
    archived                            [:maybe :boolean]
    table_db_id                         [:maybe ms/PositiveInt]
@@ -95,7 +95,8 @@
    search_native_query                 [:maybe true?]
    verified                            [:maybe true?]
    ids                                 [:maybe (ms/QueryVectorOf ms/PositiveInt)]
-   calculate_available_models          [:maybe true?]}
+   calculate_available_models          [:maybe true?]
+   include_dashboard_questions         [:maybe :boolean]}
   (api/check-valid-page-params mw.offset-paging/*limit* mw.offset-paging/*offset*)
   (let  [models-set (if (seq models)
                       (set models)
@@ -121,6 +122,7 @@
        :table-db-id                         table_db_id
        :verified                            verified
        :ids                                 (set ids)
-       :calculate-available-models?         calculate_available_models}))))
+       :calculate-available-models?         calculate_available_models
+       :include-dashboard-questions?        include_dashboard_questions}))))
 
 (api/define-routes +engine-cookie)

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -912,6 +912,7 @@
     :table_id               (serdes/fk :model/Table)
     :source_card_id         (serdes/fk :model/Card)
     :collection_id          (serdes/fk :model/Collection)
+    :dashboard_id           (serdes/fk :model/Dashboard)
     :creator_id             (serdes/fk :model/User)
     :made_public_by_id      (serdes/fk :model/User)
     :dataset_query          {:export serdes/export-mbql :import serdes/import-mbql}
@@ -922,7 +923,8 @@
 
 (defmethod serdes/dependencies "Card"
   [{:keys [collection_id database_id dataset_query parameters parameter_mappings
-           result_metadata table_id source_card_id visualization_settings]}]
+           result_metadata table_id source_card_id visualization_settings
+           dashboard_id]}]
   (set
    (concat
     (mapcat serdes/mbql-deps parameter_mappings)
@@ -931,6 +933,7 @@
     (when table_id #{(serdes/table->path table_id)})
     (when source_card_id #{[{:model "Card" :id source_card_id}]})
     (when collection_id #{[{:model "Collection" :id collection_id}]})
+    (when dashboard_id #{[{:model "Dashboard" :id dashboard_id}]})
     (result-metadata-deps result_metadata)
     (serdes/mbql-deps dataset_query)
     (serdes/visualization-settings-deps visualization_settings))))

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -411,11 +411,16 @@
   `(binding [*updating-dashboard* true]
      ~@body))
 
+(defn- was-dashboard-question? [card changes]
+  (or (dashboard-internal-card? card)
+      (and (contains? changes :dashboard_id)
+           (not (:dashboard_id changes)))))
+
 (defn- is-valid-dashboard-internal-card-for-update [card changes]
-  (or (and (not (dashboard-internal-card? card))
+  (or (and (not (was-dashboard-question? card changes))
            (not (contains? changes :dashboard_id)))
       (and
-       (dashboard-internal-card? card)
+       (was-dashboard-question? card changes)
        (or *updating-dashboard* (not (contains? changes :collection_id)))
        (not (contains? changes :collection_position))
        (or (not (contains? changes :type))

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -422,7 +422,7 @@
 
 (defn- check-dashboard-internal-card-insert [card]
   (let [correct-collection-id (t2/select-one-fn :collection_id [:model/Dashboard :collection_id] (:dashboard_id card))
-        invalid? (or (and (contains? card :collection_id)
+        invalid? (or (and (:collection_id card)
                           (not= correct-collection-id (:collection_id card)))
                      (not (contains? #{:question "question" nil} (:type card)))
                      (some? (:collection_position card)))]
@@ -652,7 +652,7 @@
   ([{:keys [dataset_query result_metadata parameters parameter_mappings type] :as card-data} creator delay-event?]
    (let [data-keys                          [:dataset_query :description :display :name :visualization_settings
                                              :parameters :parameter_mappings :collection_id :collection_position
-                                             :cache_ttl :type]
+                                             :cache_ttl :type :dashboard_id]
          ;; `zipmap` instead of `select-keys` because we want to get `nil` values for keys that aren't present. Required
          ;; by `api/maybe-reconcile-collection-position!`
          card-data                          (-> (zipmap data-keys (map card-data data-keys))

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -406,9 +406,11 @@
 (def ^:dynamic ^:private *updating-dashboard-collection-id* false)
 
 (defn- is-valid-dashboard-internal-card-for-update [card changes]
-  (or (not (dashboard-internal-card? card))
+  (or (and (not (dashboard-internal-card? card))
+           (not (contains? changes :dashboard_id)))
       (and
        (or *updating-dashboard-collection-id* (not (contains? changes :collection_id)))
+       (not (contains? changes :archived))
        (not (contains? changes :collection_position))
        (or (not (contains? changes :type))
            (contains? #{:question "question" nil} (:type changes))))))

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -417,7 +417,6 @@
       (and
        (dashboard-internal-card? card)
        (or *updating-dashboard* (not (contains? changes :collection_id)))
-       (or *updating-dashboard* (not (contains? changes :archived)))
        (not (contains? changes :collection_position))
        (or (not (contains? changes :type))
            (contains? #{:question "question" nil} (:type changes))))))

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -36,7 +36,10 @@
 (t2/define-before-insert :model/DashboardCard
   [dashcard]
   (merge {:parameter_mappings     []
-          :visualization_settings {}} dashcard))
+          :visualization_settings {}}
+         ;; `dashboard_internal_card_id` is a generated column. Its only purpose is to provide a guarantee that a
+         ;; dashboard-internal Card may not have more than one `DashboardCard` link to a dashboard.
+         (dissoc dashcard :dashboard_internal_card_id)))
 
 (declare series)
 

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -37,9 +37,7 @@
   [dashcard]
   (merge {:parameter_mappings     []
           :visualization_settings {}}
-         ;; `dashboard_internal_card_id` is a generated column. Its only purpose is to provide a guarantee that a
-         ;; dashboard-internal Card may not have more than one `DashboardCard` link to a dashboard.
-         (dissoc dashcard :dashboard_internal_card_id)))
+         dashcard))
 
 (declare series)
 

--- a/src/metabase/models/revision/diff.clj
+++ b/src/metabase/models/revision/diff.clj
@@ -89,6 +89,16 @@
     [:result_metadata _ _]
     (deferred-tru "edited the metadata")
 
+    [:dashboard_id v1 v2]
+    (cond
+      (and v1 v2) (deferred-tru "moved from dashboard {0} to {1}"
+                                (t2/select-one-fn :name :model/Dashboard :id v1)
+                                (t2/select-one-fn :name :model/Dashboard :id v2))
+      (nil? v1) (deferred-tru "made this a dashboard-internal question in {0}"
+                              (t2/select-one-fn :name :model/Dashboard :id v2))
+      (nil? v2) (deferred-tru "extracted this question from {0}"
+                              (t2/select-one-fn :name :model/Dashboard :id v1)))
+
     [:width v1 v2]
     (if (and v1 v2)
       (deferred-tru "changed the width setting from {0} to {1}" (name v1) (name v2))

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -174,6 +174,8 @@
    :last_editor_id      :integer
    :moderated_status    :text
    :display             :text
+
+   :dashboard_id        :integer
    ;; returned for Metric and Segment
    :table_id            :integer
    :table_schema        :text
@@ -294,7 +296,7 @@
 
 (defmethod columns-for-model "card"
   [_]
-  (conj default-columns :collection_id :archived_directly :collection_position :dataset_query :display :creator_id
+  (conj default-columns :collection_id :archived_directly :collection_position :dataset_query :display :creator_id :dashboard_id
         [:collection.name :collection_name]
         [:collection.type :collection_type]
         [:collection.location :collection_location]

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -129,7 +129,8 @@
    [:table-db-id                         {:optional true} ms/PositiveInt]
    ;; true to search for verified items only, nil will return all items
    [:verified                            {:optional true} true?]
-   [:ids                                 {:optional true} [:set {:min 1} ms/PositiveInt]]])
+   [:ids                                 {:optional true} [:set {:min 1} ms/PositiveInt]]
+   [:include-dashboard-questions?        {:optional true} :boolean]])
 
 (def all-search-columns
   "All columns that will appear in the search results, and the types of those columns. The generated search query is a

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -254,7 +254,8 @@
    [:model-ancestors?                    {:optional true} [:maybe boolean?]]
    [:verified                            {:optional true} [:maybe true?]]
    [:ids                                 {:optional true} [:maybe [:set ms/PositiveInt]]]
-   [:calculate-available-models?         {:optional true} [:maybe :boolean]]])
+   [:calculate-available-models?         {:optional true} [:maybe :boolean]]
+   [:include-dashboard-questions?        {:optional true} [:maybe boolean?]]])
 
 (mu/defn search-context :- SearchContext
   "Create a new search context that you can pass to other functions like [[search]]."
@@ -266,6 +267,7 @@
            current-user-perms
            filter-items-in-personal-collection
            ids
+           include-dashboard-questions?
            is-superuser?
            last-edited-at
            last-edited-by
@@ -304,6 +306,7 @@
                  (some? offset)                              (assoc :offset-int offset)
                  (some? search-native-query)                 (assoc :search-native-query search-native-query)
                  (some? verified)                            (assoc :verified verified)
+                 (some? include-dashboard-questions?)        (assoc :include-dashboard-questions? include-dashboard-questions?)
                  (seq ids)                                   (assoc :ids ids))]
     (when (and (seq ids)
                (not= (count models) 1))

--- a/src/metabase/search/legacy.clj
+++ b/src/metabase/search/legacy.clj
@@ -234,6 +234,12 @@
                              [:and
                               [:= :bookmark.card_id :card.id]
                               [:= :bookmark.user_id (:current-user-id search-ctx)]])
+      (sql.helpers/where [:or
+                          [:= nil :card.dashboard_id]
+                          [:exists
+                           {:select 1
+                            :from [:report_dashboardcard]
+                            :where [:= :card_id :card.id]}]])
       (add-collection-join-and-where-clauses "card" search-ctx)
       (add-card-db-id-clause (:table-db-id search-ctx))
       (with-last-editing-info "card")

--- a/src/metabase/search/legacy.clj
+++ b/src/metabase/search/legacy.clj
@@ -236,10 +236,11 @@
                               [:= :bookmark.user_id (:current-user-id search-ctx)]])
       (sql.helpers/where [:or
                           [:= nil :card.dashboard_id]
-                          [:exists
-                           {:select 1
-                            :from [:report_dashboardcard]
-                            :where [:= :card_id :card.id]}]])
+                          (when (:include-dashboard-questions? search-ctx)
+                            [:exists
+                             {:select 1
+                              :from [:report_dashboardcard]
+                              :where [:= :card_id :card.id]}])])
       (add-collection-join-and-where-clauses "card" search-ctx)
       (add-card-db-id-clause (:table-db-id search-ctx))
       (with-last-editing-info "card")

--- a/src/metabase/search/legacy.clj
+++ b/src/metabase/search/legacy.clj
@@ -235,7 +235,11 @@
                               [:= :bookmark.card_id :card.id]
                               [:= :bookmark.user_id (:current-user-id search-ctx)]])
       (sql.helpers/where [:or
+                          ;; we'll *always* select non-dashboard questions
                           [:= nil :card.dashboard_id]
+                          ;; when we want dashboard questions too, we *only* include those that have a DashboardCard.
+                          ;; A DashboardQuestion without a DashboardCard should effectively not exist: it's invisible
+                          ;; from the collection picker or when browsing, so it shouldn't be visible in search either.
                           (when (:include-dashboard-questions? search-ctx)
                             [:exists
                              {:select 1

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -3933,6 +3933,9 @@
       (is (t2/select-one-fn :archived :model/Card card-id))
       (is (mt/user-http-request :crowberto :put 200 (str "card/" card-id) {:archived false}))
       (is (not (t2/select-one-fn :archived :model/Card card-id))))
+    (testing "we can update the name"
+      (is (mt/user-http-request :crowberto :put 200 (str "card/" card-id) {:name "foo"}))
+      (is (= "foo" (t2/select-one-fn :name :model/Card card-id))))
     (testing "We can't update with `dashboard_id` for a normal card."
       ;; we get a 200 because the param is ignored
       (is (mt/user-http-request :crowberto :put 200 (str "card/" other-card-id) {:dashboard_id dash-id}))

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -3906,12 +3906,10 @@
       (mt/user-http-request :crowberto :post 400 "card" (assoc (card-with-name-and-query)
                                                                :dashboard_id dash-id
                                                                :collection_id other-coll-id)))
-    (testing "Note the bug: if you provide `collection_id=null`, we'll accept it."
-      (let [{id :id} (mt/user-http-request :crowberto :post 200 "card" (assoc (card-with-name-and-query)
-                                                                              :dashboard_id dash-id
-                                                                              :collection_id nil))]
-        (testing "BUT we'll ignore it in favor of the dashboard's collection_id"
-          (is (= coll-id (t2/select-one-fn :collection_id :model/Card id))))))
+    (testing "... including `null` (the root collection id)"
+      (mt/user-http-request :crowberto :post 400 "card" (assoc (card-with-name-and-query)
+                                                               :dashboard_id dash-id
+                                                               :collection_id nil)))
     (testing "We can't create a dashboard internal card with a non-question `type`"
       (mt/user-http-request :crowberto :post 400 "card" (assoc (card-with-name-and-query)
                                                                :dashboard_id dash-id

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -3920,3 +3920,26 @@
       (mt/user-http-request :crowberto :post 400 "card" (assoc (card-with-name-and-query)
                                                                :dashboard_id dash-id
                                                                :collection_position 5)))))
+
+(deftest dashboard-internal-card-updates
+  (mt/with-temp [:model/Collection {coll-id :id} {}
+                 :model/Collection {other-coll-id :id} {}
+                 :model/Dashboard {dash-id :id} {:collection_id coll-id}
+                 :model/Dashboard {other-dash-id :id} {}
+                 :model/Card {card-id :id} {:dashboard_id dash-id}
+                 :model/Card {other-card-id :id} {}]
+    (testing "We can't update with `archived=true`"
+      (is (mt/user-http-request :crowberto :put 400 (str "card/" card-id) {:archived true})))
+    (testing "We can't update with `dashboard_id` for a normal card."
+      (testing "yes, it's 200"
+        (is (mt/user-http-request :crowberto :put 200 (str "card/" other-card-id) {:dashboard_id dash-id})))
+      (testing "but we ignore the parameter"
+        (is (nil? (t2/select-one-fn :dashboard_id :model/Card :id other-card-id)))))
+    (testing "We can update with a `dashboard_id`, moving the card to the new spot"
+      (is (mt/user-http-request :crowberto :put 200 (str "card/" card-id) {:dashboard_id other-dash-id}))
+      ;; TODO: this fails, the card isn't moved yet.
+      (is (nil? (t2/select-one-fn :collection_id :model/Card :id card-id))))
+    (testing "We can't update the `collection_id`"
+      (is (mt/user-http-request :crowberto :put 400 (str "card/" card-id) {:collection_id other-coll-id})))
+    (testing "We can't set the `type`"
+      (is (mt/user-http-request :crowberto :put 400 (str "card/" card-id) {:type "model"})))))

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -3928,15 +3928,18 @@
                  :model/Dashboard {other-dash-id :id} {}
                  :model/Card {card-id :id} {:dashboard_id dash-id}
                  :model/Card {other-card-id :id} {}]
-    (testing "We can't update with `archived=true`"
-      (is (mt/user-http-request :crowberto :put 400 (str "card/" card-id) {:archived true})))
+    (testing "We can update with `archived=true` or `archived=false`"
+      (is (mt/user-http-request :crowberto :put 200 (str "card/" card-id) {:archived true}))
+      (is (t2/select-one-fn :archived :model/Card card-id))
+      (is (mt/user-http-request :crowberto :put 200 (str "card/" card-id) {:archived false}))
+      (is (not (t2/select-one-fn :archived :model/Card card-id))))
     (testing "We can't update with `dashboard_id` for a normal card."
-      (is (mt/user-http-request :crowberto :put 400 (str "card/" other-card-id) {:dashboard_id dash-id}))
+      ;; we get a 200 because the param is ignored
+      (is (mt/user-http-request :crowberto :put 200 (str "card/" other-card-id) {:dashboard_id dash-id}))
       (is (not (= dash-id (t2/select-one-fn :dashboard_id :model/Card :id other-card-id)))))
-    (testing "We can update with a `dashboard_id`, moving the card to the new spot"
+    (testing "We CAN'T update a DQ with a `dashboard_id`"
       (is (mt/user-http-request :crowberto :put 200 (str "card/" card-id) {:dashboard_id other-dash-id}))
-      ;; the card is in a new location... but, it doesn't have any dashcards - so that's not great.
-      (is (nil? (t2/select-one-fn :collection_id :model/Card :id card-id))))
+      (is (= coll-id (t2/select-one-fn :collection_id :model/Card :id card-id))))
     (testing "We can't update the `collection_id`"
       (is (mt/user-http-request :crowberto :put 400 (str "card/" card-id) {:collection_id other-coll-id})))
     (testing "We can't set the `type`"

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -3894,3 +3894,29 @@
                                     (< 0 (second (reverse row))))
                                   (get-in result [:data :rows]))]
                (first totals)))))))
+
+(deftest dashboard-internal-card-creation
+  (mt/with-temp [:model/Collection {coll-id :id} {}
+                 :model/Collection {other-coll-id :id} {}
+                 :model/Dashboard {dash-id :id} {:collection_id coll-id}]
+    (testing "We can create a dashboard internal card"
+      (mt/user-http-request :crowberto :post 200 "card" (assoc (card-with-name-and-query)
+                                                               :dashboard_id dash-id)))
+    (testing "We can't create a dashboard internal card with a collection_id different that its dashboard's"
+      (mt/user-http-request :crowberto :post 400 "card" (assoc (card-with-name-and-query)
+                                                               :dashboard_id dash-id
+                                                               :collection_id other-coll-id)))
+    (testing "Note the bug: if you provide `collection_id=null`, we'll accept it."
+      (let [{id :id} (mt/user-http-request :crowberto :post 200 "card" (assoc (card-with-name-and-query)
+                                                                              :dashboard_id dash-id
+                                                                              :collection_id nil))]
+        (testing "BUT we'll ignore it in favor of the dashboard's collection_id"
+          (is (= coll-id (t2/select-one-fn :collection_id :model/Card id))))))
+    (testing "We can't create a dashboard internal card with a non-question `type`"
+      (mt/user-http-request :crowberto :post 400 "card" (assoc (card-with-name-and-query)
+                                                               :dashboard_id dash-id
+                                                               :type "model")))
+    (testing "We can't create a dashboard internal card with a non-null :collection_position"
+      (mt/user-http-request :crowberto :post 400 "card" (assoc (card-with-name-and-query)
+                                                               :dashboard_id dash-id
+                                                               :collection_position 5)))))

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -3931,13 +3931,11 @@
     (testing "We can't update with `archived=true`"
       (is (mt/user-http-request :crowberto :put 400 (str "card/" card-id) {:archived true})))
     (testing "We can't update with `dashboard_id` for a normal card."
-      (testing "yes, it's 200"
-        (is (mt/user-http-request :crowberto :put 200 (str "card/" other-card-id) {:dashboard_id dash-id})))
-      (testing "but we ignore the parameter"
-        (is (nil? (t2/select-one-fn :dashboard_id :model/Card :id other-card-id)))))
+      (is (mt/user-http-request :crowberto :put 400 (str "card/" other-card-id) {:dashboard_id dash-id}))
+      (is (not (= dash-id (t2/select-one-fn :dashboard_id :model/Card :id other-card-id)))))
     (testing "We can update with a `dashboard_id`, moving the card to the new spot"
       (is (mt/user-http-request :crowberto :put 200 (str "card/" card-id) {:dashboard_id other-dash-id}))
-      ;; TODO: this fails, the card isn't moved yet.
+      ;; the card is in a new location... but, it doesn't have any dashcards - so that's not great.
       (is (nil? (t2/select-one-fn :collection_id :model/Card :id card-id))))
     (testing "We can't update the `collection_id`"
       (is (mt/user-http-request :crowberto :put 400 (str "card/" card-id) {:collection_id other-coll-id})))

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -2304,3 +2304,20 @@
                                      :groups {}
                                      :skip_graph true}))
       "PUTs with skip_graph should not return the coll permission graph."))
+
+(deftest dashboard-internal-cards-do-not-appear-in-collection-items
+  (mt/with-temp [:model/Collection {coll-id :id} {}
+                 :model/Dashboard {dash-id :id} {:collection_id coll-id}
+                 :model/Card {normal-card-id :id} {:collection_id coll-id}
+                 :model/Card _ {:dashboard_id dash-id}]
+    (testing "The dashboard appears and the normal card appears, but the dashboard-internal card does not"
+      (is (= #{[normal-card-id "card"]
+               [dash-id "dashboard"]}
+             (set (map (juxt :id :model) (:data (mt/user-http-request :rasta :get 200 (str "collection/" coll-id "/items")))))))))
+  (mt/with-temp [:model/Collection {parent-id :id :as parent} {}
+                 :model/Collection {coll-id :id} {:location (collection/children-location parent)}
+                 :model/Dashboard {dash-id :id} {:collection_id coll-id}
+                 :model/Card _ {:dashboard_id dash-id}]
+    (testing "Here and below are correct (they don't say a collection has a card if it's internal)"
+      (is (= ["dashboard"]
+             (:here (first (:data (mt/user-http-request :rasta :get 200 (str "collection/" parent-id "/items"))))))))))

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -4880,15 +4880,15 @@
                  :model/Dashboard {_other-dash-id :id} {}
                  :model/Card {card-id :id} {:dashboard_id dash-id}
                  :model/DashboardCard {_dashcard-id :id} {:card_id card-id
-                                                         :dashboard_id dash-id}]
+                                                          :dashboard_id dash-id}]
     #_(testing "Cannot add a dashboard internal card to another dashboard"
-      (mt/user-http-request :crowberto :put 400 (str "dashboard/" other-dash-id)
-                            {:dashcards [{:id -1
-                                          :size_x 1
-                                          :size_y 1
-                                          :row 0 :col 0
-                                          :card_id card-id
-                                          :dashboard_id other-dash-id}]}))
+        (mt/user-http-request :crowberto :put 400 (str "dashboard/" other-dash-id)
+                              {:dashcards [{:id -1
+                                            :size_x 1
+                                            :size_y 1
+                                            :row 0 :col 0
+                                            :card_id card-id
+                                            :dashboard_id other-dash-id}]}))
     (testing "Should archive all dashboard internal cards with their dashboard"
       (is (mt/user-http-request :crowberto :put 200 (str "dashboard/" dash-id)
                                 {:archived true}))
@@ -4914,7 +4914,7 @@
                                             :dataset_query (mt/mbql-query orders)
                                             :database_id   (mt/id)}
                  :model/DashboardCard {_dashcard-id :id} {:card_id card-id
-                                                         :dashboard_id dash-id}]
+                                                          :dashboard_id dash-id}]
     (let [new-dash-id (:id (mt/user-http-request :crowberto :post 200 (str "dashboard/" dash-id "/copy")))
           new-card (:card (first (:dashcards (t2/hydrate (t2/select-one :model/Dashboard :id new-dash-id) [:dashcards :card]))))]
       (is (not= (:id new-card) card-id))

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -4876,11 +4876,11 @@
   ;; - another dashboard in the root collection
   (mt/with-temp [:model/Collection {coll-id :id} {}
                  :model/Dashboard {dash-id :id} {:collection_id coll-id}
-                 :model/Dashboard {_other-dash-id :id} {}
+                 :model/Dashboard {other-dash-id :id} {}
                  :model/Card {card-id :id} {:dashboard_id dash-id}
                  :model/DashboardCard {_dashcard-id :id} {:card_id card-id
                                                           :dashboard_id dash-id}]
-    #_(testing "Cannot add a dashboard internal card to another dashboard"
+    (testing "Cannot add a dashboard internal card to another dashboard"
         (mt/user-http-request :crowberto :put 400 (str "dashboard/" other-dash-id)
                               {:dashcards [{:id -1
                                             :size_x 1

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -2116,8 +2116,7 @@
                                                   :display                "table"
                                                   :visualization_settings {}}]
                     :created_at                 true
-                    :updated_at                 true
-                    :is_dashboard_internal_card false}]
+                    :updated_at                 true}]
                   (remove-ids-and-booleanize-timestamps dashboard-cards)))
           (is (= [{:size_x 4
                    :size_y 4
@@ -2234,8 +2233,7 @@
                 :parameter_mappings         []
                 :visualization_settings     {}
                 :created_at                 true
-                :updated_at                 true
-                :is_dashboard_internal_card false}
+                :updated_at                 true}
                (remove-ids-and-booleanize-timestamps (dashboard-card/retrieve-dashboard-card dashcard-id-1))))
         (is (= {:size_x                     4
                 :size_y                     4
@@ -2245,8 +2243,7 @@
                 :visualization_settings     {}
                 :series                     []
                 :created_at                 true
-                :updated_at                 true
-                :is_dashboard_internal_card false}
+                :updated_at                 true}
                (remove-ids-and-booleanize-timestamps (dashboard-card/retrieve-dashboard-card dashcard-id-2))))
         ;; TODO adds tests for return
         (mt/user-http-request :rasta :put 200 (format "dashboard/%d" dashboard-id)
@@ -2275,8 +2272,7 @@
                                               :dataset_query          {}
                                               :visualization_settings {}}]
                 :created_at                 true
-                :updated_at                 true
-                :is_dashboard_internal_card false}
+                :updated_at                 true}
                (remove-ids-and-booleanize-timestamps (dashboard-card/retrieve-dashboard-card dashcard-id-1))))
         (is (= {:size_x                     1
                 :size_y                     1
@@ -2286,8 +2282,7 @@
                 :visualization_settings     {}
                 :series                     []
                 :created_at                 true
-                :updated_at                 true
-                :is_dashboard_internal_card false}
+                :updated_at                 true}
                (remove-ids-and-booleanize-timestamps (dashboard-card/retrieve-dashboard-card dashcard-id-2))))))))
 
 (deftest update-cards-parameter-mapping-permissions-test

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -4928,3 +4928,17 @@
               new-card))
       (is (= new-dash-id
              (:dashboard_id new-card))))))
+
+(deftest dashboard-questions-are-archived-with-the-dashboard
+  (testing "It gets archived with the dashboard"
+    (mt/with-temp [:model/Dashboard {dash-id :id} {}
+                   :model/Card {card-id :id} {:dashboard_id dash-id}]
+      (mt/user-http-request :crowberto :put 200 (str "dashboard/" dash-id) {:archived "true"})
+      (is (t2/select-one-fn :archived :model/Card card-id))))
+  (testing "It gets archived with the dashboard if the dashboard is archived from a collection"
+    (mt/with-temp [:model/Collection {coll-id :id} {}
+                   :model/Dashboard {dash-id :id} {:collection_id coll-id}
+                   :model/Card {card-id :id} {:dashboard_id dash-id}]
+      (mt/user-http-request :crowberto :put 200 (str "collection/" coll-id) {:archived "true"})
+      (is (t2/select-one-fn :archived :model/Dashboard dash-id))
+      (is (t2/select-one-fn :archived :model/Card card-id)))))

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -10,7 +10,6 @@
    [medley.core :as m]
    [metabase.analytics.snowplow-test :as snowplow-test]
    [metabase.api.card-test :as api.card-test]
-   [metabase.api.common :as api]
    [metabase.api.dashboard :as api.dashboard]
    [metabase.api.pivots :as api.pivots]
    [metabase.config :as config]

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -4881,13 +4881,13 @@
                  :model/DashboardCard {_dashcard-id :id} {:card_id card-id
                                                           :dashboard_id dash-id}]
     (testing "Cannot add a dashboard internal card to another dashboard"
-        (mt/user-http-request :crowberto :put 400 (str "dashboard/" other-dash-id)
-                              {:dashcards [{:id -1
-                                            :size_x 1
-                                            :size_y 1
-                                            :row 0 :col 0
-                                            :card_id card-id
-                                            :dashboard_id other-dash-id}]}))
+      (mt/user-http-request :crowberto :put 400 (str "dashboard/" other-dash-id)
+                            {:dashcards [{:id -1
+                                          :size_x 1
+                                          :size_y 1
+                                          :row 0 :col 0
+                                          :card_id card-id
+                                          :dashboard_id other-dash-id}]}))
     (testing "Should archive all dashboard internal cards with their dashboard"
       (is (mt/user-http-request :crowberto :put 200 (str "dashboard/" dash-id)
                                 {:archived true}))

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -4862,3 +4862,56 @@
             ;; dashcards and parameters for each dashcard, linked to a single card. Following is the proof
             ;; of things working as described.
             (is (= 1 @call-count))))))))
+
+(deftest dashboard-internal-cards-test
+  ;; setup:
+  ;; - a collection, with a dashboard in it, with a dashboard-internal card in that dashboard
+  ;; - another dashboard in the root collection
+  (mt/with-temp [:model/Collection {coll-id :id} {}
+                 :model/Dashboard {dash-id :id} {:collection_id coll-id}
+                 :model/Dashboard {other-dash-id :id} {}
+                 :model/Card {card-id :id} {:dashboard_id dash-id}
+                 :model/DashboardCard {dashcard-id :id} {:card_id card-id
+                                                         :dashboard_id dash-id}]
+    (testing "Cannot add a dashboard internal card to another dashboard"
+      (mt/user-http-request :crowberto :put 400 (str "dashboard/" other-dash-id)
+                            {:dashcards [{:id -1
+                                          :size_x 1
+                                          :size_y 1
+                                          :row 0 :col 0
+                                          :card_id card-id
+                                          :dashboard_id other-dash-id}]}))
+    (testing "Should archive all dashboard internal cards with their dashboard"
+      (is (mt/user-http-request :crowberto :put 200 (str "dashboard/" dash-id)
+                                {:archived true}))
+      (is (t2/select-one-fn :archived :model/Card :id card-id))
+      (testing "And un-archive them with their dashboard, too"
+        (is (mt/user-http-request :crowberto :put 200 (str "dashboard/" dash-id)
+                                  {:archived false}))
+        (is (not (t2/select-one-fn :archived :model/Card :id card-id)))))
+    (testing "Should move dashboard internal cards to new collection along with their dashboard"
+      (is (mt/user-http-request :crowberto :put 200 (str "dashboard/" dash-id)
+                                {:collection_id nil}))
+      (is (nil? (t2/select-one-fn :collection_id :model/Card :id card-id))))
+    (testing "If the dashboard is deleted, its dashboard internal cards are too"
+      (t2/delete! :model/Dashboard :id dash-id)
+      (is (not (t2/exists? :model/Card :dashboard_id dash-id))))))
+
+(deftest dashboard-internal-cards-copying
+  (mt/with-temp [:model/Collection {coll-id :id} {}
+                 :model/Collection {other-coll-id :id} {}
+                 :model/Dashboard {dash-id :id} {:collection_id coll-id}
+                 :model/Card {card-id :id} {:dashboard_id dash-id
+                                            :table_id      (mt/id :orders)
+                                            :dataset_query (mt/mbql-query orders)
+                                            :database_id   (mt/id)}
+                 :model/DashboardCard {dashcard-id :id} {:card_id card-id
+                                                         :dashboard_id dash-id}]
+    (let [new-dash-id (:id (mt/user-http-request :crowberto :post 200 (str "dashboard/" dash-id "/copy")))
+          new-card (:card (first (:dashcards (t2/hydrate (t2/select-one :model/Dashboard :id new-dash-id) [:dashcards :card]))))]
+      (is (not= (:id new-card) card-id))
+      (is (=? (select-keys (t2/select-one :model/Card :id card-id)
+                           [:dataset_query :display :name :description])
+              new-card))
+      (is (= new-dash-id
+             (:dashboard_id new-card))))))

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -2219,6 +2219,13 @@
                (mt/user-http-request :rasta :get 200
                                      (format "database/%d/card_autocomplete_suggestions" (mt/id))
                                      :query "flozzlebarger"))))
+      (testing "dashboard cards can be included if you pass `include_dashboard_questions=true`"
+        (is (= 1
+               (count
+                (mt/user-http-request :rasta :get 200
+                                      (format "database/%d/card_autocomplete_suggestions" (mt/id))
+                                      :query "flozzlebarger"
+                                      :include_dashboard_questions "true")))))
       (testing "sanity check: removing the `dashboard_id` lets us get it"
         (t2/update! :model/Card :id card-id {:dashboard_id nil})
         (is (= 1

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -39,6 +39,7 @@
 
 (def ^:private default-search-row
   {:archived                   false
+   :dashboard_id               false
    :effective_location         nil
    :location                   nil
    :bookmark                   nil
@@ -1588,3 +1589,25 @@
                 (when (pos? attempts-left)
                   (Thread/sleep 200)
                   (recur (dec attempts-left))))))))))
+
+(deftest dashboard-id-is-returned-for-dashboard-internal-cards
+  (testing "Dashboard internal cards get a dashboard_id when searched"
+    (let [search-name (random-uuid)
+          named #(str search-name "-" %)]
+      (mt/with-temp [:model/Dashboard {dash-id :id} {:name (named "dashboard")}
+                     :model/Card {card-id :id} {:dashboard_id dash-id :name (named "dashboard card")}
+                     :model/Card {reg-card-id :id} {:name (named "regular card")}]
+        (testing "The card data includes the `dashboard_id`"
+          (is (= dash-id
+                 (->> (mt/user-http-request :crowberto :get 200 "/search" :q search-name)
+                      :data
+                      (filter #(= card-id (:id %)))
+                      first
+                      :dashboard_id))))
+        (testing "Regular cards don't have it"
+          (is (nil?
+               (->> (mt/user-http-request :crowberto :get 200 "/search" :q search-name)
+                    :data
+                    (filter #(= reg-card-id (:id %)))
+                    first
+                    :dashboard_id))))))))

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -1601,18 +1601,23 @@
                      :model/DashboardCard _ {:dashboard_id dash-id :card_id card-id}]
         (testing "The card data includes the `dashboard_id`"
           (is (= dash-id
-                 (->> (mt/user-http-request :crowberto :get 200 "/search" :q search-name)
+                 (->> (mt/user-http-request :crowberto :get 200 "/search" :q search-name :include_dashboard_questions "true")
                       :data
                       (filter #(= card-id (:id %)))
                       first
                       :dashboard_id))))
         (testing "Regular cards don't have it"
           (is (nil?
-               (->> (mt/user-http-request :crowberto :get 200 "/search" :q search-name)
+               (->> (mt/user-http-request :crowberto :get 200 "/search" :q search-name :include_dashboard_questions "true")
                     :data
                     (filter #(= reg-card-id (:id %)))
                     first
-                    :dashboard_id)))))))
+                    :dashboard_id))))
+        (testing "Dashboard questions are only returned if you pass `include_dashboard_questions=true`"
+          (is (= []
+                 (->> (mt/user-http-request :crowberto :get 200 "/search" :q search-name :include_dashboard_questions "false")
+                      :data
+                      (filter #(= card-id (:id %))))))))))
   (testing "Dashboard questions aren't searchable without a DashboardCard"
     (let [search-name (random-uuid)
           named #(str search-name "-" %)]
@@ -1621,5 +1626,5 @@
         (is (= {:total 0
                 :data []}
                (select-keys
-                (mt/user-http-request :crowberto :get 200 "/search" :q search-name)
+                (mt/user-http-request :crowberto :get 200 "/search" :q search-name :include_dashboard_questions "true")
                 [:total :data])))))))

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -792,6 +792,7 @@
 (deftest record-revision-and-description-completeness-test
   (t2.with-temp/with-temp
     [:model/Database   db   {:name "random db"}
+     :model/Dashboard  dashboard {:name "dashboard"}
      :model/Card       base-card {}
      :model/Card       card {:name                "A Card"
                              :description         "An important card"
@@ -822,6 +823,7 @@
                             (= col :table_id)          (mt/id :venues)
                             (= col :source_card_id)    (:id base-card)
                             (= col :database_id)       (:id db)
+                            (= col :dashboard_id)      (:id dashboard)
                             (= col :query_type)        :native
                             (= col :type)              "model"
                             (= col :dataset_query)     (mt/mbql-query users)
@@ -1037,3 +1039,63 @@
           (mt/with-test-user :crowberto
             (is (false? (mi/can-read? card)))
             (is (false? (mi/can-write? card)))))))))
+
+(deftest we-cannot-insert-invalid-dashboard-internal-cards
+  (mt/with-temp [:model/Collection {coll-id :id} {}
+                 :model/Collection {other-coll-id :id} {}
+                 :model/Dashboard {dash-id :id} {:collection_id coll-id}]
+    (mt/with-model-cleanup [:model/Card]
+      (testing "You can't insert a card with a collection_id different than its dashboard's collection_id"
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid dashboard-internal card"
+                              (t2/insert! :model/Card (assoc (t2.with-temp/with-temp-defaults :model/Card)
+                                                             :dashboard_id dash-id
+                                                             :collection_id other-coll-id))))
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid dashboard-internal card"
+                              (t2/insert! :model/Card (assoc (t2.with-temp/with-temp-defaults :model/Card)
+                                                             :dashboard_id dash-id
+                                                             :collection_id nil))))
+        (testing "But you can insert a card with the *same* collection_id"
+          (t2/insert! :model/Card (assoc (t2.with-temp/with-temp-defaults :model/Card)
+                                         :dashboard_id dash-id
+                                         :collection_id coll-id)))
+        (testing "... or no collection_id"
+          (t2/insert! :model/Card (assoc (t2.with-temp/with-temp-defaults :model/Card)
+                                         :dashboard_id dash-id))))
+      (testing "You can't insert a card with a type other than `:question` as a dashboard-internal card"
+        (testing "invalid"
+          (doseq [invalid-type (disj card/card-types :question)]
+            (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid dashboard-internal card"
+                                  (t2/insert! :model/Card (assoc (t2.with-temp/with-temp-defaults :model/Card)
+                                                                 :dashboard_id dash-id
+                                                                 :type invalid-type))))))
+        (testing "these are valid"
+          (doseq [valid-type [:question "question"]]
+            (is (t2/insert! :model/Card (assoc (t2.with-temp/with-temp-defaults :model/Card)
+                                               :dashboard_id dash-id
+                                               :type valid-type))))))
+      (testing "You can't insert a dashboard-internal card with a collection_position"
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid dashboard-internal card"
+                              (t2/insert! :model/Card (assoc (t2.with-temp/with-temp-defaults :model/Card)
+                                                             :dashboard_id dash-id
+                                                             :collection_position 5))))))))
+
+(deftest no-updating-dashboard-internal-cards-with-invalid-data
+  (mt/with-temp [:model/Collection {coll-id :id} {}
+                 :model/Collection {other-coll-id :id} {}
+                 :model/Dashboard {dash-id :id} {:collection_id coll-id}
+                 :model/Card {card-id :id} {:dashboard_id dash-id}]
+    (testing "Can't update the collection_id"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid dashboard-internal card"
+                            (t2/update! :model/Card card-id {:collection_id other-coll-id}))))
+    (testing "CAN 'update' the collection_id"
+      (is (t2/update! :model/Card card-id {:collection_id coll-id})))
+    (testing "Can't update the collection_position"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid dashboard-internal card"
+                            (t2/update! :model/Card card-id {:collection_position 5}))))
+    (testing "CAN 'update' the collection_position"
+      (is (t2/update! :model/Card card-id {:collection_position nil})))
+    (testing "Can't update the type"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid dashboard-internal card"
+                            (t2/update! :model/Card card-id {:type :model}))))
+    (testing "CAN 'update' the type"
+      (is (t2/update! :model/Card card-id {:type :question})))))

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -1050,10 +1050,10 @@
                               (t2/insert! :model/Card (assoc (t2.with-temp/with-temp-defaults :model/Card)
                                                              :dashboard_id dash-id
                                                              :collection_id other-coll-id))))
-        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid dashboard-internal card"
-                              (t2/insert! :model/Card (assoc (t2.with-temp/with-temp-defaults :model/Card)
-                                                             :dashboard_id dash-id
-                                                             :collection_id nil))))
+        (testing "unless it's `nil`... which is a bug, but probably acceptable"
+          (is (t2/insert! :model/Card (assoc (t2.with-temp/with-temp-defaults :model/Card)
+                                             :dashboard_id dash-id
+                                             :collection_id nil))))
         (testing "But you can insert a card with the *same* collection_id"
           (t2/insert! :model/Card (assoc (t2.with-temp/with-temp-defaults :model/Card)
                                          :dashboard_id dash-id

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -1050,10 +1050,11 @@
                               (t2/insert! :model/Card (assoc (t2.with-temp/with-temp-defaults :model/Card)
                                                              :dashboard_id dash-id
                                                              :collection_id other-coll-id))))
-        (testing "unless it's `nil`... which is a bug, but probably acceptable"
-          (is (t2/insert! :model/Card (assoc (t2.with-temp/with-temp-defaults :model/Card)
-                                             :dashboard_id dash-id
-                                             :collection_id nil))))
+        (testing "including if it's `nil`"
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid dashboard-internal card"
+                                (t2/insert! :model/Card (assoc (t2.with-temp/with-temp-defaults :model/Card)
+                                                               :dashboard_id dash-id
+                                                               :collection_id nil)))))
         (testing "But you can insert a card with the *same* collection_id"
           (t2/insert! :model/Card (assoc (t2.with-temp/with-temp-defaults :model/Card)
                                          :dashboard_id dash-id

--- a/test_resources/serialization_baseline/collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/cards/OMuZ0wHe2O5Z_59-cLmn4_series_question_a.yaml
+++ b/test_resources/serialization_baseline/collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/cards/OMuZ0wHe2O5Z_59-cLmn4_series_question_a.yaml
@@ -26,6 +26,7 @@ serdes/meta:
   label: series_question_a
   model: Card
 archived_directly: false
-metabase_version: v1.48.1-SNAPSHOT (53cf083)
+dashboard_id: null
+metabase_version: v1.1.33-SNAPSHOT (a859933)
 source_card_id: null
 type: question

--- a/test_resources/serialization_baseline/collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/cards/XsxiHuzwlGIFNq245HdZC_series_question_b.yaml
+++ b/test_resources/serialization_baseline/collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/cards/XsxiHuzwlGIFNq245HdZC_series_question_b.yaml
@@ -26,6 +26,7 @@ serdes/meta:
   label: series_question_b
   model: Card
 archived_directly: false
-metabase_version: v1.48.1-SNAPSHOT (53cf083)
+dashboard_id: null
+metabase_version: v1.1.33-SNAPSHOT (a859933)
 source_card_id: null
 type: question

--- a/test_resources/serialization_baseline/collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/cards/f1C68pznmrpN1F5xFDj6d_some_question.yaml
+++ b/test_resources/serialization_baseline/collections/M-Q4pcV0qkiyJ0kiSWECl_some_collection/cards/f1C68pznmrpN1F5xFDj6d_some_question.yaml
@@ -26,6 +26,7 @@ serdes/meta:
   label: some_question
   model: Card
 archived_directly: false
-metabase_version: v1.48.1-SNAPSHOT (53cf083)
+dashboard_id: null
+metabase_version: v1.1.33-SNAPSHOT (a859933)
 source_card_id: null
 type: question

--- a/test_resources/serialization_baseline/collections/cards/aqpA3mIKUnfzYUlwjuGwT_source_question.yaml
+++ b/test_resources/serialization_baseline/collections/cards/aqpA3mIKUnfzYUlwjuGwT_source_question.yaml
@@ -30,6 +30,7 @@ serdes/meta:
   label: source_question
   model: Card
 archived_directly: false
-metabase_version: v1.48.1-SNAPSHOT (53cf083)
+dashboard_id: null
+metabase_version: v1.1.33-SNAPSHOT (a859933)
 source_card_id: null
 type: model

--- a/test_resources/serialization_baseline/collections/cards/ze7O4-8qRFH1v2Ho2apT1_root_card.yaml
+++ b/test_resources/serialization_baseline/collections/cards/ze7O4-8qRFH1v2Ho2apT1_root_card.yaml
@@ -26,6 +26,7 @@ serdes/meta:
   label: root_card
   model: Card
 archived_directly: false
-metabase_version: v1.48.1-SNAPSHOT (53cf083)
+dashboard_id: null
+metabase_version: v1.1.33-SNAPSHOT (a859933)
 source_card_id: null
 type: question

--- a/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/cards/m98z04nYGCF5n7cvOTfbj_grandparent_card.yaml
+++ b/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/cards/m98z04nYGCF5n7cvOTfbj_grandparent_card.yaml
@@ -26,6 +26,7 @@ serdes/meta:
   label: grandparent_card
   model: Card
 archived_directly: false
-metabase_version: v1.48.1-SNAPSHOT (53cf083)
+dashboard_id: null
+metabase_version: v1.1.33-SNAPSHOT (a859933)
 source_card_id: null
 type: question

--- a/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/qPZhJMPNGkfd3sq8jWiZS_parent_collection/cards/IBZSKSt2-QOMviIaGcQE6_parent_card.yaml
+++ b/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/qPZhJMPNGkfd3sq8jWiZS_parent_collection/cards/IBZSKSt2-QOMviIaGcQE6_parent_card.yaml
@@ -26,6 +26,7 @@ serdes/meta:
   label: parent_card
   model: Card
 archived_directly: false
-metabase_version: v1.48.1-SNAPSHOT (53cf083)
+dashboard_id: null
+metabase_version: v1.1.33-SNAPSHOT (a859933)
 source_card_id: null
 type: question

--- a/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/qPZhJMPNGkfd3sq8jWiZS_parent_collection/fJVsXIDzzipSZsaro9Pvu_child_collection/cards/Ra0JVOCXKTxH5TPbwZm0x_child_card.yaml
+++ b/test_resources/serialization_baseline/collections/olgKH56lYOjakuobH4zPz_grandparent_collection/qPZhJMPNGkfd3sq8jWiZS_parent_collection/fJVsXIDzzipSZsaro9Pvu_child_collection/cards/Ra0JVOCXKTxH5TPbwZm0x_child_card.yaml
@@ -26,6 +26,7 @@ serdes/meta:
   label: child_card
   model: Card
 archived_directly: false
-metabase_version: v1.48.1-SNAPSHOT (53cf083)
+dashboard_id: null
+metabase_version: v1.1.33-SNAPSHOT (a859933)
 source_card_id: null
 type: question


### PR DESCRIPTION
- migrations to add `report_card.dashboard_id`, and an index/foreign key for it
- accept a `dashboard_id` parameter for `POST /api/card/`
- accept a `dashboard_id` parameter for `PUT /api/card/`
- return `dashboard_id` from the search API
- do not show dashboard questions without a DashboardCard in the search API
- do not show dashboard questions in the autocomplete API
- modifies `POST /api/dashboard/:id/copy` to always copy dashboard questions
- modifies `PUT /api/dashboard/:id` to automatically move dashboard questions along with the dashboard
- modifies the Search API to allow including (or not) dashboard questions

Product doc: https://www.notion.so/metabase/Enable-saving-questions-directly-to-dashboards-and-make-this-the-default-path-a84be6e0540241189b251401fb35ca91#f9bbd61d8bc442ab8eaf908c680394b4

Epic: https://github.com/metabase/metabase/issues/47326