### PR TITLE
Verify minimum appdb version

### DIFF
--- a/docs/installation-and-operation/migrating-from-h2.md
+++ b/docs/installation-and-operation/migrating-from-h2.md
@@ -104,9 +104,9 @@ Metabase provides a custom migration command for migrating to a new application 
 - [1. Confirm that you can connect to your target application database](#1-confirm-that-you-can-connect-to-your-target-application-database-1)
 - [2. Back up your H2 application database](#2-back-up-your-h2-application-database)
 - [3. Stop the existing Metabase container](#3-stop-the-existing-metabase-container)
-- [3. Download the JAR](#3-download-the-jar)
-- [4. Run the migration command](#4-run-the-migration-command)
-- [5. Start a new Docker container that uses the new app db](#5-start-a-new-docker-container-that-uses-the-new-app-db)
+- [4. Download the JAR](#4-download-the-jar)
+- [5. Run the migration command](#5-run-the-migration-command)
+- [6. Start a new Docker container that uses the new app db](#6-start-a-new-docker-container-that-uses-the-new-app-db)
 - [7. Remove the old container that was using the H2 database](#7-remove-the-old-container-that-was-using-the-h2-database)
 
 ### 1. Confirm that you can connect to your target application database
@@ -123,13 +123,13 @@ If you don't back up your H2 database, and you replace or delete your container,
 
 You don't want people creating new stuff in your Metabase while you're migrating.
 
-### 3. Download the JAR
+### 4. Download the JAR
 
 In the directory where you saved your H2 file (that is, outside the container), [download the JAR](https://github.com/metabase/metabase/releases) for your current version.
 
 Make sure you use the same version of Metabase you've been using. If you want to upgrade, perform the upgrade after you've confirmed the migration is successful.
 
-### 4. Run the migration command
+### 5. Run the migration command
 
 Create another copy of your H2 file that you extracted from the container when you backed up your app db (step 2).
 
@@ -145,7 +145,7 @@ Metabase will start up, perform the migration (meaning, it'll take the data from
 
 See [Configuring the application database](configuring-application-database.md).
 
-### 5. Start a new Docker container that uses the new app db
+### 6. Start a new Docker container that uses the new app db
 
 With your new application database populated with your Metabase data, you can start a new container and tell the Metabase in the container to connect to the appdb. The command will looks something like this:
 

--- a/modules/drivers/mongo/src/metabase/driver/mongo.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo.clj
@@ -15,7 +15,6 @@
    [metabase.driver.mongo.parameters :as mongo.params]
    [metabase.driver.mongo.query-processor :as mongo.qp]
    [metabase.driver.mongo.util :as mongo.util]
-   [metabase.driver.util :as driver.u]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.lib.schema.common :as lib.schema.common]
@@ -24,6 +23,7 @@
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
+   [metabase.util.version :as version]
    [taoensso.nippy :as nippy])
   (:import
    (com.mongodb.client MongoClient MongoDatabase)
@@ -412,26 +412,26 @@
   [_driver _feature db]
   (-> ((some-fn :dbms-version :dbms_version) db)
       :semantic-version
-      (driver.u/semantic-version-gte [4 2])))
+      (version/semantic-version-gte [4 2])))
 
 (defmethod driver/database-supports? [:mongo :date-arithmetics]
   [_driver _feature db]
   (-> ((some-fn :dbms-version :dbms_version) db)
       :semantic-version
-      (driver.u/semantic-version-gte [5])))
+      (version/semantic-version-gte [5])))
 
 (defmethod driver/database-supports? [:mongo :datetime-diff]
   [_driver _feature db]
   (-> ((some-fn :dbms-version :dbms_version) db)
       :semantic-version
-      (driver.u/semantic-version-gte [5])))
+      (version/semantic-version-gte [5])))
 
 (defmethod driver/database-supports? [:mongo :now]
   ;; The $$NOW aggregation expression was introduced in version 4.2.
   [_driver _feature db]
   (-> ((some-fn :dbms-version :dbms_version) db)
       :semantic-version
-      (driver.u/semantic-version-gte [4 2])))
+      (version/semantic-version-gte [4 2])))
 
 (defmethod driver/database-supports? [:mongo :native-requires-specified-collection]
   [_driver _feature _db]

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -14,7 +14,6 @@
                                             $group $gt $gte $hour $limit $literal $lookup $lt $lte $match $max $min
                                             $minute $mod $month $multiply $ne $not $or $project $regexMatch $second
                                             $size $skip $sort $strcasecmp $subtract $sum $toLower $unwind $year]]
-   [metabase.driver.util :as driver.u]
    [metabase.legacy-mbql.schema :as mbql.s]
    [metabase.legacy-mbql.util :as mbql.u]
    [metabase.lib.metadata :as lib.metadata]
@@ -32,7 +31,8 @@
    [metabase.util.date-2 :as u.date]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
-   [metabase.util.malli :as mu])
+   [metabase.util.malli :as mu]
+   [metabase.util.version :as version])
   (:import
    (org.bson BsonBinarySubType)
    (org.bson.types Binary ObjectId)))
@@ -317,7 +317,7 @@
     field
     (let [supports-dateTrunc? (-> (get-mongo-version)
                                   :semantic-version
-                                  (driver.u/semantic-version-gte [5]))
+                                  (version/semantic-version-gte [5]))
           column field]
       (letfn [(truncate [unit]
                 (if supports-dateTrunc?
@@ -535,7 +535,7 @@
 (defmethod ->rvalue :replace
   [[_ & args]]
   (let [version (get-mongo-version)]
-    (if (driver.u/semantic-version-gte (:semantic-version version) [4 4])
+    (if (version/semantic-version-gte (:semantic-version version) [4 4])
       (let [[expr fnd replacement] (mapv ->rvalue args)]
         {"$replaceAll" {"input" expr "find" fnd "replacement" replacement}})
       (throw (ex-info "Replace requires MongoDB 4.4 or above"

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -11,7 +11,6 @@
    [metabase.driver :as driver]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
-   [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.models.setting :refer [defsetting]]
    [metabase.public-settings.premium-features :as premium-features]
@@ -284,26 +283,6 @@
   (set (for [driver (descendants driver/hierarchy :metabase.driver/driver)
              :when  (driver/available? driver)]
          driver)))
-
-(mu/defn semantic-version-gte :- :boolean
-  "Returns true if xv is greater than or equal to yv according to semantic versioning.
-   xv and yv are sequences of integers of the form `[major minor ...]`, where only
-   major is obligatory.
-   Examples:
-   (semantic-version-gte [4 1] [4 1]) => true
-   (semantic-version-gte [4 0 1] [4 1]) => false
-   (semantic-version-gte [4 1] [4]) => true
-   (semantic-version-gte [3 1] [4]) => false"
-  [xv :- [:maybe [:sequential ::lib.schema.common/int-greater-than-or-equal-to-zero]]
-   yv :- [:maybe [:sequential ::lib.schema.common/int-greater-than-or-equal-to-zero]]]
-  (loop [xv (seq xv), yv (seq yv)]
-    (or (nil? yv)
-        (let [[x & xs] xv
-              [y & ys] yv
-              x (if (nil? x) 0 x)
-              y (if (nil? y) 0 y)]
-          (or (> x y)
-              (and (>= x y) (recur xs ys)))))))
 
 (defn- file-upload-props [{prop-name :name, visible-if :visible-if, disp-nm :display-name, :as conn-prop}]
   (if (premium-features/is-hosted?)

--- a/src/metabase/util/version.clj
+++ b/src/metabase/util/version.clj
@@ -1,0 +1,53 @@
+(ns metabase.util.version
+  "Utilities for version comparison and database version checking."
+  (:require [metabase.lib.schema.common :as lib.schema.common]
+            [metabase.util.log :as log]
+            [metabase.util.malli :as mu]))
+
+(set! *warn-on-reflection* true)
+
+(mu/defn semantic-version-gte :- :boolean
+  "Returns true if xv is greater than or equal to yv according to semantic versioning.
+   xv and yv are sequences of integers of the form `[major minor ...]`, where only
+   major is obligatory.
+   Examples:
+   (semantic-version-gte [4 1] [4 1]) => true
+   (semantic-version-gte [4 0 1] [4 1]) => false
+   (semantic-version-gte [4 1] [4]) => true
+   (semantic-version-gte [3 1] [4]) => false"
+  [xv :- [:maybe [:sequential ::lib.schema.common/int-greater-than-or-equal-to-zero]]
+   yv :- [:maybe [:sequential ::lib.schema.common/int-greater-than-or-equal-to-zero]]]
+  (loop [xv (seq xv), yv (seq yv)]
+    (or (nil? yv)
+        (let [[x & xs] xv
+              [y & ys] yv
+              x (if (nil? x) 0 x)
+              y (if (nil? y) 0 y)]
+          (or (> x y)
+              (and (>= x y) (recur xs ys)))))))
+
+(mu/defn get-db-version
+  "Get database version information from JDBC connection metadata."
+  [^java.sql.Connection conn]
+  (let [metadata (.getMetaData conn)]
+    {:flavor           (.getDatabaseProductName metadata)
+     :version          (.getDatabaseProductVersion metadata)
+     :semantic-version [(.getDatabaseMajorVersion metadata)
+                       (.getDatabaseMinorVersion metadata)]}))
+
+(mu/defn check-min-version
+  "Check if the database version meets minimum requirements."
+  [db-type version-info min-version]
+  (when (and min-version
+             (not= db-type :h2))  ; Skip version check for H2
+    (let [{:keys [flavor semantic-version]} version-info]
+      (when-not (semantic-version-gte semantic-version min-version)
+        (let [version-error-msg (format "%s version %d.%d is below the required version %d.%d."
+                                      flavor
+                                      (first semantic-version)
+                                      (second semantic-version)
+                                      (first min-version)
+                                      (second min-version))]
+          (log/error version-error-msg)
+          (throw (ex-info version-error-msg {:current-version semantic-version
+                                           :required-version min-version})))))))

--- a/test/metabase/driver/util_test.clj
+++ b/test/metabase/driver/util_test.clj
@@ -254,25 +254,6 @@
     "hi" "aGk="
     "hi" "data:application/octet-stream;base64,aGk="))
 
-(deftest ^:parallel semantic-version-gte-test
-  (testing "semantic-version-gte works as expected"
-    (are [x y] (driver.u/semantic-version-gte x y)
-      [5 0]   [4 0]
-      [5 0 1] [4 0]
-      [5 0]   [4 0 1]
-      [5 0]   [4 1]
-      [4 1]   [4 1]
-      [4 1]   [4]
-      [4]     [4]
-      [4]     [4 0 0])
-    (are [x y] (not (driver.u/semantic-version-gte x y))
-      [3]     [4]
-      [4]     [4 1]
-      [4 0]   [4 0 1]
-      [4 0 1] [4 1]
-      [3 9]   [4 0]
-      [3 1]   [4])))
-
 (deftest ^:parallel mark-h2-superseded-test
   (testing "H2 should have :superseded-by set so it doesn't show up in the list of available drivers in the UI DB edit forms"
     (is (=? {:driver-name "H2", :superseded-by :deprecated}

--- a/test/metabase/query_processor_test/explicit_joins_test.clj
+++ b/test/metabase/query_processor_test/explicit_joins_test.clj
@@ -5,7 +5,6 @@
    [clojure.test :refer :all]
    [metabase.driver :as driver]
    [metabase.driver.sql.query-processor-test-util :as sql.qp-test-util]
-   [metabase.driver.util :as driver.u]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
@@ -20,7 +19,8 @@
    [metabase.query-processor.test-util :as qp.test-util]
    [metabase.test :as mt]
    [metabase.test.data.interface :as tx]
-   [metabase.util.date-2 :as u.date]))
+   [metabase.util.date-2 :as u.date]
+   [metabase.util.version :as version]))
 
 (deftest ^:parallel explict-join-with-default-options-test
   (testing "Can we specify an *explicit* JOIN using the default options?"
@@ -1010,7 +1010,7 @@
   [_driver _feature database]
   (-> (:dbms_version database)
       :semantic-version
-      (driver.u/semantic-version-gte [5])))
+      (version/semantic-version-gte [5])))
 
 (deftest ^:parallel join-order-test
   (testing "Joins should be emitted in the same order as they were specified in MBQL (#15342)"

--- a/test/metabase/util/version_test.clj
+++ b/test/metabase/util/version_test.clj
@@ -1,0 +1,23 @@
+(ns metabase.util.version-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.util.version :as version]))
+
+(deftest ^:parallel semantic-version-gte-test
+  (testing "semantic-version-gte works as expected"
+    (are [x y] (version/semantic-version-gte x y)
+      [5 0]   [4 0]
+      [5 0 1] [4 0]
+      [5 0]   [4 0 1]
+      [5 0]   [4 1]
+      [4 1]   [4 1]
+      [4 1]   [4]
+      [4]     [4]
+      [4]     [4 0 0])
+    (are [x y] (not (version/semantic-version-gte x y))
+      [3]     [4]
+      [4]     [4 1]
+      [4 0]   [4 0 1]
+      [4 0 1] [4 1]
+      [3 9]   [4 0]
+      [3 1]   [4])))


### PR DESCRIPTION
> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform) 

_**Per above, please only provide feedback to this PR without merging as I am not yet able to agree to all terms of the *Contributor License Agreement.***_

Closes https://github.com/metabase/metabase/issues/36848

### Description

Adds a check in `verify-db-connection` for the default database version and fails with an error if the version is below the required version level depending on the default database type.

Version minimums ([source](https://www.metabase.com/docs/latest/installation-and-operation/migrating-from-h2#supported-databases-for-storing-your-metabase-application-data)):

- PostgreSQL: 12
- MariaDB: 10.4.0
- MySQL: 8.0.17

_Limitations_

H2 database version is not checked using this approach.

`verify-db-connection` only runs against the default database (pretty sure...), so a follow up task would be required for verifying all configured databases.

### How to verify

Start application with a MySQL or PostgreSQL default database that meets the minimum version requirements, and application startup _will not fail_ due to a minimum version error.

Start application with a MySQL or PostgreSQL default database that _does not_ meet the minimum version requirements, and application startup _will fail_ due to a minimum version error.

Per demo below, the version requirements can be edited to be above the default database's version to artificially produce the minimum version error.

### Demo

Example output below for unmet minimum version. An acceptable version of MySQL (9.0.1) was configured, but the required version was changed during testing too 10.0.17 to demonstrate the unmet version case. The error thrown halts the startup process.
  
![CleanShot 2024-09-28 at 12 45 41](https://github.com/user-attachments/assets/0c97a04f-1842-4842-86ed-7825d510b7b9)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
