### PR TITLE
perf: Improve the performance of /api/collection/tree when there are many collections

### DIFF
--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -637,7 +637,7 @@
                                                                          :id
                                                                          {:include-archived-items :all}))
 
-        descendant-collection-ids (map u/the-id descendant-collections)
+        descendant-collection-ids (mapv u/the-id descendant-collections)
 
         child-type->coll-id-set
         (reduce (fn [acc {collection-id :collection_id, card-type :type, :as _card}]

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -83,8 +83,10 @@
   ;; in some circumstances we don't have a `:type` on the collection (e.g. search or collection items lists, where we
   ;; select a subset of columns). Use the type if it's there, but fall back to the ID to be sure.
   ;; We can't *only* use the id because getting that requires selecting a collection :sweat-smile:
-  (or (= (:type collection-or-id) trash-collection-type)
-      (some-> collection-or-id u/id (= (trash-collection-id)))))
+  (let [type (:type collection-or-id ::not-found)]
+    (if (identical? type ::not-found)
+      (some-> collection-or-id u/id (= (trash-collection-id)))
+      (= type trash-collection-type))))
 
 (defn is-trash-or-descendant?
   "Is this the trash collection, or a descendant of it?"


### PR DESCRIPTION
This PR is a kitchen sink of small changes I figured out when investigating whether it is possible to improve https://github.com/metabase/metabase/issues/46695 further (`/api/collection/tree` still took ~1.5 seconds for 5000 collections). While the benchmark may be artificial, it actually highlighted a few lower-level issues, fixing which will influence other endpoints too.

Anyway:
1. `is-trash?` almost always did additional transforms even if the collection instance contained `:type` (but was nil).
2. Improved `annotate-collections` and `collections->tree`.