### PR TITLE
Ensure new fields in permissions table are set properly for Examples collection

### DIFF
--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -1260,8 +1260,11 @@
                   (t2/query {:insert-into table-name :values values})))
               (let [group-id (:id (t2/query-one {:select :id :from :permissions_group :where [:= :name "All Users"]}))]
                 (t2/query {:insert-into :permissions
-                           :values      [{:object   (format "/collection/%s/" example-collection-id)
-                                          :group_id group-id}]}))
+                           :values      [{:object        (format "/collection/%s/" example-collection-id)
+                                          :group_id      group-id
+                                          :perm_type     "perms/collection-access"
+                                          :perm_value    "read-and-write"
+                                          :collection_id example-collection-id}]}))
               (t2/query {:insert-into :setting
                          :values      [{:key   "example-dashboard-id"
                                         :value (str example-dashboard-id)}]})))))))


### PR DESCRIPTION
@johnswanson added new `:perm_type`, `:perm_value` and `:collection_id` fields on the `permissions` table in #46942. Since those migrations were backported to 49, they run _before_ the migration which creates the sample content and `Examples` collection on new instances. This means that this collection doesn't have the new fields correctly populated, and thus was not showing up in the collection tree for any non-admin users.

In this PR I've updated the `CreateSampleContent` migration to set these fields correctly, and added a test case to verify.

Resolves https://github.com/metabase/metabase/issues/48594