### PR TITLE
Downgrade gh runner image for sqlserver 2017 job

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -895,7 +895,7 @@ jobs:
   be-tests-sqlserver-2017-ee:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 90
     env:
       CI: 'true'


### PR DESCRIPTION
More context in [this slack thread](https://metaboat.slack.com/archives/C5XHN8GLW/p1727077788250889).

This PR is an attempt to solve constantly failing sqlserver 2017 job (as eg. in [this job](https://github.com/metabase/metabase/actions/runs/10959961882/job/30436377720)).

Adding the diagnostic step to the job I've found out, that sqlserver container crashes very soon after it is started.

Researching the issue I've found out that there is a difference between runner's kernel version in the linked job and last passed sqlserver 2017 job (last passed job's log can be found [here](https://github.com/metabase/metabase/actions/runs/10925786668/job/30332674507)).

The `ubuntu-20.04` image is the only way I'm aware of to downgrade the kernel. I've confirmed that with this change in place the sqlserver 2017 container does not crash after a few seconds and `test-data` is correctly loaded.