### PR TITLE
Revert to non-truncating mbql.u/unique-name-generator in annotate-native-cols

### DIFF
--- a/e2e/test/scenarios/models/models.cy.spec.js
+++ b/e2e/test/scenarios/models/models.cy.spec.js
@@ -162,6 +162,91 @@ describe("scenarios > models", () => {
     cy.location("pathname").should("eq", "/collection/root");
   });
 
+  it("allows to turn a native question with a long alias into a model (metabase#47584)", () => {
+    const nativeQuery = `
+    SELECT
+      count(*) AS coun,
+      state AS Total_number_of_people_from_each_state_separated_by_state_and_then_we_do_a_count
+    FROM people
+    GROUP BY
+      Total_number_of_people_from_each_state_separated_by_state_and_then_we_do_a_count`;
+    cy.createNativeQuestion(
+      {
+        name: "People Model with long alias",
+        native: {
+          query: nativeQuery,
+        },
+      },
+      { visitQuestion: true, wrapId: true },
+    );
+
+    turnIntoModel();
+    openQuestionActions();
+    assertIsModel();
+
+    cy.get("@questionId").then(questionId => {
+      cy.wait("@dataset").then(({ response }) => {
+        expect(response.body.json_query.query["source-table"]).to.equal(
+          `card__${questionId}`,
+        );
+        expect(response.body.error).to.not.exist;
+      });
+    });
+
+    // Filtering on the long column is currently broken in master (metabase#47863),
+    // but this works in the release-x.50.x branch.
+    //
+    // filter();
+    // filterField(
+    //   "TOTAL_NUMBER_OF_PEOPLE_FROM_EACH_STATE_SEPARATED_BY_STATE_AND_THEN_WE_DO_A_COUNT",
+    //   {
+    //     operator: "Contains",
+    //     value: "A",
+    //   },
+    // );
+
+    // cy.findByTestId("apply-filters").click();
+    // cy.wait("@dataset").then(({ response }) => {
+    //   expect(response.body.error).to.not.exist;
+    // });
+
+    filter();
+    filterField("COUN", {
+      operator: "Greater than",
+      value: 30,
+    });
+
+    cy.findByTestId("apply-filters").click();
+    cy.wait("@dataset").then(({ response }) => {
+      expect(response.body.error).to.not.exist;
+    });
+
+    assertQuestionIsBasedOnModel({
+      model: "People Model with long alias",
+      collection: "Our analytics",
+      table: "People",
+    });
+
+    cy.get("@questionId").then(questionId => {
+      saveQuestionBasedOnModel({ modelId: questionId, name: "Q1" });
+    });
+
+    assertQuestionIsBasedOnModel({
+      questionName: "Q1",
+      model: "People Model with long alias",
+      collection: "Our analytics",
+      table: "People",
+    });
+
+    cy.findByTestId("qb-header").findAllByText("Our analytics").first().click();
+    getCollectionItemCard("People Model with long alias").within(() => {
+      cy.icon("model");
+    });
+    getCollectionItemRow("Q1").icon("table2");
+
+    cy.location("pathname").should("eq", "/collection/root");
+  });
+
   it("changes model's display to table", () => {
     visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
 
@@ -520,11 +605,7 @@ describe("scenarios > models", () => {
 
   it("should automatically pin newly created models", () => {
     visitQuestion(ORDERS_QUESTION_ID);
-
-    cy.intercept("PUT", "/api/card/*").as("cardUpdate");
     turnIntoModel();
-    cy.wait("@cardUpdate");
-
     visitCollection("root");
     cy.findByTestId("pinned-items").within(() => {
       cy.findByText("Models");

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -14,7 +14,6 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.schema.common :as lib.schema.common]
-   [metabase.lib.util :as lib.util]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.models.humanization :as humanization]
    [metabase.query-processor.debug :as qp.debug]
@@ -80,7 +79,7 @@
                          :type             qp.error-type/qp}))))))
 
 (defn- annotate-native-cols [cols]
-  (let [unique-name-fn (lib.util/unique-name-generator (qp.store/metadata-provider))]
+  (let [unique-name-fn (mbql.u/unique-name-generator)]
     (mapv (fn [{col-name :name, base-type :base_type, :as driver-col-metadata}]
             (let [col-name (name col-name)]
               (merge

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -232,71 +232,70 @@
 
 (deftest native-query-with-truncated-column-alias
   (testing "nested native query with long truncated column alias (metabase#47584)"
-    (mt/with-temp-copy-of-db
-      (let [short-col-name "coun"
-            long-col-name  "Total_number_of_people_from_each_state_separated_by_state_and_then_we_do_a_count"
+    (let [short-col-name "coun"
+          long-col-name  "Total_number_of_people_from_each_state_separated_by_state_and_then_we_do_a_count"
 
-            ;; Lightly validate the native form that comes back. Resist the urge to check for exact equality.
-            validate-native-form (fn [native-form-lines]
-                                   (and (some #(str/includes? % short-col-name) native-form-lines)
-                                        (some #(str/includes? % long-col-name) native-form-lines)))
+          ;; Lightly validate the native form that comes back. Resist the urge to check for exact equality.
+          validate-native-form (fn [native-form-lines]
+                                 (and (some #(str/includes? % short-col-name) native-form-lines)
+                                      (some #(str/includes? % long-col-name) native-form-lines)))
 
-            ;; Disable truncate-alias when compiling the native query to ensure we don't truncate the column.
-            ;; We want to simulate a user-defined query where the column name is long, but valid for the driver.
-            native-sub-query (with-redefs [lib.util/truncate-alias
-                                           (fn mock-truncate-alias
-                                             [ss & _] ss)]
-                               (-> (mt/mbql-query people
-                                     {:source-table $$people
-                                      :aggregation  [[:aggregation-options [:count] {:name short-col-name}]]
-                                      :breakout     [[:field %state {:name long-col-name}]]
-                                      :limit        5})
-                                   qp.compile/compile
-                                   :query))
+          ;; Disable truncate-alias when compiling the native query to ensure we don't truncate the column.
+          ;; We want to simulate a user-defined query where the column name is long, but valid for the driver.
+          native-sub-query (with-redefs [lib.util/truncate-alias
+                                         (fn mock-truncate-alias
+                                           [ss & _] ss)]
+                             (-> (mt/mbql-query people
+                                   {:source-table $$people
+                                    :aggregation  [[:aggregation-options [:count] {:name short-col-name}]]
+                                    :breakout     [[:field %state {:name long-col-name}]]
+                                    :limit        5})
+                                 qp.compile/compile
+                                 :query))
 
-            native-query (mt/native-query {:query native-sub-query})
+          native-query (mt/native-query {:query native-sub-query})
 
-            ;; Let metadata-provider-with-cards-with-metadata-for-queries calculate the result-metadata.
-            metadata-provider (qp.test-util/metadata-provider-with-cards-with-metadata-for-queries [native-query])]
-        (t2.with-temp/with-temp
-          [Card card (assoc {:dataset_query native-query}
-                            :result_metadata
-                            (-> (lib.metadata.protocols/metadatas metadata-provider :metadata/card [1])
-                                first
-                                :result-metadata))]
-          (let [card-query {:database (mt/id)
-                            :type     "query"
-                            :query    {:source-table (str "card__" (u/the-id card))}}]
-            (mt/with-native-query-testing-context card-query
-              (testing "POST /api/dataset/native"
-                (is (=? {:query  validate-native-form
-                         :params nil}
-                        (-> (mt/user-http-request :crowberto :post 200 "dataset/native" card-query)
-                            (update :query #(str/split-lines (or (driver/prettify-native-form :h2 %)
-                                                                 "error: no query generated")))))))
-              (testing "POST /api/dataset"
-                (is (=?
-                     {:data        {:rows             [["AK" 68] ["AL" 56] ["AR" 49] ["AZ" 20] ["CA" 90]]
-                                    :cols             [{:name         long-col-name
-                                                        :display_name long-col-name
-                                                        :field_ref    ["field" long-col-name {}]
-                                                        :source       "fields"}
-                                                       {:name         short-col-name
-                                                        :display_name short-col-name
-                                                        :field_ref    ["field" short-col-name {}]
-                                                        :source       "fields"}]
-                                    :native_form      {:query  validate-native-form
-                                                       :params nil}
-                                    :results_timezone "UTC"}
-                      :row_count   5
-                      :status      "completed"
-                      :context     "ad-hoc"
-                      :json_query  (merge query-defaults card-query)
-                      :database_id (mt/id)}
-                     (-> (mt/user-http-request :crowberto :post 202 "dataset" card-query)
-                         (update-in [:data :native_form :query]
-                                    #(str/split-lines (or (driver/prettify-native-form :h2 %)
-                                                          "error: no query generated"))))))))))))))
+          ;; Let metadata-provider-with-cards-with-metadata-for-queries calculate the result-metadata.
+          metadata-provider (qp.test-util/metadata-provider-with-cards-with-metadata-for-queries [native-query])]
+      (t2.with-temp/with-temp
+        [Card card (assoc {:dataset_query native-query}
+                          :result_metadata
+                          (-> (lib.metadata.protocols/metadatas metadata-provider :metadata/card [1])
+                              first
+                              :result-metadata))]
+        (let [card-query {:database (mt/id)
+                          :type     "query"
+                          :query    {:source-table (str "card__" (u/the-id card))}}]
+          (mt/with-native-query-testing-context card-query
+            (testing "POST /api/dataset/native"
+              (is (=? {:query  validate-native-form
+                       :params nil}
+                      (-> (mt/user-http-request :crowberto :post 200 "dataset/native" card-query)
+                          (update :query #(str/split-lines (or (driver/prettify-native-form :h2 %)
+                                                               "error: no query generated")))))))
+            (testing "POST /api/dataset"
+              (is (=?
+                   {:data        {:rows             [["AK" 68] ["AL" 56] ["AR" 49] ["AZ" 20] ["CA" 90]]
+                                  :cols             [{:name         long-col-name
+                                                      :display_name long-col-name
+                                                      :field_ref    ["field" long-col-name {}]
+                                                      :source       "fields"}
+                                                     {:name         short-col-name
+                                                      :display_name short-col-name
+                                                      :field_ref    ["field" short-col-name {}]
+                                                      :source       "fields"}]
+                                  :native_form      {:query  validate-native-form
+                                                     :params nil}
+                                  :results_timezone "UTC"}
+                    :row_count   5
+                    :status      "completed"
+                    :context     "ad-hoc"
+                    :json_query  (merge query-defaults card-query)
+                    :database_id (mt/id)}
+                   (-> (mt/user-http-request :crowberto :post 202 "dataset" card-query)
+                       (update-in [:data :native_form :query]
+                                  #(str/split-lines (or (driver/prettify-native-form :h2 %)
+                                                        "error: no query generated")))))))))))))
 
 (deftest formatted-results-ignore-query-constraints
   (testing "POST /api/dataset/:format"

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -250,7 +250,8 @@
                                (-> (mt/mbql-query people
                                      {:source-table $$people
                                       :aggregation  [[:aggregation-options [:count] {:name short-col-name}]]
-                                      :breakout     [[:field %state {:name long-col-name}]]})
+                                      :breakout     [[:field %state {:name long-col-name}]]
+                                      :limit        5})
                                    qp.compile/compile
                                    :query))
 
@@ -266,8 +267,7 @@
                                 :result-metadata))]
           (let [card-query {:database (mt/id)
                             :type     "query"
-                            :query    {:source-table (str "card__" (u/the-id card))
-                                       :limit        5}}]
+                            :query    {:source-table (str "card__" (u/the-id card))}}]
             (mt/with-native-query-testing-context card-query
               (testing "POST /api/dataset/native"
                 (is (=? {:query  validate-native-form

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -245,8 +245,7 @@
             ;; We want to simulate a user-defined query where the column name is long, but valid for the driver.
             native-sub-query (with-redefs [lib.util/truncate-alias
                                            (fn mock-truncate-alias
-                                             ([ss] ss)
-                                             ([ss _] ss))]
+                                             [ss & _] ss)]
                                (-> (mt/mbql-query people
                                      {:source-table $$people
                                       :aggregation  [[:aggregation-options [:count] {:name short-col-name}]]

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -16,11 +16,14 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.jvm :as lib.metadata.jvm]
+   [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.lib.schema.id :as lib.schema.id]
+   [metabase.lib.util :as lib.util]
    [metabase.models.card :refer [Card]]
    [metabase.models.data-permissions :as data-perms]
    [metabase.models.permissions-group :as perms-group]
    [metabase.models.query-execution :refer [QueryExecution]]
+   [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.middleware.constraints :as qp.constraints]
    [metabase.query-processor.test-util :as qp.test-util]
    [metabase.query-processor.util :as qp.util]
@@ -226,6 +229,75 @@
             (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :unrestricted)
             (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/create-queries :no)
             (do-test)))))))
+
+(deftest native-query-with-truncated-column-alias
+  (testing "nested native query with long truncated column alias (metabase#47584)"
+    (mt/with-temp-copy-of-db
+      (let [short-col-name "coun"
+            long-col-name  "Total_number_of_people_from_each_state_separated_by_state_and_then_we_do_a_count"
+
+            ;; Lightly validate the native form that comes back. Resist the urge to check for exact equality.
+            validate-native-form (fn [native-form-lines]
+                                   (and (some #(str/includes? % short-col-name) native-form-lines)
+                                        (some #(str/includes? % long-col-name) native-form-lines)))
+
+            ;; Disable truncate-alias when compiling the native query to ensure we don't truncate the column.
+            ;; We want to simulate a user-defined query where the column name is long, but valid for the driver.
+            native-sub-query (with-redefs [lib.util/truncate-alias
+                                           (fn mock-truncate-alias
+                                             ([ss] ss)
+                                             ([ss _] ss))]
+                               (-> (mt/mbql-query people
+                                     {:source-table $$people
+                                      :aggregation  [[:aggregation-options [:count] {:name short-col-name}]]
+                                      :breakout     [[:field %state {:name long-col-name}]]})
+                                   qp.compile/compile
+                                   :query))
+
+            native-query (mt/native-query {:query native-sub-query})
+
+            ;; Let metadata-provider-with-cards-with-metadata-for-queries calculate the result-metadata.
+            metadata-provider (qp.test-util/metadata-provider-with-cards-with-metadata-for-queries [native-query])]
+        (t2.with-temp/with-temp
+          [Card card (assoc {:dataset_query native-query}
+                            :result_metadata
+                            (-> (lib.metadata.protocols/metadatas metadata-provider :metadata/card [1])
+                                first
+                                :result-metadata))]
+          (let [card-query {:database (mt/id)
+                            :type     "query"
+                            :query    {:source-table (str "card__" (u/the-id card))
+                                       :limit        5}}]
+            (mt/with-native-query-testing-context card-query
+              (testing "POST /api/dataset/native"
+                (is (=? {:query  validate-native-form
+                         :params nil}
+                        (-> (mt/user-http-request :crowberto :post 200 "dataset/native" card-query)
+                            (update :query #(str/split-lines (or (driver/prettify-native-form :h2 %)
+                                                                 "error: no query generated")))))))
+              (testing "POST /api/dataset"
+                (is (=?
+                     {:data        {:rows             [["AK" 68] ["AL" 56] ["AR" 49] ["AZ" 20] ["CA" 90]]
+                                    :cols             [{:name         long-col-name
+                                                        :display_name long-col-name
+                                                        :field_ref    ["field" long-col-name {}]
+                                                        :source       "fields"}
+                                                       {:name         short-col-name
+                                                        :display_name short-col-name
+                                                        :field_ref    ["field" short-col-name {}]
+                                                        :source       "fields"}]
+                                    :native_form      {:query  validate-native-form
+                                                       :params nil}
+                                    :results_timezone "UTC"}
+                      :row_count   5
+                      :status      "completed"
+                      :context     "ad-hoc"
+                      :json_query  (merge query-defaults card-query)
+                      :database_id (mt/id)}
+                     (-> (mt/user-http-request :crowberto :post 202 "dataset" card-query)
+                         (update-in [:data :native_form :query]
+                                    #(str/split-lines (or (driver/prettify-native-form :h2 %)
+                                                          "error: no query generated"))))))))))))))
 
 (deftest formatted-results-ignore-query-constraints
   (testing "POST /api/dataset/:format"

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -230,8 +230,8 @@
             (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/create-queries :no)
             (do-test)))))))
 
-(deftest native-query-with-truncated-column-alias
-  (testing "nested native query with long truncated column alias (metabase#47584)"
+(deftest native-query-with-long-column-alias
+  (testing "nested native query with long column alias (metabase#47584)"
     (let [short-col-name "coun"
           long-col-name  "Total_number_of_people_from_each_state_separated_by_state_and_then_we_do_a_count"
 

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -380,11 +380,12 @@
                                  (-> (mt/mbql-query people
                                        {:source-table $$people
                                         :aggregation  [[:aggregation-options [:count] {:name coun-col-name}]]
-                                        :breakout     [[:field %state {:name long-col-name}]]})
+                                        :breakout     [[:field %state {:name long-col-name}]]
+                                        :limit        5})
                                      qp.compile/compile
                                      :query))
 
-            query              (query-with-source-card 1 (mt/$ids people {:limit 5}))]
+            query              (query-with-source-card 1)]
         (qp.store/with-metadata-provider (qp.test-util/metadata-provider-with-cards-with-metadata-for-queries
                                           [(mt/native-query {:query native-sub-query})])
           (mt/with-native-query-testing-context query


### PR DESCRIPTION
Related to (backport will close) #47584 

### Description

Context from slack: https://metaboat.slack.com/archives/C0645JP1W81/p1725899230235759

To summarize, when converting a native sql question with this query

```sql
SELECT
  count(*) AS coun,
  state AS Total_number_of_people_from_each_state_separated_by_state_and_then_we_do_a_count
FROM people
GROUP BY
  Total_number_of_people_from_each_state_separated_by_state_and_then_we_do_a_count
```

to a model, we get the following error

```
Column "source.TOTAL_NUMBER_OF_PEOPLE_FROM_EACH_STATE_SEPARATED_BY_165e2c32" not found; SQL statement:
SELECT
  "source"."COUN" AS "COUN",
  "source"."TOTAL_NUMBER_OF_PEOPLE_FROM_EACH_STATE_SEPARATED_BY_165e2c32"
    AS "TOTAL_NUMBER_OF_PEOPLE_FROM_EACH_STATE_SEPARATED_BY_165e2c32"
FROM (
  select 
    count(*) as coun, 
    state as Total_number_of_people_from_each_state_separated_by_state_and_then_we_do_a_count 
  from people
  group by 
    Total_number_of_people_from_each_state_separated_by_state_and_then_we_do_a_count
) AS "source" LIMIT 2000 [42122-214]
```

Note that this error does not occur in master due to the new `driver/query-result-metadata :sql-jdbc` method which does not truncate the aliases, but I assume it still makes sense to land the fix (and tests) in master first and backport it to v50, but can retarget this to the release branch if not.

After the changes in this PR, we instead generate the following SQL, which does not produce the error:

```sql
SELECT
  "source"."COUN" AS "COUN",
  "source"."TOTAL_NUMBER_OF_PEOPLE_FROM_EACH_STATE_SEPARATED_BY_STATE_AND_THEN_WE_DO_A_COUNT" AS "TOTAL_NUMBER_OF_PEOPLE_FROM_EACH_STATE_SEPARATED_BY_165e2c32"
FROM
  (
    SELECT
      count(*) AS coun,
      state AS Total_number_of_people_from_each_state_separated_by_state_and_then_we_do_a_count
    FROM
      people
    GROUP BY 
      Total_number_of_people_from_each_state_separated_by_state_and_then_we_do_a_count
  ) AS "source"
```

### How to verify

Use repro steps from #47584 or see included tests.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
