### PR TITLE
Snowflake Variant Type should not prevent downloads or attachments

### DIFF
--- a/test/metabase/formatter_test.clj
+++ b/test/metabase/formatter_test.clj
@@ -175,3 +175,14 @@
     (testing "We handle missing values"
       (is (= ""
              (formatter/format-geographic-coordinates :type/Longitude nil))))))
+
+(deftest ambiguous-column-types-test
+  (testing "Ambiguous column types (eg. `:type/SnowflakeVariant` pass through the formatter without error (#46981)"
+    (let [format (fn [value viz]
+                   (str ((formatter/number-formatter {:id 1
+                                                      :base_type :type/SnowflakeVariant}
+                                                     {::mb.viz/column-settings
+                                                      {{::mb.viz/field-id 1} viz}})
+                         value)))]
+      (is (= "variant works"
+             (format "variant works" {}))))))


### PR DESCRIPTION
Fixes #46981

The :type/SnowflakeVariant key matches 2 methods in `metabase.query-processor.streaming.common/global-type-settings`.

In this case, it seems that the variant type can be any type, so we shouldn't try to guess anything here, except if the user has provided a :semantic_type, which we can use.

Otherwise, we'll keep going without formatting details about the variant column, which is likely fine already, as it should result in strings in the export/attachments.