### PR TITLE
fix(sdk): update utm tags in embedding sdk cli

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/cli/steps/setup-license.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/steps/setup-license.ts
@@ -11,7 +11,7 @@ import { printEmptyLines, printWithPadding } from "../utils/print";
 import { propagateErrorResponse } from "../utils/propagate-error-response";
 
 const trialUrl = `https://store.metabase.com/checkout?plan=pro&deployment=self-hosted`;
-const trialUrlWithUtm = `${trialUrl}&utm_source=product&utm_medium=checkout&utm_campaign=embedding-sdk&utm_content=embedding-sdk-cli`;
+const trialUrlWithUtm = `${trialUrl}&utm_source=product&utm_medium=checkout&utm_campaign=embedding_sdk&utm_content=embedding_sdk_cli`;
 
 const VISIT_STORE_MESSAGE = `Please visit ${chalk.blue(
   trialUrl,


### PR DESCRIPTION
Updates the UTM tags for the embedding SDK's CLI to conform with [our specifications](https://www.notion.so/metabase/Product-UTM-Instrumentation-fc47f3584d5b48bea2e0ad02cda0376d?pvs=4).

> I think the strings are not formatted exactly as the spec. It is supposed to use - to separate between keywords and _ as space. So if embedding sdk is a single word, it should be separated by _.