### PR TITLE
Adds export description when unformatted option is selected

### DIFF
--- a/frontend/src/metabase/common/components/ExportSettingsWidget/ExportSettingsWidget.tsx
+++ b/frontend/src/metabase/common/components/ExportSettingsWidget/ExportSettingsWidget.tsx
@@ -53,10 +53,13 @@ export const ExportSettingsWidget = ({
               <Radio value="false" label={t`Unformatted`} />
             </Group>
           </Radio.Group>
-          <Text
-            size="sm"
-            color="text-medium"
-          >{t`E.g. September 6, 2024 or $187.50, like in ${applicationName}`}</Text>
+          {isFormattingEnabled && (
+            <Text
+              data-testid="formatting-description"
+              size="sm"
+              color="text-medium"
+            >{t`E.g. September 6, 2024 or $187.50, like in ${applicationName}`}</Text>
+          )}
         </Stack>
       ) : null}
       {canConfigurePivoting ? (

--- a/frontend/src/metabase/common/components/ExportSettingsWidget/ExportSettingsWidget.tsx
+++ b/frontend/src/metabase/common/components/ExportSettingsWidget/ExportSettingsWidget.tsx
@@ -53,13 +53,16 @@ export const ExportSettingsWidget = ({
               <Radio value="false" label={t`Unformatted`} />
             </Group>
           </Radio.Group>
-          {isFormattingEnabled && (
-            <Text
-              data-testid="formatting-description"
-              size="sm"
-              color="text-medium"
-            >{t`E.g. September 6, 2024 or $187.50, like in ${applicationName}`}</Text>
-          )}
+
+          <Text
+            data-testid="formatting-description"
+            size="sm"
+            color="text-medium"
+          >
+            {isFormattingEnabled
+              ? t`E.g. September 6, 2024 or $187.50, like in ${applicationName}`
+              : t`E.g. 2024-09-06 or 187.50, like in the database`}
+          </Text>
         </Stack>
       ) : null}
       {canConfigurePivoting ? (

--- a/frontend/src/metabase/query_builder/components/QueryDownloadPopover/QueryDownloadPopover.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryDownloadPopover/QueryDownloadPopover.unit.spec.tsx
@@ -97,9 +97,9 @@ describe("QueryDownloadPopover", () => {
 
       await userEvent.click(screen.getByLabelText(`.${format}`));
       await userEvent.click(screen.getByLabelText("Unformatted"));
-      expect(
-        screen.queryByTestId("formatting-description"),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByTestId("formatting-description")).toHaveTextContent(
+        `E.g. 2024-09-06 or 187.50, like in the database`,
+      );
       expect(
         screen.queryByLabelText("Keep data pivoted"),
       ).not.toBeInTheDocument();

--- a/frontend/src/metabase/query_builder/components/QueryDownloadPopover/QueryDownloadPopover.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryDownloadPopover/QueryDownloadPopover.unit.spec.tsx
@@ -96,7 +96,10 @@ describe("QueryDownloadPopover", () => {
       const { onDownload } = setup();
 
       await userEvent.click(screen.getByLabelText(`.${format}`));
-      await userEvent.click(screen.getByLabelText(`Unformatted`));
+      await userEvent.click(screen.getByLabelText("Unformatted"));
+      expect(
+        screen.queryByTestId("formatting-description"),
+      ).not.toBeInTheDocument();
       expect(
         screen.queryByLabelText("Keep data pivoted"),
       ).not.toBeInTheDocument();
@@ -107,6 +110,31 @@ describe("QueryDownloadPopover", () => {
       expect(onDownload).toHaveBeenCalledWith({
         type: format,
         enableFormatting: false,
+        enablePivot: false,
+      });
+    },
+  );
+
+  it.each(["csv", "json", "xlsx"])(
+    "should trigger formatted download for %s format",
+    async format => {
+      const { onDownload } = setup();
+
+      await userEvent.click(screen.getByLabelText(`.${format}`));
+      await userEvent.click(screen.getByLabelText("Formatted"));
+      expect(screen.queryByTestId("formatting-description")).toHaveTextContent(
+        `E.g. September 6, 2024 or $187.50, like in Metabase`,
+      );
+      expect(
+        screen.queryByLabelText("Keep data pivoted"),
+      ).not.toBeInTheDocument();
+      await userEvent.click(
+        await screen.findByTestId("download-results-button"),
+      );
+
+      expect(onDownload).toHaveBeenCalledWith({
+        type: format,
+        enableFormatting: true,
         enablePivot: false,
       });
     },


### PR DESCRIPTION
### Description

Adds export formatting description when unformatted option is selected.

### Demo

Before
<img width="288" alt="Screenshot 2024-10-17 at 9 53 16 PM" src="https://github.com/user-attachments/assets/43d7806e-2013-4652-a479-a8922d1c3ae5">

After
<img width="292" alt="Screenshot 2024-10-18 at 8 59 29 AM" src="https://github.com/user-attachments/assets/eceb8085-1512-41d5-b175-33ce86c6f9d2">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
