### PR TITLE
[serdes] reveal exception causes

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/api.clj
@@ -86,10 +86,7 @@
                        report)
                      (catch Exception e
                        (reset! err e)
-                       (log/errorf "Error during serialization: %s %s"
-                                   (ex-message e)
-                                   (-> (ex-data e)
-                                       (dissoc :toucan2/context-trace))))))]
+                       (serdes/log-stripped-error "Error during serialization" e))))]
     {:archive       (when (.exists dst)
                       dst)
      :log-file      (when (.exists log-file)
@@ -131,10 +128,7 @@
                              (v2.load/load-metabase! {:continue-on-error continue-on-error}))))
                      (catch Exception e
                        (reset! err e)
-                       (log/errorf "Error during deserialization: %s %s"
-                                   (ex-message e)
-                                   (-> (ex-data e)
-                                       (dissoc :toucan2/context-trace))))))]
+                       (serdes/log-stripped-error "Error during deserialization" e))))]
     {:log-file      log-file
      :error-message (some-> @err str)
      :report        report

--- a/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
@@ -108,10 +108,6 @@
   (serdes/with-cache
     (v2.load/load-metabase! (v2.ingest/ingest-yaml path) opts)))
 
-(defn- stripped-error [e]
-  (let [m (ex-data e)]
-    (ex-info (ex-message e) m)))
-
 (mu/defn v2-load!
   "SerDes v2 load entry point.
 
@@ -125,9 +121,7 @@
         report   (try
                    (v2-load-internal! path opts :token-check? true)
                    (catch ExceptionInfo e
-                     (if (:error (ex-data e))
-                       (reset! err (stripped-error e))
-                       (reset! err e)))
+                     (reset! err e))
                    (catch Exception e
                      (reset! err e)))
         imported (into (sorted-set) (map (comp :model last)) (:seen report))]
@@ -143,7 +137,8 @@
                             :success       (nil? @err)
                             :error_message (some-> @err str)})
     (when @err
-      (throw @err))
+      (serdes/log-stripped-error "Error during deserialization" @err)
+      (throw (ex-info (ex-message @err) {:cmd/exit true})))
     imported))
 
 (defn- select-entities-in-collections
@@ -275,7 +270,8 @@
                             :success         (nil? @err)
                             :error_message   (some-> @err str)})
     (when @err
-      (throw @err))
+      (serdes/log-stripped-error "Error during serialization" @err)
+      (throw (ex-info (ex-message @err) {:cmd/exit true})))
     (log/info (format "Export to '%s' complete!" path) (u/emoji "🚛💨 📦"))
     report))
 

--- a/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
@@ -225,6 +225,7 @@
                         (is (= #{"Card" "Database" "Collection"}
                                (log-types (str/split-lines log))))
                         (is (re-find #"Failed to read file for Collection DoesNotExist" log))
+                        (is (re-find #"Unable to ingest file" log)) ;; underlying error
                         (is (= {:deps-chain #{[{:id "**ID**", :model "Card"}]},
                                 :error      :metabase-enterprise.serialization.v2.load/not-found,
                                 :model      "Collection",

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -312,6 +312,8 @@
         (init-fn))
       (apply @(cmd->var command-name) args)
       (catch Throwable e
+        (when (:cmd/exit (ex-data e)) ;; fast-track for commands that have their own error handling
+          (System/exit 1))
         (.printStackTrace e)
         (fail! (str "Command failed with exception: " (.getMessage e))))))
   (System/exit 0))

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1,3 +1,4 @@
+;; -*- outline-regexp: "[; ]+#+[[:space:]]+" -*-
 (ns metabase.models.serialization
   "Defines core interfaces for serialization.
 
@@ -1627,6 +1628,18 @@
                                   (maybe-lift outer-xform :export :export-with-context))
    :import-with-context (compose* (maybe-lift outer-xform :import :import-with-context)
                                   (maybe-lift inner-xform :import :import-with-context))})
+
+;;; ## Utilities
+
+(defmacro log-stripped-error
+  "Log errors with no stacktrace"
+  [prefix e]
+  `(loop [prefix# ~prefix
+          e#      ~e]
+     (when e#
+       (log/errorf (str prefix# ": " (ex-message e#) " " (-> (ex-data e#)
+                                                             (dissoc :toucan2/context-trace))))
+       (recur "  caused by" (.getCause ^Exception e#)))))
 
 ;;; ## Memoizing appdb lookups
 


### PR DESCRIPTION
I still don't want users' eyes to bleed looking at (unnecessary?) stacktraces, but we need to be able to see exception causes to determine what is going wrong

references #47520
