### PR TITLE
Ensure the temp directory exists

### DIFF
--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -1,6 +1,7 @@
 (ns metabase.query-processor.streaming.xlsx
   (:require
    [cheshire.core :as json]
+   [clojure.java.io :as io]
    [clojure.string :as str]
    [dk.ative.docjure.spreadsheet :as spreadsheet]
    [java-time.api :as t]
@@ -616,6 +617,11 @@
 
 (defmethod qp.si/streaming-results-writer :xlsx
   [_ ^OutputStream os]
+  ;; working around a bug #41919. Will be fixed when we can get a release of apache poi 5.3.1. See
+  ;; https://bz.apache.org/bugzilla/show_bug.cgi?id=69323
+  (let [f (io/file (str (System/getProperty "java.io.tmpdir") "/poifiles"))]
+    (when-not (.exists f)
+      (.mkdirs f)))
   (let [workbook           (SXSSFWorkbook.)
         sheet              (spreadsheet/add-sheet! workbook (tru "Query result"))
         _                  (set-no-style-custom-helper sheet)


### PR DESCRIPTION
Fixes #41919

tl;dr: apache poi keeps some scratch documents on disk to make workbooks. It keeps them (tidily) in a directory at `<tempfile-location>/poifiles`. But if that temp file goes away it isn't smart enough to ensure it does exist. 

This has been fixed in their repo but not yet released. It will be in 5.3.1 when it comes out. They have ~ a yearly cadence of releases so might be a while. Let's ensure the file exists. The test can stay when we bump to 5.3.1 and we can remove our check to ensure the directory exists.

https://github.com/metabase/metabase/issues/41919#issuecomment-2400542908

This issue goes away in 5.3.1 of apache poi. Seems like they have a yearly release cadence so we can ensure this exists for the time being and then remove this when we can bump to 5.3.1

```diff
index b763a1ffdf..c87992c935 100644
--- a/deps.edn
+++ b/deps.edn
@@ -122,7 +122,7 @@
   {:mvn/version "2.23.1"}             ; allows the slf4j2 API to work with log4j 2
   org.apache.logging.log4j/log4j-layout-template-json
   {:mvn/version "2.23.1"}             ; allows the custom json logging format
-  org.apache.poi/poi                        {:mvn/version "5.2.5"}              ; Work with Office documents (e.g. Excel spreadsheets) -- newer version than one specified by Docjure
+  org.apache.poi/poi                        {:mvn/version "5.3.1"}              ; Work with Office documents (e.g. Excel spreadsheets) -- newer version than one specified by Docjure
   org.apache.poi/poi-ooxml                  {:mvn/version "5.2.5"
                                              :exclusions  [org.bouncycastle/bcpkix-jdk15on
                                                            org.bouncycastle/bcprov-jdk15on]}
```
