### PR TITLE
Metrics dot menu

### DIFF
--- a/e2e/test/scenarios/metrics/browse.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/browse.cy.spec.ts
@@ -269,14 +269,17 @@ describe("scenarios > browse > metrics", () => {
     });
 
     it("should be possible to navigate to the collection from the dot menu", () => {
-      createMetrics([ORDERS_SCALAR_METRIC]);
+      createMetrics([ORDERS_SCALAR_MODEL_METRIC]);
 
       cy.visit("/browse/metrics");
 
       metricsTable().findByLabelText("Metric options").click();
       popover().findByText("Open collection").should("be.visible").click();
 
-      cy.location("pathname").should("eq", "/collection/root");
+      cy.location("pathname").should(
+        "match",
+        new RegExp(`^/collection/${FIRST_COLLECTION_ID}`),
+      );
     });
 
     it("should be possible to trash a metric from the dot menu when the user has write access", () => {

--- a/e2e/test/scenarios/metrics/browse.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/browse.cy.spec.ts
@@ -292,6 +292,13 @@ describe("scenarios > browse > metrics", () => {
           "Metrics help you summarize and analyze your data effortlessly.",
         )
         .should("be.visible");
+
+      navigationSidebar().findByText("Trash").should("be.visible").click();
+      cy.button("Actions").click();
+      popover().findByText("Restore").should("be.visible").click();
+
+      navigationSidebar().findByText("Metrics").should("be.visible").click();
+      metricsTable().findByText(ORDERS_SCALAR_METRIC.name).should("be.visible");
     });
 
     it("should not be possible to trash a metric from the dot menu when the user does not have write access", () => {

--- a/e2e/test/scenarios/metrics/browse.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/browse.cy.spec.ts
@@ -301,14 +301,53 @@ describe("scenarios > browse > metrics", () => {
       metricsTable().findByText(ORDERS_SCALAR_METRIC.name).should("be.visible");
     });
 
-    it("should not be possible to trash a metric from the dot menu when the user does not have write access", () => {
-      createMetrics([ORDERS_SCALAR_METRIC]);
-      cy.signIn("readonly");
+    describe("when the user does not have write access", () => {
+      it("should not be possible to trash a metric from the dot menu when the user does not have write access", () => {
+        createMetrics([ORDERS_SCALAR_METRIC]);
+        cy.signIn("readonly");
 
-      cy.visit("/browse/metrics");
+        cy.visit("/browse/metrics");
 
-      metricsTable().findByLabelText("Metric options").click();
-      popover().findByText("Move to trash").should("not.exist");
+        metricsTable().findByLabelText("Metric options").click();
+        popover().findByText("Move to trash").should("not.exist");
+      });
+
+      it("should be possible to navigate to the collection from the dot menu", () => {
+        createMetrics([ORDERS_SCALAR_METRIC]);
+        cy.signIn("readonly");
+
+        cy.visit("/browse/metrics");
+
+        metricsTable().findByLabelText("Metric options").click();
+        popover().findByText("Open collection").should("be.visible").click();
+
+        cy.location("pathname").should("eq", "/collection/root");
+      });
+
+      it("should be possible to bookmark a metrics from the dot menu", () => {
+        createMetrics([ORDERS_SCALAR_METRIC]);
+        cy.signIn("readonly");
+
+        cy.visit("/browse/metrics");
+
+        shouldNotHaveBookmark(ORDERS_SCALAR_METRIC.name);
+
+        metricsTable().findByLabelText("Metric options").click();
+        popover().findByText("Bookmark").should("be.visible").click();
+
+        shouldHaveBookmark(ORDERS_SCALAR_METRIC.name);
+
+        metricsTable().findByLabelText("Metric options").click();
+        popover()
+          .findByText("Remove from bookmarks")
+          .should("be.visible")
+          .click();
+
+        shouldNotHaveBookmark(ORDERS_SCALAR_METRIC.name);
+
+        metricsTable().findByLabelText("Metric options").click();
+        popover().findByText("Bookmark").should("be.visible");
+      });
     });
   });
 });

--- a/e2e/test/scenarios/metrics/browse.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/browse.cy.spec.ts
@@ -9,6 +9,7 @@ import {
   createQuestion,
   main,
   navigationSidebar,
+  popover,
   restore,
 } from "e2e/support/helpers";
 
@@ -228,6 +229,62 @@ describe("scenarios > browse > metrics", () => {
       getMetricsTableItem(1).should("contain", "Metric A");
       getMetricsTableItem(2).should("contain", "Metric C");
       getMetricsTableItem(3).should("contain", "Metric D");
+    });
+  });
+
+  describe("dot menu", () => {
+    it("should be possible to bookmark a metrics from the dot menu", () => {
+      createMetrics([ORDERS_SCALAR_METRIC]);
+
+      cy.visit("/browse/metrics");
+
+      metricsTable().findByLabelText("Metric options").click();
+      popover().findByText("Bookmark").should("be.visible").click();
+
+      metricsTable().findByLabelText("Metric options").click();
+      popover()
+        .findByText("Remove from bookmarks")
+        .should("be.visible")
+        .click();
+
+      metricsTable().findByLabelText("Metric options").click();
+      popover().findByText("Bookmark").should("be.visible");
+    });
+
+    it("should be possible to navigate to the collection from the dot menu", () => {
+      createMetrics([ORDERS_SCALAR_METRIC]);
+
+      cy.visit("/browse/metrics");
+
+      metricsTable().findByLabelText("Metric options").click();
+      popover().findByText("Open collection").should("be.visible").click();
+
+      cy.location("pathname").should("eq", "/collection/root");
+    });
+
+    it("should be possible to trash a metric from the dot menu when the user has write access", () => {
+      createMetrics([ORDERS_SCALAR_METRIC]);
+
+      cy.visit("/browse/metrics");
+
+      metricsTable().findByLabelText("Metric options").click();
+      popover().findByText("Move to trash").should("be.visible").click();
+
+      main()
+        .findByText(
+          "Metrics help you summarize and analyze your data effortlessly.",
+        )
+        .should("be.visible");
+    });
+
+    it("should not be possible to trash a metric from the dot menu when the user does not have write access", () => {
+      createMetrics([ORDERS_SCALAR_METRIC]);
+      cy.signIn("readonly");
+
+      cy.visit("/browse/metrics");
+
+      metricsTable().findByLabelText("Metric options").click();
+      popover().findByText("Move to trash").should("not.exist");
     });
   });
 });

--- a/e2e/test/scenarios/metrics/browse.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/browse.cy.spec.ts
@@ -7,6 +7,7 @@ import {
   type StructuredQuestionDetails,
   assertIsEllipsified,
   createQuestion,
+  getSidebarSectionTitle,
   main,
   navigationSidebar,
   popover,
@@ -94,6 +95,16 @@ function findMetric(name: string) {
 
 function getMetricsTableItem(index: number) {
   return metricsTable().findAllByTestId("metric-name").eq(index);
+}
+
+function shouldHaveBookmark(name: string) {
+  getSidebarSectionTitle(/Bookmarks/).should("be.visible");
+  navigationSidebar().findByText(name).should("be.visible");
+}
+
+function shouldNotHaveBookmark(name: string) {
+  getSidebarSectionTitle(/Bookmarks/).should("not.exist");
+  navigationSidebar().findByText(name).should("not.exist");
 }
 
 const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
@@ -238,14 +249,20 @@ describe("scenarios > browse > metrics", () => {
 
       cy.visit("/browse/metrics");
 
+      shouldNotHaveBookmark(ORDERS_SCALAR_METRIC.name);
+
       metricsTable().findByLabelText("Metric options").click();
       popover().findByText("Bookmark").should("be.visible").click();
+
+      shouldHaveBookmark(ORDERS_SCALAR_METRIC.name);
 
       metricsTable().findByLabelText("Metric options").click();
       popover()
         .findByText("Remove from bookmarks")
         .should("be.visible")
         .click();
+
+      shouldNotHaveBookmark(ORDERS_SCALAR_METRIC.name);
 
       metricsTable().findByLabelText("Metric options").click();
       popover().findByText("Bookmark").should("be.visible");

--- a/frontend/src/metabase/api/bookmark.ts
+++ b/frontend/src/metabase/api/bookmark.ts
@@ -27,9 +27,10 @@ export const bookmarkApi = Api.injectEndpoints({
         method: "POST",
         url: `/api/bookmark/${type}/${id}`,
       }),
-      invalidatesTags: (bookmark, error) =>
+      invalidatesTags: (bookmark, error, { type, id }) =>
         invalidateTags(error, [
           listTag("bookmark"),
+          idTag(type, id),
           ...(bookmark ? [idTag("bookmark", bookmark.id)] : []),
         ]),
     }),
@@ -38,9 +39,10 @@ export const bookmarkApi = Api.injectEndpoints({
         method: "DELETE",
         url: `/api/bookmark/${type}/${id}`,
       }),
-      invalidatesTags: (bookmark, error) =>
+      invalidatesTags: (bookmark, error, { type, id }) =>
         invalidateTags(error, [
           listTag("bookmark"),
+          idTag(type, id),
           ...(bookmark ? [idTag("bookmark", bookmark.id)] : []),
         ]),
     }),

--- a/frontend/src/metabase/browse/components/BrowseTable.styled.tsx
+++ b/frontend/src/metabase/browse/components/BrowseTable.styled.tsx
@@ -36,6 +36,7 @@ export const Cell = styled.td<ResponsiveProps>`
   &:focus {
     outline: 2px solid var(--mb-color-focus);
 
+    button,
     a {
       outline: none;
     }

--- a/frontend/src/metabase/browse/components/MetricsTable.tsx
+++ b/frontend/src/metabase/browse/components/MetricsTable.tsx
@@ -22,6 +22,7 @@ import {
 import { Columns } from "metabase/components/ItemsTable/Columns";
 import type { ResponsiveProps } from "metabase/components/ItemsTable/utils";
 import { MarkdownPreview } from "metabase/core/components/MarkdownPreview";
+import Bookmarks from "metabase/entities/bookmarks";
 import Questions from "metabase/entities/questions";
 import { useDispatch } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
@@ -346,11 +347,13 @@ function MenuCell({ metric }: { metric?: MetricResult }) {
         key: "remove-bookmark",
         title: t`Remove from bookmarks`,
         icon: "bookmark",
-        action() {
-          deleteBookmark({
+        async action() {
+          await deleteBookmark({
             id: metric.id,
             type: "card",
           });
+
+          dispatch(Bookmarks.actions.invalidateLists());
         },
       });
     } else {
@@ -358,11 +361,12 @@ function MenuCell({ metric }: { metric?: MetricResult }) {
         key: "add-bookmark",
         title: c("Verb").t`Bookmark`,
         icon: "bookmark",
-        action() {
-          createBookmark({
+        async action() {
+          await createBookmark({
             id: metric.id,
             type: "card",
           });
+          dispatch(Bookmarks.actions.invalidateLists());
         },
       });
     }

--- a/frontend/src/metabase/browse/components/MetricsTable.tsx
+++ b/frontend/src/metabase/browse/components/MetricsTable.tsx
@@ -401,7 +401,12 @@ function MenuCell({ metric }: { metric?: MetricResult }) {
     <Cell onClick={stopPropagation} style={{ padding: 0 }}>
       <Menu position="bottom-end">
         <Menu.Target>
-          <Button size="xs" variant="subtle" px="sm">
+          <Button
+            size="xs"
+            variant="subtle"
+            px="sm"
+            aria-label={t`Metric options`}
+          >
             <Icon name="ellipsis" />
           </Button>
         </Menu.Target>

--- a/frontend/src/metabase/browse/components/MetricsTable.tsx
+++ b/frontend/src/metabase/browse/components/MetricsTable.tsx
@@ -78,6 +78,8 @@ const menuProps = {
   containerName: itemsTableContainerName,
 };
 
+const DOTMENU_WIDTH = 34;
+
 export function MetricsTable({
   skeleton = false,
   metrics = [],
@@ -107,7 +109,7 @@ export function MetricsTable({
         {/* <col> for Description column */}
         <TableColumn {...descriptionProps} width={`${descriptionWidth}%`} />
 
-        <TableColumn {...menuProps} width="36px" />
+        <TableColumn {...menuProps} width={DOTMENU_WIDTH} />
 
         <Columns.RightEdge.Col />
       </colgroup>
@@ -399,7 +401,7 @@ function MenuCell({ metric }: { metric?: MetricResult }) {
     <Cell onClick={stopPropagation} style={{ padding: 0 }}>
       <Menu position="bottom-end">
         <Menu.Target>
-          <Button size="sm" variant="subtle">
+          <Button size="xs" variant="subtle" px="sm">
             <Icon name="ellipsis" />
           </Button>
         </Menu.Target>


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/47322

### Description
Adds a "..." menu to the metrics items on the Browse Metrics page to show a context menu with the following items:

- bookmark
- move to trash
- open collection

### To test

1. Make sure you have at least on metric
2. Click metrics in the navigation sidebar
3. Make sure the metrics in the browse metrics page have a "..." menu and the menu items work as expected.
 