### PR TITLE
Point to a solution when the "Unknown premium setting xxx" is shown during tests

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/settings/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/settings/index.ts
@@ -1,11 +1,17 @@
 import { hasAnySsoFeature } from "metabase/common/utils/plan";
+import { isTest } from "metabase/env";
 import MetabaseSettings from "metabase/lib/settings";
 import type { TokenFeature } from "metabase-types/api";
 
 export function hasPremiumFeature(feature: TokenFeature) {
   const hasFeature = MetabaseSettings.get("token-features")?.[feature];
   if (hasFeature == null) {
-    console.warn("Unknown premium feature", feature);
+    console.warn(
+      `Unknown premium feature: '${feature}'.`,
+      isTest
+        ? "\nDid you forget to use `mockSettings` instead of `createMockSettings` when testing paid features?"
+        : "",
+    );
   }
   return hasFeature;
 }

--- a/frontend/test/__support__/settings.ts
+++ b/frontend/test/__support__/settings.ts
@@ -4,6 +4,10 @@ import type { Settings } from "metabase-types/api";
 import { createMockSettings } from "metabase-types/api/mocks";
 import { createMockSettingsState } from "metabase-types/store/mocks";
 
+/**
+ * This function mocks the settings also in MetabaseSettings,
+ * without that, you'll get the annoying "Unknown premium feature xxx" warning.
+ */
 export function mockSettings(
   params: Partial<Settings | EnterpriseSettings> = {},
 ) {


### PR DESCRIPTION
# Demo
<img width="1249" alt="image" src="https://github.com/user-attachments/assets/334f01a4-e6a3-4130-958c-ee8d8dbaa21d">

This warning easily fills the entire terminal when running jest tests, at the same time I only found out what the cause was after months of being here, I wouldn't be surprise if a lot of people don't know they're supposed to use `mockSettings`

This PR adds a suggestion when the warning shows up during tests, guiding the developer make the right thing