### PR TITLE
Rename ResizeObserver variable to prevent global clash

### DIFF
--- a/frontend/src/metabase/lib/resize-observer.ts
+++ b/frontend/src/metabase/lib/resize-observer.ts
@@ -14,7 +14,7 @@ type ResizeObserverCallback = (
 // This comes with some tradeoffs. On the SDK, there will be issues with scalars
 // not rendering properly on the first render, as we rely on rapid resize observer
 // updates to resize the text.
-const ResizeObserver = process.env.IS_EMBEDDING_SDK
+const ResizeObserverImpl = process.env.IS_EMBEDDING_SDK
   ? JuggleResizeObserver
   : window.ResizeObserver;
 
@@ -28,7 +28,7 @@ function createResizeObserver() {
     });
   }
 
-  const observer = new ResizeObserver(handler);
+  const observer = new ResizeObserverImpl(handler);
 
   return {
     observer,


### PR DESCRIPTION
@npretto mentioned that we should rename the `ResizeObserver` const to something else, since there is the possibility that the const name could clash with the global of the same name.

Let's make sure that doesn't happen, we have better things to do.