### PR TITLE
Add isLoadingTabs prop to EntityPicker

### DIFF
--- a/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
+++ b/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
@@ -67,7 +67,12 @@ export const DataPickerModal = ({
   onClose,
 }: Props) => {
   const hasNestedQueriesEnabled = useSetting("enable-nested-queries");
-  const { hasQuestions, hasModels, hasMetrics } = useAvailableData({
+  const {
+    hasQuestions,
+    hasModels,
+    hasMetrics,
+    isLoading: isLoadingAvailableData,
+  } = useAvailableData({
     databaseId,
   });
 
@@ -210,6 +215,7 @@ export const DataPickerModal = ({
       onClose={onClose}
       onItemSelect={handleChange}
       recentsContext={["selections"]}
+      isLoadingTabs={isLoadingAvailableData}
     />
   );
 };

--- a/frontend/src/metabase/common/components/DataPicker/hooks/useAvailableData.ts
+++ b/frontend/src/metabase/common/components/DataPicker/hooks/useAvailableData.ts
@@ -6,7 +6,7 @@ interface Props {
 }
 
 export const useAvailableData = ({ databaseId }: Props = {}) => {
-  const { data } = useSearchQuery(
+  const { data, isLoading } = useSearchQuery(
     {
       limit: 0,
       models: ["card"],
@@ -22,6 +22,7 @@ export const useAvailableData = ({ databaseId }: Props = {}) => {
   const hasMetrics = availableModels.includes("metric");
 
   return {
+    isLoading,
     hasQuestions,
     hasModels,
     hasMetrics,

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
@@ -22,6 +22,7 @@ import type {
   TypeWithModel,
 } from "../../types";
 import { EntityPickerSearchInput } from "../EntityPickerSearch/EntityPickerSearch";
+import { LoadingSpinner } from "../LoadingSpinner";
 import { RecentsTab } from "../RecentsTab";
 
 import { ButtonBar } from "./ButtonBar";
@@ -70,6 +71,7 @@ export interface EntityPickerModalProps<Model extends string, Item> {
   defaultToRecentTab?: boolean;
   /**recentsContext: Defaults to returning recents based off both views and selections. Can be overridden by props */
   recentsContext?: RecentContexts[];
+  isLoadingTabs?: boolean;
 }
 
 export function EntityPickerModal<
@@ -93,6 +95,7 @@ export function EntityPickerModal<
   searchParams,
   defaultToRecentTab = true,
   recentsContext = ["selections", "views"],
+  isLoadingTabs = false,
 }: EntityPickerModalProps<Model, Item>) {
   const [searchQuery, setSearchQuery] = useState<string>("");
   const { data: recentItems, isLoading: isLoadingRecentItems } =
@@ -220,34 +223,38 @@ export function EntityPickerModal<
           <Modal.CloseButton size={21} pos="relative" top="1px" />
         </Modal.Header>
         <ModalBody p="0">
-          <ErrorBoundary>
-            {hasTabs ? (
-              <TabsView
-                tabs={tabs}
-                onItemSelect={onItemSelect}
-                searchQuery={searchQuery}
-                searchResults={searchResults}
-                selectedItem={selectedItem}
-                initialValue={initialValue}
-                defaultToRecentTab={defaultToRecentTab}
-                setShowActionButtons={setShowActionButtons}
-              />
-            ) : (
-              <SinglePickerView data-testid="single-picker-view">
-                {tabs?.[0]?.element}
-              </SinglePickerView>
-            )}
-            {!!hydratedOptions.hasConfirmButtons && onConfirm && (
-              <ButtonBar
-                onConfirm={onConfirm}
-                onCancel={onClose}
-                canConfirm={canSelectItem}
-                actionButtons={showActionButtons ? actionButtons : []}
-                confirmButtonText={options?.confirmButtonText}
-                cancelButtonText={options?.cancelButtonText}
-              />
-            )}
-          </ErrorBoundary>
+          {!isLoadingTabs && !isLoadingRecentItems ? (
+            <ErrorBoundary>
+              {hasTabs ? (
+                <TabsView
+                  tabs={tabs}
+                  onItemSelect={onItemSelect}
+                  searchQuery={searchQuery}
+                  searchResults={searchResults}
+                  selectedItem={selectedItem}
+                  initialValue={initialValue}
+                  defaultToRecentTab={defaultToRecentTab}
+                  setShowActionButtons={setShowActionButtons}
+                />
+              ) : (
+                <SinglePickerView data-testid="single-picker-view">
+                  {tabs?.[0]?.element}
+                </SinglePickerView>
+              )}
+              {!!hydratedOptions.hasConfirmButtons && onConfirm && (
+                <ButtonBar
+                  onConfirm={onConfirm}
+                  onCancel={onClose}
+                  canConfirm={canSelectItem}
+                  actionButtons={showActionButtons ? actionButtons : []}
+                  confirmButtonText={options?.confirmButtonText}
+                  cancelButtonText={options?.cancelButtonText}
+                />
+              )}
+            </ErrorBoundary>
+          ) : (
+            <LoadingSpinner />
+          )}
         </ModalBody>
       </ModalContent>
     </Modal.Root>

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
@@ -6,7 +6,8 @@ import ErrorBoundary from "metabase/ErrorBoundary";
 import { useListRecentsQuery } from "metabase/api";
 import { BULK_ACTIONS_Z_INDEX } from "metabase/components/BulkActionBar";
 import { useModalOpen } from "metabase/hooks/use-modal-open";
-import { Modal } from "metabase/ui";
+import { Box, Flex, Modal, Skeleton } from "metabase/ui";
+import { Repeat } from "metabase/ui/components/feedback/Skeleton/Repeat";
 import type {
   RecentContexts,
   RecentItem,
@@ -22,7 +23,6 @@ import type {
   TypeWithModel,
 } from "../../types";
 import { EntityPickerSearchInput } from "../EntityPickerSearch/EntityPickerSearch";
-import { LoadingSpinner } from "../LoadingSpinner";
 import { RecentsTab } from "../RecentsTab";
 
 import { ButtonBar } from "./ButtonBar";
@@ -253,7 +253,7 @@ export function EntityPickerModal<
               )}
             </ErrorBoundary>
           ) : (
-            <LoadingSpinner />
+            <EntityPickerLoadingSkeleton />
           )}
         </ModalBody>
       </ModalContent>
@@ -271,3 +271,23 @@ const assertValidProps = (
     );
   }
 };
+
+const EntityPickerLoadingSkeleton = () => (
+  <Box data-testid="loading-indicator">
+    <Flex px="2rem" gap="1.5rem" mb="3.5rem">
+      <Repeat times={3}>
+        <Skeleton h="2rem" w="5rem" mb="0.5rem" />
+      </Repeat>
+    </Flex>
+    <Flex px="2rem" mb="2.5rem" direction="column">
+      <Repeat times={2}>
+        <Skeleton h="3rem" mb="0.5rem" />
+      </Repeat>
+    </Flex>
+    <Flex px="2rem" direction="column">
+      <Repeat times={3}>
+        <Skeleton h="3rem" mb="0.5rem" />
+      </Repeat>
+    </Flex>
+  </Box>
+);

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.unit.spec.tsx
@@ -39,6 +39,8 @@ interface SetupOpts {
   defaultToRecentTab?: boolean;
   initialValue?: { model: SampleModelType };
   searchDelay?: number;
+  recentsDelay?: number;
+  isLoadingTabs?: boolean;
 }
 
 const TestPicker = ({ name }: { name: string }) => (
@@ -86,11 +88,14 @@ const setup = ({
   recentItems = [],
   recentFilter,
   searchDelay = 0,
+  recentsDelay = 0,
   ...rest
 }: SetupOpts = {}) => {
   mockGetBoundingClientRect();
   mockScrollBy();
-  setupRecentViewsAndSelectionsEndpoints(recentItems);
+  setupRecentViewsAndSelectionsEndpoints(recentItems, ["selections", "views"], {
+    delay: recentsDelay,
+  });
 
   fetchMock.get("path:/api/search", mockSearchResults, { delay: searchDelay });
 
@@ -114,6 +119,15 @@ const setup = ({
 describe("EntityPickerModal", () => {
   afterEach(() => {
     jest.restoreAllMocks();
+  });
+
+  it("should show a loading state when isLoadingTabs is true", async () => {
+    setup({
+      isLoadingTabs: true,
+    });
+
+    expect(await screen.findByTestId("loading-indicator")).toBeInTheDocument();
+    expect(screen.queryByRole("tab")).not.toBeInTheDocument();
   });
 
   it("should throw when options.hasConfirmButtons is true but onConfirm prop is missing", async () => {
@@ -407,6 +421,25 @@ describe("EntityPickerModal", () => {
 
       expect(
         await screen.findByRole("button", { name: "Click Me" }),
+      ).toBeInTheDocument();
+    });
+
+    it("should wait until all tabs are determined before rendering", async () => {
+      setup({
+        recentsDelay: 500,
+        recentItems,
+      });
+
+      expect(
+        await screen.findByTestId("loading-indicator"),
+      ).toBeInTheDocument();
+
+      expect(
+        screen.queryByRole("tab", { name: /Recents/ }),
+      ).not.toBeInTheDocument();
+
+      expect(
+        await screen.findByRole("tab", { name: /Recents/ }),
       ).toBeInTheDocument();
     });
   });

--- a/frontend/src/metabase/ui/components/feedback/Skeleton/Skeleton.styled.tsx
+++ b/frontend/src/metabase/ui/components/feedback/Skeleton/Skeleton.styled.tsx
@@ -16,10 +16,10 @@ export const getSkeletonOverrides = (): MantineThemeOverride["components"] => {
         return {
           // We replace Mantine's pulsing animation with a shimmer animation
           root: {
-            backgroundColor: "rgba(0, 0, 0, .03)",
+            backgroundColor: "var(--mb-color-bg-light)",
             "&::before": {
               background:
-                "linear-gradient(100deg, transparent, rgba(0, 0, 0, .03) 50%, transparent) ! important",
+                "linear-gradient(100deg, transparent, var(--mb-color-bg-medium), transparent) ! important",
               animation: `${shimmerAnimation} 1.4s linear infinite`,
             },
             "&::after": {

--- a/frontend/src/metabase/ui/components/feedback/Skeleton/Skeleton.styled.tsx
+++ b/frontend/src/metabase/ui/components/feedback/Skeleton/Skeleton.styled.tsx
@@ -16,7 +16,7 @@ export const getSkeletonOverrides = (): MantineThemeOverride["components"] => {
         return {
           // We replace Mantine's pulsing animation with a shimmer animation
           root: {
-            backgroundColor: "var(--mb-color-bg-light)",
+            backgroundColor: "rgba(245,248,250,1.0)",
             "&::before": {
               background:
                 "linear-gradient(100deg, transparent, var(--mb-color-bg-medium), transparent) ! important",

--- a/frontend/test/__support__/server-mocks/activity.ts
+++ b/frontend/test/__support__/server-mocks/activity.ts
@@ -1,4 +1,4 @@
-import fetchMock from "fetch-mock";
+import fetchMock, { type MockOptionsMethodGet } from "fetch-mock";
 import querystring from "querystring";
 
 import type {
@@ -17,6 +17,7 @@ export function setupRecentViewsEndpoints(recentItems: RecentItem[]) {
 export function setupRecentViewsAndSelectionsEndpoints(
   recentItems: RecentItem[],
   context: RecentContexts[] = ["selections", "views"],
+  mockOptions: MockOptionsMethodGet = {},
 ) {
   fetchMock.get(
     url =>
@@ -26,6 +27,7 @@ export function setupRecentViewsAndSelectionsEndpoints(
     {
       recents: recentItems,
     },
+    { ...mockOptions },
   );
 
   fetchMock.post("path:/api/activity/recents", 200);


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/46775

### Description
Sometimes when displaying the entity picker, we need to do some async work to determine what tabs need to be shown. This means that as it's determined that tabs are valid, they will become available. This PR introduces 2 changes:

- Introduces an `isLoadingTabs` prop to the `EntityPickerModal` that can be managed by the parent
- Uses `isLoadingTabs` and `isLoadingRecents` to conditionally show a ~loading spinner~ skeleton content while tabs are being determined

This allows us to manage the tabs we pass in, as well as the tabs that are conditionally added by the `EntityPickerModal`

### How to verify
1. Find a way to slow down `/api/activity/recents?context=selections`
2. Go to New -> Question
3. You should see a loading state until the call to recents is done, and all tabs will appear at the same time

### Demo
![chrome_uqfEOEaMoT](https://github.com/user-attachments/assets/b5eb9717-de64-4d7e-a371-54956d373962)

### Checklist
- [x] Tests have been added/updated to cover changes in this PR
