### PR TITLE
Periodically recreate the search index

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -373,7 +373,10 @@
                                      metabase.sync.util}                                            ; TODO -- consolidate these into a real API namespace.
     metabase.task                  #{metabase.task
                                      metabase.task.index-values
-                                     metabase.task.persist-refresh}                                 ; TODO -- consolidate these into a real API namespace.
+                                     metabase.task.persist-refresh
+                                     ;; We need to expose this to the metabase.search module.
+                                     ;; Ideally, it would just live inside that module.
+                                     metabase.task.search-index}                                    ; TODO -- consolidate these into a real API namespace.
     metabase.troubleshooting       #{metabase.troubleshooting}
     metabase.types                 #{metabase.types}
     metabase.upload                #{metabase.upload}

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -6,6 +6,8 @@
    [metabase.public-settings :as public-settings]
    [metabase.search :as search]
    [metabase.server.middleware.offset-paging :as mw.offset-paging]
+   [metabase.task :as task]
+   [metabase.task.search-index :as task.search-index]
    [metabase.util :as u]
    [metabase.util.malli.schema :as ms]
    [ring.util.response :as response]))
@@ -47,7 +49,7 @@
 
     (search/supports-index?)
     (do
-      (search/reindex!)
+      (task/trigger-now! (task.search-index/job-key))
       {:status-code 200})
 
     :else

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -49,7 +49,9 @@
 
     (search/supports-index?)
     (do
-      (task/trigger-now! (task.search-index/job-key))
+      (if (task/job-exists? task.search-index/job-key)
+        (task/trigger-now! task.search-index/job-key)
+        (search/reindex!))
       {:status-code 200})
 
     :else

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -101,6 +101,8 @@
 (def SearchContext
   "Map with the various allowed search parameters, used to construct the SQL query."
   [:map {:closed true}
+   ;; display related
+   [:calculate-available-models? {:optional true} :boolean]
    ;;
    ;; required
    ;;
@@ -111,8 +113,8 @@
    [:model-ancestors?   :boolean]
    [:models             [:set SearchableModel]]
    ;; TODO this is optional only for tests, clean those up!
-   [:search-engine       {:optional true} keyword?]
-   [:search-string      [:maybe ms/NonBlankString]]
+   [:search-engine      {:optional true} keyword?]
+   [:search-string      {:optional true} [:maybe ms/NonBlankString]]
    ;;
    ;; optional
    ;;

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -199,22 +199,27 @@
 
 (defmulti supported-engine? "Does this instance support the given engine?" keyword)
 
-(defmethod supported-engine? :in-place [_] true)
-(defmethod supported-engine? :fulltext [_] (search.fulltext/supported-db? (mdb/db-type)))
+(defmethod supported-engine? :search.engine/in-place [_] true)
+(defmethod supported-engine? :search.engine/fulltext [_] (search.fulltext/supported-db? (mdb/db-type)))
 
 (def ^:private default-engine :search.engine/in-place)
 
+(defn- known-engine? [engine]
+  (let [registered? #(contains? (methods supported-engine?) %)]
+     (some registered? (cons engine (ancestors engine)))))
+
 (defn- parse-engine [value]
   (or (when-not (str/blank? value)
-        (cond
-          (not (contains? (methods supported-engine?) value))
-          (log/warnf "Search-engine is unknown: %s" value)
+        (let [engine (keyword "search.engine" value)]
+          (cond
+            (not (known-engine? engine))
+            (log/warnf "Search-engine is unknown: %s" value)
 
-          (not (supported-engine? value))
-          (log/warnf "Search-engine is not supported: %s" value)
+            (not (supported-engine? engine))
+            (log/warnf "Search-engine is not supported: %s" value)
 
-          :else
-          (keyword "search.engine" value)))
+            :else
+            engine)))
       default-engine))
 
 ;; This forwarding is here for tests, we should clean those up.

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -206,7 +206,7 @@
 
 (defn- known-engine? [engine]
   (let [registered? #(contains? (methods supported-engine?) %)]
-     (some registered? (cons engine (ancestors engine)))))
+    (some registered? (cons engine (ancestors engine)))))
 
 (defn- parse-engine [value]
   (or (when-not (str/blank? value)

--- a/src/metabase/task.clj
+++ b/src/metabase/task.clj
@@ -308,6 +308,11 @@
     (instance? JobKey x) x
     (string? x)          (JobKey. ^String x)))
 
+(defn job-exists?
+  "Check whether there is a Job with the given key."
+  [job-key]
+  (boolean (qs/get-job (scheduler) (->job-key job-key))))
+
 (defn job-info
   "Get info about a specific Job (`job-key` can be either a String or `JobKey`).
 

--- a/src/metabase/task.clj
+++ b/src/metabase/task.clj
@@ -311,7 +311,9 @@
 (defn job-exists?
   "Check whether there is a Job with the given key."
   [job-key]
-  (boolean (qs/get-job (scheduler) (->job-key job-key))))
+  (boolean
+   (when-let [s (scheduler)]
+     (qs/get-job s (->job-key job-key)))))
 
 (defn job-info
   "Get info about a specific Job (`job-key` can be either a String or `JobKey`).

--- a/src/metabase/task/search_index.clj
+++ b/src/metabase/task/search_index.clj
@@ -1,8 +1,8 @@
 (ns metabase.task.search-index
   (:require
    [clojurewerkz.quartzite.jobs :as jobs]
+   [clojurewerkz.quartzite.schedule.simple :as simple]
    [clojurewerkz.quartzite.triggers :as triggers]
-   [metabase.public-settings :as public-settings]
    [metabase.search :as search]
    [metabase.task :as task]
    [metabase.util.log :as log])
@@ -11,22 +11,32 @@
 
 (set! *warn-on-reflection* true)
 
-;; We need each instance to initialize on start-up currently, this will need to be refined.
-(jobs/defjob ^{DisallowConcurrentExecution false
+(def ^:private recreated? (atom false))
+
+(def job-key
+  "Key used to define and trigger the search-index task."
+  (jobs/key "metabase.task.search-index.job"))
+
+(jobs/defjob ^{DisallowConcurrentExecution true
                :doc                        "Populate Search Index"}
   SearchIndexing [_ctx]
-  (when (public-settings/experimental-fulltext-search-enabled)
-    (log/info "Recreating search index from latest schema")
-    (search/init-index! {:force-reset? true})
-    (log/info "Populating search index")
-    (search/reindex!)
+  (when (search/supports-index?)
+    (if (not @recreated?)
+      (do (log/info "Recreating search index from the latest schema")
+          ;; We need each instance to initialize on start-up currently, this will need to be refined.
+          (search/init-index! {:force-reset? (not @recreated?)})
+          (reset! recreated? true))
+      (do (log/info "Reindexing searchable entities")
+          (search/reindex!)))
     (log/info "Done indexing.")))
 
 (defmethod task/init! ::SearchIndex [_]
   (let [job     (jobs/build
                  (jobs/of-type SearchIndexing)
-                 (jobs/with-identity (jobs/key "metabase.task.search-index.job")))
+                 (jobs/with-identity job-key))
         trigger (triggers/build
                  (triggers/with-identity (triggers/key "metabase.task.search-index.trigger"))
-                 (triggers/start-now))]
+                 (triggers/start-now)
+                 (triggers/with-schedule
+                  (simple/schedule (simple/with-interval-in-hours 1))))]
     (task/schedule-task! job trigger)))

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -1565,3 +1565,10 @@
                                            :name "top level col"
                                            :type "foo"}]}
                    (:collection leaf-card-response)))))))))
+
+(deftest force-reindex-test
+  (mt/with-temp [Card {id :id} {:name "It boggles the mind!"}]
+    (let [search-results #(:data (mt/user-http-request :rasta :get 200 "search" :q "boggle" :search_engine "fulltext"))]
+      (is (empty? (search-results)))
+      (mt/user-http-request :crowberto :post 200 "search/force-reindex")
+      (is (some (comp #{id} :id) (search-results))))))

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -300,6 +300,13 @@
       (is (= 2 (:limit (search-request :crowberto :q "test" :limit "2" :offset "3"))))
       (is (= 3 (:offset (search-request :crowberto :q "test" :limit "2" :offset "3")))))))
 
+(deftest custom-engine-test
+  (testing "It returns limit and offset params in return result"
+    (with-search-items-in-root-collection "test"
+      (let [resp (search-request :crowberto :q "test" :search_engine "fulltext")]
+        ;; The index is not populated here, so there's not much interesting to assert.
+        (is (= "search.engine/fulltext" (:engine resp)))))))
+
 (deftest archived-models-test
   (testing "It returns some stuff when you get results"
     (with-search-items-in-root-collection "test"

--- a/test/metabase/search/impl_test.clj
+++ b/test/metabase/search/impl_test.clj
@@ -8,6 +8,7 @@
    [java-time.api :as t]
    [metabase.api.common :as api]
    [metabase.config :as config]
+   [metabase.search :as search]
    [metabase.search.config :as search.config]
    [metabase.search.impl :as search.impl]
    [metabase.search.legacy :as search.legacy]
@@ -23,10 +24,12 @@
             (#'search.impl/parse-engine "vespa"))))
   (testing "Registered engines"
     (is (= :search.engine/in-place (#'search.impl/parse-engine "in-place")))
-    (is (= :search.engine/fulltext (#'search.impl/parse-engine "fulltext"))))
-  (testing "Subclasses"
-    (is (= :search.engine/hybrid (#'search.impl/parse-engine "hybrid")))
-    (is (= :search.engine/minimal (#'search.impl/parse-engine "minimal")))))
+    (when (search/supports-index?)
+      (is (= :search.engine/fulltext (#'search.impl/parse-engine "fulltext")))))
+  (when (search/supports-index?)
+    (testing "Subclasses"
+      (is (= :search.engine/hybrid (#'search.impl/parse-engine "hybrid")))
+      (is (= :search.engine/minimal (#'search.impl/parse-engine "minimal"))))))
 
 (deftest ^:parallel order-clause-test
   (testing "it includes all columns and normalizes the query"

--- a/test/metabase/search/impl_test.clj
+++ b/test/metabase/search/impl_test.clj
@@ -15,6 +15,19 @@
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp]))
 
+(deftest ^:parallel parse-engine-test
+  (testing "Default engine"
+    (is (= :search.engine/in-place (#'search.impl/parse-engine nil))))
+  (testing "Unknown engine resolves to the default"
+    (is (=  (#'search.impl/parse-engine nil)
+            (#'search.impl/parse-engine "vespa"))))
+  (testing "Registered engines"
+    (is (= :search.engine/in-place (#'search.impl/parse-engine "in-place")))
+    (is (= :search.engine/fulltext (#'search.impl/parse-engine "fulltext"))))
+  (testing "Subclasses"
+    (is (= :search.engine/hybrid (#'search.impl/parse-engine "hybrid")))
+    (is (= :search.engine/minimal (#'search.impl/parse-engine "minimal")))))
+
 (deftest ^:parallel order-clause-test
   (testing "it includes all columns and normalizes the query"
     (is (= [[:case

--- a/test/metabase/task_test.clj
+++ b/test/metabase/task_test.clj
@@ -65,10 +65,10 @@
 
 (deftest job-exists?-test
   (with-temp-scheduler-and-cleanup!
-   (is (false? (task/job-exists? (.getKey (job)))))
-   (task/schedule-task! (job) (trigger-1))
-   (is (true? (task/job-exists? (.getKey (job)))))
-   (is (false? (task/job-exists? "not-found")))))
+    (is (false? (task/job-exists? (.getKey (job)))))
+    (task/schedule-task! (job) (trigger-1))
+    (is (true? (task/job-exists? (.getKey (job)))))
+    (is (false? (task/job-exists? "not-found")))))
 
 (deftest schedule-job-test
   (testing "can we schedule a job?"

--- a/test/metabase/task_test.clj
+++ b/test/metabase/task_test.clj
@@ -63,6 +63,13 @@
      {:cron-expression     (.getCronExpression trigger)
       :misfire-instruction (.getMisfireInstruction trigger)})))
 
+(deftest job-exists?-test
+  (with-temp-scheduler-and-cleanup!
+   (is (false? (task/job-exists? (.getKey (job)))))
+   (task/schedule-task! (job) (trigger-1))
+   (is (true? (task/job-exists? (.getKey (job)))))
+   (is (false? (task/job-exists? "not-found")))))
+
 (deftest schedule-job-test
   (testing "can we schedule a job?"
     (with-temp-scheduler-and-cleanup!


### PR DESCRIPTION
# Description

1. Adds periodic reindexing.
2. When the API is called, it triggers the job. This avoids concurrent re-indexing.