### PR TITLE
configurable pivot exports and attachments

### DIFF
--- a/e2e/support/helpers/e2e-downloads-helpers.ts
+++ b/e2e/support/helpers/e2e-downloads-helpers.ts
@@ -23,6 +23,7 @@ interface DownloadAndAssertParams {
   publicUuid?: string;
   dashboardId?: number;
   enableFormatting?: boolean;
+  enablePivoting?: boolean;
 }
 
 /**
@@ -42,6 +43,7 @@ export function downloadAndAssert(
     downloadMethod = "POST",
     isDashboard,
     enableFormatting = true,
+    enablePivoting = false,
   }: DownloadAndAssertParams,
   callback: (data: unknown) => void,
 ) {
@@ -84,11 +86,22 @@ export function downloadAndAssert(
   } else {
     cy.findByTestId("download-button").click();
   }
-  // Initiate the file download
-  if (!enableFormatting) {
-    cy.window().trigger("keydown", { key: "Alt" });
-  }
-  popover().findByText(`.${fileType}`).click();
+
+  popover().within(() => {
+    cy.findByText(`.${fileType}`).click();
+
+    const formattingButtonLabel = enableFormatting
+      ? "Formatted"
+      : "Unformatted";
+
+    cy.findByText(formattingButtonLabel).click();
+
+    if (enablePivoting) {
+      cy.findByText("Keep data pivoted").click();
+    }
+
+    cy.findByTestId("download-results-button").click();
+  });
 
   cy.wait("@fileDownload")
     .its("request")

--- a/e2e/support/helpers/e2e-downloads-helpers.ts
+++ b/e2e/support/helpers/e2e-downloads-helpers.ts
@@ -26,6 +26,14 @@ interface DownloadAndAssertParams {
   enablePivoting?: boolean;
 }
 
+export const exportFromDashcard = (format: string) => {
+  popover().within(() => {
+    cy.findByText("Download results").click();
+    cy.findByText(format).click();
+    cy.findByTestId("download-results-button").click();
+  });
+};
+
 /**
  * Trigger the download of CSV or XLSX files and assert on the results in the related sheet.
  * It applies to both unsaved questions (queries) and the saved ones.

--- a/e2e/test/scenarios/embedding/embed-resource-downloads.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embed-resource-downloads.cy.spec.ts
@@ -6,6 +6,7 @@ import {
   describeWithSnowplowEE,
   expectGoodSnowplowEvent,
   expectNoBadSnowplowEvents,
+  exportFromDashcard,
   getDashboardCardMenu,
   main,
   popover,
@@ -109,9 +110,7 @@ describeWithSnowplowEE(
 
         showDashboardCardActions();
         getDashboardCardMenu().click();
-        popover().findByText("Download results").click();
-        popover().findByText(".csv").click();
-
+        exportFromDashcard(".csv");
         cy.verifyDownload(".csv", { contains: true });
 
         expectGoodSnowplowEvent({
@@ -171,7 +170,10 @@ describeWithSnowplowEE(
         waitLoading();
 
         cy.findByTestId("download-button").click();
-        popover().findByText(".png").click();
+        popover().within(() => {
+          cy.findByText(".png").click();
+          cy.findByTestId("download-results-button").click();
+        });
 
         cy.verifyDownload(".png", { contains: true });
 
@@ -200,7 +202,10 @@ describeWithSnowplowEE(
 
         cy.findByTestId("download-button").click();
 
-        popover().findByText(".csv").click();
+        popover().within(() => {
+          cy.findByText(".csv").click();
+          cy.findByTestId("download-results-button").click();
+        });
 
         cy.verifyDownload(".csv", { contains: true });
 

--- a/e2e/test/scenarios/embedding/embedding-questions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-questions.cy.spec.js
@@ -299,7 +299,7 @@ describeEE("scenarios > embedding > questions > downloads", () => {
         cy.findByRole("contentinfo").icon("download").click();
 
         popover().within(() => {
-          cy.findByText("Download full results");
+          cy.findAllByText("Download").should("have.length", 2);
           cy.findByText(".csv");
           cy.findByText(".xlsx");
           cy.findByText(".json");

--- a/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
+++ b/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
@@ -11,6 +11,7 @@ import {
   describeEE,
   entityPickerModal,
   entityPickerModalTab,
+  exportFromDashcard,
   getDashboardCard,
   getDashboardCardMenu,
   getNextUnsavedDashboardCardId,
@@ -563,8 +564,8 @@ describeEE("scenarios > embedding > full app", () => {
 
       getDashboardCard().realHover();
       getDashboardCardMenu().click();
-      popover().findByText("Download results").click();
-      popover().findByText(".csv").click();
+
+      exportFromDashcard(".csv");
 
       cy.wait("@CsvDownload").then(interception => {
         expect(

--- a/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
+++ b/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
@@ -554,10 +554,9 @@ describeEE("scenarios > embedding > full app", () => {
           res.headers["X-Metabase-Anti-CSRF-Token"] = CSRF_TOKEN;
         });
       });
-      cy.intercept(
-        "POST",
-        "/api/dashboard/*/dashcard/*/card/*/query/csv?format_rows=true",
-      ).as("CsvDownload");
+      cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query/csv").as(
+        "CsvDownload",
+      );
       visitDashboardUrl({
         url: `/dashboard/${ORDERS_DASHBOARD_ID}`,
       });

--- a/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
+++ b/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
@@ -94,57 +94,60 @@ describe("scenarios > question > download", () => {
     });
   });
 
-  it("should allow downloading unformatted CSV data", () => {
-    const fieldRef = ["field", ORDERS.TOTAL, null];
-    const columnKey = `["ref",${JSON.stringify(fieldRef)}]`;
+  testCases.forEach(fileType => {
+    it(`should allow downloading unformatted ${fileType} data`, () => {
+      const fieldRef = ["field", ORDERS.TOTAL, null];
+      const columnKey = `["ref",${JSON.stringify(fieldRef)}]`;
 
-    createQuestion(
-      {
-        query: {
-          "source-table": ORDERS_ID,
-          fields: [fieldRef],
-        },
-        visualization_settings: {
-          column_settings: {
-            [columnKey]: {
-              currency: "USD",
-              currency_in_header: false,
-              currency_style: "code",
-              number_style: "currency",
+      createQuestion(
+        {
+          query: {
+            "source-table": ORDERS_ID,
+            fields: [fieldRef],
+          },
+          visualization_settings: {
+            column_settings: {
+              [columnKey]: {
+                currency: "USD",
+                currency_in_header: false,
+                currency_style: "code",
+                number_style: "currency",
+              },
             },
           },
         },
-      },
-      { visitQuestion: true, wrapId: true },
-    );
-
-    queryBuilderMain().findByText("USD 39.72").should("exist");
-
-    cy.get("@questionId").then(questionId => {
-      const opts = { questionId, fileType: "csv" };
-
-      downloadAndAssert(
-        {
-          ...opts,
-          enableFormatting: true,
-        },
-        sheet => {
-          expect(sheet["A1"].v).to.eq("Total");
-          expect(sheet["A2"].v).to.eq("USD 39.72");
-        },
+        { visitQuestion: true, wrapId: true },
       );
 
-      downloadAndAssert(
-        {
-          ...opts,
-          enableFormatting: false,
-        },
-        sheet => {
-          expect(sheet["A1"].v).to.eq("Total");
-          expect(sheet["A2"].v).to.eq(39.718145389078366);
-          expect(sheet["A2"].w).to.eq("39.718145389078366");
-        },
-      );
+      queryBuilderMain().findByText("USD 39.72").should("exist");
+
+      cy.get("@questionId").then(questionId => {
+        const opts = { questionId, fileType };
+
+        downloadAndAssert(
+          {
+            ...opts,
+            enableFormatting: true,
+          },
+          sheet => {
+            expect(sheet["A1"].v).to.eq("Total");
+            expect(sheet["A2"].v).to.eq("USD 39.72");
+          },
+        );
+
+        downloadAndAssert(
+          {
+            ...opts,
+            enableFormatting: false,
+          },
+          sheet => {
+            cy.log(sheet);
+            expect(sheet["A1"].v).to.eq("Total");
+            expect(sheet["A2"].v).to.eq(39.718145389078366);
+            expect(sheet["A2"].w).to.eq("39.718145389078366");
+          },
+        );
+      });
     });
   });
 

--- a/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
+++ b/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
@@ -142,7 +142,6 @@ describe("scenarios > question > download", () => {
             enableFormatting: false,
           },
           sheet => {
-            cy.log(sheet);
             expect(sheet["A1"].v).to.eq("Total");
             expect(sheet["A2"].v).to.eq(39.718145389078366);
             expect(sheet["A2"].w).to.eq("39.718145389078366");

--- a/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
+++ b/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
@@ -16,6 +16,7 @@ import {
   entityPickerModalTab,
   expectGoodSnowplowEvent,
   expectNoBadSnowplowEvents,
+  exportFromDashcard,
   filterWidget,
   getDashboardCard,
   getDashboardCardMenu,
@@ -278,10 +279,7 @@ describe("scenarios > question > download", () => {
       getDashboardCard(0).findByText("Created At").should("be.visible");
       getDashboardCardMenu(0).click();
 
-      popover().within(() => {
-        cy.findByText("Download results").click();
-        cy.findByText(".png").click();
-      });
+      exportFromDashcard(".png");
 
       showDashboardCardActions(1);
       getDashboardCard(1).findByText("User ID").should("be.visible");
@@ -302,6 +300,7 @@ describe("scenarios > question > download", () => {
 
       popover().within(() => {
         cy.findByText(".png").click();
+        cy.findByTestId("download-results-button").click();
       });
 
       cy.verifyDownload(".png", { contains: true });
@@ -377,10 +376,7 @@ describeWithSnowplow("[snowplow] scenarios > dashboard", () => {
     getDashboardCard(0).findByText("Created At").should("be.visible");
     getDashboardCardMenu(0).click();
 
-    popover().within(() => {
-      cy.findByText("Download results").click();
-      cy.findByText(".png").click();
-    });
+    exportFromDashcard(".png");
 
     expectGoodSnowplowEvent({
       event: "download_results_clicked",

--- a/e2e/test/scenarios/sharing/public-resource-downloads.cy.spec.ts
+++ b/e2e/test/scenarios/sharing/public-resource-downloads.cy.spec.ts
@@ -146,7 +146,10 @@ describeWithSnowplowEE(
         waitLoading();
 
         cy.findByTestId("download-button").click();
-        popover().findByText(".png").click();
+        popover().within(() => {
+          cy.findByText(".png").click();
+          cy.findByTestId("download-results-button").click();
+        });
 
         cy.verifyDownload(".png", { contains: true });
 

--- a/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
@@ -311,12 +311,7 @@ describe("scenarios > dashboard > subscriptions", () => {
       // This is extremely fragile
       // TODO: update test once changes from `https://github.com/metabase/metabase/pull/14121` are merged into `master`
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Attach results")
-        .parent()
-        .parent()
-        .next()
-        .find("input") // Toggle
-        .click();
+      cy.findByLabelText("Attach results").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Questions to attach").click();
       clickButton("Done");

--- a/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
@@ -735,8 +735,9 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
   it("should open the download popover (metabase#14750)", () => {
     createTestQuestion();
     cy.icon("download").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    popover().within(() => cy.findByText("Download full results"));
+    popover().within(() =>
+      cy.findAllByText("Download").should("have.length", 2),
+    );
   });
 
   it.skip("should work for user without data permissions (metabase#14989)", () => {

--- a/frontend/src/metabase/common/components/ExportSettingsWidget/ExportSettingsWidget.tsx
+++ b/frontend/src/metabase/common/components/ExportSettingsWidget/ExportSettingsWidget.tsx
@@ -1,0 +1,72 @@
+import { t } from "ttag";
+
+import type { ExportFormat } from "metabase/common/types/export";
+import { useSelector } from "metabase/lib/redux";
+import { getApplicationName } from "metabase/selectors/whitelabel";
+import { Checkbox, Group, Radio, Stack, Text } from "metabase/ui";
+
+interface ExportSettingsWidgetProps {
+  formats: ExportFormat[];
+  selectedFormat: ExportFormat;
+  isFormattingEnabled: boolean;
+  isPivotingEnabled: boolean;
+  canConfigurePivoting?: boolean;
+  canConfigureFormatting?: boolean;
+  onChangeFormat: (format: ExportFormat) => void;
+  onTogglePivoting: () => void;
+  onToggleFormatting: () => void;
+}
+
+export const ExportSettingsWidget = ({
+  formats,
+  selectedFormat,
+  isFormattingEnabled,
+  isPivotingEnabled,
+  canConfigureFormatting,
+  canConfigurePivoting,
+  onChangeFormat,
+  onToggleFormatting,
+  onTogglePivoting,
+}: ExportSettingsWidgetProps) => {
+  const applicationName = useSelector(getApplicationName);
+  return (
+    <Stack>
+      <Radio.Group value={selectedFormat} onChange={onChangeFormat}>
+        <Group spacing="xs" noWrap>
+          {formats.map(format => (
+            <Radio
+              variant="pill"
+              key={format}
+              value={format}
+              label={`.${format}`}
+            />
+          ))}
+        </Group>
+      </Radio.Group>
+      {canConfigureFormatting ? (
+        <Stack spacing="xs">
+          <Radio.Group
+            value={isFormattingEnabled ? "true" : "false"}
+            onChange={() => onToggleFormatting()}
+          >
+            <Group>
+              <Radio value="true" label={t`Formatted`} />
+              <Radio value="false" label={t`Unformatted`} />
+            </Group>
+          </Radio.Group>
+          <Text
+            size="sm"
+            color="text-medium"
+          >{t`E.g. September 6, 2024 or $187.50, like in ${applicationName}`}</Text>
+        </Stack>
+      ) : null}
+      {canConfigurePivoting ? (
+        <Checkbox
+          label={t`Keep data pivoted`}
+          checked={isPivotingEnabled}
+          onChange={() => onTogglePivoting()}
+        />
+      ) : null}
+    </Stack>
+  );
+};

--- a/frontend/src/metabase/common/components/ExportSettingsWidget/index.ts
+++ b/frontend/src/metabase/common/components/ExportSettingsWidget/index.ts
@@ -1,0 +1,1 @@
+export * from "./ExportSettingsWidget";

--- a/frontend/src/metabase/common/types/export.ts
+++ b/frontend/src/metabase/common/types/export.ts
@@ -1,0 +1,1 @@
+export type ExportFormat = "csv" | "xlsx" | "json" | "png";

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.unit.spec.tsx
@@ -153,7 +153,9 @@ describe("DashCardMenu", () => {
     await userEvent.click(getIcon("ellipsis"));
     await userEvent.click(await screen.findByText("Download results"));
 
-    expect(screen.getByText("Download full results")).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: /download/i }),
+    ).toBeInTheDocument();
   });
 
   it("should not display query export options when query is running", async () => {

--- a/frontend/src/metabase/lib/urls/misc.js
+++ b/frontend/src/metabase/lib/urls/misc.js
@@ -1,6 +1,0 @@
-export const exportFormats = ["csv", "xlsx", "json"];
-export const exportFormatPng = "png";
-
-export function accountSettings() {
-  return "/account/profile";
-}

--- a/frontend/src/metabase/lib/urls/misc.ts
+++ b/frontend/src/metabase/lib/urls/misc.ts
@@ -1,0 +1,8 @@
+import type { ExportFormat } from "metabase/common/types/export";
+
+export const exportFormats: ExportFormat[] = ["csv", "xlsx", "json"];
+export const exportFormatPng: ExportFormat = "png";
+
+export function accountSettings() {
+  return "/account/profile";
+}

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion.unit.spec.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion.unit.spec.tsx
@@ -133,7 +133,9 @@ describe("PublicOrEmbeddedQuestion", () => {
       await userEvent.click(getIcon("download"));
 
       expect(
-        within(screen.getByRole("dialog")).getByText("Download full results"),
+        within(screen.getByRole("dialog")).getByRole("heading", {
+          name: /download/i,
+        }),
       ).toBeInTheDocument();
     });
 

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestionView.stories.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestionView.stories.tsx
@@ -338,6 +338,7 @@ const downloadQuestionAsPng = async (
   const documentElement = within(document.documentElement);
   const pngButton = await documentElement.findByText(".png");
   await userEvent.click(pngButton);
+  await userEvent.click(canvas.getByTestId("download-results-button"));
   await canvas.findByTestId("image-downloaded");
   asyncCallback();
 };

--- a/frontend/src/metabase/public/lib/analytics.ts
+++ b/frontend/src/metabase/public/lib/analytics.ts
@@ -124,7 +124,7 @@ export const trackPublicLinkCopied = ({
   format = null,
 }: {
   artifact: EmbedResourceType;
-  format?: ExportFormatType | null;
+  format?: ExportFormatType | "html";
 }): void => {
   trackSchemaEvent(SCHEMA_NAME, {
     event: "public_link_copied",

--- a/frontend/src/metabase/query_builder/components/QueryDownloadPopover/QueryDownloadPopover.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryDownloadPopover/QueryDownloadPopover.tsx
@@ -1,29 +1,28 @@
-import { useState } from "react";
-import { useKeyPressEvent } from "react-use";
+import { useCallback, useState } from "react";
 import { t } from "ttag";
 
-import { isMac } from "metabase/lib/browser";
+import { ExportSettingsWidget } from "metabase/common/components/ExportSettingsWidget";
+import type { ExportFormat } from "metabase/common/types/export";
 import { exportFormatPng, exportFormats } from "metabase/lib/urls";
 import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
-import { Group, Icon, Stack, Text, Title, Tooltip } from "metabase/ui";
+import { Button, Icon, Stack, Text, Title } from "metabase/ui";
 import { canSavePng } from "metabase/visualizations";
 import type Question from "metabase-lib/v1/Question";
 import type { Dataset } from "metabase-types/api";
 
-import { DownloadButton } from "./DownloadButton";
-import { checkCanManageFormatting } from "./utils";
-
 type QueryDownloadPopoverProps = {
   question: Question;
   result: Dataset;
-  onDownload: (opts: { type: string; enableFormatting: boolean }) => void;
+  onDownload: (opts: {
+    type: string;
+    enableFormatting: boolean;
+    enablePivot: boolean;
+  }) => void;
 };
 
-const getFormattingInfoTooltipLabel = () => {
-  return isMac()
-    ? t`Hold the Option key to download unformatted results`
-    : t`Hold the Alt key to download unformatted results`;
-};
+const canConfigurePivoting = (format: string, display: string) =>
+  display === "pivot" && format !== "json";
+const canConfigureFormatting = (format: string) => format !== "png";
 
 export const QueryDownloadPopover = ({
   question,
@@ -31,60 +30,54 @@ export const QueryDownloadPopover = ({
   onDownload,
 }: QueryDownloadPopoverProps) => {
   const canDownloadPng = canSavePng(question.display());
+  const formats = canDownloadPng
+    ? [...exportFormats, exportFormatPng]
+    : exportFormats;
+
+  const [isPivoted, setIsPivoted] = useState(false);
+  const [isFormatted, setIsFormatted] = useState(true);
+  const [format, setFormat] = useState<ExportFormat>(formats[0]);
+
   const hasTruncatedResults =
     result.data != null && result.data.rows_truncated != null;
   const limitedDownloadSizeText =
     PLUGIN_FEATURE_LEVEL_PERMISSIONS.getDownloadWidgetMessageOverride(result) ??
     t`The maximum download size is 1 million rows.`;
 
-  const formats = canDownloadPng
-    ? [...exportFormats, exportFormatPng]
-    : exportFormats;
-
-  const [isAltPressed, toggleAltPressed] = useState(false);
-  useKeyPressEvent(
-    e => e.key === "Alt" || e.key === "Option",
-    () => {
-      toggleAltPressed(true);
-    },
-    () => {
-      toggleAltPressed(false);
-    },
-  );
+  const handleDownload = useCallback(() => {
+    onDownload({
+      type: format,
+      enableFormatting: isFormatted,
+      enablePivot: isPivoted,
+    });
+  }, [format, isFormatted, isPivoted, onDownload]);
 
   return (
-    <Stack w={hasTruncatedResults ? "18.75rem" : "16.25rem"}>
-      <Group align="center" position="apart" px="sm">
-        <Title order={4}>{t`Download full results`}</Title>
-        <Tooltip label={getFormattingInfoTooltipLabel()}>
-          <Icon name="info_filled" />
-        </Tooltip>
-      </Group>
-
+    <Stack w={hasTruncatedResults ? "18.75rem" : "16.25rem"} p={8}>
+      <Title order={4}>{t`Download`}</Title>
+      <ExportSettingsWidget
+        selectedFormat={format}
+        formats={formats}
+        isFormattingEnabled={isFormatted}
+        isPivotingEnabled={isPivoted}
+        canConfigureFormatting={canConfigureFormatting(format)}
+        canConfigurePivoting={canConfigurePivoting(format, question.display())}
+        onChangeFormat={setFormat}
+        onToggleFormatting={() => setIsFormatted(prev => !prev)}
+        onTogglePivoting={() => setIsPivoted(prev => !prev)}
+      />
       {hasTruncatedResults && (
-        <Text px="sm">
+        <Text size="sm">
           <div>{t`Your answer has a large number of rows so it could take a while to download.`}</div>
           <div>{limitedDownloadSizeText}</div>
         </Text>
       )}
-
-      <Stack spacing="sm">
-        {formats.map(format => (
-          <DownloadButton
-            key={format}
-            format={format}
-            onClick={() => {
-              onDownload({
-                type: format,
-                enableFormatting: !(
-                  checkCanManageFormatting(format) && isAltPressed
-                ),
-              });
-            }}
-            isAltPressed={isAltPressed}
-          />
-        ))}
-      </Stack>
+      <Button
+        data-testid="download-results-button"
+        leftIcon={<Icon name="download" />}
+        variant="filled"
+        onClick={handleDownload}
+      >{t`Download`}</Button>
     </Stack>
   );
 };

--- a/frontend/src/metabase/query_builder/components/QueryDownloadPopover/QueryDownloadPopover.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryDownloadPopover/QueryDownloadPopover.tsx
@@ -5,7 +5,7 @@ import { ExportSettingsWidget } from "metabase/common/components/ExportSettingsW
 import type { ExportFormat } from "metabase/common/types/export";
 import { exportFormatPng, exportFormats } from "metabase/lib/urls";
 import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
-import { Button, Icon, Stack, Text, Title } from "metabase/ui";
+import { Box, Button, Icon, Stack, Text, Title } from "metabase/ui";
 import { canSavePng } from "metabase/visualizations";
 import type Question from "metabase-lib/v1/Question";
 import type { Dataset } from "metabase-types/api";
@@ -67,9 +67,9 @@ export const QueryDownloadPopover = ({
         onTogglePivoting={() => setIsPivoted(prev => !prev)}
       />
       {hasTruncatedResults && (
-        <Text size="sm">
-          <div>{t`Your answer has a large number of rows so it could take a while to download.`}</div>
-          <div>{limitedDownloadSizeText}</div>
+        <Text size="sm" color="text-medium">
+          <Box mb="1rem">{t`Your answer has a large number of rows so it could take a while to download.`}</Box>
+          <Box>{limitedDownloadSizeText}</Box>
         </Text>
       )}
       <Button

--- a/frontend/src/metabase/query_builder/components/QueryDownloadPopover/QueryDownloadPopover.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryDownloadPopover/QueryDownloadPopover.unit.spec.tsx
@@ -1,9 +1,8 @@
-import { within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { setupCardQueryDownloadEndpoint } from "__support__/server-mocks";
 import { createMockEntitiesState } from "__support__/store";
-import { act, fireEvent, renderWithProviders, screen } from "__support__/ui";
+import { act, renderWithProviders, screen } from "__support__/ui";
 import { checkNotNull } from "metabase/lib/types";
 import { getMetadata } from "metabase/selectors/metadata";
 import registerVisualizations from "metabase/visualizations/register";
@@ -83,66 +82,75 @@ describe("QueryDownloadPopover", () => {
   it("should trigger download on click", async () => {
     const { onDownload } = setup();
     await act(async () => await userEvent.click(screen.getByText(/csv/)));
+    await userEvent.click(await screen.findByTestId("download-results-button"));
     expect(onDownload).toHaveBeenCalledWith({
       type: "csv",
       enableFormatting: true,
+      enablePivot: false,
     });
   });
 
-  it.each(["csv", "json"])(
+  it.each(["csv", "json", "xlsx"])(
     "should trigger unformatted download for %s format",
     async format => {
       const { onDownload } = setup();
-      const _userEvent = userEvent.setup();
 
-      expect(screen.queryByText(/Unformatted/i)).not.toBeInTheDocument();
-      const downloadButton = () => {
-        return screen.getByRole("button", { name: new RegExp(format) });
-      };
-
-      await fireEvent.keyDown(downloadButton(), {
-        key: "Alt",
-      });
-
-      await act(async () => await _userEvent.hover(downloadButton()));
-
+      await userEvent.click(screen.getByLabelText(`.${format}`));
+      await userEvent.click(screen.getByLabelText(`Unformatted`));
       expect(
-        await within(downloadButton()).findByText(/Unformatted/i),
-      ).toBeVisible();
-
-      await act(async () => {
-        await _userEvent.click(downloadButton());
-      });
+        screen.queryByLabelText("Keep data pivoted"),
+      ).not.toBeInTheDocument();
+      await userEvent.click(
+        await screen.findByTestId("download-results-button"),
+      );
 
       expect(onDownload).toHaveBeenCalledWith({
         type: format,
         enableFormatting: false,
+        enablePivot: false,
       });
     },
   );
 
-  it.each(["xlsx", "png"])(
-    "should not trigger unformatted download for %s format",
+  it("should not trigger unformatted download for png format", async () => {
+    const format = "png";
+    const { onDownload } = setup({ card: { ...TEST_CARD, display: "line" } });
+
+    await userEvent.click(screen.getByLabelText(`.${format}`));
+    expect(screen.queryByLabelText(`Formatted`)).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Keep data pivoted"),
+    ).not.toBeInTheDocument();
+    await userEvent.click(await screen.findByTestId("download-results-button"));
+
+    expect(onDownload).toHaveBeenCalledWith({
+      type: format,
+      enableFormatting: true,
+      enablePivot: false,
+    });
+  });
+
+  it.each(["csv", "xlsx"])(
+    "allows configure pivoting for %s format",
     async format => {
-      const { onDownload } = setup({ card: { ...TEST_CARD, display: "line" } });
-
-      const downloadButton = () => {
-        return screen.getByRole("button", { name: new RegExp(format) });
-      };
-
-      expect(screen.queryByText(/Unformatted/i)).not.toBeInTheDocument();
-      await fireEvent.keyDown(downloadButton(), {
-        key: "Alt",
+      const { onDownload } = setup({
+        card: {
+          ...TEST_CARD,
+          display: "pivot",
+        },
       });
-      expect(
-        within(downloadButton()).queryByText(/Unformatted/i),
-      ).not.toBeInTheDocument();
 
-      await act(async () => await userEvent.click(downloadButton()));
+      await userEvent.click(screen.getByLabelText(`.${format}`));
+      await userEvent.click(screen.getByLabelText(`Unformatted`));
+      await userEvent.click(screen.getByLabelText("Keep data pivoted"));
+      await userEvent.click(
+        await screen.findByTestId("download-results-button"),
+      );
 
       expect(onDownload).toHaveBeenCalledWith({
         type: format,
-        enableFormatting: true,
+        enableFormatting: false,
+        enablePivot: true,
       });
     },
   );

--- a/frontend/src/metabase/query_builder/components/QueryDownloadPopover/use-download-data.ts
+++ b/frontend/src/metabase/query_builder/components/QueryDownloadPopover/use-download-data.ts
@@ -26,6 +26,7 @@ export type UseDownloadDataParams = {
 type HandleDataDownloadParams = {
   type: string;
   enableFormatting: boolean;
+  enablePivot: boolean;
 };
 
 export const useDownloadData = ({
@@ -43,11 +44,16 @@ export const useDownloadData = ({
   const dispatch = useDispatch();
 
   return useAsyncFn(
-    async ({ type, enableFormatting }: HandleDataDownloadParams) => {
+    async ({
+      type,
+      enableFormatting,
+      enablePivot,
+    }: HandleDataDownloadParams) => {
       await dispatch(
         downloadQueryResults({
           type,
           enableFormatting,
+          enablePivot,
           question,
           result,
           dashboardId,

--- a/frontend/src/metabase/query_builder/components/QueryDownloadWidget/QueryDownloadWidget.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryDownloadWidget/QueryDownloadWidget.unit.spec.tsx
@@ -54,10 +54,9 @@ describe("QueryDownloadWidget", () => {
     setup();
 
     await userEvent.click(getIcon("download"));
-    await userEvent.unhover(getIcon("download"));
 
     expect(
-      await screen.findByText("Download full results"),
+      await screen.findByRole("heading", { name: /download/i }),
     ).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -168,8 +168,9 @@ describe("QueryBuilder", () => {
       expect(inputArea).toHaveValue("SELECT 1");
 
       await userEvent.click(screen.getByTestId("download-button"));
+      await userEvent.click(await screen.findByLabelText(".csv"));
       await userEvent.click(
-        await screen.findByRole("button", { name: ".csv" }),
+        await screen.findByTestId("download-results-button"),
       );
 
       expect(mockDownloadEndpoint.called()).toBe(true);
@@ -196,8 +197,9 @@ describe("QueryBuilder", () => {
       expect(inputArea).toHaveValue("SELECT 1 union SELECT 2");
 
       await userEvent.click(screen.getByTestId("download-button"));
+      await userEvent.click(await screen.findByLabelText(".csv"));
       await userEvent.click(
-        await screen.findByRole("button", { name: ".csv" }),
+        await screen.findByTestId("download-results-button"),
       );
 
       const [url, options] = mockDownloadEndpoint.lastCall() as MockCall;

--- a/frontend/src/metabase/sharing/components/AddEditSidebar/AddEditEmailSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/AddEditSidebar/AddEditEmailSidebar.jsx
@@ -129,26 +129,6 @@ function _AddEditEmailSidebar({
             onChange={toggleSkipIfEmpty}
           />
         </div>
-        <div
-          className={cx(
-            CS.textBold,
-            CS.py2,
-            CS.flex,
-            CS.justifyBetween,
-            CS.alignCenter,
-            CS.borderTop,
-          )}
-        >
-          <div className={cx(CS.flex, CS.alignCenter)}>
-            <Heading>{t`Attach results`}</Heading>
-            <Icon
-              name="info"
-              className={cx(CS.textMedium, CS.ml1)}
-              size={12}
-              tooltip={t`Attachments can contain up to 2,000 rows of data.`}
-            />
-          </div>
-        </div>
         <EmailAttachmentPicker
           cards={pulse.cards}
           pulse={pulse}

--- a/frontend/src/metabase/sharing/components/EmailAttachmentPicker.jsx
+++ b/frontend/src/metabase/sharing/components/EmailAttachmentPicker.jsx
@@ -4,12 +4,12 @@ import { Component } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
-import { SegmentedControl } from "metabase/components/SegmentedControl";
+import { ExportSettingsWidget } from "metabase/common/components/ExportSettingsWidget";
 import { StackedCheckBox } from "metabase/components/StackedCheckBox";
-import Label from "metabase/components/type/Label";
 import CheckBox from "metabase/core/components/CheckBox";
 import Toggle from "metabase/core/components/Toggle";
 import CS from "metabase/css/core/index.css";
+import { Box, Group, Icon, Text } from "metabase/ui";
 
 export default class EmailAttachmentPicker extends Component {
   DEFAULT_ATTACHMENT_TYPE = "csv";
@@ -17,6 +17,7 @@ export default class EmailAttachmentPicker extends Component {
   state = {
     isEnabled: false,
     isFormattingEnabled: true,
+    isPivotingEnabled: false,
     selectedAttachmentType: this.DEFAULT_ATTACHMENT_TYPE,
     selectedCardIds: new Set(),
   };
@@ -44,11 +45,14 @@ export default class EmailAttachmentPicker extends Component {
     }
   }
 
-  calculateStateFromCards() {
-    const { cards } = this.props;
-    const selectedCards = cards.filter(card => {
+  _getCardsWithAttachments() {
+    return this.props.cards.filter(card => {
       return card.include_csv || card.include_xls;
     });
+  }
+
+  calculateStateFromCards() {
+    const selectedCards = this._getCardsWithAttachments();
 
     return {
       isEnabled: selectedCards.length > 0,
@@ -56,7 +60,12 @@ export default class EmailAttachmentPicker extends Component {
         this.attachmentTypeFor(selectedCards) || this.DEFAULT_ATTACHMENT_TYPE,
       selectedCardIds: new Set(selectedCards.map(card => card.id)),
       isFormattingEnabled: getInitialFormattingState(selectedCards),
+      isPivotingEnabled: getInitialPivotingState(selectedCards),
     };
+  }
+
+  canConfigurePivoting() {
+    return this.props.cards.some(card => card.display === "pivot");
   }
 
   shouldUpdateState(newState, currentState) {
@@ -73,7 +82,7 @@ export default class EmailAttachmentPicker extends Component {
    */
   updatePulseCards(attachmentType, selectedCardIds) {
     const { pulse, setPulse } = this.props;
-    const { isFormattingEnabled } = this.state;
+    const { isFormattingEnabled, isPivotingEnabled } = this.state;
 
     const isXls = attachmentType === "xls",
       isCsv = attachmentType === "csv";
@@ -86,6 +95,7 @@ export default class EmailAttachmentPicker extends Component {
         card.include_csv = selectedCardIds.has(card.id) && isCsv;
         card.include_xls = selectedCardIds.has(card.id) && isXls;
         card.format_rows = isCsv && isFormattingEnabled; // Excel always uses formatting
+        card.pivot_results = card.display === "pivot" && isPivotingEnabled;
         return card;
       }),
     });
@@ -185,6 +195,21 @@ export default class EmailAttachmentPicker extends Component {
     );
   };
 
+  onTogglePivoting = () => {
+    this.setState(
+      prevState => ({
+        ...prevState,
+        isPivotingEnabled: !prevState.isPivotingEnabled,
+      }),
+      () => {
+        this.updatePulseCards(
+          this.state.selectedAttachmentType,
+          this.state.selectedCardIds,
+        );
+      },
+    );
+  };
+
   disableAllCards() {
     const selectedCardIds = new Set();
     this.updatePulseCards(this.state.selectedAttachmentType, selectedCardIds);
@@ -204,41 +229,44 @@ export default class EmailAttachmentPicker extends Component {
     const {
       isEnabled,
       isFormattingEnabled,
+      isPivotingEnabled,
       selectedAttachmentType,
       selectedCardIds,
     } = this.state;
 
     return (
       <div>
-        <Toggle
-          aria-label={t`Attach results`}
-          value={isEnabled}
-          onChange={this.toggleAttach}
-        />
-
+        <Group className={CS.borderTop} position="apart" pt="1.5rem">
+          <Group position="left" spacing="0">
+            <Text fw="bold">{t`Attach results as files`}</Text>
+            <Icon
+              name="info"
+              className={cx(CS.textMedium, CS.ml1)}
+              size={12}
+              tooltip={t`Attachments can contain up to 2,000 rows of data.`}
+            />
+          </Group>
+          <Toggle
+            aria-label={t`Attach results`}
+            value={isEnabled}
+            onChange={this.toggleAttach}
+          />
+        </Group>
         {isEnabled && (
           <div>
-            <div className={cx(CS.my1, CS.flex, CS.justifyBetween)}>
-              <Label className={CS.pt1}>{t`File format`}</Label>
-              <SegmentedControl
-                options={[
-                  { name: ".csv", value: "csv" },
-                  { name: ".xlsx", value: "xls" },
-                ]}
-                onChange={this.setAttachmentType}
-                value={selectedAttachmentType}
-                fullWidth
+            <Box py="1rem">
+              <ExportSettingsWidget
+                selectedFormat={selectedAttachmentType}
+                formats={["csv", "xlsx"]}
+                isFormattingEnabled={isFormattingEnabled}
+                isPivotingEnabled={isPivotingEnabled}
+                canConfigureFormatting={selectedAttachmentType === "csv"}
+                canConfigurePivoting={this.canConfigurePivoting()}
+                onChangeFormat={this.setAttachmentType}
+                onToggleFormatting={this.onToggleFormatting}
+                onTogglePivoting={this.onTogglePivoting}
               />
-            </div>
-            {selectedAttachmentType === "csv" && (
-              <div className={cx(CS.mt2, CS.mb3)}>
-                <CheckBox
-                  checked={!isFormattingEnabled}
-                  label={t`Use unformatted values in attachments`}
-                  onChange={this.onToggleFormatting}
-                />
-              </div>
-            )}
+            </Box>
             <div
               className={cx(
                 CS.textBold,
@@ -304,4 +332,11 @@ function getInitialFormattingState(cards) {
     return cards.some(card => !!card.format_rows);
   }
   return true;
+}
+
+function getInitialPivotingState(cards) {
+  if (cards.length > 0) {
+    return cards.some(card => !!card.pivot_results);
+  }
+  return false;
 }

--- a/frontend/src/metabase/sharing/components/EmailAttachmentPicker.jsx
+++ b/frontend/src/metabase/sharing/components/EmailAttachmentPicker.jsx
@@ -84,7 +84,7 @@ export default class EmailAttachmentPicker extends Component {
     const { pulse, setPulse } = this.props;
     const { isFormattingEnabled, isPivotingEnabled } = this.state;
 
-    const isXls = attachmentType === "xls",
+    const isXls = attachmentType === "xlsx",
       isCsv = attachmentType === "csv";
 
     this.setState({ selectedAttachmentType: attachmentType });
@@ -113,7 +113,7 @@ export default class EmailAttachmentPicker extends Component {
 
   attachmentTypeFor(cards) {
     if (cards.some(c => c.include_xls)) {
-      return "xls";
+      return "xlsx";
     } else if (cards.some(c => c.include_csv)) {
       return "csv";
     } else {

--- a/frontend/src/metabase/sharing/components/EmailAttachmentPicker.unit.spec.js
+++ b/frontend/src/metabase/sharing/components/EmailAttachmentPicker.unit.spec.js
@@ -1,4 +1,8 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/react";
+
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders } from "__support__/ui";
+import { createMockState } from "metabase-types/store/mocks";
 
 import EmailAttachmentPicker from "./EmailAttachmentPicker";
 
@@ -9,12 +13,19 @@ function setup({ pulse = createPulse(), hasAttachments = false } = {}) {
     pulse.cards[0]["include_xls"] = true;
   }
 
-  render(
+  const state = createMockState({
+    settings: mockSettings({
+      "application-name": "Metabase",
+    }),
+  });
+
+  renderWithProviders(
     <EmailAttachmentPicker
       cards={pulse.cards}
       pulse={pulse}
       setPulse={setPulse}
     />,
+    { storeInitialState: state },
   );
 
   return { setPulse };

--- a/frontend/src/metabase/status/components/DownloadsStatus/DownloadsStatus.unit.spec.tsx
+++ b/frontend/src/metabase/status/components/DownloadsStatus/DownloadsStatus.unit.spec.tsx
@@ -56,7 +56,7 @@ describe("DownloadsStatus", () => {
     const dispatch = store.dispatch as Dispatch;
 
     fetchMock.post(
-      "http://localhost/api/card/1/query/csv?format_rows=false",
+      "http://localhost/api/card/1/query/csv",
       {
         headers: { "Content-Disposition": 'filename="test.csv"' },
       },
@@ -94,7 +94,7 @@ describe("DownloadsStatus", () => {
     const dispatch = store.dispatch as Dispatch;
 
     fetchMock.post(
-      "http://localhost/api/card/1/query/csv?format_rows=false",
+      "http://localhost/api/card/1/query/csv",
       {
         throws: new Error("Network error"),
       },
@@ -139,7 +139,7 @@ describe("DownloadsStatus", () => {
     const dispatch = store.dispatch as Dispatch;
 
     fetchMock.post(
-      "http://localhost/api/card/1/query/csv?format_rows=false",
+      "http://localhost/api/card/1/query/csv",
       {
         headers: { "Content-Disposition": 'filename="test.csv"' },
       },

--- a/frontend/src/metabase/ui/components/inputs/Radio/Radio.stories.mdx
+++ b/frontend/src/metabase/ui/components/inputs/Radio/Radio.stories.mdx
@@ -1,5 +1,5 @@
 import { Canvas, Story, Meta } from "@storybook/addon-docs";
-import { Radio, Stack } from "metabase/ui";
+import { Radio, Stack, Group } from "metabase/ui";
 
 export const args = {
   label: "Label",
@@ -73,6 +73,20 @@ export const StateTemplate = args => (
   </Stack>
 );
 
+export const PillsTemplate = args => (
+  <Radio.Group
+    defaultValue={"csv"}
+    label="Export format"
+  >
+    <Group mt="xs" spacing="xs" noWrap>
+      <Radio value="csv" label=".csv" variant="pill" />
+      <Radio value="xlsx" label=".xlsx" variant="pill" />
+      <Radio value="json" label=".json" variant="pill" />
+      <Radio value="yaml" label=".yaml" variant="pill" />
+    </Group>
+  </Radio.Group>
+);
+
 export const Default = DefaultTemplate.bind({});
 
 <Canvas>
@@ -85,6 +99,14 @@ export const RadioGroup = RadioGroupTemplate.bind({});
 
 <Canvas>
   <Story name="Radio group">{RadioGroup}</Story>
+</Canvas>
+
+### Pill variant
+
+export const PillVariant = PillsTemplate.bind();
+
+<Canvas>
+  <Story name="Pill variant">{PillsTemplate}</Story>
 </Canvas>
 
 ### Label

--- a/frontend/src/metabase/ui/components/inputs/Radio/Radio.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Radio/Radio.styled.tsx
@@ -1,8 +1,4 @@
-import type {
-  MantineTheme,
-  MantineThemeOverride,
-  RadioStylesParams,
-} from "@mantine/core";
+import type { MantineTheme, MantineThemeOverride } from "@mantine/core";
 import { getSize, getStylesRef, rem } from "@mantine/core";
 
 const SIZES = {
@@ -14,11 +10,39 @@ export const getRadioOverrides = (): MantineThemeOverride["components"] => ({
     defaultProps: {
       size: "md",
     },
-    styles: (
-      theme: MantineTheme,
-      { labelPosition: _labelPosition }: RadioStylesParams,
-      { size = "md" },
-    ) => ({
+    variants: {
+      pill: (theme: MantineTheme) => ({
+        root: {
+          display: "inline-block",
+        },
+        inner: {
+          display: "none",
+        },
+        body: {},
+        label: {
+          fontWeight: 600,
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          minWidth: "3rem",
+          height: "2rem",
+          borderRadius: theme.radius.xl,
+          backgroundColor: "var(--mb-color-brand-light)",
+          fontSize: theme.fontSizes.sm,
+          cursor: "pointer",
+          transition: "all 0.2s ease",
+          padding: 0,
+          "&:not([data-checked])": {
+            color: theme.fn.themeColor("brand"),
+          },
+          "[data-checked] &": {
+            backgroundColor: theme.fn.themeColor("brand"),
+            color: "white",
+          },
+        },
+      }),
+    },
+    styles: (theme: MantineTheme, { size = "md" }) => ({
       root: {
         [`&:has(.${getStylesRef("input")}:disabled)`]: {
           [`.${getStylesRef("label")}`]: {


### PR DESCRIPTION
[Product doc](https://www.notion.so/metabase/Offer-reliable-pivoted-CSV-and-XLSX-exports-49e55b2d4cba41d3b2b2bbff2443975c?pvs=4)

### Description

- Improves exports popover UI and adds the ability to export pivoted results.
- Reuses the same UI for subscriptions attachments configuration

Updates the UI of the exports popover and adds a new settings whether to apply pivoting to export results.

### Demo

#### Question with a large number of rows
<img width="337" alt="Screenshot 2024-09-12 at 10 52 23 PM" src="https://github.com/user-attachments/assets/61f56dda-f768-4b2a-8156-c4dc37e966ee">

#### Dashcard pivot table exports 
<img width="1066" alt="Screenshot 2024-09-12 at 10 52 01 PM" src="https://github.com/user-attachments/assets/4e757fb6-43be-4786-8949-fffea02f587c">

#### Dashboard subscriptions
<img width="393" alt="Screenshot 2024-09-12 at 10 51 41 PM" src="https://github.com/user-attachments/assets/24385298-ea4a-4366-8297-685172306620">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
