### PR TITLE
perf: Use vectors to iterate over all user permissions

### DIFF
--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -250,16 +250,19 @@
 (defn permissions-set
   "Return a set of all permissions object paths that `user-or-id` has been granted access to. (2 DB Calls)"
   [user-or-id]
-  (set (when-let [user-id (u/the-id user-or-id)]
-         (concat
-          ;; Current User always gets readwrite perms for their Personal Collection and for its descendants! (1 DB Call)
-          (map perms/collection-readwrite-path (collection/user->personal-collection-and-descendant-ids user-or-id))
-          ;; include the other Perms entries for any Group this User is in (1 DB Call)
-          (map :object (mdb.query/query {:select [:p.object]
-                                         :from   [[:permissions_group_membership :pgm]]
-                                         :join   [[:permissions_group :pg] [:= :pgm.group_id :pg.id]
-                                                  [:permissions :p]        [:= :p.group_id :pg.id]]
-                                         :where  [:= :pgm.user_id user-id]}))))))
+  (let [s
+        (set (when-let [user-id (u/the-id user-or-id)]
+               (concat
+                ;; Current User always gets readwrite perms for their Personal Collection and for its descendants! (1 DB Call)
+                (map perms/collection-readwrite-path (collection/user->personal-collection-and-descendant-ids user-or-id))
+                ;; include the other Perms entries for any Group this User is in (1 DB Call)
+                (map :object (mdb.query/query {:select [:p.object]
+                                               :from   [[:permissions_group_membership :pgm]]
+                                               :join   [[:permissions_group :pg] [:= :pgm.group_id :pg.id]
+                                                        [:permissions :p]        [:= :p.group_id :pg.id]]
+                                               :where  [:= :pgm.user_id user-id]})))))]
+    ;; Append permissions as a vector for more efficient iteration in checks that go over each permission linearly.
+    (with-meta s {:as-vec (vec s)})))
 
 ;;; --------------------------------------------------- Hydration ----------------------------------------------------
 

--- a/src/metabase/util/performance.clj
+++ b/src/metabase/util/performance.clj
@@ -1,6 +1,6 @@
 (ns metabase.util.performance
   "Functions and utilities for faster processing."
-  (:refer-clojure :exclude [reduce mapv])
+  (:refer-clojure :exclude [reduce mapv some])
   (:import (clojure.lang LazilyPersistentVector RT)))
 
 (set! *warn-on-reflection* true)
@@ -126,3 +126,8 @@
       ([x y] (mapv #(% x y) fns))
       ([x y z] (mapv #(% x y z) fns))
       ([x y z & args] (mapv #(apply % x y z args) fns)))))
+
+(defn some
+  "Like `clojure.core/some` but uses our custom `reduce` which in turn uses iterators."
+  [f coll]
+  (unreduced (reduce #(when-let [match (f %2)] (reduced match)) nil coll)))


### PR DESCRIPTION
Doing a follow-up on https://github.com/metabase/metabase/issues/46695, I've noticed that if the user has a lot of collections (and, possibly, other objects – I'm not sure what else can grant unique path-like permissions for the user), iterating through the hashset of those permissions is not very efficient. Because of how Clojure is implemented, iterating over a PersistentHashSet produces allocations and is significantly slower.

```clj
  (let [coll (vec (range 100))]
    (time+ (reduce (fn [acc _] (inc acc)) 0 coll)))

  ;; Time per call: 501 ns   Alloc per call: 16b

  (let [coll (set (range 100))]
    (time+ (reduce (fn [acc _] (inc acc)) 0 coll)))

  ;; Time per call: 2.21 us   Alloc per call: 1,040b
```

Given that `set-has-full-permissions-for-set?` is basically O(n*m), this is worth improving.

The proposed PR is a bandaid of sorts. We can't simply make the `permissions-set` a vector – it is also used to look up permissions in it associatively. So the patch instead attaches the vector version to the set metadata, and the relevant functions are taught to look for a vector first.