### PR TITLE
Batch Add Milestones to new release branch

### DIFF
--- a/.github/workflows/check-milestone.yml
+++ b/.github/workflows/check-milestone.yml
@@ -5,6 +5,12 @@ on:
   push:
     branches:
       - release-x.**
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Major version number  (e.g. 52, 78, 109)'
+        type: number
+        required: true
 
 jobs:
   set-milestone:
@@ -19,10 +25,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           sparse-checkout: release
+          fetch-depth: ${{ github.event_name == 'workflow_dispatch' && 0 || 3 }} # we need the full history to get the commit messages
           ref: master # we want the logic from master, even though we're triggering on a release branch
       - name: Prepare build scripts
         run: cd ${{ github.workspace }}/release && yarn && yarn build
       - uses: actions/github-script@v7
+        if: ${{ github.event_name == 'push' }}
+        name: set milestone for single commit
         with:
           script: | # js
             const { setMilestoneForCommits } = require('${{ github.workspace }}/release/dist/index.cjs');
@@ -38,4 +47,35 @@ jobs:
               repo,
               branchName,
               commitMessages: [commitMessage],
+            });
+      - uses: actions/github-script@v7
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        name: set milestone for new release branch
+        env:
+          # this token has a higher rate limit than the default token, and
+          # we will need it for this workflow to work
+          GITHUB_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+        with:
+          script: | # js
+            const { getReleaseBranchCommits } = require('${{ github.workspace }}/release/dist/index.cjs');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const versionNumber = context.payload.inputs.version;
+            const branchName = `release-x.${versionNumber}.x`;
+
+
+            const commitMessages = await getReleaseBranchCommits({
+              versionNumber: Number(versionNumber),
+            });
+
+            console.log(`Found ${commitMessages.length} new commits for ${branchName}`);
+
+            await setMilestoneForCommits({
+              github,
+              owner,
+              repo,
+              branchName,
+              commitMessages: commitMessages,
+              ignoreExistingMilestones: true,
             });

--- a/.github/workflows/check-milestone.yml
+++ b/.github/workflows/check-milestone.yml
@@ -1,5 +1,5 @@
 name: Automatically set milestone
-run-name: Set milestone for ${{ github.event.head_commit.message }}
+run-name: Set milestone for ${{ github.event.head_commit.message || inputs.version }}
 
 on:
   push:
@@ -16,7 +16,9 @@ jobs:
   set-milestone:
     name: Automatically set milestone
     runs-on: ubuntu-22.04
-    timeout-minutes: 5
+    timeout-minutes: 15
+    env:
+      isNewReleaseBranch: ${{ github.event_name == 'workflow_dispatch' }}
     permissions:
       pull-requests: write
       issues: write
@@ -25,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           sparse-checkout: release
-          fetch-depth: ${{ github.event_name == 'workflow_dispatch' && 0 || 3 }} # we need the full history to get the commit messages
+          fetch-depth: ${{ !env.isNewReleaseBranch && 3 || 0 }} # we need the full history to get all the commit messages
           ref: master # we want the logic from master, even though we're triggering on a release branch
       - name: Prepare build scripts
         run: cd ${{ github.workspace }}/release && yarn && yarn build
@@ -48,8 +50,13 @@ jobs:
               branchName,
               commitMessages: [commitMessage],
             });
+      - name: Get commit messages for release branch
+        if: ${{ env.isNewReleaseBranch }}
+        run: |
+          npm i -g tsx
+          tsx release/src/release-branch-commits.ts ${{ inputs.version }} > commit-messages.json
       - uses: actions/github-script@v7
-        if: ${{ github.event_name == 'workflow_dispatch' }}
+        if: ${{ env.isNewReleaseBranch }}
         name: set milestone for new release branch
         env:
           # this token has a higher rate limit than the default token, and
@@ -57,17 +64,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
         with:
           script: | # js
-            const { getReleaseBranchCommits } = require('${{ github.workspace }}/release/dist/index.cjs');
+            const { setMilestoneForCommits } = require('${{ github.workspace }}/release/dist/index.cjs');
+            const commitMessages = require('${{ github.workspace }}/commit-messages.json');
+
             const owner = context.repo.owner;
             const repo = context.repo.repo;
 
             const versionNumber = context.payload.inputs.version;
             const branchName = `release-x.${versionNumber}.x`;
-
-
-            const commitMessages = await getReleaseBranchCommits({
-              versionNumber: Number(versionNumber),
-            });
 
             console.log(`Found ${commitMessages.length} new commits for ${branchName}`);
 

--- a/.github/workflows/check-milestone.yml
+++ b/.github/workflows/check-milestone.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Prepare build scripts
         run: cd ${{ github.workspace }}/release && yarn && yarn build
       - uses: actions/github-script@v7
-        if: ${{ github.event_name == 'push' }}
-        name: set milestone for single commit
+        if: ${{ !env.isNewReleaseBranch }}
+        name: Set milestone for single commit
         with:
           script: | # js
             const { setMilestoneForCommits } = require('${{ github.workspace }}/release/dist/index.cjs');
@@ -57,7 +57,7 @@ jobs:
           tsx release/src/release-branch-commits.ts ${{ inputs.version }} > commit-messages.json
       - uses: actions/github-script@v7
         if: ${{ env.isNewReleaseBranch }}
-        name: set milestone for new release branch
+        name: Set milestones for new release branch
         env:
           # this token has a higher rate limit than the default token, and
           # we will need it for this workflow to work

--- a/release/src/milestones.ts
+++ b/release/src/milestones.ts
@@ -2,7 +2,6 @@ import fs from "fs";
 
 import { graphql } from "@octokit/graphql";
 import _ from "underscore";
-import { $ } from "zx";
 
 import { hiddenLabels, nonUserFacingLabels } from "./constants";
 import {
@@ -50,18 +49,6 @@ function getExcludedLabels(issue: Issue) {
 
 function shouldExcludeIssueFromMilestone(issue: Issue) {
   return !!getExcludedLabels(issue).length;
-}
-
-export async function getReleaseBranchCommits(
-  { versionNumber }: { versionNumber: number }
-) {
-  const lastMajorVersion = versionNumber - 1;
-
-  // find where the last branch split off of master
-  const { stdout: branchCommit } = await $`git merge-base origin/release-x.${lastMajorVersion}.x master`;
-  const { stdout: commitMessages } = await $`git log ${branchCommit.trim()}..origin/release-x.${versionNumber}.x --pretty='format:%s'`;
-
-  return commitMessages.split('\n')
 }
 
 async function getIssuesWithExcludedTags({

--- a/release/src/milestones.ts
+++ b/release/src/milestones.ts
@@ -159,6 +159,7 @@ async function setMilestone({ github, owner, repo, issueNumber, milestone, ignor
   });
 
   if (!issue?.milestone) {
+    console.log(`Setting milestone ${milestone.title} for issue # ${issueNumber}`);
     return github.rest.issues.update({
       owner,
       repo,

--- a/release/src/milestones.ts
+++ b/release/src/milestones.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 
 import { graphql } from "@octokit/graphql";
 import _ from "underscore";
+import { $ } from "zx";
 
 import { hiddenLabels, nonUserFacingLabels } from "./constants";
 import {
@@ -49,6 +50,18 @@ function getExcludedLabels(issue: Issue) {
 
 function shouldExcludeIssueFromMilestone(issue: Issue) {
   return !!getExcludedLabels(issue).length;
+}
+
+export async function getReleaseBranchCommits(
+  { versionNumber }: { versionNumber: number }
+) {
+  const lastMajorVersion = versionNumber - 1;
+
+  // find where the last branch split off of master
+  const { stdout: branchCommit } = await $`git merge-base origin/release-x.${lastMajorVersion}.x master`;
+  const { stdout: commitMessages } = await $`git log ${branchCommit.trim()}..origin/release-x.${versionNumber}.x --pretty='format:%s'`;
+
+  return commitMessages.split('\n')
 }
 
 async function getIssuesWithExcludedTags({
@@ -149,7 +162,7 @@ async function getOriginalIssues({
   return [issue.number];
 }
 
-async function setMilestone({ github, owner, repo, issueNumber, milestone }: GithubProps & { issueNumber: number, milestone: Milestone }) {
+async function setMilestone({ github, owner, repo, issueNumber, milestone, ignoreExistingMilestones }: GithubProps & { issueNumber: number, milestone: Milestone, ignoreExistingMilestones?: boolean }) {
   // we can use this for both issues and PRs since they're the same for many purposes in github
   const issue = await getIssueWithCache({
     github,
@@ -165,6 +178,10 @@ async function setMilestone({ github, owner, repo, issueNumber, milestone }: Git
       issue_number: issueNumber,
       milestone: milestone.number,
     });
+  }
+
+  if (ignoreExistingMilestones) {
+    return;
   }
 
   const existingMilestone = issue.milestone;
@@ -223,7 +240,8 @@ export async function setMilestoneForCommits({
   repo,
   branchName,
   commitMessages,
-}: GithubProps & { commitMessages: string[], branchName: string}) {
+  ignoreExistingMilestones,
+}: GithubProps & { commitMessages: string[], branchName: string, ignoreExistingMilestones?: boolean }) {
   // figure out milestone
   const branchVersion = getVersionFromReleaseBranch(branchName);
   const majorVersion = getMajorVersion(branchVersion);
@@ -264,7 +282,14 @@ export async function setMilestoneForCommits({
   console.log(`Tagging ${uniqueIssuesToTag.length} issues with milestone ${nextMilestone.title}`)
 
   for (const issueNumber of uniqueIssuesToTag) { // for loop to avoid rate limiting
-    await setMilestone({ github, owner, repo, issueNumber, milestone: nextMilestone });
+    await setMilestone({
+      github,
+      owner,
+      repo,
+      issueNumber,
+      milestone: nextMilestone,
+      ignoreExistingMilestones,
+    });
   }
 }
 

--- a/release/src/release-branch-commits.ts
+++ b/release/src/release-branch-commits.ts
@@ -1,0 +1,19 @@
+import {$} from 'zx';
+
+export async function getReleaseBranchCommits(
+  { versionNumber }: { versionNumber: number }
+) {
+  const lastMajorVersion = versionNumber - 1;
+
+  // find where the last branch split off of master
+  const { stdout: branchCommit } = await $`git merge-base origin/release-x.${lastMajorVersion}.x master`;
+  const { stdout: commitMessages } = await $`git log ${branchCommit.trim()}..origin/release-x.${versionNumber}.x --pretty='format:%s'`;
+
+  return commitMessages.split('\n')
+}
+
+const versionNumber = Number(process.argv[2]);
+
+const commits = await getReleaseBranchCommits({ versionNumber });
+
+console.log(JSON.stringify(commits, null, 2));


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/47785

### Description

When we cut a new release branch, we want to automatically add milestones to all commits in that branch (or issues traceable to commits in that branch that don't already have a milestone.

How we do this:

1. find the commit where the last release branch forked off of master
2. get all commits between the head of the new release branch and that fork commit
3. feed those commit descriptions to the existing logic that sets milestones on individual commits when they merge to the release branch.

- [x] this [test run](https://github.com/iethree/metabase/actions/runs/11134949547/job/30944349197) is about as good as we can test without doing it live
- [x] I also ran a local test and it successfully parsed the whole release branch in my fork without hitting a github rate limit (5000 reqs/hr). It is likely that in the future we'll have to revisit this as the team grows and releases get bigger.

For posterity:

One way to deal with the github rate limit would be to split the job into:
1) find all the issues that need to be milestoned
2) write those issue numbers to a file 
3) set milestones on all those issues with a separate token.
