### PR TITLE
Fix root collection links in sidebars

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardDetails.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardDetails.tsx
@@ -68,7 +68,7 @@ export const DashboardDetails = ({ dashboard }: { dashboard: Dashboard }) => {
           <div>
             <Text>
               <Link
-                to={`/collection/${dashboard.collection_id}`}
+                to={`/collection/${dashboard.collection_id ?? "root"}`}
                 variant="brand"
               >
                 {dashboard.collection?.name}

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardDetails.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardDetails.tsx
@@ -7,6 +7,7 @@ import { SidesheetCardSection } from "metabase/common/components/Sidesheet";
 import DateTime from "metabase/components/DateTime";
 import Link from "metabase/core/components/Link";
 import Styles from "metabase/css/core/index.css";
+import { collection as collectionUrl } from "metabase/lib/urls";
 import { getUserName } from "metabase/lib/user";
 import { DashboardPublicLinkPopover } from "metabase/sharing/components/PublicLinkPopover";
 import { Box, FixedSizeIcon, Flex, Text } from "metabase/ui";
@@ -54,29 +55,28 @@ export const DashboardDetails = ({ dashboard }: { dashboard: Dashboard }) => {
           </Flex>
         )}
       </SidesheetCardSection>
-      <SidesheetCardSection
-        title={c(
-          "This is a heading that appears above the name of a collection - a collection that a dashboard is saved in. Feel free to translate this heading as though it said 'Saved in collection', if you think that would make more sense in your language.",
-        ).t`Saved in`}
-      >
-        <Flex gap="sm" align="top">
-          <FixedSizeIcon
-            name="folder"
-            className={SidebarStyles.IconMargin}
-            color="var(--mb-color-brand)"
-          />
-          <div>
-            <Text>
-              <Link
-                to={`/collection/${dashboard.collection_id ?? "root"}`}
-                variant="brand"
-              >
-                {dashboard.collection?.name}
-              </Link>
-            </Text>
-          </div>
-        </Flex>
-      </SidesheetCardSection>
+      {dashboard.collection && (
+        <SidesheetCardSection
+          title={c(
+            "This is a heading that appears above the name of a collection - a collection that a dashboard is saved in. Feel free to translate this heading as though it said 'Saved in collection', if you think that would make more sense in your language.",
+          ).t`Saved in`}
+        >
+          <Flex gap="sm" align="top">
+            <FixedSizeIcon
+              name="folder"
+              className={SidebarStyles.IconMargin}
+              color="var(--mb-color-brand)"
+            />
+            <div>
+              <Text>
+                <Link to={collectionUrl(dashboard.collection)} variant="brand">
+                  {dashboard.collection?.name}
+                </Link>
+              </Text>
+            </div>
+          </Flex>
+        </SidesheetCardSection>
+      )}
       <SharingDisplay dashboard={dashboard} />
     </>
   );

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/tests/common.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/tests/common.unit.spec.ts
@@ -152,6 +152,25 @@ describe("DashboardInfoSidebar", () => {
     expect(await screen.findByText("My little collection")).toBeInTheDocument();
   });
 
+  it("should show root collection", async () => {
+    await setup({
+      dashboard: createMockDashboard({
+        collection_id: null,
+        collection: createMockCollection({
+          name: "Our analytics",
+          // @ts-expect-error - ye olde null root collection bugbear
+          id: null,
+        }),
+      }),
+    });
+
+    expect(screen.getByText("Saved in")).toBeInTheDocument();
+    expect(await screen.findByText("Our analytics")).toHaveAttribute(
+      "href",
+      "/collection/root",
+    );
+  });
+
   it("should not show Visibility section when not shared publicly", async () => {
     await setup();
     expect(screen.queryByText("Visibility")).not.toBeInTheDocument();

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/tests/setup.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/tests/setup.tsx
@@ -1,3 +1,5 @@
+import { Route } from "react-router";
+
 import { setupEnterprisePlugins } from "__support__/enterprise";
 import {
   setupDashboardEndpoints,
@@ -59,12 +61,17 @@ export async function setup({
   }
 
   renderWithProviders(
-    <DashboardInfoSidebar
-      dashboard={dashboard}
-      setDashboardAttribute={setDashboardAttribute}
-      onClose={onClose}
+    <Route
+      path="*"
+      component={() => (
+        <DashboardInfoSidebar
+          dashboard={dashboard}
+          setDashboardAttribute={setDashboardAttribute}
+          onClose={onClose}
+        />
+      )}
     />,
-    { storeInitialState: state },
+    { storeInitialState: state, withRouter: true },
   );
   await waitForLoaderToBeRemoved();
 

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/QuestionDetails.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/QuestionDetails.tsx
@@ -63,7 +63,7 @@ export const QuestionDetails = ({ question }: { question: Question }) => {
           />
           <Text>
             <Link
-              to={`/collection/${question.collection()?.id}`}
+              to={`/collection/${question.collectionId() ?? "root"}`}
               variant="brand"
             >
               {question.collection()?.name}

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/tests/common.unit.spec.tsx
@@ -98,6 +98,21 @@ describe("QuestionInfoSidebar", () => {
       expect(screen.getByText("My Big Collection")).toBeInTheDocument();
     });
 
+    it("should show correct link for root collection", () => {
+      const card = createMockCard({
+        name: "Question",
+        // @ts-expect-error - ye olde null root collection bugbear
+        collection: createMockCollection({ id: null, name: "Our analytics" }),
+        collection_id: null,
+      });
+      setup({ card });
+
+      expect(screen.getByText("Our analytics")).toHaveAttribute(
+        "href",
+        "/collection/root",
+      );
+    });
+
     it("should show source information", () => {
       const card = createMockCard({
         name: "Question",


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/48257

### Description

Ye olde root collection has a null id rears its ugly head again.

### How to verify

- Questions and Dashboards in the root collection now have links to `/collection/root` instead of `/collection/null` in their sidebars

![Screen Shot 2024-10-02 at 8 23 23 AM](https://github.com/user-attachments/assets/d9f43f10-08bc-41e9-bde8-0fadb2a02db9)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
