### PR TITLE
Use table name in inactive table error if user has access to it

### DIFF
--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -158,8 +158,13 @@
              *sandboxes-for-user*   (delay (enforced-sandboxes-for-user ~user-id))]
      ~@body))
 
+(def ^:dynamic *use-perms-cache?*
+  "Bind to `false` to intentionally bypass the permissions cache and fetch data straight from the DB."
+  true)
+
 (defn- get-permissions [user-id perm-type db-id]
-  (if (= user-id api/*current-user-id*)
+  (if (or (= user-id api/*current-user-id*)
+          (not *use-perms-cache?*))
     ;; Use the cache if we can; if not, add perms to the cache for this DB
     (let [{:keys [db-ids perms]} @*permissions-for-user*]
       (if (db-ids db-id)

--- a/test/metabase/query_processor/middleware/permissions_test.clj
+++ b/test/metabase/query_processor/middleware/permissions_test.clj
@@ -272,12 +272,24 @@
 
 (deftest inactive-table-test
   (testing "Make sure a query on an inactive table fails to run"
-    (mt/with-full-data-perms-for-all-users!
-      (mt/with-temp [Database db {}
-                     Table    table {:db_id (u/the-id db)
-                                     :active false}]
+    (mt/with-temp [Database db {:name "Test DB"}
+                   Table    table {:db_id (u/the-id db)
+                                   :name "Inactive Table"
+                                   :schema "PUBLIC"
+                                   :active false}]
+      (mt/with-full-data-perms-for-all-users!
         (is (thrown-with-msg?
-             ExceptionInfo
+             Exception
+             #"Table \"Test DB.PUBLIC.Inactive Table\" is inactive."
+             (check-perms-for-rasta
+              {:database (u/the-id db)
+               :type     :query
+               :query    {:source-table (u/the-id table)}}))))
+
+      ;; Don't leak metadata about the table if the user doesn't have access to it, even if it's inactive
+      (mt/with-no-data-perms-for-all-users!
+        (is (thrown-with-msg?
+             Exception
              #"Table [\d,]+ is inactive."
              (check-perms-for-rasta
               {:database (u/the-id db)


### PR DESCRIPTION
If the user has data access to an inactive table (despite it being inactive), let's use it in the error message when they try to query it. If not, let's just use the table ID.