### PR TITLE
Automate SDK release version numbers

### DIFF
--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -44,8 +44,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
-          fetch-depth: 0
-          fetch-tags: true
 
       - name: Get current SDK version
         id: current-sdk-version

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -14,9 +14,9 @@ on:
           - release-x.51.x
 
 concurrency:
-  # We want to ensure only one job is running at a time because
+  # We want to ensure only one job is running at a time per branch because
   # there could be a conflict when updating the readme file.
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ inputs.branch }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -50,15 +50,16 @@ jobs:
       - name: Get current SDK version
         id: current-sdk-version
         run: |
-          VERSION=$(cat ./enterprise/frontend/src/embedding-sdk/package.template.json | jq .version)
+          VERSION=$(cat ./enterprise/frontend/src/embedding-sdk/package.template.json | jq -r .version)
           echo "::set-output name=sdk_current_version::$VERSION"
 
       - name: Get next SDK patch version
         id: new-sdk-version
         uses: actions/github-script@v7
         with:
+          result-encoding: string
           script: |
-            const currentVersion = ${{ steps.current-sdk-version.outputs.sdk_current_version }};
+            const currentVersion = "${{ steps.current-sdk-version.outputs.sdk_current_version }}";
             const versionParts = currentVersion.split(".");
             versionParts[versionParts.length - 1] = parseInt(versionParts.at(-1)) + 1;
             const newVersion = versionParts.join(".");
@@ -70,8 +71,8 @@ jobs:
         run: |
           echo '**Derived inputs:**' >> $GITHUB_STEP_SUMMARY
           echo '' >> $GITHUB_STEP_SUMMARY
-          echo '- `current_version`: ${{ steps.current-sdk-version.outputs.sdk_current_version }}' >> $GITHUB_STEP_SUMMARY
-          echo '- `next_version`: ${{ steps.new-sdk-version.outputs.result }}' >> $GITHUB_STEP_SUMMARY
+          echo '- `current_version`: "${{ steps.current-sdk-version.outputs.sdk_current_version }}"' >> $GITHUB_STEP_SUMMARY
+          echo '- `next_version`: "${{ steps.new-sdk-version.outputs.result }}"' >> $GITHUB_STEP_SUMMARY
 
   check-git-tag:
     needs: determine-version

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -4,14 +4,14 @@ on:
   workflow_dispatch:
     inputs:
       # TODO: Add a version validation, so the workflow won't fail when publishing to npm
-      sdk_version:
-        description: "SDK version (e.g. 0.1.3)"
-        type: string
+      branch:
+        description: "Branch we want to release the SDK from"
+        type: choice
         required: true
-      git_ref:
-        description: "A git commit hash that will be used to build the SDK"
-        type: string
-        required: true
+        default: "master"
+        options:
+          - master
+          - release-x.51.x
 
 concurrency:
   # We want to ensure only one job is running at a time because
@@ -20,16 +20,62 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  workflow-summary:
+    name: Log inputs
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - name: Generate workflow summary
+        run: |
+          echo '**Inputs:**' >> $GITHUB_STEP_SUMMARY
+          echo '' >> $GITHUB_STEP_SUMMARY
+          echo '- `branch`: ${{ inputs.branch }}' >> $GITHUB_STEP_SUMMARY
+          echo '' >> $GITHUB_STEP_SUMMARY
+          echo 'triggered by: @${{ github.event.sender.login }}' >> $GITHUB_STEP_SUMMARY
+
+  determine-version:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    outputs:
+      sdk_version: ${{ steps.new-sdk-version.outputs.result }}
+    steps:
+      - name: Check out the code using the provided branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Get current SDK version
+        id: current-sdk-version
+        run: |
+          VERSION=$(cat ./enterprise/frontend/src/embedding-sdk/package.template.json | jq .version)
+          echo "::set-output name=sdk_current_version::$VERSION"
+
+      - name: Get next SDK patch version
+        id: new-sdk-version
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const currentVersion = ${{ steps.current-sdk-version.outputs.sdk_current_version }};
+            const versionParts = currentVersion.split(".");
+            versionParts[versionParts.length - 1] = parseInt(versionParts.at(-1)) + 1;
+            const newVersion = versionParts.join(".");
+            console.log({currentVersion, newVersion});
+
+            return newVersion
+
   check-git-tag:
+    needs: determine-version
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     env:
-      tag: embedding-sdk-${{ inputs.sdk_version }}
+      tag: embedding-sdk-${{ needs.determine-version.outputs.sdk_version }}
     steps:
-      - name: Check out the code using the provided ref
+      - name: Check out the code using the provided branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.git_ref }}
+          ref: ${{ inputs.branch }}
           fetch-depth: 0
           fetch-tags: true
 
@@ -48,10 +94,10 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
-      - name: Check out the code using the provided ref
+      - name: Check out the code using the provided branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.git_ref }}
+          ref: ${{ inputs.branch }}
 
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
@@ -65,14 +111,14 @@ jobs:
         run: yarn embedding-sdk:test-unit
 
   build-sdk:
-    needs: test
+    needs: [test, determine-version]
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
-      - name: Check out the code using the provided ref
+      - name: Check out the code using the provided branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.git_ref }}
+          ref: ${{ inputs.branch }}
           fetch-depth: 0
           fetch-tags: true
 
@@ -84,14 +130,10 @@ jobs:
         with:
           m2-cache-key: "release-sdk"
 
-      - name: Update readme
-        run: |
-          ./bin/embedding-sdk/release_utils.bash update_readme ${{ inputs.sdk_version }}
-
       - name: Bump published npm package version
         # NOTE: this should happen before "Build SDK bundle" as we inject SDK version into the code during build step
         run: |
-          ./bin/embedding-sdk/release_utils.bash update_package_json_template ${{ inputs.sdk_version }}
+          ./bin/embedding-sdk/release_utils.bash update_package_json_template ${{ needs.determine-version.outputs.sdk_version }}
 
       - name: Update changelog
         run: |
@@ -116,15 +158,17 @@ jobs:
           path: ./changelog-diff
 
   publish-npm:
-    needs: build-sdk
+    needs: [build-sdk, determine-version]
     runs-on: ubuntu-22.04
     timeout-minutes: 20
+    env:
+      sdk_version: ${{ needs.determine-version.outputs.sdk_version }}
     steps:
-      - name: Check out master to prepare for a SDK version bump PR
+      - name: Check out branch to prepare for a SDK version bump PR
         uses: actions/checkout@v4
         with:
           # when we created version update PR, it would only have diff from 2 files SDK readme and SDK package.json template
-          ref: master
+          ref: ${{ inputs.branch}}
 
       - name: Setup git user
         run: |
@@ -133,11 +177,11 @@ jobs:
 
       - name: Update readme
         run: |
-          bash ./bin/embedding-sdk/release_utils.bash update_readme ${{ inputs.sdk_version }}
+          bash ./bin/embedding-sdk/release_utils.bash update_readme ${{ env.sdk_version }}
 
       - name: Bump published npm package version
         run: |
-          bash ./bin/embedding-sdk/release_utils.bash update_package_json_template ${{ inputs.sdk_version }}
+          bash ./bin/embedding-sdk/release_utils.bash update_package_json_template ${{ env.sdk_version }}
 
       - name: Retrieve SDK changelog diff
         uses: actions/download-artifact@v4
@@ -151,13 +195,13 @@ jobs:
 
       - name: Create a PR updating readme + published version, and changelog (using GitHub Metabase Automation account)
         run: |
-          git checkout -b update-sdk-version-${{ inputs.sdk_version }}
-          git commit -a -m 'Update Readme version references and published npm version to ${{ inputs.sdk_version }}'
+          git checkout -b update-sdk-version-${{ env.sdk_version }}
+          git commit -a -m 'Update Readme version references and published npm version to ${{ env.sdk_version }}'
           git push origin HEAD
-          gh pr create --base master\
+          gh pr create --base ${{ inputs.branch }}\
                        --assignee "${GITHUB_ACTOR}"\
-                       --title "Update SDK version to ${{ inputs.sdk_version }}"\
-                       --body "Update Readme version references and published npm package version to ${{ inputs.sdk_version }}"
+                       --title "Update SDK version to ${{ env.sdk_version }}"\
+                       --body "Update Readme version references and published npm package version to ${{ env.sdk_version }}"
         env:
           GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
 
@@ -198,16 +242,16 @@ jobs:
           npm publish
 
   git-tag:
-    needs: publish-npm
+    needs: [publish-npm, determine-version]
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     env:
-      tag: embedding-sdk-${{ inputs.sdk_version }}
+      tag: embedding-sdk-${{ needs.determine-version.outputs.sdk_version }}
     steps:
-      - name: Check out the code using the provided ref
+      - name: Check out the code using the provided branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.git_ref }}
+          ref: ${{ inputs.branch }}
 
       # Lightweight tags don't need committer name and email
       - name: Create a new git tag

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -34,6 +34,7 @@ jobs:
           echo 'triggered by: @${{ github.event.sender.login }}' >> $GITHUB_STEP_SUMMARY
 
   determine-version:
+    name: Determine SDK version
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     outputs:
@@ -64,6 +65,13 @@ jobs:
             console.log({currentVersion, newVersion});
 
             return newVersion
+
+      - name: Append workflow summary
+        run: |
+          echo '**Derived inputs:**' >> $GITHUB_STEP_SUMMARY
+          echo '' >> $GITHUB_STEP_SUMMARY
+          echo '- `current_version`: ${{ steps.current-sdk-version.outputs.sdk_current_version }}' >> $GITHUB_STEP_SUMMARY
+          echo '- `next_version`: ${{ steps.new-sdk-version.outputs.result }}' >> $GITHUB_STEP_SUMMARY
 
   check-git-tag:
     needs: determine-version

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -61,7 +61,6 @@ jobs:
             const versionParts = currentVersion.split(".");
             versionParts[versionParts.length - 1] = parseInt(versionParts.at(-1)) + 1;
             const newVersion = versionParts.join(".");
-            console.log({currentVersion, newVersion});
 
             return newVersion
 

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Get current SDK version
         id: current-sdk-version
         run: |
-          VERSION=$(cat ./enterprise/frontend/src/embedding-sdk/package.template.json | jq -r .version)
+          VERSION=$(jq -r .version ./enterprise/frontend/src/embedding-sdk/package.template.json)
           echo "::set-output name=sdk_current_version::$VERSION"
 
       - name: Get next SDK patch version

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -27,11 +27,13 @@ jobs:
     steps:
       - name: Generate workflow summary
         run: |
-          echo '**Inputs:**' >> $GITHUB_STEP_SUMMARY
-          echo '' >> $GITHUB_STEP_SUMMARY
-          echo '- `branch`: ${{ inputs.branch }}' >> $GITHUB_STEP_SUMMARY
-          echo '' >> $GITHUB_STEP_SUMMARY
-          echo 'triggered by: @${{ github.event.sender.login }}' >> $GITHUB_STEP_SUMMARY
+          tee -a $GITHUB_STEP_SUMMARY << EOF
+          **Inputs:**
+
+          - \`branch\`: ${{ inputs.branch }}
+
+          triggered by: @${{ github.event.sender.login }}
+          EOF
 
   determine-version:
     name: Determine SDK version
@@ -66,10 +68,12 @@ jobs:
 
       - name: Append workflow summary
         run: |
-          echo '**Derived inputs:**' >> $GITHUB_STEP_SUMMARY
-          echo '' >> $GITHUB_STEP_SUMMARY
-          echo '- `current_version`: "${{ steps.current-sdk-version.outputs.sdk_current_version }}"' >> $GITHUB_STEP_SUMMARY
-          echo '- `next_version`: "${{ steps.new-sdk-version.outputs.result }}"' >> $GITHUB_STEP_SUMMARY
+          tee -a $GITHUB_STEP_SUMMARY << EOF
+          **Derived inputs:**
+
+          - \`current_version\`: "${{ steps.current-sdk-version.outputs.sdk_current_version }}"
+          - \`next_version\`: "${{ steps.new-sdk-version.outputs.result }}"
+          EOF
 
   check-git-tag:
     needs: determine-version

--- a/summary
+++ b/summary
@@ -1,0 +1,10 @@
+**Inputs:**
+
+- : branch
+
+triggered by: userName
+**Inputs:**
+
+- `branch`: branch
+
+triggered by: userName


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/48822


### Description

This is one of the first steps to automate SDK release process better.

This PR changes the workflow input to only require a `branch` and nothing else. And we'll figure out the version number from `package.template.json` instead.

### How to verify
These runs were tested with [2423d91](https://github.com/metabase/metabase/pull/48838/commits/2423d9140ff4297d9b3b8bd3a71baa248bca65cc)
- [Mock `release-x.51.x` deployment](https://github.com/metabase/metabase/actions/runs/11388055173)
  - [docs PR](https://github.com/metabase/metabase/pull/48841/files) (Correct version, but wrong changelog which will be addressed in https://github.com/metabase/metabase/issues/48844)
- [Mock `master` deployment](https://github.com/metabase/metabase/actions/runs/11388131790)
  - [docs PR](https://github.com/metabase/metabase/pull/48843/files) (Correct version, but wrong changelog which will be addressed in https://github.com/metabase/metabase/issues/48844)
### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
