### PR TITLE
Make E2E test for #47061 less flaky

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
@@ -978,7 +978,7 @@ describeEE("scenarios > embedding > dashboard appearance", () => {
 
     getIframeBody().findByText("Rows 1-21 of first 2000").should("exist");
 
-    cy.get("#iframe").then($iframe => {
+    cy.get("#iframe").should($iframe => {
       const [iframe] = $iframe;
       expect(iframe.clientHeight).to.be.greaterThan(1000);
     });


### PR DESCRIPTION
Related to #47061 

Reported on [Slack](https://metaboat.slack.com/archives/C5XHN8GLW/p1725991025680609?thread_ts=1725990227.181689&cid=C5XHN8GLW)

### Description

The last assertion that assert the height doesn't retry, and from my observation even after the dashboard has rendered, it's not guaranteed that the iframe will already be resized. So to fix this changing it to `should`, should retry the assertion inside until it's true fixing the flake

### How to verify

The [stress test](https://github.com/metabase/metabase/actions/runs/10810651789) passes. [20/20] ✅ 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
