### PR TITLE
Add release channel option to publish job

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -52,9 +52,14 @@ on:
         description: Apply to OSS
         type: boolean
         default: true
+      skip:
+        description: Skip everything in this job
+        type: boolean
+        default: false
 
 jobs:
   check-version:
+    if: ${{ !inputs.skip }}
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     outputs:
@@ -135,6 +140,7 @@ jobs:
           throw new Error("No edition selected to tag");
 
   copy-to-s3:
+    if: ${{ !inputs.skip }}
     runs-on: ubuntu-22.04
     needs: check-version
     timeout-minutes: 5
@@ -216,6 +222,7 @@ jobs:
         fi
 
   tag-docker-image:
+    if: ${{ !inputs.skip }}
     runs-on: ubuntu-22.04
     needs: check-version
     timeout-minutes: 5
@@ -260,6 +267,7 @@ jobs:
         docker push $DOCKERHUB_REPO\:$TAG_NAME
 
   push-git-tags:
+    if: ${{ !inputs.skip }}
     permissions: write-all
     needs: check-version
     runs-on: ubuntu-22.04
@@ -283,6 +291,7 @@ jobs:
         fi
 
   update-release-log:
+    if: ${{ !inputs.skip }}
     needs: check-version
     uses: ./.github/workflows/release-log.yml
     with:
@@ -290,6 +299,7 @@ jobs:
     secrets: inherit
 
   update-version-info:
+    if: ${{ !inputs.skip }}
     runs-on: ubuntu-22.04
     needs: check-version
     timeout-minutes: 5

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -39,6 +39,7 @@ on:
         #   - nightly
         #   - beta
         #   - latest
+        #   - none (skips everything)
         required: true
       tag_rollout:
         description: Rollout % (0-100)
@@ -52,14 +53,17 @@ on:
         description: Apply to OSS
         type: boolean
         default: true
-      skip:
-        description: Skip everything in this job
-        type: boolean
-        default: false
 
 jobs:
+  green-check-stub:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 2
+    steps:
+    - name: Stub
+      run: echo "Stub to make this job successful even if all the rest of the steps are skipped"
   check-version:
-    if: ${{ !inputs.skip }}
+    # skips everything if the tag_name is 'none' because all later jobs depend on this job
+    if: ${{ inputs.tag_name != 'none' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     outputs:
@@ -140,7 +144,6 @@ jobs:
           throw new Error("No edition selected to tag");
 
   copy-to-s3:
-    if: ${{ !inputs.skip }}
     runs-on: ubuntu-22.04
     needs: check-version
     timeout-minutes: 5
@@ -222,7 +225,6 @@ jobs:
         fi
 
   tag-docker-image:
-    if: ${{ !inputs.skip }}
     runs-on: ubuntu-22.04
     needs: check-version
     timeout-minutes: 5
@@ -267,7 +269,6 @@ jobs:
         docker push $DOCKERHUB_REPO\:$TAG_NAME
 
   push-git-tags:
-    if: ${{ !inputs.skip }}
     permissions: write-all
     needs: check-version
     runs-on: ubuntu-22.04
@@ -278,7 +279,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 0 # fetch all history
+        fetch-depth: 0 # we want all branches and tags
+        fetch-tags: true
     - name: Add and push git tag
       run: | # sh
 
@@ -291,7 +293,6 @@ jobs:
         fi
 
   update-release-log:
-    if: ${{ !inputs.skip }}
     needs: check-version
     uses: ./.github/workflows/release-log.yml
     with:
@@ -299,7 +300,6 @@ jobs:
     secrets: inherit
 
   update-version-info:
-    if: ${{ !inputs.skip }}
     runs-on: ubuntu-22.04
     needs: check-version
     timeout-minutes: 5
@@ -343,7 +343,6 @@ jobs:
           });
 
           fs.writeFileSync('version-info.json', JSON.stringify(newVersionInfo));
-
     - name: Upload new version-info.json to S3
       run: |
         if [[ "${{ matrix.edition }}" == "ee" ]]; then

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -194,7 +194,7 @@ jobs:
 
           return upload_path;
 
-    - name: Upload to s3 latest path
+    - name: Upload to s3 ${{ inputs.tag_name }} path
       run: | # sh
         aws s3 cp \
           s3://${{ vars.AWS_S3_DOWNLOADS_BUCKET }}/${{ steps.source_path.outputs.result }}/metabase.jar \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
       id: canonical_version
       with:
         script: | # js
-          const { isValidVersionString, getCanonicalVersion, hasBeenReleased } = require('${{ github.workspace }}/release/dist/index.cjs');
+          const { isValidVersionString, getCanonicalVersion, hasBeenReleased, getMajorVersion } = require('${{ github.workspace }}/release/dist/index.cjs');
 
           const version = '${{ inputs.version }}';
 
@@ -69,9 +69,13 @@ jobs:
             throw new Error("The version format is invalid! It must start with either 'v0.' or 'v1.'.");
           }
 
+          const currentVersion = '${{ vars.CURRENT_VERSION }}';
+          const majorVersion = getMajorVersion(version);
+
           const versions = {
             ee: getCanonicalVersion(version, 'ee'),
             oss: getCanonicalVersion(version, 'oss'),
+            isCurrentMajorVersion: majorVersion === Number(currentVersion) ? 'true' : 'false',
           };
 
           const ossReleased = await hasBeenReleased({
@@ -688,11 +692,14 @@ jobs:
         --paths "/version-info.json" "/version-info-ee.json"
 
   tag-nightly:
-    if: false
+    if: ${{ inputs.auto }}
     needs: [push-tags, verify-docker-pull, verify-s3-download, check-version]
     uses: ./.github/workflows/release-tag.yml
     secrets: inherit
     with:
+      # we only want to tag the current version on the nightly channel, but we
+      # need this job to run even if we don't tag, so we send through a skip flag
+      skip: ${{ needs.check-version.outputs.isCurrentMajorVersion == 'true' }}
       version: ${{ inputs.version }}
       tag_name: nightly
       tag_rollout: 100

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,16 @@ on:
       commit:
         description: 'A full-length commit SHA-1 hash'
         required: true
+      release-channel:
+        description: 'The release channel to publish to (optional)'
+        type: choice
+        options:
+          - none
+          - latest
+          - beta
+          - nightly
+        required: true
+        default: 'none'
       skip-docker:
         description: 'Skip Docker image publishing'
         type: boolean
@@ -706,10 +716,24 @@ jobs:
       tag_ee: true
       tag_oss: true
 
+  set-release-channel:
+    if: ${{ !inputs.auto }}
+    needs: [push-tags, verify-docker-pull, verify-s3-download, publish-version-info]
+    uses: ./.github/workflows/release-tag.yml
+    secrets: inherit
+    with:
+      # we need this job to run even if we don't tag, so we send through a skip flag
+      skip: ${{ inputs.release-channel == 'none' }}
+      version: ${{ inputs.version }}
+      tag_name: ${{ inputs.release-channel }}
+      tag_rollout: 100
+      tag_ee: true
+      tag_oss: true
+
   publish-complete-message:
     if: ${{ !inputs.auto }}
     runs-on: ubuntu-22.04
-    needs: [draft-release-notes, verify-docker-pull, verify-s3-download, publish-version-info]
+    needs: set-release-channel
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,26 +21,6 @@ on:
           - nightly
         required: true
         default: 'none'
-      skip-docker:
-        description: 'Skip Docker image publishing'
-        type: boolean
-        default: false
-      skip-s3:
-        description: 'Skip S3 artifact publishing'
-        type: boolean
-        default: false
-      skip-version-info:
-        description: 'Skip publishing version-info.json'
-        type: boolean
-        default: false
-      skip-tag:
-        description: 'Skip tagging the release'
-        type: boolean
-        default: false
-      skip-release-notes:
-        description: 'Skip publishing release notes'
-        type: boolean
-        default: false
       auto:
         description: 'auto-patch release DO NOT SET MANUALLY'
         type: boolean
@@ -206,7 +186,6 @@ jobs:
           ./version.properties
 
   upload-to-s3:
-    if: ${{ inputs.skip-s3 != true }}
     runs-on: ubuntu-22.04
     needs: download-uberjar
     timeout-minutes: 15
@@ -256,7 +235,6 @@ jobs:
 
 
   verify-s3-download:
-    if: ${{ inputs.skip-s3 != true }}
     runs-on: ubuntu-22.04
     needs: upload-to-s3
     timeout-minutes: 15
@@ -290,7 +268,6 @@ jobs:
       run: grep -q $(sha256sum ./metabase-downloaded.jar) SHA256.sum && echo "checksums match" || exit 1
 
   containerize:
-    if: ${{ inputs.skip-docker != true }}
     runs-on: ubuntu-22.04
     needs: [check-version, download-uberjar]
     timeout-minutes: 15
@@ -375,7 +352,6 @@ jobs:
         echo "Finished!"
 
   verify-docker-pull:
-    if: ${{ inputs.skip-docker != true }}
     runs-on: ubuntu-22.04
     needs: containerize
     timeout-minutes: 15
@@ -424,7 +400,6 @@ jobs:
       timeout-minutes: 3
 
   push-tags:
-    if: ${{ inputs.skip-tag != true }}
     permissions: write-all
     needs: [verify-s3-download, verify-docker-pull, check-version]
     runs-on: ubuntu-22.04
@@ -475,7 +450,7 @@ jobs:
         $GITHUB_WORKSPACE/release/reorder-tags.sh ${{ needs.check-version.outputs.ee }} ${{ inputs.commit }}
 
   trigger-docs-update:
-    if: ${{ !inputs.auto && inputs.skip-release-notes != true }}
+    if: ${{ !inputs.auto }}
     needs:
       - push-tags
       - check-version
@@ -591,7 +566,7 @@ jobs:
             });
 
   draft-release-notes:
-    if: ${{ !inputs.auto && inputs.skip-release-notes != true }}
+    if: ${{ !inputs.auto }}
     needs: push-tags
     runs-on: ubuntu-22.04
     timeout-minutes: 15
@@ -643,7 +618,6 @@ jobs:
             });
 
   publish-version-info:
-    if: ${{ !inputs.auto && inputs.skip-version-info != true }}
     runs-on: ubuntu-22.04
     needs: [push-tags, check-version]
     timeout-minutes: 15
@@ -654,6 +628,11 @@ jobs:
       AWS_S3_STATIC_BUCKET: ${{ vars.AWS_S3_STATIC_BUCKET }}
       AWS_REGION: ${{ vars.AWS_REGION }}
     steps:
+    - name: Finish early
+      if: ${{ inputs.auto }}
+      run: |
+        echo "skipping version info update for nightly patch"
+        exit 0
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -701,29 +680,11 @@ jobs:
         --distribution-id ${{ vars.AWS_CLOUDFRONT_STATIC_ID }} \
         --paths "/version-info.json" "/version-info-ee.json"
 
-  tag-nightly:
-    if: ${{ inputs.auto }}
-    needs: [push-tags, verify-docker-pull, verify-s3-download, check-version]
-    uses: ./.github/workflows/release-tag.yml
-    secrets: inherit
-    with:
-      # we only want to tag the current version on the nightly channel, but we
-      # need this job to run even if we don't tag, so we send through a skip flag
-      skip: ${{ needs.check-version.outputs.isCurrentMajorVersion == 'true' }}
-      version: ${{ inputs.version }}
-      tag_name: nightly
-      tag_rollout: 100
-      tag_ee: true
-      tag_oss: true
-
   set-release-channel:
-    if: ${{ !inputs.auto }}
-    needs: [push-tags, verify-docker-pull, verify-s3-download, publish-version-info]
+    needs: publish-version-info
     uses: ./.github/workflows/release-tag.yml
     secrets: inherit
     with:
-      # we need this job to run even if we don't tag, so we send through a skip flag
-      skip: ${{ inputs.release-channel == 'none' }}
       version: ${{ inputs.version }}
       tag_name: ${{ inputs.release-channel }}
       tag_rollout: 100
@@ -731,7 +692,6 @@ jobs:
       tag_oss: true
 
   publish-complete-message:
-    if: ${{ !inputs.auto }}
     runs-on: ubuntu-22.04
     needs: set-release-channel
     timeout-minutes: 5
@@ -750,34 +710,7 @@ jobs:
           script: | # js
             const { sendPublishCompleteMessage } = require('${{ github.workspace }}/release/dist/index.cjs');
 
-            await sendPublishCompleteMessage({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              version: '${{ inputs.version }}',
-              runId: '${{ github.run_id }}',
-              channelName: '${{ vars.SLACK_RELEASE_CHANNEL }}',
-              generalChannelName: 'general',
-            }).catch(console.error);
-
-  auto-publish-complete-message:
-    if: ${{ inputs.auto }}
-    runs-on: ubuntu-22.04
-    needs: tag-nightly
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          sparse-checkout: release
-      - name: Prepare build scripts
-        run: cd ${{ github.workspace }}/release && yarn && yarn build
-      - name: Send auto publish complete message
-        uses: actions/github-script@v7
-        env:
-          SLACK_RELEASE_CHANNEL: ${{ vars.SLACK_RELEASE_CHANNEL }}
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        with:
-          script: | # js
-            const { sendPublishCompleteMessage } = require('${{ github.workspace }}/release/dist/index.cjs');
+            const isAutoRelease = '${{ inputs.auto }}' === 'true';
 
             await sendPublishCompleteMessage({
               owner: context.repo.owner,
@@ -785,7 +718,7 @@ jobs:
               version: '${{ inputs.version }}',
               runId: '${{ github.run_id }}',
               channelName: '${{ vars.SLACK_RELEASE_CHANNEL }}',
-              generalChannelName: '',
+              generalChannelName: !isAutoRelease ? '${{ vars.SLACK_GENERAL_CHANNEL }}' : '',
             }).catch(console.error);
 
   manage-milestones:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
       id: canonical_version
       with:
         script: | # js
-          const { isValidVersionString, getCanonicalVersion, hasBeenReleased, getMajorVersion } = require('${{ github.workspace }}/release/dist/index.cjs');
+          const { isValidVersionString, getCanonicalVersion, hasBeenReleased } = require('${{ github.workspace }}/release/dist/index.cjs');
 
           const version = '${{ inputs.version }}';
 
@@ -59,13 +59,9 @@ jobs:
             throw new Error("The version format is invalid! It must start with either 'v0.' or 'v1.'.");
           }
 
-          const currentVersion = '${{ vars.CURRENT_VERSION }}';
-          const majorVersion = getMajorVersion(version);
-
           const versions = {
             ee: getCanonicalVersion(version, 'ee'),
             oss: getCanonicalVersion(version, 'oss'),
-            isCurrentMajorVersion: majorVersion === Number(currentVersion) ? 'true' : 'false',
           };
 
           const ossReleased = await hasBeenReleased({


### PR DESCRIPTION
closes https://github.com/metabase/metabase/issues/48627

## Description

This does a few things to simplify the release workflow

1. Removes now-irrelevant options to skip certain release steps. We only wanted to skip these steps in order to release more "slowly". Now that we have release channels, and a separate job to set them on demand, as well as patches that we can release quietly, we don't need to be able to skip release steps (some of which had implicit dependencies that made certain combinations of step skips impossible).
2. Combines the job-complete-message step for patches and regular releases. The only difference is whether they send a message to the #general slack channel
3. Doing the above greatly simplifies the ability to adds an input parameter to be able to (optionally) trigger the set-release-channel job at the end of a release.

![Screen Shot 2024-10-23 at 4 43 15 PM](https://github.com/user-attachments/assets/80748ddb-893a-43f2-bbc5-8d6acdca5d0b)

- ✅ [Test 1 - set nightly release channel](https://github.com/iethree/metabase/actions/runs/11497177638) (failing steps were irrelevant ones that don't work in my fork)
- ✅ [Test 2 - don't set release channel](https://github.com/iethree/metabase/actions/runs/11497358693)
