### PR TITLE
fix formatting applied to percent change

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js
@@ -517,6 +517,31 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
   });
 
   describe("> single series question grouped by month on dashboard", () => {
+    it("it should not apply formatting to the percent change", () => {
+      setup({
+        question: {
+          ...SUM_OF_TOTAL_MONTH,
+          visualization_settings: {
+            column_settings: {
+              '["name","sum"]': {
+                prefix: "pref",
+                suffix: "suf",
+              },
+            },
+          },
+        },
+      }).then(dashboardId => {
+        visitDashboard(dashboardId);
+      });
+
+      showTooltipForCircleInSeries("#88BF4D", 1);
+      testTooltipPairs([
+        ["Created At", "May 2022"],
+        ["Sum of Total", "pref1,265.72suf"],
+        ["Compared to previous month", "+2,299.19%"],
+      ]);
+    });
+
     it("should show percent change in tooltip for timeseries axis", () => {
       setup({
         question: SUM_OF_TOTAL_MONTH,

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
@@ -254,7 +254,7 @@ const getTooltipFooterData = (
   return [
     {
       key: DATETIME_ABSOLUTE_UNIT_COMPARISON[unit],
-      col: seriesModel.column,
+      col: null,
       value: formatChangeWithSign(change),
     },
   ];


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/47373

### Description

Describe the overall approach and the problem being solved. There is no such issue in `master` branch because we've reworked tooltips.

### How to verify

- Create a time series line/area/bar chart
- Apply formatting to the metric column: apply prefix/suffix
- Hover chart data points to see the tooltip
- Ensure the formatting has not applied to the percent change

### Demo

<img width="648" alt="Screenshot 2024-08-29 at 6 20 22 PM" src="https://github.com/user-attachments/assets/3ba600ed-9cdb-4167-b4a0-f20a2899fc92">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
