### PR TITLE
Update default locked parameter value

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
@@ -623,19 +623,29 @@ describe("scenarios > embedding > dashboard parameters with defaults", () => {
   });
 
   it("locked parameters require a value to be specified in the JWT", () => {
-    openStaticEmbeddingModal({ activeTab: "parameters" });
+    const nameParameter = dashboardDetails.parameters.find(
+      parameter => parameter.name === "Name",
+    );
+    const sourceParameter = dashboardDetails.parameters.find(
+      parameter => parameter.name === "Source",
+    );
 
-    // ID param is disabled by default
-    setEmbeddingParameter("Name", "Editable");
-    setEmbeddingParameter("Source", "Locked");
-    publishChanges("dashboard", ({ request }) => {
-      assert.deepEqual(request.body.embedding_params, {
-        source: "locked",
-        name: "enabled",
+    cy.get("@dashboardId").then(dashboardId => {
+      cy.request("PUT", `api/dashboard/${dashboardId}`, {
+        enable_embedding: true,
+        embedding_params: {
+          [nameParameter.slug]: "enabled",
+          [sourceParameter.slug]: "locked",
+        },
       });
-    });
 
-    visitIframe();
+      const payload = {
+        resource: { dashboard: dashboardId },
+        params: { source: null },
+      };
+
+      visitEmbeddedPage(payload);
+    });
 
     // The Source parameter is 'locked', and no value has been specified in the token,
     // thus the API responds with "You must specify a value for :source in the JWT."
@@ -644,6 +654,33 @@ describe("scenarios > embedding > dashboard parameters with defaults", () => {
     getDashboardCard()
       .findByText("There was a problem displaying this chart.")
       .should("be.visible");
+  });
+
+  it("locked parameters should still render results in the preview by default (metabase#47570)", () => {
+    const nameParameter = dashboardDetails.parameters.find(
+      parameter => parameter.name === "Name",
+    );
+    const sourceParameter = dashboardDetails.parameters.find(
+      parameter => parameter.name === "Source",
+    );
+
+    cy.get("@dashboardId").then(dashboardId => {
+      cy.request("PUT", `api/dashboard/${dashboardId}`, {
+        enable_embedding: true,
+        embedding_params: {
+          [nameParameter.slug]: "enabled",
+          [sourceParameter.slug]: "locked",
+        },
+      });
+    });
+
+    visitDashboard("@dashboardId");
+    openStaticEmbeddingModal({ activeTab: "parameters" });
+    visitIframe();
+
+    cy.log("should show card results by default");
+    getDashboardCard().findByText("2").should("be.visible");
+    getDashboardCard().findByText("test question").should("be.visible");
   });
 });
 

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/StaticEmbedSetupPane.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/StaticEmbedSetupPane.tsx
@@ -408,14 +408,16 @@ function getPreviewParamsBySlug({
   );
 
   return Object.fromEntries(
-    lockedParameters.map(parameter => [
-      parameter.slug,
-      getParameterValue({
+    lockedParameters.map(parameter => {
+      const value = getParameterValue({
         parameter,
         values: parameterValues,
         defaultRequired: true,
-      }),
-    ]),
+      });
+      // metabase#47570
+      const valueWithDefaultLockedParameterValue = value === null ? [] : value;
+      return [parameter.slug, valueWithDefaultLockedParameterValue];
+    }),
   );
 }
 

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tests/common.unit.spec.tsx
@@ -340,7 +340,7 @@ describe("Static Embed Setup phase", () => {
           ).toBeVisible();
 
           expect(screen.getByTestId("text-editor-mock")).toHaveTextContent(
-            `params: { "${DATE_PARAMETER_MOCK.slug}": null }`,
+            `params: { "${DATE_PARAMETER_MOCK.slug}": [] }`,
           );
         });
 
@@ -621,7 +621,7 @@ describe("Static Embed Setup phase", () => {
 
     await userEvent.click(screen.getByText("Locked"));
 
-    const parametersChangedCode = `params: { "${DATE_PARAMETER_MOCK.slug}": null }`;
+    const parametersChangedCode = `params: { "${DATE_PARAMETER_MOCK.slug}": [] }`;
 
     expect(
       screen.getByTestId("text-editor-mock-highlighted-code"),
@@ -635,7 +635,7 @@ describe("Static Embed Setup phase", () => {
 
     expect(
       screen.getByTestId("text-editor-mock-highlighted-code"),
-    ).toHaveTextContent(`params: { "${DATE_PARAMETER_MOCK.slug}": null }`);
+    ).toHaveTextContent(`params: { "${DATE_PARAMETER_MOCK.slug}": [] }`);
 
     await userEvent.click(screen.getByText("Dark"));
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/47570

### Description

Since #40292, we will fail all static embed with locked parameter with values `null`. So, to make the static embed preview works without requiring users inputing all locked parameters values, we need to update the default value accordingly from `null` to `[]`

### How to verify

1. Embed a native question or a dashboard with a a parameter.
1. When embedding change the parameter type to `locked`
1. Click Preview and you should see the dashboard card/question render with results.

### Demo

![image](https://github.com/user-attachments/assets/6a17f898-b283-4ab8-9922-5a4ce2f85b47)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
