### PR TITLE
Fix Trash migration

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -8136,12 +8136,13 @@ databaseChangeLog:
       id: v50.2024-05-14T12:42:42
       author: johnswanson
       comment: Create the Trash collection
+      validCheckSum: ANY
       changes:
         - sql:
             sql: >-
               INSERT INTO collection (name, slug, entity_id, type) VALUES ('Trash', 'trash', 'trashtrashtrashtrasht', 'trash');
-              INSERT INTO permissions (object, group_id)
-              SELECT CONCAT('/collection/', c.id, '/'), pg.id
+              INSERT INTO permissions (object, group_id, perm_type, perm_value, collection_id)
+              SELECT CONCAT('/collection/', c.id, '/'), pg.id, 'perms/collection-access', 'read-and-write', c.id
               FROM collection c
               CROSS JOIN permissions_group pg
               WHERE c.type = 'trash' AND pg.name != 'Administrators';


### PR DESCRIPTION
The Trash migration was added a long time ago.

We recently added a v49 migration to add and populate the columns `perm_type`, `perm_value`, and `collection_id` to the `permissions` table.

If the Trash migration runs first, everything is ok: we create the trash and the relevant permissions rows, and then the v49 migration runs and populates the `perm_type`, `perm_value`, and `collection_id` columns.

However, if the v49 migration runs first, everything is not ok: we create and populate the columns, *then* create the Trash permissions, which end up with `null` values for those columns.

This change modifies the Trash migration to populate the missing columns.

I am confused that this is passing CI - locally, I get test failures without this change.