### PR TITLE
ci(sdk): [release 51] Prepare SDK numver version for release automation

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/package.template.json
+++ b/enterprise/frontend/src/embedding-sdk/package.template.json
@@ -1,6 +1,6 @@
 {
   "name": "@metabase/embedding-sdk-react",
-  "version": "0.1.37",
+  "version": "1.51.0",
   "description": "Metabase Embedding SDK for React",
   "bin": "./dist/cli.js",
   "repository": {


### PR DESCRIPTION
[Context](https://metaboat.slack.com/archives/C063Q3F1HPF/p1729167399901159)

This PR bumps the version of `release-x.51.x` to `1.51.0`. This should be merged before #48838.

