### PR TITLE
fix(sdk): fix typescript type references to "embedding-sdk" not resolving

### DIFF
--- a/bin/embedding-sdk/fixup-types-after-compilation.js
+++ b/bin/embedding-sdk/fixup-types-after-compilation.js
@@ -17,10 +17,10 @@ const REPLACES_MAP = {
   "metabase-enterprise/": `${SDK_PACKAGE_NAME}/dist/enterprise/frontend/src/metabase-enterprise/`,
   "metabase-lib/": `${SDK_PACKAGE_NAME}/dist/frontend/src/metabase-lib/`,
   "metabase-lib": `${SDK_PACKAGE_NAME}/dist/frontend/src/metabase-lib`,
-  "metabase-shared/": `${SDK_PACKAGE_NAME}/dist/frontend/src/metabase-shared/`,
   "metabase-types/": `${SDK_PACKAGE_NAME}/dist/frontend/src/metabase-types/`,
   "metabase/": `${SDK_PACKAGE_NAME}/dist/frontend/src/metabase/`,
   "embedding-sdk/": `${SDK_PACKAGE_NAME}/dist/enterprise/frontend/src/embedding-sdk/`,
+  "embedding-sdk": `${SDK_PACKAGE_NAME}/dist/enterprise/frontend/src/embedding-sdk`,
   "cljs/": `${SDK_PACKAGE_NAME}/dist/target/cljs_release/`,
 };
 

--- a/bin/embedding-sdk/fixup-types-after-compilation.js
+++ b/bin/embedding-sdk/fixup-types-after-compilation.js
@@ -14,14 +14,12 @@ const SDK_PACKAGE_NAME = "@metabase/embedding-sdk-react";
 
 // this map should be synced with "tsconfig.sdk.json"
 const REPLACES_MAP = {
-  "metabase-enterprise/": `${SDK_PACKAGE_NAME}/dist/enterprise/frontend/src/metabase-enterprise/`,
-  "metabase-lib/": `${SDK_PACKAGE_NAME}/dist/frontend/src/metabase-lib/`,
+  "metabase-enterprise": `${SDK_PACKAGE_NAME}/dist/enterprise/frontend/src/metabase-enterprise`,
   "metabase-lib": `${SDK_PACKAGE_NAME}/dist/frontend/src/metabase-lib`,
-  "metabase-types/": `${SDK_PACKAGE_NAME}/dist/frontend/src/metabase-types/`,
-  "metabase/": `${SDK_PACKAGE_NAME}/dist/frontend/src/metabase/`,
-  "embedding-sdk/": `${SDK_PACKAGE_NAME}/dist/enterprise/frontend/src/embedding-sdk/`,
+  "metabase-types": `${SDK_PACKAGE_NAME}/dist/frontend/src/metabase-types`,
+  "metabase": `${SDK_PACKAGE_NAME}/dist/frontend/src/metabase`,
   "embedding-sdk": `${SDK_PACKAGE_NAME}/dist/enterprise/frontend/src/embedding-sdk`,
-  "cljs/": `${SDK_PACKAGE_NAME}/dist/target/cljs_release/`,
+  "cljs": `${SDK_PACKAGE_NAME}/dist/target/cljs_release`,
 };
 
 const traverseFilesTree = dir => {
@@ -49,7 +47,10 @@ const replaceAliasedImports = filePath => {
 
   Object.entries(REPLACES_MAP).forEach(([alias, replacement]) => {
     fileContent = fileContent
-      .replaceAll(`from "${alias}`, `from "${replacement}`)
+      // replaces "metabase-lib/foo" with "<sdk>/metabase-lib/foo"
+      .replaceAll(`from "${alias}/`, `from "${replacement}/`)
+      // replaces "metabase-lib" with "<sdk>/metabase-lib"
+      .replaceAll(`from "${alias}"`, `from "${replacement}"`)
       .replaceAll(`import("${alias}`, `import("${replacement}`)
       .replace(
         // replace dynamic imports using alias, with possible relative paths - "../../" and "frontend/src/"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/47627

### Description

Fixes the fixup script so it now replaces both top-level imports e.g. `import whatever from "embedding-sdk"` and imports with slash, e.g. `import whatever from "embedding-sdk/foo/bar"`

### How to verify

- `yarn build-embedding-sdk`
   - This actually runs `yarn embedding-sdk:fixup-types-imports` under the hood
- Go to `resources/embedding-sdk/dist/enterprise/frontend/src/embedding-sdk`
   - Open full text search in your IDE of choice
   - Search for `from "embedding-sdk"` - you should notice they are all prefixed by `from "@metabase/embedding-sdk-react/dist/...`
- Now go to your React project, and run this command `rm -rf node_modules/@metabase && yarn add file:../metabase/resources/embedding-sdk && rm -rf node_modules/.vite`
- Look at the types for `CreateQuestion` and `InteractiveQuestion`, they should resolve fine now.
   - Notice that there is no more reference to "embedding-sdk" there

### Demo

Before

![image](https://github.com/user-attachments/assets/fe7f418a-cfce-47fe-a58b-59c9a2434261)

After

![CleanShot 2567-09-05 at 16 07 42@2x](https://github.com/user-attachments/assets/0cc142ee-9dfc-41c2-bdab-e4a6f84366e7)