### PR TITLE
Tweak areas emphasis style when hovered

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/constants/style.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/constants/style.ts
@@ -56,6 +56,8 @@ export const CHART_STYLE = {
   opacity: {
     blur: 0.3,
     area: 0.3,
+    areaFocused: 0.6,
+    areaBlurred: 0.2,
     scatter: 0.8,
   },
 };

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -584,6 +584,9 @@ const buildEChartsLineAreaSeries = (
         color: seriesModel.color,
         opacity: 1,
       },
+      areaStyle: {
+        opacity: CHART_STYLE.opacity.areaFocused,
+      },
     },
     blur: {
       label: getBlurLabelStyle(settings, hasMultipleSeries),
@@ -593,7 +596,7 @@ const buildEChartsLineAreaSeries = (
       lineStyle: {
         opacity: blurOpacity,
       },
-      areaStyle: { opacity: CHART_STYLE.opacity.area },
+      areaStyle: { opacity: CHART_STYLE.opacity.areaBlurred },
     },
     z: Z_INDEXES.lineAreaSeries,
     id: seriesModel.dataKey,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/48267

### Description

Emphasizes hovered areas a bit more.

### Demo

#### Stacked

Before
<img width="1638" alt="Screenshot 2024-10-02 at 7 16 51 PM" src="https://github.com/user-attachments/assets/23b26d66-2eb4-41a0-89ac-0a7325f809b4">

After
<img width="1606" alt="Screenshot 2024-10-02 at 7 16 29 PM" src="https://github.com/user-attachments/assets/bc88ebae-3793-47f3-9893-b0aca7354527">

#### Non-stacked

Before
<img width="1322" alt="Screenshot 2024-10-02 at 7 18 28 PM" src="https://github.com/user-attachments/assets/ffda13d8-06a1-437f-9afe-a00947e2f88d">

After
<img width="1318" alt="Screenshot 2024-10-02 at 7 18 18 PM" src="https://github.com/user-attachments/assets/9b6df702-0fa4-48b2-a5b2-f8aa4c521d4b">

