### PR TITLE
Refine 'last' version logic

### DIFF
--- a/release/src/milestones.ts
+++ b/release/src/milestones.ts
@@ -298,7 +298,7 @@ export async function checkMilestoneForRelease({
     owner,
     repo,
     version,
-    ignorePatches: true,
+    ignorePatches: true, // ignore patch versions since we don't release notes for them
   });
 
   const compareResponse = await github.rest.repos.compareCommitsWithBasehead({

--- a/release/src/milestones.ts
+++ b/release/src/milestones.ts
@@ -298,6 +298,7 @@ export async function checkMilestoneForRelease({
     owner,
     repo,
     version,
+    ignorePatches: true,
   });
 
   const compareResponse = await github.rest.repos.compareCommitsWithBasehead({

--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -232,32 +232,33 @@ export function versionSort(a: string, b: string) {
   return 0;
 }
 
-export function getLastReleaseFromTags(tags: Tag[]) {
+export function getLastReleaseFromTags({tags, ignorePatches = false}: { tags: Tag[], ignorePatches?: boolean }) {
   return tags
     .map(tag => tag.ref.replace('refs/tags/', ''))
     .filter(tag => !isRCVersion(tag)) // we want to ignore RC tags because release notes should be cumulative
-    .filter(v => !isPatchVersion(v)) // ignore patch versions since we don't release notes for them
+    .filter(ignorePatches ? v => !isPatchVersion(v) :  () => true) // ignore patch versions since we don't release notes for them
     .sort(versionSort)
     .reverse()[0];
 }
 
 /**
  * queries the github api to get all release version tags,
- * optionally filtered by a major version
+ * optionally filtered by a major version, and can optionally exclude patch versions
  */
 export async function getLastReleaseTag({
   github,
   owner,
   repo,
   version = '',
-}: GithubProps & { version?: string }) {
+  ignorePatches = false,
+}: GithubProps & { version?: string, ignorePatches?: boolean }) {
   const tags =  await github.paginate(github.rest.git.listMatchingRefs, {
     owner,
     repo,
     ref: `tags/v0.${version ? getMajorVersion(version) : ''}`,
   });
 
-  const lastRelease = getLastReleaseFromTags(tags);
+  const lastRelease = getLastReleaseFromTags({ tags, ignorePatches });
 
   return lastRelease;
 }
@@ -283,7 +284,7 @@ export const getNextPatchVersion = async ({
 }: GithubProps & { majorVersion: number }) => {
   const lastRelease = await getLastReleaseTag({
     github, owner, repo,
-    version: `v0.${majorVersion.toString()}.0`
+    version: `v0.${majorVersion.toString()}.0`,
   });
 
   const nextPatch = findNextPatchVersion(lastRelease);

--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -236,7 +236,7 @@ export function getLastReleaseFromTags({tags, ignorePatches = false}: { tags: Ta
   return tags
     .map(tag => tag.ref.replace('refs/tags/', ''))
     .filter(tag => !isRCVersion(tag)) // we want to ignore RC tags because release notes should be cumulative
-    .filter(ignorePatches ? v => !isPatchVersion(v) :  () => true) // ignore patch versions since we don't release notes for them
+    .filter(ignorePatches ? v => !isPatchVersion(v) :  () => true)
     .sort(versionSort)
     .reverse()[0];
 }

--- a/release/src/version-helpers.unit.spec.ts
+++ b/release/src/version-helpers.unit.spec.ts
@@ -474,16 +474,16 @@ describe("version-helpers", () => {
 
   describe('getLastReleaseFromTags', () => {
     it('should return the latest release tag for minor versions', () => {
-      const latest = getLastReleaseFromTags([
+      const latest = getLastReleaseFromTags({ tags: [
         { ref: 'refs/tags/v0.12.0' },
         { ref: 'refs/tags/v0.12.2' },
         { ref: 'refs/tags/v0.12.1' },
-      ] as Tag[]);
+      ] as Tag[]});
       expect(latest).toBe('v0.12.2');
     });
 
-    it('should not return the latest release tag for patch versions', () => {
-      const latest = getLastReleaseFromTags([
+    it('should return the latest release tag for patch versions', () => {
+      const latest = getLastReleaseFromTags({ tags: [
         { ref: 'refs/tags/v0.12.0' },
         { ref: 'refs/tags/v0.11.2' },
         { ref: 'refs/tags/v0.12.2' },
@@ -491,25 +491,38 @@ describe("version-helpers", () => {
         { ref: 'refs/tags/v0.12.2.0' },
         { ref: 'refs/tags/v0.12.2.3' },
         { ref: 'refs/tags/v0.12.2.2' },
-      ] as Tag[]);
+      ] as Tag[]});
+      expect(latest).toBe('v0.12.2.3');
+    });
+
+    it('should ignore patches when the ignorePatches flag is passed', () => {
+      const latest = getLastReleaseFromTags({ tags: [
+        { ref: 'refs/tags/v0.12.0' },
+        { ref: 'refs/tags/v0.11.2' },
+        { ref: 'refs/tags/v0.12.2' },
+        { ref: 'refs/tags/v0.12.1' },
+        { ref: 'refs/tags/v0.12.2.0' },
+        { ref: 'refs/tags/v0.12.2.3' },
+        { ref: 'refs/tags/v0.12.2.2' },
+      ] as Tag[], ignorePatches: true });
       expect(latest).toBe('v0.12.2');
     });
 
     it('should return the latest tag for major version', () => {
-      const latest = getLastReleaseFromTags([
+      const latest = getLastReleaseFromTags({ tags: [
         { ref: 'refs/tags/v0.12.9' },
         { ref: 'refs/tags/v0.12.8' },
         { ref: 'refs/tags/v0.13.0' },
-      ] as Tag[]);
+      ] as Tag[] });
       expect(latest).toBe('v0.13.0');
     });
 
     it('should ignore release candidates', () => {
-      const latest = getLastReleaseFromTags([
+      const latest = getLastReleaseFromTags({ tags: [
         { ref: 'refs/tags/v0.12.0' },
         { ref: 'refs/tags/v0.12.2-RC99' },
         { ref: 'refs/tags/v0.12.1' },
-      ] as Tag[]);
+      ] as Tag[]});
       expect(latest).toBe('v0.12.1');
     });
   });


### PR DESCRIPTION


### Description

On friday, our [automation messed up](https://metaboat.slack.com/archives/C864UT5CZ/p1725064243922599) and tried to re-release an already-released patch version: `v50.23.1` This was because I changed the "last version" logic in https://github.com/metabase/metabase/pull/47377 to ignore patches when determining the "last" release. The problem is, for some purposes we want to ignore patches and some, we don't. So I introduced an "ignorePatches" flag to account for this. Now:

- when we want to find the last major/minor version release (like when we want to find all commits since the last set of release notes went out) we pass the `ignorePatches` flag
- when we want the last release of any kind, like when we want to calculate the version number for the next nightly patch, the `ignorePatches` flag defaults to false

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
