### PR TITLE
Bump jetty-server to fix CVSS

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -159,8 +159,8 @@
   ;; v. 12 of jetty-server triggers "a org/eclipse/jetty/io/EofException has been compiled by a more recent version of
   ;; the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions
   ;; up to 55.0"
-  org.eclipse.jetty/jetty-server            {:mvn/version "11.0.20" #_"must be 11"} ; web server
-  org.eclipse.jetty.websocket/websocket-jetty-server {:mvn/version "11.0.20"}   ; ring-jetty-adapter needs that
+  org.eclipse.jetty/jetty-server            {:mvn/version "11.0.24" #_"must be 11"} ; web server
+  org.eclipse.jetty.websocket/websocket-jetty-server {:mvn/version "11.0.24"}   ; ring-jetty-adapter needs that
   org.flatland/ordered                      {:mvn/version "1.15.11"}            ; ordered maps & sets
   org.graalvm.js/js                         {:mvn/version "22.3.5"}             ; JavaScript engine
   org.jsoup/jsoup                           {:mvn/version "1.17.2"}             ; required by hickory


### PR DESCRIPTION
### Description

- Bump jetty-server to 11.0.24

### How to verify

Me again! Similar to #46229, our Snyk CI has flagged another vulnerability.

![image](https://github.com/user-attachments/assets/dc370ae7-ab72-4c09-92ad-7bb1b342c552)

Not relevant to this PR, but it would be a good idea to add Snyk in to this. If you need help setting that up, I can certainly look into PRing that myself 😄 

The CVSS in question is [this](https://security.snyk.io/vuln/SNYK-JAVA-ORGECLIPSEJETTY-8186142) and carries quite a high severity, so assuming this doesn't break much I would imagine you would want to merge this quite soon.

Thanks again for a great bit of software!

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
