### PR TITLE
Downgrade migration for table-level native perms

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -9296,7 +9296,12 @@ databaseChangeLog:
         - sql: "SELECT 1" # do nothing on forward migration
       rollback:
         - sqlFile:
+            dbms: postgresql,h2
             path: permissions/rollback/table_level_native_perms.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: mysql,mariadb
+            path: permissions/rollback/mysql_table_level_native_perms.sql
             relativeToChangelogFile: true
 
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -9288,6 +9288,17 @@ databaseChangeLog:
                   name: type
             indexName: idx_collection_type
 
+  - changeSet:
+      id: v51.2024-10-15T23:14:11
+      author: noahmoss
+      comment: downgrade migration for table-level native perms
+      changes:
+        - sql: "SELECT 1" # do nothing on forward migration
+      rollback:
+        - sqlFile:
+            path: permissions/rollback/table_level_native_perms.sql
+
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -9289,7 +9289,7 @@ databaseChangeLog:
             indexName: idx_collection_type
 
   - changeSet:
-      id: v51.2024-10-15T23:14:11
+      id: v52.2024-10-15T23:14:11
       author: noahmoss
       comment: downgrade migration for table-level native perms
       changes:
@@ -9297,6 +9297,7 @@ databaseChangeLog:
       rollback:
         - sqlFile:
             path: permissions/rollback/table_level_native_perms.sql
+            relativeToChangelogFile: true
 
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<

--- a/resources/migrations/permissions/rollback/mysql_table_level_native_perms.sql
+++ b/resources/migrations/permissions/rollback/mysql_table_level_native_perms.sql
@@ -36,15 +36,13 @@ WHERE dp.table_id IS NOT NULL
 GROUP BY dp.group_id, dp.db_id;
 
 -- Delete table-level permissions if a DB-level permission was created
-DELETE FROM data_permissions
-WHERE perm_value = 'query-builder'
-  AND table_id IS NOT NULL
-  AND EXISTS (
-      SELECT 1
-      FROM data_permissions dp2
-      WHERE dp2.group_id = data_permissions.group_id
-        AND dp2.db_id = data_permissions.db_id
-        AND dp2.schema_name IS NULL
-        AND dp2.table_id IS NULL
-        AND dp2.perm_value = 'query-builder'
-  );
+DELETE dp1
+FROM data_permissions dp1
+JOIN data_permissions dp2
+  ON dp1.group_id = dp2.group_id
+  AND dp1.db_id = dp2.db_id
+  AND dp2.schema_name IS NULL
+  AND dp2.table_id IS NULL
+  AND dp2.perm_value = 'query-builder'
+WHERE dp1.perm_value = 'query-builder'
+  AND dp1.table_id IS NOT NULL;

--- a/resources/migrations/permissions/rollback/table_level_native_perms.sql
+++ b/resources/migrations/permissions/rollback/table_level_native_perms.sql
@@ -1,0 +1,50 @@
+-- Downgrade table-level native access to query-builder-only access
+UPDATE data_permissions
+SET perm_value = 'query-builder'
+WHERE perm_value = 'query-builder-and-native'
+AND table_id IS NOT NULL;
+
+-- Coalesce table-level perms to DB perms: if all tables in a DB have 'query-builder' access, insert a DB-level perm
+-- instead, with a NULL schema and table ID
+INSERT INTO data_permissions (
+    group_id,
+    perm_type,
+    db_id,
+    schema_name,
+    table_id,
+    perm_value
+)
+SELECT
+  dp.group_id,
+  'perms/create-queries' AS perm_type,
+  dp.db_id,
+  NULL AS schema_name,
+  NULL AS table_id,
+  'query-builder' AS perm_value
+FROM data_permissions dp
+WHERE dp.table_id IS NOT NULL
+  AND dp.perm_value = 'query-builder'
+  AND NOT EXISTS (
+      SELECT 1
+      FROM data_permissions dp2
+      WHERE dp2.group_id = dp.group_id
+        AND dp2.db_id = dp.db_id
+        AND dp2.schema_name IS NOT NULL
+        AND dp2.perm_value = 'no'
+        AND dp2.table_id IS NOT NULL
+  )
+GROUP BY dp.group_id, dp.db_id;
+
+-- Delete table-level permissions if a DB-level permission was created
+DELETE FROM data_permissions
+WHERE perm_value = 'query-builder'
+  AND table_id IS NOT NULL
+  AND NOT EXISTS (
+      SELECT 1
+      FROM data_permissions dp2
+      WHERE dp2.group_id = data_permissions.group_id
+        AND dp2.db_id = data_permissions.db_id
+        AND dp2.schema_name IS NULL
+        AND dp2.table_id IS NULL
+        AND dp2.perm_value = 'query-builder'
+  );

--- a/resources/migrations/permissions/rollback/table_level_native_perms.sql
+++ b/resources/migrations/permissions/rollback/table_level_native_perms.sql
@@ -39,7 +39,7 @@ GROUP BY dp.group_id, dp.db_id;
 DELETE FROM data_permissions
 WHERE perm_value = 'query-builder'
   AND table_id IS NOT NULL
-  AND NOT EXISTS (
+  AND EXISTS (
       SELECT 1
       FROM data_permissions dp2
       WHERE dp2.group_id = data_permissions.group_id

--- a/resources/migrations/permissions/rollback/table_level_native_perms.sql
+++ b/resources/migrations/permissions/rollback/table_level_native_perms.sql
@@ -36,15 +36,13 @@ WHERE dp.table_id IS NOT NULL
 GROUP BY dp.group_id, dp.db_id;
 
 -- Delete table-level permissions if a DB-level permission was created
-DELETE FROM data_permissions
-WHERE perm_value = 'query-builder'
-  AND table_id IS NOT NULL
-  AND EXISTS (
-      SELECT 1
-      FROM data_permissions dp2
-      WHERE dp2.group_id = data_permissions.group_id
-        AND dp2.db_id = data_permissions.db_id
-        AND dp2.schema_name IS NULL
-        AND dp2.table_id IS NULL
-        AND dp2.perm_value = 'query-builder'
-  );
+DELETE dp1
+FROM data_permissions dp1
+JOIN data_permissions dp2
+  ON dp1.group_id = dp2.group_id
+  AND dp1.db_id = dp2.db_id
+  AND dp2.schema_name IS NULL
+  AND dp2.table_id IS NULL
+  AND dp2.perm_value = 'query-builder'
+WHERE dp1.perm_value = 'query-builder'
+  AND dp1.table_id IS NOT NULL;

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -556,12 +556,12 @@
             ;; Just assert that something was returned by the query and no exception was thrown
             (is (partial= [] (t2/query (str "SELECT 1 FROM " view-name))))))
         #_#_;; TODO: this is commented out temporarily because it flakes for MySQL (metabase#37884)
-        (migrate! :down 47)
-        (testing "Views should be removed when downgrading"
-          (doseq [view-name new-view-names]
-            (is (thrown?
-                 clojure.lang.ExceptionInfo
-                 (t2/query (str "SELECT 1 FROM " view-name))))))))))
+            (migrate! :down 47)
+          (testing "Views should be removed when downgrading"
+            (doseq [view-name new-view-names]
+              (is (thrown?
+                   clojure.lang.ExceptionInfo
+                   (t2/query (str "SELECT 1 FROM " view-name))))))))))
 
 (deftest activity-data-migration-test
   (testing "Migration v48.00-049"

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -556,12 +556,12 @@
             ;; Just assert that something was returned by the query and no exception was thrown
             (is (partial= [] (t2/query (str "SELECT 1 FROM " view-name))))))
         #_#_;; TODO: this is commented out temporarily because it flakes for MySQL (metabase#37884)
-            (migrate! :down 47)
-          (testing "Views should be removed when downgrading"
-            (doseq [view-name new-view-names]
-              (is (thrown?
-                   clojure.lang.ExceptionInfo
-                   (t2/query (str "SELECT 1 FROM " view-name))))))))))
+        (migrate! :down 47)
+        (testing "Views should be removed when downgrading"
+          (doseq [view-name new-view-names]
+            (is (thrown?
+                 clojure.lang.ExceptionInfo
+                 (t2/query (str "SELECT 1 FROM " view-name))))))))))
 
 (deftest activity-data-migration-test
   (testing "Migration v48.00-049"

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -2627,3 +2627,53 @@
                       (map #(select-keys % [:collection_id :perm_type :perm_value :object]))))))
         (testing "the invalid permissions (for a nonexistent table) were deleted"
           (is (empty? (t2/select :model/Permissions :object [:in [nonexistent-path nonexistent-read-path]]))))))))
+
+(deftest table-level-native-perms-rollback-test
+  (impl/test-migrations "v52.2024-10-15T23:14:11" [migrate!]
+    (let [migrate-up!  (fn []
+                         (migrate!)
+                         (clear-permissions!))
+          group-id     (first (t2/insert-returning-pks! (t2/table-name PermissionsGroup) {:name "Test Group"}))
+          db-id        (first (t2/insert-returning-pks! (t2/table-name Database) {:name       "db"
+                                                                                  :engine     "postgres"
+                                                                                  :created_at :%now
+                                                                                  :updated_at :%now
+                                                                                  :details    "{}"}))
+          table-id-1   (first (t2/insert-returning-pks! (t2/table-name Table) {:db_id      db-id
+                                                                               :name       "Table 1"
+                                                                               :schema     "PUBLIC"
+                                                                               :created_at :%now
+                                                                               :updated_at :%now
+                                                                               :active     true}))
+          table-id-2   (first (t2/insert-returning-pks! (t2/table-name Table) {:db_id      db-id
+                                                                               :name       "Table 2"
+                                                                               :schema     "PUBLIC"
+                                                                               :created_at :%now
+                                                                               :updated_at :%now
+                                                                               :active     true}))
+          insert-perm! (fn [perm-type perm-value & [table-id]]
+                         (t2/insert! (t2/table-name :model/DataPermissions)
+                                     :db_id db-id
+                                     :group_id group-id
+                                     :table_id table-id
+                                     :schema_name "PUBLIC"
+                                     :perm_type perm-type
+                                     :perm_value perm-value))]
+      (testing "Test that table-level native create-queries permissions get correctly cleared when rolling back from 52->51"
+        ;; If all tables end up as `query-builder`, they're replaced with a DB-level perm
+        (migrate-up!)
+        (insert-perm! "perms/create-queries" "query-builder-and-native" table-id-1)
+        (insert-perm! "perms/create-queries" "query-builder" table-id-2)
+        (migrate! :down 51)
+        (is (= #{["query-builder" nil]}
+               (t2/select-fn-set (juxt :perm_value :table_id)
+                                 (t2/table-name :model/DataPermissions) :db_id db-id :group_id group-id)))
+
+        ;; If at least one table is `no`, we keep perms at the table-level
+        (migrate-up!)
+        (insert-perm! "perms/create-queries" "query-builder-and-native" table-id-1)
+        (insert-perm! "perms/create-queries" "no" table-id-2)
+        (migrate! :down 51)
+        (is (= #{["query-builder" table-id-1] ["no" table-id-2]}
+               (t2/select-fn-set (juxt :perm_value :table_id)
+                                 (t2/table-name :model/DataPermissions) :db_id db-id :group_id group-id)))))))


### PR DESCRIPTION
Downgrade-only migration to clear table-level native query perms when migrating down from 52 to 51