### PR TITLE
Add unit tests for Urls.collection

### DIFF
--- a/frontend/src/metabase/lib/urls/collections.ts
+++ b/frontend/src/metabase/lib/urls/collections.ts
@@ -57,7 +57,7 @@ export function collection(
     ? slugifyPersonalCollection(collection)
     : slugg(collection.name);
 
-  return appendSlug(`/collection/${collection.id ?? "root"}`, slug);
+  return appendSlug(`/collection/${collection.id}`, slug);
 }
 
 export function isCollectionPath(path: string) {

--- a/frontend/src/metabase/lib/urls/collections.ts
+++ b/frontend/src/metabase/lib/urls/collections.ts
@@ -18,7 +18,7 @@ type Collection = Pick<
   "id" | "name" | "originalName" | "personal_owner_id" | "type"
 >;
 
-function slugifyPersonalCollection(collection: Collection) {
+export function slugifyPersonalCollection(collection: Collection) {
   // Current user's personal collection name is replaced with "Your personal collection"
   // `originalName` keeps the original name like "John Doe's Personal Collection"
   const name = collection.originalName || collection.name;
@@ -57,7 +57,7 @@ export function collection(
     ? slugifyPersonalCollection(collection)
     : slugg(collection.name);
 
-  return appendSlug(`/collection/${collection.id}`, slug);
+  return appendSlug(`/collection/${collection.id ?? "root"}`, slug);
 }
 
 export function isCollectionPath(path: string) {

--- a/frontend/src/metabase/lib/urls/collections.unit.spec.ts
+++ b/frontend/src/metabase/lib/urls/collections.unit.spec.ts
@@ -1,0 +1,73 @@
+import _ from "underscore";
+
+import * as utils from "metabase/collections/utils";
+import * as Urls from "metabase/lib/urls/collections";
+import * as urlsUtils from "metabase/lib/urls/utils";
+import type { Collection } from "metabase-types/api";
+import { createMockCollection } from "metabase-types/api/mocks";
+
+describe("Urls.collection", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+  it('should return "/collection/root" when collection is undefined', () => {
+    expect(Urls.collection(undefined)).toBe("/collection/root");
+  });
+
+  it('should return "/collection/root" when collection.id is null', () => {
+    expect(
+      Urls.collection(createMockCollection({ id: null as unknown as number })),
+    ).toBe("/collection/root");
+  });
+
+  it('should return "/collection/id" when collection.id is a string', () => {
+    expect(Urls.collection(createMockCollection({ id: "personal" }))).toBe(
+      "/collection/personal",
+    );
+  });
+
+  it('should return "/collection/trash" when collection is a root trash collection', () => {
+    // This test captures the actual behavior of the function, and it's fine,
+    // even though the original intent was presumably to use '/trash'.
+    // The URL /collection/trash redirects to /trash.
+    jest.spyOn(utils, "isRootTrashCollection").mockReturnValueOnce(true);
+    expect(Urls.collection(createMockCollection({ id: "trash" }))).toBe(
+      "/collection/trash",
+    );
+  });
+
+  it("should generate slug for root personal collection", () => {
+    jest.spyOn(utils, "isRootPersonalCollection").mockReturnValueOnce(true);
+    jest
+      .spyOn(Urls, "slugifyPersonalCollection")
+      .mockImplementationOnce(
+        (collection: Pick<Collection, "id" | "name">) =>
+          `{collection.id}-${collection.name}`,
+      );
+    expect(
+      Urls.collection(
+        createMockCollection({
+          id: 1,
+          name: "root-personal-collection",
+        }),
+      ),
+    ).toBe("/collection/1-root-personal-collection");
+  });
+
+  it("should append slug for non-personal and non-trash collections", () => {
+    jest
+      .spyOn(urlsUtils, "appendSlug")
+      .mockImplementationOnce((path: string | number, slug?: string) =>
+        _.compact([path, slug])
+          .map(s =>
+            typeof s === "string" ? s.replace(/ /g, "-").toLowerCase() : s,
+          )
+          .join("-"),
+      );
+    jest.spyOn(utils, "isRootPersonalCollection").mockReturnValueOnce(false);
+    jest.spyOn(utils, "isRootTrashCollection").mockReturnValueOnce(false);
+    expect(Urls.collection({ id: 1, name: "Regular collection" })).toBe(
+      "/collection/1-regular-collection",
+    );
+  });
+});


### PR DESCRIPTION
Adds some unit tests

The tests uncovered that this function returns `/collection/trash` for trash collections, rather than `/trash` (which is the return value that the authors of the function were intending). I think this is harmless since `/collection/trash` redirects to `/trash`.