### PR TITLE
Only tag nightly on the current version

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -52,9 +52,14 @@ on:
         description: Apply to OSS
         type: boolean
         default: true
+      skip:
+        description: Skip everything in this job
+        type: boolean
+        default: false
 
 jobs:
   check-version:
+    if: ${{ !inputs.skip }}
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     outputs:
@@ -135,6 +140,7 @@ jobs:
           throw new Error("No edition selected to tag");
 
   copy-to-s3:
+    if: ${{ !inputs.skip }}
     runs-on: ubuntu-22.04
     needs: check-version
     timeout-minutes: 5
@@ -216,6 +222,7 @@ jobs:
         fi
 
   tag-docker-image:
+    if: ${{ !inputs.skip }}
     runs-on: ubuntu-22.04
     needs: check-version
     timeout-minutes: 5
@@ -260,6 +267,7 @@ jobs:
         docker push $DOCKERHUB_REPO\:$TAG_NAME
 
   push-git-tags:
+    if: ${{ !inputs.skip }}
     permissions: write-all
     needs: check-version
     runs-on: ubuntu-22.04
@@ -283,6 +291,7 @@ jobs:
         fi
 
   update-release-log:
+    if: ${{ !inputs.skip }}
     needs: check-version
     uses: ./.github/workflows/release-log.yml
     with:
@@ -290,6 +299,7 @@ jobs:
     secrets: inherit
 
   update-version-info:
+    if: ${{ !inputs.skip }}
     runs-on: ubuntu-22.04
     needs: check-version
     timeout-minutes: 5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
       id: canonical_version
       with:
         script: | # js
-          const { isValidVersionString, getCanonicalVersion, hasBeenReleased } = require('${{ github.workspace }}/release/dist/index.cjs');
+          const { isValidVersionString, getCanonicalVersion, hasBeenReleased, getMajorVersion } = require('${{ github.workspace }}/release/dist/index.cjs');
 
           const version = '${{ inputs.version }}';
 
@@ -69,9 +69,13 @@ jobs:
             throw new Error("The version format is invalid! It must start with either 'v0.' or 'v1.'.");
           }
 
+          const currentVersion = '${{ vars.CURRENT_VERSION }}';
+          const majorVersion = getMajorVersion(version);
+
           const versions = {
             ee: getCanonicalVersion(version, 'ee'),
             oss: getCanonicalVersion(version, 'oss'),
+            isCurrentMajorVersion: majorVersion === Number(currentVersion) ? 'true' : 'false',
           };
 
           const ossReleased = await hasBeenReleased({
@@ -688,11 +692,14 @@ jobs:
         --paths "/version-info.json" "/version-info-ee.json"
 
   tag-nightly:
-    if: false
+    if: ${{ inputs.auto }}
     needs: [push-tags, verify-docker-pull, verify-s3-download, check-version]
     uses: ./.github/workflows/release-tag.yml
     secrets: inherit
     with:
+      # we only want to tag the current version on the nightly channel, but we
+      # need this job to run even if we don't tag, so we send through a skip flag
+      skip: ${{ needs.check-version.outputs.isCurrentMajorVersion == 'true' }}
       version: ${{ inputs.version }}
       tag_name: nightly
       tag_rollout: 100


### PR DESCRIPTION

Updates automatic release workflow to only tag the current metabase version with the `nightly` tag
