### PR TITLE
don't bundle the deps

### DIFF
--- a/bin/embedding-sdk/generate-sdk-package-files.js
+++ b/bin/embedding-sdk/generate-sdk-package-files.js
@@ -7,6 +7,12 @@ const path = require("path");
 const IGNORED_PACKAGES = ["react", "react-dom"];
 const SDK_DIST_DIR = path.resolve("./resources/embedding-sdk");
 
+// these deps are polyfilled from node in our main app by webpack
+const DEPENDENCIES_TO_ADD = {
+  events: "^3.3.0",
+  querystring: "^0.2.1",
+};
+
 function filterOutReactDependencies(object) {
   const result = {};
 
@@ -46,9 +52,10 @@ function generateSdkPackage() {
 
   const mergedContent = {
     ...sdkPackageTemplateJsonContent,
-    dependencies: filterOutReactDependencies(
-      mainPackageJsonContent.dependencies,
-    ),
+    dependencies: filterOutReactDependencies({
+      ...mainPackageJsonContent.dependencies,
+      ...DEPENDENCIES_TO_ADD,
+    }),
     resolutions: filterOutReactDependencies(mainPackageJsonContent.resolutions),
     version: maybeCommitHash
       ? `${sdkPackageTemplateJsonContent.version}-${todayDate}-${maybeCommitHash}`

--- a/package.json
+++ b/package.json
@@ -314,6 +314,7 @@
     "webpack-bundle-analyzer": "^4.10.1",
     "webpack-cli": "^5.1.1",
     "webpack-dev-server": "^5.0.4",
+    "webpack-node-externals": "^3.0.0",
     "webpack-notifier": "1.15.0",
     "webpack-stats-plugin": "^1.1.3",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz",

--- a/src/metabase/lib/schema/expression/temporal.cljc
+++ b/src/metabase/lib/schema/expression/temporal.cljc
@@ -78,17 +78,17 @@
 (mr/def ::timezone-id
   [:and
    ::common/non-blank-string
-  ;;  [:or
-  ;;   (into [:enum
-  ;;          {:error/message "valid timezone ID"
-  ;;           :error/fn      (fn [{:keys [value]} _]
-  ;;                            (str "invalid timezone ID: " (pr-str value)))}]
-  ;;         (sort
-  ;;          #?(;; 600 timezones on java 17
-  ;;             :clj (ZoneId/getAvailableZoneIds)
-  ;;             ;; 596 timezones on moment-timezone 0.5.38
-  ;;             :cljs (.names (.-tz moment)))))
-  ;;   ::literal/string.zone-offset]
+   [:or
+    (into [:enum
+           {:error/message "valid timezone ID"
+            :error/fn      (fn [{:keys [value]} _]
+                             (str "invalid timezone ID: " (pr-str value)))}]
+          (sort
+           #?(;; 600 timezones on java 17
+              :clj (ZoneId/getAvailableZoneIds)
+              ;; 596 timezones on moment-timezone 0.5.38
+              :cljs (.names (.-tz moment)))))
+    ::literal/string.zone-offset]
    ])
 
 (mbql-clause/define-catn-mbql-clause :convert-timezone

--- a/src/metabase/lib/schema/expression/temporal.cljc
+++ b/src/metabase/lib/schema/expression/temporal.cljc
@@ -78,17 +78,18 @@
 (mr/def ::timezone-id
   [:and
    ::common/non-blank-string
-   [:or
-    (into [:enum
-           {:error/message "valid timezone ID"
-            :error/fn      (fn [{:keys [value]} _]
-                             (str "invalid timezone ID: " (pr-str value)))}]
-          (sort
-           #?(;; 600 timezones on java 17
-              :clj (ZoneId/getAvailableZoneIds)
-              ;; 596 timezones on moment-timezone 0.5.38
-              :cljs (.names (.-tz moment)))))
-    ::literal/string.zone-offset]])
+  ;;  [:or
+  ;;   (into [:enum
+  ;;          {:error/message "valid timezone ID"
+  ;;           :error/fn      (fn [{:keys [value]} _]
+  ;;                            (str "invalid timezone ID: " (pr-str value)))}]
+  ;;         (sort
+  ;;          #?(;; 600 timezones on java 17
+  ;;             :clj (ZoneId/getAvailableZoneIds)
+  ;;             ;; 596 timezones on moment-timezone 0.5.38
+  ;;             :cljs (.names (.-tz moment)))))
+  ;;   ::literal/string.zone-offset]
+   ])
 
 (mbql-clause/define-catn-mbql-clause :convert-timezone
   [:datetime [:schema [:ref ::expression/temporal]]]

--- a/webpack.embedding-sdk.config.js
+++ b/webpack.embedding-sdk.config.js
@@ -128,7 +128,14 @@ module.exports = env => {
     // externals: [/(node_modules)/],
     externals: [
       nodeExternals({
-        allowlist: ["process/browser.js", "process", "moment"],
+        allowlist: [
+          "process/browser.js",
+          "process",
+          "moment",
+          "moment-timezone", // needed for some clojure code that expects it
+          "react-virtualized", // it creates issues on vite,
+          "echarts", // we have a patch on echarts
+        ],
       }),
     ],
 

--- a/webpack.embedding-sdk.config.js
+++ b/webpack.embedding-sdk.config.js
@@ -135,6 +135,9 @@ module.exports = env => {
           "moment-timezone", // needed for some clojure code that expects it
           "react-virtualized", // it creates issues on vite,
           "echarts", // we have a patch on echarts
+          "assert", // crashes on host cra app without it, but even with it :shrug:
+          "util",
+          "crypto",
         ],
       }),
     ],
@@ -156,7 +159,9 @@ module.exports = env => {
         banner:
           "/*\n* This file is subject to the terms and conditions defined in\n * file 'LICENSE.txt', which is part of this source code package.\n */\n",
       }),
-      new NodePolyfillPlugin(), // for crypto, among others
+      new NodePolyfillPlugin({
+        additionalAliases: ["asserts", "util"],
+      }), // for crypto, among others
       // https://github.com/remarkjs/remark/discussions/903
       new webpack.ProvidePlugin({
         process: "process/browser.js",

--- a/webpack.embedding-sdk.config.js
+++ b/webpack.embedding-sdk.config.js
@@ -1,6 +1,7 @@
 /* eslint-env node */
 /* eslint-disable import/no-commonjs */
 /* eslint-disable import/order */
+const nodeExternals = require("webpack-node-externals");
 const NodePolyfillPlugin = require("node-polyfill-webpack-plugin");
 const TerserPlugin = require("terser-webpack-plugin");
 const webpack = require("webpack");
@@ -118,12 +119,18 @@ module.exports = env => {
       ],
     },
 
-    externals: {
-      ...mainConfig.externals,
-      react: "react",
-      "react-dom": "react-dom",
-      "react/jsx-runtime": "react/jsx-runtime",
-    },
+    // externals: {
+    //   ...mainConfig.externals,
+    //   react: "react",
+    //   "react-dom": "react-dom",
+    //   "react/jsx-runtime": "react/jsx-runtime",
+    // },
+    // externals: [/(node_modules)/],
+    externals: [
+      nodeExternals({
+        allowlist: ["process/browser.js", "process", "moment"],
+      }),
+    ],
 
     optimization: !isDevMode
       ? {

--- a/yarn.lock
+++ b/yarn.lock
@@ -24280,6 +24280,11 @@ webpack-merge@^5.7.3:
     clone-deep "^4.0.1"
     wildcard "^2.0.0"
 
+webpack-node-externals@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/webpack-node-externals/-/webpack-node-externals-3.0.0.tgz#1a3407c158d547a9feb4229a9e3385b7b60c9917"
+  integrity sha512-LnL6Z3GGDPht/AigwRh2dvL9PQPFQ8skEpVrWZXLWBYmqcaojHNN0onvHzie6rq7EWKrrBfPYqNEzTJgiwEQDQ==
+
 webpack-notifier@1.15.0:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/webpack-notifier/-/webpack-notifier-1.15.0.tgz#72644a1a4ec96b3528704d28f79da5e70048e8ee"


### PR DESCRIPTION
Other than the changes in the commit, the host app needed
```
    "esbuild-plugin-react-virtualized": "^1.0.4",
    "events": "^3.3.0",
    "querystring": "^0.2.1",
 ```
 
 the plugin is for vite, the other two we should be able to add as deps of the sdk and we should be good