### PR TITLE
Do not ignore-errors in pprint-native-query-with-best-strategy

### DIFF
--- a/test/metabase/driver/sql/query_processor_test_util.clj
+++ b/test/metabase/driver/sql/query_processor_test_util.clj
@@ -119,7 +119,7 @@
    (pprint-native-query-with-best-strategy (or driver/*driver* :h2) query))
 
   ([driver query]
-   (u/ignore-exceptions
+   (try
      (let [{native :query, :as query} (query->raw-native-query query)]
        (str "\nNative Query =\n"
             (cond
@@ -135,7 +135,9 @@
             \newline
             \newline
             (u/pprint-to-str (dissoc query :query))
-            \newline)))))
+            \newline))
+     (catch Exception e
+       (str "Unable to pprint native query:\n" query "\n" e)))))
 
 (defn do-with-native-query-testing-context
   [query thunk]


### PR DESCRIPTION
### Description

Do not ignore-errors in `pprint-native-query-with-best-strategy`. Return a description of the Exception that occurred instead. This is helpful for debugging if `query->raw-native-query` throws an exception.

Fwiw, this was helpful while working on #47584 as the query in question would not compile prior to fixing the bug.

### How to verify

This function is called by the macro `with-native-query-testing-context`. Run any test that uses that macro, and give it some query that fails to compile.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
