### PR TITLE
Update Settings Copy to kick Ci + fix milestone setting bug

### DIFF
--- a/.github/workflows/check-milestone.yml
+++ b/.github/workflows/check-milestone.yml
@@ -27,12 +27,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           sparse-checkout: release
-          fetch-depth: ${{ !env.isNewReleaseBranch && 3 || 0 }} # we need the full history to get all the commit messages
+          fetch-depth: ${{ env.isNewReleaseBranch == 'false' && 3 || 0 }} # we need the full history to get all the commit messages
           ref: master # we want the logic from master, even though we're triggering on a release branch
       - name: Prepare build scripts
         run: cd ${{ github.workspace }}/release && yarn && yarn build
       - uses: actions/github-script@v7
-        if: ${{ !env.isNewReleaseBranch }}
+        if: ${{ env.isNewReleaseBranch == 'false' }}
         name: Set milestone for single commit
         with:
           script: | # js
@@ -51,12 +51,12 @@ jobs:
               commitMessages: [commitMessage],
             });
       - name: Get commit messages for release branch
-        if: ${{ env.isNewReleaseBranch }}
+        if: ${{ env.isNewReleaseBranch == 'true' }}
         run: |
           npm i -g tsx
           tsx release/src/release-branch-commits.ts ${{ inputs.version }} > commit-messages.json
       - uses: actions/github-script@v7
-        if: ${{ env.isNewReleaseBranch }}
+        if: ${{ env.isNewReleaseBranch == 'true' }}
         name: Set milestones for new release branch
         env:
           # this token has a higher rate limit than the default token, and

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/SettingsUpdatesForm.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/SettingsUpdatesForm.tsx
@@ -20,12 +20,16 @@ const updateChannelSetting = {
   defaultValue: "latest",
   options: [
     {
-      name: c("describes a software version").t`Stable releases`,
+      name: c("describes a set of software version releases")
+        .t`Stable releases`,
       value: "latest",
     },
-    { name: c("describes a software version").t`Beta releases`, value: "beta" },
     {
-      name: c("describes a software version").t`Nightly builds`,
+      name: c("describes a set of software version releases").t`Beta releases`,
+      value: "beta",
+    },
+    {
+      name: c("describes a set of software version releases").t`Nightly builds`,
       value: "nightly",
     },
   ],

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -82,7 +82,7 @@
     (setting/set-value-of-type! :string :update-channel new-channel)))
 
 (defsetting update-channel
-  (deferred-tru "Metabase will notify you when a new release is available for the channel you select.")
+  (deferred-tru "We'll notify you here when there's a new version of this type of release.")
   :visibility :admin
   :type       :string
   :encryption :no


### PR DESCRIPTION

### Description

1. Updates a little settings copy on the backend to kick backend CI on the release branch
2. Updates frontend string context on the frontend to trigger frontend CI on the release branch
3. fixes boolean check for milestone setting (in this context, booleans get cast to strings)
