### PR TITLE
Fix search test flake

### DIFF
--- a/src/metabase/search/postgres/ingestion.clj
+++ b/src/metabase/search/postgres/ingestion.clj
@@ -50,8 +50,7 @@
        :models             (disj search.config/all-models "indexed-entity")
        ;; we want to see everything
        :is-superuser?      true
-       ;; irrelevant, as we're acting as a super user
-       :current-user-id    1
+       :current-user-id    (t2/select-one-pk :model/User :is_superuser true)
        :current-user-perms #{"/"}
        ;; include both achived and non-archived items.
        :archived?          nil
@@ -65,7 +64,6 @@
   "Go over all searchable items and populate the index with them."
   []
   (->> (search-items-reducible)
-        ;; TODO realize and insert in batches
        (eduction
         (comp
          (map t2.realize/realize)

--- a/test/metabase/analytics/stats_test.clj
+++ b/test/metabase/analytics/stats_test.clj
@@ -4,7 +4,6 @@
    [clojure.test :refer :all]
    [java-time.api :as t]
    [metabase.analytics.stats :as stats :refer [legacy-anonymous-usage-stats]]
-   [metabase.config :as config]
    [metabase.core :as mbc]
    [metabase.db :as mdb]
    [metabase.email :as email]

--- a/test/metabase/analytics/stats_test.clj
+++ b/test/metabase/analytics/stats_test.clj
@@ -4,6 +4,7 @@
    [clojure.test :refer :all]
    [java-time.api :as t]
    [metabase.analytics.stats :as stats :refer [legacy-anonymous-usage-stats]]
+   [metabase.config :as config]
    [metabase.core :as mbc]
    [metabase.db :as mdb]
    [metabase.email :as email]
@@ -226,25 +227,26 @@
         "the new version of the executions metrics works the same way the old one did")))
 
 (deftest execution-metrics-started-at-test
-  (testing "execution metrics should not be sensitive to the app db time zone"
+  (testing "execution metrics should not be sensitive to the app db time zone\n"
     (doseq [tz ["Pacific/Auckland" "Europe/Helsinki"]]
-      (mt/with-app-db-timezone-id! tz
-        (let [get-executions #(:executions (#'stats/execution-metrics))
-              before         (get-executions)]
-          (mt/with-temp [QueryExecution _ (merge query-execution-defaults
-                                                 {:started_at (-> (t/offset-date-time (t/zone-id "UTC"))
-                                                                  (t/minus (t/days 30))
-                                                                  (t/plus (t/minutes 10)))})]
-            (is (= (inc before)
-                   (get-executions))
-                "execution metrics include query executions since 30 days ago"))
-          (mt/with-temp [QueryExecution _ (merge query-execution-defaults
-                                                 {:started_at (-> (t/offset-date-time (t/zone-id "UTC"))
-                                                                  (t/minus (t/days 30))
-                                                                  (t/minus (t/minutes 10)))})]
-            (is (= before
-                   (get-executions))
-                "the executions metrics exclude query executions before 30 days ago")))))))
+      (testing tz
+        (mt/with-app-db-timezone-id! tz
+          (let [get-executions #(:executions (#'stats/execution-metrics))
+                before         (get-executions)]
+            (mt/with-temp [QueryExecution _ (merge query-execution-defaults
+                                                   {:started_at (-> (t/offset-date-time (t/zone-id "UTC"))
+                                                                    (t/minus (t/days 30))
+                                                                    (t/plus (t/minutes 10)))})]
+              (is (= (inc before)
+                     (get-executions))
+                  "execution metrics include query executions since 30 days ago"))
+            (mt/with-temp [QueryExecution _ (merge query-execution-defaults
+                                                   {:started_at (-> (t/offset-date-time (t/zone-id "UTC"))
+                                                                    (t/minus (t/days 30))
+                                                                    (t/minus (t/minutes 10)))})]
+              (is (= before
+                     (get-executions))
+                  "the executions metrics exclude query executions before 30 days ago"))))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                Pulses & Alerts                                                 |

--- a/test/metabase/search/postgres/core_test.clj
+++ b/test/metabase/search/postgres/core_test.clj
@@ -60,21 +60,23 @@
     (testing "consistent results with minimal implementations\n"
       (doseq [term example-terms]
         (testing term
-          (is (= (hybrid term)
-                 (#'search.postgres/minimal term))))))))
+          ;; there is no ranking, so order is non-deterministic
+          (is (= (set (hybrid term))
+                 (set (#'search.postgres/minimal term)))))))))
 
 (deftest minimal-with-perms-test
   (with-setup
     (testing "consistent results with minimal implementations\n"
       (doseq [term (take 1 example-terms)]
         (testing term
-          (is (= (hybrid term)
-                 (#'search.postgres/minimal-with-perms
-                  term
-                  {:current-user-id    (mt/user->id :crowberto)
-                   :is-superuser?      true
-                   :archived?          false
-                   :current-user-perms #{"/"}
-                   :model-ancestors?   false
-                   :models             search/all-models
-                   :search-string      term}))))))))
+          ;; there is no ranking, so order is non-deterministic
+          (is (= (set (hybrid term))
+                 (set (#'search.postgres/minimal-with-perms
+                       term
+                       {:current-user-id    (mt/user->id :crowberto)
+                        :is-superuser?      true
+                        :archived?          false
+                        :current-user-perms #{"/"}
+                        :model-ancestors?   false
+                        :models             search/all-models
+                        :search-string      term})))))))))


### PR DESCRIPTION
The order is non-deterministic now, since we disabled ranking for the `minimal*` engines.