### PR TITLE
POC to investigate EE plugins usage in the sdk

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/public/index.ts
+++ b/enterprise/frontend/src/embedding-sdk/components/public/index.ts
@@ -1,5 +1,5 @@
-import "ee-overrides"; // eslint-disable-line import/no-duplicates
-import "ee-plugins"; // eslint-disable-line import/no-duplicates
+// import "ee-overrides"; // eslint-disable-line import/no-duplicates
+// import "ee-plugins"; // eslint-disable-line import/no-duplicates
 
 export { StaticQuestion } from "./StaticQuestion";
 export { InteractiveQuestion } from "./InteractiveQuestion";

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
@@ -42,123 +42,129 @@ const BLOCK_PERMISSION_OPTION = {
   iconColor: "danger",
 };
 
-if (hasPremiumFeature("advanced_permissions")) {
-  const addSelectedAdvancedPermission = (options, value) => {
-    if (value === IMPERSONATED_PERMISSION_OPTION.value) {
-      return [...options, IMPERSONATED_PERMISSION_OPTION];
-    }
+export const activateAdvancedPermissionsPlugin = () => {
+  if (hasPremiumFeature("advanced_permissions")) {
+    const addSelectedAdvancedPermission = (options, value) => {
+      if (value === IMPERSONATED_PERMISSION_OPTION.value) {
+        return [...options, IMPERSONATED_PERMISSION_OPTION];
+      }
 
-    return options;
+      return options;
+    };
+
+    PLUGIN_ADMIN_PERMISSIONS_TABLE_OPTIONS.push(BLOCK_PERMISSION_OPTION);
+    PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_OPTIONS.push(BLOCK_PERMISSION_OPTION);
+
+    PLUGIN_ADVANCED_PERMISSIONS.addTablePermissionOptions =
+      addSelectedAdvancedPermission;
+    PLUGIN_ADVANCED_PERMISSIONS.addSchemaPermissionOptions =
+      addSelectedAdvancedPermission;
+    PLUGIN_ADVANCED_PERMISSIONS.addDatabasePermissionOptions = (
+      options,
+      database,
+    ) => [
+      ...options,
+      ...(database.hasFeature("connection-impersonation")
+        ? [IMPERSONATED_PERMISSION_OPTION]
+        : []),
+      BLOCK_PERMISSION_OPTION,
+    ];
+
+    PLUGIN_ADMIN_PERMISSIONS_DATABASE_ROUTES.push(
+      <ModalRoute
+        key="impersonated/group/:groupId"
+        path="impersonated/group/:groupId"
+        modal={ImpersonationModal}
+      />,
+    );
+
+    PLUGIN_ADMIN_PERMISSIONS_DATABASE_GROUP_ROUTES.push(
+      <ModalRoute
+        key="impersonated/database/:impersonatedDatabaseId"
+        path="impersonated/database/:impersonatedDatabaseId"
+        modal={ImpersonationModal}
+      />,
+    );
+
+    PLUGIN_ADVANCED_PERMISSIONS.isBlockPermission = value =>
+      value === BLOCK_PERMISSION_OPTION.value;
+
+    PLUGIN_ADVANCED_PERMISSIONS.getDatabaseLimitedAccessPermission = value => {
+      if (value === IMPERSONATED_PERMISSION_OPTION.value) {
+        return DataPermissionValue.UNRESTRICTED;
+      }
+
+      return null;
+    };
+    PLUGIN_ADVANCED_PERMISSIONS.isAccessPermissionDisabled = (
+      value,
+      subject,
+    ) => {
+      if (subject === "tables" || subject === "fields") {
+        return value === DataPermissionValue.IMPERSONATED;
+      } else {
+        return false;
+      }
+    };
+
+    PLUGIN_ADVANCED_PERMISSIONS.isRestrictivePermission = value => {
+      return value === DataPermissionValue.BLOCKED;
+    };
+
+    PLUGIN_ADVANCED_PERMISSIONS.shouldShowViewDataColumn = true;
+
+    PLUGIN_ADVANCED_PERMISSIONS.defaultViewDataPermission =
+      DataPermissionValue.BLOCKED;
+
+    PLUGIN_ADMIN_PERMISSIONS_DATABASE_POST_ACTIONS[
+      DataPermissionValue.IMPERSONATED
+    ] = getImpersonatedPostAction;
+
+    PLUGIN_REDUCERS.advancedPermissionsPlugin =
+      advancedPermissionsSlice.reducer;
+
+    PLUGIN_DATA_PERMISSIONS.permissionsPayloadExtraSelectors.push(
+      (state, data) => {
+        const impersonations = getImpersonations(state);
+        const impersonationGroupIds = impersonations.map(i => `${i.group_id}`);
+        return [{ impersonations }, impersonationGroupIds];
+      },
+    );
+
+    PLUGIN_DATA_PERMISSIONS.hasChanges.push(
+      state => getImpersonations(state).length > 0,
+    );
+
+    PLUGIN_ADMIN_PERMISSIONS_DATABASE_ACTIONS[
+      DataPermissionValue.IMPERSONATED
+    ].push({
+      label: t`Edit Impersonated`,
+      iconColor: "warning",
+      icon: "database",
+      actionCreator: (entityId, groupId, view) =>
+        push(getEditImpersonationUrl(entityId, groupId, view)),
+    });
+
+    PLUGIN_DATA_PERMISSIONS.upgradeViewPermissionsIfNeeded =
+      upgradeViewPermissionsIfNeeded;
+
+    PLUGIN_DATA_PERMISSIONS.shouldRestrictNativeQueryPermissions =
+      shouldRestrictNativeQueryPermissions;
+  }
+
+  const getDatabaseViewImpersonationModalUrl = (entityId, groupId) => {
+    const baseUrl = getDatabaseFocusPermissionsUrl(entityId);
+    return `${baseUrl}/impersonated/group/${groupId}`;
   };
 
-  PLUGIN_ADMIN_PERMISSIONS_TABLE_OPTIONS.push(BLOCK_PERMISSION_OPTION);
-  PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_OPTIONS.push(BLOCK_PERMISSION_OPTION);
+  const getGroupViewImpersonationModalUrl = (entityId, groupId) => {
+    const baseUrl = getGroupFocusPermissionsUrl(groupId);
 
-  PLUGIN_ADVANCED_PERMISSIONS.addTablePermissionOptions =
-    addSelectedAdvancedPermission;
-  PLUGIN_ADVANCED_PERMISSIONS.addSchemaPermissionOptions =
-    addSelectedAdvancedPermission;
-  PLUGIN_ADVANCED_PERMISSIONS.addDatabasePermissionOptions = (
-    options,
-    database,
-  ) => [
-    ...options,
-    ...(database.hasFeature("connection-impersonation")
-      ? [IMPERSONATED_PERMISSION_OPTION]
-      : []),
-    BLOCK_PERMISSION_OPTION,
-  ];
-
-  PLUGIN_ADMIN_PERMISSIONS_DATABASE_ROUTES.push(
-    <ModalRoute
-      key="impersonated/group/:groupId"
-      path="impersonated/group/:groupId"
-      modal={ImpersonationModal}
-    />,
-  );
-
-  PLUGIN_ADMIN_PERMISSIONS_DATABASE_GROUP_ROUTES.push(
-    <ModalRoute
-      key="impersonated/database/:impersonatedDatabaseId"
-      path="impersonated/database/:impersonatedDatabaseId"
-      modal={ImpersonationModal}
-    />,
-  );
-
-  PLUGIN_ADVANCED_PERMISSIONS.isBlockPermission = value =>
-    value === BLOCK_PERMISSION_OPTION.value;
-
-  PLUGIN_ADVANCED_PERMISSIONS.getDatabaseLimitedAccessPermission = value => {
-    if (value === IMPERSONATED_PERMISSION_OPTION.value) {
-      return DataPermissionValue.UNRESTRICTED;
-    }
-
-    return null;
-  };
-  PLUGIN_ADVANCED_PERMISSIONS.isAccessPermissionDisabled = (value, subject) => {
-    if (subject === "tables" || subject === "fields") {
-      return value === DataPermissionValue.IMPERSONATED;
-    } else {
-      return false;
-    }
+    return `${baseUrl}/impersonated/database/${entityId.databaseId}`;
   };
 
-  PLUGIN_ADVANCED_PERMISSIONS.isRestrictivePermission = value => {
-    return value === DataPermissionValue.BLOCKED;
-  };
-
-  PLUGIN_ADVANCED_PERMISSIONS.shouldShowViewDataColumn = true;
-
-  PLUGIN_ADVANCED_PERMISSIONS.defaultViewDataPermission =
-    DataPermissionValue.BLOCKED;
-
-  PLUGIN_ADMIN_PERMISSIONS_DATABASE_POST_ACTIONS[
-    DataPermissionValue.IMPERSONATED
-  ] = getImpersonatedPostAction;
-
-  PLUGIN_REDUCERS.advancedPermissionsPlugin = advancedPermissionsSlice.reducer;
-
-  PLUGIN_DATA_PERMISSIONS.permissionsPayloadExtraSelectors.push(
-    (state, data) => {
-      const impersonations = getImpersonations(state);
-      const impersonationGroupIds = impersonations.map(i => `${i.group_id}`);
-      return [{ impersonations }, impersonationGroupIds];
-    },
-  );
-
-  PLUGIN_DATA_PERMISSIONS.hasChanges.push(
-    state => getImpersonations(state).length > 0,
-  );
-
-  PLUGIN_ADMIN_PERMISSIONS_DATABASE_ACTIONS[
-    DataPermissionValue.IMPERSONATED
-  ].push({
-    label: t`Edit Impersonated`,
-    iconColor: "warning",
-    icon: "database",
-    actionCreator: (entityId, groupId, view) =>
-      push(getEditImpersonationUrl(entityId, groupId, view)),
-  });
-
-  PLUGIN_DATA_PERMISSIONS.upgradeViewPermissionsIfNeeded =
-    upgradeViewPermissionsIfNeeded;
-
-  PLUGIN_DATA_PERMISSIONS.shouldRestrictNativeQueryPermissions =
-    shouldRestrictNativeQueryPermissions;
-}
-
-const getDatabaseViewImpersonationModalUrl = (entityId, groupId) => {
-  const baseUrl = getDatabaseFocusPermissionsUrl(entityId);
-  return `${baseUrl}/impersonated/group/${groupId}`;
+  const getEditImpersonationUrl = (entityId, groupId, view) =>
+    view === "database"
+      ? getDatabaseViewImpersonationModalUrl(entityId, groupId)
+      : getGroupViewImpersonationModalUrl(entityId, groupId);
 };
-
-const getGroupViewImpersonationModalUrl = (entityId, groupId) => {
-  const baseUrl = getGroupFocusPermissionsUrl(groupId);
-
-  return `${baseUrl}/impersonated/database/${entityId.databaseId}`;
-};
-
-const getEditImpersonationUrl = (entityId, groupId, view) =>
-  view === "database"
-    ? getDatabaseViewImpersonationModalUrl(entityId, groupId)
-    : getGroupViewImpersonationModalUrl(entityId, groupId);

--- a/enterprise/frontend/src/metabase-enterprise/application_permissions/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/application_permissions/index.ts
@@ -15,17 +15,22 @@ import {
   settingsPermissionAllowedPathGetter,
 } from "./utils";
 
-if (hasPremiumFeature("advanced_permissions")) {
-  PLUGIN_ADMIN_ALLOWED_PATH_GETTERS.push(monitoringPermissionAllowedPathGetter);
-  PLUGIN_ADMIN_ALLOWED_PATH_GETTERS.push(settingsPermissionAllowedPathGetter);
+export const activateApplicationPermissionsPlugin = () => {
+  if (hasPremiumFeature("advanced_permissions")) {
+    PLUGIN_ADMIN_ALLOWED_PATH_GETTERS.push(
+      monitoringPermissionAllowedPathGetter,
+    );
+    PLUGIN_ADMIN_ALLOWED_PATH_GETTERS.push(settingsPermissionAllowedPathGetter);
 
-  PLUGIN_APPLICATION_PERMISSIONS.getRoutes = getRoutes;
-  PLUGIN_APPLICATION_PERMISSIONS.tabs = [
-    { name: t`Application`, value: `application` },
-  ];
+    PLUGIN_APPLICATION_PERMISSIONS.getRoutes = getRoutes;
+    PLUGIN_APPLICATION_PERMISSIONS.tabs = [
+      { name: t`Application`, value: `application` },
+    ];
 
-  PLUGIN_APPLICATION_PERMISSIONS.selectors = {
-    canManageSubscriptions,
-  };
-  PLUGIN_REDUCERS.applicationPermissionsPlugin = applicationPermissionsReducer;
-}
+    PLUGIN_APPLICATION_PERMISSIONS.selectors = {
+      canManageSubscriptions,
+    };
+    PLUGIN_REDUCERS.applicationPermissionsPlugin =
+      applicationPermissionsReducer;
+  }
+};

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/index.js
@@ -13,43 +13,45 @@ import { InstanceAnalyticsButton } from "./components/InstanceAnalyticsButton/In
 import { getUserMenuRotes } from "./routes";
 import { isAuditDb } from "./utils";
 
-if (hasPremiumFeature("audit_app")) {
-  PLUGIN_ADMIN_USER_MENU_ITEMS.push(user => [
-    {
-      title: t`Unsubscribe from all subscriptions / alerts`,
-      link: `/admin/people/${user.id}/unsubscribe`,
-    },
-  ]);
-
-  PLUGIN_ADMIN_USER_MENU_ROUTES.push(getUserMenuRotes);
-
-  PLUGIN_DASHBOARD_HEADER.extraButtons = dashboard => {
-    return [
+export const activateAuditAppPlugin = () => {
+  if (hasPremiumFeature("audit_app")) {
+    PLUGIN_ADMIN_USER_MENU_ITEMS.push(user => [
       {
-        key: "Usage insights",
-        component: (
-          <InstanceAnalyticsButton
-            model="dashboard"
-            linkQueryParams={{ dashboard_id: dashboard.id }}
-          />
-        ),
+        title: t`Unsubscribe from all subscriptions / alerts`,
+        link: `/admin/people/${user.id}/unsubscribe`,
       },
-    ];
-  };
+    ]);
 
-  PLUGIN_QUERY_BUILDER_HEADER.extraButtons = question => {
-    return [
-      {
-        key: "Usage insights",
-        component: (
-          <InstanceAnalyticsButton
-            model="question"
-            linkQueryParams={{ question_id: question.id() }}
-          />
-        ),
-      },
-    ];
-  };
+    PLUGIN_ADMIN_USER_MENU_ROUTES.push(getUserMenuRotes);
 
-  PLUGIN_AUDIT.isAuditDb = isAuditDb;
-}
+    PLUGIN_DASHBOARD_HEADER.extraButtons = dashboard => {
+      return [
+        {
+          key: "Usage insights",
+          component: (
+            <InstanceAnalyticsButton
+              model="dashboard"
+              linkQueryParams={{ dashboard_id: dashboard.id }}
+            />
+          ),
+        },
+      ];
+    };
+
+    PLUGIN_QUERY_BUILDER_HEADER.extraButtons = question => {
+      return [
+        {
+          key: "Usage insights",
+          component: (
+            <InstanceAnalyticsButton
+              model="question"
+              linkQueryParams={{ question_id: question.id() }}
+            />
+          ),
+        },
+      ];
+    };
+
+    PLUGIN_AUDIT.isAuditDb = isAuditDb;
+  }
+};

--- a/enterprise/frontend/src/metabase-enterprise/auth/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/auth/index.js
@@ -29,284 +29,288 @@ import { SsoButton } from "./components/SsoButton";
 import JwtAuthCard from "./containers/JwtAuthCard";
 import SamlAuthCard from "./containers/SamlAuthCard";
 
-PLUGIN_ADMIN_SETTINGS_UPDATES.push(sections =>
-  updateIn(sections, ["authentication", "settings"], settings => {
-    const [apiKeySettings, otherSettings] = _.partition(
-      settings,
-      s => s.key === "api-keys",
-    );
-    return [
-      ...otherSettings,
-      {
-        key: "saml-enabled",
-        description: null,
-        noHeader: true,
-        widget: SamlAuthCard,
-        getHidden: () => !hasPremiumFeature("sso_saml"),
-        forceRenderWidget: true,
-      },
-      {
-        key: "jwt-enabled",
-        description: null,
-        noHeader: true,
-        widget: JwtAuthCard,
-        getHidden: () => !hasPremiumFeature("sso_jwt"),
-        forceRenderWidget: true,
-      },
-      ...apiKeySettings,
-      {
-        key: "enable-password-login",
-        display_name: t`Enable Password Authentication`,
-        description: t`When enabled, users can additionally log in with email and password.`,
-        type: "boolean",
-        getHidden: (_settings, derivedSettings) =>
-          !hasPremiumFeature("disable_password_login") ||
-          (!derivedSettings["google-auth-enabled"] &&
-            !derivedSettings["ldap-enabled"] &&
-            !derivedSettings["saml-enabled"] &&
-            !derivedSettings["jwt-enabled"]),
-      },
-      {
-        key: "session-timeout",
-        display_name: t`Session timeout`,
-        description: t`Time before inactive users are logged out.`,
-        widget: SessionTimeoutSetting,
-        getHidden: () => !hasPremiumFeature("session_timeout_config"),
-      },
-    ];
-  }),
-);
-
-PLUGIN_ADMIN_SETTINGS_UPDATES.push(sections => ({
-  ...sections,
-  "authentication/saml": {
-    getHidden: () => !hasPremiumFeature("sso_saml"),
-    component: SettingsSAMLForm,
-    settings: [
-      {
-        key: "saml-enabled",
-        getHidden: () => true,
-      },
-      {
-        key: "saml-user-provisioning-enabled?",
-        display_name: t`User Provisioning`,
-        // eslint-disable-next-line no-literal-metabase-strings -- This string only shows for admins.
-        description: t`When a user logs in via SAML, create a Metabase account for them automatically if they don't have one.`,
-        type: "boolean",
-      },
-      {
-        key: "saml-identity-provider-uri",
-        display_name: t`SAML Identity Provider SSO URL`,
-        placeholder: "https://example.com/app/my_saml_app/abc123/sso/saml",
-        type: "string",
-        required: true,
-      },
-      {
-        key: "saml-identity-provider-issuer",
-        display_name: t`SAML Identity Provider Issuer`,
-        placeholder: "http://www.example.com/abc123",
-        type: "string",
-        required: false,
-      },
-      {
-        key: "saml-identity-provider-certificate",
-        display_name: t`SAML Identity Provider Certificate`,
-        type: "text",
-        required: true,
-      },
-      {
-        key: "saml-application-name",
-        display_name: t`SAML Application Name`,
-        type: "string",
-      },
-      {
-        key: "saml-keystore-path",
-        display_name: t`SAML Keystore Path`,
-        type: "string",
-      },
-      {
-        key: "saml-keystore-password",
-        display_name: t`SAML Keystore Password`,
-        placeholder: "Shh...",
-        type: "password",
-      },
-      {
-        key: "saml-keystore-alias",
-        display_name: t`SAML Keystore Alias`,
-        type: "string",
-      },
-      {
-        key: "saml-attribute-email",
-        display_name: t`Email attribute`,
-        type: "string",
-      },
-      {
-        key: "saml-attribute-firstname",
-        display_name: t`First name attribute`,
-        type: "string",
-      },
-      {
-        key: "saml-attribute-lastname",
-        display_name: t`Last name attribute`,
-        type: "string",
-      },
-      {
-        key: "saml-group-sync",
-        display_name: t`Synchronize group memberships`,
-        description: null,
-        widget: GroupMappingsWidget,
-        props: {
-          mappingSetting: "saml-group-mappings",
-          groupHeading: t`Group Name`,
-          groupPlaceholder: "Group Name",
+export const activateAuthPlugin = () => {
+  PLUGIN_ADMIN_SETTINGS_UPDATES.push(sections =>
+    updateIn(sections, ["authentication", "settings"], settings => {
+      const [apiKeySettings, otherSettings] = _.partition(
+        settings,
+        s => s.key === "api-keys",
+      );
+      return [
+        ...otherSettings,
+        {
+          key: "saml-enabled",
+          description: null,
+          noHeader: true,
+          widget: SamlAuthCard,
+          getHidden: () => !hasPremiumFeature("sso_saml"),
+          forceRenderWidget: true,
         },
-      },
-      {
-        key: "saml-attribute-group",
-        display_name: t`Group attribute name`,
-        type: "string",
-      },
-      {
-        key: "saml-group-mappings",
-      },
-    ],
-  },
-  "authentication/jwt": {
-    component: SettingsJWTForm,
-    getHidden: () => !hasPremiumFeature("sso_jwt"),
-    settings: [
-      {
-        key: "jwt-enabled",
-        display_name: t`JWT Authentication`,
-        type: "boolean",
-      },
-      {
-        key: "jwt-user-provisioning-enabled?",
-        display_name: t`User Provisioning`,
-        // eslint-disable-next-line no-literal-metabase-strings -- This string only shows for admins.
-        description: t`When a user logs in via JWT, create a Metabase account for them automatically if they don't have one.`,
-        type: "boolean",
-      },
-      {
-        key: "jwt-identity-provider-uri",
-        display_name: t`JWT Identity Provider URI`,
-        placeholder: "https://jwt.yourdomain.org",
-        type: "string",
-        required: true,
-        autoFocus: true,
-        getHidden: (_, derivedSettings) => !derivedSettings["jwt-enabled"],
-      },
-      {
-        key: "jwt-shared-secret",
-        display_name: t`String used by the JWT signing key`,
-        type: "text",
-        required: true,
-        getHidden: (_, derivedSettings) => !derivedSettings["jwt-enabled"],
-      },
-      {
-        key: "jwt-attribute-email",
-        display_name: t`Email attribute`,
-        type: "string",
-      },
-      {
-        key: "jwt-attribute-firstname",
-        display_name: t`First name attribute`,
-        type: "string",
-      },
-      {
-        key: "jwt-attribute-lastname",
-        display_name: t`Last name attribute`,
-        type: "string",
-      },
-      {
-        key: "jwt-group-sync",
-        display_name: t`Synchronize group memberships`,
-        description: null,
-      },
-      {
-        key: "jwt-group-mappings",
-      },
-    ],
-  },
-}));
-
-const SSO_PROVIDER = {
-  name: "sso",
-  Button: SsoButton,
-};
-
-PLUGIN_AUTH_PROVIDERS.push(providers => {
-  if (
-    (hasPremiumFeature("sso_jwt") || hasPremiumFeature("sso_saml")) &&
-    MetabaseSettings.get("other-sso-enabled?")
-  ) {
-    providers = [SSO_PROVIDER, ...providers];
-  }
-  if (
-    hasPremiumFeature("disable_password_login") &&
-    !MetabaseSettings.isPasswordLoginEnabled() &&
-    !MetabaseSettings.isLdapEnabled()
-  ) {
-    providers = providers.filter(p => p.name !== "password");
-  }
-  return providers;
-});
-
-if (hasPremiumFeature("disable_password_login")) {
-  PLUGIN_IS_PASSWORD_USER.push(
-    user =>
-      !user.google_auth &&
-      !user.ldap_auth &&
-      MetabaseSettings.isPasswordLoginEnabled(),
+        {
+          key: "jwt-enabled",
+          description: null,
+          noHeader: true,
+          widget: JwtAuthCard,
+          getHidden: () => !hasPremiumFeature("sso_jwt"),
+          forceRenderWidget: true,
+        },
+        ...apiKeySettings,
+        {
+          key: "enable-password-login",
+          display_name: t`Enable Password Authentication`,
+          description: t`When enabled, users can additionally log in with email and password.`,
+          type: "boolean",
+          getHidden: (_settings, derivedSettings) =>
+            !hasPremiumFeature("disable_password_login") ||
+            (!derivedSettings["google-auth-enabled"] &&
+              !derivedSettings["ldap-enabled"] &&
+              !derivedSettings["saml-enabled"] &&
+              !derivedSettings["jwt-enabled"]),
+        },
+        {
+          key: "session-timeout",
+          display_name: t`Session timeout`,
+          description: t`Time before inactive users are logged out.`,
+          widget: SessionTimeoutSetting,
+          getHidden: () => !hasPremiumFeature("session_timeout_config"),
+        },
+      ];
+    }),
   );
-}
 
-if (hasPremiumFeature("sso_ldap")) {
-  Object.assign(PLUGIN_LDAP_FORM_FIELDS, {
-    formFieldAttributes: ["ldap-user-provisioning-enabled?"],
-    defaultableFormFieldAttributes: ["ldap-user-provisioning-enabled?"],
-    formFieldsSchemas: {
-      "ldap-user-provisioning-enabled?": Yup.boolean().default(null),
+  PLUGIN_ADMIN_SETTINGS_UPDATES.push(sections => ({
+    ...sections,
+    "authentication/saml": {
+      getHidden: () => !hasPremiumFeature("sso_saml"),
+      component: SettingsSAMLForm,
+      settings: [
+        {
+          key: "saml-enabled",
+          getHidden: () => true,
+        },
+        {
+          key: "saml-user-provisioning-enabled?",
+          display_name: t`User Provisioning`,
+          // eslint-disable-next-line no-literal-metabase-strings -- This string only shows for admins.
+          description: t`When a user logs in via SAML, create a Metabase account for them automatically if they don't have one.`,
+          type: "boolean",
+        },
+        {
+          key: "saml-identity-provider-uri",
+          display_name: t`SAML Identity Provider SSO URL`,
+          placeholder: "https://example.com/app/my_saml_app/abc123/sso/saml",
+          type: "string",
+          required: true,
+        },
+        {
+          key: "saml-identity-provider-issuer",
+          display_name: t`SAML Identity Provider Issuer`,
+          placeholder: "http://www.example.com/abc123",
+          type: "string",
+          required: false,
+        },
+        {
+          key: "saml-identity-provider-certificate",
+          display_name: t`SAML Identity Provider Certificate`,
+          type: "text",
+          required: true,
+        },
+        {
+          key: "saml-application-name",
+          display_name: t`SAML Application Name`,
+          type: "string",
+        },
+        {
+          key: "saml-keystore-path",
+          display_name: t`SAML Keystore Path`,
+          type: "string",
+        },
+        {
+          key: "saml-keystore-password",
+          display_name: t`SAML Keystore Password`,
+          placeholder: "Shh...",
+          type: "password",
+        },
+        {
+          key: "saml-keystore-alias",
+          display_name: t`SAML Keystore Alias`,
+          type: "string",
+        },
+        {
+          key: "saml-attribute-email",
+          display_name: t`Email attribute`,
+          type: "string",
+        },
+        {
+          key: "saml-attribute-firstname",
+          display_name: t`First name attribute`,
+          type: "string",
+        },
+        {
+          key: "saml-attribute-lastname",
+          display_name: t`Last name attribute`,
+          type: "string",
+        },
+        {
+          key: "saml-group-sync",
+          display_name: t`Synchronize group memberships`,
+          description: null,
+          widget: GroupMappingsWidget,
+          props: {
+            mappingSetting: "saml-group-mappings",
+            groupHeading: t`Group Name`,
+            groupPlaceholder: "Group Name",
+          },
+        },
+        {
+          key: "saml-attribute-group",
+          display_name: t`Group attribute name`,
+          type: "string",
+        },
+        {
+          key: "saml-group-mappings",
+        },
+      ],
     },
-    UserProvisioning: ({ fields, settings }) => (
-      <Stack spacing="0.75rem" m="2.5rem 0">
-        <SettingHeader
-          id="ldap-user-provisioning-enabled?"
-          setting={settings["ldap-user-provisioning-enabled?"]}
-        />
-        <FormSwitch
-          id="ldap-user-provisioning-enabled?"
-          name={fields["ldap-user-provisioning-enabled?"].name}
-          defaultChecked={fields["ldap-user-provisioning-enabled?"].default}
-        />
-      </Stack>
-    ),
+    "authentication/jwt": {
+      component: SettingsJWTForm,
+      getHidden: () => !hasPremiumFeature("sso_jwt"),
+      settings: [
+        {
+          key: "jwt-enabled",
+          display_name: t`JWT Authentication`,
+          type: "boolean",
+        },
+        {
+          key: "jwt-user-provisioning-enabled?",
+          display_name: t`User Provisioning`,
+          // eslint-disable-next-line no-literal-metabase-strings -- This string only shows for admins.
+          description: t`When a user logs in via JWT, create a Metabase account for them automatically if they don't have one.`,
+          type: "boolean",
+        },
+        {
+          key: "jwt-identity-provider-uri",
+          display_name: t`JWT Identity Provider URI`,
+          placeholder: "https://jwt.yourdomain.org",
+          type: "string",
+          required: true,
+          autoFocus: true,
+          getHidden: (_, derivedSettings) => !derivedSettings["jwt-enabled"],
+        },
+        {
+          key: "jwt-shared-secret",
+          display_name: t`String used by the JWT signing key`,
+          type: "text",
+          required: true,
+          getHidden: (_, derivedSettings) => !derivedSettings["jwt-enabled"],
+        },
+        {
+          key: "jwt-attribute-email",
+          display_name: t`Email attribute`,
+          type: "string",
+        },
+        {
+          key: "jwt-attribute-firstname",
+          display_name: t`First name attribute`,
+          type: "string",
+        },
+        {
+          key: "jwt-attribute-lastname",
+          display_name: t`Last name attribute`,
+          type: "string",
+        },
+        {
+          key: "jwt-group-sync",
+          display_name: t`Synchronize group memberships`,
+          description: null,
+        },
+        {
+          key: "jwt-group-mappings",
+        },
+      ],
+    },
+  }));
+
+  const SSO_PROVIDER = {
+    name: "sso",
+    Button: SsoButton,
+  };
+
+  PLUGIN_AUTH_PROVIDERS.push(providers => {
+    if (
+      (hasPremiumFeature("sso_jwt") || hasPremiumFeature("sso_saml")) &&
+      MetabaseSettings.get("other-sso-enabled?")
+    ) {
+      providers = [SSO_PROVIDER, ...providers];
+    }
+    if (
+      hasPremiumFeature("disable_password_login") &&
+      !MetabaseSettings.isPasswordLoginEnabled() &&
+      !MetabaseSettings.isLdapEnabled()
+    ) {
+      providers = providers.filter(p => p.name !== "password");
+    }
+    return providers;
   });
 
-  PLUGIN_ADMIN_SETTINGS_UPDATES.push(sections =>
-    updateIn(sections, ["authentication/ldap", "settings"], settings => [
-      {
-        key: "ldap-user-provisioning-enabled?",
-        display_name: t`User Provisioning`,
-        // eslint-disable-next-line no-literal-metabase-strings -- This string only shows for admins.
-        description: t`When a user logs in via LDAP, create a Metabase account for them automatically if they don't have one.`,
-        type: "boolean",
-      },
-      ...settings,
-      {
-        key: "ldap-group-membership-filter",
-        display_name: t`Group membership filter`,
-        type: "string",
-      },
-      {
-        key: "ldap-sync-admin-group",
-        display_name: t`Sync Administrator group`,
-        type: "boolean",
-      },
-    ]),
-  );
-}
+  if (hasPremiumFeature("disable_password_login")) {
+    PLUGIN_IS_PASSWORD_USER.push(
+      user =>
+        !user.google_auth &&
+        !user.ldap_auth &&
+        MetabaseSettings.isPasswordLoginEnabled(),
+    );
+  }
 
-if (hasPremiumFeature("session_timeout_config")) {
-  PLUGIN_REDUX_MIDDLEWARES.push(createSessionMiddleware([LOGIN, LOGIN_GOOGLE]));
-}
+  if (hasPremiumFeature("sso_ldap")) {
+    Object.assign(PLUGIN_LDAP_FORM_FIELDS, {
+      formFieldAttributes: ["ldap-user-provisioning-enabled?"],
+      defaultableFormFieldAttributes: ["ldap-user-provisioning-enabled?"],
+      formFieldsSchemas: {
+        "ldap-user-provisioning-enabled?": Yup.boolean().default(null),
+      },
+      UserProvisioning: ({ fields, settings }) => (
+        <Stack spacing="0.75rem" m="2.5rem 0">
+          <SettingHeader
+            id="ldap-user-provisioning-enabled?"
+            setting={settings["ldap-user-provisioning-enabled?"]}
+          />
+          <FormSwitch
+            id="ldap-user-provisioning-enabled?"
+            name={fields["ldap-user-provisioning-enabled?"].name}
+            defaultChecked={fields["ldap-user-provisioning-enabled?"].default}
+          />
+        </Stack>
+      ),
+    });
+
+    PLUGIN_ADMIN_SETTINGS_UPDATES.push(sections =>
+      updateIn(sections, ["authentication/ldap", "settings"], settings => [
+        {
+          key: "ldap-user-provisioning-enabled?",
+          display_name: t`User Provisioning`,
+          // eslint-disable-next-line no-literal-metabase-strings -- This string only shows for admins.
+          description: t`When a user logs in via LDAP, create a Metabase account for them automatically if they don't have one.`,
+          type: "boolean",
+        },
+        ...settings,
+        {
+          key: "ldap-group-membership-filter",
+          display_name: t`Group membership filter`,
+          type: "string",
+        },
+        {
+          key: "ldap-sync-admin-group",
+          display_name: t`Sync Administrator group`,
+          type: "boolean",
+        },
+      ]),
+    );
+  }
+
+  if (hasPremiumFeature("session_timeout_config")) {
+    PLUGIN_REDUX_MIDDLEWARES.push(
+      createSessionMiddleware([LOGIN, LOGIN_GOOGLE]),
+    );
+  }
+};

--- a/enterprise/frontend/src/metabase-enterprise/caching/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/index.tsx
@@ -15,26 +15,28 @@ import {
 } from "./constants";
 import { hasQuestionCacheSection } from "./utils";
 
-if (hasPremiumFeature("cache_granular_controls")) {
-  PLUGIN_CACHING.isGranularCachingEnabled = () => true;
-  PLUGIN_CACHING.StrategyFormLauncherPanel = StrategyFormLauncherPanel;
-  PLUGIN_CACHING.hasQuestionCacheSection = hasQuestionCacheSection;
-  PLUGIN_CACHING.canOverrideRootStrategy = true;
-  PLUGIN_CACHING.GranularControlsExplanation = GranularControlsExplanation;
-  PLUGIN_CACHING.InvalidateNowButton = InvalidateNowButton;
-  PLUGIN_CACHING.DashboardStrategySidebar = DashboardStrategySidebar;
-  PLUGIN_CACHING.SidebarCacheSection = SidebarCacheSection;
-  PLUGIN_CACHING.SidebarCacheForm = SidebarCacheForm;
-  PLUGIN_CACHING.strategies = {
-    inherit: PLUGIN_CACHING.strategies.inherit,
-    duration: enterpriseOnlyCachingStrategies.duration,
-    schedule: enterpriseOnlyCachingStrategies.schedule,
-    ttl: PLUGIN_CACHING.strategies.ttl,
-    nocache: PLUGIN_CACHING.strategies.nocache,
-  };
-  PLUGIN_CACHING.DashboardAndQuestionCachingTab =
-    DashboardAndQuestionCachingTab;
-  PLUGIN_CACHING.StrategyEditorForQuestionsAndDashboards =
-    StrategyEditorForQuestionsAndDashboards;
-  PLUGIN_CACHING.getTabMetadata = getEnterprisePerformanceTabMetadata;
-}
+export const activateCachingPlugin = () => {
+  if (hasPremiumFeature("cache_granular_controls")) {
+    PLUGIN_CACHING.isGranularCachingEnabled = () => true;
+    PLUGIN_CACHING.StrategyFormLauncherPanel = StrategyFormLauncherPanel;
+    PLUGIN_CACHING.hasQuestionCacheSection = hasQuestionCacheSection;
+    PLUGIN_CACHING.canOverrideRootStrategy = true;
+    PLUGIN_CACHING.GranularControlsExplanation = GranularControlsExplanation;
+    PLUGIN_CACHING.InvalidateNowButton = InvalidateNowButton;
+    PLUGIN_CACHING.DashboardStrategySidebar = DashboardStrategySidebar;
+    PLUGIN_CACHING.SidebarCacheSection = SidebarCacheSection;
+    PLUGIN_CACHING.SidebarCacheForm = SidebarCacheForm;
+    PLUGIN_CACHING.strategies = {
+      inherit: PLUGIN_CACHING.strategies.inherit,
+      duration: enterpriseOnlyCachingStrategies.duration,
+      schedule: enterpriseOnlyCachingStrategies.schedule,
+      ttl: PLUGIN_CACHING.strategies.ttl,
+      nocache: PLUGIN_CACHING.strategies.nocache,
+    };
+    PLUGIN_CACHING.DashboardAndQuestionCachingTab =
+      DashboardAndQuestionCachingTab;
+    PLUGIN_CACHING.StrategyEditorForQuestionsAndDashboards =
+      StrategyEditorForQuestionsAndDashboards;
+    PLUGIN_CACHING.getTabMetadata = getEnterprisePerformanceTabMetadata;
+  }
+};

--- a/enterprise/frontend/src/metabase-enterprise/clean_up/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/clean_up/index.tsx
@@ -6,33 +6,35 @@ import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import { CleanupCollectionModal } from "./CleanupCollectionModal";
 
-if (hasPremiumFeature("collection_cleanup")) {
-  PLUGIN_COLLECTIONS.canCleanUp = true;
+export const activateCollectionCleanupPlugin = () => {
+  if (hasPremiumFeature("collection_cleanup")) {
+    PLUGIN_COLLECTIONS.canCleanUp = true;
 
-  PLUGIN_COLLECTIONS.getCleanUpMenuItems = (
-    itemCount,
-    url,
-    isInstanceAnalyticsCustom,
-    isTrashed,
-    canWrite,
-  ) => {
-    const canCleanUpCollection =
-      itemCount !== 0 && !isInstanceAnalyticsCustom && !isTrashed && canWrite;
+    PLUGIN_COLLECTIONS.getCleanUpMenuItems = (
+      itemCount,
+      url,
+      isInstanceAnalyticsCustom,
+      isTrashed,
+      canWrite,
+    ) => {
+      const canCleanUpCollection =
+        itemCount !== 0 && !isInstanceAnalyticsCustom && !isTrashed && canWrite;
 
-    if (!canCleanUpCollection) {
-      return [];
-    }
+      if (!canCleanUpCollection) {
+        return [];
+      }
 
-    return [
-      {
-        title: t`Clean things up`,
-        icon: "archive",
-        link: `${url}/cleanup`,
-      },
-    ];
-  };
+      return [
+        {
+          title: t`Clean things up`,
+          icon: "archive",
+          link: `${url}/cleanup`,
+        },
+      ];
+    };
 
-  PLUGIN_COLLECTIONS.cleanUpRoute = (
-    <ModalRoute path="cleanup" modal={CleanupCollectionModal} />
-  );
-}
+    PLUGIN_COLLECTIONS.cleanUpRoute = (
+      <ModalRoute path="cleanup" modal={CleanupCollectionModal} />
+    );
+  }
+};

--- a/enterprise/frontend/src/metabase-enterprise/collections/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/collections/index.ts
@@ -24,62 +24,64 @@ import {
   isRegularCollection,
 } from "./utils";
 
-if (hasPremiumFeature("official_collections")) {
-  PLUGIN_COLLECTIONS.isRegularCollection = isRegularCollection;
+export const activateCollectionsPlugin = () => {
+  if (hasPremiumFeature("official_collections")) {
+    PLUGIN_COLLECTIONS.isRegularCollection = isRegularCollection;
 
-  PLUGIN_COLLECTIONS.REGULAR_COLLECTION = REGULAR_COLLECTION;
+    PLUGIN_COLLECTIONS.REGULAR_COLLECTION = REGULAR_COLLECTION;
 
-  PLUGIN_COLLECTIONS.AUTHORITY_LEVEL = AUTHORITY_LEVELS;
+    PLUGIN_COLLECTIONS.AUTHORITY_LEVEL = AUTHORITY_LEVELS;
 
-  PLUGIN_COLLECTIONS.getIcon = getIcon;
+    PLUGIN_COLLECTIONS.getIcon = getIcon;
 
-  PLUGIN_COLLECTIONS.getAuthorityLevelMenuItems = (
-    collection: Collection,
-    onUpdate: (collection: Collection, values: Partial<Collection>) => void,
-  ) => {
-    if (isRegularCollection(collection)) {
-      return [
-        {
-          title: t`Make collection official`,
-          icon: OFFICIAL_COLLECTION.icon,
-          action: () =>
-            onUpdate(collection, {
-              authority_level: OFFICIAL_COLLECTION.type,
-            }),
-        },
-      ];
-    } else {
-      return [
-        {
-          title: t`Remove Official badge`,
-          icon: "close",
-          action: () =>
-            onUpdate(collection, {
-              authority_level: REGULAR_COLLECTION.type,
-            }),
-        },
-      ];
-    }
-  };
+    PLUGIN_COLLECTIONS.getAuthorityLevelMenuItems = (
+      collection: Collection,
+      onUpdate: (collection: Collection, values: Partial<Collection>) => void,
+    ) => {
+      if (isRegularCollection(collection)) {
+        return [
+          {
+            title: t`Make collection official`,
+            icon: OFFICIAL_COLLECTION.icon,
+            action: () =>
+              onUpdate(collection, {
+                authority_level: OFFICIAL_COLLECTION.type,
+              }),
+          },
+        ];
+      } else {
+        return [
+          {
+            title: t`Remove Official badge`,
+            icon: "close",
+            action: () =>
+              onUpdate(collection, {
+                authority_level: REGULAR_COLLECTION.type,
+              }),
+          },
+        ];
+      }
+    };
 
-  PLUGIN_COLLECTIONS.filterOutItemsFromInstanceAnalytics =
-    filterOutItemsFromInstanceAnalytics;
+    PLUGIN_COLLECTIONS.filterOutItemsFromInstanceAnalytics =
+      filterOutItemsFromInstanceAnalytics;
 
-  PLUGIN_COLLECTION_COMPONENTS.FormCollectionAuthorityLevelPicker =
-    FormCollectionAuthorityLevel;
+    PLUGIN_COLLECTION_COMPONENTS.FormCollectionAuthorityLevelPicker =
+      FormCollectionAuthorityLevel;
 
-  PLUGIN_COLLECTION_COMPONENTS.CollectionAuthorityLevelIcon =
-    CollectionAuthorityLevelIcon;
-}
+    PLUGIN_COLLECTION_COMPONENTS.CollectionAuthorityLevelIcon =
+      CollectionAuthorityLevelIcon;
+  }
 
-if (hasPremiumFeature("audit_app")) {
-  PLUGIN_COLLECTION_COMPONENTS.CollectionInstanceAnalyticsIcon =
-    CollectionInstanceAnalyticsIcon;
+  if (hasPremiumFeature("audit_app")) {
+    PLUGIN_COLLECTION_COMPONENTS.CollectionInstanceAnalyticsIcon =
+      CollectionInstanceAnalyticsIcon;
 
-  PLUGIN_COLLECTIONS.getCollectionType = getCollectionType;
-  PLUGIN_COLLECTIONS.useGetDefaultCollectionId = useGetDefaultCollectionId;
-  PLUGIN_COLLECTIONS.CUSTOM_INSTANCE_ANALYTICS_COLLECTION_ENTITY_ID =
-    CUSTOM_INSTANCE_ANALYTICS_COLLECTION_ENTITY_ID;
+    PLUGIN_COLLECTIONS.getCollectionType = getCollectionType;
+    PLUGIN_COLLECTIONS.useGetDefaultCollectionId = useGetDefaultCollectionId;
+    PLUGIN_COLLECTIONS.CUSTOM_INSTANCE_ANALYTICS_COLLECTION_ENTITY_ID =
+      CUSTOM_INSTANCE_ANALYTICS_COLLECTION_ENTITY_ID;
 
-  PLUGIN_COLLECTIONS.INSTANCE_ANALYTICS_ADMIN_READONLY_MESSAGE = t`This instance analytics collection is read-only for admin users`;
-}
+    PLUGIN_COLLECTIONS.INSTANCE_ANALYTICS_ADMIN_READONLY_MESSAGE = t`This instance analytics collection is read-only for admin users`;
+  }
+};

--- a/enterprise/frontend/src/metabase-enterprise/content_verification/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/content_verification/index.ts
@@ -5,11 +5,13 @@ import { ModelFilterControls } from "./ModelFilterControls";
 import { VerifiedFilter } from "./VerifiedFilter";
 import { availableModelFilters, useModelFilterSettings } from "./utils";
 
-if (hasPremiumFeature("content_verification")) {
-  Object.assign(PLUGIN_CONTENT_VERIFICATION, {
-    VerifiedFilter,
-    ModelFilterControls,
-    availableModelFilters,
-    useModelFilterSettings,
-  });
-}
+export const activateContentVerificationPlugin = () => {
+  if (hasPremiumFeature("content_verification")) {
+    Object.assign(PLUGIN_CONTENT_VERIFICATION, {
+      VerifiedFilter,
+      ModelFilterControls,
+      availableModelFilters,
+      useModelFilterSettings,
+    });
+  }
+};

--- a/enterprise/frontend/src/metabase-enterprise/email_allow_list/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/email_allow_list/index.ts
@@ -6,20 +6,22 @@ import type { SettingElement } from "metabase/admin/settings/types";
 import { PLUGIN_ADMIN_SETTINGS_UPDATES } from "metabase/plugins";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
-if (hasPremiumFeature("email_allow_list")) {
-  PLUGIN_ADMIN_SETTINGS_UPDATES.push(
-    (sections: typeof ADMIN_SETTINGS_SECTIONS) =>
-      updateIn(
-        sections,
-        ["email", "settings"],
-        (settings: SettingElement[]) => [
-          ...settings,
-          {
-            key: "subscription-allowed-domains",
-            display_name: t`Approved domains for notifications`,
-            type: "string",
-          },
-        ],
-      ),
-  );
-}
+export const activateEmailAllowListPlugin = () => {
+  if (hasPremiumFeature("email_allow_list")) {
+    PLUGIN_ADMIN_SETTINGS_UPDATES.push(
+      (sections: typeof ADMIN_SETTINGS_SECTIONS) =>
+        updateIn(
+          sections,
+          ["email", "settings"],
+          (settings: SettingElement[]) => [
+            ...settings,
+            {
+              key: "subscription-allowed-domains",
+              display_name: t`Approved domains for notifications`,
+              type: "string",
+            },
+          ],
+        ),
+    );
+  }
+};

--- a/enterprise/frontend/src/metabase-enterprise/email_restrict_recipients/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/email_restrict_recipients/index.ts
@@ -6,29 +6,31 @@ import type { SettingElement } from "metabase/admin/settings/types";
 import { PLUGIN_ADMIN_SETTINGS_UPDATES } from "metabase/plugins";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
-if (hasPremiumFeature("email_restrict_recipients")) {
-  PLUGIN_ADMIN_SETTINGS_UPDATES.push(
-    (sections: typeof ADMIN_SETTINGS_SECTIONS) =>
-      updateIn(
-        sections,
-        ["email", "settings"],
-        (settings: SettingElement[]) => [
-          ...settings,
-          {
-            key: "user-visibility",
-            display_name: t`Suggest recipients on dashboard subscriptions and alerts`,
-            type: "select",
-            options: [
-              { value: "all", name: t`Suggest all users` },
-              {
-                value: "group",
-                name: t`Only suggest users in the same groups`,
-              },
-              { value: "none", name: t`Don't show suggestions` },
-            ],
-            defaultValue: "all",
-          },
-        ],
-      ),
-  );
-}
+export const activateEmailRestrictRecipientsPlugin = () => {
+  if (hasPremiumFeature("email_restrict_recipients")) {
+    PLUGIN_ADMIN_SETTINGS_UPDATES.push(
+      (sections: typeof ADMIN_SETTINGS_SECTIONS) =>
+        updateIn(
+          sections,
+          ["email", "settings"],
+          (settings: SettingElement[]) => [
+            ...settings,
+            {
+              key: "user-visibility",
+              display_name: t`Suggest recipients on dashboard subscriptions and alerts`,
+              type: "select",
+              options: [
+                { value: "all", name: t`Suggest all users` },
+                {
+                  value: "group",
+                  name: t`Only suggest users in the same groups`,
+                },
+                { value: "none", name: t`Don't show suggestions` },
+              ],
+              defaultValue: "all",
+            },
+          ],
+        ),
+    );
+  }
+};

--- a/enterprise/frontend/src/metabase-enterprise/embedding/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/embedding/index.js
@@ -15,57 +15,59 @@ import {
 
 const SLUG = "embedding-in-other-applications/full-app";
 
-if (hasPremiumFeature("embedding")) {
-  PLUGIN_EMBEDDING.isEnabled = () => true;
-  PLUGIN_EMBEDDING.isInteractiveEmbeddingEnabled =
-    isInteractiveEmbeddingEnabled;
+export const activateEmbeddingPlugin = () => {
+  if (hasPremiumFeature("embedding")) {
+    PLUGIN_EMBEDDING.isEnabled = () => true;
+    PLUGIN_EMBEDDING.isInteractiveEmbeddingEnabled =
+      isInteractiveEmbeddingEnabled;
 
-  PLUGIN_ADMIN_SETTINGS_UPDATES.push(sections => {
-    return {
-      ...sections,
-      [SLUG]: {
-        ...sections[SLUG],
-        settings: [
-          ...sections[SLUG]["settings"],
-          {
-            key: "embedding-app-origin",
-            display_name: t`Authorized origins`,
-            description: <EmbeddingAppOriginDescription />,
-            placeholder: "https://*.example.com",
-            type: "string",
-            getHidden: (_, derivedSettings) =>
-              !derivedSettings["enable-embedding"],
-          },
-          {
-            key: "session-cookie-samesite",
-            display_name: t`SameSite cookie setting`,
-            description: <EmbeddingAppSameSiteCookieDescription />,
-            type: "select",
-            options: [
-              {
-                value: "lax",
-                name: t`Lax (default)`,
-                description: t`Allows cookies to be sent when a user is navigating to the origin site from an external site (like when following a link).`,
-              },
-              {
-                value: "strict",
-                name: t`Strict (not recommended)`,
-                // eslint-disable-next-line no-literal-metabase-strings -- Metabase settings
-                description: t`Never allows cookies to be sent on a cross-site request. Warning: this will prevent users from following external links to Metabase.`,
-              },
-              {
-                value: "none",
-                name: t`None`,
-                description: t`Allows all cross-site requests. Incompatible with most Safari and iOS-based browsers.`,
-              },
-            ],
-            defaultValue: "lax",
-            widget: SameSiteSelectWidget,
-            getHidden: (_, derivedSettings) =>
-              !derivedSettings["enable-embedding"],
-          },
-        ],
-      },
-    };
-  });
-}
+    PLUGIN_ADMIN_SETTINGS_UPDATES.push(sections => {
+      return {
+        ...sections,
+        [SLUG]: {
+          ...sections[SLUG],
+          settings: [
+            ...sections[SLUG]["settings"],
+            {
+              key: "embedding-app-origin",
+              display_name: t`Authorized origins`,
+              description: <EmbeddingAppOriginDescription />,
+              placeholder: "https://*.example.com",
+              type: "string",
+              getHidden: (_, derivedSettings) =>
+                !derivedSettings["enable-embedding"],
+            },
+            {
+              key: "session-cookie-samesite",
+              display_name: t`SameSite cookie setting`,
+              description: <EmbeddingAppSameSiteCookieDescription />,
+              type: "select",
+              options: [
+                {
+                  value: "lax",
+                  name: t`Lax (default)`,
+                  description: t`Allows cookies to be sent when a user is navigating to the origin site from an external site (like when following a link).`,
+                },
+                {
+                  value: "strict",
+                  name: t`Strict (not recommended)`,
+                  // eslint-disable-next-line no-literal-metabase-strings -- Metabase settings
+                  description: t`Never allows cookies to be sent on a cross-site request. Warning: this will prevent users from following external links to Metabase.`,
+                },
+                {
+                  value: "none",
+                  name: t`None`,
+                  description: t`Allows all cross-site requests. Incompatible with most Safari and iOS-based browsers.`,
+                },
+              ],
+              defaultValue: "lax",
+              widget: SameSiteSelectWidget,
+              getHidden: (_, derivedSettings) =>
+                !derivedSettings["enable-embedding"],
+            },
+          ],
+        },
+      };
+    });
+  }
+};

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/index.ts
@@ -16,27 +16,31 @@ import {
   getDataColumns,
 } from "./utils";
 
-if (hasPremiumFeature("advanced_permissions")) {
-  PLUGIN_ADMIN_ALLOWED_PATH_GETTERS.push(dataModelPermissionAllowedPathGetter);
-  PLUGIN_ADMIN_ALLOWED_PATH_GETTERS.push(
-    databaseManagementPermissionAllowedPathGetter,
-  );
+export const activateFeatureLevelPermissionsPlugin = () => {
+  if (hasPremiumFeature("advanced_permissions")) {
+    PLUGIN_ADMIN_ALLOWED_PATH_GETTERS.push(
+      dataModelPermissionAllowedPathGetter,
+    );
+    PLUGIN_ADMIN_ALLOWED_PATH_GETTERS.push(
+      databaseManagementPermissionAllowedPathGetter,
+    );
 
-  PLUGIN_FEATURE_LEVEL_PERMISSIONS.getFeatureLevelDataPermissions =
-    getFeatureLevelDataPermissions;
+    PLUGIN_FEATURE_LEVEL_PERMISSIONS.getFeatureLevelDataPermissions =
+      getFeatureLevelDataPermissions;
 
-  PLUGIN_FEATURE_LEVEL_PERMISSIONS.getDataColumns = getDataColumns;
-  PLUGIN_FEATURE_LEVEL_PERMISSIONS.getDownloadWidgetMessageOverride =
-    getDownloadWidgetMessageOverride;
-  PLUGIN_FEATURE_LEVEL_PERMISSIONS.canDownloadResults = canDownloadResults;
+    PLUGIN_FEATURE_LEVEL_PERMISSIONS.getDataColumns = getDataColumns;
+    PLUGIN_FEATURE_LEVEL_PERMISSIONS.getDownloadWidgetMessageOverride =
+      getDownloadWidgetMessageOverride;
+    PLUGIN_FEATURE_LEVEL_PERMISSIONS.canDownloadResults = canDownloadResults;
 
-  PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps = {
-    include_editable_data_model: true,
-  };
+    PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps = {
+      include_editable_data_model: true,
+    };
 
-  PLUGIN_FEATURE_LEVEL_PERMISSIONS.databaseDetailsQueryProps = {
-    exclude_uneditable_details: true,
-  };
+    PLUGIN_FEATURE_LEVEL_PERMISSIONS.databaseDetailsQueryProps = {
+      exclude_uneditable_details: true,
+    };
 
-  DATA_PERMISSIONS_TOOLBAR_CONTENT.length = 0;
-}
+    DATA_PERMISSIONS_TOOLBAR_CONTENT.length = 0;
+  }
+};

--- a/enterprise/frontend/src/metabase-enterprise/group_managers/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/group_managers/index.ts
@@ -17,18 +17,22 @@ import {
   groupManagerAllowedPathGetter,
 } from "./utils";
 
-if (hasPremiumFeature("advanced_permissions")) {
-  PLUGIN_ADMIN_ALLOWED_PATH_GETTERS.push(groupManagerAllowedPathGetter);
+export const activateGroupManagersPlugin = () => {
+  if (hasPremiumFeature("advanced_permissions")) {
+    PLUGIN_ADMIN_ALLOWED_PATH_GETTERS.push(groupManagerAllowedPathGetter);
 
-  PLUGIN_GROUP_MANAGERS.UserTypeCell = UserTypeCell;
-  PLUGIN_GROUP_MANAGERS.UserTypeToggle = UserTypeToggle;
+    PLUGIN_GROUP_MANAGERS.UserTypeCell = UserTypeCell;
+    PLUGIN_GROUP_MANAGERS.UserTypeToggle = UserTypeToggle;
 
-  PLUGIN_GROUP_MANAGERS.getRemoveMembershipConfirmation =
-    getRemoveMembershipConfirmation;
-  PLUGIN_GROUP_MANAGERS.getChangeMembershipConfirmation =
-    getChangeMembershipConfirmation;
+    PLUGIN_GROUP_MANAGERS.getRemoveMembershipConfirmation =
+      getRemoveMembershipConfirmation;
+    PLUGIN_GROUP_MANAGERS.getChangeMembershipConfirmation =
+      getChangeMembershipConfirmation;
 
-  PLUGIN_GROUP_MANAGERS.deleteGroup = deleteGroup;
-  PLUGIN_GROUP_MANAGERS.confirmDeleteMembershipAction = confirmDeleteMembership;
-  PLUGIN_GROUP_MANAGERS.confirmUpdateMembershipAction = confirmUpdateMembership;
-}
+    PLUGIN_GROUP_MANAGERS.deleteGroup = deleteGroup;
+    PLUGIN_GROUP_MANAGERS.confirmDeleteMembershipAction =
+      confirmDeleteMembership;
+    PLUGIN_GROUP_MANAGERS.confirmUpdateMembershipAction =
+      confirmUpdateMembership;
+  }
+};

--- a/enterprise/frontend/src/metabase-enterprise/hosting/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/hosting/index.js
@@ -6,29 +6,32 @@ import { PLUGIN_ADMIN_SETTINGS_UPDATES } from "metabase/plugins";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import { SettingsCloudStoreLink } from "./components/SettingsCloudStoreLink";
+export const activateHostingPlugin = () => {
+  if (hasPremiumFeature("hosting")) {
+    PLUGIN_ADMIN_SETTINGS_UPDATES.push(sections =>
+      _.omit(sections, ["updates"]),
+    );
 
-if (hasPremiumFeature("hosting")) {
-  PLUGIN_ADMIN_SETTINGS_UPDATES.push(sections => _.omit(sections, ["updates"]));
-
-  PLUGIN_ADMIN_SETTINGS_UPDATES.push(sections =>
-    updateIn(sections, ["general", "settings"], settings =>
-      _.reject(settings, setting =>
-        ["site-url", "redirect-all-requests-to-https"].includes(setting.key),
+    PLUGIN_ADMIN_SETTINGS_UPDATES.push(sections =>
+      updateIn(sections, ["general", "settings"], settings =>
+        _.reject(settings, setting =>
+          ["site-url", "redirect-all-requests-to-https"].includes(setting.key),
+        ),
       ),
-    ),
-  );
+    );
 
-  PLUGIN_ADMIN_SETTINGS_UPDATES.push(sections => ({
-    ...sections,
-    cloud: {
-      name: t`Cloud`,
-      settings: [
-        {
-          key: "store-link",
-          display_name: t`Cloud Settings`,
-          widget: SettingsCloudStoreLink,
-        },
-      ],
-    },
-  }));
-}
+    PLUGIN_ADMIN_SETTINGS_UPDATES.push(sections => ({
+      ...sections,
+      cloud: {
+        name: t`Cloud`,
+        settings: [
+          {
+            key: "store-link",
+            display_name: t`Cloud Settings`,
+            widget: SettingsCloudStoreLink,
+          },
+        ],
+      },
+    }));
+  }
+};

--- a/enterprise/frontend/src/metabase-enterprise/license/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/license/index.js
@@ -5,13 +5,15 @@ import { PLUGIN_ADMIN_SETTINGS_UPDATES } from "metabase/plugins";
 
 import LicenseAndBillingSettings from "./components/LicenseAndBillingSettings";
 
-PLUGIN_ADMIN_SETTINGS_UPDATES.push(sections =>
-  updateIn(sections, ["license"], license => {
-    return {
-      ...license,
-      component: LicenseAndBillingSettings,
-      name: t`License and Billing`,
-      adminOnly: true,
-    };
-  }),
-);
+export const activateLicensePlugin = () => {
+  PLUGIN_ADMIN_SETTINGS_UPDATES.push(sections =>
+    updateIn(sections, ["license"], license => {
+      return {
+        ...license,
+        component: LicenseAndBillingSettings,
+        name: t`License and Billing`,
+        adminOnly: true,
+      };
+    }),
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/llm_autodescription/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/llm_autodescription/index.ts
@@ -3,7 +3,9 @@ import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import { LLMSuggestQuestionInfo } from "./LLMSuggestQuestionInfo";
 
-if (hasPremiumFeature("llm_autodescription")) {
-  PLUGIN_LLM_AUTODESCRIPTION.isEnabled = () => true;
-  PLUGIN_LLM_AUTODESCRIPTION.LLMSuggestQuestionInfo = LLMSuggestQuestionInfo;
-}
+export const activateLLMAutoDescriptionPlugin = () => {
+  if (hasPremiumFeature("llm_autodescription")) {
+    PLUGIN_LLM_AUTODESCRIPTION.isEnabled = () => true;
+    PLUGIN_LLM_AUTODESCRIPTION.LLMSuggestQuestionInfo = LLMSuggestQuestionInfo;
+  }
+};

--- a/enterprise/frontend/src/metabase-enterprise/model_persistence/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/model_persistence/index.ts
@@ -8,23 +8,25 @@ import ModelCacheControl, {
   toggleModelPersistence,
 } from "./components/ModelCacheControl";
 
-if (hasPremiumFeature("cache_granular_controls")) {
-  PLUGIN_MODEL_PERSISTENCE.isModelLevelPersistenceEnabled = () => true;
+export const activateModelPersistencePlugin = () => {
+  if (hasPremiumFeature("cache_granular_controls")) {
+    PLUGIN_MODEL_PERSISTENCE.isModelLevelPersistenceEnabled = () => true;
 
-  PLUGIN_MODEL_PERSISTENCE.ModelCacheControl = ModelCacheControl;
+    PLUGIN_MODEL_PERSISTENCE.ModelCacheControl = ModelCacheControl;
 
-  PLUGIN_MODEL_PERSISTENCE.getMenuItems = (
-    model: Question,
-    onChange?: (isPersisted: boolean) => void,
-  ) => {
-    const isPersisted = model.isPersisted();
+    PLUGIN_MODEL_PERSISTENCE.getMenuItems = (
+      model: Question,
+      onChange?: (isPersisted: boolean) => void,
+    ) => {
+      const isPersisted = model.isPersisted();
 
-    return {
-      title: isPersisted
-        ? t`Turn model persistence off`
-        : t`Turn model persistence on`,
-      action: () => toggleModelPersistence(model, onChange),
-      icon: "database",
+      return {
+        title: isPersisted
+          ? t`Turn model persistence off`
+          : t`Turn model persistence on`,
+        action: () => toggleModelPersistence(model, onChange),
+        icon: "database",
+      };
     };
-  };
-}
+  }
+};

--- a/enterprise/frontend/src/metabase-enterprise/moderation/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/index.js
@@ -20,50 +20,52 @@ import {
 } from "./service";
 import { getVerifyQuestionTitle } from "./utils";
 
-if (hasPremiumFeature("content_verification")) {
-  Object.assign(PLUGIN_MODERATION, {
-    isEnabled: () => true,
-    QuestionModerationIcon,
-    QuestionModerationSection,
-    QuestionModerationButton,
-    ModerationReviewBanner,
-    ModerationStatusIcon,
-    getStatusIcon,
-    getQuestionIcon,
-    getModerationTimelineEvents,
-    getMenuItems: (model, isModerator, reload) => {
-      const id = model.id();
-      const { name: verifiedIconName } = getStatusIcon(
-        MODERATION_STATUS.verified,
-      );
-      const latestModerationReview = getLatestModerationReview(
-        model.getModerationReviews(),
-      );
-      const isVerified = isItemVerified(latestModerationReview);
+export const activateModerationPlugin = () => {
+  if (hasPremiumFeature("content_verification")) {
+    Object.assign(PLUGIN_MODERATION, {
+      isEnabled: () => true,
+      QuestionModerationIcon,
+      QuestionModerationSection,
+      QuestionModerationButton,
+      ModerationReviewBanner,
+      ModerationStatusIcon,
+      getStatusIcon,
+      getQuestionIcon,
+      getModerationTimelineEvents,
+      getMenuItems: (model, isModerator, reload) => {
+        const id = model.id();
+        const { name: verifiedIconName } = getStatusIcon(
+          MODERATION_STATUS.verified,
+        );
+        const latestModerationReview = getLatestModerationReview(
+          model.getModerationReviews(),
+        );
+        const isVerified = isItemVerified(latestModerationReview);
 
-      if (isModerator) {
-        return [
-          {
-            title: isVerified
-              ? t`Remove verification`
-              : getVerifyQuestionTitle(model),
-            icon: isVerified ? "close" : verifiedIconName,
-            action: async () => {
-              if (isVerified) {
-                await removeReview({ itemId: id, itemType: "card" });
-              } else {
-                await verifyItem({ itemId: id, itemType: "card" });
-              }
-              reload();
+        if (isModerator) {
+          return [
+            {
+              title: isVerified
+                ? t`Remove verification`
+                : getVerifyQuestionTitle(model),
+              icon: isVerified ? "close" : verifiedIconName,
+              action: async () => {
+                if (isVerified) {
+                  await removeReview({ itemId: id, itemType: "card" });
+                } else {
+                  await verifyItem({ itemId: id, itemType: "card" });
+                }
+                reload();
+              },
+              testId: isVerified
+                ? "moderation-remove-verification-action"
+                : "moderation-verify-action",
             },
-            testId: isVerified
-              ? "moderation-remove-verification-action"
-              : "moderation-verify-action",
-          },
-        ];
-      }
+          ];
+        }
 
-      return [];
-    },
-  });
-}
+        return [];
+      },
+    });
+  }
+};

--- a/enterprise/frontend/src/metabase-enterprise/plugins.js
+++ b/enterprise/frontend/src/metabase-enterprise/plugins.js
@@ -69,6 +69,5 @@ export const activateEEPlugins = () => {
 };
 
 if (!isEmbeddingSdk) {
-  console.warn("EE plugins are  being activated");
-  // activateEEPlugins();
+  activateEEPlugins();
 }

--- a/enterprise/frontend/src/metabase-enterprise/plugins.js
+++ b/enterprise/frontend/src/metabase-enterprise/plugins.js
@@ -1,4 +1,3 @@
-import { isEmbeddingSdk } from "metabase/env";
 import MetabaseSettings from "metabase/lib/settings";
 import { PLUGIN_IS_EE_BUILD } from "metabase/plugins";
 
@@ -72,7 +71,3 @@ export const activateEEPlugins = () => {
   activateCollectionCleanupPlugin();
   activateTroubleshootingPlugin();
 };
-
-if (!isEmbeddingSdk) {
-  activateEEPlugins();
-}

--- a/enterprise/frontend/src/metabase-enterprise/plugins.js
+++ b/enterprise/frontend/src/metabase-enterprise/plugins.js
@@ -2,9 +2,33 @@ import { isEmbeddingSdk } from "metabase/env";
 import MetabaseSettings from "metabase/lib/settings";
 import { PLUGIN_IS_EE_BUILD } from "metabase/plugins";
 
+import { activateAdvancedPermissionsPlugin } from "./advanced_permissions";
+import { activateApplicationPermissionsPlugin } from "./application_permissions";
+import { activateAuditAppPlugin } from "./audit_app";
+import { activateAuthPlugin } from "./auth";
+import { activateCachingPlugin } from "./caching";
+import { activateCollectionCleanupPlugin } from "./clean_up";
 import { activateCollectionsPlugin } from "./collections";
 import { activateContentVerificationPlugin } from "./content_verification";
+import { activateEmailAllowListPlugin } from "./email_allow_list";
+import { activateEmailRestrictRecipientsPlugin } from "./email_restrict_recipients";
+import { activateEmbeddingPlugin } from "./embedding";
+import { activateFeatureLevelPermissionsPlugin } from "./feature_level_permissions";
+import { activateGroupManagersPlugin } from "./group_managers";
+import { activateHostingPlugin } from "./hosting";
+import { activateLicensePlugin } from "./license";
+import { activateLLMAutoDescriptionPlugin } from "./llm_autodescription";
+import { activateModelPersistencePlugin } from "./model_persistence";
+import { activateModerationPlugin } from "./moderation";
 import { enableResourceDownloadsPlugin } from "./resource_downloads";
+import { activateSandboxesPlugin } from "./sandboxes";
+import { activateSharedPlugin } from "./shared";
+import { activateSharingPlugin } from "./sharing";
+import { activateSnippetsPlugin } from "./snippets";
+import { activateToolsPlugin } from "./tools";
+import { activateTroubleshootingPlugin } from "./troubleshooting";
+import { activateUploadManagementPlugin } from "./upload_management";
+import { activateUserProvisioningPlugin } from "./user_provisioning";
 import { activateWhitelabelPlugins } from "./whitelabel";
 
 // SETTINGS OVERRIDES:
@@ -13,41 +37,38 @@ import { activateWhitelabelPlugins } from "./whitelabel";
 MetabaseSettings.docsTag = () => "latest";
 PLUGIN_IS_EE_BUILD.isEEBuild = () => true;
 
-// PLUGINS:
-import "./shared";
-import "./hosting";
-import "./tools";
-import "./sandboxes";
-import "./auth";
-import "./caching";
-import "./embedding";
-import "./snippets";
-import "./sharing";
-import "./moderation";
-import "./email_allow_list";
-import "./email_restrict_recipients";
-import "./advanced_permissions";
-import "./audit_app";
-import "./license";
-import "./model_persistence";
-import "./feature_level_permissions";
-import "./application_permissions";
-import "./group_managers";
-import "./llm_autodescription";
-import "./upload_management";
-import "./user_provisioning";
-import "./clean_up";
-import "./troubleshooting";
-
-// plugins with activate functions, so we can manually activate them for the sdk when we load the token-features
-
 export const activateEEPlugins = () => {
   activateWhitelabelPlugins();
   activateContentVerificationPlugin();
   activateCollectionsPlugin();
   enableResourceDownloadsPlugin();
+  activateSharedPlugin();
+  activateHostingPlugin();
+  activateToolsPlugin();
+  activateSandboxesPlugin();
+  activateAuthPlugin();
+  activateCachingPlugin();
+  activateEmbeddingPlugin();
+  activateSnippetsPlugin();
+  activateSharingPlugin();
+  activateModerationPlugin();
+  activateEmailAllowListPlugin();
+  activateEmailRestrictRecipientsPlugin();
+  activateAdvancedPermissionsPlugin();
+  activateAuditAppPlugin();
+  activateLicensePlugin();
+  activateModelPersistencePlugin();
+  activateFeatureLevelPermissionsPlugin();
+  activateApplicationPermissionsPlugin();
+  activateGroupManagersPlugin();
+  activateLLMAutoDescriptionPlugin();
+  activateUploadManagementPlugin();
+  activateUserProvisioningPlugin();
+  activateCollectionCleanupPlugin();
+  activateTroubleshootingPlugin();
 };
 
 if (!isEmbeddingSdk) {
-  activateEEPlugins();
+  console.warn("EE plugins are  being activated");
+  // activateEEPlugins();
 }

--- a/enterprise/frontend/src/metabase-enterprise/plugins.js
+++ b/enterprise/frontend/src/metabase-enterprise/plugins.js
@@ -1,5 +1,11 @@
+import { isEmbeddingSdk } from "metabase/env";
 import MetabaseSettings from "metabase/lib/settings";
 import { PLUGIN_IS_EE_BUILD } from "metabase/plugins";
+
+import { activateCollectionsPlugin } from "./collections";
+import { activateContentVerificationPlugin } from "./content_verification";
+import { enableResourceDownloadsPlugin } from "./resource_downloads";
+import { activateWhitelabelPlugins } from "./whitelabel";
 
 // SETTINGS OVERRIDES:
 
@@ -7,18 +13,13 @@ import { PLUGIN_IS_EE_BUILD } from "metabase/plugins";
 MetabaseSettings.docsTag = () => "latest";
 PLUGIN_IS_EE_BUILD.isEEBuild = () => true;
 
-import "./shared";
-
 // PLUGINS:
-
+import "./shared";
 import "./hosting";
 import "./tools";
 import "./sandboxes";
 import "./auth";
 import "./caching";
-import "./collections";
-import "./content_verification";
-import "./whitelabel";
 import "./embedding";
 import "./snippets";
 import "./sharing";
@@ -34,7 +35,19 @@ import "./application_permissions";
 import "./group_managers";
 import "./llm_autodescription";
 import "./upload_management";
-import "./resource_downloads";
 import "./user_provisioning";
 import "./clean_up";
 import "./troubleshooting";
+
+// plugins with activate functions, so we can manually activate them for the sdk when we load the token-features
+
+export const activateEEPlugins = () => {
+  activateWhitelabelPlugins();
+  activateContentVerificationPlugin();
+  activateCollectionsPlugin();
+  enableResourceDownloadsPlugin();
+};
+
+if (!isEmbeddingSdk) {
+  activateEEPlugins();
+}

--- a/enterprise/frontend/src/metabase-enterprise/plugins.js
+++ b/enterprise/frontend/src/metabase-enterprise/plugins.js
@@ -37,7 +37,12 @@ import { activateWhitelabelPlugins } from "./whitelabel";
 MetabaseSettings.docsTag = () => "latest";
 PLUGIN_IS_EE_BUILD.isEEBuild = () => true;
 
+let pluginEnabled = false;
 export const activateEEPlugins = () => {
+  if (pluginEnabled) {
+    return;
+  }
+  pluginEnabled = true;
   activateWhitelabelPlugins();
   activateContentVerificationPlugin();
   activateCollectionsPlugin();

--- a/enterprise/frontend/src/metabase-enterprise/resource_downloads/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/resource_downloads/index.ts
@@ -1,1 +1,1 @@
-import "./resource_downloads_plugin";
+export * from "./resource_downloads_plugin";

--- a/enterprise/frontend/src/metabase-enterprise/resource_downloads/resource_downloads_plugin.ts
+++ b/enterprise/frontend/src/metabase-enterprise/resource_downloads/resource_downloads_plugin.ts
@@ -3,26 +3,28 @@ import { match } from "ts-pattern";
 import { PLUGIN_RESOURCE_DOWNLOADS } from "metabase/plugins";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
-if (hasPremiumFeature("whitelabel")) {
-  /**
-   * Returns if 'download results' on cards and pdf exports are enabled in public and embedded contexts.
-   */
-  PLUGIN_RESOURCE_DOWNLOADS.areDownloadsEnabled = ({
-    hide_download_button,
-    downloads,
-  }: {
-    hide_download_button?: boolean | null;
-    downloads?: boolean | null;
-  }) => {
-    return (
-      match({ hide_download_button, downloads })
-        // `downloads` has priority over `hide_download_button`
-        .with({ downloads: true }, () => true)
-        .with({ downloads: false }, () => false)
-        // but we still support the old `hide_download_button` option
-        .with({ hide_download_button: true }, () => false)
-        // by default downloads are enabled
-        .otherwise(() => true)
-    );
-  };
-}
+export const enableResourceDownloadsPlugin = () => {
+  if (hasPremiumFeature("whitelabel")) {
+    /**
+     * Returns if 'download results' on cards and pdf exports are enabled in public and embedded contexts.
+     */
+    PLUGIN_RESOURCE_DOWNLOADS.areDownloadsEnabled = ({
+      hide_download_button,
+      downloads,
+    }: {
+      hide_download_button?: boolean | null;
+      downloads?: boolean | null;
+    }) => {
+      return (
+        match({ hide_download_button, downloads })
+          // `downloads` has priority over `hide_download_button`
+          .with({ downloads: true }, () => true)
+          .with({ downloads: false }, () => false)
+          // but we still support the old `hide_download_button` option
+          .with({ hide_download_button: true }, () => false)
+          // by default downloads are enabled
+          .otherwise(() => true)
+      );
+    };
+  }
+};

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/index.js
@@ -55,44 +55,46 @@ const getEditSegementedAccessUrl = (entityId, groupId, view) =>
 const getEditSegmentedAccessPostAction = (entityId, groupId, view) =>
   push(getEditSegementedAccessUrl(entityId, groupId, view));
 
-if (hasPremiumFeature("sandboxes")) {
-  PLUGIN_ADMIN_USER_FORM_FIELDS.FormLoginAttributes = LoginAttributesWidget;
+export const activateSandboxesPlugin = () => {
+  if (hasPremiumFeature("sandboxes")) {
+    PLUGIN_ADMIN_USER_FORM_FIELDS.FormLoginAttributes = LoginAttributesWidget;
 
-  PLUGIN_ADMIN_PERMISSIONS_TABLE_ROUTES.push(
-    <ModalRoute
-      key=":tableId/segmented"
-      path=":tableId/segmented"
-      modal={EditSandboxingModal}
-    />,
-  );
-  PLUGIN_ADMIN_PERMISSIONS_TABLE_GROUP_ROUTES.push(
-    <ModalRoute
-      key="segmented/group/:groupId"
-      path="segmented/group/:groupId"
-      modal={EditSandboxingModal}
-    />,
-  );
-  PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_OPTIONS.push(OPTION_SEGMENTED);
-  PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_ACTIONS[OPTION_SEGMENTED.value].push({
-    label: t`Edit sandboxed access`,
-    iconColor: "brand",
-    icon: "pencil",
-    actionCreator: (entityId, groupId, view) =>
-      push(getEditSegementedAccessUrl(entityId, groupId, view)),
-  });
-  PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_CONFIRMATIONS.push(
-    (permissions, groupId, entityId, newValue) =>
-      getSandboxedTableWarningModal(permissions, groupId, entityId, newValue),
-  );
-  PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_POST_ACTION[OPTION_SEGMENTED.value] =
-    getEditSegmentedAccessPostAction;
+    PLUGIN_ADMIN_PERMISSIONS_TABLE_ROUTES.push(
+      <ModalRoute
+        key=":tableId/segmented"
+        path=":tableId/segmented"
+        modal={EditSandboxingModal}
+      />,
+    );
+    PLUGIN_ADMIN_PERMISSIONS_TABLE_GROUP_ROUTES.push(
+      <ModalRoute
+        key="segmented/group/:groupId"
+        path="segmented/group/:groupId"
+        modal={EditSandboxingModal}
+      />,
+    );
+    PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_OPTIONS.push(OPTION_SEGMENTED);
+    PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_ACTIONS[OPTION_SEGMENTED.value].push({
+      label: t`Edit sandboxed access`,
+      iconColor: "brand",
+      icon: "pencil",
+      actionCreator: (entityId, groupId, view) =>
+        push(getEditSegementedAccessUrl(entityId, groupId, view)),
+    });
+    PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_CONFIRMATIONS.push(
+      (permissions, groupId, entityId, newValue) =>
+        getSandboxedTableWarningModal(permissions, groupId, entityId, newValue),
+    );
+    PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_POST_ACTION[OPTION_SEGMENTED.value] =
+      getEditSegmentedAccessPostAction;
 
-  PLUGIN_DATA_PERMISSIONS.permissionsPayloadExtraSelectors.push(state => {
-    const sandboxes = getDraftPolicies(state);
-    const modifiedGroupIds = _.uniq(sandboxes.map(sb => sb.group_id));
-    return [{ sandboxes }, modifiedGroupIds];
-  });
+    PLUGIN_DATA_PERMISSIONS.permissionsPayloadExtraSelectors.push(state => {
+      const sandboxes = getDraftPolicies(state);
+      const modifiedGroupIds = _.uniq(sandboxes.map(sb => sb.group_id));
+      return [{ sandboxes }, modifiedGroupIds];
+    });
 
-  PLUGIN_DATA_PERMISSIONS.hasChanges.push(hasPolicyChanges);
-  PLUGIN_REDUCERS.sandboxingPlugin = sandboxingReducer;
-}
+    PLUGIN_DATA_PERMISSIONS.hasChanges.push(hasPolicyChanges);
+    PLUGIN_REDUCERS.sandboxingPlugin = sandboxingReducer;
+  }
+};

--- a/enterprise/frontend/src/metabase-enterprise/shared/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/shared/index.ts
@@ -2,4 +2,6 @@ import { PLUGIN_REDUCERS } from "metabase/plugins";
 
 import { shared } from "./reducer";
 
-PLUGIN_REDUCERS.shared = shared.reducer;
+export const activateSharedPlugin = () => {
+  PLUGIN_REDUCERS.shared = shared.reducer;
+};

--- a/enterprise/frontend/src/metabase-enterprise/sharing/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/sharing/index.js
@@ -2,7 +2,9 @@ import { PLUGIN_DASHBOARD_SUBSCRIPTION_PARAMETERS_SECTION_OVERRIDE } from "metab
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 import { MutableParametersSection } from "metabase-enterprise/sharing/components/MutableParametersSection";
 
-if (hasPremiumFeature("dashboard_subscription_filters")) {
-  PLUGIN_DASHBOARD_SUBSCRIPTION_PARAMETERS_SECTION_OVERRIDE.Component =
-    MutableParametersSection;
-}
+export const activateSharingPlugin = () => {
+  if (hasPremiumFeature("dashboard_subscription_filters")) {
+    PLUGIN_DASHBOARD_SUBSCRIPTION_PARAMETERS_SECTION_OVERRIDE.Component =
+      MutableParametersSection;
+  }
+};

--- a/enterprise/frontend/src/metabase-enterprise/snippets/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/snippets/index.js
@@ -15,70 +15,72 @@ import CollectionOptionsButton from "./components/CollectionOptionsButton";
 import CollectionRow from "./components/CollectionRow";
 import SnippetCollectionFormModal from "./components/SnippetCollectionFormModal";
 
-if (hasPremiumFeature("snippet_collections")) {
-  PLUGIN_SNIPPET_SIDEBAR_PLUS_MENU_OPTIONS.push(snippetSidebar => ({
-    icon: "folder",
-    name: t`New folder`,
-    onClick: () =>
-      snippetSidebar.setState({
-        modalSnippetCollection: {
-          parent_id: canonicalCollectionId(
-            snippetSidebar.props.snippetCollection.id,
-          ),
-        },
-      }),
-  }));
+export const activateSnippetsPlugin = () => {
+  if (hasPremiumFeature("snippet_collections")) {
+    PLUGIN_SNIPPET_SIDEBAR_PLUS_MENU_OPTIONS.push(snippetSidebar => ({
+      icon: "folder",
+      name: t`New folder`,
+      onClick: () =>
+        snippetSidebar.setState({
+          modalSnippetCollection: {
+            parent_id: canonicalCollectionId(
+              snippetSidebar.props.snippetCollection.id,
+            ),
+          },
+        }),
+    }));
 
-  PLUGIN_SNIPPET_SIDEBAR_MODALS.push(
-    snippetSidebar =>
-      snippetSidebar.state.modalSnippetCollection && (
-        <Modal
-          onClose={() =>
-            snippetSidebar.setState({ modalSnippetCollection: null })
-          }
-        >
-          <SnippetCollectionFormModal
-            collection={snippetSidebar.state.modalSnippetCollection}
+    PLUGIN_SNIPPET_SIDEBAR_MODALS.push(
+      snippetSidebar =>
+        snippetSidebar.state.modalSnippetCollection && (
+          <Modal
             onClose={() =>
               snippetSidebar.setState({ modalSnippetCollection: null })
             }
-            onSaved={() => {
-              snippetSidebar.setState({ modalSnippetCollection: null });
-            }}
-          />
-        </Modal>
-      ),
-    snippetSidebar =>
-      snippetSidebar.state.permissionsModalCollectionId != null && (
-        <Modal
-          onClose={() =>
-            snippetSidebar.setState({ permissionsModalCollectionId: null })
-          }
-        >
-          <CollectionPermissionsModal
-            params={{
-              slug: snippetSidebar.state.permissionsModalCollectionId,
-            }}
+          >
+            <SnippetCollectionFormModal
+              collection={snippetSidebar.state.modalSnippetCollection}
+              onClose={() =>
+                snippetSidebar.setState({ modalSnippetCollection: null })
+              }
+              onSaved={() => {
+                snippetSidebar.setState({ modalSnippetCollection: null });
+              }}
+            />
+          </Modal>
+        ),
+      snippetSidebar =>
+        snippetSidebar.state.permissionsModalCollectionId != null && (
+          <Modal
             onClose={() =>
               snippetSidebar.setState({ permissionsModalCollectionId: null })
             }
-            namespace="snippets"
-          />
-        </Modal>
-      ),
-  );
-
-  PLUGIN_SNIPPET_SIDEBAR_ROW_RENDERERS.collection = CollectionRow;
-
-  PLUGIN_SNIPPET_SIDEBAR_HEADER_BUTTONS.push((snippetSidebar, props) => {
-    const collection = snippetSidebar.props.snippetCollection;
-    return (
-      <CollectionOptionsButton
-        {...snippetSidebar.props}
-        {...props}
-        setSidebarState={snippetSidebar.setState.bind(snippetSidebar)}
-        collection={collection}
-      />
+          >
+            <CollectionPermissionsModal
+              params={{
+                slug: snippetSidebar.state.permissionsModalCollectionId,
+              }}
+              onClose={() =>
+                snippetSidebar.setState({ permissionsModalCollectionId: null })
+              }
+              namespace="snippets"
+            />
+          </Modal>
+        ),
     );
-  });
-}
+
+    PLUGIN_SNIPPET_SIDEBAR_ROW_RENDERERS.collection = CollectionRow;
+
+    PLUGIN_SNIPPET_SIDEBAR_HEADER_BUTTONS.push((snippetSidebar, props) => {
+      const collection = snippetSidebar.props.snippetCollection;
+      return (
+        <CollectionOptionsButton
+          {...snippetSidebar.props}
+          {...props}
+          setSidebarState={snippetSidebar.setState.bind(snippetSidebar)}
+          collection={collection}
+        />
+      );
+    });
+  }
+};

--- a/enterprise/frontend/src/metabase-enterprise/tools/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/tools/index.js
@@ -6,22 +6,24 @@ import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import ErrorOverview from "./ErrorOverview";
 
-if (hasPremiumFeature("audit_app")) {
-  PLUGIN_ADMIN_TOOLS.INDEX_ROUTE = "errors";
+export const activateToolsPlugin = () => {
+  if (hasPremiumFeature("audit_app")) {
+    PLUGIN_ADMIN_TOOLS.INDEX_ROUTE = "errors";
 
-  PLUGIN_ADMIN_TOOLS.EXTRA_ROUTES_INFO = [
-    {
-      name: t`Questions`,
-      value: "errors",
-    },
-  ];
+    PLUGIN_ADMIN_TOOLS.EXTRA_ROUTES_INFO = [
+      {
+        name: t`Questions`,
+        value: "errors",
+      },
+    ];
 
-  PLUGIN_ADMIN_TOOLS.EXTRA_ROUTES = [
-    <Route
-      key="error-overview"
-      path="errors"
-      title={t`Erroring Questions`}
-      component={ErrorOverview}
-    />,
-  ];
-}
+    PLUGIN_ADMIN_TOOLS.EXTRA_ROUTES = [
+      <Route
+        key="error-overview"
+        path="errors"
+        title={t`Erroring Questions`}
+        component={ErrorOverview}
+      />,
+    ];
+  }
+};

--- a/enterprise/frontend/src/metabase-enterprise/troubleshooting/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/troubleshooting/index.tsx
@@ -11,31 +11,33 @@ import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import { QueryValidator } from "./components/QueryValidator";
 
-if (hasPremiumFeature("query_reference_validation")) {
-  PLUGIN_ADMIN_TROUBLESHOOTING.EXTRA_ROUTES = [
-    <Route
-      key="query-validator"
-      path="query-validator"
-      component={QueryValidator}
-    />,
-  ];
+export const activateTroubleshootingPlugin = () => {
+  if (hasPremiumFeature("query_reference_validation")) {
+    PLUGIN_ADMIN_TROUBLESHOOTING.EXTRA_ROUTES = [
+      <Route
+        key="query-validator"
+        path="query-validator"
+        component={QueryValidator}
+      />,
+    ];
 
-  PLUGIN_ADMIN_TROUBLESHOOTING.GET_EXTRA_NAV = () => [
-    <LeftNavPaneItem
-      key="query-validator"
-      name={t`Query Validator`}
-      path="/admin/troubleshooting/query-validator"
-    />,
-  ];
+    PLUGIN_ADMIN_TROUBLESHOOTING.GET_EXTRA_NAV = () => [
+      <LeftNavPaneItem
+        key="query-validator"
+        name={t`Query Validator`}
+        path="/admin/troubleshooting/query-validator"
+      />,
+    ];
 
-  PLUGIN_ADMIN_SETTINGS_UPDATES.push(sections =>
-    updateIn(sections, ["general", "settings"], settings => [
-      ...settings,
-      {
-        key: "query-analysis-enabled",
-        display_name: t`Enable query analysis`,
-        type: "boolean",
-      },
-    ]),
-  );
-}
+    PLUGIN_ADMIN_SETTINGS_UPDATES.push(sections =>
+      updateIn(sections, ["general", "settings"], settings => [
+        ...settings,
+        {
+          key: "query-analysis-enabled",
+          display_name: t`Enable query analysis`,
+          type: "boolean",
+        },
+      ]),
+    );
+  }
+};

--- a/enterprise/frontend/src/metabase-enterprise/upload_management/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/upload_management/index.ts
@@ -3,6 +3,8 @@ import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import { UploadManagementTable } from "./UploadManagementTable";
 
-if (hasPremiumFeature("upload_management")) {
-  PLUGIN_UPLOAD_MANAGEMENT.UploadManagementTable = UploadManagementTable;
-}
+export const activateUploadManagementPlugin = () => {
+  if (hasPremiumFeature("upload_management")) {
+    PLUGIN_UPLOAD_MANAGEMENT.UploadManagementTable = UploadManagementTable;
+  }
+};

--- a/enterprise/frontend/src/metabase-enterprise/user_provisioning/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/user_provisioning/index.ts
@@ -8,49 +8,51 @@ import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import { UserProvisioning } from "./components/UserProvisioning";
 
-if (hasPremiumFeature("scim")) {
-  PLUGIN_ADMIN_SETTINGS_AUTH_TABS.push({
-    name: t`User Provisioning`,
-    key: "user-provisioning",
-    to: "/admin/settings/authentication/user-provisioning",
-  });
+export const activateUserProvisioningPlugin = () => {
+  if (hasPremiumFeature("scim")) {
+    PLUGIN_ADMIN_SETTINGS_AUTH_TABS.push({
+      name: t`User Provisioning`,
+      key: "user-provisioning",
+      to: "/admin/settings/authentication/user-provisioning",
+    });
 
-  // move api keys to its own tab when scim is enabled
-  PLUGIN_ADMIN_SETTINGS_AUTH_TABS.push({
-    name: t`API Keys`,
-    key: "api-keys",
-    to: "/admin/settings/authentication/api-keys",
-  });
+    // move api keys to its own tab when scim is enabled
+    PLUGIN_ADMIN_SETTINGS_AUTH_TABS.push({
+      name: t`API Keys`,
+      key: "api-keys",
+      to: "/admin/settings/authentication/api-keys",
+    });
 
-  PLUGIN_ADMIN_SETTINGS_UPDATES.push(sections => ({
-    ...sections,
-    authentication: {
-      ...sections.authentication,
-      // remove api keys from the authentication tab's content when scim is enabled
-      settings: sections.authentication.settings.filter(
-        (setting: { key: string }) => setting.key !== "api-keys",
-      ),
-    },
-    "authentication/user-provisioning": {
-      settings: [
-        {
-          key: "scim-enabled",
-          display_name: t`User Provisioning via SCIM`,
-          type: "boolean",
-        },
-        {
-          key: "scim-base-url",
-          display_name: t`SCIM endpoint URL`,
-          type: "string",
-        },
-        {
-          key: "send-new-sso-user-admin-email?",
-          display_name: t`Notify admins of new SSO users`,
-          description: t`When enabled, administrators will receive an email the first time a user uses Single Sign-On.`,
-          type: "boolean",
-        },
-      ],
-      component: UserProvisioning,
-    },
-  }));
-}
+    PLUGIN_ADMIN_SETTINGS_UPDATES.push(sections => ({
+      ...sections,
+      authentication: {
+        ...sections.authentication,
+        // remove api keys from the authentication tab's content when scim is enabled
+        settings: sections.authentication.settings.filter(
+          (setting: { key: string }) => setting.key !== "api-keys",
+        ),
+      },
+      "authentication/user-provisioning": {
+        settings: [
+          {
+            key: "scim-enabled",
+            display_name: t`User Provisioning via SCIM`,
+            type: "boolean",
+          },
+          {
+            key: "scim-base-url",
+            display_name: t`SCIM endpoint URL`,
+            type: "string",
+          },
+          {
+            key: "send-new-sso-user-admin-email?",
+            display_name: t`Notify admins of new SSO users`,
+            description: t`When enabled, administrators will receive an email the first time a user uses Single Sign-On.`,
+            type: "boolean",
+          },
+        ],
+        component: UserProvisioning,
+      },
+    }));
+  }
+};

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/index.js
@@ -42,282 +42,285 @@ import {
 import { getLoadingMessageOptions } from "./lib/loading-message";
 import { updateColors } from "./lib/whitelabel";
 
-if (hasPremiumFeature("whitelabel")) {
-  PLUGIN_LANDING_PAGE.push(() => MetabaseSettings.get("landing-page"));
-  PLUGIN_ADMIN_SETTINGS_UPDATES.push(
-    sections => ({
-      ...sections,
-      whitelabel: {
-        name: t`Appearance`,
-        key: "-redirect-to-branding",
-        settings: [
-          {
-            key: "-redirect-to-branding",
-            widget: () => (
-              <RedirectWidget to="/admin/settings/whitelabel/branding" />
-            ),
-          },
-        ],
-      },
-      "whitelabel/branding": {
-        tabs: [
-          {
-            name: t`Branding`,
-            key: "branding",
-            to: "/admin/settings/whitelabel/branding",
-            isActive: true,
-          },
-          {
-            // eslint-disable-next-line no-literal-metabase-strings -- Admin settings
-            name: t`Conceal Metabase`,
-            key: "conceal-metabase",
-            to: "/admin/settings/whitelabel/conceal-metabase",
-          },
-        ],
-        settings: [
-          // 1. Branding tab
-          {
-            key: "-branding-introduction",
-            widget: () => (
-              <Text>
-                {t`Configure your instance to match your brand visuals and voice`}
-              </Text>
-            ),
-          },
-          {
-            key: "application-colors",
-            display_name: t`Color Palette`,
-            widget: ColorSettingsWidget,
-          },
-          {
-            key: "application-logo-url",
-            display_name: t`Logo`,
-            note: (
-              <Text size="sm" color="text-light">
-                {t`For best results, use an SVG file with a transparent
+export const activateWhitelabelPlugins = () => {
+  if (hasPremiumFeature("whitelabel")) {
+    PLUGIN_LANDING_PAGE.push(() => MetabaseSettings.get("landing-page"));
+    PLUGIN_ADMIN_SETTINGS_UPDATES.push(
+      sections => ({
+        ...sections,
+        whitelabel: {
+          name: t`Appearance`,
+          key: "-redirect-to-branding",
+          settings: [
+            {
+              key: "-redirect-to-branding",
+              widget: () => (
+                <RedirectWidget to="/admin/settings/whitelabel/branding" />
+              ),
+            },
+          ],
+        },
+        "whitelabel/branding": {
+          tabs: [
+            {
+              name: t`Branding`,
+              key: "branding",
+              to: "/admin/settings/whitelabel/branding",
+              isActive: true,
+            },
+            {
+              // eslint-disable-next-line no-literal-metabase-strings -- Admin settings
+              name: t`Conceal Metabase`,
+              key: "conceal-metabase",
+              to: "/admin/settings/whitelabel/conceal-metabase",
+            },
+          ],
+          settings: [
+            // 1. Branding tab
+            {
+              key: "-branding-introduction",
+              widget: () => (
+                <Text>
+                  {t`Configure your instance to match your brand visuals and voice`}
+                </Text>
+              ),
+            },
+            {
+              key: "application-colors",
+              display_name: t`Color Palette`,
+              widget: ColorSettingsWidget,
+            },
+            {
+              key: "application-logo-url",
+              display_name: t`Logo`,
+              note: (
+                <Text size="sm" color="text-light">
+                  {t`For best results, use an SVG file with a transparent
               background.`}
-              </Text>
-            ),
-            type: "string",
-            widget: ImageUpload,
-          },
-          {
-            key: "application-font",
-            display_name: t`Font`,
-            widget: FontWidget,
-          },
-          {
-            key: "application-font-files",
-            widget: FontFilesWidget,
-            getHidden: settings => settings["application-font-files"] == null,
-          },
-          {
-            key: "loading-message",
-            display_name: t`Loading message`,
-            widget: SettingSelect,
-            options: getLoadingMessageOptions(),
-            defaultValue: "doing-science",
-          },
-          {
-            key: "application-favicon-url",
-            display_name: t`Favicon`,
-            type: "string",
-            widget: ImageUpload,
-          },
-        ],
+                </Text>
+              ),
+              type: "string",
+              widget: ImageUpload,
+            },
+            {
+              key: "application-font",
+              display_name: t`Font`,
+              widget: FontWidget,
+            },
+            {
+              key: "application-font-files",
+              widget: FontFilesWidget,
+              getHidden: settings => settings["application-font-files"] == null,
+            },
+            {
+              key: "loading-message",
+              display_name: t`Loading message`,
+              widget: SettingSelect,
+              options: getLoadingMessageOptions(),
+              defaultValue: "doing-science",
+            },
+            {
+              key: "application-favicon-url",
+              display_name: t`Favicon`,
+              type: "string",
+              widget: ImageUpload,
+            },
+          ],
+        },
+        "whitelabel/conceal-metabase": {
+          tabs: [
+            {
+              name: t`Branding`,
+              key: "branding",
+              to: "/admin/settings/whitelabel/branding",
+            },
+            {
+              // eslint-disable-next-line no-literal-metabase-strings -- Admin settings
+              name: t`Conceal Metabase`,
+              key: "conceal-metabase",
+              to: "/admin/settings/whitelabel/conceal-metabase",
+              isActive: true,
+            },
+          ],
+          settings: [
+            // 2. Conceal Metabase tab
+            {
+              key: "-conceal-metabase-introduction",
+              tab: "conceal-metabase",
+              // eslint-disable-next-line no-literal-metabase-strings -- Admin settings
+              description: t`Hide or customize pieces of the Metabase product to tailor the experience to your brand and needs`,
+              type: "hidden",
+            },
+            {
+              key: "application-name",
+              tab: "conceal-metabase",
+              display_name: t`Application Name`,
+              widget: SettingTextInput,
+            },
+            {
+              key: "show-metabase-links",
+              tab: "conceal-metabase",
+              display_name: t`Documentation and references`,
+              // eslint-disable-next-line no-literal-metabase-strings -- Admin settings
+              description: t`Control the display of Metabase documentation and Metabase references in your instance.`,
+              widget: SwitchWidget,
+              props: {
+                // eslint-disable-next-line no-literal-metabase-strings -- Metabase settings
+                label: jt`Show links and references to Metabase ${(
+                  <MetabaseLinksToggleDescription key="show-metabase-links-description-tooltip" />
+                )}`,
+              },
+            },
+            {
+              key: "help-link",
+              tab: "conceal-metabase",
+              display_name: t`Help Link in the Settings menu`,
+              description: (
+                <p>
+                  {jt`Choose a target to the Help link in the Settings menu. It links to ${(
+                    <Anchor
+                      key="this-page"
+                      href="https://www.metabase.com/help"
+                    >{t`this page`}</Anchor>
+                  )} by default.`}
+                </p>
+              ),
+              widget: HelpLinkSettings,
+              defaultValue: "metabase",
+            },
+            {
+              key: "-metabase-illustration",
+              tab: "conceal-metabase",
+              // eslint-disable-next-line no-literal-metabase-strings -- Admin settings
+              display_name: t`Metabase illustrations`,
+              // eslint-disable-next-line no-literal-metabase-strings -- Admin settings
+              description: t`Customize each of the illustrations in Metabase`,
+              type: "hidden",
+            },
+            {
+              key: "show-metabot",
+              tab: "conceal-metabase",
+              display_name: (
+                <Text fw="bold" transform="none">{t`Metabot greeting`}</Text>
+              ),
+              description: null,
+              type: "boolean",
+              defaultValue: true,
+              widget: MetabotToggleWidget,
+            },
+            {
+              key: "login-page-illustration",
+              tab: "conceal-metabase",
+              display_name: (
+                <IllustrationTitle
+                  title={t`Login and unsubscribe pages`}
+                  errorMessageContainerId="login-page-illustration-error-container"
+                />
+              ),
+              description: null,
+              type: "string",
+              widget: IllustrationWidget,
+              props: {
+                type: "background",
+                customIllustrationSetting: "login-page-illustration-custom",
+                errorMessageContainerId:
+                  "login-page-illustration-error-container",
+              },
+            },
+            {
+              key: "landing-page-illustration",
+              tab: "conceal-metabase",
+              display_name: (
+                <IllustrationTitle
+                  title={t`Landing page`}
+                  errorMessageContainerId="landing-page-illustration-error-container"
+                />
+              ),
+              description: null,
+              type: "string",
+              widget: IllustrationWidget,
+              props: {
+                type: "background",
+                customIllustrationSetting: "landing-page-illustration-custom",
+                errorMessageContainerId:
+                  "landing-page-illustration-error-container",
+              },
+            },
+            {
+              key: "no-data-illustration",
+              tab: "conceal-metabase",
+              display_name: (
+                <IllustrationTitle
+                  title={t`When calculations return no results`}
+                  errorMessageContainerId="no-data-illustration-error-container"
+                />
+              ),
+              description: null,
+              type: "string",
+              widget: IllustrationWidget,
+              props: {
+                type: "icon",
+                customIllustrationSetting: "no-data-illustration-custom",
+                errorMessageContainerId: "no-data-illustration-error-container",
+              },
+            },
+            {
+              key: "no-object-illustration",
+              tab: "conceal-metabase",
+              display_name: (
+                <IllustrationTitle
+                  title={t`When no objects can be found`}
+                  errorMessageContainerId="no-object-illustration-error-container"
+                />
+              ),
+              description: null,
+              type: "string",
+              widget: IllustrationWidget,
+              props: {
+                type: "icon",
+                customIllustrationSetting: "no-object-illustration-custom",
+                errorMessageContainerId:
+                  "no-object-illustration-error-container",
+              },
+            },
+          ],
+        },
+      }),
+      sections => {
+        return updateIn(sections, ["general", "settings"], settings => {
+          const customHomepageIndex = settings.findIndex(
+            setting => setting.key === "custom-homepage-dashboard",
+          );
+          return [
+            ...settings.slice(0, customHomepageIndex + 1),
+            {
+              key: "landing-page",
+              display_name: t`Landing Page`,
+              type: "string",
+              placeholder: "/",
+              widget: LandingPageWidget,
+            },
+            ...settings.slice(customHomepageIndex + 1),
+          ];
+        });
       },
-      "whitelabel/conceal-metabase": {
-        tabs: [
-          {
-            name: t`Branding`,
-            key: "branding",
-            to: "/admin/settings/whitelabel/branding",
-          },
-          {
-            // eslint-disable-next-line no-literal-metabase-strings -- Admin settings
-            name: t`Conceal Metabase`,
-            key: "conceal-metabase",
-            to: "/admin/settings/whitelabel/conceal-metabase",
-            isActive: true,
-          },
-        ],
-        settings: [
-          // 2. Conceal Metabase tab
-          {
-            key: "-conceal-metabase-introduction",
-            tab: "conceal-metabase",
-            // eslint-disable-next-line no-literal-metabase-strings -- Admin settings
-            description: t`Hide or customize pieces of the Metabase product to tailor the experience to your brand and needs`,
-            type: "hidden",
-          },
-          {
-            key: "application-name",
-            tab: "conceal-metabase",
-            display_name: t`Application Name`,
-            widget: SettingTextInput,
-          },
-          {
-            key: "show-metabase-links",
-            tab: "conceal-metabase",
-            display_name: t`Documentation and references`,
-            // eslint-disable-next-line no-literal-metabase-strings -- Admin settings
-            description: t`Control the display of Metabase documentation and Metabase references in your instance.`,
-            widget: SwitchWidget,
-            props: {
-              // eslint-disable-next-line no-literal-metabase-strings -- Metabase settings
-              label: jt`Show links and references to Metabase ${(
-                <MetabaseLinksToggleDescription key="show-metabase-links-description-tooltip" />
-              )}`,
-            },
-          },
-          {
-            key: "help-link",
-            tab: "conceal-metabase",
-            display_name: t`Help Link in the Settings menu`,
-            description: (
-              <p>
-                {jt`Choose a target to the Help link in the Settings menu. It links to ${(
-                  <Anchor
-                    key="this-page"
-                    href="https://www.metabase.com/help"
-                  >{t`this page`}</Anchor>
-                )} by default.`}
-              </p>
-            ),
-            widget: HelpLinkSettings,
-            defaultValue: "metabase",
-          },
-          {
-            key: "-metabase-illustration",
-            tab: "conceal-metabase",
-            // eslint-disable-next-line no-literal-metabase-strings -- Admin settings
-            display_name: t`Metabase illustrations`,
-            // eslint-disable-next-line no-literal-metabase-strings -- Admin settings
-            description: t`Customize each of the illustrations in Metabase`,
-            type: "hidden",
-          },
-          {
-            key: "show-metabot",
-            tab: "conceal-metabase",
-            display_name: (
-              <Text fw="bold" transform="none">{t`Metabot greeting`}</Text>
-            ),
-            description: null,
-            type: "boolean",
-            defaultValue: true,
-            widget: MetabotToggleWidget,
-          },
-          {
-            key: "login-page-illustration",
-            tab: "conceal-metabase",
-            display_name: (
-              <IllustrationTitle
-                title={t`Login and unsubscribe pages`}
-                errorMessageContainerId="login-page-illustration-error-container"
-              />
-            ),
-            description: null,
-            type: "string",
-            widget: IllustrationWidget,
-            props: {
-              type: "background",
-              customIllustrationSetting: "login-page-illustration-custom",
-              errorMessageContainerId:
-                "login-page-illustration-error-container",
-            },
-          },
-          {
-            key: "landing-page-illustration",
-            tab: "conceal-metabase",
-            display_name: (
-              <IllustrationTitle
-                title={t`Landing page`}
-                errorMessageContainerId="landing-page-illustration-error-container"
-              />
-            ),
-            description: null,
-            type: "string",
-            widget: IllustrationWidget,
-            props: {
-              type: "background",
-              customIllustrationSetting: "landing-page-illustration-custom",
-              errorMessageContainerId:
-                "landing-page-illustration-error-container",
-            },
-          },
-          {
-            key: "no-data-illustration",
-            tab: "conceal-metabase",
-            display_name: (
-              <IllustrationTitle
-                title={t`When calculations return no results`}
-                errorMessageContainerId="no-data-illustration-error-container"
-              />
-            ),
-            description: null,
-            type: "string",
-            widget: IllustrationWidget,
-            props: {
-              type: "icon",
-              customIllustrationSetting: "no-data-illustration-custom",
-              errorMessageContainerId: "no-data-illustration-error-container",
-            },
-          },
-          {
-            key: "no-object-illustration",
-            tab: "conceal-metabase",
-            display_name: (
-              <IllustrationTitle
-                title={t`When no objects can be found`}
-                errorMessageContainerId="no-object-illustration-error-container"
-              />
-            ),
-            description: null,
-            type: "string",
-            widget: IllustrationWidget,
-            props: {
-              type: "icon",
-              customIllustrationSetting: "no-object-illustration-custom",
-              errorMessageContainerId: "no-object-illustration-error-container",
-            },
-          },
-        ],
-      },
-    }),
-    sections => {
-      return updateIn(sections, ["general", "settings"], settings => {
-        const customHomepageIndex = settings.findIndex(
-          setting => setting.key === "custom-homepage-dashboard",
-        );
-        return [
-          ...settings.slice(0, customHomepageIndex + 1),
-          {
-            key: "landing-page",
-            display_name: t`Landing Page`,
-            type: "string",
-            placeholder: "/",
-            widget: LandingPageWidget,
-          },
-          ...settings.slice(customHomepageIndex + 1),
-        ];
-      });
-    },
-  );
+    );
 
-  PLUGIN_APP_INIT_FUNCTIONS.push(() => {
-    updateColors();
-  });
+    PLUGIN_APP_INIT_FUNCTIONS.push(() => {
+      updateColors();
+    });
 
-  PLUGIN_LOGO_ICON_COMPONENTS.push(LogoIcon);
-  PLUGIN_SELECTORS.canWhitelabel = () => true;
+    PLUGIN_LOGO_ICON_COMPONENTS.push(LogoIcon);
+    PLUGIN_SELECTORS.canWhitelabel = () => true;
 
-  // these selectors control whitelabeling UI
-  PLUGIN_SELECTORS.getLoadingMessageFactory = getLoadingMessage;
-  PLUGIN_SELECTORS.getIsWhiteLabeling = getIsWhiteLabeling;
-  PLUGIN_SELECTORS.getApplicationName = getApplicationName;
-  PLUGIN_SELECTORS.getShowMetabaseLinks = getShowMetabaseLinks;
-  PLUGIN_SELECTORS.getLoginPageIllustration = getLoginPageIllustration;
-  PLUGIN_SELECTORS.getLandingPageIllustration = getLandingPageIllustration;
-  PLUGIN_SELECTORS.getNoDataIllustration = getNoDataIllustration;
-  PLUGIN_SELECTORS.getNoObjectIllustration = getNoObjectIllustration;
-}
+    // these selectors control whitelabeling UI
+    PLUGIN_SELECTORS.getLoadingMessageFactory = getLoadingMessage;
+    PLUGIN_SELECTORS.getIsWhiteLabeling = getIsWhiteLabeling;
+    PLUGIN_SELECTORS.getApplicationName = getApplicationName;
+    PLUGIN_SELECTORS.getShowMetabaseLinks = getShowMetabaseLinks;
+    PLUGIN_SELECTORS.getLoginPageIllustration = getLoginPageIllustration;
+    PLUGIN_SELECTORS.getLandingPageIllustration = getLandingPageIllustration;
+    PLUGIN_SELECTORS.getNoDataIllustration = getNoDataIllustration;
+    PLUGIN_SELECTORS.getNoObjectIllustration = getNoObjectIllustration;
+  }
+};

--- a/frontend/src/metabase/app.js
+++ b/frontend/src/metabase/app.js
@@ -22,7 +22,9 @@ import "metabase/plugins/builtin";
 
 // This is conditionally aliased in the webpack config.
 // If EE isn't enabled, it loads an empty file.
-import "ee-plugins"; // eslint-disable-line import/no-duplicates
+// eslint-disable-next-line import/order -- those files may have siede-effects, let's keep them as they are
+import { activateEEPlugins } from "ee-plugins"; // eslint-disable-line import/no-duplicates
+activateEEPlugins();
 
 // Set nonce for mantine v6 deps
 import "metabase/lib/csp";

--- a/frontend/src/metabase/lib/noop.js
+++ b/frontend/src/metabase/lib/noop.js
@@ -2,3 +2,4 @@
 
 // This file is the alternative to importing EE plugins.
 // Either way we import something to ensure a consisten import order.
+export const activateEEPlugins = () => {};

--- a/frontend/test/__support__/enterprise.js
+++ b/frontend/test/__support__/enterprise.js
@@ -1,3 +1,5 @@
+import { activateEEPlugins } from "metabase-enterprise/plugins";
+
 /**
  * @deprecated use setupEnterprisePlugins with settings set via mockSettings
  */
@@ -10,5 +12,5 @@ export function setupEnterpriseTest() {
 }
 
 export function setupEnterprisePlugins() {
-  require("metabase-enterprise/plugins");
+  activateEEPlugins();
 }


### PR DESCRIPTION
This is a POC to see how much work it would be to use ee plugins in the sdk.

I left inline comments in the PR to explain the changes, but the tldr is that I wrapped all the side effects of importing the ee plugins in a function and call it when we have some token features.

This breaks some unit test, i checked two of the files and it seems like the tests are doing something not officially supported, like changing the token features inside the same file (for example `frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/auth.unit.spec.tsx`). Or not calling the appropriate helpers to activate the plugins (because the test is located in the enterprise folder and is testing util function imported from the ee folder).