### PR TITLE
Fix text alignment for dashboard text card

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
@@ -22,7 +22,7 @@ import {
 
 const getSettingsStyle = settings => ({
   [CS.alignCenter]: settings["text.align_horizontal"] === "center",
-  [CS.alignStart]: settings["text.align_horizontal"] === "right",
+  [CS.alignEnd]: settings["text.align_horizontal"] === "right",
   [CS.justifyCenter]: settings["text.align_vertical"] === "middle",
   [CS.justifyEnd]: settings["text.align_vertical"] === "bottom",
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/46078

### Description

Fixes an accidental change from `align-end` to `align-start` [here](https://github.com/metabase/metabase/pull/40457/commits/2fdb4fbea9717c1bcca1479175e0777397e29805#diff-a2ba33a5dd0199912039c945da46e149555b84243e5653ee32d017f04643d684R23)

I haven't added any tests here - I'm not sure if there would be any intent to test this behaviour.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create a new dashboard
2. Add a text card with some text
3. Change the Horizontal Alignment of the text card to "Right"
4. The text should now display right-aligned.

### Demo

Screenshot of before:
<img width="1209" alt="Screenshot 2024-09-02 at 20 49 48" src="https://github.com/user-attachments/assets/d2a3a7bd-f28b-4827-b549-907f0835d50c">

Screenshot of after:
<img width="1209" alt="Screenshot 2024-09-02 at 20 50 20" src="https://github.com/user-attachments/assets/588cca81-afdb-431e-8312-8410be290220">


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
