### PR TITLE
perf: Use more efficient query validation when the argument is valid

### DIFF
--- a/src/metabase/legacy_mbql/util.cljc
+++ b/src/metabase/legacy_mbql/util.cljc
@@ -849,6 +849,16 @@
            [:field (id :guard integer?) opts]
            [id (:source-field opts)]))))
 
+(defn pred-matches-form?
+  "Check if `form` or any of its children forms match `pred`. This function is used for validation; during normal
+  operation it will never match, so calling this function before `matching-locations` is more efficient."
+  [form pred]
+  (cond
+    (pred form)        true
+    (map? form)        (reduce-kv (fn [b _ v] (or b (pred-matches-form? v pred))) false form)
+    (sequential? form) (reduce (fn [b x] (or b (pred-matches-form? x pred))) false form)
+    :else              false))
+
 (defn matching-locations
   "Find the forms matching pred, returns a list of tuples of location (as used in get-in) and the match."
   [form pred]

--- a/src/metabase/lib/schema.cljc
+++ b/src/metabase/lib/schema.cljc
@@ -99,8 +99,8 @@
 
 (defn- bad-ref-clause? [ref-type valid-ids x]
   (and (vector? x)
-       (= ref-type (first x))
-       (not (contains? valid-ids (get x 2)))))
+       (= ref-type (nth x 0 nil))
+       (not (contains? valid-ids (nth x 2 nil)))))
 
 (defn- stage-with-joins-and-namespaced-keys-removed
   "For ref validation purposes we should ignore `:joins` and any namespaced keys that might be used to record additional
@@ -114,14 +114,18 @@
              stage stage))
 
 (defn- expression-ref-errors-for-stage [stage]
-  (let [expression-names (into #{} (map (comp :lib/expression-name second)) (:expressions stage))]
-    (mbql.u/matching-locations (stage-with-joins-and-namespaced-keys-removed stage)
-                               #(bad-ref-clause? :expression expression-names %))))
+  (let [expression-names (into #{} (map (comp :lib/expression-name second)) (:expressions stage))
+        pred #(bad-ref-clause? :expression expression-names %)
+        form (stage-with-joins-and-namespaced-keys-removed stage)]
+    (when (mbql.u/pred-matches-form? form pred)
+      (mbql.u/matching-locations form pred))))
 
 (defn- aggregation-ref-errors-for-stage [stage]
-  (let [uuids (into #{} (map (comp :lib/uuid second)) (:aggregation stage))]
-    (mbql.u/matching-locations (stage-with-joins-and-namespaced-keys-removed stage)
-                               #(bad-ref-clause? :aggregation uuids %))))
+  (let [uuids (into #{} (map (comp :lib/uuid second)) (:aggregation stage))
+        pred #(bad-ref-clause? :aggregation uuids %)
+        form (stage-with-joins-and-namespaced-keys-removed stage)]
+    (when (mbql.u/pred-matches-form? form pred)
+      (mbql.u/matching-locations form pred))))
 
 (defn ref-errors-for-stage
   "Return the locations and the clauses with dangling expression or aggregation references.


### PR DESCRIPTION
Currently, `matching-locations` is always used during query validation logic (triggered by Malli). That function creates a bunch of data structures and allocates objects so that it can record the matched path in case some form matches – and they most frequently do not match. The proposed change runs a cheaper alloc-free predicate first, and invokes `matching-locations` only if the cheap predicate passes.