### PR TITLE
Pass string auto param to ee-extra

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -625,7 +625,7 @@ jobs:
               event_type: 'update-ee-extra-build',
               client_payload: {
                 version: enterpriseVersion,
-                auto: true, // always auto-merge
+                auto: 'true', // always auto-merge
               }
             });
 


### PR DESCRIPTION


### Description

ee-extra builds have not been auto-approving and merging because this was expecting a string, not a boolean. Data types in github actions are confusing 🥴 
