### PR TITLE
fix: Always cast json number types as decimal

### DIFF
--- a/modules/drivers/druid-jdbc/test/metabase/driver/druid_jdbc/nested_field_columns_test.clj
+++ b/modules/drivers/druid-jdbc/test/metabase/driver/druid_jdbc/nested_field_columns_test.clj
@@ -67,7 +67,7 @@
                   :visibility-type :normal,
                   :nfc-path [:json_bit "genres"]}
                  {:name "json_bit → 1234",
-                  :database-type "bigint",
+                  :database-type "decimal",
                   :base-type :type/Integer,
                   :database-position 0,
                   :json-unfolding false,

--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -531,18 +531,11 @@
   This is the lowest common denominator of types, hopefully,
   although as of writing this is just geared towards Postgres types"
   {:type/Text       "text"
-   :type/Integer    "bigint"
-   ;; You might think that the ordinary 'bigint' type in Postgres and MySQL should be this.
-   ;; However, Bigint in those DB's maxes out at 2 ^ 64.
-   ;; JSON, like Javascript itself, will happily represent 1.8 * (10^308),
-   ;; Losing digits merrily along the way.
-   ;; We can't really trust anyone to use MAX_SAFE_INTEGER, in JSON-land..
-   ;; So really without forcing arbitrary precision ('decimal' type),
-   ;; we have too many numerical regimes to test.
-   ;; (#22732) was basically the consequence of missing one.
+   ;; Store db type as decimal so we always cast to the least constrained type
+   :type/Integer    "decimal"
    :type/BigInteger "decimal"
-   :type/Float      "double precision"
-   :type/Number     "double precision"
+   :type/Float      "decimal"
+   :type/Number     "decimal"
    :type/Decimal    "decimal"
    :type/Boolean    "boolean"
    :type/DateTime   "timestamp"

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -528,14 +528,14 @@
                                            :aggregation  [[:count]]
                                            :breakout     [[:field (u/the-id field) nil]]}})]
               (is (= ["SELECT"
-                      "  CONVERT(JSON_EXTRACT(`json`.`json_bit`, ?), UNSIGNED) AS `json_bit → 1234`,"
+                      "  CONVERT(JSON_EXTRACT(`json`.`json_bit`, ?), DECIMAL) AS `json_bit → 1234`,"
                       "  COUNT(*) AS `count`"
                       "FROM"
                       "  `json`"
                       "GROUP BY"
-                      "  CONVERT(JSON_EXTRACT(`json`.`json_bit`, ?), UNSIGNED)"
+                      "  CONVERT(JSON_EXTRACT(`json`.`json_bit`, ?), DECIMAL)"
                       "ORDER BY"
-                      "  CONVERT(JSON_EXTRACT(`json`.`json_bit`, ?), UNSIGNED) ASC"]
+                      "  CONVERT(JSON_EXTRACT(`json`.`json_bit`, ?), DECIMAL) ASC"]
                      (str/split-lines (driver/prettify-native-form :mysql (:query compile-res)))))
               (is (= '("$.\"1234\"" "$.\"1234\"" "$.\"1234\"") (:params compile-res))))))))))
 
@@ -555,7 +555,7 @@
                                                               :min-value 0.75,
                                                               :max-value 54.0,
                                                               :bin-width 0.75}}]]
-                  (is (= ["((FLOOR(((CONVERT(JSON_EXTRACT(`json`.`json_bit`, ?), UNSIGNED) - 0.75) / 0.75)) * 0.75) + 0.75)"
+                  (is (= ["((FLOOR(((CONVERT(JSON_EXTRACT(`json`.`json_bit`, ?), DECIMAL) - 0.75) / 0.75)) * 0.75) + 0.75)"
                           "$.\"1234\""]
                          (sql.qp/format-honeysql :mysql (sql.qp/->honeysql :mysql field-clause)))))))))))))
 

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -392,10 +392,10 @@
       (let [boop-field {:nfc-path [:bleh :meh] :database-type "decimal"}]
         (is (= [::postgres/json-query
                 [::h2x/identifier :field ["boop" "bleh"]]
-                "bigint"
+                "decimal"
                 [:meh]]
                (#'sql.qp/json-query :postgres boop-identifier boop-field)))
-        (is (= ["(boop.bleh#>> array[?]::text[])::bigint" "meh"]
+        (is (= ["(boop.bleh#>> array[?]::text[])::decimal" "meh"]
                (sql/format-expr (#'sql.qp/json-query :postgres boop-identifier boop-field))))))
     (testing "What if types are weird and we have lists"
       (let [weird-field {:nfc-path [:bleh "meh" :foobar 1234] :database-type "bigint"}]

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -389,7 +389,7 @@
 (deftest ^:parallel json-query-test
   (let [boop-identifier (h2x/identifier :field "boop" "bleh -> meh")]
     (testing "Transforming MBQL query with JSON in it to postgres query works"
-      (let [boop-field {:nfc-path [:bleh :meh] :database-type "bigint"}]
+      (let [boop-field {:nfc-path [:bleh :meh] :database-type "decimal"}]
         (is (= [::postgres/json-query
                 [::h2x/identifier :field ["boop" "bleh"]]
                 "bigint"

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -561,7 +561,7 @@
           (mt/with-db database
             (sync-tables/sync-tables-and-database! database)
             (is (= #{{:name              "trivial_json → a",
-                      :database-type     "bigint",
+                      :database-type     "decimal",
                       :base-type         :type/Integer,
                       :database-position 0,
                       :json-unfolding    false,
@@ -586,7 +586,7 @@
           (mt/with-db database
             (sync-tables/sync-tables-and-database! database)
             (is (= #{{:name              "trivial_json → a",
-                      :database-type     "bigint",
+                      :database-type     "decimal",
                       :base-type         :type/Integer,
                       :database-position 0,
                       :json-unfolding    false,

--- a/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
+++ b/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
@@ -489,7 +489,7 @@
                     :visibility-type   :normal
                     :nfc-path          [:jsoncol "mybool"]}
                    {:name              "jsoncol → myint"
-                    :database-type     "double precision"
+                    :database-type     "decimal"
                     :base-type         :type/Number
                     :database-position 0
                     :json-unfolding    false

--- a/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
+++ b/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
@@ -295,7 +295,7 @@
                     :visibility-type :normal,
                     :nfc-path [:json_bit "genres"]}
                    {:name "json_bit → 1234",
-                    :database-type "bigint",
+                    :database-type "decimal",
                     :base-type :type/Integer,
                     :database-position 0,
                     :json-unfolding false,
@@ -554,7 +554,7 @@
                                (t2/select-one Table :db_id (mt/id) :name "json_with_pk")))))
               (testing "if table doesn't have pk, we fail to detect the change in type but it still syncable"
                 (is (= [{:name              "json_col → int_turn_string"
-                         :database-type     "bigint"
+                         :database-type     "decimal"
                          :base-type         :type/Integer
                          :database-position 0
                          :json-unfolding    false


### PR DESCRIPTION
Fixes #48507
