### PR TITLE
fix(sdk): allow checking React version without npm install and allow continuing setup if React is not found

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/cli/constants/messages.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/constants/messages.ts
@@ -74,3 +74,5 @@ export const SETUP_PRO_LICENSE_MESSAGE = `
 export const SDK_LEARN_MORE_MESSAGE = `All done! 🚀 Learn more about the SDK here: ${green(
   SDK_NPM_LINK,
 )}`;
+
+export const CONTINUE_SETUP_ON_WARNING_MESSAGE = `Do you want to continue setup?`;

--- a/enterprise/frontend/src/embedding-sdk/cli/steps/check-if-react-project.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/steps/check-if-react-project.ts
@@ -9,7 +9,7 @@ import {
 
 import type { CliStepMethod } from "../types/cli";
 import {
-  getDependenciesFromPackageJson,
+  getPackageVersions,
   hasPackageJson,
 } from "../utils/get-package-version";
 import { showWarningAndAskToContinue } from "../utils/show-warning-prompt";
@@ -22,19 +22,13 @@ export const checkIfReactProject: CliStepMethod = async state => {
 
   if (!(await hasPackageJson())) {
     spinner.fail();
-    return [
-      {
-        type: "error",
-        message: PACKAGE_JSON_NOT_FOUND_MESSAGE,
-      },
-      state,
-    ];
+    return [{ type: "error", message: PACKAGE_JSON_NOT_FOUND_MESSAGE }, state];
   }
 
-  const projectDependencies = await getDependenciesFromPackageJson();
+  const dependencyVersions = await getPackageVersions("react", "react-dom");
 
-  const reactDep = projectDependencies?.["react"];
-  const reactDomDep = projectDependencies?.["react-dom"];
+  const reactDep = dependencyVersions["react"];
+  const reactDomDep = dependencyVersions["react-dom"];
 
   const hasReactDependency = reactDep && reactDomDep;
 
@@ -60,7 +54,7 @@ export const checkIfReactProject: CliStepMethod = async state => {
       return [{ type: "error", message: "Canceled." }, state];
     }
   } else {
-    spinner.succeed(`React v${reactDep} and React DOM v${reactDomDep} found`);
+    spinner.succeed(`React ${reactDep} and React DOM ${reactDomDep} found`);
   }
 
   return [{ type: "success" }, state];

--- a/enterprise/frontend/src/embedding-sdk/cli/steps/check-if-react-project.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/steps/check-if-react-project.ts
@@ -6,12 +6,13 @@ import {
   PACKAGE_JSON_NOT_FOUND_MESSAGE,
   UNSUPPORTED_REACT_VERSION,
 } from "embedding-sdk/cli/constants/messages";
-import {
-  getPackageVersion,
-  hasPackageJson,
-} from "embedding-sdk/cli/utils/get-package-version";
 
 import type { CliStepMethod } from "../types/cli";
+import {
+  getDependenciesFromPackageJson,
+  hasPackageJson,
+} from "../utils/get-package-version";
+import { showWarningAndAskToContinue } from "../utils/show-warning-prompt";
 
 const isReactVersionSupported = (version: string) =>
   semver.satisfies(semver.coerce(version)!, "18.x");
@@ -30,40 +31,37 @@ export const checkIfReactProject: CliStepMethod = async state => {
     ];
   }
 
-  const reactDep = await getPackageVersion("react");
-  const reactDomDep = await getPackageVersion("react-dom");
+  const projectDependencies = await getDependenciesFromPackageJson();
+
+  const reactDep = projectDependencies?.["react"];
+  const reactDomDep = projectDependencies?.["react-dom"];
 
   const hasReactDependency = reactDep && reactDomDep;
+
   const hasSupportedReactVersion =
-    isReactVersionSupported(reactDep) && isReactVersionSupported(reactDomDep);
+    hasReactDependency &&
+    isReactVersionSupported(reactDep) &&
+    isReactVersionSupported(reactDomDep);
+
+  let warningMessage: string | null = null;
 
   if (!hasReactDependency) {
-    spinner.fail();
-    return [
-      {
-        type: "error",
-        message: MISSING_REACT_DEPENDENCY,
-      },
-      state,
-    ];
+    warningMessage = MISSING_REACT_DEPENDENCY;
+  } else if (!hasSupportedReactVersion) {
+    warningMessage = UNSUPPORTED_REACT_VERSION;
   }
 
-  if (!hasSupportedReactVersion) {
+  if (warningMessage) {
     spinner.fail();
-    return [
-      {
-        type: "error",
-        message: UNSUPPORTED_REACT_VERSION,
-      },
-      state,
-    ];
+
+    const shouldContinue = await showWarningAndAskToContinue(warningMessage);
+
+    if (!shouldContinue) {
+      return [{ type: "error", message: "Canceled." }, state];
+    }
+  } else {
+    spinner.succeed(`React v${reactDep} and React DOM v${reactDomDep} found`);
   }
 
-  spinner.succeed(`React v${reactDep} and React DOM v${reactDomDep} found`);
-  return [
-    {
-      type: "success",
-    },
-    state,
-  ];
+  return [{ type: "success" }, state];
 };

--- a/enterprise/frontend/src/embedding-sdk/cli/steps/check-sdk-available.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/steps/check-sdk-available.ts
@@ -1,26 +1,20 @@
 import ora from "ora";
 
-import { SDK_PACKAGE_NAME } from "embedding-sdk/cli/constants/config";
-import { installSdk } from "embedding-sdk/cli/steps/install-sdk";
-import { getDependenciesFromPackageJson } from "embedding-sdk/cli/utils/get-package-version";
-
+import { SDK_PACKAGE_NAME } from "../constants/config";
+import { installSdk } from "../steps/install-sdk";
 import type { CliStepMethod } from "../types/cli";
+import { getPackageVersions } from "../utils/get-package-version";
 
 export const checkSdkAvailable: CliStepMethod = async state => {
   const spinner = ora("Checking if SDK is installed…").start();
 
-  const projectDependencies = await getDependenciesFromPackageJson();
+  const projectDependencies = await getPackageVersions(SDK_PACKAGE_NAME);
   const sdkVersion = projectDependencies?.[SDK_PACKAGE_NAME];
 
   // skip install step if we already have the SDK installed
   if (sdkVersion) {
     spinner.succeed(`SDK v${sdkVersion} found`);
-    return [
-      {
-        type: "success",
-      },
-      state,
-    ];
+    return [{ type: "success" }, state];
   }
 
   spinner.fail("SDK not found");

--- a/enterprise/frontend/src/embedding-sdk/cli/steps/check-sdk-available.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/steps/check-sdk-available.ts
@@ -2,13 +2,15 @@ import ora from "ora";
 
 import { SDK_PACKAGE_NAME } from "embedding-sdk/cli/constants/config";
 import { installSdk } from "embedding-sdk/cli/steps/install-sdk";
-import { getPackageVersion } from "embedding-sdk/cli/utils/get-package-version";
+import { getDependenciesFromPackageJson } from "embedding-sdk/cli/utils/get-package-version";
 
 import type { CliStepMethod } from "../types/cli";
 
 export const checkSdkAvailable: CliStepMethod = async state => {
   const spinner = ora("Checking if SDK is installed…").start();
-  const sdkVersion = await getPackageVersion(SDK_PACKAGE_NAME);
+
+  const projectDependencies = await getDependenciesFromPackageJson();
+  const sdkVersion = projectDependencies?.[SDK_PACKAGE_NAME];
 
   // skip install step if we already have the SDK installed
   if (sdkVersion) {

--- a/enterprise/frontend/src/embedding-sdk/cli/utils/get-package-version.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/utils/get-package-version.ts
@@ -11,28 +11,27 @@ export const hasPackageJson = async () => {
   }
 };
 
-export const getPackageVersion = async (packageName: string) => {
-  try {
-    const packagePath = path.join(
-      process.cwd(),
-      "node_modules",
-      packageName,
-      "package.json",
-    );
-    const packageJson = await fs.readFile(packagePath, "utf8");
+type DependencyMap = Record<string, string>;
 
-    const packageInfo = JSON.parse(packageJson);
-    return packageInfo.version || null;
-  } catch (error) {
-    if ((error as { code: string }).code === "ENOENT") {
-      // Package not found
+export const getDependenciesFromPackageJson =
+  async (): Promise<DependencyMap | null> => {
+    try {
+      const packagePath = path.join(process.cwd(), "package.json");
+      const packageJson = await fs.readFile(packagePath, "utf8");
+
+      const packageInfo = JSON.parse(packageJson);
+
+      return packageInfo?.dependencies || null;
+    } catch (error) {
+      if ((error as { code: string }).code === "ENOENT") {
+        // Package not found
+        return null;
+      }
+
+      console.error(
+        `Error accessing package.json: ${(error as { message: string }).message}`,
+      );
+
       return null;
     }
-    console.error(
-      `Error checking package version: ${
-        (error as { message: string }).message
-      }`,
-    );
-    return null;
-  }
-};
+  };

--- a/enterprise/frontend/src/embedding-sdk/cli/utils/print.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/utils/print.ts
@@ -7,6 +7,7 @@ export const OUTPUT_STYLES = {
   version: chalk.hex("#509EE3"),
   link: chalk.underline.blueBright,
   error: chalk.red.bold,
+  warning: chalk.yellow.bold,
   success: chalk.green.bold,
   info: chalk.bold,
 };
@@ -36,6 +37,9 @@ export const printLink = (text: string) => _print(OUTPUT_STYLES.link, text);
 
 export const printError = (message: string) =>
   console.error(OUTPUT_STYLES.error(message));
+
+export const printWarning = (message: string) =>
+  console.warn(OUTPUT_STYLES.warning(message));
 
 export const printSuccess = (message: string) =>
   _print(OUTPUT_STYLES.success, message);

--- a/enterprise/frontend/src/embedding-sdk/cli/utils/show-warning-prompt.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/utils/show-warning-prompt.ts
@@ -1,0 +1,23 @@
+import { select } from "@inquirer/prompts";
+
+import { CONTINUE_SETUP_ON_WARNING_MESSAGE } from "../constants/messages";
+
+import { printWarning } from "./print";
+
+/**
+ * @returns {boolean} whether the user wants to continue setup or not
+ */
+export async function showWarningAndAskToContinue(
+  message: string,
+): Promise<boolean> {
+  printWarning(message);
+
+  return select({
+    message: CONTINUE_SETUP_ON_WARNING_MESSAGE,
+    choices: [
+      { name: "Continue", value: true },
+      { name: "Exit setup", value: false },
+    ],
+    default: true,
+  });
+}


### PR DESCRIPTION
### Description

The CLI used to abort when we didn't install the node modules via `npm install` or `yarn install`, as we only check in `node_modules/react/package.json` whether React is present. In addition, we force to CLI setup to quit as opposed to just showing a warning message, so they can continue at their own risk.

This PR adds two things:

- Make version check more reliable, by checking both the project's `package.json` file AND the underlying `node_modules/react/package.json` file. This handles both edge cases: for when the `node_modules` is not installed, and allows us to determine the **exact** version of React to show to the user, instead of a SemVer range.
- Allows setup to continue even if React is not present, or has an incompatible version. It shows a warning message, and allows you to continue.
 
### How to verify

- Run `docker rm -f metabase-enterprise-embedding && yarn add file:../metabase/resources/embedding-sdk` in your project first to link the SDK. This is important to do first, so we don't accidentally install `react` or `react-dom` again.
- Next, remove `react` and `react-dom` from both the project's `package.json` and remove `node_modules/react` and `node_modules/react-dom` and run the CLI. You should get a similar result to below screenshot.
- Next, try adding the `react` and `react-dom` to your `package.json`, but do not run `yarn install`. (Or, you could delete `node_modules/react` as well.)
- Now, you should see a SemVer range (e.g. `^18.1.x`) from package.json instead of the exact version.
- Next, try running `yarn install` as usual.
- Now you should see the exact version for both React and SDK.

### Demo

When "react" and/or "react-dom" is NOT present in both `package.json` and `node_modules/react/package.json`, you are hit with a warning prompt, but you can continue setup by selecting "Continus"

![CleanShot 2567-10-09 at 03 19 53@2x](https://github.com/user-attachments/assets/6b06a35e-92b7-4ae6-9a38-b46cb0a1c5b4)

An exact version is shown once you `yarn install`

![CleanShot 2567-10-09 at 03 29 45@2x](https://github.com/user-attachments/assets/cbb673f8-b5a1-4236-9cd2-029dad61f6c8)
