### PR TITLE
Reset the question's viz settings when converting to a model

### DIFF
--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -8,57 +8,42 @@ import {
   type NativeQuestionDetails,
   type StructuredQuestionDetails,
   assertQueryBuilderRowCount,
-  assertQueryBuilderRowCount,
   createNativeQuestion,
   createQuestion,
   describeEE,
-  describeEE,
-  editDashboard,
   editDashboard,
   enterCustomColumnDetails,
   entityPickerModal,
   entityPickerModalTab,
   getNotebookStep,
   getPinnedSection,
-  getPinnedSection,
   hovercard,
   join,
   mapColumnTo,
   modal,
   navigationSidebar,
-  navigationSidebar,
-  newButton,
   newButton,
   openColumnOptions,
   openNotebook,
   openQuestionActions,
   popover,
   questionInfoButton,
-  questionInfoButton,
   renameColumn,
   restore,
-  rightSidebar,
   rightSidebar,
   saveMetadataChanges,
   saveQuestion,
   setDropdownFilterType,
-  setDropdownFilterType,
-  setFilter,
   setFilter,
   setTokenFeatures,
-  setTokenFeatures,
-  sidebar,
   sidebar,
   sidesheet,
   startNewModel,
   startNewQuestion,
   summarize,
-  summarize,
   tableHeaderClick,
   tableInteractive,
-  tableInteractive,
   undoToast,
-  visitDashboard,
   visitDashboard,
   visitModel,
   visualize,
@@ -1313,5 +1298,42 @@ describe("issue 46221", () => {
     cy.findByTestId("head-crumbs-container")
       .should("contain", "First collection")
       .and("contain", modelDetails.name);
+  });
+});
+
+describe("issue 20624", () => {
+  const questionDetails: StructuredQuestionDetails = {
+    name: "Question",
+    type: "question",
+    query: {
+      "source-table": PRODUCTS_ID,
+    },
+    visualization_settings: {
+      column_settings: {
+        '["name","VENDOR"]': { column_title: "Retailer" },
+      },
+    },
+  };
+
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+    cy.intercept("PUT", "/api/card/*").as("updateCard");
+  });
+
+  it("should reset the question's viz settings when converting to a model", () => {
+    createQuestion(questionDetails, { visitQuestion: true });
+    tableInteractive().within(() => {
+      cy.findByText("Retailer").should("be.visible");
+      cy.findByText("Vendor").should("not.exist");
+    });
+    openQuestionActions();
+    popover().findByText("Turn into a model").click();
+    modal().findByText("Turn this into a model").click();
+    cy.wait("@updateCard");
+    tableInteractive().within(() => {
+      cy.findByText("Vendor").should("be.visible");
+      cy.findByText("Retailer").should("not.exist");
+    });
   });
 });

--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -1322,13 +1322,14 @@ describe("issue 20624", () => {
   });
 
   it("should reset the question's viz settings when converting to a model", () => {
+    cy.log("check that a column is renamed according to the viz settings");
     createQuestion(questionDetails, { visitQuestion: true });
     tableInteractive().within(() => {
       cy.findByText("Retailer").should("be.visible");
       cy.findByText("Vendor").should("not.exist");
     });
 
-    cy.log("check that viz settings are reset");
+    cy.log("check that viz settings are reset when converting to a model");
     openQuestionActions();
     popover().findByText("Turn into a model").click();
     modal().findByText("Turn this into a model").click();
@@ -1338,7 +1339,7 @@ describe("issue 20624", () => {
       cy.findByText("Retailer").should("not.exist");
     });
 
-    cy.log("achieve the same using model metadata");
+    cy.log("rename the column using the model's metadata");
     openQuestionActions();
     popover().findByText("Edit metadata").click();
     tableHeaderClick("Vendor");

--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -1327,6 +1327,8 @@ describe("issue 20624", () => {
       cy.findByText("Retailer").should("be.visible");
       cy.findByText("Vendor").should("not.exist");
     });
+
+    cy.log("check that viz settings are reset");
     openQuestionActions();
     popover().findByText("Turn into a model").click();
     modal().findByText("Turn this into a model").click();
@@ -1334,6 +1336,18 @@ describe("issue 20624", () => {
     tableInteractive().within(() => {
       cy.findByText("Vendor").should("be.visible");
       cy.findByText("Retailer").should("not.exist");
+    });
+
+    cy.log("achieve the same using model metadata");
+    openQuestionActions();
+    popover().findByText("Edit metadata").click();
+    tableHeaderClick("Vendor");
+    cy.findByLabelText("Display name").clear().type("Retailer");
+    cy.button("Save changes").should("be.enabled").click();
+    cy.wait("@updateCard");
+    tableInteractive().within(() => {
+      cy.findByText("Retailer").should("be.visible");
+      cy.findByText("Vendor").should("not.exist");
     });
   });
 });

--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -1322,7 +1322,7 @@ describe("issue 20624", () => {
   });
 
   it("should reset the question's viz settings when converting to a model", () => {
-    cy.log("check that a column is renamed according to the viz settings");
+    cy.log("check that a column is renamed via the viz settings");
     createQuestion(questionDetails, { visitQuestion: true });
     tableInteractive().within(() => {
       cy.findByText("Retailer").should("be.visible");

--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -1321,7 +1321,7 @@ describe("issue 20624", () => {
     cy.intercept("PUT", "/api/card/*").as("updateCard");
   });
 
-  it("should reset the question's viz settings when converting to a model", () => {
+  it("should reset the question's viz settings when converting to a model (metabase#20624)", () => {
     createQuestion(questionDetails, { visitQuestion: true });
     tableInteractive().within(() => {
       cy.findByText("Retailer").should("be.visible");

--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -1329,7 +1329,7 @@ describe("issue 20624", () => {
       cy.findByText("Vendor").should("not.exist");
     });
 
-    cy.log("check that viz settings are reset when converting to a model");
+    cy.log("check that the viz settings are reset when converting to a model");
     openQuestionActions();
     popover().findByText("Turn into a model").click();
     modal().findByText("Turn this into a model").click();

--- a/frontend/src/metabase/query_builder/actions/models.js
+++ b/frontend/src/metabase/query_builder/actions/models.js
@@ -24,7 +24,7 @@ export const onCancelCreateNewModel = () => async dispatch => {
   await dispatch(push("/"));
 };
 
-export const turnQuestionIntoDataset = () => async (dispatch, getState) => {
+export const turnQuestionIntoModel = () => async (dispatch, getState) => {
   const question = getQuestion(getState());
 
   await dispatch(
@@ -32,7 +32,12 @@ export const turnQuestionIntoDataset = () => async (dispatch, getState) => {
       {
         id: question.id(),
       },
-      question.setType("model").setPinned(true).setDisplay("table").card(),
+      question
+        .setType("model")
+        .setPinned(true)
+        .setDisplay("table")
+        .setSettings({})
+        .card(),
     ),
   );
 

--- a/frontend/src/metabase/query_builder/components/NewDatasetModal/NewDatasetModal.jsx
+++ b/frontend/src/metabase/query_builder/components/NewDatasetModal/NewDatasetModal.jsx
@@ -6,7 +6,7 @@ import ModalContent from "metabase/components/ModalContent";
 import Button from "metabase/core/components/Button";
 import Link from "metabase/core/components/Link";
 import CS from "metabase/css/core/index.css";
-import { turnQuestionIntoDataset } from "metabase/query_builder/actions";
+import { turnQuestionIntoModel } from "metabase/query_builder/actions";
 
 import {
   DatasetImg,
@@ -16,17 +16,17 @@ import {
 } from "./NewDatasetModal.styled";
 
 const propTypes = {
-  turnQuestionIntoDataset: PropTypes.func.isRequired,
+  turnQuestionIntoModel: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,
 };
 
 const mapDispatchToProps = {
-  turnQuestionIntoDataset,
+  turnQuestionIntoModel,
 };
 
-function NewDatasetModal({ turnQuestionIntoDataset, onClose }) {
+function NewDatasetModal({ turnQuestionIntoModel, onClose }) {
   const onConfirm = () => {
-    turnQuestionIntoDataset();
+    turnQuestionIntoModel();
     onClose();
   };
 


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/20624

This was discussed in Slack some time ago but I cannot find a thread now. The decision was to drop the viz settings during the conversion to a model to avoid issues like this.

How to verify:
- New -> Question -> Products -> Visualize
- Rename some of the columns via table column headers (i.e. viz settings) -> Save
- Dot menu -> Turn into a model -> Confirm
- The original column name is visible now and the user needs to modify the query metadata to make it work (which doesn't use viz settings)