### PR TITLE
Do not cache all token check failures

### DIFF
--- a/bin/build/resources/overrides.edn
+++ b/bin/build/resources/overrides.edn
@@ -20,6 +20,7 @@
  "amalloy"                     {"ring-gzip-middleware" {:resource "MIT.txt"}}
  "buddy"                       {"buddy-core" {:resource "apache2_0.txt"}
                                 "buddy-sign" {:resource "apache2_0.txt"}}
+ "dev.failsafe"                {"failsafe" {:resource "LICENSE"}}
  "colorize"                    {"colorize" {:resource "EPL.txt"}}
  "com.github.jnr"              {"jffi$native" {:resource "apache2_0.txt"}}
  "com.google.api-client"       {"google-api-client" {:resource "apache2_0.txt"}}

--- a/deps.edn
+++ b/deps.edn
@@ -66,6 +66,7 @@
   compojure/compojure                       {:mvn/version "1.7.1"               ; HTTP Routing library built on Ring
                                              :exclusions  [ring/ring-codec]}
   crypto-random/crypto-random               {:mvn/version "1.2.1"}              ; library for generating cryptographically secure random bytes and strings
+  diehard/diehard                           {:mvn/version "0.11.12"}
   dk.ative/docjure                          {:mvn/version "1.19.0"              ; excel export
                                              :exclusions  [org.apache.poi/poi
                                                            org.apache.poi/poi-ooxml]}

--- a/test/metabase/api/premium_features_test.clj
+++ b/test/metabase/api/premium_features_test.clj
@@ -14,7 +14,7 @@
                                                          :status   "fake"
                                                          :features ["test" "fixture"]
                                                          :trial    false})]
-      (mt/with-temporary-setting-values [:premium-embedding-token premium-features-test/random-fake-token]
+      (mt/with-temporary-setting-values [:premium-embedding-token (premium-features-test/random-token)]
         (testing "returns correctly"
           (is (= {:valid    true
                   :status   "fake"

--- a/test/metabase/util/embed_test.clj
+++ b/test/metabase/util/embed_test.clj
@@ -47,7 +47,7 @@
                                                                  :status   "fake"
                                                                  :features ["test" "fixture"]
                                                                  :trial    false})]
-              (mt/with-temporary-setting-values [premium-embedding-token premium-features-test/random-fake-token]
+              (mt/with-temporary-setting-values [premium-embedding-token (premium-features-test/random-token)]
                 (is (= (embed/show-static-embed-terms) false))
                 (embed/show-static-embed-terms! false)
                 (is (= (embed/show-static-embed-terms) false)))))


### PR DESCRIPTION
We want to cache token checks to avoid an issue where we repeatedly ask the store "hey, is this token valid?? is this token valid?? is this token valid??" for the same token.

However, transient errors can also occur. For example, maybe a network issue causes the HTTP request to fail entirely. In this case, if we cache the result, the user needs to restart metabase (or wait 5 minutes until the cache is cleared) before they can attempt to validate their token again.

This PR moves the cache logic deeper into the stack. We want to cache "successful" responses from the store API - cases where the store has told us categorically that the token is or is not valid. We don't want or need to cache other things that might happen. Maybe your token isn't the right length - we can recalculate that, it's ok. Maybe you get a 503 error from the Store - we should let you retry. Maybe your network is having issues and you can't contact the Store at all - again, we should let you retry.

~The one potential issue I see here is that if the store goes down temporarily, we'll massively increase the number of requests we send to the store, potentially making it harder to recover from an outage. If this is a concern, I can add a circuit breaker: if we repeatedly get errors back from the store, back off and stop making requests for a while.~

Edit: I added the following:

In the pathological case where the store goes down for >5 minutes, the
cache will expire and all instances everywhere will start repeatedly
making requests for token validation at once. This might make recovering
from an outage more difficult.

This adds a circuit breaker around the API request. If the call
repeatedly throws (5XX errors, socket timeouts, etc.) then we'll pause
for 30 seconds, during which time all calls to token validation will
immediately fail without making any request to the API.

After 30 seconds, we'll allow one request through to the API. If it
succeeds, we'll go back to normal operation. Otherwise, we'll wait
another 30 seconds.


Fixes #41654 