### PR TITLE
fix: bigquery handle local date params as date

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
@@ -7,7 +7,6 @@
    [metabase.driver :as driver]
    [metabase.driver.bigquery-cloud-sdk.common :as bigquery.common]
    [metabase.driver.common :as driver.common]
-   [metabase.driver.sql :as driver.sql]
    [metabase.driver.sql.parameters.substitution :as sql.params.substitution]
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.driver.sql.util :as sql.u]
@@ -983,11 +982,6 @@
 (defmethod sql.qp/quote-style :bigquery-cloud-sdk
   [_driver]
   :mysql)
-
-;; convert LocalDate to an OffsetDateTime in UTC since BigQuery doesn't handle LocalDates as we'd like
-(defmethod driver.sql/->prepared-substitution [:bigquery-cloud-sdk LocalDate]
-  [driver t]
-  (driver.sql/->prepared-substitution driver (t/offset-date-time t (t/local-time 0) (t/zone-offset 0))))
 
 (mu/defmethod sql.params.substitution/->replacement-snippet-info [:bigquery-cloud-sdk FieldFilter]
   [driver                            :- :keyword

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
@@ -619,6 +619,23 @@
                   (is (= [[0]]
                          (mt/rows (qp/process-query query)))))))))))))
 
+(deftest ^:parallel date-parameterized-sql-test
+  (mt/test-driver
+    :bigquery-cloud-sdk
+    (let [query {:database (mt/id)
+                 :type :native
+                 :native {:query "select * from (select date('2024-08-29') as y) as x where x.y = {{d}}"
+                          :template-tags {"d" {:name "d"
+                                               :display-name "Date"
+                                               :type :date}}}
+                 :parameters [{:type "date"
+                               :name "d"
+                               :target [:variable [:template-tag "d"]]
+                               :value "2024-08-29"}]}]
+      (is (= 1
+             (count
+              (mt/rows (qp/process-query query))))))))
+
 (deftest datetime-timezone-parameter-test
   (testing "Date Field Filter not includes Timezone (#43597)"
     (mt/test-driver


### PR DESCRIPTION
Fixes #30602

We were overriding localdate in bigquery driver to produce offsetdatetimes for no apparent reason. This causes a number of problems when dealing with date type columns.
