### PR TITLE
adding webhook counter to AlertListItem

### DIFF
--- a/e2e/test/scenarios/sharing/alert/alert.cy.spec.js
+++ b/e2e/test/scenarios/sharing/alert/alert.cy.spec.js
@@ -123,7 +123,7 @@ describe("scenarios > alert", () => {
 
       popover().within(() => {
         cy.findByText("You set up an alert").should("be.visible");
-        cy.findByRole("listitem", { name: "http channel count" })
+        cy.findByRole("listitem", { name: "Number of HTTP channels" })
           .should("contain.text", "2")
           .findByRole("img", { name: /webhook/i })
           .should("exist");

--- a/e2e/test/scenarios/sharing/alert/alert.cy.spec.js
+++ b/e2e/test/scenarios/sharing/alert/alert.cy.spec.js
@@ -123,6 +123,10 @@ describe("scenarios > alert", () => {
 
       popover().within(() => {
         cy.findByText("You set up an alert").should("be.visible");
+        cy.findByRole("listitem", { name: "http channel count" })
+          .should("contain.text", "2")
+          .findByRole("img", { name: /webhook/i })
+          .should("exist");
         cy.findByText("Edit").click();
       });
 

--- a/frontend/src/metabase/query_builder/components/AlertListPopoverContent/AlertListItem.tsx
+++ b/frontend/src/metabase/query_builder/components/AlertListPopoverContent/AlertListItem.tsx
@@ -50,6 +50,7 @@ export const AlertListItem = ({
   const emailEnabled = emailChannel && emailChannel.enabled;
   const slackChannel = alert.channels.find(c => c.channel_type === "slack");
   const slackEnabled = slackChannel && slackChannel.enabled;
+  const httpChannels = alert.channels.filter(c => c.channel_type === "http");
 
   return (
     <li
@@ -91,17 +92,29 @@ export const AlertListItem = ({
             />
           </li>
           {isAdmin && emailEnabled && emailChannel.recipients && (
-            <li className={cx(CS.ml3, CS.flex, CS.alignCenter)}>
+            <li
+              className={cx(CS.ml3, CS.flex, CS.alignCenter)}
+              aria-label="email recipient count"
+            >
               <Icon name="mail" className={CS.mr1} />
               {emailChannel.recipients.length}
             </li>
           )}
           {isAdmin && slackEnabled && (
-            <li className={cx(CS.ml3, CS.flex, CS.alignCenter)}>
-              <Icon name="slack" size={16} className={CS.mr1} />
-              {(slackChannel.details &&
-                slackChannel.details.channel.replace("#", "")) ||
-                t`No channel`}
+            <li
+              className={cx(CS.ml3, CS.flex, CS.alignCenter)}
+              aria-label="slack channel count"
+            >
+              <Icon name="slack" size={16} className={CS.mr1} />1
+            </li>
+          )}
+          {isAdmin && httpChannels.length > 0 && (
+            <li
+              className={cx(CS.ml3, CS.flex, CS.alignCenter)}
+              aria-label="http channel count"
+            >
+              <Icon name="webhook" size={16} className={CS.mr1} />
+              {httpChannels.length}
             </li>
           )}
         </ul>

--- a/frontend/src/metabase/query_builder/components/AlertListPopoverContent/AlertListItem.tsx
+++ b/frontend/src/metabase/query_builder/components/AlertListPopoverContent/AlertListItem.tsx
@@ -19,6 +19,11 @@ type AlertListItemProps = {
   onEdit: () => void;
 };
 
+// Used when a slack channel is present on an alert. This value is hardcoded
+// to 1 because each alert can only be sent to a single slack channel. Additional channels
+// would require their own alert.
+const SLACK_CHANNEL_COUNT = 1;
+
 export const AlertListItem = ({
   alert,
   highlight,
@@ -94,7 +99,7 @@ export const AlertListItem = ({
           {isAdmin && emailEnabled && emailChannel.recipients && (
             <li
               className={cx(CS.ml3, CS.flex, CS.alignCenter)}
-              aria-label="email recipient count"
+              aria-label={t`Number of email recipients`}
             >
               <Icon name="mail" className={CS.mr1} />
               {emailChannel.recipients.length}
@@ -103,15 +108,16 @@ export const AlertListItem = ({
           {isAdmin && slackEnabled && (
             <li
               className={cx(CS.ml3, CS.flex, CS.alignCenter)}
-              aria-label="slack channel count"
+              aria-label={t`Number of Slack channels`}
             >
-              <Icon name="slack" size={16} className={CS.mr1} />1
+              <Icon name="slack" size={16} className={CS.mr1} />
+              {SLACK_CHANNEL_COUNT}
             </li>
           )}
           {isAdmin && httpChannels.length > 0 && (
             <li
               className={cx(CS.ml3, CS.flex, CS.alignCenter)}
-              aria-label="http channel count"
+              aria-label={t`Number of HTTP channels`}
             >
               <Icon name="webhook" size={16} className={CS.mr1} />
               {httpChannels.length}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/48803

### Description
Small update to `AlertListItem` to include a counter of HTTP channels on an alert

### How to verify

1. Go to any question and set up an alert with an active HTTP Channel
2. Click save, then go to the sharing menu and select Edit Alerts
3. You should see your alert listed with a number beside a webhook icon

### Demo
![image](https://github.com/user-attachments/assets/d9c3de2b-ab14-4245-944e-e76172abac32)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
