### PR TITLE
perf: Add more timeseries insights optimizations

### DIFF
--- a/src/metabase/analyze/fingerprint/insights.clj
+++ b/src/metabase/analyze/fingerprint/insights.clj
@@ -19,17 +19,19 @@
 (set! *warn-on-reflection* true)
 
 (defn- last-2 []
-  (fn
-    ([] [])
-    ([acc]
-     (let [cnt (count acc)]
-       (cond (= cnt 0) [nil nil]
-             (= cnt 1) [nil (nth acc 0)]
-             :else acc)))
-    ([acc x]
-     (if (< (count acc) 2)
-       (conj acc x)
-       [(nth acc 1) x]))))
+  (let [none (Object.)]
+    (fn
+      ([] (object-array [none none]))
+      ([^objects acc]
+       (let [a (aget acc 0)
+             b (aget acc 1)]
+         (cond (identical? b none) [nil nil]
+               (identical? a none) [nil b]
+               :else [a b])))
+      ([^objects acc, x]
+       (aset acc 0 (aget acc 1))
+       (aset acc 1 x)
+       acc))))
 
 (defn change
   "Relative difference between `x1` an `x2`."


### PR DESCRIPTION
Follow-up to #47414 and #47424.

1. More efficient `last-2` implementation (significant since it goes over every row in the table).
2. Optimizу generation of the validation sample to only create tuples from rows for the values that got into the sample, not for each one.
3. A bit hackish rewrite of `simple-linear-regression` to separately accept the "link functions". With the current implementation where only fx and fy are passed, having to perform `math/log` on boxed numbers (and return boxed numbers too) allocates quite a lot of Double instances. The proposed change at least removes the need to box on the way out of the accessor function.