### PR TITLE
Use i18n-appropriate string interpolation for card copying

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -495,7 +495,7 @@
   [id]
   {id [:maybe ms/PositiveInt]}
   (let [orig-card (api/read-check Card id)
-        new-name  (str (trs "Copy of ") (:name orig-card))
+        new-name  (trs "Copy of {0}" (:name orig-card))
         new-card  (assoc orig-card :name new-name)]
     (-> (card/create-card! new-card @api/*current-user*)
         hydrate-card-details


### PR DESCRIPTION
Come to find out languages like Turkish put the `X` first in "Copy of `X`"

(I happened to notice this in Cam's recent blog post)
