### PR TITLE
[QP] Correctly handle `:lib/internal-remap` columns in `:result_metadata`

### DIFF
--- a/src/metabase/lib/schema/metadata.cljc
+++ b/src/metabase/lib/schema/metadata.cljc
@@ -144,7 +144,8 @@
    [:name      :string]
    ;; TODO -- ignore `base_type` and make `effective_type` required; see #29707
    [:base-type ::lib.schema.common/base-type]
-   [:id             {:optional true} ::lib.schema.id/field]
+   ;; This is nillable because internal remap columns have `:id nil`.
+   [:id             {:optional true} [:maybe ::lib.schema.id/field]]
    [:display-name   {:optional true} [:maybe :string]]
    [:effective-type {:optional true} [:maybe ::lib.schema.common/base-type]]
    ;; type of this column in the data warehouse, e.g. `TEXT` or `INTEGER`

--- a/src/metabase/query_processor/middleware/add_source_metadata.clj
+++ b/src/metabase/query_processor/middleware/add_source_metadata.clj
@@ -54,7 +54,8 @@
                    ;; don't add remapped columns to the source metadata for the source query, otherwise we're going
                    ;; to end up adding it again when the middleware runs at the top level
                    :query    (assoc-in source-query [:middleware :disable-remaps?] true)}))]
-      (for [col cols]
+      (for [col cols
+            :when (not (:remapped_from col))]
         (select-keys col [:name :id :table_id :display_name :base_type :effective_type :coercion_strategy
                           :semantic_type :unit :fingerprint :settings :source_alias :field_ref :nfc_path :parent_id])))
     (catch Throwable e

--- a/src/metabase/query_processor/middleware/fetch_source_query.clj
+++ b/src/metabase/query_processor/middleware/fetch_source_query.clj
@@ -56,7 +56,8 @@
                     stages        (for [stage stages]
                                     ;; this is for detecting circular refs below.
                                     (assoc stage :qp/stage-is-from-source-card card-id))
-                    card-metadata (lib.card/card-metadata-columns metadata-providerable card)
+                    card-metadata (into [] (remove :remapped-from)
+                                        (lib.card/card-metadata-columns metadata-providerable card))
                     last-stage    (cond-> (last stages)
                                     (seq card-metadata) (assoc-in [:lib/stage-metadata :columns] card-metadata)
                                     ;; This will be applied, if still appropriate, by

--- a/src/metabase/query_processor/middleware/fetch_source_query_legacy.clj
+++ b/src/metabase/query_processor/middleware/fetch_source_query_legacy.clj
@@ -82,5 +82,7 @@
                                          (u/the-id (lib.metadata/database (qp.store/metadata-provider)))
                                          persisted-info)))
               :database        database-id
-              :source-metadata (seq (map mbql.normalize/normalize-source-metadata result-metadata))}
+              :source-metadata (sequence (comp (map mbql.normalize/normalize-source-metadata)
+                                               (remove :remapped_from))
+                                         result-metadata)}
        (= card-type :model) (assoc :source-query/model? true)))))

--- a/src/metabase/query_processor/middleware/results_metadata.clj
+++ b/src/metabase/query_processor/middleware/results_metadata.clj
@@ -57,7 +57,7 @@
      (merge
       (select-keys final-col [:id :description :display_name :semantic_type :fk_target_field_id
                               :settings :field_ref :base_type :effective_type
-                              :coercion_strategy :visibility_type])
+                              :remapped_from :remapped_to :coercion_strategy :visibility_type])
       insights-col
       {:name (:name final-col)} ; The final cols have correctly disambiguated ID_2 names, but the insights cols don't.
       (when (= our-base-type :type/*)


### PR DESCRIPTION
Fixes #45938.

### Description

Remapping is handled at the top level of the query, and should be
ignored for inner queries. This PR hides it from `results_metadata` on
source queries.

It also fixes the interaction with `large-int-id` logic to make big
integers JS-safe.

### How to verify

1. Set up an ID column with an **internal** remap
    - (Remapping based on a fixed drop-down list, not another column.)
2. Create a model which **joins** in that column and does a breakout on it.
3. Consume that model from a question

Before this change, it will error with the message in #45938. With this change, it will remap correctly.
I also fixed a tangential issue with the `large-int-id` and internal remapping.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
