### PR TITLE
(wip) Port the dashboard 'More' menu to Mantine

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/DashboardActionMenu.module.css
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/DashboardActionMenu.module.css
@@ -1,0 +1,24 @@
+.DashboardMenuTriggerIcon {
+  color: var(--mb-color-text-dark);
+  flex-shrink: 0;
+}
+
+.DashboardMenuTriggerToolbarButton {
+  &:hover {
+    .DashboardMenuTriggerIcon {
+      color: var(--mb-color-brand);
+    }
+  }
+}
+
+.DashboardActionMenuItem {
+  white-space: nowrap;
+
+  &:hover {
+    background-color: var(--mb-color-bg-light) !important;
+
+    .DashboardActionMenuItemText {
+      color: var(--mb-color-brand);
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces a Mantine `Menu` component to power the "More" menu in the dashboard header.