### PR TITLE
[Permissions] Warn group can’t view native queries w/ Blocked schema/table access

### DIFF
--- a/e2e/test/scenarios/permissions/view-data.cy.spec.js
+++ b/e2e/test/scenarios/permissions/view-data.cy.spec.js
@@ -58,6 +58,20 @@ describeEE("scenarios > admin > permissions > view data > blocked", () => {
       assertPermissionForItem(g, DOWNLOAD_PERM_IDX, "No", true);
     });
 
+    cy.log(
+      "assert that user properly sees native query warning related to table level blocking",
+    );
+    getPermissionRowPermissions("All Users")
+      .eq(DATA_ACCESS_PERM_IDX)
+      .findByLabelText("warning icon")
+      .realHover();
+
+    cy.findByRole("tooltip")
+      .findByText(
+        /Users in groups with Blocked on a table can't view native queries on this database/,
+      )
+      .should("exist");
+
     cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`); // database level
 
     assertPermissionForItem(g, DATA_ACCESS_PERM_IDX, "Granular", false);

--- a/frontend/src/metabase/admin/permissions/selectors/confirmations.tsx
+++ b/frontend/src/metabase/admin/permissions/selectors/confirmations.tsx
@@ -90,6 +90,24 @@ export function getPermissionWarning(
   return null;
 }
 
+export function getTableBlockWarning(
+  dbValue: DataPermissionValue,
+  schemaValue: DataPermissionValue,
+  tableValue?: DataPermissionValue,
+) {
+  if (dbValue === DataPermissionValue.BLOCKED) {
+    return;
+  }
+
+  if (schemaValue === DataPermissionValue.BLOCKED) {
+    return t`Users in groups with Blocked on a schema can't view native queries on this database.`;
+  }
+
+  if (tableValue === DataPermissionValue.BLOCKED) {
+    return t`Users in groups with Blocked on a table can't view native queries on this database.`;
+  }
+}
+
 function getEntityTypeFromId(entityId: EntityId): [string, string] {
   return isTableEntityId(entityId)
     ? [t`table`, t`tables`]

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/fields.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/fields.ts
@@ -3,6 +3,7 @@ import _ from "underscore";
 import { getNativePermissionDisabledTooltip } from "metabase/admin/permissions/selectors/data-permissions/shared";
 import {
   getFieldsPermission,
+  getSchemasPermission,
   getTablesPermission,
 } from "metabase/admin/permissions/utils/graph";
 import {
@@ -28,6 +29,7 @@ import {
   getPermissionWarning,
   getPermissionWarningModal,
   getRevokingAccessToAllTablesWarningModal,
+  getTableBlockWarning,
   getWillRevokeNativeAccessWarningModal,
 } from "../confirmations";
 
@@ -53,6 +55,7 @@ const buildAccessPermission = (
     entityId,
     DataPermission.VIEW_DATA,
   );
+
   const defaultGroupValue = getFieldsPermission(
     permissions,
     defaultGroup.id,
@@ -60,13 +63,31 @@ const buildAccessPermission = (
     DataPermission.VIEW_DATA,
   );
 
-  const warning = getPermissionWarning(
+  const dbValue = getSchemasPermission(
+    originalPermissions,
+    groupId,
+    entityId,
+    DataPermission.VIEW_DATA,
+  );
+
+  const schemaValue = getTablesPermission(
+    originalPermissions,
+    groupId,
+    entityId,
+    DataPermission.VIEW_DATA,
+  );
+
+  const permissionWarning = getPermissionWarning(
     value,
     defaultGroupValue,
     "fields",
     defaultGroup,
     groupId,
   );
+
+  const blockWarning = getTableBlockWarning(dbValue, schemaValue, value);
+
+  const warning = permissionWarning || blockWarning;
 
   const confirmations = (newValue: DataPermissionValue) => [
     getPermissionWarningModal(

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
@@ -25,6 +25,7 @@ import {
 import {
   getPermissionWarning,
   getPermissionWarningModal,
+  getTableBlockWarning,
   getViewDataPermissionsTooRestrictiveWarningModal,
   getWillRevokeNativeAccessWarningModal,
 } from "../confirmations";
@@ -58,13 +59,24 @@ const buildAccessPermission = (
     DataPermission.VIEW_DATA,
   );
 
-  const warning = getPermissionWarning(
+  const dbValue = getSchemasPermission(
+    originalPermissions,
+    groupId,
+    entityId,
+    DataPermission.VIEW_DATA,
+  );
+
+  const permissionWarning = getPermissionWarning(
     value,
     defaultGroupValue,
     "tables",
     defaultGroup,
     groupId,
   );
+
+  const blockWarning = getTableBlockWarning(dbValue, value);
+
+  const warning = permissionWarning || blockWarning;
 
   const confirmations = (newValue: DataPermissionValue) => [
     getPermissionWarningModal(


### PR DESCRIPTION
Helps w/ #47547

Product direction in Slack thread: https://metaboat.slack.com/archives/C05NXACAG1G/p1725315407578979

### Description

Adds warning message on Blocked schemas or tables
![CleanShot 2024-09-20 at 14 49 16@2x](https://github.com/user-attachments/assets/779d6b77-f6bf-4474-a93a-c20251c8f204)

### How to verify

- Have a db with View Data set to "Can View" for a All Users group
- Drill down into the schema or table view
- Change a schema/table to Blocked
- Tooltip should appear with message (note another message will appear if you chose another group and the default group has more permissive access)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
