### PR TITLE
Allow markdown in database/table/field descriptions

### DIFF
--- a/frontend/src/metabase/reference/components/Detail.jsx
+++ b/frontend/src/metabase/reference/components/Detail.jsx
@@ -5,6 +5,7 @@ import { memo } from "react";
 import { Link } from "react-router";
 import { t } from "ttag";
 
+import Markdown from "metabase/core/components/Markdown";
 import CS from "metabase/css/core/index.css";
 
 import S from "./Detail.module.css";
@@ -18,6 +19,7 @@ const Detail = ({
   icon,
   isEditing,
   field,
+  isMarkdown = false,
 }) => (
   <div className={cx(S.detail)}>
     <div className={isEditing ? cx(S.detailBody, CS.flexFull) : S.detailBody}>
@@ -38,9 +40,10 @@ const Detail = ({
             defaultValue={description}
           />
         ) : (
-          <span className={subtitleClass}>
+          isMarkdown ? (
+          <Markdown className={subtitleClass}>
             {description || placeholder || t`No description yet`}
-          </span>
+          </Markdown>) : (<span className={subtitleClass}>{description || placeholder || t`No description yet`}</span>)
         )}
         {isEditing && field.error && field.touched && (
           <span className={CS.textError}>{field.error}</span>
@@ -59,6 +62,7 @@ Detail.propTypes = {
   icon: PropTypes.string,
   isEditing: PropTypes.bool,
   field: PropTypes.object,
+  isMarkdown: PropTypes.bool,
 };
 
 export default memo(Detail);

--- a/frontend/src/metabase/reference/components/Field.jsx
+++ b/frontend/src/metabase/reference/components/Field.jsx
@@ -8,6 +8,7 @@ import { P, match } from "ts-pattern";
 import { t } from "ttag";
 
 import S from "metabase/components/List/List.module.css";
+import Markdown from "metabase/core/components/Markdown";
 import Select from "metabase/core/components/Select";
 import CS from "metabase/css/core/index.css";
 import {
@@ -126,9 +127,9 @@ const Field = ({ field, foreignKeys, url, icon, isEditing, formField }) => (
             );
           })
           .with({ description: P.not(P.nullish) }, () => (
-            <div className={cx(F.fieldDescription, CS.mb2, CS.mt1)}>
+            <Markdown className={cx(F.fieldDescription, CS.mb2, CS.mt1)}>
               {field.description}
-            </div>
+            </Markdown>
           ))
           .otherwise(() => null)}
       </div>

--- a/frontend/src/metabase/reference/databases/DatabaseDetail.jsx
+++ b/frontend/src/metabase/reference/databases/DatabaseDetail.jsx
@@ -152,6 +152,7 @@ const DatabaseDetail = props => {
                     placeholder={t`No description yet`}
                     isEditing={isEditing}
                     field={getFormField("description")}
+                    isMarkdown
                   />
                 </li>
                 <li className={CS.relative}>
@@ -162,6 +163,7 @@ const DatabaseDetail = props => {
                     placeholder={t`Nothing interesting yet`}
                     isEditing={isEditing}
                     field={getFormField("points_of_interest")}
+                    isMarkdown
                   />
                 </li>
                 <li className={CS.relative}>
@@ -172,6 +174,7 @@ const DatabaseDetail = props => {
                     placeholder={t`Nothing to be aware of yet`}
                     isEditing={isEditing}
                     field={getFormField("caveats")}
+                    isMarkdown
                   />
                 </li>
               </List>

--- a/frontend/src/metabase/reference/databases/FieldDetail.jsx
+++ b/frontend/src/metabase/reference/databases/FieldDetail.jsx
@@ -201,6 +201,7 @@ const FieldDetail = props => {
                     placeholder={t`No description yet`}
                     isEditing={isEditing}
                     field={getFormField("description")}
+                    isMarkdown
                   />
                 </li>
                 {!isEditing && (
@@ -221,6 +222,7 @@ const FieldDetail = props => {
                     placeholder={t`Nothing interesting yet`}
                     isEditing={isEditing}
                     field={getFormField("points_of_interest")}
+                    isMarkdown
                   />
                 </li>
                 <li className={CS.relative}>
@@ -231,6 +233,7 @@ const FieldDetail = props => {
                     placeholder={t`Nothing to be aware of yet`}
                     isEditing={isEditing}
                     field={getFormField("caveats")}
+                    isMarkdown
                   />
                 </li>
 

--- a/frontend/src/metabase/reference/databases/TableDetail.jsx
+++ b/frontend/src/metabase/reference/databases/TableDetail.jsx
@@ -193,6 +193,7 @@ const TableDetail = props => {
                     placeholder={t`No description yet`}
                     isEditing={isEditing}
                     field={getFormField("description")}
+                    isMarkdown
                   />
                 </li>
                 {!isEditing && (
@@ -213,6 +214,7 @@ const TableDetail = props => {
                     placeholder={t`Nothing interesting yet`}
                     isEditing={isEditing}
                     field={getFormField("points_of_interest")}
+                    isMarkdown
                   />
                 </li>
                 <li className={CS.relative}>
@@ -223,6 +225,7 @@ const TableDetail = props => {
                     placeholder={t`Nothing to be aware of yet`}
                     isEditing={isEditing}
                     field={getFormField("caveats")}
+                    isMarkdown
                   />
                 </li>
                 {!isEditing && (

--- a/frontend/src/metabase/reference/segments/SegmentDetail.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentDetail.jsx
@@ -229,6 +229,7 @@ const SegmentDetail = props => {
                     placeholder={t`No description yet`}
                     isEditing={isEditing}
                     field={getFormField("description")}
+                    isMarkdown
                   />
                 </li>
                 <li className={CS.relative}>
@@ -239,6 +240,7 @@ const SegmentDetail = props => {
                     placeholder={t`Nothing interesting yet`}
                     isEditing={isEditing}
                     field={getFormField("points_of_interest")}
+                    isMarkdown
                   />
                 </li>
                 <li className={CS.relative}>
@@ -249,6 +251,7 @@ const SegmentDetail = props => {
                     placeholder={t`Nothing to be aware of yet`}
                     isEditing={isEditing}
                     field={getFormField("caveats")}
+                    isMarkdown
                   />
                 </li>
                 {!isEditing && (

--- a/frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx
@@ -176,6 +176,7 @@ const SegmentFieldDetail = props => {
                     placeholder={t`No description yet`}
                     isEditing={isEditing}
                     field={getFormField("description")}
+                    isMarkdown
                   />
                 </li>
                 {!isEditing && (
@@ -196,6 +197,7 @@ const SegmentFieldDetail = props => {
                     placeholder={t`Nothing interesting yet`}
                     isEditing={isEditing}
                     field={getFormField("points_of_interest")}
+                    isMarkdown
                   />
                 </li>
                 <li className={CS.relative}>
@@ -206,6 +208,7 @@ const SegmentFieldDetail = props => {
                     placeholder={t`Nothing to be aware of yet`}
                     isEditing={isEditing}
                     field={getFormField("caveats")}
+                    isMarkdown
                   />
                 </li>
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/15814

### Description

This adds support for markdown to database/table/field descriptions. There's already a `Markdown` component, so I've just replaced the containers for these fields using that Markdown component instead. For the `Detail` component I've added an `isMarkdown` prop as well, to avoid any issues with the use of the component by non-editable fields (e.g. it's used by the table name as well) - although this might not be necessary.

NB: I haven't added tests, but happy to do so if they're desired - if so, would appreciate some guidance on what a suitable level of testing would be for this change.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Open a database/table/field through the Databases menu
2. Edit a field so it includes markdown
3. The markdown should be rendered on saving.

### Demo

Some before/after screenshots:

<img width="1209" alt="Screenshot 2024-09-02 at 21 40 41" src="https://github.com/user-attachments/assets/53433ce8-f790-4314-b90d-9b1a1a0e2797">
<img width="1209" alt="Screenshot 2024-09-02 at 21 39 36" src="https://github.com/user-attachments/assets/81d120bc-81ef-41e6-8b76-a673b79ae08a">

<img width="1209" alt="Screenshot 2024-09-02 at 21 40 48" src="https://github.com/user-attachments/assets/c98bb780-7eae-437d-8ff9-d9aaca75d19e">
<img width="1209" alt="Screenshot 2024-09-02 at 21 39 44" src="https://github.com/user-attachments/assets/d8fb24f8-0aa9-483c-9af6-7c5e81ccb746">


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
