### PR TITLE
fix: snowflake compile day trunc to timestamp_ltz

### DIFF
--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -297,9 +297,8 @@
   [_driver _unit expr]
   (if (= (h2x/database-type expr) "date")
     expr
-    (date-trunc :day expr))
-  (-> [:to_date (date-trunc :day expr)]
-      (h2x/with-database-type-info "date")))
+    (-> [:to_date [:to_timestamp_ltz expr]]
+        (h2x/with-database-type-info "date"))))
 
 ;; these don't need to be adjusted for start of week, since we're Setting the WEEK_START connection parameter
 (defmethod sql.qp/date [:snowflake :week]

--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -869,32 +869,56 @@
                     (fn [driver connection-type database-definition]
                       (-> (original-dbdef->connection-details driver connection-type database-definition)
                           (assoc :user "BELIZE_PERSON")))]
-        (mt/dataset
-          good-datetimes-in-belize
-          (testing "Expected data is returned using yesterday filter"
-            (let [yesterday-first     (t/- (t/truncate-to (t/offset-date-time belize-offset) :days) (t/days 1))
-                  yesterday-last      (t/+ yesterday-first (t/hours 18))
-                  yesterday-first-str (t/format :iso-offset-date-time yesterday-first)
-                  yesterday-last-str  (t/format :iso-offset-date-time yesterday-last)]
-              (doseq [[tested-field-kw base-type database-type]
-                      [[:IN_Z_OFFSET        :type/DateTimeWithLocalTZ "timestamptz"]
-                       [:IN_VARIOUS_OFFSETS :type/DateTimeWithLocalTZ "timestamptz"]
-                       [:JUST_NTZ           :type/DateTime            "timestampntz"]
-                       [:JUST_LTZ           :type/DateTimeWithTZ      "timestampltz"]]
-                      :let [tested-field [:field (mt/id :GOOD_DATETIMES tested-field-kw) {:base-type base-type}]]]
-                (testing (str "on column type " database-type)
-                  (let [rows (mt/rows (qp/process-query
-                                       {:database (mt/id)
-                                        :type     :query
-                                        :query {:source-table (mt/id :GOOD_DATETIMES)
-                                                :fields [tested-field]
-                                                :filter [:time-interval tested-field -1 :day]
-                                                :order-by [[tested-field :asc]]}}))]
-                    (testing "Correct rows count returned"
-                      (is (= 4 (count rows))))
-                    (testing "First row has expected values"
-                      (is (= yesterday-first-str
-                             (ffirst rows))))
-                    (testing "Last row has expected values"
-                      (is (= yesterday-last-str
-                             (ffirst (reverse rows)))))))))))))))
+        (mt/with-temporary-setting-values [report-timezone "America/Belize"]
+          (mt/dataset
+            good-datetimes-in-belize
+            (testing "Expected data is returned using yesterday filter"
+              (let [yesterday-first     (t/- (t/truncate-to (t/offset-date-time belize-offset) :days) (t/days 1))
+                    yesterday-last      (t/+ yesterday-first (t/hours 18))
+                    yesterday-first-str (t/format :iso-offset-date-time yesterday-first)
+                    yesterday-last-str  (t/format :iso-offset-date-time yesterday-last)]
+                (doseq [[tested-field-kw base-type database-type]
+                        [[:IN_Z_OFFSET        :type/DateTimeWithLocalTZ "timestamptz"]
+                         [:IN_VARIOUS_OFFSETS :type/DateTimeWithLocalTZ "timestamptz"]
+                         [:JUST_NTZ           :type/DateTime            "timestampntz"]
+                         [:JUST_LTZ           :type/DateTimeWithTZ      "timestampltz"]]
+                        :let [tested-field [:field (mt/id :GOOD_DATETIMES tested-field-kw) {:base-type base-type}]]]
+                  (testing (str "on column type " database-type)
+                    (let [rows (mt/rows (qp/process-query
+                                         {:database (mt/id)
+                                          :type     :query
+                                          :query {:source-table (mt/id :GOOD_DATETIMES)
+                                                  :fields [tested-field]
+                                                  :filter [:time-interval tested-field -1 :day]
+                                                  :order-by [[tested-field :asc]]}}))]
+                      (testing "Correct rows count returned"
+                        (is (= 4 (count rows))))
+                      (testing "First row has expected values"
+                        (is (= yesterday-first-str
+                               (ffirst rows))))
+                      (testing "Last row has expected values"
+                        (is (= yesterday-last-str
+                               (ffirst (reverse rows)))))))
+
+                  (testing "Rows should be properly allocated to days"
+                    (let [tested-day (assoc-in tested-field [2 :temporal-unit] :day)
+                          tested-minute (assoc-in tested-field [2 :temporal-unit] :minute)]
+                      (is (=? [[string? 4] [string? 4] [string? 4]]
+                              (mt/rows
+                               (qp/process-query
+                                {:database (mt/id)
+                                 :type :query
+                                 :query {:source-table (mt/id :GOOD_DATETIMES)
+                                         :aggregation [[:count]]
+                                         :breakout [tested-day]}}))))
+                      (is (= [[yesterday-first-str 4 yesterday-first-str yesterday-last-str]]
+                             (mt/rows
+                              (qp/process-query
+                               {:database (mt/id)
+                                :type :query
+                                :query {:source-table (mt/id :GOOD_DATETIMES)
+                                        :aggregation [[:count]
+                                                      [:min tested-minute]
+                                                      [:max tested-minute]]
+                                        :breakout [tested-day]
+                                        :filter [:= tested-field (t/format :iso-local-date yesterday-last)]}})))))))))))))))


### PR DESCRIPTION
Fixes #47426

Date operations return values based on the timestamp offset rather than the session/db timezone. Converting to `timestamp_ltz` first ensures that we get predictable results.

In the test, it is important that database timezone matches report_timezone so that post-processing gives proper results.
