### PR TITLE
fix(sdk): remove the unknown premium feature console warnings

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/public/index.ts
+++ b/enterprise/frontend/src/embedding-sdk/components/public/index.ts
@@ -1,5 +1,3 @@
-import "ee-overrides"; // eslint-disable-line import/no-duplicates
-
 export { StaticQuestion } from "./StaticQuestion";
 export { InteractiveQuestion } from "./InteractiveQuestion";
 export { MetabaseProvider } from "./MetabaseProvider";

--- a/enterprise/frontend/src/embedding-sdk/components/public/index.ts
+++ b/enterprise/frontend/src/embedding-sdk/components/public/index.ts
@@ -1,5 +1,4 @@
 import "ee-overrides"; // eslint-disable-line import/no-duplicates
-import "ee-plugins"; // eslint-disable-line import/no-duplicates
 
 export { StaticQuestion } from "./StaticQuestion";
 export { InteractiveQuestion } from "./InteractiveQuestion";

--- a/enterprise/frontend/src/metabase-enterprise/settings/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/settings/index.ts
@@ -3,7 +3,11 @@ import MetabaseSettings from "metabase/lib/settings";
 import type { TokenFeature } from "metabase-types/api";
 
 export function hasPremiumFeature(feature: TokenFeature) {
-  return MetabaseSettings.get("token-features")?.[feature];
+  const hasFeature = MetabaseSettings.get("token-features")?.[feature];
+  if (hasFeature == null) {
+    console.warn("Unknown premium feature", feature);
+  }
+  return hasFeature;
 }
 
 export function hasAnySsoPremiumFeature() {

--- a/enterprise/frontend/src/metabase-enterprise/settings/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/settings/index.ts
@@ -3,11 +3,7 @@ import MetabaseSettings from "metabase/lib/settings";
 import type { TokenFeature } from "metabase-types/api";
 
 export function hasPremiumFeature(feature: TokenFeature) {
-  const hasFeature = MetabaseSettings.get("token-features")?.[feature];
-  if (hasFeature == null) {
-    console.warn("Unknown premium feature", feature);
-  }
-  return hasFeature;
+  return MetabaseSettings.get("token-features")?.[feature];
 }
 
 export function hasAnySsoPremiumFeature() {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/47656

### Description

Removes the "unknown premium feature" warning that spams the SDK's console logs by removing EE plugins and overrides. See [this comment](https://github.com/metabase/metabase/pull/47885#pullrequestreview-2299641382).

![image](https://github.com/user-attachments/assets/d4053b63-6012-4d67-b3e4-78812e3d34a7)

### How to verify

- Use the SDK
- There should no longer be console warnings