### PR TITLE
[Databricks] Use system's information schema during sync

### DIFF
--- a/modules/drivers/databricks/src/metabase/driver/databricks.clj
+++ b/modules/drivers/databricks/src/metabase/driver/databricks.clj
@@ -54,7 +54,7 @@
      "  TABLE_NAME as name,"
      "  TABLE_SCHEMA as schema,"
      "  COMMENT description"
-     "  from information_schema.tables"
+     "  from system.information_schema.tables"
      "  where TABLE_CATALOG = ?"
      "    AND TABLE_SCHEMA <> 'information_schema'"])
    catalog])
@@ -87,7 +87,7 @@
                         [:c.table_name :table-name]
                         [[:case [:= :cs.constraint_type [:inline "PRIMARY KEY"]] true :else false] :pk?]
                         [[:case [:not= :c.comment [:inline ""]] :c.comment :else nil] :field-comment]]
-               :from [[:information_schema.columns :c]]
+               :from [[:system.information_schema.columns :c]]
                ;; Following links contains contains diagram of `information_schema`:
                ;; https://docs.databricks.com/en/sql/language-manual/sql-ref-information-schema.html
                :left-join [[{:select   [[:tc.table_catalog :table_catalog]
@@ -95,8 +95,8 @@
                                         [:tc.table_name :table_name]
                                         [:ccu.column_name :column_name]
                                         [:tc.constraint_type :constraint_type]]
-                             :from     [[:information_schema.table_constraints :tc]]
-                             :join     [[:information_schema.constraint_column_usage :ccu]
+                             :from     [[:system.information_schema.table_constraints :tc]]
+                             :join     [[:system.information_schema.constraint_column_usage :ccu]
                                         [:and
                                          [:= :tc.constraint_catalog :ccu.constraint_catalog]
                                          [:= :tc.constraint_schema :ccu.constraint_schema]
@@ -136,13 +136,13 @@
                          :pk_kcu.table_schema  "pk-table-schema"
                          :pk_kcu.table_name    "pk-table-name"
                          :pk_kcu.column_name   "pk-column-name"})
-               :from [[:information_schema.key_column_usage :fk_kcu]]
-               :join [[:information_schema.referential_constraints :rc]
+               :from [[:system.information_schema.key_column_usage :fk_kcu]]
+               :join [[:system.information_schema.referential_constraints :rc]
                       [:and
                        [:= :fk_kcu.constraint_catalog :rc.constraint_catalog]
                        [:= :fk_kcu.constraint_schema :rc.constraint_schema]
                        [:= :fk_kcu.constraint_name :rc.constraint_name]]
-                      [:information_schema.key_column_usage :pk_kcu]
+                      [:system.information_schema.key_column_usage :pk_kcu]
                       [[:and
                         [:= :pk_kcu.constraint_catalog :rc.unique_constraint_catalog]
                         [:= :pk_kcu.constraint_schema :rc.unique_constraint_schema]

--- a/modules/drivers/databricks/test/metabase/driver/databricks_test.clj
+++ b/modules/drivers/databricks/test/metabase/driver/databricks_test.clj
@@ -45,102 +45,112 @@
           (is (contains? (:tables actual-tables) {:name "bird", :schema "bird-flocks", :description nil})))))))
 
 (deftest ^:parallel describe-fields-test
-  (testing "`describe-fields` returns expected values"
-    (mt/test-driver
-      :databricks
-      (is (= #{{:table-schema "test-data"
-                :table-name "orders"
-                :pk? true
-                :name "id"
-                :database-type "int"
-                :database-position 0
-                :base-type :type/Integer
-                :json-unfolding false}
-               {:table-schema "test-data"
-                :table-name "orders"
-                :pk? false
-                :name "user_id"
-                :database-type "int"
-                :database-position 1
-                :base-type :type/Integer
-                :json-unfolding false}
-               {:table-schema "test-data"
-                :table-name "orders"
-                :pk? false
-                :name "product_id"
-                :database-type "int"
-                :database-position 2
-                :base-type :type/Integer
-                :json-unfolding false}
-               {:table-schema "test-data"
-                :table-name "orders"
-                :pk? false
-                :name "subtotal"
-                :database-type "double"
-                :database-position 3
-                :base-type :type/Float
-                :json-unfolding false}
-               {:table-schema "test-data"
-                :table-name "orders"
-                :pk? false
-                :name "tax"
-                :database-type "double"
-                :database-position 4
-                :base-type :type/Float
-                :json-unfolding false}
-               {:table-schema "test-data"
-                :table-name "orders"
-                :pk? false
-                :name "total"
-                :database-type "double"
-                :database-position 5
-                :base-type :type/Float
-                :json-unfolding false}
-               {:table-schema "test-data"
-                :table-name "orders"
-                :pk? false
-                :name "discount"
-                :database-type "double"
-                :database-position 6
-                :base-type :type/Float
-                :json-unfolding false}
-               {:table-schema "test-data"
-                :table-name "orders"
-                :pk? false
-                :name "created_at"
-                :database-type "timestamp"
-                :database-position 7
-                :base-type :type/DateTimeWithLocalTZ
-                :json-unfolding false}
-               {:table-schema "test-data"
-                :table-name "orders"
-                :pk? false
-                :name "quantity"
-                :database-type "int"
-                :database-position 8
-                :base-type :type/Integer
-                :json-unfolding false}}
-             (reduce conj #{} (driver/describe-fields :databricks (mt/db) {:schema-names ["test-data"]
-                                                                           :table-names ["orders"]})))))))
+  (mt/test-driver
+    :databricks
+    (let [fields (vec (driver/describe-fields :databricks (mt/db) {:schema-names ["test-data"]
+                                                                   :table-names ["orders"]}))]
+      ;; Currently we have `test-data` in `metabase_ci` and `metabase_drivers`. Ensure the underlying sql query
+      ;; does not waste resources by returning for both.
+      (testing "Underlying query returns only fields from selected catalog"
+        (is (= 9 (count fields))))
+      (testing "Expected fields are returned"
+        (is (= #{{:table-schema "test-data"
+                  :table-name "orders"
+                  :pk? true
+                  :name "id"
+                  :database-type "int"
+                  :database-position 0
+                  :base-type :type/Integer
+                  :json-unfolding false}
+                 {:table-schema "test-data"
+                  :table-name "orders"
+                  :pk? false
+                  :name "user_id"
+                  :database-type "int"
+                  :database-position 1
+                  :base-type :type/Integer
+                  :json-unfolding false}
+                 {:table-schema "test-data"
+                  :table-name "orders"
+                  :pk? false
+                  :name "product_id"
+                  :database-type "int"
+                  :database-position 2
+                  :base-type :type/Integer
+                  :json-unfolding false}
+                 {:table-schema "test-data"
+                  :table-name "orders"
+                  :pk? false
+                  :name "subtotal"
+                  :database-type "double"
+                  :database-position 3
+                  :base-type :type/Float
+                  :json-unfolding false}
+                 {:table-schema "test-data"
+                  :table-name "orders"
+                  :pk? false
+                  :name "tax"
+                  :database-type "double"
+                  :database-position 4
+                  :base-type :type/Float
+                  :json-unfolding false}
+                 {:table-schema "test-data"
+                  :table-name "orders"
+                  :pk? false
+                  :name "total"
+                  :database-type "double"
+                  :database-position 5
+                  :base-type :type/Float
+                  :json-unfolding false}
+                 {:table-schema "test-data"
+                  :table-name "orders"
+                  :pk? false
+                  :name "discount"
+                  :database-type "double"
+                  :database-position 6
+                  :base-type :type/Float
+                  :json-unfolding false}
+                 {:table-schema "test-data"
+                  :table-name "orders"
+                  :pk? false
+                  :name "created_at"
+                  :database-type "timestamp"
+                  :database-position 7
+                  :base-type :type/DateTimeWithLocalTZ
+                  :json-unfolding false}
+                 {:table-schema "test-data"
+                  :table-name "orders"
+                  :pk? false
+                  :name "quantity"
+                  :database-type "int"
+                  :database-position 8
+                  :base-type :type/Integer
+                  :json-unfolding false}}
+               (set fields)))))))
 
 (deftest ^:parallel describe-fks-test
-  (testing "`describe-fks` returns expected values"
-    (mt/test-driver
-      :databricks
-      (is (= #{{:fk-table-schema "test-data"
-                :fk-table-name "orders"
-                :fk-column-name "product_id"
-                :pk-table-schema "test-data"
-                :pk-table-name "products"
-                :pk-column-name "id"}
-               {:fk-table-schema "test-data"
-                :fk-table-name "orders"
-                :fk-column-name "user_id"
-                :pk-table-schema "test-data"
-                :pk-table-name "people"
-                :pk-column-name "id"}}
-             (reduce conj #{} (driver/describe-fks :databricks (mt/db) {:schema-names ["test-data"]
-                                                                        :table-names ["orders"]})))))))
+  (mt/test-driver
+    :databricks
+    (let [fks (vec (driver/describe-fks :databricks (mt/db) {:schema-names ["test-data"]
+                                                             :table-names ["orders"]}))]
+      ;; Currently we have `test-data` in `metabase_ci` and `metabase_drivers`. Ensure the underlying sql query
+      ;; does not waste resources by returning for both.
+      (testing "Only fks from current catalog are registered"
+        (is (= 2 (count fks))))
+      (testing "Expected fks are returned"
+        (is (= #{{:fk-table-schema "test-data"
+                  :fk-table-name "orders"
+                  :fk-column-name "product_id"
+                  :pk-table-schema "test-data"
+                  :pk-table-name "products"
+                  :pk-column-name "id"}
+                 {:fk-table-schema "test-data"
+                  :fk-table-name "orders"
+                  :fk-column-name "user_id"
+                  :pk-table-schema "test-data"
+                  :pk-table-name "people"
+                  :pk-column-name "id"}}
+               (set fks)))))))
 
 (mt/defdataset dataset-with-ntz
   [["table_with_ntz" [{:field-name "timestamp"

--- a/modules/drivers/databricks/test/metabase/driver/databricks_test.clj
+++ b/modules/drivers/databricks/test/metabase/driver/databricks_test.clj
@@ -49,7 +49,7 @@
     :databricks
     (let [fields (vec (driver/describe-fields :databricks (mt/db) {:schema-names ["test-data"]
                                                                    :table-names ["orders"]}))]
-      ;; Currently we have `test-data` in `metabase_ci` and `metabase_drivers`. Ensure the underlying sql query
+      ;; Currently we have `test-data` in `metabase_ci` and `metabase_drivers`. Verify that the underlying sql query
       ;; does not waste resources by returning for both.
       (testing "Underlying query returns only fields from selected catalog"
         (is (= 9 (count fields))))

--- a/modules/drivers/databricks/test/metabase/driver/databricks_test.clj
+++ b/modules/drivers/databricks/test/metabase/driver/databricks_test.clj
@@ -49,8 +49,6 @@
     :databricks
     (let [fields (vec (driver/describe-fields :databricks (mt/db) {:schema-names ["test-data"]
                                                                    :table-names ["orders"]}))]
-      ;; Currently we have `test-data` in `metabase_ci` and `metabase_drivers`. Verify that the underlying sql query
-      ;; does not waste resources by returning for both.
       (testing "Underlying query returns only fields from selected catalog"
         (is (= 9 (count fields))))
       (testing "Expected fields are returned"
@@ -133,8 +131,6 @@
     :databricks
     (let [fks (vec (driver/describe-fks :databricks (mt/db) {:schema-names ["test-data"]
                                                              :table-names ["orders"]}))]
-      ;; Currently we have `test-data` in `metabase_ci` and `metabase_drivers`. Ensure the underlying sql query
-      ;; does not waste resources by returning for both.
       (testing "Only fks from current catalog are registered"
         (is (= 2 (count fks))))
       (testing "Expected fks are returned"


### PR DESCRIPTION
As per [discussion on slack](https://metaboat.slack.com/archives/C07L35T7UFQ/p1729519730751409?thread_ts=1729512048.097999&cid=C07L35T7UFQ), federated catalogs info must be searched in system's information schema. This PR adjusts sync to do that.