### PR TITLE
Do not localize prometheus metric descriptions

### DIFF
--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -196,21 +196,21 @@
   []
   ;; Iapetos will use "default" if we do not provide a namespace, so explicitly set, e.g. `metabase-email`:
   [(prometheus/counter :metabase-email/messages
-                       {:description (trs "Number of emails sent.")})
+                       {:description "Number of emails sent."})
    (prometheus/counter :metabase-email/message-errors
-                       {:description (trs "Number of errors when sending emails.")})
+                       {:description "Number of errors when sending emails."})
    (prometheus/counter :metabase-sdk/response-ok
-                       {:description (trs "Number of successful SDK requests.")})
+                       {:description "Number of successful SDK requests."})
    (prometheus/counter :metabase-sdk/response-error
-                       {:description (trs "Number of errors when responding to SDK requests.")})
+                       {:description "Number of errors when responding to SDK requests."})
    (prometheus/counter :metabase-scim/response-ok
-                       {:description (trs "Number of successful responses from SCIM endpoints")})
+                       {:description "Number of successful responses from SCIM endpoints"})
    (prometheus/counter :metabase-scim/response-error
-                       {:description (trs "Number of error responses from SCIM endpoints")})
+                       {:description "Number of error responses from SCIM endpoints"})
    (prometheus/counter :metabase-query-processor/metrics
-                       {:description (trs "Number of queries consuming metrics processed by the query processor.")})
+                       {:description "Number of queries consuming metrics processed by the query processor."})
    (prometheus/counter :metabase-query-processor/metric-errors
-                       {:description (trs "Number of errors when processing metrics.")})])
+                       {:description "Number of errors when processing metrics."})])
 
 (defn- setup-metrics!
   "Instrument the application. Conditionally done when some setting is set. If [[prometheus-server-port]] is not set it


### PR DESCRIPTION
### Description

Don't call `trs` to localize prometheus metric descriptions.

https://metaboat.slack.com/archives/CKZEMT1MJ/p1729250473701929

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
