### PR TITLE
perf: Optimize insights and fingerprinting of time series

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -174,7 +174,10 @@
   potemkin/potemkin                         {:mvn/version "0.4.7"               ; utility macros & fns
                                              :exclusions  [riddley/riddley]}
   pretty/pretty                             {:mvn/version "1.0.5"}              ; protocol for defining how custom types should be pretty printed
-  redux/redux                               {:mvn/version "0.1.4"}              ; Utility functions for building and composing transducers
+  ;; Dependency below is our fork of redux - utility functions for building and composing transducers. The
+  ;; group/artifact name is the same as with the upstream so that it overrides the original dependency everywhere.
+  redux/redux                               {:git/url "https://github.com/metabase/redux"
+                                             :sha "4a37feaf817a2a6b5ef688c927f6fd4375964433"}
   riddley/riddley                           {:mvn/version "0.2.0"}              ; code walking lib -- used interally by Potemkin, manifold, etc.
   ring/ring-core                            {:mvn/version "1.12.0"}             ; HTTP abstraction
   ring/ring-jetty-adapter                   {:mvn/version "1.12.0"              ; Jetty adapter

--- a/src/metabase/analyze/fingerprint/fingerprinters.clj
+++ b/src/metabase/analyze/fingerprint/fingerprinters.clj
@@ -125,7 +125,7 @@
        semantic-type
        :Relation/*)]))
 
-(def ^:private global-fingerprinter
+(defn- global-fingerprinter []
   (redux/post-complete
    (robust-fuse {:distinct-count cardinality
                  :nil%           (stats/share nil?)})
@@ -133,11 +133,11 @@
 
 (defmethod fingerprinter :default
   [_]
-  global-fingerprinter)
+  (global-fingerprinter))
 
 (defmethod fingerprinter [:type/* :Semantic/* :type/FK]
   [_]
-  global-fingerprinter)
+  (global-fingerprinter))
 
 (defmethod fingerprinter [:type/* :Semantic/* :type/PK]
   [_]
@@ -155,7 +155,7 @@
   (redux/post-complete
    (redux/juxt
     fingerprinter
-    global-fingerprinter)
+    (global-fingerprinter))
    (fn [[type-fingerprint global-fingerprint]]
      (merge global-fingerprint
             type-fingerprint))))

--- a/src/metabase/analyze/fingerprint/insights.clj
+++ b/src/metabase/analyze/fingerprint/insights.clj
@@ -4,7 +4,6 @@
    [java-time.api :as t]
    [kixi.stats.core :as stats]
    [kixi.stats.math :as math]
-   [kixi.stats.protocols :as p]
    [medley.core :as m]
    [metabase.analyze.fingerprint.fingerprinters :as fingerprinters]
    [metabase.legacy-mbql.util :as mbql.u]
@@ -19,16 +18,18 @@
 
 (set! *warn-on-reflection* true)
 
-(defn- last-n
-  [n]
+(defn- last-2 []
   (fn
     ([] [])
     ([acc]
-     (concat (repeat (- n (count acc)) nil) acc))
+     (let [cnt (count acc)]
+       (cond (= cnt 0) [nil nil]
+             (= cnt 1) [nil (nth acc 0)]
+             :else acc)))
     ([acc x]
-     (if (< (count acc) n)
+     (if (< (count acc) 2)
        (conj acc x)
-       (conj (subvec acc 1) x)))))
+       [(nth acc 1) x]))))
 
 (defn change
   "Relative difference between `x1` an `x2`."
@@ -42,22 +43,70 @@
         (neg? x1)                 (- (change x2 (- x1)))
         :else                     (/ (- x2 x1) x1)))))
 
-(defn reservoir-sample
+(defn- reservoir-sample
   "Transducer that samples a fixed number `n` of samples consistently.
    https://en.wikipedia.org/wiki/Reservoir_sampling. Uses java.util.Random
-  with a seed of `n` to ensure a consistent sample if a dataset has not changed."
+  with a seed of `n` to ensure a consistent sample if a dataset has not changed.
+  The returned instance is mutable, so don't reuse it."
   [n]
-  (let [rng (Random. n)]
+  (let [n (int n)
+        rng (Random. n)
+        counter (int-array 1) ;; A box for a mutable primitive int.
+        reservoir (object-array n)]
     (fn
-      ([] [[] 0])
-      ([[reservoir c] x]
-       (let [c   (inc c)
-             idx (.nextInt rng c)]
+      ([] nil)
+      ([_]
+       (let [count (aget counter 0)]
+         (vec (if (< count n)
+                (java.util.Arrays/copyOfRange reservoir 0 count)
+                reservoir))))
+      ([_ x]
+       (let [c   (aget counter (unchecked-int 0))
+             c+1 (inc c)
+             idx (.nextInt rng c+1)]
+         (aset counter 0 c+1)
          (cond
-           (<= c n)  [(conj reservoir x) c]
-           (< idx n) [(assoc reservoir idx x) c]
-           :else     [reservoir c])))
-      ([[reservoir _]] reservoir))))
+           (< c n)   (aset reservoir c x)
+           (< idx n) (aset reservoir idx x)))))))
+
+(defn- simple-linear-regression
+  "Faster and more efficient implementation of `kixi.stats.estimate/simple-linear-regression`. Computes some of squares
+  on each step, and on the completing step returns `[offset slope]`."
+  [fx fy]
+  (fn
+    ([] (double-array 6))
+    ([^doubles arr e]
+     (let [x (fx e)
+           y (fy e)]
+       (if (or (nil? x) (nil? y))
+         arr
+         (let [x    (double x)
+               y    (double y)
+               c    (aget arr 0)
+               mx   (aget arr 1)
+               my   (aget arr 2)
+               ssx  (aget arr 3)
+               ssy  (aget arr 4)
+               ssxy (aget arr 5)
+               c'   (inc c)
+               mx'  (+ mx (/ (- x mx) c'))
+               my'  (+ my (/ (- y my) c'))]
+           (aset arr 0 c')
+           (aset arr 1 mx')
+           (aset arr 2 my')
+           (aset arr 3 (+ ssx  (* (- x mx') (- x mx))))
+           (aset arr 4 (+ ssy  (* (- y my') (- y my))))
+           (aset arr 5 (+ ssxy (* (- x mx') (- y my))))
+           arr))))
+    ([^doubles arr]
+     (let [mx (aget arr 1)
+           my (aget arr 2)
+           ssx (aget arr 3)
+           ssxy (aget arr 5)]
+       (when-not (zero? ssx)
+         (let [slope (/ ssxy ssx)
+               offset (- my (* mx slope))]
+           [offset slope]))))))
 
 (defn mae
   "Given two functions: (fŷ input) and (fy input), returning the predicted and actual values of y
@@ -114,14 +163,13 @@
    (fingerprinters/robust-fuse
     {:fits           (->> (for [{:keys [x-link-fn y-link-fn formula model]} trendline-function-families]
                             (redux/post-complete
-                             (stats/simple-linear-regression (comp (stats/somef x-link-fn) fx)
-                                                             (comp (stats/somef y-link-fn) fy))
-                             (fn [fit]
-                               (let [[offset slope] (some-> fit p/parameters)]
-                                 (when (every? u/real-number? [offset slope])
-                                   {:model   (model offset slope)
-                                    :formula (formula offset slope)})))))
-                          (apply redux/juxt))
+                             (simple-linear-regression #(some-> (fx %) x-link-fn)
+                                                       #(some-> (fy %) y-link-fn))
+                             (fn [[offset slope]]
+                               (when (every? u/real-number? [offset slope])
+                                 {:model   (model offset slope)
+                                  :formula (formula offset slope)}))))
+                          redux/juxt*)
      :validation-set ((keep (fn [row]
                               (let [x (fx row)
                                     y (fy row)]
@@ -198,35 +246,34 @@
                                                     fingerprinters/->temporal
                                                     ->millis-from-epoch
                                                     ms->day))))
-       (apply redux/juxt
-              (for [number-col numbers]
-                (redux/post-complete
-                 (let [y-position (:position number-col)
-                       yfn        #(nth % y-position)]
-                   ((filter (comp u/real-number? yfn))
-                    (redux/juxt ((map yfn) (last-n 2))
-                                ((map xfn) (last-n 2))
-                                (stats/simple-linear-regression xfn yfn)
-                                (best-fit xfn yfn))))
-                 (fn [[[y-previous y-current] [x-previous x-current] fit best-fit-equation]]
-                   (let [[offset slope] (some-> fit p/parameters)
-                         unit         (let [unit (some-> datetime :unit mbql.u/normalize-token)]
-                                        (if (or (nil? unit)
-                                                (= unit :default))
-                                          (infer-unit x-previous x-current)
-                                          unit))
-                         show-change? (valid-period? x-previous x-current unit)]
-                     (fingerprinters/robust-map
-                      :last-value     y-current
-                      :previous-value (when show-change?
-                                        y-previous)
-                      :last-change    (when show-change?
-                                        (change y-current y-previous))
-                      :slope          slope
-                      :offset         offset
-                      :best-fit       best-fit-equation
-                      :col            (:name number-col)
-                      :unit           unit)))))))
+       (redux/juxt*
+        (for [number-col numbers]
+          (redux/post-complete
+           (let [y-position (:position number-col)
+                 yfn        #(nth % y-position)]
+             ((filter (comp u/real-number? yfn))
+              (redux/juxt ((map yfn) (last-2))
+                          ((map xfn) (last-2))
+                          (simple-linear-regression xfn yfn)
+                          (best-fit xfn yfn))))
+           (fn [[[y-previous y-current] [x-previous x-current] [offset slope] best-fit-equation]]
+             (let [unit         (let [unit (some-> datetime :unit mbql.u/normalize-token)]
+                                  (if (or (nil? unit)
+                                          (= unit :default))
+                                    (infer-unit x-previous x-current)
+                                    unit))
+                   show-change? (valid-period? x-previous x-current unit)]
+               (fingerprinters/robust-map
+                :last-value     y-current
+                :previous-value (when show-change?
+                                  y-previous)
+                :last-change    (when show-change?
+                                  (change y-current y-previous))
+                :slope          slope
+                :offset         offset
+                :best-fit       best-fit-equation
+                :col            (:name number-col)
+                :unit           unit)))))))
       (format "Error generating timeseries insight keyed by: %s"
               (sync-util/name-for-logging (mi/instance :model/Field datetime))))))
 

--- a/src/metabase/analyze/query_results.clj
+++ b/src/metabase/analyze/query_results.clj
@@ -110,11 +110,11 @@
                                          (fingerprinters/constant-fingerprinter fingerprint))))
       (insights/insights cols))
      (fn [[fingerprints insights]]
-       {:metadata (map (fn [fingerprint metadata]
-                         (if (instance? Throwable fingerprint)
-                           metadata
-                           (assoc metadata :fingerprint fingerprint)))
-                       fingerprints
-                       cols)
+       {:metadata (mapv (fn [fingerprint metadata]
+                          (if (instance? Throwable fingerprint)
+                            metadata
+                            (assoc metadata :fingerprint fingerprint)))
+                        fingerprints
+                        cols)
         :insights (when-not (instance? Throwable insights)
                     insights)}))))


### PR DESCRIPTION
Can be reviewed commit by commit.

1. Improved `redux.core/juxt` and made our functions use it. This is a placeholder before these changes are merged and released in a redux library fork. Completely rewrote `simple-linear-regression` from kixi.stats to allocate less and use primitive math more.

2. Rewrote `fingerprinters/with-error-handling` because the current implementation produced a lot of garbage in closure allocations since `try-catch` is very sensitive to positioning and will compile into functions and closures where it can be avoided if written by hand.

Same single-table benchmark as #47424, 20k rows displayed.

```
Before:

Time per call: 1.62 s      Alloc per call: 1,983,336,344b
Time per call: 1.52 s      Alloc per call: 1,983,146,208b
Time per call: 1.20 s      Alloc per call: 1,983,140,328b
Time per call: 1.55 s      Alloc per call: 1,983,141,464b
Time per call: 1.45 s      Alloc per call: 1,983,130,136b

After:

Time per call: 507.29 ms   Alloc per call: 427,498,416b
Time per call: 615.39 ms   Alloc per call: 427,494,792b
Time per call: 615.08 ms   Alloc per call: 427,495,176b
Time per call: 503.81 ms   Alloc per call: 427,495,624b
Time per call: 523.84 ms   Alloc per call: 427,494,920b
```

<img width="270" alt="image" src="https://github.com/user-attachments/assets/395df0d7-90b4-4333-b003-4c85ad3fe7a9">
