### PR TITLE
[MS2] Better Onboarding UX: Expanded CSV upload permissions

### DIFF
--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.unit.spec.tsx
@@ -464,19 +464,6 @@ describe("nav > containers > MainNavbar", () => {
   });
 
   describe("better onboarding section", () => {
-    it.each([
-      { role: "admins", is_superuser: true },
-      { role: "regular users", is_superuser: false },
-    ])(
-      "should render Metabase learn link to $role",
-      async ({ is_superuser }) => {
-        await setup({ user: createMockUser({ is_superuser }) });
-        const link = screen.getByRole("link", { name: /How to use Metabase/i });
-        expect(link).toBeInTheDocument();
-        expect(link).toHaveAttribute("href", "https://www.metabase.com/learn/");
-      },
-    );
-
     describe("add data section", () => {
       it("should render for admins", async () => {
         await setup({

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.unit.spec.tsx
@@ -33,6 +33,7 @@ import type { DashboardState } from "metabase-types/store";
 import {
   createMockDashboardState,
   createMockQueryBuilderState,
+  createMockSettingsState,
   createMockState,
 } from "metabase-types/store/mocks";
 
@@ -43,10 +44,12 @@ type SetupOpts = {
   route?: string;
   user?: User | null;
   hasDataAccess?: boolean;
-  hasOwnDatabase?: boolean;
+  withAdditionalDatabase?: boolean;
+  isUploadEnabled?: boolean;
   openQuestionCard?: Card;
   openDashboard?: Dashboard;
   models?: ModelResult[];
+  canCurateRootCollection?: boolean;
 };
 
 const PERSONAL_COLLECTION_BASE = createMockCollection({
@@ -60,38 +63,46 @@ const TEST_COLLECTION = createMockCollection({
   name: "Test collection",
 });
 
-const SAMPLE_DATABASE = createMockDatabase({
-  id: 1,
-  name: "Sample Database",
-  is_sample: true,
-});
-
-const USER_DATABASE = createMockDatabase({
-  id: 2,
-  name: "User Database",
-  is_sample: false,
-});
-
 async function setup({
   pathname = "/",
   route = pathname,
   user = createMockUser(),
   hasDataAccess = true,
-  hasOwnDatabase = true,
   openDashboard,
   openQuestionCard,
   models = [],
+  isUploadEnabled = false,
+  withAdditionalDatabase = true,
+  canCurateRootCollection = false,
 }: SetupOpts = {}) {
+  const SAMPLE_DATABASE = createMockDatabase({
+    id: 1,
+    name: "Sample Database",
+    is_sample: true,
+    can_upload: user?.is_superuser || (isUploadEnabled && hasDataAccess),
+  });
+
+  const USER_DATABASE = createMockDatabase({
+    id: 2,
+    name: "User Database",
+    is_sample: false,
+  });
+
   const databases = [];
-  const collections = [TEST_COLLECTION];
 
   if (hasDataAccess) {
     databases.push(SAMPLE_DATABASE);
 
-    if (hasOwnDatabase) {
+    if (withAdditionalDatabase) {
       databases.push(USER_DATABASE);
     }
   }
+  const OUR_ANALYTICS = createMockCollection({
+    ...ROOT_COLLECTION,
+    can_write: user?.is_superuser || canCurateRootCollection,
+  });
+
+  const collections = [TEST_COLLECTION];
 
   const personalCollection = user
     ? createMockCollection({
@@ -105,14 +116,17 @@ async function setup({
     collections.push(personalCollection);
   }
 
-  setupCollectionsEndpoints({ collections });
+  setupCollectionsEndpoints({
+    collections,
+    rootCollection: OUR_ANALYTICS,
+  });
   setupCollectionByIdEndpoint({
     collections: [PERSONAL_COLLECTION_BASE, TEST_COLLECTION],
   });
   setupDatabasesEndpoints(databases);
   setupSearchEndpoints(models);
   setupCollectionItemsEndpoint({
-    collection: createMockCollection(ROOT_COLLECTION),
+    collection: createMockCollection(OUR_ANALYTICS),
     collectionItems: [],
   });
   fetchMock.get("path:/api/bookmark", []);
@@ -141,6 +155,13 @@ async function setup({
     }),
     qb: createMockQueryBuilderState({ card: openQuestionCard }),
     entities: createMockEntitiesState({ dashboards: dashboardsForEntities }),
+    settings: createMockSettingsState({
+      "uploads-settings": {
+        db_id: isUploadEnabled ? SAMPLE_DATABASE.id : null,
+        schema_name: null,
+        table_prefix: null,
+      },
+    }),
   });
 
   renderWithProviders(
@@ -443,67 +464,107 @@ describe("nav > containers > MainNavbar", () => {
   });
 
   describe("better onboarding section", () => {
-    it("should render Metabase learn link to admins", async () => {
-      await setup({ user: createMockUser({ is_superuser: true }) });
-      const link = screen.getByRole("link", { name: /How to use Metabase/i });
-      expect(link).toBeInTheDocument();
-      expect(link).toHaveAttribute("href", "https://www.metabase.com/learn/");
-    });
+    it.each([
+      { role: "admins", is_superuser: true },
+      { role: "regular users", is_superuser: false },
+    ])(
+      "should render Metabase learn link to $role",
+      async ({ is_superuser }) => {
+        await setup({ user: createMockUser({ is_superuser }) });
+        const link = screen.getByRole("link", { name: /How to use Metabase/i });
+        expect(link).toBeInTheDocument();
+        expect(link).toHaveAttribute("href", "https://www.metabase.com/learn/");
+      },
+    );
 
-    it("should render Metabase learn link to regular users", async () => {
-      await setup({ user: createMockUser({ is_superuser: false }) });
-      const link = screen.getByRole("link", { name: /How to use Metabase/i });
-      expect(link).toBeInTheDocument();
-      expect(link).toHaveAttribute("href", "https://www.metabase.com/learn/");
-    });
+    describe("add data section", () => {
+      it("should render for admins", async () => {
+        await setup({
+          withAdditionalDatabase: false,
+          user: createMockUser({ is_superuser: true }),
+        });
 
-    it("data section should not render to non-admins", async () => {
-      await setup({ user: createMockUser({ is_superuser: false }) });
+        const dataSection = screen.getByTestId("sidebar-add-data-section");
+        expect(dataSection).toBeInTheDocument();
 
-      const introCTA = screen.queryByText(
-        "Start by adding your data. Connect to a database or upload a CSV file.",
-      );
-      const addDataButton = screen.queryByRole("button", { name: /Add data/i });
+        const introCTA = screen.getByText(
+          "Start by adding your data. Connect to a database or upload a CSV file.",
+        );
+        expect(introCTA).toBeInTheDocument();
 
-      expect(introCTA).not.toBeInTheDocument();
-      expect(addDataButton).not.toBeInTheDocument();
-    });
+        const addDataButton = screen.getByRole("button", { name: /Add data/i });
+        expect(addDataButton).toBeInTheDocument();
+        await userEvent.click(addDataButton);
 
-    it("intro CTA should not render when there are databases connected", async () => {
-      await setup({
-        hasOwnDatabase: true,
-        user: createMockUser({ is_superuser: true }),
+        const menu = screen.getByRole("menu");
+        const menuItems = screen.getAllByRole("menuitem");
+
+        expect(menuItems).toHaveLength(2);
+        expect(within(menu).getAllByRole("link")).toHaveLength(1);
       });
 
-      const introCTA = screen.queryByText(
-        "Start by adding your data. Connect to a database or upload a CSV file.",
-      );
-      expect(introCTA).not.toBeInTheDocument();
-    });
+      it("intro CTA should not render when there are databases connected", async () => {
+        await setup({
+          withAdditionalDatabase: true,
+          user: createMockUser({ is_superuser: true }),
+        });
 
-    it("data section should render for admins", async () => {
-      await setup({
-        hasOwnDatabase: false,
-        user: createMockUser({ is_superuser: true }),
+        const introCTA = screen.queryByText(
+          "Start by adding your data. Connect to a database or upload a CSV file.",
+        );
+        expect(introCTA).not.toBeInTheDocument();
       });
 
-      const introCTA = screen.getByText(
-        "Start by adding your data. Connect to a database or upload a CSV file.",
-      );
-      const addDataButton = screen.getByRole("button", { name: /Add data/i });
+      it("should render for regular users with 'curate' root collection permissions if uploads are disabled, but they have general data access", async () => {
+        await setup({
+          user: createMockUser({ is_superuser: false }),
+          canCurateRootCollection: true,
+          hasDataAccess: true,
+          isUploadEnabled: false,
+        });
 
-      expect(introCTA).toBeInTheDocument();
-      expect(addDataButton).toBeInTheDocument();
-      await userEvent.click(addDataButton);
+        const dataSection = screen.getByTestId("sidebar-add-data-section");
+        expect(dataSection).toBeInTheDocument();
+      });
 
-      const menu = screen.getByRole("menu");
-      const menuItems = screen.getAllByRole("menuitem");
+      it("should render for regular users with 'curate' root collection permissions if uploads are enabled for a database and they can upload to that database", async () => {
+        await setup({
+          user: createMockUser({ is_superuser: false }),
+          canCurateRootCollection: true,
+          hasDataAccess: true,
+          isUploadEnabled: true,
+        });
 
-      expect(menuItems).toHaveLength(2);
-      expect(within(menu).getAllByRole("link")).toHaveLength(1);
+        const dataSection = screen.getByTestId("sidebar-add-data-section");
+        expect(dataSection).toBeInTheDocument();
+      });
+
+      it("should not render for regular users if they cannot 'curate' the root collection", async () => {
+        await setup({
+          user: createMockUser({ is_superuser: false }),
+          canCurateRootCollection: false,
+          hasDataAccess: true,
+          isUploadEnabled: true,
+        });
+
+        const dataSection = screen.queryByTestId("sidebar-add-data-section");
+        expect(dataSection).not.toBeInTheDocument();
+      });
+
+      it("should not render for regular users if they don't have data access", async () => {
+        await setup({
+          user: createMockUser({ is_superuser: false }),
+          canCurateRootCollection: true,
+          hasDataAccess: false,
+          isUploadEnabled: true,
+        });
+
+        const dataSection = screen.queryByTestId("sidebar-add-data-section");
+        expect(dataSection).not.toBeInTheDocument();
+      });
     });
 
-    describe("'Add a database' menu option", () => {
+    describe("'Add a database' menu item", () => {
       it("should be wrapped in a link", async () => {
         await setup({
           user: createMockUser({ is_superuser: true }),
@@ -522,7 +583,7 @@ describe("nav > containers > MainNavbar", () => {
         );
       });
 
-      it("should render", async () => {
+      it("should render properly for admins", async () => {
         await setup({
           user: createMockUser({ is_superuser: true }),
         });
@@ -544,10 +605,29 @@ describe("nav > containers > MainNavbar", () => {
           within(addDatabaseMenuItem).getByLabelText("database icon"),
         ).toBeInTheDocument();
       });
+
+      it("should not render for regular users", async () => {
+        await setup({
+          user: createMockUser({ is_superuser: false }),
+          canCurateRootCollection: true,
+          hasDataAccess: true,
+          isUploadEnabled: true,
+        });
+
+        const addDataButton = screen.getByRole("button", { name: /Add data/i });
+        await userEvent.click(addDataButton);
+
+        const menuItems = screen.queryAllByRole("menuitem");
+        const [menuItem] = menuItems;
+        expect(menuItems).toHaveLength(1);
+        expect(
+          within(menuItem).queryByText("Add a database"),
+        ).not.toBeInTheDocument();
+      });
     });
 
-    describe("'Upload a spreadsheet' menu option", () => {
-      it("should render", async () => {
+    describe("'Upload a spreadsheet' menu item", () => {
+      it("should render properly for admins", async () => {
         await setup({
           user: createMockUser({ is_superuser: true }),
         });
@@ -567,9 +647,33 @@ describe("nav > containers > MainNavbar", () => {
         ).toBeInTheDocument();
       });
 
-      it("clicking on it should open a CSV info modal", async () => {
+      it("should render properly for regular users", async () => {
+        await setup({
+          user: createMockUser({ is_superuser: false }),
+          canCurateRootCollection: true,
+          hasDataAccess: true,
+          isUploadEnabled: true,
+        });
+
+        const addDataButton = screen.getByRole("button", { name: /Add data/i });
+        await userEvent.click(addDataButton);
+        const [uploadCSVMenuItem] = screen.getAllByRole("menuitem");
+
+        expect(
+          within(uploadCSVMenuItem).getByText("Upload a spreadsheet"),
+        ).toBeInTheDocument();
+        expect(
+          within(uploadCSVMenuItem).getByText(".csv, .tsv (50 MB max)"),
+        ).toBeInTheDocument();
+        expect(
+          within(uploadCSVMenuItem).getByLabelText("table2 icon"),
+        ).toBeInTheDocument();
+      });
+
+      it("clicking on it should show a CSV info modal for an admin, if uploads are disabled", async () => {
         await setup({
           user: createMockUser({ is_superuser: true }),
+          isUploadEnabled: false,
         });
 
         const addDataButton = screen.getByRole("button", { name: /Add data/i });
@@ -580,7 +684,92 @@ describe("nav > containers > MainNavbar", () => {
 
         await userEvent.click(uploadCSVMenuItem);
         expect(menu).not.toBeInTheDocument();
-        expect(screen.getByText("Upload CSVs to Metabase")).toBeInTheDocument();
+
+        const modal = screen.getByRole("dialog");
+        expect(modal).toBeInTheDocument();
+        [
+          "Upload CSVs to Metabase",
+          "Team members will be able to upload CSV files and work with them just like any other data source.",
+          "You'll be able to pick the default database where the data should be stored when enabling the feature.",
+          "Go to setup",
+        ].forEach(copy => {
+          expect(within(modal).getByText(copy)).toBeInTheDocument();
+        });
+
+        expect(within(modal).getByRole("link")).toHaveAttribute(
+          "href",
+          "/admin/settings/uploads",
+        );
+      });
+
+      it("clicking on it should show a CSV info modal for a regular user, if uploads are disabled", async () => {
+        await setup({
+          user: createMockUser({ is_superuser: false }),
+          canCurateRootCollection: true,
+          hasDataAccess: true,
+          isUploadEnabled: false,
+        });
+
+        const addDataButton = screen.getByRole("button", { name: /Add data/i });
+        await userEvent.click(addDataButton);
+
+        const menu = screen.getByRole("menu");
+        const [uploadCSVMenuItem] = screen.getAllByRole("menuitem");
+
+        await userEvent.click(uploadCSVMenuItem);
+        expect(menu).not.toBeInTheDocument();
+
+        const modal = screen.getByRole("dialog");
+        expect(modal).toBeInTheDocument();
+        [
+          "Upload CSVs to Metabase",
+          "You'll need to ask your admin to enable this feature to get started. Then, you'll be able to upload CSV files and work with them just like any other data source.",
+          "Got it",
+        ].forEach(copy => {
+          expect(within(modal).getByText(copy)).toBeInTheDocument();
+        });
+
+        expect(within(modal).queryByRole("link")).not.toBeInTheDocument();
+      });
+
+      it("clicking on it should not show a CSV info modal for an admin, if uploads are enabled", async () => {
+        await setup({
+          user: createMockUser({ is_superuser: true }),
+          isUploadEnabled: true,
+        });
+
+        const addDataButton = screen.getByRole("button", { name: /Add data/i });
+        await userEvent.click(addDataButton);
+
+        const menu = screen.getByRole("menu");
+        const [_, uploadCSVMenuItem] = screen.getAllByRole("menuitem");
+
+        await userEvent.click(uploadCSVMenuItem);
+        expect(menu).not.toBeInTheDocument();
+
+        const modal = screen.queryByRole("dialog");
+        expect(modal).not.toBeInTheDocument();
+      });
+
+      it("clicking on it should not show a CSV info modal for a regular user, if uploads are enabled", async () => {
+        await setup({
+          user: createMockUser({ is_superuser: false }),
+          canCurateRootCollection: true,
+          hasDataAccess: true,
+          isUploadEnabled: true,
+        });
+
+        const addDataButton = screen.getByRole("button", { name: /Add data/i });
+        await userEvent.click(addDataButton);
+
+        const menu = screen.getByRole("menu");
+        const [uploadCSVMenuItem] = screen.getAllByRole("menuitem");
+
+        await userEvent.click(uploadCSVMenuItem);
+        expect(menu).not.toBeInTheDocument();
+
+        const modal = screen.queryByRole("dialog");
+        expect(modal).not.toBeInTheDocument();
       });
     });
   });

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarContainer.tsx
@@ -55,6 +55,7 @@ const mapDispatchToProps = {
 interface Props extends MainNavbarProps {
   isAdmin: boolean;
   currentUser: User;
+  databases: Database[];
   selectedItems: SelectedItem[];
   bookmarks: Bookmark[];
   rootCollection: Collection;

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarContainer.tsx
@@ -23,7 +23,7 @@ import Collections, {
 } from "metabase/entities/collections";
 import Databases from "metabase/entities/databases";
 import * as Urls from "metabase/lib/urls";
-import { getHasDataAccess, getHasOwnDatabase } from "metabase/selectors/data";
+import { getHasDataAccess } from "metabase/selectors/data";
 import { getUser, getUserIsAdmin } from "metabase/selectors/user";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type { Bookmark, Collection, User } from "metabase-types/api";
@@ -42,7 +42,6 @@ function mapStateToProps(state: State, { databases = [] }: DatabaseProps) {
     currentUser: getUser(state),
     isAdmin: getUserIsAdmin(state),
     hasDataAccess: getHasDataAccess(databases),
-    hasOwnDatabase: getHasOwnDatabase(databases),
     bookmarks: getOrderedBookmarks(state),
   };
 }
@@ -60,7 +59,6 @@ interface Props extends MainNavbarProps {
   bookmarks: Bookmark[];
   rootCollection: Collection;
   hasDataAccess: boolean;
-  hasOwnDatabase: boolean;
   allError: boolean;
   allFetched: boolean;
   logout: () => void;
@@ -78,7 +76,6 @@ function MainNavbarContainer({
   selectedItems,
   isOpen,
   currentUser,
-  hasOwnDatabase,
   rootCollection,
   hasDataAccess,
   location,
@@ -192,7 +189,6 @@ function MainNavbarContainer({
         isOpen={isOpen}
         currentUser={currentUser}
         collections={collectionTree}
-        hasOwnDatabase={hasOwnDatabase}
         selectedItems={selectedItems}
         hasDataAccess={hasDataAccess}
         reorderBookmarks={reorderBookmarks}

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
@@ -183,6 +183,7 @@ export function MainNavbarView({
         </div>
         <WhatsNewNotification />
         <SidebarOnboardingSection
+          collections={collections}
           hasOwnDatabase={hasOwnDatabase}
           isAdmin={isAdmin}
         />

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
@@ -186,6 +186,7 @@ export function MainNavbarView({
         <SidebarOnboardingSection
           collections={collections}
           databases={databases}
+          hasDataAccess={hasDataAccess}
           isAdmin={isAdmin}
         />
       </SidebarContentRoot>

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
@@ -47,7 +47,6 @@ type Props = {
   currentUser: User;
   bookmarks: Bookmark[];
   hasDataAccess: boolean;
-  hasOwnDatabase: boolean;
   collections: CollectionTreeItem[];
   databases: Database[];
   selectedItems: SelectedItem[];
@@ -70,7 +69,6 @@ export function MainNavbarView({
   bookmarks,
   collections,
   databases,
-  hasOwnDatabase,
   selectedItems,
   hasDataAccess,
   reorderBookmarks,
@@ -188,7 +186,6 @@ export function MainNavbarView({
         <SidebarOnboardingSection
           collections={collections}
           databases={databases}
-          hasOwnDatabase={hasOwnDatabase}
           isAdmin={isAdmin}
         />
       </SidebarContentRoot>

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
@@ -16,6 +16,7 @@ import { isSmallScreen } from "metabase/lib/dom";
 import * as Urls from "metabase/lib/urls";
 import { WhatsNewNotification } from "metabase/nav/components/WhatsNewNotification";
 import type { IconName, IconProps } from "metabase/ui";
+import type Database from "metabase-lib/v1/metadata/Database";
 import type { Bookmark, Collection, User } from "metabase-types/api";
 
 import {
@@ -48,6 +49,7 @@ type Props = {
   hasDataAccess: boolean;
   hasOwnDatabase: boolean;
   collections: CollectionTreeItem[];
+  databases: Database[];
   selectedItems: SelectedItem[];
   handleCloseNavbar: () => void;
   handleLogout: () => void;
@@ -67,6 +69,7 @@ export function MainNavbarView({
   currentUser,
   bookmarks,
   collections,
+  databases,
   hasOwnDatabase,
   selectedItems,
   hasDataAccess,
@@ -184,6 +187,7 @@ export function MainNavbarView({
         <WhatsNewNotification />
         <SidebarOnboardingSection
           collections={collections}
+          databases={databases}
           hasOwnDatabase={hasOwnDatabase}
           isAdmin={isAdmin}
         />

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarOnboardingSection/SidebarOnboardingSection.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarOnboardingSection/SidebarOnboardingSection.tsx
@@ -197,11 +197,13 @@ export function SidebarOnboardingSection({
           onClose={() => setShowInfoModal(false)}
         />
       )}
-      <UploadInput
-        id="onboarding-upload-input"
-        ref={uploadInputRef}
-        onChange={handleFileInput}
-      />
+      {canUpload && (
+        <UploadInput
+          id="onboarding-upload-input"
+          ref={uploadInputRef}
+          onChange={handleFileInput}
+        />
+      )}
       <ModelUploadModal
         collectionId="root"
         opened={isModelUploadModalOpen}

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarOnboardingSection/SidebarOnboardingSection.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarOnboardingSection/SidebarOnboardingSection.tsx
@@ -38,7 +38,8 @@ export function SidebarOnboardingSection({
   databases,
   isAdmin,
 }: SidebarOnboardingProps) {
-  const initialState = !getHasOwnDatabase(databases);
+  const isDatabaseAdded = getHasOwnDatabase(databases);
+  const collapseCTASection = isDatabaseAdded;
 
   const [
     isModelUploadModalOpen,
@@ -164,7 +165,7 @@ export function SidebarOnboardingSection({
       bottom={0}
       pos="sticky"
       bg="bg-white"
-      className={cx({ [CS.borderTop]: !initialState })}
+      className={cx({ [CS.borderTop]: collapseCTASection })}
     >
       <Box px="md" py="md">
         {/*eslint-disable-next-line no-unconditional-metabase-links-render -- This link is only temporary. It will be replaced with an internal link to a page. */}
@@ -176,8 +177,12 @@ export function SidebarOnboardingSection({
         </ExternalLink>
       </Box>
       {canAddDatabase || canUpload ? (
-        <Box px="xl" pb="md" className={cx({ [CS.borderTop]: initialState })}>
-          {initialState && (
+        <Box
+          px="xl"
+          pb="md"
+          className={cx({ [CS.borderTop]: !collapseCTASection })}
+        >
+          {!collapseCTASection && (
             <Text
               fz="sm"
               my="md"

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarOnboardingSection/SidebarOnboardingSection.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarOnboardingSection/SidebarOnboardingSection.tsx
@@ -22,7 +22,7 @@ import {
   type UploadFileProps,
   uploadFile as uploadFileAction,
 } from "metabase/redux/uploads";
-import { getHasDataAccess } from "metabase/selectors/data";
+import { getHasDataAccess, getHasOwnDatabase } from "metabase/selectors/data";
 import { getLearnUrl, getSetting } from "metabase/selectors/settings";
 import { getApplicationName } from "metabase/selectors/whitelabel";
 import { Box, Button, Icon, Menu, Stack, Text, Title } from "metabase/ui";
@@ -36,10 +36,9 @@ import type { OnboaringMenuItemProps, SidebarOnboardingProps } from "./types";
 export function SidebarOnboardingSection({
   collections,
   databases,
-  hasOwnDatabase,
   isAdmin,
 }: SidebarOnboardingProps) {
-  const initialState = !hasOwnDatabase;
+  const initialState = !getHasOwnDatabase(databases);
 
   const [
     isModelUploadModalOpen,

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarOnboardingSection/SidebarOnboardingSection.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarOnboardingSection/SidebarOnboardingSection.tsx
@@ -11,7 +11,6 @@ import {
 } from "metabase/collections/components/ModelUploadModal";
 import type { OnFileUpload } from "metabase/collections/types";
 import { UploadInput } from "metabase/components/upload";
-import ExternalLink from "metabase/core/components/ExternalLink";
 import Link from "metabase/core/components/Link";
 import CS from "metabase/css/core/index.css";
 import { useToggle } from "metabase/hooks/use-toggle";
@@ -23,12 +22,9 @@ import {
   uploadFile as uploadFileAction,
 } from "metabase/redux/uploads";
 import { getHasOwnDatabase } from "metabase/selectors/data";
-import { getLearnUrl, getSetting } from "metabase/selectors/settings";
-import { getApplicationName } from "metabase/selectors/whitelabel";
+import { getSetting } from "metabase/selectors/settings";
 import { Box, Button, Icon, Menu, Stack, Text, Title } from "metabase/ui";
 import { breakpoints } from "metabase/ui/theme";
-
-import { PaddedSidebarLink } from "../../MainNavbar.styled";
 
 import { trackAddDataViaCSV, trackAddDataViaDatabase } from "./analytics";
 import type { OnboaringMenuItemProps, SidebarOnboardingProps } from "./types";
@@ -40,7 +36,7 @@ export function SidebarOnboardingSection({
   isAdmin,
 }: SidebarOnboardingProps) {
   const isDatabaseAdded = getHasOwnDatabase(databases);
-  const collapseCTASection = isDatabaseAdded;
+  const showCTASection = !isDatabaseAdded;
 
   const [
     isModelUploadModalOpen,
@@ -50,7 +46,6 @@ export function SidebarOnboardingSection({
   const [showInfoModal, setShowInfoModal] = useState(false);
   const [uploadedFile, setUploadedFile] = useState<File | null>(null);
 
-  const applicationName = useSelector(getApplicationName);
   const uploadDbId = useSelector(
     state => getSetting(state, "uploads-settings")?.db_id,
   );
@@ -165,28 +160,14 @@ export function SidebarOnboardingSection({
       bottom={0}
       pos="sticky"
       bg="bg-white"
-      className={cx({ [CS.borderTop]: collapseCTASection })}
+      className={cx({ [CS.borderTop]: showCTASection })}
     >
-      <Box px="md" py="md">
-        {/*eslint-disable-next-line no-unconditional-metabase-links-render -- This link is only temporary. It will be replaced with an internal link to a page. */}
-        <ExternalLink href={getLearnUrl()} className={CS.noDecoration}>
-          {/* TODO: We currently don't have a `selected` state. Will be added in MS2 when we add the onboarding page. */}
-          <PaddedSidebarLink icon="learn">
-            {t`How to use ${applicationName}`}
-          </PaddedSidebarLink>
-        </ExternalLink>
-      </Box>
       {canAddDatabase || canUpload ? (
-        <Box
-          px="xl"
-          pb="md"
-          className={cx({ [CS.borderTop]: !collapseCTASection })}
-          data-testid="sidebar-add-data-section"
-        >
-          {!collapseCTASection && (
+        <Box px="xl" py="md" data-testid="sidebar-add-data-section">
+          {showCTASection && (
             <Text
               fz="sm"
-              my="md"
+              mb="md"
               lh="1.333"
             >{t`Start by adding your data. Connect to a database or upload a CSV file.`}</Text>
           )}

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarOnboardingSection/SidebarOnboardingSection.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarOnboardingSection/SidebarOnboardingSection.tsx
@@ -181,6 +181,7 @@ export function SidebarOnboardingSection({
           px="xl"
           pb="md"
           className={cx({ [CS.borderTop]: !collapseCTASection })}
+          data-testid="sidebar-add-data-section"
         >
           {!collapseCTASection && (
             <Text

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarOnboardingSection/SidebarOnboardingSection.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarOnboardingSection/SidebarOnboardingSection.tsx
@@ -22,7 +22,7 @@ import {
   type UploadFileProps,
   uploadFile as uploadFileAction,
 } from "metabase/redux/uploads";
-import { getHasDataAccess, getHasOwnDatabase } from "metabase/selectors/data";
+import { getHasOwnDatabase } from "metabase/selectors/data";
 import { getLearnUrl, getSetting } from "metabase/selectors/settings";
 import { getApplicationName } from "metabase/selectors/whitelabel";
 import { Box, Button, Icon, Menu, Stack, Text, Title } from "metabase/ui";
@@ -36,6 +36,7 @@ import type { OnboaringMenuItemProps, SidebarOnboardingProps } from "./types";
 export function SidebarOnboardingSection({
   collections,
   databases,
+  hasDataAccess,
   isAdmin,
 }: SidebarOnboardingProps) {
   const isDatabaseAdded = getHasOwnDatabase(databases);
@@ -110,7 +111,6 @@ export function SidebarOnboardingSection({
     c => c.id === "root" || c.id === null,
   );
   const canCurateRootCollection = rootCollection?.can_write;
-  const hasDataAccess = getHasDataAccess(databases);
   const canUploadToDatabase = databases
     ?.find(db => db.id === uploadDbId)
     ?.canUpload();

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarOnboardingSection/SidebarOnboardingSection.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarOnboardingSection/SidebarOnboardingSection.tsx
@@ -52,7 +52,6 @@ export function SidebarOnboardingSection({
   const uploadDbId = useSelector(
     state => getSetting(state, "uploads-settings")?.db_id,
   );
-  const isUploadEnabled = !!uploadDbId;
 
   const { data: database } = useGetDatabaseQuery(
     uploadDbId ? { id: uploadDbId } : skipToken,
@@ -113,6 +112,33 @@ export function SidebarOnboardingSection({
   const canCurateRootCollection = rootCollection?.can_write;
   const canUploadToDatabase = database?.can_upload;
   const canUpload = canCurateRootCollection && canUploadToDatabase;
+
+  function UploadSpreadsheetButton() {
+    const isUploadEnabled = !!uploadDbId;
+
+    const icon = "table2";
+    const title = t`Upload a spreadsheet`;
+    const subtitle = t`${UPLOAD_DATA_FILE_TYPES.join(
+      ", ",
+    )} (${MAX_UPLOAD_STRING} MB max)`;
+
+    return !isUploadEnabled ? (
+      <SidebarOnboardingMenuItem
+        icon={icon}
+        title={title}
+        subtitle={subtitle}
+        onClick={() => setShowInfoModal(true)}
+      />
+    ) : (
+      <SidebarOnboardingMenuItem
+        icon={icon}
+        title={title}
+        subtitle={subtitle}
+        onClick={() => uploadInputRef.current?.click()}
+      />
+    );
+  }
+
   return (
     <Box
       m={0}
@@ -156,25 +182,7 @@ export function SidebarOnboardingSection({
                   onClick={() => trackAddDataViaDatabase()}
                 />
               </Link>
-              {!isUploadEnabled ? (
-                <SidebarOnboardingMenuItem
-                  icon="table2"
-                  title={t`Upload a spreadsheet`}
-                  subtitle={t`${UPLOAD_DATA_FILE_TYPES.join(
-                    ", ",
-                  )} (${MAX_UPLOAD_STRING} MB max)`}
-                  onClick={() => setShowInfoModal(true)}
-                />
-              ) : (
-                <SidebarOnboardingMenuItem
-                  icon="table2"
-                  title={t`Upload a spreadsheet`}
-                  subtitle={t`${UPLOAD_DATA_FILE_TYPES.join(
-                    ", ",
-                  )} (${MAX_UPLOAD_STRING} MB max)`}
-                  onClick={() => uploadInputRef.current?.click()}
-                />
-              )}
+              {canUpload && <UploadSpreadsheetButton />}
             </Menu.Dropdown>
           </Menu>
         </Box>

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarOnboardingSection/SidebarOnboardingSection.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarOnboardingSection/SidebarOnboardingSection.tsx
@@ -4,7 +4,6 @@ import { type ChangeEvent, useCallback, useRef, useState } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
-import { skipToken, useGetDatabaseQuery } from "metabase/api";
 import { UploadInfoModal } from "metabase/collections/components/CollectionHeader/CollectionUploadInfoModal";
 import {
   type CollectionOrTableIdProps,
@@ -35,6 +34,7 @@ import type { OnboaringMenuItemProps, SidebarOnboardingProps } from "./types";
 
 export function SidebarOnboardingSection({
   collections,
+  databases,
   hasOwnDatabase,
   isAdmin,
 }: SidebarOnboardingProps) {
@@ -51,10 +51,6 @@ export function SidebarOnboardingSection({
   const applicationName = useSelector(getApplicationName);
   const uploadDbId = useSelector(
     state => getSetting(state, "uploads-settings")?.db_id,
-  );
-
-  const { data: database } = useGetDatabaseQuery(
-    uploadDbId ? { id: uploadDbId } : skipToken,
   );
 
   const uploadInputRef = useRef<HTMLInputElement>(null);
@@ -110,7 +106,9 @@ export function SidebarOnboardingSection({
     c => c.id === "root" || c.id === null,
   );
   const canCurateRootCollection = rootCollection?.can_write;
-  const canUploadToDatabase = database?.can_upload;
+  const canUploadToDatabase = databases
+    ?.find(db => db.id === uploadDbId)
+    ?.canUpload();
   const canUpload = canCurateRootCollection && canUploadToDatabase;
 
   function AddDatabaseButton() {

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarOnboardingSection/SidebarOnboardingSection.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarOnboardingSection/SidebarOnboardingSection.tsx
@@ -113,6 +113,19 @@ export function SidebarOnboardingSection({
   const canUploadToDatabase = database?.can_upload;
   const canUpload = canCurateRootCollection && canUploadToDatabase;
 
+  function AddDatabaseButton() {
+    return (
+      <Link to="/admin/databases/create">
+        <SidebarOnboardingMenuItem
+          icon="database"
+          title={t`Add a database`}
+          subtitle={t`PostgreSQL, MySQL, Snowflake, ...`}
+          onClick={() => trackAddDataViaDatabase()}
+        />
+      </Link>
+    );
+  }
+
   function UploadSpreadsheetButton() {
     const isUploadEnabled = !!uploadDbId;
 
@@ -174,14 +187,7 @@ export function SidebarOnboardingSection({
               >{t`Add data`}</Button>
             </Menu.Target>
             <Menu.Dropdown>
-              <Link to="/admin/databases/create">
-                <SidebarOnboardingMenuItem
-                  icon="database"
-                  title={t`Add a database`}
-                  subtitle={t`PostgreSQL, MySQL, Snowflake, ...`}
-                  onClick={() => trackAddDataViaDatabase()}
-                />
-              </Link>
+              {canAddDatabase && <AddDatabaseButton />}
               {canUpload && <UploadSpreadsheetButton />}
             </Menu.Dropdown>
           </Menu>

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarOnboardingSection/SidebarOnboardingSection.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarOnboardingSection/SidebarOnboardingSection.tsx
@@ -113,46 +113,9 @@ export function SidebarOnboardingSection({
     canCurateRootCollection &&
     (isUploadEnabled ? canUploadToDatabase : hasDataAccess);
 
-  function AddDatabaseButton() {
-    return (
-      <Link to="/admin/databases/create">
-        <SidebarOnboardingMenuItem
-          icon="database"
-          title={t`Add a database`}
-          subtitle={t`PostgreSQL, MySQL, Snowflake, ...`}
-          onClick={() => trackAddDataViaDatabase()}
-        />
-      </Link>
-    );
-  }
-
-  function UploadSpreadsheetButton({
-    isUploadEnabled,
-  }: {
-    isUploadEnabled: boolean;
-  }) {
-    const icon = "table2";
-    const title = t`Upload a spreadsheet`;
-    const subtitle = t`${UPLOAD_DATA_FILE_TYPES.join(
-      ", ",
-    )} (${MAX_UPLOAD_STRING} MB max)`;
-
-    return !isUploadEnabled ? (
-      <SidebarOnboardingMenuItem
-        icon={icon}
-        title={title}
-        subtitle={subtitle}
-        onClick={() => setShowInfoModal(true)}
-      />
-    ) : (
-      <SidebarOnboardingMenuItem
-        icon={icon}
-        title={title}
-        subtitle={subtitle}
-        onClick={() => uploadInputRef.current?.click()}
-      />
-    );
-  }
+  const handleSpreadsheetButtonClick = isUploadEnabled
+    ? () => uploadInputRef.current?.click()
+    : () => setShowInfoModal(true);
 
   return (
     <Box
@@ -182,7 +145,9 @@ export function SidebarOnboardingSection({
             <Menu.Dropdown>
               {canAddDatabase && <AddDatabaseButton />}
               {canUpload && (
-                <UploadSpreadsheetButton isUploadEnabled={isUploadEnabled} />
+                <UploadSpreadsheetButton
+                  onClick={handleSpreadsheetButtonClick}
+                />
               )}
             </Menu.Dropdown>
           </Menu>
@@ -232,5 +197,33 @@ function SidebarOnboardingMenuItem({
         </Text>
       </Stack>
     </Menu.Item>
+  );
+}
+
+function AddDatabaseButton() {
+  return (
+    <Link to="/admin/databases/create">
+      <SidebarOnboardingMenuItem
+        icon="database"
+        title={t`Add a database`}
+        subtitle={t`PostgreSQL, MySQL, Snowflake, ...`}
+        onClick={() => trackAddDataViaDatabase()}
+      />
+    </Link>
+  );
+}
+
+function UploadSpreadsheetButton({ onClick }: { onClick: () => void }) {
+  const subtitle = t`${UPLOAD_DATA_FILE_TYPES.join(
+    ", ",
+  )} (${MAX_UPLOAD_STRING} MB max)`;
+
+  return (
+    <SidebarOnboardingMenuItem
+      icon="table2"
+      title={t`Upload a spreadsheet`}
+      subtitle={subtitle}
+      onClick={onClick}
+    />
   );
 }

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarOnboardingSection/types.ts
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarOnboardingSection/types.ts
@@ -5,7 +5,6 @@ import type Database from "metabase-lib/v1/metadata/Database";
 export type SidebarOnboardingProps = {
   collections: CollectionTreeItem[];
   databases: Database[];
-  hasOwnDatabase: boolean;
   isAdmin: boolean;
 };
 

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarOnboardingSection/types.ts
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarOnboardingSection/types.ts
@@ -1,8 +1,10 @@
 import type { CollectionTreeItem } from "metabase/entities/collections/utils";
 import type { IconName } from "metabase/ui";
+import type Database from "metabase-lib/v1/metadata/Database";
 
 export type SidebarOnboardingProps = {
   collections: CollectionTreeItem[];
+  databases: Database[];
   hasOwnDatabase: boolean;
   isAdmin: boolean;
 };

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarOnboardingSection/types.ts
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarOnboardingSection/types.ts
@@ -5,6 +5,7 @@ import type Database from "metabase-lib/v1/metadata/Database";
 export type SidebarOnboardingProps = {
   collections: CollectionTreeItem[];
   databases: Database[];
+  hasDataAccess: boolean;
   isAdmin: boolean;
 };
 

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarOnboardingSection/types.ts
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarOnboardingSection/types.ts
@@ -1,6 +1,8 @@
+import type { CollectionTreeItem } from "metabase/entities/collections/utils";
 import type { IconName } from "metabase/ui";
 
 export type SidebarOnboardingProps = {
+  collections: CollectionTreeItem[];
   hasOwnDatabase: boolean;
   isAdmin: boolean;
 };


### PR DESCRIPTION
### What does this PR accomplish?
- Resolves #48325

> [!TIP]
> All of the information you need to review this PR is in the _Milestone_ issue linked above. It contains the testing plan. But the tl;dr is:
>
> **We're expanding permissions for CSV uploads from this section to some non-admin users**

### Does anything change for admins?
- No. Everything should still work the same and all tests should be passing.

### What are the new rules for non-admins
They _must_ have:
  1. "write" permissions for the root collection AND
  2.  either:
    a) !uploadsEnabled => data access to any of the databases OR
    b) uploadsEnabled => "upload" permissions for the database for which uploads are enabled

### What else changed since #48369
> [!IMPORTANT]
> We decided to [remove the Metabase _learn_ link](https://github.com/metabase/metabase/pull/48475/commits/a314e7e0875dba4d02703f3b37ca83698ce44c27) until we introduce a [new checklist page](https://github.com/metabase/metabase/issues/48387).

---
### Documentation implication
@metabase/writers might have to update the documentation after this PR gets merged to `master`. Since we're backporting it to both 51.x release branch AND to the 50.x branch, some docs changes might be needed in there as well.

### Testing
All of these changes were possible to test with Jest integration tests. No E2E bloat needed.

Results of a local run:
```
better onboarding section
  add data section
    ✓ should render for admins (683 ms)
    ✓ intro CTA should not render when there are databases connected (392 ms)
    ✓ should render for regular users with 'curate' root collection permissions if uploads are disabled, but they have general data access (434 ms)
    ✓ should render for regular users with 'curate' root collection permissions if uploads are enabled for a database and they can upload to that database (449 ms)
    ✓ should not render for regular users if they cannot 'curate' the root collection (477 ms)
    ✓ should not render for regular users if they don't have data access (492 ms)
  'Add a database' menu item
    ✓ should be wrapped in a link (922 ms)
    ✓ should render properly for admins (877 ms)
    ✓ should not render for regular users (903 ms)
  'Upload a spreadsheet' menu item
    ✓ should render properly for admins (825 ms)
    ✓ should render properly for regular users (854 ms)
    ✓ clicking on it should show a CSV info modal for an admin, if uploads are disabled (1007 ms)
    ✓ clicking on it should show a CSV info modal for a regular user, if uploads are disabled (954 ms)
    ✓ clicking on it should not show a CSV info modal for an admin, if uploads are enabled (1019 ms)
    ✓ clicking on it should not show a CSV info modal for a regular user, if uploads are enabled (982 ms)
```