### PR TITLE
cleanup data reference tooltips

### DIFF
--- a/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.js
@@ -817,7 +817,9 @@ describe("scenarios > admin > datamodel > segments", () => {
       cy.wait(["@metadata", "@metadata", "@metadata"]);
 
       cy.get("@emptyStateMessage").should("not.exist");
-      cy.findByRole("heading", { name: "Foo" }).should("be.visible");
+      cy.findByTestId("data-reference-list-item")
+        .findByText("Foo")
+        .should("be.visible");
     });
 
     it("should update that segment", () => {

--- a/frontend/src/metabase/components/List/List.module.css
+++ b/frontend/src/metabase/components/List/List.module.css
@@ -49,17 +49,22 @@
   position: relative;
   align-items: center;
   display: flex;
+  gap: var(--padding-1);
 }
 
 .itemBody {
-  max-width: 100%;
-  flex: 1 0 auto;
+  display: flex 1 1 auto;
+  overflow: hidden;
 }
 
 .itemTitle {
   composes: textBold from "style";
   max-width: 100%;
-  overflow: hidden;
+  font-size: 1rem;
+
+  &:hover {
+    color: var(--mb-color-brand);
+  }
 }
 
 .itemSubtitle {
@@ -69,7 +74,6 @@
 }
 
 .leftIcons {
-  composes: mr2 from "style";
   align-self: flex-start;
   flex-shrink: 0;
   flex-direction: row;

--- a/frontend/src/metabase/components/ListItem/ListItem.jsx
+++ b/frontend/src/metabase/components/ListItem/ListItem.jsx
@@ -24,6 +24,7 @@ const ListItem = ({
     <Card
       hoverable
       className={cx(CS.mb2, CS.p3, CS.bgWhite, CS.rounded, CS.bordered)}
+      data-testid="data-reference-list-item"
     >
       <div className={cx(S.item)}>
         <div className={S.itemIcons}>

--- a/frontend/src/metabase/components/ListItem/ListItem.jsx
+++ b/frontend/src/metabase/components/ListItem/ListItem.jsx
@@ -5,10 +5,11 @@ import { memo } from "react";
 
 import Card from "metabase/components/Card";
 import S from "metabase/components/List/List.module.css";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 import CS from "metabase/css/core/index.css";
 import { Icon } from "metabase/ui";
 
-import { ListItemLink, ListItemName, Root } from "./ListItem.styled";
+import { ListItemLink, Root } from "./ListItem.styled";
 
 const ListItem = ({
   "data-testid": dataTestId,
@@ -30,9 +31,7 @@ const ListItem = ({
         </div>
         <div className={S.itemBody}>
           <div className={S.itemTitle}>
-            <ListItemName tooltip={name} tooltipMaxWidth="100%">
-              <h3>{name}</h3>
-            </ListItemName>
+            <Ellipsified tooltip={name}>{name}</Ellipsified>
           </div>
           {(description || placeholder) && (
             <div className={cx(S.itemSubtitle)}>

--- a/frontend/src/metabase/components/ListItem/ListItem.styled.tsx
+++ b/frontend/src/metabase/components/ListItem/ListItem.styled.tsx
@@ -1,9 +1,6 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { Link } from "react-router";
-
-import { Ellipsified } from "metabase/core/components/Ellipsified";
-
 interface Props {
   disabled?: boolean;
 }
@@ -20,15 +17,6 @@ export const Root = styled.li<Props>`
 `;
 
 export const ListItemLink = styled(Link)`
-  &:hover {
-    color: var(--mb-color-brand);
-  }
-`;
-
-export const ListItemName = styled(Ellipsified)`
-  max-width: 100%;
-  overflow: hidden;
-
   &:hover {
     color: var(--mb-color-brand);
   }


### PR DESCRIPTION
[discussion](https://metaboat.slack.com/archives/C02H619CJ8K/p1725578482670289)

### Description

**Before**

Some short things get enormous tooltips

![Screen Shot 2024-09-06 at 4 49 31 PM](https://github.com/user-attachments/assets/b7d81885-b6d4-419d-a78a-879199bfe802)

Some long things don't get tooltips or ellipses at all

![Screen Shot 2024-09-06 at 4 49 48 PM](https://github.com/user-attachments/assets/2df36516-b923-48d9-857d-86ade95450ae)

**After**

Tooltips are a normal size, and long names get ellipsified properly

![Screen Shot 2024-09-06 at 4 52 01 PM](https://github.com/user-attachments/assets/9ddb2ce2-3796-410f-8bdf-617c21d50932)

There are still some cases where tooltips show up unnecessarily, but I didn't want to waste any more time on that.

![Screen Shot 2024-09-06 at 4 47 01 PM](https://github.com/user-attachments/assets/246034c2-d75f-42e1-bac4-c1562ddb11bc)

