### PR TITLE
Include completions of the final word in fulltext search

### DIFF
--- a/frontend/src/metabase-types/api/search.ts
+++ b/frontend/src/metabase-types/api/search.ts
@@ -42,7 +42,6 @@ export interface SearchScore {
     | "text-total-occurrences"
     | "text-fullness";
   match?: string;
-  "match-context-thunk"?: string;
   column?: string;
 }
 

--- a/frontend/src/metabase/static-viz/components/ComboChart/stories-data/line-unpin-from-zero.json
+++ b/frontend/src/metabase/static-viz/components/ComboChart/stories-data/line-unpin-from-zero.json
@@ -37,7 +37,6 @@
           "name": "text-consecutivity",
           "weight": 4,
           "match": "line-unpin-from-zero",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__130228__130234$fn__130235$iter__130230__130236$fn__130237$fn__130238$fn__130241@720ce99c",
           "column": "name"
         },
         {
@@ -45,7 +44,6 @@
           "name": "text-total-occurrences",
           "weight": 4,
           "match": "line-unpin-from-zero",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__130228__130234$fn__130235$iter__130230__130236$fn__130237$fn__130238$fn__130241@6e4a4973",
           "column": "name"
         },
         {
@@ -53,7 +51,6 @@
           "name": "text-fullness",
           "weight": 2,
           "match": "line-unpin-from-zero",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__130228__130234$fn__130235$iter__130230__130236$fn__130237$fn__130238$fn__130241@f75a6de",
           "column": "name"
         }
       ],

--- a/frontend/src/metabase/static-viz/components/ComboChart/stories-data/ticks-native-week-with-gap-long-range.json
+++ b/frontend/src/metabase/static-viz/components/ComboChart/stories-data/ticks-native-week-with-gap-long-range.json
@@ -61,7 +61,6 @@
           "name": "text-consecutivity",
           "weight": 4,
           "match": "x-axis: native weekly",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__126238__126244$fn__126245$iter__126240__126246$fn__126247$fn__126248$fn__126251@3b5745af",
           "column": "name"
         },
         {
@@ -69,7 +68,6 @@
           "name": "text-total-occurrences",
           "weight": 4,
           "match": "x-axis: native weekly",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__126238__126244$fn__126245$iter__126240__126246$fn__126247$fn__126248$fn__126251@604e7000",
           "column": "name"
         },
         {
@@ -77,7 +75,6 @@
           "name": "text-fullness",
           "weight": 2,
           "match": "x-axis: native weekly",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__126238__126244$fn__126245$iter__126240__126246$fn__126247$fn__126248$fn__126251@2a40c731",
           "column": "name"
         }
       ],

--- a/frontend/src/metabase/static-viz/components/ComboChart/stories-data/ticks-native-week-with-gap-short-range.json
+++ b/frontend/src/metabase/static-viz/components/ComboChart/stories-data/ticks-native-week-with-gap-short-range.json
@@ -61,7 +61,6 @@
           "name": "text-consecutivity",
           "weight": 4,
           "match": "x-axis: native weekly",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__126238__126244$fn__126245$iter__126240__126246$fn__126247$fn__126248$fn__126251@3b5745af",
           "column": "name"
         },
         {
@@ -69,7 +68,6 @@
           "name": "text-total-occurrences",
           "weight": 4,
           "match": "x-axis: native weekly",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__126238__126244$fn__126245$iter__126240__126246$fn__126247$fn__126248$fn__126251@604e7000",
           "column": "name"
         },
         {
@@ -77,7 +75,6 @@
           "name": "text-fullness",
           "weight": 2,
           "match": "x-axis: native weekly",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__126238__126244$fn__126245$iter__126240__126246$fn__126247$fn__126248$fn__126251@2a40c731",
           "column": "name"
         }
       ],

--- a/frontend/src/metabase/static-viz/components/PieChart/stories-data/binned-dimension.json
+++ b/frontend/src/metabase/static-viz/components/PieChart/stories-data/binned-dimension.json
@@ -151,7 +151,6 @@
           "name": "text-exact-match",
           "weight": 4,
           "match": "Pie - Binned Numeric Dimension - Poke count by Gen",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__133630__133636$fn__133637$iter__133632__133638$fn__133639$fn__133640$fn__133643@6e1f99ec",
           "column": "name"
         },
         {
@@ -159,7 +158,6 @@
           "name": "text-consecutivity",
           "weight": 2,
           "match": "Pie - Binned Numeric Dimension - Poke count by Gen",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__133630__133636$fn__133637$iter__133632__133638$fn__133639$fn__133640$fn__133643@6961ee08",
           "column": "name"
         },
         {
@@ -167,7 +165,6 @@
           "name": "text-total-occurrences",
           "weight": 2,
           "match": "Pie - Binned Numeric Dimension - Poke count by Gen",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__133630__133636$fn__133637$iter__133632__133638$fn__133639$fn__133640$fn__133643@6015b1d0",
           "column": "name"
         },
         {
@@ -175,7 +172,6 @@
           "name": "text-fullness",
           "weight": 1,
           "match": "Pie - Binned Numeric Dimension - Poke count by Gen",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__133630__133636$fn__133637$iter__133632__133638$fn__133639$fn__133640$fn__133643@3ed2f680",
           "column": "name"
         },
         {
@@ -183,7 +179,6 @@
           "name": "text-prefix",
           "weight": 1,
           "match": "Pie - Binned Numeric Dimension - Poke count by Gen",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__133630__133636$fn__133637$iter__133632__133638$fn__133639$fn__133640$fn__133643@2c10d84f",
           "column": "name"
         }
       ],

--- a/frontend/src/metabase/static-viz/components/PieChart/stories-data/numeric-dimension.json
+++ b/frontend/src/metabase/static-viz/components/PieChart/stories-data/numeric-dimension.json
@@ -144,7 +144,6 @@
           "name": "text-exact-match",
           "weight": 4,
           "match": "Pie - Linear/Numeric Dimension - Poke count by Gen",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__133630__133636$fn__133637$iter__133632__133638$fn__133639$fn__133640$fn__133643@77a87a5f",
           "column": "name"
         },
         {
@@ -152,7 +151,6 @@
           "name": "text-consecutivity",
           "weight": 2,
           "match": "Pie - Linear/Numeric Dimension - Poke count by Gen",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__133630__133636$fn__133637$iter__133632__133638$fn__133639$fn__133640$fn__133643@5b61d4b4",
           "column": "name"
         },
         {
@@ -160,7 +158,6 @@
           "name": "text-total-occurrences",
           "weight": 2,
           "match": "Pie - Linear/Numeric Dimension - Poke count by Gen",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__133630__133636$fn__133637$iter__133632__133638$fn__133639$fn__133640$fn__133643@681de957",
           "column": "name"
         },
         {
@@ -168,7 +165,6 @@
           "name": "text-fullness",
           "weight": 1,
           "match": "Pie - Linear/Numeric Dimension - Poke count by Gen",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__133630__133636$fn__133637$iter__133632__133638$fn__133639$fn__133640$fn__133643@7118b132",
           "column": "name"
         },
         {
@@ -176,7 +172,6 @@
           "name": "text-prefix",
           "weight": 1,
           "match": "Pie - Linear/Numeric Dimension - Poke count by Gen",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__133630__133636$fn__133637$iter__133632__133638$fn__133639$fn__133640$fn__133643@455657cc",
           "column": "name"
         }
       ],

--- a/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/linear-null-dimension.json
+++ b/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/linear-null-dimension.json
@@ -35,7 +35,6 @@
           "name": "text-exact-match",
           "weight": 4.444444444444444,
           "match": "Waterfall Linear Null Dimension",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__126238__126244$fn__126245$iter__126240__126246$fn__126247$fn__126248$fn__126251@3cd854d4",
           "column": "name"
         },
         {
@@ -43,7 +42,6 @@
           "name": "text-consecutivity",
           "weight": 2.222222222222222,
           "match": "Waterfall Linear Null Dimension",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__126238__126244$fn__126245$iter__126240__126246$fn__126247$fn__126248$fn__126251@189ff8e6",
           "column": "name"
         },
         {
@@ -51,7 +49,6 @@
           "name": "text-total-occurrences",
           "weight": 2.222222222222222,
           "match": "Waterfall Linear Null Dimension",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__126238__126244$fn__126245$iter__126240__126246$fn__126247$fn__126248$fn__126251@4986c53e",
           "column": "name"
         },
         {
@@ -59,7 +56,6 @@
           "name": "text-fullness",
           "weight": 1.111111111111111,
           "match": "Waterfall Linear Null Dimension",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__126238__126244$fn__126245$iter__126240__126246$fn__126247$fn__126248$fn__126251@70414c19",
           "column": "name"
         }
       ],

--- a/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/native-time-series-quarter.json
+++ b/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/native-time-series-quarter.json
@@ -36,7 +36,6 @@
           "name": "text-exact-match",
           "weight": 4,
           "match": "waterfall quarter bucket native",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__126238__126244$fn__126245$iter__126240__126246$fn__126247$fn__126248$fn__126251@1310237b",
           "column": "name"
         },
         {
@@ -44,7 +43,6 @@
           "name": "text-consecutivity",
           "weight": 2,
           "match": "waterfall quarter bucket native",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__126238__126244$fn__126245$iter__126240__126246$fn__126247$fn__126248$fn__126251@4b65a3ce",
           "column": "name"
         },
         {
@@ -52,7 +50,6 @@
           "name": "text-total-occurrences",
           "weight": 2,
           "match": "waterfall quarter bucket native",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__126238__126244$fn__126245$iter__126240__126246$fn__126247$fn__126248$fn__126251@794e8bd7",
           "column": "name"
         },
         {
@@ -60,7 +57,6 @@
           "name": "text-fullness",
           "weight": 1,
           "match": "waterfall quarter bucket native",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__126238__126244$fn__126245$iter__126240__126246$fn__126247$fn__126248$fn__126251@4a0c822f",
           "column": "name"
         },
         {
@@ -68,7 +64,6 @@
           "name": "text-prefix",
           "weight": 1,
           "match": "waterfall quarter bucket native",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__126238__126244$fn__126245$iter__126240__126246$fn__126247$fn__126248$fn__126251@58957bee",
           "column": "name"
         }
       ],

--- a/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/ordinal-null-dimension.json
+++ b/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/ordinal-null-dimension.json
@@ -154,7 +154,6 @@
           "name": "text-consecutivity",
           "weight": 3.333333333333333,
           "match": "Waterfall Ordinal Null Dimension",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__126238__126244$fn__126245$iter__126240__126246$fn__126247$fn__126248$fn__126251@6385cf53",
           "column": "name"
         },
         {
@@ -162,7 +161,6 @@
           "name": "text-total-occurrences",
           "weight": 3.333333333333333,
           "match": "Waterfall Ordinal Null Dimension",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__126238__126244$fn__126245$iter__126240__126246$fn__126247$fn__126248$fn__126251@8bbd715",
           "column": "name"
         },
         {
@@ -170,7 +168,6 @@
           "name": "text-fullness",
           "weight": 1.666666666666667,
           "match": "Waterfall Ordinal Null Dimension",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__126238__126244$fn__126245$iter__126240__126246$fn__126247$fn__126248$fn__126251@1592f629",
           "column": "name"
         },
         {
@@ -178,7 +175,6 @@
           "name": "text-prefix",
           "weight": 1.666666666666667,
           "match": "Waterfall Ordinal Null Dimension",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__126238__126244$fn__126245$iter__126240__126246$fn__126247$fn__126248$fn__126251@37134f79",
           "column": "name"
         }
       ],

--- a/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/structured-time-series-year.json
+++ b/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/structured-time-series-year.json
@@ -35,7 +35,6 @@
           "name": "text-exact-match",
           "weight": 4,
           "match": "waterfall year bucket",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__126238__126244$fn__126245$iter__126240__126246$fn__126247$fn__126248$fn__126251@3e08c8e1",
           "column": "name"
         },
         {
@@ -43,7 +42,6 @@
           "name": "text-consecutivity",
           "weight": 2,
           "match": "waterfall year bucket",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__126238__126244$fn__126245$iter__126240__126246$fn__126247$fn__126248$fn__126251@3395ecc4",
           "column": "name"
         },
         {
@@ -51,7 +49,6 @@
           "name": "text-total-occurrences",
           "weight": 2,
           "match": "waterfall year bucket",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__126238__126244$fn__126245$iter__126240__126246$fn__126247$fn__126248$fn__126251@1da61d63",
           "column": "name"
         },
         {
@@ -59,7 +56,6 @@
           "name": "text-fullness",
           "weight": 1,
           "match": "waterfall year bucket",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__126238__126244$fn__126245$iter__126240__126246$fn__126247$fn__126248$fn__126251@6e9f4f32",
           "column": "name"
         },
         {
@@ -67,7 +63,6 @@
           "name": "text-prefix",
           "weight": 1,
           "match": "waterfall year bucket",
-          "match-context-thunk": "metabase.search.scoring$text_scores_with$iter__126238__126244$fn__126245$iter__126240__126246$fn__126247$fn__126248$fn__126251@16a8ddc0",
           "column": "name"
         }
       ],

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -491,7 +491,8 @@
                       collection_authority_level collection_type collection_effective_ancestors effective_parent
                       archived_directly model]}]
   (let [matching-columns    (into #{} (remove nil? (map :column relevant-scores)))
-        match-context-thunk (first (keep :match-context-thunk relevant-scores))]
+        match-context-thunk (first (keep :match-context-thunk relevant-scores))
+        remove-thunks       (partial mapv #(dissoc % :match-context-thunk))]
     (-> result
         (assoc
          :name           (if (and (contains? matching-columns :display_name) display_name)
@@ -512,7 +513,7 @@
                                   effective_parent
                                   (when collection_effective_ancestors
                                     {:effective_ancestors collection_effective_ancestors})))
-         :scores          all-scores)
+         :scores          (remove-thunks all-scores))
         (update :dataset_query (fn [dataset-query]
                                  (when-let [query (some-> dataset-query json/parse-string)]
                                    (if (get query "type")

--- a/src/metabase/search/postgres/index.clj
+++ b/src/metabase/search/postgres/index.clj
@@ -101,12 +101,11 @@
       (t2/insert! pending-table entry))))
 
 (defn- to-tsquery-expr [search-term]
-  (let [in-word? (= search-term (str/trimr search-term))
-        trimmed (str/trim search-term)
-        words (str/split trimmed #"\s+")]
-    (str (str/join " & " words)
-         (when in-word?
-           ":*"))))
+  (as-> search-term <>
+    (str/trim <>)
+    (str/split <> #"\s+")
+    (str/join " & " <>)
+    (str <> ":*")))
 
 (defn search-query
   "Query fragment for all models corresponding to a query paramter `:search-term`."

--- a/src/metabase/search/postgres/index.clj
+++ b/src/metabase/search/postgres/index.clj
@@ -136,7 +136,7 @@
   [expression]
   (str/replace expression #"(\S+)(?=\s*$)" "$1:*"))
 
-(defn to-tsquery-expr
+(defn- to-tsquery-expr
   "Given the user input, construct a query in the Postgres tsvector query language."
   [input]
   (let [trimmed        (str/trim input)

--- a/test/metabase/search/postgres/index_test.clj
+++ b/test/metabase/search/postgres/index_test.clj
@@ -109,7 +109,7 @@
 
 ;; lower level search expression tests
 
-(def search-expr search.index/to-tsquery-expr)
+(def search-expr #'search.index/to-tsquery-expr)
 
 (deftest to-tsquery-expr-test
   (is (= "a & b & c:*"

--- a/test/metabase/search/postgres/index_test.clj
+++ b/test/metabase/search/postgres/index_test.clj
@@ -106,3 +106,35 @@
     (testing "legacy search has a bunch of results"
       (is (= 3 (legacy-hits "projected revenue")))
       (is (= 0 (legacy-hits "\"projected revenue\""))))))
+
+;; lower level search expression tests
+
+(def search-expr search.index/to-tsquery-expr)
+
+(deftest to-tsquery-expr-test
+  (is (= "a & b & c:*"
+         (search-expr "a b c")))
+
+  (is (= "a & b & c:*"
+         (search-expr "a AND b AND c")))
+
+  (is (= "a & b & c"
+         (search-expr "a b \"c\"")))
+
+  (is (= "a & b | c:*"
+         (search-expr "a b or c")))
+
+  (is (= "this & !that:*"
+         (search-expr "this -that")))
+
+  (is (= "a & b & c <-> d & e | b & e:*"
+         (search-expr "a b \" c d\" e or b e")))
+
+  (is  (= "ab <-> and <-> cde <-> f | !abc & def & ghi | jkl <-> mno <-> or <-> pqr"
+          (search-expr "\"ab and cde f\" or -abc def AND ghi OR \"jkl mno OR pqr\"")))
+
+  (is (= "big & data | business <-> intelligence | data & wrangling:*"
+         (search-expr "Big Data oR \"Business Intelligence\" OR data and wrangling")))
+
+  (is (= "partial <-> quoted <-> and <-> or <-> -split:*"
+         (search-expr "\"partial quoted AND OR -split"))))

--- a/test/metabase/search/postgres/index_test.clj
+++ b/test/metabase/search/postgres/index_test.clj
@@ -58,7 +58,14 @@
       (doseq [[a b] [["revenue" "revenues"]
                      ["collect" "collection"]]]
         (is (= (search.index/search a)
-               (search.index/search b)))))))
+               (search.index/search b)))))
+
+    (testing "Or we match a completion of the final word"
+      (is (seq (search.index/search "ras")))
+      (is (seq (search.index/search "rasta coll")))
+      (is (seq (search.index/search "collection ras")))
+      (is (empty? (search.index/search "coll rasta")))
+      (is (empty? (search.index/search "ras collection"))))))
 
 (deftest either-test
   (with-index


### PR DESCRIPTION
### Description

This switches to a slightly lower level query type, so we can include completions of the final word.

~~We could do more to preserve support for operators like and, or, and not, but I think this is enough for a v1.~~ It turned out I needed to do some more clean up of the input stream, so just went ahead and got this working, as it was fun.

A big difference from the existing search is that we require all the terms, rather than some. Biasing towards search being fast, and typically this is what people will want.