### PR TITLE
Update milestone check workflow

### DIFF
--- a/.github/workflows/release-milestone-check.yml
+++ b/.github/workflows/release-milestone-check.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           SLACK_RELEASE_CHANNEL: ${{ vars.SLACK_RELEASE_CHANNEL }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+          GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
         with:
           script: | # js
             const {

--- a/release/src/milestones.ts
+++ b/release/src/milestones.ts
@@ -2,25 +2,25 @@ import fs from "fs";
 
 import _ from "underscore";
 
-import { nonUserFacingLabels } from "./constants";
+import { hiddenLabels, nonUserFacingLabels } from "./constants";
 import {
   findMilestone,
+  getIssueWithCache,
   getMilestoneIssues,
   getMilestones,
-  getIssueWithCache,
 } from "./github";
 import {
+  getBackportSourcePRNumber,
   getLinkedIssues,
   getPRsFromCommitMessage,
-  getBackportSourcePRNumber,
 } from "./linked-issues";
-import type { Issue, GithubProps, Milestone, Commit, ReleaseProps } from "./types";
+import type { Commit, GithubProps, Issue, Milestone, ReleaseProps } from "./types";
 import {
+  getLastReleaseTag,
   getMajorVersion,
   getVersionFromReleaseBranch,
-  versionSort,
   ignorePatches,
-  getLastReleaseTag,
+  versionSort,
 } from "./version-helpers";
 
 function isBackport(pullRequest: Issue) {
@@ -35,6 +35,7 @@ const isNotNull = <T>(value: T | null): value is T => value !== null;
 
 const excludedLabels = [
   ...nonUserFacingLabels,
+  ...hiddenLabels,
   '.Already Fixed',
 ];
 

--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -1,4 +1,4 @@
-import { compare as compareVersions, coerce } from "semver";
+import { coerce, compare as compareVersions } from "semver";
 
 import type { GithubProps, Tag } from "./types";
 
@@ -204,6 +204,11 @@ export function ignorePatches(version: string) {
   return version.split('.').length < 4;
 }
 
+export function isPatchVersion(version: string) {
+  // v0.50.20.1
+  return version.split('.').length === 4;
+}
+
 const normalizeVersionForSorting = (version: string) =>
   version.replace(/^(v?)(0|1)\./, '');
 
@@ -231,6 +236,7 @@ export function getLastReleaseFromTags(tags: Tag[]) {
   return tags
     .map(tag => tag.ref.replace('refs/tags/', ''))
     .filter(tag => !isRCVersion(tag)) // we want to ignore RC tags because release notes should be cumulative
+    .filter(v => !isPatchVersion(v)) // ignore patch versions since we don't release notes for them
     .sort(versionSort)
     .reverse()[0];
 }

--- a/release/src/version-helpers.unit.spec.ts
+++ b/release/src/version-helpers.unit.spec.ts
@@ -1,21 +1,21 @@
 import type { Tag } from "./types";
 import {
-  isValidVersionString,
-  getOSSVersion,
+  findNextPatchVersion,
+  getBuildRequirements,
   getEnterpriseVersion,
-  isEnterpriseVersion,
-  isRCVersion,
-  getVersionType,
+  getGenericVersion,
+  getLastReleaseFromTags,
+  getMilestoneName,
+  getNextVersions,
+  getOSSVersion,
   getReleaseBranch,
   getVersionFromReleaseBranch,
+  getVersionType,
+  isEnterpriseVersion,
   isLatestVersion,
-  getBuildRequirements,
-  getNextVersions,
-  getGenericVersion,
-  getMilestoneName,
-  findNextPatchVersion,
+  isRCVersion,
+  isValidVersionString,
   versionSort,
-  getLastReleaseFromTags,
 } from "./version-helpers";
 
 describe("version-helpers", () => {
@@ -482,7 +482,7 @@ describe("version-helpers", () => {
       expect(latest).toBe('v0.12.2');
     });
 
-    it('should return the latest release tag for patch versions', () => {
+    it('should not return the latest release tag for patch versions', () => {
       const latest = getLastReleaseFromTags([
         { ref: 'refs/tags/v0.12.0' },
         { ref: 'refs/tags/v0.11.2' },
@@ -492,7 +492,7 @@ describe("version-helpers", () => {
         { ref: 'refs/tags/v0.12.2.3' },
         { ref: 'refs/tags/v0.12.2.2' },
       ] as Tag[]);
-      expect(latest).toBe('v0.12.2.3');
+      expect(latest).toBe('v0.12.2');
     });
 
     it('should return the latest tag for major version', () => {


### PR DESCRIPTION
- use `GH_TOKEN` instead of `GITHUB_TOKEN` to hopefully fix CI permission error 🤞 
- update milestone check logic to ignore patch releases when determining when the "last" release was for the purpose of milestone correctness
- update milestone check logic to ignore documentation PRs
