### PR TITLE
fix: allow aggregation removal from qb sidebar again

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeContent/use-summarize-query.ts
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeContent/use-summarize-query.ts
@@ -39,13 +39,13 @@ export const useSummarizeQuery = ({
   const handleQueryChange = useCallback(
     (nextQuery: Lib.Query) => {
       const newAggregations = Lib.aggregations(nextQuery, STAGE_INDEX);
-      if (newAggregations.length === 0) {
+      if (hasDefaultAggregation && newAggregations.length === 0) {
         setHasDefaultAggregation(false);
       } else {
         handleChange(nextQuery);
       }
     },
-    [handleChange],
+    [handleChange, hasDefaultAggregation],
   );
 
   const handleAddBreakout = useCallback(

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.unit.spec.tsx
@@ -141,6 +141,19 @@ describe("SummarizeSidebar", () => {
       expect(onQueryChange).not.toHaveBeenCalled();
     });
 
+    it("should allow to remove last not default aggregation (metabase#48033)", async () => {
+      await setup({
+        query: createQueryWithClauses({
+          aggregations: [{ operatorName: "count" }],
+        }),
+      });
+
+      const countButton = screen.getByLabelText("Count");
+      await userEvent.click(within(countButton).getByLabelText("close icon"));
+
+      expect(screen.queryByLabelText("Count")).not.toBeInTheDocument();
+    });
+
     it("should allow to add the default aggregation manually after it was removed", async () => {
       const { getNextAggregations, onQueryChange } = await setup();
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/48033

### Description

we need to check if it's a default aggregation (when we do not explicitly specify aggregation in notebook editor)
and if it is, we should not re-run query, but if it's not, we should run query and remove aggregation from the sidebar 

### Related PRs
- https://github.com/metabase/metabase/pull/45398
- https://github.com/metabase/metabase/pull/46573 - wasn't backported, so no-backport for this PR as well

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> Orders
2. add aggregation "Count"
3. visualize
4. open Summarize and click "x" trying to remove Count aggregation 
5. aggregation should be removed

### Demo

https://github.com/user-attachments/assets/fa63b1be-3124-46de-bfc3-2695482b8313


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
