### PR TITLE
[Notification] Notification and subscription

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -320,6 +320,7 @@
     metabase.metabot               #{metabase.metabot}
     metabase.models                :any                                                             ; TODO -- scream, 62 namespaces used elsewhere, but to be fair a lot of these don't *need* to be required.
     metabase.moderation            #{metabase.moderation}
+    metabase.notification          #{metabase.notification.core}
     metabase.permissions           #{metabase.permissions.util}                                     ; TODO -- this is currently the only namespace in this module. Give it a real API namespace?
     metabase.plugins               #{metabase.plugins
                                      metabase.plugins.classloader}                                  ; TODO -- not 100% sure the classloader belongs here
@@ -416,6 +417,7 @@
     metabase.metabot               :any
     metabase.models                :any
     metabase.moderation            :any
+    metabase.notification          :any
     metabase.permissions           :any
     metabase.plugins               :any
     metabase.public-settings       :any
@@ -498,6 +500,8 @@
     metabase-enterprise.test                                      met
     metabase.analytics.sdk                                        sdk
     metabase.analytics.stats                                      stats
+    metabase.analysis.native-query-analyzer                       nqa
+    metabase.analysis.native-query-analyzer.parameter-substitution nqa.sub
     metabase.analyze.query-results                                qr
     metabase.analyze.classifiers.category                         classifiers.category
     metabase.analyze.classifiers.core                             classifiers
@@ -614,6 +618,7 @@
     metabase.models.interface                                     mi
     metabase.models.moderation-review                             moderation-review
     metabase.models.native-query-snippet                          native-query-snippet
+    metabase.models.notification                                  models.notification
     metabase.models.params                                        params
     metabase.models.permissions                                   perms
     metabase.models.permissions-group                             perms-group
@@ -627,8 +632,7 @@
     metabase.models.setting.cache                                 setting.cache
     metabase.models.timeline                                      timeline
     metabase.models.timeline-event                                timeline-event
-    metabase.analysis.native-query-analyzer                       nqa
-    metabase.analysis.native-query-analyzer.parameter-substitution nqa.sub
+    metabase.notification.core                                    notification
     metabase.plugins.initialize                                   plugins.init
     metabase.public-settings                                      public-settings
     metabase.public-settings.premium-features                     premium-features

--- a/dev/src/dev/migrate.clj
+++ b/dev/src/dev/migrate.clj
@@ -74,14 +74,14 @@
 
     ;; rollback to \"v50.2024-03-18T16:00:00\" (inclusive)
     (rollback! :id \"v50.2024-03-18T16:00:00\")"
- [k :- [:enum :id :count "id" "count"]
-  target]
- (let [n (case (keyword k)
-           :id    (migration-since target)
-           :count (maybe-parse-long target))]
-  (rollback-n-migrations! n)
-  #_{:clj-kondo/ignore [:discouraged-var]}
-  (println (format "Rollbacked %d migrations. Latest migration: %s" n (latest-migration)))))
+  [k :- [:enum :id :count "id" "count"]
+   target]
+  (let [n (case (keyword k)
+            :id    (migration-since target)
+            :count (maybe-parse-long target))]
+    (rollback-n-migrations! n)
+    #_{:clj-kondo/ignore [:discouraged-var]}
+    (println (format "Rollbacked %d migrations. Latest migration: %s" n (latest-migration)))))
 
 (defn migration-status
   "Print the latest migration ID."
@@ -159,3 +159,9 @@
                                  (str x "\n" y)) acc data))
                  {}
                  (map #(change->sql % sql-generator-factory database) (.getChanges change-set))))))))
+
+(comment
+  (rollback! :count 1)
+  (rollback! :id "v51.2024-08-30T08:00:03")
+  (migration-sql-by-id "v51.2024-09-05T08:00:04" :postgres)
+  (migrate!))

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -7,7 +7,8 @@
    "Field"
    "Segment"
    "Table"
-   "Channel"])
+   "Channel"
+   "ChannelTemplate"])
 
 (def content
   "Content model types"
@@ -62,6 +63,8 @@
    "ModerationReview"
    "Notification"
    "NotificationSubscription"
+   "NotificationHandler"
+   "NotificationRecipient"
    "Permissions"
    "PermissionsGroup"
    "PermissionsGroupMembership"

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -60,6 +60,8 @@
    "ModelIndex"
    "ModelIndexValue"
    "ModerationReview"
+   "Notification"
+   "NotificationSubscription"
    "Permissions"
    "PermissionsGroup"
    "PermissionsGroupMembership"

--- a/enterprise/backend/test/metabase_enterprise/models/entity_id_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/models/entity_id_test.clj
@@ -58,6 +58,8 @@
     :model/ModerationReview
     :model/Notification
     :model/NotificationSubscription
+    :model/NotificationHandler
+    :model/NotificationRecipient
     :model/ParameterCard
     :model/Permissions
     :model/PermissionsGroup

--- a/enterprise/backend/test/metabase_enterprise/models/entity_id_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/models/entity_id_test.clj
@@ -56,6 +56,8 @@
     :model/ModelIndex
     :model/ModelIndexValue
     :model/ModerationReview
+    :model/Notification
+    :model/NotificationSubscription
     :model/ParameterCard
     :model/Permissions
     :model/PermissionsGroup

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -839,17 +839,24 @@
       (ts/with-dbs [source-db dest-db]
         (ts/with-db source-db
           (mt/with-temp
-            [:model/Channel _ {:name "My HTTP channel"
-                               :type :channel/http
-                               :details {:url         "http://example.com"
-                                         :auth-method :none}}]
+            [:model/Channel         _ {:name "My HTTP channel"
+                                       :type :channel/http
+                                       :details {:url         "http://example.com"
+                                                 :auth-method :none}}
+             :model/ChannelTemplate _ {:name         "My template"
+                                       :channel_type :channel/http
+                                       :details      {:my-custom-template true}}]
             (storage/store! (seq (serdes/with-cache (into [] (extract/extract {})))) dump-dir)
             (ts/with-db dest-db
               (testing "doing ingestion"
                 (is (serdes/with-cache (serdes.load/load-metabase! (ingest/ingest-yaml dump-dir)))
                     "successful")
-                (is (=? {:name    "My HTTP channel"
-                         :type    :channel/http
-                         :details {:url         "http://example.com"
-                                   :auth-method "none"}}
-                        (t2/select-one :model/Channel :name "My HTTP channel")))))))))))
+               (is (=? {:name    "My HTTP channel"
+                        :type    :channel/http
+                        :details {:url         "http://example.com"
+                                  :auth-method "none"}}
+                       (t2/select-one :model/Channel :name "My HTTP channel")))
+               (is (=? {:name         "My template"
+                        :channel_type :channel/http
+                        :details      {:my-custom-template true}}
+                       (t2/select-one :model/ChannelTemplate :name "My template")))))))))))

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -9281,7 +9281,7 @@ databaseChangeLog:
       changes:
         - createTable:
             tableName: notification
-            remarks: join table that connect notification subscriptions and notification destinations
+            remarks: join table that connect notification subscriptions and notification handlers
             columns:
               - column:
                   name: id
@@ -9366,10 +9366,10 @@ databaseChangeLog:
                     nullable: false
 
   - changeSet:
-      id: v51.2024-09-05T08:00:03
+      id: v51.2024-09-05T08:00:02
       author: qnkhuat
       comment: index on notification_subscription.notification_id
-      rollback: # no need to rollback, will be removed with the table
+      rollback: # no need, will be dropped with the table
       preConditions:
         - not:
             - indexExists:
@@ -9382,6 +9382,324 @@ databaseChangeLog:
               - column:
                   name: notification_id
             indexName: idx_notification_subscription_notification_id
+
+  - changeSet:
+      id: v51.2024-09-05T08:00:03
+      author: qnkhuat
+      comment: Create the channel_template table
+      preConditions:
+        - not:
+          - tableExists:
+              tableName: channel_template
+      changes:
+        - createTable:
+            tableName: channel_template
+            remarks: custom template for the channel
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: name
+                  type: varchar(64)
+                  remarks: the name of the template
+                  constraints:
+                    nullable: false
+              - column:
+                  name: channel_type
+                  type: varchar(64)
+                  remarks: the channel type of the template
+                  constraints:
+                    nullable: false
+              - column:
+                  name: details
+                  type: ${text.type}
+                  remarks: the details of the template
+                  constraints:
+                    nullable: true
+              - column:
+                  remarks: Random NanoID tag for unique identity.
+                  name: entity_id
+                  type: char(21)
+                  constraints:
+                    nullable: false
+                    unique: true
+              - column:
+                  name: created_at
+                  type: ${timestamp_type}
+                  remarks: The timestamp of when the template was created
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: ${timestamp_type}
+                  remarks: The timestamp of when the template was last updated
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: v51.2024-09-05T08:00:04
+      author: qnkhuat
+      comment: Create the notification_handler table
+      validCheckSum: ANY
+      preConditions:
+        - not:
+          - tableExists:
+              tableName: notification_handler
+      changes:
+        - createTable:
+            tableName: notification_handler
+            remarks: which channel to send the notification to
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              # TODO: can be removed once emails and slack configuration are fully migrated to be stored in channel table.
+              - column:
+                  name: channel_type
+                  type: varchar(64)
+                  remarks: the type of the channel, like :channel/email, :channel/slack
+                  constraints:
+                    nullable: false
+              - column:
+                  name: notification_id
+                  type: int
+                  remarks: the notification that the handler is connected to
+                  constraints:
+                    nullable: false
+                    referencedTableName: notification
+                    referencedColumnNames: id
+                    foreignKeyName: fk_notification_handler_notification_id
+                    deleteCascade: true
+              - column:
+                  name: channel_id
+                  type: int
+                  remarks: the channel that the handler is connected to
+                  constraints:
+                    nullable: true # temporarily nullable, because we need to support email and slack channels as global configuration
+                    referencedTableName: channel
+                    referencedColumnNames: id
+                    foreignKeyName: fk_notification_handler_channel_id
+                    deleteCascade: true
+              - column:
+                  name: template_id
+                  type: int
+                  remarks: the template that the handler is connected to
+                  constraints:
+                    nullable: true
+              - column:
+                  name: active
+                  type: ${boolean.type}
+                  remarks: whether the handler is active
+                  defaultValueBoolean: true
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: ${timestamp_type}
+                  remarks: The timestamp of when the handler was created
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: ${timestamp_type}
+                  remarks: The timestamp of when the handler was updated
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+  - changeSet:
+      id: v51.2024-09-05T08:00:05
+      author: qnkhuat
+      comment: Add fk constraint to notification_handler.template_id
+      preConditions:
+        - not:
+          - foreignKeyConstraintExists:
+              foreignKeyName: fk_notification_handler_template_id
+              foreignKyeTableName: notification_handler
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: notification_handler
+            baseColumnNames: template_id
+            referencedTableName: channel_template
+            referencedColumnNames: id
+            constraintName: fk_notification_handler_template_id
+            onDelete: SET NULL
+
+  - changeSet:
+      id: v51.2024-09-05T08:00:06
+      author: qnkhuat
+      comment: index on notification_handler.notification_id
+      rollback: # not necessary, will be removed with the table
+      preConditions:
+        - not:
+            - indexExists:
+                tableName: notification_handler
+                indexName: idx_notification_handler_notification_id
+      changes:
+        - createIndex:
+            tableName: notification_handler
+            columns:
+              - column:
+                  name: notification_id
+            indexName: idx_notification_handler_notification_id
+
+  - changeSet:
+      id: v51.2024-09-05T08:00:07
+      author: qnkhuat
+      comment: index on notification_handler.channel_id
+      rollback: # not necessary, will be removed with the table
+      preConditions:
+        - not:
+            - indexExists:
+                tableName: notification_handler
+                indexName: idx_notification_handler_channel_id
+      changes:
+        - createIndex:
+            tableName: notification_handler
+            columns:
+              - column:
+                  name: channel_id
+            indexName: idx_notification_handler_channel_id
+
+  - changeSet:
+      id: v51.2024-09-05T08:00:08
+      author: qnkhuat
+      comment: Create the notification_recipient table
+      preConditions:
+        - not:
+          - tableExists:
+              tableName: notification_recipient
+      changes:
+        - createTable:
+            tableName: notification_recipient
+            remarks: who should receive the notification
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: notification_handler_id
+                  type: int
+                  remarks: the handler that the recipient is connected to
+                  constraints:
+                    nullable: false
+                    referencedTableName: notification_handler
+                    referencedColumnNames: id
+                    foreignKeyName: fk_notification_recipient_notification_handler_id
+                    deleteCascade: true
+              - column:
+                  name: type
+                  type: varchar(64)
+                  remarks: the type of the recipient
+                  constraints:
+                    nullable: false
+              - column:
+                  name: user_id
+                  type: int
+                  remarks: a user if the recipient has type user
+                  constraints:
+                    nullable: true
+                    referencedTableName: core_user
+                    referencedColumnNames: id
+                    foreignKeyName: fk_notification_recipient_user_id
+                    deleteCascade: true
+              - column:
+                  name: permissions_group_id
+                  type: int
+                  remarks: a permissions group if the recipient has type permissions_group
+                  constraints:
+                    nullable: true
+                    referencedTableName: permissions_group
+                    referencedColumnNames: id
+                    foreignKeyName: fk_notification_recipient_permissions_group_id
+                    deleteCascade: true
+              - column:
+                  name: details
+                  type: ${text.type}
+                  remarks: custom details for the recipient
+                  constraints:
+                    nullable: true
+              - column:
+                  name: created_at
+                  type: ${timestamp_type}
+                  remarks: The timestamp of when the recipient was created
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: ${timestamp_type}
+                  remarks: The timestamp of when the recipient was updated
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: v51.2024-09-05T08:00:09
+      author: qnkhuat
+      comment: index on notification_recipient.notification_handler_id
+      rollback: # not necessary, will be removed with the table
+      preConditions:
+        - not:
+            - indexExists:
+                tableName: notification_recipient
+                indexName: idx_notification_recipient_notification_handler_id
+      changes:
+        - createIndex:
+            tableName: notification_recipient
+            columns:
+              - column:
+                  name: notification_handler_id
+            indexName: idx_notification_recipient_notification_handler_id
+
+  - changeSet:
+      id: v51.2024-09-05T08:00:10
+      author: qnkhuat
+      comment: index on notification_recipient.user_id
+      rollback: # not necessary, will be removed with the table
+      preConditions:
+        - not:
+            - indexExists:
+                tableName: notification_recipient
+                indexName: idx_notification_recipient_user_id
+      changes:
+        - createIndex:
+            tableName: notification_recipient
+            columns:
+              - column:
+                  name: user_id
+            indexName: idx_notification_recipient_user_id
+
+  - changeSet:
+      id: v51.2024-09-05T08:00:11
+      author: qnkhuat
+      comment: index on notification_recipient.permissions_group_id
+      rollback: # not necessary, will be removed with the table
+      preConditions:
+        - not:
+            - indexExists:
+                tableName: notification_recipient
+                indexName: idx_notification_recipient_permissions_group_id
+      changes:
+        - createIndex:
+            tableName: notification_recipient
+            columns:
+              - column:
+                  name: permissions_group_id
+            indexName: idx_notification_recipient_permissions_group_id
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -9365,6 +9365,18 @@ databaseChangeLog:
                   constraints:
                     nullable: false
 
+  - changeSet:
+      id: v51.2024-09-05T08:00:03
+      author: qnkhuat
+      comment: index on notification_subscription.notification_id
+      changes:
+        - createIndex:
+            tableName: notification_subscription
+            columns:
+              - column:
+                  name: notification_id
+            indexName: idx_notification_subscription_notification_id
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -358,7 +358,7 @@ databaseChangeLog:
                   type: char(21)
                   remarks: Random NanoID tag for unique identity.
                   constraints:
-                    nullable: false
+                    nullable: true
                     unique: true
               - column:
                   name: collection_id

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -9369,6 +9369,7 @@ databaseChangeLog:
       id: v51.2024-09-05T08:00:03
       author: qnkhuat
       comment: index on notification_subscription.notification_id
+      rollback: # no need to rollback, will be removed with the table
       preConditions:
         - not:
             - indexExists:

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -9369,6 +9369,11 @@ databaseChangeLog:
       id: v51.2024-09-05T08:00:03
       author: qnkhuat
       comment: index on notification_subscription.notification_id
+      preConditions:
+        - not:
+            - indexExists:
+                tableName: notification_subscription
+                indexName: idx_notification_subscription_notification_id
       changes:
         - createIndex:
             tableName: notification_subscription

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -69,91 +69,6 @@ databaseChangeLog:
             path: initialization/metabase_h2.sql
             relativeToChangelogFile: true
 
-  - changeSet:
-      id: v51.2024-09-05T08:00:00
-      author: qnkhuat
-      comment: Create the notification table
-      preConditions:
-        - not:
-          - tableExists:
-              tableName: notification
-      changes:
-        - createTable:
-            tableName: notification
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: payload_type
-                  type: varchar(64)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: active
-                  type: ${boolean.type}
-                  constraints:
-                    nullable: false
-                  defaultValueBoolean: true
-              - column:
-                  name: created_at
-                  type: ${timestamp_type}
-                  constraints:
-                    nullable: false
-              - column:
-                  name: updated_at
-                  type: ${timestamp_type}
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v51.2024-09-05T08:00:01
-      author: qnkhuat
-      comment: Create the notification_subscription table
-      preConditions:
-        - not:
-          - tableExists:
-              tableName: notification_subscription
-      changes:
-        - createTable:
-            tableName: notification_subscription
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: notification_id
-                  type: int
-                  constraints:
-                    nullable: false
-                    referencedTableName: notification
-                    referencedColumnNames: id
-                    foreignKeyName: fk_notification_subscription_notification_id
-                    deleteCascade: true
-              - column:
-                  name: type
-                  type: varchar(64)
-                  constraints:
-                    nullable: false
-              - column:
-                  name: event_name
-                  type: varchar(64)
-                  constraints:
-                    nullable: true
-              - column:
-                  name: created_at
-                  type: ${timestamp_type}
-                  constraints:
-                    nullable: false
-
 # Note on rollback: migrations for v45 onwards should always include a rollback key unless they are supported
 # by Liquibase Auto Rollback. Most common changes are supported. See docs here:
 #
@@ -9354,6 +9269,101 @@ databaseChangeLog:
                   name: status
                   type: ${text.type}
                   remarks: running, failed, or completed
+
+  - changeSet:
+      id: v51.2024-09-05T08:00:00
+      author: qnkhuat
+      comment: Create the notification table
+      preConditions:
+        - not:
+          - tableExists:
+              tableName: notification
+      changes:
+        - createTable:
+            tableName: notification
+            remarks: join table that connect notification subscriptions and notification destinations
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: payload_type
+                  remarks: the type of the payload
+                  type: varchar(64)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: active
+                  remarks: whether the notification is active
+                  type: ${boolean.type}
+                  constraints:
+                    nullable: false
+                  defaultValueBoolean: true
+              - column:
+                  remarks: The timestamp of when the notification was created
+                  name: created_at
+                  type: ${timestamp_type}
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  remarks: The timestamp of when the notification was updated
+                  type: ${timestamp_type}
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: v51.2024-09-05T08:00:01
+      author: qnkhuat
+      comment: Create the notification_subscription table
+      preConditions:
+        - not:
+          - tableExists:
+              tableName: notification_subscription
+      changes:
+        - createTable:
+            remarks: which type of trigger a notification is subscribed to
+            tableName: notification_subscription
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: notification_id
+                  remarks: the notification that the subscription is connected to
+                  type: int
+                  constraints:
+                    nullable: false
+                    referencedTableName: notification
+                    referencedColumnNames: id
+                    foreignKeyName: fk_notification_subscription_notification_id
+                    deleteCascade: true
+              - column:
+                  name: type
+                  remarks: the type of the subscription
+                  type: varchar(64)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: event_name
+                  remarks: the event name of subscriptions with type :notification-subscription/system-event
+                  type: varchar(64)
+                  constraints:
+                    nullable: true
+              - column:
+                  name: created_at
+                  remarks: The timestamp of when the subscription was created
+                  type: ${timestamp_type}
+                  constraints:
+                    nullable: false
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -69,6 +69,91 @@ databaseChangeLog:
             path: initialization/metabase_h2.sql
             relativeToChangelogFile: true
 
+  - changeSet:
+      id: v51.2024-09-05T08:00:00
+      author: qnkhuat
+      comment: Create the notification table
+      preConditions:
+        - not:
+          - tableExists:
+              tableName: notification
+      changes:
+        - createTable:
+            tableName: notification
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: payload_type
+                  type: varchar(64)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: active
+                  type: ${boolean.type}
+                  constraints:
+                    nullable: false
+                  defaultValueBoolean: true
+              - column:
+                  name: created_at
+                  type: ${timestamp_type}
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: ${timestamp_type}
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: v51.2024-09-05T08:00:01
+      author: qnkhuat
+      comment: Create the notification_subscription table
+      preConditions:
+        - not:
+          - tableExists:
+              tableName: notification_subscription
+      changes:
+        - createTable:
+            tableName: notification_subscription
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: notification_id
+                  type: int
+                  constraints:
+                    nullable: false
+                    referencedTableName: notification
+                    referencedColumnNames: id
+                    foreignKeyName: fk_notification_subscription_notification_id
+                    deleteCascade: true
+              - column:
+                  name: type
+                  type: varchar(64)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: event_name
+                  type: varchar(64)
+                  constraints:
+                    nullable: true
+              - column:
+                  name: created_at
+                  type: ${timestamp_type}
+                  constraints:
+                    nullable: false
+
 # Note on rollback: migrations for v45 onwards should always include a rollback key unless they are supported
 # by Liquibase Auto Rollback. Most common changes are supported. See docs here:
 #

--- a/src/metabase/cmd/copy.clj
+++ b/src/metabase/cmd/copy.clj
@@ -47,6 +47,7 @@
   instances of entities before others that might depend on them, e.g. `Databases` before `Tables` before `Fields`."
   (concat
    [:model/Channel
+    :model/ChannelTemplate
     :model/Database
     :model/User
     :model/Setting
@@ -100,7 +101,9 @@
     :model/UserParameterValue
     ;; 51+
     :model/Notification
-    :model/NotificationSubscription]
+    :model/NotificationSubscription
+    :model/NotificationHandler
+    :model/NotificationRecipient]
    (when config/ee-available?
      [:model/GroupTableAccessPolicy
       :model/ConnectionImpersonation])))

--- a/src/metabase/cmd/copy.clj
+++ b/src/metabase/cmd/copy.clj
@@ -97,7 +97,10 @@
     :model/TablePrivileges
     :model/AuditLog
     :model/RecentViews
-    :model/UserParameterValue]
+    :model/UserParameterValue
+    ;; 49+
+    :model/Notification
+    :model/NotificationSubscription]
    (when config/ee-available?
      [:model/GroupTableAccessPolicy
       :model/ConnectionImpersonation])))

--- a/src/metabase/cmd/copy.clj
+++ b/src/metabase/cmd/copy.clj
@@ -98,7 +98,7 @@
     :model/AuditLog
     :model/RecentViews
     :model/UserParameterValue
-    ;; 49+
+    ;; 51+
     :model/Notification
     :model/NotificationSubscription]
    (when config/ee-available?

--- a/src/metabase/events/notification.clj
+++ b/src/metabase/events/notification.clj
@@ -1,0 +1,35 @@
+(ns metabase.events.notification
+  (:require
+   [java-time.api :as t]
+   [metabase.api.common :as api]
+   [metabase.events :as events]
+   [metabase.events.schema :as events.schema]
+   [metabase.models.notification :as models.notification]
+   [metabase.notification.core :as notification]
+   [metabase.public-settings :as public-settings]
+   [metabase.util.log :as log]
+   [methodical.core :as methodical]))
+
+(events.schema/topic->schema :event/user-invited)
+
+(derive :metabase/event ::notification)
+
+(def ^:private supported-topics #{:event/user-invited})
+
+(defn maybe-send-notification-for-topic!
+  [topic event]
+  (when-let [notifications (seq (and (supported-topics topic)
+                                     (models.notification/notifications-for-event topic)))]
+    (let [context (assoc event
+                         :settings {:application-name (public-settings/application-name)
+                                    :company          (public-settings/site-name)
+                                    :today            (t/format "MMM'&nbsp;'dd,'&nbsp;'yyyy" (t/zoned-date-time))}
+                         :current_user @api/*current-user*)]
+      (log/infof "Found %d notifications for event: %s" (count notifications) topic)
+      #_(doseq [notification notifications]
+          (notification/*send-notification!* notification context)))))
+
+
+(methodical/defmethod events/publish-event! ::notification
+  [topic event]
+  (maybe-send-notification-for-topic! topic event))

--- a/src/metabase/events/notification.clj
+++ b/src/metabase/events/notification.clj
@@ -1,35 +1,28 @@
 (ns metabase.events.notification
   (:require
-   [java-time.api :as t]
-   [metabase.api.common :as api]
    [metabase.events :as events]
-   [metabase.events.schema :as events.schema]
    [metabase.models.notification :as models.notification]
    [metabase.notification.core :as notification]
-   [metabase.public-settings :as public-settings]
    [metabase.util.log :as log]
    [methodical.core :as methodical]))
-
-(events.schema/topic->schema :event/user-invited)
 
 (derive :metabase/event ::notification)
 
 (def ^:private supported-topics #{:event/user-invited})
 
-(defn maybe-send-notification-for-topic!
-  [topic event]
-  (when-let [notifications (seq (and (supported-topics topic)
-                                     (models.notification/notifications-for-event topic)))]
-    (let [context (assoc event
-                         :settings {:application-name (public-settings/application-name)
-                                    :company          (public-settings/site-name)
-                                    :today            (t/format "MMM'&nbsp;'dd,'&nbsp;'yyyy" (t/zoned-date-time))}
-                         :current_user @api/*current-user*)]
-      (log/infof "Found %d notifications for event: %s" (count notifications) topic)
-      #_(doseq [notification notifications]
-          (notification/*send-notification!* notification context)))))
+(defn- notifications-for-topic
+  "Returns notifications for a given topic if it is supported and has notifications."
+  [topic]
+  (when (supported-topics topic)
+    (models.notification/notifications-for-event topic)))
 
+(defn- maybe-send-notification-for-topic!
+  [topic event-info]
+  (when-let [notifications (notifications-for-topic topic)]
+    (log/infof "Found %d notifications for event: %s" (count notifications) topic)
+    (doseq [notification notifications]
+      (notification/send-notification! (assoc notification :event-info event-info)))))
 
 (methodical/defmethod events/publish-event! ::notification
-  [topic event]
-  (maybe-send-notification-for-topic! topic event))
+  [topic event-info]
+  (maybe-send-notification-for-topic! topic event-info))

--- a/src/metabase/models/channel.clj
+++ b/src/metabase/models/channel.clj
@@ -10,49 +10,54 @@
 
 (set! *warn-on-reflection* true)
 
-(methodical/defmethod t2/table-name :model/Channel [_model] :channel)
+(methodical/defmethod t2/table-name :model/Channel         [_model] :channel)
+(methodical/defmethod t2/table-name :model/ChannelTemplate [_model] :channel_template)
 
 (defmethod mi/can-write? :model/Channel
   [& _]
   (or (mi/superuser?)
       (perms/current-user-has-application-permissions? :setting)))
 
-(defmethod serdes/entity-id "Channel"
-  [_ {:keys [name]}]
-  name)
+(defmethod serdes/entity-id "Channel" [_ {:keys [name]}] name)
 
-(defmethod serdes/hash-fields :model/Channel
-  [_database]
-  [:name :type])
+(defmethod serdes/hash-fields :model/Channel         [_instance] [:name :type])
+(defmethod serdes/hash-fields :model/ChannelTemplate [_instance] [:name :channel_type])
+
+(defmethod mi/can-write? :model/ChannelTemplate
+  [& _]
+  (or (mi/superuser?)
+      (perms/current-user-has-application-permissions? :setting)))
 
 (defmethod serdes/make-spec "Channel"
   [_model-name _opts]
   {:copy      [:name :description :type :details :active]
    :transform {:created_at (serdes/date)}})
 
+(defmethod serdes/make-spec "ChannelTemplate"
+  [_model-name _opts]
+  {:copy      [:name :channel_type :details :entity_id]
+   :transform {:created_at (serdes/date)}})
+
 (doto :model/Channel
   (derive :metabase/model)
   (derive :hook/timestamped?))
 
+(doto :model/ChannelTemplate
+  (derive :metabase/model)
+  (derive :hook/entity-id)
+  (derive :hook/timestamped?))
+
 (t2/deftransforms :model/Channel
-  {:type    mi/transform-keyword
+  {:type    (mi/transform-validator mi/transform-keyword (partial mi/assert-namespaced "channel"))
    :details mi/transform-encrypted-json})
 
-(defn- assert-channel-type
-  [{channel-type :type}]
-  (when-not (= "channel" (-> channel-type keyword namespace))
-    (throw (ex-info "Channel type must be a namespaced keyword like :channel/http" {:status-code  400
-                                                                                    :channel-type channel-type}))))
-
-(t2/define-before-insert :model/Channel
-  [instance]
-  (assert-channel-type instance)
-  instance)
+(t2/deftransforms :model/ChannelTemplate
+  {:channel_type  (mi/transform-validator mi/transform-keyword (partial mi/assert-namespaced "channel"))
+   :details       mi/transform-json})
 
 (t2/define-before-update :model/Channel
   [instance]
   (let [deactivation? (false? (:active (t2/changes instance)))]
-    (assert-channel-type instance)
     (when deactivation?
       (t2/delete! :model/PulseChannel :channel_id (:id instance)))
     (cond-> instance

--- a/src/metabase/models/channel.clj
+++ b/src/metabase/models/channel.clj
@@ -21,7 +21,7 @@
 (defmethod serdes/entity-id "Channel" [_ {:keys [name]}] name)
 
 (defmethod serdes/hash-fields :model/Channel         [_instance] [:name :type])
-(defmethod serdes/hash-fields :model/ChannelTemplate [_instance] [:name :channel_type])
+(defmethod serdes/hash-fields :model/ChannelTemplate [_instance] [:name :channel_type :details])
 
 (defmethod mi/can-write? :model/ChannelTemplate
   [& _]

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -252,7 +252,7 @@
    :out json-out-without-keywordization})
 
 (defn transform-validator
-  "Given a transform, returns a transform that call `assert-fn` on the value.
+  "Given a transform, returns a transform that call `assert-fn` on the "out" value.
 
   E.g: A keyword transfomer that throw an error if the value is not namespaced
     (transform-validator

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -5,6 +5,7 @@
    [cheshire.generate :as json.generate]
    [clojure.core.memoize :as memoize]
    [clojure.spec.alpha :as s]
+   [clojure.string :as str]
    [clojure.walk :as walk]
    [malli.core :as mc]
    [malli.error :as me]
@@ -250,6 +251,22 @@
   "Transform for json-no-keywordization"
   {:in  json-in
    :out json-out-without-keywordization})
+
+(mu/defn assert-enum
+  "Assert that a value is one of the values in `enum`."
+  [enum :- :set
+   value]
+  (when-not (contains? enum value)
+    (throw (ex-info (format "Invalid value %s. Must be one of %s" value (str/join ", " enum)) {:status-code 400
+                                                                                               :value       value}))))
+
+(mu/defn assert-namespaced
+  "Assert that a value is a namespaced keyword under `qualified-ns`."
+  [qualified-ns :- :string
+   value]
+  (when-not (= qualified-ns (-> value keyword namespace))
+    (throw (ex-info (format "Must be a namespaced keyword under :%s, got: %s" qualified-ns value) {:status-code 400
+                                                                                                   :value       value}))))
 
 (defn transform-validator
   "Given a transform, returns a transform that call `assert-fn` on the "out" value.

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -254,7 +254,7 @@
 
 (mu/defn assert-enum
   "Assert that a value is one of the values in `enum`."
-  [enum :- :set
+  [enum :- [:set :any]
    value]
   (when-not (contains? enum value)
     (throw (ex-info (format "Invalid value %s. Must be one of %s" value (str/join ", " enum)) {:status-code 400
@@ -262,14 +262,14 @@
 
 (mu/defn assert-namespaced
   "Assert that a value is a namespaced keyword under `qualified-ns`."
-  [qualified-ns :- :string
+  [qualified-ns :- string?
    value]
   (when-not (= qualified-ns (-> value keyword namespace))
     (throw (ex-info (format "Must be a namespaced keyword under :%s, got: %s" qualified-ns value) {:status-code 400
                                                                                                    :value       value}))))
 
 (defn transform-validator
-  "Given a transform, returns a transform that call `assert-fn` on the "out" value.
+  "Given a transform, returns a transform that call `assert-fn` on the \"out\" value.
 
   E.g: A keyword transfomer that throw an error if the value is not namespaced
     (transform-validator

--- a/src/metabase/models/notification.clj
+++ b/src/metabase/models/notification.clj
@@ -143,14 +143,15 @@
   Return the created notification."
   [notification subcriptions handlers+recipients]
   (t2/with-transaction [_conn]
-    (let [noti (t2/insert-returning-instance! :model/Notification notification)
-          noti-id      (:id noti)]
-      (t2/insert! :model/NotificationSubscription (map #(assoc % :notification_id noti-id) subcriptions))
+    (let [instance (t2/insert-returning-instance! :model/Notification notification)
+          id       (:id instance)]
+
+      (t2/insert! :model/NotificationSubscription (map #(assoc % :notification_id id) subcriptions))
       (doseq [handler handlers+recipients]
         (let [recipients (:recipients handler)
               handler    (-> handler
                              (dissoc :recipients)
-                             (assoc :notification_id noti-id))
+                             (assoc :notification_id id))
               handler-id (t2/insert-returning-pk! :model/NotificationHandler handler)]
           (t2/insert! :model/NotificationRecipient (map #(assoc % :notification_handler_id handler-id) recipients))))
-      noti)))
+      instance)))

--- a/src/metabase/models/notification.clj
+++ b/src/metabase/models/notification.clj
@@ -43,7 +43,7 @@
               :hook/timestamped?))))
 
 (defn notifications-for-event
-  "Find all notifications for a given event."
+  "Find all active notifications for a given event."
   [event-name]
   (t2/select :model/Notification
              {:select    [:n.*]

--- a/src/metabase/models/notification.clj
+++ b/src/metabase/models/notification.clj
@@ -22,7 +22,7 @@
   "Set of valid notification types."
   #{:notification/system-event})
 
-(def ^:private subscription-types #{:notification-subscription/event})
+(def ^:private subscription-types #{:notification-subscription/system-event})
 
 (t2/deftransforms :model/Notification
   {:payload_type (mi/transform-validator mi/transform-keyword (partial assert-enum notification-types))})
@@ -52,7 +52,7 @@
               :where     [:and
                           [:= :n.active true]
                           [:= :ns.event_name (u/qualified-name event-name)]
-                          [:= :ns.type (u/qualified-name :notification-subscription/event)]]}))
+                          [:= :ns.type (u/qualified-name :notification-subscription/system-event)]]}))
 
 (defn create-notification!
   "Create a new notification with `subsciptions`.

--- a/src/metabase/models/notification.clj
+++ b/src/metabase/models/notification.clj
@@ -1,6 +1,9 @@
 (ns metabase.models.notification
+  "A notification have:
+  - a payload
+  - more than one subscriptions
+  - more than one handlers where each handler has a channel, optionally a template, and more than one recpients."
   (:require
-   [clojure.string :as str]
    [metabase.models.interface :as mi]
    [metabase.util :as u]
    [methodical.core :as methodical]
@@ -10,37 +13,118 @@
 
 (methodical/defmethod t2/table-name :model/Notification             [_model] :notification)
 (methodical/defmethod t2/table-name :model/NotificationSubscription [_model] :notification_subscription)
-
-(defn- assert-enum
-  [enum value]
-  (assert (set? enum) "enum but be a set")
-  (when-not (contains? enum value)
-    (throw (ex-info (format "Invalid value %s. Must be one of %s" value (str/join ", " enum)) {:status-code 400
-                                                                                               :value       value}))))
+(methodical/defmethod t2/table-name :model/NotificationHandler      [_model] :notification_handler)
+(methodical/defmethod t2/table-name :model/NotificationRecipient    [_model] :notification_recipient)
 
 (def notification-types
   "Set of valid notification types."
   #{:notification/system-event})
 
-(def ^:private subscription-types #{:notification-subscription/system-event})
+(def ^:private subscription-types
+  #{:notification-subscription/system-event})
+
+(def ^:private notification-recipient-types
+  #{:notification-recipient/user
+    :notification-recipient/group
+    :notification-recipient/external-email})
 
 (t2/deftransforms :model/Notification
-  {:payload_type (mi/transform-validator mi/transform-keyword (partial assert-enum notification-types))})
+  {:payload_type (mi/transform-validator mi/transform-keyword (partial mi/assert-enum notification-types))})
 
 (t2/deftransforms :model/NotificationSubscription
-  {:type       (mi/transform-validator mi/transform-keyword (partial assert-enum subscription-types))
-   :event_name (mi/transform-validator mi/transform-keyword (fn [value]
-                                                              (when-not (= "event" (-> value keyword namespace))
-                                                                (throw (ex-info "Event name must be a namespaced keyword under :event" {:status-code 400
-                                                                                                                                        :value       value})))))})
+  {:type       (mi/transform-validator mi/transform-keyword (partial mi/assert-enum subscription-types))
+   :event_name (mi/transform-validator mi/transform-keyword (partial mi/assert-namespaced "event"))})
+
+(t2/deftransforms :model/NotificationHandler
+  {:channel_type (mi/transform-validator mi/transform-keyword (partial mi/assert-namespaced "channel"))})
+
+(t2/deftransforms :model/NotificationRecipient
+  {:type (mi/transform-validator mi/transform-keyword (partial mi/assert-enum notification-recipient-types))})
 
 (doseq [model [:model/Notification
-               :model/NotificationSubscription]]
+               :model/NotificationSubscription
+               :model/NotificationHandler
+               :model/NotificationRecipient]]
   (doto model
     (derive :metabase/model)
     (derive (if (= model :model/NotificationSubscription)
               :hook/created-at-timestamped?
               :hook/timestamped?))))
+
+(methodical/defmethod t2/batched-hydrate [:model/Notification :subscriptions]
+  "Batch hydration NotificationSubscriptions for a list of Notifications."
+  [_model k notifications]
+  (mi/instances-with-hydrated-data
+   notifications k
+   #(group-by :notification_id
+              (t2/select :model/NotificationSubscription :notification_id [:in (map :id notifications)]))
+   :id
+   {:default nil}))
+
+(methodical/defmethod t2/batched-hydrate [:model/Notification :handlers]
+  "Batch hydration NotificationHandlers for a list of Notifications"
+  [_model k notifications]
+  (mi/instances-with-hydrated-data
+   notifications k
+   #(group-by :notification_id
+              (t2/select :model/NotificationHandler :notification_id [:in (map :id notifications)]))
+   :id
+   {:default nil}))
+
+(methodical/defmethod t2/batched-hydrate [:model/NotificationHandler :channel]
+  "Batch hydration Channels for a list of NotificationHandlers"
+  [_model k notification-handlers]
+  (mi/instances-with-hydrated-data
+   notification-handlers k
+   #(t2/select-fn->fn :id identity :model/Channel
+                      :id [:in (map :channel_id notification-handlers)]
+                      :active true)
+   :channel_id
+   {:default nil}))
+
+(methodical/defmethod t2/batched-hydrate [:model/NotificationHandler :template]
+  "Batch hydration ChannelTemplates for a list of NotificationHandlers"
+  [_model k notification-handlers]
+  (mi/instances-with-hydrated-data
+   notification-handlers k
+   #(t2/select-fn->fn :id identity :model/ChannelTemplate
+                      :id [:in (map :template_id notification-handlers)])
+   :template_id
+   {:default nil}))
+
+(methodical/defmethod t2/batched-hydrate [:model/NotificationHandler :recipients]
+  "Batch hydration NotificationRecipients for a list of NotificationHandlers"
+  [_model k notification-handlers]
+  (mi/instances-with-hydrated-data
+   notification-handlers
+   k
+   #(group-by :notification_handler_id
+              (t2/select :model/NotificationRecipient :notification_handler_id [:in (map :id notification-handlers)]))
+   :id
+   {:default []}))
+
+(defn- cross-check-channel-type-and-template-type
+  [notification-handler]
+  (when-let [template-id (:template_id notification-handler)]
+    (let [channel-type  (:channel_type notification-handler)
+          template-type (t2/select-one-fn :channel_type [:model/ChannelTemplate :channel_type] template-id)]
+      (when (not= channel-type template-type)
+        (throw (ex-info "Channel type and template type mismatch"
+                        {:status        400
+                         :channel-type  channel-type
+                         :template-type template-type}))))))
+
+(t2/define-before-insert :model/NotificationHandler
+  [instance]
+  (cross-check-channel-type-and-template-type instance)
+  instance)
+
+(t2/define-before-update :model/NotificationHandler
+  [instance]
+  (when (or (contains? (t2/changes instance) :channel_id)
+            (contains? (t2/changes instance) :template_id))
+    (cross-check-channel-type-and-template-type instance)
+    instance))
 
 (defn notifications-for-event
   "Find all active notifications for a given event."
@@ -57,9 +141,16 @@
 (defn create-notification!
   "Create a new notification with `subsciptions`.
   Return the created notification."
-  [notification subcriptions]
+  [notification subcriptions handlers+recipients]
   (t2/with-transaction [_conn]
-    (let [noti    (t2/insert-returning-instance! :model/Notification notification)
-          noti-id (:id noti)]
+    (let [noti (t2/insert-returning-instance! :model/Notification notification)
+          noti-id      (:id noti)]
       (t2/insert! :model/NotificationSubscription (map #(assoc % :notification_id noti-id) subcriptions))
+      (doseq [handler handlers+recipients]
+        (let [recipients (:recipients handler)
+              handler    (-> handler
+                             (dissoc :recipients)
+                             (assoc :notification_id noti-id))
+              handler-id (t2/insert-returning-pk! :model/NotificationHandler handler)]
+          (t2/insert! :model/NotificationRecipient (map #(assoc % :notification_handler_id handler-id) recipients))))
       noti)))

--- a/src/metabase/models/notification.clj
+++ b/src/metabase/models/notification.clj
@@ -1,0 +1,47 @@
+(ns metabase.models.notification
+  (:require
+   [clojure.string :as str]
+   [metabase.models.interface :as mi]
+   [metabase.util :as u]
+   [methodical.core :as methodical]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(methodical/defmethod t2/table-name :model/Notification             [_model] :notification)
+(methodical/defmethod t2/table-name :model/NotificationSubscription [_model] :notification_subscription)
+
+(defn- assert-enum
+  [enum value]
+  (assert (set? enum) "enum but be a set")
+  (when-not (contains? enum value)
+    (throw (ex-info (format "Invalid value %s. Must be one of %s" value (str/join ", " enum)) {:status-code 400}))))
+
+(def ^:private notification-types #{:notification/system-event})
+(def ^:private subscription-types #{:notification-subscription/event})
+(def ^:private subscription-event-name-types (descendants :metabase/event))
+
+(t2/deftransforms :model/Notification
+  {:payload_type (mi/transform-validator mi/transform-keyword (partial assert-enum notification-types))})
+
+(t2/deftransforms :model/NotificationSubscription
+  {:type       (mi/transform-validator mi/transform-keyword (partial assert-enum subscription-types))
+   :event_name (mi/transform-validator mi/transform-keyword (partial assert-enum subscription-event-name-types))})
+
+(doseq [model [:model/Notification
+               :model/NotificationSubscription]]
+  (doto model
+    (derive :metabase/model)
+    (derive (if (= model :model/NotificationSubscription)
+              :hook/created-at-timestamped?
+              :hook/timestamped?))))
+
+(defn notifications-for-event
+  "Find all notifications for a given event."
+  [event-name]
+  (t2/select :model/Notification
+             {:select    [:n.*]
+              :from      [[:notification :n]]
+              :left-join [[:notification_subscription :ns] [:= :n.id :ns.notification_id]]
+              :where     [:and [:= :ns.event_name (u/qualified-name event-name)]
+                          [:= :ns.type (u/qualified-name :notification-subscription/event)]]}))

--- a/src/metabase/models/notification.clj
+++ b/src/metabase/models/notification.clj
@@ -53,6 +53,7 @@
                           [:= :n.active true]
                           [:= :ns.event_name (u/qualified-name event-name)]
                           [:= :ns.type (u/qualified-name :notification-subscription/event)]]}))
+
 (defn create-notification!
   "Create a new notification with `subsciptions`.
   Return the created notification."

--- a/src/metabase/models/notification.clj
+++ b/src/metabase/models/notification.clj
@@ -15,18 +15,24 @@
   [enum value]
   (assert (set? enum) "enum but be a set")
   (when-not (contains? enum value)
-    (throw (ex-info (format "Invalid value %s. Must be one of %s" value (str/join ", " enum)) {:status-code 400}))))
+    (throw (ex-info (format "Invalid value %s. Must be one of %s" value (str/join ", " enum)) {:status-code 400
+                                                                                               :value       value}))))
 
-(def ^:private notification-types #{:notification/system-event})
+(def notification-types
+  "Set of valid notification types."
+  #{:notification/system-event})
+
 (def ^:private subscription-types #{:notification-subscription/event})
-(def ^:private subscription-event-name-types (descendants :metabase/event))
 
 (t2/deftransforms :model/Notification
   {:payload_type (mi/transform-validator mi/transform-keyword (partial assert-enum notification-types))})
 
 (t2/deftransforms :model/NotificationSubscription
   {:type       (mi/transform-validator mi/transform-keyword (partial assert-enum subscription-types))
-   :event_name (mi/transform-validator mi/transform-keyword (partial assert-enum subscription-event-name-types))})
+   :event_name (mi/transform-validator mi/transform-keyword (fn [value]
+                                                              (when-not (= "event" (-> value keyword namespace))
+                                                                (throw (ex-info "Event name must be a namespaced keyword under :event" {:status-code 400
+                                                                                                                                        :value       value})))))})
 
 (doseq [model [:model/Notification
                :model/NotificationSubscription]]
@@ -43,5 +49,16 @@
              {:select    [:n.*]
               :from      [[:notification :n]]
               :left-join [[:notification_subscription :ns] [:= :n.id :ns.notification_id]]
-              :where     [:and [:= :ns.event_name (u/qualified-name event-name)]
+              :where     [:and
+                          [:= :n.active true]
+                          [:= :ns.event_name (u/qualified-name event-name)]
                           [:= :ns.type (u/qualified-name :notification-subscription/event)]]}))
+(defn create-notification!
+  "Create a new notification with `subsciptions`.
+  Return the created notification."
+  [notification subcriptions]
+  (t2/with-transaction [_conn]
+    (let [noti    (t2/insert-returning-instance! :model/Notification notification)
+          noti-id (:id noti)]
+      (t2/insert! :model/NotificationSubscription (map #(assoc % :notification_id noti-id) subcriptions))
+      noti)))

--- a/src/metabase/notification/core.clj
+++ b/src/metabase/notification/core.clj
@@ -1,1 +1,26 @@
-(ns metabase.notification.core)
+(ns metabase.notification.core
+  (:require
+   [metabase.models.notification :as models.notification]
+   [metabase.util.malli :as mu]
+   [metabase.util.malli.schema :as ms]))
+
+(def ^:private Notification
+  [:map {:closed true}
+   [:id           ms/PositiveInt]
+   [:active       :boolean]
+   [:payload_type (into [:enum] models.notification/notification-types)]
+   [:created_at   :any]
+   [:updated_at   :any]])
+
+(def ^:private NotificationInfo
+  [:multi {:dispatch :payload_type}
+   [:notification/system-event [:merge
+                                Notification
+                                [:map {:closed true}
+                                 ;; TODO: event-info schema
+                                 [:event-info [:maybe :map]]]]]])
+
+(mu/defn send-notification!
+  "Send a `notification`"
+  [_notification :- NotificationInfo]
+  ::noop)

--- a/src/metabase/notification/core.clj
+++ b/src/metabase/notification/core.clj
@@ -1,0 +1,1 @@
+(ns metabase.notification.core)

--- a/test/metabase/events/notification_test.clj
+++ b/test/metabase/events/notification_test.clj
@@ -28,17 +28,17 @@
             noti-1     (models.notification/create-notification!
                         {:payload_type :notification/system-event
                          :active       true}
-                        [{:type       :notification-subscription/event
+                        [{:type       :notification-subscription/system-event
                           :event_name topic}])
             noti-2     (models.notification/create-notification!
                         {:payload_type :notification/system-event
                          :active       true}
-                        [{:type       :notification-subscription/event
+                        [{:type       :notification-subscription/system-event
                           :event_name topic}])
             _inactive  (models.notification/create-notification!
                         {:payload_type :notification/system-event
                          :active       false}
-                        [{:type       :notification-subscription/event
+                        [{:type       :notification-subscription/system-event
                           :event_name topic}])
             sent-notis (atom #{})]
         (testing "publishing event will send all the actively subscribed notifciations"
@@ -57,7 +57,7 @@
         (models.notification/create-notification!
          {:payload_type :notification/system-event
           :active       true}
-         [{:type       :notification-subscription/event
+         [{:type       :notification-subscription/system-event
            :event_name topic}])
         (testing "publish an event that is not supported for notifications will not send any notifications"
           (with-redefs [notification/send-notification!      (fn [notification] (swap! sent-notis conj notification))

--- a/test/metabase/events/notification_test.clj
+++ b/test/metabase/events/notification_test.clj
@@ -29,17 +29,20 @@
                         {:payload_type :notification/system-event
                          :active       true}
                         [{:type       :notification-subscription/system-event
-                          :event_name topic}])
+                          :event_name topic}]
+                        nil)
             noti-2     (models.notification/create-notification!
                         {:payload_type :notification/system-event
                          :active       true}
                         [{:type       :notification-subscription/system-event
-                          :event_name topic}])
+                          :event_name topic}]
+                        nil)
             _inactive  (models.notification/create-notification!
                         {:payload_type :notification/system-event
                          :active       false}
                         [{:type       :notification-subscription/system-event
-                          :event_name topic}])
+                          :event_name topic}]
+                        nil)
             sent-notis (atom #{})]
         (testing "publishing event will send all the actively subscribed notifciations"
           (with-redefs [notification/send-notification!      (fn [notification] (swap! sent-notis conj notification))
@@ -58,7 +61,8 @@
          {:payload_type :notification/system-event
           :active       true}
          [{:type       :notification-subscription/system-event
-           :event_name topic}])
+           :event_name topic}]
+         nil)
         (testing "publish an event that is not supported for notifications will not send any notifications"
           (with-redefs [notification/send-notification!      (fn [notification] (swap! sent-notis conj notification))
                         events.notification/supported-topics #{}]

--- a/test/metabase/events/notification_test.clj
+++ b/test/metabase/events/notification_test.clj
@@ -1,0 +1,66 @@
+(ns metabase.events.notification-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.events :as events]
+   [metabase.events.notification :as events.notification]
+   [metabase.models.notification :as models.notification]
+   [metabase.notification.core :as notification]
+   [metabase.test :as mt]))
+
+(def supported-topics @#'events.notification/supported-topics)
+
+(defmacro with-temporary-event-topics
+  "Temporarily make `topics` valid event topics."
+  [topics & body]
+  `(let [topics# ~topics]
+     (try
+       (doseq [topic# topics#]
+         (derive topic# :metabase/event))
+       ~@body
+       (finally
+         (doseq [topic# topics#]
+           (underive topic# :metabase/event))))))
+
+(deftest supported-events-with-notification-will-be-sent-test
+  (mt/with-model-cleanup [:model/Notification]
+    (with-temporary-event-topics #{:event/test-notification}
+      (let [topic      :event/test-notification
+            noti-1     (models.notification/create-notification!
+                        {:payload_type :notification/system-event
+                         :active       true}
+                        [{:type       :notification-subscription/event
+                          :event_name topic}])
+            noti-2     (models.notification/create-notification!
+                        {:payload_type :notification/system-event
+                         :active       true}
+                        [{:type       :notification-subscription/event
+                          :event_name topic}])
+            _inactive  (models.notification/create-notification!
+                        {:payload_type :notification/system-event
+                         :active       false}
+                        [{:type       :notification-subscription/event
+                          :event_name topic}])
+            sent-notis (atom #{})]
+        (testing "publishing event will send all the actively subscribed notifciations"
+          (with-redefs [notification/send-notification!      (fn [notification] (swap! sent-notis conj notification))
+                        events.notification/supported-topics #{:event/test-notification}]
+            (events/publish-event! topic {::hi true})
+            (is (= #{[(:id noti-1) {::hi true}]
+                     [(:id noti-2) {::hi true}]}
+                   (set (map (juxt :id :event-info) @sent-notis))))))))))
+
+(deftest unsupported-events-will-not-send-notification-test
+  (mt/with-model-cleanup [:model/Notification]
+    (with-temporary-event-topics #{:event/unsupported-topic}
+      (let [topic      :event/unsupported-topic
+            sent-notis (atom #{})]
+        (models.notification/create-notification!
+         {:payload_type :notification/system-event
+          :active       true}
+         [{:type       :notification-subscription/event
+           :event_name topic}])
+        (testing "publish an event that is not supported for notifications will not send any notifications"
+          (with-redefs [notification/send-notification!      (fn [notification] (swap! sent-notis conj notification))
+                        events.notification/supported-topics #{}]
+            (events/publish-event! :event/unsupported-topic {::hi true})
+            (is (empty? @sent-notis))))))))

--- a/test/metabase/models/notification_test.clj
+++ b/test/metabase/models/notification_test.clj
@@ -24,7 +24,7 @@
 (deftest notification-subscription-type-test
   (mt/with-temp [:model/Notification {noti-id :id} {}]
     (testing "success path"
-      (let [sub-id (t2/insert-returning-pk! :model/NotificationSubscription {:type            :notification-subscription/event
+      (let [sub-id (t2/insert-returning-pk! :model/NotificationSubscription {:type            :notification-subscription/system-event
                                                                              :event_name      :event/card-create
                                                                              :notification_id noti-id})]
         (is (some? (t2/select-one :model/NotificationSubscription sub-id)))))
@@ -38,14 +38,14 @@
 (deftest notification-subscription-event-name-test
   (mt/with-temp [:model/Notification {noti-id :id} {}]
     (testing "success path"
-      (let [sub-id (t2/insert-returning-pk! :model/NotificationSubscription {:type            :notification-subscription/event
+      (let [sub-id (t2/insert-returning-pk! :model/NotificationSubscription {:type            :notification-subscription/system-event
                                                                              :event_name      (first (descendants :metabase/event))
                                                                              :notification_id noti-id})]
         (is (some? (t2/select-one :model/NotificationSubscription sub-id)))))
 
     (testing "failed if type is invalid"
       (is (thrown-with-msg? Exception #"Event name must be a namespaced keyword under :event"
-                            (t2/insert! :model/NotificationSubscription {:type           :notification-subscription/event
+                            (t2/insert! :model/NotificationSubscription {:type           :notification-subscription/system-event
                                                                          :event_name     :user-join
                                                                          :notification_id noti-id}))))))
 
@@ -54,11 +54,11 @@
    :active       true})
 
 (def default-user-invited-subscription
-  {:type       :notification-subscription/event
+  {:type       :notification-subscription/system-event
    :event_name :event/user-invited})
 
 (def default-card-created-subscription
-  {:type       :notification-subscription/event
+  {:type       :notification-subscription/system-event
    :event_name :event/card-create})
 
 (deftest create-notification!-test

--- a/test/metabase/models/notification_test.clj
+++ b/test/metabase/models/notification_test.clj
@@ -1,7 +1,9 @@
 (ns metabase.models.notification-test
   (:require
    [clojure.test :refer :all]
+   [metabase.api.channel-test :as api.channel-test]
    [metabase.models.notification :as models.notification]
+   [metabase.models.permissions-group :as perms-group]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 
@@ -44,7 +46,7 @@
         (is (some? (t2/select-one :model/NotificationSubscription sub-id)))))
 
     (testing "failed if type is invalid"
-      (is (thrown-with-msg? Exception #"Event name must be a namespaced keyword under :event"
+      (is (thrown-with-msg? Exception #"Must be a namespaced keyword under :event, got: :user-join"
                             (t2/insert! :model/NotificationSubscription {:type           :notification-subscription/system-event
                                                                          :event_name     :user-join
                                                                          :notification_id noti-id}))))))
@@ -61,20 +63,90 @@
   {:type       :notification-subscription/system-event
    :event_name :event/card-create})
 
-(deftest create-notification!-test
+(deftest create-notification!+hydration-keys-test
   (mt/with-model-cleanup [:model/Notification]
-    (testing "create a notification with 2 subscriptions"
+    (mt/with-temp [:model/Channel         chn-1   (assoc api.channel-test/default-test-channel :name "Channel 1")
+                   :model/Channel         chn-2   (assoc api.channel-test/default-test-channel :name "Channel 2")
+                   :model/ChannelTemplate tmpl-1 {:channel_type (:type chn-1)
+                                                  :name         "My Template"}]
+      (testing "create a notification with 2 subscriptions with 2 handlers that has 2 recipients"
+        (let [noti (models.notification/create-notification!
+                    default-system-event-notification
+                    [default-user-invited-subscription
+                     default-card-created-subscription]
+                    [{:channel_type (:type chn-1)
+                      :channel_id   (:id chn-1)
+                      :template_id  (:id tmpl-1)
+                      :recipients   [{:type     :notification-recipient/user
+                                      :user_id  (mt/user->id :rasta)}
+                                     {:type                 :notification-recipient/group
+                                      :permissions_group_id (:id (perms-group/all-users))}]}
+                     {:channel_type (:type chn-1)
+                      :channel_id   (:id chn-2)
+                      :recipients   [{:type     :notification-recipient/user
+                                      :user_id  (mt/user->id :crowberto)}
+                                     {:type     :notification-recipient/group
+                                      :permissions_group_id (:id (perms-group/admin))}]}])]
+          (is (=? {:id            (:id noti)
+                   :payload_type  :notification/system-event
+                   :active        true
+                   :subscriptions [default-user-invited-subscription
+                                   default-card-created-subscription]
+                   :handlers      [{:channel_type (:type chn-1)
+                                    :channel_id   (:id chn-1)
+                                    :channel      {:id (:id chn-1)
+                                                   :name "Channel 1"}
+                                    :template_id  (:id tmpl-1)
+                                    :template     {:id (:id tmpl-1)
+                                                   :name "My Template"}
+                                    :recipients   [{:type     :notification-recipient/user
+                                                    :user_id  (mt/user->id :rasta)}
+                                                   {:type                 :notification-recipient/group
+                                                    :permissions_group_id (:id (perms-group/all-users))}]}
+                                   {:channel_type (:type chn-2)
+                                    :channel_id   (:id chn-2)
+                                    :channel      {:id   (:id chn-2)
+                                                   :name "Channel 2"}
+                                    :template_id  nil
+                                    :template     nil
+                                    :recipients   [{:type     :notification-recipient/user
+                                                    :user_id  (mt/user->id :crowberto)}
+                                                   {:type     :notification-recipient/group
+                                                    :permissions_group_id (:id (perms-group/admin))}]}]}
+                  (t2/hydrate (t2/select-one :model/Notification (:id noti))
+                              :subscriptions
+                              [:handlers :recipients :channel :template]))))))))
+
+(deftest delete-template-set-null-on-existing-handlers-test
+  (testing "if a channel template is deleted, then set null on existing notification_handler"
+    (mt/with-temp [:model/Channel         chn-1   (assoc api.channel-test/default-test-channel :name "Channel 1")
+                   :model/ChannelTemplate tmpl-1 {:channel_type (:type chn-1)}]
       (let [noti (models.notification/create-notification!
                   default-system-event-notification
-                  [default-user-invited-subscription
-                   default-card-created-subscription])]
-        (testing "return the created notification"
-          (is (= (t2/select-one :model/Notification (:id noti))
-                 noti)))
+                  [default-user-invited-subscription]
+                  [{:channel_type (:type chn-1)
+                    :channel_id   (:id chn-1)
+                    :template_id  (:id tmpl-1)
+                    :recipients   [{:type     :notification-recipient/user
+                                    :user_id  (mt/user->id :rasta)}]}])]
+        (t2/delete! :model/ChannelTemplate (:id tmpl-1))
+        (is (=? {:template_id nil} (t2/select-one :model/NotificationHandler :notification_id (:id noti))))))))
 
-        (testing "there are 2 subscriptions"
-          (is (= [default-card-created-subscription
-                  default-user-invited-subscription]
-                 (t2/select [:model/NotificationSubscription :type :event_name]
-                            :notification_id (:id noti)
-                            {:order-by [:event_name]}))))))))
+(deftest cross-check-channel-type-and-template-type-test
+  (testing "can't create a handler with a template that has different channel type"
+    (mt/with-temp [:model/Channel         chn-1  {:type    :channel/slack}
+                   :model/ChannelTemplate tmpl-1 {:channel_type :channel/email}]
+      (is (thrown-with-msg? Exception #"Channel type and template type mismatch"
+                            (t2/insert! :model/NotificationHandler {:channel_type :channel/slack
+                                                                    :channel_id   (:id chn-1)
+                                                                    :template_id  (:id tmpl-1)})))))
+
+  (testing "can't update a handler with a template that has different channel type"
+    (mt/with-temp [:model/ChannelTemplate     email-tmpl {:channel_type :channel/email}
+                   :model/ChannelTemplate     slack-tmpl {:channel_type :channel/slack}
+                   :model/Notification        noti       {}
+                   :model/NotificationHandler handler    {:channel_type    :channel/slack
+                                                          :notification_id (:id noti)
+                                                          :template_id     (:id slack-tmpl)}]
+      (is (thrown-with-msg? Exception #"Channel type and template type mismatch"
+                            (t2/update! :model/NotificationHandler (:id handler) {:template_id (:id email-tmpl)}))))))

--- a/test/metabase/models/notification_test.clj
+++ b/test/metabase/models/notification_test.clj
@@ -11,7 +11,7 @@
 
 (deftest notification-type-test
   (mt/with-model-cleanup [:model/Notification]
-    (testing "success path"
+    (testing "success if :payload_type is supported"
       (let [noti-id (t2/insert-returning-pk! :model/Notification {:payload_type :notification/system-event
                                                                   :created_at   :%now
                                                                   :updated_at   :%now})]

--- a/test/metabase/models/notification_test.clj
+++ b/test/metabase/models/notification_test.clj
@@ -1,0 +1,70 @@
+(ns metabase.models.notification-test
+  (:require
+   [cheshire.core :as json]
+   [clojure.set :as set]
+   [clojure.test :refer :all]
+   [java-time.api :as t]
+   [metabase.audit :as audit]
+   [metabase.config :as config]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.metadata.jvm :as lib.metadata.jvm]
+   [metabase.models.card :as card]
+   [metabase.models.interface :as mi]
+   [metabase.models.parameter-card :as parameter-card]
+   [metabase.models.revision :as revision]
+   [metabase.models.serialization :as serdes]
+   [metabase.query-processor.card-test :as qp.card-test]
+   [metabase.query-processor.preprocess :as qp.preprocess]
+   [metabase.test :as mt]
+   [metabase.test.util :as tu]
+   [metabase.util :as u]
+   [toucan2.core :as t2]
+   [toucan2.tools.with-temp :as t2.with-temp]))
+
+;; ------------------------------------------------------------------------------------------------;;
+;;                                      Life cycle test                                            ;;
+;; ------------------------------------------------------------------------------------------------;;
+
+(deftest notification-type-test
+  (mt/with-model-cleanup [:model/Notification]
+    (testing "success path"
+      (let [noti-id (t2/insert-returning-pk! :model/Notification {:payload_type :notification/system-event
+                                                                  :created_at   :%now
+                                                                  :updated_at   :%now})]
+        (is (some? (t2/select-one :model/Notification noti-id)))))
+
+    (testing "failed if payload_type is invalid"
+      (is (thrown-with-msg? Exception #"Invalid value :notification/not-existed\. Must be one of .*"
+                            (t2/insert! :model/Notification {:payload_type :notification/not-existed}))))))
+
+
+(deftest notification-subscription-type-test
+  (mt/with-temp [:model/Notification {noti-id :id} {}]
+    (testing "success path"
+      (let [sub-id (t2/insert-returning-pk! :model/NotificationSubscription {:type            :notification-subscription/event
+                                                                             :event_name      :event/card-create
+                                                                             :notification_id noti-id})]
+        (is (some? (t2/select-one :model/NotificationSubscription sub-id)))))
+
+    (testing "failed if type is invalid"
+      (is (thrown-with-msg? Exception #"Invalid value :notification-subscription/not-existed\. Must be one of .*"
+                            (t2/insert! :model/NotificationSubscription {:type           :notification-subscription/not-existed
+                                                                         :event_name     :event/card-create
+                                                                         :notification_id noti-id}))))))
+
+
+
+(deftest notification-subscription-event-name-test
+  (mt/with-temp [:model/Notification {noti-id :id} {}]
+    (testing "success path"
+      (let [sub-id (t2/insert-returning-pk! :model/NotificationSubscription {:type            :notification-subscription/event
+                                                                             :event_name      (first (descendants :metabase/event))
+                                                                             :notification_id noti-id})]
+        (is (some? (t2/select-one :model/NotificationSubscription sub-id)))))
+
+    (testing "failed if type is invalid"
+      (is (thrown-with-msg? Exception #"Invalid value :event/not-existed\. Must be one of .*"
+                            (t2/insert! :model/NotificationSubscription {:type           :notification-subscription/event
+                                                                         :event_name     :event/not-existed
+                                                                         :notification_id noti-id}))))))

--- a/test/metabase/models/notification_test.clj
+++ b/test/metabase/models/notification_test.clj
@@ -21,7 +21,6 @@
       (is (thrown-with-msg? Exception #"Invalid value :notification/not-existed\. Must be one of .*"
                             (t2/insert! :model/Notification {:payload_type :notification/not-existed}))))))
 
-
 (deftest notification-subscription-type-test
   (mt/with-temp [:model/Notification {noti-id :id} {}]
     (testing "success path"
@@ -66,9 +65,9 @@
   (mt/with-model-cleanup [:model/Notification]
     (testing "create a notification with 2 subscriptions"
       (let [noti (models.notification/create-notification!
-                    default-system-event-notification
-                    [default-user-invited-subscription
-                     default-card-created-subscription])]
+                  default-system-event-notification
+                  [default-user-invited-subscription
+                   default-card-created-subscription])]
         (testing "return the created notification"
           (is (= (t2/select-one :model/Notification (:id noti))
                  noti)))

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -125,7 +125,13 @@
 
    :model/Channel
    (fn [_] (default-timestamped
-            {:name (u.random/random-name)}))
+            {:name    (u.random/random-name)
+             :details {}}))
+
+   :model/ChannelTemplate
+   (fn [_] (default-timestamped
+            {:name         (u.random/random-name)
+             :channel_type :email}))
 
    :model/Dashboard
    (fn [_] (default-timestamped

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -192,12 +192,12 @@
 
    :model/Notification
    (fn [_] (default-timestamped
-             {:payload_type :notification/system-event
-              :active       true}))
+            {:payload_type :notification/system-event
+             :active       true}))
 
    :model/NotificationSubscription
    (fn [_] (default-created-at-timestamped
-             {}))
+            {}))
 
    :model/QueryExecution
    (fn [_] {:hash         (qp.util/query-hash {})

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -190,6 +190,15 @@
              :name       (u.random/random-name)
              :content    "1 = 1"}))
 
+   :model/Notification
+   (fn [_] (default-timestamped
+             {:payload_type :notification/system-event
+              :active       true}))
+
+   :model/NotificationSubscription
+   (fn [_] (default-created-at-timestamped
+             {}))
+
    :model/QueryExecution
    (fn [_] {:hash         (qp.util/query-hash {})
             :running_time 1

--- a/test_resources/serialization_baseline/collections/channels/My HTTP channel_my_http_channel.yaml
+++ b/test_resources/serialization_baseline/collections/channels/My HTTP channel_my_http_channel.yaml
@@ -1,5 +1,5 @@
 active: true
-created_at: '2024-08-30T13:26:36.366837Z'
+created_at: '2024-09-11T15:36:01.845352Z'
 description: null
 details:
   auth-method: none

--- a/test_resources/serialization_baseline/collections/channeltemplates/M1T0161thjdnkbLjboZSL_my_template.yaml
+++ b/test_resources/serialization_baseline/collections/channeltemplates/M1T0161thjdnkbLjboZSL_my_template.yaml
@@ -1,0 +1,10 @@
+channel_type: channel/http
+created_at: '2024-09-11T15:36:01.846473Z'
+details:
+  my-custom-template: true
+entity_id: M1T0161thjdnkbLjboZSL
+name: My template
+serdes/meta:
+- id: M1T0161thjdnkbLjboZSL
+  label: my_template
+  model: ChannelTemplate


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/47438

This resolves the first 2 points of the milestone 1:
- It adds 2 tables: notification and notification_subscription
- Introduces a new event type: `:event/notification` and makes sure all published events will trigger `event/notification`. This then checks for subscribed notifications and sends them.
- introduce a new module: notification. However, the functionality is currently limited.

In short, this PR tries to make the bridge between system event <-> notification.

In the next PR, we will then work on the notification <-> channel part.