### PR TITLE
Fix cancelling of editing of a metric

### DIFF
--- a/e2e/test/scenarios/metrics/metrics-editing.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-editing.cy.spec.js
@@ -641,6 +641,7 @@ function cancelMetricEditing() {
   cy.log("click cancel but do not confirm");
   cy.button("Cancel").click();
   modal().button("Cancel").click();
+  modal().should("not.exist");
   appBar().should("not.exist");
 
   cy.log("click cancel and confirm");

--- a/e2e/test/scenarios/metrics/metrics-editing.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-editing.cy.spec.js
@@ -171,9 +171,6 @@ describe("scenarios > metrics > editing", () => {
         entityPickerModalTab("Tables").click();
         cy.findByText("Orders").click();
       });
-      cy.findByTestId("metric-editor-header")
-        .findByText("New metric")
-        .should("be.visible");
       cancelMetricEditing();
     });
 

--- a/e2e/test/scenarios/metrics/metrics-editing.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-editing.cy.spec.js
@@ -164,6 +164,29 @@ describe("scenarios > metrics > editing", () => {
         verifyScalarValue("18,760");
       });
     });
+
+    it("should not crash when cancelling creation of a new metric (metabase#48024)", () => {
+      startNewMetric();
+      entityPickerModal().within(() => {
+        entityPickerModalTab("Tables").click();
+        cy.findByText("Orders").click();
+      });
+      cy.findByTestId("metric-editor-header")
+        .findByText("New metric")
+        .should("be.visible");
+      cancelMetricEditing();
+    });
+
+    it("should not crash when cancelling editing of an existing metric (metabase#48024)", () => {
+      createQuestion(ORDERS_SCALAR_METRIC).then(({ body: card }) =>
+        visitMetric(card.id),
+      );
+      openQuestionActions();
+      popover().findByText("Edit metric definition").click();
+      addBreakout({ tableName: "Product", columnName: "Created At" });
+      cancelMetricEditing();
+      verifyScalarValue("18,760");
+    });
   });
 
   describe("data source", () => {
@@ -615,4 +638,16 @@ function verifyLineAreaBarChart({ xAxis, yAxis }) {
     cy.findByText(yAxis).should("be.visible");
     cy.findByText(xAxis).should("be.visible");
   });
+}
+
+function cancelMetricEditing() {
+  cy.log("click cancel but do not confirm");
+  cy.button("Cancel").click();
+  modal().button("Cancel").click();
+  appBar().should("not.exist");
+
+  cy.log("click cancel and confirm");
+  cy.button("Cancel").click();
+  modal().button("Discard changes").click();
+  appBar().should("be.visible");
 }

--- a/frontend/src/metabase/query_builder/actions/ui.ts
+++ b/frontend/src/metabase/query_builder/actions/ui.ts
@@ -12,7 +12,7 @@ import type {
 } from "metabase-types/store";
 
 import { updateUrl } from "./navigation";
-import { cancelQuery, runDirtyQuestionQuery } from "./querying";
+import { cancelQuery } from "./querying";
 
 export const SET_UI_CONTROLS = "metabase/qb/SET_UI_CONTROLS";
 export const setUIControls = createAction(SET_UI_CONTROLS);
@@ -121,5 +121,4 @@ export const cancelQuestionChanges =
       type: CANCEL_QUESTION_CHANGES,
       payload: { card: cardBeforeChanges },
     });
-    dispatch(runDirtyQuestionQuery());
   };

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -329,8 +329,8 @@ function DatasetEditor(props) {
   const handleCancelEdit = () => {
     setShowCancelEditWarning(false);
     cancelQuestionChanges();
-    setQueryBuilderMode("view");
     runDirtyQuestionQuery();
+    setQueryBuilderMode("view");
   };
 
   const handleCancelEditWarningClose = () => {

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -71,6 +71,7 @@ const propTypes = {
   isResultDirty: PropTypes.bool.isRequired,
   isRunning: PropTypes.bool.isRequired,
   setQueryBuilderMode: PropTypes.func.isRequired,
+  runDirtyQuestionQuery: PropTypes.func.isRequired,
   setDatasetEditorTab: PropTypes.func.isRequired,
   setMetadataDiff: PropTypes.func.isRequired,
   onSave: PropTypes.func.isRequired,
@@ -201,6 +202,7 @@ function DatasetEditor(props) {
     isDirty: isModelQueryDirty,
     isResultDirty,
     setQueryBuilderMode,
+    runDirtyQuestionQuery,
     runQuestionQuery,
     setDatasetEditorTab,
     setMetadataDiff,
@@ -328,6 +330,7 @@ function DatasetEditor(props) {
     setShowCancelEditWarning(false);
     cancelQuestionChanges();
     setQueryBuilderMode("view");
+    runDirtyQuestionQuery();
   };
 
   const handleCancelEditWarningClose = () => {

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -414,6 +414,7 @@ class View extends Component {
       runQuestionQuery,
       cancelQuery,
       setQueryBuilderMode,
+      runDirtyQuestionQuery,
       isShowingQuestionInfoSidebar,
       isShowingQuestionSettingsSidebar,
       cancelQuestionChanges,
@@ -457,9 +458,10 @@ class View extends Component {
                 setQueryBuilderMode("view");
               }}
               onCancel={question => {
-                cancelQuestionChanges();
                 if (question.isSaved()) {
+                  cancelQuestionChanges();
                   setQueryBuilderMode("view");
+                  runDirtyQuestionQuery();
                 } else {
                   onChangeLocation("/");
                 }

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -460,8 +460,8 @@ class View extends Component {
               onCancel={question => {
                 if (question.isSaved()) {
                   cancelQuestionChanges();
-                  setQueryBuilderMode("view");
                   runDirtyQuestionQuery();
+                  setQueryBuilderMode("view");
                 } else {
                   onChangeLocation("/");
                 }


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/48024

How to verify:
- New -> Metric -> Orders
- Click Cancel -> Discard changes
- You should be redirected to the home page