### PR TITLE
[Notification] fix cyclic deps

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/advanced_config/api/pulse_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/api/pulse_test.clj
@@ -3,8 +3,11 @@
    [clojure.test :refer :all]
    [metabase.models :refer [Card]]
    [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
    [toucan2.tools.with-temp :as t2.with-temp]))
+
+(use-fixtures :once (fixtures/initialize :plugins))
 
 (deftest test-pulse-endpoint-should-respect-email-domain-allow-list-test
   (testing "POST /api/pulse/test"

--- a/src/metabase/channel/core.clj
+++ b/src/metabase/channel/core.clj
@@ -49,13 +49,10 @@
 ;;                                             Utils                                               ;;
 ;; ------------------------------------------------------------------------------------------------;;
 
-(defn- find-and-load-metabase-channels!
+(defn find-and-load-metabase-channels!
   "Load namespaces that start with `metabase.channel."
   []
   (doseq [ns-symb u/metabase-namespace-symbols
           :when   (.startsWith (name ns-symb) "metabase.channel.")]
     (log/info "Loading channel namespace:" (u/format-color :blue ns-symb))
     (classloader/require ns-symb)))
-
-(when-not *compile-files*
-  (find-and-load-metabase-channels!))

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -4,6 +4,7 @@
    [clojure.tools.trace :as trace]
    [java-time.api :as t]
    [metabase.analytics.prometheus :as prometheus]
+   [metabase.channel.core :as channel]
    [metabase.config :as config]
    [metabase.core.config-from-file :as config-from-file]
    [metabase.core.initialization-status :as init-status]
@@ -158,6 +159,8 @@
   (settings/migrate-encrypted-settings!)
   ;; start scheduler at end of init!
   (task/start-scheduler!)
+  ;; load the channels
+  (channel/find-and-load-metabase-channels!)
   (init-status/set-complete!)
   (let [start-time (.getStartTime (ManagementFactory/getRuntimeMXBean))
         duration   (- (System/currentTimeMillis) start-time)]

--- a/test/metabase/test/initialize/plugins.clj
+++ b/test/metabase/test/initialize/plugins.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.java.io :as io]
    [clojure.tools.reader.edn :as edn]
+   [metabase.channel.core :as channel]
    [metabase.plugins :as plugins]
    [metabase.plugins.initialize :as plugins.init]
    [metabase.test.data.env.impl :as tx.env.impl]
@@ -61,7 +62,8 @@
 
 (defn init! []
   (plugins/load-plugins!)
-  (load-plugin-manifests!))
+  (load-plugin-manifests!)
+  (channel/find-and-load-metabase-channels!))
 
 (defn init-test-drivers!
   "Explicitly initialize the given test `drivers` via plugin manifests. These manifests can live in test_modules (having


### PR DESCRIPTION
the feature branch be-check is failing due to cyclic deps: https://github.com/metabase/metabase/actions/runs/10578335391/job/29308268988
instead of loading channel namespaces preemptively, we load them when we start MB