### PR TITLE
Bump ring-core and ring-jetty-adapter

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -182,8 +182,8 @@
   redux/redux                               {:git/url "https://github.com/metabase/redux"
                                              :sha "4a37feaf817a2a6b5ef688c927f6fd4375964433"}
   riddley/riddley                           {:mvn/version "0.2.0"}              ; code walking lib -- used interally by Potemkin, manifold, etc.
-  ring/ring-core                            {:mvn/version "1.12.2"}             ; HTTP abstraction
-  ring/ring-jetty-adapter                   {:mvn/version "1.12.2"              ; Jetty adapter
+  ring/ring-core                            {:mvn/version "1.13.0"}             ; HTTP abstraction
+  ring/ring-jetty-adapter                   {:mvn/version "1.13.0"              ; Jetty adapter
                                              :exclusions [org.eclipse.jetty/jetty-server
                                                           org.eclipse.jetty.websocket/websocket-jetty-server]}
   ring/ring-json                            {:mvn/version "0.5.1"}              ; Ring middleware for reading/writing JSON automatically


### PR DESCRIPTION
There was a new version that supports jetty 11.0.24 https://github.com/ring-clojure/ring/blob/master/CHANGELOG.md