### PR TITLE
Add a new prometheus metrics in m.qp.middleware.metrics/adjust

### DIFF
--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -266,12 +266,6 @@
   [metric]
   (some-> system .-registry metric prometheus/inc))
 
-(defn inc-and-throw!
-  "Call [[inc!]] on the given `metric` and then throw the `exception`."
-  [metric exception]
-  (inc! metric)
-  (throw exception))
-
 (comment
   (require 'iapetos.export)
   (spit "metrics" (iapetos.export/text-format (.registry system))))

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -204,7 +204,7 @@
    (prometheus/counter :metabase-sdk/response-error
                        {:description (trs "Number of errors when responding to SDK requests.")})
    (prometheus/counter :metabase-query-processor/metrics
-                       {:description (trs "Number metrics processed by the query processor.")})
+                       {:description (trs "Number of queries consuming metrics processed by the query processor.")})
    (prometheus/counter :metabase-query-processor/metrics-errors
                        {:description (trs "Number of errors when processing metrics.")})])
 

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -264,6 +264,12 @@
   [metric]
   (some-> system .-registry metric prometheus/inc))
 
+(defn inc-and-throw!
+  "Call [[inc!]] on the given `metric` and then throw the `exception`."
+  [metric exception]
+  (inc! metric)
+  (throw exception))
+
 (comment
   (require 'iapetos.export)
   (spit "metrics" (iapetos.export/text-format (.registry system))))

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -194,7 +194,7 @@
 
 (defn- product-collectors
   []
-  ;; Iapetos will use "default" if we do not provide a namespace, so explicitly set `metabase-email`:
+  ;; Iapetos will use "default" if we do not provide a namespace, so explicitly set, e.g. `metabase-email`:
   [(prometheus/counter :metabase-email/messages
                        {:description (trs "Number of emails sent.")})
    (prometheus/counter :metabase-email/message-errors
@@ -202,7 +202,9 @@
    (prometheus/counter :metabase-sdk/response-ok
                        {:description (trs "Number of successful SDK requests.")})
    (prometheus/counter :metabase-sdk/response-error
-                       {:description (trs "Number of errors when responding to SDK requests.")})])
+                       {:description (trs "Number of errors when responding to SDK requests.")})
+   (prometheus/counter :metabase-metrics/adjust-errors
+                       {:description (trs "Number of errors when adjusting metrics.")})])
 
 (defn- setup-metrics!
   "Instrument the application. Conditionally done when some setting is set. If [[prometheus-server-port]] is not set it

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -203,6 +203,8 @@
                        {:description (trs "Number of successful SDK requests.")})
    (prometheus/counter :metabase-sdk/response-error
                        {:description (trs "Number of errors when responding to SDK requests.")})
+   (prometheus/counter :metabase-query-processor/metrics
+                       {:description (trs "Number metrics processed by the query processor.")})
    (prometheus/counter :metabase-query-processor/metrics-errors
                        {:description (trs "Number of errors when processing metrics.")})])
 

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -205,7 +205,7 @@
                        {:description (trs "Number of errors when responding to SDK requests.")})
    (prometheus/counter :metabase-query-processor/metrics
                        {:description (trs "Number of queries consuming metrics processed by the query processor.")})
-   (prometheus/counter :metabase-query-processor/metrics-errors
+   (prometheus/counter :metabase-query-processor/metric-errors
                        {:description (trs "Number of errors when processing metrics.")})])
 
 (defn- setup-metrics!

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -203,8 +203,8 @@
                        {:description (trs "Number of successful SDK requests.")})
    (prometheus/counter :metabase-sdk/response-error
                        {:description (trs "Number of errors when responding to SDK requests.")})
-   (prometheus/counter :metabase-metrics/adjust-errors
-                       {:description (trs "Number of errors when adjusting metrics.")})])
+   (prometheus/counter :metabase-query-processor/metrics-errors
+                       {:description (trs "Number of errors when processing metrics.")})])
 
 (defn- setup-metrics!
   "Instrument the application. Conditionally done when some setting is set. If [[prometheus-server-port]] is not set it

--- a/src/metabase/query_processor/middleware/metrics.clj
+++ b/src/metabase/query_processor/middleware/metrics.clj
@@ -270,4 +270,5 @@
               (log/warn "Failed to replace metric"
                         (pr-str {:metric metric})))))
         (catch Throwable e
-          (prometheus/inc-and-throw! :metabase-query-processor/metrics-errors e))))))
+          (prometheus/inc! :metabase-query-processor/metrics-errors)
+          (throw e))))))

--- a/src/metabase/query_processor/middleware/metrics.clj
+++ b/src/metabase/query_processor/middleware/metrics.clj
@@ -9,7 +9,6 @@
    [metabase.lib.util.match :as lib.util.match]
    [metabase.lib.walk :as lib.walk]
    [metabase.util :as u]
-   [metabase.util.log :as log]
    [metabase.util.malli :as mu]))
 
 (defn- replace-metric-aggregation-refs [query stage-number lookup]
@@ -264,11 +263,7 @@
           (u/prog1
             (update query :stages #(adjust-metric-stages query nil %))
             (when-let [metric (find-first-metric <>)]
-              ;; There is a small chance we could wind up double-counting errors here if prometheus/inc! or log/warn
-              ;; throw an exception, but it seems unlikely enough to not warrant complications to avoid it.
-              (prometheus/inc! :metabase-query-processor/metric-errors)
-              (log/warn "Failed to replace metric"
-                        (pr-str {:metric metric})))))
+              (throw (ex-info "Failed to replace metric" {:metric metric})))))
         (catch Throwable e
           (prometheus/inc! :metabase-query-processor/metric-errors)
           (throw e))))))

--- a/src/metabase/query_processor/middleware/metrics.clj
+++ b/src/metabase/query_processor/middleware/metrics.clj
@@ -1,6 +1,7 @@
 (ns metabase.query-processor.middleware.metrics
   (:require
    [medley.core :as m]
+   [metabase.analytics.prometheus :as prometheus]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
@@ -254,5 +255,6 @@
       (update query :stages #(adjust-metric-stages query nil %))
       (when-let [metric (lib.util.match/match-one <>
                           [:metric _ _] &match)]
+        (prometheus/inc! :metabase-metrics/adjust-errors)
         (log/warn "Failed to replace metric"
                   (pr-str {:metric metric}))))))

--- a/src/metabase/query_processor/middleware/metrics.clj
+++ b/src/metabase/query_processor/middleware/metrics.clj
@@ -254,9 +254,9 @@
     (u/prog1
       (try (update query :stages #(adjust-metric-stages query nil %))
            (catch Throwable e
-             (prometheus/inc-and-throw! :metabase-metrics/adjust-errors e)))
+             (prometheus/inc-and-throw! :metabase-query-processor/metrics-errors e)))
       (when-let [metric (lib.util.match/match-one <>
                           [:metric _ _] &match)]
-        (prometheus/inc! :metabase-metrics/adjust-errors)
+        (prometheus/inc! :metabase-query-processor/metrics-errors)
         (log/warn "Failed to replace metric"
                   (pr-str {:metric metric}))))))

--- a/src/metabase/query_processor/middleware/metrics.clj
+++ b/src/metabase/query_processor/middleware/metrics.clj
@@ -123,7 +123,7 @@
                                  new-joins)]
     (lib.util/update-query-stage query-with-joins agg-stage-index add-join-aliases source-field->join-alias)))
 
-(defn splice-compatible-metrics
+(defn- splice-compatible-metrics
   "Splices in metric definitions that are compatible with the query."
   [query path expanded-stages]
   (let [agg-stage-index (aggregation-stage-index expanded-stages)]

--- a/src/metabase/query_processor/middleware/metrics.clj
+++ b/src/metabase/query_processor/middleware/metrics.clj
@@ -231,7 +231,7 @@
       :else
       expanded-stages)))
 
-(defn- match-one-metric
+(defn- find-first-metric
   [query]
   (lib.util.match/match-one query
     [:metric _ _] &match))
@@ -251,7 +251,7 @@
    2. Metric source cards can reference themselves.
       A query built from a `:source-card` of `:type :metric` can reference itself."
   [query]
-  (if-not (match-one-metric query)
+  (if-not (find-first-metric query)
     query
     (do
       (prometheus/inc! :metabase-query-processor/metrics)
@@ -263,7 +263,7 @@
                          (update stage-or-join :stages #(adjust-metric-stages query path %)))))]
           (u/prog1
             (update query :stages #(adjust-metric-stages query nil %))
-            (when-let [metric (match-one-metric <>)]
+            (when-let [metric (find-first-metric <>)]
               ;; There is a small chance we could wind up double-counting errors here if prometheus/inc! or log/warn
               ;; throw an exception, but it seems unlikely enough to not warrant complications to avoid it.
               (prometheus/inc! :metabase-query-processor/metrics-errors)

--- a/src/metabase/query_processor/middleware/metrics.clj
+++ b/src/metabase/query_processor/middleware/metrics.clj
@@ -266,9 +266,9 @@
             (when-let [metric (find-first-metric <>)]
               ;; There is a small chance we could wind up double-counting errors here if prometheus/inc! or log/warn
               ;; throw an exception, but it seems unlikely enough to not warrant complications to avoid it.
-              (prometheus/inc! :metabase-query-processor/metrics-errors)
+              (prometheus/inc! :metabase-query-processor/metric-errors)
               (log/warn "Failed to replace metric"
                         (pr-str {:metric metric})))))
         (catch Throwable e
-          (prometheus/inc! :metabase-query-processor/metrics-errors)
+          (prometheus/inc! :metabase-query-processor/metric-errors)
           (throw e))))))

--- a/test/metabase/analytics/prometheus_test.clj
+++ b/test/metabase/analytics/prometheus_test.clj
@@ -179,7 +179,7 @@
   ([expected actual epsilon]
    (< (- expected epsilon) actual (+ expected epsilon))))
 
-(deftest inc-test
+(deftest inc!-test
   (testing "inc has no effect if system is not setup"
     (prometheus/inc! :metabase-email/messages)) ; << Does not throw.
   (testing "inc has no effect when called with unknown metric"
@@ -188,7 +188,7 @@
   (testing "inc is recorded for known metrics"
     (with-prometheus-system! [_ system]
       (prometheus/inc! :metabase-email/messages)
-      (is (< 0 (-> system :registry :metabase-email/messages ops/read-value))))))
+      (is (approx= 1 (metric-value system :metabase-email/messages))))))
 
 (deftest inc-and-throw!-test
   (testing "inc-and-throw! increments counter and throws exception"

--- a/test/metabase/analytics/prometheus_test.clj
+++ b/test/metabase/analytics/prometheus_test.clj
@@ -164,7 +164,6 @@
                   (filter #(str/starts-with? % "metabase_email_"))
                   set))))))
 
-
 (defn- metric-value
   "Return the value of `metric` in `system`'s registry."
   [system metric]

--- a/test/metabase/analytics/prometheus_test.clj
+++ b/test/metabase/analytics/prometheus_test.clj
@@ -188,12 +188,3 @@
     (with-prometheus-system! [_ system]
       (prometheus/inc! :metabase-email/messages)
       (is (approx= 1 (metric-value system :metabase-email/messages))))))
-
-(deftest inc-and-throw!-test
-  (testing "inc-and-throw! increments counter and throws exception"
-    (with-prometheus-system! [_ system]
-      (is (thrown?
-           clojure.lang.ExceptionInfo
-           (prometheus/inc-and-throw! :metabase-email/message-errors
-                                      (ex-info "Test error" {}))))
-      (is (approx= 1 (metric-value system :metabase-email/message-errors))))))

--- a/test/metabase/analytics/prometheus_test.clj
+++ b/test/metabase/analytics/prometheus_test.clj
@@ -176,7 +176,7 @@
   ([expected actual]
    (approx= expected actual 0.001))
   ([expected actual epsilon]
-   (< (- expected epsilon) actual (+ expected epsilon))))
+   (< (abs (- actual expected)) epsilon)))
 
 (deftest inc!-test
   (testing "inc has no effect if system is not setup"

--- a/test/metabase/query_processor/middleware/metrics_test.clj
+++ b/test/metabase/query_processor/middleware/metrics_test.clj
@@ -92,7 +92,7 @@
                     metrics/adjust-metric-stages (fn [_ _ stages] stages)]
         (is (= query (adjust query)))
         (is (= 1 (count (filter #{:metabase-metrics/adjust-errors} @calls)))))))
-  (testing "metric missing aggregation exception"
+  (testing "metric missing aggregation increments counter and throws exception"
     (let [[bad-source-metric mp] (mock-metric (-> (lib/query meta/metadata-provider (meta/table-metadata :products))))
           query                  (-> (lib/query mp (meta/table-metadata :products))
                                      (lib/aggregate (lib/+ (lib.options/ensure-uuid

--- a/test/metabase/query_processor/middleware/metrics_test.clj
+++ b/test/metabase/query_processor/middleware/metrics_test.clj
@@ -102,7 +102,10 @@
      :metabase-query-processor/metric-errors 1
      :check-fn (fn [query]
                  (with-redefs [metrics/adjust-metric-stages (fn [_ _ stages] stages)]
-                   (is (= query (adjust query)))))))
+                   (is (thrown-with-msg?
+                        clojure.lang.ExceptionInfo
+                        #"Failed to replace metric"
+                        (adjust query)))))))
   (testing "exceptions from other libs also increment error counter"
     (check-prometheus-metrics!
      :metabase-query-processor/metrics 1

--- a/test/metabase/query_processor/middleware/metrics_test.clj
+++ b/test/metabase/query_processor/middleware/metrics_test.clj
@@ -63,7 +63,7 @@
 
 (defn- check-prometheus-metrics!
   [& {expected-metrics-count  :metabase-query-processor/metrics
-      expected-metrics-errors :metabase-query-processor/metrics-errors
+      expected-metrics-errors :metabase-query-processor/metric-errors
       metric-and-mp           :metric-and-mp
       query-fn                :query-fn
       check-fn                :check-fn}]
@@ -76,13 +76,13 @@
     (with-redefs [prometheus/inc! #(swap! metrics update % (fnil inc 0))]
       (check-fn query)
       (is (= expected-metrics-count (read-metric :metabase-query-processor/metrics)))
-      (is (= expected-metrics-errors (read-metric :metabase-query-processor/metrics-errors))))))
+      (is (= expected-metrics-errors (read-metric :metabase-query-processor/metric-errors))))))
 
 (deftest adjust-prometheus-metrics-test
   (testing "adjustment of query with no metrics does not increment either counter"
     (check-prometheus-metrics!
      :metabase-query-processor/metrics 0
-     :metabase-query-processor/metrics-errors 0
+     :metabase-query-processor/metric-errors 0
      :query-fn (fn [_mp _metric]
                  (-> (lib/query meta/metadata-provider (meta/table-metadata :products))
                      (lib/aggregate (lib/avg (meta/field-metadata :products :rating)))))
@@ -92,21 +92,21 @@
   (testing "successful adjustment does not increment error counter"
     (check-prometheus-metrics!
      :metabase-query-processor/metrics 1
-     :metabase-query-processor/metrics-errors 0
+     :metabase-query-processor/metric-errors 0
      :check-fn #(is (=? {:stages [{:source-table (meta/id :products)
                                    :aggregation  [[:avg {} [:field {} (meta/id :products :rating)]]]}]}
                         (adjust %)))))
   (testing "failure to adjust :metric clauses increments error counter"
     (check-prometheus-metrics!
      :metabase-query-processor/metrics 1
-     :metabase-query-processor/metrics-errors 1
+     :metabase-query-processor/metric-errors 1
      :check-fn (fn [query]
                  (with-redefs [metrics/adjust-metric-stages (fn [_ _ stages] stages)]
                    (is (= query (adjust query)))))))
   (testing "exceptions from other libs also increment error counter"
     (check-prometheus-metrics!
      :metabase-query-processor/metrics 1
-     :metabase-query-processor/metrics-errors 1
+     :metabase-query-processor/metric-errors 1
      :check-fn (fn [query]
                  (with-redefs [lib.metadata/bulk-metadata-or-throw (fn [& _] (throw (Exception. "Test exception")))]
                    (is (thrown-with-msg?
@@ -116,7 +116,7 @@
   (testing "metric missing aggregation increments counter and throws exception"
     (check-prometheus-metrics!
      :metabase-query-processor/metrics 1
-     :metabase-query-processor/metrics-errors 1
+     :metabase-query-processor/metric-errors 1
      :metric-and-mp (mock-metric (-> (lib/query meta/metadata-provider (meta/table-metadata :products))))
      :query-fn (fn [mp metric]
                  (-> (lib/query mp (meta/table-metadata :products))

--- a/test/metabase/query_processor/middleware/metrics_test.clj
+++ b/test/metabase/query_processor/middleware/metrics_test.clj
@@ -61,6 +61,72 @@
 (def adjust
   (comp #'metrics/adjust #'fetch-source-query/resolve-source-cards))
 
+(defn- check-prometheus-metrics!
+  [& {expected-metrics-count  :metabase-query-processor/metrics
+      expected-metrics-errors :metabase-query-processor/metrics-errors
+      metric-and-mp           :metric-and-mp
+      query-fn                :query-fn
+      check-fn                :check-fn}]
+  (let [[source-metric mp] (or metric-and-mp (mock-metric))
+        query              (if query-fn
+                             (query-fn mp source-metric)
+                             (lib/query mp source-metric))
+        calls              (atom nil)]
+    (with-redefs [prometheus/inc! #(swap! calls conj %)]
+      (check-fn query)
+      (is (= expected-metrics-count (count (filter #{:metabase-query-processor/metrics} @calls))))
+      (is (= expected-metrics-errors (count (filter #{:metabase-query-processor/metrics-errors} @calls)))))))
+
+(deftest adjust-prometheus-metrics-test
+  (testing "adjustment of query with no metrics does not increment either counter"
+    (check-prometheus-metrics!
+     :metabase-query-processor/metrics 0
+     :metabase-query-processor/metrics-errors 0
+     :query-fn (fn [_mp _metric]
+                 (-> (lib/query meta/metadata-provider (meta/table-metadata :products))
+                     (lib/aggregate (lib/avg (meta/field-metadata :products :rating)))))
+     :check-fn #(is (=? {:stages [{:source-table (meta/id :products)
+                                   :aggregation  [[:avg {} [:field {} (meta/id :products :rating)]]]}]}
+                        (adjust %)))))
+  (testing "successful adjustment does not increment error counter"
+    (check-prometheus-metrics!
+     :metabase-query-processor/metrics 1
+     :metabase-query-processor/metrics-errors 0
+     :check-fn #(is (=? {:stages [{:source-table (meta/id :products)
+                                   :aggregation  [[:avg {} [:field {} (meta/id :products :rating)]]]}]}
+                        (adjust %)))))
+  (testing "failure to adjust :metric clauses increments error counter"
+    (check-prometheus-metrics!
+     :metabase-query-processor/metrics 1
+     :metabase-query-processor/metrics-errors 1
+     :check-fn (fn [query]
+                 (with-redefs [metrics/adjust-metric-stages (fn [_ _ stages] stages)]
+                   (is (= query (adjust query)))))))
+  (testing "exceptions from other libs also increment error counter"
+    (check-prometheus-metrics!
+     :metabase-query-processor/metrics 1
+     :metabase-query-processor/metrics-errors 1
+     :check-fn (fn [query]
+                 (with-redefs [lib.metadata/bulk-metadata-or-throw (fn [& _] (throw (Exception. "Test exception")))]
+                   (is (thrown-with-msg?
+                        java.lang.Exception
+                        #"Test exception"
+                        (adjust query)))))))
+  (testing "metric missing aggregation increments counter and throws exception"
+    (check-prometheus-metrics!
+     :metabase-query-processor/metrics 1
+     :metabase-query-processor/metrics-errors 1
+     :metric-and-mp (mock-metric (-> (lib/query meta/metadata-provider (meta/table-metadata :products))))
+     :query-fn (fn [mp metric]
+                 (-> (lib/query mp (meta/table-metadata :products))
+                     (lib/aggregate (lib/+ (lib.options/ensure-uuid
+                                            [:metric {} (:id metric)]) 1))))
+     :check-fn (fn [query]
+                 (is (thrown-with-msg?
+                      clojure.lang.ExceptionInfo
+                      #"Source metric missing aggregation"
+                      (adjust query)))))))
+
 (deftest ^:parallel no-metric-should-result-in-exact-same-query
   (let [query (lib/query meta/metadata-provider (meta/table-metadata :products))]
     (is (= query
@@ -80,64 +146,6 @@
     (is (=? {:stages [{:source-table (meta/id :products)
                        :aggregation [[:avg {} [:field {} (meta/id :products :rating)]]]}]}
             (adjust query)))))
-
-(deftest adjust-errors-prometheus-metric-test
-  (testing "adjustment of query with no metrics does not increment either counter"
-    (let [query              (-> (lib/query meta/metadata-provider (meta/table-metadata :products))
-                                 (lib/aggregate (lib/avg (meta/field-metadata :products :rating))))
-          calls              (atom nil)]
-      (with-redefs [prometheus/inc! #(swap! calls conj %)]
-        (is (=? {:stages [{:source-table (meta/id :products)
-                           :aggregation  [[:avg {} [:field {} (meta/id :products :rating)]]]}]}
-                (adjust query)))
-        (is (= 0 (count (filter #{:metabase-query-processor/metrics} @calls))))
-        (is (= 0 (count (filter #{:metabase-query-processor/metrics-errors} @calls)))))))
-  (testing "successful adjustment does not increment error counter"
-    (let [[source-metric mp] (mock-metric)
-          query              (lib/query mp source-metric)
-          calls              (atom nil)]
-      (with-redefs [prometheus/inc! #(swap! calls conj %)]
-        (is (=? {:stages [{:source-table (meta/id :products)
-                           :aggregation  [[:avg {} [:field {} (meta/id :products :rating)]]]}]}
-                (adjust query)))
-        (is (= 1 (count (filter #{:metabase-query-processor/metrics} @calls))))
-        (is (= 0 (count (filter #{:metabase-query-processor/metrics-errors} @calls)))))))
-  (testing "failure to adjust :metric clauses increments error counter"
-    (let [[source-metric mp] (mock-metric)
-          query              (lib/query mp source-metric)
-          calls              (atom nil)]
-      ;; Make metrics/adjust-metric-stages a no-op and verify that the :metabase-query-processor/metrics-errors prometheus
-      ;; counter is incremented.
-      (with-redefs [prometheus/inc!              #(swap! calls conj %)
-                    metrics/adjust-metric-stages (fn [_ _ stages] stages)]
-        (is (= query (adjust query)))
-        (is (= 1 (count (filter #{:metabase-query-processor/metrics} @calls))))
-        (is (= 1 (count (filter #{:metabase-query-processor/metrics-errors} @calls)))))))
-  (testing "exceptions from other libs also increment error counter"
-    (let [[source-metric mp] (mock-metric)
-          query              (lib/query mp source-metric)
-          calls              (atom nil)]
-      (with-redefs [prometheus/inc!                     #(swap! calls conj %)
-                    lib.metadata/bulk-metadata-or-throw (fn [& _] (throw (Exception. "Test exception")))]
-        (is (thrown-with-msg?
-             java.lang.Exception
-             #"Test exception"
-             (adjust query)))
-        (is (= 1 (count (filter #{:metabase-query-processor/metrics} @calls))))
-        (is (= 1 (count (filter #{:metabase-query-processor/metrics-errors} @calls)))))))
-  (testing "metric missing aggregation increments counter and throws exception"
-    (let [[bad-source-metric mp] (mock-metric (-> (lib/query meta/metadata-provider (meta/table-metadata :products))))
-          query                  (-> (lib/query mp (meta/table-metadata :products))
-                                     (lib/aggregate (lib/+ (lib.options/ensure-uuid
-                                                            [:metric {} (:id bad-source-metric)]) 1)))
-          calls                  (atom nil)]
-      (with-redefs [prometheus/inc! #(swap! calls conj %)]
-        (is (thrown-with-msg?
-             clojure.lang.ExceptionInfo
-             #"Source metric missing aggregation"
-             (adjust query)))
-        (is (= 1 (count (filter #{:metabase-query-processor/metrics} @calls))))
-        (is (= 1 (count (filter #{:metabase-query-processor/metrics-errors} @calls))))))))
 
 (deftest ^:parallel adjust-aggregation-metric-ref-test
   (let [[source-metric mp] (mock-metric)

--- a/test/metabase/query_processor/middleware/metrics_test.clj
+++ b/test/metabase/query_processor/middleware/metrics_test.clj
@@ -3,6 +3,7 @@
    [clojure.test :refer [deftest is testing]]
    [mb.hawk.assert-exprs.approximately-equal :as =?]
    [medley.core :as m]
+   [metabase.analytics.prometheus :as prometheus]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
@@ -79,6 +80,17 @@
     (is (=? {:stages [{:source-table (meta/id :products)
                        :aggregation [[:avg {} [:field {} (meta/id :products :rating)]]]}]}
             (adjust query)))))
+
+(deftest adjust-prometheus-metric-test
+  (let [[source-metric mp] (mock-metric)
+        query              (lib/query mp source-metric)
+        calls              (atom nil)]
+    ;; Make metrics/adjust-metric-stages a no-op and verify that the :metabase-metrics/adjust-errors prometheus
+    ;; counter is incremented.
+    (with-redefs [prometheus/inc!                #(swap! calls conj %)
+                  metrics/adjust-metric-stages (fn [_ _ stages] stages)]
+      (is (= query (adjust query)))
+      (is (= 1 (count (filter #{:metabase-metrics/adjust-errors} @calls)))))))
 
 (deftest ^:parallel adjust-aggregation-metric-ref-test
   (let [[source-metric mp] (mock-metric)

--- a/test/metabase/query_processor/middleware/metrics_test.clj
+++ b/test/metabase/query_processor/middleware/metrics_test.clj
@@ -81,16 +81,29 @@
                        :aggregation [[:avg {} [:field {} (meta/id :products :rating)]]]}]}
             (adjust query)))))
 
-(deftest adjust-prometheus-metric-test
-  (let [[source-metric mp] (mock-metric)
-        query              (lib/query mp source-metric)
-        calls              (atom nil)]
-    ;; Make metrics/adjust-metric-stages a no-op and verify that the :metabase-metrics/adjust-errors prometheus
-    ;; counter is incremented.
-    (with-redefs [prometheus/inc!                #(swap! calls conj %)
-                  metrics/adjust-metric-stages (fn [_ _ stages] stages)]
-      (is (= query (adjust query)))
-      (is (= 1 (count (filter #{:metabase-metrics/adjust-errors} @calls)))))))
+(deftest adjust-errors-prometheus-metric-test
+  (testing "failure to adjust :metric clauses"
+    (let [[source-metric mp] (mock-metric)
+          query              (lib/query mp source-metric)
+          calls              (atom nil)]
+      ;; Make metrics/adjust-metric-stages a no-op and verify that the :metabase-metrics/adjust-errors prometheus
+      ;; counter is incremented.
+      (with-redefs [prometheus/inc!              #(swap! calls conj %)
+                    metrics/adjust-metric-stages (fn [_ _ stages] stages)]
+        (is (= query (adjust query)))
+        (is (= 1 (count (filter #{:metabase-metrics/adjust-errors} @calls)))))))
+  (testing "metric missing aggregation exception"
+    (let [[bad-source-metric mp] (mock-metric (-> (lib/query meta/metadata-provider (meta/table-metadata :products))))
+          query                  (-> (lib/query mp (meta/table-metadata :products))
+                                     (lib/aggregate (lib/+ (lib.options/ensure-uuid
+                                                            [:metric {} (:id bad-source-metric)]) 1)))
+          calls                  (atom nil)]
+      (with-redefs [prometheus/inc! #(swap! calls conj %)]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"Source metric missing aggregation"
+             (adjust query)))
+        (is (= 1 (count (filter #{:metabase-metrics/adjust-errors} @calls))))))))
 
 (deftest ^:parallel adjust-aggregation-metric-ref-test
   (let [[source-metric mp] (mock-metric)

--- a/test/metabase/query_processor/middleware/metrics_test.clj
+++ b/test/metabase/query_processor/middleware/metrics_test.clj
@@ -91,6 +91,7 @@
       (with-redefs [prometheus/inc!              #(swap! calls conj %)
                     metrics/adjust-metric-stages (fn [_ _ stages] stages)]
         (is (= query (adjust query)))
+        (is (= 1 (count (filter #{:metabase-query-processor/metrics} @calls))))
         (is (= 1 (count (filter #{:metabase-query-processor/metrics-errors} @calls)))))))
   (testing "metric missing aggregation increments counter and throws exception"
     (let [[bad-source-metric mp] (mock-metric (-> (lib/query meta/metadata-provider (meta/table-metadata :products))))
@@ -103,6 +104,7 @@
              clojure.lang.ExceptionInfo
              #"Source metric missing aggregation"
              (adjust query)))
+        (is (= 1 (count (filter #{:metabase-query-processor/metrics} @calls))))
         (is (= 1 (count (filter #{:metabase-query-processor/metrics-errors} @calls))))))))
 
 (deftest ^:parallel adjust-aggregation-metric-ref-test

--- a/test/metabase/query_processor/middleware/metrics_test.clj
+++ b/test/metabase/query_processor/middleware/metrics_test.clj
@@ -86,12 +86,12 @@
     (let [[source-metric mp] (mock-metric)
           query              (lib/query mp source-metric)
           calls              (atom nil)]
-      ;; Make metrics/adjust-metric-stages a no-op and verify that the :metabase-metrics/adjust-errors prometheus
+      ;; Make metrics/adjust-metric-stages a no-op and verify that the :metabase-query-processor/metrics-errors prometheus
       ;; counter is incremented.
       (with-redefs [prometheus/inc!              #(swap! calls conj %)
                     metrics/adjust-metric-stages (fn [_ _ stages] stages)]
         (is (= query (adjust query)))
-        (is (= 1 (count (filter #{:metabase-metrics/adjust-errors} @calls)))))))
+        (is (= 1 (count (filter #{:metabase-query-processor/metrics-errors} @calls)))))))
   (testing "metric missing aggregation increments counter and throws exception"
     (let [[bad-source-metric mp] (mock-metric (-> (lib/query meta/metadata-provider (meta/table-metadata :products))))
           query                  (-> (lib/query mp (meta/table-metadata :products))
@@ -103,7 +103,7 @@
              clojure.lang.ExceptionInfo
              #"Source metric missing aggregation"
              (adjust query)))
-        (is (= 1 (count (filter #{:metabase-metrics/adjust-errors} @calls))))))))
+        (is (= 1 (count (filter #{:metabase-query-processor/metrics-errors} @calls))))))))
 
 (deftest ^:parallel adjust-aggregation-metric-ref-test
   (let [[source-metric mp] (mock-metric)


### PR DESCRIPTION
### Description

Context: https://metaboat.slack.com/archives/C0645JP1W81/p1728471378145769

Add a new prometheus counter to count errors in `metabase.query-processor.middleware.metrics/adjust`.

### How to verify

* Set `MB_PROMETHEUS_SERVER_PORT` and then check the `/metrics` endpoint, should see logs like

```
# HELP metabase_query_processor_metrics_total Number metrics processed by the query processor.
# TYPE metabase_query_processor_metrics_total counter
metabase_query_processor_metrics_total 0.0
# HELP metabase_query_processor_metrics_errors_total Number of errors when processing metrics.
# TYPE metabase_query_processor_metrics_errors_total counter
metabase_query_processor_metrics_errors_total 0.0
# HELP metabase_query_processor_metrics_created Number metrics processed by the query processor.
# TYPE metabase_query_processor_metrics_created gauge
metabase_query_processor_metrics_created 1.728947783982E9
# HELP metabase_query_processor_metrics_errors_created Number of errors when processing metrics.
# TYPE metabase_query_processor_metrics_errors_created gauge
metabase_query_processor_metrics_errors_created 1.728947783982E9
```

* Or see [dpsutton's comment](https://github.com/metabase/metabase/pull/48547#issuecomment-2405875446) about testing from the repl
* See included tests

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
