### PR TITLE
Add missing "Dashboard" model to the assertion

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
@@ -222,7 +222,7 @@
                                                       {:file ba}))
                           log (slurp (io/input-stream res))]
                       (testing "3 header lines, then cards+database+collection, then the error"
-                        (is (= #{"Card" "Database" "Collection"}
+                        (is (= #{"Card" "Dashboard" "Database" "Collection"}
                                (log-types (str/split-lines log))))
                         (is (re-find #"Failed to read file for Collection DoesNotExist" log))
                         (is (re-find #"Cannot find file entry" log)) ;; underlying error


### PR DESCRIPTION
### What does this PR accomplish?
This PR attempts to fix a failing backend test by adding a missing "Dashboard" model to the assertion.

> [!Important]
> I am not sure if the actual serialization is broken or did @piranha accidentally omit this model from the assertion. Other tests in this suite have this assertion and I didn't see any part that removes dashboards from the export. So this is my half-blind stab at the fix with an assumption that the assertion is wrong.
>
> No idea why it passes/fails intermittently!

The test is failing in `master`
https://github.com/metabase/metabase/actions/runs/10925786668/job/30332668548#step:3:742

It is failing badly in the `release-x.50.x` branch
https://github.com/metabase/metabase/actions/runs/10948918535/job/30404298358

It seems to be exacerbated in some cases (see the release branch run). One such example is when we bumped Snowflake driver in #47997 where basically all driver CI jobs failed.

The actual diff from the failing logs:
```
ERROR /api/ee/serialization/import 3 header lines, then cards+database+collection, then the error
expected: #{"Card" "Collection" "Database"}
  actual: #{"Card" "Collection" "Dashboard" "Database"}
    diff: + #{"Dashboard"}
```