### PR TITLE
handle errors without crashing in SliceNameWidget

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/PieChart/SliceNameWidget.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/SliceNameWidget.tsx
@@ -18,7 +18,7 @@ export function SliceNameWidget({
 
   const row = pieRows.find(row => row.key === initialKey);
   if (row == null) {
-    throw Error(`Could not find pieRow with key ${initialKey}`);
+    return null;
   }
 
   return (

--- a/frontend/src/metabase/visualizations/visualizations/PieChart/SliceNameWidget.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/SliceNameWidget.unit.spec.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+
+import { SliceNameWidget } from "./SliceNameWidget";
+
+const MOCK_PIE_ROW = {
+  key: "some-key",
+  name: "some-name",
+  originalName: "some-original-name",
+  color: "#509EE3",
+  defaultColor: true,
+  enabled: true,
+  hidden: false,
+  isOther: false,
+};
+
+describe("SliceNameWidget", () => {
+  it("should render the name of the pieRow with initialKey", () => {
+    render(
+      <SliceNameWidget
+        initialKey={MOCK_PIE_ROW.key}
+        pieRows={[MOCK_PIE_ROW, { ...MOCK_PIE_ROW, key: "some-other-key" }]}
+        updateRowName={() => null}
+      />,
+    );
+
+    expect(screen.getByDisplayValue(MOCK_PIE_ROW.name)).toBeInTheDocument();
+  });
+
+  it("should return null if a pieRow with initialKey cannot be found", () => {
+    const { container } = render(
+      <SliceNameWidget
+        initialKey={"non-present-key"}
+        pieRows={[MOCK_PIE_ROW]}
+        updateRowName={() => null}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});


### PR DESCRIPTION
Thread https://metaboat.slack.com/archives/C05MPF0TM3L/p1725494736816499

### Description

To prevent the chart from crashing completely, we should return `null` instead of throwing an error when the correct `pieRow` cannot be found in `SliceNameWidget`. It's more preferable for the user to not be able to rename slices, than to not be able to see the chart entirely or remove it from a dashboard.

### How to verify

Confirm slice renaming still works

1. Create a pie chart (e.g. count of products by category)
2. Confirm you can rename slices in viz settings

### Demo

https://github.com/user-attachments/assets/484b4e07-f187-4fcb-8310-4a3a9589661a

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
