### PR TITLE
Fix some minor collections issues

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -9270,6 +9270,24 @@ databaseChangeLog:
                   type: ${text.type}
                   remarks: running, failed, or completed
 
+  - changeSet:
+      id: v51.2024-09-09T15:11:16
+      author: johnswanson
+      comment: add an index for `collection.type`
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - indexExists:
+                tableName: collection
+                indexName: idx_collection_type
+      changes:
+        - createIndex:
+            tableName: collection
+            columns:
+              - column:
+                  name: type
+            indexName: idx_collection_type
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -633,8 +633,7 @@
 
 (defn- annotate-collections
   [parent-coll colls]
-  (let [visible-collection-ids (collection/visible-collection-ids {:include-archived-items :all})
-        descendant-collections (collection/descendants-flat parent-coll (collection/visible-collection-filter-clause
+  (let [descendant-collections (collection/descendants-flat parent-coll (collection/visible-collection-filter-clause
                                                                          :id
                                                                          {:include-archived-items :all}))
 
@@ -668,10 +667,9 @@
 
         ;; the set of collections that contain collections (in terms of *effective* location)
         collections-containing-collections
-        (->> descendant-collections
-             (reduce (fn [accu {:keys [location] :as _coll}]
-                       (let [effective-location (collection/effective-location-path location visible-collection-ids)
-                             parent-id (collection/location-path->parent-id effective-location)]
+        (->> (t2/hydrate descendant-collections :effective_parent)
+             (reduce (fn [accu {:keys [effective_parent] :as _coll}]
+                       (let [parent-id (:id effective_parent)]
                          (conj accu parent-id)))
                      #{}))
 

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -578,8 +578,10 @@
       [:in collection-id-field
        {:select :id
         ;; the `FROM` clause is where we limit the collections to the ones we have permissions on. For a superuser,
-        ;; that's all of them. For regular users, it's a) the collections they have permission in the DB for, and b)
-        ;; their personal collection and its descendants.
+        ;; that's all of them. For regular users, it's:
+        ;; a) the collections they have permission in the DB for,
+        ;; b) the trash collection, and
+        ;; c) their personal collection and its descendants
         :from [(if is-superuser?
                  [:collection :c]
                  [{:union-all [{:select [:c.*]
@@ -595,6 +597,9 @@
                                           [:= :p.perm_value "read-and-write"]
                                           (when (= :read (:permission-level visibility-config))
                                             [:= :p.perm_value "read"])]]}
+                               {:select [[:c.*]]
+                                :from   [[:collection :c]]
+                                :where  [:= :type "trash"]}
                                (when-let [personal-collection-and-descendant-ids (user->personal-collection-and-descendant-ids current-user-id)]
                                  {:select [:c.*]
                                   :from   [[:collection :c]]
@@ -640,18 +645,14 @@
                                              (when-not (collection.root/is-root-collection? parent-coll)
                                                [:not= :c2.id (u/the-id parent-coll)])]}]]]))]}]])))
 
-(def ^{:arglists '([visibility-config])} visible-collection-ids
-  "Returns all collection IDs that are visible given the `visibility-config` passed in. (Config provides knobs for
-  toggling permission level, trash/archive visibility, etc). If you're trying to filter based on this, you should
-  probably try to use `visible-collection-filter-clause` instead.
-
-  Cached for the lifetime of the request, maximum 10 seconds."
+(def ^{:arglists '([visibility-config])} visible-collection-ids*
+  "Impl for `visible-collection-ids`, caches for the lifetime of the request, maximum 10 seconds."
   (memoize/ttl
    ^{::memoize/args-fn (fn [[visibility-config]]
                          (if-let [req-id *request-id*]
                            [req-id api/*current-user-id* visibility-config]
                            [(random-uuid) api/*current-user-id* visibility-config]))}
-   (fn visible-collection-ids*
+   (fn
      [visibility-config]
      (cond-> (t2/select-pks-set :model/Collection {:where (visible-collection-filter-clause :id visibility-config)})
        (should-display-root-collection? visibility-config)
@@ -660,37 +661,34 @@
    ;; large
    :ttl/threshold (* 60 60 1000)))
 
-(mu/defn- effective-location-path* :- [:maybe LocationPath]
-  ([collection :- CollectionWithLocationOrRoot]
-   (when-not (collection.root/is-root-collection? collection)
-     (effective-location-path* (if (:archived_directly collection)
-                                 (trash-path)
-                                 (:location collection))
-                               (visible-collection-ids
-                                {:include-archived-items    (if (:archived collection)
-                                                              :only
-                                                              :exclude)
-                                 :include-trash-collection? true
-                                 :archive-operation-id      (:archive_operation_id collection)
-                                 :permission-level          :read}))))
-  ([real-location-path     :- LocationPath
-    allowed-collection-ids :- VisibleCollections]
-   (apply location-path (for [id    (location-path->ids real-location-path)
-                              :when (contains? allowed-collection-ids id)]
-                          id))))
+(mu/defn visible-collection-ids :- VisibleCollections
+  "Returns all collection IDs that are visible given the `visibility-config` passed in. (Config provides knobs for
+  toggling permission level, trash/archive visibility, etc). If you're trying to filter based on this, you should
+  probably use `visible-collection-filter-clause` instead."
+  [visibility-config :- CollectionVisibilityConfig]
+  (visible-collection-ids* visibility-config))
 
-(mi/define-simple-hydration-method effective-location-path
+(mi/define-batched-hydration-method effective-location-path*
   :effective_location
-  "Given a `location-path` and a set of Collection IDs one is allowed to view (obtained from
-  `visible-collection-ids` above), calculate the 'effective' location path (excluding IDs of
-  Collections for which we do not have read perms) we should show to the User.
+  "Given a seq of `collections`, batch hydrates them with their effective location."
+  [collections]
+  (when (seq collections)
+    (let [collection-ids (visible-collection-ids {:include-archived-items :all
+                                                  :include-trash-collection? true})]
+      (for [collection collections]
+        (assoc collection :effective_location
+               (when-not (or (nil? collection) (collection.root/is-root-collection? collection))
+                 (let [real-location-path (if (:archived_directly collection)
+                                            (trash-path)
+                                            (:location collection))]
+                   (apply location-path (for [id    (location-path->ids real-location-path)
+                                              :when (contains? collection-ids id)]
+                                          id)))))))))
 
-  When called with a single argument, `collection`, this is used as a hydration function to hydrate
-  `:effective_location`."
-  ([collection]
-   (effective-location-path* collection))
-  ([real-location-path allowed-collection-ids]
-   (effective-location-path* real-location-path allowed-collection-ids)))
+(defn effective-location-path
+  "Given a collection, returns the effective location (hiding parts of the path that the current user doesn't have access to)."
+  [collection]
+  (:effective_location (t2/hydrate collection :effective_location)))
 
 (def ^:private effective-parent-fields
   "Fields that should be included when hydrating the `:effective_parent` of a collection. Used for displaying recent views

--- a/test/metabase/models/collection_test.clj
+++ b/test/metabase/models/collection_test.clj
@@ -500,9 +500,10 @@
 
 (deftest effective-ancestors-root-collection-test
   ;; happens if we do, e.g. `(t2/hydrate a-card-in-the-root-collection [:collection :effective_ancestors])`
-  (testing "`nil` and the root collection should get `[]` as their effective_ancestors"
-    (is (= [[] []]
-           (map :effective_ancestors (t2/hydrate [nil collection/root-collection] :effective_ancestors))))))
+  (mt/with-test-user :rasta
+    (testing "`nil` and the root collection should get `[]` as their effective_ancestors"
+      (is (= [[] []]
+             (map :effective_ancestors (t2/hydrate [nil collection/root-collection] :effective_ancestors)))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                              Nested Collections: Descendants & Effective Children                              |

--- a/test/metabase/models/collection_test.clj
+++ b/test/metabase/models/collection_test.clj
@@ -364,26 +364,27 @@
                                             :include-archived-items :all
                                             :include-trash-collection? true})))))))))
 
+(def ^:dynamic ^:private *visible-collection-ids* #{})
+
 (deftest effective-location-path-test
-  (with-redefs [audit/is-collection-id-audit? (constantly false)]
+  (with-redefs [audit/is-collection-id-audit? (constantly false)
+                collection/visible-collection-ids (fn [& _] *visible-collection-ids*)]
     (testing "valid input"
-      (doseq [[args expected] {["/10/20/30/" #{10 20}]    "/10/20/"
-                               ["/10/20/30/" #{10 30}]    "/10/30/"
-                               ["/10/20/30/" #{}]         "/"
-                               ["/10/20/30/" #{10 20 30}] "/10/20/30/"}]
-        (testing (pr-str (cons 'effective-location-path args))
+      (doseq [[[path visible-ids] expected] {["/10/20/30/" #{10 20}]    "/10/20/"
+                                             ["/10/20/30/" #{10 30}]    "/10/30/"
+                                             ["/10/20/30/" #{}]         "/"
+                                             ["/10/20/30/" #{10 20 30}] "/10/20/30/"}]
+        (testing (format "path '%s' with visible ids '%s'" path (pr-str visible-ids))
           (is (= expected
-                 (apply collection/effective-location-path args))))))
+                 (binding [*visible-collection-ids* visible-ids]
+                   (collection/effective-location-path {:location path})))))))
 
     (testing "invalid input"
-      (doseq [args [["/10/20/30/" nil]
-                    ["/10/20/30/" [20]]
-                    [nil #{}]
-                    [[10 20] #{}]]]
-        (testing (pr-str (cons 'effective-location-path args))
+      (doseq [path [nil [10 20]]]
+        (testing (format "path '%s'" path)
           (is (thrown?
                Exception
-               (apply collection/effective-location-path args))))))))
+               (collection/effective-location-path {:location path}))))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                Nested Collections: CRUD Constraints & Behavior                                 |


### PR DESCRIPTION
- explicitly provide access to the trash to all users, in the same way we provide access to personal collections. Due to migration order, we don't necessarily have a permissions row with the correct `perm_type`, `perm_value`, and `collection_id` for the Trash collection. That's ok - we don't actually move things to the Trash, so there isn't any item where `collection_id=$trash.id` - but this may affect things like effective ancestors for children of the trash. Let's be explicit about the permissions that users have.

- replace a case where we manually calculated effective location and then got the parent_id with just hydrating `:effective_parent`. This should be more efficient, and better to have this logic in one place.

- replace the simple hydration method for `effective-location-path` with a batched hydration method that fetches `visible-collection-ids` *once* and then uses it to figure out the effective location path for each collection passed.
