### PR TITLE
adding snowplow event for archiving stale items

### DIFF
--- a/e2e/test/scenarios/collections/cleanup.cy.spec.js
+++ b/e2e/test/scenarios/collections/cleanup.cy.spec.js
@@ -1,15 +1,23 @@
 import { SAMPLE_DB_TABLES } from "e2e/support/cypress_data";
 const { STATIC_ORDERS_ID } = SAMPLE_DB_TABLES;
-import { FIRST_COLLECTION_ID } from "e2e/support/cypress_sample_instance_data";
+import {
+  FIRST_COLLECTION_ID,
+  ORDERS_QUESTION_ID,
+} from "e2e/support/cypress_sample_instance_data";
 import {
   createCollection,
   describeEE,
+  describeWithSnowplowEE,
+  enableTracking,
+  expectGoodSnowplowEvent,
+  expectNoBadSnowplowEvents,
   getCollectionActions,
   main,
   modal,
   navigationSidebar,
   onlyOnOSS,
   popover,
+  resetSnowplow,
   restore,
   setTokenFeatures,
   undo,
@@ -88,10 +96,16 @@ describe("scenarios > collections > clean up", () => {
     });
   });
 
-  describeEE("clean up collection modal", () => {
+  describeWithSnowplowEE("clean up collection modal", () => {
     beforeEach(() => {
+      resetSnowplow();
       cy.signInAsAdmin();
       setTokenFeatures("all");
+      enableTracking();
+    });
+
+    afterEach(() => {
+      expectNoBadSnowplowEvents();
     });
 
     it("should be able to clean up stale items", () => {
@@ -174,6 +188,18 @@ describe("scenarios > collections > clean up", () => {
         moveToTrash();
         assertNoPagination();
 
+        // Because cutoff_date will be relative to the current date, we simply check
+        // that it exists and is a string. Snowplow will assert that it is in the correct
+        // format
+        expectGoodSnowplowEvent(
+          event =>
+            event &&
+            event.event === "stale_items_archived" &&
+            event.collection_id === seedData.collection.id &&
+            event.total_stale_items_found === 10 &&
+            typeof event.cutoff_date === "string",
+        );
+
         undo();
         assertStaleItemCount(seedData.totalStaleItemCount);
 
@@ -198,6 +224,25 @@ describe("scenarios > collections > clean up", () => {
               1, // header row
           );
         });
+
+        makeItemStale(ORDERS_QUESTION_ID, "card");
+
+        cy.findByRole("navigation").findByText("Our analytics").click();
+        selectCleanThingsUpCollectionAction();
+        cy.url().should("include", "cleanup");
+
+        selectAllItems();
+        moveToTrash();
+
+        // Ensure that stale items in Our Analytics are maked with a null collection id
+        expectGoodSnowplowEvent(
+          event =>
+            event &&
+            event.event === "stale_items_archived" &&
+            event.collection_id === null &&
+            event.total_stale_items_found === 1 &&
+            typeof event.cutoff_date === "string",
+        );
       });
     });
 

--- a/e2e/test/scenarios/collections/cleanup.cy.spec.js
+++ b/e2e/test/scenarios/collections/cleanup.cy.spec.js
@@ -196,7 +196,7 @@ describe("scenarios > collections > clean up", () => {
             event &&
             event.event === "stale_items_archived" &&
             event.collection_id === seedData.collection.id &&
-            event.total_stale_items_found === 10 &&
+            event.total_items_archived === 10 &&
             typeof event.cutoff_date === "string",
         );
 
@@ -240,7 +240,7 @@ describe("scenarios > collections > clean up", () => {
             event &&
             event.event === "stale_items_archived" &&
             event.collection_id === null &&
-            event.total_stale_items_found === 1 &&
+            event.total_items_archived === 1 &&
             typeof event.cutoff_date === "string",
         );
       });

--- a/enterprise/frontend/src/metabase-enterprise/clean_up/CleanupCollectionModal/CleanupCollectionBulkActions.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/clean_up/CleanupCollectionModal/CleanupCollectionBulkActions.tsx
@@ -16,12 +16,14 @@ interface CleanupCollectionBulkActionsProps {
   selected: CollectionItem[];
   clearSelectedItem: () => void;
   resetPagination: () => void;
+  onArchive: ({ totalArchivedItems }: { totalArchivedItems: number }) => void;
 }
 
 export const CleanupCollectionBulkActions = ({
   selected,
   clearSelectedItem,
   resetPagination,
+  onArchive,
 }: CleanupCollectionBulkActionsProps) => {
   const [undo, setUndo] = useState<Undo | undefined>();
 
@@ -41,6 +43,7 @@ export const CleanupCollectionBulkActions = ({
     Promise.all(actions)
       .then(() => {
         resetPagination();
+        onArchive({ totalArchivedItems: selected.length });
 
         const id = Date.now();
         const timeoutId = setTimeout(() => {

--- a/enterprise/frontend/src/metabase-enterprise/clean_up/CleanupCollectionModal/CleanupCollectionModal.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/clean_up/CleanupCollectionModal/CleanupCollectionModal.module.css
@@ -11,7 +11,7 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .modalFooter {

--- a/enterprise/frontend/src/metabase-enterprise/clean_up/CleanupCollectionModal/CleanupCollectionModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/clean_up/CleanupCollectionModal/CleanupCollectionModal.tsx
@@ -14,6 +14,7 @@ import { Flex, Modal } from "metabase/ui";
 import { useListStaleCollectionItemsQuery } from "metabase-enterprise/api/collection";
 import { SortDirection, type SortingOptions } from "metabase-types/api/sorting";
 
+import { trackStaleItemsArchived } from "../analytics";
 import type { StaleCollectionItem } from "../types";
 
 import { CleanupCollectionBulkActions } from "./CleanupCollectionBulkActions";
@@ -113,6 +114,22 @@ const _CleanupCollectionModal = ({
     setTotal(total);
   }, [setTotal, total]);
 
+  const handleOnArchive = ({
+    totalArchivedItems,
+  }: {
+    totalArchivedItems: number;
+  }) => {
+    // In theory if we should only get numbers or root bad for a collection id
+    // if we are dealing with Our Analytics / root, set collection_id to null
+    if (typeof collectionId === "number" || collectionId === "root") {
+      trackStaleItemsArchived({
+        collection_id: collectionId === "root" ? null : collectionId,
+        total_stale_items_found: totalArchivedItems,
+        cutoff_date: new Date(before_date).toISOString(),
+      });
+    }
+  };
+
   return (
     <Modal.Root
       opened
@@ -186,6 +203,7 @@ const _CleanupCollectionModal = ({
           selected={selection.selected}
           clearSelectedItem={selection.clear}
           resetPagination={pagination.resetPage}
+          onArchive={handleOnArchive}
         />
       </Modal.Content>
     </Modal.Root>

--- a/enterprise/frontend/src/metabase-enterprise/clean_up/CleanupCollectionModal/CleanupCollectionModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/clean_up/CleanupCollectionModal/CleanupCollectionModal.tsx
@@ -124,7 +124,7 @@ const _CleanupCollectionModal = ({
     if (typeof collectionId === "number" || collectionId === "root") {
       trackStaleItemsArchived({
         collection_id: collectionId === "root" ? null : collectionId,
-        total_stale_items_found: totalArchivedItems,
+        total_items_archived: totalArchivedItems,
         cutoff_date: new Date(before_date).toISOString(),
       });
     }

--- a/enterprise/frontend/src/metabase-enterprise/clean_up/analytics.ts
+++ b/enterprise/frontend/src/metabase-enterprise/clean_up/analytics.ts
@@ -3,17 +3,17 @@ import type { RegularCollectionId } from "metabase-types/api";
 
 export const trackStaleItemsArchived = ({
   collection_id,
-  total_stale_items_found,
+  total_items_archived,
   cutoff_date,
 }: {
   collection_id: RegularCollectionId | null;
-  total_stale_items_found: number;
+  total_items_archived: number;
   cutoff_date: string;
 }) => {
   trackSchemaEvent("cleanup", {
     event: "stale_items_archived",
     collection_id,
-    total_stale_items_found,
+    total_items_archived,
     cutoff_date,
   });
 };

--- a/enterprise/frontend/src/metabase-enterprise/clean_up/analytics.ts
+++ b/enterprise/frontend/src/metabase-enterprise/clean_up/analytics.ts
@@ -1,0 +1,19 @@
+import { trackSchemaEvent } from "metabase/lib/analytics";
+import type { RegularCollectionId } from "metabase-types/api";
+
+export const trackStaleItemsArchived = ({
+  collection_id,
+  total_stale_items_found,
+  cutoff_date,
+}: {
+  collection_id: RegularCollectionId | null;
+  total_stale_items_found: number;
+  cutoff_date: string;
+}) => {
+  trackSchemaEvent("cleanup", {
+    event: "stale_items_archived",
+    collection_id,
+    total_stale_items_found,
+    cutoff_date,
+  });
+};

--- a/frontend/src/metabase-types/analytics/cleanup.ts
+++ b/frontend/src/metabase-types/analytics/cleanup.ts
@@ -17,4 +17,11 @@ export type StaleItemsReadEvent = ValidateEvent<{
   cutoff_date: string;
 }>;
 
-export type CleanupEvent = StaleItemsReadEvent;
+export type StaleItemsArchivedEvent = ValidateEvent<{
+  event: "stale_items_archived";
+  collection_id: number | null;
+  total_stale_items_found: number;
+  cutoff_date: string;
+}>;
+
+export type CleanupEvent = StaleItemsReadEvent | StaleItemsArchivedEvent;

--- a/frontend/src/metabase-types/analytics/cleanup.ts
+++ b/frontend/src/metabase-types/analytics/cleanup.ts
@@ -2,6 +2,7 @@ type CleanupEventSchema = {
   event: string;
   collection_id?: number | null;
   total_stale_items_found?: number | null;
+  total_items_archived?: number | null;
   cutoff_date?: string | null;
 };
 
@@ -20,7 +21,7 @@ export type StaleItemsReadEvent = ValidateEvent<{
 export type StaleItemsArchivedEvent = ValidateEvent<{
   event: "stale_items_archived";
   collection_id: number | null;
-  total_stale_items_found: number;
+  total_items_archived: number;
   cutoff_date: string;
 }>;
 

--- a/frontend/src/metabase/lib/analytics.ts
+++ b/frontend/src/metabase/lib/analytics.ts
@@ -16,7 +16,7 @@ const VERSIONS: Record<SchemaType, SchemaVersion> = {
   account: "1-0-2",
   action: "1-0-0",
   browse_data: "1-0-0",
-  cleanup: "1-0-0",
+  cleanup: "1-0-1",
   csvupload: "1-0-3",
   dashboard: "1-1-6",
   database: "1-0-1",

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/cleanup/jsonschema/1-0-1
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/cleanup/jsonschema/1-0-1
@@ -1,0 +1,62 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Viewing or archiving stale collection items",
+  "self": {
+    "vendor": "com.metabase",
+    "name": "cleanup",
+    "format": "jsonschema",
+    "version": "1-0-1"
+  },
+  "type": "object",
+  "properties": {
+    "event": {
+      "description": "Event name",
+      "type": "string",
+      "enum": [
+        "stale_items_read",
+        "stale_items_archived"
+      ],
+      "maxLength": 1024
+    },
+    "collection_id": {
+      "description": "Unique identifier for the Collection where we looked for stale items",
+      "type": [
+        "null",
+        "integer"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "total_stale_items_found": {
+      "description": "The total number of stale items that were found",
+      "type": [
+        "null",
+        "integer"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "total_items_archived": {
+      "description": "The total number of stale items that were archived",
+      "type": [
+        "null",
+        "integer"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "cutoff_date": {
+      "description": "The date before which unused items are considered 'stale'",
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time",
+      "maxLength": 1024
+    }
+  },
+  "required": [
+    "event"
+  ],
+  "additionalProperties": true
+}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/48566

### Description
Adds snowplow tracking to archiving stale items via the modal

### How to verify

1. Start up Metabase with snowplow enabled and pointing to a local snowplow instance
2. Go to a collection, and move some stale stuff to the trash
3. You should see `stale_items_archived` events with the number of items archived, and the collection id they were in

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
