### PR TITLE
Query Validator e2e updates

### DIFF
--- a/e2e/test/scenarios/admin/query-validator.cy.spec.js
+++ b/e2e/test/scenarios/admin/query-validator.cy.spec.js
@@ -16,130 +16,174 @@ const SCOREBOARD_TABLE = "scoreboard_actions";
 const COLORS_TABLE = "colors27745";
 
 describeEE("query validator", { tags: "@external" }, () => {
-  beforeEach(() => {
-    restore("postgres-writable");
-    cy.signInAsAdmin();
-    setTokenFeatures("all");
+  describe("feature disbaled", () => {
+    beforeEach(() => {
+      restore("postgres-writable");
+      cy.signInAsAdmin();
+      setTokenFeatures("none");
+    });
+
+    it("Should not show the page in troubleshooting or the setting in general", () => {
+      cy.visit("/admin/troubleshooting");
+      cy.findByTestId("admin-layout-sidebar").should(
+        "not.contain",
+        "Query Validator",
+      );
+      cy.visit("/admin/settings/general");
+      cy.findByRole("switch", { name: /ENABLE QUERY ANALYSIS/i }).should(
+        "not.exist",
+      );
+    });
   });
 
-  it("picks up inactive and unknown fields and tables", () => {
-    resetTestTable({ type: "postgres", table: SCOREBOARD_TABLE });
-    resetTestTable({ type: "postgres", table: COLORS_TABLE });
-
-    resyncDatabase({
-      dbId: WRITABLE_DB_ID,
+  describe("feature enabled", () => {
+    beforeEach(() => {
+      restore("postgres-writable");
+      cy.signInAsAdmin();
+      setTokenFeatures("all");
     });
 
-    createNativeQuestion({
-      name: "Native inactive field",
-      native: { query: `Select team_name from ${SCOREBOARD_TABLE}` },
-      display: "table",
-      database: WRITABLE_DB_ID,
+    it("enable query analysis setting", () => {
+      cy.visit("/admin/settings/general");
+
+      cy.findByRole("switch", { name: /ENABLE QUERY ANALYSIS/i }).should(
+        "have.attr",
+        "checked",
+      );
+      cy.findByRole("switch", { name: /ENABLE QUERY ANALYSIS/i }).click();
+
+      cy.findByRole("link", { name: /troubleshooting/i }).click();
+
+      cy.findByTestId("admin-layout-sidebar")
+        .findByText("Query Validator")
+        .click();
+
+      cy.findByRole("link", {
+        name: "Please enable query analysis here.",
+      }).should("exist");
     });
 
-    createNativeQuestion({
-      name: "Native unknown field",
-      native: { query: `Select foo from ${SCOREBOARD_TABLE}` },
-      display: "table",
-      database: WRITABLE_DB_ID,
+    it("picks up inactive and unknown fields and tables", () => {
+      resetTestTable({ type: "postgres", table: SCOREBOARD_TABLE });
+      resetTestTable({ type: "postgres", table: COLORS_TABLE });
+
+      resyncDatabase({
+        dbId: WRITABLE_DB_ID,
+      });
+
+      createNativeQuestion({
+        name: "Native inactive field",
+        native: { query: `Select team_name from ${SCOREBOARD_TABLE}` },
+        display: "table",
+        database: WRITABLE_DB_ID,
+      });
+
+      createNativeQuestion({
+        name: "Native unknown field",
+        native: { query: `Select foo from ${SCOREBOARD_TABLE}` },
+        display: "table",
+        database: WRITABLE_DB_ID,
+      });
+
+      createNativeQuestion({
+        name: "Native inactive table",
+        native: { query: `Select team_name from ${COLORS_TABLE}` },
+        display: "table",
+        database: WRITABLE_DB_ID,
+      });
+
+      createNativeQuestion({
+        name: "Native unknown table",
+        native: { query: "Select * from electric_bugaloo" },
+        display: "line",
+      });
+
+      cy.request(`/api/database/${WRITABLE_DB_ID}/schema/public`).then(
+        ({ body: tables }) => {
+          const scoreboardTable = tables.find(
+            table => table.name === SCOREBOARD_TABLE,
+          );
+
+          cy.request(`/api/table/${scoreboardTable.id}/query_metadata`).then(
+            ({ body: { fields } }) => {
+              const teamNameField = fields.find(
+                field => field.name === "team_name",
+              );
+
+              createQuestion({
+                name: "Structured inactive field",
+                query: {
+                  "source-table": scoreboardTable.id,
+                  fields: [["field", teamNameField.id]],
+                },
+                display: "table",
+                database: WRITABLE_DB_ID,
+              });
+            },
+          );
+        },
+      );
+
+      cy.request(`/api/database/${WRITABLE_DB_ID}/schema/public`).then(
+        ({ body: tables }) => {
+          const colorsTable = tables.find(table => table.name === COLORS_TABLE);
+
+          cy.request(`/api/table/${colorsTable.id}/query_metadata`).then(
+            ({ body: { fields } }) => {
+              const colorNameField = fields.find(
+                field => field.name === "name",
+              );
+
+              createQuestion({
+                name: "Structured inactive table",
+                query: {
+                  "source-table": colorsTable.id,
+                  fields: [["field", colorNameField.id]],
+                },
+                display: "table",
+                database: WRITABLE_DB_ID,
+              });
+            },
+          );
+        },
+      );
+
+      queryWritableDB(
+        `ALTER TABLE ${SCOREBOARD_TABLE} RENAME COLUMN team_name TO team_name_`,
+      );
+
+      queryWritableDB(`DROP TABLE ${COLORS_TABLE}`);
+
+      resyncDatabase({
+        dbId: WRITABLE_DB_ID,
+      });
+
+      cy.visit("/admin/troubleshooting/query-validator");
+
+      cy.findAllByRole("row")
+        .contains("tr", "Native inactive field")
+        .and("contain.text", "Field team_name is inactive");
+
+      cy.findAllByRole("row")
+        .contains("tr", "Native unknown field")
+        .and("contain.text", "Field foo is unknown");
+
+      cy.findAllByRole("row")
+        .contains("tr", "Structured inactive field")
+        .and("contain.text", "Field team_name is inactive");
+
+      cy.findAllByRole("row")
+        .contains("tr", "Native inactive table")
+        .and("contain.text", "Table colors27745 is inactive");
+
+      cy.findAllByRole("row")
+        .contains("tr", "Native unknown table")
+        .and("contain.text", "Table electric_bugaloo is unknown");
+
+      cy.findAllByRole("row")
+        .contains("tr", "Structured inactive table")
+        .and("contain.text", "Table colors27745 is inactive");
     });
-
-    createNativeQuestion({
-      name: "Native inactive table",
-      native: { query: `Select team_name from ${COLORS_TABLE}` },
-      display: "table",
-      database: WRITABLE_DB_ID,
-    });
-
-    createNativeQuestion({
-      name: "Native unknown table",
-      native: { query: "Select * from electric_bugaloo" },
-      display: "line",
-    });
-
-    cy.request(`/api/database/${WRITABLE_DB_ID}/schema/public`).then(
-      ({ body: tables }) => {
-        const scoreboardTable = tables.find(
-          table => table.name === SCOREBOARD_TABLE,
-        );
-
-        cy.request(`/api/table/${scoreboardTable.id}/query_metadata`).then(
-          ({ body: { fields } }) => {
-            const teamNameField = fields.find(
-              field => field.name === "team_name",
-            );
-
-            createQuestion({
-              name: "Structured inactive field",
-              query: {
-                "source-table": scoreboardTable.id,
-                fields: [["field", teamNameField.id]],
-              },
-              display: "table",
-              database: WRITABLE_DB_ID,
-            });
-          },
-        );
-      },
-    );
-
-    cy.request(`/api/database/${WRITABLE_DB_ID}/schema/public`).then(
-      ({ body: tables }) => {
-        const colorsTable = tables.find(table => table.name === COLORS_TABLE);
-
-        cy.request(`/api/table/${colorsTable.id}/query_metadata`).then(
-          ({ body: { fields } }) => {
-            const colorNameField = fields.find(field => field.name === "name");
-
-            createQuestion({
-              name: "Structured inactive table",
-              query: {
-                "source-table": colorsTable.id,
-                fields: [["field", colorNameField.id]],
-              },
-              display: "table",
-              database: WRITABLE_DB_ID,
-            });
-          },
-        );
-      },
-    );
-
-    queryWritableDB(
-      `ALTER TABLE ${SCOREBOARD_TABLE} RENAME COLUMN team_name TO team_name_`,
-    );
-
-    queryWritableDB(`DROP TABLE ${COLORS_TABLE}`);
-
-    resyncDatabase({
-      dbId: WRITABLE_DB_ID,
-    });
-
-    cy.visit("/admin/troubleshooting/query-validator");
-
-    cy.findAllByRole("row")
-      .contains("tr", "Native inactive field")
-      .and("contain.text", "Field team_name is inactive");
-
-    cy.findAllByRole("row")
-      .contains("tr", "Native unknown field")
-      .and("contain.text", "Field foo is unknown");
-
-    cy.findAllByRole("row")
-      .contains("tr", "Structured inactive field")
-      .and("contain.text", "Field team_name is inactive");
-
-    cy.findAllByRole("row")
-      .contains("tr", "Native inactive table")
-      .and("contain.text", "Table colors27745 is inactive");
-
-    cy.findAllByRole("row")
-      .contains("tr", "Native unknown table")
-      .and("contain.text", "Table electric_bugaloo is unknown");
-
-    cy.findAllByRole("row")
-      .contains("tr", "Structured inactive table")
-      .and("contain.text", "Table colors27745 is inactive");
   });
 });
 
@@ -155,6 +199,10 @@ describe("OSS", { tags: "@OSS" }, () => {
     cy.findByTestId("admin-layout-sidebar").should(
       "not.contain",
       "Query Validator",
+    );
+    cy.visit("/admin/settings/general");
+    cy.findByRole("switch", { name: /ENABLE QUERY ANALYSIS/i }).should(
+      "not.exist",
     );
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/troubleshooting/components/QueryValidator.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/troubleshooting/components/QueryValidator.tsx
@@ -14,13 +14,12 @@ import {
 } from "metabase/common/components/CollectionPicker";
 import { EllipsifiedPath } from "metabase/common/components/EllipsifiedPath";
 import { Table } from "metabase/common/components/Table";
+import { useSetting } from "metabase/common/hooks";
 import { Ellipsified } from "metabase/core/components/Ellipsified";
 import CS from "metabase/css/core/index.css";
 import { usePagination } from "metabase/hooks/use-pagination";
 import { formatDateTimeWithUnit } from "metabase/lib/formatting/date";
-import { useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
-import { getSetting } from "metabase/selectors/settings";
 import {
   Box,
   Button,
@@ -64,9 +63,7 @@ type TableRow = {
 };
 
 export const QueryValidator = () => {
-  const queryAnalysisEnabled = useSelector(state =>
-    getSetting(state, "query-analysis-enabled"),
-  );
+  const queryAnalysisEnabled = useSetting("query-analysis-enabled");
   const [sortColumn, setSortColumn] = useState<string>("name");
   const [sortDirection, setSortDirection] = useState<SortDirection>(
     SortDirection.Asc,

--- a/enterprise/frontend/src/metabase-enterprise/troubleshooting/components/QueryValidator.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/troubleshooting/components/QueryValidator.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import { Link } from "react-router";
-import { t } from "ttag";
+import { jt, t } from "ttag";
 import _ from "underscore";
 
 import { useGetCollectionQuery } from "metabase/api";
@@ -18,7 +18,9 @@ import { Ellipsified } from "metabase/core/components/Ellipsified";
 import CS from "metabase/css/core/index.css";
 import { usePagination } from "metabase/hooks/use-pagination";
 import { formatDateTimeWithUnit } from "metabase/lib/formatting/date";
+import { useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
+import { getSetting } from "metabase/selectors/settings";
 import {
   Box,
   Button,
@@ -62,6 +64,9 @@ type TableRow = {
 };
 
 export const QueryValidator = () => {
+  const queryAnalysisEnabled = useSelector(state =>
+    getSetting(state, "query-analysis-enabled"),
+  );
   const [sortColumn, setSortColumn] = useState<string>("name");
   const [sortDirection, setSortDirection] = useState<SortDirection>(
     SortDirection.Asc,
@@ -78,7 +83,7 @@ export const QueryValidator = () => {
         id: collectionId,
       },
       {
-        skip: isRootCollection,
+        skip: isRootCollection || !queryAnalysisEnabled,
       },
     );
 
@@ -92,6 +97,7 @@ export const QueryValidator = () => {
     },
     {
       refetchOnMountOrArgChange: true,
+      skip: !queryAnalysisEnabled,
     },
   );
 
@@ -120,7 +126,7 @@ export const QueryValidator = () => {
     [invalidCards],
   );
 
-  return (
+  return queryAnalysisEnabled ? (
     <>
       <Box>
         <Flex mb="2rem" justify="space-between" align="center">
@@ -180,6 +186,21 @@ export const QueryValidator = () => {
         />
       )}
     </>
+  ) : (
+    <Flex justify="center" p="1rem">
+      <Text fz="1rem" color="var(--mb-color-text-light)">
+        {jt`Query Validation is currently disabled. ${(
+          <Text
+            fz="inherit"
+            color="var(--mb-color-brand)"
+            component={Link}
+            to="/admin/settings/general#query-analysis-enabled"
+          >
+            {t`Please enable query analysis here.`}
+          </Text>
+        )}`}
+      </Text>
+    </Flex>
   );
 };
 

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -255,5 +255,6 @@ export const createMockSettings = (
   "setup-license-active-at-setup": false,
   "notebook-native-preview-shown": false,
   "notebook-native-preview-sidebar-width": null,
+  "query-analysis-enabled": false,
   ...opts,
 });

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -223,6 +223,7 @@ interface InstanceSettings {
   "subscription-allowed-domains": string | null;
   "uploads-settings": UploadsSettings;
   "user-visibility": string | null;
+  "query-analysis-enabled": boolean;
 }
 
 export type EmbeddingHomepageDismissReason =


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/48092

### Description
Adds a couple e2e tests that leverage the `CYPRESS_NO_FEATURES_TOKEN` to ensure that ee customers without the feature get the correct experience, as well as handling the case where the feature is enabled, but `query_analysis_enabled` is false.

### How to verify
1. Set your metabase instance to use a token without the feature and ensure the link is not visible (probably easiest to do in cypress)
2. With the feature enabled, disable the `query_analysis_enabled` setting. Now when you navigate to the query validation, you should see a message with a link directing you to the setting to enable.

### Demo
![chrome_M53Q0QtaoD](https://github.com/user-attachments/assets/82fd3e6f-dd0e-4062-89a8-05702435cb12)

### Checklist
- [x] Tests have been added/updated to cover changes in this PR
