### PR TITLE
Basic batching for search index population

### DIFF
--- a/src/metabase/search/postgres/ingestion.clj
+++ b/src/metabase/search/postgres/ingestion.clj
@@ -11,6 +11,8 @@
    [toucan2.core :as t2]
    [toucan2.realize :as t2.realize]))
 
+(def ^:private insert-batch-size 50)
+
 (def ^:private model-rankings
   (zipmap search.config/models-search-order (range)))
 
@@ -62,5 +64,6 @@
        (eduction
         (comp
          (map t2.realize/realize)
-         (map ->entry)))
+         (map ->entry)
+         (partition-all insert-batch-size)))
        (run! search.index/update!)))

--- a/src/metabase/search/postgres/ingestion.clj
+++ b/src/metabase/search/postgres/ingestion.clj
@@ -42,7 +42,7 @@
 
 (defn- search-items-reducible []
   (-> {:search-string      nil
-       :models             search.config/all-models
+       :models             (disj search.config/all-models "indexed-entity")
        ;; we want to see everything
        :is-superuser?      true
        ;; irrelevant, as we're acting as a super user
@@ -66,4 +66,4 @@
          (map t2.realize/realize)
          (map ->entry)
          (partition-all insert-batch-size)))
-       (run! search.index/update!)))
+       (run! search.index/batch-update!)))


### PR DESCRIPTION
### Describe 

One quick trick to hopefully speed up / reduce the cost of populating the search index in staging.

This also removes the `indexed-entity` index, for two reasons:

1. They dominate the index, making up 70% of the rows.
2. They already *are* an index, we should optimize that index itself maybe.