### PR TITLE
Add tests for exporting self-joined renamed columns

### DIFF
--- a/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
+++ b/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
@@ -148,6 +148,95 @@ describe("scenarios > question > download", () => {
     });
   });
 
+  it("respects renamed columns in self-joins", () => {
+    const idLeftRef = [
+      "field",
+      ORDERS.ID,
+      {
+        "base-type": "type/BigInteger",
+      },
+    ];
+    const idRightRef = [
+      "field",
+      ORDERS.ID,
+      {
+        "base-type": "type/BigInteger",
+        "join-alias": "Orders",
+      },
+    ];
+    const totalLeftRef = [
+      "field",
+      ORDERS.TOTAL,
+      {
+        "base-type": "type/Float",
+      },
+    ];
+    const totalRightRef = [
+      "field",
+      ORDERS.TOTAL,
+      {
+        "base-type": "type/Float",
+        "join-alias": "Orders",
+      },
+    ];
+
+    const totalLeftColumnKey = '["name","TOTAL"]';
+    const totalRightColumnKey = '["name","TOTAL_2"]';
+
+    createQuestion(
+      {
+        query: {
+          "source-table": ORDERS_ID,
+          fields: [totalLeftRef],
+          joins: [
+            {
+              fields: [totalRightRef],
+              strategy: "left-join",
+              alias: "Orders",
+              condition: ["=", idLeftRef, idRightRef],
+              "source-table": ORDERS_ID,
+            },
+          ],
+          "order-by": [["desc", totalLeftRef]],
+          limit: 1,
+        },
+        visualization_settings: {
+          column_settings: {
+            [totalLeftColumnKey]: {
+              column_title: "Left Total",
+            },
+            [totalRightColumnKey]: {
+              column_title: "Right Total",
+            },
+          },
+        },
+      },
+      { visitQuestion: true, wrapId: true },
+    );
+
+    queryBuilderMain().findByText("Left Total").should("exist");
+    queryBuilderMain().findByText("Right Total").should("exist");
+
+    cy.get("@questionId").then(questionId => {
+      testCases.forEach(fileType => {
+        const opts = { questionId, fileType };
+
+        downloadAndAssert(
+          {
+            ...opts,
+            enableFormatting: true,
+          },
+          sheet => {
+            expect(sheet["A1"].v).to.eq("Left Total");
+            expect(sheet["A2"].v).to.closeTo(159.35, 0.01);
+            expect(sheet["B1"].v).to.eq("Right Total");
+            expect(sheet["B2"].v).to.closeTo(159.35, 0.01);
+          },
+        );
+      });
+    });
+  });
+
   describe("from dashboards", () => {
     it("should allow downloading card data", () => {
       cy.intercept("GET", "/api/dashboard/**").as("dashboard");

--- a/test/metabase/query_processor/streaming_test.clj
+++ b/test/metabase/query_processor/streaming_test.clj
@@ -509,6 +509,46 @@
                                  [1.0 "Red Medicine" 4.0 "Asian"]]
                                 (xlsx-test/parse-xlsx-results results))))}}))
 
+(deftest self-join-export-test
+  (do-test!
+   "Export respects renamed self-joined columns #48046"
+   {:query {:database (mt/id)
+            :query
+            {:source-table (mt/id :venues)
+             :joins
+             [{:fields       "all",
+               :source-table (mt/id :venues)
+               :condition    ["="
+                              ["field" (mt/id :venues :id) nil]
+                              ["field" (mt/id :venues :id) {:join-alias "Venues"}]],
+               :alias        "Venues"}]
+             :order-by     [["asc" ["field" (mt/id :venues :id) nil]]]
+             :limit        1}
+            :type     "query"}
+
+    :viz-settings {:column_settings
+                   {"[\"name\",\"NAME\"]"   {:column_title "Left Name"}
+                    "[\"name\",\"NAME_2\"]" {:column_title "Right Name"}}
+                   :table.columns
+                   [{:name "ID", :fieldRef [:field (mt/id :venues :id) nil], :enabled true}
+                    {:name "NAME", :fieldRef [:field (mt/id :venues :name) nil], :enabled true}
+                    {:name "NAME_2", :fieldRef [:field (mt/id :venues :name) {:join-alias "Venues"}], :enabled true}]}
+
+    :assertions {:csv (fn [results]
+                        (is (= [["ID" "Left Name" "Right Name"]
+                                ["1" "Red Medicine" "Red Medicine"]]
+                               (parse-csv-results results))))
+
+                 :json (fn [results]
+                         (is (= [["ID" "Left Name" "Right Name"]
+                                 ["1" "Red Medicine" "Red Medicine"]]
+                                (parse-json-results results))))
+
+                 :xlsx (fn [results]
+                         (is (= [["ID" "Left Name" "Right Name"]
+                                 [1.0 "Red Medicine" "Red Medicine"]]
+                                (xlsx-test/parse-xlsx-results results))))}}))
+
 (deftest native-query-test
   (mt/with-full-data-perms-for-all-users!
     (do-test!


### PR DESCRIPTION
### Description

Regression tests for #48046 to accompany the backport in #48243. This is a separate PR in order to keep the backport PR limited to backporting, and also to follow the standard merge flow of master > release branch.

### How to verify

Run the tests

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
