### PR TITLE
Disallow duplicate order-by clauses in ::lib.schema.order-by/order-bys

### DIFF
--- a/src/metabase/lib/order_by.cljc
+++ b/src/metabase/lib/order_by.cljc
@@ -95,7 +95,7 @@
      (lib.util/update-query-stage query stage-number update :order-by (fn [order-bys]
                                                                         (conj (vec order-bys) new-order-by))))))
 
-(mu/defn order-bys :- [:maybe [:sequential ::lib.schema.order-by/order-by]]
+(mu/defn order-bys :- [:maybe ::lib.schema.order-by/order-bys]
   "Get the order-by clauses in a query."
   ([query :- ::lib.schema/query]
    (order-bys query -1))

--- a/src/metabase/lib/schema/order_by.cljc
+++ b/src/metabase/lib/schema/order_by.cljc
@@ -4,6 +4,7 @@
    [metabase.lib.schema.common :as common]
    [metabase.lib.schema.expression :as expression]
    [metabase.lib.schema.mbql-clause :as mbql-clause]
+   [metabase.lib.schema.util :as lib.schema.util]
    [metabase.util.malli.registry :as mr]))
 
 (mr/def ::direction
@@ -21,6 +22,5 @@
    [:asc  :mbql.clause/asc]
    [:desc :mbql.clause/desc]])
 
-;;; TODO -- should there be a no-duplicates constraint here?
 (mr/def ::order-bys
-  [:sequential {:min 1} [:ref ::order-by]])
+  (lib.schema.util/distinct-ignoring-uuids [:sequential {:min 1} [:ref ::order-by]]))

--- a/src/metabase/lib/schema/util.cljc
+++ b/src/metabase/lib/schema/util.cljc
@@ -1,6 +1,7 @@
 (ns metabase.lib.schema.util
   (:refer-clojure :exclude [ref])
   (:require
+   [clojure.walk :as walk]
    [metabase.lib.options :as lib.options]
    [metabase.util.malli.registry :as mr]))
 
@@ -71,3 +72,13 @@
                          (dissoc acc k)
                          acc))
                      options options)))))))
+
+(defn remove-lib-uuids
+  "Recursively remove all uuids from x."
+  [x]
+  (walk/postwalk
+   (fn [x]
+     (if (map? x)
+       (dissoc x :lib/uuid)
+       x))
+   x))

--- a/src/metabase/lib/schema/util.cljc
+++ b/src/metabase/lib/schema/util.cljc
@@ -3,6 +3,7 @@
   (:require
    [clojure.walk :as walk]
    [metabase.lib.options :as lib.options]
+   [metabase.util :as u]
    [metabase.util.malli.registry :as mr]))
 
 (declare collect-uuids*)
@@ -82,3 +83,17 @@
        (dissoc x :lib/uuid)
        x))
    x))
+
+(mr/def ::distinct-ignoring-uuids
+  [:fn
+   {:error/message "values must be distinct ignoring uuids"
+    :error/fn      (fn [{:keys [value]} _]
+                     (str "Duplicate values ignoring uuids in: " (pr-str (remove-lib-uuids value))))}
+   (comp u/empty-or-distinct? remove-lib-uuids)])
+
+(defn distinct-ignoring-uuids
+  "Add an additional constraint to `schema` that requires all elements to be distinct after removing uuids."
+  [schema]
+  [:and
+   schema
+   [:ref ::distinct-ignoring-uuids]])

--- a/src/metabase/query_processor/util.clj
+++ b/src/metabase/query_processor/util.clj
@@ -11,6 +11,7 @@
    [metabase.legacy-mbql.normalize :as mbql.normalize]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.schema.expression :as lib.schema.expression]
+   [metabase.lib.schema.util :as lib.schema.util]
    [metabase.query-processor.schema :as qp.schema]
    [metabase.util :as u]
    [metabase.util.malli :as mu]))
@@ -85,17 +86,6 @@
        x))
    x))
 
-(defn- remove-lib-uuids
-  "Two queries should be the same even if they have different :lib/uuids, because they might have both been converted
-  from the same legacy query."
-  [x]
-  (walk/postwalk
-   (fn [x]
-     (if (map? x)
-       (dissoc x :lib/uuid)
-       x))
-   x))
-
 (mu/defn- select-keys-for-hashing
   "Return `query` with only the keys relevant to hashing kept.
   (This is done so irrelevant info or options that don't affect query results doesn't result in the same query
@@ -105,7 +95,7 @@
     (cond-> query
       (empty? constraints) (dissoc :constraints)
       (empty? parameters)  (dissoc :parameters)
-      true                 remove-lib-uuids
+      true                 lib.schema.util/remove-lib-uuids
       true                 walk-query-sort-maps)))
 
 (mu/defn query-hash :- bytes?

--- a/test/metabase/lib/remove_replace_test.cljc
+++ b/test/metabase/lib/remove_replace_test.cljc
@@ -19,7 +19,7 @@
 (deftest ^:parallel remove-clause-order-bys-test
   (let [query (-> lib.tu/venues-query
                   (lib/order-by (meta/field-metadata :venues :name))
-                  (lib/order-by (meta/field-metadata :venues :name)))
+                  (lib/order-by (meta/field-metadata :venues :price)))
         order-bys (lib/order-bys query)]
     (is (= 2 (count order-bys)))
     (is (= 1 (-> query
@@ -349,7 +349,7 @@
     (let [query (-> lib.tu/venues-query
                     (lib/filter (lib/= "myvenue" (meta/field-metadata :venues :name)))
                     (lib/order-by (meta/field-metadata :venues :name))
-                    (lib/order-by (meta/field-metadata :venues :name)))
+                    (lib/order-by (meta/field-metadata :venues :price)))
           order-bys (lib/order-bys query)]
       (is (= 2 (count order-bys)))
       (let [replaced (-> query

--- a/test/metabase/lib/schema/order_by_test.cljc
+++ b/test/metabase/lib/schema/order_by_test.cljc
@@ -1,0 +1,64 @@
+(ns metabase.lib.schema.order-by-test
+  (:require
+   #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
+   [clojure.test :refer [deftest is testing]]
+   [malli.core :as mc]
+   [metabase.lib.schema.expression :as lib.schema.expression]
+   [metabase.lib.schema.order-by :as lib.schema.order-by]
+   [metabase.util :as u]))
+
+(def ^:private valid-order-bys
+  [[:asc
+    {:lib/uuid "00000000-0000-0000-0000-000000000000"}
+    [:field
+     {:lib/uuid "00000000-0000-0000-0000-000000000000"
+      :base-type :type/Text}
+     63400]]
+   [:desc
+    {:lib/uuid "00000000-0000-0000-0000-000000000001"}
+    [:field
+     {:lib/uuid "00000000-0000-0000-0000-000000000001"
+      :base-type :type/DateTime
+      :effective-type :type/Integer}
+     63401]]])
+
+(def ^:private invalid-order-bys
+  [;; Invalid asc/desc key
+   [:increasing
+    {:lib/uuid "00000000-0000-0000-0000-000000000000"}
+    [:field
+     {:lib/uuid "00000000-0000-0000-0000-000000000000"
+      :base-type :type/Text}
+     63400]]
+   ;; Invalid :base-type
+   [:desc
+    {:lib/uuid "00000000-0000-0000-0000-000000000001"}
+    [:field
+     {:lib/uuid "00000000-0000-0000-0000-000000000001"
+      :base-type :type/Address}
+     63401]]])
+
+(deftest ^:parallel valid-order-by-schema-test
+  (testing "valid order-by conforms to schema"
+    (doseq [order-by valid-order-bys]
+      (testing (u/pprint-to-str order-by)
+        (is (not (mc/explain ::lib.schema.order-by/order-by order-by)))))))
+
+(deftest ^:parallel invalid-order-by-schema-test
+  (testing "invalid order-by does not conform to schema"
+    (doseq [invalid-order-by invalid-order-bys]
+      (testing (u/pprint-to-str invalid-order-by)
+        (binding [lib.schema.expression/*suppress-expression-type-check?* nil]
+          (is (mc/explain ::lib.schema.order-by/order-by invalid-order-by)))))))
+
+(deftest ^:parallel valid-order-bys-schema-test
+  (testing "valid order-bys conform to schema"
+    (is (not (mc/explain ::lib.schema.order-by/order-bys valid-order-bys)))))
+
+(deftest ^:parallel invalid-order-bys-schema-test
+  (testing "invalid order-bys do not conform to schema"
+    (binding [lib.schema.expression/*suppress-expression-type-check?* nil]
+      (is (mc/explain ::lib.schema.order-by/order-bys invalid-order-bys))))
+
+  (testing "non-distinct order-bys do not conform to schema"
+    (is (mc/explain ::lib.schema.order-by/order-bys (conj valid-order-bys (first valid-order-bys))))))

--- a/test/metabase/lib/schema/util_test.cljc
+++ b/test/metabase/lib/schema/util_test.cljc
@@ -32,6 +32,25 @@
   (query "00000000-0000-0000-0000-000000000001"
          "00000000-0000-0000-0000-000000000001"))
 
+(def ^:private query-with-no-uuids
+  {:lib/type :mbql/query
+   :database 1
+   :stages   [{:lib/type     :mbql.stage/mbql
+               :source-table 2
+               :filter       [:=
+                              {}
+                              [:field
+                               {:base-type :type/Text}
+                               3]
+                              4]}
+              {:lib/type :mbql.stage/mbql
+               :filter   [:=
+                          {}
+                          [:field
+                           {:base-type :type/Text}
+                           "my_field"]
+                          4]}]})
+
 (deftest ^:parallel collect-uuids-test
   (are [query expected-uuids] (= expected-uuids
                                  (lib.schema.util/collect-uuids query))
@@ -78,3 +97,47 @@
 
     [[:field {:lib/uuid "00000000-0000-0000-0000-000000000000", :effective-type :type/Integer} 1]
      [:field {:lib/uuid "00000000-0000-0000-0000-000000000001"} 1]]))
+
+(deftest ^:parallel remove-lib-uuids-test
+  (are [x expected] (= (lib.schema.util/remove-lib-uuids x) expected)
+    {:lib/uuid "00000000-0000-0000-0000-000000000000"}
+    {}
+
+    {:a 1, :lib/uuid "00000000-0000-0000-0000-000000000000"}
+    {:a 1}
+
+    [{:lib/uuid "00000000-0000-0000-0000-000000000000"}]
+    [{}]
+
+    [:a {:lib/uuid "00000000-0000-0000-0000-000000000000"}]
+    [:a {}]
+
+    [:a {:b [:c {:d 1, :lib/uuid "00000000-0000-0000-0000-000000000000"}]}]
+    [:a {:b [:c {:d 1}]}]
+
+    [:a {:b [:c
+             {:d 1, :lib/uuid "00000000-0000-0000-0000-000000000000"}
+             {:lib/uuid "00000000-0000-0000-0000-000000000001"}]
+         :lib/uuid "00000000-0000-0000-0000-000000000002"}]
+    [:a {:b [:c {:d 1} {}]}]
+
+    ;; order-by clause
+    [:asc
+     {:lib/uuid "81fdaa28-0af3-4168-b4a2-1afe43c389e7"}
+     [:field
+      {:lib/uuid "92d6d8d3-5685-4e41-93ce-f83d63c4156d"
+       :base-type :type/BigInteger
+       :effective-type :type/BigInteger}
+      63400]]
+    [:asc
+     {}
+     [:field
+      {:base-type :type/BigInteger,
+       :effective-type :type/BigInteger}
+      63400]]
+
+    query-with-duplicate-uuids
+    query-with-no-uuids
+
+    query-with-no-duplicate-uuids
+    query-with-no-uuids))

--- a/test/metabase/query_processor/middleware/normalize_query_test.clj
+++ b/test/metabase/query_processor/middleware/normalize_query_test.clj
@@ -21,3 +21,27 @@
                 :query    {:source-table (meta/id :venues)
                            :fields       [["field" (meta/id :venues :id) nil]
                                           ["field" (meta/id :venues :name) nil]]}}))))))
+
+(deftest ^:parallel normalize-dedups-order-bys-test
+  (testing "order-by clauses are deduped"
+    (qp.store/with-metadata-provider meta/metadata-provider
+      (is (=? {:database     (meta/id)
+               :lib/type     :mbql/query
+               :lib/metadata meta/metadata-provider
+               :stages       [{:lib/type     :mbql.stage/mbql
+                               :source-table (meta/id :venues)
+                               :fields       [[:field {:lib/uuid string?} (meta/id :venues :id)]]
+                               :order-by     [[:asc
+                                               {:lib/uuid string?}
+                                               [:field
+                                                {:lib/uuid string?
+                                                 :base-type :type/BigInteger
+                                                 :effective-type :type/BigInteger}
+                                                (meta/id :venues :id)]]]}]}
+              (normalize-query/normalize-preprocessing-middleware
+               {:database (meta/id)
+                :type     "query"
+                :query    {:source-table (meta/id :venues)
+                           :fields       [["field" (meta/id :venues :id) nil]]
+                           :order-by     [[:asc ["field" (meta/id :venues :id)]]
+                                          [:asc ["field" (meta/id :venues :id)]]]}}))))))

--- a/test/metabase/query_processor_test/order_by_test.clj
+++ b/test/metabase/query_processor_test/order_by_test.clj
@@ -26,6 +26,30 @@
                           [:asc $id]]
                :limit    10}))))))
 
+(deftest ^:parallel duplicate-order-bys-test
+  ;; This test succeeds because the normalize-preprocessing-middleware normalizes and dedups the order-by clauses
+  ;; before the query makes it to the validate-query middleware.
+  (mt/test-drivers (mt/normal-drivers)
+    (is (= [[1 12 375]
+            [1  9 139]
+            [1  1  72]
+            [2 15 129]
+            [2 12 471]
+            [2 11 325]
+            [2  9 590]
+            [2  9 833]
+            [2  8 380]
+            [2  5 719]]
+           (mt/formatted-rows
+            [int int int]
+            (mt/run-mbql-query checkins
+              {:fields   [$venue_id $user_id $id]
+               :order-by [[:asc $venue_id]
+                          [:asc $venue_id]
+                          [:desc $user_id]
+                          [:asc $id]]
+               :limit    10}))))))
+
 (deftest ^:parallel order-by-aggregate-fields-test
   (mt/test-drivers (mt/normal-drivers)
     (testing :count


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39384

### Description

1. Update `::lib.schema.order-by/order-bys` to reject duplicate order-by clauses, ignoring uuids.
2. Move `query-processor.util/remove-lib-uuids` to `lib.schema.util`
3. Fix a couple of pre-existing tests that were using duplicate order-bys in remove_replace_test.cljc
4. Add a bunch of tests

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
