### PR TITLE
Remove "Draw box to filter" from grid maps for native queries

### DIFF
--- a/frontend/src/metabase/visualizations/click-actions/Mode/Mode.ts
+++ b/frontend/src/metabase/visualizations/click-actions/Mode/Mode.ts
@@ -37,37 +37,31 @@ export class Mode {
     settings: Record<string, any>,
     extraData?: Record<string, any>,
   ): ClickAction[] {
-    // keeping try/catch here as MBQL was failing silently
-    try {
-      const mode = this._queryMode;
-      const question = this._question;
-      const props = { question, settings, clicked, extraData };
+    const mode = this._queryMode;
+    const question = this._question;
+    const props = { question, settings, clicked, extraData };
 
-      let actions = [
-        ...(mode.hasDrills
-          ? queryDrill(question, clicked, this.isDrillEnabled)
-          : []),
-        ...(mode.clickActions?.flatMap(drill => drill(props)) ?? []),
-      ];
+    let actions = [
+      ...(mode.hasDrills
+        ? queryDrill(question, clicked, this.isDrillEnabled)
+        : []),
+      ...(mode.clickActions?.flatMap(drill => drill(props)) ?? []),
+    ];
 
-      if (!actions.length && mode.fallback) {
-        actions = mode.fallback(props);
-      }
-
-      if (this._plugins?.mapQuestionClickActions) {
-        actions = this._plugins.mapQuestionClickActions(actions, {
-          value: clicked.value,
-          column: clicked.column,
-          event: clicked.event,
-          data: clicked.data,
-        });
-      }
-
-      return actions;
-    } catch (e) {
-      console.error(e);
-      return [];
+    if (!actions.length && mode.fallback) {
+      actions = mode.fallback(props);
     }
+
+    if (this._plugins?.mapQuestionClickActions) {
+      actions = this._plugins.mapQuestionClickActions(actions, {
+        value: clicked.value,
+        column: clicked.column,
+        event: clicked.event,
+        data: clicked.data,
+      });
+    }
+
+    return actions;
   }
 
   private isDrillEnabled = (drill: DrillThruDisplayInfo): boolean => {

--- a/frontend/src/metabase/visualizations/components/LeafletGridHeatMap.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletGridHeatMap.jsx
@@ -3,6 +3,8 @@ import L from "leaflet";
 import { t } from "ttag";
 
 import { color } from "metabase/lib/colors";
+import * as Lib from "metabase-lib";
+import Question from "metabase-lib/v1/Question";
 import { rangeForValue } from "metabase-lib/v1/queries/utils/range-for-value";
 import { isMetric, isNumeric } from "metabase-lib/v1/types/utils/isa";
 
@@ -104,6 +106,17 @@ export default class LeafletGridHeatMap extends LeafletMap {
       console.error(err);
       this.props.onRenderError(err.message || err);
     }
+  }
+
+  supportsFilter() {
+    const {
+      series: [{ card }],
+      metadata,
+    } = this.props;
+
+    const question = new Question(card, metadata);
+    const { isNative } = Lib.queryDisplayInfo(question.query());
+    return !isNative;
   }
 
   _createGridSquare = index => {

--- a/frontend/src/metabase/visualizations/components/LeafletMap.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletMap.jsx
@@ -121,6 +121,17 @@ export default class LeafletMap extends Component {
     this.map.remove();
   }
 
+  supportsFilter() {
+    const {
+      series: [{ card }],
+      metadata,
+    } = this.props;
+
+    const question = new Question(card, metadata);
+    const { isNative } = Lib.queryDisplayInfo(question.query());
+    return !isNative || question.isSaved();
+  }
+
   startFilter() {
     this._filter = new L.Draw.Rectangle(
       this.map,
@@ -156,9 +167,7 @@ export default class LeafletMap extends Component {
     });
 
     const question = new Question(card, metadata);
-    const { isNative } = Lib.queryDisplayInfo(question.query());
-
-    if (!isNative || question.isSaved()) {
+    if (this.supportsFilter()) {
       const query = question.query();
       const stageIndex = -1;
       const filterBounds = {

--- a/frontend/src/metabase/visualizations/components/PinMap.jsx
+++ b/frontend/src/metabase/visualizations/components/PinMap.jsx
@@ -255,33 +255,38 @@ export default class PinMap extends Component {
               {t`Save as default view`}
             </div>
           ) : null}
-          {!isDashboard && (
-            <div
-              className={cx(
-                "PinMapUpdateButton",
-                ButtonsS.Button,
-                ButtonsS.ButtonSmall,
-                CS.mb1,
-              )}
-              onClick={() => {
-                if (
-                  !this.state.filtering &&
-                  this._map &&
-                  this._map.startFilter
-                ) {
-                  this._map.startFilter();
-                } else if (
-                  this.state.filtering &&
-                  this._map &&
-                  this._map.stopFilter
-                ) {
-                  this._map.stopFilter();
-                }
-              }}
-            >
-              {!this.state.filtering ? t`Draw box to filter` : t`Cancel filter`}
-            </div>
-          )}
+          {!isDashboard &&
+            this._map &&
+            this._map.supportsFilter &&
+            this._map.supportsFilter() && (
+              <div
+                className={cx(
+                  "PinMapUpdateButton",
+                  ButtonsS.Button,
+                  ButtonsS.ButtonSmall,
+                  CS.mb1,
+                )}
+                onClick={() => {
+                  if (
+                    !this.state.filtering &&
+                    this._map &&
+                    this._map.startFilter
+                  ) {
+                    this._map.startFilter();
+                  } else if (
+                    this.state.filtering &&
+                    this._map &&
+                    this._map.stopFilter
+                  ) {
+                    this._map.stopFilter();
+                  }
+                }}
+              >
+                {!this.state.filtering
+                  ? t`Draw box to filter`
+                  : t`Cancel filter`}
+              </div>
+            )}
         </div>
       </div>
     );

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
@@ -60,6 +60,7 @@ import type { ClickObject, ClickObjectDimension } from "metabase-lib";
 import * as Lib from "metabase-lib";
 import Question from "metabase-lib/v1/Question";
 import type Metadata from "metabase-lib/v1/metadata/Metadata";
+import { isNative } from "metabase-lib/v1/queries/utils/card";
 import { getColumnKey } from "metabase-lib/v1/queries/utils/column-key";
 import type {
   CardDisplayType,
@@ -68,6 +69,7 @@ import type {
   TimelineEvent,
   TimelineEventId,
 } from "metabase-types/api";
+import { isSavedCard } from "metabase-types/guards";
 
 export const parseDataKey = (dataKey: DataKey) => {
   let cardId: Nullable<CardId> = null;
@@ -273,6 +275,7 @@ export const canBrush = (
     !!onChangeCardAndRun &&
     hasBrushableDimension &&
     !hasCombinedCards &&
+    (!isNative(series[0].card) || isSavedCard(series[0].card)) &&
     !isRemappedToString(series) &&
     !hasClickBehavior(series)
   );

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
@@ -774,9 +774,6 @@ export const getBrushData = (
   const start = checkNumber(range[0]);
   const end = checkNumber(range[1]);
 
-  // console.log("getBrushData")
-  // console.log(isTimeSeries)
-
   if (isTimeSeries) {
     const nextQuery = Lib.updateTemporalFilter(
       query,


### PR DESCRIPTION
How to verify:
- New -> SQL query -> `SELECT * FROM PEOPLE LIMIT 10` -> Save
- Change the viz type to Map
- Viz settings -> Map type -> Grid map. Select columns (latitude, longitude) -> **Save**
- Make sure that `Draw box to filter` isn't available
- Viz settings -> Map type -> Pin map -> **Save**
- Make sure that `Draw box to filter` is available

Grid map:
<img width="1728" alt="Screenshot 2024-10-08 at 12 39 35" src="https://github.com/user-attachments/assets/c29450bd-ef08-4031-8af7-8cc51f245bfb">

Pin map:
<img width="1728" alt="Screenshot 2024-10-08 at 12 41 10" src="https://github.com/user-attachments/assets/1613eadc-3680-4e5c-8cdd-ba395961873b">
