### PR TITLE
Simple API for storing KV pairs per-user

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -89,5 +89,6 @@
    "TablePrivileges"
    "TaskHistory"
    "User"
+   "UserKeyValue"
    "UserParameterValue"
    "ViewLog"])

--- a/enterprise/backend/test/metabase_enterprise/models/entity_id_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/models/entity_id_test.clj
@@ -87,6 +87,7 @@
     :model/TimelineEvent
     :model/User
     :model/UserParameterValue
+    :model/UserKeyValue
     :model/ViewLog
     :model/GroupTableAccessPolicy
     :model/ConnectionImpersonation

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10337,8 +10337,8 @@ databaseChangeLog:
       preConditions:
         - onFail: MARK_RAN
         - not:
-          - tableExists:
-              tableName: user_key_value
+            - tableExists:
+                tableName: user_key_value
       changes:
         - createTable:
             tableName: user_key_value
@@ -10364,6 +10364,8 @@ databaseChangeLog:
                   name: namespace
                   type: varchar(254)
                   remarks: 'The namespace for this KV, e.g. "dashboard-filters" or "nobody-knows"'
+                  constraints:
+                    nullable: false
               - column:
                   name: key
                   remarks: 'The key'

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -10328,6 +10328,85 @@ databaseChangeLog:
               ALTER TABLE notification_recipient ALTER COLUMN id RESTART WITH 1;
               ALTER TABLE channel_template ALTER COLUMN id RESTART WITH 1;
 
+  - changeSet:
+      id: v53.2024-12-20T19:53:50
+      author: johnswanson
+      comment: >
+        add a table for user-level KV. This is intended for use as a lightweight mechanism for the frontend to be able
+        to mark things as seen, unseen, dismissed, etc
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+          - tableExists:
+              tableName: user_key_value
+      changes:
+        - createTable:
+            tableName: user_key_value
+            remarks: A simple key value store for each user.
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: user_id
+                  type: int
+                  remarks: 'The ID of the user this KV-pair is for'
+                  constraints:
+                    nullable: false
+                    referencedTableName: core_user
+                    referencedColumnNames: id
+                    foreignKeyName: fk_user_key_value_user_id
+              - column:
+                  name: namespace
+                  type: varchar(254)
+                  remarks: 'The namespace for this KV, e.g. "dashboard-filters" or "nobody-knows"'
+              - column:
+                  name: key
+                  remarks: 'The key'
+                  type: varchar(254)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: value
+                  remarks: 'The value, serialized JSON'
+                  type: ${text.type}
+                  constraints:
+                    nullable: true
+              - column:
+                  name: created_at
+                  remarks: 'When this row was created'
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  remarks: 'When this row was last updated'
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+              - column:
+                  name: expires_at
+                  remarks: 'If set, when this row expires'
+                  type: ${timestamp_type}
+                  defaultValue: null
+
+  - changeSet:
+      id: v53.2024-12-20T19:53:59
+      author: johnswanson
+      comment: Add a unique constraint for user_id,namespace,key
+      changes:
+        - addUniqueConstraint:
+            tableName: user_key_value
+            columnNames: user_id, namespace, key
+            constraintName: unique_user_key_value_user_id_namespace_key
+      rollback: # will be deleted with table
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/api/routes.clj
+++ b/src/metabase/api/routes.clj
@@ -53,6 +53,7 @@
    [metabase.api.timeline :as api.timeline]
    [metabase.api.timeline-event :as api.timeline-event]
    [metabase.api.user :as api.user]
+   [metabase.api.user-key-value :as api.user-key-value]
    [metabase.api.util :as api.util]
    [metabase.config :as config]
    [metabase.plugins.classloader :as classloader]
@@ -153,6 +154,7 @@
   (context "/timeline"             [] (+auth api.timeline/routes))
   (context "/timeline-event"       [] (+auth api.timeline-event/routes))
   (context "/user"                 [] (+auth api.user/routes))
+  (context "/user-key-value"       [] (+auth api.user-key-value/routes))
   (context "/api-key"              [] (+auth api.api-key/routes))
   (context "/util"                 [] api.util/routes)
   (route/not-found (constantly {:status 404, :body (deferred-tru "API endpoint does not exist.")})))

--- a/src/metabase/api/user_key_value.clj
+++ b/src/metabase/api/user_key_value.clj
@@ -1,0 +1,55 @@
+(ns metabase.api.user-key-value
+  (:require [compojure.core :refer [GET PUT DELETE]]
+            [malli.core :as mc]
+            [malli.experimental.time.transform :as mett]
+            [malli.transform :as mtx]
+            [metabase.api.common :as api]
+            [metabase.models.user-key-value :as user-key-value]
+            [metabase.models.user-key-value.types :as types]
+            [metabase.util.malli.registry :as mr]
+            [metabase.util.malli.schema :as ms]))
+
+(api/defendpoint PUT "/"
+  "Upsert a KV-pair for the user"
+  [:as {{k :key
+         namespace :namespace
+         v :value
+         expires_at :expires_at} :body}]
+  {k ms/NonBlankString
+   v :any
+   namespace ms/NonBlankString
+   expires_at [:maybe :metabase.lib.schema.literal/string.datetime]}
+  (try (user-key-value/put! api/*current-user-id* (mc/coerce ::types/user-key-value
+                                                             {:key k
+                                                              :namespace namespace
+                                                              :value v
+                                                              :expires-at expires_at}
+                                                             (mtx/transformer
+                                                              (mtx/default-value-transformer)
+                                                              (mett/time-transformer)
+                                                              {:name :api-request})))
+       (catch Exception e
+         (when (= (:type (ex-data e))
+                  ::mc/coercion)
+           (api/check-400 false))
+         (throw e))))
+
+(api/defendpoint GET "/"
+  "Get a value for the user"
+  [namespace key]
+  {key (ms/QueryVectorOf ms/NonBlankString)
+   namespace ms/NonBlankString}
+  (into {}
+        (for [k key]
+          [k (user-key-value/retrieve api/*current-user-id* namespace k)])))
+
+(api/defendpoint DELETE "/"
+  "Deletes a KV-pair for the user"
+  [:as {{k :key namespace :namespace} :body}]
+  (user-key-value/delete! api/*current-user-id*
+                          namespace
+                          k))
+
+(mr/resolve-schema ::types/user-key-value)
+
+(api/define-routes)

--- a/src/metabase/api/user_key_value.clj
+++ b/src/metabase/api/user_key_value.clj
@@ -41,7 +41,7 @@
   (user-key-value/retrieve api/*current-user-id* namespace key))
 
 (api/defendpoint GET "/namespace/:namespace"
-  "Returns the values for all keys in a given namespace for the current user."
+  "Returns all KV pairs in a given namespace for the current user"
   [namespace]
   {namespace ms/NonBlankString}
   (user-key-value/retrieve-all api/*current-user-id* namespace))

--- a/src/metabase/api/user_key_value.clj
+++ b/src/metabase/api/user_key_value.clj
@@ -41,15 +41,10 @@
   (user-key-value/retrieve api/*current-user-id* namespace key))
 
 (api/defendpoint GET "/namespace/:namespace"
-  "Get the value for multiple keys in a namespace"
-  [:as {{:strs [keyyy]}
-        :query-params :as prms}
-   namespace]
-  {keyyy [:maybe (ms/QueryVectorOf ms/PositiveInt)]
-   namespace ms/NonBlankString}
-  (into {}
-        (for [k key]
-          [k (user-key-value/retrieve api/*current-user-id* namespace key)])))
+  "Returns the values for all keys in a given namespace for the current user."
+  [namespace]
+  {namespace ms/NonBlankString}
+  (user-key-value/retrieve-all api/*current-user-id* namespace))
 
 (api/defendpoint DELETE "/namespace/:namespace/key/:key"
   "Deletes a KV-pair for the user"

--- a/src/metabase/models/user_key_value.clj
+++ b/src/metabase/models/user_key_value.clj
@@ -1,0 +1,102 @@
+(ns metabase.models.user-key-value
+  "This namespace allows the frontend to store and retrieve arbitrary key-value pairs for individual users in the
+  database.
+
+  Each KVP is stored in a single 'namespace', which has a schema. You can write a schema in
+  `resources/user_key_value_types/*.edn`. (If the schema will only be used in tests, you can use
+  `test_resources/user_key_value_types/*.edn`.) The content should be a Malli schema. For example, a file
+  `resources/user_key_value_types/foo.edn` with the content
+
+  ```
+  [:map [:value [:maybe :string]]]
+  ```
+
+  would define a new namespace, `foo`, where keys and values are both arbitrary strings.
+
+  If you want, you can get more creative - for example, if you have a defined set of allowed keys, you could say:
+
+  ```
+  [:map
+   [:key [:enum \"allowed-key-1\" \"allowed-key-2\"]]
+   [:value [:maybe :string]]]
+  ```
+
+  Or you could go even further, and define a `:multi` spec that has a spec for keys in the case of particular values:
+
+  ```
+  [:multi {:dispatch :key}
+   [\"string-key\" [:map [:value [:maybe :string]]]]
+   [\"number-key\" [:map [:value [:maybe :int]]]]]
+  ```
+
+  Note that: `value` must always be `:maybe` - a null value means to delete the KVP.
+  "
+  (:require
+   [malli.core :as mc]
+   [malli.transform :as mtx]
+   [metabase.models.user-key-value.types :as types]
+   [metabase.util.malli :as mu]
+   [methodical.core :as methodical]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(methodical/defmethod t2/table-name :model/UserKeyValue [_model] :user_key_value)
+
+(doto :model/UserKeyValue
+  (derive :metabase/model)
+  (derive :hook/timestamped?))
+
+(mu/defn put!
+  "Upserts a KV-pair"
+  [user-id :- :int
+   kvp :- ::types/user-key-value]
+  (let [{:keys [namespace key value expires-at]}
+        (mc/encode ::types/user-key-value
+                   kvp
+                   (mtx/transformer
+                    (mtx/default-value-transformer)
+                    {:name :database}))]
+    (t2/with-transaction [_]
+      (if (t2/select-one :model/UserKeyValue :user_id user-id :namespace namespace :key key)
+        (t2/update! :model/UserKeyValue :user_id user-id :namespace namespace :key key {:value value
+                                                                                        :expires_at expires-at})
+        (try
+          (t2/insert! :model/UserKeyValue {:user_id user-id
+                                           :namespace namespace
+                                           :key key
+                                           :value value
+                                           :expires_at expires-at})
+          ;; in case we caught a duplicate key exception (a row was inserted between our read and write), try updating
+          (catch Exception _
+            (t2/update! :model/UserKeyValue :user_id user-id :namespace namespace :key key {:value value
+                                                                                            :expires_at expires-at})))))
+    value))
+
+(mu/defn delete!
+  "Deletes a KV-pair"
+  [user-id :- :int
+   namespace :- :string
+   k :- :string]
+  (t2/delete! :model/UserKeyValue :namespace namespace :user_id user-id :key k))
+
+(mu/defn retrieve
+  "Retrieves a KV-pair"
+  [user-id :- :int
+   namespace :- :string
+   k :- :string]
+  (when-let [ukv
+             (t2/select-one :model/UserKeyValue
+                            {:where
+                             [:and
+                              [:= :user_id user-id]
+                              [:= :namespace namespace]
+                              [:= :key k]
+                              [:or
+                               [:>= :expires_at :%now]
+                               [:= :expires_at nil]]]})]
+    (:value (mc/decode ::types/user-key-value
+                       ukv
+                       (mtx/transformer
+                        (mtx/default-value-transformer)
+                        {:name :database})))))

--- a/src/metabase/models/user_key_value/types.clj
+++ b/src/metabase/models/user_key_value/types.clj
@@ -36,7 +36,7 @@
    :keyword])
 
 (mr/def ::expires-at
-  "When the thing expires"
+  "When the key-value pair expires"
   :time/instant)
 
 (mu/defn defnamespace

--- a/src/metabase/models/user_key_value/types.clj
+++ b/src/metabase/models/user_key_value/types.clj
@@ -1,0 +1,153 @@
+(ns metabase.models.user-key-value.types
+  (:require
+   [clojure.edn :as edn]
+   [clojure.java.classpath :as classpath]
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   [metabase.config :as config]
+   [metabase.util.json :as json]
+   [metabase.util.log :as log]
+   [metabase.util.malli :as mu]
+   [metabase.util.malli.registry :as mr])
+  (:import
+   (java.io File)
+   (java.nio.file FileSystems
+                  Path
+                  StandardWatchEventKinds
+                  WatchKey
+                  WatchService
+                  WatchEvent)))
+
+(set! *warn-on-reflection* true)
+
+(defn- file->namespace [^File f]
+  (keyword "namespace" (-> f .getName (str/replace #"\.edn$" ""))))
+
+(mr/def ::namespace
+  "A namespace for the key-value pair"
+  [:and
+   {;; api request comes in, turn `foo` into `:namespace/foo`
+    :decode/api-request (partial keyword "namespace")
+    :encode/api-request name
+    ;; writing to the DB, turn `:namespace/foo` into `foo`
+    :encode/database name
+    ;; reading from the DB, turn `foo` into `:namespace/foo`
+    :decode/database (partial keyword "namespace")}
+   :keyword])
+
+(mr/def ::expires-at
+  "When the thing expires"
+  :time/instant)
+
+(mu/defn defnamespace
+  "Declare a new namespace with a schema for the value"
+  [namespace :- ::namespace
+   schema]
+  (derive namespace ::registered-namespace)
+  (mr/register! namespace schema))
+
+(defn- known-namespaces
+  []
+  (descendants ::registered-namespace))
+
+;;; this is just a placeholder so LSP can register the place it lives for jump-to-definition functionality. Actual
+;;; schema gets created below by [[user-key-value-schema]] and [[update-user-key-value-schema]]
+(mr/def ::user-key-value any?)
+
+(defn- user-key-value-schema
+  "Build the schema for a `::user-key-value`"
+  []
+  [:and
+   [:map
+    [:expires-at [:maybe ::expires-at]]
+    [:namespace ::namespace]
+    [:value {:encode/database json/encode
+             :decode/database #(json/decode % keyword)}
+     :any]]
+   (into [:multi
+          {:dispatch :namespace}]
+         (map (fn [namespace]
+                [namespace namespace]))
+         (known-namespaces))])
+
+(defn- update-user-key-value-schema! []
+  (log/debug "Updating user-key-value schema")
+  (mr/register! ::user-key-value (user-key-value-schema)))
+
+(update-user-key-value-schema!)
+
+;; Types live in `resources/user_key_value_types`
+
+(defn- types-dirs
+  "Types live in `user_key_value_types`, in both `test_resources` and `resources`."
+  []
+  (->> (classpath/classpath-directories)
+       (map #(io/file % "user_key_value_types"))
+       (filter #(.exists ^File %))))
+
+(defn- types-files []
+  (->> (types-dirs)
+       (mapcat #(file-seq (io/file %)))
+       (filter #(.isFile ^File %))
+       distinct))
+
+(defn- load-schema
+  "Load a schema from an EDN file, using its name as the namespace."
+  [^File file]
+  (let [namespace (file->namespace file)
+        schema  (-> file slurp edn/read-string)]
+    (defnamespace namespace schema)
+    (update-user-key-value-schema!)))
+
+(defn load-all-schemas
+  "Load all schemas from the types directory."
+  []
+  (doseq [^File file (types-files)]
+    (when (str/ends-with? (.getName file) ".edn")
+      (load-schema file))))
+
+(defn watch-directory
+  "Watch a directory for changes and call the callback with the affected file."
+  [dir callback]
+  (let [^WatchService watcher (.newWatchService (FileSystems/getDefault))
+        ^Path path    (.toPath (io/file dir))]
+    (.register path watcher
+               (into-array [StandardWatchEventKinds/ENTRY_CREATE
+                            StandardWatchEventKinds/ENTRY_MODIFY
+                            StandardWatchEventKinds/ENTRY_DELETE]))
+    (future
+      (loop []
+        (when-let [^WatchKey key (.take watcher)]
+          (doseq [^WatchEvent event (.pollEvents key)]
+            (let [kind (.kind event)
+                  filename (.context event)
+                  file (io/file dir (.toString filename))]
+              (cond
+                (= kind StandardWatchEventKinds/ENTRY_CREATE) (callback file :create)
+                (= kind StandardWatchEventKinds/ENTRY_MODIFY) (callback file :modify)
+                (= kind StandardWatchEventKinds/ENTRY_DELETE) (callback file :delete))))
+          (.reset key)
+          (recur))))))
+
+(defn handle-file-change
+  "Handle a file change in the types directory."
+  [^File file action]
+  (case action
+    :create (load-schema file)
+    :modify (load-schema file)
+    :delete (let [namespace (file->namespace file)]
+              ;; this is kind of silly. we don't have a way to delete something from the registry, so just hackily
+              ;; make a schema that can't ever be valid. In production, we're not going to be watching files, so
+              ;; this is solely for dev.
+              (defnamespace namespace [:and true? false?]))))
+
+(defn load-and-watch-schemas
+  "In production, just load the schemas. In development, watch for changes as well."
+  []
+  (load-all-schemas)
+  (when config/is-dev?
+    (doseq [types-dir (types-dirs)]
+      (watch-directory types-dir handle-file-change))))
+
+#_{:clj-kondo/ignore [:unused-private-var]}
+(defonce ^:private watcher (load-and-watch-schemas))

--- a/test/metabase/api/user_key_value_test.clj
+++ b/test/metabase/api/user_key_value_test.clj
@@ -34,6 +34,11 @@
       (is (= {:key1 "foo" :key2 123} (mt/user-http-request :rasta :put 200 "/user-key-value/namespace/meow/key/meow" {:value {:key1 "foo" :key2 123}})))
       (is (= {:key1 "foo" :key2 123} (mt/user-http-request :rasta :get 200 "/user-key-value/namespace/meow/key/meow"))))
 
+    (testing "Malli schema can specify default values"
+      ;; See https://github.com/metosin/malli#default-values for more details on default values
+      (is (= {:key1 "default" :key2 123} (mt/user-http-request :rasta :put 200 "/user-key-value/namespace/meow/key/meow" {:value {:key2 123}})))
+      (is (= {:key1 "default" :key2 123} (mt/user-http-request :rasta :get 200 "/user-key-value/namespace/meow/key/meow"))))
+
     (testing "Deletion works"
       (mt/user-http-request :rasta :put 200 "/user-key-value/namespace/other/key/other" {:value "true"})
       (is (= true (mt/user-http-request :rasta :get 200 "/user-key-value/namespace/other/key/other")))

--- a/test/metabase/api/user_key_value_test.clj
+++ b/test/metabase/api/user_key_value_test.clj
@@ -4,23 +4,41 @@
 
 (deftest it-works
   (mt/with-model-cleanup [:model/UserKeyValue]
-    (mt/user-http-request :rasta :put 200 "/user-key-value/namespace/cats/key/meow")
-    (is (= nil
-           (mt/user-http-request :rasta :get 204 "/user-key-value/namespace/cats/key/meow" {})))
-    (is (= "mix" (mt/user-http-request :rasta :put 200 "/user-key-value/namespace/cats/key/meow" {:value "mix"})))
-    (is (= "mix" (mt/user-http-request :rasta :get 200 "/user-key-value/namespace/cats/key/meow")))
-    (is (= "hello" (mt/user-http-request :rasta :put 200 "/user-key-value/namespace/cats/key/meow" {:value "hello"})))
-    (is (= "hello" (mt/user-http-request :rasta :get 200 "/user-key-value/namespace/cats/key/meow")))
-    (mt/user-http-request :rasta :put 200 "/user-key-value/namespace/meow/key/meow" {})
-    (is (= {:key1 "foo" :key2 123} (mt/user-http-request :rasta :put 200 "/user-key-value/namespace/meow/key/meow" {:value {:key1 "foo" :key2 123}})))
-    (is (= {:key1 "foo" :key2 123} (mt/user-http-request :rasta :get 200 "/user-key-value/namespace/meow/key/meow")))
-    (mt/user-http-request :rasta :put 400 "/user-key-value/namespace/meow/key/meow" {:value {}})
+    (testing "Can clear values by setting them to nil"
+      (mt/user-http-request :rasta :put 200 "/user-key-value/namespace/cats/key/meow" {:value nil})
+      (is (= nil (mt/user-http-request :rasta :get 204 "/user-key-value/namespace/cats/key/meow")))
+      (mt/user-http-request :crowberto :put 200 "/user-key-value/namespace/cats/key/meow" {:value nil})
+      (is (= nil (mt/user-http-request :crowberto :get 204 "/user-key-value/namespace/cats/key/meow"))))
+
+    (testing "Can set and reset user-local key-value pairs"
+      ;; Set one KV pair for Rasta
+      (is (= "mix" (mt/user-http-request :rasta :put 200 "/user-key-value/namespace/cats/key/meow" {:value "mix"})))
+      (is (= "mix" (mt/user-http-request :rasta :get 200 "/user-key-value/namespace/cats/key/meow")))
+
+      ;; Update KV pair for rasta
+      (is (= "hello" (mt/user-http-request :rasta :put 200 "/user-key-value/namespace/cats/key/meow" {:value "hello"})))
+      (is (= "hello" (mt/user-http-request :rasta :get 200 "/user-key-value/namespace/cats/key/meow")))
+
+      ;; Set KV pair for Crowberto using the same key
+      (is (= nil (mt/user-http-request :crowberto :get 204 "/user-key-value/namespace/cats/key/meow")))
+      (is (= "dog" (mt/user-http-request :crowberto :put 200 "/user-key-value/namespace/cats/key/meow" {:value "dog"})))
+      (is (= "dog" (mt/user-http-request :crowberto :get 200 "/user-key-value/namespace/cats/key/meow")))
+
+      ;; Rasta's value doesn't change
+      (is (= "hello" (mt/user-http-request :rasta :get 200 "/user-key-value/namespace/cats/key/meow"))))
+
+    (testing "Values are validated against Malli schemas on write, and transformed based on the schemas on read"
+      (mt/user-http-request :rasta :put 400 "/user-key-value/namespace/meow/key/meow" {:value {}})
+      (mt/user-http-request :rasta :put 200 "/user-key-value/namespace/meow/key/meow" {})
+
+      (is (= {:key1 "foo" :key2 123} (mt/user-http-request :rasta :put 200 "/user-key-value/namespace/meow/key/meow" {:value {:key1 "foo" :key2 123}})))
+      (is (= {:key1 "foo" :key2 123} (mt/user-http-request :rasta :get 200 "/user-key-value/namespace/meow/key/meow"))))
+
     (testing "Deletion works"
       (mt/user-http-request :rasta :put 200 "/user-key-value/namespace/other/key/other" {:value "true"})
       (is (= true (mt/user-http-request :rasta :get 200 "/user-key-value/namespace/other/key/other")))
       (mt/user-http-request :rasta :delete 200 "/user-key-value/namespace/other/key/other")
-      (is (= nil
-             (mt/user-http-request :rasta :get 204 "/user-key-value/namespace/other/key/other"))))))
+      (is (= nil (mt/user-http-request :rasta :get 204 "/user-key-value/namespace/other/key/other"))))))
 
 (deftest expiry-works
   (mt/with-model-cleanup [:model/UserKeyValue]
@@ -30,10 +48,11 @@
 
 (deftest multi-retrieve-works
   (mt/with-model-cleanup [:model/UserKeyValue]
-    (mt/user-http-request :rasta :put 200 "/user-key-value/namespace/other/key/a" {:value "a"})
-    (mt/user-http-request :rasta :put 200 "/user-key-value/namespace/other/key/b" {:value "b"})
-    (mt/user-http-request :rasta :put 200 "/user-key-value/namespace/other/key/c" {:value "c"})
-    (is (= {:a "a"
-            :b "b"
-            :c "c"}
-           (mt/user-http-request :rasta :get 200 "/user-key-value/namespace/other?a=123&keyyy=1234&keyyy=24564&keyyy=1234")))))
+    (testing "All KV pairs set in a namespace can be fetched at once"
+      (mt/user-http-request :rasta :put 200 "/user-key-value/namespace/other/key/a" {:value "a value"})
+      (mt/user-http-request :rasta :put 200 "/user-key-value/namespace/other/key/b" {:value "b value"})
+      (mt/user-http-request :rasta :put 200 "/user-key-value/namespace/other/key/c" {:value "c value"})
+      (is (= {:a "a value"
+              :b "b value"
+              :c "c value"}
+             (mt/user-http-request :rasta :get 200 "/user-key-value/namespace/other"))))))

--- a/test/metabase/api/user_key_value_test.clj
+++ b/test/metabase/api/user_key_value_test.clj
@@ -1,0 +1,31 @@
+(ns metabase.api.user-key-value-test
+  (:require [clojure.test :refer :all]
+            [metabase.test :as mt]))
+
+(deftest it-works
+  (mt/with-model-cleanup [:model/UserKeyValue]
+    (mt/user-http-request :rasta :put 200 "/user-key-value" {:key "meow" :namespace "cats"})
+    (is (= {:meow nil}
+           (mt/user-http-request :rasta :get 200 "/user-key-value?key=meow&namespace=cats")))
+    (is (= "mix" (mt/user-http-request :rasta :put 200 "/user-key-value" {:key "meow" :namespace "cats" :value "mix"})))
+    (is (= {:meow "mix"} (mt/user-http-request :rasta :get 200 "/user-key-value?key=meow&namespace=cats")))
+    (is (= "hello" (mt/user-http-request :rasta :put 200 "/user-key-value" {:key "meow" :value "hello" :namespace "cats"})))
+    (is (= {:meow "hello"} (mt/user-http-request :rasta :get 200 "/user-key-value?key=meow&namespace=cats")))
+    (mt/user-http-request :rasta :put 200 "/user-key-value" {:key "meow" :namespace "meow"})
+    (is (= {:key1 "foo" :key2 123} (mt/user-http-request :rasta :put 200 "/user-key-value" {:key "meow" :namespace "meow" :value {:key1 "foo" :key2 123}})))
+    (is (= {:meow {:key1 "foo" :key2 123}} (mt/user-http-request :rasta :get 200 "/user-key-value?key=meow&namespace=meow")))
+    (mt/user-http-request :rasta :put 400 "/user-key-value" {:key "meow" :namespace "meow" :value {}})
+    (testing "Deletion works"
+      (mt/user-http-request :rasta :put 200 "/user-key-value" {:key "other" :namespace "other" :value "true"})
+      (is (= {:other "true"} (mt/user-http-request :rasta :get 200 "/user-key-value" {} :key "other" :namespace "other")))
+      (mt/user-http-request :rasta :delete 200 "/user-key-value" {:key "other" :namespace "other"})
+      (is (= {:other nil}
+             (mt/user-http-request :rasta :get 200 "/user-key-value" {} :key "other" :namespace "other"))))))
+
+(deftest expiry-works
+  (mt/with-model-cleanup [:model/UserKeyValue]
+    (mt/user-http-request :rasta :put 200 "/user-key-value" {:namespace "cats"
+                                                             :key "meow"
+                                                             :value "the-value"
+                                                             :expires_at "2014-01-01T00:00:00Z"})
+    (is (= {:meow nil} (mt/user-http-request :rasta :get 200 "/user-key-value?key=meow&namespace=cats")))))

--- a/test/metabase/api/user_key_value_test.clj
+++ b/test/metabase/api/user_key_value_test.clj
@@ -4,28 +4,36 @@
 
 (deftest it-works
   (mt/with-model-cleanup [:model/UserKeyValue]
-    (mt/user-http-request :rasta :put 200 "/user-key-value" {:key "meow" :namespace "cats"})
-    (is (= {:meow nil}
-           (mt/user-http-request :rasta :get 200 "/user-key-value?key=meow&namespace=cats")))
-    (is (= "mix" (mt/user-http-request :rasta :put 200 "/user-key-value" {:key "meow" :namespace "cats" :value "mix"})))
-    (is (= {:meow "mix"} (mt/user-http-request :rasta :get 200 "/user-key-value?key=meow&namespace=cats")))
-    (is (= "hello" (mt/user-http-request :rasta :put 200 "/user-key-value" {:key "meow" :value "hello" :namespace "cats"})))
-    (is (= {:meow "hello"} (mt/user-http-request :rasta :get 200 "/user-key-value?key=meow&namespace=cats")))
-    (mt/user-http-request :rasta :put 200 "/user-key-value" {:key "meow" :namespace "meow"})
-    (is (= {:key1 "foo" :key2 123} (mt/user-http-request :rasta :put 200 "/user-key-value" {:key "meow" :namespace "meow" :value {:key1 "foo" :key2 123}})))
-    (is (= {:meow {:key1 "foo" :key2 123}} (mt/user-http-request :rasta :get 200 "/user-key-value?key=meow&namespace=meow")))
-    (mt/user-http-request :rasta :put 400 "/user-key-value" {:key "meow" :namespace "meow" :value {}})
+    (mt/user-http-request :rasta :put 200 "/user-key-value/namespace/cats/key/meow")
+    (is (= nil
+           (mt/user-http-request :rasta :get 204 "/user-key-value/namespace/cats/key/meow" {})))
+    (is (= "mix" (mt/user-http-request :rasta :put 200 "/user-key-value/namespace/cats/key/meow" {:value "mix"})))
+    (is (= "mix" (mt/user-http-request :rasta :get 200 "/user-key-value/namespace/cats/key/meow")))
+    (is (= "hello" (mt/user-http-request :rasta :put 200 "/user-key-value/namespace/cats/key/meow" {:value "hello"})))
+    (is (= "hello" (mt/user-http-request :rasta :get 200 "/user-key-value/namespace/cats/key/meow")))
+    (mt/user-http-request :rasta :put 200 "/user-key-value/namespace/meow/key/meow" {})
+    (is (= {:key1 "foo" :key2 123} (mt/user-http-request :rasta :put 200 "/user-key-value/namespace/meow/key/meow" {:value {:key1 "foo" :key2 123}})))
+    (is (= {:key1 "foo" :key2 123} (mt/user-http-request :rasta :get 200 "/user-key-value/namespace/meow/key/meow")))
+    (mt/user-http-request :rasta :put 400 "/user-key-value/namespace/meow/key/meow" {:value {}})
     (testing "Deletion works"
-      (mt/user-http-request :rasta :put 200 "/user-key-value" {:key "other" :namespace "other" :value "true"})
-      (is (= {:other "true"} (mt/user-http-request :rasta :get 200 "/user-key-value" {} :key "other" :namespace "other")))
-      (mt/user-http-request :rasta :delete 200 "/user-key-value" {:key "other" :namespace "other"})
-      (is (= {:other nil}
-             (mt/user-http-request :rasta :get 200 "/user-key-value" {} :key "other" :namespace "other"))))))
+      (mt/user-http-request :rasta :put 200 "/user-key-value/namespace/other/key/other" {:value "true"})
+      (is (= true (mt/user-http-request :rasta :get 200 "/user-key-value/namespace/other/key/other")))
+      (mt/user-http-request :rasta :delete 200 "/user-key-value/namespace/other/key/other")
+      (is (= nil
+             (mt/user-http-request :rasta :get 204 "/user-key-value/namespace/other/key/other"))))))
 
 (deftest expiry-works
   (mt/with-model-cleanup [:model/UserKeyValue]
-    (mt/user-http-request :rasta :put 200 "/user-key-value" {:namespace "cats"
-                                                             :key "meow"
-                                                             :value "the-value"
-                                                             :expires_at "2014-01-01T00:00:00Z"})
-    (is (= {:meow nil} (mt/user-http-request :rasta :get 200 "/user-key-value?key=meow&namespace=cats")))))
+    (mt/user-http-request :rasta :put 200 "/user-key-value/namespace/cats/key/meow" {:value "the-value"
+                                                                                     :expires_at "2014-01-01T00:00:00Z"})
+    (is (= nil (mt/user-http-request :rasta :get 204 "/user-key-value/namespace/cats/key/meow")))))
+
+(deftest multi-retrieve-works
+  (mt/with-model-cleanup [:model/UserKeyValue]
+    (mt/user-http-request :rasta :put 200 "/user-key-value/namespace/other/key/a" {:value "a"})
+    (mt/user-http-request :rasta :put 200 "/user-key-value/namespace/other/key/b" {:value "b"})
+    (mt/user-http-request :rasta :put 200 "/user-key-value/namespace/other/key/c" {:value "c"})
+    (is (= {:a "a"
+            :b "b"
+            :c "c"}
+           (mt/user-http-request :rasta :get 200 "/user-key-value/namespace/other?a=123&keyyy=1234&keyyy=24564&keyyy=1234")))))

--- a/test/metabase/cmd/copy_test.clj
+++ b/test/metabase/cmd/copy_test.clj
@@ -40,7 +40,8 @@
     :model/QueryField
     :model/QueryTable
     :model/SearchIndexMetadata
-    :model/TaskHistory})
+    :model/TaskHistory
+    :model/UserKeyValue})
 
 (defn- all-model-names []
   (into (sorted-set)

--- a/test_resources/user_key_value_types/cats.edn
+++ b/test_resources/user_key_value_types/cats.edn
@@ -1,3 +1,2 @@
-;; this is solely used in tests
 [:multi {:dispatch :key}
  ["meow" [:map [:value [:maybe :string]]]]]

--- a/test_resources/user_key_value_types/cats.edn
+++ b/test_resources/user_key_value_types/cats.edn
@@ -1,0 +1,3 @@
+;; this is solely used in tests
+[:multi {:dispatch :key}
+ ["meow" [:map [:value [:maybe :string]]]]]

--- a/test_resources/user_key_value_types/meow.edn
+++ b/test_resources/user_key_value_types/meow.edn
@@ -1,0 +1,4 @@
+[:map
+ [:value [:maybe [:map
+                  [:key1 :string]
+                  [:key2 :int]]]]]

--- a/test_resources/user_key_value_types/meow.edn
+++ b/test_resources/user_key_value_types/meow.edn
@@ -1,4 +1,4 @@
 [:map
  [:value [:maybe [:map
-                  [:key1 :string]
+                  [:key1 {:default "default"} :string]
                   [:key2 :int]]]]]

--- a/test_resources/user_key_value_types/other.edn
+++ b/test_resources/user_key_value_types/other.edn
@@ -1,0 +1,2 @@
+[:map
+ [:value :string]]


### PR DESCRIPTION
https://www.notion.so/metabase/Easier-Product-Call-Outs-11569354c90180de84aac20ad872143f

https://www.notion.so/metabase/Tech-Generic-user-specific-state-storage-14369354c901807390cbd89a381e8c12#15169354c9018096820ccf20a62e38e0



Provide a very simple store - essentially a set of keys. This is intended for use as a way to allow the frontend to do very lightweight things like "this user dismissed this modal, don't show it again" or "this user was shown some Thing, don't show it again", etc.

Each KV-pair is stored for a particular user, in a particular context.

Each context has a malli schema that allows frontend folks to easily define a schema within a given context - for example, one context could only have integer values, or a defined set of allowed keys, etc. In development, these schemas are automatically reloaded anytime they change, while in production they're only read once.