### PR TITLE
Milestone Check Perms Fix (for real this time) 😅 

### DIFF
--- a/.github/workflows/release-milestone-check.yml
+++ b/.github/workflows/release-milestone-check.yml
@@ -20,8 +20,6 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-        env:
-          GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
         with:
           sparse-checkout: release
       - name: Prepare build scripts
@@ -30,7 +28,7 @@ jobs:
         env:
           SLACK_RELEASE_CHANNEL: ${{ vars.SLACK_RELEASE_CHANNEL }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-          GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
         with:
           script: | # js
             const {

--- a/.github/workflows/release-milestone-check.yml
+++ b/.github/workflows/release-milestone-check.yml
@@ -13,12 +13,6 @@ on:
         required: true
   pull_request: # FIXME for testing
 
-env:
-  GITHUB_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
-  GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
-  SLACK_RELEASE_CHANNEL: "bot-testing"
-  SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-
 jobs:
   check-milestone:
     permissions: write-all
@@ -31,6 +25,10 @@ jobs:
       - name: Prepare build scripts
         run: yarn --cwd release --frozen-lockfile && yarn --cwd release build
       - uses: actions/github-script@v7
+        env:
+          GITHUB_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+          SLACK_RELEASE_CHANNEL: "bot-testing"
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
           script: | # js
             const {

--- a/.github/workflows/release-milestone-check.yml
+++ b/.github/workflows/release-milestone-check.yml
@@ -11,6 +11,7 @@ on:
       commit:
         description: "A full-length commit SHA-1 hash"
         required: true
+  pull_request: # FIXME for testing
 
 jobs:
   check-milestone:
@@ -18,6 +19,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+        env:
+          GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
         with:
           sparse-checkout: release
       - name: Prepare build scripts
@@ -34,8 +37,12 @@ jobs:
               sendMilestoneCheckMessage,
             } = require('${{ github.workspace }}/release/dist/index.cjs');
 
-            const version = '${{ inputs.version }}';
-            const commitHash = '${{ inputs.commit }}';
+            // const version = '${{ inputs.version }}';
+            // const commitHash = '${{ inputs.commit }}';
+
+            // FIXME for testing
+            const version = 'v0.50.23';
+            const commitHash = '961a67397abf4010d2a575132bf53369f511c7c3';
 
             const issueCount = await checkMilestoneForRelease({
               github,

--- a/.github/workflows/release-milestone-check.yml
+++ b/.github/workflows/release-milestone-check.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   check-milestone:
+    permissions: write-all
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:

--- a/.github/workflows/release-milestone-check.yml
+++ b/.github/workflows/release-milestone-check.yml
@@ -13,6 +13,12 @@ on:
         required: true
   pull_request: # FIXME for testing
 
+env:
+  GITHUB_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+  GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+  SLACK_RELEASE_CHANNEL: "bot-testing"
+  SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
 jobs:
   check-milestone:
     permissions: write-all
@@ -25,10 +31,6 @@ jobs:
       - name: Prepare build scripts
         run: yarn --cwd release --frozen-lockfile && yarn --cwd release build
       - uses: actions/github-script@v7
-        env:
-          SLACK_RELEASE_CHANNEL: ${{ vars.SLACK_RELEASE_CHANNEL }}
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
         with:
           script: | # js
             const {

--- a/.github/workflows/release-milestone-check.yml
+++ b/.github/workflows/release-milestone-check.yml
@@ -11,7 +11,6 @@ on:
       commit:
         description: "A full-length commit SHA-1 hash"
         required: true
-  pull_request: # FIXME for testing
 
 jobs:
   check-milestone:
@@ -27,7 +26,7 @@ jobs:
       - uses: actions/github-script@v7
         env:
           GITHUB_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
-          SLACK_RELEASE_CHANNEL: "bot-testing"
+          SLACK_RELEASE_CHANNEL: ${{ vars.SLACK_RELEASE_CHANNEL }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
           script: | # js
@@ -36,12 +35,8 @@ jobs:
               sendMilestoneCheckMessage,
             } = require('${{ github.workspace }}/release/dist/index.cjs');
 
-            // const version = '${{ inputs.version }}';
-            // const commitHash = '${{ inputs.commit }}';
-
-            // FIXME for testing
-            const version = 'v0.50.23';
-            const commitHash = '961a67397abf4010d2a575132bf53369f511c7c3';
+            const version = '${{ inputs.version }}';
+            const commitHash = '${{ inputs.commit }}';
 
             const issueCount = await checkMilestoneForRelease({
               github,

--- a/release/src/milestones.ts
+++ b/release/src/milestones.ts
@@ -1,5 +1,6 @@
 import fs from "fs";
 
+import { graphql } from "@octokit/graphql";
 import _ from "underscore";
 
 import { hiddenLabels, nonUserFacingLabels } from "./constants";
@@ -544,7 +545,7 @@ async function addIssueToProject({
     return;
   }
 
-  const graphqlWithAuth = github.graphql.defaults({
+  const graphqlWithAuth = graphql.defaults({
     headers: {
       authorization: `token ${process.env.GITHUB_TOKEN}`,
     },

--- a/release/src/milestones.ts
+++ b/release/src/milestones.ts
@@ -544,13 +544,19 @@ async function addIssueToProject({
     return;
   }
 
+  const authHeader = {
+    headers: {
+      authorization: `token ${process.env.GITHUB_TOKEN}`,
+    },
+  };
+
   const response = await github.graphql(`mutation {
     addProjectV2ItemById(input: {
       projectId: "${releaseIssueProject.id}",
       contentId: "${issue?.node_id}"
     })
     { item { id } }
-  }`) as { addProjectV2ItemById: { item: { id: string } } };
+  }`, authHeader) as { addProjectV2ItemById: { item: { id: string } } };
 
   const itemId = response.addProjectV2ItemById.item.id;
 
@@ -575,5 +581,5 @@ async function addIssueToProject({
         value: { text: "${version}" } }
       )
       { projectV2Item { id } }
-    }`);
+    }`, authHeader);
 }

--- a/release/src/milestones.ts
+++ b/release/src/milestones.ts
@@ -550,7 +550,13 @@ async function addIssueToProject({
     },
   };
 
-  const response = await github.graphql(`mutation {
+  const graphqlWithAuth = github.graphql.defaults({
+    headers: {
+      authorization: `token secret123`,
+    },
+  });
+
+  const response = await graphqlWithAuth(`mutation {
     addProjectV2ItemById(input: {
       projectId: "${releaseIssueProject.id}",
       contentId: "${issue?.node_id}"
@@ -565,7 +571,7 @@ async function addIssueToProject({
     return;
   }
 
-  await github.graphql(`
+  await graphqlWithAuth(`
     mutation {
       setComment: updateProjectV2ItemFieldValue( input: {
         projectId: "${releaseIssueProject.id}"

--- a/release/src/milestones.ts
+++ b/release/src/milestones.ts
@@ -387,7 +387,7 @@ export async function checkMilestoneForRelease({
       issueNumber: issue.number,
       version,
       comment: 'Issue in milestone, cannot find commit',
-    });
+    }).catch((e) => console.error(`error adding issue ${issue.number} to project`, e));
   }
 
   for (const issueNumber of issuesInCommitsNotInMilestone) {
@@ -398,7 +398,7 @@ export async function checkMilestoneForRelease({
       issueNumber: issueNumber,
       version,
       comment: 'Issue in release branch, needs milestone',
-    });
+    }).catch((e) => console.error(`error adding issue ${issueNumber} to project`, e));
   }
 
   for (const issue of openMilestoneIssues) {
@@ -409,7 +409,7 @@ export async function checkMilestoneForRelease({
       issueNumber: issue.number,
       version,
       comment: 'Issue still open in milestone',
-    });
+    }).catch((e) => console.error(`error adding issue ${issue.number} to project`, e));
   }
 
   const logText = await generateLog({
@@ -530,7 +530,7 @@ async function addIssueToProject({
   comment,
   version,
 }: GithubProps & { issueNumber: number, comment: string, version: string }) {
-  console.log(`Adding issue #${issueNumber} to project`)
+  console.log(`Possible problem issue: #${issueNumber} - ${comment}`);
 
   const issue = await getIssueWithCache({
     github,
@@ -544,15 +544,9 @@ async function addIssueToProject({
     return;
   }
 
-  const authHeader = {
-    headers: {
-      authorization: `token ${process.env.GITHUB_TOKEN}`,
-    },
-  };
-
   const graphqlWithAuth = github.graphql.defaults({
     headers: {
-      authorization: `token secret123`,
+      authorization: `token ${process.env.GITHUB_TOKEN}`,
     },
   });
 
@@ -562,7 +556,7 @@ async function addIssueToProject({
       contentId: "${issue?.node_id}"
     })
     { item { id } }
-  }`, authHeader) as { addProjectV2ItemById: { item: { id: string } } };
+  }`) as { addProjectV2ItemById: { item: { id: string } } };
 
   const itemId = response.addProjectV2ItemById.item.id;
 
@@ -587,5 +581,5 @@ async function addIssueToProject({
         value: { text: "${version}" } }
       )
       { projectV2Item { id } }
-    }`, authHeader);
+    }`);
 }

--- a/release/src/slack.ts
+++ b/release/src/slack.ts
@@ -334,7 +334,7 @@ export async function sendPublishCompleteMessage({
   const baseMessage = `:partydeploy: *${githubRunLink(`${getGenericVersion(version)} Release is Complete`, runId.toString(), owner, repo)}* :partydeploy:`;
 
   const fullMessage = `\n
-    • ${slackLink("EE Extra Build", `https://github.com/${owner}/metabase-ee-extra/pulls`)}}
+    • ${slackLink("EE Extra Build", `https://github.com/${owner}/metabase-ee-extra/pulls`)}
     • ${slackLink("Ops Issues", `https://github.com/${owner}/metabase-ops/issues`)} - ${mentionSlackTeam('successengineers')}
     • ${slackLink("Release Notes", `https://github.com/${owner}/${repo}/releases`)} - ${mentionSlackTeam('tech-writers')}
     • ${slackLink("Docs Update", `https://github.com/${owner}/metabase.github.io/pulls`)} - ${mentionSlackTeam('tech-writers')}`;


### PR DESCRIPTION
follow up to #47377 

OK, found the issue with the milestone check action. There's a problem with the `graphql` method on the `github` object provided by github actions, so I used a separately imported `graphql` method, and it all works as expected.

[Test Run](https://github.com/metabase/metabase/actions/runs/10617716014/job/29431239971?pr=47401)
[Test Slack Message](https://metaboat.slack.com/archives/C01BWAZJE0N/p1724944062907979)