### PR TITLE
Upload test fixes for drivers without auto mb-id

### DIFF
--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -1356,8 +1356,8 @@
     (let [table (sync-upload-test-table! :database (mt/db) :table-name table-name :schema-name schema-name)]
       ;; ensure we have the same display name for the auto-pk-column that a real upload would have
       (t2/update! :model/Field
-                    {:table_id (:id table), :name upload/auto-pk-column-name}
-                    {:display_name upload/auto-pk-column-name})
+                  {:table_id (:id table), :name upload/auto-pk-column-name}
+                  {:display_name upload/auto-pk-column-name})
       table)))
 
 (defn catch-ex-info* [f]

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -2310,7 +2310,6 @@
               (is (= {:row-count 1}
                      (update-csv! ::upload/append {:file file, :table-id (:id table)})))
               (testing "Check the data was appended into the table"
-                ;; TODO: clickhouse needs to worry about the wrong order
                 (is (= (set
                         (rows-with-auto-pk
                          (concat


### PR DESCRIPTION
### Description

Since all the built-in drivers supporting uploads also support auto-incrementing IDs, we weren't exercising both test paths correctly every time.

These changes came as part of getting the Clickhouse driver (partially) running on our test suite.