### PR TITLE
Don't update updated_at when setting last_used_at on a card

### DIFF
--- a/src/metabase/query_processor/middleware/results_metadata.clj
+++ b/src/metabase/query_processor/middleware/results_metadata.clj
@@ -36,7 +36,8 @@
                card-id
                ;; don't want to update metadata when we use a Card as a source Card.
                (not (:qp/source-card-id query)))
-      (t2/update! :model/Card card-id {:result_metadata metadata}))
+      (t2/update! :model/Card card-id {:result_metadata metadata
+                                       :updated_at      :updated_at}))
     ;; if for some reason we weren't able to record results metadata for this query then just proceed as normal
     ;; rather than failing the entire query
     (catch Throwable e

--- a/src/metabase/query_processor/middleware/update_used_cards.clj
+++ b/src/metabase/query_processor/middleware/update_used_cards.clj
@@ -24,7 +24,9 @@
                   {:last_used_at (into [:case]
                                        (mapcat (fn [[id timestamp]]
                                                  [[:= :id id] [:greatest [:coalesce :last_used_at (t/offset-date-time 0)] timestamp]])
-                                               card-id->timestamp))})
+                                               card-id->timestamp))
+                   ;; Set updated_at to its current value to prevent it from updating automatically
+                   :updated_at :updated_at})
       (catch Throwable e
         (log/error e "Error updating used cards")))))
 

--- a/test/metabase/query_processor/middleware/results_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/results_metadata_test.clj
@@ -98,7 +98,11 @@
         (when-not (= :completed (:status result))
           (throw (ex-info "Query failed." result))))
       (is (= (round-to-2-decimals (default-card-results-native))
-             (-> card card-metadata round-to-2-decimals))))))
+             (-> card card-metadata round-to-2-decimals)))
+
+      ;; updated_at should not be modified when saving result metadata
+      (is (= (:updated_at card)
+             (t2/select-one-fn :updated_at :model/Card :id (u/the-id card)))))))
 
 (deftest save-result-metadata-test-2
   (testing "check that using a Card as your source doesn't overwrite the results metadata..."

--- a/test/metabase/query_processor/middleware/update_used_cards_test.clj
+++ b/test/metabase/query_processor/middleware/update_used_cards_test.clj
@@ -25,15 +25,22 @@
   [card-id]
   (t2/select-one-fn :last_used_at :model/Card card-id))
 
+(defn- card-updated-at
+  [card-id]
+  (t2/select-one-fn :updated_at :model/Card card-id))
+
 (defn do-test!
   "Check if `last_used_at` of `card-id` is nil, then execute `f`, then check that `last_used_at` is non nil."
   [card-id thunk]
   (assert (fn? thunk))
-  (let [original-last-used-at (card-last-used-at card-id)]
+  (let [original-last-used-at (card-last-used-at card-id)
+        original-updated-at   (card-updated-at card-id)]
     (mt/with-temporary-setting-values [synchronous-batch-updates true]
       (thunk))
     (testing "last_used_at should be updated after executing the query"
-      (is (not= original-last-used-at (card-last-used-at card-id))))))
+      (is (not= original-last-used-at (card-last-used-at card-id))))
+    (testing "updated_at should not be updated after executing the query"
+      (is (= original-updated-at (card-updated-at card-id))))))
 
 (deftest nested-cards-test
   (with-used-cards-setup!


### PR DESCRIPTION
A Card's `updated_at` value is used to compute the hash for identifying a user's sandboxed field values. If this hash changes, the field values cache is invalidated and we need to fetch field values again.

There are a couple places where we're needlessly updating `updated_at` in the course of a Card's execution when no updates to the Card definition are actually taking place:
* When setting `last_used_at`
* When updating `result_metadata`

This causes the field values cache to be invalidated essentially every time a dashboard loads. I've fixed these spots in this PR and added tests to ensure that they don't update `:updated_at`.