### PR TITLE
Snowplow Stats Ping: keywords only allowed at the top level

### DIFF
--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -620,12 +620,12 @@
                           (update-vals count)))})
 
 (defn- snowplow-grouped-metrics [{query-executions :query_executions :as _snowplow-grouped-metric-info}]
-  [{:name :query_executions_by_source
-    :values (mapv (fn [qe-group]
-                    {:group qe-group
-                     :value (get query-executions qe-group)})
-                  ["interactive_embed" "internal" "public_link" "sdk_embed" "static_embed"])
-    :tags ["embedding"]}])
+  (->> [{:name :query_executions_by_source
+         :values (mapv (fn [qe-group]
+                         {:group qe-group :value (get query-executions qe-group)})
+                       ["interactive_embed" "internal" "public_link" "sdk_embed" "static_embed"])
+         :tags ["embedding"]}]
+       (walk/postwalk (fn [x] (if (keyword? x) (-> x u/->snake_case_en name) x)))))
 
 (defn- ->snowplow-metric-info
   "Collects Snowplow metrics data that is not in the legacy stats format. Also clears entity id translation count."


### PR DESCRIPTION
This is a fix for this issue:

Top level keywords get converted to strings, but they're the only ones.

Eventually we should fix this because it's a little counter-intuitive, since it feels like we are building json from edn data (which would stringify keywords). 


[Here's the response from http://localhost:9090/micro/good](https://gist.github.com/escherize/480e129a92d835bde9acc967d6ede815) after running the stats ping locally. To verify that it is actually fixed.