### PR TITLE
ignore .loki from vscode search

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,11 @@
   "gulp.autoDetect": "off",
   "npm.autoDetect": "off",
   "eslint.options": {
-    "rulePaths": ["frontend/lint/eslint-rules/"]
+    "rulePaths": [
+      "frontend/lint/eslint-rules/"
+    ]
+  },
+  "search.exclude": {
+    ".loki": true
   }
 }


### PR DESCRIPTION
The screenshots have such long names that they show up on the quick open even for totally unrelated searches, unless @metabase/dashviz  uses the search to open those, I think it's better to exclude them from search.

I would exclude them locally but since we committed the vscode settings file, I don't know of an easy way to do it (If you know of a way, please tell me)

Before:
Not the end of the word, but I'd want to see `SetupChecklist/index` in not that below in the list
<img width="715" alt="image" src="https://github.com/user-attachments/assets/71513fff-2d17-43eb-9e37-ff814eaff593">
After:
<img width="726" alt="image" src="https://github.com/user-attachments/assets/a96c9df6-dbee-4ea5-81af-841a08f3da5c">