### PR TITLE
Rename number of decimal places setting

### DIFF
--- a/docs/data-modeling/formatting.md
+++ b/docs/data-modeling/formatting.md
@@ -27,7 +27,7 @@ The options you'll see here will depend on the field's type. They're generally t
 - `Show a mini bar chart:` only applies to table visualizations. Displays a bar for each value to show large or small it is relative to the other values in the column.
 - `Style:` lets you choose to display the number as a plain number, a percent, in scientific notation, or as a currency.
 - `Separator style:` this gives you various options for how commas and periods are used to separate the number.
-- `Minimum number of decimal places:` forces the number to be displayed with exactly this many decimal places.
+- `Number of decimal places:` forces the number to be displayed with exactly this many decimal places.
 - `Multiply by a number:` multiplies this number by whatever you type here.
 - `Add a prefix/suffix:` lets you put a symbol, word, etc. before or after this number.
 

--- a/docs/questions/sharing/visualizations/table.md
+++ b/docs/questions/sharing/visualizations/table.md
@@ -171,7 +171,7 @@ Gives you various options for how commas and periods are used to separate the nu
 - 100000.00
 - 100'000.00
 
-### Minimum number of decimal places
+### Number of decimal places
 
 Forces the number to be displayed with exactly this many decimal places.
 

--- a/e2e/test/scenarios/visualizations-tabular/smartscalar-trend.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/smartscalar-trend.cy.spec.js
@@ -389,10 +389,7 @@ describe("scenarios > visualizations > trend chart (SmartScalar)", () => {
     cy.findByTestId("scalar-container").findByText("34’400%");
 
     // decimal places
-    cy.findByLabelText("Minimum number of decimal places")
-      .click()
-      .type("4")
-      .blur();
+    cy.findByLabelText("Number of decimal places").click().type("4").blur();
     cy.findByTestId("scalar-container").findByText("34’400.0000%");
 
     // multiply by a number

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -362,7 +362,7 @@ export const NUMBER_COLUMN_SETTINGS = {
     getDefault: getDefaultNumberSeparators,
   },
   decimals: {
-    title: t`Minimum number of decimal places`,
+    title: t`Number of decimal places`,
     widget: "number",
     props: {
       placeholder: "1",


### PR DESCRIPTION
[Slack convo](https://metaboat.slack.com/archives/C01LQQ2UW03/p1727899018915509?thread_ts=1727883391.793229&cid=C01LQQ2UW03)

Renames "Minimum number of decimal places" columns formatting setting to "Number of decimal places" which is technically a more correct label