### PR TITLE
Disallow connection impersonation roles which are not single strings

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/driver/impersonation.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/driver/impersonation.clj
@@ -51,7 +51,7 @@
 (defn connection-impersonation-role
   "Fetches the database role that should be used for the current user, if connection impersonation is in effect.
   Returns `nil` if connection impersonation should not be used for the current user. Throws an exception if multiple
-  conflicting connection impersonation policies are found."
+  conflicting connection impersonation policies are found, or the role is not a single string."
   [database-or-id]
   (when (and database-or-id (not api/*is-superuser?*))
     (let [group-ids           (t2/select-fn-set :group_id PermissionsGroupMembership :user_id api/*current-user-id*)
@@ -70,10 +70,17 @@
                 role-attribute     (:attribute conn-impersonation)
                 user-attributes    (:login_attributes @api/*current-user*)
                 role               (get user-attributes role-attribute)]
-            (if (str/blank? role)
+            (cond
+              (and (some? role) (not (string? role)))
+              (throw (ex-info (tru "Connection impersonation attribute is invalid: role must be a single string.")
+                              {:user-id api/*current-user-id*
+                               :conn-impersonations conn-impersonations}))
+
+              (str/blank? role)
               (throw (ex-info (tru "User does not have attribute required for connection impersonation.")
                               {:user-id api/*current-user-id*
                                :conn-impersonations conn-impersonations}))
+              :else
               role)))))))
 
 (defenterprise hash-key-for-impersonation

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/driver/impersonation.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/driver/impersonation.clj
@@ -71,13 +71,14 @@
                 user-attributes    (:login_attributes @api/*current-user*)
                 role               (get user-attributes role-attribute)]
             (cond
-              (and (some? role) (not (string? role)))
-              (throw (ex-info (tru "Connection impersonation attribute is invalid: role must be a single string.")
+              (nil? role)
+              (throw (ex-info (tru "User does not have attribute required for connection impersonation.")
                               {:user-id api/*current-user-id*
                                :conn-impersonations conn-impersonations}))
 
-              (str/blank? role)
-              (throw (ex-info (tru "User does not have attribute required for connection impersonation.")
+              (or (not (string? role))
+                  (str/blank? role))
+              (throw (ex-info (tru "Connection impersonation attribute is invalid: role must be a single non-empty string.")
                               {:user-id api/*current-user-id*
                                :conn-impersonations conn-impersonations}))
               :else

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/driver/impersonation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/driver/impersonation_test.clj
@@ -63,6 +63,14 @@
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo
            #"User does not have attribute required for connection impersonation."
+           (@#'impersonation/connection-impersonation-role (mt/db))))))
+
+  (testing "Throws an exception if impersonation should be enforced, but the user's attribute is not a single string"
+    (advanced-perms.api.tu/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                 :attributes     {"impersonation_attr" ["one" "two" "three"]}}
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Connection impersonation attribute is invalid: role must be a single string."
            (@#'impersonation/connection-impersonation-role (mt/db)))))))
 
 (deftest conn-impersonation-test-postgres

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/driver/impersonation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/driver/impersonation_test.clj
@@ -70,7 +70,7 @@
                                                  :attributes     {"impersonation_attr" ["one" "two" "three"]}}
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo
-           #"Connection impersonation attribute is invalid: role must be a single string."
+           #"Connection impersonation attribute is invalid: role must be a single non-empty string."
            (@#'impersonation/connection-impersonation-role (mt/db)))))))
 
 (deftest conn-impersonation-test-postgres


### PR DESCRIPTION
It's possible to have user attributes that are arrays, since we'll store anything passed in via SSO in the DB as a json blob. But this isn't an officially supported behavior (you can't set this kind of value via the UI), and if you try to use this kind of value for impersonation, we don't know how to handle it.

We may eventually use this to set multiple roles at once for DBs that support it, but that may require a UI change and a new driver method. So for now let's just return a better error message if someone tries to do this.