### PR TITLE
[MBQL lib] Allow temporal bucketing of Date(Time) expressions

### DIFF
--- a/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
@@ -85,7 +85,7 @@ describe("scenarios > question > custom column", () => {
       cy.findByText(name).click();
     });
     cy.button("Custom column").click();
-    enterCustomColumnDetails({ formula: "[cre" });
+    enterCustomColumnDetails({ formula: "[cre", blur: false });
 
     cy.findAllByTestId("expression-suggestions-list-item")
       .should("have.length", 1)
@@ -121,7 +121,7 @@ describe("scenarios > question > custom column", () => {
     getNotebookStep("summarize").findByText("Half Price").should("be.visible");
   });
 
-  it("should not show temporal units for a date/time custom column", () => {
+  it("should show temporal units for a date/time custom column", () => {
     openOrdersTable({ mode: "notebook" });
     cy.icon("add_data").click();
 
@@ -141,12 +141,12 @@ describe("scenarios > question > custom column", () => {
       .findByRole("option", { name: "Product Date" })
       .within(() => {
         cy.findByLabelText("Binning strategy").should("not.exist");
-        cy.findByLabelText("Temporal bucket").should("not.exist");
+        cy.findByLabelText("Temporal bucket").should("exist");
       })
       .click();
 
     getNotebookStep("summarize")
-      .findByText("Product Date")
+      .findByText("Product Date: Day")
       .should("be.visible");
   });
 

--- a/e2e/test/scenarios/dashboard-filters/temporal-unit-parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/temporal-unit-parameters.cy.spec.js
@@ -114,7 +114,13 @@ const expressionBreakoutQuestionDetails = {
         "day",
       ],
     },
-    breakout: [["expression", "Date", { "base-type": "type/DateTime" }]],
+    breakout: [
+      [
+        "expression",
+        "Date",
+        { "base-type": "type/DateTime", "temporal-unit": "day" },
+      ],
+    ],
   },
 };
 
@@ -313,8 +319,18 @@ describe("scenarios > dashboard > temporal unit parameters", () => {
       cy.log("breakout by expression");
       addQuestion(expressionBreakoutQuestionDetails.name);
       editParameter(parameterDetails.name);
-      getDashboardCard().findByText("No valid fields").should("be.visible");
-      dashboardParametersDoneButton().click();
+      getDashboardCard().findByText("Select…").click();
+      popover().findByText("Date").click();
+      saveDashboard();
+      filterWidget().click();
+      popover().findByText("Quarter").click();
+      getDashboardCard().within(() => {
+        cy.findByText("Date: Quarter").should("be.visible");
+        cy.findByText(expressionBreakoutQuestionDetails.name).click();
+      });
+      queryBuilderMain().findByText("Date: Quarter").should("be.visible");
+      backToDashboard();
+      editDashboard();
       removeQuestion();
 
       cy.log("breakout by a column with a binning strategy");

--- a/e2e/test/scenarios/question/column-compare.cy.spec.ts
+++ b/e2e/test/scenarios/question/column-compare.cy.spec.ts
@@ -151,6 +151,7 @@ const QUERY_TEMPORAL_EXPRESSION_BREAKOUT: StructuredQuery = {
       "Created At plus one month",
       {
         "base-type": "type/DateTime",
+        "temporal-unit": "month",
       },
     ],
   ],
@@ -633,7 +634,7 @@ describeWithSnowplow("scenarios > question > column compare", () => {
 
         verifySummarizeText(info);
 
-        tableHeaderClick("Created At plus one month");
+        tableHeaderClick("Created At plus one month: Month");
         verifyNoColumnCompareShortcut();
 
         verifyColumnDrillText(info);
@@ -668,7 +669,7 @@ describeWithSnowplow("scenarios > question > column compare", () => {
         ]);
 
         verifyBreakoutExistsAndIsFirst({
-          column: "Created At",
+          column: "Created At plus one month",
           bucket: "Month",
         });
 

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
@@ -105,33 +105,19 @@ function createQueryWithInlineExpressionWithOperator() {
   });
 }
 
-function createQueryWithDateExpressionAndAggregation() {
+function createQueryWithOpaqueBreakoutAndAggregation() {
   return createQuery({
     query: {
       database: SAMPLE_DB_ID,
       type: "query",
       query: {
-        expressions: {
-          "Created At plus one month": [
-            "datetime-add",
-            [
-              "field",
-              PRODUCTS.CREATED_AT,
-              {
-                "base-type": "type/DateTime",
-              },
-            ],
-            1,
-            "month",
-          ],
-        },
         aggregation: [["count"]],
         breakout: [
           [
-            "expression",
-            "Created At plus one month",
+            "field",
+            PRODUCTS.CATEGORY,
             {
-              "base-type": "type/DateTime",
+              "base-type": "type/Text",
             },
           ],
         ],
@@ -445,7 +431,7 @@ describe("AggregationPicker", () => {
 
     it("does not display the shortcut if there are no possible breakouts to use", () => {
       setup({
-        query: createQueryWithDateExpressionAndAggregation(),
+        query: createQueryWithOpaqueBreakoutAndAggregation(),
       });
       expect(screen.queryByText(/compare/i)).not.toBeInTheDocument();
     });

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -65,7 +65,7 @@ describe("QueryBuilder", () => {
         ).toBeInTheDocument();
       });
 
-      it("doesn't render time series grouping widget for custom date field breakout (metabase#33504)", async () => {
+      it("renders time series grouping widget for custom date field breakout", async () => {
         await setup({
           card: TEST_TIME_SERIES_WITH_CUSTOM_DATE_BREAKOUT_CARD,
         });
@@ -75,13 +75,11 @@ describe("QueryBuilder", () => {
         );
         expect(timeSeriesModeFooter).toBeInTheDocument();
         expect(
-          within(timeSeriesModeFooter).queryByText("by"),
-        ).not.toBeInTheDocument();
+          within(timeSeriesModeFooter).getByText("by"),
+        ).toBeInTheDocument();
         expect(
-          within(timeSeriesModeFooter).queryByTestId(
-            "timeseries-bucket-button",
-          ),
-        ).not.toBeInTheDocument();
+          within(timeSeriesModeFooter).getByTestId("timeseries-bucket-button"),
+        ).toBeInTheDocument();
       });
     });
 

--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -28,9 +28,12 @@
 (mu/defn column-metadata->expression-ref :- :mbql.clause/expression
   "Given `:metadata/column` column metadata for an expression, construct an `:expression` reference."
   [metadata :- ::lib.schema.metadata/column]
-  (let [options {:lib/uuid       (str (random-uuid))
-                 :base-type      (:base-type metadata)
-                 :effective-type ((some-fn :effective-type :base-type) metadata)}]
+  (let [options (merge
+                 {:lib/uuid       (str (random-uuid))
+                  :base-type      (:base-type metadata)
+                  :effective-type ((some-fn :effective-type :base-type) metadata)}
+                 (when-let [unit (:metabase.lib.field/temporal-unit metadata)]
+                   {:temporal-unit unit}))]
     [:expression options ((some-fn :lib/expression-name :name) metadata)]))
 
 (mu/defn resolve-expression :- ::lib.schema.expression/expression
@@ -57,13 +60,15 @@
 
 (defmethod lib.metadata.calculation/metadata-method :expression
   [query stage-number [_expression opts expression-name, :as expression-ref-clause]]
-  {:lib/type            :metadata/column
-   :lib/source-uuid     (:lib/uuid opts)
-   :name                expression-name
-   :lib/expression-name expression-name
-   :display-name        (lib.metadata.calculation/display-name query stage-number expression-ref-clause)
-   :base-type           (lib.metadata.calculation/type-of query stage-number expression-ref-clause)
-   :lib/source          :source/expressions})
+  (merge {:lib/type            :metadata/column
+          :lib/source-uuid     (:lib/uuid opts)
+          :name                expression-name
+          :lib/expression-name expression-name
+          :display-name        (lib.metadata.calculation/display-name query stage-number expression-ref-clause)
+          :base-type           (lib.metadata.calculation/type-of query stage-number expression-ref-clause)
+          :lib/source          :source/expressions}
+         (when-let [unit (lib.temporal-bucket/raw-temporal-bucket expression-ref-clause)]
+           {:metabase.lib.field/temporal-unit unit})))
 
 (defmethod lib.metadata.calculation/display-name-method :dispatch-type/integer
   [_query _stage-number n _style]
@@ -82,8 +87,13 @@
   (str s))
 
 (defmethod lib.metadata.calculation/display-name-method :expression
-  [_query _stage-number [_expression _opts expression-name] _style]
-  expression-name)
+  [_query _stage-number [_expression {:keys [temporal-unit] :as _opts} expression-name] _style]
+  (letfn [(temporal-format [display-name]
+            (lib.util/format "%s: %s" display-name (-> (name temporal-unit)
+                                                       (str/replace \- \space)
+                                                       u/capitalize-en)))]
+    (cond-> expression-name
+      temporal-unit temporal-format)))
 
 (defmethod lib.metadata.calculation/column-name-method :expression
   [_query _stage-number [_expression _opts expression-name]]
@@ -186,6 +196,14 @@
 (defmethod lib.metadata.calculation/column-name-method :coalesce
   [query stage-number [_coalesce _opts expr _null-expr]]
   (lib.metadata.calculation/column-name query stage-number expr))
+
+(defmethod lib.temporal-bucket/with-temporal-bucket-method :expression
+  [expr-ref unit]
+  (lib.temporal-bucket/add-temporal-bucket-to-ref expr-ref unit))
+
+(defmethod lib.temporal-bucket/temporal-bucket-method :expression
+  [[_expression {:keys [temporal-unit]} _expr-name]]
+  temporal-unit)
 
 #_(defn- conflicting-name? [query stage-number expression-name]
     (let [stage     (lib.util/query-stage query stage-number)

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -319,31 +319,8 @@
   (::temporal-unit metadata))
 
 (defmethod lib.temporal-bucket/with-temporal-bucket-method :field
-  [[_tag options id-or-name] unit]
-  ;; if `unit` is an extraction unit like `:month-of-year`, then the `:effective-type` of the ref changes to
-  ;; `:type/Integer` (month of year returns an int). We need to record the ORIGINAL effective type somewhere in case
-  ;; we need to refer back to it, e.g. to see what temporal buckets are available if we want to change the unit, or if
-  ;; we want to remove it later. We will record this with the key `::original-effective-type`. Note that changing the
-  ;; unit multiple times should keep the original first value of `::original-effective-type`.
-  (if unit
-    (let [extraction-unit?        (contains? lib.schema.temporal-bucketing/datetime-extraction-units unit)
-          original-effective-type ((some-fn ::original-effective-type :effective-type :base-type) options)
-          new-effective-type      (if extraction-unit?
-                                    :type/Integer
-                                    original-effective-type)
-          options                 (assoc options
-                                         :temporal-unit unit
-                                         :effective-type new-effective-type
-                                         ::original-effective-type original-effective-type)]
-      [:field options id-or-name])
-    ;; `unit` is `nil`: remove the temporal bucket.
-    (let [options (if-let [original-effective-type (::original-effective-type options)]
-                    (-> options
-                        (assoc :effective-type original-effective-type)
-                        (dissoc ::original-effective-type))
-                    options)
-          options (dissoc options :temporal-unit)]
-      [:field options id-or-name])))
+  [field-ref unit]
+  (lib.temporal-bucket/add-temporal-bucket-to-ref field-ref unit))
 
 (defmethod lib.temporal-bucket/with-temporal-bucket-method :metadata/column
   [metadata unit]
@@ -381,17 +358,15 @@
 
 (defmethod lib.temporal-bucket/available-temporal-buckets-method :metadata/column
   [_query _stage-number field-metadata]
-  (if (not= (:lib/source field-metadata) :source/expressions)
-    (let [effective-type ((some-fn :effective-type :base-type) field-metadata)
-          fingerprint-default (some-> field-metadata :fingerprint fingerprint-based-default-unit)]
-      (cond-> (cond
-                (isa? effective-type :type/DateTime) lib.temporal-bucket/datetime-bucket-options
-                (isa? effective-type :type/Date)     lib.temporal-bucket/date-bucket-options
-                (isa? effective-type :type/Time)     lib.temporal-bucket/time-bucket-options
-                :else                                [])
-        fingerprint-default              (mark-unit :default fingerprint-default)
-        (::temporal-unit field-metadata) (mark-unit :selected (::temporal-unit field-metadata))))
-    []))
+  (let [effective-type ((some-fn :effective-type :base-type) field-metadata)
+        fingerprint-default (some-> field-metadata :fingerprint fingerprint-based-default-unit)]
+    (cond-> (cond
+              (isa? effective-type :type/DateTime) lib.temporal-bucket/datetime-bucket-options
+              (isa? effective-type :type/Date)     lib.temporal-bucket/date-bucket-options
+              (isa? effective-type :type/Time)     lib.temporal-bucket/time-bucket-options
+              :else                                [])
+      fingerprint-default              (mark-unit :default fingerprint-default)
+      (::temporal-unit field-metadata) (mark-unit :selected (::temporal-unit field-metadata)))))
 
 ;;; ---------------------------------------- Binning ---------------------------------------------
 

--- a/src/metabase/lib/schema/ref.cljc
+++ b/src/metabase/lib/schema/ref.cljc
@@ -73,8 +73,17 @@
   (or ((some-fn :effective-type :base-type) opts)
       ::expression/type.unknown))
 
-(mbql-clause/define-tuple-mbql-clause :expression
-  #_expression-name ::common/non-blank-string)
+(mr/def ::expression.options
+  [:merge
+   ::common/options
+   [:map
+    [:temporal-unit                              {:optional true} [:ref ::temporal-bucketing/unit]]]])
+
+(mbql-clause/define-mbql-clause :expression
+  [:tuple
+   [:= {:decode/normalize common/normalize-keyword} :expression]
+   [:ref ::expression.options]
+   [:ref #_expression-name ::common/non-blank-string]])
 
 (defmethod expression/type-of-method :expression
   [[_tag opts _expression-name]]

--- a/src/metabase/lib/temporal_bucket.cljc
+++ b/src/metabase/lib/temporal_bucket.cljc
@@ -243,3 +243,34 @@
   [temporal-column
    temporal-value :- [:or :int :string]]
   (shared.ut/format-unit temporal-value (:unit (temporal-bucket temporal-column))))
+
+(defn add-temporal-bucket-to-ref
+  "Internal helper shared between a few implementations of [[with-temporal-bucket-method]].
+
+  Not intended to be called otherwise."
+  [[tag options id-or-name] unit]
+  ;; if `unit` is an extraction unit like `:month-of-year`, then the `:effective-type` of the ref changes to
+  ;; `:type/Integer` (month of year returns an int). We need to record the ORIGINAL effective type somewhere in case
+  ;; we need to refer back to it, e.g. to see what temporal buckets are available if we want to change the unit, or if
+  ;; we want to remove it later. We will record this with the key `::original-effective-type`. Note that changing the
+  ;; unit multiple times should keep the original first value of `::original-effective-type`.
+  (if unit
+    (let [extraction-unit?        (contains? lib.schema.temporal-bucketing/datetime-extraction-units unit)
+          original-effective-type ((some-fn :metabase.lib.field/original-effective-type :effective-type :base-type)
+                                   options)
+          new-effective-type      (if extraction-unit?
+                                    :type/Integer
+                                    original-effective-type)
+          options                 (assoc options
+                                         :temporal-unit unit
+                                         :effective-type new-effective-type
+                                         :metabase.lib.field/original-effective-type original-effective-type)]
+      [tag options id-or-name])
+    ;; `unit` is `nil`: remove the temporal bucket.
+    (let [options (if-let [original-effective-type (:metabase.lib.field/original-effective-type options)]
+                    (-> options
+                        (assoc :effective-type original-effective-type)
+                        (dissoc :metabase.lib.field/original-effective-type))
+                    options)
+          options (dissoc options :temporal-unit)]
+      [tag options id-or-name])))

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -138,6 +138,8 @@
 
     [:field _ (_ :guard :temporal-unit)]
     true
+    [:expression _ (_ :guard :temporal-unit)]
+    true
 
     :+
     (some (partial mbql.u/is-clause? :interval) (rest clause))
@@ -223,14 +225,16 @@
           [:expression expression-name])))))
 
 (defn- col-info-for-expression
-  [inner-query [_expression expression-name :as clause]]
+  [inner-query [_expression expression-name {:keys [temporal-unit] :as _opts} :as clause]]
   (merge
    (infer-expression-type (mbql.u/expression-with-name inner-query expression-name))
    {:name            expression-name
     :display_name    expression-name
     ;; provided so the FE can add easily add sorts and the like when someone clicks a column header
     :expression_name expression-name
-    :field_ref       (fe-friendly-expression-ref clause)}))
+    :field_ref       (fe-friendly-expression-ref clause)}
+   (when temporal-unit
+     {:unit temporal-unit})))
 
 (mu/defn- col-info-for-field-clause*
   [{:keys [source-metadata], :as inner-query} [_ id-or-name opts :as clause] :- mbql.s/field]

--- a/src/metabase/query_processor/middleware/parameters/mbql.clj
+++ b/src/metabase/query_processor/middleware/parameters/mbql.clj
@@ -109,8 +109,10 @@
                        :unit       new-unit})))
     (lib.util.match/replace-in
       query [:query :breakout]
-      [:field (_ :guard #(= target-field-id %)) (opts :guard #(= temporal-unit (:temporal-unit %)))]
-      [:field target-field-id (assoc opts :temporal-unit new-unit)])))
+      [(tag :guard #{:field :expression})
+       (_ :guard #(= target-field-id %))
+       (opts :guard #(= temporal-unit (:temporal-unit %)))]
+      [tag target-field-id (assoc opts :temporal-unit new-unit)])))
 
 (defn expand
   "Expand parameters for MBQL queries in `query` (replacing Dashboard or Card-supplied params with the appropriate


### PR DESCRIPTION
Fixes #47341.

### Description

The QP now supports temporal bucketing of custom expressions, but that has
not been surfaced in the UI until now.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Use a database other than H2, since it doesn't support time zones.
1. New question -> Anything with a DateTime column
1. Create a custom expression like `convertTimezone([Date Column], "America/New_York", "UTC")`
1. Break out by that expression

The temporal bucketing should work in the UI and in the query results, save properly, etc.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
