### PR TITLE
Use function arguments rather than a dynamic var

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/load.clj
@@ -148,7 +148,7 @@
   [entity]
   (lib.util.match/replace entity
     ;; handle legacy `:field-id` forms encoded prior to 0.39.0
-    ;; and also *current* expresion forms used in parameter mapping dimensions
+    ;; and also *current* expression forms used in parameter mapping dimensions
     ;; example relevant clause - [:dimension [:fk-> [:field-id 1] [:field-id 2]]]
     [:field-id (fully-qualified-name :guard string?)]
     (mbql-fully-qualified-names->ids* [:field fully-qualified-name nil])

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -449,11 +449,12 @@
                :cache_ttl]
    :transform {:created_at          (serdes/date)
                ;; details should be imported if available regardless of options
-               :details             {:export (fn [details]
-                                               (if (and include-database-secrets
-                                                        (not (:is_attached_dwh serdes/*current*)))
-                                                 details
-                                                 ::serdes/skip))
+               :details             {:export-with-context
+                                     (fn [current _ details]
+                                       (if (and include-database-secrets
+                                                (not (:is_attached_dwh current)))
+                                         details
+                                         ::serdes/skip))
                                      :import identity}
                :creator_id          (serdes/fk :model/User)
                :initial_sync_status {:export identity :import (constantly "complete")}}})

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -596,9 +596,9 @@
                :type         (serdes/kw)
                :field_id     {::serdes/fk true
                               :export     (constantly ::serdes/skip)
-                              :import     (fn [_]
-                                            (let [field-ref (field-path->field-ref (serdes/path serdes/*current*))]
-                                              (serdes/*import-field-fk* field-ref)))}}})
+                              :import-with-context (fn [current _ _]
+                                                     (let [field-ref (field-path->field-ref (serdes/path current))]
+                                                       (serdes/*import-field-fk* field-ref)))}}})
 
 (defmethod serdes/load-update! "FieldValues" [_ ingested local]
   ;; It's illegal to change the :type and :hash_key fields, and there's a pre-update check for this.

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -110,8 +110,6 @@
 ;;;    - For entities that existed before the column was added, have a portable way to rebuild them (see below on
 ;;;      hashing).
 
-(def ^:dynamic *current* "Instance/map being exported/imported currently" nil)
-
 (defmulti entity-id
   "Given the model name and an entity, returns its entity ID (which might be nil).
 
@@ -394,6 +392,13 @@
   {:arglists '([model-name opts])}
   (fn [model-name _opts] model-name))
 
+(defn- assert-one-defined [m k1 k2]
+  (if (contains? m k1)
+    (assert (not (contains? m k2))
+            (format "Transform must not define both %s and %s" k1 k2))
+    (assert (contains? m k2)
+            (format "Transform must define one of %s or %s" k1 k2))))
+
 (defn extract-one
   "Extracts a single entity retrieved from the database into a portable map with `:serdes/meta` attached.
   `(extract-one \"ModelName\" opts entity)`
@@ -404,24 +409,27 @@
   - Replace any foreign keys with portable values (eg. entity IDs, or a user ID with their email, etc.)"
   [model-name opts instance]
   (try
-    (binding [*current* instance]
-      (let [spec (make-spec model-name opts)]
-        (assert spec (str "No serialization spec defined for model " model-name))
-        (-> (select-keys instance (:copy spec))
-            ;; won't assoc if `generate-path` returned `nil`
-            (m/assoc-some :serdes/meta (generate-path model-name instance))
-            (into (for [[k transform] (:transform spec)
-                        :let  [export-k (:as transform k)
-                               res ((:export transform) (get instance k))]
-                        :when (not= res ::skip)]
-                    (do
-                      (when-not (contains? instance k)
-                        (throw (ex-info (format "Key %s not found, make sure it was hydrated" k)
-                                        {:model    model-name
-                                         :key      k
-                                         :instance instance})))
+    (let [spec (make-spec model-name opts)]
+      (assert spec (str "No serialization spec defined for model " model-name))
+      (-> (select-keys instance (:copy spec))
+          ;; won't assoc if `generate-path` returned `nil`
+          (m/assoc-some :serdes/meta (generate-path model-name instance))
+          (into (for [[k transform] (:transform spec)
+                      :let [_         (assert-one-defined transform :export :export-with-context)
+                            export-k  (:as transform k)
+                            input     (get instance k)
+                            f         (:export transform)
+                            f-context (:export-with-context transform)
+                            res       (if f (f input) (f-context instance k input))]
+                      :when (not= res ::skip)]
+                  (do
+                    (when-not (contains? instance k)
+                      (throw (ex-info (format "Key %s not found, make sure it was hydrated" k)
+                                      {:model    model-name
+                                       :key      k
+                                       :instance instance})))
 
-                      [export-k res]))))))
+                    [export-k res])))))
     (catch Exception e
       (throw (ex-info (format "Error extracting %s %s" model-name (:id instance))
                       (assoc (ex-data e) :model model-name :id (:id instance))
@@ -690,23 +698,29 @@
 (defn- xform-one [model-name ingested]
   (let [spec (make-spec model-name nil)]
     (assert spec (str "No serialization spec defined for model " model-name))
-    (binding [*current* ingested]
-      (-> (select-keys ingested (:copy spec))
-          (into (for [[k transform] (:transform spec)
-                      :when         (not (::nested transform))
-                      :let          [import-k (:as transform k)
-                                     res ((:import transform) (get ingested import-k))]
-                      :when         (and (not= res ::skip)
-                                         (or (some? res)
-                                             (contains? ingested import-k)))]
-                  [k res]))))))
+    (-> (select-keys ingested (:copy spec))
+        (into (for [[k transform] (:transform spec)
+                    :when (not (::nested transform))
+                    :let [_         (assert-one-defined transform :import :import-with-context)
+                          import-k  (:as transform k)
+                          input     (get ingested import-k)
+                          f         (:import transform)
+                          f-context (:import-with-context transform)
+                          res       (if f (f input) (f-context ingested k input))]
+                    :when (and (not= res ::skip)
+                               (or (some? res)
+                                   (contains? ingested import-k)))]
+                [k res])))))
 
 (defn- spec-nested! [model-name ingested instance]
-  (binding [*current* instance]
-    (let [spec (make-spec model-name nil)]
-      (doseq [[k transform] (:transform spec)
-              :when         (::nested transform)]
-        ((:import transform) (get ingested k))))))
+  (let [spec (make-spec model-name nil)]
+    (doseq [[k transform] (:transform spec)
+            :when (::nested transform)
+            :let [_         (assert-one-defined transform :import :import-with-context)
+                  input     (get ingested k)
+                  f         (:import transform)
+                  f-context (:import-with-context transform)]]
+      (if f (f input) (f-context instance k input)))))
 
 (defn default-load-one!
   "Default implementation of `load-one!`"
@@ -1074,7 +1088,7 @@
   [entity]
   (lib.util.match/replace entity
     ;; handle legacy `:field-id` forms encoded prior to 0.39.0
-    ;; and also *current* expresion forms used in parameter mapping dimensions
+    ;; and also *current* expression forms used in parameter mapping dimensions
     ;; example relevant clause - [:dimension [:fk-> [:field-id 1] [:field-id 2]]]
     [(:or :field-id "field-id") fully-qualified-name]
     (mbql-fully-qualified-names->ids* [:field fully-qualified-name])
@@ -1525,55 +1539,55 @@
   (let [model-name (name model)
         sorter     (:sort-by opts :created_at)
         key-field  (:key-field opts :entity_id)]
-    {::nested     true
-     :model       model
-     :backward-fk backward-fk
-     :opts        opts
-     :export      (fn [data]
-                    (assert (every? #(t2/instance-of? model %) data)
-                            (format "Nested data is expected to be a %s, not %s" model (t2/model (first data))))
-                    ;; `nil? data` check is for `extract-one` case in tests; make sure to add empty vectors in
-                    ;; `extract-query` implementations for nested collections
-                    (try
-                      (->> (sort-by sorter data)
-                           (mapv #(extract-one model-name opts %)))
-                      (catch Exception e
-                        (throw (ex-info (format "Error exporting nested %s" model)
-                                        {:model     model
-                                         :parent-id (:id *current*)}
-                                        e)))))
-     :import      (fn [lst]
-                    (let [parent-id (:id *current*)
-                          first-eid (some->> (first lst)
-                                             (entity-id model-name))
-                          enrich    (fn [ingested]
-                                      (-> ingested
-                                          (assoc backward-fk parent-id)
-                                          (update :serdes/meta #(or % [{:model model-name :id (get ingested key-field)}]))))]
-                      (cond
-                        (nil? first-eid) ; no entity id, just drop existing stuff
-                        (do (t2/delete! model backward-fk parent-id)
-                            (doseq [ingested lst]
-                              (load-one! (enrich ingested) nil)))
+    {::nested             true
+     :model               model
+     :backward-fk         backward-fk
+     :opts                opts
+     :export-with-context (fn [current _ data]
+                            (assert (every? #(t2/instance-of? model %) data)
+                                    (format "Nested data is expected to be a %s, not %s" model (t2/model (first data))))
+                            ;; `nil? data` check is for `extract-one` case in tests; make sure to add empty vectors in
+                            ;; `extract-query` implementations for nested collections
+                            (try
+                              (->> (sort-by sorter data)
+                                   (mapv #(extract-one model-name opts %)))
+                              (catch Exception e
+                                (throw (ex-info (format "Error exporting nested %s" model)
+                                                {:model     model
+                                                 :parent-id (:id current)}
+                                                e)))))
+     :import-with-context (fn [current _ lst]
+                            (let [parent-id (:id current)
+                                  first-eid (some->> (first lst)
+                                                     (entity-id model-name))
+                                  enrich    (fn [ingested]
+                                              (-> ingested
+                                                  (assoc backward-fk parent-id)
+                                                  (update :serdes/meta #(or % [{:model model-name :id (get ingested key-field)}]))))]
+                              (cond
+                                (nil? first-eid)            ; no entity id, just drop existing stuff
+                                (do (t2/delete! model backward-fk parent-id)
+                                    (doseq [ingested lst]
+                                      (load-one! (enrich ingested) nil)))
 
-                        (entity-id? first-eid) ; proper entity id, match by them
-                        (do (t2/delete! model backward-fk parent-id :entity_id [:not-in (map :entity_id lst)])
-                            (doseq [ingested lst
-                                    :let     [ingested (enrich ingested)
-                                              local    (lookup-by-id model (entity-id model-name ingested))]]
-                              (load-one! ingested local)))
+                                (entity-id? first-eid)      ; proper entity id, match by them
+                                (do (t2/delete! model backward-fk parent-id :entity_id [:not-in (map :entity_id lst)])
+                                    (doseq [ingested lst
+                                            :let [ingested (enrich ingested)
+                                                  local    (lookup-by-id model (entity-id model-name ingested))]]
+                                      (load-one! ingested local)))
 
-                        :else           ; identity hash
-                        (let [incoming  (set (map #(entity-id model-name %) lst))
-                              local     (->> (t2/reducible-select model backward-fk parent-id)
-                                             (into [] (map t2.realize/realize))
-                                             (m/index-by identity-hash))
-                              to-delete (into [] (comp (filter #(contains? incoming (key %)))
-                                                       (map #(:id (val %))))
-                                              local)]
-                          (t2/delete! model :id [:in (map :id to-delete)])
-                          (doseq [ingested lst]
-                            (load-one! (enrich ingested) (get local (entity-id model-name ingested))))))))}))
+                                :else                       ; identity hash
+                                (let [incoming  (set (map #(entity-id model-name %) lst))
+                                      local     (->> (t2/reducible-select model backward-fk parent-id)
+                                                     (into [] (map t2.realize/realize))
+                                                     (m/index-by identity-hash))
+                                      to-delete (into [] (comp (filter #(contains? incoming (key %)))
+                                                               (map #(:id (val %))))
+                                                      local)]
+                                  (t2/delete! model :id [:in (map :id to-delete)])
+                                  (doseq [ingested lst]
+                                    (load-one! (enrich ingested) (get local (entity-id model-name ingested))))))))}))
 
 (def parent-ref "Transformer for parent id for nested entities."
   (constantly
@@ -1594,11 +1608,25 @@
   [k xform]
   (assoc xform :as k))
 
+(defn- compose*
+  "Given two functions that transform the value at `k` within `x`, return their composition."
+  [f g]
+  (fn [m k x]
+    (let [y (g m k x)]
+      (f (assoc m k y) k y))))
+
+(defn- maybe-lift [m k k-context]
+  (let [f         (m k)
+        f-context (m k-context)]
+    (or f-context (fn [_ _ x] (f x)))))
+
 (defn compose
   "Compose two transformations."
   [inner-xform outer-xform]
-  {:export (comp (:export inner-xform) (:export outer-xform))
-   :import (comp (:import outer-xform) (:import inner-xform))})
+  {:export-with-context (compose* (maybe-lift inner-xform :export :export-with-context)
+                                  (maybe-lift outer-xform :export :export-with-context))
+   :import-with-context (compose* (maybe-lift outer-xform :import :import-with-context)
+                                  (maybe-lift inner-xform :import :import-with-context))})
 
 ;;; ## Memoizing appdb lookups
 
@@ -1609,6 +1637,6 @@
     `(binding ~(reduce into []
                        (for [[var-sym var] (ns-interns ns*)
                              :when (::cache (meta var))
-                             :let  [fq-sym (symbol (name ns*) (name var-sym))]]
+                             :let [fq-sym (symbol (name ns*) (name var-sym))]]
                          [fq-sym `(memoize ~fq-sym)]))
        ~@body)))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/47467

### Description

This gets rid of the `serdes/*current*` dynamic variable.

Instead, if you need access to it you can use the `-with-context` variant your transformation function.