### PR TITLE
fix(sdk): default font not working

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkThemeProvider.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkThemeProvider.tsx
@@ -8,6 +8,7 @@ import {
 } from "embedding-sdk/lib/theme";
 import { useSelector } from "metabase/lib/redux";
 import { getSettings } from "metabase/selectors/settings";
+import { getFont } from "metabase/styled-components/selectors";
 import { getMetabaseSdkCssVariables } from "metabase/styled-components/theme/css-variables";
 import { ThemeProvider, useMantineTheme } from "metabase/ui";
 import { getApplicationColors } from "metabase-enterprise/settings/selectors";
@@ -32,13 +33,15 @@ export const SdkThemeProvider = ({ theme, children }: Props) => {
 
   return (
     <ThemeProvider theme={themeOverride}>
-      <GlobalStyles />
+      <SDKGlobalStyles />
       {children}
     </ThemeProvider>
   );
 };
 
-function GlobalStyles() {
+function SDKGlobalStyles() {
   const theme = useMantineTheme();
-  return <Global styles={getMetabaseSdkCssVariables(theme)} />;
+  const font = useSelector(getFont);
+
+  return <Global styles={getMetabaseSdkCssVariables(theme, font)} />;
 }

--- a/enterprise/frontend/src/embedding-sdk/store/index.ts
+++ b/enterprise/frontend/src/embedding-sdk/store/index.ts
@@ -20,6 +20,7 @@ export const sdkReducers = {
 
 export const store = getStore(sdkReducers, null, {
   embed: {
+    options: {},
     isEmbeddingSdk: true,
   },
   app: {

--- a/frontend/src/metabase/styled-components/selectors.ts
+++ b/frontend/src/metabase/styled-components/selectors.ts
@@ -7,8 +7,8 @@ import { getSettings } from "metabase/selectors/settings";
 export const getFont = createSelector(
   [getSettings, getEmbedOptions],
   (settings, embedOptions) => {
-    if (embedOptions.font) {
-      return embedOptions.font;
+    if (embedOptions?.font) {
+      return embedOptions?.font;
     } else if (!_.isEmpty(settings["application-font-files"])) {
       return "Custom";
     } else {

--- a/frontend/src/metabase/styled-components/selectors.ts
+++ b/frontend/src/metabase/styled-components/selectors.ts
@@ -7,8 +7,8 @@ import { getSettings } from "metabase/selectors/settings";
 export const getFont = createSelector(
   [getSettings, getEmbedOptions],
   (settings, embedOptions) => {
-    if (embedOptions?.font) {
-      return embedOptions?.font;
+    if (embedOptions.font) {
+      return embedOptions.font;
     } else if (!_.isEmpty(settings["application-font-files"])) {
       return "Custom";
     } else {

--- a/frontend/src/metabase/styled-components/theme/css-variables.ts
+++ b/frontend/src/metabase/styled-components/theme/css-variables.ts
@@ -34,9 +34,10 @@ export function getMetabaseCssVariables(theme: MantineTheme) {
   `;
 }
 
-export function getMetabaseSdkCssVariables(theme: MantineTheme) {
+export function getMetabaseSdkCssVariables(theme: MantineTheme, font: string) {
   return css`
     :root {
+      --mb-default-font-family: ${font};
       ${getSdkDesignSystemCssVariables(theme)}
       ${getThemeSpecificCssVariables(theme)}
     }
@@ -53,8 +54,6 @@ export function getMetabaseSdkCssVariables(theme: MantineTheme) {
  **/
 function getSdkDesignSystemCssVariables(theme: MantineTheme) {
   return css`
-    --mb-default-font-family: "${theme.fontFamily}";
-
     /* Semantic colors */
     /* Dynamic colors from SDK */
     ${Object.entries(SDK_TO_MAIN_APP_COLORS_MAPPING).flatMap(


### PR DESCRIPTION

Fixes the font being the literal string `"var(....` if we don't pass a theme to the provider:

<img width="317" alt="image" src="https://github.com/user-attachments/assets/6fe954ec-c979-4435-9bc5-183ee2f9f239">

Part of https://github.com/metabase/metabase/issues/47624

PS: i'll like to add some test as this was a regression, but possibly when i'll finish with https://github.com/metabase/metabase/issues/47624 