### PR TITLE
`with-dynamic-redefs`: clarify infinite loop

### DIFF
--- a/test/metabase/test/util/dynamic_redefs.clj
+++ b/test/metabase/test/util/dynamic_redefs.clj
@@ -47,7 +47,7 @@
         ;; Log it as well as throwing it - this gives more user-friendly formatting.
         (log/error infinite-loop-error)
         (throw (ex-info infinite-loop-error {:var a-var})))
-      (binding [*already-called* (conj *already-called*)]
+      (binding [*already-called* (conj *already-called* a-var)]
         (apply current-f args)))))
 
 (defn patch-vars!


### PR DESCRIPTION
This was really confusing to me for a while before I figured it out and found the relevant example - especially because the test would pass the first time and fail on all subsequent runs. :sob: