### PR TITLE
reduce logs in cypress tests by checking before removing folder

### DIFF
--- a/e2e/support/commands/downloads/downloadUtils-untyped.js
+++ b/e2e/support/commands/downloads/downloadUtils-untyped.js
@@ -4,7 +4,11 @@ const path = require("path");
 
 const removeDirectory = path => {
   try {
-    fs.rmdirSync(path, { maxRetries: 10, recursive: true });
+    if (fs.existsSync(path)) {
+      fs.rmdirSync(path, { maxRetries: 10, recursive: true });
+    } else {
+      console.log("Directory does not exist in `removeDirectory`:", path);
+    }
   } catch (error) {
     console.log("Error while removing directory", path, error);
   }


### PR DESCRIPTION

This should make cypress logs a bit more readable as before this change this was the output:

<img width="1988" alt="image" src="https://github.com/user-attachments/assets/cc810c5d-2578-42f3-9c3a-65aba7bb35cf">

We run deleteDownloadsFolder in beforeEach, it can happen that the folder doesn't exist on first run or if we don't download anything in that specific test (maybe because it stops for a failure before the download)