### PR TITLE
Fix query_metadata not including metadata for native queries

### DIFF
--- a/frontend/src/metabase/entities/tables.js
+++ b/frontend/src/metabase/entities/tables.js
@@ -306,29 +306,6 @@ const Tables = createEntity({
       }
     }
 
-    if (type === "metabase/dashboard/FETCH_DASHBOARD/fulfilled" && !error) {
-      const virtualTables = payload.dashboard.dashcards.map(dc =>
-        convertSavedQuestionToVirtualTable(dc.card),
-      );
-
-      return virtualTables.reduce((acc, vt) => {
-        if (acc[vt.id]) {
-          return {
-            ...acc,
-            [vt.id]: {
-              ...acc[vt.id],
-              ...vt,
-            },
-          };
-        } else {
-          return {
-            ...acc,
-            [vt.id]: vt,
-          };
-        }
-      }, state);
-    }
-
     return state;
   },
   objectSelectors: {

--- a/src/metabase/api/query_metadata.clj
+++ b/src/metabase/api/query_metadata.clj
@@ -84,11 +84,12 @@
 (defn batch-fetch-card-metadata
   "Fetch dependent metadata for cards.
 
-  Models and metrics need their definitions walked as well as their own, card-level metadata."
+  Models and native queries need their definitions walked as well as their own, card-level metadata."
   [cards]
   (let [queries (into (vec (keep :dataset_query cards)) ; All the queries on all the cards
-                      ;; Plus the card-level metadata of each model.
-                      (comp (filter (comp #{:model} :type))
+                      ;; Plus the card-level metadata of each model and native query
+                      (comp (filter (fn [card] (or (= :model (:type card))
+                                                   (= :native (-> card :dataset_query :type)))))
                             (map (fn [card] {:query {:source-table (str "card__" (u/the-id card))}})))
                       cards)]
     (batch-fetch-query-metadata queries)))

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -3830,7 +3830,7 @@
                               {:id (mt/id :orders :user_id)}
                               {:id (mt/id :people :source)}
                               {:id (mt/id :people :name)}])
-            :tables (sort-by (comp str :id)
+            :tables (sort-by :id
                              [{:id (str "card__" card-id-2)}])
             :databases [{:id (mt/id) :engine string?}]}
            (-> (mt/user-http-request :crowberto :get 200 (str "card/" card-id-2 "/query_metadata"))

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -3830,7 +3830,8 @@
                               {:id (mt/id :orders :user_id)}
                               {:id (mt/id :people :source)}
                               {:id (mt/id :people :name)}])
-            :tables empty?
+            :tables (sort-by (comp str :id)
+                             [{:id (str "card__" card-id-2)}])
             :databases [{:id (mt/id) :engine string?}]}
            (-> (mt/user-http-request :crowberto :get 200 (str "card/" card-id-2 "/query_metadata"))
                 ;; The output is so large, these help debugging

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -4600,16 +4600,17 @@
                             {:id (mt/id :orders :user_id)}
                             {:id (mt/id :people :source)}
                             {:id (mt/id :people :name)}])
-          :tables (sort-by (comp str :id)
-                           [{:id (mt/id :categories)}
-                            {:id (mt/id :users)}
-                            {:id (mt/id :checkins)}
-                            {:id (mt/id :reviews)}
-                            {:id (mt/id :products)
-                             :fields sequential?}
-                            {:id (mt/id :venues)}
-                            {:id (str "card__" card-id-2)
-                             :fields sequential?}])
+          :tables (concat (sort-by :id
+                                   [{:id (mt/id :categories)}
+                                    {:id (mt/id :users)}
+                                    {:id (mt/id :checkins)}
+                                    {:id (mt/id :reviews)}
+                                    {:id (mt/id :products)
+                                     :fields sequential?}
+                                    {:id (mt/id :venues)}])
+                          (sort-by :id
+                                   [{:id (str "card__" card-id-2)
+                                     :fields sequential?}]))
           :cards [{:id link-card}]
           :databases [{:id (mt/id) :engine string?}]
           :dashboards [{:id link-dash}]}

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -4600,13 +4600,16 @@
                             {:id (mt/id :orders :user_id)}
                             {:id (mt/id :people :source)}
                             {:id (mt/id :people :name)}])
-          :tables (sort-by :id [{:id (mt/id :categories)}
-                                {:id (mt/id :users)}
-                                {:id (mt/id :checkins)}
-                                {:id (mt/id :reviews)}
-                                {:id (mt/id :products)
-                                 :fields sequential?}
-                                {:id (mt/id :venues)}])
+          :tables (sort-by (comp str :id)
+                           [{:id (mt/id :categories)}
+                            {:id (mt/id :users)}
+                            {:id (mt/id :checkins)}
+                            {:id (mt/id :reviews)}
+                            {:id (mt/id :products)
+                             :fields sequential?}
+                            {:id (mt/id :venues)}
+                            {:id (str "card__" card-id-2)
+                             :fields sequential?}])
           :cards [{:id link-card}]
           :databases [{:id (mt/id) :engine string?}]
           :dashboards [{:id link-dash}]}


### PR DESCRIPTION
Follow up https://github.com/metabase/metabase/pull/48232

Removes a FE hack to compute metadata from the dashboard response and adds card-level metadata for native queries in `query_metadata`.

How to verify 1:
- New -> SQL query -> SELECT 1 -> Run -> Visualize as a table -> Save as Q1
- Add Q1 to a dashboard and refresh the page
- Click on a cell in Q1. Drills should work.

How to verify 2:
- New -> SQL query -> SELECT * FROM ORDERS-> Run (but do not save)
- Click on a cell -> Click "Save" -> Set the name and save
- Click on the cell again. Drills should appear.