### PR TITLE
Add .swc to gitignore in the v50 release branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,6 @@ modules/drivers/*/.lsp/*
 
 # airgap
 /resources/airgap/
+
+# swc
+.swc/


### PR DESCRIPTION
For convenience ignore `.swc` directory in the release branch as well in order not to see it when switching from master