### PR TITLE
guard database create route

### DIFF
--- a/e2e/test/scenarios/permissions/database-details-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/database-details-permissions.cy.spec.js
@@ -65,6 +65,16 @@ describeEE(
       }).then(({ status }) => {
         expect(status).to.eq(403);
       });
+
+      cy.log(
+        "should not allow access to the database/create page (metabase-private#236)",
+      );
+      cy.visit("/admin/databases/create");
+      cy.findByRole("img", { name: /key/ }).should("exist");
+      cy.findByRole("status").should(
+        "contain.text",
+        "Sorry, you don’t have permission to see that.",
+      );
     });
   },
 );

--- a/frontend/src/metabase/admin/routes.jsx
+++ b/frontend/src/metabase/admin/routes.jsx
@@ -87,7 +87,9 @@ const getRoutes = (store, CanAccessSettings, IsAdmin) => (
         component={createAdminRouteGuard("databases")}
       >
         <IndexRoute component={DatabaseListApp} />
-        <Route path="create" component={DatabaseEditApp} />
+        <Route path="create" component={IsAdmin}>
+          <IndexRoute component={DatabaseEditApp} />
+        </Route>
         <Route path=":databaseId" component={DatabaseEditApp} />
       </Route>
       <Route path="datamodel" component={createAdminRouteGuard("data-model")}>


### PR DESCRIPTION
### Description
Adds a route guard to the `/admin/databases/create` page to only allow access if you are an admin. While we don't show a button to navigate to the page for non admins, previously you were able to navigate there by changing the URL. This would bring you to the DB create page, though attempting to create a DB would result in an API error

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Log in with a non admin user that has access to manage a database
2. Go to Admin -> Databases, and add `/create` to the end of the url and press enter
3. You should be taken to the unauthorized page

### Demo
![chrome_vlimIaEFa1](https://github.com/user-attachments/assets/f03a3e9f-0220-4acd-b08b-66de9576207c)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
