### PR TITLE
ci(sdk): Fix SDK deployment failure

### DIFF
--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -245,14 +245,15 @@ jobs:
           path: sdk
 
       - name: Publish to NPM
+        working-directory: sdk
         run: |
-          cd sdk
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
           # Please keep the value in sync with `inputs.branch`'s release branch
           npm publish --tag ${{fromJson('{"master": "canary", "release-x.51.x": "51-stable"}')[inputs.branch]}}
 
       - name: Add `latest` tag to the latest release branch (`release-x.51.x`) deployment
         if: ${{ inputs.branch == 'release-x.51.x' }}
+        working-directory: sdk
         run: |
           npm dist-tag add @metabase/embedding-sdk-react@${{ env.sdk_version }} latest
 


### PR DESCRIPTION
This fixes the issue where the SDK deployment fail mid-way. You can see the [failed run](https://github.com/metabase/metabase/actions/runs/11498053683) here.

The problem was that we forgot to run `npm` commands in the same directory.

### How to verify
This is [the test run](https://github.com/metabase/metabase/actions/runs/11498415381) using commit b189a42e8c9512b2475ca870f6a7ab88cb5c03b7 (with publishing, docs PR, git tag push disabled).
