### PR TITLE
Update X-ray to use rtk query

### DIFF
--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -346,3 +346,13 @@ export function removeMultiAutocompleteValue(index, filter) {
     .findByRole("button", { hidden: true })
     .click();
 }
+
+export function retryAssertion(assertFn, timeout = 4000, interval = 400) {
+  if (timeout <= 0) {
+    return;
+  }
+  assertFn();
+
+  cy.wait(interval);
+  retryAssertion(assertFn, timeout - interval, interval);
+}

--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -347,12 +347,12 @@ export function removeMultiAutocompleteValue(index, filter) {
     .click();
 }
 
-export function retryAssertion(assertFn, timeout = 4000, interval = 400) {
+export function repeatAssertion(assertFn, timeout = 4000, interval = 400) {
   if (timeout <= 0) {
     return;
   }
   assertFn();
 
   cy.wait(interval);
-  retryAssertion(assertFn, timeout - interval, interval);
+  repeatAssertion(assertFn, timeout - interval, interval);
 }

--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -20,9 +20,9 @@ import {
   navigationSidebar,
   openNavigationSidebar,
   popover,
+  repeatAssertion,
   resetSnowplow,
   restore,
-  retryAssertion,
   setTokenFeatures,
   undoToast,
   updateSetting,
@@ -91,6 +91,8 @@ describe("scenarios > home > homepage", () => {
           return new Promise(resolve => {
             setTimeout(() => {
               resolve();
+              // Setting this to be arbitrarly long so that the repeat assertion
+              // has a guarentee of finding it.
             }, 1000);
           });
         });
@@ -99,7 +101,7 @@ describe("scenarios > home > homepage", () => {
       cy.visit("/");
       cy.wait("@getXrayCandidates");
 
-      retryAssertion(() =>
+      repeatAssertion(() =>
         cy
           .findByTestId("home-page")
           .findByTestId("loading-indicator", { timeout: 0 })

--- a/frontend/src/metabase/home/components/HomeXraySection/HomeXraySection.tsx
+++ b/frontend/src/metabase/home/components/HomeXraySection/HomeXraySection.tsx
@@ -3,16 +3,18 @@ import { useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
-import { skipToken, useListDatabaseXraysQuery } from "metabase/api";
-import { useDatabaseListQuery } from "metabase/common/hooks";
+import {
+  skipToken,
+  useListDatabaseXraysQuery,
+  useListDatabasesQuery,
+} from "metabase/api";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import Select from "metabase/core/components/Select";
 import { useSelector } from "metabase/lib/redux";
 import { isSyncCompleted } from "metabase/lib/syncing";
 import * as Urls from "metabase/lib/urls";
 import { getApplicationName } from "metabase/selectors/whitelabel";
-import type Database from "metabase-lib/v1/metadata/Database";
-import type { DatabaseXray } from "metabase-types/api";
+import type { Database, DatabaseXray } from "metabase-types/api";
 
 import { HomeCaption } from "../HomeCaption";
 import { HomeHelpCard } from "../HomeHelpCard";
@@ -29,13 +31,18 @@ import {
 } from "./HomeXraySection.styled";
 
 export const HomeXraySection = () => {
-  const databaseListState = useDatabaseListQuery();
-  const database = getXrayDatabase(databaseListState.data);
+  const {
+    data: databasesData,
+    isLoading: databasesLoading,
+    error: databasesError,
+  } = useListDatabasesQuery();
+
+  const database = getXrayDatabase(databasesData?.data);
   const candidateListState = useListDatabaseXraysQuery(
     database?.id ?? skipToken,
   );
-  const isLoading = databaseListState.isLoading || candidateListState.isLoading;
-  const error = databaseListState.error ?? candidateListState.error;
+  const isLoading = databasesLoading || candidateListState.isLoading;
+  const error = databasesError ?? candidateListState.error;
 
   if (isLoading || error) {
     return <LoadingAndErrorWrapper loading={isLoading} error={error} />;
@@ -149,7 +156,7 @@ const DatabaseInfo = ({ database }: DatabaseInfoProps) => {
   );
 };
 
-const getXrayDatabase = (databases: Database[] = []) => {
+const getXrayDatabase = (databases: Database[] | undefined = []) => {
   const sampleDatabase = databases.find(d => d.is_sample && isSyncCompleted(d));
   const userDatabase = databases.find(d => !d.is_sample && isSyncCompleted(d));
   return userDatabase ?? sampleDatabase;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/49059

### Description
Moves the X Ray DB call to RTK Query so that it is unaffected by DB Syncing. This way we are not impacted by `isLoading` from the entity request

### How to verify

1. Have a fresh instance that will show you X Rays on the home page
2. sync a DB that will take a long time
3. go to the homepage, the screen should not flicker

### Checklist
- [x] Tests have been added/updated to cover changes in this PR
