### PR TITLE
Bump HoneySQL to 2.6.1161 

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -38,7 +38,7 @@
   com.draines/postal                        {:mvn/version "2.0.5"}              ; SMTP library
   ; Detect the charset in uploaded CSV files
   com.github.albfernandez/juniversalchardet {:mvn/version "2.5.0"}
-  com.github.seancorfield/honeysql          {:mvn/version "2.6.1126"}           ; Honey SQL 2. SQL generation from Clojure data maps
+  com.github.seancorfield/honeysql          {:mvn/version "2.6.1161"}           ; Honey SQL 2. SQL generation from Clojure data maps
   com.github.seancorfield/next.jdbc         {:mvn/version "1.3.925"}            ; Talk to JDBC DBs
   com.github.steffan-westcott/clj-otel-api  {:mvn/version "0.2.6"}              ; Telemetry library
   com.github.vertical-blank/sql-formatter   {:mvn/version "2.0.4"}              ; Java SQL formatting library https://github.com/vertical-blank/sql-formatter

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -19,6 +19,7 @@
    [metabase.driver.sql-jdbc.common :as sql-jdbc.common]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
+   [metabase.driver.sql-jdbc.quoting :refer [quote-columns]]
    [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.driver.sql.query-processor.util :as sql.qp.u]
@@ -796,7 +797,7 @@
         (let [tsvs    (map (partial row->tsv driver (count column-names)) values)
               dialect (sql.qp/quote-style driver)
               sql     (sql/format {::load   [file-path (keyword table-name)]
-                                   :columns (sql-jdbc.common/quote-columns dialect column-names)}
+                                   :columns (quote-columns driver column-names)}
                                   :quoted true
                                   :dialect dialect)]
           (with-open [^java.io.Writer writer (jio/writer file-path)]

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -859,7 +859,6 @@
   [driver]
   (= driver :postgres))
 
-
 (defmethod sql-jdbc.sync/alter-columns-sql :postgres
   [driver table-name column-definitions]
   (with-quoting driver

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -19,7 +19,7 @@
    [metabase.driver.sql-jdbc.common :as sql-jdbc.common]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
-   [metabase.driver.sql-jdbc.quoting :refer [with-quoting quote-columns quote-identifier quote-table]]
+   [metabase.driver.sql-jdbc.quoting :refer [with-quoting quote-columns quote-identifier]]
    [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
    [metabase.driver.sql-jdbc.sync.describe-database :as sql-jdbc.describe-database]
    [metabase.driver.sql.query-processor :as sql.qp]
@@ -862,7 +862,7 @@
 (defmethod sql-jdbc.sync/alter-columns-sql :postgres
   [driver table-name column-definitions]
   (with-quoting driver
-    (first (sql/format {:alter-table  (quote-table table-name)
+    (first (sql/format {:alter-table  (keyword table-name)
                         :alter-column (map (fn [[column-name type-and-constraints]]
                                              (vec (list* (quote-identifier column-name)
                                                          :type

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -19,7 +19,7 @@
    [metabase.driver.sql-jdbc.common :as sql-jdbc.common]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
-   [metabase.driver.sql-jdbc.quoting :refer [with-quoting quote-columns quote-identifier]]
+   [metabase.driver.sql-jdbc.quoting :refer [with-quoting quote-columns quote-identifier quote-table]]
    [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
    [metabase.driver.sql-jdbc.sync.describe-database :as sql-jdbc.describe-database]
    [metabase.driver.sql.query-processor :as sql.qp]
@@ -863,7 +863,7 @@
 (defmethod sql-jdbc.sync/alter-columns-sql :postgres
   [driver table-name column-definitions]
   (with-quoting driver
-    (first (sql/format {:alter-table  (keyword table-name)
+    (first (sql/format {:alter-table  (quote-table table-name)
                         :alter-column (map (fn [[column-name type-and-constraints]]
                                              (vec (list* (quote-identifier column-name)
                                                          :type

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -19,6 +19,7 @@
    [metabase.driver.sql-jdbc.common :as sql-jdbc.common]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
+   [metabase.driver.sql-jdbc.quoting :refer [quote-columns]]
    [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
    [metabase.driver.sql-jdbc.sync.describe-database :as sql-jdbc.describe-database]
    [metabase.driver.sql.query-processor :as sql.qp]
@@ -911,7 +912,7 @@
     (let [copy-manager (CopyManager. (.unwrap ^Connection (:connection conn) PgConnection))
           dialect      (sql.qp/quote-style driver)
           [sql & _] (sql/format {::copy       (keyword table-name)
-                                 :columns     (sql-jdbc.common/quote-columns dialect column-names)
+                                 :columns     (quote-columns driver column-names)
                                  ::from-stdin "''"}
                                 :quoted true
                                 :dialect dialect)

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -189,7 +189,7 @@
   (mu/validate-throw [:maybe [:cat :keyword]] primary-key) ; we only support adding a single primary key column for now
   (with-quoting driver
     (let [primary-key-column (first primary-key)
-          sql                (first (sql/format {:alter-table (quote-table table-name)
+          sql                (first (sql/format {:alter-table (keyword table-name)
                                                  :add-column  (map (fn [[column-name type-and-constraints]]
                                                                      (cond-> (vec (cons (quote-identifier column-name)
                                                                                         (if (string? type-and-constraints)

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -9,7 +9,7 @@
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.sql-jdbc.metadata :as sql-jdbc.metadata]
-   [metabase.driver.sql-jdbc.quoting :refer [with-quoting quote-columns quote-identifier]]
+   [metabase.driver.sql-jdbc.quoting :refer [with-quoting quote-columns quote-identifier quote-table]]
    [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.driver.sync :as driver.s]
@@ -130,7 +130,7 @@
 (defn- create-table!-sql
   [driver table-name column-definitions & {:keys [primary-key]}]
   (with-quoting driver
-    (first (sql/format {:create-table (keyword table-name)
+    (first (sql/format {:create-table (quote-table table-name)
                         :with-columns (cond-> (mapv (fn [[col-name type-spec]]
                                                       (vec (cons (quote-identifier col-name)
                                                                  (if (string? type-spec)
@@ -189,7 +189,7 @@
   (mu/validate-throw [:maybe [:cat :keyword]] primary-key) ; we only support adding a single primary key column for now
   (with-quoting driver
     (let [primary-key-column (first primary-key)
-          sql                (first (sql/format {:alter-table (keyword table-name)
+          sql                (first (sql/format {:alter-table (quote-table table-name)
                                                  :add-column  (map (fn [[column-name type-and-constraints]]
                                                                      (cond-> (vec (cons (quote-identifier column-name)
                                                                                         (if (string? type-and-constraints)

--- a/src/metabase/driver/sql_jdbc/common.clj
+++ b/src/metabase/driver/sql_jdbc/common.clj
@@ -1,7 +1,6 @@
 (ns metabase.driver.sql-jdbc.common
   (:require
    [clojure.string :as str]
-   [honey.sql :as sql]
    [metabase.util :as u]))
 
 (def ^:private valid-separator-styles #{:url :comma :semicolon})
@@ -86,10 +85,3 @@
                         [(k-fn k) v]))
           kvs       (map kv-fn pairs)]
       (into {} kvs))))
-
-(defn quote-columns
-  "Used to quote column names when building HoneySQL queries, in case they look like function calls."
-  [dialect columns]
-  (binding [sql/*dialect* (sql/get-dialect dialect)]
-    (for [c columns]
-      [:raw (sql/format-entity c)])))

--- a/src/metabase/driver/sql_jdbc/quoting.clj
+++ b/src/metabase/driver/sql_jdbc/quoting.clj
@@ -13,7 +13,7 @@
 (defn quote-table
   "Protect against a table being interpreted as a function call."
   [table-name]
-  (keyword (str "'" (sql/format-entity table-name))))
+  (keyword (str "'" (sql/format-entity #p (keyword table-name)))))
 
 (defn quote-identifier
   "Quote an identifier, in case it looks like a function call."

--- a/src/metabase/driver/sql_jdbc/quoting.clj
+++ b/src/metabase/driver/sql_jdbc/quoting.clj
@@ -10,6 +10,11 @@
              sql/*quoted*  true]
      ~@body))
 
+(defn quote-table
+  "Protect against a table being interpreted as a function call."
+  [table-name]
+  (keyword (str "'" (sql/format-entity table-name))))
+
 (defn quote-identifier
   "Quote an identifier, in case it looks like a function call."
   [ref]

--- a/src/metabase/driver/sql_jdbc/quoting.clj
+++ b/src/metabase/driver/sql_jdbc/quoting.clj
@@ -1,0 +1,22 @@
+(ns metabase.driver.sql-jdbc.quoting
+  (:require
+   [honey.sql :as sql]
+   [metabase.driver.sql.query-processor :as sql.qp]))
+
+(defmacro with-quoting
+  "Helper macro for quoting identifiers."
+  [driver & body]
+  `(binding [sql/*dialect* (sql/get-dialect (sql.qp/quote-style ~driver))
+             sql/*quoted*  true]
+     ~@body))
+
+(defn quote-identifier
+  "Quote an identifier, in case it looks like a function call."
+  [ref]
+  [:raw (sql/format-entity ref)])
+
+(defn quote-columns
+  "Used to quote column names when building HoneySQL queries, in case they look like function calls."
+  [driver columns]
+  (with-quoting driver
+    (map quote-identifier columns)))

--- a/src/metabase/driver/sql_jdbc/quoting.clj
+++ b/src/metabase/driver/sql_jdbc/quoting.clj
@@ -13,7 +13,7 @@
 (defn quote-table
   "Protect against a table being interpreted as a function call."
   [table-name]
-  (keyword (str "'" (sql/format-entity #p (keyword table-name)))))
+  (keyword (str "'" (sql/format-entity (keyword table-name)))))
 
 (defn quote-identifier
   "Quote an identifier, in case it looks like a function call."

--- a/src/metabase/driver/sql_jdbc/sync/interface.clj
+++ b/src/metabase/driver/sql_jdbc/sync/interface.clj
@@ -2,7 +2,7 @@
   (:require
    [honey.sql :as sql]
    [metabase.driver :as driver]
-   [metabase.driver.sql-jdbc.quoting :refer [quote-identifier with-quoting]]
+   [metabase.driver.sql-jdbc.quoting :refer [with-quoting  quote-identifier quote-table]]
    [metabase.driver.sql.query-processor :as sql.qp]))
 
 (defmulti active-tables
@@ -137,7 +137,7 @@
 (defmethod alter-columns-sql :sql-jdbc
   [driver table-name column-definitions]
   (with-quoting driver
-    (first (sql/format {:alter-table  (keyword table-name)
+    (first (sql/format {:alter-table  (quote-table table-name)
                         :alter-column (map (fn [[column-name type-and-constraints]]
                                              (vec (cons (quote-identifier column-name)
                                                         (if (string? type-and-constraints)

--- a/src/metabase/driver/sql_jdbc/sync/interface.clj
+++ b/src/metabase/driver/sql_jdbc/sync/interface.clj
@@ -2,6 +2,7 @@
   (:require
    [honey.sql :as sql]
    [metabase.driver :as driver]
+   [metabase.driver.sql-jdbc.quoting :refer [quote-identifier with-quoting]]
    [metabase.driver.sql.query-processor :as sql.qp]))
 
 (defmulti active-tables
@@ -126,14 +127,6 @@
   {:added "0.49.0" :arglists '([driver conn-spec & args])}
   driver/dispatch-on-initialized-driver
   :hierarchy #'driver/hierarchy)
-
-(defmacro ^:private with-quoting [driver & body]
-  `(binding [sql/*dialect* (sql/get-dialect (sql.qp/quote-style ~driver))
-             sql/*quoted*  true]
-     ~@body))
-
-(defn- quote-identifier [ref]
-  [:raw (sql/format-entity ref)])
 
 (defmulti alter-columns-sql
   "Generate the query to be used with [[driver/alter-columns!]]."

--- a/src/metabase/driver/sql_jdbc/sync/interface.clj
+++ b/src/metabase/driver/sql_jdbc/sync/interface.clj
@@ -2,7 +2,7 @@
   (:require
    [honey.sql :as sql]
    [metabase.driver :as driver]
-   [metabase.driver.sql-jdbc.quoting :refer [with-quoting  quote-identifier quote-table]]
+   [metabase.driver.sql-jdbc.quoting :refer [with-quoting  quote-identifier]]
    [metabase.driver.sql.query-processor :as sql.qp]))
 
 (defmulti active-tables
@@ -137,7 +137,7 @@
 (defmethod alter-columns-sql :sql-jdbc
   [driver table-name column-definitions]
   (with-quoting driver
-    (first (sql/format {:alter-table  (quote-table table-name)
+    (first (sql/format {:alter-table  (keyword table-name)
                         :alter-column (map (fn [[column-name type-and-constraints]]
                                              (vec (cons (quote-identifier column-name)
                                                         (if (string? type-and-constraints)


### PR DESCRIPTION
This DRY's up all the quoting helpers, fixes one more spot that was hiding, and updates our dependency.

**Don't merge this until we've updated the Clickhouse driver**

### TODO

- [x] Merge https://github.com/ClickHouse/metabase-clickhouse-driver/pull/273
- [ ] Cut Clickhouse version release
- [ ] Update https://github.com/metabase/metabase-registry/blob/main/registry.yaml