### PR TITLE
[Auto Clean-up] Add alert prompting admins to clean up a collection

### DIFF
--- a/e2e/test/scenarios/collections/cleanup.cy.spec.js
+++ b/e2e/test/scenarios/collections/cleanup.cy.spec.js
@@ -64,11 +64,11 @@ describe("scenarios > collections > clean up", () => {
       cy.log(
         "should show in a normal collection that user has write access to",
       );
+      visitCollection(FIRST_COLLECTION_ID);
       collectionMenu().click();
       popover().within(() => {
         cy.findByText("Clean things up").should("exist");
       });
-      visitCollection(FIRST_COLLECTION_ID);
 
       cy.log("should not show in custom analytics collections");
       popover().within(() => {
@@ -116,7 +116,6 @@ describe("scenarios > collections > clean up", () => {
 
         cy.log("should be able to navigate to clean up modal");
         visitCollection(seedData.collection.id);
-
         selectCleanThingsUpCollectionAction();
         cy.url().should("include", "cleanup");
 

--- a/enterprise/frontend/src/metabase-enterprise/clean_up/CleanupCollectionModal/CleanupCollectionModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/clean_up/CleanupCollectionModal/CleanupCollectionModal.tsx
@@ -61,7 +61,7 @@ const _CleanupCollectionModal = ({
   };
 
   // filters
-  const [dateFilter, setDateFilter] = useState<DateFilter>("six-months");
+  const [dateFilter, setDateFilter] = useState<DateFilter>("three-months");
   const handleChangeDateFilter = (nextDateFilter: DateFilter) => {
     setDateFilter(nextDateFilter);
     pagination.resetPage();

--- a/enterprise/frontend/src/metabase-enterprise/clean_up/CollectionCleanupAlert/CollectionCleanupAlert.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/clean_up/CollectionCleanupAlert/CollectionCleanupAlert.tsx
@@ -1,4 +1,4 @@
-import { t } from "ttag";
+import { c } from "ttag";
 
 import { skipToken } from "metabase/api";
 import Link from "metabase/core/components/Link";
@@ -9,6 +9,9 @@ import { getUserIsAdmin } from "metabase/selectors/user";
 import { Alert, Box, Icon } from "metabase/ui";
 import { useListStaleCollectionItemsQuery } from "metabase-enterprise/api/collection";
 import type { Collection } from "metabase-types/api";
+
+const translationContext =
+  "This is the heading of a banner that invites the user to clean up a collection.";
 
 export const CollectionCleanupAlert = ({
   collection,
@@ -30,7 +33,7 @@ export const CollectionCleanupAlert = ({
       : skipToken,
   );
 
-  const hasSomethingToCleanUp = (staleItems?.total ?? 0) > 0;
+  const hasSomethingToCleanUp = !!staleItems?.total;
 
   if (isLoading || error || !hasSomethingToCleanUp) {
     return null;
@@ -50,7 +53,7 @@ export const CollectionCleanupAlert = ({
       }}
     >
       <Box fz="md" c={"text-dark"}>
-        {t`Clean things up!`}{" "}
+        {c(translationContext).t`Clean things up!`}{" "}
         <Box
           component={Link}
           ml="2.5rem"
@@ -58,7 +61,7 @@ export const CollectionCleanupAlert = ({
           variant="brand"
           to={`${Urls.collection(collection)}/cleanup`}
         >
-          {t`Get rid of unused content`}
+          {c(translationContext).t`Get rid of unused content`}
         </Box>
       </Box>
     </Alert>

--- a/enterprise/frontend/src/metabase-enterprise/clean_up/CollectionCleanupAlert/CollectionCleanupAlert.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/clean_up/CollectionCleanupAlert/CollectionCleanupAlert.tsx
@@ -1,0 +1,66 @@
+import { t } from "ttag";
+
+import { skipToken } from "metabase/api";
+import Link from "metabase/core/components/Link";
+import { color } from "metabase/lib/colors";
+import { useSelector } from "metabase/lib/redux";
+import * as Urls from "metabase/lib/urls";
+import { getUserIsAdmin } from "metabase/selectors/user";
+import { Alert, Box, Icon } from "metabase/ui";
+import { useListStaleCollectionItemsQuery } from "metabase-enterprise/api/collection";
+import type { Collection } from "metabase-types/api";
+
+export const CollectionCleanupAlert = ({
+  collection,
+}: {
+  collection: Collection;
+}) => {
+  const isAdmin = useSelector(getUserIsAdmin);
+
+  const {
+    data: staleItems,
+    isLoading,
+    error,
+  } = useListStaleCollectionItemsQuery(
+    isAdmin
+      ? {
+          id: collection.id,
+          limit: 0, // only fetch pagination info
+        }
+      : skipToken,
+  );
+
+  const hasSomethingToCleanUp = (staleItems?.total ?? 0) > 0;
+
+  if (isLoading || error || !hasSomethingToCleanUp) {
+    return null;
+  }
+
+  return (
+    <Alert
+      data-testid="cleanup-alert"
+      icon={<Icon name="ai" size={16} />}
+      styles={{
+        root: { padding: 0, marginTop: "-.5rem", marginBottom: "2rem" },
+        icon: { marginRight: ".5rem" },
+        wrapper: {
+          backgroundColor: color("brand-lighter"),
+          padding: "1rem 1.5rem",
+        },
+      }}
+    >
+      <Box fz="md" c={"text-dark"}>
+        {t`Clean things up!`}{" "}
+        <Box
+          component={Link}
+          ml="2.5rem"
+          fw="bold"
+          variant="brand"
+          to={`${Urls.collection(collection)}/cleanup`}
+        >
+          {t`Get rid of unused content`}
+        </Box>
+      </Box>
+    </Alert>
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/clean_up/CollectionCleanupAlert/CollectionCleanupAlert.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/clean_up/CollectionCleanupAlert/CollectionCleanupAlert.tsx
@@ -16,7 +16,7 @@ const TEXT = {
   ).t`Clean things up!`,
   GET_RID_OF_UNUSED_CONTENT: c(
     "This is the heading of a banner that invites the user to clean up a collection.",
-  ).t`Get rid of unused content`,
+  ).t`Get rid of unused content in this collection`,
 };
 
 export const CollectionCleanupAlert = ({

--- a/enterprise/frontend/src/metabase-enterprise/clean_up/CollectionCleanupAlert/CollectionCleanupAlert.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/clean_up/CollectionCleanupAlert/CollectionCleanupAlert.tsx
@@ -10,8 +10,14 @@ import { Alert, Box, Icon } from "metabase/ui";
 import { useListStaleCollectionItemsQuery } from "metabase-enterprise/api/collection";
 import type { Collection } from "metabase-types/api";
 
-const translationContext =
-  "This is the heading of a banner that invites the user to clean up a collection.";
+const TEXT = {
+  CLEAN_THINGS_UP: c(
+    "This is the heading of a banner that invites the user to clean up a collection.",
+  ).t`Clean things up!`,
+  GET_RID_OF_UNUSED_CONTENT: c(
+    "This is the heading of a banner that invites the user to clean up a collection.",
+  ).t`Get rid of unused content`,
+};
 
 export const CollectionCleanupAlert = ({
   collection,
@@ -53,7 +59,7 @@ export const CollectionCleanupAlert = ({
       }}
     >
       <Box fz="md" c={"text-dark"}>
-        {c(translationContext).t`Clean things up!`}{" "}
+        {TEXT.CLEAN_THINGS_UP}{" "}
         <Box
           component={Link}
           ml="2.5rem"
@@ -61,7 +67,7 @@ export const CollectionCleanupAlert = ({
           variant="brand"
           to={`${Urls.collection(collection)}/cleanup`}
         >
-          {c(translationContext).t`Get rid of unused content`}
+          {TEXT.GET_RID_OF_UNUSED_CONTENT}
         </Box>
       </Box>
     </Alert>

--- a/enterprise/frontend/src/metabase-enterprise/clean_up/CollectionCleanupAlert/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/clean_up/CollectionCleanupAlert/index.tsx
@@ -1,0 +1,1 @@
+export { CollectionCleanupAlert } from "./CollectionCleanupAlert";

--- a/enterprise/frontend/src/metabase-enterprise/clean_up/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/clean_up/index.tsx
@@ -5,6 +5,7 @@ import { PLUGIN_COLLECTIONS } from "metabase/plugins";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import { CleanupCollectionModal } from "./CleanupCollectionModal";
+import { CollectionCleanupAlert } from "./CollectionCleanupAlert";
 
 if (hasPremiumFeature("collection_cleanup")) {
   PLUGIN_COLLECTIONS.canCleanUp = true;
@@ -35,4 +36,6 @@ if (hasPremiumFeature("collection_cleanup")) {
   PLUGIN_COLLECTIONS.cleanUpRoute = (
     <ModalRoute path="cleanup" modal={CleanupCollectionModal} />
   );
+
+  PLUGIN_COLLECTIONS.cleanUpAlert = CollectionCleanupAlert;
 }

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionContentView.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionContentView.tsx
@@ -32,6 +32,7 @@ import Search from "metabase/entities/search";
 import { useListSelect } from "metabase/hooks/use-list-select";
 import { useToggle } from "metabase/hooks/use-toggle";
 import { useDispatch } from "metabase/lib/redux";
+import { PLUGIN_COLLECTIONS } from "metabase/plugins";
 import { addUndo } from "metabase/redux/undo";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type {
@@ -265,6 +266,9 @@ export const CollectionContentView = ({
                   uploadsEnabled={uploadsEnabled}
                   saveFile={saveFile}
                 />
+              </ErrorBoundary>
+              <ErrorBoundary>
+                <PLUGIN_COLLECTIONS.cleanUpAlert collection={collection} />
               </ErrorBoundary>
               <ErrorBoundary>
                 <PinnedItemOverview

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -333,6 +333,9 @@ export const PLUGIN_COLLECTIONS = {
     _canWrite: boolean,
   ): CleanUpMenuItem[] => [],
   cleanUpRoute: null as React.ReactElement | null,
+  cleanUpAlert: (() => null) as (props: {
+    collection: Collection;
+  }) => JSX.Element | null,
 };
 
 export type CollectionAuthorityLevelIcon = ComponentType<


### PR DESCRIPTION
Closes #48348

### Description

Makes collection clean up more visible via an alert making admins aware of the feature for collection withs stale content.
This PR does not implement the ability to dismiss it, we're going to ship without it then add as a fast follow ([see slack thread](https://metaboat.slack.com/archives/C079CR0C27J/p1728071808761629?thread_ts=1728069240.941279&cid=C079CR0C27J)).
This PR also changes the default staleness threshold from 6 months to 3.

### How to verify

- As an admin, visit a collection with content that's over 3 months old (use `POST /api/testing/mark-stale` to create stale content if you need)
- As an admin, visit a collection without stale content
- As a non-admin, visit collections w/ + w/o stale content to verify it does not appear

### Demo
When not shown
![CleanShot 2024-10-04 at 17 47 59@2x](https://github.com/user-attachments/assets/48843bb5-f6a0-4369-8884-2c1f89af13c4)
When shown
![CleanShot 2024-10-08 at 09 15 30@2x](https://github.com/user-attachments/assets/f3042d0b-2e83-428a-9301-c70f3850ebde)
Clicking the link in the alert takes you to the clean up modal page
![CleanShot 2024-10-04 at 17 48 26@2x](https://github.com/user-attachments/assets/35c08004-44d9-4859-a460-a1403e6127de)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR