### PR TITLE
Fix query type and respect user parameters in search

### DIFF
--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -28,6 +28,7 @@
                            :created-at                          created_at
                            :created-by                          (set (u/one-or-many created_by))
                            :current-user-id                     api/*current-user-id*
+                           :is-superuser?                       api/*is-superuser?*
                            :current-user-perms                  @api/*current-user-permissions-set*
                            :filter-items-in-personal-collection filter_items_in_personal_collection
                            :last-edited-at                      last_edited_at

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -85,6 +85,7 @@
        :created-at                          created_at
        :created-by                          (set created_by)
        :current-user-id                     api/*current-user-id*
+       :is-superuser?                       api/*is-superuser?*
        :current-user-perms                  @api/*current-user-permissions-set*
        :filter-items-in-personal-collection filter_items_in_personal_collection
        :last-edited-at                      last_edited_at

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -488,6 +488,11 @@
    [:permission-level {:optional true} [:enum :read :write]]
    [:effective-child-of {:optional true} [:maybe CollectionWithLocationAndIDOrRoot]]])
 
+(def ^:private UserScope
+  [:map
+   [:current-user-id pos-int?]
+   [:is-superuser?   :boolean]])
+
 (def ^:private default-visibility-config
   {:include-archived-items :exclude
    :include-trash-collection? false
@@ -544,6 +549,12 @@
    (visible-collection-filter-clause collection-id-field {}))
   ([collection-id-field :- [:or [:tuple [:= :coalesce] :keyword :keyword] :keyword]
     visibility-config :- CollectionVisibilityConfig]
+   (visible-collection-filter-clause collection-id-field visibility-config
+                                     {:current-user-id api/*current-user-id*
+                                      :is-superuser?   api/*is-superuser?*}))
+  ([collection-id-field :- [:or [:tuple [:= :coalesce] :keyword :keyword] :keyword]
+    visibility-config :- CollectionVisibilityConfig
+    {:keys [current-user-id is-superuser?]} :- UserScope]
    (let [visibility-config (merge default-visibility-config visibility-config)]
      ;; This giant query looks scary, but it's actually only moderately terrifying! Let's walk through it step by
      ;; step. What we're doing here is adding a filter clause to a surrounding query, to make sure that
@@ -569,27 +580,26 @@
         ;; the `FROM` clause is where we limit the collections to the ones we have permissions on. For a superuser,
         ;; that's all of them. For regular users, it's a) the collections they have permission in the DB for, and b)
         ;; their personal collection and its descendants.
-        :from [[{:union-all (if api/*is-superuser?*
-                              [{:select [:c.*]
-                                :from [[:collection :c]]}]
-                              [{:select [:c.*]
-                                :from [[:collection :c]]
-                                :join [[:permissions :p]
-                                       [:= :c.id :p.collection_id]
-                                       [:permissions_group :pg] [:= :pg.id :p.group_id]
-                                       [:permissions_group_membership :pgm] [:= :pgm.group_id :pg.id]]
-                                :where [:and
-                                        [:= :pgm.user_id api/*current-user-id*]
-                                        [:= :p.perm_type "perms/collection-access"]
-                                        [:or
-                                         [:= :p.perm_value "read-and-write"]
-                                         (when (= :read (:permission-level visibility-config))
-                                           [:= :p.perm_value "read"])]]}
-                               (when-let [personal-collection-and-descendant-ids (user->personal-collection-and-descendant-ids api/*current-user-id*)]
+        :from [(if is-superuser?
+                 [:collection :c]
+                 [{:union-all [{:select [:c.*]
+                                :from   [[:collection :c]]
+                                :join   [[:permissions :p]
+                                         [:= :c.id :p.collection_id]
+                                         [:permissions_group :pg] [:= :pg.id :p.group_id]
+                                         [:permissions_group_membership :pgm] [:= :pgm.group_id :pg.id]]
+                                :where  [:and
+                                         [:= :pgm.user_id api/*current-user-id*]
+                                         [:= :p.perm_type "perms/collection-access"]
+                                         [:or
+                                          [:= :p.perm_value "read-and-write"]
+                                          (when (= :read (:permission-level visibility-config))
+                                            [:= :p.perm_value "read"])]]}
+                               (when-let [personal-collection-and-descendant-ids (user->personal-collection-and-descendant-ids current-user-id)]
                                  {:select [:c.*]
-                                  :from [[:collection :c]]
-                                  :where [:in :id personal-collection-and-descendant-ids]})])}
-                :c]]
+                                  :from   [[:collection :c]]
+                                  :where  [:in :id personal-collection-and-descendant-ids]})]}
+                  :c])]
         ;; The `WHERE` clause is where we apply the other criteria we were given:
         :where [:and
                 ;; hiding the trash collection when desired...

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -113,6 +113,7 @@
    ;;
    ;; optional
    ;;
+   [:is-superuser?                       {:optional true} :boolean] ;; ideally this would be provided on all paths
    [:created-at                          {:optional true} ms/NonBlankString]
    [:created-by                          {:optional true} [:set {:min 1} ms/PositiveInt]]
    [:filter-items-in-personal-collection {:optional true} [:enum "only" "exclude"]]

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -106,6 +106,7 @@
    ;;
    [:archived?          [:maybe :boolean]]
    [:current-user-id    pos-int?]
+   [:is-superuser?      :boolean] ;; ideally this would be provided on all paths
    [:current-user-perms [:set perms.u/PathSchema]]
    [:model-ancestors?   :boolean]
    [:models             [:set SearchableModel]]
@@ -113,7 +114,6 @@
    ;;
    ;; optional
    ;;
-   [:is-superuser?                       {:optional true} :boolean] ;; ideally this would be provided on all paths
    [:created-at                          {:optional true} ms/NonBlankString]
    [:created-by                          {:optional true} [:set {:min 1} ms/PositiveInt]]
    [:filter-items-in-personal-collection {:optional true} [:enum "only" "exclude"]]

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -106,7 +106,7 @@
    ;;
    [:archived?          [:maybe :boolean]]
    [:current-user-id    pos-int?]
-   [:is-superuser?      :boolean] ;; ideally this would be provided on all paths
+   [:is-superuser?      :boolean]
    [:current-user-perms [:set perms.u/PathSchema]]
    [:model-ancestors?   :boolean]
    [:models             [:set SearchableModel]]

--- a/test/metabase/search/filter_test.clj
+++ b/test/metabase/search/filter_test.clj
@@ -12,7 +12,7 @@
    :models             search.config/all-models
    :model-ancestors?   false
    :current-user-id    1
-   :is-superuser?      false
+   :is-superuser?      true
    :current-user-perms #{"/"}})
 
 (deftest ^:parallel ->applicable-models-test

--- a/test/metabase/search/filter_test.clj
+++ b/test/metabase/search/filter_test.clj
@@ -12,6 +12,7 @@
    :models             search.config/all-models
    :model-ancestors?   false
    :current-user-id    1
+   :is-superuser?      false
    :current-user-perms #{"/"}})
 
 (deftest ^:parallel ->applicable-models-test

--- a/test/metabase/search/impl_test.clj
+++ b/test/metabase/search/impl_test.clj
@@ -63,6 +63,7 @@
                                                  :archived?          false
                                                  :models             search.config/all-models
                                                  :current-user-id    (mt/user->id :crowberto)
+                                                 :is-superuser?      true
                                                  :current-user-perms #{"/"}
                                                  :model-ancestors?   false
                                                  :limit-int          100}))]
@@ -137,6 +138,7 @@
                                                                   :models             search.config/all-models
                                                                   :created-at         created-at
                                                                   :current-user-id    (mt/user->id :crowberto)
+                                                                  :is-superuser?      true
                                                                   :current-user-perms @api/*current-user-permissions-set*}))
                                             :data
                                             (map (juxt :model :id))
@@ -222,6 +224,7 @@
                                                                   :models             search.config/all-models
                                                                   :last-edited-at     last-edited-at
                                                                   :current-user-id    (mt/user->id :crowberto)
+                                                                  :is-superuser?      true
                                                                   :current-user-perms @api/*current-user-permissions-set*}))
                                             :data
                                             (map (juxt :model :id))


### PR DESCRIPTION
### Description

This PR consists of some minor fix-ups which will smooth the path to creating a Full-Text Search index.

1. It's optional to provide a search string, but if its omitted we throw a type error for the query we build. We make `:where` optional so that it type checks and we can re-use this query for building the index.
2. Despite search taking the current user and their permissions as first class arguments, when calling down into the collection properties the dynamic scope variables are used instead. This updates the sub-query building function to use the function scoped variables. This will make it easier for us to index every item.
3. The query for super user permissions was overly complex, and perhaps slow for engines with less intelligent query optimizers. While I'm here I simplified it a bit.

~~There's some awkward defensive coding around whether we've populated `is-superuser?` in the search context. I have another PR for that which I'll merge into this one if its simple enough.~~ Fixed.