### PR TITLE
perf: Optimize some query processor functions

### DIFF
--- a/src/metabase/query_processor/reducible.clj
+++ b/src/metabase/query_processor/reducible.clj
@@ -3,7 +3,8 @@
    [clojure.core.async :as a]
    [metabase.query-processor.pipeline :as qp.pipeline]
    [metabase.util.log :as log]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :as perf]))
 
 (set! *warn-on-reflection* true)
 
@@ -90,24 +91,24 @@
   [primary-rf     :- ifn?
    additional-rfs :- [:sequential ifn?]
    combine        :- ifn?]
-  (let [additional-accs (volatile! (mapv (fn [rf] (rf))
-                                         additional-rfs))]
+  (let [additional-accs (volatile! (perf/mapv (fn [rf] (rf))
+                                              additional-rfs))]
     (fn combine-additional-reducing-fns-rf*
       ([] (primary-rf))
 
       ([acc]
-       (let [additional-results (map (fn [rf acc]
-                                       (rf (unreduced acc)))
-                                     additional-rfs
-                                     @additional-accs)]
+       (let [additional-results (perf/mapv (fn [rf acc]
+                                             (rf (unreduced acc)))
+                                           additional-rfs
+                                           @additional-accs)]
          (apply combine acc additional-results)))
 
       ([acc x]
        (vswap! additional-accs (fn [accs]
-                                 (mapv (fn [rf acc]
-                                         (if (reduced? acc)
-                                           acc
-                                           (rf acc x)))
-                                       additional-rfs
-                                       accs)))
+                                 (perf/mapv (fn [rf acc]
+                                              (if (reduced? acc)
+                                                acc
+                                                (rf acc x)))
+                                            additional-rfs
+                                            accs)))
        (primary-rf acc x)))))


### PR DESCRIPTION
1. Making `mapv` faster and more memory-efficient for small (<32 elements) vectors improves response times for all kinds of queries.
2. In `result-int->string` which is called for each returned row that has at least one FK, instead of doing `update` on a vector, rebuild the entire vector with `mapv`. Use a boolean mask to know which column is FK and has to be stringified.