### PR TITLE
Hide time inputs in the date picker when the column does not support date+time filters

### DIFF
--- a/frontend/src/metabase/querying/filters/components/DatePicker/DatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/DatePicker.tsx
@@ -50,6 +50,7 @@ export function DatePicker({
         <SpecificDatePicker
           value={value?.type === type ? value : undefined}
           availableOperators={availableOperators}
+          availableUnits={availableUnits}
           isNew={isNew}
           onChange={onChange}
           onBack={handleBack}

--- a/frontend/src/metabase/querying/filters/components/DatePicker/DatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/DatePicker.tsx
@@ -59,6 +59,7 @@ export function DatePicker({
       return (
         <RelativeDatePicker
           value={value?.type === type ? value : undefined}
+          availableUnits={availableUnits}
           canUseRelativeOffsets={canUseRelativeOffsets}
           isNew={isNew}
           onChange={onChange}

--- a/frontend/src/metabase/querying/filters/components/DatePicker/DatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/DatePicker.tsx
@@ -6,14 +6,14 @@ import { ExcludeDatePicker } from "./ExcludeDatePicker";
 import { RelativeDatePicker } from "./RelativeDatePicker";
 import { SpecificDatePicker } from "./SpecificDatePicker";
 import {
-  DATE_PICKER_EXTRACTION_UNITS,
   DATE_PICKER_OPERATORS,
   DATE_PICKER_SHORTCUTS,
+  DATE_PICKER_UNITS,
 } from "./constants";
 import type {
-  DatePickerExtractionUnit,
   DatePickerOperator,
   DatePickerShortcut,
+  DatePickerUnit,
   DatePickerValue,
 } from "./types";
 
@@ -21,7 +21,7 @@ interface DatePickerProps {
   value?: DatePickerValue;
   availableOperators?: ReadonlyArray<DatePickerOperator>;
   availableShortcuts?: ReadonlyArray<DatePickerShortcut>;
-  availableUnits?: ReadonlyArray<DatePickerExtractionUnit>;
+  availableUnits?: ReadonlyArray<DatePickerUnit>;
   canUseRelativeOffsets?: boolean;
   backButton?: ReactNode;
   isNew?: boolean;
@@ -32,7 +32,7 @@ export function DatePicker({
   value,
   availableOperators = DATE_PICKER_OPERATORS,
   availableShortcuts = DATE_PICKER_SHORTCUTS,
-  availableUnits = DATE_PICKER_EXTRACTION_UNITS,
+  availableUnits = DATE_PICKER_UNITS,
   canUseRelativeOffsets = false,
   isNew = value == null,
   backButton,

--- a/frontend/src/metabase/querying/filters/components/DatePicker/ExcludeDatePicker/ExcludeDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/ExcludeDatePicker/ExcludeDatePicker.tsx
@@ -16,6 +16,7 @@ import { MIN_WIDTH } from "../constants";
 import type {
   DatePickerExtractionUnit,
   DatePickerOperator,
+  DatePickerUnit,
   ExcludeDatePickerOperator,
   ExcludeDatePickerValue,
 } from "../types";
@@ -33,7 +34,7 @@ import {
 export interface ExcludeDatePickerProps {
   value?: ExcludeDatePickerValue;
   availableOperators: ReadonlyArray<DatePickerOperator>;
-  availableUnits: ReadonlyArray<DatePickerExtractionUnit>;
+  availableUnits: ReadonlyArray<DatePickerUnit>;
   isNew: boolean;
   onChange: (value: ExcludeDatePickerValue) => void;
   onBack: () => void;
@@ -82,7 +83,7 @@ export function ExcludeDatePicker({
 interface ExcludeOptionPickerProps {
   value: ExcludeDatePickerValue | undefined;
   availableOperators: ReadonlyArray<DatePickerOperator>;
-  availableUnits: ReadonlyArray<DatePickerExtractionUnit>;
+  availableUnits: ReadonlyArray<DatePickerUnit>;
   onChange: (value: ExcludeDatePickerValue) => void;
   onSelectUnit: (unit: DatePickerExtractionUnit) => void;
   onBack: () => void;

--- a/frontend/src/metabase/querying/filters/components/DatePicker/ExcludeDatePicker/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/ExcludeDatePicker/utils.ts
@@ -5,6 +5,7 @@ import _ from "underscore";
 import type {
   DatePickerExtractionUnit,
   DatePickerOperator,
+  DatePickerUnit,
   ExcludeDatePickerOperator,
   ExcludeDatePickerValue,
 } from "../types";
@@ -18,7 +19,7 @@ import type {
 
 export function getExcludeUnitOptions(
   availableOperators: ReadonlyArray<DatePickerOperator>,
-  availableUnits: ReadonlyArray<DatePickerExtractionUnit>,
+  availableUnits: ReadonlyArray<DatePickerUnit>,
 ): ExcludeUnitOption[] {
   if (!availableOperators.includes("!=")) {
     return [];

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/CurrentDatePicker/CurrentDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/CurrentDatePicker/CurrentDatePicker.tsx
@@ -10,10 +10,10 @@ import type {
 } from "../../types";
 import { formatDateRange } from "../utils";
 
-import { getUnitGroups } from "./utils";
+import { getCurrentValue, getUnitGroups } from "./utils";
 
 interface CurrentDatePickerProps {
-  value: RelativeDatePickerValue;
+  value: RelativeDatePickerValue | undefined;
   availableUnits: ReadonlyArray<DatePickerUnit>;
   onChange: (value: RelativeDatePickerValue) => void;
 }
@@ -26,11 +26,11 @@ export function CurrentDatePicker({
   const unitGroups = getUnitGroups(availableUnits);
 
   const getTooltipLabel = (unit: DatePickerTruncationUnit) => {
-    return formatDateRange({ ...value, unit });
+    return formatDateRange(getCurrentValue(unit));
   };
 
   const handleClick = (unit: DatePickerTruncationUnit) => {
-    onChange({ ...value, unit });
+    onChange(getCurrentValue(unit));
   };
 
   return (
@@ -43,7 +43,7 @@ export function CurrentDatePicker({
               label={t`Right now, this is ${getTooltipLabel(unit)}`}
             >
               <Button
-                variant={unit === value.unit ? "filled" : "default"}
+                variant={unit === value?.unit ? "filled" : "default"}
                 radius="xl"
                 onClick={() => handleClick(unit)}
               >

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/CurrentDatePicker/CurrentDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/CurrentDatePicker/CurrentDatePicker.tsx
@@ -5,18 +5,26 @@ import * as Lib from "metabase-lib";
 
 import type {
   DatePickerTruncationUnit,
+  DatePickerUnit,
   RelativeDatePickerValue,
 } from "../../types";
 import { formatDateRange } from "../utils";
 
-import { UNIT_GROUPS } from "./constants";
+import { getUnitGroups } from "./utils";
 
 interface CurrentDatePickerProps {
   value: RelativeDatePickerValue;
+  availableUnits: ReadonlyArray<DatePickerUnit>;
   onChange: (value: RelativeDatePickerValue) => void;
 }
 
-export function CurrentDatePicker({ value, onChange }: CurrentDatePickerProps) {
+export function CurrentDatePicker({
+  value,
+  availableUnits,
+  onChange,
+}: CurrentDatePickerProps) {
+  const unitGroups = getUnitGroups(availableUnits);
+
   const getTooltipLabel = (unit: DatePickerTruncationUnit) => {
     return formatDateRange({ ...value, unit });
   };
@@ -27,7 +35,7 @@ export function CurrentDatePicker({ value, onChange }: CurrentDatePickerProps) {
 
   return (
     <Stack>
-      {UNIT_GROUPS.map((group, groupIndex) => (
+      {unitGroups.map((group, groupIndex) => (
         <Group key={groupIndex}>
           {group.map(unit => (
             <Tooltip

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/CurrentDatePicker/CurrentDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/CurrentDatePicker/CurrentDatePicker.unit.spec.tsx
@@ -2,7 +2,8 @@ import _userEvent from "@testing-library/user-event";
 
 import { renderWithProviders, screen } from "__support__/ui";
 
-import type { RelativeDatePickerValue } from "../../types";
+import { DATE_PICKER_UNITS } from "../../constants";
+import type { DatePickerUnit, RelativeDatePickerValue } from "../../types";
 
 import { CurrentDatePicker } from "./CurrentDatePicker";
 
@@ -14,16 +15,26 @@ const DEFAULT_VALUE: RelativeDatePickerValue = {
 
 interface SetupOpts {
   value?: RelativeDatePickerValue;
+  availableUnits?: ReadonlyArray<DatePickerUnit>;
 }
 
 const userEvent = _userEvent.setup({
   advanceTimers: jest.advanceTimersByTime,
 });
 
-function setup({ value = DEFAULT_VALUE }: SetupOpts = {}) {
+function setup({
+  value = DEFAULT_VALUE,
+  availableUnits = DATE_PICKER_UNITS,
+}: SetupOpts = {}) {
   const onChange = jest.fn();
 
-  renderWithProviders(<CurrentDatePicker value={value} onChange={onChange} />);
+  renderWithProviders(
+    <CurrentDatePicker
+      value={value}
+      availableUnits={availableUnits}
+      onChange={onChange}
+    />,
+  );
 
   return { onChange };
 }

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/CurrentDatePicker/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/CurrentDatePicker/utils.ts
@@ -1,6 +1,16 @@
-import type { DatePickerUnit } from "../../types";
+import type {
+  DatePickerTruncationUnit,
+  DatePickerUnit,
+  RelativeDatePickerValue,
+} from "../../types";
 
 import { UNIT_GROUPS } from "./constants";
+
+export function getCurrentValue(
+  unit: DatePickerTruncationUnit,
+): RelativeDatePickerValue {
+  return { type: "relative", value: "current", unit };
+}
 
 export function getUnitGroups(availableUnits: ReadonlyArray<DatePickerUnit>) {
   return UNIT_GROUPS.map(group =>

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/CurrentDatePicker/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/CurrentDatePicker/utils.ts
@@ -1,0 +1,9 @@
+import type { DatePickerUnit } from "../../types";
+
+import { UNIT_GROUPS } from "./constants";
+
+export function getUnitGroups(availableUnits: ReadonlyArray<DatePickerUnit>) {
+  return UNIT_GROUPS.map(group =>
+    group.filter(unit => availableUnits.includes(unit)),
+  ).filter(group => group.length > 0);
+}

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.tsx
@@ -13,6 +13,7 @@ import {
   Tooltip,
 } from "metabase/ui";
 
+import type { DatePickerUnit } from "../../types";
 import { IncludeCurrentSwitch } from "../IncludeCurrentSwitch";
 import type { DateIntervalValue } from "../types";
 import {
@@ -26,6 +27,7 @@ import { setDefaultOffset, setUnit } from "./utils";
 
 interface DateIntervalPickerProps {
   value: DateIntervalValue;
+  availableUnits: ReadonlyArray<DatePickerUnit>;
   isNew: boolean;
   canUseRelativeOffsets: boolean;
   onChange: (value: DateIntervalValue) => void;
@@ -34,13 +36,14 @@ interface DateIntervalPickerProps {
 
 export function DateIntervalPicker({
   value,
+  availableUnits,
   isNew,
   canUseRelativeOffsets,
   onChange,
   onSubmit,
 }: DateIntervalPickerProps) {
   const interval = getInterval(value);
-  const unitOptions = getUnitOptions(value);
+  const unitOptions = getUnitOptions(value, availableUnits);
   const dateRangeText = formatDateRange(value);
 
   const handleIntervalChange = (inputValue: number | "") => {

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.unit.spec.tsx
@@ -2,7 +2,8 @@ import userEvent from "@testing-library/user-event";
 
 import { renderWithProviders, screen } from "__support__/ui";
 
-import type { RelativeIntervalDirection } from "../../types";
+import { DATE_PICKER_UNITS } from "../../constants";
+import type { DatePickerUnit, RelativeIntervalDirection } from "../../types";
 import type { DateIntervalValue } from "../types";
 
 import { DateIntervalPicker } from "./DateIntervalPicker";
@@ -19,12 +20,14 @@ function getDefaultValue(
 
 interface SetupOpts {
   value: DateIntervalValue;
+  availableUnits?: ReadonlyArray<DatePickerUnit>;
   isNew?: boolean;
   canUseRelativeOffsets?: boolean;
 }
 
 function setup({
   value,
+  availableUnits = DATE_PICKER_UNITS,
   isNew = false,
   canUseRelativeOffsets = false,
 }: SetupOpts) {
@@ -34,6 +37,7 @@ function setup({
   renderWithProviders(
     <DateIntervalPicker
       value={value}
+      availableUnits={availableUnits}
       isNew={isNew}
       canUseRelativeOffsets={canUseRelativeOffsets}
       onChange={onChange}

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.unit.spec.tsx
@@ -155,6 +155,17 @@ describe("DateIntervalPicker", () => {
         expect(onSubmit).not.toHaveBeenCalled();
       });
 
+      it("should allow to set only available units", async () => {
+        setup({
+          value: defaultValue,
+          availableUnits: ["day", "month"],
+        });
+        await userEvent.click(screen.getByLabelText("Unit"));
+        expect(screen.getByText("days")).toBeInTheDocument();
+        expect(screen.getByText("months")).toBeInTheDocument();
+        expect(screen.queryByText("years")).not.toBeInTheDocument();
+      });
+
       it("should allow to include the current unit", async () => {
         const { onChange, onSubmit } = setup({
           value: defaultValue,

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateIntervalPicker/SimpleDateIntervalPicker/SimpleDateIntervalPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateIntervalPicker/SimpleDateIntervalPicker/SimpleDateIntervalPicker.tsx
@@ -2,6 +2,7 @@ import { t } from "ttag";
 
 import { Group, NumberInput, Select } from "metabase/ui";
 
+import type { DatePickerUnit } from "../../../types";
 import { IncludeCurrentSwitch } from "../../IncludeCurrentSwitch";
 import type { DateIntervalValue } from "../../types";
 import { getInterval, getUnitOptions, setInterval } from "../../utils";
@@ -9,15 +10,17 @@ import { setUnit } from "../utils";
 
 interface SimpleDateIntervalPickerProps {
   value: DateIntervalValue;
+  availableUnits: ReadonlyArray<DatePickerUnit>;
   onChange: (value: DateIntervalValue) => void;
 }
 
 export function SimpleDateIntervalPicker({
   value,
+  availableUnits,
   onChange,
 }: SimpleDateIntervalPickerProps) {
   const interval = getInterval(value);
-  const unitOptions = getUnitOptions(value);
+  const unitOptions = getUnitOptions(value, availableUnits);
 
   const handleIntervalChange = (inputValue: number | "") => {
     if (inputValue !== "") {

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateIntervalPicker/SimpleDateIntervalPicker/SimpleDateIntervalPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateIntervalPicker/SimpleDateIntervalPicker/SimpleDateIntervalPicker.unit.spec.tsx
@@ -1,8 +1,9 @@
 import userEvent from "@testing-library/user-event";
 
 import { renderWithProviders, screen } from "__support__/ui";
-import type { RelativeIntervalDirection } from "metabase/querying/filters/components/DatePicker/types";
 
+import { DATE_PICKER_UNITS } from "../../../constants";
+import type { DatePickerUnit, RelativeIntervalDirection } from "../../../types";
 import type { DateIntervalValue } from "../../types";
 
 import { SimpleDateIntervalPicker } from "./SimpleDateIntervalPicker";
@@ -19,15 +20,20 @@ function getDefaultValue(
 
 interface SetupOpts {
   value: DateIntervalValue;
+  availableUnits?: ReadonlyArray<DatePickerUnit>;
   isNew?: boolean;
   canUseRelativeOffsets?: boolean;
 }
 
-function setup({ value }: SetupOpts) {
+function setup({ value, availableUnits = DATE_PICKER_UNITS }: SetupOpts) {
   const onChange = jest.fn();
 
   renderWithProviders(
-    <SimpleDateIntervalPicker value={value} onChange={onChange} />,
+    <SimpleDateIntervalPicker
+      value={value}
+      availableUnits={availableUnits}
+      onChange={onChange}
+    />,
   );
 
   return { onChange };

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.tsx
@@ -11,6 +11,7 @@ import {
   Text,
 } from "metabase/ui";
 
+import type { DatePickerUnit } from "../../types";
 import type { DateIntervalValue, DateOffsetIntervalValue } from "../types";
 import {
   formatDateRange,
@@ -32,6 +33,7 @@ import {
 
 interface DateOffsetIntervalPickerProps {
   value: DateOffsetIntervalValue;
+  availableUnits: ReadonlyArray<DatePickerUnit>;
   isNew: boolean;
   onChange: (value: DateIntervalValue) => void;
   onSubmit: () => void;
@@ -39,14 +41,15 @@ interface DateOffsetIntervalPickerProps {
 
 export function DateOffsetIntervalPicker({
   value,
+  availableUnits,
   isNew,
   onChange,
   onSubmit,
 }: DateOffsetIntervalPickerProps) {
   const interval = getInterval(value);
-  const unitOptions = getUnitOptions(value);
+  const unitOptions = getUnitOptions(value, availableUnits);
   const offsetInterval = getOffsetInterval(value);
-  const offsetUnitOptions = getOffsetUnitOptions(value);
+  const offsetUnitOptions = getOffsetUnitOptions(value, availableUnits);
   const directionText = getDirectionText(value);
   const dateRangeText = formatDateRange(value);
 

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.unit.spec.tsx
@@ -2,7 +2,8 @@ import _userEvent from "@testing-library/user-event";
 
 import { renderWithProviders, screen } from "__support__/ui";
 
-import type { RelativeIntervalDirection } from "../../types";
+import { DATE_PICKER_UNITS } from "../../constants";
+import type { DatePickerUnit, RelativeIntervalDirection } from "../../types";
 import type { DateOffsetIntervalValue } from "../types";
 
 import { DateOffsetIntervalPicker } from "./DateOffsetIntervalPicker";
@@ -25,16 +26,22 @@ const userEvent = _userEvent.setup({
 
 interface SetupOpts {
   value: DateOffsetIntervalValue;
+  availableUnits?: ReadonlyArray<DatePickerUnit>;
   isNew?: boolean;
 }
 
-function setup({ value, isNew = false }: SetupOpts) {
+function setup({
+  value,
+  availableUnits = DATE_PICKER_UNITS,
+  isNew = false,
+}: SetupOpts) {
   const onChange = jest.fn();
   const onSubmit = jest.fn();
 
   renderWithProviders(
     <DateOffsetIntervalPicker
       value={value}
+      availableUnits={availableUnits}
       isNew={isNew}
       onChange={onChange}
       onSubmit={onSubmit}

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.unit.spec.tsx
@@ -159,6 +159,17 @@ describe("DateOffsetIntervalPicker", () => {
         expect(onSubmit).not.toHaveBeenCalled();
       });
 
+      it("should allow to set only available units", async () => {
+        setup({
+          value: defaultValue,
+          availableUnits: ["day", "year"],
+        });
+        await userEvent.click(screen.getByLabelText("Unit"));
+        expect(screen.getByText("days")).toBeInTheDocument();
+        expect(screen.getByText("years")).toBeInTheDocument();
+        expect(screen.queryByText("months")).not.toBeInTheDocument();
+      });
+
       it("should change the offset interval", async () => {
         const { onChange, onSubmit } = setup({
           value: defaultValue,

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.unit.spec.tsx
@@ -164,10 +164,17 @@ describe("DateOffsetIntervalPicker", () => {
           value: defaultValue,
           availableUnits: ["day", "year"],
         });
+
         await userEvent.click(screen.getByLabelText("Unit"));
         expect(screen.getByText("days")).toBeInTheDocument();
         expect(screen.getByText("years")).toBeInTheDocument();
         expect(screen.queryByText("months")).not.toBeInTheDocument();
+
+        const suffix = direction === "last" ? "ago" : "from now";
+        await userEvent.click(screen.getByLabelText("Starting from unit"));
+        expect(screen.getByText(`days ${suffix}`)).toBeInTheDocument();
+        expect(screen.getByText(`years ${suffix}`)).toBeInTheDocument();
+        expect(screen.queryByText(`months ${suffix}`)).not.toBeInTheDocument();
       });
 
       it("should change the offset interval", async () => {

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/utils.ts
@@ -2,13 +2,13 @@ import { t } from "ttag";
 
 import * as Lib from "metabase-lib";
 
-import { DATE_PICKER_TRUNCATION_UNITS } from "../../constants";
 import type {
   DatePickerTruncationUnit,
+  DatePickerUnit,
   RelativeIntervalDirection,
 } from "../../types";
 import type { DateIntervalValue, DateOffsetIntervalValue } from "../types";
-import { getDirection } from "../utils";
+import { getAvailableTruncationUnits, getDirection } from "../utils";
 
 export function getDirectionText(value: DateOffsetIntervalValue): string {
   const direction = getDirection(value);
@@ -51,16 +51,20 @@ export function removeOffset(
   return { ...value, offsetValue: undefined, offsetUnit: undefined };
 }
 
-export function getOffsetUnitOptions(value: DateOffsetIntervalValue) {
+export function getOffsetUnitOptions(
+  value: DateOffsetIntervalValue,
+  availableUnits: ReadonlyArray<DatePickerUnit>,
+) {
+  const truncationUnits = getAvailableTruncationUnits(availableUnits);
   const direction = getDirection(value);
-  const unitIndex = DATE_PICKER_TRUNCATION_UNITS.indexOf(value.unit);
+  const unitIndex = truncationUnits.indexOf(value.unit);
 
-  return DATE_PICKER_TRUNCATION_UNITS.filter(
-    (_, index) => index >= unitIndex,
-  ).map(unit => ({
-    value: unit,
-    label: getOffsetUnitText(unit, direction, value.offsetValue),
-  }));
+  return truncationUnits
+    .filter((_, index) => index >= unitIndex)
+    .map(unit => ({
+      value: unit,
+      label: getOffsetUnitText(unit, direction, value.offsetValue),
+    }));
 }
 
 function getOffsetUnitText(

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/RelativeDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/RelativeDatePicker.tsx
@@ -81,7 +81,11 @@ export function RelativeDatePicker({
             />
           ) : (
             <Box p="md">
-              <CurrentDatePicker value={value} onChange={onChange} />
+              <CurrentDatePicker
+                value={value}
+                availableUnits={availableUnits}
+                onChange={onChange}
+              />
             </Box>
           )}
         </Tabs.Panel>

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/RelativeDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/RelativeDatePicker.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 
 import { Box, Divider, Flex, PopoverBackButton, Tabs } from "metabase/ui";
 
-import type { RelativeDatePickerValue } from "../types";
+import type { DatePickerUnit, RelativeDatePickerValue } from "../types";
 
 import { CurrentDatePicker } from "./CurrentDatePicker";
 import { DateIntervalPicker } from "./DateIntervalPicker";
@@ -18,6 +18,7 @@ import {
 
 interface RelativeDatePickerProps {
   value: RelativeDatePickerValue | undefined;
+  availableUnits: ReadonlyArray<DatePickerUnit>;
   canUseRelativeOffsets: boolean;
   isNew: boolean;
   onChange: (value: RelativeDatePickerValue) => void;
@@ -26,6 +27,7 @@ interface RelativeDatePickerProps {
 
 export function RelativeDatePicker({
   value: initialValue,
+  availableUnits,
   canUseRelativeOffsets,
   isNew,
   onChange,
@@ -63,6 +65,7 @@ export function RelativeDatePicker({
           {isOffsetIntervalValue(value) ? (
             <DateOffsetIntervalPicker
               value={value}
+              availableUnits={availableUnits}
               isNew={isNew}
               onChange={setValue}
               onSubmit={handleSubmit}
@@ -70,6 +73,7 @@ export function RelativeDatePicker({
           ) : isIntervalValue(value) ? (
             <DateIntervalPicker
               value={value}
+              availableUnits={availableUnits}
               isNew={isNew}
               canUseRelativeOffsets={canUseRelativeOffsets}
               onChange={setValue}

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/RelativeDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/RelativeDatePicker.tsx
@@ -33,7 +33,9 @@ export function RelativeDatePicker({
   onChange,
   onBack,
 }: RelativeDatePickerProps) {
-  const [value, setValue] = useState(initialValue ?? DEFAULT_VALUE);
+  const [value, setValue] = useState<RelativeDatePickerValue | undefined>(
+    initialValue ?? DEFAULT_VALUE,
+  );
   const direction = getDirection(value);
 
   const handleTabChange = (tabValue: string | null) => {
@@ -44,7 +46,9 @@ export function RelativeDatePicker({
   };
 
   const handleSubmit = () => {
-    onChange(value);
+    if (value != null) {
+      onChange(value);
+    }
   };
 
   return (

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/RelativeDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/RelativeDatePicker.unit.spec.tsx
@@ -2,7 +2,8 @@ import userEvent from "@testing-library/user-event";
 
 import { renderWithProviders, screen } from "__support__/ui";
 
-import type { RelativeDatePickerValue } from "../types";
+import { DATE_PICKER_UNITS } from "../constants";
+import type { DatePickerUnit, RelativeDatePickerValue } from "../types";
 
 import { RelativeDatePicker } from "./RelativeDatePicker";
 
@@ -11,12 +12,14 @@ const TAB_CASES = TABS.flatMap(fromTab => TABS.map(toTab => [fromTab, toTab]));
 
 interface SetupOpts {
   value?: RelativeDatePickerValue;
+  availableUnits?: ReadonlyArray<DatePickerUnit>;
   canUseRelativeOffsets?: boolean;
   isNew?: boolean;
 }
 
 function setup({
   value,
+  availableUnits = DATE_PICKER_UNITS,
   canUseRelativeOffsets = false,
   isNew = false,
 }: SetupOpts = {}) {
@@ -26,6 +29,7 @@ function setup({
   renderWithProviders(
     <RelativeDatePicker
       value={value}
+      availableUnits={availableUnits}
       canUseRelativeOffsets={canUseRelativeOffsets}
       isNew={isNew}
       onChange={onChange}

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/utils.ts
@@ -13,35 +13,32 @@ import { DEFAULT_VALUE } from "./constants";
 import type { DateIntervalValue, DateOffsetIntervalValue } from "./types";
 
 export function isRelativeValue(
-  value?: DatePickerValue,
+  value: DatePickerValue | undefined,
 ): value is RelativeDatePickerValue {
-  return value?.type === "relative";
+  return value != null && value.type === "relative";
 }
 
 export function isIntervalValue(
-  value: RelativeDatePickerValue,
+  value: RelativeDatePickerValue | undefined,
 ): value is DateIntervalValue {
-  return value.value !== "current";
+  return value != null && value.value !== "current";
 }
 
 export function isOffsetIntervalValue(
-  value: RelativeDatePickerValue,
+  value: RelativeDatePickerValue | undefined,
 ): value is DateOffsetIntervalValue {
   return (
+    value != null &&
     isIntervalValue(value) &&
     value.offsetValue != null &&
     value.offsetUnit != null
   );
 }
 
-export function getDirectionDefaultValue(direction: RelativeIntervalDirection) {
-  return setDirectionAndCoerceUnit(DEFAULT_VALUE, direction);
-}
-
 export function getDirection(
-  value: RelativeDatePickerValue,
+  value: RelativeDatePickerValue | undefined,
 ): RelativeIntervalDirection {
-  if (value.value === "current") {
+  if (value == null || value.value === "current") {
     return "current";
   } else {
     return value.value < 0 ? "last" : "next";
@@ -49,12 +46,14 @@ export function getDirection(
 }
 
 export function setDirection(
-  value: RelativeDatePickerValue,
+  value: RelativeDatePickerValue = DEFAULT_VALUE,
   direction: RelativeIntervalDirection,
-  fallbackUnit: DatePickerTruncationUnit = "hour",
-): RelativeDatePickerValue {
+  fallbackUnit?: DatePickerTruncationUnit,
+): RelativeDatePickerValue | undefined {
   if (direction === "current") {
-    return { type: "relative", value: "current", unit: fallbackUnit };
+    return fallbackUnit
+      ? { type: "relative", value: "current", unit: fallbackUnit }
+      : undefined;
   }
 
   const sign = direction === "last" ? -1 : 1;

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/utils.ts
@@ -3,6 +3,7 @@ import * as Lib from "metabase-lib";
 import { DATE_PICKER_TRUNCATION_UNITS } from "../constants";
 import type {
   DatePickerTruncationUnit,
+  DatePickerUnit,
   DatePickerValue,
   RelativeDatePickerValue,
   RelativeIntervalDirection,
@@ -103,10 +104,22 @@ export function setInterval(
   };
 }
 
-export function getUnitOptions(value: DateIntervalValue) {
+export function getAvailableTruncationUnits(
+  availableUnits: ReadonlyArray<DatePickerUnit>,
+) {
+  return DATE_PICKER_TRUNCATION_UNITS.filter(unit =>
+    availableUnits.includes(unit),
+  );
+}
+
+export function getUnitOptions(
+  value: DateIntervalValue,
+  availableUnits: ReadonlyArray<DatePickerUnit>,
+) {
+  const truncationUnits = getAvailableTruncationUnits(availableUnits);
   const interval = getInterval(value);
 
-  return DATE_PICKER_TRUNCATION_UNITS.map(unit => ({
+  return truncationUnits.map(unit => ({
     value: unit,
     label: Lib.describeTemporalUnit(unit, interval).toLowerCase(),
   }));

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/utils.ts
@@ -45,6 +45,10 @@ export function getDirection(
   }
 }
 
+export function getDirectionDefaultValue(direction: RelativeIntervalDirection) {
+  return setDirectionAndCoerceUnit(DEFAULT_VALUE, direction);
+}
+
 export function setDirection(
   value: RelativeDatePickerValue = DEFAULT_VALUE,
   direction: RelativeIntervalDirection,

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/utils.unit.spec.ts
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/utils.unit.spec.ts
@@ -15,17 +15,13 @@ describe("setDirection", () => {
       "month",
       "quarter",
       "year",
-    ])('should fallback to "hour" for "%s" unit', unit => {
+    ])('should remove the value for "%s" unit', unit => {
       const value: RelativeDatePickerValue = {
         type: "relative",
         value: 1,
         unit,
       };
-      expect(setDirection(value, "current")).toEqual({
-        type: "relative",
-        value: "current",
-        unit: "hour",
-      });
+      expect(setDirection(value, "current")).toBeUndefined();
     });
   });
 

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SimpleDatePicker/SimpleDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SimpleDatePicker/SimpleDatePicker.tsx
@@ -11,16 +11,22 @@ import { isIntervalValue, isRelativeValue } from "../RelativeDatePicker/utils";
 import { SimpleSpecificDatePicker } from "../SpecificDatePicker/SimpleSpecificDatePicker";
 import { isSpecificValue } from "../SpecificDatePicker/utils";
 import { DATE_PICKER_OPERATORS } from "../constants";
-import type { DatePickerOperator, DatePickerValue } from "../types";
+import type {
+  DatePickerOperator,
+  DatePickerUnit,
+  DatePickerValue,
+} from "../types";
 
 interface SimpleDatePickerProps {
   value?: DatePickerValue;
   availableOperators?: ReadonlyArray<DatePickerOperator>;
+  availableUnits: ReadonlyArray<DatePickerUnit>;
   onChange: (value: DatePickerValue | undefined) => void;
 }
 
 export function SimpleDatePicker({
   value: initialValue,
+  availableUnits,
   availableOperators = DATE_PICKER_OPERATORS,
   onChange,
 }: SimpleDatePickerProps) {
@@ -40,7 +46,11 @@ export function SimpleDatePicker({
           onChange={setValue}
         />
         {isRelativeValue(value) && isIntervalValue(value) && (
-          <SimpleDateIntervalPicker value={value} onChange={setValue} />
+          <SimpleDateIntervalPicker
+            value={value}
+            availableUnits={availableUnits}
+            onChange={setValue}
+          />
         )}
         {isRelativeValue(value) && !isIntervalValue(value) && (
           <CurrentDatePicker value={value} onChange={setValue} />

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SimpleDatePicker/SimpleDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SimpleDatePicker/SimpleDatePicker.tsx
@@ -53,7 +53,11 @@ export function SimpleDatePicker({
           />
         )}
         {isRelativeValue(value) && !isIntervalValue(value) && (
-          <CurrentDatePicker value={value} onChange={setValue} />
+          <CurrentDatePicker
+            value={value}
+            availableUnits={availableUnits}
+            onChange={setValue}
+          />
         )}
         {isSpecificValue(value) && (
           <SimpleSpecificDatePicker value={value} onChange={setValue} />

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SimpleDatePicker/SimpleDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SimpleDatePicker/SimpleDatePicker.unit.spec.tsx
@@ -2,19 +2,25 @@ import userEvent from "@testing-library/user-event";
 
 import { renderWithProviders, screen } from "__support__/ui";
 
-import { DATE_PICKER_OPERATORS } from "../constants";
-import type { DatePickerOperator, DatePickerValue } from "../types";
+import { DATE_PICKER_OPERATORS, DATE_PICKER_UNITS } from "../constants";
+import type {
+  DatePickerOperator,
+  DatePickerUnit,
+  DatePickerValue,
+} from "../types";
 
 import { SimpleDatePicker } from "./SimpleDatePicker";
 
 interface SetupOpts {
   value?: DatePickerValue;
   availableOperators?: ReadonlyArray<DatePickerOperator>;
+  availableUnits?: ReadonlyArray<DatePickerUnit>;
 }
 
 function setup({
   value,
   availableOperators = DATE_PICKER_OPERATORS,
+  availableUnits = DATE_PICKER_UNITS,
 }: SetupOpts = {}) {
   const onChange = jest.fn();
 
@@ -22,6 +28,7 @@ function setup({
     <SimpleDatePicker
       value={value}
       availableOperators={availableOperators}
+      availableUnits={availableUnits}
       onChange={onChange}
     />,
   );

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePicker.tsx
@@ -12,6 +12,7 @@ import type { DateRangePickerValue } from "./types";
 export interface DateRangePickerProps {
   value: DateRangePickerValue;
   isNew: boolean;
+  hasTimeToggle: boolean;
   onChange: (value: DateRangePickerValue) => void;
   onSubmit: () => void;
 }
@@ -19,6 +20,7 @@ export interface DateRangePickerProps {
 export function DateRangePicker({
   value: { dateRange, hasTime },
   isNew,
+  hasTimeToggle,
   onChange,
   onSubmit,
 }: DateRangePickerProps) {
@@ -50,8 +52,10 @@ export function DateRangePicker({
         />
       </Box>
       <Divider />
-      <Group p="sm" position="apart">
-        <TimeToggle hasTime={hasTime} onClick={handleTimeToggle} />
+      <Group p="sm" position={hasTimeToggle ? "apart" : "right"}>
+        {hasTimeToggle && (
+          <TimeToggle hasTime={hasTime} onClick={handleTimeToggle} />
+        )}
         <Button variant="filled" type="submit">
           {isNew ? t`Add filter` : t`Update filter`}
         </Button>

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePicker.unit.spec.tsx
@@ -226,4 +226,12 @@ describe("SingleDatePicker", () => {
     });
     expect(onSubmit).not.toHaveBeenCalled();
   });
+
+  it("should not allow to add time when the time toggle is disabled", () => {
+    setup({
+      value: { dateRange: [START_DATE_TIME, END_DATE_TIME], hasTime: false },
+      hasTimeToggle: false,
+    });
+    expect(screen.queryByText("Add time")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePicker.unit.spec.tsx
@@ -14,6 +14,7 @@ const END_DATE_TIME = new Date(2020, 1, 9, 20, 30);
 interface SetupOpts {
   value?: DateRangePickerValue;
   isNew?: boolean;
+  hasTimeToggle?: boolean;
 }
 
 const userEvent = _userEvent.setup({
@@ -23,6 +24,7 @@ const userEvent = _userEvent.setup({
 function setup({
   value = { dateRange: [START_DATE, END_DATE], hasTime: false },
   isNew = false,
+  hasTimeToggle = false,
 }: SetupOpts = {}) {
   const onChange = jest.fn();
   const onSubmit = jest.fn();
@@ -31,6 +33,7 @@ function setup({
     <DateRangePicker
       value={value}
       isNew={isNew}
+      hasTimeToggle={hasTimeToggle}
       onChange={onChange}
       onSubmit={onSubmit}
     />,
@@ -65,6 +68,7 @@ describe("SingleDatePicker", () => {
         dateRange: [START_DATE_TIME, END_DATE_TIME],
         hasTime: true,
       },
+      hasTimeToggle: true,
     });
 
     const calendars = screen.getAllByRole("table");
@@ -100,6 +104,7 @@ describe("SingleDatePicker", () => {
         dateRange: [START_DATE_TIME, END_DATE],
         hasTime: true,
       },
+      hasTimeToggle: true,
     });
 
     const input = screen.getByLabelText("Start date");
@@ -135,6 +140,7 @@ describe("SingleDatePicker", () => {
         dateRange: [START_DATE, END_DATE_TIME],
         hasTime: true,
       },
+      hasTimeToggle: true,
     });
 
     const input = screen.getByLabelText("End date");
@@ -149,7 +155,9 @@ describe("SingleDatePicker", () => {
   });
 
   it("should be able to add time", async () => {
-    const { onChange, onSubmit } = setup();
+    const { onChange, onSubmit } = setup({
+      hasTimeToggle: true,
+    });
     expect(screen.queryByLabelText("Start time")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("End time")).not.toBeInTheDocument();
 
@@ -167,6 +175,7 @@ describe("SingleDatePicker", () => {
         dateRange: [START_DATE_TIME, END_DATE_TIME],
         hasTime: true,
       },
+      hasTimeToggle: true,
     });
 
     const input = screen.getByLabelText("Start time");
@@ -186,6 +195,7 @@ describe("SingleDatePicker", () => {
         dateRange: [START_DATE_TIME, END_DATE_TIME],
         hasTime: true,
       },
+      hasTimeToggle: true,
     });
 
     const input = screen.getByLabelText("End time");
@@ -205,6 +215,7 @@ describe("SingleDatePicker", () => {
         dateRange: [START_DATE_TIME, END_DATE_TIME],
         hasTime: true,
       },
+      hasTimeToggle: true,
     });
 
     await userEvent.click(screen.getByText("Remove time"));

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SingleDatePicker/SingleDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SingleDatePicker/SingleDatePicker.tsx
@@ -12,6 +12,7 @@ import type { SingleDatePickerValue } from "./types";
 interface SingleDatePickerProps {
   value: SingleDatePickerValue;
   isNew: boolean;
+  hasTimeToggle: boolean;
   onChange: (value: SingleDatePickerValue) => void;
   onSubmit: () => void;
 }
@@ -19,6 +20,7 @@ interface SingleDatePickerProps {
 export function SingleDatePicker({
   value: { date, hasTime },
   isNew,
+  hasTimeToggle,
   onChange,
   onSubmit,
 }: SingleDatePickerProps) {
@@ -45,8 +47,10 @@ export function SingleDatePicker({
         />
       </Box>
       <Divider />
-      <Group p="sm" position="apart">
-        <TimeToggle hasTime={hasTime} onClick={handleTimeToggle} />
+      <Group p="sm" position={hasTimeToggle ? "apart" : "right"}>
+        {hasTimeToggle && (
+          <TimeToggle hasTime={hasTime} onClick={handleTimeToggle} />
+        )}
         <Button variant="filled" type="submit">
           {isNew ? t`Add filter` : t`Update filter`}
         </Button>

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SingleDatePicker/SingleDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SingleDatePicker/SingleDatePicker.unit.spec.tsx
@@ -149,4 +149,12 @@ describe("SingleDatePicker", () => {
     });
     expect(onSubmit).not.toHaveBeenCalled();
   });
+
+  it("should not allow to add time when the time toggle is disabled", () => {
+    setup({
+      value: { date: DATE, hasTime: false },
+      hasTimeToggle: false,
+    });
+    expect(screen.queryByText("Add time")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SingleDatePicker/SingleDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SingleDatePicker/SingleDatePicker.unit.spec.tsx
@@ -11,6 +11,7 @@ const DATE_TIME = new Date(2020, 0, 10, 10, 20);
 interface SetupOpts {
   value?: SingleDatePickerValue;
   isNew?: boolean;
+  hasTimeToggle?: boolean;
 }
 
 const userEvent = _userEvent.setup({
@@ -20,6 +21,7 @@ const userEvent = _userEvent.setup({
 function setup({
   value = { date: DATE, hasTime: false },
   isNew = false,
+  hasTimeToggle = false,
 }: SetupOpts = {}) {
   const onChange = jest.fn();
   const onSubmit = jest.fn();
@@ -28,6 +30,7 @@ function setup({
     <SingleDatePicker
       value={value}
       isNew={isNew}
+      hasTimeToggle={hasTimeToggle}
       onChange={onChange}
       onSubmit={onSubmit}
     />,
@@ -57,6 +60,7 @@ describe("SingleDatePicker", () => {
   it("should be able to set the date via the calendar when there is time", async () => {
     const { onChange, onSubmit } = setup({
       value: { date: DATE_TIME, hasTime: true },
+      hasTimeToggle: true,
     });
 
     await userEvent.click(screen.getByText("12"));
@@ -88,6 +92,7 @@ describe("SingleDatePicker", () => {
   it("should be able to set the date via the input when there is time", async () => {
     const { onChange, onSubmit } = setup({
       value: { date: DATE_TIME, hasTime: true },
+      hasTimeToggle: true,
     });
 
     const input = screen.getByLabelText("Date");
@@ -103,7 +108,9 @@ describe("SingleDatePicker", () => {
   });
 
   it("should be able to add time", async () => {
-    const { onChange, onSubmit } = setup();
+    const { onChange, onSubmit } = setup({
+      hasTimeToggle: true,
+    });
 
     await userEvent.click(screen.getByText("Add time"));
 
@@ -114,6 +121,7 @@ describe("SingleDatePicker", () => {
   it("should be able to update the time", async () => {
     const { onChange, onSubmit } = setup({
       value: { date: DATE_TIME, hasTime: true },
+      hasTimeToggle: true,
     });
 
     const input = screen.getByLabelText("Time");
@@ -130,6 +138,7 @@ describe("SingleDatePicker", () => {
   it("should be able to remove time", async () => {
     const { onChange, onSubmit } = setup({
       value: { date: DATE_TIME, hasTime: true },
+      hasTimeToggle: true,
     });
 
     await userEvent.click(screen.getByText("Remove time"));

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SpecificDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SpecificDatePicker.tsx
@@ -2,7 +2,11 @@ import { useMemo, useState } from "react";
 
 import { Divider, Flex, PopoverBackButton, Tabs } from "metabase/ui";
 
-import type { DatePickerOperator, SpecificDatePickerValue } from "../types";
+import type {
+  DatePickerOperator,
+  DatePickerUnit,
+  SpecificDatePickerValue,
+} from "../types";
 
 import { DateRangePicker, type DateRangePickerValue } from "./DateRangePicker";
 import {
@@ -11,6 +15,7 @@ import {
 } from "./SingleDatePicker";
 import { TabList } from "./SpecificDatePicker.styled";
 import {
+  canSetTime,
   coerceValue,
   getDate,
   getDefaultValue,
@@ -24,6 +29,7 @@ import {
 interface SpecificDatePickerProps {
   value?: SpecificDatePickerValue;
   availableOperators: ReadonlyArray<DatePickerOperator>;
+  availableUnits: ReadonlyArray<DatePickerUnit>;
   isNew: boolean;
   onChange: (value: SpecificDatePickerValue) => void;
   onBack: () => void;
@@ -32,15 +38,14 @@ interface SpecificDatePickerProps {
 export function SpecificDatePicker({
   value: initialValue,
   availableOperators,
+  availableUnits,
   isNew,
   onChange,
   onBack,
 }: SpecificDatePickerProps) {
-  const tabs = useMemo(() => {
-    return getTabs(availableOperators);
-  }, [availableOperators]);
-
+  const tabs = useMemo(() => getTabs(availableOperators), [availableOperators]);
   const [value, setValue] = useState(() => initialValue ?? getDefaultValue());
+  const hasTimeToggle = canSetTime(value, availableUnits);
 
   const handleTabChange = (tabValue: string | null) => {
     const tab = tabs.find(tab => tab.operator === tabValue);
@@ -83,6 +88,7 @@ export function SpecificDatePicker({
             <DateRangePicker
               value={{ dateRange: value.values, hasTime: value.hasTime }}
               isNew={isNew}
+              hasTimeToggle={hasTimeToggle}
               onChange={handleDateRangeChange}
               onSubmit={handleSubmit}
             />
@@ -90,6 +96,7 @@ export function SpecificDatePicker({
             <SingleDatePicker
               value={{ date: getDate(value), hasTime: value.hasTime }}
               isNew={isNew}
+              hasTimeToggle={hasTimeToggle}
               onChange={handleDateChange}
               onSubmit={handleSubmit}
             />

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SpecificDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SpecificDatePicker.unit.spec.tsx
@@ -132,4 +132,33 @@ describe("SpecificDatePicker", () => {
       hasTime: false,
     });
   });
+
+  it("should not allow to add time when time units are not supported", async () => {
+    setup({ availableUnits: ["day", "month"] });
+    await userEvent.click(screen.getByText("On"));
+    expect(screen.queryByText("Add time")).not.toBeInTheDocument();
+  });
+
+  it("should allow to remove time even when time units are not supported", async () => {
+    const { onChange } = setup({
+      value: {
+        type: "specific",
+        operator: "=",
+        values: [new Date(2020, 0, 1, 10, 20)],
+        hasTime: true,
+      },
+      availableUnits: ["day", "month"],
+    });
+
+    await userEvent.click(screen.getByText("Remove time"));
+    await userEvent.click(screen.getByText("Update filter"));
+
+    expect(onChange).toHaveBeenCalledWith({
+      type: "specific",
+      operator: "=",
+      values: [new Date(2020, 0, 1)],
+      hasTime: false,
+    });
+    expect(screen.queryByText("Add time")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SpecificDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SpecificDatePicker.unit.spec.tsx
@@ -2,14 +2,19 @@ import _userEvent from "@testing-library/user-event";
 
 import { renderWithProviders, screen, within } from "__support__/ui";
 
-import { DATE_PICKER_OPERATORS } from "../constants";
-import type { DatePickerOperator, SpecificDatePickerValue } from "../types";
+import { DATE_PICKER_OPERATORS, DATE_PICKER_UNITS } from "../constants";
+import type {
+  DatePickerOperator,
+  DatePickerUnit,
+  SpecificDatePickerValue,
+} from "../types";
 
 import { SpecificDatePicker } from "./SpecificDatePicker";
 
 interface SetupOpts {
   value?: SpecificDatePickerValue;
   availableOperators?: ReadonlyArray<DatePickerOperator>;
+  availableUnits?: ReadonlyArray<DatePickerUnit>;
   isNew?: boolean;
 }
 
@@ -20,6 +25,7 @@ const userEvent = _userEvent.setup({
 function setup({
   value,
   availableOperators = DATE_PICKER_OPERATORS,
+  availableUnits = DATE_PICKER_UNITS,
   isNew = false,
 }: SetupOpts = {}) {
   const onChange = jest.fn();
@@ -29,6 +35,7 @@ function setup({
     <SpecificDatePicker
       value={value}
       availableOperators={availableOperators}
+      availableUnits={availableUnits}
       isNew={isNew}
       onChange={onChange}
       onBack={onBack}

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/utils.ts
@@ -2,6 +2,7 @@ import dayjs from "dayjs";
 
 import type {
   DatePickerOperator,
+  DatePickerUnit,
   DatePickerValue,
   SpecificDatePickerOperator,
   SpecificDatePickerValue,
@@ -50,6 +51,13 @@ export function getOperatorDefaultValue(
         hasTime: false,
       };
   }
+}
+
+export function canSetTime(
+  value: SpecificDatePickerValue,
+  availableUnits: ReadonlyArray<DatePickerUnit>,
+) {
+  return value.hasTime || availableUnits.includes("minute");
 }
 
 export function setOperator(

--- a/frontend/src/metabase/querying/filters/components/DatePicker/constants.ts
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/constants.ts
@@ -45,3 +45,8 @@ export const DATE_PICKER_EXTRACTION_UNITS = [
   "month-of-year",
   "quarter-of-year",
 ] as const;
+
+export const DATE_PICKER_UNITS = [
+  ...DATE_PICKER_TRUNCATION_UNITS,
+  ...DATE_PICKER_EXTRACTION_UNITS,
+] as const;

--- a/frontend/src/metabase/querying/filters/components/DatePicker/types.ts
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/types.ts
@@ -18,6 +18,10 @@ export type ExcludeDatePickerOperator =
 
 export type DatePickerShortcut = (typeof DATE_PICKER_SHORTCUTS)[number];
 
+export type DatePickerUnit =
+  | DatePickerExtractionUnit
+  | DatePickerTruncationUnit;
+
 export type DatePickerExtractionUnit =
   (typeof DATE_PICKER_EXTRACTION_UNITS)[number];
 

--- a/frontend/src/metabase/querying/filters/components/DatePicker/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/utils.ts
@@ -7,6 +7,7 @@ import type {
   DatePickerExtractionUnit,
   DatePickerOperator,
   DatePickerTruncationUnit,
+  DatePickerUnit,
 } from "./types";
 
 export function isDatePickerOperator(
@@ -16,16 +17,20 @@ export function isDatePickerOperator(
   return operators.includes(operator);
 }
 
-export function isDatePickerExtractionUnit(
-  unit: string,
-): unit is DatePickerExtractionUnit {
-  const units: ReadonlyArray<string> = DATE_PICKER_EXTRACTION_UNITS;
-  return units.includes(unit);
+export function isDatePickerUnit(unit: string): unit is DatePickerUnit {
+  return isDatePickerTruncationUnit(unit) || isDatePickerExtractionUnit(unit);
 }
 
 export function isDatePickerTruncationUnit(
   unit: string,
 ): unit is DatePickerTruncationUnit {
   const units: ReadonlyArray<string> = DATE_PICKER_TRUNCATION_UNITS;
+  return units.includes(unit);
+}
+
+export function isDatePickerExtractionUnit(
+  unit: string,
+): unit is DatePickerExtractionUnit {
+  const units: ReadonlyArray<string> = DATE_PICKER_EXTRACTION_UNITS;
   return units.includes(unit);
 }

--- a/frontend/src/metabase/querying/filters/components/FilterModal/DateFilterEditor/DateFilterEditor.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterModal/DateFilterEditor/DateFilterEditor.tsx
@@ -9,8 +9,8 @@ import { Button, Flex, Grid, Icon, Popover } from "metabase/ui";
 
 import {
   DatePicker,
-  type DatePickerExtractionUnit,
   type DatePickerOperator,
+  type DatePickerUnit,
   type DatePickerValue,
   type ShortcutOption,
 } from "../../DatePicker";
@@ -103,7 +103,7 @@ interface DateFilterPopoverProps {
   title: string | undefined;
   value: DatePickerValue | undefined;
   availableOperators: ReadonlyArray<DatePickerOperator>;
-  availableUnits: ReadonlyArray<DatePickerExtractionUnit>;
+  availableUnits: ReadonlyArray<DatePickerUnit>;
   isExpanded: boolean;
   onChange: (value: DatePickerValue | undefined) => void;
 }

--- a/frontend/src/metabase/querying/filters/components/FilterModal/DateFilterEditor/DateFilterEditor.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterModal/DateFilterEditor/DateFilterEditor.unit.spec.tsx
@@ -46,162 +46,184 @@ describe("DateFilterEditor", () => {
   const findColumn = columnFinder(defaultQuery, availableColumns);
   const column = findColumn("ORDERS", "CREATED_AT");
 
-  describe("new filter", () => {
-    it("should add a relative date filter from a shortcut", async () => {
-      const { getNextFilterName } = setup({
-        query: defaultQuery,
-        stageIndex,
-        column,
-      });
-
-      await userEvent.click(screen.getByText("Last month"));
-
-      expect(getNextFilterName()).toBe("Created At is in the previous month");
+  it("should add a relative date filter from a shortcut", async () => {
+    const { getNextFilterName } = setup({
+      query: defaultQuery,
+      stageIndex,
+      column,
     });
 
-    it("should remove a relative date filter from a shortcut", async () => {
-      const { query, filter } = createQueryWithFilter(
-        defaultQuery,
-        stageIndex,
-        Lib.relativeDateFilterClause({
-          column,
-          value: "current",
-          bucket: "day",
-          offsetValue: null,
-          offsetBucket: null,
-          options: {},
-        }),
-      );
-      const { getNextFilterName } = setup({
-        query,
-        stageIndex,
+    await userEvent.click(screen.getByText("Last month"));
+
+    expect(getNextFilterName()).toBe("Created At is in the previous month");
+  });
+
+  it("should remove a relative date filter from a shortcut", async () => {
+    const { query, filter } = createQueryWithFilter(
+      defaultQuery,
+      stageIndex,
+      Lib.relativeDateFilterClause({
         column,
-        filter,
-      });
-
-      const button = screen.getByRole("button", { name: "Today" });
-      expect(button).toHaveAttribute("aria-selected", "true");
-
-      await userEvent.click(button);
-      expect(getNextFilterName()).toBeNull();
+        value: "current",
+        bucket: "day",
+        offsetValue: null,
+        offsetBucket: null,
+        options: {},
+      }),
+    );
+    const { getNextFilterName } = setup({
+      query,
+      stageIndex,
+      column,
+      filter,
     });
 
-    it("should add a relative date filter", async () => {
-      const { getNextFilterName } = setup({
-        query: defaultQuery,
-        stageIndex,
-        column,
-      });
+    const button = screen.getByRole("button", { name: "Today" });
+    expect(button).toHaveAttribute("aria-selected", "true");
 
-      await userEvent.click(screen.getByLabelText("More options"));
-      await userEvent.click(await screen.findByText("Last 30 days"));
+    await userEvent.click(button);
+    expect(getNextFilterName()).toBeNull();
+  });
 
-      expect(getNextFilterName()).toBe("Created At is in the previous 30 days");
+  it("should add a relative date filter", async () => {
+    const { getNextFilterName } = setup({
+      query: defaultQuery,
+      stageIndex,
+      column,
     });
 
-    it("should remove a relative date filter", async () => {
-      const { query, filter } = createQueryWithFilter(
-        defaultQuery,
-        stageIndex,
-        Lib.relativeDateFilterClause({
-          column,
-          value: -30,
-          bucket: "day",
-          offsetValue: null,
-          offsetBucket: null,
-          options: {},
-        }),
-      );
-      const { getNextFilterName } = setup({
-        query,
-        stageIndex,
-        column,
-        filter,
-      });
-      expect(screen.getByText("Previous 30 Days")).toBeInTheDocument();
+    await userEvent.click(screen.getByLabelText("More options"));
+    await userEvent.click(await screen.findByText("Last 30 days"));
 
-      await userEvent.click(screen.getByLabelText("Clear"));
-      expect(getNextFilterName()).toBe(null);
+    expect(getNextFilterName()).toBe("Created At is in the previous 30 days");
+  });
+
+  it("should remove a relative date filter", async () => {
+    const { query, filter } = createQueryWithFilter(
+      defaultQuery,
+      stageIndex,
+      Lib.relativeDateFilterClause({
+        column,
+        value: -30,
+        bucket: "day",
+        offsetValue: null,
+        offsetBucket: null,
+        options: {},
+      }),
+    );
+    const { getNextFilterName } = setup({
+      query,
+      stageIndex,
+      column,
+      filter,
+    });
+    expect(screen.getByText("Previous 30 Days")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByLabelText("Clear"));
+    expect(getNextFilterName()).toBe(null);
+  });
+
+  it("should add a specific date filter", async () => {
+    const { getNextFilterName } = setup({
+      query: defaultQuery,
+      stageIndex,
+      column,
     });
 
-    it("should add a specific date filter", async () => {
-      const { getNextFilterName } = setup({
-        query: defaultQuery,
-        stageIndex,
+    await userEvent.click(screen.getByLabelText("More options"));
+    await userEvent.click(await screen.findByText("Specific dates…"));
+    await userEvent.click(screen.getByText("After"));
+    await userEvent.clear(screen.getByLabelText("Date"));
+    await userEvent.type(screen.getByLabelText("Date"), "Feb 15, 2020");
+    await userEvent.click(screen.getByText("Add filter"));
+
+    expect(getNextFilterName()).toBe("Created At is after Feb 15, 2020");
+  });
+
+  it("should remove a specific date filter", async () => {
+    const { query, filter } = createQueryWithFilter(
+      defaultQuery,
+      stageIndex,
+      Lib.specificDateFilterClause(defaultQuery, stageIndex, {
+        operator: "=",
         column,
-      });
+        values: [new Date(2020, 1, 15)],
+        hasTime: false,
+      }),
+    );
+    const { getNextFilterName } = setup({
+      query,
+      stageIndex,
+      column,
+      filter,
+    });
+    expect(screen.getByText("Feb 15, 2020")).toBeInTheDocument();
 
-      await userEvent.click(screen.getByLabelText("More options"));
-      await userEvent.click(await screen.findByText("Specific dates…"));
-      await userEvent.click(screen.getByText("After"));
-      await userEvent.clear(screen.getByLabelText("Date"));
-      await userEvent.type(screen.getByLabelText("Date"), "Feb 15, 2020");
-      await userEvent.click(screen.getByText("Add filter"));
+    await userEvent.click(screen.getByLabelText("Clear"));
+    expect(getNextFilterName()).toBe(null);
+  });
 
-      expect(getNextFilterName()).toBe("Created At is after Feb 15, 2020");
+  it("should add an exclude date filter", async () => {
+    const { getNextFilterName } = setup({
+      query: defaultQuery,
+      stageIndex,
+      column,
     });
 
-    it("should remove a specific date filter", async () => {
-      const { query, filter } = createQueryWithFilter(
-        defaultQuery,
-        stageIndex,
-        Lib.specificDateFilterClause(defaultQuery, stageIndex, {
-          operator: "=",
-          column,
-          values: [new Date(2020, 1, 15)],
-          hasTime: false,
-        }),
-      );
-      const { getNextFilterName } = setup({
-        query,
-        stageIndex,
-        column,
-        filter,
-      });
-      expect(screen.getByText("Feb 15, 2020")).toBeInTheDocument();
+    await userEvent.click(screen.getByLabelText("More options"));
+    await userEvent.click(await screen.findByText("Exclude…"));
+    await userEvent.click(screen.getByText("Hours of the day…"));
+    await userEvent.click(screen.getByText("5 PM"));
+    await userEvent.click(screen.getByText("Add filter"));
 
-      await userEvent.click(screen.getByLabelText("Clear"));
-      expect(getNextFilterName()).toBe(null);
+    expect(getNextFilterName()).toBe("Created At excludes the hour of 5 PM");
+  });
+
+  it("should remove an exclude date filter", async () => {
+    const { query, filter } = createQueryWithFilter(
+      defaultQuery,
+      stageIndex,
+      Lib.excludeDateFilterClause(defaultQuery, stageIndex, {
+        operator: "!=",
+        column,
+        values: [17],
+        bucket: "hour-of-day",
+      }),
+    );
+    const { getNextFilterName } = setup({
+      query,
+      stageIndex,
+      column,
+      filter,
+    });
+    expect(screen.getByText("Excludes 5 PM")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByLabelText("Clear"));
+    expect(getNextFilterName()).toBe(null);
+  });
+
+  it("should not allow to set time for a date only column", async () => {
+    setup({
+      query: defaultQuery,
+      stageIndex,
+      column: findColumn("PEOPLE", "BIRTH_DATE"),
     });
 
-    it("should add an exclude date filter", async () => {
-      const { getNextFilterName } = setup({
-        query: defaultQuery,
-        stageIndex,
-        column,
-      });
+    await userEvent.click(screen.getByLabelText("More options"));
+    await userEvent.click(screen.getByText("Specific dates…"));
+    await userEvent.click(screen.getByText("On"));
+    expect(screen.queryByText("Add time")).not.toBeInTheDocument();
 
-      await userEvent.click(screen.getByLabelText("More options"));
-      await userEvent.click(await screen.findByText("Exclude…"));
-      await userEvent.click(screen.getByText("Hours of the day…"));
-      await userEvent.click(screen.getByText("5 PM"));
-      await userEvent.click(screen.getByText("Add filter"));
+    await userEvent.click(screen.getByLabelText("Back"));
+    await userEvent.click(screen.getByText("Relative dates…"));
+    await userEvent.click(screen.getByDisplayValue("days"));
+    expect(screen.getByText("days")).toBeInTheDocument();
+    expect(screen.queryByText("hours")).not.toBeInTheDocument();
 
-      expect(getNextFilterName()).toBe("Created At excludes the hour of 5 PM");
-    });
-
-    it("should remove an exclude date filter", async () => {
-      const { query, filter } = createQueryWithFilter(
-        defaultQuery,
-        stageIndex,
-        Lib.excludeDateFilterClause(defaultQuery, stageIndex, {
-          operator: "!=",
-          column,
-          values: [17],
-          bucket: "hour-of-day",
-        }),
-      );
-      const { getNextFilterName } = setup({
-        query,
-        stageIndex,
-        column,
-        filter,
-      });
-      expect(screen.getByText("Excludes 5 PM")).toBeInTheDocument();
-
-      await userEvent.click(screen.getByLabelText("Clear"));
-      expect(getNextFilterName()).toBe(null);
-    });
+    await userEvent.click(screen.getByLabelText("Back"));
+    await userEvent.click(screen.getByText("Exclude…"));
+    expect(screen.getByText("Days of the week…")).toBeInTheDocument();
+    expect(screen.queryByText("Hours of the day…")).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/SimpleDateFilterPicker/SimpleDateFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/SimpleDateFilterPicker/SimpleDateFilterPicker.tsx
@@ -18,12 +18,13 @@ export function SimpleDateFilterPicker({
   filter,
   onChange,
 }: SimpleDateFilterPickerProps) {
-  const { value, availableOperators, getFilterClause } = useDateFilter({
-    query,
-    stageIndex,
-    column,
-    filter,
-  });
+  const { value, availableOperators, availableUnits, getFilterClause } =
+    useDateFilter({
+      query,
+      stageIndex,
+      column,
+      filter,
+    });
 
   const handleChange = (value: DatePickerValue | undefined) => {
     if (value) {
@@ -38,6 +39,7 @@ export function SimpleDateFilterPicker({
       <SimpleDatePicker
         value={value}
         availableOperators={availableOperators}
+        availableUnits={availableUnits}
         onChange={handleChange}
       />
     </div>

--- a/frontend/src/metabase/querying/filters/hooks/use-date-filter/utils.ts
+++ b/frontend/src/metabase/querying/filters/hooks/use-date-filter/utils.ts
@@ -1,14 +1,14 @@
 import * as Lib from "metabase-lib";
 
 import {
-  type DatePickerExtractionUnit,
   type DatePickerOperator,
+  type DatePickerUnit,
   type DatePickerValue,
   type ExcludeDatePickerValue,
   type RelativeDatePickerValue,
   type SpecificDatePickerValue,
-  isDatePickerExtractionUnit,
   isDatePickerOperator,
+  isDatePickerUnit,
 } from "../../components/DatePicker";
 
 export function getPickerValue(
@@ -163,8 +163,8 @@ export function getPickerUnits(
   query: Lib.Query,
   stageIndex: number,
   column: Lib.ColumnMetadata,
-): DatePickerExtractionUnit[] {
+): DatePickerUnit[] {
   return Lib.availableTemporalBuckets(query, stageIndex, column)
     .map(operator => Lib.displayInfo(query, stageIndex, operator).shortName)
-    .filter(isDatePickerExtractionUnit);
+    .filter(isDatePickerUnit);
 }


### PR DESCRIPTION
Related to https://github.com/metabase/metabase/issues/48608

Takes `availableUnits` into account in specific & relative date pickers.

How to verify:
- New -> Question -> People
- Filter -> Created At -> Specific dates... -> There is "Add time" button
- Filter -> Birth Date -> Specific dates... -> There is no "Add time" button
- Filter -> Birth Date -> Relative dates... -> There is no "hours" unit

<img width="504" alt="Screenshot 2024-10-16 at 23 16 56" src="https://github.com/user-attachments/assets/535fdf8f-7982-4559-9db3-78416fd55cd5">
<img width="730" alt="Screenshot 2024-10-16 at 23 17 02" src="https://github.com/user-attachments/assets/3e914940-9123-4149-a86c-73d534ab1b33">
