### PR TITLE
fix(sdk): fix zindex issues after switch to portals

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkPortalContainer.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkPortalContainer.tsx
@@ -20,4 +20,7 @@ const FixedPosition = styled.div`
   position: fixed;
   left: 0;
   top: 0;
+
+  // TODO: allow users to change this and document the behaviour
+  z-index: 1000;
 `;

--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkPortalContainer.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkPortalContainer.tsx
@@ -1,6 +1,9 @@
 import styled from "@emotion/styled";
 
-import { EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID } from "embedding-sdk/config";
+import {
+  EMBEDDING_SDK_FULL_PAGE_PORTAL_ROOT_ELEMENT_ID,
+  EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID,
+} from "embedding-sdk/config";
 
 import { PublicComponentStylesWrapper } from "./PublicComponentStylesWrapper";
 
@@ -9,9 +12,17 @@ import { PublicComponentStylesWrapper } from "./PublicComponentStylesWrapper";
  * so that it has our styles applied.
  * Mantine components needs to have the defaultProps set to use `EMBEDDING_SDK_PORTAL_CONTAINER_ELEMENT_ID` as target for the portal
  */
+export const FullPagePortalContainer = () => (
+  <PublicComponentStylesWrapper>
+    <FixedPosition
+      id={EMBEDDING_SDK_FULL_PAGE_PORTAL_ROOT_ELEMENT_ID}
+    ></FixedPosition>
+  </PublicComponentStylesWrapper>
+);
+
 export const PortalContainer = () => (
   <PublicComponentStylesWrapper>
-    <FixedPosition id={EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID}></FixedPosition>
+    <div id={EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID}></div>
   </PublicComponentStylesWrapper>
 );
 

--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkUsageProblem/index.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkUsageProblem/index.tsx
@@ -1,4 +1,4 @@
-import { EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID } from "embedding-sdk/config";
+import { EMBEDDING_SDK_FULL_PAGE_PORTAL_ROOT_ELEMENT_ID } from "embedding-sdk/config";
 import { useSdkUsageProblem } from "embedding-sdk/hooks/private/use-sdk-usage-problem";
 import type { SDKConfig } from "embedding-sdk/types";
 import { Box, Portal } from "metabase/ui";
@@ -18,7 +18,7 @@ export const SdkUsageProblemDisplay = ({ config }: Props) => {
   }
 
   return (
-    <Portal target={`#${EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID}`}>
+    <Portal target={`#${EMBEDDING_SDK_FULL_PAGE_PORTAL_ROOT_ELEMENT_ID}`}>
       <Box pos="fixed" bottom="15px" left="15px" className={S.BannerContainer}>
         <SdkUsageProblemBanner problem={usageProblem} />
       </Box>

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabaseProvider.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabaseProvider.tsx
@@ -24,7 +24,10 @@ import { EmotionCacheProvider } from "metabase/styled-components/components/Emot
 
 import { SCOPED_CSS_RESET } from "../private/PublicComponentStylesWrapper";
 import { SdkFontsGlobalStyles } from "../private/SdkGlobalFontsStyles";
-import { PortalContainer } from "../private/SdkPortalContainer";
+import {
+  FullPagePortalContainer,
+  PortalContainer,
+} from "../private/SdkPortalContainer";
 import { SdkUsageProblemDisplay } from "../private/SdkUsageProblem";
 
 import "metabase/css/index.module.css";
@@ -90,6 +93,7 @@ export const MetabaseProviderInternal = ({
           {children}
           <SdkUsageProblemDisplay config={config} />
           <PortalContainer />
+          <FullPagePortalContainer />
         </div>
       </SdkThemeProvider>
     </EmotionCacheProvider>

--- a/enterprise/frontend/src/embedding-sdk/config.ts
+++ b/enterprise/frontend/src/embedding-sdk/config.ts
@@ -1,6 +1,8 @@
 export const DEFAULT_FONT = "Lato";
 export const EMBEDDING_SDK_ROOT_ELEMENT_ID = "metabase-sdk-root";
 export const EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID = "metabase-sdk-portal-root";
+export const EMBEDDING_SDK_FULL_PAGE_PORTAL_ROOT_ELEMENT_ID =
+  "metabase-sdk-full-page-portal-root";
 
 export const getEmbeddingSdkVersion = () =>
   process.env.EMBEDDING_SDK_VERSION ?? "unknown";

--- a/enterprise/frontend/src/embedding-sdk/lib/theme/default-component-theme.ts
+++ b/enterprise/frontend/src/embedding-sdk/lib/theme/default-component-theme.ts
@@ -1,7 +1,10 @@
 import { merge } from "icepick";
 
 import type { MetabaseComponentTheme } from "embedding-sdk";
-import { EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID } from "embedding-sdk/config";
+import {
+  EMBEDDING_SDK_FULL_PAGE_PORTAL_ROOT_ELEMENT_ID,
+  EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID,
+} from "embedding-sdk/config";
 import type { DeepPartial } from "embedding-sdk/types/utils";
 import type { MantineThemeOverride } from "metabase/ui";
 
@@ -146,13 +149,13 @@ export function getEmbeddingComponentOverrides(
     ModalRoot: {
       defaultProps: {
         withinPortal: true,
-        target: `#${EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID}`,
+        target: `#${EMBEDDING_SDK_FULL_PAGE_PORTAL_ROOT_ELEMENT_ID}`,
       }, //  satisfies Partial<ModalRootProps>,
     },
     Modal: {
       defaultProps: {
         withinPortal: true,
-        target: `#${EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID}`,
+        target: `#${EMBEDDING_SDK_FULL_PAGE_PORTAL_ROOT_ELEMENT_ID}`,
       }, // satisfies Partial<ModalProps>,
     },
     Popover: {


### PR DESCRIPTION
Fixes https://metaboat.slack.com/archives/C063Q3F1HPF/p1727862906441629 and similar issues

### Description

This is the "minimum viable fix" as handling z-index on an sdk is not an easy issue and we have other priorities at the moment.

Before this zindex change I tried to put `isolation:isolate` on the MetabaseProvide, on the Public component wrapper and on the Portal hoping it would work. It works for simple cases but it failed on shoppy where we use Mantine modals in the app, and they use a portal that renders below our portal, making popovers broken.

# Demo
<img width="1452" alt="image" src="https://github.com/user-attachments/assets/a3b92305-5ed6-46b0-a855-89c7f3ec383f">


