### PR TITLE
Fix missed spots still using dynamic user vars for search

### DIFF
--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -589,7 +589,7 @@
                                          [:permissions_group :pg] [:= :pg.id :p.group_id]
                                          [:permissions_group_membership :pgm] [:= :pgm.group_id :pg.id]]
                                 :where  [:and
-                                         [:= :pgm.user_id api/*current-user-id*]
+                                         [:= :pgm.user_id current-user-id]
                                          [:= :p.perm_type "perms/collection-access"]
                                          [:or
                                           [:= :p.perm_value "read-and-write"]


### PR DESCRIPTION
Missed two spots where we still used dynamic variables when constructing the searchable entities query. One of them was a blocker for building the search index for some of the models.

We still use dynamic variables for on the non-trivial indexed-entities search path, and in the rendering, but neither of those are blockers for me.