### PR TITLE
Manual backport 'Use saved card metadata to filter fields in query metadata for sandboxed tables' to 50

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/table.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/table.clj
@@ -12,7 +12,7 @@
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
 
-(mu/defn find-sandbox-source-card :- [:maybe (ms/InstanceOf :model/Card)]
+(mu/defn ^:private find-sandbox-source-card :- [:maybe (ms/InstanceOf :model/Card)]
   "Find the associated sandboxing card (if there is one) for the given `table-or-table-id` and `user-or-user-id`.
   Returns nil if no question was found."
   [table-or-table-id user-or-user-id]

--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/table.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/table.clj
@@ -12,7 +12,7 @@
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
 
-(mu/defn ^:private find-sandbox-source-card :- [:maybe (ms/InstanceOf :model/Card)]
+(mu/defn find-sandbox-source-card :- [:maybe (ms/InstanceOf :model/Card)]
   "Find the associated sandboxing card (if there is one) for the given `table-or-table-id` and `user-or-user-id`.
   Returns nil if no question was found."
   [table-or-table-id user-or-user-id]

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/table_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/table_test.clj
@@ -4,8 +4,10 @@
    [metabase-enterprise.sandbox.api.table :as table]
    [metabase-enterprise.sandbox.test-util :as mt.tu]
    [metabase-enterprise.test :as met]
+   [metabase.models.card.metadata :as card.metadata]
    [metabase.test :as mt]
-   [metabase.util :as u]))
+   [metabase.util :as u]
+   [toucan2.core :as t2]))
 
 (def ^:private all-columns
   #{"CATEGORY_ID" "ID" "LATITUDE" "LONGITUDE" "NAME" "PRICE"})
@@ -24,7 +26,35 @@
                                    {:remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}
                                     :query      (mt.tu/restricted-column-query (mt/id))}}
                       :attributes {:cat 50}}
-      (testing "Users with restricted access to the columns of a table should only see columns included in the GTAP question"
+      (testing "Users with restricted access to the columns of a table via an MBQL sandbox should only see columns
+               included in the sandboxing question"
+        (is (= #{"CATEGORY_ID" "ID" "NAME"}
+               (field-names :rasta))))
+
+      (testing "Users with full permissions should not be affected by this field filtering"
+        (is (= all-columns
+               (field-names :crowberto)))))))
+
+(deftest native-query-metadata-test
+  (testing "GET /api/table/:id/query_metadata"
+    (met/with-gtaps! {:gtaps      {:venues
+                                   {:query (mt/native-query {:query "SELECT CATEGORY_ID, ID, NAME from venues;"})
+                                    :remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}}}
+                      :attributes {:cat 50}}
+      ;; Fetch the card and manually compute & save the metadata
+      (let [card (t2/select-one :model/Card
+                                {:select [:c.id :c.dataset_query]
+                                 :from   [[:sandboxes :s]]
+                                 :join   [[:permissions_group :pg] [:= :s.group_id :pg.id]
+                                          [:report_card :c] [:= :c.id :s.card_id]]
+                                 :where  [:= :pg.id (u/the-id &group)]})
+            {:keys [metadata metadata-future]} (@#'card.metadata/maybe-async-recomputed-metadata (:dataset_query card))]
+        (if metadata
+          (t2/update! :model/Card :id (u/the-id card) {:result_metadata metadata})
+          (card.metadata/save-metadata-async! metadata-future card)))
+
+      (testing "Users with restricted access to the columns of a table via a native query sandbox should only see
+               columns included in the sandboxing question"
         (is (= #{"CATEGORY_ID" "ID" "NAME"}
                (field-names :rasta))))
 


### PR DESCRIPTION
Manual backport of #48577 to v50