### PR TITLE
XLSX Pivot Exports/Downloads should also remove pivot-grouping`s cell style

### DIFF
--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -652,7 +652,8 @@
             (setup-header-row! sheet (count ordered-cols))
             (let [modified-row (cond->> (common/column-titles ordered-cols (::mb.viz/column-settings viz-settings) true)
                                  @pivot-grouping-idx (m/remove-nth @pivot-grouping-idx))]
-              (spreadsheet/add-row! sheet modified-row)))))
+              (spreadsheet/add-row! sheet modified-row))
+            (vreset! cell-styles (cond->> @cell-styles @pivot-grouping-idx (m/remove-nth @pivot-grouping-idx))))))
 
       (write-row! [_ row row-num ordered-cols {:keys [output-order] :as viz-settings}]
         (let [ordered-row             (vec (if output-order


### PR DESCRIPTION
Fix [#48158](https://github.com/metabase/metabase/issues/48158)

When the `pivot-grouping` column is removed, the corresponding cell style should also be removed. Otherwise, the cell style of the adjacent cells will be incorrect.

Related PR https://github.com/metabase/metabase/pull/47832