### PR TITLE
Consolidate config for MySQL/MariaDB jobs in CI driver test config

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -228,6 +228,7 @@ jobs:
             env:
               test-ssl: 'true'
         partition-index: [0, 1, 2, 3]
+    name: Test ${{ matrix.version.name }} (${{ matrix.partition-index }})
     services:
       mysql:
         image: ${{ matrix.version.docker-image }}
@@ -235,8 +236,8 @@ jobs:
           - "3306:3306"
         env:
           MYSQL_DATABASE: metabase_test
-          MYSQL_USER: root
-          MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+          MYSQL_USER: metabase
+          MYSQL_PASSWORD: metabase
     env:
       CI: 'true'
       DRIVERS: mysql
@@ -244,8 +245,10 @@ jobs:
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
       MB_DB_DBNAME: metabase_test
-      MB_DB_USER: root
-      MB_MYSQL_TEST_USER: root
+      MB_DB_USER: metabase
+      MB_DB_PASS: metabase
+      MB_MYSQL_TEST_USER: metabase
+      MB_MYSQL_TEST_PASSWORD: metabase
       # set up env vars for something named "MYSQL_SSL" to run MySQL SSL tests verifying connectivity with PEM cert
       # they are deliberately given a different name to prevent them from affecting the regular test run against
       # the configured MySQL instance, but there is one particular test (mysql-connect-with-ssl-and-pem-cert-test)

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -198,7 +198,7 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
 
-  be-tests-mariadb-10-2-ee:
+  be-tests-mysql-mariadb:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
@@ -206,6 +206,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        version:
+          - name: MariaDB Latest
+            junit-name: mariadb-latest
+            docker-image: mariadb:latest
+          - name: MariaDB 10.2
+            junit-name: mariadb-10-2
+            docker-image: mariadb:10.2.23
+          - name: MySQL 8.0
+            junit-name: mysql-8-0
+            docker-image: mysql:8.0
+          - name: MySQL Latest
+            junit-name: mysql-latest
+            docker-image: mysql:latest
         partition-index: [0, 1, 2, 3]
     env:
       CI: 'true'
@@ -213,64 +226,25 @@ jobs:
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: circle_test
+      MB_DB_DBNAME: metabase_test
       MB_DB_USER: root
+      MB_DB_PASS: ''
       MB_MYSQL_TEST_USER: root
     services:
       mariadb:
-        image: circleci/mariadb:10.2.23
+        image: ${{ matrix.version.docker-image }}
         ports:
           - "3306:3306"
+        env:
+          MYSQL_DATABASE: metabase_test
+          MYSQL_USER: root
+          MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
     steps:
     - uses: actions/checkout@v4
-    - name: Test MariaDB driver (10.2)
+    - name: Test ${{ matrix.version.name }}
       uses: ./.github/actions/test-driver
       with:
-        junit-name: 'be-tests-mariadb-10-2-ee'
-        test-args: >-
-          :partition/total 4
-          :partition/index ${{ matrix.partition-index }}
-    - name: Upload Test Results
-      uses: ./.github/actions/upload-test-results
-      if: always()
-      with:
-        input-path: ./target/junit/
-        output-name: ${{ github.job }}
-        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
-        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ vars.AWS_REGION }}
-        trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
-
-  be-tests-mariadb-latest-ee:
-    needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: ubuntu-22.04
-    timeout-minutes: 90
-    strategy:
-      fail-fast: false
-      matrix:
-        partition-index: [0, 1, 2, 3]
-    env:
-      CI: 'true'
-      DRIVERS: mysql
-      MB_DB_TYPE: mysql
-      MB_DB_HOST: localhost
-      MB_DB_PORT: 3306
-      MB_DB_DBNAME: circle_test
-      MB_DB_USER: root
-      MB_MYSQL_TEST_USER: root
-    services:
-      mariadb:
-        image: circleci/mariadb:latest
-        ports:
-          - "3306:3306"
-    steps:
-    - uses: actions/checkout@v4
-    - name: Test MariaDB driver (latest)
-      uses: ./.github/actions/test-driver
-      with:
-        junit-name: 'be-tests-mariadb-latest-ee'
+        junit-name: 'be-tests-${{ matrix.version.junit-name }}-ee'
         test-args: >-
           :partition/total 4
           :partition/index ${{ matrix.partition-index }}
@@ -531,109 +505,6 @@ jobs:
       with:
         junit-name: 'be-tests-mongo-sharded-cluster-ee'
         test-args: ':only "[metabase.driver.mongo.sharded-cluster-test]"'
-    - name: Upload Test Results
-      uses: ./.github/actions/upload-test-results
-      if: always()
-      with:
-        input-path: ./target/junit/
-        output-name: ${{ github.job }}
-        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
-        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ vars.AWS_REGION }}
-        trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
-
-  be-tests-mysql-8-0-ee:
-    needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: ubuntu-22.04
-    timeout-minutes: 90
-    strategy:
-      fail-fast: false
-      matrix:
-        partition-index: [0, 1, 2, 3]
-    env:
-      CI: 'true'
-      DRIVERS: mysql
-      MB_DB_TYPE: mysql
-      MB_DB_HOST: localhost
-      MB_DB_PORT: 3306
-      MB_DB_DBNAME: circle_test
-      MB_DB_USER: root
-      MB_MYSQL_TEST_USER: root
-    services:
-      mysql:
-        image: cimg/mysql:8.0
-        ports:
-          - "3306:3306"
-    steps:
-    - uses: actions/checkout@v4
-    - name: Test MySQL driver (8.0)
-      uses: ./.github/actions/test-driver
-      with:
-        junit-name: 'be-tests-mysql-8-0-ee'
-        test-args: >-
-          :partition/total 4
-          :partition/index ${{ matrix.partition-index }}
-    - name: Upload Test Results
-      uses: ./.github/actions/upload-test-results
-      if: always()
-      with:
-        input-path: ./target/junit/
-        output-name: ${{ github.job }}
-        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
-        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ vars.AWS_REGION }}
-        trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
-
-  be-tests-mysql-latest-ee:
-    needs: files-changed
-    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: ubuntu-22.04
-    timeout-minutes: 90
-    strategy:
-      fail-fast: false
-      matrix:
-        partition-index: [0, 1, 2, 3]
-    env:
-      CI: 'true'
-      DRIVERS: mysql
-      MB_DB_TYPE: mysql
-      MB_DB_HOST: localhost
-      MB_DB_PORT: 3306
-      MB_DB_DBNAME: circle_test
-      MB_DB_USER: root
-      MB_MYSQL_TEST_USER: root
-      # set up env vars for something named "MYSQL_SSL" to run MySQL SSL tests verifying connectivity with PEM cert
-      # they are deliberately given a different name to prevent them from affecting the regular test run against
-      # the configured MySQL instance, but there is one particular test (mysql-connect-with-ssl-and-pem-cert-test)
-      # that overrides the MB_MYSQL_TEST_* values with them
-      # the MYSQL_RDS_SSL_INSTANCE vars are defined as secrets and can be altered
-      MB_MYSQL_SSL_TEST_HOST: ${{ secrets.MYSQL_RDS_SSL_INSTANCE_HOST }}
-      MB_MYSQL_SSL_TEST_SSL: true
-      MB_MYSQL_SSL_TEST_ADDITIONAL_OPTIONS: 'verifyServerCertificate=true'
-      # the contents of the ./resources/certificates/rds-combined-ca-bundle.pem file
-      MB_MYSQL_SSL_TEST_SSL_CERT: ${{ secrets.MB_MYSQL_SSL_TEST_SSL_CERT }}
-      MB_MYSQL_SSL_TEST_USER: metabase
-      MB_MYSQL_SSL_TEST_PASSWORD: ${{ secrets.MYSQL_RDS_SSL_INSTANCE_PASSWORD }}
-    services:
-      mysql:
-        image: mysql:latest
-        env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: true
-          MYSQL_DATABASE: circle_test
-        ports:
-        - "3306:3306"
-    steps:
-    - uses: actions/checkout@v4
-    - name: Test MySQL driver (latest)
-      uses: ./.github/actions/test-driver
-      with:
-        junit-name: 'be-tests-mysql-latest-ee'
-        test-args: >-
-          :partition/total 4
-          :partition/index ${{ matrix.partition-index }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -210,16 +210,33 @@ jobs:
           - name: MariaDB Latest
             junit-name: mariadb-latest
             docker-image: mariadb:latest
+            env:
+              test-ssl: 'false'
           - name: MariaDB 10.2
             junit-name: mariadb-10-2
             docker-image: mariadb:10.2.23
+            env:
+              test-ssl: 'false'
           - name: MySQL 8.0
             junit-name: mysql-8-0
             docker-image: mysql:8.0
+            env:
+              test-ssl: 'false'
           - name: MySQL Latest
             junit-name: mysql-latest
             docker-image: mysql:latest
+            env:
+              test-ssl: 'true'
         partition-index: [0, 1, 2, 3]
+    services:
+      mysql:
+        image: ${{ matrix.version.docker-image }}
+        ports:
+          - "3306:3306"
+        env:
+          MYSQL_DATABASE: metabase_test
+          MYSQL_USER: root
+          MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
     env:
       CI: 'true'
       DRIVERS: mysql
@@ -228,37 +245,41 @@ jobs:
       MB_DB_PORT: 3306
       MB_DB_DBNAME: metabase_test
       MB_DB_USER: root
-      MB_DB_PASS: ''
       MB_MYSQL_TEST_USER: root
-    services:
-      mariadb:
-        image: ${{ matrix.version.docker-image }}
-        ports:
-          - "3306:3306"
-        env:
-          MYSQL_DATABASE: metabase_test
-          MYSQL_USER: root
-          MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+      # set up env vars for something named "MYSQL_SSL" to run MySQL SSL tests verifying connectivity with PEM cert
+      # they are deliberately given a different name to prevent them from affecting the regular test run against
+      # the configured MySQL instance, but there is one particular test (mysql-connect-with-ssl-and-pem-cert-test)
+      # that overrides the MB_MYSQL_TEST_* values with them
+      # the MYSQL_RDS_SSL_INSTANCE vars are defined as secrets and can be altered
+      #
+      # This is only enabled for MySQL latest tests
+      MB_MYSQL_SSL_TEST_SSL: ${{ matrix.version.env.test-ssl }}
+      MB_MYSQL_SSL_TEST_HOST: ${{ secrets.MYSQL_RDS_SSL_INSTANCE_HOST }}
+      MB_MYSQL_SSL_TEST_ADDITIONAL_OPTIONS: 'verifyServerCertificate=true'
+      # the contents of the ./resources/certificates/rds-combined-ca-bundle.pem file
+      MB_MYSQL_SSL_TEST_SSL_CERT: ${{ secrets.MB_MYSQL_SSL_TEST_SSL_CERT }}
+      MB_MYSQL_SSL_TEST_USER: metabase
+      MB_MYSQL_SSL_TEST_PASSWORD: ${{ secrets.MYSQL_RDS_SSL_INSTANCE_PASSWORD }}
     steps:
-    - uses: actions/checkout@v4
-    - name: Test ${{ matrix.version.name }}
-      uses: ./.github/actions/test-driver
-      with:
-        junit-name: 'be-tests-${{ matrix.version.junit-name }}-ee'
-        test-args: >-
-          :partition/total 4
-          :partition/index ${{ matrix.partition-index }}
-    - name: Upload Test Results
-      uses: ./.github/actions/upload-test-results
-      if: always()
-      with:
-        input-path: ./target/junit/
-        output-name: ${{ github.job }}
-        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
-        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ vars.AWS_REGION }}
-        trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
+      - uses: actions/checkout@v4
+      - name: Test ${{ matrix.version.name }}
+        uses: ./.github/actions/test-driver
+        with:
+          junit-name: 'be-tests-${{ matrix.version.junit-name }}-ee'
+          test-args: >-
+            :partition/total 4
+            :partition/index ${{ matrix.partition-index }}
+      - name: Upload Test Results
+        uses: ./.github/actions/upload-test-results
+        if: always()
+        with:
+          input-path: ./target/junit/
+          output-name: ${{ github.job }}
+          bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+          aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
+          trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
 
   be-tests-mongo-4-4-ee:
     needs: files-changed

--- a/src/metabase/db/data_source.clj
+++ b/src/metabase/db/data_source.clj
@@ -162,6 +162,7 @@
         properties                              (some-> (not-empty (dissoc spec :classname :subprotocol :subname))
                                                         remove-shadowed-azure-managed-identity-client-id
                                                         connection-pool/map->properties)]
-
+    (println "url:" url) ; NOCOMMIT
+    (println "(pr-str spec):" (pr-str spec)) ; NOCOMMIT
     (update-h2/update-if-needed! url)
     (->DataSource url properties)))

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -5,6 +5,7 @@
    [clojure.test :refer :all]
    [honey.sql :as sql]
    [metabase.actions.error :as actions.error]
+   [metabase.config :as config]
    [metabase.db.metadata-queries :as metadata-queries]
    [metabase.driver :as driver]
    [metabase.driver.mysql :as mysql]
@@ -450,14 +451,14 @@
 
 (deftest mysql-connect-with-ssl-and-pem-cert-test
   (mt/test-driver :mysql
-    (if (System/getenv "MB_MYSQL_SSL_TEST_SSL_CERT")
+    (if (config/config-bool :mb-mysql-ssl-test-ssl)
       (testing "MySQL with SSL connectivity using PEM certificate"
         (mt/with-env-keys-renamed-by #(str/replace-first % "mb-mysql-ssl-test" "mb-mysql-test")
           (string-extracts-test/test-breakout)))
       (log/info (u/format-color 'yellow
                                 "Skipping %s because %s env var is not set"
                                 "mysql-connect-with-ssl-and-pem-cert-test"
-                                "MB_MYSQL_SSL_TEST_SSL_CERT")))))
+                                "MB_MYSQL_SSL_TEST_SSL")))))
 
 (deftest ^:parallel json-query-test
   (let [boop-identifier (h2x/identifier :field "boop" "bleh -> meh")]


### PR DESCRIPTION
The config for MySQL and MariaDB is a 98% the same between the four different job definitions; since we're already already defining a matrix we can actually consolidate them all into one single job definition using the matrix to switch between versions. 

I switched away from the CircleCI images to the normal ones that we use in the https://github.com/metabase/dev-scripts repo as well.