### PR TITLE
Fix visualization with warnings doesn't work when embedding

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -983,3 +983,39 @@ describe("issue 40660", () => {
     });
   });
 });
+
+describe("issue 47617", () => {
+  const questionDetails = {
+    name: "issue 47617",
+    native: {
+      query: 'SELECT * FROM VALUES (1, 2), (1, 3) AS X("Month", "Value")',
+    },
+    display: "bar",
+    visualization_settings: {
+      "graph.dimensions": ["Month"],
+      "graph.metrics": ["Value"],
+    },
+    enable_embedding: true,
+  };
+
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    createNativeQuestion(questionDetails, { wrapId: true });
+  });
+
+  it("static embed question should render with warnings (metabase#47617)", () => {
+    visitQuestion("@questionId");
+
+    openStaticEmbeddingModal({
+      activeTab: "parameters",
+      previewMode: "preview",
+    });
+
+    getIframeBody().within(() => {
+      cy.findByText("Month").should("be.visible");
+      cy.findByText("Value").should("be.visible");
+    });
+  });
+});

--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -1005,7 +1005,7 @@ describe("issue 47617", () => {
     createNativeQuestion(questionDetails, { wrapId: true });
   });
 
-  it("static embed question should render with warnings (metabase#47617)", () => {
+  it("static embed question with warnings should render (metabase#47617)", () => {
     visitQuestion("@questionId");
 
     openStaticEmbeddingModal({

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
@@ -318,7 +318,14 @@ class Visualization extends PureComponent {
   };
 
   onRender = ({ yAxisSplit, warnings = [] } = {}) => {
-    this.setState({ yAxisSplit, warnings });
+    const currentYAxisSplit = this.state.yAxisSplit;
+    const currentWarnings = this.state.warnings;
+    if (
+      !_.isEqual(currentYAxisSplit, yAxisSplit) ||
+      !_.isEqual(currentWarnings, warnings)
+    ) {
+      this.setState({ yAxisSplit, warnings });
+    }
   };
 
   onRenderError = error => {


### PR DESCRIPTION
> [!note]
> This PRs directly target 50, because the code is already fixed on master, but the fix is a part of a feature which shouldn't be backported.

Closes https://github.com/metabase/metabase/issues/47617

### Description

This fixes by preventing the visualization from repeatedly updating the same warning causing the infinite loop. I don't quite grasp why this only happens on the static embed/public embed yet. But applying the same code from `master` works, so I'll go with that for simplicity.

### How to verify

Follow the repro step in #47617

### Demo
<img width="941" alt="Screenshot 2024-09-04 at 10 45 00 PM" src="https://github.com/user-attachments/assets/a27977ae-1a66-4d59-b21b-09b08737c0d6">


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
