### PR TITLE
Fix timezone comparisons in failing execution stats test

### DIFF
--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -354,6 +354,10 @@
 ;;; Execution Metrics
 
 (defn- execution-metrics-sql []
+  ;; Postgres automatically adjusts for daylight saving time when performing time calculations on TIMESTAMP WITH TIME
+  ;; ZONE. This can cause discrepancies when subtracting 30 days if the calculation crosses a DST boundary (e.g., in the
+  ;; Pacific/Auckland timezone). To avoid this, we ensure all date computations are done in UTC on Postgres to prevent
+  ;; any time shifts due to DST. See PR #48204
   (let [thirty-days-ago (case (db/db-type)
                           :postgres "CURRENT_TIMESTAMP AT TIME ZONE 'UTC' - INTERVAL '30 days'"
                           :h2       "DATEADD('DAY', -30, CURRENT_TIMESTAMP)"

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -356,11 +356,12 @@
 (defn- execution-metrics-sql []
   (let [thirty-days-ago (case (db/db-type)
                           :postgres "CURRENT_TIMESTAMP AT TIME ZONE 'UTC' - INTERVAL '30 days'"
-                          :h2       "DATEADD('DAY', -30, CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"
-                          :mysql    "UTC_TIMESTAMP() - INTERVAL 30 DAY")
+                          :h2       "DATEADD('DAY', -30, CURRENT_TIMESTAMP)"
+                          :mysql    "CURRENT_TIMESTAMP - INTERVAL 30 DAY")
         started-at      (case (db/db-type)
-                          (:postgres :h2) "started_at AT TIME ZONE 'UTC'"
-                          :mysql          "CONVERT_TZ(started_at, @@session.time_zone, '+00.00'")
+                          :postgres "started_at AT TIME ZONE 'UTC'"
+                          :h2       "started_at"
+                          :mysql    "started_at")
         timestamp-where (str started-at " > " thirty-days-ago)]
     (str/join
      "\n"


### PR DESCRIPTION
`execution-metrics-started-at-test` started failing on Postgres after New Zealand transitioned to Daylight Saving Time yesterday (Sep 29).

The reason for this, as far as I can tell, is that Postgres automatically adjusts for DST when performing time calculations on `TIMESTAMP WITH TIME ZONE`. This means that subtracting 30 days from a timestamp in the `Pacific/Auckland` timezone will account for the DST change, and result in a timestamp an hour off from the equivalent UTC time.

I've fixed this by ensuring we do these computations explicitly on UTC timestamps in the `execution-metrics-sql` query when running on Postgres. This behavior seems to be specific to Postgres, which is why it didn't fail on H2 or MySQL/MariaDB.