### PR TITLE
Simplify backend Snowplow API in preparation for migrating stats ping to Snowplow

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/llm/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/llm/client.clj
@@ -22,7 +22,6 @@
    [cheshire.core :as json]
    [metabase-enterprise.llm.settings :as llm-settings]
    [metabase.analytics.snowplow :as snowplow]
-   [metabase.api.common :as api]
    [metabase.util.log :as log]
    [wkok.openai-clojure.api :as openai.api]))
 
@@ -37,7 +36,10 @@
            usage-summary (-> (dissoc response :usage :choices)
                              (merge usage)
                              (select-keys [:id :object :created :model :prompt_tokens :completion_tokens :total_tokens :system_fingerprint]))]
-       (snowplow/track-event! ::snowplow/llm-usage api/*current-user-id* usage-summary)
+       (snowplow/track-event! ::snowplow/llm_usage
+                              (assoc
+                               usage-summary
+                               :event :llm-usage))
        ;; TODO -- Remove before final PR/merge
        ;(tap> usage-summary)
        response))

--- a/enterprise/backend/src/metabase_enterprise/serialization/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/api.clj
@@ -206,8 +206,9 @@
                 report
                 error-message
                 callback]} (serialize&pack opts)]
-    (snowplow/track-event! ::snowplow/serialization api/*current-user-id*
-                           {:direction       "export"
+    (snowplow/track-event! ::snowplow/serialization
+                           {:event           :serialization
+                            :direction       "export"
                             :source          "api"
                             :duration_ms     (int (/ (- (System/nanoTime) start) 1e6))
                             :count           (count (:seen report))
@@ -257,8 +258,9 @@
                                             {:size              (:size file)
                                              :continue-on-error continue_on_error})
           imported           (into (sorted-set) (map (comp :model last)) (:seen report))]
-      (snowplow/track-event! ::snowplow/serialization api/*current-user-id*
-                             {:direction     "import"
+      (snowplow/track-event! ::snowplow/serialization
+                             {:event         :serialization
+                              :direction     "import"
                               :source        "api"
                               :duration_ms   (int (/ (- (System/nanoTime) start) 1e6))
                               :models        (str/join "," imported)

--- a/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
@@ -126,8 +126,9 @@
                    (catch Exception e
                      (reset! err e)))
         imported (into (sorted-set) (map (comp :model last)) (:seen report))]
-    (snowplow/track-event! ::snowplow/serialization nil
-                           {:direction     "import"
+    (snowplow/track-event! ::snowplow/serialization
+                           {:event         :serialization
+                            :direction     "import"
                             :source        "cli"
                             :duration_ms   (int (u/since-ms timer))
                             :models        (str/join "," imported)

--- a/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
@@ -259,8 +259,9 @@
                        (v2.storage/store! path)))
                  (catch Exception e
                    (reset! err e)))]
-    (snowplow/track-event! ::snowplow/serialization nil
-                           {:direction       "export"
+    (snowplow/track-event! ::snowplow/serialization
+                           {:event           :serialization
+                            :direction       "export"
                             :source          "cli"
                             :duration_ms     (int (/ (- (System/nanoTime) start) 1e6))
                             :count           (count (:seen report))

--- a/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
@@ -111,7 +111,7 @@
 
 (defn do-with-random-dump-dir [prefix f]
   (let [dump-dir (random-dump-dir (or prefix ""))]
-    (testing (format "\nDump dir = %s" (pr-str dump-dir))
+    (testing (format "\nDump dir = %s\n" (pr-str dump-dir))
       (try
         (f dump-dir)
         (finally

--- a/src/metabase/actions/execution.clj
+++ b/src/metabase/actions/execution.clj
@@ -205,9 +205,11 @@
                                                :id dashcard-id
                                                :dashboard_id dashboard-id))
         action (api/check-404 (action/select-action :id (:action_id dashcard)))]
-    (snowplow/track-event! ::snowplow/action-executed api/*current-user-id* {:source    :dashboard
-                                                                             :type      (:type action)
-                                                                             :action_id (:id action)})
+    (snowplow/track-event! ::action
+                           {:event     :action-executed
+                            :source    :dashboard
+                            :type      (:type action)
+                            :action_id (:id action)})
     (execute-action! action request-parameters)))
 
 (defn- fetch-implicit-action-values

--- a/src/metabase/actions/execution.clj
+++ b/src/metabase/actions/execution.clj
@@ -205,7 +205,7 @@
                                                :id dashcard-id
                                                :dashboard_id dashboard-id))
         action (api/check-404 (action/select-action :id (:action_id dashcard)))]
-    (snowplow/track-event! ::action
+    (snowplow/track-event! ::snowplow/action
                            {:event     :action-executed
                             :source    :dashboard
                             :type      (:type action)

--- a/src/metabase/analytics/snowplow.clj
+++ b/src/metabase/analytics/snowplow.clj
@@ -119,12 +119,10 @@
   :doc false)
 
 (defn- tracker-config
-  "Returns instance of a Snowplow tracker config"
   []
   (TrackerConfiguration. "sp" "metabase"))
 
 (defn- network-config
-  "Returns instance of a Snowplow network config"
   []
   (let [request-config (-> (RequestConfig/custom)
                            ;; Set cookie spec to `STANDARD` to avoid warnings about an invalid cookie
@@ -139,12 +137,10 @@
     (NetworkConfiguration. http-client-adapter)))
 
 (defn- emitter-config
-  "An instance of a Snowplow emitter config"
   []
   (-> (EmitterConfiguration.)
       (.batchSize 1)))
 
-;; "An instance of a Snowplow tracker"
 (defonce ^:private tracker
   (Snowplow/createTracker
    ^TrackerConfiguration (tracker-config)

--- a/src/metabase/api/action.clj
+++ b/src/metabase/api/action.clj
@@ -91,8 +91,10 @@
   [action-id]
   {action-id ms/PositiveInt}
   (let [action (api/write-check Action action-id)]
-    (snowplow/track-event! ::snowplow/action-deleted api/*current-user-id* {:type      (:type action)
-                                                                            :action_id action-id}))
+    (snowplow/track-event! ::snowplow/action
+                           {:event     :action-deleted
+                            :type      (:type action)
+                            :action_id action-id}))
   (t2/delete! Action :id action-id)
   api/generic-204-no-content)
 
@@ -129,9 +131,11 @@
       (actions/check-actions-enabled-for-database!
        (t2/select-one Database :id db-id))))
   (let [action-id (action/insert! (assoc action :creator_id api/*current-user-id*))]
-    (snowplow/track-event! ::snowplow/action-created api/*current-user-id* {:type           type
-                                                                            :action_id      action-id
-                                                                            :num_parameters (count parameters)})
+    (snowplow/track-event! ::snowplow/action
+                           {:event          :action-created
+                            :type           type
+                            :action_id      action-id
+                            :num_parameters (count parameters)})
     (if action-id
       (action/select-action :id action-id)
       ;; t2/insert! does not return a value when used with h2
@@ -161,9 +165,11 @@
   (let [existing-action (api/write-check Action id)]
     (action/update! (assoc action :id id) existing-action))
   (let [{:keys [parameters type] :as action} (action/select-action :id id)]
-    (snowplow/track-event! ::snowplow/action-updated api/*current-user-id* {:type           type
-                                                                            :action_id      id
-                                                                            :num_parameters (count parameters)})
+    (snowplow/track-event! ::snowplow/action
+                           {:event          :action-updated
+                            :type           type
+                            :action_id      id
+                            :num_parameters (count parameters)})
     action))
 
 (api/defendpoint POST "/:id/public_link"
@@ -212,9 +218,11 @@
   {id         ms/PositiveInt
    parameters [:maybe [:map-of :keyword any?]]}
   (let [{:keys [type] :as action} (api/check-404 (action/select-action :id id :archived false))]
-    (snowplow/track-event! ::snowplow/action-executed api/*current-user-id* {:source    :model_detail
-                                                                             :type      type
-                                                                             :action_id id})
+    (snowplow/track-event! ::snowplow/action
+                           {:event     :action-executed
+                            :source    :model_detail
+                            :type      type
+                            :action_id id})
     (actions/execute-action! action (update-keys parameters name))))
 
 (api/define-routes)

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -1080,11 +1080,12 @@
                                 :sort-column    sort_column
                                 :sort-direction sort_direction})
 
-        snowplow-payload {:collection_id           (when-not (= :root id) id)
+        snowplow-payload {:event                   :stale-items-read
+                          :collection_id           (when-not (= :root id) id)
                           :total_stale_items_found total
                           ;; convert before-date to a date-time string before sending it.
                           :cutoff_date             (format "%sT00:00:00Z" (str before-date))}]
-    (snowplow/track-event! ::snowplow/stale-items-read api/*current-user-id* snowplow-payload)
+    (snowplow/track-event! ::snowplow/cleanup snowplow-payload)
     {:total  total
      :data   (api/present-items present-model-items rows)
      :limit  mw.offset-paging/*limit*

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -136,7 +136,9 @@
                         ;; Ok, now save the Dashboard
                          (first (t2/insert-returning-instances! :model/Dashboard dashboard-data)))]
     (events/publish-event! :event/dashboard-create {:object dash :user-id api/*current-user-id*})
-    (snowplow/track-event! ::snowplow/dashboard-created api/*current-user-id* {:dashboard-id (u/the-id dash)})
+    (snowplow/track-event! ::snowplow/dashboard
+                           {:event        :dashboard-created
+                            :dashboard-id (u/the-id dash)})
     (-> dash
         hydrate-dashboard-details
         collection.root/hydrate-root-collection
@@ -469,7 +471,9 @@
                            (cond-> dash
                              (seq uncopied)
                              (assoc :uncopied uncopied))))]
-    (snowplow/track-event! ::snowplow/dashboard-created api/*current-user-id* {:dashboard-id (u/the-id dashboard)})
+    (snowplow/track-event! ::snowplow/dashboard
+                           {:event        :dashboard-created
+                            :dashboard-id (u/the-id dashboard)})
     ;; must signal event outside of tx so cards are visible from other threads
     (when-let [newly-created-cards (seq @new-cards)]
       (doseq [card newly-created-cards]
@@ -649,20 +653,21 @@
                            {:object dashboard :user-id api/*current-user-id* :dashcards created-dashcards})
     (for [{:keys [card_id]} created-dashcards
           :when             (pos-int? card_id)]
-      (snowplow/track-event! ::snowplow/question-added-to-dashboard
-                             api/*current-user-id*
-                             {:dashboard-id dashboard-id :question-id card_id :user-id api/*current-user-id*})))
+      (snowplow/track-event! ::snowplow/dashboard
+                             {:event        :question-added-to-dashboard
+                              :dashboard-id dashboard-id
+                              :question-id  card_id})))
   ;; Tabs events
   (when (seq deleted-tab-ids)
-    (snowplow/track-event! ::snowplow/dashboard-tab-deleted
-                           api/*current-user-id*
-                           {:dashboard-id   dashboard-id
+    (snowplow/track-event! ::snowplow/dashboard
+                           {:event          :dashboard-tab-deleted
+                            :dashboard-id   dashboard-id
                             :num-tabs       (count deleted-tab-ids)
                             :total-num-tabs total-num-tabs}))
   (when (seq created-tab-ids)
-    (snowplow/track-event! ::snowplow/dashboard-tab-created
-                           api/*current-user-id*
-                           {:dashboard-id   dashboard-id
+    (snowplow/track-event! ::snowplow/dashboard
+                           {:event          :dashboard-tab-created
+                            :dashboard-id   dashboard-id
                             :num-tabs       (count created-tab-ids)
                             :total-num-tabs total-num-tabs})))
 

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -817,17 +817,18 @@
                                        (when (some? auto_run_queries)
                                          {:auto_run_queries auto_run_queries})))))
         (events/publish-event! :event/database-create {:object <> :user-id api/*current-user-id*})
-        (snowplow/track-event! ::snowplow/database-connection-successful
-                               api/*current-user-id*
-                               {:database     engine
+        (snowplow/track-event! ::snowplow/database
+                               {:event        :database-connection-successful
+                                :database     engine
                                 :database-id  (u/the-id <>)
                                 :source       connection_source
                                 :dbms-version (:version (driver/dbms-version (keyword engine) <>))}))
       ;; failed to connect, return error
       (do
-        (snowplow/track-event! ::snowplow/database-connection-failed
-                               api/*current-user-id*
-                               {:database engine :source connection_source})
+        (snowplow/track-event! ::snowplow/database
+                               {:event    :database-connection-failed
+                                :database engine
+                                :source   connection_source})
         {:status 400
          :body   (dissoc details-or-error :valid)}))))
 

--- a/src/metabase/api/model_index.clj
+++ b/src/metabase/api/model_index.clj
@@ -50,7 +50,9 @@
                                            :pk-ref     pk_ref
                                            :value-ref  value_ref
                                            :creator-id api/*current-user-id*})]
-      (snowplow/track-event! ::snowplow/index-model-entities-enabled api/*current-user-id* {:model-id model_id})
+      (snowplow/track-event! ::snowplow/model
+                             {:event    :index-model-entities-enabled
+                              :model-id model_id})
       (task.index-values/add-indexing-job model-index)
       (model-index/add-values! model-index)
       (t2/select-one ModelIndex :id (:id model-index)))))

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -681,9 +681,11 @@
         ;; you're by definition allowed to run it without a perms check anyway
         (binding [api/*current-user-permissions-set* (delay #{"/"})]
           (let [action (api/check-404 (action/select-action :public_uuid uuid :archived false))]
-            (snowplow/track-event! ::snowplow/action-executed api/*current-user-id* {:source    :public_form
-                                                                                     :type      (:type action)
-                                                                                     :action_id (:id action)})
+            (snowplow/track-event! ::snowplow/action
+                                   {:event     :action-executed
+                                    :source    :public_form
+                                    :type      (:type action)
+                                    :action_id (:id action)})
             ;; Undo middleware string->keyword coercion
             (actions/execute-action! action (update-keys parameters name))))))))
 

--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -73,7 +73,7 @@
         (events/publish-event! :event/user-joined event)))
     (record-login-history! session-uuid (u/the-id user) device-info)
     (when-not (:last_login user)
-      (snowplow/track-event! ::snowplow/new-user-created (u/the-id user)))
+      (snowplow/track-event! ::snowplow/account {:event :new-user-created} (u/the-id user)))
     (assoc session :id session-uuid)))
 
 (mu/defmethod create-session! :password :- SessionSchema

--- a/src/metabase/api/setup.clj
+++ b/src/metabase/api/setup.clj
@@ -77,8 +77,10 @@
       (u/prog1 (user/create-and-invite-user! user invitor true)
         (user/set-permissions-groups! <> [(perms-group/all-users) (perms-group/admin)])
         (events/publish-event! :event/user-invited {:object (assoc <> :invite_method "email")})
-        (snowplow/track-event! ::snowplow/invite-sent api/*current-user-id* {:invited-user-id (u/the-id <>)
-                                                                             :source          "setup"})))))
+        (snowplow/track-event! ::snowplow/invite
+                               {:event           :invite-sent
+                                :invited-user-id (u/the-id <>)
+                                :source          "setup"})))))
 
 (defn- setup-set-settings! [{:keys [email site-name site-locale]}]
   ;; set a couple preferences
@@ -135,7 +137,7 @@
       (events/publish-event! :event/user-login {:user-id user-id})
       (when-not (:last_login superuser)
         (events/publish-event! :event/user-joined {:user-id user-id}))
-      (snowplow/track-event! ::snowplow/new-user-created user-id)
+      (snowplow/track-event! ::snowplow/account {:event :new-user-created} user-id)
       ;; return response with session ID and set the cookie as well
       (mw.session/set-session-cookies request {:id session-id} session (t/zoned-date-time (t/zone-id "GMT"))))))
 

--- a/src/metabase/api/timeline_event.clj
+++ b/src/metabase/api/timeline_event.clj
@@ -43,9 +43,9 @@
                            :timestamp  parsed}
                           (when-not icon
                             {:icon (t2/select-one-fn :icon Timeline :id timeline_id)}))]
-      (snowplow/track-event! ::snowplow/new-event-created
-                             api/*current-user-id*
-                             (cond-> {:time_matters time_matters
+      (snowplow/track-event! ::snowplow/timeline
+                             (cond-> {:event         :new-event-created
+                                      :time_matters  time_matters
                                       :collection_id (:collection_id timeline)}
                                (boolean source)      (assoc :source source)
                                (boolean question_id) (assoc :question_id question_id)))

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -375,8 +375,10 @@
                                  @api/*current-user*
                                  false))]
       (maybe-set-user-group-memberships! new-user-id user_group_memberships)
-      (snowplow/track-event! ::snowplow/invite-sent api/*current-user-id* {:invited-user-id new-user-id
-                                                                           :source          "admin"})
+      (snowplow/track-event! ::snowplow/invite
+                             {:event           :invite-sent
+                              :invited-user-id new-user-id
+                              :source          "admin"})
       (-> (fetch-user :id new-user-id)
           (t2/hydrate :user_group_memberships)))))
 

--- a/src/metabase/embed/settings.clj
+++ b/src/metabase/embed/settings.clj
@@ -4,7 +4,6 @@
    [clojure.string :as str]
    [crypto.random :as crypto-random]
    [metabase.analytics.snowplow :as snowplow]
-   [metabase.api.common :as api]
    [metabase.models.setting :as setting :refer [defsetting]]
    [metabase.public-settings :as public-settings]
    [metabase.util.embed :as embed]
@@ -30,12 +29,13 @@
                   (setting/set-value-of-type! :boolean :enable-embedding new-value)
                   (when (and new-value (str/blank? (embed/embedding-secret-key)))
                     (embed/embedding-secret-key! (crypto-random/hex 32)))
-                  (let [snowplow-payload {:embedding-app-origin-set   (boolean (embedding-app-origin))
+                  (snowplow/track-event! ::snowplow/embed_share
+                                         {:event                      (if new-value
+                                                                        :embedding-enabled
+                                                                        :embedding-disabled)
+                                          :embedding-app-origin-set   (boolean (embedding-app-origin))
                                           :number-embedded-questions  (t2/count :model/Card :enable_embedding true)
-                                          :number-embedded-dashboards (t2/count :model/Dashboard :enable_embedding true)}]
-                    (if new-value
-                      (snowplow/track-event! ::snowplow/embedding-enabled api/*current-user-id* snowplow-payload)
-                      (snowplow/track-event! ::snowplow/embedding-disabled api/*current-user-id* snowplow-payload))))))
+                                          :number-embedded-dashboards (t2/count :model/Dashboard :enable_embedding true)}))))
 
 ;; settings for the embedding homepage
 (defsetting embedding-homepage

--- a/src/metabase/metabot/feedback.clj
+++ b/src/metabase/metabot/feedback.clj
@@ -3,7 +3,6 @@
    [cheshire.core :as json]
    [clj-http.client :as http]
    [metabase.analytics.snowplow :as snowplow]
-   [metabase.api.common :as api]
    [metabase.metabot.settings :as metabot-settings]))
 
 (def ^:private snowplow-keys [:entity_type :prompt_template_versions :feedback_type])
@@ -30,7 +29,6 @@
   and more detailed values in a separate endpoint."
   [feedback]
   (let [snowplow-feedback (select-keys feedback snowplow-keys)]
-    (snowplow/track-event!
-     ::snowplow/metabot-feedback-received api/*current-user-id*
-     snowplow-feedback)
+    (snowplow/track-event! ::snowplow/metabot
+                           (assoc snowplow-feedback :event :metabot-feedback-received))
     (store-detailed-feedback feedback)))

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -605,11 +605,15 @@
                                            :model-id    (:id card)
                                            :stats       stats}})
 
-        (snowplow/track-event! ::snowplow/csv-upload-successful api/*current-user-id*
-                               (assoc stats :model-id (:id card)))
+        (snowplow/track-event! ::snowplow/csvupload
+                               (assoc stats
+                                      :event    :csv-upload-successful
+                                      :model-id (:id card)))
         card)
       (catch Throwable e
-        (snowplow/track-event! ::snowplow/csv-upload-failed api/*current-user-id* (fail-stats filename file))
+        (snowplow/track-event! ::snowplow/csvupload (assoc (fail-stats filename file)
+                                                           :event :csv-upload-failed))
+
         (throw e)))))
 
 ;;; +-----------------------------
@@ -788,11 +792,12 @@
                                              :table-name  (:name table)
                                              :stats       stats}})
 
-          (snowplow/track-event! ::snowplow/csv-append-successful api/*current-user-id* stats)
+          (snowplow/track-event! ::snowplow/csvupload (assoc stats :event :csv-append-successful))
 
           {:row-count row-count})))
     (catch Throwable e
-      (snowplow/track-event! ::snowplow/csv-append-failed api/*current-user-id* (fail-stats filename file))
+      (snowplow/track-event! ::snowplow/csvupload (assoc (fail-stats filename file)
+                                                         :event :csv-append-failed))
       (throw e))))
 
 (defn- can-update-error

--- a/test/metabase/analytics/snowplow_test.clj
+++ b/test/metabase/analytics/snowplow_test.clj
@@ -33,6 +33,7 @@
   "A function that can be used in place of track-event-impl! which pulls and decodes the payload, context and subject ID
   from an event and adds it to the in-memory [[*snowplow-collector*]] queue."
   [collector _tracker ^SelfDescribing event]
+  (def event event)
   (let [payload                            (-> event .getPayload .getMap normalize-map)
         ;; Don't normalize keys in [[properties]] so that we can assert that they are snake-case strings in the test
         ;; cases
@@ -43,6 +44,7 @@
                                              (-> subject .getSubject normalize-map))
         [^SelfDescribingJson context-json] (.getContext event)
         context                            (normalize-map (.getMap context-json))]
+    (def payload payload)
     (swap! collector conj {:properties properties, :subject subject, :context context})))
 
 (defn do-with-fake-snowplow-collector!
@@ -97,7 +99,7 @@
   (testing "Snowplow events include a custom context that includes the schema, instance ID, version, token features
            and creation timestamp"
     (with-fake-snowplow-collector
-      (snowplow/track-event! ::snowplow/new-instance-created)
+      (snowplow/track-event! ::account {:event :new-instance-created})
       (is (= {:schema "iglu:com.metabase/instance/jsonschema/1-1-2",
               :data {:id                           (snowplow/analytics-uuid)
                      :version                      {:tag (:tag (public-settings/version))},
@@ -114,66 +116,86 @@
 (deftest ip-address-override-test
   (testing "IP address on Snowplow subject is overridden with a dummy value (127.0.0.1)"
     (with-fake-snowplow-collector
-      (snowplow/track-event! ::snowplow/dashboard-created 1 {:dashboard-id 1})
-      (is (partial= {:uid "1", :ip "127.0.0.1"}
-                    (:subject (first @*snowplow-collector*)))))))
+      (mt/with-test-user :rasta
+        (snowplow/track-event! ::snowplow/dashboard-created {:dashboard-id 1})
+        (is (partial= {:uid (str (mt/user->id :rasta)) :ip "127.0.0.1"}
+                      (:subject (first @*snowplow-collector*))))))))
 
 (deftest track-event-test
   (with-fake-snowplow-collector
-    (testing "Data sent into [[snowplow/track-event!]] for each event type is propagated to the Snowplow collector,
-             with keys converted into snake-case strings, and the subject's user ID being converted to a string."
-      ;; Trigger instance-creation event by calling the `instance-creation` setting function for the first time
-      (t2/delete! Setting :key "instance-creation")
-      (snowplow/instance-creation)
-      (is (= [{:data    {"event" "new_instance_created"}
-               :user-id nil}]
-             (pop-event-data-and-user-id!)))
+    (mt/with-test-user :rasta
+      (testing "Data sent into [[snowplow/track-event!]] for each event type is propagated to the Snowplow collector,
+               with keys converted into snake-case strings, and the subject's user ID being converted to a string."
+        ;; Trigger instance-creation event by calling the `instance-creation` setting function for the first time
+        (t2/delete! Setting :key "instance-creation")
+        (snowplow/instance-creation)
+        (is (= [{:data    {"event" "new_instance_created"}
+                 :user-id nil}]
+               (pop-event-data-and-user-id!)))
 
-      (snowplow/track-event! ::snowplow/new-user-created 1)
-      (is (= [{:data    {"event" "new_user_created"}
-               :user-id "1"}]
-             (pop-event-data-and-user-id!)))
+        (let [user-id-str (str (mt/user->id :rasta))]
+          (snowplow/track-event! ::snowplow/account {:event :new-user-created} 1)
+          (is (= [{:data    {"event" "new_user_created"}
+                   :user-id "1"}]
+                 (pop-event-data-and-user-id!)))
 
-      (snowplow/track-event! ::snowplow/invite-sent 1 {:invited-user-id 2, :source "admin"})
-      (is (= [{:data    {"invited_user_id" 2, "event" "invite_sent", "source" "admin"}
-               :user-id "1"}]
-             (pop-event-data-and-user-id!)))
+          (snowplow/track-event! ::snowplow/invite
+                                 {:event           :invite-sent
+                                  :invited-user-id 2
+                                  :source          "admin"})
+          (is (= [{:data    {"invited_user_id" 2, "event" "invite_sent", "source" "admin"}
+                   :user-id user-id-str}]
+                 (pop-event-data-and-user-id!)))
 
-      (snowplow/track-event! ::snowplow/dashboard-created 1 {:dashboard-id 1})
-      (is (= [{:data    {"dashboard_id" 1, "event" "dashboard_created"}
-               :user-id "1"}]
-             (pop-event-data-and-user-id!)))
+          (snowplow/track-event! ::snowplow/dashboard
+                                 {:event        :dashboard-created
+                                  :dashboard-id 1})
+          (is (= [{:data    {"dashboard_id" 1, "event" "dashboard_created"}
+                   :user-id user-id-str}]
+                 (pop-event-data-and-user-id!)))
 
-      (snowplow/track-event! ::snowplow/question-added-to-dashboard 1 {:dashboard-id 1, :question-id 2})
-      (is (= [{:data    {"dashboard_id" 1, "event" "question_added_to_dashboard", "question_id" 2}
-               :user-id "1"}]
-             (pop-event-data-and-user-id!)))
+          (snowplow/track-event! ::snowplow/dashboard
+                                 {:event        :question-added-to-dashboard
+                                  :dashboard-id 1
+                                  :question-id  2})
+          (is (= [{:data    {"dashboard_id" 1, "event" "question_added_to_dashboard", "question_id" 2}
+                   :user-id user-id-str}]
+                 (pop-event-data-and-user-id!)))
 
-      (snowplow/track-event! ::snowplow/database-connection-successful
-                             1
-                             {:database :postgres, :database-id 1, :source :admin, :dbms_version "14.1"})
-      (is (= [{:data    {"database" "postgres"
-                         "database_id" 1
-                         "event" "database_connection_successful"
-                         "dbms_version" "14.1"
-                         "source" "admin"}
-               :user-id "1"}]
-             (pop-event-data-and-user-id!)))
+          (snowplow/track-event! ::snowplow/database
+                                 {:event        :database-connection-successful
+                                  :database     :postgres
+                                  :database-id  1
+                                  :source       :admin
+                                  :dbms_version "14.1"})
+          (is (= [{:data    {"database" "postgres"
+                             "database_id" 1
+                             "event" "database_connection_successful"
+                             "dbms_version" "14.1"
+                             "source" "admin"}
+                   :user-id user-id-str}]
+                 (pop-event-data-and-user-id!)))
 
-      (snowplow/track-event! ::snowplow/database-connection-failed 1 {:database :postgres, :source :admin})
-      (is (= [{:data    {"database" "postgres", "event" "database_connection_failed", "source" "admin"}
-               :user-id "1"}]
-             (pop-event-data-and-user-id!)))
+          (snowplow/track-event! ::snowplow/database
+                                 {:event    :database-connection-failed
+                                  :database :postgres
+                                  :source   :admin})
+          (is (= [{:data    {"database" "postgres", "event" "database_connection_failed", "source" "admin"}
+                   :user-id user-id-str}]
+                 (pop-event-data-and-user-id!)))
 
-      (snowplow/track-event! ::snowplow/new-event-created 1 {:source "question", :question_id 1})
-      (is (= [{:data    {"event" "new_event_created", "source" "question", "question_id" 1}
-               :user-id "1"}]
-             (pop-event-data-and-user-id!)))
+          (snowplow/track-event! ::snowplow/timeline
+                                 {:event       :new-event-created
+                                  :source      "question"
+                                  :question_id 1})
+          (is (= [{:data    {"event" "new_event_created", "source" "question", "question_id" 1}
+                   :user-id user-id-str}]
+                 (pop-event-data-and-user-id!)))
 
-      (testing "Snowplow events are not sent when tracking is disabled"
-        (mt/with-temporary-setting-values [anon-tracking-enabled false]
-          (snowplow/track-event! ::snowplow/new-instance-created)
-          (is (= [] (pop-event-data-and-user-id!))))))))
+          (testing "Snowplow events are not sent when tracking is disabled"
+            (mt/with-temporary-setting-values [anon-tracking-enabled false]
+              (snowplow/track-event! ::account {:event :new_instance_created} nil)
+              (is (= [] (pop-event-data-and-user-id!))))))))))
 
 (deftest instance-creation-test
   (let [original-value (t2/select-one-fn :value Setting :key "instance-creation")]

--- a/test/metabase/analytics/snowplow_test.clj
+++ b/test/metabase/analytics/snowplow_test.clj
@@ -99,7 +99,7 @@
   (testing "Snowplow events include a custom context that includes the schema, instance ID, version, token features
            and creation timestamp"
     (with-fake-snowplow-collector
-      (snowplow/track-event! ::account {:event :new-instance-created})
+      (snowplow/track-event! ::snowplow/account {:event :new-instance-created})
       (is (= {:schema "iglu:com.metabase/instance/jsonschema/1-1-2",
               :data {:id                           (snowplow/analytics-uuid)
                      :version                      {:tag (:tag (public-settings/version))},
@@ -117,7 +117,7 @@
   (testing "IP address on Snowplow subject is overridden with a dummy value (127.0.0.1)"
     (with-fake-snowplow-collector
       (mt/with-test-user :rasta
-        (snowplow/track-event! ::snowplow/dashboard-created {:dashboard-id 1})
+        (snowplow/track-event! ::snowplow/dashboard {:dashboard-id 1})
         (is (partial= {:uid (str (mt/user->id :rasta)) :ip "127.0.0.1"}
                       (:subject (first @*snowplow-collector*))))))))
 
@@ -194,7 +194,7 @@
 
           (testing "Snowplow events are not sent when tracking is disabled"
             (mt/with-temporary-setting-values [anon-tracking-enabled false]
-              (snowplow/track-event! ::account {:event :new_instance_created} nil)
+              (snowplow/track-event! ::snowplow/account {:event :new_instance_created} nil)
               (is (= [] (pop-event-data-and-user-id!))))))))))
 
 (deftest instance-creation-test


### PR DESCRIPTION
The current API for tracking an event with Snowplow looks like this:

```
(snowplow/track-event! ::snowplow/event-keyword user-id payload) 
```

This has a few problems:
* It assumes that every schema includes multiple events, disambiguated with an `event` keyword. This is not the case for https://github.com/metabase/metabase/issues/40868
* It requires manually maintaining an `event->schema` map to determine the schema which should be used for a given event
* It requires the caller to always explicitly pass in `user-id` when 99% of the time it is using `api/*current-user-id*`

I've reworked the API to look like this:
```
(snowplow/track-event! ::snowplow/schema-keyword payload)
```

* `payload` can include `:event :event-keyword` but it's not required. This treats `:event` as a normal value in the payload instead of a special required property (since we're moving away from it)
* `user-id` can be optionally passed in as the third argument; otherwise it will default to `api/*current-user-id*`
* This gets rid of the `event->schema` map since the schema is always passed in explicitly

I've also adjusted the tracker to be initialized on startup rather than being wrapped in a delay and initialized on demand. In practice it initializes very quickly and I was running into some weird test failures when running in the REPL, so I think this is worth it for the sake of simplicity.

Backporting this PR since it doesn't change behavior at all, so it seems worth having it in 50 to avoid some future backport conflicts.