### PR TITLE
Sync DBs in a future when initializing MB from config file

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file/databases.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file/databases.clj
@@ -10,7 +10,7 @@
    [toucan2.core :as t2]))
 
 (defsetting config-from-file-sync-databases
-  "Whether to sync newly created Databases during config-from-file initialization. By default, true, but you can disable
+  "Whether to (asynchronously) sync newly created Databases during config-from-file initialization. By default, true, but you can disable
   this behavior if you want to sync it manually or use SerDes to populate its data model."
   :visibility :internal
   :type       :boolean
@@ -60,7 +60,8 @@
           (log/info (u/format-color :green "Creating new %s Database %s" (:engine database) (pr-str (:name database))))
           (let [db (first (t2/insert-returning-instances! Database database))]
             (if (config-from-file-sync-databases)
-              ((requiring-resolve 'metabase.sync/sync-database!) db)
+              (future
+               ((requiring-resolve 'metabase.sync/sync-database!) db))
               (log/info "Sync on database creation when initializing from file is disabled. Skipping sync."))))))))
 
 (defmethod advanced-config.file.i/initialize-section! :databases

--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file/databases.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file/databases.clj
@@ -61,7 +61,7 @@
           (let [db (first (t2/insert-returning-instances! Database database))]
             (if (config-from-file-sync-databases)
               (future
-               ((requiring-resolve 'metabase.sync/sync-database!) db))
+                ((requiring-resolve 'metabase.sync/sync-database!) db))
               (log/info "Sync on database creation when initializing from file is disabled. Skipping sync."))))))))
 
 (defmethod advanced-config.file.i/initialize-section! :databases

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/file/databases_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/file/databases_test.clj
@@ -42,10 +42,7 @@
                 (is (= 1
                        (t2/count :model/Database :name test-db-name)))
                 (is (partial= {:engine db-type}
-                              (t2/select-one :model/Database :name test-db-name))))
-              (testing "Database should have been synced"
-                (is (= (t2/count :model/Table :db_id (u/the-id original-db))
-                       (t2/count :model/Table :db_id (u/the-id db))))))))
+                              (t2/select-one :model/Database :name test-db-name)))))))
         (finally
           (t2/delete! :model/Database :name test-db-name))))))
 


### PR DESCRIPTION
Resolves #46548

* Syncs DBs off-thread using a future when starting up Metabase with databases defined in a config file
* Updates some t2 model references to be keywords

Open question: should we provide a way to opt-in to the previous blocking behavior? Most likely nobody is relying on it but who knows.