### PR TITLE
Cleanup entity picker search types

### DIFF
--- a/frontend/src/metabase-types/api/collection.ts
+++ b/frontend/src/metabase-types/api/collection.ts
@@ -63,7 +63,7 @@ export interface Collection {
   can_delete: boolean;
   archived: boolean;
   children?: Collection[];
-  authority_level?: "official" | null;
+  authority_level?: CollectionAuthorityLevel;
   type?: "instance-analytics" | "trash" | null;
 
   parent_id?: CollectionId | null;
@@ -121,6 +121,7 @@ export interface CollectionItem {
   "last-edit-info"?: LastEditInfo;
   location?: string;
   effective_location?: string;
+  authority_level?: CollectionAuthorityLevel;
   getIcon: () => IconProps;
   getUrl: (opts?: Record<string, unknown>) => string;
   setArchived?: (isArchived: boolean, opts?: Record<string, unknown>) => void;

--- a/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPicker.tsx
+++ b/frontend/src/metabase/common/components/DashboardPicker/components/DashboardPicker.tsx
@@ -161,8 +161,8 @@ const DashboardPickerInner = (
         0;
 
       if (!isParentCollectionInPath) {
-        setPath(oldPath => [
-          ...oldPath,
+        onPathChange([
+          ...path,
           {
             query: {
               id: parentCollectionId,
@@ -176,7 +176,13 @@ const DashboardPickerInner = (
       }
       handleItemSelect(newCollectionItem);
     },
-    [path, onItemSelect, userPersonalCollectionId, handleItemSelect],
+    [
+      path,
+      onItemSelect,
+      userPersonalCollectionId,
+      handleItemSelect,
+      onPathChange,
+    ],
   );
 
   // Exposing onNewDashboard so that parent can select newly created

--- a/frontend/src/metabase/common/components/EntityPicker/components/RecentsTab/utils.ts
+++ b/frontend/src/metabase/common/components/EntityPicker/components/RecentsTab/utils.ts
@@ -5,7 +5,7 @@ dayjs.extend(relativeTime);
 
 import type { RecentItem } from "metabase-types/api";
 
-import type { ResultItemType } from "../ResultItem";
+import type { SearchItem } from "../../types";
 
 const dateBuckets = [
   { title: t`Today`, days: 1 },
@@ -45,7 +45,7 @@ export function getRecentGroups(items: RecentItem[]) {
 }
 
 // put a recent item into the shape expected by ResultItem component
-export const recentItemToResultItem = (item: RecentItem): ResultItemType => ({
+export const recentItemToResultItem = (item: RecentItem): SearchItem => ({
   ...item,
   ...("parent_collection" in item
     ? {

--- a/frontend/src/metabase/common/components/EntityPicker/components/ResultItem/ResultItem.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/ResultItem/ResultItem.tsx
@@ -6,26 +6,11 @@ import { humanize, titleize } from "metabase/lib/formatting";
 import { getIcon } from "metabase/lib/icon";
 import { getName } from "metabase/lib/name";
 import { FixedSizeIcon, Flex, Tooltip } from "metabase/ui";
-import type { SearchResult } from "metabase-types/api";
 
+import type { SearchItem } from "../../types";
 import { ENTITY_PICKER_Z_INDEX } from "../EntityPickerModal";
 
 import { ChunkyListItem } from "./ResultItem.styled";
-
-export type ResultItemType = Pick<SearchResult, "model" | "name"> &
-  Partial<
-    Pick<
-      SearchResult,
-      | "id"
-      | "collection"
-      | "description"
-      | "collection_authority_level"
-      | "moderated_status"
-      | "display"
-      | "database_name"
-      | "table_schema"
-    >
-  >;
 
 export const ResultItem = ({
   item,
@@ -33,7 +18,7 @@ export const ResultItem = ({
   isSelected,
   isLast,
 }: {
-  item: ResultItemType;
+  item: SearchItem;
   onClick: () => void;
   isSelected?: boolean;
   isLast?: boolean;
@@ -91,7 +76,7 @@ export const ResultItem = ({
   );
 };
 
-function getParentInfo(item: ResultItemType) {
+function getParentInfo(item: SearchItem) {
   if (item.model === "table") {
     const icon = getIcon({ model: "database" }).name;
     const databaseName = item.database_name ?? t`Database`;

--- a/frontend/src/metabase/common/components/EntityPicker/components/ResultItem/ResultItem.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/ResultItem/ResultItem.unit.spec.tsx
@@ -13,14 +13,16 @@ import {
 } from "metabase-types/api/mocks";
 import { createMockState } from "metabase-types/store/mocks";
 
-import { ResultItem, type ResultItemType } from "./ResultItem";
+import type { SearchItem } from "../../types";
+
+import { ResultItem } from "./ResultItem";
 
 function setup({
   item,
   isSelected = false,
   onClick = jest.fn(),
 }: {
-  item: ResultItemType;
+  item: SearchItem;
   isSelected?: boolean;
   onClick?: () => void;
 }) {
@@ -47,7 +49,7 @@ function setup({
   );
 }
 
-const collectionItemWithInvalidParent: ResultItemType = {
+const collectionItemWithInvalidParent: SearchItem = {
   id: 301,
   model: "collection",
   name: "Foo Collection",
@@ -58,7 +60,7 @@ const collectionItemWithInvalidParent: ResultItemType = {
   display: null,
 };
 
-const collectionItemWithValidParent: ResultItemType = {
+const collectionItemWithValidParent: SearchItem = {
   id: 302,
   model: "collection",
   name: "Foo Collection",
@@ -69,7 +71,8 @@ const collectionItemWithValidParent: ResultItemType = {
   display: null,
 };
 
-const questionItem: ResultItemType = {
+const questionItem: SearchItem = {
+  id: 303,
   model: "card",
   name: "My Bar Chart",
   description: "",
@@ -79,7 +82,8 @@ const questionItem: ResultItemType = {
   display: "bar",
 };
 
-const dashboardItem: ResultItemType = {
+const dashboardItem: SearchItem = {
+  id: 304,
   model: "dashboard",
   name: "My Awesome Dashboard ",
   description: "This dashboard contains awesome stuff",
@@ -89,7 +93,8 @@ const dashboardItem: ResultItemType = {
   display: null,
 };
 
-const questionInOfficialCollection: ResultItemType = {
+const questionInOfficialCollection: SearchItem = {
+  id: 305,
   model: "card",
   name: "My Line Chart",
   description: "",
@@ -103,7 +108,8 @@ const questionInOfficialCollection: ResultItemType = {
   display: "line",
 };
 
-const verifiedModelItem: ResultItemType = {
+const verifiedModelItem: SearchItem = {
+  id: 306,
   model: "dataset",
   name: "My Verified Model",
   description: "",
@@ -113,18 +119,20 @@ const verifiedModelItem: ResultItemType = {
   display: null,
 };
 
-const tableItem: ResultItemType = {
+const tableItem: SearchItem = {
+  id: 307,
   model: "table",
   name: "My Flat Table",
+  description: null,
   database_name: "My Database",
 };
 
-const tableItemWithSchema: ResultItemType = {
+const tableItemWithSchema: SearchItem = {
   ...tableItem,
   table_schema: "my_schema",
 };
 
-const tableItemWithEmptySchema: ResultItemType = {
+const tableItemWithEmptySchema: SearchItem = {
   ...tableItem,
   table_schema: "",
 };

--- a/frontend/src/metabase/common/components/EntityPicker/components/SearchTab/SearchResults.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/SearchTab/SearchResults.tsx
@@ -5,9 +5,9 @@ import { VirtualizedList } from "metabase/components/VirtualizedList";
 import { NoObjectError } from "metabase/components/errors/NoObjectError";
 import { trackSearchClick } from "metabase/search/analytics";
 import { Box, Flex, Stack } from "metabase/ui";
-import type { SearchResult, SearchResultId } from "metabase-types/api";
+import type { SearchResultId } from "metabase-types/api";
 
-import type { TypeWithModel } from "../../types";
+import type { SearchItem, TypeWithModel } from "../../types";
 import { ChunkyList, ResultItem } from "../ResultItem";
 
 interface Props<
@@ -16,7 +16,7 @@ interface Props<
   Item extends TypeWithModel<Id, Model>,
 > {
   folder: Item | undefined;
-  searchResults: SearchResult[];
+  searchResults: SearchItem[];
   selectedItem: Item | null;
   onItemSelect: (item: Item) => void;
 }

--- a/frontend/src/metabase/common/components/EntityPicker/components/SearchTab/SearchTab.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/SearchTab/SearchTab.tsx
@@ -1,9 +1,13 @@
 import { msgid, ngettext, t } from "ttag";
 
 import { Box, Flex, SegmentedControl, Stack, Text } from "metabase/ui";
-import type { SearchResult, SearchResultId } from "metabase-types/api";
+import type { SearchResultId } from "metabase-types/api";
 
-import type { EntityPickerSearchScope, TypeWithModel } from "../../types";
+import type {
+  EntityPickerSearchScope,
+  SearchItem,
+  TypeWithModel,
+} from "../../types";
 import { isSchemaItem } from "../../utils";
 import { DelayedLoadingSpinner } from "../LoadingSpinner";
 
@@ -17,7 +21,7 @@ interface Props<
   folder: Item | undefined;
   isLoading: boolean;
   searchScope: EntityPickerSearchScope;
-  searchResults: SearchResult[];
+  searchResults: SearchItem[];
   selectedItem: Item | null;
   onItemSelect: (item: Item) => void;
   onSearchScopeChange: (scope: EntityPickerSearchScope) => void;

--- a/frontend/src/metabase/common/components/EntityPicker/hooks/use-scoped-search-results.ts
+++ b/frontend/src/metabase/common/components/EntityPicker/hooks/use-scoped-search-results.ts
@@ -106,16 +106,21 @@ const collectionItemsToSearchResults = <
   items: CollectionItem[],
   folder: Item | undefined,
 ): SearchItem[] => {
-  return items.map(item => ({
-    ...item,
-    model: "collection",
-    collection: folder && { ...folder, id: Number(folder.id) },
-    database_name: null,
-    display: null,
-    table_schema: null,
-    moderated_status: null,
-    collection_authority_level: null,
-  }));
+  return items.reduce((items: SearchItem[], item) => {
+    if (item.model !== "snippet") {
+      items.push({
+        ...item,
+        model: item.model,
+        collection: folder && { ...folder, id: Number(folder.id) },
+        database_name: null,
+        display: null,
+        table_schema: null,
+        moderated_status: null,
+        collection_authority_level: null,
+      });
+    }
+    return items;
+  }, []);
 };
 
 const tablesToSearchResults = (

--- a/frontend/src/metabase/common/components/EntityPicker/hooks/use-scoped-search-results.ts
+++ b/frontend/src/metabase/common/components/EntityPicker/hooks/use-scoped-search-results.ts
@@ -10,12 +10,15 @@ import { isNotNull } from "metabase/lib/types";
 import type {
   CollectionId,
   CollectionItem,
-  SearchResult,
   SearchResultId,
   Table,
 } from "metabase-types/api";
 
-import type { EntityPickerSearchScope, TypeWithModel } from "../types";
+import type {
+  EntityPickerSearchScope,
+  SearchItem,
+  TypeWithModel,
+} from "../types";
 import { isSchemaItem } from "../utils";
 
 export const useScopedSearchResults = <
@@ -27,7 +30,7 @@ export const useScopedSearchResults = <
   searchModels: string[],
   searchScope: EntityPickerSearchScope,
   folder: Item | undefined,
-): SearchResult[] | null => {
+): SearchItem[] | null => {
   const isScopedSearchEnabled = searchScope === "folder" && folder != null;
 
   const shouldUseCollectionItems =
@@ -66,7 +69,7 @@ export const useScopedSearchResults = <
     return tablesToSearchResults(tables ?? [], database?.name);
   }, [tables, database]);
 
-  const scopedSearchResults: SearchResult[] | null = useMemo(() => {
+  const scopedSearchResults: SearchItem[] | null = useMemo(() => {
     if (isScopedSearchEnabled && shouldUseCollectionItems) {
       return isFetchingCollectionItems
         ? null
@@ -102,27 +105,37 @@ const collectionItemsToSearchResults = <
 >(
   items: CollectionItem[],
   folder: Item | undefined,
-): SearchResult[] => {
+): SearchItem[] => {
   return items.map(item => ({
     ...item,
-    collection: folder,
-  })) as unknown as SearchResult[];
+    model: "collection",
+    collection: folder && { ...folder, id: Number(folder.id) },
+    database_name: null,
+    display: null,
+    table_schema: null,
+    moderated_status: null,
+    collection_authority_level: null,
+  }));
 };
 
 const tablesToSearchResults = (
   tables: Table[],
   dbName: string | undefined,
-): SearchResult[] => {
+): SearchItem[] => {
   return tables.map(table => ({
     ...table,
+    id: Number(table.id),
     model: "table",
-    database_name: dbName,
+    database_name: dbName ?? null,
     table_schema: table.schema,
-  })) as unknown as SearchResult[];
+    display: null,
+    moderated_status: null,
+    collection_authority_level: null,
+  }));
 };
 
 const filterSearchResults = (
-  results: SearchResult[],
+  results: SearchItem[],
   searchQuery: string,
   searchModels: string[],
 ) => {

--- a/frontend/src/metabase/common/components/EntityPicker/types.ts
+++ b/frontend/src/metabase/common/components/EntityPicker/types.ts
@@ -1,5 +1,5 @@
 import type { IconName } from "metabase/ui";
-import type { SearchResultId } from "metabase-types/api";
+import type { SearchResult, SearchResultId } from "metabase-types/api";
 
 import type { EntityPickerModalOptions } from "./components/EntityPickerModal";
 
@@ -78,3 +78,17 @@ export type TabFolderState<
   Model extends string,
   Item extends TypeWithModel<Id, Model>,
 > = Partial<Record<EntityPickerTabId, Item>>;
+
+export type SearchItem = Pick<SearchResult, "id" | "model" | "name"> &
+  Partial<
+    Pick<
+      SearchResult,
+      | "collection"
+      | "description"
+      | "collection_authority_level"
+      | "moderated_status"
+      | "display"
+      | "database_name"
+      | "table_schema"
+    >
+  >;

--- a/frontend/src/metabase/common/components/EntityPicker/utils.ts
+++ b/frontend/src/metabase/common/components/EntityPicker/utils.ts
@@ -16,6 +16,7 @@ import { RECENTS_TAB_ID } from "./constants";
 import type {
   EntityPickerSearchScope,
   EntityPickerTab,
+  SearchItem,
   TypeWithModel,
 } from "./types";
 
@@ -89,7 +90,7 @@ const searchResultTranslationContext = c(
 );
 
 export function getSearchTabText(
-  searchResults: SearchResult[] | null,
+  searchResults: SearchItem[] | null,
   searchQuery: string,
 ): string {
   if (!searchResults || !searchResults.length) {

--- a/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPicker.unit.spec.tsx
@@ -477,6 +477,7 @@ describe("QuestionPickerModal", () => {
     await setupModal({ models: ["card", "dataset", "metric"] });
     const searchInput = await screen.findByPlaceholderText(/search/i);
     await userEvent.type(searchInput, myMetric.name);
+    await userEvent.click(screen.getByText("Everywhere"));
     expect(await screen.findByText(myMetric.name)).toBeInTheDocument();
     expect(screen.queryByText(myQuestion.name)).not.toBeInTheDocument();
   });

--- a/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPickerModal.tsx
+++ b/frontend/src/metabase/common/components/QuestionPicker/components/QuestionPickerModal.tsx
@@ -69,10 +69,6 @@ export const QuestionPickerModal = ({
     [onChange, tryLogRecentItem],
   );
 
-  const handleInit = useCallback((item: QuestionPickerItem) => {
-    setSelectedItem(current => current ?? item);
-  }, []);
-
   const handleItemSelect = useCallback(
     (item: QuestionPickerItem) => {
       if (options.hasConfirmButtons) {
@@ -111,7 +107,7 @@ export const QuestionPickerModal = ({
           models={["card"]}
           options={options}
           path={questionsPath}
-          onInit={handleInit}
+          onInit={onItemSelect}
           onItemSelect={onItemSelect}
           onPathChange={setQuestionsPath}
         />
@@ -129,7 +125,7 @@ export const QuestionPickerModal = ({
           models={["dataset"]}
           options={options}
           path={modelsPath}
-          onInit={handleInit}
+          onInit={onItemSelect}
           onItemSelect={onItemSelect}
           onPathChange={setModelsPath}
         />
@@ -147,7 +143,7 @@ export const QuestionPickerModal = ({
           models={["metric"]}
           options={options}
           path={metricsPath}
-          onInit={handleInit}
+          onInit={onItemSelect}
           onItemSelect={onItemSelect}
           onPathChange={setMetricsPath}
         />

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker/LinkedEntityPicker.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker/LinkedEntityPicker.unit.spec.tsx
@@ -330,6 +330,7 @@ describe("LinkedEntityPicker", () => {
             await screen.findByPlaceholderText(/search/i),
             typedText,
           );
+          await userEvent.click(screen.getByText("Everywhere"));
 
           expect(
             await screen.findByText(questionSearchResult.name),
@@ -393,6 +394,7 @@ describe("LinkedEntityPicker", () => {
             await screen.findByPlaceholderText(/search/i),
             typedText,
           );
+          await userEvent.click(screen.getByText("Everywhere"));
 
           expect(
             await screen.findByText(questionSearchResult.name),


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/47281

Renames `ResultItemType` to `SearchItem`. Moves this type to top-level `EntityPicker` types and uses it in places where we expect local search results.