### PR TITLE
show additional columns in the tooltip

### DIFF
--- a/e2e/support/helpers/e2e-visual-tests-helpers.js
+++ b/e2e/support/helpers/e2e-visual-tests-helpers.js
@@ -202,3 +202,11 @@ export function assertEChartsTooltip({ header, rows, footer, blurAfter }) {
     echartsTriggerBlur();
   }
 }
+
+export function assertEChartsTooltipNotContain(rows) {
+  echartsTooltip().within(() => {
+    rows.forEach(row => {
+      cy.findByText(row).should("not.exist");
+    });
+  });
+}

--- a/e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js
@@ -279,7 +279,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       cy.findByTestId("viz-settings-button").click();
       leftSidebar().within(() => {
         cy.findByText("Display").click();
-        cy.findByPlaceholderText("Additional columns to show").click();
+        cy.findByPlaceholderText("Enter metric names").click();
       });
 
       // Select two additional metric columns to show in the tooltip

--- a/e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js
@@ -1,21 +1,25 @@
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   addOrUpdateDashboardCard,
   assertEChartsTooltip,
+  assertEChartsTooltipNotContain,
   assertTooltipRow,
   cartesianChartCircle,
   cartesianChartCircleWithColor,
   chartPathWithFillColor,
   echartsTooltip,
   echartsTriggerBlur,
+  leftSidebar,
   modal,
   restore,
   saveDashboard,
   tooltipHeader,
   visitDashboard,
+  visitQuestionAdhoc,
 } from "e2e/support/helpers";
 
-const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATABASE;
 
 const SUM_OF_TOTAL = {
   name: "Q1",
@@ -229,6 +233,107 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
+  });
+
+  describe("> additional columns setting", () => {
+    const COUNT = "Count";
+    const SUM_OF_TOTAL = "Sum of Total";
+    const AVG_OF_QUANTITY = "Average of Quantity";
+
+    const COUNT_COLOR = "#509EE3";
+    const DOOHICKEY_COLOR = "#88BF4D";
+
+    const testQuestion = {
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [
+            ["count"],
+            ["sum", ["field", ORDERS.TOTAL, null]],
+            ["avg", ["field", ORDERS.QUANTITY, null]],
+          ],
+          breakout: [
+            ["field", PRODUCTS.RATING, { "source-field": ORDERS.PRODUCT_ID }],
+            ["field", PRODUCTS.CATEGORY, { "source-field": ORDERS.CATEGORY }],
+          ],
+        },
+        type: "query",
+      },
+      display: "bar",
+      visualization_settings: {
+        "graph.x_axis.scale": "ordinal",
+        "graph.dimensions": ["RATING"],
+        "graph.metrics": ["count"],
+      },
+    };
+
+    it("should allow adding non-series columns from data to the tooltip", () => {
+      visitQuestionAdhoc(testQuestion);
+
+      // Tooltip by default shows only visible series data
+      showTooltipForBarInSeries(COUNT_COLOR);
+      assertEChartsTooltipNotContain([SUM_OF_TOTAL, AVG_OF_QUANTITY]);
+
+      // Go to the additional tooltip columns setting
+      cy.findByTestId("viz-settings-button").click();
+      leftSidebar().within(() => {
+        cy.findByText("Display").click();
+        cy.findByPlaceholderText("Additional columns to show").click();
+      });
+
+      // Select two additional metric columns to show in the tooltip
+      cy.findByRole("option", { name: SUM_OF_TOTAL }).click();
+      cy.findByRole("option", { name: AVG_OF_QUANTITY }).click();
+      // It should not suggest categorical columns
+      cy.findByRole("option", { name: "Product → Category" }).should(
+        "not.exist",
+      );
+
+      // Ensure the tooltip shows additional columns
+      showTooltipForBarInSeries(COUNT_COLOR);
+      assertEChartsTooltip({
+        header: "0",
+        rows: [
+          { name: COUNT, value: "2,308" },
+          { name: SUM_OF_TOTAL, value: "179,762.63" },
+          { name: AVG_OF_QUANTITY, value: "15.32" },
+        ],
+      });
+
+      // Add a breakout to the chart
+      leftSidebar().within(() => {
+        cy.findByText("Data").click();
+        cy.findByText("Add series breakout").click();
+      });
+
+      // Ensure the tooltip still shows additional columns
+      showTooltipForBarInSeries(DOOHICKEY_COLOR);
+      const assertBreakoutTooltip = () => {
+        assertEChartsTooltip({
+          header: "0",
+          rows: [
+            { name: "Doohickey", value: "192" },
+            { name: SUM_OF_TOTAL, value: "20,345.44" },
+            { name: AVG_OF_QUANTITY, value: "3.76" },
+            { name: "Gadget", value: "653" },
+            { name: "Gizmo", value: "370" },
+            { name: "Widget", value: "1,093" },
+          ],
+        });
+      };
+      assertBreakoutTooltip();
+
+      // Make the chart stacked
+      leftSidebar().within(() => {
+        cy.findByText("Display").click();
+        cy.findByText("Stack").click();
+      });
+
+      // Ensure the tooltip still shows additional columns
+      showTooltipForBarInSeries(DOOHICKEY_COLOR);
+      assertBreakoutTooltip();
+    });
   });
 
   describe("> single series question on dashboard", () => {

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -790,7 +790,7 @@ const getTimeseriesDataInterval = createSelector(
     const columns = series[0]?.data?.cols ?? [];
     const dimensions = settings?.["graph.dimensions"] ?? [];
     const dimensionColumns = dimensions.map(dimension =>
-      columns.find(column => column.name === dimension),
+      columns.find(column => column != null && column.name === dimension),
     );
     const columnUnits = dimensionColumns
       .map(column =>

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
@@ -12,6 +12,7 @@ import { parseValues, unique } from "./utils";
 
 export type MultiAutocompleteProps = Omit<MultiSelectProps, "shouldCreate"> & {
   shouldCreate?: (query: string, selectedValues: string[]) => boolean;
+  showInfoIcon?: boolean;
 };
 
 export function MultiAutocomplete({
@@ -22,6 +23,7 @@ export function MultiAutocomplete({
   placeholder,
   autoFocus,
   shouldCreate = defaultShouldCreate,
+  showInfoIcon = true,
   rightSection,
   onChange,
   onSearchChange,
@@ -179,7 +181,7 @@ export function MultiAutocomplete({
       onBlur={handleBlur}
       onSearchChange={handleSearchChange}
       onPaste={handlePaste}
-      rightSection={rightSection ?? infoIcon}
+      rightSection={rightSection ?? (showInfoIcon ? infoIcon : null)}
     />
   );
 }

--- a/frontend/src/metabase/visualizations/components/ChartTooltip/EChartsTooltip/EChartsTooltip.module.css
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip/EChartsTooltip/EChartsTooltip.module.css
@@ -25,12 +25,17 @@
   color: var(--mb-color-text-light);
 }
 
+.Row {
+  font-size: 14px;
+}
+
+.SecondaryRow {
+  color: var(--mb-color-text-light);
+  font-size: 12px;
+}
+
 .RowFocused {
-  background-color: color-mix(
-    in srgb,
-    var(--mb-color-bg-black) 50%,
-    #000
-  ) !important;
+  background-color: color-mix(in srgb, var(--mb-color-bg-black) 50%, #000);
 }
 
 .Cell {
@@ -59,13 +64,11 @@
 .NameCell {
   padding-left: 0.375rem;
   font-weight: 400;
-  font-size: 14px;
   text-align: left;
 }
 
 .MainValueCell {
   width: 1px;
-  font-size: 14px;
 }
 
 .SecondaryValueCell {
@@ -89,4 +92,8 @@
 
 .FooterRow .Cell {
   padding-top: 0.75rem;
+}
+
+.SecondaryRow .NameCell {
+  color: color-mix(in srgb, #fff 90%, var(--mb-color-bg-black));
 }

--- a/frontend/src/metabase/visualizations/components/ChartTooltip/EChartsTooltip/EChartsTooltip.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip/EChartsTooltip/EChartsTooltip.tsx
@@ -11,6 +11,7 @@ export interface EChartsTooltipRow {
   markerColorClass?: string;
   name: string;
   isFocused?: boolean;
+  isSecondary?: boolean;
   values: React.ReactNode[];
 }
 
@@ -38,8 +39,10 @@ export const EChartsTooltip = ({
   }, 0);
 
   const paddedRows = rows.map(row => {
-    const paddedValues = [...row.values];
-    paddedValues.length = maxValuesColumns;
+    const paddedValues = Object.assign(
+      Array(maxValuesColumns).fill(null),
+      row.values.slice(0, maxValuesColumns),
+    );
 
     return {
       ...row,
@@ -64,7 +67,11 @@ export const EChartsTooltip = ({
       >
         <tbody>
           {paddedRows.map((row, index) => {
-            return <TooltipRow key={index} {...row} />;
+            return !row.isSecondary ? (
+              <TooltipRow key={index} {...row} />
+            ) : (
+              <SecondaryRow key={index} {...row} />
+            );
           })}
         </tbody>
         {footer != null && (
@@ -89,7 +96,7 @@ const TooltipRow = ({
   isFocused,
 }: TooltipRowProps) => (
   <BaseRow
-    className={cx({ [TooltipStyles.RowFocused]: isFocused })}
+    className={cx(TooltipStyles.Row, { [TooltipStyles.RowFocused]: isFocused })}
     name={name}
     values={values}
     markerContent={
@@ -99,6 +106,17 @@ const TooltipRow = ({
     }
   />
 );
+
+const SecondaryRow = ({ name, values }: TooltipRowProps) => {
+  return (
+    <BaseRow
+      className={TooltipStyles.SecondaryRow}
+      name={name}
+      values={values}
+      markerContent={<span />}
+    />
+  );
+};
 
 const FooterRow = ({
   name,

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingMultiSelect.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingMultiSelect.tsx
@@ -1,0 +1,27 @@
+import { MultiAutocomplete } from "metabase/ui";
+
+type Value = string[] | undefined;
+
+interface ChartSettingMultiSelectProps {
+  value: Value;
+  onChange: (value: Value) => void;
+  placeholder: string;
+  placeholderNoOptions: string;
+  options: { value: string; label: string }[];
+}
+
+export const ChartSettingMultiSelect = ({
+  value,
+  onChange,
+  options = [],
+  placeholder,
+  placeholderNoOptions,
+}: ChartSettingMultiSelectProps) => (
+  <MultiAutocomplete
+    value={value}
+    onChange={onChange}
+    placeholder={options.length === 0 ? placeholderNoOptions : placeholder}
+    data={options}
+    showInfoIcon={false}
+  />
+);

--- a/frontend/src/metabase/visualizations/lib/settings.js
+++ b/frontend/src/metabase/visualizations/lib/settings.js
@@ -9,6 +9,7 @@ import ChartSettingFieldsPicker from "metabase/visualizations/components/setting
 import ChartSettingInput from "metabase/visualizations/components/settings/ChartSettingInput";
 import ChartSettingInputGroup from "metabase/visualizations/components/settings/ChartSettingInputGroup";
 import { ChartSettingInputNumeric } from "metabase/visualizations/components/settings/ChartSettingInputNumeric";
+import { ChartSettingMultiSelect } from "metabase/visualizations/components/settings/ChartSettingMultiSelect";
 import ChartSettingRadio from "metabase/visualizations/components/settings/ChartSettingRadio";
 import ChartSettingSegmentedControl from "metabase/visualizations/components/settings/ChartSettingSegmentedControl";
 import ChartSettingSelect from "metabase/visualizations/components/settings/ChartSettingSelect";
@@ -27,6 +28,7 @@ const WIDGETS = {
   fieldsPartition: ChartSettingFieldsPartition,
   color: ChartSettingColorPicker,
   colors: ChartSettingColorsPicker,
+  multiselect: ChartSettingMultiSelect,
 };
 
 export function getComputedSettings(

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -275,8 +275,8 @@ export const TOOLTIP_SETTINGS = {
   },
   "graph.tooltip_columns": {
     section: t`Display`,
-    title: t`Tooltip columns`,
-    placeholder: t`Additional columns to show`,
+    title: t`Additional tooltip metrics`,
+    placeholder: t`Enter metric names`,
     widget: "multiselect",
     useRawSeries: true,
     getValue: getComputedAdditionalColumnsValue,

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -285,15 +285,6 @@ export const TOOLTIP_SETTINGS = {
       if (vizSettings["graph.tooltip_type"] === "default") {
         return true;
       }
-
-      const hasLines = getSeriesDisplays(rawSeries, vizSettings).some(
-        display => display === "line",
-      );
-      // We do not show additional columns on stacked charts
-      if (vizSettings["stackable.stack_type"] != null && !hasLines) {
-        return true;
-      }
-
       return getAvailableAdditionalColumns(rawSeries, vizSettings).length === 0;
     },
     getProps: (rawSeries, vizSettings) => {

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -301,7 +301,6 @@ export const TOOLTIP_SETTINGS = {
     readDependencies: [
       "graph.metrics",
       "graph.dimensions",
-      "stackable.stack_type",
       "graph.tooltip_type",
     ],
   },

--- a/frontend/src/metabase/visualizations/lib/settings/graph.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.unit.spec.js
@@ -10,6 +10,7 @@ import {
   GRAPH_AXIS_SETTINGS,
   GRAPH_DISPLAY_VALUES_SETTINGS,
   STACKABLE_SETTINGS,
+  TOOLTIP_SETTINGS,
   getDefaultDimensionLabel,
 } from "./graph";
 
@@ -428,6 +429,105 @@ describe("GRAPH_DISPLAY_VALUES_SETTINGS", () => {
       );
 
       expect(isHidden).toBe(true);
+    });
+  });
+});
+
+describe("graph.tooltip_columns", () => {
+  const tooltipColumnsSetting = TOOLTIP_SETTINGS["graph.tooltip_columns"];
+
+  describe("getHidden", () => {
+    it("should be hidden when tooltip type is default", () => {
+      const isHidden = tooltipColumnsSetting.getHidden([], {
+        "graph.tooltip_type": "default",
+      });
+
+      expect(isHidden).toBe(true);
+    });
+
+    it("should be hidden when there are no available additional columns", () => {
+      const mockSeries = [
+        createMockSingleSeries(
+          createMockCard(),
+          createMockDataset({
+            data: createMockDatasetData({
+              cols: [
+                createMockColumn({ name: "dim", base_type: "type/Text" }),
+                createMockColumn({ name: "metric", base_type: "type/Number" }),
+              ],
+            }),
+          }),
+        ),
+      ];
+
+      const isHidden = tooltipColumnsSetting.getHidden(mockSeries, {
+        "graph.tooltip_type": "customized",
+        "graph.dimensions": ["dim"],
+        "graph.metrics": ["metric"],
+      });
+
+      expect(isHidden).toBe(true);
+    });
+
+    it("should not be hidden when there are available additional columns", () => {
+      const mockSeries = [
+        createMockSingleSeries(
+          createMockCard(),
+          createMockDataset({
+            data: createMockDatasetData({
+              cols: [
+                createMockColumn({ name: "dim", base_type: "type/Text" }),
+                createMockColumn({ name: "metric1", base_type: "type/Number" }),
+                createMockColumn({ name: "metric2", base_type: "type/Number" }),
+              ],
+            }),
+          }),
+        ),
+      ];
+
+      const isHidden = tooltipColumnsSetting.getHidden(mockSeries, {
+        "graph.tooltip_type": "customized",
+        "graph.dimensions": ["dim"],
+        "graph.metrics": ["metric1"],
+      });
+
+      expect(isHidden).toBe(false);
+    });
+  });
+
+  describe("getProps", () => {
+    it("should return options for available additional columns", () => {
+      const mockSeries = [
+        createMockSingleSeries(
+          createMockCard(),
+          createMockDataset({
+            data: createMockDatasetData({
+              cols: [
+                createMockColumn({ name: "dim", base_type: "type/Text" }),
+                createMockColumn({
+                  name: "metric1",
+                  display_name: "Metric 1",
+                  base_type: "type/Number",
+                }),
+                createMockColumn({
+                  name: "metric2",
+                  display_name: "Metric 2",
+                  base_type: "type/Number",
+                }),
+              ],
+            }),
+          }),
+        ),
+      ];
+
+      const props = tooltipColumnsSetting.getProps(mockSeries, {
+        "graph.dimensions": ["dim"],
+        "graph.metrics": ["metric1"],
+      });
+
+      expect(props.options).toEqual([
+        { label: "Metric 2", value: '["name","metric2"]' },
+      ]);
     });
   });
 });

--- a/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
@@ -1,6 +1,7 @@
 import { t } from "ttag";
 import _ from "underscore";
 
+import { isNotNull } from "metabase/lib/types";
 import { getMaxDimensionsSupported } from "metabase/visualizations";
 import { getCardsColumns } from "metabase/visualizations/echarts/cartesian/model";
 import { dimensionIsNumeric } from "metabase/visualizations/lib/numeric";
@@ -390,6 +391,13 @@ export function getAvailableAdditionalColumns(
   settings: ComputedVisualizationSettings,
 ): DatasetColumn[] {
   const alreadyIncludedColumns = new Set<DatasetColumn>();
+
+  if (
+    _.isEmpty(settings["graph.dimensions"]?.filter(isNotNull)) ||
+    _.isEmpty(settings["graph.metrics"]?.filter(isNotNull))
+  ) {
+    return [];
+  }
 
   getCardsColumns(rawSeries, settings).forEach(cardColumns => {
     alreadyIncludedColumns.add(cardColumns.dimension.column);

--- a/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
@@ -407,7 +407,7 @@ export function getAvailableAdditionalColumns(
     .flatMap(singleSeries => {
       return singleSeries.data.cols;
     })
-    .filter(column => !alreadyIncludedColumns.has(column));
+    .filter(column => isMetric(column) && !alreadyIncludedColumns.has(column));
 }
 
 export function getComputedAdditionalColumnsValue(

--- a/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
@@ -2,6 +2,7 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import { getMaxDimensionsSupported } from "metabase/visualizations";
+import { getCardsColumns } from "metabase/visualizations/echarts/cartesian/model";
 import { dimensionIsNumeric } from "metabase/visualizations/lib/numeric";
 import { dimensionIsTimeseries } from "metabase/visualizations/lib/timeseries";
 import {
@@ -11,6 +12,7 @@ import {
   preserveExistingColumnsOrder,
 } from "metabase/visualizations/lib/utils";
 import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
+import { getColumnKey } from "metabase-lib/v1/queries/utils/column-key";
 import {
   isAny,
   isDate,
@@ -381,4 +383,46 @@ function getDefaultLineAreaBarColumns(series: RawSeries) {
     series,
     getMaxDimensionsSupported(display),
   );
+}
+
+export function getAvailableAdditionalColumns(
+  rawSeries: RawSeries,
+  settings: ComputedVisualizationSettings,
+): DatasetColumn[] {
+  const alreadyIncludedColumns = new Set<DatasetColumn>();
+
+  getCardsColumns(rawSeries, settings).forEach(cardColumns => {
+    alreadyIncludedColumns.add(cardColumns.dimension.column);
+    if ("breakout" in cardColumns) {
+      alreadyIncludedColumns.add(cardColumns.breakout.column);
+      alreadyIncludedColumns.add(cardColumns.metric.column);
+    } else {
+      cardColumns.metrics.forEach(columnDescriptor =>
+        alreadyIncludedColumns.add(columnDescriptor.column),
+      );
+    }
+  });
+
+  return rawSeries
+    .flatMap(singleSeries => {
+      return singleSeries.data.cols;
+    })
+    .filter(column => !alreadyIncludedColumns.has(column));
+}
+
+export function getComputedAdditionalColumnsValue(
+  rawSeries: RawSeries,
+  settings: ComputedVisualizationSettings,
+) {
+  const availableAdditionalColumnKeys = new Set(
+    getAvailableAdditionalColumns(rawSeries, settings).map(column =>
+      getColumnKey(column),
+    ),
+  );
+
+  const filteredStoredColumns = (
+    settings["graph.tooltip_columns"] ?? []
+  ).filter((columnKey: string) => availableAdditionalColumnKeys.has(columnKey));
+
+  return filteredStoredColumns;
 }


### PR DESCRIPTION
[Product doc](https://www.notion.so/metabase/Migrate-tooltips-to-ECharts-for-more-predictable-behavior-364f2c71f3b248f1b839960af037279c?pvs=4#7ca169aadbd94b6da20966bba46b6658)

### Description

Adds the ability to display additional columns from dataset in the tooltip. Applies to line/area/bar/combo charts.

### How to verify

1) New -> Orders: Count, Avg of Total, Avg of Subtotal group by Created At: month -> line/area/bar/combo display
2) Ensure tooltip shows only series data
3) Remove all but Count series, enable all other columns to be shown in the tooltip
4) Ensure tooltip shows other columns in the tooltip
5) Add a breakout Product -> Category
6) Ensure tooltip shows additional columns right below the hovered series 

### Demo

<img width="851" alt="Screenshot 2024-09-05 at 4 04 46 PM" src="https://github.com/user-attachments/assets/18a4af45-7209-4a5a-8d33-3d69e910aa66">

<video src="https://github.com/user-attachments/assets/bf329fec-5dad-4347-a94b-4b664079ff19" />

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
