### PR TITLE
Restrict native query table permissions to MySQL and PostgreSQL

### DIFF
--- a/src/metabase/query_analysis/native_query_analyzer/impl.cljc
+++ b/src/metabase/query_analysis/native_query_analyzer/impl.cljc
@@ -16,7 +16,7 @@
 ;; Using a separate list to the above, as we may want this to be more restrictive.
 (def trusted-for-table-permissions?
   "Do we trust that Macaw will not give us false negatives for tables referenced by a given query?"
-  #{:mysql :postgres})
+  #{:h2 :mysql :postgres})
 
 (defn macaw-options
   "Generate the options expected by Macaw based on the nature of the given driver."

--- a/src/metabase/query_analysis/native_query_analyzer/impl.cljc
+++ b/src/metabase/query_analysis/native_query_analyzer/impl.cljc
@@ -16,7 +16,7 @@
 ;; Using a separate list to the above, as we may want this to be more restrictive.
 (def trusted-for-table-permissions?
   "Do we trust that Macaw will not give us false negatives for tables referenced by a given query?"
-  #{:h2 :mysql :postgres :redshift :sqlite :sqlserver})
+  #{:mysql :postgres})
 
 (defn macaw-options
   "Generate the options expected by Macaw based on the nature of the given driver."

--- a/test/metabase/query_analysis/native_query_analyzer_test.clj
+++ b/test/metabase/query_analysis/native_query_analyzer_test.clj
@@ -51,10 +51,9 @@
   (:tables (refs sql)))
 
 (defn- basic-table-refs [sql]
-  (->> (mt/native-query {:query sql})
-       (nqa/tables-for-native)
-       :tables
-       (sort-by (juxt :schema :table))))
+  (let [result (nqa/tables-for-native (mt/native-query {:query sql}))]
+    (or (:error result)
+        (sort-by (juxt :schema :table) (:tables result)))))
 
 (defn- table-reference [table]
   (let [reference (nqa/table-reference (mt/id) table)]


### PR DESCRIPTION
Disables the `:sqlserver` and `:redshift` drivers, as they have some dynamic features we might not handle.

Disables the lower tier ~~`:h2`~~ and `:sqlite` drivers, as they are not necessary.

This leaves just `:postgres` and `:mysql` (which includes MariaDB)

_Update: the tests use `h2`, so put that back._