### PR TITLE
Fix Transparent disabled state on mantine switch label

### DIFF
--- a/frontend/src/metabase/ui/components/inputs/Switch/Switch.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Switch/Switch.styled.tsx
@@ -74,8 +74,10 @@ export const getSwitchOverrides = (): MantineThemeOverride["components"] => ({
           color: theme.fn.themeColor("text-dark"),
           cursor: "pointer",
           "&[data-disabled]": {
-            color: theme.fn.themeColor("text-light"),
-            cursor: "default",
+            "&:not([data-css-specificity-hack='😢'])": {
+              color: theme.fn.themeColor("text-light"),
+              cursor: "default",
+            },
           },
         },
         description: {

--- a/frontend/src/metabase/ui/components/inputs/Switch/Switch.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Switch/Switch.styled.tsx
@@ -73,11 +73,9 @@ export const getSwitchOverrides = (): MantineThemeOverride["components"] => ({
           lineHeight: getSize({ size, sizes: LABEL_LINE_HEIGHT }),
           color: theme.fn.themeColor("text-dark"),
           cursor: "pointer",
-          "&[data-disabled]": {
-            "&:not([data-css-specificity-hack='😢'])": {
-              color: theme.fn.themeColor("text-light"),
-              cursor: "default",
-            },
+          "&[data-disabled]:not([data-css-specificity-hack='😢'])": {
+            color: theme.fn.themeColor("text-light"),
+            cursor: "default",
           },
         },
         description: {


### PR DESCRIPTION

### Description

Before 

![Screen Shot 2024-09-05 at 8 25 57 AM](https://github.com/user-attachments/assets/e3c7e02a-67fb-4d2e-a890-ae1850983eed)

After

![Screen Shot 2024-09-05 at 8 24 54 AM](https://github.com/user-attachments/assets/3f13dd00-c3c8-4549-b883-83c1fd814eb3)

