### PR TITLE
backported "Much better collection permission performance" (#47251)

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -6719,6 +6719,165 @@ databaseChangeLog:
             tableName: metabase_field
             constraintName: idx_unique_field
 
+  - changeSet:
+      id: v49.2024-08-21T08:33:06
+      author: johnswanson
+      comment: Add permissions.perm_value
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: permissions
+                columnName: perm_value
+      changes:
+        - addColumn:
+            columns:
+              - column:
+                  name: perm_value
+                  type: varchar(64)
+                  remarks: The value of the permission
+                  constraints:
+                    nullable: true
+            tableName: permissions
+
+  - changeSet:
+      id: v49.2024-08-21T08:33:07
+      author: johnswanson
+      comment: Add permissions.perm_type
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: permissions
+                columnName: perm_type
+      changes:
+        - addColumn:
+            columns:
+              - column:
+                  name: perm_type
+                  type: varchar(64)
+                  remarks: The type of the permission
+                  constraints:
+                    nullable: true
+            tableName: permissions
+
+  - changeSet:
+      id: v49.2024-08-21T08:33:08
+      author: johnswanson
+      comment: Add permissions.collection_id
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: permissions
+                columnName: collection_id
+      changes:
+        - addColumn:
+            tableName: permissions
+            columns:
+              - column:
+                  name: collection_id
+                  type: int
+                  remarks: The linked collection, if applicable
+                  constraints:
+                    nullable: true
+
+  # FK constraint is added separately because deleteCascade doesn't work in addColumn -- see #14321
+  - changeSet:
+      id: v49.2024-08-21T08:33:09
+      author: johnswanson
+      comment: Add `permissions.collection_id` foreign key constraint
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - foreignKeyConstraintExists:
+                - foreignKeyName: fk_permissions_ref_collection_id
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: permissions
+            baseColumnNames: collection_id
+            referencedTableName: collection
+            referencedColumnNames: id
+            constraintName: fk_permissions_ref_collection_id
+            onDelete: CASCADE
+
+  - changeSet:
+      id: v49.2024-08-21T08:33:10
+      author: johnswanson
+      comment: Populate `perm_value`, `perm_type`, and `collection_id` on permissions
+      rollback: # not needed.
+      changes:
+        - sqlFile:
+            dbms: postgresql
+            path: permissions/collection-access.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: mysql,mariadb
+            path: permissions/collection-access-mariadb.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: h2
+            path: permissions/collection-access-h2.sql
+            relativeToChangelogFile: true
+
+  - changeSet:
+      id: v49.2024-08-21T08:33:11
+      author: johnswanson
+      comment: Create index on `permissions.collection_id`
+      rollback: # deleted with the column
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - indexExists:
+                tableName: permissions
+                indexName: idx_permissions_collection_id
+      changes:
+        - createIndex:
+            tableName: permissions
+            columns:
+              - column:
+                  name: collection_id
+            indexName: idx_permissions_collection_id
+
+
+  - changeSet:
+      id: v49.2024-08-21T08:33:12
+      author: johnswanson
+      comment: Index on `permissions.perm_type`
+      rollback: # deleted with the column
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - indexExists:
+                tableName: permissions
+                indexName: idx_permissions_perm_type
+      changes:
+        - createIndex:
+            tableName: permissions
+            columns:
+              - column:
+                  name: perm_type
+            indexName: idx_permissions_perm_type
+
+  - changeSet:
+      id: v49.2024-08-21T08:33:13
+      author: johnswanson
+      comment: Index on `permissions.perm_value`
+      rollback: # deleted with the column
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - indexExists:
+                tableName: permissions
+                indexName: idx_permissions_perm_value
+      changes:
+        - createIndex:
+            tableName: permissions
+            columns:
+              - column:
+                  name: perm_value
+            indexName: idx_permissions_perm_value
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/permissions/collection-access-h2.sql
+++ b/resources/migrations/permissions/collection-access-h2.sql
@@ -1,0 +1,21 @@
+DELETE FROM permissions
+WHERE id IN (
+  SELECT p.id
+  FROM permissions p
+  LEFT OUTER JOIN collection c
+  ON p.object = '/collection/' || c.id || '/' OR p.object = '/collection/' || c.id || '/read/'
+  WHERE c.id IS NULL AND REGEXP_LIKE(p.object, '^/collection/\d+/(read/)?$')
+);
+
+UPDATE permissions p SET collection_id = (
+  SELECT id
+  FROM collection c
+  WHERE p.object = '/collection/' || c.id || '/'
+  OR p.object = '/collection/' || c.id || '/read/'
+),
+perm_value = CASE
+  WHEN object like '/collection/%/read/' THEN 'read'
+  ELSE 'read-and-write'
+END,
+perm_type = 'perms/collection-access'
+WHERE object LIKE '/collection/%';

--- a/resources/migrations/permissions/collection-access-mariadb.sql
+++ b/resources/migrations/permissions/collection-access-mariadb.sql
@@ -1,0 +1,23 @@
+DELETE p FROM permissions p
+LEFT OUTER JOIN collection c
+ON p.object = CONCAT('/collection/', c.id, '/') OR p.object = CONCAT('/collection/', c.id, '/read/')
+WHERE c.id IS NULL AND p.object REGEXP '^/collection/\\d+/(read/)?$';
+
+UPDATE permissions
+SET
+  -- extract the collection_id from the object path
+  collection_id = cast(substring_index(substring_index(object, '/', 3), '/', -1) as unsigned integer),
+
+
+  -- set the perm_type for matching permissions
+  perm_type = 'perms/collection-access',
+
+  -- set perm_value based on the presence of 'read/' in the object
+  perm_value = CASE
+    WHEN object LIKE '/collection/%/read/' THEN 'read'
+    WHEN object LIKE '/collection/%/' THEN 'read-and-write'
+    ELSE null
+  END
+WHERE
+  -- only update rows that match the collection pattern
+  object regexp '^/collection/[0-9]+/(read/)?$';

--- a/resources/migrations/permissions/collection-access.sql
+++ b/resources/migrations/permissions/collection-access.sql
@@ -1,0 +1,26 @@
+DELETE FROM permissions
+WHERE id IN (
+  SELECT p.id
+  FROM permissions p
+  LEFT OUTER JOIN collection c
+  ON p.object = '/collection/' || c.id || '/' OR p.object = '/collection/' || c.id || '/read/'
+  WHERE c.id IS NULL AND p.object ~ '^/collection/\d+/(read/)?$'
+);
+
+UPDATE permissions
+SET
+  -- extract the collection_id from the object path
+  collection_id = cast(substring(object from '/collection/(\d+)/') as integer),
+
+  -- set the perm_type for matching permissions
+  perm_type = 'perms/collection-access',
+
+  -- set perm_value based on the presence of 'read/' in the object
+  perm_value = CASE
+    WHEN object LIKE '/collection/%/read/' THEN 'read'
+    WHEN object LIKE '/collection/%/' THEN 'read-and-write'
+    ELSE null
+  END
+WHERE
+  -- only update rows that match the collection pattern
+  object ~ '^/collection/\d+/(read/)?$';

--- a/src/metabase/api/action.clj
+++ b/src/metabase/api/action.clj
@@ -70,10 +70,7 @@
                                      [:= :dataset true]
                                      [:= :archived false]
                                      ;; action permission keyed off of model permission
-                                     (collection/visible-collection-ids->honeysql-filter-clause
-                                      :collection_id
-                                      (collection/permissions-set->visible-collection-ids
-                                       @api/*current-user-permissions-set*))]}))]
+                                     (collection/visible-collection-filter-clause)]}))]
       (actions-for models))))
 
 (api/defendpoint GET "/public"

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -169,9 +169,7 @@
                                                   [:= :archived false]
                                                   [:= :dataset (= question-type :dataset)]
                                                   [:in :database_id ids-of-dbs-that-support-source-queries]
-                                                  (collection/visible-collection-ids->honeysql-filter-clause
-                                                   (collection/permissions-set->visible-collection-ids
-                                                    @api/*current-user-permissions-set*))]
+                                                  (collection/visible-collection-filter-clause)]
                                                  additional-constraints)
                                  :order-by [[:%lower.name :asc]]}))))
 

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -109,12 +109,8 @@
   so we can return its `:name`."
   [honeysql-query                                :- ms/Map
    collection-id-column                          :- keyword?
-   {:keys [current-user-perms
-           filter-items-in-personal-collection]} :- SearchContext]
-  (let [visible-collections      (collection/permissions-set->visible-collection-ids current-user-perms)
-        collection-filter-clause (collection/visible-collection-ids->honeysql-filter-clause
-                                  collection-id-column
-                                  visible-collections)]
+   {:keys [filter-items-in-personal-collection]} :- SearchContext]
+  (let [collection-filter-clause (collection/visible-collection-filter-clause collection-id-column)]
     (cond-> honeysql-query
       true
       (sql.helpers/where collection-filter-clause (perms/audit-namespace-clause :collection.namespace nil))

--- a/src/metabase/api/timeline.clj
+++ b/src/metabase/api/timeline.clj
@@ -46,8 +46,7 @@
         timelines (->> (t2/select Timeline
                          {:where    [:and
                                      [:= :archived archived?]
-                                     (collection/visible-collection-ids->honeysql-filter-clause
-                                      (collection/permissions-set->visible-collection-ids @api/*current-user-permissions-set*))]
+                                     (collection/visible-collection-filter-clause)]
                           :order-by [[:%lower.name :asc]]})
                        (map collection.root/hydrate-root-collection))]
     (cond->> (t2/hydrate timelines :creator [:collection :can_write])

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -298,9 +298,7 @@
 (defn- add-has-question-and-dashboard
   "True when the user has permissions for at least one un-archived question and one un-archived dashboard."
   [user]
-  (let [coll-ids-filter (collection/visible-collection-ids->honeysql-filter-clause
-                          :collection_id
-                          (collection/permissions-set->visible-collection-ids @api/*current-user-permissions-set*))
+  (let [coll-ids-filter (collection/visible-collection-filter-clause)
         perms-query {:where [:and
                              [:= :archived false]
                              coll-ids-filter]}]

--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -148,3 +148,7 @@
   "The user-id of the internal metabase user.
    This is needed in the OSS edition to filter out users for setup/has-user-setup."
    13371338)
+
+(def ^:dynamic *request-id*
+  "A unique identifier for the current request. This is bound by `metabase.server.middleware.request-id/wrap-request-id`."
+  nil)

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -10,6 +10,7 @@
    [metabase.api.common
     :as api
     :refer [*current-user-id* *current-user-permissions-set*]]
+   [metabase.config :refer [*request-id*]]
    [metabase.db.connection :as mdb.connection]
    [metabase.models.collection.root :as collection.root]
    [metabase.models.interface :as mi]
@@ -238,6 +239,175 @@
     (t2/select-one Collection :id new-parent-id)
     root-collection))
 
+(mu/defn children-location :- LocationPath
+  "Given a `collection` return a location path that should match the `:location` value of all the children of the
+  Collection.
+
+     (children-location collection) ; -> \"/10/20/30/\";
+
+     ;; To get children of this collection:
+     (t2/select Collection :location \"/10/20/30/\")"
+  [{:keys [location], :as collection} :- CollectionWithLocationAndIDOrRoot]
+  (if (collection.root/is-root-collection? collection)
+    "/"
+    (str location (u/the-id collection) "/")))
+
+(mu/defn descendant-ids :- [:maybe [:set ms/PositiveInt]]
+  "Return a set of IDs of all descendant Collections of a `collection`."
+  [collection :- CollectionWithLocationAndIDOrRoot]
+  (t2/select-pks-set Collection :location [:like (str (children-location collection) \%)]))
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                              Personal Collections                                              |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(mu/defn format-personal-collection-name :- ms/NonBlankString
+  "Constructs the personal collection name from user name.
+  When displaying to users we'll tranlsate it to user's locale,
+  but to keeps things consistent in the database, we'll store the name in site's locale.
+
+  Practically, use `user-or-site` = `:site` when insert or update the name in database,
+  and `:user` when we need the name for displaying purposes"
+  [first-name last-name email user-or-site]
+  {:pre [(#{:user :site} user-or-site)]}
+  (if (= :user user-or-site)
+    (cond
+      (and first-name last-name) (tru "{0} {1}''s Personal Collection" first-name last-name)
+      :else                      (tru "{0}''s Personal Collection" (or first-name last-name email)))
+    (cond
+      (and first-name last-name) (trs "{0} {1}''s Personal Collection" first-name last-name)
+      :else                      (trs "{0}''s Personal Collection" (or first-name last-name email)))))
+
+(mu/defn user->personal-collection-name :- ms/NonBlankString
+  "Come up with a nice name for the Personal Collection for `user-or-id`."
+  [user-or-id user-or-site]
+  (let [{first-name :first_name
+         last-name  :last_name
+         email      :email} (t2/select-one ['User :first_name :last_name :email]
+                                           :id (u/the-id user-or-id))]
+    (format-personal-collection-name first-name last-name email user-or-site)))
+
+(defn personal-collection-with-ui-details
+  "For Personal collection, we make sure the collection's name and slug is translated to user's locale
+  This is only used for displaying purposes, For insertion or updating  the name, use site's locale instead"
+  [{:keys [personal_owner_id] :as collection}]
+  (if-not personal_owner_id
+    collection
+    (let [collection-name (user->personal-collection-name personal_owner_id :user)]
+      (assoc collection
+             :name collection-name
+             :slug (u/slugify collection-name)))))
+
+(def ^:private CollectionWithLocationAndPersonalOwnerID
+  "Schema for a Collection instance that has a valid `:location`, and a `:personal_owner_id` key *present* (but not
+  neccesarily non-nil)."
+  [:map
+   [:location          LocationPath]
+   [:personal_owner_id [:maybe ms/PositiveInt]]])
+
+(mu/defn is-personal-collection-or-descendant-of-one? :- :boolean
+  "Is `collection` a Personal Collection, or a descendant of one?"
+  [collection :- CollectionWithLocationAndPersonalOwnerID]
+  (boolean
+   (or
+    ;; If collection has an owner ID we're already done here, we know it's a Personal Collection
+    (:personal_owner_id collection)
+
+    ;; Try to get the ID of its highest-level ancestor, e.g. if `location` is `/1/2/3/` we would get `1`. Then see if
+    ;; the root-level ancestor is a Personal Collection (Personal Collections can only exist in the Root Collection.)
+    (t2/exists? Collection
+                :id                (first (location-path->ids
+                                           (:location collection)))
+                :personal_owner_id [:not= nil]))))
+
+(mu/defn user->existing-personal-collection :- [:maybe (mi/InstanceOf Collection)]
+  "For a `user-or-id`, return their personal Collection, if it already exists.
+  Use [[metabase.models.collection/user->personal-collection]] to fetch their personal Collection *and* create it if
+  needed."
+  [user-or-id]
+  (t2/select-one Collection :personal_owner_id (u/the-id user-or-id)))
+
+(mu/defn user->personal-collection :- (mi/InstanceOf Collection)
+  "Return the Personal Collection for `user-or-id`, if it already exists; if not, create it and return it."
+  [user-or-id]
+  (or (user->existing-personal-collection user-or-id)
+      (try
+        (first (t2/insert-returning-instances! Collection
+                                               {:name              (user->personal-collection-name user-or-id :site)
+                                                :personal_owner_id (u/the-id user-or-id)}))
+        ;; if an Exception was thrown why trying to create the Personal Collection, we can assume it was a race
+        ;; condition where some other thread created it in the meantime; try one last time to fetch it
+        (catch Throwable e
+          (or (user->existing-personal-collection user-or-id)
+              (throw e))))))
+
+(def ^:private ^{:arglists '([user-id])} user->personal-collection-id
+  "Cached function to fetch the ID of the Personal Collection belonging to User with `user-id`. Since a Personal
+  Collection cannot be deleted, the ID will not change; thus it is safe to cache, saving a DB call. It is also
+  required to caclulate the Current User's permissions set, which is done for every API call; thus it is cached to
+  save a DB call for *every* API call."
+  (memoize/ttl
+   ^{::memoize/args-fn (fn [[user-id]]
+                         [(mdb.connection/unique-identifier) user-id])}
+   (fn user->personal-collection-id*
+     [user-id]
+     (u/the-id (user->personal-collection user-id)))
+   ;; cache the results for 60 minutes; TTL is here only to eventually clear out old entries/keep it from growing too
+   ;; large
+   :ttl/threshold (* 60 60 1000)))
+
+(mu/defn user->personal-collection-and-descendant-ids :- [:sequential {:min 1} ms/PositiveInt]
+  "Somewhat-optimized function that fetches the ID of a User's Personal Collection as well as the IDs of all descendants
+  of that Collection. Exists because this needs to be known to calculate the Current User's permissions set, which is
+  done for every API call; this function is an attempt to make fetching this information as efficient as reasonably
+  possible."
+  [user-or-id]
+  (let [personal-collection-id (user->personal-collection-id (u/the-id user-or-id))]
+    (cons personal-collection-id
+          ;; `descendant-ids` wants a CollectionWithLocationAndID, and luckily we know Personal Collections always go
+          ;; in Root, so we can pass it what it needs without actually having to fetch an entire CollectionInstance
+          (descendant-ids {:location "/", :id personal-collection-id}))))
+
+(mi/define-batched-hydration-method include-personal-collection-ids
+  :personal_collection_id
+  "Efficiently hydrate the `:personal_collection_id` property of a sequence of Users. (This is, predictably, the ID of
+  their Personal Collection.)"
+  [users]
+  (when (seq users)
+    ;; efficiently create a map of user ID -> personal collection ID
+    (let [user-id->collection-id (t2/select-fn->pk :personal_owner_id Collection
+                                                   :personal_owner_id [:in (set (map u/the-id users))])]
+      (assert (map? user-id->collection-id))
+      ;; now for each User, try to find the corresponding ID out of that map. If it's not present (the personal
+      ;; Collection hasn't been created yet), then instead call `user->personal-collection-id`, which will create it
+      ;; as a side-effect. This will ensure this property never comes back as `nil`
+      (for [user users]
+        (assoc user :personal_collection_id (or (user-id->collection-id (u/the-id user))
+                                                (user->personal-collection-id (u/the-id user))))))))
+
+(mi/define-batched-hydration-method collection-is-personal
+  :is_personal
+  "Efficiently hydrate the `:is_personal` property of a sequence of Collections.
+  `true` means the collection is or nested in a personal collection."
+  [collections]
+  (if (= 1 (count collections))
+    (let [collection (first collections)]
+      (if (some? collection)
+        [(assoc collection :is_personal (is-personal-collection-or-descendant-of-one? collection))]
+        ;; root collection is nil
+        [collection]))
+    (let [personal-collection-ids (t2/select-pks-set :model/collection :personal_owner_id [:not= nil])
+          location-is-personal    (fn [location]
+                                    (boolean
+                                     (and (string? location)
+                                          (some #(str/starts-with? location (format "/%d/" %)) personal-collection-ids))))]
+      (map (fn [{:keys [location personal_owner_id] :as coll}]
+             (if (some? coll)
+               (assoc coll :is_personal (or (some? personal_owner_id)
+                                            (location-is-personal location)))
+               nil))
+           collections))))
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                 Nested Collections: "Effective" Location Paths                                 |
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -250,118 +420,173 @@
 ;; breadcrumbing in the frontend.
 
 (def ^:private VisibleCollections
-  "Includes the possible values for visible collections, either `:all` or a set of ids, possibly including `\"root\"` to
-  represent the root collection."
-  [:or
-   [:= :all]
-   [:set
-    [:or [:= "root"] ms/PositiveInt]]])
+  "Includes the possible values for visible collections, possibly including `\"root\"` to represent the root
+  collection."
+  [:set
+   [:or [:= "root"] ms/PositiveInt]])
 
-(mu/defn permissions-set->visible-collection-ids :- VisibleCollections
-  "Given a `permissions-set` (presumably those of the current user), return a set of IDs of Collections that the
-  permissions set allows you to view. For those with *root* permissions (e.g., an admin), this function will return
-  `:all`, signifying that you are allowed to view all Collections. For *Root Collection* permissions, the response
-  will include \"root\".
+(def ^:private CollectionVisibilityConfig
+  [:map
+   [:include-archived-items {:optional true} [:enum :only :exclude :all]]
+   [:permission-level {:optional true} [:enum :read :write]]
+   [:effective-child-of {:optional true} [:maybe CollectionWithLocationAndIDOrRoot]]])
 
-    (permissions-set->visible-collection-ids #{\"/collection/10/\"})   ; -> #{10}
-    (permissions-set->visible-collection-ids #{\"/\"})                 ; -> :all
-    (permissions-set->visible-collection-ids #{\"/collection/root/\"}) ; -> #{\"root\"}
+(def ^:private default-visibility-config
+  {:include-archived-items :all
+   :effective-child-of nil
+   :permission-level :read})
 
-  You probably don't want to consume the results of this function directly -- most of the time, the reason you are
-  calling this function in the first place is because you want add a `FILTER` clause to an application DB query (e.g.
-  to only fetch Cards that belong to Collections visible to the current User). Use
-  [[visible-collection-ids->honeysql-filter-clause]] to generate a filter clause that handles all possible outputs of
-  this function correctly.
+(def ^:private ^{:arglists '([read-or-write])} can-access-root-collection?
+  "Cached function to determine whether the current user can access the root collection"
+  (memoize/ttl
+   ^{::memoize/args-fn (fn [[read-or-write]]
+                         ;; If this is running in the context of a request, cache it for the duration of that request.
+                         ;; Otherwise, don't cache the results at all.)
+                         (if-let [req-id *request-id*]
+                           [req-id api/*current-user-id* read-or-write]
+                           [(random-uuid) api/*current-user-id* read-or-write]))}
+   (fn can-access-root-collection?*
+     [read-or-write]
+     (or api/*is-superuser?*
+         (t2/exists? :model/Permissions {:select [:p.*]
+                                         :from [[:permissions :p]]
+                                         :join [[:permissions_group :pg] [:= :pg.id :p.group_id]
+                                                [:permissions_group_membership :pgm] [:= :pgm.group_id :pg.id]]
+                                         :where [:and
+                                                 [:= :pgm.user_id api/*current-user-id*]
+                                                 [:or
+                                                  [:= :p.object "/collection/root/"]
+                                                  (when (= :read read-or-write)
+                                                    [:= :p.object "/collection/root/read/"])]]})))
+   ;; cache the results for 10 seconds. This is a bit arbitrary but should be long enough to cover ~all requests.
+   :ttl/threshold (* 10 1000)))
 
-  !!! IMPORTANT NOTE !!!
+(defn- should-display-root-collection?
+  "Should this user be shown the root collection, given the `visibility-config` passed?"
+  [visibility-config]
+  (and
+   ;; we have permission for it.
+   (can-access-root-collection? (:permission-level visibility-config))
 
-  Because the result may include `nil` for the Root Collection, or may be `:all`, MAKE SURE YOU HANDLE THOSE
-  SITUATIONS CORRECTLY before using these IDs to make a DB call. Better yet, use
-  [[visible-collection-ids->honeysql-filter-clause]] to generate appropriate HoneySQL."
-  [permissions-set]
-  (if (contains? permissions-set "/")
-    :all
-    (set
-     (for [path  permissions-set
-           :let  [[_ id-str] (re-matches #"/collection/((?:\d+)|root)/(read/)?" path)]
-           :when id-str]
-       (cond-> id-str
-         (not= id-str "root") Integer/parseInt)))))
+   ;; we're not *only* looking for archived items
+   (not= :only (:include-archived-items visibility-config))
 
-(mu/defn visible-collection-ids->honeysql-filter-clause
-  "Generate an appropriate HoneySQL `:where` clause to filter something by visible Collection IDs, such as the ones
-  returned by `permissions-set->visible-collection-ids`. Correctly handles all possible values returned by that
-  function, including `:all` and `nil` Collection IDs (for the Root Collection).
+   ;; we're not looking for the children of a collection (root definitely isn't a child!)
+   (not (:effective-child-of visibility-config))))
 
-  Guaranteed to always generate a valid HoneySQL form, so this can be used directly in a query without further checks.
+(mu/defn visible-collection-filter-clause
+  "Given a `CollectionVisibilityConfig`, return a honeysql filter clause ready for use in queries."
+  ([]
+   (visible-collection-filter-clause :collection_id))
+  ([collection-id-field :- [:or [:tuple [:= :coalesce] :keyword :keyword] :keyword]]
+   (visible-collection-filter-clause collection-id-field {}))
+  ([collection-id-field :- [:or [:tuple [:= :coalesce] :keyword :keyword] :keyword]
+    visibility-config :- CollectionVisibilityConfig]
+   (let [visibility-config (merge default-visibility-config visibility-config)]
+     ;; This giant query looks scary, but it's actually only moderately terrifying! Let's walk through it step by
+     ;; step. What we're doing here is adding a filter clause to a surrounding query, to make sure that
+     ;; `collection-id-field` matches the criteria passed by the user. The criteria we use are:
+     ;;
+     ;; - your permissions (we don't show you something you don't have the right to see)
+     ;; - the desired permission level you need (if you're looking for stuff you can WRITE, we don't show you stuff you can READ)
+     ;; - archived (you can show/hide archived collections or select *only* archived collections)
+     ;; - effective child (if you're only interested in things that are an effective child of another collection, we can do that)
+     ;;
+     ;; So first, we check to see if we should include the root collection. That decision is outsourced to
+     ;; `should-display-root-collection?` but it's pretty simple. We can't include the root collection along with the
+     ;; rest because it's not a Real collection.
+     [:or
+      (when (should-display-root-collection? visibility-config)
+        [:= collection-id-field nil])
+      ;; the non-root collections are here. We're saying "let this row through if..."
+      [:in collection-id-field
+       {:select :id
+        ;; the `FROM` clause is where we limit the collections to the ones we have permissions on. For a superuser,
+        ;; that's all of them. For regular users, it's a) the collections they have permission in the DB for, and b)
+        ;; their personal collection and its descendants.
+        :from [[{:union-all (if api/*is-superuser?*
+                              [{:select [:c.*]
+                                :from [[:collection :c]]}]
+                              [{:select [:c.*]
+                                :from [[:collection :c]]
+                                :join [[:permissions :p]
+                                       [:= :c.id :p.collection_id]
+                                       [:permissions_group :pg] [:= :pg.id :p.group_id]
+                                       [:permissions_group_membership :pgm] [:= :pgm.group_id :pg.id]]
+                                :where [:and
+                                        [:= :pgm.user_id api/*current-user-id*]
+                                        [:= :p.perm_type "perms/collection-access"]
+                                        [:or
+                                         [:= :p.perm_value "read-and-write"]
+                                         (when (= :read (:permission-level visibility-config))
+                                           [:= :p.perm_value "read"])]]}
+                               (when-let [personal-collection-and-descendant-ids (user->personal-collection-and-descendant-ids api/*current-user-id*)]
+                                 {:select [:c.*]
+                                  :from [[:collection :c]]
+                                  :where [:in :id personal-collection-and-descendant-ids]})])}
+                :c]]
+        ;; The `WHERE` clause is where we apply the other criteria we were given:
+        :where [:and
+                ;; hiding archived items when desired...
+                (when (= :exclude (:include-archived-items visibility-config))
+                  [:= :archived false])
 
-    (t2/select Card
-      {:where (collection/visible-collection-ids->honeysql-filter-clause
-               (collection/permissions-set->visible-collection-ids
-                @*current-user-permissions-set*))})"
-  ([collection-ids :- VisibleCollections]
-   (visible-collection-ids->honeysql-filter-clause :collection_id collection-ids))
+                ;; (or showing them, if that's what you want)
+                (when (= :only (:include-archived-items visibility-config))
+                  [:= :archived true])
 
-  ([collection-id-field :- :keyword
-    collection-ids      :- VisibleCollections]
-   (if (= collection-ids :all)
-     true
-     (let [{non-root-ids false, root-id true} (group-by (partial = "root") collection-ids)
-           non-root-clause                    (when (seq non-root-ids)
-                                                [:in collection-id-field non-root-ids])
-           root-clause                        (when (seq root-id)
-                                                [:= collection-id-field nil])]
-       (cond
-         (and root-clause non-root-clause)
-         [:or root-clause non-root-clause]
+                ;; or finally, restricting the result set to effective children of the parent you passed in.
+                (when-let [parent-coll (:effective-child-of visibility-config)]
+                  [:and
+                   ;; an effective child is a descendant of the parent collection
+                   [:like :location (str (children-location parent-coll) "%")]
+                   ;; but NOT a child of any OTHER visible collection.
+                   [:not [:exists {:select 1
+                                   :from [[:collection :c2]]
+                                   :where [:and
+                                           (visible-collection-filter-clause :c2.id (dissoc visibility-config :effective-child-of))
+                                           [:= :c.location [:concat :c2.location :c2.id (h2x/literal "/")]]
+                                           (when-not (collection.root/is-root-collection? parent-coll)
+                                             [:not= :c2.id (u/the-id parent-coll)])]}]]])]}]])))
 
-         (or root-clause non-root-clause)
-         (or root-clause non-root-clause)
+(def ^{:arglists '([visibility-config])} visible-collection-ids
+  "Returns all collection IDs that are visible given the `visibility-config` passed in. (Config provides knobs for
+  toggling permission level, trash/archive visibility, etc). If you're trying to filter based on this, you should
+  probably try to use `visible-collection-filter-clause` instead.
 
-         :else
-         false)))))
-
-(mu/defn visible-collection-ids->direct-visible-descendant-clause
-  "Generates an appropriate HoneySQL `:where` clause to filter out descendants of a collection A with a specific property.
-  This property is being a descendant of a visible collection other than A. Used for effective children calculations"
-  [parent-collection :- CollectionWithLocationAndIDOrRoot, collection-ids :- VisibleCollections]
-  (let [parent-id           (or (:id parent-collection) "")
-        child-literal       (if (collection.root/is-root-collection? parent-collection)
-                              "/"
-                              (format "%%/%s/" (str parent-id)))]
-    (into
-     ;; if the collection-ids are empty, the whole into turns into nil and we have a dangling [:and] clause in query.
-     ;; the (1 = 1) is to prevent this
-     [:and [:= [:inline 1] [:inline 1]]]
-     (if (= collection-ids :all)
-       ;; In the case that visible-collection-ids is all, that means there's no invisible collection ids
-       ;; meaning, the effective children are always the direct children. So check for being a direct child.
-       [[:like :location (h2x/literal child-literal)]]
-       (let [to-disj-ids         (location-path->ids (or (:effective_location parent-collection) "/"))
-             disj-collection-ids (apply disj collection-ids (conj to-disj-ids parent-id))]
-         (for [visible-collection-id disj-collection-ids]
-           [:not-like :location (h2x/literal (format "%%/%s/%%" (str visible-collection-id)))]))))))
+  Cached for the lifetime of the request, maximum 10 seconds."
+  (memoize/ttl
+   ^{::memoize/args-fn (fn [[visibility-config]]
+                         (if-let [req-id *request-id*]
+                           [req-id api/*current-user-id* visibility-config]
+                           [(random-uuid) api/*current-user-id* visibility-config]))}
+   (fn visible-collection-ids*
+     [visibility-config]
+     (cond-> (t2/select-pks-set :model/Collection {:where (visible-collection-filter-clause :id visibility-config)})
+       (should-display-root-collection? visibility-config)
+       (conj "root")))
+   ;; cache the results for 60 minutes; TTL is here only to eventually clear out old entries/keep it from growing too
+   ;; large
+   :ttl/threshold (* 60 60 1000)))
 
 
 (mu/defn ^:private effective-location-path* :- [:maybe LocationPath]
   ([collection :- CollectionWithLocationOrRoot]
-   (if (collection.root/is-root-collection? collection)
-     nil
+   (when-not (collection.root/is-root-collection? collection)
      (effective-location-path* (:location collection)
-                               (permissions-set->visible-collection-ids @*current-user-permissions-set*))))
-
+                               (visible-collection-ids
+                                {:include-archived-items    :all
+                                 :permission-level          :read}))))
   ([real-location-path     :- LocationPath
     allowed-collection-ids :- VisibleCollections]
-   (if (= allowed-collection-ids :all)
-     real-location-path
-     (apply location-path (for [id    (location-path->ids real-location-path)
-                                :when (contains? allowed-collection-ids id)]
-                            id)))))
+   (apply location-path (for [id    (location-path->ids real-location-path)
+                              :when (contains? allowed-collection-ids id)]
+                          id))))
 
 (mi/define-simple-hydration-method effective-location-path
   :effective_location
   "Given a `location-path` and a set of Collection IDs one is allowed to view (obtained from
-  `permissions-set->visible-collection-ids` above), calculate the 'effective' location path (excluding IDs of
+  `visible-collection-ids` above), calculate the 'effective' location path (excluding IDs of
   Collections for which we do not have read perms) we should show to the User.
 
   When called with a single argument, `collection`, this is used as a hydration function to hydrate
@@ -383,20 +608,29 @@
       :id [:in ancestor-ids]
       {:order-by [:location]})))
 
-(mi/define-simple-hydration-method ^:private ancestors
+(mi/define-simple-hydration-method ancestors
   :ancestors
   "Fetch ancestors (parent, grandparent, etc.) of a `collection`. These are returned in order starting with the
   highest-level (e.g. most distant) ancestor."
   [collection]
   (ancestors* collection))
 
-(mu/defn ^:private effective-ancestors* :- [:sequential [:or RootCollection (mi/InstanceOf Collection)]]
-  [collection :- CollectionWithLocationAndIDOrRoot]
-  (if (collection.root/is-root-collection? collection)
+(mu/defn ^:private effective-ancestors*
+  "Given a collection, return the effective ancestors of that collection."
+  [collection :- [:maybe CollectionWithLocationOrRoot]
+   collection-id->collection :- :map]
+  (if (or (nil? collection)
+          (collection.root/is-root-collection? collection))
     []
-    (filter mi/can-read? (cons (root-collection-with-ui-details (:namespace collection)) (ancestors collection)))))
+    (some->> (effective-location-path collection)
+             location-path->ids
+             (map collection-id->collection)
+             (map #(select-keys % [:name :id :personal_owner_id]))
+             (map #(t2/instance :model/Collection %))
+             (cons (root-collection-with-ui-details (:namespace collection)))
+             (filter mi/can-read?))))
 
-(mi/define-simple-hydration-method effective-ancestors
+(mi/define-batched-hydration-method effective-ancestors
   :effective_ancestors
   "Fetch the ancestors of a `collection`, filtering out any ones the current User isn't allowed to see. This is used
   in the UI to power the 'breadcrumb' path to the location of a given Collection. For example, suppose we have four
@@ -414,8 +648,16 @@
 
   Thus the existence of C will be kept hidden from the current User, and for all intents and purposes the current User
   can effectively treat A as the parent of C."
-  [collection]
-  (effective-ancestors* collection))
+  [collections]
+  (let [all-ids (mapcat #(some-> % effective-location-path location-path->ids) collections)
+        collection-id->collection (if (seq all-ids)
+                                    (t2/select-pk->fn identity :model/Collection :id [:in all-ids])
+                                    {})]
+    (map (fn [collection]
+           (assoc collection
+                  :effective_ancestors
+                  (effective-ancestors* collection collection-id->collection)))
+         collections)))
 
 (mu/defn ^:private parent-id* :- [:maybe ms/PositiveInt]
   [{:keys [location]} :- CollectionWithLocationOrRoot]
@@ -426,19 +668,6 @@
   "Get the immediate parent `collection` id, if set."
   [collection]
   (parent-id* collection))
-
-(mu/defn children-location :- LocationPath
-  "Given a `collection` return a location path that should match the `:location` value of all the children of the
-  Collection.
-
-     (children-location collection) ; -> \"/10/20/30/\";
-
-     ;; To get children of this collection:
-     (t2/select Collection :location \"/10/20/30/\")"
-  [{:keys [location], :as collection} :- CollectionWithLocationAndIDOrRoot]
-  (if (collection.root/is-root-collection? collection)
-    "/"
-    (str location (u/the-id collection) "/")))
 
 (def ^:private Children
   [:schema
@@ -490,27 +719,21 @@
         ;; key
         :children)))
 
-(mu/defn descendant-ids :- [:maybe [:set ms/PositiveInt]]
-  "Return a set of IDs of all descendant Collections of a `collection`."
-  [collection :- CollectionWithLocationAndIDOrRoot]
-  (t2/select-pks-set Collection :location [:like (str (children-location collection) \%)]))
-
 (mu/defn ^:private effective-children-where-clause
+  "Given a collection, return the `WHERE` clause appropriate to return all the collections we want to show as its
+  effective children."
   [collection & additional-honeysql-where-clauses]
-  (let [visible-collection-ids (permissions-set->visible-collection-ids @*current-user-permissions-set*)]
-    ;; Collection B is an effective child of Collection A if...
-    (into
-      [:and
-       ;; it is a descendant of Collection A
-       [:like :location (h2x/literal (str (children-location collection) "%"))]
-       ;; it is visible.
-       (visible-collection-ids->honeysql-filter-clause :id visible-collection-ids)
-       ;; it is NOT a descendant of a visible Collection other than A
-       (visible-collection-ids->direct-visible-descendant-clause (t2/hydrate collection :effective_location) visible-collection-ids)
-       ;; don't want personal collections in collection items. Only on the sidebar
-       [:= :personal_owner_id nil]]
-      ;; (any additional conditions)
-      additional-honeysql-where-clauses)))
+  (into
+   [:and
+    ;; it is a visible effective child of the collection.
+    (visible-collection-filter-clause :id
+                                      {:include-archived-items    :all
+                                       :effective-child-of        collection
+                                       :permission-level          :read})
+    ;; don't want personal collections in collection items. Only on the sidebar
+    [:= :personal_owner_id nil]]
+   ;; (any additional conditions)
+   additional-honeysql-where-clauses))
 
 (mu/defn effective-children-query :- [:map
                                       [:select :any]
@@ -681,27 +904,6 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                       Toucan IModel & Perms Method Impls                                       |
 ;;; +----------------------------------------------------------------------------------------------------------------+
-
-(def ^:private CollectionWithLocationAndPersonalOwnerID
-  "Schema for a Collection instance that has a valid `:location`, and a `:personal_owner_id` key *present* (but not
-  neccesarily non-nil)."
-  [:map
-   [:location          LocationPath]
-   [:personal_owner_id [:maybe ms/PositiveInt]]])
-
-(mu/defn is-personal-collection-or-descendant-of-one? :- :boolean
-  "Is `collection` a Personal Collection, or a descendant of one?"
-  [collection :- CollectionWithLocationAndPersonalOwnerID]
-  (boolean
-   (or
-    ;; If collection has an owner ID we're already done here, we know it's a Personal Collection
-    (:personal_owner_id collection)
-    ;; Otherwise try to get the ID of its highest-level ancestor, e.g. if `location` is `/1/2/3/` we would get `1`.
-    ;; Then see if the root-level ancestor is a Personal Collection (Personal Collections can only got in the Root
-    ;; Collection.)
-    (t2/exists? Collection
-                :id                (first (location-path->ids (:location collection)))
-                :personal_owner_id [:not= nil]))))
 
 ;;; ----------------------------------------------------- INSERT -----------------------------------------------------
 
@@ -1071,136 +1273,6 @@
     (check-write-perms-for-collection (:collection_id object-before-update))
     ;; check that we're allowed to modify the new Collection
     (check-write-perms-for-collection (:collection_id object-updates))))
-
-
-;;; +----------------------------------------------------------------------------------------------------------------+
-;;; |                                              Personal Collections                                              |
-;;; +----------------------------------------------------------------------------------------------------------------+
-
-(mu/defn format-personal-collection-name :- ms/NonBlankString
-  "Constructs the personal collection name from user name.
-  When displaying to users we'll tranlsate it to user's locale,
-  but to keeps things consistent in the database, we'll store the name in site's locale.
-
-  Practically, use `user-or-site` = `:site` when insert or update the name in database,
-  and `:user` when we need the name for displaying purposes"
-  [first-name last-name email user-or-site]
-  {:pre [(#{:user :site} user-or-site)]}
-  (if (= :user user-or-site)
-    (cond
-      (and first-name last-name) (tru "{0} {1}''s Personal Collection" first-name last-name)
-      :else                      (tru "{0}''s Personal Collection" (or first-name last-name email)))
-    (cond
-      (and first-name last-name) (trs "{0} {1}''s Personal Collection" first-name last-name)
-      :else                      (trs "{0}''s Personal Collection" (or first-name last-name email)))))
-
-(mu/defn user->personal-collection-name :- ms/NonBlankString
-  "Come up with a nice name for the Personal Collection for `user-or-id`."
-  [user-or-id user-or-site]
-  (let [{first-name :first_name
-         last-name  :last_name
-         email      :email} (t2/select-one ['User :first_name :last_name :email]
-                              :id (u/the-id user-or-id))]
-    (format-personal-collection-name first-name last-name email user-or-site)))
-
-(defn personal-collection-with-ui-details
-  "For Personal collection, we make sure the collection's name and slug is translated to user's locale
-  This is only used for displaying purposes, For insertion or updating  the name, use site's locale instead"
-  [{:keys [personal_owner_id] :as collection}]
-  (if-not personal_owner_id
-    collection
-    (let [collection-name (user->personal-collection-name personal_owner_id :user)]
-      (assoc collection
-             :name collection-name
-             :slug (u/slugify collection-name)))))
-
-(mu/defn user->existing-personal-collection :- [:maybe (mi/InstanceOf Collection)]
-  "For a `user-or-id`, return their personal Collection, if it already exists.
-  Use [[metabase.models.collection/user->personal-collection]] to fetch their personal Collection *and* create it if
-  needed."
-  [user-or-id]
-  (t2/select-one Collection :personal_owner_id (u/the-id user-or-id)))
-
-(mu/defn user->personal-collection :- (mi/InstanceOf Collection)
-  "Return the Personal Collection for `user-or-id`, if it already exists; if not, create it and return it."
-  [user-or-id]
-  (or (user->existing-personal-collection user-or-id)
-      (try
-        (first (t2/insert-returning-instances! Collection
-                                               {:name              (user->personal-collection-name user-or-id :site)
-                                                :personal_owner_id (u/the-id user-or-id)}))
-        ;; if an Exception was thrown why trying to create the Personal Collection, we can assume it was a race
-        ;; condition where some other thread created it in the meantime; try one last time to fetch it
-        (catch Throwable e
-          (or (user->existing-personal-collection user-or-id)
-              (throw e))))))
-
-(def ^:private ^{:arglists '([user-id])} user->personal-collection-id
-  "Cached function to fetch the ID of the Personal Collection belonging to User with `user-id`. Since a Personal
-  Collection cannot be deleted, the ID will not change; thus it is safe to cache, saving a DB call. It is also
-  required to caclulate the Current User's permissions set, which is done for every API call; thus it is cached to
-  save a DB call for *every* API call."
-  (memoize/ttl
-   ^{::memoize/args-fn (fn [[user-id]]
-                         [(mdb.connection/unique-identifier) user-id])}
-   (fn user->personal-collection-id*
-     [user-id]
-     (u/the-id (user->personal-collection user-id)))
-   ;; cache the results for 60 minutes; TTL is here only to eventually clear out old entries/keep it from growing too
-   ;; large
-   :ttl/threshold (* 60 60 1000)))
-
-(mu/defn user->personal-collection-and-descendant-ids :- [:sequential {:min 1} ms/PositiveInt]
-  "Somewhat-optimized function that fetches the ID of a User's Personal Collection as well as the IDs of all descendants
-  of that Collection. Exists because this needs to be known to calculate the Current User's permissions set, which is
-  done for every API call; this function is an attempt to make fetching this information as efficient as reasonably
-  possible."
-  [user-or-id]
-  (let [personal-collection-id (user->personal-collection-id (u/the-id user-or-id))]
-    (cons personal-collection-id
-          ;; `descendant-ids` wants a CollectionWithLocationAndID, and luckily we know Personal Collections always go
-          ;; in Root, so we can pass it what it needs without actually having to fetch an entire CollectionInstance
-          (descendant-ids {:location "/", :id personal-collection-id}))))
-
-(mi/define-batched-hydration-method include-personal-collection-ids
-  :personal_collection_id
-  "Efficiently hydrate the `:personal_collection_id` property of a sequence of Users. (This is, predictably, the ID of
-  their Personal Collection.)"
-  [users]
-  (when (seq users)
-    ;; efficiently create a map of user ID -> personal collection ID
-    (let [user-id->collection-id (t2/select-fn->pk :personal_owner_id Collection
-                                   :personal_owner_id [:in (set (map u/the-id users))])]
-      (assert (map? user-id->collection-id))
-      ;; now for each User, try to find the corresponding ID out of that map. If it's not present (the personal
-      ;; Collection hasn't been created yet), then instead call `user->personal-collection-id`, which will create it
-      ;; as a side-effect. This will ensure this property never comes back as `nil`
-      (for [user users]
-        (assoc user :personal_collection_id (or (user-id->collection-id (u/the-id user))
-                                                (user->personal-collection-id (u/the-id user))))))))
-
-(mi/define-batched-hydration-method collection-is-personal
-  :is_personal
-  "Efficiently hydrate the `:is_personal` property of a sequence of Collections.
-  `true` means the collection is or nested in a personal collection."
-  [collections]
-  (if (= 1 (count collections))
-    (let [collection (first collections)]
-      (if (some? collection)
-        [(assoc collection :is_personal (is-personal-collection-or-descendant-of-one? collection))]
-        ;; root collection is nil
-        [collection]))
-    (let [personal-collection-ids (t2/select-pks-set :model/collection :personal_owner_id [:not= nil])
-          location-is-personal    (fn [location]
-                                    (boolean
-                                     (and (string? location)
-                                          (some #(str/starts-with? location (format "/%d/" %)) personal-collection-ids))))]
-      (map (fn [{:keys [location personal_owner_id] :as coll}]
-             (if (some? coll)
-               (assoc coll :is_personal (or (some? personal_owner_id)
-                                            (location-is-personal location)))
-               nil))
-           collections))))
 
 (defmulti allowed-namespaces
   "Set of Collection namespaces (as keywords) that instances of this model are allowed to go in. By default, only the

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -489,13 +489,28 @@
 
 (derive :model/Permissions :metabase/model)
 
+(defn- maybe-break-out-permission-data
+  "Given a `Permissions` model, add `:collection_id`, `:perm_type`, and `:perm_value` iff we know how to break that out."
+  [permissions]
+  (let [[match? coll-id-str read?] (re-matches #"^/collection/(\d+)/(read/)?" (:object permissions))]
+    (cond-> permissions
+      match? (assoc :collection_id (parse-long coll-id-str)
+                    :perm_type :perms/collection-access
+                    :perm_value (if read?
+                                  :read
+                                  :read-and-write)))))
+
 (t2/define-before-insert :model/Permissions
   [permissions]
-  (u/prog1 permissions
+  (u/prog1 (maybe-break-out-permission-data permissions)
     (assert-valid permissions)
     (log/debug (u/colorize 'green (trs "Granting permissions for group {0}: {1}"
                                        (:group_id permissions)
                                        (:object permissions))))))
+
+(t2/deftransforms :model/Permissions
+  {:perm_type mi/transform-keyword
+   :perm_value mi/transform-keyword})
 
 (t2/define-before-update :model/Permissions
   [_]

--- a/src/metabase/server/middleware/request_id.clj
+++ b/src/metabase/server/middleware/request_id.clj
@@ -1,0 +1,9 @@
+(ns metabase.server.middleware.request-id
+  (:require [metabase.config :refer [*request-id*]]))
+
+(defn wrap-request-id
+  "Attach a unique request ID to the request"
+  [handler]
+  (fn [request response raise]
+    (binding [*request-id* (random-uuid)]
+      (handler (assoc request :request-id *request-id*) response raise))))

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -439,6 +439,10 @@
                (-> (mt/user-http-request :rasta :get 200 "user/current")
                    mt/boolean-ids-and-timestamps
                    (dissoc :is_qbnewb :first_login :last_login))))))
+    (testing "on a fresh instance, `has_question_and_dashboard` is `false`"
+      (mt/with-empty-h2-app-db
+        (is (false? (-> (mt/user-http-request :rasta :get 200 "user/current")
+                        :has_question_and_dashboard)))))
     (testing "Custom homepage"
       (testing "If id is set but not enabled it is not included"
         (mt/with-temporary-setting-values [custom-homepage false

--- a/test/metabase/models/collection_test.clj
+++ b/test/metabase/models/collection_test.clj
@@ -2,16 +2,16 @@
   (:refer-clojure :exclude [ancestors descendants])
   (:require
    [clojure.math.combinatorics :as math.combo]
+   [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [clojure.walk :as walk]
-   [metabase.api.common :refer [*current-user-permissions-set*]]
    [metabase.models
     :refer [Card Collection Dashboard NativeQuerySnippet Permissions
             PermissionsGroup Pulse User]]
    [metabase.models.collection :as collection]
-   [metabase.models.interface :as mi]
    [metabase.models.permissions :as perms]
+   [metabase.models.permissions-group :as perms-group]
    [metabase.models.serialization :as serdes]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
@@ -157,16 +157,33 @@
   [[collections-binding options] & body]
   `(do-with-collection-hierarchy ~options (fn [~collections-binding] ~@body)))
 
-(defmacro with-current-user-perms-for-collections
+(defn do-with-current-user-perms-for-collections*!
+  [collections-or-ids collections-or-ids-to-discard body-fn]
+  (if (seq collections-or-ids-to-discard)
+    (mt/with-discarded-collections-perms-changes (first collections-or-ids-to-discard)
+      (do-with-current-user-perms-for-collections*! collections-or-ids (next collections-or-ids-to-discard) body-fn))
+    (let [read-paths (map perms/collection-read-path collections-or-ids)
+          write-paths (map perms/collection-readwrite-path collections-or-ids)]
+      (t2/delete! :model/Permissions :object [:in (concat read-paths write-paths)])
+      (t2/insert! :model/Permissions (map (fn [c-or-id]
+                                            {:group_id (u/the-id (perms-group/all-users))
+                                             :object (perms/collection-read-path c-or-id)})
+                                          collections-or-ids))
+      (mt/with-test-user :rasta
+        (body-fn)))))
+
+(defn do-with-current-user-perms-for-collections!
+  [collections-or-ids body-fn]
+  (do-with-current-user-perms-for-collections*! collections-or-ids collections-or-ids body-fn))
+
+(defmacro with-current-user-perms-for-collections!
   "Run `body` with the current User permissions for `collections-or-ids`.
 
      (with-current-user-perms-for-collections [a b c]
        ...)"
   {:style/indent 1}
   [collections-or-ids & body]
-  `(binding [*current-user-permissions-set* (atom #{~@(for [collection-or-id collections-or-ids]
-                                                        `(perms/collection-read-path ~collection-or-id))})]
-     ~@body))
+  `(do-with-current-user-perms-for-collections! ~collections-or-ids (fn [] ~@body)))
 
 (defn location-path-ids->names
   "Given a Collection location `path` replace all the IDs with the names of the Collections they represent. Done to make
@@ -265,43 +282,58 @@
              Exception
              (collection/children-location collection)))))))
 
-(deftest ^:parallel permissions-set->visible-collection-ids-test
-  (testing "Make sure we can look at the current user's permissions set and figure out which Collections they're allowed to see"
-    (is (= #{8 9}
-           (collection/permissions-set->visible-collection-ids
-            #{"/db/1/"
-              "/db/2/native/"
-              "/db/4/schema/"
-              "/db/5/schema/PUBLIC/"
-              "/db/6/schema/PUBLIC/table/7/"
-              "/collection/8/"
-              "/collection/9/read/"}))))
+(deftest visible-collection-ids-test
+  (with-collection-hierarchy [{:keys [a b c d e f g]}]
+    (let [->names (fn [id-set]
+                    (let [root (when (contains? id-set "root") #{"root"})
+                          others (when-let [non-root-ids (seq (disj id-set "root"))]
+                                   (t2/select-fn-set :name :model/Collection :id [:in non-root-ids]))]
+                      (set/union root others)))
+          visible-collection-ids (fn []
+                                   (->names
+                                    (set/intersection (collection/visible-collection-ids {})
+                                                      (set (conj (map :id [a b c d e f g]) "root")))))]
+      (testing "All permissions => all the collections!"
+        (with-current-user-perms-for-collections! [a b c d e f g]
+          (is (= #{"A" "B" "C" "D" "E" "F" "G"} (visible-collection-ids)))))
+      (testing "Some permissions => some of the collections!"
+        (with-current-user-perms-for-collections! [a b c]
+          (is (= #{"A" "B" "C"}
+                 (visible-collection-ids)))))
+      (testing "Some other permissions => some other collections"
+        (with-current-user-perms-for-collections! [d e f]
+          (is (= #{"D" "E" "F"}
+                 (visible-collection-ids)))))
+      (testing "If the current user is an admin, it should return *all* collections"
+        (mt/with-test-user :crowberto
+          (is (= #{"A" "B" "C" "D" "E" "F" "G" "root"}
+                 (visible-collection-ids))))))))
 
-  (testing "If the current user has root permissions then make sure the function returns `:all`, which signifies that they are able to see all Collections"
-    (is (= :all
-           (collection/permissions-set->visible-collection-ids
-            #{"/"
-              "/db/2/native/"
-              "/collection/9/read/"}))))
+(deftest permissions-set->visible-collection-ids-test-with-config
+  (mt/with-temp [:model/Collection {c1 :id} {:archived false}
+                 :model/Collection {c2 :id} {:archived true}
+                 :model/Collection {c3 :id} {:archived true}
+                 :model/Collection {c4 :id} {:archived true}]
+    (let [visible-collection-ids (fn [c] (set/intersection (collection/visible-collection-ids c)
+                                                           #{c1 c2 c3 c4 "root"}))]
+      (with-current-user-perms-for-collections! [c1 c2 c3 c4]
+        (testing "Archived"
+          (testing "Default (All)"
+            (is (= #{"root" c1 c2 c3 c4} (visible-collection-ids {}))))
+          (testing "Only"
+            (is (= #{c2 c3 c4} (visible-collection-ids {:include-archived-items :only}))))
+          (testing "Exclude"
+            (is (= #{"root" c1} (visible-collection-ids {:include-archived-items :exclude}))))
+          (testing "All"
+            (is (= #{c1 c2 c3 c4 "root"}
+                   (visible-collection-ids {:include-archived-items :all})))))))))
 
-  (testing "for the Root Collection we should return `root`"
-    (is (= #{8 9 "root"}
-           (collection/permissions-set->visible-collection-ids
-            #{"/collection/8/"
-              "/collection/9/read/"
-              "/collection/root/"})))
-
-    (is (= #{"root"}
-           (collection/permissions-set->visible-collection-ids
-            #{"/collection/root/read/"})))))
-
-(deftest ^:parallel effective-location-path-test
+(deftest effective-location-path-test
   (testing "valid input"
     (doseq [[args expected] {["/10/20/30/" #{10 20}]    "/10/20/"
                              ["/10/20/30/" #{10 30}]    "/10/30/"
                              ["/10/20/30/" #{}]         "/"
-                             ["/10/20/30/" #{10 20 30}] "/10/20/30/"
-                             ["/10/20/30/" :all]        "/10/20/30/"}]
+                             ["/10/20/30/" #{10 20 30}] "/10/20/30/"}]
       (testing (pr-str (cons 'effective-location-path args))
         (is (= expected
                (apply collection/effective-location-path args))))))
@@ -314,33 +346,7 @@
       (testing (pr-str (cons 'effective-location-path args))
         (is (thrown?
              Exception
-             (apply collection/effective-location-path args))))))
-
-  (testing "Does the function also work if we call the single-arity version that powers hydration?"
-    (testing "mix of full and read perms"
-      (binding [*current-user-permissions-set* (atom #{"/collection/10/" "/collection/20/read/"})]
-        (is (= "/10/20/"
-               (collection/effective-location-path {:location "/10/20/30/"})))))
-
-    (testing "missing some perms"
-      (binding [*current-user-permissions-set* (atom #{"/collection/10/read/" "/collection/30/read/"})]
-        (is (= "/10/30/"
-               (collection/effective-location-path {:location "/10/20/30/"})))))
-
-    (testing "no perms"
-      (binding [*current-user-permissions-set* (atom #{})]
-        (is (= "/"
-               (collection/effective-location-path {:location "/10/20/30/"})))))
-
-    (testing "read perms for all"
-      (binding [*current-user-permissions-set* (atom #{"/collection/10/" "/collection/20/read/" "/collection/30/read/"})]
-        (is (= "/10/20/30/"
-               (collection/effective-location-path {:location "/10/20/30/"})))))
-
-    (testing "root perms"
-      (binding [*current-user-permissions-set* (atom #{"/"})]
-        (is (= "/10/20/30/"
-               (collection/effective-location-path {:location "/10/20/30/"})))))))
+             (apply collection/effective-location-path args)))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                Nested Collections: CRUD Constraints & Behavior                                 |
@@ -446,27 +452,27 @@
 ;;; ---------------------------------------------- Effective Ancestors -----------------------------------------------
 
 (defn- effective-ancestors [collection]
-  (map :name (collection/effective-ancestors collection)))
+  (map :name (:effective_ancestors (t2/hydrate collection :effective_ancestors))))
 
 (deftest effective-ancestors-test
   (with-collection-hierarchy [{:keys [a c d]}]
     (testing "For D: if we don't have permissions for C, we should only see A"
-      (with-current-user-perms-for-collections [a d]
+      (with-current-user-perms-for-collections! [a d]
         (is (= ["A"]
                (effective-ancestors d)))))
 
     (testing "For D: if we don't have permissions for A, we should only see C"
-      (with-current-user-perms-for-collections [c d]
+      (with-current-user-perms-for-collections! [c d]
         (is (= ["C"]
                (effective-ancestors d)))))
 
     (testing "For D: if we have perms for all ancestors we should see them all"
-      (with-current-user-perms-for-collections [a c d]
+      (with-current-user-perms-for-collections! [a c d]
         (is (= ["A" "C"]
                (effective-ancestors d)))))
 
     (testing "For D: if we have permissions for no ancestors, we should see nothing"
-      (with-current-user-perms-for-collections [d]
+      (with-current-user-perms-for-collections! [d]
         (is (= []
                (effective-ancestors d)))))))
 
@@ -580,86 +586,88 @@
 
 ;;; ----------------------------------------------- Effective Children -----------------------------------------------
 
-(defn- effective-children [collection]
-  (set (map :name (collection/effective-children collection))))
-
 (deftest effective-children-test
   (with-collection-hierarchy [{:keys [a b c d e f g]}]
-    (testing "If we *have* perms for everything we should just see B and C."
-      (with-current-user-perms-for-collections [a b c d e f g]
-        (is (= #{"B" "C"}
-               (effective-children a)))))
+    (let [effective-children (fn [collection]
+                               (->> (collection/effective-children collection)
+                                    (filter #(contains? (set (map :id [a b c d e f g])) (:id %)))
+                                    (map :name)
+                                    set))]
 
-    (testing "make sure that `effective-children` isn't returning children or location of children! Those should get discarded."
-      (with-current-user-perms-for-collections [a b c d e f g]
-        (is (= #{:name :id :description}
-               (set (keys (first (collection/effective-children a))))))))
+      (testing "If we *have* perms for everything we should just see B and C."
+        (with-current-user-perms-for-collections! [a b c d e f g]
+          (is (= #{"B" "C"}
+                 (effective-children a)))))
 
-    (testing "If we don't have permissions for C, C's children (D and F) should be moved up one level"
-      ;;
-      ;;    +-> B                             +-> B
-      ;;    |                                 |
-      ;; A -+-> x -+-> D -> E     ===>     A -+-> D -> E
-      ;;           |                          |
-      ;;           +-> F -> G                 +-> F -> G
-      (with-current-user-perms-for-collections [a b d e f g]
+      (testing "make sure that `effective-children` isn't returning children or location of children! Those should get discarded."
+        (with-current-user-perms-for-collections! [a b c d e f g]
+          (is (= #{:name :id :description}
+                 (set (keys (first (collection/effective-children a))))))))
+
+      (testing "If we don't have permissions for C, C's children (D and F) should be moved up one level"
+        ;;
+        ;;    +-> B                             +-> B
+        ;;    |                                 |
+        ;; A -+-> x -+-> D -> E     ===>     A -+-> D -> E
+        ;;           |                          |
+        ;;           +-> F -> G                 +-> F -> G
+        (with-current-user-perms-for-collections! [a b d e f g]
+          (is (= #{"B" "D" "F"}
+                 (effective-children a)))))
+
+      (testing "If we also remove D, its child (F) should get moved up, for a total of 2 levels."
+        ;;
+        ;;    +-> B                             +-> B
+        ;;    |                                 |
+        ;; A -+-> x -+-> x -> E     ===>     A -+-> E
+        ;;           |                          |
+        ;;           +-> F -> G                 +-> F -> G
+        (with-current-user-perms-for-collections! [a b e f g]
+          (is (= #{"B" "E" "F"}
+                 (effective-children a)))))
+
+      (testing "If we remove C and both its children, both grandchildren should get get moved up"
+        ;;
+        ;;    +-> B                             +-> B
+        ;;    |                                 |
+        ;; A -+-> x -+-> x -> E     ===>     A -+-> E
+        ;;           |                          |
+        ;;           +-> x -> G                 +-> G
+        (with-current-user-perms-for-collections! [a b e g]
+          (is (= #{"B" "E" "G"}
+                 (effective-children a)))))
+
+      (testing "Now try with one of the Children. `effective-children` for C should be D & F"
+        ;;
+        ;; C -+-> D -> E              C -+-> D -> E
+        ;;    |              ===>        |
+        ;;    +-> F -> G                 +-> F -> G
+        (with-current-user-perms-for-collections! [b c d e f g]
+          (is (= #{"D" "F"}
+                 (effective-children c)))))
+
+      (testing "If we remove perms for D & F their respective children should get moved up"
+        ;;
+        ;; C -+-> x -> E              C -+-> E
+        ;;    |              ===>        |
+        ;;    +-> x -> G                 +-> G
+        (with-current-user-perms-for-collections! [b c e g]
+          (is (= #{"E" "G"}
+                 (effective-children c)))))
+
+      (testing "For the Root Collection: can we fetch its effective children?"
+        (with-current-user-perms-for-collections! [a b c d e f g]
+          (is (= #{"A"}
+                 (effective-children collection/root-collection)))))
+
+      (testing "For the Root Collection: if we don't have perms for A, we should get B and C as effective children"
+        (with-current-user-perms-for-collections! [b c d e f g]
+          (is (= #{"B" "C"}
+                 (effective-children collection/root-collection)))))
+
+      (testing "For the Root Collection: if we remove A and C we should get B, D and F"
         (is (= #{"B" "D" "F"}
-               (effective-children a)))))
-
-    (testing "If we also remove D, its child (F) should get moved up, for a total of 2 levels."
-      ;;
-      ;;    +-> B                             +-> B
-      ;;    |                                 |
-      ;; A -+-> x -+-> x -> E     ===>     A -+-> E
-      ;;           |                          |
-      ;;           +-> F -> G                 +-> F -> G
-      (with-current-user-perms-for-collections [a b e f g]
-        (is (= #{"B" "E" "F"}
-               (effective-children a)))))
-
-    (testing "If we remove C and both its children, both grandchildren should get get moved up"
-      ;;
-      ;;    +-> B                             +-> B
-      ;;    |                                 |
-      ;; A -+-> x -+-> x -> E     ===>     A -+-> E
-      ;;           |                          |
-      ;;           +-> x -> G                 +-> G
-      (with-current-user-perms-for-collections [a b e g]
-        (is (= #{"B" "E" "G"}
-               (effective-children a)))))
-
-    (testing "Now try with one of the Children. `effective-children` for C should be D & F"
-      ;;
-      ;; C -+-> D -> E              C -+-> D -> E
-      ;;    |              ===>        |
-      ;;    +-> F -> G                 +-> F -> G
-      (with-current-user-perms-for-collections [b c d e f g]
-        (is (= #{"D" "F"}
-               (effective-children c)))))
-
-    (testing "If we remove perms for D & F their respective children should get moved up"
-      ;;
-      ;; C -+-> x -> E              C -+-> E
-      ;;    |              ===>        |
-      ;;    +-> x -> G                 +-> G
-      (with-current-user-perms-for-collections [b c e g]
-        (is (= #{"E" "G"}
-               (effective-children c)))))
-
-    (testing "For the Root Collection: can we fetch its effective children?"
-      (with-current-user-perms-for-collections [a b c d e f g]
-        (is (= #{"A"}
-               (effective-children collection/root-collection)))))
-
-    (testing "For the Root Collection: if we don't have perms for A, we should get B and C as effective children"
-      (with-current-user-perms-for-collections [b c d e f g]
-        (is (= #{"B" "C"}
-               (effective-children collection/root-collection)))))
-
-    (testing "For the Root Collection: if we remove A and C we should get B, D and F"
-      (with-collection-hierarchy [{:keys [b d e f g]}]
-        (is (= #{"B" "D" "F"}
-               (with-current-user-perms-for-collections [b d e f g]
+               (with-current-user-perms-for-collections! [b d e f g]
                  (effective-children collection/root-collection))))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -1689,35 +1697,3 @@
           (is (= "e816af2d"
                  (serdes/raw-hash ["grandchild" :yolocorp c2-hash now])
                  (serdes/identity-hash c3))))))))
-
-(deftest instance-analytics-collections-test
-  (testing "Instance analytics and it's contents isn't writable, even for admins."
-    (t2.with-temp/with-temp [Collection audit-collection {:type "instance-analytics"}
-                             Card       audit-card       {:collection_id (:id audit-collection)}
-                             Dashboard  audit-dashboard  {:collection_id (:id audit-collection)}
-                             Collection cr-collection    {}
-                             Card       cr-card          {:collection_id (:id cr-collection)}
-                             Dashboard  cr-dashboard     {:collection_id (:id cr-collection)}]
-      (with-redefs [perms/default-audit-collection          (constantly audit-collection)
-                    perms/default-custom-reports-collection (constantly cr-collection)]
-        (mt/with-current-user (mt/user->id :crowberto)
-          (mt/with-additional-premium-features #{:audit-app}
-            (is (not (mi/can-write? audit-collection))
-                "Admin isn't able to write to audit collection")
-            (is (not (mi/can-write? audit-card))
-                "Admin isn't able to write to audit collection card")
-            (is (not (mi/can-write? audit-dashboard))
-                "Admin isn't able to write to audit collection dashboard"))
-          (mt/with-premium-features #{}
-            (is (not (mi/can-read? audit-collection))
-                "Admin isn't able to read audit collection when audit app isn't enabled")
-            (is (not (mi/can-read? audit-card))
-                "Admin isn't able to read audit collection card when audit app isn't enabled")
-            (is (not (mi/can-read? audit-dashboard))
-                "Admin isn't able to read audit collection dashboard when audit app isn't enabled")
-            (is (not (mi/can-read? cr-collection))
-                "Admin isn't able to read custom reports collection when audit app isn't enabled")
-            (is (not (mi/can-read? cr-card))
-                "Admin isn't able to read custom reports card when audit app isn't enabled")
-            (is (not (mi/can-read? cr-dashboard))
-                "Admin isn't able to read custom reports dashboard when audit app isn't enabled")))))))

--- a/test/metabase/models/permissions_test.clj
+++ b/test/metabase/models/permissions_test.clj
@@ -606,3 +606,21 @@
     #{2} {1 ["/db/2/schema/"]}                     {1 {2 {:data {:schemas :all}}}}
     #{2} {1 ["/query/db/2/schema/" "/data/db/2/"]} {1 {2 {:query {:schemas :all}, :data {:native :write}}}}
     #{2} {1 ["/db/2/"]}                            {1 {2 {:data {:native :write, :schemas :all}}}}))
+
+(deftest maybe-break-out-permission-data-test
+  (testing "We can break out a collection permission"
+    (are [object m] (= m (select-keys (#'perms/maybe-break-out-permission-data {:object object})
+                                      [:collection_id :perm_type :perm_value]))
+      "/collection/123/" {:collection_id 123
+                          :perm_type :perms/collection-access
+                          :perm_value :read-and-write}
+      "/collection/123/read/" {:collection_id 123
+                               :perm_type :perms/collection-access
+                               :perm_value :read}
+
+      ;; We only do this for collection permissions right now.
+      "/foo/1234/" {}
+
+      ;; Note that WE DON'T break out the root collection bits at this point. Maybe we will down the road, but we need
+      ;; to think about how this works since the collection ID will be `NULL`.
+      "/collection/root/" {})))


### PR DESCRIPTION
Oh boy, a backport of a backport!

This backports https://github.com/metabase/metabase/pull/47251 which was a backport of https://github.com/metabase/metabase/pull/46942.

The changes are the same (modulo merge conflicts) as in https://github.com/metabase/metabase/pull/47251 plus https://github.com/metabase/metabase/pull/47398.

* Much better collection permission performance (#46942)

PREFACE: THIS IS A BACKPORT COMMIT. And it was a painful one, because some previous very relevant changes hadn't been backported. So there are some changes from the original, non-backported, commit:

- removed all support for getting the trash collection, getting things that were `archived_directly`, or getting collections by `archive_operation_id`. None of these exist in this branch.

- in this branch, functions like `permissions-set->visible-collection-ids` did not check for archived status or anything other than permissions. On `master`, they do. So, the new function that replaced them,
`collection/visible-collection-filter-clause`, also checks for archived status as well as permissions. To resolve this, I chose to just default `collection/visible-collection-filter-clause` to ignore archived status and return both archived and unarchived collections.

On to the original commit message:

There are a few separate changes here:

- Migrations: add and populate indexed columns perm_value, perm_type, and collection_id to permissions

These fields allows us to efficiently run queries based on collection permissions in the DB without string manipulation. Keeping the table as permissions allows us to do this migration in-place. Note that in some cases collections may have been deleted from the database without deleting the associated permissions row (since there was no foreign key before). We need to be defensive here: if we have a permissions row without a corresponding collection, delete the row before running the rest of the migration.

- Write perm_value, perm_type, and collection_id for new collection permissions

A very simple before-insert method sets these fields before a collection permission is written to the DB.

- Replace collection/permissions-set->visible-collection-ids and collection/visible-collection-ids->honeysql-filter-clause with collection/honeysql-filter-clause

Previously, just about everywhere we used permissions-set->visible-collection-ids, what we were essentially doing was an in-app join: select all the collection IDs you have permission on, then convert it to a SQL clause like WHERE collection_id IN ( all of those collection IDs).

Replace both of these with honeysql-filter-clause, which uses the new fields we added to permissions above to construct a honeysql filter representing "all the collections I have permissions on", without needing to round-trip them to the application and back to the DB.

Of course, we can then write a function visible-collection-ids, which uses honeysql-filter-clause, for those cases where we do actually need the whole bunch in the application (we use this, for example, when constructing the effective-location for a collection).

I also added one more toggle to the VisibilityConfig that's passed into the honeysql-filter-clause (and used to be passed to permissions-set->visible-collection-ids), allowing you to select only the effective children of some collection.

* Backport: Speed up calculation of effective_ancestors

https://github.com/metabase/metabase/pull/47324

Previously, `visible-collection-ids` was effectively "free" in that we'd cached `collection-id->collection` for *all* collections, within a single request, and then locally filtered it for permissions without needing to hit the database again.

To be honest, there is probably a better fix for this - we're repeatedly calling `visible-collection-ids` when we probably could just save a single copy of it and use it when calculating the effective location of every collection.

However, this is a very quick and low-risk fix, and I want to prioritize getting this done, and then we can improve it later.

Locally, I copied down the database from stats and timed the `/api/search?model_ancestors=true` endpoint.

Before my "speedup" PR (https://github.com/metabase/metabase/pull/46942) it took ~7 seconds to return results.

After my "speedup" PR, it took ~15s to return results. :grimace:

With this change, it takes 818ms to return results. :tada: