### PR TITLE
Controlled upgrades

### DIFF
--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/SettingsUpdatesForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/SettingsUpdatesForm.jsx
@@ -8,7 +8,7 @@ import { Flex } from "metabase/ui";
 
 import { SettingsSetting } from "../SettingsSetting";
 
-import VersionUpdateNotice from "./VersionUpdateNotice/VersionUpdateNotice";
+import { VersionUpdateNotice } from "./VersionUpdateNotice/VersionUpdateNotice";
 export default function SettingsUpdatesForm({ elements, updateSetting }) {
   const settings = elements.map((setting, index) => (
     <SettingsSetting

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/SettingsUpdatesForm.unit.spec.js
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/SettingsUpdatesForm.unit.spec.js
@@ -68,7 +68,7 @@ describe("SettingsUpdatesForm", () => {
   it("shows current version when latest version info is missing", () => {
     setup({ currentVersion: "v1.0.0", latestVersion: null });
     expect(
-      screen.getByText("You're running Metabase 1.0.0"),
+      screen.getByText(/You're running Metabase 1.0.0/),
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/SettingsUpdatesForm.unit.spec.js
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/SettingsUpdatesForm.unit.spec.js
@@ -65,9 +65,11 @@ describe("SettingsUpdatesForm", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows correct message when no version checks have been run", () => {
-    setup({ currentVersion: null, latestVersion: null });
-    expect(screen.getByText("No successful checks yet.")).toBeInTheDocument();
+  it("shows current version when latest version info is missing", () => {
+    setup({ currentVersion: "v1.0.0", latestVersion: null });
+    expect(
+      screen.getByText("You're running Metabase 1.0.0"),
+    ).toBeInTheDocument();
   });
 
   it("shows upgrade call-to-action if not in Enterprise plan", () => {

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/VersionUpdateNotice/VersionUpdateNotice.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/VersionUpdateNotice/VersionUpdateNotice.tsx
@@ -37,7 +37,7 @@ export function VersionUpdateNotice() {
   if (newVersionAvailable({ currentVersion, latestVersion })) {
     return <NewVersionAvailable currentVersion={displayVersion} />;
   }
-  return <DefaultUpdateMessage currentVersion={currentVersion} />;
+  return <DefaultUpdateMessage currentVersion={displayVersion} />;
 }
 
 function CloudCustomers({ currentVersion }: { currentVersion: string }) {

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/VersionUpdateNotice/VersionUpdateNotice.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/VersionUpdateNotice/VersionUpdateNotice.tsx
@@ -1,5 +1,5 @@
 import cx from "classnames";
-import { t } from "ttag";
+import { c, t } from "ttag";
 
 import {
   getCurrentVersion,
@@ -52,7 +52,8 @@ function OnLatestVersion({ currentVersion }: { currentVersion: string }) {
   return (
     <div>
       <OnLatestVersionMessage>
-        {t`You're running Metabase ${currentVersion} which is the latest and greatest!`}
+        {c(`{0} is a version number`)
+          .t`You're running Metabase ${currentVersion} which is the latest and greatest!`}
       </OnLatestVersionMessage>
     </div>
   );
@@ -62,7 +63,8 @@ function DefaultUpdateMessage({ currentVersion }: { currentVersion: string }) {
   return (
     <div>
       <OnLatestVersionMessage>
-        {t`You're running Metabase ${currentVersion}`}
+        {c(`{0} is a version number`)
+          .t`You're running Metabase ${currentVersion}`}
       </OnLatestVersionMessage>
     </div>
   );

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/VersionUpdateNotice/VersionUpdateNotice.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/VersionUpdateNotice/VersionUpdateNotice.tsx
@@ -1,5 +1,4 @@
 import cx from "classnames";
-import PropTypes from "prop-types";
 import { t } from "ttag";
 
 import {
@@ -13,13 +12,14 @@ import { useSelector } from "metabase/lib/redux";
 import MetabaseSettings from "metabase/lib/settings";
 import { newVersionAvailable, versionIsLatest } from "metabase/lib/utils";
 import { getIsHosted } from "metabase/setup/selectors";
+import type { VersionInfoRecord } from "metabase-types/api";
 
 import {
   NewVersionContainer,
   OnLatestVersionMessage,
 } from "./VersionUpdateNotice.styled";
 
-export default function VersionUpdateNotice() {
+export function VersionUpdateNotice() {
   const currentVersion = useSelector(getCurrentVersion);
   const latestVersion = useSelector(getLatestVersion);
   const isHosted = useSelector(getIsHosted);
@@ -37,11 +37,10 @@ export default function VersionUpdateNotice() {
   if (newVersionAvailable({ currentVersion, latestVersion })) {
     return <NewVersionAvailable currentVersion={displayVersion} />;
   }
-
-  return <div>{t`No successful checks yet.`}</div>;
+  return <DefaultUpdateMessage currentVersion={currentVersion} />;
 }
 
-function CloudCustomers({ currentVersion }) {
+function CloudCustomers({ currentVersion }: { currentVersion: string }) {
   return (
     <div>
       {t`Metabase Cloud keeps your instance up-to-date. You're currently on version ${currentVersion}. Thanks for being a customer!`}
@@ -49,11 +48,7 @@ function CloudCustomers({ currentVersion }) {
   );
 }
 
-CloudCustomers.propTypes = {
-  currentVersion: PropTypes.string.isRequired,
-};
-
-function OnLatestVersion({ currentVersion }) {
+function OnLatestVersion({ currentVersion }: { currentVersion: string }) {
   return (
     <div>
       <OnLatestVersionMessage>
@@ -63,11 +58,17 @@ function OnLatestVersion({ currentVersion }) {
   );
 }
 
-OnLatestVersion.propTypes = {
-  currentVersion: PropTypes.string.isRequired,
-};
+function DefaultUpdateMessage({ currentVersion }: { currentVersion: string }) {
+  return (
+    <div>
+      <OnLatestVersionMessage>
+        {t`You're running Metabase ${currentVersion}`}
+      </OnLatestVersionMessage>
+    </div>
+  );
+}
 
-function NewVersionAvailable({ currentVersion }) {
+function NewVersionAvailable({ currentVersion }: { currentVersion: string }) {
   const latestVersion = MetabaseSettings.latestVersion();
   const versionInfo = MetabaseSettings.versionInfo();
 
@@ -119,7 +120,7 @@ function NewVersionAvailable({ currentVersion }) {
       >
         <h3 className={cx(CS.pb3, CS.textUppercase)}>{t`What's Changed:`}</h3>
 
-        <Version version={versionInfo.latest} />
+        {versionInfo.latest && <Version version={versionInfo.latest} />}
 
         {versionInfo.older &&
           versionInfo.older.map((version, index) => (
@@ -130,11 +131,7 @@ function NewVersionAvailable({ currentVersion }) {
   );
 }
 
-NewVersionAvailable.propTypes = {
-  currentVersion: PropTypes.string.isRequired,
-};
-
-function Version({ version }) {
+function Version({ version }: { version: VersionInfoRecord }) {
   if (!version) {
     return null;
   }
@@ -156,10 +153,6 @@ function Version({ version }) {
     </div>
   );
 }
-
-Version.propTypes = {
-  version: PropTypes.object.isRequired,
-};
 
 function formatVersion(versionLabel = "") {
   return versionLabel.replace(/^v/, "");

--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -124,12 +124,18 @@
    Looks something like `Metabase v0.25.0.RC1`."
   (str "Metabase " (mb-version-info :tag)))
 
+(defn major-version
+  "Detect major version from a version string.
+  ex: (major-version \"v1.50.25\") -> 50"
+  [version-string]
+  (some-> (second (re-find #"\d+\.(\d+)" version-string))
+          parse-long))
+
 (defn current-major-version
   "Returns the major version of the running Metabase JAR.
   When the version.properties file is missing (e.g., running in local dev), returns nil."
   []
-  (some-> (second (re-find #"\d+\.(\d+)" (:tag mb-version-info)))
-          parse-long))
+  (major-version (:tag mb-version-info)))
 
 (defonce ^{:doc "This UUID is randomly-generated upon launch and used to identify this specific Metabase instance during
                 this specifc run. Restarting the server will change this UUID, and each server in a horizontal cluster

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -92,11 +92,11 @@
   :default {}
   :doc     false
   :getter  (fn []
-             (let [vi      (setting/get-value-of-type :json :version-info)
-                   remove? (should-remove-upgrade? (config/current-major-version) (-> vi :latest) (upgrade-threshold))]
-               (cond-> vi
-                 remove? (dissoc vi :latest))
+             (let [vi (setting/get-value-of-type :json :version-info)]
                (try
+                 (cond-> vi
+                   (should-remove-upgrade? (config/current-major-version) (-> vi :latest) (upgrade-threshold))
+                   (dissoc :latest))
                  (catch Exception e
                    (log/error e "Error processing version info")
                    vi)))))

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -70,7 +70,13 @@
   :audit   :getter
   :default true)
 
-(declare site-uuid)
+(defsetting site-uuid
+  ;; Don't i18n this docstring because it's not user-facing! :)
+  "Unique identifier used for this instance of {0}. This is set once and only once the first time it is fetched via
+  its magic getter. Nice!"
+  :visibility :authenticated
+  :base       setting/uuid-nonce-base
+  :doc        false)
 
 (defsetting upgrade-threshold
   (deferred-tru "Threshold (value in 0-100) indicating at which treshold it should offer an upgrade to the latest major version.")
@@ -155,14 +161,6 @@
   :type       :integer
   :visibility :public
   :audit      :getter)
-
-(defsetting site-uuid
-  ;; Don't i18n this docstring because it's not user-facing! :)
-  "Unique identifier used for this instance of {0}. This is set once and only once the first time it is fetched via
-  its magic getter. Nice!"
-  :visibility :authenticated
-  :base       setting/uuid-nonce-base
-  :doc        false)
 
 (defsetting site-uuid-for-premium-features-token-checks
   "In the interest of respecting everyone's privacy and keeping things as anonymous as possible we have a *different*

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -85,7 +85,9 @@
   :type       :integer
   :setter     :none
   :getter     (fn []
-                (-> (site-uuid) hash (mod 100))))
+                ;; site-uuid is stable, current-major lets the threshold randomize during each major revision. So they
+                ;; might be early one release, and then later the next.
+                (-> (site-uuid) (str "-" (config/current-major-version)) hash (mod 100))))
 
 (defn- prevent-upgrade?
   "On a major upgrade, we check the rollout threshold to indicate whether we should remove the latest release from the

--- a/test/metabase/public_settings_test.clj
+++ b/test/metabase/public_settings_test.clj
@@ -401,9 +401,9 @@
 
 (deftest version-info*-test
   (let [version-info {:latest {:version "1.51.23.1" :rollout 50
-                               :highlights [,,,]}
-                      :older [{:version "1.51.22" :highlights [,,,]}
-                              {:version "1.51.21" :highlights [,,,]}]}]
+                               :highlights ["highlights for 1.51.23.1"]}
+                      :older [{:version "1.51.22" :highlights ["highlights for 1.51.22"]}
+                              {:version "1.51.21" :highlights ["highlights for 1.51.21"]}]}]
     (testing "When on same major, includes latest"
       (is (= version-info (info version-info {:current-major 51 :upgrade-threshold-value 25}))))
     (testing "When below major"

--- a/test/metabase/public_settings_test.clj
+++ b/test/metabase/public_settings_test.clj
@@ -370,3 +370,15 @@
              (public-settings/show-metabase-links! true)))
 
         (is (= true (public-settings/show-metabase-links)))))))
+
+(def should? #'public-settings/should-remove-upgrade?)
+
+(deftest should-remove-upgrade?-test
+  (is (should? 45 {:version "0.46" :rollout 80} 75))
+  (testing "never throws and returns falsy"
+    ;; missing threshold
+    (is (not (should? 45 {:version "0.46"} 75)))
+    ;; version is weird
+    (is (not (should? 45 {:version 45} 75)))
+    ;; misshape
+    (is (not (should? 45 {:latest {:version "0.46" :rollout 80}} 75)))))


### PR DESCRIPTION
Let's add a `rollout` number 0-100 on `latest`


Version information has two keys:

```clojure
{:latest {:version "v1.50.25",
          :released "2024-09-10",
          :patch true,
          :highlights [,,,]},
 :older [{:version "v1.50.24",
          :released "2024-09-03",
          :patch true,
          :highlights [,,,]}]}
```

The proposal here is that we add a `rollout` to the `latest` map, and then we only show the `latest` to the frontend (and therefore the upgrade) if some number of the local instance is lower than the rollout number.

```clojure
{:latest {:version "v1.50.25",
          :released "2024-09-10",
          :rollout 50 ;; number between 0 - 100 <--------- new
          :patch true,
          :highlights [,,,]},
 :older [{:version "v1.50.24",
          :released "2024-09-03",
          :patch true,
          :highlights [,,,]}]}
```

<img width="1247" alt="image" src="https://github.com/user-attachments/assets/7c0e18c3-b609-4b80-a95b-14445b58b167">


This derives the rollout threshold of the instance from the `site-uuid` which is constant for all instances in a cluster.

```clojure
(defsetting upgrade-threshold
  (deferred-tru "Threshold (value in 0-100) indicating at which treshold it should offer an upgrade to the latest major version.")
  :visibility :internal
  :export?    false
  :type       :integer
  :setter     :none
  :getter     (fn []
                (-> (site-uuid) hash (mod 100))))
```

(and of course overridable with `MB_UPGRADE_THRESHOLD=90 java -jar ...` if they want to be in a higher cohort)

This lets us uniformly distribute self-hosted instances into buckets of 0-100. And as we increase the `rollout` number of the version-info json file, more instances will show the upgrade information in the application.


```shell
❯ http get "http://localhost:3000/api/setting/version-info" x-api-key:$API_KEY | jq 'keys'
[
  "older"
]

## vs when it should show
❯ http get "http://localhost:3000/api/setting/version-info" x-api-key:$API_KEY | jq 'keys'
[
  "latest",
  "older"
]
```

This really only matters across major upgrades. We always show upgrades of minor upgrades in the same major.
Ex: `0.49.5` will always show a banner for a latest of `0.49.6`
Of course `0.49.5` will compare rollout thresholds on whether to show an update to the latest of `0.50.2`
Also, `0.49.5` will compare rollout thresholds on whether to show an update to the latest of `0.51.2` (*2* majors). We can make this show the latest 50 in the future if we want. (and the same scenario for more exaggerated version jumps, 49 -> 83 ,etc).

See [this explanation](https://www.notion.so/metabase/Checking-A-feature-in-multiple-instances-0064e6a643624b1d91cb94a5221df6da) in notion of how it worked running it 200 times.

Started a jar up 200 times, fetching versions that included a 25% rollout threshold and had the following results:
<img width="738" alt="image" src="https://github.com/user-attachments/assets/c616ed13-ec6b-4974-9aba-99c361b50994">

```
site-uuid, threshold, upgrade-available, latest-version
35095708-ad3f-42b2-8e26-65b475ec5cd7, 2, true, 1.51.1
a247324a-82c1-41e1-9f91-7016a66e9014, 87, false, 
8072a554-3ded-4a4f-83ec-0d363e7f0deb, 23, true, 1.51.1
b40db850-028e-4d17-8806-0d27758395f6, 67, false, 
a466def7-fa50-4cf7-a2ee-8b31b422749a, 20, true, 1.51.1
5effa39b-9065-49ca-b686-f17eaecf4198, 85, false, 
4158efe4-3703-4372-b94a-9458f975fa7c, 55, false, 
```