### PR TITLE
Use case expression type inference logic similar to annotate middleware in MLv2

### DIFF
--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -1400,3 +1400,37 @@ describe("issue 45877", () => {
     });
   });
 });
+
+describe("issue 47887", () => {
+  beforeEach(() => {
+    restore("setup");
+    cy.signInAsAdmin();
+  });
+
+  it("Case expression with type/Date default value and type/DateTime case value has Date filter popover enabled (metabase#47887)", () => {
+    visitQuestionAdhoc({
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        type: "query",
+        query: {
+          "source-table": PEOPLE_ID,
+          expressions: {
+            "asdfdsa": ["case", [
+              [["=", ["field", SAMPLE_DATABASE.PEOPLE.NAME, { "base-type": "type/Text" }], "Won"],
+              ["datetime-add", ["field", SAMPLE_DATABASE.PEOPLE.CREATED_AT, { "base-type": "type/DateTimeWithLocalTZ" }], 0, "month"]]],
+              { "default": ["datetime-add", ["field", SAMPLE_DATABASE.PEOPLE.BIRTH_DATE, { "base-type": "type/Date" }], 0, "month"] }]
+          },
+        },
+        parameters: [],
+      },
+    });
+
+    cy.findByText("Show Editor").click()
+    cy.findByLabelText("Filter").click()
+    cy.findByLabelText("asdfdsa").click()
+
+    // Check that Date filter popover is opened
+    // Beware of triple comma.
+    cy.findByText("Specific dates…").click()
+  });
+});

--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -1415,22 +1415,56 @@ describe("issue 47887", () => {
         query: {
           "source-table": PEOPLE_ID,
           expressions: {
-            "asdfdsa": ["case", [
-              [["=", ["field", SAMPLE_DATABASE.PEOPLE.NAME, { "base-type": "type/Text" }], "Won"],
-              ["datetime-add", ["field", SAMPLE_DATABASE.PEOPLE.CREATED_AT, { "base-type": "type/DateTimeWithLocalTZ" }], 0, "month"]]],
-              { "default": ["datetime-add", ["field", SAMPLE_DATABASE.PEOPLE.BIRTH_DATE, { "base-type": "type/Date" }], 0, "month"] }]
+            asdfdsa: [
+              "case",
+              [
+                [
+                  [
+                    "=",
+                    [
+                      "field",
+                      SAMPLE_DATABASE.PEOPLE.NAME,
+                      { "base-type": "type/Text" },
+                    ],
+                    "Won",
+                  ],
+                  [
+                    "datetime-add",
+                    [
+                      "field",
+                      SAMPLE_DATABASE.PEOPLE.CREATED_AT,
+                      { "base-type": "type/DateTimeWithLocalTZ" },
+                    ],
+                    0,
+                    "month",
+                  ],
+                ],
+              ],
+              {
+                default: [
+                  "datetime-add",
+                  [
+                    "field",
+                    SAMPLE_DATABASE.PEOPLE.BIRTH_DATE,
+                    { "base-type": "type/Date" },
+                  ],
+                  0,
+                  "month",
+                ],
+              },
+            ],
           },
         },
         parameters: [],
       },
     });
 
-    cy.findByText("Show Editor").click()
-    cy.findByLabelText("Filter").click()
-    cy.findByLabelText("asdfdsa").click()
+    cy.findByTestId("notebook-button").click();
+    cy.findAllByTestId("action-buttons").last().findByText("Filter").click();
 
-    // Check that Date filter popover is opened
-    // Beware of triple comma.
-    cy.findByText("Specific dates…").click()
+    popover().within(() => {
+      cy.findByLabelText("asdfdsa").click();
+      cy.findByText("Specific dates…").click();
+    });
   });
 });

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
@@ -279,6 +279,16 @@
     base-type
     (base-type->temporal-type base-type)))
 
+(defmethod temporal-type :case
+  [[_case & rezt]]
+  ;; Following logic for picking a type is taken from
+  ;; the [[metabase.query-processor.middleware.annotate/infer-expression-type]].
+  (loop [[cond-or-else expr & rezt*] rezt]
+    (when (and expr (not= :else cond-or-else))
+      (if-some [t (temporal-type expr)]
+        t
+        (recur rezt*)))))
+
 (defmethod temporal-type :default
   [x]
   (:bigquery-cloud-sdk/temporal-type (meta x)))

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
@@ -1265,13 +1265,15 @@
 
 (deftest ^:parallel case-expression-with-default-Date-case-DateTime-test
   (mt/test-driver
-   :bigquery-cloud-sdk
-   (testing "Query with case expression with default Date and case DateTime is executable (#47888)"
-     (is (=? {:status :completed}
-             (mt/run-mbql-query
-              people
-              {:expressions {"asdfdsa"
-                             [:case
-                              [[[:= $name "Won"] [:datetime-add $created_at 0 :month]]]
-                              {:default [:datetime-add $birth_date 0 :month]}]}
-               :filter [:time-interval [:expression "asdfdsa"] -12 :month]}))))))
+    :bigquery-cloud-sdk
+    ;; Testing only whether query executes correctly, without underlying jdbc driver throwing an exception. This
+    ;; specific case was erroneous.
+    (testing "Query with case expression with default Date and case DateTime is executable (#47888)"
+      (is (=? {:status :completed}
+              (mt/run-mbql-query
+                people
+                {:expressions {"asdfdsa"
+                               [:case
+                                [[[:= $name "Won"] [:datetime-add $created_at 0 :month]]]
+                                {:default [:datetime-add $birth_date 0 :month]}]}
+                 :filter [:time-interval [:expression "asdfdsa"] -12 :month]}))))))

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
@@ -1262,3 +1262,16 @@
                  (->> (driver/prettify-native-form :bigquery-cloud-sdk))
                  (str/replace #"v4_test_data__transient_\d+" "test_data")
                  str/split-lines))))))
+
+(deftest ^:parallel case-expression-with-default-Date-case-DateTime-test
+  (mt/test-driver
+   :bigquery-cloud-sdk
+   (testing "Query with case expression with default Date and case DateTime is executable (#47888)"
+     (is (=? {:status :completed}
+             (mt/run-mbql-query
+              people
+              {:expressions {"asdfdsa"
+                             [:case
+                              [[[:= $name "Won"] [:datetime-add $created_at 0 :month]]]
+                              {:default [:datetime-add $birth_date 0 :month]}]}
+               :filter [:time-interval [:expression "asdfdsa"] -12 :month]}))))))

--- a/src/metabase/lib/schema/expression/conditional.cljc
+++ b/src/metabase/lib/schema/expression/conditional.cljc
@@ -23,6 +23,15 @@
         (= y ::expression/type.unknown))
     ::expression/type.unknown
 
+    ;; Naive fix for https://github.com/metabase/metabase/issues/47887
+    ;; Following tuple not being in place, the :type/Temporal (the common ancestor) would be returned. That is
+    ;; unfortunately not very usable from filter pickers perspective.
+    (and (keyword? x)
+         (keyword? y)
+         (some #(isa? % :type/Date) [x y])
+         (some #(isa? % :type/DateTime) [x y]))
+    :type/Date
+
     ;; if both types are keywords return their most-specific ancestor.
     (and (keyword? x)
          (keyword? y))

--- a/test/metabase/lib/schema/expression/conditional_test.cljc
+++ b/test/metabase/lib/schema/expression/conditional_test.cljc
@@ -26,37 +26,32 @@
     clause))
 
 (deftest ^:parallel case-type-of-test
-  (are [expr expected] (= expected
-                          (expression/type-of expr))
-    ;; easy, no ambiguity
-    (case-expr 1 1)
-    :type/Integer
+  (testing "In MLv2, case expression's type is the first non-nil type of its values, same approach as in qp"
+    ;; In qp: `annotate/infer-expression-type`
+    ;; In MLv2: `expression/type-of-method :case`
+    (are [expr expected] (= expected
+                            (expression/type-of expr))
 
-    ;; Ambiguous literal types
-    (case-expr "2023-03-08")
-    #{:type/Text :type/Date}
+      (case-expr 1 1)
+      :type/Integer
 
-    (case-expr "2023-03-08" "2023-03-08")
-    #{:type/Text :type/Date}
+      (case-expr "2023-03-08")
+      #{:type/Text :type/Date}
 
-    ;; Ambiguous literal types mixed with unambiguous types
-    (case-expr "2023-03-08" "abc")
-    :type/Text
+      (case-expr "2023-03-08" "2023-03-08")
+      #{:type/Text :type/Date}
 
-    ;; Literal types that are ambiguous in different ways! `:type/Text` is the only common type between them!
-    (case-expr "2023-03-08" "05:13")
-    :type/Text
+      (case-expr "2023-03-08" "abc")
+      #{:type/Text :type/Date}
 
-    ;; Confusion! The "2023-03-08T06:15" is #{:type/String :type/DateTime}, which is less specific than
-    ;; `:type/DateTimeWithLocalTZ`. Technically this should return `:type/DateTime`, since it's the most-specific
-    ;; common ancestor type compatible with all args! But calculating that stuff is way too hard! So this will have to
-    ;; do for now! -- Cam
-    (case-expr "2023-03-08T06:15" [:field {:lib/uuid (str (random-uuid)), :base-type :type/DateTimeWithLocalTZ} 1])
-    :type/DateTimeWithLocalTZ
+      (case-expr "2023-03-08" "05:13")
+      #{:type/Text :type/Date}
 
-    ;; Differing types with a common base type that is more specific than `:type/*`
-    (case-expr 1 1.1)
-    :type/Float))
+      (case-expr "2023-03-08T06:15" [:field {:lib/uuid (str (random-uuid)), :base-type :type/DateTimeWithLocalTZ} 1])
+      #{:type/Text :type/DateTime}
+
+      (case-expr 1 1.1)
+      :type/Integer)))
 
 (deftest ^:parallel coalesce-test
   (is (mc/validate


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/47887
Closes https://github.com/metabase/metabase/issues/48010
Closes https://github.com/metabase/metabase/issues/47888

### Initial description (not actual anymore)

~~The issue is that we infer return type for `case` expression as most specific common ancestor. If the arguments are `:type/Date` and `:type/DateTime` the ancestor is `:type/Temporal`. That results in limited filter picker options.~~

~~This PR adds special case for arguments of aforemementioned types. The `:type/Date` is picked as the expression type.~~

~~The question is however, whether the current behavior is really erroneous. To the best of my knowledge there's no way to decide correct argument type in this case, and picking the `:type/Date` is best effort, that could enable some cases, but may result in error in others.~~

~~Following stack (in reverse) is significant for the context (ie. if you are interested in how I got to this specific change):~~
```
metabase.lib.util/top-level-expression-clause
metabase.lib.schema.expression/type-of :case
metabase.lib.schema.expression.conditional/best-return-type
```

### Description

This PR solves multiple problems.

#### Generic filter picker

We stopped checking for the type `Temporal` when selecting a appropriate filter picker, and switched to `Date` or `DateTime`. The case expression in #47887 is a bit tricky. It returns `DateTime` value when condition is met and `Date` value in default case. The MLv2 expression inference code was returning most specific common ancestor in this case - `Temporal`.

This PR changes the MLv2 case expression inference code to follow the logic in `metabase.query-processor.middleware.annotate/infer-expression-type`.

#### Bigquery error

Bigquery bugs have a different cause. Something changed in a way we compute expressions. In older version that was done in subquery. But in the current version, the expression from reproduction is computed on the same level. The Bigquery logic for appropriate _database type_ inference is now presented with the case expression instead of reference to field from subquery.

This PR adds `metabase.driver.bigquery-cloud-sdk.query-processor/temporal-type` implementation for `:case` expression, that follows same logic laid out in the `annotate/infer-expression-type`.

Long story short, that results in appropriate type reconciliation by means of `metabase.driver.bigquery-cloud-sdk.query-processor/reconcile-temporal-types`.

### Is that a right decision to model inference by `annotate/infer-expression-type`?

Depends on context. Yes in short term. Those 2 bugs are recent regressions and this PR addresses them in relatively non-invasive manner, expanding approach that is taken already in neighboring part of the code base.

In long term, when looking for general right solution to [Type system issues](https://www.notion.so/metabase/Type-system-issues-f95eff50b21642b0b1182ea78616e83b?pvs=4) mentioned by Ranquild, we should keep in mind this case.

Maybe that would entail creating new type hierarchies for different contexts as [noted](https://github.com/metabase/metabase/pull/47902#pullrequestreview-2303233507) by Metamben.