### PR TITLE
bypass race condition to avoid flakiness in click behaviour test

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/temporal-unit-parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/temporal-unit-parameters.cy.spec.js
@@ -554,7 +554,9 @@ describe("scenarios > dashboard > temporal unit parameters", () => {
         cy.log("verify click behavior with a valid temporal unit");
         getDashboardCard(1).findByText("year", { timeout: 10000 }).click();
         filterWidget().findByText("Year").should("be.visible");
-        getDashboardCard(0).findByText("Created At: Year").should("be.visible");
+        getDashboardCard(0)
+          .findByText("Created At: Year", { timeout: 10000 })
+          .should("be.visible");
 
         cy.log("verify that invalid temporal units are ignored");
         getDashboardCard(1).findByText("invalid").click();

--- a/e2e/test/scenarios/dashboard-filters/temporal-unit-parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/temporal-unit-parameters.cy.spec.js
@@ -552,8 +552,10 @@ describe("scenarios > dashboard > temporal unit parameters", () => {
         saveDashboard();
 
         cy.log("verify click behavior with a valid temporal unit");
-        getDashboardCard(1).findByText("year", { timeout: 10000 }).click();
-        filterWidget().findByText("Year").should("be.visible");
+        getDashboardCard(1).findByText("year").click();
+        filterWidget()
+          .findByText("Year", { timeout: 10000 })
+          .should("be.visible");
         getDashboardCard(0)
           .findByText("Created At: Year", { timeout: 10000 })
           .should("be.visible");

--- a/e2e/test/scenarios/dashboard-filters/temporal-unit-parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/temporal-unit-parameters.cy.spec.js
@@ -512,83 +512,71 @@ describe("scenarios > dashboard > temporal unit parameters", () => {
   });
 
   describe("click behaviors", () => {
-    it.only(
-      "should pass a temporal unit with 'update dashboard filter' click behavior",
-      { tags: "@flaky" },
-      () => {
-        createDashboardWithMappedQuestion({
-          extraQuestions: [nativeUnitQuestionDetails],
-        }).then(dashboard => visitDashboard(dashboard.id));
+    it("should pass a temporal unit with 'update dashboard filter' click behavior", () => {
+      createDashboardWithMappedQuestion({
+        extraQuestions: [nativeUnitQuestionDetails],
+      }).then(dashboard => {
+        cy.wrap(dashboard.id).as("dashboardId");
+        visitDashboard(dashboard.id);
+      });
 
-        cy.log("unsupported column types are ignored");
-        editDashboard();
-        getDashboardCard(0)
-          .findByLabelText("Click behavior")
-          .click({ force: true });
-        sidebar().within(() => {
-          cy.log("datetime columns cannot be mapped");
-          cy.findByText("Created At").click();
-          cy.findByText("Update a dashboard filter").click();
-          cy.findByText("No available targets").should("be.visible");
-          cy.icon("chevronleft").click();
+      cy.log("unsupported column types are ignored");
+      editDashboard();
+      getDashboardCard(0)
+        .findByLabelText("Click behavior")
+        .click({ force: true });
+      sidebar().within(() => {
+        cy.log("datetime columns cannot be mapped");
+        cy.findByText("Created At").click();
+        cy.findByText("Update a dashboard filter").click();
+        cy.findByText("No available targets").should("be.visible");
+        cy.icon("chevronleft").click();
 
-          cy.log("number columns cannot be mapped");
-          cy.findByText("Count").click();
-          cy.findByText("Update a dashboard filter").click();
-          cy.findByText("No available targets").should("be.visible");
-          cy.button("Cancel").click();
-        });
+        cy.log("number columns cannot be mapped");
+        cy.findByText("Count").click();
+        cy.findByText("Update a dashboard filter").click();
+        cy.findByText("No available targets").should("be.visible");
+        cy.button("Cancel").click();
+      });
 
-        cy.log("setup a valid click behavior with a text column");
-        getDashboardCard(1)
-          .findByLabelText("Click behavior")
-          .click({ force: true });
-        sidebar().within(() => {
-          cy.findByText("UNIT").click();
-          cy.findByText("Update a dashboard filter").click();
-          cy.findByText(parameterDetails.name).click();
-        });
-        popover().findByText("UNIT").click();
-        saveDashboard();
+      cy.log("setup a valid click behavior with a text column");
+      getDashboardCard(1)
+        .findByLabelText("Click behavior")
+        .click({ force: true });
+      sidebar().within(() => {
+        cy.findByText("UNIT").click();
+        cy.findByText("Update a dashboard filter").click();
+        cy.findByText(parameterDetails.name).click();
+      });
+      popover().findByText("UNIT").click();
+      saveDashboard();
 
-        cy.log("verify click behavior with a valid temporal unit");
+      cy.log("verify click behavior with a valid temporal unit");
 
-        cy.wait(2000);
+      // this is done to bypass race condition problem, the root cause for it is
+      // described in `updateDashboardAndCards` from frontend/src/metabase/dashboard/actions/save.js
+      visitDashboard("@dashboardId");
 
-        getDashboardCard(1).findByText("year").click();
-        // cy.wait("@dashcardQuery4");
-        // getDashboardCard(0).findByText("April 2022").should("be.visible");
-        // cy.wait(2000);
-        cy.wait("@dashcardQuery4").then(interception => {
-          // Optionally, you can assert the response if needed
-          expect(interception.response.statusCode).to.eq(202);
+      getDashboardCard(1).findByText("year").click();
 
-          console.log("Response:", interception.response.body);
-        });
+      getDashboardCard(0)
+        .findByText("Created At: Year", { timeout: 10000 })
+        .should("be.visible");
 
-        cy.url().should("include", "?unit_of_time=year");
+      filterWidget().findByText("Year").should("be.visible");
 
-        getDashboardCard(0)
-          .findByText("Created At: Year", { timeout: 10000 })
-          .should("be.visible");
+      cy.log("verify that invalid temporal units are ignored");
+      getDashboardCard(1).findByText("invalid").click();
+      filterWidget()
+        .findByText(/invalid/i)
+        .should("not.exist");
+      getDashboardCard(0).findByText("Created At: Month").should("be.visible");
 
-        filterWidget().findByText("Year").should("be.visible");
-
-        cy.log("verify that invalid temporal units are ignored");
-        getDashboardCard(1).findByText("invalid").click();
-        filterWidget()
-          .findByText(/invalid/i)
-          .should("not.exist");
-        getDashboardCard(0)
-          .findByText("Created At: Month")
-          .should("be.visible");
-
-        cy.log("verify that recovering from an invalid temporal unit works");
-        getDashboardCard(1).findByText("year").click();
-        filterWidget().findByText("Year").should("be.visible");
-        getDashboardCard(0).findByText("Created At: Year").should("be.visible");
-      },
-    );
+      cy.log("verify that recovering from an invalid temporal unit works");
+      getDashboardCard(1).findByText("year").click();
+      filterWidget().findByText("Year").should("be.visible");
+      getDashboardCard(0).findByText("Created At: Year").should("be.visible");
+    });
 
     it("should pass a temporal unit 'custom destination -> dashboard' click behavior", () => {
       createDashboardWithMappedQuestion({

--- a/e2e/test/scenarios/dashboard-filters/temporal-unit-parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/temporal-unit-parameters.cy.spec.js
@@ -552,7 +552,7 @@ describe("scenarios > dashboard > temporal unit parameters", () => {
         saveDashboard();
 
         cy.log("verify click behavior with a valid temporal unit");
-        getDashboardCard(1).findByText("year").click();
+        getDashboardCard(1).findByText("year", { timeout: 10000 }).click();
         filterWidget().findByText("Year").should("be.visible");
         getDashboardCard(0).findByText("Created At: Year").should("be.visible");
 

--- a/e2e/test/scenarios/dashboard-filters/temporal-unit-parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/temporal-unit-parameters.cy.spec.js
@@ -512,7 +512,7 @@ describe("scenarios > dashboard > temporal unit parameters", () => {
   });
 
   describe("click behaviors", () => {
-    it(
+    it.only(
       "should pass a temporal unit with 'update dashboard filter' click behavior",
       { tags: "@flaky" },
       () => {
@@ -552,13 +552,27 @@ describe("scenarios > dashboard > temporal unit parameters", () => {
         saveDashboard();
 
         cy.log("verify click behavior with a valid temporal unit");
+
+        cy.wait(2000);
+
         getDashboardCard(1).findByText("year").click();
-        filterWidget()
-          .findByText("Year", { timeout: 10000 })
-          .should("be.visible");
+        // cy.wait("@dashcardQuery4");
+        // getDashboardCard(0).findByText("April 2022").should("be.visible");
+        // cy.wait(2000);
+        cy.wait("@dashcardQuery4").then(interception => {
+          // Optionally, you can assert the response if needed
+          expect(interception.response.statusCode).to.eq(202);
+
+          console.log("Response:", interception.response.body);
+        });
+
+        cy.url().should("include", "?unit_of_time=year");
+
         getDashboardCard(0)
           .findByText("Created At: Year", { timeout: 10000 })
           .should("be.visible");
+
+        filterWidget().findByText("Year").should("be.visible");
 
         cy.log("verify that invalid temporal units are ignored");
         getDashboardCard(1).findByText("invalid").click();

--- a/frontend/src/metabase/dashboard/actions/save.js
+++ b/frontend/src/metabase/dashboard/actions/save.js
@@ -135,6 +135,14 @@ export const updateDashboardAndCards = createThunkAction(
       dispatch(setEditingDashboard(null));
 
       // make sure that we've fully cleared out any dirty state from editing (this is overkill, but simple)
+      //
+      // UPD 16.09.2024
+      // This code is a source of race condition on slow network.
+      // it fetches a dashboard without parameters and if `fetchDashboardCardData` from the lines below is slow
+      // the dashboard itself is re-rendered and re-fetches data again without parameters, so later on
+      // dashboard component re-fetches data and cancels correct query with parameters
+      // e.g. `should pass a temporal unit with 'update dashboard filter' click behavior` from temporal-unit-parameters.cy.spec.js
+      // with 3g simulation is an example of such race condition
       await dispatch(
         fetchDashboard({
           dashId: dashboard.id,


### PR DESCRIPTION
add a workaround to bypass race condition that appears on slow networks during saving the dashboard

[✅ stress 30/30](https://github.com/metabase/metabase/actions/runs/10882999620/job/30195182448)