### PR TITLE
Further improved send pulse log

### DIFF
--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -314,7 +314,7 @@
                                                          :channel-id   (:id channel)
                                                          :pulse-id     pulse-id}}
         ((retry/decorate send! (retry/random-exponential-backoff-retry (str (random-uuid)) retry-config)))
-        (log/debugf "[Pulse %d] Sent to channel %s with %d retires" pulse-id (format-channel channel) (count @retry-errors))))
+        (log/debugf "[Pulse %d] Sent to channel %s with %d retries" pulse-id (format-channel channel) (count @retry-errors))))
     (catch Throwable e
       (log/errorf e "[Pulse %d] Error sending notification!" pulse-id))))
 

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -401,7 +401,3 @@
                       (merge (when channel-ids {:channel-ids channel-ids})))]
     (when (not (:archived dashboard))
       (send-pulse!* pulse dashboard))))
-
-#_(send-pulse! (t2/select-one :model/Pulse))
-
-#_(metabase.test/set-ns-log-level! 'metabase.pulse :debug)

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -274,8 +274,14 @@
 
 (defn- should-retry-sending?
   [exception channel-type]
-  (and (= :channel/slack channel-type)
-       (contains? (:errors (ex-data exception)) :slack-token)))
+  (not (and (= :channel/slack channel-type)
+            (contains? (:errors (ex-data exception)) :slack-token))))
+
+(defn- format-channel
+  [{:keys [type id]}]
+  (if id
+    (str (name type) " " id)
+    (name type)))
 
 (defn- send-retrying!
   [pulse-id channel message]
@@ -293,9 +299,9 @@
                            (catch Exception e
                              (vswap! retry-errors conj e)
                              ;; Token errors have already been logged and we should not retry.
-                             (when-not (should-retry-sending? e (:type channel))
-                               (throw e))
-                             (log/warnf "[Pulse %d] Failed to send to channel %s %d, retring..." pulse-id (:type channel) (:id channel)))))]
+                             (when (should-retry-sending? e (:type channel))
+                               (log/warnf e "[Pulse %d] Failed to send to channel %s , retrying..." pulse-id (format-channel channel))
+                               (throw e)))))]
       (task-history/with-task-history {:task            "channel-send"
                                        :on-success-info (fn [update-map _result]
                                                           (cond-> update-map
@@ -308,9 +314,9 @@
                                                          :channel-id   (:id channel)
                                                          :pulse-id     pulse-id}}
         ((retry/decorate send! (retry/random-exponential-backoff-retry (str (random-uuid)) retry-config)))
-        (log/debugf "[Pulse %d] Sent to channel %s %d with %d retires" pulse-id (:type channel) (:id channel) (count @retry-errors))))
+        (log/debugf "[Pulse %d] Sent to channel %s with %d retires" pulse-id (format-channel channel) (count @retry-errors))))
     (catch Throwable e
-      (log/error e "Error sending notification!"))))
+      (log/errorf e "[Pulse %d] Error sending notification!" pulse-id))))
 
 (defn- execute-pulse
   [{:keys [cards] pulse-id :id :as pulse} dashboard]
@@ -355,21 +361,17 @@
                            messages (channel/render-notification (:type channel)
                                                                  (get-notification-info pulse parts pulse-channel)
                                                                  (channel-recipients pulse-channel))]
-                       (log/debugf "[Pulse %d] Rendered %d messages for %s %d to channel %s"
+                       (log/debugf "[Pulse %d] Rendered %d messages for channel %s"
                                    pulse-id
                                    (count messages)
-                                   (alert-or-pulse pulse)
-                                   (:id pulse)
-                                   (:type channel))
+                                   (format-channel channel))
                        (doseq [message messages]
-                         (log/debugf "[Pulse %d] Sending %s %d to channel %s"
+                         (log/debugf "[Pulse %d] Sending to channel %s"
                                      pulse-id
-                                     (alert-or-pulse pulse)
-                                     (:id pulse)
                                      (:channel_type pulse-channel))
                          (send-retrying! pulse-id channel message)))
                      (catch Exception e
-                       (log/errorf e "Error sending %s %d to channel %s" (alert-or-pulse pulse) (:id pulse) (:channel_type pulse-channel)))))
+                       (log/errorf e "[Pulse %d] Error sending to %s channel" (:id pulse) (:channel_type pulse-channel)))))
           (when (:alert_first_only pulse)
             (t2/delete! Pulse :id pulse-id))))
       (log/infof "Skipping sending %s %d" (alert-or-pulse pulse) (:id pulse)))))
@@ -399,3 +401,7 @@
                       (merge (when channel-ids {:channel-ids channel-ids})))]
     (when (not (:archived dashboard))
       (send-pulse!* pulse dashboard))))
+
+#_(send-pulse! (t2/select-one :model/Pulse))
+
+#_(metabase.test/set-ns-log-level! 'metabase.pulse :debug)


### PR DESCRIPTION
I was not fully happy with the last interactions. Couple of changes:
- consistent format for channel with or without id
- Consistent use of format `[Pulse {{pulse-id}}]`

Success
```
2024-10-04 09:56:51,301 DEBUG metabase.pulse :: [Pulse 1] Rendered 1 messages for channel email
2024-10-04 09:56:51,301 DEBUG metabase.pulse :: [Pulse 1] Sending to channel :email
2024-10-04 09:56:51,428 DEBUG metabase.pulse :: [Pulse 1] Sent to channel email with 0 retires
```

With retry

```
2024-10-04 10:03:31,543 DEBUG metabase.pulse :: [Pulse 1] Rendered 1 messages for channel email
2024-10-04 10:03:31,543 DEBUG metabase.pulse :: [Pulse 1] Sending to channel :email
2024-10-04 10:03:31,679 WARN metabase.pulse :: [Pulse 1] Failed to send to channel email , retrying...
clojure.lang.ExceptionInfo: Fail {}
        at metabase.channel.email$eval191325$_AMPERSAND_f__191327.invoke(NO_SOURCE_FILE:60)
        at metabase.channel.email$eval191325$fn__191330.invoke(NO_SOURCE_FILE:51)
        at clojure.lang.MultiFn.invoke(MultiFn.java:234)
        at metabase.pulse$send_retrying_BANG_$send_BANG___191198.invoke(NO_SOURCE_FILE:298)
        at clojure.lang.AFn.applyToHelper(AFn.java:152)
...
2024-10-04 10:03:32,288 DEBUG metabase.pulse :: [Pulse 1] Sent to channel email with 1 retires
```