### PR TITLE
Use name from metric aggregation after preprocessing

### DIFF
--- a/src/metabase/lib/metric.cljc
+++ b/src/metabase/lib/metric.cljc
@@ -146,5 +146,4 @@
                                    first)
         metric-name (:name metric-meta)]
     (assoc (lib.metadata.calculation/metadata query stage-number metric-aggregation)
-           :name metric-name
            :display-name metric-name)))

--- a/src/metabase/query_processor/middleware/metrics.clj
+++ b/src/metabase/query_processor/middleware/metrics.clj
@@ -50,7 +50,6 @@
          (into {}
                (map (fn [card-metadata]
                       (let [unprocessed-metric-query (lib/query query (:dataset-query card-metadata))
-                            [_ {aggregation-name :name}] (first (lib/aggregations unprocessed-metric-query))
                             metric-query (lib.convert/->pMBQL
                                           ((requiring-resolve 'metabase.query-processor.preprocess/preprocess)
                                            unprocessed-metric-query))
@@ -58,7 +57,8 @@
                         (if-let [aggregation (first (lib/aggregations metric-query))]
                           [(:id card-metadata)
                            {:query metric-query
-                            :aggregation (assoc-in aggregation [1 :name] (or aggregation-name metric-name))
+                            :aggregation (cond-> aggregation
+                                           (nil? (get-in aggregation [1 :name])) (assoc-in [1 :name] metric-name))
                             :name metric-name}]
                           (throw (ex-info "Source metric missing aggregation" {:source metric-query})))))))
          not-empty)))

--- a/src/metabase/query_processor/middleware/metrics.clj
+++ b/src/metabase/query_processor/middleware/metrics.clj
@@ -49,16 +49,16 @@
          (lib.metadata/bulk-metadata-or-throw query :metadata/card)
          (into {}
                (map (fn [card-metadata]
-                      (let [unprocessed-metric-query (lib/query query (:dataset-query card-metadata))
-                            metric-query (lib.convert/->pMBQL
+                      (let [metric-query (lib.convert/->pMBQL
                                           ((requiring-resolve 'metabase.query-processor.preprocess/preprocess)
-                                           unprocessed-metric-query))
+                                           (lib/query query (:dataset-query card-metadata))))
                             metric-name (:name card-metadata)]
                         (if-let [aggregation (first (lib/aggregations metric-query))]
                           [(:id card-metadata)
                            {:query metric-query
-                            :aggregation (cond-> aggregation
-                                           (nil? (get-in aggregation [1 :name])) (assoc-in [1 :name] metric-name))
+                            ;; Aggregation inherits `:name` of original aggregation used in a metric query. The original
+                            ;; name is added in `preprocess` above if metric is defined using unnamed aggregation.
+                            :aggregation aggregation
                             :name metric-name}]
                           (throw (ex-info "Source metric missing aggregation" {:source metric-query})))))))
          not-empty)))

--- a/test/metabase/query_processor/middleware/annotate_test.clj
+++ b/test/metabase/query_processor/middleware/annotate_test.clj
@@ -460,15 +460,14 @@
   (qp.store/with-metadata-provider meta/metadata-provider
     (testing (str "if a driver is kind enough to supply us with some information about the `:cols` that come back, we "
                   "should include that information in the results. Their information should be preferred over ours")
-      (is (=? {:cols [{:name           "totalEvents"
-                       :display_name   "Total Events"
+      (is (=? {:cols [{:display_name   "Total Events"
                        :base_type      :type/Text
                        :effective_type :type/Text
                        :source         :aggregation
                        :field_ref      [:aggregation 0]}]}
               (add-column-info
                (lib.tu.macros/mbql-query venues {:aggregation [[:metric 1]]})
-               {:cols [{:name "totalEvents", :display_name "Total Events", :base_type :type/Text}]}))))))
+               {:cols [{:display_name "Total Events", :base_type :type/Text}]}))))))
 
 (deftest ^:parallel col-info-for-aggregation-clause-test-4
   (qp.store/with-metadata-provider meta/metadata-provider

--- a/test/metabase/query_processor/middleware/metrics_test.clj
+++ b/test/metabase/query_processor/middleware/metrics_test.clj
@@ -298,7 +298,7 @@
                :expressions [[:+ {:lib/expression-name "foobar"} [:field {} (meta/id :orders :discount)] 1]]
                :fields [[:expression {} "foobar"]]}
               {:lib/type :mbql.stage/mbql,
-               :aggregation [[:avg {:name "Mock Metric"} [:field {} "foobar"]]]}]}
+               :aggregation [[:avg {:name "avg"} [:field {} "foobar"]]]}]}
             (adjust question)))))
 
 (deftest ^:parallel metric-question-on-aggregate-column-model-test
@@ -310,7 +310,7 @@
              [{:source-table (meta/id :orders)
                :aggregation [[:sum {} [:field {} (meta/id :orders :discount)]]]}
               {:lib/type :mbql.stage/mbql,
-               :aggregation [[:avg {:name "Mock Metric"} [:field {} "sum"]]]}]}
+               :aggregation [[:avg {:name "avg"} [:field {} "sum"]]]}]}
             (adjust question)))))
 
 (deftest ^:parallel metric-question-on-model-based-on-model-test
@@ -335,7 +335,7 @@
                [{:source-table (meta/id :orders)
                  :filters [[:> {} [:field {} (meta/id :orders :discount)] 3]]}
                 {}
-                {:aggregation [[:avg {:name "Mock Metric"} [:field {} "QUANTITY"]]]}]}
+                {:aggregation [[:avg {:name "avg"} [:field {} "QUANTITY"]]]}]}
               (adjust question))))))
 
 (deftest ^:parallel metric-question-on-multi-stage-model-test
@@ -350,7 +350,7 @@
              [{:source-table (meta/id :orders)
                :aggregation [[:sum {} [:field {} (meta/id :orders :discount)]]]}
               {:filters [[:> {} [:field {} "sum"] 2]]}
-              {:aggregation [[:avg {:name "Mock Metric"} [:field {} "sum"]]]}]}
+              {:aggregation [[:avg {:name "avg"} [:field {} "sum"]]]}]}
             (adjust question)))))
 
 (deftest ^:parallel metric-question-on-native-model-test
@@ -361,7 +361,7 @@
     (is (=? {:stages
              [{:lib/type :mbql.stage/native,
                :native "SELECT whatever"}
-              {:aggregation [[:avg {:name "Mock Metric"} [:field {} "sum"]]]}]}
+              {:aggregation [[:avg {:name "avg"} [:field {} "sum"]]]}]}
             (adjust question)))))
 
 (deftest ^:parallel maintain-aggregation-refs-test
@@ -486,7 +486,7 @@
 (deftest ^:parallel default-metric-names-test
   (let [[source-metric mp] (mock-metric)]
     (is (=?
-         {:stages [{:aggregation [[:avg {:display-name complement :name "Mock Metric"} some?]]}]}
+         {:stages [{:aggregation [[:avg {:display-name complement :name "avg"} some?]]}]}
          (adjust (-> (lib/query mp (meta/table-metadata :products))
                      (lib/aggregate (lib.metadata/metric mp (:id source-metric)))))))))
 
@@ -520,7 +520,7 @@
     (is (=?
          {:stages
           [{:source-table (meta/id :products)
-            :aggregation [[:avg {:name "Mock Metric"} [:field {} (meta/id :products :rating)]]]
+            :aggregation [[:avg {:name "avg"} [:field {} (meta/id :products :rating)]]]
             :filters [[:= {} [:field {} (meta/id :venues :name)] some?]]}]}
          (adjust (lib/query mp source-metric))))
     ;; Segments will be expanded in this case as the metric query that is spliced in needs to be processed
@@ -623,8 +623,8 @@
     (testing "model based metrics can be used in question based on that model"
       (is (=? {:stages [{:source-table (meta/id :products)
                          :filters [[:> {} [:field {} (meta/id :products :rating)] 2]]}
-                        {:aggregation [[:avg {:name "Mock Metric 1"} [:field {} "RATING"]]
-                                       [:count {:name "Mock Metric 2"}]]
+                        {:aggregation [[:avg {:name "avg"} [:field {} "RATING"]]
+                                       [:count {:name "count"}]]
                          :filters [[:< {} [:field {} "RATING"] [:value {} 5]]
                                    [:> {} [:field {} "RATING"] [:value {} 3]]]}]}
               (adjust query))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/48625

### Description

Prior to this PR name of metric's aggregation from before preprocessing was used. For migrated metrics (and probably also for other metrics) that was `nil`. This PR adjusts that, so the name is used after it was added by preprocessing.

### How to verify

Run the new test or follow reproduction steps from the linked issue.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
