### PR TITLE
make tests pass on 46970-milestone-2

### DIFF
--- a/e2e/snapshot-creators/default.cy.snap.js
+++ b/e2e/snapshot-creators/default.cy.snap.js
@@ -91,7 +91,10 @@ describe("snapshots", () => {
 
   function updateSettings() {
     updateSetting("enable-public-sharing", true);
-    updateSetting("enable-embedding", true).then(() => {
+    // interactive is not enabled in the snapshots as it requires a premium feature
+    // updateSetting("enable-embedding-interactive", true);
+    updateSetting("enable-embedding-sdk", true);
+    updateSetting("enable-embedding-static", true).then(() => {
       updateSetting("embedding-secret-key", METABASE_SECRET_KEY);
     });
 

--- a/e2e/support/helpers/api/updateSetting.ts
+++ b/e2e/support/helpers/api/updateSetting.ts
@@ -7,5 +7,10 @@ export const updateSetting = <
   setting: TKey,
   value: TValue,
 ): Cypress.Chainable<Cypress.Response<never>> => {
+  // TODO: remove before merging integration branch
+  if (setting === "enable-embedding-static") {
+    updateSetting("enable-embedding", value as boolean);
+  }
+
   return cy.request<never>("PUT", `/api/setting/${setting}`, { value });
 };

--- a/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
@@ -308,7 +308,6 @@ describe("scenarios > embedding > smoke tests", { tags: "@OSS" }, () => {
 });
 
 function resetEmbedding() {
-  updateSetting("enable-embedding-interactive", false);
   updateSetting("enable-embedding-static", false);
   updateSetting("embedding-secret-key", null);
 }

--- a/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
@@ -37,7 +37,7 @@ import {
 
     describe("when embedding is disabled", () => {
       beforeEach(() => {
-        updateSetting("enable-embedding", false);
+        updateSetting("enable-embedding-static", false);
       });
 
       describe("when user is admin", () => {
@@ -72,7 +72,7 @@ import {
       describe("when public sharing is enabled", () => {
         beforeEach(() => {
           updateSetting("enable-public-sharing", true);
-          updateSetting("enable-embedding", true);
+          updateSetting("enable-embedding-static", true);
         });
 
         describe("when user is admin", () => {
@@ -138,7 +138,7 @@ import {
       describe("when public sharing is disabled", () => {
         beforeEach(() => {
           updateSetting("enable-public-sharing", false);
-          updateSetting("enable-embedding", true);
+          updateSetting("enable-embedding-static", true);
         });
 
         describe("when user is admin", () => {

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSettings.tsx
@@ -18,6 +18,8 @@ export function EmbeddingSettings({
 }: AdminSettingComponentProps) {
   function handleToggleStaticEmbedding(event: ChangeEvent<HTMLInputElement>) {
     updateSetting({ key: "enable-embedding-static" }, event.target.checked);
+    // TODO: remove before merging integration branch
+    updateSetting({ key: "enable-embedding" }, event.target.checked);
   }
 
   function handleToggleEmbeddingSdk(event: ChangeEvent<HTMLInputElement>) {

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/StaticEmbeddingSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/StaticEmbeddingSettings.tsx
@@ -35,6 +35,8 @@ export function StaticEmbeddingSettings({
 
   function handleToggleStaticEmbedding(event: ChangeEvent<HTMLInputElement>) {
     updateSetting({ key: "enable-embedding-static" }, event.target.checked);
+    // TODO: remove before merging integration branch
+    updateSetting({ key: "enable-embedding" }, event.target.checked);
   }
 
   return (

--- a/frontend/src/metabase/sharing/components/SharingMenu/MenuItems/EmbedMenuItem.tsx
+++ b/frontend/src/metabase/sharing/components/SharingMenu/MenuItems/EmbedMenuItem.tsx
@@ -7,8 +7,7 @@ import { getUserIsAdmin } from "metabase/selectors/user";
 import { Center, Icon, Menu, Stack, Text, Title } from "metabase/ui";
 
 export function EmbedMenuItem({ onClick }: { onClick: () => void }) {
-  // TODO: Change this to `enable-embedding-static` once the BE is implemented.
-  const isStaticEmbeddingEnabled = useSetting("enable-embedding");
+  const isStaticEmbeddingEnabled = useSetting("enable-embedding-static");
   const isAdmin = useSelector(getUserIsAdmin);
 
   if (!isAdmin) {

--- a/frontend/src/metabase/sharing/components/SharingMenu/test/setup.tsx
+++ b/frontend/src/metabase/sharing/components/SharingMenu/test/setup.tsx
@@ -76,7 +76,7 @@ const setupState = ({
   const settingValues = createMockSettings({
     "token-features": tokenFeatures,
     "enable-public-sharing": isPublicSharingEnabled,
-    "enable-embedding": isEmbeddingEnabled,
+    "enable-embedding-static": isEmbeddingEnabled,
     "email-configured?": isEmailSetup,
     "slack-token-valid?": isSlackSetup,
   });

--- a/src/metabase/api/common/validation.clj
+++ b/src/metabase/api/common/validation.clj
@@ -20,7 +20,7 @@
 (defn check-embedding-enabled
   "Is embedding of Cards or Objects (secured access via `/api/embed` endpoints with a signed JWT enabled?"
   []
-  (api/check (embed.settings/enable-embedding)
+  (api/check (embed.settings/enable-embedding-static)
              [400 (tru "Embedding is not enabled.")]))
 
 (defn check-has-application-permission

--- a/src/metabase/api/common/validation.clj
+++ b/src/metabase/api/common/validation.clj
@@ -20,7 +20,7 @@
 (defn check-embedding-enabled
   "Is embedding of Cards or Objects (secured access via `/api/embed` endpoints with a signed JWT enabled?"
   []
-  (api/check (embed.settings/enable-embedding-static)
+  (api/check (embed.settings/enable-embedding)
              [400 (tru "Embedding is not enabled.")]))
 
 (defn check-has-application-permission


### PR DESCRIPTION
We'll need to revert https://github.com/metabase/metabase/pull/48293/commits/0888589d373d694a715582da2c30f8bed2abb8cb before we merge the integration branch on master, but for now this should make make CI green, allowing us to focus on real failures

This should make ci green on https://github.com/metabase/metabase/pull/48069