### PR TITLE
Metrics empty copy

### DIFF
--- a/e2e/test/scenarios/metrics/browse.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/browse.cy.spec.ts
@@ -113,7 +113,7 @@ describe("scenarios > browse > metrics", () => {
       cy.visit("/browse/metrics");
       main()
         .findByText(
-          "Metrics help you summarize and analyze your data effortlessly.",
+          "Create Metrics to define the official way to calculate important numbers for your team",
         )
         .should("be.visible");
     });
@@ -279,7 +279,7 @@ describe("scenarios > browse > metrics", () => {
 
       main()
         .findByText(
-          "Metrics help you summarize and analyze your data effortlessly.",
+          "Create Metrics to define the official way to calculate important numbers for your team",
         )
         .should("be.visible");
 

--- a/frontend/src/metabase/browse/metrics/BrowseMetrics.tsx
+++ b/frontend/src/metabase/browse/metrics/BrowseMetrics.tsx
@@ -88,9 +88,9 @@ export function BrowseMetrics() {
 function MetricsEmptyState() {
   return (
     <Flex align="center" justify="center" mih="70vh">
-      <Box maw="25rem">
+      <Box maw="30rem">
         <EmptyState
-          title={t`Metrics help you summarize and analyze your data effortlessly.`}
+          title={t`Create Metrics to define the official way to calculate important numbers for your team`}
           message={
             <Text mt="sm" maw="25rem">
               {t`Metrics are like pre-defined calculations: create your aggregations once, save them as metrics, and use them whenever you need to analyze your data.`}

--- a/frontend/src/metabase/browse/metrics/BrowseMetrics.unit.spec.tsx
+++ b/frontend/src/metabase/browse/metrics/BrowseMetrics.unit.spec.tsx
@@ -237,7 +237,7 @@ describe("BrowseMetrics", () => {
     setup({ metricCount: 0 });
     expect(
       await screen.findByText(
-        "Metrics help you summarize and analyze your data effortlessly.",
+        "Create Metrics to define the official way to calculate important numbers for your team",
       ),
     ).toBeInTheDocument();
   });

--- a/frontend/src/metabase/querying/metrics/components/MetricEditor/MetricEditorFooter/MetricEmptyState/MetricEmptyState.tsx
+++ b/frontend/src/metabase/querying/metrics/components/MetricEditor/MetricEditorFooter/MetricEmptyState/MetricEmptyState.tsx
@@ -20,10 +20,10 @@ export function MetricEmptyState({
       data-testid="metric-empty-state"
     >
       <Text mb="sm" fw="bold" fz="lg">
-        {t`A metric is one of the key numbers you want to keep track of`}
+        {t`Create Metrics to define the official way to calculate important numbers for your team`}
       </Text>
-      <Text mb="lg" c="text-medium" maw="28.75rem" align="center">
-        {t`To create one, you’ll need to define how it’s calculated, add any required filters, and optionally pick the main dimension for your metric.`}
+      <Text mb="lg" c="text-medium" maw="30rem" align="center">
+        {t`Metrics are like pre-defined calculations: create your aggregations once, save them as metrics, and use them whenever you need to analyze your data.`}
       </Text>
       {isRunnable && (
         <Button variant="filled" onClick={() => runQuestionQuery()}>


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/48448

### Description

Update the metric copy to be more consistent

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New -> Metric
2. The copy on the bottom of the page should match the copy on the empty `/browse/metrics` page (when it's empty).

### Demo

<img width="1474" alt="Screenshot 2024-10-08 at 15 03 12" src="https://github.com/user-attachments/assets/3d4f3839-2ab9-40ca-ad27-391c02046a44">

<img width="1474" alt="Screenshot 2024-10-08 at 15 03 19" src="https://github.com/user-attachments/assets/57878f06-496c-4ad5-9a2a-f7a13d6cfc1a">
