### PR TITLE
Return to previously opened tab when search input is cleared in Entity Picker

### DIFF
--- a/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
@@ -865,6 +865,7 @@ describe.skip("issue 25189", () => {
 
       resetTestTable({ type: dialect, table: tableName });
       cy.request("POST", `/api/database/${WRITABLE_DB_ID}/sync_schema`);
+      cy.intercept("GET", "/api/search*").as("search");
     });
 
     it("should display all summarize options if the only numeric field is a custom column (metabase#27745)", () => {
@@ -872,6 +873,7 @@ describe.skip("issue 25189", () => {
 
       entityPickerModal().within(() => {
         cy.findByPlaceholderText("Search…").type("colors");
+        cy.wait("@search");
         cy.findByTestId("result-item")
           .contains(/colors/i)
           .click();

--- a/e2e/test/scenarios/question-reproductions/reproductions-2.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-2.cy.spec.js
@@ -564,6 +564,7 @@ describe("issue 36669", () => {
   beforeEach(() => {
     restore();
     cy.signInAsNormalUser();
+    cy.intercept("GET", "/api/search*").as("search");
   });
 
   it("should be able to change question data source to raw data after selecting saved question (metabase#36669)", () => {
@@ -581,6 +582,7 @@ describe("issue 36669", () => {
 
     entityPickerModal().within(() => {
       cy.findByPlaceholderText("Search…").type("Orders 36669");
+      cy.wait("@search");
 
       cy.findByRole("tabpanel").findByText("Orders 36669").click();
     });

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
@@ -236,7 +236,7 @@ export function EntityPickerModal<
   );
 
   useEffect(() => {
-    // when the searchQuery changes, switch to the search tab
+    // automatically switch to search tab when it becomes available (i.e. when searchQuery is not empty)
     if (hasSearchTab) {
       setSelectedTabId(SEARCH_TAB_ID);
     } else {

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
@@ -116,7 +116,6 @@ export function EntityPickerModal<
   onItemSelect,
 }: EntityPickerModalProps<Id, Model, Item>) {
   const [searchQuery, setSearchQuery] = useState<string>("");
-  const hasSearchTab = searchQuery.length > 0;
   const { data: recentItems, isLoading: isLoadingRecentItems } =
     useListRecentsQuery(
       { context: recentsContext },
@@ -158,6 +157,7 @@ export function EntityPickerModal<
     const computedTabs: EntityPickerTab<Id, Model, Item>[] = [];
     const hasRecentsTab =
       hydratedOptions.hasRecents && filteredRecents.length > 0;
+    const hasSearchTab = !!searchQuery;
     // This is to prevent different tab being initially open and then flickering back
     // to recents tab once recents have loaded (due to computeInitialTab)
     const shouldOptimisticallyAddRecentsTabWhileLoading =

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.unit.spec.tsx
@@ -196,9 +196,7 @@ describe("EntityPickerModal", () => {
       await userEvent.type(
         await screen.findByPlaceholderText("Search…"),
         "My ",
-        {
-          delay: 50,
-        },
+        { delay: 50 },
       );
 
       expect(await screen.findByRole("tablist")).toBeInTheDocument();
@@ -213,6 +211,40 @@ describe("EntityPickerModal", () => {
       expect(onItemSelect).toHaveBeenCalledTimes(1);
     });
 
+    it("should return to previous tab when clearing the search input", async () => {
+      setup({
+        tabs: [TEST_CARD_TAB, TEST_TABLE_TAB],
+      });
+
+      expect(
+        await screen.findByRole("tab", { name: /All the foo/ }),
+      ).toHaveAttribute("data-active", "true");
+
+      await userEvent.click(
+        await screen.findByRole("tab", { name: /All the bar/ }),
+      );
+
+      expect(
+        await screen.findByRole("tab", { name: /All the bar/ }),
+      ).toHaveAttribute("data-active", "true");
+
+      await userEvent.type(
+        await screen.findByPlaceholderText("Search…"),
+        "My ",
+        { delay: 50 },
+      );
+
+      expect(
+        await screen.findByRole("tab", { name: /2 results for "My"/ }),
+      ).toHaveAttribute("data-active", "true");
+
+      await userEvent.clear(await screen.findByPlaceholderText("Search…"));
+
+      expect(
+        await screen.findByRole("tab", { name: /All the bar/ }),
+      ).toHaveAttribute("data-active", "true");
+    });
+
     it("should show a loading state while search is happening", async () => {
       setup({
         searchDelay: 2000,
@@ -221,9 +253,7 @@ describe("EntityPickerModal", () => {
       await userEvent.type(
         await screen.findByPlaceholderText("Search…"),
         "My ",
-        {
-          delay: 50,
-        },
+        { delay: 50 },
       );
       expect(await screen.findByRole("tablist")).toBeInTheDocument();
       expect(
@@ -272,9 +302,7 @@ describe("EntityPickerModal", () => {
       await userEvent.type(
         await screen.findByPlaceholderText("Search…"),
         "caterpie",
-        {
-          delay: 50,
-        },
+        { delay: 50 },
       );
 
       await userEvent.click(await screen.findByRole("tab", { name: /Search/ }));

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.unit.spec.tsx
@@ -211,7 +211,7 @@ describe("EntityPickerModal", () => {
       expect(onItemSelect).toHaveBeenCalledTimes(1);
     });
 
-    it("should return to previous tab when clearing the search input", async () => {
+    it("should return to previous tab when clearing the search input while search tab is open", async () => {
       setup({
         tabs: [TEST_CARD_TAB, TEST_TABLE_TAB],
       });
@@ -228,14 +228,40 @@ describe("EntityPickerModal", () => {
         await screen.findByRole("tab", { name: /All the bar/ }),
       ).toHaveAttribute("data-active", "true");
 
-      await userEvent.type(
-        await screen.findByPlaceholderText("Search…"),
-        "My ",
-        { delay: 50 },
+      await userEvent.type(await screen.findByPlaceholderText("Search…"), "M");
+
+      expect(
+        await screen.findByRole("tab", { name: /results for "M"/ }),
+      ).toHaveAttribute("data-active", "true");
+
+      await userEvent.clear(await screen.findByPlaceholderText("Search…"));
+
+      expect(
+        await screen.findByRole("tab", { name: /All the bar/ }),
+      ).toHaveAttribute("data-active", "true");
+    });
+
+    it("should not switch tab when clearing the search input while search tab is closed", async () => {
+      setup({
+        tabs: [TEST_CARD_TAB, TEST_TABLE_TAB],
+      });
+
+      await userEvent.type(await screen.findByPlaceholderText("Search…"), "M");
+
+      expect(
+        await screen.findByRole("tab", { name: /results for "M"/ }),
+      ).toHaveAttribute("data-active", "true");
+
+      await userEvent.click(
+        await screen.findByRole("tab", { name: /All the foo/ }),
+      );
+
+      await userEvent.click(
+        await screen.findByRole("tab", { name: /All the bar/ }),
       );
 
       expect(
-        await screen.findByRole("tab", { name: /2 results for "My"/ }),
+        await screen.findByRole("tab", { name: /All the bar/ }),
       ).toHaveAttribute("data-active", "true");
 
       await userEvent.clear(await screen.findByPlaceholderText("Search…"));


### PR DESCRIPTION
Closes #47289

### Description

See PR title.

_This PR does not include changes from #47794_

### Demo

#### Before


https://github.com/user-attachments/assets/29d4691a-607a-4bad-8091-173a4777be42



#### After

https://github.com/user-attachments/assets/0711d2e0-b9e8-4e80-8247-ef5577f99b74




