### PR TITLE
Remove daisy-chaining from pre-release tests

### DIFF
--- a/.github/workflows/build-for-release.yml
+++ b/.github/workflows/build-for-release.yml
@@ -243,24 +243,11 @@ jobs:
           ./COMMIT-ID
           ./SHA256.sum
 
-  trigger-tests:
-    needs: [build-uberjar-for-release]
-    permissions:
-      actions: write
-    runs-on: ubuntu-22.04
-    timeout-minutes: 5
-    steps:
-      - name: trigger pre-release testing
-        uses: actions/github-script@v7
-        with:
-          script: | # js
-            github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'pre-release.yml',
-              ref: '${{ github.ref }}',
-              inputs: {
-                commit: '${{ inputs.commit }}',
-                version: '${{ inputs.version }}',
-              }
-            });
+  run-pre-release-tests:
+    name: Run pre-release tests for ${{ inputs.version }}
+    needs: build-uberjar-for-release
+    uses: ./.github/workflows/pre-release.yml
+    secrets: inherit
+    with:
+      commit: ${{ inputs.commit }}
+      version: ${{ inputs.version }}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -10,11 +10,18 @@ on:
         required: true
       commit:
         description: "A full-length commit SHA-1 hash"
+        type: string
         required: true
-      auto:
-        description: 'auto-patch release DO NOT SET MANUALLY'
-        type: boolean
-        default: false
+  workflow_call:
+    inputs:
+      version:
+        description: "Metabase version (e.g. v0.46.3)"
+        type: string
+        required: true
+      commit:
+        description: "A full-length commit SHA-1 hash"
+        type: string
+        required: true
 
 jobs:
   release-artifact:
@@ -288,30 +295,6 @@ jobs:
       - name: Wait for Metabase to start
         run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
         timeout-minutes: 3
-
-  trigger-auto-publish:
-    if: ${{ inputs.auto }}
-    needs: [run-sanity-check, check-uberjar-health, verify-docker-pull]
-    permissions:
-      actions: write
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: trigger auto publish
-        uses: actions/github-script@v7
-        with:
-          script: | # js
-            await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'release.yml',
-              ref: '${{ github.ref }}',
-              inputs: {
-                commit: '${{ inputs.commit }}',
-                version: '${{ inputs.version }}',
-                auto: true,
-              }
-            });
 
   tests-complete-message:
     if: always()

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -53,10 +53,6 @@ on:
         description: Apply to OSS
         type: boolean
         default: true
-      skip:
-        description: Skip everything in this job
-        type: boolean
-        default: false
 
 jobs:
   green-check-stub:
@@ -148,7 +144,6 @@ jobs:
           throw new Error("No edition selected to tag");
 
   copy-to-s3:
-    if: ${{ !inputs.skip }}
     runs-on: ubuntu-22.04
     needs: check-version
     timeout-minutes: 5
@@ -230,7 +225,6 @@ jobs:
         fi
 
   tag-docker-image:
-    if: ${{ !inputs.skip }}
     runs-on: ubuntu-22.04
     needs: check-version
     timeout-minutes: 5
@@ -275,7 +269,6 @@ jobs:
         docker push $DOCKERHUB_REPO\:$TAG_NAME
 
   push-git-tags:
-    if: ${{ !inputs.skip }}
     permissions: write-all
     needs: check-version
     runs-on: ubuntu-22.04
@@ -300,7 +293,6 @@ jobs:
         fi
 
   update-release-log:
-    if: ${{ !inputs.skip }}
     needs: check-version
     uses: ./.github/workflows/release-log.yml
     with:
@@ -308,7 +300,6 @@ jobs:
     secrets: inherit
 
   update-version-info:
-    if: ${{ !inputs.skip }}
     runs-on: ubuntu-22.04
     needs: check-version
     timeout-minutes: 5

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -53,6 +53,10 @@ on:
         description: Apply to OSS
         type: boolean
         default: true
+      skip:
+        description: Skip everything in this job
+        type: boolean
+        default: false
 
 jobs:
   green-check-stub:
@@ -144,6 +148,7 @@ jobs:
           throw new Error("No edition selected to tag");
 
   copy-to-s3:
+    if: ${{ !inputs.skip }}
     runs-on: ubuntu-22.04
     needs: check-version
     timeout-minutes: 5
@@ -225,6 +230,7 @@ jobs:
         fi
 
   tag-docker-image:
+    if: ${{ !inputs.skip }}
     runs-on: ubuntu-22.04
     needs: check-version
     timeout-minutes: 5
@@ -269,6 +275,7 @@ jobs:
         docker push $DOCKERHUB_REPO\:$TAG_NAME
 
   push-git-tags:
+    if: ${{ !inputs.skip }}
     permissions: write-all
     needs: check-version
     runs-on: ubuntu-22.04
@@ -293,6 +300,7 @@ jobs:
         fi
 
   update-release-log:
+    if: ${{ !inputs.skip }}
     needs: check-version
     uses: ./.github/workflows/release-log.yml
     with:
@@ -300,6 +308,7 @@ jobs:
     secrets: inherit
 
   update-version-info:
+    if: ${{ !inputs.skip }}
     runs-on: ubuntu-22.04
     needs: check-version
     timeout-minutes: 5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,30 @@ on:
         description: 'auto-patch release DO NOT SET MANUALLY'
         type: boolean
         default: false
+  workflow_call:
+    inputs:
+      version:
+        description: 'Metabase version (e.g. v0.46.3)'
+        type: string
+        required: true
+      commit:
+        description: 'A full-length commit SHA-1 hash'
+        type: string
+        required: true
+      release-channel:
+        description: 'The release channel to publish to (optional)'
+        type: string
+        # options:
+        #   - none
+        #   - latest
+        #   - beta
+        #   - nightly
+        required: true
+        default: 'none'
+      auto:
+        description: 'auto-patch release DO NOT SET MANUALLY'
+        type: boolean
+        default: false
 
 jobs:
   check-version:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -685,23 +685,6 @@ jobs:
     uses: ./.github/workflows/release-tag.yml
     secrets: inherit
     with:
-      # we only want to tag the current version on the nightly channel, but we
-      # need this job to run even if we don't tag, so we send through a skip flag
-      skip: ${{ needs.check-version.outputs.isCurrentMajorVersion == 'true' }}
-      version: ${{ inputs.version }}
-      tag_name: ${{ inputs.release-channel }}
-      tag_rollout: 100
-      tag_ee: true
-      tag_oss: true
-
-  set-release-channel:
-    if: ${{ !inputs.auto }}
-    needs: [push-tags, verify-docker-pull, verify-s3-download, publish-version-info]
-    uses: ./.github/workflows/release-tag.yml
-    secrets: inherit
-    with:
-      # we need this job to run even if we don't tag, so we send through a skip flag
-      skip: ${{ inputs.release-channel == 'none' }}
       version: ${{ inputs.version }}
       tag_name: ${{ inputs.release-channel }}
       tag_rollout: 100

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -694,6 +694,20 @@ jobs:
       tag_ee: true
       tag_oss: true
 
+  set-release-channel:
+    if: ${{ !inputs.auto }}
+    needs: [push-tags, verify-docker-pull, verify-s3-download, publish-version-info]
+    uses: ./.github/workflows/release-tag.yml
+    secrets: inherit
+    with:
+      # we need this job to run even if we don't tag, so we send through a skip flag
+      skip: ${{ inputs.release-channel == 'none' }}
+      version: ${{ inputs.version }}
+      tag_name: ${{ inputs.release-channel }}
+      tag_rollout: 100
+      tag_ee: true
+      tag_oss: true
+
   publish-complete-message:
     runs-on: ubuntu-22.04
     needs: set-release-channel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
       id: canonical_version
       with:
         script: | # js
-          const { isValidVersionString, getCanonicalVersion, hasBeenReleased } = require('${{ github.workspace }}/release/dist/index.cjs');
+          const { isValidVersionString, getCanonicalVersion, hasBeenReleased, getMajorVersion } = require('${{ github.workspace }}/release/dist/index.cjs');
 
           const version = '${{ inputs.version }}';
 
@@ -59,9 +59,13 @@ jobs:
             throw new Error("The version format is invalid! It must start with either 'v0.' or 'v1.'.");
           }
 
+          const currentVersion = '${{ vars.CURRENT_VERSION }}';
+          const majorVersion = getMajorVersion(version);
+
           const versions = {
             ee: getCanonicalVersion(version, 'ee'),
             oss: getCanonicalVersion(version, 'oss'),
+            isCurrentMajorVersion: majorVersion === Number(currentVersion) ? 'true' : 'false',
           };
 
           const ossReleased = await hasBeenReleased({
@@ -681,6 +685,9 @@ jobs:
     uses: ./.github/workflows/release-tag.yml
     secrets: inherit
     with:
+      # we only want to tag the current version on the nightly channel, but we
+      # need this job to run even if we don't tag, so we send through a skip flag
+      skip: ${{ needs.check-version.outputs.isCurrentMajorVersion == 'true' }}
       version: ${{ inputs.version }}
       tag_name: ${{ inputs.release-channel }}
       tag_rollout: 100

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
       id: canonical_version
       with:
         script: | # js
-          const { isValidVersionString, getCanonicalVersion, hasBeenReleased, getMajorVersion } = require('${{ github.workspace }}/release/dist/index.cjs');
+          const { isValidVersionString, getCanonicalVersion, hasBeenReleased } = require('${{ github.workspace }}/release/dist/index.cjs');
 
           const version = '${{ inputs.version }}';
 
@@ -59,13 +59,9 @@ jobs:
             throw new Error("The version format is invalid! It must start with either 'v0.' or 'v1.'.");
           }
 
-          const currentVersion = '${{ vars.CURRENT_VERSION }}';
-          const majorVersion = getMajorVersion(version);
-
           const versions = {
             ee: getCanonicalVersion(version, 'ee'),
             oss: getCanonicalVersion(version, 'oss'),
-            isCurrentMajorVersion: majorVersion === Number(currentVersion) ? 'true' : 'false',
           };
 
           const ossReleased = await hasBeenReleased({

--- a/.github/workflows/tag-for-release.yml
+++ b/.github/workflows/tag-for-release.yml
@@ -233,25 +233,26 @@ jobs:
           ./COMMIT-ID
           ./SHA256.sum
 
-  trigger-tests:
-    needs: [tag-uberjar-for-release]
-    permissions:
-      actions: write
-    runs-on: ubuntu-22.04
-    timeout-minutes: 5
-    steps:
-      - name: trigger pre-release testing
-        uses: actions/github-script@v7
-        with:
-          script: | # js
-            github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'pre-release.yml',
-              ref: '${{ github.ref }}',
-              inputs: {
-                commit: '${{ inputs.commit }}',
-                version: '${{ inputs.version }}',
-                auto: '${{ inputs.auto }}',
-              }
-            });
+  run-pre-release-tests:
+    name: Run pre-release tests for ${{ inputs.version }}
+    needs: tag-uberjar-for-release
+    uses: ./.github/workflows/pre-release.yml
+    secrets: inherit
+    with:
+      commit: ${{ inputs.commit }}
+      version: ${{ inputs.version }}
+      auto: ${{ inputs.auto }}
+
+  auto-publish-release:
+    name: Auto-publish release ${{ inputs.version }}
+    if: ${{ inputs.auto }}
+    needs: run-pre-release-tests
+    uses: ./.github/workflows/release.yml
+    secrets: inherit
+    with:
+      version: ${{ inputs.version }}
+      commit: ${{ inputs.commit }}
+      auto: ${{ inputs.auto }}
+      # for now don't auto-set release channel because we don't want to have
+      # multiple nightlies due to race conditions
+      release-channel: none

--- a/.github/workflows/tag-for-release.yml
+++ b/.github/workflows/tag-for-release.yml
@@ -241,7 +241,6 @@ jobs:
     with:
       commit: ${{ inputs.commit }}
       version: ${{ inputs.version }}
-      auto: ${{ inputs.auto }}
 
   auto-publish-release:
     name: Auto-publish release ${{ inputs.version }}


### PR DESCRIPTION
Depends on https://github.com/metabase/metabase/pull/48633

## Description

This removes tests as a middle-man for automatic publishing, and makes the build jobs "include" the tests via workflow_call

Before 

![Screen Shot 2024-10-24 at 5 32 37 AM](https://github.com/user-attachments/assets/2d0446ad-62b8-4196-82af-f56aae83229e)

After

![Screen Shot 2024-10-24 at 5 35 19 AM](https://github.com/user-attachments/assets/b84023f8-3ffd-4a45-b048-89a30eee156e)



For more information, [see this slack thread](https://metaboat.slack.com/archives/C864UT5CZ/p1729769508469499).

### Checklist

- ✅  [test in my fork](https://github.com/iethree/metabase/actions/runs/11498186169)
