### PR TITLE
Improve 'Saved in' section of question and dashboard sidesheets

### DIFF
--- a/e2e/test/scenarios/collections/collections-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections-reproductions.cy.spec.js
@@ -146,7 +146,7 @@ describeEE("issue 30235", () => {
       openCollectionMenu();
 
       popover().within(() => {
-        cy.findByText("Make collection official").should("be.visible");
+        cy.findByText("Make official").should("be.visible");
         cy.findByText("Edit permissions").should("be.visible");
       });
     });

--- a/e2e/test/scenarios/organization/official-collections.cy.spec.js
+++ b/e2e/test/scenarios/organization/official-collections.cy.spec.js
@@ -262,7 +262,7 @@ function changeCollectionTypeTo(type) {
     if (type === "official") {
       cy.findByText("Make official").click();
     } else {
-      cy.findByText("Remove Official badge").click();
+      cy.findByText("Remove official status").click();
     }
   });
 }
@@ -281,7 +281,7 @@ function assertHasCollectionTypeInput() {
 
 function assertNoCollectionTypeOption() {
   cy.findByText("Make official").should("not.exist");
-  cy.findByText("Remove Official badge").should("not.exist");
+  cy.findByText("Remove official status").should("not.exist");
 }
 
 function assertSidebarIcon(collectionName, expectedIcon) {

--- a/e2e/test/scenarios/organization/official-collections.cy.spec.js
+++ b/e2e/test/scenarios/organization/official-collections.cy.spec.js
@@ -115,7 +115,7 @@ describeEE("official collections", () => {
         cy.icon("ellipsis").click();
       });
 
-      popover().findByText("Make collection official").should("exist");
+      popover().findByText("Make official").should("exist");
 
       openNewCollectionItemFlowFor("collection");
       cy.findByTestId("new-collection-modal").then(modal => {
@@ -132,7 +132,7 @@ describeEE("official collections", () => {
         cy.icon("ellipsis").should("exist");
         cy.icon("ellipsis").click();
       });
-      popover().findByText("Make collection official").should("exist");
+      popover().findByText("Make official").should("exist");
 
       openNewCollectionItemFlowFor("collection");
       cy.findByTestId("new-collection-modal").then(modal => {
@@ -260,7 +260,7 @@ function changeCollectionTypeTo(type) {
   openCollectionMenu();
   popover().within(() => {
     if (type === "official") {
-      cy.findByText("Make collection official").click();
+      cy.findByText("Make official").click();
     } else {
       cy.findByText("Remove Official badge").click();
     }
@@ -280,7 +280,7 @@ function assertHasCollectionTypeInput() {
 }
 
 function assertNoCollectionTypeOption() {
-  cy.findByText("Make collection official").should("not.exist");
+  cy.findByText("Make official").should("not.exist");
   cy.findByText("Remove Official badge").should("not.exist");
 }
 

--- a/enterprise/frontend/src/metabase-enterprise/collections/components/CollectionAuthorityLevelIcon.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/collections/components/CollectionAuthorityLevelIcon.tsx
@@ -4,19 +4,25 @@ import _ from "underscore";
 
 import { color } from "metabase/lib/colors";
 import type { CollectionAuthorityLevelIcon as CollectionAuthorityLevelIconComponent } from "metabase/plugins/index";
-import { Icon } from "metabase/ui";
+import { FixedSizeIcon as Icon } from "metabase/ui";
 
 import { AUTHORITY_LEVELS } from "../constants";
 import { isRegularCollection } from "../utils";
 
 export const CollectionAuthorityLevelIcon: CollectionAuthorityLevelIconComponent =
-  ({ collection, tooltip = "default", archived, ...iconProps }) => {
-    if (isRegularCollection(collection)) {
+  ({
+    collection,
+    tooltip = "default",
+    archived,
+    showIconForRegularCollection,
+    ...iconProps
+  }) => {
+    if (isRegularCollection(collection) && !showIconForRegularCollection) {
       return null;
     }
     const level = AUTHORITY_LEVELS[String(collection.authority_level)];
     const levelColor = level.color ? color(level.color) : undefined;
-    const iconColor = archived ? color("text-light") : levelColor;
+    const iconColor = archived ? "var(--mb-color-text-light)" : levelColor;
     return (
       <Icon
         {...iconProps}

--- a/enterprise/frontend/src/metabase-enterprise/collections/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/collections/index.ts
@@ -41,7 +41,7 @@ if (hasPremiumFeature("official_collections")) {
     if (isRegularCollection(collection)) {
       return [
         {
-          title: t`Make collection official`,
+          title: t`Make official`,
           icon: OFFICIAL_COLLECTION.icon,
           action: () =>
             onUpdate(collection, {

--- a/enterprise/frontend/src/metabase-enterprise/collections/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/collections/index.ts
@@ -52,7 +52,7 @@ if (hasPremiumFeature("official_collections")) {
     } else {
       return [
         {
-          title: t`Remove Official badge`,
+          title: t`Remove official status`,
           icon: "close",
           action: () =>
             onUpdate(collection, {

--- a/frontend/src/metabase/collections/components/CollectionHeader/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/tests/enterprise.unit.spec.tsx
@@ -110,10 +110,8 @@ describe("Official Collections Header", () => {
   it("should allow admin users to designate official collections", async () => {
     setup(officialCollectionOptions);
     await userEvent.click(getIcon("ellipsis"));
-    expect(
-      await screen.findByText("Make collection official"),
-    ).toBeInTheDocument();
-    expect(await getIcon("official_collection")).toBeInTheDocument();
+    expect(await screen.findByText("Make official")).toBeInTheDocument();
+    expect(getIcon("official_collection")).toBeInTheDocument();
   });
 
   it("should not allow non-admin users to designate official collections", async () => {
@@ -122,10 +120,8 @@ describe("Official Collections Header", () => {
       isAdmin: false,
     });
     await userEvent.click(getIcon("ellipsis"));
-    expect(
-      screen.queryByText("Make collection official"),
-    ).not.toBeInTheDocument();
-    expect(await queryIcon("official_collection")).not.toBeInTheDocument();
+    expect(screen.queryByText("Make official")).not.toBeInTheDocument();
+    expect(queryIcon("official_collection")).not.toBeInTheDocument();
   });
 
   it("should not allow admin users to designate read-only collections as official", async () => {
@@ -137,9 +133,7 @@ describe("Official Collections Header", () => {
       },
     });
     await userEvent.click(getIcon("ellipsis"));
-    expect(
-      screen.queryByText("Make collection official"),
-    ).not.toBeInTheDocument();
-    expect(await queryIcon("official_collection")).not.toBeInTheDocument();
+    expect(screen.queryByText("Make official")).not.toBeInTheDocument();
+    expect(queryIcon("official_collection")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/collections/components/CollectionMenu/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionMenu/tests/common.unit.spec.tsx
@@ -109,8 +109,6 @@ describe("CollectionMenu", () => {
     });
 
     await userEvent.click(getIcon("ellipsis"));
-    expect(
-      screen.queryByText("Make collection official"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Make official")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/collections/components/CollectionMenu/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionMenu/tests/enterprise.unit.spec.tsx
@@ -27,8 +27,6 @@ describe("CollectionMenu", () => {
     });
 
     await userEvent.click(getIcon("ellipsis"));
-    expect(
-      screen.queryByText("Make collection official"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Make official")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/collections/components/CollectionMenu/tests/premium.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionMenu/tests/premium.unit.spec.tsx
@@ -28,7 +28,7 @@ describe("CollectionMenu", () => {
     });
 
     await userEvent.click(getIcon("ellipsis"));
-    await userEvent.click(await screen.findByText("Make collection official"));
+    await userEvent.click(await screen.findByText("Make official"));
     expect(onUpdateCollection).toHaveBeenCalledWith(collection, {
       authority_level: "official",
     });
@@ -61,9 +61,7 @@ describe("CollectionMenu", () => {
     });
 
     await userEvent.click(getIcon("ellipsis"));
-    expect(
-      screen.queryByText("Make collection official"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Make official")).not.toBeInTheDocument();
   });
 
   it("should not be able to make the collection official if it's the root collection", async () => {
@@ -77,9 +75,7 @@ describe("CollectionMenu", () => {
     });
 
     await userEvent.click(getIcon("ellipsis"));
-    expect(
-      screen.queryByText("Make collection official"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Make official")).not.toBeInTheDocument();
   });
 
   it("should be able to make the collection official if it's a personal collection", async () => {
@@ -93,9 +89,7 @@ describe("CollectionMenu", () => {
     });
 
     await userEvent.click(getIcon("ellipsis"));
-    expect(
-      await screen.findByText("Make collection official"),
-    ).toBeInTheDocument();
+    expect(await screen.findByText("Make official")).toBeInTheDocument();
   });
 
   it("should be able to make the collection official if even it's a personal collection child", async () => {
@@ -109,6 +103,6 @@ describe("CollectionMenu", () => {
     });
 
     await userEvent.click(getIcon("ellipsis"));
-    expect(screen.getByText("Make collection official")).toBeInTheDocument();
+    expect(screen.getByText("Make official")).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/collections/components/CollectionMenu/tests/premium.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionMenu/tests/premium.unit.spec.tsx
@@ -45,7 +45,7 @@ describe("CollectionMenu", () => {
     });
 
     await userEvent.click(getIcon("ellipsis"));
-    await userEvent.click(await screen.findByText("Remove Official badge"));
+    await userEvent.click(await screen.findByText("Remove official status"));
     expect(onUpdateCollection).toHaveBeenCalledWith(collection, {
       authority_level: null,
     });

--- a/frontend/src/metabase/common/components/Sidesheet/SidesheetCardSection.tsx
+++ b/frontend/src/metabase/common/components/Sidesheet/SidesheetCardSection.tsx
@@ -1,23 +1,28 @@
 import type React from "react";
 
 import CS from "metabase/css/core/index.css";
+import { useUniqueId } from "metabase/hooks/use-unique-id";
 import { Box, type MantineStyleSystemProps, Title } from "metabase/ui";
 
 interface SidesheetCardSectionProps {
   title?: string;
+  titleId?: string;
   children: React.ReactNode;
   styleProps?: Partial<MantineStyleSystemProps>;
 }
 
 export const SidesheetCardSection = ({
   title,
+  titleId,
   children,
   ...styleProps
 }: SidesheetCardSectionProps) => {
+  const generatedTitleId = useUniqueId("sidesheet-card-section-title");
+  titleId ||= generatedTitleId;
   return (
-    <Box {...styleProps}>
+    <Box {...styleProps} aria-labelledby={titleId}>
       {title && (
-        <Title mb="sm" size="sm" color="text-light">
+        <Title id={titleId} mb="sm" size="sm" color="text-light">
           {title}
         </Title>
       )}

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardDetails.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardDetails.tsx
@@ -3,12 +3,14 @@ import { useState } from "react";
 import { c, t } from "ttag";
 
 import { skipToken, useGetUserQuery } from "metabase/api";
+import { getCollectionName } from "metabase/collections/utils";
 import { SidesheetCardSection } from "metabase/common/components/Sidesheet";
 import DateTime from "metabase/components/DateTime";
 import Link from "metabase/core/components/Link";
 import Styles from "metabase/css/core/index.css";
-import { collection as collectionUrl } from "metabase/lib/urls";
+import * as Urls from "metabase/lib/urls";
 import { getUserName } from "metabase/lib/user";
+import { PLUGIN_COLLECTION_COMPONENTS } from "metabase/plugins";
 import { DashboardPublicLinkPopover } from "metabase/sharing/components/PublicLinkPopover";
 import { Box, FixedSizeIcon, Flex, Text } from "metabase/ui";
 import type { Dashboard } from "metabase-types/api";
@@ -62,15 +64,18 @@ export const DashboardDetails = ({ dashboard }: { dashboard: Dashboard }) => {
           ).t`Saved in`}
         >
           <Flex gap="sm" align="top">
-            <FixedSizeIcon
-              name="folder"
+            <PLUGIN_COLLECTION_COMPONENTS.CollectionAuthorityLevelIcon
+              collection={dashboard.collection}
               className={SidebarStyles.IconMargin}
-              color="var(--mb-color-brand)"
+              showIconForRegularCollection
             />
             <div>
               <Text>
-                <Link to={collectionUrl(dashboard.collection)} variant="brand">
-                  {dashboard.collection?.name}
+                <Link
+                  to={Urls.collection(dashboard.collection)}
+                  variant="brand"
+                >
+                  {getCollectionName(dashboard.collection)}
                 </Link>
               </Text>
             </div>

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/tests/enterprise.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/tests/enterprise.unit.spec.ts
@@ -5,7 +5,13 @@ import {
   createMockDashboard,
 } from "metabase-types/api/mocks";
 
-import { setupEnterprise as setup } from "./setup";
+import { type SetupOpts, setup as baseSetup } from "./setup";
+const setup = (opts: SetupOpts) => {
+  return baseSetup({
+    ...opts,
+    shouldSetupEnterprisePlugins: true,
+  });
+};
 
 describe("DashboardInfoSidebar (EE without token)", () => {
   it("should show collection without icon even if collection is official", async () => {

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/tests/enterprise.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/tests/enterprise.unit.spec.ts
@@ -1,24 +1,37 @@
-import { screen } from "__support__/ui";
+import { screen, within } from "__support__/ui";
 import type { Dashboard } from "metabase-types/api";
-import { createMockDashboard } from "metabase-types/api/mocks";
+import {
+  createMockCollection,
+  createMockDashboard,
+} from "metabase-types/api/mocks";
 
-import type { SetupOpts } from "./setup";
-import { setup } from "./setup";
+import { setupEnterprise as setup } from "./setup";
 
-const setupEnterprise = (opts: SetupOpts) => {
-  return setup({
-    ...opts,
-    hasEnterprisePlugins: true,
+describe("DashboardInfoSidebar (EE without token)", () => {
+  it("should show collection without icon even if collection is official", async () => {
+    await setup({
+      dashboard: createMockDashboard({
+        collection: createMockCollection({
+          name: "My little collection ",
+          authority_level: "official",
+        }),
+      }),
+    });
+
+    const collectionSection = await screen.findByLabelText("Saved in");
+    expect(
+      within(collectionSection).getByText("My little collection"),
+    ).toBeInTheDocument();
+    expect(
+      within(collectionSection).queryByTestId("official-collection-marker"),
+    ).not.toBeInTheDocument();
   });
-};
-
-describe("DashboardInfoSidebar > enterprise", () => {
   describe("entity id display", () => {
     it("should not show entity ids without serialization feature", async () => {
       const dashboard = createMockDashboard({
         entity_id: "jenny8675309" as Dashboard["entity_id"],
       });
-      await setupEnterprise({ dashboard });
+      await setup({ dashboard });
 
       expect(screen.queryByText("Entity ID")).not.toBeInTheDocument();
       expect(screen.queryByText("jenny8675309")).not.toBeInTheDocument();

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/tests/premium.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/tests/premium.unit.spec.ts
@@ -1,13 +1,14 @@
-import { screen } from "__support__/ui";
+import { screen, within } from "__support__/ui";
 import type { Dashboard } from "metabase-types/api";
 import {
+  createMockCollection,
   createMockDashboard,
   createMockSettings,
   createMockTokenFeatures,
 } from "metabase-types/api/mocks";
 
 import type { SetupOpts } from "./setup";
-import { setup } from "./setup";
+import { setupEnterprise as setup } from "./setup";
 
 const setupEnterprise = (opts: SetupOpts) => {
   return setup({
@@ -20,11 +21,10 @@ const setupEnterprise = (opts: SetupOpts) => {
         audit_app: true,
       }),
     }),
-    hasEnterprisePlugins: true,
   });
 };
 
-describe("DashboardInfoSidebar > enterprise", () => {
+describe("DashboardInfoSidebar (EE with token)", () => {
   describe("entity id display", () => {
     it("should show entity ids only with serialization feature", async () => {
       const dashboard = createMockDashboard({
@@ -35,5 +35,48 @@ describe("DashboardInfoSidebar > enterprise", () => {
       expect(screen.getByText("Entity ID")).toBeInTheDocument();
       expect(screen.getByText("jenny8675309")).toBeInTheDocument();
     });
+  });
+  it("should show collection without icon when collection is not official", async () => {
+    await setup(
+      {
+        dashboard: createMockDashboard({
+          collection: createMockCollection({
+            name: "My little collection",
+          }),
+        }),
+      },
+      { official_collections: true },
+    );
+
+    const collectionSection = await screen.findByLabelText("Saved in");
+    expect(
+      within(collectionSection).getByText("My little collection"),
+    ).toBeInTheDocument();
+    expect(
+      within(collectionSection).queryByTestId("official-collection-marker"),
+    ).not.toBeInTheDocument();
+  });
+  it("should show collection with icon when collection is official", async () => {
+    await setup(
+      {
+        dashboard: createMockDashboard({
+          collection: createMockCollection({
+            name: "My little collection ",
+            authority_level: "official",
+          }),
+        }),
+      },
+      { official_collections: true },
+    );
+
+    const collectionSection = await screen.findByLabelText("Saved in");
+    expect(
+      within(collectionSection).getByText("My little collection"),
+    ).toBeInTheDocument();
+    expect(
+      await within(collectionSection).findByTestId(
+        "official-collection-marker",
+      ),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/tests/premium.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/tests/premium.unit.spec.ts
@@ -3,50 +3,44 @@ import type { Dashboard } from "metabase-types/api";
 import {
   createMockCollection,
   createMockDashboard,
-  createMockSettings,
-  createMockTokenFeatures,
 } from "metabase-types/api/mocks";
 
 import type { SetupOpts } from "./setup";
-import { setupEnterprise as setup } from "./setup";
+import { setup as baseSetup } from "./setup";
 
-const setupEnterprise = (opts: SetupOpts) => {
-  return setup({
+const setup = (opts: SetupOpts) => {
+  return baseSetup({
     ...opts,
-    settings: createMockSettings({
-      "token-features": createMockTokenFeatures({
-        content_verification: true,
-        cache_granular_controls: true,
-        serialization: true,
-        audit_app: true,
-      }),
-    }),
+    withFeatures: [
+      "content_verification",
+      "cache_granular_controls",
+      "serialization",
+      "audit_app",
+      "official_collections",
+    ],
   });
 };
 
-describe("DashboardInfoSidebar (EE with token)", () => {
+describe("DashboardInfoSidebar (EE with tokens)", () => {
   describe("entity id display", () => {
     it("should show entity ids only with serialization feature", async () => {
       const dashboard = createMockDashboard({
         entity_id: "jenny8675309" as Dashboard["entity_id"],
       });
-      await setupEnterprise({ dashboard });
+      await setup({ dashboard });
 
       expect(screen.getByText("Entity ID")).toBeInTheDocument();
       expect(screen.getByText("jenny8675309")).toBeInTheDocument();
     });
   });
   it("should show collection without icon when collection is not official", async () => {
-    await setup(
-      {
-        dashboard: createMockDashboard({
-          collection: createMockCollection({
-            name: "My little collection",
-          }),
+    await setup({
+      dashboard: createMockDashboard({
+        collection: createMockCollection({
+          name: "My little collection",
         }),
-      },
-      { official_collections: true },
-    );
+      }),
+    });
 
     const collectionSection = await screen.findByLabelText("Saved in");
     expect(
@@ -57,17 +51,14 @@ describe("DashboardInfoSidebar (EE with token)", () => {
     ).not.toBeInTheDocument();
   });
   it("should show collection with icon when collection is official", async () => {
-    await setup(
-      {
-        dashboard: createMockDashboard({
-          collection: createMockCollection({
-            name: "My little collection ",
-            authority_level: "official",
-          }),
+    await setup({
+      dashboard: createMockDashboard({
+        collection: createMockCollection({
+          name: "My little collection ",
+          authority_level: "official",
         }),
-      },
-      { official_collections: true },
-    );
+      }),
+    });
 
     const collectionSection = await screen.findByLabelText("Saved in");
     expect(

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -5,7 +5,6 @@ import type {
   ReactNode,
   SetStateAction,
 } from "react";
-import type { InjectedRouter, Route } from "react-router";
 import { t } from "ttag";
 import type { AnySchema } from "yup";
 
@@ -413,8 +412,6 @@ export type SidebarCacheFormProps = {
   item: CacheableDashboard | Question;
   model: CacheableModel;
   onClose: () => void;
-  router?: InjectedRouter;
-  route?: Route;
 } & GroupProps;
 
 export const PLUGIN_CACHING = {

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -5,8 +5,8 @@ import type {
   ReactNode,
   SetStateAction,
 } from "react";
+import type { InjectedRouter, Route } from "react-router";
 import { t } from "ttag";
-import _ from "underscore";
 import type { AnySchema } from "yup";
 
 import noResultsSource from "assets/img/no_results.svg";
@@ -339,6 +339,7 @@ export type CollectionAuthorityLevelIcon = ComponentType<
     collection: Pick<Collection, "authority_level">;
     tooltip?: "default" | "belonging";
     archived?: boolean;
+    showIconForRegularCollection?: boolean;
   }
 >;
 
@@ -412,6 +413,8 @@ export type SidebarCacheFormProps = {
   item: CacheableDashboard | Question;
   model: CacheableModel;
   onClose: () => void;
+  router?: InjectedRouter;
+  route?: Route;
 } & GroupProps;
 
 export const PLUGIN_CACHING = {

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/QuestionDetails.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/QuestionDetails.tsx
@@ -11,6 +11,7 @@ import Styles from "metabase/css/core/index.css";
 import { useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { getUserName } from "metabase/lib/user";
+import { PLUGIN_COLLECTION_COMPONENTS } from "metabase/plugins";
 import { getMetadata } from "metabase/selectors/metadata";
 import { QuestionPublicLinkPopover } from "metabase/sharing/components/PublicLinkPopover";
 import { Box, Flex, FixedSizeIcon as Icon, Text } from "metabase/ui";
@@ -24,6 +25,10 @@ export const QuestionDetails = ({ question }: { question: Question }) => {
   const createdBy = question.getCreator();
   const createdAt = question.getCreatedAt();
   const collection = question.collection();
+
+  const collectionSectionTitle = c(
+    "This is a heading that appears above the name of a collection - a collection that a dashboard is saved in. Feel free to translate this heading as though it said 'Saved in collection', if you think that would make more sense in your language.",
+  ).t`Saved in`;
 
   return (
     <>
@@ -56,23 +61,25 @@ export const QuestionDetails = ({ question }: { question: Question }) => {
           </Flex>
         )}
       </SidesheetCardSection>
-      <SidesheetCardSection title={t`Saved in`}>
-        <Flex gap="sm" align="top" color="var(--mb-color-brand)">
-          <Icon
-            name="folder"
-            color="var(--mb-color-brand)"
-            className={SidebarStyles.IconMargin}
-          />
-          <Text>
-            <Link to={Urls.collection(collection)} variant="brand">
-              {
-                // We need to use getCollectionName or the name of the root collection will not be displayed
-                getCollectionName(collection)
-              }
-            </Link>
-          </Text>
-        </Flex>
-      </SidesheetCardSection>
+      {collection && (
+        <SidesheetCardSection title={collectionSectionTitle}>
+          <Flex gap="sm" align="top" color="var(--mb-color-brand)">
+            <PLUGIN_COLLECTION_COMPONENTS.CollectionAuthorityLevelIcon
+              collection={collection}
+              className={SidebarStyles.IconMargin}
+              showIconForRegularCollection
+            />
+            <Text>
+              <Link to={Urls.collection(collection)} variant="brand">
+                {
+                  // We need to use getCollectionName or the name of the root collection will not be displayed
+                  getCollectionName(collection)
+                }
+              </Link>
+            </Text>
+          </Flex>
+        </SidesheetCardSection>
+      )}
       <SharingDisplay question={question} />
       <SourceDisplay question={question} />
     </>

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/tests/common.unit.spec.tsx
@@ -107,10 +107,8 @@ describe("QuestionInfoSidebar", () => {
       });
       setup({ card });
 
-      expect(screen.getByText("Our analytics")).toHaveAttribute(
-        "href",
-        "/collection/root",
-      );
+      const link = screen.getByRole("link", { name: "Our analytics" });
+      expect(link).toHaveAttribute("href", "/collection/root");
     });
 
     it("should show source information", () => {

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/tests/enterprise.unit.spec.tsx
@@ -1,7 +1,8 @@
-import { screen } from "__support__/ui";
+import { screen, within } from "__support__/ui";
 import type { Card } from "metabase-types/api";
 import {
   createMockCard,
+  createMockCollection,
   createMockModerationReview,
 } from "metabase-types/api/mocks";
 
@@ -38,5 +39,23 @@ describe("QuestionInfoSidebar > enterprise", () => {
       expect(screen.queryByText("Entity ID")).not.toBeInTheDocument();
       expect(screen.queryByText("jenny8675309")).not.toBeInTheDocument();
     });
+  });
+
+  it("should show collection without icon even if collection is official", async () => {
+    const card = createMockCard({
+      collection: createMockCollection({
+        name: "My little collection",
+        authority_level: "official",
+      }),
+    });
+    await setupEnterprise({ card });
+
+    const collectionSection = await screen.findByLabelText("Saved in");
+    expect(
+      within(collectionSection).getByText("My little collection"),
+    ).toBeInTheDocument();
+    expect(
+      within(collectionSection).queryByTestId("official-collection-marker"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/tests/enterprise.unit.spec.tsx
@@ -7,10 +7,10 @@ import {
 } from "metabase-types/api/mocks";
 
 import type { SetupOpts } from "./setup";
-import { setup } from "./setup";
+import { setup as baseSetup } from "./setup";
 
-const setupEnterprise = (opts: SetupOpts) => {
-  return setup({
+const setup = (opts: SetupOpts) => {
+  return baseSetup({
     ...opts,
     hasEnterprisePlugins: true,
   });
@@ -24,7 +24,7 @@ describe("QuestionInfoSidebar > enterprise", () => {
           createMockModerationReview({ status: "verified" }),
         ],
       });
-      await setupEnterprise({ card });
+      await setup({ card });
       expect(screen.queryByText(/verified this/)).not.toBeInTheDocument();
     });
   });
@@ -34,7 +34,7 @@ describe("QuestionInfoSidebar > enterprise", () => {
       const card = createMockCard({
         entity_id: "jenny8675309" as Card["entity_id"],
       });
-      await setupEnterprise({ card });
+      await setup({ card });
 
       expect(screen.queryByText("Entity ID")).not.toBeInTheDocument();
       expect(screen.queryByText("jenny8675309")).not.toBeInTheDocument();
@@ -48,7 +48,7 @@ describe("QuestionInfoSidebar > enterprise", () => {
         authority_level: "official",
       }),
     });
-    await setupEnterprise({ card });
+    await setup({ card });
 
     const collectionSection = await screen.findByLabelText("Saved in");
     expect(

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/tests/premium.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/tests/premium.unit.spec.tsx
@@ -9,10 +9,10 @@ import {
 } from "metabase-types/api/mocks";
 
 import type { SetupOpts } from "./setup";
-import { setup } from "./setup";
+import { setup as baseSetup } from "./setup";
 
-const setupPremium = (opts: SetupOpts) => {
-  return setup({
+const setup = (opts: SetupOpts) => {
+  return baseSetup({
     ...opts,
     settings: createMockSettings({
       "token-features": createMockTokenFeatures({
@@ -35,20 +35,20 @@ describe("QuestionInfoSidebar > premium", () => {
           createMockModerationReview({ status: "verified" }),
         ],
       });
-      await setupPremium({ card });
+      await setup({ card });
       expect(screen.getByText(/verified this/)).toBeInTheDocument();
     });
 
     it("should not show the verification badge for unverified content", async () => {
       const card = createMockCard();
-      await setupPremium({ card });
+      await setup({ card });
       expect(screen.queryByText(/verified this/)).not.toBeInTheDocument();
     });
   });
 
   describe("analytics content", () => {
     it("should show the history section for non analytics content", async () => {
-      await setupPremium({
+      await setup({
         card: createMockCard({
           collection: createMockCollection(),
         }),
@@ -71,7 +71,7 @@ describe("QuestionInfoSidebar > premium", () => {
   });
 
   it("should not show the history section for instance analytics question", async () => {
-    await setupPremium({
+    await setup({
       card: createMockCard({
         collection: createMockCollection({ type: "instance-analytics" }),
       }),
@@ -87,7 +87,7 @@ describe("QuestionInfoSidebar > premium", () => {
         authority_level: "official",
       }),
     });
-    await setupPremium({ card });
+    await setup({ card });
 
     const collectionSection = await screen.findByLabelText("Saved in");
     expect(


### PR DESCRIPTION
This PR updates the text for making a collection official from "Make collection official" to "Make official" across various components and tests.

It also introduces a new `CollectionAuthorityLevelDisplay` component and updates the `CollectionAuthorityLevelIcon` to support showing icons for regular collections.

### How to verify

1. Navigate to a collection that you have permission to make official.
2. Open the collection menu and verify that the option now reads "Make official" instead of "Make collection official".
3. Check the dashboard and question info sidebars to ensure the collection authority level is displayed correctly, including for regular collections.

- [x] Tests have been added/updated to cover changes in this PR