### PR TITLE
 Repro: App crashes when editing custom expression referencing metric when dependent metadata is not loaded

### DIFF
--- a/e2e/test/scenarios/metrics/reproductions/metrics-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/reproductions/metrics-reproductions.cy.spec.ts
@@ -1,0 +1,45 @@
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { createQuestion, restore } from "e2e/support/helpers";
+
+const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
+
+describe("issue 47058", () => {
+  it("should show the loading page while the question metadata is being fetched (metabase#47058)", () => {
+    restore();
+    cy.signInAsNormalUser();
+    cy.intercept("GET", "/api/card/*/query_metadata").as("metadata");
+
+    createQuestion({
+      name: "Metric 47058",
+      type: "metric",
+      query: {
+        "source-table": ORDERS_ID,
+        aggregation: [["count"]],
+      },
+    }).then(({ body: { id: metricId } }) => {
+      createQuestion({
+        name: "Question 47058",
+        type: "question",
+        query: {
+          "source-table": ORDERS_ID,
+          fields: [
+            ["field", ORDERS.ID, {}],
+            ["field", ORDERS.TOTAL, {}],
+          ],
+          aggregation: [["metric", metricId]],
+          limit: 1,
+        },
+      }).then(({ body: { id: questionId, name } }) => {
+        cy.visit(`/question/${questionId}/notebook`);
+
+        cy.findByText("Loading...").should("be.visible");
+        cy.findByText(name).should("not.exist");
+
+        // Only render the notebook editor after the metadata is loaded
+        cy.wait("@metadata");
+        cy.findByText("Loading...").should("not.exist");
+        cy.findByText(name).should("be.visible");
+      });
+    });
+  });
+});

--- a/e2e/test/scenarios/metrics/reproductions/metrics-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/reproductions/metrics-reproductions.cy.spec.ts
@@ -1,10 +1,15 @@
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { createQuestion, restore } from "e2e/support/helpers";
+import {
+  createQuestion,
+  getNotebookStep,
+  main,
+  restore,
+} from "e2e/support/helpers";
 
 const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
 
 describe("issue 47058", () => {
-  it("should show the loading page while the question metadata is being fetched (metabase#47058)", () => {
+  before(() => {
     restore();
     cy.signInAsNormalUser();
     cy.intercept("GET", "/api/card/*/query_metadata", req =>
@@ -18,7 +23,7 @@ describe("issue 47058", () => {
         "source-table": ORDERS_ID,
         aggregation: [["count"]],
       },
-    }).then(({ body: { id: metricId, name: metricName } }) => {
+    }).then(({ body: { id: metricId } }) => {
       createQuestion({
         name: "Question 47058",
         type: "question",
@@ -33,20 +38,26 @@ describe("issue 47058", () => {
         },
       }).then(({ body: { id: questionId } }) => {
         cy.visit(`/question/${questionId}/notebook`);
-
-        cy.findByText("Loading...").should("be.visible");
-        cy.findByText(metricName).should("not.exist");
-        cy.findByText("[Unknown Metric]").should("not.exist");
-
-        cy.wait("@metadata");
-        cy.log(
-          "Only renders the notebook editor (with the summarize button that has the metrics' name on it) after the metadata is loaded",
-        );
-
-        cy.findByText("Loading...").should("not.exist");
-        cy.findByText("[Unknown Metric]").should("not.exist");
-        cy.findByText(metricName).should("be.visible");
       });
+    });
+  });
+
+  it("should show the loading page while the question metadata is being fetched (metabase#47058)", () => {
+    main().within(() => {
+      cy.findByText("Loading...").should("be.visible");
+      getNotebookStep("summarize").should("not.exist");
+
+      cy.findByText("[Unknown Metric]").should("not.exist");
+
+      cy.wait("@metadata");
+      cy.log(
+        "Only renders the notebook editor (with the summarize button that has the metrics' name on it) after the metadata is loaded",
+      );
+
+      cy.findByText("Loading...").should("not.exist");
+      getNotebookStep("summarize").should("be.visible");
+
+      cy.findByText("[Unknown Metric]").should("not.exist");
     });
   });
 });

--- a/e2e/test/scenarios/metrics/reproductions/metrics-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/reproductions/metrics-reproductions.cy.spec.ts
@@ -9,7 +9,7 @@ import {
 const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
 
 describe("issue 47058", () => {
-  before(() => {
+  beforeEach(() => {
     restore();
     cy.signInAsNormalUser();
     cy.intercept("GET", "/api/card/*/query_metadata", req =>


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/47058

Adds a "reproduction" for #47058 which is now fixed because the notebook editor renders a loading indicator when the metadata has not been loaded yet, so the race condition no longer exists.

It's not a real reproduction since the issue no longer exists really, but it tests that the conditions for the issue no longer exist.

[Stress test](https://github.com/metabase/metabase/actions/runs/11288376305)