### PR TITLE
filter out virtual cards when creating a subscription

### DIFF
--- a/frontend/src/metabase/sharing/components/SharingSidebar/SharingSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar/SharingSidebar.jsx
@@ -29,6 +29,7 @@ import {
 } from "metabase/sharing/components/AddEditSidebar/AddEditSidebar";
 import { NewPulseSidebar } from "metabase/sharing/components/NewPulseSidebar";
 import PulsesListSidebar from "metabase/sharing/components/PulsesListSidebar";
+import { isVirtualCardDisplayType } from "metabase-types/api/visualization";
 
 export const CHANNEL_ICONS = {
   email: "mail",
@@ -66,9 +67,9 @@ const cardsFromDashboard = dashboard => {
   }));
 };
 
-const getSupportedCardsForSubscriptions = dashboard => {
+export const getSupportedCardsForSubscriptions = dashboard => {
   return cardsFromDashboard(dashboard).filter(
-    card => !["text", "heading", "action", "link"].includes(card.display),
+    card => !isVirtualCardDisplayType(card.display),
   );
 };
 

--- a/frontend/src/metabase/sharing/components/SharingSidebar/SharingSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar/SharingSidebar.unit.spec.tsx
@@ -1,0 +1,46 @@
+import {
+  createMockCard,
+  createMockDashboard,
+  createMockDashboardCard,
+} from "metabase-types/api/mocks";
+
+import { getSupportedCardsForSubscriptions } from "./SharingSidebar";
+
+describe("getSupportedCardsForSubscriptions", () => {
+  it("should return an empty array if dashboard is undefined", () => {
+    const result = getSupportedCardsForSubscriptions(undefined);
+    expect(result).toEqual([]);
+  });
+
+  it("should filter out virtual card display types", () => {
+    const dashboard = createMockDashboard({
+      dashcards: [
+        createMockDashboardCard({ card: createMockCard({ display: "table" }) }),
+        createMockDashboardCard({ card: createMockCard({ display: "pivot" }) }),
+        createMockDashboardCard({ card: createMockCard({ display: "bar" }) }),
+        createMockDashboardCard({
+          card: createMockCard({ display: "iframe" }),
+        }),
+        createMockDashboardCard({ card: createMockCard({ display: "text" }) }),
+        createMockDashboardCard({
+          card: createMockCard({ display: "heading" }),
+        }),
+        createMockDashboardCard({
+          card: createMockCard({ display: "action" }),
+        }),
+        createMockDashboardCard({ card: createMockCard({ display: "link" }) }),
+      ],
+    });
+
+    const result = getSupportedCardsForSubscriptions(dashboard);
+
+    expect(result).toHaveLength(3);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ display: "table" }),
+        expect.objectContaining({ display: "pivot" }),
+        expect.objectContaining({ display: "bar" }),
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
### Description

While working on [enabling pivot exports by default](https://github.com/metabase/metabase/pull/48859), I noticed that subscriptions are not getting created on dashboards that have placeholder or iframe cards. This is because the subscriptions component had a duplicated array of virtual card types which got outdated: https://github.com/metabase/metabase/pull/48861/files#diff-310e2261120875ae00968a33b4fe47a510fc77b707d93e6b0b559ecc74b33e5cL71 

### How to verify

- Create a dashboard with placeholder and iframe cards
- Try creating and saving a dashboard subscription
- It should work as expected

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
