### PR TITLE
Enable named aggregations in :offset expressions

### DIFF
--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -374,7 +374,7 @@
 
 (defclause ^{:added "0.50.0"} offset
   opts [:ref ::lib.schema.common/options]
-  expr [:or [:ref ::FieldOrExpressionDef] [:ref ::UnnamedAggregation]]
+  expr [:or [:ref ::FieldOrExpressionDef] [:ref ::Aggregation]]
   n    ::lib.schema.expression.window/offset.n)
 
 ;;; -------------------------------------------------- Expressions ---------------------------------------------------

--- a/test/metabase/lib/convert_test.cljc
+++ b/test/metabase/lib/convert_test.cljc
@@ -200,6 +200,7 @@
                                         :aggregation  [[:aggregation-options
                                                         [:sum [:field 1 nil]]
                                                         {:display-name "Revenue"}]]}}))))
+
 (deftest ^:parallel effective-type-drop-test
   (testing ":effective_type values should be dropped in ->legacy-MBQL"
     (is (=? {:type  :query


### PR DESCRIPTION
Fixes #47735

### Description

The schema didn't allow `:offset` expressions embedding `:aggregation-options` clauses.

### How to verify

Use the repro steps from from #47735. A BE test reproduces the repro steps.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
