### PR TITLE
Maintain tab state in Entity Picker

### DIFF
--- a/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPicker.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPicker.tsx
@@ -13,7 +13,7 @@ import { LoadingSpinner, NestedItemPicker } from "../../EntityPicker";
 import type {
   CollectionPickerItem,
   CollectionPickerOptions,
-  CollectionPickerPath,
+  CollectionPickerStatePath,
 } from "../types";
 import {
   getCollectionIdPath,
@@ -33,10 +33,10 @@ const defaultOptions: CollectionPickerOptions = {
 interface CollectionPickerProps {
   initialValue?: Partial<CollectionPickerItem>;
   options?: CollectionPickerOptions;
-  path: CollectionPickerPath | undefined;
+  path: CollectionPickerStatePath | undefined;
   shouldDisableItem?: (item: CollectionPickerItem) => boolean;
   onItemSelect: (item: CollectionPickerItem) => void;
-  onPathChange: (path: CollectionPickerPath) => void;
+  onPathChange: (path: CollectionPickerStatePath) => void;
 }
 
 export const CollectionPickerInner = (
@@ -128,7 +128,7 @@ export const CollectionPickerInner = (
         // if the currently selected item is not a folder, it will be once we create a new collection within it
         // so we need to select it
 
-        const newPath: CollectionPickerPath = [
+        const newPath: CollectionPickerStatePath = [
           ...path,
           {
             query: {

--- a/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPicker.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPicker.tsx
@@ -184,7 +184,12 @@ export const CollectionPickerInner = (
         }
       }
     },
-    [currentCollection, options.namespace, userPersonalCollectionId],
+    [
+      currentCollection,
+      options.namespace,
+      userPersonalCollectionId,
+      onPathChange,
+    ],
   );
 
   if (error) {

--- a/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPicker.unit.spec.tsx
@@ -150,8 +150,10 @@ const setup = ({
 
   return renderWithProviders(
     <CollectionPicker
-      onItemSelect={onItemSelect}
       initialValue={initialValue}
+      path={undefined}
+      onItemSelect={onItemSelect}
+      onPathChange={jest.fn()}
     />,
   );
 };

--- a/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPicker.unit.spec.tsx
@@ -1,5 +1,6 @@
 import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
+import { useState } from "react";
 
 import { setupCollectionItemsEndpoint } from "__support__/server-mocks";
 import {
@@ -17,7 +18,7 @@ import {
   createMockCollectionItem,
 } from "metabase-types/api/mocks";
 
-import type { CollectionPickerItem } from "../types";
+import type { CollectionPickerItem, CollectionPickerStatePath } from "../types";
 
 import { CollectionPicker } from "./CollectionPicker";
 
@@ -148,14 +149,20 @@ const setup = ({
 
   setupCollectionTreeMocks(collectionTree);
 
-  return renderWithProviders(
-    <CollectionPicker
-      initialValue={initialValue}
-      path={undefined}
-      onItemSelect={onItemSelect}
-      onPathChange={jest.fn()}
-    />,
-  );
+  function TestComponent() {
+    const [path, setPath] = useState<CollectionPickerStatePath>();
+
+    return (
+      <CollectionPicker
+        initialValue={initialValue}
+        path={path}
+        onItemSelect={onItemSelect}
+        onPathChange={setPath}
+      />
+    );
+  }
+
+  return renderWithProviders(<TestComponent />);
 };
 
 describe("CollectionPicker", () => {
@@ -167,6 +174,7 @@ describe("CollectionPicker", () => {
     act(() => {
       setup();
     });
+
     expect(
       await screen.findByRole("button", { name: /Our Analytics/ }),
     ).toHaveAttribute("data-active", "true");
@@ -184,6 +192,7 @@ describe("CollectionPicker", () => {
     act(() => {
       setup({ initialValue: { id: 3, model: "collection" } });
     });
+    await screen.findByRole("button", { name: /Our Analytics/ });
     expect(
       await screen.findByRole("button", { name: /Our Analytics/ }),
     ).toHaveAttribute("data-active", "true");

--- a/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
@@ -11,6 +11,7 @@ import { useLogRecentItem } from "../../EntityPicker/hooks/use-log-recent-item";
 import type {
   CollectionPickerItem,
   CollectionPickerOptions,
+  CollectionPickerPath,
   CollectionPickerValueItem,
 } from "../types";
 
@@ -105,6 +106,9 @@ export const CollectionPickerModal = ({
       ]
     : [];
 
+  const [collectionsPath, setCollectionsPath] =
+    useState<CollectionPickerPath>();
+
   const tabs: EntityPickerTab<
     CollectionPickerItem["id"],
     CollectionPickerItem["model"],
@@ -118,11 +122,13 @@ export const CollectionPickerModal = ({
       icon: "folder",
       render: ({ onItemSelect }) => (
         <CollectionPicker
-          onItemSelect={onItemSelect}
-          shouldDisableItem={shouldDisableItem}
           initialValue={value}
           options={options}
+          path={collectionsPath}
           ref={pickerRef}
+          shouldDisableItem={shouldDisableItem}
+          onItemSelect={onItemSelect}
+          onPathChange={setCollectionsPath}
         />
       ),
     },

--- a/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
@@ -11,7 +11,7 @@ import { useLogRecentItem } from "../../EntityPicker/hooks/use-log-recent-item";
 import type {
   CollectionPickerItem,
   CollectionPickerOptions,
-  CollectionPickerPath,
+  CollectionPickerStatePath,
   CollectionPickerValueItem,
 } from "../types";
 
@@ -107,7 +107,7 @@ export const CollectionPickerModal = ({
     : [];
 
   const [collectionsPath, setCollectionsPath] =
-    useState<CollectionPickerPath>();
+    useState<CollectionPickerStatePath>();
 
   const tabs: EntityPickerTab<
     CollectionPickerItem["id"],

--- a/frontend/src/metabase/common/components/CollectionPicker/types.ts
+++ b/frontend/src/metabase/common/components/CollectionPicker/types.ts
@@ -10,6 +10,7 @@ import type {
 import type {
   EntityPickerModalOptions,
   ListProps,
+  PickerState,
   TypeWithModel,
 } from "../EntityPicker";
 
@@ -59,4 +60,9 @@ export type CollectionItemListProps = ListProps<
   CollectionPickerItem,
   ListCollectionItemsRequest,
   CollectionPickerOptions
+>;
+
+export type CollectionPickerPath = PickerState<
+  CollectionPickerItem,
+  ListCollectionItemsRequest
 >;

--- a/frontend/src/metabase/common/components/CollectionPicker/types.ts
+++ b/frontend/src/metabase/common/components/CollectionPicker/types.ts
@@ -62,7 +62,7 @@ export type CollectionItemListProps = ListProps<
   CollectionPickerOptions
 >;
 
-export type CollectionPickerPath = PickerState<
+export type CollectionPickerStatePath = PickerState<
   CollectionPickerItem,
   ListCollectionItemsRequest
 >;

--- a/frontend/src/metabase/common/components/CollectionPicker/utils.ts
+++ b/frontend/src/metabase/common/components/CollectionPicker/utils.ts
@@ -7,7 +7,7 @@ import type {
 import type { PickerState } from "../EntityPicker";
 import type { QuestionPickerItem } from "../QuestionPicker";
 
-import type { CollectionPickerItem } from "./types";
+import type { CollectionPickerItem, CollectionPickerPath } from "./types";
 
 export const getCollectionIdPath = (
   collection: Pick<
@@ -54,7 +54,7 @@ export const getStateFromIdPath = ({
 }: {
   idPath: CollectionId[];
   namespace?: "snippets";
-}): PickerState<CollectionPickerItem, ListCollectionItemsRequest> => {
+}): CollectionPickerPath => {
   const statePath: PickerState<
     CollectionPickerItem,
     ListCollectionItemsRequest

--- a/frontend/src/metabase/common/components/CollectionPicker/utils.ts
+++ b/frontend/src/metabase/common/components/CollectionPicker/utils.ts
@@ -7,7 +7,7 @@ import type {
 import type { PickerState } from "../EntityPicker";
 import type { QuestionPickerItem } from "../QuestionPicker";
 
-import type { CollectionPickerItem, CollectionPickerPath } from "./types";
+import type { CollectionPickerItem, CollectionPickerStatePath } from "./types";
 
 export const getCollectionIdPath = (
   collection: Pick<
@@ -54,7 +54,7 @@ export const getStateFromIdPath = ({
 }: {
   idPath: CollectionId[];
   namespace?: "snippets";
-}): CollectionPickerPath => {
+}): CollectionPickerStatePath => {
   const statePath: PickerState<
     CollectionPickerItem,
     ListCollectionItemsRequest

--- a/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPicker.tsx
+++ b/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPicker.tsx
@@ -19,7 +19,7 @@ import { LoadingSpinner, NestedItemPicker } from "../../EntityPicker";
 import type {
   DashboardPickerItem,
   DashboardPickerOptions,
-  DashboardPickerPath,
+  DashboardPickerStatePath,
 } from "../types";
 import { getCollectionIdPath, getStateFromIdPath, isFolder } from "../utils";
 
@@ -33,10 +33,10 @@ interface DashboardPickerProps {
   initialValue?: Pick<DashboardPickerItem, "model" | "id">;
   options: DashboardPickerOptions;
   models?: CollectionItemModel[];
-  path: DashboardPickerPath | undefined;
+  path: DashboardPickerStatePath | undefined;
   shouldDisableItem?: (item: DashboardPickerItem) => boolean;
   onItemSelect: (item: DashboardPickerItem) => void;
-  onPathChange: (path: DashboardPickerPath) => void;
+  onPathChange: (path: DashboardPickerStatePath) => void;
 }
 
 const useGetInitialCollection = (

--- a/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPicker.tsx
+++ b/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPicker.tsx
@@ -1,5 +1,5 @@
 import type { Ref } from "react";
-import { forwardRef, useCallback, useImperativeHandle, useState } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useMemo } from "react";
 import { useDeepCompareEffect } from "react-use";
 
 import {
@@ -11,20 +11,16 @@ import { isValidCollectionId } from "metabase/collections/utils";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import { useSelector } from "metabase/lib/redux";
 import { getUserPersonalCollectionId } from "metabase/selectors/user";
-import type {
-  CollectionItemModel,
-  Dashboard,
-  ListCollectionItemsRequest,
-} from "metabase-types/api";
+import type { CollectionItemModel, Dashboard } from "metabase-types/api";
 
 import { CollectionItemPickerResolver } from "../../CollectionPicker/components/CollectionItemPickerResolver";
 import { getPathLevelForItem } from "../../CollectionPicker/utils";
-import {
-  LoadingSpinner,
-  NestedItemPicker,
-  type PickerState,
-} from "../../EntityPicker";
-import type { DashboardPickerItem, DashboardPickerOptions } from "../types";
+import { LoadingSpinner, NestedItemPicker } from "../../EntityPicker";
+import type {
+  DashboardPickerItem,
+  DashboardPickerOptions,
+  DashboardPickerPath,
+} from "../types";
 import { getCollectionIdPath, getStateFromIdPath, isFolder } from "../utils";
 
 export const defaultOptions: DashboardPickerOptions = {
@@ -34,11 +30,13 @@ export const defaultOptions: DashboardPickerOptions = {
 };
 
 interface DashboardPickerProps {
-  onItemSelect: (item: DashboardPickerItem) => void;
   initialValue?: Pick<DashboardPickerItem, "model" | "id">;
   options: DashboardPickerOptions;
   models?: CollectionItemModel[];
+  path: DashboardPickerPath | undefined;
   shouldDisableItem?: (item: DashboardPickerItem) => boolean;
+  onItemSelect: (item: DashboardPickerItem) => void;
+  onPathChange: (path: DashboardPickerPath) => void;
 }
 
 const useGetInitialCollection = (
@@ -82,22 +80,20 @@ const useGetInitialCollection = (
 
 const DashboardPickerInner = (
   {
-    onItemSelect,
     initialValue,
     options,
     models = ["dashboard"],
+    path: pathProp,
     shouldDisableItem,
+    onItemSelect,
+    onPathChange,
   }: DashboardPickerProps,
   ref: Ref<unknown>,
 ) => {
-  const [path, setPath] = useState<
-    PickerState<DashboardPickerItem, ListCollectionItemsRequest>
-  >(() =>
-    getStateFromIdPath({
-      idPath: ["root"],
-      models,
-    }),
-  );
+  const defaultPath = useMemo(() => {
+    return getStateFromIdPath({ idPath: ["root"], models });
+  }, [models]);
+  const path = pathProp ?? defaultPath;
 
   const {
     currentCollection,
@@ -116,10 +112,10 @@ const DashboardPickerInner = (
         idPath,
         models,
       });
-      setPath(newPath);
+      onPathChange(newPath);
       onItemSelect(folder);
     },
-    [setPath, onItemSelect, userPersonalCollectionId, models],
+    [onPathChange, onItemSelect, userPersonalCollectionId, models],
   );
 
   const handleItemSelect = useCallback(
@@ -133,10 +129,10 @@ const DashboardPickerInner = (
 
       const newPath = path.slice(0, pathLevel + 1);
       newPath[newPath.length - 1].selectedItem = item;
-      setPath(newPath);
+      onPathChange(newPath);
       onItemSelect(item);
     },
-    [setPath, onItemSelect, path, userPersonalCollectionId],
+    [onPathChange, onItemSelect, path, userPersonalCollectionId],
   );
 
   const handleNewDashboard = useCallback(
@@ -195,10 +191,10 @@ const DashboardPickerInner = (
               };
         }
 
-        setPath(newPath);
+        onPathChange(newPath);
       }
     },
-    [currentCollection, userPersonalCollectionId],
+    [currentCollection, userPersonalCollectionId, onPathChange],
   );
 
   if (error) {

--- a/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPicker.unit.spec.tsx
@@ -1,5 +1,6 @@
 import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
+import { useState } from "react";
 
 import {
   setupCollectionItemsEndpoint,
@@ -24,7 +25,11 @@ import {
   createMockDashboard,
 } from "metabase-types/api/mocks";
 
-import type { DashboardPickerItem, DashboardPickerValueModel } from "../types";
+import type {
+  DashboardPickerItem,
+  DashboardPickerStatePath,
+  DashboardPickerValueModel,
+} from "../types";
 
 import { DashboardPicker, defaultOptions } from "./DashboardPicker";
 import { DashboardPickerModal } from "./DashboardPickerModal";
@@ -191,15 +196,21 @@ const setupPicker = async ({
 }: SetupOpts = {}) => {
   commonSetup();
 
-  renderWithProviders(
-    <DashboardPicker
-      initialValue={initialValue}
-      options={defaultOptions}
-      path={undefined}
-      onItemSelect={onChange}
-      onPathChange={jest.fn()}
-    />,
-  );
+  function TestComponent() {
+    const [path, setPath] = useState<DashboardPickerStatePath>();
+
+    return (
+      <DashboardPicker
+        initialValue={initialValue}
+        options={defaultOptions}
+        path={path}
+        onItemSelect={onChange}
+        onPathChange={setPath}
+      />
+    );
+  }
+
+  renderWithProviders(<TestComponent />);
 
   await waitForLoaderToBeRemoved();
 };

--- a/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPicker.unit.spec.tsx
@@ -193,9 +193,11 @@ const setupPicker = async ({
 
   renderWithProviders(
     <DashboardPicker
-      onItemSelect={onChange}
       initialValue={initialValue}
       options={defaultOptions}
+      path={undefined}
+      onItemSelect={onChange}
+      onPathChange={jest.fn()}
     />,
   );
 

--- a/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPickerModal.tsx
+++ b/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPickerModal.tsx
@@ -15,7 +15,7 @@ import type {
   DashboardPickerInitialValueItem,
   DashboardPickerItem,
   DashboardPickerOptions,
-  DashboardPickerPath,
+  DashboardPickerStatePath,
   DashboardPickerValueItem,
 } from "../types";
 import { getCollectionId } from "../utils";
@@ -115,7 +115,8 @@ export const DashboardPickerModal = ({
     </Button>,
   ];
 
-  const [dashboardsPath, setDashboardsPath] = useState<DashboardPickerPath>();
+  const [dashboardsPath, setDashboardsPath] =
+    useState<DashboardPickerStatePath>();
 
   const tabs: EntityPickerTab<
     DashboardPickerItem["id"],

--- a/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPickerModal.tsx
+++ b/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPickerModal.tsx
@@ -15,6 +15,7 @@ import type {
   DashboardPickerInitialValueItem,
   DashboardPickerItem,
   DashboardPickerOptions,
+  DashboardPickerPath,
   DashboardPickerValueItem,
 } from "../types";
 import { getCollectionId } from "../utils";
@@ -114,6 +115,8 @@ export const DashboardPickerModal = ({
     </Button>,
   ];
 
+  const [dashboardsPath, setDashboardsPath] = useState<DashboardPickerPath>();
+
   const tabs: EntityPickerTab<
     DashboardPickerItem["id"],
     DashboardPickerItem["model"],
@@ -127,12 +130,14 @@ export const DashboardPickerModal = ({
       icon: "dashboard",
       render: ({ onItemSelect }) => (
         <DashboardPicker
-          onItemSelect={onItemSelect}
           initialValue={value}
-          options={options}
           models={["dashboard"]}
+          options={options}
+          path={dashboardsPath}
           ref={pickerRef}
           shouldDisableItem={shouldDisableItem}
+          onItemSelect={onItemSelect}
+          onPathChange={setDashboardsPath}
         />
       ),
     },

--- a/frontend/src/metabase/common/components/DashboardPicker/types.ts
+++ b/frontend/src/metabase/common/components/DashboardPicker/types.ts
@@ -9,7 +9,11 @@ import type {
   CollectionItemId,
   CollectionPickerItem,
 } from "../CollectionPicker";
-import type { EntityPickerModalOptions, ListProps } from "../EntityPicker";
+import type {
+  EntityPickerModalOptions,
+  ListProps,
+  PickerState,
+} from "../EntityPicker";
 
 export type DashboardPickerModel = Extract<
   CollectionPickerItem["model"],
@@ -45,4 +49,9 @@ export type DashboardItemListProps = ListProps<
   DashboardPickerItem,
   ListCollectionItemsRequest,
   DashboardPickerOptions
+>;
+
+export type DashboardPickerPath = PickerState<
+  DashboardPickerItem,
+  ListCollectionItemsRequest
 >;

--- a/frontend/src/metabase/common/components/DashboardPicker/types.ts
+++ b/frontend/src/metabase/common/components/DashboardPicker/types.ts
@@ -51,7 +51,7 @@ export type DashboardItemListProps = ListProps<
   DashboardPickerOptions
 >;
 
-export type DashboardPickerPath = PickerState<
+export type DashboardPickerStatePath = PickerState<
   DashboardPickerItem,
   ListCollectionItemsRequest
 >;

--- a/frontend/src/metabase/common/components/DashboardPicker/utils.ts
+++ b/frontend/src/metabase/common/components/DashboardPicker/utils.ts
@@ -13,6 +13,7 @@ import type { PickerState } from "../EntityPicker";
 import type {
   DashboardPickerInitialValueItem,
   DashboardPickerItem,
+  DashboardPickerPath,
 } from "./types";
 
 export const getCollectionIdPath = (
@@ -61,7 +62,7 @@ export const getStateFromIdPath = ({
   idPath: CollectionId[];
   namespace?: "snippets";
   models?: CollectionItemModel[];
-}): PickerState<DashboardPickerItem, ListCollectionItemsRequest> => {
+}): DashboardPickerPath => {
   const statePath: PickerState<
     DashboardPickerItem,
     ListCollectionItemsRequest

--- a/frontend/src/metabase/common/components/DashboardPicker/utils.ts
+++ b/frontend/src/metabase/common/components/DashboardPicker/utils.ts
@@ -13,7 +13,7 @@ import type { PickerState } from "../EntityPicker";
 import type {
   DashboardPickerInitialValueItem,
   DashboardPickerItem,
-  DashboardPickerPath,
+  DashboardPickerStatePath,
 } from "./types";
 
 export const getCollectionIdPath = (
@@ -62,7 +62,7 @@ export const getStateFromIdPath = ({
   idPath: CollectionId[];
   namespace?: "snippets";
   models?: CollectionItemModel[];
-}): DashboardPickerPath => {
+}): DashboardPickerStatePath => {
   const statePath: PickerState<
     DashboardPickerItem,
     ListCollectionItemsRequest

--- a/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
+++ b/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
@@ -147,12 +147,12 @@ export const DataPickerModal = ({
             options={options}
             path={modelsPath}
             shouldShowItem={modelsShouldShowItem}
-            onItemSelect={(questionPickerItem, path) => {
+            onItemSelect={questionPickerItem => {
               const item =
                 castQuestionPickerItemToDataPickerItem(questionPickerItem);
               onItemSelect(item);
-              setModelsPath(path);
             }}
+            onPathChange={setModelsPath}
           />
         ),
       });
@@ -172,12 +172,12 @@ export const DataPickerModal = ({
             options={options}
             path={metricsPath}
             shouldShowItem={metricsShouldShowItem}
-            onItemSelect={(questionPickerItem, path) => {
+            onItemSelect={questionPickerItem => {
               const item =
                 castQuestionPickerItemToDataPickerItem(questionPickerItem);
               onItemSelect(item);
-              setMetricsPath(path);
             }}
+            onPathChange={setMetricsPath}
           />
         ),
       });
@@ -195,10 +195,8 @@ export const DataPickerModal = ({
             databaseId={databaseId}
             path={tablesPath}
             value={isTableItem(value) ? value : undefined}
-            onItemSelect={(item, path) => {
-              onItemSelect(item);
-              setTablesPath(path);
-            }}
+            onItemSelect={onItemSelect}
+            onPathChange={setTablesPath}
           />
         ),
       });
@@ -218,12 +216,12 @@ export const DataPickerModal = ({
             options={options}
             path={questionsPath}
             shouldShowItem={questionsShouldShowItem}
-            onItemSelect={(questionPickerItem, path) => {
+            onItemSelect={questionPickerItem => {
               const item =
                 castQuestionPickerItemToDataPickerItem(questionPickerItem);
               onItemSelect(item);
-              setQuestionsPath(path);
             }}
+            onPathChange={setQuestionsPath}
           />
         ),
       });

--- a/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
+++ b/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
@@ -14,13 +14,16 @@ import type {
 import type { EntityPickerTab } from "../../EntityPicker";
 import { EntityPickerModal, defaultOptions } from "../../EntityPicker";
 import { useLogRecentItem } from "../../EntityPicker/hooks/use-log-recent-item";
-import { QuestionPicker, type QuestionPickerPath } from "../../QuestionPicker";
+import {
+  QuestionPicker,
+  type QuestionPickerStatePath,
+} from "../../QuestionPicker";
 import { useAvailableData } from "../hooks";
 import type {
   DataPickerItem,
   DataPickerModalOptions,
   DataPickerValue,
-  TablePickerPath,
+  TablePickerStatePath,
 } from "../types";
 import {
   castQuestionPickerItemToDataPickerItem,
@@ -121,10 +124,10 @@ export const DataPickerModal = ({
     [onChange, onClose, tryLogRecentItem],
   );
 
-  const [modelsPath, setModelsPath] = useState<QuestionPickerPath>();
-  const [metricsPath, setMetricsPath] = useState<QuestionPickerPath>();
-  const [questionsPath, setQuestionsPath] = useState<QuestionPickerPath>();
-  const [tablesPath, setTablesPath] = useState<TablePickerPath>();
+  const [modelsPath, setModelsPath] = useState<QuestionPickerStatePath>();
+  const [metricsPath, setMetricsPath] = useState<QuestionPickerStatePath>();
+  const [questionsPath, setQuestionsPath] = useState<QuestionPickerStatePath>();
+  const [tablesPath, setTablesPath] = useState<TablePickerStatePath>();
 
   const tabs = (function getTabs() {
     const computedTabs: EntityPickerTab<

--- a/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
+++ b/frontend/src/metabase/common/components/DataPicker/components/DataPickerModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
 
 import { useSetting } from "metabase/common/hooks";
@@ -14,12 +14,13 @@ import type {
 import type { EntityPickerTab } from "../../EntityPicker";
 import { EntityPickerModal, defaultOptions } from "../../EntityPicker";
 import { useLogRecentItem } from "../../EntityPicker/hooks/use-log-recent-item";
-import { QuestionPicker } from "../../QuestionPicker";
+import { QuestionPicker, type QuestionPickerPath } from "../../QuestionPicker";
 import { useAvailableData } from "../hooks";
 import type {
   DataPickerItem,
   DataPickerModalOptions,
   DataPickerValue,
+  TablePickerPath,
 } from "../types";
 import {
   castQuestionPickerItemToDataPickerItem,
@@ -120,6 +121,11 @@ export const DataPickerModal = ({
     [onChange, onClose, tryLogRecentItem],
   );
 
+  const [modelsPath, setModelsPath] = useState<QuestionPickerPath>();
+  const [metricsPath, setMetricsPath] = useState<QuestionPickerPath>();
+  const [questionsPath, setQuestionsPath] = useState<QuestionPickerPath>();
+  const [tablesPath, setTablesPath] = useState<TablePickerPath>();
+
   const tabs = (function getTabs() {
     const computedTabs: EntityPickerTab<
       DataPickerItem["id"],
@@ -139,11 +145,13 @@ export const DataPickerModal = ({
             initialValue={isModelItem(value) ? value : undefined}
             models={MODEL_PICKER_MODELS}
             options={options}
+            path={modelsPath}
             shouldShowItem={modelsShouldShowItem}
-            onItemSelect={questionPickerItem => {
+            onItemSelect={(questionPickerItem, path) => {
               const item =
                 castQuestionPickerItemToDataPickerItem(questionPickerItem);
               onItemSelect(item);
+              setModelsPath(path);
             }}
           />
         ),
@@ -162,11 +170,13 @@ export const DataPickerModal = ({
             initialValue={isMetricItem(value) ? value : undefined}
             models={METRIC_PICKER_MODELS}
             options={options}
+            path={metricsPath}
             shouldShowItem={metricsShouldShowItem}
-            onItemSelect={questionPickerItem => {
+            onItemSelect={(questionPickerItem, path) => {
               const item =
                 castQuestionPickerItemToDataPickerItem(questionPickerItem);
               onItemSelect(item);
+              setMetricsPath(path);
             }}
           />
         ),
@@ -183,8 +193,12 @@ export const DataPickerModal = ({
         render: ({ onItemSelect }) => (
           <TablePicker
             databaseId={databaseId}
+            path={tablesPath}
             value={isTableItem(value) ? value : undefined}
-            onItemSelect={onItemSelect}
+            onItemSelect={(item, path) => {
+              onItemSelect(item);
+              setTablesPath(path);
+            }}
           />
         ),
       });
@@ -202,11 +216,13 @@ export const DataPickerModal = ({
             initialValue={isQuestionItem(value) ? value : undefined}
             models={QUESTION_PICKER_MODELS}
             options={options}
+            path={questionsPath}
             shouldShowItem={questionsShouldShowItem}
-            onItemSelect={questionPickerItem => {
+            onItemSelect={(questionPickerItem, path) => {
               const item =
                 castQuestionPickerItemToDataPickerItem(questionPickerItem);
               onItemSelect(item);
+              setQuestionsPath(path);
             }}
           />
         ),

--- a/frontend/src/metabase/common/components/DataPicker/components/TablePicker.tsx
+++ b/frontend/src/metabase/common/components/DataPicker/components/TablePicker.tsx
@@ -31,7 +31,8 @@ interface Props {
   databaseId?: DatabaseId;
   path: TablePickerPath | undefined;
   value: TablePickerValue | undefined;
-  onItemSelect: (value: DataPickerItem, path: TablePickerPath) => void;
+  onItemSelect: (value: DataPickerItem) => void;
+  onPathChange: (path: TablePickerPath) => void;
 }
 
 export const TablePicker = ({
@@ -39,6 +40,7 @@ export const TablePicker = ({
   path,
   value,
   onItemSelect,
+  onPathChange,
 }: Props) => {
   const defaultPath = useMemo<TablePickerPath>(() => {
     return [databaseId ?? value?.db_id, value?.schema, value?.id];
@@ -94,32 +96,36 @@ export const TablePicker = ({
           const newSchemaName = schemas?.length === 1 ? schemas[0] : undefined;
           const newPath: TablePickerPath = [dbId, newSchemaName, undefined];
           setSchemaName(newSchemaName);
-          onItemSelect(folder, newPath);
+          onItemSelect(folder);
+          onPathChange(newPath);
         } else {
           const newPath: TablePickerPath = [folder.id, undefined, undefined];
           setDbId(folder.id);
           setSchemaName(undefined);
-          onItemSelect(folder, newPath);
+          onItemSelect(folder);
+          onPathChange(newPath);
         }
       }
 
       if (folder.model === "schema") {
         const newPath: TablePickerPath = [dbId, folder.id, undefined];
         setSchemaName(folder.id);
-        onItemSelect(folder, newPath);
+        onItemSelect(folder);
+        onPathChange(newPath);
       }
 
       setTableId(undefined);
     },
-    [dbId, schemas, onItemSelect],
+    [dbId, schemas, onItemSelect, onPathChange],
   );
 
   const handleTableSelect = useCallback(
     (item: DataPickerValueItem) => {
       setTableId(item.id);
-      onItemSelect(item, [dbId, schemaName, item.id]);
+      onItemSelect(item);
+      onPathChange([dbId, schemaName, item.id]);
     },
-    [dbId, schemaName, setTableId, onItemSelect],
+    [dbId, schemaName, setTableId, onItemSelect, onPathChange],
   );
 
   return (

--- a/frontend/src/metabase/common/components/DataPicker/components/TablePicker.tsx
+++ b/frontend/src/metabase/common/components/DataPicker/components/TablePicker.tsx
@@ -15,7 +15,7 @@ import type {
   DataPickerFolderItem,
   DataPickerItem,
   DataPickerValueItem,
-  TablePickerPath,
+  TablePickerStatePath,
   TablePickerValue,
 } from "../types";
 import { generateKey, getDbItem, getSchemaItem, getTableItem } from "../utils";
@@ -29,10 +29,10 @@ interface Props {
    * Limit selection to a particular database
    */
   databaseId?: DatabaseId;
-  path: TablePickerPath | undefined;
+  path: TablePickerStatePath | undefined;
   value: TablePickerValue | undefined;
   onItemSelect: (value: DataPickerItem) => void;
-  onPathChange: (path: TablePickerPath) => void;
+  onPathChange: (path: TablePickerStatePath) => void;
 }
 
 export const TablePicker = ({
@@ -42,7 +42,7 @@ export const TablePicker = ({
   onItemSelect,
   onPathChange,
 }: Props) => {
-  const defaultPath = useMemo<TablePickerPath>(() => {
+  const defaultPath = useMemo<TablePickerStatePath>(() => {
     return [databaseId ?? value?.db_id, value?.schema, value?.id];
   }, [databaseId, value]);
   const [initialDbId, initialSchemaId, initialTableId] = path ?? defaultPath;
@@ -94,12 +94,20 @@ export const TablePicker = ({
       if (folder.model === "database") {
         if (dbId === folder.id) {
           const newSchemaName = schemas?.length === 1 ? schemas[0] : undefined;
-          const newPath: TablePickerPath = [dbId, newSchemaName, undefined];
+          const newPath: TablePickerStatePath = [
+            dbId,
+            newSchemaName,
+            undefined,
+          ];
           setSchemaName(newSchemaName);
           onItemSelect(folder);
           onPathChange(newPath);
         } else {
-          const newPath: TablePickerPath = [folder.id, undefined, undefined];
+          const newPath: TablePickerStatePath = [
+            folder.id,
+            undefined,
+            undefined,
+          ];
           setDbId(folder.id);
           setSchemaName(undefined);
           onItemSelect(folder);
@@ -108,7 +116,7 @@ export const TablePicker = ({
       }
 
       if (folder.model === "schema") {
-        const newPath: TablePickerPath = [dbId, folder.id, undefined];
+        const newPath: TablePickerStatePath = [dbId, folder.id, undefined];
         setSchemaName(folder.id);
         onItemSelect(folder);
         onPathChange(newPath);

--- a/frontend/src/metabase/common/components/DataPicker/types.ts
+++ b/frontend/src/metabase/common/components/DataPicker/types.ts
@@ -78,7 +78,7 @@ export type DataPickerItem = DataPickerFolderItem | DataPickerValueItem;
 export type DataPickerModalOptions = EntityPickerModalOptions &
   QuestionPickerOptions;
 
-export type TablePickerPath = [
+export type TablePickerStatePath = [
   DatabaseId | undefined,
   SchemaName | undefined,
   TableId | undefined,

--- a/frontend/src/metabase/common/components/DataPicker/types.ts
+++ b/frontend/src/metabase/common/components/DataPicker/types.ts
@@ -77,3 +77,9 @@ export type DataPickerItem = DataPickerFolderItem | DataPickerValueItem;
 
 export type DataPickerModalOptions = EntityPickerModalOptions &
   QuestionPickerOptions;
+
+export type TablePickerPath = [
+  DatabaseId | undefined,
+  SchemaName | undefined,
+  TableId | undefined,
+];

--- a/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.tsx
+++ b/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.tsx
@@ -17,7 +17,7 @@ import { DelayedLoadingSpinner, NestedItemPicker } from "../../EntityPicker";
 import type {
   QuestionPickerItem,
   QuestionPickerOptions,
-  QuestionPickerPath,
+  QuestionPickerStatePath,
 } from "../types";
 import {
   getCollectionIdPath,
@@ -36,10 +36,10 @@ interface QuestionPickerProps {
   initialValue?: Pick<QuestionPickerItem, "model" | "id">;
   models?: CollectionItemModel[];
   options: QuestionPickerOptions;
-  path: QuestionPickerPath | undefined;
+  path: QuestionPickerStatePath | undefined;
   shouldShowItem?: (item: QuestionPickerItem) => boolean;
   onItemSelect: (item: QuestionPickerItem) => void;
-  onPathChange: (path: QuestionPickerPath) => void;
+  onPathChange: (path: QuestionPickerStatePath) => void;
 }
 
 const useGetInitialCollection = (

--- a/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.tsx
+++ b/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.tsx
@@ -154,7 +154,6 @@ export const QuestionPicker = ({
 
         newPath[newPath.length - 1].selectedItem = newSelectedItem;
 
-        onItemSelect(newSelectedItem);
         onPathChange(newPath);
       }
     },

--- a/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.tsx
+++ b/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useMemo } from "react";
 import { useDeepCompareEffect } from "react-use";
 
 import {
@@ -9,19 +9,16 @@ import {
 import { isValidCollectionId } from "metabase/collections/utils";
 import { useSelector } from "metabase/lib/redux";
 import { getUserPersonalCollectionId } from "metabase/selectors/user";
-import type {
-  CollectionItemModel,
-  ListCollectionItemsRequest,
-} from "metabase-types/api";
+import type { CollectionItemModel } from "metabase-types/api";
 
 import { CollectionItemPickerResolver } from "../../CollectionPicker/components/CollectionItemPickerResolver";
 import { getPathLevelForItem } from "../../CollectionPicker/utils";
-import {
-  DelayedLoadingSpinner,
-  NestedItemPicker,
-  type PickerState,
-} from "../../EntityPicker";
-import type { QuestionPickerItem, QuestionPickerOptions } from "../types";
+import { DelayedLoadingSpinner, NestedItemPicker } from "../../EntityPicker";
+import type {
+  QuestionPickerItem,
+  QuestionPickerOptions,
+  QuestionPickerPath,
+} from "../types";
 import {
   getCollectionIdPath,
   getQuestionPickerValueModel,
@@ -36,11 +33,12 @@ export const defaultOptions: QuestionPickerOptions = {
 };
 
 interface QuestionPickerProps {
-  onItemSelect: (item: QuestionPickerItem) => void;
   initialValue?: Pick<QuestionPickerItem, "model" | "id">;
-  options: QuestionPickerOptions;
   models?: CollectionItemModel[];
+  options: QuestionPickerOptions;
+  path: QuestionPickerPath | undefined;
   shouldShowItem?: (item: QuestionPickerItem) => boolean;
+  onItemSelect: (item: QuestionPickerItem, path: QuestionPickerPath) => void;
 }
 
 const useGetInitialCollection = (
@@ -82,20 +80,17 @@ const useGetInitialCollection = (
 };
 
 export const QuestionPicker = ({
-  onItemSelect,
   initialValue,
-  options,
   models = ["dataset", "card"],
+  options,
+  path: pathProp,
   shouldShowItem,
+  onItemSelect,
 }: QuestionPickerProps) => {
-  const [path, setPath] = useState<
-    PickerState<QuestionPickerItem, ListCollectionItemsRequest>
-  >(() =>
-    getStateFromIdPath({
-      idPath: ["root"],
-      models,
-    }),
-  );
+  const defaultPath = useMemo(() => {
+    return getStateFromIdPath({ idPath: ["root"], models });
+  }, [models]);
+  const path = pathProp ?? defaultPath;
 
   const { currentCollection, currentQuestion, isLoading } =
     useGetInitialCollection(initialValue);
@@ -108,10 +103,9 @@ export const QuestionPicker = ({
         idPath: getCollectionIdPath(folder, userPersonalCollectionId),
         models,
       });
-      setPath(newPath);
-      onItemSelect(folder);
+      onItemSelect(folder, newPath);
     },
-    [setPath, onItemSelect, userPersonalCollectionId, models],
+    [onItemSelect, userPersonalCollectionId, models],
   );
 
   const handleItemSelect = useCallback(
@@ -125,10 +119,9 @@ export const QuestionPicker = ({
 
       const newPath = path.slice(0, pathLevel + 1);
       newPath[newPath.length - 1].selectedItem = item;
-      setPath(newPath);
-      onItemSelect(item);
+      onItemSelect(item, newPath);
     },
-    [setPath, onItemSelect, path, userPersonalCollectionId],
+    [onItemSelect, path, userPersonalCollectionId],
   );
 
   useDeepCompareEffect(
@@ -143,7 +136,7 @@ export const QuestionPicker = ({
         });
 
         // start with the current item selected if we can
-        newPath[newPath.length - 1].selectedItem = currentQuestion
+        const newSelectedItem: QuestionPickerItem = currentQuestion
           ? {
               id: currentQuestion.id,
               name: currentQuestion.name,
@@ -155,7 +148,9 @@ export const QuestionPicker = ({
               model: "collection",
             };
 
-        setPath(newPath);
+        newPath[newPath.length - 1].selectedItem = newSelectedItem;
+
+        onItemSelect(newSelectedItem, newPath);
       }
     },
     [currentCollection, userPersonalCollectionId],

--- a/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.tsx
+++ b/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.tsx
@@ -38,7 +38,8 @@ interface QuestionPickerProps {
   options: QuestionPickerOptions;
   path: QuestionPickerPath | undefined;
   shouldShowItem?: (item: QuestionPickerItem) => boolean;
-  onItemSelect: (item: QuestionPickerItem, path: QuestionPickerPath) => void;
+  onItemSelect: (item: QuestionPickerItem) => void;
+  onPathChange: (path: QuestionPickerPath) => void;
 }
 
 const useGetInitialCollection = (
@@ -86,6 +87,7 @@ export const QuestionPicker = ({
   path: pathProp,
   shouldShowItem,
   onItemSelect,
+  onPathChange,
 }: QuestionPickerProps) => {
   const defaultPath = useMemo(() => {
     return getStateFromIdPath({ idPath: ["root"], models });
@@ -103,9 +105,10 @@ export const QuestionPicker = ({
         idPath: getCollectionIdPath(folder, userPersonalCollectionId),
         models,
       });
-      onItemSelect(folder, newPath);
+      onItemSelect(folder);
+      onPathChange(newPath);
     },
-    [onItemSelect, userPersonalCollectionId, models],
+    [onItemSelect, onPathChange, userPersonalCollectionId, models],
   );
 
   const handleItemSelect = useCallback(
@@ -119,9 +122,10 @@ export const QuestionPicker = ({
 
       const newPath = path.slice(0, pathLevel + 1);
       newPath[newPath.length - 1].selectedItem = item;
-      onItemSelect(item, newPath);
+      onItemSelect(item);
+      onPathChange(newPath);
     },
-    [onItemSelect, path, userPersonalCollectionId],
+    [onItemSelect, onPathChange, path, userPersonalCollectionId],
   );
 
   useDeepCompareEffect(
@@ -150,7 +154,8 @@ export const QuestionPicker = ({
 
         newPath[newPath.length - 1].selectedItem = newSelectedItem;
 
-        onItemSelect(newSelectedItem, newPath);
+        onItemSelect(newSelectedItem);
+        onPathChange(newPath);
       }
     },
     [currentCollection, userPersonalCollectionId],

--- a/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.tsx
+++ b/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.tsx
@@ -158,7 +158,7 @@ export const QuestionPicker = ({
         onPathChange(newPath);
       }
     },
-    [currentCollection, userPersonalCollectionId],
+    [currentCollection, userPersonalCollectionId, onPathChange],
   );
 
   if (isLoading) {

--- a/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.unit.spec.tsx
@@ -193,6 +193,7 @@ const setupPicker = async ({
       initialValue={initialValue}
       models={["card"]}
       options={defaultOptions}
+      path={undefined}
     />,
   );
 

--- a/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.unit.spec.tsx
@@ -1,6 +1,6 @@
 import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
-import _ from "underscore";
+import { useState } from "react";
 
 import {
   setupCollectionItemsEndpoint,
@@ -21,7 +21,11 @@ import {
   createMockCollectionItem,
 } from "metabase-types/api/mocks";
 
-import type { QuestionPickerItem, QuestionPickerValueModel } from "../types";
+import type {
+  QuestionPickerItem,
+  QuestionPickerStatePath,
+  QuestionPickerValueModel,
+} from "../types";
 
 import { QuestionPicker, defaultOptions } from "./QuestionPicker";
 import { QuestionPickerModal } from "./QuestionPickerModal";
@@ -187,16 +191,22 @@ const setupPicker = async ({
 }: SetupOpts = {}) => {
   commonSetup();
 
-  renderWithProviders(
-    <QuestionPicker
-      initialValue={initialValue}
-      models={["card"]}
-      options={defaultOptions}
-      path={undefined}
-      onItemSelect={onChange}
-      onPathChange={jest.fn()}
-    />,
-  );
+  function TestComponent() {
+    const [path, setPath] = useState<QuestionPickerStatePath>();
+
+    return (
+      <QuestionPicker
+        initialValue={initialValue}
+        models={["card"]}
+        options={defaultOptions}
+        path={path}
+        onItemSelect={onChange}
+        onPathChange={setPath}
+      />
+    );
+  }
+
+  renderWithProviders(<TestComponent />);
 
   await waitForLoaderToBeRemoved();
 };

--- a/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.unit.spec.tsx
@@ -189,11 +189,12 @@ const setupPicker = async ({
 
   renderWithProviders(
     <QuestionPicker
-      onItemSelect={onChange}
       initialValue={initialValue}
       models={["card"]}
       options={defaultOptions}
       path={undefined}
+      onItemSelect={onChange}
+      onPathChange={jest.fn()}
     />,
   );
 

--- a/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPickerModal.tsx
+++ b/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPickerModal.tsx
@@ -11,6 +11,7 @@ import type {
   QuestionPickerItem,
   QuestionPickerModel,
   QuestionPickerOptions,
+  QuestionPickerPath,
   QuestionPickerValue,
   QuestionPickerValueItem,
 } from "../types";
@@ -85,6 +86,10 @@ export const QuestionPickerModal = ({
     }
   };
 
+  const [modelsPath, setModelsPath] = useState<QuestionPickerPath>();
+  const [metricsPath, setMetricsPath] = useState<QuestionPickerPath>();
+  const [questionsPath, setQuestionsPath] = useState<QuestionPickerPath>();
+
   const tabs: EntityPickerTab<
     QuestionPickerItem["id"],
     QuestionPickerItem["model"],
@@ -98,10 +103,14 @@ export const QuestionPickerModal = ({
       icon: "table",
       render: ({ onItemSelect }) => (
         <QuestionPicker
-          onItemSelect={onItemSelect}
           initialValue={value}
-          options={options}
           models={["card"]}
+          options={options}
+          path={questionsPath}
+          onItemSelect={(item, path) => {
+            onItemSelect(item);
+            setQuestionsPath(path);
+          }}
         />
       ),
     },
@@ -113,10 +122,14 @@ export const QuestionPickerModal = ({
       icon: "model",
       render: ({ onItemSelect }) => (
         <QuestionPicker
-          onItemSelect={onItemSelect}
           initialValue={value}
-          options={options}
           models={["dataset"]}
+          options={options}
+          path={modelsPath}
+          onItemSelect={(item, path) => {
+            onItemSelect(item);
+            setModelsPath(path);
+          }}
         />
       ),
     },
@@ -128,10 +141,14 @@ export const QuestionPickerModal = ({
       icon: "metric",
       render: ({ onItemSelect }) => (
         <QuestionPicker
-          onItemSelect={onItemSelect}
           initialValue={value}
-          options={options}
           models={["metric"]}
+          options={options}
+          path={metricsPath}
+          onItemSelect={(item, path) => {
+            onItemSelect(item);
+            setMetricsPath(path);
+          }}
         />
       ),
     },

--- a/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPickerModal.tsx
+++ b/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPickerModal.tsx
@@ -107,10 +107,8 @@ export const QuestionPickerModal = ({
           models={["card"]}
           options={options}
           path={questionsPath}
-          onItemSelect={(item, path) => {
-            onItemSelect(item);
-            setQuestionsPath(path);
-          }}
+          onItemSelect={onItemSelect}
+          onPathChange={setQuestionsPath}
         />
       ),
     },
@@ -126,10 +124,8 @@ export const QuestionPickerModal = ({
           models={["dataset"]}
           options={options}
           path={modelsPath}
-          onItemSelect={(item, path) => {
-            onItemSelect(item);
-            setModelsPath(path);
-          }}
+          onItemSelect={onItemSelect}
+          onPathChange={setModelsPath}
         />
       ),
     },
@@ -145,10 +141,8 @@ export const QuestionPickerModal = ({
           models={["metric"]}
           options={options}
           path={metricsPath}
-          onItemSelect={(item, path) => {
-            onItemSelect(item);
-            setMetricsPath(path);
-          }}
+          onItemSelect={onItemSelect}
+          onPathChange={setMetricsPath}
         />
       ),
     },

--- a/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPickerModal.tsx
+++ b/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPickerModal.tsx
@@ -11,7 +11,7 @@ import type {
   QuestionPickerItem,
   QuestionPickerModel,
   QuestionPickerOptions,
-  QuestionPickerPath,
+  QuestionPickerStatePath,
   QuestionPickerValue,
   QuestionPickerValueItem,
 } from "../types";
@@ -86,9 +86,9 @@ export const QuestionPickerModal = ({
     }
   };
 
-  const [modelsPath, setModelsPath] = useState<QuestionPickerPath>();
-  const [metricsPath, setMetricsPath] = useState<QuestionPickerPath>();
-  const [questionsPath, setQuestionsPath] = useState<QuestionPickerPath>();
+  const [modelsPath, setModelsPath] = useState<QuestionPickerStatePath>();
+  const [metricsPath, setMetricsPath] = useState<QuestionPickerStatePath>();
+  const [questionsPath, setQuestionsPath] = useState<QuestionPickerStatePath>();
 
   const tabs: EntityPickerTab<
     QuestionPickerItem["id"],

--- a/frontend/src/metabase/common/components/QuestionPicker/types.ts
+++ b/frontend/src/metabase/common/components/QuestionPicker/types.ts
@@ -45,7 +45,7 @@ export type QuestionItemListProps = ListProps<
   QuestionPickerOptions
 >;
 
-export type QuestionPickerPath = PickerState<
+export type QuestionPickerStatePath = PickerState<
   QuestionPickerItem,
   ListCollectionItemsRequest
 >;

--- a/frontend/src/metabase/common/components/QuestionPicker/types.ts
+++ b/frontend/src/metabase/common/components/QuestionPicker/types.ts
@@ -8,7 +8,11 @@ import type {
   CollectionItemId,
   CollectionPickerItem,
 } from "../CollectionPicker";
-import type { EntityPickerModalOptions, ListProps } from "../EntityPicker";
+import type {
+  EntityPickerModalOptions,
+  ListProps,
+  PickerState,
+} from "../EntityPicker";
 
 export type QuestionPickerModel = Extract<
   CollectionPickerItem["model"],
@@ -39,4 +43,9 @@ export type QuestionItemListProps = ListProps<
   QuestionPickerItem,
   ListCollectionItemsRequest,
   QuestionPickerOptions
+>;
+
+export type QuestionPickerPath = PickerState<
+  QuestionPickerItem,
+  ListCollectionItemsRequest
 >;

--- a/frontend/src/metabase/common/components/QuestionPicker/utils.ts
+++ b/frontend/src/metabase/common/components/QuestionPicker/utils.ts
@@ -6,13 +6,11 @@ import type {
   CardType,
   CollectionId,
   CollectionItemModel,
-  ListCollectionItemsRequest,
 } from "metabase-types/api";
-
-import type { PickerState } from "../EntityPicker";
 
 import type {
   QuestionPickerItem,
+  QuestionPickerPath,
   QuestionPickerValue,
   QuestionPickerValueModel,
 } from "./types";
@@ -63,17 +61,16 @@ export const getStateFromIdPath = ({
   idPath: CollectionId[];
   namespace?: "snippets";
   models?: CollectionItemModel[];
-}): PickerState<QuestionPickerItem, ListCollectionItemsRequest> => {
-  const statePath: PickerState<QuestionPickerItem, ListCollectionItemsRequest> =
-    [
-      {
-        selectedItem: {
-          name: "",
-          model: "collection",
-          id: idPath[0],
-        },
+}): QuestionPickerPath => {
+  const statePath: QuestionPickerPath = [
+    {
+      selectedItem: {
+        name: "",
+        model: "collection",
+        id: idPath[0],
       },
-    ];
+    },
+  ];
 
   idPath.forEach((id, index) => {
     const nextLevelId = idPath[index + 1] ?? null;

--- a/frontend/src/metabase/common/components/QuestionPicker/utils.ts
+++ b/frontend/src/metabase/common/components/QuestionPicker/utils.ts
@@ -10,7 +10,7 @@ import type {
 
 import type {
   QuestionPickerItem,
-  QuestionPickerPath,
+  QuestionPickerStatePath,
   QuestionPickerValue,
   QuestionPickerValueModel,
 } from "./types";
@@ -61,8 +61,8 @@ export const getStateFromIdPath = ({
   idPath: CollectionId[];
   namespace?: "snippets";
   models?: CollectionItemModel[];
-}): QuestionPickerPath => {
-  const statePath: QuestionPickerPath = [
+}): QuestionPickerStatePath => {
+  const statePath: QuestionPickerStatePath = [
     {
       selectedItem: {
         name: "",


### PR DESCRIPTION
Closes #47454

### Description

This PR lifts `path` state from `QuestionPicker`, `CollectionPicker`, `DashboardPicker` and `TablePicker` components and adds `path` + `onPathChange` props to them. Thanks to this entity picker tab state is preserved when a tab is unmounted (i.e. different tab is opened).

Tests will be added separately. This PR goes to an integration branch.

----

Initially I tried 2 different approaches:
1. Using `keepMounted` prop in Mantine's `Tabs` component. Unfortunately this caused lots of e2e tests to fail because Cypress could now access elements from inactive tabs. Fixing that would require changing every place that uses `entityPickerModal()` helper (> 250 usages). Not good.
2. "Smartly" managing the state in `EntityPickerModal`. The downside is that it's hell to make it work with generic types. Type casting is not a reliable workaround.

### How to verify

CI is green.
Tab state is remembered when navigating through tabs in the entity picker (collection picker, question picker, table picker, dashboard picker). This does not apply to "Recents" and "Search" tabs.

### Demo

#### Before

https://github.com/user-attachments/assets/bbd11968-905d-44e7-a858-f9edad871469


#### After

https://github.com/user-attachments/assets/90aef6a5-6fea-4198-9cd2-422f506bf8ca

