### PR TITLE
[ParseSQL] log less warnings/errors

### DIFF
--- a/src/metabase/query_analysis.clj
+++ b/src/metabase/query_analysis.clj
@@ -144,9 +144,7 @@
               success?         (some? references)]
 
           (if-not success?
-            (do
-              (log/errorf "Failed to analyze query for card %s" card-id)
-              (t2/update! :model/QueryAnalysis analysis-id {:status "failed"}))
+            (t2/update! :model/QueryAnalysis analysis-id {:status "failed"})
             (do
               (t2/insert! :model/QueryField (map field->row (:fields references)))
               (t2/insert! :model/QueryTable (map table->row (:tables references)))
@@ -225,7 +223,7 @@
         card-id (:id card)]
     (cond
       (not card)       (log/warnf "Card not found: %s" card-id)
-      (:archived card) (log/warnf "Skipping archived card: %s" card-id)
+      (:archived card) (log/debugf "Skipping archived card: %s" card-id)
       :else            (do
                          (log/debugf "Performing query analysis for card %s" card-id)
                          (update-query-analysis-for-card! card)))))


### PR DESCRIPTION
Two reasons: it's very noisy, and the feature is not very user-visible, so does not make a lot of sense yet.

See [Slack thread](https://metaboat.slack.com/archives/C0641E4PB9B/p1728554132345679) for context.
