### PR TITLE
Enable native pivot xlsx and Incrementally add rows to Native Pivot xlsx exports

### DIFF
--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -933,3 +933,10 @@ See [fonts](../configuring-metabase/fonts.md).")
   :visibility :internal
   :export?    true
   :type       :integer)
+
+(defsetting native-pivot-exports
+  (deferred-tru "Enable pivot tables in xlsx exports.")
+  :visibility :internal
+  :export?    true
+  :default    false
+  :type       :boolean)

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -934,8 +934,8 @@ See [fonts](../configuring-metabase/fonts.md).")
   :export?    true
   :type       :integer)
 
-(defsetting native-pivot-exports
-  (deferred-tru "Enable pivot tables in xlsx exports.")
+(defsetting native-pivot-exports-enabled-in-v50
+  (deferred-tru "Enable pivot tables in xlsx exports. This is a temporary env var that will be superceded in 51 by (#46995)")
   :visibility :internal
   :export?    true
   :default    false

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -934,7 +934,7 @@ See [fonts](../configuring-metabase/fonts.md).")
   :export?    true
   :type       :integer)
 
-(defsetting native-pivot-exports-enabled-in-v50
+(defsetting temp-native-pivot-exports
   (deferred-tru "Enable pivot tables in xlsx exports. This is a temporary env var that will be superceded in 51 by (#46995)")
   :visibility :internal
   :export?    true

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -564,15 +564,6 @@
         (assoc :aggregation-functions agg-fns)
         (assoc :pivot-grouping-key (qp.pivot.postprocess/pivot-grouping-key titles)))))
 
-(defn- remove-unused-rows!
-  "For the pivot workbook, remove the unused black rows from the initialization."
-  [^XSSFSheet sheet used-rows]
-  (let [total-rows (.getLastRowNum sheet)]
-    (doseq [row-index (range total-rows used-rows -1)]
-      (let [row (.getRow sheet ^Integer row-index)]
-        (when row
-          (.removeRow sheet row))))))
-
 (defn- init-native-pivot
   [{:keys [pivot-grouping-key] :as pivot-spec}
    {:keys [ordered-cols col-settings viz-settings]}]
@@ -693,7 +684,6 @@
           (if pivot-options
             (try
               (let [pivot-workbook @pivot-workbook]
-                (remove-unused-rows! (spreadsheet/select-sheet "data" pivot-workbook) (inc row_count))
                 (spreadsheet/save-workbook-into-stream! os pivot-workbook))
               (finally
                 (.dispose workbook)

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -629,7 +629,7 @@
     (reify qp.si/StreamingResultsWriter
       (begin! [_ {{:keys [ordered-cols format-rows? pivot-export-options]} :data}
                {col-settings ::mb.viz/column-settings :as viz-settings}]
-        (let [opts (when (and (public-settings/native-pivot-exports) pivot-export-options)
+        (let [opts (when (and (public-settings/native-pivot-exports-enabled-in-v50) pivot-export-options)
                      (pivot-opts->pivot-spec (merge {:pivot-cols []
                                                      :pivot-rows []}
                                                     pivot-export-options) ordered-cols))]

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -646,7 +646,7 @@
               (reset! pivot-grouping-key (:pivot-grouping-key opts)))
             (let [wb (init-workbook {:ordered-cols ordered-cols
                                      :col-settings col-settings
-                                     :format-rows? format-rows?})]
+                                     :format-rows? true})]
               (vreset! workbook-data wb)))
 
           (let [{:keys [workbook sheet]} @workbook-data

--- a/test/metabase/api/downloads_exports_test.clj
+++ b/test/metabase/api/downloads_exports_test.clj
@@ -18,7 +18,6 @@
    [metabase.public-settings :as public-settings]
    [metabase.pulse :as pulse]
    [metabase.query-processor.streaming.csv :as qp.csv]
-   [metabase.query-processor.streaming.xlsx :as qp.xlsx]
    [metabase.test :as mt])
   (:import
    (org.apache.poi.ss.usermodel DataFormatter)
@@ -432,7 +431,7 @@
                                                                [:avg [:field (mt/id :products :rating) {:base-type :type/Float}]]]
                                                 :breakout     [[:field (mt/id :products :category) {:base-type :type/Text}]
                                                                [:field (mt/id :products :created_at) {:base-type :type/DateTime :temporal-unit :month}]]}}}]
-        (mt/with-temporary-setting-values [public-settings/native-pivot-exports true]
+        (mt/with-temporary-setting-values [public-settings/native-pivot-exports-enabled-in-v50 true]
           (let [result (mt/user-http-request :crowberto :post 200 (format "card/%d/query/xlsx?format_rows=false" pivot-card-id))
                 pivot  (with-open [in (io/input-stream result)]
                          (->> (spreadsheet/load-workbook in)
@@ -457,7 +456,7 @@
                                                 :aggregation  [[:sum [:field (mt/id :products :price) {:base-type :type/Float}]]]
                                                 :breakout     [[:field (mt/id :products :category) {:base-type :type/Text}]
                                                                [:field (mt/id :products :created_at) {:base-type :type/DateTime :temporal-unit :month}]]}}}]
-        (mt/with-temporary-setting-values [public-settings/native-pivot-exports true]
+        (mt/with-temporary-setting-values [public-settings/native-pivot-exports-enabled-in-v50 true]
           (let [result       (mt/user-http-request :crowberto :post 200 (format "card/%d/query/xlsx?format_rows=false" pivot-card-id))
                 [pivot data] (with-open [in (io/input-stream result)]
                                (let [wb    (spreadsheet/load-workbook in)
@@ -491,7 +490,7 @@
                                                {:source-table (mt/id :products)
                                                 :aggregation  [[:sum [:field (mt/id :products :price) {:base-type :type/Float}]]]
                                                 :breakout     [[:field (mt/id :products :category) {:base-type :type/Text}]]}}}]
-        (mt/with-temporary-setting-values [public-settings/native-pivot-exports true]
+        (mt/with-temporary-setting-values [public-settings/native-pivot-exports-enabled-in-v50 true]
           (let [result       (mt/user-http-request :crowberto :post 200 (format "card/%d/query/xlsx?format_rows=false" pivot-card-id))
                 [pivot data] (with-open [in (io/input-stream result)]
                                (let [wb    (spreadsheet/load-workbook in)

--- a/test/metabase/api/downloads_exports_test.clj
+++ b/test/metabase/api/downloads_exports_test.clj
@@ -431,7 +431,7 @@
                                                                [:avg [:field (mt/id :products :rating) {:base-type :type/Float}]]]
                                                 :breakout     [[:field (mt/id :products :category) {:base-type :type/Text}]
                                                                [:field (mt/id :products :created_at) {:base-type :type/DateTime :temporal-unit :month}]]}}}]
-        (mt/with-temporary-setting-values [public-settings/native-pivot-exports-enabled-in-v50 true]
+        (mt/with-temporary-setting-values [public-settings/temp-native-pivot-exports true]
           (let [result (mt/user-http-request :crowberto :post 200 (format "card/%d/query/xlsx?format_rows=false" pivot-card-id))
                 pivot  (with-open [in (io/input-stream result)]
                          (->> (spreadsheet/load-workbook in)
@@ -456,7 +456,7 @@
                                                 :aggregation  [[:sum [:field (mt/id :products :price) {:base-type :type/Float}]]]
                                                 :breakout     [[:field (mt/id :products :category) {:base-type :type/Text}]
                                                                [:field (mt/id :products :created_at) {:base-type :type/DateTime :temporal-unit :month}]]}}}]
-        (mt/with-temporary-setting-values [public-settings/native-pivot-exports-enabled-in-v50 true]
+        (mt/with-temporary-setting-values [public-settings/temp-native-pivot-exports true]
           (let [result       (mt/user-http-request :crowberto :post 200 (format "card/%d/query/xlsx?format_rows=false" pivot-card-id))
                 [pivot data] (with-open [in (io/input-stream result)]
                                (let [wb    (spreadsheet/load-workbook in)
@@ -490,7 +490,7 @@
                                                {:source-table (mt/id :products)
                                                 :aggregation  [[:sum [:field (mt/id :products :price) {:base-type :type/Float}]]]
                                                 :breakout     [[:field (mt/id :products :category) {:base-type :type/Text}]]}}}]
-        (mt/with-temporary-setting-values [public-settings/native-pivot-exports-enabled-in-v50 true]
+        (mt/with-temporary-setting-values [public-settings/temp-native-pivot-exports true]
           (let [result       (mt/user-http-request :crowberto :post 200 (format "card/%d/query/xlsx?format_rows=false" pivot-card-id))
                 [pivot data] (with-open [in (io/input-stream result)]
                                (let [wb    (spreadsheet/load-workbook in)

--- a/test/metabase/api/downloads_exports_test.clj
+++ b/test/metabase/api/downloads_exports_test.clj
@@ -432,7 +432,7 @@
                                                                [:avg [:field (mt/id :products :rating) {:base-type :type/Float}]]]
                                                 :breakout     [[:field (mt/id :products :category) {:base-type :type/Text}]
                                                                [:field (mt/id :products :created_at) {:base-type :type/DateTime :temporal-unit :month}]]}}}]
-        (binding [qp.xlsx/*pivot-export-post-processing-enabled* true]
+        (mt/with-temporary-setting-values [public-settings/native-pivot-exports true]
           (let [result (mt/user-http-request :crowberto :post 200 (format "card/%d/query/xlsx?format_rows=false" pivot-card-id))
                 pivot  (with-open [in (io/input-stream result)]
                          (->> (spreadsheet/load-workbook in)
@@ -440,7 +440,7 @@
                               ((fn [s] (.getPivotTables ^XSSFSheet s)))))]
             (is (not (nil? pivot)))))))))
 
-(deftest ^:parallel zero-column-native-pivot-tables-test
+(deftest zero-column-native-pivot-tables-test
   (testing "Pivot tables with zero columns download correctly as xlsx."
     (mt/dataset test-data
       (mt/with-temp [:model/Card {pivot-card-id :id}
@@ -457,7 +457,7 @@
                                                 :aggregation  [[:sum [:field (mt/id :products :price) {:base-type :type/Float}]]]
                                                 :breakout     [[:field (mt/id :products :category) {:base-type :type/Text}]
                                                                [:field (mt/id :products :created_at) {:base-type :type/DateTime :temporal-unit :month}]]}}}]
-        (binding [qp.xlsx/*pivot-export-post-processing-enabled* true]
+        (mt/with-temporary-setting-values [public-settings/native-pivot-exports true]
           (let [result       (mt/user-http-request :crowberto :post 200 (format "card/%d/query/xlsx?format_rows=false" pivot-card-id))
                 [pivot data] (with-open [in (io/input-stream result)]
                                (let [wb    (spreadsheet/load-workbook in)
@@ -476,7 +476,7 @@
                     ["Doohickey" #inst "2016-09-01T00:00:00.000-00:00" 45.65]]
                    (take 6 data)))))))))
 
-(deftest ^:parallel zero-row-native-pivot-tables-test
+(deftest zero-row-native-pivot-tables-test
   (testing "Pivot tables with zero rows download correctly as xlsx."
     (mt/dataset test-data
       (mt/with-temp [:model/Card {pivot-card-id :id}
@@ -491,7 +491,7 @@
                                                {:source-table (mt/id :products)
                                                 :aggregation  [[:sum [:field (mt/id :products :price) {:base-type :type/Float}]]]
                                                 :breakout     [[:field (mt/id :products :category) {:base-type :type/Text}]]}}}]
-        (binding [qp.xlsx/*pivot-export-post-processing-enabled* true]
+        (mt/with-temporary-setting-values [public-settings/native-pivot-exports true]
           (let [result       (mt/user-http-request :crowberto :post 200 (format "card/%d/query/xlsx?format_rows=false" pivot-card-id))
                 [pivot data] (with-open [in (io/input-stream result)]
                                (let [wb    (spreadsheet/load-workbook in)

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -411,7 +411,7 @@
    (with-open [bos (ByteArrayOutputStream.)
                os  (BufferedOutputStream. bos)]
      (let [results-writer (qp.si/streaming-results-writer :xlsx os)]
-       (qp.si/begin! results-writer {:data {:ordered-cols ordered-cols}} viz-settings)
+       (qp.si/begin! results-writer {:data {:ordered-cols ordered-cols :format-rows? true}} viz-settings)
        (doall (map-indexed
                (fn [i row] (qp.si/write-row! results-writer row i ordered-cols viz-settings))
                rows))

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -411,7 +411,7 @@
    (with-open [bos (ByteArrayOutputStream.)
                os  (BufferedOutputStream. bos)]
      (let [results-writer (qp.si/streaming-results-writer :xlsx os)]
-       (qp.si/begin! results-writer {:data {:ordered-cols ordered-cols :format-rows? true}} viz-settings)
+       (qp.si/begin! results-writer {:data {:ordered-cols ordered-cols}} viz-settings)
        (doall (map-indexed
                (fn [i row] (qp.si/write-row! results-writer row i ordered-cols viz-settings))
                rows))


### PR DESCRIPTION
This PR adds a boolean env var `MB_TEMP_NATIVE_PIVOT_EXPORTS` which enables the 'native pivot' feature in Downloads of xlsx files.

Targeting the 50 branch only for now, as pivot export improvements are being added holistically in 51.
Relevant Slack thread discussing this:

https://metaboat.slack.com/archives/C01LQQ2UW03/p1724874779867859