### PR TITLE
Pass credentials to nightly build tag workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -691,6 +691,7 @@ jobs:
     if: ${{ inputs.auto }}
     needs: [push-tags, verify-docker-pull, verify-s3-download]
     uses: ./.github/workflows/release-tag.yml
+    secrets: inherit
     with:
       version: ${{ inputs.version }}
       tag_name: nightly


### PR DESCRIPTION
### Description

Update the automatic nightly release tag workflow call to inherit secrets from the parent job.
