### PR TITLE
Fix startup loading page only working on the root URL

### DIFF
--- a/resources/frontend_client/inline_js/init.js
+++ b/resources/frontend_client/inline_js/init.js
@@ -45,7 +45,7 @@ function fadeInNewAnimation(counter) {
   const srcPrefix = content[counter % content.length][0];
 
   animation.className = "animation";
-  animation.src = `app/instance-loading-page/img/${srcPrefix}.png`;
+  animation.src = `/app/instance-loading-page/img/${srcPrefix}.png`;
 }
 
 function updateHeading(counter) {
@@ -55,7 +55,7 @@ function updateHeading(counter) {
 
 function poll() {
   const req = new XMLHttpRequest();
-  req.open("GET", "api/health", true);
+  req.open("GET", "/api/health", true);
   req.onreadystatechange = function() {
     if (req.readyState === 4) {
       if (req.status === 200) {


### PR DESCRIPTION
> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform) (unless it's a tiny documentation change). Also, if you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.

### Description

Fix the startup loading page being broken on non-root URLs (e.g. `/admin/settings/setup`).

### How to verify

1. Restart your Metabase server
2. While it is starting up, go to a page to see the loading animation. Go to e.g. `/admin/settings/setup` instead of `/`.
3. The loading animation page should work on any page.

### Demo

Note: I have NOT built and tested this, but I believe the fix should be this simple.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
