### PR TITLE
Ensure that correct error messages show up in the Edit user modal

### DIFF
--- a/e2e/test/scenarios/admin-2/people.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/people.cy.spec.js
@@ -255,9 +255,17 @@ describe("scenarios > admin > people", () => {
       showUserOptions(normalUserName);
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Edit user").click();
-      cy.findByDisplayValue(normal.first_name).click().clear().type(NEW_NAME);
 
-      clickButton("Update");
+      modal().within(() => {
+        cy.log("Should display error messages (metabase#46449)");
+        cy.findByLabelText("First name").click().clear().type(" ");
+        clickButton("Update");
+        cy.findByText(/non-blank string./).should("exist");
+
+        cy.findByLabelText("First name").click().clear().type(NEW_NAME);
+        clickButton("Update", { timeout: 4000 });
+      });
+
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(NEW_FULL_NAME);
       cy.location().should(loc => expect(loc.pathname).to.eq("/admin/people"));
@@ -872,8 +880,8 @@ function showUserOptions(full_name) {
     });
 }
 
-function clickButton(button_name) {
-  cy.button(button_name).should("not.be.disabled").click();
+function clickButton(button_name, opts = {}) {
+  cy.button(button_name, opts).should("not.be.disabled").click();
 }
 
 function assertTableRowsCount(length) {

--- a/frontend/src/metabase/redux/user.ts
+++ b/frontend/src/metabase/redux/user.ts
@@ -43,7 +43,8 @@ export const currentUser = createReducer<User | null>(null, builder => {
       return state;
     })
     .addCase(Users.actionTypes.UPDATE, (state, { payload }) => {
-      const isCurrentUserUpdated = state?.id === payload.user.id;
+      const isCurrentUserUpdated =
+        payload.user && state?.id === payload.user.id;
       if (isCurrentUserUpdated) {
         return {
           ...state,


### PR DESCRIPTION
Fixes #46449

On master, in the edit user modal (at `/admin/people`), if you enter a space as the first name, the form will be rejected with the unhelpful error message `Cannot read properties of undefined`:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/fb972811-a927-451d-bb16-38f4e24dbb2f.png)

If you go offline and try to edit a user you'll see the same error message:

![image](https://github.com/user-attachments/assets/9b6f9132-5963-45a5-8940-6e6c4dff95fb)

On this branch, if you enter a space for a first name, you'll see the expected error message:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/2a84023b-6e0c-4f06-a649-15f350c56c72.png)

If you go offline, you'll see a more reasonable generic error:

![image](https://github.com/user-attachments/assets/a2af422a-f1ca-464a-b7c5-6840f83f83f6)

