### PR TITLE
docs - note on DuckDB

### DIFF
--- a/docs/developers-guide/partner-and-community-drivers.md
+++ b/docs/developers-guide/partner-and-community-drivers.md
@@ -43,7 +43,7 @@ To qualify as a partner driver, the driver must:
 Current partner drivers:
 
 - [ClickHouse](https://github.com/ClickHouse/metabase-clickhouse-driver)
-- [DuckDB](https://github.com/MotherDuck-Open-Source/metabase_duckdb_driver)
+- [DuckDB](https://github.com/MotherDuck-Open-Source/metabase_duckdb_driver) (for now, only available for self-hosted Metabases)
 - [Exasol](https://github.com/exasol/metabase-driver)
 - [Firebolt](https://docs.firebolt.io/integrations/business-intelligence/connecting-to-metabase.html)
 - [Materialize](https://github.com/MaterializeInc/metabase-materialize-driver)


### PR DESCRIPTION
For now, DuckDB driver is only available for self-hosted Metabases.
