### PR TITLE
Only update version info for latest tag (for now)

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -287,9 +287,10 @@ jobs:
         sparse-checkout: release
     - name: Prepare build scripts
       run: cd ${{ github.workspace }}/release && yarn && yarn build
-    - name: Publish release notes
+    - name: Generate new version info
       uses: actions/github-script@v7
       id: new_version_info
+      if: ${{ inputs.tag_name }} == "latest"
       with:
         result-encoding: string
         script: | # js
@@ -318,6 +319,7 @@ jobs:
           aws s3 cp version-info.json s3://${{ vars.AWS_S3_STATIC_BUCKET }}/version-info.json
         fi
     - name: Create cloudfront invalidation for version-info.json and version-info-ee.json
+      if: ${{ inputs.tag_name }} == "latest"
       run: |
         aws cloudfront create-invalidation \
         --distribution-id ${{ vars.AWS_CLOUDFRONT_STATIC_ID }} \

--- a/release/src/version-info.ts
+++ b/release/src/version-info.ts
@@ -11,6 +11,7 @@ import type {
 import {
   getVersionType,
   isEnterpriseVersion,
+  isPatchVersion,
 } from "./version-helpers";
 
 const generateVersionInfo = ({
@@ -65,6 +66,13 @@ export const updateVersionInfoLatestJson = ({
   existingVersionInfo: VersionInfoFile;
   rollout?: number;
 }) => {
+  if (isPatchVersion(newLatestVersion)) {
+    // currently we don't support patch versions as latest, or store them
+    // in the version-info.json
+    console.warn(`Version ${newLatestVersion} is a patch version, skipping`);
+    return existingVersionInfo;
+  }
+
   if (existingVersionInfo.latest.version === newLatestVersion) {
     console.warn(`Version ${newLatestVersion} already latest, updating rollout % only`);
     return {


### PR DESCRIPTION
follow up to #47868 

The tag update job [failed](https://github.com/metabase/metabase/actions/runs/11018767926) when I tagged the latest nightly release as nightly because it (correctly) couldn't find the patch release information in version-info.json. Historically we don't store information about patches, or prompt users to upgrade to patch releases.

### Description

This just skips version-info.json manipulation for patch releases in the new release tag script.
