### PR TITLE
Fix unit tests in CollectionInfoSidebar

### DIFF
--- a/frontend/src/metabase/collections/components/CollectionInfoSidebar/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionInfoSidebar/tests/common.unit.spec.tsx
@@ -23,10 +23,14 @@ describe("CollectionInfoSidebar (OSS)", () => {
     expect(
       await screen.findByText("Description of a normal collection"),
     ).toBeInTheDocument();
-    expect(
-      await screen.findByText("entity_id_of_normal_collection"),
-    ).toBeInTheDocument();
+
+    // Official collections are hidden without the official_collections feature
     expect(screen.queryByText("Official collection")).not.toBeInTheDocument();
+
+    // Entity ids are hidden without the serialization feature
+    expect(
+      screen.queryByText("entity_id_of_normal_collection"),
+    ).not.toBeInTheDocument();
   });
   it("should render properly for an official collection", async () => {
     setup({
@@ -36,9 +40,13 @@ describe("CollectionInfoSidebar (OSS)", () => {
     expect(
       await screen.findByText("Description of a trusted collection"),
     ).toBeInTheDocument();
-    expect(
-      await screen.findByText("entity_id_of_trusted_collection"),
-    ).toBeInTheDocument();
+
+    // Official collections are hidden without the official_collections feature
     expect(screen.queryByText("Official collection")).not.toBeInTheDocument();
+
+    // Entity ids are hidden without the serialization feature
+    expect(
+      screen.queryByText("entity_id_of_trusted_collection"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/collections/components/CollectionInfoSidebar/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionInfoSidebar/tests/enterprise.unit.spec.tsx
@@ -14,7 +14,7 @@ const setup = ({ collection }: { collection: Collection }) =>
     enableOfficialCollections: false,
   });
 
-describe("CollectionInfoSidebar (EE without token)", () => {
+describe("CollectionInfoSidebar (EE without tokens)", () => {
   it("should render for a regular collection", async () => {
     setup({
       collection: regularCollection,
@@ -23,10 +23,14 @@ describe("CollectionInfoSidebar (EE without token)", () => {
     expect(
       await screen.findByText("Description of a normal collection"),
     ).toBeInTheDocument();
-    expect(
-      await screen.findByText("entity_id_of_normal_collection"),
-    ).toBeInTheDocument();
+
+    // Official collections are hidden without the official_collections feature
     expect(screen.queryByText("Official collection")).not.toBeInTheDocument();
+
+    // Entity ids are hidden without the serialization feature
+    expect(
+      screen.queryByText("entity_id_of_normal_collection"),
+    ).not.toBeInTheDocument();
   });
   it("should render properly for an official collection", async () => {
     setup({
@@ -36,9 +40,13 @@ describe("CollectionInfoSidebar (EE without token)", () => {
     expect(
       await screen.findByText("Description of a trusted collection"),
     ).toBeInTheDocument();
-    expect(
-      await screen.findByText("entity_id_of_trusted_collection"),
-    ).toBeInTheDocument();
+
+    // Official collections are hidden without the official_collections feature
     expect(screen.queryByText("Official collection")).not.toBeInTheDocument();
+
+    // Entity ids are hidden without the serialization feature
+    expect(
+      screen.queryByText("entity_id_of_trusted_collection"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/collections/components/CollectionInfoSidebar/tests/premium.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionInfoSidebar/tests/premium.unit.spec.tsx
@@ -11,6 +11,7 @@ const setup = ({ collection }: { collection: Collection }) =>
   baseSetup({
     collection,
     enableOfficialCollections: true,
+    enableSerialization: true,
   });
 
 describe("CollectionInfoSidebar (EE with token)", () => {

--- a/frontend/src/metabase/collections/components/CollectionInfoSidebar/tests/setup.tsx
+++ b/frontend/src/metabase/collections/components/CollectionInfoSidebar/tests/setup.tsx
@@ -1,5 +1,5 @@
 import { renderWithProviders } from "__support__/ui";
-import type { Collection } from "metabase-types/api";
+import type { Collection, TokenFeature } from "metabase-types/api";
 import { createMockCollection } from "metabase-types/api/mocks";
 
 import { CollectionInfoSidebar } from "../CollectionInfoSidebar";
@@ -8,11 +8,20 @@ export const setup = ({
   collection,
   enableEnterprisePlugins,
   enableOfficialCollections = false,
+  enableSerialization = false,
 }: {
   collection: Collection;
   enableEnterprisePlugins?: boolean;
   enableOfficialCollections: boolean;
+  enableSerialization?: boolean;
 }) => {
+  const withFeatures: TokenFeature[] = [];
+  if (enableOfficialCollections) {
+    withFeatures.push("official_collections");
+  }
+  if (enableSerialization) {
+    withFeatures.push("serialization");
+  }
   return renderWithProviders(
     <>
       {collection.name}
@@ -23,9 +32,7 @@ export const setup = ({
       />
     </>,
     {
-      withFeatures: enableOfficialCollections
-        ? ["official_collections" as const]
-        : [],
+      withFeatures,
       shouldSetupEnterprisePlugins: enableEnterprisePlugins,
     },
   );


### PR DESCRIPTION
The serialization token feature is now required for entity ids. This PR updates some tests in light of that change