### PR TITLE
Future-proof CSV uploads from next HoneySQL upgrade

### DIFF
--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -140,12 +140,12 @@
   (with-quoting driver
     (first (sql/format {:create-table (keyword table-name)
                         :with-columns (cond-> (mapv (fn [[col-name type-spec]]
-                                                         (vec (cons (quote-identifier col-name)
-                                                                    (if (string? type-spec)
-                                                                      [[:raw type-spec]]
-                                                                      type-spec))))
-                                                       column-definitions)
-                                           primary-key (conj [(into [:primary-key] primary-key)]))}
+                                                      (vec (cons (quote-identifier col-name)
+                                                                 (if (string? type-spec)
+                                                                   [[:raw type-spec]]
+                                                                   type-spec))))
+                                                    column-definitions)
+                                        primary-key (conj [(into [:primary-key] primary-key)]))}
                        :quoted true
                        :dialect (sql.qp/quote-style driver)))))
 

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -140,7 +140,10 @@
   (with-quoting driver
     (first (sql/format {:create-table (keyword table-name)
                         :with-columns (cond-> (mapv (fn [[col-name type-spec]]
-                                                         (vec (cons (quote-identifier col-name) type-spec)))
+                                                         (vec (cons (quote-identifier col-name)
+                                                                    (if (string? type-spec)
+                                                                      [[:raw type-spec]]
+                                                                      type-spec))))
                                                        column-definitions)
                                            primary-key (conj [(into [:primary-key] primary-key)]))}
                        :quoted true
@@ -196,7 +199,10 @@
     (let [primary-key-column (first primary-key)
           sql                (first (sql/format {:alter-table (keyword table-name)
                                                  :add-column  (map (fn [[column-name type-and-constraints]]
-                                                                     (cond-> (vec (cons (quote-identifier column-name) type-and-constraints))
+                                                                     (cond-> (vec (cons (quote-identifier column-name)
+                                                                                        (if (string? type-and-constraints)
+                                                                                          [[:raw type-and-constraints]]
+                                                                                          type-and-constraints)))
                                                                        (= primary-key-column column-name)
                                                                        (conj :primary-key)))
                                                                    column-definitions)}

--- a/src/metabase/driver/sql_jdbc/sync/interface.clj
+++ b/src/metabase/driver/sql_jdbc/sync/interface.clj
@@ -146,7 +146,10 @@
   (with-quoting driver
     (first (sql/format {:alter-table  (keyword table-name)
                         :alter-column (map (fn [[column-name type-and-constraints]]
-                                             (vec (cons (quote-identifier column-name) type-and-constraints)))
+                                             (vec (cons (quote-identifier column-name)
+                                                        (if (string? type-and-constraints)
+                                                          [[:raw type-and-constraints]]
+                                                          type-and-constraints))))
                                            column-definitions)}
                        :quoted true
                        :dialect (sql.qp/quote-style driver)))))

--- a/src/metabase/search/legacy.clj
+++ b/src/metabase/search/legacy.clj
@@ -314,7 +314,6 @@
 (defmethod search-query-for-model "table"
   [model {:keys [current-user-perms table-db-id], :as search-ctx}]
   (when (seq current-user-perms)
-
     (-> (base-query-for-model model search-ctx)
         (add-table-db-id-clause table-db-id)
         (sql.helpers/left-join :metabase_database [:= :table.db_id :metabase_database.id]))))

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -558,7 +558,7 @@
                                 ["number" {:base_type :type/Float}]
                                 ["date" {:base_type :type/Date}]
                                 ["datetime" {:base_type :type/DateTime}]]
-                        (driver.u/supports? driver/*driver* :upload-with-auto-pk (mt/db))
+                        (auto-pk-column?)
                         (cons ["_mb_row_id" {:semantic_type     :type/PK
                                              :base_type         :type/BigInteger}]))
                       (->> (t2/select :model/Field :table_id (:id table))
@@ -1502,7 +1502,7 @@
                               - extra_1")
 
                      ["_mb_row_id,id, extra 2"]
-                     (if (driver.u/supports? driver/*driver* :upload-with-auto-pk (mt/db))
+                     (if (auto-pk-column?)
                        (trim-lines "The CSV file is missing columns that are in the table:
                                    - name
 
@@ -1616,7 +1616,7 @@
 
 (deftest update-mb-row-id-csv-only-test
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
-    (when (driver.u/supports? driver/*driver* :upload-with-auto-pk (mt/db))
+    (when (auto-pk-column?)
       (doseq [action (actions-to-test driver/*driver*)]
         (testing (action-testing-str action)
           (testing "If the table doesn't have _mb_row_id but the CSV does, ignore the CSV _mb_row_id but create the column anyway"
@@ -1872,7 +1872,7 @@
 
 (deftest update-mb-row-id-csv-and-table-test
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
-    (when (driver.u/supports? driver/*driver* :upload-with-auto-pk (mt/db))
+    (when (auto-pk-column?)
       (doseq [action (actions-to-test driver/*driver*)]
         (testing (action-testing-str action)
           (testing "Append succeeds if the table has _mb_row_id and the CSV does too"

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -1966,7 +1966,8 @@
         (with-uploads-enabled!
           (testing "Append should handle new non-ascii columns being added in the latest CSV"
             (with-upload-table! [table (create-upload-table!)]
-              (column-display-names-for-table table)
+              (is (= ["Name"]
+                     (rest (column-display-names-for-table table))))
              ;; Reorder as well for good measure
               (let [csv-rows ["α,name"
                               "omega,Everything"]


### PR DESCRIPTION
For some reason HoneySQL is about to get more easily confused between identifiers starting with % and function calls.

This also updates the commands to work with string based type signatures, which are used by Clickhouse.

One last small fix to the test suite for Clickhouse's numeric precision sneaks through as well.