### PR TITLE
Fix adding a time in legacy date picker

### DIFF
--- a/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/DatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/DatePicker.unit.spec.tsx
@@ -240,9 +240,9 @@ describe("DatePicker", () => {
 
     describe("Specific Dates", () => {
       const singleDateOperators = [
-        ["=", "on"],
-        ["<", "before"],
-        [">", "after"],
+        ["=", "On"],
+        ["<", "Before"],
+        [">", "After"],
       ];
 
       singleDateOperators.forEach(([operator, description]) => {
@@ -263,6 +263,25 @@ describe("DatePicker", () => {
             operator,
             CREATED_AT_FIELD,
             "2020-05-21",
+          ]);
+        });
+
+        it(`can add time to a specific ${description} date filter`, async () => {
+          const onChange = jest.fn();
+
+          render(
+            <DatePickerStateWrapper filter={filter} onChange={onChange} />,
+          );
+          await userEvent.click(screen.getByText("Specific dates..."));
+          await userEvent.click(screen.getByText("On"));
+          await screen.findByTestId(`specific-date-picker`);
+          await userEvent.click(screen.getByText(description));
+          await userEvent.click(screen.getByText("Add a time"));
+
+          expect(onChange).toHaveBeenLastCalledWith([
+            operator,
+            CREATED_AT_FIELD,
+            "2020-05-01T12:30:00",
           ]);
         });
       });
@@ -286,6 +305,26 @@ describe("DatePicker", () => {
           CREATED_AT_FIELD,
           "2020-05-17",
           "2020-05-19",
+        ]);
+      });
+
+      it("can add time to a between date filter", async () => {
+        const onChange = jest.fn();
+
+        render(<DatePickerStateWrapper filter={filter} onChange={onChange} />);
+
+        await userEvent.click(await screen.findByText("Specific dates..."));
+        await userEvent.click(await screen.findByText("Between"));
+
+        await userEvent.click(screen.getByText("17")); // start date
+        await userEvent.click(screen.getByText("19")); // end date
+        await userEvent.click(screen.getByText("Add a time"));
+
+        expect(onChange).toHaveBeenLastCalledWith([
+          "between",
+          CREATED_AT_FIELD,
+          "2020-05-17T12:30:00",
+          "2020-05-19T12:30:00",
         ]);
       });
 

--- a/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/DatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/DatePicker.unit.spec.tsx
@@ -267,18 +267,14 @@ describe("DatePicker", () => {
         });
 
         it(`can add time to a specific ${description} date filter`, async () => {
+          const filter = createDateFilter(operator, "2020-05-01");
           const onChange = jest.fn();
-
           render(
             <DatePickerStateWrapper filter={filter} onChange={onChange} />,
           );
-          await userEvent.click(screen.getByText("Specific dates..."));
-          await userEvent.click(screen.getByText("On"));
-          await screen.findByTestId(`specific-date-picker`);
-          await userEvent.click(screen.getByText(description));
-          await userEvent.click(screen.getByText("Add a time"));
 
-          expect(onChange).toHaveBeenLastCalledWith([
+          await userEvent.click(screen.getByText("Add a time"));
+          expect(onChange.mock.lastCall[0]).toStrictEqual([
             operator,
             CREATED_AT_FIELD,
             "2020-05-01T12:30:00",
@@ -309,22 +305,17 @@ describe("DatePicker", () => {
       });
 
       it("can add time to a between date filter", async () => {
+        const filter = createDateFilter("between", "2020-04-01", "2020-05-01");
         const onChange = jest.fn();
-
         render(<DatePickerStateWrapper filter={filter} onChange={onChange} />);
 
-        await userEvent.click(await screen.findByText("Specific dates..."));
-        await userEvent.click(await screen.findByText("Between"));
-
-        await userEvent.click(screen.getByText("17")); // start date
-        await userEvent.click(screen.getByText("19")); // end date
         await userEvent.click(screen.getByText("Add a time"));
 
-        expect(onChange).toHaveBeenLastCalledWith([
+        expect(onChange.mock.lastCall[0]).toStrictEqual([
           "between",
           CREATED_AT_FIELD,
-          "2020-05-17T12:30:00",
-          "2020-05-19T12:30:00",
+          "2020-04-01T12:30:00",
+          "2020-05-01T12:30:00",
         ]);
       });
 

--- a/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/DatePickerFooter.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/DatePickerFooter.tsx
@@ -62,7 +62,7 @@ const DatePickerFooter: React.FC<React.PropsWithChildren<Props>> = ({
         operator,
         field,
         start,
-        operator === "between" && !end ? start : end,
+        ...(operator === "between" ? [end ?? start] : []),
       ]);
     }
   };


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/49075

How to verify:
- New -> SQL query -> `SELECT * FROM PRODUCTS WHERE CREATED_AT = {{created_at}}`
- Change the variable type to `Date`
- Click on the date picker widget -> `Add a time`
- The `Add filter` button should not be disabled and it should be possible to add the filter.

<img width="346" alt="Screenshot 2024-10-24 at 14 07 31" src="https://github.com/user-attachments/assets/a6f86bcf-48ff-48c3-b671-8ea2e07ae567">
<img width="463" alt="Screenshot 2024-10-24 at 14 07 34" src="https://github.com/user-attachments/assets/4086bc97-e317-4fee-9715-18f0da3a0105">
