### PR TITLE
Require only breakouts when adding new stage in ensure-filter-stage

### DIFF
--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-query-stages.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-query-stages.cy.spec.ts
@@ -409,7 +409,6 @@ describe("scenarios > dashboard > filters > query stages", () => {
               [...PRODUCTS_NUMBER_COLUMNS, ...PRODUCTS_NUMBER_COLUMNS],
             ], // TODO: https://github.com/metabase/metabase/issues/46845
             ["User", PEOPLE_NUMBER_COLUMNS],
-            // ["Summaries", ["Count", "Sum of Total"]], // TODO: https://github.com/metabase/metabase/issues/48339
           ]);
           verifyDashcardMappingOptions(MODEL_BASED_QUESTION_INDEX, [
             ["Base Orders Model", [...ORDERS_NUMBER_COLUMNS, "Net"]],
@@ -419,7 +418,6 @@ describe("scenarios > dashboard > filters > query stages", () => {
               [...PRODUCTS_NUMBER_COLUMNS, ...PRODUCTS_NUMBER_COLUMNS],
             ], // TODO: https://github.com/metabase/metabase/issues/46845
             ["User", PEOPLE_NUMBER_COLUMNS],
-            // ["Summaries", ["Count", "Sum of Total"]], // TODO: https://github.com/metabase/metabase/issues/48339
           ]);
           verifyDashcardMappingOptions(QUESTION_BASED_MODEL_INDEX, [
             [NAMELESS_SECTION, ["Count", "Sum of Total"]],
@@ -431,7 +429,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
       });
     });
 
-    describe("Q3 - join, custom column, no aggregations, 2 breakouts", () => {
+    describe("Q3 - join, custom column, no aggregations, 3 breakouts", () => {
       beforeEach(() => {
         createAndVisitDashboardWithCardMatrix(createQ3Query);
       });
@@ -457,14 +455,14 @@ describe("scenarios > dashboard > filters > query stages", () => {
             ["Reviews", REVIEWS_DATE_COLUMNS],
             ["Product", [...PRODUCTS_DATE_COLUMNS, ...PRODUCTS_DATE_COLUMNS]], // TODO: https://github.com/metabase/metabase/issues/46845
             ["User", PEOPLE_DATE_COLUMNS],
-            // ["Summaries", ["Created At: Month", "Created At: Year"]], // TODO: https://github.com/metabase/metabase/issues/48339
+            ["Summaries", ["Created At: Month", "Created At: Year"]],
           ]);
           verifyDashcardMappingOptions(MODEL_BASED_QUESTION_INDEX, [
             ["Base Orders Model", ORDERS_DATE_COLUMNS],
             ["Reviews", REVIEWS_DATE_COLUMNS],
             ["Product", [...PRODUCTS_DATE_COLUMNS, ...PRODUCTS_DATE_COLUMNS]], // TODO: https://github.com/metabase/metabase/issues/46845
             ["User", PEOPLE_DATE_COLUMNS],
-            // ["Summaries", ["Created At: Month", "Created At: Year"]], // TODO: https://github.com/metabase/metabase/issues/48339
+            ["Summaries", ["Created At: Month", "Created At: Year"]],
           ]);
           verifyDashcardMappingOptions(QUESTION_BASED_MODEL_INDEX, [
             [NAMELESS_SECTION, ["Created At", "User → Created At"]],
@@ -479,13 +477,13 @@ describe("scenarios > dashboard > filters > query stages", () => {
             ["Reviews", REVIEWS_TEXT_COLUMNS],
             ["Product", [...PRODUCTS_TEXT_COLUMNS, ...PRODUCTS_TEXT_COLUMNS]], // TODO: https://github.com/metabase/metabase/issues/46845
             ["User", PEOPLE_TEXT_COLUMNS],
-            // ["Summaries", ["Category"]], // TODO: https://github.com/metabase/metabase/issues/48339
+            ["Summaries", ["Category"]],
           ]);
           verifyDashcardMappingOptions(MODEL_BASED_QUESTION_INDEX, [
             ["Reviews", REVIEWS_TEXT_COLUMNS],
             ["Product", [...PRODUCTS_TEXT_COLUMNS, ...PRODUCTS_TEXT_COLUMNS]], // TODO: https://github.com/metabase/metabase/issues/46845
             ["User", PEOPLE_TEXT_COLUMNS],
-            // ["Summaries", ["Category"]], // TODO: https://github.com/metabase/metabase/issues/48339
+            ["Summaries", ["Category"]],
           ]);
           verifyDashcardMappingOptions(QUESTION_BASED_MODEL_INDEX, [
             [NAMELESS_SECTION, ["Product → Category"]],
@@ -778,7 +776,6 @@ describe("scenarios > dashboard > filters > query stages", () => {
             ],
             ["User", PEOPLE_NUMBER_COLUMNS],
             ["Summaries", ["Count", "Sum of Total", "5 * Count"]],
-            // ["Summaries (2)", ["Count", "Sum of Rating"]], // TODO: https://github.com/metabase/metabase/issues/48339
           ]);
           verifyDashcardMappingOptions(MODEL_BASED_QUESTION_INDEX, [
             ["Base Orders Model", [...ORDERS_NUMBER_COLUMNS, "Net"]],
@@ -789,7 +786,6 @@ describe("scenarios > dashboard > filters > query stages", () => {
             ],
             ["User", PEOPLE_NUMBER_COLUMNS],
             ["Summaries", ["Count", "Sum of Total", "5 * Count"]],
-            // ["Summaries (2)", ["Count", "Sum of Rating"]], // TODO: https://github.com/metabase/metabase/issues/48339
           ]);
           verifyDashcardMappingOptions(QUESTION_BASED_MODEL_INDEX, [
             [
@@ -936,25 +932,6 @@ describe("scenarios > dashboard > filters > query stages", () => {
             values: ["31", "114"],
           });
         });
-
-        // TODO: https://github.com/metabase/metabase/issues/48339
-        it.skip("2nd stage aggregation", () => {
-          setup2ndStageAggregationFilter();
-
-          verifyDashcardNoResults({ dashcardIndex: 0 });
-
-          goBackToDashboard();
-
-          verifyDashcardNoResults({ dashcardIndex: 1 });
-
-          goBackToDashboard();
-
-          verifyDashcardNoResults({ dashcardIndex: 2 });
-
-          goBackToDashboard();
-
-          verifyDashcardNoResults({ dashcardIndex: 3 });
-        });
       });
     });
 
@@ -1003,14 +980,14 @@ describe("scenarios > dashboard > filters > query stages", () => {
             ["Product", [...PRODUCTS_TEXT_COLUMNS, ...PRODUCTS_TEXT_COLUMNS]], // TODO: https://github.com/metabase/metabase/issues/46845
             ["User", PEOPLE_TEXT_COLUMNS],
             ["Summaries", ["Category"]],
-            // ["Summaries (2)", ["Reviewer", "Category"]], // TODO: https://github.com/metabase/metabase/issues/48339
+            ["Summaries (2)", ["Reviewer", "Category"]],
           ]);
           verifyDashcardMappingOptions(MODEL_BASED_QUESTION_INDEX, [
             ["Reviews", [...REVIEWS_TEXT_COLUMNS, ...REVIEWS_TEXT_COLUMNS]],
             ["Product", [...PRODUCTS_TEXT_COLUMNS, ...PRODUCTS_TEXT_COLUMNS]], // TODO: https://github.com/metabase/metabase/issues/46845
             ["User", PEOPLE_TEXT_COLUMNS],
             ["Summaries", ["Category"]],
-            // ["Summaries (2)", ["Reviewer", "Category"]], // TODO: https://github.com/metabase/metabase/issues/48339
+            ["Summaries (2)", ["Reviewer", "Category"]],
           ]);
           verifyDashcardMappingOptions(QUESTION_BASED_MODEL_INDEX, [
             [
@@ -1609,7 +1586,6 @@ describe("scenarios > dashboard > filters > query stages", () => {
             ["User", PEOPLE_NUMBER_COLUMNS],
             ["Summaries", ["Count", "Sum of Total", "5 * Count"]],
             ["Summaries (2)", ["Count", "Sum of Rating"]],
-            // ["Summaries (3)", ["Count"]], // TODO: https://github.com/metabase/metabase/issues/48339
           ]);
           verifyDashcardMappingOptions(MODEL_BASED_QUESTION_INDEX, [
             ["Base Orders Model", [...ORDERS_NUMBER_COLUMNS, "Net"]],
@@ -1621,7 +1597,6 @@ describe("scenarios > dashboard > filters > query stages", () => {
             ["User", PEOPLE_NUMBER_COLUMNS],
             ["Summaries", ["Count", "Sum of Total", "5 * Count"]],
             ["Summaries (2)", ["Count", "Sum of Rating"]],
-            // ["Summaries (3)", ["Count"]], // TODO: https://github.com/metabase/metabase/issues/48339
           ]);
           verifyDashcardMappingOptions(QUESTION_BASED_MODEL_INDEX, [
             [NAMELESS_SECTION, ["Count"]],
@@ -1820,6 +1795,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
         });
 
         // TODO: https://github.com/metabase/metabase/issues/48339
+        // TODO: https://github.com/metabase/metabase/issues/49022
         it.skip("3rd stage aggregation", () => {
           setup3rdStageAggregationFilter();
 
@@ -2196,7 +2172,7 @@ function createQ2Query(source: Card): StructuredQuery {
   };
 }
 
-// Q3 - join, custom column, no aggregations, 2 breakouts
+// Q3 - join, custom column, no aggregations, 3 breakouts
 function createQ3Query(source: Card): StructuredQuery {
   return {
     ...createQ1Query(source),
@@ -2890,16 +2866,4 @@ function verifyDashcardCellValues({
 
     cy.findAllByTestId("cell-data").eq(cellIndex).should("have.text", value);
   }
-}
-
-function verifyDashcardNoResults({ dashcardIndex }: { dashcardIndex: number }) {
-  getDashboardCard(dashcardIndex).should("have.text", "No results!");
-
-  getDashboardCard(dashcardIndex).findByTestId("legend-caption-title").click();
-  cy.wait("@dataset");
-
-  cy.findByTestId("query-visualization-root").should(
-    "have.text",
-    "No results!",
-  );
 }

--- a/src/metabase/lib/stage.cljc
+++ b/src/metabase/lib/stage.cljc
@@ -398,19 +398,18 @@
   [query]
   (let [inner-query (:query query)]
     (cond-> query
-      (and (:aggregation inner-query)
-           (:breakout inner-query))
+      (:breakout inner-query)
       (assoc :query {:source-query inner-query}))))
 
 (defn ensure-filter-stage
-  "Adds an empty stage to `query` if its last stage contains both breakouts and aggregations.
+  "Adds an empty stage to `query` if its last stage contains breakouts.
 
-  This is so that parameters can address both the stage before and after the aggregation.
-  Adding filters to the result at stage -1 will filter after the summary, filters added at
-  stage -2 filter before the summary."
+  This is so that parameters can address both the stage before and after the breakouts.
+  Adding filters to the result at stage -1 will filter after the breakouts. Filters added at
+  stage -2 filter before the breakouts."
   [query]
   (if (#{:query :native} (lib.util/normalized-query-type query))
     (ensure-legacy-filter-stage query)
     (cond-> query
-      (and (lib.breakout/breakouts query) (lib.aggregation/aggregations query))
+      (lib.breakout/breakouts query)
       append-stage)))

--- a/test/metabase/lib/stage_test.cljc
+++ b/test/metabase/lib/stage_test.cljc
@@ -411,7 +411,8 @@
                    (-> lib.tu/venues-query
                        (lib/filter (lib/= (meta/field-metadata :venues :category-id) 1)))
                    (-> lib.tu/venues-query
-                       (lib/breakout (meta/field-metadata :venues :category-id)))
+                       (lib/breakout (meta/field-metadata :venues :category-id))
+                       (lib/append-stage))
                    (-> lib.tu/venues-query
                        (lib/aggregate (lib/count)))
                    (-> lib.tu/venues-query
@@ -423,6 +424,13 @@
     (doseq [query [(-> lib.tu/venues-query
                        (lib/breakout (meta/field-metadata :venues :category-id))
                        (lib/aggregate (lib/count)))
+                   (-> lib.tu/venues-query
+                       (lib/breakout (meta/field-metadata :venues :category-id)))
+                   (-> lib.tu/venues-query
+                       (lib/append-stage)
+                       (lib/filter (lib/= (meta/field-metadata :venues :category-id) 1))
+                       (lib/breakout (meta/field-metadata :venues :category-id))
+                       (lib/breakout (meta/field-metadata :venues :price)))
                    (-> lib.tu/venues-query
                        (lib/filter (lib/= (meta/field-metadata :venues :category-id) 1))
                        (lib/breakout (meta/field-metadata :venues :category-id))


### PR DESCRIPTION
Closes #48339

### Description

Update `ensure-filter-stage` to only require breakouts when appending a new stage for filters. Previously, it required both breakouts and aggregations.

This resolves all-but-one of the TODOs in dashboard-filters-query-stages.cy.spec.ts related to #49339

### How to verify

See repro steps in #48339 and https://github.com/metabase/metabase/issues/48339#issuecomment-2393449924

Additional filter groups should now appear in both the filter modal and when adding dashboard filters to queries with breakouts but no aggregations in the final stage.

### Demo

<img width="1280" alt="Screenshot 2024-10-23 at 2 55 43 PM" src="https://github.com/user-attachments/assets/7fc5df84-8424-4e8c-a172-fd5725e19854">
<img width="1122" alt="Screenshot 2024-10-23 at 2 55 28 PM" src="https://github.com/user-attachments/assets/8eda2cbd-ffa2-4544-9750-5c6d6e42ae9f">
<img width="1402" alt="Screenshot 2024-10-23 at 2 57 01 PM" src="https://github.com/user-attachments/assets/37b8e1c1-2106-4055-940e-cb0929eda134">
<img width="585" alt="Screenshot 2024-10-23 at 2 57 24 PM" src="https://github.com/user-attachments/assets/e18df59a-b69c-45cb-9e1f-ec26a58c8d41">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
