### PR TITLE
Convey cancelation info when the client closes the connection

### DIFF
--- a/src/metabase/query_processor/streaming.clj
+++ b/src/metabase/query_processor/streaming.clj
@@ -172,7 +172,8 @@
      export-format os
      (^:once fn* [rff]
        (let [result (try
-                      (f rff)
+                      (binding [qp.pipeline/*canceled-chan* canceled-chan]
+                        (f rff))
                       (catch Throwable e
                         e))]
          (assert (some? result) "QP unexpectedly returned nil.")

--- a/test/metabase/async/streaming_response_test.clj
+++ b/test/metabase/async/streaming_response_test.clj
@@ -143,14 +143,13 @@
               ;; wait a little while for the query to start running -- this should usually happen fairly quickly
               (mt/wait-for-result start-chan (u/seconds->ms 15))
               (future-cancel futur)
-              ;; check every 50ms, up to 1000ms, whether `canceled?` is now `true`
+              ;; check every 10ms, up to 1000ms, whether `canceled?` is now `true`
               (is (loop [[wait & more] (repeat 10 100)]
                     (or @canceled?
-                        (if wait
+                        (when wait
                           (do
                             (Thread/sleep (long wait))
-                            (recur more))
-                          ::timed-out)))))))))))
+                            (recur more)))))))))))))
 
 (def ^:private ^:dynamic *number-of-cans* nil)
 


### PR DESCRIPTION
Fixes #47555

### Description

Bind `canceled-chan` when creating a streaming response. I tested the fix with presto because I did the repro with that, but the problem is much wider.

### How to verify

The modified `cancelation-test`, which doesn't succeed on timeout, should fail without the change in the production code and pass with it.

- [x] Tests have been added/updated to cover changes in this PR
