### PR TITLE
FE - Do not add extra filtering stage for pivot tables

### DIFF
--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-query-stages.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-query-stages.cy.spec.ts
@@ -1,6 +1,5 @@
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
-  type StructuredQuestionDetails,
   changeSynchronousBatchUpdateSetting,
   createDashboardWithTabs,
   createQuestion,
@@ -2362,37 +2361,30 @@ function createQ9Query(source: Card): StructuredQuery {
 
 type CreateQuery = (source: Card) => StructuredQuery;
 
-function createAndVisitDashboardWithCardMatrix(
-  createQuery: CreateQuery,
-  questionDetails?: Partial<StructuredQuestionDetails>,
-) {
+function createAndVisitDashboardWithCardMatrix(createQuery: CreateQuery) {
   cy.then(function () {
     createQuestion({
       type: "question",
       query: createQuery(this.baseQuestion),
       name: "Question-based Question",
-      ...questionDetails,
     }).then(response => cy.wrap(response.body).as("qbq"));
 
     createQuestion({
       type: "question",
       query: createQuery(this.baseModel),
       name: "Model-based Question",
-      ...questionDetails,
     }).then(response => cy.wrap(response.body).as("mbq"));
 
     createQuestion({
       type: "model",
       name: "Question-based Model",
       query: createQuery(this.baseQuestion),
-      ...questionDetails,
     }).then(response => cy.wrap(response.body).as("qbm"));
 
     createQuestion({
       type: "model",
       name: "Model-based Model",
       query: createQuery(this.baseModel),
-      ...questionDetails,
     }).then(response => cy.wrap(response.body).as("mbm"));
   });
 

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/Filter.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/Filter.tsx
@@ -46,7 +46,7 @@ const FilterInner = ({
     handleReset,
     handleSubmit,
     handleSearch,
-  } = useFilterModal(question.query(), onQueryChange);
+  } = useFilterModal(question, onQueryChange);
 
   const onApplyFilters = () => {
     handleSubmit();

--- a/frontend/src/metabase-lib/v1/Question.ts
+++ b/frontend/src/metabase-lib/v1/Question.ts
@@ -324,6 +324,22 @@ class Question {
     return this.setDisplay(display).updateSettings(settings);
   }
 
+  /**
+   * This function is used to conditionally avoid calling Lib.ensureFilterStage for pivoted questions.
+   * Pivot tables cannot work when there is an extra stage added on top of breakouts and aggregations.
+   */
+  isPivoted(): boolean {
+    const display = this.display();
+    const settings = this.settings();
+    const isPivotViz = display === "pivot";
+    const isPivotedTableViz =
+      display === "table" &&
+      settings["table.pivot_column"] != null &&
+      settings["table.cell_column"] != null;
+
+    return isPivotViz || isPivotedTableViz;
+  }
+
   settings(): VisualizationSettings {
     return (this._card && this._card.visualization_settings) || {};
   }

--- a/frontend/src/metabase-lib/v1/parameters/utils/targets.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/targets.ts
@@ -165,8 +165,7 @@ export function getParameterColumns(question: Question, parameter?: Parameter) {
     question.type() !== "question"
       ? question.composeQuestionAdhoc().query()
       : question.query();
-
-  const nextQuery = Lib.ensureFilterStage(query);
+  const nextQuery = question.isPivoted() ? query : Lib.ensureFilterStage(query);
 
   if (parameter && isTemporalUnitParameter(parameter)) {
     const needsFilterStage = Lib.stageCount(query) < Lib.stageCount(nextQuery);

--- a/frontend/src/metabase/dashboard/actions/getNewCardUrl.ts
+++ b/frontend/src/metabase/dashboard/actions/getNewCardUrl.ts
@@ -52,8 +52,13 @@ export const getNewCardUrl = ({
   if (isEditable) {
     nextQuestion = new Question(cardAfterClick, metadata);
 
+    if (!nextQuestion.isPivoted()) {
+      nextQuestion = nextQuestion.setQuery(
+        Lib.ensureFilterStage(nextQuestion.query()),
+      );
+    }
+
     nextQuestion = nextQuestion
-      .setQuery(Lib.ensureFilterStage(nextQuestion.query()))
       .setDisplay(cardAfterClick.display || previousCard.display)
       .setSettings(dashcard.card.visualization_settings)
       .lockDisplay();

--- a/frontend/src/metabase/query_builder/components/QueryModals/QueryModals.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryModals/QueryModals.tsx
@@ -222,7 +222,7 @@ export function QueryModals({
     case MODAL_TYPES.FILTERS:
       return (
         <FilterModal
-          query={question.query()}
+          question={question}
           onSubmit={onQueryChange}
           onClose={onCloseModal}
         />

--- a/frontend/src/metabase/querying/filters/components/FilterModal/FilterModal.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterModal/FilterModal.tsx
@@ -1,5 +1,6 @@
 import { Flex, Modal } from "metabase/ui";
 import type * as Lib from "metabase-lib";
+import type Question from "metabase-lib/v1/Question";
 
 import { useFilterModal } from "../../hooks/use-filter-modal";
 
@@ -10,16 +11,12 @@ import { FilterModalHeader } from "./FilterModalHeader";
 import { getModalTitle, getModalWidth } from "./utils";
 
 export interface FilterModalProps {
-  query: Lib.Query;
+  question: Question;
   onSubmit: (newQuery: Lib.Query) => void;
   onClose: () => void;
 }
 
-export function FilterModal({
-  query: initialQuery,
-  onSubmit,
-  onClose,
-}: FilterModalProps) {
+export function FilterModal({ question, onSubmit, onClose }: FilterModalProps) {
   const {
     query,
     version,
@@ -36,7 +33,7 @@ export function FilterModal({
     handleReset,
     handleSubmit,
     handleSearch,
-  } = useFilterModal(initialQuery, onSubmit);
+  } = useFilterModal(question, onSubmit);
 
   const onSubmitFilters = () => {
     handleSubmit();

--- a/frontend/src/metabase/querying/filters/components/FilterModal/FilterModal.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterModal/FilterModal.unit.spec.tsx
@@ -17,6 +17,7 @@ import {
   createQueryWithClauses,
 } from "metabase-lib/test-helpers";
 import Question from "metabase-lib/v1/Question";
+import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import { createMockCard, createMockField } from "metabase-types/api/mocks";
 import {
   ORDERS_ID,
@@ -28,14 +29,13 @@ import { FilterModal } from "./FilterModal";
 
 interface SetupOpts {
   query: Lib.Query;
+  metadata?: Metadata;
 }
 
-function setup({ query }: SetupOpts) {
+function setup({ query, metadata = SAMPLE_METADATA }: SetupOpts) {
   const onSubmit = jest.fn();
   const onClose = jest.fn();
-  const question = new Question(createMockCard(), SAMPLE_METADATA).setQuery(
-    query,
-  );
+  const question = new Question(createMockCard(), metadata).setQuery(query);
 
   setupFieldsValuesEndpoints(SAMPLE_DB_FIELD_VALUES);
 
@@ -123,7 +123,10 @@ describe("FilterModal", () => {
       databases: [createSampleDatabase()],
       fields: [unknownField],
     });
-    const { getNextQuery } = setup({ query: createQuery({ metadata }) });
+    const { getNextQuery } = setup({
+      query: createQuery({ metadata }),
+      metadata,
+    });
 
     const columnSection = screen.getByTestId(`filter-column-Unknown`);
     await userEvent.click(within(columnSection).getByLabelText("Is empty"));

--- a/frontend/src/metabase/querying/filters/components/FilterModal/FilterModal.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterModal/FilterModal.unit.spec.tsx
@@ -11,11 +11,13 @@ import {
 } from "__support__/ui";
 import * as Lib from "metabase-lib";
 import {
+  SAMPLE_METADATA,
   columnFinder,
   createQuery,
   createQueryWithClauses,
 } from "metabase-lib/test-helpers";
-import { createMockField } from "metabase-types/api/mocks";
+import Question from "metabase-lib/v1/Question";
+import { createMockCard, createMockField } from "metabase-types/api/mocks";
 import {
   ORDERS_ID,
   SAMPLE_DB_FIELD_VALUES,
@@ -31,11 +33,14 @@ interface SetupOpts {
 function setup({ query }: SetupOpts) {
   const onSubmit = jest.fn();
   const onClose = jest.fn();
+  const question = new Question(createMockCard(), SAMPLE_METADATA).setQuery(
+    query,
+  );
 
   setupFieldsValuesEndpoints(SAMPLE_DB_FIELD_VALUES);
 
   renderWithProviders(
-    <FilterModal query={query} onSubmit={onSubmit} onClose={onClose} />,
+    <FilterModal question={question} onSubmit={onSubmit} onClose={onClose} />,
   );
 
   const getNextQuery = () => {

--- a/frontend/src/metabase/querying/filters/hooks/use-filter-modal/use-filter-modal.ts
+++ b/frontend/src/metabase/querying/filters/hooks/use-filter-modal/use-filter-modal.ts
@@ -1,6 +1,7 @@
 import { useMemo, useRef, useState } from "react";
 
 import * as Lib from "metabase-lib";
+import type Question from "metabase-lib/v1/Question";
 
 import { getGroupItems, hasFilters, removeFilters } from "../../utils";
 
@@ -8,10 +9,14 @@ import { SEARCH_KEY } from "./constants";
 import { isSearchActive, searchGroupItems } from "./utils";
 
 export const useFilterModal = (
-  initialQuery: Lib.Query,
+  question: Question,
   onSubmit: (newQuery: Lib.Query) => void,
 ) => {
-  const [query, setQuery] = useState(() => Lib.ensureFilterStage(initialQuery));
+  const [query, setQuery] = useState(() =>
+    question.isPivoted()
+      ? question.query()
+      : Lib.ensureFilterStage(question.query()),
+  );
   const queryRef = useRef(query);
   const [version, setVersion] = useState(1);
   const [isChanged, setIsChanged] = useState(false);


### PR DESCRIPTION
Closes #48885

### Description

Pivot tables cannot work when there is an extra stage added on top of breakouts and aggregations.
This PR ensures that FE will not call `Lib.ensureFilterStage` for pivoted questions.

[BE part](https://github.com/metabase/metabase/issues/48884) will be implemented separately (it should address the 3 remaining failing tests). 


### How to verify

It should not be possible to filter on aggregation and breakout columns from last stage of pivoted questions in dashboards, filter modal and custom click behavior with question as target. It should still be possible to add more stages for such questions in the notebook editor.

Only 3 tests should be failing in CI (should be fixed by [BE part](https://github.com/metabase/metabase/issues/48884)):
- `multiple-column-breakouts.cy.spec.ts`
    - `should be able to use temporal-unit parameters with multiple temporal breakouts of a column`
- `temporal-unit-parameters.cy.spec.js`
    - `should connect a parameter to a question and drill thru`
    - `should connect multiple parameters to a card with multiple breakouts and drill thru`

This one should no longer fail:
- `visualizations-tabular/pivot_tables.cy.spec.js`
    - `should allow filtering drill through (metabase#14632) (metabase#14465)`

