### PR TITLE
Fix appending to models with existing non-ascii columns

### DIFF
--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -756,8 +756,7 @@
               [header & rows]    (cond-> (parse reader)
                                    auto-pk?
                                    without-auto-pk-columns)
-              normed-name->field (m/index-by #(normalize-column-name driver (:name %))
-                                             (t2/select :model/Field :table_id (:id table) :active true))
+              normed-name->field (m/index-by :name (t2/select :model/Field :table_id (:id table) :active true))
               column-names       (for [h header] (normalize-column-name driver h))
               display-names      (for [h header] (normalize-display-name h))
               create-auto-pk?    (and

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -99,9 +99,10 @@
   [driver raw-name]
   (if (str/blank? raw-name)
     "unnamed_column"
-    (u/slugify (str/trim raw-name)
-               ;; since slugified names contain only ASCII characters, we can conflate bytes and length here.
-               {:max-length (max-column-bytes driver)})))
+    (u/lower-case-en
+     (u/slugify (str/trim raw-name)
+                ;; since slugified names contain only ASCII characters, we can conflate bytes and length here.
+                {:max-length (max-column-bytes driver)}))))
 
 (def auto-pk-column-name
   "The lower-case name of the auto-incrementing PK column. The actual name in the database could be in upper-case."

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -757,17 +757,17 @@
               [header & rows]    (cond-> (parse reader)
                                    auto-pk?
                                    without-auto-pk-columns)
-              normed-name->field (m/index-by :name (t2/select :model/Field :table_id (:id table) :active true))
+              name->field        (m/index-by :name (t2/select :model/Field :table_id (:id table) :active true))
               column-names       (for [h header] (normalize-column-name driver h))
               display-names      (for [h header] (normalize-display-name h))
               create-auto-pk?    (and
                                   auto-pk?
                                   (driver/create-auto-pk-with-append-csv? driver)
-                                  (not (contains? normed-name->field auto-pk-column-name)))
-              normed-name->field (cond-> normed-name->field auto-pk? (dissoc auto-pk-column-name))
-              _                  (check-schema normed-name->field column-names)
+                                  (not (contains? name->field auto-pk-column-name)))
+              name->field        (cond-> name->field auto-pk? (dissoc auto-pk-column-name))
+              _                  (check-schema name->field column-names)
               settings           (upload-parsing/get-settings)
-              old-types          (map (comp upload-types/base-type->upload-type :base_type normed-name->field) column-names)
+              old-types          (map (comp upload-types/base-type->upload-type :base_type name->field) column-names)
               ;; in the happy, and most common, case all the values will match the existing types
               ;; for now we just plan for the worst and perform a fairly expensive operation to detect any type changes
               ;; we can come back and optimize this to an optimistic-with-fallback approach later.

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -1999,25 +1999,25 @@
     (doseq [action (actions-to-test driver/*driver*)]
       (testing (action-testing-str action)
         (with-uploads-enabled!
-         (testing "Append should handle new non-ascii columns being added in the latest CSV"
-           (with-upload-table! [table (create-upload-table!
-                                       :col->upload-type (columns-with-auto-pk {"α" ::upload-types/varchar-255}))]
+          (testing "Append should handle new non-ascii columns being added in the latest CSV"
+            (with-upload-table! [table (create-upload-table!
+                                        :col->upload-type (columns-with-auto-pk {"α" ::upload-types/varchar-255}))]
              ;; We can't type a literal uppercase Alpha, as our whitespace linter will complain.
-             (is (= (header-with-auto-pk [(u/upper-case-en "α")])
-                    (column-display-names-for-table table)))
+              (is (= (header-with-auto-pk [(u/upper-case-en "α")])
+                     (column-display-names-for-table table)))
              ;; Reorder as well for good measure
-             (let [csv-rows ["α,name"
-                             "omega,Everything"]
-                   file     (csv-file-with csv-rows)]
-               (testing "The new row is inserted with the values correctly reordered"
-                 (is (= {:row-count 1} (update-csv! action {:file file, :table-id (:id table)})))
-                 (is (= (header-with-auto-pk [(u/upper-case-en "α") "name"])
-                        (column-display-names-for-table table)))
-                 (is (= (set (updated-contents action
-                                               [["Obi-Wan Kenobi" nil]]
-                                               [["omega" "Everything"]]))
-                        (set (rows-for-table table)))))
-               (io/delete-file file)))))))))
+              (let [csv-rows ["α,name"
+                              "omega,Everything"]
+                    file     (csv-file-with csv-rows)]
+                (testing "The new row is inserted with the values correctly reordered"
+                  (is (= {:row-count 1} (update-csv! action {:file file, :table-id (:id table)})))
+                  (is (= (header-with-auto-pk [(u/upper-case-en "α") "name"])
+                         (column-display-names-for-table table)))
+                  (is (= (set (updated-contents action
+                                                [["Obi-Wan Kenobi" nil]]
+                                                [["omega" "Everything"]]))
+                         (set (rows-for-table table)))))
+                (io/delete-file file)))))))))
 
 (deftest update-type-mismatch-test
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads)

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -2006,12 +2006,13 @@
               (is (= (header-with-auto-pk [(u/upper-case-en "α")])
                      (column-display-names-for-table table)))
              ;; Reorder as well for good measure
-              (let [csv-rows ["α,name"
+              (let [csv-rows ["α,ϐ"
                               "omega,Everything"]
                     file     (csv-file-with csv-rows)]
                 (testing "The new row is inserted with the values correctly reordered"
                   (is (= {:row-count 1} (update-csv! action {:file file, :table-id (:id table)})))
-                  (is (= (header-with-auto-pk [(u/upper-case-en "α") "name"])
+                  ;; It's a historic quirk that added columns don't get humanized display names
+                  (is (= (header-with-auto-pk [(u/upper-case-en "α") "ϐ"])
                          (column-display-names-for-table table)))
                   (is (= (set (updated-contents action
                                                 [["Obi-Wan Kenobi" nil]]

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -2426,7 +2426,7 @@
 
 (deftest unique-long-column-names-test
   (let [original ["αbcdεf_αbcdεf"     "αbcdεfg_αbcdεf"   "αbc_2_etc_αbcdεf" "αbc_3_xyz_αbcdεf"]
-        expected [:%CE%B1bcd%  :%_852c229f :%CE%B1bc_2 :%CE%B1bc_3]
+        expected [:%ce%b1bcd%  :%_b59bccce :%ce%b1bc_2 :%ce%b1bc_3]
         displays ["αbcdεf" "αbcdεfg" "αbc 2 etc" "αbc 3 xyz"]]
     (is (= expected (#'upload/derive-column-names ::short-column-test-driver original)))
     (mt/with-dynamic-redefs [upload/max-bytes (constantly 10)]

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -1343,13 +1343,12 @@
         schema-name       (ddl.i/format-name driver schema-name)
         schema+table-name (#'upload/table-identifier {:schema schema-name :name table-name})
         ->normalized-col  (comp keyword (partial #'upload/normalize-column-name driver) name)
-        name->display     (->> (keys col->upload-type)
+        names             (->> (keys col->upload-type)
                                (map name)
-                               (remove #{upload/auto-pk-column-name})
-                               ((juxt
-                                 (partial map (comp name ->normalized-col))
-                                 (partial #'upload/derive-display-names driver)))
-                               (apply zipmap))
+                               (remove #{upload/auto-pk-column-name}))
+        normal-names      (for [n names] (#'upload/normalize-column-name driver n))
+        display-names     (#'upload/derive-display-names driver names)
+        name->display     (zipmap normal-names display-names)
         col->upload-type  (update-keys col->upload-type ->normalized-col)
         insert-col-names  (remove #{upload/auto-pk-column-keyword} (keys col->upload-type))
         col-definitions   (#'upload/column-definitions driver col->upload-type)]


### PR DESCRIPTION
This seems to have always been broken, noticed it as part of my clickhouse testing.