### PR TITLE
Make metabot centered again

### DIFF
--- a/frontend/src/metabase/home/components/HomeGreeting/HomeGreeting.tsx
+++ b/frontend/src/metabase/home/components/HomeGreeting/HomeGreeting.tsx
@@ -2,11 +2,10 @@ import { useEffect, useMemo, useState } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
-import Tooltip from "metabase/core/components/Tooltip";
 import styles from "metabase/css/core/animation.module.css";
 import { useSelector } from "metabase/lib/redux";
 import { getUser } from "metabase/selectors/user";
-import { Box } from "metabase/ui";
+import { Box, Tooltip } from "metabase/ui";
 
 import { getHasMetabotLogo } from "../../selectors";
 
@@ -24,14 +23,7 @@ export const HomeGreeting = (): JSX.Element => {
 
   return (
     <GreetingRoot>
-      {showLogo && (
-        <Tooltip
-          tooltip={t`Don't tell anyone, but you're my favorite.`}
-          placement="bottom"
-        >
-          <MetabotGreeting />
-        </Tooltip>
-      )}
+      {showLogo && <MetabotGreeting />}
       <GreetingMessage data-testid="greeting-message" showLogo={showLogo}>
         {message}
       </GreetingMessage>
@@ -87,25 +79,30 @@ const MetabotGreeting = () => {
   }, [buffer]);
 
   return (
-    <Box
-      style={{
-        position: "relative",
-        width: "62px",
-        height: "40px",
-        marginInlineEnd: "0.5rem",
-      }}
+    <Tooltip
+      label={t`Don't tell anyone, but you're my favorite.`}
+      position="bottom"
     >
-      <GreetingLogo
-        isCool={isCool}
-        className={`${styles.SpinOut} ${isCooling ? styles.SpinOutActive : ""}`}
-        variant="cool"
-      />
-      <GreetingLogo
-        isCool={!isCool}
-        className={`${styles.SpinOut} ${isCooling ? styles.SpinOutActive : ""}`}
-        variant="happy"
-      />
-    </Box>
+      <Box
+        style={{
+          position: "relative",
+          width: "54px",
+          height: "40px",
+          marginInlineEnd: "0.5rem",
+        }}
+      >
+        <GreetingLogo
+          isCool={isCool}
+          className={`${styles.SpinOut} ${isCooling ? styles.SpinOutActive : ""}`}
+          variant="cool"
+        />
+        <GreetingLogo
+          isCool={!isCool}
+          className={`${styles.SpinOut} ${isCooling ? styles.SpinOutActive : ""}`}
+          variant="happy"
+        />
+      </Box>
+    </Tooltip>
   );
 };
 


### PR DESCRIPTION

### Description

Center the tooltip on the metabot logo. Removes deprecated tooltip component while we're at it.


![Screen Shot 2024-10-18 at 3 28 12 PM](https://github.com/user-attachments/assets/ff8f63f5-a2a8-41a0-a8d7-891fe4550c65)
