### PR TITLE
Remove CLJS_SRC_PATH_DEV from ignored watch dirs

### DIFF
--- a/rspack.config.js
+++ b/rspack.config.js
@@ -336,7 +336,10 @@ if (shouldEnableHotRefresh) {
   };
 
   config.watchOptions = {
-    ignored: ["**/node_modules", CLJS_SRC_PATH_DEV + "/**"],
+    // Shadow's live reload does not work. I assume it could be related to rspack migration.  Namely, the compiled cljs
+    // is loaded on save. On page reload however, the compiled cljs that was used on rspack initialization is used
+    // again. The following exception fixes that, for the cost of always reloading the page when compiled cljs changes.
+    ignored: ["**/node_modules" /*, CLJS_SRC_PATH_DEV + "/**" */],
   };
 
   config.plugins.unshift(


### PR DESCRIPTION
Shadow cljs live reload is broken. This change makes the page reload always, when the compiled cljs changes.

Before this PR shadow's live reload worked when file was saved. On page reload however the stale compiled cljs was used.