### PR TITLE
Speed up minimal Postgres fulltext search 

### DIFF
--- a/dev/src/dev/search.clj
+++ b/dev/src/dev/search.clj
@@ -1,8 +1,12 @@
 (ns dev.search
   (:require
+   [metabase.api.common :as api]
+   [metabase.search :as search]
    [metabase.search.postgres.core :as search.postgres]
    [metabase.search.postgres.index :as search.index]
    [metabase.search.postgres.index-test :refer [legacy-results]]
+   [metabase.server.middleware.offset-paging :as mw.offset-paging]
+   [metabase.test :as mt]
    [toucan2.core :as t2]))
 
 (defn- basic-view [xs]
@@ -60,3 +64,46 @@
   ;; oh! this monstrocity is actually 2x faster than baseline B-)
   (mini-bench 100 :hybrid-multi "sample")
   (mini-bench 100 :minimal "sample"))
+
+(defn- test-search [search-string & [search-engine]]
+  (let [user-id    (mt/user->id :crowberto)
+        user-perms #{"/"}]
+    (binding [api/*current-user*                 (atom (t2/select-one :model/User user-id))
+              api/*current-user-id*              user-id
+              api/*is-superuser?*                true
+              api/*current-user-permissions-set* (atom user-perms)]
+      (search/search
+       (search/search-context
+        {:archived                            nil
+         :created-at                          nil
+         :created-by                          #{}
+         :current-user-id                     379
+         :is-superuser?                       true
+         :current-user-perms                  user-perms
+         :filter-items-in-personal-collection nil
+         :last-edited-at                      nil
+         :last-edited-by                      #{}
+         :limit                               mw.offset-paging/*limit*
+         :model-ancestors?                    nil
+         :models                              search/all-models
+         :offset                              mw.offset-paging/*offset*
+         :search-engine                       search-engine
+         :search-native-query                 nil
+         :search-string                       search-string
+         :table-db-id                         nil
+         :verified                            nil
+         :ids                                 nil})))))
+
+(comment
+  (require '[clj-async-profiler.core :as prof])
+  (prof/serve-ui 8080)
+
+  (prof/profile
+   (count
+    (dotimes [_ 100]
+      (test-search "trivia"))))
+
+  (prof/profile
+   (count
+    (dotimes [_ 1000]
+      (test-search "trivia" "minimal")))))

--- a/enterprise/backend/test/metabase_enterprise/search/scoring_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/search/scoring_test.clj
@@ -121,7 +121,7 @@
              (-> (scoring/top-results
                   results
                   1
-                  (map #(scoring/score-and-result % {:search-string search-string})))
+                  (keep #(scoring/score-and-result % {:search-string search-string})))
                  first
                  :name))))))
 

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -185,11 +185,11 @@
   (prof/serve-ui 8080)
 
   (prof/profile
-      (count
-       (dotimes [_ 100]
-         (test-search "trivia"))))
+   (count
+    (dotimes [_ 100]
+      (test-search "trivia"))))
 
   (prof/profile
-      (count
-       (dotimes [_ 1000]
-         (test-search "trivia" "minimal")))))
+   (count
+    (dotimes [_ 1000]
+      (test-search "trivia" "minimal")))))

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -8,8 +8,7 @@
    [metabase.server.middleware.offset-paging :as mw.offset-paging]
    [metabase.util :as u]
    [metabase.util.malli.schema :as ms]
-   [ring.util.response :as response]
-   [toucan2.core :as t2]))
+   [ring.util.response :as response]))
 
 (set! *warn-on-reflection* true)
 
@@ -152,44 +151,3 @@
        :ids                                 (set ids)}))))
 
 (api/define-routes +engine-cookie)
-
-(defn- test-search [search-string & [search-engine]]
-  (binding [api/*current-user* (atom (t2/select-one :model/User :email "chris@metabase.com"))
-            api/*current-user-id* 379
-            api/*is-superuser?* true
-            api/*current-user-permissions-set* (atom #{"/"})]
-    (search/search
-     (search/search-context
-      {:archived                            nil
-       :created-at                          nil
-       :created-by                          #{}
-       :current-user-id                     379
-       :is-superuser?                       true
-       :current-user-perms                  #{"/"}
-       :filter-items-in-personal-collection nil
-       :last-edited-at                      nil
-       :last-edited-by                      #{}
-       :limit                               mw.offset-paging/*limit*
-       :model-ancestors?                    nil
-       :models                              search/all-models
-       :offset                              mw.offset-paging/*offset*
-       :search-engine                       search-engine
-       :search-native-query                 nil
-       :search-string                       search-string
-       :table-db-id                         nil
-       :verified                            nil
-       :ids                                 nil}))))
-
-(comment
-  (require '[clj-async-profiler.core :as prof])
-  (prof/serve-ui 8080)
-
-  (prof/profile
-   (count
-    (dotimes [_ 100]
-      (test-search "trivia"))))
-
-  (prof/profile
-   (count
-    (dotimes [_ 1000]
-      (test-search "trivia" "minimal")))))

--- a/src/metabase/search.clj
+++ b/src/metabase/search.clj
@@ -47,7 +47,7 @@
      :fulltext (when (is-postgres?) search.postgres/model-set)
      :minimal  (when (is-postgres?) search.postgres/model-set)
      :in-place search.impl/query-model-set
-    nil)
+     nil)
 
    (log/warnf "%s search not supported for your AppDb, using %s" search-engine default-engine)
    (recur default-engine)))
@@ -58,7 +58,7 @@
      :fulltext (when (is-postgres?) search.postgres/no-scoring)
      :minimal  (when (is-postgres?) search.postgres/no-scoring)
      :in-place scoring/score-and-result
-    nil)
+     nil)
 
    (log/warnf "%s search not supported for your AppDb, using %s" search-engine default-engine)
    (recur default-engine)))

--- a/src/metabase/search.clj
+++ b/src/metabase/search.clj
@@ -8,6 +8,7 @@
    [metabase.search.config :as search.config]
    [metabase.search.impl :as search.impl]
    [metabase.search.postgres.core :as search.postgres]
+   [metabase.search.scoring :as scoring]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [potemkin :as p]))
@@ -37,6 +38,7 @@
      :in-place search.impl/in-place
      nil)
 
+   (log/warnf "%s search not supported for your AppDb, using %s" search-engine default-engine)
    (recur default-engine)))
 
 (defn- model-set-fn [search-engine]
@@ -45,6 +47,17 @@
      :fulltext (when (is-postgres?) search.postgres/model-set)
      :minimal  (when (is-postgres?) search.postgres/model-set)
      :in-place search.impl/query-model-set
+    nil)
+
+   (log/warnf "%s search not supported for your AppDb, using %s" search-engine default-engine)
+   (recur default-engine)))
+
+(defn- score-fn [search-engine]
+  (or
+   (case search-engine
+     :fulltext (when (is-postgres?) search.postgres/no-scoring)
+     :minimal  (when (is-postgres?) search.postgres/no-scoring)
+     :in-place scoring/score-and-result
     nil)
 
    (log/warnf "%s search not supported for your AppDb, using %s" search-engine default-engine)
@@ -72,8 +85,10 @@
   [search-ctx :- search.config/SearchContext]
   (let [engine    (:search-engine search-ctx :in-place)
         query-fn  (query-fn engine)
+        score-fn  (score-fn engine)
         models-fn (model-set-fn engine)]
     (search.impl/search
      query-fn
      models-fn
+     score-fn
      search-ctx)))

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -699,9 +699,10 @@
 (mu/defn search
   "Builds a search query that includes all the searchable entities, and runs it."
   ([search-ctx :- search.config/SearchContext]
-   (search in-place query-model-set search-ctx))
+   (search in-place query-model-set scoring/score-and-result search-ctx))
   ([results-fn
     model-set-fn
+    score-fn
     search-ctx :- search.config/SearchContext]
    (let [reducible-results (results-fn search-ctx)
          scoring-ctx       (select-keys search-ctx [:search-string :search-native-query])
@@ -710,7 +711,7 @@
                             (map normalize-result)
                             (filter (partial check-permissions-for-model search-ctx))
                             (map (partial normalize-result-more search-ctx))
-                            (keep #(scoring/score-and-result % scoring-ctx)))
+                            (keep #(score-fn % scoring-ctx)))
          total-results     (cond->> (scoring/top-results reducible-results search.config/max-filtered-results xf)
                              true                           hydrate-user-metadata
                              (:model-ancestors? search-ctx) (add-dataset-collection-hierarchy)

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -113,21 +113,21 @@
   [honeysql-query                                :- ms/Map
    model                                         :- :string
    {:keys [filter-items-in-personal-collection
-           archived
+           archived?
            current-user-id
            is-superuser?]} :- SearchContext]
   (let [collection-id-col        (if (= model "collection")
                                    :collection.id
                                    :collection_id)
         collection-filter-clause (collection/visible-collection-filter-clause
-                                  collection-id-col
-                                  {:include-archived-items :all
-                                   :include-trash-collection? true
-                                   :permission-level (if archived
-                                                       :write
-                                                       :read)}
-                                  {:current-user-id current-user-id
-                                   :is-superuser?   is-superuser?})]
+                                    collection-id-col
+                                    {:include-archived-items :all
+                                     :include-trash-collection? true
+                                     :permission-level (if archived?
+                                                         :write
+                                                         :read)}
+                                    {:current-user-id current-user-id
+                                     :is-superuser?   is-superuser?})]
     (cond-> honeysql-query
       true
       (sql.helpers/where collection-filter-clause (perms/audit-namespace-clause :collection.namespace nil))

--- a/src/metabase/search/postgres/core.clj
+++ b/src/metabase/search/postgres/core.clj
@@ -124,7 +124,6 @@
        (t2/query)
        (map :legacy_input)
        (map #(json/parse-string % keyword))
-       (filter (partial #'search.impl/check-permissions-for-model search-ctx))
        (map #(-> %
                  (update :created_at parse-datetime)
                  (update :updated_at parse-datetime)

--- a/src/metabase/search/postgres/core.clj
+++ b/src/metabase/search/postgres/core.clj
@@ -156,8 +156,8 @@
     ;; TODO use a single query
     (fn [m]
       (t2/exists? :search_index
-       (-> (search.index/search-query (:search-string search-ctx))
-           (sql.helpers/where [:= :model m]))))
+                  (-> (search.index/search-query (:search-string search-ctx))
+                      (sql.helpers/where [:= :model m]))))
     ;; TODO use only the models that apply to the given filters
     (:models search-ctx search.config/all-models))))
 

--- a/src/metabase/search/postgres/core.clj
+++ b/src/metabase/search/postgres/core.clj
@@ -147,6 +147,19 @@
     (f (:search-string search-ctx)
        (dissoc search-ctx :search-string))))
 
+(defn model-set
+  "Return a set of the models which have at least one result for the given query.
+  TODO: consider filters and permissions."
+  [search-ctx]
+  (set
+   (filter
+    ;; TODO use a single query, not N+1
+    (fn [m]
+      (t2/exists? :search_index
+       (-> (search.index/search-query (:search-string search-ctx))
+           (sql.helpers/where [:= :model m]))))
+    (:models search-ctx search.config/all-models))))
+
 (defn init!
   "Ensure that the search index exists, and has been populated with all the entities."
   [& [force-reset?]]

--- a/src/metabase/search/postgres/core.clj
+++ b/src/metabase/search/postgres/core.clj
@@ -153,11 +153,12 @@
   [search-ctx]
   (set
    (filter
-    ;; TODO use a single query, not N+1
+    ;; TODO use a single query
     (fn [m]
       (t2/exists? :search_index
        (-> (search.index/search-query (:search-string search-ctx))
            (sql.helpers/where [:= :model m]))))
+    ;; TODO use only the models that apply to the given filters
     (:models search-ctx search.config/all-models))))
 
 (defn init!

--- a/src/metabase/search/postgres/core.clj
+++ b/src/metabase/search/postgres/core.clj
@@ -161,6 +161,12 @@
     ;; TODO use only the models that apply to the given filters
     (:models search-ctx search.config/all-models))))
 
+(defn no-scoring
+  "Do no scoring, whatsover"
+  [result _scoring-ctx]
+  {:score 1
+   :result (assoc result :all-scores [] :relevant-scores [])})
+
 (defn init!
   "Ensure that the search index exists, and has been populated with all the entities."
   [& [force-reset?]]

--- a/test/metabase/search/postgres/core_test.clj
+++ b/test/metabase/search/postgres/core_test.clj
@@ -69,11 +69,11 @@
         (testing term
           (is (= (hybrid term)
                  (#'search.postgres/minimal-with-perms
-                    term
-                    {:current-user-id    (mt/user->id :crowberto)
-                     :is-superuser?      true
-                     :archived?          false
-                     :current-user-perms #{"/"}
-                     :model-ancestors?   false
-                     :models             search/all-models
-                     :search-string      term}))))))))
+                  term
+                  {:current-user-id    (mt/user->id :crowberto)
+                   :is-superuser?      true
+                   :archived?          false
+                   :current-user-perms #{"/"}
+                   :model-ancestors?   false
+                   :models             search/all-models
+                   :search-string      term}))))))))

--- a/test/metabase/search/postgres/core_test.clj
+++ b/test/metabase/search/postgres/core_test.clj
@@ -11,12 +11,6 @@
 (def ^:private hybrid
   (comp t2.realize/realize #'search.postgres/hybrid))
 
-(def ^:private hybrid-multi #'search.postgres/hybrid-multi)
-
-(def ^:private minimal #'search.postgres/minimal)
-
-(def ^:private minimal-with-perms #'search.postgres/minimal-with-perms)
-
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defmacro with-setup [& body]
   `(when (is-postgres?)
@@ -58,19 +52,28 @@
       (doseq [term example-terms]
         (testing term
           (is (= (hybrid term)
-                 (hybrid-multi term))))))))
+                 (#'search.postgres/hybrid-multi term))))))))
 
 (deftest minimal-test
   (with-setup
     (testing "consistent results with minimal implementations\n"
-      (doseq [term #_example-terms ["ven"]]
+      (doseq [term example-terms]
         (testing term
           (is (= (hybrid term)
-                 (minimal term)
-                 (minimal-with-perms term {:current-user-id    1
-                                           :is-superuser?      true
-                                           :archived?          nil
-                                           :current-user-perms #{"/"}
-                                           :model-ancestors?   false
-                                           :models             search/all-models
-                                           :search-string      term}))))))))
+                 (#'search.postgres/minimal term))))))))
+
+(deftest minimal-with-perms-test
+  (with-setup
+    (testing "consistent results with minimal implementations\n"
+      (doseq [term (take 1 example-terms)]
+        (testing term
+          (is (= (hybrid term)
+                 (#'search.postgres/minimal-with-perms
+                    term
+                    {:current-user-id    (mt/user->id :crowberto)
+                     :is-superuser?      true
+                     :archived?          false
+                     :current-user-perms #{"/"}
+                     :model-ancestors?   false
+                     :models             search/all-models
+                     :search-string      term}))))))))

--- a/test/metabase/search/postgres/core_test.clj
+++ b/test/metabase/search/postgres/core_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
-   [metabase.search :refer [is-postgres?]]
+   [metabase.search :as search :refer [is-postgres?]]
    [metabase.search.postgres.core :as search.postgres]
    [metabase.search.postgres.index-test :refer [legacy-results]]
    [metabase.test :as mt]
@@ -14,6 +14,8 @@
 (def ^:private hybrid-multi #'search.postgres/hybrid-multi)
 
 (def ^:private minimal #'search.postgres/minimal)
+
+(def ^:private minimal-with-perms #'search.postgres/minimal-with-perms)
 
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defmacro with-setup [& body]
@@ -60,8 +62,15 @@
 
 (deftest minimal-test
   (with-setup
-    (testing "consistent results between both hybrid implementations\n"
-      (doseq [term example-terms]
+    (testing "consistent results with minimal implementations\n"
+      (doseq [term #_example-terms ["ven"]]
         (testing term
           (is (= (hybrid term)
-                 (minimal term))))))))
+                 (minimal term)
+                 (minimal-with-perms term {:current-user-id    1
+                                           :is-superuser?      true
+                                           :archived?          nil
+                                           :current-user-perms #{"/"}
+                                           :model-ancestors?   false
+                                           :models             search/all-models
+                                           :search-string      term}))))))))


### PR DESCRIPTION
- Replace `query-model-set` with something faster.
- Disable ranking.
- Add a new `minimal-with-perms` strategy.
