### PR TITLE
Remove a 10-second wait from an e2e test (mini-PR)

### DIFF
--- a/e2e/test/scenarios/search/recently-viewed.cy.spec.js
+++ b/e2e/test/scenarios/search/recently-viewed.cy.spec.js
@@ -64,8 +64,6 @@ describe("search > recently viewed", () => {
     cy.findByPlaceholderText("Search…").click();
     cy.wait("@recent");
     cy.findByTestId("loading-indicator").should("not.exist");
-    cy.log("check output");
-    cy.wait(10000);
 
     assertRecentlyViewedItem(0, "Orders in a dashboard", "Dashboard");
     assertRecentlyViewedItem(1, "Orders", "Question");


### PR DESCRIPTION
I added this 10-second wait last year when I didn't know any better.