### PR TITLE
[Notification] Minor changes to the channel template type name

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -793,6 +793,17 @@
                       metabase-enterprise.advanced-permissions.models.permissions.block-permissions-test
                       metabase-enterprise.sandbox.query-processor.middleware.row-level-restrictions-test]}}
 
+
+  ;; test the notification system
+  ;;    clj -X:dev:ee:ee-dev:test:test/notification
+  :test/notification
+  {:exec-args {:only ["test/metabase/notification"
+                      "test/metabase/channel"
+                      metabase.api.channel-test
+                      metabase.models.channel-test
+                      metabase.models.notification-test
+                      metabase.events.notification-test]}}
+
   ;; test all MBQL related stuff: MLv2, the legacy shared `metabase.legacy-mbql` code, and the QP
   ;;
   ;;    clj -X:dev:ee:ee-dev:test:test/mbql

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -839,13 +839,10 @@
       (ts/with-dbs [source-db dest-db]
         (ts/with-db source-db
           (mt/with-temp
-            [:model/Channel         _ {:name "My HTTP channel"
-                                       :type :channel/http
-                                       :details {:url         "http://example.com"
-                                                 :auth-method :none}}
-             :model/ChannelTemplate _ {:name         "My template"
-                                       :channel_type :channel/http
-                                       :details      {:my-custom-template true}}]
+            [:model/Channel _ {:name "My HTTP channel"
+                               :type :channel/http
+                               :details {:url         "http://example.com"
+                                         :auth-method :none}}]
             (storage/store! (seq (serdes/with-cache (into [] (extract/extract {})))) dump-dir)
             (ts/with-db dest-db
               (testing "doing ingestion"
@@ -855,8 +852,4 @@
                          :type    :channel/http
                          :details {:url         "http://example.com"
                                    :auth-method "none"}}
-                        (t2/select-one :model/Channel :name "My HTTP channel")))
-                (is (=? {:name         "My template"
-                         :channel_type :channel/http
-                         :details      {:my-custom-template true}}
-                        (t2/select-one :model/ChannelTemplate :name "My template")))))))))))
+                        (t2/select-one :model/Channel :name "My HTTP channel")))))))))))

--- a/src/metabase/channel/email.clj
+++ b/src/metabase/channel/email.clj
@@ -140,9 +140,9 @@
 (defn- render-body
   [{:keys [details] :as _template} payload]
   (case (keyword (:type details))
-    :email/resource
+    :email/mustache-resource
     (stencil/render-file (:path details) payload)
-    :email/mustache
+    :email/mustache-text
     (stencil/render-string (:body details) payload)
     nil))
 

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -1588,7 +1588,8 @@
                                                                        handler))]
         (t2/insert! :notification_recipient (map #(merge {:notification_handler_id handler-id
                                                           :created_at              :%now
-                                                          :updated_at              :%now} %)
+                                                          :updated_at              :%now}
+                                                         %)
                                                  recipients))))))
 
 (define-migration CreateSystemNotificationUserJoined

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -1596,7 +1596,7 @@
                      :channel_template
                      {:name         "User joined Email template"
                       :channel_type "channel/email"
-                      :details      (json/generate-string {:type           "email/resource"
+                      :details      (json/generate-string {:type           "email/mustache-resource"
                                                            :subject        "{{context.extra.user-invited-email-subject}}"
                                                            :path           "metabase/email/new_user_invite.mustache"
                                                            :recipient-type :cc})
@@ -1618,7 +1618,7 @@
                      :channel_template
                      {:name         "Alert Created Email template"
                       :channel_type "channel/email"
-                      :details      (json/generate-string {:type           "email/resource"
+                      :details      (json/generate-string {:type           "email/mustache-resource"
                                                            :subject        "You set up an alert"
                                                            :path           "metabase/email/alert_new_confirmation.mustache"
                                                            :recipient-type :cc})
@@ -1639,7 +1639,7 @@
                      :channel_template
                      {:name         "Slack Token Error Email template"
                       :channel_type "channel/email"
-                      :details      (json/generate-string {:type           "email/resource"
+                      :details      (json/generate-string {:type           "email/mustache-resource"
                                                            :subject        "Your Slack connection stopped working"
                                                            :path           "metabase/email/slack_token_error.mustache"
                                                            :recipient-type :cc})

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -1588,7 +1588,7 @@
                                                                        handler))]
         (t2/insert! :notification_recipient (map #(merge {:notification_handler_id handler-id
                                                           :created_at              :%now
-                                                          :updated_at              :%now}%)
+                                                          :updated_at              :%now} %)
                                                  recipients))))))
 
 (define-migration CreateSystemNotificationUserJoined
@@ -1611,7 +1611,6 @@
        :template_id     template-id
        :recipients      [{:type    "notification-recipient/template"
                           :details (json/generate-string {:pattern "{{event-info.object.email}}"})}]}])))
-
 
 (define-migration CreateSystemNotificationAlertCreated
   (let [template-id (t2/insert-returning-pk!

--- a/src/metabase/models/channel.clj
+++ b/src/metabase/models/channel.clj
@@ -71,8 +71,8 @@
    :details       mi/transform-json})
 
 (def ^:private channel-template-details-type
-  #{:email/mustache
-    :email/resource})
+  #{:email/mustache-text
+    :email/mustache-resource})
 
 (def ^:private ChannelTemplateEmailDetails
   [:merge
@@ -81,10 +81,10 @@
     [:subject                         string?]
     [:recipient-type {:optional true} (ms/enum-keywords-and-strings :cc :bcc)]]
    [:multi {:dispatch (comp keyword :type)}
-    [:email/resource
+    [:email/mustache-resource
      [:map
       [:path string?]]]
-    [:email/mustache
+    [:email/mustache-text
      [:map
       [:body string?]]]]])
 

--- a/test/metabase/api/channel_test.clj
+++ b/test/metabase/api/channel_test.clj
@@ -1,11 +1,15 @@
 (ns metabase.api.channel-test
   (:require
    [clojure.test :refer :all]
+   [metabase.channel.core :as channel]
    [metabase.channel.http-test :as channel.http-test]
    [metabase.notification.test-util :as notification.tu]
    [metabase.public-settings.premium-features :as premium-features]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
+
+#_{:clj-kondo/ignore [:metabase/validate-deftest]}
+(use-fixtures :once (fn [& _args] (channel/find-and-load-metabase-channels!)))
 
 (set! *warn-on-reflection* true)
 

--- a/test/metabase/models/channel_test.clj
+++ b/test/metabase/models/channel_test.clj
@@ -43,23 +43,23 @@
                                                     template)))]
       (testing "template is a mustache template"
         (testing "success"
-          (is (some? (insert! {:details {:type    "email/mustache"
+          (is (some? (insert! {:details {:type    "email/mustache-text"
                                          :subject "Hello {{name}}"
                                          :body    "Welcome {{name}}"}}))))
 
         (testing "invalid template"
           (is (thrown? Exception
-                       (insert! {:details {:type    "email/mustache"
+                       (insert! {:details {:type    "email/mustache-text"
                                            :subject "Hello {{name}"
                                            :body    nil}})))))
 
       (testing "template is a resource path"
         (testing "success"
-          (is (some? (insert! {:details {:type    "email/resource"
+          (is (some? (insert! {:details {:type    "email/mustache-resource"
                                          :subject "Hello {{name}}"
                                          :path    "/path/to/resource"}}))))
         (testing "invalid template"
           (is (thrown? Exception
-                       (insert! {:details {:type    "email/resource"
+                       (insert! {:details {:type    "email/mustache-resource"
                                            :subject "Hello {{name}}"
                                            :path    nil}}))))))))

--- a/test/metabase/notification/system_event_test.clj
+++ b/test/metabase/notification/system_event_test.clj
@@ -26,7 +26,7 @@
     (mt/with-model-cleanup [:model/Notification]
       (notification.tu/with-send-notification-sync!
         (mt/with-temp [:model/ChannelTemplate tmpl {:channel_type :channel/email
-                                                    :details      {:type    :email/mustache
+                                                    :details      {:type    :email/mustache-text
                                                                    :subject "Welcome {{event-info.object.first_name}} to {{context.site-name}}"
                                                                    :body    "Hello {{event-info.object.first_name}}! Welcome to {{context.site-name}}!"}}
                        :model/User             {user-id :id} {:email "ngoc@metabase.com"}
@@ -64,7 +64,7 @@
     (mt/with-model-cleanup [:model/Notification]
       (notification.tu/with-send-notification-sync!
         (mt/with-temp [:model/ChannelTemplate tmpl {:channel_type :channel/email
-                                                    :details      {:type    :email/resource
+                                                    :details      {:type    :email/mustache-resource
                                                                    :subject "Welcome {{event-info.object.first_name}} to {{context.site-name}}"
                                                                    :path    "notification/channel_template/hello_world"}}
                        :model/User             {user-id :id} {:email "ngoc@metabase.com"}
@@ -154,36 +154,37 @@
 
 (deftest alert-create-email-test
   (mt/with-temp [:model/Card card {:name "A Card"}]
-    (let [rasta (mt/fetch-user :rasta)
-          check (fn [alert-condition condition-regex]
-                  (let [regexes [#"This is just a confirmation"
-                                 (re-pattern (format "<a href=\"%s\"*>%s</a>" (urls/card-url (:id card)) (:name card)))
-                                 condition-regex]
-                        email (-> (notification.tu/with-captured-channel-send!
-                                    (events/publish-event! :event/alert-create {:object (t2/instance :model/Pulse
-                                                                                                     (merge {:name "A Pulse"
-                                                                                                             :card card}
-                                                                                                            alert-condition))
-                                                                                :user-id (:id rasta)}))
-                                  :channel/email
-                                  first)]
-                    (is (= {:recipients     #{(:email rasta)}
-                            :message-type   :attachments
-                            :subject        "You set up an alert"
-                            :message        [(zipmap (map str regexes) (repeat true))]
-                            :recipient-type :cc}
-                           (apply mt/summarize-multipart-single-email email regexes)))))]
+    (mt/with-temporary-setting-values [site-url "https://metabase.com"]
+      (let [rasta (mt/fetch-user :rasta)
+            check (fn [alert-condition condition-regex]
+                    (let [regexes [#"This is just a confirmation"
+                                   (re-pattern (format "<a href=\"%s\"*>%s</a>" (urls/card-url (:id card)) (:name card)))
+                                   condition-regex]
+                          email   (-> (notification.tu/with-captured-channel-send!
+                                        (events/publish-event! :event/alert-create {:object (t2/instance :model/Pulse
+                                                                                                         (merge {:name "A Pulse"
+                                                                                                                 :card card}
+                                                                                                                alert-condition))
+                                                                                    :user-id (:id rasta)}))
+                                      :channel/email
+                                      first)]
+                      (is (= {:recipients     #{(:email rasta)}
+                              :message-type   :attachments
+                              :subject        "You set up an alert"
+                              :message        [(zipmap (map str regexes) (repeat true))]
+                              :recipient-type :cc}
+                             (apply mt/summarize-multipart-single-email email regexes)))))]
 
-      (doseq [[alert-condition condition-regex]
-              [[{:alert_condition "rows"}
-                #"This alert will be sent whenever this question has any results"]
-               [{:alert_condition "goal"
-                 :alert_above_goal true}
-                #"This alert will be sent when this question meets its goal"]
-               [{:alert_condition "goal"
-                 :alert_above_goal false}
-                #"This alert will be sent when this question goes below its goal"]]]
-        (check alert-condition condition-regex)))))
+        (doseq [[alert-condition condition-regex]
+                [[{:alert_condition "rows"}
+                  #"This alert will be sent whenever this question has any results"]
+                 [{:alert_condition "goal"
+                   :alert_above_goal true}
+                  #"This alert will be sent when this question meets its goal"]
+                 [{:alert_condition "goal"
+                   :alert_above_goal false}
+                  #"This alert will be sent when this question goes below its goal"]]]
+          (check alert-condition condition-regex))))))
 
 (deftest slack-error-token-email-test
   (let [check (fn [recipients regexes]

--- a/test/metabase/notification/system_event_test.clj
+++ b/test/metabase/notification/system_event_test.clj
@@ -11,8 +11,8 @@
    [toucan2.core :as t2]))
 
 (use-fixtures
- :once
- (fixtures/initialize :test-users-personal-collections))
+  :once
+  (fixtures/initialize :test-users-personal-collections))
 
 (defn- publish-user-invited-event!
   [user invitor from-setup?]
@@ -202,8 +202,8 @@
                          (apply mt/summarize-multipart-single-email email regexes)))))
         admin-emails (t2/select-fn-set :email :model/User :is_superuser true)]
     (testing "send to admins with a link to setting page"
-     (check admin-emails [#"Your Slack connection stopped working"
-                          #"<a[^>]*href=\"https?://metabase\.com/admin/settings/slack\"[^>]*>Go to settings</a>"]))
+      (check admin-emails [#"Your Slack connection stopped working"
+                           #"<a[^>]*href=\"https?://metabase\.com/admin/settings/slack\"[^>]*>Go to settings</a>"]))
 
     (mt/with-temporary-setting-values
       [admin-email "it@metabase.com"]

--- a/test/metabase/notification/test_util.clj
+++ b/test/metabase/notification/test_util.clj
@@ -36,8 +36,8 @@
       (with-redefs
        [channel/send! (fn [channel message]
                         (swap! channel-messages update (:type channel) u/conjv message))]
-       (thunk)
-       @channel-messages))))
+        (thunk)
+        @channel-messages))))
 
 (defmacro with-captured-channel-send!
   "Macro that captures all messages sent to channels in the body of the macro.

--- a/test/metabase/notification/test_util.clj
+++ b/test/metabase/notification/test_util.clj
@@ -84,7 +84,7 @@
 (def channel-template-email-with-mustatche-body
   "A :model/ChannelTemplate for email channels that has a :event/mustache template."
   {:channel_type :channel/email
-   :details      {:type    :email/mustache
+   :details      {:type    :email/mustache-text
                   :subject "Welcome {{event-info.object.first_name}} to {{settings.site-name}}"
                   :body    "Hello {{event-info.object.first_name}}! Welcome to {{settings.site-name}}!"}})
 


### PR DESCRIPTION
rename the type for `channel_template.details.type`
- email/resource -> email/mustache-resource
- email/mustache -> email/mustache-text

the motivation is that we might use more than just mustache as the template in the future

also added an alias to run notification tests

```
clj -X:dev:ee:ee-dev:test:test/notification
```