### PR TITLE
fix: bigquery add null checks to result processing

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -827,9 +827,9 @@
                                                  (log/debugf "*page-callback counting down: %d to go" pages)))]
             (mt/dataset test-data
                         ;; *page-size* is inexact - should be 300 but give it a wide margin.
-                        (is (< 10
-                               (count (mt/rows (mt/process-query (mt/query orders))))
-                               500)))))))))
+              (is (< 10
+                     (count (mt/rows (mt/process-query (mt/query orders))))
+                     500)))))))))
 
 (deftest later-page-fetch-throws-test
   (mt/test-driver :bigquery-cloud-sdk

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -815,7 +815,7 @@
                            (proxy [TableResult] []
                              (getSchema [] (.getSchema result))
                              (getValues [] (.getValues result))
-                             (getNextPageToken [] (.getNextPageToken result))
+                             (hasNextPage [] (.hasNextPage result))
                              (getNextPage []
                                (if (zero? @page-counter)
                                  (throw (ex-info "onoes BigQuery failed to fetch a later page" {}))


### PR DESCRIPTION
Fixes #47339

On the related issue there are different stacktraces indicating likely sources of null pointer exceptions.

1. `.getNextPage` is likely returning a nil value. I was unable to reproduce this but one thing I did notice is that `hasNextPage` is recommended over checking `.getNextPageToken`. Added nil handling around `page` possibly being nil.

2. `cancel-chan` may be triggered before processing begins and such `execute-bigquery` would pass nil as a TableResult to the initial reducer. Testing if cancel-chan happens at just the right moment would be too flaky for CI testing but I was able to reproduce this locally and is fixed by the nil handling added.

3. `cancel-chan` may be triggered during query processing. This is covered by a test now.
