### PR TITLE
Use consistent approach for disabling permission checks in QP to fix sandboxing error in downloads

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/dataset_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/dataset_test.clj
@@ -6,7 +6,7 @@
    [metabase.test :as mt]))
 
 (deftest dataset-parameter-test
-  (testing "POST /api/dataset/parameter/values should follow sandbox rules"
+  (testing "POST /api/dataset/parameter/values should respect sandboxing"
     (met/with-gtaps! {:gtaps {:categories {:query (mt/mbql-query categories {:filter [:<= $id 3]})}}}
       (testing "with values_source_type=card"
         (mt/with-temp

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/download_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/download_test.clj
@@ -7,8 +7,8 @@
    [metabase.test :as mt]
    [metabase.util :as u]))
 
-(deftest dataset-download-test
-  (testing "POST /api/card/:format should respect sandboxing"
+(deftest card-download-test
+  (testing "POST /api/card/:id/query/csv should respect sandboxing"
     (mt/with-model-cleanup [:model/Card]
       (met/with-gtaps! (mt/$ids people
                          {:gtaps      {:people {:remappings {"state" [:dimension $people.state]}}}

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/download_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/download_test.clj
@@ -1,0 +1,27 @@
+(ns metabase-enterprise.sandbox.api.download-test
+  (:require
+   [clojure.data.csv :as csv]
+   [clojure.test :refer :all]
+   [metabase-enterprise.test :as met]
+   [metabase.models.data-permissions :as data-perms]
+   [metabase.test :as mt]
+   [metabase.util :as u]))
+
+(deftest dataset-download-test
+  (testing "POST /api/card/:format should respect sandboxing"
+    (mt/with-model-cleanup [:model/Card]
+      (met/with-gtaps! (mt/$ids people
+                         {:gtaps      {:people {:remappings {"state" [:dimension $people.state]}}}
+                          :attributes {"state" "CA"}})
+        (mt/with-temp [:model/Card card {:dataset_query (mt/mbql-query people)}]
+          (data-perms/set-table-permission! &group (mt/id :people) :perms/download-results :one-million-rows)
+
+          ;; Sanity check: admin can download full table
+          (let [res (-> (mt/user-http-request :crowberto :post 200 (format "card/%d/query/csv" (u/the-id card)))
+                        csv/read-csv)]
+            (is (= 2501 (count res))))
+
+          ;; Sandboxed user only downloads a subset (users in CA)
+          (let [res (-> (mt/user-http-request :rasta :post 200 (format "card/%d/query/csv" (u/the-id card)))
+                        csv/read-csv)]
+            (is (= 91 (count res)))))))))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/pulse_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/pulse_test.clj
@@ -186,7 +186,7 @@
                            (csv->row-count attachment)))))))))))))
 
 (deftest csv-downloads-test
-  (testing "CSV/XLSX downloads should be sandboxed"
+  (testing "CSV/XLSX downloads attached to an email should be sandboxed"
     (met/with-gtaps! {:gtaps      {:venues {:remappings {:price [:dimension [:field (mt/id :venues :price) nil]]}}}
                       :attributes {"price" "1"}}
       (let [query (mt/mbql-query venues)]
@@ -272,6 +272,6 @@
           (mt/user-http-request :rasta :put 200 (format "pulse/%d" pulse-id)
                                 {:channels [(assoc pc :recipients [{:id (mt/user->id :rasta)}])]})
 
-;; Crowberto should now be removed as a recipient
+          ;; Crowberto should now be removed as a recipient
           (is (= [(mt/user->id :rasta)]
                  (->> (api.alert/email-channel (pulse/retrieve-alert pulse-id)) :recipients (map :id) sort))))))))

--- a/src/metabase/models/query/permissions.clj
+++ b/src/metabase/models/query/permissions.clj
@@ -18,6 +18,7 @@
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.util :as qp.util]
+   [metabase.server.middleware.session :as mw.session]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
@@ -100,7 +101,7 @@
   ;; ignore the current user for the purposes of calculating the permissions required to run the query. Don't want the
   ;; preprocessing to fail because current user doesn't have permissions to run it when we're not trying to run it at
   ;; all
-  (binding [api/*current-user-id* nil]
+  (mw.session/as-admin
     ((requiring-resolve 'metabase.query-processor.preprocess/preprocess) query)))
 
 (defn- referenced-card-ids

--- a/src/metabase/query_processor/middleware/add_source_metadata.clj
+++ b/src/metabase/query_processor/middleware/add_source_metadata.clj
@@ -1,12 +1,12 @@
 (ns metabase.query-processor.middleware.add-source-metadata
   (:require
    [clojure.walk :as walk]
-   [metabase.api.common :as api]
    [metabase.legacy-mbql.schema :as mbql.s]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.query-processor.interface :as qp.i]
    [metabase.query-processor.store :as qp.store]
+   [metabase.server.middleware.session :as mw.session]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]))
 
@@ -47,7 +47,7 @@
   "Preprocess a `source-query` so we can determine the result columns."
   [source-query :- mbql.s/MBQLQuery]
   (try
-    (let [cols (binding [api/*current-user-id* nil]
+    (let [cols (mw.session/as-admin
                  ((requiring-resolve 'metabase.query-processor.preprocess/query->expected-cols)
                   {:database (:id (lib.metadata/database (qp.store/metadata-provider)))
                    :type     :query

--- a/src/metabase/query_processor/util/nest_query.clj
+++ b/src/metabase/query_processor/util/nest_query.clj
@@ -8,7 +8,6 @@
   (:require
    [clojure.walk :as walk]
    [medley.core :as m]
-   [metabase.api.common :as api]
    [metabase.legacy-mbql.util :as mbql.u]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.util.match :as lib.util.match]
@@ -16,6 +15,7 @@
    [metabase.query-processor.middleware.resolve-joins :as qp.middleware.resolve-joins]
    [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.util.add-alias-info :as add]
+   [metabase.server.middleware.session :as mw.session]
    [metabase.util :as u]
    [metabase.util.log :as log]))
 
@@ -86,10 +86,10 @@
   (let [filter-clause (:filter inner-query)
         keep-filter? (nil? (lib.util.match/match-one filter-clause :expression))
         source (as-> (select-keys inner-query [:source-table :source-query :source-metadata :joins :expressions]) source
-                 ;; preprocess this without a current user context so it's not subject to permissions checks. To get
-                 ;; here in the first place we already had to do perms checks to make sure the query we're transforming
-                 ;; is itself ok, so we don't need to run another check
-                 (binding [api/*current-user-id* nil]
+                 ;; preprocess this without an admin user context so it's not subject to permissions checks. To get here
+                 ;; in the first place we already had to do perms checks to make sure the query we're transforming is
+                 ;; itself ok, so we don't need to run another check
+                 (mw.session/as-admin
                    ((requiring-resolve 'metabase.query-processor.preprocess/preprocess)
                     {:database (u/the-id (lib.metadata/database (qp.store/metadata-provider)))
                      :type     :query

--- a/src/metabase/query_processor/util/nest_query.clj
+++ b/src/metabase/query_processor/util/nest_query.clj
@@ -8,6 +8,7 @@
   (:require
    [clojure.walk :as walk]
    [medley.core :as m]
+   [metabase.api.common :as api]
    [metabase.legacy-mbql.util :as mbql.u]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.util.match :as lib.util.match]
@@ -15,7 +16,6 @@
    [metabase.query-processor.middleware.resolve-joins :as qp.middleware.resolve-joins]
    [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.util.add-alias-info :as add]
-   [metabase.server.middleware.session :as mw.session]
    [metabase.util :as u]
    [metabase.util.log :as log]))
 
@@ -86,10 +86,11 @@
   (let [filter-clause (:filter inner-query)
         keep-filter? (nil? (lib.util.match/match-one filter-clause :expression))
         source (as-> (select-keys inner-query [:source-table :source-query :source-metadata :joins :expressions]) source
-                 ;; preprocess this without an admin user context so it's not subject to permissions checks. To get here
-                 ;; in the first place we already had to do perms checks to make sure the query we're transforming is
-                 ;; itself ok, so we don't need to run another check
-                 (mw.session/as-admin
+                 ;; preprocess this in a superuser context so it's not subject to permissions checks. To get here in the
+                 ;; first place we already had to do perms checks to make sure the query we're transforming is itself
+                 ;; ok, so we don't need to run another check.
+                 ;; (Not using mw.session/as-admin due to cyclic dependency.)
+                 (binding [api/*is-superuser?* true]
                    ((requiring-resolve 'metabase.query-processor.preprocess/preprocess)
                     {:database (u/the-id (lib.metadata/database (qp.store/metadata-provider)))
                      :type     :query

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -2639,7 +2639,7 @@
           (update-card card {:description "a new description"})
           (is (empty? (reviews card)))))
       (testing "Does not add nil moderation reviews when there are reviews but not verified"
-          ;; testing that we aren't just adding a nil moderation each time we update a card
+         ;; testing that we aren't just adding a nil moderation each time we update a card
         (with-card :verified
           (is (verified? card))
           (moderation-review/create-review! {:moderated_item_id   (u/the-id card)


### PR DESCRIPTION
There are several places in the query processor where we want to disable permission checks for a specific function call—such as preprocessing a query or getting its expected columns when applying sandboxing rules.

Previously this was being done inconsistently. Some spots were using `metabase.server.middleware.session/as-admin` which just binds `api/*is-superuser?*` to `true`. Other spots were just binding `api/*current-user-id*` to `nil` to override the current user. 

Binding `*current-user-id*` doesn't work well for this purpose post-v50 permissions refactor, especially with the new perms caching mechanism. This is the root cause of https://github.com/metabase/metabase/issues/47478: sandboxing middleware recursively processes the query with `*current-user-id*` set to `nil`. This hits the `apply-download-limit` middleware which is a preprocessing middleware, unlike the normal perms middleware which is an execution middleware. And it tries to look up the perms for a `nil` user in the cache, returning an empty set, and defaulting to the lowest permission level.

Because `apply-download-limit` and `apply-sandboxing` are the only perms-related preprocessing middleware, I don't think this issue affects other perm checking aside from this specific interaction.

Resolves https://github.com/metabase/metabase/issues/47478