### PR TITLE
Automate npm dist-tags

### DIFF
--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -50,7 +50,7 @@ jobs:
         id: current-sdk-version
         run: |
           VERSION=$(jq -r .version ./enterprise/frontend/src/embedding-sdk/package.template.json)
-          echo "::set-output name=sdk_current_version::$VERSION"
+          echo "sdk_current_version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Get next SDK patch version
         id: new-sdk-version

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -250,7 +250,7 @@ jobs:
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
           npm publish --tag ${{fromJson('{"master": "canary", "release-x.51.x": "50-stable"}')[inputs.branch]}}
 
-      - name: Add `latest` tag to `release-x.51.x` branch deployment
+      - name: Add `latest` tag to the latest release branch (`release-x.51.x`) deployment
         if: ${{ inputs.branch == 'release-x.51.x' }}
         run: |
           npm dist-tag add @metabase/embedding-sdk-react@${{ env.sdk_version }} latest

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -248,7 +248,8 @@ jobs:
         run: |
           cd sdk
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
-          npm publish --tag ${{fromJson('{"master": "canary", "release-x.51.x": "50-stable"}')[inputs.branch]}}
+          # Please keep the value in sync with `inputs.branch`'s release branch
+          npm publish --tag ${{fromJson('{"master": "canary", "release-x.51.x": "51-stable"}')[inputs.branch]}}
 
       - name: Add `latest` tag to the latest release branch (`release-x.51.x`) deployment
         if: ${{ inputs.branch == 'release-x.51.x' }}

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -3,7 +3,6 @@ name: Release Metabase Embedding SDK for React
 on:
   workflow_dispatch:
     inputs:
-      # TODO: Add a version validation, so the workflow won't fail when publishing to npm
       branch:
         description: "Branch we want to release the SDK from"
         type: choice

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -248,7 +248,12 @@ jobs:
         run: |
           cd sdk
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
-          npm publish
+          npm publish --tag ${{fromJson('{"master": "canary", "release-x.51.x": "50-stable"}')[inputs.branch]}}
+
+      - name: Add `latest` tag to `release-x.51.x` branch deployment
+        if: ${{ inputs.branch == 'release-x.51.x' }}
+        run: |
+          npm dist-tag add @metabase/embedding-sdk-react@${{ env.sdk_version }} latest
 
   git-tag:
     needs: [publish-npm, determine-version]


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/48974
[Release workflow](https://github.com/metabase/metabase/actions/workflows/release-embedding-sdk.yml)

> [!note]
> There are 2 more PRs that modify the changelog in both master and release branch to be correct. These 2 PRs should be merged before this PR to allow the future chaneglog to be correct.
> - https://github.com/metabase/metabase/pull/48984
> - https://github.com/metabase/metabase/pull/48985

### Description

When publishing from the release branch `release-x.51.x`
- Publish the package with `51-stable` dist tags
- Add an additional `latest` tag

When publishing from `master` branch
- Publish the package with `canary` dist tags

### How to verify

All runs are tested with this commit e316be0eba7f67e5dfa6e604089f665035fcb98e

This commits prevent the following actions from happening:
- npm publish: with `--dry-run` tag
- Docs PR merge
- new git tag push


#### master branch
- [Docs PR](https://github.com/metabase/metabase/pull/48983)
- [Deployment run](https://github.com/metabase/metabase/actions/runs/11457709447)

#### release-x.51.x branch
- [Docs PR](https://github.com/metabase/metabase/pull/48979)
- [Deployment run](https://github.com/metabase/metabase/actions/runs/11457238807)
  - [Publish with `50-stable` tag](https://github.com/metabase/metabase/actions/runs/11457238807/job/31877644226#step:13:5055)
  - [Additional `latest` tag is added](https://github.com/metabase/metabase/actions/runs/11457238807/job/31877644226#step:14:9)

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~ Manual tests are performed above
