### PR TITLE
Hide temporal comparisons in the notebook editor for metrics

### DIFF
--- a/e2e/test/scenarios/metrics/metrics-editing.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-editing.cy.spec.js
@@ -11,7 +11,6 @@ import {
   getNotebookStep,
   hovercard,
   modal,
-  openNotebook,
   openQuestionActions,
   popover,
   queryBuilderHeader,
@@ -406,7 +405,8 @@ describe("scenarios > metrics > editing", () => {
       createQuestion(ORDERS_SCALAR_METRIC).then(({ body: card }) =>
         visitMetric(card.id),
       );
-      openNotebook();
+      openQuestionActions();
+      popover().findByText("Edit metric definition").click();
 
       cy.log("regular screen");
       getNotebookStep("summarize").within(() => {

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -40,6 +40,7 @@ interface AggregationPickerProps {
   clauseIndex?: number;
   operators: Lib.AggregationOperator[];
   allowCustomExpressions?: boolean;
+  allowTemporalComparisons?: boolean;
   onClose?: () => void;
   onQueryChange: (query: Lib.Query) => void;
 }
@@ -75,6 +76,7 @@ export function AggregationPicker({
   clauseIndex,
   operators,
   allowCustomExpressions = false,
+  allowTemporalComparisons = false,
   onClose,
   onQueryChange,
 }: AggregationPickerProps) {
@@ -161,7 +163,10 @@ export function AggregationPicker({
       });
     }
 
-    if (canAddTemporalCompareAggregation(query, stageIndex)) {
+    if (
+      allowTemporalComparisons &&
+      canAddTemporalCompareAggregation(query, stageIndex)
+    ) {
       sections.push({
         type: "action",
         key: "compare",
@@ -189,6 +194,7 @@ export function AggregationPicker({
     clauseIndex,
     operators,
     allowCustomExpressions,
+    allowTemporalComparisons,
   ]);
 
   const checkIsItemSelected = useCallback(

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -39,7 +39,7 @@ interface AggregationPickerProps {
   clause?: Lib.AggregationClause;
   clauseIndex?: number;
   operators: Lib.AggregationOperator[];
-  hasExpressionInput?: boolean;
+  allowCustomExpressions?: boolean;
   onClose?: () => void;
   onQueryChange: (query: Lib.Query) => void;
 }
@@ -74,7 +74,7 @@ export function AggregationPicker({
   clause,
   clauseIndex,
   operators,
-  hasExpressionInput = true,
+  allowCustomExpressions = false,
   onClose,
   onQueryChange,
 }: AggregationPickerProps) {
@@ -133,7 +133,9 @@ export function AggregationPicker({
     const metrics = Lib.availableMetrics(query, stageIndex);
     const databaseId = Lib.databaseID(query);
     const database = metadata.database(databaseId);
-    const canUseExpressions = database?.hasFeature("expression-aggregations");
+    const supportsCustomExpressions = database?.hasFeature(
+      "expression-aggregations",
+    );
 
     if (operators.length > 0) {
       const operatorItems = operators.map(operator =>
@@ -169,7 +171,7 @@ export function AggregationPicker({
       });
     }
 
-    if (hasExpressionInput && canUseExpressions) {
+    if (allowCustomExpressions && supportsCustomExpressions) {
       sections.push({
         key: "custom-expression",
         name: t`Custom Expression`,
@@ -180,7 +182,14 @@ export function AggregationPicker({
     }
 
     return sections;
-  }, [metadata, query, stageIndex, clauseIndex, operators, hasExpressionInput]);
+  }, [
+    metadata,
+    query,
+    stageIndex,
+    clauseIndex,
+    operators,
+    allowCustomExpressions,
+  ]);
 
   const checkIsItemSelected = useCallback(
     (item: ListItem) => item.selected,

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
@@ -139,6 +139,7 @@ type SetupOpts = {
   metadata?: Metadata;
   query?: Lib.Query;
   allowCustomExpressions?: boolean;
+  allowTemporalComparisons?: boolean;
 };
 
 function setup({
@@ -153,6 +154,7 @@ function setup({
   metadata = createMetadata(),
   query = createQuery({ metadata }),
   allowCustomExpressions,
+  allowTemporalComparisons,
 }: SetupOpts = {}) {
   const stageIndex = 0;
   const clause = Lib.aggregations(query, stageIndex)[0];
@@ -171,6 +173,7 @@ function setup({
       stageIndex={stageIndex}
       operators={operators}
       allowCustomExpressions={allowCustomExpressions}
+      allowTemporalComparisons={allowTemporalComparisons}
       onQueryChange={onQueryChange}
     />,
     { storeInitialState: state },
@@ -413,7 +416,7 @@ describe("AggregationPicker", () => {
 
   describe("column compare shortcut", () => {
     it("does not display the shortcut if there are no aggregations", () => {
-      setup();
+      setup({ allowCustomExpressions: true, allowTemporalComparisons: true });
       expect(screen.queryByText(/compare/i)).not.toBeInTheDocument();
     });
 
@@ -421,23 +424,43 @@ describe("AggregationPicker", () => {
       setup({
         query: createQueryWithOpaqueBreakoutAndAggregation(),
         allowCustomExpressions: true,
+        allowTemporalComparisons: true,
+      });
+      expect(screen.queryByText(/compare/i)).not.toBeInTheDocument();
+    });
+
+    it("does not display the shortcut if `allowTemporalComparisons` is not set", () => {
+      setup({
+        query: createQueryWithCountAggregation(),
+        allowCustomExpressions: true,
+        allowTemporalComparisons: false,
       });
       expect(screen.queryByText(/compare/i)).not.toBeInTheDocument();
     });
 
     it("displays the shortcut with correct label if there is 1 aggregation", () => {
-      setup({ query: createQueryWithCountAggregation() });
+      setup({
+        query: createQueryWithCountAggregation(),
+        allowCustomExpressions: true,
+        allowTemporalComparisons: true,
+      });
       expect(screen.getByText("Compare to the past")).toBeInTheDocument();
     });
 
     it("displays the shortcut with correct label if there are multiple aggregation", () => {
-      setup({ query: createQueryWithCountAndSumAggregations() });
+      setup({
+        query: createQueryWithCountAndSumAggregations(),
+        allowCustomExpressions: true,
+        allowTemporalComparisons: true,
+      });
       expect(screen.getByText("Compare to the past")).toBeInTheDocument();
     });
 
     it("calls 'onQueryChange' on submit", async () => {
       const { onQueryChange } = setup({
         query: createQueryWithCountAggregation(),
+        allowCustomExpressions: true,
+        allowTemporalComparisons: true,
       });
 
       await userEvent.click(screen.getByText("Compare to the past"));

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
@@ -5,12 +5,7 @@ import { createMockMetadata } from "__support__/metadata";
 import { createMockEntitiesState } from "__support__/store";
 import { renderWithProviders, screen } from "__support__/ui";
 import * as Lib from "metabase-lib";
-import {
-  columnFinder,
-  createQuery,
-  createQueryWithClauses,
-  findAggregationOperator,
-} from "metabase-lib/test-helpers";
+import { createQuery, createQueryWithClauses } from "metabase-lib/test-helpers";
 import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import {
   COMMON_DATABASE_FEATURES,
@@ -18,10 +13,13 @@ import {
 } from "metabase-types/api/mocks";
 import {
   ORDERS,
-  PRODUCTS,
   SAMPLE_DB_ID,
+  createOrdersIdField,
+  createOrdersProductIdField,
   createOrdersTable,
   createPeopleTable,
+  createProductsCategoryField,
+  createProductsIdField,
   createProductsTable,
   createReviewsTable,
   createSampleDatabase,
@@ -34,20 +32,14 @@ import {
 
 import { AggregationPicker } from "./AggregationPicker";
 
-function createQueryWithCountAggregation({
-  metadata,
-}: { metadata?: Metadata } = {}) {
+function createQueryWithCountAggregation() {
   return createQueryWithClauses({
-    query: createQuery({ metadata }),
     aggregations: [{ operatorName: "count" }],
   });
 }
 
-function createQueryWithCountAndSumAggregations({
-  metadata,
-}: { metadata?: Metadata } = {}) {
+function createQueryWithCountAndSumAggregations() {
   return createQueryWithClauses({
-    query: createQuery({ metadata }),
     aggregations: [
       { operatorName: "count" },
       { operatorName: "sum", columnName: "PRICE", tableName: "PRODUCTS" },
@@ -55,18 +47,12 @@ function createQueryWithCountAndSumAggregations({
   });
 }
 
-function createQueryWithMaxAggregation({
-  metadata,
-}: { metadata?: Metadata } = {}) {
-  const initialQuery = createQuery({ metadata });
-  const max = findAggregationOperator(initialQuery, "max");
-  const findColumn = columnFinder(
-    initialQuery,
-    Lib.aggregationOperatorColumns(max),
-  );
-  const quantity = findColumn("ORDERS", "QUANTITY");
-  const clause = Lib.aggregationClause(max, quantity);
-  return Lib.aggregate(initialQuery, 0, clause);
+function createQueryWithMaxAggregation() {
+  return createQueryWithClauses({
+    aggregations: [
+      { operatorName: "max", tableName: "ORDERS", columnName: "QUANTITY" },
+    ],
+  });
 }
 
 function createQueryWithInlineExpression() {
@@ -106,29 +92,31 @@ function createQueryWithInlineExpressionWithOperator() {
 }
 
 function createQueryWithOpaqueBreakoutAndAggregation() {
-  return createQuery({
-    query: {
-      database: SAMPLE_DB_ID,
-      type: "query",
-      query: {
-        aggregation: [["count"]],
-        breakout: [
-          [
-            "field",
-            PRODUCTS.CATEGORY,
-            {
-              "base-type": "type/Text",
-            },
-          ],
+  const metadata = createMockMetadata({
+    databases: [
+      createSampleDatabase({
+        tables: [
+          createOrdersTable({
+            fields: [createOrdersIdField(), createOrdersProductIdField()],
+          }),
+          createProductsTable({
+            fields: [createProductsIdField(), createProductsCategoryField()],
+          }),
         ],
-      },
-    },
+      }),
+    ],
+  });
+
+  return createQueryWithClauses({
+    query: createQuery({ metadata }),
+    aggregations: [{ operatorName: "count" }],
+    breakouts: [{ tableName: "PRODUCTS", columnName: "CATEGORY" }],
   });
 }
 
 function createMetadata({
-  hasExpressionSupport = true,
-}: { hasExpressionSupport?: boolean } = {}) {
+  allowCustomExpressions,
+}: { allowCustomExpressions?: boolean } = {}) {
   return createMockMetadata({
     databases: [
       createSampleDatabase({
@@ -138,7 +126,7 @@ function createMetadata({
           createProductsTable(),
           createReviewsTable(),
         ],
-        features: hasExpressionSupport
+        features: allowCustomExpressions
           ? COMMON_DATABASE_FEATURES
           : _.without(COMMON_DATABASE_FEATURES, "expression-aggregations"),
       }),
@@ -150,7 +138,7 @@ type SetupOpts = {
   state?: State;
   metadata?: Metadata;
   query?: Lib.Query;
-  hasExpressionInput?: boolean;
+  allowCustomExpressions?: boolean;
 };
 
 function setup({
@@ -164,7 +152,7 @@ function setup({
   }),
   metadata = createMetadata(),
   query = createQuery({ metadata }),
-  hasExpressionInput = true,
+  allowCustomExpressions,
 }: SetupOpts = {}) {
   const stageIndex = 0;
   const clause = Lib.aggregations(query, stageIndex)[0];
@@ -182,7 +170,7 @@ function setup({
       clause={clause}
       stageIndex={stageIndex}
       operators={operators}
-      hasExpressionInput={hasExpressionInput}
+      allowCustomExpressions={allowCustomExpressions}
       onQueryChange={onQueryChange}
     />,
     { storeInitialState: state },
@@ -358,7 +346,7 @@ describe("AggregationPicker", () => {
 
   describe("custom expressions", () => {
     it("should allow to enter a custom expression containing an aggregation", async () => {
-      const { getRecentClauseInfo } = setup();
+      const { getRecentClauseInfo } = setup({ allowCustomExpressions: true });
 
       const expression = "count + 1";
       const expressionName = "My expression";
@@ -402,20 +390,20 @@ describe("AggregationPicker", () => {
             card: createMockCard(),
           }),
         }),
-        metadata: createMetadata({ hasExpressionSupport: false }),
+        metadata: createMetadata({ allowCustomExpressions: false }),
       });
       expect(screen.queryByText("Custom Expression")).not.toBeInTheDocument();
     });
 
-    it("shouldn't be shown if `hasExpressionInput` prop is false", () => {
-      setup({ hasExpressionInput: false });
+    it("shouldn't be shown if `allowCustomExpressions` prop is false", () => {
+      setup({ allowCustomExpressions: false });
       expect(screen.queryByText("Custom Expression")).not.toBeInTheDocument();
     });
 
-    it("should open the editor even if `hasExpressionInput` prop is false if expression is used", () => {
+    it("should open the editor even if `allowCustomExpressions` prop is false if expression is used", () => {
       setup({
         query: createQueryWithInlineExpression(),
-        hasExpressionInput: false,
+        allowCustomExpressions: false,
       });
 
       expect(screen.getByText("Custom Expression")).toBeInTheDocument();
@@ -432,6 +420,7 @@ describe("AggregationPicker", () => {
     it("does not display the shortcut if there are no possible breakouts to use", () => {
       setup({
         query: createQueryWithOpaqueBreakoutAndAggregation(),
+        allowCustomExpressions: true,
       });
       expect(screen.queryByText(/compare/i)).not.toBeInTheDocument();
     });

--- a/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
@@ -124,7 +124,7 @@ export const NotebookContainer = ({
           style={{ flex: 1, overflowY: "auto" }}
         >
           <Notebook
-            question={question}
+            question={question.setType("question")}
             isDirty={isDirty}
             isRunnable={isRunnable}
             isResultDirty={isResultDirty}

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/AddAggregationButton/AddAggregationButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/AddAggregationButton/AddAggregationButton.tsx
@@ -52,7 +52,6 @@ export function AddAggregationButton({
           query={query}
           stageIndex={stageIndex}
           operators={operators}
-          hasExpressionInput={false}
           onQueryChange={query => {
             onQueryChange(query);
             setIsOpened(false);

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/AddAggregationButton/AddAggregationButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/AddAggregationButton/AddAggregationButton.tsx
@@ -52,6 +52,7 @@ export function AddAggregationButton({
           query={query}
           stageIndex={stageIndex}
           operators={operators}
+          allowTemporalComparisons
           onQueryChange={query => {
             onQueryChange(query);
             setIsOpened(false);

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/AggregationItem/AggregationItem.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/AggregationItem/AggregationItem.tsx
@@ -54,6 +54,7 @@ export function AggregationItem({
           clause={aggregation}
           clauseIndex={aggregationIndex}
           operators={operators}
+          allowTemporalComparisons
           onQueryChange={onQueryChange}
         />
       </Popover.Dropdown>

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/AggregationItem/AggregationItem.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/AggregationItem/AggregationItem.tsx
@@ -54,7 +54,6 @@ export function AggregationItem({
           clause={aggregation}
           clauseIndex={aggregationIndex}
           operators={operators}
-          hasExpressionInput={false}
           onQueryChange={onQueryChange}
         />
       </Popover.Dropdown>

--- a/frontend/src/metabase/querying/notebook/components/AggregateStep/AggregateStep.tsx
+++ b/frontend/src/metabase/querying/notebook/components/AggregateStep/AggregateStep.tsx
@@ -62,6 +62,7 @@ export function AggregateStep({
           stageIndex={stageIndex}
           clause={aggregation}
           clauseIndex={index}
+          isMetric={isMetric}
           onQueryChange={updateQuery}
           onClose={onClose}
         />
@@ -78,6 +79,7 @@ interface AggregationPopoverProps {
   stageIndex: number;
   clause?: Lib.AggregationClause;
   clauseIndex?: number;
+  isMetric: boolean;
   onQueryChange: (query: Lib.Query) => void;
   onClose: () => void;
 }
@@ -87,6 +89,7 @@ function AggregationPopover({
   stageIndex,
   clause,
   clauseIndex,
+  isMetric,
   onQueryChange,
   onClose,
 }: AggregationPopoverProps) {
@@ -107,6 +110,7 @@ function AggregationPopover({
       clauseIndex={clauseIndex}
       operators={operators}
       allowCustomExpressions
+      allowTemporalComparisons={!isMetric}
       onQueryChange={onQueryChange}
       onClose={onClose}
     />

--- a/frontend/src/metabase/querying/notebook/components/AggregateStep/AggregateStep.tsx
+++ b/frontend/src/metabase/querying/notebook/components/AggregateStep/AggregateStep.tsx
@@ -106,6 +106,7 @@ function AggregationPopover({
       clause={clause}
       clauseIndex={clauseIndex}
       operators={operators}
+      allowCustomExpressions
       onQueryChange={onQueryChange}
       onClose={onClose}
     />

--- a/frontend/src/metabase/querying/notebook/components/AggregateStep/AggregateStep.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/AggregateStep/AggregateStep.unit.spec.tsx
@@ -178,5 +178,30 @@ describe("AggregateStep", () => {
       expect(queryIcon("close")).not.toBeInTheDocument();
       expect(queryIcon("add")).not.toBeInTheDocument();
     });
+
+    it("should not allow to use temporal comparisons for metrics", async () => {
+      const query = createQueryWithClauses({
+        aggregations: [{ operatorName: "count" }],
+      });
+      const question = DEFAULT_QUESTION.setType("metric").setQuery(query);
+      const step = createMockNotebookStep({ question, query });
+      setup({ step });
+
+      await userEvent.click(screen.getByText("Count"));
+      expect(await screen.findByText("Average of ...")).toBeInTheDocument();
+      expect(screen.queryByText(/compare/i)).not.toBeInTheDocument();
+    });
+
+    it("should allow to use temporal comparisons for non-metrics", async () => {
+      const query = createQueryWithClauses({
+        aggregations: [{ operatorName: "count" }],
+      });
+      const question = DEFAULT_QUESTION.setType("question").setQuery(query);
+      const step = createMockNotebookStep({ question, query });
+      setup({ step });
+
+      await userEvent.click(screen.getByText("Count"));
+      expect(screen.getByText(/compare/i)).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/47147
Closes https://github.com/metabase/metabase/issues/47701

Removes `Compare to the past` option in the AggregationPicker for metrics.

How to verify:
- New -> Metric -> Orders 
- Click on `Count` -> There should be no `Compare to the past` option
- Save
- Click `Show editor` to edit an ad-hoc question based on the metric
- Click on `Count` -> There should be the `Compare to the past` option

Metric editor:
<img width="1317" alt="Screenshot 2024-09-06 at 14 40 15" src="https://github.com/user-attachments/assets/f0c3038b-dc7f-430e-b906-6fc65bab846c">

Ad-hoc question based on a metric:
<img width="1393" alt="Screenshot 2024-09-06 at 14 40 27" src="https://github.com/user-attachments/assets/46306687-0f28-4202-b0f0-d8d316c900ba">
