### PR TITLE
Bigquery verify bignumeric fingerprint and bin

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -998,3 +998,29 @@
                   qp.compile/compile-with-inline-parameters
                   :query
                   pretty-sql-lines))))))
+
+(deftest fingerprint-and-bin-bigdecimal-test
+  (mt/test-driver
+    :bigquery-cloud-sdk
+    (mt/dataset
+      (mt/dataset-definition
+        "bigthings"
+        ["bigthings"
+         [{:field-name "bd" :base-type :type/Decimal}]
+         [[12345678901234567890.1234567890M]
+          [22345678901234567890.1234567890M]
+          [32345678901234567890.1234567890M]]])
+
+      ;; Must sync field values
+      (sync/sync-database! (mt/db))
+      (is (= "BIGNUMERIC"
+             (t2/select-one-fn :database_type :model/Field :id (mt/id :bigthings :bd))))
+      (is (= [[12000000000000000000M 1]
+              [21000000000000000000M 1]
+              [30000000000000000000M 1]]
+             (mt/rows
+               (mt/run-mbql-query bigthings
+                                  {:aggregation [[:count]]
+                                   :breakout [[:field %bigthings.bd
+                                               {:type :type/Decimal
+                                                :binning {:strategy "default"}}]]})))))))

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -1004,12 +1004,12 @@
     :bigquery-cloud-sdk
     (mt/dataset
       (mt/dataset-definition
-        "bigthings"
-        ["bigthings"
-         [{:field-name "bd" :base-type :type/Decimal}]
-         [[12345678901234567890.1234567890M]
-          [22345678901234567890.1234567890M]
-          [32345678901234567890.1234567890M]]])
+       "bigthings"
+       ["bigthings"
+        [{:field-name "bd" :base-type :type/Decimal}]
+        [[12345678901234567890.1234567890M]
+         [22345678901234567890.1234567890M]
+         [32345678901234567890.1234567890M]]])
 
       ;; Must sync field values
       (sync/sync-database! (mt/db))
@@ -1019,8 +1019,8 @@
               [21000000000000000000M 1]
               [30000000000000000000M 1]]
              (mt/rows
-               (mt/run-mbql-query bigthings
-                                  {:aggregation [[:count]]
-                                   :breakout [[:field %bigthings.bd
-                                               {:type :type/Decimal
-                                                :binning {:strategy "default"}}]]})))))))
+              (mt/run-mbql-query bigthings
+                {:aggregation [[:count]]
+                 :breakout [[:field %bigthings.bd
+                             {:type :type/Decimal
+                              :binning {:strategy "default"}}]]})))))))

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
@@ -125,7 +125,7 @@
                :type/Date           :DATE
                :type/DateTime       :DATETIME
                :type/DateTimeWithTZ :TIMESTAMP
-               :type/Decimal        :NUMERIC
+               :type/Decimal        :BIGNUMERIC
                :type/Dictionary     :RECORD
                :type/Float          :FLOAT
                :type/Integer        :INTEGER


### PR DESCRIPTION
Fixes #28573

Field values must be scanned.

In 45.3, these fields were not being fingerprinted properly. (tag `v1.45.3`) In a 45 point release that appears to have been fixed. (branch `release-x.45.x`) Confirmed fixed in master, adding test
