### PR TITLE
use default line height in the embedding homepage

### DIFF
--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepageView.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepageView.tsx
@@ -49,7 +49,7 @@ export const EmbedHomepageView = (props: EmbedHomepageViewProps) => {
           <Box>
             {/* eslint-disable-next-line no-literal-metabase-strings -- only visible to admins */}
             <Title order={2} mb="md">{t`Embedding Metabase`}</Title>
-            <Text lh={1.57}>
+            <Text>
               {/* eslint-disable-next-line no-literal-metabase-strings -- only visible to admins */}
               {t`Give your customers secure, multi-tenant access to their data with as much (or as little) interactivity and tools to explore data as you want, with as much customization as you need. Embed dashboards, charts—even Metabase's query editor—with iframes or as individual React components.`}
             </Text>

--- a/frontend/src/metabase/home/components/EmbedHomepage/HeaderWithDismiss.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/HeaderWithDismiss.tsx
@@ -12,7 +12,6 @@ export const HeaderWithDismiss = ({ onDismiss }: HeaderWithDismissProps) => {
   return (
     <Group position="apart">
       <Text
-        lh={1.57}
         fw="bold"
         // eslint-disable-next-line no-literal-metabase-strings -- This string only shows for admins.
       >{t`Get started with Embedding Metabase in your app`}</Text>

--- a/frontend/src/metabase/home/components/EmbedHomepage/InteractiveContent.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/InteractiveContent.tsx
@@ -14,13 +14,12 @@ export const InteractiveContent = ({
 }: InteractiveContentProps) => (
   <Box>
     <Text
-      lh={1.57}
       fw="bold"
       mb="sm"
       size="lg"
       color="text-medium"
     >{t`Interactive embedding`}</Text>
-    <Text lh={1.57} mb="md">
+    <Text mb="md">
       {/* eslint-disable-next-line no-literal-metabase-strings -- only visible to admins */}
       {t`Interactive embedding allows you to embed the full Metabase app with iframes. It offers settings to customize appearance and includes the query builder with row-level access.`}
     </Text>

--- a/frontend/src/metabase/home/components/EmbedHomepage/NeedMoreInfoCard.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/NeedMoreInfoCard.tsx
@@ -13,12 +13,8 @@ export const NeedMoreInfoCard = ({
   analyticsDocsUrl,
 }: NeedMoreInfoCardProps) => (
   <Card px="xl">
-    <Text
-      lh={1.57}
-      color="text-dark"
-      fw="bold"
-    >{t`Need more information?`}</Text>
-    <Text lh={1.57} color="text-light" size="sm">
+    <Text color="text-dark" fw="bold">{t`Need more information?`}</Text>
+    <Text color="text-light" size="sm">
       {/* eslint-disable-next-line no-literal-metabase-strings -- only visible to admins */}
       {jt`Explore the ${(
         <ExternalLink key="embedding-docs" href={embeddingDocsUrl}>

--- a/frontend/src/metabase/home/components/EmbedHomepage/SDKContent.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/SDKContent.tsx
@@ -16,7 +16,7 @@ export const SDKContent = ({
 }: SDKContentProps) => (
   <Box>
     <Group spacing="sm" align="center" mb="sm">
-      <Text lh={1.57} fw="bold" size="lg" color="text-medium">
+      <Text fw="bold" size="lg" color="text-medium">
         {t`Embedded analytics SDK`}
       </Text>
       <Badge
@@ -27,7 +27,7 @@ export const SDKContent = ({
         uppercase={false}
       >{t`Beta`}</Badge>
     </Group>
-    <Text lh={1.57} mb="md">
+    <Text mb="md">
       {t`Embed individual components like charts, dashboards, the query builder, and more with React. Get advanced customization with CSS styling and manage granular access and interactivity per component.`}
     </Text>
     <Group spacing="md">

--- a/frontend/src/metabase/home/components/EmbedHomepage/StaticEmbedContent.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/StaticEmbedContent.tsx
@@ -18,13 +18,12 @@ export const StaticEmbedContent = ({
 }: StaticEmbedContentProps) => (
   <Box>
     <Text
-      lh={1.57}
       fw="bold"
       mb="sm"
       size="lg"
       color="text-medium"
     >{t`Static embedding`}</Text>
-    <Text lh={1.57} mb="md">
+    <Text mb="md">
       {/* eslint-disable-next-line no-literal-metabase-strings -- This string only shows for admins. */}
       {t`Embed a dashboard in a 'Powered by Metabase' iframe with interactivity limited to filters and tooltips, and a few customization options. The iframe loads a Metabase URL secured with a signed JSON Web Token (JWT). Appears with "Powered by Metabase", on Open Source and Starter plans, with the option to remove on Pro and Enterprise. As the simplest form of embedding, you can add a dashboard into your app in a few minutes with just a snippet.`}
     </Text>


### PR DESCRIPTION
# Description

We don't need the magic value as design is ok with the default value
https://metaboat.slack.com/archives/C057WD5L0JG/p1729761342082999?thread_ts=1729704963.019779&cid=C057WD5L0JG

# Demo

<img width="1476" alt="image" src="https://github.com/user-attachments/assets/5735117d-4642-471b-84cd-9e08ab71e737">
