### PR TITLE
fix: wrap `Filter by this value` in `t`

### DIFF
--- a/frontend/src/metabase/visualizations/components/ClickActions/utils.ts
+++ b/frontend/src/metabase/visualizations/components/ClickActions/utils.ts
@@ -68,7 +68,7 @@ export const getSectionTitle = (
 ): string | null => {
   switch (sectionKey) {
     case "filter":
-      return actions[0]?.sectionTitle ?? `Filter by this value`;
+      return actions[0]?.sectionTitle ?? t`Filter by this value`;
 
     case "sum":
       return t`Summarize`;


### PR DESCRIPTION

### Description

While testing allowing changing the locale for the sdk, I noticed this text didn't get translated

Before
<img width="357" alt="image" src="https://github.com/user-attachments/assets/f4a4f67b-e0df-4e79-92bc-11b15fd4eb5a">

After

<img width="358" alt="image" src="https://github.com/user-attachments/assets/169c1e0f-193a-427c-bdd4-2689c6c29980">
