### PR TITLE
Cards in Dashboards Milestone 2

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/stale/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/stale/api.clj
@@ -85,6 +85,15 @@
                   (assoc :fully_parameterized (api.collection/fully-parameterized-query? card))
                   (dissoc :dataset_query))))))
 
+(defn- annotate-dashboard-with-collection-info
+  "For dashboards, we want `here` and `location` since they can contain cards as children."
+  [dashboards]
+  (for [{parent-coll :collection
+         :as dashboard} (api.collection/annotate-dashboards dashboards)]
+    (assoc dashboard
+           :location (or (some-> parent-coll collection/children-location)
+                         "/"))))
+
 (defmethod present-model-items :model/Dashboard [_ dashboards]
   (->> (t2/hydrate (t2/select [:model/Dashboard
                                :id
@@ -101,6 +110,7 @@
 
                               :id [:in (set (map :id dashboards))])
                    :can_write :can_delete :can_restore [:collection :effective_location])
+       annotate-dashboard-with-collection-info
        present-collections))
 
 (api/defendpoint GET "/:id"

--- a/frontend/src/metabase/lib/dashboard_grid.js
+++ b/frontend/src/metabase/lib/dashboard_grid.js
@@ -1,3 +1,8 @@
+// NOTE: If we make changes to the algorithm or default values below we should change
+// [the backend version](https://github.com/metabase/metabase/blob/master/src/metabase/util/autoplace.clj).
+
+// If you change this, please change `default-grid-width` in
+// https://github.com/metabase/metabase/blob/master/src/metabase/util/autoplace.clj
 export const GRID_WIDTH = 24;
 export const GRID_ASPECT_RATIO = 10 / 9;
 
@@ -13,12 +18,15 @@ export const GRID_COLUMNS = {
   mobile: 1,
 };
 
+// If you change this, please change `default-card-size` in
+// https://github.com/metabase/metabase/blob/master/src/metabase/util/autoplace.clj
 export const DEFAULT_CARD_SIZE = { width: 4, height: 4 };
 
 export const MIN_ROW_HEIGHT = 40;
 
-// returns the first available position from left to right, top to bottom,
-// based on the existing cards,  item size, and grid width
+// returns the first available position from left to right, top to bottom, based on the existing cards, item size, and
+// grid width. NOTE: If you change the way this function works, please change `get-position-for-new-dashcard` in
+// https://github.com/metabase/metabase/blob/master/src/metabase/util/autoplace.clj
 export function getPositionForNewDashCard(
   cards,
   size_x = DEFAULT_CARD_SIZE.width,

--- a/src/metabase/api/activity.clj
+++ b/src/metabase/api/activity.clj
@@ -23,7 +23,8 @@
      "card"      [Card
                   :id :name :collection_id :description :display
                   :dataset_query :type :archived
-                  :collection.authority_level [:collection.name :collection_name]]
+                  :collection.authority_level [:collection.name :collection_name]
+                  [:dashboard.name :dashboard_name] :dashboard_id]
      "dashboard" [Dashboard
                   :id :name :collection_id :description
                   :archived
@@ -36,8 +37,10 @@
    (let [model-symb (symbol (str/capitalize model))
          self-qualify #(mdb.query/qualify model-symb %)]
      {:where [:in (self-qualify :id) ids]
-      :left-join (if (= model "table")
-                   [:metabase_database [:= :metabase_database.id (self-qualify :db_id)]]
+      :left-join (case model
+                   "table" [:metabase_database [:= :metabase_database.id (self-qualify :db_id)]]
+                   "card" [:collection [:= :collection.id (self-qualify :collection_id)]
+                           [:report_dashboard :dashboard] [:= :dashboard.id (self-qualify :dashboard_id)]]
                    [:collection [:= :collection.id (self-qualify :collection_id)]])})))
 
 (defn- models-for-views

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -522,9 +522,10 @@
 
 (api/defendpoint PUT "/:id"
   "Update a `Card`."
-  [id :as {{:keys [dataset_query description display name visualization_settings archived collection_id
+  [id delete_old_dashcards
+   :as {{:keys [dataset_query description display name visualization_settings archived collection_id
                    collection_position enable_embedding embedding_params result_metadata parameters
-                   cache_ttl collection_preview type dashboard_id delete_old_dashcards]
+                   cache_ttl collection_preview type dashboard_id]
             :as   card-updates} :body}]
   {id                     ms/PositiveInt
    name                   [:maybe ms/NonBlankString]

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -591,9 +591,33 @@
       (dissoc :display :authority_level :moderated_status :icon :personal_owner_id :collection_preview
               :dataset_query :table_id :query_type :is_upload)))
 
+(defn- annotate-dashboards
+  "Populates 'here' and 'below' on dashboard"
+  [dashboards]
+  (let [dashboard-ids (into #{} (map :id dashboards))
+        dashboards-containing-cards (->> (when (seq dashboard-ids)
+                                           (t2/query {:select-distinct [:dashboard_id]
+                                                      :from :report_card
+                                                      :where [:and
+                                                              [:= :archived false]
+                                                              [:in :dashboard_id dashboard-ids]
+                                                              [:exists {:select 1
+                                                                        :from :report_dashboardcard
+                                                                        :where [:and
+                                                                                [:= :report_dashboardcard.card_id :report_card.id]
+                                                                                [:= :report_dashboardcard.dashboard_id :report_card.dashboard_id]]}]]}))
+                                         (map :dashboard_id)
+                                         (into #{}))]
+    (for [dashboard dashboards]
+      (cond-> dashboard
+        (contains? dashboards-containing-cards (:id dashboard))
+        (assoc :here #{:card})))))
+
 (defmethod post-process-collection-children :dashboard
   [_ _options parent-collection rows]
-  (map (partial post-process-dashboard parent-collection) rows))
+  (->> rows
+       (annotate-dashboards)
+       (map (partial post-process-dashboard parent-collection))))
 
 (defenterprise snippets-collection-filter-clause
   "Clause to filter out snippet collections from the collection query on OSS instances, and instances without the

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -591,7 +591,7 @@
       (dissoc :display :authority_level :moderated_status :icon :personal_owner_id :collection_preview
               :dataset_query :table_id :query_type :is_upload)))
 
-(defn- annotate-dashboards
+(defn annotate-dashboards
   "Populates 'here' and 'below' on dashboard"
   [dashboards]
   (let [dashboard-ids (into #{} (map :id dashboards))

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -580,8 +580,11 @@
   [_ collection options]
   (dashboard-query collection options))
 
-(defn- post-process-dashboard [dashboard]
+(defn- post-process-dashboard [parent-collection dashboard]
   (-> (t2/instance :model/Dashboard dashboard)
+      (assoc :location (or (when parent-collection
+                             (collection/children-location parent-collection))
+                           "/"))
       (update :archived api/bit->boolean)
       (update :archived_directly api/bit->boolean)
       (t2/hydrate :can_write :can_restore :can_delete)
@@ -589,8 +592,8 @@
               :dataset_query :table_id :query_type :is_upload)))
 
 (defmethod post-process-collection-children :dashboard
-  [_ _options _ rows]
-  (map post-process-dashboard rows))
+  [_ _options parent-collection rows]
+  (map (partial post-process-dashboard parent-collection) rows))
 
 (defenterprise snippets-collection-filter-clause
   "Clause to filter out snippet collections from the collection query on OSS instances, and instances without the

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -669,7 +669,7 @@
 (defn- do-update-dashcards!
   [dashboard current-cards new-cards]
   (let [{:keys [to-create to-update to-delete]} (u/row-diff current-cards new-cards)]
-    (dashboard/archive-or-unarchive-internal-dashboard-questions! dashboard new-cards)
+    (dashboard/archive-or-unarchive-internal-dashboard-questions! (:id dashboard) new-cards)
     (assert-new-dashcards-are-not-internal-to-other-dashboards dashboard to-create)
     (when (seq to-update)
       (update-dashcards! dashboard to-update))

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -666,6 +666,7 @@
 (defn- do-update-dashcards!
   [dashboard current-cards new-cards]
   (let [{:keys [to-create to-update to-delete]} (u/row-diff current-cards new-cards)]
+    (dashboard/archive-or-unarchive-internal-dashboard-questions! dashboard new-cards)
     (assert-new-dashcards-are-not-internal-to-other-dashboards dashboard to-create)
     (when (seq to-update)
       (update-dashcards! dashboard to-update))

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -510,21 +510,20 @@
   {id ms/PositiveInt}
   (api/read-check :model/Dashboard id)
   ;; query copied from metabase.api.collection to match the shape of api/collection/<:id|root>/items
-  (let [query      {:select    (cond->
-                                [:c.id :c.name :c.description :c.entity_id :c.collection_position :c.display :c.collection_preview
-                                 :last_used_at :c.collection_id :c.archived_directly :c.archived :c.dataset_query :c.database_id
-                                 [(h2x/literal "card")  :model]
-                                 [{:select   [:status]
-                                   :from     [:moderation_review]
-                                   :where    [:and
-                                              [:= :moderated_item_type "card"]
-                                              [:= :moderated_item_id :c.id]
-                                              [:= :most_recent true]]
-                                      ;; limit 1 to ensure that there is only one result but this invariant should hold true, just
-                                      ;; protecting against potential bugs
-                                   :order-by [[:id :desc]]
-                                   :limit    1}
-                                  :moderated_status]])
+  (let [query      {:select [:c.id :c.name :c.description :c.entity_id :c.collection_position :c.display :c.collection_preview
+                             :last_used_at :c.collection_id :c.archived_directly :c.archived :c.dataset_query :c.database_id
+                             [(h2x/literal "card")  :model]
+                             [{:select   [:status]
+                               :from     [:moderation_review]
+                               :where    [:and
+                                          [:= :moderated_item_type "card"]
+                                          [:= :moderated_item_id :c.id]
+                                          [:= :most_recent true]]
+                               :order-by [[:id :desc]]
+                               ;; limit 1 to ensure that there is only one result but this invariant should hold true, just
+                               ;; protecting against potential bugs
+                               :limit    1}
+                              :moderated_status]]
                     :from      [[:report_card :c]]
                     :where     [:and
                                 [:= :c.dashboard_id id]

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -504,66 +504,36 @@
       (u/prog1 (first (last-edit/with-last-edit-info [dashboard] :dashboard))
         (events/publish-event! :event/dashboard-read {:object-id (:id dashboard) :user-id api/*current-user-id*})))))
 
-;; liberally copied from metabase.api.collection
-(mu/defn- coalesce-edit-info :- last-edit/MaybeAnnotated
-  "Hoist all of the last edit information into a map under the key :last-edit-info. Considers this information present
-  if `:last_edit_user` is not nil."
-  [row]
-  (letfn [(select-as [original k->k']
-            (reduce (fn [m [k k']] (assoc m k' (get original k)))
-                    {}
-                    k->k'))]
-    (let [mapping {:last_edit_user       :id
-                   :last_edit_last_name  :last_name
-                   :last_edit_first_name :first_name
-                   :last_edit_email      :email
-                   :last_edit_timestamp  :timestamp}]
-      (cond-> (apply dissoc row (keys mapping))
-        ;; don't use contains as they all have the key, we care about a value present
-        (:last_edit_user row) (assoc :last-edit-info (select-as row mapping))))))
-
 (api/defendpoint GET "/:id/items"
   "Get Dashboard with ID."
   [id]
   {id ms/PositiveInt}
   (api/read-check :model/Dashboard id)
-  ;; query copied from metabase.api.collection
-  (let [query {:select    (cond->
-                              [:c.id :c.name :c.description :c.entity_id :c.collection_position :c.display :c.collection_preview
-                               :last_used_at
-                               :c.collection_id
-                               :c.archived_directly
-                               :c.archived
-                               :c.dataset_query
-                               :c.database_id
-                               [(h2x/literal "card")  :model]
-                               [:u.id :last_edit_user]
-                               [:u.email :last_edit_email]
-                               [:u.first_name :last_edit_first_name]
-                               [:u.last_name :last_edit_last_name]
-                               [:r.timestamp :last_edit_timestamp]
-                               [{:select   [:status]
-                                 :from     [:moderation_review]
-                                 :where    [:and
-                                            [:= :moderated_item_type "card"]
-                                            [:= :moderated_item_id :c.id]
-                                            [:= :most_recent true]]
-                                 ;; limit 1 to ensure that there is only one result but this invariant should hold true, just
-                                 ;; protecting against potential bugs
-                                 :order-by [[:id :desc]]
-                                 :limit    1}
-                                :moderated_status]])
-               :from      [[:report_card :c]]
-               :left-join [[:revision :r] [:and
-                                           [:= :r.model_id :c.id]
-                                           [:= :r.most_recent true]
-                                           [:= :r.model (h2x/literal "Card")]]
-                           [:core_user :u] [:= :u.id :r.user_id]]
-               :where     [:= :c.dashboard_id id]}
-        cards (mdb.query/query query)]
-    {:total (count cards)
-     :data (into [] (comp (map coalesce-edit-info)
-                          (map #(update % :dataset_query (comp mbql.normalize/normalize json/parse-string)))) cards)
+  ;; query copied from metabase.api.collection to match the shape of api/collection/<:id|root>/items
+  (let [query      {:select    (cond->
+                                   [:c.id :c.name :c.description :c.entity_id :c.collection_position :c.display :c.collection_preview
+                                    :last_used_at :c.collection_id :c.archived_directly :c.archived :c.dataset_query :c.database_id
+                                    [(h2x/literal "card")  :model]
+                                    [{:select   [:status]
+                                      :from     [:moderation_review]
+                                      :where    [:and
+                                                 [:= :moderated_item_type "card"]
+                                                 [:= :moderated_item_id :c.id]
+                                                 [:= :most_recent true]]
+                                      ;; limit 1 to ensure that there is only one result but this invariant should hold true, just
+                                      ;; protecting against potential bugs
+                                      :order-by [[:id :desc]]
+                                      :limit    1}
+                                     :moderated_status]])
+                    :from      [[:report_card :c]]
+                    :where     [:and
+                                [:= :c.dashboard_id id]
+                                [:= :c.archived false]]}
+        cards      (mdb.query/query query)]
+    {:total  (count cards)
+     :data   (into []
+                   (map #(update % :dataset_query (comp mbql.normalize/normalize json/parse-string)))
+                   (last-edit/with-last-edit-info cards :card))
      :models ["card"]}))
 
 (defn- check-allowed-to-change-embedding

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -13,6 +13,7 @@
    [metabase.api.common.validation :as validation]
    [metabase.api.dataset :as api.dataset]
    [metabase.api.query-metadata :as api.query-metadata]
+   [metabase.db.query :as mdb.query]
    [metabase.email.messages :as messages]
    [metabase.events :as events]
    [metabase.legacy-mbql.normalize :as mbql.normalize]
@@ -48,6 +49,7 @@
    [metabase.query-processor.util :as qp.util]
    [metabase.related :as related]
    [metabase.util :as u]
+   [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.i18n :refer [deferred-tru tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
@@ -501,6 +503,68 @@
     (let [dashboard (get-dashboard id)]
       (u/prog1 (first (last-edit/with-last-edit-info [dashboard] :dashboard))
         (events/publish-event! :event/dashboard-read {:object-id (:id dashboard) :user-id api/*current-user-id*})))))
+
+;; liberally copied from metabase.api.collection
+(mu/defn- coalesce-edit-info :- last-edit/MaybeAnnotated
+  "Hoist all of the last edit information into a map under the key :last-edit-info. Considers this information present
+  if `:last_edit_user` is not nil."
+  [row]
+  (letfn [(select-as [original k->k']
+            (reduce (fn [m [k k']] (assoc m k' (get original k)))
+                    {}
+                    k->k'))]
+    (let [mapping {:last_edit_user       :id
+                   :last_edit_last_name  :last_name
+                   :last_edit_first_name :first_name
+                   :last_edit_email      :email
+                   :last_edit_timestamp  :timestamp}]
+      (cond-> (apply dissoc row (keys mapping))
+        ;; don't use contains as they all have the key, we care about a value present
+        (:last_edit_user row) (assoc :last-edit-info (select-as row mapping))))))
+
+(api/defendpoint GET "/:id/items"
+  "Get Dashboard with ID."
+  [id]
+  {id ms/PositiveInt}
+  (api/read-check :model/Dashboard id)
+  ;; query copied from metabase.api.collection
+  (let [query {:select    (cond->
+                              [:c.id :c.name :c.description :c.entity_id :c.collection_position :c.display :c.collection_preview
+                               :last_used_at
+                               :c.collection_id
+                               :c.archived_directly
+                               :c.archived
+                               :c.dataset_query
+                               :c.database_id
+                               [(h2x/literal "card")  :model]
+                               [:u.id :last_edit_user]
+                               [:u.email :last_edit_email]
+                               [:u.first_name :last_edit_first_name]
+                               [:u.last_name :last_edit_last_name]
+                               [:r.timestamp :last_edit_timestamp]
+                               [{:select   [:status]
+                                 :from     [:moderation_review]
+                                 :where    [:and
+                                            [:= :moderated_item_type "card"]
+                                            [:= :moderated_item_id :c.id]
+                                            [:= :most_recent true]]
+                                 ;; limit 1 to ensure that there is only one result but this invariant should hold true, just
+                                 ;; protecting against potential bugs
+                                 :order-by [[:id :desc]]
+                                 :limit    1}
+                                :moderated_status]])
+               :from      [[:report_card :c]]
+               :left-join [[:revision :r] [:and
+                                           [:= :r.model_id :c.id]
+                                           [:= :r.most_recent true]
+                                           [:= :r.model (h2x/literal "Card")]]
+                           [:core_user :u] [:= :u.id :r.user_id]]
+               :where     [:= :c.dashboard_id id]}
+        cards (mdb.query/query query)]
+    {:total (count cards)
+     :data (into [] (comp (map coalesce-edit-info)
+                          (map #(update % :dataset_query (comp mbql.normalize/normalize json/parse-string)))) cards)
+     :models ["card"]}))
 
 (defn- check-allowed-to-change-embedding
   "You must be a superuser to change the value of `enable_embedding` or `embedding_params`. Embedding must be

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -511,20 +511,20 @@
   (api/read-check :model/Dashboard id)
   ;; query copied from metabase.api.collection to match the shape of api/collection/<:id|root>/items
   (let [query      {:select    (cond->
-                                   [:c.id :c.name :c.description :c.entity_id :c.collection_position :c.display :c.collection_preview
-                                    :last_used_at :c.collection_id :c.archived_directly :c.archived :c.dataset_query :c.database_id
-                                    [(h2x/literal "card")  :model]
-                                    [{:select   [:status]
-                                      :from     [:moderation_review]
-                                      :where    [:and
-                                                 [:= :moderated_item_type "card"]
-                                                 [:= :moderated_item_id :c.id]
-                                                 [:= :most_recent true]]
+                                [:c.id :c.name :c.description :c.entity_id :c.collection_position :c.display :c.collection_preview
+                                 :last_used_at :c.collection_id :c.archived_directly :c.archived :c.dataset_query :c.database_id
+                                 [(h2x/literal "card")  :model]
+                                 [{:select   [:status]
+                                   :from     [:moderation_review]
+                                   :where    [:and
+                                              [:= :moderated_item_type "card"]
+                                              [:= :moderated_item_id :c.id]
+                                              [:= :most_recent true]]
                                       ;; limit 1 to ensure that there is only one result but this invariant should hold true, just
                                       ;; protecting against potential bugs
-                                      :order-by [[:id :desc]]
-                                      :limit    1}
-                                     :moderated_status]])
+                                   :order-by [[:id :desc]]
+                                   :limit    1}
+                                  :moderated_status]])
                     :from      [[:report_card :c]]
                     :where     [:and
                                 [:= :c.dashboard_id id]

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -528,13 +528,16 @@
                     :from      [[:report_card :c]]
                     :where     [:and
                                 [:= :c.dashboard_id id]
+                                [:exists {:select 1
+                                          :from [[:report_dashboardcard :dc]]
+                                          :where [:and [:= :c.id :dc.card_id] [:= :c.dashboard_id :dc.dashboard_id]]}]
                                 [:= :c.archived false]]}
         cards      (mdb.query/query query)]
     {:total  (count cards)
      :data   (into []
                    (map #(update % :dataset_query (comp mbql.normalize/normalize json/parse-string)))
                    (last-edit/with-last-edit-info cards :card))
-     :models ["card"]}))
+     :models (if (seq cards) ["card"] [])}))
 
 (defn- check-allowed-to-change-embedding
   "You must be a superuser to change the value of `enable_embedding` or `embedding_params`. Embedding must be

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -418,8 +418,7 @@
            (not (:dashboard_id changes)))))
 
 (defn- is-valid-dashboard-internal-card-for-update [card changes]
-  (or (and (not (was-dashboard-question? card changes))
-           (not (contains? changes :dashboard_id)))
+  (or (not (was-dashboard-question? card changes))
       (and
        (was-dashboard-question? card changes)
        (or *updating-dashboard* (not (contains? changes :collection_id)))
@@ -863,7 +862,7 @@
                 (u/select-keys-when card-updates
                                     ;; `collection_id` and `description` can be `nil` (in order to unset them).
                                     ;; Other values should only be modified if they're passed in as non-nil
-                                    :present #{:collection_id :collection_position :description :cache_ttl :archived_directly}
+                                    :present #{:collection_id :collection_position :description :cache_ttl :archived_directly :dashboard_id}
                                     :non-nil #{:dataset_query :display :name :visualization_settings :archived
                                                :enable_embedding :type :parameters :parameter_mappings :embedding_params
                                                :result_metadata :collection_preview :verified-result-metadata?})))

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -827,12 +827,16 @@
         {:keys [dashcards tabs]} dashboard
         already-on-dashboard? (seq (filter #(= (:id card) (:card_id %)) dashcards))
         first-tab (or (first tabs)
-                      (sort dashboard-card/dashcard-comparator dashcards))]
+                      (sort dashboard-card/dashcard-comparator dashcards)
+                      ;; if we don't have any existing cards, fake it to make the math work out
+                      [{:col 0 :row 0}])]
     (when-not already-on-dashboard?
-      (t2/insert! :model/DashboardCard {:dashboard_id dashboard-id
+      (t2/insert! :model/DashboardCard #p {:dashboard_id dashboard-id
                                         :card_id (:id card)
                                         :size_x 10 :size_y 10
-                                        :row 0 :col (+ 10 (:col (last first-tab) 0))}))))
+                                        :row (+ 10 (:row (last first-tab)))
+                                        :col 0}))))
+
 (defn update-card!
   "Update a Card. Metadata is fetched asynchronously. If it is ready before [[metadata-sync-wait-ms]] elapses it will be
   included, otherwise the metadata will be saved to the database asynchronously."

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -682,7 +682,9 @@
                                (sort dashboard-card/dashcard-comparator dashcards))
         new-spot (autoplace/get-position-for-new-dashcard cards-on-first-tab)]
     (when-not already-on-dashboard?
-      (t2/insert! :model/DashboardCard (assoc new-spot :card_id (:id card))))))
+      (t2/insert! :model/DashboardCard (assoc new-spot
+                                              :card_id (:id card)
+                                              :dashboard_id dashboard-id)))))
 
 (defn create-card!
   "Create a new Card. Metadata will be fetched off thread. If the metadata takes longer than [[metadata-sync-wait-ms]]

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -854,6 +854,10 @@
       (autoplace-dashcard-for-card! (:dashboard_id card-updates)
                                     card-before-update))
 
+    (when (and (:dashboard_id card-updates)
+               (:dashboard_id card-before-update))
+      (t2/delete! :model/DashboardCard :card_id (:id card-before-update) :dashboard_id (:dashboard_id card-before-update)))
+
     (when (and (card-is-verified? card-before-update)
                (changed? card-compare-keys card-before-update card-updates))
       ;; this is an enterprise feature but we don't care if enterprise is enabled here. If there is a review we need

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -421,10 +421,9 @@
     (if-not will-be-dq?
       true
       (and
-       (or *updating-dashboard* (not (contains? changes :collection_id)))
-       (not (contains? changes :collection_position))
-       (or (not (contains? changes :type))
-           (contains? #{:question "question" nil} (:type changes)))))))
+       (or *updating-dashboard* (not (api/column-will-change? :collection_id card changes)))
+       (not (api/column-will-change? :collection_position card changes))
+       (not (api/column-will-change? :type card changes))))))
 
 (defn- assert-is-valid-dashboard-internal-update [changes card]
   (let [dashboard-id->name (dissoc

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -869,10 +869,17 @@
       (autoplace-dashcard-for-card! (:dashboard_id card-updates)
                                     card-before-update))
 
-    (when (and (:dashboard_id card-updates)
-               (:dashboard_id card-before-update)
-               delete-old-dashcards?)
-      (t2/delete! :model/DashboardCard :card_id (:id card-before-update) :dashboard_id (:dashboard_id card-before-update)))
+    (when (or
+           ;; we're moving from one dashboard to another
+           (and (:dashboard_id card-updates)
+                (:dashboard_id card-before-update))
+           ;; we're moving from a dashboard into a collection, AND the user told us they want to remove the old dashcards
+           (and (:dashboard_id card-before-update)
+                (not (:dashboard_id card-updates))
+                delete-old-dashcards?))
+      (t2/delete! :model/DashboardCard
+                  :card_id (:id card-before-update)
+                  :dashboard_id (:dashboard_id card-before-update)))
 
     (when (and (card-is-verified? card-before-update)
                (changed? card-compare-keys card-before-update card-updates))

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -684,14 +684,15 @@
     (let [collection-ids (visible-collection-ids {:include-archived-items :all
                                                   :include-trash-collection? true})]
       (for [collection collections]
-        (assoc collection :effective_location
-               (when-not (or (nil? collection) (collection.root/is-root-collection? collection))
-                 (let [real-location-path (if (:archived_directly collection)
-                                            (trash-path)
-                                            (:location collection))]
-                   (apply location-path (for [id    (location-path->ids real-location-path)
-                                              :when (contains? collection-ids id)]
-                                          id)))))))))
+        (when (some? collection)
+          (assoc collection :effective_location
+                 (when-not (collection.root/is-root-collection? collection)
+                   (let [real-location-path (if (:archived_directly collection)
+                                              (trash-path)
+                                              (:location collection))]
+                     (apply location-path (for [id    (location-path->ids real-location-path)
+                                                :when (contains? collection-ids id)]
+                                            id))))))))))
 
 (defn effective-location-path
   "Given a collection, returns the effective location (hiding parts of the path that the current user doesn't have access to)."

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -213,6 +213,7 @@
                                       [:in :dashcard.dashboard_id (map :id dashboards)]
                                       [:or
                                        [:= :card.archived false]
+                                       [:not= :card.dashboard_id nil]
                                        [:= :card.archived nil]]] ; e.g. DashCards with no corresponding Card, e.g. text Cards
                           :order-by  [[:dashcard.dashboard_id] [:dashcard.created_at :asc]]}))
    :id

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -241,9 +241,9 @@
   Questions that *are* on the Dashboard as *not* archived. This function takes a dashboard and the set of dashcards
   about to be saved, and ensures that all DQs that appear on the dashboard are unarchived and all DQs that DON'T
   appear on the dashboard are archived."
-  [dashboard new-cards]
+  [dashboard-id new-cards]
   (let [;; the set of ALL Dashboard Questions (internal to the dashboard) for this Dashboard
-        internal-dashboard-question-ids (t2/select-pks-set :model/Card :dashboard_id (:id dashboard))
+        internal-dashboard-question-ids (t2/select-pks-set :model/Card :dashboard_id dashboard-id)
         ;; the set of all card IDs that are present on the dashboard
         used-card-ids (into #{} (map :card_id new-cards))
         ;; DQs that aren't used get archived
@@ -312,6 +312,8 @@
                             (t2/select-pks-set :model/Card
                                                {:where [:and
                                                         [:in :id card-ids]
+                                                        ;; skip when archived
+                                                        [:= :archived false]
                                                         ;; belong to this dashboard, or are not Dashboard Questions
                                                         [:or
                                                          [:= :dashboard_id dashboard-id]

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -238,7 +238,9 @@
 (defn archive-or-unarchive-internal-dashboard-questions!
   "When updating dashboard cards, if we're removing all references to a Dashboard Question (which is internal to the
   dashboard, not displayed as part of a collection) we want to archive it. Similarly, we want to mark any Dashboard
-  Questions that *are* on the Dashboard as *not* archived."
+  Questions that *are* on the Dashboard as *not* archived. This function takes a dashboard and the set of dashcards
+  about to be saved, and ensures that all DQs that appear on the dashboard are unarchived and all DQs that DON'T
+  appear on the dashboard are archived."
   [dashboard new-cards]
   (let [;; the set of ALL Dashboard Questions (internal to the dashboard) for this Dashboard
         internal-dashboard-question-ids (t2/select-pks-set :model/Card :dashboard_id (:id dashboard))
@@ -310,7 +312,6 @@
                             (t2/select-pks-set :model/Card
                                                {:where [:and
                                                         [:in :id card-ids]
-                                                        [:= :archived false]
                                                         ;; belong to this dashboard, or are not Dashboard Questions
                                                         [:or
                                                          [:= :dashboard_id dashboard-id]

--- a/src/metabase/models/recent_views.clj
+++ b/src/metabase/models/recent_views.clj
@@ -182,6 +182,11 @@
     ;; database IDs... commented out for now until someone gets a change to look at this. -- Cam
     [:multi {:dispatch :model}
      [:card [:map
+             [:dashboard {:optional true}
+              [:maybe
+               [:map
+                [:name :string]
+                [:id :int]]]]
              [:display :string]
              #_[:database_id :int]
              [:parent_collection ::pc]

--- a/src/metabase/models/recent_views.clj
+++ b/src/metabase/models/recent_views.clj
@@ -284,6 +284,8 @@
                    (parent-collection-valid? model_object)
                    (ellide-archived model_object))]
     {:id model_id
+     :dashboard {:name (:dashboard_name card)
+                 :id (:dashboard_id card)}
      :name (:name card)
      :database_id (:database_id card)
      :description (:description card)

--- a/src/metabase/models/recent_views.clj
+++ b/src/metabase/models/recent_views.clj
@@ -245,6 +245,8 @@
                          :card.id
                          :card.database_id
                          :card.display
+                         [:dashboard.id :dashboard_id]
+                         [:dashboard.name :dashboard_name]
                          [:card.collection_id :entity-coll-id]
                          [:mr.status :moderated-status]
                          [:collection.id :collection_id]
@@ -260,7 +262,10 @@
                             [:collection]
                             [:and
                              [:= :collection.id :card.collection_id]
-                             [:= :collection.archived false]]]})))
+                             [:= :collection.archived false]]
+
+                            [:report_dashboard :dashboard]
+                            [:= :dashboard.id :card.dashboard_id]]})))
 
 (defn- fill-parent-coll [model-object]
   (if (:collection_id model-object)
@@ -284,8 +289,9 @@
                    (parent-collection-valid? model_object)
                    (ellide-archived model_object))]
     {:id model_id
-     :dashboard {:name (:dashboard_name card)
-                 :id (:dashboard_id card)}
+     :dashboard (when (:dashboard_id card)
+                  {:name (:dashboard_name card)
+                   :id (:dashboard_id card)})
      :name (:name card)
      :database_id (:database_id card)
      :description (:description card)

--- a/src/metabase/util/autoplace.clj
+++ b/src/metabase/util/autoplace.clj
@@ -14,10 +14,10 @@
 
 (defn- intersects [a b]
   (not (or
-        (>= (:col b) (+ (:col a) (:x_size a)))
-        (<= (+ (:col b) (:x_size b)) (:col a))
-        (>= (:row b) (+ (:row a) (:y_size a)))
-        (<= (+ (:row b) (:y_size b)) (:row a)))))
+        (>= (:col b) (+ (:col a) (:size_x a)))
+        (<= (+ (:col b) (:size_x b)) (:col a))
+        (>= (:row b) (+ (:row a) (:size_y a)))
+        (<= (+ (:row b) (:size_y b)) (:row a)))))
 
 (defn- intersects-with-any-card? [cards position]
   (boolean (some #(intersects position %) cards)))
@@ -40,15 +40,15 @@
   "
   ([cards]
    (get-position-for-new-dashcard cards (:width default-card-size) (:height default-card-size) default-grid-width))
-  ([cards x_size y_size grid-width]
+  ([cards size_x size_y grid-width]
    (let [dashboard-tab-id (:dashboard_tab_id (first cards))]
      (first
       (for [row (range 1000)
-            col (range (inc (- grid-width x_size)))
+            col (range (inc (- grid-width size_x)))
             :let [this-card {:col col
                              :row row
-                             :x_size x_size
-                             :y_size y_size
+                             :size_x size_x
+                             :size_y size_y
                              :dashboard_tab_id dashboard-tab-id}]
             :when (not (intersects-with-any-card? cards this-card))]
         this-card)))))

--- a/src/metabase/util/autoplace.clj
+++ b/src/metabase/util/autoplace.clj
@@ -1,0 +1,54 @@
+(ns metabase.util.autoplace
+  "NOTE: It's not SUPER high impact if it falls out of sync - hopefully both will place things in a reasonable spot - but
+  ideally this namespace should be kept in sync with
+  [the frontend version](https://github.com/metabase/metabase/blob/master/frontend/src/metabase/lib/dashboard_grid.js).")
+
+(def ^:constant default-grid-width
+  "The default width of the grid. See GRID_WIDTH in
+  https://github.com/metabase/metabase/blob/master/frontend/src/metabase/lib/dashboard_grid.js" 24)
+
+(def ^:constant default-card-size
+  "The size of the default card. See DEFAULT_CARD_SIZE in
+  https://github.com/metabase/metabase/blob/master/frontend/src/metabase/lib/dashboard_grid.js"
+  {:width 4 :height 4})
+
+(defn- intersects [a b]
+  (not (or
+        (>= (:col b) (+ (:col a) (:x_size a)))
+        (<= (+ (:col b) (:x_size b)) (:col a))
+        (>= (:row b) (+ (:row a) (:y_size a)))
+        (<= (+ (:row b) (:y_size b)) (:row a)))))
+
+(defn- intersects-with-any-card? [cards position]
+  (boolean (some #(intersects position %) cards)))
+
+(defn get-position-for-new-dashcard
+  "Where should a new card be placed on a tab, given the existing dashcards?
+
+  NOTE: almost identical in behavior to `getPositionForNewDashCard` in
+  https://github.com/metabase/metabase/blob/master/frontend/src/metabase/lib/dashboard_grid.js
+
+  If you make changes here, we should keep the frontend version in sync.
+
+  There are two differences, both unlikely to matter:
+
+  - in the case where we couldn't find any position at all (there is no space at all in 1000 rows) this will return
+  `nil`, which will result in an error bubbling up. This should never happen, but something to call out.
+
+  - this includes a `dashboard_tab_id` in the returned value (which may be `nil`). This is just to make it a bit
+  easier for the caller.
+  "
+  ([cards]
+   (get-position-for-new-dashcard cards (:width default-card-size) (:height default-card-size) default-grid-width))
+  ([cards x_size y_size grid-width]
+   (let [dashboard-tab-id (:dashboard_tab_id (first cards))]
+     (first
+      (for [row (range 1000)
+            col (range (inc (- grid-width x_size)))
+            :let [this-card {:col col
+                             :row row
+                             :x_size x_size
+                             :y_size y_size
+                             :dashboard_tab_id dashboard-tab-id}]
+            :when (not (intersects-with-any-card? cards this-card))]
+        this-card)))))

--- a/test/metabase/api/activity_test.clj
+++ b/test/metabase/api/activity_test.clj
@@ -202,9 +202,26 @@
               (is (= [{:model "metric" :id (u/the-id metric) :name "rand-metric-name"}
                       {:model "table" :id (u/the-id table1) :name "rand-name"}
                       {:model "dashboard" :id (u/the-id dash) :name "rand-name2"}
-                      {:model "card" :id (u/the-id card1) :name "rand-name"}
+                      {:model "card" :id (u/the-id card1) :name "rand-name" :dashboard nil}
                       {:model "dataset" :id (u/the-id dataset) :name "rand-name"}]
-                     (map #(select-keys % [:model :id :name]) recent-views))))))))))
+                     (map #(select-keys % [:model :id :name :dashboard]) recent-views))))))))))
+
+(deftest recent-card-read-views-have-dashboard-info-for-dashboard-questions
+  (clear-recent-views-for-user :crowberto)
+  (mt/with-test-user :crowberto
+    (mt/with-model-cleanup [:model/ViewLog :model/RecentViews]
+      (mt/with-temp [:model/Dashboard {dash-id :id} {:name "the dashboard name"}
+                     :model/Card      {card-id :id} {:name "dashboard question card"
+                                                     :dashboard_id dash-id}]
+        (testing "recent_views endpoint shows the current user's recently viewed items."
+          (clear-recent-views-for-user :crowberto)
+          (testing (str "> EVENT: " :event/card-read " does create recent views.")
+            (doseq [[topic event] [[:event/card-read      {:user-id (mt/user->id :crowberto) :object-id #p card-id :context :question}]]]
+              (events/publish-event! topic (assoc event :user-id (mt/user->id :crowberto))))
+            (let [recent-views (:recents (mt/user-http-request :crowberto :get 200 "activity/recents?context=views"))]
+              (is (= [{:model "card" :id card-id :name "dashboard question card" :dashboard {:name "the dashboard name"
+                                                                                             :id   dash-id}}]
+                     (map #(select-keys % [:model :id :name :dashboard]) recent-views))))))))))
 
 (deftest recent-card-query-views-test
   (clear-recent-views-for-user :crowberto)

--- a/test/metabase/api/activity_test.clj
+++ b/test/metabase/api/activity_test.clj
@@ -216,7 +216,7 @@
         (testing "recent_views endpoint shows the current user's recently viewed items."
           (clear-recent-views-for-user :crowberto)
           (testing (str "> EVENT: " :event/card-read " does create recent views.")
-            (doseq [[topic event] [[:event/card-read      {:user-id (mt/user->id :crowberto) :object-id #p card-id :context :question}]]]
+            (doseq [[topic event] [[:event/card-read      {:user-id (mt/user->id :crowberto) :object-id card-id :context :question}]]]
               (events/publish-event! topic (assoc event :user-id (mt/user->id :crowberto))))
             (let [recent-views (:recents (mt/user-http-request :crowberto :get 200 "activity/recents?context=views"))]
               (is (= [{:model "card" :id card-id :name "dashboard question card" :dashboard {:name "the dashboard name"

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -3951,27 +3951,43 @@
                    :model/Dashboard {dash-id :id} {:collection_id coll-id}
                    :model/Card {card-id :id} {:dashboard_id dash-id}
                    :model/DashboardCard _ {:dashboard_id dash-id
-                                           :card_id card-id}]
+                                           :card_id      card-id}]
       (is (=? {:collection_id coll-id
-               :dashboard_id nil}
+               :dashboard_id  nil}
               (mt/user-http-request :rasta :put 200 (str "card/" card-id) {:collection_id coll-id
-                                                                           :dashboard_id nil})))
-      (is (= coll-id (t2/select-one-fn :collection_id :model/Card card-id)))))
+                                                                           :dashboard_id  nil})))
+      (is (= coll-id (t2/select-one-fn :collection_id :model/Card card-id)))
+      ;; the old dashboardcard is still there (we don't remove the card from the dashboard it was in)
+      (is (t2/exists? :model/DashboardCard :dashboard_id dash-id :card_id card-id))))
+  (testing "We can move a dashboard question to a collection and remove the old reference to it"
+    (mt/with-temp [:model/Collection {coll-id :id} {}
+                   :model/Dashboard {dash-id :id} {:collection_id coll-id}
+                   :model/Card {card-id :id} {:dashboard_id dash-id}
+                   :model/DashboardCard _ {:dashboard_id dash-id
+                                           :card_id      card-id}]
+      (is (=? {:collection_id coll-id
+               :dashboard_id  nil}
+              (mt/user-http-request :rasta :put 200 (str "card/" card-id) {:collection_id coll-id
+                                                                           :dashboard_id  nil
+                                                                           :delete_old_dashcards "true"})))
+      (is (= coll-id (t2/select-one-fn :collection_id :model/Card card-id)))
+      ;; we remove the card from the dashboard it was in
+      (is (not (t2/exists? :model/DashboardCard :dashboard_id dash-id :card_id card-id)))))
   (testing "We can move a question from a collection to a dashboard it is already in"
     (mt/with-temp [:model/Collection {coll-id :id} {}
                    :model/Dashboard {dash-id :id} {:collection_id coll-id}
                    :model/Card {card-id :id} {}
                    :model/DashboardCard _ {:dashboard_id dash-id
-                                           :card_id card-id}]
+                                           :card_id      card-id}]
       (is (=? {:collection_id coll-id
-               :dashboard_id dash-id}
+               :dashboard_id  dash-id}
               (mt/user-http-request :rasta :put 200 (str "card/" card-id) {:dashboard_id dash-id})))))
   (testing "We can move a question from a collection to a dashboard it is NOT already in"
     (mt/with-temp [:model/Collection {coll-id :id} {}
                    :model/Dashboard {dash-id :id} {:collection_id coll-id}
                    :model/Card {card-id :id} {}]
       (is (=? {:collection_id coll-id
-               :dashboard_id dash-id}
+               :dashboard_id  dash-id}
               (mt/user-http-request :rasta :put 200 (str "card/" card-id) {:dashboard_id dash-id})))
       (is (=? {:dashboard_id dash-id :card_id card-id}
               (t2/select-one :model/DashboardCard :dashboard_id dash-id :card_id card-id)))))
@@ -3983,9 +3999,8 @@
                    :model/Card {card-id :id} {:dashboard_id source-dash-id}
                    :model/DashboardCard _ {:dashboard_id source-dash-id :card_id card-id}]
       (is (=? {:collection_id dest-coll-id
-               :dashboard_id dest-dash-id}
-              (mt/user-http-request :rasta :put 200 (str "card/" card-id) {:dashboard_id dest-dash-id
-                                                                           :delete_old_dashcards true})))
+               :dashboard_id  dest-dash-id}
+              (mt/user-http-request :rasta :put 200 (str "card/" card-id) {:dashboard_id dest-dash-id})))
       (testing "old dashcards are deleted, a new one is created"
         (is (=? #{dest-dash-id}
                 (set (map :dashboard_id (t2/select :model/DashboardCard :card_id card-id))))))))
@@ -3995,5 +4010,5 @@
                    :model/Dashboard {other-dash-id :id} {}
                    :model/Card {card-id :id} {}
                    :model/DashboardCard _ {:dashboard_id other-dash-id
-                                           :card_id card-id}]
+                                           :card_id      card-id}]
       (mt/user-http-request :rasta :put 400 (str "card/" card-id) {:dashboard_id dash-id}))))

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -3957,12 +3957,34 @@
               (mt/user-http-request :rasta :put 200 (str "card/" card-id) {:collection_id coll-id
                                                                        :dashboard_id nil})))
       (is (= coll-id (t2/select-one-fn :collection_id :model/Card card-id)))))
-  (testing "We can move a question from a collection to a dashboard"
+  (testing "We can move a question from a collection to a dashboard it is already in"
     (mt/with-temp [:model/Collection {coll-id :id} {}
                    :model/Dashboard {dash-id :id} {:collection_id coll-id}
-                   :model/Card {card-id :id} {:collection_id coll-id}
+                   :model/Card {card-id :id} {}
                    :model/DashboardCard _ {:dashboard_id dash-id
                                            :card_id card-id}]
       (is (=? {:collection_id coll-id
                :dashboard_id dash-id}
-              (mt/user-http-request :rasta :put 200 (str "card/" card-id) {:dashboard_id dash-id}))))))
+              (mt/user-http-request :rasta :put 200 (str "card/" card-id) {:dashboard_id dash-id})))))
+  (testing "We can move a question from a collection to a dashboard it is NOT already in"
+    (mt/with-temp [:model/Collection {coll-id :id} {}
+                   :model/Dashboard {dash-id :id} {:collection_id coll-id}
+                   :model/Card {card-id :id} {}]
+      (is (=? {:collection_id coll-id
+               :dashboard_id dash-id}
+              (mt/user-http-request :rasta :put 200 (str "card/" card-id) {:dashboard_id dash-id})))
+      (is (=? {:dashboard_id dash-id :card_id card-id}
+              (t2/select-one :model/DashboardCard :dashboard_id dash-id :card_id card-id)))))
+  (testing "We can move a question from one dashboard to another"
+    (mt/with-temp [:model/Collection {source-coll-id :id} {}
+                   :model/Collection {dest-coll-id :id} {}
+                   :model/Dashboard {source-dash-id :id} {:collection_id source-coll-id}
+                   :model/Dashboard {dest-dash-id :id} {:collection_id dest-coll-id}
+                   :model/Card {card-id :id} {:dashboard_id source-dash-id}
+                   :model/DashboardCard _ {:dashboard_id source-dash-id :card_id card-id}]
+      (is (=? {:collection_id dest-coll-id
+               :dashboard_id dest-dash-id}
+              (mt/user-http-request :rasta :put 200 (str "card/" card-id) {:dashboard_id dest-dash-id})))
+      (testing "old dashcards are deleting, a new one is created"
+        (is (=? #{dest-dash-id}
+                (set (map :dashboard_id (t2/select :model/DashboardCard :card_id card-id)))))))))

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -3900,8 +3900,10 @@
                  :model/Collection {other-coll-id :id} {}
                  :model/Dashboard {dash-id :id} {:collection_id coll-id}]
     (testing "We can create a dashboard internal card"
-      (mt/user-http-request :crowberto :post 200 "card" (assoc (card-with-name-and-query)
-                                                               :dashboard_id dash-id)))
+      (let [card-id (:id (mt/user-http-request :crowberto :post 200 "card" (assoc (card-with-name-and-query)
+                                                                                  :dashboard_id dash-id)))]
+        (testing "We autoplace a dashboard card for the new question"
+          (t2/exists? :model/DashboardCard :dashboard_id dash-id :card_id card-id))))
     (testing "We can't create a dashboard internal card with a collection_id different that its dashboard's"
       (mt/user-http-request :crowberto :post 400 "card" (assoc (card-with-name-and-query)
                                                                :dashboard_id dash-id

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -3987,4 +3987,12 @@
               (mt/user-http-request :rasta :put 200 (str "card/" card-id) {:dashboard_id dest-dash-id})))
       (testing "old dashcards are deleting, a new one is created"
         (is (=? #{dest-dash-id}
-                (set (map :dashboard_id (t2/select :model/DashboardCard :card_id card-id)))))))))
+                (set (map :dashboard_id (t2/select :model/DashboardCard :card_id card-id))))))))
+  (testing "We can't move a question from a collection to a dashboard if it's in another dashboard"
+    (mt/with-temp [:model/Collection {coll-id :id} {}
+                   :model/Dashboard {dash-id :id} {:collection_id coll-id}
+                   :model/Dashboard {other-dash-id :id} {}
+                   :model/Card {card-id :id} {}
+                   :model/DashboardCard _ {:dashboard_id other-dash-id
+                                           :card_id card-id}]
+      (mt/user-http-request :rasta :put 400 (str "card/" card-id) {:dashboard_id dash-id}))))

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -3985,7 +3985,7 @@
       (is (=? {:collection_id dest-coll-id
                :dashboard_id dest-dash-id}
               (mt/user-http-request :rasta :put 200 (str "card/" card-id) {:dashboard_id dest-dash-id})))
-      (testing "old dashcards are deleting, a new one is created"
+      (testing "old dashcards are deleted, a new one is created"
         (is (=? #{dest-dash-id}
                 (set (map :dashboard_id (t2/select :model/DashboardCard :card_id card-id))))))))
   (testing "We can't move a question from a collection to a dashboard if it's in another dashboard"

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -3986,11 +3986,23 @@
   (testing "We can move a question from a collection to a dashboard it is NOT already in"
     (mt/with-temp [:model/Collection {coll-id :id} {}
                    :model/Dashboard {dash-id :id} {:collection_id coll-id}
+                   :model/DashboardCard _ {:dashboard_id dash-id}
                    :model/Card {card-id :id} {}]
       (is (=? {:collection_id coll-id
                :dashboard_id  dash-id}
               (mt/user-http-request :rasta :put 200 (str "card/" card-id) {:dashboard_id dash-id})))
       (is (=? {:dashboard_id dash-id :card_id card-id}
+              (t2/select-one :model/DashboardCard :dashboard_id dash-id :card_id card-id)))))
+  (testing "We can move a question from a collection to a dashboard with tabs"
+    (mt/with-temp [:model/Collection {coll-id :id} {}
+                   :model/Dashboard {dash-id :id} {:collection_id coll-id}
+                   :model/DashboardTab {dash-tab-id :id} {:dashboard_id dash-id}
+                   :model/DashboardCard _ {:dashboard_id dash-id :dashboard_tab_id dash-tab-id}
+                   :model/Card {card-id :id} {}]
+      (is (=? {:collection_id coll-id
+               :dashboard_id  dash-id}
+              (mt/user-http-request :rasta :put 200 (str "card/" card-id) {:dashboard_id dash-id})))
+      (is (=? {:dashboard_id dash-id :card_id card-id :dashboard_tab_id dash-tab-id}
               (t2/select-one :model/DashboardCard :dashboard_id dash-id :card_id card-id)))))
   (testing "We can move a question from one dashboard to another"
     (mt/with-temp [:model/Collection {source-coll-id :id} {}

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -3934,14 +3934,35 @@
     (testing "we can update the name"
       (is (mt/user-http-request :crowberto :put 200 (str "card/" card-id) {:name "foo"}))
       (is (= "foo" (t2/select-one-fn :name :model/Card card-id))))
-    (testing "We can't update with `dashboard_id` for a normal card."
-      ;; we get a 200 because the param is ignored
+    (testing "We can update with `dashboard_id` for a normal card."
       (is (mt/user-http-request :crowberto :put 200 (str "card/" other-card-id) {:dashboard_id dash-id}))
-      (is (not (= dash-id (t2/select-one-fn :dashboard_id :model/Card :id other-card-id)))))
-    (testing "We CAN'T update a DQ with a `dashboard_id`"
+      (is (= dash-id (t2/select-one-fn :dashboard_id :model/Card :id other-card-id))))
+    (testing "We can update a DQ with a `dashboard_id`"
       (is (mt/user-http-request :crowberto :put 200 (str "card/" card-id) {:dashboard_id other-dash-id}))
-      (is (= coll-id (t2/select-one-fn :collection_id :model/Card :id card-id))))
+      (is (nil? (t2/select-one-fn :collection_id :model/Card :id card-id))))
     (testing "We can't update the `collection_id`"
       (is (mt/user-http-request :crowberto :put 400 (str "card/" card-id) {:collection_id other-coll-id})))
     (testing "We can't set the `type`"
       (is (mt/user-http-request :crowberto :put 400 (str "card/" card-id) {:type "model"})))))
+
+(deftest moving-dashboard-questions
+  (testing "We can move a dashboard question to a collection"
+    (mt/with-temp [:model/Collection {coll-id :id} {}
+                   :model/Dashboard {dash-id :id} {:collection_id coll-id}
+                   :model/Card {card-id :id} {:dashboard_id dash-id}
+                   :model/DashboardCard _ {:dashboard_id dash-id
+                                           :card_id card-id}]
+      (is (=? {:collection_id coll-id
+               :dashboard_id nil}
+              (mt/user-http-request :rasta :put 200 (str "card/" card-id) {:collection_id coll-id
+                                                                       :dashboard_id nil})))
+      (is (= coll-id (t2/select-one-fn :collection_id :model/Card card-id)))))
+  (testing "We can move a question from a collection to a dashboard"
+    (mt/with-temp [:model/Collection {coll-id :id} {}
+                   :model/Dashboard {dash-id :id} {:collection_id coll-id}
+                   :model/Card {card-id :id} {:collection_id coll-id}
+                   :model/DashboardCard _ {:dashboard_id dash-id
+                                           :card_id card-id}]
+      (is (=? {:collection_id coll-id
+               :dashboard_id dash-id}
+              (mt/user-http-request :rasta :put 200 (str "card/" card-id) {:dashboard_id dash-id}))))))

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -3969,9 +3969,8 @@
                                            :card_id      card-id}]
       (is (=? {:collection_id coll-id
                :dashboard_id  nil}
-              (mt/user-http-request :rasta :put 200 (str "card/" card-id) {:collection_id coll-id
-                                                                           :dashboard_id  nil
-                                                                           :delete_old_dashcards "true"})))
+              (mt/user-http-request :rasta :put 200 (str "card/" card-id "?delete_old_dashcards=true") {:collection_id coll-id
+                                                                                                        :dashboard_id  nil})))
       (is (= coll-id (t2/select-one-fn :collection_id :model/Card card-id)))
       ;; we remove the card from the dashboard it was in
       (is (not (t2/exists? :model/DashboardCard :dashboard_id dash-id :card_id card-id)))))

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -3955,7 +3955,7 @@
       (is (=? {:collection_id coll-id
                :dashboard_id nil}
               (mt/user-http-request :rasta :put 200 (str "card/" card-id) {:collection_id coll-id
-                                                                       :dashboard_id nil})))
+                                                                           :dashboard_id nil})))
       (is (= coll-id (t2/select-one-fn :collection_id :model/Card card-id)))))
   (testing "We can move a question from a collection to a dashboard it is already in"
     (mt/with-temp [:model/Collection {coll-id :id} {}

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -3984,7 +3984,8 @@
                    :model/DashboardCard _ {:dashboard_id source-dash-id :card_id card-id}]
       (is (=? {:collection_id dest-coll-id
                :dashboard_id dest-dash-id}
-              (mt/user-http-request :rasta :put 200 (str "card/" card-id) {:dashboard_id dest-dash-id})))
+              (mt/user-http-request :rasta :put 200 (str "card/" card-id) {:dashboard_id dest-dash-id
+                                                                           :delete_old_dashcards true})))
       (testing "old dashcards are deleted, a new one is created"
         (is (=? #{dest-dash-id}
                 (set (map :dashboard_id (t2/select :model/DashboardCard :card_id card-id))))))))

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -4929,10 +4929,24 @@
                    :model/Card {card-id :id} {:dashboard_id dash-id}]
       (mt/user-http-request :crowberto :put 200 (str "dashboard/" dash-id) {:archived "true"})
       (is (t2/select-one-fn :archived :model/Card card-id))))
+  (testing "It gets unarchived with the dashboard"
+    (mt/with-temp [:model/Dashboard {dash-id :id} {}
+                   :model/Card {card-id :id} {:dashboard_id dash-id}]
+      (mt/user-http-request :crowberto :put 200 (str "dashboard/" dash-id) {:archived "true"})
+      (mt/user-http-request :crowberto :put 200 (str "dashboard/" dash-id) {:archived "false"})
+      (is (not (t2/select-one-fn :archived :model/Card card-id)))))
   (testing "It gets archived with the dashboard if the dashboard is archived from a collection"
     (mt/with-temp [:model/Collection {coll-id :id} {}
                    :model/Dashboard {dash-id :id} {:collection_id coll-id}
                    :model/Card {card-id :id} {:dashboard_id dash-id}]
       (mt/user-http-request :crowberto :put 200 (str "collection/" coll-id) {:archived "true"})
       (is (t2/select-one-fn :archived :model/Dashboard dash-id))
-      (is (t2/select-one-fn :archived :model/Card card-id)))))
+      (is (t2/select-one-fn :archived :model/Card card-id))))
+  (testing "It gets unarchived with the dashboard if the dashboard is unarchived from a collection"
+    (mt/with-temp [:model/Collection {coll-id :id} {}
+                   :model/Dashboard {dash-id :id} {:collection_id coll-id}
+                   :model/Card {card-id :id} {:dashboard_id dash-id}]
+      (mt/user-http-request :crowberto :put 200 (str "collection/" coll-id) {:archived true})
+      (mt/user-http-request :crowberto :put 200 (str "collection/" coll-id) {:archived false})
+      (is (not (t2/select-one-fn :archived :model/Dashboard dash-id)))
+      (is (not (t2/select-one-fn :archived :model/Card card-id))))))

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -4950,3 +4950,22 @@
       (mt/user-http-request :crowberto :put 200 (str "collection/" coll-id) {:archived false})
       (is (not (t2/select-one-fn :archived :model/Dashboard dash-id)))
       (is (not (t2/select-one-fn :archived :model/Card card-id))))))
+
+(deftest dashboard-questions-are-archived-when-unused-and-vice-versa
+  (testing "The dashboard question is archived when it's removed from the dashboard"
+    (mt/with-temp [:model/Dashboard {dash-id :id} {}
+                   :model/Card {card-id :id} {:dashboard_id dash-id}
+                   :model/DashboardCard _ {:card_id card-id :dashboard_id dash-id}]
+      (mt/user-http-request :rasta :put 200 (str "dashboard/" dash-id) {:dashcards []})
+      (is (not (t2/exists? :model/DashboardCard :card_id card-id :dashboard_id dash-id)))
+      (is (t2/select-one-fn :archived :model/Card card-id))))
+  (testing "The dashboard question is unarchived when it's re-added to the dashboard"
+    (mt/with-temp [:model/Dashboard {dash-id :id} {}
+                   :model/Card {card-id :id} {:dashboard_id dash-id}]
+      (is (mt/user-http-request :rasta :put 200 (str "dashboard/" dash-id) {:dashcards [{:card_id card-id
+                                                                                               :id -1
+                                                                                               :size_x 10
+                                                                                               :size_y 10
+                                                                                               :col 0 :row 0}]}))
+      (is (t2/exists? :model/DashboardCard :card_id card-id :dashboard_id dash-id))
+      (is (not (t2/select-one-fn :archived :model/Card card-id))))))

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -5008,14 +5008,14 @@
 
 (defn- update-dashcards! [dash-id card-ids]
   (mt/user-http-request :rasta :put 200 (str "dashboard/" dash-id)
-                           {:dashcards (map-indexed (fn [idx card-id]
-                                                      {:id (- (inc idx))
-                                                       :card_id card-id
-                                                       :col 0
-                                                       :row idx
-                                                       :size_x 10
-                                                       :size_y 10})
-                                                    card-ids)}))
+                        {:dashcards (map-indexed (fn [idx card-id]
+                                                   {:id (- (inc idx))
+                                                    :card_id card-id
+                                                    :col 0
+                                                    :row idx
+                                                    :size_x 10
+                                                    :size_y 10})
+                                                 card-ids)}))
 
 (deftest revert-dashboard-behaves-for-dashboard-questions
   (testing "POST /api/dashboard/:id/revert"

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -4963,9 +4963,9 @@
     (mt/with-temp [:model/Dashboard {dash-id :id} {}
                    :model/Card {card-id :id} {:dashboard_id dash-id}]
       (is (mt/user-http-request :rasta :put 200 (str "dashboard/" dash-id) {:dashcards [{:card_id card-id
-                                                                                               :id -1
-                                                                                               :size_x 10
-                                                                                               :size_y 10
-                                                                                               :col 0 :row 0}]}))
+                                                                                         :id -1
+                                                                                         :size_x 10
+                                                                                         :size_y 10
+                                                                                         :col 0 :row 0}]}))
       (is (t2/exists? :model/DashboardCard :card_id card-id :dashboard_id dash-id))
       (is (not (t2/select-one-fn :archived :model/Card card-id))))))

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -4998,3 +4998,46 @@
              (update (mt/user-http-request :rasta :get 200 (str "dashboard/" dash-id "/items"))
                      :data
                      #(map (fn [card] (select-keys card [:id])) %)))))))
+
+(defn- get-revisions-http-req [dash-id]
+  (mt/user-http-request :rasta :get 200 (str "dashboard/" dash-id "/revisions")))
+
+(defn- post-revert-http-req [dash-id rev-id]
+  (mt/user-http-request :rasta :post 200 (str "dashboard/" dash-id "/revert")
+                        {:revision_id rev-id}))
+
+(defn- update-dashcards! [dash-id card-ids]
+  (mt/user-http-request :rasta :put 200 (str "dashboard/" dash-id)
+                           {:dashcards (map-indexed (fn [idx card-id]
+                                                      {:id (- (inc idx))
+                                                       :card_id card-id
+                                                       :col 0
+                                                       :row idx
+                                                       :size_x 10
+                                                       :size_y 10})
+                                                    card-ids)}))
+
+(deftest revert-dashboard-behaves-for-dashboard-questions
+  (testing "POST /api/dashboard/:id/revert"
+    (testing "My DQ is moved to another Dashboard"
+      (mt/with-temp [:model/Dashboard {dash-id :id} {}
+                     :model/Dashboard {other-dash-id :id} {}
+                     :model/Card {dq-id :id} {:dashboard_id dash-id}
+                     :model/Card {card-id :id} {}]
+        (update-dashcards! dash-id [card-id dq-id])
+        (update-dashcards! dash-id [])
+        (t2/update! :model/Card dq-id {:dashboard_id other-dash-id})
+        (post-revert-http-req dash-id (:id (second (get-revisions-http-req dash-id))))
+        (is (= #{card-id} (t2/select-fn-set :card_id :model/DashboardCard :dashboard_id dash-id)))
+        (is (= 1 (t2/count :model/DashboardCard :dashboard_id dash-id)))))
+    (testing "A regular card is moved to another Dashboard"
+      (mt/with-temp [:model/Dashboard {dash-id :id} {}
+                     :model/Dashboard {other-dash-id :id} {}
+                     :model/Card {dq-id :id} {:dashboard_id dash-id}
+                     :model/Card {card-id :id} {}]
+        (update-dashcards! dash-id [card-id dq-id])
+        (update-dashcards! dash-id [])
+        (t2/update! :model/Card card-id {:dashboard_id other-dash-id})
+        (post-revert-http-req dash-id (:id (second (get-revisions-http-req dash-id))))
+        (is (= 1 (t2/count :model/DashboardCard :dashboard_id dash-id)))
+        (is (= #{dq-id} (t2/select-fn-set :card_id :model/DashboardCard :dashboard_id dash-id)))))))

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -4969,3 +4969,32 @@
                                                                                          :col 0 :row 0}]}))
       (is (t2/exists? :model/DashboardCard :card_id card-id :dashboard_id dash-id))
       (is (not (t2/select-one-fn :archived :model/Card card-id))))))
+
+(deftest dashboard-items-works
+  (testing "Dashboard items is empty when the dashboard is a normal dashboard w/o DQs"
+    (mt/with-temp [:model/Dashboard {dash-id :id} {}
+                   :model/Card {card-id :id} {}
+                   :model/DashboardCard _ {:card_id card-id :dashboard_id dash-id}]
+      (is (= {:total 0 :data [] :models []}
+             (mt/user-http-request :rasta :get 200 (str "dashboard/" dash-id "/items"))))))
+  (testing "Dashboard items is present when the dashboard has DQs"
+    (mt/with-temp [:model/Dashboard {dash-id :id} {}
+                   :model/Card {card-id :id} {:dashboard_id dash-id}
+                   :model/DashboardCard _ {:card_id card-id :dashboard_id dash-id}]
+      (is (= {:total 1
+              :data [{:id card-id}]
+              :models ["card"]}
+             (update (mt/user-http-request :rasta :get 200 (str "dashboard/" dash-id "/items"))
+                     :data
+                     #(map (fn [card] (select-keys card [:id])) %))))))
+  (testing "DQs don't appear twice even if they appear multiple times in the dashboard"
+    (mt/with-temp [:model/Dashboard {dash-id :id} {}
+                   :model/Card {card-id :id} {:dashboard_id dash-id}
+                   :model/DashboardCard _ {:card_id card-id :dashboard_id dash-id}
+                   :model/DashboardCard _ {:card_id card-id :dashboard_id dash-id}]
+      (is (= {:total 1
+              :data [{:id card-id}]
+              :models ["card"]}
+             (update (mt/user-http-request :rasta :get 200 (str "dashboard/" dash-id "/items"))
+                     :data
+                     #(map (fn [card] (select-keys card [:id])) %)))))))

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -1084,19 +1084,25 @@
   (mt/with-temp [:model/Collection {coll-id :id} {}
                  :model/Collection {other-coll-id :id} {}
                  :model/Dashboard {dash-id :id} {:collection_id coll-id}
-                 :model/Card {card-id :id} {:dashboard_id dash-id}]
+                 :model/Card card {:dashboard_id dash-id}]
     (testing "Can't update the collection_id"
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid dashboard-internal card"
-                            (t2/update! :model/Card card-id {:collection_id other-coll-id}))))
+                            (card/update-card! {:card-before-update card
+                                                :card-updates {:collection_id other-coll-id}}))))
     (testing "CAN 'update' the collection_id"
-      (is (t2/update! :model/Card card-id {:collection_id coll-id})))
+      (is (card/update-card! {:card-before-update card
+                              :card-updates {:collection_id coll-id}})))
     (testing "Can't update the collection_position"
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid dashboard-internal card"
-                            (t2/update! :model/Card card-id {:collection_position 5}))))
+                            (card/update-card! {:card-before-update card
+                                                :card-updates {:collection_position 5}}))))
     (testing "CAN 'update' the collection_position"
-      (is (t2/update! :model/Card card-id {:collection_position nil})))
+      (is (card/update-card! {:card-before-update card
+                              :card-updates {:collection_position nil}})))
     (testing "Can't update the type"
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid dashboard-internal card"
-                            (t2/update! :model/Card card-id {:type :model}))))
+                            (card/update-card! {:card-before-update card
+                                                :card-updates {:type :model}}))))
     (testing "CAN 'update' the type"
-      (is (t2/update! :model/Card card-id {:type :question})))))
+      (is (card/update-card! {:card-before-update card
+                              :card-updates {:type :question}})))))

--- a/test/metabase/models/recent_views_test.clj
+++ b/test/metabase/models/recent_views_test.clj
@@ -38,6 +38,7 @@
      :model/Card       {card-id :id} {:type "question" :name "name" :display "display" :collection_id coll-id :database_id db-id}]
     (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Card card-id :view)
     (is (= [{:description nil,
+             :dashboard nil
              :can_write true,
              :name "name",
              :parent_collection {:id coll-id, :name "my coll", :authority_level nil}
@@ -252,6 +253,7 @@
                    :parent_collection {:id "ID", :name "parent", :authority_level nil}
                    :database_id db-id}
                   {:description "this is my card",
+                   :dashboard nil
                    :can_write true,
                    :name "my card",
                    :parent_collection {:id "ID", :name "parent", :authority_level nil},

--- a/test/metabase/util/autoplace_test.clj
+++ b/test/metabase/util/autoplace_test.clj
@@ -10,7 +10,7 @@
   (autoplace/get-position-for-new-dashcard cards test-card-width test-card-height test-grid-width))
 
 (defn- pos [m]
-  (merge {:x_size 2 :y_size 2 :dashboard_tab_id nil} m))
+  (merge {:size_x 2 :size_y 2 :dashboard_tab_id nil} m))
 
 (deftest get-position-for-new-dashcard-works
   (testing "place first card at 0,0"
@@ -37,11 +37,11 @@
                           (pos {:col 4 :row 0})]))))
   (testing "place card correctly with non-default sizes"
     (is (= (pos {:col 3 :row 2})
-           (get-position [(pos {:col 1 :row 0 :x_size 2 :y_size 4})
+           (get-position [(pos {:col 1 :row 0 :size_x 2 :size_y 4})
                           (pos {:col 4 :row 0})])))
     (is (= (pos {:col 0 :row 1})
-           (get-position [(pos {:col 0 :row 0 :x_size 3 :y_size 1})
-                          (pos {:col 4 :row 0 :x_size 2 :y_size 1})]))))
+           (get-position [(pos {:col 0 :row 0 :size_x 3 :size_y 1})
+                          (pos {:col 4 :row 0 :size_x 2 :size_y 1})]))))
   (testing "should not place card over the right edge of the grid"
     (is (= (pos {:col 0 :row 1})
-           (get-position [(pos {:col 0 :row 0 :x_size 5 :y_size 1})])))))
+           (get-position [(pos {:col 0 :row 0 :size_x 5 :size_y 1})])))))

--- a/test/metabase/util/autoplace_test.clj
+++ b/test/metabase/util/autoplace_test.clj
@@ -1,0 +1,47 @@
+(ns metabase.util.autoplace-test
+  (:require [clojure.test :refer :all]
+            [metabase.util.autoplace :as autoplace]))
+
+(def ^:private test-grid-width 6)
+(def ^:private test-card-width 2)
+(def ^:private test-card-height 2)
+
+(defn- get-position [cards]
+  (autoplace/get-position-for-new-dashcard cards test-card-width test-card-height test-grid-width))
+
+(defn- pos [m]
+  (merge {:x_size 2 :y_size 2 :dashboard_tab_id nil} m))
+
+(deftest get-position-for-new-dashcard-works
+  (testing "place first card at 0,0"
+    (is (= (pos {:col 0 :row 0})
+           (get-position []))))
+  (testing "place card at correct locations on the first row"
+    (is (= (pos {:col 2 :row 0})
+           (get-position [(pos {:col 0 :row 0})])))
+    (is (= (pos {:col 3 :row 0})
+           (get-position [(pos {:col 1 :row 0})])))
+    (is (= (pos {:col 4 :row 0})
+           (get-position [(pos {:col 0 :row 0})
+                          (pos {:col 2 :row 0})])))
+    (is (= (pos {:col 2 :row 0})
+           (get-position [(pos {:col 0 :row 0})
+                          (pos {:col 4 :row 0})]))))
+  (testing "place card at correct locations on the second row"
+    (is (= (pos {:col 0 :row 2})
+           (get-position [(pos {:col 0 :row 0})
+                          (pos {:col 2 :row 0})
+                          (pos {:col 4 :row 0})])))
+    (is (= (pos {:col 0 :row 2})
+           (get-position [(pos {:col 1 :row 0})
+                          (pos {:col 4 :row 0})]))))
+  (testing "place card correctly with non-default sizes"
+    (is (= (pos {:col 3 :row 2})
+           (get-position [(pos {:col 1 :row 0 :x_size 2 :y_size 4})
+                          (pos {:col 4 :row 0})])))
+    (is (= (pos {:col 0 :row 1})
+           (get-position [(pos {:col 0 :row 0 :x_size 3 :y_size 1})
+                          (pos {:col 4 :row 0 :x_size 2 :y_size 1})]))))
+  (testing "should not place card over the right edge of the grid"
+    (is (= (pos {:col 0 :row 1})
+           (get-position [(pos {:col 0 :row 0 :x_size 5 :y_size 1})])))))


### PR DESCRIPTION
Cards in Dashboards Milestone 2:

- dashboard items, similar to collection items... but for dashboards!
- add `here` for dashboards on collection items, just like we provide for collections
- provide `location` for dashboards in collection items, just like we provide for collections
- when archiving a dashboard, we archive its dashboard questions - this contains a fix for that behavior. Normally we filter `archived` questions out of the list of dashboard `dashcards`. For Dashboard Questions, we don't want to do that - an archived dashboard should still "contain" its archived DQs.
- move dashboard questions!
  - to a new Dashboard
  - to a Collection
- move regular questions to Dashboards
- autoplace Dashboard Questions when they are moved (but not when they are created). This inconsistency is because we like the flow on create (you create the DQ, then place it - if you stop halfway through, the DQ is archived, which is a consistent state since you didn't "finish" creating it) but for moves, we definitely don't want the DQ to "disappear" if you don't complete the move including placement.
- archive DQs when they have no Dashcards, unarchive DQs when a Dashcard is recreated