### PR TITLE
Remove duplicate is-clause? fn

### DIFF
--- a/src/metabase/legacy_mbql/schema/helpers.cljc
+++ b/src/metabase/legacy_mbql/schema/helpers.cljc
@@ -10,8 +10,7 @@
 ;;; --------------------------------------------------- defclause ----------------------------------------------------
 
 (defn mbql-clause?
-  "True if `x` is an MBQL clause (a sequence with a keyword as its first arg). (Since this is used by the code in
-  `normalize` this handles pre-normalized clauses as well.)"
+  "True if `x` is an MBQL clause (a sequence with a keyword as its first arg)."
   [x]
   (and (sequential? x)
        (not (map-entry? x))

--- a/src/metabase/legacy_mbql/util.cljc
+++ b/src/metabase/legacy_mbql/util.cljc
@@ -13,10 +13,17 @@
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.shared.util.i18n :as i18n]
+   [metabase.shared.util.namespaces :as shared.ns]
    [metabase.shared.util.time :as shared.ut]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]))
+
+(shared.ns/import-fns
+ [schema.helpers
+  mbql-clause?
+  is-clause?
+  check-clause])
 
 (mu/defn normalize-token :- :keyword
   "Convert a string or keyword in various cases (`lisp-case`, `snake_case`, or `SCREAMING_SNAKE_CASE`) to a lisp-cased
@@ -27,36 +34,6 @@
       str/lower-case
       (str/replace #"_" "-")
       keyword))
-
-(defn mbql-clause?
-  "True if `x` is an MBQL clause (a sequence with a keyword as its first arg). (Since this is used by the code in
-  `normalize` this handles pre-normalized clauses as well.)"
-  [x]
-  (and (sequential? x)
-       (not (map-entry? x))
-       (keyword? (first x))))
-
-(defn is-clause?
-  "If `x` is an MBQL clause, and an instance of clauses defined by keyword(s) `k-or-ks`?
-
-    (is-clause? :count [:count 10])        ; -> true
-    (is-clause? #{:+ :- :* :/} [:+ 10 20]) ; -> true"
-  [k-or-ks x]
-  (and
-   (mbql-clause? x)
-   (if (coll? k-or-ks)
-     ((set k-or-ks) (first x))
-     (= k-or-ks (first x)))))
-
-(defn check-clause
-  "Returns `x` if it's an instance of a clause defined by keyword(s) `k-or-ks`
-
-    (check-clause :count [:count 10]) ; => [:count 10]
-    (check-clause? #{:+ :- :* :/} [:+ 10 20]) ; -> [:+ 10 20]
-    (check-clause :sum [:count 10]) ; => nil"
-  [k-or-ks x]
-  (when (is-clause? k-or-ks x)
-    x))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                       Functions for manipulating queries                                       |


### PR DESCRIPTION
Closes #39333

### Description

Move `mbql-clause?`, `is-clause?`, and `check-clause` from `mbql.u` to `schema.helpers`, and remove the duplicate definition of `is-clause?`.

If we want to reduce churn, we could just have `mbql.u` re-export the symbols from `schema.helpers`, but it seemed better to update all callers to `require` them from the new location.

h/t to @sdduursma as this is a re-implementation of his changes in #40945

### How to verify

No new tests added, but these funcs should be well covered by existing tests.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
