### PR TITLE
Automatically tag automatic releases as `nightly`

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -28,6 +28,30 @@ on:
         description: Apply to OSS
         type: boolean
         default: true
+  workflow_call:
+    inputs:
+      version:
+        type: string
+        required: true
+      tag_name:
+        type: string
+        # options:
+        #   - nightly
+        #   - beta
+        #   - latest
+        required: true
+      tag_rollout:
+        description: Rollout % (0-100)
+        type: number
+        default: 100
+      tag_ee:
+        description: Apply to EE
+        type: boolean
+        default: true
+      tag_oss:
+        description: Apply to OSS
+        type: boolean
+        default: true
 
 jobs:
   check-version:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -687,6 +687,16 @@ jobs:
         --distribution-id ${{ vars.AWS_CLOUDFRONT_STATIC_ID }} \
         --paths "/version-info.json" "/version-info-ee.json"
 
+  tag-nightly:
+    if: ${{ inputs.auto }}
+    uses: ./.github/workflows/release-tag.yml
+    with:
+      version: ${{ inputs.version }}
+      tag_name: nightly
+      tag_rollout: 100
+      tag_ee: true
+      tag_oss: true
+
   publish-complete-message:
     if: ${{ !inputs.auto }}
     runs-on: ubuntu-22.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -689,6 +689,7 @@ jobs:
 
   tag-nightly:
     if: ${{ inputs.auto }}
+    needs: [push-tags, verify-docker-pull, verify-s3-download]
     uses: ./.github/workflows/release-tag.yml
     with:
       version: ${{ inputs.version }}
@@ -729,7 +730,7 @@ jobs:
   auto-publish-complete-message:
     if: ${{ inputs.auto }}
     runs-on: ubuntu-22.04
-    needs: [push-tags, verify-docker-pull, verify-s3-download]
+    needs: tag-nightly
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
follow up to: https://github.com/metabase/metabase/pull/47868

### Description

Now that the release "tag" for any given release is separate from the release process, this re-automates tagging, but only automates adding the `nightly` tag to our automatic nightly patch releases. This simply automatically invokes the existing github action with the correct parameters.


