### PR TITLE
Respect `embedding` feature flag for interactive toggle

### DIFF
--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/common.embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/common.embedding.unit.spec.tsx
@@ -190,7 +190,7 @@ describe("[OSS] embedding settings", () => {
         ).not.toBeChecked();
         expect(
           withinInteractiveEmbeddingCard.getByLabelText("Disabled"),
-        ).toBeEnabled();
+        ).toBeDisabled();
 
         // should link to https://www.metabase.com/blog/why-full-app-embedding?utm_source=oss&utm_media=embed-settings
         expect(
@@ -397,7 +397,7 @@ describe("[OSS] embedding settings", () => {
         ).toBeChecked();
         expect(
           withinInteractiveEmbeddingCard.getByLabelText("Enabled"),
-        ).toBeEnabled();
+        ).toBeDisabled();
 
         // should link to https://www.metabase.com/blog/why-full-app-embedding?utm_source=oss&utm_media=embed-settings
         expect(

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/enterprise.embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/enterprise.embedding.unit.spec.tsx
@@ -197,7 +197,7 @@ describe("[EE, no token] embedding settings", () => {
         ).not.toBeChecked();
         expect(
           withinInteractiveEmbeddingCard.getByLabelText("Disabled"),
-        ).toBeEnabled();
+        ).toBeDisabled();
 
         // should link to https://www.metabase.com/blog/why-full-app-embedding?utm_source=oss&utm_media=embed-settings
         expect(
@@ -404,7 +404,7 @@ describe("[EE, no token] embedding settings", () => {
         ).toBeChecked();
         expect(
           withinInteractiveEmbeddingCard.getByLabelText("Enabled"),
-        ).toBeEnabled();
+        ).toBeDisabled();
 
         // should link to https://www.metabase.com/blog/why-full-app-embedding?utm_source=oss&utm_media=embed-settings
         expect(

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/premium.embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/premium.embedding.unit.spec.tsx
@@ -1,4 +1,5 @@
 import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
 
 import { screen, within } from "__support__/ui";
 import {
@@ -19,6 +20,7 @@ import {
 import type { History } from "./types";
 
 const setupPremium = (opts?: SetupOpts) => {
+  fetchMock.put("path:/api/setting/enable-embedding-interactive", 204);
   return setupEmbedding({
     ...opts,
     hasEnterprisePlugins: true,
@@ -234,6 +236,9 @@ describe("[EE, with token] embedding settings", () => {
         expect(
           screen.getByLabelText("Enable Interactive embedding"),
         ).not.toBeChecked();
+        await userEvent.click(
+          screen.getByLabelText("Enable Interactive embedding"),
+        );
 
         expect(screen.getByLabelText("Authorized origins")).toBeEnabled();
         expect(screen.getByLabelText("Authorized origins")).toHaveValue(
@@ -457,6 +462,9 @@ describe("[EE, with token] embedding settings", () => {
         expect(
           screen.getByLabelText("Enable Interactive embedding"),
         ).toBeChecked();
+        await userEvent.click(
+          screen.getByLabelText("Enable Interactive embedding"),
+        );
 
         expect(screen.getByLabelText("Authorized origins")).toBeEnabled();
         expect(screen.getByLabelText("Authorized origins")).toHaveValue(

--- a/frontend/src/metabase/admin/settings/components/widgets/EmbeddingOption/EmbeddingOption.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/EmbeddingOption/EmbeddingOption.tsx
@@ -218,6 +218,7 @@ export const InteractiveEmbeddingOptionCard = ({
           label={isInteractiveEmbeddingEnabled ? t`Enabled` : t`Disabled`}
           ml="auto"
           labelPosition="left"
+          disabled={!isEE}
           checked={isInteractiveEmbeddingEnabled}
           onChange={onToggle}
         />

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -436,9 +436,9 @@ export const ADMIN_SETTINGS_SECTIONS = {
   },
   "embedding-in-other-applications/full-app": {
     // We need to do this because EE plugins would load after this file in unit tests
-    component: ({ updateSettings }) => (
+    component: ({ updateSetting }) => (
       <PLUGIN_ADMIN_SETTINGS.InteractiveEmbeddingSettings
-        updateSettings={updateSettings}
+        updateSetting={updateSetting}
       />
     ),
     settings: [],

--- a/src/metabase/embed/settings.clj
+++ b/src/metabase/embed/settings.clj
@@ -67,6 +67,7 @@
 
 (defsetting enable-embedding-interactive
   (deferred-tru "Allow admins to embed Metabase via interactive embedding?")
+  :feature    :embedding
   :type       :boolean
   :default    false
   :visibility :authenticated


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/47881

### Description

Respects `embedding` flag, so `enable-embedding-interactive` can only be toggled when this flag is present

### How to verify

Run MB in OSS, and EE and see that the interactive embedding toggle should be disabled on OSS. Please note that you can't test or rather don't need to test the toggle inside the interactive settings page, because that settings page is already only allow access for EE users.

### Demo

![image](https://github.com/user-attachments/assets/68ad268c-5623-4cce-8135-4afbaec03525)



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
