### PR TITLE
Allow group deletion via SCIM

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/scim/v2/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/scim/v2/api.clj
@@ -418,4 +418,12 @@
             mb-group->scim
             scim-response)))))
 
+(defendpoint DELETE "/Groups/:id"
+  "Delete a group."
+  [id]
+  {id ms/NonBlankString}
+  (let [group (get-group-by-entity-id id)]
+    (t2/delete! :model/PermissionsGroup (u/the-id group))
+    (scim-response nil 204)))
+
 (api/define-routes)


### PR DESCRIPTION
Implements a `DELETE` group endpoint for SCIM. Pretty straightforward. See [here](https://metaboat.slack.com/archives/C064EB1UE5P/p1724947151989099) for context