### PR TITLE
docs(sdk): requires metabase 51 specifically in sdk docs

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/README.md
+++ b/enterprise/frontend/src/embedding-sdk/README.md
@@ -24,7 +24,7 @@ Live demo: https://metaba.se/sdk-demo
 
 ## Known limitations
 
-- The SDK requires Metabase version 50 or higher.
+- The SDK requires Metabase version 51.
 - Some of the Pro/EE features are not exposed in the UI
   - Verified content
   - Official collections
@@ -74,7 +74,7 @@ Prerequisites:
 
 ## Start Metabase
 
-The SDK requires Metabase version 50 or higher.
+The SDK requires Metabase version 51.
 
 You have the following options:
 


### PR DESCRIPTION
Updates the Metabase 51 sdk docs to require Metabase 51 specifically.