### PR TITLE
Store ::nil markers in CachedMetadataProvider for failed lookups

### DIFF
--- a/src/metabase/lib/metadata/protocols.cljc
+++ b/src/metabase/lib/metadata/protocols.cljc
@@ -9,7 +9,7 @@
 
 (#?(:clj p/defprotocol+ :cljs defprotocol) MetadataProvider
   "Protocol for something that we can get information about Tables and Fields
-  from. This can be provided in various ways various ways:
+  from. This can be provided in various ways:
 
   1. By raw metadata attached to the query itself
 

--- a/test/metabase/lib/metadata/cached_provider_test.cljc
+++ b/test/metabase/lib/metadata/cached_provider_test.cljc
@@ -58,17 +58,13 @@
       (testing "Fetch a missing id, first fetch should inc fetch count"
         (let [results (lib.metadata.protocols/metadatas provider :metadata/table #{1 missing-id})]
           (is (=? [{:id 1}]
-                  results))
-          (is (not (some #(= (:id %) missing-id)
-                         results))))
+                  results)))
         (is (= 3
                @fetch-count)))
       (testing "Fetch a missing id, second fetch should not inc fetch count"
         (let [results (lib.metadata.protocols/metadatas provider :metadata/table #{1 missing-id})]
           (is (=? [{:id 1}]
-                  results))
-          (is (not (some #(= (:id %) missing-id)
-                         results))))
+                  results)))
         (is (= 3
                @fetch-count))))))
 

--- a/test/metabase/lib/metadata/cached_provider_test.cljc
+++ b/test/metabase/lib/metadata/cached_provider_test.cljc
@@ -10,15 +10,19 @@
 
 (deftest ^:parallel caching-test
   (let [fetch-count (atom 0)
+        missing-id  123
         provider    (lib.metadata.cached-provider/cached-metadata-provider
                      (reify
                        lib.metadata.protocols/MetadataProvider
                        (metadatas [_this metadata-type ids]
                          (case metadata-type
-                           :metadata/table (for [id ids]
-                                             (do
-                                               (swap! fetch-count inc)
-                                               (assoc (meta/table-metadata :venues) :id id)))))))]
+                           :metadata/table
+                           (->> (for [id ids]
+                                  (do
+                                    (swap! fetch-count inc)
+                                    (when (not= id missing-id)
+                                      (assoc (meta/table-metadata :venues) :id id))))
+                                (filter some?))))))]
     (testing "Initial fetch"
       (is (=? {:id 1}
               (lib.metadata.protocols/table provider 1)))
@@ -50,6 +54,22 @@
                  {:id 2}]
                 (lib.metadata.protocols/metadatas provider :metadata/table #{1 2})))
         (is (= 2
+               @fetch-count)))
+      (testing "Fetch a missing id, first fetch should inc fetch count"
+        (let [results (lib.metadata.protocols/metadatas provider :metadata/table #{1 missing-id})]
+          (is (=? [{:id 1}]
+                  results))
+          (is (not (some #(= (:id %) missing-id)
+                         results))))
+        (is (= 3
+               @fetch-count)))
+      (testing "Fetch a missing id, second fetch should not inc fetch count"
+        (let [results (lib.metadata.protocols/metadatas provider :metadata/table #{1 missing-id})]
+          (is (=? [{:id 1}]
+                  results))
+          (is (not (some #(= (:id %) missing-id)
+                         results))))
+        (is (= 3
                @fetch-count))))))
 
 (deftest ^:parallel equality-test

--- a/test/metabase/lib/metadata/cached_provider_test.cljc
+++ b/test/metabase/lib/metadata/cached_provider_test.cljc
@@ -29,7 +29,7 @@
               (lib.metadata.protocols/table provider 1)))
       (is (= 1
              @fetch-count)))
-    (testing "Second fetch"
+    (testing "Third fetch"
       (is (=? {:id 1}
               (lib.metadata.protocols/table provider 1)))
       (is (= 1


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39326

### Description

Store ::nil markers in CachedMetadataProvider for any ids for which the wrapped/uncached upstream provider fails to return
metadatas. This prevents repeatedly querying the uncached-provider for ids that don't exist.

The downside is that if the uncached-provider suddenly starts returning metadata for an id that previously did not
exist, we won't pick up on it, but the assumption here is that this is no different / worse than cache invalidation
for existing ids that happen to change after we cache them.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
