### PR TITLE
Change duration to duration_ms

### DIFF
--- a/snowplow/iglu-client-embedded/schemas/com.metabase/serialization/jsonschema/1-0-1
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/serialization/jsonschema/1-0-1
@@ -1,130 +1,130 @@
 {
-    "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
-    "description": "Serialization operation",
-    "self": {
-        "vendor": "com.metabase",
-        "name": "serialization",
-        "format": "jsonschema",
-        "version": "1-0-0"
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "self": {
+    "vendor": "com.metabase",
+    "name": "serialization",
+    "format": "jsonschema",
+    "version": "1-0-1"
+  },
+  "description": "Serialization operation",
+  "properties": {
+    "event": {
+      "description": "Event name",
+      "type": "string",
+      "enum": [
+        "serialization"
+      ],
+      "maxLength": 1024
     },
-    "type": "object",
-    "required": [
-        "event",
-        "source",
-        "duration",
-        "success"
-    ],
-    "properties": {
-        "event": {
-            "description": "Event name",
-            "type": "string",
-            "enum": [
-                "serialization"
-            ],
-            "maxLength": 1024
-        },
-        "direction": {
-            "description": "Is it import or export",
-            "type": [
-                "string",
-                "null"
-            ],
-            "enum": [
-                "import",
-                "export"
-            ],
-            "maxLength": 6
-        },
-        "source": {
-            "description": "The way serialization was triggered",
-            "type": "string",
-            "enum": [
-                "cli",
-                "api"
-            ]
-        },
-        "duration_ms": {
-            "description": "Time in milliseconds it took to execute",
-            "type": [
-                "integer",
-                "null"
-            ],
-            "minimum": 0,
-            "maximum": 2147483647
-        },
-        "success": {
-            "description": "If serialization succeeded or failed",
-            "type": "boolean"
-        },
-        "error_message": {
-            "description": "Why serialization failed",
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1024
-        },
-        "count": {
-            "description": "Total count of serialized entities",
-            "type": [
-                "integer",
-                "null"
-            ],
-            "minimum": 0,
-            "maximum": 2147483647
-        },
-        "error_count": {
-            "description": "Number of errors occured during serialization (if they were skipped)",
-            "type": [
-                "integer",
-                "null"
-            ],
-            "minimum": 0,
-            "maximum": 2147483647
-        },
-        "models": {
-            "description": "Which models were imported",
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1024
-        },
-        "collection": {
-            "description": "Which collections were exported",
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1024
-        },
-        "all_collections": {
-            "description": "If all collections were exported",
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "settings": {
-            "description": "If settings were exported",
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "field_values": {
-            "description": "If field values were exported",
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "secrets": {
-            "description": "If database secrets were included in export",
-            "type": [
-                "boolean",
-                "null"
-            ]
-        }
+    "direction": {
+      "description": "Is it import or export",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "import",
+        "export"
+      ],
+      "maxLength": 6
+    },
+    "source": {
+      "description": "The way serialization was triggered",
+      "type": "string",
+      "enum": [
+        "cli",
+        "api"
+      ]
+    },
+    "duration_ms": {
+      "description": "Time in milliseconds it took to execute",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "success": {
+      "description": "If serialization succeeded or failed",
+      "type": "boolean"
+    },
+    "error_message": {
+      "description": "Why serialization failed",
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1024
+    },
+    "count": {
+      "description": "Total count of serialized entities",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "error_count": {
+      "description": "Number of errors occured during serialization (if they were skipped)",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "models": {
+      "description": "Which models were imported",
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1024
+    },
+    "collection": {
+      "description": "Which collections were exported",
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1024
+    },
+    "all_collections": {
+      "description": "If all collections were exported",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "settings": {
+      "description": "If settings were exported",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "field_values": {
+      "description": "If field values were exported",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "secrets": {
+      "description": "If database secrets were included in export",
+      "type": [
+        "boolean",
+        "null"
+      ]
     }
+  },
+  "type": "object",
+  "required": [
+    "event",
+    "source",
+    "duration_ms",
+    "success"
+  ]
 }


### PR DESCRIPTION
### Description

Our current schema had the issue that `duration` was marked as required field even though it did not exist (`duration_ms` existed instead). This updates the schema to match the version we have deployed.

Note that the diff looks a bit crazy because of the different order but there are 2 things fixed:

* `duartion` -> `duration_ms`
* `version`: This one was wrongly still at `1-0-0` and was updated to `1-0-1`