### PR TITLE
Fix - Actions are broken in 50.30 when Models are based on SQL

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
@@ -1774,8 +1774,8 @@ describe("issue 48878", () => {
     cy.log("create dummy model");
 
     // Create a dummy model so that GET /api/search does not return the model want to test.
-    // That would put card object with dataset_query attribute in redux store (entity framework) which
-    // would prevent the issue from happening.
+    // If we don't do this, GET /api/search will return and put card object with dataset_query
+    // attribute in the redux store (entity framework) which would prevent the issue from happening.
     cy.visit("/model/new");
     createModel({
       name: "Dummy model",

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
@@ -1,4 +1,4 @@
-import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DB_ID, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 import {
@@ -10,7 +10,9 @@ import {
   cypressWaitAll,
   echartsContainer,
   editDashboard,
+  focusNativeEditor,
   getDashboardCard,
+  modal,
   openNavigationSidebar,
   pieSlices,
   popover,
@@ -19,6 +21,7 @@ import {
   restore,
   resyncDatabase,
   saveDashboard,
+  setActionsEnabledForDB,
   showDashboardCardActions,
   sidebar,
   updateSetting,
@@ -1739,4 +1742,120 @@ describe("issue 43219", () => {
       cy.findByText("Series 10").should("be.visible");
     });
   });
+});
+
+describe("issue 48878", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    setActionsEnabledForDB(SAMPLE_DB_ID);
+
+    cy.signInAsNormalUser();
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    cy.intercept("POST", "/api/card").as("saveQuestion");
+    cy.intercept("POST", "/api/action").as("createAction");
+    cy.intercept("GET", "/api/dashboard/*").as("getDashboard");
+    cy.intercept("PUT", "/api/dashboard/*").as("updateDashboard");
+    setup();
+  });
+
+  // I could only reproduce this issue in Cypress when I didn't use any helpers like createQuestion, etc.
+  it("does not crash the action button viz (metabase#48878)", () => {
+    cy.intercept("GET", "/api/card/*", request => {
+      request.continue(() => new Promise(resolve => setTimeout(resolve, 2000)));
+    }).as("fetchCard");
+
+    cy.reload();
+    cy.wait("@fetchCard");
+    getDashboardCard(0).findByText("Click Me").should("be.visible");
+  });
+
+  function setup() {
+    cy.log("create dummy model");
+
+    // Create a dummy model so that GET /api/search does not return the model want to test.
+    // That would put card object with dataset_query attribute in redux store (entity framework) which
+    // would prevent the issue from happening.
+    cy.visit("/model/new");
+    createModel({
+      name: "Dummy model",
+      query: "select 1",
+    });
+
+    cy.log("create model");
+
+    cy.button("New").click();
+    popover().findByText("Model").click();
+    createModel({
+      name: "SQL Model",
+      query: "select * from orders limit 5",
+    });
+
+    cy.log("create model action");
+
+    cy.findByTestId("qb-header-info-button").click();
+    modal().findByText("See more about this model").click();
+
+    cy.findByRole("tab", { name: "Actions" }).click();
+    cy.findByTestId("model-actions-header").findByText("New action").click();
+
+    modal().within(() => {
+      focusNativeEditor().type("UPDATE orders SET plan = {{ plan ", {
+        parseSpecialCharSequences: false,
+      });
+      cy.button("Save").click();
+    });
+
+    modal()
+      .last()
+      .within(() => {
+        cy.findByPlaceholderText("My new fantastic action").type("Test action");
+        cy.button("Create").click();
+        cy.wait("@createAction");
+      });
+
+    cy.visit("/");
+
+    cy.log("create dashoard");
+
+    cy.button("New").click();
+    popover().findByText("Dashboard").click();
+
+    modal().within(() => {
+      cy.findByPlaceholderText("What is the name of your dashboard?").type(
+        "Dash",
+      );
+      cy.button("Create").click();
+      cy.wait("@getDashboard");
+    });
+
+    cy.button("Add action").click();
+    cy.button("Pick an action").click();
+    modal().within(() => {
+      cy.findByText("SQL Model").click();
+      cy.findByText("Test action").click();
+      cy.button("Done").click();
+    });
+    cy.button("Save").click();
+    cy.wait("@updateDashboard");
+  }
+
+  function createModel({ name, query }) {
+    cy.findByTestId("new-model-options")
+      .findByText("Use a native query")
+      .click();
+
+    focusNativeEditor().type(query);
+    cy.findByTestId("native-query-editor-sidebar")
+      .findByTestId("run-button")
+      .click();
+    cy.wait("@dataset");
+    cy.button("Save").click();
+
+    modal().within(() => {
+      cy.findByPlaceholderText("What is the name of your model?").type(name);
+      cy.button("Save").click();
+      cy.wait("@saveQuestion");
+    });
+  }
 });

--- a/frontend/src/metabase/actions/components/ActionViz/Action.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.tsx
@@ -65,7 +65,10 @@ const ActionComponent = ({
     dashcard.action?.model_id ? { id: dashcard.action.model_id } : skipToken,
   );
   const metadata = useSelector(getMetadata);
-  const model = card ? new Question(card, metadata) : undefined;
+  const model = useMemo(
+    () => (card ? new Question(card, metadata) : undefined),
+    [card, metadata],
+  );
 
   const actionSettings = dashcard.action?.visualization_settings;
   const actionDisplayType =

--- a/frontend/src/metabase/actions/components/ActionViz/Action.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.tsx
@@ -104,7 +104,7 @@ const ActionComponent = ({
     shouldConfirm
   );
 
-  const canWrite = model?.canWriteActions();
+  const canWrite = Boolean(model?.canWriteActions());
 
   const onSubmit = useCallback(
     async (parameters: ParametersForActionExecution) => {

--- a/frontend/src/metabase/actions/components/ActionViz/Action.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from "react";
 import { connect } from "react-redux";
 import { t } from "ttag";
 
-import { useQuestionQuery } from "metabase/common/hooks";
+import { skipToken, useGetCardQuery } from "metabase/api";
 import Tooltip from "metabase/core/components/Tooltip";
 import {
   executeRowAction,
@@ -13,7 +13,10 @@ import {
   getParameterValues,
 } from "metabase/dashboard/selectors";
 import { getActionIsEnabledInDatabase } from "metabase/dashboard/utils";
+import { useSelector } from "metabase/lib/redux";
+import { getMetadata } from "metabase/selectors/metadata";
 import type { VisualizationProps } from "metabase/visualizations/types";
+import Question from "metabase-lib/v1/Question";
 import type {
   ActionDashboardCard,
   Dashboard,
@@ -58,9 +61,11 @@ const ActionComponent = ({
   parameterValues,
   isEditingDashcard,
 }: ActionProps) => {
-  const { data: model } = useQuestionQuery({
-    id: dashcard.action?.model_id,
-  });
+  const { data: card } = useGetCardQuery(
+    dashcard.action?.model_id ? { id: dashcard.action?.model_id } : skipToken,
+  );
+  const metadata = useSelector(getMetadata);
+  const model = card ? new Question(card, metadata) : undefined;
 
   const actionSettings = dashcard.action?.visualization_settings;
   const actionDisplayType =

--- a/frontend/src/metabase/actions/components/ActionViz/Action.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.tsx
@@ -62,7 +62,7 @@ const ActionComponent = ({
   isEditingDashcard,
 }: ActionProps) => {
   const { data: card } = useGetCardQuery(
-    dashcard.action?.model_id ? { id: dashcard.action?.model_id } : skipToken,
+    dashcard.action?.model_id ? { id: dashcard.action.model_id } : skipToken,
   );
   const metadata = useSelector(getMetadata);
   const model = card ? new Question(card, metadata) : undefined;


### PR DESCRIPTION
Fixes #48878

### Description

We're going to need to backport it to v51 and v50. Bug appeared in 0.50.28.6.

What was happening:
- this issue reproduces only when GET `/api/collection/root/items?models=dataset` ends before GET `/api/card/:id` (it's a race condition, you may hit it or not)
- GET `/api/collection/root/items?models=dataset` populates `entities.questions` in redux store (entity framework) with an incomplete card object (it does not have `dataset_query` attribute)
- `ActionViz/Action` component uses `useQuestionQuery` which will give this incomplete card from redux store (entity framework)

### How to verify

CI is green.
The new test fails if run in `master`.
Stress test: https://github.com/metabase/metabase/actions/runs/11442473756