### PR TITLE
test(sdk): test that "Custom" fonts work with the sdk

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/tests/styling-sdk-tests.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk/tests/styling-sdk-tests.stories.tsx
@@ -11,7 +11,7 @@ export default {
 
 const configThatWillError: SDKConfig = {
   apiKey: "TEST",
-  metabaseInstanceUrl: "http://localhost",
+  metabaseInstanceUrl: "http://fake-host:1234",
 };
 
 /**


### PR DESCRIPTION
closes https://github.com/metabase/metabase/pull/48160

# Description

This tests that if a customer has a "Custom" font set on their instance it will be used.
They can either pass "Custom" by hand to fontFamily or let it work by default as the `getFont` selector will return "Custom".
