### PR TITLE
Remove source hacks for native query drills

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/bar_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/bar_chart.cy.spec.js
@@ -343,41 +343,6 @@ describe("scenarios > visualizations > bar chart", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Category is Doohickey").should("be.visible");
     });
-
-    it("native question should drill-through correctly when stacking", () => {
-      cy.createNativeQuestion(
-        {
-          name: "native question",
-          native: {
-            query: `
-              SELECT
-                PRODUCTS.CATEGORY AS "Category",
-                DATE_TRUNC('month', PRODUCTS.CREATED_AT) AS "CREATED_AT",
-                COUNT(*) AS "count"
-              FROM
-                PRODUCTS
-              GROUP BY
-                PRODUCTS.CATEGORY,
-                DATE_TRUNC('month', PRODUCTS.CREATED_AT)
-            `,
-          },
-          display: "bar",
-          visualization_settings: { "stackable.stack_type": "stacked" },
-        },
-        { visitQuestion: true },
-      );
-
-      cy.log("open drill menu");
-
-      cy.findAllByTestId("legend-item").findByText("Doohickey").click();
-      popover().findByText("See these native questions").click();
-
-      cy.log("show filter pill");
-      cy.findByTestId("filters-visibility-control").click();
-      cy.findByTestId("filter-pill")
-        .findByText("Category is Doohickey")
-        .should("be.visible");
-    });
   });
 
   it("supports up to 100 series (metabase#28796)", () => {

--- a/src/metabase/lib/drill_thru/automatic_insights.cljc
+++ b/src/metabase/lib/drill_thru/automatic_insights.cljc
@@ -22,7 +22,7 @@
    stage-number                                 :- :int
    {:keys [column column-ref dimensions value]} :- ::lib.schema.drill-thru/context]
   (when (and (lib.drill-thru.common/mbql-stage? query stage-number)
-             (lib.underlying/has-aggregation-or-breakout-clause? query)
+             (lib.underlying/has-aggregation-or-breakout? query)
              ;; Column with no value is not allowed - that's a column header click. Other combinations are allowed.
              (or (not column) (some? value))
              (lib.metadata/setting query :enable-xrays)

--- a/src/metabase/lib/drill_thru/automatic_insights.cljc
+++ b/src/metabase/lib/drill_thru/automatic_insights.cljc
@@ -23,7 +23,7 @@
    {:keys [column column-ref dimensions value]} :- ::lib.schema.drill-thru/context]
   (when (and (lib.drill-thru.common/mbql-stage? query stage-number)
              ;; An aggregation or a breakout is required
-             (lib.underlying/has-summarize-clause? query)
+             (lib.underlying/has-summary-clause? query)
              ;; Column with no value is not allowed - that's a column header click. Other combinations are allowed.
              (or (not column) (some? value))
              (lib.metadata/setting query :enable-xrays)

--- a/src/metabase/lib/drill_thru/automatic_insights.cljc
+++ b/src/metabase/lib/drill_thru/automatic_insights.cljc
@@ -22,8 +22,7 @@
    stage-number                                 :- :int
    {:keys [column column-ref dimensions value]} :- ::lib.schema.drill-thru/context]
   (when (and (lib.drill-thru.common/mbql-stage? query stage-number)
-             ;; An aggregation or a breakout is required
-             (lib.underlying/has-summary-clause? query)
+             (lib.underlying/has-aggregation-or-breakout-clause? query)
              ;; Column with no value is not allowed - that's a column header click. Other combinations are allowed.
              (or (not column) (some? value))
              (lib.metadata/setting query :enable-xrays)

--- a/src/metabase/lib/drill_thru/automatic_insights.cljc
+++ b/src/metabase/lib/drill_thru/automatic_insights.cljc
@@ -5,6 +5,7 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
+   [metabase.lib.underlying :as lib.underlying]
    [metabase.lib.util :as lib.util]
    [metabase.util.malli :as mu]))
 
@@ -21,8 +22,8 @@
    stage-number                                 :- :int
    {:keys [column column-ref dimensions value]} :- ::lib.schema.drill-thru/context]
   (when (and (lib.drill-thru.common/mbql-stage? query stage-number)
-             ;; HACK: This is a not a great way to disable this drill for queries whose source is a native query.
-             (not= (:lib/source column) :source/native)
+             ;; An aggregation or a breakout is required
+             (lib.underlying/has-summarize-clause? query)
              ;; Column with no value is not allowed - that's a column header click. Other combinations are allowed.
              (or (not column) (some? value))
              (lib.metadata/setting query :enable-xrays)

--- a/src/metabase/lib/drill_thru/underlying_records.cljc
+++ b/src/metabase/lib/drill_thru/underlying_records.cljc
@@ -72,8 +72,7 @@
   ;; - value is nil
   ;; - dimensions holds only the legend's column, eg. Products.CATEGORY.
   (when (and (lib.drill-thru.common/mbql-stage? query stage-number)
-             ;; An aggregation or a breakout is required
-             (lib.underlying/has-summary-clause? query)
+             (lib.underlying/has-aggregation-or-breakout-clause? query)
              ;; Either we clicked the aggregation, or there are dimensions.
              (or (= (:lib/source column) :source/aggregations)
                  (not-empty dimensions))

--- a/src/metabase/lib/drill_thru/underlying_records.cljc
+++ b/src/metabase/lib/drill_thru/underlying_records.cljc
@@ -73,7 +73,7 @@
   ;; - dimensions holds only the legend's column, eg. Products.CATEGORY.
   (when (and (lib.drill-thru.common/mbql-stage? query stage-number)
              ;; An aggregation or a breakout is required
-             (lib.underlying/has-summarize-clause? query)
+             (lib.underlying/has-summary-clause? query)
              ;; Either we clicked the aggregation, or there are dimensions.
              (or (= (:lib/source column) :source/aggregations)
                  (not-empty dimensions))

--- a/src/metabase/lib/drill_thru/underlying_records.cljc
+++ b/src/metabase/lib/drill_thru/underlying_records.cljc
@@ -72,9 +72,9 @@
   ;; - value is nil
   ;; - dimensions holds only the legend's column, eg. Products.CATEGORY.
   (when (and (lib.drill-thru.common/mbql-stage? query stage-number)
-             ;; HACK: This is a not a great way to disable this drill for queries whose source is a native query.
-             (not= (:lib/source column) :source/native)
-             ;; Underlying records requires an aggregation. Either we clicked the aggregation, or there are dimensions.
+             ;; An aggregation or a breakout is required
+             (lib.underlying/has-summarize-clause? query)
+             ;; Either we clicked the aggregation, or there are dimensions.
              (or (= (:lib/source column) :source/aggregations)
                  (not-empty dimensions))
              ;; Either we need both column and value (cell/map/data point click) or neither (chart legend click).

--- a/src/metabase/lib/drill_thru/underlying_records.cljc
+++ b/src/metabase/lib/drill_thru/underlying_records.cljc
@@ -72,7 +72,7 @@
   ;; - value is nil
   ;; - dimensions holds only the legend's column, eg. Products.CATEGORY.
   (when (and (lib.drill-thru.common/mbql-stage? query stage-number)
-             (lib.underlying/has-aggregation-or-breakout-clause? query)
+             (lib.underlying/has-aggregation-or-breakout? query)
              ;; Either we clicked the aggregation, or there are dimensions.
              (or (= (:lib/source column) :source/aggregations)
                  (not-empty dimensions))

--- a/src/metabase/lib/underlying.cljc
+++ b/src/metabase/lib/underlying.cljc
@@ -64,9 +64,7 @@
             (when prev-col
               (recur (update query :stages pop) prev-col))))))))
 
-(mu/defn has-summary-clause?
+(mu/defn has-aggregation-or-breakout-clause?
   "Whether the `query` has an aggregation or breakout clause in some query stage."
   [query :- ::lib.schema/query]
-  (let [top-query (top-level-query query)]
-    (or (not-empty (lib.aggregation/aggregations top-query))
-        (not-empty (lib.breakout/breakouts top-query)))))
+  (some? (pop-until-aggregation-or-breakout query)))

--- a/src/metabase/lib/underlying.cljc
+++ b/src/metabase/lib/underlying.cljc
@@ -63,3 +63,10 @@
                 prev-col  (lib.equality/find-matching-column query -2 (lib.ref/ref column) prev-cols)]
             (when prev-col
               (recur (update query :stages pop) prev-col))))))))
+
+(mu/defn has-summarize-clause?
+  "Whether the `query` has an aggregation or breakout clause in some query stage."
+  [query :- ::lib.schema/query]
+  (let [top-query (top-level-query query)]
+    (or (not-empty (lib.aggregation/aggregations top-query))
+        (not-empty (lib.breakout/breakouts top-query)))))

--- a/src/metabase/lib/underlying.cljc
+++ b/src/metabase/lib/underlying.cljc
@@ -64,7 +64,7 @@
             (when prev-col
               (recur (update query :stages pop) prev-col))))))))
 
-(mu/defn has-aggregation-or-breakout-clause?
+(mu/defn has-aggregation-or-breakout?
   "Whether the `query` has an aggregation or breakout clause in some query stage."
   [query :- ::lib.schema/query]
   (some? (pop-until-aggregation-or-breakout query)))

--- a/src/metabase/lib/underlying.cljc
+++ b/src/metabase/lib/underlying.cljc
@@ -64,7 +64,7 @@
             (when prev-col
               (recur (update query :stages pop) prev-col))))))))
 
-(mu/defn has-summarize-clause?
+(mu/defn has-summary-clause?
   "Whether the `query` has an aggregation or breakout clause in some query stage."
   [query :- ::lib.schema/query]
   (let [top-query (top-level-query query)]


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/48466
Follow up for https://github.com/metabase/metabase/pull/48232

The actual intent was always to check whether the `top-level-query` has aggregations or breakouts. This PR removes the hack added in a hackathon and adds the check.