### PR TITLE
Rename public-settings to settings after making most settings authenticated

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -350,6 +350,7 @@
                                      metabase.server.protocols
                                      metabase.server.request.util}                                  ; TODO -- consolidate these into a real API namespace.
     metabase.setup                 #{metabase.setup}
+    metabase.settings              #{metabase.settings}
     metabase.shared                #{metabase.shared.dashboards.constants
                                      metabase.shared.formatting.constants
                                      metabase.shared.formatting.date
@@ -418,14 +419,13 @@
     metabase.moderation            :any
     metabase.permissions           :any
     metabase.plugins               :any
-    metabase.public-settings       :any
     metabase.pulse                 :any
     metabase.query-analysis        #{metabase.config
                                      metabase.driver
                                      metabase.legacy-mbql
                                      metabase.lib
                                      metabase.models
-                                     metabase.public-settings
+                                     metabase.settings
                                      metabase.query-processor
                                      metabase.util}
     metabase.query-processor       :any
@@ -433,6 +433,7 @@
     metabase.sample-data           :any
     metabase.search                :any
     metabase.server                :any
+    metabase.settings              :any
     metabase.setup                 :any
     metabase.shared                :any
     metabase.sync                  :any
@@ -630,7 +631,7 @@
     metabase.analysis.native-query-analyzer                       nqa
     metabase.analysis.native-query-analyzer.parameter-substitution nqa.sub
     metabase.plugins.initialize                                   plugins.init
-    metabase.public-settings                                      public-settings
+    metabase.settings                                             settings
     metabase.public-settings.premium-features                     premium-features
     metabase.pulse                                                pulse ; NB some conflicts with metabase.models.pulse
     metabase.pulse.markdown                                       markdown

--- a/enterprise/backend/src/metabase_enterprise/query_reference_validation/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/query_reference_validation/api.clj
@@ -6,8 +6,8 @@
    [metabase.api.routes.common :refer [+auth]]
    [metabase.models.collection :as collection]
    [metabase.models.query-analysis :as query-analysis]
-   [metabase.public-settings :as public-settings]
    [metabase.server.middleware.offset-paging :as mw.offset-paging]
+   [metabase.settings :as settings]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
 
@@ -119,7 +119,7 @@
   [handler]
   (with-meta
    (fn [request respond raise]
-     (if (public-settings/query-analysis-enabled)
+     (if (settings/query-analysis-enabled)
        (handler request respond raise)
        (respond {:status 429 :body "Query Analysis must be enabled to use the Query Reference Validator"})))
    (meta handler)))

--- a/enterprise/backend/src/metabase_enterprise/scim/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/scim/api.clj
@@ -6,7 +6,7 @@
    [metabase.api.common :as api :refer [defendpoint]]
    [metabase.models.api-key :as api-key]
    [metabase.models.setting :as setting :refer [defsetting]]
-   [metabase.public-settings :as public-settings]
+   [metabase.settings :as settings]
    [metabase.util.i18n :refer [deferred-tru]]
    [metabase.util.secret :as u.secret]
    [toucan2.core :as t2]))
@@ -28,7 +28,7 @@
   :audit      :never
   :export?    false
   :getter     (fn []
-                (str (public-settings/site-url) "/api/ee/scim/v2")))
+                (str (settings/site-url) "/api/ee/scim/v2")))
 
 (defn- scim-api-key-name
   []

--- a/enterprise/backend/src/metabase_enterprise/serialization/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/api.clj
@@ -13,7 +13,7 @@
    [metabase.api.routes.common :refer [+auth]]
    [metabase.logger :as logger]
    [metabase.models.serialization :as serdes]
-   [metabase.public-settings :as public-settings]
+   [metabase.settings :as settings]
    [metabase.util :as u]
    [metabase.util.compress :as u.compress]
    [metabase.util.date-2 :as u.date]
@@ -68,7 +68,7 @@
 (defn- serialize&pack ^File [{:keys [dirname full-stacktrace] :as opts}]
   (let [dirname  (or dirname
                      (format "%s-%s"
-                             (u/slugify (public-settings/site-name))
+                             (u/slugify (settings/site-name))
                              (u.date/format "YYYY-MM-dd_HH-mm" (t/local-date-time))))
         path     (io/file parent-dir dirname)
         dst      (io/file (str (.getPath path) ".tar.gz"))

--- a/enterprise/backend/src/metabase_enterprise/serialization/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/load.clj
@@ -715,7 +715,7 @@
     (when-let [{email :email, google-auth? :google_auth, is-active? :is_active}
                (t2/select-one [User :email :google_auth :is_active] :id user-id)]
       (let [reset-token        (user/set-password-reset-token! user-id)
-            site-url           (public-settings/site-url)
+            site-url           (settings/site-url)
             password-reset-url (str site-url "/auth/reset_password/" reset-token)
             ;; in a web server context, the server-name ultimately comes from ServletRequest/getServerName
             ;; (i.e. the Java class, via Ring); this is the closest approximation in our batch context

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -41,10 +41,10 @@
    [metabase.api.common :as api]
    [metabase.api.session :as api.session]
    [metabase.integrations.common :as integrations.common]
-   [metabase.public-settings :as public-settings]
    [metabase.public-settings.premium-features :as premium-features]
    [metabase.server.middleware.session :as mw.session]
    [metabase.server.request.util :as req.util]
+   [metabase.settings :as settings]
    [metabase.util :as u]
    [metabase.util.i18n :refer [trs tru]]
    [metabase.util.log :as log]
@@ -114,7 +114,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn- acs-url []
-  (str (public-settings/site-url) "/auth/sso"))
+  (str (settings/site-url) "/auth/sso"))
 
 (defn- sp-cert-keystore-details []
   (when-let [path (sso-settings/saml-keystore-path)]
@@ -138,9 +138,9 @@
         redirect-url (if (nil? redirect)
                        (do
                          (log/warn "Warning: expected `redirect` param, but none is present")
-                         (public-settings/site-url))
+                         (settings/site-url))
                        (if (sso-utils/relative-uri? redirect)
-                         (str (public-settings/site-url) redirect)
+                         (str (settings/site-url) redirect)
                          redirect))]
     (sso-utils/check-sso-redirect redirect-url)
     (try
@@ -224,7 +224,7 @@
                           :group-names     groups
                           :user-attributes attrs
                           :device-info     (req.util/device-info request)})
-          response      (response/redirect (or continue-url (public-settings/site-url)))]
+          response      (response/redirect (or continue-url (settings/site-url)))]
       (mw.session/set-session-cookies request response session (t/zoned-date-time (t/zone-id "GMT"))))))
 
 (def ^:private saml2-success-status "urn:oasis:names:tc:SAML:2.0:status:Success")

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_settings.clj
@@ -8,7 +8,7 @@
    [metabase.integrations.common :as integrations.common]
    [metabase.models.setting :as setting :refer [defsetting]]
    [metabase.models.setting.multi-setting :refer [define-multi-setting-impl]]
-   [metabase.public-settings :as public-settings]
+   [metabase.settings :as settings]
    [metabase.util.i18n :refer [deferred-tru tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
@@ -104,7 +104,7 @@ on your IdP, this usually looks something like `http://www.example.com/141xkex60
 
 (defsetting saml-keystore-alias
   (deferred-tru "Alias for the key that {0} should use for signing SAML requests"
-                (public-settings/application-name-for-setting-descriptions))
+                (settings/application-name-for-setting-descriptions))
   :default "metabase"
   :feature :sso-saml
   :audit   :getter)
@@ -143,7 +143,7 @@ on your IdP, this usually looks something like `http://www.example.com/141xkex60
 (defsetting saml-group-mappings
   ;; Should be in the form: {"groupName": [1, 2, 3]} where keys are SAML groups and values are lists of MB groups IDs
   (deferred-tru "JSON containing SAML to {0} group mappings."
-                (public-settings/application-name-for-setting-descriptions))
+                (settings/application-name-for-setting-descriptions))
   :type    :json
   :cache?  false
   :default {}
@@ -232,7 +232,7 @@ on your IdP, this usually looks something like `http://www.example.com/141xkex60
 (defsetting jwt-group-mappings
   ;; Should be in the form: {"groupName": [1, 2, 3]} where keys are JWT groups and values are lists of MB groups IDs
   (deferred-tru "JSON containing JWT to {0} group mappings."
-                (public-settings/application-name-for-setting-descriptions))
+                (settings/application-name-for-setting-descriptions))
   :type    :json
   :cache?  false
   :default {}

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
@@ -7,7 +7,7 @@
    [metabase.events :as events]
    [metabase.integrations.common :as integrations.common]
    [metabase.models.user :refer [User]]
-   [metabase.public-settings :as public-settings]
+   [metabase.settings :as settings]
    [metabase.util :as u]
    [metabase.util.i18n :refer [trs tru]]
    [metabase.util.log :as log]
@@ -34,7 +34,7 @@
   [user-provisioning-type]
   (when (not user-provisioning-type)
     (throw (ex-info (trs "Sorry, but you''ll need a {0} account to view this page. Please contact your administrator."
-                         (u/slugify (public-settings/site-name))) {}))))
+                         (u/slugify (settings/site-name))) {}))))
 
 (defmulti check-user-provisioning
   "If `user-provisioning-enabled?` is false, then we should throw an error when attempting to create a new user."
@@ -103,7 +103,7 @@
   [redirect-url]
   (try
     (let [redirect (some-> redirect-url (URI.))
-          our-host (some-> (public-settings/site-url) (URI.) (.getHost))]
+          our-host (some-> (settings/site-url) (URI.) (.getHost))]
       (api/check-400 (or (nil? redirect-url)
                          (relative-uri? redirect)
                          (= (.getHost redirect) our-host))))

--- a/enterprise/backend/src/metabase_enterprise/stale.clj
+++ b/enterprise/backend/src/metabase_enterprise/stale.clj
@@ -1,7 +1,7 @@
 (ns metabase-enterprise.stale
   (:require [malli.experimental.time]
             [metabase.embed.settings :as embed.settings]
-            [metabase.public-settings :as public-settings]
+            [metabase.settings :as settings]
             [metabase.util.honey-sql-2 :as h2x]
             [metabase.util.malli :as mu]
             [toucan2.core :as t2]))
@@ -46,7 +46,7 @@
            [:<= :report_card.last_used_at (-> args :cutoff-date)]
            (when (embed.settings/enable-embedding)
              [:= :report_card.enable_embedding false])
-           (when (public-settings/enable-public-sharing)
+           (when (settings/enable-public-sharing)
              [:= :report_card.public_uuid nil])
            [:or
             (when (contains? (:collection-ids args) nil)
@@ -69,7 +69,7 @@
            [:<= :report_dashboard.last_viewed_at (-> args :cutoff-date)]
            (when (embed.settings/enable-embedding)
              [:= :report_dashboard.enable_embedding false])
-           (when (public-settings/enable-public-sharing)
+           (when (settings/enable-public-sharing)
              [:= :report_dashboard.public_uuid nil])
            [:or
             (when (contains? (:collection-ids args) nil)

--- a/enterprise/backend/test/metabase_enterprise/enhancements/integrations/ldap_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/enhancements/integrations/ldap_test.clj
@@ -5,7 +5,7 @@
    [metabase-enterprise.sso.integrations.sso-settings :as sso-settings]
    [metabase.integrations.ldap :as ldap]
    [metabase.models.user :as user :refer [User]]
-   [metabase.public-settings :as public-settings]
+   [metabase.settings :as settings]
    [metabase.test :as mt]
    [metabase.test.integrations.ldap :as ldap.test]
    [metabase.util.malli.schema :as ms]
@@ -255,7 +255,7 @@
     (ldap.test/with-ldap-server!
       (testing "an error is thrown when a new user is fetched and user provisioning is not enabled"
         (with-redefs [sso-settings/ldap-user-provisioning-enabled? (constantly false)
-                      public-settings/site-name (constantly "test")]
+                      settings/site-name (constantly "test")]
           (is (thrown-with-msg?
                clojure.lang.ExceptionInfo
                #"Sorry, but you'll need a test account to view this page. Please contact your administrator."

--- a/enterprise/backend/test/metabase_enterprise/public_settings_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/public_settings_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase.embed.settings :as embed.settings]
-   [metabase.public-settings :as public-settings]
+   [metabase.settings :as settings]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.test.util :as tu]))
@@ -19,13 +19,13 @@
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
              #"Setting enable-password-login is not enabled because feature :disable-password-login is not available"
-             (public-settings/enable-password-login! false))))
+             (settings/enable-password-login! false))))
 
       (testing "can change enable-password-login setting if jwt enabled and have disabled-password-login feature"
         (mt/with-additional-premium-features #{:disable-password-login}
-          (public-settings/enable-password-login! false)
+          (settings/enable-password-login! false)
           (is (= false
-                 (public-settings/enable-password-login))))))))
+                 (settings/enable-password-login))))))))
 
 (deftest toggle-full-app-embedding-test
   (mt/discard-setting-changes [embedding-app-origin]

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -14,8 +14,8 @@
    [metabase.models.permissions-group-membership
     :refer [PermissionsGroupMembership]]
    [metabase.models.user :refer [User]]
-   [metabase.public-settings :as public-settings]
    [metabase.public-settings.premium-features :as premium-features]
+   [metabase.settings :as settings]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
@@ -336,7 +336,7 @@
   (testing "When user provisioning is disabled, throw an error if we attempt to create a new user."
     (with-jwt-default-setup!
       (with-redefs [sso-settings/jwt-user-provisioning-enabled? (constantly false)
-                    public-settings/site-name (constantly "test")]
+                    settings/site-name (constantly "test")]
         (is
          (thrown-with-msg?
           clojure.lang.ExceptionInfo

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -10,9 +10,9 @@
    [metabase.models.permissions-group :refer [PermissionsGroup]]
    [metabase.models.permissions-group-membership :refer [PermissionsGroupMembership]]
    [metabase.models.user :refer [User]]
-   [metabase.public-settings :as public-settings]
    [metabase.public-settings.premium-features :as premium-features]
    [metabase.server.middleware.session :as mw.session]
+   [metabase.settings :as settings]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
@@ -458,7 +458,7 @@
                (let [req-options (saml-post-request-options (saml-test-response) relay-state)
                      response    (client/client-real-response :post 302 "/auth/sso" req-options)]
                  (is (successful-login? response))
-                 (is (= (public-settings/site-url)
+                 (is (= (settings/site-url)
                         (get-in response [:headers "Location"])))
                  (is (= (some-saml-attributes "rasta")
                         (saml-login-attributes "rasta@metabase.com"))))))))))))
@@ -699,7 +699,7 @@
     (with-other-sso-types-disabled!
       (with-saml-default-setup!
         (with-redefs [sso-settings/saml-user-provisioning-enabled? (constantly false)
-                      public-settings/site-name (constantly "test")]
+                      settings/site-name (constantly "test")]
           (is
            (thrown-with-msg?
             clojure.lang.ExceptionInfo

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -21,13 +21,13 @@
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.lib.util.match :as lib.util.match]
-   [metabase.public-settings :as public-settings]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.interface :as qp.i]
    [metabase.query-processor.middleware.annotate :as annotate]
    [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.timezone :as qp.timezone]
    [metabase.query-processor.util.add-alias-info :as add]
+   [metabase.settings :as settings]
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
    [metabase.util.i18n :refer [tru]]
@@ -324,7 +324,7 @@
                   {:$dateTrunc {:date column
                                 :unit (name unit)
                                 :timezone (qp.timezone/results-timezone-id)
-                                :startOfWeek (name (public-settings/start-of-week))}}
+                                :startOfWeek (name (settings/start-of-week))}}
                   (truncate-to-resolution column unit)))]
         (case unit
           :default          column

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -17,10 +17,10 @@
    [metabase.driver.sync :as driver.s]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.util.match :as lib.util.match]
-   [metabase.public-settings :as public-settings]
    [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.util :as qp.util]
    [metabase.query-processor.util.relative-datetime :as qp.relative-datetime]
+   [metabase.settings :as settings]
    [metabase.upload :as upload]
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
@@ -472,7 +472,7 @@
        (json/generate-string {:dashboard_id        dashboard-id
                               :chart_id            card-id
                               :optional_user_id    executed-by
-                              :optional_account_id (public-settings/site-uuid)
+                              :optional_account_id (settings/site-uuid)
                               :filter_values       (field->parameter-value query)})
        " */ "
        (qp.util/default-query->remark query)))

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -13,8 +13,8 @@
    [metabase.models.field :refer [Field]]
    [metabase.models.table :refer [Table]]
    [metabase.plugins.jdbc-proxy :as jdbc-proxy]
-   [metabase.public-settings :as public-settings]
    [metabase.query-processor :as qp]
+   [metabase.settings :as settings]
    [metabase.sync :as sync]
    [metabase.sync.util :as sync-util]
    [metabase.test :as mt]
@@ -90,7 +90,7 @@
                                  "LIMIT"
                                  "  2000"]]
                        (-> line
-                           (str/replace #"\Q{{site-uuid}}\E" (public-settings/site-uuid))
+                           (str/replace #"\Q{{site-uuid}}\E" (settings/site-uuid))
                            (str/replace #"\Q{{schema}}\E" (redshift.test/unique-session-schema))))]
         (is (= expected
                (sql->lines

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -26,13 +26,13 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema.temporal-bucketing :as lib.schema.temporal-bucketing]
    [metabase.models.secret :as secret]
-   [metabase.public-settings :as public-settings]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.timezone :as qp.timezone]
    [metabase.query-processor.util :as qp.util]
    [metabase.query-processor.util.add-alias-info :as add]
    [metabase.query-processor.util.relative-datetime :as qp.relative-datetime]
+   [metabase.settings :as settings]
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
    [metabase.util.honey-sql-2 :as h2x]
@@ -75,7 +75,7 @@
 (defn- start-of-week-setting->snowflake-offset
   "Value to use for the `WEEK_START` connection parameter -- see
   https://docs.snowflake.com/en/sql-reference/parameters.html#label-week-start -- based on
-  the [[metabase.public-settings/start-of-week]] Setting. Snowflake considers `:monday` to be `1`, through `:sunday`
+  the [[metabase.settings/start-of-week]] Setting. Snowflake considers `:monday` to be `1`, through `:sunday`
   as `7`."
   []
   (inc (driver.common/start-of-week->int)))
@@ -173,7 +173,7 @@
                 ;; stuff doesn't work, even though we ultimately override this when we set the session timezone
                 :timezone                                   "UTC"
                 ;; tell Snowflake to use the same start of week that we have set for the
-                ;; [[metabase.public-settings/start-of-week]] Setting.
+                ;; [[metabase.settings/start-of-week]] Setting.
                 :week_start                                 (start-of-week-setting->snowflake-offset)}
                (-> details
                    ;; original version of the Snowflake driver incorrectly used `dbname` in the details fields instead
@@ -730,7 +730,7 @@
                          :dashboardId dashboard-id
                          :databaseId  database-id
                          :queryHash   (when (bytes? query-hash) (codecs/bytes->hex query-hash))
-                         :serverId    (public-settings/site-uuid)}))
+                         :serverId    (settings/site-uuid)}))
 
 ;;; ------------------------------------------------- User Impersonation --------------------------------------------------
 

--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -24,9 +24,9 @@
    [metabase.lib.test-util :as lib.tu]
    [metabase.models :refer [Table]]
    [metabase.models.database :refer [Database]]
-   [metabase.public-settings :as public-settings]
    [metabase.query-processor :as qp]
    [metabase.query-processor.store :as qp.store]
+   [metabase.settings :as settings]
    [metabase.sync :as sync]
    [metabase.sync.util :as sync-util]
    [metabase.test :as mt]
@@ -697,7 +697,7 @@
   (testing "Queries should have a remark formatted as JSON appended to them with additional metadata"
     (mt/test-driver :snowflake
       (let [expected-map {"pulseId" nil
-                          "serverId" (public-settings/site-uuid)
+                          "serverId" (settings/site-uuid)
                           "client" "Metabase"
                           "queryHash" "cb83d4f6eedc250edb0f2c16f8d9a21e5d42f322ccece1494c8ef3d634581fe2"
                           "queryType" "query"

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -43,7 +43,7 @@
   e.g. [[metabase.driver.snowflake-test/report-timezone-test]].
 
   This is a function because [[unique-prefix]] can't be calculated until the application database is initialized
-  because it relies on [[public-settings/site-uuid]]."
+  because it relies on [[settings/site-uuid]]."
   #'sql.tu.unique-prefix/unique-prefix)
 
 (defn qualified-db-name

--- a/src/metabase/analytics/snowplow.clj
+++ b/src/metabase/analytics/snowplow.clj
@@ -8,7 +8,7 @@
    [metabase.config :as config]
    [metabase.models.setting :as setting :refer [defsetting Setting]]
    [metabase.models.user :refer [User]]
-   [metabase.public-settings :as public-settings]
+   [metabase.settings :as settings]
    [metabase.util.date-2 :as u.date]
    [metabase.util.i18n :refer [deferred-tru]]
    [metabase.util.log :as log]
@@ -84,7 +84,7 @@
   :type       :boolean
   :setter     :none
   :getter     (fn [] (and (snowplow-available)
-                          (public-settings/anon-tracking-enabled)))
+                          (settings/anon-tracking-enabled)))
   :visibility :public
   :doc        false)
 
@@ -180,8 +180,8 @@
   (new SelfDescribingJson
        (str "iglu:com.metabase/instance/jsonschema/" (schema->version ::instance))
        {"id"                           (analytics-uuid)
-        "version"                      {"tag" (:tag (public-settings/version))}
-        "token_features"               (m/map-keys name (public-settings/token-features))
+        "version"                      {"tag" (:tag (settings/version))}
+        "token_features"               (m/map-keys name (settings/token-features))
         "created_at"                   (instance-creation)
         "application_database"         (app-db-type)
         "application_database_version" (app-db-version)}))

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -21,7 +21,7 @@
             Table User]]
    [metabase.models.humanization :as humanization]
    [metabase.models.interface :as mi]
-   [metabase.public-settings :as public-settings]
+   [metabase.settings :as settings]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.log :as log]
    [toucan2.core :as t2]))
@@ -103,21 +103,21 @@
 (defn appearance-ui-colors-changed?
   "Returns true if the 'User Interface Colors' have been customized"
   []
-  (boolean (seq (select-keys (public-settings/application-colors) ui-colors))))
+  (boolean (seq (select-keys (settings/application-colors) ui-colors))))
 
 (defn appearance-chart-colors-changed?
   "Returns true if the 'Chart Colors' have been customized"
   []
-  (boolean (seq (apply dissoc (public-settings/application-colors) ui-colors))))
+  (boolean (seq (apply dissoc (settings/application-colors) ui-colors))))
 
 (defn- instance-settings
   "Figure out global info about this instance"
   []
   {:version                              (config/mb-version-info :tag)
    :running_on                           (environment-type)
-   :startup_time_millis                  (public-settings/startup-time-millis)
+   :startup_time_millis                  (settings/startup-time-millis)
    :application_database                 (config/config-str :mb-db-type)
-   :check_for_updates                    (public-settings/check-for-updates)
+   :check_for_updates                    (settings/check-for-updates)
    :report_timezone                      (driver/report-timezone)
    ; We deprecated advanced humanization but have this here anyways
    :friendly_names                       (= (humanization/humanization-strategy) "advanced")
@@ -128,19 +128,19 @@
    :has_sample_data                      (t2/exists? Database, :is_sample true)
    :enable_embedding                     (embed.settings/enable-embedding)
    :embedding_app_origin_set             (boolean (embed.settings/embedding-app-origin))
-   :appearance_site_name                 (not= (public-settings/site-name) "Metabase")
-   :appearance_help_link                 (public-settings/help-link)
-   :appearance_logo                      (not= (public-settings/application-logo-url) "app/assets/img/logo.svg")
-   :appearance_favicon                   (not= (public-settings/application-favicon-url) "app/assets/img/favicon.ico")
-   :appearance_loading_message           (not= (public-settings/loading-message) :doing-science)
-   :appearance_metabot_greeting          (not (public-settings/show-metabot))
-   :appearance_login_page_illustration   (public-settings/login-page-illustration)
-   :appearance_landing_page_illustration (public-settings/landing-page-illustration)
-   :appearance_no_data_illustration      (public-settings/no-data-illustration)
-   :appearance_no_object_illustration    (public-settings/no-object-illustration)
+   :appearance_site_name                 (not= (settings/site-name) "Metabase")
+   :appearance_help_link                 (settings/help-link)
+   :appearance_logo                      (not= (settings/application-logo-url) "app/assets/img/logo.svg")
+   :appearance_favicon                   (not= (settings/application-favicon-url) "app/assets/img/favicon.ico")
+   :appearance_loading_message           (not= (settings/loading-message) :doing-science)
+   :appearance_metabot_greeting          (not (settings/show-metabot))
+   :appearance_login_page_illustration   (settings/login-page-illustration)
+   :appearance_landing_page_illustration (settings/landing-page-illustration)
+   :appearance_no_data_illustration      (settings/no-data-illustration)
+   :appearance_no_object_illustration    (settings/no-object-illustration)
    :appearance_ui_colors                 (appearance-ui-colors-changed?)
    :appearance_chart_colors              (appearance-chart-colors-changed?)
-   :appearance_show_mb_links             (not (public-settings/show-metabase-links))})
+   :appearance_show_mb_links             (not (settings/show-metabase-links))})
 
 (defn- user-metrics
   "Get metrics based on user records.
@@ -452,7 +452,7 @@
   "generate a map of the usage stats for this instance"
   []
   (merge (instance-settings)
-         {:uuid      (public-settings/site-uuid)
+         {:uuid      (settings/site-uuid)
           :timestamp (t/offset-date-time)
           :stats     {:cache      (cache-metrics)
                       :collection (collection-metrics)
@@ -481,5 +481,5 @@
 (defn phone-home-stats!
   "Collect usage stats and phone them home"
   []
-  (when (public-settings/anon-tracking-enabled)
+  (when (settings/anon-tracking-enabled)
     (send-stats! (anonymous-usage-stats))))

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -33,11 +33,11 @@
    [metabase.models.query.permissions :as query-perms]
    [metabase.models.revision.last-edit :as last-edit]
    [metabase.models.timeline :as timeline]
-   [metabase.public-settings :as public-settings]
    [metabase.public-settings.premium-features :as premium-features]
    [metabase.query-processor.card :as qp.card]
    [metabase.query-processor.pivot :as qp.pivot]
    [metabase.server.middleware.offset-paging :as mw.offset-paging]
+   [metabase.settings :as settings]
    [metabase.task.persist-refresh :as task.persist-refresh]
    [metabase.upload :as upload]
    [metabase.util :as u]
@@ -879,7 +879,7 @@
   "This helper function exists to make testing the POST /api/card/from-csv endpoint easier."
   [{:keys [collection-id filename file]}]
   (try
-    (let [uploads-db-settings (public-settings/uploads-settings)
+    (let [uploads-db-settings (settings/uploads-settings)
           model (upload/create-csv-upload! {:collection-id collection-id
                                             :filename      filename
                                             :file          file

--- a/src/metabase/api/common/validation.clj
+++ b/src/metabase/api/common/validation.clj
@@ -5,8 +5,8 @@
    [metabase.config :as config]
    [metabase.embed.settings :as embed.settings]
    [metabase.plugins.classloader :as classloader]
-   [metabase.public-settings :as public-settings]
    [metabase.public-settings.premium-features :as premium-features]
+   [metabase.settings :as settings]
    [metabase.util.i18n :refer [tru]]))
 
 ;; TODO: figure out what other functions to move here from metabase.api.common
@@ -14,7 +14,7 @@
 (defn check-public-sharing-enabled
   "Check that the `public-sharing-enabled` Setting is `true`, or throw a `400`."
   []
-  (api/check (public-settings/enable-public-sharing)
+  (api/check (settings/enable-public-sharing)
              [400 (tru "Public sharing is not enabled.")]))
 
 (defn check-embedding-enabled

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -3,9 +3,9 @@
    [compojure.core :refer [GET]]
    [java-time.api :as t]
    [metabase.api.common :as api]
-   [metabase.public-settings :as public-settings]
    [metabase.search :as search]
    [metabase.server.middleware.offset-paging :as mw.offset-paging]
+   [metabase.settings :as settings]
    [metabase.util :as u]
    [metabase.util.malli.schema :as ms]
    [ring.util.response :as response]))
@@ -42,7 +42,7 @@
   []
   (api/check-superuser)
   (cond
-    (not (public-settings/experimental-fulltext-search-enabled))
+    (not (settings/experimental-fulltext-search-enabled))
     {:status-code 501, :message "Search index is not enabled."}
 
     (search/supports-index?)

--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -17,9 +17,9 @@
    [metabase.models.session :refer [Session]]
    [metabase.models.setting :as setting :refer [defsetting]]
    [metabase.models.user :as user :refer [User]]
-   [metabase.public-settings :as public-settings]
    [metabase.server.middleware.session :as mw.session]
    [metabase.server.request.util :as req.util]
+   [metabase.settings :as settings]
    [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru tru]]
    [metabase.util.log :as log]
@@ -81,7 +81,7 @@
    user         :- CreateSessionUserInfo
    device-info  :- req.util/DeviceInfo]
   ;; this is actually the same as `create-session!` for `:sso` but we check whether password login is enabled.
-  (when-not (public-settings/enable-password-login)
+  (when-not (settings/enable-password-login)
     (throw (ex-info (str (tru "Password login is disabled for this instance.")) {:status-code 400})))
   ((get-method create-session! :sso) session-type user device-info))
 
@@ -228,7 +228,7 @@
         ;; If user uses any SSO method to log in, no need to generate a reset token
         (messages/send-password-reset-email! email sso-source nil is-active?)
         (let [reset-token        (user/set-password-reset-token! user-id)
-              password-reset-url (str (public-settings/site-url) "/auth/reset_password/" reset-token)]
+              password-reset-url (str (settings/site-url) "/auth/reset_password/" reset-token)]
           (log/info password-reset-url)
           (messages/send-password-reset-email! email nil password-reset-url is-active?)))
       (events/publish-event! :event/password-reset-initiated

--- a/src/metabase/api/setup.clj
+++ b/src/metabase/api/setup.clj
@@ -17,9 +17,9 @@
    [metabase.models.session :refer [Session]]
    [metabase.models.setting.cache :as setting.cache]
    [metabase.models.user :as user :refer [User]]
-   [metabase.public-settings :as public-settings]
    [metabase.public-settings.premium-features :as premium-features]
    [metabase.server.middleware.session :as mw.session]
+   [metabase.settings :as settings]
    [metabase.setup :as setup]
    [metabase.util :as u]
    [metabase.util.i18n :as i18n :refer [tru]]
@@ -84,12 +84,12 @@
 
 (defn- setup-set-settings! [{:keys [email site-name site-locale]}]
   ;; set a couple preferences
-  (public-settings/site-name! site-name)
-  (public-settings/admin-email! email)
+  (settings/site-name! site-name)
+  (settings/admin-email! email)
   (when site-locale
-    (public-settings/site-locale! site-locale))
+    (settings/site-locale! site-locale))
   ;; default to `true` the setting will set itself correctly whether a boolean or boolean string is specified
-  (public-settings/anon-tracking-enabled! true))
+  (settings/anon-tracking-enabled! true))
 
 (api/defendpoint POST "/"
   "Special endpoint for creating the first user during setup. This endpoint both creates the user AND logs them in and

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -21,11 +21,11 @@
    [metabase.models.setting :refer [defsetting]]
    [metabase.models.user :as user]
    [metabase.plugins.classloader :as classloader]
-   [metabase.public-settings :as public-settings]
    [metabase.public-settings.premium-features :as premium-features]
    [metabase.server.middleware.offset-paging :as mw.offset-paging]
    [metabase.server.middleware.session :as mw.session]
    [metabase.server.request.util :as req.util]
+   [metabase.settings :as settings]
    [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru tru]]
    [metabase.util.malli.schema :as ms]
@@ -324,8 +324,8 @@
 (defn add-custom-homepage-info
   "Adds custom homepage dashboard information to the current user."
   [user]
-  (let [enabled? (public-settings/custom-homepage)
-        id       (public-settings/custom-homepage-dashboard)
+  (let [enabled? (settings/custom-homepage)
+        id       (settings/custom-homepage-dashboard)
         dash     (t2/select-one Dashboard :id id)
         valid?   (and enabled? id (some? dash) (not (:archived dash)) (mi/can-read? dash))]
     (assoc user

--- a/src/metabase/channel/slack.clj
+++ b/src/metabase/channel/slack.clj
@@ -5,10 +5,10 @@
    [metabase.channel.shared :as channel.shared]
    ;; TODO: integrations.slack should be migrated to channel.slack
    [metabase.integrations.slack :as slack]
-   [metabase.public-settings :as public-settings]
    [metabase.pulse.markdown :as markdown]
    [metabase.pulse.parameters :as pulse-params]
    [metabase.pulse.render :as render]
+   [metabase.settings :as settings]
    [metabase.util.malli :as mu]
    [metabase.util.urls :as urls]))
 
@@ -128,7 +128,7 @@
                          :fields [{:type "mrkdwn"
                                    :text (format "<%s | *Sent from %s by %s*>"
                                                  (pulse-params/dashboard-url (:id dashboard) (pulse-params/parameters pulse dashboard))
-                                                 (public-settings/site-name)
+                                                 (settings/site-name)
                                                  (-> pulse :creator :common_name))}]}
         filters         (pulse-params/parameters pulse dashboard)
         filter-fields   (for [filter filters]

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -15,16 +15,16 @@
    [metabase.events :as events]
    [metabase.logger :as logger]
    [metabase.models.cloud-migration :as cloud-migration]
-   [metabase.models.setting :as settings]
+   [metabase.models.setting :as setting]
    [metabase.plugins :as plugins]
    [metabase.plugins.classloader :as classloader]
-   [metabase.public-settings :as public-settings]
    [metabase.public-settings.premium-features
     :as premium-features
     :refer [defenterprise]]
    [metabase.sample-data :as sample-data]
    [metabase.server :as server]
    [metabase.server.handler :as handler]
+   [metabase.settings :as settings]
    [metabase.setup :as setup]
    [metabase.task :as task]
    [metabase.troubleshooting :as troubleshooting]
@@ -62,7 +62,7 @@
   []
   (let [hostname  (or (config/config-str :mb-jetty-host) "localhost")
         port      (config/config-int :mb-jetty-port)
-        site-url  (or (public-settings/site-url)
+        site-url  (or (settings/site-url)
                       (str "http://"
                            hostname
                            (when-not (= 80 port) (str ":" port))))
@@ -108,7 +108,7 @@
   ;; load any plugins as needed
   (plugins/load-plugins!)
   (init-status/set-progress! 0.3)
-  (settings/validate-settings-formatting!)
+  (setting/validate-settings-formatting!)
   ;; startup database.  validates connection & runs any necessary migrations
   (log/info "Setting up and migrating Metabase DB. Please sit tight, this may take a minute...")
   ;; Cal 2024-04-03:
@@ -156,7 +156,7 @@
   (ensure-audit-db-installed!)
   (init-status/set-progress! 0.95)
 
-  (settings/migrate-encrypted-settings!)
+  (setting/migrate-encrypted-settings!)
   ;; start scheduler at end of init!
   (task/start-scheduler!)
   ;; load the channels
@@ -172,7 +172,7 @@
   []
   (let [start-time (t/zoned-date-time)]
     (init!*)
-    (public-settings/startup-time-millis!
+    (settings/startup-time-millis!
      (.toMillis (t/duration start-time (t/zoned-date-time))))))
 
 ;;; -------------------------------------------------- Normal Start --------------------------------------------------

--- a/src/metabase/driver/common.clj
+++ b/src/metabase/driver/common.clj
@@ -4,7 +4,7 @@
    [clojure.string :as str]
    [metabase.driver :as driver]
    [metabase.models.setting :as setting]
-   [metabase.public-settings :as public-settings]
+   [metabase.settings :as settings]
    [metabase.util.i18n :refer [deferred-tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]))
@@ -214,7 +214,7 @@
   {:name   "cloud-ip-address-info"
    :type   :info
    :getter (fn []
-             (when-let [ips (public-settings/cloud-gateway-ips)]
+             (when-let [ips (settings/cloud-gateway-ips)]
                (str (deferred-tru
                      (str "If your database is behind a firewall, you may need to allow connections from our Metabase "
                           "[Cloud IP addresses](https://www.metabase.com/cloud/docs/ip-addresses-to-whitelist.html):"))
@@ -321,13 +321,13 @@
   [:monday :tuesday :wednesday :thursday :friday :saturday :sunday])
 
 (def ^:dynamic *start-of-week*
-  "Used to override the [[metabase.public-settings/start-of-week]] settings.
+  "Used to override the [[metabase.settings/start-of-week]] settings.
   Primarily being used to calculate week-of-year in US modes where the start-of-week is always Sunday.
   More in (defmethod date [:sql :week-of-year-us])."
   nil)
 
 (mu/defn start-of-week->int :- [:int {:min 0, :max 6, :error/message "Start of week integer"}]
-  "Returns the int value for the current [[metabase.public-settings/start-of-week]] Setting value, which ranges from
+  "Returns the int value for the current [[metabase.settings/start-of-week]] Setting value, which ranges from
   `0` (`:monday`) to `6` (`:sunday`). This is guaranteed to return a value."
   {:added "0.42.0"}
   []
@@ -336,7 +336,7 @@
 (defn start-of-week-offset-for-day
   "Like [[start-of-week-offset]] but takes a `start-of-week` keyword like `:sunday` rather than ` driver`. Returns the
   offset (as a negative number) needed to adjust a day of week in the range 1..7 with `start-of-week` as one to a day
-  of week in the range 1..7 with [[metabase.public-settings/start-of-week]] as 1."
+  of week in the range 1..7 with [[metabase.settings/start-of-week]] as 1."
   [start-of-week]
   (let [db-start-of-week     (.indexOf days-of-week start-of-week)
         target-start-of-week (start-of-week->int)
@@ -346,13 +346,13 @@
 
 (mu/defn start-of-week-offset :- :int
   "Return the offset needed to adjust a day of the week (in the range 1..7) returned by the `driver`, with `1`
-  corresponding to [[driver/db-start-of-week]], so that `1` corresponds to [[metabase.public-settings/start-of-week]] in
+  corresponding to [[driver/db-start-of-week]], so that `1` corresponds to [[metabase.settings/start-of-week]] in
   results.
 
   e.g.
 
   If `:my-driver` returns [[driver/db-start-of-week]] as `:sunday` (1 is Sunday, 2 is Monday, and so forth),
-  and [[metabase.public-settings/start-of-week]] is `:monday` (the results should have 1 as Monday, 2 as Tuesday... 7 is
+  and [[metabase.settings/start-of-week]] is `:monday` (the results should have 1 as Monday, 2 as Tuesday... 7 is
   Sunday), then the offset should be `-1`, because `:monday` returned by the driver (`2`) minus `1` = `1`."
   [driver]
   (start-of-week-offset-for-day (driver/db-start-of-week driver)))

--- a/src/metabase/driver/ddl/interface.clj
+++ b/src/metabase/driver/ddl/interface.clj
@@ -4,7 +4,7 @@
    [metabase.driver :as driver]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.id :as lib.schema.id]
-   [metabase.public-settings :as public-settings]
+   [metabase.settings :as settings]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.malli :as mu])
   (:import
@@ -66,9 +66,9 @@
     ;; "2023-03-29T14:01:27.871697Z"
     :value (.format DateTimeFormatter/ISO_INSTANT (Instant/now))}
    {:key   "instance-uuid"
-    :value (public-settings/site-uuid)}
+    :value (settings/site-uuid)}
    {:key   "instance-name"
-    :value (public-settings/site-name)}])
+    :value (settings/site-name)}])
 
 (defn populate-kv-table-honey-sql-form
   "The honeysql form that populates the persisted schema `cache_info` table."

--- a/src/metabase/driver/mysql/ddl.clj
+++ b/src/metabase/driver/mysql/ddl.clj
@@ -8,8 +8,8 @@
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.sql.ddl :as sql.ddl]
-   [metabase.public-settings :as public-settings]
    [metabase.query-processor.compile :as qp.compile]
+   [metabase.settings :as settings]
    [metabase.util.i18n :refer [trs]]
    [metabase.util.log :as log])
   (:import
@@ -98,7 +98,7 @@
 
 (defmethod ddl.i/check-can-persist :mysql
   [{driver :engine, :as database}]
-  (let [schema-name (ddl.i/schema-name database (public-settings/site-uuid))
+  (let [schema-name (ddl.i/schema-name database (settings/site-uuid))
         table-name (format "persistence_check_%s" (rand-int 10000))
         db-spec (sql-jdbc.conn/db->pooled-connection-spec database)
         steps [[:persist.check/create-schema

--- a/src/metabase/driver/postgres/ddl.clj
+++ b/src/metabase/driver/postgres/ddl.clj
@@ -6,8 +6,8 @@
    [metabase.driver.ddl.interface :as ddl.i]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.sql.ddl :as sql.ddl]
-   [metabase.public-settings :as public-settings]
    [metabase.query-processor.compile :as qp.compile]
+   [metabase.settings :as settings]
    [metabase.util.log :as log]))
 
 (set! *warn-on-reflection* true)
@@ -64,7 +64,7 @@
 
 (defmethod ddl.i/check-can-persist :postgres
   [{driver :engine, :as database}]
-  (let [schema-name (ddl.i/schema-name database (public-settings/site-uuid))
+  (let [schema-name (ddl.i/schema-name database (settings/site-uuid))
         table-name  (format "persistence_check_%s" (rand-int 10000))
         steps       [[:persist.check/create-schema
                       (fn check-schema [conn]

--- a/src/metabase/driver/sql/ddl.clj
+++ b/src/metabase/driver/sql/ddl.clj
@@ -3,7 +3,7 @@
    [clojure.java.jdbc :as jdbc]
    [metabase.driver.ddl.interface :as ddl.i]
    [metabase.driver.sql.util :as sql.u]
-   [metabase.public-settings :as public-settings]))
+   [metabase.settings :as settings]))
 
 (defn- quote-fn [driver]
   (fn quote [ident entity]
@@ -36,21 +36,21 @@
   [{driver :engine :as database}]
   (let [q (quote-fn driver)]
     (format "create schema %s"
-            (q :table (ddl.i/schema-name database (public-settings/site-uuid))))))
+            (q :table (ddl.i/schema-name database (settings/site-uuid))))))
 
 (defn drop-schema-sql
   "SQL string to drop a schema suitable"
   [{driver :engine :as database}]
   (let [q (quote-fn driver)]
     (format "drop schema if exists %s"
-            (q :table (ddl.i/schema-name database (public-settings/site-uuid))))))
+            (q :table (ddl.i/schema-name database (settings/site-uuid))))))
 
 (defn create-table-sql
   "Formats a create table statement within our own cache schema"
   [{driver :engine :as database} definition query]
   (let [q (quote-fn driver)]
     (format "create table %s.%s as %s"
-            (q :table (ddl.i/schema-name database (public-settings/site-uuid)))
+            (q :table (ddl.i/schema-name database (settings/site-uuid)))
             (q :table (:table-name definition))
             query)))
 
@@ -59,5 +59,5 @@
   [{driver :engine :as database} table-name]
   (let [q (quote-fn driver)]
     (format "drop table if exists %s.%s"
-            (q :table (ddl.i/schema-name database (public-settings/site-uuid)))
+            (q :table (ddl.i/schema-name database (settings/site-uuid)))
             (q :table table-name))))

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -318,7 +318,7 @@
   [driver _ honeysql-expr]
   (week-of-year driver honeysql-expr :us))
 
-;; First week begins on 1st Jan, the 2nd week will begins on the 1st [[metabase.public-settings/start-of-week]]
+;; First week begins on 1st Jan, the 2nd week will begins on the 1st [[metabase.settings/start-of-week]]
 (defmethod date [:sql :week-of-year-instance]
   [driver _ honeysql-expr]
   (week-of-year driver honeysql-expr :instance))
@@ -351,7 +351,7 @@
       (truncate-fn expr))))
 
 (mu/defn adjust-day-of-week
-  "Adjust day of week to respect the [[metabase.public-settings/start-of-week]] Setting.
+  "Adjust day of week to respect the [[metabase.settings/start-of-week]] Setting.
 
   The value a `:day-of-week` extract should return depends on the value of `start-of-week`, by default Sunday.
 

--- a/src/metabase/embed/settings.clj
+++ b/src/metabase/embed/settings.clj
@@ -5,14 +5,14 @@
    [crypto.random :as crypto-random]
    [metabase.analytics.snowplow :as snowplow]
    [metabase.models.setting :as setting :refer [defsetting]]
-   [metabase.public-settings :as public-settings]
+   [metabase.settings :as settings]
    [metabase.util.embed :as embed]
    [metabase.util.i18n :as i18n :refer [deferred-tru]]
    [toucan2.core :as t2]))
 
 (defsetting embedding-app-origin
   (deferred-tru "Allow this origin to embed the full {0} application"
-                (public-settings/application-name-for-setting-descriptions))
+                (settings/application-name-for-setting-descriptions))
   :feature    :embedding
   :visibility :public
   :audit      :getter)

--- a/src/metabase/events/persisted_info.clj
+++ b/src/metabase/events/persisted_info.clj
@@ -3,7 +3,7 @@
    [metabase.events :as events]
    [metabase.models :refer [Database PersistedInfo]]
    [metabase.models.persisted-info :as persisted-info]
-   [metabase.public-settings :as public-settings]
+   [metabase.settings :as settings]
    [metabase.util.log :as log]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
@@ -20,7 +20,7 @@
     ;; If there is already a PersistedInfo, even in "off" or "deletable" state, we skip it as this
     ;; is only supposed to be that initial edge when the dataset is being changed.
     (when (and (= (:type card) :model)
-               (public-settings/persisted-models-enabled)
+               (settings/persisted-models-enabled)
                (get-in (t2/select-one Database :id (:database_id card)) [:settings :persist-models-enabled])
                (nil? (t2/select-one-fn :id PersistedInfo :card_id (:id card))))
       (persisted-info/turn-on-model! user-id card))

--- a/src/metabase/formatter.clj
+++ b/src/metabase/formatter.clj
@@ -7,8 +7,8 @@
    [clojure.string :as str]
    [hiccup.util]
    [metabase.formatter.datetime :as datetime]
-   [metabase.public-settings :as public-settings]
    [metabase.query-processor.streaming.common :as common]
+   [metabase.settings :as settings]
    [metabase.shared.models.visualization-settings :as mb.viz]
    [metabase.shared.util.currency :as currency]
    [metabase.types :as types]
@@ -137,7 +137,7 @@
         percent?           (or (isa? semantic_type :type/Percentage) (= number-style "percent"))
         scientific?        (= number-style "scientific")
         [decimal grouping] (or number-separators
-                               (get-in (public-settings/custom-formatting) [:type/Number :number_separators])
+                               (get-in (settings/custom-formatting) [:type/Number :number_separators])
                                ".,")
         symbols            (doto (DecimalFormatSymbols.)
                              (cond-> decimal (.setDecimalSeparator decimal))

--- a/src/metabase/formatter/datetime.clj
+++ b/src/metabase/formatter/datetime.clj
@@ -3,8 +3,8 @@
   (:require
    [clojure.string :as str]
    [java-time.api :as t]
-   [metabase.public-settings :as public-settings]
    [metabase.query-processor.streaming.common :as common]
+   [metabase.settings :as settings]
    [metabase.shared.formatting.constants :as constants]
    [metabase.shared.models.visualization-settings :as mb.viz]
    [metabase.util.date-2 :as u.date]
@@ -42,7 +42,7 @@
 (defn- x-of-y
   "Format an integer as x-th of y, for example, 2nd week of year."
   [n]
-  (let [nf (RuleBasedNumberFormat. (Locale. (public-settings/site-locale)) RuleBasedNumberFormat/ORDINAL)]
+  (let [nf (RuleBasedNumberFormat. (Locale. (settings/site-locale)) RuleBasedNumberFormat/ORDINAL)]
     (.format nf n)))
 
 (defn- hour-of-day
@@ -235,7 +235,7 @@ If neither a unit nor a temporal type is provided, just bottom out by assuming a
   desired output format."
   ([timezone-id temporal-str col] (format-temporal-str timezone-id temporal-str col {}))
   ([timezone-id temporal-str col viz-settings]
-   (Locale/setDefault (Locale. (public-settings/site-locale)))
+   (Locale/setDefault (Locale. (settings/site-locale)))
    (let [merged-viz-settings (common/normalize-keys
                               (common/viz-settings-for-col col viz-settings))]
      (if (str/blank? temporal-str)

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -34,10 +34,10 @@
    [metabase.models.revision :as revision]
    [metabase.models.serialization :as serdes]
    [metabase.moderation :as moderation]
-   [metabase.public-settings :as public-settings]
    [metabase.public-settings.premium-features :as premium-features :refer [defenterprise]]
    [metabase.query-analysis :as query-analysis]
    [metabase.query-processor.util :as qp.util]
+   [metabase.settings :as settings]
    [metabase.util :as u]
    [metabase.util.embed :refer [maybe-populate-initially-published-at]]
    [metabase.util.honey-sql-2 :as h2x]
@@ -540,7 +540,7 @@
   (-> card
       (dissoc :dataset_query_metrics_v2_migration_backup)
       (m/assoc-some :source_card_id (-> card :dataset_query source-card-id))
-      public-settings/remove-public-uuid-if-public-sharing-is-disabled))
+      settings/remove-public-uuid-if-public-sharing-is-disabled))
 
 (t2/define-before-insert :model/Card
   [card]

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -24,8 +24,8 @@
    [metabase.models.revision :as revision]
    [metabase.models.serialization :as serdes]
    [metabase.moderation :as moderation]
-   [metabase.public-settings :as public-settings]
    [metabase.query-processor.metadata :as qp.metadata]
+   [metabase.settings :as settings]
    [metabase.util :as u]
    [metabase.util.embed :refer [maybe-populate-initially-published-at]]
    [metabase.util.honey-sql-2 :as h2x]
@@ -181,7 +181,7 @@
   [dashboard]
   (-> dashboard
       migrate-parameters-list
-      public-settings/remove-public-uuid-if-public-sharing-is-disabled))
+      settings/remove-public-uuid-if-public-sharing-is-disabled))
 
 (defmethod serdes/hash-fields :model/Dashboard
   [_dashboard]

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -19,8 +19,8 @@
    [metabase.models.session :refer [Session]]
    [metabase.models.setting :as setting :refer [defsetting]]
    [metabase.plugins.classloader :as classloader]
-   [metabase.public-settings :as public-settings]
    [metabase.public-settings.premium-features :as premium-features]
+   [metabase.settings :as settings]
    [metabase.setup :as setup]
    [metabase.util :as u]
    [metabase.util.honey-sql-2 :as h2x]
@@ -321,10 +321,10 @@
 
 (defn- send-welcome-email! [new-user invitor sent-from-setup?]
   (let [reset-token               (set-password-reset-token! (u/the-id new-user))
-        should-link-to-login-page (and (public-settings/sso-enabled?)
-                                       (not (public-settings/enable-password-login)))
+        should-link-to-login-page (and (settings/sso-enabled?)
+                                       (not (settings/enable-password-login)))
         join-url                  (if should-link-to-login-page
-                                    (str (public-settings/site-url) "/auth/login")
+                                    (str (settings/site-url) "/auth/login")
                                     ;; NOTE: the new user join url is just a password reset with an indicator that this is a first time user
                                     (str (form-password-reset-url reset-token) "#new"))]
     (classloader/require 'metabase.email.messages)
@@ -426,7 +426,7 @@
   "Generate a properly formed password reset url given a password reset token."
   [reset-token]
   {:pre [(string? reset-token)]}
-  (str (public-settings/site-url) "/auth/reset_password/" reset-token))
+  (str (settings/site-url) "/auth/reset_password/" reset-token))
 
 (defn set-permissions-groups!
   "Set the user's group memberships to equal the supplied group IDs. Returns `true` if updates were made, `nil`

--- a/src/metabase/pulse/markdown.clj
+++ b/src/metabase/pulse/markdown.clj
@@ -4,7 +4,7 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.walk :as walk]
-   [metabase.public-settings :as public-settings]
+   [metabase.settings :as settings]
    [metabase.util :as u])
   (:import
    (com.vladsch.flexmark.ast AutoLink BlockQuote BulletList BulletListItem Code Emphasis FencedCodeBlock HardLineBreak
@@ -205,7 +205,7 @@
                               (cond-> s
                                 (not (str/ends-with? s "/")) (str "/"))))]
     (when uri
-      (if-let [^String site-url (ensure-slash (public-settings/site-url))]
+      (if-let [^String site-url (ensure-slash (settings/site-url))]
         (.. (URI. site-url) (resolve uri) toString)
         uri))))
 

--- a/src/metabase/pulse/parameters.clj
+++ b/src/metabase/pulse/parameters.clj
@@ -2,8 +2,8 @@
   "Utilities for processing parameters for inclusion in dashboard subscriptions."
   (:require
    [clojure.string :as str]
-   [metabase.public-settings :as public-settings]
    [metabase.public-settings.premium-features :refer [defenterprise]]
+   [metabase.settings :as settings]
    [metabase.shared.parameters.parameters :as shared.params]
    [metabase.util :as u]
    [metabase.util.urls :as urls]
@@ -35,7 +35,7 @@
   [parameter]
   (let [tyype  (:type parameter)
         values (param-val-or-default parameter)]
-    (try (shared.params/formatted-value tyype values (public-settings/site-locale))
+    (try (shared.params/formatted-value tyype values (settings/site-locale))
          (catch Throwable _
            (shared.params/formatted-list (u/one-or-many values))))))
 
@@ -71,4 +71,4 @@
                                        (assoc m tag-name (get param-id->param param-id))))
                                    {}
                                    tag-names)]
-    (update-in dashcard [:visualization_settings :text] shared.params/substitute-tags tag->param (public-settings/site-locale) (escape-markdown-chars? dashcard))))
+    (update-in dashcard [:visualization_settings :text] shared.params/substitute-tags tag->param (settings/site-locale) (escape-markdown-chars? dashcard))))

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -5,7 +5,6 @@
    [medley.core :as m]
    [metabase.formatter :as formatter]
    [metabase.models.timeline-event :as timeline-event]
-   [metabase.public-settings :as public-settings]
    [metabase.pulse.render.color :as color]
    [metabase.pulse.render.image-bundle :as image-bundle]
    [metabase.pulse.render.js-svg :as js-svg]
@@ -13,6 +12,7 @@
    [metabase.pulse.render.table :as table]
    [metabase.query-processor.streaming :as qp.streaming]
    [metabase.query-processor.streaming.common :as common]
+   [metabase.settings :as settings]
    [metabase.shared.models.visualization-settings :as mb.viz]
    [metabase.types :as types]
    [metabase.util :as u]
@@ -174,7 +174,7 @@
        timezone-id
        remapping-lookup
        cols
-       (take (min (public-settings/attachment-table-row-limit) 100) rows)
+       (take (min (settings/attachment-table-row-limit) 100) rows)
        viz-settings
        data-attributes)))))
 
@@ -239,7 +239,7 @@
                                       {:cols-for-color-lookup (mapv :name ordered-cols)
                                        :col-names             (common/column-titles ordered-cols (::mb.viz/column-settings viz-settings) format-rows?)}
                                       (prep-for-html-rendering timezone-id card data))
-                                     (render-truncation-warning (public-settings/attachment-table-row-limit) (count rows))]]
+                                     (render-truncation-warning (settings/attachment-table-row-limit) (count rows))]]
     {:attachments
      nil
 
@@ -308,7 +308,7 @@
   [x-col y-col {::mb.viz/keys [column-settings] :as viz-settings}]
   (let [x-col-settings (settings-from-column x-col column-settings)
         y-col-settings (settings-from-column y-col column-settings)]
-    (cond-> {:colors (public-settings/application-colors)
+    (cond-> {:colors (settings/application-colors)
              :visualization_settings (or viz-settings {})}
       x-col-settings
       (assoc :x x-col-settings)
@@ -320,7 +320,7 @@
   is an optional string of decimal and grouping symbols to be used, ie \".,\". There will soon be a values.clj file
   that will handle this but this is here in the meantime."
   ([value]
-   (format-percentage value (get-in (public-settings/custom-formatting) [:type/Number :number_separators])))
+   (format-percentage value (get-in (settings/custom-formatting) [:type/Number :number_separators])))
   ([value [decimal grouping]]
    (let [base "#,###.##%"
          fmt (if (or decimal grouping)

--- a/src/metabase/pulse/render/js_svg.clj
+++ b/src/metabase/pulse/render/js_svg.clj
@@ -7,9 +7,9 @@
    [cheshire.core :as json]
    [clojure.string :as str]
    [metabase.config :as config]
-   [metabase.public-settings :as public-settings]
    [metabase.pulse.render.js-engine :as js]
-   [metabase.pulse.render.style :as style])
+   [metabase.pulse.render.style :as style]
+   [metabase.settings :as settings])
   (:import
    (java.io ByteArrayInputStream ByteArrayOutputStream)
    (java.nio.charset StandardCharsets)
@@ -151,7 +151,7 @@
   (let [response (.asString (js/execute-fn-name (context) "javascript_visualization"
                                                 (json/generate-string cards-with-data)
                                                 (json/generate-string dashcard-viz-settings)
-                                                (json/generate-string (public-settings/application-colors))))]
+                                                (json/generate-string (settings/application-colors))))]
     (-> response
         (json/parse-string true)
         (update :type (fnil keyword "unknown")))))
@@ -162,7 +162,7 @@
   (let [svg-string (.asString (js/execute-fn-name (context) "row_chart"
                                                   (json/generate-string settings)
                                                   (json/generate-string data)
-                                                  (json/generate-string (public-settings/application-colors))))]
+                                                  (json/generate-string (settings/application-colors))))]
     (svg-string->bytes svg-string)))
 
 (defn gauge
@@ -180,7 +180,7 @@
   (let [js-res (js/execute-fn-name (context) "progress"
                                    (json/generate-string {:value value :goal goal})
                                    (json/generate-string settings)
-                                   (json/generate-string (public-settings/application-colors)))
+                                   (json/generate-string (settings/application-colors)))
         svg-string (.asString js-res)]
     (svg-string->bytes svg-string)))
 

--- a/src/metabase/pulse/render/style.clj
+++ b/src/metabase/pulse/render/style.clj
@@ -3,7 +3,7 @@
   (:require
    [clojure.java.io :as io]
    [clojure.string :as str]
-   [metabase.public-settings :as public-settings]
+   [metabase.settings :as settings]
    [metabase.util.i18n :refer [trs]]
    [metabase.util.log :as log])
   (:import
@@ -65,12 +65,12 @@
 (defn primary-color
   "Primary color to use in Pulses; normally 'classic' MB blue, but customizable when whitelabeling is enabled."
   []
-  (public-settings/application-color))
+  (settings/application-color))
 
 (defn secondary-color
   "Secondary color to use in Pulse charts; normally red, but customizable when whitelabeling is enabled."
   []
-  (public-settings/secondary-chart-color))
+  (settings/secondary-chart-color))
 
 (defn font-style
   "Font family to use in rendered Pulses."

--- a/src/metabase/query_analysis.clj
+++ b/src/metabase/query_analysis.clj
@@ -10,9 +10,9 @@
    [metabase.legacy-mbql.util :as mbql.u]
    [metabase.lib.core :as lib]
    [metabase.lib.util :as lib.util]
-   [metabase.public-settings :as public-settings]
    [metabase.query-analysis.native-query-analyzer :as nqa]
    [metabase.query-analysis.native-query-analyzer.replacement :as nqa.replacement]
+   [metabase.settings :as settings]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.queue :as queue]
@@ -74,9 +74,9 @@
 (defn enabled-type?
   "Is analysis of the given query type enabled?"
   [query-type]
-  (and (public-settings/query-analysis-enabled)
+  (and (settings/query-analysis-enabled)
        (case query-type
-         :native     (public-settings/sql-parsing-enabled)
+         :native     (settings/sql-parsing-enabled)
          :query      true
          :mbql/query true
          false)))

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -11,13 +11,13 @@
    [java-time.api :as t]
    [medley.core :as m]
    [metabase.config :as config]
-   [metabase.public-settings :as public-settings]
    [metabase.query-processor.middleware.cache-backend.db :as backend.db]
    [metabase.query-processor.middleware.cache-backend.interface :as i]
    [metabase.query-processor.middleware.cache.impl :as impl]
    [metabase.query-processor.pipeline :as qp.pipeline]
    [metabase.query-processor.schema :as qp.schema]
    [metabase.query-processor.util :as qp.util]
+   [metabase.settings :as settings]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu])
@@ -42,8 +42,8 @@
 
 (defn- purge! [backend]
   (try
-    (log/tracef "Purging cache entries older than %s" (u/format-seconds (public-settings/query-caching-max-ttl)))
-    (i/purge-old-entries! backend (public-settings/query-caching-max-ttl))
+    (log/tracef "Purging cache entries older than %s" (u/format-seconds (settings/query-caching-max-ttl)))
+    (i/purge-old-entries! backend (settings/query-caching-max-ttl))
     (log/trace "Successfully purged old cache entries.")
     :done
     (catch Throwable e
@@ -84,7 +84,7 @@
     :done
     (catch Throwable e
       (if (= (:type (ex-data e)) ::impl/max-bytes)
-        (log/debugf e "Not caching results: results are larger than %s KB" (public-settings/query-caching-max-kb))
+        (log/debugf e "Not caching results: results are larger than %s KB" (settings/query-caching-max-kb))
         (log/errorf e "Error saving query results to cache: %s" (ex-message e))))))
 
 (defn- save-results-xform [start-time-ns metadata query-hash strategy rf]
@@ -214,7 +214,7 @@
                 (save-results-xform start-time-ns metadata query-hash cache-strategy (rff metadata)))))))))
 
 (defn- is-cacheable? {:arglists '([query])} [{:keys [cache-strategy]}]
-  (and (public-settings/enable-query-caching)
+  (and (settings/enable-query-caching)
        (some? cache-strategy)
        (not= (:type cache-strategy) :nocache)))
 

--- a/src/metabase/query_processor/middleware/cache/impl.clj
+++ b/src/metabase/query_processor/middleware/cache/impl.clj
@@ -1,7 +1,7 @@
 (ns metabase.query-processor.middleware.cache.impl
   (:require
    [flatland.ordered.map :as ordered-map]
-   [metabase.public-settings :as public-settings]
+   [metabase.settings :as settings]
    [metabase.util :as u]
    [metabase.util.i18n :refer [trs]]
    [metabase.util.log :as log]
@@ -70,7 +70,7 @@
           (in obj))
         (result)))"
   ([f]
-   (do-with-serialization f {:max-bytes (* (public-settings/query-caching-max-kb) 1024)}))
+   (do-with-serialization f {:max-bytes (* (settings/query-caching-max-kb) 1024)}))
 
   ([f {:keys [max-bytes]}]
    (with-open [bos (ByteArrayOutputStream.)]

--- a/src/metabase/query_processor/middleware/fetch_source_query.clj
+++ b/src/metabase/query_processor/middleware/fetch_source_query.clj
@@ -11,10 +11,10 @@
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.lib.walk :as lib.walk]
-   [metabase.public-settings :as public-settings]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.util.persisted-cache :as qp.persisted]
+   [metabase.settings :as settings]
    [metabase.util :as u]
    [metabase.util.i18n :refer [trs tru]]
    [metabase.util.log :as log]
@@ -49,7 +49,7 @@
     (when persisted?
       (log/infof "Found substitute cached query for card %s from %s.%s"
                  card-id
-                 (ddl.i/schema-name {:id (:database-id card)} (public-settings/site-uuid))
+                 (ddl.i/schema-name {:id (:database-id card)} (settings/site-uuid))
                  (:table-name persisted-info)))
     (letfn [(update-stages [stages]
               (let [stages        (fix-mongodb-first-stage stages)
@@ -100,7 +100,7 @@
   (when (and (= (:lib/type stage) :mbql.stage/mbql)
              (:source-card stage))
     ;; make sure nested queries are enabled before resolving them.
-    (when-not (public-settings/enable-nested-queries)
+    (when-not (settings/enable-nested-queries)
       (throw (ex-info (trs "Nested queries are disabled")
                       {:type qp.error-type/disabled-feature, :card-id (:source-card stage)})))
     ;; If the first stage came from a different source card (i.e., we are doing recursive resolution) record the

--- a/src/metabase/query_processor/middleware/fetch_source_query_legacy.clj
+++ b/src/metabase/query_processor/middleware/fetch_source_query_legacy.clj
@@ -9,9 +9,9 @@
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema.id :as lib.schema.id]
-   [metabase.public-settings :as public-settings]
    [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.util.persisted-cache :as qp.persisted]
+   [metabase.settings :as settings]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
@@ -70,7 +70,7 @@
      (when (and persisted? log?)
        (log/infof "Found substitute cached query for card %s from %s.%s"
                   card-id
-                  (ddl.i/schema-name {:id database-id} (public-settings/site-uuid))
+                  (ddl.i/schema-name {:id database-id} (settings/site-uuid))
                   (:table-name persisted-info)))
      ;; log the query at this point, it's useful for some purposes
      (log/debugf "Fetched source query from Card %s:\n%s" card-id (u/pprint-to-str 'yellow source-query))

--- a/src/metabase/query_processor/middleware/limit.clj
+++ b/src/metabase/query_processor/middleware/limit.clj
@@ -2,9 +2,9 @@
   "Middleware that handles limiting the maximum number of rows returned by a query."
   (:require
    [metabase.legacy-mbql.util :as mbql.u]
-   [metabase.public-settings :as public-settings]
    [metabase.query-processor.interface :as qp.i]
-   [metabase.query-processor.util :as qp.util]))
+   [metabase.query-processor.util :as qp.util]
+   [metabase.settings :as settings]))
 
 ;;;; Pre-processing
 
@@ -39,7 +39,7 @@
   [query]
   (when-not (disable-max-results? query)
     (cond-> (or (mbql.u/query->max-rows-limit query)
-                (public-settings/download-row-limit)
+                (settings/download-row-limit)
                 qp.i/absolute-max-results)
       (xlsx-export? query)
       (min qp.i/absolute-max-results))))

--- a/src/metabase/query_processor/middleware/visualization_settings.clj
+++ b/src/metabase/query_processor/middleware/visualization_settings.clj
@@ -2,8 +2,8 @@
   (:require
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
-   [metabase.public-settings :as public-settings]
    [metabase.query-processor.store :as qp.store]
+   [metabase.settings :as settings]
    [metabase.shared.models.visualization-settings :as mb.viz]))
 
 (defn- normalize-field-settings
@@ -72,7 +72,7 @@
           updated-column-viz-settings  (if (= (:type query) :query)
                                          (update-card-viz-settings column-viz-settings field-ids)
                                          column-viz-settings)
-          global-settings              (update-vals (public-settings/custom-formatting)
+          global-settings              (update-vals (settings/custom-formatting)
                                                     mb.viz/db->norm-column-settings-entries)
           updated-card-viz-settings    (-> normalized-card-viz-settings
                                            (assoc ::mb.viz/column-settings updated-column-viz-settings)

--- a/src/metabase/query_processor/streaming/common.clj
+++ b/src/metabase/query_processor/streaming/common.clj
@@ -3,9 +3,9 @@
   (:require
    [clojure.string :as str]
    [java-time.api :as t]
-   [metabase.public-settings :as public-settings]
    [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.timezone :as qp.timezone]
+   [metabase.settings :as settings]
    [metabase.shared.models.visualization-settings :as mb.viz]
    [metabase.shared.util.currency :as currency]
    [metabase.util.date-2 :as u.date])
@@ -70,7 +70,7 @@
   "Merge format settings defined in the localization preferences into the format settings
   for a single column."
   [format-settings global-settings-key]
-  (let [global-settings (get (public-settings/custom-formatting) global-settings-key)
+  (let [global-settings (get (settings/custom-formatting) global-settings-key)
         normalized      (mb.viz/db->norm-column-settings-entries global-settings)]
     (merge normalized format-settings)))
 
@@ -172,14 +172,14 @@
     {}))
 
 (defn- ensure-global-viz-settings
-  "The ::mb.viz/global-column-settings comes from (public-settings/custom-formatting) and is provided by the query
+  "The ::mb.viz/global-column-settings comes from (settings/custom-formatting) and is provided by the query
   processor in the `metabase.query-processor.middleware.visualization-settings` middleware _if_ `process-viz-settings?`
   is truthy. This function checks to see if those settings have been provided and adds them if they are not present."
   [{::mb.viz/keys [global-column-settings] :as viz-settings}]
   (cond-> viz-settings
     (nil? global-column-settings)
     (assoc ::mb.viz/global-column-settings
-           (update-vals (public-settings/custom-formatting)
+           (update-vals (settings/custom-formatting)
                         mb.viz/db->norm-column-settings-entries))))
 
 (defn viz-settings-for-col

--- a/src/metabase/query_processor/util/persisted_cache.clj
+++ b/src/metabase/query_processor/util/persisted_cache.clj
@@ -7,7 +7,7 @@
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.models.persisted-info :as persisted-info]
-   [metabase.public-settings :as public-settings]
+   [metabase.settings :as settings]
    [metabase.util.malli :as mu]))
 
 (mu/defn can-substitute?
@@ -37,7 +37,7 @@
             (sql.u/quote-name
              driver
              :table
-             (ddl.i/schema-name {:id database-id} (public-settings/site-uuid)))
+             (ddl.i/schema-name {:id database-id} (settings/site-uuid)))
             (sql.u/quote-name
              driver
              :table

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -6,14 +6,14 @@
    [metabase.api.common :as api]
    [metabase.models.setting :refer [defsetting]]
    [metabase.permissions.util :as perms.u]
-   [metabase.public-settings :as public-settings]
+   [metabase.settings :as settings]
    [metabase.util.i18n :refer [deferred-tru]]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]))
 
 (defsetting search-typeahead-enabled
   (deferred-tru "Enable typeahead search in the {0} navbar?"
-                (public-settings/application-name-for-setting-descriptions))
+                (settings/application-name-for-setting-descriptions))
   :type       :boolean
   :default    true
   :visibility :authenticated

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -15,7 +15,6 @@
    [metabase.models.interface :as mi]
    [metabase.models.permissions :as perms]
    [metabase.permissions.util :as perms.u]
-   [metabase.public-settings :as public-settings]
    [metabase.public-settings.premium-features :as premium-features]
    [metabase.search.config
     :as search.config
@@ -23,6 +22,7 @@
    [metabase.search.filter :as search.filter]
    [metabase.search.scoring :as scoring]
    [metabase.search.util :as search.util]
+   [metabase.settings :as settings]
    [metabase.util :as u]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.i18n :refer [tru deferred-tru]]
@@ -548,7 +548,7 @@
 (defn- allowed-engine? [engine]
   (case engine
     :in-place true
-    :fulltext (public-settings/experimental-fulltext-search-enabled)))
+    :fulltext (settings/experimental-fulltext-search-enabled)))
 
 (defn- parse-engine [value]
   (or (when-not (str/blank? value)

--- a/src/metabase/server/middleware/misc.clj
+++ b/src/metabase/server/middleware/misc.clj
@@ -4,8 +4,8 @@
    [clojure.string :as str]
    [metabase.async.streaming-response]
    [metabase.db :as mdb]
-   [metabase.public-settings :as public-settings]
    [metabase.server.request.util :as req.util]
+   [metabase.settings :as settings]
    [metabase.util.log :as log])
   (:import
    (clojure.core.async.impl.channels ManyToManyChannel)
@@ -41,13 +41,13 @@
 ;; the (initial) value of `site-url`
 (defn- maybe-set-site-url* [{{:strs [origin x-forwarded-host host user-agent]} :headers, uri :uri}]
   (when (and (mdb/db-is-set-up?)
-             (not (public-settings/site-url))
+             (not (settings/site-url))
              (not= uri "/api/health")
              (or (nil? user-agent) ((complement str/includes?) user-agent "HealthChecker")))
     (when-let [site-url (or origin x-forwarded-host host)]
       (log/infof "Setting Metabase site URL to %s" site-url)
       (try
-        (public-settings/site-url! site-url)
+        (settings/site-url! site-url)
         (catch Throwable e
           (log/warn e "Failed to set site-url"))))))
 

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -7,8 +7,8 @@
    [metabase.analytics.snowplow :as snowplow]
    [metabase.config :as config]
    [metabase.embed.settings :as embed.settings]
-   [metabase.public-settings :as public-settings]
    [metabase.server.request.util :as req.util]
+   [metabase.settings :as settings]
    [metabase.util.log :as log]
    [ring.util.codec :refer [base64-encode]])
   (:import
@@ -65,7 +65,7 @@
                                  ["'self'"
                                   "https://maps.google.com"
                                   "https://accounts.google.com"
-                                  (when (public-settings/anon-tracking-enabled)
+                                  (when (settings/anon-tracking-enabled)
                                     "https://www.google-analytics.com")
                                    ;; for webpack hot reloading
                                   (when config/is-dev?
@@ -102,7 +102,7 @@
                                  ;; MailChimp. So people can sign up for the Metabase mailing list in the sign up process
                                  "metabase.us10.list-manage.com"
                                  ;; Snowplow analytics
-                                 (when (public-settings/anon-tracking-enabled)
+                                 (when (settings/anon-tracking-enabled)
                                    (snowplow/snowplow-url))
                                  ;; Webpack dev server
                                  (when config/is-dev?

--- a/src/metabase/server/middleware/session.clj
+++ b/src/metabase/server/middleware/session.clj
@@ -33,9 +33,9 @@
     :as setting
     :refer [*user-local-values* defsetting]]
    [metabase.models.user :as user :refer [User]]
-   [metabase.public-settings :as public-settings]
    [metabase.public-settings.premium-features :as premium-features]
    [metabase.server.request.util :as req.util]
+   [metabase.settings :as settings]
    [metabase.util :as u]
    [metabase.util.i18n :as i18n :refer [deferred-tru tru]]
    [metabase.util.log :as log]
@@ -174,7 +174,7 @@
 (defn- use-permanent-cookies?
   "Check if we should use permanent cookies for a given request, which are not cleared when a browser sesion ends."
   [request]
-  (if (public-settings/session-cookies)
+  (if (settings/session-cookies)
     ;; Disallow permanent cookies if MB_SESSION_COOKIES is set
     false
     ;; Otherwise check whether the user selected "remember me" during login

--- a/src/metabase/server/middleware/ssl.clj
+++ b/src/metabase/server/middleware/ssl.clj
@@ -2,8 +2,8 @@
   "Middleware for redirecting users to HTTPS sessions"
   (:require
    [clojure.string :as str]
-   [metabase.public-settings :as public-settings]
    [metabase.server.request.util :as req.util]
+   [metabase.settings :as settings]
    [ring.util.request :as req]
    [ring.util.response :as response]))
 
@@ -19,7 +19,7 @@
 
 (defn- https-url [url-string]
   (let [url (java.net.URL. url-string)
-        site-url (java.net.URL. (public-settings/site-url))]
+        site-url (java.net.URL. (settings/site-url))]
     (str (java.net.URL. "https" (.getHost site-url) (.getPort site-url) (.getFile url)))))
 
 (defn- ssl-redirect-response
@@ -34,17 +34,17 @@
   [handler]
   (fn [request respond raise]
     (cond
-      (str/blank? (public-settings/site-url))
+      (str/blank? (settings/site-url))
       (handler request respond raise)
 
-      (not (str/starts-with? (public-settings/site-url) "https:"))
+      (not (str/starts-with? (settings/site-url) "https:"))
       (handler request respond raise)
 
       (no-redirect-https-uris (:uri request))
       (handler request respond raise)
 
       (and
-       (public-settings/redirect-all-requests-to-https)
+       (settings/redirect-all-requests-to-https)
        (not (req.util/https? request)))
       (respond (ssl-redirect-response request))
 

--- a/src/metabase/server/request/util.clj
+++ b/src/metabase/server/request/util.clj
@@ -6,7 +6,7 @@
    [clojure.string :as str]
    [java-time.api :as t]
    [metabase.config :as config]
-   [metabase.public-settings :as public-settings]
+   [metabase.settings :as settings]
    [metabase.util :as u]
    [metabase.util.i18n :refer [trs tru]]
    [metabase.util.log :as log]
@@ -83,10 +83,10 @@
   (some-> request (get-in [:headers "x-metabase-embedded"]) Boolean/parseBoolean))
 
 (defn ip-address
-  "The IP address a Ring `request` came from. Looks at the `public-settings/source-address-header` header (by default
+  "The IP address a Ring `request` came from. Looks at the `settings/source-address-header` header (by default
   `X-Forwarded-For`, or the `(:remote-addr request)` if not set."
   [{:keys [headers remote-addr]}]
-  (some-> (or (some->> (public-settings/source-address-header) (get headers))
+  (some-> (or (some->> (settings/source-address-header) (get headers))
               remote-addr)
           ;; first IP (if there are multiple) is the actual client -- see
           ;; https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For

--- a/src/metabase/server/routes.clj
+++ b/src/metabase/server/routes.clj
@@ -11,8 +11,8 @@
    [metabase.db :as mdb]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.plugins.classloader :as classloader]
-   [metabase.public-settings :as public-settings]
    [metabase.server.routes.index :as index]
+   [metabase.settings :as settings]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [ring.util.response :as response]))
@@ -31,14 +31,14 @@
 (defroutes ^:private public-routes
   (GET ["/question/:uuid.:export-format", :uuid u/uuid-regex, :export-format api.dataset/export-format-regex]
     [uuid export-format]
-    (redirect-including-query-string (format "%s/api/public/card/%s/query/%s" (public-settings/site-url) uuid export-format)))
+    (redirect-including-query-string (format "%s/api/public/card/%s/query/%s" (settings/site-url) uuid export-format)))
   (GET "*" [] index/public))
 
 ;; /embed routes. /embed/question/:token.:export-format redirects to /api/public/card/:token/query/:export-format
 (defroutes ^:private embed-routes
   (GET ["/question/:token.:export-format", :export-format api.dataset/export-format-regex]
     [token export-format]
-    (redirect-including-query-string (format "%s/api/embed/card/%s/query/%s" (public-settings/site-url) token export-format)))
+    (redirect-including-query-string (format "%s/api/embed/card/%s/query/%s" (settings/site-url) token export-format)))
   (GET "*" [] index/embed))
 
 (defroutes ^{:doc "Top-level ring routes for Metabase.", :arglists '([request] [request respond raise])} routes
@@ -47,7 +47,7 @@
         (respond nil)))
   ;; ^/$ -> index.html
   (GET "/" [] index/index)
-  (GET "/favicon.ico" [] (response/resource-response (public-settings/application-favicon-url)))
+  (GET "/favicon.ico" [] (response/resource-response (settings/application-favicon-url)))
   ;; ^/api/health -> Health Check Endpoint
   (GET "/api/health" []
     (if (init-status/complete?)

--- a/src/metabase/server/routes/index.clj
+++ b/src/metabase/server/routes/index.clj
@@ -9,7 +9,7 @@
    [hiccup.util]
    [metabase.core.initialization-status :as init-status]
    [metabase.models.setting :as setting]
-   [metabase.public-settings :as public-settings]
+   [metabase.settings :as settings]
    [metabase.util.embed :as embed]
    [metabase.util.i18n :as i18n :refer [trs]]
    [metabase.util.log :as log]
@@ -21,7 +21,7 @@
 (set! *warn-on-reflection* true)
 
 (defn- base-href []
-  (let [path (some-> (public-settings/site-url) io/as-url .getPath)]
+  (let [path (some-> (settings/site-url) io/as-url .getPath)]
     (str path "/")))
 
 (defn- escape-script [s]
@@ -83,11 +83,11 @@
       :bootstrapJSON        (escape-script (json/generate-string public-settings))
       :assetOnErrorJS       (load-inline-js "asset_loading_error")
       :userLocalizationJSON (escape-script (load-localization (:locale params)))
-      :siteLocalizationJSON (escape-script (load-localization (public-settings/site-locale)))
+      :siteLocalizationJSON (escape-script (load-localization (settings/site-locale)))
       :nonceJSON            (escape-script (json/generate-string nonce))
-      :language             (hiccup.util/escape-html (public-settings/site-locale))
-      :favicon              (hiccup.util/escape-html (public-settings/application-favicon-url))
-      :applicationName      (hiccup.util/escape-html (public-settings/application-name))
+      :language             (hiccup.util/escape-html (settings/site-locale))
+      :favicon              (hiccup.util/escape-html (settings/application-favicon-url))
+      :applicationName      (hiccup.util/escape-html (settings/application-name))
       :uri                  (hiccup.util/escape-html uri)
       :baseHref             (hiccup.util/escape-html (base-href))
       :embedCode            (when embeddable? (embed/head uri))

--- a/src/metabase/settings.clj
+++ b/src/metabase/settings.clj
@@ -1,4 +1,4 @@
-(ns metabase.public-settings
+(ns metabase.settings
   (:require
    [clojure.java.io :as io]
    [clojure.string :as str]

--- a/src/metabase/shared/util/internal/time.clj
+++ b/src/metabase/shared/util/internal/time.clj
@@ -57,7 +57,7 @@
   "The first day of the week varies by locale, but Metabase has a setting that overrides it.
   In JVM, we can just read the setting directly."
   []
-  ((requiring-resolve 'metabase.public-settings/start-of-week)))
+  ((requiring-resolve 'metabase.settings/start-of-week)))
 
 (def default-options
   "The default map of options."

--- a/src/metabase/task/analyze_queries.clj
+++ b/src/metabase/task/analyze_queries.clj
@@ -6,9 +6,9 @@
    [clojurewerkz.quartzite.jobs :as jobs]
    [clojurewerkz.quartzite.schedule.simple :as simple]
    [clojurewerkz.quartzite.triggers :as triggers]
-   [metabase.public-settings :as public-settings]
    [metabase.query-analysis :as query-analysis]
    [metabase.query-analysis.failure-map :as failure-map]
+   [metabase.settings :as settings]
    [metabase.task :as task]
    [metabase.util :as u]
    [metabase.util.log :as log])
@@ -44,7 +44,7 @@
             card-id    (u/the-id card-or-id)
             timer      (u/start-timer)
             card       (query-analysis/->analyzable card-or-id)]
-        (when (public-settings/query-analysis-enabled)
+        (when (settings/query-analysis-enabled)
           (if (failure-map/non-retryable? card)
             (log/warnf "Skipping analysis of Card %s as its query has caused failures in the past." card-id)
             (try

--- a/src/metabase/task/creator_sentiment_emails.clj
+++ b/src/metabase/task/creator_sentiment_emails.clj
@@ -10,8 +10,8 @@
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.email :as email]
    [metabase.email.messages :as messages]
-   [metabase.public-settings :as public-settings]
    [metabase.public-settings.premium-features :as premium-features]
+   [metabase.settings :as settings]
    [metabase.task :as task]
    [metabase.util.log :as log]
    [toucan2.core :as t2])
@@ -90,7 +90,7 @@
           all-creators  (fetch-creators (premium-features/enable-whitelabeling?))
           this-week?    (fn [c] (= current-week (-> c :email hash (mod 52))))
           recipients    (filter this-week? all-creators)
-          blob          (if (public-settings/anon-tracking-enabled)
+          blob          (if (settings/anon-tracking-enabled)
                           (fn [creator]
                             (user-instance-info instance-data creator))
                           (constantly nil))]

--- a/src/metabase/task/follow_up_emails.clj
+++ b/src/metabase/task/follow_up_emails.clj
@@ -9,7 +9,7 @@
    [metabase.email.messages :as messages]
    [metabase.models.setting :as setting]
    [metabase.models.user :as user :refer [User]]
-   [metabase.public-settings :as public-settings]
+   [metabase.settings :as settings]
    [metabase.task :as task]
    [metabase.util.date-2 :as u.date]
    [metabase.util.log :as log]
@@ -34,11 +34,11 @@
   []
   ;; we need access to email AND the instance must be opted into anonymous tracking AND have surveys enabled. Make sure email hasn't been sent yet
   (when (and (email/email-configured?)
-             (public-settings/anon-tracking-enabled)
+             (settings/anon-tracking-enabled)
              (email/surveys-enabled)
              (not (follow-up-email-sent)))
     ;; grab the oldest admins email address (likely the user who created this MB instance), that's who we'll send to
-    ;; TODO - Does it make to send to this user instead of `(public-settings/admin-email)`?
+    ;; TODO - Does it make to send to this user instead of `(settings/admin-email)`?
     (when-let [admin (t2/select-one User :is_superuser true, :is_active true, {:order-by [:date_joined]})]
       (try
         (messages/send-follow-up-email! (:email admin))

--- a/src/metabase/task/persist_refresh.clj
+++ b/src/metabase/task/persist_refresh.clj
@@ -17,9 +17,9 @@
     :as persisted-info
     :refer [PersistedInfo]]
    [metabase.models.task-history :as task-history]
-   [metabase.public-settings :as public-settings]
    [metabase.query-processor.middleware.limit :as limit]
    [metabase.query-processor.timezone :as qp.timezone]
+   [metabase.settings :as settings]
    [metabase.task :as task]
    [metabase.util :as u]
    [metabase.util.log :as log]
@@ -399,10 +399,10 @@
 
 (defn reschedule-refresh!
   "Reschedule refresh for all enabled databases. Removes all existing triggers, and schedules refresh for databases with
-  `:persist-models-enabled` in the settings at interval [[public-settings/persisted-model-refresh-cron-schedule]]."
+  `:persist-models-enabled` in the settings at interval [[settings/persisted-model-refresh-cron-schedule]]."
   []
   (let [dbs-with-persistence (filter (comp :persist-models-enabled :settings) (t2/select Database))
-        cron-schedule        (public-settings/persisted-model-refresh-cron-schedule)]
+        cron-schedule        (settings/persisted-model-refresh-cron-schedule)]
     (unschedule-all-refresh-triggers! refresh-job-key)
     (doseq [db dbs-with-persistence]
       (schedule-persistence-for-database! db cron-schedule))))
@@ -440,5 +440,5 @@
 (defmethod task/init! ::PersistPrune
   [_]
   (task/add-job! prune-job)
-  (when (public-settings/persisted-models-enabled)
+  (when (settings/persisted-models-enabled)
     (enable-persisting!)))

--- a/src/metabase/task/search_index.clj
+++ b/src/metabase/task/search_index.clj
@@ -2,8 +2,8 @@
   (:require
    [clojurewerkz.quartzite.jobs :as jobs]
    [clojurewerkz.quartzite.triggers :as triggers]
-   [metabase.public-settings :as public-settings]
    [metabase.search :as search]
+   [metabase.settings :as settings]
    [metabase.task :as task]
    [metabase.util.log :as log])
   (:import
@@ -15,7 +15,7 @@
 (jobs/defjob ^{DisallowConcurrentExecution false
                :doc                        "Populate Search Index"}
   SearchIndexing [_ctx]
-  (when (public-settings/experimental-fulltext-search-enabled)
+  (when (settings/experimental-fulltext-search-enabled)
     (log/info "Recreating search index from latest schema")
     (search/init-index! {:force-reset? true})
     (log/info "Populating search index")

--- a/src/metabase/task/send_anonymous_stats.clj
+++ b/src/metabase/task/send_anonymous_stats.clj
@@ -5,14 +5,14 @@
    [clojurewerkz.quartzite.schedule.cron :as cron]
    [clojurewerkz.quartzite.triggers :as triggers]
    [metabase.analytics.stats :as stats]
-   [metabase.public-settings :as public-settings]
+   [metabase.settings :as settings]
    [metabase.task :as task]
    [metabase.util.log :as log]))
 
 (set! *warn-on-reflection* true)
 
 (jobs/defjob ^{:doc "If we can collect usage data, do so and send it home"} SendAnonymousUsageStats [_]
-  (when (public-settings/anon-tracking-enabled)
+  (when (settings/anon-tracking-enabled)
     (log/debug "Sending anonymous usage stats.")
     (try
       ;; TODO: add in additional request params if anonymous tracking is enabled

--- a/src/metabase/task/sweep_query_analysis.clj
+++ b/src/metabase/task/sweep_query_analysis.clj
@@ -4,8 +4,8 @@
    [clojurewerkz.quartzite.jobs :as jobs]
    [clojurewerkz.quartzite.schedule.cron :as cron]
    [clojurewerkz.quartzite.triggers :as triggers]
-   [metabase.public-settings :as public-settings]
    [metabase.query-analysis :as query-analysis]
+   [metabase.settings :as settings]
    [metabase.task :as task]
    [metabase.util :as u]
    [metabase.util.log :as log]
@@ -86,7 +86,7 @@
 (jobs/defjob ^{DisallowConcurrentExecution true
                :doc                        "Backfill QueryField for cards created earlier. Runs once per instance."}
   SweepQueryAnalysis [_ctx]
-  (when (public-settings/query-analysis-enabled)
+  (when (settings/query-analysis-enabled)
     (sweep-query-analysis-loop!)))
 
 (defmethod task/init! ::SweepQueryAnalysis [_]

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -26,8 +26,8 @@
    [metabase.models.interface :as mi]
    [metabase.models.persisted-info :as persisted-info]
    [metabase.models.table :as table]
-   [metabase.public-settings :as public-settings]
    [metabase.public-settings.premium-features :as premium-features]
+   [metabase.settings :as settings]
    [metabase.sync :as sync]
    [metabase.sync.sync-metadata.fields :as sync-fields]
    [metabase.sync.sync-metadata.tables :as sync-tables]
@@ -436,7 +436,7 @@
                        [:= [:lower :name] [:lower :display_name]]]})))
 
 (defn- uploads-enabled? []
-  (some? (:db_id (public-settings/uploads-settings))))
+  (some? (:db_id (settings/uploads-settings))))
 
 (defn- can-use-uploads-error
   "Returns an ExceptionInfo object if the user cannot upload to the given database for the subset of reasons common to all uploads

--- a/src/metabase/upload/parsing.clj
+++ b/src/metabase/upload/parsing.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.string :as str]
    [java-time.api :as t]
-   [metabase.public-settings :as public-settings]
+   [metabase.settings :as settings]
    [metabase.util.i18n :refer [tru]])
   (:import
    (java.text NumberFormat ParsePosition)
@@ -20,7 +20,7 @@
   Includes:
     - number-separators: Decimal delimiter defaults to `.` and group delimiter defaults to `,`. Stored/returned as a string."
   []
-  {:number-separators (get-in (public-settings/custom-formatting) [:type/Number :number_separators] ".,")})
+  {:number-separators (get-in (settings/custom-formatting) [:type/Number :number_separators] ".,")})
 
 (defn- parse-bool
   "Parses a boolean value (true/t/yes/y/1 and false/f/no/n/0). Case-insensitive."

--- a/src/metabase/util/date_2.clj
+++ b/src/metabase/util/date_2.clj
@@ -218,7 +218,7 @@
     :year})
 
 (defn- start-of-week []
-  (keyword ((requiring-resolve 'metabase.public-settings/start-of-week))))
+  (keyword ((requiring-resolve 'metabase.settings/start-of-week))))
 
 (def ^:private ^{:arglists '(^java.time.DayOfWeek [k])} day-of-week*
   (let [m (u.date.common/static-instances DayOfWeek)]

--- a/src/metabase/util/embed.clj
+++ b/src/metabase/util/embed.clj
@@ -8,8 +8,8 @@
    [hiccup.core :refer [html]]
    [metabase.config :as config]
    [metabase.models.setting :as setting :refer [defsetting]]
-   [metabase.public-settings :as public-settings]
    [metabase.public-settings.premium-features :as premium-features]
+   [metabase.settings :as settings]
    [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru trs tru]]
    [ring.util.codec :as codec]))
@@ -23,10 +23,10 @@
 
      (oembed-url \"/x\") -> \"http://localhost:3000/api/public/oembed?url=x&format=json\""
   ^String [^String relative-url]
-  (str (public-settings/site-url)
+  (str (settings/site-url)
        "/api/public/oembed"
        ;; NOTE: some oEmbed consumers require `url` be the first param???
-       "?url=" (codec/url-encode (str (public-settings/site-url) relative-url))
+       "?url=" (codec/url-encode (str (settings/site-url) relative-url))
        "&format=json"))
 
 (defn- oembed-link

--- a/src/metabase/util/urls.clj
+++ b/src/metabase/util/urls.clj
@@ -6,12 +6,12 @@
    Functions for generating URLs not related to Metabase *objects* generally do not belong here, unless they are used in many places in the
    codebase; one-off URL-generation functions should go in the same namespaces or modules where they are used."
   (:require
-   [metabase.public-settings :as public-settings]))
+   [metabase.settings :as settings]))
 
 (defn site-url
   "Return the Notification Link Base URL if set by enterprise env var, or Site URL."
   []
-  (or (public-settings/notification-link-base-url) (public-settings/site-url)))
+  (or (settings/notification-link-base-url) (settings/site-url)))
 
 (defn archive-url
   "Return an appropriate URL to view the archive page."

--- a/src/metabase/xrays/automagic_dashboards/populate.clj
+++ b/src/metabase/xrays/automagic_dashboards/populate.clj
@@ -6,8 +6,8 @@
    [metabase.api.common :as api]
    [metabase.models.card :as card]
    [metabase.models.collection :as collection]
-   [metabase.public-settings :as public-settings]
    [metabase.query-processor.util :as qp.util]
+   [metabase.settings :as settings]
    [metabase.util.log :as log]
    [metabase.xrays.automagic-dashboards.filters :as filters]
    [metabase.xrays.automagic-dashboards.util :as magic.util]
@@ -48,7 +48,7 @@
       (create-collection! "Automatically Generated Dashboards" nil nil)))
 
 (defn colors
-  "A vector of colors used for coloring charts. Uses [[public-settings/application-colors]] for user choices."
+  "A vector of colors used for coloring charts. Uses [[settings/application-colors]] for user choices."
   []
   (let [order [:brand :accent1 :accent2 :accent3 :accent4 :accent5 :accent6 :accent7]
         colors-map (merge {:brand   "#509EE3"
@@ -59,7 +59,7 @@
                            :accent5 "#F2A86F"
                            :accent6 "#98D9D9"
                            :accent7 "#7172AD"}
-                          (public-settings/application-colors))]
+                          (settings/application-colors))]
     (into [] (map colors-map) order)))
 
 (defn- ensure-distinct-colors

--- a/test/metabase/analytics/snowplow_test.clj
+++ b/test/metabase/analytics/snowplow_test.clj
@@ -5,7 +5,7 @@
    [clojure.walk :as walk]
    [metabase.analytics.snowplow :as snowplow]
    [metabase.models.setting :as setting :refer [Setting]]
-   [metabase.public-settings :as public-settings]
+   [metabase.settings :as settings]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
@@ -102,8 +102,8 @@
       (snowplow/track-event! ::snowplow/account {:event :new-instance-created})
       (is (= {:schema "iglu:com.metabase/instance/jsonschema/1-1-2",
               :data {:id                           (snowplow/analytics-uuid)
-                     :version                      {:tag (:tag (public-settings/version))},
-                     :token_features               (public-settings/token-features)
+                     :version                      {:tag (:tag (settings/version))},
+                     :token_features               (settings/token-features)
                      :created_at                   (snowplow/instance-creation)
                      :application_database         (#'snowplow/app-db-type)
                      :application_database_version (#'snowplow/app-db-version)}}

--- a/test/metabase/api/downloads_exports_test.clj
+++ b/test/metabase/api/downloads_exports_test.clj
@@ -17,11 +17,11 @@
    [clojure.test :refer :all]
    [dk.ative.docjure.spreadsheet :as spreadsheet]
    [metabase.formatter :as formatter]
-   [metabase.public-settings :as public-settings]
    [metabase.pulse :as pulse]
    [metabase.pulse.test-util :as pulse.test-util]
    [metabase.query-processor.streaming.csv :as qp.csv]
    [metabase.query-processor.streaming.xlsx :as qp.xlsx]
+   [metabase.settings :as settings]
    [metabase.test :as mt])
   (:import
    (org.apache.poi.ss.usermodel DataFormatter)
@@ -632,7 +632,7 @@
 
 (deftest downloads-row-limit-test
   (testing "Downloads row limit works."
-    (mt/with-temporary-setting-values [public-settings/download-row-limit 1050000]
+    (mt/with-temporary-setting-values [settings/download-row-limit 1050000]
       (mt/dataset test-data
         (mt/with-temp [:model/Card card {:display       :table
                                          :dataset_query {:database (mt/id)

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -13,8 +13,8 @@
     :refer [LoginHistory PermissionsGroup PermissionsGroupMembership Pulse
             PulseChannel Session User]]
    [metabase.models.setting :as setting :refer [defsetting]]
-   [metabase.public-settings :as public-settings]
    [metabase.server.middleware.session :as mw.session]
+   [metabase.settings :as settings]
    [metabase.test :as mt]
    [metabase.test.data.users :as test.users]
    [metabase.test.fixtures :as fixtures]
@@ -144,7 +144,7 @@
   (testing "Test that source based throttling kicks in after the login failure threshold (50) has been reached"
     (with-redefs [api.session/login-throttlers          (cleaned-throttlers #'api.session/login-throttlers
                                                                             [:username :ip-address])
-                  public-settings/source-address-header (constantly "x-forwarded-for")]
+                  settings/source-address-header (constantly "x-forwarded-for")]
       (dotimes [n 50]
         (let [response    (send-login-request (format "user-%d" n)
                                               {"x-forwarded-for" "10.1.2.3"})
@@ -165,7 +165,7 @@
   (testing "The same as above, but ensure that throttling is done on a per request source basis."
     (with-redefs [api.session/login-throttlers          (cleaned-throttlers #'api.session/login-throttlers
                                                                             [:username :ip-address])
-                  public-settings/source-address-header (constantly "x-forwarded-for")]
+                  settings/source-address-header (constantly "x-forwarded-for")]
       (dotimes [n 50]
         (let [response    (send-login-request (format "user-%d" n)
                                               {"x-forwarded-for" "10.1.2.3"})

--- a/test/metabase/api/setup_test.clj
+++ b/test/metabase/api/setup_test.clj
@@ -15,7 +15,7 @@
    [metabase.models :refer [Database User]]
    [metabase.models.setting :as setting]
    [metabase.models.setting.cache-test :as setting.cache-test]
-   [metabase.public-settings :as public-settings]
+   [metabase.settings :as settings]
    [metabase.setup :as setup]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
@@ -80,7 +80,7 @@
             (testing "new User should be created"
               (is (t2/exists? User :email email)))
             (testing "Creating a new admin user should set the `admin-email` Setting"
-              (is (= email (public-settings/admin-email))))
+              (is (= email (settings/admin-email))))
             (testing "Should record :user-joined in the Audit Log (#12933)"
               (let [user-id (u/the-id (t2/select-one User :email email))]
                 (is (= {:topic    :user-joined
@@ -332,9 +332,9 @@
                     (t2/exists? Database :engine "h2", :name db-name))))
            (testing "Settings should not be changed"
              (is (not= site-name
-                       (public-settings/site-name)))
+                       (settings/site-name)))
              (is (= "en"
-                    (public-settings/site-locale))))
+                    (settings/site-locale))))
            (testing "Setup token should still be set"
              (is (= setup-token
                     (setup/setup-token))))))))))

--- a/test/metabase/dashboard_subscription_test.clj
+++ b/test/metabase/dashboard_subscription_test.clj
@@ -18,10 +18,10 @@
             User]]
    [metabase.models.data-permissions :as data-perms]
    [metabase.models.permissions-group :as perms-group]
-   [metabase.public-settings :as public-settings]
    [metabase.pulse]
    [metabase.pulse.render.body :as body]
    [metabase.pulse.test-util :as pulse.test-util]
+   [metabase.settings :as settings]
    [metabase.test :as mt]
    [metabase.util :as u]
    [toucan2.core :as t2]
@@ -744,7 +744,7 @@
                                                                card-id
                                                                model-id
                                                                dashboard-id]}]
-        (let [site-url (public-settings/site-url)]
+        (let [site-url (settings/site-url)]
           (testing "should returns all link cards and name are newly fetched"
             (doseq [[model id] [[Card card-id]
                                 [Table table-id]

--- a/test/metabase/driver/common/parameters/values_test.clj
+++ b/test/metabase/driver/common/parameters/values_test.clj
@@ -17,10 +17,10 @@
    [metabase.models.data-permissions :as data-perms]
    [metabase.models.permissions :as perms]
    [metabase.models.permissions-group :as perms-group]
-   [metabase.public-settings :as public-settings]
    [metabase.query-processor :as qp]
    [metabase.query-processor.middleware.permissions :as qp.perms]
    [metabase.query-processor.store :as qp.store]
+   [metabase.settings :as settings]
    [metabase.test :as mt]
    [metabase.util :as u]
    [toucan2.core :as t2]
@@ -403,7 +403,7 @@
                                       []))))
                     (testing "query hits persisted table"
                       (let [persisted-schema (ddl.i/schema-name {:id (mt/id)}
-                                                                (public-settings/site-uuid))
+                                                                (settings/site-uuid))
                             update-query     (format "update %s.%s set name = name || ' from cached table'"
                                                      persisted-schema (:table_name pi))
                             model-query (format "select c_orig.name, c_cached.name

--- a/test/metabase/driver/sql/test_util/unique_prefix.clj
+++ b/test/metabase/driver/sql/test_util/unique_prefix.clj
@@ -27,7 +27,7 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [java-time.api :as t]
-   [metabase.public-settings :as public-settings]
+   [metabase.settings :as settings]
    [metabase.util.date-2 :as u.date]))
 
 (defn- utc-date
@@ -40,7 +40,7 @@
    (unique-prefix* (utc-date)))
   ([local-date]
    {:pre [(instance? java.time.LocalDate local-date)]}
-   (-> (format "%s_%s_" local-date (public-settings/site-uuid))
+   (-> (format "%s_%s_" local-date (settings/site-uuid))
        (str/replace  #"-" "_"))))
 
 (def ^{:arglists '([])} unique-prefix

--- a/test/metabase/formatter/datetime_test.clj
+++ b/test/metabase/formatter/datetime_test.clj
@@ -3,7 +3,7 @@
    [clojure.test :refer :all]
    [medley.core :as m]
    [metabase.formatter.datetime :as datetime]
-   [metabase.public-settings :as public-settings]
+   [metabase.settings :as settings]
    [metabase.shared.models.visualization-settings :as mb.viz]
    [metabase.test :as mt]))
 
@@ -143,7 +143,7 @@
       (mt/with-temporary-setting-values [custom-formatting {:type/Temporal {:date_style      "MMMM D, YYYY"
                                                                             :date_abbreviate true}}]
         (let [global-settings (m/map-vals mb.viz/db->norm-column-settings-entries
-                                          (public-settings/custom-formatting))]
+                                          (settings/custom-formatting))]
           (is (= "Jul 16, 2020"
                  (datetime/format-temporal-str "UTC" now
                                                {:effective_type :type/Date}
@@ -151,7 +151,7 @@
       (mt/with-temporary-setting-values [custom-formatting {:type/Temporal {:date_style     "M/DD/YYYY"
                                                                             :date_separator "-"}}]
         (let [global-settings (m/map-vals mb.viz/db->norm-column-settings-entries
-                                          (public-settings/custom-formatting))]
+                                          (settings/custom-formatting))]
           (is (= "7-16-2020, 6:04 PM"
                  (datetime/format-temporal-str
                   "UTC"

--- a/test/metabase/models/login_history_test.clj
+++ b/test/metabase/models/login_history_test.clj
@@ -5,8 +5,8 @@
    [java-time.api :as t]
    [metabase.models :refer [LoginHistory User]]
    [metabase.models.login-history :as login-history]
-   [metabase.public-settings :as public-settings]
    [metabase.server.request.util :as req.util]
+   [metabase.settings :as settings]
    [metabase.test :as mt]
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
@@ -75,7 +75,7 @@
                                                       [:content :string]]]]]]]
                               @mt/inbox))
                   (let [message  (-> @mt/inbox (get email) first :body first :content)
-                        site-url (public-settings/site-url)]
+                        site-url (settings/site-url)]
                     (testing (format "\nMessage = %s\nsite-url = %s" (pr-str message) (pr-str site-url))
                       (is (string? message))
                       (when (string? message)

--- a/test/metabase/models/setting/cache_test.clj
+++ b/test/metabase/models/setting/cache_test.clj
@@ -5,7 +5,7 @@
    [metabase.models.setting :refer [Setting]]
    [metabase.models.setting-test :as setting-test]
    [metabase.models.setting.cache :as setting.cache]
-   [metabase.public-settings :as public-settings]
+   [metabase.settings :as settings]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [toucan2.core :as t2]))
@@ -139,8 +139,8 @@
 (deftest sync-test-3
   (mt/discard-setting-changes [site-locale]
     (clear-cache!)
-    (public-settings/site-locale! "en")
+    (settings/site-locale! "en")
     (simulate-another-instance-updating-setting! :site-locale "fr")
     (reset-last-update-check!)
     (is (= "fr"
-           (public-settings/site-locale)))))
+           (settings/site-locale)))))

--- a/test/metabase/public_settings/premium_features_test.clj
+++ b/test/metabase/public_settings/premium_features_test.clj
@@ -8,10 +8,10 @@
    [metabase.config :as config]
    [metabase.db.connection :as mdb.connection]
    [metabase.models.user :refer [User]]
-   [metabase.public-settings :as public-settings]
    [metabase.public-settings.premium-features
     :as premium-features
     :refer [defenterprise defenterprise-schema]]
+   [metabase.settings :as settings]
    [metabase.test :as mt]
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp]))
@@ -21,7 +21,7 @@
   (http-fake/with-fake-routes-in-isolation
     {{:address      (#'premium-features/token-status-url token @#'premium-features/token-check-url)
       :query-params {:users      (str (#'premium-features/cached-active-users-count))
-                     :site-uuid  (public-settings/site-uuid-for-premium-features-token-checks)
+                     :site-uuid  (settings/site-uuid-for-premium-features-token-checks)
                      :mb-version (:tag config/mb-version-info)}}
      (constantly premium-features-response)}
     (#'premium-features/fetch-token-status* token)))

--- a/test/metabase/public_settings_test.clj
+++ b/test/metabase/public_settings_test.clj
@@ -2,8 +2,8 @@
   (:require
    [clojure.test :refer :all]
    [metabase.models.setting :as setting]
-   [metabase.public-settings :as public-settings]
    [metabase.public-settings.premium-features :as premium-features]
+   [metabase.settings :as settings]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.util.i18n :as i18n :refer [tru]]))
@@ -15,40 +15,40 @@
 (deftest site-url-settings
   (testing "double-check that setting the `site-url` setting will automatically strip off trailing slashes"
     (mt/discard-setting-changes [site-url]
-      (public-settings/site-url! "http://localhost:3000/")
+      (settings/site-url! "http://localhost:3000/")
       (is (= "http://localhost:3000"
-             (public-settings/site-url))))))
+             (settings/site-url))))))
 
 (deftest site-url-settings-prepend-http
   (testing "double-check that setting the `site-url` setting will prepend `http://` if no protocol was specified"
     (mt/discard-setting-changes [site-url]
-      (public-settings/site-url! "localhost:3000")
+      (settings/site-url! "localhost:3000")
       (is (= "http://localhost:3000"
-             (public-settings/site-url))))))
+             (settings/site-url))))))
 
 (deftest site-url-settings-with-no-trailing-slash
   (mt/discard-setting-changes [site-url]
-    (public-settings/site-url! "http://localhost:3000")
+    (settings/site-url! "http://localhost:3000")
     (is (= "http://localhost:3000"
-           (public-settings/site-url)))))
+           (settings/site-url)))))
 
 (deftest site-url-settings-https
   (testing "if https:// was specified it should keep it"
     (mt/discard-setting-changes [site-url]
-      (public-settings/site-url! "https://localhost:3000")
+      (settings/site-url! "https://localhost:3000")
       (is (= "https://localhost:3000"
-             (public-settings/site-url))))))
+             (settings/site-url))))))
 
 (deftest site-url-settings-validate-site-url
   (testing "we should not be allowed to set an invalid `site-url` (#9850)"
     (mt/discard-setting-changes [site-url]
       (is (thrown?
            clojure.lang.ExceptionInfo
-           (public-settings/site-url! "http://https://www.camsaul.com"))))))
+           (settings/site-url! "http://https://www.camsaul.com"))))))
 
 (deftest site-url-settings-set-valid-domain-name
   (mt/discard-setting-changes [site-url]
-    (is (some? (public-settings/site-url! "https://www.camsaul.x")))))
+    (is (some? (settings/site-url! "https://www.camsaul.x")))))
 
 (deftest site-url-settings-nil-getter-when-invalid
   (testing "if `site-url` in the database is invalid, the getter for `site-url` should return `nil` (#9849)"
@@ -57,7 +57,7 @@
       (is (= "https://&"
              (setting/get-value-of-type :string :site-url)))
       (is (= nil
-             (public-settings/site-url))))))
+             (settings/site-url))))))
 
 (deftest site-url-settings-normalize
   (testing "We should normalize `site-url` when set via env var we should still normalize it (#9764)"
@@ -65,7 +65,7 @@
       (is (= "localhost:3000/"
              (setting/get-value-of-type :string :site-url)))
       (is (= "http://localhost:3000"
-             (public-settings/site-url))))))
+             (settings/site-url))))))
 
 (deftest invalid-site-url-env-var-test
   (testing (str "If `site-url` is set via an env var, and it's invalid, we should return `nil` rather than having the"
@@ -74,26 +74,26 @@
       (is (= "asd_12w31%$;"
              (setting/get-value-of-type :string :site-url)))
       (is (= nil
-             (public-settings/site-url))))))
+             (settings/site-url))))))
 
 (deftest site-url-should-update-https-redirect-test
   (testing "Changing `site-url` to non-HTTPS should disable forced HTTPS redirection"
     (mt/with-temporary-setting-values [site-url                       "https://example.com"
                                        redirect-all-requests-to-https true]
       (is (= true
-             (public-settings/redirect-all-requests-to-https)))
-      (public-settings/site-url! "http://example.com")
+             (settings/redirect-all-requests-to-https)))
+      (settings/site-url! "http://example.com")
       (is (= false
-             (public-settings/redirect-all-requests-to-https)))))
+             (settings/redirect-all-requests-to-https)))))
 
   (testing "Changing `site-url` to non-HTTPS should disable forced HTTPS redirection"
     (mt/with-temporary-setting-values [site-url                       "https://example.com"
                                        redirect-all-requests-to-https true]
       (is (= true
-             (public-settings/redirect-all-requests-to-https)))
-      (public-settings/site-url! "https://different.example.com")
+             (settings/redirect-all-requests-to-https)))
+      (settings/site-url! "https://different.example.com")
       (is (= true
-             (public-settings/redirect-all-requests-to-https))))))
+             (settings/redirect-all-requests-to-https))))))
 
 (deftest translate-public-setting
   (mt/with-mock-i18n-bundles! {"zz" {:messages {"Host" "HOST"}}}
@@ -116,14 +116,14 @@
                 "API (#9143)")
     (mt/discard-setting-changes [query-caching-max-kb]
       (is (= "1000"
-             (public-settings/query-caching-max-kb! "1000")))))
+             (settings/query-caching-max-kb! "1000")))))
 
   (testing "query-caching-max-kb should throw an error if you try to put in a huge value"
     (mt/discard-setting-changes [query-caching-max-kb]
       (is (thrown-with-msg?
            IllegalArgumentException
            #"Values greater than 204,800 \(200\.0 MB\) are not allowed"
-           (public-settings/query-caching-max-kb! (* 1024 1024)))))))
+           (settings/query-caching-max-kb! (* 1024 1024)))))))
 
 (deftest site-locale-validate-input-test
   (testing "site-locale should validate input"
@@ -132,37 +132,37 @@
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
              #"Invalid locale \"\""
-             (public-settings/site-locale! "")))
+             (settings/site-locale! "")))
         (is (= "en_US"
-               (public-settings/site-locale)))))
+               (settings/site-locale)))))
     (testing "non-existant locale"
       (mt/with-temporary-setting-values [site-locale "en_US"]
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
              #"Invalid locale \"en_EN\""
-             (public-settings/site-locale! "en_EN")))
+             (settings/site-locale! "en_EN")))
         (is (= "en_US"
-               (public-settings/site-locale)))))))
+               (settings/site-locale)))))))
 
 (deftest site-locale-normalize-input-test
   (testing "site-locale should normalize input"
     (mt/discard-setting-changes [site-locale]
-      (public-settings/site-locale! "en-us")
+      (settings/site-locale! "en-us")
       (is (= "en_US"
-             (public-settings/site-locale))))))
+             (settings/site-locale))))))
 
 (deftest unset-site-locale-test
   (testing "should be able to unset site-locale"
     (mt/discard-setting-changes [site-locale]
-      (public-settings/site-locale! "es")
-      (public-settings/site-locale! nil)
+      (settings/site-locale! "es")
+      (settings/site-locale! nil)
       (is (= "en"
-             (public-settings/site-locale))
+             (settings/site-locale))
           "should default to English"))))
 
 (deftest site-locale-only-return-valid-locales-test
   (mt/with-temporary-raw-setting-values [site-locale "wow_this_in_not_a_locale"]
-    (is (nil? (public-settings/site-locale)))))
+    (is (nil? (settings/site-locale)))))
 
 (deftest redirect-all-requests-to-https-test
   (testing "Shouldn't be allowed to set `redirect-all-requests-to-https` to `true` unless `site-url` is HTTPS"
@@ -171,29 +171,29 @@
         (testing "\n`site-url` *is* HTTPS"
           (mt/with-temporary-setting-values [site-url                       "https://example.com"
                                              redirect-all-requests-to-https false]
-            (public-settings/redirect-all-requests-to-https! v)
+            (settings/redirect-all-requests-to-https! v)
             (is (= true
-                   (public-settings/redirect-all-requests-to-https)))))
+                   (settings/redirect-all-requests-to-https)))))
 
         (testing "\n`site-url` is not HTTPS"
           (mt/with-temporary-setting-values [site-url                       "http://example.com"
                                              redirect-all-requests-to-https false]
             (is (thrown?
                  AssertionError
-                 (public-settings/redirect-all-requests-to-https! v)))
+                 (settings/redirect-all-requests-to-https! v)))
             (is (= false
-                   (public-settings/redirect-all-requests-to-https)))))))))
+                   (settings/redirect-all-requests-to-https)))))))))
 
 (deftest cloud-gateway-ips-test
   (mt/with-temp-env-var-value! [mb-cloud-gateway-ips "1.2.3.4,5.6.7.8"]
     (with-redefs [premium-features/is-hosted? (constantly true)]
       (testing "Setting returns ips given comma delimited ips."
         (is (= ["1.2.3.4" "5.6.7.8"]
-               (public-settings/cloud-gateway-ips)))))
+               (settings/cloud-gateway-ips)))))
 
     (testing "Setting returns nil in self-hosted environments"
       (with-redefs [premium-features/is-hosted? (constantly false)]
-        (is (= nil (public-settings/cloud-gateway-ips)))))))
+        (is (= nil (settings/cloud-gateway-ips)))))))
 
 (deftest start-of-week-test
   (mt/discard-setting-changes [start-of-week]
@@ -201,172 +201,172 @@
       (is (thrown-with-msg?
            Throwable
            #"Invalid day of week: :fraturday"
-           (public-settings/start-of-week! :fraturday))))
+           (settings/start-of-week! :fraturday))))
     (mt/with-temp-env-var-value! [start-of-week nil]
       (testing "Should default to Sunday"
         (is (= :sunday
-               (public-settings/start-of-week))))
+               (settings/start-of-week))))
       (testing "Sanity check: make sure we're setting the env var value correctly for the assertion after this"
         (mt/with-temp-env-var-value! [:mb-start-of-week "monday"]
           (is (= :monday
-                 (public-settings/start-of-week)))))
+                 (settings/start-of-week)))))
       (testing "Fall back to default if value is invalid"
         (mt/with-temp-env-var-value! [:mb-start-of-week "fraturday"]
           (is (= :sunday
-                 (public-settings/start-of-week))))))))
+                 (settings/start-of-week))))))))
 
 (deftest help-link-setting-test
   (mt/discard-setting-changes [help-link]
     (mt/with-premium-features #{:whitelabel}
       (testing "When whitelabeling is enabled, help-link setting can be set to any valid value"
-        (public-settings/help-link! :metabase)
-        (is (= :metabase (public-settings/help-link)))
+        (settings/help-link! :metabase)
+        (is (= :metabase (settings/help-link)))
 
-        (public-settings/help-link! :hidden)
-        (is (= :hidden (public-settings/help-link)))
+        (settings/help-link! :hidden)
+        (is (= :hidden (settings/help-link)))
 
-        (public-settings/help-link! :custom)
-        (is (= :custom (public-settings/help-link))))
+        (settings/help-link! :custom)
+        (is (= :custom (settings/help-link))))
 
       (testing "help-link cannot be set to an invalid value"
         (is (thrown-with-msg?
              Exception #"Invalid help link option"
-             (public-settings/help-link! :invalid)))))
+             (settings/help-link! :invalid)))))
 
     (mt/with-premium-features #{}
       (testing "When whitelabeling is not enabled, help-link setting cannot be set, and always returns :metabase"
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
              #"Setting help-link is not enabled because feature :whitelabel is not available"
-             (public-settings/help-link! :hidden)))
+             (settings/help-link! :hidden)))
 
-        (is (= :metabase (public-settings/help-link)))))))
+        (is (= :metabase (settings/help-link)))))))
 
 (deftest validate-help-url-test
   (testing "validate-help-url accepts valid URLs with HTTP or HTTPS protocols"
-    (is (nil? (#'public-settings/validate-help-url "http://www.metabase.com")))
-    (is (nil? (#'public-settings/validate-help-url "https://www.metabase.com"))))
+    (is (nil? (#'settings/validate-help-url "http://www.metabase.com")))
+    (is (nil? (#'settings/validate-help-url "https://www.metabase.com"))))
 
   (testing "validate-help-url accepts valid mailto: links"
-    (is (nil? (#'public-settings/validate-help-url "mailto:help@metabase.com"))))
+    (is (nil? (#'settings/validate-help-url "mailto:help@metabase.com"))))
 
   (testing "validate-help-url rejects malformed URLs and URLs with invalid protocols"
     ;; Since validate-help-url calls `u/url?` to validate URLs, we don't need to test all possible malformed URLs here.
     (is (thrown-with-msg?
          Exception
          #"Please make sure this is a valid URL"
-         (#'public-settings/validate-help-url "asdf")))
+         (#'settings/validate-help-url "asdf")))
 
     (is (thrown-with-msg?
          Exception
          #"Please make sure this is a valid URL"
-         (#'public-settings/validate-help-url "ftp://metabase.com"))))
+         (#'settings/validate-help-url "ftp://metabase.com"))))
 
   (testing "validate-help-url rejects mailto: links with invalid email addresses"
     (is (thrown-with-msg?
          Exception
          #"Please make sure this is a valid URL"
-         (#'public-settings/validate-help-url "mailto:help@metabase")))))
+         (#'settings/validate-help-url "mailto:help@metabase")))))
 
 (deftest help-link-custom-destination-setting-test
   (mt/with-premium-features #{:whitelabel}
     (testing "When whitelabeling is enabled, help-link-custom-destination can be set to valid URLs"
-      (public-settings/help-link-custom-destination! "http://www.metabase.com")
-      (is (= "http://www.metabase.com" (public-settings/help-link-custom-destination)))
+      (settings/help-link-custom-destination! "http://www.metabase.com")
+      (is (= "http://www.metabase.com" (settings/help-link-custom-destination)))
 
-      (public-settings/help-link-custom-destination! "mailto:help@metabase.com")
-      (is (= "mailto:help@metabase.com" (public-settings/help-link-custom-destination))))
+      (settings/help-link-custom-destination! "mailto:help@metabase.com")
+      (is (= "mailto:help@metabase.com" (settings/help-link-custom-destination))))
 
     (testing "help-link-custom-destination cannot be set to invalid URLs"
       (is (thrown-with-msg?
            Exception
            #"Please make sure this is a valid URL"
-           (public-settings/help-link-custom-destination! "asdf")))
+           (settings/help-link-custom-destination! "asdf")))
 
       (is (thrown-with-msg?
            Exception
            #"Please make sure this is a valid URL"
-           (public-settings/help-link-custom-destination! "ftp://metabase.com")))
+           (settings/help-link-custom-destination! "ftp://metabase.com")))
 
       (is (thrown-with-msg?
            Exception
            #"Please make sure this is a valid URL"
-           (public-settings/help-link-custom-destination! "mailto:help@metabase")))))
+           (settings/help-link-custom-destination! "mailto:help@metabase")))))
 
   (mt/with-premium-features #{}
     (testing "When whitelabeling is not enabled, help-link-custom-destination cannot be set, and always returns its default"
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo
            #"Setting help-link-custom-destination is not enabled because feature :whitelabel is not available"
-           (public-settings/help-link-custom-destination! "http://www.metabase.com")))
+           (settings/help-link-custom-destination! "http://www.metabase.com")))
 
-      (is (= nil (public-settings/help-link-custom-destination))))))
+      (is (= nil (settings/help-link-custom-destination))))))
 
 (deftest landing-page-setting-test
   (testing "should return relative url for valid inputs"
-    (public-settings/landing-page! "")
-    (is (= "" (public-settings/landing-page)))
+    (settings/landing-page! "")
+    (is (= "" (settings/landing-page)))
 
-    (public-settings/landing-page! "/")
-    (is (= "/" (public-settings/landing-page)))
+    (settings/landing-page! "/")
+    (is (= "/" (settings/landing-page)))
 
-    (public-settings/landing-page! "/one/two/three/")
-    (is (= "/one/two/three/" (public-settings/landing-page)))
+    (settings/landing-page! "/one/two/three/")
+    (is (= "/one/two/three/" (settings/landing-page)))
 
-    (public-settings/landing-page! "no-leading-slash")
-    (is (= "/no-leading-slash" (public-settings/landing-page)))
+    (settings/landing-page! "no-leading-slash")
+    (is (= "/no-leading-slash" (settings/landing-page)))
 
-    (public-settings/landing-page! "/pathname?query=param#hash")
-    (is (= "/pathname?query=param#hash" (public-settings/landing-page)))
+    (settings/landing-page! "/pathname?query=param#hash")
+    (is (= "/pathname?query=param#hash" (settings/landing-page)))
 
-    (public-settings/landing-page! "#hash")
-    (is (= "/#hash" (public-settings/landing-page)))
+    (settings/landing-page! "#hash")
+    (is (= "/#hash" (settings/landing-page)))
 
-    (with-redefs [public-settings/site-url (constantly "http://localhost")]
-      (public-settings/landing-page! "http://localhost/absolute/same-origin")
-      (is (= "/absolute/same-origin" (public-settings/landing-page)))))
+    (with-redefs [settings/site-url (constantly "http://localhost")]
+      (settings/landing-page! "http://localhost/absolute/same-origin")
+      (is (= "/absolute/same-origin" (settings/landing-page)))))
 
   (testing "landing-page cannot be set to URLs with external origin"
     (is (thrown-with-msg?
          Exception
          #"This field must be a relative URL."
-         (public-settings/landing-page! "https://google.com")))
+         (settings/landing-page! "https://google.com")))
 
     (is (thrown-with-msg?
          Exception
          #"This field must be a relative URL."
-         (public-settings/landing-page! "sms://?&body=Hello")))
+         (settings/landing-page! "sms://?&body=Hello")))
 
     (is (thrown-with-msg?
          Exception
          #"This field must be a relative URL."
-         (public-settings/landing-page! "https://localhost/test")))
+         (settings/landing-page! "https://localhost/test")))
 
     (is (thrown-with-msg?
          Exception
          #"This field must be a relative URL."
-         (public-settings/landing-page! "mailto:user@example.com")))
+         (settings/landing-page! "mailto:user@example.com")))
 
     (is (thrown-with-msg?
          Exception
          #"This field must be a relative URL."
-         (public-settings/landing-page! "file:///path/to/resource")))))
+         (settings/landing-page! "file:///path/to/resource")))))
 
 (deftest show-metabase-links-test
   (mt/discard-setting-changes [show-metabase-links]
     (mt/with-premium-features #{:whitelabel}
       (testing "When whitelabeling is enabled, show-metabase-links setting can be set to boolean"
-        (public-settings/show-metabase-links! true)
-        (is (= true (public-settings/show-metabase-links)))
+        (settings/show-metabase-links! true)
+        (is (= true (settings/show-metabase-links)))
 
-        (public-settings/show-metabase-links! false)
-        (is (= false (public-settings/show-metabase-links)))))
+        (settings/show-metabase-links! false)
+        (is (= false (settings/show-metabase-links)))))
 
     (mt/with-premium-features #{}
       (testing "When whitelabeling is not enabled, show-metabase-links setting cannot be set, and always returns true"
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
              #"Setting show-metabase-links is not enabled because feature :whitelabel is not available"
-             (public-settings/show-metabase-links! true)))
+             (settings/show-metabase-links! true)))
 
-        (is (= true (public-settings/show-metabase-links)))))))
+        (is (= true (settings/show-metabase-links)))))))

--- a/test/metabase/pulse/markdown_test.clj
+++ b/test/metabase/pulse/markdown_test.clj
@@ -1,8 +1,8 @@
 (ns metabase.pulse.markdown-test
   (:require
    [clojure.test :refer :all]
-   [metabase.public-settings :as public-settings]
    [metabase.pulse.markdown :as markdown]
+   [metabase.settings :as settings]
    [metabase.test.util :as tu]))
 
 (defn- slack
@@ -81,7 +81,7 @@
     (is (= "<https://metabase.com|`Metabase`>" (slack "[`Metabase`](https://metabase.com)"))))
 
   (testing "Relative links are resolved to the current site URL"
-    (tu/with-temporary-setting-values [public-settings/site-url "https://example.com"]
+    (tu/with-temporary-setting-values [settings/site-url "https://example.com"]
       (is (= "<https://example.com/foo|Metabase>"   (slack "[Metabase](/foo)")))))
 
   (testing "Auto-links are preserved"

--- a/test/metabase/pulse_test.clj
+++ b/test/metabase/pulse_test.clj
@@ -14,11 +14,11 @@
    [metabase.models.permissions :as perms]
    [metabase.models.permissions-group :as perms-group]
    [metabase.models.pulse :as pulse]
-   [metabase.public-settings :as public-settings]
    [metabase.pulse]
    [metabase.pulse.render :as render]
    [metabase.pulse.render.body :as body]
    [metabase.pulse.test-util :as pulse.test-util]
+   [metabase.settings :as settings]
    [metabase.test :as mt]
    [metabase.test.util :as tu]
    [metabase.util :as u]
@@ -350,7 +350,7 @@
 
       :fixture
       (fn [_ thunk]
-        (mt/with-temporary-setting-values [public-settings/download-row-limit 30]
+        (mt/with-temporary-setting-values [settings/download-row-limit 30]
           (thunk)))
       :pulse-card {:include_csv true}
       :assert

--- a/test/metabase/query_analysis_test.clj
+++ b/test/metabase/query_analysis_test.clj
@@ -6,8 +6,8 @@
    [metabase.lib.metadata.jvm :as lib.metadata.jvm]
    [metabase.models :refer [Card]]
    [metabase.models.persisted-info :as persisted-info]
-   [metabase.public-settings :as public-settings]
    [metabase.query-analysis :as query-analysis]
+   [metabase.settings :as settings]
    [metabase.test :as mt]
    [metabase.util :as u]
    [toucan2.core :as t2]
@@ -16,10 +16,10 @@
 (deftest native-query-enabled-test
   (mt/discard-setting-changes [sql-parsing-enabled]
     (testing "sql parsing enabled"
-      (public-settings/sql-parsing-enabled! true)
+      (settings/sql-parsing-enabled! true)
       (is (true? (query-analysis/enabled-type? :native))))
     (testing "sql parsing disabled"
-      (public-settings/sql-parsing-enabled! false)
+      (settings/sql-parsing-enabled! false)
       (is (false? (query-analysis/enabled-type? :native))))))
 
 (deftest non-native-query-enabled-test

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -10,7 +10,6 @@
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.models.query :as query :refer [Query]]
-   [metabase.public-settings :as public-settings]
    [metabase.query-processor :as qp]
    [metabase.query-processor.middleware.cache :as cache]
    [metabase.query-processor.middleware.cache-backend.interface :as i]
@@ -22,6 +21,7 @@
    [metabase.query-processor.streaming :as qp.streaming]
    [metabase.query-processor.util :as qp.util]
    [metabase.server.middleware.session :as mw.session]
+   [metabase.settings :as settings]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.test.util :as tu]
@@ -458,7 +458,7 @@
                                    (#'cache/save-results-xform (System/currentTimeMillis) {} (byte 0) (ttl-strategy) conj)
                                    (repeat 10000 [1]))))))
   (testing "Make sure we properly handle situations where we abort serialization (e.g. due to result being too big)"
-    (let [max-bytes (* (public-settings/query-caching-max-kb) 1024)]
+    (let [max-bytes (* (settings/query-caching-max-kb) 1024)]
       (is (= max-bytes (count (transduce identity
                                          (#'cache/save-results-xform 0 {} (byte 0) (ttl-strategy) conj)
                                          (repeat max-bytes [1]))))))))

--- a/test/metabase/query_processor/middleware/fetch_source_query_test.clj
+++ b/test/metabase/query_processor/middleware/fetch_source_query_test.clj
@@ -10,13 +10,13 @@
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
    [metabase.lib.test-util.macros :as lib.tu.macros]
-   [metabase.public-settings :as public-settings]
    [metabase.query-processor :as qp]
    [metabase.query-processor.middleware.fetch-source-query
     :as fetch-source-query]
    [metabase.query-processor.preprocess :as qp.preprocess]
    [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test-util :as qp.test-util]
+   [metabase.settings :as settings]
    [metabase.test :as mt]))
 
 (defn resolve-source-cards* [query]
@@ -115,14 +115,14 @@
   (testing "respects `enable-nested-queries` server setting when true"
     (qp.store/with-metadata-provider mock-metadata-provider
       ;; by default nested queries are enabled:
-      (is (true? (public-settings/enable-nested-queries)))
+      (is (true? (settings/enable-nested-queries)))
       (is (some? (resolve-source-cards (lib.tu.macros/mbql-query nil {:source-table "card__1"})))))))
 
 (deftest resolve-mbql-queries-test-5
   (testing "respects `enable-nested-queries` server setting when false"
     ;; if the env var is set, the setting respects it:
     (mt/with-temp-env-var-value! ["MB_ENABLE_NESTED_QUERIES" "false"]
-      (is (false? (public-settings/enable-nested-queries))))
+      (is (false? (settings/enable-nested-queries))))
     (qp.store/with-metadata-provider mock-metadata-provider
 
 ;; resolve-source-cards doesn't respect [[mt/with-temp-env-var-value!]], so set it inside the thunk:

--- a/test/metabase/query_processor/persistence_test.clj
+++ b/test/metabase/query_processor/persistence_test.clj
@@ -7,12 +7,12 @@
    [metabase.driver :as driver]
    [metabase.driver.ddl.interface :as ddl.i]
    [metabase.models :refer [Card]]
-   [metabase.public-settings :as public-settings]
    [metabase.query-processor :as qp]
    [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.interface :as qp.i]
    [metabase.query-processor.metadata :as qp.metadata]
    [metabase.query-processor.middleware.fix-bad-references :as fix-bad-refs]
+   [metabase.settings :as settings]
    [metabase.test :as mt]
    [metabase.test.data.interface :as tx]
    [toucan2.core :as t2])
@@ -44,7 +44,7 @@
             (is success? (str "Not able to persist on " driver/*driver*))
             (is (= :persist.check/valid error)))
           (testing "Populates the `cache_info` table with v1 information"
-            (let [schema-name (ddl.i/schema-name (mt/db) (public-settings/site-uuid))
+            (let [schema-name (ddl.i/schema-name (mt/db) (settings/site-uuid))
                   query       {:query
                                (first
                                 (sql/format {:select [:key :value]
@@ -52,7 +52,7 @@
                                             {:dialect (can-persist-test-honeysql-quote-style driver/*driver*)}))}
                   values      (into {} (->> query mt/native-query qp/process-query mt/rows))]
               (is (partial= {"settings-version" "1"
-                             "instance-uuid"    (public-settings/site-uuid)}
+                             "instance-uuid"    (settings/site-uuid)}
                             (into {} (->> query mt/native-query qp/process-query mt/rows))))
               (let [[low high]       [(.minus (Instant/now) 1 ChronoUnit/MINUTES)
                                       (.plus (Instant/now) 1 ChronoUnit/MINUTES)]
@@ -143,7 +143,7 @@
                                       (fn [x]
                                         (swap! bad-refs conj x))]
                               (qp/process-query query))
-                    persisted-schema (ddl.i/schema-name (mt/db) (public-settings/site-uuid))]
+                    persisted-schema (ddl.i/schema-name (mt/db) (settings/site-uuid))]
                 (testing "Was persisted"
                   (is (str/includes? (-> results :data :native_form :query) persisted-schema)))
                 (testing "Did not find bad field clauses"
@@ -169,7 +169,7 @@
                            :database (mt/id)
                            :query {:source-table (str "card__" (:id model))}}
                   results (qp/process-query query)
-                  persisted-schema (ddl.i/schema-name (mt/db) (public-settings/site-uuid))]
+                  persisted-schema (ddl.i/schema-name (mt/db) (settings/site-uuid))]
               (testing "Was persisted"
                 (is (str/includes? (-> results :data :native_form :query) persisted-schema))))
             (let [query {:type :query
@@ -178,7 +178,7 @@
                                  :aggregation [[:count]]
                                  :breakout [(mt/$ids $products.category)]}}
                   results (qp/process-query query)
-                  persisted-schema (ddl.i/schema-name (mt/db) (public-settings/site-uuid))]
+                  persisted-schema (ddl.i/schema-name (mt/db) (settings/site-uuid))]
               (testing "Was persisted"
                 (is (str/includes? (-> results :data :native_form :query) persisted-schema)))
               (is (= {"Doohickey" 3976, "Gadget" 4939,

--- a/test/metabase/server/middleware/misc_test.clj
+++ b/test/metabase/server/middleware/misc_test.clj
@@ -2,8 +2,8 @@
   (:require
    [clojure.test :refer :all]
    [medley.core :as m]
-   [metabase.public-settings :as public-settings]
    [metabase.server.middleware.misc :as mw.misc]
+   [metabase.settings :as settings]
    [metabase.test :as mt]
    [ring.mock.request :as ring.mock]))
 
@@ -31,20 +31,20 @@
         (mt/with-temporary-setting-values [site-url nil]
           (maybe-set-site-url request)
           (is (= (or origin-header x-forwarded-host-header host-header)
-                 (public-settings/site-url)))))))
+                 (settings/site-url)))))))
   (testing "Site URL should not be inferred from healthcheck requests"
     (mt/with-temporary-setting-values [site-url nil]
       (let [request (mock-request "/api/health" "https://mb1.example.com" nil nil)]
         (maybe-set-site-url request)
-        (is (nil? (public-settings/site-url))))))
+        (is (nil? (settings/site-url))))))
   (testing "Site URL should not be inferred if already set in DB"
     (mt/with-temporary-setting-values [site-url "https://mb1.example.com"]
       (let [request (mock-request "/" "https://mb2.example.com" nil nil)]
         (maybe-set-site-url request)
-        (is (= "https://mb1.example.com" (public-settings/site-url))))))
+        (is (= "https://mb1.example.com" (settings/site-url))))))
   (testing "Site URL should not be inferred if already set by env variable"
     (mt/with-temporary-setting-values [site-url nil]
       (mt/with-temp-env-var-value! [mb-site-url "https://mb1.example.com"]
         (let [request (mock-request "/" "https://mb2.example.com" nil nil)]
           (maybe-set-site-url request)
-          (is (= "https://mb1.example.com" (public-settings/site-url))))))))
+          (is (= "https://mb1.example.com" (settings/site-url))))))))

--- a/test/metabase/server/middleware/session_test.clj
+++ b/test/metabase/server/middleware/session_test.clj
@@ -16,9 +16,9 @@
    [metabase.models.setting :as setting]
    [metabase.models.setting-test :as setting-test]
    [metabase.models.user :as user]
-   [metabase.public-settings :as public-settings]
    [metabase.public-settings.premium-features :as premium-features]
    [metabase.server.middleware.session :as mw.session]
+   [metabase.settings :as settings]
    [metabase.test :as mt]
    [metabase.util.i18n :as i18n]
    [metabase.util.secret :as u.secret]
@@ -636,11 +636,11 @@
         session-id   "8df268ab-00c0-4b40-9413-d66b966b696a"
         response     {:body    "some body",
                       :cookies {}}]
-    (testing "If [[public-settings/session-cookies]] is false and the `:remember` flag is set, then the session cookie
+    (testing "If [[settings/session-cookies]] is false and the `:remember` flag is set, then the session cookie
               should have a max age attribute."
       (with-redefs [env/env (assoc env/env :max-session-age "1")]
         (mt/with-temporary-setting-values [session-timeout nil
-                                           public-settings/session-cookies false]
+                                           settings/session-cookies false]
           (let [request {:body                  {:remember true}
                          :metabase-session-id   session-id
                          :metabase-session-type :normal
@@ -665,11 +665,11 @@
         session-id   "8df268ab-00c0-4b40-9413-d66b966b696a"
         response     {:body    "some body",
                       :cookies {}}]
-    (testing "If [[public-settings/session-cookies]] is true and the `:remember` flag is set, then the session cookie
+    (testing "If [[settings/session-cookies]] is true and the `:remember` flag is set, then the session cookie
               shouldn't have a max age attribute."
       (with-redefs [env/env (assoc env/env :max-session-age "1")]
         (mt/with-temporary-setting-values [session-timeout nil
-                                           public-settings/session-cookies true]
+                                           settings/session-cookies true]
           (let [request {:metabase-session-id   session-id
                          :metabase-session-type :normal
                          :remember              "true"

--- a/test/metabase/setup_test.clj
+++ b/test/metabase/setup_test.clj
@@ -4,7 +4,7 @@
    [metabase.config :as config]
    [metabase.db :as mdb]
    [metabase.models.interface :as mi]
-   [metabase.public-settings :as public-settings]
+   [metabase.settings :as settings]
    [metabase.setup :as setup]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
@@ -57,18 +57,18 @@
     (mdb/setup-db! :create-sample-content? true)
     (testing "The example-dashboard-id setting should be set if the example content is loaded"
       (is (= 1
-             (public-settings/example-dashboard-id)))))
+             (settings/example-dashboard-id)))))
   (testing "The example-dashboard-id setting should be nil if the example content isn't loaded"
     (mt/with-temp-empty-app-db [_conn :h2]
       (mdb/setup-db! :create-sample-content? false)
-      (is (nil? (public-settings/example-dashboard-id)))))
+      (is (nil? (settings/example-dashboard-id)))))
   (testing "The example-dashboard-id setting should be reset to nil if the example dashboard is archived"
     (mt/with-temp-empty-app-db [_conn :h2]
       (mdb/setup-db! :create-sample-content? true)
       (is (= 1
-             (public-settings/example-dashboard-id)))
+             (settings/example-dashboard-id)))
       (t2/update! :model/Dashboard 1 {:archived true})
-      (is (nil? (public-settings/example-dashboard-id))))))
+      (is (nil? (settings/example-dashboard-id))))))
 
 (deftest sample-content-permissions-test
   (mt/with-temp-empty-app-db [_conn :h2]

--- a/test/metabase/task/upgrade_checks_test.clj
+++ b/test/metabase/task/upgrade_checks_test.clj
@@ -3,7 +3,7 @@
    [clj-http.fake :as http-fake]
    [clojure.test :refer :all]
    [metabase.config :as config]
-   [metabase.public-settings :as public-settings]
+   [metabase.settings :as settings]
    [metabase.task.upgrade-checks :as upgrade-checks]))
 
 (deftest site-uuid-test
@@ -11,7 +11,7 @@
     (with-redefs [config/is-prod? true]
       (http-fake/with-fake-routes-in-isolation
         {{:address #"https://static.metabase.com/version-info(-ee)?.json.*"
-          :query-params {:instance (public-settings/site-uuid-for-version-info-fetching)}}
+          :query-params {:instance (settings/site-uuid-for-version-info-fetching)}}
          (constantly {:status 200 :body "{}"})}
         (is (= {} (@#'upgrade-checks/get-version-info))))))
 

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -39,7 +39,7 @@
    [metabase.test.util.i18n :as i18n.tu]
    [metabase.test.util.log :as tu.log]
    [metabase.test.util.misc :as tu.misc]
-   [metabase.test.util.public-settings :as tu.public-setings]
+   [metabase.test.util.public-settings :as tu.public-settings]
    [metabase.test.util.thread-local :as tu.thread-local]
    [metabase.test.util.timezone :as test.tz]
    [metabase.util.log.capture]
@@ -89,7 +89,7 @@
   tu.async/keep-me
   tu.log/keep-me
   tu.misc/keep-me
-  tu.public-setings/keep-me
+  tu.public-settings/keep-me
   tu.thread-local/keep-me
   tu/keep-me
   tx.env/keep-me
@@ -292,7 +292,7 @@
   with-clock
   with-single-admin-user]
 
- [tu.public-setings
+ [tu.public-settings
   with-premium-features
   with-additional-premium-features]
 

--- a/test/metabase/util/i18n/impl_test.clj
+++ b/test/metabase/util/i18n/impl_test.clj
@@ -3,7 +3,7 @@
    [clojure.test :refer :all]
    [metabase.config :as config]
    [metabase.models.setting :as setting]
-   [metabase.public-settings :as public-settings]
+   [metabase.settings :as settings]
    [metabase.test :as mt]
    [metabase.util.i18n :as i18n]
    [metabase.util.i18n.impl :as i18n.impl]
@@ -134,8 +134,8 @@
           (testing "since the encrypted string is an invalid value for a Locale, high-level functions should return nil"
             (is (nil? (i18n/site-locale))
                 `i18n/site-locale)
-            (is (nil? (public-settings/site-locale))
-                `public-settings/site-locale))
+            (is (nil? (settings/site-locale))
+                `settings/site-locale))
           (testing "we should still be able to (no-op) i18n stuff"
             (is (= "Testing"
                    (i18n/trs "Testing")))))))))


### PR DESCRIPTION
### Description

Renames `public-settings.clj` to `settings.clj` to reflect the fact that most settings must be `:authenticated` by default unless strictly necessary (i.e. used by the setup flow, login flow, static and interactive embedding) - this is a continuation from https://github.com/metabase/metabase/pull/47901

I wanted to separate public settings to `public-settings.clj` too so we keep private and public settings in separate files, but the diffs are already scary from a renaming, so let's keep it this way for now.

### How to verify

Tests should continue to function as usual.