### PR TITLE
Let non-admins see tables in recents

### DIFF
--- a/src/metabase/models/recent_views.clj
+++ b/src/metabase/models/recent_views.clj
@@ -419,7 +419,7 @@
     (when (and (not= "hidden" (:visibility_type table))
                (:database-name table)
                (:active table)
-               (mi/can-read? table))
+               (mi/can-read? :model/Table model_id))
       {:id model_id
        :name (:name table)
        :description (:description table)

--- a/test/metabase/models/recent_views_test.clj
+++ b/test/metabase/models/recent_views_test.clj
@@ -180,7 +180,16 @@
         (is (= expected
                (mapv fixup
                      (mt/with-test-user :rasta
-                       (recent-views (mt/user->id :rasta))))))))))
+                       (recent-views (mt/user->id :rasta)))))))))
+  (testing "non admins can see tables in recents (#47420)"
+    (mt/dataset test-data
+      (let [products-id (mt/id :products)]
+        (assert (-> (mt/fetch-user :rasta) :is_superuser not) "User is a super user")
+        (recent-views/update-users-recent-views! (mt/user->id :rasta) :model/Table products-id :view)
+        (let [views (mt/with-test-user :rasta
+                      (recent-views (mt/user->id :rasta)))]
+          (is (contains? (into #{} (map (juxt :id :display_name :model)) views)
+                         [products-id "Products" :table])))))))
 
 (deftest update-users-recent-views!-duplicates-test
   (testing "`update-users-recent-views!` prunes duplicates of a certain model.`"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/47420

```shell
❯ http get "localhost:3000/api/activity/recents?context=views" Cookie:"metabase.SESSION=ba..3d" -pb
{
    "recents": [
        {
            "can_write": false,
            "database": {
                "id": 6,
                "initial_sync_status": "complete",
                "name": "pg restaurants"
            },
            "description": null,
            "display_name": "Restaurants",
            "id": 112,
            "model": "table",
            "name": "restaurants",
            "table_schema": "public",
            "timestamp": "2024-10-15T22:11:39.412100Z"
        },
        {
            "can_write": false,
            "database": {
                "id": 6,
                "initial_sync_status": "complete",
                "name": "pg restaurants"
            },
            "description": null,
            "display_name": "Reviews",
            "id": 110,
            "model": "table",
            "name": "reviews",
            "table_schema": "public",
            "timestamp": "2024-10-15T19:53:19.999445Z"
        }
    ]
}
```

We were getting permissions of a "fake" table. Instead, let the db select it and get the proper stuff. Worked for admins because mi/can-read? is presumably always true for tables, and worked in tests because we mocked mi/can-read?
