### PR TITLE
fix flaky test on embed share behaviour snowplow events

### DIFF
--- a/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
@@ -741,6 +741,7 @@ describe("#39152 sharing an unsaved question", () => {
             });
           });
         });
+
         it("should send `static_embed_unpublished` when unpublishing changes in the static embed modal", () => {
           cy.get("@resourceId").then(id => {
             enableEmbeddingForResource({ resource, id });

--- a/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
@@ -695,7 +695,7 @@ describe("#39152 sharing an unsaved question", () => {
               new_embed: true,
               time_since_creation: closeTo(
                 toSecond(Date.now() - this.timeAfterResourceCreation),
-                1,
+                15,
               ),
               time_since_initial_publication: null,
               params: {
@@ -731,8 +731,8 @@ describe("#39152 sharing an unsaved question", () => {
               event: "static_embed_published",
               artifact: resource,
               new_embed: false,
-              time_since_creation: closeTo(toSecond(HOUR), 10),
-              time_since_initial_publication: closeTo(toSecond(HOUR), 10),
+              time_since_creation: closeTo(toSecond(HOUR), 15),
+              time_since_initial_publication: closeTo(toSecond(HOUR), 15),
               params: {
                 disabled: 1,
                 locked: 1,
@@ -741,7 +741,6 @@ describe("#39152 sharing an unsaved question", () => {
             });
           });
         });
-
         it("should send `static_embed_unpublished` when unpublishing changes in the static embed modal", () => {
           cy.get("@resourceId").then(id => {
             enableEmbeddingForResource({ resource, id });


### PR DESCRIPTION
Attempt to close #48634

Stress test: https://github.com/metabase/metabase/actions/runs/11328876682/job/31503083670