### PR TITLE
session generation for sdk should be gated by enable-embedding-sdk, not static.

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -8,8 +8,8 @@
    [metabase-enterprise.sso.integrations.sso-settings :as sso-settings]
    [metabase-enterprise.sso.integrations.sso-utils :as sso-utils]
    [metabase.api.common :as api]
-   [metabase.api.common.validation :as validation]
    [metabase.api.session :as api.session]
+   [metabase.embed.settings :as embed.settings]
    [metabase.integrations.common :as integrations.common]
    [metabase.public-settings.premium-features :as premium-features]
    [metabase.server.middleware.session :as mw.session]
@@ -106,7 +106,8 @@
 
 (defn ^:private generate-response-token
   [session jwt-data]
-  (validation/check-embedding-enabled)
+  (api/check (embed.settings/enable-embedding-sdk)
+             [400 (tru "SDK Embedding is not enabled.")])
   (response/response {:id  (:id session)
                       :exp (:exp jwt-data)
                       :iat (:iat jwt-data)}))

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -107,7 +107,7 @@
 (defn ^:private generate-response-token
   [session jwt-data]
   (api/check (embed.settings/enable-embedding-sdk)
-             [400 (tru "SDK Embedding is not enabled.")])
+             [402 (tru "SDK Embedding is not enabled.")])
   (response/response {:id  (:id session)
                       :exp (:exp jwt-data)
                       :iat (:iat jwt-data)}))

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -378,7 +378,7 @@
                                       :iat        jwt-iat-time
                                       :exp        jwt-exp-time}
                                      default-jwt-secret)
-              result       (client/client-real-response :get 400 "/auth/sso"
+              result       (client/client-real-response :get 402 "/auth/sso"
                                                         :token true
                                                         :jwt jwt-payload)]
           (is result nil)))))

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -346,7 +346,7 @@
 (deftest jwt-token-test
   (testing "should return a session token when token=true"
     (with-jwt-default-setup!
-      (mt/with-temporary-setting-values [enable-embedding-static true]
+      (mt/with-temporary-setting-values [enable-embedding-sdk true]
         (let [jwt-iat-time (buddy-util/now)
               jwt-exp-time (+ (buddy-util/now) 3600)
               jwt-payload  (jwt/sign {:email      "rasta@metabase.com"
@@ -367,7 +367,7 @@
 
   (testing "should not return a session token when embedding is disabled"
     (with-jwt-default-setup!
-      (mt/with-temporary-setting-values [enable-embedding false]
+      (mt/with-temporary-setting-values [enable-embedding-sdk false]
         (let [jwt-iat-time (buddy-util/now)
               jwt-exp-time (+ (buddy-util/now) 3600)
               jwt-payload  (jwt/sign {:email      "rasta@metabase.com"
@@ -385,7 +385,7 @@
 
   (testing "should not return a session token when token=false"
     (with-jwt-default-setup!
-      (mt/with-temporary-setting-values [enable-embedding true]
+      (mt/with-temporary-setting-values [enable-embedding-sdk true]
         (let [jwt-iat-time (buddy-util/now)
               jwt-exp-time (+ (buddy-util/now) 3600)
               jwt-payload  (jwt/sign {:email      "rasta@metabase.com"


### PR DESCRIPTION
This was a miss stemming from the logic that "static embedding is handled via JWT." However we actually return a jwt with session info when setting up the sdk. so this specific instance needs to make sure that the enable-embedding-sdk, is setup not enable-embedding-static.