### PR TITLE
Relax concat args to allow any ExpressionArg

### DIFF
--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -555,8 +555,10 @@
 (defclause ^{:requires-features #{:expressions}} replace
   s StringExpressionArg, match :string, replacement :string)
 
+;; Relax the arg types to ExpressionArg for concat since many DBs allow to concatenate non-string types. This also
+;; aligns with the corresponding MLv2 schema and with the reference docs we publish.
 (defclause ^{:requires-features #{:expressions}} concat
-  a StringExpressionArg, b StringExpressionArg, more (rest StringExpressionArg))
+  a ExpressionArg, b ExpressionArg, more (rest ExpressionArg))
 
 (defclause ^{:requires-features #{:expressions :regex}} regex-match-first
   s StringExpressionArg, pattern :string)

--- a/test/metabase/lib/schema/expression/string_test.cljc
+++ b/test/metabase/lib/schema/expression/string_test.cljc
@@ -15,4 +15,32 @@
     [:concat
      {:lib/uuid "47cac41f-6240-4623-9a73-448addfdc735"}
      [:field {:lib/uuid "e47d33bc-c89c-48af-bffe-842c815f930b"} 1]
-     "2"]))
+     "2"]
+
+    [:concat
+     {:lib/uuid "47cac41f-6240-4623-9a73-448addfdc735"}
+     "concat simple nested expressions: "
+     [:get-year
+      {:lib/uuid "e47d33bc-c89c-48af-bffe-842c815f930a"}
+      [:field {:lib/uuid "e47d33bc-c89c-48af-bffe-842c815f930b"} 1]]
+     "Q"
+     [:get-quarter {:lib/uuid "e47d33bc-c89c-48af-bffe-842c815f930c"}
+      [:field {:lib/uuid "e47d33bc-c89c-48af-bffe-842c815f930d"} 2]]]
+
+    [:concat
+     {:lib/uuid "47cac41f-6240-4623-9a73-448addfdc735"}
+     "concat nested expressions of various types: "
+     [:/
+      {:lib/uuid "e47d33bc-c89c-48af-bffe-842c815f930a"}
+      3
+      [:+
+       {:lib/uuid "e47d33bc-c89c-48af-bffe-842c815f930b"}
+       1
+       [:field {:lib/uuid "e47d33bc-c89c-48af-bffe-842c815f930c"} 1]]]
+     [:and
+      {:lib/uuid "e47d33bc-c89c-48af-bffe-842c815f930a"}
+      [:or {:lib/uuid "e47d33bc-c89c-48af-bffe-842c815f930b"} 1 2]
+      3]
+     [:sum
+      {:lib/uuid "e47d33bc-c89c-48af-bffe-842c815f930a"}
+      [:field {:lib/uuid "e47d33bc-c89c-48af-bffe-842c815f930b"} 2]]]))


### PR DESCRIPTION
Closes #39439

### Description

Relax the arg types to `ExpressionArg` for `:concat` expressions since many DBs allow to concatenate non-string types. This also aligns with the corresponding MLv2 schema and with the [reference docs](https://www.metabase.com/docs/latest/questions/query-builder/expressions/concat.html#accepted-data-types).

MLv2 schema:
```clojure
(mbql-clause/define-catn-mbql-clause :concat :- :type/Text
  [:args [:repeat {:min 2} [:schema [:ref ::expression/expression]]]])
```

### How to verify

Follow repro steps in linked issue, or see tests added.

### Demo

<img width="542" alt="Screenshot 2024-10-08 at 4 03 49 PM" src="https://github.com/user-attachments/assets/ecc126e5-4a62-4cd3-b930-724fcd23f540">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
