### PR TITLE
Fix native query preview for mongo

### DIFF
--- a/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
@@ -1,5 +1,7 @@
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
+  type NativeQuestionDetails,
+  createNativeQuestion,
   createQuestion,
   getNotebookStep,
   modal,
@@ -228,4 +230,66 @@ describe("issue 39487", () => {
   function previousButton() {
     return popover().get("button[data-previous]");
   }
+});
+
+const MONGO_DB_ID = 2;
+
+describe("issue 47793", () => {
+  const questionDetails: NativeQuestionDetails = {
+    database: MONGO_DB_ID,
+    native: {
+      query: `[
+  { $match: { quantity: {{quantity}} }},
+  {
+    "$project": {
+      "_id": "$_id",
+      "id": "$id",
+      "user_id": "$user_id",
+      "product_id": "$product_id",
+      "subtotal": "$subtotal",
+      "tax": "$tax",
+      "total": "$total",
+      "created_at": "$created_at",
+      "quantity": "$quantity",
+      "discount": "$discount"
+    }
+  },
+  {
+    "$limit": 1048575
+  }
+]`,
+      "template-tags": {
+        quantity: {
+          type: "number",
+          name: "quantity",
+          id: "754ae827-661c-4fc9-b511-c0fb7b6bae2b",
+          "display-name": "Quantity",
+          default: "10",
+        },
+      },
+      collection: "orders",
+    },
+  };
+
+  beforeEach(() => {
+    restore("mongo-5");
+    cy.signInAsNormalUser();
+  });
+
+  it(
+    "should be able to preview queries for mongodb (metabase#47793)",
+    { tags: ["@external", "@mongo"] },
+    () => {
+      createNativeQuestion(questionDetails, { visitQuestion: true });
+      cy.findByTestId("visibility-toggler")
+        .findByText(/open editor/i)
+        .click();
+      cy.findByTestId("native-query-editor-container")
+        .findByLabelText("Preview the query")
+        .click();
+      modal()
+        .should("contain.text", "$project")
+        .and("contain.text", "quantity: 10");
+    },
+  );
 });

--- a/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
@@ -273,7 +273,7 @@ describe("issue 47793", () => {
 
   beforeEach(() => {
     restore("mongo-5");
-    cy.signInAsNormalUser();
+    cy.signInAsAdmin();
   });
 
   it(

--- a/frontend/src/metabase/lib/engine.ts
+++ b/frontend/src/metabase/lib/engine.ts
@@ -41,8 +41,8 @@ export function formatNativeQuery(query?: string | JSONQuery, engine?: string) {
     return formatSQL(query);
   }
 
-  if (typeof query === "object" && engineType === "json") {
-    return formatJsonQuery(query);
+  if (engineType === "json") {
+    return typeof query === "object" ? formatJsonQuery(query) : query;
   }
 
   return undefined;

--- a/frontend/src/metabase/lib/engine.unit.spec.ts
+++ b/frontend/src/metabase/lib/engine.unit.spec.ts
@@ -85,10 +85,6 @@ describe("formatNativeQuery", () => {
   });
 
   it("should return `undefined` when the query and the engine don't match", () => {
-    expect(formatNativeQuery("select 1", "mongo")).toBeUndefined();
-    expect(formatNativeQuery("foo bar baz", "mongo")).toBeUndefined();
-    expect(formatNativeQuery("", "mongo")).toBeUndefined();
-
     expect(formatNativeQuery({}, "postgres")).toBeUndefined();
     expect(formatNativeQuery([], "postgres")).toBeUndefined();
     expect(formatNativeQuery([{}], "postgres")).toBeUndefined();
@@ -117,6 +113,7 @@ describe("formatNativeQuery", () => {
     expect(formatNativeQuery([], "mongo")).toEqual("[]");
     expect(formatNativeQuery(["foo"], "mongo")).toEqual('[\n  "foo"\n]');
     expect(formatNativeQuery({ a: 1 }, "mongo")).toEqual('{\n  "a": 1\n}');
+    expect(formatNativeQuery('["foo"]', "mongo")).toEqual('["foo"]');
   });
 });
 


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/47793

How to verify:
- Add MongoDB sample DB
- New -> Question -> Orders -> Save
- Conver to Native
- Add a variable like `{ $match: { quantity: {{quantity}} }}` (see the included e2e test for the whole query)
- Click Preview
- It should work

<img width="1325" alt="Screenshot 2024-10-21 at 23 05 47" src="https://github.com/user-attachments/assets/dc0c70ab-c585-49fc-9617-d5634efb153b">
