### PR TITLE
Add `use-temp-storage` hook

### DIFF
--- a/frontend/src/metabase-types/store/app.ts
+++ b/frontend/src/metabase-types/store/app.ts
@@ -14,9 +14,20 @@ export interface AppBreadCrumbs {
   show: boolean;
 }
 
-export interface AppState {
+/**
+ * Storage for non-critical, ephemeral user preferences.
+ * Think of it as a sessionStorage alternative implemented in Redux.
+ * Only specific key/value pairs can be stored here,
+ * and then later used with the `use-temp-storage` hook.
+ */
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type TempStorage = {};
+
+interface BaseAppState {
   errorPage: AppErrorDescriptor | null;
   isNavbarOpen: boolean;
   isDndAvailable: boolean;
   isErrorDiagnosticsOpen: boolean;
 }
+
+export type AppState = BaseAppState & TempStorage;

--- a/frontend/src/metabase-types/store/app.ts
+++ b/frontend/src/metabase-types/store/app.ts
@@ -23,11 +23,13 @@ export interface AppBreadCrumbs {
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type TempStorage = {};
 
-interface BaseAppState {
+export type TempStorageKey = keyof TempStorage;
+export type TempStorageValue<Key extends TempStorageKey> = TempStorage[Key];
+
+export interface AppState {
   errorPage: AppErrorDescriptor | null;
   isNavbarOpen: boolean;
   isDndAvailable: boolean;
   isErrorDiagnosticsOpen: boolean;
+  tempStorage: TempStorage;
 }
-
-export type AppState = BaseAppState & TempStorage;

--- a/frontend/src/metabase-types/store/app.ts
+++ b/frontend/src/metabase-types/store/app.ts
@@ -24,7 +24,8 @@ export interface AppBreadCrumbs {
 export type TempStorage = {};
 
 export type TempStorageKey = keyof TempStorage;
-export type TempStorageValue<Key extends TempStorageKey> = TempStorage[Key];
+export type TempStorageValue<Key extends TempStorageKey = TempStorageKey> =
+  TempStorage[Key];
 
 export interface AppState {
   errorPage: AppErrorDescriptor | null;

--- a/frontend/src/metabase-types/store/mocks/app.ts
+++ b/frontend/src/metabase-types/store/mocks/app.ts
@@ -5,5 +5,6 @@ export const createMockAppState = (opts?: Partial<AppState>): AppState => ({
   errorPage: null,
   isDndAvailable: false,
   isErrorDiagnosticsOpen: false,
+  tempStorage: {},
   ...opts,
 });

--- a/frontend/src/metabase/common/hooks/use-temp-storage/index.ts
+++ b/frontend/src/metabase/common/hooks/use-temp-storage/index.ts
@@ -1,0 +1,1 @@
+export * from "./use-temp-storage";

--- a/frontend/src/metabase/common/hooks/use-temp-storage/use-temp-storage.ts
+++ b/frontend/src/metabase/common/hooks/use-temp-storage/use-temp-storage.ts
@@ -16,14 +16,7 @@ export const useTempStorage = <Key extends TempStorageKey>(
 
   const setValue = useCallback(
     (newValue: TempStorageValue<Key>) => {
-      try {
-        dispatch({ type: SET_TEMP_SETTING, payload: { key, value: newValue } });
-      } catch (error) {
-        console.error(
-          `Failed to write to app storage for key "${key}":`,
-          error,
-        );
-      }
+      dispatch({ type: SET_TEMP_SETTING, payload: { key, value: newValue } });
     },
     [dispatch, key],
   );

--- a/frontend/src/metabase/common/hooks/use-temp-storage/use-temp-storage.ts
+++ b/frontend/src/metabase/common/hooks/use-temp-storage/use-temp-storage.ts
@@ -2,17 +2,18 @@ import { useCallback } from "react";
 
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { SET_TEMP_SETTING } from "metabase/redux/app";
-import type { State, TempStorage } from "metabase-types/store";
-
-type TempStorageKey = keyof TempStorage;
-type TempStorageValue<Key extends TempStorageKey> = TempStorage[Key];
+import type {
+  State,
+  TempStorageKey,
+  TempStorageValue,
+} from "metabase-types/store";
 
 export const useTempStorage = <Key extends TempStorageKey>(
   key: Key,
 ): [TempStorageValue<Key>, (newValue: TempStorageValue<Key>) => void] => {
   const dispatch = useDispatch();
 
-  const value = useSelector((state: State) => state.app[key]);
+  const value = useSelector((state: State) => state.app.tempStorage[key]);
 
   const setValue = useCallback(
     (newValue: TempStorageValue<Key>) => {

--- a/frontend/src/metabase/common/hooks/use-temp-storage/use-temp-storage.ts
+++ b/frontend/src/metabase/common/hooks/use-temp-storage/use-temp-storage.ts
@@ -1,7 +1,7 @@
 import { useCallback } from "react";
 
 import { useDispatch, useSelector } from "metabase/lib/redux";
-import { SET_TEMP_SETTING } from "metabase/redux/app";
+import { setTempSetting } from "metabase/redux/app";
 import type {
   State,
   TempStorageKey,
@@ -17,7 +17,7 @@ export const useTempStorage = <Key extends TempStorageKey>(
 
   const setValue = useCallback(
     (newValue: TempStorageValue<Key>) => {
-      dispatch({ type: SET_TEMP_SETTING, payload: { key, value: newValue } });
+      dispatch(setTempSetting({ key, value: newValue }));
     },
     [dispatch, key],
   );

--- a/frontend/src/metabase/common/hooks/use-temp-storage/use-temp-storage.ts
+++ b/frontend/src/metabase/common/hooks/use-temp-storage/use-temp-storage.ts
@@ -1,0 +1,32 @@
+import { useCallback } from "react";
+
+import { useDispatch, useSelector } from "metabase/lib/redux";
+import { SET_TEMP_SETTING } from "metabase/redux/app";
+import type { State, TempStorage } from "metabase-types/store";
+
+type TempStorageKey = keyof TempStorage;
+type TempStorageValue<Key extends TempStorageKey> = TempStorage[Key];
+
+export const useTempStorage = <Key extends TempStorageKey>(
+  key: Key,
+): [TempStorageValue<Key>, (newValue: TempStorageValue<Key>) => void] => {
+  const dispatch = useDispatch();
+
+  const value = useSelector((state: State) => state.app[key]);
+
+  const setValue = useCallback(
+    (newValue: TempStorageValue<Key>) => {
+      try {
+        dispatch({ type: SET_TEMP_SETTING, payload: { key, value: newValue } });
+      } catch (error) {
+        console.error(
+          `Failed to write to app storage for key "${key}":`,
+          error,
+        );
+      }
+    },
+    [dispatch, key],
+  );
+
+  return [value, setValue];
+};

--- a/frontend/src/metabase/common/hooks/use-temp-storage/use-temp-storage.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-temp-storage/use-temp-storage.unit.spec.tsx
@@ -1,0 +1,76 @@
+import userEvent from "@testing-library/user-event";
+
+import { renderWithProviders, screen } from "__support__/ui";
+import type {
+  TempStorage,
+  TempStorageKey,
+  TempStorageValue,
+} from "metabase-types/store";
+import {
+  createMockAppState,
+  createMockState,
+} from "metabase-types/store/mocks";
+
+import { useTempStorage } from "./use-temp-storage";
+
+const TestComponent = ({
+  entry,
+  newValue,
+}: {
+  entry: TempStorageKey;
+  newValue?: TempStorageValue;
+}) => {
+  const [value, setValue] = useTempStorage(entry);
+
+  return (
+    <div>
+      {/* @ts-expect-error - The hook still doesn't accept any k/v pair */}
+      <button onClick={() => setValue(newValue)} />
+      <div data-testid="result">{`Value is: ${value}`}</div>
+    </div>
+  );
+};
+
+type SetupProps = {
+  tempStorage: TempStorage;
+  entry: TempStorageKey;
+  newValue?: TempStorageValue;
+};
+
+const setup = ({ tempStorage = {}, entry, newValue }: SetupProps) => {
+  const initialState = createMockState({
+    app: createMockAppState({ tempStorage }),
+  });
+
+  renderWithProviders(<TestComponent entry={entry} newValue={newValue} />, {
+    storeInitialState: initialState,
+  });
+};
+
+describe("useTempStorage hook", () => {
+  it("should return undefined for uninitialized key", () => {
+    const tempStorage = {
+      animal: undefined,
+    };
+    // @ts-expect-error - The hook still doesn't accept any k/v pair
+    setup({ tempStorage, entry: "animal" });
+
+    expect(screen.getByTestId("result")).toHaveTextContent(
+      "Value is: undefined",
+    );
+  });
+
+  it("should read and set the value", async () => {
+    const tempStorage = {
+      animal: "dog",
+    };
+
+    // @ts-expect-error - The hook still doesn't accept any k/v pair
+    setup({ tempStorage, entry: "animal", newValue: "cat" });
+
+    expect(screen.getByTestId("result")).toHaveTextContent("Value is: dog");
+
+    await userEvent.click(screen.getByRole("button"));
+    expect(screen.getByTestId("result")).toHaveTextContent("Value is: cat");
+  });
+});

--- a/frontend/src/metabase/redux/app.ts
+++ b/frontend/src/metabase/redux/app.ts
@@ -1,4 +1,8 @@
-import { createAction } from "@reduxjs/toolkit";
+import {
+  type PayloadAction,
+  createAction,
+  createSlice,
+} from "@reduxjs/toolkit";
 import { LOCATION_CHANGE, push } from "react-router-redux";
 
 import {
@@ -112,24 +116,23 @@ const isErrorDiagnosticsOpen = handleActions(
   false,
 );
 
-export const SET_TEMP_SETTING = "metabase/app/SET_TEMP_SETTING";
-const tempStorageReducer = (
-  state: TempStorage = {},
-  action: {
-    type: typeof SET_TEMP_SETTING;
-    payload: { key: TempStorageKey; value: TempStorageValue<TempStorageKey> };
+const tempStorageSlice = createSlice({
+  name: "tempStorage",
+  initialState: {} as TempStorage,
+  reducers: {
+    setTempSetting: (
+      state,
+      action: PayloadAction<{
+        key: TempStorageKey;
+        value: TempStorageValue<TempStorageKey>;
+      }>,
+    ) => {
+      state[action.payload.key] = action.payload.value;
+    },
   },
-): TempStorage => {
-  switch (action.type) {
-    case SET_TEMP_SETTING:
-      return {
-        ...state,
-        [action.payload.key]: action.payload.value,
-      };
-    default:
-      return state;
-  }
-};
+});
+
+export const { setTempSetting } = tempStorageSlice.actions;
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export default combineReducers({
@@ -142,5 +145,5 @@ export default combineReducers({
     return true;
   },
   isErrorDiagnosticsOpen,
-  tempStorage: tempStorageReducer,
+  tempStorage: tempStorageSlice.reducer,
 });

--- a/frontend/src/metabase/redux/app.ts
+++ b/frontend/src/metabase/redux/app.ts
@@ -7,7 +7,12 @@ import {
   shouldOpenInBlankWindow,
 } from "metabase/lib/dom";
 import { combineReducers, handleActions } from "metabase/lib/redux";
-import type { Dispatch } from "metabase-types/store";
+import type {
+  Dispatch,
+  TempStorage,
+  TempStorageKey,
+  TempStorageValue,
+} from "metabase-types/store";
 
 interface LocationChangeAction {
   type: string; // "@@router/LOCATION_CHANGE"
@@ -108,6 +113,23 @@ const isErrorDiagnosticsOpen = handleActions(
 );
 
 export const SET_TEMP_SETTING = "metabase/app/SET_TEMP_SETTING";
+const tempStorageReducer = (
+  state: TempStorage = {},
+  action: {
+    type: typeof SET_TEMP_SETTING;
+    payload: { key: TempStorageKey; value: TempStorageValue<TempStorageKey> };
+  },
+): TempStorage => {
+  switch (action.type) {
+    case SET_TEMP_SETTING:
+      return {
+        ...state,
+        [action.payload.key]: action.payload.value,
+      };
+    default:
+      return state;
+  }
+};
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export default combineReducers({
@@ -120,4 +142,5 @@ export default combineReducers({
     return true;
   },
   isErrorDiagnosticsOpen,
+  tempStorage: tempStorageReducer,
 });

--- a/frontend/src/metabase/redux/app.ts
+++ b/frontend/src/metabase/redux/app.ts
@@ -107,6 +107,8 @@ const isErrorDiagnosticsOpen = handleActions(
   false,
 );
 
+export const SET_TEMP_SETTING = "metabase/app/SET_TEMP_SETTING";
+
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export default combineReducers({
   errorPage,


### PR DESCRIPTION
Resolves #48944

- [x] Tests have been added.

Please note:
> [!CAUTION]
> We have to ignore the TS errors in the test since we're initializing this temporary storage without any key/value pairs. We want to be very strict as to which values can be used here. Once we add the first k/v pair to the `TemporaryStorage` type, this test needs to be updated.