### PR TITLE
Update serialization fixtures to track new database field

### DIFF
--- a/test_resources/serialization_baseline/databases/My Database/My Database.yaml
+++ b/test_resources/serialization_baseline/databases/My Database/My Database.yaml
@@ -11,8 +11,9 @@ is_full_sync: true
 is_on_demand: false
 is_sample: false
 is_audit: false
-metadata_sync_schedule: 0 17 * * * ? *
-cache_field_values_schedule: 0 0 18 * * ? *
+is_attached_dwh: false
+metadata_sync_schedule: 0 9 * * * ? *
+cache_field_values_schedule: 0 0 12 * * ? *
 settings:
   database-source-dataset-name: test-data
 caveats: null

--- a/test_resources/serialization_baseline/databases/test-data (h2)/test-data (h2).yaml
+++ b/test_resources/serialization_baseline/databases/test-data (h2)/test-data (h2).yaml
@@ -16,8 +16,9 @@ is_full_sync: true
 is_on_demand: false
 is_sample: false
 is_audit: false
-metadata_sync_schedule: 0 8 * * * ? *
-cache_field_values_schedule: 0 0 19 * * ? *
+is_attached_dwh: false
+metadata_sync_schedule: 0 3 * * * ? *
+cache_field_values_schedule: 0 0 11 * * ? *
 settings:
   database-source-dataset-name: test-data
 caveats: null


### PR DESCRIPTION
An extra field was added to the dump in parallel to us adding the end-to-end tests.
