### PR TITLE
Mock audit info requests

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/collections/use-get-default-collection-id/use-get-default-collection-id.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/collections/use-get-default-collection-id/use-get-default-collection-id.unit.spec.tsx
@@ -1,9 +1,9 @@
-import fetchMock from "fetch-mock";
-
-import { setupCollectionByIdEndpoint } from "__support__/server-mocks";
+import {
+  setupAuditEndpoints,
+  setupCollectionByIdEndpoint,
+} from "__support__/server-mocks";
 import { createMockEntitiesState } from "__support__/store";
 import { renderWithProviders, screen } from "__support__/ui";
-import type { AuditInfo } from "metabase-enterprise/audit_app/types/state";
 import type { Collection, CollectionId } from "metabase-types/api";
 import { createMockCollection, createMockUser } from "metabase-types/api/mocks";
 import { createMockState } from "metabase-types/store/mocks";
@@ -18,12 +18,6 @@ const TestComponent = ({
   const defaultCollectionId = useGetDefaultCollectionId(collectionId);
 
   return <div>id: {JSON.stringify(defaultCollectionId)}</div>;
-};
-
-const defaultAuditInfo: AuditInfo = {
-  dashboard_overview: 201,
-  question_overview: 202,
-  custom_reports: 203,
 };
 
 const user = createMockUser({
@@ -59,7 +53,7 @@ const setup = ({
   hasRootAccess?: boolean;
 }) => {
   setupCollectionByIdEndpoint({ collections });
-  fetchMock.get("path:/api/ee/audit-app/user/audit-info", defaultAuditInfo);
+  setupAuditEndpoints();
 
   const entitiesState = createMockEntitiesState({
     collections: [

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/tests/setup.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/tests/setup.tsx
@@ -2,6 +2,7 @@ import { Route } from "react-router";
 
 import { setupEnterprisePlugins } from "__support__/enterprise";
 import {
+  setupAuditEndpoints,
   setupDashboardEndpoints,
   setupPerformanceEndpoints,
   setupRevisionsEndpoints,
@@ -41,6 +42,7 @@ export async function setup({
   setupUsersEndpoints([currentUser]);
   setupRevisionsEndpoints([]);
   setupPerformanceEndpoints([]);
+  setupAuditEndpoints();
 
   const state = createMockState({
     currentUser,

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/tests/setup.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/tests/setup.tsx
@@ -2,6 +2,7 @@ import { Route } from "react-router";
 
 import { setupEnterprisePlugins } from "__support__/enterprise";
 import {
+  setupAuditEndpoints,
   setupCardEndpoints,
   setupRevisionsEndpoints,
   setupUsersEndpoints,
@@ -39,6 +40,7 @@ export const setup = async ({
   setupUsersEndpoints([currentUser]);
   setupRevisionsEndpoints([]);
   setupPerformanceEndpoints([]);
+  setupAuditEndpoints();
 
   const state = createMockState({
     currentUser,

--- a/frontend/test/__support__/server-mocks/audit.ts
+++ b/frontend/test/__support__/server-mocks/audit.ts
@@ -1,0 +1,23 @@
+import fetchMock from "fetch-mock";
+
+import type { CardId, CollectionId, DashboardId } from "metabase-types/api";
+
+interface AuditInfo {
+  dashboard_overview: DashboardId;
+  question_overview: CardId;
+  custom_reports: CollectionId;
+}
+
+const defaultAuditInfo: AuditInfo = {
+  dashboard_overview: 201,
+  question_overview: 202,
+  custom_reports: 203,
+};
+
+export const setupAuditEndpoints = ({
+  auditInfo = defaultAuditInfo,
+}: {
+  auditInfo?: AuditInfo;
+} = {}) => {
+  fetchMock.get("path:/api/ee/audit-app/user/audit-info", auditInfo);
+};

--- a/frontend/test/__support__/server-mocks/index.ts
+++ b/frontend/test/__support__/server-mocks/index.ts
@@ -2,6 +2,7 @@ export * from "./action";
 export * from "./activity";
 export * from "./alert";
 export * from "./api-key";
+export * from "./audit";
 export * from "./automagic-dashboards";
 export * from "./bookmark";
 export * from "./card";


### PR DESCRIPTION
This PR
* mocks audit requests in tests of `DashboardInfoSidebar` and `QuestionInfoSidebar` (these tests were flaking)
* introduces a helper, `setupAuditEndpoints`, to facilitate this in the future
* uses the helper in one other place where audit requests were getting mocked
