### PR TITLE
fix(sdk): modal pushing content below when opened

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkPortalContainer.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkPortalContainer.tsx
@@ -1,0 +1,22 @@
+import styled from "@emotion/styled";
+
+import { EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID } from "embedding-sdk/config";
+
+import { PublicComponentStylesWrapper } from "./PublicComponentStylesWrapper";
+
+/**
+ * This is the portal container used by popovers modals etc, it is wrapped with PublicComponentStylesWrapper
+ * so that it has our styles applied.
+ * Mantine components needs to have the defaultProps set to use `EMBEDDING_SDK_PORTAL_CONTAINER_ELEMENT_ID` as target for the portal
+ */
+export const PortalContainer = () => (
+  <PublicComponentStylesWrapper>
+    <FixedPosition id={EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID}></FixedPosition>
+  </PublicComponentStylesWrapper>
+);
+
+const FixedPosition = styled.div`
+  // needed otherwise it will rendered "in place" and push the content below
+  position: fixed;
+  z-index: 10;
+`;

--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkPortalContainer.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkPortalContainer.tsx
@@ -18,5 +18,6 @@ export const PortalContainer = () => (
 const FixedPosition = styled.div`
   // needed otherwise it will rendered "in place" and push the content below
   position: fixed;
-  z-index: 10;
+  left: 0;
+  top: 0;
 `;

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabaseProvider.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabaseProvider.tsx
@@ -4,10 +4,7 @@ import { type JSX, type ReactNode, memo, useEffect } from "react";
 import { Provider } from "react-redux";
 
 import { SdkThemeProvider } from "embedding-sdk/components/private/SdkThemeProvider";
-import {
-  EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID,
-  EMBEDDING_SDK_ROOT_ELEMENT_ID,
-} from "embedding-sdk/config";
+import { EMBEDDING_SDK_ROOT_ELEMENT_ID } from "embedding-sdk/config";
 import { useInitData } from "embedding-sdk/hooks";
 import type { SdkEventHandlersConfig } from "embedding-sdk/lib/events";
 import type { SdkPluginsConfig } from "embedding-sdk/lib/plugins";
@@ -25,14 +22,12 @@ import type { MetabaseTheme } from "embedding-sdk/types/theme";
 import { setOptions } from "metabase/redux/embed";
 import { EmotionCacheProvider } from "metabase/styled-components/components/EmotionCacheProvider";
 
-import {
-  PublicComponentStylesWrapper,
-  SCOPED_CSS_RESET,
-} from "../private/PublicComponentStylesWrapper";
+import { SCOPED_CSS_RESET } from "../private/PublicComponentStylesWrapper";
 import { SdkFontsGlobalStyles } from "../private/SdkGlobalFontsStyles";
-import "metabase/css/index.module.css";
+import { PortalContainer } from "../private/SdkPortalContainer";
 import { SdkUsageProblemDisplay } from "../private/SdkUsageProblem";
 
+import "metabase/css/index.module.css";
 import "metabase/css/vendor.css";
 
 export interface MetabaseProviderProps {
@@ -113,14 +108,3 @@ export const MetabaseProvider = memo(function MetabaseProvider({
     </Provider>
   );
 });
-
-/**
- * This is the portal container used by popovers modals etc, it is wrapped with PublicComponentStylesWrapper
- * so that it has our styles applied.
- * Mantine components needs to have the defaultProps set to use `EMBEDDING_SDK_PORTAL_CONTAINER_ELEMENT_ID` as target for the portal
- */
-const PortalContainer = () => (
-  <PublicComponentStylesWrapper>
-    <div id={EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID}></div>
-  </PublicComponentStylesWrapper>
-);

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabaseProvider.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabaseProvider.tsx
@@ -87,9 +87,9 @@ export const MetabaseProviderInternal = ({
       <SdkThemeProvider theme={theme}>
         <SdkFontsGlobalStyles baseUrl={config.metabaseInstanceUrl} />
         <div className={className} id={EMBEDDING_SDK_ROOT_ELEMENT_ID}>
-          <PortalContainer />
           {children}
           <SdkUsageProblemDisplay config={config} />
+          <PortalContainer />
         </div>
       </SdkThemeProvider>
     </EmotionCacheProvider>


### PR DESCRIPTION

# Description
Fixes https://metaboat.slack.com/archives/C063Q3F1HPF/p1727704037169859?thread_ts=1727689147.114469&cid=C063Q3F1HPF

I think this was caused by https://github.com/metabase/metabase/pull/47764 , the modals are rendered inside the provider, pushing the other sdk content below. 

# Demo

## Before

https://github.com/user-attachments/assets/ae123d6b-de9d-46c8-900a-70c15ecff001



## After

https://github.com/user-attachments/assets/4bdb030d-131a-4ced-86fc-687929ede5c3

