### PR TITLE
Reset join condition state when the rhs table changes

### DIFF
--- a/frontend/src/metabase/querying/notebook/components/JoinStep/JoinComplete/JoinComplete.tsx
+++ b/frontend/src/metabase/querying/notebook/components/JoinStep/JoinComplete/JoinComplete.tsx
@@ -69,6 +69,7 @@ export function JoinComplete({
     } else {
       onDraftRhsTableChange(newTable);
     }
+    setIsAddingNewCondition(false);
   };
 
   const handleAddCondition = (newCondition: Lib.JoinCondition) => {

--- a/frontend/src/metabase/querying/notebook/components/JoinStep/JoinConditionDraft/JoinConditionDraft.tsx
+++ b/frontend/src/metabase/querying/notebook/components/JoinStep/JoinConditionDraft/JoinConditionDraft.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useLayoutEffect, useState } from "react";
 
 import { Box, Flex } from "metabase/ui";
 import * as Lib from "metabase-lib";
@@ -76,6 +76,13 @@ export function JoinConditionDraft({
     setRhsColumn(newRhsColumn);
     handleColumnChange(lhsColumn, newRhsColumn);
   };
+
+  useLayoutEffect(() => {
+    setLhsColumn(undefined);
+    setRhsColumn(undefined);
+    setIsLhsOpened(true);
+    setIsRhsOpened(false);
+  }, [joinable]);
 
   return (
     <JoinConditionRoot>

--- a/frontend/src/metabase/querying/notebook/components/JoinStep/JoinConditionDraft/JoinConditionDraft.tsx
+++ b/frontend/src/metabase/querying/notebook/components/JoinStep/JoinConditionDraft/JoinConditionDraft.tsx
@@ -16,6 +16,7 @@ interface JoinConditionDraftProps {
   stageIndex: number;
   joinable: Lib.JoinOrJoinable;
   lhsTableName: string;
+  rhsTable?: Lib.Joinable;
   rhsTableName: string | undefined;
   isReadOnly: boolean;
   isRemovable: boolean;
@@ -29,6 +30,7 @@ export function JoinConditionDraft({
   stageIndex,
   joinable,
   lhsTableName,
+  rhsTable,
   rhsTableName,
   isReadOnly,
   isRemovable,
@@ -82,7 +84,7 @@ export function JoinConditionDraft({
     setRhsColumn(undefined);
     setIsLhsOpened(true);
     setIsRhsOpened(false);
-  }, [joinable]);
+  }, [rhsTable]);
 
   return (
     <JoinConditionRoot>

--- a/frontend/src/metabase/querying/notebook/components/JoinStep/JoinDraft/JoinDraft.tsx
+++ b/frontend/src/metabase/querying/notebook/components/JoinStep/JoinDraft/JoinDraft.tsx
@@ -33,7 +33,6 @@ export function JoinDraft({
   isReadOnly,
   onJoinChange,
 }: JoinDraftProps) {
-  const databaseId = Lib.databaseID(query);
   const sourceTableId = Lib.sourceTableOrCardId(query);
   const [strategy, setStrategy] = useState(
     () => initialStrategy ?? getDefaultJoinStrategy(query, stageIndex),
@@ -99,7 +98,7 @@ export function JoinDraft({
   const handleResetRef = useLatest(handleReset);
   useLayoutEffect(
     () => handleResetRef.current(),
-    [databaseId, sourceTableId, handleResetRef],
+    [sourceTableId, handleResetRef],
   );
 
   return (

--- a/frontend/src/metabase/querying/notebook/components/JoinStep/JoinDraft/JoinDraft.tsx
+++ b/frontend/src/metabase/querying/notebook/components/JoinStep/JoinDraft/JoinDraft.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useLayoutEffect, useMemo, useState } from "react";
 import { useLatest } from "react-use";
 import { t } from "ttag";
 
@@ -34,6 +34,7 @@ export function JoinDraft({
   onJoinChange,
 }: JoinDraftProps) {
   const databaseId = Lib.databaseID(query);
+  const sourceTableId = Lib.sourceTableOrCardId(query);
   const [strategy, setStrategy] = useState(
     () => initialStrategy ?? getDefaultJoinStrategy(query, stageIndex),
   );
@@ -87,23 +88,18 @@ export function JoinDraft({
     }
   };
 
-  const resetStateRef = useLatest(() => {
-    const rhsTableColumns = initialRhsTable
-      ? Lib.joinableColumns(query, stageIndex, initialRhsTable)
-      : [];
-
-    setStrategy(initialStrategy ?? getDefaultJoinStrategy(query, stageIndex));
-    setRhsTable(initialRhsTable);
-    setRhsTableColumns(rhsTableColumns);
-    setSelectedRhsTableColumns(rhsTableColumns);
+  const handleReset = () => {
+    setStrategy(getDefaultJoinStrategy(query, stageIndex));
+    setRhsTable(undefined);
+    setRhsTableColumns([]);
+    setSelectedRhsTableColumns([]);
     setLhsColumn(undefined);
-  });
+  };
 
-  useEffect(
-    function resetStateOnDatabaseChange() {
-      resetStateRef.current();
-    },
-    [databaseId, resetStateRef],
+  const handleResetRef = useLatest(handleReset);
+  useLayoutEffect(
+    () => handleResetRef.current(),
+    [databaseId, sourceTableId, handleResetRef],
   );
 
   return (

--- a/frontend/src/metabase/querying/notebook/components/JoinStep/JoinDraft/JoinDraft.tsx
+++ b/frontend/src/metabase/querying/notebook/components/JoinStep/JoinDraft/JoinDraft.tsx
@@ -148,6 +148,7 @@ export function JoinDraft({
               stageIndex={stageIndex}
               joinable={rhsTable}
               lhsTableName={lhsTableName}
+              rhsTable={rhsTable}
               rhsTableName={rhsTableName}
               isReadOnly={isReadOnly}
               isRemovable={false}

--- a/frontend/src/metabase/querying/notebook/components/JoinStep/JoinDraft/JoinDraft.tsx
+++ b/frontend/src/metabase/querying/notebook/components/JoinStep/JoinDraft/JoinDraft.tsx
@@ -88,10 +88,13 @@ export function JoinDraft({
   };
 
   const handleReset = () => {
-    setStrategy(getDefaultJoinStrategy(query, stageIndex));
-    setRhsTable(undefined);
-    setRhsTableColumns([]);
-    setSelectedRhsTableColumns([]);
+    const rhsTableColumns = initialRhsTable
+      ? Lib.joinableColumns(query, stageIndex, initialRhsTable)
+      : [];
+    setStrategy(initialStrategy ?? getDefaultJoinStrategy(query, stageIndex));
+    setRhsTable(initialRhsTable);
+    setRhsTableColumns(rhsTableColumns);
+    setSelectedRhsTableColumns(rhsTableColumns);
     setLhsColumn(undefined);
   };
 

--- a/frontend/src/metabase/querying/notebook/components/JoinStep/JoinStep.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/JoinStep/JoinStep.unit.spec.tsx
@@ -559,6 +559,30 @@ describe("Notebook Editor > Join Step", () => {
     expect(condition.operator.shortName).toBe("!=");
   });
 
+  it("should reset the draft join condition state when the rhs table is changed", async () => {
+    setup();
+    const rhsTablePicker = screen.getByLabelText("Right table");
+    await userEvent.click(within(rhsTablePicker).getByRole("button"));
+    const entityPickerModal = await screen.findByTestId("entity-picker-modal");
+    await waitForLoaderToBeRemoved();
+    await userEvent.click(within(entityPickerModal).getByText("Reviews"));
+    const lhsColumnPicker = await screen.findByTestId("lhs-column-picker");
+    await userEvent.click(within(lhsColumnPicker).getByText("ID"));
+
+    const newRhsTablePicker = screen.getByLabelText("Right table");
+    await userEvent.click(within(newRhsTablePicker).getByText("Reviews"));
+    const newEntityPickerModal = await screen.findByTestId(
+      "entity-picker-modal",
+    );
+    await waitForLoaderToBeRemoved();
+    await userEvent.click(within(newEntityPickerModal).getByText("Orders"));
+    const newLhsColumn = screen.getByLabelText("Left column");
+    expect(
+      within(newLhsColumn).getByText("Pick a column…"),
+    ).toBeInTheDocument();
+    expect(within(newLhsColumn).queryByText("ID")).not.toBeInTheDocument();
+  });
+
   describe("join strategies", () => {
     it("should be able to change the join strategy for a new join clause", async () => {
       const { getRecentJoin } = setup();

--- a/frontend/src/metabase/querying/notebook/components/JoinStep/JoinStep.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/JoinStep/JoinStep.unit.spec.tsx
@@ -576,11 +576,9 @@ describe("Notebook Editor > Join Step", () => {
     );
     await waitForLoaderToBeRemoved();
     await userEvent.click(within(newEntityPickerModal).getByText("Orders"));
-    const newLhsColumn = screen.getByLabelText("Left column");
-    expect(
-      within(newLhsColumn).getByText("Pick a column…"),
-    ).toBeInTheDocument();
-    expect(within(newLhsColumn).queryByText("ID")).not.toBeInTheDocument();
+    const lhsColumn = screen.getByLabelText("Left column");
+    expect(within(lhsColumn).getByText("Pick a column…")).toBeInTheDocument();
+    expect(within(lhsColumn).queryByText("ID")).not.toBeInTheDocument();
   });
 
   describe("join strategies", () => {

--- a/frontend/src/metabase/querying/notebook/components/NotebookStepList/NotebookStepList.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookStepList/NotebookStepList.tsx
@@ -1,8 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
 
-import { useSelector } from "metabase/lib/redux";
 import { getQuestionSteps } from "metabase/querying/notebook/utils/steps";
-import { getMetadata } from "metabase/selectors/metadata";
 import type { Query } from "metabase-lib";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
@@ -39,7 +37,7 @@ export function NotebookStepList({
   updateQuestion,
   readOnly = false,
 }: NotebookStepListProps) {
-  const metadata = useSelector(getMetadata);
+  const metadata = question.metadata();
   const [openSteps, setOpenSteps] = useState<OpenSteps>(
     getInitialOpenSteps(question, readOnly),
   );


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/46675

Case 1: source table change
- New -> Question -> Orders
- Join -> Reviews -> ID (LHS column). Do not pick the RHS column.
- Click on Orders -> Change to Products
- The draft join state should be reset; Reviews should not be present

Case 2: RHS table change
- New -> Question -> Orders
- Join -> Reviews -> ID (LHS column). Do not pick the RHS column.
- Click on Reviews -> Change to Orders
- The draft join state should be reset; the LHS column should not be selected and there should be a column picker opened.

<img width="1088" alt="Screenshot 2024-10-21 at 15 24 40" src="https://github.com/user-attachments/assets/18945de9-99ba-451e-8346-2153620d3e60">
