### PR TITLE
Revert multiple inheritance with SnowflakeVariant

### DIFF
--- a/src/metabase/types.cljc
+++ b/src/metabase/types.cljc
@@ -267,6 +267,7 @@
 ;;; The Snowflake `VARIANT` type is allowed to be anything. See
 ;;; https://docs.snowflake.com/en/sql-reference/data-types-semistructured
 (derive :type/SnowflakeVariant :type/*)
+(derive :type/SnowflakeVariant :type/Large)
 
 ;;; Text-Like Types: Things that should be displayed as text for most purposes but that *shouldn't* support advanced
 ;;; filter options like starts with / contains

--- a/src/metabase/types.cljc
+++ b/src/metabase/types.cljc
@@ -264,15 +264,9 @@
 (derive :type/DruidHyperUnique :type/*)
 (derive :type/DruidHyperUnique :type/field-values-unsupported)
 
-;;; The Snowflake `VARIANT` type is allowed to be anything, so just mark it as deriving from the core root types so
-;;; we're allowed to use any sort of filter with it (whether it makes sense or not). See
+;;; The Snowflake `VARIANT` type is allowed to be anything. See
 ;;; https://docs.snowflake.com/en/sql-reference/data-types-semistructured
-(doseq [t [:type/Number
-           :type/Text
-           :type/Temporal
-           :type/Boolean
-           :type/Collection]]
-  (derive :type/SnowflakeVariant t))
+(derive :type/SnowflakeVariant :type/*)
 
 ;;; Text-Like Types: Things that should be displayed as text for most purposes but that *shouldn't* support advanced
 ;;; filter options like starts with / contains


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/47639
Revert type hierarchy changes in https://github.com/metabase/metabase/pull/45674

The original PR aimed to solve expression type checking issue with Snowflake's `VARIANT`. It allowed executing existing queries but broke the notebook editor. This PR relies on the fact that we don't have expression type checking anymore; we need to derive the `:type/SnowflakeVariant` directly from `:type/*` to make the FE allow only `is-null` and `not-null` operators by default.

The expression editor doesn't check argument types and will allow anything atm.