### PR TITLE
Convert card embedding endpoints to RTK

### DIFF
--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -308,8 +308,8 @@ export interface UpdateCardRequest {
   collection_preview?: boolean;
 }
 
-export type UpdateCardKeyRequest<Key extends keyof UpdateCardRequest> =
-  Required<Pick<UpdateCardRequest, "id" | Key>>;
+export type UpdateCardKeyRequest<PropertyKey extends keyof UpdateCardRequest> =
+  Required<Pick<UpdateCardRequest, "id" | PropertyKey>>;
 
 export type CardError = {
   field?: string;

--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -308,6 +308,9 @@ export interface UpdateCardRequest {
   collection_preview?: boolean;
 }
 
+export type UpdateCardKeyRequest<Key extends keyof UpdateCardRequest> =
+  Required<Pick<UpdateCardRequest, "id" | Key>>;
+
 export type CardError = {
   field?: string;
   table: string;

--- a/frontend/src/metabase/api/card.ts
+++ b/frontend/src/metabase/api/card.ts
@@ -9,6 +9,7 @@ import type {
   GetEmbeddableCard,
   GetPublicCard,
   ListCardsRequest,
+  UpdateCardKeyRequest,
   UpdateCardRequest,
 } from "metabase-types/api";
 
@@ -26,177 +27,197 @@ import {
 const PERSISTED_MODEL_REFRESH_DELAY = 200;
 
 export const cardApi = Api.injectEndpoints({
-  endpoints: builder => ({
-    listCards: builder.query<Card[], ListCardsRequest | void>({
-      query: params => ({
-        method: "GET",
-        url: "/api/card",
-        params,
+  endpoints: builder => {
+    const updateCardKeyMutation = <Key extends keyof UpdateCardRequest>() =>
+      builder.mutation<Card, UpdateCardKeyRequest<Key>>({
+        query: ({ id, ...body }) => ({
+          method: "PUT",
+          url: `/api/card/${id}`,
+          body,
+        }),
+        invalidatesTags: (_, error, { id }) =>
+          invalidateTags(error, [
+            listTag("card"),
+            idTag("card", id),
+            idTag("table", `card__${id}`),
+          ]),
+      });
+
+    return {
+      listCards: builder.query<Card[], ListCardsRequest | void>({
+        query: params => ({
+          method: "GET",
+          url: "/api/card",
+          params,
+        }),
+        providesTags: (cards = []) => provideCardListTags(cards),
       }),
-      providesTags: (cards = []) => provideCardListTags(cards),
-    }),
-    getCard: builder.query<Card, GetCardRequest>({
-      query: ({ id, ignore_error, ...params }) => ({
-        method: "GET",
-        url: `/api/card/${id}`,
-        params,
-        noEvent: ignore_error,
+      getCard: builder.query<Card, GetCardRequest>({
+        query: ({ id, ignore_error, ...params }) => ({
+          method: "GET",
+          url: `/api/card/${id}`,
+          params,
+          noEvent: ignore_error,
+        }),
+        providesTags: card => (card ? provideCardTags(card) : []),
       }),
-      providesTags: card => (card ? provideCardTags(card) : []),
-    }),
-    getCardQueryMetadata: builder.query<CardQueryMetadata, CardId>({
-      query: id => ({
-        method: "GET",
-        url: `/api/card/${id}/query_metadata`,
+      getCardQueryMetadata: builder.query<CardQueryMetadata, CardId>({
+        query: id => ({
+          method: "GET",
+          url: `/api/card/${id}/query_metadata`,
+        }),
+        providesTags: (metadata, error, id) =>
+          metadata ? provideCardQueryMetadataTags(id, metadata) : [],
       }),
-      providesTags: (metadata, error, id) =>
-        metadata ? provideCardQueryMetadataTags(id, metadata) : [],
-    }),
-    getCardQuery: builder.query<Dataset, CardQueryRequest>({
-      query: ({ cardId, ...body }) => ({
-        method: "POST",
-        url: `/api/card/${cardId}/query`,
-        body,
+      getCardQuery: builder.query<Dataset, CardQueryRequest>({
+        query: ({ cardId, ...body }) => ({
+          method: "POST",
+          url: `/api/card/${cardId}/query`,
+          body,
+        }),
+        providesTags: (_data, _error, { cardId }) =>
+          provideCardQueryTags(cardId),
       }),
-      providesTags: (_data, _error, { cardId }) => provideCardQueryTags(cardId),
-    }),
-    createCard: builder.mutation<Card, CreateCardRequest>({
-      query: body => ({
-        method: "POST",
-        url: "/api/card",
-        body,
+      createCard: builder.mutation<Card, CreateCardRequest>({
+        query: body => ({
+          method: "POST",
+          url: "/api/card",
+          body,
+        }),
+        invalidatesTags: (_, error) => invalidateTags(error, [listTag("card")]),
       }),
-      invalidatesTags: (_, error) => invalidateTags(error, [listTag("card")]),
-    }),
-    updateCard: builder.mutation<Card, UpdateCardRequest>({
-      query: ({ id, ...body }) => ({
-        method: "PUT",
-        url: `/api/card/${id}`,
-        body,
+      updateCard: builder.mutation<Card, UpdateCardRequest>({
+        query: ({ id, ...body }) => ({
+          method: "PUT",
+          url: `/api/card/${id}`,
+          body,
+        }),
+        invalidatesTags: (_, error, { id }) =>
+          invalidateTags(error, [
+            listTag("card"),
+            idTag("card", id),
+            idTag("table", `card__${id}`),
+          ]),
       }),
-      invalidatesTags: (_, error, { id }) =>
-        invalidateTags(error, [
-          listTag("card"),
-          idTag("card", id),
-          idTag("table", `card__${id}`),
-        ]),
-    }),
-    deleteCard: builder.mutation<void, CardId>({
-      query: id => ({
-        method: "DELETE",
-        url: `/api/card/${id}`,
+      deleteCard: builder.mutation<void, CardId>({
+        query: id => ({
+          method: "DELETE",
+          url: `/api/card/${id}`,
+        }),
+        invalidatesTags: (_, error, id) =>
+          invalidateTags(error, [
+            listTag("card"),
+            idTag("card", id),
+            idTag("table", `card__${id}`),
+          ]),
       }),
-      invalidatesTags: (_, error, id) =>
-        invalidateTags(error, [
-          listTag("card"),
-          idTag("card", id),
-          idTag("table", `card__${id}`),
-        ]),
-    }),
-    copyCard: builder.mutation<Card, CardId>({
-      query: id => ({
-        method: "POST",
-        url: `/api/card/${id}/copy`,
+      copyCard: builder.mutation<Card, CardId>({
+        query: id => ({
+          method: "POST",
+          url: `/api/card/${id}/copy`,
+        }),
+        invalidatesTags: (_, error) => invalidateTags(error, [listTag("card")]),
       }),
-      invalidatesTags: (_, error) => invalidateTags(error, [listTag("card")]),
-    }),
-    persistModel: builder.mutation<void, CardId>({
-      query: id => ({
-        method: "POST",
-        url: `/api/card/${id}/persist`,
+      persistModel: builder.mutation<void, CardId>({
+        query: id => ({
+          method: "POST",
+          url: `/api/card/${id}/persist`,
+        }),
+        async onQueryStarted(id, { dispatch, queryFulfilled }) {
+          await queryFulfilled;
+          // we wait to invalidate this tag so the cache refresh has time to start before we refetch
+          setTimeout(() => {
+            dispatch(
+              Api.util.invalidateTags([
+                idTag("card", id),
+                idTag("persisted-model", id),
+                listTag("persisted-info"),
+              ]),
+            );
+          }, PERSISTED_MODEL_REFRESH_DELAY);
+        },
       }),
-      async onQueryStarted(id, { dispatch, queryFulfilled }) {
-        await queryFulfilled;
-        // we wait to invalidate this tag so the cache refresh has time to start before we refetch
-        setTimeout(() => {
-          dispatch(
-            Api.util.invalidateTags([
-              idTag("card", id),
-              idTag("persisted-model", id),
-              listTag("persisted-info"),
-            ]),
-          );
-        }, PERSISTED_MODEL_REFRESH_DELAY);
-      },
-    }),
-    unpersistModel: builder.mutation<void, CardId>({
-      query: id => ({
-        method: "POST",
-        url: `/api/card/${id}/unpersist`,
+      unpersistModel: builder.mutation<void, CardId>({
+        query: id => ({
+          method: "POST",
+          url: `/api/card/${id}/unpersist`,
+        }),
+        invalidatesTags: (_, error, id) =>
+          invalidateTags(error, [
+            idTag("card", id),
+            idTag("persisted-model", id),
+            listTag("persisted-info"),
+          ]),
       }),
-      invalidatesTags: (_, error, id) =>
-        invalidateTags(error, [
-          idTag("card", id),
-          idTag("persisted-model", id),
-          listTag("persisted-info"),
-        ]),
-    }),
-    refreshModelCache: builder.mutation<void, CardId>({
-      query: id => ({
-        method: "POST",
-        url: `/api/card/${id}/refresh`,
+      refreshModelCache: builder.mutation<void, CardId>({
+        query: id => ({
+          method: "POST",
+          url: `/api/card/${id}/refresh`,
+        }),
+        async onQueryStarted(id, { dispatch, queryFulfilled }) {
+          await queryFulfilled;
+          // we wait to invalidate this tag so the cache refresh has time to start before we refetch
+          setTimeout(() => {
+            dispatch(
+              Api.util.invalidateTags([
+                idTag("card", id),
+                idTag("persisted-model", id),
+                listTag("persisted-info"),
+              ]),
+            );
+          }, PERSISTED_MODEL_REFRESH_DELAY);
+        },
       }),
-      async onQueryStarted(id, { dispatch, queryFulfilled }) {
-        await queryFulfilled;
-        // we wait to invalidate this tag so the cache refresh has time to start before we refetch
-        setTimeout(() => {
-          dispatch(
-            Api.util.invalidateTags([
-              idTag("card", id),
-              idTag("persisted-model", id),
-              listTag("persisted-info"),
-            ]),
-          );
-        }, PERSISTED_MODEL_REFRESH_DELAY);
-      },
-    }),
-    listEmbeddableCards: builder.query<GetEmbeddableCard[], void>({
-      query: params => ({
-        method: "GET",
-        url: "/api/card/embeddable",
-        params,
+      listEmbeddableCards: builder.query<GetEmbeddableCard[], void>({
+        query: params => ({
+          method: "GET",
+          url: "/api/card/embeddable",
+          params,
+        }),
+        providesTags: (result = []) => [
+          ...result.map(res => idTag("embed-card", res.id)),
+          listTag("embed-card"),
+        ],
       }),
-      providesTags: (result = []) => [
-        ...result.map(res => idTag("embed-card", res.id)),
-        listTag("embed-card"),
-      ],
-    }),
-    listPublicCards: builder.query<GetPublicCard[], void>({
-      query: params => ({
-        method: "GET",
-        url: "/api/card/public",
-        params,
-      }),
-      providesTags: (result = []) => [
-        ...result.map(res => idTag("public-card", res.id)),
-        listTag("public-card"),
-      ],
-    }),
-    deleteCardPublicLink: builder.mutation<void, Pick<Card, "id">>({
-      query: ({ id }) => ({
-        method: "DELETE",
-        url: `/api/card/${id}/public_link`,
-      }),
-      invalidatesTags: (_, error, { id }) =>
-        invalidateTags(error, [
+      listPublicCards: builder.query<GetPublicCard[], void>({
+        query: params => ({
+          method: "GET",
+          url: "/api/card/public",
+          params,
+        }),
+        providesTags: (result = []) => [
+          ...result.map(res => idTag("public-card", res.id)),
           listTag("public-card"),
-          idTag("public-card", id),
-        ]),
-    }),
-    createCardPublicLink: builder.mutation<
-      {
-        uuid: Card["public_uuid"];
-      },
-      Pick<Card, "id">
-    >({
-      query: ({ id }) => ({
-        method: "POST",
-        url: `/api/card/${id}/public_link`,
+        ],
       }),
-      invalidatesTags: (_, error) =>
-        invalidateTags(error, [listTag("public-card")]),
-    }),
-  }),
+      deleteCardPublicLink: builder.mutation<void, Pick<Card, "id">>({
+        query: ({ id }) => ({
+          method: "DELETE",
+          url: `/api/card/${id}/public_link`,
+        }),
+        invalidatesTags: (_, error, { id }) =>
+          invalidateTags(error, [
+            listTag("public-card"),
+            idTag("public-card", id),
+          ]),
+      }),
+      createCardPublicLink: builder.mutation<
+        {
+          uuid: Card["public_uuid"];
+        },
+        Pick<Card, "id">
+      >({
+        query: ({ id }) => ({
+          method: "POST",
+          url: `/api/card/${id}/public_link`,
+        }),
+        invalidatesTags: (_, error) =>
+          invalidateTags(error, [listTag("public-card")]),
+      }),
+      updateCardEnableEmbedding: updateCardKeyMutation<"enable_embedding">(),
+      updateCardEmbeddingParams: updateCardKeyMutation<"embedding_params">(),
+    };
+  },
 });
 
 export const {
@@ -214,5 +235,12 @@ export const {
   useListEmbeddableCardsQuery,
   useListPublicCardsQuery,
   useDeleteCardPublicLinkMutation,
-  endpoints: { createCardPublicLink, deleteCardPublicLink },
+  useUpdateCardEmbeddingParamsMutation,
+  useUpdateCardEnableEmbeddingMutation,
+  endpoints: {
+    createCardPublicLink,
+    deleteCardPublicLink,
+    updateCardEnableEmbedding,
+    updateCardEmbeddingParams,
+  },
 } = cardApi;

--- a/frontend/src/metabase/api/card.ts
+++ b/frontend/src/metabase/api/card.ts
@@ -28,8 +28,10 @@ const PERSISTED_MODEL_REFRESH_DELAY = 200;
 
 export const cardApi = Api.injectEndpoints({
   endpoints: builder => {
-    const updateCardKeyMutation = <Key extends keyof UpdateCardRequest>() =>
-      builder.mutation<Card, UpdateCardKeyRequest<Key>>({
+    const updateCardPropertyMutation = <
+      PropertyKey extends keyof UpdateCardRequest,
+    >() =>
+      builder.mutation<Card, UpdateCardKeyRequest<PropertyKey>>({
         query: ({ id, ...body }) => ({
           method: "PUT",
           url: `/api/card/${id}`,
@@ -214,8 +216,10 @@ export const cardApi = Api.injectEndpoints({
         invalidatesTags: (_, error) =>
           invalidateTags(error, [listTag("public-card")]),
       }),
-      updateCardEnableEmbedding: updateCardKeyMutation<"enable_embedding">(),
-      updateCardEmbeddingParams: updateCardKeyMutation<"embedding_params">(),
+      updateCardEnableEmbedding:
+        updateCardPropertyMutation<"enable_embedding">(),
+      updateCardEmbeddingParams:
+        updateCardPropertyMutation<"embedding_params">(),
     };
   },
 });

--- a/frontend/src/metabase/query_builder/actions/sharing.ts
+++ b/frontend/src/metabase/query_builder/actions/sharing.ts
@@ -1,10 +1,6 @@
-import { createAsyncThunk } from "@reduxjs/toolkit";
-
 import { createCardPublicLink, deleteCardPublicLink } from "metabase/api";
 import { createThunkAction } from "metabase/lib/redux";
-import type { EmbeddingParameters } from "metabase/public/lib/types";
-import { CardApi } from "metabase/services";
-import type { Card, CardId } from "metabase-types/api";
+import type { Card } from "metabase-types/api";
 
 export const CREATE_PUBLIC_LINK = "metabase/card/CREATE_PUBLIC_LINK";
 
@@ -25,25 +21,4 @@ export const deletePublicLink = createThunkAction(
   DELETE_PUBLIC_LINK,
   (card: Card) => async dispatch =>
     await dispatch(deleteCardPublicLink.initiate(card)),
-);
-
-export const updateEnableEmbedding = createAsyncThunk<
-  Pick<Card, "id" | "enable_embedding"> & { uuid: Card["public_uuid"] },
-  Pick<Card, "id" | "enable_embedding">
->("metabase/card/UPDATE_ENABLE_EMBEDDING", async ({ id, enable_embedding }) => {
-  const response = await CardApi.update({
-    id,
-    enable_embedding,
-  });
-
-  return { id, uuid: response.uuid, enable_embedding };
-});
-
-export const updateEmbeddingParams = createAsyncThunk<
-  Card,
-  { id: CardId; embedding_params: EmbeddingParameters }
->(
-  "metabase/card/UPDATE_EMBEDDING_PARAMS",
-  async ({ id, embedding_params }) =>
-    await CardApi.update({ id, embedding_params }),
 );

--- a/frontend/src/metabase/query_builder/components/QuestionEmbedWidget/QuestionEmbedWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionEmbedWidget/QuestionEmbedWidget.tsx
@@ -1,21 +1,19 @@
+import {
+  useUpdateCardEmbeddingParamsMutation,
+  useUpdateCardEnableEmbeddingMutation,
+} from "metabase/api";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { publicQuestion } from "metabase/lib/urls";
 import {
   EmbedModal,
   EmbedModalContent,
 } from "metabase/public/components/EmbedModal";
-import type { EmbeddingParameters } from "metabase/public/lib/types";
 import { getMetadata } from "metabase/selectors/metadata";
 import type { ExportFormatType } from "metabase/sharing/components/PublicLinkPopover/types";
 import { getCardUiParameters } from "metabase-lib/v1/parameters/utils/cards";
 import type { Card } from "metabase-types/api";
 
-import {
-  createPublicLink,
-  deletePublicLink,
-  updateEmbeddingParams,
-  updateEnableEmbedding,
-} from "../../actions";
+import { createPublicLink, deletePublicLink } from "../../actions";
 
 type QuestionEmbedWidgetProps = {
   className?: string;
@@ -27,25 +25,12 @@ export const QuestionEmbedWidget = (props: QuestionEmbedWidgetProps) => {
 
   const metadata = useSelector(getMetadata);
 
+  const [updateEnableEmbedding] = useUpdateCardEnableEmbeddingMutation();
+  const [updateEmbeddingParams] = useUpdateCardEmbeddingParamsMutation();
+
   const dispatch = useDispatch();
   const createPublicQuestionLink = () => dispatch(createPublicLink(card));
   const deletePublicQuestionLink = () => dispatch(deletePublicLink(card));
-  const updateQuestionEnableEmbedding = (enable_embedding: boolean) =>
-    dispatch(
-      updateEnableEmbedding({
-        id: card.id,
-        enable_embedding,
-      }),
-    );
-  const updateQuestionEmbeddingParams = (
-    embedding_params: EmbeddingParameters,
-  ) =>
-    dispatch(
-      updateEmbeddingParams({
-        id: card.id,
-        embedding_params,
-      }),
-    );
 
   const getPublicQuestionUrl = (
     publicUuid: string,
@@ -64,8 +49,12 @@ export const QuestionEmbedWidget = (props: QuestionEmbedWidgetProps) => {
           resourceParameters={getCardUiParameters(card, metadata)}
           onCreatePublicLink={createPublicQuestionLink}
           onDeletePublicLink={deletePublicQuestionLink}
-          onUpdateEnableEmbedding={updateQuestionEnableEmbedding}
-          onUpdateEmbeddingParams={updateQuestionEmbeddingParams}
+          onUpdateEnableEmbedding={enable_embedding =>
+            updateEnableEmbedding({ id: card.id, enable_embedding })
+          }
+          onUpdateEmbeddingParams={embedding_params =>
+            updateEmbeddingParams({ id: card.id, embedding_params })
+          }
           getPublicUrl={getPublicQuestionUrl}
         />
       )}

--- a/frontend/src/metabase/query_builder/reducers-typed.ts
+++ b/frontend/src/metabase/query_builder/reducers-typed.ts
@@ -1,5 +1,9 @@
 import { createReducer } from "@reduxjs/toolkit";
 
+import {
+  updateCardEmbeddingParams,
+  updateCardEnableEmbedding,
+} from "metabase/api";
 import type { Card, DatasetQuery } from "metabase-types/api";
 
 import {
@@ -15,8 +19,6 @@ import {
   SET_CARD_AND_RUN,
   SOFT_RELOAD_CARD,
   UPDATE_QUESTION,
-  updateEmbeddingParams,
-  updateEnableEmbedding,
 } from "./actions";
 
 // the card that is actively being worked on
@@ -140,7 +142,7 @@ export const card = createReducer<Card<DatasetQuery> | null>(null, builder => {
         public_uuid: null,
       };
     })
-    .addCase(updateEnableEmbedding.fulfilled, (state, action) => {
+    .addMatcher(updateCardEnableEmbedding.matchFulfilled, (state, action) => {
       if (!state) {
         return state;
       }
@@ -149,7 +151,7 @@ export const card = createReducer<Card<DatasetQuery> | null>(null, builder => {
         enable_embedding: action.payload.enable_embedding,
       };
     })
-    .addCase(updateEmbeddingParams.fulfilled, (state, action) => {
+    .addMatcher(updateCardEmbeddingParams.matchFulfilled, (state, action) => {
       if (!state) {
         return state;
       }


### PR DESCRIPTION
Migrates the card embed endpoints to RTK query - these endpoints are  for enabling embedding and setting embedding parameters.

_**Why?**_
We're able to use RTK query now for validating and invalidating lists, instead of using a `key` to ensure that lists are loaded on the embed settings.

It also removes the intermediate `updateEnableEmbedding` and `updateEmbeddingParams` actions, so it should be easier to track things in the future.
