### PR TITLE
Allow boolean functions in custom columns

### DIFF
--- a/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
@@ -223,6 +223,14 @@ describe("scenarios > custom column > boolean functions", () => {
       createQuestion(questionDetails, { visitQuestion: true });
       openNotebook();
 
+      cy.log("add a literal column");
+      getNotebookStep("expression").icon("add").click();
+      enterCustomColumnDetails({
+        formula: "True",
+        name: "Literal column",
+      });
+      popover().button("Done").click();
+
       cy.log("add an identity column");
       getNotebookStep("expression").icon("add").click();
       enterCustomColumnDetails({
@@ -246,10 +254,11 @@ describe("scenarios > custom column > boolean functions", () => {
         columns: [
           "Category",
           expressionName,
+          "Literal column",
           "Identity column",
           "Simple expression",
         ],
-        firstRows: [["Gizmo", "true", "true", "false"]],
+        firstRows: [["Gizmo", "true", "true", "true", "false"]],
       });
     });
 

--- a/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
@@ -452,7 +452,36 @@ describe("scenarios > custom column > boolean functions", () => {
         };
       }
 
-      it("should be able to add a filter for the source column", () => {
+      it("should be able to add a custom column for a source boolean column", () => {
+        createQuestion(questionDetails).then(({ body: card }) =>
+          createQuestion(getNestedQuestionDetails(card.id), {
+            visitQuestion: true,
+          }),
+        );
+
+        cy.log("add a custom column");
+        openNotebook();
+        getNotebookStep("data").button("Custom column").click();
+        enterCustomColumnDetails({
+          formula: `[${expressionName}] != True`,
+          name: "Simple expression",
+        });
+        popover().button("Done").click();
+        visualize();
+        cy.wait("@dataset");
+        assertQueryBuilderRowCount(200);
+
+        cy.log("use the new custom column in a filter");
+        tableHeaderClick("Simple expression");
+        popover().within(() => {
+          cy.findByText("Filter by this column").click();
+          cy.findByLabelText("True").click();
+          cy.findByText("Add filter").click();
+        });
+        assertQueryBuilderRowCount(149);
+      });
+
+      it("should be able to add a filter for a source boolean column", () => {
         createQuestion(questionDetails).then(({ body: card }) =>
           createQuestion(getNestedQuestionDetails(card.id), {
             visitQuestion: true,

--- a/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
@@ -205,6 +205,10 @@ describe("scenarios > custom column > boolean functions", () => {
     const questionDetails: StructuredQuestionDetails = {
       query: {
         "source-table": PRODUCTS_ID,
+        fields: [
+          ["field", PRODUCTS.CATEGORY, null],
+          ["expression", expressionName],
+        ],
         expressions: {
           [expressionName]: [
             "starts-with",
@@ -214,6 +218,40 @@ describe("scenarios > custom column > boolean functions", () => {
         },
       },
     };
+
+    it("should be able to add a same-stage custom column", () => {
+      createQuestion(questionDetails, { visitQuestion: true });
+      openNotebook();
+
+      cy.log("add an identity column");
+      getNotebookStep("expression").icon("add").click();
+      enterCustomColumnDetails({
+        formula: `[${expressionName}]`,
+        name: "Identity column",
+      });
+      popover().button("Done").click();
+
+      cy.log("add a simple expression");
+      getNotebookStep("expression").icon("add").click();
+      enterCustomColumnDetails({
+        formula: `[${expressionName}] != True`,
+        name: "Simple expression",
+      });
+      popover().button("Done").click();
+
+      cy.log("assert query results");
+      visualize();
+      cy.wait("@dataset");
+      assertTableData({
+        columns: [
+          "Category",
+          expressionName,
+          "Identity column",
+          "Simple expression",
+        ],
+        firstRows: [["Gizmo", "true", "true", "false"]],
+      });
+    });
 
     it("should be able to add a same-stage filter", () => {
       createQuestion(questionDetails, { visitQuestion: true });

--- a/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
@@ -521,7 +521,7 @@ describe("scenarios > custom column > boolean functions", () => {
         });
       });
 
-      it.skip("should be able to add a breakout and sorting for a source boolean column", () => {
+      it.skip("should be able to add a breakout and sorting for a source boolean column (metabase#49305)", () => {
         createQuestion(questionDetails).then(({ body: card }) =>
           createQuestion(getNestedQuestionDetails(card.id), {
             visitQuestion: true,

--- a/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
@@ -1,5 +1,6 @@
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
+  type DashboardDetails,
   type StructuredQuestionDetails,
   assertQueryBuilderRowCount,
   assertTableData,
@@ -22,7 +23,6 @@ import {
   tableHeaderClick,
   visitDashboard,
   visualize,
-  DashboardDetails,
 } from "e2e/support/helpers";
 import type { CardId, DashboardParameterMapping } from "metabase-types/api";
 import { createMockDashboardCard } from "metabase-types/api/mocks";
@@ -237,14 +237,6 @@ describe("scenarios > custom column > boolean functions", () => {
         createQuestion(questionDetails, { visitQuestion: true });
         openNotebook();
 
-        cy.log("add a literal column");
-        getNotebookStep("expression").icon("add").click();
-        enterCustomColumnDetails({
-          formula: "True",
-          name: "Literal column",
-        });
-        popover().button("Done").click();
-
         cy.log("add an identity column");
         getNotebookStep("expression").icon("add").click();
         enterCustomColumnDetails({
@@ -268,11 +260,10 @@ describe("scenarios > custom column > boolean functions", () => {
           columns: [
             "Category",
             expressionName,
-            "Literal column",
             "Identity column",
             "Simple expression",
           ],
-          firstRows: [["Gizmo", "true", "true", "true", "false"]],
+          firstRows: [["Gizmo", "true", "true", "false"]],
         });
       });
 

--- a/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
@@ -25,16 +25,7 @@ describe("scenarios > custom column > boolean functions", () => {
   });
 
   describe("expression editor", () => {
-    type ExpressionTestCase = {
-      name: string;
-      questionDetails: StructuredQuestionDetails;
-      questionColumns: string[];
-      newExpression: string;
-      newExpressionRows: string[][];
-      modifiedExpression: string;
-      modifiedExpressionRows: string[][];
-    };
-
+    const stringQuestionColumns = ["Category"];
     const stringQuestionDetails: StructuredQuestionDetails = {
       query: {
         "source-table": PRODUCTS_ID,
@@ -43,8 +34,8 @@ describe("scenarios > custom column > boolean functions", () => {
         limit: 1,
       },
     };
-    const stringQuestionColumns = ["Category"];
 
+    const numberQuestionColumns = ["Total"];
     const numberQuestionDetails: StructuredQuestionDetails = {
       query: {
         "source-table": ORDERS_ID,
@@ -53,8 +44,8 @@ describe("scenarios > custom column > boolean functions", () => {
         limit: 1,
       },
     };
-    const numberQuestionColumns = ["Total"];
 
+    const dateQuestionColumns = ["Created At"];
     const dateQuestionDetails: StructuredQuestionDetails = {
       query: {
         "source-table": ORDERS_ID,
@@ -63,128 +54,142 @@ describe("scenarios > custom column > boolean functions", () => {
         limit: 1,
       },
     };
-    const dateQuestionColumns = ["Created At"];
 
-    const expressionTestCases: ExpressionTestCase[] = [
-      {
-        name: "isNull",
+    function testExpression({
+      questionDetails,
+      questionColumns,
+      newExpression,
+      newExpressionRows,
+      modifiedExpression,
+      modifiedExpressionRows,
+    }: {
+      questionDetails: StructuredQuestionDetails;
+      questionColumns: string[];
+      newExpression: string;
+      newExpressionRows: string[][];
+      modifiedExpression: string;
+      modifiedExpressionRows: string[][];
+    }) {
+      createQuestion(questionDetails, { visitQuestion: true });
+
+      cy.log("add a new custom column");
+      openNotebook();
+      getNotebookStep("data").button("Custom column").click();
+      enterCustomColumnDetails({
+        formula: newExpression,
+        name: expressionName,
+      });
+      popover().button("Done").click();
+      visualize();
+      cy.wait("@dataset");
+      assertTableData({
+        columns: [...questionColumns, expressionName],
+        firstRows: newExpressionRows,
+      });
+
+      cy.log("modify an existing custom column");
+      openNotebook();
+      getNotebookStep("expression").findByText(expressionName).click();
+      enterCustomColumnDetails({
+        formula: modifiedExpression,
+        name: expressionName,
+      });
+      popover().button("Update").click();
+      visualize();
+      cy.wait("@dataset");
+      assertTableData({
+        columns: [...questionColumns, expressionName],
+        firstRows: modifiedExpressionRows,
+      });
+    }
+
+    it("isNull", () => {
+      testExpression({
         questionDetails: stringQuestionDetails,
         questionColumns: stringQuestionColumns,
         newExpression: "isNull([Category])",
         newExpressionRows: [["Gizmo", "false"]],
         modifiedExpression: "notNull([Category])",
         modifiedExpressionRows: [["Gizmo", "true"]],
-      },
-      {
-        name: "isEmpty",
+      });
+    });
+
+    it("isEmpty", () => {
+      testExpression({
         questionDetails: stringQuestionDetails,
         questionColumns: stringQuestionColumns,
         newExpression: "isEmpty([Category])",
         newExpressionRows: [["Gizmo", "false"]],
         modifiedExpression: "notEmpty([Category])",
         modifiedExpressionRows: [["Gizmo", "true"]],
-      },
-      {
-        name: "startsWith",
+      });
+    });
+
+    it("startsWith", () => {
+      testExpression({
         questionDetails: stringQuestionDetails,
         questionColumns: stringQuestionColumns,
         newExpression: 'startsWith([Category], "Gi")',
         newExpressionRows: [["Gizmo", "true"]],
         modifiedExpression: 'startsWith([Category], "mo")',
         modifiedExpressionRows: [["Gizmo", "false"]],
-      },
-      {
-        name: "endsWith",
+      });
+    });
+
+    it("endsWith", () => {
+      testExpression({
         questionDetails: stringQuestionDetails,
         questionColumns: stringQuestionColumns,
         newExpression: 'endsWith([Category], "Gi")',
         newExpressionRows: [["Gizmo", "false"]],
         modifiedExpression: 'endsWith([Category], "mo")',
         modifiedExpressionRows: [["Gizmo", "true"]],
-      },
-      {
-        name: "contains",
+      });
+    });
+
+    it("contains", () => {
+      testExpression({
         questionDetails: stringQuestionDetails,
         questionColumns: stringQuestionColumns,
         newExpression: 'contains([Category], "zm")',
         newExpressionRows: [["Gizmo", "true"]],
         modifiedExpression: 'contains([Category], "mz")',
         modifiedExpressionRows: [["Gizmo", "false"]],
-      },
-      {
-        name: "doesNotContain",
+      });
+    });
+
+    it("doesNotContain", () => {
+      testExpression({
         questionDetails: stringQuestionDetails,
         questionColumns: stringQuestionColumns,
         newExpression: 'doesNotContain([Category], "zm")',
         newExpressionRows: [["Gizmo", "false"]],
         modifiedExpression: 'doesNotContain([Category], "mz")',
         modifiedExpressionRows: [["Gizmo", "true"]],
-      },
-      {
-        name: "between",
+      });
+    });
+
+    it("between", () => {
+      testExpression({
         questionDetails: numberQuestionDetails,
         questionColumns: numberQuestionColumns,
         newExpression: "between([Total], 20, 30)",
         newExpressionRows: [["39.72", "false"]],
         modifiedExpression: "between([Total], 30, 40)",
         modifiedExpressionRows: [["39.72", "true"]],
-      },
-      {
-        name: "timeInterval",
+      });
+    });
+
+    it("timeInterval", () => {
+      testExpression({
         questionDetails: dateQuestionDetails,
         questionColumns: dateQuestionColumns,
         newExpression: 'interval([Created At], -30, "year")',
         newExpressionRows: [["April 30, 2022, 6:56 PM", "true"]],
         modifiedExpression: 'interval([Created At], 2, "month")',
         modifiedExpressionRows: [["April 30, 2022, 6:56 PM", "false"]],
-      },
-    ];
-
-    expressionTestCases.forEach(
-      ({
-        name,
-        questionDetails,
-        questionColumns,
-        newExpression,
-        newExpressionRows,
-        modifiedExpression,
-        modifiedExpressionRows,
-      }) => {
-        it(name, () => {
-          createQuestion(questionDetails, { visitQuestion: true });
-
-          cy.log("add a new custom column");
-          openNotebook();
-          getNotebookStep("data").button("Custom column").click();
-          enterCustomColumnDetails({
-            formula: newExpression,
-            name: expressionName,
-          });
-          popover().button("Done").click();
-          visualize();
-          cy.wait("@dataset");
-          assertTableData({
-            columns: [...questionColumns, expressionName],
-            firstRows: newExpressionRows,
-          });
-
-          cy.log("modify an existing custom column");
-          openNotebook();
-          getNotebookStep("expression").findByText(expressionName).click();
-          enterCustomColumnDetails({
-            formula: modifiedExpression,
-            name: expressionName,
-          });
-          popover().button("Update").click();
-          visualize();
-          cy.wait("@dataset");
-          assertTableData({
-            columns: [...questionColumns, expressionName],
-            firstRows: modifiedExpressionRows,
-          });
-        });
-      },
-    );
+      });
+    });
   });
 
   describe("same stage", () => {

--- a/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
@@ -11,41 +11,7 @@ import {
   visualize,
 } from "e2e/support/helpers";
 
-const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
-
-const expressionName = "Expression";
-
-const numberQuestionColumns = ["Total"];
-const numberQuestionDetails: StructuredQuestionDetails = {
-  query: {
-    "source-table": ORDERS_ID,
-    fields: [["field", ORDERS.TOTAL, null]],
-    limit: 1,
-    "order-by": [["asc", ["field", ORDERS.ID, null]]],
-  },
-};
-
-type ExpressionTestCase = {
-  name: string;
-  questionDetails: StructuredQuestionDetails;
-  questionColumns: string[];
-  newExpression: string;
-  newExpressionRows: string[][];
-  modifiedExpression: string;
-  modifiedExpressionRows: string[][];
-};
-
-const expressionTestCases: ExpressionTestCase[] = [
-  {
-    name: "between",
-    questionDetails: numberQuestionDetails,
-    questionColumns: numberQuestionColumns,
-    newExpression: "between([Total], 20, 30)",
-    newExpressionRows: [["39.72", "false"]],
-    modifiedExpression: "between([Total], 30, 40)",
-    modifiedExpressionRows: [["39.72", "true"]],
-  },
-];
+const { ORDERS_ID, ORDERS, PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;
 
 describe("scenarios > custom column > boolean functions", () => {
   beforeEach(() => {
@@ -55,6 +21,123 @@ describe("scenarios > custom column > boolean functions", () => {
   });
 
   describe("expression editor", () => {
+    type ExpressionTestCase = {
+      name: string;
+      questionDetails: StructuredQuestionDetails;
+      questionColumns: string[];
+      newExpression: string;
+      newExpressionRows: string[][];
+      modifiedExpression: string;
+      modifiedExpressionRows: string[][];
+    };
+
+    const expressionName = "Expression";
+
+    const stringQuestionDetails: StructuredQuestionDetails = {
+      query: {
+        "source-table": PRODUCTS_ID,
+        fields: [["field", PRODUCTS.CATEGORY, null]],
+        "order-by": [["asc", ["field", PRODUCTS.ID, null]]],
+        limit: 1,
+      },
+    };
+    const stringQuestionColumns = ["Category"];
+
+    const numberQuestionDetails: StructuredQuestionDetails = {
+      query: {
+        "source-table": ORDERS_ID,
+        fields: [["field", ORDERS.TOTAL, null]],
+        "order-by": [["asc", ["field", ORDERS.ID, null]]],
+        limit: 1,
+      },
+    };
+    const numberQuestionColumns = ["Total"];
+
+    const dateQuestionDetails: StructuredQuestionDetails = {
+      query: {
+        "source-table": ORDERS_ID,
+        fields: [["field", ORDERS.CREATED_AT, null]],
+        "order-by": [["asc", ["field", ORDERS.CREATED_AT, null]]],
+        limit: 1,
+      },
+    };
+    const dateQuestionColumns = ["Created At"];
+
+    const expressionTestCases: ExpressionTestCase[] = [
+      {
+        name: "isNull",
+        questionDetails: stringQuestionDetails,
+        questionColumns: stringQuestionColumns,
+        newExpression: "isNull([Category])",
+        newExpressionRows: [["Gizmo", "false"]],
+        modifiedExpression: "notNull([Category])",
+        modifiedExpressionRows: [["Gizmo", "true"]],
+      },
+      {
+        name: "isEmpty",
+        questionDetails: stringQuestionDetails,
+        questionColumns: stringQuestionColumns,
+        newExpression: "isEmpty([Category])",
+        newExpressionRows: [["Gizmo", "false"]],
+        modifiedExpression: "notEmpty([Category])",
+        modifiedExpressionRows: [["Gizmo", "true"]],
+      },
+      {
+        name: "startsWith",
+        questionDetails: stringQuestionDetails,
+        questionColumns: stringQuestionColumns,
+        newExpression: 'startsWith([Category], "Gi")',
+        newExpressionRows: [["Gizmo", "true"]],
+        modifiedExpression: 'startsWith([Category], "mo")',
+        modifiedExpressionRows: [["Gizmo", "false"]],
+      },
+      {
+        name: "endsWith",
+        questionDetails: stringQuestionDetails,
+        questionColumns: stringQuestionColumns,
+        newExpression: 'endsWith([Category], "Gi")',
+        newExpressionRows: [["Gizmo", "false"]],
+        modifiedExpression: 'endsWith([Category], "mo")',
+        modifiedExpressionRows: [["Gizmo", "true"]],
+      },
+      {
+        name: "contains",
+        questionDetails: stringQuestionDetails,
+        questionColumns: stringQuestionColumns,
+        newExpression: 'contains([Category], "zm")',
+        newExpressionRows: [["Gizmo", "true"]],
+        modifiedExpression: 'contains([Category], "mz")',
+        modifiedExpressionRows: [["Gizmo", "false"]],
+      },
+      {
+        name: "doesNotContain",
+        questionDetails: stringQuestionDetails,
+        questionColumns: stringQuestionColumns,
+        newExpression: 'doesNotContain([Category], "zm")',
+        newExpressionRows: [["Gizmo", "false"]],
+        modifiedExpression: 'doesNotContain([Category], "mz")',
+        modifiedExpressionRows: [["Gizmo", "true"]],
+      },
+      {
+        name: "between",
+        questionDetails: numberQuestionDetails,
+        questionColumns: numberQuestionColumns,
+        newExpression: "between([Total], 20, 30)",
+        newExpressionRows: [["39.72", "false"]],
+        modifiedExpression: "between([Total], 30, 40)",
+        modifiedExpressionRows: [["39.72", "true"]],
+      },
+      {
+        name: "timeInterval",
+        questionDetails: dateQuestionDetails,
+        questionColumns: dateQuestionColumns,
+        newExpression: 'interval([Created At], -30, "year")',
+        newExpressionRows: [["April 30, 2022, 6:56 PM", "true"]],
+        modifiedExpression: 'interval([Created At], 2, "month")',
+        modifiedExpressionRows: [["April 30, 2022, 6:56 PM", "false"]],
+      },
+    ];
+
     expressionTestCases.forEach(
       ({
         name,

--- a/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
@@ -298,19 +298,19 @@ describe("scenarios > custom column > boolean functions", () => {
       createQuestion(questionDetails, { visitQuestion: true });
       openNotebook();
       getNotebookStep("expression").button("Summarize").click();
-      popover().findByText("Count of rows");
+      popover().findByText("Count of rows").click();
       getNotebookStep("summarize")
         .findByTestId("breakout-step")
-        .icon("add")
+        .findByText("Pick a column to group by")
         .click();
       popover().findByText(expressionName).click();
       visualize();
       cy.wait("@dataset");
       assertTableData({
-        columns: ["Count", expressionName],
+        columns: [expressionName, "Count"],
         firstRows: [
-          ["1", "false"],
-          ["3", "true"],
+          ["false", "149"],
+          ["true", "51"],
         ],
       });
     });
@@ -377,6 +377,53 @@ describe("scenarios > custom column > boolean functions", () => {
         cy.findByText("Add filter").click();
       });
       assertQueryBuilderRowCount(1);
+    });
+
+    it("should be able to add a post-aggregation aggregation", () => {
+      createQuestion(questionDetails, { visitQuestion: true });
+      openNotebook();
+      getNotebookStep("summarize").button("Summarize").click();
+      popover().findByText("Minimum of ...").click();
+      popover().findByText(expressionName).click();
+      visualize();
+      cy.wait("@dataset");
+      assertTableData({
+        columns: [`Min of ${expressionName}`],
+        firstRows: [["false"]],
+      });
+    });
+
+    it("should be possible to add a post-aggregation breakout and sorting", () => {
+      createQuestion(questionDetails, { visitQuestion: true });
+      openNotebook();
+      getNotebookStep("summarize").button("Summarize").click();
+      popover().findByText("Count of rows").click();
+      getNotebookStep("summarize", { stage: 1 })
+        .findByTestId("breakout-step")
+        .findByText("Pick a column to group by")
+        .click();
+      popover().findByText(expressionName).click();
+      visualize();
+      cy.wait("@dataset");
+      assertTableData({
+        columns: [expressionName, "Count"],
+        firstRows: [
+          ["false", 1],
+          ["true", 1],
+        ],
+      });
+      openNotebook();
+      getNotebookStep("summarize", { stage: 1 }).button("Sort").click();
+      popover().findByText(expressionName).click();
+      getNotebookStep("sort", { stage: 1 }).icon("arrow_up").click();
+      visualize();
+      assertTableData({
+        columns: [expressionName, "Count"],
+        firstRows: [
+          ["true", 1],
+          ["false", 1],
+        ],
+      });
     });
   });
 

--- a/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
@@ -315,7 +315,7 @@ describe("scenarios > custom column > boolean functions", () => {
       });
     });
 
-    it("should be able to add a same-stage order by clause", () => {
+    it("should be able to add a same-stage sorting", () => {
       createQuestion(questionDetails, { visitQuestion: true });
       openNotebook();
       getNotebookStep("expression").button("Sort").click();

--- a/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
@@ -1,0 +1,104 @@
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import {
+  type StructuredQuestionDetails,
+  assertTableData,
+  createQuestion,
+  enterCustomColumnDetails,
+  getNotebookStep,
+  openNotebook,
+  popover,
+  restore,
+  visualize,
+} from "e2e/support/helpers";
+
+const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
+
+const expressionName = "Expression";
+
+const numberQuestionColumns = ["Total"];
+const numberQuestionDetails: StructuredQuestionDetails = {
+  query: {
+    "source-table": ORDERS_ID,
+    fields: [["field", ORDERS.TOTAL, null]],
+    limit: 1,
+    "order-by": [["asc", ["field", ORDERS.ID, null]]],
+  },
+};
+
+type ExpressionTestCase = {
+  name: string;
+  questionDetails: StructuredQuestionDetails;
+  questionColumns: string[];
+  newExpression: string;
+  newExpressionRows: string[][];
+  modifiedExpression: string;
+  modifiedExpressionRows: string[][];
+};
+
+const expressionTestCases: ExpressionTestCase[] = [
+  {
+    name: "between",
+    questionDetails: numberQuestionDetails,
+    questionColumns: numberQuestionColumns,
+    newExpression: "between([Total], 20, 30)",
+    newExpressionRows: [["39.72", "false"]],
+    modifiedExpression: "between([Total], 30, 40)",
+    modifiedExpressionRows: [["39.72", "true"]],
+  },
+];
+
+describe("scenarios > custom column > boolean functions", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+    cy.intercept("POST", "/api/dataset").as("dataset");
+  });
+
+  describe("expression editor", () => {
+    expressionTestCases.forEach(
+      ({
+        name,
+        questionDetails,
+        questionColumns,
+        newExpression,
+        newExpressionRows,
+        modifiedExpression,
+        modifiedExpressionRows,
+      }) => {
+        it(name, () => {
+          createQuestion(questionDetails, { visitQuestion: true });
+
+          cy.log("add a new custom column");
+          openNotebook();
+          getNotebookStep("data").button("Custom column").click();
+          enterCustomColumnDetails({
+            formula: newExpression,
+            name: expressionName,
+          });
+          popover().button("Done").click();
+          visualize();
+          cy.wait("@dataset");
+          assertTableData({
+            columns: [...questionColumns, expressionName],
+            firstRows: newExpressionRows,
+          });
+
+          cy.log("modify an existing custom column");
+          openNotebook();
+          getNotebookStep("expression").findByText(expressionName).click();
+          enterCustomColumnDetails({
+            formula: modifiedExpression,
+            name: expressionName,
+          });
+          popover().button("Update").click();
+          visualize();
+          cy.wait("@dataset");
+          assertTableData({
+            columns: [...questionColumns, expressionName],
+            firstRows: modifiedExpressionRows,
+          });
+        });
+      },
+    );
+  });
+});

--- a/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
@@ -6,8 +6,10 @@ import {
   createQuestion,
   enterCustomColumnDetails,
   getNotebookStep,
+  modal,
   openNotebook,
   popover,
+  queryBuilderHeader,
   restore,
   tableHeaderClick,
   visualize,
@@ -22,6 +24,7 @@ describe("scenarios > custom column > boolean functions", () => {
     restore();
     cy.signInAsNormalUser();
     cy.intercept("POST", "/api/dataset").as("dataset");
+    cy.intercept("PUT", "/api/card/*").as("updateCard");
   });
 
   describe("expression editor", () => {
@@ -101,6 +104,12 @@ describe("scenarios > custom column > boolean functions", () => {
         columns: [...questionColumns, expressionName],
         firstRows: modifiedExpressionRows,
       });
+
+      cy.log("assert that the question can be saved");
+      queryBuilderHeader().button("Save").click();
+      modal().button("Save").click();
+      cy.wait("@updateCard");
+      queryBuilderHeader().button("Save").should("not.exist");
     }
 
     it("isNull", () => {
@@ -248,7 +257,7 @@ describe("scenarios > custom column > boolean functions", () => {
     });
   });
 
-  describe("source card", () => {
+  describe.skip("source card", () => {
     const questionDetails: StructuredQuestionDetails = {
       query: {
         "source-table": PRODUCTS_ID,

--- a/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
@@ -293,6 +293,40 @@ describe("scenarios > custom column > boolean functions", () => {
         firstRows: [["false", "true"]],
       });
     });
+
+    it("should be able to add a same-stage breakout", () => {
+      createQuestion(questionDetails, { visitQuestion: true });
+      openNotebook();
+      getNotebookStep("expression").button("Summarize").click();
+      popover().findByText("Count of rows");
+      getNotebookStep("summarize")
+        .findByTestId("breakout-step")
+        .icon("add")
+        .click();
+      popover().findByText(expressionName).click();
+      visualize();
+      cy.wait("@dataset");
+      assertTableData({
+        columns: ["Count", expressionName],
+        firstRows: [
+          ["1", "false"],
+          ["3", "true"],
+        ],
+      });
+    });
+
+    it("should be able to add a same stage order by clause", () => {
+      createQuestion(questionDetails, { visitQuestion: true });
+      openNotebook();
+      getNotebookStep("expression").button("Sort").click();
+      popover().findByText(expressionName).click();
+      visualize();
+      cy.wait("@dataset");
+      assertTableData({
+        columns: ["Category", expressionName],
+        firstRows: [["Doohickey", "false"]],
+      });
+    });
   });
 
   describe("previous stage", () => {

--- a/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
@@ -207,7 +207,7 @@ describe("scenarios > custom column > boolean functions", () => {
         "source-table": PRODUCTS_ID,
         fields: [
           ["field", PRODUCTS.CATEGORY, null],
-          ["expression", expressionName],
+          ["expression", expressionName, { "base-type": "type/Boolean" }],
         ],
         expressions: {
           [expressionName]: [
@@ -315,7 +315,7 @@ describe("scenarios > custom column > boolean functions", () => {
       });
     });
 
-    it("should be able to add a same stage order by clause", () => {
+    it("should be able to add a same-stage order by clause", () => {
       createQuestion(questionDetails, { visitQuestion: true });
       openNotebook();
       getNotebookStep("expression").button("Sort").click();
@@ -341,9 +341,31 @@ describe("scenarios > custom column > boolean functions", () => {
           ],
         },
         aggregation: [["count"]],
-        breakout: [["expression", expressionName]],
+        breakout: [
+          ["expression", expressionName, { "base-type": "type/Boolean" }],
+        ],
       },
     };
+
+    it("should be able to add a post-aggregation custom column", () => {
+      createQuestion(questionDetails, { visitQuestion: true });
+      openNotebook();
+      getNotebookStep("summarize").button("Custom column").click();
+      enterCustomColumnDetails({
+        formula: `not([${expressionName}])`,
+        name: "Simple expression",
+      });
+      popover().button("Done").click();
+      visualize();
+      cy.wait("@dataset");
+      assertTableData({
+        columns: [expressionName, "Count", "Simple expression"],
+        firstRows: [
+          ["false", "149", "true"],
+          ["true", "51", "false"],
+        ],
+      });
+    });
 
     it("should be able to add a post-aggregation filter", () => {
       createQuestion(questionDetails, { visitQuestion: true });
@@ -382,7 +404,7 @@ describe("scenarios > custom column > boolean functions", () => {
       };
     }
 
-    it("should be able to add a source column filter", () => {
+    it("should be able to add a filter for the source column", () => {
       createQuestion(questionDetails).then(({ body: card }) =>
         createQuestion(getNestedQuestionDetails(card.id), {
           visitQuestion: true,

--- a/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
@@ -625,35 +625,6 @@ describe("scenarios > custom column > boolean functions", () => {
       );
     }
 
-    it("should be able to setup an 'update filter' click behavior and convert the value based on the connected fields", () => {
-      createDashboardWithQuestion().then(dashboard =>
-        visitDashboard(dashboard.id),
-      );
-
-      cy.log("setup click behavior");
-      editDashboard();
-      showDashboardCardActions();
-      getDashboardCard().findByLabelText("Click behavior").click();
-      sidebar().within(() => {
-        cy.findByText(expressionName).click();
-        cy.findByText("Update a dashboard filter").click();
-        cy.findByText(parameterDetails.name).click();
-      });
-      popover().findByText(expressionName).click();
-      saveDashboard();
-
-      cy.log("verify click behavior");
-      getDashboardCard().within(() => {
-        cy.findByText("Hudson Borer").should("be.visible");
-        cy.findByText("Sydney Rempel").should("not.exist");
-        cy.findAllByText("false").first().click();
-      });
-      getDashboardCard().within(() => {
-        cy.findByText("Hudson Borer").should("not.exist");
-        cy.findByText("Sydney Rempel").should("be.visible");
-      });
-    });
-
     it("should be able setup an 'open question' click behavior", () => {
       createDashboardWithQuestion().then(dashboard =>
         visitDashboard(dashboard.id),

--- a/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
@@ -264,6 +264,26 @@ describe("scenarios > custom column > boolean functions", () => {
       });
       assertQueryBuilderRowCount(51);
     });
+
+    it("should be able to add a same-stage aggregation", () => {
+      createQuestion(questionDetails, { visitQuestion: true });
+      openNotebook();
+      getNotebookStep("expression").button("Summarize").click();
+      popover().findByText("Minimum of ...").click();
+      popover().findByText(expressionName).click();
+      getNotebookStep("summarize")
+        .findByTestId("aggregate-step")
+        .icon("add")
+        .click();
+      popover().findByText("Maximum of ...").click();
+      popover().findByText(expressionName).click();
+      visualize();
+      cy.wait("@dataset");
+      assertTableData({
+        columns: [`Min of ${expressionName}`, `Max of ${expressionName}`],
+        firstRows: [["false", "true"]],
+      });
+    });
   });
 
   describe("previous stage", () => {

--- a/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
@@ -458,7 +458,7 @@ describe("scenarios > custom column > boolean functions", () => {
         };
       }
 
-      it("should be able to add a custom column for a source boolean column", () => {
+      it("should be able to add a custom column for a boolean column", () => {
         createQuestion(questionDetails).then(({ body: card }) =>
           createQuestion(getNestedQuestionDetails(card.id), {
             visitQuestion: true,
@@ -487,7 +487,7 @@ describe("scenarios > custom column > boolean functions", () => {
         assertQueryBuilderRowCount(149);
       });
 
-      it("should be able to add a filter for a source boolean column", () => {
+      it("should be able to add a filter for a boolean column", () => {
         createQuestion(questionDetails).then(({ body: card }) =>
           createQuestion(getNestedQuestionDetails(card.id), {
             visitQuestion: true,
@@ -503,7 +503,7 @@ describe("scenarios > custom column > boolean functions", () => {
         assertQueryBuilderRowCount(51);
       });
 
-      it("should be able to add an aggregation for a source boolean column", () => {
+      it("should be able to add an aggregation for a boolean column", () => {
         createQuestion(questionDetails).then(({ body: card }) =>
           createQuestion(getNestedQuestionDetails(card.id), {
             visitQuestion: true,
@@ -521,7 +521,7 @@ describe("scenarios > custom column > boolean functions", () => {
         });
       });
 
-      it.skip("should be able to add a breakout and sorting for a source boolean column (metabase#49305)", () => {
+      it.skip("should be able to add a breakout and sorting for a boolean column (metabase#49305)", () => {
         createQuestion(questionDetails).then(({ body: card }) =>
           createQuestion(getNestedQuestionDetails(card.id), {
             visitQuestion: true,

--- a/frontend/src/metabase-lib/v1/expressions/diagnostics.ts
+++ b/frontend/src/metabase-lib/v1/expressions/diagnostics.ts
@@ -17,7 +17,7 @@ import {
   adjustOptions,
   useShorthands,
 } from "./recursive-parser";
-import { COMPARISON_OPS, LOGICAL_OPS, resolve } from "./resolver";
+import { resolve } from "./resolver";
 import { OPERATOR, TOKEN, tokenize } from "./tokenizer";
 import type { ErrorWithMessage } from "./types";
 
@@ -121,13 +121,6 @@ export function diagnose({
 
     if (isErrorWithMessage(mbqlOrError)) {
       return mbqlOrError;
-    }
-
-    if (startRule === "expression" && isBooleanExpression(mbqlOrError)) {
-      throw new ResolverError(
-        t`Custom columns do not support boolean expressions`,
-        mbqlOrError.node,
-      );
     }
   } catch (err) {
     if (isErrorWithMessage(err)) {
@@ -257,15 +250,6 @@ function prattCompiler({
   });
 
   return mbql;
-}
-
-function isBooleanExpression(
-  expr: unknown,
-): expr is [string, ...Expr[]] & { node?: Node } {
-  return (
-    Array.isArray(expr) &&
-    (LOGICAL_OPS.includes(expr[0]) || COMPARISON_OPS.includes(expr[0]))
-  );
 }
 
 function isErrorWithMessage(err: unknown): err is ErrorWithMessage {

--- a/frontend/src/metabase-lib/v1/expressions/resolver.js
+++ b/frontend/src/metabase-lib/v1/expressions/resolver.js
@@ -55,7 +55,7 @@ const isCompatible = (expectedType, inferredType) => {
   }
   if (
     expectedType === "expression" &&
-    ["datetime", "number", "string"].includes(inferredType)
+    ["datetime", "number", "string", "boolean"].includes(inferredType)
   ) {
     return true;
   }

--- a/frontend/src/metabase-lib/v1/metadata/Field.ts
+++ b/frontend/src/metabase-lib/v1/metadata/Field.ts
@@ -36,6 +36,7 @@ import {
   isScope,
   isState,
   isString,
+  isStringLike,
   isSummable,
   isTime,
   isTypeFK,
@@ -207,6 +208,10 @@ class FieldInner extends Base {
 
   isString() {
     return isString(this);
+  }
+
+  isStringLike() {
+    return isStringLike(this);
   }
 
   isAddress() {

--- a/frontend/src/metabase-lib/v1/parameters/utils/click-behavior.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/click-behavior.ts
@@ -54,6 +54,7 @@ interface SourceFilters {
 
 interface ExtraData {
   dashboard?: Dashboard;
+  parameters?: Parameter[];
   dashboards?: Record<Dashboard["id"], Dashboard>;
 }
 
@@ -416,7 +417,7 @@ export function formatSourceForTarget(
     }
   }
 
-  return datum.value;
+  return parameter ? parseParameterValue(datum.value, parameter) : datum.value;
 }
 
 function formatDateForParameterType(
@@ -470,7 +471,7 @@ function getParameter(
   },
 ): Parameter | undefined {
   if (clickBehavior.type === "crossfilter") {
-    const parameters = extraData.dashboard?.parameters || [];
+    const parameters = extraData.parameters ?? [];
     return parameters.find(parameter => parameter.id === target.id);
   }
 
@@ -480,9 +481,11 @@ function getParameter(
     (clickBehavior.linkType === "dashboard" ||
       clickBehavior.linkType === "question")
   ) {
-    const dashboard =
-      extraData.dashboards?.[clickBehavior.targetId as DashboardId];
-    const parameters = dashboard?.parameters || [];
+    const dashboardId = clickBehavior.targetId as DashboardId;
+    const parameters =
+      extraData.dashboard?.id === dashboardId
+        ? (extraData.parameters ?? [])
+        : (extraData.dashboards?.[dashboardId]?.parameters ?? []);
     return parameters.find(parameter => parameter.id === target.id);
   }
 

--- a/frontend/src/metabase-lib/v1/parameters/utils/click-behavior.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/click-behavior.unit.spec.ts
@@ -517,11 +517,10 @@ describe("metabase/lib/click-behavior", () => {
       };
       const extraData = {
         // the UI wouldn't actually let you configure a text column -> date param link
-        dashboard: createMockDashboard({
-          parameters: [
-            createMockParameter({ id: "param123", type: "date/single" }),
-          ],
-        }),
+        dashboard: createMockDashboard(),
+        parameters: [
+          createMockParameter({ id: "param123", type: "date/single" }),
+        ],
       };
       const clickBehavior = { type: "crossfilter" as const };
       const value = formatSourceForTarget(source, target, {
@@ -553,11 +552,10 @@ describe("metabase/lib/click-behavior", () => {
         },
       };
       const extraData = {
-        dashboard: createMockDashboard({
-          parameters: [
-            createMockParameter({ id: "param123", type: "date/all-options" }),
-          ],
-        }),
+        dashboard: createMockDashboard(),
+        parameters: [
+          createMockParameter({ id: "param123", type: "date/all-options" }),
+        ],
       };
       const clickBehavior = { type: "crossfilter" as const };
       const value = formatSourceForTarget(source, target, {
@@ -586,11 +584,10 @@ describe("metabase/lib/click-behavior", () => {
         },
       };
       const extraData = {
-        dashboard: createMockDashboard({
-          parameters: [
-            createMockParameter({ id: "param123", type: "date/month-year" }),
-          ],
-        }),
+        dashboard: createMockDashboard(),
+        parameters: [
+          createMockParameter({ id: "param123", type: "date/month-year" }),
+        ],
       };
       const clickBehavior = { type: "crossfilter" as const };
       const value = formatSourceForTarget(source, target, {

--- a/frontend/src/metabase-lib/v1/parameters/utils/parameter-parsing.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/parameter-parsing.ts
@@ -84,21 +84,25 @@ function parseParameterValueForNumber(value: string | string[]) {
 }
 
 function parseParameterValueForFields(
-  value: string | string[],
+  value: ParameterValueOrArray,
   fields: Field[],
-): ParameterValueOrArray | boolean {
+): ParameterValueOrArray {
   if (Array.isArray(value)) {
     return value.map(v => parseParameterValueForFields(v, fields));
   }
 
   // unix dates fields are numeric but query params shouldn't be parsed as numbers
   if (fields.every(f => f.isNumeric() && !f.isDate())) {
-    const number = parseFloat(value);
+    const number = parseFloat(String(value));
     return isNaN(number) ? [] : number;
   }
 
   if (fields.every(f => f.isBoolean())) {
-    return value === "true" ? true : value === "false" ? false : value;
+    return value === "true" ? true : value === "false" ? false : [];
+  }
+
+  if (fields.every(f => f.isString() || f.isStringLike())) {
+    return String(value);
   }
 
   return value;

--- a/frontend/src/metabase-lib/v1/parameters/utils/parameter-parsing.unit.spec.js
+++ b/frontend/src/metabase-lib/v1/parameters/utils/parameter-parsing.unit.spec.js
@@ -191,18 +191,15 @@ describe("parameters/utils/parameter-values", () => {
       ).toEqual(["123.456"]);
     });
 
-    it("should convert boolean arguments to strings", () => {
-      field1.isNumeric = () => true;
-      field1.isDate = () => true;
-
-      field4.isNumeric = () => true;
-      field4.isDate = () => false;
+    it("should convert boolean arguments to strings if all mapped fields are strings", () => {
+      field1.isString = () => true;
+      field4.isStringLike = () => true;
 
       expect(
         getParameterValueFromQueryParams(parameter1, {
-          [parameter1.slug]: "123.456",
+          [parameter1.slug]: true,
         }),
-      ).toEqual(["123.456"]);
+      ).toEqual(["true"]);
     });
 
     it("should parse a value of 'true' or 'false' as a boolean if all associated fields are booleans", () => {

--- a/frontend/src/metabase-lib/v1/parameters/utils/parameter-parsing.unit.spec.js
+++ b/frontend/src/metabase-lib/v1/parameters/utils/parameter-parsing.unit.spec.js
@@ -21,6 +21,8 @@ describe("parameters/utils/parameter-values", () => {
     field1 = {
       id: 1,
       table_id: 1,
+      isString: () => false,
+      isStringLike: () => false,
       isNumeric: () => false,
       isDate: () => false,
       isBoolean: () => false,
@@ -28,6 +30,8 @@ describe("parameters/utils/parameter-values", () => {
     field2 = {
       id: 2,
       table_id: 1,
+      isString: () => false,
+      isStringLike: () => false,
       isNumeric: () => false,
       isDate: () => false,
       isBoolean: () => false,
@@ -35,6 +39,8 @@ describe("parameters/utils/parameter-values", () => {
     field3 = {
       id: 3,
       table_id: 1,
+      isString: () => false,
+      isStringLike: () => false,
       isNumeric: () => false,
       isDate: () => false,
       isBoolean: () => false,
@@ -42,6 +48,8 @@ describe("parameters/utils/parameter-values", () => {
     field4 = {
       id: 4,
       table_id: 1,
+      isString: () => false,
+      isStringLike: () => false,
       isNumeric: () => false,
       isDate: () => false,
       isBoolean: () => false,
@@ -183,6 +191,20 @@ describe("parameters/utils/parameter-values", () => {
       ).toEqual(["123.456"]);
     });
 
+    it("should convert boolean arguments to strings", () => {
+      field1.isNumeric = () => true;
+      field1.isDate = () => true;
+
+      field4.isNumeric = () => true;
+      field4.isDate = () => false;
+
+      expect(
+        getParameterValueFromQueryParams(parameter1, {
+          [parameter1.slug]: "123.456",
+        }),
+      ).toEqual(["123.456"]);
+    });
+
     it("should parse a value of 'true' or 'false' as a boolean if all associated fields are booleans", () => {
       field1.isBoolean = () => true;
       field4.isBoolean = () => true;
@@ -209,7 +231,7 @@ describe("parameters/utils/parameter-values", () => {
         getParameterValueFromQueryParams(parameter1, {
           [parameter1.slug]: "foo",
         }),
-      ).toEqual(["foo"]);
+      ).toEqual([]);
     });
 
     it("should not normalize date parameters", () => {

--- a/frontend/src/metabase-lib/v1/types/utils/isa.js
+++ b/frontend/src/metabase-lib/v1/types/utils/isa.js
@@ -106,6 +106,7 @@ export const isNumeric = isFieldType.bind(null, NUMBER);
 export const isInteger = isFieldType.bind(null, INTEGER);
 export const isBoolean = isFieldType.bind(null, BOOLEAN);
 export const isString = isFieldType.bind(null, STRING);
+export const isStringLike = isFieldType.bind(null, STRING_LIKE);
 export const isSummable = isFieldType.bind(null, SUMMABLE);
 export const isScope = isFieldType.bind(null, SCOPE);
 export const isCategory = isFieldType.bind(null, CATEGORY);

--- a/frontend/src/metabase-types/api/parameters.ts
+++ b/frontend/src/metabase-types/api/parameters.ts
@@ -90,7 +90,7 @@ export type StructuredParameterDimensionTarget = [
   ConcreteFieldReference | ExpressionReference,
 ];
 
-export type ParameterValueOrArray = string | number | Array<any>;
+export type ParameterValueOrArray = string | number | boolean | Array<any>;
 
 export type HumanReadableParameterValue = string;
 export type NotRemappedParameterValue = [RowValue];

--- a/frontend/src/metabase/dashboard/hooks/use-click-behavior-data.js
+++ b/frontend/src/metabase/dashboard/hooks/use-click-behavior-data.js
@@ -5,6 +5,7 @@ import {
   getDashCardById,
   getDashboardComplete,
   getParameterValuesBySlugMap,
+  getParameters,
 } from "metabase/dashboard/selectors";
 import { getLinkTargets } from "metabase/lib/click-behavior";
 import { useStore } from "metabase/lib/redux";
@@ -15,6 +16,7 @@ function createGetExtraDataForClick(store, dashcardId) {
     const state = store.getState();
     const dashboard = getDashboardComplete(state);
     const dashcard = getDashCardById(state, dashcardId);
+    const parameters = getParameters(state);
     const parameterValuesBySlug = getParameterValuesBySlugMap(state);
     const userAttributes = getUserAttributes(state);
 
@@ -34,6 +36,7 @@ function createGetExtraDataForClick(store, dashcardId) {
       .value();
     return {
       ...entitiesByTypeAndId,
+      parameters,
       parameterValuesBySlug,
       dashboard,
       dashcard,

--- a/frontend/test/metabase/lib/expressions/diagnostics.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/diagnostics.unit.spec.js
@@ -57,11 +57,4 @@ describe("metabase-lib/v1/expressions/diagnostics", () => {
         .message,
     ).toEqual("Function contains expects 2 arguments");
   });
-
-  it("should show an error for custom columns with a root boolean expression", () => {
-    expect(
-      diagnose({ source: "[Canceled] = [Returned]", startRule: "expression" })
-        .message,
-    ).toEqual("Custom columns do not support boolean expressions");
-  });
 });

--- a/frontend/test/metabase/lib/expressions/resolver.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/resolver.unit.spec.js
@@ -102,11 +102,6 @@ describe("metabase-lib/v1/expressions/resolve", () => {
       expect(() => filter(["<=", ["lower", A], "P"])).not.toThrow();
     });
 
-    it("should reject a less/greater comparison on functions returning boolean", () => {
-      // IsEmpty([A]) < 0
-      expect(() => filter(["<", ["is-empty", A], 0])).toThrow();
-    });
-
     // backward-compatibility
     it("should reject a number literal on the left-hand side of a comparison", () => {
       // 0 < [A]

--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -416,7 +416,7 @@
 
 (def ^:private boolean-functions
   "Functions that return boolean values. Should match [[BooleanExpression]]."
-  #{:and :or :not :< :<= :> :>= := :!=})
+  #{:and :or :not :< :<= :> :>= := :!= :is-null :not-null})
 
 (def ^:private aggregations
   #{:sum :avg :stddev :var :median :percentile :min :max :cum-count :cum-sum :count-where :sum-where :share :distinct
@@ -877,7 +877,7 @@
   segment-id [:or SegmentID ::lib.schema.common/non-blank-string])
 
 (mr/def ::BooleanExpression
-  (one-of and or not < <= > >= = !=))
+  (one-of and or not < <= > >= = != is-null not-null))
 
 (mr/def ::Filter
   [:multi

--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -416,7 +416,8 @@
 
 (def ^:private boolean-functions
   "Functions that return boolean values. Should match [[BooleanExpression]]."
-  #{:and :or :not :< :<= :> :>= := :!= :is-null :not-null})
+  #{:and :or :not :< :<= :> :>= := :!= :between :starts-with :ends-with :contains :does-not-contain :inside :is-empty
+    :not-empty :is-null :not-null :relative-time-interval :time-interval})
 
 (def ^:private aggregations
   #{:sum :avg :stddev :var :median :percentile :min :max :cum-count :cum-sum :count-where :sum-where :share :distinct
@@ -877,7 +878,11 @@
   segment-id [:or SegmentID ::lib.schema.common/non-blank-string])
 
 (mr/def ::BooleanExpression
-  (one-of and or not < <= > >= = != is-null not-null))
+  (one-of
+    ;; filters drivers must implement
+    and or not = != < > <= >= between starts-with ends-with contains
+    ;; SUGAR filters drivers do not need to implement
+   does-not-contain inside is-empty not-empty is-null not-null relative-time-interval time-interval))
 
 (mr/def ::Filter
   [:multi
@@ -893,11 +898,7 @@
    [:numeric  NumericExpression]
    [:string   StringExpression]
    [:boolean  BooleanExpression]
-   [:else    (one-of
-              ;; filters drivers must implement
-              and or not = != < > <= >= between starts-with ends-with contains
-              ;; SUGAR filters drivers do not need to implement
-              does-not-contain inside is-empty not-empty is-null not-null relative-time-interval time-interval segment)]])
+   [:else     (one-of segment)]])
 
 (def ^:private CaseClause
   [:tuple {:error/message ":case subclause"} Filter ExpressionArg])

--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -414,7 +414,7 @@
     ;; SUGAR drivers do not need to implement
     :get-year :get-quarter :get-month :get-week :get-day :get-day-of-week :get-hour :get-minute :get-second})
 
-(def ^:private boolean-functions
+(def boolean-functions
   "Functions that return boolean values. Should match [[BooleanExpression]]."
   #{:and :or :not :< :<= :> :>= := :!= :between :starts-with :ends-with :contains :does-not-contain :inside :is-empty
     :not-empty :is-null :not-null :relative-time-interval :time-interval})

--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -879,8 +879,8 @@
 
 (mr/def ::BooleanExpression
   (one-of
-    ;; filters drivers must implement
-    and or not = != < > <= >= between starts-with ends-with contains
+   ;; filters drivers must implement
+   and or not = != < > <= >= between starts-with ends-with contains
     ;; SUGAR filters drivers do not need to implement
    does-not-contain inside is-empty not-empty is-null not-null relative-time-interval time-interval))
 

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -162,6 +162,9 @@
     (number? expression)
     {:base_type :type/Number}
 
+    (boolean? expression)
+    {:base_type :type/Boolean}
+
     (mbql.u/is-clause? :field expression)
     (col-info-for-field-clause {} expression)
 
@@ -205,6 +208,9 @@
 
     (mbql.u/is-clause? mbql.s/numeric-functions expression)
     {:base_type :type/Float}
+
+    (mbql.u/is-clause? mbql.s/boolean-functions expression)
+    {:base_type :type/Boolean}
 
     :else
     {:base_type :type/*}))

--- a/test/metabase/query_processor/middleware/annotate_test.clj
+++ b/test/metabase/query_processor/middleware/annotate_test.clj
@@ -301,7 +301,34 @@
              (lib.tu.macros/$ids venues
                (#'annotate/col-info-for-field-clause
                 {:expressions {"double-price" [:* $price 2]}}
-                [:expression "double-price"])))))))
+                [:expression "double-price"])))))
+    (testing "col info for a boolean `expression` should have the correct `base_type`"
+      (lib.tu.macros/$ids people
+        (doseq [expression [[:< $id 10]
+                            [:<= $id 10]
+                            [:> $id 10]
+                            [:>= $id 10]
+                            [:= $id 10]
+                            [:!= $id 10]
+                            [:between $id 10 20]
+                            [:starts-with $id "a"]
+                            [:ends-with $id "a"]
+                            [:contains $id "a"]
+                            [:does-not-contain $name "a"]
+                            [:inside $latitude $longitude 90 -90 -90 90]
+                            [:is-empty $name]
+                            [:not-empty $name]
+                            [:is-null $name]
+                            [:not-null $name]
+                            [:time-interval $created-at 1 :year]
+                            [:relative-time-interval $created-at 1 :year -2 :year]
+                            [:and [:> $id 10] [:< $id 20]]
+                            [:or [:> $id 10] [:< $id 20]]
+                            [:not [:> $id 10]]]]
+          (is (=? {:base_type :type/Boolean}
+                  (#'annotate/col-info-for-field-clause
+                   {:expressions {"expression" expression}}
+                   [:expression "expression"]))))))))
 
 (deftest ^:parallel col-info-expressions-test-2
   (qp.store/with-metadata-provider meta/metadata-provider


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/15922

Allows all existing boolean functions in custom columns, except `segment`:
```
:between :starts-with :ends-with :contains :does-not-contain :inside :is-empty
:not-empty :is-null :not-null :relative-time-interval :time-interval
```

By type:
- anything - `:is-null :not-null`
- string - `:starts-with :ends-with :contains :does-not-contain :is-empty :not-empty`
- numbers - `between`
- numbers + coordinates - `:inside`
- dates - `:time-interval :relative-time-interval`

Notes:
- Currently `string/` parameters are actually `Text or Category` so they allow string columns + categorical columns of any type (numbers, booleans, anything). It means that we allow any column when configuring a click behavior where a string parameter is used. However, if there is a type mismatch between the passed value (from query results) to the parameter (based on the fields), a QP error would be thrown. I've tried to address some of the cases by coercing the value based on the types of the mapped fields in click behaviors. This is the same logic used elsewhere. However, it currently works with real fields only; if you map your string parameter to e.g. a string custom expression we would not be able to check the type and will pass whatever we got. This is the existing behavior, but hopefully this PR will address some common issues in this area.
- `inside` and `relative-time-interval` functions are not exposed in the expression editor and there is no documentation for them

Testing dimensions:
- all functions, manual input via the expression editor, new expression vs editing an existing expression
- column source - same stage, previous stage, source card
- clause type - join?, expression, filter, aggregation, breakout, sort
- click behavior -> update filter, custom destination - dashboard (same or external!), question, url