### PR TITLE
Always startup prometheus metrics

### DIFF
--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -5,7 +5,6 @@
 
   Api is quite simple: [[setup!]] and [[shutdown!]]. After that you can retrieve metrics from
   http://localhost:<prometheus-server-port>/metrics."
-  (:refer-clojure :exclude [inc])
   (:require
    [clojure.java.jmx :as jmx]
    [iapetos.collector :as collector]
@@ -253,7 +252,7 @@
              (catch Exception e
                (log/warn e "Error stopping prometheus web-server")))))))
 
-(defn inc
+(defn inc!
   "Call iapetos.core/inc on the metric in the global registry,
    if it has already been initialized and the metric is registered."
   [metric]

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -126,10 +126,9 @@
 
   (init-status/set-progress! 0.5)
   ;; Set up Prometheus
-  (when (prometheus/prometheus-server-port)
-    (log/info "Setting up prometheus metrics")
-    (prometheus/setup!)
-    (init-status/set-progress! 0.6))
+  (log/info "Setting up prometheus metrics")
+  (prometheus/setup!)
+  (init-status/set-progress! 0.6)
 
   (premium-features/airgap-check-user-count)
   (init-status/set-progress! 0.65)

--- a/src/metabase/email.clj
+++ b/src/metabase/email.clj
@@ -175,11 +175,11 @@
                     (when-let [reply-to (email-reply-to)]
                       {:reply-to reply-to}))))
     (catch Throwable e
-      (prometheus/inc :metabase-email/message-errors)
+      (prometheus/inc! :metabase-email/message-errors)
       (when (not= :smtp-host-not-set (:cause (ex-data e)))
         (throw e)))
     (finally
-      (prometheus/inc :metabase-email/messages))))
+      (prometheus/inc! :metabase-email/messages))))
 
 (mu/defn send-email-retrying!
   "Like [[send-message-or-throw!]] but retries sending on errors according to the retry settings."

--- a/test/metabase/analytics/prometheus_test.clj
+++ b/test/metabase/analytics/prometheus_test.clj
@@ -166,11 +166,11 @@
 
 (deftest inc-test
   (testing "inc has no effect if system is not setup"
-    (prometheus/inc :metabase-email/messages)) ; << Does not throw.
+    (prometheus/inc! :metabase-email/messages)) ; << Does not throw.
   (testing "inc has no effect when called with unknown metric"
     (with-prometheus-system! [_ _system]
-      (prometheus/inc :metabase-email/unknown-metric))) ; << Does not throw.
+      (prometheus/inc! :metabase-email/unknown-metric))) ; << Does not throw.
   (testing "inc is recorded for known metrics"
     (with-prometheus-system! [_ system]
-      (prometheus/inc :metabase-email/messages)
+      (prometheus/inc! :metabase-email/messages)
       (is (< 0 (-> system :registry :metabase-email/messages ops/read-value))))))

--- a/test/metabase/email_test.clj
+++ b/test/metabase/email_test.clj
@@ -270,7 +270,7 @@
              (@inbox "test@test.com")))))
     (testing "metrics collection"
       (let [calls (atom nil)]
-        (with-redefs [prometheus/inc #(swap! calls conj %)]
+        (with-redefs [prometheus/inc! #(swap! calls conj %)]
           (with-fake-inbox
             (email/send-message!
              :subject      "101 Reasons to use Metabase"
@@ -285,7 +285,7 @@
                                 :max-attempts 1
                                 :initial-interval-millis 1)
             test-retry   (retry/random-exponential-backoff-retry "test-retry" retry-config)]
-        (with-redefs [prometheus/inc    #(swap! calls conj %)
+        (with-redefs [prometheus/inc!   #(swap! calls conj %)
                       retry/decorate    (rt/test-retry-decorate-fn test-retry)
                       email/send-email! (fn [_ _] (throw (Exception. "test-exception")))]
           (email/send-message!


### PR DESCRIPTION
previously only started up when a port was provided

```
MB_PROMETHEUS_SERVER_PORT=9191 java -jar metabase.jar
```

But these counters are useful to be included in anonymous stats. So let's start up the collectors and then we can get their values like:

```clojure
prometheus=> (dotimes [_ 500] (inc :metabase-email/messages))
nil
;; prometheus/value is iapetos.core/value here
prometheus=> (-> system :registry :metabase-email/messages prometheus/value)
501.0
```
 and at startup

```
2024-10-09 20:49:35,543 INFO metabase.core :: Setting up prometheus metrics
2024-10-09 20:49:35,544 INFO analytics.prometheus :: Running prometheus metrics without a webserver.
2024-10-09 20:49:35,544 INFO analytics.prometheus :: Starting prometheus metrics collector
```