### PR TITLE
Support downgrading to 47 from newer versions

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -881,7 +881,7 @@ jobs:
   be-tests-sqlserver-2017-ee:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 90
     env:
       CI: 'true'

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -61,7 +61,7 @@
 
 (deftest rollback-after-47-test
   (testing "Migrating to latest version, rolling back to v44, and then migrating up again"
-    (let [changesets-per-filename #(try (->> (jdbc/query (get-conn) ["SELECT FILENAME FROM DATABASECHANGELOG"])
+    (let [changesets-per-filename #(try (->> (jdbc/query (get-conn) ["SELECT filename FROM DATABASECHANGELOG"])
                                              (map :filename)
                                              frequencies)
                                         ;; The table might not exist yet.

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -65,7 +65,10 @@
 
 (deftest rollback-after-47-test
   (testing "Migrating to latest version, rolling back to v44, and then migrating up again"
-    (let [changesets-per-filename #(frequencies (t2/select-fn-vec :filename [:databasechangelog :filename]))]
+    (let [changesets-per-filename #(try (frequencies (t2/select-fn-vec :filename [:databasechangelog :filename]))
+                                        (catch Exception _
+                                          ;; The table might not exist yet.
+                                          {}))]
       ;; Initialize at 48.00-001, i.e. 48.00-002 is next.
       (impl/test-migrations ["v48.00-002" "v48.00-003"] [migrate!]
         (is (= ["migrations/001_update_migrations.yaml"] (keys (changesets-per-filename))))


### PR DESCRIPTION
Closes #47232

### Description

This works by inserting dummy changelog executed entries for all the migrations that were aggregated from version 48 onwards.

This was developed against 48, and will need to be forward ported to 49, 50, and master.

### How to verify

1. Start on version 48.
2. `metabase=# select filename, count(*) from databasechangelog group by 1;`
  ```sql
               filename                | count
---------------------------------------+-------
 migrations/001_update_migrations.yaml |   210
```
3. `clojure -M:ee:ee-dev:run migrate down`
4. `metabase=# select filename, count(*) from databasechangelog group by 1;`
  ```sql
               filename                | count
---------------------------------------+-------
 migrations/000_migrations.yaml        |   465
 migrations/001_update_migrations.yaml |   156
```
5. Switch to version 47.
6. `clojure -M:ee:ee-dev:run migrate up`
7. No migrations run, and more importantly: no errors.