### PR TITLE
fix pie chart e2e test flake

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
@@ -186,6 +186,8 @@ describe("scenarios > visualizations > pie chart", () => {
 
     changeRowLimit(2, 4);
     ensurePieChartRendered(["Doohickey", "Katget", "Gizmo", "Woooget"]);
+
+    cy.findByTestId("chart-legend").findByText("Woooget").realHover();
     chartPathWithFillColor("#509EE3").should("be.visible");
 
     cy.findByTestId("chart-legend").within(() => {


### PR DESCRIPTION
### Description

This test was flaking due to a legend item randomly being hovered, causing the color of the `Woodget` slice to be faded, making the assertion fail.

We fix this by explicitly hovering hover the `Woodget` legend item to ensure it has the right color on the chart.

### Demo

https://github.com/user-attachments/assets/82a0accd-76c8-498c-9f03-0a64585b4aae

### Checklist

- [x] Tests have been added/updated to cover changes in this PR


Stress test ✅ https://github.com/metabase/metabase/actions/runs/11113866453/job/30879129907