### PR TITLE
Do not clear http channels when sending pulse

### DIFF
--- a/test/metabase/channel/http_test.clj
+++ b/test/metabase/channel/http_test.clj
@@ -7,7 +7,7 @@
    [compojure.core :as compojure]
    [medley.core :as m]
    [metabase.channel.core :as channel]
-   [metabase.pulse :as pulse]
+   [metabase.task.send-pulses :as task.send-pulses]
    [metabase.test :as mt]
    [metabase.util.i18n :refer [deferred-tru]]
    [ring.adapter.jetty :as jetty]
@@ -328,10 +328,10 @@
          :model/Channel      {chn-id :id}  {:type    :channel/http
                                             :details {:url         (str url (:path receive-route))
                                                       :auth-method "none"}}
-         :model/PulseChannel _             {:pulse_id     pulse-id
+         :model/PulseChannel {pc-id :id}   {:pulse_id     pulse-id
                                             :channel_type "http"
                                             :channel_id   chn-id}]
-        (pulse/send-pulse! pulse)
+        (#'task.send-pulses/send-pulse!* pulse-id [pc-id])
         (is (=? {:body {:type               "alert"
                         :alert_id           pulse-id
                         :alert_creator_id   (mt/malli=? int?)

--- a/test/metabase/task/send_pulses_test.clj
+++ b/test/metabase/task/send_pulses_test.clj
@@ -77,25 +77,25 @@
           (is (= 0
                  (t2/count PulseChannel))))))
 
-   (testing "http"
-     (testing "do not clear if has a channel_id"
-       (mt/with-temp [:model/Channel {channel-id :id} {:type :channel/metabase-test
-                                                       :details {}}
-                      :model/Pulse  {pulse-id :id} {}
-                      :model/PulseChannel _ {:pulse_id     pulse-id
-                                             :channel_id   channel-id
-                                             :channel_type "http"}]
-         (#'task.send-pulses/clear-pulse-channels-no-recipients! pulse-id)
-         (is (= 1
-                (t2/count :model/PulseChannel)))))
+    (testing "http"
+      (testing "do not clear if has a channel_id"
+        (mt/with-temp [:model/Channel {channel-id :id} {:type :channel/metabase-test
+                                                        :details {}}
+                       :model/Pulse  {pulse-id :id} {}
+                       :model/PulseChannel _ {:pulse_id     pulse-id
+                                              :channel_id   channel-id
+                                              :channel_type "http"}]
+          (#'task.send-pulses/clear-pulse-channels-no-recipients! pulse-id)
+          (is (= 1
+                 (t2/count :model/PulseChannel)))))
 
-     (testing "clear if there is no channel_id"
-       (mt/with-temp [:model/Pulse  {pulse-id :id} {}
-                      :model/PulseChannel _ {:pulse_id     pulse-id
-                                             :channel_type :http}]
-         (#'task.send-pulses/clear-pulse-channels-no-recipients! pulse-id)
-         (is (= 0
-                (t2/count :model/PulseChannel))))))))
+      (testing "clear if there is no channel_id"
+        (mt/with-temp [:model/Pulse  {pulse-id :id} {}
+                       :model/PulseChannel _ {:pulse_id     pulse-id
+                                              :channel_type :http}]
+          (#'task.send-pulses/clear-pulse-channels-no-recipients! pulse-id)
+          (is (= 0
+                 (t2/count :model/PulseChannel))))))))
 
 (def ^:private daily-at-1am
   {:schedule_type  "daily"

--- a/test/metabase/task/send_pulses_test.clj
+++ b/test/metabase/task/send_pulses_test.clj
@@ -30,33 +30,72 @@
                (t2/count PulseChannel)))
         (is (:archived (t2/select-one Pulse :id pulse-id)))))
 
-    (testing "Has PulseChannelRecipient"
-      (mt/with-temp [Pulse                 {pulse-id :id} {}
-                     PulseChannel          {pc-id :id} {:pulse_id     pulse-id
-                                                        :channel_type :email}
-                     PulseChannelRecipient _           {:user_id          (mt/user->id :rasta)
-                                                        :pulse_channel_id pc-id}]
-        (#'task.send-pulses/clear-pulse-channels-no-recipients! pulse-id)
-        (is (= 1
-               (t2/count PulseChannel)))))
+    (testing "emails"
+      (testing "keep if has PulseChannelRecipient"
+        (mt/with-temp [Pulse                 {pulse-id :id} {}
+                       PulseChannel          {pc-id :id} {:pulse_id     pulse-id
+                                                          :channel_type :email}
+                       PulseChannelRecipient _           {:user_id          (mt/user->id :rasta)
+                                                          :pulse_channel_id pc-id}]
+          (#'task.send-pulses/clear-pulse-channels-no-recipients! pulse-id)
+          (is (= 1
+                 (t2/count PulseChannel)))))
 
-    (testing "Has email"
-      (mt/with-temp [Pulse        {pulse-id :id} {}
-                     PulseChannel _ {:pulse_id     pulse-id
-                                     :channel_type :email
-                                     :details      {:emails ["test@metabase.com"]}}]
-        (#'task.send-pulses/clear-pulse-channels-no-recipients! pulse-id)
-        (is (= 1
-               (t2/count PulseChannel)))))
+      (testing "keep if has external email"
+        (mt/with-temp [Pulse        {pulse-id :id} {}
+                       PulseChannel _ {:pulse_id     pulse-id
+                                       :channel_type :email
+                                       :details      {:emails ["test@metabase.com"]}}]
+          (#'task.send-pulses/clear-pulse-channels-no-recipients! pulse-id)
+          (is (= 1
+                 (t2/count PulseChannel)))))
 
-    (testing "Has channel"
-      (mt/with-temp [Pulse        {pulse-id :id} {}
-                     PulseChannel _ {:pulse_id     pulse-id
-                                     :channel_type :slack
-                                     :details      {:channel ["#test"]}}]
-        (#'task.send-pulses/clear-pulse-channels-no-recipients! pulse-id)
-        (is (= 1
-               (t2/count PulseChannel)))))))
+      (testing "clear if no recipients"
+        (mt/with-temp [Pulse        {pulse-id :id} {}
+                       PulseChannel _ {:pulse_id     pulse-id
+                                       :channel_type :email}]
+          (#'task.send-pulses/clear-pulse-channels-no-recipients! pulse-id)
+          (is (= 0
+                 (t2/count PulseChannel))))))
+
+    (testing "slack"
+      (testing "Has channel"
+        (mt/with-temp [Pulse        {pulse-id :id} {}
+                       PulseChannel _ {:pulse_id     pulse-id
+                                       :channel_type :slack
+                                       :details      {:channel "#test"}}]
+          (#'task.send-pulses/clear-pulse-channels-no-recipients! pulse-id)
+          (is (= 1
+                 (t2/count PulseChannel)))))
+
+      (testing "No channel"
+        (mt/with-temp [Pulse        {pulse-id :id} {}
+                       PulseChannel _ {:pulse_id     pulse-id
+                                       :channel_type :slack
+                                       :details      {:channel nil}}]
+          (#'task.send-pulses/clear-pulse-channels-no-recipients! pulse-id)
+          (is (= 0
+                 (t2/count PulseChannel))))))
+
+   (testing "http"
+     (testing "do not clear if has a channel_id"
+       (mt/with-temp [:model/Channel {channel-id :id} {:type :channel/metabase-test
+                                                       :details {}}
+                      :model/Pulse  {pulse-id :id} {}
+                      :model/PulseChannel _ {:pulse_id     pulse-id
+                                             :channel_id   channel-id
+                                             :channel_type "http"}]
+         (#'task.send-pulses/clear-pulse-channels-no-recipients! pulse-id)
+         (is (= 1
+                (t2/count :model/PulseChannel)))))
+
+     (testing "clear if there is no channel_id"
+       (mt/with-temp [:model/Pulse  {pulse-id :id} {}
+                      :model/PulseChannel _ {:pulse_id     pulse-id
+                                             :channel_type :http}]
+         (#'task.send-pulses/clear-pulse-channels-no-recipients! pulse-id)
+         (is (= 0
+                (t2/count :model/PulseChannel))))))))
 
 (def ^:private daily-at-1am
   {:schedule_type  "daily"


### PR DESCRIPTION
When sending pulses, we have a function that delete PulseChannels that has no "recipients",(e.g: no email addresses for email, no channel for slack).

The logic to check this doesn't take into account HTTP channels, and it mistakenly deleted all of them.

It's silly that it was not caught in the test, even though we had a flow test, but it does not use the `send-pulse` function in the `task` namespace. I updated the test, so it's more e2e now.

[thread](https://metaboat.slack.com/archives/C07318NQ5M2/p1727989441710569)