### PR TITLE
update embedding homepage now that we don't auto-enable embedding

### DIFF
--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.stories.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.stories.tsx
@@ -33,7 +33,6 @@ export const Default: Story = {
     );
   },
   args: {
-    embeddingAutoEnabled: true,
     hasExampleDashboard: true,
     licenseActiveAtSetup: true,
     initialTab: "interactive",

--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.tsx
@@ -17,7 +17,6 @@ import { dismissEmbeddingHomepage } from "./actions";
 export const EmbedHomepage = () => {
   const [feedbackModalOpened, setFeedbackModalOpened] = useState(false);
   const dispatch = useDispatch();
-  const embeddingAutoEnabled = useSetting("setup-embedding-autoenabled");
   const licenseActiveAtSetup = useSetting("setup-license-active-at-setup");
   const exampleDashboardId = useSetting("example-dashboard-id");
   const [sendProductFeedback] = useSendProductFeedbackMutation();
@@ -93,7 +92,6 @@ export const EmbedHomepage = () => {
       <EmbedHomepageView
         onDismiss={onDismiss}
         exampleDashboardId={exampleDashboardId}
-        embeddingAutoEnabled={embeddingAutoEnabled}
         licenseActiveAtSetup={licenseActiveAtSetup}
         initialTab={initialTab}
         interactiveEmbeddingQuickstartUrl={

--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepageView.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepageView.tsx
@@ -1,4 +1,3 @@
-import { Link } from "react-router";
 import { jt, t } from "ttag";
 
 import ExternalLink from "metabase/core/components/ExternalLink";
@@ -36,14 +35,8 @@ export type EmbedHomepageViewProps = {
 };
 
 export const EmbedHomepageView = (props: EmbedHomepageViewProps) => {
-  const {
-    embeddingAutoEnabled,
-    initialTab,
-    embeddingDocsUrl,
-    analyticsDocsUrl,
-    sdkUrl,
-    onDismiss,
-  } = props;
+  const { initialTab, embeddingDocsUrl, analyticsDocsUrl, sdkUrl, onDismiss } =
+    props;
   return (
     <Stack maw={550}>
       <Group position="apart">
@@ -108,28 +101,6 @@ export const EmbedHomepageView = (props: EmbedHomepageViewProps) => {
           </Anchor>
         </Text>
       </Card>
-
-      {embeddingAutoEnabled && (
-        <Card>
-          <Text
-            color="text-dark"
-            fw="bold"
-          >{t`Embedding has been automatically enabled for you`}</Text>
-          <Text color="text-light" size="sm">
-            {/* eslint-disable-next-line no-literal-metabase-strings -- only visible to admins */}
-            {jt`Because you expressed interest in embedding Metabase, we took this step for you so that you can more easily try it out. You can turn it off anytime in ${(
-              <Anchor
-                size="sm"
-                component={Link}
-                to="/admin/settings/embedding-in-other-applications"
-                key="link"
-              >
-                admin/settings/embedding-in-other-applications
-              </Anchor>
-            )}.`}
-          </Text>
-        </Card>
-      )}
 
       <Card>
         <Text color="text-dark" fw="bold">{t`Need more information?`}</Text>

--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepageView.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepageView.tsx
@@ -20,7 +20,6 @@ import { StaticTabContent } from "./StaticTabContent";
 import type { EmbeddingHomepageInitialTab } from "./types";
 
 export type EmbedHomepageViewProps = {
-  embeddingAutoEnabled: boolean;
   exampleDashboardId: number | null;
   licenseActiveAtSetup: boolean;
   initialTab: EmbeddingHomepageInitialTab;

--- a/frontend/src/metabase/home/components/EmbedHomepage/InteractiveTabContent.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/InteractiveTabContent.tsx
@@ -9,7 +9,6 @@ import type { EmbedHomepageViewProps } from "./EmbedHomepageView";
 import { trackEmbeddingHomepageQuickstartClick } from "./analytics";
 
 export const InteractiveTabContent = ({
-  embeddingAutoEnabled,
   interactiveEmbeddingQuickstartUrl,
   exampleDashboardId,
   licenseActiveAtSetup,
@@ -35,15 +34,13 @@ export const InteractiveTabContent = ({
             >{t`Activate your commercial license`}</Anchor>
           </List.Item>
         )}
-        {embeddingAutoEnabled === false && (
-          <List.Item>
-            <Anchor
-              size="sm"
-              component={Link}
-              to="/admin/settings/embedding-in-other-applications"
-            >{t`Enable embedding in the settings`}</Anchor>
-          </List.Item>
-        )}
+        <List.Item>
+          <Anchor
+            size="sm"
+            component={Link}
+            to="/admin/settings/embedding-in-other-applications"
+          >{t`Enable interactive embedding in the settings`}</Anchor>
+        </List.Item>
         {exampleDashboardId === undefined && (
           <List.Item>{t`Create a dashboard to be embedded`}</List.Item>
         )}

--- a/frontend/src/metabase/home/components/EmbedHomepage/StaticTabContent.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/StaticTabContent.tsx
@@ -9,7 +9,6 @@ import type { EmbedHomepageViewProps } from "./EmbedHomepageView";
 import { trackEmbeddingHomepageExampleDashboardClick } from "./analytics";
 
 export const StaticTabContent = ({
-  embeddingAutoEnabled,
   exampleDashboardId,
   learnMoreStaticEmbedUrl,
   initialTab,
@@ -24,15 +23,13 @@ export const StaticTabContent = ({
       <Text fw="bold" mb="md">{t`The TL;DR:`}</Text>
 
       <List type="ordered" mb="lg" size="sm">
-        {embeddingAutoEnabled === false && (
-          <List.Item>
-            <Anchor
-              size="sm"
-              component={Link}
-              to="/admin/settings/embedding-in-other-applications"
-            >{t`Enable embedding in the settings`}</Anchor>
-          </List.Item>
-        )}
+        <List.Item>
+          <Anchor
+            size="sm"
+            component={Link}
+            to="/admin/settings/embedding-in-other-applications"
+          >{t`Enable static embedding in the settings`}</Anchor>
+        </List.Item>
         <List.Item>{jt`${
           isNotNull(exampleDashboardId) ? t`Select` : `Create`
         } a question or dashboard to embed. Then click ${(

--- a/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
@@ -59,7 +59,7 @@ describe("EmbedHomepage (OSS)", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("should prompt to enable embedding", () => {
+  it("should prompt to enable static embedding", () => {
     setup();
 
     expect(

--- a/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
@@ -59,27 +59,11 @@ describe("EmbedHomepage (OSS)", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("should prompt to enable embedding if it wasn't auto enabled", () => {
-    setup({ settings: { "setup-embedding-autoenabled": false } });
+  it("should prompt to enable embedding", () => {
+    setup();
 
     expect(
-      screen.getByText("Enable embedding in the settings"),
-    ).toBeInTheDocument();
-
-    expect(
-      screen.queryByText("Embedding has been automatically enabled for you"),
-    ).not.toBeInTheDocument();
-  });
-
-  it("should not prompt to enable embedding if it was auto enabled", () => {
-    setup({ settings: { "setup-embedding-autoenabled": true } });
-
-    expect(
-      screen.queryByText("Enable embedding in the settings"),
-    ).not.toBeInTheDocument();
-
-    expect(
-      screen.getByText("Embedding has been automatically enabled for you"),
+      screen.getByText("Enable static embedding in the settings"),
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/metabase/home/components/EmbedHomepage/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/tests/enterprise.unit.spec.tsx
@@ -23,6 +23,14 @@ describe("EmbedHomepage (EE, no token)", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("should prompt to enable interactive embedding", () => {
+    setup();
+
+    expect(
+      screen.getByText("Enable interactive embedding in the settings"),
+    ).toBeInTheDocument();
+  });
+
   it("should prompt to activate the license if it wasn't found at the end of the setup", () => {
     setupEnterprise();
 


### PR DESCRIPTION
https://metaboat.slack.com/archives/C063Q3F1HPF/p1728393877512229?thread_ts=1728033780.348469&cid=C063Q3F1HPF

## Changes

After we split the embedding setting in three independent toggles, we don't automatically enabled embedding for the user. This changes the embedding homepage to reflect that

- Removes
![image](https://github.com/user-attachments/assets/b43db023-ace2-459a-baaa-949619fb1104)
- always show the "Enable embedding" step
- specify which embedding needs to be enabled (static/interactive)

I'll create a follow up PR to change the setup to not send the `embedding-autoenabled` setting and to clean up related code and tests, this PR is to unblock master
