### PR TITLE
More grouped metrics data

### DIFF
--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -615,7 +615,7 @@
   (let [qe (t2/select [:model/QueryExecution :embedding_client :executor_id :started_at])
         one-day-ago (->one-day-ago)
         ;; reuse the query data:
-        qe-24h (filter (fn [{started-at :started_at}] (->> started-at (t/after? one-day-ago))) qe)]
+        qe-24h (filter (fn [{started-at :started_at}] (t/after? one-day-ago started-at)) qe)]
     {:query-executions (merge
                         {"sdk_embed" 0 "interactive_embed" 0 "static_embed" 0 "public_link" 0 "internal" 0}
                         (-> (group-by categorize-query-execution qe)

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -647,8 +647,7 @@
   "Collects Snowplow metrics data that is not in the legacy stats format. Also clears entity id translation count."
   []
   (let [one-day-ago (->one-day-ago)
-        total-translation-count (:total (get-translation-count))
-        _ (clear-translation-count!)]
+        total-translation-count (:total (get-translation-count))]
     {:models                          (t2/count :model/Card :type :model :archived false)
      :new_embedded_dashboards         (t2/count :model/Dashboard
                                                 :enable_embedding true
@@ -896,6 +895,9 @@
    (fn [x] (if (keyword? x) (-> x u/->snake_case_en name) x))
    data))
 
+(defn- stats-post-cleanup []
+  (clear-translation-count!))
+
 (defn phone-home-stats!
   "Collect usage stats and phone them home"
   []
@@ -913,4 +915,5 @@
               (str "Missing required keys in snowplow-data. got:" (sort (keys snowplow-data))))
       #_{:clj-kondo/ignore [:deprecated-var]}
       (send-stats-deprecated! stats)
-      (snowplow/track-event! ::snowplow/instance_stats snowplow-data))))
+      (snowplow/track-event! ::snowplow/instance_stats snowplow-data)
+      (stats-post-cleanup))))

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -885,7 +885,7 @@
                 ;; `:num_queries_cached_unbinned` is added to [[legacy-anonymous-usage-stats]]'s return value to make
                 ;; computing [[snowplow-anonymous-usage-stats]] more efficient. It shouldn't be sent by
                 ;; [[send-stats-deprecited!]].
-                (update-in [:stats :stats :cache] dissoc :num_queries_cached_unbinned))
+                (update-in [:stats :cache] dissoc :num_queries_cached_unbinned))
      :snowplow-stats (snowplow-anonymous-usage-stats stats)}))
 
 (defn- deep-string-keywords

--- a/src/metabase/eid_translation.clj
+++ b/src/metabase/eid_translation.clj
@@ -1,9 +1,16 @@
 (ns metabase.eid-translation)
 
+(def statuses
+  "Possible statuses from an entity-id -> id translation:
+   If the translation from entity-id -> id is successful, the status is `:ok`.
+   If the id is not found, the status is `:not-found`.
+   If the format of the entity-id is invalid, the status is `:invalid-format`."
+  [:ok :not-found :invalid-format])
+
 (def Status
   "Malli enum for possible statuses for entity_id -> id translations."
-  [:enum :ok :not-found :invalid-format])
+  (into [:enum] statuses))
 
 (def default-counter
   "The empty counter for tracking the number of entity_id -> id translations."
-  (zipmap (rest Status) (repeat 0)))
+  (zipmap statuses (repeat 0)))

--- a/test/metabase/analytics/stats_test.clj
+++ b/test/metabase/analytics/stats_test.clj
@@ -461,3 +461,13 @@
 
       ;; make sure features are not duplicated
       (is (= (count included-features) (count included-features-set))))))
+
+(deftest snowplow-grouped-metric-info-test
+  (testing "query_executions"
+    (let [{:keys [query_executions query_executions_24h]} (#'stats/->snowplow-grouped-metric-info)]
+      (doseq [k (keys query_executions)]
+        (testing (str "> key " k))
+        (is (contains? query_executions_24h k))
+        (is (not (< (get query_executions k)
+                    (get query_executions_24h k)))
+            "There are never more query executions in the 24h version than all-of-time.")))))


### PR DESCRIPTION
- [x] [Adds query_executions_by_source_24h and entity_id_translations_last_24h](https://github.com/metabase/metabase/commit/da1ca0c83b370ce8f9be1e12a4f6c8c0011fe198)

- [x] Adds post-cleanup hook for clearing things after the stat ping is sent

- [x] Adds `deep-string-keywords` to make sure we don't send through keywords (which _is_ easy to do if you are in a hurry).

Notes:

reuses the query for `query-executions` to generate `query-executions-24h`, with a test to make sure `after?` is done right.
