### PR TITLE
Fix LSP for defendpoint

### DIFF
--- a/.clj-kondo/src/hooks/metabase/api/common.clj
+++ b/.clj-kondo/src/hooks/metabase/api/common.clj
@@ -19,29 +19,14 @@
               (-> (api/list-node
                    (list
                     (api/token-node 'do)
-                    (api/token-node (symbol "compojure.core" (str (api/sexpr method))))
-                    (-> (api/list-node
-                         (list*
-                          (api/token-node 'clojure.core/defn)
-                          (api/token-node (route-fn-name (api/sexpr method) (api/sexpr route)))
-                          body))
-                        (with-meta (meta node)))))
+                    (-> (api/token-node (symbol "compojure.core" (str (api/sexpr method))))
+                        (with-meta (meta method)))
+                    (api/list-node
+                     (list*
+                      (api/token-node 'clojure.core/defn)
+                      (-> (api/token-node (route-fn-name (api/sexpr method) (api/sexpr route)))
+                          (with-meta (meta route)))
+                      body))))
+                  (with-meta (meta node))
                   hooks.common/add-lsp-ignore-unused-public-var-metadata)))]
     (update arg :node update-defendpoint)))
-
-(comment
-  (-> {:node (-> '(api/defendpoint POST "/:id/copy"
-                    "Copy a `Card`, with the new name 'Copy of _name_'"
-                    [id]
-                    {id [:maybe ms/PositiveInt]}
-                    (let [orig-card (api/read-check Card id)
-                          new-name  (str (trs "Copy of ") (:name orig-card))
-                          new-card  (assoc orig-card :name new-name)]
-                      (-> (card/create-card! new-card @api/*current-user*)
-                          hydrate-card-details
-                          (assoc :last-edit-info (last-edit/edit-information-for-user @api/*current-user*)))))
-                 pr-str
-                 api/parse-string)}
-      defendpoint
-      :node
-      api/sexpr))

--- a/.clj-kondo/test/hooks/metabase/api/common_test.clj
+++ b/.clj-kondo/test/hooks/metabase/api/common_test.clj
@@ -1,0 +1,35 @@
+(ns hooks.metabase.api.common-test
+  (:require
+   [clj-kondo.hooks-api :as api]
+   [clojure.test :refer :all]
+   [hooks.metabase.api.common]))
+
+(deftest ^:parallel defendpoint-test
+  (is (= '(do
+            compojure.core/POST
+            (clojure.core/defn
+              POST_:id_copy
+              "Copy a `Card`, with the new name 'Copy of _name_'"
+              [id]
+              {id [:maybe ms/PositiveInt]}
+              (let [orig-card (api/read-check Card id)
+                    new-name (str (trs "Copy of ") (:name orig-card))
+                    new-card (assoc orig-card :name new-name)]
+                (-> (card/create-card! new-card @api/*current-user*)
+                    hydrate-card-details
+                    (assoc :last-edit-info (last-edit/edit-information-for-user @api/*current-user*))))))
+         (-> {:node (-> '(api/defendpoint POST "/:id/copy"
+                           "Copy a `Card`, with the new name 'Copy of _name_'"
+                           [id]
+                           {id [:maybe ms/PositiveInt]}
+                           (let [orig-card (api/read-check Card id)
+                                 new-name  (str (trs "Copy of ") (:name orig-card))
+                                 new-card  (assoc orig-card :name new-name)]
+                             (-> (card/create-card! new-card @api/*current-user*)
+                                 hydrate-card-details
+                                 (assoc :last-edit-info (last-edit/edit-information-for-user @api/*current-user*)))))
+                        pr-str
+                        api/parse-string)}
+             hooks.metabase.api.common/defendpoint
+             :node
+             api/sexpr))))


### PR DESCRIPTION
We were all annoyed by it, but jumping to definition with LSP inside `defendpoint` was completely broken. Anyways after literally weeks of trying to figure out why I managed to fix it. 

I wrote up my findings here https://camsaul.com/clojure/2024/09/03/debugging-clojure-lsp-jump-to-definition.html if anyone else wants to know how to debug LSP + custom Kondo hooks.