### PR TITLE
fix flakiness during resize

### DIFF
--- a/e2e/support/helpers/e2e-ui-elements-overflow-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-overflow-helpers.js
@@ -34,10 +34,18 @@ export const assertDescendantNotOverflowsContainer = (
     return;
   }
 
-  cy.wrap(descendantRect.bottom).should("be.lte", containerRect.bottom);
-  cy.wrap(descendantRect.top).should("be.gte", containerRect.top);
-  cy.wrap(descendantRect.left).should("be.gte", containerRect.left);
-  cy.wrap(descendantRect.right).should("be.lte", containerRect.right);
+  cy.wrap(descendantRect).should($descendantRect => {
+    expect($descendantRect.bottom, `${message} bottom`).to.be.lte(
+      containerRect.bottom,
+    );
+    expect($descendantRect.top, `${message} top`).to.be.gte(containerRect.top);
+    expect($descendantRect.left, `${message} left`).to.be.gte(
+      containerRect.left,
+    );
+    expect($descendantRect.right, `${message} right`).to.be.lte(
+      containerRect.right,
+    );
+  });
 };
 
 export const assertIsEllipsified = element => {

--- a/e2e/support/helpers/e2e-ui-elements-overflow-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-overflow-helpers.js
@@ -34,14 +34,10 @@ export const assertDescendantNotOverflowsContainer = (
     return;
   }
 
-  expect(descendantRect.bottom, `${message} bottom`).to.be.lte(
-    containerRect.bottom,
-  );
-  expect(descendantRect.top, `${message} top`).to.be.gte(containerRect.top);
-  expect(descendantRect.left, `${message} left`).to.be.gte(containerRect.left);
-  expect(descendantRect.right, `${message} right`).to.be.lte(
-    containerRect.right,
-  );
+  cy.wrap(descendantRect.bottom).should("be.lte", containerRect.bottom);
+  cy.wrap(descendantRect.top).should("be.gte", containerRect.top);
+  cy.wrap(descendantRect.left).should("be.gte", containerRect.left);
+  cy.wrap(descendantRect.right).should("be.lte", containerRect.right);
 };
 
 export const assertIsEllipsified = element => {


### PR DESCRIPTION
`should` retries, `expect` doesn't retry and resizing is always flaky, so we have to retry

stress test https://github.com/metabase/metabase/actions/runs/11273383328/job/31350278141

it ran too many tests and failed because of that but all the tests we're interested in (1280*800, 2 high cells) passed

example of a failing job https://github.com/metabase/metabase/actions/runs/11272842062/job/31350486802