### PR TITLE
Fix redundant `isSmallAppBar` prop warning

### DIFF
--- a/frontend/src/metabase/nav/components/AppBar/AppBarLogo.styled.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLogo.styled.tsx
@@ -1,9 +1,12 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 
+import { doNotForwardProps } from "metabase/common/utils/doNotForwardProps";
 import Link from "metabase/core/components/Link";
 
-export const LogoLink = styled(Link)<{ isSmallAppBar: boolean }>`
+export const LogoLink = styled(Link, doNotForwardProps("isSmallAppBar"))<{
+  isSmallAppBar: boolean;
+}>`
   cursor: pointer;
   display: flex;
   align-items: center;


### PR DESCRIPTION
### Description

Fixes this warning:

![image](https://github.com/user-attachments/assets/665139d7-056a-4d68-bc22-ccf6afe4b385)


### How to verify

Open app on the index page. There should be no warning in JS console.