### PR TITLE
Make beta releases play nicer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -690,6 +690,8 @@ jobs:
   tag-nightly:
     if: ${{ inputs.auto }}
     needs: [push-tags, verify-docker-pull, verify-s3-download]
+    if: false
+    needs: [push-tags, verify-docker-pull, verify-s3-download, check-version]
     uses: ./.github/workflows/release-tag.yml
     secrets: inherit
     with:

--- a/release/src/github.ts
+++ b/release/src/github.ts
@@ -237,6 +237,7 @@ export async function getLatestGreenCommit({
   return null;
 }
 
+// note: only checks if the commit is the last one released for the major version
 export async function hasCommitBeenReleased({
   github,
   owner,
@@ -244,9 +245,12 @@ export async function hasCommitBeenReleased({
   ref,
   majorVersion,
 }: GithubProps & { ref: string, majorVersion: number }) {
+    // TODO: a better approach would be to fetch the ref and see if it has any release tags
     const lastTag = await getLastReleaseTag({
       github, owner, repo,
       version: `v0.${majorVersion}.0`,
+      ignorePatches: false,
+      ignorePreReleases: false,
     });
 
     const tagDetail = await github.rest.git.getRef({

--- a/release/src/milestones.ts
+++ b/release/src/milestones.ts
@@ -312,6 +312,7 @@ export async function checkMilestoneForRelease({
     repo,
     version,
     ignorePatches: true, // ignore patch versions since we don't release notes for them
+    ignorePreReleases: true, // ignore pre-releases because we want cumulative notes for them
   });
 
   const compareResponse = await github.rest.repos.compareCommitsWithBasehead({

--- a/release/src/release-channel-log.ts
+++ b/release/src/release-channel-log.ts
@@ -35,8 +35,8 @@ export async function gitLog(channel: ReleaseChannel, edition: Edition): Promise
 function processCommit(commitLine: string, edition: Edition): CommitInfo {
   const [refs, message, hash, date] = commitLine.split('||');
   const version = edition === "ee"
-   ? refs?.match(/(v1\.[\d\.\-RCrc]+)/)?.[1] ?? ''
-   : refs?.match(/(v0\.[\d\.\-RCrc]+)/)?.[1] ?? '';
+   ? refs?.match(/(v1\.[\d\.\-(RC|beta|alpha)]+)/i)?.[1] ?? ''
+   : refs?.match(/(v0\.[\d\.\-(RC|beta|alpha)]+)/i)?.[1] ?? '';
 
   return { version, message, hash, date};
 }

--- a/release/src/release-log.ts
+++ b/release/src/release-log.ts
@@ -14,7 +14,8 @@ type CommitInfo = {
 const tablePageTemplate = fs.readFileSync('./src/tablePageTemplate.html', 'utf8');
 
 export async function gitLog(majorVersion: number) {
-  const { stdout } = await $`git log origin/release-x.${majorVersion}.x ..v1.${majorVersion}.0-RC1 --pretty='format:%(decorate:prefix=,suffix=)||%s||%H||%ah'`;
+  const { stdout: baseCommit } = await $`git merge-base origin/release-x.${majorVersion}.x master`;
+  const { stdout } = await $`git log origin/release-x.${majorVersion}.x ..${baseCommit.trim()} --pretty='format:%(decorate:prefix=,suffix=)||%s||%H||%ah'`;
   const processedCommits = stdout.split('\n').map(processCommit);
   return buildTable(processedCommits, majorVersion);
 }

--- a/release/src/version-helpers.unit.spec.ts
+++ b/release/src/version-helpers.unit.spec.ts
@@ -442,13 +442,25 @@ describe("version-helpers", () => {
       expect(latest).toBe('v0.13.0');
     });
 
-    it('should not ignore pre releases', () => {
+    it('should not ignore pre releases by default', () => {
       const latest = getLastReleaseFromTags({ tags: [
         { ref: 'refs/tags/v0.12.0' },
         { ref: 'refs/tags/v0.12.1' },
         { ref: 'refs/tags/v0.12.2-RC99' },
-        { ref: 'refs/tags/v0.12.1-beta' },
+        { ref: 'refs/tags/v0.12.3-alpha' },
+        { ref: 'refs/tags/v0.12.4-beta' },
       ] as Tag[]});
+      expect(latest).toBe('v0.12.4-beta');
+    });
+
+    it('should ignore pre releases with a flag passeed', () => {
+      const latest = getLastReleaseFromTags({ tags: [
+        { ref: 'refs/tags/v0.12.0' },
+        { ref: 'refs/tags/v0.12.1' },
+        { ref: 'refs/tags/v0.12.2-RC99' },
+        { ref: 'refs/tags/v0.12.3-alpha' },
+        { ref: 'refs/tags/v0.12.4-beta' },
+      ] as Tag[], ignorePreReleases: true });
       expect(latest).toBe('v0.12.1');
     });
   });


### PR DESCRIPTION
### Description

1. Fixes a bug in _last_ release parsing so that we can accurately calculate the version number of the _next_ release.
2. Fixes a broken assumption in git branch parsing (that we should parse back to RC1 tag to find everything in the release branch) used to find commit history and produce release logs
3. (temporarily) Disables automatic "nightly" release tagging because it is susceptible to a race condition when multiple automatic patches run at the same time. (I have a fix for this, but I want to test it more thoroughly before pushing it)


