### PR TITLE
Reset the dashboard parameter when setting the default value

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/dashboard-filter-defaults.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filter-defaults.cy.spec.ts
@@ -76,14 +76,16 @@ describe("scenarios > dashboard > filters > reset", () => {
   });
 
   it("should reset a filters value when editing the default", () => {
-    // Default dashboard filter
+    cy.log("Default dashboard filter");
     cy.location("search").should("eq", "?filter_one=&filter_two=Bar");
 
     clearFilterWidget(1);
 
     cy.location("search").should("eq", "?filter_one=&filter_two=");
 
-    // Finally, when we remove dashboard filter's default value, the url should reflect that by removing the placeholder
+    cy.log(
+      "Finally, when we remove dashboard filter's default value, the url should reflect that by removing the placeholder",
+    );
     editDashboard();
 
     openFilterOptions("Filter Two");

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filter-defaults.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filter-defaults.cy.spec.ts
@@ -1,0 +1,139 @@
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import {
+  type StructuredQuestionDetails,
+  clearFilterWidget,
+  createQuestionAndDashboard,
+  editDashboard,
+  filterWidget,
+  popover,
+  restore,
+  saveDashboard,
+  sidebar,
+  visitDashboard,
+} from "e2e/support/helpers";
+
+const { PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;
+
+const QUESTION: StructuredQuestionDetails = {
+  name: "Return input value",
+  display: "scalar",
+  query: {
+    "source-table": PRODUCTS_ID,
+  },
+};
+
+const FILTER_ONE = {
+  name: "Filter One",
+  slug: "filter_one",
+  id: "904aa8b7",
+  type: "string/=",
+  sectionId: "string",
+  default: undefined,
+};
+
+const FILTER_TWO = {
+  name: "Filter Two",
+  slug: "filter_two",
+  id: "904aa8b8",
+  type: "string/=",
+  sectionId: "string",
+  default: "Bar",
+};
+
+const DASHBOARD = {
+  name: "Filters Dashboard",
+  parameters: [FILTER_ONE, FILTER_TWO],
+};
+
+describe("scenarios > dashboard > filters > reset", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    createQuestionAndDashboard({
+      questionDetails: QUESTION,
+      dashboardDetails: DASHBOARD,
+    }).then(({ body: dashboardCard }) => {
+      const { card_id, dashboard_id } = dashboardCard;
+
+      cy.editDashboardCard(dashboardCard, {
+        parameter_mappings: [
+          {
+            parameter_id: FILTER_ONE.id,
+            card_id,
+            target: ["dimension", ["field", PRODUCTS.CATEGORY, null]],
+          },
+          {
+            parameter_id: FILTER_TWO.id,
+            card_id,
+            target: ["dimension", ["field", PRODUCTS.TITLE, null]],
+          },
+        ],
+      });
+
+      visitDashboard(dashboard_id);
+    });
+  });
+
+  it("should reset a filters value when editing the default", () => {
+    // Default dashboard filter
+    cy.location("search").should("eq", "?filter_one=&filter_two=Bar");
+
+    clearFilterWidget(1);
+
+    cy.location("search").should("eq", "?filter_one=&filter_two=");
+
+    // Finally, when we remove dashboard filter's default value, the url should reflect that by removing the placeholder
+    editDashboard();
+
+    openFilterOptions("Filter Two");
+
+    sidebar().within(() => {
+      cy.findByLabelText("Input box").click();
+      clearDefaultFilterValue();
+      setDefaultFilterValue("Foo");
+    });
+
+    popover().button("Add filter").click();
+
+    cy.location("search").should("eq", "?filter_one=&filter_two=Foo");
+
+    saveDashboard();
+
+    cy.location("search").should("eq", "?filter_one=&filter_two=Foo");
+
+    filterWidget().contains("Filter One").should("be.visible");
+    filterWidget().contains("Foo").should("be.visible");
+
+    editDashboard();
+
+    openFilterOptions("Filter One");
+
+    sidebar().within(() => {
+      cy.findByLabelText("Input box").click();
+      setDefaultFilterValue("Quu");
+    });
+
+    popover().button("Add filter").click();
+
+    cy.location("search").should("eq", "?filter_one=Quu&filter_two=Foo");
+
+    saveDashboard();
+
+    cy.location("search").should("eq", "?filter_one=Quu&filter_two=Foo");
+    filterWidget().contains("Quu").should("be.visible");
+    filterWidget().contains("Foo").should("be.visible");
+  });
+});
+
+function openFilterOptions(name: string) {
+  cy.findByText(name).parent().find(".Icon-gear").click();
+}
+
+function clearDefaultFilterValue() {
+  cy.findByLabelText("No default").parent().find(".Icon-close").click();
+}
+
+function setDefaultFilterValue(value: string) {
+  cy.findByLabelText("No default").type(value);
+}

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filter-defaults.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filter-defaults.cy.spec.ts
@@ -129,11 +129,11 @@ describe("scenarios > dashboard > filters > reset", () => {
 });
 
 function openFilterOptions(name: string) {
-  cy.findByText(name).parent().find(".Icon-gear").click();
+  cy.findByText(name).parent().icon("gear").click();
 }
 
 function clearDefaultFilterValue() {
-  cy.findByLabelText("No default").parent().find(".Icon-close").click();
+  cy.findByLabelText("No default").parent().icon("close").click();
 }
 
 function setDefaultFilterValue(value: string) {

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-required-simple-filter.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-required-simple-filter.cy.spec.js
@@ -113,8 +113,8 @@ describe("scenarios > dashboard > filters > SQL > simple filter > required ", ()
 
     saveDashboard();
 
-    // The URL query params should include the last used parameter value
-    cy.location("search").should("eq", "?text=Bar");
+    // The URL query params should include the value from the dashboard filter default
+    cy.location("search").should("eq", "?text=");
   });
 });
 

--- a/frontend/src/metabase/dashboard/actions/parameters.ts
+++ b/frontend/src/metabase/dashboard/actions/parameters.ts
@@ -471,7 +471,7 @@ export const setParameterDefaultValue = createThunkAction(
       ...parameter,
       default: defaultValue,
     }));
-    setParameterValue(parameterId, defaultValue)(dispatch, getState);
+    dispatch(setParameterValue(parameterId, defaultValue));
     return { id: parameterId, defaultValue };
   },
 );

--- a/frontend/src/metabase/dashboard/actions/parameters.ts
+++ b/frontend/src/metabase/dashboard/actions/parameters.ts
@@ -471,6 +471,7 @@ export const setParameterDefaultValue = createThunkAction(
       ...parameter,
       default: defaultValue,
     }));
+    setParameterValue(parameterId, defaultValue)(dispatch, getState);
     return { id: parameterId, defaultValue };
   },
 );


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/48084

## Description

When editing the default value the value of the filter does not change. This leads to confusing results and repetitive work.

This PR makes it so that when a users edits the default value of a filter, the filter value is also set to that value.

## To verify

1. Create a new dashboard (or use an existing one) with at least one filter
2. Edit dashboard -> select the filter -> edit the default value
3. Verify that the filter value changes to the new default in the url
4. Save the dashboard
5. Verify that the filter widget contains the new default value