### PR TITLE
fix(sdk): decrease specificity of css reset in embedding sdk

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentStylesWrapper.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentStylesWrapper.tsx
@@ -1,3 +1,4 @@
+import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 
 import { aceEditorStyles } from "metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.styled";
@@ -12,18 +13,6 @@ export const PublicComponentStylesWrapper = styled.div`
   // Try to reset as much as possible to avoid css leaking from host app to our components
   all: initial;
   text-decoration: none;
-
-  // # Basic css reset
-  // We can't apply a global css reset as it would leak into the host app
-  // but we can't also apply our entire css reset scoped to this container,
-  // as it would be of higher specificity than some of our styles.
-  // We'll have to hand pick the css resets that we neeed
-
-  button {
-    border: 0;
-    background-color: transparent;
-  }
-  // end of RESET
 
   font-style: normal;
 
@@ -46,5 +35,21 @@ export const PublicComponentStylesWrapper = styled.div`
 
   :where(svg) {
     display: inline;
+  }
+`;
+/**
+ * We can't apply a global css reset as it would leak into the host app but we
+ * can't also apply our entire css reset scoped to this container, as it would
+ * be of higher specificity than some of our styles.
+ *
+ * The reason why this works is two things combined:
+ * - `*:where(button)` doesn't increase specificity, so the resulting specificity is (0,1,0)
+ * - this global css is loaded in the provider, before our other styles
+ * - -> our other code with specificity (0,1,0) will override this as they're loaded after
+ */
+export const SCOPED_CSS_RESET = css`
+  ${PublicComponentStylesWrapper} *:where(button) {
+    border: 0;
+    background-color: transparent;
   }
 `;

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabaseProvider.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabaseProvider.tsx
@@ -1,3 +1,4 @@
+import { Global } from "@emotion/react";
 import type { Action, Store } from "@reduxjs/toolkit";
 import { type JSX, type ReactNode, memo, useEffect } from "react";
 import { Provider } from "react-redux";
@@ -24,10 +25,14 @@ import type { MetabaseTheme } from "embedding-sdk/types/theme";
 import { setOptions } from "metabase/redux/embed";
 import { EmotionCacheProvider } from "metabase/styled-components/components/EmotionCacheProvider";
 
-import { PublicComponentStylesWrapper } from "../private/PublicComponentStylesWrapper";
+import {
+  PublicComponentStylesWrapper,
+  SCOPED_CSS_RESET,
+} from "../private/PublicComponentStylesWrapper";
 import { SdkFontsGlobalStyles } from "../private/SdkGlobalFontsStyles";
 import "metabase/css/index.module.css";
 import { SdkUsageProblemDisplay } from "../private/SdkUsageProblem";
+
 import "metabase/css/vendor.css";
 
 export interface MetabaseProviderProps {
@@ -83,6 +88,7 @@ export const MetabaseProviderInternal = ({
 
   return (
     <EmotionCacheProvider>
+      <Global styles={SCOPED_CSS_RESET} />
       <SdkThemeProvider theme={theme}>
         <SdkFontsGlobalStyles baseUrl={config.metabaseInstanceUrl} />
         <div className={className} id={EMBEDDING_SDK_ROOT_ELEMENT_ID}>


### PR DESCRIPTION
### Description

Context: in [first iteration to scope sdk styles to our components (+161 −198)](https://github.com/metabase/metabase/pull/47764) I added a "scoped" css reset to fix a bunch of issue, it created another issue though, as the scoped css reset was overriding some of our code.
Let's take the button reset, its selector was `.{emotion-class} button` which had [specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity) `(0,1,1)`.

Most of our styles have specificity `(0,1,0)` though, which means that the reset will win over it and that's why some buttons didn't have background-color even if it was set.

This PR addresses the issue hopefully for good.
There reason why it works is in a comment in the code, if that explanation is not good enough please tell me so we can update it



Issues that *should* be fixed with this, or are already fixed but this should make it official, please verify it when reviewing it 🙏 

Closes https://github.com/metabase/metabase/issues/47344
Closes https://github.com/metabase/metabase/issues/47561


Note: this has no tests because it's not currently easy to test for visual changes, today or tomorrow I'll share with the team a small document where I'll propose something about it