### PR TITLE
invalidate channels html as well

### DIFF
--- a/.github/workflows/release-log.yml
+++ b/.github/workflows/release-log.yml
@@ -55,4 +55,4 @@ jobs:
         run: |
           aws cloudfront create-invalidation \
           --distribution-id ${{ vars.AWS_CLOUDFRONT_STATIC_ID }} \
-          --paths /release-log/v$VERSION.html
+          --paths "/release-log/v$VERSION.html" "/release-log/channels.html"


### PR DESCRIPTION
Another little follow up to https://github.com/metabase/metabase/pull/47868

### Description

Invalidate the cloudfront cache for `channels.html` so the page updates faster
