### PR TITLE
Disable github actions running on a cron for forks

### DIFF
--- a/.github/workflows/backend-cloverage.yml
+++ b/.github/workflows/backend-cloverage.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   be-linter-cloverage:
+    # don't run this workflow on a cron for forks
+    if: ${{ github.event_name != 'schedule' || github.repository == 'metabase/metabase' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     steps:

--- a/.github/workflows/e2e-cross-version.yml
+++ b/.github/workflows/e2e-cross-version.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   files-changed:
     name: Check which files changed
+    # don't run this workflow on a cron for forks
+    if: ${{ github.event_name != 'schedule' || github.repository == 'metabase/metabase' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 3
     outputs:

--- a/.github/workflows/flake-issue-creator.yml
+++ b/.github/workflows/flake-issue-creator.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   flake-issue-creator:
+    # don't run this workflow on a cron for forks
+    if: ${{ github.event_name != 'schedule' || github.repository == 'metabase/metabase' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:

--- a/.github/workflows/flake-status.yml
+++ b/.github/workflows/flake-status.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   flake-status-report:
+    # don't run this workflow on a cron for forks
+    if: ${{ github.event_name != 'schedule' || github.repository == 'metabase/metabase' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:

--- a/.github/workflows/release-log.yml
+++ b/.github/workflows/release-log.yml
@@ -21,6 +21,8 @@ jobs:
   update-release-log:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # don't run this workflow on a cron for forks
+    if: ${{ github.event_name != 'schedule' || github.repository == 'metabase/metabase' }}
     env:
       VERSION: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call')
         && inputs.version || vars.CURRENT_VERSION }}

--- a/.github/workflows/release-patch.yml
+++ b/.github/workflows/release-patch.yml
@@ -13,6 +13,8 @@ on:
 
 jobs:
   auto-patch-trigger:
+    # don't run this workflow on a cron for forks
+    if: ${{ github.event_name != 'schedule' || github.repository == 'metabase/metabase' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:

--- a/.github/workflows/release-status.yml
+++ b/.github/workflows/release-status.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   check-release-status:
+    # don't run this workflow on a cron for forks
+    if: ${{ github.event_name != 'schedule' || github.repository == 'metabase/metabase' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -16,6 +16,8 @@ on:
 
 jobs:
   monitor:
+    # don't run this workflow on a cron for forks
+    if: ${{ github.event_name != 'schedule' || github.repository == 'metabase/metabase' }}
     name: Generate Snyk report
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,6 +8,8 @@ permissions:
 
 jobs:
   close-stale-prs:
+    # don't run this workflow on a cron for forks
+    if: ${{ github.event_name != 'schedule' || github.repository == 'metabase/metabase' }}
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/stale@v6


### PR DESCRIPTION
Forks generally shouldn't be running these sorts of administrative workflows, it's just a waste of CI time if they work at all.
