### PR TITLE
hide dashcard actions when editing iframe card content

### DIFF
--- a/e2e/support/helpers/e2e-dashboard-helpers.ts
+++ b/e2e/support/helpers/e2e-dashboard-helpers.ts
@@ -156,7 +156,7 @@ export function addIFrameWhileEditing(
   options: Partial<Cypress.TypeOptions> = {},
 ) {
   cy.findByLabelText("Add a link or iframe").click();
-  popover().findByText("IFrame").click();
+  popover().findByText("Iframe").click();
   cy.findByTestId("iframe-card-input").type(embed, options);
 }
 

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -326,7 +326,10 @@ describe("scenarios > dashboard", () => {
         it("should be possible to add an iframe card", () => {
           editDashboard();
           addIFrameWhileEditing("https://example.com");
+          cy.findByTestId("dashboardcard-actions-panel").should("not.exist");
           cy.button("Done").click();
+          getDashboardCards().eq(0).realHover();
+          cy.findByTestId("dashboardcard-actions-panel").should("be.visible");
           validateIFrame("https://example.com");
           saveDashboard();
           validateIFrame("https://example.com");

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
@@ -21,6 +21,7 @@ import { isJWT } from "metabase/lib/utils";
 import { PLUGIN_COLLECTIONS } from "metabase/plugins";
 import EmbedFrameS from "metabase/public/components/EmbedFrame/EmbedFrame.module.css";
 import { getIsEmbeddingSdk } from "metabase/selectors/embed";
+import { getVisualizationRaw } from "metabase/visualizations";
 import type { Mode } from "metabase/visualizations/click-actions/Mode";
 import { extendCardWithDashcardSettings } from "metabase/visualizations/lib/settings/typed-utils";
 import type { QueryClickActionsMode } from "metabase/visualizations/types";
@@ -260,7 +261,9 @@ function DashCardInner({
     }
   }, [dashcard, dashboard.collection_authority_level]);
 
-  const isEditingCardContent = !isPreviewingCard;
+  const { supportPreviewing } = getVisualizationRaw(series) ?? {};
+  const isEditingCardContent = supportPreviewing && !isPreviewingCard;
+
   const isEditingDashboardLayout =
     isEditing &&
     !clickBehaviorSidebarDashcard &&

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
@@ -260,8 +260,12 @@ function DashCardInner({
     }
   }, [dashcard, dashboard.collection_authority_level]);
 
+  const isEditingCardContent = !isPreviewingCard;
   const isEditingDashboardLayout =
-    isEditing && !clickBehaviorSidebarDashcard && !isEditingParameter;
+    isEditing &&
+    !clickBehaviorSidebarDashcard &&
+    !isEditingParameter &&
+    !isEditingCardContent;
 
   const isClickBehaviorSidebarOpen = !!clickBehaviorSidebarDashcard;
   const isEditingDashCardClickBehavior =

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -157,7 +157,7 @@ export function DashCardVisualization({
             text: t`Text Card`,
             heading: t`Heading Card`,
             placeholder: t`Placeholder Card`,
-            iframe: t`IFrame Card`,
+            iframe: t`Iframe Card`,
           }[virtualDashcardType] ??
           t`This card does not support click mappings`;
 

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/AddLinkOrEmbedButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/AddLinkOrEmbedButton.tsx
@@ -59,7 +59,7 @@ export const AddLinkOrEmbedButton = () => {
         </Menu.Item>
         <Menu.Item onClick={onAddIFrameCard}>
           <Text pr="xl" fw="bold">
-            {t`IFrame`}
+            {t`Iframe`}
           </Text>
         </Menu.Item>
       </Menu.Dropdown>

--- a/frontend/src/metabase/visualizations/visualizations/IFrameViz/IFrameViz.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/IFrameViz/IFrameViz.tsx
@@ -67,7 +67,6 @@ export function IFrameViz({
             </Text>{" "}
             <Box ml="auto">
               <Button
-                disabled={!iframeOrUrl}
                 compact
                 variant="filled"
                 style={{ pointerEvents: "all" }}

--- a/frontend/src/metabase/visualizations/visualizations/IFrameViz/IFrameViz.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/IFrameViz/IFrameViz.unit.spec.tsx
@@ -83,14 +83,14 @@ describe("IFrameViz", () => {
     });
   });
 
-  it("should disable 'Done' button when iframe is empty", () => {
+  it("should not disable 'Done' button when iframe is empty so users can quit editing", () => {
     setup({
       isEditing: true,
       dashcard: emptyIFrameDashcard,
       settings: emptyIFrameDashcard.visualization_settings,
     });
 
-    expect(screen.getByRole("button", { name: "Done" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Done" })).toBeEnabled();
   });
 
   it("should enable 'Done' button when iframe is not empty", () => {

--- a/frontend/src/metabase/visualizations/visualizations/IFrameViz/IFrameVizSettings.ts
+++ b/frontend/src/metabase/visualizations/visualizations/IFrameViz/IFrameVizSettings.ts
@@ -21,7 +21,7 @@ export const settings = {
   settings: {
     "card.title": {
       dashboard: false,
-      default: t`IFrame card`,
+      default: t`Iframe card`,
     },
     "card.description": {
       dashboard: false,


### PR DESCRIPTION
### Description

[We want](https://metaboat.slack.com/archives/C064QMXEV9N/p1727965605832939?thread_ts=1727486608.110099&cid=C064QMXEV9N) not to show the dashcard actions hover popup on iframe cards when editing their content. Also changes copy from `IFrame` to `Iframe` based on the thread.

### Demo (hovered state)

#### Before
<img width="557" alt="Screenshot 2024-10-03 at 2 04 07 PM" src="https://github.com/user-attachments/assets/de337a91-f4d4-4899-ab10-ff3148c5dc17">

#### After
<img width="558" alt="Screenshot 2024-10-03 at 2 04 01 PM" src="https://github.com/user-attachments/assets/881c1389-d703-43c9-a7e7-807d2d9741eb">

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
