### PR TITLE
Sanatize props passed to icons

### DIFF
--- a/frontend/src/metabase/ui/components/icons/Icon/Icon.tsx
+++ b/frontend/src/metabase/ui/components/icons/Icon/Icon.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { Box, type BoxProps } from "@mantine/core";
+import { Box, type BoxProps, extractSystemStyles } from "@mantine/core";
 import cx from "classnames";
 import type { MouseEvent, ReactNode, SVGAttributes } from "react";
 import { forwardRef } from "react";
@@ -26,6 +26,7 @@ export const Icon = forwardRef<SVGSVGElement, IconProps>(function Icon(
 ) {
   const IconComponent = (Icons[name] ?? Icons["unknown"]).component;
 
+  const { systemStyles } = extractSystemStyles(restProps);
   const icon = (
     <Box
       component={IconComponent}
@@ -35,7 +36,7 @@ export const Icon = forwardRef<SVGSVGElement, IconProps>(function Icon(
       className={cx(`Icon Icon-${name}`, className)}
       width={size}
       height={size}
-      {...restProps}
+      {...systemStyles}
     />
   );
 


### PR DESCRIPTION
### Description
Ever since switching the `<Icon>` prop to be a box, we have had a large number of invalid dom prop warnings in the app. Even just loading the home screen causes a handful. This change sanitizes the props that are being passed to Box so that only valid Mantine style props make it through


### How to verify
1. Open the home page and look at the console
2. Rejoice as it's not completely filled with red (though there is an invalid dom nesting warning still there)

### Demo
before:
![image](https://github.com/user-attachments/assets/1514cf14-d696-4e37-b491-42de290ec749)

