### PR TITLE
fix uncentered pie chart

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
@@ -41,6 +41,17 @@ describe("scenarios > visualizations > pie chart", () => {
 
     ensurePieChartRendered(["Doohickey", "Gadget", "Gizmo", "Widget"], 200);
 
+    // chart should be centered (#48123)
+    cy.findByTestId("chart-legend").then(([legend]) => {
+      const legendWidth = legend.getBoundingClientRect().width;
+
+      cy.findByTestId("chart-legend-spacer").then(([spacer]) => {
+        const spacerWidth = spacer.getBoundingClientRect().width;
+
+        expect(legendWidth).to.be.equal(spacerWidth);
+      });
+    });
+
     cy.log("#35244");
     cy.findByLabelText("Switch to data").click();
     tableHeaderClick("Count");

--- a/frontend/src/metabase/visualizations/components/ChartWithLegend.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartWithLegend.jsx
@@ -146,6 +146,7 @@ class ChartWithLegend extends Component {
             className={cx(styles.LegendSpacer)}
             // don't center the chart on dashboards
             style={isDashboard ? { flexBasis: 0 } : {}}
+            data-testid="chart-legend-spacer"
           >
             {legend}
           </div>

--- a/frontend/src/metabase/visualizations/components/ChartWithLegend.module.css
+++ b/frontend/src/metabase/visualizations/components/ChartWithLegend.module.css
@@ -13,8 +13,11 @@
 
 .ChartWithLegend .LegendSpacer,
 .ChartWithLegend .LegendWrapper {
+  display: flex;
+  justify-content: center;
   flex-basis: auto;
   flex-grow: 1;
+  flex-shrink: 1;
 
   /* allow legend and spacer to shrink */
   min-width: 0;
@@ -23,13 +26,6 @@
 
 .ChartWithLegend .LegendSpacer {
   visibility: hidden;
-  flex-shrink: 10; /* shrink the spacer much faster than the wrapper */
-}
-
-.ChartWithLegend .LegendWrapper {
-  display: flex;
-  justify-content: center;
-  flex-shrink: 1;
 }
 
 .ChartWithLegend .Chart {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/48123

### Description

Fixes the pie chart being uncentered by applying the same css to the legend and legend spacer elements in `ChartWithLegend.jsx`.

### How to verify

1. Create a pie chart (e.g. count orders by product category)
2. Chart should seem centered (can compare flanking element sizes using browser inspect)

### Demo


https://github.com/user-attachments/assets/3b16e2dd-918f-4cad-887e-d31fdc4269ed

Both flanking elements have same width

https://github.com/user-attachments/assets/38cff7ea-abb8-47fb-9ac5-e1a6f06f9f7e

Stays centered when resizing in query builder

https://github.com/user-attachments/assets/e77a75cd-af63-4187-ab18-dfef3c4ae80c

As well as in a dashcard

https://github.com/user-attachments/assets/2a6aa22e-d916-4b38-aacc-ce85ed4fdd9b

Choropleth map, which also uses `ChartWithLegend`, is also centered

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
