### PR TITLE
Expose more basic table analysis from Macaw

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -80,7 +80,7 @@
   io.github.eerohele/pp                     {:git/tag "2024-01-04.60"           ; super fast pretty-printing library
                                              :git/sha "a428751"
                                              :git/url "https://github.com/eerohele/pp"}
-  io.github.metabase/macaw                  {:mvn/version "0.2.10"}             ; Parse native SQL queries
+  io.github.metabase/macaw                  {:mvn/version "0.2.15"}             ; Parse native SQL queries
   ;; The 2.X line of Resilience4j requires Java 17, so we cannot upgrade this dependency until that is our minimum JVM version
   io.github.resilience4j/resilience4j-retry {:mvn/version "1.7.1" #_"must be 1.7.1"} ; Support for retrying operations
   io.prometheus/simpleclient_hotspot        {:mvn/version "0.16.0"}             ; prometheus jvm collector

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -695,7 +695,10 @@
     ;; Whether the driver supports loading dynamic test datasets on each test run. Eg. datasets with names like
     ;; `checkins:4-per-minute` are created dynamically in each test run. This should be truthy for every driver we test
     ;; against except for Athena and Databricks which currently require test data to be loaded separately.
-    :test/dynamic-dataset-loading})
+    :test/dynamic-dataset-loading
+
+    ;; Whether the driver is officially supported by Metabase's query parser.
+    :sql-parsing})
 
 (defmulti database-supports?
   "Does this driver and specific instance of a database support a certain `feature`?

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -695,10 +695,7 @@
     ;; Whether the driver supports loading dynamic test datasets on each test run. Eg. datasets with names like
     ;; `checkins:4-per-minute` are created dynamically in each test run. This should be truthy for every driver we test
     ;; against except for Athena and Databricks which currently require test data to be loaded separately.
-    :test/dynamic-dataset-loading
-
-    ;; Whether the driver is officially supported by Metabase's query parser.
-    :sql-parsing})
+    :test/dynamic-dataset-loading})
 
 (defmulti database-supports?
   "Does this driver and specific instance of a database support a certain `feature`?

--- a/src/metabase/query_analysis/native_query_analyzer.clj
+++ b/src/metabase/query_analysis/native_query_analyzer.clj
@@ -183,16 +183,15 @@
 
 (defn- table-refs-for-query
   "Given the results of query analysis, return references to the corresponding tables and cards."
-  [{table-maps :tables} db-id]
-  (let [tables (map :component table-maps)]
-    (consolidate-tables
-     tables
-     (t2/select :model/QueryTable
-                {:select [[:t.id :table-id] [:t.name :table] [:t.schema :schema]]
-                 :from   [[(t2/table-name :model/Table) :t]]
-                 :where  [:and
-                          [:= :t.db_id db-id]
-                          (into [:or] (map table-query tables))]}))))
+  [tables db-id]
+  (consolidate-tables
+   tables
+   (t2/select :model/QueryTable
+              {:select [[:t.id :table-id] [:t.name :table] [:t.schema :schema]]
+               :from   [[(t2/table-name :model/Table) :t]]
+               :where  [:and
+                        [:= :t.db_id db-id]
+                        (into [:or] (map table-query tables))]})))
 
 (defn- fill-missing-table-ids-hack
   "See if we can qualify the schema and table-id for any explicit field refs which couldn't resolve their field"
@@ -276,7 +275,8 @@
         macaw-opts    (nqa.impl/macaw-options driver)
         sql-string    (:query (nqa.sub/replace-tags query))
         parsed-query  (macaw/query->components (macaw/parsed-query sql-string macaw-opts) macaw-opts)
-        table-refs    (table-refs-for-query parsed-query db-id)
+        tables        (map :component (:tables parsed-query))
+        table-refs    (table-refs-for-query tables db-id)
         explicit-refs (explicit-field-refs-for-query parsed-query db-id table-refs)
         implicit-refs (-> (implicit-references-for-query parsed-query db-id)
                           (set/difference explicit-refs))
@@ -284,6 +284,29 @@
                               (mark-reference implicit-refs false))]
     {:tables (strip-model-refs table-refs)
      :fields (strip-model-refs field-refs)}))
+
+;; tmp - waiting for macaw version bump
+(defn- raw-components [xs]
+  (into (empty xs) (keep :component) xs))
+
+;; tmp - waiting for macaw version bump
+(defn- query->tables
+  [sql & {:as opts}]
+  (-> (macaw/parsed-query sql)
+      (macaw/query->components opts)
+      :tables
+      raw-components))
+
+(defn- tables-for-sql
+  "Returns a set of table identifiers that (may) be referenced in the given card's query.
+  Errs on the side of optimism: i.e., it may return talbes that are *not* in the query, and is unlikely to fail
+  to return tables that are in the query."
+  [driver query]
+  (let [db-id         (:database query)
+        macaw-opts    (nqa.impl/macaw-options driver)
+        sql-string    (:query (nqa.sub/replace-tags query))
+        parsed-query  (#_macaw/query->tables query->tables sql-string macaw-opts)]
+    (table-refs-for-query parsed-query db-id)))
 
 (defn references-for-native
   "Returns a `{:explicit #{...} :implicit #{...}}` map with field IDs that (may) be referenced in the given card's
@@ -294,3 +317,12 @@
     ;; See https://github.com/metabase/metabase/issues/43516 for long term solution.
     (when (isa? driver/hierarchy driver :sql)
       (references-for-sql driver query))))
+
+(defn tables-for-native
+  "TODO"
+  [query]
+  (let [driver (driver.u/database->driver (:database query))]
+    ;; TODO this approach is not extensible, we need to move to multimethods.
+    ;; See https://github.com/metabase/metabase/issues/43516 for long term solution.
+    (when (isa? driver/hierarchy driver :sql)
+      (tables-for-sql driver query))))

--- a/src/metabase/query_analysis/native_query_analyzer.clj
+++ b/src/metabase/query_analysis/native_query_analyzer.clj
@@ -308,7 +308,9 @@
       (references-for-sql driver query))))
 
 (defn tables-for-native
-  "TODO"
+  "Returns a set of table identifiers that (may) be referenced in the given card's query.
+  Takes an options :mode option, which determines the complexity of queries it can handle, and what types of false
+  positives it may return."
   [query & {:as opts}]
   (let [driver (driver.u/database->driver (:database query))]
     ;; TODO this approach is not extensible, we need to move to multimethods.

--- a/src/metabase/query_analysis/native_query_analyzer/impl.cljc
+++ b/src/metabase/query_analysis/native_query_analyzer/impl.cljc
@@ -10,7 +10,13 @@
 (def ^:private considered-drivers
   "Since we are unable to ask basic questions of the driver hierarchy outside of that module, we need to explicitly
   mention all sub-types. This is probably not a bad thing."
-  #{:mysql :sqlserver :h2 :sqlite :postgres :redshift})
+  #{:h2 :mysql :postgres :redshift :sqlite :sqlserver})
+
+;; At some point, we may want a way for 3rd party drivers to opt in, but a public API deserves some hammock time.
+;; Using a separate list to the above, as we may want this to be more restrictive.
+(def trusted-for-table-permissions?
+  "Do we trust that Macaw will not give us false negatives for tables referenced by a given query?"
+  #{:h2 :mysql :postgres :redshift :sqlite :sqlserver})
 
 (defn macaw-options
   "Generate the options expected by Macaw based on the nature of the given driver."

--- a/test/metabase/query_analysis/native_query_analyzer_test.clj
+++ b/test/metabase/query_analysis/native_query_analyzer_test.clj
@@ -52,7 +52,7 @@
 
 (defn- basic-table-refs [sql]
   (->> (mt/native-query {:query sql})
-       (#'nqa/tables-for-native)
+       (nqa/tables-for-native)
        (sort-by (juxt :schema :table))))
 
 (defn- table-reference [table]

--- a/test/metabase/query_analysis/native_query_analyzer_test.clj
+++ b/test/metabase/query_analysis/native_query_analyzer_test.clj
@@ -1,4 +1,4 @@
-(ns metabase.query-analysis.native-query-analyzer-test
+(ns ^:parallel metabase.query-analysis.native-query-analyzer-test
   (:require
    [clojure.test :refer :all]
    [metabase.driver :as driver]
@@ -6,7 +6,7 @@
    [metabase.test :as mt]
    [metabase.util :as u]))
 
-(deftest ^:parallel field-quoting-test
+(deftest field-quoting-test
   (testing "unquoted fields are case-insensitive"
     (is (= [:= [:lower :f.name] "test"]
            (#'nqa/field-query :f.name "test")
@@ -19,7 +19,7 @@
            ;; this is "Perv""e""rse"
            (#'nqa/field-query :f.name "\"Perv\"\"e\"\"rse\"")))))
 
-(deftest ^:parallel consolidate-columns-test
+(deftest consolidate-columns-test
   (testing "We match references with known fields where possible, and remove redundancies"
     (is (= [{:field-id 1, :table "t1", :column "c1"}
             {:field-id 2, :table "t3", :column "c1"}
@@ -86,14 +86,14 @@
     ;; the table might be resolved...
     (nqa/table-reference (mt/id) schema table))))
 
-(deftest ^:parallel field-matching-simple-test
+(deftest field-matching-simple-test
   (testing "simple query matches"
     (let [sql "select id from venues"]
       (is (= [(field-reference :venues :id)] (field-refs sql)))
       (is (= [(table-reference :venues)] (table-refs sql)))
       (is (= [(table-reference :venues)] (basic-table-refs sql))))))
 
-(deftest ^:parallel field-matching-schema-test
+(deftest field-matching-schema-test
   (testing "real existent schema"
     (let [sql "select id from public.venues"]
       (is (= [(field-reference :venues :id)] (field-refs sql)))
@@ -105,7 +105,7 @@
       (is (= [{:schema "blah", :table "venues"}] (table-refs sql)))
       (is (= [{:schema "blah", :table "venues"}] (basic-table-refs sql))))))
 
-(deftest ^:parallel field-matching-case-test
+(deftest field-matching-case-test
   (testing "quotes stop case matching"
     (is (= [(missing-field-reference :venues :id)] (field-refs "select \"id\" from venues")))
     (is (= [(field-reference :venues :id)] (field-refs "select \"ID\" from venues"))))
@@ -140,7 +140,7 @@
             (field-reference :venues :name)]
            (field-refs "select v.`ID`, v.name from venues v")))))
 
-(deftest ^:parallel field-matching-multi-test
+(deftest field-matching-multi-test
   (testing "It will find all relevant columns if query is not specific"
     (is (= [(field-reference :checkins :id)
             (field-reference :venues :id)]
@@ -154,13 +154,13 @@
     (is (= {false 6}
            (frequencies (map :explicit-reference (field-refs "select v.* from venues v join checkins")))))))
 
-(deftest ^:parallel pseudo-table-fields-tests
+(deftest pseudo-table-fields-tests
   (testing "When macaw returns an unknown field without a table, we keep it even if it could be phantom."
     ;; At the time of writing this test, Macaw would (incorrectly) return "week" as an ambiguous source column.
     (is (= [{:column "some_exotic_constant", :explicit-reference true}]
            (field-refs "SELECT some_exotic_constant")))))
 
-(deftest ^:parallel field-matching-keywords-test
+(deftest field-matching-keywords-test
   (when (not (contains? #{:snowflake :oracle} driver/*driver*))
     (testing "Analysis does not fail due to keywords that are only reserved in other databases"
       (is (= [(field-reference :venues :id)]
@@ -168,7 +168,7 @@
       (is (= [(missing-field-reference :venues :final)]
              (field-refs "select final from venues"))))))
 
-(deftest ^:parallel table-without-field-reference-test
+(deftest table-without-field-reference-test
   (testing "We track table dependencies even when there are no fields being used"
     (is (= {:tables [(table-reference :venues)]
             :fields []}


### PR DESCRIPTION
This is the glue to expose the new more conservative analysis being added to Macaw for table permission checking.

- [x] Bump Macaw
- [x] Use actual Macaw API
- [x] ~~Add a way to opt-in driver by driver~~
- [x] Put a hard restriction on the drivers we support, in a non-extensible way.