### PR TITLE
add security-events: write to uberjar permissions

### DIFF
--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -89,6 +89,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      security-events: write
     steps:
     - name: Extract and clean branch name
       shell: bash


### PR DESCRIPTION
### Description

The Trivy vulnerability scanner upload requires additional permissions. Since the ee-extra overrode the default permissions it is now failing.

### How to verify

1. Push to master
2. Check that docker image is created and pushed
