### PR TITLE
Pre fill non-sensitive user information during setup for hosted instances

### DIFF
--- a/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
@@ -8,9 +8,12 @@ import {
   expectNoBadSnowplowEvents,
   isEE,
   main,
+  mockSessionProperty,
+  onlyOnEE,
   popover,
   resetSnowplow,
   restore,
+  setTokenFeatures,
 } from "e2e/support/helpers";
 import { SUBSCRIBE_URL } from "metabase/setup/constants";
 
@@ -230,6 +233,29 @@ describe("scenarios > setup", () => {
         "have.value",
         "Epic Team",
       );
+    });
+  });
+
+  it("should pre-fill user info for hosted instances (infra-frontend#1109)", () => {
+    onlyOnEE();
+    setTokenFeatures("none");
+    mockSessionProperty("is-hosted?", true);
+
+    cy.visit(
+      "/setup?first_name=John&last_name=Doe&email=john@doe.test&site_name=Doe%20Unlimited",
+    );
+
+    skipWelcomePage();
+    selectPreferredLanguageAndContinue();
+
+    cy.findByTestId("setup-forms").within(() => {
+      cy.findByDisplayValue("John").should("exist");
+      cy.findByDisplayValue("Doe").should("exist");
+      cy.findByDisplayValue("john@doe.test").should("exist");
+      cy.findByDisplayValue("Doe Unlimited").should("exist");
+      cy.findByLabelText("Create a password")
+        .should("be.focused")
+        .and("be.empty");
     });
   });
 

--- a/frontend/src/metabase/setup/components/UserForm/UserForm.tsx
+++ b/frontend/src/metabase/setup/components/UserForm/UserForm.tsx
@@ -93,7 +93,10 @@ export const UserForm = ({
           type="password"
           title={t`Create a password`}
           placeholder={t`Shhh...`}
-          autoFocus={isHosted}
+          // Hosted instances always pass user information in the URLSearchParams
+          // during the initial setup. Password is the first empty field
+          // so it makes sense to focus on it.
+          autoFocus={isHosted && initialValues.site_name !== ""}
         />
         <FormInput
           name="password_confirm"

--- a/frontend/src/metabase/setup/components/UserForm/UserForm.tsx
+++ b/frontend/src/metabase/setup/components/UserForm/UserForm.tsx
@@ -32,12 +32,14 @@ const USER_SCHEMA = Yup.object({
 
 interface UserFormProps {
   user?: UserInfo;
+  isHosted: boolean;
   onValidatePassword: (password: string) => Promise<string | undefined>;
   onSubmit: (user: UserInfo) => Promise<void>;
 }
 
 export const UserForm = ({
   user,
+  isHosted,
   onValidatePassword,
   onSubmit,
 }: UserFormProps) => {
@@ -66,7 +68,7 @@ export const UserForm = ({
             title={t`First name`}
             placeholder={t`Johnny`}
             nullable
-            autoFocus
+            autoFocus={!isHosted}
           />
           <FormInput
             name="last_name"
@@ -91,6 +93,7 @@ export const UserForm = ({
           type="password"
           title={t`Create a password`}
           placeholder={t`Shhh...`}
+          autoFocus={isHosted}
         />
         <FormInput
           name="password_confirm"

--- a/frontend/src/metabase/setup/components/UserStep/UserStep.tsx
+++ b/frontend/src/metabase/setup/components/UserStep/UserStep.tsx
@@ -17,19 +17,6 @@ import { StepDescription } from "./UserStep.styled";
 export const UserStep = ({ stepLabel }: NumberedStepProps): JSX.Element => {
   const { isStepActive, isStepCompleted } = useStep("user_info");
 
-  const params = new URLSearchParams(window.location.search);
-  const getParam = (key: string, defaultValue = "") =>
-    params.get(key) || defaultValue;
-
-  const cloudUser = {
-    first_name: getParam("first_name"),
-    last_name: getParam("last_name"),
-    email: getParam("email"),
-    site_name: getParam("site_name"),
-    password: "",
-    password_confirm: "",
-  };
-
   const user = useSelector(getUser);
   const isHosted = useSelector(getIsHosted);
 
@@ -58,7 +45,7 @@ export const UserStep = ({ stepLabel }: NumberedStepProps): JSX.Element => {
         </StepDescription>
       )}
       <UserForm
-        user={isHosted ? cloudUser : user}
+        user={user}
         isHosted={isHosted}
         onValidatePassword={validatePassword}
         onSubmit={handleSubmit}

--- a/frontend/src/metabase/setup/components/UserStep/UserStep.tsx
+++ b/frontend/src/metabase/setup/components/UserStep/UserStep.tsx
@@ -16,6 +16,20 @@ import { StepDescription } from "./UserStep.styled";
 
 export const UserStep = ({ stepLabel }: NumberedStepProps): JSX.Element => {
   const { isStepActive, isStepCompleted } = useStep("user_info");
+
+  const params = new URLSearchParams(window.location.search);
+  const getParam = (key: string, defaultValue = "") =>
+    params.get(key) || defaultValue;
+
+  const cloudUser = {
+    first_name: getParam("first_name"),
+    last_name: getParam("last_name"),
+    email: getParam("email"),
+    site_name: getParam("site_name"),
+    password: "",
+    password_confirm: "",
+  };
+
   const user = useSelector(getUser);
   const isHosted = useSelector(getIsHosted);
 
@@ -44,7 +58,7 @@ export const UserStep = ({ stepLabel }: NumberedStepProps): JSX.Element => {
         </StepDescription>
       )}
       <UserForm
-        user={user}
+        user={isHosted ? cloudUser : user}
         onValidatePassword={validatePassword}
         onSubmit={handleSubmit}
       />

--- a/frontend/src/metabase/setup/components/UserStep/UserStep.tsx
+++ b/frontend/src/metabase/setup/components/UserStep/UserStep.tsx
@@ -59,6 +59,7 @@ export const UserStep = ({ stepLabel }: NumberedStepProps): JSX.Element => {
       )}
       <UserForm
         user={isHosted ? cloudUser : user}
+        isHosted={isHosted}
         onValidatePassword={validatePassword}
         onSubmit={handleSubmit}
       />

--- a/frontend/src/metabase/setup/components/UserStep/UserStep.unit.spec.tsx
+++ b/frontend/src/metabase/setup/components/UserStep/UserStep.unit.spec.tsx
@@ -46,7 +46,8 @@ describe("UserStep", () => {
   });
 
   it("should autofocus the password input field for hosted instances", () => {
-    setup({ step: "user_info", isHosted: true });
+    const user = createMockUserInfo();
+    setup({ step: "user_info", isHosted: true, user });
 
     expect(screen.getByLabelText("Create a password")).toHaveFocus();
   });

--- a/frontend/src/metabase/setup/reducers.ts
+++ b/frontend/src/metabase/setup/reducers.ts
@@ -23,8 +23,8 @@ const getUserFromQueryParams = () => {
     params.get(key) || defaultValue;
 
   return {
-    first_name: getParam("first_name"),
-    last_name: getParam("last_name"),
+    first_name: getParam("first_name") || null,
+    last_name: getParam("last_name") || null,
     email: getParam("email"),
     site_name: getParam("site_name"),
     password: "",

--- a/frontend/src/metabase/setup/reducers.ts
+++ b/frontend/src/metabase/setup/reducers.ts
@@ -17,15 +17,33 @@ import {
   updateTracking,
 } from "./actions";
 
+const getUserFromQueryParams = () => {
+  const params = new URLSearchParams(window.location.search);
+  const getParam = (key: string, defaultValue = "") =>
+    params.get(key) || defaultValue;
+
+  return {
+    first_name: getParam("first_name"),
+    last_name: getParam("last_name"),
+    email: getParam("email"),
+    site_name: getParam("site_name"),
+    password: "",
+    password_confirm: "",
+  };
+};
+
 const initialState: SetupState = {
   step: "welcome",
   isLocaleLoaded: false,
   isTrackingAllowed: true,
+  user: getUserFromQueryParams(),
 };
 
 export const reducer = createReducer(initialState, builder => {
   builder.addCase(loadUserDefaults.fulfilled, (state, { payload: user }) => {
-    state.user = user;
+    if (user) {
+      state.user = user;
+    }
   });
   builder.addCase(
     loadLocaleDefaults.fulfilled,


### PR DESCRIPTION
### What does this PR accomplish?
This PR prepares the main Metabase app to accept the parameterized non-sensitive user information that is to be used during the initial setup. Once the cloud instance is created, it will redirect to the Metabase setup. We already have the necessary user information - no need to force them to type all that again.

See https://github.com/metabase/infra-frontend/issues/1109 for more information.

### Testing
Result of a complementary E2E test:
<img width="1993" alt="image" src="https://github.com/user-attachments/assets/5e2b5446-5657-4e73-89f0-106c06c9140e">
