### PR TITLE
update prettier so we can use `satisfies`

### DIFF
--- a/e2e/runner/cypress-runner-generate-snapshots.js
+++ b/e2e/runner/cypress-runner-generate-snapshots.js
@@ -23,9 +23,8 @@ const generateSnapshots = async (baseUrl, exitFunction) => {
   const snapshotConfig = Object.assign({}, baseConfig, customBrowser);
 
   try {
-    const { status, message, totalFailed, failures } = await cypress.run(
-      snapshotConfig,
-    );
+    const { status, message, totalFailed, failures } =
+      await cypress.run(snapshotConfig);
 
     // At least one test failed. We can't continue to the next step.
     // Cypress tests rely on snapshots correctly generated at this stage.

--- a/e2e/test/scenarios/embedding/shared/embedding-snippets.js
+++ b/e2e/test/scenarios/embedding/shared/embedding-snippets.js
@@ -22,10 +22,10 @@ var token = jwt.sign(payload, METABASE_SECRET_KEY);
 
 var iframeUrl = METABASE_SITE_URL + "/embed/${type}/" + token +
   "#${getThemeParameter(theme)}${getBackgroundParameter(
-      background,
-    )}bordered=true&titled=true${getParameter({
-      downloads,
-    })}";`
+    background,
+  )}bordered=true&titled=true${getParameter({
+    downloads,
+  })}";`
       .split("\n")
       .join("")
       .replace(/[-\/\\^$*+?.()|[\]{}]/g, "\\$&")

--- a/enterprise/frontend/src/embedding-sdk/cli/types/cli.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/types/cli.ts
@@ -48,7 +48,7 @@ export type CliError = {
 
 export type CliSuccess = {
   type: "success";
-  nextStep?: typeof CLI_STEPS[number]["id"];
+  nextStep?: (typeof CLI_STEPS)[number]["id"];
 };
 
 export type CliDone = {

--- a/enterprise/frontend/src/embedding-sdk/components/public/CollectionBrowser/CollectionBrowser.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/CollectionBrowser/CollectionBrowser.tsx
@@ -21,7 +21,7 @@ const USER_FACING_ENTITY_NAMES = [
   "model",
 ] as const;
 
-type UserFacingEntityName = typeof USER_FACING_ENTITY_NAMES[number];
+type UserFacingEntityName = (typeof USER_FACING_ENTITY_NAMES)[number];
 
 const ENTITY_NAME_MAP: Partial<
   Record<UserFacingEntityName, CollectionItemModel>

--- a/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm/SettingsJWTForm.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm/SettingsJWTForm.tsx
@@ -166,7 +166,7 @@ const getAttributeValues = (
     JWT_ATTRS.map(key => [
       key,
       DEFAULTABLE_JWT_ATTRS.has(key)
-        ? values[key] ?? settings[key]?.default
+        ? (values[key] ?? settings[key]?.default)
         : values[key],
     ]),
   );

--- a/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm/SettingsSAMLForm.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm/SettingsSAMLForm.jsx
@@ -266,7 +266,7 @@ const getAttributeValues = (values, defaults) => {
   return Object.fromEntries(
     Object.entries(IS_SAML_ATTR_DEFAULTABLE).map(([key, isDefaultable]) => [
       key,
-      isDefaultable ? values[key] ?? defaults[key] : values[key],
+      isDefaultable ? (values[key] ?? defaults[key]) : values[key],
     ]),
   );
 };

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyFormLauncher.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyFormLauncher.styled.tsx
@@ -20,12 +20,11 @@ export const PolicyToken = styled(Button)<
   border-style: solid;
   justify-content: center;
 
-  ${({ variant }) =>
-    css`
-      border-color: ${["filled", "outline"].includes(variant || "")
-        ? "var(--mb-color-brand)"
-        : "var(--mb-color-border)"} !important;
-    `};
+  ${({ variant }) => css`
+    border-color: ${["filled", "outline"].includes(variant || "")
+      ? "var(--mb-color-brand)"
+      : "var(--mb-color-border)"} !important;
+  `};
   span {
     gap: 0.5rem;
   }
@@ -55,12 +54,11 @@ export const StyledLauncher = styled(
   border-style: solid;
   justify-content: center;
   width: 100%;
-  ${({ variant }) =>
-    css`
-      border-color: ${["filled", "outline"].includes(variant || "")
-        ? "var(--mb-color-brand)"
-        : "var(--mb-color-border)"} !important;
-    `};
+  ${({ variant }) => css`
+    border-color: ${["filled", "outline"].includes(variant || "")
+      ? "var(--mb-color-brand)"
+      : "var(--mb-color-border)"} !important;
+  `};
   font-weight: ${({ forRoot, inheritsRootStrategy }) =>
     forRoot || inheritsRootStrategy ? "normal" : "bold"};
   background-color: ${({ forRoot }) =>

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyFormLauncher.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyFormLauncher.tsx
@@ -44,8 +44,8 @@ export const StrategyFormLauncher = ({
     isBeingEdited || hovered
       ? "filled"
       : inheritsRootStrategy || forRoot
-      ? "default"
-      : "outline";
+        ? "default"
+        : "outline";
   const shortStrategyLabel = getShortStrategyLabel(
     inheritsRootStrategy ? rootStrategy : strategy,
   );
@@ -53,10 +53,10 @@ export const StrategyFormLauncher = ({
   const ariaLabel = forRoot
     ? t`Edit default policy (currently: ${shortStrategyLabel})`
     : inheritsRootStrategy
-    ? t`Edit policy for database '${title}' (currently inheriting the default policy, ${getShortStrategyLabel(
-        rootStrategy,
-      )})`
-    : t`Edit policy for database '${title}' (currently: ${shortStrategyLabel})`;
+      ? t`Edit policy for database '${title}' (currently inheriting the default policy, ${getShortStrategyLabel(
+          rootStrategy,
+        )})`
+      : t`Edit policy for database '${title}' (currently: ${shortStrategyLabel})`;
 
   const launchForm = () => {
     if (targetId !== forId) {

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/utils.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/utils.tsx
@@ -19,7 +19,7 @@ export const getItemName = (
 ) =>
   model === "dashboard"
     ? (item as CacheableDashboard).name
-    : (item as Question).displayName() ?? t`Untitled question`;
+    : ((item as Question).displayName() ?? t`Untitled question`);
 
 export const getItemUrl = (
   model: CacheableModel,

--- a/enterprise/frontend/src/metabase-enterprise/clean_up/CleanupCollectionModal/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/clean_up/CleanupCollectionModal/utils.ts
@@ -59,8 +59,8 @@ export const dateFilterOptions = [
   },
 ] as const;
 
-export type DateFilter = typeof dateFilterOptions[number]["value"];
-export type DateDurations = typeof dateFilterOptions[number]["duration"];
+export type DateFilter = (typeof dateFilterOptions)[number]["value"];
+export type DateDurations = (typeof dateFilterOptions)[number]["duration"];
 export type DateFilterOption = {
   label: string;
   value: DateFilter;

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/data-model-permission.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/data-model-permission.unit.spec.ts
@@ -27,7 +27,7 @@ const getPermissionGraph = (value = "all"): GroupsPermissions =>
         },
       },
     },
-  } as any);
+  }) as any;
 
 const isAdmin = true;
 const isNotAdmin = false;

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/details-permission.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/details-permission.unit.spec.ts
@@ -23,7 +23,7 @@ const getPermissionGraph = (value = "yes"): GroupsPermissions =>
         details: value,
       },
     },
-  } as any);
+  }) as any;
 
 const isAdmin = true;
 const isNotAdmin = false;

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.unit.spec.ts
@@ -27,7 +27,7 @@ const getPermissionGraph = (downloadValue = "all"): GroupsPermissions =>
         },
       },
     },
-  } as any);
+  }) as any;
 
 const isAdmin = true;
 const isNotAdmin = false;

--- a/enterprise/frontend/src/metabase-enterprise/group_managers/actions.js
+++ b/enterprise/frontend/src/metabase-enterprise/group_managers/actions.js
@@ -19,21 +19,22 @@ export const CONFIRM_DELETE_MEMBERSHIP =
   "metabase-enterprise/group_managers/CONFIRM_DELETE_MEMBERSHIP";
 export const confirmDeleteMembership = createThunkAction(
   CONFIRM_DELETE_MEMBERSHIP,
-  (membershipId, currentUserMemberships, view) => async (dispatch, getState) => {
-    await dispatch(deleteMembership(membershipId));
-    await dispatch(refreshCurrentUser());
+  (membershipId, currentUserMemberships, view) =>
+    async (dispatch, getState) => {
+      await dispatch(deleteMembership(membershipId));
+      await dispatch(refreshCurrentUser());
 
-    const adminPaths = getAdminPaths(getState());
+      const adminPaths = getAdminPaths(getState());
 
-    const redirectUrl =
-      view === "people"
-        ? getRevokeManagerPeopleRedirect(currentUserMemberships, adminPaths)
-        : getRevokeManagerGroupsRedirect(currentUserMemberships, adminPaths);
+      const redirectUrl =
+        view === "people"
+          ? getRevokeManagerPeopleRedirect(currentUserMemberships, adminPaths)
+          : getRevokeManagerGroupsRedirect(currentUserMemberships, adminPaths);
 
-    if (redirectUrl) {
-      await dispatch(push(redirectUrl));
-    }
-  },
+      if (redirectUrl) {
+        await dispatch(push(redirectUrl));
+      }
+    },
 );
 
 export const CONFIRM_UPDATE_MEMBERSHIP =

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/components/EditSandboxingModal/EditSandboxingModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/components/EditSandboxingModal/EditSandboxingModal.tsx
@@ -253,7 +253,7 @@ const EditSandboxingModal = ({
             {typeof error === "string"
               ? error
               : // @ts-expect-error provide correct type for error
-                error.data.message ?? ERROR_MESSAGE}
+                (error.data.message ?? ERROR_MESSAGE)}
           </div>
         )}
       </div>

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/FontWidget/FontWidget.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/FontWidget/FontWidget.tsx
@@ -24,7 +24,7 @@ const FontWidget = ({
   onChangeSetting,
 }: FontWidgetProps): JSX.Element => {
   const value = !settingValues["application-font-files"]
-    ? setting.value ?? setting.default
+    ? (setting.value ?? setting.default)
     : CUSTOM;
 
   const options = useMemo(

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/IllustrationWidget/IllustrationWidget.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/IllustrationWidget/IllustrationWidget.tsx
@@ -185,8 +185,8 @@ export function IllustrationWidget({
                 {!customIllustrationSource
                   ? t`No file chosen`
                   : fileName
-                  ? fileName
-                  : t`Remove uploaded image`}
+                    ? fileName
+                    : t`Remove uploaded image`}
               </Text>
               {customIllustrationSource && (
                 <Button

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -306,28 +306,30 @@ export type FilterOperatorName =
   | ExcludeDateFilterOperatorName
   | CoordinateFilterOperatorName;
 
-export type StringFilterOperatorName = typeof STRING_FILTER_OPERATORS[number];
+export type StringFilterOperatorName = (typeof STRING_FILTER_OPERATORS)[number];
 
-export type NumberFilterOperatorName = typeof NUMBER_FILTER_OPERATORS[number];
+export type NumberFilterOperatorName = (typeof NUMBER_FILTER_OPERATORS)[number];
 
 export type CoordinateFilterOperatorName =
-  typeof COORDINATE_FILTER_OPERATORS[number];
+  (typeof COORDINATE_FILTER_OPERATORS)[number];
 
-export type BooleanFilterOperatorName = typeof BOOLEAN_FILTER_OPERATORS[number];
+export type BooleanFilterOperatorName =
+  (typeof BOOLEAN_FILTER_OPERATORS)[number];
 
 export type SpecificDateFilterOperatorName =
-  typeof SPECIFIC_DATE_FILTER_OPERATORS[number];
+  (typeof SPECIFIC_DATE_FILTER_OPERATORS)[number];
 
 export type ExcludeDateFilterOperatorName =
-  typeof EXCLUDE_DATE_FILTER_OPERATORS[number];
+  (typeof EXCLUDE_DATE_FILTER_OPERATORS)[number];
 
-export type TimeFilterOperatorName = typeof TIME_FILTER_OPERATORS[number];
+export type TimeFilterOperatorName = (typeof TIME_FILTER_OPERATORS)[number];
 
-export type DefaultFilterOperatorName = typeof DEFAULT_FILTER_OPERATORS[number];
+export type DefaultFilterOperatorName =
+  (typeof DEFAULT_FILTER_OPERATORS)[number];
 
-export type RelativeDateBucketName = typeof RELATIVE_DATE_BUCKETS[number];
+export type RelativeDateBucketName = (typeof RELATIVE_DATE_BUCKETS)[number];
 
-export type ExcludeDateBucketName = typeof EXCLUDE_DATE_BUCKETS[number];
+export type ExcludeDateBucketName = (typeof EXCLUDE_DATE_BUCKETS)[number];
 
 export type FilterOperatorDisplayInfo = {
   shortName: FilterOperatorName;

--- a/frontend/src/metabase-lib/v1/Alert/types.ts
+++ b/frontend/src/metabase-lib/v1/Alert/types.ts
@@ -10,4 +10,4 @@ const ALERT_TYPES = [
   ALERT_TYPE_PROGRESS_BAR_GOAL,
 ] as const;
 
-export type AlertType = typeof ALERT_TYPES[number];
+export type AlertType = (typeof ALERT_TYPES)[number];

--- a/frontend/src/metabase-lib/v1/Dimension.ts
+++ b/frontend/src/metabase-lib/v1/Dimension.ts
@@ -162,7 +162,7 @@ export default class Dimension {
    */
   // TODO Atte Keinänen 5/21/17: Rename either this or the static method with the same name
   // Also making it clear in the method name that we're working with sub-dimensions would be good
-  dimensions(DimensionTypes?: typeof Dimension[]): Dimension[] {
+  dimensions(DimensionTypes?: (typeof Dimension)[]): Dimension[] {
     const dimensionOptions = this.field().dimension_options;
 
     if (!DimensionTypes && dimensionOptions) {
@@ -915,7 +915,7 @@ export class FieldDimension extends Dimension {
     return this.field().icon();
   }
 
-  dimensions(DimensionTypes?: typeof Dimension[]): FieldDimension[] {
+  dimensions(DimensionTypes?: (typeof Dimension)[]): FieldDimension[] {
     let dimensions = super.dimensions(DimensionTypes);
     const joinAlias = this.joinAlias();
 
@@ -1667,7 +1667,7 @@ export class TemplateTagDimension extends FieldDimension {
   }
 }
 
-const DIMENSION_TYPES: typeof Dimension[] = [
+const DIMENSION_TYPES: (typeof Dimension)[] = [
   FieldDimension,
   ExpressionDimension,
   AggregationDimension,

--- a/frontend/src/metabase-lib/v1/ValidationError/types.ts
+++ b/frontend/src/metabase-lib/v1/ValidationError/types.ts
@@ -1,4 +1,4 @@
 import type { VALIDATION_ERROR_TYPES } from "./constants";
 
 export type ErrorType =
-  typeof VALIDATION_ERROR_TYPES[keyof typeof VALIDATION_ERROR_TYPES];
+  (typeof VALIDATION_ERROR_TYPES)[keyof typeof VALIDATION_ERROR_TYPES];

--- a/frontend/src/metabase-lib/v1/expressions/diagnostics.ts
+++ b/frontend/src/metabase-lib/v1/expressions/diagnostics.ts
@@ -93,12 +93,12 @@ export function diagnose({
     mismatchedParentheses === 1
       ? t`Expecting a closing parenthesis`
       : mismatchedParentheses > 1
-      ? t`Expecting ${mismatchedParentheses} closing parentheses`
-      : mismatchedParentheses === -1
-      ? t`Expecting an opening parenthesis`
-      : mismatchedParentheses < -1
-      ? t`Expecting ${-mismatchedParentheses} opening parentheses`
-      : null;
+        ? t`Expecting ${mismatchedParentheses} closing parentheses`
+        : mismatchedParentheses === -1
+          ? t`Expecting an opening parenthesis`
+          : mismatchedParentheses < -1
+            ? t`Expecting ${-mismatchedParentheses} opening parentheses`
+            : null;
 
   if (message) {
     return { message };

--- a/frontend/src/metabase-lib/v1/expressions/pratt/types.ts
+++ b/frontend/src/metabase-lib/v1/expressions/pratt/types.ts
@@ -88,7 +88,10 @@ abstract class ExpressionError extends Error {
 }
 
 export class CompileError extends ExpressionError {
-  constructor(message: string, private data: any) {
+  constructor(
+    message: string,
+    private data: any,
+  ) {
     super(message);
   }
 
@@ -102,7 +105,10 @@ export class CompileError extends ExpressionError {
 }
 
 export class ResolverError extends ExpressionError {
-  constructor(message: string, private node?: Node) {
+  constructor(
+    message: string,
+    private node?: Node,
+  ) {
     super(message);
   }
 

--- a/frontend/src/metabase-lib/v1/queries/structured/Filter.ts
+++ b/frontend/src/metabase-lib/v1/queries/structured/Filter.ts
@@ -79,8 +79,8 @@ export default class Filter extends MBQLClause {
         const detectedUnit = dates.some(d => d.minutes())
           ? "minute"
           : dates.some(d => d.hours())
-          ? "hour"
-          : "day";
+            ? "hour"
+            : "day";
         const unit = this.dimension()?.temporalUnit() ?? detectedUnit;
         return [dates, unit];
       }

--- a/frontend/src/metabase-types/api/activity.ts
+++ b/frontend/src/metabase-types/api/activity.ts
@@ -10,7 +10,7 @@ export const ACTIVITY_MODELS = [
   "collection",
 ] as const;
 
-export type ActivityModel = typeof ACTIVITY_MODELS[number];
+export type ActivityModel = (typeof ACTIVITY_MODELS)[number];
 
 export const isActivityModel = (model: string): model is ActivityModel =>
   (ACTIVITY_MODELS as unknown as string[]).includes(model);

--- a/frontend/src/metabase-types/api/bookmark.ts
+++ b/frontend/src/metabase-types/api/bookmark.ts
@@ -9,7 +9,7 @@ export const BOOKMARK_TYPES = [
   "snippet",
   "indexed-entity",
 ] as const;
-export type BookmarkType = typeof BOOKMARK_TYPES[number];
+export type BookmarkType = (typeof BOOKMARK_TYPES)[number];
 export type BookmarkId = string;
 
 export interface Bookmark {

--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -126,7 +126,7 @@ export type StackType = "stacked" | "normalized" | null;
 export type StackValuesDisplay = "total" | "all" | "series";
 
 export const numericScale = ["linear", "pow", "log"] as const;
-export type NumericScale = typeof numericScale[number];
+export type NumericScale = (typeof numericScale)[number];
 
 export type XAxisScale = "ordinal" | "histogram" | "timeseries" | NumericScale;
 

--- a/frontend/src/metabase-types/api/collection.ts
+++ b/frontend/src/metabase-types/api/collection.ts
@@ -91,7 +91,7 @@ export const COLLECTION_ITEM_MODELS = [
   "collection",
   "indexed-entity",
 ] as const;
-export type CollectionItemModel = typeof COLLECTION_ITEM_MODELS[number];
+export type CollectionItemModel = (typeof COLLECTION_ITEM_MODELS)[number];
 
 export type CollectionItemId = number;
 

--- a/frontend/src/metabase-types/api/mocks/actions.ts
+++ b/frontend/src/metabase-types/api/mocks/actions.ts
@@ -141,4 +141,4 @@ export const createMockImplicitActionFieldSettings = (
     id: "",
     hidden: false,
     ...opts,
-  } as FieldSettings);
+  }) as FieldSettings;

--- a/frontend/src/metabase-types/api/query.ts
+++ b/frontend/src/metabase-types/api/query.ts
@@ -73,8 +73,8 @@ export const dateTimeUnits = [
   ...dateTimeRelativeUnits,
 ] as const;
 
-export type DateTimeAbsoluteUnit = typeof dateTimeAbsoluteUnits[number];
-export type DateTimeRelativeUnit = typeof dateTimeRelativeUnits[number];
+export type DateTimeAbsoluteUnit = (typeof dateTimeAbsoluteUnits)[number];
+export type DateTimeRelativeUnit = (typeof dateTimeRelativeUnits)[number];
 export type DatetimeUnit =
   | "default"
   | DateTimeAbsoluteUnit

--- a/frontend/src/metabase-types/api/search.ts
+++ b/frontend/src/metabase-types/api/search.ts
@@ -23,9 +23,9 @@ const ENABLED_SEARCH_MODELS = [
 
 export const SEARCH_MODELS = [...ENABLED_SEARCH_MODELS, "segment"] as const;
 
-export type EnabledSearchModel = typeof ENABLED_SEARCH_MODELS[number];
+export type EnabledSearchModel = (typeof ENABLED_SEARCH_MODELS)[number];
 
-export type SearchModel = typeof SEARCH_MODELS[number];
+export type SearchModel = (typeof SEARCH_MODELS)[number];
 
 export interface SearchScore {
   weight: number;

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -170,7 +170,7 @@ export const tokenFeatures = [
   "query_reference_validation",
 ] as const;
 
-export type TokenFeature = typeof tokenFeatures[number];
+export type TokenFeature = (typeof tokenFeatures)[number];
 export type TokenFeatures = Record<TokenFeature, boolean>;
 
 export type PasswordComplexity = {

--- a/frontend/src/metabase-types/api/visualization.ts
+++ b/frontend/src/metabase-types/api/visualization.ts
@@ -6,7 +6,7 @@ export const virtualCardDisplayTypes = [
   "text",
 ] as const;
 
-export type VirtualCardDisplay = typeof virtualCardDisplayTypes[number];
+export type VirtualCardDisplay = (typeof virtualCardDisplayTypes)[number];
 
 export const isVirtualCardDisplayType = (
   value: string,
@@ -38,6 +38,6 @@ export const isCardDisplayType = (value: unknown): value is CardDisplayType =>
   typeof value === "string" &&
   cardDisplayTypes.includes(value as CardDisplayType);
 
-export type CardDisplayType = typeof cardDisplayTypes[number];
+export type CardDisplayType = (typeof cardDisplayTypes)[number];
 
 export type VisualizationDisplay = VirtualCardDisplay | CardDisplayType;

--- a/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
@@ -394,9 +394,8 @@ describe("Actions > ActionViz > Action", () => {
       const editorModal = await screen.findByTestId("action-editor-modal");
 
       // edit action title
-      const actionTitleField = await within(editorModal).findByTestId(
-        "editable-text",
-      );
+      const actionTitleField =
+        await within(editorModal).findByTestId("editable-text");
       await userEvent.type(actionTitleField, updatedTitle);
       await userEvent.tab(); // blur field
 

--- a/frontend/src/metabase/admin/databases/components/DeleteDatabaseModel/DeleteDatabaseModal.styled.tsx
+++ b/frontend/src/metabase/admin/databases/components/DeleteDatabaseModel/DeleteDatabaseModal.styled.tsx
@@ -24,7 +24,9 @@ export const DeleteDatabaseModalSection = styled.div<DeleteDatabaseModalSectionP
   height: ${props => (props.isHidden ? 0 : "unset")};
   opacity: ${props => (props.isHidden ? 0 : 1)};
   padding: 0.125rem;
-  transition: all 350ms, opacity 200ms;
+  transition:
+    all 350ms,
+    opacity 200ms;
   overflow: hidden;
 
   & + & {

--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.unit.spec.tsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.unit.spec.tsx
@@ -179,9 +179,8 @@ describe("DatabaseEditApp", () => {
 
       const displayNameInput = await screen.findByLabelText("Display name");
       await userEvent.type(displayNameInput, "Test database");
-      const connectionStringInput = await screen.findByLabelText(
-        "Connection String",
-      );
+      const connectionStringInput =
+        await screen.findByLabelText("Connection String");
       await userEvent.type(
         connectionStringInput,
         "file:/sample-database.db;USER=GUEST;PASSWORD=guest",

--- a/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/HoursMinutesInput.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/HoursMinutesInput.tsx
@@ -37,8 +37,8 @@ const HoursMinutesInput = ({
         is24HourMode
           ? String(hours)
           : hours % 12 === 0
-          ? "12"
-          : String(hours % 12)
+            ? "12"
+            : String(hours % 12)
       }
       onChange={
         is24HourMode

--- a/frontend/src/metabase/admin/datamodel/components/filters/pickers/LegacyDatePicker/HoursMinutesInput.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/filters/pickers/LegacyDatePicker/HoursMinutesInput.jsx
@@ -27,8 +27,8 @@ const HoursMinutesInput = ({
         is24HourMode
           ? String(hours)
           : hours % 12 === 0
-          ? "12"
-          : String(hours % 12)
+            ? "12"
+            : String(hours % 12)
       }
       onChange={
         is24HourMode

--- a/frontend/src/metabase/admin/datamodel/metadata/components/FieldRemappingSettings/FieldRemappingSettings.jsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/FieldRemappingSettings/FieldRemappingSettings.jsx
@@ -328,8 +328,8 @@ class ValueRemappings extends Component {
           mappedOrUndefined !== undefined
             ? mappedOrUndefined.toString()
             : original === null
-            ? "null"
-            : original.toString();
+              ? "null"
+              : original.toString();
 
         return [original, mappedString];
       }),

--- a/frontend/src/metabase/admin/people/components/GroupsListing.jsx
+++ b/frontend/src/metabase/admin/people/components/GroupsListing.jsx
@@ -70,15 +70,15 @@ function DeleteGroupModal({
     apiKeysCount === 0
       ? t`Remove this group?`
       : apiKeysCount === 1
-      ? t`Are you sure you want remove this group and its API key?`
-      : t`Are you sure you want remove this group and its API keys?`;
+        ? t`Are you sure you want remove this group and its API key?`
+        : t`Are you sure you want remove this group and its API keys?`;
 
   const confirmButtonText =
     apiKeysCount === 0
       ? t`Remove group`
       : apiKeysCount === 1
-      ? t`Remove group and API key`
-      : t`Remove group and API keys`;
+        ? t`Remove group and API key`
+        : t`Remove group and API keys`;
 
   return (
     <ModalContent title={modalTitle} onClose={onClose}>
@@ -299,8 +299,9 @@ function GroupsTable({
             index={index}
             apiKeys={
               isDefaultGroup(group)
-                ? apiKeys ?? []
-                : apiKeys?.filter(apiKey => apiKey.group.id === group.id) ?? []
+                ? (apiKeys ?? [])
+                : (apiKeys?.filter(apiKey => apiKey.group.id === group.id) ??
+                  [])
             }
             groupBeingEdited={groupBeingEdited}
             onEditGroupClicked={onEditGroupClicked}

--- a/frontend/src/metabase/admin/people/forms/UserForm.unit.spec.tsx
+++ b/frontend/src/metabase/admin/people/forms/UserForm.unit.spec.tsx
@@ -195,15 +195,11 @@ describe("UserForm", () => {
       await userEvent.click(await screen.findByText("Add an attribute"));
 
       await userEvent.type(
-        (
-          await screen.findAllByPlaceholderText("Key")
-        )[1],
+        (await screen.findAllByPlaceholderText("Key"))[1],
         "exp",
       );
       await userEvent.type(
-        (
-          await screen.findAllByPlaceholderText("Value")
-        )[1],
+        (await screen.findAllByPlaceholderText("Value"))[1],
         "1234",
       );
 
@@ -257,9 +253,7 @@ describe("UserForm", () => {
       await userEvent.click(await screen.findByText("Add an attribute"));
 
       await userEvent.type(
-        (
-          await screen.findAllByPlaceholderText("Key")
-        )[1],
+        (await screen.findAllByPlaceholderText("Key"))[1],
         "1",
       );
 
@@ -281,9 +275,7 @@ describe("UserForm", () => {
       // setValue, so we need to ensure that no other setValue calls are in
       // flight before typing the letter can causes the error.
       await userEvent.type(
-        (
-          await screen.findAllByPlaceholderText("Key")
-        )[1],
+        (await screen.findAllByPlaceholderText("Key"))[1],
         "team",
         { delay: 100 },
       );

--- a/frontend/src/metabase/admin/permissions/selectors/confirmations.tsx
+++ b/frontend/src/metabase/admin/permissions/selectors/confirmations.tsx
@@ -94,8 +94,8 @@ function getEntityTypeFromId(entityId: EntityId): [string, string] {
   return isTableEntityId(entityId)
     ? [t`table`, t`tables`]
     : isSchemaEntityId(entityId)
-    ? [t`schema`, t`schemas`]
-    : [t`entity`, t`entities`];
+      ? [t`schema`, t`schemas`]
+      : [t`entity`, t`entities`];
 }
 
 export function getPermissionWarningModal(

--- a/frontend/src/metabase/admin/settings/components/SettingsLdapForm.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsLdapForm.tsx
@@ -234,7 +234,7 @@ const getAttributeValues = (
     ldapAttributes.map(key => [
       key,
       defaultableAttrs.has(key)
-        ? values[key] ?? settings[key]?.default
+        ? (values[key] ?? settings[key]?.default)
         : values[key],
     ]),
   );

--- a/frontend/src/metabase/admin/upsells/components/Upsells.styled.tsx
+++ b/frontend/src/metabase/admin/upsells/components/Upsells.styled.tsx
@@ -67,12 +67,12 @@ export const UpsellCardComponent = styled.div<Variants>`
           width: 100%;
         `
       : maxWidth
-      ? css`
-          max-width: ${maxWidth}px;
-        `
-      : css`
-          max-width: 200px;
-        `}
+        ? css`
+            max-width: ${maxWidth}px;
+          `
+        : css`
+            max-width: 200px;
+          `}
   border-radius: 0.5rem;
   overflow: hidden;
   border: 1px solid ${upsellColors.secondary};

--- a/frontend/src/metabase/api/entity-id.ts
+++ b/frontend/src/metabase/api/entity-id.ts
@@ -25,7 +25,7 @@ const validEntityTypes = [
   "user",
 ] as const;
 
-export type EntityType = typeof validEntityTypes[number];
+export type EntityType = (typeof validEntityTypes)[number];
 
 type TranslateEntityIdRequest = Partial<Record<EntityType, BaseEntityId[]>>;
 

--- a/frontend/src/metabase/api/query.ts
+++ b/frontend/src/metabase/api/query.ts
@@ -15,7 +15,7 @@ const isAllowedHTTPMethod = (method: any): method is AllowedHTTPMethods => {
 
 // custom fetcher that wraps our Api client
 export const apiQuery: BaseQueryFn = async (args, ctx) => {
-  const method = typeof args === "string" ? "GET" : args?.method ?? "GET";
+  const method = typeof args === "string" ? "GET" : (args?.method ?? "GET");
   const url = typeof args === "string" ? args : args.url;
   const { bodyParamName, noEvent } = args;
 

--- a/frontend/src/metabase/api/tags/constants.ts
+++ b/frontend/src/metabase/api/tags/constants.ts
@@ -1,4 +1,4 @@
-export type TagType = typeof TAG_TYPES[number];
+export type TagType = (typeof TAG_TYPES)[number];
 
 export const TAG_TYPES = [
   "action",

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.tsx
@@ -112,7 +112,7 @@ function PinnedItemCard({
   return (
     <ItemLink
       className={className}
-      to={item ? modelToUrl(item) ?? "/" : undefined}
+      to={item ? (modelToUrl(item) ?? "/") : undefined}
       onClick={onClick}
     >
       <ItemCard flat>

--- a/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
@@ -159,8 +159,8 @@ export const CollectionPickerModal = ({
           canSelectItem(selectedItem)
             ? selectedItem.id
             : canSelectItem(value)
-            ? value.id
-            : "root"
+              ? value.id
+              : "root"
         }
         onNewCollection={handleNewCollectionCreate}
         namespace={options.namespace}

--- a/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPickerModal.tsx
+++ b/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPickerModal.tsx
@@ -158,8 +158,8 @@ export const DashboardPickerModal = ({
           options.showRootCollection === false
             ? { filter_items_in_personal_collection: "only" }
             : options.showPersonalCollections === false
-            ? { filter_items_in_personal_collection: "exclude" }
-            : undefined
+              ? { filter_items_in_personal_collection: "exclude" }
+              : undefined
         }
         trapFocus={!isCreateDialogOpen}
       />

--- a/frontend/src/metabase/common/components/DataPicker/utils.ts
+++ b/frontend/src/metabase/common/components/DataPicker/utils.ts
@@ -51,8 +51,8 @@ export const getDataPickerValue = (
       model: displayInfo.isModel
         ? "dataset"
         : displayInfo.isMetric
-        ? "metric"
-        : "card",
+          ? "metric"
+          : "card",
     };
   }
 

--- a/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPickerModal.tsx
+++ b/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPickerModal.tsx
@@ -147,8 +147,8 @@ export const QuestionPickerModal = ({
         options.showRootCollection === false
           ? { filter_items_in_personal_collection: "only" }
           : options.showPersonalCollections === false
-          ? { filter_items_in_personal_collection: "exclude" }
-          : undefined
+            ? { filter_items_in_personal_collection: "exclude" }
+            : undefined
       }
       searchResultFilter={results => results}
       actionButtons={[]}

--- a/frontend/src/metabase/components/EntityItem/EntityItem.styled.tsx
+++ b/frontend/src/metabase/components/EntityItem/EntityItem.styled.tsx
@@ -12,8 +12,8 @@ function getForeground(model: string, disabled: boolean) {
   return disabled
     ? darken(color("border"), 0.38)
     : model === "dataset"
-    ? color("accent2")
-    : color("brand");
+      ? color("accent2")
+      : color("brand");
 }
 
 const getItemPadding = (variant?: string) => {

--- a/frontend/src/metabase/components/ErrorDetails/ErrorBox.tsx
+++ b/frontend/src/metabase/components/ErrorDetails/ErrorBox.tsx
@@ -7,7 +7,7 @@ export const ErrorBox = ({ children }: { children: ErrorDetails }) => (
     {typeof children === "string"
       ? children
       : typeof children.message === "string"
-      ? children.message
-      : String(children)}
+        ? children.message
+        : String(children)}
   </MonospaceErrorDisplay>
 );

--- a/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.tsx
+++ b/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.tsx
@@ -205,9 +205,8 @@ export function FieldValuesWidgetInner({
         newOptions = values;
         newValuesMode = has_more_values ? "search" : newValuesMode;
       } else if (canUseParameterEndpoints(parameter)) {
-        const { values, has_more_values } = await dispatchFetchParameterValues(
-          query,
-        );
+        const { values, has_more_values } =
+          await dispatchFetchParameterValues(query);
         newOptions = values;
         newValuesMode = has_more_values ? "search" : newValuesMode;
       } else {

--- a/frontend/src/metabase/components/ItemsTable/BaseItemsTable.styled.tsx
+++ b/frontend/src/metabase/components/ItemsTable/BaseItemsTable.styled.tsx
@@ -46,13 +46,12 @@ Table.defaultProps = { className: AdminS.ContentTable };
 export const hideResponsively = ({
   hideAtContainerBreakpoint,
   containerName,
-}: ResponsiveProps) =>
-  css`
-    ${getContainerQuery({
-      hideAtContainerBreakpoint,
-      containerName,
-    })}
-  `;
+}: ResponsiveProps) => css`
+  ${getContainerQuery({
+    hideAtContainerBreakpoint,
+    containerName,
+  })}
+`;
 
 export const ColumnHeader = styled.th<ResponsiveProps>`
   th& {

--- a/frontend/src/metabase/components/MetadataInfo/ColumnFingerprintInfo/CategoryFingerprint.styled.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/ColumnFingerprintInfo/CategoryFingerprint.styled.tsx
@@ -54,7 +54,8 @@ export const Fade = styled.div<{ visible?: boolean }>`
 export const FadeAndSlide = styled.div<{ visible?: boolean }>`
   position: absolute;
   width: 100%;
-  transition: opacity ${TRANSITION_DURATION} linear,
+  transition:
+    opacity ${TRANSITION_DURATION} linear,
     transform ${TRANSITION_DURATION} linear;
   opacity: ${({ visible }) => (visible ? "1" : "0")};
   transform: ${({ visible }) =>

--- a/frontend/src/metabase/components/MetadataInfo/TableInfo/TableInfo.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/TableInfo/TableInfo.tsx
@@ -57,9 +57,8 @@ function useDependentTableMetadata({
   const isMissingFields = !table?.numFields();
   const isMissingFks = table?.fks === undefined;
   const shouldFetchMetadata = isMissingFields || isMissingFks;
-  const [hasFetchedMetadata, setHasFetchedMetadata] = useState(
-    !shouldFetchMetadata,
-  );
+  const [hasFetchedMetadata, setHasFetchedMetadata] =
+    useState(!shouldFetchMetadata);
   const fetchDependentData = useSafeAsyncFunction(() => {
     return Promise.all([
       isMissingFields && fetchMetadata({ id: tableId }),

--- a/frontend/src/metabase/components/Modal/utils.tsx
+++ b/frontend/src/metabase/components/Modal/utils.tsx
@@ -4,7 +4,7 @@ import _ from "underscore";
 import ModalContent from "metabase/components/ModalContent";
 
 export const modalSizes = ["small", "medium", "wide", "tall", "fit"] as const;
-export type ModalSize = typeof modalSizes[number];
+export type ModalSize = (typeof modalSizes)[number];
 
 export type BaseModalProps = {
   children?: React.ReactNode;

--- a/frontend/src/metabase/components/Popover/Popover.jsx
+++ b/frontend/src/metabase/components/Popover/Popover.jsx
@@ -251,10 +251,10 @@ export default class Popover extends Component {
         {typeof this.props.children === "function"
           ? this.props.children(childProps)
           : Children.count(this.props.children) === 1 &&
-            // NOTE: workaround for https://github.com/facebook/react/issues/12136
-            !Array.isArray(this.props.children)
-          ? cloneElement(Children.only(this.props.children), childProps)
-          : this.props.children}
+              // NOTE: workaround for https://github.com/facebook/react/issues/12136
+              !Array.isArray(this.props.children)
+            ? cloneElement(Children.only(this.props.children), childProps)
+            : this.props.children}
       </div>
     );
     if (this.props.noOnClickOutsideWrapper) {
@@ -305,8 +305,8 @@ export default class Popover extends Component {
       attachmentY === "top"
         ? window.innerHeight - bottom - this.props.targetOffsetY - PAGE_PADDING
         : attachmentY === "bottom"
-        ? top - this.props.targetOffsetY - PAGE_PADDING
-        : 0,
+          ? top - this.props.targetOffsetY - PAGE_PADDING
+          : 0,
     );
 
     // get the largest available height, then subtract .PopoverBody's border and padding

--- a/frontend/src/metabase/components/Popover/Popover.module.css
+++ b/frontend/src/metabase/components/Popover/Popover.module.css
@@ -27,7 +27,10 @@
 :global(.tippy-box),
 :global(.tippy-content) {
   max-height: inherit;
-  transition: transform 0s, visibility 0.3s, opacity 0.3s;
+  transition:
+    transform 0s,
+    visibility 0.3s,
+    opacity 0.3s;
 }
 
 :global(.tippy-box[data-theme~="tooltip"]) {

--- a/frontend/src/metabase/components/SingleSelectListField/SingleSelectListField.tsx
+++ b/frontend/src/metabase/components/SingleSelectListField/SingleSelectListField.tsx
@@ -139,7 +139,7 @@ const SingleSelectListField = ({
             <OptionItem
               data-testid={`${option[0]}-filter-value`}
               selectedColor={
-                checkedColor ?? isDashboardFilter
+                (checkedColor ?? isDashboardFilter)
                   ? "var(--mb-color-background-selected)"
                   : "var(--mb-color-filter)"
               }

--- a/frontend/src/metabase/containers/Unsubscribe.tsx
+++ b/frontend/src/metabase/containers/Unsubscribe.tsx
@@ -32,7 +32,7 @@ const SUBSCRIPTION = {
   RESUBSCRIBE: "resubscribe",
 } as const;
 
-type Subscription = typeof SUBSCRIPTION[keyof typeof SUBSCRIPTION];
+type Subscription = (typeof SUBSCRIPTION)[keyof typeof SUBSCRIPTION];
 
 export const UnsubscribePage = ({
   location,

--- a/frontend/src/metabase/core/components/AccordionList/utils.ts
+++ b/frontend/src/metabase/core/components/AccordionList/utils.ts
@@ -65,7 +65,7 @@ export const getNextCursor = (
 
     for (
       let itemIndex =
-        sectionIndex === cursor.sectionIndex ? cursor.itemIndex ?? 0 : 0;
+        sectionIndex === cursor.sectionIndex ? (cursor.itemIndex ?? 0) : 0;
       itemIndex < section.items.length;
       itemIndex++
     ) {
@@ -121,7 +121,7 @@ export const getPrevCursor = (
       for (
         let itemIndex =
           sectionIndex === cursor.sectionIndex
-            ? cursor.itemIndex ?? 0
+            ? (cursor.itemIndex ?? 0)
             : section.items.length - 1;
         itemIndex >= 0;
         itemIndex--

--- a/frontend/src/metabase/core/components/Select/Select.tsx
+++ b/frontend/src/metabase/core/components/Select/Select.tsx
@@ -277,13 +277,13 @@ class BaseSelect<TValue, TOption = SelectOption<TValue>> extends Component<
               {this.props.buttonText
                 ? this.props.buttonText
                 : selectedNames.length > 0
-                ? selectedNames.map((name, index) => (
-                    <span key={index}>
-                      {name}
-                      {index < selectedNames.length - 1 ? ", " : ""}
-                    </span>
-                  ))
-                : placeholder}
+                  ? selectedNames.map((name, index) => (
+                      <span key={index}>
+                        {name}
+                        {index < selectedNames.length - 1 ? ", " : ""}
+                      </span>
+                    ))
+                  : placeholder}
             </SelectButton>
           )
         }

--- a/frontend/src/metabase/css/components/modal.module.css
+++ b/frontend/src/metabase/css/components/modal.module.css
@@ -94,7 +94,9 @@
 
 .ModalBackdrop.ModalAppearActive .Modal,
 .ModalBackdrop.ModalEnterActive .Modal {
-  transition: opacity 200ms linear 100ms, transform 200ms ease-in-out 100ms;
+  transition:
+    opacity 200ms linear 100ms,
+    transform 200ms ease-in-out 100ms;
   opacity: 1;
   transform: translate(0, 0);
 }
@@ -105,7 +107,9 @@
 }
 
 .ModalBackdrop.ModalExitActive .Modal {
-  transition: opacity 200ms linear, transform 200ms ease-in-out;
+  transition:
+    opacity 200ms linear,
+    transform 200ms ease-in-out;
   opacity: 0.01;
   transform: translate(0, -40px);
 }

--- a/frontend/src/metabase/css/dashboard.module.css
+++ b/frontend/src/metabase/css/dashboard.module.css
@@ -38,7 +38,9 @@
 /* Night mode transition */
 .Dashboard.DashboardFullscreen,
 .Dashboard.DashboardFullscreen .DashCard .Card {
-  transition: background-color 1s linear, border 1s linear;
+  transition:
+    background-color 1s linear,
+    border 1s linear;
 }
 
 .DashEditing {
@@ -46,7 +48,9 @@
 }
 
 .DashEditing .DashCard .Card {
-  transition: border 0.3s, background-color 0.3s;
+  transition:
+    border 0.3s,
+    background-color 0.3s;
 }
 
 .DashEditing .CardTitle:first-of-type {

--- a/frontend/src/metabase/css/query_builder.module.css
+++ b/frontend/src/metabase/css/query_builder.module.css
@@ -282,7 +282,9 @@
 
 .RunButton {
   opacity: 1;
-  transition: transform 0.25s, opacity 0.25s;
+  transition:
+    transform 0.25s,
+    opacity 0.25s;
 }
 
 .RunButton.RunButtonCompact {

--- a/frontend/src/metabase/dashboard/actions/cards-typed.ts
+++ b/frontend/src/metabase/dashboard/actions/cards-typed.ts
@@ -243,12 +243,12 @@ export const replaceCard =
 export const removeCardFromDashboard = createThunkAction(
   REMOVE_CARD_FROM_DASH,
   ({
-      dashcardId,
-      cardId,
-    }: {
-      dashcardId: DashCardId;
-      cardId: DashboardCard["card_id"];
-    }) =>
+    dashcardId,
+    cardId,
+  }: {
+    dashcardId: DashCardId;
+    cardId: DashboardCard["card_id"];
+  }) =>
     dispatch => {
       dispatch(closeAddCardAutoWireToasts());
 

--- a/frontend/src/metabase/dashboard/actions/parameters.ts
+++ b/frontend/src/metabase/dashboard/actions/parameters.ts
@@ -351,9 +351,8 @@ function restoreParameterMappingsIfNeeded(
     setParamType(parameterToRestore, parameterToRestore.type, sectionId),
   );
 
-  const parameterMappingsBeforeEditing = getParameterMappingsBeforeEditing(
-    getState(),
-  );
+  const parameterMappingsBeforeEditing =
+    getParameterMappingsBeforeEditing(getState());
   const parameterMappings = parameterMappingsBeforeEditing[parameterId];
 
   if (!parameterMappings) {
@@ -538,20 +537,21 @@ export const SET_PARAMETER_IS_MULTI_SELECT =
   "metabase/dashboard/SET_PARAMETER_DEFAULT_VALUE";
 export const setParameterIsMultiSelect = createThunkAction(
   SET_PARAMETER_IS_MULTI_SELECT,
-  (parameterId: ParameterId, isMultiSelect: boolean) => (dispatch, getState) => {
-    updateParameter(dispatch, getState, parameterId, parameter => ({
-      ...parameter,
-      isMultiSelect: isMultiSelect,
-      default:
-        !isMultiSelect &&
-        Array.isArray(parameter.default) &&
-        parameter.default.length > 1
-          ? [parameter.default[0]]
-          : parameter.default,
-    }));
+  (parameterId: ParameterId, isMultiSelect: boolean) =>
+    (dispatch, getState) => {
+      updateParameter(dispatch, getState, parameterId, parameter => ({
+        ...parameter,
+        isMultiSelect: isMultiSelect,
+        default:
+          !isMultiSelect &&
+          Array.isArray(parameter.default) &&
+          parameter.default.length > 1
+            ? [parameter.default[0]]
+            : parameter.default,
+      }));
 
-    return { id: parameterId, isMultiSelect };
-  },
+      return { id: parameterId, isMultiSelect };
+    },
 );
 
 export const SET_PARAMETER_TEMPORAL_UNITS =

--- a/frontend/src/metabase/dashboard/actions/tabs.ts
+++ b/frontend/src/metabase/dashboard/actions/tabs.ts
@@ -584,7 +584,7 @@ export const tabsReducer = createReducer<DashboardState>(
       const tabId =
         idFromSlug && prevTabs.map(t => t.id).includes(idFromSlug)
           ? idFromSlug
-          : prevTabs[0]?.id ?? null;
+          : (prevTabs[0]?.id ?? null);
 
       state.selectedTabId = tabId;
     });

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker/LinkedEntityPicker.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker/LinkedEntityPicker.tsx
@@ -186,7 +186,7 @@ export function LinkedEntityPicker({
   const dashboardTabs = targetDashboard?.tabs ?? NO_DASHBOARD_TABS;
   const defaultDashboardTabId: number | undefined = dashboardTabs[0]?.id;
   const dashboardTabId = isDashboard
-    ? clickBehavior.tabId ?? defaultDashboardTabId
+    ? (clickBehavior.tabId ?? defaultDashboardTabId)
     : undefined;
   const dashboardTabExists = dashboardTabs.some(
     tab => tab.id === dashboardTabId,

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.tsx
@@ -117,7 +117,9 @@ export const ParametersWidgetContainer = styled(FullWidthContainer)<{
   ${({ isFullscreen }) =>
     isFullscreen &&
     css`
-      transition: background-color 1s linear, border-color 1s linear,
+      transition:
+        background-color 1s linear,
+        border-color 1s linear,
         color 1s linear;
     `}
 

--- a/frontend/src/metabase/dashboard/hooks/use-location-sync.ts
+++ b/frontend/src/metabase/dashboard/hooks/use-location-sync.ts
@@ -18,14 +18,14 @@ const DEFAULT_SYNCED_DASHBOARD_OPTIONS = {
 } as const;
 
 const getDefaultDisplayOption = <
-  Value extends typeof DEFAULT_SYNCED_DASHBOARD_OPTIONS[Key],
+  Value extends (typeof DEFAULT_SYNCED_DASHBOARD_OPTIONS)[Key],
   Key extends SYNCED_KEY,
 >(
   key: Key,
 ): Value => DEFAULT_SYNCED_DASHBOARD_OPTIONS[key] as Value;
 
 const isEmptyOrDefault = <
-  Value extends typeof DEFAULT_SYNCED_DASHBOARD_OPTIONS[Key],
+  Value extends (typeof DEFAULT_SYNCED_DASHBOARD_OPTIONS)[Key],
   Key extends SYNCED_KEY,
 >(
   value: Value,
@@ -33,7 +33,7 @@ const isEmptyOrDefault = <
 ) => isNullOrUndefined(value) || value === getDefaultDisplayOption(key);
 
 export const useLocationSync = <
-  Value extends typeof DEFAULT_SYNCED_DASHBOARD_OPTIONS[Key],
+  Value extends (typeof DEFAULT_SYNCED_DASHBOARD_OPTIONS)[Key],
   Key extends SYNCED_KEY = any,
 >({
   key,

--- a/frontend/src/metabase/entities/collections/getExpandedCollectionsById.js
+++ b/frontend/src/metabase/entities/collections/getExpandedCollectionsById.js
@@ -24,8 +24,8 @@ function getExpandedCollectionsById(
         c.id === "root"
           ? []
           : c.location != null
-          ? ["root", ...c.location.split("/").filter(l => l)]
-          : null,
+            ? ["root", ...c.location.split("/").filter(l => l)]
+            : null,
       parent: null,
       children: [],
     };

--- a/frontend/src/metabase/entities/containers/EntityObjectLoader.jsx
+++ b/frontend/src/metabase/entities/containers/EntityObjectLoader.jsx
@@ -196,14 +196,13 @@ export const entityObjectLoader =
   eolProps =>
   ComposedComponent =>
   // eslint-disable-next-line react/display-name
-  props =>
-    (
-      <EntityObjectLoader {...props} {...eolProps}>
-        {childProps => (
-          <ComposedComponent
-            {..._.omit(props, ...CONSUMED_PROPS)}
-            {...childProps}
-          />
-        )}
-      </EntityObjectLoader>
-    );
+  props => (
+    <EntityObjectLoader {...props} {...eolProps}>
+      {childProps => (
+        <ComposedComponent
+          {..._.omit(props, ...CONSUMED_PROPS)}
+          {...childProps}
+        />
+      )}
+    </EntityObjectLoader>
+  );

--- a/frontend/src/metabase/entities/search.js
+++ b/frontend/src/metabase/entities/search.js
@@ -131,30 +131,30 @@ export default createEntity({
     getCollection: object => {
       const entity = entityForObject(object);
       return entity
-        ? entity?.objectSelectors?.getCollection?.(object) ??
+        ? (entity?.objectSelectors?.getCollection?.(object) ??
             object?.collection ??
-            null
+            null)
         : warnEntityAndReturnObject(object);
     },
 
     getName: object => {
       const entity = entityForObject(object);
       return entity
-        ? entity?.objectSelectors?.getName?.(object) ?? object?.name
+        ? (entity?.objectSelectors?.getName?.(object) ?? object?.name)
         : warnEntityAndReturnObject(object);
     },
 
     getColor: object => {
       const entity = entityForObject(object);
       return entity
-        ? entity?.objectSelectors?.getColor?.(object) ?? null
+        ? (entity?.objectSelectors?.getColor?.(object) ?? null)
         : warnEntityAndReturnObject(object);
     },
 
     getIcon: object => {
       const entity = entityForObject(object);
       return entity
-        ? entity?.objectSelectors?.getIcon?.(object) ?? null
+        ? (entity?.objectSelectors?.getIcon?.(object) ?? null)
         : warnEntityAndReturnObject(object);
     },
   },

--- a/frontend/src/metabase/hoc/RenderPropToHOC.jsx
+++ b/frontend/src/metabase/hoc/RenderPropToHOC.jsx
@@ -1,9 +1,8 @@
 export default function renderPropToHoc(RenderPropComponent) {
   // eslint-disable-next-line react/display-name
-  return ComposedComponent => props =>
-    (
-      <RenderPropComponent {...props}>
-        {childrenProps => <ComposedComponent {...props} {...childrenProps} />}
-      </RenderPropComponent>
-    );
+  return ComposedComponent => props => (
+    <RenderPropComponent {...props}>
+      {childrenProps => <ComposedComponent {...props} {...childrenProps} />}
+    </RenderPropComponent>
+  );
 }

--- a/frontend/src/metabase/lib/click-behavior.js
+++ b/frontend/src/metabase/lib/click-behavior.js
@@ -30,10 +30,10 @@ export function getClickBehaviorDescription(dashcard) {
     return linkType == null
       ? t`Go to...`
       : linkType === "dashboard"
-      ? t`Go to dashboard`
-      : linkType === "question"
-      ? t`Go to question`
-      : t`Go to url`;
+        ? t`Go to dashboard`
+        : linkType === "question"
+          ? t`Go to question`
+          : t`Go to url`;
   }
 
   return t`Filter this dashboard`;

--- a/frontend/src/metabase/lib/entities.js
+++ b/frontend/src/metabase/lib/entities.js
@@ -399,8 +399,8 @@ export function createEntity(def) {
     typeof entityId === "object"
       ? JSON.stringify(entityId)
       : entityId
-      ? entityId
-      : "",
+        ? entityId
+        : "",
   ); // must stringify objects
 
   // LIST SELECTORS

--- a/frontend/src/metabase/lib/formatting/datetime-utils.ts
+++ b/frontend/src/metabase/lib/formatting/datetime-utils.ts
@@ -6,8 +6,8 @@ export const DEFAULT_DATE_STYLE = "MMMM D, YYYY";
 const UNITS_WITH_HOUR = ["default", "minute", "hour", "hour-of-day"] as const;
 const UNITS_WITH_DAY = ["default", "minute", "hour", "day", "week"] as const;
 
-type UNITS_WITH_HOUR_TYPE = typeof UNITS_WITH_HOUR[number];
-type UNITS_WITH_DAY_TYPE = typeof UNITS_WITH_DAY[number];
+type UNITS_WITH_HOUR_TYPE = (typeof UNITS_WITH_HOUR)[number];
+type UNITS_WITH_DAY_TYPE = (typeof UNITS_WITH_DAY)[number];
 
 const UNITS_WITH_HOUR_SET = new Set(UNITS_WITH_HOUR);
 const UNITS_WITH_DAY_SET = new Set(UNITS_WITH_DAY);

--- a/frontend/src/metabase/lib/formatting/geography.ts
+++ b/frontend/src/metabase/lib/formatting/geography.ts
@@ -27,7 +27,7 @@ export function formatCoordinate(value: number, options: OptionsType = {}) {
   const formattedValue = binWidth
     ? BINNING_DEGREES_FORMATTER(value, binWidth)
     : options.compact
-    ? DECIMAL_DEGREES_FORMATTER_COMPACT(value)
-    : DECIMAL_DEGREES_FORMATTER(value);
+      ? DECIMAL_DEGREES_FORMATTER_COMPACT(value)
+      : DECIMAL_DEGREES_FORMATTER(value);
   return formattedValue + "°" + direction;
 }

--- a/frontend/src/metabase/lib/formatting/time.ts
+++ b/frontend/src/metabase/lib/formatting/time.ts
@@ -53,8 +53,8 @@ export function formatTimeWithUnit(
   const timeEnabled = options.time_enabled
     ? options.time_enabled
     : hasHour(unit)
-    ? "minutes"
-    : null;
+      ? "minutes"
+      : null;
 
   const timeFormat = options.time_format
     ? options.time_format

--- a/frontend/src/metabase/nav/components/ProfileLink/useHelpLink.ts
+++ b/frontend/src/metabase/nav/components/ProfileLink/useHelpLink.ts
@@ -33,8 +33,8 @@ export const useHelpLink = (): { visible: boolean; href: string } => {
     helpLinkSetting === "custom"
       ? helpLinkCustomDestinationSetting
       : isAdmin && isPaidPlan
-      ? `https://www.metabase.com/help-premium?utm_source=in-product&utm_medium=menu&utm_campaign=help&instance_version=${version.tag}&diag=${compactBugReportDetailsForUrl}`
-      : `https://www.metabase.com/help?utm_source=in-product&utm_medium=menu&utm_campaign=help&instance_version=${version.tag}`;
+        ? `https://www.metabase.com/help-premium?utm_source=in-product&utm_medium=menu&utm_campaign=help&instance_version=${version.tag}&diag=${compactBugReportDetailsForUrl}`
+        : `https://www.metabase.com/help?utm_source=in-product&utm_medium=menu&utm_campaign=help&instance_version=${version.tag}`;
 
   return { visible, href };
 };

--- a/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.styled.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.styled.tsx
@@ -36,6 +36,7 @@ export const SearchInputContainer = styled.div<{
     }
     return css`
       background-color: var(--mb-color-bg-white);
+
       &:hover {
         background-color: var(--mb-color-bg-light);
       }
@@ -43,7 +44,9 @@ export const SearchInputContainer = styled.div<{
   }}
   border: 1px solid var(--mb-color-border);
   overflow: hidden;
-  transition: background 150ms, width 0.2s;
+  transition:
+    background 150ms,
+    width 0.2s;
 
   @media (prefers-reduced-motion) {
     transition: none;

--- a/frontend/src/metabase/palette/components/PaletteResultItem.unit.spec.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResultItem.unit.spec.tsx
@@ -12,7 +12,7 @@ const mockPaletteActionImpl = (opts: Partial<PaletteActionImpl>) =>
     ancestors: [],
     children: [],
     ...opts,
-  } as PaletteActionImpl);
+  }) as PaletteActionImpl;
 
 const setup = ({
   active = false,

--- a/frontend/src/metabase/palette/utils.unit.spec.ts
+++ b/frontend/src/metabase/palette/utils.unit.spec.ts
@@ -12,7 +12,7 @@ const createMockAction = ({
   section = "basic",
   disabled,
 }: mockAction): PaletteActionImpl =>
-  ({ name, section, disabled } as PaletteActionImpl);
+  ({ name, section, disabled }) as PaletteActionImpl;
 
 describe("command palette utils", () => {
   describe("processSection", () => {

--- a/frontend/src/metabase/parameters/components/ParameterValuePicker/OwnDatePicker/OwnDatePicker.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValuePicker/OwnDatePicker/OwnDatePicker.tsx
@@ -65,7 +65,7 @@ export function OwnDatePicker(props: OwnDatePickerProps) {
       <Popover.Target>
         <TextInputTrirgger
           ref={setTriggerRef}
-          value={typeof formatted === "string" ? formatted : value ?? ""} // required by Mantine
+          value={typeof formatted === "string" ? formatted : (value ?? "")} // required by Mantine
           readOnly
           placeholder={placeholder}
           onClick={openPopover}

--- a/frontend/src/metabase/parameters/utils/dashboards.ts
+++ b/frontend/src/metabase/parameters/utils/dashboards.ts
@@ -201,7 +201,7 @@ function buildFieldFilterUiParameter(
       },
     )
     .map(({ field, shouldResolveFkField }) => {
-      return shouldResolveFkField ? field.target ?? field : field;
+      return shouldResolveFkField ? (field.target ?? field) : field;
     });
 
   return {

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/EmbedModalContentStatusBar.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/EmbedModalContentStatusBar.tsx
@@ -38,8 +38,8 @@ export const EmbedModalContentStatusBar = ({
           {!isPublished
             ? t`You will need to publish this ${resourceType} before you can embed it in another application.`
             : hasSettingsChanges
-            ? t`You’ve made changes that need to be published before they will be reflected in your application embed.`
-            : t`This ${resourceType} is published and ready to be embedded.`}
+              ? t`You’ve made changes that need to be published before they will be reflected in your application embed.`
+              : t`This ${resourceType} is published and ready to be embedded.`}
         </Text>
 
         <Group spacing="1rem" className={CS.flexNoShrink}>

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/LookAndFeelSettings.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/LookAndFeelSettings.tsx
@@ -32,7 +32,7 @@ const THEME_OPTIONS = [
   { label: t`Light`, value: "light" },
   { label: t`Dark`, value: "night" },
 ] as const;
-type ThemeOptions = typeof THEME_OPTIONS[number]["value"];
+type ThemeOptions = (typeof THEME_OPTIONS)[number]["value"];
 
 interface AppearanceSettingsProps {
   resourceType: EmbedResourceType;

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/StaticEmbedSetupPane.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/StaticEmbedSetupPane.tsx
@@ -239,7 +239,7 @@ export const StaticEmbedSetupPane = ({
   };
 
   const [activeTab, setActiveTab] = useState<
-    typeof EMBED_MODAL_TABS[keyof typeof EMBED_MODAL_TABS]
+    (typeof EMBED_MODAL_TABS)[keyof typeof EMBED_MODAL_TABS]
   >(EMBED_MODAL_TABS.Overview);
   return (
     <Stack spacing={0}>

--- a/frontend/src/metabase/pulse/components/RecipientPicker.unit.spec.tsx
+++ b/frontend/src/metabase/pulse/components/RecipientPicker.unit.spec.tsx
@@ -80,9 +80,7 @@ describe("recipient picker", () => {
       );
 
       await userEvent.click(
-        (
-          await screen.findAllByRole("img", { name: /close/ })
-        )[2],
+        (await screen.findAllByRole("img", { name: /close/ }))[2],
       );
 
       expect(onRecipientsChange).toHaveBeenCalledWith([

--- a/frontend/src/metabase/query_builder/actions/core/core.js
+++ b/frontend/src/metabase/query_builder/actions/core/core.js
@@ -119,10 +119,10 @@ export const setCardAndRun = (nextCard, { shouldUpdateUrl = true } = {}) => {
       ? // If the original card id is present, dynamically load its information for showing lineage
         await loadCard(card.original_card_id, { dispatch, getState })
       : // Otherwise, use a current card as the original card if the card has been saved
-      // This is needed for checking whether the card is in dirty state or not
-      card.id
-      ? card
-      : null;
+        // This is needed for checking whether the card is in dirty state or not
+        card.id
+        ? card
+        : null;
 
     // Update the card and originalCard before running the actual query
     dispatch({ type: SET_CARD_AND_RUN, payload: { card, originalCard } });

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -345,9 +345,8 @@ async function handleQBInit(
 
   const objectId = params?.objectId || queryParams?.objectId;
 
-  uiControls.isShowingNotebookNativePreview = getIsNotebookNativePreviewShown(
-    getState(),
-  );
+  uiControls.isShowingNotebookNativePreview =
+    getIsNotebookNativePreviewShown(getState());
   uiControls.notebookNativePreviewSidebarWidth =
     getNotebookNativePreviewSidebarWidth(getState());
 

--- a/frontend/src/metabase/query_builder/actions/navigation.js
+++ b/frontend/src/metabase/query_builder/actions/navigation.js
@@ -125,16 +125,16 @@ export const UPDATE_URL = "metabase/qb/UPDATE_URL";
 export const updateUrl = createThunkAction(
   UPDATE_URL,
   (
-      question,
-      {
-        dirty,
-        replaceState,
-        preserveParameters = true,
-        queryBuilderMode,
-        datasetEditorTab,
-        objectId,
-      } = {},
-    ) =>
+    question,
+    {
+      dirty,
+      replaceState,
+      preserveParameters = true,
+      queryBuilderMode,
+      datasetEditorTab,
+      objectId,
+    } = {},
+  ) =>
     (dispatch, getState) => {
       if (!question) {
         question = getQuestion(getState());

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.tsx
@@ -113,8 +113,8 @@ const DataSelectorDatabaseSchemaPicker = ({
   let openSection = selectedSchema
     ? databases.findIndex(db => db.id === selectedSchema.database?.id)
     : selectedDatabase
-    ? databases.findIndex(db => db.id === selectedDatabase.id)
-    : -1;
+      ? databases.findIndex(db => db.id === selectedDatabase.id)
+      : -1;
 
   if (openSection >= 0 && databases[openSection]?.getSchemas().length === 1) {
     openSection = -1;

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -183,8 +183,8 @@ function getColumnTabIndex(columnIndex, focusedFieldIndex) {
   return columnIndex === focusedFieldIndex
     ? EDITOR_TAB_INDEXES.FOCUSED_FIELD
     : columnIndex > focusedFieldIndex
-    ? EDITOR_TAB_INDEXES.NEXT_FIELDS
-    : EDITOR_TAB_INDEXES.PREVIOUS_FIELDS;
+      ? EDITOR_TAB_INDEXES.NEXT_FIELDS
+      : EDITOR_TAB_INDEXES.PREVIOUS_FIELDS;
 }
 
 function DatasetEditor(props) {

--- a/frontend/src/metabase/query_builder/components/QueryDownloadPopover/DownloadButton.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryDownloadPopover/DownloadButton.tsx
@@ -7,7 +7,7 @@ import DownloadButtonS from "./DownloadButton.module.css";
 import { checkCanManageFormatting } from "./utils";
 
 type DownloadButtonProps = {
-  format: typeof exportFormats[number] | typeof exportFormatPng;
+  format: (typeof exportFormats)[number] | typeof exportFormatPng;
   onClick: () => void;
   isAltPressed: boolean;
 };

--- a/frontend/src/metabase/query_builder/components/dataref/TableInfoLoader.tsx
+++ b/frontend/src/metabase/query_builder/components/dataref/TableInfoLoader.tsx
@@ -29,9 +29,8 @@ function useDependentTableMetadata({
   const isMissingFields = !table.numFields();
   const isMissingFks = table.fks === undefined;
   const shouldFetchMetadata = isMissingFields || isMissingFks;
-  const [hasFetchedMetadata, setHasFetchedMetadata] = useState(
-    !shouldFetchMetadata,
-  );
+  const [hasFetchedMetadata, setHasFetchedMetadata] =
+    useState(!shouldFetchMetadata);
   const fetchDependentData = useSafeAsyncFunction(() => {
     return Promise.all([
       isMissingFields && fetchMetadata({ id: table.id }),

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.styled.tsx
@@ -85,7 +85,9 @@ EditorContainer.defaultProps = {
 };
 
 export const EditorEqualsSign = styled.div`
-  font: 12px / normal Monaco, monospace;
+  font:
+    12px / normal Monaco,
+    monospace;
   height: 12px;
   font-weight: 700;
   margin: 0 3px 0 ${space(0)};

--- a/frontend/src/metabase/query_builder/components/view/ViewButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewButton.tsx
@@ -17,7 +17,9 @@ const ViewButton = styled(Button)<Props>`
     active ? "var(--mb-color-text-white)" : color};
 
   border: none;
-  transition: background 300ms linear, border 300ms linear;
+  transition:
+    background 300ms linear,
+    border 300ms linear;
 
   &:hover {
     background-color: ${({ active, color = getDefaultColor() }) =>

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewTitleHeader.module.css
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewTitleHeader.module.css
@@ -53,7 +53,9 @@
 }
 
 .SummarizeButton {
-  transition: background 300ms linear, border 300ms linear;
+  transition:
+    background 300ms linear,
+    border 300ms linear;
 
   &:hover:not([data-active="true"]) {
     color: var(--mb-color-summarize);

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewTitleHeader.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewTitleHeader.styled.tsx
@@ -91,7 +91,9 @@ export const HeaderButton = styled(Button)<{
     color: ${({ color }) => color};
   }
 
-  transition: background 300ms linear, border 300ms linear;
+  transition:
+    background 300ms linear,
+    border 300ms linear;
 
   > .Icon {
     opacity: 0.6;

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/AdHocQuestionDescription/AdHocQuestionDescription.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/AdHocQuestionDescription/AdHocQuestionDescription.tsx
@@ -22,32 +22,33 @@ export const AdHocQuestionDescription = ({
     aggregations.length === 0
       ? null
       : aggregations.length > 2
-      ? ngettext(
-          msgid`${aggregations.length} metric`,
-          `${aggregations.length} metrics`,
-          aggregations.length,
-        )
-      : aggregations
-          .map(
-            aggregation =>
-              Lib.displayInfo(query, STAGE_INDEX, aggregation).longDisplayName,
+        ? ngettext(
+            msgid`${aggregations.length} metric`,
+            `${aggregations.length} metrics`,
+            aggregations.length,
           )
-          .join(t` and `);
+        : aggregations
+            .map(
+              aggregation =>
+                Lib.displayInfo(query, STAGE_INDEX, aggregation)
+                  .longDisplayName,
+            )
+            .join(t` and `);
   const breakoutDescription =
     breakouts.length === 0
       ? null
       : breakouts.length > 2
-      ? ngettext(
-          msgid`${breakouts.length} breakout`,
-          `${breakouts.length} breakouts`,
-          breakouts.length,
-        )
-      : breakouts
-          .map(
-            breakout =>
-              Lib.displayInfo(query, STAGE_INDEX, breakout).longDisplayName,
+        ? ngettext(
+            msgid`${breakouts.length} breakout`,
+            `${breakouts.length} breakouts`,
+            breakouts.length,
           )
-          .join(t` and `);
+        : breakouts
+            .map(
+              breakout =>
+                Lib.displayInfo(query, STAGE_INDEX, breakout).longDisplayName,
+            )
+            .join(t` and `);
 
   if (aggregationDescription || breakoutDescription) {
     return (

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/AggregationItem/AggregationItem.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/AggregationItem/AggregationItem.styled.tsx
@@ -11,7 +11,9 @@ export const Root = styled.button`
   border-radius: 6px;
   color: var(--mb-color-text-white);
   background-color: var(--mb-color-summarize);
-  transition: background 300ms linear, border 300ms linear;
+  transition:
+    background 300ms linear,
+    border 300ms linear;
   min-height: 34px;
   min-width: 34px;
   cursor: pointer;

--- a/frontend/src/metabase/query_builder/constants.ts
+++ b/frontend/src/metabase/query_builder/constants.ts
@@ -19,7 +19,7 @@ export const MODAL_TYPES = {
   PREVIEW_QUERY: "preview-query",
 } as const;
 
-export type QueryModalType = typeof MODAL_TYPES[keyof typeof MODAL_TYPES];
+export type QueryModalType = (typeof MODAL_TYPES)[keyof typeof MODAL_TYPES];
 
 export const SIDEBAR_SIZES = {
   NORMAL: 355,

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -53,9 +53,8 @@ describe("QueryBuilder", () => {
         await setup({
           card: TEST_TIME_SERIES_WITH_DATE_BREAKOUT_CARD,
         });
-        const timeSeriesModeFooter = await screen.findByTestId(
-          "timeseries-chrome",
-        );
+        const timeSeriesModeFooter =
+          await screen.findByTestId("timeseries-chrome");
         expect(timeSeriesModeFooter).toBeInTheDocument();
         expect(
           within(timeSeriesModeFooter).getByText("by"),
@@ -70,9 +69,8 @@ describe("QueryBuilder", () => {
           card: TEST_TIME_SERIES_WITH_CUSTOM_DATE_BREAKOUT_CARD,
         });
 
-        const timeSeriesModeFooter = await screen.findByTestId(
-          "timeseries-chrome",
-        );
+        const timeSeriesModeFooter =
+          await screen.findByTestId("timeseries-chrome");
         expect(timeSeriesModeFooter).toBeInTheDocument();
         expect(
           within(timeSeriesModeFooter).getByText("by"),

--- a/frontend/src/metabase/query_builder/containers/test-utils.tsx
+++ b/frontend/src/metabase/query_builder/containers/test-utils.tsx
@@ -390,9 +390,8 @@ export const triggerNotebookQueryChange = async () => {
  */
 export const revertNotebookQueryChange = async () => {
   const limitStep = screen.getByTestId("step-limit-0-0");
-  const limitInput = await within(limitStep).findByPlaceholderText(
-    "Enter a limit",
-  );
+  const limitInput =
+    await within(limitStep).findByPlaceholderText("Enter a limit");
 
   await userEvent.click(limitInput);
   await userEvent.type(limitInput, "{backspace}");

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -1053,8 +1053,8 @@ export const getDataReferenceStack = createSelector(
     uiControls.dataReferenceStack
       ? uiControls.dataReferenceStack
       : dbId
-      ? [{ type: "database", item: { id: dbId } }]
-      : [],
+        ? [{ type: "database", item: { id: dbId } }]
+        : [],
 );
 
 export const getDashboardId = state => {

--- a/frontend/src/metabase/querying/filters/components/DatePicker/types.ts
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/types.ts
@@ -11,18 +11,18 @@ export type DatePickerOperator =
   | ExcludeDatePickerOperator;
 
 export type SpecificDatePickerOperator =
-  typeof SPECIFIC_DATE_PICKER_OPERATORS[number];
+  (typeof SPECIFIC_DATE_PICKER_OPERATORS)[number];
 
 export type ExcludeDatePickerOperator =
-  typeof EXCLUDE_DATE_PICKER_OPERATORS[number];
+  (typeof EXCLUDE_DATE_PICKER_OPERATORS)[number];
 
-export type DatePickerShortcut = typeof DATE_PICKER_SHORTCUTS[number];
+export type DatePickerShortcut = (typeof DATE_PICKER_SHORTCUTS)[number];
 
 export type DatePickerExtractionUnit =
-  typeof DATE_PICKER_EXTRACTION_UNITS[number];
+  (typeof DATE_PICKER_EXTRACTION_UNITS)[number];
 
 export type DatePickerTruncationUnit =
-  typeof DATE_PICKER_TRUNCATION_UNITS[number];
+  (typeof DATE_PICKER_TRUNCATION_UNITS)[number];
 
 export interface SpecificDatePickerValue {
   type: "specific";

--- a/frontend/src/metabase/querying/notebook/components/JoinStep/JoinConditionColumnPicker/JoinConditionColumnPicker.styled.tsx
+++ b/frontend/src/metabase/querying/notebook/components/JoinStep/JoinConditionColumnPicker/JoinConditionColumnPicker.styled.tsx
@@ -43,7 +43,10 @@ export const JoinCellItem = styled.button<{
       ? getHasColumnStyle(theme, isOpen)
       : getNoColumnStyle(theme, isOpen)};
   cursor: ${props => (props.isReadOnly ? "default" : "pointer")};
-  transition: background 300ms linear, border 300ms linear, color 300ms linear;
+  transition:
+    background 300ms linear,
+    border 300ms linear,
+    color 300ms linear;
 `;
 
 export const JoinColumnPicker = styled(QueryColumnPicker)`

--- a/frontend/src/metabase/querying/notebook/components/JoinStep/JoinConditionOperatorPicker/JoinConditionOperatorPicker.styled.tsx
+++ b/frontend/src/metabase/querying/notebook/components/JoinStep/JoinConditionOperatorPicker/JoinConditionOperatorPicker.styled.tsx
@@ -37,7 +37,10 @@ export const OperatorPickerButton = styled.button<{
   padding: 4px 8px;
   border-radius: 4px;
   cursor: ${props => (props.disabled ? "default" : "pointer")};
-  transition: background 300ms linear, border 300ms linear, color 300ms linear;
+  transition:
+    background 300ms linear,
+    border 300ms linear,
+    color 300ms linear;
 `;
 
 export const OperatorList = styled(SelectList)`

--- a/frontend/src/metabase/redux/downloads.ts
+++ b/frontend/src/metabase/redux/downloads.ts
@@ -66,8 +66,8 @@ const getDownloadedResourceType = ({
   const defaultAccessedVia = process.env.EMBEDDING_SDK_VERSION
     ? "sdk-embed"
     : isInIframe
-    ? "interactive-iframe-embed"
-    : "internal";
+      ? "interactive-iframe-embed"
+      : "internal";
 
   if (dashcardId != null && token != null) {
     return { resourceType: "dashcard", accessedVia: "static-embed" };

--- a/frontend/src/metabase/redux/uploads.ts
+++ b/frontend/src/metabase/redux/uploads.ts
@@ -54,13 +54,13 @@ export interface UploadFileProps {
 export const uploadFile = createThunkAction(
   UPLOAD_FILE_TO_COLLECTION,
   ({
-      file,
-      collectionId,
-      tableId,
-      modelId,
-      uploadMode,
-      reloadQuestionData,
-    }: UploadFileProps) =>
+    file,
+    collectionId,
+    tableId,
+    modelId,
+    uploadMode,
+    reloadQuestionData,
+  }: UploadFileProps) =>
     async (dispatch: Dispatch) => {
       const id = Date.now();
 

--- a/frontend/src/metabase/reference/selectors.js
+++ b/frontend/src/metabase/reference/selectors.js
@@ -59,8 +59,8 @@ export const getTable = createSelector(
     tableId
       ? tables[tableId] || { id: tableId }
       : segmentId
-      ? tableBySegment
-      : {},
+        ? tableBySegment
+        : {},
 );
 
 export const getFieldId = (state, props) =>

--- a/frontend/src/metabase/sharing/components/PublicLinkPopover/types.ts
+++ b/frontend/src/metabase/sharing/components/PublicLinkPopover/types.ts
@@ -1,3 +1,3 @@
 import type { exportFormats } from "metabase/lib/urls";
 
-export type ExportFormatType = typeof exportFormats[number] | null;
+export type ExportFormatType = (typeof exportFormats)[number] | null;

--- a/frontend/src/metabase/visualizations/click-actions/Mode/types.ts
+++ b/frontend/src/metabase/visualizations/click-actions/Mode/types.ts
@@ -1,3 +1,3 @@
 import type { MODES_TYPES } from "./constants";
 
-export type ModeType = typeof MODES_TYPES[number];
+export type ModeType = (typeof MODES_TYPES)[number];

--- a/frontend/src/metabase/visualizations/components/ChartTooltip/ChartTooltip.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip/ChartTooltip.tsx
@@ -61,8 +61,8 @@ const ChartTooltip = ({ hovered, settings }: ChartTooltipProps) => {
   const target = hasTargetElement
     ? hovered?.element
     : hasTargetEvent
-    ? getEventTarget(hovered.event)
-    : null;
+      ? getEventTarget(hovered.event)
+      : null;
 
   return target ? (
     <Tooltip

--- a/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
+++ b/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
@@ -84,8 +84,8 @@ export function getLegendTitles(groups, columnSettings) {
     return index === groups.length - 1
       ? `${min} +` // the last value in the list
       : min !== max
-      ? `${min} - ${max}` // typical case
-      : min; // special case to avoid zero-width ranges e.g. $88-$88
+        ? `${min} - ${max}` // typical case
+        : min; // special case to avoid zero-width ranges e.g. $88-$88
   });
 }
 

--- a/frontend/src/metabase/visualizations/components/MiniBar.jsx
+++ b/frontend/src/metabase/visualizations/components/MiniBar.jsx
@@ -25,22 +25,22 @@ const MiniBar = ({ value, extent: [min, max], options }) => {
         borderRadius: BORDER_RADIUS,
       }
     : isNegative
-    ? {
-        width: barPercent / 2 + "%",
-        right: "50%",
-        borderTopRightRadius: 0,
-        borderBottomRightRadius: 0,
-        borderTopLeftRadius: BORDER_RADIUS,
-        borderBottomLeftRadius: BORDER_RADIUS,
-      }
-    : {
-        width: barPercent / 2 + "%",
-        left: "50%",
-        borderTopLeftRadius: 0,
-        borderBottomLeftRadius: 0,
-        borderTopRightRadius: BORDER_RADIUS,
-        borderBottomRightRadius: BORDER_RADIUS,
-      };
+      ? {
+          width: barPercent / 2 + "%",
+          right: "50%",
+          borderTopRightRadius: 0,
+          borderBottomRightRadius: 0,
+          borderTopLeftRadius: BORDER_RADIUS,
+          borderBottomLeftRadius: BORDER_RADIUS,
+        }
+      : {
+          width: barPercent / 2 + "%",
+          left: "50%",
+          borderTopLeftRadius: 0,
+          borderBottomLeftRadius: 0,
+          borderTopRightRadius: BORDER_RADIUS,
+          borderBottomRightRadius: BORDER_RADIUS,
+        };
 
   return (
     <div className={cx(CS.flex, CS.alignCenter, CS.justifyEnd, CS.relative)}>

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx
@@ -314,13 +314,13 @@ const RuleDescription = ({ rule }) => {
       {rule.type === "range"
         ? t`Cells in this column will be tinted based on their values.`
         : rule.type === "single"
-        ? jt`When a cell in these columns ${(
-            <span className={CS.textBold}>
-              {ALL_OPERATOR_NAMES[rule.operator]}
-              {getValueForDescription(rule)}
-            </span>
-          )} it will be tinted this color.`
-        : null}
+          ? jt`When a cell in these columns ${(
+              <span className={CS.textBold}>
+                {ALL_OPERATOR_NAMES[rule.operator]}
+                {getValueForDescription(rule)}
+              </span>
+            )} it will be tinted this color.`
+          : null}
     </span>
   );
 };
@@ -426,10 +426,10 @@ const RuleEditor = ({
               ...(isBooleanRule
                 ? BOOLEAN_OPERATIOR_NAMES
                 : isNumericRule
-                ? NUMBER_OPERATOR_NAMES
-                : isStringRule
-                ? STRING_OPERATOR_NAMES
-                : {}),
+                  ? NUMBER_OPERATOR_NAMES
+                  : isStringRule
+                    ? STRING_OPERATOR_NAMES
+                    : {}),
             }).map(([operator, operatorName]) => (
               <Option key={operatorName} value={operator}>
                 {operatorName}

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/axis.ts
@@ -284,19 +284,22 @@ const getYAxisSplit = (
       : [nonStackedKeys, stackedKeys];
   }
 
-  const axisBySeriesKey = seriesModels.reduce((acc, seriesModel) => {
-    const seriesSettings: SeriesSettings = settings.series(
-      seriesModel.legacySeriesSettingsObjectKey,
-    );
+  const axisBySeriesKey = seriesModels.reduce(
+    (acc, seriesModel) => {
+      const seriesSettings: SeriesSettings = settings.series(
+        seriesModel.legacySeriesSettingsObjectKey,
+      );
 
-    const seriesStack = stackModels.find(stackModel =>
-      stackModel.seriesKeys.includes(seriesModel.dataKey),
-    );
+      const seriesStack = stackModels.find(stackModel =>
+        stackModel.seriesKeys.includes(seriesModel.dataKey),
+      );
 
-    acc[seriesModel.dataKey] =
-      seriesStack != null ? seriesStack.axis : seriesSettings?.["axis"];
-    return acc;
-  }, {} as Record<DataKey, string | undefined>);
+      acc[seriesModel.dataKey] =
+        seriesStack != null ? seriesStack.axis : seriesSettings?.["axis"];
+      return acc;
+    },
+    {} as Record<DataKey, string | undefined>,
+  );
 
   const left: DataKey[] = [];
   const right: DataKey[] = [];
@@ -615,7 +618,7 @@ export function getYAxesModels(
       columnByDataKey,
       settings["stackable.stack_type"] === "normalized"
         ? null
-        : settings["stackable.stack_type"] ?? null,
+        : (settings["stackable.stack_type"] ?? null),
       renderingContext,
       { compact: isCompactFormatting },
     ),
@@ -826,8 +829,8 @@ export function getXAxisModel(
   };
 
   const histogramInterval = isHistogram
-    ? dimensionColumn.binning_info?.bin_width ??
-      computeNumericDataInverval(dataset.map(datum => datum[X_AXIS_DATA_KEY]))
+    ? (dimensionColumn.binning_info?.bin_width ??
+      computeNumericDataInverval(dataset.map(datum => datum[X_AXIS_DATA_KEY])))
     : undefined;
 
   const valuesCount = isScatter

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.ts
@@ -947,29 +947,35 @@ export const getCardColumnByDataKeyMap = (
       ? getBreakoutDistinctValues(data, columns.breakout.index)
       : null;
 
-  return data.cols.reduce((acc, column) => {
-    if (breakoutValues != null) {
-      breakoutValues.forEach(breakoutValue => {
-        acc[getDatasetKey(column, card.id, breakoutValue)] = column;
-      });
-    } else {
-      acc[getDatasetKey(column, card.id)] = column;
-    }
-    return acc;
-  }, {} as Record<DataKey, DatasetColumn>);
+  return data.cols.reduce(
+    (acc, column) => {
+      if (breakoutValues != null) {
+        breakoutValues.forEach(breakoutValue => {
+          acc[getDatasetKey(column, card.id, breakoutValue)] = column;
+        });
+      } else {
+        acc[getDatasetKey(column, card.id)] = column;
+      }
+      return acc;
+    },
+    {} as Record<DataKey, DatasetColumn>,
+  );
 };
 
 export const getCardsColumnByDataKeyMap = (
   rawSeries: RawSeries,
   cardsColumns: CartesianChartColumns[],
 ): Record<DataKey, DatasetColumn> => {
-  return rawSeries.reduce((acc, cardSeries, index) => {
-    const columns = cardsColumns[index];
-    const cardColumnByDataKeyMap = getCardColumnByDataKeyMap(
-      cardSeries,
-      columns,
-    );
+  return rawSeries.reduce(
+    (acc, cardSeries, index) => {
+      const columns = cardsColumns[index];
+      const cardColumnByDataKeyMap = getCardColumnByDataKeyMap(
+        cardSeries,
+        columns,
+      );
 
-    return { ...acc, ...cardColumnByDataKeyMap };
-  }, {} as Record<DataKey, DatasetColumn>);
+      return { ...acc, ...cardColumnByDataKeyMap };
+    },
+    {} as Record<DataKey, DatasetColumn>,
+  );
 };

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/series.ts
@@ -284,11 +284,14 @@ export const getDimensionModel = (
   return {
     column: cardsColumns[0].dimension.column,
     columnIndex: cardsColumns[0].dimension.index,
-    columnByCardId: rawSeries.reduce((columnByCardId, series, index) => {
-      const cardColumns = cardsColumns[index];
-      columnByCardId[series.card.id] = cardColumns.dimension.column;
-      return columnByCardId;
-    }, {} as Record<CardId, DatasetColumn>),
+    columnByCardId: rawSeries.reduce(
+      (columnByCardId, series, index) => {
+        const cardColumns = cardsColumns[index];
+        columnByCardId[series.card.id] = cardColumns.dimension.column;
+        return columnByCardId;
+      },
+      {} as Record<CardId, DatasetColumn>,
+    ),
   };
 };
 
@@ -543,12 +546,15 @@ export function getDisplaySeriesSettingsByDataKey(
   stackModels: StackModel[] | null,
   settings: ComputedVisualizationSettings,
 ) {
-  const seriesSettingsByKey = seriesModels.reduce((acc, seriesModel) => {
-    acc[seriesModel.dataKey] = settings.series(
-      seriesModel.legacySeriesSettingsObjectKey,
-    );
-    return acc;
-  }, {} as Record<DataKey, SeriesSettings>);
+  const seriesSettingsByKey = seriesModels.reduce(
+    (acc, seriesModel) => {
+      acc[seriesModel.dataKey] = settings.series(
+        seriesModel.legacySeriesSettingsObjectKey,
+      );
+      return acc;
+    },
+    {} as Record<DataKey, SeriesSettings>,
+  );
 
   if (stackModels != null) {
     stackModels.forEach(({ display, seriesKeys }) => {

--- a/frontend/src/metabase/visualizations/lib/table_format.js
+++ b/frontend/src/metabase/visualizations/lib/table_format.js
@@ -81,11 +81,11 @@ export const OPERATOR_FORMATTER_FACTORIES = {
     typeof value === "number" && v >= value ? color : null,
   ">": (value, color) => v =>
     typeof value === "number" && v > value ? color : null,
-  "=": (value, color) => v => v === value ? color : null,
+  "=": (value, color) => v => (v === value ? color : null),
   "!=": (value, color) => v =>
     !isEmptyString(value) && v !== value ? color : null,
-  "is-null": (_value, color) => v => v === null ? color : null,
-  "not-null": (_value, color) => v => v !== null ? color : null,
+  "is-null": (_value, color) => v => (v === null ? color : null),
+  "not-null": (_value, color) => v => (v !== null ? color : null),
   contains: (value, color) => v =>
     canCompareSubstrings(value, v) && v.indexOf(value) >= 0 ? color : null,
   "does-not-contain": (value, color) => v =>
@@ -94,8 +94,8 @@ export const OPERATOR_FORMATTER_FACTORIES = {
     canCompareSubstrings(value, v) && v.startsWith(value) ? color : null,
   "ends-with": (value, color) => v =>
     canCompareSubstrings(value, v) && v.endsWith(value) ? color : null,
-  "is-true": (_value, color) => v => v ? color : null,
-  "is-false": (_value, color) => v => v ? null : color,
+  "is-true": (_value, color) => v => (v ? color : null),
+  "is-false": (_value, color) => v => (v ? null : color),
 };
 
 export function compileFormatter(
@@ -125,14 +125,14 @@ export function compileFormatter(
       format.min_type === "custom"
         ? parseFloat(format.min_value)
         : format.min_type === "all"
-        ? Math.min(...format.columns.map(columnMin))
-        : columnMin(columnName);
+          ? Math.min(...format.columns.map(columnMin))
+          : columnMin(columnName);
     const max =
       format.max_type === "custom"
         ? parseFloat(format.max_value)
         : format.max_type === "all"
-        ? Math.max(...format.columns.map(columnMax))
-        : columnMax(columnName);
+          ? Math.max(...format.columns.map(columnMax))
+          : columnMax(columnName);
 
     if (typeof max !== "number" || typeof min !== "number") {
       console.warn("Invalid range min/max", min, max);

--- a/frontend/src/metabase/visualizations/lib/utils.js
+++ b/frontend/src/metabase/visualizations/lib/utils.js
@@ -259,10 +259,10 @@ export function getCardAfterVisualizationClick(nextCard, previousCard) {
         ? // Just recycle the original card id of previous card if there was one
           previousCard.original_card_id
         : // A multi-aggregation or multi-breakout series legend / drill-through action
-        // should always use the id of underlying/previous card
-        isMultiseriesQuestion
-        ? previousCard.id
-        : nextCard.id,
+          // should always use the id of underlying/previous card
+          isMultiseriesQuestion
+          ? previousCard.id
+          : nextCard.id,
       id: null,
     };
   } else {

--- a/frontend/src/metabase/visualizations/shared/utils/colors.ts
+++ b/frontend/src/metabase/visualizations/shared/utils/colors.ts
@@ -9,13 +9,16 @@ export const getSeriesColors = <TDatum, TSeriesInfo>(
 ): Record<string, string> => {
   const settingsColorMapping = Object.entries(
     settings.series_settings ?? {},
-  ).reduce((mapping, [seriesName, seriesSettings]) => {
-    if (typeof seriesSettings.color === "string") {
-      mapping[seriesName] = seriesSettings.color;
-    }
+  ).reduce(
+    (mapping, [seriesName, seriesSettings]) => {
+      if (typeof seriesSettings.color === "string") {
+        mapping[seriesName] = seriesSettings.color;
+      }
 
-    return mapping;
-  }, {} as Record<string, string>);
+      return mapping;
+    },
+    {} as Record<string, string>,
+  );
 
   return getColorsForValues(
     series.map(series => series.seriesKey),

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
@@ -188,7 +188,7 @@ const getEventColumnsData = (
       const displayValue =
         isBreakoutSeries(seriesModel) && seriesModel.breakoutColumn === col
           ? seriesModel.name
-          : value ?? NULL_DISPLAY_VALUE;
+          : (value ?? NULL_DISPLAY_VALUE);
 
       return {
         key,

--- a/frontend/src/metabase/visualizations/visualizations/Map/Map.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Map/Map.jsx
@@ -201,10 +201,10 @@ export class Map extends Component {
         vizSettings["map.type"] === "heat"
           ? "heat"
           : vizSettings["map.type"] === "grid"
-          ? "grid"
-          : data.rows.length >= 1000
-          ? "tiles"
-          : "markers",
+            ? "grid"
+            : data.rows.length >= 1000
+              ? "tiles"
+              : "markers",
       getHidden: (series, vizSettings) =>
         !PIN_MAP_TYPES.has(vizSettings["map.type"]),
     },

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/RowToggleIcon.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/RowToggleIcon.tsx
@@ -59,28 +59,28 @@ export function RowToggleIcon({
             }) // remove any already collapsed items in this column
             .concat(ref) // add column to list
       : !isColumn && isColumnCollapsed // single row in collapsed column
-      ? (settingValue: PivotTableCollapsedRowsSetting["value"]) =>
-          settingValue
-            .filter(v => v !== columnRef) // remove column from list
-            .concat(
-              // add other rows in this columns so they stay closed
-              rowIndex
-                .filter(
-                  item =>
-                    // equal length means they're in the same column
-                    item.length === value.length &&
-                    // but not exactly this item
-                    !_.isEqual(item, value),
-                )
-                // serialize those paths
-                .map(item => JSON.stringify(item)),
-            )
-      : isCollapsed // closed row or column
-      ? (settingValue: PivotTableCollapsedRowsSetting["value"]) =>
-          settingValue.filter(v => v !== ref)
-      : // open row or column
-        (settingValue: PivotTableCollapsedRowsSetting["value"]) =>
-          settingValue.concat(ref);
+        ? (settingValue: PivotTableCollapsedRowsSetting["value"]) =>
+            settingValue
+              .filter(v => v !== columnRef) // remove column from list
+              .concat(
+                // add other rows in this columns so they stay closed
+                rowIndex
+                  .filter(
+                    item =>
+                      // equal length means they're in the same column
+                      item.length === value.length &&
+                      // but not exactly this item
+                      !_.isEqual(item, value),
+                  )
+                  // serialize those paths
+                  .map(item => JSON.stringify(item)),
+              )
+        : isCollapsed // closed row or column
+          ? (settingValue: PivotTableCollapsedRowsSetting["value"]) =>
+              settingValue.filter(v => v !== ref)
+          : // open row or column
+            (settingValue: PivotTableCollapsedRowsSetting["value"]) =>
+              settingValue.concat(ref);
 
   return (
     <RowToggleIconRoot

--- a/package.json
+++ b/package.json
@@ -288,7 +288,7 @@
     "postcss-styled-syntax": "^0.6.4",
     "postcss-url": "^10.1.3",
     "postinstall-postinstall": "^2.1.0",
-    "prettier": "^2.7.1",
+    "prettier": "^3.3.3",
     "promise-loader": "^1.0.0",
     "raf": "^3.4.0",
     "react-docgen-typescript-plugin": "^1.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19307,10 +19307,10 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.0.tgz#b6a5bf1284026ae640f17f7ff5658a7567fc0d18"
   integrity sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==
 
-prettier@^2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
-  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
+prettier@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.3.3.tgz#30c54fe0be0d8d12e6ae61dbb10109ea00d53105"
+  integrity sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==
 
 pretty-bytes@^5.6.0:
   version "5.6.0"


### PR DESCRIPTION
### Description
<img width="1075" alt="image" src="https://github.com/user-attachments/assets/5ab00564-708c-437d-81d1-3f6f4d203ee1">

We currently can't use the typescript `satisfies` keyword because we have an old version of prettier that will make it fail on the pre-commit.

It seems like the new version formats things a bit differently though, so I ran it with `yarn prettier --write '(frontend|enterprise/frontend)/**/*.{js,jsx,ts,tsx}'` 

All the changes are purely formatting so conflicts shouldn't be an issue



Edit: manual backport for v50: https://github.com/metabase/metabase/pull/47894