### PR TITLE
fix formatting null values adds prefix and suffix

### DIFF
--- a/frontend/src/metabase/lib/formatting/value.tsx
+++ b/frontend/src/metabase/lib/formatting/value.tsx
@@ -80,7 +80,7 @@ export function formatValue(value: unknown, _options: OptionsType = {}) {
       return formatted;
     }
   }
-  if (prefix || suffix) {
+  if ((prefix || suffix) && formatted != null) {
     if (options.jsx && typeof formatted !== "string") {
       return (
         <span>

--- a/frontend/src/metabase/lib/formatting/value.unit.spec.tsx
+++ b/frontend/src/metabase/lib/formatting/value.unit.spec.tsx
@@ -53,6 +53,16 @@ describe("link", () => {
     expect(screen.getByText("23.12")).toBeInTheDocument();
   });
 
+  it("should not apply prefix or suffix to null values", () => {
+    setup(null, {
+      prefix: "foo ",
+      suffix: " bar",
+    });
+
+    const anyContent = screen.queryByText(/./);
+    expect(anyContent).not.toBeInTheDocument();
+  });
+
   it("should trim values to specified decimals", () => {
     setup(23.123459, {
       decimals: 5,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/42867

### Description

Fixes formatting: when formatting `null` we should ignore suffix and prefix and just return null to avoid strings `prefix_null_suffix`

### How to verify

To repro it on a pivot table as in the issue create the following sql query in H2 sample DB:
```sql
SELECT 
    id,
    CASE 
        WHEN id % 3 = 0 THEN 'Category A'
        WHEN id % 3 = 1 THEN 'Category B'
        ELSE 'Category C'
    END AS category1,
    CASE 
        WHEN id % 4 = 0 THEN 'Type 1'
        WHEN id % 4 = 1 THEN 'Type 2'
        WHEN id % 4 = 2 THEN 'Type 3'
        ELSE 'Type 4'
    END AS category2,
    CASE 
        WHEN id % 5 = 0 THEN 'Region X'
        WHEN id % 5 = 1 THEN 'Region Y'
        WHEN id % 5 = 2 THEN 'Region Z'
        WHEN id % 5 = 3 THEN 'Region W'
        ELSE 'Region V'
    END AS category3,
    CASE WHEN id % 2 = 0 THEN ROUND(RAND() * 1000, 2) ELSE NULL END AS metric1,
    CASE WHEN id % 2 = 1 THEN ROUND(RAND() * 100, 2) ELSE NULL END AS metric2,
    CASE WHEN id % 2 = 0 THEN ROUND(RAND() * 50, 2) ELSE NULL END AS metric3
FROM SYSTEM_RANGE(1, 50) AS t(id)
```

Click Explore results, and create the following pivot table:
<img width="1042" alt="Screenshot 2024-08-29 at 7 53 57 PM" src="https://github.com/user-attachments/assets/943bd29f-b1b5-4b9f-95fb-c6f8c1fbece4">

Add prefix and suffix to metric columns and ensure nulls are not rendered as `prefix_null_suffix`.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
