### PR TITLE
Popover timing tweaks

### DIFF
--- a/frontend/src/metabase/components/MetadataInfo/ColumnInfoIcon/ColumnInfoIcon.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/ColumnInfoIcon/ColumnInfoIcon.tsx
@@ -27,7 +27,6 @@ type QueryColumnInfoIconProps = QueryColumnInfoPopoverProps & {
 
 export function QueryColumnInfoIcon({
   className,
-  delay,
   size,
   icon,
   color,
@@ -40,7 +39,7 @@ export function QueryColumnInfoIcon({
 
   return (
     <>
-      <QueryColumnInfoPopover {...props} delay={delay}>
+      <QueryColumnInfoPopover {...props}>
         <span aria-label={t`More info`}>
           <PopoverDefaultIcon
             className={className}
@@ -70,7 +69,6 @@ type TableColumnInfoIconProps = TableColumnInfoPopoverProps & {
 
 export function TableColumnInfoIcon({
   className,
-  delay,
   field,
   icon,
   size,
@@ -78,7 +76,7 @@ export function TableColumnInfoIcon({
   ...props
 }: TableColumnInfoIconProps) {
   return (
-    <TableColumnInfoPopover {...props} field={field} delay={delay}>
+    <TableColumnInfoPopover {...props} field={field}>
       <span aria-label={t`More info`}>
         <PopoverDefaultIcon
           className={className}

--- a/frontend/src/metabase/components/MetadataInfo/ColumnInfoIcon/ColumnInfoIcon.unit.spec.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/ColumnInfoIcon/ColumnInfoIcon.unit.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "__support__/ui";
+import { fireEvent, render, screen, waitFor } from "__support__/ui";
 import * as Lib from "metabase-lib";
 import { columnFinder, createQuery } from "metabase-lib/test-helpers";
 
@@ -26,6 +26,13 @@ describe("QueryColumnInfoIcon", () => {
 
     fireEvent.mouseEnter(icon);
 
-    expect(await screen.findByText("Category")).toBeInTheDocument();
+    await waitFor(
+      () => {
+        expect(screen.getByText("Category")).toBeInTheDocument();
+      },
+      {
+        timeout: 1200,
+      },
+    );
   });
 });

--- a/frontend/src/metabase/components/MetadataInfo/ColumnInfoPopover/ColumnInfoPopover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/ColumnInfoPopover/ColumnInfoPopover.tsx
@@ -8,7 +8,6 @@ export type QueryColumnInfoPopoverProps = QueryColumnInfoProps &
 
 export function QueryColumnInfoPopover({
   position,
-  delay,
   disabled,
   children,
   ...rest
@@ -16,7 +15,6 @@ export function QueryColumnInfoPopover({
   return (
     <Popover
       position={position}
-      delay={delay}
       disabled={disabled}
       content={<QueryColumnInfo {...rest} />}
     >
@@ -30,7 +28,6 @@ export type TableColumnInfoPopoverProps = TableColumnInfoProps &
 
 export function TableColumnInfoPopover({
   position,
-  delay,
   disabled,
   children,
   ...rest
@@ -38,7 +35,6 @@ export function TableColumnInfoPopover({
   return (
     <Popover
       position={position}
-      delay={delay}
       disabled={disabled}
       content={<TableColumnInfo {...rest} />}
     >

--- a/frontend/src/metabase/components/MetadataInfo/ColumnInfoPopover/ColumnInfoPopover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/ColumnInfoPopover/ColumnInfoPopover.tsx
@@ -10,12 +10,14 @@ export function QueryColumnInfoPopover({
   position,
   disabled,
   children,
+  openDelay,
   ...rest
 }: QueryColumnInfoPopoverProps) {
   return (
     <Popover
       position={position}
       disabled={disabled}
+      openDelay={openDelay}
       content={<QueryColumnInfo {...rest} />}
     >
       {children}
@@ -29,6 +31,7 @@ export type TableColumnInfoPopoverProps = TableColumnInfoProps &
 export function TableColumnInfoPopover({
   position,
   disabled,
+  openDelay,
   children,
   ...rest
 }: TableColumnInfoPopoverProps) {
@@ -36,6 +39,7 @@ export function TableColumnInfoPopover({
     <Popover
       position={position}
       disabled={disabled}
+      openDelay={openDelay}
       content={<TableColumnInfo {...rest} />}
     >
       {children}

--- a/frontend/src/metabase/components/MetadataInfo/Popover/Popover.styled.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/Popover/Popover.styled.tsx
@@ -15,6 +15,6 @@ export const HackyInvisibleTargetFiller = styled.div`
   position: absolute;
   width: 100%;
   top: -10px;
-  min-height: 5px;
+  min-height: 10px;
   z-index: -1;
 `;

--- a/frontend/src/metabase/components/MetadataInfo/Popover/Popover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/Popover/Popover.tsx
@@ -5,8 +5,22 @@ import useSequencedContentCloseHandler from "metabase/hooks/use-sequenced-conten
 import type { HoverCardProps } from "metabase/ui";
 import { HoverCard, useDelayGroup } from "metabase/ui";
 
-export const POPOVER_DELAY: [number, number] = [1000, 150];
-export const POPOVER_TRANSITION_DURATION = 150;
+const POPOVER_TRANSITION_DURATION = 150;
+
+// Initially, the user will have to hover for this long to open the popover
+const POPOVER_SLOW_OPEN_DELAY = 1000;
+
+// When an item in the same delay group is already open, we want to open the
+// popover immediately, without waiting for the user to hover for POPOVER_SLOW_OPEN_DELAY.
+// This way the user can move the cursor between hover targets and get feedback immediately.
+//
+// When opening fast, we still delay a little bit to avoid a flickering popover
+// when the target is being clicked.
+const POPOVER_FAST_OPEN_DELAY = 150;
+
+// When switching to another hover target in the same delay group,
+// we don't close immediately but delay by a short amount to avoid flicker.
+const POPOVER_CLOSE_DELAY = POPOVER_FAST_OPEN_DELAY + 30;
 
 import {
   Dropdown,
@@ -14,15 +28,10 @@ import {
   WidthBound,
 } from "./Popover.styled";
 
-// When switching to another hover target in the same delay group,
-// we don't close immediately but delay by a short amount to avoid flicker.
-export const POPOVER_CLOSE_DELAY = 20;
-
 export type PopoverProps = Pick<
   HoverCardProps,
   "children" | "position" | "disabled"
 > & {
-  delay?: [number, number];
   width?: number;
   content: ReactNode;
 };
@@ -30,7 +39,6 @@ export type PopoverProps = Pick<
 export function Popover({
   position = "bottom-start",
   disabled,
-  delay = POPOVER_DELAY,
   content,
   width,
   children,
@@ -57,8 +65,10 @@ export function Popover({
     <HoverCard
       position={position}
       disabled={disabled}
-      openDelay={group.shouldDelay ? delay[0] : 0}
-      closeDelay={group.shouldDelay ? delay[1] : POPOVER_CLOSE_DELAY}
+      openDelay={
+        group.shouldDelay ? POPOVER_SLOW_OPEN_DELAY : POPOVER_FAST_OPEN_DELAY
+      }
+      closeDelay={POPOVER_CLOSE_DELAY}
       onOpen={handleOpen}
       onClose={handleClose}
       transitionProps={{

--- a/frontend/src/metabase/components/MetadataInfo/Popover/Popover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/Popover/Popover.tsx
@@ -5,7 +5,7 @@ import useSequencedContentCloseHandler from "metabase/hooks/use-sequenced-conten
 import type { HoverCardProps } from "metabase/ui";
 import { HoverCard, useDelayGroup } from "metabase/ui";
 
-export const POPOVER_DELAY: [number, number] = [250, 150];
+export const POPOVER_DELAY: [number, number] = [1000, 150];
 export const POPOVER_TRANSITION_DURATION = 150;
 
 import {

--- a/frontend/src/metabase/components/MetadataInfo/Popover/Popover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/Popover/Popover.tsx
@@ -8,7 +8,7 @@ import { HoverCard, useDelayGroup } from "metabase/ui";
 const POPOVER_TRANSITION_DURATION = 150;
 
 // Initially, the user will have to hover for this long to open the popover
-const POPOVER_SLOW_OPEN_DELAY = 1000;
+const POPOVER_SLOW_OPEN_DELAY = 500;
 
 // When an item in the same delay group is already open, we want to open the
 // popover immediately, without waiting for the user to hover for POPOVER_SLOW_OPEN_DELAY.

--- a/frontend/src/metabase/components/MetadataInfo/Popover/Popover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/Popover/Popover.tsx
@@ -8,7 +8,7 @@ import { HoverCard, useDelayGroup } from "metabase/ui";
 const POPOVER_TRANSITION_DURATION = 150;
 
 // Initially, the user will have to hover for this long to open the popover
-const POPOVER_SLOW_OPEN_DELAY = 500;
+const POPOVER_SLOW_OPEN_DELAY = 250;
 
 // When an item in the same delay group is already open, we want to open the
 // popover immediately, without waiting for the user to hover for POPOVER_SLOW_OPEN_DELAY.
@@ -34,12 +34,14 @@ export type PopoverProps = Pick<
 > & {
   width?: number;
   content: ReactNode;
+  openDelay?: number;
 };
 
 export function Popover({
   position = "bottom-start",
   disabled,
   content,
+  openDelay = POPOVER_SLOW_OPEN_DELAY,
   width,
   children,
 }: PopoverProps) {
@@ -65,9 +67,7 @@ export function Popover({
     <HoverCard
       position={position}
       disabled={disabled}
-      openDelay={
-        group.shouldDelay ? POPOVER_SLOW_OPEN_DELAY : POPOVER_FAST_OPEN_DELAY
-      }
+      openDelay={group.shouldDelay ? openDelay : POPOVER_FAST_OPEN_DELAY}
       closeDelay={POPOVER_CLOSE_DELAY}
       onOpen={handleOpen}
       onClose={handleClose}

--- a/frontend/src/metabase/components/MetadataInfo/TableInfoIcon/TableInfoIcon.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/TableInfoIcon/TableInfoIcon.tsx
@@ -19,14 +19,13 @@ type TableInfoIconProps = TableInfoPopoverProps & {
 
 export function TableInfoIcon({
   className,
-  delay,
   table,
   size,
   icon = "table",
   ...props
 }: TableInfoIconProps) {
   return (
-    <TableInfoPopover {...props} table={table} delay={delay}>
+    <TableInfoPopover {...props} table={table}>
       <span aria-label={t`More info`}>
         <PopoverDefaultIcon name={icon} className={className} size={size} />
         <PopoverHoverTarget

--- a/frontend/src/metabase/components/MetadataInfo/TableInfoPopover/TableInfoPopover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/TableInfoPopover/TableInfoPopover.tsx
@@ -15,7 +15,6 @@ export type TableInfoPopoverProps = Omit<PopoverProps, "content"> &
 
 export function TableInfoPopover({
   children,
-  delay,
   disabled,
   position,
   table,
@@ -30,7 +29,6 @@ export function TableInfoPopover({
   return (
     <Popover
       position={position}
-      delay={delay}
       disabled={disabled}
       content={<TableInfo tableId={table.id} {...rest} />}
     >

--- a/frontend/src/metabase/components/MetadataInfo/TableInfoPopover/TableInfoPopover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/TableInfoPopover/TableInfoPopover.tsx
@@ -17,6 +17,7 @@ export function TableInfoPopover({
   children,
   disabled,
   position,
+  openDelay,
   table,
   ...rest
 }: TableInfoPopoverProps) {
@@ -30,6 +31,7 @@ export function TableInfoPopover({
     <Popover
       position={position}
       disabled={disabled}
+      openDelay={openDelay}
       content={<TableInfo tableId={table.id} {...rest} />}
     >
       {children}

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -919,6 +919,7 @@ class TableInteractive extends Component {
             column={query && Lib.fromLegacyColumn(query, stageIndex, column)}
             timezone={data.results_timezone}
             disabled={this.props.clicked != null || !hasMetadataPopovers}
+            openDelay={500}
             showFingerprintInfo
           >
             {renderTableHeaderWrapper(


### PR DESCRIPTION

Closes https://github.com/metabase/metabase/issues/47694

### Description

Tweaks the timing of the info popovers to make them less intrusive.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Open a question or table and select the table visualisation
2. Hover the header items and make sure the information popover is visible, but only after hovering for 1s
3. Move the cursor to other header items and make sure the popover shows immediately
4. Click the headers and make sure the popover does not flicker

### Demo


https://github.com/user-attachments/assets/c6d17681-f1e8-411c-8cb7-d450700742ee



### Checklist
No functionality changed, just some timing