### PR TITLE
Rename 'Date Filter' to 'All Options' in field filters

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
@@ -192,7 +192,7 @@ describe("scenarios > dashboard > filters > date", () => {
     });
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Filtre de date").click(); // "Date Filter"
+    cy.findByText("Toutes les options").click(); // "All Options"
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Exclure...").click(); // "Exclude..."
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -205,7 +205,7 @@ describe("scenarios > dashboard > filters > date", () => {
 
     cy.url().should(
       "match",
-      /\/dashboard\/\d+\?filtre_de_date=exclude-months-Jan/,
+      /\/dashboard\/\d+\?toutes_les_options=exclude-months-Jan/,
     );
   });
 });

--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -634,7 +634,7 @@ describe("scenarios > dashboard > parameters", () => {
       editDashboard();
 
       cy.findByTestId("edit-dashboard-parameters-widget-container")
-        .findByText("Date Filter")
+        .findByText("All Options")
         .click();
 
       selectDashboardFilter(getDashboardCard(0), "Created At");
@@ -650,7 +650,7 @@ describe("scenarios > dashboard > parameters", () => {
 
       editDashboard();
       cy.findByTestId("edit-dashboard-parameters-widget-container")
-        .findByText("Date Filter")
+        .findByText("All Options")
         .click();
       selectDashboardFilter(getDashboardCard(0), "Created At");
 
@@ -663,7 +663,7 @@ describe("scenarios > dashboard > parameters", () => {
       editDashboard();
 
       cy.findByTestId("edit-dashboard-parameters-widget-container")
-        .findByText("Date Filter")
+        .findByText("All Options")
         .click();
 
       disconnectDashboardFilter(getDashboardCard(0));

--- a/e2e/test/scenarios/native-filters/helpers/e2e-field-filter-data-objects.js
+++ b/e2e/test/scenarios/native-filters/helpers/e2e-field-filter-data-objects.js
@@ -82,7 +82,7 @@ export const DATE_FILTER_SUBTYPES = {
     },
     representativeResult: "Gorgeous Wooden Car",
   },
-  "Date Filter": {
+  "All Options": {
     value: {
       timeBucket: "month",
     },

--- a/e2e/test/scenarios/native-filters/sql-field-filter-types.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-field-filter-types.cy.spec.js
@@ -50,7 +50,7 @@ describe("scenarios > filters > sql filters > field filter > Date", () => {
         DateFilter.setRelativeDate(filterValue);
         break;
 
-      case "Date Filter":
+      case "All Options":
         DateFilter.setAdHocFilter(filterValue);
         break;
 

--- a/e2e/test/scenarios/question-reproductions/reproductions-1.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-1.cy.spec.js
@@ -512,7 +512,7 @@ describe("issue 17514", () => {
   };
 
   const filter = {
-    name: "Date Filter",
+    name: "All Options",
     slug: "date_filter",
     id: "23ccbbf",
     type: "date/all-options",

--- a/frontend/src/metabase-lib/v1/parameters/constants.ts
+++ b/frontend/src/metabase-lib/v1/parameters/constants.ts
@@ -100,7 +100,7 @@ export const PARAMETER_OPERATOR_TYPES = {
     {
       type: "date/all-options",
       operator: "all-options",
-      name: t`Date Filter`,
+      name: t`All Options`,
       menuName: t`All Options`,
       description: t`Contains all of the above`,
     },


### PR DESCRIPTION
Following a [Slack thread](https://metaboat.slack.com/archives/C01LQQ2UW03/p1725044483092269):

> When selecting a type of date filter for a dashboard filter, there's an "All Options" option. When selecting the type of the filter widget for a field filter, the option that produces the same type of widget is called "Date Filter" instead (other options are called the same).
>
> Could we rename this option for the field filter to also be "All Options"? For consistency, but also because "Date Filter" is overloaded already and it becomes confusing (is someone saying "date filter" referring to a basic filter but with date variable type, or field filter with "date filter" widget type?...)

This PR does just that.

### To verify

1. New → SQL Query
2. `SELECT {{ x }}`
3. Change the variable type to `Field Filter` → `Accounts` → `Created At`
4. Change `Filter widget type` and make sure the `All Options` dropdown item exists