### PR TITLE
Fix failed Loki snapshots not uploading to CI

### DIFF
--- a/.github/workflows/loki.yml
+++ b/.github/workflows/loki.yml
@@ -83,5 +83,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: loki-report
+          include-hidden-files: true
           path: .loki/
           if-no-files-found: ignore


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/48778

### Description

GitHub Action `upload-artifact` seems to be updated with a breaking change recently. [See here](https://github.com/actions/upload-artifact/commit/d7c12077c478ad3d03aeeb01e2f6917d1ac93c3a) that they've added the section about the new breaking change in the Readme recently.

### How to verify

The current Loki snapshot should fail since I just override one snapshot with another snapshot from a totally different component, and we should see the failed snapshots in the uploaded artifact once again.

Andddd the artifact is back!!! [See the run here.](https://github.com/metabase/metabase/actions/runs/11361688558?pr=48779) I tested with this commit 5923306c66

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~ (No tests since it's a CI fix)
