### PR TITLE
[serdes] check full export for escaping cards

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
@@ -76,16 +76,16 @@
     [model-name (serdes/eid->id model-name id)]
     target))
 
-(defn- escape-analysis [{colls "Collection" cards "Card" :as _nodes} reasons]
+(defn- escape-analysis [{colls "Collection" cards "Card"} nodes]
   (log/tracef "Running escape analysis for %d colls and %d cards" (count colls) (count cards))
-  (when-let [colls (some-> colls not-empty set)]
+  (when-let [colls (-> colls set not-empty)]
     (let [known-cards (t2/select-pks-set Card {:where [:or
                                                        [:in :collection_id colls]
                                                        (when (contains? colls nil)
                                                          [:= :collection_id nil])]})
           escaped     (->> (set/difference (set cards) known-cards)
                            (mapv (fn [id]
-                                   (-> (get reasons ["Card" id])
+                                   (-> (get nodes ["Card" id])
                                        (assoc :escapee id)))))]
       escaped)))
 
@@ -123,12 +123,13 @@
   (let [inner-targets (if (seq targets)
                         (mapv parse-target targets)
                         (mapv vector (repeat "Collection") (collection-set-for-user user-id)))
+        ;; nodes are a map of `{[model-name id] {dep-model dep-id ...}}`
         nodes         (set/union
                        (u/traverse inner-targets #(serdes/ascendants (first %) (second %)))
                        (u/traverse inner-targets #(serdes/descendants (first %) (second %))))
-        reasons       (u/index-by #(take 2 %) #(first (nnext %)) nodes)
-        by-model      (u/group-by first second nodes)
-        escaped       (escape-analysis by-model reasons)]
+        ;; by model is a map of `{model-name [ids ...]}`
+        by-model      (u/group-by first second (keys nodes))
+        escaped       (escape-analysis by-model nodes)]
     (if (seq escaped)
       (log-escape-report! escaped)
       (let [models         (model-set opts)
@@ -154,9 +155,8 @@
 
 (comment
   (def nodes (let [colls (mapv vector (repeat "Collection") (collection-set-for-user nil))]
-               (set/union
+               (merge
                 (u/traverse colls #(serdes/ascendants (first %) (second %)))
                 (u/traverse colls #(serdes/descendants (first %) (second %))))))
-  (def escaped (escape-analysis (u/group-by first second nodes)
-                                (u/index-by #(take 2 %) #(first (nnext %)) nodes)))
+  (def escaped (escape-analysis (u/group-by first second (keys nodes)) nodes))
   (log-escape-report! escaped))

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
@@ -80,9 +80,8 @@
   (when-let [colls (some-> colls not-empty set)]
     (let [known-cards (t2/select-pks-set Card {:where [:or
                                                        [:in :collection_id colls]
-                                                       (if (contains? colls nil)
-                                                         [:= :collection_id nil]
-                                                         false)]})
+                                                       (when (contains? colls nil)
+                                                         [:= :collection_id nil])]})
           escaped     (->> (set/difference (set cards) known-cards)
                            (mapv (fn [id]
                                    (-> (get reasons ["Card" id])

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
@@ -7,7 +7,7 @@
    [clojure.string :as str]
    [metabase-enterprise.serialization.v2.backfill-ids :as serdes.backfill]
    [metabase-enterprise.serialization.v2.models :as serdes.models]
-   [metabase.models :refer [Card Collection Dashboard DashboardCard]]
+   [metabase.models :refer [Card Collection Dashboard]]
    [metabase.models.collection :as collection]
    [metabase.models.serialization :as serdes]
    [metabase.util :as u]
@@ -58,66 +58,6 @@
         (into (map :id) roots)
         (into (mapcat collection/descendant-ids) roots))))
 
-(defn- extract-metabase
-  "Returns reducible stream of serializable entity maps, with `:serdes/meta` keys.
-   Takes an options map which is passed on to [[serdes/extract-all]] for each model."
-  [{:keys [user-id] :as opts}]
-  (log/tracef "Extracting Metabase with options: %s" (pr-str opts))
-  (let [extract-opts (assoc opts :collection-set (collection-set-for-user user-id))]
-    (eduction (map #(serdes/extract-all % extract-opts)) cat (model-set opts))))
-
-(defn- escape-analysis
-  "Given a target seq, explore the contents of any collections looking for \"leaks\". For example, a
-  Dashboard that contains Cards which are not (transitively) in the given set of collections, or a Card that depends on
-  a Card as a model, which is not in the given collections.
-
-  Returns a data structure detailing the gaps. Use [[escape-report]] to output this data in a human-friendly format.
-  Returns nil if there are no escaped values, which is useful for a test."
-  [targets]
-  (let [collection-ids (into #{} (map second) (targets-of-type targets "Collection"))
-        collection-set (into collection-ids (mapcat collection/descendant-ids) (t2/select Collection :id [:in collection-ids]))
-        dashboards     (t2/select Dashboard :collection_id [:in collection-set])
-        ;; All cards that are in this collection set.
-        cards          (reduce set/union #{} (for [coll-id collection-set]
-                                               (t2/select-pks-set Card :collection_id coll-id)))
-
-        ;; Map of {dashboard-id #{DashboardCard}} for dashcards whose cards OR parameter-bound cards are outside the
-        ;; transitive collection set.
-        escaped-dashcards  (into {}
-                                 (for [dash  dashboards
-                                       :let [dcs (t2/select DashboardCard :dashboard_id (:id dash))
-                                             escapees (->> dcs
-                                                           (keep :card_id) ; Text cards have a nil card_id
-                                                           set)
-                                             params   (->> dcs
-                                                           (mapcat :parameter_mappings)
-                                                           (keep :card_id)
-                                                           set)
-                                             combined (set/difference (set/union escapees params) cards)]
-                                       :when (seq combined)]
-                                   [(:id dash) combined]))
-        ;; {source-card-id target-card-id} the key is in the curated set, the value is not.
-        all-cards          (for [id cards]
-                             (t2/select-one [Card :id :collection_id :dataset_query] :id id))
-        bad-source         (for [card all-cards
-                                 :let [^String src (some-> card :dataset_query :query :source-table)]
-                                 :when (and (string? src) (.startsWith src "card__"))
-                                 :let [card-id (Integer/parseInt (.substring src 6))]
-                                 :when (not (cards card-id))]
-                             [(:id card) card-id])
-        bad-template-tags  (for [card all-cards
-                                 :let [card-ids (some->> card :dataset_query :native
-                                                         :template-tags vals (keep :card-id))]
-                                 card-id card-ids
-                                 :when   (not (cards card-id))]
-                             [(:id card) card-id])
-        escaped-questions  (into {} (concat bad-source bad-template-tags))
-        problem-cards      (reduce set/union (set (vals escaped-questions)) (vals escaped-dashcards))]
-    (cond-> nil
-      (seq escaped-dashcards) (assoc :escaped-dashcards escaped-dashcards)
-      (seq escaped-questions) (assoc :escaped-questions escaped-questions)
-      (seq problem-cards)     (assoc :problem-cards     problem-cards))))
-
 (defn- collection-label [coll-id]
   (if coll-id
     (let [collection (t2/hydrate (t2/select-one Collection :id coll-id) :ancestors)
@@ -131,19 +71,39 @@
   (let [card (t2/select-one [Card :collection_id :name] :id card-id)]
     (format "Card %d (%s from collection %s)" card-id (:name card) (collection-label (:collection_id card)))))
 
-(defn- escape-report
-  "Given the analysis map from [[escape-analysis]], report the results in a human-readable format with Card titles etc."
-  [{:keys [escaped-dashcards escaped-questions]}]
-  (when-not (empty? escaped-dashcards)
-    (doseq [[dash-id card-ids] escaped-dashcards
-            :let [dash-name (t2/select-one-fn :name Dashboard :id dash-id)]]
-      (log/warnf "Failed to export Dashboard %d (%s) containing Cards saved outside requested collections: %s"
-                 dash-id dash-name (str/join ", " (map card-label card-ids)))))
+(defn- parse-target [[model-name id :as target]]
+  (if (string? id)
+    [model-name (serdes/eid->id model-name id)]
+    target))
 
-  (when-not (empty? escaped-questions)
-    (log/warnf "Failed to export Cards based on questions outside requested collections: %s"
-               (str/join ", " (for [[curated-id alien-id] escaped-questions]
-                                (str (card-label curated-id) " -> " (card-label alien-id)))))))
+(defn- escape-analysis [{colls "Collection" cards "Card" :as _nodes} reasons]
+  (when-let [colls (some-> colls not-empty set)]
+    (let [known-cards (t2/select-pks-set Card {:where [:or
+                                                       [:in :collection_id colls]
+                                                       (if (contains? colls nil)
+                                                         [:= :collection_id nil]
+                                                         false)]})
+          escaped     (->> (set/difference (set cards) known-cards)
+                           (mapv (fn [id]
+                                   (-> (get reasons ["Card" id])
+                                       (assoc :escapee id)))))]
+      escaped)))
+
+(defn- escape-report [escaped]
+  (let [dashboards (group-by #(get % "Dashboard") escaped)]
+    (doseq [[dash-id escapes] (dissoc dashboards nil)]
+      (log/warnf "Failed to export Dashboard %d (%s) containing Card saved outside requested collections: %s"
+                 dash-id
+                 (t2/select-one-fn :name Dashboard :id dash-id)
+                 (str/join ", " (map #(card-label (:escapee %)) escapes))))
+    (when-let [other (not-empty (get dashboards nil))]
+      (log/warnf "Failed to export Cards based on questions outside requested collections: %s"
+                 (str/join ", " (for [item other]
+                                  (format "%s -> %s"
+                                          (if (get item "Card")
+                                            (card-label (get item "Card"))
+                                            (dissoc item :escapee))
+                                          (card-label (:escapee item)))))))))
 
 (defn- extract-subtrees
   "Extracts the targeted entities and all their descendants into a reducible stream of extracted maps.
@@ -152,43 +112,42 @@
 
   [[serdes/descendants]] is recursively called on these entities and all their descendants, until the
   complete transitive closure of all descendants is found. This produces a set of `[\"ModelName\" id]` pairs, which
-  entities are then extracted the same way as [[extract-metabase]].
-Eg. if Dashboard B includes a Card A that is derived from a
-  Card C that's in an alien collection, warnings will be emitted for C, A and B, and all three will be excluded from the
-  serialized output."
-  [{:keys [targets] :as opts}]
+  entities are then returned as a reducible stream of serializable entity maps, with `:serdes/meta` keys.
+
+  Eg. if Dashboard B includes a Card A that is derived from a Card C that's in an alien collection, warnings will be
+  emitted for C, A and B, and all three will be excluded from the serialized output.
+
+  `opts` are passed down to [[serdes/extract-all]] for each model."
+  [{:keys [targets user-id] :as opts}]
   (log/tracef "Extracting subtrees with options: %s" (pr-str opts))
-  (let [targets  (->> targets
-                      (mapv (fn [[model-name id :as target]]
-                              (if (number? id)
-                                target
-                                [model-name (serdes/eid->id model-name id)]))))
-        analysis (escape-analysis targets)]
-    (if analysis
-      ;; If that is non-nil, emit the report.
-      (escape-report analysis)
-      ;; If it's nil, there are no errors, and we can proceed to do the dump.
-      ;; TODO This is not handled at all, but we should be able to exclude illegal data - and it should be
-      ;; contagious. Eg. a Dashboard with an illegal Card gets excluded too.
-      (let [nodes       (set/union
-                         (u/traverse targets #(serdes/ascendants (first %) (second %)))
-                         (u/traverse targets #(serdes/descendants (first %) (second %))))
-            models      (model-set opts)
-            ;; filter the selected models based on user options
-            by-model    (-> (group-by first nodes)
-                            (select-keys models)
-                            (update-vals #(set (map second %))))
-            extract-ids (fn [[model ids]]
-                          (serdes/extract-all model (merge opts {:where [:in :id ids]})))]
+  (let [inner-targets (if (seq targets)
+                        (mapv parse-target targets)
+                        (mapv vector (repeat "Collection") (collection-set-for-user user-id)))
+        nodes         (set/union
+                       (u/traverse inner-targets #(serdes/ascendants (first %) (second %)))
+                       (u/traverse inner-targets #(serdes/descendants (first %) (second %))))
+        reasons       (u/index-by #(take 2 %) #(first (nnext %)) nodes)
+        by-model      (u/group-by first second nodes)
+        escaped       (escape-analysis by-model reasons)]
+    (if (seq escaped)
+      (escape-report escaped)
+      (let [models         (model-set opts)
+            coll-set       (get by-model "Collection")
+            by-model       (select-keys by-model models)
+            extract-by-ids (fn [[model ids]]
+                             (serdes/extract-all model (merge opts {:collection-set coll-set
+                                                                    :where          [:in :id ids]})))
+            extract-all    (fn [model]
+                            (serdes/extract-all model (assoc opts :collection-set coll-set)))]
         (eduction cat
-                  [(eduction (map extract-ids) cat by-model)
+                  [(if (seq targets)
+                     (eduction (map extract-by-ids) cat by-model)
+                     (eduction (map extract-all) cat (set/intersection (set serdes.models/content) models)))
                    ;; extract all non-content entities like data model and settings if necessary
                    (eduction (map #(serdes/extract-all % opts)) cat (remove (set serdes.models/content) models))])))))
 
 (defn extract
   "Returns a reducible stream of entities to serialize"
-  [{:keys [targets] :as opts}]
+  [opts]
   (serdes.backfill/backfill-ids!)
-  (if (seq targets)
-    (extract-subtrees opts)
-    (extract-metabase opts)))
+  (extract-subtrees opts))

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/ingest.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/ingest.clj
@@ -96,7 +96,7 @@
             (ingest-file (second target))
             (catch Exception e
               (throw (ex-info "Unable to ingest file" {:abs-path abs-path} e))))
-          (throw (ex-info "Cannot find file entry" {:abs-path abs-path})))))))
+          (throw (ex-info "Cannot find file" {:abs-path abs-path})))))))
 
 (defn ingest-yaml
   "Creates a new Ingestable on a directory of YAML files, as created by

--- a/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
@@ -223,7 +223,7 @@
                           log (slurp (io/input-stream res))]
                       (testing "3 header lines, then cards+database+collection, then the error"
                         (is (re-find #"Failed to read file for Collection DoesNotExist" log))
-                        (is (re-find #"Cannot find file entry" log)) ;; underlying error
+                        (is (re-find #"Cannot find file" log)) ;; underlying error
                         (is (= {:deps-chain #{[{:id "**ID**", :model "Card"}]},
                                 :error      :metabase-enterprise.serialization.v2.load/not-found,
                                 :model      "Collection",

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -1198,7 +1198,7 @@
 
                        ;; Fourth dashboard where its parameter's source is another card
                        Collection   {coll4-id   :id
-                                     coll4-eid  :entity_id}    {:name     "Forth collection"}
+                                     _coll4-eid :entity_id}    {:name     "Forth collection"}
                        Card         {c4-id  :id
                                      c4-eid :entity_id}        {:name          "Question 4-1"
                                                                 :database_id   db-id
@@ -1376,19 +1376,19 @@
                         (map serdes/path)
                         set))))
 
-          #_ ;; (sanya) NOTE: this looks like an irrelevant test? I mean if we do escape analysis and don't allow
+          #_;; (sanya) NOTE: this looks like an irrelevant test? I mean if we do escape analysis and don't allow
           ;; leaking cards from unrelated collections, why this test?
-          (testing "select a collection where a dashboard contains parameter's source is card from another collection"
-            (is (=? #{[{:model "Collection"    :id coll4-eid :label "forth_collection"}]
-                      [{:model "Dashboard"     :id dash4-eid :label "dashboard_4"}]
-                      [{:model "Card"          :id c4-eid  :label "question_4_1"}]
-                      ;; card that parameter on dashboard linked to
-                      [{:model "Card"          :id c1-1-eid  :label "question_1_1"}]
-                      ;; card that the card on dashboard linked to
-                      [{:model "Card"          :id c1-2-eid  :label "question_1_2"}]}
-                    (->> (extract/extract {:targets [["Collection" coll4-id]] :no-settings true :no-data-model true})
-                         (map serdes/path)
-                         set)))))))))
+            (testing "select a collection where a dashboard contains parameter's source is card from another collection"
+              (is (=? #{[{:model "Collection"    :id coll4-eid :label "forth_collection"}]
+                        [{:model "Dashboard"     :id dash4-eid :label "dashboard_4"}]
+                        [{:model "Card"          :id c4-eid  :label "question_4_1"}]
+                        ;; card that parameter on dashboard linked to
+                        [{:model "Card"          :id c1-1-eid  :label "question_1_1"}]
+                        ;; card that the card on dashboard linked to
+                        [{:model "Card"          :id c1-2-eid  :label "question_1_2"}]}
+                      (->> (extract/extract {:targets [["Collection" coll4-id]] :no-settings true :no-data-model true})
+                           (map serdes/path)
+                           set)))))))))
 
 (deftest field-references-test
   (mt/with-empty-h2-app-db

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -1376,6 +1376,8 @@
                         (map serdes/path)
                         set))))
 
+          #_ ;; (sanya) NOTE: this looks like an irrelevant test? I mean if we do escape analysis and don't allow
+          ;; leaking cards from unrelated collections, why this test?
           (testing "select a collection where a dashboard contains parameter's source is card from another collection"
             (is (=? #{[{:model "Collection"    :id coll4-eid :label "forth_collection"}]
                       [{:model "Dashboard"     :id dash4-eid :label "dashboard_4"}]
@@ -1422,13 +1424,26 @@
   (mt/with-empty-h2-app-db
     (ts/with-temp-dpc [Collection    {coll1-id :id} {:name "Some Collection"}
                        Collection    {coll2-id :id} {:name "Other Collection"}
+                       Collection    {coll3-id :id} {:name "Third Collection"}
                        Dashboard     {dash-id :id}  {:name "A Dashboard" :collection_id coll1-id}
                        Card          {card1-id :id} {:name "Some Card"}
                        DashboardCard _              {:card_id card1-id :dashboard_id dash-id}
                        Card          _              {:name          "Dependent Card"
                                                      :collection_id coll2-id
-                                                     :dataset_query {:query {:source-table (str "card__" card1-id)
-                                                                             :aggregation  [[:count]]}}}]
+                                                     :dataset_query {:query {:source-table (str "card__" card1-id)}}}
+                       User          user           {:email "dirk@kirk.ir"}
+                       Collection    pcoll          {:name              "Personal Collection"
+                                                     :personal_owner_id (:id user)}
+                       Card          pcard          {:name          "Personal Card"
+                                                     :collection_id (:id pcoll)}
+                       Card          _              {:name          "External Card"
+                                                     :dataset_query {:query {:source-table (str "card__" (:id pcard))}}}
+                       Card          _              {:name          "Card with parameters"
+                                                     :collection_id coll3-id
+                                                     :parameters    [{:id                   "abc"
+                                                                      :type                 "category"
+                                                                      :values_source_type   "card"
+                                                                      :values_source_config {:card_id card1-id}}]}]
       (testing "Complain about card not available for exporting"
         (mt/with-log-messages-for-level [messages [metabase-enterprise :warn]]
           (extract/extract {:targets       [["Collection" coll1-id]]
@@ -1438,15 +1453,34 @@
                     (into #{}
                           (map :message)
                           (messages))))))
-      (testing "Complain about card depending on an outside card"
-        (mt/with-log-messages-for-level [messages [metabase-enterprise :warn]]
-          (extract/extract {:targets       [["Collection" coll2-id]]
-                            :no-settings   true
-                            :no-data-model true})
-          (is (some #(str/starts-with? % "Failed to export Cards")
-                    (into #{}
-                          (map :message)
-                          (messages)))))))))
+      (testing "Complain about card depending on an outside card: "
+        (testing "when its :source-table"
+          (mt/with-log-messages-for-level [messages [metabase-enterprise :warn]]
+            (extract/extract {:targets       [["Collection" coll2-id]]
+                              :no-settings   true
+                              :no-data-model true})
+            (is (some #(str/starts-with? % "Failed to export Cards")
+                      (into #{}
+                            (map :message)
+                            (messages))))))
+        (testing "when it's :parameters"
+          (mt/with-log-messages-for-level [messages [metabase-enterprise :warn]]
+            (extract/extract {:targets       [["Collection" coll2-id]]
+                              :no-settings   true
+                              :no-data-model true})
+            (is (some #(str/starts-with? % "Failed to export Cards")
+                      (into #{}
+                            (map :message)
+                            (messages)))))))
+      (testing "When exporting all collections"
+        (testing "Complain about dependents in personal collections"
+          (mt/with-log-messages-for-level [messages [metabase-enterprise :warn]]
+            (extract/extract {:no-settings   true
+                              :no-data-model true})
+            (is (some #(str/starts-with? % "Failed to export Cards")
+                      (into #{}
+                            (map :message)
+                            (messages))))))))))
 
 (deftest recursive-colls-test
   (mt/with-empty-h2-app-db

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -967,7 +967,7 @@
                                             :type          :query
                                             :dataset_query (mt/mbql-query users {:limit 1})
                                             :database_id   (:id db)})]
-            (reset! serialized (into [] (serdes.extract/extract {})))
+            (reset! serialized (into [] (serdes.extract/extract {:no-settings true})))
             (let [action-serialized (first (filter (fn [{[{:keys [model id]}] :serdes/meta}]
                                                      (and (= model "Action") (= id eid)))
                                                    @serialized))]

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/storage_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/storage_test.clj
@@ -106,7 +106,8 @@
                          NativeQuerySnippet c2          {:name "grandparent snippet" :collection_id (:id grandparent)}
                          NativeQuerySnippet c3          {:name "parent snippet" :collection_id (:id parent)}
                          NativeQuerySnippet c4          {:name "child snippet" :collection_id (:id child)}]
-        (let [export (into [] (extract/extract nil))]
+        (let [export (into [] (extract/extract {:no-settings   true
+                                                :no-data-model true}))]
           (storage/store! export dump-dir)
           (let [gp-dir (str (:entity_id grandparent) "_grandparent_collection")
                 p-dir  (str (:entity_id parent)      "_parent_collection")

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -893,17 +893,16 @@
         template-tags      (some->> card :dataset_query :native :template-tags vals (keep :card-id))
         parameters-card-id (some->> card :parameters (keep (comp :card_id :values_source_config)))
         snippets           (some->> card :dataset_query :native :template-tags vals (keep :snippet-id))]
-    (set
-     (concat
-      (when (and (string? source-table)
-                 (str/starts-with? source-table "card__"))
-        [["Card" (parse-long (subs source-table 6)) {"Card" id}]])
-      (for [card-id template-tags]
-        ["Card" card-id {"Card" id}])
-      (for [card-id parameters-card-id]
-        ["Card" card-id {"Card" id}])
-      (for [snippet-id snippets]
-        ["NativeQuerySnippet" snippet-id {"Card" id}])))))
+    (into {} (concat
+              (when (and (string? source-table)
+                         (str/starts-with? source-table "card__"))
+                {["Card" (parse-long (subs source-table 6))] {"Card" id}})
+              (for [card-id template-tags]
+                {["Card" card-id] {"Card" id}})
+              (for [card-id parameters-card-id]
+                {["Card" card-id] {"Card" id}})
+              (for [snippet-id snippets]
+                {["NativeQuerySnippet" snippet-id] {"Card" id}})))))
 
 ;;; ------------------------------------------------ Audit Log --------------------------------------------------------
 

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -897,13 +897,13 @@
      (concat
       (when (and (string? source-table)
                  (str/starts-with? source-table "card__"))
-        [["Card" (parse-long (subs source-table 6))]])
+        [["Card" (parse-long (subs source-table 6)) {"Card" id}]])
       (for [card-id template-tags]
-        ["Card" card-id])
+        ["Card" card-id {"Card" id}])
       (for [card-id parameters-card-id]
-        ["Card" card-id])
+        ["Card" card-id {"Card" id}])
       (for [snippet-id snippets]
-        ["NativeQuerySnippet" snippet-id])))))
+        ["NativeQuerySnippet" snippet-id {"Card" id}])))))
 
 ;;; ------------------------------------------------ Audit Log --------------------------------------------------------
 

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -1410,22 +1410,24 @@
   (when id
     (let [{:keys [location]} (t2/select-one :model/Collection :id id)]
       ;; it would work returning just one, but why not return all if it's cheap
-      (set (map vector (repeat "Collection") (location-path->ids location))))))
+      (into {} (for [parent-id (location-path->ids location)]
+                 {["Collection" parent-id] {"Collection" id}})))))
 
 (defmethod serdes/descendants "Collection" [_model-name id]
   (let [location    (when id (t2/select-one-fn :location Collection :id id))
-        child-colls (when id ;; (sanya) NOTE: I'm not sure we should not descend here, but it seems we did not before
-                      (set (for [child-id (t2/select-pks-set :model/Collection {:where [:and
-                                                                                        [:like :location (str location id "/%")]
-                                                                                        [:or
-                                                                                         [:not= :type trash-collection-type]
-                                                                                         [:= :type nil]]]})]
-                             ["Collection" child-id {"Collection" id}])))
-        dashboards  (set (for [dash-id (t2/select-pks-set :model/Dashboard {:where [:= :collection_id id]})]
-                           ["Dashboard" dash-id {"Collection" id}]))
-        cards       (set (for [card-id (t2/select-pks-set :model/Card {:where [:= :collection_id id]})]
-                           ["Card" card-id {"Collection" id}]))]
-    (set/union child-colls dashboards cards)))
+        child-colls (when id ; traversing root coll will return all (even personal) colls, do not do it
+                      (into {} (for [child-id (t2/select-pks-set :model/Collection
+                                                                 {:where [:and
+                                                                          [:= :location (str location id "/")]
+                                                                          [:or
+                                                                           [:not= :type trash-collection-type]
+                                                                           [:= :type nil]]]})]
+                                 {["Collection" child-id] {"Collection" id}})))
+        dashboards  (into {} (for [dash-id (t2/select-pks-set :model/Dashboard {:where [:= :collection_id id]})]
+                               {["Dashboard" dash-id] {"Collection" id}}))
+        cards       (into {} (for [card-id (t2/select-pks-set :model/Card {:where [:= :collection_id id]})]
+                               {["Card" card-id] {"Collection" id}}))]
+    (merge child-colls dashboards cards)))
 
 (defmethod serdes/storage-path "Collection" [coll {:keys [collections]}]
   (let [parental (get collections (:entity_id coll))]

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -1386,7 +1386,9 @@
       (t2/reducible-select Collection
                            {:where
                             [:and
-                             [:in :id collection-set]
+                             [:or
+                              [:in :id collection-set]
+                              (when (some nil? collection-set) [:= :id nil])]
                              not-trash-clause
                              (or where true)]})
       (t2/reducible-select Collection

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -616,31 +616,32 @@
                              :dashboard_id id)
         dashboard (t2/select-one Dashboard :id id)
         dash-id   id]
-    (set/union
+    (merge-with
+     merge
      ;; DashboardCards are inlined into Dashboards, but we need to capture what those those DashboardCards rely on
      ;; here. So their actions, and their cards both direct, mentioned in their parameters viz settings, and related
      ;; via dashboard card series.
-     (set (for [{:keys [id card_id parameter_mappings]} dashcards
-                ;; Capture all card_ids in the parameters, plus this dashcard's card_id if non-nil.
-                card-id (cond-> (set (keep :card_id parameter_mappings))
-                          card_id (conj card_id))]
-            ["Card" card-id {"DashboardCard" id "Dashboard" dash-id}]))
+     (into {} (for [{:keys [id card_id parameter_mappings]} dashcards
+                    ;; Capture all card_ids in the parameters, plus this dashcard's card_id if non-nil.
+                    card-id (cond-> (set (keep :card_id parameter_mappings))
+                              card_id (conj card_id))]
+                {["Card" card-id] {"DashboardCard" id "Dashboard" dash-id}}))
      (when (not-empty dashcards)
-       (set (for [{:keys [id card_id dashboardcard_id]} (t2/select [:model/DashboardCardSeries :id :card_id :dashboardcard_id]
-                                                                   :dashboardcard_id [:in (map :id dashcards)])]
-              ["Card" card_id {"DashboardCardSeries" id
-                               "DashboardCard"       dashboardcard_id
-                               "Dashboard"           dash-id}])))
-     (set (for [{:keys [id action_id]} dashcards
-                :when action_id]
-            ["Action" action_id {"DashboardCard" id
-                                 "Dashboard"     dash-id}]))
-     (reduce set/union #{}
-             (for [dc dashcards]
-               (serdes/visualization-settings-descendants (:visualization_settings dc))))
+       (into {} (for [{:keys [id card_id dashboardcard_id]} (t2/select [:model/DashboardCardSeries :id :card_id :dashboardcard_id]
+                                                                       :dashboardcard_id [:in (map :id dashcards)])]
+                  {["Card" card_id] {"DashboardCardSeries" id
+                                     "DashboardCard"       dashboardcard_id
+                                     "Dashboard"           dash-id}})))
+     (into {} (for [{:keys [id action_id]} dashcards
+                    :when action_id]
+                {["Action" action_id] {"DashboardCard" id
+                                       "Dashboard"     dash-id}}))
+     (into {} (for [dc dashcards]
+                (serdes/visualization-settings-descendants (:visualization_settings dc) {"DashboardCard" id
+                                                                                         "Dashboard"     dash-id})))
      ;; parameter with values_source_type = "card" will depend on a card
-     (set (for [card-id (some->> dashboard :parameters (keep (comp :card_id :values_source_config)))]
-            ["Card" card-id {"Dashboard" dash-id}])))))
+     (into {} (for [card-id (some->> dashboard :parameters (keep (comp :card_id :values_source_config)))]
+                {["Card" card-id] {"Dashboard" dash-id}})))))
 
 ;;; ------------------------------------------------ Audit Log --------------------------------------------------------
 

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -513,8 +513,8 @@
       nested? (extract-reducible-nested model-name (dissoc opts :where)))))
 
 (defmulti descendants
-  "Returns set of `[model-name database-id]` pairs for all entities contained or used by this entity. e.g. the Dashboard
-   implementation should return pairs for all DashboardCard entities it contains, etc.
+  "Returns set of `[model-name database-id {initiating-model id}]` pairs for all entities contained or used by this
+   entity. e.g. the Dashboard implementation should return pairs for all DashboardCard entities it contains, etc.
 
    Dispatched on model-name."
   {:arglists '([model-name db-id])}

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -501,7 +501,7 @@
       (t2/reducible-select model {:where [:and
                                           [:or
                                            [:in :collection_id collection-set]
-                                           (when (contains? collection-set nil)
+                                           (when (some nil? collection-set)
                                              [:= :collection_id nil])]
                                           (when where
                                             where)]}))))

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -662,7 +662,7 @@
                    :model/Card card2 {:name "derived card"
                                       :dataset_query {:query {:source-table (str "card__" (:id card1))}}}]
       (is (empty? (serdes/descendants "Card" (:id card1))))
-      (is (= #{["Card" (:id card1)]}
+      (is (= #{["Card" (:id card1) {"Card" (:id card2)}]}
              (serdes/descendants "Card" (:id card2)))))))
 
 (deftest ^:parallel descendants-test-3
@@ -676,7 +676,7 @@
                                                                :snippet-name "snippet"
                                                                :snippet-id   (:id snippet)}}
                                      :query "select * from products where {{snippet}}"}}}]
-      (is (= #{["NativeQuerySnippet" (:id snippet)]}
+      (is (= #{["NativeQuerySnippet" (:id snippet) {"Card" (:id card)}]}
              (serdes/descendants "Card" (:id card)))))))
 
 (deftest ^:parallel descendants-test-4
@@ -687,7 +687,7 @@
                                                     :type                 "id"
                                                     :values_source_type   "card"
                                                     :values_source_config {:card_id (:id card1)}}]}]
-      (is (= #{["Card" (:id card1)]}
+      (is (= #{["Card" (:id card1) {"Card" (:id card2)}]}
              (serdes/descendants "Card" (:id card2)))))))
 
 (deftest ^:parallel extract-test

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -662,7 +662,7 @@
                    :model/Card card2 {:name "derived card"
                                       :dataset_query {:query {:source-table (str "card__" (:id card1))}}}]
       (is (empty? (serdes/descendants "Card" (:id card1))))
-      (is (= #{["Card" (:id card1) {"Card" (:id card2)}]}
+      (is (= {["Card" (:id card1)] {"Card" (:id card2)}}
              (serdes/descendants "Card" (:id card2)))))))
 
 (deftest ^:parallel descendants-test-3
@@ -676,7 +676,7 @@
                                                                :snippet-name "snippet"
                                                                :snippet-id   (:id snippet)}}
                                      :query "select * from products where {{snippet}}"}}}]
-      (is (= #{["NativeQuerySnippet" (:id snippet) {"Card" (:id card)}]}
+      (is (= {["NativeQuerySnippet" (:id snippet)] {"Card" (:id card)}}
              (serdes/descendants "Card" (:id card)))))))
 
 (deftest ^:parallel descendants-test-4
@@ -687,7 +687,7 @@
                                                     :type                 "id"
                                                     :values_source_type   "card"
                                                     :values_source_config {:card_id (:id card1)}}]}]
-      (is (= #{["Card" (:id card1) {"Card" (:id card2)}]}
+      (is (= {["Card" (:id card1)] {"Card" (:id card2)}}
              (serdes/descendants "Card" (:id card2)))))))
 
 (deftest ^:parallel extract-test

--- a/test/metabase/models/dashboard_test.clj
+++ b/test/metabase/models/dashboard_test.clj
@@ -1011,7 +1011,7 @@
                                           :values_source_type   "card"
                                           :values_source_config {:card_id     (:id card)
                                                                  :value_field [:field (:id field) nil]}}]}]
-      (is (= #{["Card" (:id card) {"Dashboard" (:id dashboard)}]}
+      (is (= {["Card" (:id card)] {"Dashboard" (:id dashboard)}}
              (serdes/descendants "Dashboard" (:id dashboard))))))
 
   (testing "dashboard which has a dashcard with an action"
@@ -1021,8 +1021,8 @@
          DashboardCard dc        {:action_id          action-id
                                   :dashboard_id       (:id dashboard)
                                   :parameter_mappings []}]
-        (is (= #{["Action" action-id {"Dashboard"     (:id dashboard)
-                                      "DashboardCard" (:id dc)}]}
+        (is (= {["Action" action-id] {"Dashboard"     (:id dashboard)
+                                      "DashboardCard" (:id dc)}}
                (serdes/descendants "Dashboard" (:id dashboard)))))))
 
   (testing "dashboard in which its dashcards has parameter_mappings to a card"
@@ -1038,10 +1038,10 @@
                                 :parameter_mappings [{:parameter_id "_CATEGORY_NAME_"
                                                       :card_id      (:id card2)
                                                       :target       [:dimension (mt/$ids $categories.name)]}]}]
-      (is (= #{["Card" (:id card1) {"Dashboard"     (:id dashboard)
-                                    "DashboardCard" (:id dc)}]
-               ["Card" (:id card2) {"Dashboard"     (:id dashboard)
-                                    "DashboardCard" (:id dc)}]}
+      (is (= {["Card" (:id card1)] {"Dashboard"     (:id dashboard)
+                                    "DashboardCard" (:id dc)}
+              ["Card" (:id card2)] {"Dashboard"     (:id dashboard)
+                                    "DashboardCard" (:id dc)}}
              (serdes/descendants "Dashboard" (:id dashboard))))))
 
   (testing "dashboard in which its dashcards have series"
@@ -1056,10 +1056,10 @@
        DashboardCard       dashcard {:card_id (:id card1), :dashboard_id (:id dashboard)}
        DashboardCardSeries s2       {:dashboardcard_id (:id dashcard), :card_id (:id card2), :position 0}
        DashboardCardSeries s3       {:dashboardcard_id (:id dashcard), :card_id (:id card3), :position 1}]
-      (is (= (set (for [[card series] [[card1 nil] [card2 s2] [card3 s3]]]
-                    ["Card" (:id card) (cond-> {"Dashboard"           (:id dashboard)
-                                                "DashboardCard"       (:id dashcard)}
-                                         series (assoc "DashboardCardSeries" (:id series)))]))
+      (is (= (into {} (for [[card series] [[card1 nil] [card2 s2] [card3 s3]]]
+                        [["Card" (:id card)] (cond-> {"Dashboard"           (:id dashboard)
+                                                      "DashboardCard"       (:id dashcard)}
+                                               series (assoc "DashboardCardSeries" (:id series)))]))
              (serdes/descendants "Dashboard" (:id dashboard)))))))
 
 (deftest ^:parallel hydrate-tabs-test

--- a/test/metabase/models/dashboard_test.clj
+++ b/test/metabase/models/dashboard_test.clj
@@ -1006,22 +1006,23 @@
       [Field     field     {:name "A field"}
        Card      card      {:name "A card"}
        Dashboard dashboard {:name       "A dashboard"
-                            :parameters [{:id "abc"
-                                          :type "category"
-                                          :values_source_type "card"
+                            :parameters [{:id                   "abc"
+                                          :type                 "category"
+                                          :values_source_type   "card"
                                           :values_source_config {:card_id     (:id card)
                                                                  :value_field [:field (:id field) nil]}}]}]
-      (is (= #{["Card" (:id card)]}
+      (is (= #{["Card" (:id card) {"Dashboard" (:id dashboard)}]}
              (serdes/descendants "Dashboard" (:id dashboard))))))
 
   (testing "dashboard which has a dashcard with an action"
     (mt/with-actions [{:keys [action-id]} {}]
       (mt/with-temp
-        [Dashboard dashboard {:name "A dashboard"}
-         DashboardCard _ {:action_id          action-id
-                          :dashboard_id       (:id dashboard)
-                          :parameter_mappings []}]
-        (is (= #{["Action" action-id]}
+        [Dashboard     dashboard {:name "A dashboard"}
+         DashboardCard dc        {:action_id          action-id
+                                  :dashboard_id       (:id dashboard)
+                                  :parameter_mappings []}]
+        (is (= #{["Action" action-id {"Dashboard"     (:id dashboard)
+                                      "DashboardCard" (:id dc)}]}
                (serdes/descendants "Dashboard" (:id dashboard)))))))
 
   (testing "dashboard in which its dashcards has parameter_mappings to a card"
@@ -1032,13 +1033,15 @@
                                               :slug "category_name"
                                               :id   "_CATEGORY_NAME_"
                                               :type "category"}]}
-       DashboardCard _         {:card_id            (:id card1)
+       DashboardCard dc        {:card_id            (:id card1)
                                 :dashboard_id       (:id dashboard)
                                 :parameter_mappings [{:parameter_id "_CATEGORY_NAME_"
                                                       :card_id      (:id card2)
                                                       :target       [:dimension (mt/$ids $categories.name)]}]}]
-      (is (= #{["Card" (:id card1)]
-               ["Card" (:id card2)]}
+      (is (= #{["Card" (:id card1) {"Dashboard"     (:id dashboard)
+                                    "DashboardCard" (:id dc)}]
+               ["Card" (:id card2) {"Dashboard"     (:id dashboard)
+                                    "DashboardCard" (:id dc)}]}
              (serdes/descendants "Dashboard" (:id dashboard))))))
 
   (testing "dashboard in which its dashcards have series"
@@ -1051,10 +1054,12 @@
                                                     :id   "_CATEGORY_NAME_"
                                                     :type "category"}]}
        DashboardCard       dashcard {:card_id (:id card1), :dashboard_id (:id dashboard)}
-       DashboardCardSeries _        {:dashboardcard_id (:id dashcard), :card_id (:id card2), :position 0}
-       DashboardCardSeries _        {:dashboardcard_id (:id dashcard), :card_id (:id card3), :position 1}]
-      (is (= (set (for [card [card1 card2 card3]]
-                    ["Card" (:id card)]))
+       DashboardCardSeries s2       {:dashboardcard_id (:id dashcard), :card_id (:id card2), :position 0}
+       DashboardCardSeries s3       {:dashboardcard_id (:id dashcard), :card_id (:id card3), :position 1}]
+      (is (= (set (for [[card series] [[card1 nil] [card2 s2] [card3 s3]]]
+                    ["Card" (:id card) (cond-> {"Dashboard"           (:id dashboard)
+                                                "DashboardCard"       (:id dashcard)}
+                                         series (assoc "DashboardCardSeries" (:id series)))]))
              (serdes/descendants "Dashboard" (:id dashboard)))))))
 
 (deftest ^:parallel hydrate-tabs-test


### PR DESCRIPTION
Fixes #47991 

Combines two paths of serialization we had before (`extract-metabase` and `extract-subtrees`) into a single one, so that `escape-analysis` is always checked. Also contains rewrite of `escape-analysis` to reduce the number of queries in an attempt to lessen the slowdown of full export.

@bshepherdson asking for your review just because my serialization-reviewing teammate is ooo for 1.5 weeks :)

----

*Timings for the full export*

On my laptop for stats db after a few runs
Old way: 256s
New way: 278s

This is a 9% slowdown, which I think is acceptable to make it more correct. It's not very scientific though as it fluctuates from 200 to 250s. 🤯 Also partial exports are a bit faster, since those had escape analysis anyways and now it makes less requests to the database.