### PR TITLE
🏎️🚀 🏎️🚀 🏎️🚀 Test partitioning for MySQL: shave ~5 minutes off of CI runs 🏎️🚀🏎️🚀 🏎️🚀

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -203,6 +203,10 @@ jobs:
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        partition-index: [0, 1]
     env:
       CI: 'true'
       DRIVERS: mysql
@@ -223,6 +227,9 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-mariadb-10-2-ee'
+        test-args: >-
+          :partition/total 2
+          :partition/index ${{ matrix.partition-index }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -240,6 +247,10 @@ jobs:
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        partition-index: [0, 1]
     env:
       CI: 'true'
       DRIVERS: mysql
@@ -260,6 +271,9 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-mariadb-latest-ee'
+        test-args: >-
+          :partition/total 2
+          :partition/index ${{ matrix.partition-index }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -534,6 +548,10 @@ jobs:
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        partition-index: [0, 1]
     env:
       CI: 'true'
       DRIVERS: mysql
@@ -554,6 +572,9 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-mysql-8-0-ee'
+        test-args: >-
+          :partition/total 2
+          :partition/index ${{ matrix.partition-index }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -571,6 +592,10 @@ jobs:
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        partition-index: [0, 1]
     env:
       CI: 'true'
       DRIVERS: mysql
@@ -606,6 +631,9 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-mysql-latest-ee'
+        test-args: >-
+          :partition/total 2
+          :partition/index ${{ matrix.partition-index }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()

--- a/test/metabase/permissions/test_util.clj
+++ b/test/metabase/permissions/test_util.clj
@@ -80,6 +80,8 @@
   "Implementation of `with-no-data-perms-for-all-users`. Sets every data permission for all databases to the
   least permissive value for the All Users permission group for the duration of the test."
   [thunk]
+  ;; force creation of test-data if it is not already created
+  (data/db)
   (with-restored-data-perms-for-group! (u/the-id (perms-group/all-users))
     (doseq [[perm-type _] data-perms/Permissions
             db-id         (t2/select-pks-set :model/Database)]

--- a/test/metabase/query_processor/middleware/permissions_test.clj
+++ b/test/metabase/query_processor/middleware/permissions_test.clj
@@ -16,7 +16,6 @@
    [metabase.test :as mt]
    [metabase.util :as u]
    [metabase.util.malli.fn :as mu.fn]
-   [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp])
   (:import
    (clojure.lang ExceptionInfo)))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/45009

Split off from https://github.com/metabase/metabase/pull/47681

Split up our the slowest CI jobs (MySQL and MariaDB) into two separate jobs (one to run the first half of the tests and one to run the second half of the tests) using the new test partitioning features I added to Hawk in https://github.com/metabase/hawk/pull/28 and https://github.com/metabase/hawk/pull/31 

This turns our ~50 minute jobs into one ~45 minute job and one ~15 minute job. I'm still investigating why the split isn't closer to ~30/~30, I think it's because test run time is dominated by a few certain mega-slow tests (SerDes and migration tests)... once this PR lands I'll experiment with splitting tests up into additional jobs or maybe just splitting the migration tests off into their own jobs