### PR TITLE
Reduce cache TTL for billing info from 5h to 5min

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/billing/billing.clj
+++ b/enterprise/backend/src/metabase_enterprise/billing/billing.clj
@@ -32,7 +32,7 @@
                   (json/parse-string keyword))
           (catch JsonParseException _
             {:content nil})))
-   :ttl/threshold (u/hours->ms 5)))
+   :ttl/threshold (u/minutes->ms 5)))
 
 (defn- valid-thru []
   (some->> (premium-features/premium-embedding-token)


### PR DESCRIPTION
Store API can handle higher load and customers might want to see
changes earlier.

Fixes: cc28ee604134a36c4ff8aad20f6da6f02bd4b9d6
