### PR TITLE
In sidesheets, show correct sources for a model

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/utils.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/utils.tsx
@@ -13,7 +13,6 @@ import {
   getQuestionVirtualTableId,
   isVirtualCardId,
 } from "metabase-lib/v1/metadata/utils/saved-questions";
-import type NativeQuery from "metabase-lib/v1/queries/NativeQuery";
 import * as ML_Urls from "metabase-lib/v1/urls";
 
 import { HeadBreadcrumbs } from "../HeaderBreadcrumbs";
@@ -45,9 +44,11 @@ export function getDataSourceParts({
   }
 
   const query = question.query();
+
   const { isEditable, isNative } = Lib.queryDisplayInfo(query);
 
   const hasDataPermission = isEditable;
+
   if (!hasDataPermission) {
     return [];
   }
@@ -55,6 +56,7 @@ export function getDataSourceParts({
   const parts: DataSourcePart[] = [];
 
   const metadata = question.metadata();
+
   const database = metadata.database(Lib.databaseID(query));
 
   if (database) {
@@ -69,6 +71,7 @@ export function getDataSourceParts({
   const table = !isNative
     ? metadata.table(Lib.sourceTableOrCardId(query))
     : (question.legacyQuery() as NativeQuery).table();
+
   if (table && table.hasSchema()) {
     const isBasedOnSavedQuestion = isVirtualCardId(table.id);
     if (database != null && !isBasedOnSavedQuestion) {
@@ -91,39 +94,43 @@ export function getDataSourceParts({
       ];
     }
 
-    const allTables = [
-      table,
-      ...Lib.joins(query, -1)
-        .map(join => Lib.pickerInfo(query, Lib.joinedThing(query, join)))
-        .map(pickerInfo => {
-          if (pickerInfo?.tableId != null) {
-            return metadata.table(pickerInfo.tableId);
-          }
+    if (formatTableAsComponent) {
+      const allTables = [
+        table,
+        ...Lib.joins(query, -1)
+          .map(join => Lib.pickerInfo(query, Lib.joinedThing(query, join)))
+          .map(pickerInfo => {
+            if (pickerInfo?.tableId != null) {
+              return metadata.table(pickerInfo.tableId);
+            }
 
-          if (pickerInfo?.cardId != null) {
-            return metadata.table(getQuestionVirtualTableId(pickerInfo.cardId));
-          }
+            if (pickerInfo?.cardId != null) {
+              return metadata.table(
+                getQuestionVirtualTableId(pickerInfo.cardId),
+              );
+            }
 
-          return undefined;
-        }),
-    ].filter(isNotNull);
+            return undefined;
+          }),
+      ].filter(isNotNull);
 
-    const part: DataSourcePart = formatTableAsComponent ? (
-      <QuestionTableBadges
-        tables={allTables}
-        subHead={subHead}
-        hasLink={hasTableLink}
-        isLast={!isObjectDetail}
-      />
-    ) : (
-      {
+      const part: DataSourcePart = (
+        <QuestionTableBadges
+          tables={allTables}
+          subHead={subHead}
+          hasLink={hasTableLink}
+          isLast={!isObjectDetail}
+        />
+      );
+      parts.push(part);
+    } else {
+      const part = {
         name: table.displayName(),
         href: hasTableLink ? getTableURL(table) : "",
         model: table.type ?? "table",
-      }
-    );
-
-    parts.push(part);
+      };
+      parts.push(part);
+    }
   }
 
   return parts.filter(

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/QuestionDetails.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/QuestionDetails.tsx
@@ -71,7 +71,7 @@ export const QuestionDetails = ({ question }: { question: Question }) => {
         </Flex>
       </SidesheetCardSection>
       <SharingDisplay question={question} />
-      <QuestionSources question={question} />
+      <QuestionSources />
     </>
   );
 };

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/components/QuestionSources.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/components/QuestionSources.tsx
@@ -13,7 +13,7 @@ import type { QuestionSource } from "./types";
 import { getIconPropsForSource } from "./utils";
 
 export const QuestionSources = () => {
-  /** Retrieve current question from the redux store */
+  /** Retrieve current question from the Redux store */
   const questionWithParameters = useSelector(getQuestionWithParameters);
 
   const sourcesWithIcons: QuestionSource[] = useMemo(() => {

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/components/QuestionSources.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/components/QuestionSources.tsx
@@ -13,6 +13,7 @@ import type { QuestionSource } from "./types";
 import { getIconPropsForSource } from "./utils";
 
 export const QuestionSources = () => {
+  /** Retrieve current question from the redux store */
   const questionWithParameters = useSelector(getQuestionWithParameters);
 
   const sourcesWithIcons: QuestionSource[] = useMemo(() => {

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/components/QuestionSources.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/components/QuestionSources.tsx
@@ -3,30 +3,34 @@ import { c } from "ttag";
 
 import { SidesheetCardSection } from "metabase/common/components/Sidesheet";
 import Link from "metabase/core/components/Link";
+import { useSelector } from "metabase/lib/redux";
+import { getQuestionWithParameters } from "metabase/query_builder/selectors";
 import { Flex, FixedSizeIcon as Icon } from "metabase/ui";
-import type Question from "metabase-lib/v1/Question";
 
 import { getDataSourceParts } from "../../../ViewHeader/components/QuestionDataSource/utils";
 
 import type { QuestionSource } from "./types";
 import { getIconPropsForSource } from "./utils";
 
-export const QuestionSources = ({ question }: { question: Question }) => {
-  const sources = getDataSourceParts({
-    question,
-    subHead: false,
-    isObjectDetail: true,
-    formatTableAsComponent: false,
-  }) as unknown as QuestionSource[];
+export const QuestionSources = () => {
+  const questionWithParameters = useSelector(getQuestionWithParameters);
 
   const sourcesWithIcons: QuestionSource[] = useMemo(() => {
+    const sources = questionWithParameters
+      ? (getDataSourceParts({
+          question: questionWithParameters,
+          subHead: false,
+          isObjectDetail: true,
+          formatTableAsComponent: false,
+        }) as QuestionSource[])
+      : [];
     return sources.map(source => ({
       ...source,
       iconProps: getIconPropsForSource(source),
     }));
-  }, [sources]);
+  }, [questionWithParameters]);
 
-  if (!sources.length) {
+  if (!questionWithParameters || !sourcesWithIcons.length) {
     return null;
   }
 
@@ -47,7 +51,9 @@ export const QuestionSources = ({ question }: { question: Question }) => {
                 {name}
               </Flex>
             </Link>
-            {index < sources.length - 1 && <Flex lh="1.25rem">{"/"}</Flex>}
+            {index < sourcesWithIcons.length - 1 && (
+              <Flex lh="1.25rem">{"/"}</Flex>
+            )}
           </Fragment>
         ))}
       </Flex>

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/components/QuestionSources.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/components/QuestionSources.unit.spec.tsx
@@ -5,8 +5,6 @@ import { mockSettings } from "__support__/settings";
 import { createMockEntitiesState } from "__support__/store";
 import { renderWithProviders, screen, within } from "__support__/ui";
 import { modelIconMap } from "metabase/lib/icon";
-import { checkNotNull } from "metabase/lib/types";
-import { getMetadata } from "metabase/selectors/metadata";
 import { convertSavedQuestionToVirtualTable } from "metabase-lib/v1/metadata/utils/saved-questions";
 import type { Card, NormalizedTable } from "metabase-types/api";
 import { createMockCard, createMockSettings } from "metabase-types/api/mocks";
@@ -58,14 +56,8 @@ const setup = async ({
     };
   }
 
-  const metadata = getMetadata(state);
-  const question = checkNotNull(metadata.question(card.id));
-
   return renderWithProviders(
-    <Route
-      path="/"
-      component={() => <QuestionSources question={question} />}
-    />,
+    <Route path="/" component={() => <QuestionSources />} />,
     {
       withRouter: true,
       storeInitialState: state,

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/components/QuestionSources.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/components/QuestionSources.unit.spec.tsx
@@ -11,7 +11,10 @@ import { convertSavedQuestionToVirtualTable } from "metabase-lib/v1/metadata/uti
 import type { Card, NormalizedTable } from "metabase-types/api";
 import { createMockCard, createMockSettings } from "metabase-types/api/mocks";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
-import { createMockState } from "metabase-types/store/mocks";
+import {
+  createMockQueryBuilderState,
+  createMockState,
+} from "metabase-types/store/mocks";
 
 import { QuestionSources } from "./QuestionSources";
 
@@ -25,6 +28,7 @@ const setup = async ({
   sourceCard,
 }: SetupOpts = {}) => {
   const state = createMockState({
+    qb: createMockQueryBuilderState({ card }),
     settings: mockSettings(createMockSettings()),
     entities: createMockEntitiesState({
       databases: [createSampleDatabase()],
@@ -64,6 +68,7 @@ const setup = async ({
     />,
     {
       withRouter: true,
+      storeInitialState: state,
     },
   );
 };
@@ -140,6 +145,40 @@ describe("QuestionSources", () => {
     expect(questionLink).toHaveAttribute(
       "href",
       "/question/2-my-source-question",
+    );
+  });
+
+  it("shows source information for a model (its database and table)", async () => {
+    const model = createMockCard({
+      name: "My Model",
+      type: "model",
+    });
+
+    await setup({ card: model });
+
+    const databaseLink = await screen.findByRole("link", {
+      name: /Sample Database/i,
+    });
+
+    expect(
+      await within(databaseLink).findByLabelText("database icon"),
+    ).toBeInTheDocument();
+    expect(databaseLink).toHaveAttribute(
+      "href",
+      "/browse/databases/1-sample-database",
+    );
+
+    expect(screen.getByText("/")).toBeInTheDocument();
+
+    expect(screen.getByText("/")).toBeInTheDocument();
+    const tableLink = await screen.findByRole("link", { name: /Products/i });
+    expect(tableLink).toBeInTheDocument();
+    expect(
+      await within(tableLink).findByLabelText(`table icon`),
+    ).toBeInTheDocument();
+    expect(tableLink).toHaveAttribute(
+      "href",
+      expect.stringMatching(/^\/question#[a-zA-Z0-9]{20}/),
     );
   });
 });

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/components/QuestionSources.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/components/QuestionSources.unit.spec.tsx
@@ -170,7 +170,6 @@ describe("QuestionSources", () => {
 
     expect(screen.getByText("/")).toBeInTheDocument();
 
-    expect(screen.getByText("/")).toBeInTheDocument();
     const tableLink = await screen.findByRole("link", { name: /Products/i });
     expect(tableLink).toBeInTheDocument();
     expect(

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/tests/setup.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/tests/setup.tsx
@@ -20,7 +20,10 @@ import {
   createMockUser,
 } from "metabase-types/api/mocks";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
-import { createMockState } from "metabase-types/store/mocks";
+import {
+  createMockQueryBuilderState,
+  createMockState,
+} from "metabase-types/store/mocks";
 
 import { QuestionInfoSidebar } from "../QuestionInfoSidebar";
 
@@ -47,6 +50,7 @@ export const setup = async ({
   const state = createMockState({
     currentUser,
     settings: mockSettings(settings),
+    qb: createMockQueryBuilderState({ card }),
     entities: createMockEntitiesState({
       databases: [createSampleDatabase()],
       questions: [card],


### PR DESCRIPTION
The bug: in the info sidesheet, models have incorrect information in the "Based on" section. In this branch, the database and table of a model are correctly listed in that section.

| Before | After |
| ------ | ------ |
| ![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/f37c1bff-f1d5-4b87-aa8d-505b17060328.png) | ![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/389c4ea8-b870-4544-9f0c-6da872b0131c.png) |

Closes #48698