### PR TITLE
don't set enable-embedding and setup-embedding-autoenabled in /setup

### DIFF
--- a/e2e/test/scenarios/onboarding/embedding-homepage.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/embedding-homepage.cy.spec.ts
@@ -18,7 +18,6 @@ describeWithSnowplow("scenarios > embedding-homepage > snowplow events", () => {
     cy.intercept("GET", "/api/session/properties", req => {
       req.continue(res => {
         res.body["embedding-homepage"] = "visible";
-        res.body["setup-embedding-autoenabled"] = true;
         res.body["example-dashboard-id"] = 1;
         res.body["setup-license-active-at-setup"] = true;
         res.send();

--- a/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
@@ -387,15 +387,6 @@ describe("scenarios > setup", () => {
         .click();
     });
 
-    cy.log(
-      "Make sure the embedding secret key is set after embedding has been autoenabled",
-    );
-    cy.wait("@properties").then(request => {
-      expect(request.response?.body["embedding-secret-key"]?.length).to.equal(
-        64,
-      );
-    });
-
     cy.location("pathname").should("eq", "/");
 
     main()

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -260,7 +260,6 @@ export const createMockSettings = (
   "last-acknowledged-version": "v1",
   "last-used-native-database-id": 1,
   "embedding-homepage": "hidden",
-  "setup-embedding-autoenabled": false,
   "setup-license-active-at-setup": false,
   "notebook-native-preview-shown": false,
   "notebook-native-preview-sidebar-width": null,

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -267,7 +267,6 @@ interface AdminSettings {
   "last-acknowledged-version": string | null;
   "show-static-embed-terms": boolean | null;
   "embedding-homepage": EmbeddingHomepageStatus;
-  "setup-embedding-autoenabled": boolean;
   "setup-license-active-at-setup": boolean;
   "store-url": string;
 }

--- a/frontend/src/metabase/setup/actions.ts
+++ b/frontend/src/metabase/setup/actions.ts
@@ -2,7 +2,6 @@ import { createAction } from "@reduxjs/toolkit";
 import { t } from "ttag";
 
 import { createDatabase } from "metabase/admin/databases/database";
-import { getSettings } from "metabase/admin/settings/selectors";
 import {
   initializeSettings,
   updateSetting,
@@ -227,10 +226,6 @@ export const setEmbeddingHomepageFlags = createAsyncThunk(
   async (_, { getState, dispatch }) => {
     const usageReason = getUsageReason(getState());
     const tokenFeatures = getSetting(getState(), "token-features");
-    const adminSettings = getSettings(getState());
-    const enableEmbeddingSetByEnv = adminSettings.find(
-      (setting: { key: string }) => setting.key === "enable-embedding",
-    )?.is_env_setting;
 
     const interestedInEmbedding =
       usageReason === "embedding" || usageReason === "both";
@@ -240,11 +235,6 @@ export const setEmbeddingHomepageFlags = createAsyncThunk(
 
     if (interestedInEmbedding) {
       settingsToChange["embedding-homepage"] = "visible";
-    }
-
-    if (interestedInEmbedding && !enableEmbeddingSetByEnv) {
-      settingsToChange["enable-embedding"] = true;
-      settingsToChange["setup-embedding-autoenabled"] = true;
     }
 
     settingsToChange["setup-license-active-at-setup"] = isLicenseActive;

--- a/frontend/src/metabase/setup/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/setup/tests/common.unit.spec.tsx
@@ -145,8 +145,6 @@ describe("setup (OSS)", () => {
 
       expect(await getLastSettingsPutPayload()).toEqual({
         "embedding-homepage": "visible",
-        "enable-embedding": true,
-        "setup-embedding-autoenabled": true,
         "setup-license-active-at-setup": false,
       });
     });

--- a/frontend/src/metabase/setup/tests/premium-pro-cloud.unit.spec.tsx
+++ b/frontend/src/metabase/setup/tests/premium-pro-cloud.unit.spec.tsx
@@ -69,8 +69,6 @@ describe("setup (EE build, `hosting` and `embedding` features to simulate pro on
 
     expect(await getLastSettingsPutPayload()).toEqual({
       "embedding-homepage": "visible",
-      "enable-embedding": true,
-      "setup-embedding-autoenabled": true,
       "setup-license-active-at-setup": true,
     });
   });

--- a/frontend/src/metabase/setup/tests/premium-pro-selfhosted.unit.spec.tsx
+++ b/frontend/src/metabase/setup/tests/premium-pro-selfhosted.unit.spec.tsx
@@ -70,8 +70,6 @@ describe("setup (EE build, `embedding` feature but no `hosting` to simulate pro 
 
     expect(await getLastSettingsPutPayload()).toEqual({
       "embedding-homepage": "visible",
-      "enable-embedding": true,
-      "setup-embedding-autoenabled": true,
       "setup-license-active-at-setup": true,
     });
   });

--- a/frontend/src/metabase/setup/tests/premium-starter-cloud.unit.spec.tsx
+++ b/frontend/src/metabase/setup/tests/premium-starter-cloud.unit.spec.tsx
@@ -68,8 +68,6 @@ describe("setup (EE build, only `hosting` feature to simulate starter plan on cl
 
     expect(await getLastSettingsPutPayload()).toEqual({
       "embedding-homepage": "visible",
-      "enable-embedding": true,
-      "setup-embedding-autoenabled": true,
       "setup-license-active-at-setup": false,
     });
   });


### PR DESCRIPTION

Follow up after  [update embedding homepage now that we don't auto-enable embedding](https://github.com/metabase/metabase/pull/48455)

# Changes
- don't set "enable-embedding" and "setup-embedding-autoenabled" to true anymore in /setup
- remove "setup-embedding-autoenabled" from the FE settings types
- updated tests accordingly