### PR TITLE
Hide the toggle all checkbox when there are no search results

### DIFF
--- a/frontend/src/metabase/components/ListField/ListField.tsx
+++ b/frontend/src/metabase/components/ListField/ListField.tsx
@@ -151,15 +151,17 @@ export const ListField = ({
       )}
 
       <OptionsList isDashboardFilter={isDashboardFilter}>
-        <OptionContainer>
-          <Checkbox
-            variant="stacked"
-            label={getToggleAllLabel(debouncedFilter, isAll)}
-            checked={isAll}
-            indeterminate={!isAll && !isNone}
-            onChange={handleToggleAll}
-          />
-        </OptionContainer>
+        {filteredOptions.length > 0 && (
+          <OptionContainer>
+            <Checkbox
+              variant="stacked"
+              label={getToggleAllLabel(debouncedFilter, isAll)}
+              checked={isAll}
+              indeterminate={!isAll && !isNone}
+              onChange={handleToggleAll}
+            />
+          </OptionContainer>
+        )}
         {filteredOptions.map((option, index) => (
           <OptionContainer key={index}>
             <Checkbox

--- a/frontend/src/metabase/components/ListField/ListField.unit.spec.tsx
+++ b/frontend/src/metabase/components/ListField/ListField.unit.spec.tsx
@@ -128,4 +128,17 @@ describe("ListField", () => {
     expect(onChange).toHaveBeenCalledWith(["Doohickey", "Widget"]);
     expect(screen.getByLabelText("Gadget")).not.toBeChecked();
   });
+
+  it("should not show the toggle all checkbox when search results are empty", async () => {
+    setup({
+      value: [],
+      options: allOptions,
+    });
+    await userEvent.type(
+      screen.getByPlaceholderText("Search the list"),
+      "Invalid",
+    );
+    expect(screen.queryByLabelText("Select all")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Select none")).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/48761

How to verify:
- New -> Question -> Orders -> Save as Q1
- New -> Dashboard -> Save
- Edit -> Add Q1 -> Filter -> Text or Category -> Product.Category -> Save
- Open the filter widget -> Type some non-existing category
- There should be an empty state but no Select all/none checkbox

Before:
![image](https://github.com/user-attachments/assets/5609603d-9b22-41f0-baa4-af18280c9b80)

After:
<img width="358" alt="Screenshot 2024-10-16 at 22 51 40" src="https://github.com/user-attachments/assets/8ba83d2b-4bb2-4d0e-8c7e-4d75fa1fb272">
