### PR TITLE
Revert "Hide upload config when data warehouse is attached"

### DIFF
--- a/e2e/test/scenarios/admin-2/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/settings.cy.spec.js
@@ -15,7 +15,6 @@ import {
   isEE,
   isOSS,
   main,
-  mockSessionPropertiesTokenFeatures,
   modal,
   onlyOnOSS,
   openNativeEditor,
@@ -1180,50 +1179,5 @@ describe("notifications", { tags: "@external" }, () => {
       .click();
 
     cy.findByRole("heading", { name: "Add a webhook" }).should("exist");
-  });
-});
-
-describe("admin > upload settings", () => {
-  describe("scenarios > admin > uploads (OSS)", { tags: "@OSS" }, () => {
-    beforeEach(() => {
-      restore();
-      cy.signInAsAdmin();
-    });
-
-    it("should show the uploads settings page", () => {
-      cy.visit("/admin/settings/uploads");
-      cy.findByTestId("admin-list-settings-items").findByText("Uploads");
-      cy.findByLabelText("Upload Settings Form").findByText(
-        "Database to use for uploads",
-      );
-    });
-  });
-  describeEE("scenarios > admin > uploads (EE)", () => {
-    beforeEach(() => {
-      restore();
-      cy.signInAsAdmin();
-      setTokenFeatures("all");
-    });
-
-    it("without attached-dwh should show the uploads settings page", () => {
-      mockSessionPropertiesTokenFeatures({ attached_dwh: false });
-      cy.visit("/admin/settings/uploads");
-      cy.findByTestId("admin-list-settings-items").findByText("Uploads");
-      cy.findByLabelText("Upload Settings Form").findByText(
-        "Database to use for uploads",
-      );
-    });
-
-    it("with attached-dwh should not show the uploads settings page", () => {
-      mockSessionPropertiesTokenFeatures({ attached_dwh: true });
-      cy.visit("/admin/settings/uploads");
-      cy.findByTestId("admin-list-settings-items")
-        .findByText("Uploads")
-        .should("not.exist");
-
-      cy.findAllByLabelText("error page").findByText(
-        "The page you asked for couldn't be found.",
-      );
-    });
   });
 });

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -388,7 +388,6 @@ export const ADMIN_SETTINGS_SECTIONS = {
         key: "uploads-settings",
       },
     ],
-    getHidden: settings => settings["token-features"]?.attached_dwh === true,
   },
 
   "public-sharing": {

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -840,8 +840,6 @@ See [fonts](../configuring-metabase/fonts.md).")
                    :table_prefix (:uploads_table_prefix db)}))
   :setter     (fn [{:keys [db_id schema_name table_prefix]}]
                 (cond
-                  (premium-features/has-feature? :attached-dwh)
-                  (api/throw-403)
                   (nil? db_id)
                   (t2/update! :model/Database :uploads_enabled true {:uploads_enabled      false
                                                                      :uploads_schema_name  nil

--- a/test/metabase/api/setting_test.clj
+++ b/test/metabase/api/setting_test.clj
@@ -3,7 +3,6 @@
    [clojure.test :refer :all]
    [metabase.api.common.validation :as validation]
    [metabase.driver.h2 :as h2]
-   [metabase.models :refer [Database]]
    [metabase.models.setting :as setting :refer [defsetting]]
    [metabase.models.setting-test :as models.setting-test]
    [metabase.test :as mt]
@@ -221,75 +220,6 @@
              (mt/user-http-request :crowberto :put 204 "setting" {:test-sensitive-setting "**********56"})))
       (is (= "123456"
              (models.setting-test/test-sensitive-setting))))))
-
-(deftest fetch-conditionally-read-only-setting-test
-  (testing "GET requests are unaffected by the conditional read-only status"
-    (testing "GET /api/session/properties with attached-dwh"
-      (mt/with-premium-features #{:attached-dwh}
-        (is (=? {:db_id        nil
-                 :schema_name  nil
-                 :table_prefix nil}
-                (:uploads-settings (mt/user-http-request :crowberto :get 200 "session/properties"))))))
-    (testing "GET /api/setting with attached-dwh"
-      (mt/with-premium-features #{:attached-dwh}
-        (is (=? {:db_id        nil
-                 :schema_name  nil
-                 :table_prefix nil}
-                (:value (first (filter (comp #{"uploads-settings"} :key)
-                                       (mt/user-http-request :crowberto :get 200 "setting"))))))))
-    (testing "GET /api/setting/uploads-settings with attached-dwh"
-      (mt/with-premium-features #{:attached-dwh}
-        (is (=? {:db_id        nil
-                 :schema_name  nil
-                 :table_prefix nil}
-                (mt/user-http-request :crowberto :get 200 "setting/uploads-settings")))))
-    (testing "GET /api/session/properties without attached-dwh"
-      (is (=? {:db_id        nil
-               :schema_name  nil
-               :table_prefix nil}
-              (:uploads-settings (mt/user-http-request :crowberto :get 200 "session/properties")))))
-    (testing "GET /api/setting without attached-dwh"
-      (is (=? {:db_id        nil
-               :schema_name  nil
-               :table_prefix nil}
-              (:value (first (filter (comp #{"uploads-settings"} :key)
-                                     (mt/user-http-request :crowberto :get 200 "setting")))))))
-    (testing "GET /api/setting/uploads-settings without attached-dwh"
-      (is (=? {:db_id        nil
-               :schema_name  nil
-               :table_prefix nil}
-              (mt/user-http-request :crowberto :get 200 "setting/uploads-settings"))))))
-
-(deftest set-conditionally-read-only-setting-test
-  (testing "PUT requests are rejected with attached-dwh but permitted without"
-    (mt/with-temp [Database {:keys [id]} {:engine :postgres
-                                          :name   "The Chosen One"}]
-      (testing "PUT /api/setting with attached-dwh"
-        (mt/with-premium-features #{:attached-dwh}
-          (mt/user-http-request :crowberto :put 403 "setting" {:uploads-settings {:db_id id}}))
-        (is (=? {:db_id        nil
-                 :schema_name  nil
-                 :table_prefix nil}
-                (mt/user-http-request :crowberto :get 200 "setting/uploads-settings"))))
-      (testing "PUT /api/setting/uploads-settings with attached-dwh"
-        (mt/with-premium-features #{:attached-dwh}
-          (mt/user-http-request :crowberto :put 403 "setting/uploads-settings" {:value {:db_id id}}))
-        (is (=? {:db_id        nil
-                 :schema_name  nil
-                 :table_prefix nil}
-                (mt/user-http-request :crowberto :get 200 "setting/uploads-settings"))))
-      (testing "PUT /api/setting without attached-dwh"
-        (mt/user-http-request :crowberto :put 204 "setting" {:uploads-settings {:db_id id}})
-        (is (=? {:db_id        id
-                 :schema_name  nil
-                 :table_prefix nil}
-                (mt/user-http-request :crowberto :get 200 "setting/uploads-settings"))))
-      (testing "PUT /api/setting/uploads-settings without attached-dwh"
-        (mt/user-http-request :crowberto :put 204 "setting/uploads-settings" {:value {:db_id id}})
-        (is (=? {:db_id        id
-                 :schema_name  nil
-                 :table_prefix nil}
-                (mt/user-http-request :crowberto :get 200 "setting/uploads-settings")))))))
 
 ;; there are additional tests for this functionality in [[metabase.models.models.setting-test/set-many!-test]], since
 ;; this API endpoint is just a thin wrapper around that function


### PR DESCRIPTION
The way this was implemented, it also hid the section for management
of uploaded CSV files.  Further, admins might want to intentionally
switch from uploading to the data warehouse provided by Metabase to
one of their own.

This reverts commit fbaf58ad032afd3283baa3d6c7fb056ac6a23b8a.

This needs to be backported to v50.

References: https://github.com/metabase/harbormaster/issues/5121
References: https://metaboat.slack.com/archives/C032LFJFANL/p1725296255637989
