### PR TITLE
render notebook step actions in the natural order

### DIFF
--- a/frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx
@@ -52,37 +52,30 @@ export function NotebookStep({
     useToggle(false);
 
   const actionButtons = useMemo(() => {
-    const actions = [];
     const hasLargeActionButtons =
       isLastStep && step.actions.some(hasLargeButton);
 
-    actions.push(
-      ...step.actions.map(action => {
-        const stepUi = getStepConfig(action.type);
-        const title = stepUi.title;
-        return {
-          priority: stepUi.priority,
-          button: (
-            <NotebookActionButton
-              key={`actionButton_${title}`}
-              className={cx({
-                [cx(CS.mr2, CS.mt2)]: isLastStep,
-                [CS.mr1]: !isLastStep,
-              })}
-              large={hasLargeActionButtons}
-              {...stepUi}
-              title={title}
-              aria-label={title}
-              onClick={() => action.action({ openStep })}
-            />
-          ),
-        };
-      }),
-    );
+    const actions = step.actions.map(action => {
+      const stepUi = getStepConfig(action.type);
+      const title = stepUi.title;
 
-    actions.sort((a, b) => (b.priority || 0) - (a.priority || 0));
+      return (
+        <NotebookActionButton
+          key={`actionButton_${title}`}
+          className={cx({
+            [cx(CS.mr2, CS.mt2)]: isLastStep,
+            [CS.mr1]: !isLastStep,
+          })}
+          large={hasLargeActionButtons}
+          {...stepUi}
+          title={title}
+          aria-label={title}
+          onClick={() => action.action({ openStep })}
+        />
+      );
+    });
 
-    return actions.map(action => action.button);
+    return actions;
   }, [step.actions, isLastStep, openStep]);
 
   const handleClickRevert = useCallback(() => {
@@ -97,6 +90,8 @@ export function NotebookStep({
   }, [step, updateQuery]);
 
   const { title, color, Step, StepHeader } = getStepConfig(step.type);
+
+  // console.log({ actionButtons })
 
   const canPreview = step.previewQuery != null;
   const hasPreviewButton = !isPreviewOpen && canPreview;

--- a/frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStep.tsx
@@ -91,8 +91,6 @@ export function NotebookStep({
 
   const { title, color, Step, StepHeader } = getStepConfig(step.type);
 
-  // console.log({ actionButtons })
-
   const canPreview = step.previewQuery != null;
   const hasPreviewButton = !isPreviewOpen && canPreview;
   const canRevert = step.revert != null && !readOnly;

--- a/frontend/src/metabase/querying/notebook/components/NotebookStep/utils.ts
+++ b/frontend/src/metabase/querying/notebook/components/NotebookStep/utils.ts
@@ -25,7 +25,6 @@ import { NotebookStepHeader } from "./NotebookStepHeader";
 type StepUIItem = {
   title: string;
   icon?: IconName;
-  priority?: number;
   transparent?: boolean;
   compact?: boolean;
   color: () => string;
@@ -43,7 +42,6 @@ const STEPS: Record<NotebookStepType, StepUIItem> = {
   join: {
     title: t`Join data`,
     icon: "join_left_outer",
-    priority: 1,
     color: () => color("brand"),
     Step: JoinStep,
     StepHeader: NotebookStepHeader,
@@ -59,7 +57,6 @@ const STEPS: Record<NotebookStepType, StepUIItem> = {
   filter: {
     title: t`Filter`,
     icon: "filter",
-    priority: 10,
     color: () => color("filter"),
     Step: FilterStep,
     StepHeader: NotebookStepHeader,
@@ -67,7 +64,6 @@ const STEPS: Record<NotebookStepType, StepUIItem> = {
   summarize: {
     title: t`Summarize`,
     icon: "sum",
-    priority: 5,
     color: () => color("summarize"),
     Step: SummarizeStep,
     StepHeader: SummarizeStepHeader,
@@ -75,7 +71,6 @@ const STEPS: Record<NotebookStepType, StepUIItem> = {
   aggregate: {
     title: t`Aggregate`,
     icon: "sum",
-    priority: 5,
     color: () => color("summarize"),
     Step: AggregateStep,
     StepHeader: NotebookStepHeader,
@@ -83,7 +78,6 @@ const STEPS: Record<NotebookStepType, StepUIItem> = {
   breakout: {
     title: t`Breakout`,
     icon: "segment",
-    priority: 1,
     color: () => color("accent4"),
     Step: BreakoutStep,
     StepHeader: NotebookStepHeader,

--- a/frontend/src/metabase/querying/notebook/components/NotebookStepList/NotebookStepList.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookStepList/NotebookStepList.unit.spec.tsx
@@ -1,14 +1,22 @@
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["assertActionButtonsOrder"] }] */
 import type { ComponentProps } from "react";
 
 import { createMockEntitiesState } from "__support__/store";
 import { renderWithProviders, screen } from "__support__/ui";
 import { getMetadata } from "metabase/selectors/metadata";
 import Question from "metabase-lib/v1/Question";
+import type { Card, Filter, JoinCondition } from "metabase-types/api";
 import {
   createMockCard,
   createMockStructuredDatasetQuery,
 } from "metabase-types/api/mocks";
-import { ORDERS, PEOPLE, PRODUCTS, PRODUCTS_ID, createSampleDatabase } from "metabase-types/api/mocks/presets";
+import {
+  ORDERS,
+  ORDERS_ID,
+  PRODUCTS,
+  PRODUCTS_ID,
+  createSampleDatabase,
+} from "metabase-types/api/mocks/presets";
 import {
   createMockQueryBuilderState,
   createMockState,
@@ -16,41 +24,25 @@ import {
 
 import { NotebookStepList } from "./NotebookStepList";
 
-const ORDERS_PRODUCT_JOIN_CONDITION = [
+const ORDERS_PRODUCT_JOIN_CONDITION: JoinCondition = [
   "=",
   ["field", ORDERS.PRODUCT_ID, null],
   ["field", PRODUCTS.ID, { "join-alias": "Products" }],
 ];
-
-const ORDERS_PEOPLE_JOIN_CONDITION = [
-  "=",
-  ["field", ORDERS.USER_ID, null],
-  ["field", PEOPLE.ID, { "join-alias": "People" }],
-];
-const RANDOM_ORDER_ID = 155;
 
 const PRODUCTS_JOIN = {
   alias: "Products",
   condition: ORDERS_PRODUCT_JOIN_CONDITION,
   "source-table": PRODUCTS_ID,
 };
-const ORDERS_PK_FILTER = ["=", ["field", ORDERS.ID, null], RANDOM_ORDER_ID];
+const ORDERS_FILTER: Filter = [">", ["field", ORDERS.TAX, null], 10];
 
 type SetupOpts = Partial<ComponentProps<typeof NotebookStepList>>;
 
-function setup(opts: SetupOpts = {}) {
+function setup(opts: SetupOpts = {}, card: Card) {
   const database = createSampleDatabase();
   const reportTimezone = "UTC";
 
-  const card = createMockCard({
-    dataset_query: createMockStructuredDatasetQuery({
-      query: {
-        "source-table": 1,
-        // joins: [PRODUCTS_JOIN],
-        filter: ["and", ORDERS_PK_FILTER],
-      }
-    }),
-  });
   const state = createMockState({
     qb: createMockQueryBuilderState({
       card,
@@ -76,21 +68,109 @@ function setup(opts: SetupOpts = {}) {
 }
 
 describe("NotebookStepList", () => {
-  it("renders a list of actions in correct order", () => {
-    setup();
+  it("renders a list of actions for data step", () => {
+    const card = createMockCard({
+      dataset_query: createMockStructuredDatasetQuery({
+        query: {
+          "source-table": ORDERS_ID,
+        },
+      }),
+    });
 
-    const actionButtonsContainer = screen.getAllByTestId(
-      "action-buttons",
-    ).at(-1) as HTMLElement;
-    const buttons = actionButtonsContainer.querySelectorAll("button");
+    setup({}, card);
 
-    screen.logTestingPlaygroundURL();
+    assertActionButtonsOrder([
+      "Join data",
+      "Custom column",
+      "Filter",
+      "Summarize",
+      "Sort",
+      "Row limit",
+    ]);
+  });
 
-    expect(buttons[0]).toHaveTextContent("Join data");
-    expect(buttons[1]).toHaveTextContent("Custom column");
-    expect(buttons[2]).toHaveTextContent("Filter");
-    expect(buttons[3]).toHaveTextContent("Summarize");
-    expect(buttons[4]).toHaveTextContent("Sort");
-    expect(buttons[5]).toHaveTextContent("Row limit");
+  it("renders a list of actions for join step", () => {
+    const card = createMockCard({
+      dataset_query: createMockStructuredDatasetQuery({
+        query: {
+          "source-table": ORDERS_ID,
+          joins: [PRODUCTS_JOIN],
+        },
+      }),
+    });
+    setup({}, card);
+
+    assertActionButtonsOrder([
+      "Join data",
+      "Custom column",
+      "Filter",
+      "Summarize",
+      "Sort",
+      "Row limit",
+    ]);
+  });
+
+  it("renders a list of actions for Custom column step", () => {
+    const card = createMockCard({
+      dataset_query: createMockStructuredDatasetQuery({
+        query: {
+          "source-table": ORDERS_ID,
+          expressions: {
+            "Custom column": ["+", 1, 1],
+          },
+        },
+      }),
+    });
+    setup({}, card);
+
+    assertActionButtonsOrder(["Filter", "Summarize", "Sort", "Row limit"]);
+  });
+
+  it("renders a list of actions for Filter step", () => {
+    const card = createMockCard({
+      dataset_query: createMockStructuredDatasetQuery({
+        query: {
+          "source-table": ORDERS_ID,
+          filter: ORDERS_FILTER,
+        },
+      }),
+    });
+    setup({}, card);
+
+    assertActionButtonsOrder(["Summarize", "Sort", "Row limit"]);
+  });
+
+  it("renders a list of actions for Summarize step", () => {
+    const card = createMockCard({
+      dataset_query: createMockStructuredDatasetQuery({
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+          breakout: [["field", ORDERS.CREATED_AT, null]],
+        },
+      }),
+    });
+    setup({}, card);
+
+    assertActionButtonsOrder([
+      "Sort",
+      "Row limit",
+      "Join data",
+      "Custom column",
+      "Filter",
+      "Summarize",
+    ]);
   });
 });
+
+function assertActionButtonsOrder(buttonNames: string[]) {
+  const actionButtonsContainer = screen
+    .getAllByTestId("action-buttons")
+    .at(-1) as HTMLElement;
+  const buttons = actionButtonsContainer.querySelectorAll("button");
+
+  expect(buttons.length).toBe(buttonNames.length);
+  buttonNames.forEach((name, index) => {
+    expect(buttons[index]).toHaveTextContent(name);
+  });
+}

--- a/frontend/src/metabase/querying/notebook/components/NotebookStepList/NotebookStepList.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookStepList/NotebookStepList.unit.spec.tsx
@@ -8,13 +8,33 @@ import {
   createMockCard,
   createMockStructuredDatasetQuery,
 } from "metabase-types/api/mocks";
-import { createSampleDatabase } from "metabase-types/api/mocks/presets";
+import { ORDERS, PEOPLE, PRODUCTS, PRODUCTS_ID, createSampleDatabase } from "metabase-types/api/mocks/presets";
 import {
   createMockQueryBuilderState,
   createMockState,
 } from "metabase-types/store/mocks";
 
 import { NotebookStepList } from "./NotebookStepList";
+
+const ORDERS_PRODUCT_JOIN_CONDITION = [
+  "=",
+  ["field", ORDERS.PRODUCT_ID, null],
+  ["field", PRODUCTS.ID, { "join-alias": "Products" }],
+];
+
+const ORDERS_PEOPLE_JOIN_CONDITION = [
+  "=",
+  ["field", ORDERS.USER_ID, null],
+  ["field", PEOPLE.ID, { "join-alias": "People" }],
+];
+const RANDOM_ORDER_ID = 155;
+
+const PRODUCTS_JOIN = {
+  alias: "Products",
+  condition: ORDERS_PRODUCT_JOIN_CONDITION,
+  "source-table": PRODUCTS_ID,
+};
+const ORDERS_PK_FILTER = ["=", ["field", ORDERS.ID, null], RANDOM_ORDER_ID];
 
 type SetupOpts = Partial<ComponentProps<typeof NotebookStepList>>;
 
@@ -23,7 +43,13 @@ function setup(opts: SetupOpts = {}) {
   const reportTimezone = "UTC";
 
   const card = createMockCard({
-    dataset_query: createMockStructuredDatasetQuery(),
+    dataset_query: createMockStructuredDatasetQuery({
+      query: {
+        "source-table": 1,
+        // joins: [PRODUCTS_JOIN],
+        filter: ["and", ORDERS_PK_FILTER],
+      }
+    }),
   });
   const state = createMockState({
     qb: createMockQueryBuilderState({
@@ -53,10 +79,12 @@ describe("NotebookStepList", () => {
   it("renders a list of actions in correct order", () => {
     setup();
 
-    const actionButtonsContainer = screen.getByTestId(
+    const actionButtonsContainer = screen.getAllByTestId(
       "action-buttons",
-    ) as HTMLElement;
+    ).at(-1) as HTMLElement;
     const buttons = actionButtonsContainer.querySelectorAll("button");
+
+    screen.logTestingPlaygroundURL();
 
     expect(buttons[0]).toHaveTextContent("Join data");
     expect(buttons[1]).toHaveTextContent("Custom column");

--- a/frontend/src/metabase/querying/notebook/components/NotebookStepList/NotebookStepList.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookStepList/NotebookStepList.unit.spec.tsx
@@ -1,0 +1,68 @@
+import type { ComponentProps } from "react";
+
+import { createMockEntitiesState } from "__support__/store";
+import { renderWithProviders, screen } from "__support__/ui";
+import { getMetadata } from "metabase/selectors/metadata";
+import Question from "metabase-lib/v1/Question";
+import {
+  createMockCard,
+  createMockStructuredDatasetQuery,
+} from "metabase-types/api/mocks";
+import { createSampleDatabase } from "metabase-types/api/mocks/presets";
+import {
+  createMockQueryBuilderState,
+  createMockState,
+} from "metabase-types/store/mocks";
+
+import { NotebookStepList } from "./NotebookStepList";
+
+type SetupOpts = Partial<ComponentProps<typeof NotebookStepList>>;
+
+function setup(opts: SetupOpts = {}) {
+  const database = createSampleDatabase();
+  const reportTimezone = "UTC";
+
+  const card = createMockCard({
+    dataset_query: createMockStructuredDatasetQuery(),
+  });
+  const state = createMockState({
+    qb: createMockQueryBuilderState({
+      card,
+    }),
+    entities: createMockEntitiesState({
+      databases: [database],
+    }),
+  });
+  const metadata = getMetadata(state);
+  const question = new Question(card, metadata);
+
+  renderWithProviders(
+    <NotebookStepList
+      question={question}
+      reportTimezone={reportTimezone}
+      updateQuestion={jest.fn()}
+      {...opts}
+    />,
+    {
+      storeInitialState: state,
+    },
+  );
+}
+
+describe("NotebookStepList", () => {
+  it("renders a list of actions in correct order", () => {
+    setup();
+
+    const actionButtonsContainer = screen.getByTestId(
+      "action-buttons",
+    ) as HTMLElement;
+    const buttons = actionButtonsContainer.querySelectorAll("button");
+
+    expect(buttons[0]).toHaveTextContent("Join data");
+    expect(buttons[1]).toHaveTextContent("Custom column");
+    expect(buttons[2]).toHaveTextContent("Filter");
+    expect(buttons[3]).toHaveTextContent("Summarize");
+    expect(buttons[4]).toHaveTextContent("Sort");
+    expect(buttons[5]).toHaveTextContent("Row limit");
+  });
+});

--- a/frontend/src/metabase/querying/notebook/components/NotebookStepList/NotebookStepList.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookStepList/NotebookStepList.unit.spec.tsx
@@ -5,7 +5,12 @@ import { createMockEntitiesState } from "__support__/store";
 import { renderWithProviders, screen } from "__support__/ui";
 import { getMetadata } from "metabase/selectors/metadata";
 import Question from "metabase-lib/v1/Question";
-import type { Card, Filter, JoinCondition } from "metabase-types/api";
+import type {
+  Card,
+  Filter,
+  JoinCondition,
+  StructuredQuery,
+} from "metabase-types/api";
 import {
   createMockCard,
   createMockStructuredDatasetQuery,
@@ -69,13 +74,7 @@ function setup(opts: SetupOpts = {}, card: Card) {
 
 describe("NotebookStepList", () => {
   it("renders a list of actions for data step", () => {
-    const card = createMockCard({
-      dataset_query: createMockStructuredDatasetQuery({
-        query: {
-          "source-table": ORDERS_ID,
-        },
-      }),
-    });
+    const card = createOrdersCard();
 
     setup({}, card);
 
@@ -90,13 +89,8 @@ describe("NotebookStepList", () => {
   });
 
   it("renders a list of actions for join step", () => {
-    const card = createMockCard({
-      dataset_query: createMockStructuredDatasetQuery({
-        query: {
-          "source-table": ORDERS_ID,
-          joins: [PRODUCTS_JOIN],
-        },
-      }),
+    const card = createOrdersCard({
+      joins: [PRODUCTS_JOIN],
     });
     setup({}, card);
 
@@ -111,15 +105,10 @@ describe("NotebookStepList", () => {
   });
 
   it("renders a list of actions for Custom column step", () => {
-    const card = createMockCard({
-      dataset_query: createMockStructuredDatasetQuery({
-        query: {
-          "source-table": ORDERS_ID,
-          expressions: {
-            "Custom column": ["+", 1, 1],
-          },
-        },
-      }),
+    const card = createOrdersCard({
+      expressions: {
+        "Custom column": ["+", 1, 1],
+      },
     });
     setup({}, card);
 
@@ -127,13 +116,8 @@ describe("NotebookStepList", () => {
   });
 
   it("renders a list of actions for Filter step", () => {
-    const card = createMockCard({
-      dataset_query: createMockStructuredDatasetQuery({
-        query: {
-          "source-table": ORDERS_ID,
-          filter: ORDERS_FILTER,
-        },
-      }),
+    const card = createOrdersCard({
+      filter: ORDERS_FILTER,
     });
     setup({}, card);
 
@@ -141,14 +125,9 @@ describe("NotebookStepList", () => {
   });
 
   it("renders a list of actions for Summarize step", () => {
-    const card = createMockCard({
-      dataset_query: createMockStructuredDatasetQuery({
-        query: {
-          "source-table": ORDERS_ID,
-          aggregation: [["count"]],
-          breakout: [["field", ORDERS.CREATED_AT, null]],
-        },
-      }),
+    const card = createOrdersCard({
+      aggregation: [["count"]],
+      breakout: [["field", ORDERS.CREATED_AT, null]],
     });
     setup({}, card);
 
@@ -172,5 +151,16 @@ function assertActionButtonsOrder(buttonNames: string[]) {
   expect(buttons.length).toBe(buttonNames.length);
   buttonNames.forEach((name, index) => {
     expect(buttons[index]).toHaveTextContent(name);
+  });
+}
+
+function createOrdersCard(opts: Partial<StructuredQuery> = {}): Card {
+  return createMockCard({
+    dataset_query: createMockStructuredDatasetQuery({
+      query: {
+        "source-table": ORDERS_ID,
+        ...opts,
+      },
+    }),
   });
 }


### PR DESCRIPTION
[Epic](https://github.com/metabase/metabase/issues/47911)

Changes order of the action buttons to the more natural

<img width="1339" alt="Screenshot 2024-09-25 at 00 11 36" src="https://github.com/user-attachments/assets/0c0c6276-c508-4ddf-b441-2863d30f4159">
<img width="1320" alt="Screenshot 2024-09-25 at 00 11 47" src="https://github.com/user-attachments/assets/aca636d9-432d-464a-b56c-72d6dd6f21a1">

<img width="1411" alt="Screenshot 2024-09-25 at 00 12 02" src="https://github.com/user-attachments/assets/46938f82-3382-4cf6-bbf6-812e3c03f50c">
<img width="1335" alt="Screenshot 2024-09-25 at 00 12 23" src="https://github.com/user-attachments/assets/186e25e2-26eb-4f59-ae9b-ff798b1345b9">
<img width="1283" alt="Screenshot 2024-09-25 at 00 12 48" src="https://github.com/user-attachments/assets/8a3a6127-5da4-4a37-a6d6-285422649ed4">
