### PR TITLE
Do not save metric viz settings to metric

### DIFF
--- a/e2e/support/helpers/api/createQuestion.ts
+++ b/e2e/support/helpers/api/createQuestion.ts
@@ -166,6 +166,10 @@ export const question = (
           cy.intercept("POST", "/api/dataset").as("dataset");
           cy.visit(`/model/${body.id}`);
           cy.wait("@dataset"); // Wait for `result_metadata` to load
+        } else if (type === "metric") {
+          cy.intercept("POST", "/api/dataset").as("dataset");
+          cy.visit(`/metric/${body.id}`);
+          cy.wait("@dataset"); // Wait for `result_metadata` to load
         } else {
           // We need to use the wildcard because endpoint for pivot tables has the following format: `/api/card/pivot/${id}/query`
           cy.intercept("POST", `/api/card/**/${body.id}/query`).as(

--- a/e2e/test/scenarios/metrics/reproductions/metrics-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/reproductions/metrics-reproductions.cy.spec.ts
@@ -71,7 +71,7 @@ describe("issue 47058", () => {
   });
 });
 
-describe("Issue 44171", () => {
+describe("issue 44171", () => {
   const METRIC_A: StructuredQuestionDetails = {
     name: "Metric 44171-A",
     type: "metric",

--- a/e2e/test/scenarios/metrics/reproductions/metrics-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/reproductions/metrics-reproductions.cy.spec.ts
@@ -125,6 +125,8 @@ describe("issue 44171", () => {
   });
 
   it("should not save viz settings on metrics", () => {
+    cy.intercept("PUT", "/api/card/*").as("saveCard");
+
     openQuestionActions();
     popover().findByText("Edit metric definition").click();
     getNotebookStep("summarize").button("Count").click();
@@ -136,6 +138,11 @@ describe("issue 44171", () => {
     cy.get<number>("@dashboardId").then(id => {
       visitDashboard(id);
     });
+
+    cy.get("@saveCard")
+      .its("request.body")
+      .its("visualization_settings")
+      .should("not.exist");
 
     editDashboard();
     cy.findByTestId("dashboard-header")

--- a/e2e/test/scenarios/metrics/reproductions/metrics-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/reproductions/metrics-reproductions.cy.spec.ts
@@ -13,6 +13,7 @@ import {
   restore,
   showDashboardCardActions,
   sidebar,
+  visitDashboard,
 } from "e2e/support/helpers";
 
 const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
@@ -132,8 +133,8 @@ describe("issue 44171", () => {
       cy.findByText("Total").click();
     });
     cy.button("Save changes").click();
-    cy.get("@dashboardId").then(id => {
-      cy.visit(`/dashboard/${id}`);
+    cy.get<number>("@dashboardId").then(id => {
+      visitDashboard(id);
     });
 
     editDashboard();

--- a/e2e/test/scenarios/metrics/reproductions/metrics-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/reproductions/metrics-reproductions.cy.spec.ts
@@ -1,9 +1,18 @@
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
+  type StructuredQuestionDetails,
+  createDashboard,
   createQuestion,
+  editDashboard,
+  getDashboardCard,
   getNotebookStep,
   main,
+  modal,
+  openQuestionActions,
+  popover,
   restore,
+  showDashboardCardActions,
+  sidebar,
 } from "e2e/support/helpers";
 
 const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
@@ -59,5 +68,83 @@ describe("issue 47058", () => {
 
       cy.findByText("[Unknown Metric]").should("not.exist");
     });
+  });
+});
+
+describe("Issue 44171", () => {
+  const METRIC_A: StructuredQuestionDetails = {
+    name: "Metric 44171-A",
+    type: "metric",
+    display: "line",
+    query: {
+      "source-table": ORDERS_ID,
+      aggregation: [["count"]],
+      breakout: [
+        [
+          "field",
+          ORDERS.CREATED_AT,
+          { "temporal-unit": "month", "base-type": "type/DateTime" },
+        ],
+      ],
+    },
+  };
+
+  const METRIC_B: StructuredQuestionDetails = {
+    name: "Metric 44171-B",
+    type: "metric",
+    display: "line",
+    query: {
+      "source-table": ORDERS_ID,
+      aggregation: [["count"]],
+      breakout: [
+        [
+          "field",
+          ORDERS.CREATED_AT,
+          { "temporal-unit": "month", "base-type": "type/DateTime" },
+        ],
+      ],
+    },
+  };
+
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    createQuestion(METRIC_A);
+    createQuestion(METRIC_B).then(({ body: { id } }) => {
+      cy.visit(`/metric/${id}`);
+    });
+    createDashboard(
+      {
+        name: "Dashboard 44171",
+        dashcards: [],
+      },
+      { wrapId: true },
+    );
+  });
+
+  it("should not save viz settings on metrics", () => {
+    openQuestionActions();
+    popover().findByText("Edit metric definition").click();
+    getNotebookStep("summarize").button("Count").click();
+    popover().within(() => {
+      cy.findByText("Sum of ...").click();
+      cy.findByText("Total").click();
+    });
+    cy.button("Save changes").click();
+    cy.get("@dashboardId").then(id => {
+      cy.visit(`/dashboard/${id}`);
+    });
+
+    editDashboard();
+    cy.findByTestId("dashboard-header")
+      .findByLabelText("Add questions")
+      .click();
+
+    sidebar().findByText("Metric 44171-A").click();
+
+    showDashboardCardActions(0);
+    getDashboardCard(0).findByLabelText("Add series").click();
+    modal().findByText("Metric 44171-B").should("be.visible");
   });
 });

--- a/e2e/test/scenarios/metrics/reproductions/metrics-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/reproductions/metrics-reproductions.cy.spec.ts
@@ -112,9 +112,7 @@ describe("issue 44171", () => {
     cy.signInAsAdmin();
 
     createQuestion(METRIC_A);
-    createQuestion(METRIC_B).then(({ body: { id } }) => {
-      cy.visit(`/metric/${id}`);
-    });
+    createQuestion(METRIC_B, { visitQuestion: true });
     createDashboard(
       {
         name: "Dashboard 44171",

--- a/frontend/src/metabase/query_builder/actions/core/core.js
+++ b/frontend/src/metabase/query_builder/actions/core/core.js
@@ -342,12 +342,12 @@ async function reduxUpdateQuestion(
 ) {
   const fullCard = question.card();
 
-  const omit = [
+  const keysToOmit = [
     excludeDatasetQuery ? "dataset_query" : null,
     excludeVizualisationSettings ? "visualization_settings" : null,
   ].filter(Boolean);
 
-  const card = _.omit(fullCard, ...omit);
+  const card = _.omit(fullCard, ...keysToOmit);
 
   const action = await dispatch(
     Questions.actions.update({ id: question.id() }, card),

--- a/frontend/src/metabase/query_builder/actions/core/core.js
+++ b/frontend/src/metabase/query_builder/actions/core/core.js
@@ -256,7 +256,7 @@ export const apiUpdateQuestion = (question, { rerunQuery } = {}) => {
           question,
           originalQuestion,
         ),
-        excludeVizualisationSettings: isMetric,
+        excludeVisualisationSettings: isMetric,
       },
     );
 
@@ -338,13 +338,13 @@ async function reduxCreateQuestion(question, dispatch) {
 async function reduxUpdateQuestion(
   question,
   dispatch,
-  { excludeDatasetQuery = false, excludeVizualisationSettings = false },
+  { excludeDatasetQuery = false, excludeVisualisationSettings = false },
 ) {
   const fullCard = question.card();
 
   const keysToOmit = [
     excludeDatasetQuery ? "dataset_query" : null,
-    excludeVizualisationSettings ? "visualization_settings" : null,
+    excludeVisualisationSettings ? "visualization_settings" : null,
   ].filter(Boolean);
 
   const card = _.omit(fullCard, ...keysToOmit);

--- a/frontend/src/metabase/query_builder/actions/core/core.js
+++ b/frontend/src/metabase/query_builder/actions/core/core.js
@@ -235,6 +235,7 @@ export const apiUpdateQuestion = (question, { rerunQuery } = {}) => {
 
     const isResultDirty = getIsResultDirty(getState());
     const isModel = question.type() === "model";
+    const isMetric = question.type() === "metric";
 
     const { isNative } = Lib.queryDisplayInfo(question.query());
 
@@ -255,6 +256,7 @@ export const apiUpdateQuestion = (question, { rerunQuery } = {}) => {
           question,
           originalQuestion,
         ),
+        excludeVizualisationSettings: isMetric,
       },
     );
 
@@ -336,12 +338,17 @@ async function reduxCreateQuestion(question, dispatch) {
 async function reduxUpdateQuestion(
   question,
   dispatch,
-  { excludeDatasetQuery = false },
+  { excludeDatasetQuery = false, excludeVizualisationSettings = false },
 ) {
   const fullCard = question.card();
-  const card = excludeDatasetQuery
-    ? _.omit(fullCard, "dataset_query")
-    : fullCard;
+
+  const omit = [
+    excludeDatasetQuery ? "dataset_query" : null,
+    excludeVizualisationSettings ? "visualization_settings" : null,
+  ].filter(Boolean);
+
+  const card = _.omit(fullCard, ...omit);
+
   const action = await dispatch(
     Questions.actions.update({ id: question.id() }, card),
   );


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/44171

### Description

This PR adds a reproduction for #44171, and fixes the underlying issue.

It does this by not unsetting `visualization_settings` when saving a metric, so it does not get written.

### How to verify
  - New → Metric, Orders, Count, Created At → Save as Metric 1 **without previewing**
  - New → Metric, Orders, Count, Created At → Save as Metric 2 without previewing
  - Now click on the run button and see the results for Metric 2
  - Click “Edit query definition” and change “Count” to “Sum of Total” and save the query **without previewing**
  - Create a dashboard and add Metric 1
  - Hover → Add series → Make sure you see have Metric 2 in the list


