### PR TITLE
Misc. API auto-generated documentation fixes.

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -452,7 +452,7 @@
 ;;; ------------------------------------------------- Creating Cards -------------------------------------------------
 
 (mr/def ::card-type
-  (into [:enum {:decode/json keyword}] (mapcat (juxt identity u/qualified-name)) card/card-types))
+  (into [:enum {:decode/json keyword}] card/card-types))
 
 (defn- check-if-card-can-be-saved
   [dataset-query card-type]

--- a/src/metabase/util/malli/describe.cljc
+++ b/src/metabase/util/malli/describe.cljc
@@ -6,32 +6,44 @@
    [malli.experimental.describe :as med]
    [metabase.util.malli.registry :as mr]))
 
+(defn- description [schema]
+  (or (:description (mc/type-properties schema))
+      (:description (mc/properties schema))))
+
+(declare describe)
+
+(defn- accept-ref [schema [k :as _children] options]
+  (or (description schema)
+      (if (contains? (::parent-refs options) k)
+        (str "recursive " (str k))
+        (describe (mr/resolve-schema schema)
+                  (update options ::parent-refs #(conj (set %) k))))))
+
+;;; these implementations replace the normal ones which do not recursively resolve refs and schemas. We track
+;;; `::parent-refs` to prevent infinite loops with self-referencing schemas
+
+(defmethod med/accept :ref
+  [_name schema children options]
+  (accept-ref schema children options))
+
+(defmethod med/accept :schema
+  [_name schema children options]
+  (accept-ref schema children options))
+
 (defn describe
   "Given a schema, returns a string explaining the required shape in English"
   ([?schema]
    (describe ?schema nil))
   ([?schema options]
-   (let [options (merge options
-                        {::mc/walk-entry-vals true
-                         ::med/definitions    (atom {})
-                         ::med/describe       med/-describe})]
+   (let [options (merge
+                  (when (keyword? ?schema)
+                    {::parent-refs #{?schema}})
+                  options
+                  {::mc/walk-entry-vals true
+                   ::med/definitions    (atom {})
+                   ::med/describe       med/-describe})]
      (-> ?schema
          mr/resolve-schema
          (med/-describe options)
          str
          str/trim))))
-
-;;; This is a fix for upstream issue https://github.com/metosin/malli/issues/924 (the generated descriptions for
-;;; `:min` and `:max` were backwards). We can remove this when that issue is fixed upstream.
-
-#?(:clj
-   (defn- -length-suffix [schema]
-     (let [{:keys [min max]} (-> schema mc/properties)]
-       (cond
-         (and min max) (str " with length between " min " and " max " inclusive")
-         min           (str " with length >= " min)
-         max           (str " with length <= " max)
-         :else         ""))))
-
-#?(:clj
-   (alter-var-root #'med/-length-suffix (constantly -length-suffix)))

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -726,8 +726,11 @@
 
 (deftest ^:parallel docstring-test
   (testing "Make sure generated docstring resolves Malli schemas in the registry correctly (#46799)"
-    (is (str/includes? (-> #'api.card/POST_ meta :doc)
-                       "-  **`type`** nullable enum of :question, question, :metric, metric, :model, model."))))
+    (let [doc (-> #'api.card/POST_ meta :doc)]
+      (testing 'type
+        (is (str/includes? doc "**`type`** nullable enum of :question, :metric, :model.")))
+      (testing 'result_metadata
+        (is (str/includes? doc "**`result_metadata`** nullable value must be an array of valid results column metadata maps."))))))
 
 (deftest create-a-card
   (testing "POST /api/card"

--- a/test/metabase/util/malli/describe_test.cljc
+++ b/test/metabase/util/malli/describe_test.cljc
@@ -2,18 +2,16 @@
   "Additional tests for this live in [[metabase.util.malli-test]]."
   (:require
    [clojure.test :refer [are deftest is testing]]
+   [malli.core :as mc]
    [metabase.util.malli.describe :as umd]
    [metabase.util.malli.registry :as mr]))
 
-;;; this is only fixed in Clojure
-
-#?(:clj
-   (deftest ^:parallel correct-string-length-descriptions-test
-     (testing "Work around upstream issue https://github.com/metosin/malli/issues/924"
-       (are [schema expected] (= expected
-                                 (umd/describe schema))
-         [:string {:min 5}] "string with length >= 5"
-         [:string {:max 5}] "string with length <= 5"))))
+(deftest ^:parallel correct-string-length-descriptions-test
+  (testing "Work around upstream issue https://github.com/metosin/malli/issues/924"
+    (are [schema expected] (= expected
+                              (umd/describe schema))
+      [:string {:min 5}] "string with length >= 5"
+      [:string {:max 5}] "string with length <= 5")))
 
 (mr/def ::card-type*
   [:enum :question :metric :model])
@@ -24,7 +22,9 @@
 (deftest ^:parallel describe-registry-schema-test
   (testing "describe should work for schemas in our registry (#46799)"
     (is (= "nullable enum of :question, :metric, :model"
-           (umd/describe [:maybe ::card-type])))))
+           (umd/describe [:maybe ::card-type])))
+    (is (= "nullable enum of :question, :metric, :model"
+           (umd/describe [:maybe [:ref ::card-type]])))))
 
 (mr/def ::positive-int*
   [:int {:min 0}])
@@ -45,3 +45,19 @@
                      ::positive-int*]]
     (is (= "value must be an integer greater than zero."
            (umd/describe PositiveInt)))))
+
+(mr/def ::cons
+  [:maybe [:tuple any? [:ref ::cons]]])
+
+(mr/def ::map
+  [:map
+   [:k keyword?]
+   [:parent {:optional true} [:ref ::map]]])
+
+(deftest ^:parallel handle-circular-refs-test
+  (is (mc/validate ::cons [1 [2 [3 nil]]]))
+  (is (= "nullable vector with exactly 2 items of type: anything, recursive :metabase.util.malli.describe-test/cons"
+         (umd/describe ::cons)))
+  (is (mc/validate ::map {:k :child, :parent {:k :parent}}))
+  (is (= "map where {:k -> <keyword>, :parent (optional) -> <recursive :metabase.util.malli.describe-test/map>}"
+         (umd/describe ::map))))


### PR DESCRIPTION
Fix some errors mentioned in https://metaboat.slack.com/archives/C051AG38B2S/p1725900105564369?thread_ts=1722278253.246549&cid=C051AG38B2S

- Fix duplicate enum values for Card `type`
- Fix schemas inside our registry not getting dereferenced if they were wrapped in `[:maybe ...]`

Generated documentation for `POST /api/card/` is now:

## `POST /api/card/`

Create a new `Card`. Card `type` can be `question`, `metric`, or `model`.

### PARAMS:

-  **`visualization_settings`** Value must be a map.

-  **`parameters`** nullable sequence of parameter must be a map with :id and :type keys.

-  **`description`** nullable value must be a non-blank string.

-  **`collection_position`** nullable value must be an integer greater than zero.

-  **`result_metadata`** nullable value must be an array of valid results column metadata maps.

-  **`collection_id`** nullable value must be an integer greater than zero.

-  **`name`** value must be a non-blank string.

-  **`type`** nullable enum of :question, :metric, :model.

-  **`cache_ttl`** nullable value must be an integer greater than zero.

-  **`dataset_query`** Value must be a map.

-  **`parameter_mappings`** nullable sequence of parameter_mapping must be a map with :parameter_id and :target keys.

-  **`display`** value must be a non-blank string.