### PR TITLE
Update release channel settings copy

### DIFF
--- a/e2e/test/scenarios/admin-2/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/settings.cy.spec.js
@@ -1329,7 +1329,7 @@ describe("admin > settings > updates", () => {
   it("should show the updates page", () => {
     cy.findByLabelText("Check for updates").should("be.visible");
     cy.findByTestId("update-channel-setting")
-      .findByText("Update Channel")
+      .findByText("Types of releases to check for")
       .should("be.visible");
 
     cy.findByTestId("settings-updates").within(() => {
@@ -1342,7 +1342,7 @@ describe("admin > settings > updates", () => {
     cy.findByLabelText("Check for updates").click();
 
     cy.findByTestId("settings-updates").within(() => {
-      cy.findByText("Update Channel").should("not.exist");
+      cy.findByText("Types of releases to check for").should("not.exist");
       cy.findByText("Some old feature").should("not.exist");
     });
   });
@@ -1352,20 +1352,20 @@ describe("admin > settings > updates", () => {
       cy.findByText(/Metabase 1\.86\.76 is available/).should("be.visible");
       cy.findByText("Some old feature").should("be.visible");
       cy.findByText("New latest feature").should("be.visible");
-      cy.findByText("Stable").click();
+      cy.findByText("Stable releases").click();
     });
 
-    popover().findByText("Beta").click();
+    popover().findByText("Beta releases").click();
 
     cy.findByTestId("settings-updates").within(() => {
       cy.findByText(/Metabase 1\.86\.75\.309 is available/).should(
         "be.visible",
       );
       cy.findByText("New beta feature").should("be.visible");
-      cy.findByText("Beta").click();
+      cy.findByText("Beta releases").click();
     });
 
-    popover().findByText("Nightly").click();
+    popover().findByText("Nightly builds").click();
 
     cy.findByTestId("settings-updates").within(() => {
       cy.findByText(/Metabase 1\.86\.75\.311 is available/).should(

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/SettingsUpdatesForm.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/SettingsUpdatesForm.tsx
@@ -13,15 +13,21 @@ import { VersionUpdateNotice } from "./VersionUpdateNotice/VersionUpdateNotice";
 
 const updateChannelSetting = {
   key: "update-channel",
-  display_name: "Update Channel",
+  display_name: "Types of releases to check for",
   type: "select",
   description:
-    "Metabase will notify you when a new release is available for the channel you select.",
+    "We'll notify you here when there's a new version of this type of release.",
   defaultValue: "latest",
   options: [
-    { name: c("describes a software version").t`Stable`, value: "latest" },
-    { name: c("describes a software version").t`Beta`, value: "beta" },
-    { name: c("describes a software version").t`Nightly`, value: "nightly" },
+    {
+      name: c("describes a software version").t`Stable releases`,
+      value: "latest",
+    },
+    { name: c("describes a software version").t`Beta releases`, value: "beta" },
+    {
+      name: c("describes a software version").t`Nightly builds`,
+      value: "nightly",
+    },
   ],
 };
 

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/SettingsUpdatesForm.unit.spec.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/SettingsUpdatesForm.unit.spec.jsx
@@ -78,7 +78,9 @@ describe("SettingsUpdatesForm", () => {
   it("shows release channel selection", async () => {
     setup({ currentVersion: "v1.0.0", latestVersion: "v1.0.0" });
 
-    expect(await screen.findByText("Update Channel")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Types of releases to check for"),
+    ).toBeInTheDocument();
   });
 
   it("shows correct message when latest version is installed", async () => {


### PR DESCRIPTION
follow up to https://github.com/metabase/metabase/pull/48126

see [discussion](https://metaboat.slack.com/archives/C064EB1UE5P/p1728340680724549?thread_ts=1727725973.449529&cid=C064EB1UE5P)

### Description

Updates release channel settings copy to be more human-friendly.

![Screen Shot 2024-10-07 at 5 02 38 PM](https://github.com/user-attachments/assets/0f7e2f64-2566-498e-9434-ac28ea0d7e70)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
