### PR TITLE
Make it possible to remove a broken parameter target when there are no options available

### DIFF
--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -14,6 +14,7 @@ import {
   changeSynchronousBatchUpdateSetting,
   commandPalette,
   commandPaletteSearch,
+  createDashboard,
   createDashboardWithTabs,
   createNativeQuestion,
   createQuestion,
@@ -3805,4 +3806,92 @@ describe("issue 35852", () => {
       });
     });
   }
+});
+
+describe("issue 32573", () => {
+  const modelDetails = {
+    name: "M1",
+    type: "model",
+    query: {
+      "source-table": ORDERS_ID,
+      fields: [["field", ORDERS.TAX, null]],
+    },
+  };
+
+  const parameterDetails = {
+    id: "92eb69ea",
+    name: "ID",
+    sectionId: "id",
+    slug: "id",
+    type: "id",
+    default: 1,
+  };
+
+  const dashboardDetails = {
+    parameters: [parameterDetails],
+  };
+
+  function getQuestionDetails(modelId) {
+    return {
+      name: "Q1",
+      type: "question",
+      query: {
+        "source-table": `card__${modelId}`,
+      },
+    };
+  }
+
+  function getParameterMapping(questionId) {
+    return {
+      card_id: questionId,
+      parameter_id: parameterDetails.id,
+      target: [
+        "dimension",
+        ["field", "ID", { "base-type": "type/BigInteger" }],
+      ],
+    };
+  }
+
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("should not crash a dashboard when there is a missing parameter column (metabase#32573)", () => {
+    createQuestion(modelDetails).then(({ body: model }) => {
+      createQuestion(getQuestionDetails(model.id)).then(
+        ({ body: question }) => {
+          createDashboard(dashboardDetails).then(({ body: dashboard }) => {
+            return cy
+              .request("PUT", `/api/dashboard/${dashboard.id}`, {
+                dashcards: [
+                  createMockDashboardCard({
+                    card_id: question.id,
+                    parameter_mappings: [getParameterMapping(question.id)],
+                    size_x: 6,
+                    size_y: 6,
+                  }),
+                ],
+              })
+              .then(() => visitDashboard(dashboard.id));
+          });
+        },
+      );
+    });
+    getDashboardCard()
+      .findByText("There was a problem displaying this chart.")
+      .should("be.visible");
+
+    editDashboard();
+    cy.findByTestId("fixed-width-filters").findByText("ID").click();
+    getDashboardCard().within(() => {
+      cy.findByText("Unknown Field").should("be.visible");
+      cy.findByLabelText("Disconnect").click();
+    });
+    saveDashboard();
+    getDashboardCard().within(() => {
+      cy.findByText("Q1").should("be.visible");
+      cy.findByText("Tax").should("be.visible");
+    });
+  });
 });

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapperButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapperButton.tsx
@@ -71,6 +71,22 @@ export const DashCardCardParameterMapperButton = ({
         };
       }
 
+      if (target != null && !selectedMappingOption) {
+        return {
+          buttonVariant: "invalid",
+          buttonText: t`Unknown Field`,
+          buttonIcon: (
+            <CloseIconButton
+              aria-label={t`Disconnect`}
+              onClick={e => {
+                handleChangeTarget(null);
+                e.stopPropagation();
+              }}
+            />
+          ),
+        };
+      }
+
       if (isDisabled && !isVirtual) {
         return {
           buttonVariant: "disabled",
@@ -88,22 +104,6 @@ export const DashCardCardParameterMapperButton = ({
           buttonIcon: (
             <CloseIconButton
               role="button"
-              aria-label={t`Disconnect`}
-              onClick={e => {
-                handleChangeTarget(null);
-                e.stopPropagation();
-              }}
-            />
-          ),
-        };
-      }
-
-      if (target != null) {
-        return {
-          buttonVariant: "invalid",
-          buttonText: t`Unknown Field`,
-          buttonIcon: (
-            <CloseIconButton
               aria-label={t`Disconnect`}
               onClick={e => {
                 handleChangeTarget(null);


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/32573

Changes:
- Modifies the dashboard parameter component so that it's possible to remove a broken parameter target when there are no options available

How to verify:
- Sample Dataset -> Orders -> Save as a model M1
- Create Q1 from M1
- Add Q1 on a dashboard D1
- Add an ID filter, connect it to Q1: Orders.Id and set any default value
- Edit model definition of M1 and in the notebook editor simply remove Id column from it
- Go to the D1 dashboard, ensure the chart is broken

<img width="429" alt="Screenshot 2024-10-23 at 12 32 25" src="https://github.com/user-attachments/assets/0ed4a880-bf1d-4a14-9053-7332a530eb32">
<img width="286" alt="Screenshot 2024-10-23 at 12 32 38" src="https://github.com/user-attachments/assets/7c5ece6d-f57e-4a7d-ab85-4eca72c1be33">
<img width="300" alt="Screenshot 2024-10-23 at 12 32 52" src="https://github.com/user-attachments/assets/51255248-a7ef-4f43-86a3-d2ba38e508b1">
