### PR TITLE
Always allow localhost:* on CORS

### DIFF
--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -214,7 +214,7 @@
      (cache-prevention-headers))
    strict-transport-security-header
    (content-security-policy-header-with-frame-ancestors allow-iframes? nonce)
-   (when (embedding-app-origin) (access-control-headers origin))
+   (when (embedding-app-origin-sdk) (access-control-headers origin))
    (when-not allow-iframes?
      ;; Tell browsers not to render our site as an iframe (prevent clickjacking)
      {"X-Frame-Options"                 (if (embedding-app-origin)

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -118,6 +118,11 @@
   (when (and (embed.settings/enable-embedding) (embed.settings/embedding-app-origin))
     (embed.settings/embedding-app-origin)))
 
+(defn- embedding-app-origin-sdk
+  []
+  (when (embed.settings/enable-embedding)
+    (str "localhost:* " (embed.settings/embedding-app-origin))))
+
 (defn- content-security-policy-header-with-frame-ancestors
   [allow-iframes? nonce]
   (update (content-security-policy-header nonce)
@@ -179,11 +184,12 @@
                 (approved-port? (:port origin) (:port approved-origin))))
              approved-list)))))
 
-(defn- access-control-headers
+(defn access-control-headers
+  "Returns headers for CORS requests"
   [origin]
   (merge
    (when
-    (approved-origin? origin (embedding-app-origin))
+    (approved-origin? origin (embedding-app-origin-sdk))
      {"Access-Control-Allow-Origin" origin
       "Vary"                        "Origin"})
 

--- a/test/metabase/server/middleware/security_test.clj
+++ b/test/metabase/server/middleware/security_test.clj
@@ -196,5 +196,5 @@
   (testing "Should work with embedding-app-origin"
     (mt/with-premium-features #{:embedding}
       (tu/with-temporary-setting-values [enable-embedding     true
-                                        embedding-app-origin "example.com"]
+                                         embedding-app-origin "example.com"]
         (is (= "https://example.com" (get (mw.security/access-control-headers "https://example.com") "Access-Control-Allow-Origin")))))))

--- a/test/metabase/server/middleware/security_test.clj
+++ b/test/metabase/server/middleware/security_test.clj
@@ -188,7 +188,6 @@
                                        embedding-app-origin nil]
       (is (= "http://localhost:8080" (get (mw.security/access-control-headers "http://localhost:8080") "Access-Control-Allow-Origin")))))
 
-
   (testing "Should disable CORS when embedding is disabled"
     (tu/with-temporary-setting-values [enable-embedding     false
                                        embedding-app-origin nil]

--- a/test/metabase/server/middleware/security_test.clj
+++ b/test/metabase/server/middleware/security_test.clj
@@ -181,3 +181,21 @@
 
   (testing "Should handle invalid origins"
     (is (true? (mw.security/approved-origin? "http://example.com" "  fpt://something http://example.com ://123  4")))))
+
+(deftest test-access-control-headers?
+  (testing "Should always allow localhost:*"
+    (tu/with-temporary-setting-values [enable-embedding     true
+                                       embedding-app-origin nil]
+      (is (= "http://localhost:8080" (get (mw.security/access-control-headers "http://localhost:8080") "Access-Control-Allow-Origin")))))
+
+
+  (testing "Should disable CORS when embedding is disabled"
+    (tu/with-temporary-setting-values [enable-embedding     false
+                                       embedding-app-origin nil]
+      (is (= nil (get (mw.security/access-control-headers "http://localhost:8080") "Access-Control-Allow-Origin")))))
+
+  (testing "Should work with embedding-app-origin"
+    (mt/with-premium-features #{:embedding}
+      (tu/with-temporary-setting-values [enable-embedding     true
+                                        embedding-app-origin "example.com"]
+        (is (= "https://example.com" (get (mw.security/access-control-headers "https://example.com") "Access-Control-Allow-Origin")))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/47615

### Description

This is a temporary measure until the https://github.com/metabase/metabase/issues/46970 is shipped.

This is needed because we're shipping the CLI, and users can't test the SDK without having a license currently.

### How to verify

1. Run Metabase OSS and enable embedding
2. Run a dev server with a different port
3. open devtool and run
    ```ts
    fetch('http://localhost:3000/api/session/properties')
    ```
4. Observe the network tab, and the request should go through.

### Demo
1. Running OSS
![Screenshot 2024-09-05 at 6 02 56 PM](https://github.com/user-attachments/assets/284a62b2-8241-40f0-ba14-423f93225008)
2. Fetch request is successful with `Access-Control-Allow-Origin` header in the response.
![Screenshot 2024-09-05 at 6 03 18 PM](https://github.com/user-attachments/assets/9b2163bb-cdb1-4ac0-b42f-5749cdc852f7)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
