### PR TITLE
Make select all/none search-aware

### DIFF
--- a/frontend/src/metabase/components/ListField/ListField.tsx
+++ b/frontend/src/metabase/components/ListField/ListField.tsx
@@ -61,8 +61,6 @@ export const ListField = ({
   const [filter, setFilter] = useState("");
   const waitTime = useContext(waitTimeContext);
   const debouncedFilter = useDebouncedValue(filter, waitTime);
-  const isAll = selectedValues.size === sortedOptions.length;
-  const isNone = selectedValues.size === 0;
 
   const filteredOptions = useMemo(() => {
     const formattedFilter = debouncedFilter.trim().toLowerCase();
@@ -89,6 +87,12 @@ export const ListField = ({
     });
   }, [augmentedOptions, debouncedFilter, sortedOptions]);
 
+  const selectedFilteredOptions = filteredOptions.filter(([value]) =>
+    selectedValues.has(value),
+  );
+  const isAll = selectedFilteredOptions.length === filteredOptions.length;
+  const isNone = selectedFilteredOptions.length === 0;
+
   const shouldShowEmptyState =
     augmentedOptions.length > 0 && filteredOptions.length === 0;
 
@@ -114,14 +118,15 @@ export const ListField = ({
     setFilter(e.target.value);
 
   const handleToggleAll = () => {
-    if (isAll) {
-      setSelectedValues(new Set());
-      onChange([]);
-    } else {
-      const allValues = sortedOptions.map(([value]) => value);
-      setSelectedValues(new Set(allValues));
-      onChange(allValues);
-    }
+    const newSelectedValuesSet = new Set(selectedValues);
+    filteredOptions.forEach(([value]) => {
+      if (isAll) {
+        newSelectedValuesSet.delete(value);
+      } else {
+        newSelectedValuesSet.add(value);
+      }
+    });
+    onChange(Array.from(newSelectedValuesSet));
   };
 
   return (

--- a/frontend/src/metabase/components/ListField/ListField.tsx
+++ b/frontend/src/metabase/components/ListField/ListField.tsx
@@ -127,6 +127,7 @@ export const ListField = ({
       }
     });
     onChange(Array.from(newSelectedValuesSet));
+    setSelectedValues(newSelectedValuesSet);
   };
 
   return (

--- a/frontend/src/metabase/components/ListField/ListField.unit.spec.tsx
+++ b/frontend/src/metabase/components/ListField/ListField.unit.spec.tsx
@@ -76,23 +76,22 @@ describe("ListField", () => {
     expect(onChange).toHaveBeenCalledWith(allValues);
   });
 
-  it("should allow to select all options after search", async () => {
+  it("should allow to select only visible options after search", async () => {
     const { onChange } = setup({
-      value: [],
+      value: ["Doohickey", "Gadget"],
       options: allOptions,
     });
 
-    await userEvent.type(
-      screen.getByPlaceholderText("Search the list"),
-      allValues[0],
-    );
-    expect(screen.getByLabelText(allValues[0])).toBeInTheDocument();
-    expect(screen.queryByLabelText(allValues[1])).not.toBeInTheDocument();
+    await userEvent.type(screen.getByPlaceholderText("Search the list"), "get");
+    expect(screen.getByLabelText("Gadget")).toBeInTheDocument();
+    expect(screen.getByLabelText("Widget")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Gizmo")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Doohickey")).not.toBeInTheDocument();
 
     const checkbox = screen.getByLabelText("Select all");
     expect(checkbox).not.toBeChecked();
     await userEvent.click(checkbox);
-    expect(onChange).toHaveBeenCalledWith(allValues);
+    expect(onChange).toHaveBeenCalledWith(["Doohickey", "Gadget", "Widget"]);
   });
 
   it("should allow to deselect all options", async () => {
@@ -110,20 +109,20 @@ describe("ListField", () => {
 
   it("should allow to deselect all options after search", async () => {
     const { onChange } = setup({
-      value: allValues,
+      value: ["Doohickey", "Gadget", "Widget"],
       options: allOptions,
     });
 
     await userEvent.type(
       screen.getByPlaceholderText("Search the list"),
-      allValues[0],
+      "Gadget",
     );
-    expect(screen.getByLabelText(allValues[0])).toBeInTheDocument();
-    expect(screen.queryByLabelText(allValues[1])).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Gadget")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Widget")).not.toBeInTheDocument();
 
     const checkbox = screen.getByLabelText("Select none");
     expect(checkbox).toBeChecked();
     await userEvent.click(checkbox);
-    expect(onChange).toHaveBeenCalledWith([]);
+    expect(onChange).toHaveBeenCalledWith(["Doohickey", "Widget"]);
   });
 });

--- a/frontend/src/metabase/components/ListField/ListField.unit.spec.tsx
+++ b/frontend/src/metabase/components/ListField/ListField.unit.spec.tsx
@@ -92,6 +92,8 @@ describe("ListField", () => {
     expect(checkbox).not.toBeChecked();
     await userEvent.click(checkbox);
     expect(onChange).toHaveBeenCalledWith(["Doohickey", "Gadget", "Widget"]);
+    expect(screen.getByLabelText("Gadget")).toBeChecked();
+    expect(screen.getByLabelText("Widget")).toBeChecked();
   });
 
   it("should allow to deselect all options", async () => {
@@ -124,5 +126,6 @@ describe("ListField", () => {
     expect(checkbox).toBeChecked();
     await userEvent.click(checkbox);
     expect(onChange).toHaveBeenCalledWith(["Doohickey", "Widget"]);
+    expect(screen.getByLabelText("Gadget")).not.toBeChecked();
   });
 });

--- a/frontend/src/metabase/components/ListField/types.ts
+++ b/frontend/src/metabase/components/ListField/types.ts
@@ -4,7 +4,7 @@ import type { RowValue } from "metabase-types/api";
 export type Option = any[];
 
 export interface ListFieldProps {
-  onChange: (value: string[]) => void;
+  onChange: (value: RowValue[]) => void;
   value: RowValue[];
   options: Option;
   optionRenderer: (option: any) => JSX.Element;

--- a/frontend/src/metabase/querying/filters/components/FilterValuePicker/ListValuePicker/ListValuePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterValuePicker/ListValuePicker/ListValuePicker.tsx
@@ -56,13 +56,13 @@ function CheckboxListPicker({
     selectedValues,
     elevatedValues,
   );
-  const visibleOptions = searchOptions(availableOptions, searchValue);
+  const filteredOptions = searchOptions(availableOptions, searchValue);
   const selectedValuesSet = new Set(selectedValues);
-  const selectedVisibleOptions = visibleOptions.filter(option =>
+  const selectedFilteredOptions = filteredOptions.filter(option =>
     selectedValuesSet.has(option.value),
   );
-  const isAll = selectedVisibleOptions.length === visibleOptions.length;
-  const isNone = selectedVisibleOptions.length === 0;
+  const isAll = selectedFilteredOptions.length === filteredOptions.length;
+  const isNone = selectedFilteredOptions.length === 0;
 
   const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
     setSearchValue(event.currentTarget.value);
@@ -70,7 +70,7 @@ function CheckboxListPicker({
 
   const handleToggleAll = () => {
     const newSelectedValuesSet = new Set(selectedValues);
-    visibleOptions.forEach(option => {
+    filteredOptions.forEach(option => {
       if (isAll) {
         newSelectedValuesSet.delete(option.value);
       } else {
@@ -88,7 +88,7 @@ function CheckboxListPicker({
         autoFocus={autoFocus}
         onChange={handleInputChange}
       />
-      {visibleOptions.length > 0 ? (
+      {filteredOptions.length > 0 ? (
         <Stack>
           <Checkbox
             variant="stacked"
@@ -100,7 +100,7 @@ function CheckboxListPicker({
           />
           <Checkbox.Group value={selectedValues} onChange={onChange}>
             <Stack>
-              {visibleOptions.map(option => (
+              {filteredOptions.map(option => (
                 <Checkbox
                   key={option.value}
                   value={option.value}

--- a/frontend/src/metabase/querying/filters/components/FilterValuePicker/ListValuePicker/ListValuePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterValuePicker/ListValuePicker/ListValuePicker.tsx
@@ -51,25 +51,33 @@ function CheckboxListPicker({
 }: ListValuePickerProps) {
   const [searchValue, setSearchValue] = useState("");
   const [elevatedValues] = useState(selectedValues);
-  const options = getEffectiveOptions(
+  const availableOptions = getEffectiveOptions(
     fieldValues,
     selectedValues,
     elevatedValues,
   );
-  const visibleOptions = searchOptions(options, searchValue);
-  const isAll = options.length === selectedValues.length;
-  const isNone = selectedValues.length === 0;
+  const visibleOptions = searchOptions(availableOptions, searchValue);
+  const selectedValuesSet = new Set(selectedValues);
+  const selectedVisibleOptions = visibleOptions.filter(option =>
+    selectedValuesSet.has(option.value),
+  );
+  const isAll = selectedVisibleOptions.length === visibleOptions.length;
+  const isNone = selectedVisibleOptions.length === 0;
 
   const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
     setSearchValue(event.currentTarget.value);
   };
 
   const handleToggleAll = () => {
-    if (isAll) {
-      onChange([]);
-    } else {
-      onChange(options.map(option => option.value));
-    }
+    const newSelectedValuesSet = new Set(selectedValues);
+    visibleOptions.forEach(option => {
+      if (isAll) {
+        newSelectedValuesSet.delete(option.value);
+      } else {
+        newSelectedValuesSet.add(option.value);
+      }
+    });
+    onChange(Array.from(newSelectedValuesSet));
   };
 
   return (

--- a/frontend/src/metabase/querying/filters/components/FilterValuePicker/ListValuePicker/ListValuePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterValuePicker/ListValuePicker/ListValuePicker.unit.spec.tsx
@@ -75,23 +75,25 @@ describe("ListValuePicker", () => {
       expect(onChange).toHaveBeenCalledWith(allValues);
     });
 
-    it("should allow to select all options after search", async () => {
+    it("should allow to select only visible options after search", async () => {
       const { onChange } = setup({
         fieldValues: allOptions,
-        selectedValues: [],
+        selectedValues: ["Doohickey", "Gadget"],
       });
 
       await userEvent.type(
         screen.getByPlaceholderText("Search the list"),
-        allValues[0],
+        "get",
       );
-      expect(screen.getByLabelText(allValues[0])).toBeInTheDocument();
-      expect(screen.queryByLabelText(allValues[1])).not.toBeInTheDocument();
+      expect(screen.getByLabelText("Gadget")).toBeInTheDocument();
+      expect(screen.getByLabelText("Widget")).toBeInTheDocument();
+      expect(screen.queryByLabelText("Gizmo")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Doohickey")).not.toBeInTheDocument();
 
       const checkbox = screen.getByLabelText("Select all");
       expect(checkbox).not.toBeChecked();
       await userEvent.click(checkbox);
-      expect(onChange).toHaveBeenCalledWith(allValues);
+      expect(onChange).toHaveBeenCalledWith(["Doohickey", "Gadget", "Widget"]);
     });
 
     it("should allow to deselect all options", async () => {
@@ -107,23 +109,23 @@ describe("ListValuePicker", () => {
       expect(onChange).toHaveBeenCalledWith([]);
     });
 
-    it("should allow to deselect all options after search", async () => {
+    it("should allow to deselect only visible options after search", async () => {
       const { onChange } = setup({
         fieldValues: allOptions,
-        selectedValues: allValues,
+        selectedValues: ["Doohickey", "Gadget", "Widget"],
       });
 
       await userEvent.type(
         screen.getByPlaceholderText("Search the list"),
-        allValues[0],
+        "Gadget",
       );
-      expect(screen.getByLabelText(allValues[0])).toBeInTheDocument();
-      expect(screen.queryByLabelText(allValues[1])).not.toBeInTheDocument();
+      expect(screen.getByLabelText("Gadget")).toBeInTheDocument();
+      expect(screen.queryByLabelText("Widget")).not.toBeInTheDocument();
 
       const checkbox = screen.getByLabelText("Select none");
       expect(checkbox).toBeChecked();
       await userEvent.click(checkbox);
-      expect(onChange).toHaveBeenCalledWith([]);
+      expect(onChange).toHaveBeenCalledWith(["Doohickey", "Widget"]);
     });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/48070

Changes:
1. `Select all` in dashboard & QB filters will now select only visible (e.g. filtered) items and not every item
2. `Select none` will now deselect only visible items; other selected items are retained

Unfortunately the changes should be implemented twice because of the current state of dashboard filter widgets.

Demo https://www.loom.com/share/33a7d5e72aa24eb192b7334bb85cfc7e