### PR TITLE
fix: bigquery more resilient querying

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/deps.edn
+++ b/modules/drivers/bigquery-cloud-sdk/deps.edn
@@ -3,10 +3,12 @@
 
  :deps
  ;; TODO: figure out how to be able to leave off this version string and use the version from the BOM
- {com.google.cloud/google-cloud-bigquery      {:mvn/version "2.38.1"
+ {com.google.cloud/google-cloud-bigquery      {:mvn/version "2.42.3"
                                                ;; this appears to be dual licensed EPL, GPL2.0 but it's not super
                                                ;; clear so we're excluding it
                                                :exclusions [javax.annotation/javax.annotation-api]}
   com.google.guava/guava                      {:mvn/version "33.1.0-jre"} ; specified separately so that Snyk is happy
   com.google.code.gson/gson                   {:mvn/version "2.10.1"}
-  com.google.oauth-client/google-oauth-client {:mvn/version "1.35.0"}}}
+  com.google.oauth-client/google-oauth-client {:mvn/version "1.35.0"}
+  com.google.protobuf/protobuf-java           {:mvn/version "3.25.5"}
+  com.google.protobuf/protobuf-java-util      {:mvn/version "3.25.5"}}}

--- a/modules/drivers/bigquery-cloud-sdk/deps.edn
+++ b/modules/drivers/bigquery-cloud-sdk/deps.edn
@@ -10,5 +10,5 @@
   com.google.guava/guava                      {:mvn/version "33.1.0-jre"} ; specified separately so that Snyk is happy
   com.google.code.gson/gson                   {:mvn/version "2.10.1"}
   com.google.oauth-client/google-oauth-client {:mvn/version "1.35.0"}
-  com.google.protobuf/protobuf-java           {:mvn/version "3.25.5"}
+  com.google.protobuf/protobuf-java           {:mvn/version "3.25.5"} ; specified separately so that Snyk is happy
   com.google.protobuf/protobuf-java-util      {:mvn/version "3.25.5"}}}

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -549,7 +549,7 @@
                 (do
                   (log/trace "BigQuery: New page returned")
                   (recur new-page new-iter acc (inc n)))
-                (throw (ex-info "Cannot get next-page iterator." {:page n}))))
+                (throw (ex-info "Cannot get next page from BigQuery" {:page n}))))
 
             ;; All pages exhausted, so just return.
             :else

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -69,54 +69,6 @@
 (defn- values-iterator ^Iterator [^TableResult page]
   (.iterator (.getValues page)))
 
-(defn- reducible-bigquery-results
-  [^TableResult page cancel-chan]
-  (reify
-    clojure.lang.IReduceInit
-    (reduce [_ rf init]
-      ;; TODO: Once we're confident that the memory/thread leaks in BigQuery are resolved, we can remove some of this
-      ;; logging, and certainly remove the `n` counter.
-      ;; NOTE: Page can be nil in various situations, some are understood (early cancel) and some are not. (#47339)
-      (loop [^TableResult page page
-             it                (some-> page values-iterator)
-             acc               init
-             n                 0]
-        (cond
-          ;; Early exit: If the cancel-chan is provided, close it. This prevents thread leaks in execute-bigquery.
-          (reduced? acc)
-          (do (log/tracef "BigQuery: Early exit from reducer after %d rows" n)
-              (some-> cancel-chan a/close!)
-              (unreduced acc))
-
-          ;; Cancel signaled, just stop.
-          (some-> cancel-chan a/poll!)
-          (do (log/tracef "BigQuery: Aborting due to cancel-chan (%d rows)" n)
-              acc)
-
-          ;; Clear to send: if there's more in `it`, then send it and recur.
-          (some-> it .hasNext)
-          (let [acc' (try
-                       (rf acc (.next it))
-                       (catch Throwable e
-                         (log/errorf e "error in reducible-bigquery-results! %d rows" n)
-                         (some-> cancel-chan a/close!)
-                         (throw e)))]
-            (recur page it acc' (inc n)))
-
-          ;; This page is exhausted - check for another page and keep processing.
-          (some-> page (.hasNextPage))
-          (let [_        (log/tracef "BigQuery: Fetching new page after %d rows" n)
-                _        (*page-callback*)
-                new-page (.getNextPage page)]
-            (log/trace "BigQuery: New page returned")
-            (recur new-page (some-> new-page values-iterator) acc (inc n)))
-
-          ;; All pages exhausted, so just return.
-          ;; Make sure to close the cancel-chan as well, to prevent thread leaks in execute-bigquery.
-          :else (do (log/tracef "BigQuery: All rows consumed (%d) ; closing %s" n cancel-chan)
-                    (some-> cancel-chan a/close!)
-                    acc))))))
-
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                      Sync                                                      |
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -173,7 +125,7 @@
      (.getTable client (TableId/of project-id dataset-id table-id) empty-table-options)
      (.getTable client dataset-id table-id empty-table-options))))
 
-(declare *process-native*)
+(declare ^:dynamic *process-native*)
 
 (defn- information-schema-table [project-id dataset-id table]
   (keyword (format "%s.%s.INFORMATION_SCHEMA.%s" project-id dataset-id table)))
@@ -430,6 +382,8 @@
          (parse-field-value (.get values idx) parser))
        field-idxs parsers))
 
+(declare reducible-bigquery-results)
+
 (defn- sample-table
   "Process a sample of rows of fields corresponding to the Metabase fields
   `fields` from the BigQuery table `bq-table` using the query result reducing
@@ -452,7 +406,7 @@
       ;; metadata from the schema, but that probably makes no
       ;; difference and currently the metadata is ignored anyway.
      (rff {:cols fields})
-     (reducible-bigquery-results page nil))))
+     (reducible-bigquery-results page nil (constantly nil)))))
 
 (defn- ingestion-time-partitioned-table?
   [table-id]
@@ -490,6 +444,33 @@
                   {:type qp.error-type/invalid-query, :sql sql, :parameters parameters}
                   e)))
 
+(defn- throw-cancelled [sql parameters]
+  (throw (ex-info (tru "Query cancelled")
+                  {:sql sql :parameters parameters})))
+
+(defn- handle-bigquery-exception [^Throwable t ^String sql parameters]
+  (condp instance? t
+    java.util.concurrent.CancellationException
+    (throw-cancelled sql parameters)
+
+    BigQueryException
+    (let [bqe ^BigQueryException t]
+      (if (.isRetryable bqe)
+        (throw (ex-info (tru "BigQueryException executing query")
+                        {:retryable? (.isRetryable bqe)
+                         :sql        sql
+                         :parameters parameters}
+                        bqe))
+        (throw-invalid-query bqe sql parameters)))
+
+    Throwable
+    (throw-invalid-query t sql parameters)))
+
+(defn- effective-query-timezone-id [database]
+  (if (get-in database [:details :use-jvm-timezone])
+    (qp.timezone/system-timezone-id)
+    "UTC"))
+
 (defn- build-bigquery-request [^String sql parameters]
   (.build
    (doto (QueryJobConfiguration/newBuilder sql)
@@ -502,102 +483,112 @@
       ;; realizing more rows as per the maximum result size
      (.setMaxResults *page-size*))))
 
-(defn- execute-bigquery-off-thread
-  [^BigQuery client ^QueryJobConfiguration request result-promise]
-  ;; As long as we don't set certain additional QueryJobConfiguration options, our queries *should* always be
-  ;; following the fast query path (i.e. RPC).
-  ;; Check out com.google.cloud.bigquery.QueryRequestInfo.isFastQuerySupported for full details.
-  (future
-    (log/trace "BigQuery exec thread sending query job")
-    (try
-      ;; TODO: If we create a JobId and send it with the other `.query` arity, then we should be able to cancel the
-      ;; BQ job before getting this first response comes back!
-      (let [result (.query client request (u/varargs BigQuery$JobOption))]
-        (log/trace "BigQuery request finished successfully; delivering the result to the promise")
-        (deliver result-promise [:done result])
-        (log/trace "BigQuery thread exiting"))
-      (catch Throwable t
-        (deliver result-promise [:error t])))
-    nil))
+(defn- reducible-bigquery-results
+  [^TableResult page cancel-chan attempt-job-cancel-fn]
+  (reify
+    clojure.lang.IReduceInit
+    (reduce [_ rf init]
+      ;; TODO: Once we're confident that the memory/thread leaks in BigQuery are resolved, we can remove some of this
+      ;; logging, and certainly remove the `n` counter.
+      ;; NOTE: Page can be nil in various situations, some are understood (early cancel) and some are not. (#47339)
+      (try
+        (loop [^TableResult page page
+               it                (some-> page values-iterator)
+               acc               init
+               n                 0]
+          (cond
+            ;; Early exit. This happens in middleware/limit `(take max)`
+            (reduced? acc)
+            (do (log/tracef "BigQuery: Early exit from reducer after %d rows" n)
+                (attempt-job-cancel-fn)
+                (unreduced acc))
 
-(defn- cancel-on-promise [cancel-chan job-atom result-promise]
-  (a/go
-    ;; TODO: When we early exit from a query, should we be cancelling the BigQuery job also?
-    (when-let [cancelled (a/<! cancel-chan)]
-      (deliver result-promise [:cancel cancelled])
-      (some-> @job-atom future-cancel))))
+            ;; While middleware is processing rows, check for browser initiated cancel.
+            (some-> cancel-chan a/poll!)
+            (throw (ex-info (tru "Query cancelled") {:page n}))
 
-(defn- handle-bigquery-exception [^Throwable t ^String sql parameters]
-  (condp instance? t
-    java.util.concurrent.CancellationException
-    (throw (ex-info (tru "Query cancelled")
-                    {:sql sql :parameters parameters ::cancelled? true}))
-    BigQueryException
-    (let [bqe ^BigQueryException t]
-      (if (.isRetryable bqe)
-        (throw (ex-info (tru "BigQueryException executing query")
-                        {:retryable? (.isRetryable bqe)
-                         :sql        sql
-                         :parameters parameters}
-                        bqe))
-        (throw-invalid-query bqe sql parameters)))
-    Throwable
-    (throw-invalid-query t sql parameters)))
+            ;; Clear to send: if there's more in `it`, then send it and recur.
+            (some-> it .hasNext)
+            (let [acc' (try
+                         (rf acc (.next it))
+                         (catch Throwable e
+                           (log/errorf e "error in reducible-bigquery-results! %d rows" n)
+                           (throw e)))]
+              (recur page it acc' (inc n)))
 
-(defn- execute-bigquery
-  ^TableResult [^BigQuery client ^String sql parameters cancel-chan]
-  {:pre [client (not (str/blank? sql))]}
-  ;; Kicking off two async jobs:
-  ;; - Waiting for the cancel-chan to get either a cancel message or to be closed.
-  ;; - Running the BigQuery execution in another thread, since it's blocking.
-  (let [result-promise (promise)
-        exec-future    (execute-bigquery-off-thread client (build-bigquery-request sql parameters) result-promise)
-        ;; Wrap that future in an Atom, so we can replace it with nil after the initial page is fetched.
-        future-atom    (atom exec-future)]
-    (when cancel-chan
-      (cancel-on-promise cancel-chan future-atom result-promise))
-    ;; Now block the original thread on that promise.
-    ;; It will receive either [:done TableResult], [:error Throwable], or [:cancel truthy].
-    (let [[result payload] @result-promise]
-      (reset! future-atom nil)
-      (case result
-        :done   payload
-        :error  (handle-bigquery-exception payload sql parameters)
-        :cancel nil))))
+            ;; This page is exhausted - check for another page and keep processing.
+            (some-> page .hasNextPage)
+            (let [_        (log/tracef "BigQuery: Fetching new page after %d rows" n)
+                  _        (*page-callback*)
+                  new-page (.getNextPage page)]
+              (if-let [new-iter (some-> new-page values-iterator)]
+                (do
+                  (log/trace "BigQuery: New page returned")
+                  (recur new-page new-iter acc (inc n)))
+                (throw (ex-info "Cannot get next-page iterator." {:page n}))))
 
-(mu/defn- execute-bigquery-on-db :- some?
-  ^TableResult
-  [database :- [:map [:details :map]] sql parameters cancel-chan]
-  (execute-bigquery
-   (database-details->client (:details database))
-   sql
-   parameters
-   cancel-chan))
+            ;; All pages exhausted, so just return.
+            :else
+            (do (log/tracef "BigQuery: All rows consumed (%d)" n)
+                acc)))
+        (catch Throwable t
+          (attempt-job-cancel-fn)
+          (throw t))))))
 
-(mu/defn- post-process-native :- some?
-  "Parse results of a BigQuery query. `respond` is the same function passed to
-  `metabase.driver/execute-reducible-query`, and has the signature
-
-    (respond results-metadata rows)"
-  [respond ^TableResult resp cancel-chan]
-  (let [^Schema schema
-        (some-> resp .getSchema)
-
-        parsers
-        (some-> schema get-field-parsers)
-
-        columns
-        (for [column (some-> schema .getFields fields->metabase-field-info)]
-          (-> column
-              (set/rename-keys {:base-type :base_type})
-              (dissoc :database-type :database-position)))
+(defn- bigquery-execute-response
+  "Given the initial query page, respond with metadata and a lazy reducible that will page through the rest of the data."
+  [^TableResult page ^BigQuery client respond cancel-chan]
+  (let [job-id (.getJobId page)
+        attempt-job-cancel-fn #(try
+                                 (.cancel client job-id)
+                                 (catch Throwable e
+                                   ;; Just log exception if it can't be cancelled.
+                                   (log/debugf e "Could not cancel job-id: %s" job-id)))
+        ^Schema schema (some-> page .getSchema)
+        parsers (some-> schema get-field-parsers)
+        columns (for [column (some-> schema .getFields fields->metabase-field-info)]
+                  (-> column
+                      (set/rename-keys {:base-type :base_type})
+                      (dissoc :database-type :database-position)))
         cols {:cols columns}
         results (eduction (map (fn [^FieldValueList row]
                                  (mapv parse-field-value row parsers)))
-                          (reducible-bigquery-results resp cancel-chan))]
-    (respond
-     cols
-     results)))
+                          (reducible-bigquery-results page cancel-chan attempt-job-cancel-fn))]
+    (respond cols results)))
+
+(defn- execute-bigquery
+  [respond database-details ^String sql parameters cancel-chan]
+  {:pre [(not (str/blank? sql))]}
+  ;; Kicking off two async jobs:
+  ;; - Waiting for the cancel-chan to get either a cancel message or to be closed.
+  ;; - Running the BigQuery execution in another thread, since it's blocking.
+  (let [^BigQuery client (database-details->client database-details)
+        result-promise (promise)
+        request (build-bigquery-request sql parameters)
+        query-future (future
+                       (try
+                         (*page-callback*)
+                         (if-let [result (.query client request (u/varargs BigQuery$JobOption))]
+                           (deliver result-promise [:ready result])
+                           (throw (ex-info "Null response from query" {})))
+                         (catch Throwable t
+                           (deliver result-promise [:error t]))))]
+
+    ;; This `go` is responsible for cancelling the *initial* .query call.
+    ;; Future pages may still not be fetched and so the reducer needs to check `cancel-chan` as well.
+    (when cancel-chan
+      (a/go
+        (when-let [cancelled (a/<! cancel-chan)]
+          (deliver result-promise [:cancel cancelled])
+          (some-> query-future future-cancel))))
+
+    ;; Now block the original thread on that promise.
+    ;; It will receive either [:ready [& respond-args]], [:error Throwable], or [:cancel truthy].
+    (let [[status result] @result-promise]
+      (case status
+        :error  (handle-bigquery-exception result sql parameters)
+        :cancel (throw-cancelled sql parameters)
+        :ready  (bigquery-execute-response result client respond cancel-chan)))))
 
 (mu/defn- ^:dynamic *process-native*
   [respond  :- fn?
@@ -609,26 +600,19 @@
   ;; automatically retry the query if it times out or otherwise fails. This is on top of the auto-retry added by
   ;; `execute`
   (let [thunk (fn []
-                (post-process-native respond
-                                     (execute-bigquery-on-db
-                                      database
-                                      sql
-                                      parameters
-                                      cancel-chan)
-                                     cancel-chan))]
+                (execute-bigquery
+                 respond
+                 (:details database)
+                 sql
+                 parameters
+                 cancel-chan))]
     (try
       (thunk)
       (catch Throwable e
         (let [ex-data (u/all-ex-data e)]
-          (if (and (not (::cancelled? ex-data))
-                   (or (:retryable? ex-data) (not (qp.error-type/client-error? (:type ex-data)))))
+          (if (:retryable? ex-data)
             (thunk)
             (throw e)))))))
-
-(defn- effective-query-timezone-id [database]
-  (if (get-in database [:details :use-jvm-timezone])
-    (qp.timezone/system-timezone-id)
-    "UTC"))
 
 (defmethod driver/execute-reducible-query :bigquery-cloud-sdk
   [_driver {{sql :query, :keys [params]} :native, :as outer-query} _context respond]

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -24,7 +24,7 @@
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp])
   (:import
-   (com.google.cloud.bigquery BigQuery TableResult)))
+   (com.google.cloud.bigquery TableResult)))
 
 (set! *warn-on-reflection* true)
 
@@ -803,12 +803,12 @@
     (let [fake-execute-called (atom false)
           orig-fn             @#'bigquery/execute-bigquery]
       (testing "Retry functionality works as expected"
-        (with-redefs [bigquery/execute-bigquery (fn [^BigQuery client ^String sql parameters _]
+        (with-redefs [bigquery/execute-bigquery (fn [& args]
                                                   (if-not @fake-execute-called
                                                     (do (reset! fake-execute-called true)
                                                         ;; simulate a transient error being thrown
                                                         (throw (ex-info "Transient error" {:retryable? true})))
-                                                    (orig-fn client sql parameters nil)))]
+                                                    (apply orig-fn args)))]
           ;; run any other test that requires a successful query execution
           (table-rows-sample-test)
           ;; make sure that the fake exception was thrown, and thus the query execution was retried
@@ -819,13 +819,12 @@
     (let [fake-execute-called (atom false)
           orig-fn        @#'bigquery/execute-bigquery]
       (testing "Should not retry query on cancellation"
-        (with-redefs [bigquery/execute-bigquery (fn [^BigQuery client ^String sql parameters _]
-                                                  ;; We only want to simulate exception on the query that we're testing and not on possible db setup queries
-                                                  (if (and (re-find #"notRetryCancellationExceptionTest" sql) (not @fake-execute-called))
+        (with-redefs [bigquery/execute-bigquery (fn [& args]
+                                                  (if (not @fake-execute-called)
                                                     (do (reset! fake-execute-called true)
                                                         ;; Simulate a cancellation happening
                                                         (throw (ex-info "Query cancelled" {::bigquery/cancelled? true})))
-                                                    (orig-fn client sql parameters nil)))]
+                                                    (apply orig-fn args)))]
           (try
             (qp/process-query {:native {:query "SELECT CURRENT_TIMESTAMP() AS notRetryCancellationExceptionTest"} :database (mt/id)
                                :type     :native})
@@ -889,8 +888,8 @@
                                (if (zero? @page-counter)
                                  nil
                                  (wrap-result (.getNextPage result))))))]
-        (with-redefs [bigquery/execute-bigquery (fn [^BigQuery client ^String sql parameters cancel-chan]
-                                                  (wrap-result (orig-exec client sql parameters cancel-chan)))]
+        (with-redefs [bigquery/execute-bigquery (fn [& args]
+                                                  (wrap-result (apply orig-exec args)))]
           (binding [bigquery/*page-size*     100 ; small pages so there are several
                     bigquery/*page-callback* (fn []
                                                (let [pages (swap! page-counter #(max (dec %) 0))]
@@ -916,8 +915,8 @@
                                (if (zero? @page-counter)
                                  (throw (ex-info "onoes BigQuery failed to fetch a later page" {}))
                                  (wrap-result (.getNextPage result))))))]
-        (with-redefs [bigquery/execute-bigquery (fn [^BigQuery client ^String sql parameters cancel-chan]
-                                                  (wrap-result (orig-exec client sql parameters cancel-chan)))]
+        (with-redefs [bigquery/execute-bigquery (fn [& args]
+                                                  (wrap-result (apply orig-exec args)))]
           (dotimes [_ 10]
             (reset! page-counter 3)
             (binding [bigquery/*page-size*     100 ; small pages so there are several
@@ -1123,3 +1122,27 @@
                  :breakout [[:field %bigthings.bd
                              {:type :type/Decimal
                               :binning {:strategy "default"}}]]})))))))
+
+(deftest bigquery-process-stop-test
+  (mt/test-driver
+    :bigquery-cloud-sdk
+    (sync/sync-database! (mt/db) {:scan :schema})
+    (let [before-names (future-thread-names)]
+      (doseq [:let [callbacks (atom 0)]
+              [stop-tag stopper] [[:exception #(throw (Exception. "My Exception"))]
+                                  [:cancelled #(a/>!! qp.pipeline/*canceled-chan* true)]]
+              [tag callback] [[:initial-query stopper]
+                              [:during-page #(when (>= (swap! callbacks inc) 2)
+                                               (stopper))]]]
+        (testing (format "%s %s" tag stop-tag)
+          (reset! callbacks 0)
+          (binding [bigquery/*page-callback* callback
+                    bigquery/*page-size* 10]
+            (let [query  {:database (mt/id)
+                          :type "native"
+                          :native {:query (format "select * from `%s.orders` limit 100" test-db-name)}}
+                  result (mt/user-http-request :crowberto :post 202 "dataset" query)]
+              (is (= "failed" (:status result)))
+              (is (= (if (= :cancelled stop-tag) "Query cancelled" "My Exception")
+                     (:error result)))))))
+      (is (< (count before-names) (+ (count (future-thread-names)) 5))))))

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -896,9 +896,9 @@
                                                  (log/debugf "*page-callback counting down: %d to go" pages)))]
             (mt/dataset test-data
               (is (thrown-with-msg?
-                    clojure.lang.ExceptionInfo
-                    #"Cannot get next page from BigQuery"
-                    (mt/process-query (mt/query orders)))))))))))
+                   clojure.lang.ExceptionInfo
+                   #"Cannot get next page from BigQuery"
+                   (mt/process-query (mt/query orders)))))))))))
 
 (deftest later-page-fetch-throws-test
   (mt/test-driver :bigquery-cloud-sdk
@@ -942,10 +942,10 @@
                     bigquery/*page-callback* (fn [] (a/put! canceled-chan true))]
             (mt/dataset test-data
               (is (thrown-with-msg?
-                    Exception
-                    #"Query cancelled"
-                    (-> (mt/query orders {:query {:limit max-rows}})
-                        mt/process-query))))))))))
+                   Exception
+                   #"Query cancelled"
+                   (-> (mt/query orders {:query {:limit max-rows}})
+                       mt/process-query))))))))))
 
 (defn- synced-tables [db-attributes]
   (t2.with-temp/with-temp [Database db db-attributes]

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -878,7 +878,7 @@
   (mt/test-driver :bigquery-cloud-sdk
     (testing "BigQuery queries which fail on later pages are caught properly"
       (let [page-counter (atom 3)
-            orig-exec    @#'bigquery/execute-bigquery
+            orig-exec    @#'bigquery/reducible-bigquery-results
             wrap-result  (fn wrap-result [^TableResult result]
                            (proxy [TableResult] []
                              (getSchema [] (.getSchema result))
@@ -888,24 +888,24 @@
                                (if (zero? @page-counter)
                                  nil
                                  (wrap-result (.getNextPage result))))))]
-        (with-redefs [bigquery/execute-bigquery (fn [& args]
-                                                  (wrap-result (apply orig-exec args)))]
-          (binding [bigquery/*page-size*     100 ; small pages so there are several
+        (with-redefs [bigquery/reducible-bigquery-results (fn [page & args]
+                                                            (apply orig-exec (wrap-result page) args))]
+          (binding [bigquery/*page-size*     10 ; small pages so there are several
                     bigquery/*page-callback* (fn []
                                                (let [pages (swap! page-counter #(max (dec %) 0))]
                                                  (log/debugf "*page-callback counting down: %d to go" pages)))]
             (mt/dataset test-data
-                        ;; *page-size* is inexact - should be 300 but give it a wide margin.
-              (is (< 10
-                     (count (mt/rows (mt/process-query (mt/query orders))))
-                     500)))))))))
+              (is (thrown-with-msg?
+                    clojure.lang.ExceptionInfo
+                    #"Cannot get next page from BigQuery"
+                    (mt/process-query (mt/query orders)))))))))))
 
 (deftest later-page-fetch-throws-test
   (mt/test-driver :bigquery-cloud-sdk
     (testing "BigQuery queries which fail on later pages are caught properly"
       (let [count-before (count (future-thread-names))
             page-counter (atom 3)
-            orig-exec    @#'bigquery/execute-bigquery
+            orig-exec    @#'bigquery/reducible-bigquery-results
             wrap-result  (fn wrap-result [^TableResult result]
                            (proxy [TableResult] []
                              (getSchema [] (.getSchema result))
@@ -915,8 +915,8 @@
                                (if (zero? @page-counter)
                                  (throw (ex-info "onoes BigQuery failed to fetch a later page" {}))
                                  (wrap-result (.getNextPage result))))))]
-        (with-redefs [bigquery/execute-bigquery (fn [& args]
-                                                  (wrap-result (apply orig-exec args)))]
+        (with-redefs [bigquery/reducible-bigquery-results (fn [page & args]
+                                                            (apply orig-exec (wrap-result page) args))]
           (dotimes [_ 10]
             (reset! page-counter 3)
             (binding [bigquery/*page-size*     100 ; small pages so there are several
@@ -941,13 +941,11 @@
                     bigquery/*page-size*     page-size
                     bigquery/*page-callback* (fn [] (a/put! canceled-chan true))]
             (mt/dataset test-data
-              ;; Page size does not guarantee the size of the response but orders table is ~20k rows.
-              (is (< 0
-                     (-> (mt/query orders {:query {:limit max-rows}})
-                         mt/process-query
-                         mt/rows
-                         count)
-                     1000)))))))))
+              (is (thrown-with-msg?
+                    Exception
+                    #"Query cancelled"
+                    (-> (mt/query orders {:query {:limit max-rows}})
+                        mt/process-query))))))))))
 
 (defn- synced-tables [db-attributes]
   (t2.with-temp/with-temp [Database db db-attributes]

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
@@ -7,7 +7,6 @@
    [metabase.driver.bigquery-cloud-sdk :as bigquery]
    [metabase.driver.ddl.interface :as ddl.i]
    [metabase.lib.schema.common :as lib.schema.common]
-   [metabase.test.data :as data]
    [metabase.test.data.interface :as tx]
    [metabase.test.data.sql :as sql.tx]
    [metabase.util :as u]
@@ -19,7 +18,7 @@
    (com.google.cloud.bigquery BigQuery BigQuery$DatasetDeleteOption BigQuery$DatasetListOption BigQuery$DatasetOption
                               BigQuery$TableListOption BigQuery$TableOption Dataset DatasetId DatasetInfo Field Field$Mode
                               InsertAllRequest InsertAllRequest$RowToInsert InsertAllResponse LegacySQLTypeName Schema
-                              StandardTableDefinition TableId TableInfo TableResult)))
+                              StandardTableDefinition TableId TableInfo)))
 
 (set! *warn-on-reflection* true)
 
@@ -70,6 +69,9 @@
   ^BigQuery []
   (#'bigquery/database-details->client (test-db-details)))
 
+(defn execute-respond [_ rows]
+  (into [] rows))
+
 (defn project-id
   "BigQuery project ID that we're using for tests, either from the env var `MB_BIGQUERY_TEST_PROJECT_ID`, or if that is
   not set, from the BigQuery client instance itself (which ultimately comes from the value embedded in the service
@@ -106,12 +108,12 @@
 (defn execute!
   "Execute arbitrary (presumably DDL) SQL statements against the test project. Waits for statement to complete, throwing
   an Exception if it fails."
-  ^TableResult [format-string & args]
+  [format-string & args]
   (driver/with-driver :bigquery-cloud-sdk
     (let [sql (apply format format-string args)]
       (log/infof "[BigQuery] %s\n" sql)
       (flush)
-      (#'bigquery/execute-bigquery-on-db (data/db) sql nil nil))))
+      (#'bigquery/execute-bigquery execute-respond (test-db-details) sql [] nil))))
 
 (mu/defn- delete-table!
   [dataset-id :- ::lib.schema.common/non-blank-string
@@ -178,12 +180,8 @@
   (log/info (u/format-color 'blue "Created BigQuery table `%s.%s.%s`." (project-id) dataset-id table-id)))
 
 (defn- table-row-count ^Integer [^String dataset-id, ^String table-id]
-  (let [sql                           (format "SELECT count(*) FROM `%s.%s.%s`" (project-id) dataset-id table-id)
-        respond                       (fn [_ rows]
-                                        (ffirst (into [] rows)))
-        client                        (bigquery)
-        ^TableResult query-response   (#'bigquery/execute-bigquery client sql [] nil)]
-    (#'bigquery/post-process-native respond query-response #_cancel-chan nil)))
+  (let [sql (format "SELECT count(*) FROM `%s.%s.%s`" (project-id) dataset-id table-id)]
+    (ffirst (#'bigquery/execute-bigquery execute-respond (test-db-details) sql [] nil))))
 
 (defprotocol ^:private Insertable
   (^:private ->insertable [this]


### PR DESCRIPTION
Fixes #47990

Inline some function calls to make it easier to track what's happening.

Make sure that cancellation during the initial query and subsequent page fetches are handled properly. Explicitly throw when cancelled.

Only retry queries if bigquery says they are retryable.

Try to cancel the BigQuery job if an exception or cancellation occurs.
