### PR TITLE
Fix shape of metadata in Snowplow stats ping to conform to new schema

### DIFF
--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -731,4 +731,7 @@
       #_{:clj-kondo/ignore [:deprecated-var]}
       (send-stats-deprecated! stats)
       (snowplow/track-event! ::snowplow/instance_stats
-                             (assoc snowplow-stats :metadata [{"stats_export_time_seconds" elapsed-secs}])))))
+                             (assoc snowplow-stats
+                                    :metadata
+                                    [{"key"   "stats_export_time_seconds"
+                                      "value" elapsed-secs}])))))


### PR DESCRIPTION
Fixes the shape of the metadata we send in the new Snowplow stats ping. The schema changed last minute and I forgot to update the code accordingly. 

I'm still investigating why e2e tests didn't catch this, since it results in a failed event send which should have been detected. But I've validated that an event can be sent successfully locally. We might want to get this fix on stats to verify it there, while I continue to look into the Cypress issue.