### PR TITLE
Upgrade Macaw to 0.2.10

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -77,7 +77,7 @@
   io.github.eerohele/pp                     {:git/tag "2024-01-04.60"           ; super fast pretty-printing library
                                              :git/sha "a428751"
                                              :git/url "https://github.com/eerohele/pp"}
-  io.github.metabase/macaw                  {:mvn/version "0.2.6"}              ; Parse native SQL queries
+  io.github.metabase/macaw                  {:mvn/version "0.2.10"}             ; Parse native SQL queries
   ;; The 2.X line of Resilience4j requires Java 17, so we cannot upgrade this dependency until that is our minimum JVM version
   io.github.resilience4j/resilience4j-retry {:mvn/version "1.7.1" #_ "must be 1.7.1"} ; Support for retrying operations
   io.prometheus/simpleclient_hotspot        {:mvn/version "0.16.0"}             ; prometheus jvm collector


### PR DESCRIPTION
Includes https://github.com/metabase/macaw/pull/97, which will prevent some false positives