### PR TITLE
Entity Picker Search gracefully handle API errors

### DIFF
--- a/frontend/src/metabase/api/search.ts
+++ b/frontend/src/metabase/api/search.ts
@@ -17,10 +17,12 @@ export const searchApi = Api.injectEndpoints({
       onQueryStarted: (args, { queryFulfilled }) => {
         if (args.context) {
           const start = Date.now();
-          queryFulfilled.then(({ data }) => {
-            const duration = Date.now() - start;
-            trackSearchRequest(args, data, duration);
-          });
+          queryFulfilled
+            .then(({ data }) => {
+              const duration = Date.now() - start;
+              trackSearchRequest(args, data, duration);
+            })
+            .catch(console.warn);
         }
       },
     }),

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
@@ -98,6 +98,7 @@ export function EntityPickerModal<
   isLoadingTabs = false,
 }: EntityPickerModalProps<Model, Item>) {
   const [searchQuery, setSearchQuery] = useState<string>("");
+  const [searchError, setSearchError] = useState<Error | null>(null);
   const { data: recentItems, isLoading: isLoadingRecentItems } =
     useListRecentsQuery(
       { context: recentsContext },
@@ -217,6 +218,7 @@ export function EntityPickerModal<
                 setSearchQuery={setSearchQuery}
                 searchFilter={searchResultFilter}
                 searchParams={searchParams}
+                setSearchError={setSearchError}
               />
             )}
           </GrowFlex>
@@ -231,6 +233,7 @@ export function EntityPickerModal<
                   onItemSelect={onItemSelect}
                   searchQuery={searchQuery}
                   searchResults={searchResults}
+                  searchError={searchError}
                   selectedItem={selectedItem}
                   initialValue={initialValue}
                   defaultToRecentTab={defaultToRecentTab}

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.unit.spec.tsx
@@ -7,6 +7,7 @@ import {
   mockScrollBy,
   renderWithProviders,
   screen,
+  waitForLoaderToBeRemoved,
   within,
 } from "__support__/ui";
 import { Button } from "metabase/ui";
@@ -297,6 +298,46 @@ describe("EntityPickerModal", () => {
       expect(
         screen.queryByRole("button", { name: "Click Me" }),
       ).not.toBeInTheDocument();
+    });
+
+    it("should gracefully handle search errors", async () => {
+      setup();
+
+      fetchMock.get("path:/api/search", 500, {
+        overwriteRoutes: true,
+      });
+
+      await userEvent.type(
+        await screen.findByPlaceholderText("Search…"),
+        "My ",
+        {
+          delay: 50,
+        },
+      );
+
+      await waitForLoaderToBeRemoved();
+
+      expect(await screen.findByText("It's dead Jim")).toBeInTheDocument();
+    });
+
+    it("should gracefully handle non json responses", async () => {
+      setup();
+
+      fetchMock.get("path:/api/search", "It's a string", {
+        overwriteRoutes: true,
+      });
+
+      await userEvent.type(
+        await screen.findByPlaceholderText("Search…"),
+        "My ",
+        {
+          delay: 50,
+        },
+      );
+
+      await waitForLoaderToBeRemoved();
+
+      expect(await screen.findByText("It's dead Jim")).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/TabsView.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/TabsView.tsx
@@ -53,11 +53,13 @@ export const TabsView = <
   initialValue,
   defaultToRecentTab,
   setShowActionButtons,
+  searchError,
 }: {
   tabs: EntityTab<Model>[];
   onItemSelect: (item: Item) => void;
   searchQuery: string;
   searchResults: SearchResult[] | null;
+  searchError: Error | null;
   selectedItem: Item | null;
   initialValue?: Partial<Item>;
   searchParams?: Partial<SearchRequest>;
@@ -160,6 +162,7 @@ export const TabsView = <
         >
           <EntityPickerSearchResults
             searchResults={searchResults}
+            searchError={searchError}
             onItemSelect={onItemSelect}
             selectedItem={selectedItem}
           />

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerSearch/EntityPickerSearch.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerSearch/EntityPickerSearch.tsx
@@ -4,10 +4,11 @@ import { t } from "ttag";
 
 import { useSearchQuery } from "metabase/api";
 import EmptyState from "metabase/components/EmptyState";
+import { ErrorState } from "metabase/components/ErrorState";
 import { VirtualizedList } from "metabase/components/VirtualizedList";
 import { NoObjectError } from "metabase/components/errors/NoObjectError";
 import { trackSearchClick } from "metabase/search/analytics";
-import { Box, Flex, Icon, Stack, Tabs, TextInput } from "metabase/ui";
+import { Box, Flex, Icon, Image, Stack, Tabs, TextInput } from "metabase/ui";
 import type {
   SearchModel,
   SearchRequest,
@@ -107,15 +108,20 @@ export const EntityPickerSearchResults = <
   searchResults: SearchResult[] | null;
   onItemSelect: (item: Item) => void;
   selectedItem: Item | null;
-  searchError: Error;
+  searchError: Error | null;
 }) => {
   if (searchError) {
     return (
       <Box h="100%" bg="bg-light">
         <Flex direction="column" justify="center" h="100%">
-          <EmptyState
-            title={t`It's dead Jim`}
-            message={t`Not sure why, but the search errored`}
+          <ErrorState
+            illustrationElement={
+              <Image
+                src="app/img/something_went_wrong_trees.svg"
+                height={120}
+              />
+            }
+            title={t`Something went wrong`}
           />
         </Flex>
       </Box>

--- a/frontend/src/metabase/components/EmptyState/EmptyState.tsx
+++ b/frontend/src/metabase/components/EmptyState/EmptyState.tsx
@@ -1,3 +1,5 @@
+import type { HTMLAttributes } from "react";
+
 import Button from "metabase/core/components/Button";
 import Link from "metabase/core/components/Link";
 import CS from "metabase/css/core/index.css";
@@ -48,6 +50,7 @@ type EmptyStateProps = {
   className?: string;
   icon?: IconName;
   image?: string;
+  titleProps?: HTMLAttributes<HTMLHeadingElement>;
 };
 
 const EmptyState = ({

--- a/frontend/src/metabase/components/ErrorState/ErrorState.tsx
+++ b/frontend/src/metabase/components/ErrorState/ErrorState.tsx
@@ -1,0 +1,29 @@
+import type React from "react";
+
+import { Box, Flex, Text } from "metabase/ui";
+
+interface ErrorStateProps {
+  illustrationElement: React.ReactNode;
+  message?: string;
+  title?: string;
+}
+
+export const ErrorState = ({
+  illustrationElement,
+  message,
+  title,
+}: ErrorStateProps) => (
+  <Flex direction="column" align="center">
+    {illustrationElement && <Box>{illustrationElement}</Box>}
+    {title && (
+      <Text role="status" color="var(--mb-color-text-light)">
+        {title}
+      </Text>
+    )}
+    {message && (
+      <Text role="status" color="light">
+        {message}
+      </Text>
+    )}
+  </Flex>
+);

--- a/frontend/src/metabase/components/ErrorState/index.ts
+++ b/frontend/src/metabase/components/ErrorState/index.ts
@@ -1,0 +1,1 @@
+export * from "./ErrorState";

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestionView.stories.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestionView.stories.tsx
@@ -143,6 +143,17 @@ export const LightThemeDefaultNoResults = {
   },
 };
 
+export const LightThemeDefaultError = {
+  render: Template,
+
+  args: {
+    ...defaultArgs,
+    result: createMockDataset({
+      error: "Squawk",
+    }),
+  },
+};
+
 export const LightThemeDownload = {
   render: Template,
 

--- a/resources/frontend_client/app/img/something_went_wrong_trees.svg
+++ b/resources/frontend_client/app/img/something_went_wrong_trees.svg
@@ -1,0 +1,24 @@
+<svg width="122" height="120" viewBox="0 0 122 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M121 95L1 95" stroke="#F0F0F0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7 91L7 95" stroke="#F0F0F0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M33 91L33 95" stroke="#F0F0F0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M36 93L36 95" stroke="#F0F0F0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M68 93L68 95" stroke="#F0F0F0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M48 93L48 95" stroke="#F0F0F0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M71 92L71 95" stroke="#F0F0F0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M30 92L30 95" stroke="#F0F0F0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11 93L11 95" stroke="#F0F0F0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M24 93L24 95" stroke="#F0F0F0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M84.35 78.49L80.4 93.99L113.38 94.14L84.35 78.49Z" fill="white"/>
+<path d="M103.5 89L80.4 93.99L113.38 94.14L103.5 89Z" fill="#F4F4F4" stroke="#F4F4F4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M84.35 78.49L80.4 93.99L113.38 94.14L84.35 78.49Z" stroke="#DCDCDC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M90.12 88.21L74.62 84.26" stroke="#DCDCDC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M42 85.6H61.2L51.6 47.2L42 85.6Z" fill="white"/>
+<path d="M56.4 85.6H61.2L51.6 47.2L56.4 85.6Z" fill="#F4F4F4" stroke="#F4F4F4" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M42 85.6H61.2L51.6 47.2L42 85.6Z" stroke="#DCDCDC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M51.6 76V95.2" stroke="#DCDCDC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11 87.2H27L19 55.2L11 87.2Z" fill="white"/>
+<path d="M23 87.2H27L19 55.2L23 87.2Z" fill="#F4F4F4" stroke="#F4F4F4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11 87.2H27L19 55.2L11 87.2Z" stroke="#DCDCDC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M19 79.2V95.2" stroke="#DCDCDC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/45586

### Description
In the event that the API returns an error or non-json response on search, we should handle this gracefully. Previously, the entity picker would either display an infinite loading indicator, or it would crash completely. Now, we will display a search panel with an error message

### How to verify

1. Find a way to force an error with the `/search` endpoint (this can be done in chrome by right clicking a search request and selecting "block request url"
2. Open the entity picker (new => dashbaord => pick collection), and perform a search
3. You should see an error message displayed in the picker

### Demo
![image](https://github.com/user-attachments/assets/a019f189-6e59-41e7-9c21-44bda3b9887e)

### Checklist

- [s] Tests have been added/updated to cover changes in this PR
