### PR TITLE
Notifications Followup

### DIFF
--- a/frontend/src/metabase/admin/settings/notifications/WebhookForm.tsx
+++ b/frontend/src/metabase/admin/settings/notifications/WebhookForm.tsx
@@ -127,7 +127,7 @@ const renderAuthSection = (type: string) => {
             <FormTextInput
               name="auth-info-key"
               label={t`Key`}
-              placeholder={t`API Key`}
+              placeholder={t`X-API-KEY`}
               {...styles}
               mb="1.5rem"
             />

--- a/frontend/src/metabase/admin/settings/slack/components/SlackSettings/SlackSettings.tsx
+++ b/frontend/src/metabase/admin/settings/slack/components/SlackSettings/SlackSettings.tsx
@@ -1,7 +1,18 @@
+import cx from "classnames";
 import { useCallback, useEffect, useState } from "react";
+import { t } from "ttag";
+
+import Breadcrumbs from "metabase/components/Breadcrumbs";
+import CS from "metabase/css/core/index.css";
+import { Stack } from "metabase/ui";
 
 import SlackSetup from "../../containers/SlackSetup";
 import SlackStatus from "../../containers/SlackStatus";
+
+const BREADCRUMBS = [
+  [t`Notification channels`, "/admin/settings/notifications"],
+  ["Slack"],
+];
 
 export interface SlackSettingsProps {
   isApp?: boolean;
@@ -29,7 +40,12 @@ const SlackSettings = ({
     handleMount();
   }, [isApp, handleMount]);
 
-  return isApp ? <SlackStatus /> : <SlackSetup manifest={manifest} />;
+  return (
+    <Stack>
+      <Breadcrumbs crumbs={BREADCRUMBS} className={cx(CS.mb2, CS.pl2)} />
+      {isApp ? <SlackStatus /> : <SlackSetup manifest={manifest} />}
+    </Stack>
+  );
 };
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/47452

### Description
Adds breadcrumbs to the Slack admin page, updates placeholder text and adds some more e2e tests

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Admin -> Settings -> Notification Channels -> Slack
2. You should see breadcrumbs near the top of the page
3. Go back to notifications and open the form to create a new webhook
4. Choose API Key as your auth type, and note the updated placeholder for `Key`

### Demo

![image](https://github.com/user-attachments/assets/329a39de-ab36-423e-8e4f-8fc2154499e7)
![image](https://github.com/user-attachments/assets/b848d440-f23f-475e-950f-cb2c7832773f)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
