### PR TITLE
Remove column group singularization

### DIFF
--- a/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.js
@@ -596,7 +596,7 @@ describe("scenarios > admin > datamodel > metadata", () => {
       cy.get("[data-element-id=list-section-header]").should("have.length", 3);
       cy.get("[data-element-id=list-section-header]")
         .eq(0)
-        .should("have.text", "Review");
+        .should("have.text", "Reviews");
       cy.get("[data-element-id=list-section-header]")
         .eq(1)
         .should("have.text", "Product");

--- a/e2e/test/scenarios/binning/qb-implicit-joins.cy.spec.js
+++ b/e2e/test/scenarios/binning/qb-implicit-joins.cy.spec.js
@@ -1,6 +1,7 @@
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 import {
   changeBinningForDimension,
+  popover,
   restore,
   summarize,
   visitQuestion,
@@ -85,8 +86,7 @@ describe("scenarios > binning > from a saved QB question using implicit joins", 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Pick a column to group by").click();
       // Click "Order" accordion to collapse it and expose the other tables
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Order").click();
+      popover().findByText("Orders").click();
     });
 
     it("should work for time series", () => {

--- a/e2e/test/scenarios/dashboard-cards/dashcard-replace-question.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashcard-replace-question.cy.spec.js
@@ -204,7 +204,7 @@ describeWithSnowplow("scenarios > dashboard cards > replace question", () => {
     });
     assertDashboardFilterMapping(findTargetDashcard(), {
       filterName: PARAMETER.UNUSED.name,
-      expectedColumName: "Order.Discount",
+      expectedColumName: "Orders.Discount",
     });
 
     // Ensure changes are persisted

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-wiring.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-wiring.cy.spec.js
@@ -535,7 +535,7 @@ describe("dashboard filters auto-wiring", () => {
         .findByRole("button", { name: "Auto-connect" })
         .click();
 
-      getDashboardCard(0).findByText("Product.ID").should("exist");
+      getDashboardCard(0).findByText("Products.ID").should("exist");
       getDashboardCard(1).findByText("Product.ID").should("exist");
       getDashboardCard(2).findByText("Product.ID").should("exist");
 
@@ -585,7 +585,7 @@ describe("dashboard filters auto-wiring", () => {
 
       goToFilterMapping("ID");
 
-      getDashboardCard(0).findByText("Product.ID").should("exist");
+      getDashboardCard(0).findByText("Products.ID").should("exist");
       getDashboardCard(1).findByText("Product.ID").should("exist");
       getDashboardCard(2).findByText("Product.ID").should("exist");
 

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-management.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-management.cy.spec.js
@@ -99,18 +99,18 @@ describe("scenarios > dashboard > filters > management", () => {
 
       selectFilter("Location");
 
-      getDashboardCard().contains("Person.State");
+      getDashboardCard().contains("People.State");
       getDashboardCard(1).contains("User.City");
 
       cy.log("Disconnect cards");
       sidebar().findByText("Disconnect from cards").click();
 
-      getDashboardCard().should("not.contain", "Person.State");
+      getDashboardCard().should("not.contain", "People.State");
       getDashboardCard(1).should("not.contain", "User.City");
 
       selectFilter("Text");
 
-      getDashboardCard().should("contain", "Person.Name");
+      getDashboardCard().should("contain", "People.Name");
       getDashboardCard(1).should("contain", "User.Name");
 
       saveDashboard();
@@ -125,7 +125,7 @@ describe("scenarios > dashboard > filters > management", () => {
 
       selectFilter("Text");
 
-      getDashboardCard().should("contain", "Person.Name");
+      getDashboardCard().should("contain", "People.Name");
 
       cy.log("change filter type");
 
@@ -141,7 +141,7 @@ describe("scenarios > dashboard > filters > management", () => {
         // verifies no default value
         cy.findByText("No default").should("exist");
       });
-      getDashboardCard().should("not.contain", "Person.Name");
+      getDashboardCard().should("not.contain", "People.Name");
 
       saveDashboard();
 
@@ -284,17 +284,17 @@ describe("scenarios > dashboard > filters > management", () => {
 
       sidebar().findByDisplayValue("Does not contain").should("exist");
 
-      getDashboardCard().should("contain", "Person.Name");
+      getDashboardCard().should("contain", "People.Name");
 
       changeFilterType("Number");
 
       cy.log("verify that mapping is cleared");
-      getDashboardCard().should("not.contain", "Person.Name");
+      getDashboardCard().should("not.contain", "People.Name");
 
       changeFilterType("Text or Category");
 
       cy.log("verify that mapping is restored");
-      getDashboardCard().should("contain", "Person.Name");
+      getDashboardCard().should("contain", "People.Name");
     });
   });
 
@@ -307,11 +307,11 @@ describe("scenarios > dashboard > filters > management", () => {
       // verifies default value is there
       sidebar().findByText("value to check default").should("exist");
 
-      getDashboardCard().should("contain", "Person.Name");
+      getDashboardCard().should("contain", "People.Name");
 
       changeOperator("Contains");
 
-      getDashboardCard().should("contain", "Person.Name");
+      getDashboardCard().should("contain", "People.Name");
 
       // verifies default value does not exist
       sidebar().findByText("No default").should("exist");

--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -1241,7 +1241,7 @@ describe("issue 22482", () => {
 
 describe("issue 22788", () => {
   const ccName = "Custom Category";
-  const ccDisplayName = "Product.Custom Category";
+  const ccDisplayName = "Products.Custom Category";
 
   const questionDetails = {
     name: "22788",
@@ -1717,7 +1717,7 @@ describe("issue 25248", () => {
     popover().findAllByText("Created At").first().click();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Order.Created At").should("be.visible");
+    cy.findByText("Orders.Created At").should("be.visible");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select…").should("be.visible");
   });
@@ -2185,7 +2185,7 @@ describe("issue 27768", () => {
 
     getDashboardCard().within(() => {
       cy.findByText("Select…").should("not.exist");
-      cy.contains("Product.CCategory");
+      cy.contains("Products.CCategory");
     });
   });
 });

--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -686,7 +686,7 @@ describe("issue 25990", () => {
     queryBuilderHeader().button("Filter").click();
 
     modal().within(() => {
-      cy.findByText("Person").click();
+      cy.findByText("People").click();
       cy.findByPlaceholderText("Enter an ID").type("10").blur();
       cy.button("Apply filters").click();
     });

--- a/e2e/test/scenarios/filters/filter-sources.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter-sources.cy.spec.js
@@ -265,7 +265,7 @@ describe("scenarios > filters > filter sources", () => {
       visitQuestionAdhoc(tableQuestionWithJoin, { mode: "notebook" });
       filter({ mode: "notebook" });
       popover().within(() => {
-        cy.findByText("Product").click();
+        cy.findByText("Products").click();
         cy.findByText("Vendor").click();
         cy.findByText("Aufderhar-Boehm").click();
         cy.button("Add filter").click();
@@ -279,7 +279,7 @@ describe("scenarios > filters > filter sources", () => {
       visitQuestionAdhoc(tableQuestionWithJoinAndFields, { mode: "notebook" });
       filter({ mode: "notebook" });
       popover().within(() => {
-        cy.findByText("Product").click();
+        cy.findByText("Products").click();
         cy.findByText("Rating").click();
       });
       selectFilterOperator("Equal to");
@@ -394,7 +394,7 @@ describe("scenarios > filters > filter sources", () => {
       });
       filter({ mode: "notebook" });
       popover().within(() => {
-        cy.findByText("Product").click();
+        cy.findByText("Products").click();
         cy.findByText("Vendor").click();
         cy.findByText("Aufderhar-Boehm").click();
         cy.button("Add filter").click();
@@ -412,7 +412,7 @@ describe("scenarios > filters > filter sources", () => {
       });
       filter({ mode: "notebook" });
       popover().within(() => {
-        cy.findByText("Product").click();
+        cy.findByText("Products").click();
         cy.findByText("Rating").click();
       });
       selectFilterOperator("Equal to");
@@ -433,7 +433,7 @@ describe("scenarios > filters > filter sources", () => {
       });
       filter({ mode: "notebook" });
       popover().within(() => {
-        cy.findByText("Product").click();
+        cy.findByText("Products").click();
         cy.findByText("Ean").click();
       });
       selectFilterOperator("Is");
@@ -543,7 +543,7 @@ describe("scenarios > filters > filter sources", () => {
       });
       filter({ mode: "notebook" });
       popover().within(() => {
-        cy.findByText("Product").click();
+        cy.findByText("Products").click();
         cy.findByText("Vendor").click();
         cy.findByText("Aufderhar-Boehm").click();
         cy.button("Add filter").click();
@@ -561,7 +561,7 @@ describe("scenarios > filters > filter sources", () => {
       });
       filter({ mode: "notebook" });
       popover().within(() => {
-        cy.findByText("Product").click();
+        cy.findByText("Products").click();
         cy.findByText("Rating").click();
       });
       selectFilterOperator("Equal to");
@@ -582,7 +582,7 @@ describe("scenarios > filters > filter sources", () => {
       });
       filter({ mode: "notebook" });
       popover().within(() => {
-        cy.findByText("Product").click();
+        cy.findByText("Products").click();
         cy.findByText("Ean").click();
       });
       selectFilterOperator("Is");

--- a/e2e/test/scenarios/filters/filter.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter.cy.spec.js
@@ -44,7 +44,7 @@ describe("scenarios > question > filter", () => {
 
     filter({ mode: "notebook" });
     popover().within(() => {
-      cy.findByText("Product").click();
+      cy.findByText("Products").click();
       cy.findByText("Category").click();
       cy.findByDisplayValue("Is").click();
     });

--- a/e2e/test/scenarios/joins/joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins.cy.spec.js
@@ -69,7 +69,7 @@ describe("scenarios > question > joined questions", () => {
     openNotebook();
     filter({ mode: "notebook" });
     popover().within(() => {
-      cy.findByText("Review").click();
+      cy.findByText("Reviews").click();
       cy.findByText("Rating").click();
     });
     selectFilterOperator("Equal to");
@@ -82,10 +82,10 @@ describe("scenarios > question > joined questions", () => {
     summarize({ mode: "notebook" });
     addSummaryField({
       metric: "Average of ...",
-      table: "Review",
+      table: "Reviews",
       field: "Rating",
     });
-    addSummaryGroupingField({ table: "Review", field: "Reviewer" });
+    addSummaryGroupingField({ table: "Reviews", field: "Reviewer" });
 
     visualize();
 
@@ -254,7 +254,7 @@ describe("scenarios > question > joined questions", () => {
 
     summarize({ mode: "notebook" });
     addSummaryField({ metric: "Count of rows" });
-    addSummaryGroupingField({ table: "Product", field: "ID" });
+    addSummaryGroupingField({ table: "Products", field: "ID" });
 
     cy.findAllByTestId("action-buttons").last().button("Join data").click();
     joinTable("Reviews");

--- a/e2e/test/scenarios/models/models.cy.spec.js
+++ b/e2e/test/scenarios/models/models.cy.spec.js
@@ -295,7 +295,7 @@ describe("scenarios > models", () => {
         .findByText("Add filters to narrow your answer")
         .click();
       popover().within(() => {
-        cy.findByText("Product").click();
+        cy.findByText("Products").click();
         cy.findByText("Price").click();
       });
       selectFilterOperator("Less than");

--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
@@ -1,10 +1,7 @@
 import type { ReactNode } from "react";
 import { useCallback, useMemo } from "react";
 
-import {
-  getColumnGroupIcon,
-  getColumnGroupName,
-} from "metabase/common/utils/column-groups";
+import { getColumnGroupIcon } from "metabase/common/utils/column-groups";
 import {
   HoverParent,
   QueryColumnInfoIcon,
@@ -78,7 +75,7 @@ export function QueryColumnPicker({
         }));
 
         return {
-          name: getColumnGroupName(groupInfo),
+          name: groupInfo.displayName,
           icon: getColumnGroupIcon(groupInfo),
           items,
         };

--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.unit.spec.tsx
@@ -65,7 +65,7 @@ describe("QueryColumnPicker", () => {
     setup();
 
     // Tables
-    expect(screen.getByText("Order")).toBeInTheDocument();
+    expect(screen.getByText("Orders")).toBeInTheDocument();
     expect(screen.getByText("Product")).toBeInTheDocument();
     expect(screen.getByText("User")).toBeInTheDocument();
 

--- a/frontend/src/metabase/common/utils/column-groups.ts
+++ b/frontend/src/metabase/common/utils/column-groups.ts
@@ -1,14 +1,9 @@
-import { singularize } from "metabase/lib/formatting";
 import type { IconName } from "metabase/ui";
 import type { ColumnGroupDisplayInfo } from "metabase-lib";
 
-export function getColumnGroupName(groupInfo: ColumnGroupDisplayInfo) {
-  return singularize(groupInfo.displayName);
-}
-
 export function getColumnGroupIcon(
   groupInfo: ColumnGroupDisplayInfo,
-): IconName | undefined {
+): IconName {
   if (groupInfo.isSourceTable) {
     return "table";
   }
@@ -18,5 +13,5 @@ export function getColumnGroupIcon(
   if (groupInfo.isImplicitlyJoinable) {
     return "connections";
   }
-  return;
+  return "sum";
 }

--- a/frontend/src/metabase/parameters/utils/mapping-options.ts
+++ b/frontend/src/metabase/parameters/utils/mapping-options.ts
@@ -1,6 +1,5 @@
 import { tag_names } from "cljs/metabase.shared.parameters.parameters";
 import { isActionDashCard } from "metabase/actions/utils";
-import { getColumnGroupName } from "metabase/common/utils/column-groups";
 import { getColumnIcon } from "metabase/common/utils/columns";
 import { isVirtualDashCard } from "metabase/dashboard/utils";
 import * as Lib from "metabase-lib";
@@ -50,7 +49,7 @@ function buildStructuredQuerySectionOptions(
     const columnInfo = Lib.displayInfo(query, stageIndex, column);
 
     return {
-      sectionName: getColumnGroupName(groupInfo),
+      sectionName: groupInfo.displayName,
       name: columnInfo.displayName,
       icon: getColumnIcon(column),
       target: buildColumnTarget(query, stageIndex, column),

--- a/frontend/src/metabase/parameters/utils/mapping-options.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/mapping-options.unit.spec.js
@@ -94,7 +94,7 @@ describe("parameters/utils/mapping-options", () => {
             icon: "calendar",
             isForeign: false,
             name: "~*~Created At~*~",
-            sectionName: "Order",
+            sectionName: "Orders",
             target: [
               "dimension",
               ["field", "CREATED_AT", { "base-type": "type/DateTime" }],
@@ -148,7 +148,7 @@ describe("parameters/utils/mapping-options", () => {
         );
         expect(options).toEqual([
           {
-            sectionName: "Review",
+            sectionName: "Reviews",
             icon: "calendar",
             name: "Created At",
             target: [
@@ -203,7 +203,7 @@ describe("parameters/utils/mapping-options", () => {
         );
         expect(options).toEqual([
           {
-            sectionName: "Order",
+            sectionName: "Orders",
             name: "Created At",
             icon: "calendar",
             target: [
@@ -213,7 +213,7 @@ describe("parameters/utils/mapping-options", () => {
             isForeign: false,
           },
           {
-            sectionName: "Product",
+            sectionName: "Products",
             name: "Created At",
             icon: "calendar",
             target: [

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/BreakoutColumnList/BreakoutColumnList.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/BreakoutColumnList/BreakoutColumnList.tsx
@@ -1,7 +1,6 @@
 import { type ChangeEvent, useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
 
-import { getColumnGroupName } from "metabase/common/utils/column-groups";
 import Input from "metabase/core/components/Input";
 import { useDebouncedValue } from "metabase/hooks/use-debounced-value";
 import { SEARCH_DEBOUNCE_DURATION } from "metabase/lib/constants";
@@ -231,7 +230,7 @@ function getColumnSections(
     );
 
     return {
-      name: getColumnGroupName(groupInfo),
+      name: groupInfo.displayName,
       items,
     };
   });

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
@@ -1,10 +1,7 @@
 import { useMemo } from "react";
 import { t } from "ttag";
 
-import {
-  getColumnGroupIcon,
-  getColumnGroupName,
-} from "metabase/common/utils/column-groups";
+import { getColumnGroupIcon } from "metabase/common/utils/column-groups";
 import {
   HoverParent,
   QueryColumnInfoIcon,
@@ -84,7 +81,7 @@ export function FilterColumnPicker({
         : [];
 
       return {
-        name: getColumnGroupName(groupInfo),
+        name: groupInfo.displayName,
         icon: getColumnGroupIcon(groupInfo),
         items: [...segmentItems, ...columnItems],
       };

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPicker.unit.spec.tsx
@@ -190,7 +190,7 @@ describe("FilterPicker", () => {
     it("should list filterable columns", async () => {
       setup();
 
-      expect(screen.getByText("Order")).toBeInTheDocument();
+      expect(screen.getByText("Orders")).toBeInTheDocument();
       expect(screen.getByText("Discount")).toBeInTheDocument();
 
       await userEvent.click(screen.getByText("Product"));

--- a/frontend/src/metabase/querying/filters/hooks/use-filter-modal/utils/filters.ts
+++ b/frontend/src/metabase/querying/filters/hooks/use-filter-modal/utils/filters.ts
@@ -1,9 +1,6 @@
 import { t } from "ttag";
 
-import {
-  getColumnGroupIcon,
-  getColumnGroupName,
-} from "metabase/common/utils/column-groups";
+import { getColumnGroupIcon } from "metabase/common/utils/column-groups";
 import * as Lib from "metabase-lib";
 
 import type { GroupItem } from "../types";
@@ -36,8 +33,8 @@ export function getGroupItems(query: Lib.Query): GroupItem[] {
 
       return {
         key: `${stageIndex}-${groupIndex}`,
-        displayName: getColumnGroupName(groupInfo) || t`Summaries`,
-        icon: getColumnGroupIcon(groupInfo) || "sum",
+        displayName: groupInfo.displayName || t`Summaries`,
+        icon: getColumnGroupIcon(groupInfo),
         columnItems: availableColumns.map(column => {
           const columnInfo = Lib.displayInfo(query, stageIndex, column);
           return {

--- a/frontend/src/metabase/querying/notebook/components/BreakoutStep/BreakoutStep.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/BreakoutStep/BreakoutStep.unit.spec.tsx
@@ -492,7 +492,7 @@ describe("BreakoutStep", () => {
       const { getNextBreakouts } = setup({ step });
 
       await userEvent.click(screen.getByText("Pick a column to group by"));
-      expect(await screen.findByText("Order")).toBeInTheDocument();
+      expect(await screen.findByText("Orders")).toBeInTheDocument();
       expect(await screen.findByText("Created At")).toBeInTheDocument();
       expect(screen.queryByText("Tax")).not.toBeInTheDocument();
 

--- a/frontend/src/metabase/querying/notebook/components/JoinStep/JoinStep.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/JoinStep/JoinStep.unit.spec.tsx
@@ -343,7 +343,7 @@ describe("Notebook Editor > Join Step", () => {
 
     const lhsColumnPicker = await screen.findByTestId("lhs-column-picker");
 
-    expect(within(lhsColumnPicker).getByText("Order")).toBeInTheDocument();
+    expect(within(lhsColumnPicker).getByText("Orders")).toBeInTheDocument();
     expect(within(lhsColumnPicker).getByText("Product ID")).toBeInTheDocument();
     expect(
       within(lhsColumnPicker).queryByText(/Review/i),

--- a/frontend/src/metabase/querying/notebook/components/SortStep/SortStep.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/SortStep/SortStep.unit.spec.tsx
@@ -78,7 +78,7 @@ describe("SortStep", () => {
     await userEvent.click(getIcon("add"));
 
     // Tables
-    expect(await screen.findByText("Order")).toBeInTheDocument();
+    expect(await screen.findByText("Orders")).toBeInTheDocument();
     expect(screen.getByText("Product")).toBeInTheDocument();
     expect(screen.getByText("User")).toBeInTheDocument();
     // Order columns


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/47800
Closes https://github.com/metabase/metabase/issues/47802
Context https://metaboat.slack.com/archives/C01LQQ2UW03/p1725912348509929

Removes the logic to singularize column group names.

How to verify:
- New -> Question -> Orders
- Join -> Products
- Add a breakout. "Orders" should say "Orders" (and not "Order"), "Products" -> "Products", and FK fields should remain the same.

<img width="1298" alt="Screenshot 2024-09-10 at 11 53 49" src="https://github.com/user-attachments/assets/780c4345-5911-4f64-9195-6722e4ee5650">
