### PR TITLE
Fix release log generation 😅 

### DIFF
--- a/.github/workflows/release-log.yml
+++ b/.github/workflows/release-log.yml
@@ -14,7 +14,7 @@ on:
     inputs:
       version:
         description: 'Major Metabase version (e.g. 45, 52, 68)'
-        type: number
+        type: number # needs to be a number to pass variables
         required: true
 
 jobs:
@@ -22,7 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || vars.CURRENT_VERSION }}
+      VERSION: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call')
+        && inputs.version || vars.CURRENT_VERSION }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/release-log.yml
+++ b/.github/workflows/release-log.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install Dependencies
         run: yarn --cwd release --frozen-lockfile && npm i -g tsx
       - name: generate release Log
-        run: cd release && tsx ./src/release-log.ts $VERSION > v$VERSION.html
+        run: cd release && tsx ./src/release-log-run.ts $VERSION > v$VERSION.html
       - name: generate release channel log
         run: cd release && tsx ./src/release-channel-log.ts > channels.html
       - name: upload release log to the web

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -262,7 +262,7 @@ jobs:
     needs: check-version
     uses: ./.github/workflows/release-log.yml
     with:
-      version: ${{ vars.CURRENT_VERSION }}
+      version: ${{ fromJSON(vars.CURRENT_VERSION) }} # cast string to number
     secrets: inherit
 
   update-version-info:

--- a/release/src/release-log-run.ts
+++ b/release/src/release-log-run.ts
@@ -1,0 +1,3 @@
+import { generateReleaseLog } from './release-log';
+
+generateReleaseLog();


### PR DESCRIPTION
Follow up to #47868

### Description

When I added unit tests to #47868 , I failed to update how we run that script (namely piping console output to a file) so it just produces empty files now. 🤦 


- add a new `release-log-run.ts` file that calls the correct function and outputs the release log html for the success team.
