### PR TITLE
Reset filters in dashboard click action

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -19,6 +19,7 @@ import {
   getLinkCardDetails,
   getTextCardDetails,
   modal,
+  multiAutocompleteInput,
   openStaticEmbeddingModal,
   popover,
   queryBuilderHeader,
@@ -131,6 +132,15 @@ const DASHBOARD_FILTER_NUMBER = createMockActionParameter({
   slug: "filter-number",
   type: "number/>=",
   sectionId: "number",
+});
+
+const DASHBOARD_FILTER_TEXT_WITH_DEFAULT = createMockActionParameter({
+  id: "4",
+  name: "Text filter with default",
+  slug: "filter-with-default",
+  type: "string/=",
+  sectionId: "string",
+  default: "Hello",
 });
 
 const QUERY_FILTER_CREATED_AT = [
@@ -632,6 +642,171 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
         cy.location().should(({ pathname, search }) => {
           expect(pathname).to.equal(`/dashboard/${targetDashboardId}`);
           expect(search).to.equal(`?tab=${TAB_SLUG_MAP[FIRST_TAB.name]}`);
+        });
+      });
+    });
+
+    it("sets non-specified parameters to default values when accessed from a click action", () => {
+      cy.createDashboard(
+        {
+          ...TARGET_DASHBOARD,
+          parameters: [
+            DASHBOARD_FILTER_TEXT,
+            DASHBOARD_FILTER_TEXT_WITH_DEFAULT,
+          ],
+        },
+        {
+          wrapId: true,
+          idAlias: "targetDashboardId",
+        },
+      )
+        .then(dashboardId => {
+          return cy
+            .request("PUT", `/api/dashboard/${dashboardId}`, {
+              dashcards: [
+                createMockDashboardCard({
+                  card_id: ORDERS_QUESTION_ID,
+                  parameter_mappings: [
+                    createTextFilterMapping({ card_id: ORDERS_QUESTION_ID }),
+                    createTextFilterWithDefaultMapping({
+                      card_id: ORDERS_QUESTION_ID,
+                    }),
+                  ],
+                }),
+              ],
+            })
+            .then(() => dashboardId);
+        })
+        .then(dashboardId => {
+          visitDashboard(dashboardId);
+        });
+
+      filterWidget().contains("Hello").click();
+      popover().within(() => {
+        multiAutocompleteInput().type("{backspace}World{enter}");
+        cy.button("Update filter").click();
+      });
+
+      cy.createQuestionAndDashboard({ questionDetails }).then(
+        ({ body: card }) => {
+          visitDashboard(card.dashboard_id);
+        },
+      );
+
+      editDashboard();
+
+      getDashboardCard().realHover().icon("click").click();
+      addDashboardDestination();
+      cy.get("aside").findByText("Select a dashboard tab").should("not.exist");
+      cy.get("aside").findByText("No available targets").should("not.exist");
+      addTextParameter();
+      cy.get("aside").button("Done").click();
+
+      saveDashboard({ waitMs: 250 });
+
+      clickLineChartPoint();
+
+      cy.findAllByTestId("field-set")
+        .contains(DASHBOARD_FILTER_TEXT.name)
+        .parent()
+        .should("contain.text", POINT_COUNT);
+      cy.findAllByTestId("field-set")
+        .contains(DASHBOARD_FILTER_TEXT_WITH_DEFAULT.name)
+        .parent()
+        .should("contain.text", DASHBOARD_FILTER_TEXT_WITH_DEFAULT.default);
+
+      cy.get("@targetDashboardId").then(targetDashboardId => {
+        cy.location().should(({ pathname, search }) => {
+          expect(pathname).to.equal(`/dashboard/${targetDashboardId}`);
+          expect(search).to.equal(
+            `?${DASHBOARD_FILTER_TEXT.slug}=${POINT_COUNT}&${DASHBOARD_FILTER_TEXT_WITH_DEFAULT.slug}=Hello`,
+          );
+        });
+      });
+    });
+
+    it("sets parameters with default values to the correct value when accessed via click action", () => {
+      cy.createDashboard(
+        {
+          ...TARGET_DASHBOARD,
+          parameters: [
+            DASHBOARD_FILTER_TEXT,
+            DASHBOARD_FILTER_TEXT_WITH_DEFAULT,
+          ],
+        },
+        {
+          wrapId: true,
+          idAlias: "targetDashboardId",
+        },
+      )
+        .then(dashboardId => {
+          return cy
+            .request("PUT", `/api/dashboard/${dashboardId}`, {
+              dashcards: [
+                createMockDashboardCard({
+                  card_id: ORDERS_QUESTION_ID,
+                  parameter_mappings: [
+                    createTextFilterMapping({ card_id: ORDERS_QUESTION_ID }),
+                    createTextFilterWithDefaultMapping({
+                      card_id: ORDERS_QUESTION_ID,
+                    }),
+                  ],
+                }),
+              ],
+            })
+            .then(() => dashboardId);
+        })
+        .then(dashboardId => {
+          visitDashboard(dashboardId);
+        });
+
+      cy.findAllByTestId("field-set")
+        .contains(DASHBOARD_FILTER_TEXT.name)
+        .parent()
+        .click();
+      popover().within(() => {
+        multiAutocompleteInput().type("John Doe{enter}");
+        cy.button("Add filter").click();
+      });
+
+      cy.findAllByTestId("field-set")
+        .contains(DASHBOARD_FILTER_TEXT_WITH_DEFAULT.name)
+        .parent()
+        .click();
+      popover().within(() => {
+        multiAutocompleteInput().type("{backspace}World{enter}");
+        cy.button("Update filter").click();
+      });
+
+      cy.createQuestionAndDashboard({ questionDetails }).then(
+        ({ body: card }) => {
+          visitDashboard(card.dashboard_id);
+        },
+      );
+
+      editDashboard();
+
+      getDashboardCard().realHover().icon("click").click();
+      addDashboardDestination();
+      cy.get("aside").findByText("Select a dashboard tab").should("not.exist");
+      cy.get("aside").findByText("No available targets").should("not.exist");
+      addTextWithDefaultParameter();
+      cy.get("aside").button("Done").click();
+
+      saveDashboard({ waitMs: 250 });
+
+      clickLineChartPoint();
+      cy.findAllByTestId("field-set")
+        .contains(DASHBOARD_FILTER_TEXT_WITH_DEFAULT.name)
+        .parent()
+        .should("contain.text", POINT_COUNT);
+
+      cy.get("@targetDashboardId").then(targetDashboardId => {
+        cy.location().should(({ pathname, search }) => {
+          expect(pathname).to.equal(`/dashboard/${targetDashboardId}`);
+          expect(search).to.equal(
+            `?${DASHBOARD_FILTER_TEXT.slug}=&${DASHBOARD_FILTER_TEXT_WITH_DEFAULT.slug}=${POINT_COUNT}`,
+          );
         });
       });
     });
@@ -2280,6 +2455,14 @@ const addTextParameter = () => {
   });
 };
 
+const addTextWithDefaultParameter = () => {
+  cy.get("aside").findByText(DASHBOARD_FILTER_TEXT_WITH_DEFAULT.name).click();
+  popover().within(() => {
+    cy.findByText(CREATED_AT_COLUMN_NAME).should("exist");
+    cy.findByText(COUNT_COLUMN_NAME).should("exist").click();
+  });
+};
+
 const addTimeParameter = () => {
   cy.get("aside").findByText(DASHBOARD_FILTER_TIME.name).click();
   popover().within(() => {
@@ -2309,6 +2492,23 @@ const createTextFilterMapping = ({ card_id }) => {
   return {
     card_id,
     parameter_id: DASHBOARD_FILTER_TEXT.id,
+    target: ["dimension", fieldRef],
+  };
+};
+
+const createTextFilterWithDefaultMapping = ({ card_id }) => {
+  const fieldRef = [
+    "field",
+    PEOPLE.NAME,
+    {
+      "base-type": "type/Text",
+      "source-field": ORDERS.USER_ID,
+    },
+  ];
+
+  return {
+    card_id,
+    parameter_id: DASHBOARD_FILTER_TEXT_WITH_DEFAULT.id,
     target: ["dimension", fieldRef],
   };
 };

--- a/frontend/src/metabase-lib/v1/queries/drills/dashboard-click-drill.js
+++ b/frontend/src/metabase-lib/v1/queries/drills/dashboard-click-drill.js
@@ -82,16 +82,30 @@ export function getDashboardDrillUrl(clicked) {
     clickBehavior,
   );
 
+  const targetDashboard = extraData.dashboards[targetId];
+  const targetDefaultParameters = Object.fromEntries(
+    targetDashboard.parameters.map(parameter => [
+      parameter.slug,
+      parameter.default ?? "",
+    ]),
+  );
+
   const baseQueryParams = getParameterValuesBySlug(parameterMapping, {
     data,
     extraData,
     clickBehavior,
   });
 
-  const queryParams =
+  const tabParams =
     typeof clickBehavior.tabId === "undefined"
-      ? baseQueryParams
-      : { ...baseQueryParams, tab: clickBehavior.tabId };
+      ? {}
+      : { tab: clickBehavior.tabId };
+
+  const queryParams = {
+    ...targetDefaultParameters,
+    ...baseQueryParams,
+    ...tabParams,
+  };
 
   const path = Urls.dashboard({ id: targetId });
   return `${path}?${querystring.stringify(queryParams)}`;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/48074

### Description

When opening a dashboard from a click action, currently all parameters not set by the click action itself are set to the users' last value for that parameter. This leads to unwanted results where the dashboard returns no results due to the filter values not being correct/compatible.

This PR fixes that by resetting all parameters (other than the ones specified by the click-action) to their default value.

### How to verify


1. Create a dashboard with two parameters mapped to a question, eg.
  A. New dashboard -> "Foo"
  B. Add questions -> Orders with People
  C. Add parameter -> Text -> Product: Vendor -> set name to "Vendor"
  D. Add parameter -> Text -> Product: Category -> set name to "Category"
    - Add default value: Gizmo
  E. Save dashboard
2. Set the Vendor filter to any value
3. Create another dashboard, eg.
  A. New dashboard -> "Bar"
  B. Add questions -> Total orders by category
  C. Add click action -> Go to a custom destination -> Dashboard -> Foo -> Link "Category" parameter to "Product -> Category" -> Done
  D. Save
4. Click on of the categories
5. Verify that in the target dashboard:
   - The "Category" parameter is set to the clicked category
   - The "Vendor" parameter is empty (and not what you set before)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
