### PR TITLE
change the visual style of the buttons so that they all look active

### DIFF
--- a/frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookActionButton/NotebookActionButton.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookActionButton/NotebookActionButton.tsx
@@ -9,7 +9,6 @@ interface NotebookActionButtonProps {
   icon?: IconName;
   title: string;
   color: string;
-  transparent?: boolean;
   large?: boolean;
   onClick: () => void;
 }
@@ -18,7 +17,6 @@ export function NotebookActionButton({
   icon,
   title,
   color,
-  transparent,
   large,
   onClick,
   ...props
@@ -30,7 +28,6 @@ export function NotebookActionButton({
       icon={icon}
       small={!large}
       color={color}
-      transparent={transparent}
       iconVertical={large}
       iconSize={large ? 20 : 16}
       aria-label={label}

--- a/frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.styled.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.styled.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 
 import Button from "metabase/core/components/Button";
-import { alpha, color, darken } from "metabase/lib/colors";
+import { alpha, color, darken, lighten } from "metabase/lib/colors";
 import { breakpointMinSmall } from "metabase/styled-components/theme";
 
 const getPercentage = (number: number): string => {
@@ -38,16 +38,19 @@ export const StepActionsContainer = styled.div`
 
 interface ColorButtonProps {
   color: string;
+  transparent?: boolean;
 }
 
 export const ColorButton = styled(Button)<ColorButtonProps>`
   border: none;
   color: ${({ color }) => color};
-  background-color: ${({ color }) => alpha(color, 0.2)};
+  background-color: ${({ color, transparent }) =>
+    transparent ? null : alpha(color, 0.2)};
 
   &:hover {
     color: ${({ color }) => darken(color, 0.115)};
-    background-color: ${({ color }) => alpha(color, 0.35)};
+    background-color: ${({ color, transparent }) =>
+      transparent ? lighten(color, 0.5) : alpha(color, 0.35)};
   }
 
   transition: background 300ms;
@@ -55,6 +58,7 @@ export const ColorButton = styled(Button)<ColorButtonProps>`
 
 interface PreviewButtonProps {
   icon?: string;
+  transparent?: boolean;
   hasPreviewButton?: boolean;
 }
 

--- a/frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.styled.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.styled.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 
 import Button from "metabase/core/components/Button";
-import { alpha, color, darken, lighten } from "metabase/lib/colors";
+import { alpha, color, darken } from "metabase/lib/colors";
 import { breakpointMinSmall } from "metabase/styled-components/theme";
 
 const getPercentage = (number: number): string => {
@@ -38,19 +38,16 @@ export const StepActionsContainer = styled.div`
 
 interface ColorButtonProps {
   color: string;
-  transparent?: boolean;
 }
 
 export const ColorButton = styled(Button)<ColorButtonProps>`
   border: none;
   color: ${({ color }) => color};
-  background-color: ${({ color, transparent }) =>
-    transparent ? null : alpha(color, 0.2)};
+  background-color: ${({ color }) => alpha(color, 0.2)};
 
   &:hover {
     color: ${({ color }) => darken(color, 0.115)};
-    background-color: ${({ color, transparent }) =>
-      transparent ? lighten(color, 0.5) : alpha(color, 0.35)};
+    background-color: ${({ color }) => alpha(color, 0.35)};
   }
 
   transition: background 300ms;
@@ -58,7 +55,6 @@ export const ColorButton = styled(Button)<ColorButtonProps>`
 
 interface PreviewButtonProps {
   icon?: string;
-  transparent?: boolean;
   hasPreviewButton?: boolean;
 }
 

--- a/frontend/src/metabase/querying/notebook/components/NotebookStep/utils.ts
+++ b/frontend/src/metabase/querying/notebook/components/NotebookStep/utils.ts
@@ -26,7 +26,6 @@ type StepUIItem = {
   title: string;
   icon?: IconName;
   priority?: number;
-  transparent?: boolean;
   compact?: boolean;
   color: () => string;
   Step: ComponentType<NotebookStepProps>;
@@ -51,7 +50,6 @@ const STEPS: Record<NotebookStepType, StepUIItem> = {
   expression: {
     title: t`Custom column`,
     icon: "add_data",
-    transparent: true,
     color: () => color("bg-dark"),
     Step: ExpressionStep,
     StepHeader: NotebookStepHeader,
@@ -92,7 +90,6 @@ const STEPS: Record<NotebookStepType, StepUIItem> = {
     title: t`Sort`,
     icon: "sort",
     compact: true,
-    transparent: true,
     color: () => color("bg-dark"),
     Step: SortStep,
     StepHeader: NotebookStepHeader,
@@ -101,7 +98,6 @@ const STEPS: Record<NotebookStepType, StepUIItem> = {
     title: t`Row limit`,
     icon: "list",
     compact: true,
-    transparent: true,
     color: () => color("bg-dark"),
     Step: LimitStep,
     StepHeader: NotebookStepHeader,


### PR DESCRIPTION
[Epic](https://github.com/metabase/metabase/issues/47911)

Remove transparency from the buttons

<img width="1396" alt="image" src="https://github.com/user-attachments/assets/19e1169f-b9f3-4fd5-ac0d-aa86c84530fb">

