### PR TITLE
Analyze native tables more conservatively by default

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -79,7 +79,7 @@
   io.github.eerohele/pp                     {:git/tag "2024-01-04.60"           ; super fast pretty-printing library
                                              :git/sha "a428751"
                                              :git/url "https://github.com/eerohele/pp"}
-  io.github.metabase/macaw                  {:mvn/version "0.2.15"}             ; Parse native SQL queries
+  io.github.metabase/macaw                  {:mvn/version "0.2.18"}             ; Parse native SQL queries
   ;; The 2.X line of Resilience4j requires Java 17, so we cannot upgrade this dependency until that is our minimum JVM version
   io.github.resilience4j/resilience4j-retry {:mvn/version "1.7.1" #_"must be 1.7.1"} ; Support for retrying operations
   io.prometheus/simpleclient_hotspot        {:mvn/version "0.16.0"}             ; prometheus jvm collector

--- a/src/metabase/query_analysis/native_query_analyzer.clj
+++ b/src/metabase/query_analysis/native_query_analyzer.clj
@@ -186,12 +186,13 @@
   [tables db-id]
   (consolidate-tables
    tables
-   (t2/select :model/QueryTable
-              {:select [[:t.id :table-id] [:t.name :table] [:t.schema :schema]]
-               :from   [[(t2/table-name :model/Table) :t]]
-               :where  [:and
-                        [:= :t.db_id db-id]
-                        (into [:or] (map table-query tables))]})))
+   (when (seq tables)
+     (t2/select :model/QueryTable
+                {:select [[:t.id :table-id] [:t.name :table] [:t.schema :schema]]
+                 :from   [[(t2/table-name :model/Table) :t]]
+                 :where  [:and
+                          [:= :t.db_id db-id]
+                          (into [:or] (map table-query tables))]}))))
 
 (defn- fill-missing-table-ids-hack
   "See if we can qualify the schema and table-id for any explicit field refs which couldn't resolve their field"
@@ -285,19 +286,24 @@
     {:tables (strip-model-refs table-refs)
      :fields (strip-model-refs field-refs)}))
 
+(defn- wrap-if-legacy [result]
+  (cond
+    (map? result)     result
+    (keyword? result) {:error result}
+    (coll? result)    {:tables result}
+    :else             result))
+
 (defn- tables-via-macaw
   "Returns a set of table identifiers that (may) be referenced in the given card's query.
   Errs on the side of optimism: i.e., it may return tables that are *not* in the query, and is unlikely to fail
   to return tables that are in the query."
   [driver query & {:keys [mode] :or {mode :basic-select}}]
-  (let [db-id         (:database query)
-        macaw-opts    (nqa.impl/macaw-options driver)
-        table-opts    (assoc macaw-opts :mode mode)
-        sql-string    (:query (nqa.sub/replace-tags query))
-        tables-or-err (macaw/query->tables sql-string table-opts)]
-    (if (keyword? tables-or-err)
-      tables-or-err
-      (table-refs-for-query tables-or-err db-id))))
+  (let [db-id      (:database query)
+        macaw-opts (nqa.impl/macaw-options driver)
+        table-opts (assoc macaw-opts :mode mode)
+        sql-string (:query (nqa.sub/replace-tags query))
+        result     (wrap-if-legacy (macaw/query->tables sql-string table-opts))]
+    (u/update-if-exists result :tables table-refs-for-query db-id)))
 
 ;; Keeping this multimethod private for now, need some hammock time on what to expose to drivers.
 (defmulti ^:private tables-for-native*
@@ -317,7 +323,7 @@
   [driver query opts]
   (if (nqa.impl/trusted-for-table-permissions? driver)
     (tables-via-macaw driver query opts)
-    :query-analysis.error/driver-not-supported))
+    {:error :query-analysis.error/driver-not-supported}))
 
 (defn references-for-native
   "Returns a `{:explicit #{...} :implicit #{...}}` map with field IDs that (may) be referenced in the given card's

--- a/src/metabase/query_analysis/native_query_analyzer.clj
+++ b/src/metabase/query_analysis/native_query_analyzer.clj
@@ -289,13 +289,15 @@
   "Returns a set of table identifiers that (may) be referenced in the given card's query.
   Errs on the side of optimism: i.e., it may return tables that are *not* in the query, and is unlikely to fail
   to return tables that are in the query."
-  [driver query & {:keys [mode] :or {mode :ast-walker-1}}]
+  [driver query & {:keys [mode] :or {mode :basic-select}}]
   (let [db-id        (:database query)
         macaw-opts   (nqa.impl/macaw-options driver)
         table-opts   (assoc macaw-opts :mode mode)
         sql-string   (:query (nqa.sub/replace-tags query))
-        parsed-query (macaw/query->tables sql-string table-opts)]
-    (table-refs-for-query parsed-query db-id)))
+        tables       (macaw/query->tables sql-string table-opts)]
+    (if (keyword? tables)
+      tables
+      (table-refs-for-query tables db-id))))
 
 ;; Keeping this multimethod private for now, need some hammock time on what to expose to drivers.
 (defmulti ^:private tables-for-native*

--- a/src/metabase/query_analysis/native_query_analyzer.clj
+++ b/src/metabase/query_analysis/native_query_analyzer.clj
@@ -290,14 +290,14 @@
   Errs on the side of optimism: i.e., it may return tables that are *not* in the query, and is unlikely to fail
   to return tables that are in the query."
   [driver query & {:keys [mode] :or {mode :basic-select}}]
-  (let [db-id        (:database query)
-        macaw-opts   (nqa.impl/macaw-options driver)
-        table-opts   (assoc macaw-opts :mode mode)
-        sql-string   (:query (nqa.sub/replace-tags query))
-        tables       (macaw/query->tables sql-string table-opts)]
-    (if (keyword? tables)
-      tables
-      (table-refs-for-query tables db-id))))
+  (let [db-id         (:database query)
+        macaw-opts    (nqa.impl/macaw-options driver)
+        table-opts    (assoc macaw-opts :mode mode)
+        sql-string    (:query (nqa.sub/replace-tags query))
+        tables-or-err (macaw/query->tables sql-string table-opts)]
+    (if (keyword? tables-or-err)
+      tables-or-err
+      (table-refs-for-query tables-or-err db-id))))
 
 ;; Keeping this multimethod private for now, need some hammock time on what to expose to drivers.
 (defmulti ^:private tables-for-native*

--- a/test/metabase/query_analysis/native_query_analyzer_test.clj
+++ b/test/metabase/query_analysis/native_query_analyzer_test.clj
@@ -50,15 +50,11 @@
 (defn- table-refs [sql]
   (:tables (refs sql)))
 
-(defn- sort-tables [tables-or-err]
-  (if (keyword? tables-or-err)
-    tables-or-err
-    (sort-by (juxt :schema :table) tables-or-err)))
-
 (defn- basic-table-refs [sql]
   (->> (mt/native-query {:query sql})
        (nqa/tables-for-native)
-       sort-tables))
+       :tables
+       (sort-by (juxt :schema :table))))
 
 (defn- table-reference [table]
   (let [reference (nqa/table-reference (mt/id) table)]

--- a/test/metabase/query_analysis/native_query_analyzer_test.clj
+++ b/test/metabase/query_analysis/native_query_analyzer_test.clj
@@ -50,10 +50,15 @@
 (defn- table-refs [sql]
   (:tables (refs sql)))
 
+(defn- sort-tables [tables]
+  (if (keyword? tables)
+    tables
+    (sort-by (juxt :schema :table) tables)))
+
 (defn- basic-table-refs [sql]
   (->> (mt/native-query {:query sql})
        (nqa/tables-for-native)
-       (sort-by (juxt :schema :table))))
+       sort-tables))
 
 (defn- table-reference [table]
   (let [reference (nqa/table-reference (mt/id) table)]

--- a/test/metabase/query_analysis/native_query_analyzer_test.clj
+++ b/test/metabase/query_analysis/native_query_analyzer_test.clj
@@ -50,10 +50,10 @@
 (defn- table-refs [sql]
   (:tables (refs sql)))
 
-(defn- sort-tables [tables]
-  (if (keyword? tables)
-    tables
-    (sort-by (juxt :schema :table) tables)))
+(defn- sort-tables [tables-or-err]
+  (if (keyword? tables-or-err)
+    tables-or-err
+    (sort-by (juxt :schema :table) tables-or-err)))
 
 (defn- basic-table-refs [sql]
   (->> (mt/native-query {:query sql})


### PR DESCRIPTION
### Description

This is a low level step towards applying table-level permissions to native queries.

It replaces the more generic and powerful `:ast-walker-1` analyzer with the more conservative `:basic-select` version we recently landed. The advantage of this version is that it protects against dynamic table references and false negatives due to masking.