### PR TITLE
Partition (parallelize) Postgres driver tests

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -738,6 +738,10 @@ jobs:
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        partition-index: [0, 1]
     env:
       CI: 'true'
       DRIVERS: postgres
@@ -762,12 +766,19 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-postgres-ee'
+        test-args: >-
+          :partition/total 2
+          :partition/index ${{ matrix.partition-index }}
 
   be-tests-postgres-latest-ee:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        partition-index: [0, 1]
     env:
       CI: 'true'
       DRIVERS: postgres
@@ -795,6 +806,9 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-postgres-latest-ee'
+        test-args: >-
+          :partition/total 2
+          :partition/index ${{ matrix.partition-index }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()


### PR DESCRIPTION
Part of #45009

Now that #48422 and #48489 are in, Postgres tests are the new slowest backend test jobs at approximately ~40 minutes each.

This PR splits the 2 Postgres jobs up into 4 which will hopefully make things a little bit faster overall.

After this PR the slower job is ~32 minutes, so this shaves ~8 minutes off of Postgres test runs