### PR TITLE
fix aggressive legend truncation

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/legend.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/legend.cy.spec.js
@@ -344,14 +344,14 @@ describe("scenarios > visualizations > legend", () => {
       pieSlices().should("have.length", 3);
       cy.findByText("18,760").should("not.exist");
       cy.findByText("17,418").should("exist");
-      getPieChartLegendItemPercentage("TX").should("not.exist");
+      getPieChartLegendItemPercentage("TX").should("have.text", "");
 
       hideSeries(3); // "Other" slice
 
       pieSlices().should("have.length", 2);
       cy.findByText("17,418").should("not.exist");
       cy.findByText("1,660").should("exist");
-      getPieChartLegendItemPercentage("Other").should("not.exist");
+      getPieChartLegendItemPercentage("Other").should("have.text", "");
       getPieChartLegendItemPercentage("MT").should("have.text", "52.5%");
       getPieChartLegendItemPercentage("MN").should("have.text", "47.5%");
 

--- a/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
@@ -77,6 +77,30 @@ describe("scenarios > visualizations > pie chart", () => {
     ].map(args => checkLegendItemAriaCurrent(args[0], args[1]));
   });
 
+  it("should not truncate legend titles when enabling percentages (metabase#48207)", () => {
+    visitQuestionAdhoc({
+      dataset_query: testQuery,
+      display: "pie",
+      visualization_settings: {
+        "pie.percent_visibility": "off",
+      },
+    });
+
+    cy.findByTestId("viz-settings-button").click();
+
+    leftSidebar().within(() => {
+      cy.findByText("Display").click();
+      cy.findByText("In legend").click();
+    });
+
+    cy.findByTestId("chart-legend").within(() => {
+      cy.findByText("Widget").then(([element]) => {
+        // When text is truncated, offsetWidth will be less than scrollWidth
+        expect(element.offsetWidth).to.eq(element.scrollWidth);
+      });
+    });
+  });
+
   it("should instantly toggle the total after changing the setting", () => {
     visitQuestionAdhoc({
       dataset_query: testQuery,

--- a/frontend/src/metabase/visualizations/components/LegendVertical.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendVertical.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 /* eslint-disable react/no-string-refs */
 import cx from "classnames";
-import { Component, createRef } from "react";
+import { Component } from "react";
 import ReactDOM from "react-dom";
 import { t } from "ttag";
 
@@ -18,15 +18,7 @@ export default class LegendVertical extends Component {
   state = {
     overflowCount: 0,
     size: null,
-    listWidth: null,
   };
-
-  listRef = createRef();
-
-  componentDidMount() {
-    const listWidth = this.listRef.current.getBoundingClientRect().width;
-    this.setState({ listWidth });
-  }
 
   componentDidUpdate(prevProps, prevState) {
     // Get the bounding rectangle of the chart widget to determine if
@@ -55,20 +47,6 @@ export default class LegendVertical extends Component {
         this.setState({ overflowCount, size });
       }
     }
-
-    const [previousSampleTitle] = prevProps.titles || [];
-    const [sampleTitle] = this.props.titles || [];
-
-    if (
-      sampleTitle &&
-      previousSampleTitle &&
-      previousSampleTitle.length !== sampleTitle.length
-    ) {
-      this.setState({ listWidth: null }, () => {
-        const listWidth = this.listRef.current.getBoundingClientRect().width;
-        this.setState({ listWidth });
-      });
-    }
   }
 
   render() {
@@ -93,11 +71,7 @@ export default class LegendVertical extends Component {
       items = titles;
     }
     return (
-      <ol
-        className={cx(className, LegendS.Legend, LegendS.vertical)}
-        style={{ width: this.state.listWidth }}
-        ref={this.listRef}
-      >
+      <ol className={cx(className, LegendS.Legend, LegendS.vertical)}>
         {items.map((title, index) => {
           const isMuted =
             hovered && hovered.index != null && index !== hovered.index;

--- a/frontend/src/metabase/visualizations/components/LegendVertical.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendVertical.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 /* eslint-disable react/no-string-refs */
 import cx from "classnames";
-import { Component } from "react";
+import { Component, createRef } from "react";
 import ReactDOM from "react-dom";
 import { t } from "ttag";
 
@@ -17,8 +17,15 @@ export default class LegendVertical extends Component {
 
   state = {
     overflowCount: 0,
-    size: null,
+    listWidth: null,
   };
+
+  listRef = createRef();
+
+  componentDidMount() {
+    const listWidth = this.listRef.current.getBoundingClientRect().width;
+    this.setState({ listWidth });
+  }
 
   componentDidUpdate(prevProps, prevState) {
     // Get the bounding rectangle of the chart widget to determine if
@@ -47,6 +54,20 @@ export default class LegendVertical extends Component {
         this.setState({ overflowCount, size });
       }
     }
+
+    const [previousSampleTitle] = prevProps.titles || [];
+    const [sampleTitle] = this.props.titles || [];
+
+    if (
+      sampleTitle &&
+      previousSampleTitle &&
+      previousSampleTitle.length !== sampleTitle.length
+    ) {
+      this.setState({ listWidth: null }, () => {
+        const listWidth = this.listRef.current.getBoundingClientRect().width;
+        this.setState({ listWidth });
+      });
+    }
   }
 
   render() {
@@ -71,7 +92,11 @@ export default class LegendVertical extends Component {
       items = titles;
     }
     return (
-      <ol className={cx(className, LegendS.Legend, LegendS.vertical)}>
+      <ol
+        className={cx(className, LegendS.Legend, LegendS.vertical)}
+        style={{ width: this.state.listWidth }}
+        ref={this.listRef}
+      >
         {items.map((title, index) => {
           const isMuted =
             hovered && hovered.index != null && index !== hovered.index;

--- a/frontend/src/metabase/visualizations/components/LegendVertical.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendVertical.jsx
@@ -17,6 +17,7 @@ export default class LegendVertical extends Component {
 
   state = {
     overflowCount: 0,
+    size: null,
     listWidth: null,
   };
 

--- a/frontend/src/metabase/visualizations/visualizations/PieChart/PieChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/PieChart.tsx
@@ -106,17 +106,19 @@ export function PieChart(props: VisualizationProps) {
       const label = s.data.name;
 
       // Hidden slices don't have a percentage
-      if (s.data.normalizedPercentage === 0) {
-        return label;
+      const sliceHidden = s.data.normalizedPercentage === 0;
+      const percentDisabled =
+        settings["pie.percent_visibility"] !== "legend" &&
+        settings["pie.percent_visibility"] !== "both";
+
+      if (sliceHidden || percentDisabled) {
+        return [label];
       }
 
-      const percent =
-        settings["pie.percent_visibility"] === "legend" ||
-        settings["pie.percent_visibility"] === "both"
-          ? formatters.formatPercent(s.data.normalizedPercentage, "legend")
-          : undefined;
-
-      return [label, percent];
+      return [
+        label,
+        formatters.formatPercent(s.data.normalizedPercentage, "legend"),
+      ];
     });
 
   const hiddenSlicesLegendIndices = chartModel.slices


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/48125

### Description

Legend titles on pie chart were being truncated very aggressively, specifically when turning the percentage setting on (see before demo). This PR fixes this issue by correcting the `legendTitles` prop supplied by `PieChart.tsx` to the legend component.

### How to verify

1. Create a pie chart question (e.g. count of orders by product category)
2. Turn the percentage in legend setting off, then refresh the page
3. Turn it back on, the legend titles should not be truncated

### Demo

https://github.com/user-attachments/assets/e4ca000a-ce13-498b-9bb3-b3a1360fa30c

Before

https://github.com/user-attachments/assets/b13fe867-3325-4dc9-8967-370a71d1f1ea

After

https://github.com/user-attachments/assets/c448f8b2-024b-485d-9869-d0cae6e0c332

https://github.com/user-attachments/assets/e8047853-e34d-4168-a483-557360638b3d

Confirmed legend still resizes nicely

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
