### PR TITLE
Fix non-bool value in CSV upload availability check for stats ping

### DIFF
--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -589,11 +589,11 @@
   "Is CSV upload currently available to be used on this instance?"
   []
   (boolean
-    (let [major-version (config/current-major-version)
-          minor-version (config/current-minor-version)
-          engines       (t2/select-fn-set :engine :model/Database
-                                          {:where [:in :engine (map name (keys csv-upload-version-availability))]})]
-      (when (and major-version minor-version)
+   (let [major-version (config/current-major-version)
+         minor-version (config/current-minor-version)
+         engines       (t2/select-fn-set :engine :model/Database
+                                         {:where [:in :engine (map name (keys csv-upload-version-availability))]})]
+     (when (and major-version minor-version)
        (some
         (fn [engine]
           (when-let [[required-major required-minor] (csv-upload-version-availability engine)]

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -588,12 +588,12 @@
 (defn- csv-upload-available?
   "Is CSV upload currently available to be used on this instance?"
   []
-  (let [major-version (config/current-major-version)
-        minor-version (config/current-minor-version)
-        engines       (t2/select-fn-set :engine :model/Database
-                                        {:where [:in :engine (map name (keys csv-upload-version-availability))]})]
-    (when (and major-version minor-version)
-      (boolean
+  (boolean
+    (let [major-version (config/current-major-version)
+          minor-version (config/current-minor-version)
+          engines       (t2/select-fn-set :engine :model/Database
+                                          {:where [:in :engine (map name (keys csv-upload-version-availability))]})]
+      (when (and major-version minor-version)
        (some
         (fn [engine]
           (when-let [[required-major required-minor] (csv-upload-version-availability engine)]


### PR DESCRIPTION
We should return `false` instead of `nil` if for some reason the current MB build doesn't have version information available, so that we're still compliant with the Snowplow schema. Slack context: https://metaboat.slack.com/archives/C064EB1UE5P/p1727449849928259

Also added a unit test for this helper function.