### PR TITLE
Fix question header when the original question is a native query

### DIFF
--- a/frontend/src/metabase-types/api/table.ts
+++ b/frontend/src/metabase-types/api/table.ts
@@ -1,4 +1,4 @@
-import type { Card } from "./card";
+import type { Card, CardType } from "./card";
 import type { Database, DatabaseId, InitialSyncStatus } from "./database";
 import type { Field, FieldDimensionOption, FieldId } from "./field";
 import type { Segment } from "./segment";
@@ -22,7 +22,7 @@ export type TableFieldOrder = "database" | "alphabetical" | "custom" | "smart";
 
 export type Table = {
   id: TableId;
-
+  type?: CardType;
   name: string;
   display_name: string;
   description: string | null;

--- a/frontend/src/metabase/lib/urls/browse.ts
+++ b/frontend/src/metabase/lib/urls/browse.ts
@@ -18,7 +18,7 @@ export function browseDatabase(database: DatabaseV1 | Database) {
 
 export function browseSchema(table: {
   db_id?: Table["db_id"];
-  schema_name: Table["schema_name"] | null;
+  schema_name?: Table["schema_name"] | null;
   db?: Pick<DatabaseV1, "id">;
 }) {
   const databaseId = table.db?.id || table.db_id;

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/QuestionDataSource.jsx
@@ -14,7 +14,7 @@ import {
 
 import { HeadBreadcrumbs } from "../HeaderBreadcrumbs";
 
-import { getDataSourceParts } from "./utils";
+import { getDataSourceParts, getQuestionIcon } from "./utils";
 
 QuestionDataSource.propTypes = {
   question: PropTypes.object,
@@ -121,7 +121,7 @@ function SourceDatasetBreadcrumbs({ question, ...props }) {
         <HeadBreadcrumbs.Badge
           key="dataset-collection"
           to={Urls.collection(collection)}
-          icon={question.type() === "metric" ? "metric" : "model"}
+          icon={getQuestionIcon(question)}
           inactiveColor="text-light"
         >
           {collection?.name || t`Our analytics`}

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/utils.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/utils.tsx
@@ -1,27 +1,44 @@
-import PropTypes from "prop-types";
-import { isValidElement } from "react";
+import { type ReactElement, isValidElement } from "react";
 
 import { TableInfoIcon } from "metabase/components/MetadataInfo/TableInfoIcon/TableInfoIcon";
 import { isNotNull } from "metabase/lib/types";
 import * as Urls from "metabase/lib/urls";
+import type { IconName } from "metabase/ui";
 import * as Lib from "metabase-lib";
+import type Question from "metabase-lib/v1/Question";
+import type Table from "metabase-lib/v1/metadata/Table";
 import {
   getQuestionIdFromVirtualTableId,
   getQuestionVirtualTableId,
   isVirtualCardId,
 } from "metabase-lib/v1/metadata/utils/saved-questions";
+import type NativeQuery from "metabase-lib/v1/queries/NativeQuery";
 import * as ML_Urls from "metabase-lib/v1/urls";
 
 import { HeadBreadcrumbs } from "../HeaderBreadcrumbs";
 
 import { IconWrapper, TablesDivider } from "./QuestionDataSource.styled";
 
+type DataSourcePart = ReactElement | DataSourceBadgePart;
+
+type DataSourceBadgePart = {
+  name?: string;
+  href?: string;
+  icon?: IconName;
+  model?: "database" | "schema" | "table" | "question" | "model" | "metric";
+};
+
 export function getDataSourceParts({
   question,
   subHead,
   isObjectDetail,
   formatTableAsComponent = true,
-}) {
+}: {
+  question: Question;
+  subHead?: boolean;
+  isObjectDetail?: boolean;
+  formatTableAsComponent?: boolean;
+}): DataSourcePart[] {
   if (!question) {
     return [];
   }
@@ -34,7 +51,7 @@ export function getDataSourceParts({
     return [];
   }
 
-  const parts = [];
+  const parts: DataSourcePart[] = [];
 
   const metadata = question.metadata();
   const database = metadata.database(Lib.databaseID(query));
@@ -43,21 +60,21 @@ export function getDataSourceParts({
     parts.push({
       icon: !subHead ? "database" : undefined,
       name: database.displayName(),
-      href: database.id >= 0 && Urls.browseDatabase(database),
+      href: database.id >= 0 ? Urls.browseDatabase(database) : undefined,
       model: "database",
     });
   }
 
   const table = !isNative
     ? metadata.table(Lib.sourceTableOrCardId(query))
-    : question.legacyQuery().table();
+    : (question.legacyQuery() as NativeQuery).table();
   if (table && table.hasSchema()) {
     const isBasedOnSavedQuestion = isVirtualCardId(table.id);
-    if (!isBasedOnSavedQuestion) {
+    if (database != null && !isBasedOnSavedQuestion) {
       parts.push({
         model: "schema",
         name: table.schema_name,
-        href: database.id >= 0 && Urls.browseSchema(table),
+        href: database.id >= 0 ? Urls.browseSchema(table) : undefined,
       });
     }
   }
@@ -65,10 +82,12 @@ export function getDataSourceParts({
   if (table) {
     const hasTableLink = subHead || isObjectDetail;
     if (isNative) {
-      return {
-        name: table.displayName(),
-        link: hasTableLink ? getTableURL() : "",
-      };
+      return [
+        {
+          name: table.displayName(),
+          href: hasTableLink ? getTableURL(table) : "",
+        },
+      ];
     }
 
     const allTables = [
@@ -88,7 +107,7 @@ export function getDataSourceParts({
         }),
     ].filter(isNotNull);
 
-    const part = formatTableAsComponent ? (
+    const part: DataSourcePart = formatTableAsComponent ? (
       <QuestionTableBadges
         tables={allTables}
         subHead={subHead}
@@ -106,17 +125,27 @@ export function getDataSourceParts({
     parts.push(part);
   }
 
-  return parts.filter(part => isValidElement(part) || part.name || part.icon);
+  return parts.filter(
+    part =>
+      isValidElement(part) ||
+      ("name" in part && part.name) ||
+      ("icon" in part && part.icon),
+  );
 }
 
-QuestionTableBadges.propTypes = {
-  tables: PropTypes.arrayOf(PropTypes.object).isRequired,
-  hasLink: PropTypes.bool,
-  subHead: PropTypes.bool,
-  isLast: PropTypes.bool,
+type QuestionTableBadgesProps = {
+  tables: Table[];
+  subHead?: boolean;
+  hasLink?: boolean;
+  isLast?: boolean;
 };
 
-function QuestionTableBadges({ tables, subHead, hasLink, isLast }) {
+function QuestionTableBadges({
+  tables,
+  subHead,
+  hasLink,
+  isLast,
+}: QuestionTableBadgesProps) {
   const badgeInactiveColor = isLast && !subHead ? "text-dark" : "text-light";
 
   const parts = tables.map(table => (
@@ -151,10 +180,12 @@ function QuestionTableBadges({ tables, subHead, hasLink, isLast }) {
   );
 }
 
-function getTableURL(table) {
+function getTableURL(table: Table) {
   if (isVirtualCardId(table.id)) {
     const cardId = getQuestionIdFromVirtualTableId(table.id);
-    return Urls.question({ id: cardId, name: table.displayName() });
+    if (cardId != null) {
+      return Urls.question({ id: cardId, name: table.displayName() });
+    }
   }
   return ML_Urls.getUrl(table.newQuestion());
 }

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/utils.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/utils.tsx
@@ -1,4 +1,5 @@
 import { type ReactElement, isValidElement } from "react";
+import { match } from "ts-pattern";
 
 import { TableInfoIcon } from "metabase/components/MetadataInfo/TableInfoIcon/TableInfoIcon";
 import { isNotNull } from "metabase/lib/types";
@@ -188,4 +189,13 @@ function getTableURL(table: Table) {
     }
   }
   return ML_Urls.getUrl(table.newQuestion());
+}
+
+export function getQuestionIcon(question: Question): IconName {
+  return match(question.type())
+    .returnType<IconName>()
+    .with("question", () => "table2")
+    .with("model", () => "model")
+    .with("metric", () => "metric")
+    .exhaustive();
 }


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/48690

Changes:
- Converts `QuestionDataSource` utils to TypeScript
- Fixes a bug with an icon when the original question is a native query

How to verify:
- New -> SQL query -> `SELECT * FROM ORDERS` -> Save as `SQL query` -> Run
- Click on a cell -> Filter -> Click on an operator -> You should get an ad-hoc query
- Check that the icon in the query builder header is now `table2`, which matches what you get in the notebook editor (click `Show Editor` to verify)

<img width="1727" alt="Screenshot 2024-10-16 at 21 53 51" src="https://github.com/user-attachments/assets/518bb7d2-b9c6-4657-99d0-ad6c7ea1c93d">
