### PR TITLE
Add utm params to doc link in expression editor

### DIFF
--- a/frontend/src/metabase/admin/settings/auth/components/GoogleAuthForm/GoogleAuthForm.tsx
+++ b/frontend/src/metabase/admin/settings/auth/components/GoogleAuthForm/GoogleAuthForm.tsx
@@ -52,10 +52,9 @@ const GoogleAuthForm = ({
     return { ...values, [ENABLED_KEY]: true };
   }, [settingValues]);
 
-  const { url: docsUrl } = useDocsUrl(
-    "people-and-groups/google-and-ldap",
-    "enabling-google-sign-in",
-  );
+  const { url: docsUrl } = useDocsUrl("people-and-groups/google-and-ldap", {
+    anchor: "enabling-google-sign-in",
+  });
 
   return (
     <FormProvider

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings.tsx
@@ -1,17 +1,17 @@
 import { match } from "ts-pattern";
 import { jt, t } from "ttag";
 
-import { useDocsUrl, useMergeSetting, useSetting } from "metabase/common/hooks";
-import { getPlan } from "metabase/common/utils/plan";
+import {
+  useDocsUrl,
+  useMergeSetting,
+  useSetting,
+  useUrlWithUtm,
+} from "metabase/common/hooks";
 import Breadcrumbs from "metabase/components/Breadcrumbs";
 import ExternalLink from "metabase/core/components/ExternalLink";
 import { useSelector } from "metabase/lib/redux";
 import { PLUGIN_EMBEDDING_SDK } from "metabase/plugins";
-import {
-  getLearnUrl,
-  getSetting,
-  getUpgradeUrl,
-} from "metabase/selectors/settings";
+import { getLearnUrl, getUpgradeUrl } from "metabase/selectors/settings";
 import { Alert, Box, Button, Icon, Stack, Text } from "metabase/ui";
 
 import SettingHeader from "../SettingHeader";
@@ -21,25 +21,21 @@ import { SettingTextInput } from "../widgets/SettingTextInput";
 
 import type { AdminSettingComponentProps } from "./types";
 
+function useAddUtmToLink(url: string) {
+  return useUrlWithUtm(url, {
+    utm_source: "product",
+    utm_medium: "docs",
+    utm_campaign: "embedding-sdk",
+    utm_content: "embedding-sdk-admin",
+  });
+}
+
 export function EmbeddingSdkSettings({
   updateSetting,
 }: AdminSettingComponentProps) {
   const isEE = PLUGIN_EMBEDDING_SDK.isEnabled();
   const isEmbeddingSdkEnabled = useSetting("enable-embedding-sdk");
   const canEditSdkOrigins = isEE && isEmbeddingSdkEnabled;
-
-  const plan = useSelector(state =>
-    getPlan(getSetting(state, "token-features")),
-  );
-
-  const addUtmToLink = (url: string) =>
-    `${url}?${new URLSearchParams({
-      utm_source: "product",
-      utm_medium: "docs",
-      utm_campaign: "embedding-sdk",
-      utm_content: "embedding-sdk-admin",
-      source_plan: plan,
-    })}`;
 
   const isHosted = useSetting("is-hosted?");
 
@@ -82,14 +78,14 @@ export function EmbeddingSdkSettings({
     "paid-features/activating-the-enterprise-edition",
   );
 
-  const switchMetabaseBinariesUrl = addUtmToLink(activationUrl);
+  const switchMetabaseBinariesUrl = useAddUtmToLink(activationUrl);
 
-  const implementJwtUrl = addUtmToLink(
+  const implementJwtUrl = useAddUtmToLink(
     getLearnUrl("metabase-basics/embedding/securing-embeds"),
   );
 
-  const quickStartUrl = addUtmToLink("https://metaba.se/sdk-quick-start");
-  const documentationUrl = addUtmToLink("https://metaba.se/sdk-docs");
+  const quickStartUrl = useAddUtmToLink("https://metaba.se/sdk-quick-start");
+  const documentationUrl = useAddUtmToLink("https://metaba.se/sdk-docs");
 
   const apiKeyBannerText = match({
     isOSS: !isEE && !isHosted,

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings.tsx
@@ -74,8 +74,7 @@ export function EmbeddingSdkSettings({
 
   const { url: switchMetabaseBinariesUrl } = useDocsUrl(
     "paid-features/activating-the-enterprise-edition",
-    undefined,
-    utmTags,
+    { utm: utmTags },
   );
 
   const implementJwtUrl = useUrlWithUtm(

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings.tsx
@@ -21,14 +21,12 @@ import { SettingTextInput } from "../widgets/SettingTextInput";
 
 import type { AdminSettingComponentProps } from "./types";
 
-function useAddUtmToLink(url: string) {
-  return useUrlWithUtm(url, {
-    utm_source: "product",
-    utm_medium: "docs",
-    utm_campaign: "embedding-sdk",
-    utm_content: "embedding-sdk-admin",
-  });
-}
+const utmTags = {
+  utm_source: "product",
+  utm_medium: "docs",
+  utm_campaign: "embedding-sdk",
+  utm_content: "embedding-sdk-admin",
+};
 
 export function EmbeddingSdkSettings({
   updateSetting,
@@ -74,18 +72,22 @@ export function EmbeddingSdkSettings({
     updateSetting({ key: "enable-embedding-sdk" }, value);
   }
 
-  const { url: activationUrl } = useDocsUrl(
+  const { url: switchMetabaseBinariesUrl } = useDocsUrl(
     "paid-features/activating-the-enterprise-edition",
+    undefined,
+    utmTags,
   );
 
-  const switchMetabaseBinariesUrl = useAddUtmToLink(activationUrl);
-
-  const implementJwtUrl = useAddUtmToLink(
+  const implementJwtUrl = useUrlWithUtm(
     getLearnUrl("metabase-basics/embedding/securing-embeds"),
+    utmTags,
   );
 
-  const quickStartUrl = useAddUtmToLink("https://metaba.se/sdk-quick-start");
-  const documentationUrl = useAddUtmToLink("https://metaba.se/sdk-docs");
+  const quickStartUrl = useUrlWithUtm(
+    "https://metaba.se/sdk-quick-start",
+    utmTags,
+  );
+  const documentationUrl = useUrlWithUtm("https://metaba.se/sdk-docs", utmTags);
 
   const apiKeyBannerText = match({
     isOSS: !isEE && !isHosted,

--- a/frontend/src/metabase/admin/upsells/components/use-upsell-link.ts
+++ b/frontend/src/metabase/admin/upsells/components/use-upsell-link.ts
@@ -1,5 +1,4 @@
-import { useSetting } from "metabase/common/hooks";
-import { getPlan } from "metabase/common/utils/plan";
+import { useUrlWithUtm } from "metabase/common/hooks";
 
 interface UpsellLinkProps {
   /* The URL we're sending them to */
@@ -14,14 +13,10 @@ interface UpsellLinkProps {
  * We need to add extra anonymous information to upsell links to know where the user came from
  */
 export const useUpsellLink = ({ url, campaign, source }: UpsellLinkProps) => {
-  const plan = getPlan(useSetting("token-features"));
-
-  const queryString = new URLSearchParams({
+  return useUrlWithUtm(url, {
     utm_source: "product",
     utm_medium: "upsell",
     utm_campaign: campaign,
     utm_content: source,
-    source_plan: plan,
-  }).toString();
-  return `${url}?${queryString}`;
+  });
 };

--- a/frontend/src/metabase/admin/upsells/components/use-upsell-link.unit.spec.tsx
+++ b/frontend/src/metabase/admin/upsells/components/use-upsell-link.unit.spec.tsx
@@ -53,7 +53,7 @@ const setup = ({
 describe("Upsells > useUpsellLink", () => {
   it("should return a URL with the correct query parameters", () => {
     const props = {
-      url: "https://www.metabase.com",
+      url: "https://www.metabase.com/",
       campaign: "test-campaign",
       source: "test-source",
     };

--- a/frontend/src/metabase/common/hooks/index.ts
+++ b/frontend/src/metabase/common/hooks/index.ts
@@ -4,3 +4,4 @@ export * from "./use-docs-url";
 export * from "./use-locale";
 export * from "./use-notification-channels";
 export * from "./use-has-token-feature";
+export * from "./use-url-with-utm";

--- a/frontend/src/metabase/common/hooks/use-docs-url/use-docs-url.ts
+++ b/frontend/src/metabase/common/hooks/use-docs-url/use-docs-url.ts
@@ -1,10 +1,27 @@
 import { useSelector } from "metabase/lib/redux";
-import { getDocsUrl } from "metabase/selectors/settings";
+import { type UtmProps, getDocsUrl } from "metabase/selectors/settings";
 import { getShowMetabaseLinks } from "metabase/selectors/whitelabel";
 
-export const useDocsUrl = (page: string, anchor?: string) => {
+type DocsUtmProps = Omit<UtmProps, "utm_medium"> & {
+  utm_medium?: UtmProps["utm_medium"];
+};
+
+export const useDocsUrl = (
+  page: string,
+  anchor?: string,
+  utm?: DocsUtmProps,
+) => {
   const showMetabaseLinks = useSelector(getShowMetabaseLinks);
-  const url = useSelector(state => getDocsUrl(state, { page, anchor }));
+  const url = useSelector(state =>
+    getDocsUrl(state, {
+      page,
+      anchor,
+      utm: utm && {
+        ...utm,
+        utm_medium: utm.utm_medium ?? "docs",
+      },
+    }),
+  );
 
   return { url, showMetabaseLinks };
 };

--- a/frontend/src/metabase/common/hooks/use-docs-url/use-docs-url.ts
+++ b/frontend/src/metabase/common/hooks/use-docs-url/use-docs-url.ts
@@ -8,8 +8,13 @@ type DocsUtmProps = Omit<UtmProps, "utm_medium"> & {
 
 export const useDocsUrl = (
   page: string,
-  anchor?: string,
-  utm?: DocsUtmProps,
+  {
+    anchor,
+    utm,
+  }: {
+    anchor?: string;
+    utm?: DocsUtmProps;
+  } = {},
 ) => {
   const showMetabaseLinks = useSelector(getShowMetabaseLinks);
   const url = useSelector(state =>

--- a/frontend/src/metabase/common/hooks/use-url-with-utm/index.ts
+++ b/frontend/src/metabase/common/hooks/use-url-with-utm/index.ts
@@ -1,0 +1,1 @@
+export { useUrlWithUtm } from "./use-url-with-utm";

--- a/frontend/src/metabase/common/hooks/use-url-with-utm/use-url-with-utm.ts
+++ b/frontend/src/metabase/common/hooks/use-url-with-utm/use-url-with-utm.ts
@@ -1,0 +1,6 @@
+import { useSelector } from "metabase/lib/redux";
+import { type UtmProps, getUrlWithUtm } from "metabase/selectors/settings";
+
+export function useUrlWithUtm(url: string, utm: UtmProps) {
+  return useSelector(state => getUrlWithUtm(state, { url, ...utm }));
+}

--- a/frontend/src/metabase/databases/components/DatabaseSslKeyDescription/DatabaseSslKeyDescription.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseSslKeyDescription/DatabaseSslKeyDescription.tsx
@@ -10,10 +10,9 @@ const DatabaseSslKeyDescription = (): JSX.Element | null => {
   const { engine } = values;
 
   // eslint-disable-next-line no-unconditional-metabase-links-render -- Admin settings
-  const { url: docsUrl } = useDocsUrl(
-    "databases/connections/postgresql",
-    "authenticate-client-certificate",
-  );
+  const { url: docsUrl } = useDocsUrl("databases/connections/postgresql", {
+    anchor: "authenticate-client-certificate",
+  });
 
   if (engine !== "postgres") {
     return null;

--- a/frontend/src/metabase/public/components/EmbedModal/EmbedModalContent/EmbedModalContent.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/EmbedModalContent/EmbedModalContent.unit.spec.tsx
@@ -48,7 +48,7 @@ describe("EmbedModalContent", () => {
         screen.getByRole("link", { name: /Embedded analytics SDK/ }),
       ).toHaveAttribute(
         "href",
-        "https://metaba.se/sdk?utm_source=product&source_plan=oss&utm_content=embed-modal",
+        "https://metaba.se/sdk?utm_source=product&utm_content=embed-modal&source_plan=oss",
       );
     });
   });

--- a/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SelectEmbedTypePane.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SelectEmbedTypePane.tsx
@@ -2,7 +2,7 @@ import cx from "classnames";
 import { useState } from "react";
 import { t } from "ttag";
 
-import { getPlan } from "metabase/common/utils/plan";
+import { useUrlWithUtm } from "metabase/common/hooks";
 import Link from "metabase/core/components/Link";
 import CS from "metabase/css/core/index.css";
 import { Badge } from "metabase/home/components/EmbedHomepage/Badge";
@@ -45,11 +45,16 @@ export function SelectEmbedTypePane({
 
   const interactiveEmbeddingCta = useInteractiveEmbeddingCta();
 
-  const plan = useSelector(state =>
-    getPlan(getSetting(state, "token-features")),
-  );
+  const utmTags = {
+    utm_content: "embed-modal",
+  };
 
-  const utmTags = `?utm_source=product&source_plan=${plan}&utm_content=embed-modal`;
+  const sdkUrl = useUrlWithUtm("https://metaba.se/sdk", utmTags);
+  const embeddingUrl = useUrlWithUtm(
+    // eslint-disable-next-line no-unconditional-metabase-links-render -- only visible to admins
+    "https://www.metabase.com/docs/latest/embedding/introduction#comparison-of-embedding-types",
+    utmTags,
+  );
 
   const isPublicSharingEnabled = useSelector(state =>
     getSetting(state, "enable-public-sharing"),
@@ -128,7 +133,7 @@ export function SelectEmbedTypePane({
 
         {/* REACT SDK */}
         <a
-          href={"https://metaba.se/sdk" + utmTags}
+          href={sdkUrl}
           style={{ height: "100%" }}
           target="_blank"
           rel="noreferrer"
@@ -174,11 +179,7 @@ export function SelectEmbedTypePane({
         <a
           className={cx(CS.link, CS.textBold)}
           style={{ display: "flex", alignItems: "center", gap: 4 }}
-          href={
-            // eslint-disable-next-line no-unconditional-metabase-links-render -- only visible to admins
-            "https://www.metabase.com/docs/latest/embedding/introduction#comparison-of-embedding-types" +
-            utmTags
-          }
+          href={embeddingUrl}
         >
           {t`Compare options`} <Icon name="share" />
         </a>
@@ -191,8 +192,15 @@ export const useInteractiveEmbeddingCta = () => {
   const isInteractiveEmbeddingEnabled = useSelector(
     PLUGIN_EMBEDDING.isInteractiveEmbeddingEnabled,
   );
-  const plan = useSelector(state =>
-    getPlan(getSetting(state, "token-features")),
+
+  const url = useUrlWithUtm(
+    `https://www.metabase.com/product/embedded-analytics`,
+    {
+      utm_source: "product",
+      utm_medium: "upsell",
+      utm_campaign: "embedding-interactive",
+      utm_content: "static-embed-popover",
+    },
   );
 
   if (isInteractiveEmbeddingEnabled) {
@@ -202,15 +210,7 @@ export const useInteractiveEmbeddingCta = () => {
   }
 
   return {
-    url: `https://www.metabase.com/product/embedded-analytics?${new URLSearchParams(
-      {
-        utm_source: "product",
-        utm_medium: "upsell",
-        utm_campaign: "embedding-interactive",
-        utm_content: "static-embed-popover",
-        source_plan: plan,
-      },
-    )}`,
+    url,
     target: "_blank",
   };
 };

--- a/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SelectEmbedTypePane.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SelectEmbedTypePane.tsx
@@ -2,7 +2,7 @@ import cx from "classnames";
 import { useState } from "react";
 import { t } from "ttag";
 
-import { useUrlWithUtm } from "metabase/common/hooks";
+import { useDocsUrl, useUrlWithUtm } from "metabase/common/hooks";
 import Link from "metabase/core/components/Link";
 import CS from "metabase/css/core/index.css";
 import { Badge } from "metabase/home/components/EmbedHomepage/Badge";
@@ -50,9 +50,11 @@ export function SelectEmbedTypePane({
   };
 
   const sdkUrl = useUrlWithUtm("https://metaba.se/sdk", utmTags);
-  const embeddingUrl = useUrlWithUtm(
-    // eslint-disable-next-line no-unconditional-metabase-links-render -- only visible to admins
-    "https://www.metabase.com/docs/latest/embedding/introduction#comparison-of-embedding-types",
+
+  // eslint-disable-next-line no-unconditional-metabase-links-render -- only visible to admins
+  const { url: embeddingUrl } = useDocsUrl(
+    "embedding/introduction",
+    "comparison-of-embedding-types",
     utmTags,
   );
 

--- a/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SelectEmbedTypePane.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SelectEmbedTypePane.tsx
@@ -52,11 +52,10 @@ export function SelectEmbedTypePane({
   const sdkUrl = useUrlWithUtm("https://metaba.se/sdk", utmTags);
 
   // eslint-disable-next-line no-unconditional-metabase-links-render -- only visible to admins
-  const { url: embeddingUrl } = useDocsUrl(
-    "embedding/introduction",
-    "comparison-of-embedding-types",
-    utmTags,
-  );
+  const { url: embeddingUrl } = useDocsUrl("embedding/introduction", {
+    anchor: "comparison-of-embedding-types",
+    utm: utmTags,
+  });
 
   const isPublicSharingEnabled = useSelector(state =>
     getSetting(state, "enable-public-sharing"),

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/LookAndFeelSettings.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/LookAndFeelSettings.tsx
@@ -2,7 +2,7 @@ import { match } from "ts-pattern";
 import { jt, t } from "ttag";
 
 import { UpsellMetabaseBanner } from "metabase/admin/upsells/UpsellMetabaseBanner";
-import { getPlan } from "metabase/common/utils/plan";
+import { useDocsUrl } from "metabase/common/hooks";
 import ExternalLink from "metabase/core/components/ExternalLink";
 import { color } from "metabase/lib/colors";
 import { useSelector } from "metabase/lib/redux";
@@ -10,11 +10,7 @@ import type {
   EmbedResourceType,
   EmbeddingDisplayOptions,
 } from "metabase/public/lib/types";
-import {
-  getDocsUrl,
-  getSetting,
-  getUpgradeUrl,
-} from "metabase/selectors/settings";
+import { getSetting, getUpgradeUrl } from "metabase/selectors/settings";
 import { getCanWhitelabel } from "metabase/selectors/whitelabel";
 import {
   Divider,
@@ -45,20 +41,22 @@ export const LookAndFeelSettings = ({
   displayOptions,
   onChangeDisplayOptions,
 }: AppearanceSettingsProps): JSX.Element => {
-  const docsUrl = useSelector(state =>
-    // eslint-disable-next-line no-unconditional-metabase-links-render -- Only appear to admins
-    getDocsUrl(state, {
-      page: "embedding/static-embedding",
-    }),
+  // eslint-disable-next-line no-unconditional-metabase-links-render -- Only appear to admins
+  const { url: docsUrl } = useDocsUrl(
+    "embedding/static-embedding",
+    "customizing-the-appearance-of-static-embeds",
+    {
+      utm_source: "product",
+      utm_medium: "docs",
+      utm_campaign: "embedding-static",
+      utm_content: "static-embed-settings-look-and-feel",
+    },
   );
   const upgradePageUrl = useSelector(state =>
     getUpgradeUrl(state, {
       utm_campaign: "embedding-static-font",
       utm_content: "static-embed-settings-look-and-feel",
     }),
-  );
-  const plan = useSelector(state =>
-    getPlan(getSetting(state, "token-features")),
   );
   const canWhitelabel = useSelector(getCanWhitelabel);
   const availableFonts = useSelector(state =>
@@ -74,13 +72,7 @@ export const LookAndFeelSettings = ({
           <Text>{jt`These options require changing the server code. You can play around with and preview the options here. Check out the ${(
             <ExternalLink
               key="doc"
-              href={`${docsUrl}?${new URLSearchParams({
-                utm_source: "product",
-                utm_medium: "docs",
-                utm_campaign: "embedding-static",
-                utm_content: "static-embed-settings-look-and-feel",
-                source_plan: plan,
-              })}#customizing-the-appearance-of-static-embeds`}
+              href={docsUrl}
             >{t`documentation`}</ExternalLink>
           )} for more.`}</Text>
 

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/LookAndFeelSettings.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/LookAndFeelSettings.tsx
@@ -42,16 +42,15 @@ export const LookAndFeelSettings = ({
   onChangeDisplayOptions,
 }: AppearanceSettingsProps): JSX.Element => {
   // eslint-disable-next-line no-unconditional-metabase-links-render -- Only appear to admins
-  const { url: docsUrl } = useDocsUrl(
-    "embedding/static-embedding",
-    "customizing-the-appearance-of-static-embeds",
-    {
+  const { url: docsUrl } = useDocsUrl("embedding/static-embedding", {
+    anchor: "customizing-the-appearance-of-static-embeds",
+    utm: {
       utm_source: "product",
       utm_medium: "docs",
       utm_campaign: "embedding-static",
       utm_content: "static-embed-settings-look-and-feel",
     },
-  );
+  });
   const upgradePageUrl = useSelector(state =>
     getUpgradeUrl(state, {
       utm_campaign: "embedding-static-font",

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/OverviewSettings.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/OverviewSettings.tsx
@@ -3,16 +3,14 @@ import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
 import { jt, t } from "ttag";
 
-import { getPlan } from "metabase/common/utils/plan";
+import { useDocsUrl } from "metabase/common/hooks";
 import ExternalLink from "metabase/core/components/ExternalLink";
 import CS from "metabase/css/core/index.css";
-import { useSelector } from "metabase/lib/redux";
 import { getEmbedClientCodeExampleOptions } from "metabase/public/lib/code";
 import type {
   EmbedResourceType,
   ServerCodeSampleConfig,
 } from "metabase/public/lib/types";
-import { getDocsUrl, getSetting } from "metabase/selectors/settings";
 import { Box, Center, Stack, Text } from "metabase/ui";
 
 import { ClientEmbedCodePane } from "./ClientEmbedCodePane";
@@ -34,17 +32,17 @@ export const OverviewSettings = ({
   selectedServerCodeOption,
   onClientCodeCopy,
 }: OverviewSettingsProps): JSX.Element => {
-  const docsUrl = useSelector(state =>
-    // eslint-disable-next-line no-unconditional-metabase-links-render -- Only appear to admins
-    getDocsUrl(state, { page: "embedding/static-embedding" }),
-  );
-  const plan = useSelector(state =>
-    getPlan(getSetting(state, "token-features")),
-  );
-
   const [selectedClientCodeOptionId, setSelectedClientCodeOptionId] = useState(
     clientCodeOptions[0].id,
   );
+
+  // eslint-disable-next-line no-unconditional-metabase-links-render -- This links only shows for admins.
+  const { url: docsUrl } = useDocsUrl("embedding/static-embedding", undefined, {
+    utm_source: "product",
+    utm_medium: "docs",
+    utm_campaign: "embedding-static",
+    utm_content: "static-embed-settings-overview",
+  });
 
   useEffect(() => {
     if (selectedServerCodeOption) {
@@ -76,13 +74,7 @@ export const OverviewSettings = ({
           <Text>{jt`Check out the ${(
             <ExternalLink
               key="doc"
-              href={`${docsUrl}?${new URLSearchParams({
-                utm_source: "product",
-                utm_medium: "docs",
-                utm_campaign: "embedding-static",
-                utm_content: "static-embed-settings-overview",
-                source_plan: plan,
-              })}`}
+              href={docsUrl}
             >{t`documentation`}</ExternalLink>
           )} for more.`}</Text>
         </StaticEmbedSetupPaneSettingsContentSection>

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/OverviewSettings.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/OverviewSettings.tsx
@@ -37,11 +37,13 @@ export const OverviewSettings = ({
   );
 
   // eslint-disable-next-line no-unconditional-metabase-links-render -- This links only shows for admins.
-  const { url: docsUrl } = useDocsUrl("embedding/static-embedding", undefined, {
-    utm_source: "product",
-    utm_medium: "docs",
-    utm_campaign: "embedding-static",
-    utm_content: "static-embed-settings-overview",
+  const { url: docsUrl } = useDocsUrl("embedding/static-embedding", {
+    utm: {
+      utm_source: "product",
+      utm_medium: "docs",
+      utm_campaign: "embedding-static",
+      utm_content: "static-embed-settings-overview",
+    },
   });
 
   useEffect(() => {

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.unit.spec.tsx
@@ -37,7 +37,7 @@ describe("ExpressionWidget", () => {
 
     expect(link).toHaveAttribute(
       "href",
-      "https://www.metabase.com/docs/latest/questions/query-builder/expressions.html",
+      "https://www.metabase.com/docs/latest/questions/query-builder/expressions.html?utm_source=product&utm_medium=docs&utm_campaign=custom-expressions&source_plan=oss",
     );
 
     await userEvent.hover(link);

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidgetInfo/ExpressionWidgetInfo.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidgetInfo/ExpressionWidgetInfo.tsx
@@ -12,6 +12,10 @@ import {
 export function ExpressionWidgetInfo() {
   const { url: docsUrl, showMetabaseLinks } = useDocsUrl(
     "questions/query-builder/expressions",
+    undefined,
+    {
+      utm_campaign: "custom-expressions",
+    },
   );
 
   return showMetabaseLinks ? (

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidgetInfo/ExpressionWidgetInfo.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidgetInfo/ExpressionWidgetInfo.tsx
@@ -12,9 +12,10 @@ import {
 export function ExpressionWidgetInfo() {
   const { url: docsUrl, showMetabaseLinks } = useDocsUrl(
     "questions/query-builder/expressions",
-    undefined,
     {
-      utm_campaign: "custom-expressions",
+      utm: {
+        utm_campaign: "custom-expressions",
+      },
     },
   );
 

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidgetInfo/tests/common.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidgetInfo/tests/common.unit.spec.ts
@@ -12,7 +12,7 @@ describe("ExpressionWidgetInfo (OSS)", () => {
       screen.getByRole("link", { name: "Open expressions documentation" }),
     ).toHaveProperty(
       "href",
-      "https://www.metabase.com/docs/latest/questions/query-builder/expressions.html",
+      "https://www.metabase.com/docs/latest/questions/query-builder/expressions.html?utm_source=product&utm_medium=docs&utm_campaign=custom-expressions&source_plan=oss",
     );
     await userEvent.hover(screen.getByLabelText("info icon"));
     expect(
@@ -29,7 +29,7 @@ describe("ExpressionWidgetInfo (OSS)", () => {
       screen.getByRole("link", { name: "Open expressions documentation" }),
     ).toHaveProperty(
       "href",
-      "https://www.metabase.com/docs/latest/questions/query-builder/expressions.html",
+      "https://www.metabase.com/docs/latest/questions/query-builder/expressions.html?utm_source=product&utm_medium=docs&utm_campaign=custom-expressions&source_plan=oss",
     );
     await userEvent.hover(screen.getByLabelText("info icon"));
     expect(

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidgetInfo/tests/enterprise.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidgetInfo/tests/enterprise.unit.spec.ts
@@ -17,7 +17,7 @@ describe("ExpressionWidgetInfo (EE without token)", () => {
       screen.getByRole("link", { name: "Open expressions documentation" }),
     ).toHaveProperty(
       "href",
-      "https://www.metabase.com/docs/latest/questions/query-builder/expressions.html",
+      "https://www.metabase.com/docs/latest/questions/query-builder/expressions.html?utm_source=product&utm_medium=docs&utm_campaign=custom-expressions&source_plan=oss",
     );
     await userEvent.hover(screen.getByLabelText("info icon"));
     expect(
@@ -34,7 +34,7 @@ describe("ExpressionWidgetInfo (EE without token)", () => {
       screen.getByRole("link", { name: "Open expressions documentation" }),
     ).toHaveProperty(
       "href",
-      "https://www.metabase.com/docs/latest/questions/query-builder/expressions.html",
+      "https://www.metabase.com/docs/latest/questions/query-builder/expressions.html?utm_source=product&utm_medium=docs&utm_campaign=custom-expressions&source_plan=oss",
     );
     await userEvent.hover(screen.getByLabelText("info icon"));
     expect(

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidgetInfo/tests/premium.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidgetInfo/tests/premium.unit.spec.ts
@@ -21,7 +21,7 @@ describe("ExpressionWidgetInfo (EE with token)", () => {
       screen.getByRole("link", { name: "Open expressions documentation" }),
     ).toHaveProperty(
       "href",
-      "https://www.metabase.com/docs/latest/questions/query-builder/expressions.html",
+      "https://www.metabase.com/docs/latest/questions/query-builder/expressions.html?utm_source=product&utm_medium=docs&utm_campaign=custom-expressions&source_plan=pro-self-hosted",
     );
     await userEvent.hover(screen.getByLabelText("info icon"));
     expect(

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/FilterWidgetTypeSelect.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/FilterWidgetTypeSelect.tsx
@@ -41,7 +41,7 @@ export function FilterWidgetTypeSelect({
   // eslint-disable-next-line no-unconditional-metabase-links-render -- It's hard to tell if this is still used in the app. Please see https://metaboat.slack.com/archives/C505ZNNH4/p1703243785315819
   const { url: docsUrl } = useDocsUrl(
     "questions/native-editor/sql-parameters",
-    "the-field-filter-variable-type",
+    { anchor: "the-field-filter-variable-type" },
   );
 
   return (

--- a/frontend/src/metabase/selectors/settings.ts
+++ b/frontend/src/metabase/selectors/settings.ts
@@ -45,6 +45,39 @@ export const getLearnUrl = (path = "") => {
   return `https://www.metabase.com/learn/${path}`;
 };
 
+type UtmProps = {
+  utm_source?: string;
+  utm_medium: string;
+  utm_campaign: string;
+  utm_content?: string;
+};
+
+type UrlWithUtmProps = { url: string } & UtmProps;
+
+export const getUrlWithUtm = createSelector(
+  (state: State, props: UrlWithUtmProps) => props,
+  (state: State) => getPlan(getSetting(state, "token-features")),
+  (props: UrlWithUtmProps, plan: string) => {
+    const {
+      utm_source = "product",
+      utm_medium,
+      utm_campaign,
+      utm_content,
+    } = props;
+
+    const url = new URL(props.url);
+    url.searchParams.set("utm_source", utm_source);
+    url.searchParams.set("utm_medium", utm_medium);
+    url.searchParams.set("utm_campaign", utm_campaign);
+    if (utm_content) {
+      url.searchParams.set("utm_content", utm_content);
+    }
+    url.searchParams.set("source_plan", plan);
+
+    return url.toString();
+  },
+);
+
 interface DocsUrlProps {
   page?: string;
   anchor?: string;

--- a/frontend/src/metabase/selectors/settings.ts
+++ b/frontend/src/metabase/selectors/settings.ts
@@ -84,23 +84,24 @@ interface DocsUrlProps {
   utm?: UtmProps;
 }
 
-export const getDocsUrl = createSelector(
-  (state: State, props: DocsUrlProps) => props,
-  (state: State) => getSetting(state, "version"),
-  (state: State, props: DocsUrlProps, version: Version | undefined) =>
-    getDocsUrlForVersion(state, version, props.page, props.anchor, props.utm),
-  (props, version, url) => url,
-);
+export const getDocsUrl = (state: State, props: DocsUrlProps) => {
+  const version = getSetting(state, "version");
+  const url = getDocsUrlForVersion(version, props.page, props.anchor);
+
+  if (!props.utm) {
+    return url;
+  }
+
+  return getUrlWithUtm(state, { url, ...props.utm });
+};
 
 export const getDocsSearchUrl = (query: Record<string, string>) =>
   `https://www.metabase.com/search?${new URLSearchParams(query)}`;
 
 const getDocsUrlForVersion = (
-  state: State,
   version: Version | undefined,
   page = "",
   anchor = "",
-  utm?: UtmProps,
 ) => {
   let tag = version?.tag;
   const matches = tag && tag.match(/v[01]\.(\d+)(?:\.\d+)?(-.*)?/);
@@ -131,13 +132,7 @@ const getDocsUrlForVersion = (
   }
 
   // eslint-disable-next-line no-unconditional-metabase-links-render -- This function is only used by this file and "metabase/lib/settings"
-  const url = `https://www.metabase.com/docs/${tag}/${page}${anchor}`;
-
-  if (!utm) {
-    return url;
-  }
-
-  return getUrlWithUtm(state, { url, ...utm });
+  return `https://www.metabase.com/docs/${tag}/${page}${anchor}`;
 };
 
 interface UpgradeUrlOpts {

--- a/frontend/src/metabase/selectors/settings.ts
+++ b/frontend/src/metabase/selectors/settings.ts
@@ -67,8 +67,12 @@ export const getUrlWithUtm = createSelector(
 
     const url = new URL(props.url);
     url.searchParams.set("utm_source", utm_source);
-    url.searchParams.set("utm_medium", utm_medium);
-    url.searchParams.set("utm_campaign", utm_campaign);
+    if (utm_medium) {
+      url.searchParams.set("utm_medium", utm_medium);
+    }
+    if (utm_campaign) {
+      url.searchParams.set("utm_campaign", utm_campaign);
+    }
     if (utm_content) {
       url.searchParams.set("utm_content", utm_content);
     }

--- a/frontend/src/metabase/selectors/settings.ts
+++ b/frontend/src/metabase/selectors/settings.ts
@@ -47,8 +47,8 @@ export const getLearnUrl = (path = "") => {
 
 export type UtmProps = {
   utm_source?: string;
-  utm_medium: string;
-  utm_campaign: string;
+  utm_medium?: string;
+  utm_campaign?: string;
   utm_content?: string;
 };
 


### PR DESCRIPTION
### Description

Add utm parameters to docs link in expression editor.

Also adds helpers to add utm parameters to urls more easily.
