### PR TITLE
Fix empty header in BooleanFilterPicker

### DIFF
--- a/frontend/src/metabase/querying/filters/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.tsx
@@ -58,10 +58,12 @@ export function BooleanFilterPicker({
       data-testid="boolean-filter-picker"
       onSubmit={handleSubmit}
     >
-      <FilterPickerHeader
-        columnName={columnInfo.longDisplayName}
-        onBack={onBack}
-      />
+      {onBack && (
+        <FilterPickerHeader
+          columnName={columnInfo.longDisplayName}
+          onBack={onBack}
+        />
+      )}
       <div>
         <Radio.Group value={optionType} onChange={handleOptionChange}>
           <Stack p="md" pb={isExpanded ? "md" : 0} spacing="sm">


### PR DESCRIPTION
Slack https://metaboat.slack.com/archives/C02H619CJ8K/p1726085413877219

Usually there is a filter operator picker in the filter picker header, but not for booleans. If there is no back button, it results in an empty header. In this PR we remove the header if it is empty.

<img width="569" alt="Screenshot 2024-09-12 at 09 06 22" src="https://github.com/user-attachments/assets/c615326e-097b-40f1-97aa-d7bea0550077">
<img width="469" alt="Screenshot 2024-09-12 at 09 06 30" src="https://github.com/user-attachments/assets/56cae973-e186-46e4-897f-686cc485d567">
<img width="341" alt="Screenshot 2024-09-12 at 09 06 41" src="https://github.com/user-attachments/assets/ecc2b059-3e7d-4b76-88aa-d0d9bcb5e747">
<img width="335" alt="Screenshot 2024-09-12 at 09 06 45" src="https://github.com/user-attachments/assets/d2118268-b28f-45d1-8adb-c2013e27b1f8">
