### PR TITLE
[Notification] Send asynchronously

### DIFF
--- a/src/metabase/notification/core.clj
+++ b/src/metabase/notification/core.clj
@@ -5,7 +5,10 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
-   [toucan2.core :as t2]))
+   [toucan2.core :as t2])
+  (:import
+   (java.util.concurrent Callable Executors ExecutorService)
+   (org.apache.commons.lang3.concurrent BasicThreadFactory$Builder)))
 
 (set! *warn-on-reflection* true)
 
@@ -37,8 +40,15 @@
               :template
               :recipients))
 
-(mu/defn send-notification!
-  "Send the notification to all handlers synchronously."
+(defonce ^:private pool
+  (Executors/newFixedThreadPool
+   10 ;; TODO: this should be configurable
+   (.build
+    (doto (BasicThreadFactory$Builder.)
+      (.namingPattern "send-notification-thread-pool-%d")))))
+
+(mu/defn- send-notification-sync!
+  "Send the notification to all handlers synchronously. Do not use this directly, use *send-notification!* instead."
   [notification-info :- NotificationInfo]
   (let [noti-handlers (hydrate-notification-handler (t2/select :model/NotificationHandler :notification_id (:id notification-info)))]
     (log/infof "[Notification %d] Found %d handlers" (:id notification-info) (count noti-handlers))
@@ -52,4 +62,17 @@
         (log/infof "[Notification %d] Got %d messages for channel %s" (:id notification-info) (count messages) (:channel_type handler))
         (doseq [message messages]
           (channel/send! (or (:channel handler)
-                             {:type channel-type}) message))))))
+                             {:type channel-type}) message)))))
+  nil)
+
+(defn- send-notification-async!
+  "Send a notification asynchronously."
+  [notification]
+  (let [task (bound-fn []
+               (send-notification-sync! notification))]
+    (.submit ^ExecutorService pool ^Callable task))
+  nil)
+
+(def ^:dynamic send-notification!
+  "The function to send a notification. Defaults to `send-notification-async!`."
+  send-notification-async!)

--- a/test/metabase/notification/system_event_test.clj
+++ b/test/metabase/notification/system_event_test.clj
@@ -3,78 +3,81 @@
    [clojure.test :refer :all]
    [metabase.events :as events]
    [metabase.models.notification :as models.notification]
+   [metabase.notification.core :as notification]
    [metabase.test :as mt]))
 
 (deftest system-event-e2e-test
   (testing "a system event that sends to an email channel with a custom template to an user recipient"
     (mt/with-model-cleanup [:model/Notification]
-      (mt/with-temp [:model/ChannelTemplate tmpl {:channel_type :channel/email
-                                                  :details      {:type    :email/mustache
-                                                                 :subject "Welcome {{event-info.object.first_name}} to {{settings.site-name}}"
-                                                                 :body    "Hello {{event-info.object.first_name}}! Welcome to {{settings.site-name}}!"}}
-                     :model/User             {user-id :id} {:email "ngoc@metabase.com"}
-                     :model/PermissionsGroup {group-id :id} {:name "Avengers"}
-                     :model/PermissionsGroupMembership _ {:group_id group-id
-                                                          :user_id user-id}]
-        (let [rasta (mt/fetch-user :rasta)]
-          (models.notification/create-notification!
-           {:payload_type :notification/system-event}
-           [{:type       :notification-subscription/system-event
-             :event_name :event/user-invited}]
-           [{:channel_type :channel/email
-             :template_id  (:id tmpl)
-             :recipients   [{:type    :notification-recipient/user
-                             :user_id (mt/user->id :crowberto)}
-                            {:type                 :notification-recipient/group
-                             :permissions_group_id group-id}
-                            {:type    :notification-recipient/external-email
-                             :details {:email "hi@metabase.com"}}]}])
-          (mt/with-temporary-setting-values
-            [site-name "Metabase Test"]
-            (mt/with-fake-inbox
-              (events/publish-event! :event/user-invited {:object rasta})
-              (let [email {:from    "notifications@metabase.com",
-                           :subject "Welcome Rasta to Metabase Test"
-                           :body    [{:type    "text/html; charset=utf-8"
-                                      :content "Hello Rasta! Welcome to Metabase Test!"}]}]
-                (is (=? {"crowberto@metabase.com" [email]
-                         "ngoc@metabase.com"      [email]
-                         "hi@metabase.com"        [email]}
-                        @mt/inbox))))))))))
+      (binding [notification/send-notification! #'notification/send-notification-sync!]
+        (mt/with-temp [:model/ChannelTemplate tmpl {:channel_type :channel/email
+                                                    :details      {:type    :email/mustache
+                                                                   :subject "Welcome {{event-info.object.first_name}} to {{settings.site-name}}"
+                                                                   :body    "Hello {{event-info.object.first_name}}! Welcome to {{settings.site-name}}!"}}
+                       :model/User             {user-id :id} {:email "ngoc@metabase.com"}
+                       :model/PermissionsGroup {group-id :id} {:name "Avengers"}
+                       :model/PermissionsGroupMembership _ {:group_id group-id
+                                                            :user_id user-id}]
+          (let [rasta (mt/fetch-user :rasta)]
+            (models.notification/create-notification!
+             {:payload_type :notification/system-event}
+             [{:type       :notification-subscription/system-event
+               :event_name :event/user-invited}]
+             [{:channel_type :channel/email
+               :template_id  (:id tmpl)
+               :recipients   [{:type    :notification-recipient/user
+                               :user_id (mt/user->id :crowberto)}
+                              {:type                 :notification-recipient/group
+                               :permissions_group_id group-id}
+                              {:type    :notification-recipient/external-email
+                               :details {:email "hi@metabase.com"}}]}])
+            (mt/with-temporary-setting-values
+              [site-name "Metabase Test"]
+              (mt/with-fake-inbox
+                (events/publish-event! :event/user-invited {:object rasta})
+                (let [email {:from    "notifications@metabase.com",
+                             :subject "Welcome Rasta to Metabase Test"
+                             :body    [{:type    "text/html; charset=utf-8"
+                                        :content "Hello Rasta! Welcome to Metabase Test!"}]}]
+                  (is (=? {"crowberto@metabase.com" [email]
+                           "ngoc@metabase.com"      [email]
+                           "hi@metabase.com"        [email]}
+                          @mt/inbox)))))))))))
 
 (deftest system-event-resouce-template-test
   (testing "a system event that sends to an email channel with a custom template to an user recipient"
     (mt/with-model-cleanup [:model/Notification]
-      (mt/with-temp [:model/ChannelTemplate tmpl {:channel_type :channel/email
-                                                  :details      {:type    :email/resource
-                                                                 :subject "Welcome {{event-info.object.first_name}} to {{settings.site-name}}"
-                                                                 :path    "notification/channel_template/hello_world"}}
-                     :model/User             {user-id :id} {:email "ngoc@metabase.com"}
-                     :model/PermissionsGroup {group-id :id} {:name "Avengers"}
-                     :model/PermissionsGroupMembership _ {:group_id group-id
-                                                          :user_id user-id}]
-        (let [rasta (mt/fetch-user :rasta)]
-          (models.notification/create-notification!
-           {:payload_type :notification/system-event}
-           [{:type       :notification-subscription/system-event
-             :event_name :event/user-invited}]
-           [{:channel_type :channel/email
-             :template_id  (:id tmpl)
-             :recipients   [{:type    :notification-recipient/user
-                             :user_id (mt/user->id :crowberto)}
-                            {:type                 :notification-recipient/group
-                             :permissions_group_id group-id}
-                            {:type    :notification-recipient/external-email
-                             :details {:email "hi@metabase.com"}}]}])
-          (mt/with-temporary-setting-values
-            [site-name "Metabase Test"]
-            (mt/with-fake-inbox
-              (events/publish-event! :event/user-invited {:object rasta})
-              (let [email {:from    "notifications@metabase.com",
-                           :subject "Welcome Rasta to Metabase Test"
-                           :body    [{:type    "text/html; charset=utf-8"
-                                      :content "Hello Rasta! Welcome to Metabase Test!\n"}]}]
-                (is (=? {"crowberto@metabase.com" [email]
-                         "ngoc@metabase.com"      [email]
-                         "hi@metabase.com"        [email]}
-                        @mt/inbox))))))))))
+      (binding [notification/send-notification! #'notification/send-notification-sync!]
+        (mt/with-temp [:model/ChannelTemplate tmpl {:channel_type :channel/email
+                                                    :details      {:type    :email/resource
+                                                                   :subject "Welcome {{event-info.object.first_name}} to {{settings.site-name}}"
+                                                                   :path    "notification/channel_template/hello_world"}}
+                       :model/User             {user-id :id} {:email "ngoc@metabase.com"}
+                       :model/PermissionsGroup {group-id :id} {:name "Avengers"}
+                       :model/PermissionsGroupMembership _ {:group_id group-id
+                                                            :user_id user-id}]
+          (let [rasta (mt/fetch-user :rasta)]
+            (models.notification/create-notification!
+             {:payload_type :notification/system-event}
+             [{:type       :notification-subscription/system-event
+               :event_name :event/user-invited}]
+             [{:channel_type :channel/email
+               :template_id  (:id tmpl)
+               :recipients   [{:type    :notification-recipient/user
+                               :user_id (mt/user->id :crowberto)}
+                              {:type                 :notification-recipient/group
+                               :permissions_group_id group-id}
+                              {:type    :notification-recipient/external-email
+                               :details {:email "hi@metabase.com"}}]}])
+            (mt/with-temporary-setting-values
+              [site-name "Metabase Test"]
+              (mt/with-fake-inbox
+                (events/publish-event! :event/user-invited {:object rasta})
+                (let [email {:from    "notifications@metabase.com",
+                             :subject "Welcome Rasta to Metabase Test"
+                             :body    [{:type    "text/html; charset=utf-8"
+                                        :content "Hello Rasta! Welcome to Metabase Test!\n"}]}]
+                  (is (=? {"crowberto@metabase.com" [email]
+                           "ngoc@metabase.com"      [email]
+                           "hi@metabase.com"        [email]}
+                          @mt/inbox)))))))))))


### PR DESCRIPTION
Our event system is synchronous, and we dont' want sending notifications that subscribed to an event to block the execution of the main thread. This PR creates a pooled executor to send noti asynchronously

Epic: https://github.com/metabase/metabase/issues/47438