### PR TITLE
Use current user api instead of search to check for models

### DIFF
--- a/frontend/src/metabase-types/api/user.ts
+++ b/frontend/src/metabase-types/api/user.ts
@@ -36,6 +36,10 @@ export interface User extends BaseUser {
   } | null;
 }
 
+export interface CurrentUser extends User {
+  has_model: boolean;
+}
+
 export interface UserListResult {
   id: UserId;
   first_name: string | null;

--- a/frontend/src/metabase/api/user.ts
+++ b/frontend/src/metabase/api/user.ts
@@ -1,3 +1,4 @@
+import { updateCurrentUser } from "metabase/redux/user";
 import type {
   CreateUserRequest,
   CurrentUser,
@@ -50,6 +51,13 @@ export const userApi = Api.injectEndpoints({
         url: "/api/user/current",
       }),
       providesTags: user => (user ? provideUserTags(user) : []),
+      onCacheEntryAdded: async (_, { dispatch, cacheDataLoaded }) => {
+        // lots of stuff relies on the currentUser global state, so let's also update it there
+        const response = await cacheDataLoaded;
+        if (response.data) {
+          dispatch(updateCurrentUser(response.data));
+        }
+      },
     }),
     createUser: builder.mutation<User, CreateUserRequest>({
       query: body => ({

--- a/frontend/src/metabase/api/user.ts
+++ b/frontend/src/metabase/api/user.ts
@@ -1,5 +1,6 @@
 import type {
   CreateUserRequest,
+  CurrentUser,
   ListUsersRequest,
   ListUsersResponse,
   UpdatePasswordRequest,
@@ -40,6 +41,13 @@ export const userApi = Api.injectEndpoints({
       query: id => ({
         method: "GET",
         url: `/api/user/${id}`,
+      }),
+      providesTags: user => (user ? provideUserTags(user) : []),
+    }),
+    getCurrentUser: builder.query<CurrentUser, void>({
+      query: () => ({
+        method: "GET",
+        url: "/api/user/current",
       }),
       providesTags: user => (user ? provideUserTags(user) : []),
     }),
@@ -92,6 +100,7 @@ export const {
   useListUsersQuery,
   useListUserRecipientsQuery,
   useGetUserQuery,
+  useGetCurrentUserQuery,
   useCreateUserMutation,
   useUpdatePasswordMutation,
   useDeactivateUserMutation,

--- a/frontend/src/metabase/common/hooks/index.ts
+++ b/frontend/src/metabase/common/hooks/index.ts
@@ -4,3 +4,4 @@ export * from "./use-docs-url";
 export * from "./use-locale";
 export * from "./use-notification-channels";
 export * from "./use-has-token-feature";
+export * from "./use-has-model";

--- a/frontend/src/metabase/common/hooks/use-has-model.tsx
+++ b/frontend/src/metabase/common/hooks/use-has-model.tsx
@@ -1,0 +1,11 @@
+import { skipToken, useGetCurrentUserQuery } from "metabase/api";
+
+// check if the user has access to any model
+export const useHasModel = (
+  { enabled }: { enabled?: boolean } = { enabled: true },
+) => {
+  const { data: currentUser } = useGetCurrentUserQuery(
+    enabled ? undefined : skipToken,
+  );
+  return !!currentUser?.has_model;
+};

--- a/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
+++ b/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { useMemo } from "react";
 import { t } from "ttag";
 
+import { useHasModel } from "metabase/common/hooks";
 import EntityMenu from "metabase/components/EntityMenu";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
@@ -16,7 +17,6 @@ export interface NewItemMenuProps {
   trigger?: ReactNode;
   triggerIcon?: string;
   triggerTooltip?: string;
-  hasModels: boolean;
   hasDataAccess: boolean;
   hasNativeWrite: boolean;
   hasDatabaseWithJsonEngine: boolean;
@@ -40,7 +40,6 @@ const NewItemMenu = ({
   trigger,
   triggerIcon,
   triggerTooltip,
-  hasModels,
   hasDataAccess,
   hasNativeWrite,
   hasDatabaseWithJsonEngine,
@@ -52,6 +51,8 @@ const NewItemMenu = ({
   const lastUsedDatabaseId = useSelector(state =>
     getSetting(state, "last-used-native-database-id"),
   );
+
+  const hasModels = useHasModel();
 
   const menuItems = useMemo(() => {
     const items: NewMenuItem[] = [];

--- a/frontend/src/metabase/containers/NewItemMenu/NewItemMenu.tsx
+++ b/frontend/src/metabase/containers/NewItemMenu/NewItemMenu.tsx
@@ -4,7 +4,6 @@ import _ from "underscore";
 
 import NewItemMenu from "metabase/components/NewItemMenu";
 import Databases from "metabase/entities/databases";
-import Search from "metabase/entities/search";
 import { closeNavbar } from "metabase/redux/app";
 import {
   getHasDataAccess,
@@ -41,13 +40,6 @@ const mapDispatchToProps = {
 export default _.compose(
   Databases.loadList({
     loadingAndErrorWrapper: false,
-  }),
-  Search.loadList({
-    // Checking if there is at least one model,
-    // so we can decide if "Action" option should be shown
-    query: { models: ["dataset"], limit: 1 },
-    loadingAndErrorWrapper: false,
-    listName: "models",
   }),
   connect(mapStateToProps, mapDispatchToProps),
 )(NewItemMenu);

--- a/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
@@ -4,10 +4,7 @@ import type { WithRouterProps } from "react-router";
 import { push } from "react-router-redux";
 import { t } from "ttag";
 
-import {
-  useDatabaseListQuery,
-  useSearchListQuery,
-} from "metabase/common/hooks";
+import { useDatabaseListQuery, useHasModel } from "metabase/common/hooks";
 import Collections from "metabase/entities/collections/collections";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
@@ -30,16 +27,13 @@ export const useCommandPaletteBasicActions = ({
   const { data: databases = [] } = useDatabaseListQuery({
     enabled: isLoggedIn,
   });
-  const { data: models = [] } = useSearchListQuery({
-    query: { models: ["dataset"], limit: 1 },
-    enabled: isLoggedIn,
-  });
+
+  const hasModels = useHasModel({ enabled: isLoggedIn });
 
   const hasDataAccess = getHasDataAccess(databases);
   const hasNativeWrite = getHasNativeWrite(databases);
   const hasDatabaseWithActionsEnabled =
     getHasDatabaseWithActionsEnabled(databases);
-  const hasModels = models.length > 0;
 
   const openNewModal = useCallback(
     (modalId: string) => {

--- a/frontend/src/metabase/redux/user.ts
+++ b/frontend/src/metabase/redux/user.ts
@@ -1,17 +1,17 @@
 import { createAction, createReducer } from "@reduxjs/toolkit";
 
+import { userApi } from "metabase/api/user";
 import Dashboards from "metabase/entities/dashboards";
 import Users from "metabase/entities/users";
 import { createAsyncThunk } from "metabase/lib/redux";
 import { CLOSE_QB_NEWB_MODAL } from "metabase/query_builder/actions";
-import { UserApi } from "metabase/services";
-import type { User } from "metabase-types/api";
+import type { CurrentUser, User } from "metabase-types/api";
 
 export const refreshCurrentUser = createAsyncThunk(
   "metabase/user/REFRESH_CURRENT_USER",
-  async (_, { fulfillWithValue }) => {
+  async (_, { dispatch, fulfillWithValue }) => {
     try {
-      return UserApi.current();
+      await dispatch(userApi.endpoints.getCurrentUser.initiate());
     } catch (e) {
       return fulfillWithValue(null);
     }
@@ -25,6 +25,11 @@ export const loadCurrentUser = createAsyncThunk(
       await dispatch(refreshCurrentUser());
     }
   },
+);
+
+// update current user with provided value
+export const updateCurrentUser = createAction<CurrentUser>(
+  "metabase/user/UPDATE_CURRENT_USER",
 );
 
 export const clearCurrentUser = createAction(
@@ -61,5 +66,8 @@ export const currentUser = createReducer<User | null>(null, builder => {
       ) {
         state.custom_homepage = null;
       }
+    })
+    .addCase(updateCurrentUser, (_state, { payload: currentUser }) => {
+      return currentUser;
     });
 });

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -429,7 +429,6 @@ export const SetupApi = {
 
 export const UserApi = {
   list: GET("/api/user/recipients"),
-  current: GET("/api/user/current"),
   update_qbnewb: PUT("/api/user/:id/modal/qbnewb"),
 };
 


### PR DESCRIPTION
### Description

In several places, but most importantly in the new item menu (on every page load) we call the heavy search API to check if the user has access to any models. We also have this information in the much faster current user API, so we should get it from there.

Before 
```ts
Search.loadList({
    query: { models: ["dataset"], limit: 1 },
    loadingAndErrorWrapper: false,
    listName: "models",
  }),
```

After
```ts
const hasModels = useHasModel();
```

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
