### PR TITLE
Fix date formatting of parameter values with time

### DIFF
--- a/frontend/src/metabase-lib/v1/queries/utils/query-time.js
+++ b/frontend/src/metabase-lib/v1/queries/utils/query-time.js
@@ -146,7 +146,7 @@ function generateTimeValueDescription(value, bucketing, isExclude) {
     if (bucketing) {
       return formatDateTimeWithUnit(value, bucketing, { isExclude });
     } else if (m.hours() || m.minutes()) {
-      return m.format("MMMM D, YYYY hh:mm a");
+      return m.format("MMMM D, YYYY hh:mm A");
     } else {
       return m.format("MMMM D, YYYY");
     }

--- a/frontend/src/metabase/parameters/utils/date-formatting.ts
+++ b/frontend/src/metabase/parameters/utils/date-formatting.ts
@@ -128,7 +128,7 @@ function parseDateRangeValue(value: string) {
 
 function formatSingleDate(date: Moment) {
   if (date.hours() || date.minutes()) {
-    return date.format("MMMM D, YYYY hh:mm a");
+    return date.format("MMMM D, YYYY hh:mm A");
   } else {
     return date.format("MMMM D, YYYY");
   }

--- a/frontend/src/metabase/parameters/utils/date-formatting.ts
+++ b/frontend/src/metabase/parameters/utils/date-formatting.ts
@@ -1,4 +1,4 @@
-import moment from "moment-timezone"; // eslint-disable-line no-restricted-imports -- deprecated usage
+import moment, { type Moment } from "moment-timezone"; // eslint-disable-line no-restricted-imports -- deprecated usage
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -126,16 +126,24 @@ function parseDateRangeValue(value: string) {
   return { start: moment(start, true), end: moment(end, true) };
 }
 
+function formatSingleDate(date: Moment) {
+  if (date.hours() || date.minutes()) {
+    return date.format("MMMM D, YYYY hh:mm a");
+  } else {
+    return date.format("MMMM D, YYYY");
+  }
+}
+
 export function formatRangeWidget(value: string): string | null {
   const { start, end } = parseDateRangeValue(value);
   return start.isValid() && end.isValid()
-    ? start.format("MMMM D, YYYY") + " - " + end.format("MMMM D, YYYY")
+    ? formatSingleDate(start) + " - " + formatSingleDate(end)
     : null;
 }
 
 function formatSingleWidget(value: string): string | null {
   const m = moment(value, true);
-  return m.isValid() ? m.format("MMMM D, YYYY") : null;
+  return m.isValid() ? formatSingleDate(m) : null;
 }
 
 function formatMonthYearWidget(value: string): string | null {

--- a/frontend/src/metabase/parameters/utils/formatting.unit.spec.ts
+++ b/frontend/src/metabase/parameters/utils/formatting.unit.spec.ts
@@ -49,7 +49,7 @@ describe("metabase/parameters/utils/formatting", () => {
       {
         type: "date/range",
         value: "2018-01-01T12:30:00~2018-01-10",
-        expected: "January 1, 2018 12:30 pm - January 10, 2018",
+        expected: "January 1, 2018 12:30 PM - January 10, 2018",
       },
       {
         type: "date/range",
@@ -59,7 +59,7 @@ describe("metabase/parameters/utils/formatting", () => {
       {
         type: "date/range",
         value: "2018-01-01T12:30:00~2018-01-10T08:15:00",
-        expected: "January 1, 2018 12:30 pm - January 10, 2018 08:15 AM",
+        expected: "January 1, 2018 12:30 PM - January 10, 2018 08:15 AM",
       },
       {
         type: "date/all-options",

--- a/frontend/src/metabase/parameters/utils/formatting.unit.spec.ts
+++ b/frontend/src/metabase/parameters/utils/formatting.unit.spec.ts
@@ -32,14 +32,34 @@ describe("metabase/parameters/utils/formatting", () => {
   describe("formatParameterValue", () => {
     const cases = [
       {
+        type: "date/single",
+        value: "2018-01-01",
+        expected: "January 1, 2018",
+      },
+      {
+        type: "date/single",
+        value: "2018-01-01T12:30:00",
+        expected: "January 1, 2018 12:30 pm",
+      },
+      {
         type: "date/range",
         value: "1995-01-01~1995-01-10",
         expected: "January 1, 1995 - January 10, 1995",
       },
       {
-        type: "date/single",
-        value: "2018-01-01",
-        expected: "January 1, 2018",
+        type: "date/range",
+        value: "2018-01-01T12:30:00~2018-01-10",
+        expected: "January 1, 2018 12:30 pm - January 10, 2018",
+      },
+      {
+        type: "date/range",
+        value: "2018-01-01~2018-01-10T08:15:00",
+        expected: "January 1, 2018 - January 10, 2018 08:15 am",
+      },
+      {
+        type: "date/range",
+        value: "2018-01-01T12:30:00~2018-01-10T08:15:00",
+        expected: "January 1, 2018 12:30 pm - January 10, 2018 08:15 am",
       },
       {
         type: "date/all-options",

--- a/frontend/src/metabase/parameters/utils/formatting.unit.spec.ts
+++ b/frontend/src/metabase/parameters/utils/formatting.unit.spec.ts
@@ -39,7 +39,7 @@ describe("metabase/parameters/utils/formatting", () => {
       {
         type: "date/single",
         value: "2018-01-01T12:30:00",
-        expected: "January 1, 2018 12:30 pm",
+        expected: "January 1, 2018 12:30 PM",
       },
       {
         type: "date/range",
@@ -54,12 +54,12 @@ describe("metabase/parameters/utils/formatting", () => {
       {
         type: "date/range",
         value: "2018-01-01~2018-01-10T08:15:00",
-        expected: "January 1, 2018 - January 10, 2018 08:15 am",
+        expected: "January 1, 2018 - January 10, 2018 08:15 AM",
       },
       {
         type: "date/range",
         value: "2018-01-01T12:30:00~2018-01-10T08:15:00",
-        expected: "January 1, 2018 12:30 pm - January 10, 2018 08:15 am",
+        expected: "January 1, 2018 12:30 pm - January 10, 2018 08:15 AM",
       },
       {
         type: "date/all-options",


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/39627

Uses the same date format used for `date/all-options` for `date/single` and `date/range` parameters to handle time.

How to verify:
- New -> SQL query -> `SELECT * FROM PRODUCTS WHERE CREATED_AT = {{created_at}}`
- Change the variable type to `Date`
- Open the date picker -> Select date and time -> Add filter
- Make sure that the time is displayed correctly

<img width="700" alt="Screenshot 2024-10-23 at 13 15 35" src="https://github.com/user-attachments/assets/41cd2ce6-d729-47a0-ab3b-28bd7a929828">
