### PR TITLE
Add alternative release channel info to version-info.json

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -314,7 +314,6 @@ jobs:
     - name: Generate new version info
       uses: actions/github-script@v7
       id: new_version_info
-      if: ${{ inputs.tag_name }} == "latest"
       with:
         result-encoding: string
         script: | # js
@@ -336,7 +335,6 @@ jobs:
           fs.writeFileSync('version-info.json', JSON.stringify(newVersionInfo));
 
     - name: Upload new version-info.json to S3
-      if: ${{ inputs.tag_name }} == "latest"
       run: |
         if [[ "${{ matrix.edition }}" == "ee" ]]; then
           aws s3 cp version-info.json s3://${{ vars.AWS_S3_STATIC_BUCKET }}/version-info-ee.json
@@ -344,7 +342,6 @@ jobs:
           aws s3 cp version-info.json s3://${{ vars.AWS_S3_STATIC_BUCKET }}/version-info.json
         fi
     - name: Create cloudfront invalidation for version-info.json and version-info-ee.json
-      if: ${{ inputs.tag_name }} == "latest"
       run: |
         aws cloudfront create-invalidation \
         --distribution-id ${{ vars.AWS_CLOUDFRONT_STATIC_ID }} \

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -318,7 +318,7 @@ jobs:
       with:
         result-encoding: string
         script: | # js
-          const { updateVersionInfoLatest } = require('${{ github.workspace }}/release/dist/index.cjs');
+          const { updateVersionInfoChannel } = require('${{ github.workspace }}/release/dist/index.cjs');
           const fs = require('fs');
 
           const edition = '${{ matrix.edition }}';
@@ -327,8 +327,9 @@ jobs:
             ? '${{ needs.check-version.outputs.ee }}'
             : '${{ needs.check-version.outputs.oss }}';
 
-          const newVersionInfo = await updateVersionInfoLatest({
-            newLatestVersion: canonical_version,
+          const newVersionInfo = await updateVersionInfoChannel({
+            channel: '${{ inputs.tag_name }}',
+            newVersion: canonical_version,
             rollout: ${{ inputs.tag_rollout }},
           });
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -651,7 +651,7 @@ jobs:
         sparse-checkout: release
     - name: Prepare build scripts
       run: cd ${{ github.workspace }}/release && yarn && yarn build
-    - name: Publish release notes
+    - name: Publish version info
       uses: actions/github-script@v7
       id: new_version_info
       with:

--- a/release/src/types.ts
+++ b/release/src/types.ts
@@ -38,6 +38,8 @@ export interface VersionInfoFile {
   older: VersionInfo[];
 }
 
+export type ReleaseChannel = "latest" | "beta" | "nightly";
+
 export type Issue = {
   number: number;
   node_id: string;

--- a/release/src/types.ts
+++ b/release/src/types.ts
@@ -35,6 +35,8 @@ export interface VersionInfo {
 
 export interface VersionInfoFile {
   latest: VersionInfo;
+  beta?: VersionInfo;
+  nightly?: VersionInfo;
   older: VersionInfo[];
 }
 

--- a/release/src/version-info.ts
+++ b/release/src/version-info.ts
@@ -102,6 +102,7 @@ export const updateVersionInfoLatestJson = ({
   oldLatestVersionInfo.rollout = undefined;
 
   return {
+    ...existingVersionInfo,
     latest: {
       ...newLatestVersionInfo,
       rollout,

--- a/release/src/version-info.unit.spec.ts
+++ b/release/src/version-info.unit.spec.ts
@@ -1,5 +1,5 @@
 import type { Issue, VersionInfoFile } from "./types";
-import { generateVersionInfoJson, getVersionInfoUrl, updateVersionInfoLatestJson } from "./version-info";
+import { generateVersionInfoJson, getVersionInfoUrl, updateVersionInfoChannelJson, updateVersionInfoLatestJson } from "./version-info";
 
 describe("version-info", () => {
   describe("generateVersionInfoJson", () => {
@@ -261,6 +261,105 @@ describe("version-info", () => {
         patch: true,
         highlights: ["Old Issue 1", "Old Issue 2"],
         // no rollout
+      });
+    });
+  });
+
+  describe("updateVersionInfoChannelJson", () => {
+    const oldJson = {
+      latest: {
+        version: "v0.2.4",
+        released: "2022-01-01",
+        patch: true,
+        highlights: ["Old Issue 1", "Old Issue 2"],
+      },
+      nightly: {
+        version: "v0.2.4.1",
+        released: "2022-01-03",
+        patch: true,
+        highlights: [],
+      },
+      beta: {
+        version: "v0.2.6",
+        released: "2022-01-02",
+        patch: true,
+        highlights: [],
+      },
+      older: [
+        {
+          version: "v0.2.5",
+          released: "2023-01-01",
+          patch: true,
+          highlights: ["New Issue 31", "New Issue 41"],
+        },
+        {
+          version: "v0.2.3",
+          released: "2021-01-01",
+          patch: true,
+          highlights: ["Old Issue 3", "Old Issue 4"],
+        },
+        {
+          version: "v0.2.2",
+          released: "2020-01-01",
+          patch: true,
+          highlights: ["Old Issue 5", "Old Issue 6"],
+        },
+      ],
+    } as VersionInfoFile;
+
+    it("should update nightly version", () => {
+      const updatedJson = updateVersionInfoChannelJson({
+        version: "v0.2.4.2",
+        existingVersionInfo: oldJson,
+        channel: "nightly",
+        rollout: 51,
+      });
+
+      expect(updatedJson.nightly).toEqual({
+        version: "v0.2.4.2",
+        released: expect.any(String),
+        rollout: 51,
+        highlights: [],
+      });
+    });
+
+    it("should update beta version", () => {
+      const updatedJson = updateVersionInfoChannelJson({
+        version: "v0.2.7",
+        existingVersionInfo: oldJson,
+        channel: "beta",
+        rollout: 51,
+      });
+
+      expect(updatedJson.beta).toEqual({
+        version: "v0.2.7",
+        released: expect.any(String),
+        rollout: 51,
+        highlights: [],
+      });
+    });
+
+    it("should update latest version", () => {
+      const updatedJson = updateVersionInfoChannelJson({
+        version: "v0.2.5", // must be in the older array
+        existingVersionInfo: oldJson,
+        channel: "latest",
+        rollout: 51,
+      });
+
+      expect(updatedJson.latest).toEqual({
+        version: "v0.2.5",
+        released: expect.any(String),
+        rollout: 51,
+        patch: true,
+        highlights: ["New Issue 31", "New Issue 41"],
+      });
+
+      expect(updatedJson.older).toContainEqual({
+        version: "v0.2.4",
+        released: "2022-01-01",
+        patch: true,
+        highlights: ["Old Issue 1", "Old Issue 2"],
       });
     });
   });

--- a/release/src/version-info.unit.spec.ts
+++ b/release/src/version-info.unit.spec.ts
@@ -147,6 +147,8 @@ describe("version-info", () => {
       });
 
       expect(updatedJson.latest.version).toEqual("v0.2.5");
+      expect(updatedJson.beta).toEqual(oldJson.beta);
+      expect(updatedJson.nightly).toEqual(oldJson.nightly);
     });
 
     it("should ignore if version is already latest", () => {
@@ -321,6 +323,9 @@ describe("version-info", () => {
         rollout: 51,
         highlights: [],
       });
+
+      expect(updatedJson.beta).toEqual(oldJson.beta);
+      expect(updatedJson.latest).toEqual(oldJson.latest);
     });
 
     it("should update beta version", () => {
@@ -337,6 +342,9 @@ describe("version-info", () => {
         rollout: 51,
         highlights: [],
       });
+
+      expect(updatedJson.latest).toEqual(oldJson.latest);
+      expect(updatedJson.nightly).toEqual(oldJson.nightly);
     });
 
     it("should update latest version", () => {
@@ -361,6 +369,9 @@ describe("version-info", () => {
         patch: true,
         highlights: ["Old Issue 1", "Old Issue 2"],
       });
+
+      expect(updatedJson.beta).toEqual(oldJson.beta);
+      expect(updatedJson.nightly).toEqual(oldJson.nightly);
     });
   });
 


### PR DESCRIPTION
part of #48121

### Description

Updates version-info.json tagging logic to update `nightly` and `beta` keys.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] test in my fork: [success](https://github.com/iethree/metabase/actions/runs/11129028677)
