### PR TITLE
fix: calculate row for object details correctly

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
@@ -184,6 +184,16 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
     assertOrderDetailView({ id: FIRST_ORDER_ID });
   });
 
+  it("calculates a row after scrolling correctly (metabase#48323)", () => {
+    openOrdersTable();
+    cy.get(".ReactVirtualized__Grid").eq(1).scrollTo(0, 15000);
+    cy.icon("expand").first().click();
+    cy.findByRole("dialog")
+      .should("contain", "418")
+      .and("contain", "58")
+      .and("contain", "February 14, 2026, 10:12 AM");
+  });
+
   it("handles browsing records by FKs (metabase#21756)", () => {
     openOrdersTable();
 

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -409,9 +409,9 @@ class TableInteractive extends Component {
   };
 
   recomputeGridSize = () => {
-    if (this.header && this.grid) {
+    if (this.header && this.gridRef.current) {
       this.header.recomputeGridSize();
-      this.grid.recomputeGridSize();
+      this.gridRef.current.recomputeGridSize();
     }
   };
 
@@ -1043,7 +1043,7 @@ class TableInteractive extends Component {
       return;
     }
 
-    const scrollOffset = this.gridRef.current?.scrollTop || 0;
+    const scrollOffset = this.gridRef.current?.props?.scrollTop || 0;
 
     // infer row index from mouse position when we hover the gutter column
     if (event?.currentTarget?.id === "gutter-column") {
@@ -1262,7 +1262,7 @@ class TableInteractive extends Component {
                 />
                 <Grid
                   id="main-data-grid"
-                  ref={ref => (this.grid = ref)}
+                  ref={this.gridRef}
                   style={{
                     top: headerHeight,
                     left: 0,


### PR DESCRIPTION
fixes https://github.com/metabase/metabase/issues/48323

### Description

the bug appeared in https://github.com/metabase/metabase/pull/48109 as a result of migration away from the old React api - findDomNode

### How to verify

Describe the steps to verify that the changes are working as expected.

1. open orders table -> scroll down by several screens 
2. click on expand icon that appears when you place mouse over a row
3. correct data should be displayed in the modal - the same as displayed in the row you selected

### Demo


### Before

https://github.com/user-attachments/assets/726fa16e-7f18-4c39-8f0b-b9be03a3bac3



### After

https://github.com/user-attachments/assets/3f1a9bea-9146-4fd1-99c5-d26e862ace6a





### Checklist

- [x] Tests have been added/updated to cover changes in this PR
